### PR TITLE
Reject generics explicitly for #[pyclass]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ inventory = "0.1.3"
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 indoc = "0.3.3"
+trybuild = "1.0"
 
 [build-dependencies]
 regex = "1.1.6"

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -154,6 +154,7 @@ pub fn build_py_class(class: &mut syn::ItemStruct, attr: &PyClassArgs) -> syn::R
     let doc = utils::get_doc(&class.attrs, true);
     let mut descriptors = Vec::new();
 
+    check_generics(class)?;
     if let syn::Fields::Named(ref mut fields) = class.fields {
         for field in fields.named.iter_mut() {
             let field_descs = parse_descriptors(field)?;
@@ -459,5 +460,16 @@ fn impl_descriptors(cls: &syn::Type, descriptors: Vec<(syn::Field, Vec<FnType>)>
                 <ClsInventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(#py_methods),*])
             }
         }
+    }
+}
+
+fn check_generics(class: &mut syn::ItemStruct) -> syn::Result<()> {
+    if class.generics.params.is_empty() {
+        Ok(())
+    } else {
+        Err(syn::Error::new_spanned(
+            &class.generics,
+            "#[pyclass] cannot have generic parameters",
+        ))
     }
 }

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,0 +1,6 @@
+#[test]
+#[cfg(testkcovstopmarker)]
+fn test_compile_errors() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/reject_generics.rs");
+}

--- a/tests/ui/reject_generics.rs
+++ b/tests/ui/reject_generics.rs
@@ -1,0 +1,8 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+struct ClassWithGenerics<A> {
+    a: A,
+}
+
+fn main() {}

--- a/tests/ui/reject_generics.stderr
+++ b/tests/ui/reject_generics.stderr
@@ -1,0 +1,5 @@
+error: #[pyclass] cannot have generic parameters
+ --> $DIR/reject_generics.rs:4:25
+  |
+4 | struct ClassWithGenerics<A> {
+  |                         ^^^


### PR DESCRIPTION
As per the discussion in #502, I tried to improve the error message for pyclasses with generic parameters.
In this PR, I also introduced the use of [trybuild](https://github.com/dtolnay/trybuild), which is a great library to test compile error messages for proc-macro functions.
