### PR TITLE
Remove too strict version requirement for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Supported Python versions:
 Supported Rust version:
 
 * Rust 1.23.0-nightly 2017-11-07 or later
-* On Windows, we require rustc 1.23.0-nightly 2017-11-07
 
 ## Usage
 


### PR DESCRIPTION
The special rustc version requirement for Windows was introduced in
https://github.com/dgrunwald/rust-cpython/commit/f6ed2bbae9b9e9bb0f213d9de051f13bc463005f#diff-04c6e90faac2675aa89e2176d2eec7d8R23

Required versions converged in
https://github.com/PyO3/pyo3/commit/0c7293125cc16639fc8a2a8ccd1682cc391ed1ec#diff-04c6e90faac2675aa89e2176d2eec7d8R19

And since then it seems they were updated mechanically in sync.