### PR TITLE
Make &Py~ types unsendable

### DIFF
--- a/src/internal_tricks.rs
+++ b/src/internal_tricks.rs
@@ -1,0 +1,6 @@
+use std::marker::PhantomData;
+use std::rc::Rc;
+
+/// A marker type that makes the type !Send.
+/// Temporal hack until https://github.com/rust-lang/rust/issues/13231 is resolved.
+pub(crate) type Unsendable = PhantomData<Rc<()>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ pub mod exceptions;
 pub mod freelist;
 mod gil;
 mod instance;
+mod internal_tricks;
 pub mod marshal;
 mod object;
 mod objectprotocol;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1,5 +1,6 @@
 use crate::conversion::AsPyPointer;
 use crate::err::PyDowncastError;
+use crate::internal_tricks::Unsendable;
 use crate::{ffi, PyObject, PyRef, PyRefMut, PyTryFrom, PyTypeInfo};
 
 /// Represents a python's [Any](https://docs.python.org/3/library/typing.html#typing.Any) type.
@@ -21,7 +22,7 @@ use crate::{ffi, PyObject, PyRef, PyRefMut, PyTryFrom, PyTypeInfo};
 /// assert!(any.downcast_ref::<PyList>().is_err());
 /// ```
 #[repr(transparent)]
-pub struct PyAny(PyObject);
+pub struct PyAny(PyObject, Unsendable);
 pyobject_native_type_named!(PyAny);
 pyobject_native_type_convert!(PyAny, ffi::PyBaseObject_Type, ffi::PyObject_Check);
 

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 use crate::ffi;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::PyAny;
 use crate::FromPyObject;
@@ -10,7 +11,7 @@ use crate::{PyTryFrom, ToPyObject};
 
 /// Represents a Python `bool`.
 #[repr(transparent)]
-pub struct PyBool(PyObject);
+pub struct PyBool(PyObject, Unsendable);
 
 pyobject_native_type!(PyBool, ffi::PyBool_Type, ffi::PyBool_Check);
 

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
-
 use crate::err::{PyErr, PyResult};
 use crate::ffi;
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::AsPyPointer;
 use crate::Python;
@@ -11,7 +11,7 @@ use std::slice;
 
 /// Represents a Python `bytearray`.
 #[repr(transparent)]
-pub struct PyByteArray(PyObject);
+pub struct PyByteArray(PyObject, Unsendable);
 
 pyobject_native_type!(PyByteArray, ffi::PyByteArray_Type, ffi::PyByteArray_Check);
 

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,6 +1,7 @@
 use crate::conversion::FromPyObject;
 use crate::conversion::{PyTryFrom, ToPyObject};
 use crate::err::PyResult;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::PyAny;
 use crate::AsPyPointer;
@@ -15,7 +16,7 @@ use std::str;
 ///
 /// This type is immutable
 #[repr(transparent)]
