### PR TITLE
Remove unwrap for attribute parsing

### DIFF
--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -286,7 +286,7 @@ fn parse_attributes(attrs: &mut Vec<syn::Attribute>) -> syn::Result<(FnType, Vec
     let mut res: Option<FnType> = None;
 
     for attr in attrs.iter() {
-        match attr.parse_meta().unwrap() {
+        match attr.parse_meta()? {
             syn::Meta::Path(ref name) => {
                 if name.is_ident("new") || name.is_ident("__new__") {
                     res = Some(FnType::FnNew)


### PR DESCRIPTION
This change enables getting a helpful error message.

For example
```rust
error: expected literal
   --> tests/test_methods.rs:218:19
    |
218 |     #[args(test = None)]
    |                   ^^^^
```
instead of 
```rust
error: custom attribute panicked
   --> tests/test_methods.rs:211:1
    |
211 | #[pymethods]
    | ^^^^^^^^^^^^
    |
    = help: message: called `Result::unwrap()` on an `Err` value: Error("expected literal")
```

The only downside is that in the example above you also get additional errors like
```rust
error: cannot find attribute `args` in this scope
   --> tests/test_methods.rs:218:7
    |
218 |     #[args(test = None)]
    |       ^^^^
```