### PR TITLE
Added a function to PyModule to load a module from a string of Python

### DIFF
--- a/src/objects/module.rs
+++ b/src/objects/module.rs
@@ -46,20 +46,21 @@ impl PyModule {
     /// 'file_name' is the file name to associate with the module 
     ///     (this is used when Python reports errors, for example)
     /// 'module_name' is the name to give the module
+    #[cfg(Py_3)]
     pub fn from_code<'p>(py: Python<'p>, code: &str, file_name: &str, module_name: &str) -> PyResult<&'p PyModule> {
 
         let data = CString::new(code)?;
-        let filename = CString::new(file_name)?;
+        let filename = CString::new(file_name)?.as_ptr();
         let module = CString::new(module_name)?;
 
         unsafe {
 
-            let cptr = ffi::Py_CompileString(data.as_ptr(), filename.as_ptr(), ffi::Py_file_input);
+            let cptr = ffi::Py_CompileString(data.as_ptr(), filename, ffi::Py_file_input);
             if cptr.is_null() {
                 return Err(PyErr::fetch(py));
             }
 
-            let mptr = ffi::PyImport_ExecCodeModuleEx(module.as_ptr(), cptr, filename.as_ptr());
+            let mptr = ffi::PyImport_ExecCodeModuleEx(module.as_ptr(), cptr, filename);
             if mptr.is_null() {
                 return Err(PyErr::fetch(py));
             }

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate pyo3;
 
-use pyo3::{PyDict, PyModule, PyObject, PyResult, Python};
+use pyo3::{PyDict, PyModule, PyObject, PyResult, Python, ToPyObject};
 use pyo3::py::{class, function, modinit};
 
 

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -59,3 +59,30 @@ fn test_module_with_functions() {
     py.run("assert module_with_functions.double(3) == 6", None, Some(d)).unwrap();
     py.run("assert module_with_functions.also_double(3) == 6", None, Some(d)).unwrap();
 }
+
+#[test]
+#[cfg(Py_3)]
+fn test_module_from_code() {
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let adder_mod = PyModule::from_code(py, 
+        "def add(a,b):\n\treturn a+b", 
+        "adder_mod.py", 
+        "adder_mod")
+        .expect("Module code should be loaded");
+
+    let add_func = adder_mod
+        .get("add")
+        .expect("Add fucntion should be in the module")
+        .to_object(py);
+
+    let ret_value: i32 = add_func
+        .call1(py, (1, 2))
+        .expect("A value should be returned")
+        .extract(py)
+        .expect("The value should be able to be converted to an i32");
+
+    assert_eq!(ret_value, 3);
+}


### PR DESCRIPTION
I have a situation where I have a blob of Python code that I want to load into a module so that I can later pluck functions out of it to call throughout my application, import it, etc, etc.  

As such I figured it made sense to add the function defined in this pull request to the `PyModule` struct so you can construct such a struct containing some code as a kind of sibling function to the `new` and `import` functions you already have.

Is this something you would like?  If not, can you explain how I would get the same functionality from outside of the library? 