### PR TITLE
Add `#[classattr]` methods to define Python class attributes

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -573,6 +573,37 @@ impl MyClass {
 }
 ```
 
+## Class attributes
+
+To create a class attribute (also called [class variable][classattr]), a method without
+any arguments can be annotated with the `#[classattr]` attribute. The return type must be `T` for
+some `T` that implements `IntoPy<PyObject>`.
+
+```rust
+# use pyo3::prelude::*;
+# #[pyclass]
+# struct MyClass {}
+#[pymethods]
+impl MyClass {
+    #[classattr]
+    fn my_attribute() -> String {
+        "hello".to_string()
+    }
+}
+
+let gil = Python::acquire_gil();
+let py = gil.python();
+let my_class = py.get_type::<MyClass>();
+pyo3::py_run!(py, my_class, "assert my_class.my_attribute == 'hello'")
+```
+
+Note that unlike class variables defined in Python code, class attributes defined in Rust cannot
+be mutated at all:
+```rust,ignore
+// Would raise a `TypeError: can't set attributes of built-in/extension type 'MyClass'`
+pyo3::py_run!(py, my_class, "my_class.my_attribute = 'foo'")
+```
+
 ## Callable objects
 
 To specify a custom `__call__` method for a custom class, the method needs to be annotated with
@@ -914,3 +945,5 @@ To escape this we use [inventory](https://github.com/dtolnay/inventory), which a
 [`PyClassInitializer<T>`]: https://pyo3.rs/master/doc/pyo3/pyclass_init/struct.PyClassInitializer.html
 
 [`RefCell`]: https://doc.rust-lang.org/std/cell/struct.RefCell.html
+
+[classattr]: https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -24,7 +24,9 @@ pub use self::descr::PyDescrProtocol;
 pub use self::gc::{PyGCProtocol, PyTraverseError, PyVisit};
 pub use self::iter::PyIterProtocol;
 pub use self::mapping::PyMappingProtocol;
-pub use self::methods::{PyGetterDef, PyMethodDef, PyMethodDefType, PyMethodType, PySetterDef};
+pub use self::methods::{
+    PyClassAttributeDef, PyGetterDef, PyMethodDef, PyMethodDefType, PyMethodType, PySetterDef,
+};
 pub use self::number::PyNumberProtocol;
 pub use self::pyasync::PyAsyncProtocol;
 pub use self::sequence::PySequenceProtocol;

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -1,0 +1,29 @@
+use pyo3::prelude::*;
+
+mod common;
+
+#[pyclass]
+struct Foo {}
+
+#[pymethods]
+impl Foo {
+    #[classattr]
+    fn a() -> i32 {
+        5
+    }
+
+    #[classattr]
+    #[name = "B"]
+    fn b() -> String {
+        "bar".to_string()
+    }
+}
+
+#[test]
+fn class_attributes() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let foo_obj = py.get_type::<Foo>();
+    py_assert!(py, foo_obj, "foo_obj.a == 5");
+    py_assert!(py, foo_obj, "foo_obj.B == 'bar'");
+}

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -3,7 +3,16 @@ use pyo3::prelude::*;
 mod common;
 
 #[pyclass]
-struct Foo {}
+struct Foo {
+    #[pyo3(get)]
+    x: i32,
+}
+
+#[pyclass]
+struct Bar {
+    #[pyo3(get)]
+    x: i32,
+}
 
 #[pymethods]
 impl Foo {
@@ -16,6 +25,24 @@ impl Foo {
     #[name = "B"]
     fn b() -> String {
         "bar".to_string()
+    }
+
+    #[classattr]
+    fn foo() -> Foo {
+        Foo { x: 1 }
+    }
+
+    #[classattr]
+    fn bar() -> Bar {
+        Bar { x: 2 }
+    }
+}
+
+#[pymethods]
+impl Bar {
+    #[classattr]
+    fn foo() -> Foo {
+        Foo { x: 3 }
     }
 }
 
@@ -34,4 +61,15 @@ fn class_attributes_are_immutable() {
     let py = gil.python();
     let foo_obj = py.get_type::<Foo>();
     py_expect_exception!(py, foo_obj, "foo_obj.a = 6", TypeError);
+}
+
+#[test]
+fn recursive_class_attributes() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let foo_obj = py.get_type::<Foo>();
+    let bar_obj = py.get_type::<Bar>();
+    py_assert!(py, foo_obj, "foo_obj.foo.x == 1");
+    py_assert!(py, foo_obj, "foo_obj.bar.x == 2");
+    py_assert!(py, bar_obj, "bar_obj.foo.x == 3");
 }

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -27,3 +27,11 @@ fn class_attributes() {
     py_assert!(py, foo_obj, "foo_obj.a == 5");
     py_assert!(py, foo_obj, "foo_obj.B == 'bar'");
 }
+
+#[test]
+fn class_attributes_are_immutable() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let foo_obj = py.get_type::<Foo>();
+    py_expect_exception!(py, foo_obj, "foo_obj.a = 6", TypeError);
+}


### PR DESCRIPTION
Here is my approach to #662: we add an attribute on methods defined in `#[pymethods]` impl blocks to allow defining class attributes (also named class variables).

A class attribute method cannot take arguments, and must return `impl IntoPy<PyObject>`.

For example, given the following Python code:
```python
class Foo:
    foo = 5
    BAR = 'bar'
```

a translation in Rust with `pyo3` could be given by:
```rust
#[pyclass]
struct Foo { }

#[pymethods]
impl Foo {
    #[classattr]
    fn foo() -> i32 {
        5
    }

    #[classattr]
    #[name = "BAR"]
    fn bar() -> String {
        "bar".to_string()
    }
}
```