### PR TITLE
Fix proc macro for init fn.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 and `PyString::to_string_lossy` [#642](https://github.com/PyO3/pyo3/pull/642).
 * Remove `__contains__` and `__iter__` from PyMappingProtocol. [#644](https://github.com/PyO3/pyo3/pull/644)
 * Fix proc-macro definition of PySetAttrProtocol. [#645](https://github.com/PyO3/pyo3/pull/645)
+* Fix `impl_wrap_init`. [#651](https://github.com/PyO3/pyo3/pull/651)
 
 
 ## [0.8.1]

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -226,7 +226,7 @@ fn impl_wrap_init(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) -> Toke
     let output = &spec.output;
     let result_empty: syn::Type = syn::parse_quote!(PyResult<()>);
     let empty: syn::Type = syn::parse_quote!(());
-    if output != &result_empty || output != &empty {
+    if output != &result_empty && output != &empty {
         panic!("Constructor must return PyResult<()> or a ()");
     }
 


### PR DESCRIPTION
The if statement evaluated to true if the return type was not `"()"` or `"PyResult<()>"` which was always the case since `"()" != "PyResult<()>"`.