### PR TITLE
MAINT: Move offset calculation code to PyCell

### DIFF
--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -361,6 +361,20 @@ impl<T: PyClass> PyCell<T> {
         (*self_).thread_checker = T::ThreadChecker::new();
         Ok(self_)
     }
+
+    /// Calculate the offset of the `dict` from the end of the struct.
+    /// E.g., in 64bit devices, offset is -4 (without weakref) or -8 (without weakref).
+    /// Please take care that the offset depends on the order of the members.
+    pub(crate) fn dict_offset() -> Option<isize> {
+        T::Dict::OFFSET.map(|o| o + T::WeakRef::OFFSET.unwrap_or(0))
+    }
+
+    /// Calculate the offset of the `weakref` from the end of the struct.
+    /// E.g., in 64bit devices, offset is -4.
+    /// Please take care that the offset depends on the order of the members.
+    pub(crate) fn weakref_offset() -> Option<isize> {
+        T::WeakRef::OFFSET
+    }
 }
 
 unsafe impl<T: PyClass> PyLayout<T> for PyCell<T> {

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -137,18 +137,15 @@ where
     // type size
     type_object.tp_basicsize = std::mem::size_of::<T::Layout>() as ffi::Py_ssize_t;
 
-    let mut offset = type_object.tp_basicsize;
-
     // __dict__ support
-    if let Some(dict_offset) = T::Dict::OFFSET {
-        offset += dict_offset as ffi::Py_ssize_t;
-        type_object.tp_dictoffset = offset;
+    if let Some(dict_offset) = T::Layout::dict_offset() {
+        type_object.tp_dictoffset = type_object.tp_basicsize + dict_offset as ffi::Py_ssize_t;
     }
 
     // weakref support
-    if let Some(weakref_offset) = T::WeakRef::OFFSET {
-        offset += weakref_offset as ffi::Py_ssize_t;
-        type_object.tp_weaklistoffset = offset;
+    if let Some(weakref_offset) = T::Layout::weakref_offset() {
+        type_object.tp_weaklistoffset =
+            type_object.tp_basicsize + weakref_offset as ffi::Py_ssize_t;
     }
 
     // GC support

--- a/tests/test_unsendable_dict.rs
+++ b/tests/test_unsendable_dict.rs
@@ -8,7 +8,7 @@ struct UnsendableDictClass {}
 impl UnsendableDictClass {
     #[new]
     fn new() -> Self {
-        UnsendableDictClass {}
+        Self {}
     }
 }
 
@@ -18,4 +18,28 @@ fn test_unsendable_dict() {
     let py = gil.python();
     let inst = Py::new(py, UnsendableDictClass {}).unwrap();
     py_run!(py, inst, "assert inst.__dict__ == {}");
+}
+
+#[pyclass(dict, unsendable, weakref)]
+struct UnsendableDictClassWithWeakRef {}
+
+#[pymethods]
+impl UnsendableDictClassWithWeakRef {
+    #[new]
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+#[test]
+fn test_unsendable_dict_with_weakref() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let inst = Py::new(py, UnsendableDictClassWithWeakRef {}).unwrap();
+    py_run!(py, inst, "assert inst.__dict__ == {}");
+    py_run!(
+        py,
+        inst,
+        "import weakref; assert weakref.ref(inst)() is inst; inst.a = 1; assert inst.a == 1"
+    );
 }


### PR DESCRIPTION
Follow up of #1058. Make it cleaner and correct (current code has a bug in that it assumes `weakref, dict` order).
