### PR TITLE
Allow omitting return type for `#[pyproto]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `#[pyproto]` is re-implemented without specialization. [#961](https://github.com/PyO3/pyo3/pull/961)
 - `PyClassAlloc::alloc` is renamed to `PyClassAlloc::new`. [#990](https://github.com/PyO3/pyo3/pull/990)
 - `#[pyproto]` methods can now have return value `T` or `PyResult<T>` (previously only `PyResult<T>` was supported). [#996](https://github.com/PyO3/pyo3/pull/996)
+- `#[pyproto]` methods can now skip annotating the return type if it is `()`. [#998](https://github.com/PyO3/pyo3/pull/998)
 
 ### Removed
 - Remove `ManagedPyRef` (unused, and needs specialization) [#930](https://github.com/PyO3/pyo3/pull/930)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -689,7 +689,7 @@ Python object behavior, you need to implement the specific trait for your struct
 each protocol implementation block has to be annotated with the `#[pyproto]` attribute.
 
 All `#[pyproto]` methods which can be defined below can return `T` instead of `PyResult<T>` if the
-method implementation is infallible.
+method implementation is infallible. In addition, if the return type is `()`, it can be omitted altogether.
 
 ### Basic object customization
 

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -18,27 +18,27 @@ impl UnaryArithmetic {
 
 #[pyproto]
 impl PyObjectProtocol for UnaryArithmetic {
-    fn __repr__(&self) -> PyResult<String> {
-        Ok(format!("UA({})", self.inner))
+    fn __repr__(&self) -> String {
+        format!("UA({})", self.inner)
     }
 }
 
 #[pyproto]
 impl PyNumberProtocol for UnaryArithmetic {
-    fn __neg__(&self) -> PyResult<Self> {
-        Ok(Self::new(-self.inner))
+    fn __neg__(&self) -> Self {
+        Self::new(-self.inner)
     }
 
-    fn __pos__(&self) -> PyResult<Self> {
-        Ok(Self::new(self.inner))
+    fn __pos__(&self) -> Self {
+        Self::new(self.inner)
     }
 
-    fn __abs__(&self) -> PyResult<Self> {
-        Ok(Self::new(self.inner.abs()))
+    fn __abs__(&self) -> Self {
+        Self::new(self.inner.abs())
     }
 
-    fn __round__(&self, _ndigits: Option<u32>) -> PyResult<Self> {
-        Ok(Self::new(self.inner.round()))
+    fn __round__(&self, _ndigits: Option<u32>) -> Self {
+        Self::new(self.inner.round())
     }
 }
 
@@ -60,8 +60,8 @@ struct BinaryArithmetic {}
 
 #[pyproto]
 impl PyObjectProtocol for BinaryArithmetic {
-    fn __repr__(&self) -> PyResult<&'static str> {
-        Ok("BA")
+    fn __repr__(&self) -> &'static str {
+        "BA"
     }
 }
 
@@ -72,56 +72,47 @@ struct InPlaceOperations {
 
 #[pyproto]
 impl PyObjectProtocol for InPlaceOperations {
-    fn __repr__(&self) -> PyResult<String> {
-        Ok(format!("IPO({:?})", self.value))
+    fn __repr__(&self) -> String {
+        format!("IPO({:?})", self.value)
     }
 }
 
 #[pyproto]
 impl PyNumberProtocol for InPlaceOperations {
-    fn __iadd__(&mut self, other: u32) -> PyResult<()> {
+    fn __iadd__(&mut self, other: u32) {
         self.value += other;
-        Ok(())
     }
 
-    fn __isub__(&mut self, other: u32) -> PyResult<()> {
+    fn __isub__(&mut self, other: u32) {
         self.value -= other;
-        Ok(())
     }
 
-    fn __imul__(&mut self, other: u32) -> PyResult<()> {
+    fn __imul__(&mut self, other: u32) {
         self.value *= other;
-        Ok(())
     }
 
-    fn __ilshift__(&mut self, other: u32) -> PyResult<()> {
+    fn __ilshift__(&mut self, other: u32) {
         self.value <<= other;
-        Ok(())
     }
 
-    fn __irshift__(&mut self, other: u32) -> PyResult<()> {
+    fn __irshift__(&mut self, other: u32) {
         self.value >>= other;
-        Ok(())
     }
 
-    fn __iand__(&mut self, other: u32) -> PyResult<()> {
+    fn __iand__(&mut self, other: u32) {
         self.value &= other;
-        Ok(())
     }
 
-    fn __ixor__(&mut self, other: u32) -> PyResult<()> {
+    fn __ixor__(&mut self, other: u32) {
         self.value ^= other;
-        Ok(())
     }
 
-    fn __ior__(&mut self, other: u32) -> PyResult<()> {
+    fn __ior__(&mut self, other: u32) {
         self.value |= other;
-        Ok(())
     }
 
-    fn __ipow__(&mut self, other: u32) -> PyResult<()> {
+    fn __ipow__(&mut self, other: u32) {
         self.value = self.value.pow(other);
-        Ok(())
     }
 }
 
@@ -151,40 +142,40 @@ fn inplace_operations() {
 
 #[pyproto]
 impl PyNumberProtocol for BinaryArithmetic {
-    fn __add__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} + {:?}", lhs, rhs))
+    fn __add__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} + {:?}", lhs, rhs)
     }
 
-    fn __sub__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} - {:?}", lhs, rhs))
+    fn __sub__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} - {:?}", lhs, rhs)
     }
 
-    fn __mul__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} * {:?}", lhs, rhs))
+    fn __mul__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} * {:?}", lhs, rhs)
     }
 
-    fn __lshift__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} << {:?}", lhs, rhs))
+    fn __lshift__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} << {:?}", lhs, rhs)
     }
 
-    fn __rshift__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} >> {:?}", lhs, rhs))
+    fn __rshift__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} >> {:?}", lhs, rhs)
     }
 
-    fn __and__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} & {:?}", lhs, rhs))
+    fn __and__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} & {:?}", lhs, rhs)
     }
 
-    fn __xor__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} ^ {:?}", lhs, rhs))
+    fn __xor__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} ^ {:?}", lhs, rhs)
     }
 
-    fn __or__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} | {:?}", lhs, rhs))
+    fn __or__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} | {:?}", lhs, rhs)
     }
 
