### PR TITLE
Change travis dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,7 @@ env:
 addons:
   apt:
     packages:
-      - libcurl4-openssl-dev
-      - libelf-dev
-      - libdw-dev
-      - cmake
-      - gcc
-      - binutils-dev
-      - libiberty-dev
+      - libgoogle-perftools-dev
 
 before_install:
   - source ./ci/travis/setup.sh


### PR DESCRIPTION
- To make the latest grcov binary work, we need libgoogle-perftools-dev. See https://github.com/mozilla/grcov/pull/402.
- I try to remove some unused dependencies.
