### PR TITLE
Make FFIs Python3.8 compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Use `parking_lot::Mutex` instead of `spin::Mutex`. [#734](https://github.com/PyO3/pyo3/pull/734)
 * Bumped minimum Rust version to `1.42.0-nightly 2020-01-21`. [#761](https://github.com/PyO3/pyo3/pull/761)
 * `PyRef` and `PyRefMut` are renewed for `PyCell`. [#770](https://github.com/PyO3/pyo3/pull/770)
+* Some new FFI functions for Python 3.8. [#784](https://github.com/PyO3/pyo3/pull/784)
 
 ### Added
 * `PyCell`, which has RefCell-like features. [#770](https://github.com/PyO3/pyo3/pull/770)

--- a/src/ffi/ceval.rs
+++ b/src/ffi/ceval.rs
@@ -90,5 +90,6 @@ extern "C" {
     pub fn PyEval_AcquireThread(tstate: *mut PyThreadState) -> ();
     #[cfg_attr(PyPy, link_name = "PyPyEval_ReleaseThread")]
     pub fn PyEval_ReleaseThread(tstate: *mut PyThreadState) -> ();
+    #[cfg(not(Py_3_8))]
     pub fn PyEval_ReInitThreads() -> ();
 }

--- a/src/ffi/code.rs
+++ b/src/ffi/code.rs
@@ -2,6 +2,9 @@ use crate::ffi::object::*;
 use crate::ffi::pyport::Py_ssize_t;
 use std::os::raw::{c_char, c_int, c_uchar, c_void};
 
+#[cfg(Py_3_8)]
+pub enum _PyOpcache {}
+
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyCodeObject {
@@ -29,6 +32,14 @@ pub struct PyCodeObject {
     pub co_weakreflist: *mut PyObject,
     #[cfg(Py_3_6)]
     pub co_extra: *mut c_void,
+    #[cfg(Py_3_8)]
+    pub co_opcache_map: *mut c_uchar,
+    #[cfg(Py_3_8)]
+    pub co_opcache: *mut _PyOpcache,
+    #[cfg(Py_3_8)]
+    pub co_opcache_flag: c_int,
+    #[cfg(Py_3_8)]
+    pub co_opcache_size: c_uchar,
 }
 
 /* Masks for co_flags */
@@ -77,21 +88,40 @@ extern "C" {
 
     #[cfg_attr(PyPy, link_name = "PyPyCode_New")]
     pub fn PyCode_New(
-        arg1: c_int,
-        arg2: c_int,
-        arg3: c_int,
-        arg4: c_int,
-        arg5: c_int,
-        arg6: *mut PyObject,
-        arg7: *mut PyObject,
-        arg8: *mut PyObject,
-        arg9: *mut PyObject,
-        arg10: *mut PyObject,
-        arg11: *mut PyObject,
-        arg12: *mut PyObject,
-        arg13: *mut PyObject,
-        arg14: c_int,
-        arg15: *mut PyObject,
+        argcount: c_int,
+        kwonlyargcount: c_int,
+        nlocals: c_int,
+        stacksize: c_int,
+        flags: c_int,
+        code: *mut PyObject,
+        consts: *mut PyObject,
+        names: *mut PyObject,
+        varnames: *mut PyObject,
+        freevars: *mut PyObject,
+        cellvars: *mut PyObject,
+        filename: *mut PyObject,
+        name: *mut PyObject,
+        firstlineno: c_int,
+        lnotab: *mut PyObject,
+    ) -> *mut PyCodeObject;
+    #[cfg(Py_3_8)]
+    pub fn PyCode_NewWithPosOnlyArgs(
+        argcount: c_int,
+        posonlyargcount: c_int,
+        kwonlyargcount: c_int,
+        nlocals: c_int,
+        stacksize: c_int,
+        flags: c_int,
+        code: *mut PyObject,
+        consts: *mut PyObject,
+        names: *mut PyObject,
+        varnames: *mut PyObject,
+        freevars: *mut PyObject,
+        cellvars: *mut PyObject,
+        filename: *mut PyObject,
+        name: *mut PyObject,
+        firstlineno: c_int,
+        lnotab: *mut PyObject,
     ) -> *mut PyCodeObject;
     #[cfg_attr(PyPy, link_name = "PyPyCode_NewEmpty")]
     pub fn PyCode_NewEmpty(

--- a/src/ffi/compile.rs
+++ b/src/ffi/compile.rs
@@ -60,8 +60,13 @@ extern "C" {
     ) -> *mut PyFutureFeatures;
 
     pub fn PyCompile_OpcodeStackEffect(opcode: c_int, oparg: c_int) -> c_int;
+
+    #[cfg(Py_3_8)]
+    pub fn PyCompile_OpcodeStackEffectWithJump(opcode: c_int, oparg: c_int, jump: c_int) -> c_int;
 }
 
 pub const Py_single_input: c_int = 256;
 pub const Py_file_input: c_int = 257;
 pub const Py_eval_input: c_int = 258;
+#[cfg(Py_3_8)]
+pub const Py_func_type_input: c_int = 345;

--- a/src/ffi/dictobject.rs
+++ b/src/ffi/dictobject.rs
@@ -1,5 +1,5 @@
 use crate::ffi::object::*;
-use crate::ffi::pyport::{Py_hash_t, Py_ssize_t};
+use crate::ffi::pyport::Py_ssize_t;
 use std::os::raw::{c_char, c_int};
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
@@ -11,6 +11,12 @@ extern "C" {
     pub static mut PyDictKeys_Type: PyTypeObject;
     pub static mut PyDictItems_Type: PyTypeObject;
     pub static mut PyDictValues_Type: PyTypeObject;
+    #[cfg(Py_3_8)]
+    pub static mut PyDictRevIterKey_Type: PyTypeObject;
+    #[cfg(Py_3_8)]
+    pub static mut PyDictRevIterValue_Type: PyTypeObject;
+    #[cfg(Py_3_8)]
+    pub static mut PyDictRevIterItem_Type: PyTypeObject;
 }
 
 #[repr(C)]
@@ -73,7 +79,7 @@ extern "C" {
         mp: *mut PyObject,
         key: *mut PyObject,
         item: *mut PyObject,
-        hash: Py_hash_t,
+        hash: crate::ffi::pyport::Py_hash_t,
     ) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyDict_DelItem")]
     pub fn PyDict_DelItem(mp: *mut PyObject, key: *mut PyObject) -> c_int;


### PR DESCRIPTION
Resolves #704.
Includes a refactoring of `type_object_init!` macros.
