### PR TITLE
Pass -c instead of --workdir to "examples/*" tox invocation

### DIFF
--- a/ci/travis/test.sh
+++ b/ci/travis/test.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
-# Note: Avoid using "-e" globally, its behaviour may sometimes be convoluted.
-# For more details, see http://mywiki.wooledge.org/BashFAQ/105
-set -x
+set -ex
 
-cargo fmt --all -- --check || exit 1
-cargo test --features "$FEATURES" || exit 1
-cargo clippy --features "$FEATURES" || exit 1
+cargo fmt --all -- --check
+cargo test --features "$FEATURES"
+cargo clippy --features "$FEATURES"
 
 for example_dir in examples/*; do
-    tox -c "$example_dir/tox.ini" -e py || exit 1
+    tox -c "$example_dir/tox.ini" -e py
 done

--- a/ci/travis/test.sh
+++ b/ci/travis/test.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
+# Note: Avoid using "-e" globally, its behaviour may sometimes be convoluted.
+# For more details, see http://mywiki.wooledge.org/BashFAQ/105
+set -x
 
-set -ex
+cargo fmt --all -- --check || exit 1
+cargo test --features "$FEATURES" || exit 1
+cargo clippy --features "$FEATURES" || exit 1
 
-cargo fmt --all -- --check
-cargo test --features $FEATURES
-cargo clippy --features $FEATURES
-
-for example in examples/*; do
-    tox -e py --workdir $example
+for example_dir in examples/*; do
+    tox -c "$example_dir/tox.ini" -e py || exit 1
 done

--- a/examples/rustapi_module/tox.ini
+++ b/examples/rustapi_module/tox.ini
@@ -10,5 +10,4 @@ skip_missing_interpreters = true
 description = Run the unit tests under {basepython}
 deps = -rrequirements-dev.txt
 usedevelop = True
-commands = pip install -e .
-           pytest
+commands = pytest {posargs}

--- a/examples/word-count/tox.ini
+++ b/examples/word-count/tox.ini
@@ -10,5 +10,4 @@ skip_missing_interpreters = true
 description = Run the unit tests under {basepython}
 deps = -rrequirements-dev.txt
 usedevelop = True
-commands = pip install -e .
-           pytest tests
+commands = pytest {posargs}


### PR DESCRIPTION
The `-c example-path/tox.init` parameter will read the tox.ini from the
provided location and also set `workdir` and `toxinidir` to the
directory of the passed tox.ini

Previously, when only --workdir was passed, tox read the root `tox.ini`,
with the effect that tox was never run on the projects in `examples/`.