### PR TITLE
Allow slf: PyRef<Self>/PyRefMut<Self> in pymethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
  * Have `PyModule` generate an index of its members (`__all__` list).
+ * Allow `slf: PyRef<T>` for pyclass(#419)
 
 ### Changed
 

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-use crate::method::{FnArg, FnSpec, FnType};
+use crate::method::{FnArg, FnSpec, FnType, PySelfType};
 use crate::utils;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
@@ -18,6 +18,12 @@ pub fn gen_py_method(
 
     match spec.tp {
         FnType::Fn => impl_py_method_def(name, doc, &spec, &impl_wrap(cls, name, &spec, true)),
+        FnType::PySelf(pyslf) => impl_py_method_def(
+            name,
+            doc,
+            &spec,
+            &impl_wrap_pyslf(cls, name, &spec, pyslf, true),
+        ),
         FnType::FnNew => impl_py_method_def_new(name, doc, &impl_wrap_new(cls, name, &spec)),
         FnType::FnInit => impl_py_method_def_init(name, doc, &impl_wrap_init(cls, name, &spec)),
         FnType::FnCall => impl_py_method_def_call(name, doc, &impl_wrap(cls, name, &spec, false)),
@@ -48,7 +54,45 @@ pub fn impl_wrap(
     noargs: bool,
 ) -> TokenStream {
     let body = impl_call(cls, name, &spec);
+    let slf = quote! {
+        let _slf = _py.mut_from_borrowed_ptr::<#cls>(_slf);
+    };
+    impl_wrap_common(cls, name, spec, noargs, slf, body)
+}
 
+pub fn impl_wrap_pyslf(
+    cls: &syn::Type,
+    name: &syn::Ident,
+    spec: &FnSpec<'_>,
+    slftype: PySelfType,
+    noargs: bool,
+) -> TokenStream {
+    let names = get_arg_names(spec);
+    let body = quote! {
+        #cls::#name(_slf, #(#names),*)
+    };
+    let slf = match slftype {
+        PySelfType::Py => quote! {
+            let _slf = pyo3::Py::<#cls>::from_borrowed_ptr(_slf);
+        },
+        PySelfType::PyRef => quote! {
+            let _slf = pyo3::PyRef::<#cls>::from_borrowed_ptr(_py, _slf);
+        },
+        PySelfType::PyRefMut => quote! {
+            let _slf = pyo3::PyRefMut::<#cls>::from_borrowed_ptr(_py, _slf);
+        },
+    };
+    impl_wrap_common(cls, name, spec, noargs, slf, body)
+}
+
+fn impl_wrap_common(
+    cls: &syn::Type,
+    name: &syn::Ident,
+    spec: &FnSpec<'_>,
+    noargs: bool,
+    slf: TokenStream,
+    body: TokenStream,
+) -> TokenStream {
     if spec.args.is_empty() && noargs {
         quote! {
             unsafe extern "C" fn __wrap(
@@ -59,8 +103,7 @@ pub fn impl_wrap(
                     stringify!(#cls), ".", stringify!(#name), "()");
                 let _pool = pyo3::GILPool::new();
                 let _py = pyo3::Python::assume_gil_acquired();
-                let _slf = _py.mut_from_borrowed_ptr::<#cls>(_slf);
-
+                #slf
                 let _result = {
                     pyo3::derive_utils::IntoPyResult::into_py_result(#body)
                 };
@@ -82,7 +125,7 @@ pub fn impl_wrap(
                     stringify!(#cls), ".", stringify!(#name), "()");
                 let _pool = pyo3::GILPool::new();
                 let _py = pyo3::Python::assume_gil_acquired();
-                let _slf = _py.mut_from_borrowed_ptr::<#cls>(_slf);
+                #slf
                 let _args = _py.from_borrowed_ptr::<pyo3::types::PyTuple>(_args);
                 let _kwargs: Option<&pyo3::types::PyDict> = _py.from_borrowed_ptr_or_opt(_kwargs);
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -430,6 +430,7 @@ impl FromPy<()> for Py<PyTuple> {
     }
 }
 
+/// Raw level conversion between `*mut ffi::PyObject` and PyO3 types.
 pub unsafe trait FromPyPointer<'p>: Sized {
     unsafe fn from_owned_ptr_or_opt(py: Python<'p>, ptr: *mut ffi::PyObject) -> Option<Self>;
     unsafe fn from_owned_ptr_or_panic(py: Python<'p>, ptr: *mut ffi::PyObject) -> Self {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -9,8 +9,7 @@ use crate::type_object::PyTypeCreate;
 use crate::type_object::{PyTypeInfo, PyTypeObject};
 use crate::types::PyAny;
 use crate::{
-    AsPyPointer, FromPyObject, FromPyPointer, IntoPyObject, IntoPyPointer, PyTryFrom, Python,
-    ToPyObject,
+    AsPyPointer, FromPyObject, FromPyPointer, IntoPyObject, IntoPyPointer, Python, ToPyObject,
 };
 use std::marker::PhantomData;
 use std::mem;
@@ -104,15 +103,6 @@ impl<'a, T: PyTypeInfo> Deref for PyRef<'a, T> {
     }
 }
 
-impl<'a, T> FromPyObject<'a> for PyRef<'a, T>
-where
-    T: PyTypeInfo,
-{
-    fn extract(ob: &'a PyAny) -> PyResult<PyRef<'a, T>> {
-        T::try_from(ob).map(PyRef::from_ref).map_err(Into::into)
-    }
-}
-
 unsafe impl<'p, T> FromPyPointer<'p> for PyRef<'p, T>
 where
     T: PyTypeInfo,
@@ -190,17 +180,6 @@ impl<'a, T: PyTypeInfo> Deref for PyRefMut<'a, T> {
 impl<'a, T: PyTypeInfo> DerefMut for PyRefMut<'a, T> {
     fn deref_mut(&mut self) -> &mut T {
         self.0
-    }
-}
-
-impl<'a, T> FromPyObject<'a> for PyRefMut<'a, T>
-where
-    T: PyTypeInfo,
-{
-    fn extract(ob: &'a PyAny) -> PyResult<PyRefMut<'a, T>> {
-        T::try_from_mut(ob)
-            .map(PyRefMut::from_mut)
-            .map_err(Into::into)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,8 @@
 
 pub use crate::class::*;
 pub use crate::conversion::{
-    AsPyPointer, FromPy, FromPyObject, IntoPy, IntoPyObject, IntoPyPointer, PyTryFrom, PyTryInto,
-    ToBorrowedObject, ToPyObject,
+    AsPyPointer, FromPy, FromPyObject, FromPyPointer, IntoPy, IntoPyObject, IntoPyPointer,
+    PyTryFrom, PyTryInto, ToBorrowedObject, ToPyObject,
 };
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyErrValue, PyResult};
 pub use crate::gil::{init_once, GILGuard, GILPool};

--- a/src/python.rs
+++ b/src/python.rs
@@ -240,7 +240,6 @@ impl<'p> Python<'p> {
 
     /// Register `ffi::PyObject` pointer in release pool,
     /// and do unchecked downcast to specific type.
-
     pub unsafe fn from_owned_ptr<T>(self, ptr: *mut ffi::PyObject) -> &'p T
     where
         T: PyTypeInfo,

--- a/tests/test_nested_iter.rs
+++ b/tests/test_nested_iter.rs
@@ -20,7 +20,7 @@ impl Reader {
     fn get_optional(&self, test: Option<i32>) -> PyResult<i32> {
         Ok(test.unwrap_or(10))
     }
-    fn get_iter(slf: PyRef<Reader>, keys: Py<PyBytes>) -> PyResult<Iter> {
+    fn get_iter(slf: PyRef<Self>, keys: Py<PyBytes>) -> PyResult<Iter> {
         Ok(Iter {
             reader: slf.into(),
             keys: keys,

--- a/tests/test_nested_iter.rs
+++ b/tests/test_nested_iter.rs
@@ -20,7 +20,7 @@ impl Reader {
     fn get_optional(&self, test: Option<i32>) -> PyResult<i32> {
         Ok(test.unwrap_or(10))
     }
-    fn get_iter(slf: PyRef<Self>, keys: Py<PyBytes>) -> PyResult<Iter> {
+    fn get_iter(slf: PyRef<Reader>, keys: Py<PyBytes>) -> PyResult<Iter> {
         Ok(Iter {
             reader: slf.into(),
             keys: keys,

--- a/tests/test_nested_iter.rs
+++ b/tests/test_nested_iter.rs
@@ -1,0 +1,78 @@
+//! Rust value -> Python Iterator
+//! Inspired by https://github.com/jothan/cordoba, thanks.
+use pyo3;
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyString};
+use pyo3::PyIterProtocol;
+use std::collections::HashMap;
+
+#[macro_use]
+mod common;
+
+/// Assumes it's a file reader or so.
+#[pyclass]
+struct Reader {
+    inner: HashMap<u8, String>,
+}
+
+#[pymethods]
+impl Reader {
+    fn get_optional(&self, test: Option<i32>) -> PyResult<i32> {
+        Ok(test.unwrap_or(10))
+    }
+    fn get_iter(slf: PyRef<Self>, keys: Py<PyBytes>) -> PyResult<Iter> {
+        Ok(Iter {
+            reader: slf.into(),
+            keys: keys,
+            idx: 0,
+        })
+    }
+}
+
+#[pyclass]
+struct Iter {
+    reader: Py<Reader>,
+    keys: Py<PyBytes>,
+    idx: usize,
+}
+
+#[pyproto]
+impl PyIterProtocol for Iter {
+    fn __iter__(slf: PyRefMut<Self>) -> PyResult<PyObject> {
+        let py = unsafe { Python::assume_gil_acquired() };
+        Ok(slf.to_object(py))
+    }
+
+    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PyObject>> {
+        let py = unsafe { Python::assume_gil_acquired() };
+        match slf.keys.as_ref(py).as_bytes().get(slf.idx) {
+            Some(&b) => {
+                let res = slf
+                    .reader
+                    .as_ref(py)
+                    .inner
+                    .get(&b)
+                    .map(|s| PyString::new(py, s).into());
+                slf.idx += 1;
+                Ok(res)
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[test]
+fn test_nested_iter() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let reader = [(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e")];
+    let reader = Reader {
+        inner: reader.iter().map(|(k, v)| (*k, v.to_string())).collect(),
+    }
+    .into_object(py);
+    py_assert!(
+        py,
+        reader,
+        "list(reader.get_iter(bytes([3, 5, 2]))) == ['c', 'e', 'b']"
+    );
+}

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -1,5 +1,4 @@
-//! Rust value -> Python Iterator
-//! Inspired by https://github.com/jothan/cordoba, thanks.
+//! Test slf: PyRef/PyMutRef<Self>(especially, slf.into::<Py>) works
 use pyo3;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
@@ -10,20 +9,32 @@ use std::collections::HashMap;
 mod common;
 
 /// Assumes it's a file reader or so.
+/// Inspired by https://github.com/jothan/cordoba, thanks.
 #[pyclass]
+#[derive(Clone)]
 struct Reader {
     inner: HashMap<u8, String>,
 }
 
 #[pymethods]
 impl Reader {
-    fn get_optional(&self, test: Option<i32>) -> PyResult<i32> {
-        Ok(test.unwrap_or(10))
-    }
     fn get_iter(slf: PyRef<Self>, keys: Py<PyBytes>) -> PyResult<Iter> {
         Ok(Iter {
             reader: slf.into(),
-            keys: keys,
+            keys,
+            idx: 0,
+        })
+    }
+    fn get_iter_and_reset(
+        mut slf: PyRefMut<Self>,
+        keys: Py<PyBytes>,
+        py: Python,
+    ) -> PyResult<Iter> {
+        let reader = Py::new(py, slf.clone())?;
+        slf.inner.clear();
+        Ok(Iter {
+            reader,
+            keys,
             idx: 0,
         })
     }
@@ -42,7 +53,6 @@ impl PyIterProtocol for Iter {
         let py = unsafe { Python::assume_gil_acquired() };
         Ok(slf.to_object(py))
     }
-
     fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PyObject>> {
         let py = unsafe { Python::assume_gil_acquired() };
         match slf.keys.as_ref(py).as_bytes().get(slf.idx) {
@@ -75,4 +85,25 @@ fn test_nested_iter() {
         reader,
         "list(reader.get_iter(bytes([3, 5, 2]))) == ['c', 'e', 'b']"
     );
+}
+
+#[test]
+fn test_nested_iter_reset() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let reader = [(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e")];
+    let reader = PyRef::new(
+        py,
+        Reader {
+            inner: reader.iter().map(|(k, v)| (*k, v.to_string())).collect(),
+        },
+    )
+    .unwrap();
+    let obj = reader.into_object(py);
+    py_assert!(
+        py,
+        obj,
+        "list(obj.get_iter_and_reset(bytes([3, 5, 2]))) == ['c', 'e', 'b']"
+    );
+    assert!(reader.inner.is_empty());
 }


### PR DESCRIPTION
Looks like 
```rust
#[pymethods]
impl Reader {
    fn get_iter(slf: PyRef<Self>, keys: Py<PyBytes>) -> PyResult<Iter> {
        Ok(Iter {
            reader: slf.into(),
            keys: keys,
            idx: 0,
        })
    }
}
```
and can be called like usual methods from python.
Resolves https://github.com/PyO3/pyo3/issues/356#issuecomment-465742221
Currently only `slf: PyRef` is tested.
Another concern is I observed an undesirable segfault when using `arg: PyRef<PyBytes>` in pymethod(though I'm not sure it's related to this PR