### PR TITLE
Support TryFromSliceError/TryFromIntError -> PyErr conversion

### DIFF
--- a/src/err.rs
+++ b/src/err.rs
@@ -490,8 +490,10 @@ impl<W: Send + std::fmt::Debug> PyErrArguments for std::io::IntoInnerError<W> {
     }
 }
 
+impl_to_pyerr!(std::array::TryFromSliceError, exceptions::ValueError);
 impl_to_pyerr!(std::num::ParseIntError, exceptions::ValueError);
 impl_to_pyerr!(std::num::ParseFloatError, exceptions::ValueError);
+impl_to_pyerr!(std::num::TryFromIntError, exceptions::ValueError);
 impl_to_pyerr!(std::string::ParseError, exceptions::ValueError);
 impl_to_pyerr!(std::str::ParseBoolError, exceptions::ValueError);
 impl_to_pyerr!(std::ffi::IntoStringError, exceptions::UnicodeDecodeError);

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -155,11 +155,12 @@ impl PySequenceProtocol for Sequence {
         Ok(5)
     }
 
-    fn __getitem__(&self, key: isize) -> PyResult<isize> {
-        if key == 5 {
+    fn __getitem__(&self, key: isize) -> PyResult<usize> {
+        let idx: usize = std::convert::TryFrom::try_from(key)?;
+        if idx == 5 {
             return Err(PyErr::new::<IndexError, _>(()));
         }
-        Ok(key)
+        Ok(idx)
     }
 }
 
@@ -170,6 +171,7 @@ fn sequence() {
 
     let c = Py::new(py, Sequence {}).unwrap();
     py_assert!(py, c, "list(c) == [0, 1, 2, 3, 4]");
+    py_assert!(py, c, "c[-1] == 4");
     py_expect_exception!(py, c, "c['abc']", TypeError);
 }
 


### PR DESCRIPTION
This enables
```rust
    fn __getitem__(&self, key: isize) -> PyResult<...> {
        let idx = usize::try_from(key)?;
        ...
    }
```
