### PR TITLE
Fix compilation on platforms that don't use i8 for c_char

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 ### Fixed
 - Fix building for a 32-bit Python on 64-bit Windows with a 64-bit Rust toolchain. [#1179](https://github.com/PyO3/pyo3/pull/1179)
+- Fix building on platforms where `c_char` is `u8` [#1182][https://github.com/PyO3/pyo3/pull/1182]
 
 ## [0.12.0] - 2020-09-12
 ### Added

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -6,6 +6,7 @@ use crate::type_object::PySizedLayout;
 use crate::{ffi, PyResult, Python};
 use std::ffi::CStr;
 use std::ops;
+use std::os::raw::c_char;
 
 /// The boilerplate to convert between a Rust type and a Python exception.
 #[macro_export]
@@ -445,7 +446,7 @@ impl PyUnicodeDecodeError {
         unsafe {
             py.from_owned_ptr_or_err(ffi::PyUnicodeDecodeError_Create(
                 encoding.as_ptr(),
-                input.as_ptr() as *const i8,
+                input.as_ptr() as *const c_char,
                 input.len() as ffi::Py_ssize_t,
                 range.start as ffi::Py_ssize_t,
                 range.end as ffi::Py_ssize_t,


### PR DESCRIPTION
This commit changes the cast of an c_char to be a c_char type instead of
i8. On x86 platforms i8 == c_char, but it can also be u8 on other
platforms. [1][2] This should fix compilation on those platforms by just
using the c_char type so that we're casting as the right type regardless
of which platform PyO3 is being built for.

Fixes #1181

[1] https://doc.rust-lang.org/std/os/raw/type.c_char.html
[2] https://github.com/rust-lang/rust/blob/master/library/std/src/os/raw/mod.rs#L55-L99