### PR TITLE
Add accessor methods to `PyByteArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add FFI definition `PyObject_AsFileDescriptor` [#938](https://github.com/PyO3/pyo3/pull/938)
+- Add `PyByteArray::data`, `PyByteArray::as_bytes`, and `PyByteArray::as_bytes_mut`. [#967](https://github.com/PyO3/pyo3/pull/967)
 
 ### Changed
 - Simplify internals of `#[pyo3(get)]` attribute. (Remove the hidden API `GetPropertyValue`.) [#934](https://github.com/PyO3/pyo3/pull/934)


### PR DESCRIPTION
Closes #632 .

This adds `PyByteArray::data` and `PyByteArray::as_bytes` as proposed in that issue.

I decided to also add `as_bytes_mut`, but if you think it's too far I can happily remove it. (Users can always implement themselves using `std::slice::from_raw_parts_mut(b.data(), b.len())`.)