### PR TITLE
Bump version to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.1]
+
+### Added
+
+ * Conversion between [num-bigint](https://github.com/rust-num/num-bigint) and Python int. [#608](https://github.com/PyO3/pyo3/pull/608)
+
 
 ### Fixed
 
  * Make sure the right Python interpreter is used in OSX builds. [#604](https://github.com/PyO3/pyo3/pull/604)
- * Patch specialization being broken by Rust 1.40 [#614](https://github.com/PyO3/pyo3/issues/614)
+ * Patch specialization being broken by Rust 1.40. [#614](https://github.com/PyO3/pyo3/issues/614)
+ * Fix a segfault around PyErr. [#597](https://github.com/PyO3/pyo3/pull/597)
 
 ## [0.8.0] - 2018-09-05
 
@@ -324,7 +330,8 @@ Yanked
 
 * Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/pyo3/pyo3/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/pyo3/pyo3/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/pyo3/pyo3/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/pyo3/pyo3/compare/v0.5.3...v0.6.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.8.0"
+version = "0.8.1"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -22,7 +22,7 @@ appveyor = { repository = "fafhrd91/pyo3" }
 libc = "0.2.62"
 spin = "0.5.1"
 num-traits = "0.2.8"
-pyo3cls = { path = "pyo3cls", version = "=0.8.0" }
+pyo3cls = { path = "pyo3cls", version = "=0.8.1" }
 num-complex = { version = ">= 0.2", optional = true }
 num-bigint = { version = ">= 0.2", optional = true }
 inventory = "0.1.4"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 * User Guide: [stable](https://pyo3.rs) | [master](https://pyo3.rs/master)
 
-* API Documentation: [stable](https://docs.rs/pyo3/0.8.0/pyo3/) |  [master](https://pyo3.rs/master/doc)
+* API Documentation: [stable](https://docs.rs/pyo3/0.8.1/pyo3/) |  [master](https://pyo3.rs/master/doc)
 
 A comparison with rust-cpython can be found [in the guide](https://pyo3.rs/master/rust_cpython.html).
 
@@ -46,7 +46,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.8.0"
+version = "0.8.1"
 features = ["extension-module"]
 ```
 
@@ -91,7 +91,7 @@ Add `pyo3` to your `Cargo.toml` like this:
 
 ```toml
 [dependencies]
-pyo3 = "0.8.0"
+pyo3 = "0.8.1"
 ```
 
 Example program displaying the value of `sys.version` and the current user name:

--- a/guide/src/advanced.md
+++ b/guide/src/advanced.md
@@ -12,7 +12,7 @@ Currently, [#341](https://github.com/PyO3/pyo3/issues/341) causes `cargo test` t
 
 ```toml
 [dependencies.pyo3]
-version = "0.8.0"
+version = "0.8.1"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -477,7 +477,7 @@ each protocol implementation block has to be annotated with the `#[pyproto]` att
 
 ### Basic object customization
 
-The [`PyObjectProtocol`](https://docs.rs/pyo3/0.8.0/pyo3/class/basic/trait.PyObjectProtocol.html) trait provides several basic customizations.
+The [`PyObjectProtocol`](https://docs.rs/pyo3/0.8.1/pyo3/class/basic/trait.PyObjectProtocol.html) trait provides several basic customizations.
 
 #### Attribute access
 
@@ -531,7 +531,7 @@ Each method corresponds to Python's `self.attr`, `self.attr = value` and `del se
 If your type owns references to other Python objects, you will need to
 integrate with Python's garbage collector so that the GC is aware of
 those references.
-To do this, implement the [`PyGCProtocol`](https://docs.rs/pyo3/0.8.0/pyo3/class/gc/trait.PyGCProtocol.html) trait for your struct.
+To do this, implement the [`PyGCProtocol`](https://docs.rs/pyo3/0.8.1/pyo3/class/gc/trait.PyGCProtocol.html) trait for your struct.
 It includes two methods `__traverse__` and `__clear__`.
 These correspond to the slots `tp_traverse` and `tp_clear` in the Python C API.
 `__traverse__` must call `visit.call()` for each reference to another Python object.
@@ -587,7 +587,7 @@ struct GCTracked {} // Fails because it does not implement PyGCProtocol
 ### Iterator Types
 
 Iterators can be defined using the
-[`PyIterProtocol`](https://docs.rs/pyo3/0.8.0/pyo3/class/iter/trait.PyIterProtocol.html) trait.
+[`PyIterProtocol`](https://docs.rs/pyo3/0.8.1/pyo3/class/iter/trait.PyIterProtocol.html) trait.
 It includes two methods `__iter__` and `__next__`:
   * `fn __iter__(slf: PyRefMut<Self>) -> PyResult<impl IntoPy<PyObject>>`
   * `fn __next__(slf: PyRefMut<Self>) -> PyResult<Option<impl IntoPy<PyObject>>>`

--- a/guide/src/conversions.md
+++ b/guide/src/conversions.md
@@ -106,8 +106,8 @@ Many conversions in PyO3 can't use `std::convert::Into` because they need a GIL 
 
 Eventually, traits such as `ToPyObject` will be replaced by this trait and a `FromPy` trait will be added that will implement `IntoPy`, just like with `From` and `Into`.
 
-[`ToPyObject`]: https://docs.rs/pyo3/0.8.0/pyo3/trait.ToPyObject.html
-[PyObject]: https://docs.rs/pyo3/0.8.0/pyo3/struct.PyObject.html
-[PyTuple]: https://docs.rs/pyo3/0.8.0/pyo3/types/struct.PyTuple.html
-[ObjectProtocol]: https://docs.rs/pyo3/0.8.0/pyo3/trait.ObjectProtocol.html
-[IntoPyDict]: https://docs.rs/pyo3/0.8.0/pyo3/types/trait.IntoPyDict.html
+[`ToPyObject`]: https://docs.rs/pyo3/0.8.1/pyo3/trait.ToPyObject.html
+[PyObject]: https://docs.rs/pyo3/0.8.1/pyo3/struct.PyObject.html
+[PyTuple]: https://docs.rs/pyo3/0.8.1/pyo3/types/struct.PyTuple.html
+[ObjectProtocol]: https://docs.rs/pyo3/0.8.1/pyo3/trait.ObjectProtocol.html
+[IntoPyDict]: https://docs.rs/pyo3/0.8.1/pyo3/types/trait.IntoPyDict.html

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -35,7 +35,7 @@ fn main() {
 
 ## Raise an exception
 
-To raise an exception, first you need to obtain an exception type and construct a new [`PyErr`](https://docs.rs/pyo3/0.8.0/pyo3/struct.PyErr.html), then call the [`PyErr::restore()`](https://docs.rs/pyo3/0.8.0/pyo3/struct.PyErr.html#method.restore) method to write the exception back to the Python interpreter's global state.
+To raise an exception, first you need to obtain an exception type and construct a new [`PyErr`](https://docs.rs/pyo3/0.8.1/pyo3/struct.PyErr.html), then call the [`PyErr::restore()`](https://docs.rs/pyo3/0.8.1/pyo3/struct.PyErr.html#method.restore) method to write the exception back to the Python interpreter's global state.
 
 ```rust
 use pyo3::{Python, PyErr};
@@ -50,7 +50,7 @@ fn main() {
 }
 ```
 
-If you already have a Python exception instance, you can simply call [`PyErr::from_instance()`](https://docs.rs/pyo3/0.8.0/pyo3/struct.PyErr.html#method.from_instance).
+If you already have a Python exception instance, you can simply call [`PyErr::from_instance()`](https://docs.rs/pyo3/0.8.1/pyo3/struct.PyErr.html#method.from_instance).
 
 ```rust,ignore
 PyErr::from_instance(py, err).restore(py);
@@ -77,7 +77,7 @@ fn my_func(arg: PyObject) -> PyResult<()> {
 ## Check exception type
 
 Python has an [`isinstance`](https://docs.python.org/3/library/functions.html#isinstance) method to check an object's type,
-in PyO3 there is a [`Python::is_instance()`](https://docs.rs/pyo3/0.8.0/pyo3/struct.Python.html#method.is_instance) method which does the same thing.
+in PyO3 there is a [`Python::is_instance()`](https://docs.rs/pyo3/0.8.1/pyo3/struct.Python.html#method.is_instance) method which does the same thing.
 
 ```rust
 use pyo3::Python;
@@ -93,7 +93,7 @@ fn main() {
 }
 ```
 
-[`Python::is_instance()`](https://docs.rs/pyo3/0.8.0/pyo3/struct.Python.html#method.is_instance) calls the underlying [`PyType::is_instance`](https://docs.rs/pyo3/0.8.0/pyo3/types/struct.PyType.html#method.is_instance) method to do the actual work.
+[`Python::is_instance()`](https://docs.rs/pyo3/0.8.1/pyo3/struct.Python.html#method.is_instance) calls the underlying [`PyType::is_instance`](https://docs.rs/pyo3/0.8.1/pyo3/types/struct.PyType.html#method.is_instance) method to do the actual work.
 
 To check the type of an exception, you can simply do:
 
@@ -110,10 +110,10 @@ err.is_instance::<exceptions::TypeError>(py);
 
 ## Handle Rust Errors
 
-The vast majority of operations in this library will return [`PyResult<T>`](https://docs.rs/pyo3/0.8.0/pyo3/prelude/type.PyResult.html).
+The vast majority of operations in this library will return [`PyResult<T>`](https://docs.rs/pyo3/0.8.1/pyo3/prelude/type.PyResult.html).
 This is an alias for the type `Result<T, PyErr>`.
 
-A [`PyErr`](https://docs.rs/pyo3/0.8.0/pyo3/struct.PyErr.html) represents a Python exception.
+A [`PyErr`](https://docs.rs/pyo3/0.8.1/pyo3/struct.PyErr.html) represents a Python exception.
 Errors within the PyO3 library are also exposed as Python exceptions.
 
 The PyO3 library handles Python exceptions in two stages. During the first stage, a `PyErr` instance is
@@ -124,7 +124,7 @@ In simple cases, for custom errors adding an implementation of `std::convert::Fr
 for this custom error is enough. `PyErr::new` accepts an argument in the form
 of `ToPyObject + 'static`. If the `'static` constraint can not be satisfied or
 more complex arguments are required, the
-[`PyErrArguments`](https://docs.rs/pyo3/0.8.0/pyo3/trait.PyErrArguments.html)
+[`PyErrArguments`](https://docs.rs/pyo3/0.8.1/pyo3/trait.PyErrArguments.html)
 trait can be implemented. In that case, actual exception argument creation is delayed
 until a `Python` object is available.
 
@@ -202,5 +202,5 @@ fn tell(file: PyObject) -> PyResult<u64> {
 
 ```
 
-[`pyo3::exceptions`](https://docs.rs/pyo3/0.8.0/pyo3/exceptions/index.html)
+[`pyo3::exceptions`](https://docs.rs/pyo3/0.8.1/pyo3/exceptions/index.html)
 defines exceptions for several standard library modules.

--- a/guide/src/get_started.md
+++ b/guide/src/get_started.md
@@ -40,7 +40,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.8.0"
+version = "0.8.1"
 features = ["extension-module"]
 ```
 
@@ -85,7 +85,7 @@ Add `pyo3` to your `Cargo.toml` like this:
 
 ```toml
 [dependencies]
-pyo3 = "0.8.0"
+pyo3 = "0.8.1"
 ```
 
 Example program displaying the value of `sys.version` and the current user name:

--- a/guide/src/parallelism.md
+++ b/guide/src/parallelism.md
@@ -4,7 +4,7 @@ CPython has the infamous GIL (Global Interpreter Lock), which prevents developer
 from getting true parallelism when running pure Python code. With PyO3, you can
 release the GIL when executing Rust code to achieve true parallelism.
 
-The [`Python::allow_threads`](https://docs.rs/pyo3/0.8.0/pyo3/struct.Python.html#method.allow_threads)
+The [`Python::allow_threads`](https://docs.rs/pyo3/0.8.1/pyo3/struct.Python.html#method.allow_threads)
 method temporarily releases the GIL, thus allowing other Python threads to run.
 
 ```rust,ignore

--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-derive-backend"
-version = "0.8.0"
+version = "0.8.1"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3cls"
-version = "0.8.0"
+version = "0.8.1"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -17,7 +17,7 @@ proc-macro = true
 quote = "1"
 proc-macro2 = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.8.0" }
+pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.8.1" }
 
 [features]
 unsound-subclass = ["pyo3-derive-backend/unsound-subclass"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies.pyo3]
-//! version = "0.8.0"
+//! version = "0.8.1"
 //! features = ["extension-module"]
 //! ```
 //!
@@ -93,7 +93,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pyo3 = "0.8.0"
+//! pyo3 = "0.8.1"
 //! ```
 //!
 //! Example program displaying the value of `sys.version`:


### PR DESCRIPTION
The main cause of this release is #614.
We can't use PyO3 <= 0.8.0 with the latest nightly.

Please check diffs!
Since I'm sleepy now, I feel like I get something wrong...
