### PR TITLE
Reintroduce PyPy for Windows in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
           { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc" },
         ]
         exclude:
-          # See https://github.com/PyO3/pyo3/pull/1215 for why.
+          # There is no 64-bit pypy on windows
           - python-version: pypy3
-            platform: { os: "windows-latest" }
+            platform: { os: "windows-latest", python-architecture: "x64" }
         include:
           # Test minimal supported Rust version
           - rust: 1.45.0
@@ -111,7 +111,7 @@ jobs:
         shell: bash
         run: |
           for example_dir in examples/*; do
-              tox -c $example_dir -e py
+              tox --discover $(which python) -c $example_dir -e py
           done
 
     env:


### PR DESCRIPTION
Fixes #1216 

The  reason tox is failing with pypy on Windows is because `os.path.exists('')` returns `True` in that version of pypy which causes things to break during interpreter discovery. I found a wokaround using `--discover` which basically points tox to the interpreter. Once the next release of pypy lands in azure pipelines the issue will be fixed and `--discover` can be removed. 