-    fn __pow__(lhs: &PyAny, rhs: &PyAny, mod_: Option<u32>) -> PyResult<String> {
-        Ok(format!("{:?} ** {:?} (mod: {:?})", lhs, rhs, mod_))
+    fn __pow__(lhs: &PyAny, rhs: &PyAny, mod_: Option<u32>) -> String {
+        format!("{:?} ** {:?} (mod: {:?})", lhs, rhs, mod_)
     }
 }
 
@@ -224,40 +215,40 @@ struct RhsArithmetic {}
 
 #[pyproto]
 impl PyNumberProtocol for RhsArithmetic {
-    fn __radd__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} + RA", other))
+    fn __radd__(&self, other: &PyAny) -> String {
+        format!("{:?} + RA", other)
     }
 
-    fn __rsub__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} - RA", other))
+    fn __rsub__(&self, other: &PyAny) -> String {
+        format!("{:?} - RA", other)
     }
 
-    fn __rmul__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} * RA", other))
+    fn __rmul__(&self, other: &PyAny) -> String {
+        format!("{:?} * RA", other)
     }
 
-    fn __rlshift__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} << RA", other))
+    fn __rlshift__(&self, other: &PyAny) -> String {
+        format!("{:?} << RA", other)
     }
 
-    fn __rrshift__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} >> RA", other))
+    fn __rrshift__(&self, other: &PyAny) -> String {
+        format!("{:?} >> RA", other)
     }
 
-    fn __rand__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} & RA", other))
+    fn __rand__(&self, other: &PyAny) -> String {
+        format!("{:?} & RA", other)
     }
 
-    fn __rxor__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} ^ RA", other))
+    fn __rxor__(&self, other: &PyAny) -> String {
+        format!("{:?} ^ RA", other)
     }
 
-    fn __ror__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} | RA", other))
+    fn __ror__(&self, other: &PyAny) -> String {
+        format!("{:?} | RA", other)
     }
 
-    fn __rpow__(&self, other: &PyAny, _mod: Option<&'p PyAny>) -> PyResult<String> {
-        Ok(format!("{:?} ** RA", other))
+    fn __rpow__(&self, other: &PyAny, _mod: Option<&'p PyAny>) -> String {
+        format!("{:?} ** RA", other)
     }
 }
 
