### PR TITLE
Fixes PyObjectDelAttrProtocol signature

### DIFF
--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -31,7 +31,7 @@ pub const OBJECT: Proto = Proto {
         MethodProto::Binary {
             name: "__delattr__",
             arg: "Name",
-            pyres: true,
+            pyres: false,
             proto: "pyo3::class::basic::PyObjectDelAttrProtocol",
         },
         MethodProto::Unary {


### PR DESCRIPTION
This PR fixes the bug when implementing `__delattr__` for in `PyObjectProtocol`, you got the following error message:

> error[E0437]: type `Success` is not a member of trait `pyo3::class::basic::PyObjectDelAttrProtocol`

