### PR TITLE
Lazy type objects without once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ parking_lot = { version = "0.10", features = ["nightly"] }
 paste = "0.1.6"
 pyo3cls = { path = "pyo3cls", version = "=0.9.0-alpha.1" }
 unindent = "0.1.4"
-once_cell = "1.3.1"
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -43,10 +43,10 @@ unsafe impl pyo3::PyTypeInfo for MyClass {
     const FLAGS: usize = 0;
 
     #[inline]
-    fn type_object() -> std::ptr::NonNull<pyo3::ffi::PyTypeObject> {
+    fn type_object() -> &'static pyo3::ffi::PyTypeObject {
         use pyo3::type_object::LazyStaticType;
         static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
-        TYPE_OBJECT.get_pyclass_type::<Self>()
+        TYPE_OBJECT.get::<Self>()
     }
 }
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -46,7 +46,7 @@ unsafe impl pyo3::PyTypeInfo for MyClass {
     fn type_object() -> &'static pyo3::ffi::PyTypeObject {
         use pyo3::type_object::LazyStaticType;
         static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
-        TYPE_OBJECT.get::<Self>()
+        TYPE_OBJECT.get_or_init::<Self>()
     }
 }
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -44,8 +44,8 @@ unsafe impl pyo3::PyTypeInfo for MyClass {
 
     #[inline]
     fn type_object() -> std::ptr::NonNull<pyo3::ffi::PyTypeObject> {
-        use pyo3::type_object::LazyTypeObject;
-        static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
+        use pyo3::type_object::LazyStaticType;
+        static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
         TYPE_OBJECT.get_pyclass_type::<Self>()
     }
 }

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -384,8 +384,8 @@ fn impl_class(
             #[inline]
             fn type_object() -> &'static pyo3::ffi::PyTypeObject {
                 use pyo3::type_object::LazyStaticType;
-                static TYPE_OBJECT: LazyStaticType = LazyStaticType::new_static();
-                TYPE_OBJECT.get_pyclass_type::<Self>()
+                static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
+                TYPE_OBJECT.get::<Self>()
             }
         }
 

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -382,9 +382,9 @@ fn impl_class(
             const FLAGS: usize = #(#flags)|* | #extended;
 
             #[inline]
-            fn type_object() -> std::ptr::NonNull<pyo3::ffi::PyTypeObject> {
-                use pyo3::type_object::LazyTypeObject;
-                static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
+            fn type_object() -> &'static pyo3::ffi::PyTypeObject {
+                use pyo3::type_object::LazyStaticType;
+                static TYPE_OBJECT: LazyStaticType = LazyStaticType::new_static();
                 TYPE_OBJECT.get_pyclass_type::<Self>()
             }
         }

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -385,7 +385,7 @@ fn impl_class(
             fn type_object() -> &'static pyo3::ffi::PyTypeObject {
                 use pyo3::type_object::LazyStaticType;
                 static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
-                TYPE_OBJECT.get::<Self>()
+                TYPE_OBJECT.get_or_init::<Self>()
             }
         }
 

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -9,8 +9,8 @@ use crate::types::{PyAny, PyTuple};
 use crate::Python;
 use crate::{AsPyPointer, ToPyObject};
 use std::ffi::CStr;
+use std::ops;
 use std::os::raw::c_char;
-use std::{self, ops};
 
 /// The boilerplate to convert between a rust type and a python exception
 #[macro_export]
