### PR TITLE
Enable setting the module name of a class

### DIFF
--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -1,4 +1,5 @@
 use pyo3::prelude::*;
+use pyo3::type_object::initialize_type;
 
 #[macro_use]
 mod common;
@@ -71,4 +72,9 @@ fn empty_class_in_module() {
     // We currently have no way of determining a canonical module, so builtins is better
     // than using whatever calls init first.
     assert_eq!(module, "builtins");
+
+    // The module name can also be set manually by calling `initialize_type`.
+    initialize_type::<EmptyClassInModule>(py, Some("test_module.nested")).unwrap();
+    let module: String = ty.getattr("__module__").unwrap().extract().unwrap();
+    assert_eq!(module, "test_module.nested");
 }


### PR DESCRIPTION
Didn't implement setting it automatically to avoid unexpected behavior. Pickling is possible but very awkward.

#100
Closes #474