### PR TITLE
_PyDict_SetItem_KnownHash(), _Py_HashBytes()

### DIFF
--- a/src/ffi/dictobject.rs
+++ b/src/ffi/dictobject.rs
@@ -1,5 +1,5 @@
 use crate::ffi::object::*;
-use crate::ffi::pyport::Py_ssize_t;
+use crate::ffi::pyport::{Py_hash_t, Py_ssize_t};
 use std::os::raw::{c_char, c_int};
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
@@ -68,6 +68,13 @@ extern "C" {
     pub fn PyDict_GetItemWithError(mp: *mut PyObject, key: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyDict_SetItem")]
     pub fn PyDict_SetItem(mp: *mut PyObject, key: *mut PyObject, item: *mut PyObject) -> c_int;
+    #[cfg(not(PyPy))]
+    pub fn _PyDict_SetItem_KnownHash(
+        mp: *mut PyObject,
+        key: *mut PyObject,
+        item: *mut PyObject,
+        hash: Py_hash_t,
+    ) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyDict_DelItem")]
     pub fn PyDict_DelItem(mp: *mut PyObject, key: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyDict_Clear")]

--- a/src/ffi/pyhash.rs
+++ b/src/ffi/pyhash.rs
@@ -20,4 +20,6 @@ impl Default for PyHash_FuncDef {
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyHash_GetFuncDef() -> *mut PyHash_FuncDef;
+    #[cfg(not(PyPy))]
+    pub fn _Py_HashBytes(src: *const c_void, len: Py_ssize_t) -> Py_hash_t;
 }


### PR DESCRIPTION
These are two CPython-specific APIs available since before 3.5. I've used these locally with success.