### PR TITLE
Add nightly-optimizations feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Gate some optimizations needing specialization in a `nightly-optimizations` feature (disabled by default). [#927](https://github.com/PyO3/pyo3/pull/927)
 
 ## [0.10.0] - 2020-05-14
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,10 @@ python3 = []
 # so that the module can also be used with statically linked python interpreters.
 extension-module = []
 
+# Use this feature to enable optimizations only possible on nightly Rust.
+# (Dependent on specialization.)
+nightly-optimizations = []
+
 # The stable cpython abi as defined in PEP 384. Currently broken with
 # many compilation errors. Pull Requests working towards fixing that
 # are welcome.


### PR DESCRIPTION
Add a feature to gate the sequence implementations using buffer + specialization behind feature flag.

Questions: 
 - Should this feature be disabled or enabled by default?
 - How should we configure CI to test this feature?

TODO:
- [ ] I'd like to write some documentation about this feature before merge. Wanted to propose this feature before I spend too long writing docs.