### PR TITLE
Add catch_unwind! macro to prevent panics crossing ffi boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+* Panics from Rust will now be caught and raised as Python errors. [#797](https://github.com/PyO3/pyo3/pull/797)
 * `PyObject` and `Py<T>` reference counts are now decremented sooner after `drop()`. [#851](https://github.com/PyO3/pyo3/pull/851)
   * When the GIL is held, the refcount is now decreased immediately on drop. (Previously would wait until just before releasing the GIL.)
   * When the GIL is not held, the refcount is now decreased when the GIL is next acquired. (Previously would wait until next time the GIL was released.)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,7 @@ mod internal_tricks;
 pub mod marshal;
 mod object;
 mod objectprotocol;
+pub mod panic;
 pub mod prelude;
 pub mod pycell;
 pub mod pyclass;

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,12 @@
+use crate::exceptions::BaseException;
+
+/// The exception raised when Rust code called from Python panics.
+///
+/// Like SystemExit, this exception is derived from BaseException so that
+/// it will typically propagate all the way through the stack and cause the
+/// Python interpreter to exit.
+pub struct PanicException {
+    _private: (),
+}
+
+pyo3_exception!(PanicException, BaseException);


### PR DESCRIPTION
Fixes #492 

This is a first attempt at updating all the wrapping code to use `catch_unwind` to prevent unsoundness of panics inside Rust callback functions.

I implemented this using a `pyo3::catch_unwind` macro, which takes a `Python` token and a body of code which should evaluate to a `PyResult`.

I ran into complications around lifetimes and the callback converters so I ended up simplifying a lot of the callback conversion code. I think a lot of those macros are now in slightly better shape but there's probably more refactoring that could be done.

Please give this a thorough review, I'm prepared to rework this as many times as needed to get it right.

TODO:
  - [X] Custom Exception type from BaseException
    - [ ] Mechanism for users to import this Exception (will do later after #805)
    - [x] Resume unwind when pyO3 gets this Exception in a PyErr
  - [ ] Panic section for the book