### PR TITLE
Make more constructors return &PyX instead of Py<PyX>

### DIFF
--- a/examples/rustapi_module/src/datetime.rs
+++ b/examples/rustapi_module/src/datetime.rs
@@ -6,7 +6,7 @@ use pyo3::types::{
 use pyo3::wrap_pyfunction;
 
 #[pyfunction]
-fn make_date(py: Python<'_>, year: i32, month: u8, day: u8) -> PyResult<Py<PyDate>> {
+fn make_date<'p>(py: Python<'p>, year: i32, month: u8, day: u8) -> PyResult<&'p PyDate> {
     PyDate::new(py, year, month, day)
 }
 
@@ -19,19 +19,19 @@ fn get_date_tuple(py: Python<'_>, d: &PyDate) -> Py<PyTuple> {
 }
 
 #[pyfunction]
-fn date_from_timestamp(py: Python<'_>, timestamp: i64) -> PyResult<Py<PyDate>> {
+fn date_from_timestamp<'p>(py: Python<'p>, timestamp: i64) -> PyResult<&'p PyDate> {
     PyDate::from_timestamp(py, timestamp)
 }
 
 #[pyfunction]
-fn make_time(
-    py: Python<'_>,
+fn make_time<'p>(
+    py: Python<'p>,
     hour: u8,
     minute: u8,
     second: u8,
     microsecond: u32,
     tzinfo: Option<&PyTzInfo>,
-) -> PyResult<Py<PyTime>> {
+) -> PyResult<&'p PyTime> {
     PyTime::new(
         py,
         hour,
@@ -44,15 +44,15 @@ fn make_time(
 
 #[cfg(Py_3_6)]
 #[pyfunction]
-fn time_with_fold(
-    py: Python,
+fn time_with_fold<'p>(
+    py: Python<'p>,
     hour: u8,
     minute: u8,
     second: u8,
     microsecond: u32,
     tzinfo: Option<&PyTzInfo>,
     fold: bool,
-) -> PyResult<Py<PyTime>> {
+) -> PyResult<&'p PyTime> {
     PyTime::new_with_fold(
         py,
         hour,
@@ -93,7 +93,12 @@ fn get_time_tuple_fold(py: Python, dt: &PyTime) -> Py<PyTuple> {
 }
 
 #[pyfunction]
-fn make_delta(py: Python<'_>, days: i32, seconds: i32, microseconds: i32) -> PyResult<Py<PyDelta>> {
+fn make_delta<'p>(
+    py: Python<'p>,
+    days: i32,
+    seconds: i32,
+    microseconds: i32,
+) -> PyResult<&'p PyDelta> {
     PyDelta::new(py, days, seconds, microseconds, true)
 }
 
@@ -110,8 +115,8 @@ fn get_delta_tuple(py: Python<'_>, delta: &PyDelta) -> Py<PyTuple> {
 }
 
 #[pyfunction]
-fn make_datetime(
-    py: Python<'_>,
+fn make_datetime<'p>(
+    py: Python<'p>,
     year: i32,
     month: u8,
     day: u8,
@@ -120,7 +125,7 @@ fn make_datetime(
     second: u8,
     microsecond: u32,
     tzinfo: Option<&PyTzInfo>,
-) -> PyResult<Py<PyDateTime>> {
+) -> PyResult<&'p PyDateTime> {
     PyDateTime::new(
         py,
         year,
@@ -169,11 +174,11 @@ fn get_datetime_tuple_fold(py: Python, dt: &PyDateTime) -> Py<PyTuple> {
 }
 
 #[pyfunction]
-fn datetime_from_timestamp(
-    py: Python<'_>,
+fn datetime_from_timestamp<'p>(
+    py: Python<'p>,
     ts: f64,
     tz: Option<&PyTzInfo>,
-) -> PyResult<Py<PyDateTime>> {
+) -> PyResult<&'p PyDateTime> {
     PyDateTime::from_timestamp(py, ts, tz)
 }
 
@@ -194,7 +199,7 @@ impl TzClass {
         obj.init(TzClass {})
     }
 
-    fn utcoffset(&self, py: Python<'_>, _dt: &PyDateTime) -> PyResult<Py<PyDelta>> {
+    fn utcoffset<'p>(&self, py: Python<'p>, _dt: &PyDateTime) -> PyResult<&'p PyDelta> {
         PyDelta::new(py, 0, 3600, 0, true)
     }
 

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -25,7 +25,6 @@ use crate::ffi::{
     PyDateTime_TIME_GET_HOUR, PyDateTime_TIME_GET_MICROSECOND, PyDateTime_TIME_GET_MINUTE,
     PyDateTime_TIME_GET_SECOND,
 };
-use crate::instance::Py;
 use crate::object::PyObject;
 use crate::types::PyTuple;
 use crate::AsPyPointer;
@@ -70,7 +69,7 @@ pub struct PyDate(PyObject);
 pyobject_native_type!(PyDate, *PyDateTimeAPI.DateType, PyDate_Check);
 
 impl PyDate {
-    pub fn new(py: Python, year: i32, month: u8, day: u8) -> PyResult<Py<PyDate>> {
+    pub fn new<'p>(py: Python<'p>, year: i32, month: u8, day: u8) -> PyResult<&'p PyDate> {
         unsafe {
             let ptr = (PyDateTimeAPI.Date_FromDate)(
                 year,
@@ -78,14 +77,14 @@ impl PyDate {
                 c_int::from(day),
                 PyDateTimeAPI.DateType,
             );
-            Py::from_owned_ptr_or_err(py, ptr)
+            py.from_owned_ptr_or_err(ptr)
         }
     }
 
     /// Construct a `datetime.date` from a POSIX timestamp
     ///
     /// This is equivalent to `datetime.date.fromtimestamp`
-    pub fn from_timestamp(py: Python, timestamp: i64) -> PyResult<Py<PyDate>> {
+    pub fn from_timestamp<'p>(py: Python<'p>, timestamp: i64) -> PyResult<&'p PyDate> {
         let time_tuple = PyTuple::new(py, &[timestamp]);
 
         unsafe {
@@ -96,7 +95,7 @@ impl PyDate {
             let ptr =
                 (PyDateTimeAPI.Date_FromTimestamp)(PyDateTimeAPI.DateType, time_tuple.as_ptr());
 
-            Py::from_owned_ptr_or_err(py, ptr)
+            py.from_owned_ptr_or_err(ptr)
         }
     }
 }
@@ -120,8 +119,8 @@ pub struct PyDateTime(PyObject);
 pyobject_native_type!(PyDateTime, *PyDateTimeAPI.DateTimeType, PyDateTime_Check);
 
 impl PyDateTime {
-    pub fn new(
-        py: Python,
+    pub fn new<'p>(
+        py: Python<'p>,
         year: i32,
         month: u8,
         day: u8,
@@ -130,7 +129,7 @@ impl PyDateTime {
         second: u8,
         microsecond: u32,
         tzinfo: Option<&PyObject>,
-    ) -> PyResult<Py<PyDateTime>> {
+    ) -> PyResult<&'p PyDateTime> {
         unsafe {
             let ptr = (PyDateTimeAPI.DateTime_FromDateAndTime)(
                 year,
@@ -143,18 +142,18 @@ impl PyDateTime {
                 opt_to_pyobj(py, tzinfo),
                 PyDateTimeAPI.DateTimeType,
             );
-            Py::from_owned_ptr_or_err(py, ptr)
+            py.from_owned_ptr_or_err(ptr)
         }
     }
 
     /// Construct a `datetime` object from a POSIX timestamp
     ///
     /// This is equivalent to `datetime.datetime.from_timestamp`
-    pub fn from_timestamp(
-        py: Python,
+    pub fn from_timestamp<'p>(
+        py: Python<'p>,
         timestamp: f64,
         time_zone_info: Option<&PyTzInfo>,
-    ) -> PyResult<Py<PyDateTime>> {
+    ) -> PyResult<&'p PyDateTime> {
         let timestamp: PyObject = timestamp.to_object(py);
 
         let time_zone_info: PyObject = match time_zone_info {
@@ -177,7 +176,7 @@ impl PyDateTime {
                 )
             };
 
-            Py::from_owned_ptr_or_err(py, ptr)
+            py.from_owned_ptr_or_err(ptr)
         }
     }
 }
@@ -224,14 +223,14 @@ pub struct PyTime(PyObject);
 pyobject_native_type!(PyTime, *PyDateTimeAPI.TimeType, PyTime_Check);
 
 impl PyTime {
-    pub fn new(
-        py: Python,
+    pub fn new<'p>(
+        py: Python<'p>,
         hour: u8,
         minute: u8,
         second: u8,
         microsecond: u32,
         tzinfo: Option<&PyObject>,
-    ) -> PyResult<Py<PyTime>> {
+    ) -> PyResult<&'p PyTime> {
         unsafe {
             let ptr = (PyDateTimeAPI.Time_FromTime)(
                 c_int::from(hour),
@@ -241,7 +240,7 @@ impl PyTime {
                 opt_to_pyobj(py, tzinfo),
                 PyDateTimeAPI.TimeType,
             );
-            Py::from_owned_ptr_or_err(py, ptr)
+            py.from_owned_ptr_or_err(ptr)
         }
     }
 
@@ -249,15 +248,15 @@ impl PyTime {
     /// Alternate constructor that takes a `fold` argument
     ///
     /// First available in Python 3.6.
-    pub fn new_with_fold(
-        py: Python,
+    pub fn new_with_fold<'p>(
+        py: Python<'p>,
         hour: u8,
         minute: u8,
         second: u8,
         microsecond: u32,
         tzinfo: Option<&PyObject>,
         fold: bool,
-    ) -> PyResult<Py<PyTime>> {
+    ) -> PyResult<&'p PyTime> {
         unsafe {
             let ptr = (PyDateTimeAPI.Time_FromTimeAndFold)(
                 c_int::from(hour),
@@ -268,7 +267,7 @@ impl PyTime {
                 fold as c_int,
                 PyDateTimeAPI.TimeType,
             );
-            Py::from_owned_ptr_or_err(py, ptr)
+            py.from_owned_ptr_or_err(ptr)
         }
     }
 }
@@ -307,13 +306,13 @@ pub struct PyDelta(PyObject);
 pyobject_native_type!(PyDelta, *PyDateTimeAPI.DeltaType, PyDelta_Check);
 
 impl PyDelta {
-    pub fn new(
-        py: Python,
+    pub fn new<'p>(
+        py: Python<'p>,
         days: i32,
         seconds: i32,
         microseconds: i32,
         normalize: bool,
-    ) -> PyResult<Py<PyDelta>> {
+    ) -> PyResult<&'p PyDelta> {
         unsafe {
             let ptr = (PyDateTimeAPI.Delta_FromDelta)(
                 days as c_int,
@@ -322,7 +321,7 @@ impl PyDelta {
                 normalize as c_int,
                 PyDateTimeAPI.DeltaType,
             );
-            Py::from_owned_ptr_or_err(py, ptr)
+            py.from_owned_ptr_or_err(ptr)
         }
     }
 }

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -4,7 +4,7 @@
 
 use crate::err::PyErr;
 use crate::ffi;
-use crate::instance::{Py, PyNativeType};
+use crate::instance::PyNativeType;
 use crate::object::PyObject;
 use crate::objectprotocol::ObjectProtocol;
 use crate::types::PyAny;
@@ -28,8 +28,8 @@ pyobject_native_type!(PyFloat, ffi::PyFloat_Type, ffi::PyFloat_Check);
 
 impl PyFloat {
     /// Creates a new Python `float` object.
-    pub fn new(_py: Python, val: c_double) -> Py<PyFloat> {
-        unsafe { Py::from_owned_ptr_or_panic(ffi::PyFloat_FromDouble(val)) }
+    pub fn new<'p>(py: Python<'p>, val: c_double) -> &'p PyFloat {
+        unsafe { py.from_owned_ptr(ffi::PyFloat_FromDouble(val)) }
     }
 
     /// Gets the value of this float.

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -5,7 +5,7 @@ use crate::conversion::{IntoPyObject, PyTryFrom, ToPyObject};
 use crate::err::{PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi;
-use crate::instance::{Py, PyNativeType};
+use crate::instance::PyNativeType;
 use crate::object::PyObject;
 use crate::types::PyAny;
 use crate::AsPyPointer;
@@ -30,10 +30,10 @@ impl PyString {
     /// Creates a new Python string object.
     ///
     /// Panics if out of memory.
-    pub fn new(_py: Python, s: &str) -> Py<PyString> {
+    pub fn new<'p>(py: Python<'p>, s: &str) -> &'p PyString {
         let ptr = s.as_ptr() as *const c_char;
         let len = s.len() as ffi::Py_ssize_t;
-        unsafe { Py::from_owned_ptr_or_panic(ffi::PyUnicode_FromStringAndSize(ptr, len)) }
+        unsafe { py.from_owned_ptr(ffi::PyUnicode_FromStringAndSize(ptr, len)) }
     }
 
     pub fn from_object<'p>(src: &'p PyAny, encoding: &str, errors: &str) -> PyResult<&'p PyString> {
@@ -87,17 +87,17 @@ impl PyBytes {
     /// The byte string is initialized by copying the data from the `&[u8]`.
     ///
     /// Panics if out of memory.
-    pub fn new(_py: Python, s: &[u8]) -> Py<PyBytes> {
+    pub fn new<'p>(py: Python<'p>, s: &[u8]) -> &'p PyBytes {
         let ptr = s.as_ptr() as *const c_char;
         let len = s.len() as ffi::Py_ssize_t;
-        unsafe { Py::from_owned_ptr_or_panic(ffi::PyBytes_FromStringAndSize(ptr, len)) }
+        unsafe { py.from_owned_ptr(ffi::PyBytes_FromStringAndSize(ptr, len)) }
     }
 
     /// Creates a new Python byte string object from raw pointer.
     ///
     /// Panics if out of memory.
-    pub unsafe fn from_ptr(_py: Python, ptr: *const u8, len: usize) -> Py<PyBytes> {
-        Py::from_owned_ptr_or_panic(ffi::PyBytes_FromStringAndSize(
+    pub unsafe fn from_ptr<'p>(py: Python<'p>, ptr: *const u8, len: usize) -> &'p PyBytes {
+        py.from_owned_ptr(ffi::PyBytes_FromStringAndSize(
             ptr as *const _,
             len as isize,
         ))


### PR DESCRIPTION
fixes #405

**Remaining** one is PyTuple, where I'm running into a test failure. Will provide as a separate PR.