### PR TITLE
Remove hidden PyErr::restore_and_minus1 and PyErr::restore_and_null

### DIFF
--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -25,10 +25,10 @@ pub fn py_init(fnname: &Ident, name: &Ident, doc: syn::LitStr) -> TokenStream {
             use pyo3::derive_utils::ModuleDef;
             const NAME: &'static str = concat!(stringify!(#name), "\0");
             static MODULE_DEF: ModuleDef = unsafe { ModuleDef::new(NAME) };
-            match MODULE_DEF.make_module(#doc, #fnname) {
-                Ok(m) => m,
-                Err(e) => e.restore_and_null(unsafe { pyo3::Python::assume_gil_acquired() }),
-            }
+
+            let pool = pyo3::GILPool::new();
+            let py = pool.python();
+            pyo3::callback_body!(_py, { MODULE_DEF.make_module(#doc, #fnname) })
         }
     }
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -390,20 +390,6 @@ impl PyErr {
         unsafe { ffi::PyErr_Restore(ptype.into_ptr(), pvalue, ptraceback.into_ptr()) }
     }
 
-    /// Utility method for proc-macro code
-    #[doc(hidden)]
-    pub fn restore_and_null<T>(self, py: Python) -> *mut T {
-        self.restore(py);
-        std::ptr::null_mut()
-    }
-
-    /// Utility method for proc-macro code
-    #[doc(hidden)]
-    pub fn restore_and_minus1(self, py: Python) -> crate::libc::c_int {
-        self.restore(py);
-        -1
-    }
-
     /// Issues a warning message.
     /// May return a `PyErr` if warnings-as-errors is enabled.
     pub fn warn(py: Python, category: &PyAny, message: &str, stacklevel: i32) -> PyResult<()> {


### PR DESCRIPTION
These functions are superseded by `pyo3::callback_body!`.