### PR TITLE
Allow use of `#[pyo3(get, set)]` with `Py<T>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `PyObject` and `Py<T>` reference counts are now decremented sooner after `drop()`. [#851](https://github.com/PyO3/pyo3/pull/851)
   * When the GIL is held, the refcount is now decreased immediately on drop. (Previously would wait until just before releasing the GIL.)
   * When the GIL is not held, the refcount is now decreased when the GIL is next acquired. (Previously would wait until next time the GIL was released.)
+* `FromPyObject` for `Py<T>` now works for a wider range of `T`, in particular for `T: PyClass`. [#880](https://github.com/PyO3/pyo3/pull/880)
 
 ### Added
 * `_PyDict_NewPresized`. [#849](https://github.com/PyO3/pyo3/pull/849)
@@ -21,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * `__radd__` and other `__r*__` methods now correctly work with operators. [#839](https://github.com/PyO3/pyo3/pull/839)
 * Garbage Collector causing random panics when traversing objects that were mutably borrowed. [#855](https://github.com/PyO3/pyo3/pull/855)
 * `&'static Py~` being allowed as arguments. [#869](https://github.com/PyO3/pyo3/pull/869)
+* `#[pyo3(get)]` for `Py<T>`. [#880](https://github.com/PyO3/pyo3/pull/880)
+
 
 ## [0.9.2]
 

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -10,7 +10,7 @@ use crate::instance::PyNativeType;
 use crate::pyclass::PyClass;
 use crate::pyclass_init::PyClassInitializer;
 use crate::types::{PyAny, PyDict, PyModule, PyTuple};
-use crate::{ffi, GILPool, IntoPy, PyCell, PyObject, Python};
+use crate::{ffi, GILPool, IntoPy, Py, PyCell, PyObject, Python};
 use std::cell::UnsafeCell;
 
 /// Description of a python parameter; used for `parse_args()`.
@@ -212,6 +212,12 @@ where
 impl GetPropertyValue for PyObject {
     fn get_property_value(&self, py: Python) -> PyObject {
         self.clone_ref(py)
+    }
+}
+
+impl<T> GetPropertyValue for Py<T> {
+    fn get_property_value(&self, py: Python) -> PyObject {
+        self.clone_ref(py).into()
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -295,13 +295,14 @@ where
 
 impl<'a, T> FromPyObject<'a> for Py<T>
 where
-    T: AsPyPointer,
-    &'a T: 'a + FromPyObject<'a>,
+    T: PyTypeInfo,
+    &'a T::AsRefTarget: FromPyObject<'a>,
+    T::AsRefTarget: 'a + AsPyPointer,
 {
     /// Extracts `Self` from the source `PyObject`.
     fn extract(ob: &'a PyAny) -> PyResult<Self> {
         unsafe {
-            ob.extract::<&T>()
+            ob.extract::<&T::AsRefTarget>()
                 .map(|val| Py::from_borrowed_ptr(val.as_ptr()))
         }
     }


### PR DESCRIPTION
Noticed support for this was missing after writing some comments for #877 .