### PR TITLE
pyproto: remove inventory from implementation

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -772,23 +772,30 @@ impl pyo3::class::methods::HasMethodsInventory for MyClass {
 }
 pyo3::inventory::collect!(Pyo3MethodsInventoryForMyClass);
 
-
-pub struct Pyo3ProtoInventoryForMyClass {
-    def: pyo3::class::proto_methods::PyProtoMethodDef,
-}
-impl pyo3::class::proto_methods::PyProtoInventory for Pyo3ProtoInventoryForMyClass {
-    fn new(def: pyo3::class::proto_methods::PyProtoMethodDef) -> Self {
-        Self { def }
+impl pyo3::class::proto_methods::PyProtoMethods for MyClass {
+    fn for_each_proto_slot<Visitor: FnMut(pyo3::ffi::PyType_Slot)>(visitor: Visitor) {
+        // Implementation which uses dtolnay specialization to load all slots.
+        use pyo3::class::proto_methods::*;
+        let protocols = PyClassProtocols::<MyClass>::new();
+        protocols.object_protocol_slots()
+            .iter()
+            .chain(protocols.number_protocol_slots())
+            .chain(protocols.iter_protocol_slots())
+            .chain(protocols.gc_protocol_slots())
+            .chain(protocols.descr_protocol_slots())
+            .chain(protocols.mapping_protocol_slots())
+            .chain(protocols.sequence_protocol_slots())
+            .chain(protocols.async_protocol_slots())
+            .cloned()
+            .for_each(visitor);
     }
-    fn get(&'static self) -> &'static pyo3::class::proto_methods::PyProtoMethodDef {
-        &self.def
+
+    fn get_buffer() -> Option<&'static pyo3::class::proto_methods::PyBufferProcs> {
+        use pyo3::class::proto_methods::*;
+        let protocols = PyClassProtocols::<MyClass>::new();
+        protocols.buffer_procs()
     }
 }
-impl pyo3::class::proto_methods::HasProtoInventory for MyClass {
-    type ProtoMethods = Pyo3ProtoInventoryForMyClass;
-}
-pyo3::inventory::collect!(Pyo3ProtoInventoryForMyClass);
-
 
 impl pyo3::pyclass::PyClassSend for MyClass {
     type ThreadChecker = pyo3::pyclass::ThreadCheckerStub<MyClass>;

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -786,6 +786,7 @@ impl pyo3::class::proto_methods::PyProtoMethods for MyClass {
             .chain(protocols.mapping_protocol_slots())
             .chain(protocols.sequence_protocol_slots())
             .chain(protocols.async_protocol_slots())
+            .chain(protocols.buffer_protocol_slots())
             .cloned()
             .for_each(visitor);
     }

--- a/pyo3-macros-backend/src/defs.rs
+++ b/pyo3-macros-backend/src/defs.rs
@@ -195,7 +195,7 @@ pub const BUFFER: Proto = Proto {
     name: "Buffer",
     module: "pyo3::class::buffer",
     slots_trait: "PyBufferProtocolSlots",
-    slots_trait_slots: "buffer_procs",
+    slots_trait_slots: "buffer_protocol_slots",
     methods: &[
         MethodProto::new("bf_getbuffer", "PyBufferGetBufferProtocol").has_self(),
         MethodProto::new("bf_releasebuffer", "PyBufferReleaseBufferProtocol").has_self(),

--- a/pyo3-macros-backend/src/defs.rs
+++ b/pyo3-macros-backend/src/defs.rs
@@ -6,6 +6,8 @@ use std::collections::HashSet;
 pub struct Proto {
     /// The name of this protocol. E.g., Iter.
     pub name: &'static str,
+    /// The path to the module which contains this proto implementation.
+    module: &'static str,
     /// Trait which stores the slots
     pub slots_trait: &'static str,
     /// Trait method which accesses the slots.
@@ -25,12 +27,20 @@ impl Proto {
     {
         self.methods.iter().find(|m| query == m.name)
     }
+
     pub(crate) fn get_method<Q>(&self, query: Q) -> Option<&'static PyMethod>
     where
         Q: PartialEq<&'static str>,
     {
         self.py_methods.iter().find(|m| query == m.name)
     }
+
+    // Returns the hard-coded module as a path
+    #[inline]
+    pub(crate) fn module(&self) -> syn::Path {
+        syn::parse_str(self.module).expect("module def not valid path")
+    }
+
     // Since the order matters, we expose only the iterator instead of the slice.
     pub(crate) fn slot_defs(
         &self,
@@ -109,826 +119,490 @@ impl SlotDef {
 
 pub const OBJECT: Proto = Proto {
     name: "Object",
-    slots_trait: "pyo3::class::proto_methods::PyObjectProtocolSlots",
+    module: "pyo3::class::basic",
+    slots_trait: "PyObjectProtocolSlots",
     slots_trait_slots: "object_protocol_slots",
     methods: &[
-        MethodProto::new("__getattr__", "pyo3::class::basic::PyObjectGetAttrProtocol")
+        MethodProto::new("__getattr__", "PyObjectGetAttrProtocol")
             .args(&["Name"])
             .has_self(),
-        MethodProto::new("__setattr__", "pyo3::class::basic::PyObjectSetAttrProtocol")
+        MethodProto::new("__setattr__", "PyObjectSetAttrProtocol")
             .args(&["Name", "Value"])
             .has_self(),
-        MethodProto::new("__delattr__", "pyo3::class::basic::PyObjectDelAttrProtocol")
+        MethodProto::new("__delattr__", "PyObjectDelAttrProtocol")
             .args(&["Name"])
             .has_self(),
-        MethodProto::new("__str__", "pyo3::class::basic::PyObjectStrProtocol").has_self(),
-        MethodProto::new("__repr__", "pyo3::class::basic::PyObjectReprProtocol").has_self(),
-        MethodProto::new("__format__", "pyo3::class::basic::PyObjectFormatProtocol")
+        MethodProto::new("__str__", "PyObjectStrProtocol").has_self(),
+        MethodProto::new("__repr__", "PyObjectReprProtocol").has_self(),
+        MethodProto::new("__format__", "PyObjectFormatProtocol")
             .args(&["Format"])
             .has_self(),
-        MethodProto::new("__hash__", "pyo3::class::basic::PyObjectHashProtocol").has_self(),
-        MethodProto::new("__bytes__", "pyo3::class::basic::PyObjectBytesProtocol").has_self(),
-        MethodProto::new("__richcmp__", "pyo3::class::basic::PyObjectRichcmpProtocol")
+        MethodProto::new("__hash__", "PyObjectHashProtocol").has_self(),
+        MethodProto::new("__bytes__", "PyObjectBytesProtocol").has_self(),
+        MethodProto::new("__richcmp__", "PyObjectRichcmpProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__bool__", "pyo3::class::basic::PyObjectBoolProtocol").has_self(),
+        MethodProto::new("__bool__", "PyObjectBoolProtocol").has_self(),
     ],
     py_methods: &[
-        PyMethod::new("__format__", "pyo3::class::basic::FormatProtocolImpl"),
-        PyMethod::new("__bytes__", "pyo3::class::basic::BytesProtocolImpl"),
-        PyMethod::new("__unicode__", "pyo3::class::basic::UnicodeProtocolImpl"),
+        PyMethod::new("__format__", "FormatProtocolImpl"),
+        PyMethod::new("__bytes__", "BytesProtocolImpl"),
+        PyMethod::new("__unicode__", "UnicodeProtocolImpl"),
     ],
     slot_defs: &[
-        SlotDef::new(&["__str__"], "Py_tp_str", "pyo3::class::basic::str"),
-        SlotDef::new(&["__repr__"], "Py_tp_repr", "pyo3::class::basic::repr"),
-        SlotDef::new(&["__hash__"], "Py_tp_hash", "pyo3::class::basic::hash"),
-        SlotDef::new(
-            &["__getattr__"],
-            "Py_tp_getattro",
-            "pyo3::class::basic::getattr",
-        ),
-        SlotDef::new(
-            &["__richcmp__"],
-            "Py_tp_richcompare",
-            "pyo3::class::basic::richcmp",
-        ),
+        SlotDef::new(&["__str__"], "Py_tp_str", "str"),
+        SlotDef::new(&["__repr__"], "Py_tp_repr", "repr"),
+        SlotDef::new(&["__hash__"], "Py_tp_hash", "hash"),
+        SlotDef::new(&["__getattr__"], "Py_tp_getattro", "getattr"),
+        SlotDef::new(&["__richcmp__"], "Py_tp_richcompare", "richcmp"),
         SlotDef::new(
             &["__setattr__", "__delattr__"],
             "Py_tp_setattro",
-            "pyo3::class::basic::setdelattr",
+            "setdelattr",
         ),
-        SlotDef::new(
-            &["__setattr__"],
-            "Py_tp_setattro",
-            "pyo3::class::basic::setattr",
-        ),
-        SlotDef::new(
-            &["__delattr__"],
-            "Py_tp_setattro",
-            "pyo3::class::basic::delattr",
-        ),
-        SlotDef::new(&["__bool__"], "Py_nb_bool", "pyo3::class::basic::bool"),
+        SlotDef::new(&["__setattr__"], "Py_tp_setattro", "setattr"),
+        SlotDef::new(&["__delattr__"], "Py_tp_setattro", "delattr"),
+        SlotDef::new(&["__bool__"], "Py_nb_bool", "bool"),
     ],
 };
 
 pub const ASYNC: Proto = Proto {
     name: "Async",
-    slots_trait: "pyo3::class::proto_methods::PyAsyncProtocolSlots",
+    module: "pyo3::class::pyasync",
+    slots_trait: "PyAsyncProtocolSlots",
     slots_trait_slots: "async_protocol_slots",
     methods: &[
-        MethodProto::new("__await__", "pyo3::class::pyasync::PyAsyncAwaitProtocol")
-            .args(&["Receiver"]),
-        MethodProto::new("__aiter__", "pyo3::class::pyasync::PyAsyncAiterProtocol")
-            .args(&["Receiver"]),
-        MethodProto::new("__anext__", "pyo3::class::pyasync::PyAsyncAnextProtocol")
-            .args(&["Receiver"]),
-        MethodProto::new("__aenter__", "pyo3::class::pyasync::PyAsyncAenterProtocol").has_self(),
-        MethodProto::new("__aexit__", "pyo3::class::pyasync::PyAsyncAexitProtocol")
+        MethodProto::new("__await__", "PyAsyncAwaitProtocol").args(&["Receiver"]),
+        MethodProto::new("__aiter__", "PyAsyncAiterProtocol").args(&["Receiver"]),
+        MethodProto::new("__anext__", "PyAsyncAnextProtocol").args(&["Receiver"]),
+        MethodProto::new("__aenter__", "PyAsyncAenterProtocol").has_self(),
+        MethodProto::new("__aexit__", "PyAsyncAexitProtocol")
             .args(&["ExcType", "ExcValue", "Traceback"])
             .has_self(),
     ],
     py_methods: &[
-        PyMethod::new(
-            "__aenter__",
-            "pyo3::class::pyasync::PyAsyncAenterProtocolImpl",
-        ),
-        PyMethod::new(
-            "__aexit__",
-            "pyo3::class::pyasync::PyAsyncAexitProtocolImpl",
-        ),
+        PyMethod::new("__aenter__", "PyAsyncAenterProtocolImpl"),
+        PyMethod::new("__aexit__", "PyAsyncAexitProtocolImpl"),
     ],
     slot_defs: &[
-        SlotDef::new(
-            &["__await__"],
-            "Py_am_await",
-            "pyo3::class::pyasync::await_",
-        ),
-        SlotDef::new(&["__aiter__"], "Py_am_aiter", "pyo3::class::pyasync::aiter"),
-        SlotDef::new(&["__anext__"], "Py_am_anext", "pyo3::class::pyasync::anext"),
+        SlotDef::new(&["__await__"], "Py_am_await", "await_"),
+        SlotDef::new(&["__aiter__"], "Py_am_aiter", "aiter"),
+        SlotDef::new(&["__anext__"], "Py_am_anext", "anext"),
     ],
 };
 
 pub const BUFFER: Proto = Proto {
     name: "Buffer",
-    slots_trait: "pyo3::class::proto_methods::PyBufferProtocolSlots",
+    module: "pyo3::class::buffer",
+    slots_trait: "PyBufferProtocolSlots",
     slots_trait_slots: "buffer_procs",
     methods: &[
-        MethodProto::new(
-            "bf_getbuffer",
-            "pyo3::class::buffer::PyBufferGetBufferProtocol",
-        )
-        .has_self(),
-        MethodProto::new(
-            "bf_releasebuffer",
-            "pyo3::class::buffer::PyBufferReleaseBufferProtocol",
-        )
-        .has_self(),
+        MethodProto::new("bf_getbuffer", "PyBufferGetBufferProtocol").has_self(),
+        MethodProto::new("bf_releasebuffer", "PyBufferReleaseBufferProtocol").has_self(),
     ],
     py_methods: &[],
     slot_defs: &[
-        SlotDef::new(
-            &["bf_getbuffer"],
-            "Py_bf_getbuffer",
-            "pyo3::class::buffer::getbuffer",
-        ),
+        SlotDef::new(&["bf_getbuffer"], "Py_bf_getbuffer", "getbuffer"),
         SlotDef::new(
             &["bf_releasebuffer"],
             "Py_bf_releasebuffer",
-            "pyo3::class::buffer::releasebuffer",
+            "releasebuffer",
         ),
     ],
 };
 
 pub const CONTEXT: Proto = Proto {
     name: "Context",
-    slots_trait: "pyo3::class::proto_methods::PyContextProtocolSlots",
-    slots_trait_slots: "context_protocol_slots",
+    module: "pyo3::class::context",
+    slots_trait: "",
+    slots_trait_slots: "",
     methods: &[
-        MethodProto::new("__enter__", "pyo3::class::context::PyContextEnterProtocol").has_self(),
-        MethodProto::new("__exit__", "pyo3::class::context::PyContextExitProtocol")
+        MethodProto::new("__enter__", "PyContextEnterProtocol").has_self(),
+        MethodProto::new("__exit__", "PyContextExitProtocol")
             .args(&["ExcType", "ExcValue", "Traceback"])
             .has_self(),
     ],
     py_methods: &[
-        PyMethod::new(
-            "__enter__",
-            "pyo3::class::context::PyContextEnterProtocolImpl",
-        ),
-        PyMethod::new(
-            "__exit__",
-            "pyo3::class::context::PyContextExitProtocolImpl",
-        ),
+        PyMethod::new("__enter__", "PyContextEnterProtocolImpl"),
+        PyMethod::new("__exit__", "PyContextExitProtocolImpl"),
     ],
     slot_defs: &[],
 };
 
 pub const GC: Proto = Proto {
     name: "GC",
-    slots_trait: "pyo3::class::proto_methods::PyGCProtocolSlots",
+    module: "pyo3::class::gc",
+    slots_trait: "PyGCProtocolSlots",
     slots_trait_slots: "gc_protocol_slots",
     methods: &[
-        MethodProto::new("__traverse__", "pyo3::class::gc::PyGCTraverseProtocol")
+        MethodProto::new("__traverse__", "PyGCTraverseProtocol")
             .has_self()
             .no_result(),
-        MethodProto::new("__clear__", "pyo3::class::gc::PyGCClearProtocol")
+        MethodProto::new("__clear__", "PyGCClearProtocol")
             .has_self()
             .no_result(),
     ],
     py_methods: &[],
     slot_defs: &[
-        SlotDef::new(
-            &["__traverse__"],
-            "Py_tp_traverse",
-            "pyo3::class::gc::traverse",
-        ),
-        SlotDef::new(&["__clear__"], "Py_tp_clear", "pyo3::class::gc::clear"),
+        SlotDef::new(&["__traverse__"], "Py_tp_traverse", "traverse"),
+        SlotDef::new(&["__clear__"], "Py_tp_clear", "clear"),
     ],
 };
 
 pub const DESCR: Proto = Proto {
     name: "Descriptor",
-    slots_trait: "pyo3::class::proto_methods::PyDescrProtocolSlots",
+    module: "pyo3::class::descr",
+    slots_trait: "PyDescrProtocolSlots",
     slots_trait_slots: "descr_protocol_slots",
     methods: &[
-        MethodProto::new("__get__", "pyo3::class::descr::PyDescrGetProtocol")
-            .args(&["Receiver", "Inst", "Owner"]),
-        MethodProto::new("__set__", "pyo3::class::descr::PyDescrSetProtocol")
-            .args(&["Receiver", "Inst", "Value"]),
-        MethodProto::new("__det__", "pyo3::class::descr::PyDescrDelProtocol")
+        MethodProto::new("__get__", "PyDescrGetProtocol").args(&["Receiver", "Inst", "Owner"]),
+        MethodProto::new("__set__", "PyDescrSetProtocol").args(&["Receiver", "Inst", "Value"]),
+        MethodProto::new("__det__", "PyDescrDelProtocol")
             .args(&["Inst"])
             .has_self(),
-        MethodProto::new("__set_name__", "pyo3::class::descr::PyDescrSetNameProtocol")
+        MethodProto::new("__set_name__", "PyDescrSetNameProtocol")
             .args(&["Inst"])
             .has_self(),
     ],
     py_methods: &[
-        PyMethod::new("__del__", "pyo3::class::context::PyDescrDelProtocolImpl"),
-        PyMethod::new(
-            "__set_name__",
-            "pyo3::class::context::PyDescrNameProtocolImpl",
-        ),
+        PyMethod::new("__del__", "PyDescrDelProtocolImpl"),
+        PyMethod::new("__set_name__", "PyDescrNameProtocolImpl"),
     ],
     slot_defs: &[
-        SlotDef::new(
-            &["__get__"],
-            "Py_tp_descr_get",
-            "pyo3::class::descr::descr_get",
-        ),
-        SlotDef::new(
-            &["__set__"],
-            "Py_tp_descr_set",
-            "pyo3::class::descr::descr_set",
-        ),
+        SlotDef::new(&["__get__"], "Py_tp_descr_get", "descr_get"),
+        SlotDef::new(&["__set__"], "Py_tp_descr_set", "descr_set"),
     ],
 };
 
 pub const ITER: Proto = Proto {
     name: "Iter",
-    slots_trait: "pyo3::class::proto_methods::PyIterProtocolSlots",
+    module: "pyo3::class::iter",
+    slots_trait: "PyIterProtocolSlots",
     slots_trait_slots: "iter_protocol_slots",
     py_methods: &[],
     methods: &[
-        MethodProto::new("__iter__", "pyo3::class::iter::PyIterIterProtocol").args(&["Receiver"]),
-        MethodProto::new("__next__", "pyo3::class::iter::PyIterNextProtocol").args(&["Receiver"]),
+        MethodProto::new("__iter__", "PyIterIterProtocol").args(&["Receiver"]),
+        MethodProto::new("__next__", "PyIterNextProtocol").args(&["Receiver"]),
     ],
     slot_defs: &[
-        SlotDef::new(&["__iter__"], "Py_tp_iter", "pyo3::class::iter::iter"),
-        SlotDef::new(
-            &["__next__"],
-            "Py_tp_iternext",
-            "pyo3::class::iter::iternext",
-        ),
+        SlotDef::new(&["__iter__"], "Py_tp_iter", "iter"),
+        SlotDef::new(&["__next__"], "Py_tp_iternext", "iternext"),
     ],
 };
 
 pub const MAPPING: Proto = Proto {
     name: "Mapping",
-    slots_trait: "pyo3::class::proto_methods::PyMappingProtocolSlots",
+    module: "pyo3::class::mapping",
+    slots_trait: "PyMappingProtocolSlots",
     slots_trait_slots: "mapping_protocol_slots",
     methods: &[
-        MethodProto::new("__len__", "pyo3::class::mapping::PyMappingLenProtocol").has_self(),
-        MethodProto::new(
-            "__getitem__",
-            "pyo3::class::mapping::PyMappingGetItemProtocol",
-        )
-        .args(&["Key"])
-        .has_self(),
-        MethodProto::new(
-            "__setitem__",
-            "pyo3::class::mapping::PyMappingSetItemProtocol",
-        )
-        .args(&["Key", "Value"])
-        .has_self(),
-        MethodProto::new(
-            "__delitem__",
-            "pyo3::class::mapping::PyMappingDelItemProtocol",
-        )
-        .args(&["Key"])
-        .has_self(),
-        MethodProto::new(
-            "__reversed__",
-            "pyo3::class::mapping::PyMappingReversedProtocol",
-        )
-        .has_self(),
+        MethodProto::new("__len__", "PyMappingLenProtocol").has_self(),
+        MethodProto::new("__getitem__", "PyMappingGetItemProtocol")
+            .args(&["Key"])
+            .has_self(),
+        MethodProto::new("__setitem__", "PyMappingSetItemProtocol")
+            .args(&["Key", "Value"])
+            .has_self(),
+        MethodProto::new("__delitem__", "PyMappingDelItemProtocol")
+            .args(&["Key"])
+            .has_self(),
+        MethodProto::new("__reversed__", "PyMappingReversedProtocol").has_self(),
     ],
     py_methods: &[PyMethod::new(
         "__reversed__",
-        "pyo3::class::mapping::PyMappingReversedProtocolImpl",
+        "PyMappingReversedProtocolImpl",
     )],
     slot_defs: &[
-        SlotDef::new(&["__len__"], "Py_mp_length", "pyo3::class::mapping::len"),
-        SlotDef::new(
-            &["__getitem__"],
-            "Py_mp_subscript",
-            "pyo3::class::mapping::getitem",
-        ),
+        SlotDef::new(&["__len__"], "Py_mp_length", "len"),
+        SlotDef::new(&["__getitem__"], "Py_mp_subscript", "getitem"),
         SlotDef::new(
             &["__setitem__", "__delitem__"],
             "Py_mp_ass_subscript",
-            "pyo3::class::mapping::setdelitem",
+            "setdelitem",
         ),
-        SlotDef::new(
-            &["__setitem__"],
-            "Py_mp_ass_subscript",
-            "pyo3::class::mapping::setitem",
-        ),
-        SlotDef::new(
-            &["__delitem__"],
-            "Py_mp_ass_subscript",
-            "pyo3::class::mapping::delitem",
-        ),
+        SlotDef::new(&["__setitem__"], "Py_mp_ass_subscript", "setitem"),
+        SlotDef::new(&["__delitem__"], "Py_mp_ass_subscript", "delitem"),
     ],
 };
 
 pub const SEQ: Proto = Proto {
     name: "Sequence",
-    slots_trait: "pyo3::class::proto_methods::PySequenceProtocolSlots",
+    module: "pyo3::class::sequence",
+    slots_trait: "PySequenceProtocolSlots",
     slots_trait_slots: "sequence_protocol_slots",
     methods: &[
-        MethodProto::new("__len__", "pyo3::class::sequence::PySequenceLenProtocol").has_self(),
-        MethodProto::new(
-            "__getitem__",
-            "pyo3::class::sequence::PySequenceGetItemProtocol",
-        )
-        .args(&["Index"])
-        .has_self(),
-        MethodProto::new(
-            "__setitem__",
-            "pyo3::class::sequence::PySequenceSetItemProtocol",
-        )
-        .args(&["Index", "Value"])
-        .has_self(),
-        MethodProto::new(
-            "__delitem__",
-            "pyo3::class::sequence::PySequenceDelItemProtocol",
-        )
-        .args(&["Index"])
-        .has_self(),
-        MethodProto::new(
-            "__contains__",
-            "pyo3::class::sequence::PySequenceContainsProtocol",
-        )
-        .args(&["Item"])
-        .has_self(),
-        MethodProto::new(
-            "__concat__",
-            "pyo3::class::sequence::PySequenceConcatProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new(
-            "__repeat__",
-            "pyo3::class::sequence::PySequenceRepeatProtocol",
-        )
-        .args(&["Index"])
-        .has_self(),
-        MethodProto::new(
-            "__inplace_concat__",
-            "pyo3::class::sequence::PySequenceInplaceConcatProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new(
-            "__inplace_repeat__",
-            "pyo3::class::sequence::PySequenceInplaceRepeatProtocol",
-        )
-        .args(&["Index"])
-        .has_self(),
+        MethodProto::new("__len__", "PySequenceLenProtocol").has_self(),
+        MethodProto::new("__getitem__", "PySequenceGetItemProtocol")
+            .args(&["Index"])
+            .has_self(),
+        MethodProto::new("__setitem__", "PySequenceSetItemProtocol")
+            .args(&["Index", "Value"])
+            .has_self(),
+        MethodProto::new("__delitem__", "PySequenceDelItemProtocol")
+            .args(&["Index"])
+            .has_self(),
+        MethodProto::new("__contains__", "PySequenceContainsProtocol")
+            .args(&["Item"])
+            .has_self(),
+        MethodProto::new("__concat__", "PySequenceConcatProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__repeat__", "PySequenceRepeatProtocol")
+            .args(&["Index"])
+            .has_self(),
+        MethodProto::new("__inplace_concat__", "PySequenceInplaceConcatProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__inplace_repeat__", "PySequenceInplaceRepeatProtocol")
+            .args(&["Index"])
+            .has_self(),
     ],
     py_methods: &[],
     slot_defs: &[
-        SlotDef::new(&["__len__"], "Py_sq_length", "pyo3::class::sequence::len"),
-        SlotDef::new(
-            &["__concat__"],
-            "Py_sq_concat",
-            "pyo3::class::sequence::concat",
-        ),
-        SlotDef::new(
-            &["__repeat__"],
-            "Py_sq_repeat",
-            "pyo3::class::sequence::repeat",
-        ),
-        SlotDef::new(
-            &["__getitem__"],
-            "Py_sq_item",
-            "pyo3::class::sequence::getitem",
-        ),
+        SlotDef::new(&["__len__"], "Py_sq_length", "len"),
+        SlotDef::new(&["__concat__"], "Py_sq_concat", "concat"),
+        SlotDef::new(&["__repeat__"], "Py_sq_repeat", "repeat"),
+        SlotDef::new(&["__getitem__"], "Py_sq_item", "getitem"),
         SlotDef::new(
             &["__setitem__", "__delitem__"],
             "Py_sq_ass_item",
-            "pyo3::class::sequence::setdelitem",
+            "setdelitem",
         ),
-        SlotDef::new(
-            &["__setitem__"],
-            "Py_sq_ass_item",
-            "pyo3::class::sequence::setitem",
-        ),
-        SlotDef::new(
-            &["__delitem__"],
-            "Py_sq_ass_item",
-            "pyo3::class::sequence::delitem",
-        ),
-        SlotDef::new(
-            &["__contains__"],
-            "Py_sq_contains",
-            "pyo3::class::sequence::contains",
-        ),
+        SlotDef::new(&["__setitem__"], "Py_sq_ass_item", "setitem"),
+        SlotDef::new(&["__delitem__"], "Py_sq_ass_item", "delitem"),
+        SlotDef::new(&["__contains__"], "Py_sq_contains", "contains"),
         SlotDef::new(
             &["__inplace_concat__"],
             "Py_sq_inplace_concat",
-            "pyo3::class::sequence::inplace_concat",
+            "inplace_concat",
         ),
         SlotDef::new(
             &["__inplace_repeat__"],
             "Py_sq_inplace_repeat",
-            "pyo3::class::sequence::inplace_repeat",
+            "inplace_repeat",
         ),
     ],
 };
 
 pub const NUM: Proto = Proto {
     name: "Number",
-    slots_trait: "pyo3::class::proto_methods::PyNumberProtocolSlots",
+    module: "pyo3::class::number",
+    slots_trait: "PyNumberProtocolSlots",
     slots_trait_slots: "number_protocol_slots",
     methods: &[
-        MethodProto::new("__add__", "pyo3::class::number::PyNumberAddProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__sub__", "pyo3::class::number::PyNumberSubProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__mul__", "pyo3::class::number::PyNumberMulProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__matmul__", "pyo3::class::number::PyNumberMatmulProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new(
-            "__truediv__",
-            "pyo3::class::number::PyNumberTruedivProtocol",
-        )
-        .args(&["Left", "Right"]),
-        MethodProto::new(
-            "__floordiv__",
-            "pyo3::class::number::PyNumberFloordivProtocol",
-        )
-        .args(&["Left", "Right"]),
-        MethodProto::new("__mod__", "pyo3::class::number::PyNumberModProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__divmod__", "pyo3::class::number::PyNumberDivmodProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__pow__", "pyo3::class::number::PyNumberPowProtocol")
-            .args(&["Left", "Right", "Modulo"]),
-        MethodProto::new("__lshift__", "pyo3::class::number::PyNumberLShiftProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__rshift__", "pyo3::class::number::PyNumberRShiftProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__and__", "pyo3::class::number::PyNumberAndProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__xor__", "pyo3::class::number::PyNumberXorProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__or__", "pyo3::class::number::PyNumberOrProtocol")
-            .args(&["Left", "Right"]),
-        MethodProto::new("__radd__", "pyo3::class::number::PyNumberRAddProtocol")
+        MethodProto::new("__add__", "PyNumberAddProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__sub__", "PyNumberSubProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__mul__", "PyNumberMulProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__matmul__", "PyNumberMatmulProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__truediv__", "PyNumberTruedivProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__floordiv__", "PyNumberFloordivProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__mod__", "PyNumberModProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__divmod__", "PyNumberDivmodProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__pow__", "PyNumberPowProtocol").args(&["Left", "Right", "Modulo"]),
+        MethodProto::new("__lshift__", "PyNumberLShiftProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__rshift__", "PyNumberRShiftProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__and__", "PyNumberAndProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__xor__", "PyNumberXorProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__or__", "PyNumberOrProtocol").args(&["Left", "Right"]),
+        MethodProto::new("__radd__", "PyNumberRAddProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__rsub__", "pyo3::class::number::PyNumberRSubProtocol")
+        MethodProto::new("__rsub__", "PyNumberRSubProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__rmul__", "pyo3::class::number::PyNumberRMulProtocol")
+        MethodProto::new("__rmul__", "PyNumberRMulProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new(
-            "__rmatmul__",
-            "pyo3::class::number::PyNumberRMatmulProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new(
-            "__rtruediv__",
-            "pyo3::class::number::PyNumberRTruedivProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new(
-            "__rfloordiv__",
-            "pyo3::class::number::PyNumberRFloordivProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new("__rmod__", "pyo3::class::number::PyNumberRModProtocol")
+        MethodProto::new("__rmatmul__", "PyNumberRMatmulProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new(
-            "__rdivmod__",
-            "pyo3::class::number::PyNumberRDivmodProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new("__rpow__", "pyo3::class::number::PyNumberRPowProtocol")
+        MethodProto::new("__rtruediv__", "PyNumberRTruedivProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__rfloordiv__", "PyNumberRFloordivProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__rmod__", "PyNumberRModProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__rdivmod__", "PyNumberRDivmodProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__rpow__", "PyNumberRPowProtocol")
             .args(&["Other", "Modulo"])
             .has_self(),
-        MethodProto::new(
-            "__rlshift__",
-            "pyo3::class::number::PyNumberRLShiftProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new(
-            "__rrshift__",
-            "pyo3::class::number::PyNumberRRShiftProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new("__rand__", "pyo3::class::number::PyNumberRAndProtocol")
+        MethodProto::new("__rlshift__", "PyNumberRLShiftProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__rxor__", "pyo3::class::number::PyNumberRXorProtocol")
+        MethodProto::new("__rrshift__", "PyNumberRRShiftProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__ror__", "pyo3::class::number::PyNumberROrProtocol")
+        MethodProto::new("__rand__", "PyNumberRAndProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__iadd__", "pyo3::class::number::PyNumberIAddProtocol")
+        MethodProto::new("__rxor__", "PyNumberRXorProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__isub__", "pyo3::class::number::PyNumberISubProtocol")
+        MethodProto::new("__ror__", "PyNumberROrProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__imul__", "pyo3::class::number::PyNumberIMulProtocol")
+        MethodProto::new("__iadd__", "PyNumberIAddProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new(
-            "__imatmul__",
-            "pyo3::class::number::PyNumberIMatmulProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new(
-            "__itruediv__",
-            "pyo3::class::number::PyNumberITruedivProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new(
-            "__ifloordiv__",
-            "pyo3::class::number::PyNumberIFloordivProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new("__imod__", "pyo3::class::number::PyNumberIModProtocol")
+        MethodProto::new("__isub__", "PyNumberISubProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__ipow__", "pyo3::class::number::PyNumberIPowProtocol")
+        MethodProto::new("__imul__", "PyNumberIMulProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new(
-            "__ilshift__",
-            "pyo3::class::number::PyNumberILShiftProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new(
-            "__irshift__",
-            "pyo3::class::number::PyNumberIRShiftProtocol",
-        )
-        .args(&["Other"])
-        .has_self(),
-        MethodProto::new("__iand__", "pyo3::class::number::PyNumberIAndProtocol")
+        MethodProto::new("__imatmul__", "PyNumberIMatmulProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__ixor__", "pyo3::class::number::PyNumberIXorProtocol")
+        MethodProto::new("__itruediv__", "PyNumberITruedivProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__ior__", "pyo3::class::number::PyNumberIOrProtocol")
+        MethodProto::new("__ifloordiv__", "PyNumberIFloordivProtocol")
             .args(&["Other"])
             .has_self(),
-        MethodProto::new("__neg__", "pyo3::class::number::PyNumberNegProtocol").has_self(),
-        MethodProto::new("__pos__", "pyo3::class::number::PyNumberPosProtocol").has_self(),
-        MethodProto::new("__abs__", "pyo3::class::number::PyNumberAbsProtocol").has_self(),
-        MethodProto::new("__invert__", "pyo3::class::number::PyNumberInvertProtocol").has_self(),
-        MethodProto::new(
-            "__complex__",
-            "pyo3::class::number::PyNumberComplexProtocol",
-        )
-        .has_self(),
-        MethodProto::new("__int__", "pyo3::class::number::PyNumberIntProtocol").has_self(),
-        MethodProto::new("__float__", "pyo3::class::number::PyNumberFloatProtocol").has_self(),
-        MethodProto::new("__index__", "pyo3::class::number::PyNumberIndexProtocol").has_self(),
-        MethodProto::new("__round__", "pyo3::class::number::PyNumberRoundProtocol")
+        MethodProto::new("__imod__", "PyNumberIModProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__ipow__", "PyNumberIPowProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__ilshift__", "PyNumberILShiftProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__irshift__", "PyNumberIRShiftProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__iand__", "PyNumberIAndProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__ixor__", "PyNumberIXorProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__ior__", "PyNumberIOrProtocol")
+            .args(&["Other"])
+            .has_self(),
+        MethodProto::new("__neg__", "PyNumberNegProtocol").has_self(),
+        MethodProto::new("__pos__", "PyNumberPosProtocol").has_self(),
+        MethodProto::new("__abs__", "PyNumberAbsProtocol").has_self(),
+        MethodProto::new("__invert__", "PyNumberInvertProtocol").has_self(),
+        MethodProto::new("__complex__", "PyNumberComplexProtocol").has_self(),
+        MethodProto::new("__int__", "PyNumberIntProtocol").has_self(),
+        MethodProto::new("__float__", "PyNumberFloatProtocol").has_self(),
+        MethodProto::new("__index__", "PyNumberIndexProtocol").has_self(),
+        MethodProto::new("__round__", "PyNumberRoundProtocol")
             .args(&["NDigits"])
             .has_self(),
     ],
     py_methods: &[
-        PyMethod::coexist("__radd__", "pyo3::class::number::PyNumberRAddProtocolImpl"),
-        PyMethod::coexist("__rsub__", "pyo3::class::number::PyNumberRSubProtocolImpl"),
-        PyMethod::coexist("__rmul__", "pyo3::class::number::PyNumberRMulProtocolImpl"),
-        PyMethod::coexist(
-            "__rmatmul__",
-            "pyo3::class::number::PyNumberRMatmulProtocolImpl",
-        ),
-        PyMethod::coexist(
-            "__rtruediv__",
-            "pyo3::class::number::PyNumberRTruedivProtocolImpl",
-        ),
-        PyMethod::coexist(
-            "__rfloordiv__",
-            "pyo3::class::number::PyNumberRFloordivProtocolImpl",
-        ),
-        PyMethod::coexist("__rmod__", "pyo3::class::number::PyNumberRModProtocolImpl"),
-        PyMethod::coexist(
-            "__rdivmod__",
-            "pyo3::class::number::PyNumberRDivmodProtocolImpl",
-        ),
-        PyMethod::coexist("__rpow__", "pyo3::class::number::PyNumberRPowProtocolImpl"),
-        PyMethod::coexist(
-            "__rlshift__",
-            "pyo3::class::number::PyNumberRLShiftProtocolImpl",
-        ),
-        PyMethod::coexist(
-            "__rrshift__",
-            "pyo3::class::number::PyNumberRRShiftProtocolImpl",
-        ),
-        PyMethod::coexist("__rand__", "pyo3::class::number::PyNumberRAndProtocolImpl"),
-        PyMethod::coexist("__rxor__", "pyo3::class::number::PyNumberRXorProtocolImpl"),
-        PyMethod::coexist("__ror__", "pyo3::class::number::PyNumberROrProtocolImpl"),
-        PyMethod::new(
-            "__complex__",
-            "pyo3::class::number::PyNumberComplexProtocolImpl",
-        ),
-        PyMethod::new(
-            "__round__",
-            "pyo3::class::number::PyNumberRoundProtocolImpl",
-        ),
+        PyMethod::coexist("__radd__", "PyNumberRAddProtocolImpl"),
+        PyMethod::coexist("__rsub__", "PyNumberRSubProtocolImpl"),
+        PyMethod::coexist("__rmul__", "PyNumberRMulProtocolImpl"),
+        PyMethod::coexist("__rmatmul__", "PyNumberRMatmulProtocolImpl"),
+        PyMethod::coexist("__rtruediv__", "PyNumberRTruedivProtocolImpl"),
+        PyMethod::coexist("__rfloordiv__", "PyNumberRFloordivProtocolImpl"),
+        PyMethod::coexist("__rmod__", "PyNumberRModProtocolImpl"),
+        PyMethod::coexist("__rdivmod__", "PyNumberRDivmodProtocolImpl"),
+        PyMethod::coexist("__rpow__", "PyNumberRPowProtocolImpl"),
+        PyMethod::coexist("__rlshift__", "PyNumberRLShiftProtocolImpl"),
+        PyMethod::coexist("__rrshift__", "PyNumberRRShiftProtocolImpl"),
+        PyMethod::coexist("__rand__", "PyNumberRAndProtocolImpl"),
+        PyMethod::coexist("__rxor__", "PyNumberRXorProtocolImpl"),
+        PyMethod::coexist("__ror__", "PyNumberROrProtocolImpl"),
+        PyMethod::new("__complex__", "PyNumberComplexProtocolImpl"),
+        PyMethod::new("__round__", "PyNumberRoundProtocolImpl"),
     ],
     slot_defs: &[
-        SlotDef::new(
-            &["__add__", "__radd__"],
-            "Py_nb_add",
-            "pyo3::class::number::add_radd",
-        ),
-        SlotDef::new(&["__add__"], "Py_nb_add", "pyo3::class::number::add"),
-        SlotDef::new(&["__radd__"], "Py_nb_add", "pyo3::class::number::radd"),
-        SlotDef::new(
-            &["__sub__", "__rsub__"],
-            "Py_nb_subtract",
-            "pyo3::class::number::sub_rsub",
-        ),
-        SlotDef::new(&["__sub__"], "Py_nb_subtract", "pyo3::class::number::sub"),
-        SlotDef::new(&["__rsub__"], "Py_nb_subtract", "pyo3::class::number::rsub"),
-        SlotDef::new(
-            &["__mul__", "__rmul__"],
-            "Py_nb_multiply",
-            "pyo3::class::number::mul_rmul",
-        ),
-        SlotDef::new(&["__mul__"], "Py_nb_multiply", "pyo3::class::number::mul"),
-        SlotDef::new(&["__rmul__"], "Py_nb_multiply", "pyo3::class::number::rmul"),
-        SlotDef::new(&["__mod__"], "Py_nb_remainder", "pyo3::class::number::mod_"),
+        SlotDef::new(&["__add__", "__radd__"], "Py_nb_add", "add_radd"),
+        SlotDef::new(&["__add__"], "Py_nb_add", "add"),
+        SlotDef::new(&["__radd__"], "Py_nb_add", "radd"),
+        SlotDef::new(&["__sub__", "__rsub__"], "Py_nb_subtract", "sub_rsub"),
+        SlotDef::new(&["__sub__"], "Py_nb_subtract", "sub"),
+        SlotDef::new(&["__rsub__"], "Py_nb_subtract", "rsub"),
+        SlotDef::new(&["__mul__", "__rmul__"], "Py_nb_multiply", "mul_rmul"),
+        SlotDef::new(&["__mul__"], "Py_nb_multiply", "mul"),
+        SlotDef::new(&["__rmul__"], "Py_nb_multiply", "rmul"),
+        SlotDef::new(&["__mod__"], "Py_nb_remainder", "mod_"),
         SlotDef::new(
             &["__divmod__", "__rdivmod__"],
             "Py_nb_divmod",
-            "pyo3::class::number::divmod_rdivmod",
+            "divmod_rdivmod",
         ),
-        SlotDef::new(
-            &["__divmod__"],
-            "Py_nb_divmod",
-            "pyo3::class::number::divmod",
-        ),
-        SlotDef::new(
-            &["__rdivmod__"],
-            "Py_nb_divmod",
-            "pyo3::class::number::rdivmod",
-        ),
-        SlotDef::new(
-            &["__pow__", "__rpow__"],
-            "Py_nb_power",
-            "pyo3::class::number::pow_rpow",
-        ),
-        SlotDef::new(&["__pow__"], "Py_nb_power", "pyo3::class::number::pow"),
-        SlotDef::new(&["__rpow__"], "Py_nb_power", "pyo3::class::number::rpow"),
-        SlotDef::new(&["__neg__"], "Py_nb_negative", "pyo3::class::number::neg"),
-        SlotDef::new(&["__pos__"], "Py_nb_positive", "pyo3::class::number::pos"),
-        SlotDef::new(&["__abs__"], "Py_nb_absolute", "pyo3::class::number::abs"),
-        SlotDef::new(
-            &["__invert__"],
-            "Py_nb_invert",
-            "pyo3::class::number::invert",
-        ),
+        SlotDef::new(&["__divmod__"], "Py_nb_divmod", "divmod"),
+        SlotDef::new(&["__rdivmod__"], "Py_nb_divmod", "rdivmod"),
+        SlotDef::new(&["__pow__", "__rpow__"], "Py_nb_power", "pow_rpow"),
+        SlotDef::new(&["__pow__"], "Py_nb_power", "pow"),
+        SlotDef::new(&["__rpow__"], "Py_nb_power", "rpow"),
+        SlotDef::new(&["__neg__"], "Py_nb_negative", "neg"),
+        SlotDef::new(&["__pos__"], "Py_nb_positive", "pos"),
+        SlotDef::new(&["__abs__"], "Py_nb_absolute", "abs"),
+        SlotDef::new(&["__invert__"], "Py_nb_invert", "invert"),
         SlotDef::new(
             &["__lshift__", "__rlshift__"],
             "Py_nb_lshift",
-            "pyo3::class::number::lshift_rlshift",
+            "lshift_rlshift",
         ),
-        SlotDef::new(
-            &["__lshift__"],
-            "Py_nb_lshift",
-            "pyo3::class::number::lshift",
-        ),
-        SlotDef::new(
-            &["__rlshift__"],
-            "Py_nb_lshift",
-            "pyo3::class::number::rlshift",
-        ),
+        SlotDef::new(&["__lshift__"], "Py_nb_lshift", "lshift"),
+        SlotDef::new(&["__rlshift__"], "Py_nb_lshift", "rlshift"),
         SlotDef::new(
             &["__rshift__", "__rrshift__"],
             "Py_nb_rshift",
-            "pyo3::class::number::rshift_rrshift",
+            "rshift_rrshift",
         ),
-        SlotDef::new(
-            &["__rshift__"],
-            "Py_nb_rshift",
-            "pyo3::class::number::rshift",
-        ),
-        SlotDef::new(
-            &["__rrshift__"],
-            "Py_nb_rshift",
-            "pyo3::class::number::rrshift",
-        ),
-        SlotDef::new(
-            &["__and__", "__rand__"],
-            "Py_nb_and",
-            "pyo3::class::number::and_rand",
-        ),
-        SlotDef::new(&["__and__"], "Py_nb_and", "pyo3::class::number::and"),
-        SlotDef::new(&["__rand__"], "Py_nb_and", "pyo3::class::number::rand"),
-        SlotDef::new(
-            &["__xor__", "__rxor__"],
-            "Py_nb_xor",
-            "pyo3::class::number::xor_rxor",
-        ),
-        SlotDef::new(&["__xor__"], "Py_nb_xor", "pyo3::class::number::xor"),
-        SlotDef::new(&["__rxor__"], "Py_nb_xor", "pyo3::class::number::rxor"),
-        SlotDef::new(
-            &["__or__", "__ror__"],
-            "Py_nb_or",
-            "pyo3::class::number::or_ror",
-        ),
-        SlotDef::new(&["__or__"], "Py_nb_or", "pyo3::class::number::or"),
-        SlotDef::new(&["__ror__"], "Py_nb_or", "pyo3::class::number::ror"),
-        SlotDef::new(&["__int__"], "Py_nb_int", "pyo3::class::number::int"),
-        SlotDef::new(&["__float__"], "Py_nb_float", "pyo3::class::number::float"),
-        SlotDef::new(
-            &["__iadd__"],
-            "Py_nb_inplace_add",
-            "pyo3::class::number::iadd",
-        ),
-        SlotDef::new(
-            &["__isub__"],
-            "Py_nb_inplace_subtract",
-            "pyo3::class::number::isub",
-        ),
-        SlotDef::new(
-            &["__imul__"],
-            "Py_nb_inplace_multiply",
-            "pyo3::class::number::imul",
-        ),
-        SlotDef::new(
-            &["__imod__"],
-            "Py_nb_inplace_remainder",
-            "pyo3::class::number::imod",
-        ),
-        SlotDef::new(
-            &["__ipow__"],
-            "Py_nb_inplace_power",
-            "pyo3::class::number::ipow",
-        ),
-        SlotDef::new(
-            &["__ilshift__"],
-            "Py_nb_inplace_lshift",
-            "pyo3::class::number::ilshift",
-        ),
-        SlotDef::new(
-            &["__irshift__"],
-            "Py_nb_inplace_rshift",
-            "pyo3::class::number::irshift",
-        ),
-        SlotDef::new(
-            &["__iand__"],
-            "Py_nb_inplace_and",
-            "pyo3::class::number::iand",
-        ),
-        SlotDef::new(
-            &["__ixor__"],
-            "Py_nb_inplace_xor",
-            "pyo3::class::number::ixor",
-        ),
-        SlotDef::new(&["__ior__"], "Py_nb_inplace_or", "pyo3::class::number::ior"),
+        SlotDef::new(&["__rshift__"], "Py_nb_rshift", "rshift"),
+        SlotDef::new(&["__rrshift__"], "Py_nb_rshift", "rrshift"),
+        SlotDef::new(&["__and__", "__rand__"], "Py_nb_and", "and_rand"),
+        SlotDef::new(&["__and__"], "Py_nb_and", "and"),
+        SlotDef::new(&["__rand__"], "Py_nb_and", "rand"),
+        SlotDef::new(&["__xor__", "__rxor__"], "Py_nb_xor", "xor_rxor"),
+        SlotDef::new(&["__xor__"], "Py_nb_xor", "xor"),
+        SlotDef::new(&["__rxor__"], "Py_nb_xor", "rxor"),
+        SlotDef::new(&["__or__", "__ror__"], "Py_nb_or", "or_ror"),
+        SlotDef::new(&["__or__"], "Py_nb_or", "or"),
+        SlotDef::new(&["__ror__"], "Py_nb_or", "ror"),
+        SlotDef::new(&["__int__"], "Py_nb_int", "int"),
+        SlotDef::new(&["__float__"], "Py_nb_float", "float"),
+        SlotDef::new(&["__iadd__"], "Py_nb_inplace_add", "iadd"),
+        SlotDef::new(&["__isub__"], "Py_nb_inplace_subtract", "isub"),
+        SlotDef::new(&["__imul__"], "Py_nb_inplace_multiply", "imul"),
+        SlotDef::new(&["__imod__"], "Py_nb_inplace_remainder", "imod"),
+        SlotDef::new(&["__ipow__"], "Py_nb_inplace_power", "ipow"),
+        SlotDef::new(&["__ilshift__"], "Py_nb_inplace_lshift", "ilshift"),
+        SlotDef::new(&["__irshift__"], "Py_nb_inplace_rshift", "irshift"),
+        SlotDef::new(&["__iand__"], "Py_nb_inplace_and", "iand"),
+        SlotDef::new(&["__ixor__"], "Py_nb_inplace_xor", "ixor"),
+        SlotDef::new(&["__ior__"], "Py_nb_inplace_or", "ior"),
         SlotDef::new(
             &["__floordiv__", "__rfloordiv__"],
             "Py_nb_floor_divide",
-            "pyo3::class::number::floordiv_rfloordiv",
+            "floordiv_rfloordiv",
         ),
-        SlotDef::new(
-            &["__floordiv__"],
-            "Py_nb_floor_divide",
-            "pyo3::class::number::floordiv",
-        ),
-        SlotDef::new(
-            &["__rfloordiv__"],
-            "Py_nb_floor_divide",
-            "pyo3::class::number::rfloordiv",
-        ),
+        SlotDef::new(&["__floordiv__"], "Py_nb_floor_divide", "floordiv"),
+        SlotDef::new(&["__rfloordiv__"], "Py_nb_floor_divide", "rfloordiv"),
         SlotDef::new(
             &["__truediv__", "__rtruediv__"],
             "Py_nb_true_divide",
-            "pyo3::class::number::truediv_rtruediv",
+            "truediv_rtruediv",
         ),
-        SlotDef::new(
-            &["__truediv__"],
-            "Py_nb_true_divide",
-            "pyo3::class::number::truediv",
-        ),
-        SlotDef::new(
-            &["__rtruediv__"],
-            "Py_nb_true_divide",
-            "pyo3::class::number::rtruediv",
-        ),
+        SlotDef::new(&["__truediv__"], "Py_nb_true_divide", "truediv"),
+        SlotDef::new(&["__rtruediv__"], "Py_nb_true_divide", "rtruediv"),
         SlotDef::new(
             &["__ifloordiv__"],
             "Py_nb_inplace_floor_divide",
-            "pyo3::class::number::ifloordiv",
+            "ifloordiv",
         ),
-        SlotDef::new(
-            &["__itruediv__"],
-            "Py_nb_inplace_true_divide",
-            "pyo3::class::number::itruediv",
-        ),
-        SlotDef::new(&["__index__"], "Py_nb_index", "pyo3::class::number::index"),
+        SlotDef::new(&["__itruediv__"], "Py_nb_inplace_true_divide", "itruediv"),
+        SlotDef::new(&["__index__"], "Py_nb_index", "index"),
         SlotDef::new(
             &["__matmul__", "__rmatmul__"],
             "Py_nb_matrix_multiply",
-            "pyo3::class::number::matmul_rmatmul",
+            "matmul_rmatmul",
         ),
-        SlotDef::new(
-            &["__matmul__"],
-            "Py_nb_matrix_multiply",
-            "pyo3::class::number::matmul",
-        ),
-        SlotDef::new(
-            &["__rmatmul__"],
-            "Py_nb_matrix_multiply",
-            "pyo3::class::number::rmatmul",
-        ),
-        SlotDef::new(
-            &["__imatmul__"],
-            "Py_nb_inplace_matrix_multiply",
-            "pyo3::class::number::imatmul",
-        ),
+        SlotDef::new(&["__matmul__"], "Py_nb_matrix_multiply", "matmul"),
+        SlotDef::new(&["__rmatmul__"], "Py_nb_matrix_multiply", "rmatmul"),
+        SlotDef::new(&["__imatmul__"], "Py_nb_inplace_matrix_multiply", "imatmul"),
     ],
 };

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -457,6 +457,7 @@ fn impl_class(
                     .chain(protocols.mapping_protocol_slots())
                     .chain(protocols.sequence_protocol_slots())
                     .chain(protocols.async_protocol_slots())
+                    .chain(protocols.buffer_protocol_slots())
                     .cloned()
                     .for_each(visitor);
             }

--- a/src/class/basic.rs
+++ b/src/class/basic.rs
@@ -8,9 +8,8 @@
 //! Parts of the documentation are copied from the respective methods from the
 //! [typeobj docs](https://docs.python.org/3/c-api/typeobj.html)
 
-use super::proto_methods::TypedSlot;
 use crate::callback::{HashCallbackOutput, IntoPyCallbackOutput};
-use crate::{exceptions, ffi, FromPyObject, PyAny, PyCell, PyClass, PyObject, PyResult};
+use crate::{exceptions, ffi, FromPyObject, PyAny, PyCell, PyClass, PyObject};
 use std::os::raw::c_int;
 
 /// Operators for the __richcmp__ method
@@ -134,150 +133,73 @@ pub trait PyObjectRichcmpProtocol<'p>: PyObjectProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
-/// Extension trait for proc-macro backend.
+py_unary_func!(str, PyObjectStrProtocol, T::__str__);
+py_unary_func!(repr, PyObjectReprProtocol, T::__repr__);
+py_unary_func!(hash, PyObjectHashProtocol, T::__hash__, ffi::Py_hash_t);
+
 #[doc(hidden)]
-pub trait PyBasicSlots {
-    fn get_str() -> TypedSlot<ffi::reprfunc>
-    where
-        Self: for<'p> PyObjectStrProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_str,
-            py_unary_func!(PyObjectStrProtocol, Self::__str__),
-        )
-    }
-
-    fn get_repr() -> TypedSlot<ffi::reprfunc>
-    where
-        Self: for<'p> PyObjectReprProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_repr,
-            py_unary_func!(PyObjectReprProtocol, Self::__repr__),
-        )
-    }
-
-    fn get_hash() -> TypedSlot<ffi::hashfunc>
-    where
-        Self: for<'p> PyObjectHashProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_hash,
-            py_unary_func!(PyObjectHashProtocol, Self::__hash__, ffi::Py_hash_t),
-        )
-    }
-
-    fn get_getattr() -> TypedSlot<ffi::getattrofunc>
-    where
-        Self: for<'p> PyObjectGetAttrProtocol<'p>,
-    {
-        unsafe extern "C" fn wrap<T>(
-            slf: *mut ffi::PyObject,
-            arg: *mut ffi::PyObject,
-        ) -> *mut ffi::PyObject
-        where
-            T: for<'p> PyObjectGetAttrProtocol<'p>,
-        {
-            crate::callback_body!(py, {
-                // Behave like python's __getattr__ (as opposed to __getattribute__) and check
-                // for existing fields and methods first
-                let existing = ffi::PyObject_GenericGetAttr(slf, arg);
-                if existing.is_null() {
-                    // PyObject_HasAttr also tries to get an object and clears the error if it fails
-                    ffi::PyErr_Clear();
-                } else {
-                    return Ok(existing);
-                }
-
-                let slf = py.from_borrowed_ptr::<PyCell<T>>(slf);
-                let arg = py.from_borrowed_ptr::<PyAny>(arg);
-                call_ref!(slf, __getattr__, arg).convert(py)
-            })
+pub unsafe extern "C" fn getattr<T>(
+    slf: *mut ffi::PyObject,
+    arg: *mut ffi::PyObject,
+) -> *mut ffi::PyObject
+where
+    T: for<'p> PyObjectGetAttrProtocol<'p>,
+{
+    crate::callback_body!(py, {
+        // Behave like python's __getattr__ (as opposed to __getattribute__) and check
+        // for existing fields and methods first
+        let existing = ffi::PyObject_GenericGetAttr(slf, arg);
+        if existing.is_null() {
+            // PyObject_HasAttr also tries to get an object and clears the error if it fails
+            ffi::PyErr_Clear();
+        } else {
+            return Ok(existing);
         }
-        TypedSlot(ffi::Py_tp_getattro, wrap::<Self>)
-    }
 
-    fn get_richcmp() -> TypedSlot<ffi::richcmpfunc>
-    where
-        Self: for<'p> PyObjectRichcmpProtocol<'p>,
-    {
-        fn extract_op(op: c_int) -> PyResult<CompareOp> {
-            match op {
-                ffi::Py_LT => Ok(CompareOp::Lt),
-                ffi::Py_LE => Ok(CompareOp::Le),
-                ffi::Py_EQ => Ok(CompareOp::Eq),
-                ffi::Py_NE => Ok(CompareOp::Ne),
-                ffi::Py_GT => Ok(CompareOp::Gt),
-                ffi::Py_GE => Ok(CompareOp::Ge),
-                _ => Err(exceptions::PyValueError::new_err(
-                    "tp_richcompare called with invalid comparison operator",
-                )),
-            }
-        }
-        unsafe extern "C" fn wrap<T>(
-            slf: *mut ffi::PyObject,
-            arg: *mut ffi::PyObject,
-            op: c_int,
-        ) -> *mut ffi::PyObject
-        where
-            T: for<'p> PyObjectRichcmpProtocol<'p>,
-        {
-            crate::callback_body!(py, {
-                let slf = py.from_borrowed_ptr::<crate::PyCell<T>>(slf);
-                let arg = extract_or_return_not_implemented!(py, arg);
-                let op = extract_op(op)?;
-
-                slf.try_borrow()?.__richcmp__(arg, op).convert(py)
-            })
-        }
-        TypedSlot(ffi::Py_tp_richcompare, wrap::<Self>)
-    }
-
-    fn get_setattr() -> TypedSlot<ffi::setattrofunc>
-    where
-        Self: for<'p> PyObjectSetAttrProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_setattro,
-            py_func_set!(PyObjectSetAttrProtocol, Self::__setattr__),
-        )
-    }
-
-    fn get_delattr() -> TypedSlot<ffi::setattrofunc>
-    where
-        Self: for<'p> PyObjectDelAttrProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_setattro,
-            py_func_del!(PyObjectDelAttrProtocol, Self::__delattr__),
-        )
-    }
-
-    fn get_setdelattr() -> TypedSlot<ffi::setattrofunc>
-    where
-        Self: for<'p> PyObjectSetAttrProtocol<'p> + for<'p> PyObjectDelAttrProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_setattro,
-            py_func_set_del!(
-                PyObjectSetAttrProtocol,
-                PyObjectDelAttrProtocol,
-                Self,
-                __setattr__,
-                __delattr__
-            ),
-        )
-    }
-
-    fn get_bool() -> TypedSlot<ffi::inquiry>
-    where
-        Self: for<'p> PyObjectBoolProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_bool,
-            py_unary_func!(PyObjectBoolProtocol, Self::__bool__, c_int),
-        )
-    }
+        let slf = py.from_borrowed_ptr::<PyCell<T>>(slf);
+        let arg = py.from_borrowed_ptr::<PyAny>(arg);
+        call_ref!(slf, __getattr__, arg).convert(py)
+    })
 }
 
-impl<'p, T> PyBasicSlots for T where T: PyObjectProtocol<'p> {}
+#[doc(hidden)]
+pub unsafe extern "C" fn richcmp<T>(
+    slf: *mut ffi::PyObject,
+    arg: *mut ffi::PyObject,
+    op: c_int,
+) -> *mut ffi::PyObject
+where
+    T: for<'p> PyObjectRichcmpProtocol<'p>,
+{
+    crate::callback_body!(py, {
+        let slf = py.from_borrowed_ptr::<crate::PyCell<T>>(slf);
+        let arg = extract_or_return_not_implemented!(py, arg);
+        let op = match op {
+            ffi::Py_LT => CompareOp::Lt,
+            ffi::Py_LE => CompareOp::Le,
+            ffi::Py_EQ => CompareOp::Eq,
+            ffi::Py_NE => CompareOp::Ne,
+            ffi::Py_GT => CompareOp::Gt,
+            ffi::Py_GE => CompareOp::Ge,
+            _ => {
+                return Err(exceptions::PyValueError::new_err(
+                    "tp_richcompare called with invalid comparison operator",
+                ))
+            }
+        };
+
+        slf.try_borrow()?.__richcmp__(arg, op).convert(py)
+    })
+}
+
+py_func_set!(setattr, PyObjectSetAttrProtocol, T::__setattr__);
+py_func_del!(delattr, PyObjectDelAttrProtocol, T::__delattr__);
+py_func_set_del!(
+    setdelattr,
+    PyObjectSetAttrProtocol,
+    PyObjectDelAttrProtocol,
+    Self,
+    __setattr__,
+    __delattr__
+);
+py_unary_func!(bool, PyObjectBoolProtocol, T::__bool__, c_int);

--- a/src/class/buffer.rs
+++ b/src/class/buffer.rs
@@ -11,22 +11,18 @@ use std::os::raw::c_int;
 /// Buffer protocol interface
 ///
 /// For more information check [buffer protocol](https://docs.python.org/3/c-api/buffer.html)
-/// c-api
+/// c-api.
 #[allow(unused_variables)]
 pub trait PyBufferProtocol<'p>: PyClass {
+    // No default implementations so that implementors of this trait provide both methods.
+
     fn bf_getbuffer(slf: PyRefMut<Self>, view: *mut ffi::Py_buffer, flags: c_int) -> Self::Result
     where
-        Self: PyBufferGetBufferProtocol<'p>,
-    {
-        unimplemented!()
-    }
+        Self: PyBufferGetBufferProtocol<'p>;
 
     fn bf_releasebuffer(slf: PyRefMut<Self>, view: *mut ffi::Py_buffer) -> Self::Result
     where
-        Self: PyBufferReleaseBufferProtocol<'p>,
-    {
-        unimplemented!()
-    }
+        Self: PyBufferReleaseBufferProtocol<'p>;
 }
 
 pub trait PyBufferGetBufferProtocol<'p>: PyBufferProtocol<'p> {
@@ -37,46 +33,28 @@ pub trait PyBufferReleaseBufferProtocol<'p>: PyBufferProtocol<'p> {
     type Result: IntoPyCallbackOutput<()>;
 }
 
-/// Extension trait for proc-macro backend.
 #[doc(hidden)]
-pub trait PyBufferSlots {
-    fn get_getbuffer() -> ffi::getbufferproc
-    where
-        Self: for<'p> PyBufferGetBufferProtocol<'p>,
-    {
-        unsafe extern "C" fn wrap<T>(
-            slf: *mut ffi::PyObject,
-            arg1: *mut ffi::Py_buffer,
-            arg2: c_int,
-        ) -> c_int
-        where
-            T: for<'p> PyBufferGetBufferProtocol<'p>,
-        {
-            crate::callback_body!(py, {
-                let slf = py.from_borrowed_ptr::<PyCell<T>>(slf);
-                T::bf_getbuffer(slf.try_borrow_mut()?, arg1, arg2).convert(py)
-            })
-        }
-
-        wrap::<Self>
-    }
-
-    fn get_releasebuffer() -> ffi::releasebufferproc
-    where
-        Self: for<'p> PyBufferReleaseBufferProtocol<'p>,
-    {
-        unsafe extern "C" fn wrap<T>(slf: *mut ffi::PyObject, arg1: *mut ffi::Py_buffer)
-        where
-            T: for<'p> PyBufferReleaseBufferProtocol<'p>,
-        {
-            crate::callback_body!(py, {
-                let slf = py.from_borrowed_ptr::<crate::PyCell<T>>(slf);
-                T::bf_releasebuffer(slf.try_borrow_mut()?, arg1).convert(py)
-            })
-        }
-
-        wrap::<Self>
-    }
+pub unsafe extern "C" fn getbuffer<T>(
+    slf: *mut ffi::PyObject,
+    arg1: *mut ffi::Py_buffer,
+    arg2: c_int,
+) -> c_int
+where
+    T: for<'p> PyBufferGetBufferProtocol<'p>,
+{
+    crate::callback_body!(py, {
+        let slf = py.from_borrowed_ptr::<PyCell<T>>(slf);
+        T::bf_getbuffer(slf.try_borrow_mut()?, arg1, arg2).convert(py)
+    })
 }
 
-impl<'p, T> PyBufferSlots for T where T: PyBufferProtocol<'p> {}
+#[doc(hidden)]
+pub unsafe extern "C" fn releasebuffer<T>(slf: *mut ffi::PyObject, arg1: *mut ffi::Py_buffer)
+where
+    T: for<'p> PyBufferReleaseBufferProtocol<'p>,
+{
+    crate::callback_body!(py, {
+        let slf = py.from_borrowed_ptr::<crate::PyCell<T>>(slf);
+        T::bf_releasebuffer(slf.try_borrow_mut()?, arg1).convert(py)
+    })
+}

--- a/src/class/descr.rs
+++ b/src/class/descr.rs
@@ -5,10 +5,9 @@
 //! [Python information](
 //! https://docs.python.org/3/reference/datamodel.html#implementing-descriptors)
 
-use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::types::PyAny;
-use crate::{ffi, FromPyObject, PyClass, PyObject};
+use crate::{FromPyObject, PyClass, PyObject};
 use std::os::raw::c_int;
 
 /// Descriptor interface
@@ -71,28 +70,5 @@ pub trait PyDescrSetNameProtocol<'p>: PyDescrProtocol<'p> {
     type Result: IntoPyCallbackOutput<()>;
 }
 
-/// Extension trait for our proc-macro backend.
-#[doc(hidden)]
-pub trait PyDescrSlots {
-    fn get_descr_get() -> TypedSlot<ffi::descrgetfunc>
-    where
-        Self: for<'p> PyDescrGetProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_descr_get,
-            py_ternarys_func!(PyDescrGetProtocol, Self::__get__),
-        )
-    }
-
-    fn get_descr_set() -> TypedSlot<ffi::descrsetfunc>
-    where
-        Self: for<'p> PyDescrSetProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_descr_set,
-            py_ternarys_func!(PyDescrSetProtocol, Self::__set__, c_int),
-        )
-    }
-}
-
-impl<'p, T> PyDescrSlots for T where T: PyDescrProtocol<'p> {}
+py_ternarys_func!(descr_get, PyDescrGetProtocol, Self::__get__);
+py_ternarys_func!(descr_set, PyDescrSetProtocol, Self::__set__, c_int);

