### PR TITLE
Use ToPyObject instead of GetPropertyValue for #[pyo3(get)]

### DIFF
--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -275,8 +275,8 @@ pub(crate) fn impl_wrap_getter(
             (
                 name.unraw(),
                 quote!({
-                    use pyo3::derive_utils::GetPropertyValue;
-                    (&_slf.#name).get_property_value(_py)
+                    use pyo3::ToPyObject;
+                    (&_slf.#name).to_object(_py)
                 }),
             )
         }

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -10,7 +10,7 @@ use crate::instance::PyNativeType;
 use crate::pyclass::PyClass;
 use crate::pyclass_init::PyClassInitializer;
 use crate::types::{PyAny, PyDict, PyModule, PyTuple};
-use crate::{ffi, GILPool, IntoPy, Py, PyCell, PyObject, Python};
+use crate::{ffi, GILPool, IntoPy, PyCell, PyObject, Python};
 use std::cell::UnsafeCell;
 
 /// Description of a python parameter; used for `parse_args()`.
@@ -192,32 +192,6 @@ impl<T: PyClass, I: Into<PyClassInitializer<T>>> IntoPyNewResult<T, I> for I {
 impl<T: PyClass, I: Into<PyClassInitializer<T>>> IntoPyNewResult<T, I> for PyResult<I> {
     fn into_pynew_result(self) -> PyResult<I> {
         self
-    }
-}
-
-#[doc(hidden)]
-pub trait GetPropertyValue {
-    fn get_property_value(&self, py: Python) -> PyObject;
-}
-
-impl<T> GetPropertyValue for &T
-where
-    T: IntoPy<PyObject> + Clone,
-{
-    fn get_property_value(&self, py: Python) -> PyObject {
-        (*self).clone().into_py(py)
-    }
-}
-
-impl GetPropertyValue for PyObject {
-    fn get_property_value(&self, py: Python) -> PyObject {
-        self.clone_ref(py)
-    }
-}
-
-impl<T> GetPropertyValue for Py<T> {
-    fn get_property_value(&self, py: Python) -> PyObject {
-        self.clone_ref(py).into()
     }
 }
 

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -141,8 +141,6 @@ fn empty_class_in_module() {
 
 #[pyclass]
 struct ClassWithObjectField {
-    // PyObject has special case for derive_utils::GetPropertyValue,
-    // so this test is making sure it compiles!
     #[pyo3(get, set)]
     value: PyObject,
 }


### PR DESCRIPTION
Some how it works.
cc: #903 