### PR TITLE
python: add version() to get running version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add support for conversion between `char` and `PyString`. [#1282](https://github.com/PyO3/pyo3/pull/1282)
 - Add FFI definitions for `PyBuffer_SizeFromFormat`, `PyObject_LengthHint`, `PyObject_CallNoArgs`, `PyObject_CallOneArg`, `PyObject_CallMethodNoArgs`, `PyObject_CallMethodOneArg`, `PyObject_VectorcallDict`, and `PyObject_VectorcallMethod`. [#1287](https://github.com/PyO3/pyo3/pull/1287)
 - Add conversions between u128/i128 and PyLong for PyPy. [#1310](https://github.com/PyO3/pyo3/pull/1310)
+- Add `Python::version()` and `Python::version_info()` to get the running interpreter version. [#1322](https://github.com/PyO3/pyo3/pull/1322)
 
 ### Changed
 - Change return type `PyType::name()` from `Cow<str>` to `PyResult<&str>`. [#1152](https://github.com/PyO3/pyo3/pull/1152)

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -602,10 +602,12 @@ mod tests {
             .split(", ");
 
         assert_eq!(fields.next().unwrap(), "type: <class 'Exception'>");
-        #[cfg(not(Py_3_7))] // Python 3.6 and below formats the repr differently
-        assert_eq!(fields.next().unwrap(), ("value: Exception('banana',)"));
-        #[cfg(Py_3_7)]
-        assert_eq!(fields.next().unwrap(), "value: Exception('banana')");
+        if py.version_info() >= (3, 7) {
+            assert_eq!(fields.next().unwrap(), "value: Exception('banana')");
+        } else {
+            // Python 3.6 and below formats the repr differently
+            assert_eq!(fields.next().unwrap(), ("value: Exception('banana',)"));
+        }
 
         let traceback = fields.next().unwrap();
         assert!(traceback.starts_with("traceback: Some(<traceback object at 0x"));

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -562,17 +562,19 @@ mod test {
             .into_instance(py)
             .into_ref(py);
 
-        #[cfg(Py_3_7)]
-        assert_eq!(format!("{:?}", exc), "Exception('banana')");
-        #[cfg(not(Py_3_7))]
-        assert_eq!(format!("{:?}", exc), "Exception('banana',)");
+        if py.version_info() >= (3, 7) {
+            assert_eq!(format!("{:?}", exc), "Exception('banana')");
+        } else {
+            assert_eq!(format!("{:?}", exc), "Exception('banana',)");
+        }
 
         let source = exc.source().expect("cause should exist");
 
-        #[cfg(Py_3_7)]
-        assert_eq!(format!("{:?}", source), "TypeError('peach')");
-        #[cfg(not(Py_3_7))]
-        assert_eq!(format!("{:?}", source), "TypeError('peach',)");
+        if py.version_info() >= (3, 7) {
+            assert_eq!(format!("{:?}", source), "TypeError('peach')");
+        } else {
+            assert_eq!(format!("{:?}", source), "TypeError('peach',)");
+        }
 
         let source_source = source.source();
         assert!(source_source.is_none(), "source_source should be None");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub use crate::instance::{Py, PyNativeType, PyObject};
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};
 pub use crate::pyclass::PyClass;
 pub use crate::pyclass_init::PyClassInitializer;
-pub use crate::python::{prepare_freethreaded_python, Python};
+pub use crate::python::{prepare_freethreaded_python, Python, PythonVersionInfo};
 pub use crate::type_object::{type_flags, PyTypeInfo};
 // Since PyAny is as important as PyObject, we expose it to the top level.
 pub use crate::types::PyAny;


### PR DESCRIPTION
This PR adds a new API `Python::version()` which is a safe convenience wrapper around `Py_GetVersion()`.

Now that we offer abi3 wheels which may need to support multiple different Python versions, such an API will come in helpful. We saw this already in #1320.