### PR TITLE
Remove specialization from some blanket impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 * The blanket implementations for `FromPyObject` for `&T` and `&mut T` are no longer specializable. Implement `PyTryFrom` for your type to control the behavior of `FromPyObject::extract()` for your types.
+* The implementation for `IntoPy<U> for T` where `U: FromPy<T>` is no longer specializable. Control the behavior of this via the implementation of `FromPy`.
 
 ## [0.8.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+* The blanket implementations for `FromPyObject` for `&T` and `&mut T` are no longer specializable. Implement `PyTryFrom` for your type to control the behavior of `FromPyObject::extract()` for your types.
+
 ## [0.8.5]
 
 * Support for `#[name = "foo"]` attribute for `#[pyfunction]` and in `#[pymethods]`. [#692](https://github.com/PyO3/pyo3/pull/692)

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -250,7 +250,7 @@ where
     T: PyTryFrom<'a>,
 {
     #[inline]
-    default fn extract(ob: &'a PyAny) -> PyResult<&'a T> {
+    fn extract(ob: &'a PyAny) -> PyResult<&'a T> {
         Ok(T::try_from(ob)?)
     }
 }
@@ -261,7 +261,7 @@ where
     T: PyTryFrom<'a>,
 {
     #[inline]
-    default fn extract(ob: &'a PyAny) -> PyResult<&'a mut T> {
+    fn extract(ob: &'a PyAny) -> PyResult<&'a mut T> {
         Ok(T::try_from_mut(ob)?)
     }
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -146,7 +146,7 @@ impl<T, U> IntoPy<U> for T
 where
     U: FromPy<T>,
 {
-    default fn into_py(self, py: Python) -> U {
+    fn into_py(self, py: Python) -> U {
         U::from_py(self, py)
     }
 }


### PR DESCRIPTION
While getting my head around #697 I noticed that we seem to no longer need specialization for these blanket impls.