### PR TITLE
anaconda: fix for building in a virtualenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix missing field in `PyCodeObject` struct (`co_posonlyargcount`) - caused invalid access to other fields in Python >3.7. [#1260](https://github.com/PyO3/pyo3/pull/1260)
 - Fix building for `x86_64-unknown-linux-musl` target from `x86_65-unknown-linux-gnu` host. [#1267](https://github.com/PyO3/pyo3/pull/1267)
 - Fix `#[text_signature]` interacting badly with rust `r#raw_identifiers`. [#1286](https://github.com/PyO3/pyo3/pull/1286)
+- Fix building with Anaconda python inside a virtualenv. [#1290](https://github.com/PyO3/pyo3/pull/1290)
 
 ## [0.12.3] - 2020-10-12
 ### Fixed

--- a/build.rs
+++ b/build.rs
@@ -713,12 +713,7 @@ PYPY = platform.python_implementation() == "PyPy"
 # Anaconda based python distributions have a static python executable, but include
 # the shared library. Use the shared library for embedding to avoid rust trying to
 # LTO the static library (and failing with newer gcc's, because it is old).
-ANACONDA = os.path.exists(os.path.join(sys.prefix, 'conda-meta'))
-
-try:
-    base_prefix = sys.base_prefix
-except AttributeError:
-    base_prefix = sys.exec_prefix
+ANACONDA = os.path.exists(os.path.join(sys.base_prefix, 'conda-meta'))
 
 libdir = sysconfig.get_config_var('LIBDIR')
 
@@ -728,7 +723,7 @@ print("implementation", platform.python_implementation())
 if libdir is not None:
     print("libdir", libdir)
 print("ld_version", sysconfig.get_config_var('LDVERSION') or sysconfig.get_config_var('py_version_short'))
-print("base_prefix", base_prefix)
+print("base_prefix", sys.base_prefix)
 print("shared", PYPY or ANACONDA or bool(sysconfig.get_config_var('Py_ENABLE_SHARED')))
 print("executable", sys.executable)
 print("calcsize_pointer", struct.calcsize("P"))


### PR DESCRIPTION
Using `sys.base_prefix` for anaconda detection works even when inside a virtualenv. Tested locally and confirmed working.

Also `sys.base_prefix` has been present since Python 3.3 so we don't need to check for `AttributeError` any more when using it.