### PR TITLE
pypy: fix more warnings

### DIFF
--- a/src/ffi/boolobject.rs
+++ b/src/ffi/boolobject.rs
@@ -12,14 +12,9 @@ extern "C" {
     static mut _Py_TrueStruct: PyLongObject;
     #[cfg_attr(PyPy, link_name = "PyPyBool_FromLong")]
     pub fn PyBool_FromLong(arg1: c_long) -> *mut PyObject;
-
-    #[cfg(PyPy)]
-    #[link_name = "PyPyBool_Check"]
-    pub fn PyBool_Check(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
-#[cfg(not(PyPy))]
 pub unsafe fn PyBool_Check(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyBool_Type) as c_int
 }

--- a/src/ffi/sliceobject.rs
+++ b/src/ffi/sliceobject.rs
@@ -17,14 +17,9 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPySlice_Type")]
     pub static mut PySlice_Type: PyTypeObject;
     pub static mut PyEllipsis_Type: PyTypeObject;
-
-    #[cfg(PyPy)]
-    #[link_name = "PyPySlice_Check"]
-    pub fn PySlice_Check(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
-#[cfg(not(PyPy))]
 pub unsafe fn PySlice_Check(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PySlice_Type) as c_int
 }


### PR DESCRIPTION
#1323 got merged a little too quickly... Here's the last of the PyPy fixes needed.

These two symbols aren't actually exported in pypy's lib.