### PR TITLE
fix broken test in examples/word-count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Cargo.lock
 /doc
 /gh-pages
 build/
+*.py[co]
 __pycache__/
 .cache
 .pytest_cache/

--- a/examples/word-count/setup.py
+++ b/examples/word-count/setup.py
@@ -23,9 +23,8 @@ class PyTest(TestCommand):
         self.run_command("test_rust")
 
         import subprocess
-        import sys
 
-        subprocess.check_call([sys.executable, "-m", "pytest", "tests"])
+        subprocess.check_call(["pytest", "tests"])
 
 
 setup_requires = ["setuptools-rust>=0.10.1", "wheel"]

--- a/examples/word-count/tests/test_word_count.py
+++ b/examples/word-count/tests/test_word_count.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import os
 
 import pytest

--- a/examples/word-count/word_count/__init__.py
+++ b/examples/word-count/word_count/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from .word_count import WordCounter, count_line
 
 __all__ = ["WordCounter", "count_line", "search_py"]


### PR DESCRIPTION
This PR do following three things:

- fix broken unit-test
- remove `from __future__ import absolute_import`
- ignore `.pyc`, `.pyo` file

When run `python setup.py test`, it will complain:

```
ImportError while importing test module '/root/pyo3/examples/word-count/tests/test_word_count.py'.                                                                                           
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/test_word_count.py:7: in <module>
    import word_count
word_count/__init__.py:4: in <module>
    from .word_count import WordCounter, count_line
E   ModuleNotFoundError: No module named 'word_count.word_count'
```

After read the code of `setup.py`, I found that it run `python -m pytest tests` in a subprocess. Actually, Python will insert current dir into `sys.path`. When executed `import word_count` in `test_word_count.py` line 7, it will not import `word_count` package we have installed, but the `word_count` in current dir.

I have saw the `from __future__ import absolute_import`, but it means that Python will lookup top-level module(search in `sys.path` if not found), rather than the script located dir. So I think `from __future__ import absolute_import` is meaningless here.

Replace the command with `pytest tests` will have no problem.

If there is anything wrong with the above comments, please correct me : )

Test Env:
Python 2.7.15 and Python 3.7.0 with pytest 3.8.2