### PR TITLE
Move the ThreadChecker field in front of dict and weakref.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Conversion from types with an `__index__` method to Rust BigInts. [#1027](https://github.com/PyO3/pyo3/pull/1027)
+- Fix segfault with #[pyclass(dict, unsendable)] [#1058](https://github.com/PyO3/pyo3/pull/1058)
 
 ## [0.11.1] - 2020-06-30
 ### Added

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -161,9 +161,9 @@ impl<T: PyClass> PyCellInner<T> {
 #[repr(C)]
 pub struct PyCell<T: PyClass> {
     inner: PyCellInner<T>,
+    thread_checker: T::ThreadChecker,
     dict: T::Dict,
     weakref: T::WeakRef,
-    thread_checker: T::ThreadChecker,
 }
 
 unsafe impl<T: PyClass> PyNativeType for PyCell<T> {}

--- a/tests/test_unsendable_dict.rs
+++ b/tests/test_unsendable_dict.rs
@@ -1,0 +1,21 @@
+use pyo3::prelude::*;
+use pyo3::py_run;
+
+#[pyclass(dict, unsendable)]
+struct UnsendableDictClass {}
+
+#[pymethods]
+impl UnsendableDictClass {
+    #[new]
+    fn new() -> Self {
+        UnsendableDictClass {}
+    }
+}
+
+#[test]
+fn test_unsendable_dict() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let inst = Py::new(py, UnsendableDictClass {}).unwrap();
+    py_run!(py, inst, "assert inst.__dict__ == {}");
+}


### PR DESCRIPTION
Addresses #1022

Changing the order doesn't seem to cause any other issues. If changing the order seems risky, we can also calculate the initial offsets based on `offset -= std::mem::size_of::<T::ThreadChecker>() as isize;`

----------------
Offsets for dict and weakref are calculated from the end of the PyCell struct. When using the non-dummy ThreadChecker, the offsets were invalid since the `ThreadCheckerImpl` is not zero-sized.

----------------

Thank you for contributing to pyo3!

Here are some things you should check for submitting your pull request:

 - Run `cargo fmt` (This is checked by travis ci)
 - Run `cargo clippy` and check there are no hard errors (There are a bunch of existing warnings; This is also checked by travis)
 - If applicable, add an entry in the changelog.
 - If applicable, add documentation to all new items and extend the guide.
 - If applicable, add tests for all new or fixed functions
 - If you changed any python code, run `black .`. You can install black with `pip install black`)

You might want to run `tox` (`pip install tox`) locally to check compatibility with all supported python versions. If you're using linux or mac you might find the Makefile helpful for testing.
