### PR TITLE
Make `PyErr: Send + Sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Correct FFI definition `_PyLong_AsByteArray` `*mut c_uchar` argument instead of `*const c_uchar`. [#1029](https://github.com/PyO3/pyo3/pull/1029)
 - `PyType::as_type_ptr` is no longer `unsafe`. [#1047](https://github.com/PyO3/pyo3/pull/1047)
 - Change `PyIterator::from_object` to return `PyResult<PyIterator>` instead of `Result<PyIterator, PyDowncastError>`. [#1051](https://github.com/PyO3/pyo3/pull/1051)
+- Implement `Send + Sync` for `PyErr`. `PyErr::new`, `PyErr::from_type`, `PyException::py_err` and `PyException::into` have had these bounds added to their arguments. [#1067](https://github.com/PyO3/pyo3/pull/1067)
 
 ### Removed
 - Remove `PyString::as_bytes`. [#1023](https://github.com/PyO3/pyo3/pull/1023)

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -26,10 +26,12 @@ macro_rules! impl_exception_boilerplate {
         }
 
         impl $name {
-            pub fn py_err<V: $crate::ToPyObject + 'static>(args: V) -> $crate::PyErr {
+            pub fn py_err<V: $crate::ToPyObject + Send + Sync + 'static>(args: V) -> $crate::PyErr {
                 $crate::PyErr::new::<$name, V>(args)
             }
-            pub fn into<R, V: $crate::ToPyObject + 'static>(args: V) -> $crate::PyResult<R> {
+            pub fn into<R, V: $crate::ToPyObject + Send + Sync + 'static>(
+                args: V,
+            ) -> $crate::PyResult<R> {
                 $crate::PyErr::new::<$name, V>(args).into()
             }
         }


### PR DESCRIPTION
Changes `PyErr` to implement `Send + Sync`. This allows easier integration with libraries such as [anyhow](https://docs.rs/anyhow/1.0.31/anyhow/trait.Context.html#foreign-impls), which often require `Send + Sync` errors.

While technically breaking, I think it is unlikely to cause much frustration, because most types convertible to Python are `Send + Sync` already since we added the `#[pyclass]` requirements.

Also, `PyErr::from_value` can be used where the new bounds are restrictive.
