### PR TITLE
wrap_pyfunction: allow working on all crate functions

### DIFF
--- a/pyo3-derive-backend/src/module.rs
+++ b/pyo3-derive-backend/src/module.rs
@@ -209,7 +209,7 @@ pub fn add_fn_to_module(
     let wrapper = function_c_wrapper(name, &wrapper_ident, &spec, pyfn_attrs.pass_module);
     Ok(quote! {
         #wrapper
-        fn #function_wrapper_ident<'a>(
+        pub(crate) fn #function_wrapper_ident<'a>(
             args: impl Into<pyo3::derive_utils::PyFunctionArguments<'a>>
         ) -> pyo3::PyResult<&'a pyo3::types::PyCFunction> {
             let name = concat!(stringify!(#python_name), "\0");


### PR DESCRIPTION
This tweak allows for importing pyfunctions across modules in crates using glob imports.

e.g.

`functions.rs`

```
#[pyfunction]
fn foo() { }
```

`module.rs`

```
use functions::*;  // this will now pull in the pub(crate) generated function wrapper

// ...
wrap_pyfunction!(foo, m)?;
```

It's still not very user-friendly, so I don't really want to document this, but some users might want to do it, and I don't see why not. (I am aware of at least one person who's asked me offline about this.)

I think it might also be helpful to have support for this internally for the proposed pymodule syntax in #694 .