--- a/src/class/iter.rs
+++ b/src/class/iter.rs
@@ -2,7 +2,6 @@
 //! Python Iterator Interface.
 //! Trait and support implementation for implementing iterators
 
-use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::derive_utils::TryFromPyCell;
 use crate::err::PyResult;
@@ -72,30 +71,8 @@ pub trait PyIterNextProtocol<'p>: PyIterProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyIterNextOutput>;
 }
 
-/// Extension trait for proc-macro backend.
-#[doc(hidden)]
-pub trait PyIterSlots {
-    fn get_iter() -> TypedSlot<ffi::getiterfunc>
-    where
-        Self: for<'p> PyIterIterProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_iter,
-            py_unarys_func!(PyIterIterProtocol, Self::__iter__),
-        )
-    }
-    fn get_iternext() -> TypedSlot<ffi::iternextfunc>
-    where
-        Self: for<'p> PyIterNextProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_tp_iternext,
-            py_unarys_func!(PyIterNextProtocol, Self::__next__),
-        )
-    }
-}
-
-impl<'p, T> PyIterSlots for T where T: PyIterProtocol<'p> {}
+py_unarys_func!(iter, PyIterIterProtocol, Self::__iter__);
+py_unarys_func!(iternext, PyIterNextProtocol, Self::__next__);
 
 /// Output of `__next__` which can either `yield` the next value in the iteration, or
 /// `return` a value to raise `StopIteration` in Python.

