### PR TITLE
Fix layout of gh-pages guide build

### DIFF
--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -17,15 +17,16 @@ jobs:
         with:
           mdbook-version: '0.4.1'
 
-      # This builds the book in target/guide. See https://github.com/rust-lang-nursery/mdBook/issues/698
+      # This builds the book in gh-pages-build. See https://github.com/rust-lang-nursery/mdBook/issues/698
       - name: Build the guide
-        run: mdbook build -d ../target/guide guide
+        run: mdbook build -d ../gh-pages-build guide
 
-        # This builds the doc in target/doc
+        # This adds the docs to gh-pages-build/doc
       - name: Build the doc
         run: |
           cargo doc --features="default num-bigint num-complex" --no-deps
-          echo "<meta http-equiv=refresh content=0;url=pyo3/index.html>" > target/doc/index.html
+          cp -r target/doc gh-pages-build/doc
+          echo "<meta http-equiv=refresh content=0;url=pyo3/index.html>" > gh-pages-build/doc/index.html
 
       - name: Prepare tag
         id: prepare_tag
@@ -37,6 +38,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3.7.0-8
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/
+          publish_dir: ./gh-pages-build/
           destination_dir: ${{ steps.prepare_tag.outputs.tag_name }}
           full_commit_message: 'Upload documentation for ${{ steps.prepare_tag.outputs.tag_name }}'


### PR DESCRIPTION
I got the layout slightly wrong in the last build. 🤦 

Contents on gh-pages atm:

```
master/guide/
master/doc/
```

What it should be:

```
master/                   # contains the guide
master/doc/
```
