### PR TITLE
build.rs: Handle `python` being Python 2

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -503,7 +503,10 @@ if PYPY:
 else:
     print(sysconfig.get_config_var('Py_ENABLE_SHARED'))
 print(sysconfig.get_config_var('LDVERSION') or sysconfig.get_config_var('py_version_short'))
-print(sys.base_prefix)
+try:
+    print(sys.base_prefix)
+except AttributeError:
+    print(sys.exec_prefix)
 print(platform.python_implementation())
 "#;
     let out = run_python_script(interpreter, script)?;


### PR DESCRIPTION
If `python` refers to Python 2 (as recommended in [1]) the build fails
with: `AttributeError: 'module' object has no attribute 'base_prefix'`

Since there is no `base_prefix` in Python 2, simply use `exec_prefix` if
the AttributeError is raised.

[1] https://www.python.org/dev/peps/pep-0394/