### PR TITLE
Change Python::run to return PyResult<()>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  * Add `marshal` module. [#460](https://github.com/PyO3/pyo3/pull/460)
 
 ### Changed
-
+ * `Python::run` returns `PyResult<()>` instead of `PyResult<&PyAny>`.
  * Methods decorated with `#[getter]` and `#[setter]` can now omit wrapping the
    result type in `PyResult` if they don't raise exceptions.
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -108,8 +108,11 @@ impl<'p> Python<'p> {
         code: &str,
         globals: Option<&PyDict>,
         locals: Option<&PyDict>,
-    ) -> PyResult<&'p PyAny> {
-        self.run_code(code, ffi::Py_file_input, globals, locals)
+    ) -> PyResult<()> {
+        let res = self.run_code(code, ffi::Py_file_input, globals, locals);
+        res.map(|obj| {
+            debug_assert!(crate::ObjectProtocol::is_none(obj));
+        })
     }
 
     /// Runs code in the given context.


### PR DESCRIPTION
When we pass `ffi::Py_file_input` to [`ffi::PyRun_StringFlags`](https://docs.python.org/3/c-api/veryhigh.html#c.PyRun_StringFlags), it always returns `None`.
So it's confusing to return `PyResult<&PyAny>`.

I found this behavior *empirically* and can be incorrect.