### PR TITLE
pyany: add is_instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add FFI definitions for PEP 587 "Python Initialization Configuration". [#1247](https://github.com/PyO3/pyo3/pull/1247)
 - Add `PyEval_SetProfile` and `PyEval_SetTrace` to FFI. [#1255](https://github.com/PyO3/pyo3/pull/1255)
 - Add context.h functions (`PyContext_New`, etc) to FFI. [#1259](https://github.com/PyO3/pyo3/pull/1259)
+- Add `PyAny::is_instance()` method. [#1276](https://github.com/PyO3/pyo3/pull/1276)
 - Add support for conversion between `char` and `PyString`. [#1282](https://github.com/PyO3/pyo3/pull/1282)
 
 ### Changed

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -96,8 +96,8 @@ fn my_func(arg: PyObject) -> PyResult<()> {
 
 ## Checking exception types
 
-Python has an [`isinstance`](https://docs.python.org/3/library/functions.html#isinstance) method to check an object's type,
-in PyO3 there is a [`Python::is_instance`] method which does the same thing.
+Python has an [`isinstance`](https://docs.python.org/3/library/functions.html#isinstance) method to check an object's type.
+In PyO3 every native type has access to the [`PyAny::is_instance`] method which does the same thing.
 
 ```rust
 use pyo3::Python;
@@ -106,13 +106,13 @@ use pyo3::types::{PyBool, PyList};
 fn main() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    assert!(py.is_instance::<PyBool, _>(PyBool::new(py, true)).unwrap());
+    assert!(PyBool::new(py, true).is_instance::<PyBool>().unwrap());
     let list = PyList::new(py, &[1, 2, 3, 4]);
-    assert!(!py.is_instance::<PyBool, _>(list.as_ref()).unwrap());
-    assert!(py.is_instance::<PyList, _>(list.as_ref()).unwrap());
+    assert!(!list.is_instance::<PyBool>().unwrap());
+    assert!(list.is_instance::<PyList>().unwrap());
 }
 ```
-[`Python::is_instance`] calls the underlying [`PyType::is_instance`](https://docs.rs/pyo3/latest/pyo3/types/struct.PyType.html#method.is_instance)
+[`PyAny::is_instance`] calls the underlying [`PyType::is_instance`](https://docs.rs/pyo3/latest/pyo3/types/struct.PyType.html#method.is_instance)
 method to do the actual work.
 
 To check the type of an exception, you can similarly do:


### PR DESCRIPTION
Adds `PyAny::is_instance::<T>()`.

This is an alternative to `Python::is_instance()` which offers slightly nicer syntax. I think there's a good consistency argument to adding this:
- We expose other builtins like `dir()`, `hash()`, `len()` as `PyAny::dir` instead of `Python::dir` - `is_instance` has been a special case.
- It's also consistent with `PyErr::is_instance::<T>(py)`.

To encourage only one way to do things, I'm very tempted to mark `#[deprecated]` on `Python::is_instance` and `Python::is_subclass` (which is already redundant to `PyType::is_subclass`). What do you think of this?

Comparing from the documentation:

`Python::is_instance`:

```
fn main() {
    let gil = Python::acquire_gil();
    let py = gil.python();
    assert!(py.is_instance::<PyBool, _>(PyBool::new(py, true)).unwrap());
    let list = PyList::new(py, &[1, 2, 3, 4]);
    assert!(!py.is_instance::<PyBool, _>(list).unwrap());
    assert!(py.is_instance::<PyList, _>(list).unwrap());
}
```

`PyAny::is_instance`:

```
fn main() {
    let gil = Python::acquire_gil();
    let py = gil.python();
    assert!(PyBool::new(py, true).is_instance::<PyBool>().unwrap());
    let list = PyList::new(py, &[1, 2, 3, 4]);
    assert!(!list.is_instance::<PyBool>().unwrap());
    assert!(list.is_instance::<PyList>().unwrap());
}
```