### PR TITLE
Remove unrequired encoding header

### DIFF
--- a/examples/word-count/word_count/__init__.py
+++ b/examples/word-count/word_count/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .word_count import WordCounter, count_line
 
 __all__ = ["WordCounter", "count_line", "search_py"]


### PR DESCRIPTION
This is not required anymore for Python 3.