### PR TITLE
Add Clone for PyObject / Py<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `_PyDict_NewPresized`. [#849](https://github.com/PyO3/pyo3/pull/849)
 - `IntoPy<PyObject>` for `HashSet` and `BTreeSet`. [#864](https://github.com/PyO3/pyo3/pull/864)
 - `PyAny::dir`. [#886](https://github.com/PyO3/pyo3/pull/886)
+- `impl Clone` for `PyObject` and `Py<T>`. [#908](https://github.com/PyO3/pyo3/pull/908)
 - All builtin types (`PyList`, `PyTuple`, `PyDict`) etc. now implement `Deref<Target = PyAny>`. [#911](https://github.com/PyO3/pyo3/pull/911)
 - `PyCell<T>` now implements `Deref<Target = PyAny>`. [#911](https://github.com/PyO3/pyo3/pull/911)
 - Methods and associated constants can now be annotated with `#[classattr]` to define class attributes. [#905](https://github.com/PyO3/pyo3/pull/905) [#914](https://github.com/PyO3/pyo3/pull/914)

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -265,11 +265,20 @@ impl<T> PartialEq for Py<T> {
     }
 }
 
+impl<T> Clone for Py<T> {
+    fn clone(&self) -> Self {
+        unsafe {
+            gil::register_incref(self.0);
+        }
+        Self(self.0, PhantomData)
+    }
+}
+
 /// Dropping a `Py` instance decrements the reference count on the object by 1.
 impl<T> Drop for Py<T> {
     fn drop(&mut self) {
         unsafe {
-            gil::register_pointer(self.0);
+            gil::register_decref(self.0);
         }
     }
 }

--- a/src/object.rs
+++ b/src/object.rs
@@ -308,11 +308,20 @@ impl<'a> FromPyObject<'a> for PyObject {
     }
 }
 
+impl Clone for PyObject {
+    fn clone(&self) -> Self {
+        unsafe {
+            gil::register_incref(self.0);
+        }
+        Self(self.0)
+    }
+}
+
 /// Dropping a `PyObject` instance decrements the reference count on the object by 1.
 impl Drop for PyObject {
     fn drop(&mut self) {
         unsafe {
-            gil::register_pointer(self.0);
+            gil::register_decref(self.0);
         }
     }
 }


### PR DESCRIPTION
I had this idea suddenly that similar to how we store pending `Py_DECREF`, I believe we can also store pending `Py_INCREF`, as long as all increfs are done before decrefs.

This allows `Py` and `PyObject` to have `Clone` implemented. If the GIL is held the reference count is updated immediately, otherwise the reference count increase is saved for the next time a thread acquires the GIL.

I have been mulling this over in my head and cannot find a way that this produces a dangling `PyObject`. Please do challenge me on this one though - I would prefer to be proved wrong and we don't merge this if it is not safe.

I will add tests later - gotta go to work! Just wanted to share it with you first as I think having `Clone` for these types will open the way for simplifying some things. (e.g. I think we could potentially add blanket impl `ToPyObject` for all `T: Clone`? Haven't thought too hard about that.)