### PR TITLE
Add (probably) forgotten type parameters ...

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -127,7 +127,7 @@ macro_rules! pyobject_native_type_convert(
             }
         }
 
-        impl $crate::typeob::PyObjectAlloc for $name {}
+        impl<$($type_param,)*> $crate::typeob::PyObjectAlloc for $name {}
 
         impl<$($type_param,)*> $crate::typeob::PyTypeCreate for $name {
             #[inline]


### PR DESCRIPTION
... to the `pyobject_native_type_convert` macro.

This is needed for `rust-numpy` to compile.