### PR TITLE
Add utility function is_instance

### DIFF
--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -102,3 +102,33 @@ impl BaseObject for PyObject {
         }
     }
 }
+
+
+pub fn is_instance(py: Python, obj: &PyObject, typ: &PyType) -> PyResult<bool> {
+    let result = unsafe {
+        ffi::PyObject_IsInstance(obj.as_ptr(), typ.as_ptr())
+    };
+    if result == -1 {
+        Err(err::PyErr::fetch(py))
+    } else if result == 1 {
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use python::{Python, PythonObject};
+    use objects::{PyBool, PyList};
+    use super::{is_instance, PyTypeObject};
+
+    #[test]
+    fn test_isinstance() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        assert!(is_instance(py, py.True().as_object(), &PyBool::type_object(py)).unwrap());
+        let list = PyList::new(py, &[1, 2, 3, 4]);
+        assert!(!is_instance(py, list.as_object(), &PyBool::type_object(py)).unwrap());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub use python::{Python, PythonObject,
                  PythonObjectWithCheckedDowncast, PythonObjectDowncastError, PyClone, PyDrop};
 pub use pythonrun::{GILGuard, GILProtected, prepare_freethreaded_python};
 pub use conversion::{FromPyObject, RefFromPyObject, ToPyObject, ToPyTuple};
-pub use class::{CompareOp};
+pub use class::{CompareOp, PyTypeObject, is_instance};
 pub use objectprotocol::{ObjectProtocol};
 
 #[allow(non_camel_case_types)]

--- a/src/objects/boolobject.rs
+++ b/src/objects/boolobject.rs
@@ -3,6 +3,8 @@ use python::{Python, PythonObject};
 use err::PyResult;
 use super::{PyObject};
 use conversion::{ToPyObject};
+use class::PyTypeObject;
+use objects::PyType;
 
 /// Represents a Python `bool`.
 pub struct PyBool(PyObject);
@@ -39,6 +41,12 @@ impl ToPyObject for bool {
     }
 }
 
+impl PyTypeObject for PyBool {
+    fn type_object(py: Python) -> PyType {
+        unsafe { PyType::from_type_ptr(py, &mut ffi::PyBool_Type) }
+    }
+}
+
 /// Converts a Python `bool` to a rust `bool`.
 ///
 /// Fails with `TypeError` if the input is not a Python `bool`.
@@ -50,6 +58,7 @@ extract!(obj to bool; py => {
 mod test {
     use python::{Python, PythonObject};
     use conversion::ToPyObject;
+    use class::PyTypeObject;
 
     #[test]
     fn test_true() {
@@ -67,5 +76,15 @@ mod test {
         assert!(!py.False().is_true());
         assert_eq!(false, py.False().as_object().extract(py).unwrap());
         assert!(false.to_py_object(py).as_object() == py.False().as_object());
+    }
+
+    #[test]
+    fn test_type_object() {
+        use super::PyBool;
+
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let typ = PyBool::type_object(py);
+        assert_eq!(typ.name(py), "bool");
     }
 }

--- a/src/objects/bytearray.rs
+++ b/src/objects/bytearray.rs
@@ -7,6 +7,8 @@ use ffi;
 use python::{Python, PythonObject, ToPythonPointer};
 use objects::PyObject;
 use err::{self, PyResult, PyErr};
+use class::PyTypeObject;
+use objects::PyType;
 
 /// Represents a Python bytearray.
 pub struct PyByteArray(PyObject);
@@ -71,6 +73,12 @@ impl PyByteArray {
     }
 }
 
+impl PyTypeObject for PyByteArray {
+    fn type_object(py: Python) -> PyType {
+        unsafe { PyType::from_type_ptr(py, &mut ffi::PyByteArray_Type) }
+    }
+}
+
 
 #[cfg(test)]
 mod test {
@@ -101,5 +109,13 @@ mod test {
         } else {
             panic!("error");
         }
+    }
+
+    #[test]
+    fn test_type_object() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let typ = PyByteArray::type_object(py);
+        assert_eq!(typ.name(py), "bytearray");
     }
 }

--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -21,6 +21,8 @@ use python::{Python, PythonObject};
 use objects::PyObject;
 use ffi::{self, Py_ssize_t};
 use conversion::ToPyObject;
+use class::PyTypeObject;
+use objects::PyType;
 
 /// Represents a Python `list`.
 pub struct PyList(PyObject);
@@ -133,11 +135,18 @@ impl <T> ToPyObject for Vec<T> where T: ToPyObject {
     }
 }
 
