### PR TITLE
Fix deprecation warnings on sync and mem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - name: Minimum nightly
       python: "3.7"
       # Keep this synced up with build.rs
-      env: TRAVIS_RUST_VERSION=nightly-2019-02-07
+      env: TRAVIS_RUST_VERSION=nightly-2019-06-22
       # Tested via anaconda PyPy (since travis's PyPy version is too old)
     - name: PyPy3.5 7.0
       python: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
   - source ./ci/travis/setup.sh
 
 install:
-  - pip install setuptools-rust pytest pytest-benchmark tox tox-venv
+  - pip install setuptools-rust pytest pytest-benchmark tox
 
 script:
   - ./ci/travis/test.sh

--- a/build.rs
+++ b/build.rs
@@ -16,8 +16,8 @@ use version_check::{is_min_date, is_min_version, supports_features};
 /// Specifies the minimum nightly version needed to compile pyo3.
 /// Keep this synced up with the travis ci config,
 /// But note that this is the rustc version which can be lower than the nightly version
-const MIN_DATE: &'static str = "2019-02-06";
-const MIN_VERSION: &'static str = "1.34.0-nightly";
+const MIN_DATE: &'static str = "2019-06-21";
+const MIN_VERSION: &'static str = "1.37.0-nightly";
 
 /// Information returned from python interpreter
 #[derive(Deserialize, Debug)]

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -9,8 +9,8 @@ use spin;
 use std::ptr::NonNull;
 use std::{any, marker, rc, sync};
 
-static START: sync::Once = sync::ONCE_INIT;
-static START_PYO3: sync::Once = sync::ONCE_INIT;
+static START: sync::Once = sync::Once::new();
+static START_PYO3: sync::Once = sync::Once::new();
 
 /// Prepares the use of Python in a free-threaded context.
 ///
@@ -301,7 +301,8 @@ mod array_list {
         pub fn push_back(&mut self, item: T) -> &T {
             let next_idx = self.next_idx();
             if next_idx == 0 {
-                self.inner.push_back(unsafe { mem::uninitialized() });
+                self.inner
+                    .push_back(unsafe { mem::MaybeUninit::uninit().assume_init() });
             }
             self.inner.back_mut().unwrap()[next_idx] = item;
             self.length += 1;

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -10,7 +10,7 @@ use crate::AsPyPointer;
 use crate::IntoPyPointer;
 use crate::Python;
 use crate::{IntoPyObject, ToBorrowedObject, ToPyObject};
-use std::{cmp, collections, hash, mem};
+use std::{cmp, collections, hash};
 
 /// Represents a Python `dict`.
 #[repr(transparent)]
@@ -172,8 +172,8 @@ impl<'py> Iterator for PyDictIterator<'py> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         unsafe {
-            let mut key: *mut ffi::PyObject = mem::uninitialized();
-            let mut value: *mut ffi::PyObject = mem::uninitialized();
+            let mut key: *mut ffi::PyObject = std::ptr::null_mut();
+            let mut value: *mut ffi::PyObject = std::ptr::null_mut();
             if ffi::PyDict_Next(self.dict.as_ptr(), &mut self.pos, &mut key, &mut value) != 0 {
                 let py = self.py;
                 Some((py.from_borrowed_ptr(key), py.from_borrowed_ptr(value)))

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -12,7 +12,7 @@ use crate::AsPyPointer;
 use crate::Python;
 use std::borrow::Cow;
 use std::os::raw::c_char;
-use std::{mem, str};
+use std::str;
 
 /// Represents a Python `string`.
 #[repr(transparent)]
@@ -56,7 +56,7 @@ impl PyString {
     #[inline]
     pub fn as_bytes(&self) -> &[u8] {
         unsafe {
-            let mut size: ffi::Py_ssize_t = mem::uninitialized();
+            let mut size: ffi::Py_ssize_t = 0;
             let data = ffi::PyUnicode_AsUTF8AndSize(self.0.as_ptr(), &mut size) as *const u8;
             // PyUnicode_AsUTF8AndSize would return null if the pointer did not reference a valid
             // unicode object, but because we have a valid PyString, assume success


### PR DESCRIPTION
```
warning: use of deprecated item 'std::sync::ONCE_INIT': the `new` function is now preferred
  --> src/gil.rs:12:28
   |
12 | static START: sync::Once = sync::ONCE_INIT;
   |                            ^^^^^^^^^^^^^^^ help: replace the use of the deprecated item: `Once::new()`
   |
   = note: #[warn(deprecated)] on by default

...

warning: use of deprecated item 'std::mem::uninitialized': use `mem::MaybeUninit` instead
   --> src/gil.rs:304:47
    |
304 |                 self.inner.push_back(unsafe { mem::uninitialized() });
    |                                               ^^^^^^^^^^^^^^^^^^

...
```