### PR TITLE
Add dict-derive to Examples and tooling section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ fn main() -> PyResult<()> {
    * Contains an example of building wheels on Azure Pipelines
  * [fastuuid](https://github.com/thedrow/fastuuid/) _Python bindings to Rust's UUID library_
  * [python-ext-wasm](https://github.com/wasmerio/python-ext-wasm) _Python library to run WebAssembly binaries_
+ * [dict-derive](https://github.com/gperinazzo/dict-derive) _Derive FromPyObject to automatically transform Python dicts into Rust structs_
 
 ## License
 


### PR DESCRIPTION
@konstin, @kngwyu: @gperinazzo asked on [gitter](https://gitter.im/PyO3/Lobby?at=5cfd7245702b7e5e765982b4) if it's ok to use PyO3 in the name.