### PR TITLE
Add `Python::with_gil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add FFI definitions `Py_FinalizeEx`, `PyOS_getsig`, `PyOS_setsig`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
+- Add `Python::with_gil` for executing a closure with the Python GIL. [#1037](https://github.com/PyO3/pyo3/pull/1037)
 
 ### Changed
 - Correct FFI definitions `Py_SetProgramName` and `Py_SetPythonHome` to take `*const` argument instead of `*mut`. [#1021](https://github.com/PyO3/pyo3/pull/1021)

--- a/README.md
+++ b/README.md
@@ -108,12 +108,12 @@ use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 
 fn main() -> Result<(), ()> {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    main_(py).map_err(|e| {
-        // We can't display Python exceptions via std::fmt::Display,
-        // so print the error here manually.
-        e.print_and_set_sys_last_vars(py);
+    Python::with_gil(|py| {
+        main_(py).map_err(|e| {
+          // We can't display Python exceptions via std::fmt::Display,
+          // so print the error here manually.
+          e.print_and_set_sys_last_vars(py);
+        })
     })
 }
 

--- a/guide/src/trait_bounds.md
+++ b/guide/src/trait_bounds.md
@@ -79,37 +79,36 @@ struct UserModel {
 impl Model for UserModel {
     fn set_variables(&mut self, var: &Vec<f64>) {
         println!("Rust calling Python to set the variables");
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let values: Vec<f64> = var.clone();
-        let list: PyObject = values.into_py(py);
-        let py_model = self.model.as_ref(py);
-        py_model
-            .call_method("set_variables", (list,), None)
-            .unwrap();
+        Python::with_gil(|py| {
+            let values: Vec<f64> = var.clone();
+            let list: PyObject = values.into_py(py);
+            let py_model = self.model.as_ref(py);
+            py_model
+                .call_method("set_variables", (list,), None)
+                .unwrap();
+        })
     }
 
     fn get_results(&self) -> Vec<f64> {
         println!("Rust calling Python to get the results");
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        self
-            .model
-            .as_ref(py)
-            .call_method("get_results", (), None)
-            .unwrap()
-            .extract()
-            .unwrap()
+        Python::with_gil(|py| {
+            self.model
+                .as_ref(py)
+                .call_method("get_results", (), None)
+                .unwrap()
+                .extract()
+                .unwrap()
+        })
     }
 
     fn compute(&mut self) {
         println!("Rust calling Python to perform the computation");
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        self.model
-            .as_ref(py)
-            .call_method("compute", (), None)
-            .unwrap();
+        Python::with_gil(|py| {
+            self.model
+                .as_ref(py)
+                .call_method("compute", (), None)
+                .unwrap();
+        })
     }
 }
 ```
@@ -180,61 +179,55 @@ This wrapper will also perform the type conversions between Python and Rust.
 # impl Model for UserModel {
 #  fn set_variables(&mut self, var: &Vec<f64>) {
 #      println!("Rust calling Python to set the variables");
-#      let gil = Python::acquire_gil();
-#      let py = gil.python();
-#      let values: Vec<f64> = var.clone();
-#      let list: PyObject = values.into_py(py);
-#      let py_model = self.model.as_ref(py);
-#      py_model
-#          .call_method("set_variables", (list,), None)
-#          .unwrap();
+#      Python::with_gil(|py| {
+#          let values: Vec<f64> = var.clone();
+#          let list: PyObject = values.into_py(py);
+#          let py_model = self.model.as_ref(py);
+#          py_model
+#              .call_method("set_variables", (list,), None)
+#              .unwrap();
+#      })
 #  }
 #
 #  fn get_results(&self) -> Vec<f64> {
 #      println!("Rust calling Python to get the results");
-#      let gil = Python::acquire_gil();
-#      let py = gil.python();
-#      self
-#          .model
-#          .as_ref(py)
-#          .call_method("get_results", (), None)
-#          .unwrap()
-#          .extract()
-#          .unwrap()
+#      Python::with_gil(|py| {
+#          self.model
+#              .as_ref(py)
+#              .call_method("get_results", (), None)
+#              .unwrap()
+#              .extract()
+#              .unwrap()
+#      })
 #  }
 #
 #  fn compute(&mut self) {
 #      println!("Rust calling Python to perform the computation");
