### PR TITLE
ffi module cleanup: genobject.h to iterobject.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add support for `#[pyclass(dict)]` and `#[pyclass(weakref)]` with the `abi3` feature on Python 3.9 and up. [#1342](https://github.com/PyO3/pyo3/pull/1342)
+- Add FFI definitions `PyOS_BeforeFork`, `PyOS_AfterFork_Parent`, `PyOS_AfterFork_Child` for Python 3.7 and up. [#1348](https://github.com/PyO3/pyo3/pull/1348)
 
 ### Changed
 - Deprecate FFI definitions `PyEval_CallObjectWithKeywords`, `PyEval_CallObject`, `PyEval_CallFunction`, `PyEval_CallMethod` when building for Python 3.9. [#1338](https://github.com/PyO3/pyo3/pull/1338)
 - Deprecate FFI definitions `PyGetSetDef_DICT` and `PyGetSetDef_INIT` which have never been in the Python API. [#1341](https://github.com/PyO3/pyo3/pull/1341)
+- Deprecate FFI definitions `PyGen_NeedsFinalizing`, `PyImport_Cleanup` (removed in 3.9), and `PyOS_InitInterrupts` (3.10). [#1348](https://github.com/PyO3/pyo3/pull/1348)
+- Deprecate FFI definition `PyOS_AfterFork` for Python 3.7 and up. [#1348](https://github.com/PyO3/pyo3/pull/1348)
+- Deprecate FFI definition `PyCoro_Check` and `PyAsyncGen_Check` in favor of `PyCoro_CheckExact` and `PyAsyncGen_CheckExact` respectively to mirror Python API. [#1348](https://github.com/PyO3/pyo3/pull/1348)
+- Deprecate FFI definition `PyCoroWrapper_Check` which has never been in the Python API. [#1348](https://github.com/PyO3/pyo3/pull/1348)
 
 ### Removed
 - Remove FFI definition `PyFrame_ClearFreeList` when building for Python 3.9. [#1341](https://github.com/PyO3/pyo3/pull/1341)
 - Remove FFI definition `_PyDict_Contains` when building for Python 3.10. [#1341](https://github.com/PyO3/pyo3/pull/1341)
+- Remove FFI definitions `PyGen_NeedsFinalizing`, `PyImport_Cleanup` (for 3.9 and up), and `PyOS_InitInterrupts` (3.10). [#1348](https://github.com/PyO3/pyo3/pull/1348)
 
 ### Fixed
 - Stop including `Py_TRACE_REFS` config setting automatically if `Py_DEBUG` is set on Python 3.8 and up. [#1334](https://github.com/PyO3/pyo3/pull/1334)

--- a/src/ffi/cpython/mod.rs
+++ b/src/ffi/cpython/mod.rs
@@ -8,6 +8,7 @@ pub mod code;
 pub mod dictobject;
 // skipped fileobject.h
 pub mod frameobject;
+// skipped import.h
 
 pub use self::abstract_::*;
 #[cfg(not(PyPy))]

--- a/src/ffi/genobject.rs
+++ b/src/ffi/genobject.rs
@@ -35,35 +35,66 @@ pub unsafe fn PyGen_CheckExact(op: *mut PyObject) -> c_int {
 
 extern "C" {
     pub fn PyGen_New(frame: *mut PyFrameObject) -> *mut PyObject;
+    // skipped PyGen_New
+    // skipped PyGen_NewWithQualName
+    // skipped _PyGen_SetStopIterationValue
+    // skipped _PyGen_FetchStopIterationValue
+    // skipped _PyGen_yf
+    // skipped _PyGen_Finalize
+    #[cfg(not(Py_3_9))]
+    #[deprecated(note = "This function was never documented in the Python API.")]
     pub fn PyGen_NeedsFinalizing(op: *mut PyGenObject) -> c_int;
 }
+
+// skipped PyCoroObject
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub static mut PyCoro_Type: PyTypeObject;
+    pub static mut _PyCoroWrapper_Type: PyTypeObject;
 }
 
+#[deprecated(since = "0.14.0", note = "use PyCoro_CheckExact instead")]
 #[inline]
 pub unsafe fn PyCoro_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &mut PyCoro_Type)
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
-extern "C" {
-    pub static mut _PyCoroWrapper_Type: PyTypeObject;
+#[inline]
+pub unsafe fn PyCoro_CheckExact(op: *mut PyObject) -> c_int {
+    PyObject_TypeCheck(op, &mut PyCoro_Type)
 }
 
+#[deprecated(since = "0.14.0", note = "not in Python API")]
 #[inline]
 pub unsafe fn PyCoroWrapper_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &mut _PyCoroWrapper_Type)
 }
 
+// skipped _PyCoro_GetAwaitableIter
+// skipped PyCoro_New
+
+// skipped PyAsyncGenObject
+
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub static mut PyAsyncGen_Type: PyTypeObject;
+// skipped _PyAsyncGenASend_Type
+// skipped _PyAsyncGenWrappedValue_Type
+// skipped _PyAsyncGenAThrow_Type
 }
 
+// skipped PyAsyncGen_New
+
+#[deprecated(since = "0.14.0", note = "use PyCoro_CheckExact instead")]
 #[inline]
 pub unsafe fn PyAsyncGen_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &mut PyAsyncGen_Type)
 }
+
+#[inline]
+pub unsafe fn PyAsyncGen_CheckExact(op: *mut PyObject) -> c_int {
+    PyObject_TypeCheck(op, &mut PyAsyncGen_Type)
+}
+
+// skipped _PyAsyncGenValueWrapperNew

--- a/src/ffi/import.rs
+++ b/src/ffi/import.rs
@@ -26,6 +26,7 @@ extern "C" {
     ) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyImport_GetModuleDict")]
     pub fn PyImport_GetModuleDict() -> *mut PyObject;
+    // skipped Python 3.7 / ex-non-limited PyImport_GetModule
     pub fn PyImport_AddModuleObject(name: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyImport_AddModule")]
     pub fn PyImport_AddModule(name: *const c_char) -> *mut PyObject;
@@ -67,6 +68,11 @@ extern "C" {
     pub fn PyImport_Import(name: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyImport_ReloadModule")]
     pub fn PyImport_ReloadModule(m: *mut PyObject) -> *mut PyObject;
+    #[cfg(not(Py_3_9))]
+    #[deprecated(
+        since = "0.14.0",
+        note = "Removed in Python 3.9 as it was \"For internal use only\"."
+    )]
     pub fn PyImport_Cleanup();
     pub fn PyImport_ImportFrozenModuleObject(name: *mut PyObject) -> c_int;
     pub fn PyImport_ImportFrozenModule(name: *const c_char) -> c_int;

--- a/src/ffi/intrcheck.rs
+++ b/src/ffi/intrcheck.rs
@@ -3,7 +3,23 @@ use std::os::raw::c_int;
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyOS_InterruptOccurred")]
     pub fn PyOS_InterruptOccurred() -> c_int;
+    #[cfg(not(Py_3_10))]
+    #[deprecated(
+        since = "0.14.0",
+        note = "Not documented in Python API; see Python 3.10 release notes"
+    )]
     pub fn PyOS_InitInterrupts();
+
+    #[cfg(any(not(Py_LIMITED_API), Py_3_7))]
+    pub fn PyOS_BeforeFork();
+    #[cfg(any(not(Py_LIMITED_API), Py_3_7))]
+    pub fn PyOS_AfterFork_Parent();
+    #[cfg(any(not(Py_LIMITED_API), Py_3_7))]
+    pub fn PyOS_AfterFork_Child();
+    #[cfg_attr(Py_3_7, deprecated(note = "use PyOS_AfterFork_Child instead"))]
     #[cfg_attr(PyPy, link_name = "PyPyOS_AfterFork")]
     pub fn PyOS_AfterFork();
+
+// skipped non-limited _PyOS_IsMainThread
+// skipped non-limited Windows _PyOS_SigintEvent
 }

--- a/src/ffi/iterobject.rs
+++ b/src/ffi/iterobject.rs
@@ -7,19 +7,22 @@ extern "C" {
     pub static mut PyCallIter_Type: PyTypeObject;
 }
 
-extern "C" {
-    #[cfg_attr(PyPy, link_name = "PyPySeqIter_New")]
-    pub fn PySeqIter_New(arg1: *mut PyObject) -> *mut PyObject;
-    #[cfg_attr(PyPy, link_name = "PyPyCallIter_New")]
-    pub fn PyCallIter_New(arg1: *mut PyObject, arg2: *mut PyObject) -> *mut PyObject;
-}
-
 #[inline]
 pub unsafe fn PySeqIter_Check(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PySeqIter_Type) as c_int
 }
 
+extern "C" {
+    #[cfg_attr(PyPy, link_name = "PyPySeqIter_New")]
+    pub fn PySeqIter_New(arg1: *mut PyObject) -> *mut PyObject;
+}
+
 #[inline]
 pub unsafe fn PyCallIter_Check(op: *mut PyObject) -> c_int {
     (Py_TYPE(op) == &mut PyCallIter_Type) as c_int
+}
+
+extern "C" {
+    #[cfg_attr(PyPy, link_name = "PyPyCallIter_New")]
+    pub fn PyCallIter_New(arg1: *mut PyObject, arg2: *mut PyObject) -> *mut PyObject;
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -31,6 +31,7 @@ pub use self::eval::*;
 pub use self::fileobject::*;
 pub use self::floatobject::*;
 pub use self::funcobject::*;
+#[cfg(not(Py_LIMITED_API))]
 pub use self::genobject::*;
 pub use self::import::*;
 #[cfg(all(Py_3_8, not(any(PY_LIMITED_API, PyPy))))]
@@ -111,7 +112,15 @@ mod floatobject; // TODO supports PEP-384 only
 
 // skipped empty frameobject.h
 // skipped genericaliasobject.h
+#[cfg(not(Py_LIMITED_API))]
+mod genobject; // TODO: incomplete
+mod import; // TODO: incomplete
+
 // skipped interpreteridobject.h
+mod intrcheck; // TODO supports PEP-384 only
+mod iterobject;
+mod listobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
+
 // skipped longintrepr.h
 // skipped namespaceobject.h
 // skipped odictobject.h
@@ -158,7 +167,6 @@ mod typeslots;
 mod longobject;
 mod unicodeobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
                    // mod longintrepr; TODO excluded by PEP-384
-mod listobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod memoryobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod rangeobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod tupleobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
@@ -170,11 +178,8 @@ mod setobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 an
                // mod classobject; TODO excluded by PEP-384
 mod pycapsule; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod sliceobject;
-mod traceback; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
-               // mod cellobject; TODO excluded by PEP-384
-mod genobject; // TODO excluded by PEP-384
-mod iterobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod structseq;
+mod traceback; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod warnings; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod weakrefobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 
@@ -189,8 +194,6 @@ mod modsupport; // TODO supports PEP-384 only; needs adjustment for Python 3.3 a
 mod pyarena; // TODO: incomplete
 mod pythonrun; // TODO some functions need to be moved to pylifecycle
                //mod pylifecycle; // TODO new in 3.5
-mod import;
-mod intrcheck; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod osmodule;
 mod sysmodule; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 


### PR DESCRIPTION
Partial fix for #1289. This one is slightly more complex.
