### PR TITLE
structure code to avoid a use-after-free

### DIFF
--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -235,7 +235,8 @@ fn initialize_tp_dict(
     // the POV of other threads.
     for (key, val) in items {
         let ret = unsafe {
-            ffi::PyDict_SetItemString(tp_dict, CString::new(key)?.as_ptr(), val.into_ptr())
+            let key_cstr = CString::new(key)?;
+            ffi::PyDict_SetItemString(tp_dict, key_cstr.as_ptr(), val.into_ptr())
         };
         if ret < 0 {
             return Err(PyErr::fetch(py));


### PR DESCRIPTION
I don't understand why the existing code works -- I'd expect the `CString` value to be `Drop`'d before `PyDict_SetItemString` was called, but it doesn't appear to work that way. Structuring the code like this makes it clear the lifetimes are safe.
