### PR TITLE
Object protocols without specialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Change return type of `PyTuple::as_slice` to `&[&PyAny]`. [#971](https://github.com/PyO3/pyo3/pull/971)
 - Update `num-complex` optional dependendency from `0.2` to `0.3`. [#977](https://github.com/PyO3/pyo3/pull/977)
 - Update `num-bigint` optional dependendency from `0.2` to `0.3`. [#978](https://github.com/PyO3/pyo3/pull/978)
+- `#[pyproto]` is re-implemented without specialization. [#961](https://github.com/PyO3/pyo3/pull/961)
 
 ### Removed
 - Remove `ManagedPyRef` (unused, and needs specialization) [#930](https://github.com/PyO3/pyo3/pull/930)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ travis-ci = { repository = "PyO3/pyo3", branch = "master" }
 appveyor = { repository = "fafhrd91/pyo3" }
 
 [dependencies]
+ctor = { version = "0.1", optional = true }
 indoc = { version = "0.3.4", optional = true }
 inventory = { version = "0.1.4", optional = true }
 libc = "0.2.62"
@@ -38,7 +39,7 @@ version_check = "0.9.1"
 
 [features]
 default = ["macros"]
-macros = ["indoc", "inventory", "paste", "pyo3cls", "unindent"]
+macros = ["ctor", "indoc", "inventory", "paste", "pyo3cls", "unindent"]
 
 # this is no longer needed internally, but setuptools-rust assumes this feature
 python3 = []

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -957,7 +957,7 @@ impl pyo3::class::methods::HasMethodsInventory for MyClass {
 pyo3::inventory::collect!(Pyo3MethodsInventoryForMyClass);
 
 impl pyo3::class::proto_methods::HasProtoRegistry for MyClass {
-    fn registory() -> &'static pyo3::class::proto_methods::PyProtoRegistry {
+    fn registry() -> &'static pyo3::class::proto_methods::PyProtoRegistry {
         static REGISTRY: pyo3::class::proto_methods::PyProtoRegistry
             = pyo3::class::proto_methods::PyProtoRegistry::new();
         &REGISTRY

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -955,6 +955,14 @@ impl pyo3::class::methods::HasMethodsInventory for MyClass {
     type Methods = Pyo3MethodsInventoryForMyClass;
 }
 pyo3::inventory::collect!(Pyo3MethodsInventoryForMyClass);
+
+impl pyo3::class::proto_methods::HasProtoRegistry for MyClass {
+    fn registory() -> &'static pyo3::class::proto_methods::PyProtoRegistry {
+        static REGISTRY: pyo3::class::proto_methods::PyProtoRegistry
+            = pyo3::class::proto_methods::PyProtoRegistry::new();
+        &REGISTRY
+    }
+}
 # let gil = Python::acquire_gil();
 # let py = gil.python();
 # let cls = py.get_type::<MyClass>();

--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -284,18 +284,20 @@ pub const DESCR: Proto = Proto {
     slot_table: "pyo3::class::descr::PyDescrMethods",
     set_slot_table: "set_descr_methods",
     methods: &[
-        MethodProto::Ternary {
+        MethodProto::TernaryS {
             name: "__get__",
-            arg1: "Inst",
-            arg2: "Owner",
+            arg1: "Receiver",
+            arg2: "Inst",
+            arg3: "Owner",
             pyres: true,
             proto: "pyo3::class::descr::PyDescrGetProtocol",
         },
-        MethodProto::Ternary {
+        MethodProto::TernaryS {
             name: "__set__",
-            arg1: "Inst",
-            arg2: "Value",
-            pyres: true,
+            arg1: "Receiver",
+            arg2: "Inst",
+            arg3: "Value",
+            pyres: false,
             proto: "pyo3::class::descr::PyDescrSetProtocol",
         },
         MethodProto::Binary {

--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -147,8 +147,8 @@ pub const OBJECT: Proto = Proto {
 
 pub const ASYNC: Proto = Proto {
     name: "Async",
-    slot_table: "",
-    set_slot_table: "",
+    slot_table: "pyo3::ffi::PyAsyncMethods",
+    set_slot_table: "set_async_methods",
     methods: &[
         MethodProto::Unary {
             name: "__await__",
@@ -188,7 +188,11 @@ pub const ASYNC: Proto = Proto {
             "pyo3::class::pyasync::PyAsyncAexitProtocolImpl",
         ),
     ],
-    slot_setters: &[],
+    slot_setters: &[
+        SlotSetter::new(&["__await__"], "set_await"),
+        SlotSetter::new(&["__aiter__"], "set_aiter"),
+        SlotSetter::new(&["__anext__"], "set_anext"),
+    ],
 };
 
 pub const BUFFER: Proto = Proto {
@@ -390,8 +394,8 @@ pub const MAPPING: Proto = Proto {
 
 pub const SEQ: Proto = Proto {
     name: "Sequence",
-    slot_table: "",
-    set_slot_table: "",
+    slot_table: "pyo3::ffi::PySequenceMethods",
+    set_slot_table: "set_sequence_methods",
     methods: &[
         MethodProto::Unary {
             name: "__len__",
@@ -449,7 +453,22 @@ pub const SEQ: Proto = Proto {
         },
     ],
     py_methods: &[],
-    slot_setters: &[],
+    slot_setters: &[
+        SlotSetter::new(&["__len__"], "set_len"),
+        SlotSetter::new(&["__concat__"], "set_concat"),
+        SlotSetter::new(&["__repeat__"], "set_repeat"),
+        SlotSetter::new(&["__getitem__"], "set_getitem"),
+        SlotSetter {
+            proto_names: &["__setitem__", "__delitem__"],
+            set_function: "set_setdelitem",
+            skipped_setters: &["set_setitem", "set_delitem"],
+        },
+        SlotSetter::new(&["__setitem__"], "set_setitem"),
+        SlotSetter::new(&["__delitem__"], "set_delitem"),
+        SlotSetter::new(&["__contains__"], "set_contains"),
+        SlotSetter::new(&["__inplace_concat__"], "set_inplace_concat"),
+        SlotSetter::new(&["__inplace_repeat__"], "set_inplace_repeat"),
+    ],
 };
 
 pub const NUM: Proto = Proto {

--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -1,12 +1,19 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 use crate::func::MethodProto;
 
+/// Predicates for `#[pyproto]`.
 pub struct Proto {
+    /// The name of this protocol. E.g., Iter.
     pub name: &'static str,
+    /// The name of slot table. E.g., PyIterMethods.
     pub slot_table: &'static str,
+    /// The name of the setter used to set the table to `PyProtoRegistry`.
     pub set_slot_table: &'static str,
+    /// All methods.
     pub methods: &'static [MethodProto],
+    /// All methods registered as normal methods like `#[pymethods]`.
     pub py_methods: &'static [PyMethod],
+    /// All methods registered to the slot table.
     pub slot_setters: &'static [SlotSetter],
 }
 
@@ -25,6 +32,7 @@ impl Proto {
     }
 }
 
+/// Represents a method registered as a normal method like `#[pymethods]`.
 // TODO(kngwyu): Currently only __radd__-like methods use METH_COEXIST to prevent
 // __add__-like methods from overriding them.
 pub struct PyMethod {
@@ -50,9 +58,15 @@ impl PyMethod {
     }
 }
 
+/// Represents a setter used to register a method to the method table.
 pub struct SlotSetter {
+    /// Protocols necessary for invoking this setter.
+    /// E.g., we need `__setattr__` and `__delattr__` for invoking `set_setdelitem`.
     pub proto_names: &'static [&'static str],
+    /// The name of the setter called to the method table.
     pub set_function: &'static str,
+    /// Represents a set of setters disabled by this setter.
+    /// E.g., `set_setdelitem` have to disable `set_setitem` and `set_delitem`.
     pub skipped_setters: &'static [&'static str],
 }
 

--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -156,18 +156,21 @@ pub const ASYNC: Proto = Proto {
     slot_table: "pyo3::ffi::PyAsyncMethods",
     set_slot_table: "set_async_methods",
     methods: &[
-        MethodProto::Unary {
+        MethodProto::UnaryS {
             name: "__await__",
+            arg: "Receiver",
             pyres: true,
             proto: "pyo3::class::pyasync::PyAsyncAwaitProtocol",
         },
-        MethodProto::Unary {
+        MethodProto::UnaryS {
             name: "__aiter__",
+            arg: "Receiver",
             pyres: true,
             proto: "pyo3::class::pyasync::PyAsyncAiterProtocol",
         },
-        MethodProto::Unary {
+        MethodProto::UnaryS {
             name: "__anext__",
+            arg: "Receiver",
             pyres: true,
             proto: "pyo3::class::pyasync::PyAsyncAnextProtocol",
         },

--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -123,6 +123,11 @@ pub const OBJECT: Proto = Proto {
             pyres: true,
             proto: "pyo3::class::basic::PyObjectRichcmpProtocol",
         },
+        MethodProto::Unary {
+            name: "__bool__",
+            pyres: false,
+            proto: "pyo3::class::basic::PyObjectBoolProtocol",
+        },
     ],
     py_methods: &[
         PyMethod::new("__format__", "pyo3::class::basic::FormatProtocolImpl"),
@@ -142,6 +147,7 @@ pub const OBJECT: Proto = Proto {
         },
         SlotSetter::new(&["__setattr__"], "set_setattr"),
         SlotSetter::new(&["__delattr__"], "set_delattr"),
+        SlotSetter::new(&["__bool__"], "set_bool"),
     ],
 };
 
@@ -784,11 +790,6 @@ pub const NUM: Proto = Proto {
             pyres: true,
             proto: "pyo3::class::number::PyNumberRoundProtocol",
         },
-        MethodProto::Unary {
-            name: "__bool__",
-            pyres: false,
-            proto: "pyo3::class::number::PyNumberBoolProtocol",
-        },
     ],
     py_methods: &[
         PyMethod::coexist("__radd__", "pyo3::class::number::PyNumberRAddProtocolImpl"),
@@ -867,7 +868,6 @@ pub const NUM: Proto = Proto {
         SlotSetter::new(&["__neg__"], "set_neg"),
         SlotSetter::new(&["__pos__"], "set_pos"),
         SlotSetter::new(&["__abs__"], "set_abs"),
-        SlotSetter::new(&["__bool__"], "set_bool"),
         SlotSetter::new(&["__invert__"], "set_invert"),
         SlotSetter::new(&["__rdivmod__"], "set_rdivmod"),
         SlotSetter {

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -237,10 +237,10 @@ fn impl_methods_inventory(cls: &syn::Ident) -> TokenStream {
 }
 
 /// TODO(kngwyu): doc
-fn impl_proto_registory(cls: &syn::Ident) -> TokenStream {
+fn impl_proto_registry(cls: &syn::Ident) -> TokenStream {
     quote! {
         impl pyo3::class::proto_methods::HasProtoRegistry for #cls {
-            fn registory() -> &'static pyo3::class::proto_methods::PyProtoRegistry {
+            fn registry() -> &'static pyo3::class::proto_methods::PyProtoRegistry {
                 static REGISTRY: pyo3::class::proto_methods::PyProtoRegistry
                     = pyo3::class::proto_methods::PyProtoRegistry::new();
                 &REGISTRY
@@ -353,7 +353,7 @@ fn impl_class(
     };
 
     let impl_inventory = impl_methods_inventory(&cls);
-    let impl_proto_registory = impl_proto_registory(&cls);
+    let impl_proto_registry = impl_proto_registry(&cls);
 
     let base = &attr.base;
     let flags = &attr.flags;
@@ -428,7 +428,7 @@ fn impl_class(
 
         #impl_inventory
 
-        #impl_proto_registory
+        #impl_proto_registry
 
         #extra
 

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -236,6 +236,19 @@ fn impl_methods_inventory(cls: &syn::Ident) -> TokenStream {
     }
 }
 
+/// TODO(kngwyu): doc
+fn impl_proto_registory(cls: &syn::Ident) -> TokenStream {
+    quote! {
+        impl pyo3::class::proto_methods::HasPyProtoRegistry for #cls {
+            fn registory() -> &'static pyo3::class::proto_methods::PyProtoRegistry {
+                static REGISTRY: pyo3::class::proto_methods::PyProtoRegistry
+                    = pyo3::class::proto_methods::PyProtoRegistry::new();
+                &REGISTRY
+            }
+        }
+    }
+}
+
 fn get_class_python_name(cls: &syn::Ident, attr: &PyClassArgs) -> TokenStream {
     match &attr.name {
         Some(name) => quote! { #name },
@@ -340,6 +353,7 @@ fn impl_class(
     };
 
     let impl_inventory = impl_methods_inventory(&cls);
+    let impl_proto_registory = impl_proto_registory(&cls);
 
     let base = &attr.base;
     let flags = &attr.flags;
@@ -413,6 +427,8 @@ fn impl_class(
         #into_pyobject
 
         #impl_inventory
+
+        #impl_proto_registory
 
         #extra
 

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -239,7 +239,7 @@ fn impl_methods_inventory(cls: &syn::Ident) -> TokenStream {
 /// TODO(kngwyu): doc
 fn impl_proto_registory(cls: &syn::Ident) -> TokenStream {
     quote! {
-        impl pyo3::class::proto_methods::HasPyProtoRegistry for #cls {
+        impl pyo3::class::proto_methods::HasProtoRegistry for #cls {
             fn registory() -> &'static pyo3::class::proto_methods::PyProtoRegistry {
                 static REGISTRY: pyo3::class::proto_methods::PyProtoRegistry
                     = pyo3::class::proto_methods::PyProtoRegistry::new();

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -236,7 +236,7 @@ fn impl_methods_inventory(cls: &syn::Ident) -> TokenStream {
     }
 }
 
-/// TODO(kngwyu): doc
+/// Implement `HasProtoRegistry` for the class for lazy protocol initialization.
 fn impl_proto_registry(cls: &syn::Ident) -> TokenStream {
     quote! {
         impl pyo3::class::proto_methods::HasProtoRegistry for #cls {

--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -4,9 +4,10 @@ use crate::defs;
 use crate::func::impl_method_proto;
 use crate::method::FnSpec;
 use crate::pymethod;
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use quote::ToTokens;
+use std::collections::HashSet;
 
 pub fn build_py_proto(ast: &mut syn::ItemImpl) -> syn::Result<TokenStream> {
     if let Some((_, ref mut path, _)) = ast.trait_ {
@@ -60,12 +61,17 @@ fn impl_proto_impl(
 ) -> syn::Result<TokenStream> {
     let mut trait_impls = TokenStream::new();
     let mut py_methods = Vec::new();
+    let mut method_names = HashSet::new();
 
     for iimpl in impls.iter_mut() {
         if let syn::ImplItem::Method(ref mut met) = iimpl {
+            // impl Py~Protocol<'p> { type = ... }
             if let Some(m) = proto.get_proto(&met.sig.ident) {
                 impl_method_proto(ty, &mut met.sig, m).to_tokens(&mut trait_impls);
+                // Insert the method to the HashSet
+                method_names.insert(met.sig.ident.to_string());
             }
+            // Add non-slot methods to inventory slots
             if let Some(m) = proto.get_method(&met.sig.ident) {
                 let name = &met.sig.ident;
                 let fn_spec = FnSpec::parse(&met.sig, &mut met.attrs, false)?;
@@ -76,7 +82,7 @@ fn impl_proto_impl(
                 } else {
                     quote!(0)
                 };
-                // TODO(kngwyu): doc
+                // TODO(kngwyu): ml_doc
                 py_methods.push(quote! {
                     pyo3::class::PyMethodDefType::Method({
                         #method
@@ -91,20 +97,77 @@ fn impl_proto_impl(
             }
         }
     }
+    let inventory_submission = inventory_submission(py_methods, ty);
+    let slot_initialization = slot_initialization(method_names, ty, proto)?;
+    Ok(quote! {
+        #trait_impls
+        #inventory_submission
+        #slot_initialization
+    })
+}
 
+fn inventory_submission(py_methods: Vec<TokenStream>, ty: &syn::Type) -> TokenStream {
     if py_methods.is_empty() {
-        return Ok(quote! { #trait_impls });
+        return quote! {};
     }
-    let inventory_submission = quote! {
+    quote! {
         pyo3::inventory::submit! {
             #![crate = pyo3] {
                 type Inventory = <#ty as pyo3::class::methods::HasMethodsInventory>::Methods;
                 <Inventory as pyo3::class::methods::PyMethodsInventory>::new(&[#(#py_methods),*])
             }
         }
-    };
+    }
+}
+
+fn slot_initialization(
+    method_names: HashSet<String>,
+    ty: &syn::Type,
+    proto: &defs::Proto,
+) -> syn::Result<TokenStream> {
+    let mut initializers: Vec<TokenStream> = vec![];
+    // This is for setters.
+    // If we can use set_setdelattr, skip set_setattr and set_setdelattr.
+    let mut skip_indices = vec![];
+    'setter_loop: for (i, m) in proto.slot_setters.iter().enumerate() {
+        if skip_indices.contains(&i) {
+            continue;
+        }
+        for name in m.proto_names {
+            if !method_names.contains(*name) {
+                // This `#[pyproto] impl` doesn't have all required methods,
+                // let's skip implementation.
+                continue 'setter_loop;
+            }
+        }
+        skip_indices.extend_from_slice(m.exclude_indices);
+        // Add slot methods to PyProtoRegistry
+        let set = syn::Ident::new(m.set_function, Span::call_site());
+        initializers.push(quote! { table.#set::<#ty>(); });
+    }
+    if initializers.is_empty() {
+        return Ok(quote! {});
+    }
+    let table: syn::Path = syn::parse_str(proto.slot_table)?;
+    let set = syn::Ident::new(proto.set_slot_table, Span::call_site());
+    let ty_hash = typename_hash(ty);
+    let init = syn::Ident::new(
+        &format!("__init_{}_{}", proto.name, ty_hash),
+        Span::call_site(),
+    );
     Ok(quote! {
-        #trait_impls
-        #inventory_submission
+        #[pyo3::ctor::ctor]
+        fn #init() {
+            let mut table = #table::default();
+            #(#initializers)*
+            <#ty as pyo3::class::proto_methods::HasPyProtoRegistry>::registory().#set(table);
+        }
     })
+}
+
+fn typename_hash(ty: &syn::Type) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    ty.hash(&mut hasher);
+    hasher.finish()
 }

--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -162,7 +162,7 @@ fn slot_initialization(
         fn #init() {
             let mut table = #table::default();
             #(#initializers)*
-            <#ty as pyo3::class::proto_methods::HasProtoRegistry>::registory().#set(table);
+            <#ty as pyo3::class::proto_methods::HasProtoRegistry>::registry().#set(table);
         }
     })
 }

--- a/src/class/basic.rs
+++ b/src/class/basic.rs
@@ -135,7 +135,7 @@ pub trait PyObjectRichcmpProtocol<'p>: PyObjectProtocol<'p> {
     type Result: Into<PyResult<Self::Success>>;
 }
 
-/// All functions necessary for basic protocols.
+/// All FFI functions for basic protocols.
 #[derive(Default)]
 pub struct PyObjectMethods {
     pub tp_str: Option<ffi::reprfunc>,
@@ -147,7 +147,7 @@ pub struct PyObjectMethods {
 }
 
 impl PyObjectMethods {
-    pub(crate) fn prepare_type_obj(&self, type_object: &mut ffi::PyTypeObject) {
+    pub(crate) fn update_typeobj(&self, type_object: &mut ffi::PyTypeObject) {
         type_object.tp_str = self.tp_str;
         type_object.tp_repr = self.tp_repr;
         type_object.tp_hash = self.tp_hash;

--- a/src/class/basic.rs
+++ b/src/class/basic.rs
@@ -153,6 +153,7 @@ pub struct PyObjectMethods {
     pub nb_bool: Option<ffi::inquiry>,
 }
 
+#[doc(hidden)]
 impl PyObjectMethods {
     pub(crate) fn update_typeobj(&self, type_object: &mut ffi::PyTypeObject) {
         type_object.tp_str = self.tp_str;
@@ -162,7 +163,7 @@ impl PyObjectMethods {
         type_object.tp_richcompare = self.tp_richcompare;
         type_object.tp_setattro = self.tp_setattro;
     }
-
+    // Set functions used by `#[pyproto]`.
     pub fn set_str<T>(&mut self)
     where
         T: for<'p> PyObjectStrProtocol<'p>,

--- a/src/class/basic.rs
+++ b/src/class/basic.rs
@@ -90,6 +90,12 @@ pub trait PyObjectProtocol<'p>: PyClass {
     {
         unimplemented!()
     }
+    fn __bool__(&'p self) -> Self::Result
+    where
+        Self: PyObjectBoolProtocol<'p>,
+    {
+        unimplemented!()
+    }
 }
 
 pub trait PyObjectGetAttrProtocol<'p>: PyObjectProtocol<'p> {
@@ -144,6 +150,7 @@ pub struct PyObjectMethods {
     pub tp_getattro: Option<ffi::getattrofunc>,
     pub tp_richcompare: Option<ffi::richcmpfunc>,
     pub tp_setattro: Option<ffi::setattrofunc>,
+    pub nb_bool: Option<ffi::inquiry>,
 }
 
 impl PyObjectMethods {
@@ -214,6 +221,12 @@ impl PyObjectMethods {
             __setattr__,
             __delattr__
         )
+    }
+    pub fn set_bool<T>(&mut self)
+    where
+        T: for<'p> PyObjectBoolProtocol<'p>,
+    {
+        self.nb_bool = py_unary_func!(PyObjectBoolProtocol, T::__bool__, c_int);
     }
 }
 

--- a/src/class/buffer.rs
+++ b/src/class/buffer.rs
@@ -40,6 +40,8 @@ pub trait PyBufferReleaseBufferProtocol<'p>: PyBufferProtocol<'p> {
     type Result: Into<PyResult<()>>;
 }
 
+/// Set functions used by `#[pyproto]`.
+#[doc(hidden)]
 impl PyBufferProcs {
     pub fn set_getbuffer<T>(&mut self)
     where

--- a/src/class/descr.rs
+++ b/src/class/descr.rs
@@ -72,7 +72,7 @@ pub struct PyDescrMethods {
 }
 
 impl PyDescrMethods {
-    pub(crate) fn prepare_type_obj(&self, type_object: &mut ffi::PyTypeObject) {
+    pub(crate) fn update_typeobj(&self, type_object: &mut ffi::PyTypeObject) {
         type_object.tp_descr_get = self.tp_descr_get;
         type_object.tp_descr_set = self.tp_descr_set;
     }

--- a/src/class/descr.rs
+++ b/src/class/descr.rs
@@ -71,12 +71,14 @@ pub trait PyDescrSetNameProtocol<'p>: PyDescrProtocol<'p> {
     type Result: Into<PyResult<()>>;
 }
 
+/// All FFI functions for description protocols.
 #[derive(Default)]
 pub struct PyDescrMethods {
     pub tp_descr_get: Option<ffi::descrgetfunc>,
     pub tp_descr_set: Option<ffi::descrsetfunc>,
 }
 
+#[doc(hidden)]
 impl PyDescrMethods {
     pub(crate) fn update_typeobj(&self, type_object: &mut ffi::PyTypeObject) {
         type_object.tp_descr_get = self.tp_descr_get;

--- a/src/class/gc.rs
+++ b/src/class/gc.rs
@@ -18,69 +18,23 @@ pub trait PyGCProtocol<'p>: PyClass {
 pub trait PyGCTraverseProtocol<'p>: PyGCProtocol<'p> {}
 pub trait PyGCClearProtocol<'p>: PyGCProtocol<'p> {}
 
-#[doc(hidden)]
-pub trait PyGCProtocolImpl {
-    fn update_type_object(_type_object: &mut ffi::PyTypeObject);
+/// All FFI functions for gc protocols.
+#[derive(Default)]
+pub struct PyGCMethods {
+    pub tp_traverse: Option<ffi::traverseproc>,
+    pub tp_clear: Option<ffi::inquiry>,
 }
 
-impl<'p, T> PyGCProtocolImpl for T {
-    default fn update_type_object(_type_object: &mut ffi::PyTypeObject) {}
-}
-
-impl<'p, T> PyGCProtocolImpl for T
-where
-    T: PyGCProtocol<'p>,
-{
-    fn update_type_object(type_object: &mut ffi::PyTypeObject) {
-        type_object.tp_traverse = Self::tp_traverse();
-        type_object.tp_clear = Self::tp_clear();
+impl PyGCMethods {
+    pub(crate) fn update_typeobj(&self, type_object: &mut ffi::PyTypeObject) {
+        type_object.tp_traverse = self.tp_traverse;
+        type_object.tp_clear = self.tp_clear;
     }
-}
 
-#[derive(Copy, Clone)]
-pub struct PyVisit<'p> {
-    visit: ffi::visitproc,
-    arg: *mut c_void,
-    /// VisitProc contains a Python instance to ensure that
-    /// 1) it is cannot be moved out of the traverse() call
-    /// 2) it cannot be sent to other threads
-    _py: Python<'p>,
-}
-
-impl<'p> PyVisit<'p> {
-    pub fn call<T>(&self, obj: &T) -> Result<(), PyTraverseError>
+    pub fn set_traverse<T>(&mut self)
     where
-        T: AsPyPointer,
+        T: for<'p> PyGCTraverseProtocol<'p>,
     {
-        let r = unsafe { (self.visit)(obj.as_ptr(), self.arg) };
-        if r == 0 {
-            Ok(())
-        } else {
-            Err(PyTraverseError(r))
-        }
-    }
-}
-
-trait PyGCTraverseProtocolImpl {
-    fn tp_traverse() -> Option<ffi::traverseproc>;
-}
-
-impl<'p, T> PyGCTraverseProtocolImpl for T
-where
-    T: PyGCProtocol<'p>,
-{
-    default fn tp_traverse() -> Option<ffi::traverseproc> {
-        None
-    }
-}
-
-#[doc(hidden)]
-impl<T> PyGCTraverseProtocolImpl for T
-where
-    T: for<'p> PyGCTraverseProtocol<'p>,
-{
-    #[inline]
-    fn tp_traverse() -> Option<ffi::traverseproc> {
         unsafe extern "C" fn tp_traverse<T>(
             slf: *mut ffi::PyObject,
             visit: ffi::visitproc,
@@ -108,30 +62,13 @@ where
                 0
             }
         }
-
-        Some(tp_traverse::<T>)
+        self.tp_traverse = Some(tp_traverse::<T>);
     }
-}
 
-trait PyGCClearProtocolImpl {
-    fn tp_clear() -> Option<ffi::inquiry>;
-}
-
-impl<'p, T> PyGCClearProtocolImpl for T
-where
-    T: PyGCProtocol<'p>,
-{
-    default fn tp_clear() -> Option<ffi::inquiry> {
-        None
-    }
-}
-
-impl<T> PyGCClearProtocolImpl for T
-where
-    T: for<'p> PyGCClearProtocol<'p>,
-{
-    #[inline]
-    fn tp_clear() -> Option<ffi::inquiry> {
+    pub fn set_clear<T>(&mut self)
+    where
+        T: for<'p> PyGCClearProtocol<'p>,
+    {
         unsafe extern "C" fn tp_clear<T>(slf: *mut ffi::PyObject) -> c_int
         where
             T: for<'p> PyGCClearProtocol<'p>,
@@ -143,6 +80,32 @@ where
             slf.borrow_mut().__clear__();
             0
         }
-        Some(tp_clear::<T>)
+        self.tp_clear = Some(tp_clear::<T>);
+    }
+}
+
+/// Object visitor for GC.
+#[derive(Copy, Clone)]
+pub struct PyVisit<'p> {
+    visit: ffi::visitproc,
+    arg: *mut c_void,
+    /// VisitProc contains a Python instance to ensure that
+    /// 1) it is cannot be moved out of the traverse() call
+    /// 2) it cannot be sent to other threads
+    _py: Python<'p>,
+}
+
+impl<'p> PyVisit<'p> {
+    /// Visit `obj`.
+    pub fn call<T>(&self, obj: &T) -> Result<(), PyTraverseError>
+    where
+        T: AsPyPointer,
+    {
+        let r = unsafe { (self.visit)(obj.as_ptr(), self.arg) };
+        if r == 0 {
+            Ok(())
+        } else {
+            Err(PyTraverseError(r))
+        }
     }
 }

--- a/src/class/gc.rs
+++ b/src/class/gc.rs
@@ -25,6 +25,7 @@ pub struct PyGCMethods {
     pub tp_clear: Option<ffi::inquiry>,
 }
 
+#[doc(hidden)]
 impl PyGCMethods {
     pub(crate) fn update_typeobj(&self, type_object: &mut ffi::PyTypeObject) {
         type_object.tp_traverse = self.tp_traverse;

--- a/src/class/iter.rs
+++ b/src/class/iter.rs
@@ -46,6 +46,7 @@ pub struct PyIterMethods {
     pub tp_iternext: Option<ffi::iternextfunc>,
 }
 
+#[doc(hidden)]
 impl PyIterMethods {
     pub(crate) fn update_typeobj(&self, type_object: &mut ffi::PyTypeObject) {
         type_object.tp_iter = self.tp_iter;

--- a/src/class/iter.rs
+++ b/src/class/iter.rs
@@ -47,7 +47,7 @@ pub struct PyIterMethods {
 }
 
 impl PyIterMethods {
-    pub(crate) fn prepare_type_obj(&self, type_object: &mut ffi::PyTypeObject) {
+    pub(crate) fn update_typeobj(&self, type_object: &mut ffi::PyTypeObject) {
         type_object.tp_iter = self.tp_iter;
         type_object.tp_iternext = self.tp_iternext;
     }

--- a/src/class/iter.rs
+++ b/src/class/iter.rs
@@ -40,69 +40,28 @@ pub trait PyIterNextProtocol<'p>: PyIterProtocol<'p> {
     type Result: Into<PyResult<Option<Self::Success>>>;
 }
 
-#[doc(hidden)]
-pub trait PyIterProtocolImpl {
-    fn tp_as_iter(_typeob: &mut ffi::PyTypeObject);
+#[derive(Default)]
+pub struct PyIterMethods {
+    pub tp_iter: Option<ffi::getiterfunc>,
+    pub tp_iternext: Option<ffi::iternextfunc>,
 }
 
-impl<T> PyIterProtocolImpl for T {
-    default fn tp_as_iter(_typeob: &mut ffi::PyTypeObject) {}
-}
-
-impl<'p, T> PyIterProtocolImpl for T
-where
-    T: PyIterProtocol<'p>,
-{
-    #[inline]
-    fn tp_as_iter(typeob: &mut ffi::PyTypeObject) {
-        typeob.tp_iter = Self::tp_iter();
-        typeob.tp_iternext = Self::tp_iternext();
+impl PyIterMethods {
+    pub(crate) fn prepare_type_obj(&self, type_object: &mut ffi::PyTypeObject) {
+        type_object.tp_iter = self.tp_iter;
+        type_object.tp_iternext = self.tp_iternext;
     }
-}
-
-trait PyIterIterProtocolImpl {
-    fn tp_iter() -> Option<ffi::getiterfunc>;
-}
-
-impl<'p, T> PyIterIterProtocolImpl for T
-where
-    T: PyIterProtocol<'p>,
-{
-    default fn tp_iter() -> Option<ffi::getiterfunc> {
-        None
+    pub fn set_iter<T>(&mut self)
+    where
+        T: for<'p> PyIterIterProtocol<'p>,
+    {
+        self.tp_iter = py_unarys_func!(PyIterIterProtocol, T::__iter__);
     }
-}
-
-impl<T> PyIterIterProtocolImpl for T
-where
-    T: for<'p> PyIterIterProtocol<'p>,
-{
-    #[inline]
-    fn tp_iter() -> Option<ffi::getiterfunc> {
-        py_unarys_func!(PyIterIterProtocol, T::__iter__)
-    }
-}
-
-trait PyIterNextProtocolImpl {
-    fn tp_iternext() -> Option<ffi::iternextfunc>;
-}
-
-impl<'p, T> PyIterNextProtocolImpl for T
-where
-    T: PyIterProtocol<'p>,
-{
-    default fn tp_iternext() -> Option<ffi::iternextfunc> {
-        None
-    }
-}
-
-impl<T> PyIterNextProtocolImpl for T
-where
-    T: for<'p> PyIterNextProtocol<'p>,
-{
-    #[inline]
-    fn tp_iternext() -> Option<ffi::iternextfunc> {
-        py_unarys_func!(PyIterNextProtocol, T::__next__, IterNextConverter)
+    pub fn set_iternext<T>(&mut self)
+    where
+        T: for<'p> PyIterNextProtocol<'p>,
+    {
+        self.tp_iternext = py_unarys_func!(PyIterNextProtocol, T::__next__, IterNextConverter);
     }
 }
 

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -178,7 +178,7 @@ macro_rules! py_ssizearg_func {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! py_ternary_func {
+macro_rules! py_ternarys_func {
     ($trait:ident, $class:ident :: $f:ident, $return_type:ty) => {{
         unsafe extern "C" fn wrap<T>(
             slf: *mut $crate::ffi::PyObject,
@@ -190,6 +190,9 @@ macro_rules! py_ternary_func {
         {
             $crate::callback_body!(py, {
                 let slf = py.from_borrowed_ptr::<$crate::PyCell<T>>(slf);
+                let slf =
+                    <T::Receiver as $crate::derive_utils::TryFromPyCell<_>>::try_from_pycell(slf)
+                        .map_err(|e| e.into())?;
                 let arg1 = py
                     .from_borrowed_ptr::<$crate::types::PyAny>(arg1)
                     .extract()?;
@@ -197,14 +200,14 @@ macro_rules! py_ternary_func {
                     .from_borrowed_ptr::<$crate::types::PyAny>(arg2)
                     .extract()?;
 
-                slf.try_borrow()?.$f(arg1, arg2).into()
+                $class::$f(slf, arg1, arg2).into()
             })
         }
 
         Some(wrap::<T>)
     }};
     ($trait:ident, $class:ident :: $f:ident) => {
-        py_ternary_func!($trait, $class::$f, *mut $crate::ffi::PyObject);
+        py_ternarys_func!($trait, $class::$f, *mut $crate::ffi::PyObject);
     };
 }
 

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -34,8 +34,9 @@ macro_rules! py_unarys_func {
         {
             $crate::callback_body!(py, {
                 let slf = py.from_borrowed_ptr::<$crate::PyCell<T>>(slf);
-                let borrow = <T::Receiver>::try_from_pycell(slf)
-                    .map_err(|e| e.into())?;
+                let borrow =
+                    <T::Receiver as $crate::derive_utils::TryFromPyCell<_>>::try_from_pycell(slf)
+                        .map_err(|e| e.into())?;
 
                 $class::$f(borrow).into()$(.map($conv))?
             })

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -106,7 +106,7 @@ macro_rules! py_binary_num_func {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! py_binary_reverse_num_func {
+macro_rules! py_binary_reversed_num_func {
     ($trait:ident, $class:ident :: $f:ident) => {{
         unsafe extern "C" fn wrap<T>(
             lhs: *mut ffi::PyObject,
@@ -240,7 +240,7 @@ macro_rules! py_ternary_num_func {
 
 #[macro_export]
 #[doc(hidden)]
-macro_rules! py_ternary_reverse_num_func {
+macro_rules! py_ternary_reversed_num_func {
     ($trait:ident, $class:ident :: $f:ident) => {{
         unsafe extern "C" fn wrap<T>(
             arg1: *mut $crate::ffi::PyObject,

--- a/src/class/mapping.rs
+++ b/src/class/mapping.rs
@@ -74,6 +74,7 @@ pub trait PyMappingReversedProtocol<'p>: PyMappingProtocol<'p> {
     type Result: Into<PyResult<Self::Success>>;
 }
 
+#[doc(hidden)]
 impl ffi::PyMappingMethods {
     pub fn set_length<T>(&mut self)
     where

--- a/src/class/mapping.rs
+++ b/src/class/mapping.rs
@@ -74,155 +74,41 @@ pub trait PyMappingReversedProtocol<'p>: PyMappingProtocol<'p> {
     type Result: Into<PyResult<Self::Success>>;
 }
 
-#[doc(hidden)]
-pub trait PyMappingProtocolImpl {
-    fn tp_as_mapping() -> Option<ffi::PyMappingMethods>;
-}
-
-impl<T> PyMappingProtocolImpl for T {
-    default fn tp_as_mapping() -> Option<ffi::PyMappingMethods> {
-        None
+impl ffi::PyMappingMethods {
+    pub fn set_length<T>(&mut self)
+    where
+        T: for<'p> PyMappingLenProtocol<'p>,
+    {
+        self.mp_length = py_len_func!(PyMappingLenProtocol, T::__len__);
     }
-}
-
-impl<'p, T> PyMappingProtocolImpl for T
-where
-    T: PyMappingProtocol<'p>,
-{
-    #[inline]
-    fn tp_as_mapping() -> Option<ffi::PyMappingMethods> {
-        let f = if let Some(df) = Self::mp_del_subscript() {
-            Some(df)
-        } else {
-            Self::mp_ass_subscript()
-        };
-
-        Some(ffi::PyMappingMethods {
-            mp_length: Self::mp_length(),
-            mp_subscript: Self::mp_subscript(),
-            mp_ass_subscript: f,
-        })
+    pub fn set_getitem<T>(&mut self)
+    where
+        T: for<'p> PyMappingGetItemProtocol<'p>,
+    {
+        self.mp_subscript = py_binary_func!(PyMappingGetItemProtocol, T::__getitem__);
     }
-}
-
-trait PyMappingLenProtocolImpl {
-    fn mp_length() -> Option<ffi::lenfunc>;
-}
-
-impl<'p, T> PyMappingLenProtocolImpl for T
-where
-    T: PyMappingProtocol<'p>,
-{
-    default fn mp_length() -> Option<ffi::lenfunc> {
-        None
+    pub fn set_setitem<T>(&mut self)
+    where
+        T: for<'p> PyMappingSetItemProtocol<'p>,
+    {
+        self.mp_ass_subscript = py_func_set!(PyMappingSetItemProtocol, T, __setitem__);
     }
-}
-
-impl<T> PyMappingLenProtocolImpl for T
-where
-    T: for<'p> PyMappingLenProtocol<'p>,
-{
-    #[inline]
-    fn mp_length() -> Option<ffi::lenfunc> {
-        py_len_func!(PyMappingLenProtocol, T::__len__)
+    pub fn set_delitem<T>(&mut self)
+    where
+        T: for<'p> PyMappingDelItemProtocol<'p>,
+    {
+        self.mp_ass_subscript = py_func_del!(PyMappingDelItemProtocol, T, __delitem__);
     }
-}
-
-trait PyMappingGetItemProtocolImpl {
-    fn mp_subscript() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyMappingGetItemProtocolImpl for T
-where
-    T: PyMappingProtocol<'p>,
-{
-    default fn mp_subscript() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyMappingGetItemProtocolImpl for T
-where
-    T: for<'p> PyMappingGetItemProtocol<'p>,
-{
-    #[inline]
-    fn mp_subscript() -> Option<ffi::binaryfunc> {
-        py_binary_func!(PyMappingGetItemProtocol, T::__getitem__)
-    }
-}
-
-trait PyMappingSetItemProtocolImpl {
-    fn mp_ass_subscript() -> Option<ffi::objobjargproc>;
-}
-
-impl<'p, T> PyMappingSetItemProtocolImpl for T
-where
-    T: PyMappingProtocol<'p>,
-{
-    default fn mp_ass_subscript() -> Option<ffi::objobjargproc> {
-        None
-    }
-}
-
-impl<T> PyMappingSetItemProtocolImpl for T
-where
-    T: for<'p> PyMappingSetItemProtocol<'p>,
-{
-    #[inline]
-    fn mp_ass_subscript() -> Option<ffi::objobjargproc> {
-        py_func_set!(PyMappingSetItemProtocol, T, __setitem__)
-    }
-}
-
-/// Returns `None` if PyMappingDelItemProtocol isn't implemented, otherwise dispatches to
-/// `DelSetItemDispatch`
-trait DeplItemDipatch {
-    fn mp_del_subscript() -> Option<ffi::objobjargproc>;
-}
-
-impl<'p, T> DeplItemDipatch for T
-where
-    T: PyMappingProtocol<'p>,
-{
-    default fn mp_del_subscript() -> Option<ffi::objobjargproc> {
-        None
-    }
-}
-
-/// Returns `py_func_set_del` if PyMappingSetItemProtocol is implemented, otherwise `py_func_del`
-trait DelSetItemDispatch: Sized + for<'p> PyMappingDelItemProtocol<'p> {
-    fn det_set_dispatch() -> Option<ffi::objobjargproc>;
-}
-
-impl<T> DelSetItemDispatch for T
-where
-    T: Sized + for<'p> PyMappingDelItemProtocol<'p>,
-{
-    default fn det_set_dispatch() -> Option<ffi::objobjargproc> {
-        py_func_del!(PyMappingDelItemProtocol, Self, __delitem__)
-    }
-}
-
-impl<T> DelSetItemDispatch for T
-where
-    T: for<'p> PyMappingSetItemProtocol<'p> + for<'p> PyMappingDelItemProtocol<'p>,
-{
-    fn det_set_dispatch() -> Option<ffi::objobjargproc> {
-        py_func_set_del!(
+    pub fn set_setdelitem<T>(&mut self)
+    where
+        T: for<'p> PyMappingSetItemProtocol<'p> + for<'p> PyMappingDelItemProtocol<'p>,
+    {
+        self.mp_ass_subscript = py_func_set_del!(
             PyMappingSetItemProtocol,
             PyMappingDelItemProtocol,
             T,
             __setitem__,
             __delitem__
-        )
-    }
-}
-
-impl<T> DeplItemDipatch for T
-where
-    T: Sized + for<'p> PyMappingDelItemProtocol<'p>,
-{
-    fn mp_del_subscript() -> Option<ffi::objobjargproc> {
-        <T as DelSetItemDispatch>::det_set_dispatch()
+        );
     }
 }

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -14,6 +14,7 @@ pub mod iter;
 pub mod mapping;
 pub mod methods;
 pub mod number;
+pub mod proto_methods;
 pub mod pyasync;
 pub mod sequence;
 

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -626,1137 +626,299 @@ pub trait PyNumberBoolProtocol<'p>: PyNumberProtocol<'p> {
     type Result: Into<PyResult<bool>>;
 }
 
-#[doc(hidden)]
-pub trait PyNumberProtocolImpl {
-    fn tp_as_number() -> Option<ffi::PyNumberMethods>;
-}
-
-impl<'p, T> PyNumberProtocolImpl for T {
-    default fn tp_as_number() -> Option<ffi::PyNumberMethods> {
-        None
-    }
-}
-
-impl<'p, T> PyNumberProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    fn tp_as_number() -> Option<ffi::PyNumberMethods> {
-        Some(ffi::PyNumberMethods {
-            nb_add: Self::nb_add().or_else(Self::nb_add_fallback),
-            nb_subtract: Self::nb_subtract().or_else(Self::nb_sub_fallback),
-            nb_multiply: Self::nb_multiply().or_else(Self::nb_mul_fallback),
-            nb_remainder: Self::nb_remainder(),
-            nb_divmod: Self::nb_divmod().or_else(Self::nb_divmod_fallback),
-            nb_power: Self::nb_power().or_else(Self::nb_pow_fallback),
-            nb_negative: Self::nb_negative(),
-            nb_positive: Self::nb_positive(),
-            nb_absolute: Self::nb_absolute(),
-            nb_bool: Self::nb_bool(),
-            nb_invert: Self::nb_invert(),
-            nb_lshift: Self::nb_lshift().or_else(Self::nb_lshift_fallback),
-            nb_rshift: Self::nb_rshift().or_else(Self::nb_rshift_fallback),
-            nb_and: Self::nb_and().or_else(Self::nb_and_fallback),
-            nb_xor: Self::nb_xor().or_else(Self::nb_xor_fallback),
-            nb_or: Self::nb_or().or_else(Self::nb_or_fallback),
-            nb_int: Self::nb_int(),
-            nb_reserved: ::std::ptr::null_mut(),
-            nb_float: Self::nb_float(),
-            nb_inplace_add: Self::nb_inplace_add(),
-            nb_inplace_subtract: Self::nb_inplace_subtract(),
-            nb_inplace_multiply: Self::nb_inplace_multiply(),
-            nb_inplace_remainder: Self::nb_inplace_remainder(),
-            nb_inplace_power: Self::nb_inplace_power(),
-            nb_inplace_lshift: Self::nb_inplace_lshift(),
-            nb_inplace_rshift: Self::nb_inplace_rshift(),
-            nb_inplace_and: Self::nb_inplace_and(),
-            nb_inplace_xor: Self::nb_inplace_xor(),
-            nb_inplace_or: Self::nb_inplace_or(),
-            nb_floor_divide: Self::nb_floor_divide().or_else(Self::nb_floordiv_fallback),
-            nb_true_divide: Self::nb_true_divide().or_else(Self::nb_truediv_fallback),
-            nb_inplace_floor_divide: Self::nb_inplace_floor_divide(),
-            nb_inplace_true_divide: Self::nb_inplace_true_divide(),
-            nb_index: Self::nb_index(),
-            nb_matrix_multiply: Self::nb_matrix_multiply().or_else(Self::nb_matmul_fallback),
-            nb_inplace_matrix_multiply: Self::nb_inplace_matrix_multiply(),
-        })
-    }
-}
-
-trait PyNumberAddProtocolImpl {
-    fn nb_add() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberAddProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_add() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberAddProtocolImpl for T
-where
-    T: for<'p> PyNumberAddProtocol<'p>,
-{
-    fn nb_add() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberAddProtocol, T::__add__)
-    }
-}
-
-trait PyNumberSubProtocolImpl {
-    fn nb_subtract() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberSubProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_subtract() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberSubProtocolImpl for T
-where
-    T: for<'p> PyNumberSubProtocol<'p>,
-{
-    fn nb_subtract() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberSubProtocol, T::__sub__)
-    }
-}
-
-trait PyNumberMulProtocolImpl {
-    fn nb_multiply() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberMulProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_multiply() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberMulProtocolImpl for T
-where
-    T: for<'p> PyNumberMulProtocol<'p>,
-{
-    fn nb_multiply() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberMulProtocol, T::__mul__)
-    }
-}
-
-trait PyNumberMatmulProtocolImpl {
-    fn nb_matrix_multiply() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberMatmulProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_matrix_multiply() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberMatmulProtocolImpl for T
-where
-    T: for<'p> PyNumberMatmulProtocol<'p>,
-{
-    fn nb_matrix_multiply() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberMatmulProtocol, T::__matmul__)
-    }
-}
-
-trait PyNumberTruedivProtocolImpl {
-    fn nb_true_divide() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberTruedivProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_true_divide() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberTruedivProtocolImpl for T
-where
-    T: for<'p> PyNumberTruedivProtocol<'p>,
-{
-    fn nb_true_divide() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberTruedivProtocol, T::__truediv__)
-    }
-}
-
-trait PyNumberFloordivProtocolImpl {
-    fn nb_floor_divide() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberFloordivProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_floor_divide() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberFloordivProtocolImpl for T
-where
-    T: for<'p> PyNumberFloordivProtocol<'p>,
-{
-    fn nb_floor_divide() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberFloordivProtocol, T::__floordiv__)
-    }
-}
-
-trait PyNumberModProtocolImpl {
-    fn nb_remainder() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberModProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_remainder() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberModProtocolImpl for T
-where
-    T: for<'p> PyNumberModProtocol<'p>,
-{
-    fn nb_remainder() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberModProtocol, T::__mod__)
-    }
-}
-
-trait PyNumberDivmodProtocolImpl {
-    fn nb_divmod() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberDivmodProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_divmod() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberDivmodProtocolImpl for T
-where
-    T: for<'p> PyNumberDivmodProtocol<'p>,
-{
-    fn nb_divmod() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberDivmodProtocol, T::__divmod__)
-    }
-}
-
-trait PyNumberPowProtocolImpl {
-    fn nb_power() -> Option<ffi::ternaryfunc>;
-}
-
-impl<'p, T> PyNumberPowProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_power() -> Option<ffi::ternaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberPowProtocolImpl for T
-where
-    T: for<'p> PyNumberPowProtocol<'p>,
-{
-    fn nb_power() -> Option<ffi::ternaryfunc> {
-        py_ternary_num_func!(PyNumberPowProtocol, T::__pow__)
-    }
-}
-
-trait PyNumberLShiftProtocolImpl {
-    fn nb_lshift() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberLShiftProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_lshift() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberLShiftProtocolImpl for T
-where
-    T: for<'p> PyNumberLShiftProtocol<'p>,
-{
-    fn nb_lshift() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberLShiftProtocol, T::__lshift__)
-    }
-}
-
-trait PyNumberRShiftProtocolImpl {
-    fn nb_rshift() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberRShiftProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_rshift() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberRShiftProtocolImpl for T
-where
-    T: for<'p> PyNumberRShiftProtocol<'p>,
-{
-    fn nb_rshift() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberRShiftProtocol, T::__rshift__)
-    }
-}
-
-trait PyNumberAndProtocolImpl {
-    fn nb_and() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberAndProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_and() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberAndProtocolImpl for T
-where
-    T: for<'p> PyNumberAndProtocol<'p>,
-{
-    fn nb_and() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberAndProtocol, T::__and__)
-    }
-}
-
-trait PyNumberXorProtocolImpl {
-    fn nb_xor() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberXorProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_xor() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberXorProtocolImpl for T
-where
-    T: for<'p> PyNumberXorProtocol<'p>,
-{
-    fn nb_xor() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberXorProtocol, T::__xor__)
-    }
-}
-
-trait PyNumberOrProtocolImpl {
-    fn nb_or() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberOrProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_or() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberOrProtocolImpl for T
-where
-    T: for<'p> PyNumberOrProtocol<'p>,
-{
-    fn nb_or() -> Option<ffi::binaryfunc> {
-        py_binary_num_func!(PyNumberOrProtocol, T::__or__)
-    }
-}
-
-trait PyNumberIAddProtocolImpl {
-    fn nb_inplace_add() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberIAddProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_add() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIAddProtocolImpl for T
-where
-    T: for<'p> PyNumberIAddProtocol<'p>,
-{
-    fn nb_inplace_add() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberIAddProtocol, T::__iadd__)
-    }
-}
-
-trait PyNumberISubProtocolImpl {
-    fn nb_inplace_subtract() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberISubProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_subtract() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberISubProtocolImpl for T
-where
-    T: for<'p> PyNumberISubProtocol<'p>,
-{
-    fn nb_inplace_subtract() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberISubProtocol, T::__isub__)
-    }
-}
-
-trait PyNumberIMulProtocolImpl {
-    fn nb_inplace_multiply() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberIMulProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_multiply() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIMulProtocolImpl for T
-where
-    T: for<'p> PyNumberIMulProtocol<'p>,
-{
-    fn nb_inplace_multiply() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberIMulProtocol, T::__imul__)
-    }
-}
-
-trait PyNumberIMatmulProtocolImpl {
-    fn nb_inplace_matrix_multiply() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberIMatmulProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_matrix_multiply() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIMatmulProtocolImpl for T
-where
-    T: for<'p> PyNumberIMatmulProtocol<'p>,
-{
-    fn nb_inplace_matrix_multiply() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberIMatmulProtocol, T::__imatmul__)
-    }
-}
-
-trait PyNumberITruedivProtocolImpl {
-    fn nb_inplace_true_divide() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberITruedivProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_true_divide() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberITruedivProtocolImpl for T
-where
-    T: for<'p> PyNumberITruedivProtocol<'p>,
-{
-    fn nb_inplace_true_divide() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberITruedivProtocol, T::__itruediv__)
-    }
-}
-
-trait PyNumberIFloordivProtocolImpl {
-    fn nb_inplace_floor_divide() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberIFloordivProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_floor_divide() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIFloordivProtocolImpl for T
-where
-    T: for<'p> PyNumberIFloordivProtocol<'p>,
-{
-    fn nb_inplace_floor_divide() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberIFloordivProtocol, T::__ifloordiv__)
-    }
-}
-
-trait PyNumberIModProtocolImpl {
-    fn nb_inplace_remainder() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberIModProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_remainder() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIModProtocolImpl for T
-where
-    T: for<'p> PyNumberIModProtocol<'p>,
-{
-    fn nb_inplace_remainder() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberIModProtocol, T::__imod__)
-    }
-}
-
-trait PyNumberIPowProtocolImpl {
-    fn nb_inplace_power() -> Option<ffi::ternaryfunc>;
-}
-
-impl<'p, T> PyNumberIPowProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_power() -> Option<ffi::ternaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIPowProtocolImpl for T
-where
-    T: for<'p> PyNumberIPowProtocol<'p>,
-{
-    fn nb_inplace_power() -> Option<ffi::ternaryfunc> {
-        py_dummy_ternary_self_func!(PyNumberIPowProtocol, T::__ipow__)
-    }
-}
-
-trait PyNumberILShiftProtocolImpl {
-    fn nb_inplace_lshift() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberILShiftProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_lshift() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberILShiftProtocolImpl for T
-where
-    T: for<'p> PyNumberILShiftProtocol<'p>,
-{
-    fn nb_inplace_lshift() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberILShiftProtocol, T::__ilshift__)
-    }
-}
-
-trait PyNumberIRShiftProtocolImpl {
-    fn nb_inplace_rshift() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberIRShiftProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_rshift() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIRShiftProtocolImpl for T
-where
-    T: for<'p> PyNumberIRShiftProtocol<'p>,
-{
-    fn nb_inplace_rshift() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberIRShiftProtocol, T::__irshift__)
-    }
-}
-
-trait PyNumberIAndProtocolImpl {
-    fn nb_inplace_and() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberIAndProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_and() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIAndProtocolImpl for T
-where
-    T: for<'p> PyNumberIAndProtocol<'p>,
-{
-    fn nb_inplace_and() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberIAndProtocol, T::__iand__)
-    }
-}
-
-trait PyNumberIXorProtocolImpl {
-    fn nb_inplace_xor() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberIXorProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_xor() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIXorProtocolImpl for T
-where
-    T: for<'p> PyNumberIXorProtocol<'p>,
-{
-    fn nb_inplace_xor() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberIXorProtocol, T::__ixor__)
-    }
-}
-
-trait PyNumberIOrProtocolImpl {
-    fn nb_inplace_or() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberIOrProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_inplace_or() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIOrProtocolImpl for T
-where
-    T: for<'p> PyNumberIOrProtocol<'p>,
-{
-    fn nb_inplace_or() -> Option<ffi::binaryfunc> {
-        py_binary_self_func!(PyNumberIOrProtocol, T::__ior__)
-    }
-}
-
-// Fallback trait for nb_add
-trait PyNumberAddFallback {
-    fn nb_add_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberAddFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_add_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberAddFallback for T
-where
-    T: for<'p> PyNumberRAddProtocol<'p>,
-{
-    fn nb_add_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRAddProtocol, T::__radd__)
-    }
-}
-
-trait PyNumberSubFallback {
-    fn nb_sub_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberSubFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_sub_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberSubFallback for T
-where
-    T: for<'p> PyNumberRSubProtocol<'p>,
-{
-    fn nb_sub_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRSubProtocol, T::__rsub__)
-    }
-}
-
-trait PyNumberMulFallback {
-    fn nb_mul_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberMulFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_mul_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberMulFallback for T
-where
-    T: for<'p> PyNumberRMulProtocol<'p>,
-{
-    fn nb_mul_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRMulProtocol, T::__rmul__)
-    }
-}
-
-trait PyNumberMatmulFallback {
-    fn nb_matmul_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberMatmulFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_matmul_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberMatmulFallback for T
-where
-    T: for<'p> PyNumberRMatmulProtocol<'p>,
-{
-    fn nb_matmul_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRMatmulProtocol, T::__rmatmul__)
-    }
-}
-
-trait PyNumberTruedivFallback {
-    fn nb_truediv_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberTruedivFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_truediv_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberTruedivFallback for T
-where
-    T: for<'p> PyNumberRTruedivProtocol<'p>,
-{
-    fn nb_truediv_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRTruedivProtocol, T::__rtruediv__)
-    }
-}
-
-trait PyNumberFloordivFallback {
-    fn nb_floordiv_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberFloordivFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_floordiv_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberFloordivFallback for T
-where
-    T: for<'p> PyNumberRFloordivProtocol<'p>,
-{
-    fn nb_floordiv_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRFloordivProtocol, T::__rfloordiv__)
-    }
-}
-
-trait PyNumberModFallback {
-    fn nb_mod_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberModFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_mod_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberModFallback for T
-where
-    T: for<'p> PyNumberRModProtocol<'p>,
-{
-    fn nb_mod_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRModProtocol, T::__rmod__)
-    }
-}
-
-trait PyNumberDivmodFallback {
-    fn nb_divmod_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberDivmodFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_divmod_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberDivmodFallback for T
-where
-    T: for<'p> PyNumberRDivmodProtocol<'p>,
-{
-    fn nb_divmod_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRDivmodProtocol, T::__rdivmod__)
-    }
-}
-
-trait PyNumberPowFallback {
-    fn nb_pow_fallback() -> Option<ffi::ternaryfunc>;
-}
-
-impl<'p, T> PyNumberPowFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_pow_fallback() -> Option<ffi::ternaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberPowFallback for T
-where
-    T: for<'p> PyNumberRPowProtocol<'p>,
-{
-    fn nb_pow_fallback() -> Option<ffi::ternaryfunc> {
-        py_ternary_reverse_num_func!(PyNumberRPowProtocol, T::__rpow__)
-    }
-}
-
-trait PyNumberLShiftFallback {
-    fn nb_lshift_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberLShiftFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_lshift_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberLShiftFallback for T
-where
-    T: for<'p> PyNumberRLShiftProtocol<'p>,
-{
-    fn nb_lshift_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRLShiftProtocol, T::__rlshift__)
-    }
-}
-
-trait PyNumberRRshiftFallback {
-    fn nb_rshift_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberRRshiftFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_rshift_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberRRshiftFallback for T
-where
-    T: for<'p> PyNumberRRShiftProtocol<'p>,
-{
-    fn nb_rshift_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRRShiftProtocol, T::__rrshift__)
-    }
-}
-
-trait PyNumberAndFallback {
-    fn nb_and_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberAndFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_and_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberAndFallback for T
-where
-    T: for<'p> PyNumberRAndProtocol<'p>,
-{
-    fn nb_and_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRAndProtocol, T::__rand__)
-    }
-}
-
-trait PyNumberXorFallback {
-    fn nb_xor_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberXorFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_xor_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberXorFallback for T
-where
-    T: for<'p> PyNumberRXorProtocol<'p>,
-{
-    fn nb_xor_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberRXorProtocol, T::__rxor__)
-    }
-}
-
-trait PyNumberOrFallback {
-    fn nb_or_fallback() -> Option<ffi::binaryfunc>;
-}
-
-impl<'p, T> PyNumberOrFallback for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_or_fallback() -> Option<ffi::binaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberOrFallback for T
-where
-    T: for<'p> PyNumberROrProtocol<'p>,
-{
-    fn nb_or_fallback() -> Option<ffi::binaryfunc> {
-        py_binary_reverse_num_func!(PyNumberROrProtocol, T::__ror__)
-    }
-}
-
-trait PyNumberNegProtocolImpl {
-    fn nb_negative() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyNumberNegProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_negative() -> Option<ffi::unaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberNegProtocolImpl for T
-where
-    T: for<'p> PyNumberNegProtocol<'p>,
-{
-    #[inline]
-    fn nb_negative() -> Option<ffi::unaryfunc> {
-        py_unary_func!(PyNumberNegProtocol, T::__neg__)
-    }
-}
-
-trait PyNumberPosProtocolImpl {
-    fn nb_positive() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyNumberPosProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_positive() -> Option<ffi::unaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberPosProtocolImpl for T
-where
-    T: for<'p> PyNumberPosProtocol<'p>,
-{
-    fn nb_positive() -> Option<ffi::unaryfunc> {
-        py_unary_func!(PyNumberPosProtocol, T::__pos__)
-    }
-}
-
-trait PyNumberAbsProtocolImpl {
-    fn nb_absolute() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyNumberAbsProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_absolute() -> Option<ffi::unaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberAbsProtocolImpl for T
-where
-    T: for<'p> PyNumberAbsProtocol<'p>,
-{
-    fn nb_absolute() -> Option<ffi::unaryfunc> {
-        py_unary_func!(PyNumberAbsProtocol, T::__abs__)
-    }
-}
-
-trait PyNumberInvertProtocolImpl {
-    fn nb_invert() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyNumberInvertProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_invert() -> Option<ffi::unaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberInvertProtocolImpl for T
-where
-    T: for<'p> PyNumberInvertProtocol<'p>,
-{
-    fn nb_invert() -> Option<ffi::unaryfunc> {
-        py_unary_func!(PyNumberInvertProtocol, T::__invert__)
-    }
-}
-
-trait PyNumberIntProtocolImpl {
-    fn nb_int() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyNumberIntProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_int() -> Option<ffi::unaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIntProtocolImpl for T
-where
-    T: for<'p> PyNumberIntProtocol<'p>,
-{
-    fn nb_int() -> Option<ffi::unaryfunc> {
-        py_unary_func!(PyNumberIntProtocol, T::__int__)
-    }
-}
-
-trait PyNumberFloatProtocolImpl {
-    fn nb_float() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyNumberFloatProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_float() -> Option<ffi::unaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberFloatProtocolImpl for T
-where
-    T: for<'p> PyNumberFloatProtocol<'p>,
-{
-    fn nb_float() -> Option<ffi::unaryfunc> {
-        py_unary_func!(PyNumberFloatProtocol, T::__float__)
-    }
-}
-
-trait PyNumberIndexProtocolImpl {
-    fn nb_index() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyNumberIndexProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_index() -> Option<ffi::unaryfunc> {
-        None
-    }
-}
-
-impl<T> PyNumberIndexProtocolImpl for T
-where
-    T: for<'p> PyNumberIndexProtocol<'p>,
-{
-    fn nb_index() -> Option<ffi::unaryfunc> {
-        py_unary_func!(PyNumberIndexProtocol, T::__index__)
-    }
-}
-
-trait PyNumberBoolProtocolImpl {
-    fn nb_bool() -> Option<ffi::inquiry>;
-}
-impl<'p, T> PyNumberBoolProtocolImpl for T
-where
-    T: PyNumberProtocol<'p>,
-{
-    default fn nb_bool() -> Option<ffi::inquiry> {
-        None
-    }
-}
-impl<T> PyNumberBoolProtocolImpl for T
-where
-    T: for<'p> PyNumberBoolProtocol<'p>,
-{
-    fn nb_bool() -> Option<ffi::inquiry> {
-        py_unary_func!(PyNumberBoolProtocol, T::__bool__, c_int)
+impl ffi::PyNumberMethods {
+    pub fn set_add<T>(&mut self)
+    where
+        T: for<'p> PyNumberAddProtocol<'p>,
+    {
+        self.nb_add = py_binary_num_func!(PyNumberAddProtocol, T::__add__);
+    }
+    pub fn set_radd<T>(&mut self)
+    where
+        T: for<'p> PyNumberRAddProtocol<'p>,
+    {
+        self.nb_add = py_binary_reversed_num_func!(PyNumberRAddProtocol, T::__radd__);
+    }
+    pub fn set_sub<T>(&mut self)
+    where
+        T: for<'p> PyNumberSubProtocol<'p>,
+    {
+        self.nb_subtract = py_binary_num_func!(PyNumberSubProtocol, T::__sub__);
+    }
+    pub fn set_rsub<T>(&mut self)
+    where
+        T: for<'p> PyNumberRSubProtocol<'p>,
+    {
+        self.nb_subtract = py_binary_reversed_num_func!(PyNumberRSubProtocol, T::__rsub__);
+    }
+    pub fn set_mul<T>(&mut self)
+    where
+        T: for<'p> PyNumberMulProtocol<'p>,
+    {
+        self.nb_multiply = py_binary_num_func!(PyNumberMulProtocol, T::__mul__);
+    }
+    pub fn set_rmul<T>(&mut self)
+    where
+        T: for<'p> PyNumberRMulProtocol<'p>,
+    {
+        self.nb_multiply = py_binary_reversed_num_func!(PyNumberRMulProtocol, T::__rmul__);
+    }
+    pub fn set_mod<T>(&mut self)
+    where
+        T: for<'p> PyNumberModProtocol<'p>,
+    {
+        self.nb_remainder = py_binary_num_func!(PyNumberModProtocol, T::__mod__);
+    }
+    pub fn set_divmod<T>(&mut self)
+    where
+        T: for<'p> PyNumberDivmodProtocol<'p>,
+    {
+        self.nb_divmod = py_binary_num_func!(PyNumberDivmodProtocol, T::__divmod__);
+    }
+    pub fn set_rdivmod<T>(&mut self)
+    where
+        T: for<'p> PyNumberRDivmodProtocol<'p>,
+    {
+        self.nb_divmod = py_binary_reversed_num_func!(PyNumberRDivmodProtocol, T::__rdivmod__);
+    }
+    pub fn set_pow<T>(&mut self)
+    where
+        T: for<'p> PyNumberPowProtocol<'p>,
+    {
+        self.nb_power = py_ternary_num_func!(PyNumberPowProtocol, T::__pow__);
+    }
+    pub fn set_rpow<T>(&mut self)
+    where
+        T: for<'p> PyNumberRPowProtocol<'p>,
+    {
+        self.nb_power = py_ternary_reversed_num_func!(PyNumberRPowProtocol, T::__rpow__);
+    }
+    pub fn set_neg<T>(&mut self)
+    where
+        T: for<'p> PyNumberNegProtocol<'p>,
+    {
+        self.nb_negative = py_unary_func!(PyNumberNegProtocol, T::__neg__);
+    }
+    pub fn set_pos<T>(&mut self)
+    where
+        T: for<'p> PyNumberPosProtocol<'p>,
+    {
+        self.nb_positive = py_unary_func!(PyNumberPosProtocol, T::__pos__);
+    }
+    pub fn set_abs<T>(&mut self)
+    where
+        T: for<'p> PyNumberAbsProtocol<'p>,
+    {
+        self.nb_absolute = py_unary_func!(PyNumberAbsProtocol, T::__abs__);
+    }
+    pub fn set_bool<T>(&mut self)
+    where
+        T: for<'p> PyNumberBoolProtocol<'p>,
+    {
+        self.nb_bool = py_unary_func!(PyNumberBoolProtocol, T::__bool__, c_int);
+    }
+    pub fn set_invert<T>(&mut self)
+    where
+        T: for<'p> PyNumberInvertProtocol<'p>,
+    {
+        self.nb_invert = py_unary_func!(PyNumberInvertProtocol, T::__invert__);
+    }
+    pub fn set_lshift<T>(&mut self)
+    where
+        T: for<'p> PyNumberLShiftProtocol<'p>,
+    {
+        self.nb_lshift = py_binary_num_func!(PyNumberLShiftProtocol, T::__lshift__);
+    }
+    pub fn set_rlshift<T>(&mut self)
+    where
+        T: for<'p> PyNumberRLShiftProtocol<'p>,
+    {
+        self.nb_lshift = py_binary_reversed_num_func!(PyNumberRLShiftProtocol, T::__rlshift__);
+    }
+    pub fn set_rshift<T>(&mut self)
+    where
+        T: for<'p> PyNumberRShiftProtocol<'p>,
+    {
+        self.nb_rshift = py_binary_num_func!(PyNumberRShiftProtocol, T::__rshift__);
+    }
+    pub fn set_rrshift<T>(&mut self)
+    where
+        T: for<'p> PyNumberRRShiftProtocol<'p>,
+    {
+        self.nb_rshift = py_binary_reversed_num_func!(PyNumberRRShiftProtocol, T::__rrshift__);
+    }
+    pub fn set_and<T>(&mut self)
+    where
+        T: for<'p> PyNumberAndProtocol<'p>,
+    {
+        self.nb_and = py_binary_num_func!(PyNumberAndProtocol, T::__and__);
+    }
+    pub fn set_rand<T>(&mut self)
+    where
+        T: for<'p> PyNumberRAndProtocol<'p>,
+    {
+        self.nb_and = py_binary_reversed_num_func!(PyNumberRAndProtocol, T::__rand__);
+    }
+    pub fn set_xor<T>(&mut self)
+    where
+        T: for<'p> PyNumberXorProtocol<'p>,
+    {
+        self.nb_xor = py_binary_num_func!(PyNumberXorProtocol, T::__xor__);
+    }
+    pub fn set_rxor<T>(&mut self)
+    where
+        T: for<'p> PyNumberRXorProtocol<'p>,
+    {
+        self.nb_xor = py_binary_reversed_num_func!(PyNumberRXorProtocol, T::__rxor__);
+    }
+    pub fn set_or<T>(&mut self)
+    where
+        T: for<'p> PyNumberOrProtocol<'p>,
+    {
+        self.nb_or = py_binary_num_func!(PyNumberOrProtocol, T::__or__);
+    }
+    pub fn set_ror<T>(&mut self)
+    where
+        T: for<'p> PyNumberROrProtocol<'p>,
+    {
+        self.nb_or = py_binary_reversed_num_func!(PyNumberROrProtocol, T::__ror__);
+    }
+    pub fn set_int<T>(&mut self)
+    where
+        T: for<'p> PyNumberIntProtocol<'p>,
+    {
+        self.nb_int = py_unary_func!(PyNumberIntProtocol, T::__int__);
+    }
+    pub fn set_float<T>(&mut self)
+    where
+        T: for<'p> PyNumberFloatProtocol<'p>,
+    {
+        self.nb_float = py_unary_func!(PyNumberFloatProtocol, T::__float__);
+    }
+    pub fn set_iadd<T>(&mut self)
+    where
+        T: for<'p> PyNumberIAddProtocol<'p>,
+    {
+        self.nb_inplace_add = py_binary_self_func!(PyNumberIAddProtocol, T::__iadd__);
+    }
+    pub fn set_isub<T>(&mut self)
+    where
+        T: for<'p> PyNumberISubProtocol<'p>,
+    {
+        self.nb_inplace_subtract = py_binary_self_func!(PyNumberISubProtocol, T::__isub__);
+    }
+    pub fn set_imul<T>(&mut self)
+    where
+        T: for<'p> PyNumberIMulProtocol<'p>,
+    {
+        self.nb_inplace_multiply = py_binary_self_func!(PyNumberIMulProtocol, T::__imul__);
+    }
+    pub fn set_imod<T>(&mut self)
+    where
+        T: for<'p> PyNumberIModProtocol<'p>,
+    {
+        self.nb_inplace_remainder = py_binary_self_func!(PyNumberIModProtocol, T::__imod__);
+    }
+    pub fn set_ipow<T>(&mut self)
+    where
+        T: for<'p> PyNumberIPowProtocol<'p>,
+    {
+        self.nb_inplace_power = py_dummy_ternary_self_func!(PyNumberIPowProtocol, T::__ipow__)
+    }
+    pub fn set_ilshift<T>(&mut self)
+    where
+        T: for<'p> PyNumberILShiftProtocol<'p>,
+    {
+        self.nb_inplace_lshift = py_binary_self_func!(PyNumberILShiftProtocol, T::__ilshift__);
+    }
+    pub fn set_irshift<T>(&mut self)
+    where
+        T: for<'p> PyNumberIRShiftProtocol<'p>,
+    {
+        self.nb_inplace_rshift = py_binary_self_func!(PyNumberIRShiftProtocol, T::__irshift__);
+    }
+    pub fn set_iand<T>(&mut self)
+    where
+        T: for<'p> PyNumberIAndProtocol<'p>,
+    {
+        self.nb_inplace_and = py_binary_self_func!(PyNumberIAndProtocol, T::__iand__);
+    }
+    pub fn set_ixor<T>(&mut self)
+    where
+        T: for<'p> PyNumberIXorProtocol<'p>,
+    {
+        self.nb_inplace_xor = py_binary_self_func!(PyNumberIXorProtocol, T::__ixor__);
+    }
+    pub fn set_ior<T>(&mut self)
+    where
+        T: for<'p> PyNumberIOrProtocol<'p>,
+    {
+        self.nb_inplace_or = py_binary_self_func!(PyNumberIOrProtocol, T::__ior__);
+    }
+    pub fn set_floordiv<T>(&mut self)
+    where
+        T: for<'p> PyNumberFloordivProtocol<'p>,
+    {
+        self.nb_floor_divide = py_binary_num_func!(PyNumberFloordivProtocol, T::__floordiv__);
+    }
+    pub fn set_rfloordiv<T>(&mut self)
+    where
+        T: for<'p> PyNumberRFloordivProtocol<'p>,
+    {
+        self.nb_floor_divide =
+            py_binary_reversed_num_func!(PyNumberRFloordivProtocol, T::__rfloordiv__);
+    }
+    pub fn set_truediv<T>(&mut self)
+    where
+        T: for<'p> PyNumberTruedivProtocol<'p>,
+    {
+        self.nb_true_divide = py_binary_num_func!(PyNumberTruedivProtocol, T::__truediv__);
+    }
+    pub fn set_rtruediv<T>(&mut self)
+    where
+        T: for<'p> PyNumberRTruedivProtocol<'p>,
+    {
+        self.nb_true_divide =
+            py_binary_reversed_num_func!(PyNumberRTruedivProtocol, T::__rtruediv__);
+    }
+    pub fn set_ifloordiv<T>(&mut self)
+    where
+        T: for<'p> PyNumberIFloordivProtocol<'p>,
+    {
+        self.nb_inplace_floor_divide =
+            py_binary_self_func!(PyNumberIFloordivProtocol, T::__ifloordiv__);
+    }
+    pub fn set_itruediv<T>(&mut self)
+    where
+        T: for<'p> PyNumberITruedivProtocol<'p>,
+    {
+        self.nb_inplace_true_divide =
+            py_binary_self_func!(PyNumberITruedivProtocol, T::__itruediv__);
+    }
+    pub fn set_index<T>(&mut self)
+    where
+        T: for<'p> PyNumberIndexProtocol<'p>,
+    {
+        self.nb_index = py_unary_func!(PyNumberIndexProtocol, T::__index__);
+    }
+    pub fn set_matmul<T>(&mut self)
+    where
+        T: for<'p> PyNumberMatmulProtocol<'p>,
+    {
+        self.nb_matrix_multiply = py_binary_num_func!(PyNumberMatmulProtocol, T::__matmul__);
+    }
+    pub fn set_rmatmul<T>(&mut self)
+    where
+        T: for<'p> PyNumberRMatmulProtocol<'p>,
+    {
+        self.nb_matrix_multiply =
+            py_binary_reversed_num_func!(PyNumberRMatmulProtocol, T::__rmatmul__);
+    }
+    pub fn set_imatmul<T>(&mut self)
+    where
+        T: for<'p> PyNumberIMatmulProtocol<'p>,
+    {
+        self.nb_inplace_matrix_multiply =
+            py_binary_self_func!(PyNumberIMatmulProtocol, T::__imatmul__);
     }
 }

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -615,6 +615,7 @@ pub trait PyNumberIndexProtocol<'p>: PyNumberProtocol<'p> {
     type Result: Into<PyResult<Self::Success>>;
 }
 
+#[doc(hidden)]
 impl ffi::PyNumberMethods {
     pub(crate) fn from_nb_bool(nb_bool: ffi::inquiry) -> *mut Self {
         let mut nm = ffi::PyNumberMethods_INIT;

--- a/src/class/proto_methods.rs
+++ b/src/class/proto_methods.rs
@@ -9,8 +9,8 @@ use std::{
     sync::atomic::{AtomicPtr, Ordering},
 };
 
-/// Defines all methods for object protocols.
-// Note: stub implementations are for rust-numpy. Please remove them.
+/// Defines all method tables we need for object protocols.
+// Note(kngwyu): default implementations are for rust-numpy. Please don't remove them.
 pub trait PyProtoMethods {
     fn async_methods() -> Option<NonNull<PyAsyncMethods>> {
         None

--- a/src/class/proto_methods.rs
+++ b/src/class/proto_methods.rs
@@ -9,8 +9,8 @@ use std::{
     sync::atomic::{AtomicPtr, Ordering},
 };
 
-/// Defines what we need for method protocols.
-/// Stub implementations are for rust-numpy.
+/// Defines all methods for object protocols.
+// Note: stub implementations are for rust-numpy. Please remove them.
 pub trait PyProtoMethods {
     fn async_methods() -> Option<NonNull<PyAsyncMethods>> {
         None
@@ -41,7 +41,7 @@ pub trait PyProtoMethods {
     }
 }
 
-/// Indicates that a type has a protocol registry.
+/// Indicates that a type has a protocol registry. Implemented by `#[pyclass]`.
 #[doc(hidden)]
 pub trait HasProtoRegistry: Sized + 'static {
     fn registry() -> &'static PyProtoRegistry;
@@ -49,34 +49,36 @@ pub trait HasProtoRegistry: Sized + 'static {
 
 impl<T: HasProtoRegistry> PyProtoMethods for T {
     fn async_methods() -> Option<NonNull<PyAsyncMethods>> {
-        NonNull::new(Self::registry().async_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().async_methods.load(Ordering::Relaxed))
     }
     fn basic_methods() -> Option<NonNull<PyObjectMethods>> {
-        NonNull::new(Self::registry().basic_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().basic_methods.load(Ordering::Relaxed))
     }
     fn buffer_methods() -> Option<NonNull<PyBufferProcs>> {
-        NonNull::new(Self::registry().buffer_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().buffer_methods.load(Ordering::Relaxed))
     }
     fn descr_methods() -> Option<NonNull<PyDescrMethods>> {
-        NonNull::new(Self::registry().descr_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().descr_methods.load(Ordering::Relaxed))
     }
     fn gc_methods() -> Option<NonNull<PyGCMethods>> {
-        NonNull::new(Self::registry().gc_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().gc_methods.load(Ordering::Relaxed))
     }
     fn mapping_methods() -> Option<NonNull<PyMappingMethods>> {
-        NonNull::new(Self::registry().mapping_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().mapping_methods.load(Ordering::Relaxed))
     }
     fn number_methods() -> Option<NonNull<PyNumberMethods>> {
-        NonNull::new(Self::registry().number_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().number_methods.load(Ordering::Relaxed))
     }
     fn iter_methods() -> Option<NonNull<PyIterMethods>> {
-        NonNull::new(Self::registry().iter_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().iter_methods.load(Ordering::Relaxed))
     }
     fn sequence_methods() -> Option<NonNull<PySequenceMethods>> {
-        NonNull::new(Self::registry().sequence_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().sequence_methods.load(Ordering::Relaxed))
     }
 }
 
+/// Stores all method protocols.
+/// Used in the proc-macro code as a static variable.
 #[doc(hidden)]
 pub struct PyProtoRegistry {
     /// Async protocols.
@@ -115,38 +117,38 @@ impl PyProtoRegistry {
     }
     pub fn set_async_methods(&self, methods: PyAsyncMethods) {
         self.async_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
     pub fn set_basic_methods(&self, methods: PyObjectMethods) {
         self.basic_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
     pub fn set_buffer_methods(&self, methods: PyBufferProcs) {
         self.buffer_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
     pub fn set_descr_methods(&self, methods: PyDescrMethods) {
         self.descr_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
     pub fn set_gc_methods(&self, methods: PyGCMethods) {
         self.gc_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
     pub fn set_mapping_methods(&self, methods: PyMappingMethods) {
         self.mapping_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
     pub fn set_number_methods(&self, methods: PyNumberMethods) {
         self.number_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
     pub fn set_iter_methods(&self, methods: PyIterMethods) {
         self.iter_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
     pub fn set_sequence_methods(&self, methods: PySequenceMethods) {
         self.sequence_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
 }

--- a/src/class/proto_methods.rs
+++ b/src/class/proto_methods.rs
@@ -1,24 +1,45 @@
-use crate::class::{basic::PyObjectMethods, descr::PyDescrMethods, iter::PyIterMethods};
-use crate::ffi::PyBufferProcs;
+use crate::class::{
+    basic::PyObjectMethods, descr::PyDescrMethods, gc::PyGCMethods, iter::PyIterMethods,
+};
+use crate::ffi::{PyBufferProcs, PyMappingMethods, PyNumberMethods};
 use std::{
     ptr::{self, NonNull},
     sync::atomic::{AtomicPtr, Ordering},
 };
 
-/// For rust-numpy, we need a stub implementation.
+/// Defines what we need for method protocols.
+/// Stub implementations are for rust-numpy.
 pub trait PyProtoMethods {
-    fn basic_methods() -> Option<NonNull<PyObjectMethods>>;
-    fn buffer_methods() -> Option<NonNull<PyBufferProcs>>;
-    fn descr_methods() -> Option<NonNull<PyDescrMethods>>;
-    fn iter_methods() -> Option<NonNull<PyIterMethods>>;
+    fn basic_methods() -> Option<NonNull<PyObjectMethods>> {
+        None
+    }
+    fn buffer_methods() -> Option<NonNull<PyBufferProcs>> {
+        None
+    }
+    fn descr_methods() -> Option<NonNull<PyDescrMethods>> {
+        None
+    }
+    fn gc_methods() -> Option<NonNull<PyGCMethods>> {
+        None
+    }
+    fn mapping_methods() -> Option<NonNull<PyMappingMethods>> {
+        None
+    }
+    fn number_methods() -> Option<NonNull<PyNumberMethods>> {
+        None
+    }
+    fn iter_methods() -> Option<NonNull<PyIterMethods>> {
+        None
+    }
 }
 
+/// Indicates that a type has a protocol registory.
 #[doc(hidden)]
-pub trait HasPyProtoRegistry: Sized + 'static {
+pub trait HasProtoRegistry: Sized + 'static {
     fn registory() -> &'static PyProtoRegistry;
 }
 
-impl<T: HasPyProtoRegistry> PyProtoMethods for T {
+impl<T: HasProtoRegistry> PyProtoMethods for T {
     fn basic_methods() -> Option<NonNull<PyObjectMethods>> {
         NonNull::new(Self::registory().basic_methods.load(Ordering::SeqCst))
     }
@@ -28,6 +49,15 @@ impl<T: HasPyProtoRegistry> PyProtoMethods for T {
     fn descr_methods() -> Option<NonNull<PyDescrMethods>> {
         NonNull::new(Self::registory().descr_methods.load(Ordering::SeqCst))
     }
+    fn gc_methods() -> Option<NonNull<PyGCMethods>> {
+        NonNull::new(Self::registory().gc_methods.load(Ordering::SeqCst))
+    }
+    fn mapping_methods() -> Option<NonNull<PyMappingMethods>> {
+        NonNull::new(Self::registory().mapping_methods.load(Ordering::SeqCst))
+    }
+    fn number_methods() -> Option<NonNull<PyNumberMethods>> {
+        NonNull::new(Self::registory().number_methods.load(Ordering::SeqCst))
+    }
     fn iter_methods() -> Option<NonNull<PyIterMethods>> {
         NonNull::new(Self::registory().iter_methods.load(Ordering::SeqCst))
     }
@@ -35,13 +65,19 @@ impl<T: HasPyProtoRegistry> PyProtoMethods for T {
 
 #[doc(hidden)]
 pub struct PyProtoRegistry {
-    // Basic Protocols
+    /// Basic protocols.
     basic_methods: AtomicPtr<PyObjectMethods>,
-    // Buffer Protocols
+    /// Buffer protocols.
     buffer_methods: AtomicPtr<PyBufferProcs>,
-    // Descr Protocols
+    /// Descr pProtocols.
     descr_methods: AtomicPtr<PyDescrMethods>,
-    // Iterator Protocols
+    /// GC protocols.
+    gc_methods: AtomicPtr<PyGCMethods>,
+    /// Mapping protocols.
+    mapping_methods: AtomicPtr<PyMappingMethods>,
+    /// Number protocols.
+    number_methods: AtomicPtr<PyNumberMethods>,
+    /// Iterator protocols.
     iter_methods: AtomicPtr<PyIterMethods>,
 }
 
@@ -51,6 +87,9 @@ impl PyProtoRegistry {
             basic_methods: AtomicPtr::new(ptr::null_mut()),
             buffer_methods: AtomicPtr::new(ptr::null_mut()),
             descr_methods: AtomicPtr::new(ptr::null_mut()),
+            gc_methods: AtomicPtr::new(ptr::null_mut()),
+            mapping_methods: AtomicPtr::new(ptr::null_mut()),
+            number_methods: AtomicPtr::new(ptr::null_mut()),
             iter_methods: AtomicPtr::new(ptr::null_mut()),
         }
     }
@@ -64,6 +103,18 @@ impl PyProtoRegistry {
     }
     pub fn set_descr_methods(&self, methods: PyDescrMethods) {
         self.descr_methods
+            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+    }
+    pub fn set_gc_methods(&self, methods: PyGCMethods) {
+        self.gc_methods
+            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+    }
+    pub fn set_mapping_methods(&self, methods: PyMappingMethods) {
+        self.mapping_methods
+            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+    }
+    pub fn set_number_methods(&self, methods: PyNumberMethods) {
+        self.number_methods
             .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
     }
     pub fn set_iter_methods(&self, methods: PyIterMethods) {

--- a/src/class/proto_methods.rs
+++ b/src/class/proto_methods.rs
@@ -1,0 +1,73 @@
+use crate::class::{basic::PyObjectMethods, descr::PyDescrMethods, iter::PyIterMethods};
+use crate::ffi::PyBufferProcs;
+use std::{
+    ptr::{self, NonNull},
+    sync::atomic::{AtomicPtr, Ordering},
+};
+
+/// For rust-numpy, we need a stub implementation.
+pub trait PyProtoMethods {
+    fn basic_methods() -> Option<NonNull<PyObjectMethods>>;
+    fn buffer_methods() -> Option<NonNull<PyBufferProcs>>;
+    fn descr_methods() -> Option<NonNull<PyDescrMethods>>;
+    fn iter_methods() -> Option<NonNull<PyIterMethods>>;
+}
+
+#[doc(hidden)]
+pub trait HasPyProtoRegistry: Sized + 'static {
+    fn registory() -> &'static PyProtoRegistry;
+}
+
+impl<T: HasPyProtoRegistry> PyProtoMethods for T {
+    fn basic_methods() -> Option<NonNull<PyObjectMethods>> {
+        NonNull::new(Self::registory().basic_methods.load(Ordering::SeqCst))
+    }
+    fn buffer_methods() -> Option<NonNull<PyBufferProcs>> {
+        NonNull::new(Self::registory().buffer_methods.load(Ordering::SeqCst))
+    }
+    fn descr_methods() -> Option<NonNull<PyDescrMethods>> {
+        NonNull::new(Self::registory().descr_methods.load(Ordering::SeqCst))
+    }
+    fn iter_methods() -> Option<NonNull<PyIterMethods>> {
+        NonNull::new(Self::registory().iter_methods.load(Ordering::SeqCst))
+    }
+}
+
+#[doc(hidden)]
+pub struct PyProtoRegistry {
+    // Basic Protocols
+    basic_methods: AtomicPtr<PyObjectMethods>,
+    // Buffer Protocols
+    buffer_methods: AtomicPtr<PyBufferProcs>,
+    // Descr Protocols
+    descr_methods: AtomicPtr<PyDescrMethods>,
+    // Iterator Protocols
+    iter_methods: AtomicPtr<PyIterMethods>,
+}
+
+impl PyProtoRegistry {
+    pub const fn new() -> Self {
+        PyProtoRegistry {
+            basic_methods: AtomicPtr::new(ptr::null_mut()),
+            buffer_methods: AtomicPtr::new(ptr::null_mut()),
+            descr_methods: AtomicPtr::new(ptr::null_mut()),
+            iter_methods: AtomicPtr::new(ptr::null_mut()),
+        }
+    }
+    pub fn set_basic_methods(&self, methods: PyObjectMethods) {
+        self.basic_methods
+            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+    }
+    pub fn set_buffer_methods(&self, methods: PyBufferProcs) {
+        self.buffer_methods
+            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+    }
+    pub fn set_descr_methods(&self, methods: PyDescrMethods) {
+        self.descr_methods
+            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+    }
+    pub fn set_iter_methods(&self, methods: PyIterMethods) {
+        self.iter_methods
+            .store(Box::into_raw(Box::new(methods)), Ordering::SeqCst)
+    }
+}

--- a/src/class/proto_methods.rs
+++ b/src/class/proto_methods.rs
@@ -41,39 +41,39 @@ pub trait PyProtoMethods {
     }
 }
 
-/// Indicates that a type has a protocol registory.
+/// Indicates that a type has a protocol registry.
 #[doc(hidden)]
 pub trait HasProtoRegistry: Sized + 'static {
-    fn registory() -> &'static PyProtoRegistry;
+    fn registry() -> &'static PyProtoRegistry;
 }
 
 impl<T: HasProtoRegistry> PyProtoMethods for T {
     fn async_methods() -> Option<NonNull<PyAsyncMethods>> {
-        NonNull::new(Self::registory().async_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().async_methods.load(Ordering::SeqCst))
     }
     fn basic_methods() -> Option<NonNull<PyObjectMethods>> {
-        NonNull::new(Self::registory().basic_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().basic_methods.load(Ordering::SeqCst))
     }
     fn buffer_methods() -> Option<NonNull<PyBufferProcs>> {
-        NonNull::new(Self::registory().buffer_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().buffer_methods.load(Ordering::SeqCst))
     }
     fn descr_methods() -> Option<NonNull<PyDescrMethods>> {
-        NonNull::new(Self::registory().descr_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().descr_methods.load(Ordering::SeqCst))
     }
     fn gc_methods() -> Option<NonNull<PyGCMethods>> {
-        NonNull::new(Self::registory().gc_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().gc_methods.load(Ordering::SeqCst))
     }
     fn mapping_methods() -> Option<NonNull<PyMappingMethods>> {
-        NonNull::new(Self::registory().mapping_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().mapping_methods.load(Ordering::SeqCst))
     }
     fn number_methods() -> Option<NonNull<PyNumberMethods>> {
-        NonNull::new(Self::registory().number_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().number_methods.load(Ordering::SeqCst))
     }
     fn iter_methods() -> Option<NonNull<PyIterMethods>> {
-        NonNull::new(Self::registory().iter_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().iter_methods.load(Ordering::SeqCst))
     }
     fn sequence_methods() -> Option<NonNull<PySequenceMethods>> {
-        NonNull::new(Self::registory().sequence_methods.load(Ordering::SeqCst))
+        NonNull::new(Self::registry().sequence_methods.load(Ordering::SeqCst))
     }
 }
 

--- a/src/class/pyasync.rs
+++ b/src/class/pyasync.rs
@@ -89,6 +89,7 @@ pub trait PyAsyncAexitProtocol<'p>: PyAsyncProtocol<'p> {
     type Result: Into<PyResult<Self::Success>>;
 }
 
+#[doc(hidden)]
 impl ffi::PyAsyncMethods {
     pub fn set_await<T>(&mut self)
     where

--- a/src/class/pyasync.rs
+++ b/src/class/pyasync.rs
@@ -85,92 +85,29 @@ pub trait PyAsyncAexitProtocol<'p>: PyAsyncProtocol<'p> {
     type Result: Into<PyResult<Self::Success>>;
 }
 
-#[doc(hidden)]
-pub trait PyAsyncProtocolImpl {
-    fn tp_as_async() -> Option<ffi::PyAsyncMethods>;
-}
-
-impl<T> PyAsyncProtocolImpl for T {
-    default fn tp_as_async() -> Option<ffi::PyAsyncMethods> {
-        None
+impl ffi::PyAsyncMethods {
+    pub fn set_await<T>(&mut self)
+    where
+        T: for<'p> PyAsyncAwaitProtocol<'p>,
+    {
+        self.am_await = py_unary_func!(PyAsyncAwaitProtocol, T::__await__);
     }
-}
-
-impl<'p, T> PyAsyncProtocolImpl for T
-where
-    T: PyAsyncProtocol<'p>,
-{
-    #[inline]
-    fn tp_as_async() -> Option<ffi::PyAsyncMethods> {
-        Some(ffi::PyAsyncMethods {
-            am_await: Self::am_await(),
-            am_aiter: Self::am_aiter(),
-            am_anext: Self::am_anext(),
-        })
+    pub fn set_aiter<T>(&mut self)
+    where
+        T: for<'p> PyAsyncAiterProtocol<'p>,
+    {
+        self.am_aiter = py_unary_func!(PyAsyncAiterProtocol, T::__aiter__);
     }
-}
-
-trait PyAsyncAwaitProtocolImpl {
-    fn am_await() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyAsyncAwaitProtocolImpl for T
-where
-    T: PyAsyncProtocol<'p>,
-{
-    default fn am_await() -> Option<ffi::unaryfunc> {
-        None
-    }
-}
-
-impl<T> PyAsyncAwaitProtocolImpl for T
-where
-    T: for<'p> PyAsyncAwaitProtocol<'p>,
-{
-    #[inline]
-    fn am_await() -> Option<ffi::unaryfunc> {
-        py_unary_func!(PyAsyncAwaitProtocol, T::__await__)
-    }
-}
-
-trait PyAsyncAiterProtocolImpl {
-    fn am_aiter() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyAsyncAiterProtocolImpl for T
-where
-    T: PyAsyncProtocol<'p>,
-{
-    default fn am_aiter() -> Option<ffi::unaryfunc> {
-        None
-    }
-}
-
-impl<T> PyAsyncAiterProtocolImpl for T
-where
-    T: for<'p> PyAsyncAiterProtocol<'p>,
-{
-    #[inline]
-    fn am_aiter() -> Option<ffi::unaryfunc> {
-        py_unary_func!(PyAsyncAiterProtocol, T::__aiter__)
-    }
-}
-
-trait PyAsyncAnextProtocolImpl {
-    fn am_anext() -> Option<ffi::unaryfunc>;
-}
-
-impl<'p, T> PyAsyncAnextProtocolImpl for T
-where
-    T: PyAsyncProtocol<'p>,
-{
-    default fn am_anext() -> Option<ffi::unaryfunc> {
-        None
+    pub fn set_anext<T>(&mut self)
+    where
+        T: for<'p> PyAsyncAnextProtocol<'p>,
+    {
+        self.am_anext = anext::am_anext::<T>();
     }
 }
 
 mod anext {
-    use super::{PyAsyncAnextProtocol, PyAsyncAnextProtocolImpl};
+    use super::PyAsyncAnextProtocol;
     use crate::callback::IntoPyCallbackOutput;
     use crate::err::PyResult;
     use crate::IntoPyPointer;
@@ -191,19 +128,17 @@ mod anext {
         }
     }
 
-    impl<T> PyAsyncAnextProtocolImpl for T
+    #[inline]
+    pub(super) fn am_anext<T>() -> Option<ffi::unaryfunc>
     where
         T: for<'p> PyAsyncAnextProtocol<'p>,
     {
-        #[inline]
-        fn am_anext() -> Option<ffi::unaryfunc> {
-            py_unary_func!(
-                PyAsyncAnextProtocol,
-                T::__anext__,
-                call_mut,
-                *mut crate::ffi::PyObject,
-                IterANextOutput
-            )
-        }
+        py_unary_func!(
+            PyAsyncAnextProtocol,
+            T::__anext__,
+            call_mut,
+            *mut crate::ffi::PyObject,
+            IterANextOutput
+        )
     }
 }

--- a/src/class/sequence.rs
+++ b/src/class/sequence.rs
@@ -126,6 +126,7 @@ pub trait PySequenceInplaceRepeatProtocol<'p>: PySequenceProtocol<'p> + IntoPy<P
     type Result: Into<PyResult<Self>>;
 }
 
+#[doc(hidden)]
 impl ffi::PySequenceMethods {
     pub fn set_len<T>(&mut self)
     where

--- a/src/ffi/object.rs
+++ b/src/ffi/object.rs
@@ -438,14 +438,16 @@ mod typeobject {
     impl Default for PyAsyncMethods {
         #[inline]
         fn default() -> Self {
-            unsafe { mem::zeroed() }
+            PyAsyncMethods_INIT
         }
     }
+
     pub const PyAsyncMethods_INIT: PyAsyncMethods = PyAsyncMethods {
         am_await: None,
         am_aiter: None,
         am_anext: None,
     };
+
     #[repr(C)]
     #[derive(Copy, Clone, Debug)]
     pub struct PyBufferProcs {
@@ -456,9 +458,10 @@ mod typeobject {
     impl Default for PyBufferProcs {
         #[inline]
         fn default() -> Self {
-            unsafe { mem::zeroed() }
+            PyBufferProcs_INIT
         }
     }
+
     pub const PyBufferProcs_INIT: PyBufferProcs = PyBufferProcs {
         bf_getbuffer: None,
         bf_releasebuffer: None,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -45,9 +45,8 @@ pub unsafe trait PyNativeType: Sized {
 #[repr(transparent)]
 pub struct Py<T>(NonNull<ffi::PyObject>, PhantomData<T>);
 
-unsafe impl<T> Send for Py<T> {}
-
-unsafe impl<T> Sync for Py<T> {}
+unsafe impl<T: Send> Send for Py<T> {}
+unsafe impl<T: Sync> Sync for Py<T> {}
 
 impl<T> Py<T> {
     /// Create a new instance `Py<T>`.

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -45,8 +45,8 @@ pub unsafe trait PyNativeType: Sized {
 #[repr(transparent)]
 pub struct Py<T>(NonNull<ffi::PyObject>, PhantomData<T>);
 
-unsafe impl<T: Send> Send for Py<T> {}
-unsafe impl<T: Sync> Sync for Py<T> {}
+unsafe impl<T> Send for Py<T> {}
+unsafe impl<T> Sync for Py<T> {}
 
 impl<T> Py<T> {
     /// Create a new instance `Py<T>`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,7 @@ pub use crate::types::PyAny;
 #[cfg(feature = "macros")]
 #[doc(hidden)]
 pub use {
+    ctor,      // Re-exported for pyproto
     indoc,     // Re-exported for py_run
     inventory, // Re-exported for pymethods
     paste,     // Re-exported for wrap_function

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -372,7 +372,7 @@ impl<T: PyClass> AsPyPointer for PyCell<T> {
     }
 }
 
-impl<T: PyClass + Send + Sync> ToPyObject for &PyCell<T> {
+impl<T: PyClass> ToPyObject for &PyCell<T> {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         unsafe { PyObject::from_borrowed_ptr(py, self.as_ptr()) }
     }

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -372,7 +372,7 @@ impl<T: PyClass> AsPyPointer for PyCell<T> {
     }
 }
 
-impl<T: PyClass> ToPyObject for &PyCell<T> {
+impl<T: PyClass + Send + Sync> ToPyObject for &PyCell<T> {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         unsafe { PyObject::from_borrowed_ptr(py, self.as_ptr()) }
     }

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -157,21 +157,14 @@ where
         unsafe { basic.as_ref() }.update_typeobj(type_object);
     }
 
-    fn to_ptr<T>(value: Option<T>) -> *mut T {
-        value
-            .map(|v| Box::into_raw(Box::new(v)))
-            .unwrap_or_else(ptr::null_mut)
-    }
-
     // number methods
     type_object.tp_as_number = T::number_methods().map_or_else(ptr::null_mut, |p| p.as_ptr());
     // mapping methods
     type_object.tp_as_mapping = T::mapping_methods().map_or_else(ptr::null_mut, |p| p.as_ptr());
     // sequence methods
-    type_object.tp_as_sequence =
-        to_ptr(<T as class::sequence::PySequenceProtocolImpl>::tp_as_sequence());
+    type_object.tp_as_sequence = T::sequence_methods().map_or_else(ptr::null_mut, |p| p.as_ptr());
     // async methods
-    type_object.tp_as_async = to_ptr(<T as class::pyasync::PyAsyncProtocolImpl>::tp_as_async());
+    type_object.tp_as_async = T::async_methods().map_or_else(ptr::null_mut, |p| p.as_ptr());
     // buffer protocol
     type_object.tp_as_buffer = T::buffer_methods().map_or_else(ptr::null_mut, |p| p.as_ptr());
 

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -607,12 +607,12 @@ import sys
 async def main():
     res = await Once(await asyncio.sleep(0.1))
     return res
-
-# It looks like that https://bugs.python.org/issue38563 solves this problem,
-# but we see still errors on Github actions...
+# For an odd error similar to https://bugs.python.org/issue38563
 if sys.platform == "win32" and sys.version_info >= (3, 8, 0):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-loop = asyncio.get_event_loop()
+# get_event_loop can raise an error: https://github.com/PyO3/pyo3/pull/961#issuecomment-645238579
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
 assert loop.run_until_complete(main()) is None
 loop.close()
 "#

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -121,10 +121,6 @@ impl PyObjectProtocol for Comparisons {
     fn __hash__(&self) -> PyResult<isize> {
         Ok(self.val as isize)
     }
-}
-
-#[pyproto]
-impl pyo3::class::PyNumberProtocol for Comparisons {
     fn __bool__(&self) -> PyResult<bool> {
         Ok(self.val != 0)
     }

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -121,6 +121,10 @@ impl PyObjectProtocol for Comparisons {
     fn __hash__(&self) -> PyResult<isize> {
         Ok(self.val as isize)
     }
+}
+
+#[pyproto]
+impl pyo3::class::PyNumberProtocol for Comparisons {
     fn __bool__(&self) -> PyResult<bool> {
         Ok(self.val != 0)
     }


### PR DESCRIPTION
For #210.
Now all pyclass has a method registory for protocols:
```rust
impl pyo3::class::proto_methods::HasProtoRegistry for MyClass {
    fn registory() -> &'static pyo3::class::proto_methods::PyProtoRegistry {
        static REGISTRY: PyProtoRegistry = PyProtoRegistry::new();
        &REGISTRY
    }
}
```
, where `PyProtoRegistory` is a set of *method tables*:
```rust
#[doc(hidden)]
pub struct PyProtoRegistry {
    async_methods: AtomicPtr<PyAsyncMethods>,
    basic_methods: AtomicPtr<PyObjectMethods>,
    ...
}
```
.

Using the [`ctor`](https://github.com/mmastrac/rust-ctor) crate, we insert some initialization codes for this registry.
For example, when we write this code:
```rust
#[pyproto]
impl PyObjectProtocol for MyClass {
    fn __hash__(&self) -> PyResult<isize> {
        Ok(self.val as isize)
    }
}
```
, (roughly) the following code is generated:
```rust
#[ctor]
fn __init_Object_2817873() {
    let mut table = pyo3::class::PyObjectMethods::default();
    table.set_hash::<MyClass>();
    <MyClass as pyo3::class::proto_methods::HasProtoRegistry>::registory().set_basic_methods(table);
}
```

One disadvantage of this solution is it needs redundant `Box::new` for some protocols(basic, iter, and so on). However, to keep `PyProtoRegistry` simple and small, I chose this design.


Unfortunately, some protocols are not yet tested.

### TODO
- [x] Add tests for async protocols
  - [x] Maybe we need to change the trait definition to make it work?
- [x] Add tests for descr protocols
- [x] Maybe need some more doc comments?