### PR TITLE
Bump minimum Rust version to 1.42.0-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
       python: "3.7"
       # Keep this synced up with build.rs and ensure that the nightly version does have clippy available
       # https://static.rust-lang.org/dist/YYYY-MM-DD/clippy-nightly-x86_64-unknown-linux-gnu.tar.gz exists
-      env: TRAVIS_RUST_VERSION=nightly-2019-07-19
+      env: TRAVIS_RUST_VERSION=nightly-2020-01-21
     - name: PyPy3.5 7.0 # Tested via anaconda PyPy (since travis's PyPy version is too old)
       python: "3.7"
       env: FEATURES="pypy" PATH="$PATH:/opt/anaconda/envs/pypy3/bin"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * The blanket implementations for `FromPyObject` for `&T` and `&mut T` are no longer specializable. Implement `PyTryFrom` for your type to control the behavior of `FromPyObject::extract()` for your types. [#713](https://github.com/PyO3/pyo3/pull/713)
 * The implementation for `IntoPy<U> for T` where `U: FromPy<T>` is no longer specializable. Control the behavior of this via the implementation of `FromPy`. [#713](https://github.com/PyO3/pyo3/pull/713)
 * Use `parking_lot::Mutex` instead of `spin::Mutex`. [#734](https://github.com/PyO3/pyo3/pull/734)
+* Bumped minimum Rust version to `1.42.0-nightly 2020-01-21`. [#761](https://github.com/PyO3/pyo3/pull/761)
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A comparison with rust-cpython can be found [in the guide](https://pyo3.rs/maste
 
 ## Usage
 
-PyO3 supports Python 3.5 and up. The minimum required Rust version is 1.37.0-nightly 2019-07-19.
+PyO3 supports Python 3.5 and up. The minimum required Rust version is 1.42.0-nightly 2020-01-21.
 
 If you have never used nightly Rust, the official guide has
 [a great section](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#rustup-and-the-role-of-rust-nightly)

--- a/build.rs
+++ b/build.rs
@@ -19,9 +19,9 @@ use version_check::{Channel, Date, Version};
 /// Specifies the minimum nightly version needed to compile pyo3.
 /// Keep this synced up with the travis ci config,
 /// But note that this is the rustc version which can be lower than the nightly version
-const MIN_DATE: &str = "2019-07-18";
-const MIN_VERSION: &str = "1.37.0-nightly";
-//const PYTHON_INTERPRETER: &'static str = "python3";
+const MIN_DATE: &str = "2020-01-20";
+const MIN_VERSION: &str = "1.42.0-nightly";
+//const PYTHON_INTERPRETER: &str = "python3";
 
 lazy_static! {
     static ref PYTHON_INTERPRETER: &'static str = {

--- a/build.rs
+++ b/build.rs
@@ -19,8 +19,8 @@ use version_check::{Channel, Date, Version};
 /// Specifies the minimum nightly version needed to compile pyo3.
 /// Keep this synced up with the travis ci config,
 /// But note that this is the rustc version which can be lower than the nightly version
-const MIN_DATE: &'static str = "2019-07-18";
-const MIN_VERSION: &'static str = "1.37.0-nightly";
+const MIN_DATE: &str = "2019-07-18";
+const MIN_VERSION: &str = "1.37.0-nightly";
 //const PYTHON_INTERPRETER: &'static str = "python3";
 
 lazy_static! {
@@ -85,7 +85,7 @@ impl fmt::Display for PythonVersion {
 
 const PY3_MIN_MINOR: u8 = 5;
 
-const CFG_KEY: &'static str = "py_sys_config";
+const CFG_KEY: &str = "py_sys_config";
 
 /// A list of python interpreter compile-time preprocessor defines that
 /// we will pick up and pass to rustc via --cfg=py_sys_config={varname};
@@ -100,7 +100,7 @@ const CFG_KEY: &'static str = "py_sys_config";
 /// (hrm, this is sort of re-implementing what distutils does, except
 /// by passing command line args instead of referring to a python.h)
 #[cfg(not(target_os = "windows"))]
-static SYSCONFIG_FLAGS: [&'static str; 7] = [
+static SYSCONFIG_FLAGS: [&str; 7] = [
     "Py_USING_UNICODE",
     "Py_UNICODE_WIDE",
     "WITH_THREAD",
@@ -110,7 +110,7 @@ static SYSCONFIG_FLAGS: [&'static str; 7] = [
     "COUNT_ALLOCS",
 ];
 
-static SYSCONFIG_VALUES: [&'static str; 1] = [
+static SYSCONFIG_VALUES: [&str; 1] = [
     // cfg doesn't support flags with values, just bools - so flags
     // below are translated into bools as {varname}_{val}
     //
@@ -188,7 +188,7 @@ fn load_cross_compile_info() -> Result<(InterpreterConfig, HashMap<String, Strin
     let shared = match config_map
         .get("Py_ENABLE_SHARED")
         .map(|x| x.as_str())
-        .ok_or("Py_ENABLE_SHARED is not defined".to_string())?
+        .ok_or_else(|| "Py_ENABLE_SHARED is not defined".to_string())?
     {
         "1" | "true" | "True" => true,
         "0" | "false" | "False" => false,
@@ -279,7 +279,7 @@ fn get_config_vars(_: &str) -> Result<HashMap<String, String>, String> {
 }
 
 fn is_value(key: &str) -> bool {
-    SYSCONFIG_VALUES.iter().find(|x| **x == key).is_some()
+    SYSCONFIG_VALUES.iter().any(|x| *x == key)
 }
 
 fn cfg_line_for_var(key: &str, val: &str) -> Option<String> {
@@ -321,7 +321,7 @@ fn run_python_script(interpreter: &str, script: &str) -> Result<String, String> 
     };
 
     if !out.status.success() {
-        return Err(format!("python script failed"));
+        return Err("python script failed".to_string());
     }
 
     Ok(String::from_utf8(out.stdout).unwrap())
@@ -451,7 +451,7 @@ fn find_interpreter_and_get_config() -> Result<(InterpreterConfig, HashMap<Strin
         ));
     }
 
-    Err(format!("No python interpreter found"))
+    Err("No python interpreter found".to_string())
 }
 
 /// Extract compilation vars from the specified interpreter.
@@ -513,7 +513,7 @@ fn configure(interpreter_config: &InterpreterConfig) -> Result<String, String> {
 
     if interpreter_config.version.implementation == PythonInterpreterKind::PyPy {
         println!("cargo:rustc-cfg=PyPy");
-        flags += format!("CFG_PyPy").as_ref();
+        flags += "CFG_PyPy";
     };
 
     if interpreter_config.version.major == 2 {
@@ -533,7 +533,7 @@ fn configure(interpreter_config: &InterpreterConfig) -> Result<String, String> {
     }
     println!("cargo:rustc-cfg=Py_3");
 
-    return Ok(flags);
+    Ok(flags)
 }
 
 fn check_rustc_version() {
@@ -603,9 +603,8 @@ fn main() -> Result<(), String> {
     }
 
     for (key, val) in &config_map {
-        match cfg_line_for_var(key, val) {
-            Some(line) => println!("{}", line),
-            None => (),
+        if let Some(line) = cfg_line_for_var(key, val) {
+            println!("{}", line)
         }
     }
 
@@ -634,7 +633,7 @@ fn main() -> Result<(), String> {
 
     println!(
         "cargo:python_flags={}",
-        if flags.len() > 0 {
+        if !flags.is_empty() {
             &flags[..flags.len() - 1]
         } else {
             ""

--- a/build.rs
+++ b/build.rs
@@ -236,15 +236,14 @@ fn get_config_vars(python_path: &str) -> Result<HashMap<String, String>, String>
         ));
     }
     let all_vars = SYSCONFIG_FLAGS.iter().chain(SYSCONFIG_VALUES.iter());
-    let all_vars = all_vars.zip(split_stdout.iter()).fold(
-        HashMap::new(),
-        |mut memo: HashMap<String, String>, (&k, &v)| {
-            if !(v.to_owned() == "None" && is_value(k)) {
-                memo.insert(k.to_owned(), v.to_owned());
+    let all_vars = all_vars
+        .zip(split_stdout.iter())
+        .fold(HashMap::new(), |mut memo, (&k, &v)| {
+            if !(v == "None" && is_value(k)) {
+                memo.insert(k.to_string(), v.to_string());
             }
             memo
-        },
-    );
+        });
 
     Ok(fix_config_map(all_vars))
 }

--- a/guide/src/get_started.md
+++ b/guide/src/get_started.md
@@ -10,7 +10,7 @@ A comparison with rust-cpython can be found [in the guide](https://pyo3.rs/maste
 
 ## Usage
 
-PyO3 supports Python 3.5 and up. The minimum required Rust version is 1.37.0-nightly 2019-07-19.
+PyO3 supports Python 3.5 and up. The minimum required Rust version is 1.42.0-nightly 2019-01-21.
 
 If you have never used nightly Rust, the official guide has
 [a great section](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html#rustup-and-the-role-of-rust-nightly)

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -25,7 +25,7 @@ fn rust2py(py: Python, m: &PyModule) -> PyResult<()> {
 
 // logic implemented as a normal rust function
 fn sum_as_string(a:i64, b:i64) -> String {
-    format!("{}", a + b).to_string()
+    format!("{}", a + b)
 }
 
 # fn main() {}

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -332,7 +332,7 @@ fn impl_class(
 
     // Enforce at compile time that PyGCProtocol is implemented
     let gc_impl = if has_gc {
-        let closure_name = format!("__assertion_closure_{}", cls.to_string());
+        let closure_name = format!("__assertion_closure_{}", cls);
         let closure_token = syn::Ident::new(&closure_name, Span::call_site());
         quote! {
             fn #closure_token() {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -23,7 +23,6 @@ use crate::ffi;
 use crate::types::PyAny;
 use crate::AsPyPointer;
 use crate::Python;
-use libc;
 use std::ffi::CStr;
 use std::os::raw;
 use std::pin::Pin;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(specialization)]
+#![allow(clippy::missing_safety_doc)] // FIXME (#698)
 
 //! Rust bindings to the Python interpreter.
 //!

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -154,7 +154,7 @@ struct Sequence {
 impl Default for Sequence {
     fn default() -> Sequence {
         let mut fields = vec![];
-        for s in &["A", "B", "C", "D", "E", "F", "G"] {
+        for &s in &["A", "B", "C", "D", "E", "F", "G"] {
             fields.push(s.to_string());
         }
         Sequence { fields }

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -2,11 +2,13 @@ use pyo3::prelude::*;
 use pyo3::{exceptions, py_run, wrap_pyfunction, PyErr, PyResult};
 use std::error::Error;
 use std::fmt;
+#[cfg(not(target_os = "windows"))]
 use std::fs::File;
 
 mod common;
 
 #[pyfunction]
+#[cfg(not(target_os = "windows"))]
 fn fail_to_open_file() -> PyResult<()> {
     File::open("not_there.txt")?;
     Ok(())

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -11,7 +11,7 @@ struct AnonClass {}
 struct LocatedClass {}
 
 fn sum_as_string(a: i64, b: i64) -> String {
-    format!("{}", a + b).to_string()
+    format!("{}", a + b)
 }
 
 #[pyfunction]

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -84,7 +84,7 @@ impl PyIterProtocol for Iter {
 fn reader() -> Reader {
     let reader = [(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e")];
     Reader {
-        inner: reader.iter().map(|(k, v)| (*k, v.to_string())).collect(),
+        inner: reader.iter().map(|(k, v)| (*k, (*v).to_string())).collect(),
     }
 }
 


### PR DESCRIPTION
I fixed all the clippy warnings as of present.

To silence the safety warnings for now (#698) I've added an `#![allow(clippy::missing_safety_doc)]`. This should make it easier to check for new clippy errors when people are developing patches while we wait for someone to pick up #698.