### PR TITLE
Use existing fields and methods before calling custom __getattr__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
  * `module` argument to `pyclass` macro. [#499](https://github.com/PyO3/pyo3/pull/499)
  * `py_run!` macro [#512](https://github.com/PyO3/pyo3/pull/512)
+ * Use existing fields and methods before calling custom __getattr__. [#505](https://github.com/PyO3/pyo3/pull/512)
 
 ### Fixed
 

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -462,3 +462,25 @@ fn weakref_dunder_dict_support() {
         "import weakref; assert weakref.ref(inst)() is inst; inst.a = 1; assert inst.a == 1"
     );
 }
+
+#[pyclass]
+struct ClassWithGetAttr {
+    #[pyo3(get, set)]
+    data: u32,
+}
+
+#[pyproto]
+impl PyObjectProtocol for ClassWithGetAttr {
+    fn __getattr__(&self, _name: &str) -> PyResult<u32> {
+        Ok(self.data * 2)
+    }
+}
+
+#[test]
+fn getattr_doesnt_override_member() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let inst = PyRef::new(py, ClassWithGetAttr { data: 4 }).unwrap();
+    py_assert!(py, inst, "inst.data == 4");
+    py_assert!(py, inst, "inst.a == 8");
+}


### PR DESCRIPTION
Previously, defining `__getattr__` would override all existing fields and methods. This changes it to behave like a `__getattr__` method defined in python, i.e. the custom method is only called if there isn't a field or method of that name.