### PR TITLE
Remove default implementation for PyGCProtocol

### DIFF
--- a/src/class/gc.rs
+++ b/src/class/gc.rs
@@ -15,13 +15,8 @@ pub struct PyTraverseError(c_int);
 /// GC support
 #[allow(unused_variables)]
 pub trait PyGCProtocol<'p>: PyTypeInfo {
-    fn __traverse__(&'p self, visit: PyVisit) -> Result<(), PyTraverseError> {
-        unimplemented!()
-    }
-
-    fn __clear__(&'p mut self) {
-        unimplemented!()
-    }
+    fn __traverse__(&'p self, visit: PyVisit) -> Result<(), PyTraverseError>;
+    fn __clear__(&'p mut self);
 }
 
 pub trait PyGCTraverseProtocol<'p>: PyGCProtocol<'p> {}

--- a/src/class/gc.rs
+++ b/src/class/gc.rs
@@ -13,7 +13,6 @@ use std::os::raw::{c_int, c_void};
 pub struct PyTraverseError(c_int);
 
 /// GC support
-#[allow(unused_variables)]
 pub trait PyGCProtocol<'p>: PyTypeInfo {
     fn __traverse__(&'p self, visit: PyVisit) -> Result<(), PyTraverseError>;
     fn __clear__(&'p mut self);

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -185,6 +185,7 @@ impl PyGCProtocol for GCIntegration2 {
     fn __traverse__(&self, _visit: PyVisit) -> Result<(), PyTraverseError> {
         Ok(())
     }
+    fn __clear__(&mut self) {}
 }
 
 #[test]


### PR DESCRIPTION
Implementations for these methods should always be provided. See #531