### PR TITLE
upgrade version reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.4"
+version = "0.5"
 features = ["extension-module"]
 ```
 
@@ -92,7 +92,7 @@ Add `pyo3` this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pyo3 = "0.4"
+pyo3 = "0.5"
 ```
 
 Example program displaying the value of `sys.version`:

--- a/guide/src/building-and-distribution.md
+++ b/guide/src/building-and-distribution.md
@@ -14,7 +14,7 @@ If you have e.g. a library crate and a profiling crate alongside, you need to us
 
 ```toml
 [dependencies]
-pyo3 = "0.5.0"
+pyo3 = "0.5.1"
 
 [lib]
 name = "hyperjson"
@@ -29,7 +29,7 @@ And this in the profiling crate:
 ```toml
 [dependencies]
 my_main_crate = { path = "..", default-features = false }
-pyo3 = "0.5.0"
+pyo3 = "0.5.2"
 ```
 
 On linux/mac you might have to change `LD_LIBRARY_PATH` to include libpython, while on windows you might need to set `LIB` to include `pythonxy.lib` (where x and y are major and minor version), which is normally either in the `libs` or `Lib` folder of a python installation.

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -429,7 +429,7 @@ with `#[pyproto]` attribute.
 
 ### Basic object customization
 
-[`PyObjectProtocol`](https://docs.rs/pyo3/0.2.7/class/basic/trait.PyObjectProtocol.html) trait provide several basic customizations.
+[`PyObjectProtocol`](https://docs.rs/pyo3/0.5.2/class/basic/trait.PyObjectProtocol.html) trait provide several basic customizations.
 
 #### Attribute access
 
@@ -493,7 +493,7 @@ Each methods corresponds to python's `self.attr`, `self.attr = value` and `del s
 If your type owns references to other python objects, you will need to
 integrate with Python's garbage collector so that the GC is aware of
 those references.
-To do this, implement [`PyGCProtocol`](https://docs.rs/pyo3/0.2.7/class/gc/trait.PyGCProtocol.html) trait for your struct.
+To do this, implement [`PyGCProtocol`](https://docs.rs/pyo3/0.5.2/class/gc/trait.PyGCProtocol.html) trait for your struct.
 It includes two methods `__traverse__` and `__clear__`.
 These correspond to the slots `tp_traverse` and `tp_clear` in the Python C API.
 `__traverse__` must call `visit.call()` for each reference to another python object.
@@ -540,7 +540,7 @@ collector, and it is possible to track them with `gc` module methods.
 ### Iterator Types
 
 Iterators can be defined using the
-[`PyIterProtocol`](https://docs.rs/pyo3/0.2.7/class/iter/trait.PyIterProtocol.html) trait.
+[`PyIterProtocol`](https://docs.rs/pyo3/0.5.2/class/iter/trait.PyIterProtocol.html) trait.
 It includes two methods `__iter__` and `__next__`:
   * `fn __iter__(&mut self) -> PyResult<impl IntoPyObject>`
   * `fn __next__(&mut self) -> PyResult<Option<impl IntoPyObject>>`

--- a/guide/src/conversions.md
+++ b/guide/src/conversions.md
@@ -121,10 +121,10 @@ fn main() {
 
 TODO
 
-[`ToPyObject`]: https://docs.rs/pyo3/0.2.7/trait.ToPyObject.html
-[IntoPyObject]: https://docs.rs/pyo3/0.2.7/trait.IntoPyObject.html
-[PyObject]: https://docs.rs/pyo3/0.2.7/struct.PyObject.html
-[IntoPyTuple]: https://docs.rs/pyo3/0.2.7/trait.IntoPyTuple.html
-[PyTuple]: https://docs.rs/pyo3/0.2.7/struct.PyTuple.html
-[ObjectProtocol]: https://docs.rs/pyo3/0.2.7/trait.ObjectProtocol.html
-[IntoPyDict]: https://docs.rs/pyo3/0.2.7/trait.IntoPyDict.html
+[`ToPyObject`]: https://docs.rs/pyo3/0.5.2/trait.ToPyObject.html
+[IntoPyObject]: https://docs.rs/pyo3/0.5.2/trait.IntoPyObject.html
+[PyObject]: https://docs.rs/pyo3/0.5.2/struct.PyObject.html
+[IntoPyTuple]: https://docs.rs/pyo3/0.5.2/trait.IntoPyTuple.html
+[PyTuple]: https://docs.rs/pyo3/0.5.2/struct.PyTuple.html
+[ObjectProtocol]: https://docs.rs/pyo3/0.5.2/trait.ObjectProtocol.html
+[IntoPyDict]: https://docs.rs/pyo3/0.5.2/trait.IntoPyDict.html

--- a/guide/src/get_started.md
+++ b/guide/src/get_started.md
@@ -26,7 +26,7 @@ name = "rust_py"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.3"
+version = "0.5"
 features = ["extension-module"]
 ```
 
@@ -75,7 +75,7 @@ Add `pyo3` this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pyo3 = "0.3"
+pyo3 = "0.5"
 ```
 
 Example program displaying the value of `sys.version`:


### PR DESCRIPTION
This upgrades the version reference on the documentation.
When I new user, such as myself, tries to install pyo3 and follows the docs, it will fail because of the reference to 0.3 (and sometimes to 0.4) in the examples