+impl PyTypeObject for PyList {
+    fn type_object(py: Python) -> PyType {
+        unsafe { PyType::from_type_ptr(py, &mut ffi::PyList_Type) }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use python::{Python, PythonObject};
     use conversion::ToPyObject;
     use objects::PyList;
+    use class::PyTypeObject;
 
     #[test]
     fn test_len() {
@@ -208,5 +217,13 @@ mod test {
         let list = PyList::new(py, &v);
         let v2 = list.into_object().extract::<Vec<i32>>(py).unwrap();
         assert_eq!(v, v2);
+    }
+
+    #[test]
+    fn test_type_object() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let typ = PyList::type_object(py);
+        assert_eq!(typ.name(py), "list");
     }
 }

--- a/src/objects/module.rs
+++ b/src/objects/module.rs
@@ -25,6 +25,7 @@ use conversion::{ToPyObject, ToPyTuple};
 use objects::{PyObject, PyDict, PyType, exc};
 use err::{self, PyResult, PyErr};
 use std::ffi::{CStr, CString};
+use class::PyTypeObject;
 
 /// Represents a Python module object.
 pub struct PyModule(PyObject);
@@ -128,5 +129,26 @@ impl PyModule {
         };
 
         self.add(py, type_name, ty)
+    }
+}
+
+impl PyTypeObject for PyModule {
+    fn type_object(py: Python) -> PyType {
+        unsafe { PyType::from_type_ptr(py, &mut ffi::PyModule_Type) }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use class::PyTypeObject;
+    use python::{Python, PythonObject};
+    use objects::PyModule;
+
+    #[test]
+    fn test_type_object() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let typ = PyModule::type_object(py);
+        assert_eq!(typ.name(py), "module");
     }
 }

--- a/src/objects/tuple.rs
+++ b/src/objects/tuple.rs
@@ -23,6 +23,8 @@ use super::exc;
 use ffi::{self, Py_ssize_t};
 use conversion::{FromPyObject, ToPyObject, ToPyTuple};
 use std::slice;
+use class::PyTypeObject;
+use objects::PyType;
 
 /// Represents a Python tuple object.
 pub struct PyTuple(PyObject);
@@ -214,9 +216,17 @@ extract!(obj to NoArgs; py => {
 });
 
 
+impl PyTypeObject for PyTuple {
+    fn type_object(py: Python) -> PyType {
+        unsafe { PyType::from_type_ptr(py, &mut ffi::PyTuple_Type) }
+    }
+}
+
+
 #[cfg(test)]
 mod test {
     use PyTuple;
+    use class::PyTypeObject;
     use python::{Python, PythonObject, PythonObjectWithCheckedDowncast};
 
     #[test]
@@ -226,6 +236,14 @@ mod test {
         let tuple = PyTuple::new(py, &[1, 2, 3]);
         assert_eq!(3, tuple.len(py));
         assert_eq!((1, 2, 3), tuple.into_object().extract(py).unwrap());
+    }
+
+    #[test]
+    fn test_type_object() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let typ = PyTuple::type_object(py);
+        assert_eq!(typ.name(py), "tuple");
     }
 }
 


### PR DESCRIPTION
I was play with PyO3 to find myself [doing this](https://github.com/messense/rsjson/blob/master/src/lib.rs#L43), had to hardcode type names. Then I wish I have `isinstance` in PyO3 but that only exists in `PyType`:

```rust
impl PyType {
    pub fn is_instance(&self, _: Python, obj : &PyObject) -> bool {}
}
```

But I can't get a `PyType` instance from `PyDict`, `PyList` etc., thus I came up with this.