### PR TITLE
Add PEP 523 frame eval API methods and definitions

### DIFF
--- a/src/ffi3/ceval.rs
+++ b/src/ffi3/ceval.rs
@@ -1,6 +1,7 @@
 use std::os::raw::{c_void, c_char, c_int};
 use ffi3::object::PyObject;
 use ffi3::pystate::PyThreadState;
+#[cfg(Py_3_6)]
 use ffi3::code::FreeFunc;
 
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {

--- a/src/ffi3/ceval.rs
+++ b/src/ffi3/ceval.rs
@@ -1,6 +1,7 @@
 use std::os::raw::{c_void, c_char, c_int};
 use ffi3::object::PyObject;
 use ffi3::pystate::PyThreadState;
+use ffi3::code::FreeFunc;
 
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
     pub fn PyEval_CallObjectWithKeywords(func: *mut PyObject,
@@ -37,11 +38,19 @@ pub unsafe fn PyEval_CallObject(func: *mut PyObject, arg: *mut PyObject) -> *mut
 
 // TODO: Py_EnterRecursiveCall etc.
 
+#[cfg(Py_3_6)]
+pub type _PyFrameEvalFunction = extern "C" fn(*mut ::ffi3::PyFrameObject, c_int) -> *mut PyObject;
+
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
     pub fn PyEval_GetFuncName(arg1: *mut PyObject) -> *const c_char;
     pub fn PyEval_GetFuncDesc(arg1: *mut PyObject) -> *const c_char;
     pub fn PyEval_GetCallStats(arg1: *mut PyObject) -> *mut PyObject;
     pub fn PyEval_EvalFrame(arg1: *mut ::ffi3::PyFrameObject) -> *mut PyObject;
+    #[cfg(Py_3_6)]
+    pub fn _PyEval_EvalFrameDefault(arg1: *mut ::ffi3::PyFrameObject,
+                                    exc: c_int) -> *mut PyObject;
+    #[cfg(Py_3_6)]
+    pub fn _PyEval_RequestCodeExtraIndex(func: FreeFunc) -> c_int;
     pub fn PyEval_EvalFrameEx(f: *mut ::ffi3::PyFrameObject, exc: c_int)
      -> *mut PyObject;
     pub fn PyEval_SaveThread() -> *mut PyThreadState;

--- a/src/ffi3/code.rs
+++ b/src/ffi3/code.rs
@@ -64,8 +64,17 @@ pub const CO_FUTURE_GENERATOR_STOP : c_int = 0x8_0000;
 
 pub const CO_MAXBLOCKS: usize = 20;
 
+#[cfg(Py_3_6)]
+pub type FreeFunc = extern "C" fn(*mut c_void) -> c_void;
+
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
     pub static mut PyCode_Type: PyTypeObject;
+    #[cfg(Py_3_6)]
+    pub fn _PyCode_GetExtra(code: *mut PyObject, index: Py_ssize_t,
+                            extra: *const *mut c_void) -> c_int;
+    #[cfg(Py_3_6)]
+    pub fn _PyCode_SetExtra(code: *mut PyObject, index: Py_ssize_t,
+                            extra: *mut c_void) -> c_int;
 
     pub fn PyCode_New(arg1: c_int, arg2: c_int,
                       arg3: c_int, arg4: c_int,

--- a/src/ffi3/pystate.rs
+++ b/src/ffi3/pystate.rs
@@ -1,12 +1,25 @@
 use std::os::raw::{c_int, c_long};
 use ffi3::object::PyObject;
 use ffi3::moduleobject::PyModuleDef;
+use ffi3::ceval::_PyFrameEvalFunction;
 
 #[cfg(Py_3_6)]
 pub const MAX_CO_EXTRA_USERS: c_int = 255;
 
-pub enum PyInterpreterState { }
-pub enum PyThreadState { }
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyInterpreterState {
+    pub ob_base: PyObject,
+    #[cfg(Py_3_6)]
+    pub eval_frame: _PyFrameEvalFunction,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyThreadState { 
+    pub ob_base: PyObject,
+    pub interp: *mut PyInterpreterState,
+}
 
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
     pub fn PyInterpreterState_New() -> *mut PyInterpreterState;

--- a/src/ffi3/pystate.rs
+++ b/src/ffi3/pystate.rs
@@ -1,6 +1,7 @@
 use std::os::raw::{c_int, c_long};
 use ffi3::object::PyObject;
 use ffi3::moduleobject::PyModuleDef;
+#[cfg(Py_3_6)]
 use ffi3::ceval::_PyFrameEvalFunction;
 
 #[cfg(Py_3_6)]

--- a/src/ffi3/pythonrun.rs
+++ b/src/ffi3/pythonrun.rs
@@ -25,7 +25,7 @@ use ffi3::pyarena::PyArena;
 #[derive(Copy, Clone)]
 #[cfg(not(Py_LIMITED_API))]
 pub struct PyCompilerFlags {
-    cf_flags : c_int
+    pub cf_flags : c_int
 }
 
 #[cfg(not(Py_LIMITED_API))]

--- a/src/ffi3/sysmodule.rs
+++ b/src/ffi3/sysmodule.rs
@@ -1,8 +1,10 @@
 use std::os::raw::{c_char, c_int};
 use libc::wchar_t;
 use ffi3::object::PyObject;
+use ffi3::pyport::Py_ssize_t;
 
 #[cfg_attr(windows, link(name="pythonXY"))] extern "C" {
+    pub fn Py_DecodeLocale(arg1: *const c_char, arg2: Py_ssize_t) -> *mut wchar_t;
     pub fn PySys_GetObject(arg1: *const c_char) -> *mut PyObject;
     pub fn PySys_SetObject(arg1: *const c_char, arg2: *mut PyObject)
      -> c_int;


### PR DESCRIPTION
I also added a  utility function (`Py_DecodeLocale`) which I found useful.