### PR TITLE
Don't consider it cross-compilation when building for 32-bit Windows on 64-bit windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix building for a 32-bit Python on 64-bit Windows with a 64-bit Rust toolchain. [#1179](https://github.com/PyO3/pyo3/pull/1179)
 
-## [0.12.0] - 2020-10-12
+## [0.12.0] - 2020-09-12
 ### Added
 - Add FFI definitions `Py_FinalizeEx`, `PyOS_getsig`, and `PyOS_setsig`. [#1021](https://github.com/PyO3/pyo3/pull/1021)
 - Add `PyString::to_str` for accessing `PyString` as `&str`. [#1023](https://github.com/PyO3/pyo3/pull/1023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/master/migration
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+### Changed
+### Removed
+### Fixed
+- Fix building for a 32-bit Python on 64-bit Windows with a 64-bit Rust toolchain. [#1179](https://github.com/PyO3/pyo3/pull/1179)
+
 ## [0.12.0] - 2020-10-12
 ### Added
 - Add FFI definitions `Py_FinalizeEx`, `PyOS_getsig`, and `PyOS_setsig`. [#1021](https://github.com/PyO3/pyo3/pull/1021)

--- a/build.rs
+++ b/build.rs
@@ -148,7 +148,9 @@ impl CrossCompileConfig {
 }
 
 fn cross_compiling() -> Result<Option<CrossCompileConfig>> {
-    if env::var("TARGET")? == env::var("HOST")? {
+    let target = env::var("TARGET")?;
+    let host = env::var("HOST")?;
+    if target == host || (target == "i686-pc-windows-msvc" && host == "x86_64-pc-windows-msvc") {
         return Ok(None);
     }
 


### PR DESCRIPTION
This is a bit of an untested hack :-)

In https://github.com/PyO3/setuptools-rust/pull/77 we introduced the ability to automatically build for 32-bit Windows when running a 32-bit Python on a 64-bit Windows (and Rust toolchain). The 0.12 release of pyo3 unfortunately broke this. I believe this PR may resolve it.