### PR TITLE
Make PyTypeInfo::type_object return &'static instead of NonNull

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -43,9 +43,9 @@ unsafe impl pyo3::PyTypeInfo for MyClass {
     const FLAGS: usize = 0;
 
     #[inline]
-    fn type_object() -> std::ptr::NonNull<pyo3::ffi::PyTypeObject> {
-        use pyo3::type_object::LazyTypeObject;
-        static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
+    fn type_object() -> &'static pyo3::ffi::PyTypeObject {
+        use pyo3::type_object::LazyStaticType;
+        static TYPE_OBJECT: LazyStaticType = LazyStaticType::new_static();
         TYPE_OBJECT.get_pyclass_type::<Self>()
     }
 }

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -382,9 +382,9 @@ fn impl_class(
             const FLAGS: usize = #(#flags)|* | #extended;
 
             #[inline]
-            fn type_object() -> std::ptr::NonNull<pyo3::ffi::PyTypeObject> {
-                use pyo3::type_object::LazyTypeObject;
-                static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
+            fn type_object() -> &'static pyo3::ffi::PyTypeObject {
+                use pyo3::type_object::LazyStaticType;
+                static TYPE_OBJECT: LazyStaticType = LazyStaticType::new_static();
                 TYPE_OBJECT.get_pyclass_type::<Self>()
             }
         }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -9,8 +9,8 @@ use crate::types::{PyAny, PyTuple};
 use crate::Python;
 use crate::{AsPyPointer, ToPyObject};
 use std::ffi::CStr;
+use std::ops;
 use std::os::raw::c_char;
-use std::{self, ops};
 
 /// The boilerplate to convert between a rust type and a python exception
 #[macro_export]
@@ -90,8 +90,8 @@ macro_rules! import_exception_type_object {
     ($module: expr, $name: ident) => {
         unsafe impl $crate::type_object::PyTypeObject for $name {
             fn type_object() -> $crate::Py<$crate::types::PyType> {
-                use $crate::type_object::LazyTypeObject;
-                static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
+                use $crate::type_object::LazyHeapType;
+                static TYPE_OBJECT: LazyHeapType = LazyHeapType::new_heap();
 
                 let ptr = TYPE_OBJECT
                     .get_or_init(|| {
@@ -178,8 +178,8 @@ macro_rules! create_exception_type_object {
     ($module: ident, $name: ident, $base: ty) => {
         unsafe impl $crate::type_object::PyTypeObject for $name {
             fn type_object() -> $crate::Py<$crate::types::PyType> {
-                use $crate::type_object::LazyTypeObject;
-                static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
+                use $crate::type_object::LazyHeapType;
+                static TYPE_OBJECT: LazyHeapType = LazyHeapType::new_heap();
 
                 let ptr = TYPE_OBJECT
                     .get_or_init(|| {

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -74,7 +74,7 @@ where
 {
     unsafe fn alloc(_py: Python) -> *mut Self::ConcreteLayout {
         if let Some(obj) = <Self as PyClassWithFreeList>::get_free_list().pop() {
-            ffi::PyObject_Init(obj, <Self as PyTypeInfo>::type_object().as_ptr() as *mut _);
+            ffi::PyObject_Init(obj, <Self as PyTypeInfo>::type_object() as *const _ as _);
             obj as _
         } else {
             crate::pyclass::default_alloc::<Self>() as _
@@ -90,7 +90,7 @@ where
         }
 
         if let Some(obj) = <Self as PyClassWithFreeList>::get_free_list().insert(obj) {
-            match Self::type_object().as_ref().tp_free {
+            match Self::type_object().tp_free {
                 Some(free) => free(obj as *mut c_void),
                 None => tp_free_fallback(obj),
             }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -124,8 +124,8 @@ macro_rules! pyobject_native_type_convert(
             const MODULE: Option<&'static str> = $module;
 
             #[inline]
-            fn type_object() -> std::ptr::NonNull<$crate::ffi::PyTypeObject> {
-                unsafe { std::ptr::NonNull::new_unchecked(&mut $typeobject as *mut _) }
+            fn type_object() -> &'static $crate::ffi::PyTypeObject {
+                unsafe{ &$typeobject }
             }
 
             #[allow(unused_unsafe)]


### PR DESCRIPTION
Here `NonNull` doesn't mean so much and... I think `static` means what we need clearer.