### PR TITLE
Refactor and Export Pyobject_* macros

### DIFF
--- a/src/objects/boolobject.rs
+++ b/src/objects/boolobject.rs
@@ -7,8 +7,7 @@ use conversion::{ToPyObject, IntoPyObject, ToBorrowedObject, PyTryFrom};
 /// Represents a Python `bool`.
 pub struct PyBool(PyObject);
 
-pyobject_convert!(PyBool);
-pyobject_nativetype!(PyBool, PyBool_Type, PyBool_Check);
+pyobject_native_type!(PyBool, PyBool_Type, PyBool_Check);
 
 
 impl PyBool {

--- a/src/objects/bytearray.rs
+++ b/src/objects/bytearray.rs
@@ -11,8 +11,7 @@ use err::{PyResult, PyErr};
 /// Represents a Python `bytearray`.
 pub struct PyByteArray(PyObject);
 
-pyobject_convert!(PyByteArray);
-pyobject_nativetype!(PyByteArray, PyByteArray_Type, PyByteArray_Check);
+pyobject_native_type!(PyByteArray, PyByteArray_Type, PyByteArray_Check);
 
 impl PyByteArray {
     /// Creates a new Python bytearray object.

--- a/src/objects/dict.rs
+++ b/src/objects/dict.rs
@@ -14,8 +14,7 @@ use err::{self, PyResult, PyErr};
 /// Represents a Python `dict`.
 pub struct PyDict(PyObject);
 
-pyobject_convert!(PyDict);
-pyobject_nativetype!(PyDict, PyDict_Type, PyDict_Check);
+pyobject_native_type!(PyDict, PyDict_Type, PyDict_Check);
 
 
 impl PyDict {

--- a/src/objects/floatob.rs
+++ b/src/objects/floatob.rs
@@ -19,8 +19,7 @@ use conversion::{ToPyObject, IntoPyObject};
 /// with `f32`/`f64`.
 pub struct PyFloat(PyObject);
 
-pyobject_convert!(PyFloat);
-pyobject_nativetype!(PyFloat, PyFloat_Type, PyFloat_Check);
+pyobject_native_type!(PyFloat, PyFloat_Type, PyFloat_Check);
 
 
 impl PyFloat {

--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -15,8 +15,7 @@ use conversion::{ToPyObject, IntoPyObject, ToBorrowedObject};
 /// Represents a Python `list`.
 pub struct PyList(PyObject);
 
-pyobject_convert!(PyList);
-pyobject_nativetype!(PyList, PyList_Type, PyList_Check);
+pyobject_native_type!(PyList, PyList_Type, PyList_Check);
 
 impl PyList {
     /// Construct a new list with the given elements.

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -33,6 +33,7 @@ pub use self::num2::{PyInt, PyLong};
 
 /// Implements typesafe conversions from a PyObjectRef, given a typecheck function as second
 /// parameter
+#[macro_export]
 macro_rules! pyobject_downcast(
     ($name: ident, $checkfunction: ident) => (
         impl<'a> $crate::FromPyObject<'a> for &'a $name
@@ -53,6 +54,7 @@ macro_rules! pyobject_downcast(
     );
 );
 
+#[macro_export]
 macro_rules! pyobject_native_type_named(
     ($name: ident) => {
         impl $crate::PyNativeType for $name {}
@@ -88,6 +90,7 @@ macro_rules! pyobject_native_type_named(
     };
 );
 
+#[macro_export]
 macro_rules! pyobject_native_type(
     ($name: ident, $typeobject: ident, $checkfunction: ident) => {
         pyobject_native_type_named!($name);
@@ -102,6 +105,7 @@ macro_rules! pyobject_native_type(
     };
 );
 
+#[macro_export]
 macro_rules! pyobject_native_type_convert(
     ($name: ident, $typeobject: ident, $checkfunction: ident) => {
         impl $crate::typeob::PyTypeInfo for $name {
@@ -174,6 +178,7 @@ macro_rules! pyobject_native_type_convert(
     };
 );
 
+#[macro_export]
 macro_rules! pyobject_extract(
     ($obj:ident to $t:ty => $body: block) => {
         impl<'source> $crate::FromPyObject<'source> for $t

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -31,6 +31,8 @@ pub use self::num3::PyLong as PyInt;
 pub use self::num2::{PyInt, PyLong};
 
 
+/// Implements typesafe conversions from a PyObjectRef, given a typecheck function as second
+/// parameter
 macro_rules! pyobject_downcast(
     ($name: ident, $checkfunction: ident) => (
         impl<'a> $crate::FromPyObject<'a> for &'a $name
@@ -51,17 +53,7 @@ macro_rules! pyobject_downcast(
     );
 );
 
-macro_rules! pyobject_convert(
-    ($name: ident) => (
-        impl<'a> $crate::std::convert::From<&'a $name> for &'a $crate::PyObjectRef {
-            fn from(ob: &'a $name) -> Self {
-                unsafe{$crate::std::mem::transmute(ob)}
-            }
-        }
-    )
-);
-
-macro_rules! pyobject_nativetype(
+macro_rules! pyobject_native_type_named(
     ($name: ident) => {
         impl $crate::PyNativeType for $name {}
 
@@ -71,12 +63,14 @@ macro_rules! pyobject_nativetype(
                 unsafe{$crate::std::mem::transmute(self)}
             }
         }
+
         impl $crate::PyObjectWithToken for $name {
             #[inline(always)]
             fn py(&self) -> $crate::Python {
                 unsafe { $crate::Python::assume_gil_acquired() }
             }
         }
+
         impl $crate::python::ToPyPointer for $name {
             /// Gets the underlying FFI pointer, returns a borrowed pointer.
             #[inline]
@@ -84,6 +78,7 @@ macro_rules! pyobject_nativetype(
                 self.0.as_ptr()
             }
         }
+
         impl PartialEq for $name {
             #[inline]
             fn eq(&self, o: &$name) -> bool {
@@ -91,10 +86,24 @@ macro_rules! pyobject_nativetype(
             }
         }
     };
+);
 
+macro_rules! pyobject_native_type(
     ($name: ident, $typeobject: ident, $checkfunction: ident) => {
-        pyobject_nativetype!($name);
+        pyobject_native_type_named!($name);
+        pyobject_native_type_convert!($name, $typeobject, $checkfunction);
+        pyobject_downcast!($name, $checkfunction);
 
+        impl<'a> $crate::std::convert::From<&'a $name> for &'a $crate::PyObjectRef {
+            fn from(ob: &'a $name) -> Self {
+                unsafe{$crate::std::mem::transmute(ob)}
+            }
+        }
+    };
+);
+
+macro_rules! pyobject_native_type_convert(
+    ($name: ident, $typeobject: ident, $checkfunction: ident) => {
         impl $crate::typeob::PyTypeInfo for $name {
             type Type = ();
             type BaseType = $crate::PyObjectRef;
@@ -162,9 +171,7 @@ macro_rules! pyobject_nativetype(
                 f.write_str(&s.to_string_lossy())
             }
         }
-
-        pyobject_downcast!($name, $checkfunction);
-};
+    };
 );
 
 macro_rules! pyobject_extract(
@@ -201,7 +208,9 @@ use python::ToPyPointer;
 
 /// Represents general python instance.
 pub struct PyObjectRef(::PyObject);
-pyobject_nativetype!(PyObjectRef, PyBaseObject_Type, PyObject_Check);
+pyobject_native_type_named!(PyObjectRef);
+pyobject_native_type_convert!(PyObjectRef, PyBaseObject_Type, PyObject_Check);
+pyobject_downcast!(PyObjectRef, PyObject_Check);
 
 mod typeobject;
 mod module;

--- a/src/objects/module.rs
+++ b/src/objects/module.rs
@@ -20,8 +20,7 @@ use err::{PyResult, PyErr};
 /// Represents a Python `module` object.
 pub struct PyModule(PyObject);
 
-pyobject_convert!(PyModule);
-pyobject_nativetype!(PyModule, PyModule_Type, PyModule_Check);
+pyobject_native_type!(PyModule, PyModule_Type, PyModule_Check);
 
 
 impl PyModule {

--- a/src/objects/num2.rs
+++ b/src/objects/num2.rs
@@ -25,8 +25,7 @@ use conversion::{ToPyObject, IntoPyObject, FromPyObject};
 /// with the primitive Rust integer types.
 pub struct PyInt(PyObject);
 
-pyobject_convert!(PyInt);
-pyobject_nativetype!(PyInt, PyInt_Type, PyInt_Check);
+pyobject_native_type!(PyInt, PyInt_Type, PyInt_Check);
 
 /// In Python 2.x, represents a Python `long` object.
 /// Both `PyInt` and `PyLong` refer to the same type on Python 3.x.
@@ -37,8 +36,7 @@ pyobject_nativetype!(PyInt, PyInt_Type, PyInt_Check);
 /// with the primitive Rust integer types.
 pub struct PyLong(PyObject);
 
-pyobject_convert!(PyLong);
-pyobject_nativetype!(PyLong, PyLong_Type, PyLong_Check);
+pyobject_native_type!(PyLong, PyLong_Type, PyLong_Check);
 
 impl PyInt {
     /// Creates a new Python 2.7 `int` object.

--- a/src/objects/num3.rs
+++ b/src/objects/num3.rs
@@ -23,8 +23,7 @@ use conversion::{ToPyObject, IntoPyObject, FromPyObject};
 /// with the primitive Rust integer types.
 pub struct PyLong(PyObject);
 
-pyobject_convert!(PyLong);
-pyobject_nativetype!(PyLong, PyLong_Type, PyLong_Check);
+pyobject_native_type!(PyLong, PyLong_Type, PyLong_Check);
 
 
 macro_rules! int_fits_c_long(

--- a/src/objects/sequence.rs
+++ b/src/objects/sequence.rs
@@ -15,8 +15,7 @@ use objectprotocol::ObjectProtocol;
 
 /// Represents a reference to a python object supporting the sequence protocol.
 pub struct PySequence(PyObject);
-
-pyobject_nativetype!(PySequence);
+pyobject_native_type_named!(PySequence);
 pyobject_downcast!(PySequence, PySequence_Check);
 
 

--- a/src/objects/set.rs
+++ b/src/objects/set.rs
@@ -16,10 +16,8 @@ pub struct PySet(PyObject);
 /// Represents a  Python `frozenset`
 pub struct PyFrozenSet(PyObject);
 
-pyobject_convert!(PySet);
-pyobject_convert!(PyFrozenSet);
-pyobject_nativetype!(PySet, PySet_Type, PySet_Check);
-pyobject_nativetype!(PyFrozenSet, PyFrozenSet_Type, PyFrozenSet_Check);
+
+pyobject_native_type!(PySet, PySet_Type, PySet_Check);pyobject_native_type!(PyFrozenSet, PyFrozenSet_Type, PyFrozenSet_Check);
 
 impl PySet {
     /// Creates a new set.

--- a/src/objects/slice.rs
+++ b/src/objects/slice.rs
@@ -14,8 +14,7 @@ use conversion::ToPyObject;
 /// Only `c_long` indeces supprted at the moment by `PySlice` object.
 pub struct PySlice(PyObject);
 
-pyobject_convert!(PySlice);
-pyobject_nativetype!(PySlice, PySlice_Type, PySlice_Check);
+pyobject_native_type!(PySlice, PySlice_Type, PySlice_Check);
 
 
 /// Represents a Python `slice` indices

--- a/src/objects/string.rs
+++ b/src/objects/string.rs
@@ -16,8 +16,7 @@ use super::PyStringData;
 /// Represents a Python `string`.
 pub struct PyString(PyObject);
 
-pyobject_convert!(PyString);
-pyobject_nativetype!(PyString, PyUnicode_Type, PyUnicode_Check);
+pyobject_native_type!(PyString, PyUnicode_Type, PyUnicode_Check);
 
 /// Represents a Python `unicode string`.
 /// Corresponds to `unicode` in Python 2, and `str` in Python 3.
@@ -26,8 +25,7 @@ pub use PyString as PyUnicode;
 /// Represents a Python `byte` string.
 pub struct PyBytes(PyObject);
 
-pyobject_convert!(PyBytes);
-pyobject_nativetype!(PyBytes, PyBytes_Type, PyBytes_Check);
+pyobject_native_type!(PyBytes, PyBytes_Type, PyBytes_Check);
 
 
 impl PyString {

--- a/src/objects/string2.rs
+++ b/src/objects/string2.rs
@@ -18,20 +18,17 @@ use super::{PyObjectRef, PyStringData};
 /// Represents a Python `string`.
 pub struct PyString(PyObject);
 
-pyobject_convert!(PyString);
-pyobject_nativetype!(PyString, PyBaseString_Type, PyBaseString_Check);
+pyobject_native_type!(PyString, PyBaseString_Type, PyBaseString_Check);
 
 /// Represents a Python `unicode string`.
 pub struct PyUnicode(PyObject);
 
-pyobject_convert!(PyUnicode);
-pyobject_nativetype!(PyUnicode, PyUnicode_Type, PyUnicode_Check);
+pyobject_native_type!(PyUnicode, PyUnicode_Type, PyUnicode_Check);
 
 /// Represents a Python `byte` string. Corresponds to `str` in Python 2
 pub struct PyBytes(PyObject);
 
-pyobject_convert!(PyBytes);
-pyobject_nativetype!(PyBytes, PyBaseString_Type, PyString_Check);
+pyobject_native_type!(PyBytes, PyBaseString_Type, PyString_Check);
 
 
 impl PyString {

--- a/src/objects/tuple.rs
+++ b/src/objects/tuple.rs
@@ -15,8 +15,7 @@ use super::exc;
 /// Represents a Python `tuple` object.
 pub struct PyTuple(PyObject);
 
-pyobject_convert!(PyTuple);
-pyobject_nativetype!(PyTuple, PyTuple_Type, PyTuple_Check);
+pyobject_native_type!(PyTuple, PyTuple_Type, PyTuple_Check);
 
 
 impl PyTuple {

--- a/src/objects/typeobject.rs
+++ b/src/objects/typeobject.rs
@@ -15,8 +15,7 @@ use typeob::{PyTypeInfo, PyTypeObject};
 /// Represents a reference to a Python `type object`.
 pub struct PyType(PyObject);
 
-pyobject_convert!(PyType);
-pyobject_nativetype!(PyType, PyType_Type, PyType_Check);
+pyobject_native_type!(PyType, PyType_Type, PyType_Check);
 
 
 impl PyType {


### PR DESCRIPTION
Sometimes you want to add other native types e.g. for https://github.com/termoshtt/rust-numpy. For those you need some conversions, which in pyo3 are implemented by macros. This pull request exports those macros so they are usable in other libraries. It also refactors the macros a bit, replacing calling `pyobject_convert` and `pyobject_nativetype` with a single `pyobject_native_type`.

@termoshtt Does this expose everything needed for rust-numpy?