### PR TITLE
Make doctest dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,10 @@ pyo3cls = { path = "pyo3cls", version = "=0.7.0-alpha.1" }
 mashup = "0.1.9"
 num-complex = { version = "0.2.1", optional = true }
 inventory = "0.1.3"
-doc-comment = "0.3"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
+doc-comment = "0.3"
 indoc = "0.3.1"
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,25 +116,28 @@
 //!     Ok(())
 //! }
 //! ```
-use doc_comment::doctest;
 
 // Test readme and user guide
-doctest!("../README.md", readme_md);
-doctest!("../guide/src/advanced.md", guide_advanced_md);
-doctest!(
-    "../guide/src/building_and_distribution.md",
-    guide_building_and_distribution_md
-);
-doctest!("../guide/src/class.md", guide_class_md);
-doctest!("../guide/src/conversions.md", guide_conversions_md);
-doctest!("../guide/src/debugging.md", guide_debugging_md);
-doctest!("../guide/src/exception.md", guide_exception_md);
-doctest!("../guide/src/function.md", guide_function_md);
-doctest!("../guide/src/get_started.md", guide_get_started_md);
-doctest!("../guide/src/module.md", guide_module_md);
-doctest!("../guide/src/parallelism.md", guide_parallelism_md);
-doctest!("../guide/src/pypy.md", guide_pypy_md);
-doctest!("../guide/src/rust_cpython.md", guide_rust_cpython_md);
+macro_rules! cfg_test { ($($test_item: item)+) => {$(#[cfg(test)] $test_item)+} }
+cfg_test! {
+    use doc_comment::doctest;
+    doctest!("../README.md", readme_md);
+    doctest!("../guide/src/advanced.md", guide_advanced_md);
+    doctest!(
+        "../guide/src/building_and_distribution.md",
+        guide_building_and_distribution_md
+    );
+    doctest!("../guide/src/class.md", guide_class_md);
+    doctest!("../guide/src/conversions.md", guide_conversions_md);
+    doctest!("../guide/src/debugging.md", guide_debugging_md);
+    doctest!("../guide/src/exception.md", guide_exception_md);
+    doctest!("../guide/src/function.md", guide_function_md);
+    doctest!("../guide/src/get_started.md", guide_get_started_md);
+    doctest!("../guide/src/module.md", guide_module_md);
+    doctest!("../guide/src/parallelism.md", guide_parallelism_md);
+    doctest!("../guide/src/pypy.md", guide_pypy_md);
+    doctest!("../guide/src/rust_cpython.md", guide_rust_cpython_md);
+}
 
 pub use crate::class::*;
 pub use crate::conversion::{


### PR DESCRIPTION
Maybe we don't need it when `#[cfg(not(test))]`.
cc: @Alexander-N 