### PR TITLE
Cleanups to ensure GIL-safety of Py<T> and PyObject methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Call `Py_Finalize` at exit to flush buffers, etc. [#943](https://github.com/PyO3/pyo3/pull/943)
 - Add type parameter to PyBuffer. #[951](https://github.com/PyO3/pyo3/pull/951)
 - Require `Send` bound for `#[pyclass]`. [#966](https://github.com/PyO3/pyo3/pull/966)
+- Add `Python` argument to most methods on `PyObject` and `Py<T>` to ensure GIL safety. [#970](https://github.com/PyO3/pyo3/pull/970)
+- Change signature of `PyTypeObject::type_object()` - now takes `Python` argument and returns `&PyType`. [#970](https://github.com/PyO3/pyo3/pull/970)
+- Change return type of `PyTuple::slice()` and `PyTuple::split_from()` from `Py<PyTuple>` to `&PyTuple`. [#970](https://github.com/PyO3/pyo3/pull/970)
 - Change return type of `PyTuple::as_slice` to `&[&PyAny]`. [#971](https://github.com/PyO3/pyo3/pull/971)
 
 ### Removed

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -419,7 +419,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     unsafe fn from_owned_ptr_or_panic(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         match Self::from_owned_ptr_or_opt(py, ptr) {
             Some(s) => s,
-            None => err::panic_after_error(),
+            None => err::panic_after_error(py),
         }
     }
     unsafe fn from_owned_ptr(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
@@ -436,7 +436,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     unsafe fn from_borrowed_ptr_or_panic(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         match Self::from_borrowed_ptr_or_opt(py, ptr) {
             Some(s) => s,
-            None => err::panic_after_error(),
+            None => err::panic_after_error(py),
         }
     }
     unsafe fn from_borrowed_ptr(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -89,7 +89,7 @@ macro_rules! import_exception {
 macro_rules! import_exception_type_object {
     ($module: expr, $name: ident) => {
         unsafe impl $crate::type_object::PyTypeObject for $name {
-            fn type_object() -> $crate::Py<$crate::types::PyType> {
+            fn type_object(py: $crate::Python) -> &$crate::types::PyType {
                 use $crate::type_object::LazyHeapType;
                 static TYPE_OBJECT: LazyHeapType = LazyHeapType::new();
 
@@ -111,7 +111,7 @@ macro_rules! import_exception_type_object {
                     }
                 });
 
-                unsafe { $crate::Py::from_borrowed_ptr(ptr.as_ptr() as *mut $crate::ffi::PyObject) }
+                unsafe { py.from_borrowed_ptr(ptr.as_ptr() as *mut $crate::ffi::PyObject) }
             }
         }
     };
@@ -173,7 +173,7 @@ macro_rules! create_exception {
 macro_rules! create_exception_type_object {
     ($module: ident, $name: ident, $base: ty) => {
         unsafe impl $crate::type_object::PyTypeObject for $name {
-            fn type_object() -> $crate::Py<$crate::types::PyType> {
+            fn type_object(py: $crate::Python) -> &$crate::types::PyType {
                 use $crate::type_object::LazyHeapType;
                 static TYPE_OBJECT: LazyHeapType = LazyHeapType::new();
 
@@ -186,7 +186,7 @@ macro_rules! create_exception_type_object {
                     )
                 });
 
-                unsafe { $crate::Py::from_borrowed_ptr(ptr.as_ptr() as *mut $crate::ffi::PyObject) }
+                unsafe { py.from_borrowed_ptr(ptr.as_ptr() as *mut $crate::ffi::PyObject) }
             }
         }
     };
@@ -215,8 +215,8 @@ macro_rules! impl_native_exception (
             }
         }
         unsafe impl PyTypeObject for $name {
-            fn type_object() -> $crate::Py<$crate::types::PyType> {
-                unsafe { $crate::Py::from_borrowed_ptr(ffi::$exc_name) }
+            fn type_object(py: $crate::Python) -> &$crate::types::PyType {
+                unsafe { py.from_borrowed_ptr(ffi::$exc_name) }
             }
         }
     );

--- a/src/object.rs
+++ b/src/object.rs
@@ -48,11 +48,11 @@ impl PyObject {
     /// Panics if the pointer is NULL.
     /// Undefined behavior if the pointer is invalid.
     #[inline]
-    pub unsafe fn from_owned_ptr_or_panic(_py: Python, ptr: *mut ffi::PyObject) -> PyObject {
+    pub unsafe fn from_owned_ptr_or_panic(py: Python, ptr: *mut ffi::PyObject) -> PyObject {
         match NonNull::new(ptr) {
             Some(nonnull_ptr) => PyObject(nonnull_ptr),
             None => {
-                crate::err::panic_after_error();
+                crate::err::panic_after_error(py);
             }
         }
     }
@@ -119,7 +119,7 @@ impl PyObject {
     }
 
     /// Gets the reference count of the ffi::PyObject pointer.
-    pub fn get_refcnt(&self) -> isize {
+    pub fn get_refcnt(&self, _py: Python) -> isize {
         unsafe { ffi::Py_REFCNT(self.0.as_ptr()) }
     }
 
@@ -131,7 +131,7 @@ impl PyObject {
     /// Returns whether the object is considered to be None.
     ///
     /// This is equivalent to the Python expression `self is None`.
-    pub fn is_none(&self) -> bool {
+    pub fn is_none(&self, _py: Python) -> bool {
         unsafe { ffi::Py_None() == self.as_ptr() }
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -6,9 +6,7 @@ use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::gil::{self, GILGuard, GILPool};
 use crate::type_object::{PyTypeInfo, PyTypeObject};
 use crate::types::{PyAny, PyDict, PyModule, PyType};
-use crate::{
-    ffi, AsPyPointer, AsPyRef, FromPyPointer, IntoPyPointer, PyNativeType, PyObject, PyTryFrom,
-};
+use crate::{ffi, AsPyPointer, FromPyPointer, IntoPyPointer, PyNativeType, PyObject, PyTryFrom};
 use std::ffi::CString;
 use std::marker::PhantomData;
 use std::os::raw::c_int;
@@ -253,7 +251,7 @@ impl<'p> Python<'p> {
     where
         T: PyTypeObject,
     {
-        unsafe { self.from_borrowed_ptr(T::type_object().into_ptr()) }
+        T::type_object(self)
     }
 
     /// Imports the Python module with the specified name.
@@ -265,7 +263,7 @@ impl<'p> Python<'p> {
     ///
     /// This is equivalent to the Python `isinstance` function.
     pub fn is_instance<T: PyTypeObject, V: AsPyPointer>(self, obj: &V) -> PyResult<bool> {
-        T::type_object().as_ref(self).is_instance(obj)
+        T::type_object(self).is_instance(obj)
     }
 
     /// Checks whether type `T` is subclass of type `U`.
@@ -276,7 +274,7 @@ impl<'p> Python<'p> {
         T: PyTypeObject,
         U: PyTypeObject,
     {
-        T::type_object().as_ref(self).is_subclass::<U>()
+        T::type_object(self).is_subclass::<U>()
     }
 
     /// Gets the Python builtin value `None`.

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -4,7 +4,7 @@
 use crate::pyclass::{initialize_type_object, PyClass};
 use crate::pyclass_init::PyObjectInit;
 use crate::types::{PyAny, PyType};
-use crate::{ffi, AsPyPointer, Py, Python};
+use crate::{ffi, AsPyPointer, Python};
 use std::cell::UnsafeCell;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -124,15 +124,15 @@ pub unsafe trait PyTypeInfo: Sized {
 /// See [PyTypeInfo::type_object]
 pub unsafe trait PyTypeObject {
     /// Returns the safe abstraction over the type object.
-    fn type_object() -> Py<PyType>;
+    fn type_object(py: Python) -> &PyType;
 }
 
 unsafe impl<T> PyTypeObject for T
 where
     T: PyTypeInfo,
 {
-    fn type_object() -> Py<PyType> {
-        unsafe { Py::from_borrowed_ptr(<Self as PyTypeInfo>::type_object() as *const _ as _) }
+    fn type_object(py: Python) -> &PyType {
+        unsafe { py.from_borrowed_ptr(<Self as PyTypeInfo>::type_object() as *const _ as _) }
     }
 }
 

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -479,11 +479,11 @@ mod test {
         {
             let _pool = unsafe { crate::GILPool::new() };
             let none = py.None();
-            cnt = none.get_refcnt();
+            cnt = none.get_refcnt(py);
             let _dict = [(10, none)].into_py_dict(py);
         }
         {
-            assert_eq!(cnt, py.None().get_refcnt());
+            assert_eq!(cnt, py.None().get_refcnt(py));
         }
     }
 

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -118,7 +118,7 @@ mod tests {
             let gil_guard = Python::acquire_gil();
             let py = gil_guard.python();
             obj = vec![10, 20].to_object(py);
-            count = obj.get_refcnt();
+            count = obj.get_refcnt(py);
         }
 
         {
@@ -129,7 +129,7 @@ mod tests {
 
             assert_eq!(10, it.next().unwrap().unwrap().extract().unwrap());
         }
-        assert_eq!(count, obj.get_refcnt());
+        assert_eq!(count, obj.get_refcnt(Python::acquire_gil().python()));
     }
 
     #[test]
@@ -146,7 +146,7 @@ mod tests {
             none = py.None();
             l.append(10).unwrap();
             l.append(&none).unwrap();
-            count = none.get_refcnt();
+            count = none.get_refcnt(py);
             obj = l.to_object(py);
         }
 
@@ -158,7 +158,7 @@ mod tests {
             assert_eq!(10, it.next().unwrap().unwrap().extract().unwrap());
             assert!(it.next().unwrap().unwrap().is_none());
         }
-        assert_eq!(count, none.get_refcnt());
+        assert_eq!(count, none.get_refcnt(py));
     }
 
     #[test]

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -303,11 +303,11 @@ mod test {
             let ob = v.to_object(py);
             let list = <PyList as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
             let none = py.None();
-            cnt = none.get_refcnt();
+            cnt = none.get_refcnt(py);
             list.set_item(0, none).unwrap();
         }
 
-        assert_eq!(cnt, py.None().get_refcnt());
+        assert_eq!(cnt, py.None().get_refcnt(py));
     }
 
     #[test]
@@ -336,11 +336,11 @@ mod test {
             let _pool = unsafe { crate::GILPool::new() };
             let list = PyList::empty(py);
             let none = py.None();
-            cnt = none.get_refcnt();
+            cnt = none.get_refcnt(py);
             list.insert(0, none).unwrap();
         }
 
-        assert_eq!(cnt, py.None().get_refcnt());
+        assert_eq!(cnt, py.None().get_refcnt(py));
     }
 
     #[test]
@@ -365,10 +365,10 @@ mod test {
             let _pool = unsafe { crate::GILPool::new() };
             let list = PyList::empty(py);
             let none = py.None();
-            cnt = none.get_refcnt();
+            cnt = none.get_refcnt(py);
             list.append(none).unwrap();
         }
-        assert_eq!(cnt, py.None().get_refcnt());
+        assert_eq!(cnt, py.None().get_refcnt(py));
     }
 
     #[test]

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -176,7 +176,7 @@ impl PyModule {
     where
         T: PyClass,
     {
-        self.add(T::NAME, <T as PyTypeObject>::type_object())
+        self.add(T::NAME, <T as PyTypeObject>::type_object(self.py()))
     }
 
     /// Adds a function or a (sub)module to a module, using the functions __name__ as name.

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -521,8 +521,8 @@ mod test {
         }
         {
             let gil = Python::acquire_gil();
-            let _py = gil.python();
-            assert_eq!(1, obj.get_refcnt());
+            let py = gil.python();
+            assert_eq!(1, obj.get_refcnt(py));
         }
     }
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -3,7 +3,7 @@
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
 use crate::err::{PyErr, PyResult};
-use crate::instance::{Py, PyNativeType};
+use crate::instance::PyNativeType;
 use crate::type_object::PyTypeObject;
 use crate::{ffi, AsPyPointer, PyAny, Python};
 use std::borrow::Cow;
@@ -18,8 +18,8 @@ pyobject_native_var_type!(PyType, ffi::PyType_Type, ffi::PyType_Check);
 impl PyType {
     /// Creates a new type object.
     #[inline]
-    pub fn new<T: PyTypeObject>() -> Py<PyType> {
-        T::type_object()
+    pub fn new<T: PyTypeObject>(py: Python) -> &PyType {
+        T::type_object(py)
     }
 
     /// Retrieves the underlying FFI pointer associated with this Python object.
@@ -48,7 +48,8 @@ impl PyType {
     where
         T: PyTypeObject,
     {
-        let result = unsafe { ffi::PyObject_IsSubclass(self.as_ptr(), T::type_object().as_ptr()) };
+        let result =
+            unsafe { ffi::PyObject_IsSubclass(self.as_ptr(), T::type_object(self.py()).as_ptr()) };
         if result == -1 {
             Err(PyErr::fetch(self.py()))
         } else if result == 1 {

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -284,7 +284,7 @@ fn gc_during_borrow() {
         }
 
         // get the traverse function
-        let ty = TraversableClass::type_object().as_ref(py).as_type_ptr();
+        let ty = TraversableClass::type_object(py).as_type_ptr();
         let traverse = (*ty).tp_traverse.unwrap();
 
         // create an object and check that traversing it works normally


### PR DESCRIPTION
Closes #949 

This introduces `Python` arguments to `Py<T>` and `PyObject` methods which really should be requiring the GIL.

Doing this higlighted a couple of other places across the codebase which could be tweaked:
- `PyTypeObject::type_object` now returns `&PyType` instead of `Py<PyType>` - should be faster as now no reference count increase needed.
- `PyTuple::slice` and `PyTuple::split_from` now return `&PyTuple`.