### PR TITLE
Add assertions around memory_diff in test_pybuffer_doesnot_leak_memory

### DIFF
--- a/examples/rustapi_module/src/buf_and_str.rs
+++ b/examples/rustapi_module/src/buf_and_str.rs
@@ -13,14 +13,14 @@ impl BytesExtractor {
         obj.init({ BytesExtractor {} });
     }
 
-    pub fn to_vec(&mut self, bytes: &PyBytes) -> PyResult<usize> {
+    pub fn from_bytes(&mut self, bytes: &PyBytes) -> PyResult<usize> {
         let byte_vec: Vec<u8> = bytes.extract().unwrap();
         Ok(byte_vec.len())
     }
 
-    pub fn to_str(&mut self, bytes: &PyString) -> PyResult<usize> {
-        let byte_str: String = bytes.extract().unwrap();
-        Ok(byte_str.len())
+    pub fn from_str(&mut self, string: &PyString) -> PyResult<usize> {
+        let rust_string: String = string.extract().unwrap();
+        Ok(rust_string.len())
     }
 }
 

--- a/examples/rustapi_module/tests/test_buf_and_str.py
+++ b/examples/rustapi_module/tests/test_buf_and_str.py
@@ -34,5 +34,5 @@ def test_pybuffer_doesnot_leak_memory():
         for i in range(N):
             extractor.to_str(message_s)
 
-    memory_diff(to_vec) == 0
-    memory_diff(to_str) == 0
+    assert memory_diff(to_vec) == 0
+    assert memory_diff(to_str) == 0

--- a/examples/rustapi_module/tests/test_buf_and_str.py
+++ b/examples/rustapi_module/tests/test_buf_and_str.py
@@ -26,13 +26,13 @@ def test_pybuffer_doesnot_leak_memory():
     message_b = b'\\(-"-;) Praying that memory leak would not happen..'
     message_s = '\\(-"-;) Praying that memory leak would not happen..'
 
-    def to_vec():
+    def from_bytes():
         for i in range(N):
-            extractor.to_vec(message_b)
+            extractor.from_bytes(message_b)
 
-    def to_str():
+    def from_str():
         for i in range(N):
-            extractor.to_str(message_s)
+            extractor.from_str(message_s)
 
-    assert memory_diff(to_vec) == 0
-    assert memory_diff(to_str) == 0
+    assert memory_diff(from_bytes) == 0
+    assert memory_diff(from_str) == 0


### PR DESCRIPTION
The goal of this CR is to make `test_pybuffer_doesnot_leak_memory` more accurate.
The test was introduced in #598.

As the test was written it would fail only for "logic" issues on the rust side implementation instead of failing in case of memory leaks (as the test name would suggest).

This is caused by the missing `assert` statements on the tests check, which are going to be to be introduced by this CR.