@@ -292,35 +283,35 @@ struct LhsAndRhsArithmetic {}
 
 #[pyproto]
 impl PyNumberProtocol for LhsAndRhsArithmetic {
-    fn __radd__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} + RA", other))
+    fn __radd__(&self, other: &PyAny) -> String {
+        format!("{:?} + RA", other)
     }
 
-    fn __rsub__(&self, other: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} - RA", other))
+    fn __rsub__(&self, other: &PyAny) -> String {
+        format!("{:?} - RA", other)
     }
 
-    fn __rpow__(&self, other: &PyAny, _mod: Option<&'p PyAny>) -> PyResult<String> {
-        Ok(format!("{:?} ** RA", other))
+    fn __rpow__(&self, other: &PyAny, _mod: Option<&'p PyAny>) -> String {
+        format!("{:?} ** RA", other)
     }
 
-    fn __add__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} + {:?}", lhs, rhs))
+    fn __add__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} + {:?}", lhs, rhs)
     }
 
-    fn __sub__(lhs: &PyAny, rhs: &PyAny) -> PyResult<String> {
-        Ok(format!("{:?} - {:?}", lhs, rhs))
+    fn __sub__(lhs: &PyAny, rhs: &PyAny) -> String {
+        format!("{:?} - {:?}", lhs, rhs)
     }
 
-    fn __pow__(lhs: &PyAny, rhs: &PyAny, _mod: Option<u32>) -> PyResult<String> {
-        Ok(format!("{:?} ** {:?}", lhs, rhs))
+    fn __pow__(lhs: &PyAny, rhs: &PyAny, _mod: Option<u32>) -> String {
+        format!("{:?} ** {:?}", lhs, rhs)
     }
 }
 
 #[pyproto]
 impl PyObjectProtocol for LhsAndRhsArithmetic {
-    fn __repr__(&self) -> PyResult<&'static str> {
-        Ok("BA")
+    fn __repr__(&self) -> &'static str {
+        "BA"
     }
 }
 
@@ -345,18 +336,18 @@ struct RichComparisons {}
 
 #[pyproto]
 impl PyObjectProtocol for RichComparisons {
-    fn __repr__(&self) -> PyResult<&'static str> {
-        Ok("RC")
+    fn __repr__(&self) -> &'static str {
+        "RC"
     }
 
-    fn __richcmp__(&self, other: &PyAny, op: CompareOp) -> PyResult<String> {
+    fn __richcmp__(&self, other: &PyAny, op: CompareOp) -> String {
         match op {
-            CompareOp::Lt => Ok(format!("{} < {:?}", self.__repr__().unwrap(), other)),
-            CompareOp::Le => Ok(format!("{} <= {:?}", self.__repr__().unwrap(), other)),
-            CompareOp::Eq => Ok(format!("{} == {:?}", self.__repr__().unwrap(), other)),
-            CompareOp::Ne => Ok(format!("{} != {:?}", self.__repr__().unwrap(), other)),
-            CompareOp::Gt => Ok(format!("{} > {:?}", self.__repr__().unwrap(), other)),
-            CompareOp::Ge => Ok(format!("{} >= {:?}", self.__repr__().unwrap(), other)),
+            CompareOp::Lt => format!("{} < {:?}", self.__repr__(), other),
+            CompareOp::Le => format!("{} <= {:?}", self.__repr__(), other),
+            CompareOp::Eq => format!("{} == {:?}", self.__repr__(), other),
+            CompareOp::Ne => format!("{} != {:?}", self.__repr__(), other),
+            CompareOp::Gt => format!("{} > {:?}", self.__repr__(), other),
+            CompareOp::Ge => format!("{} >= {:?}", self.__repr__(), other),
         }
     }
 }
@@ -366,16 +357,17 @@ struct RichComparisons2 {}
 
 #[pyproto]
 impl PyObjectProtocol for RichComparisons2 {
-    fn __repr__(&self) -> PyResult<&'static str> {
-        Ok("RC2")
+    fn __repr__(&self) -> &'static str {
+        "RC2"
     }
 
-    fn __richcmp__(&self, _other: &PyAny, op: CompareOp) -> PyResult<PyObject> {
+    fn __richcmp__(&self, _other: &PyAny, op: CompareOp) -> PyObject {
         let gil = GILGuard::acquire();
+        let py = gil.python();
         match op {
-            CompareOp::Eq => Ok(true.to_object(gil.python())),
-            CompareOp::Ne => Ok(false.to_object(gil.python())),
-            _ => Ok(gil.python().NotImplemented()),
+            CompareOp::Eq => true.into_py(py),
+            CompareOp::Ne => false.into_py(py),
+            _ => py.NotImplemented(),
         }
     }
 }

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -65,9 +65,7 @@ impl PyBufferProtocol for TestBufferClass {
         Ok(())
     }
 
