### PR TITLE
Add mocpy to the list of examples using pyo3

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ about this topic.
  * [fastuuid](https://github.com/thedrow/fastuuid/) _Python bindings to Rust's UUID library_
  * [python-ext-wasm](https://github.com/wasmerio/python-ext-wasm) _Python library to run WebAssembly binaries_
  * [dict-derive](https://github.com/gperinazzo/dict-derive) _Derive FromPyObject to automatically transform Python dicts into Rust structs_
+ * [mocpy](https://github.com/cds-astro/mocpy) _Astronomical Python library offering data structures for describing any arbitrary coverage regions on the unit sphere_
 
 ## License
 


### PR DESCRIPTION
MOCpy is an astronomical Python library used for describing arbitrary
coverage regions on the sky unit sphere. It relies on the HEALPix tesselation
scheme and because of this, it is very easy and fast to compute the
intersection/union... between coverage regions!

Please check the documentation of mocpy [here](https://cds-astro.github.io/mocpy/) if you are curious.