### PR TITLE
Disable fail-fast in CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} ${{ matrix.msrv }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
+      fail-fast: false  # If one platform fails, allow the rest to keep testing.
       matrix:
         rust: [stable]
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9-dev, pypy3]


### PR DESCRIPTION
Switching this off allows all platforms to continue testing, rather than stop when the first one fails.

When there's spurious failures, this allows the process to continue to (hopefully) mean fewer rounds of iteration / re-running jobs needed overall.