### PR TITLE
Remove redundant iter test

### DIFF
--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -168,16 +168,3 @@ fn test_pickle() {
     "#
     );
 }
-
-#[test]
-fn incorrect_iter() {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    let int = 13isize.to_object(py);
-    let int_ref = int.as_ref(py);
-    // Should not segfault.
-    assert!(int_ref.iter().is_err());
-    assert!(py
-        .eval("print('Exception state should not be set.')", None, None)
-        .is_ok());
-}


### PR DESCRIPTION
This test produces extra "Exception state should not be set." output, which I found confusing.

```
$ cargo test --test test_various incorrect
    Finished test [unoptimized + debuginfo] target(s) in 0.02s
     Running target/debug/deps/test_various-756839897d6f2700

running 1 test
Exception state should not be set.
test incorrect_iter ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out
```

It's also redundant as the following test checks exactly the same behaviour:

https://github.com/PyO3/pyo3/blob/3809e2b3e991668b05ba1ce0483d9da29dc2f159/src/types/iterator.rs#L183-L184