### PR TITLE
Update to `syn 0.13` and `quote 0.5`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pyo3"
 version = "0.2.5"
 description = "Bindings to Python interpreter"
-authors = ["PyO3 Project and Contributors"]
+authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
 keywords = ["pyo3", "python", "cpython"]
 homepage = "https://github.com/pyo3/pyo3"

--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pyo3-derive-backend"
 version = "0.2.5"
 description = "Code generation for PyO3 package"
-authors = ["PyO3 Project and Contributors <https://github.com/PyO3"]
+authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 homepage = "https://github.com/pyo3/pyo3"
 repository = "https://github.com/pyo3/pyo3.git"
 documentation = "http://pyo3.github.io/PyO3/pyo3/"

--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -10,9 +10,9 @@ categories = ["api-bindings", "development-tools::ffi"]
 license = "Apache-2.0"
 
 [dependencies]
-quote="0.3"
 log="0.4"
+quote="0.5"
 
 [dependencies.syn]
-version="0.11"
-features=["full"]
+version="0.13"
+features=["full", "parsing", "printing", "extra-traits"]

--- a/pyo3-derive-backend/src/args.rs
+++ b/pyo3-derive-backend/src/args.rs
@@ -150,15 +150,22 @@ pub fn parse_arguments(items: &[syn::NestedMeta]) -> Vec<Argument> {
 
 #[cfg(test)]
 mod test {
+
     use syn;
     use args::{Argument, parse_arguments};
+    use quote::ToTokens;
+    use syn::buffer::TokenBuffer;
+    use proc_macro::TokenStream;
 
     fn items(s: &'static str) -> Vec<syn::NestedMeta> {
-        let i = syn::parse_outer_attr(s).unwrap();
 
-        match i.value {
-            syn::Meta::List(_, items) => {
-                items
+        let stream = s.parse::<TokenStream>().unwrap();
+        let buffer = TokenBuffer::new(stream);
+        let i = syn::Attribute::parse_outer(buffer.begin()).unwrap().0;
+
+        match i.interpret_meta() {
+            Some(syn::Meta::List(syn::MetaList { nested, .. })) => {
+                nested.iter().map(Clone::clone).collect()
             }
             _ => unreachable!()
         }

--- a/pyo3-derive-backend/src/func.rs
+++ b/pyo3-derive-backend/src/func.rs
@@ -44,7 +44,7 @@ impl MethodProto {
 
 
 pub fn impl_method_proto(
-    cls: &Box<syn::Type>,
+    cls: &syn::Type,
     sig: &mut syn::MethodSig,
     meth: &MethodProto
 ) -> Tokens {

--- a/pyo3-derive-backend/src/func.rs
+++ b/pyo3-derive-backend/src/func.rs
@@ -45,14 +45,17 @@ impl MethodProto {
 }
 
 
-pub fn impl_method_proto(cls: &Box<syn::Ty>,
-                         sig: &mut syn::MethodSig,
-                         meth: &MethodProto) -> Tokens {
+pub fn impl_method_proto(
+    cls: &Box<syn::Type>,
+    sig: &mut syn::MethodSig,
+    meth: &MethodProto
+) -> Tokens {
+
     let decl = sig.decl.clone();
 
     match *meth {
         MethodProto::Free{name: _, proto} => {
-            let p = syn::Ident::from(proto);
+            let p: syn::Path = syn::parse_str(proto).unwrap();
             return quote! {
                 impl<'p> #p<'p> for #cls {}
             }
@@ -61,16 +64,16 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
     };
 
     match decl.output {
-        syn::FunctionRetTy::Ty(ref ty) => {
+        syn::ReturnType::Type(_, ref ty) => {
             match *meth {
                 MethodProto::Free{name: _, proto: _} => unreachable!(),
                 MethodProto::Unary{name: _, pyres, proto} => {
-                    let p = syn::Ident::from(proto);
+                    let p: syn::Path = syn::parse_str(proto).unwrap();
                     let (ty, succ) = get_res_success(ty);
 
-                    let tmp = extract_decl(syn::parse_item(
-                        quote! {fn test(&self)
-                                        -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
+                    let tmp = extract_decl(parse_quote!{
+                        fn test(&self) -> <#cls as #p<'p>>::Result {}
+                    });
                     sig.decl.output = tmp.output.clone();
                     modify_self_ty(sig);
 
@@ -90,25 +93,27 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
                     }
                 },
                 MethodProto::Binary{name: n, arg, pyres, proto} => {
+
                     if sig.decl.inputs.len() <= 1 {
                         println!("Not enough arguments for {}", n);
                         return Tokens::new();
                     }
-                    let p = syn::Ident::from(proto);
+
+                    let p: syn::Path = syn::parse_str(proto).unwrap();
                     let arg_name = syn::Ident::from(arg);
                     let arg_ty = get_arg_ty(sig, 1);
                     let (ty, succ) = get_res_success(ty);
 
-                    let tmp = extract_decl(syn::parse_item(
-                        quote! {fn test(
-                            &self,
-                            arg: <#cls as #p<'p>>::#arg_name)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
-                    let tmp2 = extract_decl(syn::parse_item(
-                        quote! {fn test(
-                            &self,
-                            arg: Option<<#cls as #p<'p>>::#arg_name>)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
+                    let tmp = extract_decl(
+                        parse_quote!{
+                            fn test(&self,arg: <#cls as #p<'p>>::#arg_name)-> <#cls as #p<'p>>::Result {}
+                        });
+
+                    let tmp2 = extract_decl(
+                        parse_quote!{
+                            fn test( &self, arg: Option<<#cls as #p<'p>>::#arg_name>) -> <#cls as #p<'p>>::Result {}
+                        });
+
                     modify_arg_ty(sig, 1, &tmp, &tmp2);
                     modify_self_ty(sig);
 
@@ -134,7 +139,7 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
                         print_err(format!("Not enough arguments {}", n), quote!(sig));
                         return Tokens::new();
                     }
-                    let p = syn::Ident::from(proto);
+                    let p: syn::Path = syn::parse_str(proto).unwrap();
                     let arg1_name = syn::Ident::from(arg1);
                     let arg1_ty = get_arg_ty(sig, 0);
                     let arg2_name = syn::Ident::from(arg2);
@@ -142,16 +147,16 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
                     let (ty, succ) = get_res_success(ty);
 
                     // rewrite ty
-                    let tmp = extract_decl(syn::parse_item(
-                        quote! {fn test(
+                    let tmp = extract_decl(
+                        parse_quote!{fn test(
                             arg1: <#cls as #p<'p>>::#arg1_name,
                             arg2: <#cls as #p<'p>>::#arg2_name)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
-                    let tmp2 = extract_decl(syn::parse_item(
-                        quote! {fn test(
+                                -> <#cls as #p<'p>>::Result {}});
+                    let tmp2 = extract_decl(
+                        parse_quote!{fn test(
                             arg1: Option<<#cls as #p<'p>>::#arg1_name>,
                             arg2: Option<<#cls as #p<'p>>::#arg2_name>)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
+                                -> <#cls as #p<'p>>::Result {}});
                     modify_arg_ty(sig, 0, &tmp, &tmp2);
                     modify_arg_ty(sig, 1, &tmp, &tmp2);
 
@@ -179,7 +184,7 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
                         print_err(format!("Not enough arguments {}", n), quote!(sig));
                         return Tokens::new();
                     }
-                    let p = syn::Ident::from(proto);
+                    let p: syn::Path = syn::parse_str(proto).unwrap();
                     let arg1_name = syn::Ident::from(arg1);
                     let arg1_ty = get_arg_ty(sig, 1);
                     let arg2_name = syn::Ident::from(arg2);
@@ -187,18 +192,18 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
                     let (ty, succ) = get_res_success(ty);
 
                     // rewrite ty
-                    let tmp = extract_decl(syn::parse_item(
-                        quote! {fn test(
+                    let tmp = extract_decl(
+                        parse_quote! {fn test(
                             &self,
                             arg1: <#cls as #p<'p>>::#arg1_name,
                             arg2: <#cls as #p<'p>>::#arg2_name)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
-                    let tmp2 = extract_decl(syn::parse_item(
-                        quote! {fn test(
+                                -> <#cls as #p<'p>>::Result {}});
+                    let tmp2 = extract_decl(
+                        parse_quote! {fn test(
                             &self,
                             arg1: Option<<#cls as #p<'p>>::#arg1_name>,
                             arg2: Option<<#cls as #p<'p>>::#arg2_name>)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
+                                -> <#cls as #p<'p>>::Result {}});
                     modify_arg_ty(sig, 1, &tmp, &tmp2);
                     modify_arg_ty(sig, 2, &tmp, &tmp2);
                     modify_self_ty(sig);
@@ -227,7 +232,7 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
                         print_err(format!("Not enough arguments {}", n), quote!(sig));
                         return Tokens::new();
                     }
-                    let p = syn::Ident::from(proto);
+                    let p: syn::Path = syn::parse_str(proto).unwrap();
                     let arg1_name = syn::Ident::from(arg1);
                     let arg1_ty = get_arg_ty(sig, 0);
                     let arg2_name = syn::Ident::from(arg2);
@@ -237,18 +242,18 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
                     let (ty, succ) = get_res_success(ty);
 
                     // rewrite ty
-                    let tmp = extract_decl(syn::parse_item(
-                        quote! {fn test(
+                    let tmp = extract_decl(
+                        parse_quote! {fn test(
                             arg1: <#cls as #p<'p>>::#arg1_name,
                             arg2: <#cls as #p<'p>>::#arg2_name,
                             arg3: <#cls as #p<'p>>::#arg3_name)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
-                    let tmp2 = extract_decl(syn::parse_item(
-                        quote! {fn test(
+                                -> <#cls as #p<'p>>::Result {}});
+                    let tmp2 = extract_decl(
+                        parse_quote! {fn test(
                             arg1: Option<<#cls as #p<'p>>::#arg1_name>,
                             arg2: Option<<#cls as #p<'p>>::#arg2_name>,
                             arg3: Option<<#cls as #p<'p>>::#arg3_name>)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
+                                -> <#cls as #p<'p>>::Result {}});
                     modify_arg_ty(sig, 0, &tmp, &tmp2);
                     modify_arg_ty(sig, 1, &tmp, &tmp2);
                     modify_arg_ty(sig, 2, &tmp, &tmp2);
@@ -279,7 +284,7 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
                         print_err(format!("Not enough arguments {}", n), quote!(sig));
                         return Tokens::new();
                     }
-                    let p = syn::Ident::from(proto);
+                    let p: syn::Path = syn::parse_str(proto).unwrap();
                     let arg1_name = syn::Ident::from(arg1);
                     let arg1_ty = get_arg_ty(sig, 1);
                     let arg2_name = syn::Ident::from(arg2);
@@ -289,20 +294,20 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
                     let (ty, succ) = get_res_success(ty);
 
                     // rewrite ty
-                    let tmp = extract_decl(syn::parse_item(
-                        quote! {fn test(
+                    let tmp = extract_decl(
+                        parse_quote! {fn test(
                             &self,
                             arg1: <#cls as #p<'p>>::#arg1_name,
                             arg2: <#cls as #p<'p>>::#arg2_name,
                             arg3: <#cls as #p<'p>>::#arg3_name)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
-                    let tmp2 = extract_decl(syn::parse_item(
-                        quote! {fn test(
+                                -> <#cls as #p<'p>>::Result {}});
+                    let tmp2 = extract_decl(
+                        parse_quote! {fn test(
                             &self,
                             arg1: Option<<#cls as #p<'p>>::#arg1_name>,
                             arg2: Option<<#cls as #p<'p>>::#arg2_name>,
                             arg3: Option<<#cls as #p<'p>>::#arg3_name>)
-                                -> <#cls as #p<'p>>::Result {}}.as_str()).unwrap());
+                                -> <#cls as #p<'p>>::Result {}});
                     modify_arg_ty(sig, 1, &tmp, &tmp2);
                     modify_arg_ty(sig, 2, &tmp, &tmp2);
                     modify_arg_ty(sig, 3, &tmp, &tmp2);
@@ -326,72 +331,68 @@ pub fn impl_method_proto(cls: &Box<syn::Ty>,
 
 
 // TODO: better arg ty detection
-fn get_arg_ty(sig: &syn::MethodSig, idx: usize) -> syn::Ty {
+fn get_arg_ty(sig: &syn::MethodSig, idx: usize) -> syn::Type {
     let mut ty = match sig.decl.inputs[idx] {
-        syn::FnArg::Captured(_, ref arg_ty) => {
-            match arg_ty {
-                &syn::Ty::Path(_, ref path) => {
+        syn::FnArg::Captured(ref cap) => {
+            match cap.ty {
+                syn::Type::Path(ref ty) => {
                     // use only last path segment for Option<>
-                    let seg = path.segments.last().unwrap().clone();
+                    let seg = ty.path.segments.last().unwrap().value().clone();
                     if seg.ident.as_ref() == "Option" {
-                        match seg.parameters {
-                            syn::PathParameters::AngleBracketed(ref data) => {
-                                if let Some(ty) = data.types.last() {
-                                    return ty.clone()
-                                }
+                        match seg.arguments {
+                            syn::PathArguments::AngleBracketed(ref data) => {
+                                if let Some(pair) = data.args.last() {
+                                    match pair.value() {
+                                        syn::GenericArgument::Type(ref ty) => return ty.clone(),
+                                        _ => panic!("Option only accepted for concrete types"),
+                                    }
+                                };
                             }
                             _ => (),
                         }
                     }
-                    arg_ty.clone()
+                    cap.ty.clone()
                 },
-                _ => arg_ty.clone()
+                _ => cap.ty.clone()
             }
         },
         _ => panic!("fn arg type is not supported"),
     };
 
-    match ty {
-        syn::Ty::Rptr(ref mut lifetime, _) => {
-            match lifetime {
-                &mut None => {
-                    *lifetime = Some(syn::Lifetime {ident: syn::Ident::from("'p")})
-                }
-                _ => (),
-            }
-        }
-        _ => ()
+
+    if let syn::Type::Reference(ref mut r) = ty {
+        r.lifetime.get_or_insert(parse_quote!{'p});
     }
 
     ty
 }
 
 // Success
-fn get_res_success(ty: &syn::Ty) -> (Tokens, syn::Ty) {
+fn get_res_success(ty: &syn::Type) -> (Tokens, syn::GenericArgument) {
     let mut result;
     let mut succ;
 
     match ty {
-        &syn::Ty::Path(_, ref path) => {
-            if let Some(segment) = path.segments.last() {
-                match segment.ident.as_ref() {
+        &syn::Type::Path(ref typath) => {
+            if let Some(segment) = typath.path.segments.last() {
+                match segment.value().ident.as_ref() {
                     // check for PyResult<T>
-                    "PyResult" => match segment.parameters {
-                        syn::PathParameters::AngleBracketed(ref data) => {
+                    "PyResult" => match segment.value().arguments {
+                        syn::PathArguments::AngleBracketed(ref data) => {
                             result = true;
-                            succ = data.types[0].clone();
+                            succ = data.args[0].clone();
 
                             // check for PyResult<Option<T>>
-                            match data.types[0] {
-                                syn::Ty::Path(_, ref path) =>
-                                    if let Some(segment) = path.segments.last() {
-                                        match segment.ident.as_ref() {
+                            match data.args[0] {
+                                syn::GenericArgument::Type(syn::Type::Path(ref typath)) =>
+                                    if let Some(segment) = typath.path.segments.last() {
+                                        match segment.value().ident.as_ref() {
                                             // get T from Option<T>
-                                            "Option" => match segment.parameters {
-                                                syn::PathParameters::AngleBracketed(ref data) =>
+                                            "Option" => match segment.value().arguments {
+                                                syn::PathArguments::AngleBracketed(ref data) =>
                                                 {
                                                     result = false;
-                                                    succ = data.types[0].clone();
+                                                    succ = data.args[0].clone();
                                                 },
                                                 _ => (),
                                             },
@@ -404,10 +405,10 @@ fn get_res_success(ty: &syn::Ty) -> (Tokens, syn::Ty) {
                         _ => panic!("fn result type is not supported"),
                     },
                     _ => panic!("fn result type has to be PyResult or (), got {:?}",
-                                segment.ident.as_ref())
+                                segment.value().ident.as_ref())
                 }
             } else {
-                panic!("fn result is not supported {:?}", path)
+                panic!("fn result is not supported {:?}", typath)
             }
         }
         _ => panic!("not supported: {:?}", ty),
@@ -425,8 +426,8 @@ fn get_res_success(ty: &syn::Ty) -> (Tokens, syn::Ty) {
 
 
 fn extract_decl(spec: syn::Item) -> syn::FnDecl {
-    match spec.node {
-        syn::ItemKind::Fn(decl, _, _, _, _, _) => *decl,
+    match spec {
+        syn::Item::Fn(f) => *f.decl,
         _ => panic!()
     }
 }
@@ -437,18 +438,18 @@ fn modify_arg_ty(sig: &mut syn::MethodSig, idx: usize,
 {
     let arg = sig.decl.inputs[idx].clone();
     match arg {
-        syn::FnArg::Captured(ref pat, ref arg_ty) => {
-            match arg_ty {
-                &syn::Ty::Path(_, ref path) => {
-                    let seg = path.segments.last().unwrap().clone();
+        syn::FnArg::Captured(ref cap) => {
+            match cap.ty {
+                syn::Type::Path(ref typath) => {
+                    let seg = typath.path.segments.last().unwrap().value().clone();
                     if seg.ident.as_ref() == "Option" {
-                        sig.decl.inputs[idx] = fix_name(pat, &decl2.inputs[idx]);
+                        sig.decl.inputs[idx] = fix_name(&cap.pat, &decl2.inputs[idx]);
                     } else {
-                        sig.decl.inputs[idx] = fix_name(pat, &decl1.inputs[idx]);
+                        sig.decl.inputs[idx] = fix_name(&cap.pat, &decl1.inputs[idx]);
                     }
                 },
                 _ => {
-                    sig.decl.inputs[idx] = fix_name(pat, &decl1.inputs[idx]);
+                    sig.decl.inputs[idx] = fix_name(&cap.pat, &decl1.inputs[idx]);
                 }
             }
         },
@@ -458,20 +459,22 @@ fn modify_arg_ty(sig: &mut syn::MethodSig, idx: usize,
     sig.decl.output = decl1.output.clone();
 }
 
-fn modify_self_ty(sig: &mut syn::MethodSig)
-{
-    match sig.decl.inputs[0] {
-        syn::FnArg::SelfRef(ref mut lifetime, _) => {
-            *lifetime = Some(syn::Lifetime {ident: syn::Ident::from("'p")})
-        },
-        _ => panic!("not supported"),
+fn modify_self_ty(sig: &mut syn::MethodSig) {
+    if let syn::FnArg::SelfRef(ref mut r) = sig.decl.inputs[0] {
+        r.lifetime = Some(parse_quote!{'p});
+    } else {
+        panic!("not supported")
     }
 }
 
 fn fix_name(pat: &syn::Pat, arg: &syn::FnArg) -> syn::FnArg {
-    match arg {
-        &syn::FnArg::Captured(_, ref arg_ty) =>
-            syn::FnArg::Captured(pat.clone(), arg_ty.clone()),
-        _ => panic!("func.rs::296"),
+    if let syn::FnArg::Captured(ref cap) = arg {
+        syn::FnArg::Captured(syn::ArgCaptured {
+            pat: pat.clone(),
+            colon_token: cap.colon_token,
+            ty: cap.ty.clone(),
+        })
+    } else {
+        panic!("func.rs::296")
     }
 }

--- a/pyo3-derive-backend/src/lib.rs
+++ b/pyo3-derive-backend/src/lib.rs
@@ -6,6 +6,7 @@
 extern crate log;
 #[macro_use]
 extern crate quote;
+#[macro_use]
 extern crate syn;
 extern crate proc_macro;
 

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -125,7 +125,7 @@ impl<'a> FnSpec<'a> {
         for s in self.attrs.iter() {
             match *s {
                 Argument::VarArgs(ref ident) =>
-                    return name.as_ref() == ident.as_str(),
+                    return name == ident,
                 _ => (),
             }
         }
@@ -147,7 +147,7 @@ impl<'a> FnSpec<'a> {
         for s in self.attrs.iter() {
             match *s {
                 Argument::KeywordArgs(ref ident) =>
-                    return name.as_ref() == ident.as_str(),
+                    return name == ident,
                 _ => (),
             }
         }
@@ -168,7 +168,7 @@ impl<'a> FnSpec<'a> {
         for s in self.attrs.iter() {
             match *s {
                 Argument::Arg(ref ident, ref opt) => {
-                    if ident.as_str() == name.as_ref() {
+                    if ident == name {
                         if let &Some(ref val) = opt {
                             let i: syn::Expr = syn::parse_str(&val).unwrap();
                             return Some(i.into_tokens())
@@ -176,7 +176,7 @@ impl<'a> FnSpec<'a> {
                     }
                 },
                 Argument::Kwarg(ref ident, ref opt) => {
-                    if ident.as_str() == name.as_ref() {
+                    if ident == name {
                         let i: syn::Expr = syn::parse_str(&opt).unwrap();
                         return Some(i.into_tokens())
                     }
@@ -191,7 +191,7 @@ impl<'a> FnSpec<'a> {
         for s in self.attrs.iter() {
             match *s {
                 Argument::Kwarg(ref ident, _) => {
-                    if ident.as_str() == name.as_ref() {
+                    if ident == name {
                         return true
                     }
                 },

--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -26,7 +26,7 @@ pub fn py3_init(fnname: &syn::Ident, name: &syn::Ident, doc: syn::Lit) -> Tokens
             static mut MODULE_DEF: pyo3::ffi::PyModuleDef = pyo3::ffi::PyModuleDef_INIT;
             // We can't convert &'static str to *const c_char within a static initializer,
             // so we'll do it here in the module initialization:
-            MODULE_DEF.name = concat!(stringify!(#name), "\0").as_ptr() as *const _;
+            MODULE_DEF.m_name = concat!(stringify!(#name), "\0").as_ptr() as *const _;
 
             #[cfg(py_sys_config = "WITH_THREAD")]
             pyo3::ffi::PyEval_InitThreads();

--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -59,7 +59,7 @@ pub fn py3_init(fnname: &syn::Ident, name: &syn::Ident, doc: syn::Lit) -> Tokens
 
 pub fn py2_init(fnname: &syn::Ident, name: &syn::Ident, doc: syn::Lit) -> Tokens {
 
-    let cb_name: syn::Ident = syn::parse_str(&format!("PyInit_{}", name)).unwrap();
+    let cb_name: syn::Ident = syn::parse_str(&format!("init{}", name)).unwrap();
 
     quote! {
         #[no_mangle]

--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -199,8 +199,6 @@ fn extract_pyfn_attrs(
     }
 
     *attrs = new_attrs;
-    // attrs.clear();
-    // attrs.extend(new_attrs);
     Some((modname?, fnname?, fn_attrs))
 }
 
@@ -291,10 +289,6 @@ fn function_c_wrapper(name: &syn::Ident, spec: &method::FnSpec) -> Tokens {
     let body = py_method::impl_arg_params(spec, cb);
     let body_to_result = py_method::body_to_result(&body, spec);
 
-    // FIXME(althonos): the `use::pyo3::ObjectProtocol` does not belong here,
-    //                  but removing it will cause the code produced by
-    //                  `impl_arg_param` to error because of unknown
-    //                  `extract` method
     quote! {
         #[allow(unused_variables, unused_imports)]
         unsafe extern "C" fn __wrap(
@@ -302,9 +296,6 @@ fn function_c_wrapper(name: &syn::Ident, spec: &method::FnSpec) -> Tokens {
             _args: *mut _pyo3::ffi::PyObject,
             _kwargs: *mut _pyo3::ffi::PyObject) -> *mut _pyo3::ffi::PyObject
         {
-
-            use pyo3::ObjectProtocol;
-
             const _LOCATION: &'static str = concat!(stringify!(#name), "()");
 
             let _pool = _pyo3::GILPool::new();

--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -109,7 +109,7 @@ pub fn process_functions_in_module(func: &mut syn::ItemFn) {
                 let item: syn::ItemFn = parse_quote!{
                     fn block_wrapper() {
                         #function_to_python
-                        #module_name.add_function(&#function_wrapper_ident);
+                        #module_name.add_function(&#function_wrapper_ident)?;
                     }
                 };
                 stmts.extend(item.block.stmts.into_iter());

--- a/pyo3-derive-backend/src/py_class.rs
+++ b/pyo3-derive-backend/src/py_class.rs
@@ -1,10 +1,9 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-use std;
 use std::collections::HashMap;
 
 use syn;
-use quote::{Tokens, ToTokens};
+use quote::Tokens;
 
 use utils;
 use method::{FnType, FnSpec, FnArg};

--- a/pyo3-derive-backend/src/py_class.rs
+++ b/pyo3-derive-backend/src/py_class.rs
@@ -334,7 +334,7 @@ fn impl_descriptors(
             let field_ty = &field.ty;
             match *desc {
                 FnType::Getter(ref getter) => {
-                    impl_py_getter_def(&name, doc, getter, &impl_wrap_getter(&Box::new(cls.clone()), &name))
+                    impl_py_getter_def(&name, doc, getter, &impl_wrap_getter(&cls, &name))
                 }
                 FnType::Setter(ref setter) => {
                     let setter_name = syn::Ident::from(format!("set_{}", name));
@@ -356,7 +356,7 @@ fn impl_descriptors(
                         &name,
                         doc,
                         setter,
-                        &impl_wrap_setter(&Box::new(cls.clone()), &setter_name, &spec)
+                        &impl_wrap_setter(&cls, &setter_name, &spec)
                     )
                 },
                 _ => unreachable!()

--- a/pyo3-derive-backend/src/py_impl.rs
+++ b/pyo3-derive-backend/src/py_impl.rs
@@ -18,7 +18,7 @@ pub fn build_py_methods(ast: &mut syn::Item) -> Tokens {
     }
 }
 
-pub fn impl_methods(ty: &Box<syn::Type>, impls: &mut Vec<syn::ImplItem>) -> Tokens {
+pub fn impl_methods(ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> Tokens {
 
     // get method names in impl block
     let mut methods = Vec::new();
@@ -40,7 +40,7 @@ pub fn impl_methods(ty: &Box<syn::Type>, impls: &mut Vec<syn::ImplItem>) -> Toke
         }
     };
 
-    let n = if let &syn::Type::Path(ref typath) = ty.as_ref() {
+    let n = if let &syn::Type::Path(ref typath) = ty {
         typath.path.segments.last().as_ref().unwrap().value().ident.as_ref()
     } else {
         "CLS_METHODS"

--- a/pyo3-derive-backend/src/py_impl.rs
+++ b/pyo3-derive-backend/src/py_impl.rs
@@ -10,7 +10,7 @@ pub fn build_py_methods(ast: &mut syn::ItemImpl) -> Tokens {
     if ast.trait_.is_some() {
         panic!("#[methods] can not be used only with trait impl block");
     } else {
-        impl_methods(&iimpl.self_ty, &mut iimpl.items)
+        impl_methods(&ast.self_ty, &mut ast.items)
     }
 }
 

--- a/pyo3-derive-backend/src/py_impl.rs
+++ b/pyo3-derive-backend/src/py_impl.rs
@@ -6,15 +6,11 @@ use quote::Tokens;
 use py_method;
 
 
-pub fn build_py_methods(ast: &mut syn::Item) -> Tokens {
-    if let syn::Item::Impl(ref mut iimpl) = ast {
-        if iimpl.trait_.is_some() {
-            panic!("#[methods] can not be used only with trait impl block");
-        } else {
-            impl_methods(&iimpl.self_ty, &mut iimpl.items)
-        }
+pub fn build_py_methods(ast: &mut syn::ItemImpl) -> Tokens {
+    if ast.trait_.is_some() {
+        panic!("#[methods] can not be used only with trait impl block");
     } else {
-        panic!("#[methods] can only be used with Impl blocks")
+        impl_methods(&iimpl.self_ty, &mut iimpl.items)
     }
 }
 

--- a/pyo3-derive-backend/src/py_method.rs
+++ b/pyo3-derive-backend/src/py_method.rs
@@ -7,9 +7,12 @@ use method::{FnArg, FnSpec, FnType};
 use utils;
 
 
-pub fn gen_py_method<'a>(cls: &Box<syn::Ty>, name: &syn::Ident,
-                         sig: &mut syn::MethodSig, meth_attrs: &mut Vec<syn::Attribute>) -> Tokens
-{
+pub fn gen_py_method<'a>(
+    cls: &Box<syn::Type>,
+    name: &syn::Ident,
+    sig: &mut syn::MethodSig,
+    meth_attrs: &mut Vec<syn::Attribute>
+) -> Tokens {
     check_generic(name, sig);
 
     let doc = utils::get_doc(&meth_attrs, true);
@@ -37,7 +40,7 @@ pub fn gen_py_method<'a>(cls: &Box<syn::Ty>, name: &syn::Ident,
 
 
 fn check_generic(name: &syn::Ident, sig: &syn::MethodSig) {
-    if !sig.generics.ty_params.is_empty() {
+    if !sig.decl.generics.params.is_empty() {
         panic!("python method can not be generic: {:?}", name);
     }
 }
@@ -54,7 +57,7 @@ pub fn body_to_result(body: &Tokens, spec: &FnSpec) -> Tokens {
 }
 
 /// Generate function wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec, noargs: bool) -> Tokens {
+pub fn impl_wrap(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec, noargs: bool) -> Tokens {
     let body = impl_call(cls, name, &spec);
 
     if spec.args.is_empty() && noargs {
@@ -103,7 +106,7 @@ pub fn impl_wrap(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec, noargs: b
 }
 
 /// Generate function wrapper for protocol method (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_proto_wrap(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub fn impl_proto_wrap(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let cb = impl_call(cls, name, &spec);
     let body = impl_arg_params(&spec, cb);
 
@@ -131,7 +134,7 @@ pub fn impl_proto_wrap(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> 
 }
 
 /// Generate class method wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap_new(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub fn impl_wrap_new(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let names: Vec<syn::Ident> = spec.args.iter().enumerate().map(
         |item| if item.1.py {syn::Ident::from("_py")} else {
             syn::Ident::from(format!("arg{}", item.0))}).collect();
@@ -180,7 +183,7 @@ pub fn impl_wrap_new(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> To
 }
 
 /// Generate function wrapper for ffi::initproc
-fn impl_wrap_init(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+fn impl_wrap_init(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let cb = impl_call(cls, name, &spec);
     let output = &spec.output;
     if quote! {#output} != quote! {PyResult<()>} || quote! {#output} != quote! {()}{
@@ -217,7 +220,7 @@ fn impl_wrap_init(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> Token
 }
 
 /// Generate class method wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap_class(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub fn impl_wrap_class(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let names: Vec<syn::Ident> = spec.args.iter().enumerate().map(
         |item| if item.1.py {syn::Ident::from("_py")} else {
             syn::Ident::from(format!("arg{}", item.0))}).collect();
@@ -250,7 +253,7 @@ pub fn impl_wrap_class(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> 
 }
 
 /// Generate static method wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap_static(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub fn impl_wrap_static(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let names: Vec<syn::Ident> = spec.args.iter().enumerate().map(
         |item| if item.1.py {syn::Ident::from("_py")} else {
             syn::Ident::from(format!("arg{}", item.0))}).collect();
@@ -282,7 +285,7 @@ pub fn impl_wrap_static(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) ->
 }
 
 /// Generate functiona wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub(crate) fn impl_wrap_getter(cls: &Box<syn::Ty>, name: &syn::Ident) -> Tokens {
+pub(crate) fn impl_wrap_getter(cls: &Box<syn::Type>, name: &syn::Ident) -> Tokens {
     quote! {
         unsafe extern "C" fn __wrap(
             _slf: *mut _pyo3::ffi::PyObject, _: *mut _pyo3::c_void) -> *mut _pyo3::ffi::PyObject
@@ -308,7 +311,7 @@ pub(crate) fn impl_wrap_getter(cls: &Box<syn::Ty>, name: &syn::Ident) -> Tokens 
 }
 
 /// Generate functiona wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub(crate) fn impl_wrap_setter(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub(crate) fn impl_wrap_setter(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     if spec.args.len() < 1 {
         println!("Not enough arguments for setter {}::{}", quote!{#cls}, name);
     }
@@ -342,7 +345,7 @@ pub(crate) fn impl_wrap_setter(cls: &Box<syn::Ty>, name: &syn::Ident, spec: &FnS
 }
 
 
-fn impl_call(_cls: &Box<syn::Ty>, fname: &syn::Ident, spec: &FnSpec) -> Tokens {
+fn impl_call(_cls: &Box<syn::Type>, fname: &syn::Ident, spec: &FnSpec) -> Tokens {
     let names: Vec<syn::Ident> = spec.args.iter().enumerate().map(
         |item| if item.1.py {
             syn::Ident::from("_py")

--- a/pyo3-derive-backend/src/py_method.rs
+++ b/pyo3-derive-backend/src/py_method.rs
@@ -447,10 +447,10 @@ fn impl_arg_param(arg: &FnArg, spec: &FnSpec, body: &Tokens, idx: usize) -> Toke
 
     if spec.is_args(&name) {
         quote! {
-            <#ty as _pyo3::FromPyObject>::extract(_args.as_ref())
+            <#ty as ::pyo3::FromPyObject>::extract(_args.as_ref())
                 .and_then(|#arg_name| {
-                        #body
-                    })
+                    #body
+                })
         }
     } else if spec.is_kwargs(&name) {
         quote! {{
@@ -481,7 +481,8 @@ fn impl_arg_param(arg: &FnArg, spec: &FnSpec, body: &Tokens, idx: usize) -> Toke
                                 }
                             }
                         },
-                        None => Ok(#default) }
+                        None => Ok(#default)
+                    }
                 {
                     Ok(#arg_name) => #body,
                     Err(e) => Err(e)
@@ -508,7 +509,7 @@ fn impl_arg_param(arg: &FnArg, spec: &FnSpec, body: &Tokens, idx: usize) -> Toke
             }
         } else {
             quote! {
-                _iter.next().unwrap().as_ref().unwrap().extract()
+                ::pyo3::ObjectProtocol::extract(_iter.next().unwrap().unwrap())
                     .and_then(|#arg_name| {
                         #body
                     })

--- a/pyo3-derive-backend/src/py_method.rs
+++ b/pyo3-derive-backend/src/py_method.rs
@@ -8,7 +8,7 @@ use utils;
 
 
 pub fn gen_py_method<'a>(
-    cls: &Box<syn::Type>,
+    cls: &syn::Type,
     name: &syn::Ident,
     sig: &mut syn::MethodSig,
     meth_attrs: &mut Vec<syn::Attribute>
@@ -57,7 +57,7 @@ pub fn body_to_result(body: &Tokens, spec: &FnSpec) -> Tokens {
 }
 
 /// Generate function wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec, noargs: bool) -> Tokens {
+pub fn impl_wrap(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec, noargs: bool) -> Tokens {
     let body = impl_call(cls, name, &spec);
 
     if spec.args.is_empty() && noargs {
@@ -106,7 +106,7 @@ pub fn impl_wrap(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec, noargs:
 }
 
 /// Generate function wrapper for protocol method (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_proto_wrap(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub fn impl_proto_wrap(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let cb = impl_call(cls, name, &spec);
     let body = impl_arg_params(&spec, cb);
 
@@ -134,7 +134,7 @@ pub fn impl_proto_wrap(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -
 }
 
 /// Generate class method wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap_new(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub fn impl_wrap_new(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let names: Vec<syn::Ident> = spec.args.iter().enumerate().map(
         |item| if item.1.py {syn::Ident::from("_py")} else {
             syn::Ident::from(format!("arg{}", item.0))}).collect();
@@ -183,7 +183,7 @@ pub fn impl_wrap_new(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> 
 }
 
 /// Generate function wrapper for ffi::initproc
-fn impl_wrap_init(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+fn impl_wrap_init(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let cb = impl_call(cls, name, &spec);
     let output = &spec.output;
     if quote! {#output} != quote! {PyResult<()>} || quote! {#output} != quote! {()}{
@@ -220,7 +220,7 @@ fn impl_wrap_init(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tok
 }
 
 /// Generate class method wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap_class(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub fn impl_wrap_class(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let names: Vec<syn::Ident> = spec.args.iter().enumerate().map(
         |item| if item.1.py {syn::Ident::from("_py")} else {
             syn::Ident::from(format!("arg{}", item.0))}).collect();
@@ -253,7 +253,7 @@ pub fn impl_wrap_class(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -
 }
 
 /// Generate static method wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap_static(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub fn impl_wrap_static(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     let names: Vec<syn::Ident> = spec.args.iter().enumerate().map(
         |item| if item.1.py {syn::Ident::from("_py")} else {
             syn::Ident::from(format!("arg{}", item.0))}).collect();
@@ -285,7 +285,7 @@ pub fn impl_wrap_static(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) 
 }
 
 /// Generate functiona wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub(crate) fn impl_wrap_getter(cls: &Box<syn::Type>, name: &syn::Ident) -> Tokens {
+pub(crate) fn impl_wrap_getter(cls: &syn::Type, name: &syn::Ident) -> Tokens {
     quote! {
         unsafe extern "C" fn __wrap(
             _slf: *mut _pyo3::ffi::PyObject, _: *mut _pyo3::c_void) -> *mut _pyo3::ffi::PyObject
@@ -311,7 +311,7 @@ pub(crate) fn impl_wrap_getter(cls: &Box<syn::Type>, name: &syn::Ident) -> Token
 }
 
 /// Generate functiona wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub(crate) fn impl_wrap_setter(cls: &Box<syn::Type>, name: &syn::Ident, spec: &FnSpec) -> Tokens {
+pub(crate) fn impl_wrap_setter(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec) -> Tokens {
     if spec.args.len() < 1 {
         println!("Not enough arguments for setter {}::{}", quote!{#cls}, name);
     }
@@ -345,7 +345,7 @@ pub(crate) fn impl_wrap_setter(cls: &Box<syn::Type>, name: &syn::Ident, spec: &F
 }
 
 
-fn impl_call(_cls: &Box<syn::Type>, fname: &syn::Ident, spec: &FnSpec) -> Tokens {
+fn impl_call(_cls: &syn::Type, fname: &syn::Ident, spec: &FnSpec) -> Tokens {
     let names: Vec<syn::Ident> = spec.args.iter().enumerate().map(
         |item| if item.1.py {
             syn::Ident::from("_py")

--- a/pyo3-derive-backend/src/py_proto.rs
+++ b/pyo3-derive-backend/src/py_proto.rs
@@ -62,7 +62,7 @@ pub fn build_py_proto(ast: &mut syn::Item) -> Tokens {
 }
 
 fn impl_proto_impl(
-    ty: &Box<syn::Type>,
+    ty: &syn::Type,
     impls: &mut Vec<syn::ImplItem>,
     proto: &defs::Proto
 ) -> Tokens {
@@ -113,7 +113,7 @@ fn impl_proto_impl(
 
     // unique mod name
     let p = proto.name;
-    let n = if let syn::Type::Path(ref typath) = ty.as_ref() {
+    let n = if let syn::Type::Path(ref typath) = ty {
         typath.path.segments.last().as_ref().unwrap().value().ident.as_ref()
     } else {
         "PROTO_METHODS"

--- a/pyo3-derive-backend/src/py_proto.rs
+++ b/pyo3-derive-backend/src/py_proto.rs
@@ -10,31 +10,33 @@ use func::impl_method_proto;
 
 
 pub fn build_py_proto(ast: &mut syn::Item) -> Tokens {
-    match ast.node {
-        syn::ItemKind::Impl(_, _, ref mut gen, ref mut path, ref ty, ref mut impl_items) => {
-            if let &mut Some(ref mut path) = path {
+    match ast {
+        syn::Item::Impl(ref mut expr) => {
+            if let Some((_, ref mut path, _)) = expr.trait_ {
                 let tokens = if let Some(ref mut segment) = path.segments.last() {
-                    match segment.ident.as_ref() {
+                    let ty = &expr.self_ty;
+                    let items = &mut expr.items;
+                    match segment.value().ident.as_ref() {
                         "PyObjectProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::OBJECT),
+                            impl_proto_impl(ty, items, &defs::OBJECT),
                         "PyAsyncProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::ASYNC),
+                            impl_proto_impl(ty, items, &defs::ASYNC),
                         "PyMappingProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::MAPPING),
+                            impl_proto_impl(ty, items, &defs::MAPPING),
                         "PyIterProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::ITER),
+                            impl_proto_impl(ty, items, &defs::ITER),
                         "PyContextProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::CONTEXT),
+                            impl_proto_impl(ty, items, &defs::CONTEXT),
                         "PySequenceProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::SEQ),
+                            impl_proto_impl(ty, items, &defs::SEQ),
                         "PyNumberProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::NUM),
+                            impl_proto_impl(ty, items, &defs::NUM),
                         "PyDescrProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::DESCR),
+                            impl_proto_impl(ty, items, &defs::DESCR),
                         "PyBufferProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::BUFFER),
+                            impl_proto_impl(ty, items, &defs::BUFFER),
                         "PyGCProtocol" =>
-                            impl_proto_impl(ty, impl_items, &defs::GC),
+                            impl_proto_impl(ty, items, &defs::GC),
                         _ => {
                             warn!("#[proto] can not be used with this block");
                             return Tokens::new()
@@ -45,18 +47,10 @@ pub fn build_py_proto(ast: &mut syn::Item) -> Tokens {
                 };
 
                 // attach lifetime
-                gen.lifetimes = vec![syn::LifetimeDef {
-                    attrs: vec![], bounds: vec![],
-                    lifetime: syn::Lifetime { ident: syn::Ident::from("\'p") },
-                }];
-
-                let seg = path.segments.pop().unwrap();
-                path.segments.push(syn::PathSegment{
-                    ident: seg.ident.clone(),
-                    parameters: syn::PathParameters::AngleBracketed(
-                        syn::AngleBracketedParameterData {
-                            lifetimes: vec![syn::Lifetime { ident: syn::Ident::from("\'p") }],
-                            types: vec![], bindings: vec![] })});
+                let mut seg = path.segments.pop().unwrap().into_value();
+                seg.arguments = syn::PathArguments::AngleBracketed(parse_quote!{<'p>});
+                path.segments.push(seg);
+                expr.generics.params = parse_quote!{'p};
 
                 tokens
             } else {
@@ -67,27 +61,31 @@ pub fn build_py_proto(ast: &mut syn::Item) -> Tokens {
     }
 }
 
-fn impl_proto_impl(ty: &Box<syn::Ty>,
-                   impls: &mut Vec<syn::ImplItem>, proto: &defs::Proto) -> Tokens
-{
+fn impl_proto_impl(
+    ty: &Box<syn::Type>,
+    impls: &mut Vec<syn::ImplItem>,
+    proto: &defs::Proto
+) -> Tokens {
     let mut tokens = Tokens::new();
     let mut py_methods = Vec::new();
 
     for iimpl in impls.iter_mut() {
-        match iimpl.node {
-            syn::ImplItemKind::Method(ref mut sig, _) => {
+        match iimpl {
+            syn::ImplItem::Method(ref mut met) => {
                 for m in proto.methods {
-                    if m.eq(iimpl.ident.as_ref()) {
-                        impl_method_proto(ty, sig, m).to_tokens(&mut tokens);
+                    if m.eq(met.sig.ident.as_ref()) {
+                        impl_method_proto(ty, &mut met.sig, m).to_tokens(&mut tokens);
                     }
                 }
                 for m in proto.py_methods {
-                    if m.name == iimpl.ident.as_ref() {
-                        let name = syn::Ident::from(m.name);
-                        let proto = syn::Ident::from(m.proto);
+                    let ident = met.sig.ident.clone();
+                    if m.name == ident.as_ref() {
 
-                        let fn_spec = FnSpec::parse(&iimpl.ident, sig, &mut iimpl.attrs);
-                        let meth = py_method::impl_proto_wrap(ty, &iimpl.ident, &fn_spec);
+                        let name: syn::Ident = syn::parse_str(m.name).unwrap();
+                        let proto: syn::Path = syn::parse_str(m.proto).unwrap();
+
+                        let fn_spec = FnSpec::parse(&ident, &mut met.sig, &mut met.attrs);
+                        let meth = py_method::impl_proto_wrap(ty, &ident, &fn_spec);
 
                         py_methods.push(
                             quote! {
@@ -115,14 +113,13 @@ fn impl_proto_impl(ty: &Box<syn::Ty>,
 
     // unique mod name
     let p = proto.name;
-    let n = match ty.as_ref() {
-        &syn::Ty::Path(_, ref p) => {
-        p.segments.last().as_ref().unwrap().ident.as_ref()
-    }
-    _ => "PROTO_METHODS"
+    let n = if let syn::Type::Path(ref typath) = ty.as_ref() {
+        typath.path.segments.last().as_ref().unwrap().value().ident.as_ref()
+    } else {
+        "PROTO_METHODS"
     };
 
-    let dummy_const = syn::Ident::new(format!("_IMPL_PYO3_{}_{}", n, p));
+    let dummy_const: syn::Path = syn::parse_str(&format!("_IMPL_PYO3_{}_{}", n, p)).unwrap();
     quote! {
         #[feature(specialization)]
         #[allow(non_upper_case_globals, unused_attributes,

--- a/pyo3-derive-backend/src/py_proto.rs
+++ b/pyo3-derive-backend/src/py_proto.rs
@@ -9,56 +9,52 @@ use method::FnSpec;
 use func::impl_method_proto;
 
 
-pub fn build_py_proto(ast: &mut syn::Item) -> Tokens {
-    match ast {
-        syn::Item::Impl(ref mut expr) => {
-            if let Some((_, ref mut path, _)) = expr.trait_ {
-                let tokens = if let Some(ref mut segment) = path.segments.last() {
-                    let ty = &expr.self_ty;
-                    let items = &mut expr.items;
-                    match segment.value().ident.as_ref() {
-                        "PyObjectProtocol" =>
-                            impl_proto_impl(ty, items, &defs::OBJECT),
-                        "PyAsyncProtocol" =>
-                            impl_proto_impl(ty, items, &defs::ASYNC),
-                        "PyMappingProtocol" =>
-                            impl_proto_impl(ty, items, &defs::MAPPING),
-                        "PyIterProtocol" =>
-                            impl_proto_impl(ty, items, &defs::ITER),
-                        "PyContextProtocol" =>
-                            impl_proto_impl(ty, items, &defs::CONTEXT),
-                        "PySequenceProtocol" =>
-                            impl_proto_impl(ty, items, &defs::SEQ),
-                        "PyNumberProtocol" =>
-                            impl_proto_impl(ty, items, &defs::NUM),
-                        "PyDescrProtocol" =>
-                            impl_proto_impl(ty, items, &defs::DESCR),
-                        "PyBufferProtocol" =>
-                            impl_proto_impl(ty, items, &defs::BUFFER),
-                        "PyGCProtocol" =>
-                            impl_proto_impl(ty, items, &defs::GC),
-                        _ => {
-                            warn!("#[proto] can not be used with this block");
-                            return Tokens::new()
-                        }
+pub fn build_py_proto(ast: &mut syn::ItemImpl) -> Tokens {
+        if let Some((_, ref mut path, _)) = ast.trait_ {
+
+            let tokens = if let Some(ref mut segment) = path.segments.last() {
+                let ty = &ast.self_ty;
+                let items = &mut ast.items;
+                match segment.value().ident.as_ref() {
+                    "PyObjectProtocol" =>
+                        impl_proto_impl(ty, items, &defs::OBJECT),
+                    "PyAsyncProtocol" =>
+                        impl_proto_impl(ty, items, &defs::ASYNC),
+                    "PyMappingProtocol" =>
+                        impl_proto_impl(ty, items, &defs::MAPPING),
+                    "PyIterProtocol" =>
+                        impl_proto_impl(ty, items, &defs::ITER),
+                    "PyContextProtocol" =>
+                        impl_proto_impl(ty, items, &defs::CONTEXT),
+                    "PySequenceProtocol" =>
+                        impl_proto_impl(ty, items, &defs::SEQ),
+                    "PyNumberProtocol" =>
+                        impl_proto_impl(ty, items, &defs::NUM),
+                    "PyDescrProtocol" =>
+                        impl_proto_impl(ty, items, &defs::DESCR),
+                    "PyBufferProtocol" =>
+                        impl_proto_impl(ty, items, &defs::BUFFER),
+                    "PyGCProtocol" =>
+                        impl_proto_impl(ty, items, &defs::GC),
+                    _ => {
+                        warn!("#[proto] can not be used with this block");
+                        return Tokens::new()
                     }
-                } else {
-                    panic!("#[proto] can only be used with protocol trait implementations")
-                };
-
-                // attach lifetime
-                let mut seg = path.segments.pop().unwrap().into_value();
-                seg.arguments = syn::PathArguments::AngleBracketed(parse_quote!{<'p>});
-                path.segments.push(seg);
-                expr.generics.params = parse_quote!{'p};
-
-                tokens
+                }
             } else {
                 panic!("#[proto] can only be used with protocol trait implementations")
-            }
-        },
-        _ => panic!("#[proto] can only be used with Impl blocks"),
-    }
+            };
+
+            // attach lifetime
+            let mut seg = path.segments.pop().unwrap().into_value();
+            seg.arguments = syn::PathArguments::AngleBracketed(parse_quote!{<'p>});
+            path.segments.push(seg);
+            expr.generics.params = parse_quote!{'p};
+
+            tokens
+        } else {
+            panic!("#[proto] can only be used with protocol trait implementations")
+        }
 }
 
 fn impl_proto_impl(

--- a/pyo3-derive-backend/src/py_proto.rs
+++ b/pyo3-derive-backend/src/py_proto.rs
@@ -49,7 +49,7 @@ pub fn build_py_proto(ast: &mut syn::ItemImpl) -> Tokens {
             let mut seg = path.segments.pop().unwrap().into_value();
             seg.arguments = syn::PathArguments::AngleBracketed(parse_quote!{<'p>});
             path.segments.push(seg);
-            expr.generics.params = parse_quote!{'p};
+            ast.generics.params = parse_quote!{'p};
 
             tokens
         } else {

--- a/pyo3-derive-backend/src/py_proto.rs
+++ b/pyo3-derive-backend/src/py_proto.rs
@@ -123,7 +123,8 @@ fn impl_proto_impl(
     quote! {
         #[feature(specialization)]
         #[allow(non_upper_case_globals, unused_attributes,
-                unused_qualifications, unused_variables)]
+                unused_qualifications, unused_variables,
+                unused_imports)]
         const #dummy_const: () = {
             use pyo3 as _pyo3;
 

--- a/pyo3-derive-backend/src/utils.rs
+++ b/pyo3-derive-backend/src/utils.rs
@@ -1,49 +1,33 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 use syn;
-use syn::spanned::Spanned;
-use quote::{Tokens, ToTokens};
-use proc_macro::TokenStream;
-
-
-/// https://github.com/rust-lang/rust/pull/50120 removed the parantheses from
-/// the attr TokenStream, so we need to re-add them manually.
-///
-/// nightly-2018-04-05: ( name=CustomName )
-/// nightly-2018-04-28: name=CustomName
-// pub fn attr_with_parentheses(attr: TokenStream) -> String {
-//     let attr = attr.to_string();
-//     if attr.len() > 0 && !attr.starts_with("(") {
-//         return format!("({})", attr);
-//     } else {
-//         return attr;
-//     }
-// }
+use quote::{ToTokens, Tokens};
 
 pub fn print_err(msg: String, t: Tokens) {
     println!("Error: {} in '{}'", msg, t.to_string());
 }
 
 pub fn for_err_msg(i: &ToTokens) -> String {
-    let mut tokens = Tokens::new();
-
-    i.to_tokens(&mut tokens);
-    format!("{:?}", tokens).to_string()
+    format!("{:?}", i.into_tokens())
 }
-
 
 // FIXME(althonos): not sure the docstring formatting is on par here.
 pub fn get_doc(attrs: &Vec<syn::Attribute>, null_terminated: bool) -> syn::Lit {
-
     let mut doc = Vec::new();
-    let mut span = None;
+
+    // TODO(althonos): set span on produced doc str literal
+    // let mut span = None;
 
     for attr in attrs.iter() {
         if let Some(syn::Meta::NameValue(ref metanv)) = attr.interpret_meta() {
             if metanv.ident == "doc" {
-                span = Some(metanv.span());
+                // span = Some(metanv.span());
                 if let syn::Lit::Str(ref litstr) = metanv.lit {
                     let d = litstr.value();
-                    doc.push(if d.starts_with(" ") { d[1..d.len()].to_string() } else {d});
+                    doc.push(if d.starts_with(" ") {
+                        d[1..d.len()].to_string()
+                    } else {
+                        d
+                    });
                 } else {
                     panic!("could not parse doc");
                 }
@@ -59,5 +43,4 @@ pub fn get_doc(attrs: &Vec<syn::Attribute>, null_terminated: bool) -> syn::Lit {
     } else {
         format!("\"{}\"", doc)
     }).unwrap()
-
 }

--- a/pyo3-derive-backend/src/utils.rs
+++ b/pyo3-derive-backend/src/utils.rs
@@ -10,14 +10,14 @@ use proc_macro::TokenStream;
 ///
 /// nightly-2018-04-05: ( name=CustomName )
 /// nightly-2018-04-28: name=CustomName
-pub fn attr_with_parentheses(attr: TokenStream) -> String {
-    let attr = attr.to_string();
-    if attr.len() > 0 && !attr.starts_with("(") {
-        return format!("({})", attr);
-    } else {
-        return attr;
-    }
-}
+// pub fn attr_with_parentheses(attr: TokenStream) -> String {
+//     let attr = attr.to_string();
+//     if attr.len() > 0 && !attr.starts_with("(") {
+//         return format!("({})", attr);
+//     } else {
+//         return attr;
+//     }
+// }
 
 pub fn print_err(msg: String, t: Tokens) {
     println!("Error: {} in '{}'", msg, t.to_string());

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -13,11 +13,12 @@ license = "Apache-2.0"
 proc-macro = true
 
 [dependencies]
-quote="0.3"
+quote="0.5"
 
 [dependencies.syn]
-version="0.11"
-features=["full"]
+version="0.13"
+features=["full", "parsing", "printing", "extra-traits"]
+
 
 [dependencies.pyo3-derive-backend]
 path = "../pyo3-derive-backend"

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pyo3cls"
 version = "0.2.5"
 description = "Proc macros for PyO3 package"
-authors = ["PyO3 Project and Contributors <https://github.com/PyO3"]
+authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 homepage = "https://github.com/pyo3/pyo3"
 repository = "https://github.com/pyo3/pyo3.git"
 documentation = "http://pyo3.github.io/PyO3/pyo3/"

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -19,7 +19,6 @@ quote="0.5"
 version="0.13"
 features=["full", "parsing", "printing", "extra-traits"]
 
-
 [dependencies.pyo3-derive-backend]
 path = "../pyo3-derive-backend"
 version = "0.2.5"

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -6,16 +6,15 @@
 extern crate proc_macro;
 extern crate pyo3_derive_backend;
 extern crate quote;
-#[macro_use]
 extern crate syn;
 
-use std::str::FromStr;
-
 use proc_macro::TokenStream;
-use pyo3_derive_backend::*;
-use quote::{ToTokens, Tokens};
+use quote::ToTokens;
 use syn::buffer::TokenBuffer;
 use syn::punctuated::Punctuated;
+use syn::token::Comma;
+
+use pyo3_derive_backend::*;
 
 
 #[proc_macro_attribute]
@@ -84,9 +83,9 @@ pub fn class(attr: TokenStream, input: TokenStream) -> TokenStream {
         .expect("#[class] must be used on an ");
 
     // Parse the macro arguments into a list of expressions
-    let mut args: Vec<syn::Expr> = {
+    let args: Vec<syn::Expr> = {
         let buffer = TokenBuffer::new(attr);
-        let punc = Punctuated::<syn::Expr, Token![,]>::parse_terminated(buffer.begin());
+        let punc = Punctuated::<syn::Expr,Comma>::parse_terminated(buffer.begin());
         punc.expect("could not parse macro arguments").0.into_iter().collect()
     };
 

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -6,136 +6,119 @@
 extern crate proc_macro;
 extern crate pyo3_derive_backend;
 extern crate quote;
+#[macro_use]
 extern crate syn;
+
+use std::str::FromStr;
 
 use proc_macro::TokenStream;
 use pyo3_derive_backend::*;
 use quote::{ToTokens, Tokens};
-use std::str::FromStr;
+use syn::buffer::TokenBuffer;
+use syn::punctuated::Punctuated;
+
 
 #[proc_macro_attribute]
 pub fn mod2init(attr: TokenStream, input: TokenStream) -> TokenStream {
-    // Construct a string representation of the type definition
-    let source = input.to_string();
+    // Parse the token stream into a syntax tree
+    let mut ast: syn::ItemFn = syn::parse(input).unwrap();
 
-    // Parse the string representation into a syntax tree
-    let mut ast = syn::parse_item(&source).unwrap();
+    // Extract the mod name
+    let modname: syn::Ident = syn::parse(attr).unwrap();
 
-    // Build the output
+    // Process the functions within the module
     module::process_functions_in_module(&mut ast);
 
-    let attr = utils::attr_with_parentheses(attr);
-
-    let modname = &attr[1..attr.len() - 1].to_string();
-
+    // Create the module initialisation function
     let init = module::py2_init(&ast.ident, &modname, utils::get_doc(&ast.attrs, false));
 
-    // Return the generated impl as a TokenStream
-    let mut tokens = Tokens::new();
-    ast.to_tokens(&mut tokens);
-    let s = String::from(tokens.as_str()) + init.as_str();
-
-    TokenStream::from_str(s.as_str()).unwrap()
+    // Return the generated code as a TokenStream
+    let mut tokens = ast.into_tokens();
+    tokens.append_all(init);
+    tokens.into()
 }
 
 #[proc_macro_attribute]
 pub fn mod3init(attr: TokenStream, input: TokenStream) -> TokenStream {
-    // Construct a string representation of the type definition
-    let source = input.to_string();
+    // Parse the token stream into a syntax tree
+    let mut ast: syn::ItemFn = syn::parse(input).unwrap();
 
-    // Parse the string representation into a syntax tree
-    let mut ast = syn::parse_item(&source).unwrap();
+    // Extract the mod name
+    let modname: syn::Ident = syn::parse(attr).unwrap();
 
-    // Build the output
+    // Process the functions within the module
     module::process_functions_in_module(&mut ast);
 
-    let attr = utils::attr_with_parentheses(attr);
-
-    let modname = &attr[1..attr.len() - 1].to_string();
-
+    // Create the module initialisation function
     let init = module::py3_init(&ast.ident, &modname, utils::get_doc(&ast.attrs, false));
 
-    // Return the generated impl as a TokenStream
-    let mut tokens = Tokens::new();
-    ast.to_tokens(&mut tokens);
-    let s = String::from(tokens.as_str()) + init.as_str();
-
-    TokenStream::from_str(s.as_str()).unwrap()
+    // Return the generated code as a TokenStream
+    let mut tokens = ast.into_tokens();
+    tokens.append_all(init);
+    tokens.into()
 }
 
 #[proc_macro_attribute]
 pub fn proto(_: TokenStream, input: TokenStream) -> TokenStream {
-    // Construct a string representation of the type definition
-    let source = input.to_string();
-
-    // Parse the string representation into a syntax tree
-    let mut ast = syn::parse_item(&source).unwrap();
+    // Parse the token stream into a syntax tree
+    let mut ast: syn::Item = syn::parse(input).unwrap();
 
     // Build the output
     let expanded = py_proto::build_py_proto(&mut ast);
 
     // Return the generated impl as a TokenStream
-    let mut tokens = Tokens::new();
-    ast.to_tokens(&mut tokens);
-    let s = String::from(tokens.as_str()) + expanded.as_str();
-
-    TokenStream::from_str(s.as_str()).unwrap()
+    let mut tokens = ast.into_tokens();
+    tokens.append_all(expanded);
+    tokens.into()
 }
 
 #[proc_macro_attribute]
 pub fn class(attr: TokenStream, input: TokenStream) -> TokenStream {
-    // Construct a string representation of the type definition
-    let source = input.to_string();
+    // Parse the token stream into a syntax tree
+    let mut ast: syn::DeriveInput = syn::parse(input).unwrap();
 
-    // Parse the string representation into a syntax tree
-    let mut ast = syn::parse_derive_input(&source).unwrap();
+    // Parse the macro arguments into a list of expressions
+    let mut args: Vec<syn::Expr> = {
+        let buffer = TokenBuffer::new(attr);
+        let punc = Punctuated::<syn::Expr, Token![,]>::parse_terminated(buffer.begin());
+        punc.expect("could not parse arguments").0.into_iter().collect()
+    };
 
     // Build the output
-    let expanded = py_class::build_py_class(&mut ast, utils::attr_with_parentheses(attr));
+    let expanded = py_class::build_py_class(&mut ast, &args);
 
     // Return the generated impl as a TokenStream
-    let mut tokens = Tokens::new();
-    ast.to_tokens(&mut tokens);
-    let s = String::from(tokens.as_str()) + expanded.as_str();
-
-    TokenStream::from_str(s.as_str()).unwrap()
+    let mut tokens = ast.into_tokens();
+    tokens.append_all(expanded);
+    tokens.into()
 }
 
 #[proc_macro_attribute]
 pub fn methods(_: TokenStream, input: TokenStream) -> TokenStream {
-    // Construct a string representation of the type definition
-    let source = input.to_string();
-
-    // Parse the string representation into a syntax tree
-    let mut ast = syn::parse_item(&source).unwrap();
+    // Parse the token stream into a syntax tree
+    let mut ast: syn::Item = syn::parse(input).unwrap();
 
     // Build the output
     let expanded = py_impl::build_py_methods(&mut ast);
 
     // Return the generated impl as a TokenStream
-    let mut tokens = Tokens::new();
-    ast.to_tokens(&mut tokens);
-    let s = String::from(tokens.as_str()) + expanded.as_str();
-
-    TokenStream::from_str(s.as_str()).unwrap()
+    let mut tokens = ast.into_tokens();
+    tokens.append_all(expanded);
+    tokens.into()
 }
 
 #[proc_macro_attribute]
 pub fn function(_: TokenStream, input: TokenStream) -> TokenStream {
-    // Construct a string representation of the type definition
-    let source = input.to_string();
-
-    // Parse the string representation into a syntax tree
-    let mut ast = syn::parse_item(&source).unwrap();
+    // Parse the token stream into a syntax tree
+    let mut ast: syn::ItemFn = syn::parse(input)
+        .expect("#[function] must be used on function definitions");
 
     // Build the output
     let python_name = ast.ident.clone();
     let expanded = module::add_fn_to_module(&mut ast, &python_name, Vec::new());
 
     // Return the generated impl as a TokenStream
-    let mut tokens = Tokens::new();
-    ast.to_tokens(&mut tokens);
-    let s = String::from(tokens.as_str()) + expanded.as_str();
-
-    TokenStream::from_str(s.as_str()).unwrap()
+    let mut tokens = ast.into_tokens();
+    tokens.append_all(expanded);
+    tokens.into()
 }

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -64,7 +64,7 @@ pub fn mod3init(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn proto(_: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the token stream into a syntax tree
-    let mut ast: syn::Item = syn::parse(input)
+    let mut ast: syn::ItemImpl = syn::parse(input)
         .expect("#[proto] must be used on an `impl` block");
 
     // Build the output
@@ -80,7 +80,7 @@ pub fn proto(_: TokenStream, input: TokenStream) -> TokenStream {
 pub fn class(attr: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the token stream into a syntax tree
     let mut ast: syn::DeriveInput = syn::parse(input)
-        .expect("#[class] must be used on an ");
+        .expect("#[class] must be used on a `struct`");
 
     // Parse the macro arguments into a list of expressions
     let args: Vec<syn::Expr> = {
@@ -101,7 +101,7 @@ pub fn class(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn methods(_: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the token stream into a syntax tree
-    let mut ast: syn::Item = syn::parse(input)
+    let mut ast: syn::ItemImpl = syn::parse(input)
         .expect("#[methods] must be used on an `impl` block");
 
     // Build the output

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -21,10 +21,12 @@ use syn::punctuated::Punctuated;
 #[proc_macro_attribute]
 pub fn mod2init(attr: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the token stream into a syntax tree
-    let mut ast: syn::ItemFn = syn::parse(input).unwrap();
+    let mut ast: syn::ItemFn = syn::parse(input)
+        .expect("#[modinit] must be used on a function");
 
     // Extract the mod name
-    let modname: syn::Ident = syn::parse(attr).unwrap();
+    let modname: syn::Ident = syn::parse(attr)
+        .expect("could not parse module name");
 
     // Process the functions within the module
     module::process_functions_in_module(&mut ast);
@@ -41,10 +43,12 @@ pub fn mod2init(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn mod3init(attr: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the token stream into a syntax tree
-    let mut ast: syn::ItemFn = syn::parse(input).unwrap();
+    let mut ast: syn::ItemFn = syn::parse(input)
+        .expect("#[modinit] must be used on a `fn` block");
 
     // Extract the mod name
-    let modname: syn::Ident = syn::parse(attr).unwrap();
+    let modname: syn::Ident = syn::parse(attr)
+        .expect("could not parse module name");
 
     // Process the functions within the module
     module::process_functions_in_module(&mut ast);
@@ -61,7 +65,8 @@ pub fn mod3init(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn proto(_: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the token stream into a syntax tree
-    let mut ast: syn::Item = syn::parse(input).unwrap();
+    let mut ast: syn::Item = syn::parse(input)
+        .expect("#[proto] must be used on an `impl` block");
 
     // Build the output
     let expanded = py_proto::build_py_proto(&mut ast);
@@ -75,13 +80,14 @@ pub fn proto(_: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn class(attr: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the token stream into a syntax tree
-    let mut ast: syn::DeriveInput = syn::parse(input).unwrap();
+    let mut ast: syn::DeriveInput = syn::parse(input)
+        .expect("#[class] must be used on an ");
 
     // Parse the macro arguments into a list of expressions
     let mut args: Vec<syn::Expr> = {
         let buffer = TokenBuffer::new(attr);
         let punc = Punctuated::<syn::Expr, Token![,]>::parse_terminated(buffer.begin());
-        punc.expect("could not parse arguments").0.into_iter().collect()
+        punc.expect("could not parse macro arguments").0.into_iter().collect()
     };
 
     // Build the output
@@ -96,7 +102,8 @@ pub fn class(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn methods(_: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the token stream into a syntax tree
-    let mut ast: syn::Item = syn::parse(input).unwrap();
+    let mut ast: syn::Item = syn::parse(input)
+        .expect("#[methods] must be used on an `impl` block");
 
     // Build the output
     let expanded = py_impl::build_py_methods(&mut ast);
@@ -111,7 +118,7 @@ pub fn methods(_: TokenStream, input: TokenStream) -> TokenStream {
 pub fn function(_: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the token stream into a syntax tree
     let mut ast: syn::ItemFn = syn::parse(input)
-        .expect("#[function] must be used on function definitions");
+        .expect("#[function] must be used on a `fn` block");
 
     // Build the output
     let python_name = ast.ident.clone();

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -176,6 +176,11 @@ struct MethArgs {
 #[pymethods]
 impl MethArgs {
 
+    #[args(test)]
+    fn get_optional(&self, test: Option<i32>) -> PyResult<i32> {
+        Ok(test.unwrap_or(10))
+    }
+
     #[args(test="10")]
     fn get_default(&self, test: i32) -> PyResult<i32> {
         Ok(test)
@@ -196,6 +201,8 @@ fn meth_args() {
     let py = gil.python();
     let inst = py.init(|t| MethArgs{token: t}).unwrap();
 
+    py_run!(py, inst, "assert inst.get_optional() == 10");
+    py_run!(py, inst, "assert inst.get_optional(100) == 100");
     py_run!(py, inst, "assert inst.get_default() == 10");
     py_run!(py, inst, "assert inst.get_default(100) == 100");
     py_run!(py, inst, "assert inst.get_kwarg() == 10");

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -51,7 +51,7 @@ fn test_module_with_functions() {
 
     let d = PyDict::new(py);
     d.set_item("module_with_functions", unsafe { PyObject::from_owned_ptr(py, PyInit_module_with_functions()) }).unwrap();
-    py.run("assert module_with_functions.__doc__.strip() == 'This module is implemented in Rust.'", None, Some(d)).unwrap();
+    py.run("assert module_with_functions.__doc__ == 'This module is implemented in Rust.'", None, Some(d)).unwrap();
     py.run("assert module_with_functions.sum_as_string(1, 2) == '3'", None, Some(d)).unwrap();
     py.run("assert module_with_functions.no_parameters() == 42", None, Some(d)).unwrap();
     py.run("assert module_with_functions.foo == 'bar'", None, Some(d)).unwrap();


### PR DESCRIPTION
Opening a PR for this so we can discuss possible improvements before merging.

I tried to remove interconversions between `Ident` and `String` as much as possible, so that original spans are preserved.

Notable change in the `syn` API is the `Ident` type not being as generic as before (now it only accepts valid Rust identifiers, whereas before it would also accept paths). I used `Path` where necessary, and left `Ident` everywhere else. 

## Changes

Some function signatures were restricted:
* `build_py_proto` and `build_py_methods` only accept an `impl` block
* `py2_init`, `py3_init` and `add_fn_to_module` only accept an `fn` block

The `Argument` struct use `Ident` internally, instead of `String`.

## Possible improvement with crate name

Are we sticking with `pyo3-derive-backend` ? Because this is not actually a crate with `derive` macros, but with `proc_macro_attribute`-style macros ! 

## Possible improvement with docs

`syn` now desugars doc comments into plain attributes, but the indentation is not mangled with. I'd suggest using the [`textwrap`](https://crates.io/crates/textwrap) crate to keep the indentation clean independently from the style of doc comments definitions (`///` vs `//!` vs `/!*` etc.).

## Possible improvement with internal attributes

Rust does not require attribute arguments to follow the *meta* syntax anymore, so we could write our own parser for attributes arguments, for instance to support a lighter syntax:
```rust
#[args(integer=10, string="string", *, args=*, kwargs=**)]
#[class(base=::some::type::Path, freelist=2, dict)]
```

We have to syntaxes for macro arguments currently:
*  the one for `#[args(...)]`:
    ```
    ARG  := IDENT 
          | IDENT = LITTERAL
    ARGS := ARG 
          | ARG, ARGS
    ```
* the one for `#[class(...)]`:
   ```
    ARG  := IDENT
          | IDENT = EXPR
          | IDENT = TYPE
    ARGS := ARG 
          | ARG, ARGS
   ```






