### PR TITLE
Improve performance on pointer drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+* `PyObject` and `Py<T>` reference counts are now decremented sooner after `drop()`. [#851](https://github.com/PyO3/pyo3/pull/851)
+  * When the GIL is held, the refcount is now decreased immediately on drop. (Previously would wait until just before releasing the GIL.)
+  * When the GIL is not held, the refcount is now decreased when the GIL is next acquired. (Previously would wait until next time the GIL was released.)
+
 ### Added
 
 * `FromPyObject` implementations for `HashSet` and `BTreeSet`. [#842](https://github.com/PyO3/pyo3/pull/842)

--- a/benches/bench_pyobject.rs
+++ b/benches/bench_pyobject.rs
@@ -1,0 +1,16 @@
+#![feature(test)]
+
+extern crate test;
+use pyo3::prelude::*;
+use test::Bencher;
+
+#[bench]
+fn drop_many_objects(b: &mut Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    b.iter(|| {
+        for _ in 0..1000 {
+            std::mem::drop(py.None());
+        }
+    });
+}

--- a/src/ffi/pystate.rs
+++ b/src/ffi/pystate.rs
@@ -65,6 +65,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyGILState_Release")]
     pub fn PyGILState_Release(arg1: PyGILState_STATE);
     pub fn PyGILState_GetThisThreadState() -> *mut PyThreadState;
+    pub fn PyGILState_Check() -> c_int;
 }
 
 #[inline]

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -433,7 +433,7 @@ impl<T: PyClass + fmt::Debug> fmt::Debug for PyCell<T> {
 /// # let gil = Python::acquire_gil();
 /// # let py = gil.python();
 /// # let sub = PyCell::new(py, Child::new()).unwrap();
-/// # pyo3::py_run!(py, sub, "assert sub.format() == 'Caterpillar(base: Butterfly, cnt: 4)'");
+/// # pyo3::py_run!(py, sub, "assert sub.format() == 'Caterpillar(base: Butterfly, cnt: 3)'");
 /// ```
 pub struct PyRef<'p, T: PyClass> {
     inner: &'p PyCellInner<T>,


### PR DESCRIPTION
There's a `Mutex` involved each time we drop a `PyObject` or `Py<T>`, so that we can safely push the reference into the shared `Vec`. I have been wondering for a while if we could add a simple check if the GIL is held (as a `thread_local!` variable) and if so, decrease the refcount immediately.

I tried this out - turns out in the simple benchmark I made (`bench_object`) that adding this check makes the benchmark 5x faster.

I think decreasing the reference count sooner is also more predictable from a pyo3 user perspective. It helps with some of the issues around #311. (Though this doesn't improve the situation for references.)

If the GIL is not held, then I made it so that the pointers will be released as soon as the GIL is next acquired.

To track when the GIL is held I have added counters to `GILGuard::new()` and `GILGuard:drop()`.

For this optimization to apply all the time we also need to increment / decrement this counter when we call `assume_gil_acquired()` - which suggests to me that we should wait to finish this off once #800 is solved.

TODO:
 - [x] ~~Also increment / decrement GIL_COUNT when we call `assume_gil_acquired()`~~ (solved by also using `GILPool` for the counter)