### PR TITLE
Test with PyPy and PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,18 @@ matrix:
       python: "3.7"
       # Keep this synced up with build.rs
       env: FEATURES=python3 TRAVIS_RUST_VERSION=nightly-2019-02-07
+    - name: PyPy2.7 6.0
+      python: "pypy2.7-6.0"
+      env: FEATURES=python2
+    - name: PyPy3.5 6.0
+      python: "pypy3.5-6.0"
+      env: FEATURES=python3
   allow_failures:
     - python: "3.8-dev"
+      env: FEATURES=python3
+    - python: pypy2.7-6.0
+      env: FEATURES=python2
+    - python: pypy3.5-6.0
       env: FEATURES=python3
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,6 @@ matrix:
   allow_failures:
     - python: "3.8-dev"
       env: FEATURES=python3
-    - python: pypy2.7-6.0
-      env: FEATURES=python2
     - python: pypy3.5-6.0
       env: FEATURES=python3
 


### PR DESCRIPTION
PyPy has a compatibility layer called cpyext which allows us to use CPython extensions.
I think it's worth our time to test PyO3 with it. I have marked the PyPy jobs as allowed failures for now.