### PR TITLE
examples: simplify tox instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,7 @@ jobs:
         shell: bash
         run: |
           for example_dir in examples/*; do
-              cd $example_dir
-              tox -c "tox.ini" -e py
-              cd -
+              tox -c $example_dir -e py
           done
 
     env:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test: lint test_py
 	cargo test
 
 test_py:
-	for example in examples/*; do tox -e py -c $$example/tox.ini || exit 1; done
+	for example in examples/*; do tox -e py -c $$example || exit 1; done
 
 fmt:
 	cargo fmt --all -- --check

--- a/examples/rustapi_module/README.md
+++ b/examples/rustapi_module/README.md
@@ -1,0 +1,17 @@
+# rustapi_module
+
+A simple extension module built using PyO3.
+
+## Build
+
+```shell
+python setup.py install
+```
+
+## Testing
+
+To test install tox globally and run
+
+```shell
+tox -e py
+```

--- a/examples/rustapi_module/pyproject.toml
+++ b/examples/rustapi_module/pyproject.toml
@@ -1,3 +1,2 @@
 [build-system]
-requires = ["setuptools>=41.0.0", "wheel", "setuptools_rust>=0.10.2", "toml"]
-build-backend = "setuptools.build_meta"
+requires = ["setuptools>=41.0.0", "wheel", "setuptools_rust>=0.10.2"]

--- a/examples/rustapi_module/setup.py
+++ b/examples/rustapi_module/setup.py
@@ -1,59 +1,8 @@
-import os
 import sys
 import platform
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
-from setuptools.command.sdist import sdist as SdistCommand
 from setuptools_rust import RustExtension
-
-
-class PyTest(TestCommand):
-    user_options = []
-
-    def run(self):
-        self.run_command("test_rust")
-
-        import subprocess
-
-        errno = subprocess.call(["pytest", "tests"])
-        raise SystemExit(errno)
-
-
-class CargoModifiedSdist(SdistCommand):
-    """Modifies Cargo.toml to use an absolute rather than a relative path
-
-    The current implementation of PEP 517 in pip always does builds in an
-    isolated temporary directory. This causes problems with the build, because
-    Cargo.toml necessarily refers to the current version of pyo3 by a relative
-    path.
-
-    Since these sdists are never meant to be used for anything other than
-    tox / pip installs, at sdist build time, we will modify the Cargo.toml
-    in the sdist archive to include an *absolute* path to pyo3.
-    """
-
-    def make_release_tree(self, base_dir, files):
-        """Stages the files to be included in archives"""
-        super().make_release_tree(base_dir, files)
-
-        import toml
-
-        # Cargo.toml is now staged and ready to be modified
-        cargo_loc = os.path.join(base_dir, "Cargo.toml")
-        assert os.path.exists(cargo_loc)
-
-        with open(cargo_loc, "r") as f:
-            cargo_toml = toml.load(f)
-
-        rel_pyo3_path = cargo_toml["dependencies"]["pyo3"]["path"]
-        base_path = os.path.dirname(__file__)
-        abs_pyo3_path = os.path.abspath(os.path.join(base_path, rel_pyo3_path))
-
-        cargo_toml["dependencies"]["pyo3"]["path"] = abs_pyo3_path
-
-        with open(cargo_loc, "w") as f:
-            toml.dump(cargo_toml, f)
 
 
 def get_py_version_cfgs():
@@ -75,9 +24,6 @@ def make_rust_extension(module_name):
         module_name, "Cargo.toml", rustc_flags=get_py_version_cfgs(), debug=True
     )
 
-
-install_requires = []
-tests_require = install_requires + ["pytest", "pytest-benchmark"]
 
 setup(
     name="rustapi-module",
@@ -101,9 +47,6 @@ setup(
         make_rust_extension("rustapi_module.test_dict"),
         make_rust_extension("rustapi_module.pyclass_iter"),
     ],
-    install_requires=install_requires,
-    tests_require=tests_require,
     include_package_data=True,
     zip_safe=False,
-    cmdclass={"test": PyTest, "sdist": CargoModifiedSdist},
 )

--- a/examples/rustapi_module/tox.ini
+++ b/examples/rustapi_module/tox.ini
@@ -1,14 +1,10 @@
 [tox]
-envlist = py35,
-          py36,
-          py37,
-          py38,
-          pypy3
-minversion = 3.4.0
-skip_missing_interpreters = true
-isolated_build = true
+# can't install from sdist because local pyo3 repo can't be included in the sdist
+skipsdist = true
 
 [testenv]
 description = Run the unit tests under {basepython}
 deps = -rrequirements-dev.txt
-commands = pytest {posargs}
+commands =
+    python setup.py install
+    pytest {posargs}

--- a/examples/word-count/README.md
+++ b/examples/word-count/README.md
@@ -35,8 +35,8 @@ pytest -v tests
 
 ## Testing
 
-To test python 3.5, 3.6 and 3.7, install tox globally and run
+To test install tox globally and run
 
 ```shell
-tox
+tox -e py
 ```

--- a/examples/word-count/pyproject.toml
+++ b/examples/word-count/pyproject.toml
@@ -1,3 +1,2 @@
 [build-system]
-requires = ["setuptools>=41.0.0", "wheel", "setuptools_rust>=0.10.2", "toml"]
-build-backend = "setuptools.build_meta"
+requires = ["setuptools>=41.0.0", "wheel", "setuptools_rust>=0.10.2"]

--- a/examples/word-count/setup.py
+++ b/examples/word-count/setup.py
@@ -1,73 +1,6 @@
-import os
-import sys
-
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
-from setuptools.command.sdist import sdist as SdistCommand
+from setuptools_rust import RustExtension
 
-try:
-    from setuptools_rust import RustExtension
-except ImportError:
-    import subprocess
-
-    errno = subprocess.call([sys.executable, "-m", "pip", "install", "setuptools-rust"])
-    if errno:
-        print("Please install setuptools-rust package")
-        raise SystemExit(errno)
-    else:
-        from setuptools_rust import RustExtension
-
-
-class CargoModifiedSdist(SdistCommand):
-    """Modifies Cargo.toml to use an absolute rather than a relative path
-
-    The current implementation of PEP 517 in pip always does builds in an
-    isolated temporary directory. This causes problems with the build, because
-    Cargo.toml necessarily refers to the current version of pyo3 by a relative
-    path.
-
-    Since these sdists are never meant to be used for anything other than
-    tox / pip installs, at sdist build time, we will modify the Cargo.toml
-    in the sdist archive to include an *absolute* path to pyo3.
-    """
-
-    def make_release_tree(self, base_dir, files):
-        """Stages the files to be included in archives"""
-        super().make_release_tree(base_dir, files)
-
-        import toml
-
-        # Cargo.toml is now staged and ready to be modified
-        cargo_loc = os.path.join(base_dir, "Cargo.toml")
-        assert os.path.exists(cargo_loc)
-
-        with open(cargo_loc, "r") as f:
-            cargo_toml = toml.load(f)
-
-        rel_pyo3_path = cargo_toml["dependencies"]["pyo3"]["path"]
-        base_path = os.path.dirname(__file__)
-        abs_pyo3_path = os.path.abspath(os.path.join(base_path, rel_pyo3_path))
-
-        cargo_toml["dependencies"]["pyo3"]["path"] = abs_pyo3_path
-
-        with open(cargo_loc, "w") as f:
-            toml.dump(cargo_toml, f)
-
-
-class PyTest(TestCommand):
-    user_options = []
-
-    def run(self):
-        self.run_command("test_rust")
-
-        import subprocess
-
-        subprocess.check_call(["pytest", "tests"])
-
-
-setup_requires = ["setuptools-rust>=0.10.1", "wheel"]
-install_requires = []
-tests_require = install_requires + ["pytest", "pytest-benchmark"]
 
 setup(
     name="word-count",
@@ -83,10 +16,6 @@ setup(
     ],
     packages=["word_count"],
     rust_extensions=[RustExtension("word_count.word_count", "Cargo.toml", debug=False)],
-    install_requires=install_requires,
-    tests_require=tests_require,
-    setup_requires=setup_requires,
     include_package_data=True,
     zip_safe=False,
-    cmdclass={"test": PyTest, "sdist": CargoModifiedSdist},
 )

--- a/examples/word-count/tox.ini
+++ b/examples/word-count/tox.ini
@@ -1,14 +1,10 @@
 [tox]
-envlist = py36,
-          py37,
-          py38,
-          py39,
-          pypy3
-minversion = 3.6.0
-skip_missing_interpreters = true
-isolated_build = true
+# can't install from sdist because local pyo3 repo can't be included in the sdist
+skipsdist=true
 
 [testenv]
 description = Run the unit tests under {basepython}
 deps = -rrequirements-dev.txt
-commands = pytest {posargs}
+commands =
+    python setup.py install
+    pytest {posargs}


### PR DESCRIPTION
Simplifies the tox configuration for the examples a bit, based on some things I learned fighting with `setuptools-rust` CI today!