### PR TITLE
Fix doc redirect on release

### DIFF
--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.prepare_tag.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v2
 
@@ -44,3 +46,22 @@ jobs:
           publish_dir: ./gh-pages-build/
           destination_dir: ${{ steps.prepare_tag.outputs.tag_name }}
           full_commit_message: 'Upload documentation for ${{ steps.prepare_tag.outputs.tag_name }}'
+
+  release:
+    needs: deploy
+    if: ${{ env.GITHUB_EVENT_NAME == 'release' }}
+    steps:
+      - name: Create latest tag redirect
+        env:
+          TAG_NAME: ${{ needs.deploy.outputs.tag_name }}
+        run: |
+          mkdir public
+          echo "<meta http-equiv=refresh content=0;url='$TAG_NAME/'>" > public/index.html
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3.7.0-8
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public/
+          full_commit_message: 'Release ${{ steps.prepare_tag.outputs.tag_name }}'
+          keep_files: true


### PR DESCRIPTION
Looks like the move from travis to actions for the guide accidentally broke the ability for https://pyo3.rs to automatically redirect to the latest version. (It's still going to `0.11.1`.)

I believe this job should fix it; I'll merge and use it when releasing `0.12.1` shortly.