### PR TITLE
Fix some clippy warnings

### DIFF
--- a/pyo3cls/src/py_class.rs
+++ b/pyo3cls/src/py_class.rs
@@ -99,7 +99,7 @@ fn impl_class(cls: &syn::Ident, base: &syn::Ident,
             }
             impl std::convert::AsRef<PyObjectRef> for #cls {
                 fn as_ref(&self) -> &_pyo3::PyObjectRef {
-                    unsafe{std::mem::transmute(self.as_ptr())}
+                    unsafe{&*(self.as_ptr() as *const pyo3::PyObjectRef)}
                 }
             }
             impl<'a> std::convert::From<&'a mut #cls> for &'a #cls
@@ -235,13 +235,13 @@ fn impl_class(cls: &syn::Ident, base: &syn::Ident,
             {
                 let offset = <#cls as _pyo3::typeob::PyTypeInfo>::offset();
                 let ptr = (ob.as_ptr() as *mut u8).offset(offset) as *mut #cls;
-                std::mem::transmute(ptr)
+                &*ptr
             }
             unsafe fn unchecked_mut_downcast_from(ob: &_pyo3::PyObjectRef) -> &mut Self
             {
                 let offset = <#cls as _pyo3::typeob::PyTypeInfo>::offset();
                 let ptr = (ob.as_ptr() as *mut u8).offset(offset) as *mut #cls;
-                std::mem::transmute(ptr)
+                &mut *ptr
             }
         }
         impl _pyo3::PyMutDowncastFrom for #cls

--- a/src/argparse.rs
+++ b/src/argparse.rs
@@ -102,7 +102,7 @@ pub fn parse_args<'p>(py: Python<'p>,
 
 #[inline]
 #[doc(hidden)]
