### PR TITLE
Use PyMethodsImpl instead of *ProtocolImpl::methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `GILGuard` returned from `Python::acquire_gil` will now only assume responsiblity for freeing owned references on drop if no other `GILPool` or `GILGuard` exists. This ensures that multiple calls to the safe api `Python::acquire_gil` cannot lead to dangling references. [#893](https://github.com/PyO3/pyo3/pull/893)
 - The trait `ObjectProtocol` has been removed, and all the methods from the trait have been moved to `PyAny`. [#911](https://github.com/PyO3/pyo3/pull/911)
   - The exception to this is `ObjectProtocol::None`, which has simply been removed. Use `Python::None` instead.
+- No `#![feature(specialization)]` in user code. [#917](https://github.com/PyO3/pyo3/pull/917)
 
 ### Removed
 - `PyMethodsProtocol` is now renamed to `PyMethodsImpl` and hidden. [#889](https://github.com/PyO3/pyo3/pull/889)
 - `num-traits` is no longer a dependency. [#895](https://github.com/PyO3/pyo3/pull/895)
 - `ObjectProtocol`. [#911](https://github.com/PyO3/pyo3/pull/911)
+- All `*ProtocolImpl` traits. [#917](https://github.com/PyO3/pyo3/pull/917)
 
 ### Fixed
 - `__radd__` and other `__r*__` methods now correctly work with operators. [#839](https://github.com/PyO3/pyo3/pull/839)

--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -36,7 +36,7 @@ pub fn build_py_proto(ast: &mut syn::ItemImpl) -> syn::Result<TokenStream> {
             ));
         };
 
-        let tokens = impl_proto_impl(&ast.self_ty, &mut ast.items, proto);
+        let tokens = impl_proto_impl(&ast.self_ty, &mut ast.items, proto)?;
 
         // attach lifetime
         let mut seg = path.segments.pop().unwrap().into_value();
@@ -57,53 +57,54 @@ fn impl_proto_impl(
     ty: &syn::Type,
     impls: &mut Vec<syn::ImplItem>,
     proto: &defs::Proto,
-) -> TokenStream {
-    let mut tokens = TokenStream::new();
+) -> syn::Result<TokenStream> {
+    let mut trait_impls = TokenStream::new();
     let mut py_methods = Vec::new();
 
     for iimpl in impls.iter_mut() {
         if let syn::ImplItem::Method(ref mut met) = iimpl {
             if let Some(m) = proto.get_proto(&met.sig.ident) {
-                impl_method_proto(ty, &mut met.sig, m).to_tokens(&mut tokens);
+                impl_method_proto(ty, &mut met.sig, m).to_tokens(&mut trait_impls);
             }
             if let Some(m) = proto.get_method(&met.sig.ident) {
                 let name = &met.sig.ident;
-                let proto: syn::Path = syn::parse_str(m.proto).unwrap();
-
-                let fn_spec = match FnSpec::parse(&met.sig, &mut met.attrs, false) {
-                    Ok(fn_spec) => fn_spec,
-                    Err(err) => return err.to_compile_error(),
-                };
-                let meth = pymethod::impl_proto_wrap(ty, &fn_spec);
+                let fn_spec = FnSpec::parse(&met.sig, &mut met.attrs, false)?;
+                let method = pymethod::impl_proto_wrap(ty, &fn_spec);
                 let coexist = if m.can_coexist {
+                    // We need METH_COEXIST here to prevent __add__  from overriding __radd__
                     quote!(pyo3::ffi::METH_COEXIST)
                 } else {
                     quote!(0)
                 };
+                // TODO(kngwyu): doc
                 py_methods.push(quote! {
-                    impl #proto for #ty
-                    {
-                        #[inline]
-                        fn #name() -> Option<pyo3::class::methods::PyMethodDef> {
-                            #meth
-
-                            Some(pyo3::class::PyMethodDef {
-                                ml_name: stringify!(#name),
-                                ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
-                                // We need METH_COEXIST here to prevent __add__  from overriding __radd__
-                                ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS | #coexist,
-                                ml_doc: ""
-                            })
+                    pyo3::class::PyMethodDefType::Method({
+                        #method
+                        pyo3::class::PyMethodDef {
+                            ml_name: stringify!(#name),
+                            ml_meth: pyo3::class::PyMethodType::PyCFunctionWithKeywords(__wrap),
+                            ml_flags: pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS | #coexist,
+                            ml_doc: ""
                         }
-                    }
+                    })
                 });
             }
         }
     }
 
-    quote! {
-        #tokens
-
-        #(#py_methods)*
+    if py_methods.is_empty() {
+        return Ok(quote! { #trait_impls });
     }
+    let inventory_submission = quote! {
+        pyo3::inventory::submit! {
+            #![crate = pyo3] {
+                type ProtoInventory = <#ty as pyo3::class::methods::PyMethodsImpl>::Methods;
+                <ProtoInventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(#py_methods),*])
+            }
+        }
+    };
+    Ok(quote! {
+        #trait_impls
+        #inventory_submission
+    })
 }

--- a/src/class/context.rs
+++ b/src/class/context.rs
@@ -4,7 +4,6 @@
 //! Trait and support implementation for context manager api
 //!
 
-use crate::class::methods::PyMethodDef;
 use crate::err::PyResult;
 use crate::{PyClass, PyObject};
 
@@ -42,62 +41,4 @@ pub trait PyContextExitProtocol<'p>: PyContextProtocol<'p> {
     type Traceback: crate::FromPyObject<'p>;
     type Success: crate::IntoPy<PyObject>;
     type Result: Into<PyResult<Self::Success>>;
-}
-
-#[doc(hidden)]
-pub trait PyContextProtocolImpl {
-    fn methods() -> Vec<PyMethodDef>;
-}
-
-impl<T> PyContextProtocolImpl for T {
-    default fn methods() -> Vec<PyMethodDef> {
-        Vec::new()
-    }
-}
-
-impl<'p, T> PyContextProtocolImpl for T
-where
-    T: PyContextProtocol<'p>,
-{
-    #[inline]
-    fn methods() -> Vec<PyMethodDef> {
-        let mut methods = Vec::new();
-
-        if let Some(def) = <Self as PyContextEnterProtocolImpl>::__enter__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyContextExitProtocolImpl>::__exit__() {
-            methods.push(def)
-        }
-
-        methods
-    }
-}
-
-#[doc(hidden)]
-pub trait PyContextEnterProtocolImpl {
-    fn __enter__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyContextEnterProtocolImpl for T
-where
-    T: PyContextProtocol<'p>,
-{
-    default fn __enter__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
-#[doc(hidden)]
-pub trait PyContextExitProtocolImpl {
-    fn __exit__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyContextExitProtocolImpl for T
-where
-    T: PyContextProtocol<'p>,
-{
-    default fn __exit__() -> Option<PyMethodDef> {
-        None
-    }
 }

--- a/src/class/descr.rs
+++ b/src/class/descr.rs
@@ -123,14 +123,10 @@ impl<'p, T> PyDescrSetNameProtocolImpl for T where T: PyDescrProtocol<'p> {}
 
 #[doc(hidden)]
 pub trait PyDescrProtocolImpl {
-    fn methods() -> Vec<PyMethodDef>;
     fn tp_as_descr(_type_object: &mut ffi::PyTypeObject);
 }
 
 impl<T> PyDescrProtocolImpl for T {
-    default fn methods() -> Vec<PyMethodDef> {
-        Vec::new()
-    }
     default fn tp_as_descr(_type_object: &mut ffi::PyTypeObject) {}
 }
 
@@ -138,9 +134,6 @@ impl<'p, T> PyDescrProtocolImpl for T
 where
     T: PyDescrProtocol<'p>,
 {
-    fn methods() -> Vec<PyMethodDef> {
-        Vec::new()
-    }
     fn tp_as_descr(type_object: &mut ffi::PyTypeObject) {
         type_object.tp_descr_get = Self::tp_descr_get();
         type_object.tp_descr_set = Self::tp_descr_set();

--- a/src/class/mapping.rs
+++ b/src/class/mapping.rs
@@ -3,7 +3,6 @@
 //! Python Mapping Interface
 //! Trait and support implementation for implementing mapping support
 
-use crate::class::methods::PyMethodDef;
 use crate::err::{PyErr, PyResult};
 use crate::{exceptions, ffi, FromPyObject, IntoPy, PyClass, PyObject};
 
@@ -78,15 +77,11 @@ pub trait PyMappingReversedProtocol<'p>: PyMappingProtocol<'p> {
 #[doc(hidden)]
 pub trait PyMappingProtocolImpl {
     fn tp_as_mapping() -> Option<ffi::PyMappingMethods>;
-    fn methods() -> Vec<PyMethodDef>;
 }
 
 impl<T> PyMappingProtocolImpl for T {
     default fn tp_as_mapping() -> Option<ffi::PyMappingMethods> {
         None
-    }
-    default fn methods() -> Vec<PyMethodDef> {
-        Vec::new()
     }
 }
 
@@ -107,17 +102,6 @@ where
             mp_subscript: Self::mp_subscript(),
             mp_ass_subscript: f,
         })
-    }
-
-    #[inline]
-    fn methods() -> Vec<PyMethodDef> {
-        let mut methods = Vec::new();
-
-        if let Some(def) = <Self as PyMappingReversedProtocolImpl>::__reversed__() {
-            methods.push(def)
-        }
-
-        methods
     }
 }
 
@@ -240,19 +224,5 @@ where
 {
     fn mp_del_subscript() -> Option<ffi::objobjargproc> {
         <T as DelSetItemDispatch>::det_set_dispatch()
-    }
-}
-
-#[doc(hidden)]
-pub trait PyMappingReversedProtocolImpl {
-    fn __reversed__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyMappingReversedProtocolImpl for T
-where
-    T: PyMappingProtocol<'p>,
-{
-    default fn __reversed__() -> Option<PyMethodDef> {
-        None
     }
 }

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -135,16 +135,16 @@ impl PySetterDef {
 }
 
 /// Implementation detail. Only to be used through the proc macros.
-/// Allows arbitrary pymethod blocks to submit their methods, which are eventually
-/// collected by pyclass.
+/// Allows arbitrary `#[pymethod]/#[pyproto]` blocks to submit their methods,
+/// which are eventually collected by `#[pyclass]`.
 #[doc(hidden)]
 #[cfg(feature = "macros")]
 pub trait PyMethodsInventory: inventory::Collect {
     /// Create a new instance
     fn new(methods: &'static [PyMethodDefType]) -> Self;
 
-    /// Returns the methods for a single impl block
-    fn get_methods(&self) -> &'static [PyMethodDefType];
+    /// Returns the methods for a single `#[pymethods] impl` block
+    fn get(&self) -> &'static [PyMethodDefType];
 }
 
 /// Implementation detail. Only to be used through the proc macros.
@@ -159,7 +159,7 @@ pub trait PyMethodsImpl {
     fn py_methods() -> Vec<&'static PyMethodDefType> {
         inventory::iter::<Self::Methods>
             .into_iter()
-            .flat_map(PyMethodsInventory::get_methods)
+            .flat_map(PyMethodsInventory::get)
             .collect()
     }
 }

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -4,7 +4,6 @@
 //! Trait and support implementation for implementing number protocol
 
 use crate::class::basic::PyObjectProtocolImpl;
-use crate::class::methods::PyMethodDef;
 use crate::err::PyResult;
 use crate::{ffi, FromPyObject, IntoPy, PyClass, PyObject};
 
@@ -619,14 +618,10 @@ pub trait PyNumberIndexProtocol<'p>: PyNumberProtocol<'p> {
 
 #[doc(hidden)]
 pub trait PyNumberProtocolImpl: PyObjectProtocolImpl {
-    fn methods() -> Vec<PyMethodDef>;
     fn tp_as_number() -> Option<ffi::PyNumberMethods>;
 }
 
 impl<'p, T> PyNumberProtocolImpl for T {
-    default fn methods() -> Vec<PyMethodDef> {
-        Vec::new()
-    }
     default fn tp_as_number() -> Option<ffi::PyNumberMethods> {
         if let Some(nb_bool) = <Self as PyObjectProtocolImpl>::nb_bool_fn() {
             let meth = ffi::PyNumberMethods {
@@ -683,62 +678,6 @@ where
             nb_matrix_multiply: Self::nb_matrix_multiply().or_else(Self::nb_matmul_fallback),
             nb_inplace_matrix_multiply: Self::nb_inplace_matrix_multiply(),
         })
-    }
-
-    #[inline]
-    fn methods() -> Vec<PyMethodDef> {
-        let mut methods = Vec::new();
-
-        if let Some(def) = <Self as PyNumberRAddProtocolImpl>::__radd__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRSubProtocolImpl>::__rsub__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRMulProtocolImpl>::__rmul__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRMatmulProtocolImpl>::__rmatmul__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRTruedivProtocolImpl>::__rtruediv__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRFloordivProtocolImpl>::__rfloordiv__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRModProtocolImpl>::__rmod__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRDivmodProtocolImpl>::__rdivmod__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRPowProtocolImpl>::__rpow__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRLShiftProtocolImpl>::__rlshift__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRRShiftProtocolImpl>::__rrshift__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRAndProtocolImpl>::__rand__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRXorProtocolImpl>::__rxor__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberROrProtocolImpl>::__ror__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberComplexProtocolImpl>::__complex__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyNumberRoundProtocolImpl>::__round__() {
-            methods.push(def)
-        }
-
-        methods
     }
 }
 
@@ -1336,20 +1275,6 @@ where
     }
 }
 
-#[doc(hidden)]
-pub trait PyNumberRAddProtocolImpl {
-    fn __radd__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRAddProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __radd__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
 // Fallback trait for nb_add
 trait PyNumberAddFallback {
     fn nb_add_fallback() -> Option<ffi::binaryfunc>;
@@ -1370,20 +1295,6 @@ where
 {
     fn nb_add_fallback() -> Option<ffi::binaryfunc> {
         py_binary_reverse_num_func!(PyNumberRAddProtocol, T::__radd__)
-    }
-}
-
-#[doc(hidden)]
-pub trait PyNumberRSubProtocolImpl {
-    fn __rsub__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRSubProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rsub__() -> Option<PyMethodDef> {
-        None
     }
 }
 
@@ -1409,20 +1320,6 @@ where
     }
 }
 
-#[doc(hidden)]
-pub trait PyNumberRMulProtocolImpl {
-    fn __rmul__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRMulProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rmul__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
 trait PyNumberMulFallback {
     fn nb_mul_fallback() -> Option<ffi::binaryfunc>;
 }
@@ -1442,20 +1339,6 @@ where
 {
     fn nb_mul_fallback() -> Option<ffi::binaryfunc> {
         py_binary_reverse_num_func!(PyNumberRMulProtocol, T::__rmul__)
-    }
-}
-
-#[doc(hidden)]
-pub trait PyNumberRMatmulProtocolImpl {
-    fn __rmatmul__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRMatmulProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rmatmul__() -> Option<PyMethodDef> {
-        None
     }
 }
 
@@ -1481,20 +1364,6 @@ where
     }
 }
 
-#[doc(hidden)]
-pub trait PyNumberRTruedivProtocolImpl {
-    fn __rtruediv__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRTruedivProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rtruediv__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
 trait PyNumberTruedivFallback {
     fn nb_truediv_fallback() -> Option<ffi::binaryfunc>;
 }
@@ -1514,20 +1383,6 @@ where
 {
     fn nb_truediv_fallback() -> Option<ffi::binaryfunc> {
         py_binary_reverse_num_func!(PyNumberRTruedivProtocol, T::__rtruediv__)
-    }
-}
-
-#[doc(hidden)]
-pub trait PyNumberRFloordivProtocolImpl {
-    fn __rfloordiv__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRFloordivProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rfloordiv__() -> Option<PyMethodDef> {
-        None
     }
 }
 
@@ -1553,20 +1408,6 @@ where
     }
 }
 
-#[doc(hidden)]
-pub trait PyNumberRModProtocolImpl {
-    fn __rmod__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRModProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rmod__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
 trait PyNumberModFallback {
     fn nb_mod_fallback() -> Option<ffi::binaryfunc>;
 }
@@ -1586,20 +1427,6 @@ where
 {
     fn nb_mod_fallback() -> Option<ffi::binaryfunc> {
         py_binary_reverse_num_func!(PyNumberRModProtocol, T::__rmod__)
-    }
-}
-
-#[doc(hidden)]
-pub trait PyNumberRDivmodProtocolImpl {
-    fn __rdivmod__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRDivmodProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rdivmod__() -> Option<PyMethodDef> {
-        None
     }
 }
 
@@ -1625,20 +1452,6 @@ where
     }
 }
 
-#[doc(hidden)]
-pub trait PyNumberRPowProtocolImpl {
-    fn __rpow__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRPowProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rpow__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
 trait PyNumberPowFallback {
     fn nb_pow_fallback() -> Option<ffi::ternaryfunc>;
 }
@@ -1658,20 +1471,6 @@ where
 {
     fn nb_pow_fallback() -> Option<ffi::ternaryfunc> {
         py_ternary_reverse_num_func!(PyNumberRPowProtocol, T::__rpow__)
-    }
-}
-
-#[doc(hidden)]
-pub trait PyNumberRLShiftProtocolImpl {
-    fn __rlshift__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRLShiftProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rlshift__() -> Option<PyMethodDef> {
-        None
     }
 }
 
@@ -1697,20 +1496,6 @@ where
     }
 }
 
-#[doc(hidden)]
-pub trait PyNumberRRShiftProtocolImpl {
-    fn __rrshift__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRRShiftProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rrshift__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
 trait PyNumberRRshiftFallback {
     fn nb_rshift_fallback() -> Option<ffi::binaryfunc>;
 }
@@ -1730,20 +1515,6 @@ where
 {
     fn nb_rshift_fallback() -> Option<ffi::binaryfunc> {
         py_binary_reverse_num_func!(PyNumberRRShiftProtocol, T::__rrshift__)
-    }
-}
-
-#[doc(hidden)]
-pub trait PyNumberRAndProtocolImpl {
-    fn __rand__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRAndProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rand__() -> Option<PyMethodDef> {
-        None
     }
 }
 
@@ -1769,20 +1540,6 @@ where
     }
 }
 
-#[doc(hidden)]
-pub trait PyNumberRXorProtocolImpl {
-    fn __rxor__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRXorProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __rxor__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
 trait PyNumberXorFallback {
     fn nb_xor_fallback() -> Option<ffi::binaryfunc>;
 }
@@ -1802,20 +1559,6 @@ where
 {
     fn nb_xor_fallback() -> Option<ffi::binaryfunc> {
         py_binary_reverse_num_func!(PyNumberRXorProtocol, T::__rxor__)
-    }
-}
-
-#[doc(hidden)]
-pub trait PyNumberROrProtocolImpl {
-    fn __ror__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberROrProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __ror__() -> Option<PyMethodDef> {
-        None
     }
 }
 
@@ -1993,31 +1736,5 @@ where
 {
     fn nb_index() -> Option<ffi::unaryfunc> {
         py_unary_func!(PyNumberIndexProtocol, T::__index__)
-    }
-}
-
-pub trait PyNumberComplexProtocolImpl {
-    fn __complex__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberComplexProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __complex__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
-pub trait PyNumberRoundProtocolImpl {
-    fn __round__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyNumberRoundProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn __round__() -> Option<PyMethodDef> {
-        None
     }
 }

--- a/src/class/pyasync.rs
+++ b/src/class/pyasync.rs
@@ -8,7 +8,6 @@
 //! [PEP-0492](https://www.python.org/dev/peps/pep-0492/)
 //!
 
-use crate::class::methods::PyMethodDef;
 use crate::err::PyResult;
 use crate::{ffi, PyClass, PyObject};
 
@@ -89,16 +88,11 @@ pub trait PyAsyncAexitProtocol<'p>: PyAsyncProtocol<'p> {
 #[doc(hidden)]
 pub trait PyAsyncProtocolImpl {
     fn tp_as_async() -> Option<ffi::PyAsyncMethods>;
-    fn methods() -> Vec<PyMethodDef>;
 }
 
 impl<T> PyAsyncProtocolImpl for T {
     default fn tp_as_async() -> Option<ffi::PyAsyncMethods> {
         None
-    }
-
-    default fn methods() -> Vec<PyMethodDef> {
-        Vec::new()
     }
 }
 
@@ -113,20 +107,6 @@ where
             am_aiter: Self::am_aiter(),
             am_anext: Self::am_anext(),
         })
-    }
-
-    #[inline]
-    fn methods() -> Vec<PyMethodDef> {
-        let mut methods = Vec::new();
-
-        if let Some(def) = <Self as PyAsyncAenterProtocolImpl>::__aenter__() {
-            methods.push(def)
-        }
-        if let Some(def) = <Self as PyAsyncAexitProtocolImpl>::__aexit__() {
-            methods.push(def)
-        }
-
-        methods
     }
 }
 
@@ -225,31 +205,5 @@ mod anext {
                 IterANextOutput
             )
         }
-    }
-}
-
-trait PyAsyncAenterProtocolImpl {
-    fn __aenter__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyAsyncAenterProtocolImpl for T
-where
-    T: PyAsyncProtocol<'p>,
-{
-    default fn __aenter__() -> Option<PyMethodDef> {
-        None
-    }
-}
-
-trait PyAsyncAexitProtocolImpl {
-    fn __aexit__() -> Option<PyMethodDef>;
-}
-
-impl<'p, T> PyAsyncAexitProtocolImpl for T
-where
-    T: PyAsyncProtocol<'p>,
-{
-    default fn __aexit__() -> Option<PyMethodDef> {
-        None
     }
 }

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -172,7 +172,7 @@ where
     // normal methods
     if !methods.is_empty() {
         methods.push(ffi::PyMethodDef_INIT);
-        type_object.tp_methods = Box::into_raw(methods.into_boxed_slice()) as *mut _;
+        type_object.tp_methods = Box::into_raw(methods.into_boxed_slice()) as _;
     }
 
     // class attributes
@@ -197,7 +197,7 @@ where
     }
     if !props.is_empty() {
         props.push(ffi::PyGetSetDef_INIT);
-        type_object.tp_getset = Box::into_raw(props.into_boxed_slice()) as *mut _;
+        type_object.tp_getset = Box::into_raw(props.into_boxed_slice()) as _;
     }
 
     // set type flags
@@ -264,31 +264,7 @@ fn py_class_method_defs<T: PyMethodsImpl>() -> (
         }
     }
 
-    for def in <T as class::basic::PyObjectProtocolImpl>::methods() {
-        defs.push(def.as_method_def());
-    }
-    for def in <T as class::context::PyContextProtocolImpl>::methods() {
-        defs.push(def.as_method_def());
-    }
-    for def in <T as class::mapping::PyMappingProtocolImpl>::methods() {
-        defs.push(def.as_method_def());
-    }
-    for def in <T as class::number::PyNumberProtocolImpl>::methods() {
-        defs.push(def.as_method_def());
-    }
-    for def in <T as class::descr::PyDescrProtocolImpl>::methods() {
-        defs.push(def.as_method_def());
-    }
-
-    py_class_async_methods::<T>(&mut defs);
-
     (new, call, defs, attrs)
-}
-
-fn py_class_async_methods<T>(defs: &mut Vec<ffi::PyMethodDef>) {
-    for def in <T as class::pyasync::PyAsyncProtocolImpl>::methods() {
-        defs.push(def.as_method_def());
-    }
 }
 
 fn py_class_properties<T: PyMethodsImpl>() -> Vec<ffi::PyGetSetDef> {

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -1,5 +1,3 @@
-#![feature(specialization)]
-
 use pyo3::class::basic::CompareOp;
 use pyo3::class::*;
 use pyo3::prelude::*;

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -1,5 +1,3 @@
-#![feature(specialization)]
-
 use pyo3::class::{
     PyContextProtocol, PyIterProtocol, PyMappingProtocol, PyObjectProtocol, PySequenceProtocol,
 };

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -1,4 +1,3 @@
-#![feature(specialization)]
 use std::collections::HashMap;
 
 use pyo3::exceptions::KeyError;


### PR DESCRIPTION
To reduce specialization.
We have two kinds of protocol methods.
1. Slot methods. We have to set these methods to the type object. E.g., we have to set `mp_length` to enable `len(obj)`.
2. Normal methods, called `PyMethods` in our proc-macro implementation. 

For the later one, we don't need to use specialization. We can use the same trick as `#[pymethods]`.

#897 should be merged before this PR.
I'll add CHANGELOG later to make rebasing easier.
