### PR TITLE
Add failing test to create tzinfo subclass

### DIFF
--- a/examples/rustapi_module/src/lib.rs
+++ b/examples/rustapi_module/src/lib.rs
@@ -186,6 +186,29 @@ fn issue_219() -> PyResult<()> {
     Ok(())
 }
 
+#[pyclass(extends=PyTzInfo)]
+pub struct TzClass {}
+
+#[pymethods]
+impl TzClass {
+    #[new]
+    fn __new__(obj: &PyRawObject) -> PyResult<()> {
+        obj.init(|_| TzClass {})
+    }
+
+    fn utcoffset(&self, py: Python, dt: &PyDateTime) -> PyResult<Py<PyDelta>> {
+        PyDelta::new(py, 0, 3600, 0, true)
+    }
+
+    fn tzname(&self, py: Python, dt: &PyDateTime) -> PyResult<String> {
+        Ok(String::from("+01:00"))
+    }
+
+    fn dst(&self, py: Python, dt: &PyDateTime) -> PyResult<Option<&PyDelta>> {
+        Ok(None)
+    }
+}
+
 #[pymodinit]
 fn datetime(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_function!(make_date))?;
@@ -209,5 +232,6 @@ fn datetime(_py: Python, m: &PyModule) -> PyResult<()> {
 
     m.add_function(wrap_function!(issue_219))?;
 
+    m.add_class::<TzClass>()?;
     Ok(())
 }

--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -3,8 +3,7 @@ import rustapi_module.datetime as rdt
 import sys
 import datetime as pdt
 
-import pytest
-
+import pytest 
 from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.strategies import dates, datetimes
@@ -263,3 +262,12 @@ def test_delta_err(args, err_type):
 
 def test_issue_219():
     rdt.issue_219()
+
+def test_tz_class():
+    tzi = rdt.TzClass()
+
+    dt = pdt.datetime(2018, 1, 1, tzinfo=tzi)
+
+    assert dt.tzname() == "+01:00"
+    assert dt.utcoffset() == pdt.timedelta(hours=1)
+    assert dt.dst() is None


### PR DESCRIPTION
Currently this fails at import time with undefined symbol: `PyDateTime_TZInfoType`.

This is a reproducing example for bug #234.