-pub unsafe fn get_kwargs<'p>(py: Python<'p>, ptr: *mut ffi::PyObject) -> Option<&PyDict> {
+pub unsafe fn get_kwargs(py: Python, ptr: *mut ffi::PyObject) -> Option<&PyDict> {
     if ptr.is_null() {
         None
     } else {

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -112,7 +112,7 @@ impl PySetterDef {
             dst.name = CString::new(self.name).expect(
                 "Method name must not contain NULL byte").into_raw();
         }
-        dst.set = Some(self.meth.clone());
+        dst.set = Some(self.meth);
     }
 }
 

--- a/src/err.rs
+++ b/src/err.rs
@@ -197,7 +197,7 @@ impl PyErr {
     }
 
     fn new_helper(_py: Python, ty: &PyType, value: PyObject) -> PyErr {
-        assert!(unsafe { ffi::PyExceptionClass_Check(ty.as_ptr()) } != 0);
+        assert_ne!(unsafe { ffi::PyExceptionClass_Check(ty.as_ptr()) }, 0);
         PyErr {
             ptype: ty.into(),
             pvalue: Some(value),
@@ -214,7 +214,7 @@ impl PyErr {
         PyErr::from_instance_helper(py, obj.into_object(py))
     }
 
-    fn from_instance_helper<'p>(py: Python, obj: PyObject) -> PyErr {
+    fn from_instance_helper(py: Python, obj: PyObject) -> PyErr {
         let ptr = obj.as_ptr();
 
         if unsafe { ffi::PyExceptionInstance_Check(ptr) } != 0 {
@@ -418,7 +418,7 @@ impl ToPyErr for io::Error {
         let errno = self.raw_os_error().unwrap_or(0);
         let errdesc = self.description();
 
-        PyErr::new_err(py, &tp, (errno, errdesc))
+        PyErr::new_err(py, tp, (errno, errdesc))
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -112,8 +112,8 @@ impl PyObject {
     /// Transmutes a slice of owned FFI pointers to `&[PyObject]`.
     /// Undefined behavior if any pointer in the slice is NULL or invalid.
     #[inline]
-    pub unsafe fn borrow_from_owned_ptr_slice<'a>(ptr: &'a [*mut ffi::PyObject])
-                                                  -> &'a [PyObject] {
+    pub unsafe fn borrow_from_owned_ptr_slice(ptr: &[*mut ffi::PyObject])
+                                                  -> &[PyObject] {
         std::mem::transmute(ptr)
     }
 

--- a/src/objectprotocol.rs
+++ b/src/objectprotocol.rs
@@ -115,7 +115,7 @@ pub trait ObjectProtocol {
     /// Takes an object and returns an iterator for it.
     /// This is typically a new iterator but if the argument
     /// is an iterator, this returns itself.
-    fn iter<'p>(&'p self) -> PyResult<PyIterator<'p>>;
+    fn iter(&self) -> PyResult<PyIterator>;
 
     /// Gets the Python type object for this object's type.
     fn get_type(&self) -> &PyType;

--- a/src/objects/boolobject.rs
+++ b/src/objects/boolobject.rs
@@ -14,7 +14,7 @@ pyobject_nativetype!(PyBool, PyBool_Type, PyBool_Check);
 impl PyBool {
     /// Depending on `val`, returns `py.True()` or `py.False()`.
     #[inline]
-    pub fn new<'p>(py: Python<'p>, val: bool) -> &'p PyBool {
+    pub fn new(py: Python, val: bool) -> &PyBool {
         unsafe {
             py.cast_from_borrowed_ptr(if val { ffi::Py_True() } else { ffi::Py_False() })
         }

--- a/src/objects/bytearray.rs
+++ b/src/objects/bytearray.rs
@@ -30,7 +30,7 @@ impl PyByteArray {
 
     /// Creates a new Python bytearray object
     /// from other PyObject, that implements the buffer protocol.
-    pub fn from<'p, I>(py: Python<'p>, src: I) -> PyResult<&'p PyByteArray>
+    pub fn from<I>(py: Python, src: I) -> PyResult<&PyByteArray>
         where I: ToPyPointer
     {
         unsafe {

--- a/src/objects/dict.rs
+++ b/src/objects/dict.rs
@@ -23,7 +23,7 @@ impl PyDict {
     /// Creates a new empty dictionary.
     ///
     /// May panic when running out of memory.
-    pub fn new<'p>(py: Python<'p>) -> &'p PyDict {
+    pub fn new(py: Python) -> &PyDict {
         unsafe {
             py.cast_from_ptr::<PyDict>(ffi::PyDict_New())
         }

--- a/src/objects/exc.rs
+++ b/src/objects/exc.rs
@@ -25,7 +25,7 @@ macro_rules! exc_type(
             fn init_type(_py: Python) {}
 
             #[inline]
-            fn type_object<'p>(py: $crate::python::Python<'p>) -> &'p $crate::PyType {
+            fn type_object(py: $crate::python::Python) -> &$crate::PyType {
                 unsafe { PyType::from_type_ptr(py, ffi::$exc_name as *mut ffi::PyTypeObject) }
             }
         }
@@ -129,7 +129,7 @@ impl UnicodeDecodeError {
         }
     }
 
-    pub fn new_utf8<'p>(py: Python, input: &[u8], err: std::str::Utf8Error)
+    pub fn new_utf8(py: Python, input: &[u8], err: std::str::Utf8Error)
                         -> PyResult<PyObject>
     {
         let pos = err.valid_up_to();

--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -30,7 +30,7 @@ impl PyList {
     }
 
     /// Construct a new empty list.
-    pub fn empty<'p>(py: Python<'p>) -> &'p PyList {
+    pub fn empty(py: Python) -> &PyList {
         unsafe {
             py.cast_from_ptr::<PyList>(ffi::PyList_New(0))
         }

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -97,7 +97,7 @@ macro_rules! pyobject_nativetype(
         }
         impl $crate::PyObjectWithToken for $name {
             #[inline(always)]
-            fn py<'p>(&'p self) -> $crate::Python<'p> {
+            fn py(&self) -> $crate::Python {
                 unsafe { $crate::Python::assume_gil_acquired() }
             }
         }
@@ -165,7 +165,7 @@ macro_rules! pyobject_nativetype(
             fn init_type(_py: $crate::Python) {}
 
             #[inline]
-            fn type_object<'p>(py: $crate::Python<'p>) -> &'p $crate::PyType {
+            fn type_object(py: $crate::Python) -> &$crate::PyType {
                 unsafe { $crate::PyType::from_type_ptr(py, &mut $crate::ffi::$typeobject) }
             }
         }
@@ -173,7 +173,7 @@ macro_rules! pyobject_nativetype(
         impl $crate::ToPyObject for $name
         {
             #[inline]
-            fn to_object<'p>(&self, py: $crate::Python<'p>) -> $crate::PyObject {
+            fn to_object(&self, py: $crate::Python) -> $crate::PyObject {
                 unsafe {$crate::PyObject::from_borrowed_ptr(py, self.0.as_ptr())}
             }
 
@@ -188,7 +188,7 @@ macro_rules! pyobject_nativetype(
         impl<'a> $crate::IntoPyObject for &'a $name
         {
             #[inline]
-            fn into_object<'p>(self, py: $crate::Python) -> $crate::PyObject {
+            fn into_object(self, py: $crate::Python) -> $crate::PyObject {
                 unsafe { $crate::PyObject::from_borrowed_ptr(py, self.as_ptr()) }
             }
         }

--- a/src/objects/module.rs
+++ b/src/objects/module.rs
@@ -51,7 +51,7 @@ impl PyModule {
         }
     }
 
-    unsafe fn str_from_ptr<'a>(&'a self, ptr: *const c_char) -> PyResult<&'a str> {
+    unsafe fn str_from_ptr(&self, ptr: *const c_char) -> PyResult<&str> {
         if ptr.is_null() {
             Err(PyErr::fetch(self.py()))
         } else {
@@ -68,14 +68,14 @@ impl PyModule {
     /// Gets the module name.
     ///
     /// May fail if the module does not have a `__name__` attribute.
-    pub fn name<'a>(&'a self) -> PyResult<&'a str> {
+    pub fn name(&self) -> PyResult<&str> {
         unsafe { self.str_from_ptr(ffi::PyModule_GetName(self.as_ptr())) }
     }
 
     /// Gets the module filename.
     ///
     /// May fail if the module does not have a `__file__` attribute.
-    pub fn filename<'a>(&'a self) -> PyResult<&'a str> {
+    pub fn filename(&self) -> PyResult<&str> {
         unsafe { self.str_from_ptr(ffi::PyModule_GetFilename(self.as_ptr())) }
     }
 

--- a/src/objects/num3.rs
+++ b/src/objects/num3.rs
@@ -81,7 +81,7 @@ macro_rules! int_fits_larger_int(
 );
 
 
-fn err_if_invalid_value<'p, T: PartialEq>
+fn err_if_invalid_value<T: PartialEq>
     (py: Python, invalid_value: T, actual_value: T) -> PyResult<T>
 {
     if actual_value == invalid_value && PyErr::occurred(py) {

--- a/src/objects/slice.rs
+++ b/src/objects/slice.rs
@@ -40,7 +40,7 @@ impl PySliceIndices {
 impl PySlice {
 
     /// Construct a new slice with the given elements.
-    pub fn new<'p>(py: Python<'p>, start: isize, stop: isize, step: isize) -> &'p PySlice {
+    pub fn new(py: Python, start: isize, stop: isize, step: isize) -> &PySlice {
         unsafe {
             let ptr = ffi::PySlice_New(ffi::PyLong_FromLong(start as i64),
                                        ffi::PyLong_FromLong(stop as i64),

--- a/src/objects/tuple.rs
+++ b/src/objects/tuple.rs
@@ -65,7 +65,7 @@ impl PyTuple {
     }
 
     #[inline]
-    pub fn as_slice<'a>(&'a self) -> &'a [PyObject] {
+    pub fn as_slice(&self) -> &[PyObject] {
         // This is safe because PyObject has the same memory layout as *mut ffi::PyObject,
         // and because tuples are immutable.
         // (We don't even need a Python token, thanks to immutability)

--- a/src/objects/typeobject.rs
+++ b/src/objects/typeobject.rs
@@ -30,13 +30,13 @@ impl PyType {
     /// This increments the reference count on the type object.
     /// Undefined behavior if the pointer is NULL or invalid.
     #[inline]
-    pub unsafe fn from_type_ptr<'p>(py: Python<'p>, p: *mut ffi::PyTypeObject) -> &'p PyType
+    pub unsafe fn from_type_ptr(py: Python, p: *mut ffi::PyTypeObject) -> &PyType
     {
         py.cast_from_borrowed_ptr::<PyType>(p as *mut ffi::PyObject)
     }
 
     /// Gets the name of the PyType.
-    pub fn name<'a>(&'a self) -> Cow<'a, str> {
+    pub fn name(&self) -> Cow<str> {
         unsafe {
             CStr::from_ptr((*self.as_type_ptr()).tp_name).to_string_lossy()
         }

--- a/src/python.rs
+++ b/src/python.rs
@@ -54,15 +54,15 @@ pub trait PyMutDowncastFrom : Sized {
 pub trait PyDowncastInto : Sized {
 
     /// Cast Self to a concrete Python object type.
-    fn downcast_into<'p, I>(Python<'p>, I) -> Result<Self, PyDowncastError<'p>>
+    fn downcast_into<I>(Python, I) -> Result<Self, PyDowncastError>
         where I: ToPyPointer + IntoPyPointer;
 
     /// Cast from ffi::PyObject to a concrete Python object type.
-    fn downcast_into_from_ptr<'p>(py: Python<'p>, ptr: *mut ffi::PyObject)
-                                  -> Result<Self, PyDowncastError<'p>>;
+    fn downcast_into_from_ptr(py: Python, ptr: *mut ffi::PyObject)
+                                  -> Result<Self, PyDowncastError>;
 
     /// Cast from ffi::PyObject to a concrete Python object type.
-    fn unchecked_downcast_into<'p, I>(I) -> Self where I: IntoPyPointer;
+    fn unchecked_downcast_into<I>(I) -> Self where I: IntoPyPointer;
 }
 
 /// This trait allows retrieving the underlying FFI pointer from Python objects.
@@ -84,7 +84,7 @@ impl<'p, T> ToPyPointer for Option<&'p T> where T: ToPyPointer {
     #[inline]
     default fn as_ptr(&self) -> *mut ffi::PyObject {
         match *self {
-            Some(ref t) => t.as_ptr(),
+            Some(t) => t.as_ptr(),
             None => std::ptr::null_mut()
         }
     }


### PR DESCRIPTION
Notable changes:

1. Elide lifetime annotations if possible
2. Prefer dereference over transmute