### PR TITLE
Move macros into separate feature.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,9 @@ jobs:
           toolchain: nightly
           default: true
       - run: rustup set default-host ${{ matrix.platform.rust-target }}
-      - name: Build
+      - name: Build without default features
+        run: cargo build --no-default-features --verbose
+      - name: Build with default features
         run: cargo build --verbose
       - name: Install test dependencies
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ travis-ci = { repository = "PyO3/pyo3", branch = "master" }
 appveyor = { repository = "fafhrd91/pyo3" }
 
 [dependencies]
-indoc = "0.3.4"
-inventory = "0.1.4"
+indoc = { version = "0.3.4", optional = true }
+inventory = { version = "0.1.4", optional = true }
 libc = "0.2.62"
 num-bigint = { version = "0.2", optional = true }
 num-complex = { version = "0.2", optional = true }
-paste = "0.1.6"
-pyo3cls = { path = "pyo3cls", version = "=0.9.2" }
-unindent = "0.1.4"
+paste = { version = "0.1.6", optional = true }
+pyo3cls = { path = "pyo3cls", version = "=0.9.2", optional = true }
+unindent = { version = "0.1.4", optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
@@ -36,7 +36,8 @@ trybuild = "1.0.23"
 version_check = "0.9.1"
 
 [features]
-default = []
+default = ["macros"]
+macros = ["indoc", "inventory", "paste", "pyo3cls", "unindent"]
 
 # this is no longer needed internally, but setuptools-rust assumes this feature
 python3 = []

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -138,6 +138,7 @@ impl PySetterDef {
 /// Allows arbitrary pymethod blocks to submit their methods, which are eventually
 /// collected by pyclass.
 #[doc(hidden)]
+#[cfg(feature = "macros")]
 pub trait PyMethodsInventory: inventory::Collect {
     /// Create a new instance
     fn new(methods: &'static [PyMethodDefType]) -> Self;
@@ -149,6 +150,7 @@ pub trait PyMethodsInventory: inventory::Collect {
 /// Implementation detail. Only to be used through the proc macros.
 /// For pyclass derived structs, this trait collects method from all impl blocks using inventory.
 #[doc(hidden)]
+#[cfg(feature = "macros")]
 pub trait PyMethodsImpl {
     /// Normal methods. Mainly defined by `#[pymethod]`.
     type Methods: PyMethodsInventory;
@@ -159,5 +161,13 @@ pub trait PyMethodsImpl {
             .into_iter()
             .flat_map(PyMethodsInventory::get_methods)
             .collect()
+    }
+}
+
+#[doc(hidden)]
+#[cfg(not(feature = "macros"))]
+pub trait PyMethodsImpl {
+    fn py_methods() -> Vec<&'static PyMethodDefType> {
+        Vec::new()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,21 +150,18 @@ pub use crate::type_object::{type_flags, PyTypeInfo};
 // Since PyAny is as important as PyObject, we expose it to the top level.
 pub use crate::types::PyAny;
 
-// Re-exported for wrap_function
+#[cfg(feature = "macros")]
 #[doc(hidden)]
-pub use paste;
-// Re-exported for py_run
-#[doc(hidden)]
-pub use indoc;
-// Re-exported for pymethods
-#[doc(hidden)]
-pub use inventory;
+pub use {
+    indoc,     // Re-exported for py_run
+    inventory, // Re-exported for pymethods
+    paste,     // Re-exported for wrap_function
+    unindent,  // Re-exported for py_run
+};
+
 // Re-exported for the `__wrap` functions
 #[doc(hidden)]
 pub use libc;
-// Re-exported for py_run
-#[doc(hidden)]
-pub use unindent;
 
 pub mod buffer;
 #[doc(hidden)]
@@ -197,6 +194,7 @@ pub mod type_object;
 pub mod types;
 
 /// The proc macros, which are also part of the prelude.
+#[cfg(feature = "macros")]
 pub mod proc_macro {
     pub use pyo3cls::pymodule;
     /// The proc macro attributes
@@ -278,6 +276,7 @@ macro_rules! wrap_pymodule {
 /// If you need to handle failures, please use [Python::run] directly.
 ///
 #[macro_export]
+#[cfg(feature = "macros")]
 macro_rules! py_run {
     ($py:expr, $($val:ident)+, $code:literal) => {{
         pyo3::py_run_impl!($py, $($val)+, pyo3::indoc::indoc!($code))
@@ -289,6 +288,7 @@ macro_rules! py_run {
 
 #[macro_export]
 #[doc(hidden)]
+#[cfg(feature = "macros")]
 macro_rules! py_run_impl {
     ($py:expr, $($val:ident)+, $code:expr) => {{
         use pyo3::types::IntoPyDict;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,5 +20,5 @@ pub use crate::python::Python;
 pub use crate::{FromPy, FromPyObject, IntoPy, IntoPyPointer, PyTryFrom, PyTryInto, ToPyObject};
 // PyModule is only part of the prelude because we need it for the pymodule function
 pub use crate::types::{PyAny, PyModule};
-pub use pyo3cls::pymodule;
-pub use pyo3cls::{pyclass, pyfunction, pymethods, pyproto};
+#[cfg(feature = "macros")]
+pub use pyo3cls::{pyclass, pyfunction, pymethods, pymodule, pyproto};


### PR DESCRIPTION
This makes it possible to opt-out of all the (proc) macros, which reduces the amount of dependencies that need to be downloaded and built.

Together with #895, #896 and #899, this reduces the dependency tree from:

```
pyo3 v0.9.2
├── indoc v0.3.5
│   ├── indoc-impl v0.3.5
│   │   ├── proc-macro-hack v0.5.15
│   │   ├── proc-macro2 v1.0.10
│   │   │   └── unicode-xid v0.2.0
│   │   ├── quote v1.0.3
│   │   │   └── proc-macro2 v1.0.10 (*)
│   │   ├── syn v1.0.17
│   │   │   ├── proc-macro2 v1.0.10 (*)
│   │   │   ├── quote v1.0.3 (*)
│   │   │   └── unicode-xid v0.2.0
│   │   └── unindent v0.1.5
│   └── proc-macro-hack v0.5.15
├── inventory v0.1.6
│   ├── ctor v0.1.14
│   │   ├── quote v1.0.3 (*)
│   │   └── syn v1.0.17 (*)
│   ├── ghost v0.1.1
│   │   ├── proc-macro2 v1.0.10 (*)
│   │   ├── quote v1.0.3 (*)
│   │   └── syn v1.0.17 (*)
│   └── inventory-impl v0.1.6
│       ├── proc-macro2 v1.0.10 (*)
│       ├── quote v1.0.3 (*)
│       └── syn v1.0.17 (*)
├── libc v0.2.69
├── num-traits v0.2.11
│   [build-dependencies]
│   └── autocfg v1.0.0
├── parking_lot v0.10.2
│   ├── lock_api v0.3.4
│   │   └── scopeguard v1.1.0
│   └── parking_lot_core v0.7.2
│       ├── cfg-if v0.1.10
│       ├── libc v0.2.69
│       └── smallvec v1.4.0
├── paste v0.1.11
│   ├── paste-impl v0.1.11
│   │   ├── proc-macro-hack v0.5.15
│   │   ├── proc-macro2 v1.0.10 (*)
│   │   ├── quote v1.0.3 (*)
│   │   └── syn v1.0.17 (*)
│   └── proc-macro-hack v0.5.15
├── pyo3cls v0.9.2 (/home/mara/dev-ext/pyo3/pyo3cls)
│   ├── pyo3-derive-backend v0.9.2 (/home/mara/dev-ext/pyo3/pyo3-derive-backend)
│   │   ├── proc-macro2 v1.0.10 (*)
│   │   ├── quote v1.0.3 (*)
│   │   └── syn v1.0.17 (*)
│   ├── quote v1.0.3 (*)
│   └── syn v1.0.17 (*)
└── unindent v0.1.5
[build-dependencies]
├── regex v1.3.7
│   └── regex-syntax v0.6.17
├── serde v1.0.106
│   └── serde_derive v1.0.106
│       ├── proc-macro2 v1.0.10 (*)
│       ├── quote v1.0.3 (*)
│       └── syn v1.0.17 (*)
├── serde_json v1.0.51
│   ├── itoa v0.4.5
│   ├── ryu v1.0.3
│   └── serde v1.0.106 (*)
└── version_check v0.9.1
```
to:
```
pyo3 v0.9.2
└── libc v0.2.69
[build-dependencies]
└── version_check v0.9.1
```
with `--no-default-features`.