--- a/src/class/mapping.rs
+++ b/src/class/mapping.rs
@@ -3,7 +3,6 @@
 //! Python Mapping Interface
 //! Trait and support implementation for implementing mapping support
 
-use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::{exceptions, ffi, FromPyObject, PyClass, PyObject};
 
@@ -73,64 +72,15 @@ pub trait PyMappingReversedProtocol<'p>: PyMappingProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
-/// Extension trait for proc-macro backend.
-#[doc(hidden)]
-pub trait PyMappingSlots {
-    fn get_len() -> TypedSlot<ffi::lenfunc>
-    where
-        Self: for<'p> PyMappingLenProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_mp_length,
-            py_len_func!(PyMappingLenProtocol, Self::__len__),
-        )
-    }
-
-    fn get_getitem() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyMappingGetItemProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_mp_subscript,
-            py_binary_func!(PyMappingGetItemProtocol, Self::__getitem__),
-        )
-    }
-
-    fn get_setitem() -> TypedSlot<ffi::objobjargproc>
-    where
-        Self: for<'p> PyMappingSetItemProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_mp_ass_subscript,
-            py_func_set!(PyMappingSetItemProtocol, Self::__setitem__),
-        )
-    }
-
-    fn get_delitem() -> TypedSlot<ffi::objobjargproc>
-    where
-        Self: for<'p> PyMappingDelItemProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_mp_ass_subscript,
-            py_func_del!(PyMappingDelItemProtocol, Self::__delitem__),
-        )
-    }
-
-    fn get_setdelitem() -> TypedSlot<ffi::objobjargproc>
-    where
-        Self: for<'p> PyMappingSetItemProtocol<'p> + for<'p> PyMappingDelItemProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_mp_ass_subscript,
-            py_func_set_del!(
-                PyMappingSetItemProtocol,
-                PyMappingDelItemProtocol,
-                Self,
-                __setitem__,
-                __delitem__
-            ),
-        )
-    }
-}
-
-impl<'p, T> PyMappingSlots for T where T: PyMappingProtocol<'p> {}
+py_len_func!(len, PyMappingLenProtocol, Self::__len__);
+py_binary_func!(getitem, PyMappingGetItemProtocol, Self::__getitem__);
+py_func_set!(setitem, PyMappingSetItemProtocol, Self::__setitem__);
+py_func_del!(delitem, PyMappingDelItemProtocol, Self::__delitem__);
+py_func_set_del!(
+    setdelitem,
+    PyMappingSetItemProtocol,
+    PyMappingDelItemProtocol,
+    Self,
+    __setitem__,
+    __delitem__
+);

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -16,6 +16,7 @@ pub mod mapping;
 #[doc(hidden)]
 pub mod methods;
 pub mod number;
