### PR TITLE
Fix the interpretation of vararg separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Usage of raw identifiers with `#[pyo3(set)]`. [#745](https://github.com/PyO3/pyo3/pull/745)
 * Usage of `PyObject` with `#[pyo3(get)]`. [#760](https://github.com/PyO3/pyo3/pull/760)
 * `#[pymethods]` used in conjunction with `#[cfg]`. #[769](https://github.com/PyO3/pyo3/pull/769)
-* Interpretation of `*`. #[792](https://github.com/PyO3/pyo3/pull/792)
+* Interpretation of `*` and some unreasonable behaviors of `#[args]`. #[792](https://github.com/PyO3/pyo3/pull/792)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Usage of raw identifiers with `#[pyo3(set)]`. [#745](https://github.com/PyO3/pyo3/pull/745)
 * Usage of `PyObject` with `#[pyo3(get)]`. [#760](https://github.com/PyO3/pyo3/pull/760)
 * `#[pymethods]` used in conjunction with `#[cfg]`. #[769](https://github.com/PyO3/pyo3/pull/769)
-* Interpretation of `*` and some unreasonable behaviors of `#[args]`. #[792](https://github.com/PyO3/pyo3/pull/792)
+* `"*"` in a `#[pyfunction()]` argument list incorrectly accepting any number of positional arguments (use `args = "*"` when this behaviour is desired). #[792](https://github.com/PyO3/pyo3/pull/792)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Usage of raw identifiers with `#[pyo3(set)]`. [#745](https://github.com/PyO3/pyo3/pull/745)
 * Usage of `PyObject` with `#[pyo3(get)]`. [#760](https://github.com/PyO3/pyo3/pull/760)
 * `#[pymethods]` used in conjunction with `#[cfg]`. #[769](https://github.com/PyO3/pyo3/pull/769)
+* Interpretation of `*`. #[792](https://github.com/PyO3/pyo3/pull/792)
 
 ### Removed
 

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -206,30 +206,10 @@ impl<'a> FnSpec<'a> {
         false
     }
 
-    pub fn accept_args(&self) -> bool {
-        for s in self.attrs.iter() {
-            match *s {
-                Argument::VarArgs(_) => return true,
-                Argument::VarArgsSeparator => return true,
-                _ => (),
-            }
-        }
-        false
-    }
-
     pub fn is_kwargs(&self, name: &syn::Ident) -> bool {
         for s in self.attrs.iter() {
             if let Argument::KeywordArgs(ref path) = s {
                 return path.is_ident(name);
-            }
-        }
-        false
-    }
-
-    pub fn accept_kwargs(&self) -> bool {
-        for s in self.attrs.iter() {
-            if let Argument::KeywordArgs(_) = s {
-                return true;
             }
         }
         false

--- a/pyo3-derive-backend/src/pyfunction.rs
+++ b/pyo3-derive-backend/src/pyfunction.rs
@@ -52,34 +52,30 @@ impl PyFunctionAttr {
             NestedMeta::Lit(ref lit) => {
                 self.add_literal(item, lit)?;
             }
-            _ => {
-                return Err(syn::Error::new_spanned(item, "Unknown argument"));
+            NestedMeta::Meta(syn::Meta::List(ref list)) => {
+                return Err(syn::Error::new_spanned(
+                    list,
+                    "List is not supported as argument",
+                ));
             }
         }
-
         Ok(())
     }
 
     fn add_literal(&mut self, item: &NestedMeta, lit: &syn::Lit) -> syn::Result<()> {
         match lit {
-            syn::Lit::Str(ref lits) => {
+            syn::Lit::Str(ref lits) if lits.value() == "*" => {
                 // "*"
-                if lits.value() == "*" {
-                    self.vararg_is_ok(item)?;
-                    self.has_varargs = true;
-                    self.arguments.push(Argument::VarArgsSeparator);
-                } else {
-                    return Err(syn::Error::new_spanned(lits, "Unknown string literal"));
-                }
+                self.vararg_is_ok(item)?;
+                self.has_varargs = true;
+                self.arguments.push(Argument::VarArgsSeparator);
+                Ok(())
             }
-            _ => {
-                return Err(syn::Error::new_spanned(
-                    item,
-                    format!("Only string literal is supported, got: {:?}", lit),
-                ));
-            }
-        };
-        Ok(())
+            _ => Err(syn::Error::new_spanned(
+                item,
+                format!("Only \"*\" is supported here, got: {:?}", lit),
+            )),
+        }
     }
 
     fn add_work(&mut self, item: &NestedMeta, path: &Path) -> syn::Result<()> {
@@ -195,11 +191,8 @@ pub fn parse_name_attribute(attrs: &mut Vec<syn::Attribute>) -> syn::Result<Opti
             *span,
             "Expected string literal for #[name] argument",
         )),
-        // TODO: The below pattern is unstable, so instead we match the wildcard.
-        // slice_patterns due to be stable soon: https://github.com/rust-lang/rust/issues/62254
-        // [(_, span), _, ..] => {
-        _ => Err(syn::Error::new(
-            name_attrs[0].1,
+        [(_, span), ..] => Err(syn::Error::new(
+            *span,
             "#[name] can not be specified multiple times",
         )),
     }

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -61,7 +61,7 @@ pub fn parse_fn_args<'p>(
                 if i < nargs {
                     raise_error!("got multiple values for argument: {}", p.name)
                 }
-                kwargs.as_ref().unwrap().del_item(p.name).unwrap();
+                kwargs.as_ref().unwrap().del_item(p.name)?;
                 Some(kwarg)
             }
             None => {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -18,7 +18,7 @@ macro_rules! py_expect_exception {
         let res = $py.run($code, None, Some(d));
         let err = res.unwrap_err();
         if !err.matches($py, $py.get_type::<pyo3::exceptions::$err>()) {
-            panic!(format!("Expected {} but got {:?}", stringify!($err), err))
+            panic!("Expected {} but got {:?}", stringify!($err), err)
         }
     }};
 }

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,6 +1,7 @@
 #[test]
 fn test_compile_errors() {
     let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/invalid_macro_args.rs");
     t.compile_fail("tests/ui/invalid_property_args.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
     t.compile_fail("tests/ui/missing_clone.rs");

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -231,8 +231,13 @@ impl MethArgs {
         [a.to_object(py), args.into(), kwargs.to_object(py)].to_object(py)
     }
 
-    #[args("*", c = 10)]
-    fn get_pos_arg_kw_sep(&self, a: i32, b: i32, c: i32) -> PyResult<i32> {
+    #[args(a, b = 2, "*", c = 3)]
+    fn get_pos_arg_kw_sep1(&self, a: i32, b: i32, c: i32) -> PyResult<i32> {
+        Ok(a + b + c)
+    }
+
+    #[args(a, "*", b = 2, c = 3)]
+    fn get_pos_arg_kw_sep2(&self, a: i32, b: i32, c: i32) -> PyResult<i32> {
         Ok(a + b + c)
     }
 
@@ -299,15 +304,22 @@ fn meth_args() {
     py_expect_exception!(py, inst, "inst.get_pos_arg_kw(1, a=1)", TypeError);
     py_expect_exception!(py, inst, "inst.get_pos_arg_kw(b=2)", TypeError);
 
-    py_run!(py, inst, "assert inst.get_pos_arg_kw_sep(1, 2, c=3) == 6");
-    py_run!(py, inst, "assert inst.get_pos_arg_kw_sep(1, 2) == 13");
-    py_expect_exception!(py, inst, "assert inst.get_pos_arg_kw_sep(1)", TypeError);
-    py_expect_exception!(
+    py_run!(py, inst, "assert inst.get_pos_arg_kw_sep1(1) == 6");
+    py_run!(py, inst, "assert inst.get_pos_arg_kw_sep1(1, 2) == 6");
+    py_run!(
         py,
         inst,
-        "assert inst.get_pos_arg_kw_sep(1, 2, 3)",
-        TypeError
+        "assert inst.get_pos_arg_kw_sep1(1, 2, c=13) == 16"
     );
+    py_expect_exception!(py, inst, "inst.get_pos_arg_kw_sep1(1, 2, 3)", TypeError);
+
+    py_run!(py, inst, "assert inst.get_pos_arg_kw_sep2(1) == 6");
+    py_run!(
+        py,
+        inst,
+        "assert inst.get_pos_arg_kw_sep2(1, b=12, c=13) == 26"
+    );
+    py_expect_exception!(py, inst, "inst.get_pos_arg_kw_sep2(1, 2)", TypeError);
 
     py_run!(py, inst, "assert inst.get_pos_kw(1, b=2) == [1, {'b': 2}]");
     py_expect_exception!(py, inst, "inst.get_pos_kw(1,2)", TypeError);

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -231,11 +231,15 @@ impl MethArgs {
         [a.to_object(py), args.into(), kwargs.to_object(py)].to_object(py)
     }
 
+    #[args("*", c = 10)]
+    fn get_pos_arg_kw_sep(&self, a: i32, b: i32, c: i32) -> PyResult<i32> {
+        Ok(a + b + c)
+    }
+
     #[args(kwargs = "**")]
     fn get_pos_kw(&self, py: Python, a: i32, kwargs: Option<&PyDict>) -> PyObject {
         [a.to_object(py), kwargs.to_object(py)].to_object(py)
     }
-
     // "args" can be anything that can be extracted from PyTuple
     #[args(args = "*")]
     fn args_as_vec(&self, args: Vec<i32>) -> i32 {
@@ -264,7 +268,7 @@ fn meth_args() {
     py_run!(py, inst, "assert inst.get_default() == 10");
     py_run!(py, inst, "assert inst.get_default(100) == 100");
     py_run!(py, inst, "assert inst.get_kwarg() == 10");
-    py_run!(py, inst, "assert inst.get_kwarg(100) == 10");
+    py_expect_exception!(py, inst, "inst.get_kwarg(100)", TypeError);
     py_run!(py, inst, "assert inst.get_kwarg(test=100) == 100");
     py_run!(py, inst, "assert inst.get_kwargs() == [(), None]");
     py_run!(py, inst, "assert inst.get_kwargs(1,2,3) == [(1,2,3), None]");
@@ -294,6 +298,16 @@ fn meth_args() {
     py_expect_exception!(py, inst, "inst.get_pos_arg_kw()", TypeError);
     py_expect_exception!(py, inst, "inst.get_pos_arg_kw(1, a=1)", TypeError);
     py_expect_exception!(py, inst, "inst.get_pos_arg_kw(b=2)", TypeError);
+
+    py_run!(py, inst, "assert inst.get_pos_arg_kw_sep(1, 2, c=3) == 6");
+    py_run!(py, inst, "assert inst.get_pos_arg_kw_sep(1, 2) == 13");
+    py_expect_exception!(py, inst, "assert inst.get_pos_arg_kw_sep(1)", TypeError);
+    py_expect_exception!(
+        py,
+        inst,
+        "assert inst.get_pos_arg_kw_sep(1, 2, 3)",
+        TypeError
+    );
 
     py_run!(py, inst, "assert inst.get_pos_kw(1, b=2) == [1, {'b': 2}]");
     py_expect_exception!(py, inst, "inst.get_pos_kw(1,2)", TypeError);

--- a/tests/ui/invalid_macro_args.rs
+++ b/tests/ui/invalid_macro_args.rs
@@ -1,0 +1,18 @@
+use pyo3::prelude::*;
+
+#[pyfunction(a = 5, b)]
+fn pos_after_kw(py: Python, a: i32, b: i32) -> PyObject {
+    [a.to_object(py), vararg.into()].to_object(py)
+}
+
+#[pyfunction(a, "*", b)]
+fn pos_after_separator(py: Python, a: i32, b: i32) -> PyObject {
+    [a.to_object(py), vararg.into()].to_object(py)
+}
+
+#[pyfunction(kwargs = "**", a = 5)]
+fn kw_after_kwargs(py: Python, kwargs: &PyDict, a: i32) -> PyObject {
+    [a.to_object(py), vararg.into()].to_object(py)
+}
+
+fn main() {}

--- a/tests/ui/invalid_macro_args.stderr
+++ b/tests/ui/invalid_macro_args.stderr
@@ -1,0 +1,17 @@
+error: Positional argument or varargs(*) is not allowed after keyword arguments
+ --> $DIR/invalid_macro_args.rs:3:21
+  |
+3 | #[pyfunction(a = 5, b)]
+  |                     ^
+
+error: Positional argument or varargs(*) is not allowed after *
+ --> $DIR/invalid_macro_args.rs:8:22
+  |
+8 | #[pyfunction(a, "*", b)]
+  |                      ^
+
+error: Keyword argument or kwargs(**) is not allowed after kwargs(**)
+  --> $DIR/invalid_macro_args.rs:13:29
+   |
+13 | #[pyfunction(kwargs = "**", a = 5)]
+   |                             ^^^^^


### PR DESCRIPTION
Resolves #790 
`*` does not mean `accept_args` and we should reject `fn(10)` for `def fn(*, var=10)`.