### PR TITLE
Introduce #[pyclass(unsendable)]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `#[pyclass(unsendable)]`. [#1009](https://github.com/PyO3/pyo3/pull/1009)
 
 ## [0.11.0] - 2020-06-28
 ### Added

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -124,6 +124,8 @@ If a custom class contains references to other Python objects that can be collec
 * `extends=BaseType` - Use a custom base class. The base `BaseType` must implement `PyTypeInfo`.
 * `subclass` - Allows Python classes to inherit from this class.
 * `dict` - Adds `__dict__` support, so that the instances of this type have a dictionary containing arbitrary instance variables.
+* `unsendable` - Making it safe to expose `!Send` structs to Python, where all object can be accessed
+   by multiple threads. A class marked with `unsendable` panics when accessed by another thread.
 * `module="XXX"` - Set the name of the module the class will be shown as defined in. If not given, the class
   will be a virtual member of the `builtins` module.
 
@@ -973,6 +975,10 @@ impl pyo3::class::proto_methods::HasProtoRegistry for MyClass {
             = pyo3::class::proto_methods::PyProtoRegistry::new();
         &REGISTRY
     }
+}
+
+impl pyo3::pyclass::PyClassSend for MyClass {
+    type ThreadChecker = pyo3::pyclass::ThreadCheckerStub<MyClass>;
 }
 # let gil = Python::acquire_gil();
 # let py = gil.python();

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -8,43 +8,71 @@ For a detailed list of all changes, see [CHANGELOG.md](https://github.com/PyO3/p
 ### Stable Rust
 PyO3 now supports the stable Rust toolchain. The minimum required version is 1.39.0.
 
-### `#[pyclass]` structs must now be `Send`
+### `#[pyclass]` structs must now be `Send` or `unsendable`
 Because `#[pyclass]` structs can be sent between threads by the Python interpreter, they must implement
-`Send` to guarantee thread safety. This bound was added in PyO3 `0.11.0`.
+`Send` or declared as `unsendable` (by `#[pyclass(unsendable)]`).
+Note that `unsendable` is added in PyO3 `0.11.1` and `Send` is always required in PyO3 `0.11.0`.
 
-This may "break" some code which previously was accepted, even though it was unsound. To resolve this,
-consider using types like `Arc` instead of `Rc`, `Mutex` instead of `RefCell`, and add `Send` to any
-boxed closures stored inside the `#[pyclass]`.
+This may "break" some code which previously was accepted, even though it could be unsound.
+There can be two fixes:
 
-Before:
-```rust,compile_fail
-use pyo3::prelude::*;
-use std::rc::Rc;
-use std::cell::RefCell;
+1. If you think that your `#[pyclass]` actually must be `Send`able, then let's implement `Send`.
+   A common, safer way is using thread-safe types. E.g., `Arc` instead of `Rc`, `Mutex` instead of
+   `RefCell`, and `Box<dyn Send + T>` instead of `Box<dyn T>`.
 
-#[pyclass]
-struct NotThreadSafe {
-    shared_bools: Rc<RefCell<Vec<bool>>>,
-    closure: Box<Fn()>
-}
-```
+   Before:
+   ```rust,compile_fail
+   use pyo3::prelude::*;
+   use std::rc::Rc;
+   use std::cell::RefCell;
 
-After:
-```rust
-use pyo3::prelude::*;
-use std::sync::{Arc, Mutex};
+   #[pyclass]
+   struct NotThreadSafe {
+       shared_bools: Rc<RefCell<Vec<bool>>>,
+       closure: Box<dyn Fn()>
+   }
+   ```
 
-#[pyclass]
-struct ThreadSafe {
-    shared_bools: Arc<Mutex<Vec<bool>>>,
-    closure: Box<Fn() + Send>
-}
-```
+   After:
+   ```rust
+   use pyo3::prelude::*;
+   use std::sync::{Arc, Mutex};
 
-Or in situations where you cannot change your `#[pyclass]` to automatically implement `Send`
-(e.g., when it contains a raw pointer), you can use `unsafe impl Send`.
-In such cases, care should be taken to ensure the struct is actually thread safe.
-See [the Rustnomicon](ttps://doc.rust-lang.org/nomicon/send-and-sync.html) for more.
+   #[pyclass]
+   struct ThreadSafe {
+       shared_bools: Arc<Mutex<Vec<bool>>>,
+       closure: Box<dyn Fn() + Send>
+   }
+   ```
+
+   In situations where you cannot change your `#[pyclass]` to automatically implement `Send`
+   (e.g., when it contains a raw pointer), you can use `unsafe impl Send`. 
+   In such cases, care should be taken to ensure the struct is actually thread safe.
+   See [the Rustnomicon](https://doc.rust-lang.org/nomicon/send-and-sync.html) for more.
+
+2. If you think that your `#[pyclass]` should not be accessed by another thread, you can use
+   `unsendable` flag. A class marked with `unsendable` panics when accessed by another thread,
+   making it thread-safe to expose an unsendable object to the Python interpreter.
+
+   Before:
+   ```rust,compile_fail
+   use pyo3::prelude::*;
+
+   #[pyclass]
+   struct Unsendable {
+       pointers: Vec<*mut std::os::raw::c_char>,
+   }
+   ```
+
+   After:
+   ```rust
+   use pyo3::prelude::*;
+
+   #[pyclass(unsendable)]
+   struct Unsendable {
+       pointers: Vec<*mut std::os::raw::c_char>,
+   }
+   ```
 
 ### All `PyObject` and `Py<T>` methods now take `Python` as an argument
 Previously, a few methods such as `Object::get_refcnt` did not take `Python` as an argument (to

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -7,7 +7,7 @@
 use crate::err::{PyErr, PyResult};
 use crate::exceptions::TypeError;
 use crate::instance::PyNativeType;
-use crate::pyclass::PyClass;
+use crate::pyclass::{PyClass, PyClassThreadChecker};
 use crate::types::{PyAny, PyDict, PyModule, PyTuple};
 use crate::{ffi, GILPool, IntoPy, PyCell, Python};
 use std::cell::UnsafeCell;
@@ -157,11 +157,12 @@ impl ModuleDef {
 
 /// Utilities for basetype
 #[doc(hidden)]
-pub trait PyBaseTypeUtils {
+pub trait PyBaseTypeUtils: Sized {
     type Dict;
     type WeakRef;
     type LayoutAsBase;
     type BaseNativeType;
+    type ThreadChecker: PyClassThreadChecker<Self>;
 }
 
 impl<T: PyClass> PyBaseTypeUtils for T {
@@ -169,6 +170,7 @@ impl<T: PyClass> PyBaseTypeUtils for T {
     type WeakRef = T::WeakRef;
     type LayoutAsBase = crate::pycell::PyCellInner<T>;
     type BaseNativeType = T::BaseNativeType;
+    type ThreadChecker = T::ThreadChecker;
 }
 
 /// Utility trait to enable &PyClass as a pymethod/function argument

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -75,6 +75,7 @@ macro_rules! pyobject_native_type {
             type WeakRef = $crate::pyclass_slots::PyClassDummySlot;
             type LayoutAsBase = $crate::pycell::PyCellBase<$name>;
             type BaseNativeType = $name;
+            type ThreadChecker = $crate::pyclass::ThreadCheckerStub<$crate::PyObject>;
         }
         pyobject_native_type_named!($name $(,$type_param)*);
         pyobject_native_type_convert!($name, $layout, $typeobject, $module, $checkfunction $(,$type_param)*);

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -22,7 +22,7 @@ error: Expected string literal (e.g., "my_mod")
 12 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
-error: Expected one of gc/weakref/subclass/dict
+error: Expected one of gc/weakref/subclass/dict/unsendable
   --> $DIR/invalid_pyclass_args.rs:15:11
    |
 15 | #[pyclass(weakrev)]


### PR DESCRIPTION
Now `PyClass` requires `Send`, but what should we do when we *really* don't want it sent to another thread?
Then we can use `#[pyclass(unsendable)]`.
Inspired by [send-wrapper](https://github.com/thk1/send_wrapper), a class with `unsendable` panics when it is accessed by another thread.
```rust
#[pyclass(unsendable)]
struct Unsendable { ... }
```
```python
unsendable = Unsendable()
def func():
    return unsendable.value()
import threading
# func is executed in anohter thread, thus causes panic
threading.Thread.start(target=func)
```
To enable this, I introduced the `PyClassSend` trait.
```rust
pub trait PyClassSend {
    type ThreadChecker: PyClassThreadChecker;
}
```

Without `unsendable`, we use `ThreadCheckerStub` as a ThreadChecker, which requires `Send`. Thus not `unsendable` class has to be `Send`able.
```rust
impl pyo3::pyclass::PyClassSend for Class {
    type ThreadChecker = pyo3::pyclass::ThreadCheckerStub<Class>;
}
```

- [ ] Documentation