### PR TITLE
Set RUST_BACKTRACE=1 in windows tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,5 @@ jobs:
           pip install setuptools-rust pytest pytest-benchmark tox tox-venv
       - name: Test
         run: ci/actions/test
+    env:
+      RUST_BACKTRACE: 1


### PR DESCRIPTION
Setting `RUST_BACKTRACE=1` as suggested in https://github.com/PyO3/pyo3/issues/720#issuecomment-573414444.
