### PR TITLE
Load compilation options from _sysconfigdata_*.py file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PyObject` is now just a type alias for `Py<PyAny>`. [#1063](https://github.com/PyO3/pyo3/pull/1063)
 - Implement `Send + Sync` for `PyErr`. `PyErr::new`, `PyErr::from_type`, `PyException::py_err` and `PyException::into` have had these bounds added to their arguments. [#1067](https://github.com/PyO3/pyo3/pull/1067)
 - Change `#[pyproto]` to return NotImplemented for operators for which Python can try a reversed operation. [1072](https://github.com/PyO3/pyo3/pull/1072)
+- Change method for getting cross-compilation configurations using the file which provides the `sysconfig` module with its data, `_sysconfig_*.py` located in the lib directory. [1077](https://github.com/PyO3/pyo3/issues/1077)
 
 ### Removed
 - Remove `PyString::as_bytes`. [#1023](https://github.com/PyO3/pyo3/pull/1023)
@@ -42,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allows `&Self` as a `#[pymethods]` argument again. [#1071](https://github.com/PyO3/pyo3/pull/1071)
 - Fix best-effort build against PyPy 3.6. #[1092](https://github.com/PyO3/pyo3/pull/1092)
 - Improve lifetime elision in `#[pyproto]`. [#1093](https://github.com/PyO3/pyo3/pull/1093)
+- Linking against libpython when compiling for android even with `extension-module` set[#1082](https://github.com/PyO3/pyo3/issues/1082)
 
 ## [0.11.1] - 2020-06-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PyObject` is now just a type alias for `Py<PyAny>`. [#1063](https://github.com/PyO3/pyo3/pull/1063)
 - Implement `Send + Sync` for `PyErr`. `PyErr::new`, `PyErr::from_type`, `PyException::py_err` and `PyException::into` have had these bounds added to their arguments. [#1067](https://github.com/PyO3/pyo3/pull/1067)
 - Change `#[pyproto]` to return NotImplemented for operators for which Python can try a reversed operation. [1072](https://github.com/PyO3/pyo3/pull/1072)
-- Change method for getting cross-compilation configurations using the file which provides the `sysconfig` module with its data, `_sysconfig_*.py` located in the lib directory. [1077](https://github.com/PyO3/pyo3/issues/1077)
 
 ### Removed
 - Remove `PyString::as_bytes`. [#1023](https://github.com/PyO3/pyo3/pull/1023)
@@ -43,7 +42,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allows `&Self` as a `#[pymethods]` argument again. [#1071](https://github.com/PyO3/pyo3/pull/1071)
 - Fix best-effort build against PyPy 3.6. #[1092](https://github.com/PyO3/pyo3/pull/1092)
 - Improve lifetime elision in `#[pyproto]`. [#1093](https://github.com/PyO3/pyo3/pull/1093)
-- Linking against libpython when compiling for android even with `extension-module` set[#1082](https://github.com/PyO3/pyo3/issues/1082)
+- Fix python configuration detection when cross-compiling. [1077](https://github.com/PyO3/pyo3/issues/1077)
+- Link against libpython on android with `extension-module` set. [#1082](https://github.com/PyO3/pyo3/issues/1082)
 
 ## [0.11.1] - 2020-06-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Allows `&Self` as a `#[pymethods]` argument again. [#1071](https://github.com/PyO3/pyo3/pull/1071)
 - Fix best-effort build against PyPy 3.6. #[1092](https://github.com/PyO3/pyo3/pull/1092)
 - Improve lifetime elision in `#[pyproto]`. [#1093](https://github.com/PyO3/pyo3/pull/1093)
-- Fix python configuration detection when cross-compiling. [1077](https://github.com/PyO3/pyo3/issues/1077)
-- Link against libpython on android with `extension-module` set. [#1082](https://github.com/PyO3/pyo3/issues/1082)
+- Fix python configuration detection when cross-compiling. [#1095](https://github.com/PyO3/pyo3/pull/1095)
+- Link against libpython on android with `extension-module` set. [#1095](https://github.com/PyO3/pyo3/pull/1095)
 
 ## [0.11.1] - 2020-06-30
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ trybuild = "1.0.23"
 rustversion = "1.0"
 
 [build-dependencies]
-walkdir = "~2.3"
-regex = "~1.3"
+walkdir = {version = "~2.3", optional = true }
+regex = { version = "~1.3", optional = true }
 
 [features]
 default = ["macros"]
@@ -53,6 +53,9 @@ extension-module = []
 # many compilation errors. Pull Requests working towards fixing that
 # are welcome.
 # abi3 = []
+
+# Use this feature when cross-compiling the library
+cross-compile = ["walkdir", "regex"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ assert_approx_eq = "1.1.0"
 trybuild = "1.0.23"
 rustversion = "1.0"
 
+[build-dependencies]
+walkdir = "~2.3"
+regex = "~1.3"
+
 [features]
 default = ["macros"]
 macros = ["ctor", "indoc", "inventory", "paste", "pyo3cls", "unindent"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,6 @@ assert_approx_eq = "1.1.0"
 trybuild = "1.0.23"
 rustversion = "1.0"
 
-[build-dependencies]
-walkdir = {version = "~2.3", optional = true }
-regex = { version = "~1.3", optional = true }
-
 [features]
 default = ["macros"]
 macros = ["ctor", "indoc", "inventory", "paste", "pyo3cls", "unindent"]
@@ -53,9 +49,6 @@ extension-module = []
 # many compilation errors. Pull Requests working towards fixing that
 # are welcome.
 # abi3 = []
-
-# Use this feature when cross-compiling the library
-cross-compile = ["walkdir", "regex"]
 
 [workspace]
 members = [

--- a/build.rs
+++ b/build.rs
@@ -270,12 +270,10 @@ fn find_sysconfigdata(path: impl AsRef<Path>, cross: &CrossPython) -> Option<Pat
                 } else {
                     &cross.os
                 }) {
-                    println!("{:?}", f);
                     continue;
                 }
                 // Check if right arch
                 if !name.to_string_lossy().contains(&cross.arch) {
-                    println!("{:?}", f);
                     continue;
                 }
                 find_sysconfigdata(f.path(), cross)
@@ -316,7 +314,7 @@ fn load_cross_compile_from_sysconfigdata(
 
     let interpreter_config = InterpreterConfig {
         version: python_version,
-        libdir: Some(python_paths.lib_dir.to_owned()),
+        libdir: Some(python_paths.lib_dir),
         shared,
         ld_version,
         base_prefix: "".to_string(),
@@ -363,7 +361,7 @@ fn load_cross_compile_from_headers(
 
     let interpreter_config = InterpreterConfig {
         version: python_version,
-        libdir: Some(python_paths.lib_dir.to_owned()),
+        libdir: Some(python_paths.lib_dir),
         shared,
         ld_version: format!("{}.{}", major, minor),
         base_prefix: "".to_string(),
@@ -382,10 +380,10 @@ fn load_cross_compile_info(
     // Because compiling for windows on linux still includes the unix target family
     if target_family == "unix" {
         // Configure for unix platforms using the sysconfigdata file
-        return load_cross_compile_from_sysconfigdata(python_paths);
+        load_cross_compile_from_sysconfigdata(python_paths)
     } else {
         // Must configure by headers on windows platform
-        return load_cross_compile_from_headers(python_paths);
+        load_cross_compile_from_headers(python_paths)
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -175,7 +175,6 @@ fn parse_sysconfigdata(config_path: impl AsRef<Path>) -> Result<HashMap<String, 
 }
 
 fn load_cross_compile_from_sysconfigdata(
-    python_include_dir: &Path,
     python_lib_dir: &str,
 ) -> Result<(InterpreterConfig, HashMap<String, String>)> {
     // find info from sysconfig
@@ -207,7 +206,7 @@ fn load_cross_compile_from_sysconfigdata(
 
     let (major, minor) = match config_map.get("VERSION") {
         Some(s) => {
-            let split = s.split(".").collect::<Vec<&str>>();
+            let split = s.split('.').collect::<Vec<&str>>();
             (split[0].parse::<u8>()?, split[1].parse::<u8>()?)
         }
         None => bail!("Could not find python version"),
@@ -237,9 +236,10 @@ fn load_cross_compile_from_sysconfigdata(
 }
 
 fn load_cross_compile_from_headers(
-    python_include_dir: &Path,
+    python_include_dir: &str,
     python_lib_dir: &str,
 ) -> Result<(InterpreterConfig, HashMap<String, String>)> {
+    let python_include_dir = Path::new(&python_include_dir);
     let patchlevel_defines = parse_header_defines(python_include_dir.join("patchlevel.h"))?;
 
     let major = match patchlevel_defines
@@ -294,13 +294,12 @@ fn load_cross_compile_info(
     python_include_dir: String,
     python_lib_dir: String,
 ) -> Result<(InterpreterConfig, HashMap<String, String>)> {
-    let python_include_dir = Path::new(&python_include_dir);
     // Try to configure from the sysconfigdata file which is more accurate for the information
     // provided at python's compile time
-    match load_cross_compile_from_sysconfigdata(python_include_dir, &python_lib_dir) {
+    match load_cross_compile_from_sysconfigdata(&python_lib_dir) {
         Ok(ret) => Ok(ret),
         // If the config could not be loaded by sysconfigdata, failover to configuring from headers
-        Err(_) => load_cross_compile_from_headers(python_include_dir, &python_lib_dir),
+        Err(_) => load_cross_compile_from_headers(&python_include_dir, &python_lib_dir),
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -297,7 +297,7 @@ fn ends_with(entry: &DirEntry, pat: &str) -> bool {
 /// [1]: https://github.com/python/cpython/blob/3.5/Lib/sysconfig.py#L389
 fn find_sysconfigdata(cross: &CrossCompileConfig) -> Result<PathBuf> {
     let mut sysconfig_paths = search_lib_dir(&cross.lib_dir, &cross);
-    if sysconfig_paths.len() == 0 {
+    if sysconfig_paths.is_empty() {
         bail!(
             "Could not find either libpython.so or _sysconfigdata*.py in {}",
             cross.lib_dir.display()

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -51,8 +51,9 @@ See https://github.com/japaric/rust-cross for a primer on cross compiling Rust i
 
 After you've obtained the above, you can build a cross compiled PyO3 module by setting a few extra environment variables:
 
-* `PYO3_CROSS_INCLUDE_DIR`: This variable must be set to the directory containing the headers for the target's Python interpreter.
+* `PYO3_CROSS_INCLUDE_DIR`: This variable must be set to the directory containing the headers for the target's Python interpreter. It is only necessary if compiling for Windows platforms
 * `PYO3_CROSS_LIB_DIR`: This variable must be set to the directory containing the target's libpython DSO.
+* If compiling for unix platforms, the `cross-compile` feature must be set.
 
 An example might look like the following (assuming your target's sysroot is at `/home/pyo3/cross/sysroot` and that your target is `armv7`):
 

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -54,7 +54,7 @@ After you've obtained the above, you can build a cross compiled PyO3 module by s
 
 * `PYO3_CROSS_INCLUDE_DIR`: This variable must be set to the directory containing the headers for the target's Python interpreter. **It is only necessary if targeting Windows platforms**
 * `PYO3_CROSS_LIB_DIR`: This variable must be set to the directory containing the target's libpython DSO and the associated `_sysconfigdata*.py` file.
-* `PYO3_PYTHON_VERSION`: This variable must be set if there are multiple versions of python compiled for a unix machine.
+* `PYO3_CROSS_PYTHON_VERSION`: This variable must be set if there are multiple versions of python compiled for a unix machine.
 
 An example might look like the following (assuming your target's sysroot is at `/home/pyo3/cross/sysroot` and that your target is `armv7`):
 
@@ -66,7 +66,7 @@ cargo build --target armv7-unknown-linux-gnueabihf
 
 If there are multiple python versions at the cross lib directory and you cannot set a more precise location to include both the `libpython` DSO and `_sysconfigdata*.py` files, you can set the required version:
 ```sh
-export PYO3_PYTHON_VERSION=3.8
+export PYO3_CROSS_PYTHON_VERSION=3.8
 export PYO3_CROSS_LIB_DIR="/home/pyo3/cross/sysroot/usr/lib"
 
 cargo build --target armv7-unknown-linux-gnueabihf

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -45,21 +45,28 @@ Cross compiling PyO3 modules is relatively straightforward and requires a few pi
 * A toolchain for your target.
 * The appropriate options in your Cargo `.config` for the platform you're targeting and the toolchain you are using.
 * A Python interpreter that's already been compiled for your target.
+* A Python interpreter that is built for your host and available through the `PATH`.
 * The headers that match the above interpreter.
 
 See https://github.com/japaric/rust-cross for a primer on cross compiling Rust in general.
 
 After you've obtained the above, you can build a cross compiled PyO3 module by setting a few extra environment variables:
 
-* `PYO3_CROSS_INCLUDE_DIR`: This variable must be set to the directory containing the headers for the target's Python interpreter. It is only necessary if compiling for Windows platforms
+* `PYO3_CROSS_INCLUDE_DIR`: This variable must be set to the directory containing the headers for the target's Python interpreter. **It is only necessary if targeting Windows platforms**
 * `PYO3_CROSS_LIB_DIR`: This variable must be set to the directory containing the target's libpython DSO.
-* If compiling for unix platforms, the `cross-compile` feature must be set.
 
 An example might look like the following (assuming your target's sysroot is at `/home/pyo3/cross/sysroot` and that your target is `armv7`):
 
 ```sh
-export PYO3_CROSS_INCLUDE_DIR="/home/pyo3/cross/sysroot/usr/include"
 export PYO3_CROSS_LIB_DIR="/home/pyo3/cross/sysroot/usr/lib"
 
 cargo build --target armv7-unknown-linux-gnueabihf
+```
+
+Or another example with the same sys root but building for windows:
+```sh
+export PYO3_CROSS_INCLUDE_DIR="/home/pyo3/cross/sysroot/usr/include"
+export PYO3_CROSS_LIB_DIR="/home/pyo3/cross/sysroot/usr/lib"
+
+cargo build --target x86_64-pc-windows-gnu
 ```

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -45,7 +45,7 @@ Cross compiling PyO3 modules is relatively straightforward and requires a few pi
 * A toolchain for your target.
 * The appropriate options in your Cargo `.config` for the platform you're targeting and the toolchain you are using.
 * A Python interpreter that's already been compiled for your target.
-* A Python interpreter that is built for your host and available through the `PATH`.
+* A Python interpreter that is built for your host and available through the `PATH` or setting the [`PYO3_PYTHON`](#python-version) variable.
 * The headers that match the above interpreter.
 
 See https://github.com/japaric/rust-cross for a primer on cross compiling Rust in general.

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -53,11 +53,20 @@ See https://github.com/japaric/rust-cross for a primer on cross compiling Rust i
 After you've obtained the above, you can build a cross compiled PyO3 module by setting a few extra environment variables:
 
 * `PYO3_CROSS_INCLUDE_DIR`: This variable must be set to the directory containing the headers for the target's Python interpreter. **It is only necessary if targeting Windows platforms**
-* `PYO3_CROSS_LIB_DIR`: This variable must be set to the directory containing the target's libpython DSO.
+* `PYO3_CROSS_LIB_DIR`: This variable must be set to the directory containing the target's libpython DSO and the associated `_sysconfigdata*.py` file.
+* `PYO3_PYTHON_VERSION`: This variable must be set if there are multiple versions of python compiled for a unix machine.
 
 An example might look like the following (assuming your target's sysroot is at `/home/pyo3/cross/sysroot` and that your target is `armv7`):
 
 ```sh
+export PYO3_CROSS_LIB_DIR="/home/pyo3/cross/sysroot/usr/lib"
+
+cargo build --target armv7-unknown-linux-gnueabihf
+```
+
+If there are multiple python versions at the cross lib directory and you cannot set a more precise location to include both the `libpython` DSO and `_sysconfigdata*.py` files, you can set the required version:
+```sh
+export PYO3_PYTHON_VERSION=3.8
 export PYO3_CROSS_LIB_DIR="/home/pyo3/cross/sysroot/usr/lib"
 
 cargo build --target armv7-unknown-linux-gnueabihf


### PR DESCRIPTION
Following the discussion in #1077 this change allows the compilation
script to load the configurations from a `_sysconfigdata_*.py` file
in the library directory.

This file is also provided on target systems in the same directory.
At least on Manjaro Linux.
Which could remove the need to run a python script at compile time
for compiling the the host.

I've also addressed the linking need for android in #1082.

The paths provided are now checked if they exist.

## Future improvements
The build script subsequently grew quite a bit.
I will probably contribute to https://github.com/davidhewitt/python-config in order to refactor most of the python configuration logic there. It should also improve the debugability of the build script.

~~Another issue I encountered was when I miss-spelled the path to one of the cross-compilation paths, checking if the paths supplied are valid before even trying to get the configs would be a good simple improvement. This would also help consumers of the library when they inevitably make mistakes.~~
