### PR TITLE
Fix **kwargs

### DIFF
--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -45,7 +45,7 @@ pub fn parse_fn_args<'p>(
 ) -> PyResult<()> {
     let nargs = args.len();
     let nkeywords = kwargs.map_or(0, |d| d.len());
-    if !accept_args && (nargs + nkeywords > params.len()) {
+    if !accept_args && !accept_kwargs && (nargs + nkeywords > params.len()) {
         return Err(TypeError::py_err(format!(
             "{}{} takes at most {} argument{} ({} given)",
             fname.unwrap_or("function"),

--- a/tests/test_variable_arguments.rs
+++ b/tests/test_variable_arguments.rs
@@ -1,0 +1,52 @@
+#![feature(custom_attribute)]
+#![feature(specialization)]
+
+extern crate pyo3;
+
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
+
+#[macro_use]
+mod common;
+
+#[pyclass]
+struct MyClass {}
+
+#[pymethods]
+impl MyClass {
+    #[staticmethod]
+    #[args(args = "*")]
+    fn test_args(args: &PyTuple) -> PyResult<&PyTuple> {
+        Ok(args)
+    }
+
+    #[staticmethod]
+    #[args(kwargs = "**")]
+    fn test_kwargs(kwargs: Option<&PyDict>) -> PyResult<Option<&PyDict>> {
+        Ok(kwargs)
+    }
+}
+
+#[test]
+fn variable_args() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let my_obj = py.get_type::<MyClass>();
+    py_assert!(py, my_obj, "my_obj.test_args() == ()");
+    py_assert!(py, my_obj, "my_obj.test_args(1) == (1,)");
+    py_assert!(py, my_obj, "my_obj.test_args(1, 2) == (1, 2)");
+}
+
+#[test]
+fn variable_kwargs() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let my_obj = py.get_type::<MyClass>();
+    py_assert!(py, my_obj, "my_obj.test_kwargs() == None");
+    py_assert!(py, my_obj, "my_obj.test_kwargs(test=1) == {'test': 1}");
+    py_assert!(
+        py,
+        my_obj,
+        "my_obj.test_kwargs(test1=1, test2=2) == {'test1':1, 'test2':2}"
+    );
+}


### PR DESCRIPTION
`**kwargs` was broken by a check for the number of given arguments. Only
apply this check if no arbitrary number of keyword arguments are allowed
by a "**" parameter of `#[args(...)`.

Closes #318