### PR TITLE
Change time_zone_info argument type for PyDateTime::from_timestamp() due to broken design

### DIFF
--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -144,12 +144,12 @@ impl PyDateTime {
     pub fn from_timestamp(
         py: Python,
         timestamp: f64,
-        time_zone_info: Option<&PyTzInfo>,
+        time_zone_info: Option<&PyObject>,
     ) -> PyResult<Py<PyDateTime>> {
         let timestamp: PyObject = timestamp.to_object(py);
 
         let time_zone_info: PyObject = match time_zone_info {
-            Some(time_zone_info) => time_zone_info.to_object(py),
+            Some(time_zone_info) => time_zone_info,
             None => py.None(),
         };
 

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -149,8 +149,8 @@ impl PyDateTime {
         let timestamp: PyObject = timestamp.to_object(py);
 
         let time_zone_info = match time_zone_info {
-            Some(time_zone_info) => time_zone_info,
-            None => &py.None(),
+            Some(time_zone_info) => *time_zone_info,
+            None => py.None(),
         };
 
         let args = PyTuple::new(py, &[timestamp, time_zone_info]);

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -148,7 +148,7 @@ impl PyDateTime {
     ) -> PyResult<Py<PyDateTime>> {
         let timestamp: PyObject = timestamp.to_object(py);
 
-        let time_zone_info: PyObject = match time_zone_info {
+        let time_zone_info = match time_zone_info {
             Some(time_zone_info) => time_zone_info,
             None => py.None(),
         };

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -150,7 +150,7 @@ impl PyDateTime {
 
         let time_zone_info = match time_zone_info {
             Some(time_zone_info) => time_zone_info,
-            None => py.None(),
+            None => &py.None(),
         };
 
         let args = PyTuple::new(py, &[timestamp, time_zone_info]);

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -125,6 +125,32 @@ fn test_datetime_utc() {
     assert_eq!(offset, 0f32);
 }
 
+
+#[test]
+#[cfg(Py_3)]
+fn test_datetime_from_timestamp_utc() {
+    use pyo3::types::PyDateTime;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let datetime = py.import("datetime").map_err(|e| e.print(py)).unwrap();
+    let timezone = datetime.get("timezone").unwrap();
+    let utc = timezone.getattr("utc").unwrap().to_object(py);
+
+    let dt = PyDateTime::from_timestamp(py, 1551279638, Some(&utc)).unwrap();
+
+    let locals = PyDict::new(py);
+    locals.set_item("dt", dt).unwrap();
+
+    let offset: f32 = py
+        .eval("dt.utcoffset().total_seconds()", None, Some(locals))
+        .unwrap()
+        .extract()
+        .unwrap();
+    assert_eq!(offset, 0f32);
+}
+
 #[cfg(Py_3)]
 static INVALID_DATES: &'static [(i32, u8, u8)] = &[
     (-1, 1, 1),


### PR DESCRIPTION
Since Rust has no inheritance, specifying `Option<&PyTzInfo>` as the argument type of time_zone_info prevents us entirely from specifying time zones since no time zone is of the type `PyTzInfo`.
The time zone struct may inherit from it (using Python inheritance) or it may be imported from Python.

It is possible to change the API of `from_timestamp()` to expect a `TzInfo` trait but that will require more extensive refactoring.