### PR TITLE
Add Python 3.8 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
     - name: PyPy3.5 7.0 # Tested via anaconda PyPy (since travis's PyPy version is too old)
       python: "3.7"
       env: FEATURES="pypy" PATH="$PATH:/opt/anaconda/envs/pypy3/bin"
-  allow_failures:
-    - python: "3.8-dev"
 
 env:
   global:

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py35,
           py36,
           py37,
+          py38,
 minversion = 3.4.0
 skip_missing_interpreters = true
 


### PR DESCRIPTION
The problem mentioned in https://github.com/PyO3/pyo3/issues/704#issuecomment-569410933 seems gone, probably fixed by https://github.com/python/cpython/commit/8d0f36940e728989822c3789025b0813a8fe249a.