### PR TITLE
Require Send for #[pyclass] (no compilefail test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Simplify internals of `#[pyo3(get)]` attribute. (Remove the hidden API `GetPropertyValue`.) [#934](https://github.com/PyO3/pyo3/pull/934)
 - Call `Py_Finalize` at exit to flush buffers, etc. [#943](https://github.com/PyO3/pyo3/pull/943)
 - Add type parameter to PyBuffer. #[951](https://github.com/PyO3/pyo3/pull/951)
+- Require `Send` bound for `#[pyclass]`. [#966](https://github.com/PyO3/pyo3/pull/966)
 
 ### Removed
 - Remove `ManagedPyRef` (unused, and needs specialization) [#930](https://github.com/PyO3/pyo3/pull/930)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -14,10 +14,9 @@ struct MyClass {
 }
 ```
 
-The above example generates implementations for [`PyTypeInfo`], [`PyTypeObject`],
-and [`PyClass`] for `MyClass`.
+Because Python objects are freely shared between threads by the Python interpreter, all structs annotated with `#[pyclass]` must implement `Send`.
 
-If you curious what `#[pyclass]` generates, see [How methods are implemented](#how-methods-are-implemented) section.
+The above example generates implementations for [`PyTypeInfo`], [`PyTypeObject`], and [`PyClass`] for `MyClass`. To see these generated implementations, refer to the section [How methods are implemented](#how-methods-are-implemented) at the end of this chapter.
 
 ## Adding the class to a module
 

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -72,7 +72,9 @@ pub unsafe fn tp_free_fallback(obj: *mut ffi::PyObject) {
 ///
 /// The `#[pyclass]` attribute automatically implements this trait for your Rust struct,
 /// so you don't have to use this trait directly.
-pub trait PyClass: PyTypeInfo<Layout = PyCell<Self>> + Sized + PyClassAlloc + PyMethods {
+pub trait PyClass:
+    PyTypeInfo<Layout = PyCell<Self>> + Sized + PyClassAlloc + PyMethods + Send
+{
     /// Specify this class has `#[pyclass(dict)]` or not.
     type Dict: PyClassDict;
     /// Specify this class has `#[pyclass(weakref)]` or not.

--- a/tests/ui/static_ref.rs
+++ b/tests/ui/static_ref.rs
@@ -1,17 +1,9 @@
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
-#[pyclass]
-struct MyClass {
-    list: &'static PyList,
-}
-
-#[pymethods]
-impl MyClass {
-    #[new]
-    fn new(list: &'static PyList) -> Self {
-        Self { list }
-    }
+#[pyfunction]
+fn static_ref(list: &'static PyList) -> usize {
+    list.len()
 }
 
 fn main() {}

--- a/tests/ui/static_ref.stderr
+++ b/tests/ui/static_ref.stderr
@@ -1,8 +1,8 @@
 error[E0597]: `pool` does not live long enough
- --> $DIR/static_ref.rs:9:1
+ --> $DIR/static_ref.rs:4:1
   |
-9 | #[pymethods]
-  | ^^^^^^^^^^^^
+4 | #[pyfunction]
+  | ^^^^^^^^^^^^^
   | |
   | borrowed value does not live long enough
   | `pool` dropped here while still borrowed


### PR DESCRIPTION
This is the same as #948, rebased on master, without the compile_fail test. I wanted to propose merging this fix without blocking on the `trybuild` issue.

I will leave #948 open, and once my bugfix for `trybuild` is released, I will rebase it and we can merge the test.