### PR TITLE
Change the initializer style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
@@ -10,21 +11,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
  * Added a `wrap_pymodule!` macro similar to the existing `wrap_pyfunction!` macro. Only available on python 3
  * Added support for cross compiling (e.g. to arm v7) by mtp401 in [#327](https://github.com/PyO3/pyo3/pull/327). See the "Cross Compiling" section in the "Building and Distribution" chapter of the guide for more details.
+ * The `PyRef` and `PyRefMut` types, which allow to differentiate between an instance of a rust struct on the rust heap and an instance that is embedded inside a python object. By kngwyu in [#335](https://github.com/PyO3/pyo3/pull/335)
 
 ### Changed
 
  * Renamed `add_function` to `add_wrapped` as it now also supports modules.
- * Renamed `#[pymodinit]` to `#[pymodule]`.
- * `init`, `init_ref` and `init_mut` now take a value instead of a function that returns the value. (Migrating normally just removing `||`)
- * Renamed `py_exception` to `create_exception` and refactored the error macros.
+ * Renamed `#[pymodinit]` to `#[pymodule]`
+ * `py.init(|| value)` becomes `Py::new(value)`
+ * `py.init_ref(|| value)` becomes `PyRef::new(value)`
+ * `py.init_mut(|| value)` becomes `PyRefMut::new(value)`.
+ * `PyRawObject::init` is now infallible, e.g. it returns `()` instead of `PyResult<()>`.
+ * Renamed `py_exception!` to `create_exception!` and refactored the error macros.
  * Renamed `wrap_function!` to `wrap_pyfunction!`
  * Migrated to the 2018 edition
  * Replace `IntoPyTuple` with `IntoPy<Py<PyTuple>>`. Eventually `IntoPy<T>` should replace `ToPyObject` and be itself implemented through `FromPy<T>`
+ * PyTypeObject is now a direct subtrait PyTypeCreate, removing the old cyclical implementation in [#350](https://github.com/PyO3/pyo3/pull/350)
 
 ### Removed
 
  * `PyToken` was removed due to unsoundness (See [#94](https://github.com/PyO3/pyo3/issues/94)).
  * Removed the unnecessary type parameter from `PyObjectAlloc`
+
+### Fixed
+
+ * A soudness hole where every instances of a `#[pyclass]` struct was considered to be part of a python object, even though you can create instances that are not part of the python heap. This was fixed through `PyRef` and `PyRefMut`. 
 
 ## [0.5.3] - 2019-01-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.6.0-alpha.2"
+version = "0.6.0-alpha.3"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"

--- a/examples/rustapi_module/src/datetime.rs
+++ b/examples/rustapi_module/src/datetime.rs
@@ -191,7 +191,7 @@ pub struct TzClass {}
 impl TzClass {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
-        obj.init(TzClass {})
+        Ok(obj.init(TzClass {}))
     }
 
     fn utcoffset(&self, py: Python<'_>, _dt: &PyDateTime) -> PyResult<Py<PyDelta>> {

--- a/examples/rustapi_module/src/dict_iter.rs
+++ b/examples/rustapi_module/src/dict_iter.rs
@@ -17,7 +17,7 @@ pub struct DictSize {
 impl DictSize {
     #[new]
     fn __new__(obj: &PyRawObject, expected: u32) -> PyResult<()> {
-        obj.init(DictSize { expected })
+        Ok(obj.init(DictSize { expected }))
     }
 
     fn iter_dict(&mut self, _py: Python<'_>, dict: &PyDict) -> PyResult<u32> {

--- a/examples/rustapi_module/src/othermod.rs
+++ b/examples/rustapi_module/src/othermod.rs
@@ -14,9 +14,9 @@ pub struct ModClass {
 impl ModClass {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
-        obj.init(ModClass {
+        Ok(obj.init(ModClass {
             _somefield: String::from("contents"),
-        })
+        }))
     }
 
     fn noop(&self, x: usize) -> usize {

--- a/examples/rustapi_module/src/subclassing.rs
+++ b/examples/rustapi_module/src/subclassing.rs
@@ -9,7 +9,7 @@ pub struct Subclassable {}
 impl Subclassable {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
-        obj.init(Subclassable {})
+        Ok(obj.init(Subclassable {}))
     }
 }
 

--- a/examples/word-count/src/lib.rs
+++ b/examples/word-count/src/lib.rs
@@ -17,9 +17,9 @@ struct WordCounter {
 impl WordCounter {
     #[new]
     fn __new__(obj: &PyRawObject, path: String) -> PyResult<()> {
-        obj.init(WordCounter {
+        Ok(obj.init(WordCounter {
             path: PathBuf::from(path),
-        })
+        }))
     }
 
     /// Searches for the word, parallelized by rayon

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -2,7 +2,6 @@
 
 //! Free allocation list
 
-use crate::err::PyResult;
 use crate::ffi;
 use crate::python::Python;
 use crate::typeob::{pytype_drop, PyObjectAlloc, PyTypeInfo};
@@ -72,15 +71,13 @@ impl<T> PyObjectAlloc for T
 where
     T: PyObjectWithFreeList,
 {
-    unsafe fn alloc(_py: Python) -> PyResult<*mut ffi::PyObject> {
-        let obj = if let Some(obj) = <Self as PyObjectWithFreeList>::get_free_list().pop() {
+    unsafe fn alloc(_py: Python) -> *mut ffi::PyObject {
+        if let Some(obj) = <Self as PyObjectWithFreeList>::get_free_list().pop() {
             ffi::PyObject_Init(obj, <Self as PyTypeInfo>::type_object());
             obj
         } else {
             ffi::PyType_GenericAlloc(<Self as PyTypeInfo>::type_object(), 0)
-        };
-
-        Ok(obj)
+        }
     }
 
     #[cfg(Py_3)]

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -32,7 +32,7 @@ fn unary_arithmetic() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init(UnaryArithmetic {}).unwrap();
+    let c = Py::new(py, UnaryArithmetic {}).unwrap();
     py_run!(py, c, "assert -c == 'neg'");
     py_run!(py, c, "assert +c == 'pos'");
     py_run!(py, c, "assert abs(c) == 'abs'");
@@ -110,7 +110,7 @@ fn inplace_operations() {
     let py = gil.python();
 
     let init = |value, code| {
-        let c = py.init(InPlaceOperations { value }).unwrap();
+        let c = Py::new(py, InPlaceOperations { value }).unwrap();
         py_run!(py, c, code);
     };
 
@@ -164,7 +164,7 @@ fn binary_arithmetic() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init(BinaryArithmetic {}).unwrap();
+    let c = Py::new(py, BinaryArithmetic {}).unwrap();
     py_run!(py, c, "assert c + c == 'BA + BA'");
     py_run!(py, c, "assert c + 1 == 'BA + 1'");
     py_run!(py, c, "assert 1 + c == '1 + BA'");
@@ -230,7 +230,7 @@ fn rich_comparisons() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init(RichComparisons {}).unwrap();
+    let c = Py::new(py, RichComparisons {}).unwrap();
     py_run!(py, c, "assert (c < c) == 'RC < RC'");
     py_run!(py, c, "assert (c < 1) == 'RC < 1'");
     py_run!(py, c, "assert (1 < c) == 'RC > 1'");
@@ -257,7 +257,7 @@ fn rich_comparisons_python_3_type_error() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c2 = py.init(RichComparisons2 {}).unwrap();
+    let c2 = Py::new(py, RichComparisons2 {}).unwrap();
     py_expect_exception!(py, c2, "c2 < c2", TypeError);
     py_expect_exception!(py, c2, "c2 < 1", TypeError);
     py_expect_exception!(py, c2, "1 < c2", TypeError);

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -65,11 +65,13 @@ fn test_buffer() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let t = py
-        .init(TestClass {
+    let t = Py::new(
+        py,
+        TestClass {
             vec: vec![b' ', b'2', b'3'],
-        })
-        .unwrap();
+        },
+    )
+    .unwrap();
 
     let d = PyDict::new(py);
     d.set_item("ob", t).unwrap();
@@ -82,11 +84,13 @@ fn test_buffer() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let t = py
-        .init(TestClass {
+    let t = Py::new(
+        py,
+        TestClass {
             vec: vec![b' ', b'2', b'3'],
-        })
-        .unwrap();
+        },
+    )
+    .unwrap();
 
     let d = PyDict::new(py);
     d.set_item("ob", t).unwrap();

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -8,7 +8,7 @@ struct EmptyClassWithNew {}
 impl EmptyClassWithNew {
     #[__new__]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
-        obj.init(EmptyClassWithNew {})
+        Ok(obj.init(EmptyClassWithNew {}))
     }
 }
 
@@ -33,7 +33,7 @@ struct NewWithOneArg {
 impl NewWithOneArg {
     #[new]
     fn __new__(obj: &PyRawObject, arg: i32) -> PyResult<()> {
-        obj.init(NewWithOneArg { _data: arg })
+        Ok(obj.init(NewWithOneArg { _data: arg }))
     }
 }
 
@@ -57,10 +57,10 @@ struct NewWithTwoArgs {
 impl NewWithTwoArgs {
     #[new]
     fn __new__(obj: &PyRawObject, arg1: i32, arg2: i32) -> PyResult<()> {
-        obj.init(NewWithTwoArgs {
+        Ok(obj.init(NewWithTwoArgs {
             _data1: arg1,
             _data2: arg2,
-        })
+        }))
     }
 }
 

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -188,7 +188,7 @@ fn sequence() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init(Sequence {}).unwrap();
+    let c = Py::new(py, Sequence {}).unwrap();
     py_assert!(py, c, "list(c) == [0, 1, 2, 3, 4]");
     py_expect_exception!(py, c, "c['abc']", TypeError);
 }
@@ -209,11 +209,11 @@ fn callable() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init(Callable {}).unwrap();
+    let c = Py::new(py, Callable {}).unwrap();
     py_assert!(py, c, "callable(c)");
     py_assert!(py, c, "c(7) == 42");
 
-    let nc = py.init(Comparisons { val: 0 }).unwrap();
+    let nc = Py::new(py, Comparisons { val: 0 }).unwrap();
     py_assert!(py, nc, "not callable(nc)");
 }
 
@@ -237,7 +237,7 @@ fn setitem() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init_ref(SetItem { key: 0, val: 0 }).unwrap();
+    let c = PyRef::new(py, SetItem { key: 0, val: 0 }).unwrap();
     py_run!(py, c, "c[1] = 2");
     assert_eq!(c.key, 1);
     assert_eq!(c.val, 2);
@@ -262,7 +262,7 @@ fn delitem() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init_ref(DelItem { key: 0 }).unwrap();
+    let c = PyRef::new(py, DelItem { key: 0 }).unwrap();
     py_run!(py, c, "del c[1]");
     assert_eq!(c.key, 1);
     py_expect_exception!(py, c, "c[1] = 2", NotImplementedError);
@@ -291,7 +291,7 @@ fn setdelitem() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init_ref(SetDelItem { val: None }).unwrap();
+    let c = PyRef::new(py, SetDelItem { val: None }).unwrap();
     py_run!(py, c, "c[1] = 2");
     assert_eq!(c.val, Some(2));
     py_run!(py, c, "del c[1]");
@@ -313,7 +313,7 @@ fn reversed() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init(Reversed {}).unwrap();
+    let c = Py::new(py, Reversed {}).unwrap();
     py_run!(py, c, "assert reversed(c) == 'I am reversed'");
 }
 
@@ -332,7 +332,7 @@ fn contains() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let c = py.init(Contains {}).unwrap();
+    let c = Py::new(py, Contains {}).unwrap();
     py_run!(py, c, "assert 1 in c");
     py_run!(py, c, "assert -1 not in c");
     py_expect_exception!(py, c, "assert 'wrong type' not in c", TypeError);
@@ -370,7 +370,7 @@ fn context_manager() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let mut c = py.init_mut(ContextManager { exit_called: false }).unwrap();
+    let mut c = PyRefMut::new(py, ContextManager { exit_called: false }).unwrap();
     py_run!(py, c, "with c as x: assert x == 42");
     assert!(c.exit_called);
 
@@ -427,7 +427,7 @@ fn test_cls_impl() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let ob = py.init(Test {}).unwrap();
+    let ob = Py::new(py, Test {}).unwrap();
     let d = PyDict::new(py);
     d.set_item("ob", ob).unwrap();
 

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -31,7 +31,7 @@ fn class_with_properties() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let inst = py.init(ClassWithProperties { num: 10 }).unwrap();
+    let inst = Py::new(py, ClassWithProperties { num: 10 }).unwrap();
 
     py_run!(py, inst, "assert inst.get_num() == 10");
     py_run!(py, inst, "assert inst.get_num() == inst.DATA");
@@ -60,12 +60,14 @@ fn getter_setter_autogen() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let inst = py
-        .init(GetterSetter {
+    let inst = Py::new(
+        py,
+        GetterSetter {
             num: 10,
             text: "Hello".to_string(),
-        })
-        .unwrap();
+        },
+    )
+    .unwrap();
 
     py_run!(py, inst, "assert inst.num == 10");
     py_run!(py, inst, "inst.num = 20; assert inst.num == 20");

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -35,7 +35,7 @@ fn subclass() {
 impl BaseClass {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
-        obj.init(BaseClass { val1: 10 })
+        Ok(obj.init(BaseClass { val1: 10 }))
     }
 }
 
@@ -49,7 +49,7 @@ struct SubClass {
 impl SubClass {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
-        obj.init(SubClass { val2: 5 })?;
+        obj.init(SubClass { val2: 5 });
         BaseClass::__new__(obj)
     }
 }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -23,7 +23,7 @@ fn instance_method() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let obj = py.init_ref(InstanceMethod { member: 42 }).unwrap();
+    let obj = PyRefMut::new(py, InstanceMethod { member: 42 }).unwrap();
     assert_eq!(obj.method().unwrap(), 42);
     let d = PyDict::new(py);
     d.set_item("obj", obj).unwrap();
@@ -50,7 +50,7 @@ fn instance_method_with_args() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let obj = py.init_ref(InstanceMethodWithArgs { member: 7 }).unwrap();
+    let obj = PyRefMut::new(py, InstanceMethodWithArgs { member: 7 }).unwrap();
     assert_eq!(obj.method(6).unwrap(), 42);
     let d = PyDict::new(py);
     d.set_item("obj", obj).unwrap();
@@ -66,7 +66,7 @@ struct ClassMethod {}
 impl ClassMethod {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
-        obj.init(ClassMethod {})
+        Ok(obj.init(ClassMethod {}))
     }
 
     #[classmethod]
@@ -130,7 +130,7 @@ struct StaticMethod {}
 impl StaticMethod {
     #[new]
     fn __new__(obj: &PyRawObject) -> PyResult<()> {
-        obj.init(StaticMethod {})
+        Ok(obj.init(StaticMethod {}))
     }
 
     #[staticmethod]
@@ -219,7 +219,7 @@ impl MethArgs {
 fn meth_args() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let inst = py.init(MethArgs {}).unwrap();
+    let inst = Py::new(py, MethArgs {}).unwrap();
 
     py_run!(py, inst, "assert inst.get_optional() == 10");
     py_run!(py, inst, "assert inst.get_optional(100) == 100");

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -26,8 +26,8 @@ impl MutRefArg {
 fn mut_ref_arg() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let inst1 = py.init(MutRefArg { n: 0 }).unwrap();
-    let inst2 = py.init(MutRefArg { n: 0 }).unwrap();
+    let inst1 = Py::new(py, MutRefArg { n: 0 }).unwrap();
+    let inst2 = Py::new(py, MutRefArg { n: 0 }).unwrap();
 
     let d = PyDict::new(py);
     d.set_item("inst1", &inst1).unwrap();


### PR DESCRIPTION
The first commit simplifies the initializers by making them take a value instead of a function. This essentially means removing `||`. 

The second commit is more opinionated in that it removes `py.init[_mut|_ref](...)`, meaning that you need to call `Py::new[_ref|_mut](py, ...)`. The reason is that this decouples code (the gil token shouldn't be bound to what `Py<T>` does) and that it makes more apparent that we're actually instantiating a `Py<T>` here.

I've also discovered that `PyRawObject::init` never actually returns an error, so I made it infallible (as in it can only fail with a panic/segfault).

Eventually I'd like to make calling in consturctors `Py::new` unnecessary through `into_object`, which would also remove the `Ok()` wrapping introduced in commit two.