### PR TITLE
Add subclassing testcase which previously caused a segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 * Clear error indicator when the exception is handled on the Rust side. [#719](https://github.com/PyO3/pyo3/pull/719)
+* Fixed unsoundness of subclassing. [#683](https://github.com/PyO3/pyo3/pull/683).
 
 ### Removed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,6 @@ extension-module = []
 # are welcome.
 # abi3 = []
 
-# Activate subclassing support
-unsound-subclass = ["pyo3cls/unsound-subclass"]
-
 [workspace]
 members = [
     "pyo3cls",

--- a/examples/rustapi_module/Cargo.toml
+++ b/examples/rustapi_module/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies.pyo3]
 path = "../../"
-features = ["extension-module", "unsound-subclass"]
+features = ["extension-module"]
 
 [lib]
 name = "rustapi_module"

--- a/examples/rustapi_module/tests/test_subclassing.py
+++ b/examples/rustapi_module/tests/test_subclassing.py
@@ -9,6 +9,7 @@ class SomeSubClass(Subclassable):
     pass
 
 
-if not PYPY:
-    a = SomeSubClass()
-    _b = str(a) + repr(a)
+def test_subclassing():
+    if not PYPY:
+        a = SomeSubClass()
+        _b = str(a) + repr(a)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -173,10 +173,10 @@ so that they can benefit from a freelist. `XXX` is a number of items for the fre
 If a custom class contains references to other Python objects that can be collected, the `PyGCProtocol` trait has to be implemented.
 * `weakref` - Adds support for Python weak references.
 * `extends=BaseType` - Use a custom base class. The base `BaseType` must implement `PyTypeInfo`.
+* `subclass` - Allows Python classes to inherit from this class.
 * `dict` - Adds `__dict__` support, so that the instances of this type have a dictionary containing arbitrary instance variables.
 * `module="XXX"` - Set the name of the module the class will be shown as defined in. If not given, the class
   will be a virtual member of the `builtins` module.
-* `subclass` - Allows Python classes to inherit from this class. This feature is hidden behind a `unsound-subclass` feature because it is currently causing segmentation faults
 
 ## Constructor
 

--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -14,6 +14,3 @@ edition = "2018"
 quote = "1"
 proc-macro2 = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-
-[features]
-unsound-subclass = []

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -136,12 +136,6 @@ impl PyClassArgs {
                 parse_quote! {pyo3::type_flags::WEAKREF}
             }
             "subclass" => {
-                if cfg!(not(feature = "unsound-subclass")) {
-                    return Err(syn::Error::new_spanned(
-                        exp.path.clone(),
-                        "You need to activate the `unsound-subclass` feature if you want to use subclassing",
-                    ));
-                }
                 parse_quote! {pyo3::type_flags::BASETYPE}
             }
             "dict" => {

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -18,6 +18,3 @@ quote = "1"
 proc-macro2 = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
 pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.8.5" }
-
-[features]
-unsound-subclass = ["pyo3-derive-backend/unsound-subclass"]

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -1,7 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::py_run;
 
-#[cfg(feature = "unsound-subclass")]
 use pyo3::types::IntoPyDict;
 
 use pyo3::types::{PyDict, PySet};
@@ -13,11 +12,9 @@ struct BaseClass {
     val1: usize,
 }
 
-#[cfg(feature = "unsound-subclass")]
 #[pyclass(subclass)]
 struct SubclassAble {}
 
-#[cfg(feature = "unsound-subclass")]
 #[test]
 fn subclass() {
     let gil = Python::acquire_gil();


### PR DESCRIPTION
Add a testcase from #407. Both test cases don't segfault after the
change to the #[pyclass] system in #683.

Edit: Also remove unsound-subclass feature.

Closes #407, Closes #220