### PR TITLE
Avoid using CString where unnecessary

### DIFF
--- a/src/ffi/import.rs
+++ b/src/ffi/import.rs
@@ -63,6 +63,7 @@ pub unsafe fn PyImport_ImportModuleEx(
 
 extern "C" {
     pub fn PyImport_GetImporter(path: *mut PyObject) -> *mut PyObject;
+    #[cfg_attr(PyPy, link_name = "PyPyImport_Import")]
     pub fn PyImport_Import(name: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyImport_ReloadModule")]
     pub fn PyImport_ReloadModule(m: *mut PyObject) -> *mut PyObject;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -21,6 +21,7 @@ pub use self::num::PyLong as PyInt;
 pub use self::sequence::PySequence;
 pub use self::set::{PyFrozenSet, PySet};
 pub use self::slice::{PySlice, PySliceIndices};
+pub(crate) use self::string::with_tmp_string;
 pub use self::string::{PyString, PyString as PyUnicode};
 pub use self::tuple::PyTuple;
 pub use self::typeobject::PyType;


### PR DESCRIPTION
Use APIs that take a Python string instead of those taking a C string,
which are a convenience in C but require an unncessary allocation
for us.
