### PR TITLE
Fix handling of invalid utf-8 sequences in PyString::to_string_lossy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * FFI compatibility for PEP 590 Vectorcall.
 
+### Fixed
+
+* Fix handling of invalid utf-8 sequences in `PyString::as_bytes` [#639](https://github.com/PyO3/pyo3/pull/639)
+and `PyString::to_string_lossy` [#642](https://github.com/PyO3/pyo3/pull/642).
+
 ## [0.8.1]
 
 ### Added

--- a/examples/rustapi_module/src/buf_and_str.rs
+++ b/examples/rustapi_module/src/buf_and_str.rs
@@ -22,6 +22,11 @@ impl BytesExtractor {
         let rust_string: String = string.extract().unwrap();
         Ok(rust_string.len())
     }
+
+    pub fn from_str_lossy(&mut self, string: &PyString) -> PyResult<usize> {
+        let rust_string_lossy: String = string.to_string_lossy().to_string();
+        Ok(rust_string_lossy.len())
+    }
 }
 
 #[pymodule]

--- a/examples/rustapi_module/tests/test_buf_and_str.py
+++ b/examples/rustapi_module/tests/test_buf_and_str.py
@@ -30,6 +30,7 @@ def test_pybuffer_doesnot_leak_memory():
 
     message_b = b'\\(-"-;) Praying that memory leak would not happen..'
     message_s = '\\(-"-;) Praying that memory leak would not happen..'
+    message_surrogate = '\\(-"-;) Praying that memory leak would not happen.. \ud800'
 
     def from_bytes():
         extractor.from_bytes(message_b)
@@ -37,9 +38,14 @@ def test_pybuffer_doesnot_leak_memory():
     def from_str():
         extractor.from_str(message_s)
 
+    def from_str_lossy():
+        extractor.from_str_lossy(message_surrogate)
+
     # Running the memory_diff to warm-up the garbage collector
     memory_diff(from_bytes)
     memory_diff(from_str)
+    memory_diff(from_str_lossy)
 
     assert memory_diff(from_bytes) == 0
     assert memory_diff(from_str) == 0
+    assert memory_diff(from_str_lossy) == 0


### PR DESCRIPTION
See discussion in #479 and #634.