### PR TITLE
Remove doc-comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ pyo3cls = { path = "pyo3cls", version = "=0.7.0-alpha.1" }
 mashup = "0.1.9"
 num-complex = { version = "0.2.1", optional = true }
 inventory = "0.1.3"
-doc-comment = "0.3"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,25 +116,6 @@
 //!     Ok(())
 //! }
 //! ```
-use doc_comment::doctest;
-
-// Test readme and user guide
-doctest!("../README.md", readme_md);
-doctest!("../guide/src/advanced.md", guide_advanced_md);
-doctest!(
-    "../guide/src/building_and_distribution.md",
-    guide_building_and_distribution_md
-);
-doctest!("../guide/src/class.md", guide_class_md);
-doctest!("../guide/src/conversions.md", guide_conversions_md);
-doctest!("../guide/src/debugging.md", guide_debugging_md);
-doctest!("../guide/src/exception.md", guide_exception_md);
-doctest!("../guide/src/function.md", guide_function_md);
-doctest!("../guide/src/get_started.md", guide_get_started_md);
-doctest!("../guide/src/module.md", guide_module_md);
-doctest!("../guide/src/parallelism.md", guide_parallelism_md);
-doctest!("../guide/src/pypy.md", guide_pypy_md);
-doctest!("../guide/src/rust_cpython.md", guide_rust_cpython_md);
 
 pub use crate::class::*;
 pub use crate::conversion::{
@@ -226,4 +207,38 @@ macro_rules! wrap_pymodule {
             &|py| unsafe { pyo3::PyObject::from_owned_ptr(py, "method"()) }
         }
     }};
+}
+
+/// Test readme and user guide
+#[doc(hidden)]
+pub mod doc_test {
+    macro_rules! doc_comment {
+        ($x:expr, $($tt:tt)*) => {
+            #[doc = $x]
+            $($tt)*
+        };
+    }
+
+    macro_rules! doctest {
+        ($x:expr, $y:ident) => {
+            doc_comment!(include_str!($x), mod $y {});
+        };
+    }
+
+    doctest!("../README.md", readme_md);
+    doctest!("../guide/src/advanced.md", guide_advanced_md);
+    doctest!(
+        "../guide/src/building_and_distribution.md",
+        guide_building_and_distribution_md
+    );
+    doctest!("../guide/src/class.md", guide_class_md);
+    doctest!("../guide/src/conversions.md", guide_conversions_md);
+    doctest!("../guide/src/debugging.md", guide_debugging_md);
+    doctest!("../guide/src/exception.md", guide_exception_md);
+    doctest!("../guide/src/function.md", guide_function_md);
+    doctest!("../guide/src/get_started.md", guide_get_started_md);
+    doctest!("../guide/src/module.md", guide_module_md);
+    doctest!("../guide/src/parallelism.md", guide_parallelism_md);
+    doctest!("../guide/src/pypy.md", guide_pypy_md);
+    doctest!("../guide/src/rust_cpython.md", guide_rust_cpython_md);
 }


### PR DESCRIPTION
When I tried to make doc-comment a dev-dependency, I realized it actually only creates a mod with the file as doc string and can be replaced by two small macros.

CC @kngwyu @Alexander-N