### PR TITLE
Only use `#[link]` for static mut

### DIFF
--- a/src/ffi/bytearrayobject.rs
+++ b/src/ffi/bytearrayobject.rs
@@ -20,7 +20,6 @@ pub unsafe fn PyByteArray_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyByteArray_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyByteArray_FromObject")]
     pub fn PyByteArray_FromObject(o: *mut PyObject) -> *mut PyObject;

--- a/src/ffi/bytesobject.rs
+++ b/src/ffi/bytesobject.rs
@@ -19,7 +19,6 @@ pub unsafe fn PyBytes_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyBytes_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyBytes_FromStringAndSize")]
     pub fn PyBytes_FromStringAndSize(arg1: *const c_char, arg2: Py_ssize_t) -> *mut PyObject;

--- a/src/ffi/ceval.rs
+++ b/src/ffi/ceval.rs
@@ -4,7 +4,6 @@ use crate::ffi::object::PyObject;
 use crate::ffi::pystate::PyThreadState;
 use std::os::raw::{c_char, c_int, c_void};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyEval_CallObjectWithKeywords")]
     pub fn PyEval_CallObjectWithKeywords(
@@ -19,7 +18,6 @@ pub unsafe fn PyEval_CallObject(func: *mut PyObject, arg: *mut PyObject) -> *mut
     PyEval_CallObjectWithKeywords(func, arg, ::std::ptr::null_mut())
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyEval_CallFunction")]
     pub fn PyEval_CallFunction(obj: *mut PyObject, format: *const c_char, ...) -> *mut PyObject;
@@ -49,6 +47,10 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPy_GetRecursionLimit")]
     pub fn Py_GetRecursionLimit() -> c_int;
     fn _Py_CheckRecursiveCall(_where: *mut c_char) -> c_int;
+}
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
     static mut _Py_CheckRecursionLimit: c_int;
 }
 