-    fn bf_releasebuffer(_slf: PyRefMut<Self>, _view: *mut ffi::Py_buffer) -> PyResult<()> {
-        Ok(())
-    }
+    fn bf_releasebuffer(_slf: PyRefMut<Self>, _view: *mut ffi::Py_buffer) {}
 }
 
 impl Drop for TestBufferClass {

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -18,8 +18,8 @@ pub struct Len {
 
 #[pyproto]
 impl PyMappingProtocol for Len {
-    fn __len__(&self) -> PyResult<usize> {
-        Ok(self.l)
+    fn __len__(&self) -> usize {
+        self.l
     }
 }
 
@@ -52,12 +52,12 @@ struct Iterator {
 
 #[pyproto]
 impl<'p> PyIterProtocol for Iterator {
-    fn __iter__(slf: PyRef<'p, Self>) -> PyResult<Py<Iterator>> {
-        Ok(slf.into())
+    fn __iter__(slf: PyRef<'p, Self>) -> Py<Iterator> {
+        slf.into()
     }
 
-    fn __next__(mut slf: PyRefMut<'p, Self>) -> PyResult<Option<i32>> {
-        Ok(slf.iter.next())
+    fn __next__(mut slf: PyRefMut<'p, Self>) -> Option<i32> {
+        slf.iter.next()
     }
 }
 
@@ -82,21 +82,21 @@ struct StringMethods {}
 
 #[pyproto]
 impl<'p> PyObjectProtocol<'p> for StringMethods {
-    fn __str__(&self) -> PyResult<&'static str> {
-        Ok("str")
+    fn __str__(&self) -> &'static str {
+        "str"
     }
 
-    fn __repr__(&self) -> PyResult<&'static str> {
-        Ok("repr")
+    fn __repr__(&self) -> &'static str {
+        "repr"
     }
 
-    fn __format__(&self, format_spec: String) -> PyResult<String> {
-        Ok(format!("format({})", format_spec))
+    fn __format__(&self, format_spec: String) -> String {
+        format!("format({})", format_spec)
     }
 
-    fn __bytes__(&self) -> PyResult<PyObject> {
+    fn __bytes__(&self) -> PyObject {
         let gil = GILGuard::acquire();
-        Ok(PyBytes::new(gil.python(), b"bytes").into())
+        PyBytes::new(gil.python(), b"bytes").into()
     }
 }
 
@@ -119,11 +119,11 @@ struct Comparisons {
 
 #[pyproto]
 impl PyObjectProtocol for Comparisons {
-    fn __hash__(&self) -> PyResult<isize> {
-        Ok(self.val as isize)
+    fn __hash__(&self) -> isize {
+        self.val as isize
     }
-    fn __bool__(&self) -> PyResult<bool> {
-        Ok(self.val != 0)
+    fn __bool__(&self) -> bool {
+        self.val != 0
     }
 }
 
@@ -162,8 +162,8 @@ impl Default for Sequence {
 
 #[pyproto]
 impl PySequenceProtocol for Sequence {
-    fn __len__(&self) -> PyResult<usize> {
-        Ok(self.fields.len())
+    fn __len__(&self) -> usize {
+        self.fields.len()
     }
 
     fn __getitem__(&self, key: isize) -> PyResult<String> {
@@ -211,8 +211,8 @@ struct Callable {}
 #[pymethods]
 impl Callable {
     #[__call__]
-    fn __call__(&self, arg: i32) -> PyResult<i32> {
-        Ok(arg * 6)
+    fn __call__(&self, arg: i32) -> i32 {
+        arg * 6
     }
 }
 
@@ -238,10 +238,9 @@ struct SetItem {
 
 #[pyproto]
 impl PyMappingProtocol<'a> for SetItem {
-    fn __setitem__(&mut self, key: i32, val: i32) -> PyResult<()> {
+    fn __setitem__(&mut self, key: i32, val: i32) {
         self.key = key;
         self.val = val;
-        Ok(())
     }
 }
 
@@ -267,9 +266,8 @@ struct DelItem {
 
 #[pyproto]
 impl PyMappingProtocol<'a> for DelItem {
-    fn __delitem__(&mut self, key: i32) -> PyResult<()> {
+    fn __delitem__(&mut self, key: i32) {
         self.key = key;
-        Ok(())
     }
 }
 
@@ -294,14 +292,12 @@ struct SetDelItem {
 
 #[pyproto]
 impl PyMappingProtocol for SetDelItem {
-    fn __setitem__(&mut self, _key: i32, val: i32) -> PyResult<()> {
+    fn __setitem__(&mut self, _key: i32, val: i32) {
         self.val = Some(val);
-        Ok(())
     }
 
-    fn __delitem__(&mut self, _key: i32) -> PyResult<()> {
+    fn __delitem__(&mut self, _key: i32) {
         self.val = None;
-        Ok(())
     }
 }
 
@@ -326,8 +322,8 @@ struct Reversed {}
 
 #[pyproto]
 impl PyMappingProtocol for Reversed {
-    fn __reversed__(&self) -> PyResult<&'static str> {
-        Ok("I am reversed")
+    fn __reversed__(&self) -> &'static str {
+        "I am reversed"
     }
 }
 
@@ -345,8 +341,8 @@ struct Contains {}
 
 #[pyproto]
 impl PySequenceProtocol for Contains {
-    fn __contains__(&self, item: i32) -> PyResult<bool> {
-        Ok(item >= 0)
+    fn __contains__(&self, item: i32) -> bool {
+        item >= 0
     }
 }
 
@@ -368,8 +364,8 @@ struct ContextManager {
 
 #[pyproto]
 impl<'p> PyContextProtocol<'p> for ContextManager {
-    fn __enter__(&mut self) -> PyResult<i32> {
-        Ok(42)
+    fn __enter__(&mut self) -> i32 {
+        42
     }
 
     fn __exit__(
@@ -377,14 +373,10 @@ impl<'p> PyContextProtocol<'p> for ContextManager {
         ty: Option<&'p PyType>,
         _value: Option<&'p PyAny>,
         _traceback: Option<&'p PyAny>,
-    ) -> PyResult<bool> {
+    ) -> bool {
         let gil = GILGuard::acquire();
         self.exit_called = true;
-        if ty == Some(gil.python().get_type::<ValueError>()) {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        ty == Some(gil.python().get_type::<ValueError>())
     }
 }
 
@@ -540,8 +532,8 @@ struct ClassWithGetAttr {
 
 #[pyproto]
 impl PyObjectProtocol for ClassWithGetAttr {
-    fn __getattr__(&self, _name: &str) -> PyResult<u32> {
-        Ok(self.data * 2)
+    fn __getattr__(&self, _name: &str) -> u32 {
+        self.data * 2
     }
 }
 
@@ -574,22 +566,22 @@ impl OnceFuture {
 
 #[pyproto]
 impl PyAsyncProtocol for OnceFuture {
-    fn __await__(slf: PyRef<'p, Self>) -> PyResult<PyRef<'p, Self>> {
-        Ok(slf)
+    fn __await__(slf: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        slf
     }
 }
 
 #[pyproto]
 impl PyIterProtocol for OnceFuture {
-    fn __iter__(slf: PyRef<'p, Self>) -> PyResult<PyRef<'p, Self>> {
-        Ok(slf)
+    fn __iter__(slf: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        slf
     }
-    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PyObject>> {
+    fn __next__(mut slf: PyRefMut<Self>) -> Option<PyObject> {
         if !slf.polled {
             slf.polled = true;
-            Ok(Some(slf.future.clone()))
+            Some(slf.future.clone())
         } else {
-            Ok(None)
+            None
         }
     }
 }
@@ -645,17 +637,12 @@ impl PyDescrProtocol for DescrCounter {
         mut slf: PyRefMut<'p, Self>,
         _instance: &PyAny,
         _owner: Option<&'p PyType>,
-    ) -> PyResult<PyRefMut<'p, Self>> {
+    ) -> PyRefMut<'p, Self> {
         slf.count += 1;
-        Ok(slf)
+        slf
     }
-    fn __set__(
-        _slf: PyRef<'p, Self>,
-        _instance: &PyAny,
-        mut new_value: PyRefMut<'p, Self>,
-    ) -> PyResult<()> {
+    fn __set__(_slf: PyRef<'p, Self>, _instance: &PyAny, mut new_value: PyRefMut<'p, Self>) {
         new_value.count = _slf.count;
-        Ok(())
     }
 }
 

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -32,8 +32,8 @@ impl Mapping {
 
 #[pyproto]
 impl PyMappingProtocol for Mapping {
-    fn __len__(&self) -> PyResult<usize> {
-        Ok(self.index.len())
+    fn __len__(&self) -> usize {
+        self.index.len()
     }
 
     fn __getitem__(&self, query: String) -> PyResult<usize> {
@@ -43,9 +43,8 @@ impl PyMappingProtocol for Mapping {
             .ok_or_else(|| KeyError::py_err("unknown key"))
     }
 
-    fn __setitem__(&mut self, key: String, value: usize) -> PyResult<()> {
+    fn __setitem__(&mut self, key: String, value: usize) {
         self.index.insert(key, value);
-        Ok(())
     }
 
     fn __delitem__(&mut self, key: String) -> PyResult<()> {
@@ -57,14 +56,13 @@ impl PyMappingProtocol for Mapping {
     }
 
     /// not an actual reversed implementation, just to demonstrate that the method is callable.
-    fn __reversed__(&self) -> PyResult<PyObject> {
+    fn __reversed__(&self) -> PyObject {
         let gil = Python::acquire_gil();
-        Ok(self
-            .index
+        self.index
             .keys()
             .cloned()
             .collect::<Vec<String>>()
-            .into_py(gil.python()))
+            .into_py(gil.python())
     }
 }
 

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -54,17 +54,16 @@ struct Iter {
 
 #[pyproto]
 impl PyIterProtocol for Iter {
-    fn __iter__(slf: PyRef<Self>) -> PyResult<PyObject> {
-        let py = unsafe { Python::assume_gil_acquired() };
-        Ok(slf.into_py(py))
+    fn __iter__(slf: PyRef<Self>) -> PyRef<'p, Self> {
+        slf
     }
 
     fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PyObject>> {
-        let py = unsafe { Python::assume_gil_acquired() };
-        let bytes = slf.keys.as_ref(py).as_bytes();
+        let bytes = slf.keys.as_ref(slf.py()).as_bytes();
         match bytes.get(slf.idx) {
             Some(&b) => {
                 slf.idx += 1;
+                let py = slf.py();
                 let reader = slf.reader.as_ref(py);
                 let reader_ref = reader.try_borrow()?;
                 let res = reader_ref

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -33,8 +33,8 @@ impl ByteSequence {
 
 #[pyproto]
 impl PySequenceProtocol for ByteSequence {
-    fn __len__(&self) -> PyResult<usize> {
-        Ok(self.elements.len())
+    fn __len__(&self) -> usize {
+        self.elements.len()
     }
 
     fn __getitem__(&self, idx: isize) -> PyResult<u8> {
@@ -44,9 +44,8 @@ impl PySequenceProtocol for ByteSequence {
             .ok_or_else(|| IndexError::py_err("list index out of range"))
     }
 
-    fn __setitem__(&mut self, idx: isize, value: u8) -> PyResult<()> {
+    fn __setitem__(&mut self, idx: isize, value: u8) {
         self.elements[idx as usize] = value;
-        Ok(())
     }
 
     fn __delitem__(&mut self, idx: isize) -> PyResult<()> {
@@ -58,17 +57,17 @@ impl PySequenceProtocol for ByteSequence {
         }
     }
 
-    fn __contains__(&self, other: &PyAny) -> PyResult<bool> {
+    fn __contains__(&self, other: &PyAny) -> bool {
         match u8::extract(other) {
-            Ok(ref x) => Ok(self.elements.contains(x)),
-            Err(_) => Ok(false),
+            Ok(ref x) => self.elements.contains(x),
+            Err(_) => false,
         }
     }
 
-    fn __concat__(&self, other: PyRef<'p, Self>) -> PyResult<Self> {
+    fn __concat__(&self, other: PyRef<'p, Self>) -> Self {
         let mut elements = self.elements.clone();
         elements.extend_from_slice(&other.elements);
-        Ok(Self { elements })
+        Self { elements }
     }
 
     fn __repeat__(&self, count: isize) -> PyResult<Self> {


### PR DESCRIPTION
This builds on #996 by removing the need to write `-> ()` in the return type for `#[pyproto]` methods.