### PR TITLE
Remove GetPropertyValue & improve property docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add FFI definition `PyObject_AsFileDescriptor` [#938](https://github.com/PyO3/pyo3/pull/938)
 
+### Changed
+- Simplify internals of `#[pyo3(get)]` attribute. (Remove the hidden API `GetPropertyValue`.) [#934](https://github.com/PyO3/pyo3/pull/934)
+
 ### Removed
 - Remove `ManagedPyRef` (unused, and needs specialization) [#930](https://github.com/PyO3/pyo3/pull/930)
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -309,8 +309,38 @@ impl SubClass {
 
 ## Object properties
 
-Property descriptor methods can be defined in a `#[pymethods]` `impl` block only and have to be
-annotated with `#[getter]` and `#[setter]` attributes. For example:
+PyO3 supports two ways to add properties to your `#[pyclass]`:
+- For simple fields with no side effects, a `#[pyo3(get, set)]` attribute can be added directly to the field definition in the `#[pyclass]`.
+- For properties which require computation you can define `#[getter]` and `#[setter]` functions in the `#[pymethods]` block.
+
+We'll cover each of these in the following sections.
+
+### Object properties using `#[pyo3(get, set)]`
+
+For simple cases where a member variable is just read and written with no side effects, you can declare getters and setters in your `#[pyclass]` field definition using the `pyo3` attribute, like in the example below:
+
+```rust
+# use pyo3::prelude::*;
+#[pyclass]
+struct MyClass {
+    #[pyo3(get, set)]
+    num: i32
+}
+```
+
+The above would make the `num` property available for reading and writing from Python code as `self.num`.
+
+Properties can be readonly or writeonly by using just `#[pyo3(get)]` or `#[pyo3(set)]` respectively.
+
+To use these annotations, your field type must implement some conversion traits:
+- For `get` the field type must implement both `IntoPy<PyObject>` and `Clone`.
+- For `set` the field type must implement `FromPyObject`.
+
+### Object properties using `#[getter]` and `#[setter]`
+
+For cases which don't satisfy the `#[pyo3(get, set)]` trait requirements, or need side effects, descriptor methods can be defined in a `#[pymethods]` `impl` block.
+
+This is done using the `#[getter]` and `#[setter]` attributes, like in the example below:
 
 ```rust
 # use pyo3::prelude::*;
@@ -385,20 +415,6 @@ impl MyClass {
 ```
 
 In this case, the property `number` is defined and available from Python code as `self.number`.
-
-For simple cases where a member variable is just read and written with no side effects, you
-can also declare getters and setters in your Rust struct field definition, for example:
-
-```rust
-# use pyo3::prelude::*;
-#[pyclass]
-struct MyClass {
-    #[pyo3(get, set)]
-    num: i32
-}
-```
-
-Then it is available from Python code as `self.num`.
 
 ## Instance methods
 

--- a/pyo3-derive-backend/src/pymethod.rs
+++ b/pyo3-derive-backend/src/pymethod.rs
@@ -310,8 +310,7 @@ pub(crate) fn impl_wrap_getter(
             (
                 name.unraw(),
                 quote!({
-                    use pyo3::derive_utils::GetPropertyValue;
-                    (&_slf.#name).get_property_value(_py)
+                    _slf.#name.clone()
                 }),
             )
         }

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -10,7 +10,7 @@ use crate::instance::PyNativeType;
 use crate::pyclass::PyClass;
 use crate::pyclass_init::PyClassInitializer;
 use crate::types::{PyAny, PyDict, PyModule, PyTuple};
-use crate::{ffi, GILPool, IntoPy, Py, PyCell, PyObject, Python};
+use crate::{ffi, GILPool, IntoPy, PyCell, PyObject, Python};
 use std::cell::UnsafeCell;
 
 /// Description of a python parameter; used for `parse_args()`.
@@ -192,32 +192,6 @@ impl<T: PyClass, I: Into<PyClassInitializer<T>>> IntoPyNewResult<T, I> for I {
 impl<T: PyClass, I: Into<PyClassInitializer<T>>> IntoPyNewResult<T, I> for PyResult<I> {
     fn into_pynew_result(self) -> PyResult<I> {
         self
-    }
-}
-
-#[doc(hidden)]
-pub trait GetPropertyValue {
-    fn get_property_value(&self, py: Python) -> PyObject;
-}
-
-impl<T> GetPropertyValue for &T
-where
-    T: IntoPy<PyObject> + Clone,
-{
-    fn get_property_value(&self, py: Python) -> PyObject {
-        (*self).clone().into_py(py)
-    }
-}
-
-impl GetPropertyValue for PyObject {
-    fn get_property_value(&self, py: Python) -> PyObject {
-        self.clone_ref(py)
-    }
-}
-
-impl<T> GetPropertyValue for Py<T> {
-    fn get_property_value(&self, py: Python) -> PyObject {
-        self.clone_ref(py).into()
     }
 }
 

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -141,8 +141,8 @@ fn empty_class_in_module() {
 
 #[pyclass]
 struct ClassWithObjectField {
-    // PyObject has special case for derive_utils::GetPropertyValue,
-    // so this test is making sure it compiles!
+    // It used to be that PyObject was not supported with (get, set)
+    // - this test is just ensuring it compiles.
     #[pyo3(get, set)]
     value: PyObject,
 }


### PR DESCRIPTION
Now that we have `Clone` for `PyObject` and `Py<T>`, we don't need `GetPropertyValue` any more, so this cleans that up.

At the same time I also:
- Added a test for `Vec<PyObject>` with `#[pyo3(get)]`  (which was broken in `0.9.2`, see #903)
- Improved documentation for `#[pyo3(get, set)]`.

This is all internal refactoring so I think this can be merged without blocking us from making another patch release for `0.10.x` if necessary.

Closes #903