### PR TITLE
Tidy up guide release

### DIFF
--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   release:
+    types: [published]
 
 env:
   CARGO_TERM_COLOR: always
@@ -64,5 +65,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public/
-          full_commit_message: 'Release ${{ steps.prepare_tag.outputs.tag_name }}'
+          full_commit_message: 'Release ${{ needs.deploy.outputs.tag_name }}'
           keep_files: true


### PR DESCRIPTION
The changes from #1198 worked nicely, but the process is a bit messy. It currently runs three times and also doesn't have the version number in the commit that gets pushed to github pages.

This PR just tidies up those loose ends for when the next release happens.