### PR TITLE
Ignore return code of coverage script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,12 @@ script:
   - ./ci/travis/test.sh
 
 after_success:
-  - ./ci/travis/cover.sh
+  - ./ci/travis/cover.sh || true
 
 deploy:
   - provider: script
     skip_cleanup: true
-    script: ./ci/travis/cover.sh
+    script: ./ci/travis/cover.sh || true
     on:
       branch: master
       condition: $TRAVIS_EVENT_TYPE != "cron"


### PR DESCRIPTION
As suggested in https://github.com/PyO3/pyo3/issues/439#issuecomment-498853201, a failure in the coverage script should not cause the whole build to
fail.

#439