### PR TITLE
Use syn::ext::IdentExt::unraw

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ travis-ci = { repository = "PyO3/pyo3", branch = "master" }
 appveyor = { repository = "fafhrd91/pyo3" }
 
 [dependencies]
-libc = "0.2.48"
+libc = "0.2.51"
 spin = "0.5.0"
 num-traits = "0.2.6"
 pyo3cls = { path = "pyo3cls", version = "=0.7.0-alpha.1" }
@@ -33,7 +33,7 @@ assert_approx_eq = "1.1.0"
 indoc = "0.3.1"
 
 [build-dependencies]
-regex = "1.1.0"
+regex = "1.1.6"
 version_check = "0.1.5"
 
 [features]

--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -11,6 +11,6 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-quote = "0.6.9"
-proc-macro2 = "0.4.20"
-syn = { version = "0.15.15", features = ["full", "extra-traits"] }
+quote = "0.6.12"
+proc-macro2 = "0.4.28"
+syn = { version = "0.15.33", features = ["full", "extra-traits"] }

--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -9,6 +9,7 @@ use crate::pymethod::get_arg_names;
 use crate::utils;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
+use syn::ext::IdentExt;
 use syn::Ident;
 
 /// Generates the function that is called by the python interpreter to initialize the native
@@ -138,12 +139,8 @@ fn extract_pyfn_attrs(
 /// Coordinates the naming of a the add-function-to-python-module function
 fn function_wrapper_ident(name: &Ident) -> Ident {
     // Make sure this ident matches the one of wrap_pyfunction
-    // The trim_start_matches("r#") is for https://github.com/dtolnay/syn/issues/478
     Ident::new(
-        &format!(
-            "__pyo3_get_function_{}",
-            name.to_string().trim_start_matches("r#")
-        ),
+        &format!("__pyo3_get_function_{}", name.unraw().to_string()),
         Span::call_site(),
     )
 }

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -10,6 +10,7 @@ use pyo3_derive_backend::{
     process_functions_in_module, py_init, PyClassArgs, PyFunctionAttr,
 };
 use quote::quote;
+use syn::ext::IdentExt;
 use syn::parse_macro_input;
 
 /// Internally, this proc macro create a new c function called `PyInit_{my_module}`
@@ -77,11 +78,7 @@ pub fn pyfunction(attr: TokenStream, input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as syn::ItemFn);
     let args = parse_macro_input!(attr as PyFunctionAttr);
 
-    // Workaround for https://github.com/dtolnay/syn/issues/478
-    let python_name = syn::Ident::new(
-        &ast.ident.to_string().trim_start_matches("r#"),
-        Span::call_site(),
-    );
+    let python_name = syn::Ident::new(&ast.ident.unraw().to_string(), Span::call_site());
     let expanded = add_fn_to_module(&ast, &python_name, args.arguments);
 
     quote!(


### PR DESCRIPTION
With https://github.com/dtolnay/syn/pull/625 fixing https://github.com/dtolnay/syn/issues/478, we can remove our workarounds.

This pull request is waiting for the next syn release (those happen frequently), so I can remove the path section.