### PR TITLE
Char support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add FFI definitions for PEP 587 "Python Initialization Configuration". [#1247](https://github.com/PyO3/pyo3/pull/1247)
 - Add `PyEval_SetProfile` and `PyEval_SetTrace` to FFI. [#1255](https://github.com/PyO3/pyo3/pull/1255)
 - Add context.h functions (`PyContext_New`, etc) to FFI. [#1259](https://github.com/PyO3/pyo3/pull/1259)
+- Add support for conversion between `char` and `PyString`. [#1282](https://github.com/PyO3/pyo3/pull/1282)
 
 ### Changed
 - Change return type `PyType::name()` from `Cow<str>` to `PyResult<&str>`. [#1152](https://github.com/PyO3/pyo3/pull/1152)

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -174,10 +174,7 @@ pub trait FromPyObject<'source>: Sized {
 
 /// Identity conversion: allows using existing `PyObject` instances where
 /// `T: ToPyObject` is expected.
-impl<'a, T: ?Sized> ToPyObject for &'a T
-where
-    T: ToPyObject,
-{
+impl<'a, T: ?Sized + ToPyObject> ToPyObject for &'a T {
     #[inline]
     fn to_object(&self, py: Python) -> PyObject {
         <T as ToPyObject>::to_object(*self, py)

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -174,7 +174,7 @@ pub trait FromPyObject<'source>: Sized {
 
 /// Identity conversion: allows using existing `PyObject` instances where
 /// `T: ToPyObject` is expected.
-impl<'a, T: ?Sized + ToPyObject> ToPyObject for &'a T {
+impl<T: ?Sized + ToPyObject> ToPyObject for &'_ T {
     #[inline]
     fn to_object(&self, py: Python) -> PyObject {
         <T as ToPyObject>::to_object(*self, py)

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -177,16 +177,16 @@ impl<'source> FromPyObject<'source> for &'source str {
 
 /// Allows extracting strings from Python objects.
 /// Accepts Python `str` and `unicode` objects.
-impl<'source> FromPyObject<'source> for String {
-    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+impl FromPyObject<'_> for String {
+    fn extract(obj: &PyAny) -> PyResult<Self> {
         <PyString as PyTryFrom>::try_from(obj)?
             .to_str()
             .map(ToOwned::to_owned)
     }
 }
 
-impl<'source> FromPyObject<'source> for char {
-    fn extract(obj: &'source PyAny) -> PyResult<Self> {
+impl FromPyObject<'_> for char {
+    fn extract(obj: &PyAny) -> PyResult<Self> {
         let s = PyString::try_from(obj)?.to_str()?;
         let mut iter = s.chars();
         if let (Some(ch), None) = (iter.next(), iter.next()) {

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -207,22 +207,22 @@ mod test {
 
     #[test]
     fn test_non_bmp() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let s = "\u{1F30F}";
-        let py_string = s.to_object(py);
-        assert_eq!(s, py_string.extract::<String>(py).unwrap());
+        Python::with_gil(|py| {
+            let s = "\u{1F30F}";
+            let py_string = s.to_object(py);
+            assert_eq!(s, py_string.extract::<String>(py).unwrap());
+        })
     }
 
     #[test]
     fn test_extract_str() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let s = "Hello Python";
-        let py_string = s.to_object(py);
+        Python::with_gil(|py| {
+            let s = "Hello Python";
+            let py_string = s.to_object(py);
 
-        let s2: &str = FromPyObject::extract(py_string.as_ref(py)).unwrap();
-        assert_eq!(s, s2);
+            let s2: &str = FromPyObject::extract(py_string.as_ref(py)).unwrap();
+            assert_eq!(s, s2);
+        })
     }
 
     #[test]
@@ -237,60 +237,60 @@ mod test {
 
     #[test]
     fn test_to_str_ascii() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let s = "ascii 🐈";
-        let obj: PyObject = PyString::new(py, s).into();
-        let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
-        assert_eq!(s, py_string.to_str().unwrap());
+        Python::with_gil(|py| {
+            let s = "ascii 🐈";
+            let obj: PyObject = PyString::new(py, s).into();
+            let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            assert_eq!(s, py_string.to_str().unwrap());
+        })
     }
 
     #[test]
     fn test_to_str_surrogate() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let obj: PyObject = py.eval(r#"'\ud800'"#, None, None).unwrap().into();
-        let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
-        assert!(py_string.to_str().is_err());
+        Python::with_gil(|py| {
+            let obj: PyObject = py.eval(r#"'\ud800'"#, None, None).unwrap().into();
+            let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            assert!(py_string.to_str().is_err());
+        })
     }
 
     #[test]
     fn test_to_str_unicode() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let s = "哈哈🐈";
-        let obj: PyObject = PyString::new(py, s).into();
-        let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
-        assert_eq!(s, py_string.to_str().unwrap());
+        Python::with_gil(|py| {
+            let s = "哈哈🐈";
+            let obj: PyObject = PyString::new(py, s).into();
+            let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            assert_eq!(s, py_string.to_str().unwrap());
+        })
     }
 
     #[test]
     fn test_to_string_lossy() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let obj: PyObject = py
-            .eval(r#"'🐈 Hello \ud800World'"#, None, None)
-            .unwrap()
-            .into();
-        let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
-        assert_eq!(py_string.to_string_lossy(), "🐈 Hello ���World");
+        Python::with_gil(|py| {
+            let obj: PyObject = py
+                .eval(r#"'🐈 Hello \ud800World'"#, None, None)
+                .unwrap()
+                .into();
+            let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            assert_eq!(py_string.to_string_lossy(), "🐈 Hello ���World");
+        })
     }
 
     #[test]
     fn test_debug_string() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let v = "Hello\n".to_object(py);
-        let s = <PyString as PyTryFrom>::try_from(v.as_ref(py)).unwrap();
-        assert_eq!(format!("{:?}", s), "'Hello\\n'");
+        Python::with_gil(|py| {
+            let v = "Hello\n".to_object(py);
+            let s = <PyString as PyTryFrom>::try_from(v.as_ref(py)).unwrap();
+            assert_eq!(format!("{:?}", s), "'Hello\\n'");
+        })
     }
 
     #[test]
     fn test_display_string() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let v = "Hello\n".to_object(py);
-        let s = <PyString as PyTryFrom>::try_from(v.as_ref(py)).unwrap();
-        assert_eq!(format!("{}", s), "Hello\n");
+        Python::with_gil(|py| {
+            let v = "Hello\n".to_object(py);
+            let s = <PyString as PyTryFrom>::try_from(v.as_ref(py)).unwrap();
+            assert_eq!(format!("{}", s), "Hello\n");
+        })
     }
 }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -192,9 +192,9 @@ impl<'source> FromPyObject<'source> for char {
         if let (Some(ch), None) = (iter.next(), iter.next()) {
             Ok(ch)
         } else {
-            Err(crate::exceptions::PyValueError::new_err(format!(
-                "Expected a sting of length 1",
-            )))
+            Err(crate::exceptions::PyValueError::new_err(
+                "expected a string of length 1",
+            ))
         }
     }
 }
@@ -232,6 +232,19 @@ mod test {
             let py_string = ch.to_object(py);
             let ch2: char = FromPyObject::extract(py_string.as_ref(py)).unwrap();
             assert_eq!(ch, ch2);
+        })
+    }
+
+    #[test]
+    fn test_extract_char_err() {
+        Python::with_gil(|py| {
+            let s = "Hello Python";
+            let py_string = s.to_object(py);
+            let err: crate::PyResult<char> = FromPyObject::extract(py_string.as_ref(py));
+            assert!(err
+                .unwrap_err()
+                .to_string()
+                .contains("expected a string of length 1"));
         })
     }
 


### PR DESCRIPTION
Resolve #1281. Support char and `PyString` conversion.
I'm sorry this PR includes some unrelated cleanups. Since recently I don't have much time for PyO3, I think it would be better to do some cleanups when I find the necessity.
