### PR TITLE
Fix PyLayout and restrict PyRef::as_ref for non-native types

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -83,7 +83,6 @@ impl pyo3::class::methods::PyMethodsInventoryDispatch for MyClass {
 }
 
 pyo3::inventory::collect!(MyClassGeneratedPyo3Inventory);
-
 # let gil = Python::acquire_gil();
 # let py = gil.python();
 # let cls = py.get_type::<MyClass>();
@@ -304,8 +303,6 @@ impl SubSubClass {
       SubClass::method2(super_).map(|x| x * v)
    }
 }
-
-
 # let gil = Python::acquire_gil();
 # let py = gil.python();
 # let subsub = pyo3::PyCell::new(py, SubSubClass::new()).unwrap();
@@ -342,7 +339,6 @@ impl DictWithCounter {
        dict.set_item(key, value)
    }
 }
-
 # let gil = Python::acquire_gil();
 # let py = gil.python();
 # let cnt = pyo3::PyCell::new(py, DictWithCounter::new()).unwrap();
@@ -379,14 +375,13 @@ annotated with `#[getter]` and `#[setter]` attributes. For example:
 
 ```rust
 # use pyo3::prelude::*;
-# #[pyclass]
-# struct MyClass {
-#    num: i32,
-# }
-#
+#[pyclass]
+struct MyClass {
+   num: i32,
+}
+
 #[pymethods]
 impl MyClass {
-
      #[getter]
      fn num(&self) -> PyResult<i32> {
         Ok(self.num)
@@ -409,10 +404,8 @@ can be used since Rust 2018).
 # struct MyClass {
 #    num: i32,
 # }
-#
 #[pymethods]
 impl MyClass {
-
      #[getter]
      fn get_num(&self) -> PyResult<i32> {
         Ok(self.num)
@@ -437,10 +430,8 @@ If this parameter is specified, it is used as the property name, i.e.
 # struct MyClass {
 #    num: i32,
 # }
-#
 #[pymethods]
 impl MyClass {
-
      #[getter(number)]
      fn num(&self) -> PyResult<i32> {
         Ok(self.num)
@@ -482,10 +473,8 @@ block with some variations, like descriptors, class method static methods, etc.
 # struct MyClass {
 #    num: i32,
 # }
-#
 #[pymethods]
 impl MyClass {
-
      fn method1(&self) -> PyResult<i32> {
         Ok(10)
      }
@@ -511,7 +500,6 @@ gets injected by the method wrapper, e.g.
 #    num: i32,
 #    debug: bool,
 # }
-
 #[pymethods]
 impl MyClass {
      fn method2(&self, py: Python) -> PyResult<i32> {
@@ -535,7 +523,6 @@ with the `#[classmethod]` attribute.
 #    num: i32,
 #    debug: bool,
 # }
-
 #[pymethods]
 impl MyClass {
      #[classmethod]
@@ -566,7 +553,6 @@ To create a static method for a custom class, the method needs to be annotated w
 #    num: i32,
 #    debug: bool,
 # }
-
 #[pymethods]
 impl MyClass {
      #[staticmethod]
@@ -589,7 +575,6 @@ use pyo3::types::PyTuple;
 #    num: i32,
 #    debug: bool,
 # }
-
 #[pymethods]
 impl MyClass {
      #[call]
@@ -632,7 +617,6 @@ use pyo3::types::{PyDict, PyTuple};
 #    num: i32,
 #    debug: bool,
 # }
-#
 #[pymethods]
 impl MyClass {
     #[new]

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -440,6 +440,8 @@ pub struct PyRef<'p, T: PyClass> {
     inner: &'p PyCellInner<T>,
 }
 
+unsafe impl<'p, T: PyClass> crate::PyNativeType for PyRef<'p, T> {}
+
 impl<'p, T, U> AsRef<U> for PyRef<'p, T>
 where
     T: PyClass + PyTypeInfo<BaseType = U, BaseLayout = PyCellInner<U>>,
@@ -548,6 +550,8 @@ impl<T: PyClass + fmt::Debug> fmt::Debug for PyRef<'_, T> {
 pub struct PyRefMut<'p, T: PyClass> {
     inner: &'p PyCellInner<T>,
 }
+
+unsafe impl<'p, T: PyClass> crate::PyNativeType for PyRefMut<'p, T> {}
 
 impl<'p, T, U> AsRef<U> for PyRefMut<'p, T>
 where

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -21,7 +21,6 @@ pub unsafe trait PyLayout<T: PyTypeInfo> {
     }
     unsafe fn py_init(&mut self, _value: T) {}
     unsafe fn py_drop(&mut self, _py: Python) {}
-    unsafe fn get_ptr(&self) -> *mut T;
 }
 
 /// `T: PySizedLayout<U>` represents `T` is not a instance of

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -23,11 +23,7 @@ use crate::{ffi, PyObject};
 /// ```
 #[repr(transparent)]
 pub struct PyAny(PyObject, Unsendable);
-unsafe impl crate::type_object::PyLayout<PyAny> for ffi::PyObject {
-    unsafe fn get_ptr(&self) -> *mut PyAny {
-        (&self) as *const &Self as *const _ as *mut _
-    }
-}
+unsafe impl crate::type_object::PyLayout<PyAny> for ffi::PyObject {}
 impl crate::type_object::PySizedLayout<PyAny> for ffi::PyObject {}
 pyobject_native_type_named!(PyAny);
 pyobject_native_type_convert!(

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -56,20 +56,10 @@ macro_rules! pyobject_native_type_named (
     };
 );
 
-macro_rules! impl_layout {
-    ($name: ty, $layout: path) => {
-        unsafe impl $crate::type_object::PyLayout<$name> for $layout {
-            unsafe fn get_ptr(&self) -> *mut $name {
-                (&self) as *const &Self as *const _ as *mut _
-            }
-        }
-    };
-}
-
 #[macro_export]
 macro_rules! pyobject_native_type {
     ($name: ty, $layout: path, $typeobject: expr, $module: expr, $checkfunction: path $(,$type_param: ident)*) => {
-        impl_layout!($name, $layout);
+        unsafe impl $crate::type_object::PyLayout<$name> for $layout {}
         impl $crate::type_object::PySizedLayout<$name> for $layout {}
         impl $crate::derive_utils::PyBaseTypeUtils for $name {
             type Dict = $crate::pyclass_slots::PyClassDummySlot;
@@ -97,7 +87,7 @@ macro_rules! pyobject_native_type {
 #[macro_export]
 macro_rules! pyobject_native_var_type {
     ($name: ty, $typeobject: expr, $module: expr, $checkfunction: path $(,$type_param: ident)*) => {
-        impl_layout!($name, $crate::ffi::PyObject);
+        unsafe impl $crate::type_object::PyLayout<$name> for $crate::ffi::PyObject {}
         pyobject_native_type_named!($name $(,$type_param)*);
         pyobject_native_type_convert!($name, $crate::ffi::PyObject,
                                       $typeobject, $module, $checkfunction $(,$type_param)*);


### PR DESCRIPTION
Fix #782.
Simply I make `get_ptr` a private method of `PyCellInner`.
This change forbids to get a base object of `#[pyclass(extends=NativeType]` style pyclasses.
Current `&PyAny` style API uses mainly *a pointer of a pointer* as an object handle, and integrates really badly with new `PyCell` :persevere: 