### PR TITLE
Fix documentation-related bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  * `type_object::PyTypeObject` has been marked unsafe because breaking the contract `type_object::PyTypeObject::init_type` can lead to UB.
  * Fixed automatic derive of `PySequenceProtocol` implementation in [#423](https://github.com/PyO3/pyo3/pull/423).
  * Capitalization & better wording to README.md.
+ * Docstrings of properties is now properly set using the doc of the `#[getter]` method.
+ * Fixed issues with `pymethods` crashing on doc comments containing double quotes.
 
 ## [0.6.0] - 2018-03-28
 

--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -113,7 +113,7 @@ fn extract_pyfn_attrs(
                     // read Python fonction name
                     match meta[1] {
                         syn::NestedMeta::Literal(syn::Lit::Str(ref lits)) => {
-                            fnname = Some(syn::parse_str(&lits.value()).unwrap());
+                            fnname = Some(syn::Ident::new(&lits.value(), lits.span()));
                         }
                         _ => panic!("The second parameter of pyfn must be a Literal"),
                     }

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -265,7 +265,8 @@ fn impl_class(
     };
 
     let extra = if !descriptors.is_empty() {
-        let ty = syn::parse_str(&cls.to_string()).expect("no name");
+        let path = syn::Path::from(syn::PathSegment::from(cls.clone()));
+        let ty = syn::Type::from(syn::TypePath { path, qself: None });
         let desc_impls = impl_descriptors(&ty, descriptors);
         quote! {
             #desc_impls
@@ -389,7 +390,7 @@ fn impl_descriptors(cls: &syn::Type, descriptors: Vec<(syn::Field, Vec<FnType>)>
                     let name = field.ident.clone().unwrap();
 
                     // FIXME better doc?
-                    let doc: syn::Lit = syn::parse_str(&format!("\"{}\"", name)).unwrap();
+                    let doc = syn::Lit::from(syn::LitStr::new(&name.to_string(), name.span()));
 
                     let field_ty = &field.ty;
                     match *desc {

--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -5,6 +5,7 @@ use crate::func::impl_method_proto;
 use crate::method::FnSpec;
 use crate::pymethod;
 use proc_macro2::TokenStream;
+use proc_macro2::Span;
 use quote::quote;
 use quote::ToTokens;
 
@@ -71,7 +72,7 @@ fn impl_proto_impl(
             for m in proto.py_methods {
                 let ident = met.sig.ident.clone();
                 if m.name == ident.to_string().as_str() {
-                    let name: syn::Ident = syn::parse_str(m.name).unwrap();
+                    let name = syn::Ident::new(m.name, Span::call_site());
                     let proto: syn::Path = syn::parse_str(m.proto).unwrap();
 
                     let fn_spec = match FnSpec::parse(&ident, &met.sig, &mut met.attrs) {

--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -4,8 +4,8 @@ use crate::defs;
 use crate::func::impl_method_proto;
 use crate::method::FnSpec;
 use crate::pymethod;
-use proc_macro2::TokenStream;
 use proc_macro2::Span;
+use proc_macro2::TokenStream;
 use quote::quote;
 use quote::ToTokens;
 

--- a/pyo3-derive-backend/src/utils.rs
+++ b/pyo3-derive-backend/src/utils.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-use proc_macro2::TokenStream;
 use proc_macro2::Span;
+use proc_macro2::TokenStream;
 use syn;
 
 pub fn print_err(msg: String, t: TokenStream) {

--- a/pyo3-derive-backend/src/utils.rs
+++ b/pyo3-derive-backend/src/utils.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
 use proc_macro2::TokenStream;
+use proc_macro2::Span;
 use syn;
 
 pub fn print_err(msg: String, t: TokenStream) {
@@ -32,13 +33,10 @@ pub fn get_doc(attrs: &[syn::Attribute], null_terminated: bool) -> syn::Lit {
         }
     }
 
-    let doc = doc.join("\n");
+    let mut docstr = doc.join("\n");
+    if null_terminated {
+        docstr.push('\0');
+    }
 
-    // FIXME: add span
-    syn::parse_str(&if null_terminated {
-        format!("\"{}\0\"", doc)
-    } else {
-        format!("\"{}\"", doc)
-    })
-    .unwrap()
+    syn::Lit::Str(syn::LitStr::new(&docstr, Span::call_site()))
 }

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -97,6 +97,9 @@ impl PyGetterDef {
                 .expect("Method name must not contain NULL byte")
                 .into_raw();
         }
+        if dst.doc.is_null() {
+            dst.doc = self.doc.as_ptr() as *mut libc::c_char;
+        }
         dst.get = Some(self.meth);
     }
 }

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -42,7 +42,12 @@ fn class_with_properties() {
     py_run!(py, inst, "assert inst.get_num() == inst.DATA");
 
     let d = [("C", py.get_type::<ClassWithProperties>())].into_py_dict(py);
-    py.run("assert C.DATA.__doc__ == 'a getter for data'", None, Some(d)).unwrap();
+    py.run(
+        "assert C.DATA.__doc__ == 'a getter for data'",
+        None,
+        Some(d),
+    )
+    .unwrap();
 }
 
 #[pyclass]

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use pyo3::types::IntoPyDict;
 use std::isize;
 
 #[macro_use]
@@ -16,6 +17,7 @@ impl ClassWithProperties {
     }
 
     #[getter(DATA)]
+    /// a getter for data
     fn get_data(&self) -> PyResult<i32> {
         Ok(self.num)
     }
@@ -38,6 +40,9 @@ fn class_with_properties() {
     py_run!(py, inst, "inst.DATA = 20");
     py_run!(py, inst, "assert inst.get_num() == 20");
     py_run!(py, inst, "assert inst.get_num() == inst.DATA");
+
+    let d = [("C", py.get_type::<ClassWithProperties>())].into_py_dict(py);
+    py.run("assert C.DATA.__doc__ == 'a getter for data'", None, Some(d)).unwrap();
 }
 
 #[pyclass]

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -43,7 +43,7 @@ impl InstanceMethodWithArgs {
     }
 }
 
-//#[test]
+#[test]
 #[allow(dead_code)]
 fn instance_method_with_args() {
     let gil = Python::acquire_gil();
@@ -68,6 +68,7 @@ impl ClassMethod {
     }
 
     #[classmethod]
+    /// Test class method.
     fn method(cls: &PyType) -> PyResult<String> {
         Ok(format!("{}.method()!", cls.name()))
     }
@@ -87,6 +88,18 @@ fn class_method() {
     .unwrap();
     py.run(
         "assert C().method() == 'ClassMethod.method()!'",
+        None,
+        Some(d),
+    )
+    .unwrap();
+    py.run(
+        "assert C.method.__doc__ == 'Test class method.'",
+        None,
+        Some(d),
+    )
+    .unwrap();
+    py.run(
+        "assert C().method.__doc__ == 'Test class method.'",
         None,
         Some(d),
     )
@@ -129,6 +142,7 @@ impl StaticMethod {
     }
 
     #[staticmethod]
+    /// Test static method.
     fn method(_py: Python) -> PyResult<&'static str> {
         Ok("StaticMethod.method()!")
     }
@@ -150,6 +164,18 @@ fn static_method() {
     .unwrap();
     py.run(
         "assert C().method() == 'StaticMethod.method()!'",
+        None,
+        Some(d),
+    )
+    .unwrap();
+    py.run(
+        "assert C.method.__doc__ == 'Test static method.'",
+        None,
+        Some(d),
+    )
+    .unwrap();
+    py.run(
+        "assert C().method.__doc__ == 'Test static method.'",
         None,
         Some(d),
     )

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -260,3 +260,49 @@ fn meth_args() {
         "assert inst.get_kwargs(1,2,3,t=1,n=2) == [(1,2,3), {'t': 1, 'n': 2}]"
     );
 }
+
+#[pyclass]
+/// A class with "documentation".
+struct MethDocs {
+    x: i32,
+}
+
+#[pymethods]
+impl MethDocs {
+    /// A method with "documentation" as well.
+    fn method(&self) -> PyResult<i32> {
+        Ok(0)
+    }
+
+    #[getter]
+    /// `int`: a very "important" member of 'this' instance.
+    fn get_x(&self) -> PyResult<i32> {
+        Ok(self.x)
+    }
+}
+
+#[test]
+fn meth_doc() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let d = [("C", py.get_type::<MethDocs>())].into_py_dict(py);
+
+    py.run(
+        "assert C.__doc__ == 'A class with \"documentation\".'",
+        None,
+        Some(d),
+    )
+    .unwrap();
+    py.run(
+        "assert C.method.__doc__ == 'A method with \"documentation\" as well.'",
+        None,
+        Some(d),
+    )
+    .unwrap();
+    py.run(
+        "assert C.x.__doc__ == '`int`: a very \"important\" member of \\'this\\' instance.'",
+        None,
+        Some(d),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
Hi,

After trying to get PyO3 working with Sphinx, I noticed the following bugs:

* [x] Having unescaped double quotes in a doc comment would cause the derive macros to fail, because
  of how the doc comment were handled in `pyo3-derive-backend`
* [x] The `__doc__` attribute was not properly set for `#[getter]` methods.
* [ ] The `__doc__` attribute is not properly set for `#[new]` methods.

This PR fixes the two first issues and adds tests for the second bugfix.

## Maintenance

 - Run `cargo fmt` :white_check_mark: 
 - Run `cargo clippy` and check there are no hard errors :white_check_mark: 
 - If applicable, add an entry in the changelog :white_check_mark: 
 - If applicable, add documentation to all new items and extend the guide.
 - If applicable, add tests for all new or fixed functions :white_check_mark: 


