### PR TITLE
Python::run should return PyObjectRef result

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -132,9 +132,8 @@ impl<'p> Python<'p> {
     /// If `globals` is `None`, it defaults to Python module `__main__`.
     /// If `locals` is `None`, it defaults to the value of `globals`.
     pub fn run(self, code: &str, globals: Option<&PyDict>,
-                locals: Option<&PyDict>) -> PyResult<()> {
-        let _ = self.run_code(code, ffi::Py_file_input, globals, locals)?;
-        Ok(())
+                locals: Option<&PyDict>) -> PyResult<&'p PyObjectRef> {
+        self.run_code(code, ffi::Py_file_input, globals, locals)
     }
 
     /// Runs code in the given context.


### PR DESCRIPTION
Hello, 

First, thank you for this work done here! :100: 

https://github.com/PyO3/pyo3/blob/2627fa8a083616c031a3161a7517018de6149892/src/python.rs#L146

I think this should be made public. It's a bit hard for me to develop a certain outcome when I can only use a single python expression in `Python::eval` to get back a `PyObjectRef` when I'd like to use `ffi::Py_file_input` in order to run a formatted Python script; which `Python::run` uses, but doesn't return a `PyObjectRef`

Let me know if I'm missing something here.
Thanks again!