### PR TITLE
Add $crate:: prefix in create_exception!

### DIFF
--- a/src/types/exceptions.rs
+++ b/src/types/exceptions.rs
@@ -171,9 +171,9 @@ macro_rules! create_exception {
         #[allow(non_camel_case_types)] // E.g. `socket.herror`
         pub struct $name;
 
-        impl_exception_boilerplate!($name);
+        $crate::impl_exception_boilerplate!($name);
 
-        create_exception_type_object!($module, $name, $base);
+        $crate::create_exception_type_object!($module, $name, $base);
     };
 }
 


### PR DESCRIPTION
This allows for selective macro includes in Rust 2018 projects. Surrounding code already makes heavy use of the `$crate` construct, so I suspect it was simply forgotten in these two places.