### PR TITLE
Tighten down locking on datetime tests

### DIFF
--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -66,9 +66,9 @@ macro_rules! lock {
 
 #[test]
 fn test_date_check() {
+    lock!();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "date", "2018, 1, 1").unwrap();
 
     assert_check_exact!(PyDate_Check, obj);
@@ -78,9 +78,9 @@ fn test_date_check() {
 
 #[test]
 fn test_time_check() {
+    lock!();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "time", "12, 30, 15").unwrap();
 
     assert_check_exact!(PyTime_Check, obj);
@@ -90,9 +90,9 @@ fn test_time_check() {
 
 #[test]
 fn test_datetime_check() {
+    lock!();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "datetime", "2018, 1, 1, 13, 30, 15")
         .map_err(|e| e.print(py))
         .unwrap();
@@ -105,9 +105,9 @@ fn test_datetime_check() {
 
 #[test]
 fn test_delta_check() {
+    lock!();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "timedelta", "1, -3").unwrap();
 
     assert_check_exact!(PyDelta_Check, obj);
@@ -120,9 +120,9 @@ fn test_datetime_utc() {
     use assert_approx_eq::assert_approx_eq;
     use pyo3::types::PyDateTime;
 
+    lock!();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let datetime = py.import("datetime").map_err(|e| e.print(py)).unwrap();
     let timezone = datetime.get("timezone").unwrap();
     let utc = timezone.getattr("utc").unwrap().to_object(py);
@@ -161,6 +161,7 @@ static INVALID_TIMES: &[(u8, u8, u8, u32)] =
 fn test_pydate_out_of_bounds() {
     use pyo3::types::PyDate;
 
+    lock!();
     // This test is an XFAIL on Python < 3.6 until bounds checking is implemented
     let gil = Python::acquire_gil();
     let py = gil.python();
@@ -176,6 +177,7 @@ fn test_pydate_out_of_bounds() {
 fn test_pytime_out_of_bounds() {
     use pyo3::types::PyTime;
 
+    lock!();
     // This test is an XFAIL on Python < 3.6 until bounds checking is implemented
     let gil = Python::acquire_gil();
     let py = gil.python();
@@ -192,6 +194,7 @@ fn test_pydatetime_out_of_bounds() {
     use pyo3::types::PyDateTime;
     use std::iter;
 
+    lock!();
     // This test is an XFAIL on Python < 3.6 until bounds checking is implemented
     let gil = Python::acquire_gil();
     let py = gil.python();


### PR DESCRIPTION
After the datetime tests failed again on my machine, I realised that `lock!()` needs to go _before_ the `acquire_gil()` call - otherwise released objects can still go into the "wrong" GILPool.