### PR TITLE
PyFloat_AS_DOUBLE()

### DIFF
--- a/src/ffi3/floatobject.rs
+++ b/src/ffi3/floatobject.rs
@@ -1,6 +1,13 @@
 use crate::ffi3::object::*;
 use std::os::raw::{c_double, c_int};
 
+#[cfg(not(Py_LIMITED_API))]
+#[repr(C)]
+pub struct PyFloatObject {
+    pub ob_base: PyObject,
+    pub ob_fval: c_double,
+}
+
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub static mut PyFloat_Type: PyTypeObject;
@@ -14,6 +21,12 @@ pub unsafe fn PyFloat_Check(op: *mut PyObject) -> c_int {
 #[inline]
 pub unsafe fn PyFloat_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyFloat_Type) as c_int
+}
+
+#[cfg(not(Py_LIMITED_API))]
+#[inline]
+pub unsafe fn PyFloat_AS_DOUBLE(op: *mut PyObject) -> c_double {
+    (*(op as *mut PyFloatObject)).ob_fval
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -84,8 +84,8 @@ impl<'source> FromPyObject<'source> for f32 {
 
 #[cfg(test)]
 mod test {
-    use crate::Python;
-    use crate::ToPyObject;
+    use crate::ffi::PyFloat_AS_DOUBLE;
+    use crate::{AsPyPointer, Python, ToPyObject};
 
     macro_rules! num_to_py_object_and_back (
         ($func_name:ident, $t1:ty, $t2:ty) => (
@@ -103,4 +103,13 @@ mod test {
     num_to_py_object_and_back!(to_from_f64, f64, f64);
     num_to_py_object_and_back!(to_from_f32, f32, f32);
     num_to_py_object_and_back!(int_to_float, i32, f64);
+
+    #[test]
+    fn test_as_double_macro() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let v = 1.23f64;
+        let obj = v.to_object(py);
+        assert_eq!(v, unsafe { PyFloat_AS_DOUBLE(obj.as_ptr()) });
+    }
 }


### PR DESCRIPTION
This is a reimplementation of https://github.com/python/cpython/blob/e42b705188271da108de42b55d9344642170aa2b/Include/floatobject.h#L50-L52.