### PR TITLE
Fix memory leak in ArrayList

### DIFF
--- a/src/pythonrun.rs
+++ b/src/pythonrun.rs
@@ -298,7 +298,7 @@ mod array_list {
         pub fn pop_back(&mut self) -> Option<T> {
             self.length -= 1;
             let current_idx = self.next_idx();
-            if self.length >= BLOCK_SIZE && current_idx == 0 {
+            if current_idx == 0 {
                 let last_list = self.inner.pop_back()?;
                 return Some(last_list[0].clone());
             }


### PR DESCRIPTION
To make algorithm clear, I designed `pythonrun::array_list::ArrayList` to always have minimum capacity to hold pointers.
But I found a bug. In current implementation, when arraylist's length becomes 0 from 1, excess capacity remains and causes memory leak.
It's my mistake, sorry :sweat: 
@konstin 
This is a serious bug so could you please release 0.5.3 with this PR?