+#[doc(hidden)]
 pub mod proto_methods;
 pub mod pyasync;
 pub mod sequence;

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -2,7 +2,6 @@
 
 //! Python Number Interface
 //! Trait and support implementation for implementing number protocol
-use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::err::PyErr;
 use crate::{ffi, FromPyObject, PyClass, PyObject};
@@ -579,721 +578,202 @@ pub trait PyNumberIndexProtocol<'p>: PyNumberProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
-/// Extension trait for proc-macro backend.
+py_binary_fallback_num_func!(
+    add_radd,
+    T,
+    PyNumberAddProtocol::__add__,
+    PyNumberRAddProtocol::__radd__
+);
+py_binary_num_func!(add, PyNumberAddProtocol, T::__add__);
+py_binary_reversed_num_func!(radd, PyNumberRAddProtocol, T::__radd__);
+py_binary_fallback_num_func!(
+    sub_rsub,
+    T,
+    PyNumberSubProtocol::__sub__,
+    PyNumberRSubProtocol::__rsub__
+);
+py_binary_num_func!(sub, PyNumberSubProtocol, T::__sub__);
+py_binary_reversed_num_func!(rsub, PyNumberRSubProtocol, T::__rsub__);
+py_binary_fallback_num_func!(
+    mul_rmul,
+    T,
+    PyNumberMulProtocol::__mul__,
+    PyNumberRMulProtocol::__rmul__
+);
+py_binary_num_func!(mul, PyNumberMulProtocol, T::__mul__);
+py_binary_reversed_num_func!(rmul, PyNumberRMulProtocol, T::__rmul__);
+py_binary_num_func!(mod_, PyNumberModProtocol, T::__mod__);
+py_binary_fallback_num_func!(
+    divmod_rdivmod,
+    T,
+    PyNumberDivmodProtocol::__divmod__,
+    PyNumberRDivmodProtocol::__rdivmod__
+);
+py_binary_num_func!(divmod, PyNumberDivmodProtocol, T::__divmod__);
+py_binary_reversed_num_func!(rdivmod, PyNumberRDivmodProtocol, T::__rdivmod__);
+
 #[doc(hidden)]
