### PR TITLE
Support `#[pyfunction]` inside `#[pymodule]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+* Support for `#[pyfunction]` inside `#[pymodule]`. [#693](https://github.com/PyO3/pyo3/pull/693)
+
 ## [0.8.4]
 
 ### Added

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -25,7 +25,9 @@ pub fn pymodule(attr: TokenStream, input: TokenStream) -> TokenStream {
         parse_macro_input!(attr as syn::Ident)
     };
 
-    process_functions_in_module(&mut ast);
+    if let Err(err) = process_functions_in_module(&mut ast) {
+        return err.to_compile_error().into();
+    }
 
     let doc = match get_doc(&ast.attrs, None, false) {
         Ok(doc) => doc,

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -148,6 +148,28 @@ fn test_raw_idents() {
     py_assert!(py, module, "module.move() == 42");
 }
 
+#[pymodule]
+fn pyfunction_module(_py: Python, module: &PyModule) -> PyResult<()> {
+    #[pyfunction]
+    fn foobar() -> usize {
+        101
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_pyfunction_module() {
+    use pyo3::wrap_pymodule;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let module = wrap_pymodule!(pyfunction_module)(py);
+
+    py_assert!(py, module, "module.foobar() == 101");
+}
+
 #[pyfunction]
 fn subfunction() -> String {
     "Subfunction".to_string()


### PR DESCRIPTION
It struck me as strange that `#[pyfn]` exists at all when it should be possible to use `#[pyfunction]` inside pymodule.

This PR adds exactly that. Maybe this is a road to deprecating / removing `#[pyfn]` so as to make the overall API simpler? (Just one `#[pyfunction]` attribute instead of two.)

TODO:
- [ ] Update documentation
