### PR TITLE
User Guide: Rewrite parallelism chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ about this topic.
 
 ## Examples
 
- * [examples/word-count](examples/word-count) _Counting the occurrences of a word in a text file_
  * [hyperjson](https://github.com/mre/hyperjson) _A hyper-fast Python module for reading/writing JSON data using Rust's serde-json_
  * [html-py-ever](https://github.com/PyO3/setuptools-rust/tree/master/html-py-ever) _Using [html5ever](https://github.com/servo/html5ever) through [kuchiki](https://github.com/kuchiki-rs/kuchiki) to speed up html parsing and css-selecting._
  * [point-process](https://github.com/ManifoldFR/point-process-rust/tree/master/pylib) _High level API for pointprocesses as a Python library_

--- a/examples/word-count/setup.py
+++ b/examples/word-count/setup.py
@@ -82,7 +82,7 @@ setup(
         "Operating System :: MacOS :: MacOS X",
     ],
     packages=["word_count"],
-    rust_extensions=[RustExtension("word_count.word_count", "Cargo.toml", debug=True)],
+    rust_extensions=[RustExtension("word_count.word_count", "Cargo.toml", debug=False)],
     install_requires=install_requires,
     tests_require=tests_require,
     setup_requires=setup_requires,

--- a/examples/word-count/src/lib.rs
+++ b/examples/word-count/src/lib.rs
@@ -42,7 +42,6 @@ fn matches(word: &str, needle: &str) -> bool {
 }
 
 /// Count the occurences of needle in line, case insensitive
-#[pyfunction]
 fn count_line(line: &str, needle: &str) -> usize {
     let mut total = 0;
     for word in line.split(' ') {
@@ -55,7 +54,6 @@ fn count_line(line: &str, needle: &str) -> usize {
 
 #[pymodule]
 fn word_count(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(count_line))?;
     m.add_wrapped(wrap_pyfunction!(search))?;
     m.add_wrapped(wrap_pyfunction!(search_sequential))?;
 

--- a/examples/word-count/src/lib.rs
+++ b/examples/word-count/src/lib.rs
@@ -7,11 +7,11 @@ use rayon::prelude::*;
 
 /// Searches for the word, parallelized by rayon
 #[pyfunction]
-fn search(py: Python<'_>, contents: &str, search: String) -> PyResult<usize> {
+fn search(py: Python<'_>, contents: &str, needle: &str) -> PyResult<usize> {
     let count = py.allow_threads(move || {
         contents
             .par_lines()
-            .map(|line| count_line(line, &search))
+            .map(|line| count_line(line, needle))
             .sum()
     });
     Ok(count)
@@ -19,8 +19,8 @@ fn search(py: Python<'_>, contents: &str, search: String) -> PyResult<usize> {
 
 /// Searches for a word in a classic sequential fashion
 #[pyfunction]
-fn search_sequential(contents: &str, needle: String) -> PyResult<usize> {
-    let result = contents.lines().map(|line| count_line(line, &needle)).sum();
+fn search_sequential(contents: &str, needle: &str) -> PyResult<usize> {
+    let result = contents.lines().map(|line| count_line(line, needle)).sum();
     Ok(result)
 }
 

--- a/examples/word-count/tests/test_word_count.py
+++ b/examples/word-count/tests/test_word_count.py
@@ -8,8 +8,8 @@ current_dir = os.path.abspath(os.path.dirname(__file__))
 path = os.path.join(current_dir, "zen-of-python.txt")
 
 
-@pytest.fixture(scope="session", autouse=True)
-def textfile():
+@pytest.fixture(scope="session")
+def contents() -> str:
     text = """
 The Zen of Python, by Tim Peters
 
@@ -33,23 +33,19 @@ If the implementation is hard to explain, it's a bad idea.
 If the implementation is easy to explain, it may be a good idea.
 Namespaces are one honking great idea -- let's do more of those!
 """
-
-    with open(path, "w") as f:
-        f.write(text * 1000)
-    yield
-    os.remove(path)
+    return text * 1000
 
 
-def test_word_count_rust_parallel(benchmark):
-    count = benchmark(word_count.WordCounter(path).search, "is")
+def test_word_count_rust_parallel(benchmark, contents):
+    count = benchmark(word_count.search, contents, "is")
     assert count == 10000
 
 
-def test_word_count_rust_sequential(benchmark):
-    count = benchmark(word_count.WordCounter(path).search_sequential, "is")
+def test_word_count_rust_sequential(benchmark, contents):
+    count = benchmark(word_count.search_sequential, contents, "is")
     assert count == 10000
 
 
-def test_word_count_python_sequential(benchmark):
-    count = benchmark(word_count.search_py, path, "is")
+def test_word_count_python_sequential(benchmark, contents):
+    count = benchmark(word_count.search_py, contents, "is")
     assert count == 10000

--- a/examples/word-count/word_count/__init__.py
+++ b/examples/word-count/word_count/__init__.py
@@ -1,14 +1,13 @@
-from .word_count import WordCounter, count_line
+from .word_count import count_line, search, search_sequential
 
-__all__ = ["WordCounter", "count_line", "search_py"]
+__all__ = ["count_line", "search_py", "search", "search_sequential"]
 
 
-def search_py(path, needle):
+def search_py(contents, needle):
     total = 0
-    with open(path, "r") as f:
-        for line in f:
-            words = line.split(" ")
-            for word in words:
-                if word == needle:
-                    total += 1
+    for line in contents.split():
+        words = line.split(" ")
+        for word in words:
+            if word == needle:
+                total += 1
     return total

--- a/examples/word-count/word_count/__init__.py
+++ b/examples/word-count/word_count/__init__.py
@@ -1,6 +1,6 @@
-from .word_count import count_line, search, search_sequential
+from .word_count import search, search_sequential
 
-__all__ = ["count_line", "search_py", "search", "search_sequential"]
+__all__ = ["search_py", "search", "search_sequential"]
 
 
 def search_py(contents, needle):

--- a/examples/word-count/word_count/__init__.py
+++ b/examples/word-count/word_count/__init__.py
@@ -1,6 +1,11 @@
-from .word_count import search, search_sequential
+from .word_count import search, search_sequential, search_sequential_allow_threads
 
-__all__ = ["search_py", "search", "search_sequential"]
+__all__ = [
+    "search_py",
+    "search",
+    "search_sequential",
+    "search_sequential_allow_threads",
+]
 
 
 def search_py(contents, needle):

--- a/guide/src/get_started.md
+++ b/guide/src/get_started.md
@@ -132,7 +132,6 @@ about this topic.
 
 ## Examples
 
- * [examples/word-count](examples/word-count) _Counting the occurrences of a word in a text file_
  * [hyperjson](https://github.com/mre/hyperjson) _A hyper-fast Python module for reading/writing JSON data using Rust's serde-json_
  * [html-py-ever](https://github.com/PyO3/setuptools-rust/tree/master/html-py-ever) _Using [html5ever](https://github.com/servo/html5ever) through [kuchiki](https://github.com/kuchiki-rs/kuchiki) to speed up html parsing and css-selecting._
  * [point-process](https://github.com/ManifoldFR/point-process-rust/tree/master/pylib) _High level API for pointprocesses as a Python library_

--- a/guide/src/parallelism.md
+++ b/guide/src/parallelism.md
@@ -1,6 +1,6 @@
 # Parallelism
 
-CPython has the infamous [Global Interpreter Lock](https://docs.python.org/3/glossary.html#term-global-interpreter-lock), which prevent that several threads can execute Python code in parallel. This makes threading in Python a bad fit for [CPU-bound](https://stackoverflow.com/questions/868568/) tasks and often forces developers to accept the overhead of multiprocessing.
+CPython has the infamous [Global Interpreter Lock](https://docs.python.org/3/glossary.html#term-global-interpreter-lock), which prevents that several threads can execute Python code in parallel. This makes threading in Python a bad fit for [CPU-bound](https://stackoverflow.com/questions/868568/) tasks and often forces developers to accept the overhead of multiprocessing.
 
 In PyO3 parallelism can be easily achieved in Rust-only code. Let's take a look at our [word-count](https://github.com/PyO3/pyo3/blob/master/examples/word-count/src/lib.rs) example, where we have a `search` function that utilizes the [rayon](https://github.com/nikomatsakis/rayon) crate to count words in parallel.
 ```rust
@@ -70,6 +70,6 @@ test_word_count_python_sequential                      27.3985 (15.82)    45.452
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
-You can see that the Python threaded version is not much slower than the Rust sequential version, which means compared to an execution on a single CPU-core the speed has doubled.
+You can see that the Python threaded version is not much slower than the Rust sequential version, which means compared to an execution on a single CPU core the speed has doubled.
 
 [`Python::allow_threads`]: https://docs.rs/pyo3/latest/pyo3/struct.Python.html#method.allow_threads

--- a/guide/src/parallelism.md
+++ b/guide/src/parallelism.md
@@ -1,6 +1,6 @@
 # Parallelism
 
-CPython has the infamous [Global Interpreter Lock](https://docs.python.org/3/glossary.html#term-global-interpreter-lock), which prevents that several threads can execute Python code in parallel. This makes threading in Python a bad fit for [CPU-bound](https://stackoverflow.com/questions/868568/) tasks and often forces developers to accept the overhead of multiprocessing.
+CPython has the infamous [Global Interpreter Lock](https://docs.python.org/3/glossary.html#term-global-interpreter-lock), which prevents several threads from executing Python bytecode in parallel. This makes threading in Python a bad fit for [CPU-bound](https://stackoverflow.com/questions/868568/) tasks and often forces developers to accept the overhead of multiprocessing.
 
 In PyO3 parallelism can be easily achieved in Rust-only code. Let's take a look at our [word-count](https://github.com/PyO3/pyo3/blob/master/examples/word-count/src/lib.rs) example, where we have a `search` function that utilizes the [rayon](https://github.com/nikomatsakis/rayon) crate to count words in parallel.
 ```rust, ignore


### PR DESCRIPTION
I took a stab at rewriting the parallelism chapter because it seemed to suggest that you need to release the GIL in order to achieve parallelism within your Rust code and that `allow_threads` enables running of Python code in parallel. See #640 and #649 for discussion and thanks @Askannz for the nice example which I included.

Also included the previous PR #957 to make the benchmarks more comparable.

Closes #956 