### PR TITLE
Move cargo test guidelines to faq

### DIFF
--- a/guide/src/advanced.md
+++ b/guide/src/advanced.md
@@ -16,19 +16,6 @@ For most use cases this behaviour is invisible. Occasionally, however, users may
 
 The unsafe function `Python::new_pool` allows you to create a new `GILPool`. When doing this, you must be very careful to ensure that once the `GILPool` is dropped you do not retain access any owned references created after the `GILPool` was created.
 
-## Testing
-
-Currently, [#341](https://github.com/PyO3/pyo3/issues/341) causes `cargo test` to fail with weird linking errors when the `extension-module` feature is activated. For now you can work around this by making the `extension-module` feature optional and running the tests with `cargo test --no-default-features`:
-
-```toml
-[dependencies.pyo3]
-version = "0.8.1"
-
-[features]
-extension-module = ["pyo3/extension-module"]
-default = ["extension-module"]
-```
-
 ## The `nightly` feature
 
 The `pyo3/nightly` feature needs the nightly Rust compiler. This allows PyO3 to use Rust's unstable specialization feature to apply the following optimizations:

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -14,3 +14,16 @@
 PyO3 provides a struct [`GILOnceCell`] which works equivalently to `OnceCell` but relies solely on the Python GIL for thread safety. This means it can be used in place of `lazy_static` or `once_cell` where you are experiencing the deadlock described above. See the documentation for [`GILOnceCell`] for an example how to use it.
 
 [`GILOnceCell`]: https://docs.rs/pyo3/latest/pyo3/once_cell/struct.GILOnceCell.html
+
+## I can't run `cargo test`: I'm having linker issues like "Symbol not found" or "Undefined reference to _PyExc_SystemError"!
+
+Currently, [#341](https://github.com/PyO3/pyo3/issues/341) causes `cargo test` to fail with linking errors when the `extension-module` feature is activated. For now you can work around this by making the `extension-module` feature optional and running the tests with `cargo test --no-default-features`:
+
+```toml
+[dependencies.pyo3]
+version = "0.8.1"
+
+[features]
+extension-module = ["pyo3/extension-module"]
+default = ["extension-module"]
+```


### PR DESCRIPTION
I just thought the new FAQ section might be a good place for the "Testing" bit from advanced.md - which I think users don't always find.