### PR TITLE
Add PyClass borrow methods to Py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add FFI definition `PyObject_AsFileDescriptor` [#938](https://github.com/PyO3/pyo3/pull/938)
 - Add `PyByteArray::data`, `PyByteArray::as_bytes`, and `PyByteArray::as_bytes_mut`. [#967](https://github.com/PyO3/pyo3/pull/967)
+- Add `Py::borrow`, `Py::borrow_mut`, `Py::try_borrow`, and `Py::try_borrow_mut` for accessing `#[pyclass]` values. [#976](https://github.com/PyO3/pyo3/pull/976)
 
 ### Changed
 - Simplify internals of `#[pyo3(get)]` attribute. (Remove the hidden API `GetPropertyValue`.) [#934](https://github.com/PyO3/pyo3/pull/934)

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -166,8 +166,11 @@ pub struct PyCell<T: PyClass> {
 unsafe impl<T: PyClass> PyNativeType for PyCell<T> {}
 
 impl<T: PyClass> PyCell<T> {
-    /// Make new `PyCell` on the Python heap and returns the reference of it.
+    /// Make a new `PyCell` on the Python heap and return the reference to it.
     ///
+    /// In cases where the value in the cell does not need to be accessed immediately after
+    /// creation, consider [`Py::new`](../instance/struct.Py.html#method.new) as a more efficient
+    /// alternative.
     pub fn new(py: Python, value: impl Into<PyClassInitializer<T>>) -> PyResult<&Self>
     where
         T::BaseLayout: PyBorrowFlagLayout<T::BaseType>,

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -73,7 +73,11 @@ pub unsafe fn tp_free_fallback(obj: *mut ffi::PyObject) {
 /// The `#[pyclass]` attribute automatically implements this trait for your Rust struct,
 /// so you don't have to use this trait directly.
 pub trait PyClass:
-    PyTypeInfo<Layout = PyCell<Self>> + Sized + PyClassAlloc + PyMethods + Send
+    PyTypeInfo<Layout = PyCell<Self>, AsRefTarget = PyCell<Self>>
+    + Sized
+    + PyClassAlloc
+    + PyMethods
+    + Send
 {
     /// Specify this class has `#[pyclass(dict)]` or not.
     type Dict: PyClassDict;


### PR DESCRIPTION
This is a bit of an experimental follow-up to #974 .

As `Py::new` is more efficient than `PyCell::new`, maybe we can help encourage use of `Py::new` in most situations by adding `.borrow()`, `.try_borrow()`, `.borrow_mut()` and `.try_borrow_mut()` to `Py`.

It seems quite nice to me and leads to no breaking changes. If others also like this then I'd like to update the guide a bit to recommend use of `Py<T>` a bit clearer before merging.