### PR TITLE
PyTryFrom::try_from_unchecked()

### DIFF
--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -293,8 +293,7 @@ impl PyTryFrom for PySequence {
     fn try_from_mut(value: &PyObjectRef) -> Result<&mut PySequence, PyDowncastError> {
         unsafe {
             if ffi::PySequence_Check(value.as_ptr()) != 0 {
-                let ptr = value as *const _ as *mut PySequence;
-                Ok(&mut *ptr)
+                Ok(<PySequence as PyTryFrom>::try_from_mut_unchecked(value))
             } else {
                 Err(PyDowncastError)
             }
@@ -302,13 +301,19 @@ impl PyTryFrom for PySequence {
     }
 
     fn try_from_mut_exact(value: &PyObjectRef) -> Result<&mut PySequence, PyDowncastError> {
-        PySequence::try_from_mut(value)
+        <PySequence as PyTryFrom>::try_from_mut(value)
     }
 
     #[inline]
     unsafe fn try_from_unchecked(value: &PyObjectRef) -> &PySequence {
         let ptr = value as *const _ as *const PySequence;
         &*ptr
+    }
+
+    #[inline]
+    unsafe fn try_from_mut_unchecked(value: &PyObjectRef) -> &mut PySequence {
+        let ptr = value as *const _ as *mut PySequence;
+        &mut *ptr
     }
 }
 


### PR DESCRIPTION
This allows casting a PyObjectRef to a specific type of PyObject
with no overhead. 