### PR TITLE
Remove ToPyPointer and so on from pyclass

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -17,11 +17,15 @@ struct MyClass {
 The above example generates implementations for `PyTypeInfo` and `PyTypeObject` for `MyClass`.
 
 ## Get Python objects from `pyclass`
-In rust side, we can get a Python object which includes `pyclass` by 3 methods.
+You can use `pyclass`es like normal rust structs.
+
+However, if instantiate noramlly, you can't treat `pyclass`es as Python objects.
+
+To get a Python object which includes `pyclass`, we have to use some special methods.
 
 ### `PyRef`
-`PyRef` is a special reference, which ensures the reffrered struct is a part of
-a Python object.
+`PyRef` is a special reference, which ensures that the reffrered struct is a part of
+a Python object, and you are also holding the GIL.
 
 You can get an instance of `PyRef` by `PyRef::new`, which does 3 things:
 1. Allocate a Python object in the Python heap

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -16,6 +16,53 @@ struct MyClass {
 
 The above example generates implementations for `PyTypeInfo` and `PyTypeObject` for `MyClass`.
 
+## Get Python objects from `pyclass`
+In rust side, we can get a Python object which includes `pyclass` by 3 methods.
+
+### `PyRef`
+`PyRef` is a special reference, which ensures the reffrered struct is a part of
+a Python object.
+
+You can get an instance of `PyRef` by `PyRef::new`, which does 3 things:
+1. Allocate a Python object in the Python heap
+2. Copies the rust struct into the Python object
+3. Returns a reference of it
+
+You can use `PyRef` just like `&T`, because it implements `Deref<Target=T>`.
+```rust
+# use pyo3::prelude::*;
+#[pyclass]
+struct MyClass {
+   num: i32,
+   debug: bool,
+}
+let gil = Python::acquire_gil();
+let py = gil.python();
+let obj = PyRef::new(py, || MyClass { num: 3, debug: true }).unwrap();
+assert_eq!(obj.num, 3);
+let dict = PyDict::new();
+// You can treat a `PyRef` as a Python object
+dict.set_item("obj", obj)).unwrap();
+```
+
+### `PyRefMut`
+`PyRefMut` is a mutable version of `PyRef`.
+```rust
+# use pyo3::prelude::*;
+#[pyclass]
+struct MyClass {
+   num: i32,
+   debug: bool,
+}
+let gil = Python::acquire_gil();
+let py = gil.python();
+let mut obj = PyRefMut::new(py, || MyClass { num: 3, debug: true }).unwrap();
+obj.num = 5;
+```
+
+### `Py`
+`Py` is a object wrapper which stores an object longer than the GIL lifetime.
+TODO: Write a good example
 
 ## Customizing the class
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -62,7 +62,22 @@ obj.num = 5;
 
 ### `Py`
 `Py` is a object wrapper which stores an object longer than the GIL lifetime.
-TODO: Write a good example
+
+You can use it to avoid lifetime problems.
+```rust
+# use pyo3::prelude::*;
+#[pyclass]
+struct MyClass {
+   num: i32,
+}
+fn return_myclass() -> Py<MyClass> {
+    let gil = Python::acquire_gil();
+    Py::new(|| MyClass { num: 1 })
+}
+let gil = Python::acquire_gil();
+let obj = return_myclass();
+assert_eq!(obj.as_ref(gil.python()).num, 1);
+```
 
 ## Customizing the class
 

--- a/pyo3-derive-backend/src/func.rs
+++ b/pyo3-derive-backend/src/func.rs
@@ -492,10 +492,12 @@ fn modify_arg_ty(sig: &mut syn::MethodSig, idx: usize, decl1: &syn::FnDecl, decl
 }
 
 fn modify_self_ty(sig: &mut syn::MethodSig) {
-    if let syn::FnArg::SelfRef(ref mut r) = sig.decl.inputs[0] {
-        r.lifetime = Some(syn::parse_quote! {'p});
-    } else {
-        panic!("not supported")
+    match sig.decl.inputs[0] {
+        syn::FnArg::SelfRef(ref mut slf) => {
+            slf.lifetime = Some(syn::parse_quote! {'p});
+        }
+        syn::FnArg::Captured(_) => {}
+        _ => panic!("not supported"),
     }
 }
 

--- a/pyo3-derive-backend/src/py_class.rs
+++ b/pyo3-derive-backend/src/py_class.rs
@@ -210,34 +210,8 @@ fn impl_class(
             }
         }
 
-<<<<<<< HEAD
-        impl ::pyo3::ToPyObject for #cls {
-            fn to_object(&self, py: ::pyo3::Python) -> ::pyo3::PyObject {
-                use ::pyo3::python::ToPyPointer;
-                unsafe { ::pyo3::PyObject::from_borrowed_ptr(py, self.as_ptr()) }
-            }
-        }
-
-        impl ::pyo3::ToPyPointer for #cls {
-            fn as_ptr(&self) -> *mut ::pyo3::ffi::PyObject {
-                unsafe {
-                    {self as *const _ as *mut u8}
-                    .offset(-<#cls as ::pyo3::typeob::PyTypeInfo>::OFFSET) as *mut ::pyo3::ffi::PyObject
-                }
-            }
-        }
-
-        impl<'a> ::pyo3::ToPyObject for &'a mut #cls {
-            fn to_object(&self, py: ::pyo3::Python) -> ::pyo3::PyObject {
-                use ::pyo3::python::ToPyPointer;
-                unsafe { ::pyo3::PyObject::from_borrowed_ptr(py, self.as_ptr()) }
-            }
-        }
-
         #inventory_impl
 
-=======
->>>>>>> Remove ToPyPointer and so on from pyclass
         #extra
     }
 }

--- a/pyo3-derive-backend/src/py_class.rs
+++ b/pyo3-derive-backend/src/py_class.rs
@@ -210,6 +210,7 @@ fn impl_class(
             }
         }
 
+<<<<<<< HEAD
         impl ::pyo3::ToPyObject for #cls {
             fn to_object(&self, py: ::pyo3::Python) -> ::pyo3::PyObject {
                 use ::pyo3::python::ToPyPointer;
@@ -235,6 +236,8 @@ fn impl_class(
 
         #inventory_impl
 
+=======
+>>>>>>> Remove ToPyPointer and so on from pyclass
         #extra
     }
 }

--- a/src/class/iter.rs
+++ b/src/class/iter.rs
@@ -8,6 +8,7 @@ use crate::callback::{CallbackConverter, PyObjectCallbackConverter};
 use crate::conversion::IntoPyObject;
 use crate::err::PyResult;
 use crate::ffi;
+use crate::instance::PyRefMut;
 use crate::python::{IntoPyPointer, Python};
 use crate::typeob::PyTypeInfo;
 
@@ -16,15 +17,15 @@ use crate::typeob::PyTypeInfo;
 /// more information
 /// `https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_iter`
 #[allow(unused_variables)]
-pub trait PyIterProtocol<'p>: PyTypeInfo {
-    fn __iter__(&'p mut self) -> Self::Result
+pub trait PyIterProtocol<'p>: PyTypeInfo + Sized {
+    fn __iter__(slf: PyRefMut<'p, Self>) -> Self::Result
     where
         Self: PyIterIterProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __next__(&'p mut self) -> Self::Result
+    fn __next__(slf: PyRefMut<'p, Self>) -> Self::Result
     where
         Self: PyIterNextProtocol<'p>,
     {
@@ -74,7 +75,7 @@ where
 {
     #[inline]
     fn tp_iter() -> Option<ffi::getiterfunc> {
-        py_unary_func!(
+        py_unary_pyref_func!(
             PyIterIterProtocol,
             T::__iter__,
             T::Success,
@@ -97,7 +98,7 @@ where
 {
     #[inline]
     fn tp_iternext() -> Option<ffi::iternextfunc> {
-        py_unary_func!(
+        py_unary_pyref_func!(
             PyIterNextProtocol,
             T::__next__,
             Option<T::Success>,

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -29,17 +29,17 @@ macro_rules! py_unary_func {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! py_unary_func_self {
-    ($trait:ident, $class:ident :: $f:ident, $res_type:ty, $conv:ty) => {{
+macro_rules! py_unary_pyref_func {
+    ($trait:ident, $class:ident :: $f:ident, $res_type:ty, $conv:expr) => {{
         unsafe extern "C" fn wrap<T>(slf: *mut $crate::ffi::PyObject) -> *mut $crate::ffi::PyObject
         where
             T: for<'p> $trait<'p>,
         {
-            use $crate::ObjectProtocol;
+            use $crate::instance::PyRefMut;
             let _pool = $crate::GILPool::new();
             let py = $crate::Python::assume_gil_acquired();
             let slf = py.mut_from_borrowed_ptr::<T>(slf);
-            let res = slf.$f().into();
+            let res = $class::$f(PyRefMut::new(slf)).into();
             $crate::callback::cb_convert($conv, py, res)
         }
         Some(wrap::<$class>)

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -39,7 +39,7 @@ macro_rules! py_unary_pyref_func {
             let _pool = $crate::GILPool::new();
             let py = $crate::Python::assume_gil_acquired();
             let slf = py.mut_from_borrowed_ptr::<T>(slf);
-            let res = $class::$f(PyRefMut::new(slf)).into();
+            let res = $class::$f(PyRefMut::from_mut(slf)).into();
             $crate::callback::cb_convert($conv, py, res)
         }
         Some(wrap::<$class>)

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -357,6 +357,8 @@ impl<T: IntoPyObject> ReturnTypeIntoPyResult for PyResult<T> {
     }
 }
 
+
+
 #[cfg(test)]
 mod test {
     use super::PyTryFrom;

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -374,20 +374,20 @@ impl<T> std::convert::From<Py<T>> for PyObject {
     }
 }
 
-impl<'a, T> std::convert::From<&'a T> for Py<T>
+impl<'a, T> std::convert::From<PyRef<'a, T>> for Py<T>
 where
-    T: ToPyPointer,
+    T: PyTypeInfo,
 {
-    fn from(ob: &'a T) -> Self {
+    fn from(ob: PyRef<'a, T>) -> Self {
         unsafe { Py::from_borrowed_ptr(ob.as_ptr()) }
     }
 }
 
-impl<'a, T> std::convert::From<&'a mut T> for Py<T>
+impl<'a, T> std::convert::From<PyRefMut<'a, T>> for Py<T>
 where
-    T: ToPyPointer,
+    T: PyTypeInfo,
 {
-    fn from(ob: &'a mut T) -> Self {
+    fn from(ob: PyRefMut<'a, T>) -> Self {
         unsafe { Py::from_borrowed_ptr(ob.as_ptr()) }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub use crate::conversion::{
     ToBorrowedObject, ToPyObject,
 };
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyErrValue, PyResult};
-pub use crate::instance::{AsPyRef, Py, PyNativeType, PyObjectWithGIL};
+pub use crate::instance::{AsPyRef, Py, PyNativeType, PyObjectWithGIL, PyRef, PyRefMut};
 pub use crate::noargs::NoArgs;
 pub use crate::object::PyObject;
 pub use crate::objectprotocol::ObjectProtocol;

--- a/src/object.rs
+++ b/src/object.rs
@@ -257,11 +257,11 @@ impl PyObject {
 impl AsPyRef<PyObjectRef> for PyObject {
     #[inline]
     fn as_ref(&self, _py: Python) -> PyRef<PyObjectRef> {
-        unsafe { PyRef::new(&*(self as *const _ as *const PyObjectRef)) }
+        unsafe { PyRef::from_ref(&*(self as *const _ as *const PyObjectRef)) }
     }
     #[inline]
     fn as_mut(&mut self, _py: Python) -> PyRefMut<PyObjectRef> {
-        unsafe { PyRefMut::new(&mut *(self as *mut _ as *mut PyObjectRef)) }
+        unsafe { PyRefMut::from_mut(&mut *(self as *mut _ as *mut PyObjectRef)) }
     }
 }
 

--- a/src/objectprotocol.rs
+++ b/src/objectprotocol.rs
@@ -187,7 +187,7 @@ pub trait ObjectProtocol {
     /// Casts the PyObject to a concrete Python object type.
     fn cast_as<'a, D>(&'a self) -> Result<&'a D, PyDowncastError>
     where
-        D: PyTryFrom,
+        D: PyTryFrom<'a>,
         &'a PyObjectRef: std::convert::From<&'a Self>;
 
     /// Extracts some type from the Python object.
@@ -471,10 +471,10 @@ where
 
     fn cast_as<'a, D>(&'a self) -> Result<&'a D, PyDowncastError>
     where
-        D: PyTryFrom,
+        D: PyTryFrom<'a>,
         &'a PyObjectRef: std::convert::From<&'a Self>,
     {
-        D::try_from(self.into())
+        D::try_from(self)
     }
 
     fn extract<'a, D>(&'a self) -> PyResult<D>

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,7 +12,7 @@
 
 pub use crate::conversion::{FromPyObject, IntoPyObject, PyTryFrom, PyTryInto, ToPyObject};
 pub use crate::err::{PyErr, PyResult};
-pub use crate::instance::{AsPyRef, Py};
+pub use crate::instance::{AsPyRef, Py, PyRef, PyRefMut};
 pub use crate::noargs::NoArgs;
 pub use crate::object::PyObject;
 pub use crate::objectprotocol::ObjectProtocol;

--- a/src/python.rs
+++ b/src/python.rs
@@ -266,7 +266,7 @@ impl<'p> Python<'p> {
         F: FnOnce() -> T,
         T: PyTypeCreate,
     {
-        Py::new_ref(self, f)
+        PyRef::new(self, f)
     }
 
     /// Create new instance of `T` and move it under python management.
@@ -277,7 +277,7 @@ impl<'p> Python<'p> {
         F: FnOnce() -> T,
         T: PyTypeCreate,
     {
-        Py::new_mut(self, f)
+        PyRefMut::new(self, f)
     }
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -5,7 +5,7 @@
 use crate::conversion::PyTryFrom;
 use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::ffi;
-use crate::instance::{AsPyRef, Py};
+use crate::instance::{AsPyRef, Py, PyRef, PyRefMut};
 use crate::object::PyObject;
 use crate::pythonrun::{self, GILGuard};
 use crate::typeob::PyTypeCreate;
@@ -89,7 +89,6 @@ where
     }
 }
 
-/// Gets the underlying FFI pointer, returns a borrowed pointer.
 impl<'a, T> IntoPyPointer for &'a T
 where
     T: ToPyPointer,
@@ -262,7 +261,7 @@ impl<'p> Python<'p> {
     /// Create new instance of `T` and move it under python management.
     /// Created object get registered in release pool. Returns references to `T`
     #[inline]
-    pub fn init_ref<T, F>(self, f: F) -> PyResult<&'p T>
+    pub fn init_ref<T, F>(self, f: F) -> PyResult<PyRef<'p, T>>
     where
         F: FnOnce() -> T,
         T: PyTypeCreate,
@@ -273,7 +272,7 @@ impl<'p> Python<'p> {
     /// Create new instance of `T` and move it under python management.
     /// Created object get registered in release pool. Returns mutable references to `T`
     #[inline]
-    pub fn init_mut<T, F>(self, f: F) -> PyResult<&'p mut T>
+    pub fn init_mut<T, F>(self, f: F) -> PyResult<PyRefMut<'p, T>>
     where
         F: FnOnce() -> T,
         T: PyTypeCreate,

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -85,12 +85,12 @@ impl<'p> Drop for PyIterator<'p> {
 mod tests {
     use indoc::indoc;
 
-    use crate::conversion::{PyTryFrom, ToPyObject};
+    use crate::conversion::ToPyObject;
     use crate::instance::AsPyRef;
     use crate::objectprotocol::ObjectProtocol;
     use crate::python::Python;
     use crate::pythonrun::GILPool;
-    use crate::types::{PyDict, PyList, PyObjectRef};
+    use crate::types::{PyDict, PyList};
     use crate::GILGuard;
 
     #[test]
@@ -98,7 +98,7 @@ mod tests {
         let gil_guard = Python::acquire_gil();
         let py = gil_guard.python();
         let obj = vec![10, 20].to_object(py);
-        let inst = <PyObjectRef as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+        let inst = obj.as_ref(py);
         let mut it = inst.iter().unwrap();
         assert_eq!(10, it.next().unwrap().unwrap().extract().unwrap());
         assert_eq!(20, it.next().unwrap().unwrap().extract().unwrap());
@@ -119,7 +119,7 @@ mod tests {
         {
             let gil_guard = Python::acquire_gil();
             let py = gil_guard.python();
-            let inst = <PyObjectRef as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            let inst = obj.as_ref(py);
             let mut it = inst.iter().unwrap();
 
             assert_eq!(10, it.next().unwrap().unwrap().extract().unwrap());
@@ -147,7 +147,7 @@ mod tests {
 
         {
             let _pool = GILPool::new();
-            let inst = <PyObjectRef as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            let inst = obj.as_ref(py);
             let mut it = inst.iter().unwrap();
 
             assert_eq!(10, it.next().unwrap().unwrap().extract().unwrap());

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -275,8 +275,9 @@ where
     Ok(v)
 }
 
-impl PyTryFrom for PySequence {
-    fn try_from(value: &PyObjectRef) -> Result<&PySequence, PyDowncastError> {
+impl<'v> PyTryFrom<'v> for PySequence {
+    fn try_from<V: Into<&'v PyObjectRef>>(value: V) -> Result<&'v PySequence, PyDowncastError> {
+        let value = value.into();
         unsafe {
             if ffi::PySequence_Check(value.as_ptr()) != 0 {
                 Ok(<PySequence as PyTryFrom>::try_from_unchecked(value))
@@ -286,11 +287,16 @@ impl PyTryFrom for PySequence {
         }
     }
 
-    fn try_from_exact(value: &PyObjectRef) -> Result<&PySequence, PyDowncastError> {
+    fn try_from_exact<V: Into<&'v PyObjectRef>>(
+        value: V,
+    ) -> Result<&'v PySequence, PyDowncastError> {
         <PySequence as PyTryFrom>::try_from(value)
     }
 
-    fn try_from_mut(value: &PyObjectRef) -> Result<&mut PySequence, PyDowncastError> {
+    fn try_from_mut<V: Into<&'v PyObjectRef>>(
+        value: V,
+    ) -> Result<&'v mut PySequence, PyDowncastError> {
+        let value = value.into();
         unsafe {
             if ffi::PySequence_Check(value.as_ptr()) != 0 {
                 Ok(<PySequence as PyTryFrom>::try_from_mut_unchecked(value))
@@ -300,19 +306,21 @@ impl PyTryFrom for PySequence {
         }
     }
 
-    fn try_from_mut_exact(value: &PyObjectRef) -> Result<&mut PySequence, PyDowncastError> {
+    fn try_from_mut_exact<V: Into<&'v PyObjectRef>>(
+        value: V,
+    ) -> Result<&'v mut PySequence, PyDowncastError> {
         <PySequence as PyTryFrom>::try_from_mut(value)
     }
 
     #[inline]
-    unsafe fn try_from_unchecked(value: &PyObjectRef) -> &PySequence {
-        let ptr = value as *const _ as *const PySequence;
+    unsafe fn try_from_unchecked<V: Into<&'v PyObjectRef>>(value: V) -> &'v PySequence {
+        let ptr = value.into() as *const _ as *const PySequence;
         &*ptr
     }
 
     #[inline]
-    unsafe fn try_from_mut_unchecked(value: &PyObjectRef) -> &mut PySequence {
-        let ptr = value as *const _ as *mut PySequence;
+    unsafe fn try_from_mut_unchecked<V: Into<&'v PyObjectRef>>(value: V) -> &'v mut PySequence {
+        let ptr = value.into() as *const _ as *mut PySequence;
         &mut *ptr
     }
 }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -141,7 +141,7 @@ mod test {
         let s = "Hello Python";
         let py_string = s.to_object(py);
 
-        let s2: &str = FromPyObject::extract(py_string.as_ref(py)).unwrap();
+        let s2: &str = FromPyObject::extract(py_string.as_ref(py).into()).unwrap();
         assert_eq!(s, s2);
     }
 

--- a/src/types/string2.rs
+++ b/src/types/string2.rs
@@ -228,7 +228,7 @@ mod test {
         let s = "Hello Python";
         let py_string = s.to_object(py);
 
-        let s2: &str = FromPyObject::extract(py_string.as_ref(py)).unwrap();
+        let s2: &str = FromPyObject::extract(py_string.as_ref(py).into()).unwrap();
         assert_eq!(s, s2);
     }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -115,7 +115,7 @@ impl<'a> Iterator for PyTupleIterator<'a> {
         if self.index < self.slice.len() {
             let item = self.slice[self.index].as_ref(self.py);
             self.index += 1;
-            Some(item)
+            Some(item.into())
         } else {
             None
         }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -133,7 +133,7 @@ impl<'a> IntoIterator for &'a PyTuple {
 
 impl<'a> IntoPyTuple for &'a PyTuple {
     fn into_tuple(self, _py: Python) -> Py<PyTuple> {
-        self.into()
+        unsafe { Py::from_borrowed_ptr(self.as_ptr()) }
     }
 }
 

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -439,7 +439,7 @@ struct DunderDictSupport {}
 fn dunder_dict_support() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let inst = Py::new_ref(py, || DunderDictSupport {}).unwrap();
+    let inst = PyRef::new(py, || DunderDictSupport {}).unwrap();
     py_run!(
         py,
         inst,
@@ -457,7 +457,7 @@ struct WeakRefDunderDictSupport {}
 fn weakref_dunder_dict_support() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let inst = Py::new_ref(py, || WeakRefDunderDictSupport {}).unwrap();
+    let inst = PyRef::new(py, || WeakRefDunderDictSupport {}).unwrap();
     py_run!(
         py,
         inst,

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -51,13 +51,13 @@ struct Iterator {
 }
 
 #[pyproto]
-impl PyIterProtocol for Iterator {
-    fn __iter__(&mut self) -> PyResult<Py<Iterator>> {
-        Ok(self.into())
+impl<'p> PyIterProtocol for Iterator {
+    fn __iter__(slf: PyRefMut<Self>) -> PyResult<Py<Iterator>> {
+        Ok(slf.into())
     }
 
-    fn __next__(&mut self) -> PyResult<Option<i32>> {
-        Ok(self.iter.next())
+    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<i32>> {
+        Ok(slf.iter.next())
     }
 }
 
@@ -364,7 +364,7 @@ fn context_manager() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py
+    let mut c = py
         .init_mut(|| ContextManager { exit_called: false })
         .unwrap();
     py_run!(py, c, "with c as x: assert x == 42");

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -165,7 +165,7 @@ fn gc_integration() {
         })
         .unwrap();
 
-        *inst.self_ref.borrow_mut() = inst.into();
+        *inst.self_ref.borrow_mut() = inst.to_object(py);
     }
 
     let gil = Python::acquire_gil();
@@ -262,7 +262,7 @@ fn inheritance_with_new_methods_with_drop() {
         obj.data = Some(Arc::clone(&drop_called1));
 
         let base: &mut <SubClassWithDrop as pyo3::PyTypeInfo>::BaseType =
-            unsafe { py.mut_from_borrowed_ptr(obj.as_ptr()) };
+            unsafe { py.mut_from_borrowed_ptr(inst.as_ptr()) };
         base.data = Some(Arc::clone(&drop_called2));
     }
 

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -157,7 +157,7 @@ fn gc_integration() {
     {
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let inst = Py::new_ref(py, || GCIntegration {
+        let inst = PyRef::new(py, || GCIntegration {
             self_ref: RefCell::new(py.None()),
             dropped: TestDropCall {
                 drop_called: Arc::clone(&drop_called),
@@ -183,7 +183,7 @@ fn gc_integration2() {
     let py = gil.python();
     // Temporarily disable pythons garbage collector to avoid a race condition
     py.run("import gc; gc.disable()", None, None).unwrap();
-    let inst = Py::new_ref(py, || GCIntegration2 {}).unwrap();
+    let inst = PyRef::new(py, || GCIntegration2 {}).unwrap();
     py_run!(py, inst, "assert inst in gc.get_objects()");
     py.run("gc.enable()", None, None).unwrap();
 }
@@ -195,7 +195,7 @@ struct WeakRefSupport {}
 fn weakref_support() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let inst = Py::new_ref(py, || WeakRefSupport {}).unwrap();
+    let inst = PyRef::new(py, || WeakRefSupport {}).unwrap();
     py_run!(
         py,
         inst,


### PR DESCRIPTION
And introduce `PyRef` and `PyRefMut`.
See #320 for the reason.

Currently I don't have good idea for [`PyIterProtocol` test](https://github.com/PyO3/pyo3/blob/ee4fc3b21d05236df2a3fd2addf83b0aab8fcdf6/tests/test_dunder.rs#L56) and it still fails to be compiled.

Fixes #308