### PR TITLE
Fix potential panics caused by Garbage Collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 * `FromPyObject` implementations for `HashSet` and `BTreeSet`. [#842](https://github.com/PyO3/pyo3/pull/842)
 
+### Fixed
+- Garbage Collector causing random panics when traversing objects that were mutably borrowed. [#855](https://github.com/PyO3/pyo3/pull/855)
+
 ## [0.9.1]
 
 ### Fixed

--- a/src/class/gc.rs
+++ b/src/class/gc.rs
@@ -98,9 +98,14 @@ where
                 arg,
                 _py: py,
             };
-            match slf.borrow().__traverse__(visit) {
-                Ok(()) => 0,
-                Err(PyTraverseError(code)) => code,
+
+            if let Ok(borrow) = slf.try_borrow() {
+                match borrow.__traverse__(visit) {
+                    Ok(()) => 0,
+                    Err(PyTraverseError(code)) => code,
+                }
+            } else {
+                0
             }
         }
 

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -2,6 +2,7 @@ use pyo3::class::PyGCProtocol;
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
 use pyo3::prelude::*;
+use pyo3::type_object::PyTypeObject;
 use pyo3::{py_run, AsPyPointer, PyCell, PyTryInto};
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -244,4 +245,64 @@ fn inheritance_with_new_methods_with_drop() {
 
     assert!(drop_called1.load(Ordering::Relaxed));
     assert!(drop_called2.load(Ordering::Relaxed));
+}
+
+#[pyclass(gc)]
+struct TraversableClass {
+    traversed: AtomicBool,
+}
+
+impl TraversableClass {
+    fn new() -> Self {
+        Self {
+            traversed: AtomicBool::new(false),
+        }
+    }
+}
+
+#[pyproto]
+impl PyGCProtocol for TraversableClass {
+    fn __clear__(&mut self) {}
+    fn __traverse__(&self, _visit: PyVisit) -> Result<(), PyTraverseError> {
+        self.traversed.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[test]
+fn gc_during_borrow() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    unsafe {
+        // declare a dummy visitor function
+        extern "C" fn novisit(
+            object: *mut pyo3::ffi::PyObject,
+            arg: *mut core::ffi::c_void,
+        ) -> std::os::raw::c_int {
+            0
+        }
+
+        // get the traverse function
+        let ty = TraversableClass::type_object().as_ref(py).as_type_ptr();
+        let traverse = (*ty).tp_traverse.unwrap();
+
+        // create an object and check that traversing it works normally
+        // when it's not borrowed
+        let cell = PyCell::new(py, TraversableClass::new()).unwrap();
+        let obj = cell.to_object(py);
+        assert!(!cell.borrow().traversed.load(Ordering::Relaxed));
+        traverse(obj.as_ptr(), novisit, std::ptr::null_mut());
+        assert!(cell.borrow().traversed.load(Ordering::Relaxed));
+
+        // create an object and check that it is not traversed if the GC
+        // is invoked while it is already borrowed mutably
+        let cell2 = PyCell::new(py, TraversableClass::new()).unwrap();
+        let obj2 = cell2.to_object(py);
+        let guard = cell2.borrow_mut();
+        assert!(!guard.traversed.load(Ordering::Relaxed));
+        traverse(obj2.as_ptr(), novisit, std::ptr::null_mut());
+        assert!(!guard.traversed.load(Ordering::Relaxed));
+        drop(guard);
+    }
 }

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -277,8 +277,8 @@ fn gc_during_borrow() {
     unsafe {
         // declare a dummy visitor function
         extern "C" fn novisit(
-            object: *mut pyo3::ffi::PyObject,
-            arg: *mut core::ffi::c_void,
+            _object: *mut pyo3::ffi::PyObject,
+            _arg: *mut core::ffi::c_void,
         ) -> std::os::raw::c_int {
             0
         }


### PR DESCRIPTION
As discovered in #854, having a mutable borrow at any point on a `PyClass` that also implements the Garbage Collection protocol leads to unexpected panics, since the garbage collector can be run at any time, including when our class is already mutably borrowed.

As a solution, the wrapper for the garbage collector now calls `PyCell::try_borrow` instead of `PyCell::borrow`, and simply returns if it could not acquire the cell. I'm not sure about the expected behaviour here though, feedback is welcome.


## Maintenance 

 - Run `cargo fmt` :white_check_mark: 
 - Run `cargo clippy` and check there are no hard errors (There are a bunch of existing warnings; This is also checked by travis) :white_check_mark: 
 - If applicable, add an entry in the changelog. :white_check_mark: 
 - If applicable, add documentation to all new items and extend the guide. 
 - If applicable, add tests for all new or fixed functions :white_check_mark: 
 - If you changed any python code, run `black .`. You can install black with `pip install black`)

