### PR TITLE
Modify pyobject_native_type to take path instead of ident

### DIFF
--- a/src/objects/boolobject.rs
+++ b/src/objects/boolobject.rs
@@ -7,7 +7,7 @@ use conversion::{ToPyObject, IntoPyObject, ToBorrowedObject, PyTryFrom};
 /// Represents a Python `bool`.
 pub struct PyBool(PyObject);
 
-pyobject_native_type!(PyBool, PyBool_Type, PyBool_Check);
+pyobject_native_type!(PyBool, ffi::PyBool_Type, ffi::PyBool_Check);
 
 
 impl PyBool {

--- a/src/objects/bytearray.rs
+++ b/src/objects/bytearray.rs
@@ -11,7 +11,7 @@ use err::{PyResult, PyErr};
 /// Represents a Python `bytearray`.
 pub struct PyByteArray(PyObject);
 
-pyobject_native_type!(PyByteArray, PyByteArray_Type, PyByteArray_Check);
+pyobject_native_type!(PyByteArray, ffi::PyByteArray_Type, ffi::PyByteArray_Check);
 
 impl PyByteArray {
     /// Creates a new Python bytearray object.

--- a/src/objects/dict.rs
+++ b/src/objects/dict.rs
@@ -14,7 +14,7 @@ use err::{self, PyResult, PyErr};
 /// Represents a Python `dict`.
 pub struct PyDict(PyObject);
 
-pyobject_native_type!(PyDict, PyDict_Type, PyDict_Check);
+pyobject_native_type!(PyDict, ffi::PyDict_Type, ffi::PyDict_Check);
 
 
 impl PyDict {

--- a/src/objects/floatob.rs
+++ b/src/objects/floatob.rs
@@ -20,7 +20,7 @@ use objectprotocol::ObjectProtocol;
 /// with `f32`/`f64`.
 pub struct PyFloat(PyObject);
 
-pyobject_native_type!(PyFloat, PyFloat_Type, PyFloat_Check);
+pyobject_native_type!(PyFloat, ffi::PyFloat_Type, ffi::PyFloat_Check);
 
 
 impl PyFloat {

--- a/src/objects/list.rs
+++ b/src/objects/list.rs
@@ -15,7 +15,7 @@ use conversion::{ToPyObject, IntoPyObject, ToBorrowedObject};
 /// Represents a Python `list`.
 pub struct PyList(PyObject);
 
-pyobject_native_type!(PyList, PyList_Type, PyList_Check);
+pyobject_native_type!(PyList, ffi::PyList_Type, ffi::PyList_Check);
 
 impl PyList {
     /// Construct a new list with the given elements.

--- a/src/objects/module.rs
+++ b/src/objects/module.rs
@@ -19,7 +19,7 @@ use err::{PyResult, PyErr};
 /// Represents a Python `module` object.
 pub struct PyModule(PyObject);
 
-pyobject_native_type!(PyModule, PyModule_Type, PyModule_Check);
+pyobject_native_type!(PyModule, ffi::PyModule_Type, ffi::PyModule_Check);
 
 
 impl PyModule {

--- a/src/objects/num2.rs
+++ b/src/objects/num2.rs
@@ -26,7 +26,7 @@ use super::num_common::{err_if_invalid_value, IS_LITTLE_ENDIAN};
 /// with the primitive Rust integer types.
 pub struct PyInt(PyObject);
 
-pyobject_native_type!(PyInt, PyInt_Type, PyInt_Check);
+pyobject_native_type!(PyInt, ffi::PyInt_Type, ffi::PyInt_Check);
 
 /// In Python 2.x, represents a Python `long` object.
 /// Both `PyInt` and `PyLong` refer to the same type on Python 3.x.
@@ -37,7 +37,7 @@ pyobject_native_type!(PyInt, PyInt_Type, PyInt_Check);
 /// with the primitive Rust integer types.
 pub struct PyLong(PyObject);
 
-pyobject_native_type!(PyLong, PyLong_Type, PyLong_Check);
+pyobject_native_type!(PyLong, ffi::PyLong_Type, ffi::PyLong_Check);
 
 impl PyInt {
     /// Creates a new Python 2.7 `int` object.

--- a/src/objects/num3.rs
+++ b/src/objects/num3.rs
@@ -23,7 +23,7 @@ use super::num_common::{err_if_invalid_value, IS_LITTLE_ENDIAN};
 /// with the primitive Rust integer types.
 pub struct PyLong(PyObject);
 
-pyobject_native_type!(PyLong, PyLong_Type, PyLong_Check);
+pyobject_native_type!(PyLong, ffi::PyLong_Type, ffi::PyLong_Check);
 
 macro_rules! int_fits_c_long(
     ($rust_type:ty) => (

--- a/src/objects/sequence.rs
+++ b/src/objects/sequence.rs
@@ -16,7 +16,7 @@ use objectprotocol::ObjectProtocol;
 /// Represents a reference to a python object supporting the sequence protocol.
 pub struct PySequence(PyObject);
 pyobject_native_type_named!(PySequence);
-pyobject_downcast!(PySequence, PySequence_Check);
+pyobject_downcast!(PySequence, ffi::PySequence_Check);
 
 
 #[cfg_attr(feature = "cargo-clippy", allow(len_without_is_empty))]

--- a/src/objects/set.rs
+++ b/src/objects/set.rs
@@ -17,7 +17,8 @@ pub struct PySet(PyObject);
 pub struct PyFrozenSet(PyObject);
 
 
-pyobject_native_type!(PySet, PySet_Type, PySet_Check);pyobject_native_type!(PyFrozenSet, PyFrozenSet_Type, PyFrozenSet_Check);
+pyobject_native_type!(PySet, ffi::PySet_Type, ffi::PySet_Check);
+pyobject_native_type!(PyFrozenSet, ffi::PyFrozenSet_Type, ffi::PyFrozenSet_Check);
 
 impl PySet {
     /// Creates a new set.

--- a/src/objects/slice.rs
+++ b/src/objects/slice.rs
@@ -14,7 +14,7 @@ use conversion::ToPyObject;
 /// Only `c_long` indeces supprted at the moment by `PySlice` object.
 pub struct PySlice(PyObject);
 
-pyobject_native_type!(PySlice, PySlice_Type, PySlice_Check);
+pyobject_native_type!(PySlice, ffi::PySlice_Type, ffi::PySlice_Check);
 
 
 /// Represents a Python `slice` indices

--- a/src/objects/string.rs
+++ b/src/objects/string.rs
@@ -16,7 +16,7 @@ use super::PyStringData;
 /// Represents a Python `string`.
 pub struct PyString(PyObject);
 
-pyobject_native_type!(PyString, PyUnicode_Type, PyUnicode_Check);
+pyobject_native_type!(PyString, ffi::PyUnicode_Type, ffi::PyUnicode_Check);
 
 /// Represents a Python `unicode string`.
 /// Corresponds to `unicode` in Python 2, and `str` in Python 3.
@@ -25,7 +25,7 @@ pub use PyString as PyUnicode;
 /// Represents a Python `byte` string.
 pub struct PyBytes(PyObject);
 
-pyobject_native_type!(PyBytes, PyBytes_Type, PyBytes_Check);
+pyobject_native_type!(PyBytes, ffi::PyBytes_Type, ffi::PyBytes_Check);
 
 
 impl PyString {

--- a/src/objects/string2.rs
+++ b/src/objects/string2.rs
@@ -18,17 +18,17 @@ use super::{PyObjectRef, PyStringData};
 /// Represents a Python `string`.
 pub struct PyString(PyObject);
 
-pyobject_native_type!(PyString, PyBaseString_Type, PyBaseString_Check);
+pyobject_native_type!(PyString, ffi::PyBaseString_Type, ffi::PyBaseString_Check);
 
 /// Represents a Python `unicode string`.
 pub struct PyUnicode(PyObject);
 
-pyobject_native_type!(PyUnicode, PyUnicode_Type, PyUnicode_Check);
+pyobject_native_type!(PyUnicode, ffi::PyUnicode_Type, ffi::PyUnicode_Check);
 
 /// Represents a Python `byte` string. Corresponds to `str` in Python 2
 pub struct PyBytes(PyObject);
 
-pyobject_native_type!(PyBytes, PyBaseString_Type, PyString_Check);
+pyobject_native_type!(PyBytes, ffi::PyBaseString_Type, ffi::PyString_Check);
 
 
 impl PyString {

--- a/src/objects/tuple.rs
+++ b/src/objects/tuple.rs
@@ -15,7 +15,7 @@ use super::exc;
 /// Represents a Python `tuple` object.
 pub struct PyTuple(PyObject);
 
-pyobject_native_type!(PyTuple, PyTuple_Type, PyTuple_Check);
+pyobject_native_type!(PyTuple, ffi::PyTuple_Type, ffi::PyTuple_Check);
 
 
 impl PyTuple {

--- a/src/objects/typeobject.rs
+++ b/src/objects/typeobject.rs
@@ -15,7 +15,7 @@ use typeob::{PyTypeInfo, PyTypeObject};
 /// Represents a reference to a Python `type object`.
 pub struct PyType(PyObject);
 
-pyobject_native_type!(PyType, PyType_Type, PyType_Check);
+pyobject_native_type!(PyType, ffi::PyType_Type, ffi::PyType_Check);
 
 
 impl PyType {


### PR DESCRIPTION
So that we can use this macro outside this crate.
Almost same as #158.