### PR TITLE
`LazyStaticType::get_or_init` returns an `*mut` instead of a `&` ref

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -927,7 +927,7 @@ unsafe impl pyo3::PyTypeInfo for MyClass {
     const FLAGS: usize = 0;
 
     #[inline]
-    fn type_object_raw(py: pyo3::Python) -> &'static pyo3::ffi::PyTypeObject {
+    fn type_object_raw(py: pyo3::Python) -> *mut pyo3::ffi::PyTypeObject {
         use pyo3::type_object::LazyStaticType;
         static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
         TYPE_OBJECT.get_or_init::<Self>(py)

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -401,7 +401,7 @@ fn impl_class(
             const FLAGS: usize = #(#flags)|* | #extended;
 
             #[inline]
-            fn type_object_raw(py: pyo3::Python) -> &'static pyo3::ffi::PyTypeObject {
+            fn type_object_raw(py: pyo3::Python) -> *mut pyo3::ffi::PyTypeObject {
                 use pyo3::type_object::LazyStaticType;
                 static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
                 TYPE_OBJECT.get_or_init::<Self>(py)

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -72,9 +72,8 @@ where
     T: PyTypeInfo + PyClassWithFreeList,
 {
     unsafe fn new(py: Python, subtype: *mut ffi::PyTypeObject) -> *mut Self::Layout {
-        let type_obj = Self::type_object_raw(py) as *const _ as _;
         // if subtype is not equal to this type, we cannot use the freelist
-        if subtype == type_obj {
+        if subtype == Self::type_object_raw(py) {
             if let Some(obj) = <Self as PyClassWithFreeList>::get_free_list().pop() {
                 ffi::PyObject_Init(obj, subtype);
                 return obj as _;

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -18,7 +18,7 @@ pub(crate) unsafe fn default_new<T: PyTypeInfo>(
     // if the class derives native types(e.g., PyDict), call special new
     if T::FLAGS & type_flags::EXTENDED != 0 && T::BaseLayout::IS_NATIVE_TYPE {
         let base_tp = T::BaseType::type_object_raw(py);
-        if let Some(base_new) = base_tp.tp_new {
+        if let Some(base_new) = (*base_tp).tp_new {
             return base_new(subtype, ptr::null_mut(), ptr::null_mut());
         }
     }
@@ -122,7 +122,7 @@ where
         s => CString::new(s)?.into_raw(),
     };
 
-    type_object.tp_base = T::BaseType::type_object_raw(py) as *const _ as _;
+    type_object.tp_base = T::BaseType::type_object_raw(py);
 
     type_object.tp_name = match module_name {
         Some(module_name) => CString::new(format!("{}.{}", module_name, T::NAME))?.into_raw(),

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -120,7 +120,7 @@ impl<T: PyClass> PyClassInitializer<T> {
         T: PyClass,
         T::BaseLayout: PyBorrowFlagLayout<T::BaseType>,
     {
-        unsafe { self.create_cell_from_subtype(py, T::type_object_raw(py) as *const _ as _) }
+        unsafe { self.create_cell_from_subtype(py, T::type_object_raw(py)) }
     }
 
     /// Create a new PyCell and initialize it given a typeobject `subtype`.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -143,8 +143,11 @@ macro_rules! pyobject_native_type_convert(
             const MODULE: Option<&'static str> = $module;
 
             #[inline]
-            fn type_object_raw(_py: Python) -> &'static $crate::ffi::PyTypeObject {
-                unsafe{ &$typeobject }
+            fn type_object_raw(_py: Python) -> *mut $crate::ffi::PyTypeObject {
+                // Create a very short lived mutable reference and directly
+                // cast it to a pointer: no mutable references can be aliasing
+                // because we hold the GIL.
+                unsafe { &mut $typeobject }
             }
 
             #[allow(unused_unsafe)]


### PR DESCRIPTION
Previously, we were returning a `&ffi::PyTypeObject`. However, we were often casting this immutable reference to a `*mut ffi::PyTypeObject` and then passing that pointer to FFI functions.

But we don't know whether the FFI functions mutate the `PyTypeObject` behind our back or not, and if they do, I believe that this is Undefined Behavior because the pointer comes from a shared reference.

Unfortunately, these things are very badly documented: I'm only aware of this because I followed many Unsafe Code Guideline discussions. Best source that I could get is the following [comment](https://github.com/rust-lang/rust/issues/66136#issuecomment-550009220) from @RalfJung, who is very knowledgeable on the subject. The details are probably written in the Stacked Borrows paper, to be fair.

Even if it's not UB *right now* because of ill-specification or because of the compiler not taking advantage of it, we'd better be safe.