### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.11.0] - 2020-06-23
 ### Added
 - Support stable versions of Rust (>=1.39). [#969](https://github.com/PyO3/pyo3/pull/969)
 - Add FFI definition `PyObject_AsFileDescriptor`. [#938](https://github.com/PyO3/pyo3/pull/938)
@@ -426,7 +428,8 @@ Yanked
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.10.1...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.11.0...HEAD
+[0.11.0] https://github.com/pyo3/pyo3/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/pyo3/pyo3/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/pyo3/pyo3/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/pyo3/pyo3/compare/v0.9.1...v0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.11.0] - 2020-06-23
+## [0.11.0] - 2020-06-28
 ### Added
 - Support stable versions of Rust (>=1.39). [#969](https://github.com/PyO3/pyo3/pull/969)
 - Add FFI definition `PyObject_AsFileDescriptor`. [#938](https://github.com/PyO3/pyo3/pull/938)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.10.1"
+version = "0.11.0"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -27,7 +27,7 @@ parking_lot = "0.10.2"
 num-bigint = { version = "0.3", optional = true }
 num-complex = { version = "0.3", optional = true }
 paste = { version = "0.1.6", optional = true }
-pyo3cls = { path = "pyo3cls", version = "=0.10.1", optional = true }
+pyo3cls = { path = "pyo3cls", version = "=0.11.0", optional = true }
 unindent = { version = "0.1.4", optional = true }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.10.1"
+version = "0.11.0"
 features = ["extension-module"]
 ```
 
@@ -98,7 +98,7 @@ use it to run Python code, add `pyo3` to your `Cargo.toml` like this:
 
 ```toml
 [dependencies]
-pyo3 = "0.10.1"
+pyo3 = "0.11.0"
 ```
 
 Example program displaying the value of `sys.version` and the current user name:

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -21,7 +21,7 @@ Currently, [#341](https://github.com/PyO3/pyo3/issues/341) causes `cargo test` t
 
 ```toml
 [dependencies.pyo3]
-version = "0.8.1"
+version = "0.11.0"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -3,6 +3,9 @@
 This guide can help you upgrade code through breaking changes from one PyO3 version to the next.
 For a detailed list of all changes, see [CHANGELOG.md](https://github.com/PyO3/pyo3/blob/master/CHANGELOG.md)
 
+## from 0.10.* to 0.11
+Now PyO3 supports stable Rust toolchain. The minimum required version is 1.39.0.
+
 ## from 0.9.* to 0.10
 
 ### `ObjectProtocol` is removed

--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-derive-backend"
-version = "0.10.1"
+version = "0.11.0"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3cls"
-version = "0.10.1"
+version = "0.11.0"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.10.1" }
+pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.11.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies.pyo3]
-//! version = "0.10.1"
+//! version = "0.11.0"
 //! features = ["extension-module"]
 //! ```
 //!
@@ -109,7 +109,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pyo3 = "0.10.1"
+//! pyo3 = "0.11.0"
 //! ```
 //!
 //! Example program displaying the value of `sys.version`:


### PR DESCRIPTION
The first version that can be used with stable Rust.
- [x] Check the compatibility with `rust-numpy`