### PR TITLE
py: fix reference count bug in From(Py<T>) for PyObject

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -494,9 +494,9 @@ impl<T> std::convert::From<Py<T>> for PyObject
 where
     T: AsRef<PyAny>,
 {
+    #[inline]
     fn from(other: Py<T>) -> Self {
-        let Py(ptr, _) = other;
-        Py(ptr, PhantomData)
+        unsafe { Self::from_non_null(other.into_non_null()) }
     }
 }
 
@@ -646,5 +646,15 @@ mod test {
             Py::from(native)
         };
         assert_eq!(unsafe { ffi::Py_REFCNT(dict.as_ptr()) }, 1);
+    }
+
+    #[test]
+    fn pyobject_from_py() {
+        Python::with_gil(|py| {
+            let dict: Py<PyDict> = PyDict::new(py).into();
+            let cnt = dict.get_refcnt(py);
+            let p: PyObject = dict.into();
+            assert_eq!(p.get_refcnt(py), cnt);
+        });
     }
 }


### PR DESCRIPTION
I have just discovered a reference counting issue in one of our `From` implementations. It leads to a reference count being decreased when it should not. Unfortunately this was an implementation introduced by me since `0.12` 🤦 

The offending line is here: https://github.com/PyO3/pyo3/blob/32be8d9a3c463fbc3689b57680d73953355b36e0/src/instance.rs#L477

I incorrectly thought the destructuring would mean that `Py::drop()` is not run for `other`. What _actually_ happens is that `ptr` implements `Copy`, so it is *copied* from `other`, and then `other` is dropped.

This means `ptr` has a reference count decreased when it should not.

This PR corrects the issue and adds a test. The test fails on master.

cc @kngwyu - I think I will have to backport a bugfix `0.12.4` and yank the rest of the `0.12` releases.