-pub trait PyNumberSlots {
-    fn get_add_radd() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberAddProtocol<'p> + for<'p> PyNumberRAddProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_add,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberAddProtocol::__add__,
-                PyNumberRAddProtocol::__radd__
-            ),
-        )
-    }
-
-    fn get_add() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberAddProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_add,
-            py_binary_num_func!(PyNumberAddProtocol, Self::__add__),
-        )
-    }
-
-    fn get_radd() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRAddProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_add,
-            py_binary_reversed_num_func!(PyNumberRAddProtocol, Self::__radd__),
-        )
-    }
-
-    fn get_sub_rsub() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberSubProtocol<'p> + for<'p> PyNumberRSubProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_subtract,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberSubProtocol::__sub__,
-                PyNumberRSubProtocol::__rsub__
-            ),
-        )
-    }
-
-    fn get_sub() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberSubProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_subtract,
-            py_binary_num_func!(PyNumberSubProtocol, Self::__sub__),
-        )
-    }
-
-    fn get_rsub() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRSubProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_subtract,
-            py_binary_reversed_num_func!(PyNumberRSubProtocol, Self::__rsub__),
-        )
-    }
-
-    fn get_mul_rmul() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberMulProtocol<'p> + for<'p> PyNumberRMulProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_multiply,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberMulProtocol::__mul__,
-                PyNumberRMulProtocol::__rmul__
-            ),
-        )
-    }
-
-    fn get_mul() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberMulProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_multiply,
-            py_binary_num_func!(PyNumberMulProtocol, Self::__mul__),
-        )
-    }
-
-    fn get_rmul() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRMulProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_multiply,
-            py_binary_reversed_num_func!(PyNumberRMulProtocol, Self::__rmul__),
-        )
-    }
-
-    fn get_mod() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberModProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_remainder,
-            py_binary_num_func!(PyNumberModProtocol, Self::__mod__),
-        )
-    }
-
-    fn get_divmod_rdivmod() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberDivmodProtocol<'p> + for<'p> PyNumberRDivmodProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_divmod,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberDivmodProtocol::__divmod__,
-                PyNumberRDivmodProtocol::__rdivmod__
-            ),
-        )
-    }
-
-    fn get_divmod() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberDivmodProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_divmod,
-            py_binary_num_func!(PyNumberDivmodProtocol, Self::__divmod__),
-        )
-    }
-
-    fn get_rdivmod() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRDivmodProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_divmod,
-            py_binary_reversed_num_func!(PyNumberRDivmodProtocol, Self::__rdivmod__),
-        )
-    }
-
-    fn get_pow_rpow() -> TypedSlot<ffi::ternaryfunc>
-    where
-        Self: for<'p> PyNumberPowProtocol<'p> + for<'p> PyNumberRPowProtocol<'p>,
-    {
-        unsafe extern "C" fn wrap_pow_and_rpow<T>(
-            lhs: *mut ffi::PyObject,
-            rhs: *mut ffi::PyObject,
-            modulo: *mut ffi::PyObject,
-        ) -> *mut ffi::PyObject
-        where
-            T: for<'p> PyNumberPowProtocol<'p> + for<'p> PyNumberRPowProtocol<'p>,
-        {
-            crate::callback_body!(py, {
-                let lhs = py.from_borrowed_ptr::<crate::PyAny>(lhs);
-                let rhs = py.from_borrowed_ptr::<crate::PyAny>(rhs);
-                let modulo = py.from_borrowed_ptr::<crate::PyAny>(modulo);
-                // First, try __pow__
-                match (lhs.extract(), rhs.extract(), modulo.extract()) {
-                    (Ok(l), Ok(r), Ok(m)) => T::__pow__(l, r, m).convert(py),
-                    _ => {
-                        // Then try __rpow__
-                        let slf: &crate::PyCell<T> = extract_or_return_not_implemented!(rhs);
-                        let arg = extract_or_return_not_implemented!(lhs);
-                        let modulo = extract_or_return_not_implemented!(modulo);
-                        slf.try_borrow()?.__rpow__(arg, modulo).convert(py)
-                    }
-                }
-            })
-        }
-
-        TypedSlot(ffi::Py_nb_power, wrap_pow_and_rpow::<Self>)
-    }
-
-    fn get_pow() -> TypedSlot<ffi::ternaryfunc>
-    where
-        Self: for<'p> PyNumberPowProtocol<'p>,
-    {
-        unsafe extern "C" fn wrap_pow<T>(
-            lhs: *mut ffi::PyObject,
-            rhs: *mut ffi::PyObject,
-            modulo: *mut ffi::PyObject,
-        ) -> *mut ffi::PyObject
-        where
-            T: for<'p> PyNumberPowProtocol<'p>,
-        {
-            crate::callback_body!(py, {
-                let lhs = extract_or_return_not_implemented!(py, lhs);
-                let rhs = extract_or_return_not_implemented!(py, rhs);
-                let modulo = extract_or_return_not_implemented!(py, modulo);
-                T::__pow__(lhs, rhs, modulo).convert(py)
-            })
-        }
-
-        TypedSlot(ffi::Py_nb_power, wrap_pow::<Self>)
-    }
-
-    fn get_rpow() -> TypedSlot<ffi::ternaryfunc>
-    where
-        Self: for<'p> PyNumberRPowProtocol<'p>,
-    {
-        unsafe extern "C" fn wrap_rpow<T>(
-            arg: *mut ffi::PyObject,
-            slf: *mut ffi::PyObject,
-            modulo: *mut ffi::PyObject,
-        ) -> *mut ffi::PyObject
-        where
-            T: for<'p> PyNumberRPowProtocol<'p>,
-        {
-            crate::callback_body!(py, {
-                let slf: &crate::PyCell<T> = extract_or_return_not_implemented!(py, slf);
-                let arg = extract_or_return_not_implemented!(py, arg);
-                let modulo = extract_or_return_not_implemented!(py, modulo);
+pub unsafe extern "C" fn pow_rpow<T>(
+    lhs: *mut ffi::PyObject,
+    rhs: *mut ffi::PyObject,
+    modulo: *mut ffi::PyObject,
+) -> *mut ffi::PyObject
+where
+    T: for<'p> PyNumberPowProtocol<'p> + for<'p> PyNumberRPowProtocol<'p>,
+{
+    crate::callback_body!(py, {
+        let lhs = py.from_borrowed_ptr::<crate::PyAny>(lhs);
+        let rhs = py.from_borrowed_ptr::<crate::PyAny>(rhs);
+        let modulo = py.from_borrowed_ptr::<crate::PyAny>(modulo);
+        // First, try __pow__
+        match (lhs.extract(), rhs.extract(), modulo.extract()) {
+            (Ok(l), Ok(r), Ok(m)) => T::__pow__(l, r, m).convert(py),
+            _ => {
+                // Then try __rpow__
+                let slf: &crate::PyCell<T> = extract_or_return_not_implemented!(rhs);
+                let arg = extract_or_return_not_implemented!(lhs);
+                let modulo = extract_or_return_not_implemented!(modulo);
                 slf.try_borrow()?.__rpow__(arg, modulo).convert(py)
-            })
+            }
         }
-
-        TypedSlot(ffi::Py_nb_power, wrap_rpow::<Self>)
-    }
-
-    fn get_neg() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyNumberNegProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_negative,
-            py_unary_func!(PyNumberNegProtocol, Self::__neg__),
-        )
-    }
-
-    fn get_pos() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyNumberPosProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_positive,
-            py_unary_func!(PyNumberPosProtocol, Self::__pos__),
-        )
-    }
-
-    fn get_abs() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyNumberAbsProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_absolute,
-            py_unary_func!(PyNumberAbsProtocol, Self::__abs__),
-        )
-    }
-
-    fn get_invert() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyNumberInvertProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_invert,
-            py_unary_func!(PyNumberInvertProtocol, Self::__invert__),
-        )
-    }
-
-    fn get_lshift_rlshift() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberLShiftProtocol<'p> + for<'p> PyNumberRLShiftProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_lshift,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberLShiftProtocol::__lshift__,
-                PyNumberRLShiftProtocol::__rlshift__
-            ),
-        )
-    }
-
-    fn get_lshift() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberLShiftProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_lshift,
-            py_binary_num_func!(PyNumberLShiftProtocol, Self::__lshift__),
-        )
-    }
-
-    fn get_rlshift() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRLShiftProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_lshift,
-            py_binary_reversed_num_func!(PyNumberRLShiftProtocol, Self::__rlshift__),
-        )
-    }
-
-    fn get_rshift_rrshift() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRShiftProtocol<'p> + for<'p> PyNumberRRShiftProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_rshift,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberRShiftProtocol::__rshift__,
-                PyNumberRRShiftProtocol::__rrshift__
-            ),
-        )
-    }
-
-    fn get_rshift() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRShiftProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_rshift,
-            py_binary_num_func!(PyNumberRShiftProtocol, Self::__rshift__),
-        )
-    }
-
-    fn get_rrshift() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRRShiftProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_rshift,
-            py_binary_reversed_num_func!(PyNumberRRShiftProtocol, Self::__rrshift__),
-        )
-    }
-
-    fn get_and_rand() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberAndProtocol<'p> + for<'p> PyNumberRAndProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_and,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberAndProtocol::__and__,
-                PyNumberRAndProtocol::__rand__
-            ),
-        )
-    }
-
-    fn get_and() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberAndProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_and,
-            py_binary_num_func!(PyNumberAndProtocol, Self::__and__),
-        )
-    }
-
-    fn get_rand() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRAndProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_and,
-            py_binary_reversed_num_func!(PyNumberRAndProtocol, Self::__rand__),
-        )
-    }
-
-    fn get_xor_rxor() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberXorProtocol<'p> + for<'p> PyNumberRXorProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_xor,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberXorProtocol::__xor__,
-                PyNumberRXorProtocol::__rxor__
-            ),
-        )
-    }
-
-    fn get_xor() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberXorProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_xor,
-            py_binary_num_func!(PyNumberXorProtocol, Self::__xor__),
-        )
-    }
-
-    fn get_rxor() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRXorProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_xor,
-            py_binary_reversed_num_func!(PyNumberRXorProtocol, Self::__rxor__),
-        )
-    }
-
-    fn get_or_ror() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberOrProtocol<'p> + for<'p> PyNumberROrProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_or,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberOrProtocol::__or__,
-                PyNumberROrProtocol::__ror__
-            ),
-        )
-    }
-
-    fn get_or() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberOrProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_or,
-            py_binary_num_func!(PyNumberOrProtocol, Self::__or__),
-        )
-    }
-
-    fn get_ror() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberROrProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_or,
-            py_binary_reversed_num_func!(PyNumberROrProtocol, Self::__ror__),
-        )
-    }
-
-    fn get_int() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyNumberIntProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_int,
-            py_unary_func!(PyNumberIntProtocol, Self::__int__),
-        )
-    }
-
-    fn get_float() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyNumberFloatProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_float,
-            py_unary_func!(PyNumberFloatProtocol, Self::__float__),
-        )
-    }
-
-    fn get_iadd() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberIAddProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_add,
-            py_binary_self_func!(PyNumberIAddProtocol, Self::__iadd__),
-        )
-    }
-
-    fn get_isub() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberISubProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_subtract,
-            py_binary_self_func!(PyNumberISubProtocol, Self::__isub__),
-        )
-    }
-
-    fn get_imul() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberIMulProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_multiply,
-            py_binary_self_func!(PyNumberIMulProtocol, Self::__imul__),
-        )
-    }
-
-    fn get_imod() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberIModProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_remainder,
-            py_binary_self_func!(PyNumberIModProtocol, Self::__imod__),
-        )
-    }
-
-    fn get_ipow() -> TypedSlot<ffi::ternaryfunc>
-    where
-        Self: for<'p> PyNumberIPowProtocol<'p>,
-    {
-        // NOTE: Somehow __ipow__ causes SIGSEGV in Python < 3.8 when we extract,
-        // so we ignore it. It's the same as what CPython does.
-        unsafe extern "C" fn wrap_ipow<T>(
-            slf: *mut ffi::PyObject,
-            other: *mut ffi::PyObject,
-            _modulo: *mut ffi::PyObject,
-        ) -> *mut ffi::PyObject
-        where
-            T: for<'p> PyNumberIPowProtocol<'p>,
-        {
-            crate::callback_body!(py, {
-                let slf_cell = py.from_borrowed_ptr::<crate::PyCell<T>>(slf);
-                let other = py.from_borrowed_ptr::<crate::PyAny>(other);
-                call_operator_mut!(py, slf_cell, __ipow__, other).convert(py)?;
-                ffi::Py_INCREF(slf);
-                Ok::<_, PyErr>(slf)
-            })
-        }
-
-        TypedSlot(ffi::Py_nb_inplace_power, wrap_ipow::<Self>)
-    }
-
-    fn get_ilshift() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberILShiftProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_lshift,
-            py_binary_self_func!(PyNumberILShiftProtocol, Self::__ilshift__),
-        )
-    }
-
-    fn get_irshift() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberIRShiftProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_rshift,
-            py_binary_self_func!(PyNumberIRShiftProtocol, Self::__irshift__),
-        )
-    }
-
-    fn get_iand() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberIAndProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_and,
-            py_binary_self_func!(PyNumberIAndProtocol, Self::__iand__),
-        )
-    }
-
-    fn get_ixor() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberIXorProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_xor,
-            py_binary_self_func!(PyNumberIXorProtocol, Self::__ixor__),
-        )
-    }
-
-    fn get_ior() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberIOrProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_or,
-            py_binary_self_func!(PyNumberIOrProtocol, Self::__ior__),
-        )
-    }
-
-    fn get_floordiv_rfloordiv() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberFloordivProtocol<'p> + for<'p> PyNumberRFloordivProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_floor_divide,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberFloordivProtocol::__floordiv__,
-                PyNumberRFloordivProtocol::__rfloordiv__
-            ),
-        )
-    }
-
-    fn get_floordiv() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberFloordivProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_floor_divide,
-            py_binary_num_func!(PyNumberFloordivProtocol, Self::__floordiv__),
-        )
-    }
-
-    fn get_rfloordiv() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRFloordivProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_floor_divide,
-            py_binary_reversed_num_func!(PyNumberRFloordivProtocol, Self::__rfloordiv__),
-        )
-    }
-
-    fn get_truediv_rtruediv() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberTruedivProtocol<'p> + for<'p> PyNumberRTruedivProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_true_divide,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberTruedivProtocol::__truediv__,
-                PyNumberRTruedivProtocol::__rtruediv__
-            ),
-        )
-    }
-
-    fn get_truediv() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberTruedivProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_true_divide,
-            py_binary_num_func!(PyNumberTruedivProtocol, Self::__truediv__),
-        )
-    }
-
-    fn get_rtruediv() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRTruedivProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_true_divide,
-            py_binary_reversed_num_func!(PyNumberRTruedivProtocol, Self::__rtruediv__),
-        )
-    }
-
-    fn get_ifloordiv() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberIFloordivProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_floor_divide,
-            py_binary_self_func!(PyNumberIFloordivProtocol, Self::__ifloordiv__),
-        )
-    }
-
-    fn get_itruediv() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberITruedivProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_true_divide,
-            py_binary_self_func!(PyNumberITruedivProtocol, Self::__itruediv__),
-        )
-    }
-
-    fn get_index() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyNumberIndexProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_index,
-            py_unary_func!(PyNumberIndexProtocol, Self::__index__),
-        )
-    }
-
-    fn get_matmul_rmatmul() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberMatmulProtocol<'p> + for<'p> PyNumberRMatmulProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_matrix_multiply,
-            py_binary_fallback_num_func!(
-                Self,
-                PyNumberMatmulProtocol::__matmul__,
-                PyNumberRMatmulProtocol::__rmatmul__
-            ),
-        )
-    }
-
-    fn get_matmul() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberMatmulProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_matrix_multiply,
-            py_binary_num_func!(PyNumberMatmulProtocol, Self::__matmul__),
-        )
-    }
-
-    fn get_rmatmul() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberRMatmulProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_matrix_multiply,
-            py_binary_reversed_num_func!(PyNumberRMatmulProtocol, Self::__rmatmul__),
-        )
-    }
-
-    fn get_imatmul() -> TypedSlot<ffi::binaryfunc>
-    where
-        Self: for<'p> PyNumberIMatmulProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_nb_inplace_matrix_multiply,
-            py_binary_self_func!(PyNumberIMatmulProtocol, Self::__imatmul__),
-        )
-    }
+    })
 }
 
