### PR TITLE
Fix synchronization of datetime tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2.62"
 num-bigint = { version = "0.2", optional = true }
 num-complex = { version = "0.2", optional = true }
 num-traits = "0.2.8"
-parking_lot = { version = "0.10", features = ["nightly"] }
+parking_lot = { version = "0.10.2" }
 paste = "0.1.6"
 pyo3cls = { path = "pyo3cls", version = "=0.9.2" }
 unindent = "0.1.4"

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -1,5 +1,6 @@
 #![feature(concat_idents)]
 
+use parking_lot::{lock_api::RawMutex as _RawMutex, RawMutex};
 use pyo3::ffi::*;
 use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
@@ -56,19 +57,14 @@ macro_rules! assert_check_only {
 
 // Because of the relase pool unsoundness reported in https://github.com/PyO3/pyo3/issues/756,
 // we need to stop other threads before calling `py.import()`.
-// TODO(kngwyu): Remove this macro
-macro_rules! lock {
-    () => {
-        let _mutex = std::sync::Mutex::new(());
-        let _lock = _mutex.lock().unwrap();
-    };
-}
+// TODO(kngwyu): Remove this variable
+static MUTEX: RawMutex = RawMutex::INIT;
 
 #[test]
 fn test_date_check() {
+    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "date", "2018, 1, 1").unwrap();
 
     assert_check_exact!(PyDate_Check, obj);
@@ -78,9 +74,9 @@ fn test_date_check() {
 
 #[test]
 fn test_time_check() {
+    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "time", "12, 30, 15").unwrap();
 
     assert_check_exact!(PyTime_Check, obj);
@@ -90,9 +86,9 @@ fn test_time_check() {
 
 #[test]
 fn test_datetime_check() {
+    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "datetime", "2018, 1, 1, 13, 30, 15")
         .map_err(|e| e.print(py))
         .unwrap();
@@ -105,9 +101,9 @@ fn test_datetime_check() {
 
 #[test]
 fn test_delta_check() {
+    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "timedelta", "1, -3").unwrap();
 
     assert_check_exact!(PyDelta_Check, obj);
@@ -120,9 +116,9 @@ fn test_datetime_utc() {
     use assert_approx_eq::assert_approx_eq;
     use pyo3::types::PyDateTime;
 
+    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
-    lock!();
     let datetime = py.import("datetime").map_err(|e| e.print(py)).unwrap();
     let timezone = datetime.get("timezone").unwrap();
     let utc = timezone.getattr("utc").unwrap().to_object(py);

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -1,6 +1,5 @@
 #![feature(concat_idents)]
 
-use parking_lot::{lock_api::RawMutex as _RawMutex, RawMutex};
 use pyo3::ffi::*;
 use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
@@ -58,7 +57,7 @@ macro_rules! assert_check_only {
 // Because of the relase pool unsoundness reported in https://github.com/PyO3/pyo3/issues/756,
 // we need to stop other threads before calling `py.import()`.
 // TODO(kngwyu): Remove this variable
-static MUTEX: RawMutex = RawMutex::INIT;
+static MUTEX: parking_lot::Mutex<()> = parking_lot::const_mutex(());
 
 #[test]
 fn test_date_check() {


### PR DESCRIPTION
As reported by @programmerjake  by [this comment](https://github.com/PyO3/pyo3/pull/866#issuecomment-612257127), the `lock!` macro used in the datetime tests doesn't work.
This PR
- Fixes the synchronization
and
- Remove `nighly` feature from parking_lot

@davidhewitt 
I'm sorry that this PR conflicts with #866. I wanted to fix my fault myself.
