### PR TITLE
Fix example

### DIFF
--- a/guide/src/get_started.md
+++ b/guide/src/get_started.md
@@ -45,6 +45,8 @@ features = ["extension-module"]
 **`src/lib.rs`**
 
 ```rust
+extern crate pyo3;
+
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 


### PR DESCRIPTION
Just added `extern crate pyo3;` since it was missing.