### PR TITLE
Revert soft-duplicated for Py::new

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -52,9 +52,8 @@ unsafe impl<T> Sync for Py<T> {}
 impl<T> Py<T> {
     /// Create a new instance `Py<T>`.
     ///
-    /// This method is **soft-duplicated** since PyO3 0.9.0.
-    /// Use [`PyCell::new`](../pycell/struct.PyCell.html#method.new) and
-    /// `Py::from` instead.
+    /// You can crate [`PyCell::new`](../pycell/struct.PyCell.html#method.new) and `Py::from`,
+    /// but this method can be more efficient.
     pub fn new(py: Python, value: impl Into<PyClassInitializer<T>>) -> PyResult<Py<T>>
     where
         T: PyClass,


### PR DESCRIPTION
Since `PyCell` is registered to GILPool, `Py<T>::new` can be more efficient especially when the object is directly returned to Python.
E.g.,
```rust
#[pyfunction] 
fn new_class(py: Python) -> Py<MyClass> {
    Py::new(py, ...)
}
```