### PR TITLE
Build rust doc on travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 * User Guide: [stable](https://pyo3.rs) | [master](https://pyo3.rs/master)
 
+* API Documentation: [master](https://pyo3.rs/master/doc)
+
 A comparison with rust-cpython can be found [in the guide](https://pyo3.rs/master/rust-cpython.html).
 
 ## Usage

--- a/ci/travis/guide.sh
+++ b/ci/travis/guide.sh
@@ -16,8 +16,13 @@ fi
 # Build and then upload the guide to a specific folder on the gh-pages branch. This way we can have multiple versions
 # of the guide at the same time (See #165)
 
-# This builds the book in target/doc/guide. See https://github.com/rust-lang-nursery/mdBook/issues/698
-mdbook build -d ../target/doc/guide guide
+# This builds the book in target/guide. See https://github.com/rust-lang-nursery/mdBook/issues/698
+mdbook build -d ../target/guide guide
+
+# Build the doc
+# This builds the book in target/doc
+cargo doc --all-features --no-deps
+echo "<meta http-equiv=refresh content=0;url=pyo3/index.html>" > target/doc/index.html
 
 # Get the lastest tag across all branches
 # https://stackoverflow.com/a/7261049/3549270
@@ -32,7 +37,8 @@ echo "pyo3.rs" > CNAME
 
 # For builds triggered by a tag, $TRAVIS_BRANCH will be set to the tag
 rm -rf "$TRAVIS_BRANCH"
-cp -r ../target/doc/guide "$TRAVIS_BRANCH"
+cp -r ../target/guide "$TRAVIS_BRANCH"
+cp -r ../target/doc "$TRAVIS_BRANCH"
 git add --all
 git commit -m "Upload documentation for $TRAVIS_BRANCH"
 

--- a/guide/src/overview.md
+++ b/guide/src/overview.md
@@ -2,7 +2,7 @@
 
 [Rust](http://www.rust-lang.org/) bindings for [Python](https://www.python.org/). This includes running and interacting with python code from a rust binaries as well as writing native python modules.
 
-[API documentation](../doc/index.html)
+[API documentation](./doc/index.html)
 
 ## Usage
 

--- a/guide/src/overview.md
+++ b/guide/src/overview.md
@@ -2,6 +2,8 @@
 
 [Rust](http://www.rust-lang.org/) bindings for [Python](https://www.python.org/). This includes running and interacting with python code from a rust binaries as well as writing native python modules.
 
+[API documentation](../doc/index.html)
+
 ## Usage
 
 Pyo3 supports python 2.7 as well as python 3.5 and up. The minimum required rust version is 1.29.0-nightly 2018-07-16.


### PR DESCRIPTION
Since our docs.rs build is broken, we should host our own doc.