### PR TITLE
Exclude PyPy CI for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
           { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc" },
         ]
         exclude:
-          # There is no 64-bit pypy on windows
+          # See https://github.com/PyO3/pyo3/pull/1215 for why.
           - python-version: pypy3
-            platform: { os: "windows-latest", python-architecture: "x64" }
+            platform: { os: "windows-latest" }
         include:
           # Test minimal supported Rust version
           - rust: 1.39.0

--- a/examples/rustapi_module/tox.ini
+++ b/examples/rustapi_module/tox.ini
@@ -3,7 +3,7 @@ envlist = py35,
           py36,
           py37,
           py38,
-          pypy36
+          pypy3
 minversion = 3.4.0
 skip_missing_interpreters = true
 isolated_build = true

--- a/examples/word-count/tox.ini
+++ b/examples/word-count/tox.ini
@@ -3,7 +3,7 @@ envlist = py35,
           py36,
           py37,
           py38,
-          pypy35
+          pypy3
 minversion = 3.4.0
 skip_missing_interpreters = true
 isolated_build = true


### PR DESCRIPTION
I don't know what to do but for now, push some changes *experimentally*.