### PR TITLE
Implement PyGCProtocol in test class

### DIFF
--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -180,15 +180,19 @@ fn gc_integration() {
 #[pyclass(gc)]
 struct GCIntegration2 {}
 
+#[pyproto]
+impl PyGCProtocol for GCIntegration2 {
+    fn __traverse__(&self, _visit: PyVisit) -> Result<(), PyTraverseError> {
+        Ok(())
+    }
+}
+
 #[test]
 fn gc_integration2() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    // Temporarily disable pythons garbage collector to avoid a race condition
-    py.run("import gc; gc.disable()", None, None).unwrap();
     let inst = PyRef::new(py, GCIntegration2 {}).unwrap();
-    py_run!(py, inst, "assert inst in gc.get_objects()");
-    py.run("gc.enable()", None, None).unwrap();
+    py_run!(py, inst, "import gc; assert inst in gc.get_objects()");
 }
 
 #[pyclass(weakref)]


### PR DESCRIPTION
For the garbage collection to work the PyGCProtocol has to be
implemented. Ideally it should not even get compiled if it doesn't since
a missing tp_traverse can produce a segfault.

Issues #323 #395