### PR TITLE
ffi3 list macros, matching ffi2

### DIFF
--- a/src/ffi2/listobject.rs
+++ b/src/ffi2/listobject.rs
@@ -32,7 +32,7 @@ pub unsafe fn PyList_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == u) as c_int
 }
 
-// Macro, trading safety for speed
+/// Macro, trading safety for speed
 #[inline]
 pub unsafe fn PyList_GET_ITEM(op: *mut PyObject, i: Py_ssize_t) -> *mut PyObject {
     *(*(op as *mut PyListObject)).ob_item.offset(i as isize)

--- a/src/ffi2/tupleobject.rs
+++ b/src/ffi2/tupleobject.rs
@@ -31,7 +31,7 @@ pub unsafe fn PyTuple_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == u) as c_int
 }
 
-// Macro, trading safety for speed
+/// Macro, trading safety for speed
 #[inline]
 pub unsafe fn PyTuple_GET_ITEM(op: *mut PyObject, i: Py_ssize_t) -> *mut PyObject {
     *(*(op as *mut PyTupleObject))

--- a/src/ffi3/listobject.rs
+++ b/src/ffi3/listobject.rs
@@ -2,6 +2,20 @@ use crate::ffi3::object::*;
 use crate::ffi3::pyport::Py_ssize_t;
 use std::os::raw::c_int;
 
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyListObject {
+    #[cfg(py_sys_config = "Py_TRACE_REFS")]
+    pub _ob_next: *mut PyObject,
+    #[cfg(py_sys_config = "Py_TRACE_REFS")]
+    pub _ob_prev: *mut PyObject,
+    pub ob_refcnt: Py_ssize_t,
+    pub ob_type: *mut PyTypeObject,
+    pub ob_size: Py_ssize_t,
+    pub ob_item: *mut *mut PyObject,
+    pub allocated: Py_ssize_t,
+}
+
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub static mut PyList_Type: PyTypeObject;
@@ -17,6 +31,26 @@ pub unsafe fn PyList_Check(op: *mut PyObject) -> c_int {
 #[inline]
 pub unsafe fn PyList_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyList_Type) as c_int
+}
+
+// Macro, trading safety for speed
+#[cfg(not(Py_LIMITED_API))]
+#[inline]
+pub unsafe fn PyList_GET_ITEM(op: *mut PyObject, i: Py_ssize_t) -> *mut PyObject {
+    *(*(op as *mut PyListObject)).ob_item.offset(i as isize)
+}
+
+#[cfg(not(Py_LIMITED_API))]
+#[inline]
+pub unsafe fn PyList_GET_SIZE(op: *mut PyObject) -> Py_ssize_t {
+    Py_SIZE(op)
+}
+
+/// Macro, *only* to be used to fill in brand new lists
+#[cfg(not(Py_LIMITED_API))]
+#[inline]
+pub unsafe fn PyList_SET_ITEM(op: *mut PyObject, i: Py_ssize_t, v: *mut PyObject) {
+    *(*(op as *mut PyListObject)).ob_item.offset(i as isize) = v;
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/src/ffi3/listobject.rs
+++ b/src/ffi3/listobject.rs
@@ -33,7 +33,7 @@ pub unsafe fn PyList_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyList_Type) as c_int
 }
 
-// Macro, trading safety for speed
+/// Macro, trading safety for speed
 #[cfg(not(Py_LIMITED_API))]
 #[inline]
 pub unsafe fn PyList_GET_ITEM(op: *mut PyObject, i: Py_ssize_t) -> *mut PyObject {

--- a/src/ffi3/tupleobject.rs
+++ b/src/ffi3/tupleobject.rs
@@ -40,7 +40,7 @@ extern "C" {
     pub fn PyTuple_ClearFreeList() -> c_int;
 }
 
-// Macro, trading safety for speed
+/// Macro, trading safety for speed
 #[inline]
 #[cfg(not(Py_LIMITED_API))]
 pub unsafe fn PyTuple_GET_ITEM(op: *mut PyObject, i: Py_ssize_t) -> *mut PyObject {


### PR DESCRIPTION
This matches macros that are in ffi2. There were no apparent changes to PyListObject from py2 to py3: https://github.com/python/cpython/blob/master/Include/listobject.h#L23-L40. I've added the cfg on Py_LIMITED_API to match https://github.com/python/cpython/blob/master/Include/listobject.h#L71-L76.