### PR TITLE
Don't watch PYTHON_SYS_EXECUTABLE and PATH when unnecessary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -893,16 +893,19 @@ fn main() -> Result<()> {
         // TODO: Find out how we can set -undefined dynamic_lookup here (if this is possible)
     }
 
-    let env_vars = [
-        "LD_LIBRARY_PATH",
-        "PATH",
-        "PYTHON_SYS_EXECUTABLE",
-        "PYO3_PYTHON",
-        "LIB",
-    ];
-
-    for var in env_vars.iter() {
+    for var in ["LIB", "LD_LIBRARY_PATH", "PYO3_PYTHON"].iter() {
         println!("cargo:rerun-if-env-changed={}", var);
+    }
+
+    if env::var_os("PYO3_PYTHON").is_none() {
+        // When PYO3_PYTHON is not used, PYTHON_SYS_EXECUTABLE has the highest priority.
+        // Let's watch it.
+        println!("cargo:rerun-if-env-changed=PYTHON_SYS_EXECUTABLE");
+        if env::var_os("PYTHON_SYS_EXECUTABLE").is_none() {
+            // When PYTHON_SYS_EXECUTABLE is also not used, then we use PATH.
+            // Let's watch this, too.
+            println!("cargo:rerun-if-env-changed=PATH");
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Fixes #1229. 
I confirmed that this works manually, though it's better if @nikhilmitrax can check this.