### PR TITLE
Make PyNativeType unsafe

### DIFF
--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -172,12 +172,7 @@ impl IntoPyPointer for PyRawObject {
     }
 }
 
-impl PyNativeType for PyRawObject {
-    #[inline]
-    fn py(&self) -> Python {
-        unsafe { Python::assume_gil_acquired() }
-    }
-}
+unsafe impl PyNativeType for PyRawObject {}
 
 pub(crate) unsafe fn pytype_drop<T: PyTypeInfo>(py: Python, obj: *mut ffi::PyObject) {
     if T::OFFSET != 0 {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -64,11 +64,7 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
-        impl<$($type_param,)*> $crate::PyNativeType for $name {
-            fn py(&self) -> $crate::Python {
-                unsafe { $crate::Python::assume_gil_acquired() }
-            }
-        }
+        unsafe impl<$($type_param,)*> $crate::PyNativeType for $name {}
 
         impl<$($type_param,)*> $crate::ToPyPointer for $name {
             /// Gets the underlying FFI pointer, returns a borrowed pointer.


### PR DESCRIPTION
Somehow it's now used to zero cost conversion from pointer to reference, so it's dangerous to expose it.