### PR TITLE
Poc dunder without specialization

### DIFF
--- a/examples/rustapi_module/setup.py
+++ b/examples/rustapi_module/setup.py
@@ -102,6 +102,11 @@ setup(
             "Cargo.toml",
             rustc_flags=get_py_version_cfgs(),
         ),
+        RustExtension(
+            "rustapi_module.dunder",
+            "Cargo.toml",
+            rustc_flags=get_py_version_cfgs(),
+        ),
     ],
     install_requires=install_requires,
     tests_require=tests_require,

--- a/examples/rustapi_module/src/dunder.rs
+++ b/examples/rustapi_module/src/dunder.rs
@@ -1,0 +1,25 @@
+use pyo3::prelude::*;
+
+#[pymodule]
+fn dunder(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_class::<Number>()?;
+    Ok(())
+}
+
+#[pyclass]
+pub struct Number {
+    value: u32,
+}
+
+#[pymethods]
+impl Number {
+    #[new]
+    fn new(obj: &PyRawObject, value: u32) {
+        obj.init(Number { value })
+    }
+
+    /// Very basic add function
+    fn __add__(&self, other: u32) -> PyResult<u32> {
+        Ok(self.value + other)
+    }
+}

--- a/examples/rustapi_module/src/lib.rs
+++ b/examples/rustapi_module/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod datetime;
 pub mod dict_iter;
+pub mod dunder;
 pub mod othermod;
 pub mod subclassing;

--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -8,7 +8,6 @@ from hypothesis import given, example
 from hypothesis import strategies as st
 from hypothesis.strategies import dates, datetimes
 
-
 # Constants
 def _get_utc():
     timezone = getattr(pdt, "timezone", None)

--- a/examples/rustapi_module/tests/test_dunder.py
+++ b/examples/rustapi_module/tests/test_dunder.py
@@ -1,0 +1,5 @@
+import rustapi_module.dunder
+
+
+def test_add():
+    assert rustapi_module.dunder.Number(10) + 20 == 30

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -217,6 +217,8 @@ fn impl_inventory(cls: &syn::Ident) -> TokenStream {
     // it comes up in error messages
     let name = cls.to_string() + "GeneratedPyo3Inventory";
     let inventory_cls = syn::Ident::new(&name, Span::call_site());
+    let protocol_name = cls.to_string() + "GeneratedPyo3InventoryProtocol";
+    let protocol_inventory_cls = syn::Ident::new(&protocol_name, Span::call_site());
 
     quote! {
         #[doc(hidden)]
@@ -241,6 +243,31 @@ fn impl_inventory(cls: &syn::Ident) -> TokenStream {
         }
 
         pyo3::inventory::collect!(#inventory_cls);
+
+        // Dunder methods/Protocol support
+
+        #[doc(hidden)]
+        pub struct #protocol_inventory_cls {
+            methods: &'static [pyo3::methods::protocols::PyProcotolMethodWrapped],
+        }
+
+        impl pyo3::class::methods::protocols::PyProtocolInventory for #protocol_inventory_cls {
+            fn new(methods: &'static [pyo3::methods::protocols::PyProcotolMethodWrapped]) -> Self {
+                Self {
+                    methods
+                }
+            }
+
+            fn get_methods(&self) -> &'static [pyo3::methods::protocols::PyProcotolMethodWrapped] {
+                self.methods
+            }
+        }
+
+        impl pyo3::class::methods::protocols::PyProtocolInventoryDispatch for #cls {
+            type ProtocolInventoryType = #protocol_inventory_cls;
+        }
+
+        pyo3::inventory::collect!(#protocol_inventory_cls);
     }
 }
 

--- a/pyo3-derive-backend/src/pyimpl.rs
+++ b/pyo3-derive-backend/src/pyimpl.rs
@@ -20,12 +20,60 @@ pub fn build_py_methods(ast: &mut syn::ItemImpl) -> syn::Result<TokenStream> {
     }
 }
 