@@ -90,8 +90,8 @@ macro_rules! import_exception_type_object {
     ($module: expr, $name: ident) => {
         unsafe impl $crate::type_object::PyTypeObject for $name {
             fn type_object() -> $crate::Py<$crate::types::PyType> {
-                use $crate::type_object::LazyTypeObject;
-                static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
+                use $crate::type_object::LazyHeapType;
+                static TYPE_OBJECT: LazyHeapType = LazyHeapType::new_heap();
 
                 let ptr = TYPE_OBJECT
                     .get_or_init(|| {
@@ -178,8 +178,8 @@ macro_rules! create_exception_type_object {
     ($module: ident, $name: ident, $base: ty) => {
         unsafe impl $crate::type_object::PyTypeObject for $name {
             fn type_object() -> $crate::Py<$crate::types::PyType> {
-                use $crate::type_object::LazyTypeObject;
-                static TYPE_OBJECT: LazyTypeObject = LazyTypeObject::new();
+                use $crate::type_object::LazyHeapType;
+                static TYPE_OBJECT: LazyHeapType = LazyHeapType::new_heap();
 
                 let ptr = TYPE_OBJECT
                     .get_or_init(|| {

--- a/src/ffi/object.rs
+++ b/src/ffi/object.rs
@@ -177,23 +177,23 @@ mod bufferinfo {
     pub const PyBUF_WRITEABLE: c_int = PyBUF_WRITABLE;
     pub const PyBUF_FORMAT: c_int = 0x0004;
     pub const PyBUF_ND: c_int = 0x0008;
-    pub const PyBUF_STRIDES: c_int = (0x0010 | PyBUF_ND);
-    pub const PyBUF_C_CONTIGUOUS: c_int = (0x0020 | PyBUF_STRIDES);
-    pub const PyBUF_F_CONTIGUOUS: c_int = (0x0040 | PyBUF_STRIDES);
-    pub const PyBUF_ANY_CONTIGUOUS: c_int = (0x0080 | PyBUF_STRIDES);
-    pub const PyBUF_INDIRECT: c_int = (0x0100 | PyBUF_STRIDES);
+    pub const PyBUF_STRIDES: c_int = 0x0010 | PyBUF_ND;
+    pub const PyBUF_C_CONTIGUOUS: c_int = 0x0020 | PyBUF_STRIDES;
+    pub const PyBUF_F_CONTIGUOUS: c_int = 0x0040 | PyBUF_STRIDES;
+    pub const PyBUF_ANY_CONTIGUOUS: c_int = 0x0080 | PyBUF_STRIDES;
+    pub const PyBUF_INDIRECT: c_int = 0x0100 | PyBUF_STRIDES;
 
-    pub const PyBUF_CONTIG: c_int = (PyBUF_ND | PyBUF_WRITABLE);
-    pub const PyBUF_CONTIG_RO: c_int = (PyBUF_ND);
+    pub const PyBUF_CONTIG: c_int = PyBUF_ND | PyBUF_WRITABLE;
+    pub const PyBUF_CONTIG_RO: c_int = PyBUF_ND;
 
-    pub const PyBUF_STRIDED: c_int = (PyBUF_STRIDES | PyBUF_WRITABLE);
-    pub const PyBUF_STRIDED_RO: c_int = (PyBUF_STRIDES);
+    pub const PyBUF_STRIDED: c_int = PyBUF_STRIDES | PyBUF_WRITABLE;
+    pub const PyBUF_STRIDED_RO: c_int = PyBUF_STRIDES;
 
-    pub const PyBUF_RECORDS: c_int = (PyBUF_STRIDES | PyBUF_WRITABLE | PyBUF_FORMAT);
-    pub const PyBUF_RECORDS_RO: c_int = (PyBUF_STRIDES | PyBUF_FORMAT);
+    pub const PyBUF_RECORDS: c_int = PyBUF_STRIDES | PyBUF_WRITABLE | PyBUF_FORMAT;
+    pub const PyBUF_RECORDS_RO: c_int = PyBUF_STRIDES | PyBUF_FORMAT;
 
-    pub const PyBUF_FULL: c_int = (PyBUF_INDIRECT | PyBUF_WRITABLE | PyBUF_FORMAT);
-    pub const PyBUF_FULL_RO: c_int = (PyBUF_INDIRECT | PyBUF_FORMAT);
+    pub const PyBUF_FULL: c_int = PyBUF_INDIRECT | PyBUF_WRITABLE | PyBUF_FORMAT;
+    pub const PyBUF_FULL_RO: c_int = PyBUF_INDIRECT | PyBUF_FORMAT;
 
     pub const PyBUF_READ: c_int = 0x100;
     pub const PyBUF_WRITE: c_int = 0x200;
@@ -848,42 +848,42 @@ extern "C" {
 pub const Py_PRINT_RAW: c_int = 1; // No string quotes etc.
 
 /// Set if the type object is dynamically allocated
-pub const Py_TPFLAGS_HEAPTYPE: c_ulong = (1 << 9);
+pub const Py_TPFLAGS_HEAPTYPE: c_ulong = 1 << 9;
 
 /// Set if the type allows subclassing
-pub const Py_TPFLAGS_BASETYPE: c_ulong = (1 << 10);
+pub const Py_TPFLAGS_BASETYPE: c_ulong = 1 << 10;
 
 /// Set if the type implements the vectorcall protocol (PEP 590)
 #[cfg(all(Py_3_8, not(Py_LIMITED_API)))]
-pub const _Py_TPFLAGS_HAVE_VECTORCALL: c_ulong = (1 << 11);
+pub const _Py_TPFLAGS_HAVE_VECTORCALL: c_ulong = 1 << 11;
 
 /// Set if the type is 'ready' -- fully initialized
-pub const Py_TPFLAGS_READY: c_ulong = (1 << 12);
+pub const Py_TPFLAGS_READY: c_ulong = 1 << 12;
 
 /// Set while the type is being 'readied', to prevent recursive ready calls
-pub const Py_TPFLAGS_READYING: c_ulong = (1 << 13);
+pub const Py_TPFLAGS_READYING: c_ulong = 1 << 13;
 
 /// Objects support garbage collection (see objimp.h)
-pub const Py_TPFLAGS_HAVE_GC: c_ulong = (1 << 14);
+pub const Py_TPFLAGS_HAVE_GC: c_ulong = 1 << 14;
 
 const Py_TPFLAGS_HAVE_STACKLESS_EXTENSION: c_ulong = 0;
 
 /// Objects support type attribute cache
-pub const Py_TPFLAGS_HAVE_VERSION_TAG: c_ulong = (1 << 18);
-pub const Py_TPFLAGS_VALID_VERSION_TAG: c_ulong = (1 << 19);
+pub const Py_TPFLAGS_HAVE_VERSION_TAG: c_ulong = 1 << 18;
+pub const Py_TPFLAGS_VALID_VERSION_TAG: c_ulong = 1 << 19;
 
 /* Type is abstract and cannot be instantiated */
-pub const Py_TPFLAGS_IS_ABSTRACT: c_ulong = (1 << 20);
+pub const Py_TPFLAGS_IS_ABSTRACT: c_ulong = 1 << 20;
 
 /* These flags are used to determine if a type is a subclass. */
-pub const Py_TPFLAGS_LONG_SUBCLASS: c_ulong = (1 << 24);
-pub const Py_TPFLAGS_LIST_SUBCLASS: c_ulong = (1 << 25);
-pub const Py_TPFLAGS_TUPLE_SUBCLASS: c_ulong = (1 << 26);
-pub const Py_TPFLAGS_BYTES_SUBCLASS: c_ulong = (1 << 27);
-pub const Py_TPFLAGS_UNICODE_SUBCLASS: c_ulong = (1 << 28);
-pub const Py_TPFLAGS_DICT_SUBCLASS: c_ulong = (1 << 29);
-pub const Py_TPFLAGS_BASE_EXC_SUBCLASS: c_ulong = (1 << 30);
-pub const Py_TPFLAGS_TYPE_SUBCLASS: c_ulong = (1 << 31);
+pub const Py_TPFLAGS_LONG_SUBCLASS: c_ulong = 1 << 24;
+pub const Py_TPFLAGS_LIST_SUBCLASS: c_ulong = 1 << 25;
+pub const Py_TPFLAGS_TUPLE_SUBCLASS: c_ulong = 1 << 26;
+pub const Py_TPFLAGS_BYTES_SUBCLASS: c_ulong = 1 << 27;
+pub const Py_TPFLAGS_UNICODE_SUBCLASS: c_ulong = 1 << 28;
+pub const Py_TPFLAGS_DICT_SUBCLASS: c_ulong = 1 << 29;
+pub const Py_TPFLAGS_BASE_EXC_SUBCLASS: c_ulong = 1 << 30;
+pub const Py_TPFLAGS_TYPE_SUBCLASS: c_ulong = 1 << 31;
 
 pub const Py_TPFLAGS_DEFAULT: c_ulong =
     Py_TPFLAGS_HAVE_STACKLESS_EXTENSION | Py_TPFLAGS_HAVE_VERSION_TAG;

--- a/src/ffi/structmember.rs
+++ b/src/ffi/structmember.rs
@@ -49,7 +49,7 @@ pub const T_NONE: c_int = 20; /* Value is always None */
 pub const READONLY: c_int = 1;
 pub const READ_RESTRICTED: c_int = 2;
 pub const PY_WRITE_RESTRICTED: c_int = 4;
-pub const RESTRICTED: c_int = (READ_RESTRICTED | PY_WRITE_RESTRICTED);
+pub const RESTRICTED: c_int = READ_RESTRICTED | PY_WRITE_RESTRICTED;
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -74,7 +74,7 @@ where
 {
     unsafe fn alloc(_py: Python) -> *mut Self::ConcreteLayout {
         if let Some(obj) = <Self as PyClassWithFreeList>::get_free_list().pop() {
-            ffi::PyObject_Init(obj, <Self as PyTypeInfo>::type_object().as_ptr() as *mut _);
+            ffi::PyObject_Init(obj, <Self as PyTypeInfo>::type_object() as *const _ as _);
             obj as _
         } else {
             crate::pyclass::default_alloc::<Self>() as _
@@ -90,7 +90,7 @@ where
         }
 
         if let Some(obj) = <Self as PyClassWithFreeList>::get_free_list().insert(obj) {
-            match Self::type_object().as_ref().tp_free {
+            match Self::type_object().tp_free {
                 Some(free) => free(obj as *mut c_void),
                 None => tp_free_fallback(obj),
             }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -124,8 +124,8 @@ macro_rules! pyobject_native_type_convert(
             const MODULE: Option<&'static str> = $module;
 
             #[inline]
-            fn type_object() -> std::ptr::NonNull<$crate::ffi::PyTypeObject> {
-                unsafe { std::ptr::NonNull::new_unchecked(&mut $typeobject as *mut _) }
+            fn type_object() -> &'static $crate::ffi::PyTypeObject {
+                unsafe{ &$typeobject }
             }
 
             #[allow(unused_unsafe)]


### PR DESCRIPTION
The point is the use of our *great* GIL to make the global operation safe, and now we don't need `Box::into_raw` for type objects. 
I'm sure this does not bring huge merits to users who have only a few `#[pyclass]`es in their crates... but somehow I enjoyed trying to remove `Box`. It was fun :slightly_smiling_face: 