### PR TITLE
Fix minimum and maximum for datetime tests

### DIFF
--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -40,21 +40,8 @@ MIN_DAYS = pdt.timedelta.min // pdt.timedelta(days=1)
 MAX_MICROSECONDS = int(pdt.timedelta.max.total_seconds() * 1e6)
 MIN_MICROSECONDS = int(pdt.timedelta.min.total_seconds() * 1e6)
 
-IS_X86 = platform.architecture()[0] == "32bit"
-IS_WINDOWS = sys.platform == "win32"
-if IS_WINDOWS:
-    MIN_DATETIME_FROM_TIMESTAMP = pdt.datetime.fromtimestamp(86400)
-    if IS_X86:
-        MAX_DATETIME_FROM_TIMESTAMP = pdt.datetime.fromtimestamp(32536789199)
-    else:
-        MAX_DATETIME_FROM_TIMESTAMP = pdt.datetime.fromtimestamp(32536799999)
-else:
-    if IS_X86:
-        MIN_DATETIME_FROM_TIMESTAMP = pdt.datetime.fromtimestamp(-2147483648)
-        MAX_DATETIME_FROM_TIMESTAMP = pdt.datetime.fromtimestamp(2147483647)
-    else:
-        MIN_DATETIME_FROM_TIMESTAMP = pdt.datetime.fromtimestamp(-62135510400)
-        MAX_DATETIME_FROM_TIMESTAMP = pdt.datetime.fromtimestamp(253402300799)
+MIN_DATETIME = pdt.datetime.min
+MAX_DATETIME = pdt.datetime.max
 
 PYPY = platform.python_implementation() == "PyPy"
 HAS_FOLD = getattr(pdt.datetime, "fold", False)
@@ -85,9 +72,7 @@ def test_invalid_date_fails():
         rdt.make_date(2017, 2, 30)
 
 
-@given(
-    d=st.dates(MIN_DATETIME_FROM_TIMESTAMP.date(), MAX_DATETIME_FROM_TIMESTAMP.date())
-)
+@given(d=st.dates(MIN_DATETIME.date(), MAX_DATETIME.date()))
 def test_date_from_timestamp(d):
     if PYPY and d < pdt.date(1900, 1, 1):
         pytest.xfail("pdt.datetime.timestamp will raise on PyPy with dates before 1900")
@@ -226,7 +211,7 @@ def test_datetime_typeerror():
         rdt.make_datetime("2011", 1, 1, 0, 0, 0, 0)
 
 
-@given(dt=st.datetimes(MIN_DATETIME_FROM_TIMESTAMP, MAX_DATETIME_FROM_TIMESTAMP))
+@given(dt=st.datetimes(MIN_DATETIME, MAX_DATETIME))
 @example(dt=pdt.datetime(1970, 1, 2, 0, 0))
 def test_datetime_from_timestamp(dt):
     if PYPY and dt < pdt.datetime(1900, 1, 1):

--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -40,8 +40,8 @@ MIN_DAYS = pdt.timedelta.min // pdt.timedelta(days=1)
 MAX_MICROSECONDS = int(pdt.timedelta.max.total_seconds() * 1e6)
 MIN_MICROSECONDS = int(pdt.timedelta.min.total_seconds() * 1e6)
 
-MIN_DATETIME = pdt.datetime.min
-MAX_DATETIME = pdt.datetime.max
+MIN_DATETIME = pdt.datetime(1970, 1, 1)
+MAX_DATETIME = pdt.datetime(3000, 1, 1)
 
 PYPY = platform.python_implementation() == "PyPy"
 HAS_FOLD = getattr(pdt.datetime, "fold", False)

--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -40,8 +40,22 @@ MIN_DAYS = pdt.timedelta.min // pdt.timedelta(days=1)
 MAX_MICROSECONDS = int(pdt.timedelta.max.total_seconds() * 1e6)
 MIN_MICROSECONDS = int(pdt.timedelta.min.total_seconds() * 1e6)
 
-MIN_DATETIME = pdt.datetime(1970, 1, 1)
-MAX_DATETIME = pdt.datetime(3000, 1, 1)
+IS_X86 = platform.architecture()[0] == "32bit"
+IS_WINDOWS = sys.platform == "win32"
+if IS_WINDOWS:
+    MIN_DATETIME = pdt.datetime(1970, 1, 2, 0, 0)
+    if IS_X86:
+        MAX_DATETIME = pdt.datetime(3001, 1, 19, 4, 59, 59)
+    else:
+        MAX_DATETIME = pdt.datetime(3001, 1, 19, 7, 59, 59)
+else:
+    if IS_X86:
+        # TS ±2147483648 (2**31)
+        MIN_DATETIME = pdt.datetime(1901, 12, 13, 20, 45, 52)
+        MAX_DATETIME = pdt.datetime(2038, 1, 19, 3, 14, 8)
+    else:
+        MIN_DATETIME = pdt.datetime(1, 1, 2, 0, 0)
+        MAX_DATETIME = pdt.datetime(9999, 12, 31, 18, 59, 59)
 
 PYPY = platform.python_implementation() == "PyPy"
 HAS_FOLD = getattr(pdt.datetime, "fold", False)


### PR DESCRIPTION
Depending on the local timezone one could get
```python 
ValueError: year 0 is out of range
```
This does fix the tests for me, what do you think @pganssle?

Closes #587