### PR TITLE
Fix definition of _PyLong_AsByteArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add FFI definitions `Py_FinalizeEx`, `PyOS_getsig`, `PyOS_setsig`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
 
 ### Changed
-- Change FFI definitions `Py_SetProgramName` and `Py_SetPythonHome` to take `*const` argument instead of `*mut`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
+- Correct FFI definitions `Py_SetProgramName` and `Py_SetPythonHome` to take `*const` argument instead of `*mut`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
 - Rename `PyString::to_string` to `to_str`, change return type `Cow<str>` to `&str`. [#1023](https://github.com/PyO3/pyo3/pull/1023)
+- Correct FFI definition `_PyLong_AsByteArray` `*mut c_uchar` argument instead of `*const c_uchar`. [#1029](https://github.com/PyO3/pyo3/pull/1029)
 
 ### Removed
 - Remove `PyString::as_bytes`. [#1023](https://github.com/PyO3/pyo3/pull/1023)

--- a/src/ffi/longobject.rs
+++ b/src/ffi/longobject.rs
@@ -95,7 +95,7 @@ extern "C" {
 
     pub fn _PyLong_AsByteArray(
         v: *mut PyLongObject,
-        bytes: *const c_uchar,
+        bytes: *mut c_uchar,
         n: size_t,
         little_endian: c_int,
         is_signed: c_int,


### PR DESCRIPTION
Correct FFI defintion from `*const` to `*mut` for `_PyLong_AsByteArray`, which writes to the pointer. Looks like there might have been some UB sneaking in there.