### PR TITLE
Fix wrong macro being tagged with `macro_export`

### DIFF
--- a/src/objects/exc_impl.rs
+++ b/src/objects/exc_impl.rs
@@ -38,6 +38,7 @@ macro_rules! dot_stringify {
 ///     py.run("import socket; assert gaierror is socket.gaierror", None, Some(ctx)).unwrap();
 /// }
 /// ```
+#[macro_export]
 macro_rules! import_exception {
     ($($module:ident).+ , $name: ident) => {
         #[allow(non_camel_case_types)]


### PR DESCRIPTION
I forgot to tag `ìmport_exception` with `#[macro_export]`, so now it can't be used by dependent crates.