### PR TITLE
Add arg=string example in the method arguments section in the guide

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -460,8 +460,8 @@ use pyo3::types::{PyDict, PyTuple};
 #
 #[pymethods]
 impl MyClass {
-    #[args(arg1=true, args="*", arg2=10, kwargs="**")]
-    fn method(&self, arg1: bool, args: &PyTuple, arg2: i32, kwargs: Option<&PyDict>) -> PyResult<i32> {
+    #[args(arg1=true, args="*", arg2=10, args3="\"Hello\"", kwargs="**")]
+    fn method(&self, arg1: bool, args: &PyTuple, arg2: i32, arg3: &str, kwargs: Option<&PyDict>) -> PyResult<i32> {
         Ok(1)
     }
 }


### PR DESCRIPTION
It is not intuitive that we have to use `arg = "\"esaceped str\""` to pass &str as default arguments, though we can use other literals like integer without wrapping by str.
Related to: #514 
