### PR TITLE
Fix derive for PyObjectSetAttrProtocol.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Fix handling of invalid utf-8 sequences in `PyString::as_bytes` [#639](https://github.com/PyO3/pyo3/pull/639)
 and `PyString::to_string_lossy` [#642](https://github.com/PyO3/pyo3/pull/642).
+* Fix proc-macro definition of PySetAttrProtocol. [#645](https://github.com/PyO3/pyo3/pull/645)
 
 ## [0.8.1]
 

--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -25,7 +25,7 @@ pub const OBJECT: Proto = Proto {
             name: "__setattr__",
             arg1: "Name",
             arg2: "Value",
-            pyres: true,
+            pyres: false,
             proto: "pyo3::class::basic::PyObjectSetAttrProtocol",
         },
         MethodProto::Binary {


### PR DESCRIPTION
PyObjectSetAttrProtocol doesn't define associated type Success.

Thank you for contributing to pyo3!

Here are some things you should check for submitting your pull request:

 - [x] Run `cargo fmt` (This is checked by travis ci)
 - [x] Run `cargo clippy` and check there are no hard errors (There are a bunch of existing warnings; This is also checked by travis)
 - [x] If applicable, add an entry in the changelog.

________
Fixes #609 