### PR TITLE
Allow tiny coverage drop in PR to reduce "failure" noise

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,9 @@
 comment: off
 
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # Allow a tiny drop of overall project coverage in PR to reduce spurious failures.
+        threshold: 0.25%


### PR DESCRIPTION
I think this'll help make most legitimate PRs green again.