### PR TITLE
Do not include PyBuffer APIs when building for abi3

### DIFF
--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -6,6 +6,7 @@
 mod macros;
 
 pub mod basic;
+#[cfg(not(Py_LIMITED_API))]
 pub mod buffer;
 pub mod context;
 pub mod descr;
@@ -19,6 +20,7 @@ pub mod pyasync;
 pub mod sequence;
 
 pub use self::basic::PyObjectProtocol;
+#[cfg(not(Py_LIMITED_API))]
 pub use self::buffer::PyBufferProtocol;
 pub use self::context::PyContextProtocol;
 pub use self::descr::PyDescrProtocol;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,8 @@ pub use {
 #[doc(hidden)]
 pub use libc;
 
+// The CPython stable ABI does not include PyBuffer.
+#[cfg(not(Py_LIMITED_API))]
 pub mod buffer;
 #[doc(hidden)]
 pub mod callback;


### PR DESCRIPTION
Refs #1125

Reduces the number of compilation failures with `--features abi3` from 87 to 56.
