### PR TITLE
Rename PYTHON_SYS_EXECUTABLE to PYO3_PYTHON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Correct FFI definitions `Py_SetProgramName` and `Py_SetPythonHome` to take `*const` argument instead of `*mut`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
 - Rename `PyString::to_string` to `to_str`, change return type `Cow<str>` to `&str`. [#1023](https://github.com/PyO3/pyo3/pull/1023)
 - Correct FFI definition `_PyLong_AsByteArray` `*mut c_uchar` argument instead of `*const c_uchar`. [#1029](https://github.com/PyO3/pyo3/pull/1029)
+- Rename `PYTHON_SYS_EXECUTABLE` to `PYO3_PYTHON`. The old name will continue to work but will be undocumented, and will be removed in a future release. [#1039](https://github.com/PyO3/pyo3/pull/1039)
 - `PyType::as_type_ptr` is no longer `unsafe`. [#1047](https://github.com/PyO3/pyo3/pull/1047)
 - Change `PyIterator::from_object` to return `PyResult<PyIterator>` instead of `Result<PyIterator, PyDowncastError>`. [#1051](https://github.com/PyO3/pyo3/pull/1051)
 - Implement `Send + Sync` for `PyErr`. `PyErr::new`, `PyErr::from_type`, `PyException::py_err` and `PyException::into` have had these bounds added to their arguments. [#1067](https://github.com/PyO3/pyo3/pull/1067)

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -2,7 +2,7 @@
 
 ## Python version
 
-PyO3 uses a build script to determine the Python version and set the correct linker arguments. By default it uses the `python3` executable. You can override the Python interpreter by setting `PYTHON_SYS_EXECUTABLE`, e.g., `PYTHON_SYS_EXECUTABLE=python3.6`.
+PyO3 uses a build script to determine the Python version and set the correct linker arguments. By default it uses the `python3` executable. You can override the Python interpreter by setting `PYO3_PYTHON`, e.g., `PYO3_PYTHON=python3.6`.
 
 ## Linking
 

--- a/guide/src/pypy.md
+++ b/guide/src/pypy.md
@@ -6,9 +6,9 @@ Support is only provided for building Rust extension for code running under PyPy
 
 This is a limitation of cpyext and support for embedding cpyext is not planned.
 
-Compilation against PyPy is done by exporting the `PYTHON_SYS_EXECUTABLE` to point to a PyPy binary or by compiling in a PyPy virtualenv.
+Compilation against PyPy is done by exporting `PYO3_PYTHON` to point to a PyPy binary or by compiling in a PyPy virtualenv.
 
-For example, `PYTHON_SYS_EXECUTABLE="/path/to/pypy3" /path/to/pypy3 setup.py install`
+For example, `PYO3_PYTHON="/path/to/pypy3" /path/to/pypy3 setup.py install`
 
 
 ## Unsupported features


### PR DESCRIPTION
As suggested in #539 .

Once merged, I'll update `setuptools-rust` and `maturin` to output both environment variables for now, as a compatible way to manage the migration.