-pub struct PyBytes(PyObject);
+pub struct PyBytes(PyObject, Unsendable);
 
 pyobject_native_type!(
     PyBytes,

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -1,6 +1,7 @@
 use crate::ffi;
 #[cfg(not(PyPy))]
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::AsPyPointer;
 use crate::PyObject;
 use crate::Python;
@@ -10,7 +11,7 @@ use std::os::raw::c_double;
 
 /// Represents a Python `complex`.
 #[repr(transparent)]
-pub struct PyComplex(PyObject);
+pub struct PyComplex(PyObject, Unsendable);
 
 pyobject_native_type!(PyComplex, ffi::PyComplex_Type, ffi::PyComplex_Check);
 

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -25,6 +25,7 @@ use crate::ffi::{
     PyDateTime_TIME_GET_HOUR, PyDateTime_TIME_GET_MICROSECOND, PyDateTime_TIME_GET_MINUTE,
     PyDateTime_TIME_GET_SECOND,
 };
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::PyTuple;
 use crate::AsPyPointer;
@@ -65,7 +66,7 @@ pub trait PyTimeAccess {
 }
 
 /// Bindings around `datetime.date`
-pub struct PyDate(PyObject);
+pub struct PyDate(PyObject, Unsendable);
 pyobject_native_type!(
     PyDate,
     *PyDateTimeAPI.DateType,
@@ -120,7 +121,7 @@ impl PyDateAccess for PyDate {
 }
 
 /// Bindings for `datetime.datetime`
-pub struct PyDateTime(PyObject);
+pub struct PyDateTime(PyObject, Unsendable);
 pyobject_native_type!(
     PyDateTime,
     *PyDateTimeAPI.DateTimeType,
@@ -229,7 +230,7 @@ impl PyTimeAccess for PyDateTime {
 }
 
 /// Bindings for `datetime.time`
-pub struct PyTime(PyObject);
+pub struct PyTime(PyObject, Unsendable);
 pyobject_native_type!(
     PyTime,
     *PyDateTimeAPI.TimeType,
@@ -313,7 +314,7 @@ impl PyTimeAccess for PyTime {
 /// Bindings for `datetime.tzinfo`
 ///
 /// This is an abstract base class and should not be constructed directly.
-pub struct PyTzInfo(PyObject);
+pub struct PyTzInfo(PyObject, Unsendable);
 pyobject_native_type!(
     PyTzInfo,
     *PyDateTimeAPI.TZInfoType,
@@ -322,7 +323,7 @@ pyobject_native_type!(
 );
 
 /// Bindings for `datetime.timedelta`
-pub struct PyDelta(PyObject);
+pub struct PyDelta(PyObject, Unsendable);
 pyobject_native_type!(
     PyDelta,
     *PyDateTimeAPI.DeltaType,

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -2,6 +2,7 @@
 
 use crate::err::{self, PyErr, PyResult};
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::{PyAny, PyList};
 use crate::AsPyPointer;
@@ -14,7 +15,7 @@ use std::{cmp, collections, hash};
 
 /// Represents a Python `dict`.
 #[repr(transparent)]
-pub struct PyDict(PyObject);
+pub struct PyDict(PyObject, Unsendable);
 
 pyobject_native_type!(PyDict, ffi::PyDict_Type, ffi::PyDict_Check);
 

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -5,6 +5,7 @@
 use crate::err::PyErr;
 use crate::ffi;
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::objectprotocol::ObjectProtocol;
 use crate::types::PyAny;
@@ -22,7 +23,7 @@ use std::os::raw::c_double;
 /// and [extract](struct.PyObject.html#method.extract)
 /// with `f32`/`f64`.
 #[repr(transparent)]
-pub struct PyFloat(PyObject);
+pub struct PyFloat(PyObject, Unsendable);
 
 pyobject_native_type!(PyFloat, ffi::PyFloat_Type, ffi::PyFloat_Check);
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -5,6 +5,7 @@
 use crate::err::{self, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::PyAny;
 use crate::IntoPyPointer;
@@ -14,7 +15,7 @@ use crate::{ToBorrowedObject, ToPyObject};
 
 /// Represents a Python `list`.
 #[repr(transparent)]
-pub struct PyList(PyObject);
+pub struct PyList(PyObject, Unsendable);
 
 pyobject_native_type!(PyList, ffi::PyList_Type, ffi::PyList_Check);
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -6,6 +6,7 @@ use crate::err::{PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi;
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::objectprotocol::ObjectProtocol;
 use crate::type_object::PyTypeCreate;
@@ -23,7 +24,7 @@ use std::str;
 
 /// Represents a Python `module` object.
 #[repr(transparent)]
-pub struct PyModule(PyObject);
+pub struct PyModule(PyObject, Unsendable);
 
 pyobject_native_type!(PyModule, ffi::PyModule_Type, ffi::PyModule_Check);
 

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -6,6 +6,7 @@ use crate::err::{PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi;
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::PyAny;
 use crate::AsPyPointer;
@@ -117,7 +118,7 @@ macro_rules! int_convert_128 {
 /// and [extract](struct.PyObject.html#method.extract)
 /// with the primitive Rust integer types.
 #[repr(transparent)]
-pub struct PyLong(PyObject);
+pub struct PyLong(PyObject, Unsendable);
 
 pyobject_native_type!(
     PyLong,

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -4,6 +4,7 @@ use crate::buffer;
 use crate::err::{self, PyDowncastError, PyErr, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::objectprotocol::ObjectProtocol;
 use crate::types::{PyAny, PyList, PyTuple};
@@ -12,7 +13,7 @@ use crate::{FromPyObject, PyTryFrom, ToBorrowedObject};
 
 /// Represents a reference to a python object supporting the sequence protocol.
 #[repr(transparent)]
-pub struct PySequence(PyObject);
+pub struct PySequence(PyObject, Unsendable);
 pyobject_native_type_named!(PySequence);
 
 impl PySequence {

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -4,6 +4,7 @@
 use crate::err::{self, PyErr, PyResult};
 use crate::ffi;
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::AsPyPointer;
 use crate::Python;
@@ -13,11 +14,11 @@ use std::{collections, hash};
 
 /// Represents a Python `set`
 #[repr(transparent)]
-pub struct PySet(PyObject);
+pub struct PySet(PyObject, Unsendable);
 
 /// Represents a  Python `frozenset`
 #[repr(transparent)]
-pub struct PyFrozenSet(PyObject);
+pub struct PyFrozenSet(PyObject, Unsendable);
 
 pyobject_native_type!(PySet, ffi::PySet_Type, Some("builtins"), ffi::PySet_Check);
 pyobject_native_type!(PyFrozenSet, ffi::PyFrozenSet_Type, ffi::PyFrozenSet_Check);

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -3,6 +3,7 @@
 use crate::err::{PyErr, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::Python;
 use crate::{AsPyPointer, ToPyObject};
@@ -12,7 +13,7 @@ use std::os::raw::c_long;
 ///
 /// Only `c_long` indices supported at the moment by `PySlice` object.
 #[repr(transparent)]
-pub struct PySlice(PyObject);
+pub struct PySlice(PyObject, Unsendable);
 
 pyobject_native_type!(PySlice, ffi::PySlice_Type, ffi::PySlice_Check);
 

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -5,6 +5,7 @@ use crate::conversion::{PyTryFrom, ToPyObject};
 use crate::err::{PyErr, PyResult};
 use crate::gil;
 use crate::instance::PyNativeType;
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::PyAny;
 use crate::AsPyPointer;
@@ -21,7 +22,7 @@ use std::str;
 ///
 /// This type is immutable
 #[repr(transparent)]
-pub struct PyString(PyObject);
+pub struct PyString(PyObject, Unsendable);
 
 pyobject_native_type!(PyString, ffi::PyUnicode_Type, ffi::PyUnicode_Check);
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -5,6 +5,7 @@ use crate::err::{PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi::{self, Py_ssize_t};
 use crate::instance::{AsPyRef, Py, PyNativeType};
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::PyAny;
 use crate::AsPyPointer;
@@ -15,7 +16,7 @@ use std::slice;
 
 /// Represents a Python `tuple` object.
 #[repr(transparent)]
-pub struct PyTuple(PyObject);
+pub struct PyTuple(PyObject, Unsendable);
 
 pyobject_native_type!(PyTuple, ffi::PyTuple_Type, ffi::PyTuple_Check);
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -5,6 +5,7 @@
 use crate::err::{PyErr, PyResult};
 use crate::ffi;
 use crate::instance::{Py, PyNativeType};
+use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::type_object::{PyTypeInfo, PyTypeObject};
 use crate::AsPyPointer;
@@ -14,7 +15,7 @@ use std::ffi::CStr;
 
 /// Represents a reference to a Python `type object`.
 #[repr(transparent)]
-pub struct PyType(PyObject);
+pub struct PyType(PyObject, Unsendable);
 
 pyobject_native_type!(PyType, ffi::PyType_Type, ffi::PyType_Check);
 


### PR DESCRIPTION
They should not be shared between threads.
E.g., prevents
```rust
    let s = PyString::new(py, "This object should not be shared >_<");
    py.allow_threads(|| {
        println!("{:?}", s);
    });
```
Resolves #652.