### PR TITLE
Fix PyIterator segfault

### DIFF
--- a/src/objects/iterator.rs
+++ b/src/objects/iterator.rs
@@ -44,7 +44,7 @@ impl <'p> Iterator for PyIterator<'p> {
         let py = self.0.py();
 
         match unsafe {
-            py.cast_from_ptr_or_opt(ffi::PyIter_Next(self.0.as_ptr())) }
+            py.cast_from_borrowed_ptr_or_opt(ffi::PyIter_Next(self.0.as_ptr())) }
         {
             Some(obj) => Some(Ok(obj)),
             None => {


### PR DESCRIPTION
Fixes #71 

https://docs.python.org/3/c-api/iter.html#c.PyIter_Next

`PyIter_Next` **Return value: New reference**

That means here we should use `cast_from_borrowed_ptr_or_opt`, right?

I'm still a little confused about `cast_from_*` methods. May need more docs on that.