### PR TITLE
ci: pin to working setup-python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      # FIXME: Use "v2" tag once https://github.com/actions/setup-python/issues/171 is resolved.
+      - uses: actions/setup-python@v2.1.4
       - run: pip install black==19.10b0
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Workaround for https://github.com/actions/setup-python/issues/171 by using an old working version for now.