### PR TITLE
Remove symbols that are removed in python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Removed
-- Remove unused `python3` feature. [#1209](https://github.com/PyO3/pyo3/pull/1209)
+- Remove deprecated ffi definitions `PyUnicode_AsUnicodeCopy`, `PyUnicode_GetMax`, `_Py_CheckRecursionLimit`, `PyObject_AsCharBuffer`, `PyObject_AsReadBuffer`, `PyObject_CheckReadBuffer` and `PyObject_AsWriteBuffer`, which will be removed in Python 3.10. [#1217](https://github.com/PyO3/pyo3/pull/1217)
+- Remove unused `python3` feature. [#1235](https://github.com/PyO3/pyo3/pull/1235)
 
 ## [0.12.3] - 2020-10-12
 ### Fixed
@@ -22,9 +23,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix invalid document for protocol methods. [#1169](https://github.com/PyO3/pyo3/pull/1169)
 - Hide docs of PyO3 private implementation details in `pyo3::class::methods`. [#1169](https://github.com/PyO3/pyo3/pull/1169)
 - Fix unnecessary rebuild on PATH changes when the python interpreter is provided by PYO3_PYTHON. [#1231](https://github.com/PyO3/pyo3/pull/1231)
-
-### Removed
-- Removed `PyUnicode_AsUnicodeCopy`, `PyUnicode_GetMax`, `_Py_CheckRecursionLimit`, `PyObject_AsCharBuffer`, `PyObject_AsReadBuffer`, `PyObject_CheckReadBuffer` and `PyObject_AsWriteBuffer` which have been removed in python 3.10
 
 ## [0.12.1] - 2020-09-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Hide docs of PyO3 private implementation details in `pyo3::class::methods`. [#1169](https://github.com/PyO3/pyo3/pull/1169)
 - Fix unnecessary rebuild on PATH changes when the python interpreter is provided by PYO3_PYTHON. [#1231](https://github.com/PyO3/pyo3/pull/1231)
 
+### Removed
+- Removed `PyUnicode_AsUnicodeCopy`, `PyUnicode_GetMax`, `_Py_CheckRecursionLimit`, `PyObject_AsCharBuffer`, `PyObject_AsReadBuffer`, `PyObject_CheckReadBuffer` and `PyObject_AsWriteBuffer` which have been removed in python 3.10
+
 ## [0.12.1] - 2020-09-16
 ### Fixed
 - Fix building for a 32-bit Python on 64-bit Windows with a 64-bit Rust toolchain. [#1179](https://github.com/PyO3/pyo3/pull/1179)

--- a/src/ffi/ceval.rs
+++ b/src/ffi/ceval.rs
@@ -49,11 +49,6 @@ extern "C" {
     fn _Py_CheckRecursiveCall(_where: *mut c_char) -> c_int;
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
-extern "C" {
-    static mut _Py_CheckRecursionLimit: c_int;
-}
-
 // TODO: Py_EnterRecursiveCall etc.
 #[cfg(Py_3_6)]
 pub type _PyFrameEvalFunction =

--- a/src/ffi/objectabstract.rs
+++ b/src/ffi/objectabstract.rs
@@ -71,26 +71,6 @@ extern "C" {
     pub fn PyObject_SetItem(o: *mut PyObject, key: *mut PyObject, v: *mut PyObject) -> c_int;
     pub fn PyObject_DelItemString(o: *mut PyObject, key: *const c_char) -> c_int;
     pub fn PyObject_DelItem(o: *mut PyObject, key: *mut PyObject) -> c_int;
-    #[cfg_attr(PyPy, link_name = "PyPyObject_AsCharBuffer")]
-    pub fn PyObject_AsCharBuffer(
-        obj: *mut PyObject,
-        buffer: *mut *const c_char,
-        buffer_len: *mut Py_ssize_t,
-    ) -> c_int;
-    #[cfg_attr(PyPy, link_name = "PyPyObject_CheckReadBuffer")]
-    pub fn PyObject_CheckReadBuffer(obj: *mut PyObject) -> c_int;
-    #[cfg_attr(PyPy, link_name = "PyPyObject_AsReadBuffer")]
-    pub fn PyObject_AsReadBuffer(
-        obj: *mut PyObject,
-        buffer: *mut *const c_void,
-        buffer_len: *mut Py_ssize_t,
-    ) -> c_int;
-    #[cfg_attr(PyPy, link_name = "PyPyObject_AsWriteBuffer")]
-    pub fn PyObject_AsWriteBuffer(
-        obj: *mut PyObject,
-        buffer: *mut *mut c_void,
-        buffer_len: *mut Py_ssize_t,
-    ) -> c_int;
 }
 
 #[cfg(not(Py_LIMITED_API))]

--- a/src/ffi/unicodeobject.rs
+++ b/src/ffi/unicodeobject.rs
@@ -96,9 +96,6 @@ extern "C" {
         index: Py_ssize_t,
         character: Py_UCS4,
     ) -> c_int;
-    #[cfg(not(Py_LIMITED_API))]
-    #[cfg_attr(PyPy, link_name = "PyPyUnicode_GetMax")]
-    pub fn PyUnicode_GetMax() -> Py_UNICODE;
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_Resize")]
     pub fn PyUnicode_Resize(unicode: *mut *mut PyObject, length: Py_ssize_t) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_FromEncodedObject")]
@@ -462,6 +459,4 @@ extern "C" {
     pub fn PyUnicode_Format(format: *mut PyObject, args: *mut PyObject) -> *mut PyObject;
     pub fn PyUnicode_Contains(container: *mut PyObject, element: *mut PyObject) -> c_int;
     pub fn PyUnicode_IsIdentifier(s: *mut PyObject) -> c_int;
-    #[cfg(not(Py_LIMITED_API))]
-    pub fn PyUnicode_AsUnicodeCopy(unicode: *mut PyObject) -> *mut Py_UNICODE;
 }


### PR DESCRIPTION
Those functions and variable are listed in https://docs.python.org/3.10/whatsnew/3.10.html#id4

