### PR TITLE
Re-enable recursive class attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 - Remove `ManagedPyRef` (unused, and needs specialization) [#930](https://github.com/PyO3/pyo3/pull/930)
-- Disable `#[classattr]` where the class attribute is the same type as the class. (This may be re-enabled in the future; the previous implemenation was unsound.) [#975](https://github.com/PyO3/pyo3/pull/975)
 
 ### Fixed
 - Fix passing explicit `None` to `Option<T>` argument `#[pyfunction]` with a default value. [#936](https://github.com/PyO3/pyo3/pull/936)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -565,11 +565,6 @@ impl MyClass {
 }
 ```
 
-Note that defining a class attribute of the same type as the class will make the class unusable.
-Attempting to use the class will cause a panic reading `Recursive evaluation of type_object`.
-As an alternative, if having the attribute on instances is acceptable, create a `#[getter]` which
-uses a `GILOnceCell` to cache the attribute value. Or add the attribute to a module instead.
-
 ## Callable objects
 
 To specify a custom `__call__` method for a custom class, the method needs to be annotated with

--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -58,6 +58,10 @@ impl<T> GILOnceCell<T> {
     ///     calling `f()`. Even when this happens `GILOnceCell` guarantees that only **one** write
     ///     to the cell ever occurs - other threads will simply discard the value they compute and
     ///     return the result of the first complete computation.
+    ///  3) if f() does not release the GIL and does not panic, it is guaranteed to be called
+    ///     exactly once, even if multiple threads attempt to call `get_or_init`
+    ///  4) if f() can panic but still does not release the GIL, it may be called multiple times,
+    ///     but it is guaranteed that f() will never be called concurrently
     pub fn get_or_init<F>(&self, py: Python, f: F) -> &T
     where
         F: FnOnce() -> T,


### PR DESCRIPTION
Builds on #994 (it's actually the call to `PyType_Modify` through a shared reference which made me realize the problem!).

Last thing to do will be to replace `value: GILOnceCell<*mut ffi::PyTypeObject>` with `UnsafeCell<ffi::PyTypeObject>` + `GILOnceCell<()>` as suggested by @kngwyu.