-impl<'p, T> PyNumberSlots for T where T: PyNumberProtocol<'p> {}
+#[doc(hidden)]
+pub unsafe extern "C" fn pow<T>(
+    lhs: *mut ffi::PyObject,
+    rhs: *mut ffi::PyObject,
+    modulo: *mut ffi::PyObject,
+) -> *mut ffi::PyObject
+where
+    T: for<'p> PyNumberPowProtocol<'p>,
+{
+    crate::callback_body!(py, {
+        let lhs = extract_or_return_not_implemented!(py, lhs);
+        let rhs = extract_or_return_not_implemented!(py, rhs);
+        let modulo = extract_or_return_not_implemented!(py, modulo);
+        T::__pow__(lhs, rhs, modulo).convert(py)
+    })
+}
+
+#[doc(hidden)]
+pub unsafe extern "C" fn rpow<T>(
+    arg: *mut ffi::PyObject,
+    slf: *mut ffi::PyObject,
+    modulo: *mut ffi::PyObject,
+) -> *mut ffi::PyObject
+where
+    T: for<'p> PyNumberRPowProtocol<'p>,
+{
+    crate::callback_body!(py, {
+        let slf: &crate::PyCell<T> = extract_or_return_not_implemented!(py, slf);
+        let arg = extract_or_return_not_implemented!(py, arg);
+        let modulo = extract_or_return_not_implemented!(py, modulo);
+        slf.try_borrow()?.__rpow__(arg, modulo).convert(py)
+    })
+}
+
+py_unary_func!(neg, PyNumberNegProtocol, T::__neg__);
+py_unary_func!(pos, PyNumberPosProtocol, T::__pos__);
+py_unary_func!(abs, PyNumberAbsProtocol, T::__abs__);
+py_unary_func!(invert, PyNumberInvertProtocol, T::__invert__);
+py_binary_fallback_num_func!(
+    lshift_rlshift,
+    T,
+    PyNumberLShiftProtocol::__lshift__,
+    PyNumberRLShiftProtocol::__rlshift__
+);
+py_binary_num_func!(lshift, PyNumberLShiftProtocol, T::__lshift__);
+py_binary_reversed_num_func!(rlshift, PyNumberRLShiftProtocol, T::__rlshift__);
+py_binary_fallback_num_func!(
+    rshift_rrshift,
+    T,
+    PyNumberRShiftProtocol::__rshift__,
+    PyNumberRRShiftProtocol::__rrshift__
+);
+py_binary_num_func!(rshift, PyNumberRShiftProtocol, T::__rshift__);
+py_binary_reversed_num_func!(rrshift, PyNumberRRShiftProtocol, T::__rrshift__);
+py_binary_fallback_num_func!(
+    and_rand,
+    T,
+    PyNumberAndProtocol::__and__,
+    PyNumberRAndProtocol::__rand__
+);
+py_binary_num_func!(and, PyNumberAndProtocol, T::__and__);
+py_binary_reversed_num_func!(rand, PyNumberRAndProtocol, T::__rand__);
+py_binary_fallback_num_func!(
+    xor_rxor,
+    T,
+    PyNumberXorProtocol::__xor__,
+    PyNumberRXorProtocol::__rxor__
+);
+py_binary_num_func!(xor, PyNumberXorProtocol, T::__xor__);
+py_binary_reversed_num_func!(rxor, PyNumberRXorProtocol, T::__rxor__);
+py_binary_fallback_num_func!(
+    or_ror,
+    T,
+    PyNumberOrProtocol::__or__,
+    PyNumberROrProtocol::__ror__
+);
+py_binary_num_func!(or, PyNumberOrProtocol, T::__or__);
+py_binary_reversed_num_func!(ror, PyNumberROrProtocol, T::__ror__);
+py_unary_func!(int, PyNumberIntProtocol, T::__int__);
+py_unary_func!(float, PyNumberFloatProtocol, T::__float__);
+py_binary_self_func!(iadd, PyNumberIAddProtocol, T::__iadd__);
+py_binary_self_func!(isub, PyNumberISubProtocol, T::__isub__);
+py_binary_self_func!(imul, PyNumberIMulProtocol, T::__imul__);
+py_binary_self_func!(imod, PyNumberIModProtocol, T::__imod__);
+
+#[doc(hidden)]
+pub unsafe extern "C" fn ipow<T>(
+    slf: *mut ffi::PyObject,
+    other: *mut ffi::PyObject,
+    _modulo: *mut ffi::PyObject,
+) -> *mut ffi::PyObject
+where
+    T: for<'p> PyNumberIPowProtocol<'p>,
+{
+    // NOTE: Somehow __ipow__ causes SIGSEGV in Python < 3.8 when we extract,
+    // so we ignore it. It's the same as what CPython does.
+    crate::callback_body!(py, {
+        let slf_cell = py.from_borrowed_ptr::<crate::PyCell<T>>(slf);
+        let other = py.from_borrowed_ptr::<crate::PyAny>(other);
+        call_operator_mut!(py, slf_cell, __ipow__, other).convert(py)?;
+        ffi::Py_INCREF(slf);
+        Ok::<_, PyErr>(slf)
+    })
+}
+
+py_binary_self_func!(ilshift, PyNumberILShiftProtocol, T::__ilshift__);
+py_binary_self_func!(irshift, PyNumberIRShiftProtocol, T::__irshift__);
+py_binary_self_func!(iand, PyNumberIAndProtocol, T::__iand__);
+py_binary_self_func!(ixor, PyNumberIXorProtocol, T::__ixor__);
+py_binary_self_func!(ior, PyNumberIOrProtocol, T::__ior__);
+py_binary_fallback_num_func!(
+    floordiv_rfloordiv,
+    T,
+    PyNumberFloordivProtocol::__floordiv__,
+    PyNumberRFloordivProtocol::__rfloordiv__
+);
+py_binary_num_func!(floordiv, PyNumberFloordivProtocol, T::__floordiv__);
+py_binary_reversed_num_func!(rfloordiv, PyNumberRFloordivProtocol, T::__rfloordiv__);
+py_binary_fallback_num_func!(
+    truediv_rtruediv,
+    T,
+    PyNumberTruedivProtocol::__truediv__,
+    PyNumberRTruedivProtocol::__rtruediv__
+);
+py_binary_num_func!(truediv, PyNumberTruedivProtocol, T::__truediv__);
+py_binary_reversed_num_func!(rtruediv, PyNumberRTruedivProtocol, T::__rtruediv__);
+py_binary_self_func!(ifloordiv, PyNumberIFloordivProtocol, T::__ifloordiv__);
+py_binary_self_func!(itruediv, PyNumberITruedivProtocol, T::__itruediv__);
+py_unary_func!(index, PyNumberIndexProtocol, T::__index__);
+py_binary_fallback_num_func!(
+    matmul_rmatmul,
+    T,
+    PyNumberMatmulProtocol::__matmul__,
+    PyNumberRMatmulProtocol::__rmatmul__
+);
+py_binary_num_func!(matmul, PyNumberMatmulProtocol, T::__matmul__);
+py_binary_reversed_num_func!(rmatmul, PyNumberRMatmulProtocol, T::__rmatmul__);
+py_binary_self_func!(imatmul, PyNumberIMatmulProtocol, T::__imatmul__);

