### PR TITLE
Expose py_run! macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
  * `module` argument to `pyclass` macro. [#499](https://github.com/PyO3/pyo3/pull/499)
+ * `py_run!` macro [#512](https://github.com/PyO3/pyo3/pull/512)
 
+### Fixed
+
+ * More readable error message for generics in pyclass [#503](https://github.com/PyO3/pyo3/pull/503)
+
+### Changed
 
 ## [0.7.0] - 2018-05-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,11 +25,11 @@ num-traits = "0.2.6"
 pyo3cls = { path = "pyo3cls", version = "=0.7.0" }
 mashup = "0.1.9"
 num-complex = { version = "0.2.1", optional = true }
+indoc = "0.3.3"
 inventory = "0.1.3"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
-indoc = "0.3.3"
 trybuild = "1.0"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ num-traits = "0.2.6"
 pyo3cls = { path = "pyo3cls", version = "=0.7.0" }
 mashup = "0.1.9"
 num-complex = { version = "0.2.1", optional = true }
-indoc = "0.3.3"
 inventory = "0.1.3"
+indoc = "0.3.3"
+unindent = "0.1.3"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,48 +2,10 @@
 //!  - Tests are run in parallel; There's still a race condition in test_owned with some other test
 //!  - You need to use flush=True to get any output from print
 
-/// Removes indentation from multiline strings in pyrun commands
-#[allow(unused)] // macro scoping is fooling the compiler
-pub fn indoc(commands: &str) -> String {
-    let indent;
-    if let Some(second) = commands.lines().nth(1) {
-        indent = second
-            .chars()
-            .take_while(char::is_ascii_whitespace)
-            .collect::<String>();
-    } else {
-        indent = "".to_string();
-    }
-
-    commands
-        .trim_end()
-        .replace(&("\n".to_string() + &indent), "\n")
-        + "\n"
-}
-
-#[macro_export]
-macro_rules! py_run {
-    ($py:expr, $val:expr, $code:expr) => {{
-        use pyo3::types::IntoPyDict;
-        let d = [(stringify!($val), &$val)].into_py_dict($py);
-
-        $py.run(&common::indoc($code), None, Some(d))
-            .map_err(|e| {
-                e.print($py);
-                // So when this c api function the last line called printed the error to stderr,
-                // the output is only written into a buffer which is never flushed because we
-                // panic before flushing. This is where this hack comes into place
-                $py.run("import sys; sys.stderr.flush()", None, None)
-                    .unwrap();
-            })
-            .expect(&common::indoc($code))
-    }};
-}
-
 #[macro_export]
 macro_rules! py_assert {
     ($py:expr, $val:ident, $assertion:expr) => {
-        py_run!($py, $val, concat!("assert ", $assertion))
+        pyo3::py_run!($py, $val, concat!("assert ", $assertion))
     };
 }
 

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -1,9 +1,9 @@
 use pyo3::class::basic::CompareOp;
 use pyo3::class::*;
 use pyo3::prelude::*;
+use pyo3::py_run;
 use pyo3::types::PyAny;
 
-#[macro_use]
 mod common;
 
 #[pyclass]

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
+use pyo3::py_run;
 use pyo3::type_object::initialize_type;
 
-#[macro_use]
 mod common;
 
 #[pyclass]

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -6,11 +6,11 @@ use pyo3::class::{
 use pyo3::exceptions::{IndexError, ValueError};
 use pyo3::ffi;
 use pyo3::prelude::*;
+use pyo3::py_run;
 use pyo3::types::{IntoPyDict, PyAny, PyBytes, PySlice, PyType};
 use pyo3::AsPyPointer;
 use std::{isize, iter};
 
-#[macro_use]
 mod common;
 
 #[pyclass]

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -3,6 +3,7 @@ use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
 use pyo3::ffi;
 use pyo3::prelude::*;
+use pyo3::py_run;
 use pyo3::types::PyAny;
 use pyo3::types::PyTuple;
 use pyo3::AsPyPointer;
@@ -11,7 +12,6 @@ use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-#[macro_use]
 mod common;
 
 #[pyclass(freelist = 2)]

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -1,8 +1,8 @@
 use pyo3::prelude::*;
+use pyo3::py_run;
 use pyo3::types::IntoPyDict;
 use std::isize;
 
-#[macro_use]
 mod common;
 
 #[pyclass]

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -1,8 +1,8 @@
 use pyo3::prelude::*;
+use pyo3::py_run;
 use pyo3::types::IntoPyDict;
 use std::isize;
 
-#[macro_use]
 mod common;
 
 #[pyclass]

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -1,8 +1,8 @@
 use pyo3::prelude::*;
+use pyo3::py_run;
 use pyo3::types::{IntoPyDict, PyDict, PyList, PySet, PyString, PyTuple, PyType};
 use pyo3::PyRawObject;
 
-#[macro_use]
 mod common;
 
 #[pyclass]

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -2,7 +2,6 @@ use pyo3::prelude::*;
 
 use pyo3::types::IntoPyDict;
 
-#[macro_use]
 mod common;
 
 #[pyclass]

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -5,7 +5,6 @@ use pyo3::types::{PyBytes, PyString};
 use pyo3::PyIterProtocol;
 use std::collections::HashMap;
 
-#[macro_use]
 mod common;
 
 /// Assumes it's a file reader or so.

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -6,9 +6,6 @@ use pyo3::types::IntoPyDict;
 use pyo3::types::PyAny;
 use pyo3::types::PyList;
 
-#[macro_use]
-mod common;
-
 #[pyclass]
 struct ByteSequence {
     elements: Vec<u8>,

--- a/tests/test_variable_arguments.rs
+++ b/tests/test_variable_arguments.rs
@@ -1,7 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 
-#[macro_use]
 mod common;
 
 #[pyclass]

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -2,10 +2,9 @@ use pyo3::prelude::*;
 use pyo3::type_object::initialize_type;
 use pyo3::types::IntoPyDict;
 use pyo3::types::{PyDict, PyTuple};
-use pyo3::wrap_pyfunction;
+use pyo3::{py_run, wrap_pyfunction};
 use std::isize;
 
-#[macro_use]
 mod common;
 
 #[pyclass]


### PR DESCRIPTION
Currently, we have a macro named `py_run` in tests/common.rs.
I think this macro is useful for users (e.g. when testing libraries).

When exposing this macro, I made a modification.
When string literal is passed, we use [indoc](https://github.com/dtolnay/indoc) to generate an indented string in compile time.
In other cases, we do string conversion in runtime.
