### PR TITLE
Refactor according to #[warn(bare_trait_objects)]

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -20,8 +20,8 @@ use std::os::raw::c_char;
 pub enum PyErrValue {
     None,
     Value(PyObject),
-    ToArgs(Box<PyErrArguments>),
-    ToObject(Box<ToPyObject>),
+    ToArgs(Box<dyn PyErrArguments>),
+    ToObject(Box<dyn ToPyObject>),
 }
 
 /// Represents a Python exception that was raised.

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -123,7 +123,7 @@ struct ReleasePool {
     owned: ArrayList<NonNull<ffi::PyObject>>,
     borrowed: ArrayList<NonNull<ffi::PyObject>>,
     pointers: *mut Vec<NonNull<ffi::PyObject>>,
-    obj: Vec<Box<any::Any>>,
+    obj: Vec<Box<dyn any::Any>>,
     p: spin::Mutex<*mut Vec<NonNull<ffi::PyObject>>>,
 }
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -192,7 +192,7 @@ impl PyModule {
     /// ```rust,ignore
     /// m.add("also_double", wrap_pyfunction!(double)(py));
     /// ```
-    pub fn add_wrapped(&self, wrapper: &Fn(Python) -> PyObject) -> PyResult<()> {
+    pub fn add_wrapped(&self, wrapper: &impl Fn(Python) -> PyObject) -> PyResult<()> {
         let function = wrapper(self.py());
         let name = function
             .getattr(self.py(), "__name__")

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -49,7 +49,7 @@ fn len() {
 
 #[pyclass]
 struct Iterator {
-    iter: Box<iter::Iterator<Item = i32> + Send>,
+    iter: Box<dyn iter::Iterator<Item = i32> + Send>,
 }
 
 #[pyproto]


### PR DESCRIPTION
The latest nightly compiler raises warnings for `Box<Trait>` patterns.
So I fixed them mostly by adding `dyn`, except `add_wrapped` that I modified to take `&impl Fn` as its argument.
