### PR TITLE
Release notes for backported 0.12.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix FFI definitions for `PyObject_Vectorcall` and `PyVectorcall_Call`. [#1287](https://github.com/PyO3/pyo3/pull/1285)
 - Fix building with Anaconda python inside a virtualenv. [#1290](https://github.com/PyO3/pyo3/pull/1290)
 
+## [0.12.4] - 2020-11-28
+### Fixed
+- Fix reference count bug in implementation of `From<Py<T>>` for `PyObject`, a regression introduced in PyO3 0.12. [#1297](https://github.com/PyO3/pyo3/pull/1297)
+
 ## [0.12.3] - 2020-10-12
 ### Fixed
 - Fix support for Rust versions 1.39 to 1.44, broken by an incorrect internal update to paste 1.0 which was done in PyO3 0.12.2. [#1234](https://github.com/PyO3/pyo3/pull/1234)
@@ -555,7 +559,8 @@ Yanked
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.12.3...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.12.4...HEAD
+[0.12.4]: https://github.com/pyo3/pyo3/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/pyo3/pyo3/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/pyo3/pyo3/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/pyo3/pyo3/compare/v0.12.0...v0.12.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.12.3"
+version = "0.12.4"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -24,7 +24,7 @@ parking_lot = "0.11.0"
 num-bigint = { version = "0.3", optional = true }
 num-complex = { version = "0.3", optional = true }
 paste = { version = "1.0.3", optional = true }
-pyo3cls = { path = "pyo3cls", version = "=0.12.3", optional = true }
+pyo3cls = { path = "pyo3cls", version = "=0.12.4", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = "0.9", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.12.3"
+version = "0.12.4"
 features = ["extension-module"]
 ```
 
@@ -99,7 +99,7 @@ use it to run Python code, add `pyo3` to your `Cargo.toml` like this:
 
 ```toml
 [dependencies]
-pyo3 = "0.12.3"
+pyo3 = "0.12.4"
 ```
 
 Example program displaying the value of `sys.version` and the current user name:

--- a/pyo3-derive-backend/Cargo.toml
+++ b/pyo3-derive-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-derive-backend"
-version = "0.12.3"
+version = "0.12.4"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3cls/Cargo.toml
+++ b/pyo3cls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3cls"
-version = "0.12.3"
+version = "0.12.4"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.12.3" }
+pyo3-derive-backend = { path = "../pyo3-derive-backend", version = "=0.12.4" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies.pyo3]
-//! version = "0.12.3"
+//! version = "0.12.4"
 //! features = ["extension-module"]
 //! ```
 //!
@@ -109,7 +109,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! pyo3 = "0.12.3"
+//! pyo3 = "0.12.4"
 //! ```
 //!
 //! Example program displaying the value of `sys.version`:


### PR DESCRIPTION
I released pyo3 `0.12.4` to crates.io already; this PR just pulls the release notes into master.