### PR TITLE
ci: deny clippy warnings for examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ fmt:
 
 clippy:
 	@touch src/lib.rs  # Touching file to ensure that cargo clippy will re-check the project
-	cargo clippy --features="default num-bigint num-complex" --tests -- -Dwarnings
-	for example in examples/*; do (cd $$example/; cargo clippy) || exit 1; done
+	cargo clippy --features="num-bigint num-complex hashbrown" --tests -- -Dwarnings
+	cargo clippy --features="abi3 num-bigint num-complex hashbrown" --tests -- -Dwarnings
+	for example in examples/*; do cargo clippy --manifest-path $$example/Cargo.toml -- -Dwarnings || exit 1; done
 
 lint: fmt clippy
 	@true

--- a/examples/rustapi_module/src/datetime.rs
+++ b/examples/rustapi_module/src/datetime.rs
@@ -6,7 +6,7 @@ use pyo3::types::{
 use pyo3::wrap_pyfunction;
 
 #[pyfunction]
-fn make_date<'p>(py: Python<'p>, year: i32, month: u8, day: u8) -> PyResult<&'p PyDate> {
+fn make_date(py: Python, year: i32, month: u8, day: u8) -> PyResult<&PyDate> {
     PyDate::new(py, year, month, day)
 }
 
@@ -19,7 +19,7 @@ fn get_date_tuple<'p>(py: Python<'p>, d: &PyDate) -> &'p PyTuple {
 }
 
 #[pyfunction]
-fn date_from_timestamp<'p>(py: Python<'p>, timestamp: i64) -> PyResult<&'p PyDate> {
+fn date_from_timestamp(py: Python, timestamp: i64) -> PyResult<&PyDate> {
     PyDate::from_timestamp(py, timestamp)
 }
 
@@ -93,12 +93,7 @@ fn get_time_tuple_fold<'p>(py: Python<'p>, dt: &PyTime) -> &'p PyTuple {
 }
 
 #[pyfunction]
-fn make_delta<'p>(
-    py: Python<'p>,
-    days: i32,
-    seconds: i32,
-    microseconds: i32,
-) -> PyResult<&'p PyDelta> {
+fn make_delta(py: Python, days: i32, seconds: i32, microseconds: i32) -> PyResult<&PyDelta> {
     PyDelta::new(py, days, seconds, microseconds, true)
 }
 


### PR DESCRIPTION
I noticed that `make clippy` was not denying warnings for the examples.