### PR TITLE
Remove default from ReturnTypeIntoPyResult

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -335,7 +335,7 @@ pub trait ReturnTypeIntoPyResult {
 impl<T: IntoPyObject> ReturnTypeIntoPyResult for T {
     type Inner = T;
 
-    default fn return_type_into_py_result(self) -> PyResult<Self::Inner> {
+    fn return_type_into_py_result(self) -> PyResult<Self::Inner> {
         Ok(self)
     }
 }


### PR DESCRIPTION
But I don't know why it compiles...
It looks there can be conflicting trait implementation for `PyResult<T>` :thinking: 