### PR TITLE
Fixing mashup import build issue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,13 +226,13 @@ macro_rules! wrap_function {
 #[macro_export]
 macro_rules! wrap_module {
     ($module_name:ident) => {{
-        use $crate::mashup::*;
+        use $crate::mashup;
 
-        mashup! {
+        mashup::mashup! {
             m["method"] = PyInit_ $module_name;
         }
 
-        m! {
+        mashup::m! {
             &|py| unsafe { crate::PyObject::from_owned_ptr(py, "method"()) }
         }
     }};


### PR DESCRIPTION
This updates the way mashup is imported in the wrap_function macro, as importing the entire module with an asterisk was causing macro name conflicts and preventing build in certain projects.