### PR TITLE
Fix compilation on nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ features = ["extension-module"]
 extern crate pyo3;
 use pyo3::prelude::*;
 
+use pyo3::py::modinit as pymodinit;
+
 // add bindings to the generated python module
 // N.B: names: "librust2py" must be the name of the `.so` or `.pyd` file
 /// This module is implemented in Rust.
-#[py::modinit(rust2py)]
+#[pymodinit(rust2py)]
 fn init_mod(py: Python, m: &PyModule) -> PyResult<()> {
 
     #[pyfn(m, "sum_as_string")]

--- a/examples/word-count-cls/src/lib.rs
+++ b/examples/word-count-cls/src/lib.rs
@@ -12,13 +12,17 @@ use std::io::prelude::*;
 use rayon::prelude::*;
 use pyo3::prelude::*;
 
-#[py::class]
+use pyo3::py::methods as pymethods;
+use pyo3::py::class as pyclass;
+use pyo3::py::modinit as pymodinit;
+
+#[pyclass]
 struct WordCounter {
     path: String,
     token: PyToken,
 }
 
-#[py::methods]
+#[pymethods]
 impl WordCounter {
 
     #[new]
@@ -81,9 +85,7 @@ fn wc_parallel(lines: &str, search: &str) -> i32 {
          .sum()
 }
 
-
-
-#[py::modinit(_word_count)]
+#[pymodinit(_word_count)]
 fn init_mod(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<WordCounter>()?;
 

--- a/examples/word-count/src/lib.rs
+++ b/examples/word-count/src/lib.rs
@@ -10,6 +10,8 @@ use std::io::prelude::*;
 use rayon::prelude::*;
 use pyo3::prelude::*;
 
+use pyo3::py::modinit as pymodinit;
+
 fn matches(word: &str, search: &str) -> bool {
     let mut search = search.chars();
     for ch in word.chars().skip_while(|ch| !ch.is_alphabetic()) {
@@ -47,7 +49,7 @@ fn wc_parallel(lines: &str, search: &str) -> i32 {
          .sum()
 }
 
-#[py::modinit(_word_count)]
+#[pymodinit(_word_count)]
 fn init_mod(py: Python, m: &PyModule) -> PyResult<()> {
 
     #[pyfn(m, "search")]

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -28,10 +28,12 @@ Now you can write your module, for example
 extern crate pyo3;
 use pyo3::{py, PyResult, Python, PyModule};
 
+use pyo3::py::modinit as pymodinit;
+
 // add bindings to the generated python module
 // N.B: names: "librust2py" must be the name of the `.so` or `.pyd` file
 /// This module is implemented in Rust.
-#[py::modinit(rust2py)]
+#[pymodinit(rust2py)]
 fn init_mod(py: Python, m: &PyModule) -> PyResult<()> {
 
     // pyo3 aware function. All of our python interface could be declared in a separate module.

--- a/guide/src/overview.md
+++ b/guide/src/overview.md
@@ -78,10 +78,12 @@ features = ["extension-module"]
 extern crate pyo3;
 use pyo3::{py, PyResult, Python, PyModule};
 
+use pyo3::py::modinit as pymodinit;
+
 // add bindings to the generated python module
 // N.B: names: "librust2py" must be the name of the `.so` or `.pyd` file
 /// This module is implemented in Rust.
-#[py::modinit(rust2py)]
+#[pymodinit(rust2py)]
 fn init_mod(py: Python, m: &PyModule) -> PyResult<()> {
 
     #[pyfn(m, "sum_as_string")]

--- a/guide/src/parallelism.md
+++ b/guide/src/parallelism.md
@@ -28,7 +28,7 @@ Then in the Python bridge, we have a function `search` exposed to Python runtime
 `Python::allow_threads` method to enable true parallelism:
 
 ```rust,ignore
-#[py::modinit(_word_count)]
+#[pymodinit(_word_count)]
 fn init_mod(py: Python, m: &PyModule) -> PyResult<()> {
 
     #[pyfn(m, "search")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,10 +54,10 @@
 //! # Python extension
 //!
 //! To allow Python to load the rust code as a Python extension
-//! module, you need provide initialization function and annotate it with `#[py::modinit(name)]`.
-//! `py::modinit` expands to an `extern "C"` function.
+//! module, you need provide initialization function and annotate it with `#[pymodinit(name)]`.
+//! `pymodinit` expands to an `extern "C"` function.
 //!
-//! Macro syntax: `#[py::modinit(name)]`
+//! Macro syntax: `#[pymodinit(name)]`
 //!
 //! 1. `name`: The module name as a Rust identifier
 //! 2. Decorate init function `Fn(Python, &PyModule) -> PyResult<()>`.
@@ -80,11 +80,13 @@
 //! extern crate pyo3;
 //! use pyo3::{py, Python, PyResult, PyModule, PyString};
 //!
+//! use pyo3::py::modinit as pymodinit;
+//!
 //! // add bindings to the generated python module
 //! // N.B: names: "libhello" must be the name of the `.so` or `.pyd` file
 //!
 //! /// Module documentation string
-//! #[py::modinit(hello)]
+//! #[pymodinit(hello)]
 //! fn init_module(py: Python, m: &PyModule) -> PyResult<()> {
 //!
 //!     // pyo3 aware function. All of our python interface could be declared

--- a/src/pythonrun.rs
+++ b/src/pythonrun.rs
@@ -27,7 +27,7 @@ static START_PYO3: sync::Once = sync::ONCE_INIT;
 /// thread (the thread which originally initialized Python) also initializes
 /// threading.
 ///
-/// When writing an extension module, the `#[py::modinit(..)]` macro
+/// When writing an extension module, the `#[pymodinit(..)]` macro
 /// will ensure that Python threading is initialized.
 ///
 pub fn prepare_freethreaded_python() {

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -8,14 +8,17 @@ use std::os::raw::{c_int, c_void};
 
 use pyo3::*;
 
+use pyo3::py::class as pyclass;
+use pyo3::py::proto as pyproto;
 
-#[py::class]
+
+#[pyclass]
 struct TestClass {
     vec: Vec<u8>,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl class::PyBufferProtocol for TestClass {
 
     fn bf_getbuffer(&self, view: *mut ffi::Py_buffer, flags: c_int) -> PyResult<()> {

--- a/tests/test_class.rs
+++ b/tests/test_class.rs
@@ -10,6 +10,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use pyo3::ffi;
 
+use pyo3::py::class as pyclass;
+use pyo3::py::methods as pymethods;
+use pyo3::py::proto as pyproto;
 
 macro_rules! py_run {
     ($py:expr, $val:ident, $code:expr) => {{
@@ -35,7 +38,7 @@ macro_rules! py_expect_exception {
     }}
 }
 
-#[py::class]
+#[pyclass]
 struct EmptyClass { }
 
 #[test]
@@ -53,7 +56,7 @@ fn empty_class() {
 ///Line2
 ///  Line3
 // this is not doc string
-#[py::class]
+#[pyclass]
 struct ClassWithDocs { }
 
 #[test]
@@ -66,7 +69,7 @@ fn class_with_docstr() {
     }
 }
 
-#[py::class(name=CustomName)]
+#[pyclass(name=CustomName)]
 struct EmptyClass2 { }
 
 #[test]
@@ -77,7 +80,7 @@ fn custom_class_name() {
     py_assert!(py, typeobj, "typeobj.__name__ == 'CustomName'");
 }
 
-#[py::class]
+#[pyclass]
 struct EmptyClassInModule { }
 
 #[test]
@@ -92,12 +95,12 @@ fn empty_class_in_module() {
     assert_eq!(ty.getattr("__module__").unwrap().extract::<String>().unwrap(), "test_module.nested");
 }
 
-#[py::class]
+#[pyclass]
 struct EmptyClassWithNew {
     token: PyToken
 }
 
-#[py::methods]
+#[pymethods]
 impl EmptyClassWithNew {
     #[__new__]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
@@ -113,13 +116,13 @@ fn empty_class_with_new() {
     assert!(typeobj.call(NoArgs, NoArgs).unwrap().cast_as::<EmptyClassWithNew>().is_ok());
 }
 
-#[py::class]
+#[pyclass]
 struct NewWithOneArg {
     _data: i32,
     token: PyToken
 }
 
-#[py::methods]
+#[pymethods]
 impl NewWithOneArg {
     #[new]
     fn __new__(obj: &PyRawObject, arg: i32) -> PyResult<()> {
@@ -137,7 +140,7 @@ fn new_with_one_arg() {
     assert_eq!(obj._data, 42);
 }
 
-#[py::class]
+#[pyclass]
 struct NewWithTwoArgs {
     _data1: i32,
     _data2: i32,
@@ -145,7 +148,7 @@ struct NewWithTwoArgs {
     token: PyToken
 }
 
-#[py::methods]
+#[pymethods]
 impl NewWithTwoArgs {
     #[new]
     fn __new__(obj: &PyRawObject, arg1: i32, arg2: i32) -> PyResult<()>
@@ -165,7 +168,7 @@ fn new_with_two_args() {
     assert_eq!(obj._data2, 20);
 }
 
-#[py::class(freelist=2)]
+#[pyclass(freelist=2)]
 struct ClassWithFreelist{token: PyToken}
 
 #[test]
@@ -202,7 +205,7 @@ impl Drop for TestDropCall {
     }
 }
 
-#[py::class]
+#[pyclass]
 struct DataIsDropped {
     member1: TestDropCall,
     member2: TestDropCall,
@@ -231,7 +234,7 @@ fn data_is_dropped() {
     assert!(drop_called2.load(Ordering::Relaxed));
 }
 
-#[py::class]
+#[pyclass]
 struct ClassWithDrop {
     token: PyToken,
 }
@@ -277,13 +280,13 @@ fn create_pointers_in_drop() {
     }
 }
 
-#[py::class]
+#[pyclass]
 struct InstanceMethod {
     member: i32,
     token: PyToken
 }
 
-#[py::methods]
+#[pymethods]
 impl InstanceMethod {
     /// Test method
     fn method(&self) -> PyResult<i32> {
@@ -304,13 +307,13 @@ fn instance_method() {
     py.run("assert obj.method.__doc__ == 'Test method'", None, Some(d)).unwrap();
 }
 
-#[py::class]
+#[pyclass]
 struct InstanceMethodWithArgs {
     member: i32,
     token: PyToken
 }
 
-#[py::methods]
+#[pymethods]
 impl InstanceMethodWithArgs {
     fn method(&self, multiplier: i32) -> PyResult<i32> {
         Ok(self.member * multiplier)
@@ -331,10 +334,10 @@ fn instance_method_with_args() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct ClassMethod {token: PyToken}
 
-#[py::methods]
+#[pymethods]
 impl ClassMethod {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
@@ -359,10 +362,10 @@ fn class_method() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct ClassMethodWithArgs{token: PyToken}
 
-#[py::methods]
+#[pymethods]
 impl ClassMethodWithArgs {
     #[classmethod]
     fn method(cls: &PyType, input: &PyString) -> PyResult<String> {
@@ -380,12 +383,12 @@ fn class_method_with_args() {
     py.run("assert C.method('abc') == 'ClassMethodWithArgs.method(abc)'", None, Some(d)).unwrap();
 }
 
-#[py::class]
+#[pyclass]
 struct StaticMethod {
     token: PyToken
 }
 
-#[py::methods]
+#[pymethods]
 impl StaticMethod {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
@@ -410,10 +413,10 @@ fn static_method() {
     py.run("assert C().method() == 'StaticMethod.method()!'", None, Some(d)).unwrap();
 }
 
-#[py::class]
+#[pyclass]
 struct StaticMethodWithArgs{token: PyToken}
 
-#[py::methods]
+#[pymethods]
 impl StaticMethodWithArgs {
 
     #[staticmethod]
@@ -434,14 +437,14 @@ fn static_method_with_args() {
     py.run("assert C.method(1337) == '0x539'", None, Some(d)).unwrap();
 }
 
-#[py::class]
+#[pyclass]
 struct GCIntegration {
     self_ref: RefCell<PyObject>,
     dropped: TestDropCall,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl PyGCProtocol for GCIntegration {
     fn __traverse__(&self, visit: PyVisit) -> Result<(), PyTraverseError> {
         visit.call(&*self.self_ref.borrow())
@@ -473,7 +476,7 @@ fn gc_integration() {
     assert!(drop_called.load(Ordering::Relaxed));
 }
 
-#[py::class(gc)]
+#[pyclass(gc)]
 struct GCIntegration2 {
     token: PyToken,
 }
@@ -485,7 +488,7 @@ fn gc_integration2() {
     py_run!(py, inst, "import gc; assert inst in gc.get_objects()");
 }
 
-#[py::class(weakref)]
+#[pyclass(weakref)]
 struct WeakRefSupport {
     token: PyToken,
 }
@@ -497,13 +500,13 @@ fn weakref_support() {
     py_run!(py, inst, "import weakref; assert weakref.ref(inst)() is inst");
 }
 
-#[py::class]
+#[pyclass]
 pub struct Len {
     l: usize,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl PyMappingProtocol for Len {
     fn __len__(&self) -> PyResult<usize> {
         Ok(self.l)
@@ -526,13 +529,13 @@ fn len() {
     py_expect_exception!(py, inst, "len(inst)", OverflowError);
 }
 
-#[py::class]
+#[pyclass]
 struct Iterator{
     iter: Box<iter::Iterator<Item=i32> + Send>,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl PyIterProtocol for Iterator {
     fn __iter__(&mut self) -> PyResult<Py<Iterator>> {
         Ok(self.into())
@@ -553,10 +556,10 @@ fn iterator() {
     py_assert!(py, inst, "list(inst) == [5, 6, 7]");
 }
 
-#[py::class]
+#[pyclass]
 struct StringMethods {token: PyToken}
 
-#[py::proto]
+#[pyproto]
 impl<'p> PyObjectProtocol<'p> for StringMethods {
     fn __str__(&self) -> PyResult<&'static str> {
         Ok("str")
@@ -606,13 +609,13 @@ fn string_methods() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct Comparisons {
     val: i32,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl PyObjectProtocol for Comparisons {
     fn __hash__(&self) -> PyResult<isize> {
         Ok(self.val as isize)
@@ -641,12 +644,12 @@ fn comparisons() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct Sequence {
     token: PyToken
 }
 
-#[py::proto]
+#[pyproto]
 impl PySequenceProtocol for Sequence {
     fn __len__(&self) -> PyResult<usize> {
         Ok(5)
@@ -671,10 +674,10 @@ fn sequence() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct Callable {token: PyToken}
 
-#[py::methods]
+#[pymethods]
 impl Callable {
 
     #[__call__]
@@ -696,14 +699,14 @@ fn callable() {
     py_assert!(py, nc, "not callable(nc)");
 }
 
-#[py::class]
+#[pyclass]
 struct SetItem {
     key: i32,
     val: i32,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl PyMappingProtocol<'a> for SetItem {
     fn __setitem__(&mut self, key: i32, val: i32) -> PyResult<()> {
         self.key = key;
@@ -724,13 +727,13 @@ fn setitem() {
     py_expect_exception!(py, c, "del c[1]", NotImplementedError);
 }
 
-#[py::class]
+#[pyclass]
 struct DelItem {
     key: i32,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl PyMappingProtocol<'a> for DelItem {
     fn __delitem__(&mut self, key: i32) -> PyResult<()> {
         self.key = key;
@@ -749,13 +752,13 @@ fn delitem() {
     py_expect_exception!(py, c, "c[1] = 2", NotImplementedError);
 }
 
-#[py::class]
+#[pyclass]
 struct SetDelItem {
     val: Option<i32>,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl PyMappingProtocol for SetDelItem {
     fn __setitem__(&mut self, key: i32, val: i32) -> PyResult<()> {
         self.val = Some(val);
@@ -780,10 +783,10 @@ fn setdelitem() {
     assert_eq!(c.val, None);
 }
 
-#[py::class]
+#[pyclass]
 struct Reversed {token: PyToken}
 
-#[py::proto]
+#[pyproto]
 impl PyMappingProtocol for Reversed{
     fn __reversed__(&self) -> PyResult<&'static str> {
         Ok("I am reversed")
@@ -799,10 +802,10 @@ fn reversed() {
     py_run!(py, c, "assert reversed(c) == 'I am reversed'");
 }
 
-#[py::class]
+#[pyclass]
 struct Contains {token: PyToken}
 
-#[py::proto]
+#[pyproto]
 impl PySequenceProtocol for Contains {
     fn __contains__(&self, item: i32) -> PyResult<bool> {
         Ok(item >= 0)
@@ -822,10 +825,10 @@ fn contains() {
 
 
 
-#[py::class]
+#[pyclass]
 struct UnaryArithmetic {token: PyToken}
 
-#[py::proto]
+#[pyproto]
 impl PyNumberProtocol for UnaryArithmetic {
 
     fn __neg__(&self) -> PyResult<&'static str> {
@@ -858,19 +861,19 @@ fn unary_arithmetic() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct BinaryArithmetic {
     token: PyToken
 }
 
-#[py::proto]
+#[pyproto]
 impl PyObjectProtocol for BinaryArithmetic {
     fn __repr__(&self) -> PyResult<&'static str> {
         Ok("BA")
     }
 }
 
-#[py::proto]
+#[pyproto]
 impl PyNumberProtocol for BinaryArithmetic {
     fn __add__(lhs: &PyObjectRef, rhs: &PyObjectRef) -> PyResult<String> {
         Ok(format!("{:?} + {:?}", lhs, rhs))
@@ -932,12 +935,12 @@ fn binary_arithmetic() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct RichComparisons {
     token: PyToken
 }
 
-#[py::proto]
+#[pyproto]
 impl PyObjectProtocol for RichComparisons {
     fn __repr__(&self) -> PyResult<&'static str> {
         Ok("RC")
@@ -955,12 +958,12 @@ impl PyObjectProtocol for RichComparisons {
     }
 }
 
-#[py::class]
+#[pyclass]
 struct RichComparisons2 {
     py: PyToken
 }
 
-#[py::proto]
+#[pyproto]
 impl PyObjectProtocol for RichComparisons2 {
     fn __repr__(&self) -> PyResult<&'static str> {
         Ok("RC2")
@@ -1028,20 +1031,20 @@ fn rich_comparisons_python_3_type_error() {
     py_expect_exception!(py, c2, "1 >= c2", TypeError);
 }
 
-#[py::class]
+#[pyclass]
 struct InPlaceOperations {
     value: u32,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl PyObjectProtocol for InPlaceOperations {
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!("IPO({:?})", self.value))
     }
 }
 
-#[py::proto]
+#[pyproto]
 impl PyNumberProtocol for InPlaceOperations {
     fn __iadd__(&mut self, other: u32) -> PyResult<()> {
         self.value += other;
@@ -1114,13 +1117,13 @@ fn inplace_operations() {
     py_run!(py, c, "d = c; c ^= 5; assert repr(c) == repr(d) == 'IPO(9)'");
 }
 
-#[py::class]
+#[pyclass]
 struct ContextManager {
     exit_called: bool,
     token: PyToken,
 }
 
-#[py::proto]
+#[pyproto]
 impl<'p> PyContextProtocol<'p> for ContextManager {
 
     fn __enter__(&mut self) -> PyResult<i32> {
@@ -1159,13 +1162,13 @@ fn context_manager() {
     assert!(c.exit_called);
 }
 
-#[py::class]
+#[pyclass]
 struct ClassWithProperties {
     num: i32,
     token: PyToken,
 }
 
-#[py::methods]
+#[pymethods]
 impl ClassWithProperties {
 
     fn get_num(&self) -> PyResult<i32> {
@@ -1197,12 +1200,12 @@ fn class_with_properties() {
     py_run!(py, inst, "assert inst.get_num() == inst.DATA");
 }
 
-#[py::class]
+#[pyclass]
 struct MethArgs {
     token: PyToken
 }
 
-#[py::methods]
+#[pymethods]
 impl MethArgs {
 
     #[args(test="10")]
@@ -1237,7 +1240,7 @@ fn meth_args() {
     // py_expect_exception!(py, inst, "inst.get_kwarg(100)", TypeError);
 }
 
-#[py::class(subclass)]
+#[pyclass(subclass)]
 struct SubclassAble {}
 
 #[test]
@@ -1252,7 +1255,7 @@ fn subclass() {
       .unwrap();
 }
 
-#[py::class(dict)]
+#[pyclass(dict)]
 struct DunderDictSupport {
     token: PyToken,
 }
@@ -1265,7 +1268,7 @@ fn dunder_dict_support() {
     py_run!(py, inst, "inst.a = 1; assert inst.a == 1");
 }
 
-#[py::class(weakref, dict)]
+#[pyclass(weakref, dict)]
 struct WeakRefDunderDictSupport {
     token: PyToken,
 }
@@ -1278,14 +1281,14 @@ fn weakref_dunder_dict_support() {
     py_run!(py, inst, "import weakref; assert weakref.ref(inst)() is inst; inst.a = 1; assert inst.a == 1");
 }
 
-#[py::class]
+#[pyclass]
 struct GetterSetter {
     #[prop(get, set)]
     num: i32,
     token: PyToken
 }
 
-#[py::methods]
+#[pymethods]
 impl GetterSetter {
 
     fn get_num2(&self) -> PyResult<i32> {
@@ -1304,13 +1307,13 @@ fn getter_setter_autogen() {
     py_run!(py, inst, "inst.num = 20; assert inst.num == 20");
 }
 
-#[py::class]
+#[pyclass]
 struct BaseClass {
     #[prop(get)]
     val1: usize,
 }
 
-#[py::methods]
+#[pymethods]
 impl BaseClass {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
@@ -1318,13 +1321,13 @@ impl BaseClass {
     }
 }
 
-#[py::class(base=BaseClass)]
+#[pyclass(base=BaseClass)]
 struct SubClass {
     #[prop(get)]
     val2: usize,
 }
 
-#[py::methods]
+#[pymethods]
 impl SubClass {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
@@ -1344,13 +1347,13 @@ fn inheritance_with_new_methods() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct BaseClassWithDrop {
     token: PyToken,
     data: Option<Arc<AtomicBool>>,
 }
 
-#[py::methods]
+#[pymethods]
 impl BaseClassWithDrop {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
@@ -1366,13 +1369,13 @@ impl Drop for BaseClassWithDrop {
     }
 }
 
-#[py::class(base=BaseClassWithDrop)]
+#[pyclass(base=BaseClassWithDrop)]
 struct SubClassWithDrop {
     token: PyToken,
     data: Option<Arc<AtomicBool>>,
 }
 
-#[py::methods]
+#[pymethods]
 impl SubClassWithDrop {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
@@ -1413,13 +1416,13 @@ fn inheritance_with_new_methods_with_drop() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct MutRefArg {
     n: i32,
     token: PyToken,
 }
 
-#[py::methods]
+#[pymethods]
 impl MutRefArg {
 
     fn get(&self) -> PyResult<i32> {

--- a/tests/test_slice.rs
+++ b/tests/test_slice.rs
@@ -5,6 +5,9 @@ extern crate pyo3;
 
 use pyo3::*;
 
+use pyo3::py::class as pyclass;
+use pyo3::py::proto as pyproto;
+
 
 #[test]
 fn test_basics() {
@@ -20,12 +23,12 @@ fn test_basics() {
 }
 
 
-#[py::class]
+#[pyclass]
 struct Test {
     token: PyToken
 }
 
-#[py::proto]
+#[pyproto]
 impl<'p> PyMappingProtocol<'p> for Test
 {
     fn __getitem__(&self, idx: &PyObjectRef) -> PyResult<PyObject> {


### PR DESCRIPTION
rust-lang/rust#50120 has made two breaking changes that break pyo3's compilation:

 * Custom attributes must only have a path of length one, longer paths got an extra feature gate `proc_macro_path_invoc`. This means that e.g. `#[py::modinit(rust2py)]` fails to compile. 
 * The attr TokenStream no longer gets the braces, e.g. it now only gets `rust2py` and not `(rust2py)`.

This pull request fixes both. I've tried to avoid introducing breaking changes and instead replaced `py::modinit` with a `pymodinit` alias. I wouldn't mind removing the alias or renaming the proc macros.