### PR TITLE
Fix inaccurate comment

### DIFF
--- a/ci/travis/cover.sh
+++ b/ci/travis/cover.sh
@@ -2,12 +2,14 @@
 
 set -ex
 
-### Run kcov in parallel #######################################################
+### Run kcov ###################################################################
 
 rm -f target/debug/pyo3*.d
 rm -f target/debug/test_*.d
 rm -f target/debug/test_doc-*
 
+# Note: On travis this is run with -P1 because it started failing with
+# `-P $(nproc)`. kcov can probably be run in parallel if used with different CI
 FILES=$(find . -path ./target/debug/pyo3\* -or -path ./target/debug/test_\*)
 echo $FILES | xargs -n1 -P1 sh -c '
   dir="target/cov/$(basename $@)"


### PR DESCRIPTION
The previous commit was merged somewhat prematurely, and fixed the coverage on Travis by limiting `kcov` to a single process.

The previous commit also pins to a specific branch, which was not necessary to fix this issue, but is a good idea anyway to prevent bad commits on kcov's master branch from breaking PyO3's build.

This is cleanup for #452.