### PR TITLE
supporting classes with generic lifetimes

### DIFF
--- a/pyo3-derive-backend/src/py_impl.rs
+++ b/pyo3-derive-backend/src/py_impl.rs
@@ -14,6 +14,8 @@ pub fn build_py_methods(ast: &mut syn::ItemImpl) -> TokenStream {
 }
 
 pub fn impl_methods(generics: &syn::Generics, ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> TokenStream {
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
     // get method names in impl block
     let mut methods = Vec::new();
     for iimpl in impls.iter_mut() {
@@ -28,8 +30,8 @@ pub fn impl_methods(generics: &syn::Generics, ty: &syn::Type, impls: &mut Vec<sy
         }
     }
 
-    let result = quote! {
-        impl ::pyo3::class::methods::PyMethodsProtocolImpl for #ty {
+    quote! {
+        impl #impl_generics ::pyo3::class::methods::PyMethodsProtocolImpl for #ty #where_clause {
             fn py_methods() -> &'static [::pyo3::class::PyMethodDefType] {
                 static METHODS: &'static [::pyo3::class::PyMethodDefType] = &[
                     #(#methods),*
@@ -37,7 +39,5 @@ pub fn impl_methods(generics: &syn::Generics, ty: &syn::Type, impls: &mut Vec<sy
                 METHODS
             }
         }
-    };
-    println!("{}", result);
-    result
+    }
 }

--- a/pyo3-derive-backend/src/py_impl.rs
+++ b/pyo3-derive-backend/src/py_impl.rs
@@ -9,11 +9,11 @@ pub fn build_py_methods(ast: &mut syn::ItemImpl) -> TokenStream {
     if ast.trait_.is_some() {
         panic!("#[methods] can not be used only with trait impl block");
     } else {
-        impl_methods(&ast.self_ty, &mut ast.items)
+        impl_methods(&ast.generics, &ast.self_ty, &mut ast.items)
     }
 }
 
-pub fn impl_methods(ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> TokenStream {
+pub fn impl_methods(generics: &syn::Generics, ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> TokenStream {
     // get method names in impl block
     let mut methods = Vec::new();
     for iimpl in impls.iter_mut() {
@@ -28,7 +28,7 @@ pub fn impl_methods(ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> TokenStre
         }
     }
 
-    quote! {
+    let result = quote! {
         impl ::pyo3::class::methods::PyMethodsProtocolImpl for #ty {
             fn py_methods() -> &'static [::pyo3::class::PyMethodDefType] {
                 static METHODS: &'static [::pyo3::class::PyMethodDefType] = &[
@@ -37,5 +37,7 @@ pub fn impl_methods(ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> TokenStre
                 METHODS
             }
         }
-    }
+    };
+    println!("{}", result);
+    result
 }

--- a/tests/test_class_derive.rs
+++ b/tests/test_class_derive.rs
@@ -3,7 +3,7 @@
 extern crate pyo3;
 
 use pyo3::prelude::*;
-use pyo3::py::class;
+use pyo3::py::{class, methods};
 
 #[class]
 pub struct User {
@@ -14,7 +14,15 @@ pub struct User {
 #[class]
 pub struct LinkedListNode<'a> {
     data: u32,
-    next: &'a LinkedListNode<'a>,
+    next: Option<&'a LinkedListNode<'a>>,
+}
+
+#[methods]
+impl<'a> LinkedListNode<'a> {
+    #[new]
+    fn __new__(obj: &PyRawObject, data: u32) -> PyResult<()> {
+        obj.init(|t| LinkedListNode { data, next: None })
+    }
 }
 
 #[test]

--- a/tests/test_class_derive.rs
+++ b/tests/test_class_derive.rs
@@ -5,11 +5,8 @@ extern crate pyo3;
 use pyo3::prelude::*;
 use pyo3::py::{class, methods};
 
-#[class]
-pub struct User {
-    name: String,
-    age: u32
-}
+#[macro_use]
+mod common;
 
 #[class]
 pub struct LinkedListNode<'a> {
@@ -26,6 +23,12 @@ impl<'a> LinkedListNode<'a> {
 }
 
 #[test]
-fn test_user_derive() {
+fn test_class_generic_lifetime_derive() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let typeobj = py.get_type::<LinkedListNode>();
+    assert!(typeobj.call(NoArgs, NoArgs).is_err());
+
+    py_assert!(py, typeobj, "typeobj.__name__ == 'LinkedListNode'");
 }
 

--- a/tests/test_class_derive.rs
+++ b/tests/test_class_derive.rs
@@ -1,0 +1,23 @@
+#![feature(proc_macro, specialization)]
+
+extern crate pyo3;
+
+use pyo3::prelude::*;
+use pyo3::py::class;
+
+#[class]
+pub struct User {
+    name: String,
+    age: u32
+}
+
+#[class]
+pub struct LinkedListNode<'a> {
+    data: u32,
+    next: &'a LinkedListNode<'a>,
+}
+
+#[test]
+fn test_user_derive() {
+}
+


### PR DESCRIPTION
this is kinda hacky for now but they way the macros work right now, it just discards generics information, so when used on structs like

```rust
#[py::class]
pub struct Foo<'a> {
}
```

it fails to generate python class information with generics. i'm not too sure about how lifetimes are being used in the actual python-facing calls, but this is something i think that should be supported by this library.

thanks!