### PR TITLE
Release 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,15 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/master/migration
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.12.2] - 2020-10-12
 ### Added
 - Add support for keyword-only arguments without default values in `#[pyfunction]`. [#1209](https://github.com/PyO3/pyo3/pull/1209)
-- Add a wrapper for `PyErr_CheckSignals()` as `Python::check_signals()`. [#1214](https://github.com/PyO3/pyo3/pull/1214)
-
-### Changed
-- Fields of `PyMethodDef`, `PyGetterDef`, `PySetterDef`, and `PyClassAttributeDef` are now private. [#1169](https://github.com/PyO3/pyo3/pull/1169)
+- Add `Python::check_signals()` as a safe a wrapper for `PyErr_CheckSignals()`. [#1214](https://github.com/PyO3/pyo3/pull/1214)
 
 ### Fixed
 - Fix invalid document for protocol methods. [#1169](https://github.com/PyO3/pyo3/pull/1169)
+- Hide docs of PyO3 private implementation details in `pyo3::class::methods`. [#1169](https://github.com/PyO3/pyo3/pull/1169)
+- Fix unnecessary rebuild on PATH changes when the python interpreter is provided by PYO3_PYTHON. [#1231](https://github.com/PyO3/pyo3/pull/1231)
 
 ## [0.12.1] - 2020-09-16
 ### Fixed
@@ -512,7 +511,8 @@ Yanked
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.12.1...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.12.2...HEAD
+[0.12.2]: https://github.com/pyo3/pyo3/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/pyo3/pyo3/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/pyo3/pyo3/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/pyo3/pyo3/compare/v0.11.0...v0.11.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.12.1"
+version = "0.12.2"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -23,7 +23,7 @@ parking_lot = "0.11.0"
 num-bigint = { version = "0.3", optional = true }
 num-complex = { version = "0.3", optional = true }
 paste = { version = "1.0.1", optional = true }
-pyo3cls = { path = "pyo3cls", version = "=0.12.1", optional = true }
+pyo3cls = { path = "pyo3cls", version = "=0.12.2", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = "0.9", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.12.1"
+version = "0.12.2"
 features = ["extension-module"]
 ```
 
@@ -99,7 +99,7 @@ use it to run Python code, add `pyo3` to your `Cargo.toml` like this:
 
 ```toml
 [dependencies]
-pyo3 = "0.12.1"
+pyo3 = "0.12.2"
 ```
 
 Example program displaying the value of `sys.version` and the current user name:

--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-derive-backend"
-version = "0.12.1"
+version = "0.12.2"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3cls"
-version = "0.12.1"
+version = "0.12.2"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.12.1" }
+pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.12.2" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies.pyo3]
-//! version = "0.12.1"
+//! version = "0.12.2"
 //! features = ["extension-module"]
 //! ```
 //!
@@ -109,7 +109,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pyo3 = "0.12.1"
+//! pyo3 = "0.12.2"
 //! ```
 //!
 //! Example program displaying the value of `sys.version`:


### PR DESCRIPTION
As we've got a few breaking changes queueing up to merge like the abi3 branch and some other smaller tidy ups, this will be the final patch release for the PyO3 0.12 series.

If I don't hear any reason to wait on this release, I'll put it live this tomorrow evening. 