### PR TITLE
compile_error test for PyClass: Send

### DIFF
--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -6,6 +6,7 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_pyclass_args.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
     t.compile_fail("tests/ui/missing_clone.rs");
+    t.compile_fail("tests/ui/pyclass_send.rs");
     t.compile_fail("tests/ui/reject_generics.rs");
     t.compile_fail("tests/ui/wrong_aspyref_lifetimes.rs");
     // Since the current minimum nightly(2020-01-20) has a different error message,

--- a/tests/ui/pyclass_send.rs
+++ b/tests/ui/pyclass_send.rs
@@ -1,0 +1,25 @@
+use pyo3::prelude::*;
+use std::rc::Rc;
+
+#[pyclass]
+struct NotThreadSafe {
+    data: Rc<i32>
+}
+
+fn main() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let obj = PyCell::new(py, NotThreadSafe { data: Rc::new(5) }).unwrap().to_object(py);
+    drop(gil);
+
+    std::thread::spawn(move || {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        // Uh oh, moved Rc to a new thread!
+        let c: &PyCell<NotThreadSafe> = obj.as_ref(py).downcast().unwrap();
+
+        assert_eq!(*c.borrow().data, 5);
+    }).join().unwrap();
+}

--- a/tests/ui/pyclass_send.stderr
+++ b/tests/ui/pyclass_send.stderr
@@ -1,0 +1,14 @@
+error[E0277]: `std::rc::Rc<i32>` cannot be sent between threads safely
+  --> $DIR/pyclass_send.rs:4:1
+   |
+4  | #[pyclass]
+   | ^^^^^^^^^^ `std::rc::Rc<i32>` cannot be sent between threads safely
+   |
+  ::: $WORKSPACE/src/pyclass.rs:76:76
+   |
+76 |     PyTypeInfo<Layout = PyCell<Self>> + Sized + PyClassAlloc + PyMethods + Send
+   |                                                                            ---- required by this bound in `pyo3::pyclass::PyClass`
+   |
+   = help: within `NotThreadSafe`, the trait `std::marker::Send` is not implemented for `std::rc::Rc<i32>`
+   = note: required because it appears within the type `NotThreadSafe`
+   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
I realised that we have to require `Send` + `Sync` for `#[pyclass]`.

Otherwise we violate Rust's thread safety by allowing things like `Rc<RefCell<T>>` to cross between threads, which isn't good!