### PR TITLE
New Native Types and Lighter GILPool

### DIFF
--- a/guide/src/rust_cpython.md
+++ b/guide/src/rust_cpython.md
@@ -47,7 +47,8 @@ impl MyClass {
 
 ## Ownership and lifetimes
 
-All objects are owned by the PyO3 library and all APIs available with references, while in rust-cpython, you own python objects.
+While in rust-cpython you always own python objects, PyO3 allows efficient *borrowed objects*
+and most APIs are available with references.
 
 Here is an example of the PyList API:
 
@@ -73,7 +74,8 @@ impl PyList {
 }
 ```
 
-Because PyO3 allows only references to Python objects, all references have the GIL lifetime. So the owned Python object is not required, and it is safe to have functions like `fn py<'p>(&'p self) -> Python<'p> {}`.
+In PyO3, all object references are bounded by the GIL lifetime.
+So the owned Python object is not required, and it is safe to have functions like `fn py<'p>(&'p self) -> Python<'p> {}`.
 
 ## Error handling
 

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -3,7 +3,8 @@
 //! Interaction with python's global interpreter lock
 
 use crate::{ffi, internal_tricks::Unsendable, Python};
-use std::cell::{Cell, UnsafeCell};
+use parking_lot::Mutex;
+use std::cell::{Cell, RefCell, UnsafeCell};
 use std::{any, mem::ManuallyDrop, ptr::NonNull, sync};
 
 static START: sync::Once = sync::Once::new();
@@ -16,6 +17,13 @@ thread_local! {
     ///
     /// As a result, if this thread has the GIL, GIL_COUNT is greater than zero.
     static GIL_COUNT: Cell<u32> = Cell::new(0);
+
+    /// These are objects owned by the current thread, to be released when the GILPool drops.
+    static OWNED_OBJECTS: RefCell<Vec<NonNull<ffi::PyObject>>> = RefCell::new(Vec::with_capacity(256));
+
+    /// These are non-python objects such as (String) owned by the current thread, to be released
+    /// when the GILPool drops.
+    static OWNED_ANYS: RefCell<Vec<Box<dyn any::Any>>> = RefCell::new(Vec::with_capacity(256));
 }
 
 /// Check whether the GIL is acquired.
