### PR TITLE
Left-hand operands are fellback to right-hand ones for type mismatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Improve lifetime elision in `#[pyproto]`. [#1093](https://github.com/PyO3/pyo3/pull/1093)
 - Fix python configuration detection when cross-compiling. [#1095](https://github.com/PyO3/pyo3/pull/1095)
 - Link against libpython on android with `extension-module` set. [#1095](https://github.com/PyO3/pyo3/pull/1095)
+- Fix support for both `__add__` and `__radd__`  in the `+` operator when both are defined in `PyNumberProtocol`
+  (and similar for all other reversible operators). [#1107](https://github.com/PyO3/pyo3/pull/1107)
 
 ## [0.11.1] - 2020-06-30
 ### Added

--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -65,18 +65,13 @@ pub struct SlotSetter {
     pub proto_names: &'static [&'static str],
     /// The name of the setter called to the method table.
     pub set_function: &'static str,
-    /// Represents a set of setters disabled by this setter.
-    /// E.g., `set_setdelitem` have to disable `set_setitem` and `set_delitem`.
-    pub skipped_setters: &'static [&'static str],
 }
 
 impl SlotSetter {
-    const EMPTY_SETTERS: &'static [&'static str] = &[];
     const fn new(names: &'static [&'static str], set_function: &'static str) -> Self {
         SlotSetter {
             proto_names: names,
             set_function,
-            skipped_setters: Self::EMPTY_SETTERS,
         }
     }
 }
