### PR TITLE
[NEED DISCUSSION] Remove #[init] attribute

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -486,7 +486,7 @@ print(json.dumps({
     serde_json::from_str(&json).map_err(|e| format!("Deserializing failed: {}", e))
 }
 
-fn configure(interpreter_config: &InterpreterConfig) -> Result<(String), String> {
+fn configure(interpreter_config: &InterpreterConfig) -> Result<String, String> {
     if let Some(minor) = interpreter_config.version.minor {
         if minor < PY3_MIN_MINOR {
             return Err(format!(

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -292,8 +292,8 @@ fn parse_attributes(attrs: &mut Vec<syn::Attribute>) -> syn::Result<(FnType, Vec
                 } else if name.is_ident("init") || name.is_ident("__init__") {
                     return Err(syn::Error::new_spanned(
                         name,
-                        "#[init] is duplicated from PyO3 0.9.0!",
-                    ))
+                        "#[init] is disabled from PyO3 0.9.0",
+                    ));
                 } else if name.is_ident("call") || name.is_ident("__call__") {
                     res = Some(FnType::FnCall)
                 } else if name.is_ident("classmethod") {
@@ -326,8 +326,8 @@ fn parse_attributes(attrs: &mut Vec<syn::Attribute>) -> syn::Result<(FnType, Vec
                 } else if path.is_ident("init") {
                     return Err(syn::Error::new_spanned(
                         path,
-                        "#[init] is duplicated from PyO3 0.9.0!",
-                    ))
+                        "#[init] is disabled from PyO3 0.9.0",
+                    ));
                 } else if path.is_ident("call") {
                     res = Some(FnType::FnCall)
                 } else if path.is_ident("setter") || path.is_ident("getter") {

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -24,7 +24,6 @@ pub enum FnType {
     Setter(Option<String>),
     Fn,
     FnNew,
-    FnInit,
     FnCall,
     FnClass,
     FnStatic,
@@ -291,7 +290,10 @@ fn parse_attributes(attrs: &mut Vec<syn::Attribute>) -> syn::Result<(FnType, Vec
                 if name.is_ident("new") || name.is_ident("__new__") {
                     res = Some(FnType::FnNew)
                 } else if name.is_ident("init") || name.is_ident("__init__") {
-                    res = Some(FnType::FnInit)
+                    return Err(syn::Error::new_spanned(
+                        name,
+                        "#[init] is duplicated from PyO3 0.9.0!",
+                    ))
                 } else if name.is_ident("call") || name.is_ident("__call__") {
                     res = Some(FnType::FnCall)
                 } else if name.is_ident("classmethod") {
@@ -322,7 +324,10 @@ fn parse_attributes(attrs: &mut Vec<syn::Attribute>) -> syn::Result<(FnType, Vec
                 if path.is_ident("new") {
                     res = Some(FnType::FnNew)
                 } else if path.is_ident("init") {
-                    res = Some(FnType::FnInit)
+                    return Err(syn::Error::new_spanned(
+                        path,
+                        "#[init] is duplicated from PyO3 0.9.0!",
+                    ))
                 } else if path.is_ident("call") {
                     res = Some(FnType::FnCall)
                 } else if path.is_ident("setter") || path.is_ident("getter") {

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -10,8 +10,6 @@ use std::ffi::CString;
 pub enum PyMethodDefType {
     /// Represents class `__new__` method
     New(PyMethodDef),
-    /// Represents class `__init__` method
-    Init(PyMethodDef),
     /// Represents class `__call__` method
     Call(PyMethodDef),
     /// Represents class method


### PR DESCRIPTION
See #651 for detail.

Now we can override `__init__` function of pyclasses, by
```rust
#[pymethods]
impl Foo {
    #[init]
    fn init(&mut self) -> () {
        // some initialization codes
    }
```
.
But this feature is not very popular and confusing since we mainly use `#[new]`.

So I think this feature should be removed.
Our proc-macro code tends to be complicated, so make it as simple as possible is important.
Any idea?