### PR TITLE
Fix #[pyclass] arguments description

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -131,7 +131,7 @@ assert_eq!(obj_ref.num, 1);
 
 The `#[pyclass]` macro accepts the following parameters:
 
-* `name=XXX` - Set the class name shown in Python code. By default, the struct name is used as the class name.
+* `name="XXX"` - Set the class name shown in Python code. By default, the struct name is used as the class name.
 * `freelist=XXX` - The `freelist` parameter adds support of free allocation list to custom class.
 The performance improvement applies to types that are often created and deleted in a row,
 so that they can benefit from a freelist. `XXX` is a number of items for the free list.


### PR DESCRIPTION
This is a minor change to the `#[pyclass]` parameters documentation.
I added quotes to reflect the changes in 0.13

I initially thought that the `name` value should be just an identifier without quotes, unlike `module`, but the compiler was quick to correct me: `error: since PyO3 0.13 a pyclass name should be in double-quotes, e.g. "Profile"`