### PR TITLE
Add `jsonschema-rs` and `css-inline` to the examples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ about this topic.
  * [mocpy](https://github.com/cds-astro/mocpy) _Astronomical Python library offering data structures for describing any arbitrary coverage regions on the unit sphere_
  * [tokenizers](https://github.com/huggingface/tokenizers/tree/master/bindings/python) _Python bindings to the Hugging Face tokenizers (NLP) written in Rust_
  * [pyre](https://github.com/Project-Dream-Weaver/Pyre) _Fast Python HTTP server written in Rust_
+ * [jsonschema-rs](https://github.com/Stranger6667/jsonschema-rs/tree/master/python) _Fast JSON Schema validation library_
+ * [css-inline](https://github.com/Stranger6667/css-inline/tree/master/python) _CSS inlining for Python implemented in Rust_
 
 ## License
 


### PR DESCRIPTION
Hi! This PR adds two extra projects that use `PyO3` - `jsonschema-rs` and `css-inline`. Let me know if they can be included :)

And thank you for the great library!