-#      let gil = Python::acquire_gil();
-#      let py = gil.python();
-#      self.model
-#          .as_ref(py)
-#          .call_method("compute", (), None)
-#          .unwrap();
+#      Python::with_gil(|py| {
+#          self.model
+#              .as_ref(py)
+#              .call_method("compute", (), None)
+#              .unwrap();
+#      })
+#
 #  }
 # }
 
 #[pymethods]
 impl UserModel {
-    pub fn set_variables(&mut self, var: Vec<f64>) -> PyResult<()> {
+    pub fn set_variables(&mut self, var: Vec<f64>) {
         println!("Set variables from Python calling Rust");
-        Model::set_variables(self, &var);
-        Ok(())
+        Model::set_variables(self, &var)
     }
 
-    pub fn get_results(&mut self) -> PyResult<Vec<f64>> {
+    pub fn get_results(&mut self) -> Vec<f64> {
         println!("Get results from Python calling Rust");
-        let results = Model::get_results(self);
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let py_results = results.into_py(py);
-        Ok(py_results)
+        Model::get_results(self)
     }
 
-    pub fn compute(&mut self) -> PyResult<()> {
+    pub fn compute(&mut self) {
         println!("Compute from Python calling Rust");
-        Model::compute(self);
-        Ok(())
+        Model::compute(self)
     }
 }
 ```
@@ -353,39 +346,38 @@ We used in our `get_results` method the following call that performs the type co
 # }
 
 impl Model for UserModel {
-  fn get_results(&self) -> Vec<f64> {
-    println!("Get results from Rust calling Python");
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    self
-        .model
-        .as_ref(py)
-        .call_method("get_results", (), None)
-        .unwrap()
-        .extract()
-        .unwrap()
+    fn get_results(&self) -> Vec<f64> {
+        println!("Rust calling Python to get the results");
+        Python::with_gil(|py| {
+            self.model
+                .as_ref(py)
+                .call_method("get_results", (), None)
+                .unwrap()
+                .extract()
+                .unwrap()
+        })
     }
-#  fn set_variables(&mut self, var: &Vec<f64>) {
-#      println!("Rust calling Python to set the variables");
-#      let gil = Python::acquire_gil();
-#      let py = gil.python();
-#      let values: Vec<f64> = var.clone();
-#      let list: PyObject = values.into_py(py);
-#      let py_model = self.model.as_ref(py);
-#      py_model
-#          .call_method("set_variables", (list,), None)
-#          .unwrap();
-#  }
+#     fn set_variables(&mut self, var: &Vec<f64>) {
+#         println!("Rust calling Python to set the variables");
+#         Python::with_gil(|py| {
+#             let values: Vec<f64> = var.clone();
+#             let list: PyObject = values.into_py(py);
+#             let py_model = self.model.as_ref(py);
+#             py_model
+#                 .call_method("set_variables", (list,), None)
+#                 .unwrap();
+#         })
+#     }
 #
-#  fn compute(&mut self) {
-#      println!("Rust calling Python to perform the computation");
-#      let gil = Python::acquire_gil();
-#      let py = gil.python();
-#      self.model
-#          .as_ref(py)
-#          .call_method("compute", (), None)
-#          .unwrap();
-#  }
+#     fn compute(&mut self) {
+#         println!("Rust calling Python to perform the computation");
+#         Python::with_gil(|py| {
+#             self.model
+#                 .as_ref(py)
+#                 .call_method("compute", (), None)
+#                 .unwrap();
+#         })
+#     }
 }
 ```
 
@@ -407,42 +399,43 @@ Let's break it down in order to perform better error handling:
 # }
 
 impl Model for UserModel {
-  fn get_results(&self) -> Vec<f64> {
-      println!("Get results from Rust calling Python");
-      let gil = Python::acquire_gil();
-      let py = gil.python();
-      let py_result: &PyAny = self
-          .model
-          .as_ref(py)
-          .call_method("get_results", (), None)
-          .unwrap();
+    fn get_results(&self) -> Vec<f64> {
+        println!("Get results from Rust calling Python");
+        Python::with_gil(|py| {
+            let py_result: &PyAny = self
+                .model
+                .as_ref(py)
+                .call_method("get_results", (), None)
+                .unwrap();
 
-      if py_result.get_type().name() != "list" {
-          panic!("Expected a list for the get_results() method signature, got {}", py_result.get_type().name());
-      }
-      py_result.extract().unwrap()
-  }
-#  fn set_variables(&mut self, var: &Vec<f64>) {
-#      println!("Rust calling Python to set the variables");
-#      let gil = Python::acquire_gil();
-#      let py = gil.python();
-#      let values: Vec<f64> = var.clone();
-#      let list: PyObject = values.into_py(py);
-#      let py_model = self.model.as_ref(py);
-#      py_model
-#          .call_method("set_variables", (list,), None)
-#          .unwrap();
-#  }
+            if py_result.get_type().name() != "list" {
+                panic!("Expected a list for the get_results() method signature, got {}", py_result.get_type().name());
+            }
+            py_result.extract()
+        })
+        .unwrap()
+    }
+#     fn set_variables(&mut self, var: &Vec<f64>) {
+#         println!("Rust calling Python to set the variables");
+#         Python::with_gil(|py| {
+#             let values: Vec<f64> = var.clone();
+#             let list: PyObject = values.into_py(py);
+#             let py_model = self.model.as_ref(py);
+#             py_model
+#                 .call_method("set_variables", (list,), None)
+#                 .unwrap();
+#         })
+#     }
 #
-#  fn compute(&mut self) {
-#      println!("Rust calling Python to perform the computation");
-#      let gil = Python::acquire_gil();
-#      let py = gil.python();
-#      self.model
-#          .as_ref(py)
-#          .call_method("compute", (), None)
-#          .unwrap();
-#  }
+#     fn compute(&mut self) {
+#         println!("Rust calling Python to perform the computation");
+#         Python::with_gil(|py| {
+#             self.model
+#                 .as_ref(py)
+#                 .call_method("compute", (), None)
+#                 .unwrap();
+#         })
+#     }
 }
 ```
 
@@ -495,7 +488,7 @@ pub struct UserModel {
 #[pymodule]
 fn trait_exposure(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<UserModel>()?;
-    m.add_wrapped(wrap_pyfunction!(solve_wrapper)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(solve_wrapper))?;
     Ok(())
 }
 
@@ -506,64 +499,59 @@ impl UserModel {
         UserModel { model }
     }
 
-    pub fn set_variables(&mut self, var: Vec<f64>) -> PyResult<()> {
+    pub fn set_variables(&mut self, var: Vec<f64>) {
         println!("Set variables from Python calling Rust");
-        Model::set_variables(self, &var);
-        Ok(())
+        Model::set_variables(self, &var)
     }
 
-    pub fn get_results(&mut self) -> PyResult<Vec<f64>> {
+    pub fn get_results(&mut self) -> Vec<f64> {
         println!("Get results from Python calling Rust");
-        let results = Model::get_results(self);
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let py_results = results.into_py(py);
-        Ok(py_results)
+        Model::get_results(self)
     }
 
-    pub fn compute(&mut self) -> PyResult<()> {
-        Model::compute(self);
-        Ok(())
+    pub fn compute(&mut self) {
+        Model::compute(self)
     }
 }
 
 impl Model for UserModel {
     fn set_variables(&mut self, var: &Vec<f64>) {
-        println!("Set variables from Rust calling Python");
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let values: Vec<f64> = var.clone();
-        let list: PyObject = values.into_py(py);
-        let py_model = self.model.as_ref(py);
-        py_model
-            .call_method("set_variables", (list,), None)
-            .unwrap();
+        println!("Rust calling Python to set the variables");
+        Python::with_gil(|py| {
+            let values: Vec<f64> = var.clone();
+            let list: PyObject = values.into_py(py);
+            let py_model = self.model.as_ref(py);
+            py_model
+                .call_method("set_variables", (list,), None)
+                .unwrap();
+        })
     }
 
     fn get_results(&self) -> Vec<f64> {
         println!("Get results from Rust calling Python");
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let py_result: &PyAny = self
-            .model
-            .as_ref(py)
-            .call_method("get_results", (), None)
-            .unwrap();
+        Python::with_gil(|py| {
+            let py_result: &PyAny = self
+                .model
+                .as_ref(py)
+                .call_method("get_results", (), None)
+                .unwrap();
 
-        if py_result.get_type().name() != "list" {
-            panic!("Expected a list for the get_results() method signature, got {}", py_result.get_type().name());
-        }
-        py_result.extract().unwrap()
+            if py_result.get_type().name() != "list" {
+                panic!("Expected a list for the get_results() method signature, got {}", py_result.get_type().name());
+            }
+            py_result.extract()
+        })
+        .unwrap()
     }
 
     fn compute(&mut self) {
-        println!("Compute from Rust calling Python");
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        self.model
-            .as_ref(py)
-            .call_method("compute", (), None)
-            .unwrap();
+        println!("Rust calling Python to perform the computation");
+        Python::with_gil(|py| {
+            self.model
+                .as_ref(py)
+                .call_method("compute", (), None)
+                .unwrap();
+        })
     }
 }
 ```

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -569,8 +569,7 @@ fn buffer_readonly_error() -> PyResult<()> {
 
 impl<T> Drop for PyBuffer<T> {
     fn drop(&mut self) {
-        let _gil_guard = Python::acquire_gil();
-        unsafe { ffi::PyBuffer_Release(&mut *self.0) }
+        Python::with_gil(|_| unsafe { ffi::PyBuffer_Release(&mut *self.0) });
     }
 }
 


### PR DESCRIPTION
As suggested in #1019, this is a new `Python::with_gil` API for executing a closure with the GIL.

It avoids some of the potential panics introduced in #1036, and also might be "nicer" because the usual `acquire_gil(); gil.python()` dance can be replaced by a single `with_gil` call.

I've updated some key examples in the documentation to use `with_gil`, as I think it's probably better to encourage users to use this new API rather than `acquire_gil()`.