### PR TITLE
FFI for PEP 590 Vectorcall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+* FFI compatibility for PEP 590 Vectorcall.
+
 ## [0.8.1]
 
 ### Added

--- a/src/ffi/object.rs
+++ b/src/ffi/object.rs
@@ -463,7 +463,10 @@ mod typeobject {
         pub tp_basicsize: Py_ssize_t,
         pub tp_itemsize: Py_ssize_t,
         pub tp_dealloc: Option<object::destructor>,
+        #[cfg(not(Py_3_8))]
         pub tp_print: Option<object::printfunc>,
+        #[cfg(Py_3_8)]
+        pub tp_vectorcall_offset: Py_ssize_t,
         pub tp_getattr: Option<object::getattrfunc>,
         pub tp_setattr: Option<object::setattrfunc>,
         pub tp_as_async: *mut PyAsyncMethods,
@@ -529,7 +532,10 @@ mod typeobject {
                     tp_basicsize: 0,
                     tp_itemsize: 0,
                     tp_dealloc: None,
+                    #[cfg(not(Py_3_8))]
                     tp_print: None,
+                    #[cfg(Py_3_8)]
+                    tp_vectorcall_offset: 0,
                     tp_getattr: None,
                     tp_setattr: None,
                     $tp_as_async: ptr::null_mut(),
@@ -846,6 +852,10 @@ pub const Py_TPFLAGS_HEAPTYPE: c_ulong = (1 << 9);
 
 /// Set if the type allows subclassing
 pub const Py_TPFLAGS_BASETYPE: c_ulong = (1 << 10);
+
+/// Set if the type implements the vectorcall protocol (PEP 590)
+#[cfg(all(Py_3_8, not(Py_LIMITED_API)))]
+pub const _Py_TPFLAGS_HAVE_VECTORCALL: c_ulong = (1 << 11);
 
 /// Set if the type is 'ready' -- fully initialized
 pub const Py_TPFLAGS_READY: c_ulong = (1 << 12);


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0590/

This was tested on 3.7 using _PyCFunctionFast and 3.8
using PyObject_Vectorcall. Extending pyo3-derive-backend
to generate code using vectorcall is not done here.

This exposes PyObject_Vectorcall with a link_name to the
underscored name on 3.8 because it is expected to be stabilized
on 3.9.

This fixes the "fast" objects being new in 3.7, not 3.6.