### PR TITLE
Fix build script always using `python3` in OSX builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+ * Make sure the right Python interpreter is used in OSX builds. [#604](https://github.com/PyO3/pyo3/pull/604)
+
 ## [0.8.0] - 2018-09-05
 
 ### Added


### PR DESCRIPTION
Hi!

I noticed that when compiling `pyo3` on OSX for a non-standard Python interpreter (such as PyPy), the build script would at some point assume `python` or `python3` to be the name of the interpreter, despite `PYTHON_SYS_EXECUTABLE` being set. This was caused by `get_macos_linkmodel` using the default `PYTHON_INTERPRETER` eventually.


> Thank you for contributing to pyo3!
>  - Run `cargo fmt` (This is checked by travis ci) :white_check_mark: 
>  - Run `cargo clippy` and check there are no hard errors (There are a bunch of existing warnings; This is also checked by travis) :white_check_mark: 
>  - If applicable, add an entry in the changelog. :white_check_mark: 
