### PR TITLE
pyerr: improve debug & display impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `#[pyclass(subclass)]` is now required for subclassing from Rust (was previously just required for subclassing from Python). [#1152](https://github.com/PyO3/pyo3/pull/1152)
 - Change `PyIterator` to be consistent with other native types: it is now used as `&PyIterator` instead of `PyIterator<'a>`. [#1176](https://github.com/PyO3/pyo3/pull/1176)
 - Change formatting of `PyDowncastError` messages to be closer to Python's builtin error messages. [#1212](https://github.com/PyO3/pyo3/pull/1212)
+- Change `Debug` and `Display` impls for `PyException` to be consistent with `PyAny`. [#1275](https://github.com/PyO3/pyo3/pull/1275)
+- Change `Debug` impl of `PyErr` to output more helpful information (acquiring the GIL if necessary). [#1275](https://github.com/PyO3/pyo3/pull/1275)
 
 ### Removed
 - Remove deprecated ffi definitions `PyUnicode_AsUnicodeCopy`, `PyUnicode_GetMax`, `_Py_CheckRecursionLimit`, `PyObject_AsCharBuffer`, `PyObject_AsReadBuffer`, `PyObject_CheckReadBuffer` and `PyObject_AsWriteBuffer`, which will be removed in Python 3.10. [#1217](https://github.com/PyO3/pyo3/pull/1217)

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -176,7 +176,8 @@ impl PyErr {
     /// use pyo3::{Python, PyErr, exceptions::PyTypeError, types::PyType};
     /// Python::with_gil(|py| {
     ///     let err = PyTypeError::new_err(("some type error",));
-    ///     assert_eq!(err.pvalue(py).to_string(), "TypeError: some type error");
+    ///     assert!(err.is_instance::<PyTypeError>(py));
+    ///     assert_eq!(err.pvalue(py).to_string(), "some type error");
     /// });
     /// ```
     pub fn pvalue<'py>(&'py self, py: Python<'py>) -> &'py PyBaseException {
@@ -447,13 +448,28 @@ impl PyErr {
 
 impl std::fmt::Debug for PyErr {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        f.write_str(format!("PyErr {{ type: {:?} }}", self.ptype_ptr()).as_str())
+        Python::with_gil(|py| {
+            f.debug_struct("PyErr")
+                .field("type", self.ptype(py))
+                .field("value", self.pvalue(py))
+                .field("traceback", &self.ptraceback(py))
+                .finish()
+        })
     }
 }
 
 impl std::fmt::Display for PyErr {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        Python::with_gil(|py| self.instance(py).fmt(f))
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        Python::with_gil(|py| {
+            let instance = self.instance(py);
+            let type_name = instance.get_type().name().map_err(|_| std::fmt::Error)?;
+            write!(f, "{}", type_name)?;
+            if let Ok(s) = instance.str() {
+                write!(f, ": {}", &s.to_string_lossy())
+            } else {
+                write!(f, ": <exception str() failed>")
+            }
+        })
     }
 }
 
@@ -557,6 +573,55 @@ mod tests {
 
         // should resume unwind
         let _ = PyErr::fetch(py);
+    }
+
+    #[test]
+    fn err_debug() {
+        // Debug representation should be like the following (without the newlines):
+        // PyErr {
+        //     type: <class 'Exception'>,
+        //     value: Exception('banana'),
+        //     traceback: Some(<traceback object at 0x..)"
+        // }
+
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let err = py
+            .run("raise Exception('banana')", None, None)
+            .expect_err("raising should have given us an error");
+
+        let debug_str = format!("{:?}", err);
+        assert!(debug_str.starts_with("PyErr { "));
+        assert!(debug_str.ends_with(" }"));
+
+        let mut fields = debug_str
+            .strip_prefix("PyErr { ")
+            .unwrap()
+            .strip_suffix(" }")
+            .unwrap()
+            .split(", ");
+
+        assert_eq!(fields.next().unwrap(), "type: <class 'Exception'>");
+        #[cfg(not(Py_3_7))] // Python 3.6 and below formats the repr differently
+        assert_eq!(fields.next().unwrap(), ("value: Exception('banana',)"));
+        #[cfg(Py_3_7)]
+        assert_eq!(fields.next().unwrap(), "value: Exception('banana')");
+
+        let traceback = fields.next().unwrap();
+        assert!(traceback.starts_with("traceback: Some(<traceback object at 0x"));
+        assert!(traceback.ends_with(">)"));
+
+        assert!(fields.next().is_none());
+    }
+
+    #[test]
+    fn err_display() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        let err = py
+            .run("raise Exception('banana')", None, None)
+            .expect_err("raising should have given us an error");
+        assert_eq!(err.to_string(), "Exception: banana");
     }
 
     #[test]

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -99,10 +99,7 @@ fn mutation_fails() {
     let e = py
         .run("obj.base_set(lambda: obj.sub_set_and_ret(1))", global, None)
         .unwrap_err();
-    assert_eq!(
-        &e.instance(py).to_string(),
-        "RuntimeError: Already borrowed"
-    )
+    assert_eq!(&e.to_string(), "RuntimeError: Already borrowed")
 }
 
 #[pyclass(subclass)]


### PR DESCRIPTION
This PR aims to improve the ergonomics of `PyErr`'s debug output. 

Now, instead of `PyErr { type: 0x... }` the repr of type and value are printed (using `Python::with_gil` to acquire the GIL if needed). We already acquire the GIL in the `Display` impl so I think we have acceptable precedent to do this. It also makes the output much more useful for PyO3 users.

As a simplification, I also removed the special `impl Debug` and `impl Display` for `PyException`. They now just use the underlying Python object's `.repr()` and `.str()`, just like `PyAny`. I think there's a strong consistency argument for doing this.

Before:

```
PyErr debug         = PyErr { type: 0x7ff6f7b50420 }
PyErr display       = ValueError: bar
PyException debug   = ValueError
PyException display = ValueError: bar
PyAny debug         = ValueError('bar')
PyAny display       = bar
```

After:

```
PyErr debug         = PyErr { type: <class 'ValueError'>, value: ValueError('bar'), traceback: None }
PyErr display       = ValueError: bar
PyException debug   = ValueError('bar')
PyException display = bar
PyAny debug         = ValueError('bar')
PyAny display       = bar
```