--- a/src/class/proto_methods.rs
+++ b/src/class/proto_methods.rs
@@ -1,78 +1,135 @@
 use crate::ffi;
-#[cfg(not(Py_LIMITED_API))]
-use crate::ffi::PyBufferProcs;
-
-/// ABI3 doesn't have buffer APIs, so here we define the empty one.
-#[cfg(Py_LIMITED_API)]
-#[doc(hidden)]
-#[derive(Clone)]
-pub struct PyBufferProcs;
+use std::marker::PhantomData;
 
 // Note(kngwyu): default implementations are for rust-numpy. Please don't remove them.
 pub trait PyProtoMethods {
-    fn get_type_slots() -> Vec<ffi::PyType_Slot> {
-        vec![]
-    }
-    fn get_buffer() -> Option<PyBufferProcs> {
+    fn for_each_proto_slot<Visitor: FnMut(ffi::PyType_Slot)>(_visitor: Visitor) {}
+    fn get_buffer() -> Option<&'static PyBufferProcs> {
         None
     }
 }
 
-/// Typed version of `ffi::PyType_Slot`
-#[doc(hidden)]
-pub struct TypedSlot<T: Sized>(pub std::os::raw::c_int, pub T);
+pub struct PyClassProtocols<T>(PhantomData<T>);
 
