### PR TITLE
Remove special case of PyIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Change `PyIterator` to be consistent with other native types: it is now used as `&PyIterator` instead of `PyIterator<'a>`. [#1176](https://github.com/PyO3/pyo3/pull/1176)
+
 ### Removed
 - Remove unused `python3` feature. [#1209](https://github.com/PyO3/pyo3/pull/1209)
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -362,7 +362,7 @@ impl PyAny {
     ///
     /// This is typically a new iterator but if the argument is an iterator,
     /// this returns itself.
-    pub fn iter(&self) -> PyResult<PyIterator> {
+    pub fn iter(&self) -> PyResult<&PyIterator> {
         PyIterator::from_object(self.py(), self)
     }
 

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -96,8 +96,7 @@ mod tests {
     use crate::exceptions::PyTypeError;
     use crate::gil::GILPool;
     use crate::types::{PyDict, PyList};
-    use crate::Python;
-    use crate::ToPyObject;
+    use crate::{Python, Py, PyAny, ToPyObject, PyTryFrom};
     use indoc::indoc;
 
     #[test]
@@ -198,5 +197,14 @@ mod tests {
         let err = PyIterator::from_object(py, &x).unwrap_err();
 
         assert!(err.is_instance::<PyTypeError>(py))
+    }
+
+    #[test]
+    fn iterator_try_from() {
+        let gil_guard = Python::acquire_gil();
+        let py = gil_guard.python();
+        let obj: Py<PyAny> = vec![10, 20].to_object(py).as_ref(py).iter().unwrap().into();
+        let iter: &PyIterator = PyIterator::try_from(obj.as_ref(py)).unwrap();
+        assert_eq!(obj, iter.into());
     }
 }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -96,7 +96,7 @@ mod tests {
     use crate::exceptions::PyTypeError;
     use crate::gil::GILPool;
     use crate::types::{PyDict, PyList};
-    use crate::{Python, Py, PyAny, ToPyObject, PyTryFrom};
+    use crate::{Py, PyAny, PyTryFrom, Python, ToPyObject};
     use indoc::indoc;
 
     #[test]

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -9,6 +9,10 @@ use crate::{ffi, AsPyPointer, PyAny, PyErr, PyNativeType, PyResult, Python};
 /// Unlike other Python objects, this class includes a `Python<'p>` token
 /// so that `PyIterator` can implement the Rust `Iterator` trait.
 ///
+/// This means that you can't use `PyIterator` in many places where other
+/// types like `PyList` can automatically be extracted from objects, such
+/// as function arguments.
+///
 /// # Example
 ///
 /// ```rust
@@ -29,7 +33,9 @@ use crate::{ffi, AsPyPointer, PyAny, PyErr, PyNativeType, PyResult, Python};
 pub struct PyIterator<'p>(&'p PyAny);
 
 impl<'p> PyIterator<'p> {
-    /// Constructs a `PyIterator` from a Python iterator object.
+    /// Constructs a `PyIterator` from a Python iterable object.
+    ///
+    /// Equivalent to Python's built-in `iter` function.
     pub fn from_object<T>(py: Python<'p>, obj: &T) -> PyResult<PyIterator<'p>>
     where
         T: AsPyPointer,


### PR DESCRIPTION
Instead of `PyIterator<'p>` implement the iter protocol on `&'p PyIterator`.

This lets us implement `PyNativeType`, pass `PyIterator` as a function argument etc.

Is there a reason I don't get why this was handled specially?