### PR TITLE
Enforce GC contract at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+ * Implementing the Using the `gc` parameter for `pyclass` (e.g. `#[pyclass(gc)]`) without implementing the `class::PyGCProtocol` trait is now a compile-time error. Failing to implement this trait could lead to segfaults. [#532](https://github.com/PyO3/pyo3/pull/532)
+
 ## [0.7.0] - 2018-05-26
 
 ### Added

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -573,9 +573,16 @@ impl PyGCProtocol for ClassWithGCSupport {
 
 Special protocol trait implementations have to be annotated with the `#[pyproto]` attribute.
 
-It is also possible to enable GC for custom class using the `gc` parameter of the `pyclass` attribute.
+It is also possible to enable GC for custom classes using the `gc` parameter of the `pyclass` attribute.
 i.e. `#[pyclass(gc)]`. In that case instances of custom class participate in Python garbage
-collection, and it is possible to track them with `gc` module methods.
+collection, and it is possible to track them with `gc` module methods. When using the `gc` parameter,
+it is *required* to implement the `PyGCProtocol` trait, failure to do so will result in an error
+at compile time:
+
+```compile_fail
+#[pyclass(gc)]
+struct GCTracked {} // Fails because it does not implement PyGCProtocol
+```
 
 ### Iterator Types
 


### PR DESCRIPTION
PyGCProtocol must be implemented for anything registered as tracked by the garbage collector. This modifies the `pyclass` macro to enforce this at compile time.