### PR TITLE
Specify proc-macro2 version more precisely

### DIFF
--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -15,7 +15,7 @@ log="0.4"
 quote="0.6"
 
 [dependencies.proc-macro2]
-version = "0.4"
+version = "0.4.9"
 features = ["nightly"]
 
 [dependencies.syn]

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -25,5 +25,5 @@ path = "../pyo3-derive-backend"
 version = "0.3.2"
 
 [dependencies.proc-macro2]
-version = "0.4"
+version = "0.4.9"
 features= ["nightly"]


### PR DESCRIPTION
Since we can't compile 0.4.8 in current nightly, I think it's more convenient to specify 0.4.9.
See https://github.com/rust-lang/rust/pull/52552/ and https://github.com/alexcrichton/proc-macro2/commit/9f0a28a9c95d59c6969dd05121115884138dede4 for detail.