### PR TITLE
Print error before on class init panic

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -20,8 +20,8 @@ use std::os::raw::c_char;
 pub enum PyErrValue {
     None,
     Value(PyObject),
-    ToArgs(Box<PyErrArguments>),
-    ToObject(Box<ToPyObject>),
+    ToArgs(Box<dyn PyErrArguments>),
+    ToObject(Box<dyn ToPyObject>),
 }
 
 /// Represents a Python exception that was raised.

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -123,7 +123,7 @@ struct ReleasePool {
     owned: ArrayList<NonNull<ffi::PyObject>>,
     borrowed: ArrayList<NonNull<ffi::PyObject>>,
     pointers: *mut Vec<NonNull<ffi::PyObject>>,
-    obj: Vec<Box<any::Any>>,
+    obj: Vec<Box<dyn any::Any>>,
     p: spin::Mutex<*mut Vec<NonNull<ffi::PyObject>>>,
 }
 

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -259,7 +259,8 @@ where
             let gil = Python::acquire_gil();
             let py = gil.python();
 
-            initialize_type::<Self>(py, <Self as PyTypeInfo>::MODULE).unwrap_or_else(|_| {
+            initialize_type::<Self>(py, <Self as PyTypeInfo>::MODULE).unwrap_or_else(|e| {
+                e.print(py);
                 panic!("An error occurred while initializing class {}", Self::NAME)
             });
         }

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -192,7 +192,7 @@ impl PyModule {
     /// ```rust,ignore
     /// m.add("also_double", wrap_pyfunction!(double)(py));
     /// ```
-    pub fn add_wrapped(&self, wrapper: &dyn Fn(Python) -> PyObject) -> PyResult<()> {
+    pub fn add_wrapped(&self, wrapper: &impl Fn(Python) -> PyObject) -> PyResult<()> {
         let function = wrapper(self.py());
         let name = function
             .getattr(self.py(), "__name__")

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -192,7 +192,7 @@ impl PyModule {
     /// ```rust,ignore
     /// m.add("also_double", wrap_pyfunction!(double)(py));
     /// ```
-    pub fn add_wrapped(&self, wrapper: &Fn(Python) -> PyObject) -> PyResult<()> {
+    pub fn add_wrapped(&self, wrapper: &dyn Fn(Python) -> PyObject) -> PyResult<()> {
         let function = wrapper(self.py());
         let name = function
             .getattr(self.py(), "__name__")

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -49,7 +49,7 @@ fn len() {
 
 #[pyclass]
 struct Iterator {
-    iter: Box<iter::Iterator<Item = i32> + Send>,
+    iter: Box<dyn iter::Iterator<Item = i32> + Send>,
 }
 
 #[pyproto]


### PR DESCRIPTION
Inspired by https://github.com/rust-numpy/rust-numpy/issues/97, also fixes some warnings from the latest nightly.
