### PR TITLE
Make CI fail on clippy warnings

### DIFF
--- a/ci/travis/test.sh
+++ b/ci/travis/test.sh
@@ -12,7 +12,7 @@ fi
 
 if [ "$TRAVIS_JOB_NAME" = "Minimum nightly" ]; then
     cargo fmt --all -- --check
-    cargo clippy --features "$FEATURES num-complex"
+    cargo clippy --features "$FEATURES num-complex" -- -D warnings
 fi
 
 for example_dir in examples/*; do

--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -47,10 +47,10 @@ pub fn build_py_proto(ast: &mut syn::ItemImpl) -> syn::Result<TokenStream> {
 
         Ok(tokens)
     } else {
-        return Err(syn::Error::new_spanned(
+        Err(syn::Error::new_spanned(
             ast,
             "#[pyproto] can only be used with protocol trait implementations",
-        ));
+        ))
     }
 }
 

--- a/src/class/basic.rs
+++ b/src/class/basic.rs
@@ -221,7 +221,7 @@ where
             // Behave like python's __getattr__ (as opposed to __getattribute__) and check
             // for existing fields and methods first
             let existing = ffi::PyObject_GenericGetAttr(slf, arg);
-            if existing == std::ptr::null_mut() {
+            if existing.is_null() {
                 // PyObject_HasAttr also tries to get an object and clears the error if it fails
                 ffi::PyErr_Clear();
             } else {
@@ -233,7 +233,7 @@ where
 
             let result = match arg.extract() {
                 Ok(arg) => slf.__getattr__(arg).into(),
-                Err(e) => Err(e.into()),
+                Err(e) => Err(e),
             };
             crate::callback::cb_convert(PyObjectCallbackConverter, py, result)
         }

--- a/src/python.rs
+++ b/src/python.rs
@@ -234,6 +234,7 @@ impl<'p> Python<'p> {
     }
 
     /// Register `ffi::PyObject` pointer in release pool
+    #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_borrowed_ptr_to_obj(self, ptr: *mut ffi::PyObject) -> &'p PyAny {
         match NonNull::new(ptr) {
             Some(p) => gil::register_borrowed(self, p),
@@ -243,6 +244,7 @@ impl<'p> Python<'p> {
 
     /// Register `ffi::PyObject` pointer in release pool,
     /// and do unchecked downcast to specific type.
+    #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_owned_ptr<T>(self, ptr: *mut ffi::PyObject) -> &'p T
     where
         T: PyTypeInfo,
@@ -262,6 +264,7 @@ impl<'p> Python<'p> {
     /// Register owned `ffi::PyObject` pointer in release pool.
     /// Returns `Err(PyErr)` if the pointer is `null`.
     /// do unchecked downcast to specific type.
+    #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_owned_ptr_or_err<T>(self, ptr: *mut ffi::PyObject) -> PyResult<&'p T>
     where
         T: PyTypeInfo,
@@ -272,6 +275,7 @@ impl<'p> Python<'p> {
     /// Register owned `ffi::PyObject` pointer in release pool.
     /// Returns `None` if the pointer is `null`.
     /// do unchecked downcast to specific type.
+    #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_owned_ptr_or_opt<T>(self, ptr: *mut ffi::PyObject) -> Option<&'p T>
     where
         T: PyTypeInfo,
@@ -282,6 +286,7 @@ impl<'p> Python<'p> {
     /// Register borrowed `ffi::PyObject` pointer in release pool.
     /// Panics if the pointer is `null`.
     /// do unchecked downcast to specific type.
+    #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_borrowed_ptr<T>(self, ptr: *mut ffi::PyObject) -> &'p T
     where
         T: PyTypeInfo,
@@ -302,6 +307,7 @@ impl<'p> Python<'p> {
     /// Register borrowed `ffi::PyObject` pointer in release pool.
     /// Returns `Err(PyErr)` if the pointer is `null`.
     /// do unchecked downcast to specific type.
+    #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_borrowed_ptr_or_err<T>(self, ptr: *mut ffi::PyObject) -> PyResult<&'p T>
     where
         T: PyTypeInfo,
@@ -312,6 +318,7 @@ impl<'p> Python<'p> {
     /// Register borrowed `ffi::PyObject` pointer in release pool.
     /// Returns `None` if the pointer is `null`.
     /// do unchecked downcast to specific `T`.
+    #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_borrowed_ptr_or_opt<T>(self, ptr: *mut ffi::PyObject) -> Option<&'p T>
     where
         T: PyTypeInfo,

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -21,10 +21,7 @@ pyobject_native_type!(PyTuple, ffi::PyTuple_Type, ffi::PyTuple_Check);
 
 impl PyTuple {
     /// Construct a new tuple with the given elements.
-    pub fn new<'p, T, U>(
-        py: Python<'p>,
-        elements: impl IntoIterator<Item = T, IntoIter = U>,
-    ) -> &'p PyTuple
+    pub fn new<T, U>(py: Python, elements: impl IntoIterator<Item = T, IntoIter = U>) -> &PyTuple
     where
         T: ToPyObject,
         U: ExactSizeIterator<Item = T>,
@@ -41,7 +38,7 @@ impl PyTuple {
     }
 
     /// Retrieves the empty tuple.
-    pub fn empty<'p>(py: Python<'p>) -> &'p PyTuple {
+    pub fn empty(py: Python) -> &PyTuple {
         unsafe { py.from_owned_ptr(ffi::PyTuple_New(0)) }
     }
 


### PR DESCRIPTION
Fix or ignore all current clippy warnings and let the CI fail if in the future if there are warnings.