### PR TITLE
add #[text_signature = "..."] attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+* Support for `#[text_signature]` attribute. [#675](https://github.com/PyO3/pyo3/pull/675)
+
 ## [0.8.3]
 
 ### Fixed

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -47,10 +47,10 @@ pub fn get_return_info(output: &syn::ReturnType) -> syn::Type {
 
 impl<'a> FnSpec<'a> {
     /// Parser function signature and function attributes
-    pub fn parse<'b>(
+    pub fn parse(
         name: &'a syn::Ident,
         sig: &'a syn::Signature,
-        meth_attrs: &'b mut Vec<syn::Attribute>,
+        meth_attrs: &mut Vec<syn::Attribute>,
     ) -> syn::Result<FnSpec<'a>> {
         let (mut fn_type, fn_attrs) = parse_attributes(meth_attrs)?;
 

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -47,10 +47,10 @@ pub fn get_return_info(output: &syn::ReturnType) -> syn::Type {
 
 impl<'a> FnSpec<'a> {
     /// Parser function signature and function attributes
-    pub fn parse(
+    pub fn parse<'b>(
         name: &'a syn::Ident,
         sig: &'a syn::Signature,
-        meth_attrs: &'a mut Vec<syn::Attribute>,
+        meth_attrs: &'b mut Vec<syn::Attribute>,
     ) -> syn::Result<FnSpec<'a>> {
         let (mut fn_type, fn_attrs) = parse_attributes(meth_attrs)?;
 

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -262,7 +262,7 @@ fn impl_class(
     doc: syn::Lit,
     descriptors: Vec<(syn::Field, Vec<FnType>)>,
 ) -> TokenStream {
-    let cls_name = get_class_python_name(cls, attr);
+    let cls_name = get_class_python_name(cls, attr).to_string();
 
     let extra = {
         if let Some(freelist) = &attr.freelist {

--- a/pyo3-derive-backend/src/utils.rs
+++ b/pyo3-derive-backend/src/utils.rs
@@ -2,6 +2,7 @@
 
 use proc_macro2::Span;
 use proc_macro2::TokenStream;
+use std::fmt::Display;
 
 pub fn print_err(msg: String, t: TokenStream) {
     println!("Error: {} in '{}'", msg, t.to_string());
@@ -20,9 +21,108 @@ pub fn if_type_is_python(ty: &syn::Type) -> bool {
     }
 }
 
+pub fn is_text_signature_attr(attr: &syn::Attribute) -> bool {
+    attr.path.is_ident("text_signature")
+}
+
+fn parse_text_signature_attr<T: Display + quote::ToTokens + ?Sized>(
+    attr: &syn::Attribute,
+    python_name: &T,
+    text_signature: &mut Option<syn::LitStr>,
+) -> syn::Result<Option<()>> {
+    if !is_text_signature_attr(attr) {
+        return Ok(None);
+    }
+    if text_signature.is_some() {
+        return Err(syn::Error::new_spanned(
+            attr,
+            "text_signature attribute already specified previously",
+        ));
+    }
+    let value: String;
+    match attr.parse_meta()? {
+        syn::Meta::NameValue(syn::MetaNameValue {
+            lit: syn::Lit::Str(lit),
+            ..
+        }) => {
+            value = lit.value();
+            *text_signature = Some(lit);
+        }
+        meta => {
+            return Err(syn::Error::new_spanned(
+                meta,
+                "text_signature must be of the form #[text_signature = \"\"]",
+            ));
+        }
+    };
+    let python_name_str = python_name.to_string();
+    let python_name_str = python_name_str
+        .rsplit('.')
+        .next()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
+            syn::Error::new_spanned(
+                &python_name,
+                format!("failed to parse python name: {}", python_name),
+            )
+        })?;
+    if !value.starts_with(&python_name_str) || !value[python_name_str.len()..].starts_with('(') {
+        return Err(syn::Error::new_spanned(
+            text_signature,
+            format!("text_signature must start with \"{}(\"", python_name_str),
+        ));
+    }
+    if !value.ends_with(')') {
+        return Err(syn::Error::new_spanned(
+            text_signature,
+            "text_signature must end with \")\"",
+        ));
+    }
+    Ok(Some(()))
+}
+
+pub fn parse_text_signature_attrs<T: Display + quote::ToTokens + ?Sized>(
+    attrs: &mut Vec<syn::Attribute>,
+    python_name: &T,
+) -> syn::Result<Option<syn::LitStr>> {
+    let mut parse_error: Option<syn::Error> = None;
+    let mut text_signature = None;
+    attrs.retain(|attr| {
+        match parse_text_signature_attr(attr, python_name, &mut text_signature) {
+            Ok(None) => return true,
+            Ok(Some(_)) => {}
+            Err(err) => {
+                if let Some(parse_error) = &mut parse_error {
+                    parse_error.combine(err);
+                } else {
+                    parse_error = Some(err);
+                }
+            }
+        }
+        false
+    });
+    if let Some(parse_error) = parse_error {
+        return Err(parse_error);
+    }
+    Ok(text_signature)
+}
+
 // FIXME(althonos): not sure the docstring formatting is on par here.
-pub fn get_doc(attrs: &[syn::Attribute], null_terminated: bool) -> syn::Lit {
+pub fn get_doc(
+    attrs: &[syn::Attribute],
+    text_signature: Option<syn::LitStr>,
+    null_terminated: bool,
+) -> syn::Result<syn::Lit> {
     let mut doc = Vec::new();
+    let mut needs_terminating_newline = false;
+
+    if let Some(text_signature) = text_signature {
+        doc.push(text_signature.value());
+        doc.push("--".to_string());
+        doc.push(String::new());
+        needs_terminating_newline = true;
+    }
 
     // TODO(althonos): set span on produced doc str literal
     // let mut span = None;
@@ -38,11 +138,16 @@ pub fn get_doc(attrs: &[syn::Attribute], null_terminated: bool) -> syn::Lit {
                     } else {
                         d
                     });
+                    needs_terminating_newline = false;
                 } else {
-                    panic!("Invalid doc comment");
+                    return Err(syn::Error::new_spanned(metanv, "Invalid doc comment"));
                 }
             }
         }
+    }
+
+    if needs_terminating_newline {
+        doc.push(String::new());
     }
 
     let mut docstr = doc.join("\n");
@@ -50,5 +155,5 @@ pub fn get_doc(attrs: &[syn::Attribute], null_terminated: bool) -> syn::Lit {
         docstr.push('\0');
     }
 
-    syn::Lit::Str(syn::LitStr::new(&docstr, Span::call_site()))
+    Ok(syn::Lit::Str(syn::LitStr::new(&docstr, Span::call_site())))
 }

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -1,0 +1,186 @@
+use pyo3::prelude::*;
+use pyo3::{types::PyType, wrap_pyfunction, wrap_pymodule};
+
+mod common;
+
+#[test]
+fn class_without_docs_or_signature() {
+    #[pyclass]
+    struct MyClass {}
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let typeobj = py.get_type::<MyClass>();
+
+    py_assert!(py, typeobj, "typeobj.__doc__ is None");
+    py_assert!(py, typeobj, "typeobj.__text_signature__ is None");
+}
+
+#[test]
+fn class_with_docs() {
+    /// docs line1
+    #[pyclass]
+    /// docs line2
+    struct MyClass {}
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let typeobj = py.get_type::<MyClass>();
+
+    py_assert!(py, typeobj, "typeobj.__doc__ == 'docs line1\\ndocs line2'");
+    py_assert!(py, typeobj, "typeobj.__text_signature__ is None");
+}
+
+#[test]
+fn class_with_docs_and_signature() {
+    /// docs line1
+    #[pyclass]
+    /// docs line2
+    #[text_signature = "(a, b=None, *, c=42)"]
+    /// docs line3
+    struct MyClass {}
+
+    #[pymethods]
+    impl MyClass {
+        #[new]
+        #[args(a, b = "None", "*", c = 42)]
+        fn __new__(obj: &PyRawObject, a: i32, b: Option<i32>, c: i32) {
+            let _ = (a, b, c);
+            obj.init(Self {});
+        }
+    }
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let typeobj = py.get_type::<MyClass>();
+
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.__doc__ == 'docs line1\\ndocs line2\\ndocs line3'"
+    );
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.__text_signature__ == '(a, b=None, *, c=42)'"
+    );
+}
+
+#[test]
+fn class_with_signature() {
+    #[pyclass]
+    #[text_signature = "(a, b=None, *, c=42)"]
+    struct MyClass {}
+
+    #[pymethods]
+    impl MyClass {
+        #[new]
+        #[args(a, b = "None", "*", c = 42)]
+        fn __new__(obj: &PyRawObject, a: i32, b: Option<i32>, c: i32) {
+            let _ = (a, b, c);
+            obj.init(Self {});
+        }
+    }
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let typeobj = py.get_type::<MyClass>();
+
+    py_assert!(py, typeobj, "typeobj.__doc__ is None");
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.__text_signature__ == '(a, b=None, *, c=42)'"
+    );
+}
+
+#[test]
+fn test_function() {
+    #[pyfunction(a, b = "None", "*", c = 42)]
+    #[text_signature = "(a, b=None, *, c=42)"]
+    fn my_function(a: i32, b: Option<i32>, c: i32) {
+        let _ = (a, b, c);
+    }
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let f = wrap_pyfunction!(my_function)(py);
+
+    py_assert!(py, f, "f.__text_signature__ == '(a, b=None, *, c=42)'");
+}
+
+#[test]
+fn test_pyfn() {
+    #[pymodule]
+    fn my_module(_py: Python, m: &PyModule) -> PyResult<()> {
+        #[pyfn(m, "my_function", a, b = "None", "*", c = 42)]
+        #[text_signature = "(a, b=None, *, c=42)"]
+        fn my_function(a: i32, b: Option<i32>, c: i32) {
+            let _ = (a, b, c);
+        }
+        Ok(())
+    }
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let m = wrap_pymodule!(my_module)(py);
+
+    py_assert!(
+        py,
+        m,
+        "m.my_function.__text_signature__ == '(a, b=None, *, c=42)'"
+    );
+}
+
+#[test]
+fn test_methods() {
+    #[pyclass]
+    struct MyClass {}
+
+    #[pymethods]
+    impl MyClass {
+        #[text_signature = "($self, a)"]
+        fn method(&self, a: i32) {
+            let _ = a;
+        }
+        #[text_signature = "($self, b)"]
+        fn pyself_method(_this: PyRef<Self>, b: i32) {
+            let _ = b;
+        }
+        #[classmethod]
+        #[text_signature = "($cls, c)"]
+        fn class_method(_cls: &PyType, c: i32) {
+            let _ = c;
+        }
+        #[staticmethod]
+        #[text_signature = "(d)"]
+        fn static_method(d: i32) {
+            let _ = d;
+        }
+    }
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let typeobj = py.get_type::<MyClass>();
+
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.method.__text_signature__ == '($self, a)'"
+    );
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.pyself_method.__text_signature__ == '($self, b)'"
+    );
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.class_method.__text_signature__ == '($cls, c)'"
+    );
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.static_method.__text_signature__ == '(d)'"
+    );
+}


### PR DESCRIPTION
Based on design at https://github.com/PyO3/pyo3/issues/310#issuecomment-556038749

Just implemented parsing `#[text_signature = "..."]` and adding to generated doc strings.
Still need to add docs, tests, changelog entries, etc.

Demo code:

```rust
/// doc string 1
#[pyclass]
#[text_signature = "(arg1, *, arg2=0)"]
/// doc string 2
struct MyClass {}

#[pymethods]
impl MyClass {
    #[new]
    #[args(arg1, "*", arg2 = "0")]
    fn new(obj: &PyRawObject, arg1: i32, arg2: i32) {
        obj.init(Self {});
    }

    /// doc string 1
    #[text_signature = "($self)"]
    /// doc string 2
    fn my_method(&self) {}

    #[staticmethod]
    #[text_signature = "()"]
    fn method_without_docs() {}
}

/// doc string 1
#[pyfunction]
#[text_signature = "(arg1, arg2)"]
/// doc string 2
fn my_function(arg1: i32, arg2: i32) -> i32 {
    0
}
```
