### PR TITLE
Turn off codecov PR comments and remove badge from readme

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment: off
+


### PR DESCRIPTION
Coverage will still be collected and the coverage change should still be shown in the status checks.

See https://docs.codecov.io/docs/pull-request-comments#section-disable-comment