@@ -136,85 +144,75 @@ impl GILGuard {
 impl Drop for GILGuard {
     fn drop(&mut self) {
         unsafe {
+            // Must drop the objects in the pool before releasing the GILGuard
             ManuallyDrop::drop(&mut self.pool);
             ffi::PyGILState_Release(self.gstate);
         }
     }
 }
 
-/// Implementation of release pool
-struct ReleasePoolImpl {
-    owned: Vec<NonNull<ffi::PyObject>>,
-    pointers: *mut Vec<NonNull<ffi::PyObject>>,
-    obj: Vec<Box<dyn any::Any>>,
-    p: parking_lot::Mutex<*mut Vec<NonNull<ffi::PyObject>>>,
-}
-
-impl ReleasePoolImpl {
-    fn new() -> Self {
-        Self {
-            owned: Vec::with_capacity(256),
-            pointers: Box::into_raw(Box::new(Vec::with_capacity(256))),
-            obj: Vec::with_capacity(8),
-            p: parking_lot::Mutex::new(Box::into_raw(Box::new(Vec::with_capacity(256)))),
-        }
-    }
-
-    unsafe fn release_pointers(&mut self) {
-        let mut v = self.p.lock();
-        let vec = &mut **v;
-        if vec.is_empty() {
-            return;
-        }
-
-        // switch vectors
-        std::mem::swap(&mut self.pointers, &mut *v);
-        drop(v);
-
-        // release PyObjects
-        for ptr in vec.iter_mut() {
-            ffi::Py_DECREF(ptr.as_ptr());
-        }
-        vec.set_len(0);
-    }
-
-    pub unsafe fn drain(&mut self, _py: Python, owned: usize) {
-        // Release owned objects(call decref)
-        for i in owned..self.owned.len() {
-            ffi::Py_DECREF(self.owned[i].as_ptr());
-        }
-        self.owned.truncate(owned);
-        self.release_pointers();
-        self.obj.clear();
-    }
-}
-
-/// Sync wrapper of ReleasePoolImpl
+/// Thread-safe storage for objects which were dropped while the GIL was not held.
 struct ReleasePool {
-    value: UnsafeCell<Option<ReleasePoolImpl>>,
+    pointers_to_drop: Mutex<*mut Vec<NonNull<ffi::PyObject>>>,
+    pointers_being_dropped: UnsafeCell<*mut Vec<NonNull<ffi::PyObject>>>,
 }
 
 impl ReleasePool {
     const fn new() -> Self {
         Self {
-            value: UnsafeCell::new(None),
+            pointers_to_drop: parking_lot::const_mutex(std::ptr::null_mut()),
+            pointers_being_dropped: UnsafeCell::new(std::ptr::null_mut()),
         }
     }
-    /// # Safety
-    /// This function is not thread safe. Thus, the caller has to have GIL.
-    #[allow(clippy::mut_from_ref)]
-    unsafe fn get_or_init(&self) -> &mut ReleasePoolImpl {
-        (*self.value.get()).get_or_insert_with(ReleasePoolImpl::new)
+
+    fn register_pointer(&self, obj: NonNull<ffi::PyObject>) {
+        let mut storage = self.pointers_to_drop.lock();
+        if storage.is_null() {
+            *storage = Box::into_raw(Box::new(Vec::with_capacity(256)))
+        }
+        unsafe {
+            (**storage).push(obj);
+        }
+    }
+
+    fn release_pointers(&self, _py: Python) {
+        let mut v = self.pointers_to_drop.lock();
+
+        if v.is_null() {
+            // No pointers have been registered
+            return;
+        }
+
+        unsafe {
+            // Function is safe to call because GIL is held, so only one thread can be inside this
+            // block at a time
+
+            let vec = &mut **v;
+            if vec.is_empty() {
+                return;
+            }
+
+            // switch vectors
+            std::mem::swap(&mut *self.pointers_being_dropped.get(), &mut *v);
+            drop(v);
+
+            // release PyObjects
+            for ptr in vec.iter_mut() {
+                ffi::Py_DECREF(ptr.as_ptr());
+            }
+            vec.set_len(0);
+        }
     }
 }
 
-static POOL: ReleasePool = ReleasePool::new();
-
 unsafe impl Sync for ReleasePool {}
+
+static POOL: ReleasePool = ReleasePool::new();
 
 #[doc(hidden)]
 pub struct GILPool {
-    owned: usize,
+    owned_objects_start: usize,
+    owned_anys_start: usize,
     // Stable solution for impl !Send
     no_send: Unsendable,
 }
@@ -226,10 +224,10 @@ impl GILPool {
     pub unsafe fn new() -> GILPool {
         increment_gil_count();
         // Release objects that were dropped since last GIL acquisition
-        let pool = POOL.get_or_init();
-        pool.release_pointers();
+        POOL.release_pointers(Python::assume_gil_acquired());
         GILPool {
-            owned: pool.owned.len(),
+            owned_objects_start: OWNED_OBJECTS.with(|o| o.borrow().len()),
+            owned_anys_start: OWNED_ANYS.with(|o| o.borrow().len()),
             no_send: Unsendable::default(),
         }
     }
@@ -241,37 +239,68 @@ impl GILPool {
 impl Drop for GILPool {
     fn drop(&mut self) {
         unsafe {
-            let pool = POOL.get_or_init();
-            pool.drain(self.python(), self.owned);
+            OWNED_OBJECTS.with(|owned_objects| {
+                // Note: inside this closure we must be careful to not hold a borrow too long, because
+                // while calling Py_DECREF we may cause other callbacks to run which will need to
+                // register objects into the GILPool.
+                let len = owned_objects.borrow().len();
+                for i in self.owned_objects_start..len {
+                    let ptr = owned_objects.borrow().get_unchecked(i).as_ptr();
+                    ffi::Py_DECREF(ptr);
+                }
+                // If this assertion fails, something weird is going on where another GILPool that was
+                // created after this one has not yet been dropped.
+                debug_assert!(owned_objects.borrow().len() == len);
+                owned_objects
+                    .borrow_mut()
+                    .truncate(self.owned_objects_start);
+            });
+
+            OWNED_ANYS.with(|owned_anys| owned_anys.borrow_mut().truncate(self.owned_anys_start));
         }
         decrement_gil_count();
     }
 }
 
-pub unsafe fn register_any<'p, T: 'static>(obj: T) -> &'p T {
-    let pool = POOL.get_or_init();
-
-    pool.obj.push(Box::new(obj));
-    pool.obj
-        .last()
-        .unwrap()
-        .as_ref()
-        .downcast_ref::<T>()
-        .unwrap()
-}
-
+/// Register a Python object pointer inside the release pool, to have reference count decreased
+/// next time the GIL is acquired in pyo3.
+///
+/// # Safety
+/// The object must be an owned Python reference.
 pub unsafe fn register_pointer(obj: NonNull<ffi::PyObject>) {
-    let pool = POOL.get_or_init();
     if gil_is_acquired() {
         ffi::Py_DECREF(obj.as_ptr())
     } else {
-        (**pool.p.lock()).push(obj);
+        POOL.register_pointer(obj);
     }
 }
 
+/// Register an owned object inside the GILPool.
+///
+/// # Safety
+/// The object must be an owned Python reference.
 pub unsafe fn register_owned(_py: Python, obj: NonNull<ffi::PyObject>) {
-    let pool = POOL.get_or_init();
-    pool.owned.push(obj);
+    debug_assert!(gil_is_acquired());
+    OWNED_OBJECTS.with(|objs| objs.borrow_mut().push(obj));
+}
+
+/// Register any value inside the GILPool.
+///
+/// # Safety
+/// It is the caller's responsibility to ensure that the inferred lifetime 'p is not inferred by
+/// the Rust compiler to outlast the current GILPool.
+pub unsafe fn register_any<'p, T: 'static>(obj: T) -> &'p T {
+    debug_assert!(gil_is_acquired());
+    OWNED_ANYS.with(|owned_anys| {
+        let boxed = Box::new(obj);
+        let value_ref: &T = &*boxed;
+
+        // Sneaky - extend the lifetime of the reference so that the box can be moved
+        let value_ref_extended_lifetime = std::mem::transmute(value_ref);
+
+        owned_anys.borrow_mut().push(boxed);
+        value_ref_extended_lifetime
+    })
 }
 
 /// Increment pyo3's internal GIL count - to be called whenever GILPool or GILGuard is created.
@@ -295,7 +324,7 @@ fn decrement_gil_count() {
 
 #[cfg(test)]
 mod test {
-    use super::{GILPool, GIL_COUNT, POOL};
+    use super::{GILPool, GIL_COUNT, OWNED_OBJECTS};
     use crate::{ffi, gil, AsPyPointer, IntoPyPointer, PyObject, Python, ToPyObject};
     use std::ptr::NonNull;
 
@@ -309,6 +338,10 @@ mod test {
         obj.to_object(py)
     }
 
+    fn owned_object_count() -> usize {
+        OWNED_OBJECTS.with(|objs| objs.borrow().len())
+    }
+
     #[test]
     fn test_owned() {
         let gil = Python::acquire_gil();
@@ -319,18 +352,16 @@ mod test {
         let _ref = obj.clone_ref(py);
 
         unsafe {
-            let p = POOL.get_or_init();
-
             {
                 let gil = Python::acquire_gil();
                 gil::register_owned(gil.python(), NonNull::new_unchecked(obj.into_ptr()));
 
                 assert_eq!(ffi::Py_REFCNT(obj_ptr), 2);
-                assert_eq!(p.owned.len(), 1);
+                assert_eq!(owned_object_count(), 1);
             }
             {
                 let _gil = Python::acquire_gil();
-                assert_eq!(p.owned.len(), 0);
+                assert_eq!(owned_object_count(), 0);
                 assert_eq!(ffi::Py_REFCNT(obj_ptr), 1);
             }
         }
@@ -346,26 +377,24 @@ mod test {
         let obj_ptr = obj.as_ptr();
 
         unsafe {
-            let p = POOL.get_or_init();
-
             {
                 let _pool = GILPool::new();
-                assert_eq!(p.owned.len(), 0);
+                assert_eq!(owned_object_count(), 0);
 
                 gil::register_owned(py, NonNull::new_unchecked(obj.into_ptr()));
 
-                assert_eq!(p.owned.len(), 1);
+                assert_eq!(owned_object_count(), 1);
                 assert_eq!(ffi::Py_REFCNT(obj_ptr), 2);
                 {
                     let _pool = GILPool::new();
                     let obj = get_object();
                     gil::register_owned(py, NonNull::new_unchecked(obj.into_ptr()));
-                    assert_eq!(p.owned.len(), 2);
+                    assert_eq!(owned_object_count(), 2);
                 }
-                assert_eq!(p.owned.len(), 1);
+                assert_eq!(owned_object_count(), 1);
             }
             {
-                assert_eq!(p.owned.len(), 0);
+                assert_eq!(owned_object_count(), 0);
                 assert_eq!(ffi::Py_REFCNT(obj_ptr), 1);
             }
         }
@@ -381,10 +410,8 @@ mod test {
         let obj_ptr = obj.as_ptr();
 
         unsafe {
-            let p = POOL.get_or_init();
-
             {
-                assert_eq!(p.owned.len(), 0);
+                assert_eq!(owned_object_count(), 0);
                 assert_eq!(ffi::Py_REFCNT(obj_ptr), 2);
             }
 
@@ -404,10 +431,8 @@ mod test {
         let obj_ptr = obj.as_ptr();
 
         unsafe {
-            let p = POOL.get_or_init();
-
             {
-                assert_eq!(p.owned.len(), 0);
+                assert_eq!(owned_object_count(), 0);
                 assert_eq!(ffi::Py_REFCNT(obj_ptr), 2);
             }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -25,8 +25,8 @@ pub unsafe trait PyNativeType: Sized {
     ///
     /// # Safety
     ///
-    /// Unless obj is not an instance of a type corresponding to Self,
-    /// this method causes undefined behavior.
+    /// `obj` must have the same layout as `*const ffi::PyObject` and must be
+    /// an instance of a type corresponding to `Self`.
     unsafe fn unchecked_downcast(obj: &PyAny) -> &Self {
         &*(obj.as_ptr() as *const Self)
     }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -3,7 +3,7 @@ use crate::err::{PyErr, PyResult};
 use crate::gil;
 use crate::object::PyObject;
 use crate::objectprotocol::ObjectProtocol;
-use crate::type_object::{PyBorrowFlagLayout, PyDowncastImpl};
+use crate::type_object::PyBorrowFlagLayout;
 use crate::{
     ffi, AsPyPointer, FromPyObject, IntoPy, IntoPyPointer, PyAny, PyCell, PyClass,
     PyClassInitializer, PyRef, PyRefMut, PyTypeInfo, Python, ToPyObject,
@@ -20,6 +20,15 @@ use std::ptr::NonNull;
 pub unsafe trait PyNativeType: Sized {
     fn py(&self) -> Python {
         unsafe { Python::assume_gil_acquired() }
+    }
+    /// Cast `&PyAny` to `&Self` without no type checking.
+    ///
+    /// # Safety
+    ///
+    /// Unless obj is not an instance of a type corresponding to Self,
+    /// this method causes undefined behavior.
+    unsafe fn unchecked_downcast(obj: &PyAny) -> &Self {
+        &*(obj.as_ptr() as *const Self)
     }
 }
 
@@ -176,8 +185,8 @@ where
 {
     type Target = T::AsRefTarget;
     fn as_ref<'p>(&'p self, _py: Python<'p>) -> &'p Self::Target {
-        let any = self as *const Py<T> as *const PyAny;
-        unsafe { PyDowncastImpl::unchecked_downcast(&*any) }
+        let any = self.as_ptr() as *const PyAny;
+        unsafe { PyNativeType::unchecked_downcast(&*any) }
     }
 }
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -32,13 +32,6 @@ impl PyObject {
         PyObject(ptr)
     }
 
-    #[cfg(test)]
-    pub(crate) unsafe fn into_nonnull(self) -> NonNull<ffi::PyObject> {
-        let res = self.0;
-        std::mem::forget(self); // Avoid Drop
-        res
-    }
-
     /// Creates a `PyObject` instance for the given FFI pointer.
     /// This moves ownership over the pointer into the `PyObject`.
     /// Undefined behavior if the pointer is NULL or invalid.

--- a/src/object.rs
+++ b/src/object.rs
@@ -32,6 +32,7 @@ impl PyObject {
         PyObject(ptr)
     }
 
+    #[cfg(test)]
     pub(crate) unsafe fn into_nonnull(self) -> NonNull<ffi::PyObject> {
         let res = self.0;
         std::mem::forget(self); // Avoid Drop
@@ -268,7 +269,7 @@ impl PyObject {
 impl AsPyRef for PyObject {
     type Target = PyAny;
     fn as_ref<'p>(&'p self, _py: Python<'p>) -> &'p PyAny {
-        unsafe { &*(self as *const _ as *const PyAny) }
+        unsafe { &*(self.as_ptr() as *const PyAny) }
     }
 }
 

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -2,8 +2,8 @@
 use crate::conversion::{AsPyPointer, FromPyPointer, ToPyObject};
 use crate::pyclass_init::PyClassInitializer;
 use crate::pyclass_slots::{PyClassDict, PyClassWeakRef};
-use crate::type_object::{PyBorrowFlagLayout, PyDowncastImpl, PyLayout, PySizedLayout, PyTypeInfo};
-use crate::{ffi, FromPy, PyAny, PyClass, PyErr, PyNativeType, PyObject, PyResult, Python};
+use crate::type_object::{PyBorrowFlagLayout, PyLayout, PySizedLayout, PyTypeInfo};
+use crate::{ffi, FromPy, PyClass, PyErr, PyNativeType, PyObject, PyResult, Python};
 use std::cell::{Cell, UnsafeCell};
 use std::fmt;
 use std::mem::ManuallyDrop;
@@ -158,6 +158,8 @@ pub struct PyCell<T: PyClass> {
     dict: T::Dict,
     weakref: T::WeakRef,
 }
+
+unsafe impl<T: PyClass> PyNativeType for PyCell<T> {}
 
 impl<T: PyClass> PyCell<T> {
     /// Make new `PyCell` on the Python heap and returns the reference of it.
@@ -358,13 +360,6 @@ unsafe impl<T: PyClass> PyLayout<T> for PyCell<T> {
         self.weakref.clear_weakrefs(self.as_ptr(), py);
         self.inner.ob_base.py_drop(py);
     }
-}
-
-unsafe impl<T: PyClass> PyDowncastImpl for PyCell<T> {
-    unsafe fn unchecked_downcast(obj: &PyAny) -> &Self {
-        &*(obj.as_ptr() as *const Self)
-    }
-    private_impl! {}
 }
 
 impl<T: PyClass> AsPyPointer for PyCell<T> {

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,5 +1,4 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
-use crate::internal_tricks::Unsendable;
 use crate::{
     ffi, AsPyPointer, FromPy, FromPyObject, PyAny, PyObject, PyResult, PyTryFrom, Python,
     ToPyObject,
@@ -7,7 +6,7 @@ use crate::{
 
 /// Represents a Python `bool`.
 #[repr(transparent)]
-pub struct PyBool(PyObject, Unsendable);
+pub struct PyBool(PyAny);
 
 pyobject_native_type!(PyBool, ffi::PyObject, ffi::PyBool_Type, ffi::PyBool_Check);
 

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -1,17 +1,13 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 use crate::err::{PyErr, PyResult};
-use crate::ffi;
 use crate::instance::PyNativeType;
-use crate::internal_tricks::Unsendable;
-use crate::object::PyObject;
-use crate::AsPyPointer;
-use crate::Python;
+use crate::{ffi, AsPyPointer, PyAny, Python};
 use std::os::raw::c_char;
 use std::slice;
 
 /// Represents a Python `bytearray`.
 #[repr(transparent)]
-pub struct PyByteArray(PyObject, Unsendable);
+pub struct PyByteArray(PyAny);
 
 pyobject_native_var_type!(PyByteArray, ffi::PyByteArray_Type, ffi::PyByteArray_Check);
 
@@ -38,7 +34,7 @@ impl PyByteArray {
     #[inline]
     pub fn len(&self) -> usize {
         // non-negative Py_ssize_t should always fit into Rust usize
-        unsafe { ffi::PyByteArray_Size(self.0.as_ptr()) as usize }
+        unsafe { ffi::PyByteArray_Size(self.as_ptr()) as usize }
     }
 
     /// Checks if the bytearray is empty.
@@ -69,8 +65,8 @@ impl PyByteArray {
     /// ```
     pub fn to_vec(&self) -> Vec<u8> {
         let slice = unsafe {
-            let buffer = ffi::PyByteArray_AsString(self.0.as_ptr()) as *mut u8;
-            let length = ffi::PyByteArray_Size(self.0.as_ptr()) as usize;
+            let buffer = ffi::PyByteArray_AsString(self.as_ptr()) as *mut u8;
+            let length = ffi::PyByteArray_Size(self.as_ptr()) as usize;
             slice::from_raw_parts_mut(buffer, length)
         };
         slice.to_vec()
@@ -79,7 +75,7 @@ impl PyByteArray {
     /// Resizes the bytearray object to the new length `len`.
     pub fn resize(&self, len: usize) -> PyResult<()> {
         unsafe {
-            let result = ffi::PyByteArray_Resize(self.0.as_ptr(), len as ffi::Py_ssize_t);
+            let result = ffi::PyByteArray_Resize(self.as_ptr(), len as ffi::Py_ssize_t);
             if result == 0 {
                 Ok(())
             } else {

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,4 +1,3 @@
-use crate::internal_tricks::Unsendable;
 use crate::{
     ffi, AsPyPointer, FromPy, FromPyObject, PyAny, PyObject, PyResult, PyTryFrom, Python,
     ToPyObject,
@@ -12,7 +11,7 @@ use std::str;
 ///
 /// This type is immutable.
 #[repr(transparent)]
-pub struct PyBytes(PyObject, Unsendable);
+pub struct PyBytes(PyAny);
 
 pyobject_native_var_type!(PyBytes, ffi::PyBytes_Type, ffi::PyBytes_Check);
 

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -1,17 +1,13 @@
-use crate::ffi;
 #[cfg(not(PyPy))]
 use crate::instance::PyNativeType;
-use crate::internal_tricks::Unsendable;
-use crate::AsPyPointer;
-use crate::PyObject;
-use crate::Python;
+use crate::{ffi, AsPyPointer, PyAny, Python};
 #[cfg(not(PyPy))]
 use std::ops::*;
 use std::os::raw::c_double;
 
 /// Represents a Python `complex`.
 #[repr(transparent)]
-pub struct PyComplex(PyObject, Unsendable);
+pub struct PyComplex(PyAny);
 
 pyobject_native_type!(
     PyComplex,
@@ -133,7 +129,7 @@ impl<'py> Neg for &'py PyComplex {
 #[cfg(feature = "num-complex")]
 mod complex_conversion {
     use super::*;
-    use crate::{FromPyObject, PyAny, PyErr, PyResult, ToPyObject};
+    use crate::{FromPyObject, PyAny, PyErr, PyObject, PyResult, ToPyObject};
     use num_complex::Complex;
 
     impl PyComplex {

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -25,12 +25,9 @@ use crate::ffi::{
     PyDateTime_TIME_GET_HOUR, PyDateTime_TIME_GET_MICROSECOND, PyDateTime_TIME_GET_MINUTE,
     PyDateTime_TIME_GET_SECOND,
 };
-use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::PyTuple;
-use crate::AsPyPointer;
-use crate::Python;
-use crate::ToPyObject;
+use crate::{AsPyPointer, PyAny, Python, ToPyObject};
 use std::os::raw::c_int;
 #[cfg(not(PyPy))]
 use std::ptr;
@@ -66,7 +63,8 @@ pub trait PyTimeAccess {
 }
 
 /// Bindings around `datetime.date`
-pub struct PyDate(PyObject, Unsendable);
+#[repr(transparent)]
+pub struct PyDate(PyAny);
 pyobject_native_type!(
     PyDate,
     crate::ffi::PyDateTime_Date,
@@ -122,7 +120,8 @@ impl PyDateAccess for PyDate {
 }
 
 /// Bindings for `datetime.datetime`
-pub struct PyDateTime(PyObject, Unsendable);
+#[repr(transparent)]
+pub struct PyDateTime(PyAny);
 pyobject_native_type!(
     PyDateTime,
     crate::ffi::PyDateTime_DateTime,
@@ -232,7 +231,8 @@ impl PyTimeAccess for PyDateTime {
 }
 
 /// Bindings for `datetime.time`
-pub struct PyTime(PyObject, Unsendable);
+#[repr(transparent)]
+pub struct PyTime(PyAny);
 pyobject_native_type!(
     PyTime,
     crate::ffi::PyDateTime_Time,
@@ -317,7 +317,8 @@ impl PyTimeAccess for PyTime {
 /// Bindings for `datetime.tzinfo`
 ///
 /// This is an abstract base class and should not be constructed directly.
-pub struct PyTzInfo(PyObject, Unsendable);
+#[repr(transparent)]
+pub struct PyTzInfo(PyAny);
 pyobject_native_type!(
     PyTzInfo,
     crate::ffi::PyObject,
@@ -327,7 +328,8 @@ pyobject_native_type!(
 );
 
 /// Bindings for `datetime.timedelta`
-pub struct PyDelta(PyObject, Unsendable);
+#[repr(transparent)]
+pub struct PyDelta(PyAny);
 pyobject_native_type!(
     PyDelta,
     crate::ffi::PyDateTime_Delta,

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -2,22 +2,19 @@
 
 use crate::err::{self, PyErr, PyResult};
 use crate::instance::PyNativeType;
-use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::types::{PyAny, PyList};
-use crate::AsPyPointer;
 #[cfg(not(PyPy))]
 use crate::IntoPyPointer;
-use crate::Python;
-use crate::{ffi, IntoPy};
-use crate::{FromPyObject, PyTryFrom};
-use crate::{ToBorrowedObject, ToPyObject};
+use crate::{
+    ffi, AsPyPointer, FromPyObject, IntoPy, PyTryFrom, Python, ToBorrowedObject, ToPyObject,
+};
 use std::collections::{BTreeMap, HashMap};
 use std::{cmp, collections, hash};
 
 /// Represents a Python `dict`.
 #[repr(transparent)]
-pub struct PyDict(PyObject, Unsendable);
+pub struct PyDict(PyAny);
 
 pyobject_native_type!(
     PyDict,

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 //
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
-use crate::internal_tricks::Unsendable;
 use crate::{
     ffi, AsPyPointer, FromPy, FromPyObject, ObjectProtocol, PyAny, PyErr, PyNativeType, PyObject,
     PyResult, Python, ToPyObject,
@@ -15,7 +14,7 @@ use std::os::raw::c_double;
 /// and [extract](struct.PyObject.html#method.extract)
 /// with `f32`/`f64`.
 #[repr(transparent)]
-pub struct PyFloat(PyObject, Unsendable);
+pub struct PyFloat(PyAny);
 
 pyobject_native_type!(
     PyFloat,
@@ -32,7 +31,7 @@ impl PyFloat {
 
     /// Gets the value of this float.
     pub fn value(&self) -> c_double {
-        unsafe { ffi::PyFloat_AsDouble(self.0.as_ptr()) }
+        unsafe { ffi::PyFloat_AsDouble(self.as_ptr()) }
     }
 }
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -4,7 +4,6 @@
 
 use crate::err::{self, PyResult};
 use crate::ffi::{self, Py_ssize_t};
-use crate::internal_tricks::Unsendable;
 use crate::{
     AsPyPointer, IntoPy, IntoPyPointer, PyAny, PyNativeType, PyObject, Python, ToBorrowedObject,
     ToPyObject,
@@ -12,7 +11,7 @@ use crate::{
 
 /// Represents a Python `list`.
 #[repr(transparent)]
-pub struct PyList(PyObject, Unsendable);
+pub struct PyList(PyAny);
 
 pyobject_native_var_type!(PyList, ffi::PyList_Type, ffi::PyList_Check);
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -31,7 +31,7 @@ macro_rules! pyobject_native_type_named (
         impl<$($type_param,)*> ::std::convert::AsRef<$crate::PyAny> for $name {
             #[inline]
             fn as_ref(&self) -> &$crate::PyAny {
-                unsafe{&*(self as *const $name as *const $crate::PyAny)}
+                unsafe { &*(self.as_ptr() as *const $crate::PyAny) }
             }
         }
 
@@ -150,7 +150,7 @@ macro_rules! pyobject_native_type_convert(
             #[inline]
             fn to_object(&self, py: $crate::Python) -> $crate::PyObject {
                 use $crate::AsPyPointer;
-                unsafe {$crate::PyObject::from_borrowed_ptr(py, self.0.as_ptr())}
+                unsafe { $crate::PyObject::from_borrowed_ptr(py, self.as_ptr()) }
             }
         }
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -6,7 +6,6 @@ use crate::err::{PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi;
 use crate::instance::PyNativeType;
-use crate::internal_tricks::Unsendable;
 use crate::object::PyObject;
 use crate::objectprotocol::ObjectProtocol;
 use crate::pyclass::PyClass;
@@ -20,7 +19,7 @@ use std::str;
 
 /// Represents a Python `module` object.
 #[repr(transparent)]
-pub struct PyModule(PyObject, Unsendable);
+pub struct PyModule(PyAny);
 
 pyobject_native_var_type!(PyModule, ffi::PyModule_Type, ffi::PyModule_Check);
 

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -2,7 +2,6 @@
 //
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
-use crate::internal_tricks::Unsendable;
 use crate::{
     exceptions, ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyErr, PyNativeType, PyObject,
     PyResult, Python, ToPyObject,
@@ -111,7 +110,7 @@ macro_rules! int_convert_128 {
 /// and [extract](struct.PyObject.html#method.extract)
 /// with the primitive Rust integer types.
 #[repr(transparent)]
-pub struct PyLong(PyObject, Unsendable);
+pub struct PyLong(PyAny);
 
 pyobject_native_var_type!(PyLong, ffi::PyLong_Type, ffi::PyLong_Check);
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -5,8 +5,6 @@ use crate::err::{self, PyDowncastError, PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi::{self, Py_ssize_t};
 use crate::instance::PyNativeType;
-use crate::internal_tricks::Unsendable;
-use crate::object::PyObject;
 use crate::objectprotocol::ObjectProtocol;
 use crate::types::{PyAny, PyList, PyTuple};
 use crate::AsPyPointer;
@@ -14,7 +12,7 @@ use crate::{FromPyObject, PyTryFrom, ToBorrowedObject};
 
 /// Represents a reference to a Python object supporting the sequence protocol.
 #[repr(transparent)]
-pub struct PySequence(PyObject, Unsendable);
+pub struct PySequence(PyAny);
 pyobject_native_type_named!(PySequence);
 pyobject_native_type_extract!(PySequence);
 

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -2,7 +2,6 @@
 //
 
 use crate::err::{self, PyErr, PyResult};
-use crate::internal_tricks::Unsendable;
 use crate::{
     ffi, AsPyPointer, FromPy, FromPyObject, IntoPy, PyAny, PyNativeType, PyObject, Python,
     ToBorrowedObject, ToPyObject,
@@ -13,11 +12,11 @@ use std::{collections, hash, ptr};
 
 /// Represents a Python `set`
 #[repr(transparent)]
-pub struct PySet(PyObject, Unsendable);
+pub struct PySet(PyAny);
 
 /// Represents a  Python `frozenset`
 #[repr(transparent)]
-pub struct PyFrozenSet(PyObject, Unsendable);
+pub struct PyFrozenSet(PyAny);
 
 pyobject_native_type!(PySet, ffi::PySetObject, ffi::PySet_Type, ffi::PySet_Check);
 pyobject_native_type!(

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -3,17 +3,14 @@
 use crate::err::{PyErr, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::instance::PyNativeType;
-use crate::internal_tricks::Unsendable;
-use crate::object::PyObject;
-use crate::Python;
-use crate::{AsPyPointer, ToPyObject};
+use crate::{AsPyPointer, PyAny, PyObject, Python, ToPyObject};
 use std::os::raw::c_long;
 
 /// Represents a Python `slice`.
 ///
 /// Only `c_long` indices supported at the moment by the `PySlice` object.
 #[repr(transparent)]
-pub struct PySlice(PyObject, Unsendable);
+pub struct PySlice(PyAny);
 
 pyobject_native_type!(
     PySlice,

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-use crate::internal_tricks::Unsendable;
 use crate::{
     ffi, gil, AsPyPointer, FromPy, FromPyObject, IntoPy, PyAny, PyErr, PyNativeType, PyObject,
     PyResult, PyTryFrom, Python, ToPyObject,
@@ -15,7 +14,7 @@ use std::str;
 ///
 /// This type is immutable.
 #[repr(transparent)]
-pub struct PyString(PyObject, Unsendable);
+pub struct PyString(PyAny);
 
 pyobject_native_var_type!(PyString, ffi::PyUnicode_Type, ffi::PyUnicode_Check);
 
@@ -48,7 +47,7 @@ impl PyString {
     pub fn as_bytes(&self) -> PyResult<&[u8]> {
         unsafe {
             let mut size: ffi::Py_ssize_t = 0;
-            let data = ffi::PyUnicode_AsUTF8AndSize(self.0.as_ptr(), &mut size) as *const u8;
+            let data = ffi::PyUnicode_AsUTF8AndSize(self.as_ptr(), &mut size) as *const u8;
             if data.is_null() {
                 Err(PyErr::fetch(self.py()))
             } else {
@@ -74,7 +73,7 @@ impl PyString {
             Err(_) => {
                 unsafe {
                     let py_bytes = ffi::PyUnicode_AsEncodedString(
-                        self.0.as_ptr(),
+                        self.as_ptr(),
                         CStr::from_bytes_with_nul(b"utf-8\0").unwrap().as_ptr(),
                         CStr::from_bytes_with_nul(b"surrogatepass\0")
                             .unwrap()

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
 use crate::ffi::{self, Py_ssize_t};
-use crate::internal_tricks::Unsendable;
 use crate::{
     exceptions, AsPyPointer, AsPyRef, FromPy, FromPyObject, IntoPy, IntoPyPointer, Py, PyAny,
     PyErr, PyNativeType, PyObject, PyResult, PyTryFrom, Python, ToPyObject,
@@ -12,7 +11,7 @@ use std::slice;
 ///
 /// This type is immutable.
 #[repr(transparent)]
-pub struct PyTuple(PyObject, Unsendable);
+pub struct PyTuple(PyAny);
 
 pyobject_native_var_type!(PyTuple, ffi::PyTuple_Type, ffi::PyTuple_Check);
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -3,19 +3,15 @@
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
 use crate::err::{PyErr, PyResult};
-use crate::ffi;
 use crate::instance::{Py, PyNativeType};
-use crate::internal_tricks::Unsendable;
-use crate::object::PyObject;
 use crate::type_object::PyTypeObject;
-use crate::AsPyPointer;
-use crate::Python;
+use crate::{ffi, AsPyPointer, PyAny, Python};
 use std::borrow::Cow;
 use std::ffi::CStr;
 
 /// Represents a reference to a Python `type object`.
 #[repr(transparent)]
-pub struct PyType(PyObject, Unsendable);
+pub struct PyType(PyAny);
 
 pyobject_native_var_type!(PyType, ffi::PyType_Type, ffi::PyType_Check);
 

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -54,14 +54,8 @@ macro_rules! assert_check_only {
     };
 }
 
-// Because of the relase pool unsoundness reported in https://github.com/PyO3/pyo3/issues/756,
-// we need to stop other threads before calling `py.import()`.
-// TODO(kngwyu): Remove this variable
-static MUTEX: parking_lot::Mutex<()> = parking_lot::const_mutex(());
-
 #[test]
 fn test_date_check() {
-    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "date", "2018, 1, 1").unwrap();
@@ -73,7 +67,6 @@ fn test_date_check() {
 
 #[test]
 fn test_time_check() {
-    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "time", "12, 30, 15").unwrap();
@@ -85,7 +78,6 @@ fn test_time_check() {
 
 #[test]
 fn test_datetime_check() {
-    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "datetime", "2018, 1, 1, 13, 30, 15")
@@ -100,7 +92,6 @@ fn test_datetime_check() {
 
 #[test]
 fn test_delta_check() {
-    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "timedelta", "1, -3").unwrap();
@@ -115,7 +106,6 @@ fn test_datetime_utc() {
     use assert_approx_eq::assert_approx_eq;
     use pyo3::types::PyDateTime;
 
-    let _lock = MUTEX.lock();
     let gil = Python::acquire_gil();
     let py = gil.python();
     let datetime = py.import("datetime").map_err(|e| e.print(py)).unwrap();


### PR DESCRIPTION
# TL; DR
This PR changes the internal representation of `PyAny` from `*mut ffi::PyObject` to `UnsafeCell<ffi::PyObject>`.
Thus, `&PyAny` was 'a pointer to a pointer', but now it is simply a pointer.
Related parts (e.g, GILPool) are also changed.
Partly resolves #679.

## What does this PR resolve?
We store almost all objects(except `PyObject` and `Py<T>`) to the internal storage, which costs when we get many objects.
This PR resolves 60% of this problem.
Since now `&PyAny` is a pointer, we don't need to store borrowed pointers to the object storage. So we can simply remove it. 50% of the problem is resolved by this.
However, for owned pointers, we still need the object storage so that we can do `obj.refcnt -= 1` when `gil` drops. But we can make the storage a bit faster than now. Now we use LinkedList for the storage so that the pointer to a pointer(=&PyAny) has a consistent address, but after this PR, we can use faster `Vec` since we don't use that reference. I believe this optimization resolves 10% of the problem.

## What does not this PR resolve?
We still have the object storage after this PR. How should we remove this?
Yeah, we can remove it if all constructors return `Py<T>` instead of `T`, say:
```rust
impl PyDict {
    pub fn new(py: Python) -> Py<PyDict> {}
}
```
`Py` can decrease its own reference count when dropping, so it would be efficient.

## Comparison with #885?

#885 also tries to resolve this problem by introducing `PyAny<'py>`, which is a GIL-bounded 'owned' object type. One thing I'm worried about `PyAny<'py>` is that it requires users to change too many codes.
The pro of this PR is **it does not change almost all API**, though it suggests that we should gradually change constructors to return `Py<T>`.