### PR TITLE
Use PyType_Spec for creating new types in Rust

### DIFF
--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -1,6 +1,7 @@
 import datetime as pdt
 import platform
 import struct
+import re
 import sys
 
 import pytest
@@ -327,4 +328,5 @@ def test_tz_class_introspection():
     tzi = rdt.TzClass()
 
     assert tzi.__class__ == rdt.TzClass
-    assert repr(tzi).startswith("<TzClass object at")
+    # PyPy generate <importlib.bootstrap.TzClass ...> for some reason.
+    assert re.match(r"^<[\w\.]*TzClass object at", repr(tzi))

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -205,7 +205,7 @@ or by `self_.into_super()` as `PyRef<Self::BaseClass>`.
 ```rust
 # use pyo3::prelude::*;
 
-#[pyclass]
+#[pyclass(subclass)]
 struct BaseClass {
     val1: usize,
 }
@@ -222,7 +222,7 @@ impl BaseClass {
     }
 }
 
-#[pyclass(extends=BaseClass)]
+#[pyclass(extends=BaseClass, subclass)]
 struct SubClass {
     val2: usize,
 }

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -581,11 +581,6 @@ pub trait PyNumberIndexProtocol<'p>: PyNumberProtocol<'p> {
 
 #[doc(hidden)]
 impl ffi::PyNumberMethods {
-    pub(crate) fn from_nb_bool(nb_bool: ffi::inquiry) -> *mut Self {
-        let mut nm = ffi::PyNumberMethods_INIT;
-        nm.nb_bool = Some(nb_bool);
-        Box::into_raw(Box::new(nm))
-    }
     pub fn set_add_radd<T>(&mut self)
     where
         T: for<'p> PyNumberAddProtocol<'p> + for<'p> PyNumberRAddProtocol<'p>,

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -455,7 +455,7 @@ impl<T: PyClass + fmt::Debug> fmt::Debug for PyCell<T> {
 /// - You want to get super class.
 /// ```
 /// # use pyo3::prelude::*;
-/// #[pyclass]
+/// #[pyclass(subclass)]
 /// struct Parent {
 ///     basename: &'static str,
 /// }
@@ -516,11 +516,11 @@ where
     /// # Examples
     /// ```
     /// # use pyo3::prelude::*;
-    /// #[pyclass]
+    /// #[pyclass(subclass)]
     /// struct Base1 {
     ///     name1: &'static str,
     /// }
-    /// #[pyclass(extends=Base1)]
+    /// #[pyclass(extends=Base1, subclass)]
     /// struct Base2 {
     ///     name2: &'static str,
     ///  }

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -30,12 +30,12 @@ impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
 /// ```
 /// # use pyo3::prelude::*;
 /// # use pyo3::py_run;
-/// #[pyclass]
+/// #[pyclass(subclass)]
 /// struct BaseClass {
 ///     #[pyo3(get)]
 ///     basename: &'static str,
 /// }
-/// #[pyclass(extends=BaseClass)]
+/// #[pyclass(extends=BaseClass, subclass)]
 /// struct SubClass {
 ///     #[pyo3(get)]
 ///     subname: &'static str,

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -51,7 +51,10 @@ fn class_attributes() {
     py_assert!(py, foo_obj, "foo_obj.MY_CONST == 'foobar'");
 }
 
+// Ignored because heap types are not immutable:
+// https://github.com/python/cpython/blob/master/Objects/typeobject.c#L3399-L3409
 #[test]
+#[ignore]
 fn class_attributes_are_immutable() {
     let gil = Python::acquire_gil();
     let py = gil.python();

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -119,7 +119,11 @@ fn test_raw_idents() {
 #[pyclass]
 struct EmptyClassInModule {}
 
+// Ignored because heap types do not show up as being in builtins, instead they
+// raise AttributeError:
+// https://github.com/python/cpython/blob/master/Objects/typeobject.c#L544-L573
 #[test]
+#[ignore]
 fn empty_class_in_module() {
     let gil = Python::acquire_gil();
     let py = gil.python();
@@ -165,7 +169,7 @@ fn class_with_object_field() {
     py_assert!(py, ty, "ty(None).value == None");
 }
 
-#[pyclass(unsendable)]
+#[pyclass(unsendable, subclass)]
 struct UnsendableBase {
     value: std::rc::Rc<usize>,
 }

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -30,7 +30,7 @@ fn test_cloneable_pyclass() {
     assert_eq!(&c, &*mrc);
 }
 
-#[pyclass]
+#[pyclass(subclass)]
 #[derive(Default)]
 struct BaseClass {
     value: i32,

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -453,7 +453,7 @@ fn test_cls_impl() {
         .unwrap();
 }
 
-#[pyclass(dict)]
+#[pyclass(dict, subclass)]
 struct DunderDictSupport {}
 
 #[test]

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -146,7 +146,7 @@ fn gc_integration2() {
     py_run!(py, inst, "import gc; assert inst in gc.get_objects()");
 }
 
-#[pyclass(weakref)]
+#[pyclass(weakref, subclass)]
 struct WeakRefSupport {}
 
 #[test]
@@ -179,7 +179,7 @@ fn inherited_weakref() {
     );
 }
 
-#[pyclass]
+#[pyclass(subclass)]
 struct BaseClassWithDrop {
     data: Option<Arc<AtomicBool>>,
 }

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -6,7 +6,7 @@ use pyo3::types::IntoPyDict;
 use pyo3::types::{PyDict, PySet};
 mod common;
 
-#[pyclass]
+#[pyclass(subclass)]
 struct BaseClass {
     #[pyo3(get)]
     val1: usize,
@@ -106,7 +106,7 @@ fn mutation_fails() {
     )
 }
 
-#[pyclass]
+#[pyclass(subclass)]
 struct BaseClassWithResult {
     _val: usize,
 }

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -31,7 +31,10 @@ fn class_with_docs() {
     py_assert!(py, typeobj, "typeobj.__text_signature__ is None");
 }
 
+// Ignored because heap types don't have working __text_signature__:
+// https://github.com/python/cpython/blob/master/Objects/typeobject.c#L864-L870
 #[test]
+#[ignore]
 fn class_with_docs_and_signature() {
     /// docs line1
     #[pyclass]
@@ -66,7 +69,10 @@ fn class_with_docs_and_signature() {
     );
 }
 
+// Ignored because heap types don't have working __text_signature__:
+// https://github.com/python/cpython/blob/master/Objects/typeobject.c#L864-L870
 #[test]
+#[ignore]
 fn class_with_signature() {
     #[pyclass]
     #[text_signature = "(a, b=None, *, c=42)"]


### PR DESCRIPTION
This is a proof of concept -- implements just enough of it to prove the idea works! There's still a lot of missing elements of this (look at all the commented out code!)

Before I went too much further and implemented all the different function pointers, I wanted to check in and see if this approach looked ok.