### PR TITLE
NonNull pointer for Py, PyObject

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -11,10 +11,13 @@ use crate::pythonrun::{self, GILGuard};
 use crate::typeob::PyTypeCreate;
 use crate::typeob::{PyTypeInfo, PyTypeObject};
 use crate::types::{PyDict, PyModule, PyObjectRef, PyType};
-use std;
 use std::ffi::CString;
 use std::marker::PhantomData;
 use std::os::raw::c_int;
+use std::ptr::NonNull;
+use std;
+
+pub type NonNullPyObject = NonNull<ffi::PyObject>;
 
 /// Marker type that indicates that the GIL is currently held.
 ///

--- a/src/pythonrun.rs
+++ b/src/pythonrun.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 use crate::ffi;
-use crate::python::Python;
+use crate::python::{Python, NonNullPyObject};
 use crate::types::PyObjectRef;
 use spin;
 use std::{any, marker, rc, sync};
@@ -230,12 +230,12 @@ pub unsafe fn register_any<'p, T: 'static>(obj: T) -> &'p T {
         .unwrap()
 }
 
-pub unsafe fn register_pointer(obj: *mut ffi::PyObject) {
+pub unsafe fn register_pointer(obj: NonNullPyObject) {
     let pool: &'static mut ReleasePool = &mut *POOL;
 
     let mut v = pool.p.lock();
     let pool: &'static mut Vec<*mut ffi::PyObject> = &mut *(*v);
-    pool.push(obj);
+    pool.push(obj.as_ptr());
 }
 
 pub unsafe fn register_owned(_py: Python, obj: *mut ffi::PyObject) -> &PyObjectRef {

--- a/src/typeob.rs
+++ b/src/typeob.rs
@@ -163,6 +163,7 @@ impl PyRawObject {
 }
 
 impl<T: PyTypeInfo> AsRef<T> for PyRawObject {
+    #[inline]
     fn as_ref(&self) -> &T {
         // TODO: check is object initialized
         unsafe {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -60,6 +60,7 @@ macro_rules! pyobject_native_type_named (
         impl<$($type_param,)*> $crate::PyNativeType for $name {}
 
         impl<$($type_param,)*> ::std::convert::AsRef<$crate::types::PyObjectRef> for $name {
+            #[inline]
             fn as_ref(&self) -> &$crate::types::PyObjectRef {
                 unsafe{&*(self as *const $name as *const $crate::types::PyObjectRef)}
             }


### PR DESCRIPTION
This feels marginally safer and the combination of NonNull and inlines yield a small performance improvement in a library I have.