### PR TITLE
Renew #[pyproto] implementation for abi3 branch

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -772,13 +772,23 @@ impl pyo3::class::methods::HasMethodsInventory for MyClass {
 }
 pyo3::inventory::collect!(Pyo3MethodsInventoryForMyClass);
 
-impl pyo3::class::proto_methods::HasProtoRegistry for MyClass {
-    fn registry() -> &'static pyo3::class::proto_methods::PyProtoRegistry {
-        static REGISTRY: pyo3::class::proto_methods::PyProtoRegistry
-            = pyo3::class::proto_methods::PyProtoRegistry::new();
-        &REGISTRY
+
+pub struct Pyo3ProtoInventoryForMyClass {
+    def: pyo3::class::proto_methods::PyProtoMethodDef,
+}
+impl pyo3::class::proto_methods::PyProtoInventory for Pyo3ProtoInventoryForMyClass {
+    fn new(def: pyo3::class::proto_methods::PyProtoMethodDef) -> Self {
+        Self { def }
+    }
+    fn get(&'static self) -> &'static pyo3::class::proto_methods::PyProtoMethodDef {
+        &self.def
     }
 }
+impl pyo3::class::proto_methods::HasProtoInventory for MyClass {
+    type ProtoMethods = Pyo3ProtoInventoryForMyClass;
+}
+pyo3::inventory::collect!(Pyo3ProtoInventoryForMyClass);
+
 
 impl pyo3::pyclass::PyClassSend for MyClass {
     type ThreadChecker = pyo3::pyclass::ThreadCheckerStub<MyClass>;

--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -6,16 +6,14 @@ use std::collections::HashSet;
 pub struct Proto {
     /// The name of this protocol. E.g., Iter.
     pub name: &'static str,
-    /// The name of slot table. E.g., PyIterMethods.
-    pub slot_table: &'static str,
-    /// The name of the setter used to set the table to `PyProtoRegistry`.
-    pub set_slot_table: &'static str,
+    /// Extension trait that has `get_*` methods
+    pub extension_trait: &'static str,
     /// All methods.
     pub methods: &'static [MethodProto],
     /// All methods registered as normal methods like `#[pymethods]`.
     pub py_methods: &'static [PyMethod],
     /// All methods registered to the slot table.
-    slot_setters: &'static [SlotSetter],
+    slot_getters: &'static [SlotGetter],
 }
 
 impl Proto {
@@ -32,13 +30,13 @@ impl Proto {
         self.py_methods.iter().find(|m| query == m.name)
     }
     // Since the order matters, we expose only the iterator instead of the slice.
-    pub(crate) fn setters(
+    pub(crate) fn slot_getters(
         &self,
         mut implemented_protocols: HashSet<String>,
     ) -> impl Iterator<Item = &'static str> {
-        self.slot_setters.iter().filter_map(move |setter| {
+        self.slot_getters.iter().filter_map(move |getter| {
             // If any required method is not implemented, we skip this setter.
-            if setter
+            if getter
                 .proto_names
                 .iter()
                 .any(|name| !implemented_protocols.contains(*name))
@@ -47,10 +45,10 @@ impl Proto {
             }
             // To use 'paired' setter in priority, we remove used protocols.
             // For example, if set_add_radd is already used, we shouldn't use set_add and set_radd.
-            for name in setter.proto_names {
+            for name in getter.proto_names {
                 implemented_protocols.remove(*name);
             }
-            Some(setter.set_function)
+            Some(getter.get_function)
         })
     }
 }
@@ -82,27 +80,26 @@ impl PyMethod {
 }
 
 /// Represents a setter used to register a method to the method table.
-struct SlotSetter {
+struct SlotGetter {
     /// Protocols necessary for invoking this setter.
     /// E.g., we need `__setattr__` and `__delattr__` for invoking `set_setdelitem`.
     pub proto_names: &'static [&'static str],
     /// The name of the setter called to the method table.
-    pub set_function: &'static str,
+    pub get_function: &'static str,
 }
 
-impl SlotSetter {
-    const fn new(names: &'static [&'static str], set_function: &'static str) -> Self {
-        SlotSetter {
+impl SlotGetter {
+    const fn new(names: &'static [&'static str], get_function: &'static str) -> Self {
+        SlotGetter {
             proto_names: names,
-            set_function,
+            get_function,
         }
     }
 }
 
 pub const OBJECT: Proto = Proto {
     name: "Object",
-    slot_table: "pyo3::class::basic::PyObjectMethods",
-    set_slot_table: "set_basic_methods",
+    extension_trait: "pyo3::class::basic::PyBasicSlots",
     methods: &[
         MethodProto::Binary {
             name: "__getattr__",
@@ -156,23 +153,22 @@ pub const OBJECT: Proto = Proto {
         PyMethod::new("__bytes__", "pyo3::class::basic::BytesProtocolImpl"),
         PyMethod::new("__unicode__", "pyo3::class::basic::UnicodeProtocolImpl"),
     ],
-    slot_setters: &[
-        SlotSetter::new(&["__str__"], "set_str"),
-        SlotSetter::new(&["__repr__"], "set_repr"),
-        SlotSetter::new(&["__hash__"], "set_hash"),
-        SlotSetter::new(&["__getattr__"], "set_getattr"),
-        SlotSetter::new(&["__richcmp__"], "set_richcompare"),
-        SlotSetter::new(&["__setattr__", "__delattr__"], "set_setdelattr"),
-        SlotSetter::new(&["__setattr__"], "set_setattr"),
-        SlotSetter::new(&["__delattr__"], "set_delattr"),
-        SlotSetter::new(&["__bool__"], "set_bool"),
+    slot_getters: &[
+        SlotGetter::new(&["__str__"], "get_str"),
+        SlotGetter::new(&["__repr__"], "get_repr"),
+        SlotGetter::new(&["__hash__"], "get_hash"),
+        SlotGetter::new(&["__getattr__"], "get_getattr"),
+        SlotGetter::new(&["__richcmp__"], "get_richcompare"),
+        SlotGetter::new(&["__setattr__", "__delattr__"], "get_setdelattr"),
+        SlotGetter::new(&["__setattr__"], "get_setattr"),
+        SlotGetter::new(&["__delattr__"], "get_delattr"),
+        SlotGetter::new(&["__bool__"], "get_bool"),
     ],
 };
 
 pub const ASYNC: Proto = Proto {
     name: "Async",
-    slot_table: "pyo3::class::pyasync::PyAsyncMethods",
-    set_slot_table: "set_async_methods",
+    extension_trait: "pyo3::class::pyasync::PyAsyncSlots",
     methods: &[
         MethodProto::UnaryS {
             name: "__await__",
@@ -211,17 +207,16 @@ pub const ASYNC: Proto = Proto {
             "pyo3::class::pyasync::PyAsyncAexitProtocolImpl",
         ),
     ],
-    slot_setters: &[
-        SlotSetter::new(&["__await__"], "set_await"),
-        SlotSetter::new(&["__aiter__"], "set_aiter"),
-        SlotSetter::new(&["__anext__"], "set_anext"),
+    slot_getters: &[
+        SlotGetter::new(&["__await__"], "get_await"),
+        SlotGetter::new(&["__aiter__"], "get_aiter"),
+        SlotGetter::new(&["__anext__"], "get_anext"),
     ],
 };
 
 pub const BUFFER: Proto = Proto {
     name: "Buffer",
-    slot_table: "pyo3::class::buffer::PyBufferProcs",
-    set_slot_table: "set_buffer_methods",
+    extension_trait: "pyo3::class::buffer::PyBufferSlots",
     methods: &[
         MethodProto::Unary {
             name: "bf_getbuffer",
@@ -233,16 +228,15 @@ pub const BUFFER: Proto = Proto {
         },
     ],
     py_methods: &[],
-    slot_setters: &[
-        SlotSetter::new(&["bf_getbuffer"], "set_getbuffer"),
-        SlotSetter::new(&["bf_releasebuffer"], "set_releasebuffer"),
+    slot_getters: &[
+        SlotGetter::new(&["bf_getbuffer"], "get_getbuffer"),
+        SlotGetter::new(&["bf_releasebuffer"], "get_releasebuffer"),
     ],
 };
 
 pub const CONTEXT: Proto = Proto {
     name: "Context",
-    slot_table: "",
-    set_slot_table: "",
+    extension_trait: "",
     methods: &[
         MethodProto::Unary {
             name: "__enter__",
@@ -266,13 +260,12 @@ pub const CONTEXT: Proto = Proto {
             "pyo3::class::context::PyContextExitProtocolImpl",
         ),
     ],
-    slot_setters: &[],
+    slot_getters: &[],
 };
 
 pub const GC: Proto = Proto {
     name: "GC",
-    slot_table: "pyo3::class::gc::PyGCMethods",
-    set_slot_table: "set_gc_methods",
+    extension_trait: "pyo3::class::gc::PyGCSlots",
     methods: &[
         MethodProto::Free {
             name: "__traverse__",
@@ -284,16 +277,15 @@ pub const GC: Proto = Proto {
         },
     ],
     py_methods: &[],
-    slot_setters: &[
-        SlotSetter::new(&["__traverse__"], "set_traverse"),
-        SlotSetter::new(&["__clear__"], "set_clear"),
+    slot_getters: &[
+        SlotGetter::new(&["__traverse__"], "get_traverse"),
+        SlotGetter::new(&["__clear__"], "get_clear"),
     ],
 };
 
 pub const DESCR: Proto = Proto {
     name: "Descriptor",
-    slot_table: "pyo3::class::descr::PyDescrMethods",
-    set_slot_table: "set_descr_methods",
+    extension_trait: "pyo3::class::descr::PyDescrSlots",
     methods: &[
         MethodProto::TernaryS {
             name: "__get__",
@@ -327,16 +319,15 @@ pub const DESCR: Proto = Proto {
             "pyo3::class::context::PyDescrNameProtocolImpl",
         ),
     ],
-    slot_setters: &[
-        SlotSetter::new(&["__get__"], "set_descr_get"),
-        SlotSetter::new(&["__set__"], "set_descr_set"),
+    slot_getters: &[
+        SlotGetter::new(&["__get__"], "get_descr_get"),
+        SlotGetter::new(&["__set__"], "get_descr_set"),
     ],
 };
 
 pub const ITER: Proto = Proto {
     name: "Iter",
-    slot_table: "pyo3::class::iter::PyIterMethods",
-    set_slot_table: "set_iter_methods",
+    extension_trait: "pyo3::class::iter::PyIterSlots",
     py_methods: &[],
     methods: &[
         MethodProto::UnaryS {
@@ -350,16 +341,15 @@ pub const ITER: Proto = Proto {
             proto: "pyo3::class::iter::PyIterNextProtocol",
         },
     ],
-    slot_setters: &[
-        SlotSetter::new(&["__iter__"], "set_iter"),
-        SlotSetter::new(&["__next__"], "set_iternext"),
+    slot_getters: &[
+        SlotGetter::new(&["__iter__"], "get_iter"),
+        SlotGetter::new(&["__next__"], "get_iternext"),
     ],
 };
 
 pub const MAPPING: Proto = Proto {
     name: "Mapping",
-    slot_table: "pyo3::class::mapping::PyMappingMethods",
-    set_slot_table: "set_mapping_methods",
+    extension_trait: "pyo3::class::mapping::PyMappingSlots",
     methods: &[
         MethodProto::Unary {
             name: "__len__",
@@ -390,19 +380,18 @@ pub const MAPPING: Proto = Proto {
         "__reversed__",
         "pyo3::class::mapping::PyMappingReversedProtocolImpl",
     )],
-    slot_setters: &[
-        SlotSetter::new(&["__len__"], "set_length"),
-        SlotSetter::new(&["__getitem__"], "set_getitem"),
-        SlotSetter::new(&["__setitem__", "__delitem__"], "set_setdelitem"),
-        SlotSetter::new(&["__setitem__"], "set_setitem"),
-        SlotSetter::new(&["__delitem__"], "set_delitem"),
+    slot_getters: &[
+        SlotGetter::new(&["__len__"], "get_length"),
+        SlotGetter::new(&["__getitem__"], "get_getitem"),
+        SlotGetter::new(&["__setitem__", "__delitem__"], "get_setdelitem"),
+        SlotGetter::new(&["__setitem__"], "get_setitem"),
+        SlotGetter::new(&["__delitem__"], "get_delitem"),
     ],
 };
 
 pub const SEQ: Proto = Proto {
     name: "Sequence",
-    slot_table: "pyo3::class::sequence::PySequenceMethods",
-    set_slot_table: "set_sequence_methods",
+    extension_trait: "pyo3::class::sequence::PySequenceSlots",
     methods: &[
         MethodProto::Unary {
             name: "__len__",
@@ -451,24 +440,23 @@ pub const SEQ: Proto = Proto {
         },
     ],
     py_methods: &[],
-    slot_setters: &[
-        SlotSetter::new(&["__len__"], "set_len"),
-        SlotSetter::new(&["__concat__"], "set_concat"),
-        SlotSetter::new(&["__repeat__"], "set_repeat"),
-        SlotSetter::new(&["__getitem__"], "set_getitem"),
-        SlotSetter::new(&["__setitem__", "__delitem__"], "set_setdelitem"),
-        SlotSetter::new(&["__setitem__"], "set_setitem"),
-        SlotSetter::new(&["__delitem__"], "set_delitem"),
-        SlotSetter::new(&["__contains__"], "set_contains"),
-        SlotSetter::new(&["__inplace_concat__"], "set_inplace_concat"),
-        SlotSetter::new(&["__inplace_repeat__"], "set_inplace_repeat"),
+    slot_getters: &[
+        SlotGetter::new(&["__len__"], "get_len"),
+        SlotGetter::new(&["__concat__"], "get_concat"),
+        SlotGetter::new(&["__repeat__"], "get_repeat"),
+        SlotGetter::new(&["__getitem__"], "get_getitem"),
+        SlotGetter::new(&["__setitem__", "__delitem__"], "get_setdelitem"),
+        SlotGetter::new(&["__setitem__"], "get_setitem"),
+        SlotGetter::new(&["__delitem__"], "get_delitem"),
+        SlotGetter::new(&["__contains__"], "get_contains"),
+        SlotGetter::new(&["__inplace_concat__"], "get_inplace_concat"),
+        SlotGetter::new(&["__inplace_repeat__"], "get_inplace_repeat"),
     ],
 };
 
 pub const NUM: Proto = Proto {
     name: "Number",
-    slot_table: "pyo3::class::number::PyNumberMethods",
-    set_slot_table: "set_number_methods",
+    extension_trait: "pyo3::class::number::PyNumberSlots",
     methods: &[
         MethodProto::BinaryS {
             name: "__add__",
@@ -771,66 +759,66 @@ pub const NUM: Proto = Proto {
             "pyo3::class::number::PyNumberRoundProtocolImpl",
         ),
     ],
-    slot_setters: &[
-        SlotSetter::new(&["__add__", "__radd__"], "set_add_radd"),
-        SlotSetter::new(&["__add__"], "set_add"),
-        SlotSetter::new(&["__radd__"], "set_radd"),
-        SlotSetter::new(&["__sub__", "__rsub__"], "set_sub_rsub"),
-        SlotSetter::new(&["__sub__"], "set_sub"),
-        SlotSetter::new(&["__rsub__"], "set_rsub"),
-        SlotSetter::new(&["__mul__", "__rmul__"], "set_mul_rmul"),
-        SlotSetter::new(&["__mul__"], "set_mul"),
-        SlotSetter::new(&["__rmul__"], "set_rmul"),
-        SlotSetter::new(&["__mod__"], "set_mod"),
-        SlotSetter::new(&["__divmod__", "__rdivmod__"], "set_divmod_rdivmod"),
-        SlotSetter::new(&["__divmod__"], "set_divmod"),
-        SlotSetter::new(&["__rdivmod__"], "set_rdivmod"),
-        SlotSetter::new(&["__pow__", "__rpow__"], "set_pow_rpow"),
-        SlotSetter::new(&["__pow__"], "set_pow"),
-        SlotSetter::new(&["__rpow__"], "set_rpow"),
-        SlotSetter::new(&["__neg__"], "set_neg"),
-        SlotSetter::new(&["__pos__"], "set_pos"),
-        SlotSetter::new(&["__abs__"], "set_abs"),
-        SlotSetter::new(&["__invert__"], "set_invert"),
-        SlotSetter::new(&["__lshift__", "__rlshift__"], "set_lshift_rlshift"),
-        SlotSetter::new(&["__lshift__"], "set_lshift"),
-        SlotSetter::new(&["__rlshift__"], "set_rlshift"),
-        SlotSetter::new(&["__rshift__", "__rrshift__"], "set_rshift_rrshift"),
-        SlotSetter::new(&["__rshift__"], "set_rshift"),
-        SlotSetter::new(&["__rrshift__"], "set_rrshift"),
-        SlotSetter::new(&["__and__", "__rand__"], "set_and_rand"),
-        SlotSetter::new(&["__and__"], "set_and"),
-        SlotSetter::new(&["__rand__"], "set_rand"),
-        SlotSetter::new(&["__xor__", "__rxor__"], "set_xor_rxor"),
-        SlotSetter::new(&["__xor__"], "set_xor"),
-        SlotSetter::new(&["__rxor__"], "set_rxor"),
-        SlotSetter::new(&["__or__", "__ror__"], "set_or_ror"),
-        SlotSetter::new(&["__or__"], "set_or"),
-        SlotSetter::new(&["__ror__"], "set_ror"),
-        SlotSetter::new(&["__int__"], "set_int"),
-        SlotSetter::new(&["__float__"], "set_float"),
-        SlotSetter::new(&["__iadd__"], "set_iadd"),
-        SlotSetter::new(&["__isub__"], "set_isub"),
-        SlotSetter::new(&["__imul__"], "set_imul"),
-        SlotSetter::new(&["__imod__"], "set_imod"),
-        SlotSetter::new(&["__ipow__"], "set_ipow"),
-        SlotSetter::new(&["__ilshift__"], "set_ilshift"),
-        SlotSetter::new(&["__irshift__"], "set_irshift"),
-        SlotSetter::new(&["__iand__"], "set_iand"),
-        SlotSetter::new(&["__ixor__"], "set_ixor"),
-        SlotSetter::new(&["__ior__"], "set_ior"),
-        SlotSetter::new(&["__floordiv__", "__rfloordiv__"], "set_floordiv_rfloordiv"),
-        SlotSetter::new(&["__floordiv__"], "set_floordiv"),
-        SlotSetter::new(&["__rfloordiv__"], "set_rfloordiv"),
-        SlotSetter::new(&["__truediv__", "__rtruediv__"], "set_truediv_rtruediv"),
-        SlotSetter::new(&["__truediv__"], "set_truediv"),
-        SlotSetter::new(&["__rtruediv__"], "set_rtruediv"),
-        SlotSetter::new(&["__ifloordiv__"], "set_ifloordiv"),
-        SlotSetter::new(&["__itruediv__"], "set_itruediv"),
-        SlotSetter::new(&["__index__"], "set_index"),
-        SlotSetter::new(&["__matmul__", "__rmatmul__"], "set_matmul_rmatmul"),
-        SlotSetter::new(&["__matmul__"], "set_matmul"),
-        SlotSetter::new(&["__rmatmul__"], "set_rmatmul"),
-        SlotSetter::new(&["__imatmul__"], "set_imatmul"),
+    slot_getters: &[
+        SlotGetter::new(&["__add__", "__radd__"], "get_add_radd"),
+        SlotGetter::new(&["__add__"], "get_add"),
+        SlotGetter::new(&["__radd__"], "get_radd"),
+        SlotGetter::new(&["__sub__", "__rsub__"], "get_sub_rsub"),
+        SlotGetter::new(&["__sub__"], "get_sub"),
+        SlotGetter::new(&["__rsub__"], "get_rsub"),
+        SlotGetter::new(&["__mul__", "__rmul__"], "get_mul_rmul"),
+        SlotGetter::new(&["__mul__"], "get_mul"),
+        SlotGetter::new(&["__rmul__"], "get_rmul"),
+        SlotGetter::new(&["__mod__"], "get_mod"),
+        SlotGetter::new(&["__divmod__", "__rdivmod__"], "get_divmod_rdivmod"),
+        SlotGetter::new(&["__divmod__"], "get_divmod"),
+        SlotGetter::new(&["__rdivmod__"], "get_rdivmod"),
+        SlotGetter::new(&["__pow__", "__rpow__"], "get_pow_rpow"),
+        SlotGetter::new(&["__pow__"], "get_pow"),
+        SlotGetter::new(&["__rpow__"], "get_rpow"),
+        SlotGetter::new(&["__neg__"], "get_neg"),
+        SlotGetter::new(&["__pos__"], "get_pos"),
+        SlotGetter::new(&["__abs__"], "get_abs"),
+        SlotGetter::new(&["__invert__"], "get_invert"),
+        SlotGetter::new(&["__lshift__", "__rlshift__"], "get_lshift_rlshift"),
+        SlotGetter::new(&["__lshift__"], "get_lshift"),
+        SlotGetter::new(&["__rlshift__"], "get_rlshift"),
+        SlotGetter::new(&["__rshift__", "__rrshift__"], "get_rshift_rrshift"),
+        SlotGetter::new(&["__rshift__"], "get_rshift"),
+        SlotGetter::new(&["__rrshift__"], "get_rrshift"),
+        SlotGetter::new(&["__and__", "__rand__"], "get_and_rand"),
+        SlotGetter::new(&["__and__"], "get_and"),
+        SlotGetter::new(&["__rand__"], "get_rand"),
+        SlotGetter::new(&["__xor__", "__rxor__"], "get_xor_rxor"),
+        SlotGetter::new(&["__xor__"], "get_xor"),
+        SlotGetter::new(&["__rxor__"], "get_rxor"),
+        SlotGetter::new(&["__or__", "__ror__"], "get_or_ror"),
+        SlotGetter::new(&["__or__"], "get_or"),
+        SlotGetter::new(&["__ror__"], "get_ror"),
+        SlotGetter::new(&["__int__"], "get_int"),
+        SlotGetter::new(&["__float__"], "get_float"),
+        SlotGetter::new(&["__iadd__"], "get_iadd"),
+        SlotGetter::new(&["__isub__"], "get_isub"),
+        SlotGetter::new(&["__imul__"], "get_imul"),
+        SlotGetter::new(&["__imod__"], "get_imod"),
+        SlotGetter::new(&["__ipow__"], "get_ipow"),
+        SlotGetter::new(&["__ilshift__"], "get_ilshift"),
+        SlotGetter::new(&["__irshift__"], "get_irshift"),
+        SlotGetter::new(&["__iand__"], "get_iand"),
+        SlotGetter::new(&["__ixor__"], "get_ixor"),
+        SlotGetter::new(&["__ior__"], "get_ior"),
+        SlotGetter::new(&["__floordiv__", "__rfloordiv__"], "get_floordiv_rfloordiv"),
+        SlotGetter::new(&["__floordiv__"], "get_floordiv"),
+        SlotGetter::new(&["__rfloordiv__"], "get_rfloordiv"),
+        SlotGetter::new(&["__truediv__", "__rtruediv__"], "get_truediv_rtruediv"),
+        SlotGetter::new(&["__truediv__"], "get_truediv"),
+        SlotGetter::new(&["__rtruediv__"], "get_rtruediv"),
+        SlotGetter::new(&["__ifloordiv__"], "get_ifloordiv"),
+        SlotGetter::new(&["__itruediv__"], "get_itruediv"),
+        SlotGetter::new(&["__index__"], "get_index"),
+        SlotGetter::new(&["__matmul__", "__rmatmul__"], "get_matmul_rmatmul"),
+        SlotGetter::new(&["__matmul__"], "get_matmul"),
+        SlotGetter::new(&["__rmatmul__"], "get_rmatmul"),
+        SlotGetter::new(&["__imatmul__"], "get_imatmul"),
     ],
 };

--- a/pyo3-derive-backend/src/defs.rs
+++ b/pyo3-derive-backend/src/defs.rs
@@ -158,7 +158,7 @@ pub const OBJECT: Proto = Proto {
         SlotGetter::new(&["__repr__"], "get_repr"),
         SlotGetter::new(&["__hash__"], "get_hash"),
         SlotGetter::new(&["__getattr__"], "get_getattr"),
-        SlotGetter::new(&["__richcmp__"], "get_richcompare"),
+        SlotGetter::new(&["__richcmp__"], "get_richcmp"),
         SlotGetter::new(&["__setattr__", "__delattr__"], "get_setdelattr"),
         SlotGetter::new(&["__setattr__"], "get_setattr"),
         SlotGetter::new(&["__delattr__"], "get_delattr"),
@@ -381,7 +381,7 @@ pub const MAPPING: Proto = Proto {
         "pyo3::class::mapping::PyMappingReversedProtocolImpl",
     )],
     slot_getters: &[
-        SlotGetter::new(&["__len__"], "get_length"),
+        SlotGetter::new(&["__len__"], "get_len"),
         SlotGetter::new(&["__getitem__"], "get_getitem"),
         SlotGetter::new(&["__setitem__", "__delitem__"], "get_setdelitem"),
         SlotGetter::new(&["__setitem__"], "get_setitem"),

--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -138,7 +138,7 @@ fn submit_protocol_methods(
         return Ok(quote! {});
     }
     let ext_trait: syn::Path = syn::parse_str(proto.extension_trait)?;
-    let mut tokens: Vec<TokenStream> = vec![];
+    let mut tokens = vec![];
     if proto.name == "Buffer" {
         // For buffer, we construct `PyProtoMethods` from PyBufferProcs
         tokens.push(quote! {
@@ -154,9 +154,12 @@ fn submit_protocol_methods(
         tokens.push(quote! { let mut proto_methods = vec![]; });
         for getter in proto.slot_getters(method_names) {
             let get = syn::Ident::new(getter, Span::call_site());
-            tokens.push(quote! { proto_methods.push(<#ty as #ext_trait>::#get()); });
+            tokens.push(quote! {
+                let slot = <#ty as #ext_trait>::#get();
+                proto_methods.push(pyo3::ffi::PyType_Slot { slot: slot.0, pfunc: slot.1 as _ });
+            });
         }
-    }
+    };
     if tokens.len() <= 1 {
         return Ok(quote! {});
     }

--- a/src/class/basic.rs
+++ b/src/class/basic.rs
@@ -181,7 +181,7 @@ pub trait PyBasicSlots {
         Self: for<'p> PyObjectRichcmpProtocol<'p>,
     {
         ffi::PyType_Slot {
-            slot: ffi::Py_tp_getattro,
+            slot: ffi::Py_tp_richcompare,
             pfunc: tp_richcompare::<Self>() as _,
         }
     }

--- a/src/class/descr.rs
+++ b/src/class/descr.rs
@@ -8,6 +8,7 @@
 use crate::callback::IntoPyCallbackOutput;
 use crate::types::PyAny;
 use crate::{ffi, FromPyObject, PyClass, PyObject};
+use std::os::raw::c_int;
 
 /// Descriptor interface
 #[allow(unused_variables)]
@@ -88,7 +89,7 @@ pub trait PyDescrSlots {
     {
         ffi::PyType_Slot {
             slot: ffi::Py_tp_descr_set,
-            pfunc: py_ternarys_func!(PyDescrSetProtocol, Self::__set__) as _,
+            pfunc: py_ternarys_func!(PyDescrSetProtocol, Self::__set__, c_int) as _,
         }
     }
 }

--- a/src/class/descr.rs
+++ b/src/class/descr.rs
@@ -5,6 +5,7 @@
 //! [Python information](
 //! https://docs.python.org/3/reference/datamodel.html#implementing-descriptors)
 
+use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::types::PyAny;
 use crate::{ffi, FromPyObject, PyClass, PyObject};
@@ -73,24 +74,24 @@ pub trait PyDescrSetNameProtocol<'p>: PyDescrProtocol<'p> {
 /// Extension trait for our proc-macro backend.
 #[doc(hidden)]
 pub trait PyDescrSlots {
-    fn get_descr_get() -> ffi::PyType_Slot
+    fn get_descr_get() -> TypedSlot<ffi::descrgetfunc>
     where
         Self: for<'p> PyDescrGetProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_tp_descr_get,
-            pfunc: py_ternarys_func!(PyDescrGetProtocol, Self::__get__) as _,
-        }
+        TypedSlot(
+            ffi::Py_tp_descr_get,
+            py_ternarys_func!(PyDescrGetProtocol, Self::__get__),
+        )
     }
 
-    fn get_descr_set() -> ffi::PyType_Slot
+    fn get_descr_set() -> TypedSlot<ffi::descrsetfunc>
     where
         Self: for<'p> PyDescrSetProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_tp_descr_set,
-            pfunc: py_ternarys_func!(PyDescrSetProtocol, Self::__set__, c_int) as _,
-        }
+        TypedSlot(
+            ffi::Py_tp_descr_set,
+            py_ternarys_func!(PyDescrSetProtocol, Self::__set__, c_int),
+        )
     }
 }
 

--- a/src/class/descr.rs
+++ b/src/class/descr.rs
@@ -8,7 +8,6 @@
 use crate::callback::IntoPyCallbackOutput;
 use crate::types::PyAny;
 use crate::{ffi, FromPyObject, PyClass, PyObject};
-use std::os::raw::c_int;
 
 /// Descriptor interface
 #[allow(unused_variables)]
@@ -70,29 +69,28 @@ pub trait PyDescrSetNameProtocol<'p>: PyDescrProtocol<'p> {
     type Result: IntoPyCallbackOutput<()>;
 }
 
-/// All FFI functions for description protocols.
-#[derive(Default)]
-pub struct PyDescrMethods {
-    pub tp_descr_get: Option<ffi::descrgetfunc>,
-    pub tp_descr_set: Option<ffi::descrsetfunc>,
+/// Extension trait for our proc-macro backend.
+#[doc(hidden)]
+pub trait PyDescrSlots {
+    fn get_descr_get() -> ffi::PyType_Slot
+    where
+        Self: for<'p> PyDescrGetProtocol<'p>,
+    {
+        ffi::PyType_Slot {
+            slot: ffi::Py_tp_descr_get,
+            pfunc: py_ternarys_func!(PyDescrGetProtocol, Self::__get__) as _,
+        }
+    }
+
+    fn get_descr_set() -> ffi::PyType_Slot
+    where
+        Self: for<'p> PyDescrSetProtocol<'p>,
+    {
+        ffi::PyType_Slot {
+            slot: ffi::Py_tp_descr_set,
+            pfunc: py_ternarys_func!(PyDescrSetProtocol, Self::__set__) as _,
+        }
+    }
 }
 
-#[doc(hidden)]
-impl PyDescrMethods {
-    pub fn set_descr_get<T>(&mut self)
-    where
-        T: for<'p> PyDescrGetProtocol<'p>,
-    {
-        self.tp_descr_get = py_ternarys_func!(PyDescrGetProtocol, T::__get__);
-    }
-    pub fn set_descr_set<T>(&mut self)
-    where
-        T: for<'p> PyDescrSetProtocol<'p>,
-    {
-        self.tp_descr_set = py_ternarys_func!(PyDescrSetProtocol, T::__set__, c_int);
-    }
-    pub(crate) fn update_slots(&self, slots: &mut crate::pyclass::TypeSlots) {
-        slots.maybe_push(ffi::Py_tp_descr_get, self.tp_descr_get.map(|v| v as _));
-        slots.maybe_push(ffi::Py_tp_descr_set, self.tp_descr_set.map(|v| v as _));
-    }
-}
+impl<'p, T> PyDescrSlots for T where T: PyDescrProtocol<'p> {}

--- a/src/class/iter.rs
+++ b/src/class/iter.rs
@@ -2,6 +2,7 @@
 //! Python Iterator Interface.
 //! Trait and support implementation for implementing iterators
 
+use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::derive_utils::TryFromPyCell;
 use crate::err::PyResult;
@@ -74,23 +75,23 @@ pub trait PyIterNextProtocol<'p>: PyIterProtocol<'p> {
 /// Extension trait for proc-macro backend.
 #[doc(hidden)]
 pub trait PyIterSlots {
-    fn get_iter() -> ffi::PyType_Slot
+    fn get_iter() -> TypedSlot<ffi::getiterfunc>
     where
         Self: for<'p> PyIterIterProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_tp_iter,
-            pfunc: py_unarys_func!(PyIterIterProtocol, Self::__iter__) as _,
-        }
+        TypedSlot(
+            ffi::Py_tp_iter,
+            py_unarys_func!(PyIterIterProtocol, Self::__iter__),
+        )
     }
-    fn get_iternext() -> ffi::PyType_Slot
+    fn get_iternext() -> TypedSlot<ffi::iternextfunc>
     where
         Self: for<'p> PyIterNextProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_tp_iternext,
-            pfunc: py_unarys_func!(PyIterNextProtocol, Self::__next__) as _,
-        }
+        TypedSlot(
+            ffi::Py_tp_iternext,
+            py_unarys_func!(PyIterNextProtocol, Self::__next__),
+        )
     }
 }
 

--- a/src/class/mapping.rs
+++ b/src/class/mapping.rs
@@ -3,6 +3,7 @@
 //! Python Mapping Interface
 //! Trait and support implementation for implementing mapping support
 
+use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::{exceptions, ffi, FromPyObject, PyClass, PyObject};
 
@@ -75,60 +76,60 @@ pub trait PyMappingReversedProtocol<'p>: PyMappingProtocol<'p> {
 /// Extension trait for proc-macro backend.
 #[doc(hidden)]
 pub trait PyMappingSlots {
-    fn get_length() -> ffi::PyType_Slot
+    fn get_len() -> TypedSlot<ffi::lenfunc>
     where
         Self: for<'p> PyMappingLenProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_mp_length,
-            pfunc: py_len_func!(PyMappingLenProtocol, Self::__len__) as _,
-        }
+        TypedSlot(
+            ffi::Py_mp_length,
+            py_len_func!(PyMappingLenProtocol, Self::__len__),
+        )
     }
 
-    fn get_getitem() -> ffi::PyType_Slot
+    fn get_getitem() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyMappingGetItemProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_mp_subscript,
-            pfunc: py_binary_func!(PyMappingGetItemProtocol, Self::__getitem__) as _,
-        }
+        TypedSlot(
+            ffi::Py_mp_subscript,
+            py_binary_func!(PyMappingGetItemProtocol, Self::__getitem__),
+        )
     }
 
-    fn get_setitem() -> ffi::PyType_Slot
+    fn get_setitem() -> TypedSlot<ffi::objobjargproc>
     where
         Self: for<'p> PyMappingSetItemProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_mp_ass_subscript,
-            pfunc: py_func_set!(PyMappingSetItemProtocol, Self::__setitem__) as _,
-        }
+        TypedSlot(
+            ffi::Py_mp_ass_subscript,
+            py_func_set!(PyMappingSetItemProtocol, Self::__setitem__),
+        )
     }
 
-    fn get_delitem() -> ffi::PyType_Slot
+    fn get_delitem() -> TypedSlot<ffi::objobjargproc>
     where
         Self: for<'p> PyMappingDelItemProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_mp_ass_subscript,
-            pfunc: py_func_del!(PyMappingDelItemProtocol, Self::__delitem__) as _,
-        }
+        TypedSlot(
+            ffi::Py_mp_ass_subscript,
+            py_func_del!(PyMappingDelItemProtocol, Self::__delitem__),
+        )
     }
 
-    fn get_setdelitem() -> ffi::PyType_Slot
+    fn get_setdelitem() -> TypedSlot<ffi::objobjargproc>
     where
         Self: for<'p> PyMappingSetItemProtocol<'p> + for<'p> PyMappingDelItemProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_mp_ass_subscript,
-            pfunc: py_func_set_del!(
+        TypedSlot(
+            ffi::Py_mp_ass_subscript,
+            py_func_set_del!(
                 PyMappingSetItemProtocol,
                 PyMappingDelItemProtocol,
                 Self,
                 __setitem__,
                 __delitem__
-            ) as _,
-        }
+            ),
+        )
     }
 }
 

--- a/src/class/mapping.rs
+++ b/src/class/mapping.rs
@@ -6,17 +6,6 @@
 use crate::callback::IntoPyCallbackOutput;
 use crate::{exceptions, ffi, FromPyObject, PyClass, PyObject};
 
-#[cfg(Py_LIMITED_API)]
-#[derive(Clone, Default)]
-pub struct PyMappingMethods {
-    pub mp_length: Option<ffi::lenfunc>,
-    pub mp_subscript: Option<ffi::binaryfunc>,
-    pub mp_ass_subscript: Option<ffi::objobjargproc>,
-}
-
-#[cfg(not(Py_LIMITED_API))]
-pub use ffi::PyMappingMethods;
-
 /// Mapping interface
 #[allow(unused_variables)]
 pub trait PyMappingProtocol<'p>: PyClass {
@@ -83,50 +72,64 @@ pub trait PyMappingReversedProtocol<'p>: PyMappingProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
+/// Extension trait for proc-macro backend.
 #[doc(hidden)]
-impl PyMappingMethods {
-    pub fn set_length<T>(&mut self)
+pub trait PyMappingSlots {
+    fn get_length() -> ffi::PyType_Slot
     where
-        T: for<'p> PyMappingLenProtocol<'p>,
+        Self: for<'p> PyMappingLenProtocol<'p>,
     {
-        self.mp_length = py_len_func!(PyMappingLenProtocol, T::__len__);
+        ffi::PyType_Slot {
+            slot: ffi::Py_mp_length,
+            pfunc: py_len_func!(PyMappingLenProtocol, Self::__len__) as _,
+        }
     }
-    pub fn set_getitem<T>(&mut self)
+
+    fn get_getitem() -> ffi::PyType_Slot
     where
-        T: for<'p> PyMappingGetItemProtocol<'p>,
+        Self: for<'p> PyMappingGetItemProtocol<'p>,
     {
-        self.mp_subscript = py_binary_func!(PyMappingGetItemProtocol, T::__getitem__);
+        ffi::PyType_Slot {
+            slot: ffi::Py_mp_subscript,
+            pfunc: py_binary_func!(PyMappingGetItemProtocol, Self::__getitem__) as _,
+        }
     }
-    pub fn set_setitem<T>(&mut self)
+
+    fn get_setitem() -> ffi::PyType_Slot
     where
-        T: for<'p> PyMappingSetItemProtocol<'p>,
+        Self: for<'p> PyMappingSetItemProtocol<'p>,
     {
-        self.mp_ass_subscript = py_func_set!(PyMappingSetItemProtocol, T, __setitem__);
+        ffi::PyType_Slot {
+            slot: ffi::Py_mp_ass_subscript,
+            pfunc: py_func_set!(PyMappingSetItemProtocol, Self::__setitem__) as _,
+        }
     }
-    pub fn set_delitem<T>(&mut self)
+
+    fn get_delitem() -> ffi::PyType_Slot
     where
-        T: for<'p> PyMappingDelItemProtocol<'p>,
+        Self: for<'p> PyMappingDelItemProtocol<'p>,
     {
-        self.mp_ass_subscript = py_func_del!(PyMappingDelItemProtocol, T, __delitem__);
+        ffi::PyType_Slot {
+            slot: ffi::Py_mp_ass_subscript,
+            pfunc: py_func_del!(PyMappingDelItemProtocol, Self::__delitem__) as _,
+        }
     }
-    pub fn set_setdelitem<T>(&mut self)
+
+    fn get_setdelitem() -> ffi::PyType_Slot
     where
-        T: for<'p> PyMappingSetItemProtocol<'p> + for<'p> PyMappingDelItemProtocol<'p>,
+        Self: for<'p> PyMappingSetItemProtocol<'p> + for<'p> PyMappingDelItemProtocol<'p>,
     {
-        self.mp_ass_subscript = py_func_set_del!(
-            PyMappingSetItemProtocol,
-            PyMappingDelItemProtocol,
-            T,
-            __setitem__,
-            __delitem__
-        );
-    }
-    pub(crate) fn update_slots(&self, slots: &mut crate::pyclass::TypeSlots) {
-        slots.maybe_push(ffi::Py_mp_length, self.mp_length.map(|v| v as _));
-        slots.maybe_push(ffi::Py_mp_subscript, self.mp_subscript.map(|v| v as _));
-        slots.maybe_push(
-            ffi::Py_mp_ass_subscript,
-            self.mp_ass_subscript.map(|v| v as _),
-        );
+        ffi::PyType_Slot {
+            slot: ffi::Py_mp_ass_subscript,
+            pfunc: py_func_set_del!(
+                PyMappingSetItemProtocol,
+                PyMappingDelItemProtocol,
+                Self,
+                __setitem__,
+                __delitem__
+            ) as _,
+        }
     }
 }
+
+impl<'p, T> PyMappingSlots for T where T: PyMappingProtocol<'p> {}

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -825,17 +825,17 @@ pub trait PyNumberSlots {
         }
     }
 
-    fn get_pos<T>() -> ffi::PyType_Slot
+    fn get_pos() -> ffi::PyType_Slot
     where
         Self: for<'p> PyNumberPosProtocol<'p>,
     {
         ffi::PyType_Slot {
-            slot: ffi::Py_nb_absolute,
+            slot: ffi::Py_nb_positive,
             pfunc: py_unary_func!(PyNumberPosProtocol, Self::__pos__) as _,
         }
     }
 
-    fn get_abs<T>() -> ffi::PyType_Slot
+    fn get_abs() -> ffi::PyType_Slot
     where
         Self: for<'p> PyNumberAbsProtocol<'p>,
     {
@@ -845,7 +845,7 @@ pub trait PyNumberSlots {
         }
     }
 
-    fn get_invert<T>() -> ffi::PyType_Slot
+    fn get_invert() -> ffi::PyType_Slot
     where
         Self: for<'p> PyNumberInvertProtocol<'p>,
     {

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -2,6 +2,7 @@
 
 //! Python Number Interface
 //! Trait and support implementation for implementing number protocol
+use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::err::PyErr;
 use crate::{ffi, FromPyObject, PyClass, PyObject};
@@ -581,153 +582,153 @@ pub trait PyNumberIndexProtocol<'p>: PyNumberProtocol<'p> {
 /// Extension trait for proc-macro backend.
 #[doc(hidden)]
 pub trait PyNumberSlots {
-    fn get_add_radd() -> ffi::PyType_Slot
+    fn get_add_radd() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberAddProtocol<'p> + for<'p> PyNumberRAddProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_add,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_add,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberAddProtocol::__add__,
                 PyNumberRAddProtocol::__radd__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_add() -> ffi::PyType_Slot
+    fn get_add() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberAddProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_add,
-            pfunc: py_binary_num_func!(PyNumberAddProtocol, Self::__add__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_add,
+            py_binary_num_func!(PyNumberAddProtocol, Self::__add__),
+        )
     }
 
-    fn get_radd() -> ffi::PyType_Slot
+    fn get_radd() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRAddProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_add,
-            pfunc: py_binary_reversed_num_func!(PyNumberRAddProtocol, Self::__radd__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_add,
+            py_binary_reversed_num_func!(PyNumberRAddProtocol, Self::__radd__),
+        )
     }
 
-    fn get_sub_rsub() -> ffi::PyType_Slot
+    fn get_sub_rsub() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberSubProtocol<'p> + for<'p> PyNumberRSubProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_subtract,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_subtract,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberSubProtocol::__sub__,
                 PyNumberRSubProtocol::__rsub__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_sub() -> ffi::PyType_Slot
+    fn get_sub() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberSubProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_subtract,
-            pfunc: py_binary_num_func!(PyNumberSubProtocol, Self::__sub__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_subtract,
+            py_binary_num_func!(PyNumberSubProtocol, Self::__sub__),
+        )
     }
 
-    fn get_rsub() -> ffi::PyType_Slot
+    fn get_rsub() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRSubProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_subtract,
-            pfunc: py_binary_reversed_num_func!(PyNumberRSubProtocol, Self::__rsub__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_subtract,
+            py_binary_reversed_num_func!(PyNumberRSubProtocol, Self::__rsub__),
+        )
     }
 
-    fn get_mul_rmul() -> ffi::PyType_Slot
+    fn get_mul_rmul() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberMulProtocol<'p> + for<'p> PyNumberRMulProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_multiply,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_multiply,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberMulProtocol::__mul__,
                 PyNumberRMulProtocol::__rmul__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_mul() -> ffi::PyType_Slot
+    fn get_mul() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberMulProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_multiply,
-            pfunc: py_binary_num_func!(PyNumberMulProtocol, Self::__mul__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_multiply,
+            py_binary_num_func!(PyNumberMulProtocol, Self::__mul__),
+        )
     }
 
-    fn get_rmul() -> ffi::PyType_Slot
+    fn get_rmul() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRMulProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_multiply,
-            pfunc: py_binary_reversed_num_func!(PyNumberRMulProtocol, Self::__rmul__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_multiply,
+            py_binary_reversed_num_func!(PyNumberRMulProtocol, Self::__rmul__),
+        )
     }
 
-    fn get_mod() -> ffi::PyType_Slot
+    fn get_mod() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberModProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_remainder,
-            pfunc: py_binary_num_func!(PyNumberModProtocol, Self::__mod__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_remainder,
+            py_binary_num_func!(PyNumberModProtocol, Self::__mod__),
+        )
     }
 
-    fn get_divmod_rdivmod() -> ffi::PyType_Slot
+    fn get_divmod_rdivmod() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberDivmodProtocol<'p> + for<'p> PyNumberRDivmodProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_divmod,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_divmod,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberDivmodProtocol::__divmod__,
                 PyNumberRDivmodProtocol::__rdivmod__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_divmod() -> ffi::PyType_Slot
+    fn get_divmod() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberDivmodProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_divmod,
-            pfunc: py_binary_num_func!(PyNumberDivmodProtocol, Self::__divmod__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_divmod,
+            py_binary_num_func!(PyNumberDivmodProtocol, Self::__divmod__),
+        )
     }
 
-    fn get_rdivmod() -> ffi::PyType_Slot
+    fn get_rdivmod() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRDivmodProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_divmod,
-            pfunc: py_binary_reversed_num_func!(PyNumberRDivmodProtocol, Self::__rdivmod__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_divmod,
+            py_binary_reversed_num_func!(PyNumberRDivmodProtocol, Self::__rdivmod__),
+        )
     }
 
-    fn get_pow_rpow() -> ffi::PyType_Slot
+    fn get_pow_rpow() -> TypedSlot<ffi::ternaryfunc>
     where
         Self: for<'p> PyNumberPowProtocol<'p> + for<'p> PyNumberRPowProtocol<'p>,
     {
@@ -757,13 +758,10 @@ pub trait PyNumberSlots {
             })
         }
 
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_power,
-            pfunc: wrap_pow_and_rpow::<Self> as _,
-        }
+        TypedSlot(ffi::Py_nb_power, wrap_pow_and_rpow::<Self>)
     }
 
-    fn get_pow() -> ffi::PyType_Slot
+    fn get_pow() -> TypedSlot<ffi::ternaryfunc>
     where
         Self: for<'p> PyNumberPowProtocol<'p>,
     {
@@ -783,13 +781,10 @@ pub trait PyNumberSlots {
             })
         }
 
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_power,
-            pfunc: wrap_pow::<Self> as _,
-        }
+        TypedSlot(ffi::Py_nb_power, wrap_pow::<Self>)
     }
 
-    fn get_rpow() -> ffi::PyType_Slot
+    fn get_rpow() -> TypedSlot<ffi::ternaryfunc>
     where
         Self: for<'p> PyNumberRPowProtocol<'p>,
     {
@@ -809,283 +804,280 @@ pub trait PyNumberSlots {
             })
         }
 
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_power,
-            pfunc: wrap_rpow::<Self> as _,
-        }
+        TypedSlot(ffi::Py_nb_power, wrap_rpow::<Self>)
     }
 
-    fn get_neg() -> ffi::PyType_Slot
+    fn get_neg() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyNumberNegProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_negative,
-            pfunc: py_unary_func!(PyNumberNegProtocol, Self::__neg__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_negative,
+            py_unary_func!(PyNumberNegProtocol, Self::__neg__),
+        )
     }
 
-    fn get_pos() -> ffi::PyType_Slot
+    fn get_pos() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyNumberPosProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_positive,
-            pfunc: py_unary_func!(PyNumberPosProtocol, Self::__pos__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_positive,
+            py_unary_func!(PyNumberPosProtocol, Self::__pos__),
+        )
     }
 
-    fn get_abs() -> ffi::PyType_Slot
+    fn get_abs() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyNumberAbsProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_absolute,
-            pfunc: py_unary_func!(PyNumberAbsProtocol, Self::__abs__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_absolute,
+            py_unary_func!(PyNumberAbsProtocol, Self::__abs__),
+        )
     }
 
-    fn get_invert() -> ffi::PyType_Slot
+    fn get_invert() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyNumberInvertProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_invert,
-            pfunc: py_unary_func!(PyNumberInvertProtocol, Self::__invert__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_invert,
+            py_unary_func!(PyNumberInvertProtocol, Self::__invert__),
+        )
     }
 
-    fn get_lshift_rlshift() -> ffi::PyType_Slot
+    fn get_lshift_rlshift() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberLShiftProtocol<'p> + for<'p> PyNumberRLShiftProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_lshift,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_lshift,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberLShiftProtocol::__lshift__,
                 PyNumberRLShiftProtocol::__rlshift__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_lshift() -> ffi::PyType_Slot
+    fn get_lshift() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberLShiftProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_lshift,
-            pfunc: py_binary_num_func!(PyNumberLShiftProtocol, Self::__lshift__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_lshift,
+            py_binary_num_func!(PyNumberLShiftProtocol, Self::__lshift__),
+        )
     }
 
