### PR TITLE
Python3 bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ regex = "1.2.1"
 version_check = "0.9.1"
 serde = { version = "1.0.99", features = ["derive"] }
 serde_json = "1.0.40"
+lazy_static = "1.4"
 
 [features]
 default = []

--- a/build.rs
+++ b/build.rs
@@ -18,6 +18,7 @@ use version_check::{Channel, Date, Version};
 /// But note that this is the rustc version which can be lower than the nightly version
 const MIN_DATE: &'static str = "2019-07-18";
 const MIN_VERSION: &'static str = "1.37.0-nightly";
+const PYTHON_INTERPRETER: &'static str = "python3";
 
 /// Information returned from python interpreter
 #[derive(Deserialize, Debug)]
@@ -357,7 +358,7 @@ elif sysconfig.get_config_var("Py_ENABLE_SHARED"):
 else:
     print("static")
 "#;
-    let out = run_python_script("python", script).unwrap();
+    let out = run_python_script(PYTHON_INTERPRETER, script).unwrap();
     Ok(out.trim_end().to_owned())
 }
 
@@ -425,22 +426,19 @@ fn find_interpreter_and_get_config() -> Result<(InterpreterConfig, HashMap<Strin
     };
 
     // check default python
-    let interpreter_path = "python";
-
-    let interpreter_config = get_config_from_interpreter(interpreter_path)?;
+    let interpreter_config = get_config_from_interpreter(PYTHON_INTERPRETER)?;
     if interpreter_config.version.major == 3 {
         return Ok((
             interpreter_config,
-            fix_config_map(get_config_vars(interpreter_path)?),
+            fix_config_map(get_config_vars(PYTHON_INTERPRETER)?),
         ));
     }
 
-    let major_interpreter_path = "python3";
-    let interpreter_config = get_config_from_interpreter(major_interpreter_path)?;
+    let interpreter_config = get_config_from_interpreter(PYTHON_INTERPRETER)?;
     if interpreter_config.version.major == 3 {
         return Ok((
             interpreter_config,
-            fix_config_map(get_config_vars(major_interpreter_path)?),
+            fix_config_map(get_config_vars(PYTHON_INTERPRETER)?),
         ));
     }
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate lazy_static;
+
 use regex::Regex;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -18,7 +21,18 @@ use version_check::{Channel, Date, Version};
 /// But note that this is the rustc version which can be lower than the nightly version
 const MIN_DATE: &'static str = "2019-07-18";
 const MIN_VERSION: &'static str = "1.37.0-nightly";
-const PYTHON_INTERPRETER: &'static str = "python3";
+//const PYTHON_INTERPRETER: &'static str = "python3";
+
+lazy_static! {
+    static ref PYTHON_INTERPRETER: &'static str = {
+        ["python3", "python"]
+            .iter()
+            .map(|bin| (bin, Command::new(bin).spawn()))
+            .find(|(_, r)| r.is_ok())
+            .map(|(bin, _)| bin)
+            .expect("Python 3.x interpreter not found")
+    };
+}
 
 /// Information returned from python interpreter
 #[derive(Deserialize, Debug)]
@@ -358,7 +372,7 @@ elif sysconfig.get_config_var("Py_ENABLE_SHARED"):
 else:
     print("static")
 "#;
-    let out = run_python_script(PYTHON_INTERPRETER, script).unwrap();
+    let out = run_python_script(&PYTHON_INTERPRETER, script).unwrap();
     Ok(out.trim_end().to_owned())
 }
 
@@ -426,19 +440,19 @@ fn find_interpreter_and_get_config() -> Result<(InterpreterConfig, HashMap<Strin
     };
 
     // check default python
-    let interpreter_config = get_config_from_interpreter(PYTHON_INTERPRETER)?;
+    let interpreter_config = get_config_from_interpreter(&PYTHON_INTERPRETER)?;
     if interpreter_config.version.major == 3 {
         return Ok((
             interpreter_config,
-            fix_config_map(get_config_vars(PYTHON_INTERPRETER)?),
+            fix_config_map(get_config_vars(&PYTHON_INTERPRETER)?),
         ));
     }
 
-    let interpreter_config = get_config_from_interpreter(PYTHON_INTERPRETER)?;
+    let interpreter_config = get_config_from_interpreter(&PYTHON_INTERPRETER)?;
     if interpreter_config.version.major == 3 {
         return Ok((
             interpreter_config,
-            fix_config_map(get_config_vars(PYTHON_INTERPRETER)?),
+            fix_config_map(get_config_vars(&PYTHON_INTERPRETER)?),
         ));
     }
 


### PR DESCRIPTION
Explicitly use the `python3` binary instead of lain `python` to target Python 3.x even on systems where Python 2.x is not installed