### PR TITLE
Remove duplicate pool and py in py_init.

### DIFF
--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -26,8 +26,6 @@ pub fn py_init(fnname: &Ident, name: &Ident, doc: syn::LitStr) -> TokenStream {
             const NAME: &'static str = concat!(stringify!(#name), "\0");
             static MODULE_DEF: ModuleDef = unsafe { ModuleDef::new(NAME) };
 
-            let pool = pyo3::GILPool::new();
-            let py = pool.python();
             pyo3::callback_body!(_py, { MODULE_DEF.make_module(#doc, #fnname) })
         }
     }


### PR DESCRIPTION
`callback_body!` already creates a pool and acquires `Python`:

~~~Rust
let pool = ::pyo3::GILPool::new();
let unwind_safe_py = std::panic::AssertUnwindSafe(pool.python());
~~~

I think these two lines can be removed safely, at least all tests still pass locally!