-    fn get_rlshift() -> ffi::PyType_Slot
+    fn get_rlshift() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRLShiftProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_lshift,
-            pfunc: py_binary_reversed_num_func!(PyNumberRLShiftProtocol, Self::__rlshift__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_lshift,
+            py_binary_reversed_num_func!(PyNumberRLShiftProtocol, Self::__rlshift__),
+        )
     }
 
-    fn get_rshift_rrshift() -> ffi::PyType_Slot
+    fn get_rshift_rrshift() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRShiftProtocol<'p> + for<'p> PyNumberRRShiftProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_rshift,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_rshift,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberRShiftProtocol::__rshift__,
                 PyNumberRRShiftProtocol::__rrshift__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_rshift() -> ffi::PyType_Slot
+    fn get_rshift() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRShiftProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_rshift,
-            pfunc: py_binary_num_func!(PyNumberRShiftProtocol, Self::__rshift__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_rshift,
+            py_binary_num_func!(PyNumberRShiftProtocol, Self::__rshift__),
+        )
     }
 
-    fn get_rrshift() -> ffi::PyType_Slot
+    fn get_rrshift() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRRShiftProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_rshift,
-            pfunc: py_binary_reversed_num_func!(PyNumberRRShiftProtocol, Self::__rrshift__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_rshift,
+            py_binary_reversed_num_func!(PyNumberRRShiftProtocol, Self::__rrshift__),
+        )
     }
 
