### PR TITLE
coverage: simplify mechanism for panic=unwind tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,3 +384,9 @@ pub mod doc_test {
     doctest!("../guide/src/types.md", guide_types_md);
     doctest!("../guide/src/trait_bounds.md", guide_trait_bounds_md);
 }
+
+// interim helper until #[cfg(panic = ...)] is stable
+#[cfg(test)]
+fn cfg_panic_unwind() -> bool {
+    option_env!("RUSTFLAGS").map_or(true, |var| !var.contains("-Cpanic=abort"))
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -588,11 +588,8 @@ mod test {
 
     #[test]
     fn test_allow_threads_panics_safely() {
-        // If -Cpanic=abort is specified, we can't catch panic.
-        if option_env!("RUSTFLAGS")
-            .map(|s| s.contains("-Cpanic=abort"))
-            .unwrap_or(false)
-        {
+        // TODO replace with #[cfg(panic = "unwind")] once stable
+        if !crate::cfg_panic_unwind() {
             return;
         }
 


### PR DESCRIPTION
I recently added `#[cfg(panic = ...)]` to nightly rust, and wanted to use it here but it turned out to be a little awkward. So I simplified the way to check for `panic=abort` in tests which care about it while we wait for `#[cfg(panic = ...)]` to become stable.