### PR TITLE
Adjust the varargs/kwds objects to remove arguments consumed by parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
    the items are not hashable.
  * Fixed building using `venv` on Windows.
  * `PyTuple::new` now returns `&PyTuple` instead of `Py<PyTuple>`.
+ * Fixed several issues with argument parsing; notable, the `*args` and `**kwargs`
+   tuple/dict now doesn't contain arguments that are otherwise assigned to parameters.
 
 ## [0.6.0] - 2018-03-28
 

--- a/guide/src/function.md
+++ b/guide/src/function.md
@@ -46,6 +46,34 @@ fn module_with_functions(py: Python, m: &PyModule) -> PyResult<()> {
 # fn main() {}
 ```
 
+## Argument parsing
+
+Both the `#[pyfunction]` and `#[pyfn]` attributes support specifying details of
+argument parsing.  The details are given in the section "Method arguments" in
+the [Classes](class.md) chapter.  Here is an example for a function that accepts
+arbitrary keyword arguments (`**kwargs` in Python syntax) and returns the number
+that was passed:
+
+```rust
+# extern crate pyo3;
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+use pyo3::types::PyDict;
+
+#[pyfunction(kwds="**")]
+fn num_kwds(kwds: Option<&PyDict>) -> usize {
+    kwds.map_or(0, |dict| dict.len())
+}
+
+#[pymodule]
+fn module_with_functions(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(num_kwds)).unwrap();
+    Ok(())
+}
+
+# fn main() {}
+```
+
 ### Making the function signature available to Python
 
 In order to make the function signature available to Python to be retrieved via

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -450,14 +450,17 @@ pub fn impl_arg_params(spec: &FnSpec<'_>, body: TokenStream) -> TokenStream {
         ];
 
         let mut output = [#(#placeholders),*];
+        let mut _args = _args;
+        let mut _kwargs = _kwargs;
 
         // Workaround to use the question mark operator without rewriting everything
         let _result = (|| {
             pyo3::derive_utils::parse_fn_args(
+                _py,
                 Some(_LOCATION),
                 PARAMS,
-                &_args,
-                _kwargs,
+                &mut _args,
+                &mut _kwargs,
                 #accept_args,
                 #accept_kwargs,
                 &mut output

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -475,12 +475,12 @@ pub fn impl_arg_params(spec: &FnSpec<'_>, body: TokenStream) -> TokenStream {
 
         // Workaround to use the question mark operator without rewriting everything
         let _result = (|| {
-            pyo3::derive_utils::parse_fn_args(
+            let (_args, _kwargs) = pyo3::derive_utils::parse_fn_args(
                 _py,
                 Some(_LOCATION),
                 PARAMS,
-                &mut _args,
-                &mut _kwargs,
+                _args,
+                _kwargs,
                 #accept_args,
                 #accept_kwargs,
                 &mut output

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -476,7 +476,6 @@ pub fn impl_arg_params(spec: &FnSpec<'_>, body: TokenStream) -> TokenStream {
         // Workaround to use the question mark operator without rewriting everything
         let _result = (|| {
             let (_args, _kwargs) = pyo3::derive_utils::parse_fn_args(
-                _py,
                 Some(_LOCATION),
                 PARAMS,
                 _args,

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -7,6 +7,7 @@
 use crate::err::PyResult;
 use crate::exceptions::TypeError;
 use crate::init_once;
+use crate::instance::PyNativeType;
 use crate::types::{PyAny, PyDict, PyModule, PyTuple};
 use crate::GILPool;
 use crate::Python;
@@ -33,7 +34,6 @@ pub struct ParamDescription {
 /// * output: Output array that receives the arguments.
 ///           Must have same length as `params` and must be initialized to `None`.
 pub fn parse_fn_args<'p>(
-    py: Python<'p>,
     fname: Option<&str>,
     params: &[ParamDescription],
     args: &'p PyTuple,
@@ -99,6 +99,7 @@ pub fn parse_fn_args<'p>(
     }
     // Adjust the remaining args
     let args = if accept_args {
+        let py = args.py();
         let slice = args.slice(used_args as isize, nargs as isize).into_py(py);
         py.checked_cast_as(slice).unwrap()
     } else {

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -46,11 +46,10 @@ pub fn parse_fn_args<'p>(
     let nkeywords = kwargs.map_or(0, PyDict::len);
     if !accept_args && !accept_kwargs && (nargs + nkeywords > params.len()) {
         return Err(TypeError::py_err(format!(
-            "{}{} takes at most {} argument{} ({} given)",
+            "{} takes at most {} argument{} ({} given)",
             fname.unwrap_or("function"),
-            if fname.is_some() { "()" } else { "" },
             params.len(),
-            if params.len() == 1 { "s" } else { "" },
+            if params.len() == 1 { "" } else { "s" },
             nargs + nkeywords
         )));
     }


### PR DESCRIPTION
There should be a *lot* more tests for argument parsing.  I think keyword-only param handling is still broken.

If the code changes here are looking good, I'll see if I can copy and adapt some tests from the CPython test suite.