### PR TITLE
[WIP] FromPyObject for #[pyclass] with T: Clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+* `FromPyObject` is now automatically implemented for `T: Clone` pyclasses. [#730](https://github.com/PyO3/pyo3/pull/730)
 * Implemented `IntoIterator` for `PySet` and `PyFrozenSet`. [#716](https://github.com/PyO3/pyo3/pull/716)
 * `PyClass`, `PyClassShell`, `PyObjectLayout`, `PyClassInitializer` [#683](https://github.com/PyO3/pyo3/pull/683)
 

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -395,6 +395,18 @@ fn impl_class(
             #weakref
         }
 
+        impl pyo3::conversion::FromPyObjectImpl for #cls {
+            type Impl = pyo3::conversion::extract_impl::Cloned;
+        }
+
+        impl pyo3::conversion::FromPyObjectImpl for &'_ #cls {
+            type Impl = pyo3::conversion::extract_impl::Reference;
+        }
+
+        impl pyo3::conversion::FromPyObjectImpl for &'_ mut #cls {
+            type Impl = pyo3::conversion::extract_impl::MutReference;
+        }
+
         #into_pyobject
 
         #inventory_impl

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub mod buffer;
 #[doc(hidden)]
 pub mod callback;
 pub mod class;
-mod conversion;
+pub mod conversion;
 #[doc(hidden)]
 pub mod derive_utils;
 mod err;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -142,6 +142,10 @@ macro_rules! pyobject_native_type_convert(
             }
         }
 
+        impl<$($type_param,)*> $crate::conversion::FromPyObjectImpl for &'_ $name {
+            type Impl = $crate::conversion::extract_impl::Reference;
+        }
+
         impl<$($type_param,)*> ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter)
                    -> Result<(), ::std::fmt::Error>

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -1,0 +1,25 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+#[derive(Clone, Debug, PartialEq)]
+struct Cloneable {
+    x: i32,
+}
+
+#[test]
+fn test_cloneable_pyclass() {
+    let c = Cloneable { x: 10 };
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let py_c = Py::new(py, c.clone()).unwrap().to_object(py);
+
+    let c2: Cloneable = py_c.extract(py).unwrap();
+    let rc: &Cloneable = py_c.extract(py).unwrap();
+    let mrc: &mut Cloneable = py_c.extract(py).unwrap();
+
+    assert_eq!(c, c2);
+    assert_eq!(&c, rc);
+    assert_eq!(&c, mrc);
+}

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,7 +1,8 @@
 #[test]
 fn test_compile_errors() {
     let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/invalid_pymethod_names.rs");
+    t.compile_fail("tests/ui/missing_clone.rs");
     t.compile_fail("tests/ui/reject_generics.rs");
     t.compile_fail("tests/ui/too_many_args_to_getter.rs");
-    t.compile_fail("tests/ui/invalid_pymethod_names.rs");
 }

--- a/tests/ui/missing_clone.rs
+++ b/tests/ui/missing_clone.rs
@@ -1,0 +1,16 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+struct TestClass {
+    num: u32,
+}
+
+fn main() {
+    let t = TestClass { num: 10 };
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let pyvalue = Py::new(py, t).unwrap().to_object(py);
+    let t: TestClass = pyvalue.extract(py).unwrap();
+}

--- a/tests/ui/missing_clone.stderr
+++ b/tests/ui/missing_clone.stderr
@@ -1,0 +1,8 @@
+error[E0277]: the trait bound `TestClass: std::clone::Clone` is not satisfied
+  --> $DIR/missing_clone.rs:15:32
+   |
+15 |     let t: TestClass = pyvalue.extract(py).unwrap();
+   |                                ^^^^^^^ the trait `std::clone::Clone` is not implemented for `TestClass`
+   |
+   = note: required because of the requirements on the impl of `pyo3::conversion::extract_impl::ExtractImpl<'_, TestClass>` for `pyo3::conversion::extract_impl::Cloned`
+   = note: required because of the requirements on the impl of `pyo3::conversion::FromPyObject<'_>` for `TestClass`


### PR DESCRIPTION
I had an idea how to support extracting for pyclasses automatically for `T: Clone`.

It also has really nice error messages if the user attempts to extract a non-clone `#[pyclass]` (see the `ui` test).

Closes #706 