-    fn get_and_rand() -> ffi::PyType_Slot
+    fn get_and_rand() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberAndProtocol<'p> + for<'p> PyNumberRAndProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_and,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_and,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberAndProtocol::__and__,
                 PyNumberRAndProtocol::__rand__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_and() -> ffi::PyType_Slot
+    fn get_and() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberAndProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_and,
-            pfunc: py_binary_num_func!(PyNumberAndProtocol, Self::__and__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_and,
+            py_binary_num_func!(PyNumberAndProtocol, Self::__and__),
+        )
     }
 
-    fn get_rand() -> ffi::PyType_Slot
+    fn get_rand() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRAndProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_and,
-            pfunc: py_binary_reversed_num_func!(PyNumberRAndProtocol, Self::__rand__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_and,
+            py_binary_reversed_num_func!(PyNumberRAndProtocol, Self::__rand__),
+        )
     }
 
-    fn get_xor_rxor() -> ffi::PyType_Slot
+    fn get_xor_rxor() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberXorProtocol<'p> + for<'p> PyNumberRXorProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_xor,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_xor,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberXorProtocol::__xor__,
                 PyNumberRXorProtocol::__rxor__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_xor() -> ffi::PyType_Slot
+    fn get_xor() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberXorProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_xor,
-            pfunc: py_binary_num_func!(PyNumberXorProtocol, Self::__xor__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_xor,
+            py_binary_num_func!(PyNumberXorProtocol, Self::__xor__),
+        )
     }
 
