### PR TITLE
Attempting to fix #549

### DIFF
--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -1271,7 +1271,7 @@ where
     }
 }
 
-trait PyNumberRAddProtocolImpl {
+pub trait PyNumberRAddProtocolImpl {
     fn __radd__() -> Option<PyMethodDef> {
         None
     }
@@ -1279,7 +1279,7 @@ trait PyNumberRAddProtocolImpl {
 
 impl<'p, T> PyNumberRAddProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRSubProtocolImpl {
+pub trait PyNumberRSubProtocolImpl {
     fn __rsub__() -> Option<PyMethodDef> {
         None
     }
@@ -1287,7 +1287,7 @@ trait PyNumberRSubProtocolImpl {
 
 impl<'p, T> PyNumberRSubProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRMulProtocolImpl {
+pub trait PyNumberRMulProtocolImpl {
     fn __rmul__() -> Option<PyMethodDef> {
         None
     }
@@ -1295,7 +1295,7 @@ trait PyNumberRMulProtocolImpl {
 
 impl<'p, T> PyNumberRMulProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRMatmulProtocolImpl {
+pub trait PyNumberRMatmulProtocolImpl {
     fn __rmatmul__() -> Option<PyMethodDef> {
         None
     }
@@ -1303,7 +1303,7 @@ trait PyNumberRMatmulProtocolImpl {
 
 impl<'p, T> PyNumberRMatmulProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRTruedivProtocolImpl {
+pub trait PyNumberRTruedivProtocolImpl {
     fn __rtruediv__() -> Option<PyMethodDef> {
         None
     }
@@ -1311,7 +1311,7 @@ trait PyNumberRTruedivProtocolImpl {
 
 impl<'p, T> PyNumberRTruedivProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRFloordivProtocolImpl {
+pub trait PyNumberRFloordivProtocolImpl {
     fn __rfloordiv__() -> Option<PyMethodDef> {
         None
     }
@@ -1319,7 +1319,7 @@ trait PyNumberRFloordivProtocolImpl {
 
 impl<'p, T> PyNumberRFloordivProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRModProtocolImpl {
+pub trait PyNumberRModProtocolImpl {
     fn __rmod__() -> Option<PyMethodDef> {
         None
     }
@@ -1327,7 +1327,7 @@ trait PyNumberRModProtocolImpl {
 
 impl<'p, T> PyNumberRModProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRDivmodProtocolImpl {
+pub trait PyNumberRDivmodProtocolImpl {
     fn __rdivmod__() -> Option<PyMethodDef> {
         None
     }
@@ -1335,7 +1335,7 @@ trait PyNumberRDivmodProtocolImpl {
 
 impl<'p, T> PyNumberRDivmodProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRPowProtocolImpl {
+pub trait PyNumberRPowProtocolImpl {
     fn __rpow__() -> Option<PyMethodDef> {
         None
     }
@@ -1343,7 +1343,7 @@ trait PyNumberRPowProtocolImpl {
 
 impl<'p, T> PyNumberRPowProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRLShiftProtocolImpl {
+pub trait PyNumberRLShiftProtocolImpl {
     fn __rlshift__() -> Option<PyMethodDef> {
         None
     }
@@ -1351,7 +1351,7 @@ trait PyNumberRLShiftProtocolImpl {
 
 impl<'p, T> PyNumberRLShiftProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRRShiftProtocolImpl {
+pub trait PyNumberRRShiftProtocolImpl {
     fn __rrshift__() -> Option<PyMethodDef> {
         None
     }
@@ -1359,7 +1359,7 @@ trait PyNumberRRShiftProtocolImpl {
 
 impl<'p, T> PyNumberRRShiftProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRAndProtocolImpl {
+pub trait PyNumberRAndProtocolImpl {
     fn __rand__() -> Option<PyMethodDef> {
         None
     }
@@ -1367,7 +1367,7 @@ trait PyNumberRAndProtocolImpl {
 
 impl<'p, T> PyNumberRAndProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberRXorProtocolImpl {
+pub trait PyNumberRXorProtocolImpl {
     fn __rxor__() -> Option<PyMethodDef> {
         None
     }
@@ -1375,7 +1375,7 @@ trait PyNumberRXorProtocolImpl {
 
 impl<'p, T> PyNumberRXorProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
-trait PyNumberROrProtocolImpl {
+pub trait PyNumberROrProtocolImpl {
     fn __ror__() -> Option<PyMethodDef> {
         None
     }

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -1271,6 +1271,7 @@ where
     }
 }
 
+#[doc(hidden)]
 pub trait PyNumberRAddProtocolImpl {
     fn __radd__() -> Option<PyMethodDef> {
         None
@@ -1279,6 +1280,7 @@ pub trait PyNumberRAddProtocolImpl {
 
 impl<'p, T> PyNumberRAddProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRSubProtocolImpl {
     fn __rsub__() -> Option<PyMethodDef> {
         None
@@ -1287,6 +1289,7 @@ pub trait PyNumberRSubProtocolImpl {
 
 impl<'p, T> PyNumberRSubProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRMulProtocolImpl {
     fn __rmul__() -> Option<PyMethodDef> {
         None
@@ -1295,6 +1298,7 @@ pub trait PyNumberRMulProtocolImpl {
 
 impl<'p, T> PyNumberRMulProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRMatmulProtocolImpl {
     fn __rmatmul__() -> Option<PyMethodDef> {
         None
@@ -1303,6 +1307,7 @@ pub trait PyNumberRMatmulProtocolImpl {
 
 impl<'p, T> PyNumberRMatmulProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRTruedivProtocolImpl {
     fn __rtruediv__() -> Option<PyMethodDef> {
         None
@@ -1311,6 +1316,7 @@ pub trait PyNumberRTruedivProtocolImpl {
 
 impl<'p, T> PyNumberRTruedivProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRFloordivProtocolImpl {
     fn __rfloordiv__() -> Option<PyMethodDef> {
         None
@@ -1319,6 +1325,7 @@ pub trait PyNumberRFloordivProtocolImpl {
 
 impl<'p, T> PyNumberRFloordivProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRModProtocolImpl {
     fn __rmod__() -> Option<PyMethodDef> {
         None
@@ -1327,6 +1334,7 @@ pub trait PyNumberRModProtocolImpl {
 
 impl<'p, T> PyNumberRModProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRDivmodProtocolImpl {
     fn __rdivmod__() -> Option<PyMethodDef> {
         None
@@ -1335,6 +1343,7 @@ pub trait PyNumberRDivmodProtocolImpl {
 
 impl<'p, T> PyNumberRDivmodProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRPowProtocolImpl {
     fn __rpow__() -> Option<PyMethodDef> {
         None
@@ -1343,6 +1352,7 @@ pub trait PyNumberRPowProtocolImpl {
 
 impl<'p, T> PyNumberRPowProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRLShiftProtocolImpl {
     fn __rlshift__() -> Option<PyMethodDef> {
         None
@@ -1351,6 +1361,7 @@ pub trait PyNumberRLShiftProtocolImpl {
 
 impl<'p, T> PyNumberRLShiftProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRRShiftProtocolImpl {
     fn __rrshift__() -> Option<PyMethodDef> {
         None
@@ -1359,6 +1370,7 @@ pub trait PyNumberRRShiftProtocolImpl {
 
 impl<'p, T> PyNumberRRShiftProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRAndProtocolImpl {
     fn __rand__() -> Option<PyMethodDef> {
         None
@@ -1367,6 +1379,7 @@ pub trait PyNumberRAndProtocolImpl {
 
 impl<'p, T> PyNumberRAndProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberRXorProtocolImpl {
     fn __rxor__() -> Option<PyMethodDef> {
         None
@@ -1375,6 +1388,7 @@ pub trait PyNumberRXorProtocolImpl {
 
 impl<'p, T> PyNumberRXorProtocolImpl for T where T: PyNumberProtocol<'p> {}
 
+#[doc(hidden)]
 pub trait PyNumberROrProtocolImpl {
     fn __ror__() -> Option<PyMethodDef> {
         None

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -205,7 +205,9 @@ fn rhs_arithmetic() {
 
     let c = Py::new(py, RhsArithmetic {}).unwrap();
     py_run!(py, c, "assert c.__radd__(1) == '1 + RA'");
-    py_run!(py, c, "assert 1 + c == '1 + RA'");
+    // TODO: commented out for now until reflected arithemtics gets fixed.
+    // see discussion here: https://github.com/PyO3/pyo3/pull/550
+    // py_run!(py, c, "assert 1 + c == '1 + RA'");
 }
 
 #[pyclass]

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -1,3 +1,5 @@
+#![feature(specialization)]
+
 use pyo3::class::basic::CompareOp;
 use pyo3::class::*;
 use pyo3::prelude::*;
@@ -184,6 +186,26 @@ fn binary_arithmetic() {
     py_run!(py, c, "assert 1 ^ c == '1 ^ BA'");
     py_run!(py, c, "assert c | 1 == 'BA | 1'");
     py_run!(py, c, "assert 1 | c == '1 | BA'");
+}
+
+#[pyclass]
+struct RhsArithmetic {}
+
+#[pyproto]
+impl PyNumberProtocol for RhsArithmetic {
+    fn __radd__(&self, other: &PyAny) -> PyResult<String> {
+        Ok(format!("{:?} + RA", other))
+    }
+}
+
+#[test]
+fn rhs_arithmetic() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let c = Py::new(py, RhsArithmetic {}).unwrap();
+    py_run!(py, c, "assert c.__radd__(1) == '1 + RA'");
+    py_run!(py, c, "assert 1 + c == '1 + RA'");
 }
 
 #[pyclass]


### PR DESCRIPTION
Attempting to fix https://github.com/PyO3/pyo3/issues/549

Now code that implements `__radd__`, etc compiles, but when tested in python, they are not getting called... instead it seems some default implementations that return `NotImplemented` is executed. It would be great if maintainers could point me towards the right direction.

Thanks!