### PR TITLE
Update FFI definitions for pylifecycle.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add FFI definitions `Py_FinalizeEx`, `PyOS_getsig`, `PyOS_setsig`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
+
+### Changed
+- Change FFI definitions `Py_SetProgramName` and `Py_SetPythonHome` to take `*const` argument instead of `*mut`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
 
 ## [0.11.1] - 2020-06-30
 ### Added

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -40,6 +40,7 @@ pub use self::pycapsule::*;
 pub use self::pydebug::*;
 pub use self::pyerrors::*;
 pub use self::pyhash::*;
+pub use self::pylifecycle::*;
 pub use self::pymem::*;
 pub use self::pyport::*;
 pub use self::pystate::*;
@@ -107,8 +108,9 @@ mod weakrefobject; // TODO supports PEP-384 only; needs adjustment for Python 3.
                    // mod namespaceobject; TODO
 
 mod codecs; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
-mod pyerrors; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 
+mod pyerrors; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
+mod pylifecycle;
 mod pystate; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 
 #[cfg(Py_LIMITED_API)]

--- a/src/ffi/pylifecycle.rs
+++ b/src/ffi/pylifecycle.rs
@@ -1,0 +1,56 @@
+use crate::ffi::pystate::PyThreadState;
+use libc::wchar_t;
+use std::os::raw::{c_char, c_int};
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
+    pub fn Py_Initialize();
+    pub fn Py_InitializeEx(arg1: c_int);
+    pub fn Py_Finalize();
+    #[cfg(Py_3_6)]
+    pub fn Py_FinalizeEx() -> c_int;
+
+    #[cfg_attr(PyPy, link_name = "PyPy_IsInitialized")]
+    pub fn Py_IsInitialized() -> c_int;
+
+    pub fn Py_NewInterpreter() -> *mut PyThreadState;
+    pub fn Py_EndInterpreter(arg1: *mut PyThreadState);
+
+    // TODO: these moved to pylifecycle.h
+    #[cfg_attr(PyPy, link_name = "PyPy_AtExit")]
+    pub fn Py_AtExit(func: Option<extern "C" fn()>) -> c_int;
+
+    pub fn Py_Exit(arg1: c_int);
+
+    pub fn Py_Main(argc: c_int, argv: *mut *mut wchar_t) -> c_int;
+    pub fn Py_BytesMain(argc: c_int, argv: *mut *mut c_char) -> c_int;
+
+    pub fn Py_SetProgramName(arg1: *const wchar_t);
+    #[cfg_attr(PyPy, link_name = "PyPy_GetProgramName")]
+    pub fn Py_GetProgramName() -> *mut wchar_t;
+
+    pub fn Py_SetPythonHome(arg1: *const wchar_t);
+    pub fn Py_GetPythonHome() -> *mut wchar_t;
+
+    pub fn Py_GetProgramFullPath() -> *mut wchar_t;
+
+    pub fn Py_GetPrefix() -> *mut wchar_t;
+    pub fn Py_GetExecPrefix() -> *mut wchar_t;
+    pub fn Py_GetPath() -> *mut wchar_t;
+    pub fn Py_SetPath(arg1: *const wchar_t);
+
+    #[cfg_attr(PyPy, link_name = "PyPy_GetVersion")]
+    pub fn Py_GetVersion() -> *const c_char;
+    pub fn Py_GetPlatform() -> *const c_char;
+    pub fn Py_GetCopyright() -> *const c_char;
+    pub fn Py_GetCompiler() -> *const c_char;
+    pub fn Py_GetBuildInfo() -> *const c_char;
+}
+
+type PyOS_sighandler_t = unsafe extern "C" fn(arg1: c_int);
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
+    pub fn PyOS_getsig(arg1: c_int) -> PyOS_sighandler_t;
+    pub fn PyOS_setsig(arg1: c_int, arg2: PyOS_sighandler_t) -> PyOS_sighandler_t;
+}

--- a/src/ffi/pythonrun.rs
+++ b/src/ffi/pythonrun.rs
@@ -1,29 +1,11 @@
 use crate::ffi::object::*;
 #[cfg(not(Py_LIMITED_API))]
 use crate::ffi::pyarena::PyArena;
-use crate::ffi::pystate::PyThreadState;
-use libc::{wchar_t, FILE};
+use libc::FILE;
 use std::os::raw::{c_char, c_int};
 use std::ptr;
 
 // TODO: PyCF_MASK etc. constants
-
-#[cfg_attr(windows, link(name = "pythonXY"))]
-extern "C" {
-    // TODO: these moved to pylifecycle.h
-    pub fn Py_SetProgramName(arg1: *mut wchar_t);
-    #[cfg_attr(PyPy, link_name = "PyPy_GetProgramName")]
-    pub fn Py_GetProgramName() -> *mut wchar_t;
-    pub fn Py_SetPythonHome(arg1: *mut wchar_t);
-    pub fn Py_GetPythonHome() -> *mut wchar_t;
-    pub fn Py_Initialize();
-    pub fn Py_InitializeEx(arg1: c_int);
-    pub fn Py_Finalize();
-    #[cfg_attr(PyPy, link_name = "PyPy_IsInitialized")]
-    pub fn Py_IsInitialized() -> c_int;
-    pub fn Py_NewInterpreter() -> *mut PyThreadState;
-    pub fn Py_EndInterpreter(arg1: *mut PyThreadState);
-}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -225,21 +207,4 @@ extern "C" {
     pub fn PyErr_PrintEx(arg1: c_int);
     #[cfg_attr(PyPy, link_name = "PyPyErr_Display")]
     pub fn PyErr_Display(arg1: *mut PyObject, arg2: *mut PyObject, arg3: *mut PyObject);
-
-    // TODO: these moved to pylifecycle.h
-    #[cfg_attr(PyPy, link_name = "PyPy_AtExit")]
-    pub fn Py_AtExit(func: Option<extern "C" fn()>) -> c_int;
-    pub fn Py_Exit(arg1: c_int);
-    pub fn Py_Main(argc: c_int, argv: *mut *mut wchar_t) -> c_int;
-    pub fn Py_GetProgramFullPath() -> *mut wchar_t;
-    pub fn Py_GetPrefix() -> *mut wchar_t;
-    pub fn Py_GetExecPrefix() -> *mut wchar_t;
-    pub fn Py_GetPath() -> *mut wchar_t;
-    pub fn Py_SetPath(arg1: *const wchar_t);
-    #[cfg_attr(PyPy, link_name = "PyPy_GetVersion")]
-    pub fn Py_GetVersion() -> *const c_char;
-    pub fn Py_GetPlatform() -> *const c_char;
-    pub fn Py_GetCopyright() -> *const c_char;
-    pub fn Py_GetCompiler() -> *const c_char;
-    pub fn Py_GetBuildInfo() -> *const c_char;
 }


### PR DESCRIPTION
I moved the relevant FFI definitions to `pylifecycle.rs`.

At the same time, I added a couple of missing definitions and fixed #1017 