### PR TITLE
Remove T: ToPyObject requirement for the IntoPyObject impl of Vec<T> #398

### DIFF
--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -191,7 +191,7 @@ where
 
 impl<T> IntoPyObject for Vec<T>
 where
-    T: IntoPyObject + ToPyObject,
+    T: IntoPyObject,
 {
     fn into_object(self, py: Python) -> PyObject {
         unsafe {


### PR DESCRIPTION
it… just wasn't used