### PR TITLE
Bug #178 Getters can not be added to non-Copy types

### DIFF
--- a/examples/my-class/Cargo.toml
+++ b/examples/my-class/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+authors = ["Antonio Yang<yanganto@gmail.com>"]
+name = "my-class"
+version = "0.1.0"
+
+[dependencies]
+
+[dependencies.pyo3]
+path = "../../"
+
+[lib]
+name = "my_class"
+crate-type = ["cdylib"]

--- a/examples/my-class/README.md
+++ b/examples/my-class/README.md
@@ -1,0 +1,17 @@
+# word-count
+
+## Build
+
+```bash
+python setup.py install
+```
+
+## Usage
+
+```python
+from my_class import MyClass
+
+c = MyClass("title")
+c.title = "new title"
+print("The title of c is {}".format(c.title))
+```

--- a/examples/my-class/my_class/__init__.py
+++ b/examples/my-class/my_class/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from ._my_class import MyClass
+
+__all__ = ['MyClass']
+

--- a/examples/my-class/setup.py
+++ b/examples/my-class/setup.py
@@ -14,8 +14,22 @@ except ImportError:
     else:
         from setuptools_rust import RustExtension
 
+class PyTest(TestCommand):
+    user_options = []
+    
+    def run(self):
+        self.run_command("test_rust")
+
+        import subprocess
+        import sys
+        errno = subprocess.call([sys.executable, '-m', 'pytest', 'tests'])
+        raise SystemExit(errno)
+
+
 setup_requires = ['setuptools-rust>=0.6.1']
 install_requires = []
+tests_require = install_requires + ['pytest']
+
 
 setup(
     name='my-class',
@@ -27,4 +41,5 @@ setup(
     setup_requires=setup_requires,
     include_package_data=True,
     zip_safe=False,
+    cmdclass=dict(test=PyTest)
 )

--- a/examples/my-class/setup.py
+++ b/examples/my-class/setup.py
@@ -1,0 +1,30 @@
+import sys
+
+from setuptools import setup
+from setuptools.command.test import test as TestCommand
+
+try:
+    from setuptools_rust import RustExtension
+except ImportError:
+    import subprocess
+    errno = subprocess.call([sys.executable, '-m', 'pip', 'install', 'setuptools-rust'])
+    if errno:
+        print("Please install setuptools-rust package")
+        raise SystemExit(errno)
+    else:
+        from setuptools_rust import RustExtension
+
+setup_requires = ['setuptools-rust>=0.6.1']
+install_requires = []
+
+setup(
+    name='my-class',
+    version='0.1.0',
+    classifiers=[],
+    packages=['my_class'],
+    rust_extensions=[RustExtension('my_class._my_class', 'Cargo.toml')],
+    install_requires=install_requires,
+    setup_requires=setup_requires,
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/examples/my-class/src/lib.rs
+++ b/examples/my-class/src/lib.rs
@@ -1,0 +1,31 @@
+#![allow(unused_variables)]
+#![feature(proc_macro, specialization, const_fn)]
+extern crate pyo3;
+use pyo3::prelude::*;
+use pyo3::py::{class, methods, modinit};
+
+
+#[class]
+struct MyClass{
+    title: String, // has Clone trait
+    // #[prop(get, set)]
+    num: i32 // has Copy trait
+}
+
+#[methods]
+impl MyClass{
+
+    #[new]
+    fn __new__(obj: &PyRawObject, title: String) -> PyResult<()> {
+        obj.init(|t| MyClass{title: title, num: 1987})
+    }
+
+}
+
+
+#[modinit(_my_class)]
+fn init_mod(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<MyClass>()?;
+
+    Ok(())
+}

--- a/examples/my-class/src/lib.rs
+++ b/examples/my-class/src/lib.rs
@@ -7,8 +7,9 @@ use pyo3::py::{class, methods, modinit};
 
 #[class]
 struct MyClass{
+    #[prop(clone_get, set)]
     title: String, // has Clone trait
-    // #[prop(get, set)]
+    #[prop(get, set)]
     num: i32 // has Copy trait
 }
 

--- a/examples/my-class/tests/test_my_class.py
+++ b/examples/my-class/tests/test_my_class.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import os
+
+import pytest
+
+from my_class import MyClass
+
+
+def test_get_from_clone():
+    c = MyClass("title")
+    assert c.title == "title"
+

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -22,6 +22,7 @@ pub struct FnArg<'a> {
 #[derive(Clone, PartialEq, Debug)]
 pub enum FnType {
     Getter(Option<String>),
+    CloneGetter(Option<String>),
     Setter(Option<String>),
     Fn,
     FnNew,

--- a/pyo3-derive-backend/src/py_method.rs
+++ b/pyo3-derive-backend/src/py_method.rs
@@ -33,6 +33,8 @@ pub fn gen_py_method<'a>(
             impl_py_method_def_static(name, doc, &impl_wrap_static(cls, name, &spec)),
         FnType::Getter(ref getter) =>
             impl_py_getter_def(name, doc, getter, &impl_wrap_getter(cls, name)),
+        FnType::CloneGetter(ref getter) =>
+            impl_py_getter_def(name, doc, getter, &impl_wrap_getter(cls, name)),
         FnType::Setter(ref setter) =>
             impl_py_setter_def(name, doc, setter, &impl_wrap_setter(cls, name, &spec)),
     }


### PR DESCRIPTION
To fix bug #178, I add a macro clone_get, so field (such as String) without copy trait can use 
`#[prop(clone_get)]`.

If there is another way to do it better please kindly tell me.

Thank you.