### PR TITLE
Add #[name = "foo"] attribute to #[pymethods]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+* Support for `#[name = "foo"]` attribute in `#[pymethods]`. [#692](https://github.com/PyO3/pyo3/pull/692)
+
 ## [0.8.4]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-* Support for `#[name = "foo"]` attribute in `#[pymethods]`. [#692](https://github.com/PyO3/pyo3/pull/692)
+* Support for `#[name = "foo"]` attribute for `#[pyfunction]` and in `#[pymethods]`. [#692](https://github.com/PyO3/pyo3/pull/692)
 
 ## [0.8.4]
 

--- a/pyo3-derive-backend/src/func.rs
+++ b/pyo3-derive-backend/src/func.rs
@@ -55,16 +55,16 @@ pub enum MethodProto {
     },
 }
 
-impl PartialEq<str> for MethodProto {
-    fn eq(&self, name: &str) -> bool {
+impl MethodProto {
+    pub fn name(&self) -> &str {
         match *self {
-            MethodProto::Free { name: n, .. } => n == name,
-            MethodProto::Unary { name: n, .. } => n == name,
-            MethodProto::Binary { name: n, .. } => n == name,
-            MethodProto::BinaryS { name: n, .. } => n == name,
-            MethodProto::Ternary { name: n, .. } => n == name,
-            MethodProto::TernaryS { name: n, .. } => n == name,
-            MethodProto::Quaternary { name: n, .. } => n == name,
+            MethodProto::Free { ref name, .. } => name,
+            MethodProto::Unary { ref name, .. } => name,
+            MethodProto::Binary { ref name, .. } => name,
+            MethodProto::BinaryS { ref name, .. } => name,
+            MethodProto::Ternary { ref name, .. } => name,
+            MethodProto::TernaryS { ref name, .. } => name,
+            MethodProto::Quaternary { ref name, .. } => name,
         }
     }
 }

--- a/pyo3-derive-backend/src/lib.rs
+++ b/pyo3-derive-backend/src/lib.rs
@@ -16,7 +16,7 @@ mod utils;
 
 pub use module::{add_fn_to_module, process_functions_in_module, py_init};
 pub use pyclass::{build_py_class, PyClassArgs};
-pub use pyfunction::PyFunctionAttr;
+pub use pyfunction::{build_py_function, PyFunctionAttr};
 pub use pyimpl::{build_py_methods, impl_methods};
 pub use pyproto::build_py_proto;
 pub use utils::get_doc;

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -2,6 +2,7 @@
 
 use crate::pyfunction::Argument;
 use crate::pyfunction::PyFunctionAttr;
+use crate::utils;
 use proc_macro2::TokenStream;
 use quote::quote;
 use quote::ToTokens;
@@ -20,8 +21,8 @@ pub struct FnArg<'a> {
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum FnType {
-    Getter(Option<String>),
-    Setter(Option<String>),
+    Getter,
+    Setter,
     Fn,
     FnNew,
     FnCall,
@@ -33,9 +34,14 @@ pub enum FnType {
 #[derive(Clone, PartialEq, Debug)]
 pub struct FnSpec<'a> {
     pub tp: FnType,
+    // Rust function name
+    pub name: &'a syn::Ident,
+    // Wrapped python name
+    pub python_name: Option<syn::Ident>,
     pub attrs: Vec<Argument>,
     pub args: Vec<FnArg<'a>>,
     pub output: syn::Type,
+    pub doc: syn::LitStr,
 }
 
 pub fn get_return_info(output: &syn::ReturnType) -> syn::Type {
@@ -48,11 +54,29 @@ pub fn get_return_info(output: &syn::ReturnType) -> syn::Type {
 impl<'a> FnSpec<'a> {
     /// Parser function signature and function attributes
     pub fn parse(
-        name: &'a syn::Ident,
         sig: &'a syn::Signature,
         meth_attrs: &mut Vec<syn::Attribute>,
+        allow_custom_name: bool,
     ) -> syn::Result<FnSpec<'a>> {
-        let (mut fn_type, fn_attrs) = parse_attributes(meth_attrs)?;
+        let name = &sig.ident;
+        let (mut fn_type, fn_attrs, mut python_name) =
+            parse_attributes(meth_attrs, allow_custom_name)?;
+
+        // "Tweak" getter / setter names: strip off set_ and get_ if needed
+        if let FnType::Getter | FnType::Setter = &fn_type {
+            if python_name.is_none() {
+                let prefix = match &fn_type {
+                    FnType::Getter => "get_",
+                    FnType::Setter => "set_",
+                    _ => unreachable!(),
+                };
+
+                let ident = sig.ident.to_string();
+                if ident.starts_with(prefix) {
+                    python_name = Some(syn::Ident::new(&ident[prefix.len()..], ident.span()))
+                }
+            }
+        }
 
         let mut has_self = false;
         let mut arguments = Vec::new();
@@ -112,12 +136,53 @@ impl<'a> FnSpec<'a> {
             fn_type = FnType::PySelf(tp);
         }
 
+        let mut parse_erroneous_text_signature = |error_msg: &str| {
+            let py_name = python_name.as_ref().unwrap_or(name);
+
+            // try to parse anyway to give better error messages
+            if let Some(text_signature) =
+                utils::parse_text_signature_attrs(&mut *meth_attrs, py_name)?
+            {
+                Err(syn::Error::new_spanned(text_signature, error_msg))
+            } else {
+                Ok(None)
+            }
+        };
+
+        let text_signature = match &fn_type {
+            FnType::Fn | FnType::PySelf(_) | FnType::FnClass | FnType::FnStatic => {
+                utils::parse_text_signature_attrs(&mut *meth_attrs, name)?
+            }
+            FnType::FnNew => parse_erroneous_text_signature(
+                "text_signature not allowed on __new__; if you want to add a signature on \
+                 __new__, put it on the struct definition instead",
+            )?,
+            FnType::FnCall => {
+                parse_erroneous_text_signature("text_signature not allowed on __call__")?
+            }
+            FnType::Getter => {
+                parse_erroneous_text_signature("text_signature not allowed on getter")?
+            }
+            FnType::Setter => {
+                parse_erroneous_text_signature("text_signature not allowed on setter")?
+            }
+        };
+
+        let doc = utils::get_doc(&meth_attrs, text_signature, true)?;
+
         Ok(FnSpec {
             tp: fn_type,
+            name,
+            python_name,
             attrs: fn_attrs,
             args: arguments,
             output: ty,
+            doc,
         })
+    }
+
+    pub fn py_name(&self) -> &syn::Ident {
+        self.python_name.as_ref().unwrap_or(self.name)
     }
 
     pub fn is_args(&self, name: &syn::Ident) -> bool {
@@ -279,10 +344,15 @@ pub fn check_arg_ty_and_optional<'a>(
     }
 }
 
-fn parse_attributes(attrs: &mut Vec<syn::Attribute>) -> syn::Result<(FnType, Vec<Argument>)> {
+fn parse_attributes(
+    attrs: &mut Vec<syn::Attribute>,
+    allow_custom_name: bool,
+) -> syn::Result<(FnType, Vec<Argument>, Option<syn::Ident>)> {
     let mut new_attrs = Vec::new();
     let mut spec = Vec::new();
     let mut res: Option<FnType> = None;
+    let mut name_with_span = None;
+    let mut property_name = None;
 
     for attr in attrs.iter() {
         match attr.parse_meta()? {
@@ -302,15 +372,21 @@ fn parse_attributes(attrs: &mut Vec<syn::Attribute>) -> syn::Result<(FnType, Vec
                     res = Some(FnType::FnStatic)
                 } else if name.is_ident("setter") || name.is_ident("getter") {
                     if let syn::AttrStyle::Inner(_) = attr.style {
-                        panic!("Inner style attribute is not supported for setter and getter");
+                        return Err(syn::Error::new_spanned(
+                            attr,
+                            "Inner style attribute is not supported for setter and getter",
+                        ));
                     }
                     if res != None {
-                        panic!("setter/getter attribute can not be used mutiple times");
+                        return Err(syn::Error::new_spanned(
+                            attr,
+                            "setter/getter attribute can not be used mutiple times",
+                        ));
                     }
                     if name.is_ident("setter") {
-                        res = Some(FnType::Setter(None))
+                        res = Some(FnType::Setter)
                     } else {
-                        res = Some(FnType::Getter(None))
+                        res = Some(FnType::Getter)
                     }
                 } else {
                     new_attrs.push(attr.clone())
@@ -332,46 +408,73 @@ fn parse_attributes(attrs: &mut Vec<syn::Attribute>) -> syn::Result<(FnType, Vec
                     res = Some(FnType::FnCall)
                 } else if path.is_ident("setter") || path.is_ident("getter") {
                     if let syn::AttrStyle::Inner(_) = attr.style {
-                        panic!(
-                            "Inner style attribute is not
-                                    supported for setter and getter"
-                        );
+                        return Err(syn::Error::new_spanned(
+                            attr,
+                            "Inner style attribute is not supported for setter and getter",
+                        ));
                     }
                     if res != None {
-                        panic!("setter/getter attribute can not be used mutiple times");
+                        return Err(syn::Error::new_spanned(
+                            attr,
+                            "setter/getter attribute can not be used mutiple times",
+                        ));
                     }
                     if nested.len() != 1 {
-                        panic!("setter/getter requires one value");
+                        return Err(syn::Error::new_spanned(
+                            attr,
+                            "setter/getter requires one value",
+                        ));
                     }
-                    match nested.first().unwrap() {
-                        syn::NestedMeta::Meta(syn::Meta::Path(ref w)) => {
-                            if path.is_ident("setter") {
-                                res = Some(FnType::Setter(Some(w.segments[0].ident.to_string())))
-                            } else {
-                                res = Some(FnType::Getter(Some(w.segments[0].ident.to_string())))
-                            }
+
+                    res = if path.is_ident("setter") {
+                        Some(FnType::Setter)
+                    } else {
+                        Some(FnType::Getter)
+                    };
+
+                    property_name = match nested.first().unwrap() {
+                        syn::NestedMeta::Meta(syn::Meta::Path(ref w)) if w.segments.len() == 1 => {
+                            Some(w.segments[0].ident.clone())
                         }
                         syn::NestedMeta::Lit(ref lit) => match *lit {
-                            syn::Lit::Str(ref s) => {
-                                if path.is_ident("setter") {
-                                    res = Some(FnType::Setter(Some(s.value())))
-                                } else {
-                                    res = Some(FnType::Getter(Some(s.value())))
-                                }
-                            }
+                            syn::Lit::Str(ref s) => Some(s.parse()?),
                             _ => {
-                                panic!("setter/getter attribute requires str value");
+                                return Err(syn::Error::new_spanned(
+                                    lit,
+                                    "setter/getter attribute requires str value",
+                                ))
                             }
                         },
                         _ => {
-                            println!("cannot parse {:?} attribute: {:?}", path, nested);
+                            return Err(syn::Error::new_spanned(
+                                nested.first().unwrap(),
+                                "expected ident or string literal for property name",
+                            ))
                         }
-                    }
+                    };
                 } else if path.is_ident("args") {
                     let attrs = PyFunctionAttr::from_meta(nested)?;
                     spec.extend(attrs.arguments)
                 } else {
                     new_attrs.push(attr.clone())
+                }
+            }
+            syn::Meta::NameValue(nv) if allow_custom_name && nv.path.is_ident("name") => {
+                if name_with_span.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        nv.path,
+                        "name can not be specified multiple times",
+                    ));
+                }
+
+                match nv.lit {
+                    syn::Lit::Str(s) => name_with_span = Some((s.parse()?, nv.path.span())),
+                    _ => {
+                        return Err(syn::Error::new_spanned(
+                            nv.lit,
+                            "Expected string literal for method name",
+                        ))
+                    }
                 }
             }
             syn::Meta::NameValue(_) => new_attrs.push(attr.clone()),
@@ -380,9 +483,47 @@ fn parse_attributes(attrs: &mut Vec<syn::Attribute>) -> syn::Result<(FnType, Vec
     attrs.clear();
     attrs.extend(new_attrs);
 
+    if let Some((_, span)) = &name_with_span {
+        match &res {
+            Some(FnType::FnNew) => {
+                return Err(syn::Error::new(
+                    *span,
+                    "name can not be specified with #[new]",
+                ))
+            }
+            Some(FnType::FnCall) => {
+                return Err(syn::Error::new(
+                    *span,
+                    "name can not be specified with #[call]",
+                ))
+            }
+            Some(FnType::Getter) => {
+                return Err(syn::Error::new(
+                    *span,
+                    "name can not be specified for getter",
+                ))
+            }
+            Some(FnType::Setter) => {
+                return Err(syn::Error::new(
+                    *span,
+                    "name can not be specified for setter",
+                ))
+            }
+            _ => {}
+        }
+    }
+
+    // Thanks to check above we can be sure that this generates the right python name
+    let python_name = match res {
+        Some(FnType::FnNew) => Some(syn::Ident::new("__new__", proc_macro2::Span::call_site())),
+        Some(FnType::FnCall) => Some(syn::Ident::new("__call__", proc_macro2::Span::call_site())),
+        Some(FnType::Getter) | Some(FnType::Setter) => property_name,
+        _ => name_with_span.map(|ns| ns.0),
+    };
+
     match res {
-        Some(tp) => Ok((tp, spec)),
-        None => Ok((FnType::Fn, spec)),
+        Some(tp) => Ok((tp, spec, python_name)),
+        None => Ok((FnType::Fn, spec, python_name)),
     }
 }
 

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -459,19 +459,19 @@ fn parse_attributes(
                     new_attrs.push(attr.clone())
                 }
             }
-            syn::Meta::NameValue(nv) if allow_custom_name && nv.path.is_ident("name") => {
+            syn::Meta::NameValue(ref nv) if allow_custom_name && nv.path.is_ident("name") => {
                 if name_with_span.is_some() {
                     return Err(syn::Error::new_spanned(
-                        nv.path,
+                        &nv.path,
                         "name can not be specified multiple times",
                     ));
                 }
 
-                match nv.lit {
+                match &nv.lit {
                     syn::Lit::Str(s) => name_with_span = Some((s.parse()?, nv.path.span())),
                     _ => {
                         return Err(syn::Error::new_spanned(
-                            nv.lit,
+                            &nv.lit,
                             "Expected string literal for method name",
                         ))
                     }

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
 use crate::pyfunction::Argument;
-use crate::pyfunction::{PyFunctionAttr, parse_name_attribute};
+use crate::pyfunction::{parse_name_attribute, PyFunctionAttr};
 use crate::utils;
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -61,8 +61,11 @@ impl<'a> FnSpec<'a> {
         allow_custom_name: bool,
     ) -> syn::Result<FnSpec<'a>> {
         let name = &sig.ident;
-        let MethodAttributes { ty: mut fn_type, args: fn_attrs, mut python_name } =
-            parse_method_attributes(meth_attrs, allow_custom_name)?;
+        let MethodAttributes {
+            ty: mut fn_type,
+            args: fn_attrs,
+            mut python_name,
+        } = parse_method_attributes(meth_attrs, allow_custom_name)?;
 
         let mut has_self = false;
         let mut arguments = Vec::new();
@@ -346,7 +349,7 @@ pub fn check_arg_ty_and_optional<'a>(
 struct MethodAttributes {
     ty: FnType,
     args: Vec<Argument>,
-    python_name: Option<syn::Ident>
+    python_name: Option<syn::Ident>,
 }
 
 fn parse_method_attributes(
@@ -477,36 +480,47 @@ fn parse_method_attributes(
         property_name
     };
 
-    Ok(MethodAttributes { ty, args, python_name })
+    Ok(MethodAttributes {
+        ty,
+        args,
+        python_name,
+    })
 }
 
 fn parse_method_name_attribute(
     ty: &FnType,
     attrs: &mut Vec<syn::Attribute>,
-    property_name: Option<syn::Ident>
+    property_name: Option<syn::Ident>,
 ) -> syn::Result<Option<syn::Ident>> {
-
     let name = parse_name_attribute(attrs)?;
 
     // Reject some invalid combinations
     if let Some(name) = &name {
         match ty {
-            FnType::FnNew => return Err(syn::Error::new_spanned(
-                name,
-                "name can not be specified with #[new]",
-            )),
-            FnType::FnCall => return Err(syn::Error::new_spanned(
-                name,
-                "name can not be specified with #[call]",
-            )),
-            FnType::Getter => return Err(syn::Error::new_spanned(
-                name,
-                "name can not be specified for getter",
-            )),
-            FnType::Setter => return Err(syn::Error::new_spanned(
-                name,
-                "name can not be specified for setter",
-            )),
+            FnType::FnNew => {
+                return Err(syn::Error::new_spanned(
+                    name,
+                    "name can not be specified with #[new]",
+                ))
+            }
+            FnType::FnCall => {
+                return Err(syn::Error::new_spanned(
+                    name,
+                    "name can not be specified with #[call]",
+                ))
+            }
+            FnType::Getter => {
+                return Err(syn::Error::new_spanned(
+                    name,
+                    "name can not be specified for getter",
+                ))
+            }
+            FnType::Setter => {
+                return Err(syn::Error::new_spanned(
+                    name,
+                    "name can not be specified for setter",
+                ))
+            }
             _ => {}
         }
     }

--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -161,7 +161,7 @@ pub fn add_fn_to_module(
     let spec = method::FnSpec {
         tp: method::FnType::Fn,
         name: &function_wrapper_ident,
-        python_name: Some(python_name),
+        python_name,
         attrs: pyfn_attrs,
         args: arguments,
         output: ty,
@@ -170,7 +170,7 @@ pub fn add_fn_to_module(
 
     let doc = &spec.doc;
 
-    let python_name = spec.py_name();
+    let python_name = &spec.python_name;
 
     let wrapper = function_c_wrapper(&func.sig.ident, &spec);
 

--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -13,7 +13,7 @@ use syn::Ident;
 
 /// Generates the function that is called by the python interpreter to initialize the native
 /// module
-pub fn py_init(fnname: &Ident, name: &Ident, doc: syn::Lit) -> TokenStream {
+pub fn py_init(fnname: &Ident, name: &Ident, doc: syn::LitStr) -> TokenStream {
     let cb_name = Ident::new(&format!("PyInit_{}", name), Span::call_site());
 
     quote! {
@@ -36,7 +36,7 @@ pub fn process_functions_in_module(func: &mut syn::ItemFn) {
             if let Some((module_name, python_name, pyfn_attrs)) =
                 extract_pyfn_attrs(&mut func.attrs)
             {
-                let function_to_python = add_fn_to_module(func, &python_name, pyfn_attrs);
+                let function_to_python = add_fn_to_module(func, python_name, pyfn_attrs);
                 let function_wrapper_ident = function_wrapper_ident(&func.sig.ident);
                 let item: syn::ItemFn = syn::parse_quote! {
                     fn block_wrapper() {
@@ -134,7 +134,7 @@ fn function_wrapper_ident(name: &Ident) -> Ident {
 /// function
 pub fn add_fn_to_module(
     func: &mut syn::ItemFn,
-    python_name: &Ident,
+    python_name: Ident,
     pyfn_attrs: Vec<pyfunction::Argument>,
 ) -> TokenStream {
     let mut arguments = Vec::new();
@@ -147,17 +147,7 @@ pub fn add_fn_to_module(
 
     let ty = method::get_return_info(&func.sig.output);
 
-    let spec = method::FnSpec {
-        tp: method::FnType::Fn,
-        attrs: pyfn_attrs,
-        args: arguments,
-        output: ty,
-    };
-
-    let function_wrapper_ident = function_wrapper_ident(&func.sig.ident);
-
-    let wrapper = function_c_wrapper(&func.sig.ident, &spec);
-    let text_signature = match utils::parse_text_signature_attrs(&mut func.attrs, python_name) {
+    let text_signature = match utils::parse_text_signature_attrs(&mut func.attrs, &python_name) {
         Ok(text_signature) => text_signature,
         Err(err) => return err.to_compile_error(),
     };
@@ -165,6 +155,24 @@ pub fn add_fn_to_module(
         Ok(doc) => doc,
         Err(err) => return err.to_compile_error(),
     };
+
+    let function_wrapper_ident = function_wrapper_ident(&func.sig.ident);
+
+    let spec = method::FnSpec {
+        tp: method::FnType::Fn,
+        name: &function_wrapper_ident,
+        python_name: Some(python_name),
+        attrs: pyfn_attrs,
+        args: arguments,
+        output: ty,
+        doc,
+    };
+
+    let doc = &spec.doc;
+
+    let python_name = spec.py_name();
+
+    let wrapper = function_c_wrapper(&func.sig.ident, &spec);
 
     let tokens = quote! {
         fn #function_wrapper_ident(py: pyo3::Python) -> pyo3::PyObject {

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -5,6 +5,7 @@ use crate::pymethod::{impl_py_getter_def, impl_py_setter_def, impl_wrap_getter, 
 use crate::utils;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
+use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{parse_quote, Expr, Token};
@@ -455,7 +456,7 @@ fn impl_descriptors(
                             let spec = FnSpec {
                                 tp: FnType::Getter,
                                 name: &name,
-                                python_name: None,
+                                python_name: name.unraw(),
                                 attrs: Vec::new(),
                                 args: Vec::new(),
                                 output: parse_quote!(PyResult<#field_ty>),
@@ -469,7 +470,7 @@ fn impl_descriptors(
                             let spec = FnSpec {
                                 tp: FnType::Setter,
                                 name: &setter_name,
-                                python_name: Some(name.clone()),
+                                python_name: name.unraw(),
                                 attrs: Vec::new(),
                                 args: vec![FnArg {
                                     name: &name,

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -179,7 +179,7 @@ pub fn build_py_class(class: &mut syn::ItemStruct, attr: &PyClassArgs) -> syn::R
         ));
     }
 
-    Ok(impl_class(&class.ident, &attr, doc, descriptors))
+    impl_class(&class.ident, &attr, doc, descriptors)
 }
 
 /// Parses `#[pyo3(get, set)]`
@@ -192,9 +192,9 @@ fn parse_descriptors(item: &mut syn::Field) -> syn::Result<Vec<FnType>> {
                 for meta in list.nested.iter() {
                     if let syn::NestedMeta::Meta(ref metaitem) = meta {
                         if metaitem.path().is_ident("get") {
-                            descs.push(FnType::Getter(None));
+                            descs.push(FnType::Getter);
                         } else if metaitem.path().is_ident("set") {
-                            descs.push(FnType::Setter(None));
+                            descs.push(FnType::Setter);
                         } else {
                             return Err(syn::Error::new_spanned(
                                 metaitem,
@@ -259,9 +259,9 @@ fn get_class_python_name(cls: &syn::Ident, attr: &PyClassArgs) -> TokenStream {
 fn impl_class(
     cls: &syn::Ident,
     attr: &PyClassArgs,
-    doc: syn::Lit,
+    doc: syn::LitStr,
     descriptors: Vec<(syn::Field, Vec<FnType>)>,
-) -> TokenStream {
+) -> syn::Result<TokenStream> {
     let cls_name = get_class_python_name(cls, attr).to_string();
 
     let extra = {
@@ -293,7 +293,7 @@ fn impl_class(
     let extra = if !descriptors.is_empty() {
         let path = syn::Path::from(syn::PathSegment::from(cls.clone()));
         let ty = syn::Type::from(syn::TypePath { path, qself: None });
-        let desc_impls = impl_descriptors(&ty, descriptors);
+        let desc_impls = impl_descriptors(&ty, descriptors)?;
         quote! {
             #desc_impls
             #extra
@@ -354,7 +354,7 @@ fn impl_class(
     let base = &attr.base;
     let flags = &attr.flags;
 
-    quote! {
+    Ok(quote! {
         impl pyo3::type_object::PyTypeInfo for #cls {
             type Type = #cls;
             type BaseType = #base;
@@ -396,10 +396,13 @@ fn impl_class(
 
         #gc_impl
 
-    }
+    })
 }
 
-fn impl_descriptors(cls: &syn::Type, descriptors: Vec<(syn::Field, Vec<FnType>)>) -> TokenStream {
+fn impl_descriptors(
+    cls: &syn::Type,
+    descriptors: Vec<(syn::Field, Vec<FnType>)>,
+) -> syn::Result<TokenStream> {
     let methods: Vec<TokenStream> = descriptors
         .iter()
         .flat_map(|&(ref field, ref fns)| {
@@ -408,7 +411,7 @@ fn impl_descriptors(cls: &syn::Type, descriptors: Vec<(syn::Field, Vec<FnType>)>
                     let name = field.ident.clone().unwrap();
                     let field_ty = &field.ty;
                     match *desc {
-                        FnType::Getter(_) => {
+                        FnType::Getter => {
                             quote! {
                                 impl #cls {
                                     fn #name(&self) -> pyo3::PyResult<#field_ty> {
@@ -417,7 +420,7 @@ fn impl_descriptors(cls: &syn::Type, descriptors: Vec<(syn::Field, Vec<FnType>)>
                                 }
                             }
                         }
-                        FnType::Setter(_) => {
+                        FnType::Setter => {
                             let setter_name =
                                 syn::Ident::new(&format!("set_{}", name), Span::call_site());
                             quote! {
@@ -444,21 +447,29 @@ fn impl_descriptors(cls: &syn::Type, descriptors: Vec<(syn::Field, Vec<FnType>)>
                     let name = field.ident.clone().unwrap();
 
                     // FIXME better doc?
-                    let doc = syn::Lit::from(syn::LitStr::new(&name.to_string(), name.span()));
+                    let doc = syn::LitStr::new(&name.to_string(), name.span());
 
                     let field_ty = &field.ty;
                     match *desc {
-                        FnType::Getter(ref getter) => impl_py_getter_def(
-                            &name,
-                            doc,
-                            getter,
-                            &impl_wrap_getter(&cls, &name, false),
-                        ),
-                        FnType::Setter(ref setter) => {
+                        FnType::Getter => {
+                            let spec = FnSpec {
+                                tp: FnType::Getter,
+                                name: &name,
+                                python_name: None,
+                                attrs: Vec::new(),
+                                args: Vec::new(),
+                                output: parse_quote!(PyResult<#field_ty>),
+                                doc,
+                            };
+                            Ok(impl_py_getter_def(&spec, &impl_wrap_getter(&cls, &spec)?))
+                        }
+                        FnType::Setter => {
                             let setter_name =
                                 syn::Ident::new(&format!("set_{}", name), Span::call_site());
                             let spec = FnSpec {
-                                tp: FnType::Setter(None),
+                                tp: FnType::Setter,
+                                name: &setter_name,
+                                python_name: Some(name.clone()),
                                 attrs: Vec::new(),
                                 args: vec![FnArg {
                                     name: &name,
@@ -470,22 +481,18 @@ fn impl_descriptors(cls: &syn::Type, descriptors: Vec<(syn::Field, Vec<FnType>)>
                                     reference: false,
                                 }],
                                 output: parse_quote!(PyResult<()>),
-                            };
-                            impl_py_setter_def(
-                                &name,
                                 doc,
-                                setter,
-                                &impl_wrap_setter(&cls, &setter_name, &spec),
-                            )
+                            };
+                            Ok(impl_py_setter_def(&spec, &impl_wrap_setter(&cls, &spec)?))
                         }
                         _ => unreachable!(),
                     }
                 })
-                .collect::<Vec<TokenStream>>()
+                .collect::<Vec<syn::Result<TokenStream>>>()
         })
-        .collect();
+        .collect::<syn::Result<_>>()?;
 
-    quote! {
+    Ok(quote! {
         #(#methods)*
 
         pyo3::inventory::submit! {
@@ -494,7 +501,7 @@ fn impl_descriptors(cls: &syn::Type, descriptors: Vec<(syn::Field, Vec<FnType>)>
                 <ClsInventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(#py_methods),*])
             }
         }
-    }
+    })
 }
 
 fn check_generics(class: &mut syn::ItemStruct) -> syn::Result<()> {

--- a/pyo3-derive-backend/src/pyfunction.rs
+++ b/pyo3-derive-backend/src/pyfunction.rs
@@ -1,12 +1,12 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
+use crate::module::add_fn_to_module;
+use proc_macro2::TokenStream;
 use syn::ext::IdentExt;
 use syn::parse::ParseBuffer;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{NestedMeta, Path};
-use proc_macro2::TokenStream;
-use crate::module::add_fn_to_module;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Argument {
@@ -201,21 +201,22 @@ pub fn parse_name_attribute(attrs: &mut Vec<syn::Attribute>) -> syn::Result<Opti
     let mut name_attrs = Vec::new();
 
     // Using retain will extract all name attributes from the attribute list
-    attrs.retain(|attr| {
-        match attr.parse_meta() {
-            Ok(syn::Meta::NameValue(ref nv)) if nv.path.is_ident("name") => {
-                name_attrs.push((nv.lit.clone(), attr.span()));
-                false
-            }
-            _ => true
+    attrs.retain(|attr| match attr.parse_meta() {
+        Ok(syn::Meta::NameValue(ref nv)) if nv.path.is_ident("name") => {
+            name_attrs.push((nv.lit.clone(), attr.span()));
+            false
         }
+        _ => true,
     });
 
     let mut name = None;
 
     for (lit, span) in name_attrs {
         if name.is_some() {
-            return Err(syn::Error::new(span, "#[name] can not be specified multiple times"))
+            return Err(syn::Error::new(
+                span,
+                "#[name] can not be specified multiple times",
+            ));
         }
 
         name = match lit {
@@ -224,8 +225,13 @@ pub fn parse_name_attribute(attrs: &mut Vec<syn::Attribute>) -> syn::Result<Opti
                 // This span is the whole attribute span, which is nicer for reporting errors.
                 ident.set_span(span);
                 Some(ident)
-            },
-            _ => return Err(syn::Error::new(span, "Expected string literal for #[name] argument"))
+            }
+            _ => {
+                return Err(syn::Error::new(
+                    span,
+                    "Expected string literal for #[name] argument",
+                ))
+            }
         };
     }
 

--- a/pyo3-derive-backend/src/pyfunction.rs
+++ b/pyo3-derive-backend/src/pyfunction.rs
@@ -1,8 +1,12 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
+use syn::ext::IdentExt;
 use syn::parse::ParseBuffer;
 use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
 use syn::{NestedMeta, Path};
+use proc_macro2::TokenStream;
+use crate::module::add_fn_to_module;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Argument {
@@ -191,6 +195,47 @@ impl PyFunctionAttr {
         };
         Ok(())
     }
+}
+
+pub fn parse_name_attribute(attrs: &mut Vec<syn::Attribute>) -> syn::Result<Option<syn::Ident>> {
+    let mut name_attrs = Vec::new();
+
+    // Using retain will extract all name attributes from the attribute list
+    attrs.retain(|attr| {
+        match attr.parse_meta() {
+            Ok(syn::Meta::NameValue(ref nv)) if nv.path.is_ident("name") => {
+                name_attrs.push((nv.lit.clone(), attr.span()));
+                false
+            }
+            _ => true
+        }
+    });
+
+    let mut name = None;
+
+    for (lit, span) in name_attrs {
+        if name.is_some() {
+            return Err(syn::Error::new(span, "#[name] can not be specified multiple times"))
+        }
+
+        name = match lit {
+            syn::Lit::Str(s) => {
+                let mut ident: syn::Ident = s.parse()?;
+                // This span is the whole attribute span, which is nicer for reporting errors.
+                ident.set_span(span);
+                Some(ident)
+            },
+            _ => return Err(syn::Error::new(span, "Expected string literal for #[name] argument"))
+        };
+    }
+
+    Ok(name)
+}
+
+pub fn build_py_function(ast: &mut syn::ItemFn, args: PyFunctionAttr) -> syn::Result<TokenStream> {
+    let python_name =
+        parse_name_attribute(&mut ast.attrs)?.unwrap_or_else(|| ast.sig.ident.unraw());
+    Ok(add_fn_to_module(ast, python_name, args.arguments))
 }
 
 #[cfg(test)]

--- a/pyo3-derive-backend/src/pyimpl.rs
+++ b/pyo3-derive-backend/src/pyimpl.rs
@@ -25,13 +25,7 @@ pub fn impl_methods(ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> syn::Resu
     let mut methods = Vec::new();
     for iimpl in impls.iter_mut() {
         if let syn::ImplItem::Method(ref mut meth) = iimpl {
-            let name = meth.sig.ident.clone();
-            methods.push(pymethod::gen_py_method(
-                ty,
-                &name,
-                &mut meth.sig,
-                &mut meth.attrs,
-            )?);
+            methods.push(pymethod::gen_py_method(ty, &mut meth.sig, &mut meth.attrs)?);
         }
     }
 

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -72,7 +72,7 @@ fn impl_wrap_common(
     slf: TokenStream,
     body: TokenStream,
 ) -> TokenStream {
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     if spec.args.is_empty() && noargs {
         quote! {
             unsafe extern "C" fn __wrap(
@@ -80,7 +80,7 @@ fn impl_wrap_common(
             ) -> *mut pyo3::ffi::PyObject
             {
                 const _LOCATION: &'static str = concat!(
-                    stringify!(#cls), ".", stringify!(#py_name), "()");
+                    stringify!(#cls), ".", stringify!(#python_name), "()");
                 let _py = pyo3::Python::assume_gil_acquired();
                 let _pool = pyo3::GILPool::new(_py);
                 #slf
@@ -102,7 +102,7 @@ fn impl_wrap_common(
                 _kwargs: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
             {
                 const _LOCATION: &'static str = concat!(
-                    stringify!(#cls), ".", stringify!(#py_name), "()");
+                    stringify!(#cls), ".", stringify!(#python_name), "()");
                 let _py = pyo3::Python::assume_gil_acquired();
                 let _pool = pyo3::GILPool::new(_py);
                 #slf
@@ -120,7 +120,7 @@ fn impl_wrap_common(
 
 /// Generate function wrapper for protocol method (PyCFunction, PyCFunctionWithKeywords)
 pub fn impl_proto_wrap(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     let cb = impl_call(cls, &spec);
     let body = impl_arg_params(&spec, cb);
 
@@ -131,7 +131,7 @@ pub fn impl_proto_wrap(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
             _args: *mut pyo3::ffi::PyObject,
             _kwargs: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#python_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             let _slf = _py.mut_from_borrowed_ptr::<#cls>(_slf);
@@ -149,7 +149,7 @@ pub fn impl_proto_wrap(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
 /// Generate class method wrapper (PyCFunction, PyCFunctionWithKeywords)
 pub fn impl_wrap_new(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
     let name = &spec.name;
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     let names: Vec<syn::Ident> = get_arg_names(&spec);
     let cb = quote! { #cls::#name(&_obj, #(#names),*) };
 
@@ -164,7 +164,7 @@ pub fn impl_wrap_new(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
         {
             use pyo3::type_object::PyTypeInfo;
 
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#python_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             match pyo3::type_object::PyRawObject::new(_py, #cls::type_object(), _cls) {
@@ -194,7 +194,7 @@ pub fn impl_wrap_new(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
 /// Generate class method wrapper (PyCFunction, PyCFunctionWithKeywords)
 pub fn impl_wrap_class(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
     let name = &spec.name;
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     let names: Vec<syn::Ident> = get_arg_names(&spec);
     let cb = quote! { #cls::#name(&_cls, #(#names),*) };
 
@@ -207,7 +207,7 @@ pub fn impl_wrap_class(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
             _args: *mut pyo3::ffi::PyObject,
             _kwargs: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#python_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             let _cls = pyo3::types::PyType::from_type_ptr(_py, _cls as *mut pyo3::ffi::PyTypeObject);
@@ -225,7 +225,7 @@ pub fn impl_wrap_class(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
 /// Generate static method wrapper (PyCFunction, PyCFunctionWithKeywords)
 pub fn impl_wrap_static(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
     let name = &spec.name;
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     let names: Vec<syn::Ident> = get_arg_names(&spec);
     let cb = quote! { #cls::#name(#(#names),*) };
 
@@ -238,7 +238,7 @@ pub fn impl_wrap_static(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
             _args: *mut pyo3::ffi::PyObject,
             _kwargs: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#python_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             let _args = _py.from_borrowed_ptr::<pyo3::types::PyTuple>(_args);
@@ -266,7 +266,7 @@ pub(crate) fn impl_wrap_getter(cls: &syn::Type, spec: &FnSpec) -> syn::Result<To
     };
 
     let name = &spec.name;
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
 
     let fncall = if takes_py {
         quote! { _slf.#name(_py) }
@@ -278,7 +278,7 @@ pub(crate) fn impl_wrap_getter(cls: &syn::Type, spec: &FnSpec) -> syn::Result<To
         unsafe extern "C" fn __wrap(
             _slf: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> *mut pyo3::ffi::PyObject
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#python_name),"()");
 
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
@@ -302,7 +302,7 @@ pub(crate) fn impl_wrap_getter(cls: &syn::Type, spec: &FnSpec) -> syn::Result<To
 /// Generate functiona wrapper (PyCFunction, PyCFunctionWithKeywords)
 pub(crate) fn impl_wrap_setter(cls: &syn::Type, spec: &FnSpec<'_>) -> syn::Result<TokenStream> {
     let name = &spec.name;
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
 
     let val_ty = match &*spec.args {
         [] => {
@@ -326,7 +326,7 @@ pub(crate) fn impl_wrap_setter(cls: &syn::Type, spec: &FnSpec<'_>) -> syn::Resul
             _slf: *mut pyo3::ffi::PyObject,
             _value: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> pyo3::libc::c_int
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#python_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             let _slf = _py.mut_from_borrowed_ptr::<#cls>(_slf);
@@ -517,7 +517,7 @@ fn impl_arg_param(
 }
 
 pub fn impl_py_method_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     let doc = &spec.doc;
     if spec.args.is_empty() {
         quote! {
@@ -525,7 +525,7 @@ pub fn impl_py_method_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
                 #wrapper
 
                 pyo3::class::PyMethodDef {
-                    ml_name: stringify!(#py_name),
+                    ml_name: stringify!(#python_name),
                     ml_meth: pyo3::class::PyMethodType::PyNoArgsFunction(__wrap),
                     ml_flags: pyo3::ffi::METH_NOARGS,
                     ml_doc: #doc,
@@ -538,7 +538,7 @@ pub fn impl_py_method_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
                 #wrapper
 
                 pyo3::class::PyMethodDef {
-                    ml_name: stringify!(#py_name),
+                    ml_name: stringify!(#python_name),
                     ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
                     ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS,
                     ml_doc: #doc,
@@ -549,14 +549,14 @@ pub fn impl_py_method_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
 }
 
 pub fn impl_py_method_def_new(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     let doc = &spec.doc;
     quote! {
         pyo3::class::PyMethodDefType::New({
             #wrapper
 
             pyo3::class::PyMethodDef {
-                ml_name: stringify!(#py_name),
+                ml_name: stringify!(#python_name),
                 ml_meth: pyo3::class::PyMethodType::PyNewFunc(__wrap),
                 ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS,
                 ml_doc: #doc,
@@ -566,14 +566,14 @@ pub fn impl_py_method_def_new(spec: &FnSpec, wrapper: &TokenStream) -> TokenStre
 }
 
 pub fn impl_py_method_def_class(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     let doc = &spec.doc;
     quote! {
         pyo3::class::PyMethodDefType::Class({
             #wrapper
 
             pyo3::class::PyMethodDef {
-                ml_name: stringify!(#py_name),
+                ml_name: stringify!(#python_name),
                 ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
                 ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS |
                 pyo3::ffi::METH_CLASS,
@@ -584,14 +584,14 @@ pub fn impl_py_method_def_class(spec: &FnSpec, wrapper: &TokenStream) -> TokenSt
 }
 
 pub fn impl_py_method_def_static(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     let doc = &spec.doc;
     quote! {
         pyo3::class::PyMethodDefType::Static({
             #wrapper
 
             pyo3::class::PyMethodDef {
-                ml_name: stringify!(#py_name),
+                ml_name: stringify!(#python_name),
                 ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
                 ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS | pyo3::ffi::METH_STATIC,
                 ml_doc: #doc,
@@ -601,14 +601,14 @@ pub fn impl_py_method_def_static(spec: &FnSpec, wrapper: &TokenStream) -> TokenS
 }
 
 pub fn impl_py_method_def_call(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
-    let py_name = spec.py_name();
+    let python_name = &spec.python_name;
     let doc = &spec.doc;
     quote! {
         pyo3::class::PyMethodDefType::Call({
             #wrapper
 
             pyo3::class::PyMethodDef {
-                ml_name: stringify!(#py_name),
+                ml_name: stringify!(#python_name),
                 ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
                 ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS,
                 ml_doc: #doc,
@@ -618,7 +618,7 @@ pub fn impl_py_method_def_call(spec: &FnSpec, wrapper: &TokenStream) -> TokenStr
 }
 
 pub(crate) fn impl_py_setter_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
-    let py_name = &spec.py_name();
+    let python_name = &&spec.python_name;
     let doc = &spec.doc;
 
     quote! {
@@ -626,7 +626,7 @@ pub(crate) fn impl_py_setter_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenS
             #wrapper
 
             pyo3::class::PySetterDef {
-                name: stringify!(#py_name),
+                name: stringify!(#python_name),
                 meth: __wrap,
                 doc: #doc,
             }
@@ -635,7 +635,7 @@ pub(crate) fn impl_py_setter_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenS
 }
 
 pub(crate) fn impl_py_getter_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
-    let py_name = &spec.py_name();
+    let python_name = &&spec.python_name;
     let doc = &spec.doc;
 
     quote! {
@@ -643,7 +643,7 @@ pub(crate) fn impl_py_getter_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenS
             #wrapper
 
             pyo3::class::PyGetterDef {
-                name: stringify!(#py_name),
+                name: stringify!(#python_name),
                 meth: __wrap,
                 doc: #doc,
             }

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -6,97 +6,29 @@ use quote::quote;
 
 pub fn gen_py_method(
     cls: &syn::Type,
-    name: &syn::Ident,
     sig: &mut syn::Signature,
     meth_attrs: &mut Vec<syn::Attribute>,
 ) -> syn::Result<TokenStream> {
-    check_generic(name, sig)?;
+    check_generic(sig)?;
 
-    let spec = FnSpec::parse(name, sig, &mut *meth_attrs)?;
-
-    let mut parse_erroneous_text_signature = |alt_name: Option<&str>, error_msg: &str| {
-        let python_name;
-        let python_name = match alt_name {
-            None => name,
-            Some(alt_name) => {
-                python_name = syn::Ident::new(alt_name, name.span());
-                &python_name
-            }
-        };
-        // try to parse anyway to give better error messages
-        if let Some(text_signature) =
-            utils::parse_text_signature_attrs(&mut *meth_attrs, python_name)?
-        {
-            Err(syn::Error::new_spanned(text_signature, error_msg))
-        } else {
-            Ok(None)
-        }
-    };
-
-    let text_signature = match &spec.tp {
-        FnType::Fn | FnType::PySelf(_) | FnType::FnClass | FnType::FnStatic => {
-            utils::parse_text_signature_attrs(&mut *meth_attrs, name)?
-        }
-        FnType::FnNew => parse_erroneous_text_signature(
-            Some("__new__"),
-            "text_signature not allowed on __new__; if you want to add a signature on \
-             __new__, put it on the struct definition instead",
-        )?,
-        FnType::FnCall => parse_erroneous_text_signature(
-            Some("__call__"),
-            "text_signature not allowed on __call__",
-        )?,
-        FnType::Getter(getter_name) => parse_erroneous_text_signature(
-            getter_name.as_ref().map(|v| &**v),
-            "text_signature not allowed on getter",
-        )?,
-        FnType::Setter(setter_name) => parse_erroneous_text_signature(
-            setter_name.as_ref().map(|v| &**v),
-            "text_signature not allowed on setter",
-        )?,
-    };
-    let doc = utils::get_doc(&meth_attrs, text_signature, true)?;
+    let spec = FnSpec::parse(sig, &mut *meth_attrs, true)?;
 
     Ok(match spec.tp {
-        FnType::Fn => impl_py_method_def(name, doc, &spec, &impl_wrap(cls, name, &spec, true)),
-        FnType::PySelf(ref self_ty) => impl_py_method_def(
-            name,
-            doc,
-            &spec,
-            &impl_wrap_pyslf(cls, name, &spec, self_ty, true),
-        ),
-        FnType::FnNew => impl_py_method_def_new(name, doc, &impl_wrap_new(cls, name, &spec)),
-        FnType::FnCall => impl_py_method_def_call(name, doc, &impl_wrap(cls, name, &spec, false)),
-        FnType::FnClass => impl_py_method_def_class(name, doc, &impl_wrap_class(cls, name, &spec)),
-        FnType::FnStatic => {
-            impl_py_method_def_static(name, doc, &impl_wrap_static(cls, name, &spec))
+        FnType::Fn => impl_py_method_def(&spec, &impl_wrap(cls, &spec, true)),
+        FnType::PySelf(ref self_ty) => {
+            impl_py_method_def(&spec, &impl_wrap_pyslf(cls, &spec, self_ty, true))
         }
-        FnType::Getter(ref getter) => {
-            let takes_py = match &*spec.args {
-                [] => false,
-                [arg] if utils::if_type_is_python(arg.ty) => true,
-                _ => {
-                    return Err(syn::Error::new_spanned(
-                        spec.args[0].ty,
-                        "Getter function can only have one argument of type pyo3::Python!",
-                    ));
-                }
-            };
-            impl_py_getter_def(name, doc, getter, &impl_wrap_getter(cls, name, takes_py))
-        }
-        FnType::Setter(ref setter) => {
-            impl_py_setter_def(name, doc, setter, &impl_wrap_setter(cls, name, &spec))
-        }
+        FnType::FnNew => impl_py_method_def_new(&spec, &impl_wrap_new(cls, &spec)),
+        FnType::FnCall => impl_py_method_def_call(&spec, &impl_wrap(cls, &spec, false)),
+        FnType::FnClass => impl_py_method_def_class(&spec, &impl_wrap_class(cls, &spec)),
+        FnType::FnStatic => impl_py_method_def_static(&spec, &impl_wrap_static(cls, &spec)),
+        FnType::Getter => impl_py_getter_def(&spec, &impl_wrap_getter(cls, &spec)?),
+        FnType::Setter => impl_py_setter_def(&spec, &impl_wrap_setter(cls, &spec)?),
     })
 }
 
-fn check_generic(name: &syn::Ident, sig: &syn::Signature) -> syn::Result<()> {
-    let err_msg = |typ| {
-        format!(
-            "A Python method can't have a generic {} parameter: {}",
-            name, typ
-        )
-    };
+fn check_generic(sig: &syn::Signature) -> syn::Result<()> {
+    let err_msg = |typ| format!("A Python method can't have a generic {} parameter", typ);
     for param in &sig.generics.params {
         match param {
             syn::GenericParam::Lifetime(_) => {}
@@ -112,40 +44,35 @@ fn check_generic(name: &syn::Ident, sig: &syn::Signature) -> syn::Result<()> {
 }
 
 /// Generate function wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap(
-    cls: &syn::Type,
-    name: &syn::Ident,
-    spec: &FnSpec<'_>,
-    noargs: bool,
-) -> TokenStream {
-    let body = impl_call(cls, name, &spec);
+pub fn impl_wrap(cls: &syn::Type, spec: &FnSpec<'_>, noargs: bool) -> TokenStream {
+    let body = impl_call(cls, &spec);
     let slf = impl_self(&quote! { &mut #cls });
-    impl_wrap_common(cls, name, spec, noargs, slf, body)
+    impl_wrap_common(cls, spec, noargs, slf, body)
 }
 
 pub fn impl_wrap_pyslf(
     cls: &syn::Type,
-    name: &syn::Ident,
     spec: &FnSpec<'_>,
     self_ty: &syn::TypePath,
     noargs: bool,
 ) -> TokenStream {
     let names = get_arg_names(spec);
+    let name = &spec.name;
     let body = quote! {
         #cls::#name(_slf, #(#names),*)
     };
     let slf = impl_self(self_ty);
-    impl_wrap_common(cls, name, spec, noargs, slf, body)
+    impl_wrap_common(cls, spec, noargs, slf, body)
 }
 
 fn impl_wrap_common(
     cls: &syn::Type,
-    name: &syn::Ident,
     spec: &FnSpec<'_>,
     noargs: bool,
     slf: TokenStream,
     body: TokenStream,
 ) -> TokenStream {
+    let py_name = spec.py_name();
     if spec.args.is_empty() && noargs {
         quote! {
             unsafe extern "C" fn __wrap(
@@ -153,7 +80,7 @@ fn impl_wrap_common(
             ) -> *mut pyo3::ffi::PyObject
             {
                 const _LOCATION: &'static str = concat!(
-                    stringify!(#cls), ".", stringify!(#name), "()");
+                    stringify!(#cls), ".", stringify!(#py_name), "()");
                 let _py = pyo3::Python::assume_gil_acquired();
                 let _pool = pyo3::GILPool::new(_py);
                 #slf
@@ -175,7 +102,7 @@ fn impl_wrap_common(
                 _kwargs: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
             {
                 const _LOCATION: &'static str = concat!(
-                    stringify!(#cls), ".", stringify!(#name), "()");
+                    stringify!(#cls), ".", stringify!(#py_name), "()");
                 let _py = pyo3::Python::assume_gil_acquired();
                 let _pool = pyo3::GILPool::new(_py);
                 #slf
@@ -192,8 +119,9 @@ fn impl_wrap_common(
 }
 
 /// Generate function wrapper for protocol method (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_proto_wrap(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) -> TokenStream {
-    let cb = impl_call(cls, name, &spec);
+pub fn impl_proto_wrap(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
+    let py_name = spec.py_name();
+    let cb = impl_call(cls, &spec);
     let body = impl_arg_params(&spec, cb);
 
     quote! {
@@ -203,7 +131,7 @@ pub fn impl_proto_wrap(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) ->
             _args: *mut pyo3::ffi::PyObject,
             _kwargs: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             let _slf = _py.mut_from_borrowed_ptr::<#cls>(_slf);
@@ -219,7 +147,9 @@ pub fn impl_proto_wrap(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) ->
 }
 
 /// Generate class method wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap_new(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) -> TokenStream {
+pub fn impl_wrap_new(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
+    let name = &spec.name;
+    let py_name = spec.py_name();
     let names: Vec<syn::Ident> = get_arg_names(&spec);
     let cb = quote! { #cls::#name(&_obj, #(#names),*) };
 
@@ -234,7 +164,7 @@ pub fn impl_wrap_new(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) -> T
         {
             use pyo3::type_object::PyTypeInfo;
 
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             match pyo3::type_object::PyRawObject::new(_py, #cls::type_object(), _cls) {
@@ -262,7 +192,9 @@ pub fn impl_wrap_new(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) -> T
 }
 
 /// Generate class method wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap_class(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) -> TokenStream {
+pub fn impl_wrap_class(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
+    let name = &spec.name;
+    let py_name = spec.py_name();
     let names: Vec<syn::Ident> = get_arg_names(&spec);
     let cb = quote! { #cls::#name(&_cls, #(#names),*) };
 
@@ -275,7 +207,7 @@ pub fn impl_wrap_class(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) ->
             _args: *mut pyo3::ffi::PyObject,
             _kwargs: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             let _cls = pyo3::types::PyType::from_type_ptr(_py, _cls as *mut pyo3::ffi::PyTypeObject);
@@ -291,7 +223,9 @@ pub fn impl_wrap_class(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) ->
 }
 
 /// Generate static method wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub fn impl_wrap_static(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) -> TokenStream {
+pub fn impl_wrap_static(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
+    let name = &spec.name;
+    let py_name = spec.py_name();
     let names: Vec<syn::Ident> = get_arg_names(&spec);
     let cb = quote! { #cls::#name(#(#names),*) };
 
@@ -304,7 +238,7 @@ pub fn impl_wrap_static(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) -
             _args: *mut pyo3::ffi::PyObject,
             _kwargs: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             let _args = _py.from_borrowed_ptr::<pyo3::types::PyTuple>(_args);
@@ -319,17 +253,32 @@ pub fn impl_wrap_static(cls: &syn::Type, name: &syn::Ident, spec: &FnSpec<'_>) -
 }
 
 /// Generate functiona wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub(crate) fn impl_wrap_getter(cls: &syn::Type, name: &syn::Ident, takes_py: bool) -> TokenStream {
+pub(crate) fn impl_wrap_getter(cls: &syn::Type, spec: &FnSpec) -> syn::Result<TokenStream> {
+    let takes_py = match &*spec.args {
+        [] => false,
+        [arg] if utils::if_type_is_python(arg.ty) => true,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                spec.args[0].ty,
+                "Getter function can only have one argument of type pyo3::Python!",
+            ));
+        }
+    };
+
+    let name = &spec.name;
+    let py_name = spec.py_name();
+
     let fncall = if takes_py {
         quote! { _slf.#name(_py) }
     } else {
         quote! { _slf.#name() }
     };
-    quote! {
+
+    Ok(quote! {
         unsafe extern "C" fn __wrap(
             _slf: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> *mut pyo3::ffi::PyObject
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
 
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
@@ -347,31 +296,37 @@ pub(crate) fn impl_wrap_getter(cls: &syn::Type, name: &syn::Ident, takes_py: boo
                 }
             }
         }
-    }
+    })
 }
 
 /// Generate functiona wrapper (PyCFunction, PyCFunctionWithKeywords)
-pub(crate) fn impl_wrap_setter(
-    cls: &syn::Type,
-    name: &syn::Ident,
-    spec: &FnSpec<'_>,
-) -> TokenStream {
-    if spec.args.is_empty() {
-        println!(
-            "Not enough arguments for setter {}::{}",
-            quote! {#cls},
-            name
-        );
-    }
-    let val_ty = spec.args[0].ty;
+pub(crate) fn impl_wrap_setter(cls: &syn::Type, spec: &FnSpec<'_>) -> syn::Result<TokenStream> {
+    let name = &spec.name;
+    let py_name = spec.py_name();
 
-    quote! {
+    let val_ty = match &*spec.args {
+        [] => {
+            return Err(syn::Error::new_spanned(
+                &spec.name,
+                "Not enough arguments for setter {}::{}",
+            ))
+        }
+        [arg] => &arg.ty,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                spec.args[0].ty,
+                "Setter function must have exactly one argument",
+            ))
+        }
+    };
+
+    Ok(quote! {
         #[allow(unused_mut)]
         unsafe extern "C" fn __wrap(
             _slf: *mut pyo3::ffi::PyObject,
             _value: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> pyo3::libc::c_int
         {
-            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#name),"()");
+            const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#py_name),"()");
             let _py = pyo3::Python::assume_gil_acquired();
             let _pool = pyo3::GILPool::new(_py);
             let _slf = _py.mut_from_borrowed_ptr::<#cls>(_slf);
@@ -391,7 +346,7 @@ pub(crate) fn impl_wrap_setter(
                 }
             }
         }
-    }
+    })
 }
 
 /// This function abstracts away some copied code and can propably be simplified itself
@@ -401,7 +356,8 @@ pub fn get_arg_names(spec: &FnSpec) -> Vec<syn::Ident> {
         .collect()
 }
 
-fn impl_call(_cls: &syn::Type, fname: &syn::Ident, spec: &FnSpec<'_>) -> TokenStream {
+fn impl_call(_cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
+    let fname = &spec.name;
     let names = get_arg_names(spec);
     quote! { _slf.#fname(#(#names),*) }
 }
@@ -560,19 +516,16 @@ fn impl_arg_param(
     }
 }
 
-pub fn impl_py_method_def(
-    name: &syn::Ident,
-    doc: syn::Lit,
-    spec: &FnSpec<'_>,
-    wrapper: &TokenStream,
-) -> TokenStream {
+pub fn impl_py_method_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
+    let py_name = spec.py_name();
+    let doc = &spec.doc;
     if spec.args.is_empty() {
         quote! {
             pyo3::class::PyMethodDefType::Method({
                 #wrapper
 
                 pyo3::class::PyMethodDef {
-                    ml_name: stringify!(#name),
+                    ml_name: stringify!(#py_name),
                     ml_meth: pyo3::class::PyMethodType::PyNoArgsFunction(__wrap),
                     ml_flags: pyo3::ffi::METH_NOARGS,
                     ml_doc: #doc,
@@ -585,7 +538,7 @@ pub fn impl_py_method_def(
                 #wrapper
 
                 pyo3::class::PyMethodDef {
-                    ml_name: stringify!(#name),
+                    ml_name: stringify!(#py_name),
                     ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
                     ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS,
                     ml_doc: #doc,
@@ -595,17 +548,15 @@ pub fn impl_py_method_def(
     }
 }
 
-pub fn impl_py_method_def_new(
-    name: &syn::Ident,
-    doc: syn::Lit,
-    wrapper: &TokenStream,
-) -> TokenStream {
+pub fn impl_py_method_def_new(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
+    let py_name = spec.py_name();
+    let doc = &spec.doc;
     quote! {
         pyo3::class::PyMethodDefType::New({
             #wrapper
 
             pyo3::class::PyMethodDef {
-                ml_name: stringify!(#name),
+                ml_name: stringify!(#py_name),
                 ml_meth: pyo3::class::PyMethodType::PyNewFunc(__wrap),
                 ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS,
                 ml_doc: #doc,
@@ -614,17 +565,15 @@ pub fn impl_py_method_def_new(
     }
 }
 
-pub fn impl_py_method_def_class(
-    name: &syn::Ident,
-    doc: syn::Lit,
-    wrapper: &TokenStream,
-) -> TokenStream {
+pub fn impl_py_method_def_class(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
+    let py_name = spec.py_name();
+    let doc = &spec.doc;
     quote! {
         pyo3::class::PyMethodDefType::Class({
             #wrapper
 
             pyo3::class::PyMethodDef {
-                ml_name: stringify!(#name),
+                ml_name: stringify!(#py_name),
                 ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
                 ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS |
                 pyo3::ffi::METH_CLASS,
@@ -634,17 +583,15 @@ pub fn impl_py_method_def_class(
     }
 }
 
-pub fn impl_py_method_def_static(
-    name: &syn::Ident,
-    doc: syn::Lit,
-    wrapper: &TokenStream,
-) -> TokenStream {
+pub fn impl_py_method_def_static(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
+    let py_name = spec.py_name();
+    let doc = &spec.doc;
     quote! {
         pyo3::class::PyMethodDefType::Static({
             #wrapper
 
             pyo3::class::PyMethodDef {
-                ml_name: stringify!(#name),
+                ml_name: stringify!(#py_name),
                 ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
                 ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS | pyo3::ffi::METH_STATIC,
                 ml_doc: #doc,
@@ -653,17 +600,15 @@ pub fn impl_py_method_def_static(
     }
 }
 
-pub fn impl_py_method_def_call(
-    name: &syn::Ident,
-    doc: syn::Lit,
-    wrapper: &TokenStream,
-) -> TokenStream {
+pub fn impl_py_method_def_call(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
+    let py_name = spec.py_name();
+    let doc = &spec.doc;
     quote! {
         pyo3::class::PyMethodDefType::Call({
             #wrapper
 
             pyo3::class::PyMethodDef {
-                ml_name: stringify!(#name),
+                ml_name: stringify!(#py_name),
                 ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
                 ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS,
                 ml_doc: #doc,
@@ -672,29 +617,16 @@ pub fn impl_py_method_def_call(
     }
 }
 
-pub(crate) fn impl_py_setter_def(
-    name: &syn::Ident,
-    doc: syn::Lit,
-    setter: &Option<String>,
-    wrapper: &TokenStream,
-) -> TokenStream {
-    let n = if let Some(ref name) = setter {
-        name.to_string()
-    } else {
-        let n = name.to_string();
-        if n.starts_with("set_") {
-            n[4..].to_string()
-        } else {
-            n
-        }
-    };
+pub(crate) fn impl_py_setter_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
+    let py_name = &spec.py_name();
+    let doc = &spec.doc;
 
     quote! {
         pyo3::class::PyMethodDefType::Setter({
             #wrapper
 
             pyo3::class::PySetterDef {
-                name: #n,
+                name: stringify!(#py_name),
                 meth: __wrap,
                 doc: #doc,
             }
@@ -702,29 +634,16 @@ pub(crate) fn impl_py_setter_def(
     }
 }
 
-pub(crate) fn impl_py_getter_def(
-    name: &syn::Ident,
-    doc: syn::Lit,
-    getter: &Option<String>,
-    wrapper: &TokenStream,
-) -> TokenStream {
-    let n = if let Some(ref name) = getter {
-        name.to_string()
-    } else {
-        let n = name.to_string();
-        if n.starts_with("get_") {
-            n[4..].to_string()
-        } else {
-            n
-        }
-    };
+pub(crate) fn impl_py_getter_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
+    let py_name = &spec.py_name();
+    let doc = &spec.doc;
 
     quote! {
         pyo3::class::PyMethodDefType::Getter({
             #wrapper
 
             pyo3::class::PyGetterDef {
-                name: #n,
+                name: stringify!(#py_name),
                 meth: __wrap,
                 doc: #doc,
             }

--- a/pyo3-derive-backend/src/utils.rs
+++ b/pyo3-derive-backend/src/utils.rs
@@ -98,7 +98,7 @@ pub fn get_doc(
     attrs: &[syn::Attribute],
     text_signature: Option<syn::LitStr>,
     null_terminated: bool,
-) -> syn::Result<syn::Lit> {
+) -> syn::Result<syn::LitStr> {
     let mut doc = String::new();
     let mut span = Span::call_site();
 
@@ -139,5 +139,5 @@ pub fn get_doc(
         doc.push('\0');
     }
 
-    Ok(syn::Lit::Str(syn::LitStr::new(&doc, span)))
+    Ok(syn::LitStr::new(&doc, span))
 }

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -83,8 +83,9 @@ pub fn pyfunction(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as syn::ItemFn);
     let args = parse_macro_input!(attr as PyFunctionAttr);
 
+    // TODO: Support #[name = "..."] attribute?
     let python_name = syn::Ident::new(&ast.sig.ident.unraw().to_string(), Span::call_site());
-    let expanded = add_fn_to_module(&mut ast, &python_name, args.arguments);
+    let expanded = add_fn_to_module(&mut ast, python_name, args.arguments);
 
     quote!(
         #ast

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -4,13 +4,11 @@
 
 extern crate proc_macro;
 use proc_macro::TokenStream;
-use proc_macro2::Span;
 use pyo3_derive_backend::{
-    add_fn_to_module, build_py_class, build_py_methods, build_py_proto, get_doc,
+    build_py_class, build_py_function, build_py_methods, build_py_proto, get_doc,
     process_functions_in_module, py_init, PyClassArgs, PyFunctionAttr,
 };
 use quote::quote;
-use syn::ext::IdentExt;
 use syn::parse_macro_input;
 
 /// Internally, this proc macro create a new c function called `PyInit_{my_module}`
@@ -83,9 +81,7 @@ pub fn pyfunction(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as syn::ItemFn);
     let args = parse_macro_input!(attr as PyFunctionAttr);
 
-    // TODO: Support #[name = "..."] attribute?
-    let python_name = syn::Ident::new(&ast.sig.ident.unraw().to_string(), Span::call_site());
-    let expanded = add_fn_to_module(&mut ast, python_name, args.arguments);
+    let expanded = build_py_function(&mut ast, args).unwrap_or_else(|e| e.to_compile_error());
 
     quote!(
         #ast

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -69,6 +69,23 @@ fn custom_names() {
 }
 
 #[pyclass]
+struct RawIdents {}
+
+#[pymethods]
+impl RawIdents {
+    fn r#fn(&self) { }
+}
+
+#[test]
+fn test_raw_idents() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let typeobj = py.get_type::<RawIdents>();
+    py_assert!(py, typeobj, "not hasattr(typeobj, 'r#fn')");
+    py_assert!(py, typeobj, "hasattr(typeobj, 'fn')");
+}
+
+#[pyclass]
 struct EmptyClassInModule {}
 
 #[test]

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -42,12 +42,30 @@ fn class_with_docstr() {
 #[pyclass(name=CustomName)]
 struct EmptyClass2 {}
 
+#[pymethods]
+impl EmptyClass2 {
+    #[name = "custom_fn"]
+    fn bar(&self) {}
+
+    #[staticmethod]
+    #[name = "custom_static"]
+    fn bar_static() {}
+}
+
 #[test]
-fn custom_class_name() {
+fn custom_names() {
     let gil = Python::acquire_gil();
     let py = gil.python();
     let typeobj = py.get_type::<EmptyClass2>();
     py_assert!(py, typeobj, "typeobj.__name__ == 'CustomName'");
+    py_assert!(py, typeobj, "typeobj.custom_fn.__name__ == 'custom_fn'");
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.custom_static.__name__ == 'custom_static'"
+    );
+    py_assert!(py, typeobj, "not hasattr(typeobj, 'bar')");
+    py_assert!(py, typeobj, "not hasattr(typeobj, 'bar_static')");
 }
 
 #[pyclass]

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -73,7 +73,7 @@ struct RawIdents {}
 
 #[pymethods]
 impl RawIdents {
-    fn r#fn(&self) { }
+    fn r#fn(&self) {}
 }
 
 #[test]

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -3,4 +3,5 @@ fn test_compile_errors() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/reject_generics.rs");
     t.compile_fail("tests/ui/too_many_args_to_getter.rs");
+    t.compile_fail("tests/ui/invalid_pymethod_names.rs");
 }

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -149,6 +149,32 @@ fn test_raw_idents() {
 }
 
 #[pyfunction]
+#[name = "foobar"]
+fn custom_named_fn() -> usize {
+    42
+}
+
+#[pymodule]
+fn foobar_module(_py: Python, module: &PyModule) -> PyResult<()> {
+    use pyo3::wrap_pyfunction;
+
+    module.add_wrapped(wrap_pyfunction!(custom_named_fn))
+}
+
+#[test]
+fn test_custom_names() {
+    use pyo3::wrap_pymodule;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let module = wrap_pymodule!(foobar_module)(py);
+
+    py_assert!(py, module, "not hasattr(module, 'custom_named_fn')");
+    py_assert!(py, module, "module.foobar() == 42");
+}
+
+#[pyfunction]
 fn subfunction() -> String {
     "Subfunction".to_string()
 }

--- a/tests/ui/invalid_pymethod_names.rs
+++ b/tests/ui/invalid_pymethod_names.rs
@@ -1,0 +1,29 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+struct TestClass {
+    num: u32,
+}
+
+#[pymethods]
+impl TestClass {
+    #[name = "num"]
+    #[getter(number)]
+    fn get_num(&self) -> u32 { self.num }
+}
+
+#[pymethods]
+impl TestClass {
+    #[name = "foo"]
+    #[name = "bar"]
+    fn qux(&self) -> u32 { self.num }
+}
+
+#[pymethods]
+impl TestClass {
+    #[name = "makenew"]
+    #[new]
+    fn new(&self) -> Self { Self { num: 0 } }
+}
+
+fn main() {}

--- a/tests/ui/invalid_pymethod_names.stderr
+++ b/tests/ui/invalid_pymethod_names.stderr
@@ -1,0 +1,29 @@
+error: name can not be specified for getter
+  --> $DIR/invalid_pymethod_names.rs:10:7
+   |
+10 |     #[name = "num"]
+   |       ^^^^
+
+error: name can not be specified multiple times
+  --> $DIR/invalid_pymethod_names.rs:18:7
+   |
+18 |     #[name = "bar"]
+   |       ^^^^
+
+error: name can not be specified with #[new]
+  --> $DIR/invalid_pymethod_names.rs:24:7
+   |
+24 |     #[name = "makenew"]
+   |       ^^^^
+
+error: cannot find attribute `name` in this scope
+  --> $DIR/invalid_pymethod_names.rs:17:7
+   |
+17 |     #[name = "foo"]
+   |       ^^^^
+
+error: cannot find attribute `name` in this scope
+  --> $DIR/invalid_pymethod_names.rs:18:7
+   |
+18 |     #[name = "bar"]
+   |       ^^^^

--- a/tests/ui/invalid_pymethod_names.stderr
+++ b/tests/ui/invalid_pymethod_names.stderr
@@ -1,16 +1,16 @@
-error: name can not be specified for getter
+error: name not allowed with this attribute
   --> $DIR/invalid_pymethod_names.rs:10:5
    |
 10 |     #[name = "num"]
    |     ^^^^^^^^^^^^^^^
 
 error: #[name] can not be specified multiple times
-  --> $DIR/invalid_pymethod_names.rs:18:5
+  --> $DIR/invalid_pymethod_names.rs:17:5
    |
-18 |     #[name = "bar"]
+17 |     #[name = "foo"]
    |     ^^^^^^^^^^^^^^^
 
-error: name can not be specified with #[new]
+error: name not allowed with this attribute
   --> $DIR/invalid_pymethod_names.rs:24:5
    |
 24 |     #[name = "makenew"]

--- a/tests/ui/invalid_pymethod_names.stderr
+++ b/tests/ui/invalid_pymethod_names.stderr
@@ -1,29 +1,17 @@
 error: name can not be specified for getter
-  --> $DIR/invalid_pymethod_names.rs:10:7
+  --> $DIR/invalid_pymethod_names.rs:10:5
    |
 10 |     #[name = "num"]
-   |       ^^^^
+   |     ^^^^^^^^^^^^^^^
 
-error: name can not be specified multiple times
-  --> $DIR/invalid_pymethod_names.rs:18:7
+error: #[name] can not be specified multiple times
+  --> $DIR/invalid_pymethod_names.rs:18:5
    |
 18 |     #[name = "bar"]
-   |       ^^^^
+   |     ^^^^^^^^^^^^^^^
 
 error: name can not be specified with #[new]
-  --> $DIR/invalid_pymethod_names.rs:24:7
+  --> $DIR/invalid_pymethod_names.rs:24:5
    |
 24 |     #[name = "makenew"]
-   |       ^^^^
-
-error: cannot find attribute `name` in this scope
-  --> $DIR/invalid_pymethod_names.rs:17:7
-   |
-17 |     #[name = "foo"]
-   |       ^^^^
-
-error: cannot find attribute `name` in this scope
-  --> $DIR/invalid_pymethod_names.rs:18:7
-   |
-18 |     #[name = "bar"]
-   |       ^^^^
+   |     ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes #663 

To achieve this, I added to `FnSpec`:
- a new field `name` - the name of the Rust function this maps to
- a new field `python_name` - either the optionally-set `#[name]`, or the `.unraw()` rust name

While I was at it I did some refactoring to swap some `panic!`-s to spanned errors, and a bit of cleanup.

TODO:
- [ ] Bikeshed name - `#[pyname]` perhaps?
- [x] Support `#[pyfunction]`?
- [ ] Update documentation
