### PR TITLE
Remove default from ReturnTypeIntoPyResult

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -168,7 +168,7 @@ where
     T: PyTryFrom,
 {
     #[inline]
-    default fn extract(ob: &'a PyObjectRef) -> PyResult<&'a T> {
+    fn extract(ob: &'a PyObjectRef) -> PyResult<&'a T> {
         Ok(T::try_from(ob)?)
     }
 }
@@ -179,7 +179,7 @@ where
     T: PyTryFrom,
 {
     #[inline]
-    default fn extract(ob: &'a PyObjectRef) -> PyResult<&'a mut T> {
+    fn extract(ob: &'a PyObjectRef) -> PyResult<&'a mut T> {
         Ok(T::try_from_mut(ob)?)
     }
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -335,7 +335,7 @@ pub trait ReturnTypeIntoPyResult {
 impl<T: IntoPyObject> ReturnTypeIntoPyResult for T {
     type Inner = T;
 
-    default fn return_type_into_py_result(self) -> PyResult<Self::Inner> {
+    fn return_type_into_py_result(self) -> PyResult<Self::Inner> {
         Ok(self)
     }
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -168,7 +168,7 @@ where
     T: PyTryFrom,
 {
     #[inline]
-    fn extract(ob: &'a PyObjectRef) -> PyResult<&'a T> {
+    default fn extract(ob: &'a PyObjectRef) -> PyResult<&'a T> {
         Ok(T::try_from(ob)?)
     }
 }
@@ -179,7 +179,7 @@ where
     T: PyTryFrom,
 {
     #[inline]
-    fn extract(ob: &'a PyObjectRef) -> PyResult<&'a mut T> {
+    default fn extract(ob: &'a PyObjectRef) -> PyResult<&'a mut T> {
         Ok(T::try_from_mut(ob)?)
     }
 }


### PR DESCRIPTION
It passes tests, but I haven't tested its backward compatibility yet :thinking: 