### PR TITLE
Allow `#[classattr]` on associated constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PyAny::dir`. [#886](https://github.com/PyO3/pyo3/pull/886)
 - All builtin types (`PyList`, `PyTuple`, `PyDict`) etc. now implement `Deref<Target = PyAny>`. [#911](https://github.com/PyO3/pyo3/pull/911)
 - `PyCell<T>` now implements `Deref<Target = PyAny>`. [#911](https://github.com/PyO3/pyo3/pull/911)
+- Methods and associated constants can now be annotated with `#[classattr]` to define class attributes. [#905](https://github.com/PyO3/pyo3/pull/905) [#914](https://github.com/PyO3/pyo3/pull/914)
 
 ### Changed
 - Panics from Rust will now be caught and raised as Python errors. [#797](https://github.com/PyO3/pyo3/pull/797)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -604,6 +604,20 @@ be mutated at all:
 pyo3::py_run!(py, my_class, "my_class.my_attribute = 'foo'")
 ```
 
+If the class attribute is defined with `const` code only, one can also annotate associated
+constants:
+
+```rust
+# use pyo3::prelude::*;
+# #[pyclass]
+# struct MyClass {}
+#[pymethods]
+impl MyClass {
+    #[classattr]
+    const MY_CONST_ATTRIBUTE: &'static str = "foobar";
+}
+```
+
 ## Callable objects
 
 To specify a custom `__call__` method for a custom class, the method needs to be annotated with

--- a/pyo3-derive-backend/src/konst.rs
+++ b/pyo3-derive-backend/src/konst.rs
@@ -1,0 +1,34 @@
+use crate::pyfunction::parse_name_attribute;
+use syn::ext::IdentExt;
+
+#[derive(Clone, PartialEq, Debug)]
+pub struct ConstSpec {
+    pub is_class_attr: bool,
+    pub python_name: syn::Ident,
+}
+
+impl ConstSpec {
+    // For now, the only valid attribute is `#[classattr]`.
+    pub fn parse(name: &syn::Ident, attrs: &mut Vec<syn::Attribute>) -> syn::Result<ConstSpec> {
+        let mut new_attrs = Vec::new();
+        let mut is_class_attr = false;
+
+        for attr in attrs.iter() {
+            if let syn::Meta::Path(name) = attr.parse_meta()? {
+                if name.is_ident("classattr") {
+                    is_class_attr = true;
+                    continue;
+                }
+            }
+            new_attrs.push(attr.clone());
+        }
+
+        attrs.clear();
+        attrs.extend(new_attrs);
+
+        Ok(ConstSpec {
+            is_class_attr,
+            python_name: parse_name_attribute(attrs)?.unwrap_or_else(|| name.unraw()),
+        })
+    }
+}

--- a/pyo3-derive-backend/src/lib.rs
+++ b/pyo3-derive-backend/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod defs;
 mod func;
+mod konst;
 mod method;
 mod module;
 mod pyclass;

--- a/pyo3-derive-backend/src/pyimpl.rs
+++ b/pyo3-derive-backend/src/pyimpl.rs
@@ -24,9 +24,18 @@ pub fn impl_methods(ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> syn::Resu
     let mut methods = Vec::new();
     let mut cfg_attributes = Vec::new();
     for iimpl in impls.iter_mut() {
-        if let syn::ImplItem::Method(ref mut meth) = iimpl {
-            methods.push(pymethod::gen_py_method(ty, &mut meth.sig, &mut meth.attrs)?);
-            cfg_attributes.push(get_cfg_attributes(&meth.attrs));
+        match iimpl {
+            syn::ImplItem::Method(meth) => {
+                methods.push(pymethod::gen_py_method(ty, &mut meth.sig, &mut meth.attrs)?);
+                cfg_attributes.push(get_cfg_attributes(&meth.attrs));
+            }
+            syn::ImplItem::Const(konst) => {
+                if let Some(meth) = pymethod::gen_py_const(ty, &konst.ident, &mut konst.attrs)? {
+                    methods.push(meth);
+                }
+                cfg_attributes.push(get_cfg_attributes(&konst.attrs));
+            }
+            _ => (),
         }
     }
 

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -17,6 +17,9 @@ struct Bar {
 #[pymethods]
 impl Foo {
     #[classattr]
+    const MY_CONST: &'static str = "foobar";
+
+    #[classattr]
     fn a() -> i32 {
         5
     }
@@ -53,6 +56,7 @@ fn class_attributes() {
     let foo_obj = py.get_type::<Foo>();
     py_assert!(py, foo_obj, "foo_obj.a == 5");
     py_assert!(py, foo_obj, "foo_obj.B == 'bar'");
+    py_assert!(py, foo_obj, "foo_obj.MY_CONST == 'foobar'");
 }
 
 #[test]


### PR DESCRIPTION
```rust
#[pymethods]
impl Foo {
    #[classattr]
    const MY_CONST: &'static str = "foobar";
}
```