### PR TITLE
Update build.rs and remove serde and regex dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,7 @@ assert_approx_eq = "1.1.0"
 trybuild = "1.0.23"
 
 [build-dependencies]
-regex = { version = "1", default_features = false, features = ["std"] }
 version_check = "0.9.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 
 [features]
 default = []


### PR DESCRIPTION
Before:
```
[build-dependencies]
├── regex v1.3.7
│   └── regex-syntax v0.6.17
├── serde v1.0.106
│   └── serde_derive v1.0.106
│       ├── proc-macro2 v1.0.10
│       │   └── unicode-xid v0.2.0
│       ├── quote v1.0.3
│       │   └── proc-macro2 v1.0.10 (*)
│       └── syn v1.0.17 (*)
│           ├── proc-macro2 v1.0.10 (*)
│           ├── quote v1.0.3 (*)
│           └── unicode-xid v0.2.0
├── serde_json v1.0.51
│   ├── itoa v0.4.5
│   ├── ryu v1.0.3
│   └── serde v1.0.106 (*)
└── version_check v0.9.1
```

After:
```
[build-dependencies]
└── version_check v0.9.1
```