### PR TITLE
pyclass: fix deprecation warning for no __module__ attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Stop including `Py_TRACE_REFS` config setting automatically if `Py_DEBUG` is set on Python 3.8 and up. [#1334](https://github.com/PyO3/pyo3/pull/1334)
 - Remove `#[deny(warnings)]` attribute (and instead refuse warnings only in CI). [#1340](https://github.com/PyO3/pyo3/pull/1340)
 - Deprecate FFI definitions `PyEval_CallObjectWithKeywords`, `PyEval_CallObject`, `PyEval_CallFunction`, `PyEval_CallMethod` when building for Python 3.9. [#1338](https://github.com/PyO3/pyo3/pull/1338)
+- Fix deprecation warning for missing `__module__` with `#[pyclass]`. [#1343](https://github.com/PyO3/pyo3/pull/1343)
 
 ## [0.13.0] - 2020-12-22
 ### Packaging

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -153,7 +153,7 @@ fn tp_doc<T: PyClass>() -> PyResult<Option<*mut c_void>> {
 fn get_type_name<T: PyTypeInfo>(module_name: Option<&str>) -> PyResult<*mut c_char> {
     Ok(match module_name {
         Some(module_name) => CString::new(format!("{}.{}", module_name, T::NAME))?.into_raw(),
-        None => CString::new(T::NAME)?.into_raw(),
+        None => CString::new(format!("builtins.{}", T::NAME))?.into_raw(),
     })
 }
 


### PR DESCRIPTION
Closes #1298 .

This ensures that `__module__` is always set (usually to "builtins", which is consistent with what we already do).