@@ -144,11 +139,7 @@ pub const OBJECT: Proto = Proto {
         SlotSetter::new(&["__hash__"], "set_hash"),
         SlotSetter::new(&["__getattr__"], "set_getattr"),
         SlotSetter::new(&["__richcmp__"], "set_richcompare"),
-        SlotSetter {
-            proto_names: &["__setattr__", "__delattr__"],
-            set_function: "set_setdelattr",
-            skipped_setters: &["set_setattr", "set_delattr"],
-        },
+        SlotSetter::new(&["__setattr__", "__delattr__"], "set_setdelattr"),
         SlotSetter::new(&["__setattr__"], "set_setattr"),
         SlotSetter::new(&["__delattr__"], "set_delattr"),
         SlotSetter::new(&["__bool__"], "set_bool"),
@@ -379,11 +370,7 @@ pub const MAPPING: Proto = Proto {
     slot_setters: &[
         SlotSetter::new(&["__len__"], "set_length"),
         SlotSetter::new(&["__getitem__"], "set_getitem"),
-        SlotSetter {
-            proto_names: &["__setitem__", "__delitem__"],
-            set_function: "set_setdelitem",
-            skipped_setters: &["set_setitem", "set_delitem"],
-        },
+        SlotSetter::new(&["__setitem__", "__delitem__"], "set_setdelitem"),
         SlotSetter::new(&["__setitem__"], "set_setitem"),
         SlotSetter::new(&["__delitem__"], "set_delitem"),
     ],
@@ -446,11 +433,7 @@ pub const SEQ: Proto = Proto {
         SlotSetter::new(&["__concat__"], "set_concat"),
         SlotSetter::new(&["__repeat__"], "set_repeat"),
         SlotSetter::new(&["__getitem__"], "set_getitem"),
-        SlotSetter {
-            proto_names: &["__setitem__", "__delitem__"],
-            set_function: "set_setdelitem",
-            skipped_setters: &["set_setitem", "set_delitem"],
-        },
+        SlotSetter::new(&["__setitem__", "__delitem__"], "set_setdelitem"),
         SlotSetter::new(&["__setitem__"], "set_setitem"),
         SlotSetter::new(&["__delitem__"], "set_delitem"),
         SlotSetter::new(&["__contains__"], "set_contains"),
@@ -766,71 +749,40 @@ pub const NUM: Proto = Proto {
         ),
     ],
     slot_setters: &[
-        SlotSetter {
-            proto_names: &["__add__"],
-            set_function: "set_add",
-            skipped_setters: &["set_radd"],
-        },
+        SlotSetter::new(&["__add__", "__radd__"], "set_add_radd"),
+        SlotSetter::new(&["__add__"], "set_add"),
         SlotSetter::new(&["__radd__"], "set_radd"),
-        SlotSetter {
-            proto_names: &["__sub__"],
-            set_function: "set_sub",
-            skipped_setters: &["set_rsub"],
-        },
+        SlotSetter::new(&["__sub__", "__rsub__"], "set_sub_rsub"),
+        SlotSetter::new(&["__sub__"], "set_sub"),
         SlotSetter::new(&["__rsub__"], "set_rsub"),
-        SlotSetter {
-            proto_names: &["__mul__"],
-            set_function: "set_mul",
-            skipped_setters: &["set_rmul"],
-        },
+        SlotSetter::new(&["__mul__", "__rmul__"], "set_mul_rmul"),
+        SlotSetter::new(&["__mul__"], "set_mul"),
         SlotSetter::new(&["__rmul__"], "set_rmul"),
         SlotSetter::new(&["__mod__"], "set_mod"),
-        SlotSetter {
-            proto_names: &["__divmod__"],
-            set_function: "set_divmod",
-            skipped_setters: &["set_rdivmod"],
-        },
+        SlotSetter::new(&["__divmod__", "__rdivmod__"], "set_divmod_rdivmod"),
+        SlotSetter::new(&["__divmod__"], "set_divmod"),
         SlotSetter::new(&["__rdivmod__"], "set_rdivmod"),
-        SlotSetter {
-            proto_names: &["__pow__"],
-            set_function: "set_pow",
-            skipped_setters: &["set_rpow"],
-        },
+        SlotSetter::new(&["__pow__", "__rpow__"], "set_pow_rpow"),
+        SlotSetter::new(&["__pow__"], "set_pow"),
         SlotSetter::new(&["__rpow__"], "set_rpow"),
         SlotSetter::new(&["__neg__"], "set_neg"),
         SlotSetter::new(&["__pos__"], "set_pos"),
         SlotSetter::new(&["__abs__"], "set_abs"),
         SlotSetter::new(&["__invert__"], "set_invert"),
-        SlotSetter::new(&["__rdivmod__"], "set_rdivmod"),
-        SlotSetter {
-            proto_names: &["__lshift__"],
-            set_function: "set_lshift",
-            skipped_setters: &["set_rlshift"],
-        },
+        SlotSetter::new(&["__lshift__", "__rlshift__"], "set_lshift_rlshift"),
+        SlotSetter::new(&["__lshift__"], "set_lshift"),
         SlotSetter::new(&["__rlshift__"], "set_rlshift"),
-        SlotSetter {
-            proto_names: &["__rshift__"],
-            set_function: "set_rshift",
-            skipped_setters: &["set_rrshift"],
-        },
+        SlotSetter::new(&["__rshift__", "__rrshift__"], "set_rshift_rrshift"),
+        SlotSetter::new(&["__rshift__"], "set_rshift"),
         SlotSetter::new(&["__rrshift__"], "set_rrshift"),
-        SlotSetter {
-            proto_names: &["__and__"],
-            set_function: "set_and",
-            skipped_setters: &["set_rand"],
-        },
+        SlotSetter::new(&["__and__", "__rand__"], "set_and_rand"),
+        SlotSetter::new(&["__and__"], "set_and"),
         SlotSetter::new(&["__rand__"], "set_rand"),
-        SlotSetter {
-            proto_names: &["__xor__"],
-            set_function: "set_xor",
-            skipped_setters: &["set_rxor"],
-        },
+        SlotSetter::new(&["__xor__", "__rxor__"], "set_xor_rxor"),
+        SlotSetter::new(&["__xor__"], "set_xor"),
         SlotSetter::new(&["__rxor__"], "set_rxor"),
-        SlotSetter {
-            proto_names: &["__or__"],
-            set_function: "set_or",
-            skipped_setters: &["set_ror"],
-        },
+        SlotSetter::new(&["__or__", "__ror__"], "set_or_ror"),
+        SlotSetter::new(&["__or__"], "set_or"),
         SlotSetter::new(&["__ror__"], "set_ror"),
         SlotSetter::new(&["__int__"], "set_int"),
         SlotSetter::new(&["__float__"], "set_float"),
@@ -844,26 +796,17 @@ pub const NUM: Proto = Proto {
         SlotSetter::new(&["__iand__"], "set_iand"),
         SlotSetter::new(&["__ixor__"], "set_ixor"),
         SlotSetter::new(&["__ior__"], "set_ior"),
-        SlotSetter {
-            proto_names: &["__floordiv__"],
-            set_function: "set_floordiv",
-            skipped_setters: &["set_rfloordiv"],
-        },
+        SlotSetter::new(&["__floordiv__", "__rfloordiv__"], "set_floordiv_rfloordiv"),
+        SlotSetter::new(&["__floordiv__"], "set_floordiv"),
         SlotSetter::new(&["__rfloordiv__"], "set_rfloordiv"),
-        SlotSetter {
-            proto_names: &["__truediv__"],
-            set_function: "set_truediv",
-            skipped_setters: &["set_rtruediv"],
-        },
+        SlotSetter::new(&["__truediv__", "__rtruediv__"], "set_truediv_rtruediv"),
+        SlotSetter::new(&["__truediv__"], "set_truediv"),
         SlotSetter::new(&["__rtruediv__"], "set_rtruediv"),
         SlotSetter::new(&["__ifloordiv__"], "set_ifloordiv"),
         SlotSetter::new(&["__itruediv__"], "set_itruediv"),
         SlotSetter::new(&["__index__"], "set_index"),
-        SlotSetter {
-            proto_names: &["__matmul__"],
-            set_function: "set_matmul",
-            skipped_setters: &["set_rmatmul"],
-        },
+        SlotSetter::new(&["__matmul__", "__rmatmul__"], "set_matmul_rmatmul"),
+        SlotSetter::new(&["__matmul__"], "set_matmul"),
         SlotSetter::new(&["__rmatmul__"], "set_rmatmul"),
         SlotSetter::new(&["__imatmul__"], "set_imatmul"),
     ],

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -109,7 +109,7 @@ macro_rules! py_binary_reversed_num_func {
     }};
 }
 
-macro_rules! py_binary_fallbacked_num_func {
+macro_rules! py_binary_fallback_num_func {
     ($class:ident, $lop_trait: ident :: $lop: ident, $rop_trait: ident :: $rop: ident) => {{
         unsafe extern "C" fn wrap<T>(
             lhs: *mut ffi::PyObject,

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -125,7 +125,7 @@ macro_rules! py_binary_fallback_num_func {
                 match (lhs.extract(), rhs.extract()) {
                     (Ok(l), Ok(r)) => $class::$lop(l, r).convert(py),
                     _ => {
-                        // Next, try the right hand method (e.g., __add__)
+                        // Next, try the right hand method (e.g., __radd__)
                         let slf: &$crate::PyCell<T> = extract_or_return_not_implemented!(rhs);
                         let arg = extract_or_return_not_implemented!(lhs);
                         $class::$rop(&*slf.try_borrow()?, arg).convert(py)

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -1,7 +1,5 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_unary_func {
     ($trait: ident, $class:ident :: $f:ident, $call:ident, $ret_type: ty) => {{
         unsafe extern "C" fn wrap<T>(slf: *mut $crate::ffi::PyObject) -> $ret_type
@@ -24,8 +22,6 @@ macro_rules! py_unary_func {
     };
 }
 
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_unarys_func {
     ($trait:ident, $class:ident :: $f:ident) => {{
         unsafe extern "C" fn wrap<T>(slf: *mut $crate::ffi::PyObject) -> *mut $crate::ffi::PyObject
@@ -45,16 +41,12 @@ macro_rules! py_unarys_func {
     }};
 }
 
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_len_func {
     ($trait:ident, $class:ident :: $f:ident) => {
         py_unary_func!($trait, $class::$f, $crate::ffi::Py_ssize_t)
     };
 }
 
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_binary_func {
     // Use call_ref! by default
     ($trait:ident, $class:ident :: $f:ident, $return:ty, $call:ident) => {{
@@ -78,8 +70,6 @@ macro_rules! py_binary_func {
     };
 }
 
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_binary_num_func {
     ($trait:ident, $class:ident :: $f:ident) => {{
         unsafe extern "C" fn wrap<T>(
@@ -99,8 +89,6 @@ macro_rules! py_binary_num_func {
     }};
 }
 
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_binary_reversed_num_func {
     ($trait:ident, $class:ident :: $f:ident) => {{
         unsafe extern "C" fn wrap<T>(
@@ -121,8 +109,6 @@ macro_rules! py_binary_reversed_num_func {
     }};
 }
 
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_binary_fallbacked_num_func {
     ($class:ident, $lop_trait: ident :: $lop: ident, $rop_trait: ident :: $rop: ident) => {{
         unsafe extern "C" fn wrap<T>(
@@ -152,8 +138,6 @@ macro_rules! py_binary_fallbacked_num_func {
 }
 
 // NOTE(kngwyu): This macro is used only for inplace operations, so I used call_mut here.
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_binary_self_func {
     ($trait:ident, $class:ident :: $f:ident) => {{
         unsafe extern "C" fn wrap<T>(
@@ -175,8 +159,6 @@ macro_rules! py_binary_self_func {
     }};
 }
 
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_ssizearg_func {
     // Use call_ref! by default
     ($trait:ident, $class:ident :: $f:ident) => {
@@ -199,8 +181,6 @@ macro_rules! py_ssizearg_func {
     }};
 }
 
-#[macro_export]
-#[doc(hidden)]
 macro_rules! py_ternarys_func {
     ($trait:ident, $class:ident :: $f:ident, $return_type:ty) => {{
         unsafe extern "C" fn wrap<T>(
@@ -232,32 +212,6 @@ macro_rules! py_ternarys_func {
     ($trait:ident, $class:ident :: $f:ident) => {
         py_ternarys_func!($trait, $class::$f, *mut $crate::ffi::PyObject);
     };
-}
-
-// NOTE(kngwyu): Somehow __ipow__ causes SIGSEGV in Python < 3.8 when we extract arg2,
-// so we ignore it. It's the same as what CPython does.
-#[macro_export]
-#[doc(hidden)]
-macro_rules! py_dummy_ternary_self_func {
-    ($trait:ident, $class:ident :: $f:ident) => {{
-        unsafe extern "C" fn wrap<T>(
-            slf: *mut $crate::ffi::PyObject,
-            arg1: *mut $crate::ffi::PyObject,
-            _arg2: *mut $crate::ffi::PyObject,
-        ) -> *mut $crate::ffi::PyObject
-        where
-            T: for<'p> $trait<'p>,
-        {
-            $crate::callback_body!(py, {
-                let slf_cell = py.from_borrowed_ptr::<$crate::PyCell<T>>(slf);
-                let arg1 = py.from_borrowed_ptr::<$crate::PyAny>(arg1);
-                call_operator_mut!(py, slf_cell, $f, arg1).convert(py)?;
-                ffi::Py_INCREF(slf);
-                Ok(slf)
-            })
-        }
-        Some(wrap::<$class>)
-    }};
 }
 
 macro_rules! py_func_set {

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -585,6 +585,16 @@ impl ffi::PyNumberMethods {
         nm.nb_bool = Some(nb_bool);
         Box::into_raw(Box::new(nm))
     }
+    pub fn set_add_radd<T>(&mut self)
+    where
+        T: for<'p> PyNumberAddProtocol<'p> + for<'p> PyNumberRAddProtocol<'p>,
+    {
+        self.nb_add = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberAddProtocol::__add__,
+            PyNumberRAddProtocol::__radd__
+        );
+    }
     pub fn set_add<T>(&mut self)
     where
         T: for<'p> PyNumberAddProtocol<'p>,
@@ -597,6 +607,16 @@ impl ffi::PyNumberMethods {
     {
         self.nb_add = py_binary_reversed_num_func!(PyNumberRAddProtocol, T::__radd__);
     }
+    pub fn set_sub_rsub<T>(&mut self)
+    where
+        T: for<'p> PyNumberSubProtocol<'p> + for<'p> PyNumberRSubProtocol<'p>,
+    {
+        self.nb_subtract = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberSubProtocol::__sub__,
+            PyNumberRSubProtocol::__rsub__
+        );
+    }
     pub fn set_sub<T>(&mut self)
     where
         T: for<'p> PyNumberSubProtocol<'p>,
@@ -608,6 +628,16 @@ impl ffi::PyNumberMethods {
         T: for<'p> PyNumberRSubProtocol<'p>,
     {
         self.nb_subtract = py_binary_reversed_num_func!(PyNumberRSubProtocol, T::__rsub__);
+    }
+    pub fn set_mul_rmul<T>(&mut self)
+    where
+        T: for<'p> PyNumberMulProtocol<'p> + for<'p> PyNumberRMulProtocol<'p>,
+    {
+        self.nb_multiply = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberMulProtocol::__mul__,
+            PyNumberRMulProtocol::__rmul__
+        );
     }
     pub fn set_mul<T>(&mut self)
     where
@@ -627,6 +657,16 @@ impl ffi::PyNumberMethods {
     {
         self.nb_remainder = py_binary_num_func!(PyNumberModProtocol, T::__mod__);
     }
+    pub fn set_divmod_rdivmod<T>(&mut self)
+    where
+        T: for<'p> PyNumberDivmodProtocol<'p> + for<'p> PyNumberRDivmodProtocol<'p>,
+    {
+        self.nb_divmod = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberDivmodProtocol::__divmod__,
+            PyNumberRDivmodProtocol::__rdivmod__
+        );
+    }
     pub fn set_divmod<T>(&mut self)
     where
         T: for<'p> PyNumberDivmodProtocol<'p>,
@@ -639,17 +679,78 @@ impl ffi::PyNumberMethods {
     {
         self.nb_divmod = py_binary_reversed_num_func!(PyNumberRDivmodProtocol, T::__rdivmod__);
     }
+    pub fn set_pow_rpow<T>(&mut self)
+    where
+        T: for<'p> PyNumberPowProtocol<'p> + for<'p> PyNumberRPowProtocol<'p>,
+    {
+        unsafe extern "C" fn wrap_pow_and_rpow<T>(
+            lhs: *mut crate::ffi::PyObject,
+            rhs: *mut crate::ffi::PyObject,
+            modulo: *mut crate::ffi::PyObject,
+        ) -> *mut crate::ffi::PyObject
+        where
+            T: for<'p> PyNumberPowProtocol<'p> + for<'p> PyNumberRPowProtocol<'p>,
+        {
+            crate::callback_body!(py, {
+                let lhs = py.from_borrowed_ptr::<crate::PyAny>(lhs);
+                let rhs = py.from_borrowed_ptr::<crate::PyAny>(rhs);
+                let modulo = py.from_borrowed_ptr::<crate::PyAny>(modulo);
+                // First, try __pow__
+                match (lhs.extract(), rhs.extract(), modulo.extract()) {
+                    (Ok(l), Ok(r), Ok(m)) => T::__pow__(l, r, m).convert(py),
+                    _ => {
+                        // Then try __rpow__
+                        let slf: &crate::PyCell<T> = extract_or_return_not_implemented!(rhs);
+                        let arg = extract_or_return_not_implemented!(lhs);
+                        let modulo = extract_or_return_not_implemented!(modulo);
+                        slf.try_borrow()?.__rpow__(arg, modulo).convert(py)
+                    }
+                }
+            })
+        }
+        self.nb_power = Some(wrap_pow_and_rpow::<T>);
+    }
     pub fn set_pow<T>(&mut self)
     where
         T: for<'p> PyNumberPowProtocol<'p>,
     {
-        self.nb_power = py_ternary_num_func!(PyNumberPowProtocol, T::__pow__);
+        unsafe extern "C" fn wrap_pow<T>(
+            lhs: *mut crate::ffi::PyObject,
+            rhs: *mut crate::ffi::PyObject,
+            modulo: *mut crate::ffi::PyObject,
+        ) -> *mut crate::ffi::PyObject
+        where
+            T: for<'p> PyNumberPowProtocol<'p>,
+        {
+            crate::callback_body!(py, {
+                let lhs = extract_or_return_not_implemented!(py, lhs);
+                let rhs = extract_or_return_not_implemented!(py, rhs);
+                let modulo = extract_or_return_not_implemented!(py, modulo);
+                T::__pow__(lhs, rhs, modulo).convert(py)
+            })
+        }
+        self.nb_power = Some(wrap_pow::<T>);
     }
     pub fn set_rpow<T>(&mut self)
     where
         T: for<'p> PyNumberRPowProtocol<'p>,
     {
-        self.nb_power = py_ternary_reversed_num_func!(PyNumberRPowProtocol, T::__rpow__);
+        unsafe extern "C" fn wrap_rpow<T>(
+            arg: *mut crate::ffi::PyObject,
+            slf: *mut crate::ffi::PyObject,
+            modulo: *mut crate::ffi::PyObject,
+        ) -> *mut crate::ffi::PyObject
+        where
+            T: for<'p> PyNumberRPowProtocol<'p>,
+        {
+            crate::callback_body!(py, {
+                let slf: &crate::PyCell<T> = extract_or_return_not_implemented!(py, slf);
+                let arg = extract_or_return_not_implemented!(py, arg);
+                let modulo = extract_or_return_not_implemented!(py, modulo);
+                slf.try_borrow()?.__rpow__(arg, modulo).convert(py)
+            })
+        }
+        self.nb_power = Some(wrap_rpow::<T>);
     }
     pub fn set_neg<T>(&mut self)
     where
@@ -675,6 +776,16 @@ impl ffi::PyNumberMethods {
     {
         self.nb_invert = py_unary_func!(PyNumberInvertProtocol, T::__invert__);
     }
+    pub fn set_lshift_rlshift<T>(&mut self)
+    where
+        T: for<'p> PyNumberLShiftProtocol<'p> + for<'p> PyNumberRLShiftProtocol<'p>,
+    {
+        self.nb_lshift = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberLShiftProtocol::__lshift__,
+            PyNumberRLShiftProtocol::__rlshift__
+        );
+    }
     pub fn set_lshift<T>(&mut self)
     where
         T: for<'p> PyNumberLShiftProtocol<'p>,
@@ -686,6 +797,16 @@ impl ffi::PyNumberMethods {
         T: for<'p> PyNumberRLShiftProtocol<'p>,
     {
         self.nb_lshift = py_binary_reversed_num_func!(PyNumberRLShiftProtocol, T::__rlshift__);
+    }
+    pub fn set_rshift_rrshift<T>(&mut self)
+    where
+        T: for<'p> PyNumberRShiftProtocol<'p> + for<'p> PyNumberRRShiftProtocol<'p>,
+    {
+        self.nb_rshift = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberRShiftProtocol::__rshift__,
+            PyNumberRRShiftProtocol::__rrshift__
+        );
     }
     pub fn set_rshift<T>(&mut self)
     where
@@ -699,6 +820,16 @@ impl ffi::PyNumberMethods {
     {
         self.nb_rshift = py_binary_reversed_num_func!(PyNumberRRShiftProtocol, T::__rrshift__);
     }
+    pub fn set_and_rand<T>(&mut self)
+    where
+        T: for<'p> PyNumberAndProtocol<'p> + for<'p> PyNumberRAndProtocol<'p>,
+    {
+        self.nb_and = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberAndProtocol::__and__,
+            PyNumberRAndProtocol::__rand__
+        );
+    }
     pub fn set_and<T>(&mut self)
     where
         T: for<'p> PyNumberAndProtocol<'p>,
@@ -711,6 +842,16 @@ impl ffi::PyNumberMethods {
     {
         self.nb_and = py_binary_reversed_num_func!(PyNumberRAndProtocol, T::__rand__);
     }
+    pub fn set_xor_rxor<T>(&mut self)
+    where
+        T: for<'p> PyNumberXorProtocol<'p> + for<'p> PyNumberRXorProtocol<'p>,
+    {
+        self.nb_xor = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberXorProtocol::__xor__,
+            PyNumberRXorProtocol::__rxor__
+        );
+    }
     pub fn set_xor<T>(&mut self)
     where
         T: for<'p> PyNumberXorProtocol<'p>,
@@ -722,6 +863,16 @@ impl ffi::PyNumberMethods {
         T: for<'p> PyNumberRXorProtocol<'p>,
     {
         self.nb_xor = py_binary_reversed_num_func!(PyNumberRXorProtocol, T::__rxor__);
+    }
+    pub fn set_or_ror<T>(&mut self)
+    where
+        T: for<'p> PyNumberOrProtocol<'p> + for<'p> PyNumberROrProtocol<'p>,
+    {
+        self.nb_or = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberOrProtocol::__or__,
+            PyNumberROrProtocol::__ror__
+        );
     }
     pub fn set_or<T>(&mut self)
     where
@@ -807,6 +958,16 @@ impl ffi::PyNumberMethods {
     {
         self.nb_inplace_or = py_binary_self_func!(PyNumberIOrProtocol, T::__ior__);
     }
+    pub fn set_floordiv_rfloordiv<T>(&mut self)
+    where
+        T: for<'p> PyNumberFloordivProtocol<'p> + for<'p> PyNumberRFloordivProtocol<'p>,
+    {
+        self.nb_floor_divide = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberFloordivProtocol::__floordiv__,
+            PyNumberRFloordivProtocol::__rfloordiv__
+        );
+    }
     pub fn set_floordiv<T>(&mut self)
     where
         T: for<'p> PyNumberFloordivProtocol<'p>,
@@ -819,6 +980,16 @@ impl ffi::PyNumberMethods {
     {
         self.nb_floor_divide =
             py_binary_reversed_num_func!(PyNumberRFloordivProtocol, T::__rfloordiv__);
+    }
+    pub fn set_truediv_rtruediv<T>(&mut self)
+    where
+        T: for<'p> PyNumberTruedivProtocol<'p> + for<'p> PyNumberRTruedivProtocol<'p>,
+    {
+        self.nb_true_divide = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberTruedivProtocol::__truediv__,
+            PyNumberRTruedivProtocol::__rtruediv__
+        );
     }
     pub fn set_truediv<T>(&mut self)
     where
@@ -852,6 +1023,16 @@ impl ffi::PyNumberMethods {
         T: for<'p> PyNumberIndexProtocol<'p>,
     {
         self.nb_index = py_unary_func!(PyNumberIndexProtocol, T::__index__);
+    }
+    pub fn set_matmul_rmatmul<T>(&mut self)
+    where
+        T: for<'p> PyNumberMatmulProtocol<'p> + for<'p> PyNumberRMatmulProtocol<'p>,
+    {
+        self.nb_matrix_multiply = py_binary_fallbacked_num_func!(
+            T,
+            PyNumberMatmulProtocol::__matmul__,
+            PyNumberRMatmulProtocol::__rmatmul__
+        );
     }
     pub fn set_matmul<T>(&mut self)
     where

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -589,7 +589,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberAddProtocol<'p> + for<'p> PyNumberRAddProtocol<'p>,
     {
-        self.nb_add = py_binary_fallbacked_num_func!(
+        self.nb_add = py_binary_fallback_num_func!(
             T,
             PyNumberAddProtocol::__add__,
             PyNumberRAddProtocol::__radd__
@@ -611,7 +611,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberSubProtocol<'p> + for<'p> PyNumberRSubProtocol<'p>,
     {
-        self.nb_subtract = py_binary_fallbacked_num_func!(
+        self.nb_subtract = py_binary_fallback_num_func!(
             T,
             PyNumberSubProtocol::__sub__,
             PyNumberRSubProtocol::__rsub__
@@ -633,7 +633,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberMulProtocol<'p> + for<'p> PyNumberRMulProtocol<'p>,
     {
-        self.nb_multiply = py_binary_fallbacked_num_func!(
+        self.nb_multiply = py_binary_fallback_num_func!(
             T,
             PyNumberMulProtocol::__mul__,
             PyNumberRMulProtocol::__rmul__
@@ -661,7 +661,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberDivmodProtocol<'p> + for<'p> PyNumberRDivmodProtocol<'p>,
     {
-        self.nb_divmod = py_binary_fallbacked_num_func!(
+        self.nb_divmod = py_binary_fallback_num_func!(
             T,
             PyNumberDivmodProtocol::__divmod__,
             PyNumberRDivmodProtocol::__rdivmod__
@@ -780,7 +780,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberLShiftProtocol<'p> + for<'p> PyNumberRLShiftProtocol<'p>,
     {
-        self.nb_lshift = py_binary_fallbacked_num_func!(
+        self.nb_lshift = py_binary_fallback_num_func!(
             T,
             PyNumberLShiftProtocol::__lshift__,
             PyNumberRLShiftProtocol::__rlshift__
@@ -802,7 +802,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberRShiftProtocol<'p> + for<'p> PyNumberRRShiftProtocol<'p>,
     {
-        self.nb_rshift = py_binary_fallbacked_num_func!(
+        self.nb_rshift = py_binary_fallback_num_func!(
             T,
             PyNumberRShiftProtocol::__rshift__,
             PyNumberRRShiftProtocol::__rrshift__
@@ -824,7 +824,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberAndProtocol<'p> + for<'p> PyNumberRAndProtocol<'p>,
     {
-        self.nb_and = py_binary_fallbacked_num_func!(
+        self.nb_and = py_binary_fallback_num_func!(
             T,
             PyNumberAndProtocol::__and__,
             PyNumberRAndProtocol::__rand__
@@ -846,7 +846,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberXorProtocol<'p> + for<'p> PyNumberRXorProtocol<'p>,
     {
-        self.nb_xor = py_binary_fallbacked_num_func!(
+        self.nb_xor = py_binary_fallback_num_func!(
             T,
             PyNumberXorProtocol::__xor__,
             PyNumberRXorProtocol::__rxor__
@@ -868,7 +868,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberOrProtocol<'p> + for<'p> PyNumberROrProtocol<'p>,
     {
-        self.nb_or = py_binary_fallbacked_num_func!(
+        self.nb_or = py_binary_fallback_num_func!(
             T,
             PyNumberOrProtocol::__or__,
             PyNumberROrProtocol::__ror__
@@ -980,7 +980,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberFloordivProtocol<'p> + for<'p> PyNumberRFloordivProtocol<'p>,
     {
-        self.nb_floor_divide = py_binary_fallbacked_num_func!(
+        self.nb_floor_divide = py_binary_fallback_num_func!(
             T,
             PyNumberFloordivProtocol::__floordiv__,
             PyNumberRFloordivProtocol::__rfloordiv__
@@ -1003,7 +1003,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberTruedivProtocol<'p> + for<'p> PyNumberRTruedivProtocol<'p>,
     {
-        self.nb_true_divide = py_binary_fallbacked_num_func!(
+        self.nb_true_divide = py_binary_fallback_num_func!(
             T,
             PyNumberTruedivProtocol::__truediv__,
             PyNumberRTruedivProtocol::__rtruediv__
@@ -1046,7 +1046,7 @@ impl ffi::PyNumberMethods {
     where
         T: for<'p> PyNumberMatmulProtocol<'p> + for<'p> PyNumberRMatmulProtocol<'p>,
     {
-        self.nb_matrix_multiply = py_binary_fallbacked_num_func!(
+        self.nb_matrix_multiply = py_binary_fallback_num_func!(
             T,
             PyNumberMatmulProtocol::__matmul__,
             PyNumberRMatmulProtocol::__rmatmul__

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -333,6 +333,58 @@ fn lhs_override_rhs() {
 }
 
 #[pyclass]
+#[derive(Debug)]
+struct Lhs2Rhs {}
+
+#[pyproto]
+impl PyNumberProtocol for Lhs2Rhs {
+    fn __add__(lhs: PyRef<Lhs2Rhs>, rhs: &PyAny) -> String {
+        format!("{:?} + {:?}", lhs, rhs)
+    }
+    fn __sub__(lhs: PyRef<Lhs2Rhs>, rhs: &PyAny) -> String {
+        format!("{:?} - {:?}", lhs, rhs)
+    }
+    fn __pow__(lhs: PyRef<Lhs2Rhs>, rhs: &PyAny, _mod: Option<usize>) -> String {
+        format!("{:?} ** {:?}", lhs, rhs)
+    }
+    fn __matmul__(lhs: PyRef<Lhs2Rhs>, rhs: &PyAny) -> String {
+        format!("{:?} @ {:?}", lhs, rhs)
+    }
+
+    fn __radd__(&self, other: &PyAny) -> String {
+        format!("{:?} + RA", other)
+    }
+    fn __rsub__(&self, rhs: &PyAny) -> String {
+        format!("{:?} - RA", rhs)
+    }
+    fn __rpow__(&self, rhs: &PyAny, _mod: Option<usize>) -> String {
+        format!("{:?} ** RA", rhs)
+    }
+    fn __rmatmul__(&self, rhs: &PyAny) -> String {
+        format!("{:?} @ RA", rhs)
+    }
+}
+
+#[pyproto]
+impl PyObjectProtocol for Lhs2Rhs {
+    fn __repr__(&self) -> &'static str {
+        "BA"
+    }
+}
+
+#[test]
+fn lhs_fallbacked_to_rhs() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let c = PyCell::new(py, Lhs2Rhs {}).unwrap();
+    // Fallbacked to RHS because of type mismatching
+    py_run!(py, c, "assert 1 + c == '1 + RA'");
+    py_run!(py, c, "assert 1 - c == '1 - RA'");
+    py_run!(py, c, "assert 1 ** c == '1 ** RA'");
+}
+
+#[pyclass]
 struct RichComparisons {}
 
 #[pyproto]


### PR DESCRIPTION
Fixes #844. 
Include some other refactorings:
- ` SlotSetter` is refactored not to have `skipped_setters` field.
- `py_ternary_num_func` macros are removed since they are just called once.
- `#[macro_export]` for macros in `class/macros.rs` are removed.