### PR TITLE
Add `FromPyObject` and `Clone` impls for every `PyNativeType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## Fixed
+### Added
+
+ * Added `FromPyObject` and `Clone` implementations for Python native types.
+
+### Fixed
 
  * `type_object::PyTypeObject` has been marked unsafe because breaking the contract `type_object::PyTypeObject::init_type` can lead to UB.
  * Fixed automatic derive of `PySequenceProtocol` implementation in [#423](https://github.com/PyO3/pyo3/pull/423).

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -86,6 +86,17 @@ macro_rules! pyobject_native_type (
                 unsafe{&*(ob as *const $name as *const $crate::types::PyAny)}
             }
         }
+
+        impl Clone for $name {
+            fn clone(&self) -> Self {
+                use $crate::AsPyPointer;
+                use $crate::PyNativeType;
+
+                unsafe {
+                    $name($crate::PyObject::from_borrowed_ptr(self.py(), self.0.as_ptr()))
+                }
+            }
+        }
     };
 );
 


### PR DESCRIPTION
This PR adds `FromPyObject` and `Clone` to structs implementing `PyNativeType`:

* `FromPyObject`  is only as complicated as checking the `PyAny` pointer can be downcasted and then wrapping the pointer if successful
* `Clone` only requires to call `clone_ref` using the internal token.

I am still not super at ease with the whole holding-the-GIL contract, so I'm not sure if I'm actually breaking everything or just providing the right implementation. 

I had to change the `$name: ty` to `$name: ident` in several macros because Rust does not accept `$name(...thing...)` when expanding even if it is valid for tuple types.

## Side effect 

Structs with native types in their fields implemented with `#[pyclass]` trying to use `#[pyo3(get, set)] should now compile properly:
```rust
#[pyclass]
pub struct DateWrapper {
    #[pyo3(get, set)]
    date: PyDateTime,
}
```

## Maintenance

 - Run `cargo fmt` (This is checked by travis ci) :white_check_mark: 
 - Run `cargo clippy` and check there are no hard errors (There are a bunch of existing warnings; This is also checked by travis) :white_check_mark: 
 - If applicable, add an entry in the changelog. :white_check_mark: 
 - If applicable, add documentation to all new items and extend the guide.
 - If applicable, add tests for all new or fixed functions.


