### PR TITLE
Failing test for tzinfo subclass introspection

### DIFF
--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -271,3 +271,10 @@ def test_tz_class():
     assert dt.tzname() == "+01:00"
     assert dt.utcoffset() == pdt.timedelta(hours=1)
     assert dt.dst() is None
+
+def test_tz_class_introspection():
+    tzi = rdt.TzClass()
+
+    assert tzi.__class__ == rdt.TzClass
+    assert repr(tzi) == "TzClass()"
+


### PR DESCRIPTION
After pulling in @kngwyu's fix for #234, I realized that there's another problem here: accessing `__class__` on the TzClass instance raises a segmentation fault.

The core dump says:

```
Program terminated with signal SIGBUS, Bus error.
#0  0x00007fc0e187196f in type_qualname (context=0x0, 
    type=0x7fc0db8231a0 <<rustapi_module::TzClass as pyo3::typeob::PyTypeInfo>::type_object::TYPE_OBJECT>) at Objects/typeobject.c:395
395	Objects/typeobject.c: No such file or directory.
```

I think it's an issue accessing the qualified name, though I'm not sure if it's an issue with my implementation of `TzInfo` or a more general problem.

After #237 is merged, I can rebase this PR against master.