### PR TITLE
Don't fill in structs from the unlimited API, instead have our own structs

### DIFF
--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -171,7 +171,7 @@ pub const OBJECT: Proto = Proto {
 
 pub const ASYNC: Proto = Proto {
     name: "Async",
-    slot_table: "pyo3::ffi::PyAsyncMethods",
+    slot_table: "pyo3::class::pyasync::PyAsyncMethods",
     set_slot_table: "set_async_methods",
     methods: &[
         MethodProto::UnaryS {
@@ -220,7 +220,7 @@ pub const ASYNC: Proto = Proto {
 
 pub const BUFFER: Proto = Proto {
     name: "Buffer",
-    slot_table: "pyo3::ffi::PyBufferProcs",
+    slot_table: "pyo3::class::buffer::PyBufferMethods",
     set_slot_table: "set_buffer_methods",
     methods: &[
         MethodProto::Unary {
@@ -358,7 +358,7 @@ pub const ITER: Proto = Proto {
 
 pub const MAPPING: Proto = Proto {
     name: "Mapping",
-    slot_table: "pyo3::ffi::PyMappingMethods",
+    slot_table: "pyo3::class::mapping::PyMappingMethods",
     set_slot_table: "set_mapping_methods",
     methods: &[
         MethodProto::Unary {
@@ -401,7 +401,7 @@ pub const MAPPING: Proto = Proto {
 
 pub const SEQ: Proto = Proto {
     name: "Sequence",
-    slot_table: "pyo3::ffi::PySequenceMethods",
+    slot_table: "pyo3::class::sequence::PySequenceMethods",
     set_slot_table: "set_sequence_methods",
     methods: &[
         MethodProto::Unary {
@@ -467,7 +467,7 @@ pub const SEQ: Proto = Proto {
 
 pub const NUM: Proto = Proto {
     name: "Number",
-    slot_table: "pyo3::ffi::PyNumberMethods",
+    slot_table: "pyo3::class::number::PyNumberMethods",
     set_slot_table: "set_number_methods",
     methods: &[
         MethodProto::BinaryS {

--- a/src/class/buffer.rs
+++ b/src/class/buffer.rs
@@ -5,10 +5,7 @@
 //! For more information check [buffer protocol](https://docs.python.org/3/c-api/buffer.html)
 //! c-api
 use crate::callback::IntoPyCallbackOutput;
-use crate::{
-    ffi::{self, PyBufferProcs},
-    PyCell, PyClass, PyRefMut,
-};
+use crate::{ffi, PyCell, PyClass, PyRefMut};
 use std::os::raw::c_int;
 
 /// Buffer protocol interface
@@ -40,9 +37,15 @@ pub trait PyBufferReleaseBufferProtocol<'p>: PyBufferProtocol<'p> {
     type Result: IntoPyCallbackOutput<()>;
 }
 
+#[derive(Default)]
+pub struct PyBufferMethods {
+    pub bf_getbuffer: Option<ffi::getbufferproc>,
+    pub bf_releasebuffer: Option<ffi::releasebufferproc>,
+}
+
 /// Set functions used by `#[pyproto]`.
 #[doc(hidden)]
-impl PyBufferProcs {
+impl PyBufferMethods {
     pub fn set_getbuffer<T>(&mut self)
     where
         T: for<'p> PyBufferGetBufferProtocol<'p>,

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -5,7 +5,9 @@
 
 use crate::callback::IntoPyCallbackOutput;
 use crate::err::PyErr;
+use crate::pyclass::maybe_push_slot;
 use crate::{ffi, FromPyObject, PyClass, PyObject};
+use std::os::raw::c_void;
 
 /// Number interface
 #[allow(unused_variables)]
@@ -579,8 +581,204 @@ pub trait PyNumberIndexProtocol<'p>: PyNumberProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
+#[derive(Default)]
+pub struct PyNumberMethods {
+    pub nb_add: Option<ffi::binaryfunc>,
+    pub nb_subtract: Option<ffi::binaryfunc>,
+    pub nb_multiply: Option<ffi::binaryfunc>,
+    pub nb_remainder: Option<ffi::binaryfunc>,
+    pub nb_divmod: Option<ffi::binaryfunc>,
+    pub nb_power: Option<ffi::ternaryfunc>,
+    pub nb_negative: Option<ffi::unaryfunc>,
+    pub nb_positive: Option<ffi::unaryfunc>,
+    pub nb_absolute: Option<ffi::unaryfunc>,
+    pub nb_bool: Option<ffi::inquiry>,
+    pub nb_invert: Option<ffi::unaryfunc>,
+    pub nb_lshift: Option<ffi::binaryfunc>,
+    pub nb_rshift: Option<ffi::binaryfunc>,
+    pub nb_and: Option<ffi::binaryfunc>,
+    pub nb_xor: Option<ffi::binaryfunc>,
+    pub nb_or: Option<ffi::binaryfunc>,
+    pub nb_int: Option<ffi::unaryfunc>,
+    pub nb_float: Option<ffi::unaryfunc>,
+    pub nb_inplace_add: Option<ffi::binaryfunc>,
+    pub nb_inplace_subtract: Option<ffi::binaryfunc>,
+    pub nb_inplace_multiply: Option<ffi::binaryfunc>,
+    pub nb_inplace_remainder: Option<ffi::binaryfunc>,
+    pub nb_inplace_power: Option<ffi::ternaryfunc>,
+    pub nb_inplace_lshift: Option<ffi::binaryfunc>,
+    pub nb_inplace_rshift: Option<ffi::binaryfunc>,
+    pub nb_inplace_and: Option<ffi::binaryfunc>,
+    pub nb_inplace_xor: Option<ffi::binaryfunc>,
+    pub nb_inplace_or: Option<ffi::binaryfunc>,
+    pub nb_floor_divide: Option<ffi::binaryfunc>,
+    pub nb_true_divide: Option<ffi::binaryfunc>,
+    pub nb_inplace_floor_divide: Option<ffi::binaryfunc>,
+    pub nb_inplace_true_divide: Option<ffi::binaryfunc>,
+    pub nb_index: Option<ffi::unaryfunc>,
+    pub nb_matrix_multiply: Option<ffi::binaryfunc>,
+    pub nb_inplace_matrix_multiply: Option<ffi::binaryfunc>,
+}
+
 #[doc(hidden)]
-impl ffi::PyNumberMethods {
+impl PyNumberMethods {
+    pub(crate) fn update_slots(&self, slots: &mut Vec<ffi::PyType_Slot>) {
+        maybe_push_slot(slots, ffi::Py_nb_add, self.nb_add.map(|v| v as *mut c_void));
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_subtract,
+            self.nb_subtract.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_multiply,
+            self.nb_multiply.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_remainder,
+            self.nb_remainder.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_divmod,
+            self.nb_divmod.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_power,
+            self.nb_power.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_negative,
+            self.nb_negative.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_positive,
+            self.nb_positive.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_absolute,
+            self.nb_absolute.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_bool,
+            self.nb_bool.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_invert,
+            self.nb_invert.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_lshift,
+            self.nb_lshift.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_rshift,
+            self.nb_rshift.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(slots, ffi::Py_nb_and, self.nb_and.map(|v| v as *mut c_void));
+        maybe_push_slot(slots, ffi::Py_nb_xor, self.nb_xor.map(|v| v as *mut c_void));
+        maybe_push_slot(slots, ffi::Py_nb_or, self.nb_or.map(|v| v as *mut c_void));
+        maybe_push_slot(slots, ffi::Py_nb_int, self.nb_int.map(|v| v as *mut c_void));
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_float,
+            self.nb_float.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_add,
+            self.nb_inplace_add.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_subtract,
+            self.nb_inplace_subtract.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_multiply,
+            self.nb_inplace_multiply.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_remainder,
+            self.nb_inplace_remainder.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_power,
+            self.nb_inplace_power.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_lshift,
+            self.nb_inplace_lshift.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_rshift,
+            self.nb_inplace_rshift.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_and,
+            self.nb_inplace_and.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_xor,
+            self.nb_inplace_xor.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_or,
+            self.nb_inplace_or.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_floor_divide,
+            self.nb_floor_divide.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_true_divide,
+            self.nb_true_divide.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_floor_divide,
+            self.nb_inplace_floor_divide.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_true_divide,
+            self.nb_inplace_true_divide.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_index,
+            self.nb_index.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_matrix_multiply,
+            self.nb_matrix_multiply.map(|v| v as *mut c_void),
+        );
+        maybe_push_slot(
+            slots,
+            ffi::Py_nb_inplace_matrix_multiply,
+            self.nb_inplace_matrix_multiply.map(|v| v as *mut c_void),
+        );
+    }
     pub fn set_add_radd<T>(&mut self)
     where
         T: for<'p> PyNumberAddProtocol<'p> + for<'p> PyNumberRAddProtocol<'p>,

--- a/src/class/proto_methods.rs
+++ b/src/class/proto_methods.rs
@@ -1,8 +1,7 @@
 use crate::class::{
-    basic::PyObjectMethods, descr::PyDescrMethods, gc::PyGCMethods, iter::PyIterMethods,
-};
-use crate::ffi::{
-    PyAsyncMethods, PyBufferProcs, PyMappingMethods, PyNumberMethods, PySequenceMethods,
+    basic::PyObjectMethods, buffer::PyBufferMethods, descr::PyDescrMethods, gc::PyGCMethods,
+    iter::PyIterMethods, mapping::PyMappingMethods, number::PyNumberMethods,
+    pyasync::PyAsyncMethods, sequence::PySequenceMethods,
 };
 use std::{
     ptr::{self, NonNull},
@@ -18,7 +17,7 @@ pub trait PyProtoMethods {
     fn basic_methods() -> Option<NonNull<PyObjectMethods>> {
         None
     }
-    fn buffer_methods() -> Option<NonNull<PyBufferProcs>> {
+    fn buffer_methods() -> Option<NonNull<PyBufferMethods>> {
         None
     }
     fn descr_methods() -> Option<NonNull<PyDescrMethods>> {
@@ -54,7 +53,7 @@ impl<T: HasProtoRegistry> PyProtoMethods for T {
     fn basic_methods() -> Option<NonNull<PyObjectMethods>> {
         NonNull::new(Self::registry().basic_methods.load(Ordering::Relaxed))
     }
-    fn buffer_methods() -> Option<NonNull<PyBufferProcs>> {
+    fn buffer_methods() -> Option<NonNull<PyBufferMethods>> {
         NonNull::new(Self::registry().buffer_methods.load(Ordering::Relaxed))
     }
     fn descr_methods() -> Option<NonNull<PyDescrMethods>> {
@@ -86,7 +85,7 @@ pub struct PyProtoRegistry {
     /// Basic protocols.
     basic_methods: AtomicPtr<PyObjectMethods>,
     /// Buffer protocols.
-    buffer_methods: AtomicPtr<PyBufferProcs>,
+    buffer_methods: AtomicPtr<PyBufferMethods>,
     /// Descr pProtocols.
     descr_methods: AtomicPtr<PyDescrMethods>,
     /// GC protocols.
@@ -123,7 +122,7 @@ impl PyProtoRegistry {
         self.basic_methods
             .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }
-    pub fn set_buffer_methods(&self, methods: PyBufferProcs) {
+    pub fn set_buffer_methods(&self, methods: PyBufferMethods) {
         self.buffer_methods
             .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
     }

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -118,264 +118,6 @@ pub(crate) fn maybe_push_slot(
     }
 }
 
-fn push_numbers_slots(slots: &mut Vec<ffi::PyType_Slot>, numbers: &ffi::PyNumberMethods) {
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_add,
-        numbers.nb_add.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_subtract,
-        numbers.nb_subtract.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_multiply,
-        numbers.nb_multiply.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_remainder,
-        numbers.nb_remainder.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_divmod,
-        numbers.nb_divmod.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_power,
-        numbers.nb_power.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_negative,
-        numbers.nb_negative.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_positive,
-        numbers.nb_positive.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_absolute,
-        numbers.nb_absolute.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_bool,
-        numbers.nb_bool.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_invert,
-        numbers.nb_invert.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_lshift,
-        numbers.nb_lshift.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_rshift,
-        numbers.nb_rshift.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_and,
-        numbers.nb_and.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_xor,
-        numbers.nb_xor.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_or,
-        numbers.nb_or.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_int,
-        numbers.nb_int.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_float,
-        numbers.nb_float.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_add,
-        numbers.nb_inplace_add.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_subtract,
-        numbers.nb_inplace_subtract.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_multiply,
-        numbers.nb_inplace_multiply.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_remainder,
-        numbers.nb_inplace_remainder.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_power,
-        numbers.nb_inplace_power.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_lshift,
-        numbers.nb_inplace_lshift.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_rshift,
-        numbers.nb_inplace_rshift.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_and,
-        numbers.nb_inplace_and.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_xor,
-        numbers.nb_inplace_xor.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_or,
-        numbers.nb_inplace_or.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_floor_divide,
-        numbers.nb_floor_divide.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_true_divide,
-        numbers.nb_true_divide.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_floor_divide,
-        numbers.nb_inplace_floor_divide.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_true_divide,
-        numbers.nb_inplace_true_divide.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_index,
-        numbers.nb_index.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_matrix_multiply,
-        numbers.nb_matrix_multiply.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_nb_inplace_matrix_multiply,
-        numbers.nb_inplace_matrix_multiply.map(|v| v as *mut c_void),
-    );
-}
-
-fn push_mapping_slots(slots: &mut Vec<ffi::PyType_Slot>, mapping: &ffi::PyMappingMethods) {
-    maybe_push_slot(
-        slots,
-        ffi::Py_mp_length,
-        mapping.mp_length.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_mp_subscript,
-        mapping.mp_subscript.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_mp_ass_subscript,
-        mapping.mp_ass_subscript.map(|v| v as *mut c_void),
-    );
-}
-
-fn push_sequence_slots(slots: &mut Vec<ffi::PyType_Slot>, seq: &ffi::PySequenceMethods) {
-    maybe_push_slot(
-        slots,
-        ffi::Py_sq_length,
-        seq.sq_length.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_sq_concat,
-        seq.sq_concat.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_sq_repeat,
-        seq.sq_repeat.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_sq_item,
-        seq.sq_item.map(|v| v as *mut c_void),
-    );
-
-    maybe_push_slot(
-        slots,
-        ffi::Py_sq_ass_item,
-        seq.sq_ass_item.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_sq_contains,
-        seq.sq_contains.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_sq_inplace_concat,
-        seq.sq_inplace_concat.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_sq_inplace_repeat,
-        seq.sq_inplace_repeat.map(|v| v as *mut c_void),
-    );
-}
-
-fn push_async_slots(slots: &mut Vec<ffi::PyType_Slot>, asnc: &ffi::PyAsyncMethods) {
-    maybe_push_slot(
-        slots,
-        ffi::Py_am_await,
-        asnc.am_await.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_am_aiter,
-        asnc.am_aiter.map(|v| v as *mut c_void),
-    );
-    maybe_push_slot(
-        slots,
-        ffi::Py_am_anext,
-        asnc.am_anext.map(|v| v as *mut c_void),
-    );
-}
-
 pub(crate) fn create_type_object<T>(
     py: Python,
     module_name: Option<&str>,
@@ -436,8 +178,8 @@ where
         unsafe { basic.as_ref() }.update_slots(&mut slots);
     }
 
-    if let Some(number) = T::number_methods() {
-        push_numbers_slots(&mut slots, unsafe { number.as_ref() });
+    if let Some(numbers) = T::number_methods() {
+        unsafe { numbers.as_ref() }.update_slots(&mut slots);
     }
 
     // iterator methods
@@ -447,12 +189,12 @@ where
 
     // mapping methods
     if let Some(mapping) = T::mapping_methods() {
-        push_mapping_slots(&mut slots, unsafe { mapping.as_ref() });
+        unsafe { mapping.as_ref() }.update_slots(&mut slots);
     }
 
     // sequence methods
     if let Some(seq) = T::sequence_methods() {
-        push_sequence_slots(&mut slots, unsafe { seq.as_ref() });
+        unsafe { seq.as_ref() }.update_slots(&mut slots);
     }
 
     // descriptor protocol
@@ -462,7 +204,7 @@ where
 
     // async methods
     if let Some(asnc) = T::async_methods() {
-        push_async_slots(&mut slots, unsafe { asnc.as_ref() });
+        unsafe { asnc.as_ref() }.update_slots(&mut slots);
     }
 
     // GC support


### PR DESCRIPTION

We convert them to slots immediately anyways. Makes Buffer/Mapping/Number/Async/Sequence consistent with Basic/Iter/Descr/Gc.

This takes us from 44 compilation errors to 33 with `cargo test --features abi3`