+fn binary_func_protocol_wrap(ty: &syn::Type, name: &syn::Ident) -> TokenStream {
+    quote! {{
+        #[allow(unused_mut)]
+        unsafe extern "C" fn wrap(
+            lhs: *mut pyo3::ffi::PyObject,
+            rhs: *mut pyo3::ffi::PyObject,
+        ) -> *mut pyo3::ffi::PyObject {
+            use pyo3::ObjectProtocol;
+            let _pool = pyo3::GILPool::new();
+            let py = pyo3::Python::assume_gil_acquired();
+            let lhs = py.from_borrowed_ptr::<pyo3::types::PyAny>(lhs);
+            let rhs = py.from_borrowed_ptr::<pyo3::types::PyAny>(rhs);
+
+            let result = match lhs.extract() {
+                Ok(lhs) => match rhs.extract() {
+                    Ok(rhs) => #ty::#name(lhs, rhs).into(),
+                    Err(e) => Err(e.into()),
+                },
+                Err(e) => Err(e.into()),
+            };
+            pyo3::callback::cb_convert(pyo3::callback::PyObjectCallbackConverter, py, result)
+        }
+        pyo3::class::methods::protocols::PyProcotolMethodWrapped::Add(wrap)
+    }}
+}
+
 pub fn impl_methods(ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> syn::Result<TokenStream> {
     // get method names in impl block
     let mut methods = Vec::new();
+    let mut protocol_methods = Vec::new();
     for iimpl in impls.iter_mut() {
         if let syn::ImplItem::Method(ref mut meth) = iimpl {
             let name = meth.sig.ident.clone();
+
+            if name.to_string().starts_with("__") && name.to_string().ends_with("__") {
+                #[allow(clippy::single_match)]
+                {
+                    match name.to_string().as_str() {
+                        "__add__" => {
+                            protocol_methods.push(binary_func_protocol_wrap(&ty, &name));
+                        }
+                        _ => {
+                            // This currently breaks the tests
+                            /*
+                                return Err(syn::Error::new_spanned(
+                                    meth.sig.ident.clone(),
+                                    "Unknown dunder method",
+                                ))
+                            */
+                        }
+                    }
+                }
+            }
+
             methods.push(pymethod::gen_py_method(
                 ty,
                 &name,
@@ -36,10 +84,17 @@ pub fn impl_methods(ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> syn::Resu
     }
 
     Ok(quote! {
-       pyo3::inventory::submit! {
+        pyo3::inventory::submit! {
             #![crate = pyo3] {
                 type TyInventory = <#ty as pyo3::class::methods::PyMethodsInventoryDispatch>::InventoryType;
                 <TyInventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(#methods),*])
+            }
+        }
+
+        pyo3::inventory::submit! {
+            #![crate = pyo3] {
+                type ProtocolInventory = <#ty as pyo3::class::methods::protocols::PyProtocolInventoryDispatch>::ProtocolInventoryType;
+                <ProtocolInventory as pyo3::class::methods::protocols::PyProtocolInventory>::new(&[#(#protocol_methods),*])
             }
         }
     })

--- a/src/ffi3/object.rs
+++ b/src/ffi3/object.rs
@@ -299,7 +299,7 @@ mod typeobject {
     impl Default for PyNumberMethods {
         #[inline]
         fn default() -> Self {
-            unsafe { mem::zeroed() }
+            PyNumberMethods_INIT
         }
     }
     macro_rules! as_expr {

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -2,6 +2,7 @@
 
 //! Python type object information
 
+use crate::class::methods::protocols::PyProtocol;
 use crate::class::methods::PyMethodDefType;
 use crate::err::{PyErr, PyResult};
 use crate::instance::{Py, PyNativeType};
@@ -249,7 +250,7 @@ pub unsafe trait PyTypeObject {
 
 unsafe impl<T> PyTypeObject for T
 where
-    T: PyTypeInfo + PyMethodsProtocol + PyObjectAlloc,
+    T: PyTypeInfo + PyMethodsProtocol + PyObjectAlloc + PyProtocol,
 {
     fn init_type() -> NonNull<ffi::PyTypeObject> {
         let type_object = unsafe { <Self as PyTypeInfo>::type_object() };
@@ -297,7 +298,7 @@ impl<T> PyTypeCreate for T where T: PyObjectAlloc + PyTypeObject + Sized {}
 #[cfg(not(Py_LIMITED_API))]
 pub fn initialize_type<T>(py: Python, module_name: Option<&str>) -> PyResult<*mut ffi::PyTypeObject>
 where
-    T: PyObjectAlloc + PyTypeInfo + PyMethodsProtocol,
+    T: PyObjectAlloc + PyTypeInfo + PyMethodsProtocol + PyProtocol,
 {
     let type_object: &mut ffi::PyTypeObject = unsafe { T::type_object() };
     let base_type_object: &mut ffi::PyTypeObject =
@@ -438,7 +439,7 @@ fn py_class_flags<T: PyTypeInfo>(type_object: &mut ffi::PyTypeObject) {
     }
 }
 
-fn py_class_method_defs<T: PyMethodsProtocol>() -> (
+fn py_class_method_defs<T: PyMethodsProtocol + PyProtocol>() -> (
     Option<ffi::newfunc>,
     Option<ffi::initproc>,
     Option<ffi::PyCFunctionWithKeywords>,


### PR DESCRIPTION
This is a prove of concept to how we can support dunder methods/protocols without specialization using inventory. Currently the only implemented method is `__add__`.

I don't have the time to bring this into a mergeable state or extend it to all dunder methods, so feel free to take this branch as a starting point.