### PR TITLE
msrv: bump to 1.45

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
             platform: { os: "windows-latest" }
         include:
           # Test minimal supported Rust version
-          - rust: 1.39.0
+          - rust: 1.45.0
             python-version: 3.9
             platform: { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
             msrv: "MSRV"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Packaging
 - Drop support for Python 3.5 (as it is now end-of-life). [#1250](https://github.com/PyO3/pyo3/pull/1250)
+- Bump minimum supported Rust version to 1.45. [#1272](https://github.com/PyO3/pyo3/pull/1272)
+- Bump indoc dependency to 1.0. [#1272](https://github.com/PyO3/pyo3/pull/1272)
+- Bump paste dependency to 1.0. [#1272](https://github.com/PyO3/pyo3/pull/1272)
 
 ### Added
 - Add support for building for CPython limited API. This required a few minor changes to runtime behaviour of of pyo3 `#[pyclass]` types. See the migration guide for full details. [#1152](https://github.com/PyO3/pyo3/pull/1152)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,13 @@ edition = "2018"
 
 [dependencies]
 ctor = { version = "0.1", optional = true }
-indoc = { version = "0.3.4", optional = true }
+indoc = { version = "1.0.3", optional = true }
 inventory = { version = "0.1.4", optional = true }
 libc = "0.2.62"
 parking_lot = "0.11.0"
 num-bigint = { version = "0.3", optional = true }
 num-complex = { version = "0.3", optional = true }
-paste = { version = "0.1.6", optional = true }
+paste = { version = "1.0.3", optional = true }
 pyo3cls = { path = "pyo3cls", version = "=0.12.3", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = "0.9", optional = true }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Actions Status](https://github.com/PyO3/pyo3/workflows/Test/badge.svg)](https://github.com/PyO3/pyo3/actions)
 [![codecov](https://codecov.io/gh/PyO3/pyo3/branch/master/graph/badge.svg)](https://codecov.io/gh/PyO3/pyo3)
 [![crates.io](http://meritbadge.herokuapp.com/pyo3)](https://crates.io/crates/pyo3)
-[![minimum rustc 1.39](https://img.shields.io/badge/rustc-1.39+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
+[![minimum rustc 1.45](https://img.shields.io/badge/rustc-1.45+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![Join the dev chat](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/PyO3/Lobby)
 
 [Rust](http://www.rust-lang.org/) bindings for [Python](https://www.python.org/). This includes running and interacting with Python code from a Rust binary, as well as writing native Python modules.
@@ -18,7 +18,7 @@ A comparison with rust-cpython can be found [in the guide](https://pyo3.rs/maste
 
 ## Usage
 
-PyO3 supports Python 3.6 and up. The minimum required Rust version is 1.39.0.
+PyO3 supports Python 3.6 and up. The minimum required Rust version is 1.45.0.
 
 Building with PyPy is also possible (via cpyext) for Python 3.6, targeted PyPy version is 7.3+.
 Please refer to the [pypy section in the guide](https://pyo3.rs/master/pypy.html).

--- a/build.rs
+++ b/build.rs
@@ -341,16 +341,16 @@ fn find_sysconfigdata(cross: &CrossCompileConfig) -> Result<PathBuf> {
 /// recursive search for _sysconfigdata, returns all possibilities of sysconfigdata paths
 fn search_lib_dir(path: impl AsRef<Path>, cross: &CrossCompileConfig) -> Vec<PathBuf> {
     let mut sysconfig_paths = vec![];
-    let version_pat = if let Some(ref v) = cross.version {
+    let version_pat = if let Some(v) = &cross.version {
         format!("python{}", v)
     } else {
         "python3.".into()
     };
     for f in fs::read_dir(path).expect("Path does not exist") {
-        let sysc = match f {
-            Ok(ref f) if starts_with(f, "_sysconfigdata") && ends_with(f, "py") => vec![f.path()],
-            Ok(ref f) if starts_with(f, "build") => search_lib_dir(f.path(), cross),
-            Ok(ref f) if starts_with(f, "lib.") => {
+        let sysc = match &f {
+            Ok(f) if starts_with(f, "_sysconfigdata") && ends_with(f, "py") => vec![f.path()],
+            Ok(f) if starts_with(f, "build") => search_lib_dir(f.path(), cross),
+            Ok(f) if starts_with(f, "lib.") => {
                 let name = f.file_name();
                 // check if right target os
                 if !name.to_string_lossy().contains(if cross.os == "android" {
@@ -366,7 +366,7 @@ fn search_lib_dir(path: impl AsRef<Path>, cross: &CrossCompileConfig) -> Vec<Pat
                 }
                 search_lib_dir(f.path(), cross)
             }
-            Ok(ref f) if starts_with(f, &version_pat) => search_lib_dir(f.path(), cross),
+            Ok(f) if starts_with(f, &version_pat) => search_lib_dir(f.path(), cross),
             _ => continue,
         };
         sysconfig_paths.extend(sysc);
@@ -569,7 +569,7 @@ fn run_python_script(interpreter: &Path, script: &str) -> Result<String> {
                 );
             }
         }
-        Ok(ref ok) if !ok.status.success() => bail!("Python script failed: {}"),
+        Ok(ok) if !ok.status.success() => bail!("Python script failed: {}"),
         Ok(ok) => Ok(String::from_utf8(ok.stdout)?),
     }
 }

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -175,7 +175,7 @@ struct ClassWithGCSupport {
 #[pyproto]
 impl PyGCProtocol for ClassWithGCSupport {
     fn __traverse__(&self, visit: PyVisit) -> Result<(), PyTraverseError> {
-        if let Some(ref obj) = self.obj {
+        if let Some(obj) = &self.obj {
             visit.call(obj)?
         }
         Ok(())

--- a/pyo3-derive-backend/src/from_pyobject.rs
+++ b/pyo3-derive-backend/src/from_pyobject.rs
@@ -137,13 +137,10 @@ impl<'a> Container<'a> {
         }
         let style = match (fields, transparent) {
             (Fields::Unnamed(_), true) => ContainerType::TupleNewtype,
-            (Fields::Unnamed(unnamed), false) => {
-                if unnamed.unnamed.len() == 1 {
-                    ContainerType::TupleNewtype
-                } else {
-                    ContainerType::Tuple(unnamed.unnamed.len())
-                }
-            }
+            (Fields::Unnamed(unnamed), false) => match unnamed.unnamed.len() {
+                1 => ContainerType::TupleNewtype,
+                len => ContainerType::Tuple(len),
+            },
             (Fields::Named(named), true) => {
                 let field = named
                     .named
@@ -457,14 +454,15 @@ fn get_pyo3_meta_list(attrs: &[Attribute]) -> Result<MetaList> {
 }
 
 fn verify_and_get_lifetime(generics: &syn::Generics) -> Result<Option<&syn::LifetimeDef>> {
-    let lifetimes = generics.lifetimes().collect::<Vec<_>>();
-    if lifetimes.len() > 1 {
+    let mut lifetimes = generics.lifetimes();
+    let lifetime = lifetimes.next();
+    if lifetimes.next().is_some() {
         return Err(spanned_err(
             &generics,
             "FromPyObject can be derived with at most one lifetime parameter.",
         ));
     }
-    Ok(lifetimes.into_iter().next())
+    Ok(lifetime)
 }
 
 /// Derive FromPyObject for enums and structs.

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -100,7 +100,7 @@ pub struct FnSpec<'a> {
 pub fn get_return_info(output: &syn::ReturnType) -> syn::Type {
     match output {
         syn::ReturnType::Default => syn::Type::Infer(syn::parse_quote! {_}),
-        syn::ReturnType::Type(_, ref ty) => *ty.clone(),
+        syn::ReturnType::Type(_, ty) => *ty.clone(),
     }
 }
 
@@ -109,7 +109,7 @@ pub fn parse_method_receiver(arg: &syn::FnArg) -> syn::Result<SelfType> {
         syn::FnArg::Receiver(recv) => Ok(SelfType::Receiver {
             mutable: recv.mutability.is_some(),
         }),
-        syn::FnArg::Typed(syn::PatType { ref ty, .. }) => Ok(SelfType::TryFromPyCell(ty.span())),
+        syn::FnArg::Typed(syn::PatType { ty, .. }) => Ok(SelfType::TryFromPyCell(ty.span())),
     }
 }
 
@@ -198,14 +198,12 @@ impl<'a> FnSpec<'a> {
                         "Unexpected receiver for method",
                     ));
                 }
-                syn::FnArg::Typed(syn::PatType {
-                    ref pat, ref ty, ..
-                }) => {
-                    let (ident, by_ref, mutability) = match **pat {
+                syn::FnArg::Typed(syn::PatType { pat, ty, .. }) => {
+                    let (ident, by_ref, mutability) = match &**pat {
                         syn::Pat::Ident(syn::PatIdent {
-                            ref ident,
-                            ref by_ref,
-                            ref mutability,
+                            ident,
+                            by_ref,
+                            mutability,
                             ..
                         }) => (ident, by_ref, mutability),
                         _ => {
@@ -267,7 +265,7 @@ impl<'a> FnSpec<'a> {
 
     pub fn is_args(&self, name: &syn::Ident) -> bool {
         for s in self.attrs.iter() {
-            if let Argument::VarArgs(ref path) = s {
+            if let Argument::VarArgs(path) = s {
                 return path.is_ident(name);
             }
         }
@@ -276,7 +274,7 @@ impl<'a> FnSpec<'a> {
 
     pub fn is_kwargs(&self, name: &syn::Ident) -> bool {
         for s in self.attrs.iter() {
-            if let Argument::KeywordArgs(ref path) = s {
+            if let Argument::KeywordArgs(path) = s {
                 return path.is_ident(name);
             }
         }
@@ -285,10 +283,10 @@ impl<'a> FnSpec<'a> {
 
     pub fn default_value(&self, name: &syn::Ident) -> Option<TokenStream> {
         for s in self.attrs.iter() {
-            match *s {
-                Argument::Arg(ref path, ref opt) | Argument::Kwarg(ref path, ref opt) => {
+            match s {
+                Argument::Arg(path, opt) | Argument::Kwarg(path, opt) => {
                     if path.is_ident(name) {
-                        if let Some(ref val) = opt {
+                        if let Some(val) = opt {
                             let i: syn::Expr = syn::parse_str(&val).unwrap();
                             return Some(i.into_token_stream());
                         }
@@ -302,7 +300,7 @@ impl<'a> FnSpec<'a> {
 
     pub fn is_kw_only(&self, name: &syn::Ident) -> bool {
         for s in self.attrs.iter() {
-            if let Argument::Kwarg(ref path, _) = s {
+            if let Argument::Kwarg(path, _) = s {
                 if path.is_ident(name) {
                     return true;
                 }
@@ -341,7 +339,7 @@ fn parse_method_attributes(
 
     for attr in attrs.iter() {
         match attr.parse_meta()? {
-            syn::Meta::Path(ref name) => {
+            syn::Meta::Path(name) => {
                 if name.is_ident("new") || name.is_ident("__new__") {
                     set_ty!(MethodTypeAttribute::New, name);
                 } else if name.is_ident("init") || name.is_ident("__init__") {
@@ -373,11 +371,7 @@ fn parse_method_attributes(
                     new_attrs.push(attr.clone())
                 }
             }
-            syn::Meta::List(syn::MetaList {
-                ref path,
-                ref nested,
-                ..
-            }) => {
+            syn::Meta::List(syn::MetaList { path, nested, .. }) => {
                 if path.is_ident("new") {
                     set_ty!(MethodTypeAttribute::New, path);
                 } else if path.is_ident("init") {
@@ -408,11 +402,11 @@ fn parse_method_attributes(
                     };
 
                     property_name = match nested.first().unwrap() {
-                        syn::NestedMeta::Meta(syn::Meta::Path(ref w)) if w.segments.len() == 1 => {
+                        syn::NestedMeta::Meta(syn::Meta::Path(w)) if w.segments.len() == 1 => {
                             Some(w.segments[0].ident.clone())
                         }
-                        syn::NestedMeta::Lit(ref lit) => match *lit {
-                            syn::Lit::Str(ref s) => Some(s.parse()?),
+                        syn::NestedMeta::Lit(lit) => match lit {
+                            syn::Lit::Str(s) => Some(s.parse()?),
                             _ => {
                                 return Err(syn::Error::new_spanned(
                                     lit,
@@ -428,7 +422,7 @@ fn parse_method_attributes(
                         }
                     };
                 } else if path.is_ident("args") {
-                    let attrs = PyFunctionAttr::from_meta(nested)?;
+                    let attrs = PyFunctionAttr::from_meta(&nested)?;
                     args.extend(attrs.arguments)
                 } else {
                     new_attrs.push(attr.clone())

--- a/pyo3-derive-backend/src/pyimpl.rs
+++ b/pyo3-derive-backend/src/pyimpl.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 pub fn build_py_methods(ast: &mut syn::ItemImpl) -> syn::Result<TokenStream> {
-    if let Some((_, ref path, _)) = ast.trait_ {
+    if let Some((_, path, _)) = &ast.trait_ {
         Err(syn::Error::new_spanned(
             path,
             "#[pymethods] cannot be used on trait impl blocks",

--- a/pyo3-derive-backend/src/pyproto.rs
+++ b/pyo3-derive-backend/src/pyproto.rs
@@ -10,8 +10,8 @@ use quote::ToTokens;
 use std::collections::HashSet;
 
 pub fn build_py_proto(ast: &mut syn::ItemImpl) -> syn::Result<TokenStream> {
-    if let Some((_, ref mut path, _)) = ast.trait_ {
-        let proto = if let Some(ref mut segment) = path.segments.last() {
+    if let Some((_, path, _)) = &mut ast.trait_ {
+        let proto = if let Some(segment) = path.segments.last() {
             match segment.ident.to_string().as_str() {
                 "PyObjectProtocol" => &defs::OBJECT,
                 "PyAsyncProtocol" => &defs::ASYNC,
@@ -64,7 +64,7 @@ fn impl_proto_impl(
     let mut method_names = HashSet::new();
 
     for iimpl in impls.iter_mut() {
-        if let syn::ImplItem::Method(ref mut met) = iimpl {
+        if let syn::ImplItem::Method(met) = iimpl {
             // impl Py~Protocol<'p> { type = ... }
             if let Some(m) = proto.get_proto(&met.sig.ident) {
                 impl_method_proto(ty, &mut met.sig, m)?.to_tokens(&mut trait_impls);

--- a/pyo3-derive-backend/src/utils.rs
+++ b/pyo3-derive-backend/src/utils.rs
@@ -10,7 +10,7 @@ pub fn print_err(msg: String, t: TokenStream) {
 /// Check if the given type `ty` is `pyo3::Python`.
 pub fn is_python(ty: &syn::Type) -> bool {
     match ty {
-        syn::Type::Path(ref typath) => typath
+        syn::Type::Path(typath) => typath
             .path
             .segments
             .last()
@@ -125,9 +125,9 @@ pub fn get_doc(
     let mut first = true;
 
     for attr in attrs.iter() {
-        if let Ok(syn::Meta::NameValue(ref metanv)) = attr.parse_meta() {
+        if let Ok(syn::Meta::NameValue(metanv)) = attr.parse_meta() {
             if metanv.path.is_ident("doc") {
-                if let syn::Lit::Str(ref litstr) = metanv.lit {
+                if let syn::Lit::Str(litstr) = metanv.lit {
                     if first {
                         first = false;
                         span = litstr.span();

--- a/pyo3cls/src/lib.rs
+++ b/pyo3cls/src/lib.rs
@@ -2,7 +2,6 @@
 //! This crate declares only the proc macro attributes, as a crate defining proc macro attributes
 //! must not contain any other public items.
 
-extern crate proc_macro;
 use proc_macro::TokenStream;
 use pyo3_derive_backend::{
     build_derive_from_pyobject, build_py_class, build_py_function, build_py_methods,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -46,17 +46,12 @@ pub enum ElementType {
 
 impl ElementType {
     pub fn from_format(format: &CStr) -> ElementType {
-        let slice = format.to_bytes();
-        if slice.len() == 1 {
-            native_element_type_from_type_char(slice[0])
-        } else if slice.len() == 2 {
-            match slice[0] {
-                b'@' => native_element_type_from_type_char(slice[1]),
-                b'=' | b'<' | b'>' | b'!' => standard_element_type_from_type_char(slice[1]),
-                _ => ElementType::Unknown,
+        match format.to_bytes() {
+            [char] | [b'@', char] => native_element_type_from_type_char(*char),
+            [modifier, char] if matches!(modifier, b'=' | b'<' | b'>' | b'!') => {
+                standard_element_type_from_type_char(*char)
             }
-        } else {
-            ElementType::Unknown
+            _ => ElementType::Unknown,
         }
     }
 }

--- a/src/ffi/datetime.rs
+++ b/src/ffi/datetime.rs
@@ -322,7 +322,7 @@ pub unsafe fn PyTZInfo_CheckExact(op: *mut PyObject) -> c_int {
 /// Accessor functions
 #[cfg(not(PyPy))]
 macro_rules! _access_field {
-    ($obj:expr, $type: ident, $field:tt) => {
+    ($obj:expr, $type: ident, $field:ident) => {
         (*($obj as *mut $type)).$field
     };
 }
@@ -504,7 +504,7 @@ pub unsafe fn PyDateTime_TIME_GET_TZINFO(o: *mut PyObject) -> *mut PyObject {
 // Accessor functions for PyDateTime_Delta
 #[cfg(not(PyPy))]
 macro_rules! _access_delta_field {
-    ($obj:expr, $field:tt) => {
+    ($obj:expr, $field:ident) => {
         _access_field!($obj, PyDateTime_Delta, $field)
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ pub mod proc_macro {
 #[macro_export]
 macro_rules! wrap_pyfunction {
     ($function_name: ident) => {{
-        &pyo3::paste::expr! { [<__pyo3_get_function_ $function_name>] }
+        &pyo3::paste::paste! { [<__pyo3_get_function_ $function_name>] }
     }};
 
     ($function_name: ident, $arg: expr) => {
@@ -244,7 +244,7 @@ macro_rules! wrap_pyfunction {
 #[macro_export]
 macro_rules! raw_pycfunction {
     ($function_name: ident) => {{
-        pyo3::paste::expr! { [<__pyo3_raw_ $function_name>] }
+        pyo3::paste::paste! { [<__pyo3_raw_ $function_name>] }
     }};
 }
 
@@ -254,7 +254,7 @@ macro_rules! raw_pycfunction {
 #[macro_export]
 macro_rules! wrap_pymodule {
     ($module_name:ident) => {{
-        pyo3::paste::expr! {
+        pyo3::paste::paste! {
             &|py| unsafe { pyo3::PyObject::from_owned_ptr(py, [<PyInit_ $module_name>]()) }
         }
     }};
@@ -349,9 +349,9 @@ macro_rules! py_run_impl {
 #[doc(hidden)]
 pub mod doc_test {
     macro_rules! doc_comment {
-        ($x:expr, $($tt:tt)*) => {
+        ($x:expr, $module:item) => {
             #[doc = $x]
-            $($tt)*
+            $module
         };
     }
 

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -317,18 +317,18 @@ fn py_class_method_defs<T: PyMethods>() -> (
     let mut new = fallback_new();
 
     for def in T::py_methods() {
-        match *def {
-            PyMethodDefType::New(ref def) => {
+        match def {
+            PyMethodDefType::New(def) => {
                 new = def.get_new_func();
                 debug_assert!(new.is_some());
             }
-            PyMethodDefType::Call(ref def) => {
+            PyMethodDefType::Call(def) => {
                 call = def.get_cfunction_with_keywords();
                 debug_assert!(call.is_some());
             }
-            PyMethodDefType::Method(ref def)
-            | PyMethodDefType::Class(ref def)
-            | PyMethodDefType::Static(ref def) => {
+            PyMethodDefType::Method(def)
+            | PyMethodDefType::Class(def)
+            | PyMethodDefType::Static(def) => {
                 defs.push(def.as_method_def());
             }
             _ => (),
@@ -346,15 +346,15 @@ fn py_class_properties<T: PyClass>() -> Vec<ffi::PyGetSetDef> {
     let mut defs = std::collections::HashMap::new();
 
     for def in T::py_methods() {
-        match *def {
-            PyMethodDefType::Getter(ref getter) => {
+        match def {
+            PyMethodDefType::Getter(getter) => {
                 if !defs.contains_key(getter.name) {
                     let _ = defs.insert(getter.name.to_owned(), ffi::PyGetSetDef_INIT);
                 }
                 let def = defs.get_mut(getter.name).expect("Failed to call get_mut");
                 getter.copy_to(def);
             }
-            PyMethodDefType::Setter(ref setter) => {
+            PyMethodDefType::Setter(setter) => {
                 if !defs.contains_key(setter.name) {
                     let _ = defs.insert(setter.name.to_owned(), ffi::PyGetSetDef_INIT);
                 }

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -8,17 +8,10 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_pyclass_args.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
     t.compile_fail("tests/ui/reject_generics.rs");
+    t.compile_fail("tests/ui/static_ref.rs");
     t.compile_fail("tests/ui/wrong_aspyref_lifetimes.rs");
 
-    tests_rust_1_43(&t);
     tests_rust_1_46(&t);
-
-    #[rustversion::since(1.43)]
-    fn tests_rust_1_43(t: &trybuild::TestCases) {
-        t.compile_fail("tests/ui/static_ref.rs");
-    }
-    #[rustversion::before(1.43)]
-    fn tests_rust_1_43(_t: &trybuild::TestCases) {}
 
     #[rustversion::since(1.46)]
     fn tests_rust_1_46(t: &trybuild::TestCases) {

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -36,7 +36,7 @@ macro_rules! assert_check_exact {
         unsafe {
             use pyo3::{AsPyPointer, ffi::*};
             assert!($check_func(($obj).as_ptr()) != 0);
-            assert!(pyo3::paste::expr!([<$check_func Exact>])(($obj).as_ptr()) != 0);
+            assert!(pyo3::paste::paste!([<$check_func Exact>])(($obj).as_ptr()) != 0);
         }
     };
 }
@@ -46,7 +46,7 @@ macro_rules! assert_check_only {
         unsafe {
             use pyo3::{AsPyPointer, ffi::*};
             assert!($check_func(($obj).as_ptr()) != 0);
-            assert!(pyo3::paste::expr!([<$check_func Exact>])(($obj).as_ptr()) == 0);
+            assert!(pyo3::paste::paste!([<$check_func Exact>])(($obj).as_ptr()) == 0);
         }
     };
 }

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -196,7 +196,7 @@ impl BaseClassWithDrop {
 
 impl Drop for BaseClassWithDrop {
     fn drop(&mut self) {
-        if let Some(ref mut data) = self.data {
+        if let Some(data) = &self.data {
             data.store(true, Ordering::Relaxed);
         }
     }
@@ -220,7 +220,7 @@ impl SubClassWithDrop {
 
 impl Drop for SubClassWithDrop {
     fn drop(&mut self) {
-        if let Some(ref mut data) = self.data {
+        if let Some(data) = &self.data {
             data.store(true, Ordering::Relaxed);
         }
     }

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -59,7 +59,7 @@ impl PySequenceProtocol for ByteSequence {
 
     fn __contains__(&self, other: &PyAny) -> bool {
         match u8::extract(other) {
-            Ok(ref x) => self.elements.contains(x),
+            Ok(x) => self.elements.contains(&x),
             Err(_) => false,
         }
     }

--- a/tests/ui/invalid_pymethod_names.stderr
+++ b/tests/ui/invalid_pymethod_names.stderr
@@ -5,9 +5,9 @@ error: name not allowed with this method type
    |     ^
 
 error: #[name] can not be specified multiple times
-  --> $DIR/invalid_pymethod_names.rs:17:5
+  --> $DIR/invalid_pymethod_names.rs:18:5
    |
-17 |     #[name = "foo"]
+18 |     #[name = "bar"]
    |     ^
 
 error: name not allowed with this method type


### PR DESCRIPTION
Bumps minimum supported Rust version to 1.45.

I think there's a few places now where the older Rust version is beginning to hold us up, and also RHEL now supports Rust 1.45: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/8.3_release_notes/overview

From #1269 I discovered that maturin needs MSRV 1.40
In #1270 the usage of `const fn` there needs a slightly newer compiler than 1.39 (not sure exactly which one).

Closes #1252 
Closes #1262 