### PR TITLE
Move fmt and clippy to actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,31 @@ name: Test
 on: [push, pull_request]
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+      - run: pip install black==19.10b0
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Check python formatting (black)
+        run: black --check .
+      - name: Check rust formatting (rustfmt)
+        run: cargo fmt --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: make clippy
+
   build:
+    needs: [fmt] # don't wait for clippy as fails rarely and takes longer
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
@@ -19,7 +43,6 @@ jobs:
           # There is no 64-bit pypy on windows
           - python-version: pypy3
             platform: { os: "windows-latest", python-architecture: "x64" }
-
 
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ jobs:
       python: "3.7"
     - name: Python 3.8
       python: "3.8"
-      # Run clippy and rustfmt
-      env: RUN_LINT=1
     - name: Python 3.9-dev
       python: "3.9-dev"
     - name: Nightly

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 .PHONY: test test_py publish clippy lint fmt
 
-# Constant used in clippy target
-CLIPPY_LINTS_TO_DENY := warnings
-
 test: lint test_py
 	cargo test
 
@@ -15,8 +12,7 @@ fmt:
 
 clippy:
 	@touch src/lib.rs  # Touching file to ensure that cargo clippy will re-check the project
-	cargo clippy --features="default num-bigint num-complex" --tests -- \
-		$(addprefix -D ,${CLIPPY_LINTS_TO_DENY})
+	cargo clippy --features="default num-bigint num-complex" --tests -- -Dwarnings
 	for example in examples/*; do (cd $$example/; cargo clippy) || exit 1; done
 
 lint: fmt clippy

--- a/build.rs
+++ b/build.rs
@@ -392,7 +392,7 @@ fn find_interpreter() -> Result<PathBuf> {
                 }
             })
             .map(PathBuf::from)
-            .ok_or("Python 3.x interpreter not found".into())
+            .ok_or_else(|| "Python 3.x interpreter not found".into())
     }
 }
 

--- a/ci/travis/test.sh
+++ b/ci/travis/test.sh
@@ -10,11 +10,6 @@ else
   cargo build;
 fi
 
-if [[ $RUN_LINT == 1 ]]; then
-    pip install --pre black==19.3b0
-    make lint
-fi
-
 for example_dir in examples/*; do
     cd $example_dir
     if [[ $FEATURES == *"pypy"* ]]; then


### PR DESCRIPTION
I think that having these checks in actions makes it easier to see when it fails, rather than having to look at the bottom of the min-stable travis job.

I made it so that tests don't bother running if fmt fails, but I can remove that "needs" if you think it's not so nice. I think it's a good habit to not waste energy running tests for a commit we won't merge! 😄 

