### PR TITLE
Allow #[pymethods] to use lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  * PyPy support by omerbenamram in [#393](https://github.com/PyO3/pyo3/pull/393)
  * Have `PyModule` generate an index of its members (`__all__` list).
  * Allow `slf: PyRef<T>` for pyclass(#419)
+ * Allow to use lifetime specifiers in `pymethods`
 
 ### Changed
 

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -40,8 +40,18 @@ pub fn gen_py_method(
 }
 
 fn check_generic(name: &syn::Ident, sig: &syn::MethodSig) {
-    if !sig.decl.generics.params.is_empty() {
-        panic!("python method can not be generic: {:?}", name);
+    for param in &sig.decl.generics.params {
+        match param {
+            syn::GenericParam::Lifetime(_) => {}
+            syn::GenericParam::Type(_) => panic!(
+                "A Python method can't have a generic type parameter: {}",
+                name
+            ),
+            syn::GenericParam::Const(_) => panic!(
+                "A Python method can't have a const generic parameter: {}",
+                name
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
E.g., allow
```rust
fn method<'py>(py: Python<'py>) -> &'py PyList {...}
```