### PR TITLE
Fix `cargo test` with `extension-module` feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove `PYO3_CROSS_INCLUDE_DIR` environment variable and the associated C header parsing functionality.
 
 ### Fixed
+- Fix `cargo test` with `extension-module` feature. (Requires `cargo +nightly -Zextra-link-arg test` for now.) #[1123](https://github.com/PyO3/pyo3/pull/1123)
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - `PYO3_CROSS_LIB_DIR` enviroment variable no long required when compiling for x86-64 Python from macOS arm64 and reverse. [#1428](https://github.com/PyO3/pyo3/pull/1428)
 - Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -15,17 +15,18 @@ PyO3 provides a struct [`GILOnceCell`] which works equivalently to `OnceCell` bu
 
 [`GILOnceCell`]: {{#PYO3_DOCS_URL}}/pyo3/once_cell/struct.GILOnceCell.html
 
-## I can't run `cargo test`: I'm having linker issues like "Symbol not found" or "Undefined reference to _PyExc_SystemError"!
+## I can't run `cargo test` or `cargo run`: I'm having linker issues like "Symbol not found" or "Undefined reference to _PyExc_SystemError"!
 
-Currently, [#341](https://github.com/PyO3/pyo3/issues/341) causes `cargo test` to fail with linking errors when the `extension-module` feature is activated. For now you can work around this by making the `extension-module` feature optional and running the tests with `cargo test --no-default-features`:
+On unix operating systems the `extension-module` feature is required to disable linking against libpython to meet criteria of how Python extension modules should be built.
 
-```toml
-[dependencies.pyo3]
-version = "{{#PYO3_VERSION}}"
+PyO3 is able to re-enable linking for binaries and tests in the project, but it requires a nightly cargo feature. To use this feature, you must opt into it, e.g.:
 
-[features]
-extension-module = ["pyo3/extension-module"]
-default = ["extension-module"]
+```
+# For cargo test
+cargo +nightly -Zextra-link-arg test
+
+# For cargo run
+cargo +nightly -Zextra-link-arg run
 ```
 
 ## I can't run `cargo test`: my crate cannot be found for tests in `tests/` directory!


### PR DESCRIPTION
The excellent news is that https://github.com/rust-lang/cargo/pull/8441 will resolve a lot of our existing issues with `extension-module`. The bad news is that it's not yet merged, so please wait with merging this for now!

I'm not sure if this solves #904 (proc-macro crate) - we'll have to test and perhaps refine. I was able to confirm locally that `cargo test` and `cargo run` are fixed with this feature.

Fixes #1084 
Fixes #771 
Fixes #341 
Fixes #340