### PR TITLE
Fix #1285, text_signature and raw ident interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Fix missing field in `PyCodeObject` struct (`co_posonlyargcount`) - caused invalid access to other fields in Python >3.7. [#1260](https://github.com/PyO3/pyo3/pull/1260)
 - Fix building for `x86_64-unknown-linux-musl` target from `x86_65-unknown-linux-gnu` host. [#1267](https://github.com/PyO3/pyo3/pull/1267)
+- Fix `#[text_signature]` interacting badly with rust `r#raw_identifiers`. [#1286](https://github.com/PyO3/pyo3/pull/1286)
 
 ## [0.12.3] - 2020-10-12
 ### Fixed

--- a/pyo3-derive-backend/src/method.rs
+++ b/pyo3-derive-backend/src/method.rs
@@ -237,7 +237,7 @@ impl<'a> FnSpec<'a> {
 
         let text_signature = match &fn_type {
             FnType::Fn(_) | FnType::FnClass | FnType::FnStatic => {
-                utils::parse_text_signature_attrs(&mut *meth_attrs, name)?
+                utils::parse_text_signature_attrs(&mut *meth_attrs, &python_name)?
             }
             FnType::FnNew => parse_erroneous_text_signature(
                 "text_signature not allowed on __new__; if you want to add a signature on \

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -190,3 +190,33 @@ fn test_methods() {
         "typeobj.static_method.__text_signature__ == '(d)'"
     );
 }
+
+#[test]
+#[cfg_attr(all(Py_LIMITED_API, not(Py_3_10)), ignore)]
+fn test_raw_identifiers() {
+    #[pyclass]
+    #[text_signature = "($self)"]
+    struct r#MyClass {}
+
+    #[pymethods]
+    impl MyClass {
+        #[new]
+        fn new() -> MyClass {
+            MyClass {}
+        }
+        #[text_signature = "($self)"]
+        fn r#method(&self) {}
+    }
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let typeobj = py.get_type::<MyClass>();
+
+    py_assert!(py, typeobj, "typeobj.__text_signature__ == '($self)'");
+
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.method.__text_signature__ == '($self)'"
+    );
+}


### PR DESCRIPTION
Fixes #1285

Fix ended up being simple: `parse_text_signature_attrs` took the raw name instead of the pythonized name. I added some simple tests to make sure we avoid regressions.