### PR TITLE
Allow `#[pyclass(name = "string literal")]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `PyAny::is_instance()` method. [#1276](https://github.com/PyO3/pyo3/pull/1276)
 - Add support for conversion between `char` and `PyString`. [#1282](https://github.com/PyO3/pyo3/pull/1282)
 - Add FFI definitions for `PyBuffer_SizeFromFormat`, `PyObject_LengthHint`, `PyObject_CallNoArgs`, `PyObject_CallOneArg`, `PyObject_CallMethodNoArgs`, `PyObject_CallMethodOneArg`, `PyObject_VectorcallDict`, and `PyObject_VectorcallMethod`. [#1287](https://github.com/PyO3/pyo3/pull/1287)
+- Allow the use of a string literal in `#[pyclass(name = "string literal")]`. [#1295](https://github.com/PyO3/pyo3/pull/1295)
 
 ### Changed
 - Change return type `PyType::name()` from `Cow<str>` to `PyResult<&str>`. [#1152](https://github.com/PyO3/pyo3/pull/1152)

--- a/pyo3-derive-backend/src/pyclass.rs
+++ b/pyo3-derive-backend/src/pyclass.rs
@@ -92,10 +92,20 @@ impl PyClassArgs {
                 self.freelist = Some(syn::Expr::clone(right));
             }
             "name" => match &**right {
+                syn::Expr::Lit(
+                    lit
+                    @
+                    syn::ExprLit {
+                        lit: syn::Lit::Str(..),
+                        ..
+                    },
+                ) => {
+                    self.name = Some(lit.clone().into());
+                }
                 syn::Expr::Path(exp) if exp.path.segments.len() == 1 => {
                     self.name = Some(exp.clone().into());
                 }
-                _ => expected!("type name (e.g., Name)"),
+                _ => expected!("type name (e.g., Name or \"Name\")"),
             },
             "extends" => match &**right {
                 syn::Expr::Path(exp) => {

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -10,7 +10,7 @@ error: Expected type path (e.g., my_mod::BaseClass)
 6 | #[pyclass(extends = "PyDict")]
   |                     ^^^^^^^^
 
-error: Expected type name (e.g., Name)
+error: Expected type name (e.g., Name or "Name")
  --> $DIR/invalid_pyclass_args.rs:9:18
   |
 9 | #[pyclass(name = m::MyClass)]


### PR DESCRIPTION
This is also more in line with the `#[name = "..."]` attribute on methods.
