### PR TITLE
Add #[allow(non_snake_case)] to function with generated name

### DIFF
--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -166,6 +166,7 @@ fn slot_initialization(
         Span::call_site(),
     );
     Ok(quote! {
+        #[allow(non_snake_case)]
         #[pyo3::ctor::ctor]
         fn #init() {
             let mut table = #table::default();


### PR DESCRIPTION
Fixes #1145
