### PR TITLE
Enable sudo for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
-
 dist: xenial
+sudo: required
 
 cache:
   pip: true


### PR DESCRIPTION
Attempt to fix the kcov errors on travis. See
https://github.com/travis-ci/travis-ci/issues/9061 and
https://blog.travis-ci.com/2018-01-08-travis-response-meltdown-spectre
for context.

#439