### PR TITLE
Fix MSRV CI to correctly use MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,26 +78,25 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.platform.rust-target }}
           profile: minimal
+          default: true
 
       - if: matrix.platform.os == 'ubuntu-latest'
         name: Prepare LD_LIBRARY_PATH (Ubuntu only)
-        run: echo LD_LIBRARY_PATH=${pythonLocation}/lib > $GITHUB_ENV
-
-      - run: rustup set default-host ${{ matrix.platform.rust-target }}
+        run: echo LD_LIBRARY_PATH=${pythonLocation}/lib >> $GITHUB_ENV
 
       - name: Build without default features
-        run: cargo build --no-default-features --verbose
+        run: cargo build --no-default-features --verbose --target ${{ matrix.platform.rust-target }}
 
       - name: Build with default features
-        run: cargo build --features "num-bigint num-complex" --verbose
+        run: cargo build --features "num-bigint num-complex" --verbose --target ${{ matrix.platform.rust-target }}
 
       # Run tests (except on PyPy, because no embedding API).
       - if: matrix.python-version != 'pypy3'
         name: Test
-        run: cargo test --features "num-bigint num-complex"
+        run: cargo test --features "num-bigint num-complex" --target ${{ matrix.platform.rust-target }}
 
       - name: Test proc-macro code
-        run: cargo test --manifest-path=pyo3-derive-backend/Cargo.toml
+        run: cargo test --manifest-path=pyo3-derive-backend/Cargo.toml --target ${{ matrix.platform.rust-target }}
 
       - name: Install python test dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/master/migration
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fix support for Rust versions 1.39 to 1.44, broken by an incorrect internal update to paste 1.0 which was done in PyO3 0.12.2. [#1234](https://github.com/PyO3/pyo3/pull/1234)
+
 ## [0.12.2] - 2020-10-12
 ### Added
 - Add support for keyword-only arguments without default values in `#[pyfunction]`. [#1209](https://github.com/PyO3/pyo3/pull/1209)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ libc = "0.2.62"
 parking_lot = "0.11.0"
 num-bigint = { version = "0.3", optional = true }
 num-complex = { version = "0.3", optional = true }
-paste = { version = "1.0.1", optional = true }
+paste = { version = "0.1.6", optional = true }
 pyo3cls = { path = "pyo3cls", version = "=0.12.2", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = "0.9", optional = true }

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -2,7 +2,6 @@
 #[test]
 fn test_compile_errors() {
     let t = trybuild::TestCases::new();
-    t.compile_fail("tests/ui/invalid_frompy_derive.rs");
     t.compile_fail("tests/ui/invalid_macro_args.rs");
     t.compile_fail("tests/ui/invalid_need_module_arg_position.rs");
     t.compile_fail("tests/ui/invalid_property_args.rs");
@@ -23,6 +22,7 @@ fn test_compile_errors() {
 
     #[rustversion::since(1.46)]
     fn tests_rust_1_46(t: &trybuild::TestCases) {
+        t.compile_fail("tests/ui/invalid_frompy_derive.rs");
         t.compile_fail("tests/ui/invalid_pymethod_receiver.rs");
         t.compile_fail("tests/ui/invalid_result_conversion.rs");
         t.compile_fail("tests/ui/missing_clone.rs");


### PR DESCRIPTION
I think without this setting the specified Rust version does not become the default, and I think #1204 may have broken MSRV support 😢 