-    fn get_rxor() -> ffi::PyType_Slot
+    fn get_rxor() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRXorProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_xor,
-            pfunc: py_binary_reversed_num_func!(PyNumberRXorProtocol, Self::__rxor__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_xor,
+            py_binary_reversed_num_func!(PyNumberRXorProtocol, Self::__rxor__),
+        )
     }
 
-    fn get_or_ror() -> ffi::PyType_Slot
+    fn get_or_ror() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberOrProtocol<'p> + for<'p> PyNumberROrProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_or,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_or,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberOrProtocol::__or__,
                 PyNumberROrProtocol::__ror__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_or() -> ffi::PyType_Slot
+    fn get_or() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberOrProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_or,
-            pfunc: py_binary_num_func!(PyNumberOrProtocol, Self::__or__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_or,
+            py_binary_num_func!(PyNumberOrProtocol, Self::__or__),
+        )
     }
 
-    fn get_ror() -> ffi::PyType_Slot
+    fn get_ror() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberROrProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_or,
-            pfunc: py_binary_reversed_num_func!(PyNumberROrProtocol, Self::__ror__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_or,
+            py_binary_reversed_num_func!(PyNumberROrProtocol, Self::__ror__),
+        )
     }
 
-    fn get_int() -> ffi::PyType_Slot
+    fn get_int() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyNumberIntProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_int,
-            pfunc: py_unary_func!(PyNumberIntProtocol, Self::__int__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_int,
+            py_unary_func!(PyNumberIntProtocol, Self::__int__),
+        )
     }
 
-    fn get_float() -> ffi::PyType_Slot
+    fn get_float() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyNumberFloatProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_float,
-            pfunc: py_unary_func!(PyNumberFloatProtocol, Self::__float__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_float,
+            py_unary_func!(PyNumberFloatProtocol, Self::__float__),
+        )
     }
 
-    fn get_iadd() -> ffi::PyType_Slot
+    fn get_iadd() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberIAddProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_add,
-            pfunc: py_binary_self_func!(PyNumberIAddProtocol, Self::__iadd__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_add,
+            py_binary_self_func!(PyNumberIAddProtocol, Self::__iadd__),
+        )
     }
 
-    fn get_isub() -> ffi::PyType_Slot
+    fn get_isub() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberISubProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_subtract,
-            pfunc: py_binary_self_func!(PyNumberISubProtocol, Self::__isub__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_subtract,
+            py_binary_self_func!(PyNumberISubProtocol, Self::__isub__),
+        )
     }
 
-    fn get_imul() -> ffi::PyType_Slot
+    fn get_imul() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberIMulProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_multiply,
-            pfunc: py_binary_self_func!(PyNumberIMulProtocol, Self::__imul__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_multiply,
+            py_binary_self_func!(PyNumberIMulProtocol, Self::__imul__),
+        )
     }
 
-    fn get_imod() -> ffi::PyType_Slot
+    fn get_imod() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberIModProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_remainder,
-            pfunc: py_binary_self_func!(PyNumberIModProtocol, Self::__imod__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_remainder,
+            py_binary_self_func!(PyNumberIModProtocol, Self::__imod__),
+        )
     }
 
-    fn get_ipow() -> ffi::PyType_Slot
+    fn get_ipow() -> TypedSlot<ffi::ternaryfunc>
     where
         Self: for<'p> PyNumberIPowProtocol<'p>,
     {
@@ -1108,203 +1100,199 @@ pub trait PyNumberSlots {
             })
         }
 
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_power,
-            pfunc: wrap_ipow::<Self> as _,
-        }
+        TypedSlot(ffi::Py_nb_inplace_power, wrap_ipow::<Self>)
     }
 
-    fn get_ilshift() -> ffi::PyType_Slot
+    fn get_ilshift() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberILShiftProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_lshift,
-            pfunc: py_binary_self_func!(PyNumberILShiftProtocol, Self::__ilshift__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_lshift,
+            py_binary_self_func!(PyNumberILShiftProtocol, Self::__ilshift__),
+        )
     }
 
-    fn get_irshift() -> ffi::PyType_Slot
+    fn get_irshift() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberIRShiftProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_rshift,
-            pfunc: py_binary_self_func!(PyNumberIRShiftProtocol, Self::__irshift__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_rshift,
+            py_binary_self_func!(PyNumberIRShiftProtocol, Self::__irshift__),
+        )
     }
 
-    fn get_iand() -> ffi::PyType_Slot
+    fn get_iand() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberIAndProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_and,
-            pfunc: py_binary_self_func!(PyNumberIAndProtocol, Self::__iand__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_and,
+            py_binary_self_func!(PyNumberIAndProtocol, Self::__iand__),
+        )
     }
 
-    fn get_ixor() -> ffi::PyType_Slot
+    fn get_ixor() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberIXorProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_xor,
-            pfunc: py_binary_self_func!(PyNumberIXorProtocol, Self::__ixor__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_xor,
+            py_binary_self_func!(PyNumberIXorProtocol, Self::__ixor__),
+        )
     }
 
-    fn get_ior() -> ffi::PyType_Slot
+    fn get_ior() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberIOrProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_or,
-            pfunc: py_binary_self_func!(PyNumberIOrProtocol, Self::__ior__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_or,
+            py_binary_self_func!(PyNumberIOrProtocol, Self::__ior__),
+        )
     }
 
-    fn get_floordiv_rfloordiv() -> ffi::PyType_Slot
+    fn get_floordiv_rfloordiv() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberFloordivProtocol<'p> + for<'p> PyNumberRFloordivProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_floor_divide,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_floor_divide,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberFloordivProtocol::__floordiv__,
                 PyNumberRFloordivProtocol::__rfloordiv__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_floordiv() -> ffi::PyType_Slot
+    fn get_floordiv() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberFloordivProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_floor_divide,
-            pfunc: py_binary_num_func!(PyNumberFloordivProtocol, Self::__floordiv__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_floor_divide,
+            py_binary_num_func!(PyNumberFloordivProtocol, Self::__floordiv__),
+        )
     }
 
-    fn get_rfloordiv() -> ffi::PyType_Slot
+    fn get_rfloordiv() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRFloordivProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_floor_divide,
-            pfunc: py_binary_reversed_num_func!(PyNumberRFloordivProtocol, Self::__rfloordiv__)
-                as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_floor_divide,
+            py_binary_reversed_num_func!(PyNumberRFloordivProtocol, Self::__rfloordiv__),
+        )
     }
 
-    fn get_truediv_rtruediv() -> ffi::PyType_Slot
+    fn get_truediv_rtruediv() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberTruedivProtocol<'p> + for<'p> PyNumberRTruedivProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_true_divide,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_true_divide,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberTruedivProtocol::__truediv__,
                 PyNumberRTruedivProtocol::__rtruediv__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_truediv() -> ffi::PyType_Slot
+    fn get_truediv() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberTruedivProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_true_divide,
-            pfunc: py_binary_num_func!(PyNumberTruedivProtocol, Self::__truediv__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_true_divide,
+            py_binary_num_func!(PyNumberTruedivProtocol, Self::__truediv__),
+        )
     }
 
-    fn get_rtruediv() -> ffi::PyType_Slot
+    fn get_rtruediv() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRTruedivProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_true_divide,
-            pfunc: py_binary_reversed_num_func!(PyNumberRTruedivProtocol, Self::__rtruediv__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_true_divide,
+            py_binary_reversed_num_func!(PyNumberRTruedivProtocol, Self::__rtruediv__),
+        )
     }
 
-    fn get_ifloordiv() -> ffi::PyType_Slot
+    fn get_ifloordiv() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberIFloordivProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_floor_divide,
-            pfunc: py_binary_self_func!(PyNumberIFloordivProtocol, Self::__ifloordiv__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_floor_divide,
+            py_binary_self_func!(PyNumberIFloordivProtocol, Self::__ifloordiv__),
+        )
     }
 
-    fn get_itruediv() -> ffi::PyType_Slot
+    fn get_itruediv() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberITruedivProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_true_divide,
-            pfunc: py_binary_self_func!(PyNumberITruedivProtocol, Self::__itruediv__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_true_divide,
+            py_binary_self_func!(PyNumberITruedivProtocol, Self::__itruediv__),
+        )
     }
 
-    fn get_index() -> ffi::PyType_Slot
+    fn get_index() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyNumberIndexProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_index,
-            pfunc: py_unary_func!(PyNumberIndexProtocol, Self::__index__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_index,
+            py_unary_func!(PyNumberIndexProtocol, Self::__index__),
+        )
     }
 
-    fn get_matmul_rmatmul() -> ffi::PyType_Slot
+    fn get_matmul_rmatmul() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberMatmulProtocol<'p> + for<'p> PyNumberRMatmulProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_matrix_multiply,
-            pfunc: py_binary_fallback_num_func!(
+        TypedSlot(
+            ffi::Py_nb_matrix_multiply,
+            py_binary_fallback_num_func!(
                 Self,
                 PyNumberMatmulProtocol::__matmul__,
                 PyNumberRMatmulProtocol::__rmatmul__
-            ) as _,
-        }
+            ),
+        )
     }
 
-    fn get_matmul() -> ffi::PyType_Slot
+    fn get_matmul() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberMatmulProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_matrix_multiply,
-            pfunc: py_binary_num_func!(PyNumberMatmulProtocol, Self::__matmul__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_matrix_multiply,
+            py_binary_num_func!(PyNumberMatmulProtocol, Self::__matmul__),
+        )
     }
 
-    fn get_rmatmul() -> ffi::PyType_Slot
+    fn get_rmatmul() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberRMatmulProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_matrix_multiply,
-            pfunc: py_binary_reversed_num_func!(PyNumberRMatmulProtocol, Self::__rmatmul__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_matrix_multiply,
+            py_binary_reversed_num_func!(PyNumberRMatmulProtocol, Self::__rmatmul__),
+        )
     }
 
-    fn get_imatmul() -> ffi::PyType_Slot
+    fn get_imatmul() -> TypedSlot<ffi::binaryfunc>
     where
         Self: for<'p> PyNumberIMatmulProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_nb_inplace_matrix_multiply,
-            pfunc: py_binary_self_func!(PyNumberIMatmulProtocol, Self::__imatmul__) as _,
-        }
+        TypedSlot(
+            ffi::Py_nb_inplace_matrix_multiply,
+            py_binary_self_func!(PyNumberIMatmulProtocol, Self::__imatmul__),
+        )
     }
 }
 

--- a/src/class/proto_methods.rs
+++ b/src/class/proto_methods.rs
@@ -1,160 +1,55 @@
-#[cfg(not(Py_LIMITED_API))]
 use crate::class::buffer::PyBufferProcs;
-use crate::class::{
-    basic::PyObjectMethods, descr::PyDescrMethods, gc::PyGCMethods, iter::PyIterMethods,
-    mapping::PyMappingMethods, number::PyNumberMethods, pyasync::PyAsyncMethods,
-    sequence::PySequenceMethods,
-};
-use std::{
-    ptr::{self, NonNull},
-    sync::atomic::{AtomicPtr, Ordering},
-};
+use crate::ffi;
 
