### PR TITLE
Link python3.lib instead of python3x.lib on Windows in abi3 mode

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -555,6 +555,11 @@ fn run_python_script(interpreter: &Path, script: &str) -> Result<String> {
 
 fn get_library_link_name(version: &PythonVersion, ld_version: &str) -> String {
     if cfg!(target_os = "windows") {
+        // Mirrors the behavior in CPython's `PC/pyconfig.h`.
+        if env::var_os("CARGO_FEATURE_ABI3").is_some() {
+            return "python3".to_string();
+        }
+
         let minor_or_empty_string = match version.minor {
             Some(minor) => format!("{}", minor),
             None => String::new(),

--- a/src/ffi/descrobject.rs
+++ b/src/ffi/descrobject.rs
@@ -1,6 +1,6 @@
 use crate::ffi::methodobject::PyMethodDef;
 use crate::ffi::object::{PyObject, PyTypeObject};
-#[cfg(not(PyPy))]
+#[cfg(all(not(PyPy), not(Py_LIMITED_API)))]
 use crate::ffi::object::{PyObject_GenericGetDict, PyObject_GenericSetDict};
 use crate::ffi::structmember::PyMemberDef;
 use std::os::raw::{c_char, c_int, c_void};
@@ -28,11 +28,12 @@ pub const PyGetSetDef_INIT: PyGetSetDef = PyGetSetDef {
     closure: ptr::null_mut(),
 };
 
-#[cfg(PyPy)]
+#[cfg(any(PyPy, Py_LIMITED_API))]
 pub const PyGetSetDef_DICT: PyGetSetDef = PyGetSetDef_INIT;
 
 // PyPy doesn't export neither PyObject_GenericGetDict/PyObject_GenericSetDict
-#[cfg(not(PyPy))]
+// Py_LIMITED_API exposes PyObject_GenericSetDict but not Get.
+#[cfg(all(not(PyPy), not(Py_LIMITED_API)))]
 pub const PyGetSetDef_DICT: PyGetSetDef = PyGetSetDef {
     name: "__dict__\0".as_ptr() as *mut c_char,
     get: Some(PyObject_GenericGetDict),

--- a/src/ffi/funcobject.rs
+++ b/src/ffi/funcobject.rs
@@ -4,10 +4,12 @@ use crate::ffi::object::{PyObject, PyTypeObject, Py_TYPE};
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
+    #[cfg(not(Py_LIMITED_API))]
     #[cfg_attr(PyPy, link_name = "PyPyFunction_Type")]
     pub static mut PyFunction_Type: PyTypeObject;
 }
 
+#[cfg(not(Py_LIMITED_API))]
 #[inline]
 pub unsafe fn PyFunction_Check(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyFunction_Type) as c_int

--- a/src/ffi/marshal.rs
+++ b/src/ffi/marshal.rs
@@ -1,6 +1,7 @@
 use super::PyObject;
 use std::os::raw::{c_char, c_int};
 
+#[cfg(not(Py_LIMITED_API))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyMarshal_WriteObjectToString")]
     pub fn PyMarshal_WriteObjectToString(object: *mut PyObject, version: c_int) -> *mut PyObject;

--- a/src/ffi/object.rs
+++ b/src/ffi/object.rs
@@ -716,6 +716,7 @@ extern "C" {
         arg2: *mut PyObject,
         arg3: *mut PyObject,
     ) -> c_int;
+    #[cfg(not(Py_LIMITED_API))]
     pub fn PyObject_GenericGetDict(arg1: *mut PyObject, arg2: *mut c_void) -> *mut PyObject;
     pub fn PyObject_GenericSetDict(
         arg1: *mut PyObject,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,7 @@ mod gil;
 mod instance;
 #[macro_use]
 mod internal_tricks;
+#[cfg(not(Py_LIMITED_API))]
 pub mod marshal;
 pub mod once_cell;
 pub mod panic;

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -1,3 +1,5 @@
+#![cfg(not(Py_LIMITED_API))]
+
 use crate::ffi;
 use crate::types::{PyAny, PyBytes};
 use crate::{AsPyPointer, FromPyPointer, PyResult, Python};

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -87,4 +87,5 @@ impl PyCFunction {
 #[repr(transparent)]
 pub struct PyFunction(PyAny);
 
+#[cfg(not(Py_LIMITED_API))]
 pyobject_native_var_type!(PyFunction, ffi::PyFunction_Type, ffi::PyFunction_Check);

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -1,7 +1,9 @@
 #[cfg(not(Py_LIMITED_API))]
 use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
-use pyo3::types::{PyCFunction, PyFunction};
+use pyo3::types::PyCFunction;
+#[cfg(not(Py_LIMITED_API))]
+use pyo3::types::PyFunction;
 use pyo3::{raw_pycfunction, wrap_pyfunction};
 
 mod common;
@@ -67,6 +69,7 @@ assert a, array.array("i", [2, 4, 6, 8])
     );
 }
 
+#[cfg(not(Py_LIMITED_API))]
 #[pyfunction]
 fn function_with_pyfunction_arg(fun: &PyFunction) -> PyResult<&PyAny> {
     fun.call((), None)
@@ -81,21 +84,31 @@ fn function_with_pycfunction_arg(fun: &PyCFunction) -> PyResult<&PyAny> {
 fn test_functions_with_function_args() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let py_func_arg = wrap_pyfunction!(function_with_pyfunction_arg)(py).unwrap();
     let py_cfunc_arg = wrap_pyfunction!(function_with_pycfunction_arg)(py).unwrap();
     let bool_to_string = wrap_pyfunction!(optional_bool)(py).unwrap();
 
     pyo3::py_run!(
         py,
-        py_func_arg
         py_cfunc_arg
         bool_to_string,
         r#"
-        def foo(): return "bar"
-        assert py_func_arg(foo) == "bar"
         assert py_cfunc_arg(bool_to_string) == "Some(true)"
         "#
-    )
+    );
+
+    #[cfg(not(Py_LIMITED_API))]
+    {
+        let py_func_arg = wrap_pyfunction!(function_with_pyfunction_arg)(py).unwrap();
+
+        pyo3::py_run!(
+            py,
+            py_func_arg,
+            r#"
+            def foo(): return "bar"
+            assert py_func_arg(foo) == "bar"
+            "#
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Without this, on windows we'd link `python35.lib` (for example) which doesn't exist on other pythons of course :-)