### PR TITLE
Use to_string() instead of description() for exception messages

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -11,7 +11,6 @@ use crate::IntoPyPointer;
 use crate::Python;
 use crate::{IntoPyObject, ToBorrowedObject, ToPyObject};
 use libc::c_int;
-use std::error::Error;
 use std::ffi::CString;
 use std::io;
 use std::os::raw::c_char;
@@ -412,7 +411,7 @@ macro_rules! impl_to_pyerr {
     ($err: ty, $pyexc: ty) => {
         impl PyErrArguments for $err {
             fn arguments(&self, py: Python) -> PyObject {
-                self.description().to_object(py)
+                self.to_string().to_object(py)
             }
         }
 
@@ -459,10 +458,9 @@ impl std::convert::From<io::Error> for PyErr {
     }
 }
 
-/// Extract `errno` and `errdesc` from from `io::Error`
 impl PyErrArguments for io::Error {
     fn arguments(&self, py: Python) -> PyObject {
-        (self.raw_os_error().unwrap_or(0), self.description()).to_object(py)
+        self.to_string().to_object(py)
     }
 }
 
@@ -474,7 +472,7 @@ impl<W: 'static + Send + std::fmt::Debug> std::convert::From<std::io::IntoInnerE
 
 impl<W: Send + std::fmt::Debug> PyErrArguments for std::io::IntoInnerError<W> {
     fn arguments(&self, py: Python) -> PyObject {
-        self.description().to_object(py)
+        self.to_string().to_object(py)
     }
 }
 

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -1,0 +1,28 @@
+use pyo3::prelude::*;
+use pyo3::types::IntoPyDict;
+use pyo3::wrap_pyfunction;
+use std::fs::File;
+
+mod common;
+
+#[pyfunction]
+fn fail_to_open_file() -> PyResult<()> {
+    File::open("not_there.txt")?;
+    Ok(())
+}
+
+#[test]
+fn test_filenotfounderror() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let fail_to_open_file = wrap_pyfunction!(fail_to_open_file)(py);
+    let d = [("fail_to_open_file", fail_to_open_file)].into_py_dict(py);
+    match py.run("fail_to_open_file()", None, Some(d)) {
+        Ok(()) => panic!("Call should raise a FileNotFoundError"),
+        Err(e) => {
+            py_assert!(py, e, "isinstance(e, FileNotFoundError)");
+            py_assert!(py, e, "'No such file or directory (os error 2)' == str(e)");
+        }
+    };
+}


### PR DESCRIPTION
`description()` is soft-deprecated and can differ from `to_string()`.

For example for NotFound error:
* `description()`: "entity not found"
* `to_string()`: "No such file or directory (os error 2)"

Since io errors provide their error code through the Display trait there
is no need to get it through `raw_os_error()`.