### PR TITLE
Simplify ReleasePool, remove parking_lot dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ inventory = "0.1.4"
 libc = "0.2.62"
 num-bigint = { version = "0.2", optional = true }
 num-complex = { version = "0.2", optional = true }
-parking_lot = { version = "0.10.2" }
 paste = "0.1.6"
 pyo3cls = { path = "pyo3cls", version = "=0.9.2" }
 unindent = "0.1.4"


### PR DESCRIPTION
Replaces the parking_lot Mutex by a simple AtomicBool spinlock, and simplifies the ReleasePool to contain one Vec instead of pointers to two Vecs.