### PR TITLE
Use stable Python 3.9 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false  # If one platform fails, allow the rest to keep testing.
       matrix:
         rust: [stable]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9-dev, pypy3]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
         platform: [
           { os: "macOS-latest",   python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
@@ -59,7 +59,7 @@ jobs:
         include:
           # Test minimal supported Rust version
           - rust: 1.39.0
-            python-version: 3.8
+            python-version: 3.9
             platform: { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
             msrv: "MSRV"
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -49,7 +49,7 @@ Here are a few things to note when you are writing PRs.
 
 The PyO3 repo uses Github Actions. PRs are blocked from merging if CI is not successful.
 
-Formatting, linting and tests are checked for all Rust and Python code. Tests run with all supported Python versions with the latest stable Rust compiler, as well as for Python 3.8 with the minimum supported Rust version.
+Formatting, linting and tests are checked for all Rust and Python code. Tests run with all supported Python versions with the latest stable Rust compiler, as well as for Python 3.9 with the minimum supported Rust version.
 
 ### Minimum supported Rust version
 


### PR DESCRIPTION
Use released Python 3.9, add Python 3.10-dev, and remove Python 3.5.