### PR TITLE
Move impl From for Py<T> to macros not used in rust-numpy

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -72,15 +72,6 @@ macro_rules! pyobject_native_type_named (
                 unsafe { $crate::Py::from_borrowed_ptr(py, self.as_ptr()) }
             }
         }
-
-        impl<$($type_param,)*> From<&'_ $name> for $crate::Py<$name> {
-            #[inline]
-            fn from(other: &$name) -> Self {
-                use $crate::AsPyPointer;
-                use $crate::PyNativeType;
-                unsafe { $crate::Py::from_borrowed_ptr(other.py(), other.as_ptr()) }
-            }
-        }
     };
 );
 
@@ -95,6 +86,18 @@ macro_rules! pyobject_native_type_core {
         impl<'a, $($type_param,)*> ::std::convert::From<&'a $name> for &'a $crate::PyAny {
             fn from(ob: &'a $name) -> Self {
                 unsafe{&*(ob as *const $name as *const $crate::PyAny)}
+            }
+        }
+
+
+        // TODO: Rust>=1.40 allows this impl for rust-numpy.
+        // So we should move this to `named` or `convert` when we bump MSRV.
+        impl<$($type_param,)*> From<&'_ $name> for $crate::Py<$name> {
+            #[inline]
+            fn from(other: &$name) -> Self {
+                use $crate::AsPyPointer;
+                use $crate::PyNativeType;
+                unsafe { $crate::Py::from_borrowed_ptr(other.py(), other.as_ptr()) }
             }
         }
     }


### PR DESCRIPTION
Implementing this for `PyArray` is not allowed in older Rust.
Fixes https://github.com/PyO3/rust-numpy/issues/159.

I also remove `$(,$type_param: ident)*` from macros not used in rust-numpy.
