### PR TITLE
Make PyTuple constructors return &PyTuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  * `PySet::new` and `PyFrozenSet::new` now return `PyResult<&Py[Frozen]Set>`; exceptions are raised if
    the items are not hashable.
  * Fixed building using `venv` on Windows.
+ * `PyTuple::new` now returns `&PyTuple` instead of `Py<PyTuple>`.
 
 ## [0.6.0] - 2018-03-28
 

--- a/examples/rustapi_module/src/datetime.rs
+++ b/examples/rustapi_module/src/datetime.rs
@@ -11,7 +11,7 @@ fn make_date<'p>(py: Python<'p>, year: i32, month: u8, day: u8) -> PyResult<&'p 
 }
 
 #[pyfunction]
-fn get_date_tuple(py: Python<'_>, d: &PyDate) -> Py<PyTuple> {
+fn get_date_tuple<'p>(py: Python<'p>, d: &PyDate) -> &'p PyTuple {
     PyTuple::new(
         py,
         &[d.get_year(), d.get_month() as i32, d.get_day() as i32],
@@ -65,7 +65,7 @@ fn time_with_fold<'p>(
 }
 
 #[pyfunction]
-fn get_time_tuple(py: Python<'_>, dt: &PyTime) -> Py<PyTuple> {
+fn get_time_tuple<'p>(py: Python<'p>, dt: &PyTime) -> &'p PyTuple {
     PyTuple::new(
         py,
         &[
@@ -79,7 +79,7 @@ fn get_time_tuple(py: Python<'_>, dt: &PyTime) -> Py<PyTuple> {
 
 #[cfg(Py_3_6)]
 #[pyfunction]
-fn get_time_tuple_fold(py: Python, dt: &PyTime) -> Py<PyTuple> {
+fn get_time_tuple_fold<'p>(py: Python<'p>, dt: &PyTime) -> &'p PyTuple {
     PyTuple::new(
         py,
         &[
@@ -103,7 +103,7 @@ fn make_delta<'p>(
 }
 
 #[pyfunction]
-fn get_delta_tuple(py: Python<'_>, delta: &PyDelta) -> Py<PyTuple> {
+fn get_delta_tuple<'p>(py: Python<'p>, delta: &PyDelta) -> &'p PyTuple {
     PyTuple::new(
         py,
         &[
@@ -140,7 +140,7 @@ fn make_datetime<'p>(
 }
 
 #[pyfunction]
-fn get_datetime_tuple(py: Python<'_>, dt: &PyDateTime) -> Py<PyTuple> {
+fn get_datetime_tuple<'p>(py: Python<'p>, dt: &PyDateTime) -> &'p PyTuple {
     PyTuple::new(
         py,
         &[
@@ -157,7 +157,7 @@ fn get_datetime_tuple(py: Python<'_>, dt: &PyDateTime) -> Py<PyTuple> {
 
 #[cfg(Py_3_6)]
 #[pyfunction]
-fn get_datetime_tuple_fold(py: Python, dt: &PyDateTime) -> Py<PyTuple> {
+fn get_datetime_tuple_fold<'p>(py: Python<'p>, dt: &PyDateTime) -> &'p PyTuple {
     PyTuple::new(
         py,
         &[

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -426,7 +426,7 @@ where
 /// Converts `()` to an empty Python tuple.
 impl FromPy<()> for Py<PyTuple> {
     fn from_py(_: (), py: Python) -> Py<PyTuple> {
-        PyTuple::empty(py)
+        Py::from_py(PyTuple::empty(py), py)
     }
 }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -21,7 +21,10 @@ pyobject_native_type!(PyTuple, ffi::PyTuple_Type, ffi::PyTuple_Check);
 
 impl PyTuple {
     /// Construct a new tuple with the given elements.
-    pub fn new<'p, T, U>(py: Python<'p>, elements: impl IntoIterator<Item = T, IntoIter = U>) -> &'p PyTuple
+    pub fn new<'p, T, U>(
+        py: Python<'p>,
+        elements: impl IntoIterator<Item = T, IntoIter = U>,
+    ) -> &'p PyTuple
     where
         T: ToPyObject,
         U: ExactSizeIterator<Item = T>,

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -93,8 +93,9 @@ impl Drop for ClassWithDrop {
         unsafe {
             let py = Python::assume_gil_acquired();
 
-            let _empty1 = PyTuple::empty(py);
-            let _empty2: PyObject = PyTuple::empty(py).into();
+            let _empty1: Py<PyTuple> = FromPy::from_py(PyTuple::empty(py), py);
+            let _empty2: Py<PyTuple> = FromPy::from_py(PyTuple::empty(py), py);
+            let _empty2: PyObject = _empty2.into();
             let _empty3: &PyAny = py.from_owned_ptr(ffi::PyTuple_New(0));
         }
     }
@@ -110,7 +111,7 @@ fn create_pointers_in_drop() {
     {
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let empty = PyTuple::empty(py);
+        let empty: Py<PyTuple> = FromPy::from_py(PyTuple::empty(py), py);
         ptr = empty.as_ptr();
         cnt = empty.get_refcnt() - 1;
         let inst = Py::new(py, ClassWithDrop {}).unwrap();

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -94,8 +94,7 @@ impl Drop for ClassWithDrop {
             let py = Python::assume_gil_acquired();
 
             let _empty1: Py<PyTuple> = FromPy::from_py(PyTuple::empty(py), py);
-            let _empty2: Py<PyTuple> = FromPy::from_py(PyTuple::empty(py), py);
-            let _empty2: PyObject = _empty2.into();
+            let _empty2 = PyTuple::empty(py).into_object(py);
             let _empty3: &PyAny = py.from_owned_ptr(ffi::PyTuple_New(0));
         }
     }
@@ -111,9 +110,10 @@ fn create_pointers_in_drop() {
     {
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let empty: Py<PyTuple> = FromPy::from_py(PyTuple::empty(py), py);
+        let empty = PyTuple::empty(py).into_object(py);
         ptr = empty.as_ptr();
-        cnt = empty.get_refcnt() - 1;
+        // substract 2, because `PyTuple::empty(py).into_object(py)` increases the refcnt by 2
+        cnt = empty.get_refcnt() - 2;
         let inst = Py::new(py, ClassWithDrop {}).unwrap();
         drop(inst);
     }

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -129,9 +129,10 @@ impl PickleSupport {
         obj.init({ PickleSupport {} });
     }
 
-    pub fn __reduce__(slf: PyRef<Self>) -> PyResult<(PyObject, Py<PyTuple>, PyObject)> {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
+    pub fn __reduce__<'py>(
+        slf: PyRef<Self>,
+        py: Python<'py>,
+    ) -> PyResult<(PyObject, &'py PyTuple, PyObject)> {
         let cls = slf.to_object(py).getattr(py, "__class__")?;
         let dict = slf.to_object(py).getattr(py, "__dict__")?;
         Ok((cls, PyTuple::empty(py), dict))


### PR DESCRIPTION
This has a test failure in test_gc:
```
---- create_pointers_in_drop stdout ----
thread 'create_pointers_in_drop' panicked at 'assertion failed: `(left == right)`
  left: `2127`,
 right: `2126`', tests/test_gc.rs:123:9
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

Also I'm not sure about the `FromPy` impl...