### PR TITLE
Reduce build dependencies from regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ assert_approx_eq = "1.1.0"
 trybuild = "1.0.23"
 
 [build-dependencies]
-regex = "1"
+regex = { version = "1", default_features = false, features = ["std"] }
 version_check = "0.9.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
This avoids users compiling four crates for the "perf" and
"unicode" features. regex is only used in build.rs to parse
some #define lines so it doesn't need to compile support for
thread-local caches etc or parsing by unicode code point.