### PR TITLE
Ignore missing `# Safety` section in ffi module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,8 @@ pub use libc;
 pub use unindent;
 
 /// Raw ffi declarations for the c interface of python
+#[allow(clippy::unknown_clippy_lints)]
+#[allow(clippy::missing_safety_doc)]
 pub mod ffi;
 
 pub mod buffer;


### PR DESCRIPTION
I'm all for documenting unsafe functions, but I would suggest excluding the ffi module.

#698