### PR TITLE
Remove tox -e py from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ test: lint test_py
 	cargo test
 
 test_py:
-	tox -e py
 	for example in examples/*; do tox -e py -c $$example/tox.ini || exit 1; done
 
 fmt:


### PR DESCRIPTION
I don't know even what this is for...
BTW, this PR would make `make publish` work.
