### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
This commit adds a dependabot config to automatically open pull requests
with version bumps for dependencies. This will configure dependabot to
check daily if any pyo3 dependency versions are out of date and if they
are it will open a PR for each dependency. You can find more details on
the dependabot configuration and usage in in the github
documentation. [1]

[1] https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates