### PR TITLE
abi3-py36 now passes tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,11 @@ jobs:
         name: Test (abi3)
         run: cargo test --no-default-features --features "abi3,macros" --target ${{ matrix.platform.rust-target }}
 
+      # Run tests again, for abi3-py36 (the minimal Python version)
+      - if: (matrix.python-version != 'pypy3') && (matrix.python-version != '3.6')
+        name: Test (abi3-py36)
+        run: cargo test --no-default-features --features "abi3-py36,macros" --target ${{ matrix.platform.rust-target }}
+
       - name: Test proc-macro code
         run: cargo test --manifest-path=pyo3-macros-backend/Cargo.toml --target ${{ matrix.platform.rust-target }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: cargo test --no-default-features --features "abi3,macros" --target ${{ matrix.platform.rust-target }}
 
       # Run tests again, for abi3-py36 (the minimal Python version)
-      - if: (matrix.python-version != 'pypy3') && (matrix.python-version != '3.6')
+      - if: (matrix.python-version != 'pypy-3.6') && (matrix.python-version != '3.6')
         name: Test (abi3-py36)
         run: cargo test --no-default-features --features "abi3-py36,macros" --target ${{ matrix.platform.rust-target }}
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -22,6 +22,7 @@ pub use self::codecs::*;
 pub use self::compile::*;
 pub use self::complexobject::*;
 pub use self::context::*;
+#[cfg(not(Py_LIMITED_API))]
 pub use self::datetime::*;
 pub use self::descrobject::*;
 pub use self::dictobject::*;
@@ -178,6 +179,7 @@ pub mod frameobject {
     opaque_struct!(PyFrameObject);
 }
 
+#[cfg(not(Py_LIMITED_API))]
 pub(crate) mod datetime;
 pub(crate) mod marshal;
 

--- a/src/ffi/pythonrun.rs
+++ b/src/ffi/pythonrun.rs
@@ -14,6 +14,9 @@ pub struct PyCompilerFlags {
     pub cf_flags: c_int,
 }
 
+#[cfg(Py_LIMITED_API)]
+opaque_struct!(PyCompilerFlags);
+
 #[cfg(not(Py_LIMITED_API))]
 opaque_struct!(_mod);
 
@@ -145,8 +148,7 @@ extern "C" {
     #[cfg(Py_LIMITED_API)]
     #[cfg(not(PyPy))]
     pub fn Py_CompileString(string: *const c_char, p: *const c_char, s: c_int) -> *mut PyObject;
-    #[cfg(PyPy)]
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(any(PyPy, not(Py_LIMITED_API)))]
     #[cfg_attr(PyPy, link_name = "PyPy_CompileStringFlags")]
     pub fn Py_CompileStringFlags(
         string: *const c_char,

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -64,7 +64,6 @@ pub fn prepare_freethreaded_python() {
         if ffi::Py_IsInitialized() != 0 {
             // If Python is already initialized, we expect Python threading to also be initialized,
             // as we can't make the existing Python main thread acquire the GIL.
-            #[cfg(not(Py_3_7))]
             debug_assert_ne!(ffi::PyEval_ThreadsInitialized(), 0);
         } else {
             // Initialize Python.

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -64,7 +64,7 @@ pub fn prepare_freethreaded_python() {
         if ffi::Py_IsInitialized() != 0 {
             // If Python is already initialized, we expect Python threading to also be initialized,
             // as we can't make the existing Python main thread acquire the GIL.
-            debug_assert_ne!(ffi::PyEval_ThreadsInitialized(), 0);
+            assert_ne!(ffi::PyEval_ThreadsInitialized(), 0);
         } else {
             // Initialize Python.
             // We use Py_InitializeEx() with initsigs=0 to disable Python signal handling.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,9 +7,9 @@ pub use self::boolobject::PyBool;
 pub use self::bytearray::PyByteArray;
 pub use self::bytes::PyBytes;
 pub use self::complex::PyComplex;
-pub use self::datetime::PyDeltaAccess;
+#[cfg(not(Py_LIMITED_API))]
 pub use self::datetime::{
-    PyDate, PyDateAccess, PyDateTime, PyDelta, PyTime, PyTimeAccess, PyTzInfo,
+    PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess, PyTzInfo,
 };
 pub use self::dict::{IntoPyDict, PyDict};
 pub use self::floatob::PyFloat;
@@ -231,6 +231,7 @@ mod boolobject;
 mod bytearray;
 mod bytes;
 mod complex;
+#[cfg(not(Py_LIMITED_API))]
 mod datetime;
 mod dict;
 mod floatob;

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -1,3 +1,5 @@
+#![cfg(not(Py_LIMITED_API))]
+
 use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -271,12 +271,6 @@ impl PyGCProtocol for TraversableClass {
     }
 }
 
-#[cfg(PyPy)]
-unsafe fn get_type_traverse(tp: *mut pyo3::ffi::PyTypeObject) -> Option<pyo3::ffi::traverseproc> {
-    (*tp).tp_traverse
-}
-
-#[cfg(not(PyPy))]
 unsafe fn get_type_traverse(tp: *mut pyo3::ffi::PyTypeObject) -> Option<pyo3::ffi::traverseproc> {
     std::mem::transmute(pyo3::ffi::PyType_GetSlot(tp, pyo3::ffi::Py_tp_traverse))
 }


### PR DESCRIPTION
Now `cargo test --features=abi3-py36` fails since `ffi::PyEval_InitThreads()` is called after `Py_InitializeEx`.
So now `py36` build is not actually forward-compatible.
We have a small fix for this problem (this PR), but this also suggests that `py3*` build can be broken in the future version.
Though I'm not sure the breakage is likely to happen in the user code, maybe we want to add a note about it.