### PR TITLE
Revert #889

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -936,7 +936,7 @@ impl pyo3::class::methods::PyMethodsInventory for Pyo3MethodsInventoryForMyClass
         self.methods
     }
 }
-impl pyo3::class::methods::PyMethodsImpl for MyClass {
+impl pyo3::class::methods::HasMethodsInventory for MyClass {
     type Methods = Pyo3MethodsInventoryForMyClass;
 }
 pyo3::inventory::collect!(Pyo3MethodsInventoryForMyClass);

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -228,7 +228,7 @@ fn impl_methods_inventory(cls: &syn::Ident) -> TokenStream {
             }
         }
 
-        impl pyo3::class::methods::PyMethodsImpl for #cls {
+        impl pyo3::class::methods::HasMethodsInventory for #cls {
             type Methods = #inventory_cls;
         }
 
@@ -455,8 +455,8 @@ fn impl_descriptors(
     Ok(quote! {
         pyo3::inventory::submit! {
             #![crate = pyo3] {
-                type ClsInventory = <#cls as pyo3::class::methods::PyMethodsImpl>::Methods;
-                <ClsInventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(#py_methods),*])
+                type Inventory = <#cls as pyo3::class::methods::HasMethodsInventory>::Methods;
+                <Inventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(#py_methods),*])
             }
         }
     })

--- a/pyo3-derive-backend/src/pyimpl.rs
+++ b/pyo3-derive-backend/src/pyimpl.rs
@@ -42,8 +42,8 @@ pub fn impl_methods(ty: &syn::Type, impls: &mut Vec<syn::ImplItem>) -> syn::Resu
     Ok(quote! {
        pyo3::inventory::submit! {
             #![crate = pyo3] {
-                type TyInventory = <#ty as pyo3::class::methods::PyMethodsImpl>::Methods;
-                <TyInventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(
+                type Inventory = <#ty as pyo3::class::methods::HasMethodsInventory>::Methods;
+                <Inventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(
                     #(#cfg_attributes)*
                     #methods
                 ),*])

--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -98,8 +98,8 @@ fn impl_proto_impl(
     let inventory_submission = quote! {
         pyo3::inventory::submit! {
             #![crate = pyo3] {
-                type ProtoInventory = <#ty as pyo3::class::methods::PyMethodsImpl>::Methods;
-                <ProtoInventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(#py_methods),*])
+                type Inventory = <#ty as pyo3::class::methods::HasMethodsInventory>::Methods;
+                <Inventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(#py_methods),*])
             }
         }
     };

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -147,27 +147,28 @@ pub trait PyMethodsInventory: inventory::Collect {
     fn get(&self) -> &'static [PyMethodDefType];
 }
 
+#[doc(hidden)]
+#[cfg(feature = "macros")]
+pub trait HasMethodsInventory {
+    type Methods: PyMethodsInventory;
+}
+
 /// Implementation detail. Only to be used through the proc macros.
 /// For pyclass derived structs, this trait collects method from all impl blocks using inventory.
 #[doc(hidden)]
-#[cfg(feature = "macros")]
 pub trait PyMethodsImpl {
-    /// Normal methods. Mainly defined by `#[pymethod]`.
-    type Methods: PyMethodsInventory;
-
     /// Returns all methods that are defined for a class.
     fn py_methods() -> Vec<&'static PyMethodDefType> {
-        inventory::iter::<Self::Methods>
-            .into_iter()
-            .flat_map(PyMethodsInventory::get)
-            .collect()
+        Vec::new()
     }
 }
 
-#[doc(hidden)]
-#[cfg(not(feature = "macros"))]
-pub trait PyMethodsImpl {
+#[cfg(feature = "macros")]
+impl<T: HasMethodsInventory> PyMethodsImpl for T {
     fn py_methods() -> Vec<&'static PyMethodDefType> {
-        Vec::new()
+        inventory::iter::<T::Methods>
+            .into_iter()
+            .flat_map(PyMethodsInventory::get)
+            .collect()
     }
 }


### PR DESCRIPTION
rust-numpy has a stub implementation of `PyMethodsImpl`, so it should not require inventory storage by default.