### PR TITLE
ci: deny warnings using RUSTFLAGS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
 
     env:
       RUST_BACKTRACE: 1
+      RUSTFLAGS: "-D warnings"
 
   coverage:
     needs: [fmt]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Stop including `Py_TRACE_REFS` config setting automatically if `Py_DEBUG` is set on Python 3.8 and up. [#1334](https://github.com/PyO3/pyo3/pull/1334)
+- Remove `#[deny(warnings)]` attribute (and instead refuse warnings only in CI). [#1340](https://github.com/PyO3/pyo3/pull/1340)
 
 ## [0.13.0] - 2020-12-22
 ### Packaging

--- a/Contributing.md
+++ b/Contributing.md
@@ -49,7 +49,9 @@ Here are a few things to note when you are writing PRs.
 
 The PyO3 repo uses Github Actions. PRs are blocked from merging if CI is not successful.
 
-Formatting, linting and tests are checked for all Rust and Python code. Tests run with all supported Python versions with the latest stable Rust compiler, as well as for Python 3.9 with the minimum supported Rust version.
+Formatting, linting and tests are checked for all Rust and Python code. In addition, all warnings in Rust code are disallowed (using `RUSTFLAGS="-D warnings"`).
+
+Tests run with all supported Python versions with the latest stable Rust compiler, as well as for Python 3.9 with the minimum supported Rust version.
 
 ### Minimum supported Rust version
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(feature = "nightly", feature(specialization))]
 #![allow(clippy::missing_safety_doc)] // FIXME (#698)
-#![deny(warnings)]
 
 //! Rust bindings to the Python interpreter.
 //!


### PR DESCRIPTION
Move `#[deny(warnings)]` to CI, using `RUSTFLAGS`, as suggested in https://github.com/PyO3/pyo3/pull/1338#discussion_r548366038