-/// Defines all method tables we need for object protocols.
 // Note(kngwyu): default implementations are for rust-numpy. Please don't remove them.
 pub trait PyProtoMethods {
-    fn async_methods() -> Option<NonNull<PyAsyncMethods>> {
-        None
+    fn get_type_slots() -> Vec<ffi::PyType_Slot> {
+        vec![]
     }
-    fn basic_methods() -> Option<NonNull<PyObjectMethods>> {
-        None
-    }
-    #[cfg(not(Py_LIMITED_API))]
-    fn buffer_methods() -> Option<NonNull<PyBufferProcs>> {
-        None
-    }
-    fn descr_methods() -> Option<NonNull<PyDescrMethods>> {
-        None
-    }
-    fn gc_methods() -> Option<NonNull<PyGCMethods>> {
-        None
-    }
-    fn mapping_methods() -> Option<NonNull<PyMappingMethods>> {
-        None
-    }
-    fn number_methods() -> Option<NonNull<PyNumberMethods>> {
-        None
-    }
-    fn iter_methods() -> Option<NonNull<PyIterMethods>> {
-        None
-    }
-    fn sequence_methods() -> Option<NonNull<PySequenceMethods>> {
+    fn get_buffer() -> Option<PyBufferProcs> {
         None
     }
 }
 
-/// Indicates that a type has a protocol registry. Implemented by `#[pyclass]`.
 #[doc(hidden)]
-pub trait HasProtoRegistry: Sized + 'static {
-    fn registry() -> &'static PyProtoRegistry;
+pub enum PyProtoMethodDef {
+    Slots(Vec<ffi::PyType_Slot>),
+    Buffer(PyBufferProcs),
 }
 
-impl<T: HasProtoRegistry> PyProtoMethods for T {
-    fn async_methods() -> Option<NonNull<PyAsyncMethods>> {
-        NonNull::new(Self::registry().async_methods.load(Ordering::Relaxed))
-    }
-    fn basic_methods() -> Option<NonNull<PyObjectMethods>> {
-        NonNull::new(Self::registry().basic_methods.load(Ordering::Relaxed))
-    }
-    #[cfg(not(Py_LIMITED_API))]
-    fn buffer_methods() -> Option<NonNull<PyBufferProcs>> {
-        NonNull::new(Self::registry().buffer_methods.load(Ordering::Relaxed))
-    }
-    fn descr_methods() -> Option<NonNull<PyDescrMethods>> {
-        NonNull::new(Self::registry().descr_methods.load(Ordering::Relaxed))
-    }
-    fn gc_methods() -> Option<NonNull<PyGCMethods>> {
-        NonNull::new(Self::registry().gc_methods.load(Ordering::Relaxed))
-    }
-    fn mapping_methods() -> Option<NonNull<PyMappingMethods>> {
-        NonNull::new(Self::registry().mapping_methods.load(Ordering::Relaxed))
-    }
-    fn number_methods() -> Option<NonNull<PyNumberMethods>> {
-        NonNull::new(Self::registry().number_methods.load(Ordering::Relaxed))
-    }
-    fn iter_methods() -> Option<NonNull<PyIterMethods>> {
-        NonNull::new(Self::registry().iter_methods.load(Ordering::Relaxed))
-    }
-    fn sequence_methods() -> Option<NonNull<PySequenceMethods>> {
-        NonNull::new(Self::registry().sequence_methods.load(Ordering::Relaxed))
-    }
-}
-
-/// Stores all method protocols.
-/// Used in the proc-macro code as a static variable.
 #[doc(hidden)]
-pub struct PyProtoRegistry {
-    /// Async protocols.
-    async_methods: AtomicPtr<PyAsyncMethods>,
-    /// Basic protocols.
-    basic_methods: AtomicPtr<PyObjectMethods>,
-    /// Buffer protocols.
-    #[cfg(not(Py_LIMITED_API))]
-    buffer_methods: AtomicPtr<PyBufferProcs>,
-    /// Descr pProtocols.
-    descr_methods: AtomicPtr<PyDescrMethods>,
-    /// GC protocols.
-    gc_methods: AtomicPtr<PyGCMethods>,
-    /// Mapping protocols.
-    mapping_methods: AtomicPtr<PyMappingMethods>,
-    /// Number protocols.
-    number_methods: AtomicPtr<PyNumberMethods>,
-    /// Iterator protocols.
-    iter_methods: AtomicPtr<PyIterMethods>,
-    /// Sequence protocols.
-    sequence_methods: AtomicPtr<PySequenceMethods>,
+#[cfg(feature = "macros")]
+pub trait PyProtoMethodsInventory: inventory::Collect {
+    fn new(methods: PyProtoMethodDef) -> Self;
+    fn get(&'static self) -> &'static PyProtoMethodDef;
 }
 
-impl PyProtoRegistry {
-    pub const fn new() -> Self {
-        PyProtoRegistry {
-            async_methods: AtomicPtr::new(ptr::null_mut()),
-            basic_methods: AtomicPtr::new(ptr::null_mut()),
-            #[cfg(not(Py_LIMITED_API))]
-            buffer_methods: AtomicPtr::new(ptr::null_mut()),
-            descr_methods: AtomicPtr::new(ptr::null_mut()),
-            gc_methods: AtomicPtr::new(ptr::null_mut()),
-            mapping_methods: AtomicPtr::new(ptr::null_mut()),
-            number_methods: AtomicPtr::new(ptr::null_mut()),
-            iter_methods: AtomicPtr::new(ptr::null_mut()),
-            sequence_methods: AtomicPtr::new(ptr::null_mut()),
-        }
+#[doc(hidden)]
+#[cfg(feature = "macros")]
+pub trait HasProtoMethodsInventory {
+    type ProtoMethods: PyProtoMethodsInventory;
+}
+
+#[cfg(feature = "macros")]
+impl<T: HasProtoMethodsInventory> PyProtoMethods for T {
+    fn get_type_slots() -> Vec<ffi::PyType_Slot> {
+        inventory::iter::<T::ProtoMethods>
+            .into_iter()
+            .filter_map(|def| match def.get() {
+                PyProtoMethodDef::Slots(slots) => Some(slots),
+                PyProtoMethodDef::Buffer(_) => None,
+            })
+            .flatten()
+            .cloned()
+            .collect()
     }
-    pub fn set_async_methods(&self, methods: PyAsyncMethods) {
-        self.async_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
-    }
-    pub fn set_basic_methods(&self, methods: PyObjectMethods) {
-        self.basic_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
-    }
-    #[cfg(not(Py_LIMITED_API))]
-    pub fn set_buffer_methods(&self, methods: PyBufferProcs) {
-        self.buffer_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
-    }
-    pub fn set_descr_methods(&self, methods: PyDescrMethods) {
-        self.descr_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
-    }
-    pub fn set_gc_methods(&self, methods: PyGCMethods) {
-        self.gc_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
-    }
-    pub fn set_mapping_methods(&self, methods: PyMappingMethods) {
-        self.mapping_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
-    }
-    pub fn set_number_methods(&self, methods: PyNumberMethods) {
-        self.number_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
-    }
-    pub fn set_iter_methods(&self, methods: PyIterMethods) {
-        self.iter_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
-    }
-    pub fn set_sequence_methods(&self, methods: PySequenceMethods) {
-        self.sequence_methods
-            .store(Box::into_raw(Box::new(methods)), Ordering::Relaxed)
+
+    fn get_buffer() -> Option<PyBufferProcs> {
+        inventory::iter::<T::ProtoMethods>
+            .into_iter()
+            .find_map(|def| match def.get() {
+                PyProtoMethodDef::Slots(_) => None,
+                PyProtoMethodDef::Buffer(buf) => Some(buf.clone()),
+            })
     }
 }

--- a/src/class/proto_methods.rs
+++ b/src/class/proto_methods.rs
@@ -18,6 +18,10 @@ pub trait PyProtoMethods {
     }
 }
 
+/// Typed version of `ffi::PyType_Slot`
+#[doc(hidden)]
+pub struct TypedSlot<T: Sized>(pub std::os::raw::c_int, pub T);
+
 #[doc(hidden)]
 pub enum PyProtoMethodDef {
     Slots(Vec<ffi::PyType_Slot>),

--- a/src/class/pyasync.rs
+++ b/src/class/pyasync.rs
@@ -8,6 +8,7 @@
 //! [PEP-0492](https://www.python.org/dev/peps/pep-0492/)
 //!
 
+use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::derive_utils::TryFromPyCell;
 use crate::err::PyResult;
@@ -88,34 +89,34 @@ pub trait PyAsyncAexitProtocol<'p>: PyAsyncProtocol<'p> {
 /// Extension trait for proc-macro backend.
 #[doc(hidden)]
 pub trait PyAsyncSlots {
-    fn get_await() -> ffi::PyType_Slot
+    fn get_await() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyAsyncAwaitProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_am_await,
-            pfunc: py_unarys_func!(PyAsyncAwaitProtocol, Self::__await__) as _,
-        }
+        TypedSlot(
+            ffi::Py_am_await,
+            py_unarys_func!(PyAsyncAwaitProtocol, Self::__await__),
+        )
     }
 
-    fn get_aiter() -> ffi::PyType_Slot
+    fn get_aiter() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyAsyncAiterProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_am_aiter,
-            pfunc: py_unarys_func!(PyAsyncAiterProtocol, Self::__aiter__) as _,
-        }
+        TypedSlot(
+            ffi::Py_am_aiter,
+            py_unarys_func!(PyAsyncAiterProtocol, Self::__aiter__),
+        )
     }
 
-    fn get_anext() -> ffi::PyType_Slot
+    fn get_anext() -> TypedSlot<ffi::unaryfunc>
     where
         Self: for<'p> PyAsyncAnextProtocol<'p>,
     {
-        ffi::PyType_Slot {
-            slot: ffi::Py_am_anext,
-            pfunc: py_unarys_func!(PyAsyncAnextProtocol, Self::__anext__) as _,
-        }
+        TypedSlot(
+            ffi::Py_am_anext,
+            py_unarys_func!(PyAsyncAnextProtocol, Self::__anext__),
+        )
     }
 }
 

--- a/src/class/pyasync.rs
+++ b/src/class/pyasync.rs
@@ -13,17 +13,6 @@ use crate::derive_utils::TryFromPyCell;
 use crate::err::PyResult;
 use crate::{ffi, IntoPy, IntoPyPointer, PyClass, PyObject, Python};
 
-#[cfg(Py_LIMITED_API)]
-#[derive(Clone, Default)]
-pub struct PyAsyncMethods {
-    pub am_await: Option<ffi::unaryfunc>,
-    pub am_aiter: Option<ffi::unaryfunc>,
-    pub am_anext: Option<ffi::unaryfunc>,
-}
-
-#[cfg(not(Py_LIMITED_API))]
-pub use ffi::PyAsyncMethods;
-
 /// Python Async/Await support interface.
 ///
 /// Each method in this trait corresponds to Python async/await implementation.
@@ -114,7 +103,7 @@ pub trait PyAsyncSlots {
         Self: for<'p> PyAsyncAiterProtocol<'p>,
     {
         ffi::PyType_Slot {
-            slot: ffi::Py_am_await,
+            slot: ffi::Py_am_aiter,
             pfunc: py_unarys_func!(PyAsyncAiterProtocol, Self::__aiter__) as _,
         }
     }

--- a/src/class/pyasync.rs
+++ b/src/class/pyasync.rs
@@ -96,34 +96,43 @@ pub trait PyAsyncAexitProtocol<'p>: PyAsyncProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
+/// Extension trait for proc-macro backend.
 #[doc(hidden)]
-impl PyAsyncMethods {
-    pub fn set_await<T>(&mut self)
+pub trait PyAsyncSlots {
+    fn get_await() -> ffi::PyType_Slot
     where
-        T: for<'p> PyAsyncAwaitProtocol<'p>,
+        Self: for<'p> PyAsyncAwaitProtocol<'p>,
     {
-        self.am_await = py_unarys_func!(PyAsyncAwaitProtocol, T::__await__);
-    }
-    pub fn set_aiter<T>(&mut self)
-    where
-        T: for<'p> PyAsyncAiterProtocol<'p>,
-    {
-        self.am_aiter = py_unarys_func!(PyAsyncAiterProtocol, T::__aiter__);
-    }
-    pub fn set_anext<T>(&mut self)
-    where
-        T: for<'p> PyAsyncAnextProtocol<'p>,
-    {
-        self.am_anext = am_anext::<T>();
+        ffi::PyType_Slot {
+            slot: ffi::Py_am_await,
+            pfunc: py_unarys_func!(PyAsyncAwaitProtocol, Self::__await__) as _,
+        }
     }
 
-    pub(crate) fn update_slots(&self, slots: &mut crate::pyclass::TypeSlots) {
-        slots.maybe_push(ffi::Py_am_await, self.am_await.map(|v| v as _));
-        slots.maybe_push(ffi::Py_am_aiter, self.am_aiter.map(|v| v as _));
-        slots.maybe_push(ffi::Py_am_anext, self.am_anext.map(|v| v as _));
+    fn get_aiter() -> ffi::PyType_Slot
+    where
+        Self: for<'p> PyAsyncAiterProtocol<'p>,
+    {
+        ffi::PyType_Slot {
+            slot: ffi::Py_am_await,
+            pfunc: py_unarys_func!(PyAsyncAiterProtocol, Self::__aiter__) as _,
+        }
+    }
+
+    fn get_anext() -> ffi::PyType_Slot
+    where
+        Self: for<'p> PyAsyncAnextProtocol<'p>,
+    {
+        ffi::PyType_Slot {
+            slot: ffi::Py_am_anext,
+            pfunc: py_unarys_func!(PyAsyncAnextProtocol, Self::__anext__) as _,
+        }
     }
 }
 
+impl<'p, T> PyAsyncSlots for T where T: PyAsyncProtocol<'p> {}
+
+/// Output of `__anext__`.
 pub enum IterANextOutput<T, U> {
     Yield(T),
     Return(U),
@@ -165,12 +174,4 @@ where
             None => Ok(PyIterANextOutput::Return(py.None())),
         }
     }
-}
-
-#[inline]
-fn am_anext<T>() -> Option<ffi::unaryfunc>
-where
-    T: for<'p> PyAsyncAnextProtocol<'p>,
-{
-    py_unarys_func!(PyAsyncAnextProtocol, T::__anext__)
 }


### PR DESCRIPTION
So what's the problem?
Currently, on the master, `#[pyproto]` is implemented via 'table initialization'.
I.e., `#[pyproto]` generates basically such a function:
```rust
#[ctor] 
fn __table_initialization() {
    let mut methods = PyNumberMethods::default();
    methods.set_add::<MyClass>();
    <MyClass as HasProtoRegistory>::add_number_methods(methods);  // I don't remember the function name correctly...
}
```
I designed this since many protocols required such kinds of tables before. 
However, when we are to use ABI3, most protocols are initialized via `PyType_Slot` and tables are unnecessary.
So I decided to renew the whole design, using `Vec<PyType_Slot>` instead of tables.
I believe the new implementation is simpler but has one disadvantage: weak typing.
`PyType_Slot` casts function pointers to `*mut c_void` so the function type is eliminated, which can lead to bugs. We should carefully check the `slot` and `pfunc` of each `PyType_Slot` are correct.

Now `#[pyproto]` generates (roughly):
```rust
pyo3::inventory::submit!( {
    let mut proto_methods = vec![];
    proto_methods.push(<MyClass as PyNumberSlots>::get_add());
    proto_methods.into()
});
```