### PR TITLE
#1064: Comparisons with __eq__ should not raise TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PyType::as_type_ptr` is no longer `unsafe`. [#1047](https://github.com/PyO3/pyo3/pull/1047)
 - Change `PyIterator::from_object` to return `PyResult<PyIterator>` instead of `Result<PyIterator, PyDowncastError>`. [#1051](https://github.com/PyO3/pyo3/pull/1051)
 - Implement `Send + Sync` for `PyErr`. `PyErr::new`, `PyErr::from_type`, `PyException::py_err` and `PyException::into` have had these bounds added to their arguments. [#1067](https://github.com/PyO3/pyo3/pull/1067)
+- Change `#[pyproto]` to return NotImplemented for operators for which Python can try a reversed operation. [1072](https://github.com/PyO3/pyo3/pull/1072)
 
 ### Removed
 - Remove `PyString::as_bytes`. [#1023](https://github.com/PyO3/pyo3/pull/1023)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -758,7 +758,7 @@ Each method corresponds to Python's `self.attr`, `self.attr = value` and `del se
 
 ### Emulating numeric types
 
-The [`PyNumberProtocol`] trait allows [emulate numeric types](https://docs.python.org/3/reference/datamodel.html?highlight=__ipow__#emulating-numeric-types).
+The [`PyNumberProtocol`] trait allows [emulate numeric types](https://docs.python.org/3/reference/datamodel.html#emulating-numeric-types).
 
   * `fn __add__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
   * `fn __sub__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
@@ -775,9 +775,8 @@ The [`PyNumberProtocol`] trait allows [emulate numeric types](https://docs.pytho
   * `fn __or__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
   * `fn __xor__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
 
-These methods are called to implement the binary arithmetic operations (`+`,
-`-`, `*`, `@`, `/`, `//`, `%`, `divmod()`, `pow()` and `**`, `<<`, `>>`, `&`,
-`^`, and `|`).
+These methods are called to implement the binary arithmetic operations
+(`+`, `-`, `*`, `@`, `/`, `//`, `%`, `divmod()`, `pow()` and `**`, `<<`, `>>`, `&`, `^`, and `|`).
 
 If `rhs` is not of the type specified in the signature, the generated code
 will automatically `return NotImplemented`.  This is not the case for `lhs`
@@ -822,8 +821,7 @@ This trait also has support the augmented arithmetic assignments (`+=`, `-=`,
   * `fn __ior__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
   * `fn __ixor__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
 
-The following implement the unary arithmetic operations (`-`, `+`, `abs()` and
-`~`):
+The following methods implement the unary arithmetic operations (`-`, `+`, `abs()` and `~`):
 
   * `fn __neg__(&'p self) -> PyResult<impl ToPyObject>`
   * `fn __pos__(&'p self) -> PyResult<impl ToPyObject>`

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -803,6 +803,11 @@ The reflected operations are also available:
 The code generated for these methods expect that all arguments match the
 signature, or raise a TypeError.
 
+*Note*: Currently implementing the method for a binary arithmetic operations
+(e.g, `__add__`) shadows the reflected operation (e.g, `__radd__`).  This is
+being addressed in [#844](https://github.com/PyO3/pyo3/issues/844).  to make
+these methods
+
 
 This trait also has support the augmented arithmetic assignments (`+=`, `-=`,
 `*=`, `@=`, `/=`, `//=`, `%=`, `**=`, `<<=`, `>>=`, `&=`, `^=`, `|=`):

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -756,6 +756,91 @@ Each method corresponds to Python's `self.attr`, `self.attr = value` and `del se
 
     Determines the "truthyness" of the object.
 
+### Emulating numeric types
+
+The [`PyNumberProtocol`] trait allows [emulate numeric types](https://docs.python.org/3/reference/datamodel.html?highlight=__ipow__#emulating-numeric-types).
+
+  * `fn __add__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __sub__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __mul__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __matmul__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __truediv__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __floordiv__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __mod__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __divmod__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __pow__(lhs: impl FromPyObject, rhs: impl FromPyObject, modulo: Option<impl FromPyObject>) -> PyResult<impl ToPyObject>`
+  * `fn __lshift__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rshift__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __and__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __or__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __xor__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+
+These methods are called to implement the binary arithmetic operations (`+`,
+`-`, `*`, `@`, `/`, `//`, `%`, `divmod()`, `pow()` and `**`, `<<`, `>>`, `&`,
+`^`, and `|`).
+
+If `rhs` is not of the type specified in the signature, the generated code
+will automatically `return NotImplemented`.  This is not the case for `lhs`
+which must match signature or else raise a TypeError.
+
+
+The reflected operations are also available:
+
+  * `fn __radd__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rsub__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rmul__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rmatmul__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rtruediv__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rfloordiv__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rmod__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rdivmod__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rpow__(lhs: impl FromPyObject, rhs: impl FromPyObject, modulo: Option<impl FromPyObject>) -> PyResult<impl ToPyObject>`
+  * `fn __rlshift__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rrshift__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rand__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __ror__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+  * `fn __rxor__(lhs: impl FromPyObject, rhs: impl FromPyObject) -> PyResult<impl ToPyObject>`
+
+The code generated for these methods expect that all arguments match the
+signature, or raise a TypeError.
+
+
+This trait also has support the augmented arithmetic assignments (`+=`, `-=`,
+`*=`, `@=`, `/=`, `//=`, `%=`, `**=`, `<<=`, `>>=`, `&=`, `^=`, `|=`):
+
+  * `fn __iadd__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __isub__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __imul__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __imatmul__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __itruediv__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __ifloordiv__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __imod__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __ipow__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __ilshift__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __irshift__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __iand__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __ior__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+  * `fn __ixor__(&'p mut self, other: impl FromPyObject) -> PyResult<()>`
+
+The following implement the unary arithmetic operations (`-`, `+`, `abs()` and
+`~`):
+
+  * `fn __neg__(&'p self) -> PyResult<impl ToPyObject>`
+  * `fn __pos__(&'p self) -> PyResult<impl ToPyObject>`
+  * `fn __abs__(&'p self) -> PyResult<impl ToPyObject>`
+  * `fn __invert__(&'p self) -> PyResult<impl ToPyObject>`
+
+Support for coercions:
+
+  * `fn __complex__(&'p self) -> PyResult<impl ToPyObject>`
+  * `fn __int__(&'p self) -> PyResult<impl ToPyObject>`
+  * `fn __float__(&'p self) -> PyResult<impl ToPyObject>`
+
+Other:
+
+  * `fn __index__(&'p self) -> PyResult<impl ToPyObject>`
+  * `fn __round__(&'p self, ndigits: Option<impl FromPyObject>) -> PyResult<impl ToPyObject>`
+
 ### Garbage Collector Integration
 
 If your type owns references to other Python objects, you will need to

--- a/src/class/basic.rs
+++ b/src/class/basic.rs
@@ -275,13 +275,9 @@ where
     {
         crate::callback_body!(py, {
             let slf = py.from_borrowed_ptr::<crate::PyCell<T>>(slf);
-            let arg = py.from_borrowed_ptr::<PyAny>(arg);
-
+            let arg = extract_or_return_not_implemented!(py, arg);
             let op = extract_op(op)?;
-            let arg = match arg.extract() {
-                Ok(param) => param,
-                _ => return py.NotImplemented().convert(py),
-            };
+
             slf.try_borrow()?.__richcmp__(arg, op).convert(py)
         })
     }

--- a/src/class/basic.rs
+++ b/src/class/basic.rs
@@ -278,8 +278,10 @@ where
             let arg = py.from_borrowed_ptr::<PyAny>(arg);
 
             let op = extract_op(op)?;
-            let arg = arg.extract()?;
-
+            let arg = match arg.extract() {
+                Ok(param) => param,
+                _ => return py.NotImplemented().convert(py),
+            };
             slf.try_borrow()?.__richcmp__(arg, op).convert(py)
         })
     }

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -92,8 +92,11 @@ macro_rules! py_binary_num_func {
             $crate::callback_body!(py, {
                 let lhs = py.from_borrowed_ptr::<$crate::PyAny>(lhs);
                 let rhs = py.from_borrowed_ptr::<$crate::PyAny>(rhs);
-
-                $class::$f(lhs.extract()?, rhs.extract()?).convert(py)
+                let param = match rhs.extract::<<$class as $trait>::Right>() {
+                    Ok(param) => param,
+                    _ => return py.NotImplemented().convert(py),
+                };
+                $class::$f(lhs.extract()?, param).convert(py)
             })
         }
         Some(wrap::<$class>)

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -225,13 +225,14 @@ macro_rules! py_ternary_num_func {
                 let arg1 = py
                     .from_borrowed_ptr::<$crate::types::PyAny>(arg1)
                     .extract()?;
-                let arg2 = py
-                    .from_borrowed_ptr::<$crate::types::PyAny>(arg2)
-                    .extract()?;
-                let arg3 = py
-                    .from_borrowed_ptr::<$crate::types::PyAny>(arg3)
-                    .extract()?;
-
+                let arg2 = match py.from_borrowed_ptr::<$crate::types::PyAny>(arg2).extract() {
+                    Ok(arg) => arg,
+                    _ => return py.NotImplemented().convert(py),
+                };
+                let arg3 = match py.from_borrowed_ptr::<$crate::types::PyAny>(arg3).extract() {
+                    Ok(arg) => arg,
+                    _ => return py.NotImplemented().convert(py),
+                };
                 $class::$f(arg1, arg2, arg3).convert(py)
             })
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,7 @@ pub mod buffer;
 pub mod callback;
 pub mod class;
 pub mod conversion;
+#[macro_use]
 #[doc(hidden)]
 pub mod derive_utils;
 mod err;

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -467,12 +467,12 @@ c2 {} Other()",
                 operator
             )
         );
-        py_expect_exception!(
-            py,
-            c2,
-            &format!("class Other: pass; c2 {} Other()", operator),
-            PyTypeError
-        );
+        // py_expect_exception!(
+        //     py,
+        //     c2,
+        //     &format!("class Other: pass; c2 {} Other()", operator),
+        //     PyTypeError
+        // );
     }
 
     macro_rules! not_implemented_test {

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -523,7 +523,6 @@ c2 {} Other()",
         not_implemented_test![(lt, "<"), (le, "<="), (gt, ">"), (ge, ">="),];
     }
 
-    #[cfg(feature = "remove-this-when-implemented")]
     mod reversed {
         use super::*;
 

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -644,9 +644,17 @@ assert tmp is c2",
     }
 
     #[test]
-    #[ignore]
     fn ipow() {
-        // TODO: Move to `inplace_arith` when it passes
-        _test_inplace_num_operator("**=");
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let c2 = PyCell::new(py, RichComparisonToSelf {}).unwrap();
+        let other = get_other_type(py);
+        py_run!(
+            py,
+            c2 other,
+            "assert (c2.__ipow__(other())) is NotImplemented"
+        );
+
+        py_expect_exception!(py, c2, "class Other: pass\nc2 **= Other()", PyTypeError)
     }
 }

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -443,6 +443,51 @@ mod return_not_implemented {
         }
     }
 
+    #[pyproto]
+    impl<'p> PyNumberProtocol<'p> for RichComparisonToSelf {
+        fn __add__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+        fn __sub__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+        fn __mul__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+        fn __matmul__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+        fn __truediv__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+        fn __floordiv__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+        fn __mod__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+        fn __lshift__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+        fn __rshift__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+        fn __divmod__(lhs: &'p PyAny, _other: PyRef<'p, Self>) -> &'p PyAny {
+            lhs
+        }
+
+        fn __iadd__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __isub__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __imul__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __imatmul__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __itruediv__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __ifloordiv__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __imod__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __ipow__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __ilshift__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __irshift__(&'p mut self, _other: PyRef<'p, Self>) {}
+    }
+
     fn test_dunder(operator: &str, raises_typeerror: bool) {
         let gil = Python::acquire_gil();
         let py = gil.python();

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -488,50 +488,6 @@ mod return_not_implemented {
             lhs
         }
 
-        // Reverse operations
-        fn __radd__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rsub__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rmul__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rmatmul__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rtruediv__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rfloordiv__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rmod__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rpow__(&'p self, other: PyRef<'p, Self>, _modulo: Option<u8>) -> PyObject {
-            other.py().None()
-        }
-        fn __rlshift__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rrshift__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rdivmod__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rand__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __ror__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-        fn __rxor__(&'p self, other: PyRef<'p, Self>) -> PyObject {
-            other.py().None()
-        }
-
         // Inplace assignments
         fn __iadd__(&'p mut self, _other: PyRef<'p, Self>) {}
         fn __isub__(&'p mut self, _other: PyRef<'p, Self>) {}


### PR DESCRIPTION
RichComparisonToSelf expects to compare itself with objects of the same type, but then we shouldn't raise TypeError but return NotImplemented.

Fixes #1064