### PR TITLE
use struct.calcsize("P") rather than platform.machine()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         ]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/ci/actions/test.sh
+++ b/ci/actions/test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-cargo test --features "$FEATURES num-bigint num-complex"
+set -e -u -o pipefail
+
+cargo test --features "${FEATURES:-} num-bigint num-complex"
 (cd pyo3-derive-backend; cargo test)
 
 for example_dir in examples/*; do

--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -7,7 +7,6 @@ import pytest
 import rustapi_module.datetime as rdt
 from hypothesis import given, example
 from hypothesis import strategies as st
-from hypothesis.strategies import dates, datetimes
 
 
 # Constants
@@ -78,6 +77,11 @@ xfail_date_bounds = pytest.mark.xfail(
     reason="Date bounds were not checked in the C constructor prior to version 3.6",
 )
 
+xfail_macos_datetime_bounds = pytest.mark.xfail(
+    sys.version_info < (3, 6) and platform.system() == "Darwin",
+    reason="Unclearly failing. See https://github.com/PyO3/pyo3/pull/830 for more.",
+)
+
 
 # Tests
 def test_date():
@@ -98,6 +102,7 @@ def test_invalid_date_fails():
         rdt.make_date(2017, 2, 30)
 
 
+@xfail_macos_datetime_bounds
 @given(d=st.dates(MIN_DATETIME.date(), MAX_DATETIME.date()))
 def test_date_from_timestamp(d):
     if PYPY and d < pdt.date(1900, 1, 1):
@@ -237,6 +242,7 @@ def test_datetime_typeerror():
         rdt.make_datetime("2011", 1, 1, 0, 0, 0, 0)
 
 
+@xfail_macos_datetime_bounds
 @given(dt=st.datetimes(MIN_DATETIME, MAX_DATETIME))
 @example(dt=pdt.datetime(1970, 1, 2, 0, 0))
 def test_datetime_from_timestamp(dt):

--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -1,6 +1,7 @@
 import datetime as pdt
-import sys
 import platform
+import struct
+import sys
 
 import pytest
 import rustapi_module.datetime as rdt
@@ -40,16 +41,27 @@ MIN_DAYS = pdt.timedelta.min // pdt.timedelta(days=1)
 MAX_MICROSECONDS = int(pdt.timedelta.max.total_seconds() * 1e6)
 MIN_MICROSECONDS = int(pdt.timedelta.min.total_seconds() * 1e6)
 
-IS_X86 = platform.architecture()[0] == "32bit"
+# The reason we don't use platform.architecture() here is that it's not
+# reliable on macOS. See https://stackoverflow.com/a/1405971/823869. Similarly,
+# sys.maxsize is not reliable on Windows. See
+# https://stackoverflow.com/questions/1405913/how-do-i-determine-if-my-python-shell-is-executing-in-32bit-or-64bit-mode-on-os/1405971#comment6209952_1405971
+# and https://stackoverflow.com/a/3411134/823869.
+_pointer_size = struct.calcsize("P")
+if _pointer_size == 8:
+    IS_32_BIT = False
+elif _pointer_size == 4:
+    IS_32_BIT = True
+else:
+    raise RuntimeError("unexpected pointer size: " + repr(_pointer_size))
 IS_WINDOWS = sys.platform == "win32"
 if IS_WINDOWS:
     MIN_DATETIME = pdt.datetime(1970, 1, 2, 0, 0)
-    if IS_X86:
+    if IS_32_BIT:
         MAX_DATETIME = pdt.datetime(3001, 1, 19, 4, 59, 59)
     else:
         MAX_DATETIME = pdt.datetime(3001, 1, 19, 7, 59, 59)
 else:
-    if IS_X86:
+    if IS_32_BIT:
         # TS ±2147483648 (2**31)
         MIN_DATETIME = pdt.datetime(1901, 12, 13, 20, 45, 52)
         MAX_DATETIME = pdt.datetime(2038, 1, 19, 3, 14, 8)


### PR DESCRIPTION
platform.machine() gives the wrong answer if you're running 32-bit
Python on a 64-bit machine. ~sys.maxsize~ struct.calcsize("P") (EDITED based on https://github.com/PyO3/pyo3/pull/830#issuecomment-603906094) gives the answer we want. See
also https://stackoverflow.com/a/1405971/823869.

Also use CARGO_CFG_TARGET_POINTER_WIDTH rather than inferring the
pointer width from CARGO_CFG_TARGET_ARCH.