### PR TITLE
Clarify pyo3 version on issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -7,11 +7,12 @@ When reporting a bug, please provide the following information. If this is not a
  - Your operating system and version:
  - Your python version:
  - How did you install python (e.g. apt or pyenv)? Did you use a virtualenv?:
- - Your rust version (`rustc --version`):
- - Are you using the latest pyo3 version? Have you tried using latest master (replace `version = "0.x.y"` with `git = "https://github.com/PyO3/pyo3")?` 
+ - Your Rust version (`rustc --version`):
+ - Your PyO3 version:
+ - Have you tried using latest PyO3 master (replace `version = "0.x.y"` with `git = "https://github.com/PyO3/pyo3")?`:
 
 ### 💥 Reproducing
 
-Please provide a [minimal working example](https://stackoverflow.com/help/mcve). This means both the rust code and the python.
+Please provide a [minimal working example](https://stackoverflow.com/help/mcve). This means both the Rust code and the Python.
 
 Please also write what exact flags are required to reproduce your results.


### PR DESCRIPTION
When looking at old bug reports, it's hard to tell from a glance if they are still relevant because they don't list exactly the pyo3 version they relate to. So I have adjusted the list of requested information slightly so this is captured.