### PR TITLE
Fix PEP 517 build issues in test extensions

### DIFF
--- a/examples/rustapi_module/MANIFEST.in
+++ b/examples/rustapi_module/MANIFEST.in
@@ -1,0 +1,2 @@
+include pyproject.toml Cargo.toml
+recursive-include src *

--- a/examples/rustapi_module/pyproject.toml
+++ b/examples/rustapi_module/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_rust>=0.10.2"]
+requires = ["setuptools", "wheel", "setuptools_rust>=0.10.2", "toml"]

--- a/examples/rustapi_module/pyproject.toml
+++ b/examples/rustapi_module/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "setuptools_rust>=0.10.2", "toml"]
+build-backend = "setuptools.build_meta"

--- a/examples/rustapi_module/setup.py
+++ b/examples/rustapi_module/setup.py
@@ -1,8 +1,10 @@
+import os
 import sys
 import platform
 
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
+from setuptools.command.sdist import sdist as SdistCommand
 from setuptools_rust import RustExtension
 
 
@@ -16,6 +18,41 @@ class PyTest(TestCommand):
 
         errno = subprocess.call(["pytest", "tests"])
         raise SystemExit(errno)
+
+
+class CargoModifiedSdist(SdistCommand):
+    """Modifies Cargo.toml to use an absolute rather than a relative path
+
+    The current implementation of PEP 517 in pip always does builds in an
+    isolated temporary directory. This causes problems with the build, because
+    Cargo.toml necessarily refers to the current version of pyo3 by a relative
+    path.
+
+    Since these sdists are never meant to be used for anything other than
+    tox / pip installs, at sdist build time, we will modify the Cargo.toml
+    in the sdist archive to include an *absolute* path to pyo3.
+    """
+
+    def make_release_tree(self, base_dir, files):
+        """Stages the files to be included in archives"""
+        super().make_release_tree(base_dir, files)
+
+        import toml
+        # Cargo.toml is now staged and ready to be modified
+        cargo_loc = os.path.join(base_dir, 'Cargo.toml')
+        assert os.path.exists(cargo_loc)
+
+        with open(cargo_loc, 'r') as f:
+            cargo_toml = toml.load(f)
+
+        rel_pyo3_path = cargo_toml['dependencies']['pyo3']['path']
+        base_path = os.path.dirname(__file__)
+        abs_pyo3_path = os.path.abspath(os.path.join(base_path, rel_pyo3_path))
+
+        cargo_toml['dependencies']['pyo3']['path'] = abs_pyo3_path
+
+        with open(cargo_loc, 'w') as f:
+            toml.dump(cargo_toml, f)
 
 
 def get_py_version_cfgs():
@@ -70,5 +107,8 @@ setup(
     tests_require=tests_require,
     include_package_data=True,
     zip_safe=False,
-    cmdclass=dict(test=PyTest),
+    cmdclass={
+        'test': PyTest,
+        'sdist': CargoModifiedSdist,
+    },
 )

--- a/examples/rustapi_module/tox.ini
+++ b/examples/rustapi_module/tox.ini
@@ -3,11 +3,11 @@ envlist = py35,
           py36,
           py37,
           pypy35
-minversion = 2.9.0
+minversion = 3.4.0
 skip_missing_interpreters = true
+isolated_build = true
 
 [testenv]
 description = Run the unit tests under {basepython}
 deps = -rrequirements-dev.txt
-usedevelop = True
 commands = pytest {posargs}

--- a/examples/word-count/MANIFEST.in
+++ b/examples/word-count/MANIFEST.in
@@ -1,0 +1,2 @@
+include pyproject.toml Cargo.toml
+recursive-include src *

--- a/examples/word-count/pyproject.toml
+++ b/examples/word-count/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-rust"]
+requires = ["setuptools", "wheel", "setuptools-rust", "toml"]
+build-backend = "setuptools.build_meta"

--- a/examples/word-count/setup.py
+++ b/examples/word-count/setup.py
@@ -1,7 +1,9 @@
+import os
 import sys
 
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
+from setuptools.command.sdist import sdist as SdistCommand
 
 try:
     from setuptools_rust import RustExtension
@@ -14,6 +16,41 @@ except ImportError:
         raise SystemExit(errno)
     else:
         from setuptools_rust import RustExtension
+
+
+class CargoModifiedSdist(SdistCommand):
+    """Modifies Cargo.toml to use an absolute rather than a relative path
+
+    The current implementation of PEP 517 in pip always does builds in an
+    isolated temporary directory. This causes problems with the build, because
+    Cargo.toml necessarily refers to the current version of pyo3 by a relative
+    path.
+
+    Since these sdists are never meant to be used for anything other than
+    tox / pip installs, at sdist build time, we will modify the Cargo.toml
+    in the sdist archive to include an *absolute* path to pyo3.
+    """
+
+    def make_release_tree(self, base_dir, files):
+        """Stages the files to be included in archives"""
+        super().make_release_tree(base_dir, files)
+
+        import toml
+        # Cargo.toml is now staged and ready to be modified
+        cargo_loc = os.path.join(base_dir, 'Cargo.toml')
+        assert os.path.exists(cargo_loc)
+
+        with open(cargo_loc, 'r') as f:
+            cargo_toml = toml.load(f)
+
+        rel_pyo3_path = cargo_toml['dependencies']['pyo3']['path']
+        base_path = os.path.dirname(__file__)
+        abs_pyo3_path = os.path.abspath(os.path.join(base_path, rel_pyo3_path))
+
+        cargo_toml['dependencies']['pyo3']['path'] = abs_pyo3_path
+
+        with open(cargo_loc, 'w') as f:
+            toml.dump(cargo_toml, f)
 
 
 class PyTest(TestCommand):
@@ -50,5 +87,8 @@ setup(
     setup_requires=setup_requires,
     include_package_data=True,
     zip_safe=False,
-    cmdclass=dict(test=PyTest),
+    cmdclass={
+        'test': PyTest,
+        'sdist': CargoModifiedSdist,
+    },
 )

--- a/examples/word-count/tox.ini
+++ b/examples/word-count/tox.ini
@@ -5,9 +5,9 @@ envlist = py35,
           pypy35
 minversion = 3.4.0
 skip_missing_interpreters = true
+isolated_build = true
 
 [testenv]
 description = Run the unit tests under {basepython}
 deps = -rrequirements-dev.txt
-usedevelop = True
 commands = pytest {posargs}


### PR DESCRIPTION
I'm not sure why we had `usedevelop` on in the first place, but with `pip>19.1`, it has started hard-failing.

FIxes #462