### PR TITLE
Fix cargo test with Anaconda python, and divergent gcc versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Fix `build.rs` to work with Anaconda python
 - Add FFI definitions `Py_FinalizeEx`, `PyOS_getsig`, `PyOS_setsig`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
 - Add `Python::with_gil` for executing a closure with the Python GIL. [#1037](https://github.com/PyO3/pyo3/pull/1037)
 - Implement `Debug` for `PyIterator`. [#1051](https://github.com/PyO3/pyo3/pull/1051)

--- a/build.rs
+++ b/build.rs
@@ -680,8 +680,14 @@ import platform
 import struct
 import sys
 import sysconfig
+import os.path
 
 PYPY = platform.python_implementation() == "PyPy"
+
+# Anaconda based python distributions have a static python executable, but include
+# the shared library. Use the shared library for embedding to avoid rust trying to
+# LTO the static library (and failing with newer gcc's, because it is old).
+ANACONDA = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
 
 try:
     base_prefix = sys.base_prefix
@@ -697,7 +703,7 @@ if libdir is not None:
     print("libdir", libdir)
 print("ld_version", sysconfig.get_config_var('LDVERSION') or sysconfig.get_config_var('py_version_short'))
 print("base_prefix", base_prefix)
-print("shared", PYPY or bool(sysconfig.get_config_var('Py_ENABLE_SHARED')))
+print("shared", PYPY or ANACONDA or bool(sysconfig.get_config_var('Py_ENABLE_SHARED')))
 print("executable", sys.executable)
 print("calcsize_pointer", struct.calcsize("P"))
 "#;


### PR DESCRIPTION
This change forces pyo3 to use python from a shared library when using Anaconda python distributions.  Currently cargo test fails with:
```
= note: lto1: fatal error: bytecode stream in file '.../target/debug/deps/libpyo3-90ae49a6516fe776.rlib' generated with LTO version 6.0 instead of the expected 8.1
          compilation terminated.
```

unless you match the gcc version with Anaconda's.

Anaconda includes both static and shared versions of python however the python executable is static, so build.rs pyo3 embeds the  libpython*.a file, built with Anaconda's gcc 7.3.

This causes the tests and downstream crates to see it also and breaks builds where a different version of gcc is used as the LTO versions in the archive become unsupported. 

With this change we always use the .so and avoid any embedded LTO issues altogether. 



