### PR TITLE
Remove proc-macro panics.

### DIFF
--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -67,7 +67,7 @@ fn impl_proto_impl(
         if let syn::ImplItem::Method(ref mut met) = iimpl {
             // impl Py~Protocol<'p> { type = ... }
             if let Some(m) = proto.get_proto(&met.sig.ident) {
-                impl_method_proto(ty, &mut met.sig, m).to_tokens(&mut trait_impls);
+                impl_method_proto(ty, &mut met.sig, m)?.to_tokens(&mut trait_impls);
                 // Insert the method to the HashSet
                 method_names.insert(met.sig.ident.to_string());
             }


### PR DESCRIPTION
In `pyo3-derive-backend`:

Previously:
~~~sh
$ grep "panic" ./**/*.rs -n
./src/method.rs:335:                                panic!("argument type is not supported by python method: {:?} ({:?}) {:?}",
./src/method.rs:346:                            panic!(
./src/module.rs:100:                        _ => panic!("The first parameter of pyfn must be a MetaItem"),
./src/module.rs:107:                        _ => panic!("The second parameter of pyfn must be a Literal"),
./src/module.rs:116:                    panic!("can not parse 'pyfn' params {:?}", attr);
./src/proto_method.rs:347:        ty => panic!("Unsupported argument type: {:?}", ty),
./src/proto_method.rs:388:        _ => panic!(),
./src/proto_method.rs:414:        _ => panic!("not supported"),
./src/proto_method.rs:438:        panic!("func.rs::296")
~~~

Now:
~~~sh
$ grep "panic" ./**/*.rs -n
./src/proto_method.rs:394:        _ => panic!(),
~~~

This should improve errors with incorrect macro inputs. Not sure whether the remaining panic could / should also be changed to returning `Result`:

~~~Rust
fn extract_decl(spec: syn::Item) -> syn::Signature {
    match spec {
        syn::Item::Fn(f) => f.sig,
        _ => panic!(),
    }
}
~~~