### PR TITLE
[WIP] Add PyTypeObject impl to PyRef

### DIFF
--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -173,7 +173,7 @@ macro_rules! create_exception {
 #[macro_export]
 macro_rules! create_exception_type_object {
     ($module: ident, $name: ident, $base: ty) => {
-        impl $crate::type_object::PyTypeObject for $name {
+        unsafe impl $crate::type_object::PyTypeObject for $name {
             fn init_type() -> std::ptr::NonNull<$crate::ffi::PyTypeObject> {
                 // We can't use lazy_static here because raw pointers aren't Send
                 static TYPE_OBJECT_ONCE: ::std::sync::Once = ::std::sync::Once::new();

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -244,6 +244,13 @@ pub unsafe trait PyTypeObject {
     }
 }
 
+/// Returns the statically known type for an object.
+///
+/// Eventually, this should become part of a trait
+pub fn get_type_from_object<T: PyTypeObject>(_object: &T) -> Py<PyType> {
+    T::type_object()
+}
+
 unsafe impl<T> PyTypeObject for T
 where
     T: PyTypeInfo + PyMethodsProtocol + PyObjectAlloc,


### PR DESCRIPTION
As @DeflatedPickle noticed on gitter, there was no way to get the `PyType` from the associated type of a `PyRef`. 

Open question: Do we want to add the following?

```rust
impl<T> AsPyRef<T> for T
where
    T: PyTypeInfo,
{
    #[inline]
    fn as_ref(&self, _py: Python) -> PyRef<T> {
        PyRef::from_ref(self)
    }
    #[inline]
    fn as_mut(&mut self, _py: Python) -> PyRefMut<T> {
        PyRefMut::from_mut(self)
    }
}
```