### PR TITLE
Add introduction to guide

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -1,5 +1,9 @@
 # Summary
 
+[Introduction](index.md)
+
+---
+
 - [Python Modules](module.md)
 - [Python Functions](function.md)
 - [Python Classes](class.md)
@@ -13,7 +17,10 @@
 - [Building and Distribution](building_and_distribution.md)
 - [PyPy support](pypy.md)
 - [FAQ & Troubleshooting](faq.md)
-- [Appendix A: PyO3 and rust-cpython](rust_cpython.md)
-- [Appendix B: Migration Guide](migration.md)
-- [Appendix C: Trait bounds](trait_bounds.md)
-- [Appendix D: Logging](logging.md)
+
+---
+
+[Appendix A: PyO3 and rust-cpython](rust_cpython.md)
+[Appendix B: Migration Guide](migration.md)
+[Appendix C: Trait bounds](trait_bounds.md)
+[Appendix D: Logging](logging.md)

--- a/guide/src/index.md
+++ b/guide/src/index.md
@@ -1,0 +1,7 @@
+# The PyO3 Guide
+
+Welcome to the PyO3 user guide! This book is a companion to [PyO3's API docs](https://docs.rs/pyo3). It contains examples and documentation to explain all of PyO3's use cases in detail.
+
+Please choose from the chapters on the left to jump to individual topics, or continue below to start with PyO3's README.
+
+{{#include ../../README.md}}


### PR DESCRIPTION
I've been thinking about doing this for a while... I just added a very basic introduction page and added a copy of the README to the guide, because some topics are covered only in the README (and it's nice not to need to duplicate them).