### PR TITLE
Add IntoPyTuple tests

### DIFF
--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -76,7 +76,7 @@ fn intopytuple_primitive() {
     py_assert!(py, tup, "tup == (1, 2, 'foo')");
     py_assert!(py, tup, "tup[0] == 1");
     py_assert!(py, tup, "tup[1] == 2");
-    py_assert!(py, tup, "tup[3] == 'foo'");
+    py_assert!(py, tup, "tup[2] == 'foo'");
 }
 
 #[pyclass]
@@ -87,9 +87,12 @@ fn intopytuple_pyclass() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let tup = (SimplePyClass {}, SimplePyClass {});
-    py_assert!(py, tup, "tup[0].__name__ == 'SimplePyClass'");
-    py_assert!(py, tup, "tup[0].__name__ == tup[1].__name__");
+    let tup = (
+        py.init(|| SimplePyClass {}).unwrap(),
+        py.init(|| SimplePyClass {}).unwrap(),
+    );
+    py_assert!(py, tup, "type(tup[0]).__name__ == 'SimplePyClass'");
+    py_assert!(py, tup, "type(tup[0]).__name__ == type(tup[1]).__name__");
     py_assert!(py, tup, "tup[0] != tup[1]");
 }
 
@@ -107,8 +110,11 @@ fn pytuple_pyclass_iter() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let tup = PyTuple::new(py, [SimplePyClass {}, SimplePyClass {}].into_iter());
-    py_assert!(py, tup, "tup[0].__name__ == 'SimplePyClass'");
-    py_assert!(py, tup, "tup[0].__name__ == tup[1].__name__");
+    let tup = PyTuple::new(py, [
+        py.init(|| SimplePyClass {}).unwrap(),
+        py.init(|| SimplePyClass {}).unwrap(),
+    ].into_iter());
+    py_assert!(py, tup, "type(tup[0]).__name__ == 'SimplePyClass'");
+    py_assert!(py, tup, "type(tup[0]).__name__ == type(tup[0]).__name__");
     py_assert!(py, tup, "tup[0] != tup[1]");
 }

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -4,7 +4,7 @@
 extern crate pyo3;
 
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyTuple};
 use std::isize;
 
 #[macro_use]
@@ -88,6 +88,26 @@ fn intopytuple_pyclass() {
     let py = gil.python();
 
     let tup = (SimplePyClass {}, SimplePyClass {});
+    py_assert!(py, tup, "tup[0].__name__ == 'SimplePyClass'");
+    py_assert!(py, tup, "tup[0].__name__ == tup[1].__name__");
+    py_assert!(py, tup, "tup[0] != tup[1]");
+}
+
+#[test]
+fn pytuple_primitive_iter() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let tup = PyTuple::new(py, [1u32, 2, 3].into_iter());
+    py_assert!(py, tup, "tup == (1, 2, 3)");
+}
+
+#[test]
+fn pytuple_pyclass_iter() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let tup = PyTuple::new(py, [SimplePyClass {}, SimplePyClass {}].into_iter());
     py_assert!(py, tup, "tup[0].__name__ == 'SimplePyClass'");
     py_assert!(py, tup, "tup[0].__name__ == tup[1].__name__");
     py_assert!(py, tup, "tup[0] != tup[1]");

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -66,3 +66,29 @@ fn return_custom_class() {
     let get_zero = wrap_function!(get_zero)(py);
     py_assert!(py, get_zero, "get_zero().value == 0");
 }
+
+#[test]
+fn intopytuple_primitive() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let tup = (1, 2, "foo");
+    py_assert!(py, tup, "tup == (1, 2, 'foo')");
+    py_assert!(py, tup, "tup[0] == 1");
+    py_assert!(py, tup, "tup[1] == 2");
+    py_assert!(py, tup, "tup[3] == 'foo'");
+}
+
+#[pyclass]
+struct SimplePyClass {}
+
+#[test]
+fn intopytuple_pyclass() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let tup = (SimplePyClass {}, SimplePyClass {});
+    py_assert!(py, tup, "tup[0].__name__ == 'SimplePyClass'");
+    py_assert!(py, tup, "tup[0].__name__ == tup[1].__name__");
+    py_assert!(py, tup, "tup[0] != tup[1]");
+}


### PR DESCRIPTION
This adds two tests for the `IntoPyTuple` implementation. Currently, they either unpredictably fail or `SEGSEGV`. Will create an issue for this any second.

**Edit:** SIGSEGVs was due to an issue unrelated to tuples. Anyways, I guess having a few extra tests doesn't hurt. If you want to merge this, I'd recommend squashing it to get rid of the 2 fixup commits.