### PR TITLE
Remove static mut from PyTypeInfo implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * `PyRef`, `PyRefMut`, `PyRawObject`. [#683](https://github.com/PyO3/pyo3/pull/683)
 * `PyNoArgsFunction`. [#741](https://github.com/PyO3/pyo3/pull/741)
+* `initialize_type()`. To set the module name for a `#[pyclass]`, use the `module` argument to the macro. #[751](https://github.com/PyO3/pyo3/pull/751)
 
 ## [0.8.5]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ parking_lot = { version = "0.10", features = ["nightly"] }
 paste = "0.1.6"
 pyo3cls = { path = "pyo3cls", version = "=0.9.0-alpha.1" }
 unindent = "0.1.4"
+once_cell = "1.3.1"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -43,9 +43,10 @@ impl pyo3::PyTypeInfo for MyClass {
     const FLAGS: usize = 0;
 
     #[inline]
-    unsafe fn type_object() -> &'static mut pyo3::ffi::PyTypeObject {
-        static mut TYPE_OBJECT: pyo3::ffi::PyTypeObject = pyo3::ffi::PyTypeObject_INIT;
-        &mut TYPE_OBJECT
+    fn type_object() -> *mut pyo3::ffi::PyTypeObject {
+        static TYPE_OBJECT: pyo3::derive_utils::LazyTypeObject =
+            pyo3::derive_utils::LazyTypeObject::new();
+        TYPE_OBJECT.get()
     }
 }
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -44,22 +44,9 @@ unsafe impl pyo3::PyTypeInfo for MyClass {
 
     #[inline]
     fn type_object() -> std::ptr::NonNull<pyo3::ffi::PyTypeObject> {
-        use std::ptr::NonNull;
         use pyo3::type_object::LazyTypeObject;
         static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
-        TYPE_OBJECT.get_or_init(|| {
-                // automatically initialize the class on-demand
-                let gil = pyo3::Python::acquire_gil();
-                let py = gil.python();
-                let boxed = pyo3::pyclass::create_type_object::<Self>(py, Self::MODULE)?;
-                Ok(unsafe { NonNull::new_unchecked(Box::into_raw(boxed)) })
-            })
-            .unwrap_or_else(|e| {
-                let gil = Python::acquire_gil();
-                let py = gil.python();
-                e.print(py);
-                panic!("An error occurred while initializing class {}", Self::NAME)
-            })
+        TYPE_OBJECT.get_pyclass_type::<Self>()
     }
 }
 

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -384,9 +384,10 @@ fn impl_class(
             const FLAGS: usize = #(#flags)|* | #extended;
 
             #[inline]
-            unsafe fn type_object() -> &'static mut pyo3::ffi::PyTypeObject {
-                static mut TYPE_OBJECT: pyo3::ffi::PyTypeObject = pyo3::ffi::PyTypeObject_INIT;
-                &mut TYPE_OBJECT
+            fn type_object() -> *mut pyo3::ffi::PyTypeObject {
+                static TYPE_OBJECT: pyo3::derive_utils::LazyTypeObject =
+                    pyo3::derive_utils::LazyTypeObject::new();
+                TYPE_OBJECT.get()
             }
         }
 

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -273,8 +273,6 @@ fn impl_class(
                             if FREELIST.is_null() {
                                 FREELIST = Box::into_raw(Box::new(
                                     pyo3::freelist::FreeList::with_capacity(#freelist)));
-
-                                <#cls as pyo3::type_object::PyTypeObject>::init_type();
                             }
                             &mut *FREELIST
                         }
@@ -372,7 +370,7 @@ fn impl_class(
     };
 
     Ok(quote! {
-        impl pyo3::type_object::PyTypeInfo for #cls {
+        unsafe impl pyo3::type_object::PyTypeInfo for #cls {
             type Type = #cls;
             type BaseType = #base;
             type ConcreteLayout = pyo3::pyclass::PyClassShell<Self>;
@@ -384,10 +382,23 @@ fn impl_class(
             const FLAGS: usize = #(#flags)|* | #extended;
 
             #[inline]
-            fn type_object() -> *mut pyo3::ffi::PyTypeObject {
-                static TYPE_OBJECT: pyo3::derive_utils::LazyTypeObject =
-                    pyo3::derive_utils::LazyTypeObject::new();
-                TYPE_OBJECT.get()
+            fn type_object() -> std::ptr::NonNull<pyo3::ffi::PyTypeObject> {
+                use std::ptr::NonNull;
+                use pyo3::type_object::LazyTypeObject;
+                static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
+                TYPE_OBJECT.get_or_init(|| {
+                        // automatically initialize the class on-demand
+                        let gil = pyo3::Python::acquire_gil();
+                        let py = gil.python();
+                        let boxed = pyo3::pyclass::create_type_object::<Self>(py, Self::MODULE)?;
+                        Ok(unsafe { NonNull::new_unchecked(Box::into_raw(boxed)) })
+                    })
+                    .unwrap_or_else(|e| {
+                        let gil = Python::acquire_gil();
+                        let py = gil.python();
+                        e.print(py);
+                        panic!("An error occurred while initializing class {}", Self::NAME)
+                    })
             }
         }
 

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -383,22 +383,9 @@ fn impl_class(
 
             #[inline]
             fn type_object() -> std::ptr::NonNull<pyo3::ffi::PyTypeObject> {
-                use std::ptr::NonNull;
                 use pyo3::type_object::LazyTypeObject;
                 static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
-                TYPE_OBJECT.get_or_init(|| {
-                        // automatically initialize the class on-demand
-                        let gil = pyo3::Python::acquire_gil();
-                        let py = gil.python();
-                        let boxed = pyo3::pyclass::create_type_object::<Self>(py, Self::MODULE)?;
-                        Ok(unsafe { NonNull::new_unchecked(Box::into_raw(boxed)) })
-                    })
-                    .unwrap_or_else(|e| {
-                        let gil = Python::acquire_gil();
-                        let py = gil.python();
-                        e.print(py);
-                        panic!("An error occurred while initializing class {}", Self::NAME)
-                    })
+                TYPE_OBJECT.get_pyclass_type::<Self>()
             }
         }
 

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -12,6 +12,8 @@ use crate::pyclass::PyClass;
 use crate::pyclass_init::PyClassInitializer;
 use crate::types::{PyAny, PyDict, PyModule, PyTuple};
 use crate::{ffi, GILPool, IntoPy, PyObject, Python};
+use once_cell::sync::OnceCell;
+use std::cell::UnsafeCell;
 use std::ptr;
 
 /// Description of a python parameter; used for `parse_args()`.
@@ -199,3 +201,28 @@ impl<T: PyClass, I: Into<PyClassInitializer<T>>> IntoPyNewResult<T, I> for PyRes
         self
     }
 }
+
+/// Type used to store type objects
+pub struct LazyTypeObject {
+    cell: OnceCell<UnsafeCell<ffi::PyTypeObject>>,
+}
+
+impl LazyTypeObject {
+    pub const fn new() -> Self {
+        Self {
+            cell: OnceCell::new(),
+        }
+    }
+
+    pub fn get(&self) -> *mut ffi::PyTypeObject {
+        self.cell
+            .get_or_init(|| UnsafeCell::new(ffi::PyTypeObject_INIT))
+            .get()
+    }
+}
+
+// This is necessary for making static `LazyTypeObject`s
+//
+// Type objects are shared between threads by the Python interpreter anyway, so it is no worse
+// to allow sharing on the Rust side too.
+unsafe impl Sync for LazyTypeObject {}

--- a/src/err.rs
+++ b/src/err.rs
@@ -14,6 +14,7 @@ use libc::c_int;
 use std::ffi::CString;
 use std::io;
 use std::os::raw::c_char;
+use std::ptr::NonNull;
 
 /// Represents a `PyErr` value
 ///
@@ -179,7 +180,7 @@ impl PyErr {
         name: &str,
         base: Option<&PyType>,
         dict: Option<PyObject>,
-    ) -> *mut ffi::PyTypeObject {
+    ) -> NonNull<ffi::PyTypeObject> {
         let base: *mut ffi::PyObject = match base {
             None => std::ptr::null_mut(),
             Some(obj) => obj.as_ptr(),
@@ -193,8 +194,12 @@ impl PyErr {
         unsafe {
             let null_terminated_name =
                 CString::new(name).expect("Failed to initialize nul terminated exception name");
-            ffi::PyErr_NewException(null_terminated_name.as_ptr() as *mut c_char, base, dict)
-                as *mut ffi::PyTypeObject
+
+            NonNull::new_unchecked(ffi::PyErr_NewException(
+                null_terminated_name.as_ptr() as *mut c_char,
+                base,
+                dict,
+            ) as *mut ffi::PyTypeObject)
         }
     }
 

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -90,7 +90,7 @@ where
         }
 
         if let Some(obj) = <Self as PyClassWithFreeList>::get_free_list().insert(obj) {
-            match Self::type_object().tp_free {
+            match (*Self::type_object()).tp_free {
                 Some(free) => free(obj as *mut c_void),
                 None => tp_free_fallback(obj),
             }

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -74,7 +74,7 @@ where
 {
     unsafe fn alloc(_py: Python) -> *mut Self::ConcreteLayout {
         if let Some(obj) = <Self as PyClassWithFreeList>::get_free_list().pop() {
-            ffi::PyObject_Init(obj, <Self as PyTypeInfo>::type_object());
+            ffi::PyObject_Init(obj, <Self as PyTypeInfo>::type_object().as_ptr() as *mut _);
             obj as _
         } else {
             crate::pyclass::default_alloc::<Self>() as _
@@ -90,7 +90,7 @@ where
         }
 
         if let Some(obj) = <Self as PyClassWithFreeList>::get_free_list().insert(obj) {
-            match (*Self::type_object()).tp_free {
+            match Self::type_object().as_ref().tp_free {
                 Some(free) => free(obj as *mut c_void),
                 None => tp_free_fallback(obj),
             }

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -3,7 +3,7 @@ use crate::class::methods::{PyMethodDefType, PyMethodsProtocol};
 use crate::conversion::{AsPyPointer, FromPyPointer, ToPyObject};
 use crate::pyclass_init::PyClassInitializer;
 use crate::pyclass_slots::{PyClassDict, PyClassWeakRef};
-use crate::type_object::{type_flags, PyObjectLayout, PyObjectSizedLayout, PyTypeObject};
+use crate::type_object::{type_flags, PyObjectLayout, PyObjectSizedLayout};
 use crate::types::PyAny;
 use crate::{class, ffi, gil, PyErr, PyObject, PyResult, PyTypeInfo, Python};
 use std::ffi::CString;
@@ -13,12 +13,12 @@ use std::ptr::{self, NonNull};
 
 #[inline]
 pub(crate) unsafe fn default_alloc<T: PyTypeInfo>() -> *mut ffi::PyObject {
-    let tp_ptr = T::type_object();
+    let tp_ptr = T::type_object().as_ptr();
     if T::FLAGS & type_flags::EXTENDED != 0
         && <T::BaseType as PyTypeInfo>::ConcreteLayout::IS_NATIVE_TYPE
     {
-        let base_tp_ptr = <T::BaseType as PyTypeInfo>::type_object();
-        if let Some(base_new) = (*base_tp_ptr).tp_new {
+        let base_tp = <T::BaseType as PyTypeInfo>::type_object();
+        if let Some(base_new) = base_tp.as_ref().tp_new {
             return base_new(tp_ptr, ptr::null_mut(), ptr::null_mut());
         }
     }
@@ -47,7 +47,7 @@ pub trait PyClassAlloc: PyTypeInfo + Sized {
             return;
         }
 
-        match (*Self::type_object()).tp_free {
+        match Self::type_object().as_ref().tp_free {
             Some(free) => free(obj as *mut c_void),
             None => tp_free_fallback(obj),
         }
@@ -80,30 +80,6 @@ pub trait PyClass:
 {
     type Dict: PyClassDict;
     type WeakRef: PyClassWeakRef;
-}
-
-unsafe impl<T> PyTypeObject for T
-where
-    T: PyClass,
-{
-    fn init_type() -> NonNull<ffi::PyTypeObject> {
-        <T::BaseType as PyTypeObject>::init_type();
-        let type_object = <Self as PyTypeInfo>::type_object();
-        let type_flags = unsafe { (*type_object).tp_flags };
-
-        if (type_flags & ffi::Py_TPFLAGS_READY) == 0 {
-            // automatically initialize the class on-demand
-            let gil = Python::acquire_gil();
-            let py = gil.python();
-
-            initialize_type::<Self>(py, <Self as PyTypeInfo>::MODULE).unwrap_or_else(|e| {
-                e.print(py);
-                panic!("An error occurred while initializing class {}", Self::NAME)
-            });
-        }
-
-        unsafe { NonNull::new_unchecked(type_object) }
-    }
 }
 
 /// `PyClassShell` represents the concrete layout of `T: PyClass` when it is converted
@@ -179,7 +155,6 @@ impl<T: PyClass> PyClassShell<T> {
         <T::BaseType as PyTypeInfo>::ConcreteLayout:
             crate::type_object::PyObjectSizedLayout<T::BaseType>,
     {
-        T::init_type();
         let base = T::alloc(py);
         if base.is_null() {
             return Err(PyErr::fetch(py));
@@ -277,14 +252,17 @@ where
     }
 }
 
-/// Register `T: PyClass` to Python interpreter.
 #[cfg(not(Py_LIMITED_API))]
-pub fn initialize_type<T>(py: Python, module_name: Option<&str>) -> PyResult<*mut ffi::PyTypeObject>
+pub fn create_type_object<T>(
+    py: Python,
+    module_name: Option<&str>,
+) -> PyResult<Box<ffi::PyTypeObject>>
 where
     T: PyClass,
 {
-    let type_object: &mut ffi::PyTypeObject = unsafe { &mut *T::type_object() };
-    let base_type_object = <T::BaseType as PyTypeInfo>::type_object();
+    let mut boxed = Box::new(ffi::PyTypeObject_INIT);
+    let mut type_object = boxed.as_mut();
+    let base_type_object = <T::BaseType as PyTypeInfo>::type_object().as_ptr();
 
     // PyPy will segfault if passed only a nul terminator as `tp_doc`.
     // ptr::null() is OK though.
@@ -391,7 +369,7 @@ where
     // register type object
     unsafe {
         if ffi::PyType_Ready(type_object) == 0 {
-            Ok(type_object as *mut ffi::PyTypeObject)
+            Ok(boxed)
         } else {
             PyErr::fetch(py).into()
         }

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -253,13 +253,15 @@ where
 }
 
 #[cfg(not(Py_LIMITED_API))]
-pub fn create_type_object<T>(
+pub(crate) fn create_type_object<T>(
     py: Python,
     module_name: Option<&str>,
 ) -> PyResult<Box<ffi::PyTypeObject>>
 where
     T: PyClass,
 {
+    // Box (or some other heap allocation) is needed because PyType_Ready expects the type object
+    // to have a permanent memory address.
     let mut boxed = Box::new(ffi::PyTypeObject_INIT);
     let mut type_object = boxed.as_mut();
     let base_type_object = <T::BaseType as PyTypeInfo>::type_object().as_ptr();

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -1,10 +1,12 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 //! Python type object information
 
+use crate::err::PyResult;
 use crate::instance::Py;
 use crate::pyclass_init::PyObjectInit;
 use crate::types::{PyAny, PyType};
 use crate::{ffi, AsPyPointer, Python};
+use once_cell::sync::OnceCell;
 use std::ptr::NonNull;
 
 /// `T: PyObjectLayout<U>` represents that `T` is a concrete representaion of `U` in Python heap.
@@ -60,7 +62,11 @@ pub mod type_flags {
 
 /// Python type information.
 /// All Python native types(e.g., `PyDict`) and `#[pyclass]` structs implement this trait.
-pub trait PyTypeInfo: Sized {
+///
+/// This trait is marked unsafe because:
+///  - specifying the incorrect layout can lead to memory errors
+///  - the return value of type_object must always point to the same PyTypeObject instance
+pub unsafe trait PyTypeInfo: Sized {
     /// Type of objects to store in PyObject struct
     type Type;
 
@@ -85,32 +91,64 @@ pub trait PyTypeInfo: Sized {
     /// Initializer for layout
     type Initializer: PyObjectInit<Self>;
 
-    /// PyTypeObject instance for this type, which might still need to
-    /// be initialized
-    fn type_object() -> *mut ffi::PyTypeObject;
+    /// PyTypeObject instance for this type, guaranteed to be global and initialized.
+    fn type_object() -> NonNull<ffi::PyTypeObject>;
 
     /// Check if `*mut ffi::PyObject` is instance of this type
     fn is_instance(object: &PyAny) -> bool {
-        unsafe { ffi::PyObject_TypeCheck(object.as_ptr(), Self::type_object()) != 0 }
+        unsafe {
+            ffi::PyObject_TypeCheck(object.as_ptr(), Self::type_object().as_ptr() as *mut _) != 0
+        }
     }
 
     /// Check if `*mut ffi::PyObject` is exact instance of this type
     fn is_exact_instance(object: &PyAny) -> bool {
-        unsafe { (*object.as_ptr()).ob_type == Self::type_object() }
+        unsafe { (*object.as_ptr()).ob_type == Self::type_object().as_ptr() as *mut _ }
     }
 }
 
 /// Python object types that have a corresponding type object.
 ///
-/// This trait is marked unsafe because not fulfilling the contract for [PyTypeObject::init_type]
-/// leads to UB
+/// This trait is marked unsafe because not fulfilling the contract for type_object
+/// leads to UB.
+///
+/// See [PyTypeInfo::type_object]
 pub unsafe trait PyTypeObject {
-    /// This function must make sure that the corresponding type object gets
-    /// initialized exactly once and return it.
-    fn init_type() -> NonNull<ffi::PyTypeObject>;
+    /// Returns the safe abstraction over the type object.
+    fn type_object() -> Py<PyType>;
+}
 
-    /// Returns the safe abstraction over the type object from [PyTypeObject::init_type]
+unsafe impl<T> PyTypeObject for T
+where
+    T: PyTypeInfo,
+{
     fn type_object() -> Py<PyType> {
-        unsafe { Py::from_borrowed_ptr(Self::init_type().as_ptr() as *mut ffi::PyObject) }
+        unsafe { Py::from_borrowed_ptr(<Self as PyTypeInfo>::type_object().as_ptr() as *mut _) }
     }
 }
+
+/// Type used to store type objects
+pub struct LazyTypeObject {
+    cell: OnceCell<NonNull<ffi::PyTypeObject>>,
+}
+
+impl LazyTypeObject {
+    pub const fn new() -> Self {
+        Self {
+            cell: OnceCell::new(),
+        }
+    }
+
+    pub fn get_or_init<F>(&self, constructor: F) -> PyResult<NonNull<ffi::PyTypeObject>>
+    where
+        F: Fn() -> PyResult<NonNull<ffi::PyTypeObject>>,
+    {
+        Ok(*self.cell.get_or_try_init(constructor)?)
+    }
+}
+
+// This is necessary for making static `LazyTypeObject`s
+//
+// Type objects are shared between threads by the Python interpreter anyway, so it is no worse
+// to allow sharing on the Rust side too.
+unsafe impl Sync for LazyTypeObject {}

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -87,7 +87,7 @@ pub trait PyTypeInfo: Sized {
 
     /// PyTypeObject instance for this type, which might still need to
     /// be initialized
-    unsafe fn type_object() -> &'static mut ffi::PyTypeObject;
+    fn type_object() -> *mut ffi::PyTypeObject;
 
     /// Check if `*mut ffi::PyObject` is instance of this type
     fn is_instance(object: &PyAny) -> bool {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -111,8 +111,8 @@ macro_rules! pyobject_native_type_convert(
             const MODULE: Option<&'static str> = $module;
 
             #[inline]
-            unsafe fn type_object() -> &'static mut $crate::ffi::PyTypeObject {
-                &mut $typeobject
+            fn type_object() -> *mut $crate::ffi::PyTypeObject {
+                unsafe { &mut $typeobject as *mut _ }
             }
 
             #[allow(unused_unsafe)]
@@ -127,7 +127,7 @@ macro_rules! pyobject_native_type_convert(
             fn init_type() -> std::ptr::NonNull<$crate::ffi::PyTypeObject> {
                 unsafe {
                     std::ptr::NonNull::new_unchecked(
-                        <Self as $crate::type_object::PyTypeInfo>::type_object() as *mut _
+                        <Self as $crate::type_object::PyTypeInfo>::type_object()
                     )
                 }
             }

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -7,7 +7,7 @@ use crate::ffi;
 use crate::instance::{Py, PyNativeType};
 use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
-use crate::type_object::{PyTypeInfo, PyTypeObject};
+use crate::type_object::PyTypeObject;
 use crate::AsPyPointer;
 use crate::Python;
 use std::borrow::Cow;
@@ -21,8 +21,8 @@ pyobject_native_var_type!(PyType, ffi::PyType_Type, ffi::PyType_Check);
 
 impl PyType {
     #[inline]
-    pub fn new<T: PyTypeInfo>() -> Py<PyType> {
-        unsafe { Py::from_borrowed_ptr(T::type_object() as *const _ as *mut ffi::PyObject) }
+    pub fn new<T: PyTypeObject>() -> Py<PyType> {
+        T::type_object()
     }
 
     /// Retrieves the underlying FFI pointer associated with this Python object.

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -1,6 +1,5 @@
 use pyo3::prelude::*;
 use pyo3::py_run;
-use pyo3::pyclass::initialize_type;
 
 mod common;
 
@@ -111,9 +110,4 @@ fn empty_class_in_module() {
     // We currently have no way of determining a canonical module, so builtins is better
     // than using whatever calls init first.
     assert_eq!(module, "builtins");
-
-    // The module name can also be set manually by calling `initialize_type`.
-    initialize_type::<EmptyClassInModule>(py, Some("test_module.nested")).unwrap();
-    let module: String = ty.getattr("__module__").unwrap().extract().unwrap();
-    assert_eq!(module, "test_module.nested");
 }

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -1,5 +1,4 @@
 use pyo3::prelude::*;
-use pyo3::pyclass::initialize_type;
 use pyo3::types::IntoPyDict;
 use pyo3::types::{PyDict, PyTuple};
 use pyo3::{py_run, wrap_pyfunction, AsPyRef, PyClassShell};
@@ -117,7 +116,7 @@ fn pytuple_pyclass_iter() {
     py_assert!(py, tup, "tup[0] != tup[1]");
 }
 
-#[pyclass(dict)]
+#[pyclass(dict, module = "test_module")]
 struct PickleSupport {}
 
 #[pymethods]
@@ -153,7 +152,6 @@ fn test_pickle() {
     let module = PyModule::new(py, "test_module").unwrap();
     module.add_class::<PickleSupport>().unwrap();
     add_module(py, module).unwrap();
-    initialize_type::<PickleSupport>(py, Some("test_module")).unwrap();
     let inst = PyClassShell::new_ref(py, PickleSupport {}).unwrap();
     py_run!(
         py,


### PR DESCRIPTION
Fixes #699 .

I looked at using `lazy_static!` and a couple other options, in the end I went for `once_cell`.

I modified the signature of `PyTypeInfo::type_object()` to return `*mut` instead of `&mut`. It's a minor thing but handing out `&mut` in this way is definitely breaking Rust's aliasing rules.

Also removed `unsafe` from the function because there's nothing unsafe about calling it - the user is responsible for using the returned  `*mut ffi::PyTypeInfo` pointer safely.

Might need a changelog entry because the trait signature changed?

(As a note, I plan to follow up this PR with a second one which removes the need for `init_type()`. Let's start with this to keep the PR smaller and simpler.)