### PR TITLE
Fix clippy complaint of empty return type

### DIFF
--- a/src/ffi/bytesobject.rs
+++ b/src/ffi/bytesobject.rs
@@ -37,9 +37,9 @@ extern "C" {
     pub fn PyBytes_AsString(arg1: *mut PyObject) -> *mut c_char;
     pub fn PyBytes_Repr(arg1: *mut PyObject, arg2: c_int) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyBytes_Concat")]
-    pub fn PyBytes_Concat(arg1: *mut *mut PyObject, arg2: *mut PyObject) -> ();
+    pub fn PyBytes_Concat(arg1: *mut *mut PyObject, arg2: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPyBytes_ConcatAndDel")]
-    pub fn PyBytes_ConcatAndDel(arg1: *mut *mut PyObject, arg2: *mut PyObject) -> ();
+    pub fn PyBytes_ConcatAndDel(arg1: *mut *mut PyObject, arg2: *mut PyObject);
     pub fn PyBytes_DecodeEscape(
         arg1: *const c_char,
         arg2: Py_ssize_t,

--- a/src/ffi/ceval.rs
+++ b/src/ffi/ceval.rs
@@ -45,7 +45,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPy_MakePendingCalls")]
     pub fn Py_MakePendingCalls() -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPy_SetRecursionLimit")]
-    pub fn Py_SetRecursionLimit(arg1: c_int) -> ();
+    pub fn Py_SetRecursionLimit(arg1: c_int);
     #[cfg_attr(PyPy, link_name = "PyPy_GetRecursionLimit")]
     pub fn Py_GetRecursionLimit() -> c_int;
     fn _Py_CheckRecursiveCall(_where: *mut c_char) -> c_int;
@@ -74,7 +74,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyEval_SaveThread")]
     pub fn PyEval_SaveThread() -> *mut PyThreadState;
     #[cfg_attr(PyPy, link_name = "PyPyEval_RestoreThread")]
-    pub fn PyEval_RestoreThread(arg1: *mut PyThreadState) -> ();
+    pub fn PyEval_RestoreThread(arg1: *mut PyThreadState);
 }
 
 #[cfg(py_sys_config = "WITH_THREAD")]
@@ -83,13 +83,13 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyEval_ThreadsInitialized")]
     pub fn PyEval_ThreadsInitialized() -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyEval_InitThreads")]
-    pub fn PyEval_InitThreads() -> ();
-    pub fn PyEval_AcquireLock() -> ();
-    pub fn PyEval_ReleaseLock() -> ();
+    pub fn PyEval_InitThreads();
+    pub fn PyEval_AcquireLock();
+    pub fn PyEval_ReleaseLock();
     #[cfg_attr(PyPy, link_name = "PyPyEval_AcquireThread")]
-    pub fn PyEval_AcquireThread(tstate: *mut PyThreadState) -> ();
+    pub fn PyEval_AcquireThread(tstate: *mut PyThreadState);
     #[cfg_attr(PyPy, link_name = "PyPyEval_ReleaseThread")]
-    pub fn PyEval_ReleaseThread(tstate: *mut PyThreadState) -> ();
+    pub fn PyEval_ReleaseThread(tstate: *mut PyThreadState);
     #[cfg(not(Py_3_8))]
-    pub fn PyEval_ReInitThreads() -> ();
+    pub fn PyEval_ReInitThreads();
 }

--- a/src/ffi/dictobject.rs
+++ b/src/ffi/dictobject.rs
@@ -84,7 +84,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyDict_DelItem")]
     pub fn PyDict_DelItem(mp: *mut PyObject, key: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyDict_Clear")]
-    pub fn PyDict_Clear(mp: *mut PyObject) -> ();
+    pub fn PyDict_Clear(mp: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPyDict_Next")]
     pub fn PyDict_Next(
         mp: *mut PyObject,

--- a/src/ffi/frameobject.rs
+++ b/src/ffi/frameobject.rs
@@ -65,17 +65,12 @@ extern "C" {
         locals: *mut PyObject,
     ) -> *mut PyFrameObject;
 
-    pub fn PyFrame_BlockSetup(
-        f: *mut PyFrameObject,
-        _type: c_int,
-        handler: c_int,
-        level: c_int,
-    ) -> ();
+    pub fn PyFrame_BlockSetup(f: *mut PyFrameObject, _type: c_int, handler: c_int, level: c_int);
     pub fn PyFrame_BlockPop(f: *mut PyFrameObject) -> *mut PyTryBlock;
 
-    pub fn PyFrame_LocalsToFast(f: *mut PyFrameObject, clear: c_int) -> ();
+    pub fn PyFrame_LocalsToFast(f: *mut PyFrameObject, clear: c_int);
     pub fn PyFrame_FastToLocalsWithError(f: *mut PyFrameObject) -> c_int;
-    pub fn PyFrame_FastToLocals(f: *mut PyFrameObject) -> ();
+    pub fn PyFrame_FastToLocals(f: *mut PyFrameObject);
 
     pub fn PyFrame_ClearFreeList() -> c_int;
     pub fn PyFrame_GetLineNumber(f: *mut PyFrameObject) -> c_int;

--- a/src/ffi/import.rs
+++ b/src/ffi/import.rs
@@ -68,7 +68,7 @@ extern "C" {
     pub fn PyImport_Import(name: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyImport_ReloadModule")]
     pub fn PyImport_ReloadModule(m: *mut PyObject) -> *mut PyObject;
-    pub fn PyImport_Cleanup() -> ();
+    pub fn PyImport_Cleanup();
     pub fn PyImport_ImportFrozenModuleObject(name: *mut PyObject) -> c_int;
     pub fn PyImport_ImportFrozenModule(name: *const c_char) -> c_int;
 

--- a/src/ffi/intrcheck.rs
+++ b/src/ffi/intrcheck.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_int;
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyOS_InterruptOccurred")]
     pub fn PyOS_InterruptOccurred() -> c_int;
-    pub fn PyOS_InitInterrupts() -> ();
+    pub fn PyOS_InitInterrupts();
     #[cfg_attr(PyPy, link_name = "PyPyOS_AfterFork")]
-    pub fn PyOS_AfterFork() -> ();
+    pub fn PyOS_AfterFork();
 }

--- a/src/ffi/object.rs
+++ b/src/ffi/object.rs
@@ -165,7 +165,7 @@ mod bufferinfo {
         arg3: c_int,
     ) -> c_int;
     pub type releasebufferproc =
-        unsafe extern "C" fn(arg1: *mut crate::ffi::PyObject, arg2: *mut Py_buffer) -> ();
+        unsafe extern "C" fn(arg1: *mut crate::ffi::PyObject, arg2: *mut Py_buffer);
 
     /// Maximum number of dimensions
     pub const PyBUF_MAX_NDIM: c_int = 64;
@@ -829,9 +829,9 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyCallable_Check")]
     pub fn PyCallable_Check(arg1: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyObject_ClearWeakRefs")]
-    pub fn PyObject_ClearWeakRefs(arg1: *mut PyObject) -> ();
+    pub fn PyObject_ClearWeakRefs(arg1: *mut PyObject);
     #[cfg(not(Py_LIMITED_API))]
-    pub fn PyObject_CallFinalizer(arg1: *mut PyObject) -> ();
+    pub fn PyObject_CallFinalizer(arg1: *mut PyObject);
     #[cfg(not(Py_LIMITED_API))]
     #[cfg_attr(PyPy, link_name = "PyPyObject_CallFinalizerFromDealloc")]
     pub fn PyObject_CallFinalizerFromDealloc(arg1: *mut PyObject) -> c_int;
@@ -839,7 +839,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyObject_Dir")]
     pub fn PyObject_Dir(arg1: *mut PyObject) -> *mut PyObject;
     pub fn Py_ReprEnter(arg1: *mut PyObject) -> c_int;
-    pub fn Py_ReprLeave(arg1: *mut PyObject) -> ();
+    pub fn Py_ReprLeave(arg1: *mut PyObject);
 }
 
 // Flag bits for printing:
@@ -908,7 +908,7 @@ pub unsafe fn PyType_FastSubclass(t: *mut PyTypeObject, f: c_ulong) -> c_int {
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "_PyPy_Dealloc")]
-    pub fn _Py_Dealloc(arg1: *mut PyObject) -> ();
+    pub fn _Py_Dealloc(arg1: *mut PyObject);
 }
 
 // Reference counting macros.

--- a/src/ffi/objectabstract.rs
+++ b/src/ffi/objectabstract.rs
@@ -132,7 +132,7 @@ extern "C" {
         strides: *mut Py_ssize_t,
         itemsize: c_int,
         fort: c_char,
-    ) -> ();
+    );
     #[cfg_attr(PyPy, link_name = "PyPyBuffer_FillInfo")]
     pub fn PyBuffer_FillInfo(
         view: *mut Py_buffer,
@@ -143,7 +143,7 @@ extern "C" {
         flags: c_int,
     ) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyBuffer_Release")]
-    pub fn PyBuffer_Release(view: *mut Py_buffer) -> ();
+    pub fn PyBuffer_Release(view: *mut Py_buffer);
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/src/ffi/objimpl.rs
+++ b/src/ffi/objimpl.rs
@@ -11,7 +11,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyObject_Realloc")]
     pub fn PyObject_Realloc(ptr: *mut c_void, new_size: size_t) -> *mut c_void;
     #[cfg_attr(PyPy, link_name = "PyPyObject_Free")]
-    pub fn PyObject_Free(ptr: *mut c_void) -> ();
+    pub fn PyObject_Free(ptr: *mut c_void);
 
     #[cfg(not(Py_LIMITED_API))]
     pub fn _Py_GetAllocatedBlocks() -> Py_ssize_t;
@@ -37,7 +37,7 @@ extern "C" {
 pub struct PyObjectArenaAllocator {
     pub ctx: *mut c_void,
     pub alloc: Option<extern "C" fn(ctx: *mut c_void, size: size_t) -> *mut c_void>,
-    pub free: Option<extern "C" fn(ctx: *mut c_void, ptr: *mut c_void, size: size_t) -> ()>,
+    pub free: Option<extern "C" fn(ctx: *mut c_void, ptr: *mut c_void, size: size_t)>,
 }
 
 #[cfg(not(Py_LIMITED_API))]
@@ -50,8 +50,8 @@ impl Default for PyObjectArenaAllocator {
 #[cfg(not(Py_LIMITED_API))]
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
-    pub fn PyObject_GetArenaAllocator(allocator: *mut PyObjectArenaAllocator) -> ();
-    pub fn PyObject_SetArenaAllocator(allocator: *mut PyObjectArenaAllocator) -> ();
+    pub fn PyObject_GetArenaAllocator(allocator: *mut PyObjectArenaAllocator);
+    pub fn PyObject_SetArenaAllocator(allocator: *mut PyObjectArenaAllocator);
 }
 
 /// Test if a type has a GC head
@@ -84,10 +84,10 @@ extern "C" {
     pub fn _PyObject_GC_New(arg1: *mut PyTypeObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "_PyPyObject_GC_NewVar")]
     pub fn _PyObject_GC_NewVar(arg1: *mut PyTypeObject, arg2: Py_ssize_t) -> *mut PyVarObject;
-    pub fn PyObject_GC_Track(arg1: *mut c_void) -> ();
-    pub fn PyObject_GC_UnTrack(arg1: *mut c_void) -> ();
+    pub fn PyObject_GC_Track(arg1: *mut c_void);
+    pub fn PyObject_GC_UnTrack(arg1: *mut c_void);
     #[cfg_attr(PyPy, link_name = "PyPyObject_GC_Del")]
-    pub fn PyObject_GC_Del(arg1: *mut c_void) -> ();
+    pub fn PyObject_GC_Del(arg1: *mut c_void);
 }
 
 /// Test if a type supports weak references

--- a/src/ffi/pyerrors.rs
+++ b/src/ffi/pyerrors.rs
@@ -9,31 +9,31 @@ use std::os::raw::{c_char, c_int};
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyErr_SetNone")]
-    pub fn PyErr_SetNone(arg1: *mut PyObject) -> ();
+    pub fn PyErr_SetNone(arg1: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPyErr_SetObject")]
-    pub fn PyErr_SetObject(arg1: *mut PyObject, arg2: *mut PyObject) -> ();
+    pub fn PyErr_SetObject(arg1: *mut PyObject, arg2: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPyErr_SetString")]
-    pub fn PyErr_SetString(exception: *mut PyObject, string: *const c_char) -> ();
+    pub fn PyErr_SetString(exception: *mut PyObject, string: *const c_char);
     #[cfg_attr(PyPy, link_name = "PyPyErr_Occurred")]
     pub fn PyErr_Occurred() -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyErr_Clear")]
-    pub fn PyErr_Clear() -> ();
+    pub fn PyErr_Clear();
     #[cfg_attr(PyPy, link_name = "PyPyErr_Fetch")]
     pub fn PyErr_Fetch(
         arg1: *mut *mut PyObject,
         arg2: *mut *mut PyObject,
         arg3: *mut *mut PyObject,
-    ) -> ();
+    );
     #[cfg_attr(PyPy, link_name = "PyPyErr_Restore")]
-    pub fn PyErr_Restore(arg1: *mut PyObject, arg2: *mut PyObject, arg3: *mut PyObject) -> ();
+    pub fn PyErr_Restore(arg1: *mut PyObject, arg2: *mut PyObject, arg3: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPyErr_GetExcInfo")]
     pub fn PyErr_GetExcInfo(
         arg1: *mut *mut PyObject,
         arg2: *mut *mut PyObject,
         arg3: *mut *mut PyObject,
-    ) -> ();
+    );
     #[cfg_attr(PyPy, link_name = "PyPyErr_SetExcInfo")]
-    pub fn PyErr_SetExcInfo(arg1: *mut PyObject, arg2: *mut PyObject, arg3: *mut PyObject) -> ();
+    pub fn PyErr_SetExcInfo(arg1: *mut PyObject, arg2: *mut PyObject, arg3: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPy_FatalError")]
     pub fn Py_FatalError(message: *const c_char) -> !;
     #[cfg_attr(PyPy, link_name = "PyPyErr_GivenExceptionMatches")]
@@ -45,7 +45,7 @@ extern "C" {
         arg1: *mut *mut PyObject,
         arg2: *mut *mut PyObject,
         arg3: *mut *mut PyObject,
-    ) -> ();
+    );
     #[cfg_attr(PyPy, link_name = "PyPyException_SetTraceback")]
     pub fn PyException_SetTraceback(arg1: *mut PyObject, arg2: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyException_GetTraceback")]
@@ -53,11 +53,11 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyException_GetCause")]
     pub fn PyException_GetCause(arg1: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyException_SetCause")]
-    pub fn PyException_SetCause(arg1: *mut PyObject, arg2: *mut PyObject) -> ();
+    pub fn PyException_SetCause(arg1: *mut PyObject, arg2: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPyException_GetContext")]
     pub fn PyException_GetContext(arg1: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyException_SetContext")]
-    pub fn PyException_SetContext(arg1: *mut PyObject, arg2: *mut PyObject) -> ();
+    pub fn PyException_SetContext(arg1: *mut PyObject, arg2: *mut PyObject);
 }
 
 #[inline]
@@ -277,8 +277,8 @@ extern "C" {
         arg3: *mut PyObject,
     ) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyErr_BadInternalCall")]
-    pub fn PyErr_BadInternalCall() -> ();
-    pub fn _PyErr_BadInternalCall(filename: *const c_char, lineno: c_int) -> ();
+    pub fn PyErr_BadInternalCall();
+    pub fn _PyErr_BadInternalCall(filename: *const c_char, lineno: c_int);
     #[cfg_attr(PyPy, link_name = "PyPyErr_NewException")]
     pub fn PyErr_NewException(
         name: *const c_char,
@@ -293,13 +293,13 @@ extern "C" {
         dict: *mut PyObject,
     ) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyErr_WriteUnraisable")]
-    pub fn PyErr_WriteUnraisable(arg1: *mut PyObject) -> ();
+    pub fn PyErr_WriteUnraisable(arg1: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPyErr_CheckSignals")]
     pub fn PyErr_CheckSignals() -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyErr_SetInterrupt")]
-    pub fn PyErr_SetInterrupt() -> ();
-    pub fn PyErr_SyntaxLocation(filename: *const c_char, lineno: c_int) -> ();
-    pub fn PyErr_SyntaxLocationEx(filename: *const c_char, lineno: c_int, col_offset: c_int) -> ();
+    pub fn PyErr_SetInterrupt();
+    pub fn PyErr_SyntaxLocation(filename: *const c_char, lineno: c_int);
+    pub fn PyErr_SyntaxLocationEx(filename: *const c_char, lineno: c_int, col_offset: c_int);
     pub fn PyErr_ProgramText(filename: *const c_char, lineno: c_int) -> *mut PyObject;
     #[cfg(not(PyPy))]
     pub fn PyUnicodeDecodeError_Create(

--- a/src/ffi/pymem.rs
+++ b/src/ffi/pymem.rs
@@ -11,7 +11,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyMem_RawRealloc")]
     pub fn PyMem_RawRealloc(ptr: *mut c_void, new_size: size_t) -> *mut c_void;
     #[cfg_attr(PyPy, link_name = "PyPyMem_RawFree")]
-    pub fn PyMem_RawFree(ptr: *mut c_void) -> ();
+    pub fn PyMem_RawFree(ptr: *mut c_void);
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
@@ -23,7 +23,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyMem_Realloc")]
     pub fn PyMem_Realloc(ptr: *mut c_void, new_size: size_t) -> *mut c_void;
     #[cfg_attr(PyPy, link_name = "PyPyMem_Free")]
-    pub fn PyMem_Free(ptr: *mut c_void) -> ();
+    pub fn PyMem_Free(ptr: *mut c_void);
 }
 
 #[cfg(not(Py_LIMITED_API))]
@@ -45,15 +45,13 @@ pub struct PyMemAllocatorEx {
         Option<extern "C" fn(ctx: *mut c_void, nelem: size_t, elsize: size_t) -> *mut c_void>,
     pub realloc:
         Option<extern "C" fn(ctx: *mut c_void, ptr: *mut c_void, new_size: size_t) -> *mut c_void>,
-    pub free: Option<extern "C" fn(ctx: *mut c_void, ptr: *mut c_void) -> ()>,
+    pub free: Option<extern "C" fn(ctx: *mut c_void, ptr: *mut c_void)>,
 }
 
 #[cfg(not(Py_LIMITED_API))]
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
-    pub fn PyMem_GetAllocator(domain: PyMemAllocatorDomain, allocator: *mut PyMemAllocatorEx)
-        -> ();
-    pub fn PyMem_SetAllocator(domain: PyMemAllocatorDomain, allocator: *mut PyMemAllocatorEx)
-        -> ();
-    pub fn PyMem_SetupDebugHooks() -> ();
+    pub fn PyMem_GetAllocator(domain: PyMemAllocatorDomain, allocator: *mut PyMemAllocatorEx);
+    pub fn PyMem_SetAllocator(domain: PyMemAllocatorDomain, allocator: *mut PyMemAllocatorEx);
+    pub fn PyMem_SetupDebugHooks();
 }

--- a/src/ffi/pystate.rs
+++ b/src/ffi/pystate.rs
@@ -25,8 +25,8 @@ pub struct PyThreadState {
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyInterpreterState_New() -> *mut PyInterpreterState;
-    pub fn PyInterpreterState_Clear(arg1: *mut PyInterpreterState) -> ();
-    pub fn PyInterpreterState_Delete(arg1: *mut PyInterpreterState) -> ();
+    pub fn PyInterpreterState_Clear(arg1: *mut PyInterpreterState);
+    pub fn PyInterpreterState_Delete(arg1: *mut PyInterpreterState);
     //fn _PyState_AddModule(arg1: *mut PyObject,
     //                      arg2: *mut PyModuleDef) -> c_int;
     pub fn PyState_FindModule(arg1: *mut PyModuleDef) -> *mut PyObject;
@@ -34,14 +34,14 @@ extern "C" {
     pub fn PyThreadState_New(arg1: *mut PyInterpreterState) -> *mut PyThreadState;
     //fn _PyThreadState_Prealloc(arg1: *mut PyInterpreterState)
     // -> *mut PyThreadState;
-    //fn _PyThreadState_Init(arg1: *mut PyThreadState) -> ();
+    //fn _PyThreadState_Init(arg1: *mut PyThreadState);
     #[cfg_attr(PyPy, link_name = "PyPyThreadState_Clear")]
-    pub fn PyThreadState_Clear(arg1: *mut PyThreadState) -> ();
+    pub fn PyThreadState_Clear(arg1: *mut PyThreadState);
     #[cfg_attr(PyPy, link_name = "PyPyThreadState_Delete")]
-    pub fn PyThreadState_Delete(arg1: *mut PyThreadState) -> ();
+    pub fn PyThreadState_Delete(arg1: *mut PyThreadState);
     #[cfg(py_sys_config = "WITH_THREAD")]
     #[cfg_attr(PyPy, link_name = "PyPyThreadState_DeleteCurrent")]
-    pub fn PyThreadState_DeleteCurrent() -> ();
+    pub fn PyThreadState_DeleteCurrent();
     #[cfg_attr(PyPy, link_name = "PyPyThreadState_Get")]
     pub fn PyThreadState_Get() -> *mut PyThreadState;
     #[cfg_attr(PyPy, link_name = "PyPyThreadState_Swap")]
@@ -63,7 +63,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyGILState_Ensure")]
     pub fn PyGILState_Ensure() -> PyGILState_STATE;
     #[cfg_attr(PyPy, link_name = "PyPyGILState_Release")]
-    pub fn PyGILState_Release(arg1: PyGILState_STATE) -> ();
+    pub fn PyGILState_Release(arg1: PyGILState_STATE);
     pub fn PyGILState_GetThisThreadState() -> *mut PyThreadState;
 }
 

--- a/src/ffi/pythonrun.rs
+++ b/src/ffi/pythonrun.rs
@@ -11,18 +11,18 @@ use std::ptr;
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     // TODO: these moved to pylifecycle.h
-    pub fn Py_SetProgramName(arg1: *mut wchar_t) -> ();
+    pub fn Py_SetProgramName(arg1: *mut wchar_t);
     #[cfg_attr(PyPy, link_name = "PyPy_GetProgramName")]
     pub fn Py_GetProgramName() -> *mut wchar_t;
-    pub fn Py_SetPythonHome(arg1: *mut wchar_t) -> ();
+    pub fn Py_SetPythonHome(arg1: *mut wchar_t);
     pub fn Py_GetPythonHome() -> *mut wchar_t;
-    pub fn Py_Initialize() -> ();
-    pub fn Py_InitializeEx(arg1: c_int) -> ();
-    pub fn Py_Finalize() -> ();
+    pub fn Py_Initialize();
+    pub fn Py_InitializeEx(arg1: c_int);
+    pub fn Py_Finalize();
     #[cfg_attr(PyPy, link_name = "PyPy_IsInitialized")]
     pub fn Py_IsInitialized() -> c_int;
     pub fn Py_NewInterpreter() -> *mut PyThreadState;
-    pub fn Py_EndInterpreter(arg1: *mut PyThreadState) -> ();
+    pub fn Py_EndInterpreter(arg1: *mut PyThreadState);
 }
 
 #[repr(C)]
@@ -220,22 +220,22 @@ extern "C" {
     ) -> *mut symtable;
 
     #[cfg_attr(PyPy, link_name = "PyPyErr_Print")]
-    pub fn PyErr_Print() -> ();
+    pub fn PyErr_Print();
     #[cfg_attr(PyPy, link_name = "PyPyErr_PrintEx")]
-    pub fn PyErr_PrintEx(arg1: c_int) -> ();
+    pub fn PyErr_PrintEx(arg1: c_int);
     #[cfg_attr(PyPy, link_name = "PyPyErr_Display")]
-    pub fn PyErr_Display(arg1: *mut PyObject, arg2: *mut PyObject, arg3: *mut PyObject) -> ();
+    pub fn PyErr_Display(arg1: *mut PyObject, arg2: *mut PyObject, arg3: *mut PyObject);
 
     // TODO: these moved to pylifecycle.h
     #[cfg_attr(PyPy, link_name = "PyPy_AtExit")]
-    pub fn Py_AtExit(func: Option<extern "C" fn() -> ()>) -> c_int;
-    pub fn Py_Exit(arg1: c_int) -> ();
+    pub fn Py_AtExit(func: Option<extern "C" fn()>) -> c_int;
+    pub fn Py_Exit(arg1: c_int);
     pub fn Py_Main(argc: c_int, argv: *mut *mut wchar_t) -> c_int;
     pub fn Py_GetProgramFullPath() -> *mut wchar_t;
     pub fn Py_GetPrefix() -> *mut wchar_t;
     pub fn Py_GetExecPrefix() -> *mut wchar_t;
     pub fn Py_GetPath() -> *mut wchar_t;
-    pub fn Py_SetPath(arg1: *const wchar_t) -> ();
+    pub fn Py_SetPath(arg1: *const wchar_t);
     #[cfg_attr(PyPy, link_name = "PyPy_GetVersion")]
     pub fn Py_GetVersion() -> *const c_char;
     pub fn Py_GetPlatform() -> *const c_char;

--- a/src/ffi/structseq.rs
+++ b/src/ffi/structseq.rs
@@ -22,10 +22,6 @@ pub struct PyStructSequence_Desc {
 extern "C" {
     pub fn PyStructSequence_NewType(desc: *mut PyStructSequence_Desc) -> *mut PyTypeObject;
     pub fn PyStructSequence_New(_type: *mut PyTypeObject) -> *mut PyObject;
-    pub fn PyStructSequence_SetItem(
-        arg1: *mut PyObject,
-        arg2: Py_ssize_t,
-        arg3: *mut PyObject,
-    ) -> ();
+    pub fn PyStructSequence_SetItem(arg1: *mut PyObject, arg2: Py_ssize_t, arg3: *mut PyObject);
     pub fn PyStructSequence_GetItem(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject;
 }

--- a/src/ffi/sysmodule.rs
+++ b/src/ffi/sysmodule.rs
@@ -10,19 +10,19 @@ extern "C" {
     pub fn PySys_GetObject(arg1: *const c_char) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPySys_SetObject")]
     pub fn PySys_SetObject(arg1: *const c_char, arg2: *mut PyObject) -> c_int;
-    pub fn PySys_SetArgv(arg1: c_int, arg2: *mut *mut wchar_t) -> ();
-    pub fn PySys_SetArgvEx(arg1: c_int, arg2: *mut *mut wchar_t, arg3: c_int) -> ();
-    pub fn PySys_SetPath(arg1: *const wchar_t) -> ();
+    pub fn PySys_SetArgv(arg1: c_int, arg2: *mut *mut wchar_t);
+    pub fn PySys_SetArgvEx(arg1: c_int, arg2: *mut *mut wchar_t, arg3: c_int);
+    pub fn PySys_SetPath(arg1: *const wchar_t);
     #[cfg_attr(PyPy, link_name = "PyPySys_WriteStdout")]
-    pub fn PySys_WriteStdout(format: *const c_char, ...) -> ();
+    pub fn PySys_WriteStdout(format: *const c_char, ...);
     #[cfg_attr(PyPy, link_name = "PyPySys_WriteStderr")]
-    pub fn PySys_WriteStderr(format: *const c_char, ...) -> ();
-    pub fn PySys_FormatStdout(format: *const c_char, ...) -> ();
-    pub fn PySys_FormatStderr(format: *const c_char, ...) -> ();
-    pub fn PySys_ResetWarnOptions() -> ();
-    pub fn PySys_AddWarnOption(arg1: *const wchar_t) -> ();
-    pub fn PySys_AddWarnOptionUnicode(arg1: *mut PyObject) -> ();
+    pub fn PySys_WriteStderr(format: *const c_char, ...);
+    pub fn PySys_FormatStdout(format: *const c_char, ...);
+    pub fn PySys_FormatStderr(format: *const c_char, ...);
+    pub fn PySys_ResetWarnOptions();
+    pub fn PySys_AddWarnOption(arg1: *const wchar_t);
+    pub fn PySys_AddWarnOptionUnicode(arg1: *mut PyObject);
     pub fn PySys_HasWarnOptions() -> c_int;
-    pub fn PySys_AddXOption(arg1: *const wchar_t) -> ();
+    pub fn PySys_AddXOption(arg1: *const wchar_t);
     pub fn PySys_GetXOptions() -> *mut PyObject;
 }

--- a/src/ffi/unicodeobject.rs
+++ b/src/ffi/unicodeobject.rs
@@ -116,8 +116,8 @@ extern "C" {
     //                             vargs: va_list) -> *mut PyObject;
     pub fn PyUnicode_FromFormat(format: *const c_char, ...) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_InternInPlace")]
-    pub fn PyUnicode_InternInPlace(arg1: *mut *mut PyObject) -> ();
-    pub fn PyUnicode_InternImmortal(arg1: *mut *mut PyObject) -> ();
+    pub fn PyUnicode_InternInPlace(arg1: *mut *mut PyObject);
+    pub fn PyUnicode_InternImmortal(arg1: *mut *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_InternFromString")]
     pub fn PyUnicode_InternFromString(u: *const c_char) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_FromWideChar")]
@@ -389,8 +389,8 @@ extern "C" {
     pub fn PyUnicode_EncodeFSDefault(unicode: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_Concat")]
     pub fn PyUnicode_Concat(left: *mut PyObject, right: *mut PyObject) -> *mut PyObject;
-    pub fn PyUnicode_Append(pleft: *mut *mut PyObject, right: *mut PyObject) -> ();
-    pub fn PyUnicode_AppendAndDel(pleft: *mut *mut PyObject, right: *mut PyObject) -> ();
+    pub fn PyUnicode_Append(pleft: *mut *mut PyObject, right: *mut PyObject);
+    pub fn PyUnicode_AppendAndDel(pleft: *mut *mut PyObject, right: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_Split")]
     pub fn PyUnicode_Split(
         s: *mut PyObject,

--- a/src/internal_tricks.rs
+++ b/src/internal_tricks.rs
@@ -12,7 +12,7 @@ macro_rules! private_decl {
         /// This trait is private to implement; this method exists to make it
         /// impossible to implement outside the crate.
         fn __private__(&self) -> crate::internal_tricks::PrivateMarker;
-    }
+    };
 }
 
 macro_rules! private_impl {
@@ -21,7 +21,7 @@ macro_rules! private_impl {
         fn __private__(&self) -> crate::internal_tricks::PrivateMarker {
             crate::internal_tricks::PrivateMarker
         }
-    }
+    };
 }
 
 macro_rules! pyo3_exception {


### PR DESCRIPTION
Clippy on recent nightly is telling me that the empty return type is not necessary. (` -> () `)