### PR TITLE
Revise pyobject_* macro exports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(specialization, proc_macro)]
+#![feature(specialization, proc_macro, fn_must_use)]
 
 //! Rust bindings to the Python interpreter.
 //!

--- a/src/objects/boolobject.rs
+++ b/src/objects/boolobject.rs
@@ -7,7 +7,7 @@ use conversion::{ToPyObject, IntoPyObject, ToBorrowedObject, PyTryFrom};
 /// Represents a Python `bool`.
 pub struct PyBool(PyObject);
 
-pyobject_native_type!(PyBool, PyBool_Type, PyBool_Check);
+pyobject_native_type!(PyBool, ffi::PyBool_Type, ffi::PyBool_Check);
 
 
 impl PyBool {

--- a/src/objects/bytearray.rs
+++ b/src/objects/bytearray.rs
@@ -11,7 +11,7 @@ use err::{PyResult, PyErr};
 /// Represents a Python `bytearray`.
 pub struct PyByteArray(PyObject);
 
-pyobject_native_type!(PyByteArray, PyByteArray_Type, PyByteArray_Check);
+pyobject_native_type!(PyByteArray, ffi::PyByteArray_Type, ffi::PyByteArray_Check);
 
 impl PyByteArray {
     /// Creates a new Python bytearray object.

--- a/src/objects/dict.rs
+++ b/src/objects/dict.rs
@@ -14,7 +14,7 @@ use err::{self, PyResult, PyErr};
 /// Represents a Python `dict`.
 pub struct PyDict(PyObject);
 
-pyobject_native_type!(PyDict, PyDict_Type, PyDict_Check);
+pyobject_native_type!(PyDict, ffi::PyDict_Type, ffi::PyDict_Check);
 
 
 impl PyDict {

--- a/src/objects/floatob.rs
+++ b/src/objects/floatob.rs
@@ -19,7 +19,7 @@ use conversion::{ToPyObject, IntoPyObject};
 /// with `f32`/`f64`.
 pub struct PyFloat(PyObject);
 
-pyobject_native_type!(PyFloat, PyFloat_Type, PyFloat_Check);
+pyobject_native_type!(PyFloat, ffi::PyFloat_Type, ffi::PyFloat_Check);
 
 
 impl PyFloat {

--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -15,7 +15,7 @@ use conversion::{ToPyObject, IntoPyObject, ToBorrowedObject};
 /// Represents a Python `list`.
 pub struct PyList(PyObject);
 
-pyobject_native_type!(PyList, PyList_Type, PyList_Check);
+pyobject_native_type!(PyList, ffi::PyList_Type, ffi::PyList_Check);
 
 impl PyList {
     /// Construct a new list with the given elements.

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -44,7 +44,7 @@ macro_rules! pyobject_downcast(
             {
                 unsafe {
                     if $crate::ffi::$checkfunction(ob.as_ptr()) != 0 {
-                        Ok($crate::std::mem::transmute(ob))
+                        Ok(::std::mem::transmute(ob))
                     } else {
                         Err($crate::PyDowncastError.into())
                     }
@@ -59,10 +59,10 @@ macro_rules! pyobject_native_type_named(
     ($name: ident) => {
         impl $crate::PyNativeType for $name {}
 
-        impl $crate::std::convert::AsRef<$crate::PyObjectRef> for $name {
+        impl ::std::convert::AsRef<$crate::PyObjectRef> for $name {
             #[cfg_attr(feature = "cargo-clippy", allow(useless_transmute))]
             fn as_ref(&self) -> &$crate::PyObjectRef {
-                unsafe{$crate::std::mem::transmute(self)}
+                unsafe{::std::mem::transmute(self)}
             }
         }
 
@@ -97,9 +97,9 @@ macro_rules! pyobject_native_type(
         pyobject_native_type_convert!($name, $typeobject, $checkfunction);
         pyobject_downcast!($name, $checkfunction);
 
-        impl<'a> $crate::std::convert::From<&'a $name> for &'a $crate::PyObjectRef {
+        impl<'a> ::std::convert::From<&'a $name> for &'a $crate::PyObjectRef {
             fn from(ob: &'a $name) -> Self {
-                unsafe{$crate::std::mem::transmute(ob)}
+                unsafe{::std::mem::transmute(ob)}
             }
         }
     };
@@ -113,7 +113,7 @@ macro_rules! pyobject_native_type_convert(
             type BaseType = $crate::PyObjectRef;
 
             const NAME: &'static str = stringify!($name);
-            const SIZE: usize = $crate::std::mem::size_of::<$crate::ffi::PyObject>();
+            const SIZE: usize = ::std::mem::size_of::<$crate::ffi::PyObject>();
             const OFFSET: isize = 0;
 
             #[inline]
@@ -156,22 +156,22 @@ macro_rules! pyobject_native_type_convert(
             }
         }
 
-        impl $crate::std::fmt::Debug for $name {
-            fn fmt(&self, f: &mut $crate::std::fmt::Formatter)
-                   -> Result<(), $crate::std::fmt::Error>
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter)
+                   -> Result<(), ::std::fmt::Error>
             {
                 use $crate::ObjectProtocol;
-                let s = try!(self.repr().map_err(|_| $crate::std::fmt::Error));
+                let s = try!(self.repr().map_err(|_| ::std::fmt::Error));
                 f.write_str(&s.to_string_lossy())
             }
         }
 
-        impl $crate::std::fmt::Display for $name {
-            fn fmt(&self, f: &mut $crate::std::fmt::Formatter)
-                   -> Result<(), $crate::std::fmt::Error>
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter)
+                   -> Result<(), ::std::fmt::Error>
             {
                 use $crate::ObjectProtocol;
-                let s = try!(self.str().map_err(|_| $crate::std::fmt::Error));
+                let s = try!(self.str().map_err(|_| ::std::fmt::Error));
                 f.write_str(&s.to_string_lossy())
             }
         }
@@ -193,7 +193,7 @@ macro_rules! pyobject_extract(
         }
 
         #[cfg(feature = "try_from")]
-        impl<'source> $crate::std::convert::TryFrom<&'source $crate::PyObjectRef> for $t
+        impl<'source> ::std::convert::TryFrom<&'source $crate::PyObjectRef> for $t
         {
             type Error = $crate::PyErr;
 

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -35,7 +35,7 @@ pub use self::num2::{PyInt, PyLong};
 /// parameter
 #[macro_export]
 macro_rules! pyobject_downcast(
-    ($name: ident, $checkfunction: ident) => (
+    ($name: ident, $checkfunction: path) => (
         impl<'a> $crate::FromPyObject<'a> for &'a $name
         {
             /// Extracts `Self` from the source `PyObject`.
@@ -43,7 +43,7 @@ macro_rules! pyobject_downcast(
             fn extract(ob: &'a $crate::PyObjectRef) -> $crate::PyResult<Self>
             {
                 unsafe {
-                    if $crate::ffi::$checkfunction(ob.as_ptr()) != 0 {
+                    if $checkfunction(ob.as_ptr()) != 0 {
                         Ok(::std::mem::transmute(ob))
                     } else {
                         Err($crate::PyDowncastError.into())
@@ -92,7 +92,7 @@ macro_rules! pyobject_native_type_named(
 
 #[macro_export]
 macro_rules! pyobject_native_type(
-    ($name: ident, $typeobject: ident, $checkfunction: ident) => {
+    ($name: ident, $typeobject: expr, $checkfunction: path) => {
         pyobject_native_type_named!($name);
         pyobject_native_type_convert!($name, $typeobject, $checkfunction);
         pyobject_downcast!($name, $checkfunction);
@@ -107,7 +107,7 @@ macro_rules! pyobject_native_type(
 
 #[macro_export]
 macro_rules! pyobject_native_type_convert(
-    ($name: ident, $typeobject: ident, $checkfunction: ident) => {
+    ($name: ident, $typeobject: expr, $checkfunction: path) => {
         impl $crate::typeob::PyTypeInfo for $name {
             type Type = ();
             type BaseType = $crate::PyObjectRef;
@@ -118,13 +118,13 @@ macro_rules! pyobject_native_type_convert(
 
             #[inline]
             unsafe fn type_object() -> &'static mut $crate::ffi::PyTypeObject {
-                &mut $crate::ffi::$typeobject
+                &mut $typeobject
             }
 
             #[cfg_attr(feature = "cargo-clippy", allow(not_unsafe_ptr_arg_deref))]
             fn is_instance(ptr: *mut $crate::ffi::PyObject) -> bool {
                 #[allow(unused_unsafe)]
-                unsafe { $crate::ffi::$checkfunction(ptr) > 0 }
+                unsafe { $checkfunction(ptr) > 0 }
             }
         }
 

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -73,7 +73,7 @@ macro_rules! pyobject_native_type_named(
             }
         }
 
-        impl $crate::python::ToPyPointer for $name {
+        impl $crate::ToPyPointer for $name {
             /// Gets the underlying FFI pointer, returns a borrowed pointer.
             #[inline]
             fn as_ptr(&self) -> *mut $crate::ffi::PyObject {

--- a/src/objects/mod.rs
+++ b/src/objects/mod.rs
@@ -208,14 +208,14 @@ macro_rules! pyobject_extract(
     }
 );
 
-
+use ffi;
 use python::ToPyPointer;
 
 /// Represents general python instance.
 pub struct PyObjectRef(::PyObject);
 pyobject_native_type_named!(PyObjectRef);
-pyobject_native_type_convert!(PyObjectRef, PyBaseObject_Type, PyObject_Check);
-pyobject_downcast!(PyObjectRef, PyObject_Check);
+pyobject_native_type_convert!(PyObjectRef, ffi::PyBaseObject_Type, ffi::PyObject_Check);
+pyobject_downcast!(PyObjectRef, ffi::PyObject_Check);
 
 mod typeobject;
 mod module;

--- a/src/objects/module.rs
+++ b/src/objects/module.rs
@@ -20,7 +20,7 @@ use err::{PyResult, PyErr};
 /// Represents a Python `module` object.
 pub struct PyModule(PyObject);
 
-pyobject_native_type!(PyModule, PyModule_Type, PyModule_Check);
+pyobject_native_type!(PyModule, ffi::PyModule_Type, ffi::PyModule_Check);
 
 
 impl PyModule {

--- a/src/objects/num3.rs
+++ b/src/objects/num3.rs
@@ -23,7 +23,7 @@ use conversion::{ToPyObject, IntoPyObject, FromPyObject};
 /// with the primitive Rust integer types.
 pub struct PyLong(PyObject);
 
-pyobject_native_type!(PyLong, PyLong_Type, PyLong_Check);
+pyobject_native_type!(PyLong, ffi::PyLong_Type, ffi::PyLong_Check);
 
 
 macro_rules! int_fits_c_long(

--- a/src/objects/sequence.rs
+++ b/src/objects/sequence.rs
@@ -16,7 +16,7 @@ use objectprotocol::ObjectProtocol;
 /// Represents a reference to a python object supporting the sequence protocol.
 pub struct PySequence(PyObject);
 pyobject_native_type_named!(PySequence);
-pyobject_downcast!(PySequence, PySequence_Check);
+pyobject_downcast!(PySequence, ffi::PySequence_Check);
 
 
 #[cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty))]

--- a/src/objects/set.rs
+++ b/src/objects/set.rs
@@ -16,8 +16,8 @@ pub struct PySet(PyObject);
 /// Represents a  Python `frozenset`
 pub struct PyFrozenSet(PyObject);
 
-
-pyobject_native_type!(PySet, PySet_Type, PySet_Check);pyobject_native_type!(PyFrozenSet, PyFrozenSet_Type, PyFrozenSet_Check);
+pyobject_native_type!(PySet, ffi::PySet_Type, ffi::PySet_Check);
+pyobject_native_type!(PyFrozenSet, ffi::PyFrozenSet_Type, ffi::PyFrozenSet_Check);
 
 impl PySet {
     /// Creates a new set.

--- a/src/objects/slice.rs
+++ b/src/objects/slice.rs
@@ -14,7 +14,7 @@ use conversion::ToPyObject;
 /// Only `c_long` indeces supprted at the moment by `PySlice` object.
 pub struct PySlice(PyObject);
 
-pyobject_native_type!(PySlice, PySlice_Type, PySlice_Check);
+pyobject_native_type!(PySlice, ffi::PySlice_Type, ffi::PySlice_Check);
 
 
 /// Represents a Python `slice` indices

--- a/src/objects/string.rs
+++ b/src/objects/string.rs
@@ -16,7 +16,7 @@ use super::PyStringData;
 /// Represents a Python `string`.
 pub struct PyString(PyObject);
 
-pyobject_native_type!(PyString, PyUnicode_Type, PyUnicode_Check);
+pyobject_native_type!(PyString, ffi::PyUnicode_Type, ffi::PyUnicode_Check);
 
 /// Represents a Python `unicode string`.
 /// Corresponds to `unicode` in Python 2, and `str` in Python 3.
@@ -25,7 +25,7 @@ pub use PyString as PyUnicode;
 /// Represents a Python `byte` string.
 pub struct PyBytes(PyObject);
 
-pyobject_native_type!(PyBytes, PyBytes_Type, PyBytes_Check);
+pyobject_native_type!(PyBytes, ffi::PyBytes_Type, ffi::PyBytes_Check);
 
 
 impl PyString {

--- a/src/objects/tuple.rs
+++ b/src/objects/tuple.rs
@@ -15,7 +15,7 @@ use super::exc;
 /// Represents a Python `tuple` object.
 pub struct PyTuple(PyObject);
 
-pyobject_native_type!(PyTuple, PyTuple_Type, PyTuple_Check);
+pyobject_native_type!(PyTuple, ffi::PyTuple_Type, ffi::PyTuple_Check);
 
 
 impl PyTuple {

--- a/src/objects/typeobject.rs
+++ b/src/objects/typeobject.rs
@@ -15,7 +15,7 @@ use typeob::{PyTypeInfo, PyTypeObject};
 /// Represents a reference to a Python `type object`.
 pub struct PyType(PyObject);
 
-pyobject_native_type!(PyType, PyType_Type, PyType_Check);
+pyobject_native_type!(PyType, ffi::PyType_Type, ffi::PyType_Check);
 
 
 impl PyType {


### PR DESCRIPTION
Fix for #155

- Use `expr` and `path` for macro arguments
  - Fix macro call
- Re-enable `fn_must_use` to reduce warnings