### PR TITLE
Bump version to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [0.9.1]
+
 ### Fixed
 
+* Error messages for `#[pyclass]`. [#826](https://github.com/PyO3/pyo3/pull/826)
 * `FromPyObject` implementation for `PySequence`. [#827](https://github.com/PyO3/pyo3/pull/827)
 
 ## [0.9.0]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.9.0"
+version = "0.9.1"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -27,7 +27,7 @@ num-complex = { version = "0.2", optional = true }
 num-traits = "0.2.8"
 parking_lot = { version = "0.10", features = ["nightly"] }
 paste = "0.1.6"
-pyo3cls = { path = "pyo3cls", version = "=0.9.0" }
+pyo3cls = { path = "pyo3cls", version = "=0.9.1" }
 unindent = "0.1.4"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.9.0"
+version = "0.9.1"
 features = ["extension-module"]
 ```
 
@@ -95,7 +95,7 @@ Add `pyo3` to your `Cargo.toml` like this:
 
 ```toml
 [dependencies]
-pyo3 = "0.9.0"
+pyo3 = "0.9.1"
 ```
 
 Example program displaying the value of `sys.version` and the current user name:

--- a/guide/src/get_started.md
+++ b/guide/src/get_started.md
@@ -44,7 +44,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.9.0"
+version = "0.9.1"
 features = ["extension-module"]
 ```
 
@@ -90,7 +90,7 @@ use it to run Python code, add `pyo3` to your `Cargo.toml` like this:
 
 ```toml
 [dependencies]
-pyo3 = "0.9.0"
+pyo3 = "0.9.1"
 ```
 
 Example program displaying the value of `sys.version` and the current user name:

--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-derive-backend"
-version = "0.9.0"
+version = "0.9.1"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -323,7 +323,7 @@ fn parse_method_attributes(
                 } else if name.is_ident("init") || name.is_ident("__init__") {
                     return Err(syn::Error::new_spanned(
                         name,
-                        "#[init] is disabled from PyO3 0.9.0",
+                        "#[init] is disabled since PyO3 0.9.0",
                     ));
                 } else if name.is_ident("call") || name.is_ident("__call__") {
                     res = Some(FnType::FnCall)
@@ -363,7 +363,7 @@ fn parse_method_attributes(
                 } else if path.is_ident("init") {
                     return Err(syn::Error::new_spanned(
                         path,
-                        "#[init] is disabled from PyO3 0.9.0",
+                        "#[init] is disabled since PyO3 0.9.0",
                     ));
                 } else if path.is_ident("call") {
                     res = Some(FnType::FnCall)

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3cls"
-version = "0.9.0"
+version = "0.9.1"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.9.0" }
+pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.9.1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies.pyo3]
-//! version = "0.9.0"
+//! version = "0.9.1"
 //! features = ["extension-module"]
 //! ```
 //!
@@ -109,7 +109,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pyo3 = "0.9.0"
+//! pyo3 = "0.9.1"
 //! ```
 //!
 //! Example program displaying the value of `sys.version`:


### PR DESCRIPTION
0.9.0 contains an unintended breaking change(`&PySequence` does not implement `FromPyObject`).
This version includes an immidiate fix #827 for that.