-#[doc(hidden)]
-pub enum PyProtoMethodDef {
-    Slots(Vec<ffi::PyType_Slot>),
-    Buffer(PyBufferProcs),
-}
-
-impl From<Vec<ffi::PyType_Slot>> for PyProtoMethodDef {
-    fn from(slots: Vec<ffi::PyType_Slot>) -> Self {
-        PyProtoMethodDef::Slots(slots)
+impl<T> PyClassProtocols<T> {
+    pub fn new() -> Self {
+        Self(PhantomData)
     }
 }
 
-impl From<PyBufferProcs> for PyProtoMethodDef {
-    fn from(buffer_procs: PyBufferProcs) -> Self {
-        PyProtoMethodDef::Buffer(buffer_procs)
+impl<T> Default for PyClassProtocols<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-#[doc(hidden)]
-#[cfg(feature = "macros")]
-pub trait PyProtoInventory: inventory::Collect {
-    fn new(methods: PyProtoMethodDef) -> Self;
-    fn get(&'static self) -> &'static PyProtoMethodDef;
-}
-
-#[doc(hidden)]
-#[cfg(feature = "macros")]
-pub trait HasProtoInventory {
-    type ProtoMethods: PyProtoInventory;
-}
-
-#[cfg(feature = "macros")]
-impl<T: HasProtoInventory> PyProtoMethods for T {
-    fn get_type_slots() -> Vec<ffi::PyType_Slot> {
-        inventory::iter::<T::ProtoMethods>
-            .into_iter()
-            .filter_map(|def| match def.get() {
-                PyProtoMethodDef::Slots(slots) => Some(slots),
-                PyProtoMethodDef::Buffer(_) => None,
-            })
-            .flatten()
-            .cloned()
-            .collect()
+impl<T> Clone for PyClassProtocols<T> {
+    fn clone(&self) -> Self {
+        Self::new()
     }
+}
 
-    fn get_buffer() -> Option<PyBufferProcs> {
-        inventory::iter::<T::ProtoMethods>
-            .into_iter()
-            .find_map(|def| match def.get() {
-                PyProtoMethodDef::Slots(_) => None,
-                PyProtoMethodDef::Buffer(buf) => Some(buf.clone()),
-            })
+impl<T> Copy for PyClassProtocols<T> {}
+
+// All traits describing slots, as well as the fallback implementations for unimplemented protos
+//
+// Protos which are implented use dtolnay specialization to implement for PyClassProtocols<T>
+
+pub trait PyObjectProtocolSlots<T> {
+    fn object_protocol_slots(self) -> &'static [ffi::PyType_Slot];
+}
+
+impl<T> PyObjectProtocolSlots<T> for &'_ PyClassProtocols<T> {
+    fn object_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
+        &[]
+    }
+}
+
+pub trait PyDescrProtocolSlots<T> {
+    fn descr_protocol_slots(self) -> &'static [ffi::PyType_Slot];
+}
+
+impl<T> PyDescrProtocolSlots<T> for &'_ PyClassProtocols<T> {
+    fn descr_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
+        &[]
+    }
+}
+
+pub trait PyGCProtocolSlots<T> {
+    fn gc_protocol_slots(self) -> &'static [ffi::PyType_Slot];
+}
+
+impl<T> PyGCProtocolSlots<T> for &'_ PyClassProtocols<T> {
+    fn gc_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
+        &[]
+    }
+}
+
+pub trait PyIterProtocolSlots<T> {
+    fn iter_protocol_slots(self) -> &'static [ffi::PyType_Slot];
+}
+
+impl<T> PyIterProtocolSlots<T> for &'_ PyClassProtocols<T> {
+    fn iter_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
+        &[]
+    }
+}
+
+pub trait PyMappingProtocolSlots<T> {
+    fn mapping_protocol_slots(self) -> &'static [ffi::PyType_Slot];
+}
+
+impl<T> PyMappingProtocolSlots<T> for &'_ PyClassProtocols<T> {
+    fn mapping_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
+        &[]
+    }
+}
+
+pub trait PyNumberProtocolSlots<T> {
+    fn number_protocol_slots(self) -> &'static [ffi::PyType_Slot];
+}
+
+impl<T> PyNumberProtocolSlots<T> for &'_ PyClassProtocols<T> {
+    fn number_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
+        &[]
+    }
+}
+
+pub trait PyAsyncProtocolSlots<T> {
+    fn async_protocol_slots(self) -> &'static [ffi::PyType_Slot];
+}
+
+impl<T> PyAsyncProtocolSlots<T> for &'_ PyClassProtocols<T> {
+    fn async_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
+        &[]
+    }
+}
+
+pub trait PySequenceProtocolSlots<T> {
+    fn sequence_protocol_slots(self) -> &'static [ffi::PyType_Slot];
+}
+
+impl<T> PySequenceProtocolSlots<T> for &'_ PyClassProtocols<T> {
+    fn sequence_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
+        &[]
+    }
+}
+
+// Buffer protocol has a slightly different implementation because the slots can't actually be used
+// to set the buffer protocol...
+
+#[cfg(not(Py_LIMITED_API))]
+pub use ffi::PyBufferProcs;
+
+#[cfg(Py_LIMITED_API)]
+pub struct PyBufferProcs;
+
+pub trait PyBufferProtocolSlots<T> {
+    fn buffer_procs(self) -> Option<&'static PyBufferProcs>;
+}
+
+impl<T> PyBufferProtocolSlots<T> for &'_ PyClassProtocols<T> {
+    fn buffer_procs(self) -> Option<&'static PyBufferProcs> {
+        None
     }
 }

--- a/src/class/pyasync.rs
+++ b/src/class/pyasync.rs
@@ -8,7 +8,6 @@
 //! [PEP-0492](https://www.python.org/dev/peps/pep-0492/)
 //!
 
-use super::proto_methods::TypedSlot;
 use crate::callback::IntoPyCallbackOutput;
 use crate::derive_utils::TryFromPyCell;
 use crate::err::PyResult;
@@ -86,41 +85,9 @@ pub trait PyAsyncAexitProtocol<'p>: PyAsyncProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
-/// Extension trait for proc-macro backend.
-#[doc(hidden)]
-pub trait PyAsyncSlots {
-    fn get_await() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyAsyncAwaitProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_am_await,
-            py_unarys_func!(PyAsyncAwaitProtocol, Self::__await__),
-        )
-    }
-
-    fn get_aiter() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyAsyncAiterProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_am_aiter,
-            py_unarys_func!(PyAsyncAiterProtocol, Self::__aiter__),
-        )
-    }
-
-    fn get_anext() -> TypedSlot<ffi::unaryfunc>
-    where
-        Self: for<'p> PyAsyncAnextProtocol<'p>,
-    {
-        TypedSlot(
-            ffi::Py_am_anext,
-            py_unarys_func!(PyAsyncAnextProtocol, Self::__anext__),
-        )
-    }
-}
-
-impl<'p, T> PyAsyncSlots for T where T: PyAsyncProtocol<'p> {}
+py_unarys_func!(await_, PyAsyncAwaitProtocol, Self::__await__);
+py_unarys_func!(aiter, PyAsyncAiterProtocol, Self::__aiter__);
+py_unarys_func!(anext, PyAsyncAnextProtocol, Self::__anext__);
 
 /// Output of `__anext__`.
 pub enum IterANextOutput<T, U> {

--- a/src/ffi/typeslots.rs
+++ b/src/ffi/typeslots.rs
@@ -1,5 +1,9 @@
 use std::os::raw::c_int;
 
+#[cfg(not(Py_LIMITED_API))]
+pub const Py_bf_getbuffer: c_int = 1;
+#[cfg(not(Py_LIMITED_API))]
+pub const Py_bf_releasebuffer: c_int = 2;
 pub const Py_mp_ass_subscript: c_int = 3;
 pub const Py_mp_length: c_int = 4;
 pub const Py_mp_subscript: c_int = 5;

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -238,6 +238,9 @@ fn tp_init_additional<T: PyClass>(type_object: *mut ffi::PyTypeObject) {
         }
     }
 
+    // Setting buffer protocols via slots doesn't work until Python 3.9, so on older versions we
+    // must manually fixup the type object.
+    #[cfg(not(Py_3_9))]
     if let Some(buffer) = T::get_buffer() {
         unsafe {
             (*(*type_object).tp_as_buffer).bf_getbuffer = buffer.bf_getbuffer;

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -191,11 +191,11 @@ where
 
     // protocol methods
     let mut has_gc_methods = false;
-    for slot in T::get_type_slots() {
+    T::for_each_proto_slot(|slot| {
         has_gc_methods |= slot.slot == ffi::Py_tp_clear;
         has_gc_methods |= slot.slot == ffi::Py_tp_traverse;
         slots.0.push(slot);
-    }
+    });
 
     slots.push(0, ptr::null_mut());
     let mut spec = ffi::PyType_Spec {


### PR DESCRIPTION
This is a refactoring for `#[pyproto]` which uses dtolnay specialization instead of inventory as the underlying implementation.

The dtolnay specialization is done for a type `PyClassProtocols<T: PyClass>`. There are traits `PyObjectProtocolSlots<T>` etc. which are what get specialized. The default implementation is `PyObjectProtocolSlots<T> for &'_ PyClassProtocols<T>`, and the specialized implementation is `PyObjectProtocolSlots<T> for PyClassProtocols<T>`.

The traits with slot getter methods have been replaced by free functions to implement the slots, which the pyproto macro code directly uses.

It works out as slightly fewer LOC and also because all the protocols are known at compile time, the compiler should be able to optimise pyclass initialization better.

At the moment we lost the type checking we had with `TypedSlot`. If that's a concern I think I can reintroduce a type check in the slot defs in the macro code.

Follow-ups:
- I think I can see a way to refactor the code further to implement #1206, but I'm not entirely sure it'll work out. So I stopped here for now which works nicely and I think is a nice simplification.
- I think that we can make `inventory` an optional feature where it's only needed when users want multiple `#[pymethods]` blocks for a single PyClass. That'd be a nice simplification to remove overheads.