### PR TITLE
Optimize `Python.run_code`

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -276,17 +276,9 @@ impl<'p> Python<'p> {
                 return Err(PyErr::fetch(self));
             }
 
-            let mdict = ffi::PyModule_GetDict(mptr);
-
-            let globals = match globals {
-                Some(g) => g.as_ptr(),
-                None => mdict,
-            };
-
-            let locals = match locals {
-                Some(l) => l.as_ptr(),
-                None => globals
-            };
+            let globals = globals.map(|g| g.as_ptr())
+                                 .unwrap_or_else(|| ffi::PyModule_GetDict(mptr));
+            let locals = locals.map(|l| l.as_ptr()).unwrap_or(globals);
 
             let res_ptr = ffi::PyRun_StringFlags(code.as_ptr(),
                 start, globals, locals, 0 as *mut _);
@@ -355,6 +347,10 @@ mod test {
 
         let d = PyDict::new(py);
         d.set_item(py, "foo", 13).unwrap();
+
+        // Inject our own global namespace
+        let v: i32 = py.eval("foo + 29", Some(&d), None).unwrap().extract(py).unwrap();
+        assert_eq!(v, 42);
 
         // Inject our own local namespace
         let v: i32 = py.eval("foo + 29", None, Some(&d)).unwrap().extract(py).unwrap();


### PR DESCRIPTION
No need to call `ffi::PyModule_GetDict` if `globals` provided.