### PR TITLE
Use Nightly for coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,12 @@ jobs:
       python: "3.7"
       env: FEATURES="pypy" PATH="$PATH:/opt/anaconda/envs/pypy3/bin"
   allow_failures:
-    - name: Nightly
     - python: 3.9-dev
 
 env:
   global:
     - TRAVIS_RUST_VERSION=stable
     - RUST_BACKTRACE=1
-    - RUN_LINT=0
 
 before_install:
   - source ./ci/travis/setup.sh
@@ -56,23 +54,21 @@ deploy:
     on:
       branch: master
       repo: PyO3/pyo3
-      python: 3.6
-      condition: $TRAVIS_EVENT_TYPE != "cron"
+      condition: $TRAVIS_JOB_NAME == "Nightly" && $TRAVIS_EVENT_TYPE != "cron"
   - provider: script
     script: ./ci/travis/guide.sh
     edge: true
     on:
       branch: master
       repo: PyO3/pyo3
-      python: 3.6
-      condition: $TRAVIS_EVENT_TYPE != "cron"
+      condition: $TRAVIS_JOB_NAME == "Python 3.7" && $TRAVIS_EVENT_TYPE != "cron"
   - provider: script
     script: ./ci/travis/guide.sh
     edge: true
     on:
       tags: true
       repo: PyO3/pyo3
-      python: 3.6
+      condition: $TRAVIS_JOB_NAME == "Python 3.7"
 
 notifications:
   email: false

--- a/ci/travis/cover.sh
+++ b/ci/travis/cover.sh
@@ -2,12 +2,6 @@
 
 set -ex
 
-### PyPy does not run the test suite ###########################################
-
-if [[ $FEATURES == *"pypy"* ]]; then
-  exit 0
-fi
-
 ### Run grcov ##################################################################
 # export env vars and re-run tests
 export CARGO_INCREMENTAL=0
@@ -18,4 +12,3 @@ cargo test --features "$FEATURES num-bigint num-complex"
 zip -0 ccov.zip `find . \( -name "pyo3*.gc*" \) -print`;
 ./grcov ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore "/*" -o lcov.info;
 bash <(curl -s https://codecov.io/bash) -f lcov.info;
-


### PR DESCRIPTION
Somehow we get
```
error: can't instrument with gcov profiling when compiling incrementally
```
with stable Rust, even if [`RUSTC_BOOTSTRAP=1`](https://github.com/mozilla/grcov/issues/433) is set.
