### PR TITLE
We need nightly, so make that explicit.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Added a rust-toolchain file so people don't have to type `rustup default nightly` - instead `cargo build` just works.