### PR TITLE
dict: use with_capacity in HashMap extraction

### DIFF
--- a/benches/bench_dict.rs
+++ b/benches/bench_dict.rs
@@ -3,6 +3,7 @@
 extern crate test;
 use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
+use std::collections::{BTreeMap, HashMap};
 use test::Bencher;
 
 #[bench]
@@ -32,4 +33,32 @@ fn dict_get_item(b: &mut Bencher) {
             sum += dict.get_item(i).unwrap().extract::<usize>().unwrap();
         }
     });
+}
+
+#[bench]
+fn extract_hashmap(b: &mut Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    const LEN: usize = 100_000;
+    let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
+    b.iter(|| HashMap::<u64, u64>::extract(dict));
+}
+
+#[bench]
+fn extract_btreemap(b: &mut Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    const LEN: usize = 100_000;
+    let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
+    b.iter(|| BTreeMap::<u64, u64>::extract(dict));
+}
+
+#[bench]
+#[cfg(feature = "hashbrown")]
+fn extract_hashbrown_map(b: &mut Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    const LEN: usize = 100_000;
+    let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
+    b.iter(|| hashbrown::HashMap::<u64, u64>::extract(dict));
 }

--- a/benches/bench_set.rs
+++ b/benches/bench_set.rs
@@ -3,6 +3,7 @@
 extern crate test;
 use pyo3::prelude::*;
 use pyo3::types::PySet;
+use std::collections::{BTreeSet, HashSet};
 use test::Bencher;
 
 #[bench]
@@ -18,4 +19,32 @@ fn iter_set(b: &mut Bencher) {
             sum += i;
         }
     });
+}
+
+#[bench]
+fn extract_hashset(b: &mut Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    const LEN: usize = 100_000;
+    let set = PySet::new(py, &(0..LEN).collect::<Vec<_>>()).unwrap();
+    b.iter(|| HashSet::<u64>::extract(set));
+}
+
+#[bench]
+fn extract_btreeset(b: &mut Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    const LEN: usize = 100_000;
+    let set = PySet::new(py, &(0..LEN).collect::<Vec<_>>()).unwrap();
+    b.iter(|| BTreeSet::<u64>::extract(set));
+}
+
+#[bench]
+#[cfg(feature = "hashbrown")]
+fn extract_hashbrown_set(b: &mut Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    const LEN: usize = 100_000;
+    let set = PySet::new(py, &(0..LEN).collect::<Vec<_>>()).unwrap();
+    b.iter(|| hashbrown::HashSet::<u64>::extract(set));
 }

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -331,7 +331,7 @@ where
 {
     fn extract(ob: &'source PyAny) -> Result<Self, PyErr> {
         let dict = <PyDict as PyTryFrom>::try_from(ob)?;
-        let mut ret = HashMap::default();
+        let mut ret = HashMap::with_capacity_and_hasher(dict.len(), S::default());
         for (k, v) in dict.iter() {
             ret.insert(K::extract(k)?, V::extract(v)?);
         }
@@ -392,7 +392,7 @@ mod hashbrown_hashmap_conversion {
     {
         fn extract(ob: &'source PyAny) -> Result<Self, PyErr> {
             let dict = <PyDict as PyTryFrom>::try_from(ob)?;
-            let mut ret = hashbrown::HashMap::default();
+            let mut ret = hashbrown::HashMap::with_capacity_and_hasher(dict.len(), S::default());
             for (k, v) in dict.iter() {
                 ret.insert(K::extract(k)?, V::extract(v)?);
             }


### PR DESCRIPTION
A tiny PR to improve performance when extracting `HashMap` from Python.

I added some new benchmarks to prove it was worth adding. For the two relevant benchmarks, I get the following results.

Before:

```
test extract_hashbrown_map ... bench:   4,310,640 ns/iter (+/- 438,993)
test extract_hashmap       ... bench:   6,350,030 ns/iter (+/- 499,598)
```

After:

```
test extract_hashbrown_map ... bench:   3,645,450 ns/iter (+/- 408,332)
test extract_hashmap       ... bench:   4,759,320 ns/iter (+/- 285,136)
```

So definitely helps.

