### PR TITLE
Small cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ clippy:
 	@touch src/lib.rs  # Touching file to ensure that cargo clippy will re-check the project
 	cargo clippy --all-features --all-targets -- \
 		$(addprefix -D ,${CLIPPY_LINTS_TO_DENY})
+	for example in examples/*; do (cd $$example/; cargo clippy) || exit 1; done
 
 lint: fmt clippy
 	@true

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,14 @@
-.PHONY: test test_py3 publish clippy lint fmt
+.PHONY: test test_py publish clippy lint fmt
 
 # Constant used in clippy target
 CLIPPY_LINTS_TO_DENY := warnings
 
-test:
+test: lint test_py
 	cargo test
-	${MAKE} clippy
-	tox
-	for example in examples/*; do tox -e py -c $$example/tox.ini || exit 1; done
 
-test_py3:
-	tox -e py3
-	for example in examples/*; do tox -e py3 -c $$example/tox.ini || exit 1; done
+test_py:
+	tox -e py
+	for example in examples/*; do tox -e py -c $$example/tox.ini || exit 1; done
 
 fmt:
 	cargo fmt --all -- --check

--- a/examples/rustapi_module/src/datetime.rs
+++ b/examples/rustapi_module/src/datetime.rs
@@ -114,6 +114,7 @@ fn get_delta_tuple<'p>(py: Python<'p>, delta: &PyDelta) -> &'p PyTuple {
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 #[pyfunction]
 fn make_datetime<'p>(
     py: Python<'p>,

--- a/examples/word-count/src/lib.rs
+++ b/examples/word-count/src/lib.rs
@@ -59,7 +59,7 @@ fn matches(word: &str, needle: &str) -> bool {
             }
         }
     }
-    return needle.next().is_none();
+    needle.next().is_none()
 }
 
 /// Count the occurences of needle in line, case insensitive

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -613,6 +613,7 @@ mod test {
         // Move obj to a thread which does not have the GIL, and clone it
         let t = std::thread::spawn(move || {
             // Cloning without GIL should not update reference count
+            #[allow(clippy::redundant_clone)]
             let _ = obj.clone();
             assert_eq!(count, obj.get_refcnt());
 

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -1,5 +1,4 @@
 //! Test slf: PyRef/PyMutRef<Self>(especially, slf.into::<Py>) works
-use pyo3;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
 use pyo3::{AsPyRef, PyCell, PyIterProtocol};


### PR DESCRIPTION
- Small cleanup of Makefile to reuse targets
- Also check examples when running make clippy
- Fix or ignore clippy lints