### PR TITLE
Change PyIterator::from_object` to return underlying TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add FFI definitions `Py_FinalizeEx`, `PyOS_getsig`, `PyOS_setsig`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
 - Add `Python::with_gil` for executing a closure with the Python GIL. [#1037](https://github.com/PyO3/pyo3/pull/1037)
+- Implement `Debug` for `PyIterator`. [#1051](https://github.com/PyO3/pyo3/pull/1051)
 
 ### Changed
 - Exception types have been renamed from e.g. `RuntimeError` to `PyRuntimeError`, and are now only accessible by `&T` or `Py<T>` similar to other Python-native types. The old names continue to exist but are deprecated. [#1024](https://github.com/PyO3/pyo3/pull/1024)
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rename `PyString::to_string` to `to_str`, change return type `Cow<str>` to `&str`. [#1023](https://github.com/PyO3/pyo3/pull/1023)
 - Correct FFI definition `_PyLong_AsByteArray` `*mut c_uchar` argument instead of `*const c_uchar`. [#1029](https://github.com/PyO3/pyo3/pull/1029)
 - `PyType::as_type_ptr` is no longer `unsafe`. [#1047](https://github.com/PyO3/pyo3/pull/1047)
+- Change `PyIterator::from_object` to return `PyResult<PyIterator>` instead of `Result<PyIterator, PyDowncastError>`. [#1051](https://github.com/PyO3/pyo3/pull/1051)
 
 ### Removed
 - Remove `PyString::as_bytes`. [#1023](https://github.com/PyO3/pyo3/pull/1023)

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -363,7 +363,7 @@ impl PyAny {
     /// This is typically a new iterator but if the argument is an iterator,
     /// this returns itself.
     pub fn iter(&self) -> PyResult<PyIterator> {
-        Ok(PyIterator::from_object(self.py(), self)?)
+        PyIterator::from_object(self.py(), self)
     }
 
     /// Returns the Python type object for this object's type.


### PR DESCRIPTION
Reviewing #1050 I realised that `PyIterator::from_object()` makes an unneccessary `PyIter_Check()` call as a successful result is already guaranteed to be an iterator.

I simplified it so that the function now returns the error from `PyObject_GetIter()` instead of a `PyDowncastError`. This helps the implementation of #1050 and I think also improves the experience here.

Now this function will return the well-known `TypeError: 'Foo' object is not iterable` which comes from `PyObject_GetIter()`: (https://github.com/python/cpython/blob/8182cc2e68a3c6ea5d5342fed3f1c76b0521fbc1/Objects/abstract.c#L2624)