### PR TITLE
Fix no method named `extract` found for type `&&pyo3::PyInstance`

### DIFF
--- a/pyo3cls/src/module.rs
+++ b/pyo3cls/src/module.rs
@@ -266,6 +266,7 @@ fn wrap_fn(item: &mut syn::Item) -> Option<Box<syn::Block>> {
                     {
                         use std;
                         use pyo3 as _pyo3;
+                        use pyo3::ObjectProtocol;
 
                         #wrapper
 


### PR DESCRIPTION
Fixes #43 