### PR TITLE
Travis uses 3.7 instead of 3.7-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+dist: xenial
+
 cache:
   pip: true
   cargo: true
@@ -12,10 +14,7 @@ matrix:
       env: FEATURES=python3
     - python: "3.6"
       env: FEATURES=python3
-    - python: "3.7-dev"
-      env: FEATURES=python3
-  allow_failures:
-    - python: "3.7-dev"
+    - python: "3.7"
       env: FEATURES=python3
 
 env:


### PR DESCRIPTION
It requires xenial for support per
https://docs.travis-ci.com/user/languages/python/

I tried specifying 3.8-dev in allow_failures, but it was not
picked up.