@@ -57,7 +59,6 @@ extern "C" {
 pub type _PyFrameEvalFunction =
     extern "C" fn(*mut crate::ffi::PyFrameObject, c_int) -> *mut PyObject;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyEval_GetFuncName(arg1: *mut PyObject) -> *const c_char;
     pub fn PyEval_GetFuncDesc(arg1: *mut PyObject) -> *const c_char;
@@ -78,7 +79,6 @@ extern "C" {
 }
 
 #[cfg(py_sys_config = "WITH_THREAD")]
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyEval_ThreadsInitialized")]
     pub fn PyEval_ThreadsInitialized() -> c_int;

--- a/src/ffi/code.rs
+++ b/src/ffi/code.rs
@@ -77,6 +77,9 @@ pub type FreeFunc = extern "C" fn(*mut c_void) -> c_void;
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub static mut PyCode_Type: PyTypeObject;
+}
+
+extern "C" {
     #[cfg(Py_3_6)]
     pub fn _PyCode_GetExtra(
         code: *mut PyObject,

--- a/src/ffi/codecs.rs
+++ b/src/ffi/codecs.rs
@@ -1,7 +1,6 @@
 use crate::ffi::object::PyObject;
 use std::os::raw::{c_char, c_int};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyCodec_Register(search_function: *mut PyObject) -> c_int;
     pub fn PyCodec_KnownEncoding(encoding: *const c_char) -> c_int;

--- a/src/ffi/compile.rs
+++ b/src/ffi/compile.rs
@@ -32,7 +32,6 @@ pub const FUTURE_BARRY_AS_BDFL: &str = "barry_as_FLUFL";
 pub const FUTURE_GENERATOR_STOP: &str = "generator_stop";
 
 #[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyNode_Compile(arg1: *mut _node, arg2: *const c_char) -> *mut PyCodeObject;
 

--- a/src/ffi/complexobject.rs
+++ b/src/ffi/complexobject.rs
@@ -17,7 +17,6 @@ pub unsafe fn PyComplex_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyComplex_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyComplex_FromDoubles")]
     pub fn PyComplex_FromDoubles(real: c_double, imag: c_double) -> *mut PyObject;
@@ -42,7 +41,6 @@ pub struct PyComplexObject {
 }
 
 #[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn _Py_c_sum(left: Py_complex, right: Py_complex) -> Py_complex;
     pub fn _Py_c_diff(left: Py_complex, right: Py_complex) -> Py_complex;

--- a/src/ffi/descrobject.rs
+++ b/src/ffi/descrobject.rs
@@ -56,7 +56,9 @@ extern "C" {
     pub static mut PyWrapperDescr_Type: PyTypeObject;
     #[cfg_attr(PyPy, link_name = "PyPyDictProxy_Type")]
     pub static mut PyDictProxy_Type: PyTypeObject;
+}
 
+extern "C" {
     pub fn PyDescr_NewMethod(arg1: *mut PyTypeObject, arg2: *mut PyMethodDef) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyDescr_NewClassMethod")]
     pub fn PyDescr_NewClassMethod(arg1: *mut PyTypeObject, arg2: *mut PyMethodDef)

--- a/src/ffi/dictobject.rs
+++ b/src/ffi/dictobject.rs
@@ -65,7 +65,6 @@ pub unsafe fn PyDictViewSet_Check(op: *mut PyObject) -> c_int {
     (PyDictKeys_Check(op) != 0 || PyDictItems_Check(op) != 0) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyDict_New")]
     pub fn PyDict_New() -> *mut PyObject;

--- a/src/ffi/eval.rs
+++ b/src/ffi/eval.rs
@@ -1,7 +1,6 @@
 use crate::ffi::object::PyObject;
 use std::os::raw::c_int;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyEval_EvalCode")]
     pub fn PyEval_EvalCode(

--- a/src/ffi/fileobject.rs
+++ b/src/ffi/fileobject.rs
@@ -3,7 +3,6 @@ use std::os::raw::{c_char, c_int};
 
 pub const PY_STDIOTEXTMODE: &str = "b";
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyFile_FromFd(
         arg1: c_int,
@@ -23,7 +22,10 @@ extern "C" {
     pub fn PyFile_WriteObject(arg1: *mut PyObject, arg2: *mut PyObject, arg3: c_int) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyFile_WriteString")]
     pub fn PyFile_WriteString(arg1: *const c_char, arg2: *mut PyObject) -> c_int;
+}
 
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
     pub static mut Py_FileSystemDefaultEncoding: *const c_char;
     #[cfg(Py_3_6)]
     pub static mut Py_FileSystemDefaultEncodeErrors: *const c_char;

--- a/src/ffi/floatobject.rs
+++ b/src/ffi/floatobject.rs
@@ -29,7 +29,6 @@ pub unsafe fn PyFloat_AS_DOUBLE(op: *mut PyObject) -> c_double {
     (*(op as *mut PyFloatObject)).ob_fval
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyFloat_GetMax() -> c_double;
     pub fn PyFloat_GetMin() -> c_double;

--- a/src/ffi/frameobject.rs
+++ b/src/ffi/frameobject.rs
@@ -55,7 +55,6 @@ pub unsafe fn PyFrame_Check(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyFrame_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyFrame_New")]
     pub fn PyFrame_New(

--- a/src/ffi/genobject.rs
+++ b/src/ffi/genobject.rs
@@ -33,7 +33,6 @@ pub unsafe fn PyGen_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyGen_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyGen_New(frame: *mut PyFrameObject) -> *mut PyObject;
     pub fn PyGen_NeedsFinalizing(op: *mut PyGenObject) -> c_int;

--- a/src/ffi/import.rs
+++ b/src/ffi/import.rs
@@ -1,7 +1,6 @@
 use crate::ffi::object::PyObject;
 use std::os::raw::{c_char, c_int, c_long};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyImport_GetMagicNumber() -> c_long;
     pub fn PyImport_GetMagicTag() -> *const c_char;
@@ -62,7 +61,6 @@ pub unsafe fn PyImport_ImportModuleEx(
     PyImport_ImportModuleLevel(name, globals, locals, fromlist, 0)
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyImport_GetImporter(path: *mut PyObject) -> *mut PyObject;
     pub fn PyImport_Import(name: *mut PyObject) -> *mut PyObject;

--- a/src/ffi/intrcheck.rs
+++ b/src/ffi/intrcheck.rs
@@ -1,6 +1,5 @@
 use std::os::raw::c_int;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyOS_InterruptOccurred")]
     pub fn PyOS_InterruptOccurred() -> c_int;

--- a/src/ffi/iterobject.rs
+++ b/src/ffi/iterobject.rs
@@ -5,7 +5,9 @@ use std::os::raw::c_int;
 extern "C" {
     pub static mut PySeqIter_Type: PyTypeObject;
     pub static mut PyCallIter_Type: PyTypeObject;
+}
 
+extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPySeqIter_New")]
     pub fn PySeqIter_New(arg1: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyCallIter_New")]

--- a/src/ffi/listobject.rs
+++ b/src/ffi/listobject.rs
@@ -48,7 +48,6 @@ pub unsafe fn PyList_SET_ITEM(op: *mut PyObject, i: Py_ssize_t, v: *mut PyObject
     *(*(op as *mut PyListObject)).ob_item.offset(i as isize) = v;
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyList_New")]
     pub fn PyList_New(size: Py_ssize_t) -> *mut PyObject;

--- a/src/ffi/longobject.rs
+++ b/src/ffi/longobject.rs
@@ -27,7 +27,6 @@ pub unsafe fn PyLong_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyLong_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyLong_FromLong")]
     pub fn PyLong_FromLong(arg1: c_long) -> *mut PyObject;
@@ -81,7 +80,6 @@ extern "C" {
 }
 
 #[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn _PyLong_NumBits(obj: *mut PyObject) -> c_int;
 

--- a/src/ffi/marshal.rs
+++ b/src/ffi/marshal.rs
@@ -1,7 +1,6 @@
 use super::PyObject;
 use std::os::raw::{c_char, c_int};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyMarshal_WriteObjectToString")]
     pub fn PyMarshal_WriteObjectToString(object: *mut PyObject, version: c_int) -> *mut PyObject;

--- a/src/ffi/memoryobject.rs
+++ b/src/ffi/memoryobject.rs
@@ -13,7 +13,6 @@ pub unsafe fn PyMemoryView_Check(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyMemoryView_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyMemoryView_FromObject")]
     pub fn PyMemoryView_FromObject(base: *mut PyObject) -> *mut PyObject;

--- a/src/ffi/methodobject.rs
+++ b/src/ffi/methodobject.rs
@@ -7,6 +7,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyCFunction_Type")]
     pub static mut PyCFunction_Type: PyTypeObject;
 }
+
 #[inline]
 pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyCFunction_Type) as c_int
@@ -61,7 +62,6 @@ pub type PyCFunctionWithKeywords = unsafe extern "C" fn(
     kwds: *mut PyObject,
 ) -> *mut PyObject;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyCFunction_GetFunction")]
     pub fn PyCFunction_GetFunction(f: *mut PyObject) -> Option<PyCFunction>;
@@ -102,7 +102,6 @@ pub unsafe fn PyCFunction_New(ml: *mut PyMethodDef, slf: *mut PyObject) -> *mut 
     PyCFunction_NewEx(ml, slf, ptr::null_mut())
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyCFunction_NewEx")]
     pub fn PyCFunction_NewEx(
@@ -137,7 +136,6 @@ be specified alone or with METH_KEYWORDS. */
 #[cfg(all(Py_3_7, not(Py_LIMITED_API)))]
 pub const METH_FASTCALL: c_int = 0x0080;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyCFunction_ClearFreeList() -> c_int;
 }

--- a/src/ffi/modsupport.rs
+++ b/src/ffi/modsupport.rs
@@ -4,7 +4,6 @@ use crate::ffi::object::PyObject;
 use crate::ffi::pyport::Py_ssize_t;
 use std::os::raw::{c_char, c_int, c_long};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyArg_Parse")]
     pub fn PyArg_Parse(arg1: *mut PyObject, arg2: *const c_char, ...) -> c_int;
@@ -60,7 +59,6 @@ pub const Py_CLEANUP_SUPPORTED: i32 = 0x2_0000;
 pub const PYTHON_API_VERSION: i32 = 1013;
 pub const PYTHON_ABI_VERSION: i32 = 3;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg(not(py_sys_config = "Py_TRACE_REFS"))]
     #[cfg_attr(PyPy, link_name = "PyPyModule_Create2")]

--- a/src/ffi/moduleobject.rs
+++ b/src/ffi/moduleobject.rs
@@ -19,7 +19,6 @@ pub unsafe fn PyModule_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyModule_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyModule_NewObject(name: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyModule_New")]
@@ -36,6 +35,10 @@ extern "C" {
     pub fn PyModule_GetState(arg1: *mut PyObject) -> *mut c_void;
     #[cfg_attr(PyPy, link_name = "PyPyModuleDef_Init")]
     pub fn PyModuleDef_Init(arg1: *mut PyModuleDef) -> *mut PyObject;
+}
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
     pub static mut PyModuleDef_Type: PyTypeObject;
 }
 

--- a/src/ffi/object.rs
+++ b/src/ffi/object.rs
@@ -713,7 +713,6 @@ impl Default for PyType_Spec {
     }
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyType_FromSpec")]
     pub fn PyType_FromSpec(arg1: *mut PyType_Spec) -> *mut PyObject;
@@ -724,7 +723,6 @@ extern "C" {
     pub fn PyType_GetSlot(arg1: *mut PyTypeObject, arg2: c_int) -> *mut c_void;
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyType_IsSubtype")]
     pub fn PyType_IsSubtype(a: *mut PyTypeObject, b: *mut PyTypeObject) -> c_int;
@@ -745,7 +743,9 @@ extern "C" {
     pub static mut PyBaseObject_Type: PyTypeObject;
     /// built-in 'super'
     pub static mut PySuper_Type: PyTypeObject;
+}
 
+extern "C" {
     pub fn PyType_GetFlags(arg1: *mut PyTypeObject) -> c_ulong;
 }
 
@@ -759,7 +759,6 @@ pub unsafe fn PyType_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyType_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyType_Ready")]
     pub fn PyType_Ready(t: *mut PyTypeObject) -> c_int;
@@ -919,7 +918,6 @@ pub unsafe fn PyType_FastSubclass(t: *mut PyTypeObject, f: c_ulong) -> c_int {
     PyType_HasFeature(t, f)
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "_PyPy_Dealloc")]
     pub fn _Py_Dealloc(arg1: *mut PyObject);
@@ -970,13 +968,15 @@ pub unsafe fn Py_XDECREF(op: *mut PyObject) {
     }
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPy_IncRef")]
     pub fn Py_IncRef(o: *mut PyObject);
     #[cfg_attr(PyPy, link_name = "PyPy_DecRef")]
     pub fn Py_DecRef(o: *mut PyObject);
+}
 
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
     #[cfg_attr(PyPy, link_name = "_PyPy_NoneStruct")]
     static mut _Py_NoneStruct: PyObject;
     #[cfg_attr(PyPy, link_name = "_PyPy_NotImplementedStruct")]

--- a/src/ffi/objectabstract.rs
+++ b/src/ffi/objectabstract.rs
@@ -15,7 +15,6 @@ pub unsafe fn PyObject_DelAttr(o: *mut PyObject, attr_name: *mut PyObject) -> c_
     PyObject_SetAttr(o, attr_name, ptr::null_mut())
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyObject_Call")]
     pub fn PyObject_Call(
@@ -61,7 +60,6 @@ pub unsafe fn PyObject_Length(o: *mut PyObject) -> Py_ssize_t {
     PyObject_Size(o)
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg(not(Py_LIMITED_API))]
     #[cfg_attr(PyPy, link_name = "PyPyObject_LengthHint")]
@@ -103,7 +101,6 @@ pub unsafe fn PyObject_CheckBuffer(o: *mut PyObject) -> c_int {
 }
 
 #[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyObject_GetBuffer")]
     pub fn PyObject_GetBuffer(obj: *mut PyObject, view: *mut Py_buffer, flags: c_int) -> c_int;
@@ -146,7 +143,6 @@ extern "C" {
     pub fn PyBuffer_Release(view: *mut Py_buffer);
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyObject_Format")]
     pub fn PyObject_Format(obj: *mut PyObject, format_spec: *mut PyObject) -> *mut PyObject;
@@ -167,7 +163,6 @@ pub unsafe fn PyIter_Check(o: *mut PyObject) -> c_int {
     }) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyIter_Next")]
     pub fn PyIter_Next(arg1: *mut PyObject) -> *mut PyObject;
@@ -221,7 +216,6 @@ pub unsafe fn PyIndex_Check(o: *mut PyObject) -> c_int {
     (!tp_as_number.is_null() && (*tp_as_number).nb_index.is_some()) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyNumber_Index")]
     pub fn PyNumber_Index(o: *mut PyObject) -> *mut PyObject;
@@ -275,7 +269,6 @@ pub unsafe fn PySequence_Length(o: *mut PyObject) -> Py_ssize_t {
     PySequence_Size(o)
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPySequence_Concat")]
     pub fn PySequence_Concat(o1: *mut PyObject, o2: *mut PyObject) -> *mut PyObject;
@@ -315,7 +308,6 @@ pub unsafe fn PySequence_In(o: *mut PyObject, value: *mut PyObject) -> c_int {
     PySequence_Contains(o, value)
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPySequence_Index")]
     pub fn PySequence_Index(o: *mut PyObject, value: *mut PyObject) -> Py_ssize_t;
@@ -345,7 +337,6 @@ pub unsafe fn PyMapping_DelItem(o: *mut PyObject, key: *mut PyObject) -> c_int {
     PyObject_DelItem(o, key)
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyMapping_HasKeyString")]
     pub fn PyMapping_HasKeyString(o: *mut PyObject, key: *const c_char) -> c_int;

--- a/src/ffi/objimpl.rs
+++ b/src/ffi/objimpl.rs
@@ -3,7 +3,6 @@ use crate::ffi::pyport::Py_ssize_t;
 use libc::size_t;
 use std::os::raw::{c_int, c_void};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyObject_Malloc")]
     pub fn PyObject_Malloc(size: size_t) -> *mut c_void;
@@ -48,7 +47,6 @@ impl Default for PyObjectArenaAllocator {
     }
 }
 #[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyObject_GetArenaAllocator(allocator: *mut PyObjectArenaAllocator);
     pub fn PyObject_SetArenaAllocator(allocator: *mut PyObjectArenaAllocator);
@@ -72,7 +70,6 @@ pub unsafe fn PyObject_IS_GC(o: *mut PyObject) -> c_int {
         }) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn _PyObject_GC_Resize(arg1: *mut PyVarObject, arg2: Py_ssize_t) -> *mut PyVarObject;
 

--- a/src/ffi/osmodule.rs
+++ b/src/ffi/osmodule.rs
@@ -1,7 +1,6 @@
 // This header is new in Python 3.6
 use crate::ffi::object::PyObject;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyOS_FSPath(path: *mut PyObject) -> *mut PyObject;
 }

--- a/src/ffi/pycapsule.rs
+++ b/src/ffi/pycapsule.rs
@@ -14,7 +14,6 @@ pub unsafe fn PyCapsule_CheckExact(ob: *mut PyObject) -> c_int {
     (Py_TYPE(ob) == &mut PyCapsule_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyCapsule_New")]
     pub fn PyCapsule_New(

--- a/src/ffi/pyerrors.rs
+++ b/src/ffi/pyerrors.rs
@@ -77,7 +77,6 @@ pub struct PyStopIterationObject {
     pub value: *mut PyObject,
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyErr_SetNone")]
     pub fn PyErr_SetNone(arg1: *mut PyObject);
@@ -312,7 +311,9 @@ extern "C" {
     pub static mut PyExc_BytesWarning: *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyExc_ResourceWarning")]
     pub static mut PyExc_ResourceWarning: *mut PyObject;
+}
 
+extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyErr_BadArgument")]
     pub fn PyErr_BadArgument() -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyErr_NoMemory")]

--- a/src/ffi/pyhash.rs
+++ b/src/ffi/pyhash.rs
@@ -17,7 +17,6 @@ impl Default for PyHash_FuncDef {
     }
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyHash_GetFuncDef() -> *mut PyHash_FuncDef;
     #[cfg(not(PyPy))]

--- a/src/ffi/pylifecycle.rs
+++ b/src/ffi/pylifecycle.rs
@@ -2,7 +2,6 @@ use crate::ffi::pystate::PyThreadState;
 use libc::wchar_t;
 use std::os::raw::{c_char, c_int};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn Py_Initialize();
     pub fn Py_InitializeEx(arg1: c_int);
@@ -49,7 +48,6 @@ extern "C" {
 
 type PyOS_sighandler_t = unsafe extern "C" fn(arg1: c_int);
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyOS_getsig(arg1: c_int) -> PyOS_sighandler_t;
     pub fn PyOS_setsig(arg1: c_int, arg2: PyOS_sighandler_t) -> PyOS_sighandler_t;

--- a/src/ffi/pymem.rs
+++ b/src/ffi/pymem.rs
@@ -2,7 +2,6 @@ use libc::size_t;
 use std::os::raw::c_void;
 
 #[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyMem_RawMalloc")]
     pub fn PyMem_RawMalloc(size: size_t) -> *mut c_void;
@@ -14,7 +13,6 @@ extern "C" {
     pub fn PyMem_RawFree(ptr: *mut c_void);
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyMem_Malloc")]
     pub fn PyMem_Malloc(size: size_t) -> *mut c_void;
@@ -49,7 +47,6 @@ pub struct PyMemAllocatorEx {
 }
 
 #[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyMem_GetAllocator(domain: PyMemAllocatorDomain, allocator: *mut PyMemAllocatorEx);
     pub fn PyMem_SetAllocator(domain: PyMemAllocatorDomain, allocator: *mut PyMemAllocatorEx);

--- a/src/ffi/pystate.rs
+++ b/src/ffi/pystate.rs
@@ -22,7 +22,6 @@ pub struct PyThreadState {
     pub interp: *mut PyInterpreterState,
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyInterpreterState_New() -> *mut PyInterpreterState;
     pub fn PyInterpreterState_Clear(arg1: *mut PyInterpreterState);
@@ -58,7 +57,6 @@ pub enum PyGILState_STATE {
     PyGILState_UNLOCKED,
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyGILState_Ensure")]
     pub fn PyGILState_Ensure() -> PyGILState_STATE;

--- a/src/ffi/pystrtod.rs
+++ b/src/ffi/pystrtod.rs
@@ -1,7 +1,6 @@
 use crate::ffi::object::PyObject;
 use std::os::raw::{c_char, c_double, c_int};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyOS_string_to_double")]
     pub fn PyOS_string_to_double(

--- a/src/ffi/pythonrun.rs
+++ b/src/ffi/pythonrun.rs
@@ -18,7 +18,6 @@ pub struct PyCompilerFlags {
 pub enum _mod {}
 
 #[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyRun_SimpleStringFlags(arg1: *const c_char, arg2: *mut PyCompilerFlags) -> c_int;
     pub fn PyRun_AnyFileFlags(
@@ -105,7 +104,6 @@ pub unsafe fn PyParser_SimpleParseFile(fp: *mut FILE, s: *const c_char, b: c_int
     PyParser_SimpleParseFileFlags(fp, s, b, 0)
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyParser_SimpleParseStringFlags(
         arg1: *const c_char,
@@ -170,7 +168,6 @@ pub unsafe fn Py_CompileString(string: *const c_char, p: *const c_char, s: c_int
     Py_CompileStringFlags(string, p, s, ptr::null_mut())
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg(not(Py_LIMITED_API))]
     #[cfg(not(PyPy))]

--- a/src/ffi/setobject.rs
+++ b/src/ffi/setobject.rs
@@ -65,7 +65,6 @@ pub unsafe fn PyFrozenSet_Check(ob: *mut PyObject) -> c_int {
         || PyType_IsSubtype(Py_TYPE(ob), &mut PyFrozenSet_Type) != 0) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPySet_New")]
     pub fn PySet_New(arg1: *mut PyObject) -> *mut PyObject;

--- a/src/ffi/sliceobject.rs
+++ b/src/ffi/sliceobject.rs
@@ -2,7 +2,6 @@ use crate::ffi::object::*;
 use crate::ffi::pyport::Py_ssize_t;
 use std::os::raw::c_int;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "_PyPy_EllipsisObject")]
     static mut _Py_EllipsisObject: PyObject;
@@ -34,7 +33,6 @@ pub struct PySliceObject {
     pub step: *mut PyObject,
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPySlice_New")]
     pub fn PySlice_New(

--- a/src/ffi/structmember.rs
+++ b/src/ffi/structmember.rs
@@ -51,7 +51,6 @@ pub const READ_RESTRICTED: c_int = 2;
 pub const PY_WRITE_RESTRICTED: c_int = 4;
 pub const RESTRICTED: c_int = READ_RESTRICTED | PY_WRITE_RESTRICTED;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyMember_GetOne(addr: *const c_char, l: *mut PyMemberDef) -> *mut PyObject;
     pub fn PyMember_SetOne(addr: *mut c_char, l: *mut PyMemberDef, value: *mut PyObject) -> c_int;

--- a/src/ffi/structseq.rs
+++ b/src/ffi/structseq.rs
@@ -18,7 +18,6 @@ pub struct PyStructSequence_Desc {
     pub n_in_sequence: c_int,
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyStructSequence_NewType(desc: *mut PyStructSequence_Desc) -> *mut PyTypeObject;
     pub fn PyStructSequence_New(_type: *mut PyTypeObject) -> *mut PyObject;

--- a/src/ffi/sysmodule.rs
+++ b/src/ffi/sysmodule.rs
@@ -3,7 +3,6 @@ use crate::ffi::pyport::Py_ssize_t;
 use libc::wchar_t;
 use std::os::raw::{c_char, c_int};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn Py_DecodeLocale(arg1: *const c_char, arg2: Py_ssize_t) -> *mut wchar_t;
     #[cfg_attr(PyPy, link_name = "PyPySys_GetObject")]

--- a/src/ffi/traceback.rs
+++ b/src/ffi/traceback.rs
@@ -1,12 +1,15 @@
 use crate::ffi::object::*;
 use std::os::raw::c_int;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyTraceBack_Here")]
     pub fn PyTraceBack_Here(arg1: *mut crate::ffi::PyFrameObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyTraceBack_Print")]
     pub fn PyTraceBack_Print(arg1: *mut PyObject, arg2: *mut PyObject) -> c_int;
+}
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyTraceBack_Type")]
     pub static mut PyTraceBack_Type: PyTypeObject;
 }

--- a/src/ffi/tupleobject.rs
+++ b/src/ffi/tupleobject.rs
@@ -25,7 +25,6 @@ pub unsafe fn PyTuple_CheckExact(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyTuple_Type) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyTuple_New")]
     pub fn PyTuple_New(size: Py_ssize_t) -> *mut PyObject;

--- a/src/ffi/unicodeobject.rs
+++ b/src/ffi/unicodeobject.rs
@@ -31,7 +31,6 @@ pub unsafe fn PyUnicode_CheckExact(op: *mut PyObject) -> c_int {
 
 pub const Py_UNICODE_REPLACEMENT_CHARACTER: Py_UCS4 = 0xFFFD;
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg(not(Py_LIMITED_API))]
     pub fn PyUnicode_New(size: Py_ssize_t, maxchar: Py_UCS4) -> *mut PyObject;

--- a/src/ffi/warnings.rs
+++ b/src/ffi/warnings.rs
@@ -2,7 +2,6 @@ use crate::ffi::object::PyObject;
 use crate::ffi::pyport::Py_ssize_t;
 use std::os::raw::{c_char, c_int};
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyErr_WarnEx(
         category: *mut PyObject,

--- a/src/ffi/weakrefobject.rs
+++ b/src/ffi/weakrefobject.rs
@@ -3,7 +3,6 @@ use std::os::raw::c_int;
 
 pub enum PyWeakReference {}
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     static mut _PyWeakref_RefType: PyTypeObject;
     static mut _PyWeakref_ProxyType: PyTypeObject;
@@ -34,7 +33,6 @@ pub unsafe fn PyWeakref_Check(op: *mut PyObject) -> c_int {
     (PyWeakref_CheckRef(op) != 0 || PyWeakref_CheckProxy(op) != 0) as c_int
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyWeakref_NewRef")]
     pub fn PyWeakref_NewRef(ob: *mut PyObject, callback: *mut PyObject) -> *mut PyObject;


### PR DESCRIPTION
I just happened to notice that this was the only place where the attribute is actually needed. The rest of the ffi definitions can link happily without this attribute even on windows.