### PR TITLE
Enable to give None as default value for an argument

### DIFF
--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -523,11 +523,14 @@ fn impl_arg_param(
         }
     } else if arg.optional.is_some() {
         let default = if let Some(d) = spec.default_value(name) {
-            quote! { Some(#d) }
+            if d.to_string() == "None" {
+                quote! { None }
+            } else {
+                quote! { Some(#d) }
+            }
         } else {
             quote! { None }
         };
-
         quote! {
             let #arg_name = match #arg_value.as_ref() {
                 Some(_obj) => {

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -214,6 +214,21 @@ impl MethArgs {
     fn get_optional(&self, test: Option<i32>) -> PyResult<i32> {
         Ok(test.unwrap_or(10))
     }
+    fn get_optional2(&self, test: Option<i32>) -> PyResult<Option<i32>> {
+        Ok(test)
+    }
+    #[args(test = "None")]
+    fn get_optional3(&self, test: Option<i32>) -> PyResult<Option<i32>> {
+        Ok(test)
+    }
+    fn get_optional_positional(
+        &self,
+        _t1: Option<i32>,
+        t2: Option<i32>,
+        _t3: Option<i32>,
+    ) -> PyResult<Option<i32>> {
+        Ok(t2)
+    }
 
     #[args(test = "10")]
     fn get_default(&self, test: i32) -> PyResult<i32> {
@@ -264,6 +279,15 @@ fn meth_args() {
 
     py_run!(py, inst, "assert inst.get_optional() == 10");
     py_run!(py, inst, "assert inst.get_optional(100) == 100");
+    py_run!(py, inst, "assert inst.get_optional2() == None");
+    py_run!(py, inst, "assert inst.get_optional(100) == 100");
+    py_run!(py, inst, "assert inst.get_optional3() == None");
+    py_run!(
+        py,
+        inst,
+        "assert inst.get_optional_positional(1, 2, 3) == 2"
+    );
+    py_run!(py, inst, "assert inst.get_optional_positional(1) == None");
     py_run!(py, inst, "assert inst.get_default() == 10");
     py_run!(py, inst, "assert inst.get_default(100) == 100");
     py_run!(py, inst, "assert inst.get_kwarg() == 10");


### PR DESCRIPTION
Also added some tests which show that it is not strictly necessary to provide `None` explicitly.

Closes #486
