### PR TITLE
Fix #240

### DIFF
--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -272,10 +272,9 @@ def test_tz_class():
     assert dt.utcoffset() == pdt.timedelta(hours=1)
     assert dt.dst() is None
 
-@pytest.mark.skip(reason='to debug with the latest master')
 def test_tz_class_introspection():
     tzi = rdt.TzClass()
 
     assert tzi.__class__ == rdt.TzClass
-    assert repr(tzi) == "TzClass()"
+    assert repr(tzi).startswith('<rustapi_module.datetime.TzClass object at')
 

--- a/src/typeob.rs
+++ b/src/typeob.rs
@@ -441,11 +441,6 @@ where
 
     // set type flags
     py_class_flags::<T>(type_object);
-    if type_object.tp_base
-        != unsafe { &ffi::PyBaseObject_Type as *const ffi::PyTypeObject as *mut ffi::PyTypeObject }
-    {
-        type_object.tp_flags |= ffi::Py_TPFLAGS_HEAPTYPE
-    }
 
     // register type object
     unsafe {


### PR DESCRIPTION
According to [python doc](https://docs.python.org/3/c-api/typeobj.html#Py_TPFLAGS_HEAPTYPE), Py_TPFLAGS_HEAPTYPE is set when the type object itself is allocated on the (python?) heap.
But currently it's set for all subclasses, though we always have pyclass' type object as a [static variable](https://github.com/PyO3/pyo3/blob/ecae8544f480c47a01eb002a9dfc015722ab3707/pyo3-derive-backend/src/py_class.rs#L202).
This causes segfault in #240.
I'm sure current approach is wrong, but I'm not sure how we should distinct a type is a heaptype or not(Maybe we should extend current API to have `is_heap` flag?).
Anyway, I feel there's many points to be fixed around our current approach for type object and tp_flags.
cc: @pganssle, @konstin 
