### PR TITLE
Remove PyEval_ThreadsInitialized() assertion #110

### DIFF
--- a/src/pythonrun.rs
+++ b/src/pythonrun.rs
@@ -41,8 +41,6 @@ pub fn prepare_freethreaded_python() {
             // as we can't make the existing Python main thread acquire the GIL.
             assert_ne!(ffi::PyEval_ThreadsInitialized(), 0);
         } else {
-            // If Python isn't initialized yet, we expect that Python threading isn't initialized either.
-            assert_eq!(ffi::PyEval_ThreadsInitialized(), 0);
             // Initialize Python.
             // We use Py_InitializeEx() with initsigs=0 to disable Python signal handling.
             // Signal handling depends on the notion of a 'main thread', which doesn't exist in this case.


### PR DESCRIPTION
First, this function should not be called before `Py_Initialize()`.
It accesses the field `_PyRuntime.ceval.gil.locked` of the global
variable, which is zero initially, but uses -1 to indicate that
the GIL is not created or destroyed.
(https://github.com/python/cpython/blob/8ff53564730f7ba503f5ad94418c309c48e8516d/Python/ceval_gil.h#L98)

Second, this assertion can't be moved after `Py_InitializeEx(0)` call,
because in Python 3.7 they started calling `PyEval_InitThreads()`
from `Py_Initialize()`.
(https://github.com/python/cpython/commit/2914bb32e2adf8dff77c0ca58b33201bc94e398c#diff-baf5eab51059d96fb8837152dab0d1a4R689)