### PR TITLE
Rename PyMethodsImpl -> PyMethods

### DIFF
--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -134,7 +134,16 @@ impl PySetterDef {
     }
 }
 
-/// Implementation detail. Only to be used through the proc macros.
+/// Indicates that the type `T` has some Python methods.
+pub trait PyMethods {
+    /// Returns all methods that are defined for a class.
+    fn py_methods() -> Vec<&'static PyMethodDefType> {
+        Vec::new()
+    }
+}
+
+/// Implementation detail. Only to be used through our proc macro code.
+/// Method storage for `#[pyclass]`.
 /// Allows arbitrary `#[pymethod]/#[pyproto]` blocks to submit their methods,
 /// which are eventually collected by `#[pyclass]`.
 #[doc(hidden)]
@@ -147,24 +156,16 @@ pub trait PyMethodsInventory: inventory::Collect {
     fn get(&self) -> &'static [PyMethodDefType];
 }
 
+/// Implemented for `#[pyclass]` in our proc macro code.
+/// Indicates that the pyclass has its own method storage.
 #[doc(hidden)]
 #[cfg(feature = "macros")]
 pub trait HasMethodsInventory {
     type Methods: PyMethodsInventory;
 }
 
-/// Implementation detail. Only to be used through the proc macros.
-/// For pyclass derived structs, this trait collects method from all impl blocks using inventory.
-#[doc(hidden)]
-pub trait PyMethodsImpl {
-    /// Returns all methods that are defined for a class.
-    fn py_methods() -> Vec<&'static PyMethodDefType> {
-        Vec::new()
-    }
-}
-
 #[cfg(feature = "macros")]
-impl<T: HasMethodsInventory> PyMethodsImpl for T {
+impl<T: HasMethodsInventory> PyMethods for T {
     fn py_methods() -> Vec<&'static PyMethodDefType> {
         inventory::iter::<T::Methods>
             .into_iter()

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -1,5 +1,5 @@
 //! `PyClass` trait
-use crate::class::methods::{PyClassAttributeDef, PyMethodDefType, PyMethodsImpl};
+use crate::class::methods::{PyClassAttributeDef, PyMethodDefType, PyMethods};
 use crate::conversion::{IntoPyPointer, ToPyObject};
 use crate::pyclass_slots::{PyClassDict, PyClassWeakRef};
 use crate::type_object::{type_flags, PyLayout};
@@ -72,9 +72,7 @@ pub unsafe fn tp_free_fallback(obj: *mut ffi::PyObject) {
 ///
 /// The `#[pyclass]` attribute automatically implements this trait for your Rust struct,
 /// so you don't have to use this trait directly.
-pub trait PyClass:
-    PyTypeInfo<Layout = PyCell<Self>> + Sized + PyClassAlloc + PyMethodsImpl
-{
+pub trait PyClass: PyTypeInfo<Layout = PyCell<Self>> + Sized + PyClassAlloc + PyMethods {
     /// Specify this class has `#[pyclass(dict)]` or not.
     type Dict: PyClassDict;
     /// Specify this class has `#[pyclass(weakref)]` or not.
@@ -227,7 +225,7 @@ fn py_class_flags<T: PyTypeInfo>(type_object: &mut ffi::PyTypeObject) {
     }
 }
 
-fn py_class_method_defs<T: PyMethodsImpl>() -> (
+fn py_class_method_defs<T: PyMethods>() -> (
     Option<ffi::newfunc>,
     Option<ffi::PyCFunctionWithKeywords>,
     Vec<ffi::PyMethodDef>,
@@ -267,7 +265,7 @@ fn py_class_method_defs<T: PyMethodsImpl>() -> (
     (new, call, defs, attrs)
 }
 
-fn py_class_properties<T: PyMethodsImpl>() -> Vec<ffi::PyGetSetDef> {
+fn py_class_properties<T: PyMethods>() -> Vec<ffi::PyGetSetDef> {
     let mut defs = std::collections::HashMap::new();
 
     for def in T::py_methods() {


### PR DESCRIPTION
As I'll introduce `PyProtoMethods`, I renamed `PyMethodsImple` for consistent naming.
