### PR TITLE
[EXPERIMENTAL] Panics to prevent objects from outliving

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -343,8 +343,7 @@ where
 #[repr(transparent)]
 pub struct ManagedPyRef<'p, T: ToPyObject + ?Sized> {
     data: *mut ffi::PyObject,
-    data_type: PhantomData<T>,
-    _py: Python<'p>,
+    data_type: PhantomData<&'p T>,
 }
 
 /// This should eventually be replaced with a generic `IntoPy` trait impl by figuring
@@ -382,7 +381,6 @@ impl<T: ToPyObject + ?Sized> ManagedPyRefDispatch for T {
         ManagedPyRef {
             data: self.to_object(py).into_ptr(),
             data_type: PhantomData,
-            _py: py,
         }
     }
 
@@ -396,11 +394,10 @@ impl<T: ToPyObject + ?Sized> ManagedPyRefDispatch for T {
 /// The object we're getting is an owned pointer, it might have it's own drop impl.
 impl<T: ToPyObject + AsPyPointer + ?Sized> ManagedPyRefDispatch for T {
     /// Use AsPyPointer to copy the pointer and store it as borrowed pointer
-    fn to_managed_py_ref<'p>(&self, py: Python<'p>) -> ManagedPyRef<'p, Self> {
+    fn to_managed_py_ref<'p>(&self, _py: Python<'p>) -> ManagedPyRef<'p, Self> {
         ManagedPyRef {
             data: self.as_ptr(),
             data_type: PhantomData,
-            _py: py,
         }
     }
 

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -477,10 +477,10 @@ mod test {
 
         let cnt;
         {
-            let _pool = unsafe { crate::GILPool::new() };
+            let pool = unsafe { crate::GILPool::new() };
             let none = py.None();
             cnt = none.get_refcnt();
-            let _dict = [(10, none)].into_py_dict(py);
+            let _dict = [(10, none)].into_py_dict(unsafe { pool.python() });
         }
         {
             assert_eq!(cnt, py.None().get_refcnt());

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -130,14 +130,14 @@ mod tests {
 
     #[test]
     fn iter_item_refcnt() {
-        let gil_guard = Python::acquire_gil();
-        let py = gil_guard.python();
+        let _gil_guard = Python::acquire_gil();
 
         let obj;
         let none;
         let count;
         {
-            let _pool = unsafe { GILPool::new() };
+            let pool = unsafe { GILPool::new() };
+            let py = unsafe { pool.python() };
             let l = PyList::empty(py);
             none = py.None();
             l.append(10).unwrap();
@@ -147,7 +147,8 @@ mod tests {
         }
 
         {
-            let _pool = unsafe { GILPool::new() };
+            let pool = unsafe { GILPool::new() };
+            let py = unsafe { pool.python() };
             let inst = obj.as_ref(py);
             let mut it = inst.iter().unwrap();
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -299,7 +299,8 @@ mod test {
 
         let cnt;
         {
-            let _pool = unsafe { crate::GILPool::new() };
+            let pool = unsafe { crate::GILPool::new() };
+            let py = unsafe { pool.python() };
             let v = vec![2];
             let ob = v.to_object(py);
             let list = <PyList as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
@@ -334,7 +335,8 @@ mod test {
 
         let cnt;
         {
-            let _pool = unsafe { crate::GILPool::new() };
+            let pool = unsafe { crate::GILPool::new() };
+            let py = unsafe { pool.python() };
             let list = PyList::empty(py);
             let none = py.None();
             cnt = none.get_refcnt();
@@ -363,7 +365,8 @@ mod test {
 
         let cnt;
         {
-            let _pool = unsafe { crate::GILPool::new() };
+            let pool = unsafe { crate::GILPool::new() };
+            let py = unsafe { pool.python() };
             let list = PyList::empty(py);
             let none = py.None();
             cnt = none.get_refcnt();


### PR DESCRIPTION
Make `Python` have the gil count when GILPool/GILGuard is created.
And if we detect an older `Python` is used, we cause panic.

1.2x slower than the master :thinking: 
