### PR TITLE
Prefer docs.rs doc links

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -266,7 +266,7 @@ impl SubSubClass {
 ```
 
 You can also inherit native types such as `PyDict`, if they implement
-[`PySizedLayout`](https://pyo3.rs/master/doc/pyo3/type_object/trait.PySizedLayout.html).
+[`PySizedLayout`](https://docs.rs/pyo3/latest/pyo3/type_object/trait.PySizedLayout.html).
 
 However, because of some technical problems, we don't currently provide safe upcasting methods for types
 that inherit native types. Even in such cases, you can unsafely get a base class by raw pointer conversion.
@@ -1094,11 +1094,11 @@ impl pyo3::pyclass::PyClassSend for MyClass {
 [`PyTypeInfo`]: https://docs.rs/pyo3/latest/pyo3/type_object/trait.PyTypeInfo.html
 [`PyTypeObject`]: https://docs.rs/pyo3/latest/pyo3/type_object/trait.PyTypeObject.html
 
-[`PyCell`]: https://pyo3.rs/master/doc/pyo3/pycell/struct.PyCell.html
-[`PyClass`]: https://pyo3.rs/master/doc/pyo3/pyclass/trait.PyClass.html
-[`PyRef`]: https://pyo3.rs/master/doc/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: https://pyo3.rs/master/doc/pyo3/pycell/struct.PyRefMut.html
-[`PyClassInitializer<T>`]: https://pyo3.rs/master/doc/pyo3/pyclass_init/struct.PyClassInitializer.html
+[`PyCell`]: https://docs.rs/pyo3/latest/pyo3/pycell/struct.PyCell.html
+[`PyClass`]: https://docs.rs/pyo3/latest/pyo3/pyclass/trait.PyClass.html
+[`PyRef`]: https://docs.rs/pyo3/latest/pyo3/pycell/struct.PyRef.html
+[`PyRefMut`]: https://docs.rs/pyo3/latest/pyo3/pycell/struct.PyRefMut.html
+[`PyClassInitializer<T>`]: https://docs.rs/pyo3/latest/pyo3/pyclass_init/struct.PyClassInitializer.html
 
 [`RefCell`]: https://doc.rust-lang.org/std/cell/struct.RefCell.html
 

--- a/guide/src/conversions.md
+++ b/guide/src/conversions.md
@@ -236,7 +236,7 @@ Eventually, traits such as [`ToPyObject`] will be replaced by this trait and a [
 [`PyAny`]: https://docs.rs/pyo3/latest/pyo3/struct.PyAny.html
 [`IntoPyDict`]: https://docs.rs/pyo3/latest/pyo3/types/trait.IntoPyDict.html
 
-[`PyRef`]: https://pyo3.rs/master/doc/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: https://pyo3.rs/master/doc/pyo3/pycell/struct.PyRefMut.html
+[`PyRef`]: https://docs.rs/pyo3/latest/pyo3/pycell/struct.PyRef.html
+[`PyRefMut`]: https://docs.rs/pyo3/latest/pyo3/pycell/struct.PyRefMut.html
 
 [^1]: Requires the `num-complex` optional feature.

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -46,7 +46,7 @@ There can be two fixes:
    ```
 
    In situations where you cannot change your `#[pyclass]` to automatically implement `Send`
-   (e.g., when it contains a raw pointer), you can use `unsafe impl Send`. 
+   (e.g., when it contains a raw pointer), you can use `unsafe impl Send`.
    In such cases, care should be taken to ensure the struct is actually thread safe.
    See [the Rustnomicon](https://doc.rust-lang.org/nomicon/send-and-sync.html) for more.
 
@@ -216,7 +216,7 @@ However, for `#[pyproto]` and some functions, you need to manually fix the code.
 In 0.8 object creation was done with `PyRef::new` and `PyRefMut::new`.
 In 0.9 these have both been removed.
 To upgrade code, please use
-[`PyCell::new`](https://pyo3.rs/master/doc/pyo3/pycell/struct.PyCell.html#method.new) instead.
+[`PyCell::new`](https://docs.rs/pyo3/latest/pyo3/pycell/struct.PyCell.html#method.new) instead.
 If you need [`PyRef`] or [`PyRefMut`], just call `.borrow()` or `.borrow_mut()`
 on the newly-created `PyCell`.
 

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -5,7 +5,7 @@ PyO3 is built for an extension module or not.
 
 ## Want to access Python APIs? Then use `PyModule::import`.
 
-[`Pymodule::import`](https://pyo3.rs/master/doc/pyo3/types/struct.PyModule.html#method.import) can
+[`Pymodule::import`](https://docs.rs/pyo3/latest/pyo3/types/struct.PyModule.html#method.import) can
 be used to get handle to a Python module from Rust. You can use this to import and use any Python
 module available in your environment.
 
@@ -24,7 +24,7 @@ fn main() -> PyResult<()> {
 
 ## Want to run just an expression? Then use `eval`.
 
-[`Python::eval`](https://pyo3.rs/master/doc/pyo3/struct.Python.html#method.eval) is
+[`Python::eval`](https://docs.rs/pyo3/latest/pyo3/struct.Python.html#method.eval) is
 a method to execute a [Python expression](https://docs.python.org/3.7/reference/expressions.html)
 and return the evaluated value as a `&PyAny` object.
 
@@ -94,7 +94,7 @@ assert userdata.as_tuple() == userdata_as_tuple
 
 ## You have a Python file or Python function? Then use `PyModule::from_code`.
 
-[PyModule::from_code](https://pyo3.rs/master/doc/pyo3/types/struct.PyModule.html#method.from_code)
+[PyModule::from_code](https://docs.rs/pyo3/latest/pyo3/types/struct.PyModule.html#method.from_code)
 can be used to generate a Python module which can then be used just as if it was imported with
 `PyModule::import`.
 
@@ -124,5 +124,5 @@ def leaky_relu(x, slope=0.01):
 # }
 ```
 
-[`Python::run`]: https://pyo3.rs/master/doc/pyo3/struct.Python.html#method.run
-[`py_run!`]: https://pyo3.rs/master/doc/pyo3/macro.py_run.html
+[`Python::run`]: https://docs.rs/pyo3/latest/pyo3/struct.Python.html#method.run
+[`py_run!`]: https://docs.rs/pyo3/latest/pyo3/macro.py_run.html

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -249,7 +249,7 @@ This trait marks structs that mirror native Python types, such as `PyList`.
 
 [eval]: https://docs.rs/pyo3/latest/pyo3/struct.Python.html#method.eval
 [clone_ref]: https://docs.rs/pyo3/latest/pyo3/struct.PyObject.html#method.clone_ref
-[pyo3::types]: https://pyo3.rs/master/doc/pyo3/types/index.html
+[pyo3::types]: https://docs.rs/pyo3/latest/pyo3/types/index.html
 [PyAny]: https://docs.rs/pyo3/latest/pyo3/types/struct.PyAny.html
 [PyList_append]: https://docs.rs/pyo3/latest/pyo3/types/struct.PyList.html#method.append
 [RefCell]: https://doc.rust-lang.org/std/cell/struct.RefCell.html


### PR DESCRIPTION
I noticed sometimes we use `docs.rs/pyo3/latest` and sometimes we use `pyo3.rs/doc/master`.

I don't really mind which we use, but I think we should only use one. So I picked `docs.rs`. I can change this PR to be the other way round if you prefer `pyo3.rs.`