### PR TITLE
docs: fix a couple of small typos

### DIFF
--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -120,7 +120,7 @@ pub unsafe trait PyTypeInfo: Sized {
 /// This trait is marked unsafe because not fulfilling the contract for type_object
 /// leads to UB.
 ///
-/// See [PyTypeInfo::type_object]
+/// See also [PyTypeInfo::type_object_raw](trait.PyTypeInfo.html#tymethod.type_object_raw).
 pub unsafe trait PyTypeObject {
     /// Returns the safe abstraction over the type object.
     fn type_object(py: Python) -> &PyType;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -424,7 +424,7 @@ impl PyAny {
 
     /// Retrieves the hash code of self.
     ///
-    /// This is equivalent to the Python expression `hash(obi)`.
+    /// This is equivalent to the Python expression `hash(self)`.
     pub fn hash(&self) -> PyResult<isize> {
         let v = unsafe { ffi::PyObject_Hash(self.as_ptr()) };
         if v == -1 {


### PR DESCRIPTION
Fixes an intra-doc link, and also a typo.