### PR TITLE
gil: tidy ups to finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add `prepare_freethreaded_python_without_finalizer` to initalize a Python interpreter while avoiding potential finalization issues in C-extensions like SciPy. [#1355](https://github.com/PyO3/pyo3/pull/1355)
 - Add `serde` feature to support `Serialize/Deserialize` for `Py<T>`. [#1366](https://github.com/PyO3/pyo3/pull/1366)
+
+### Changed
+- Call `Py_Finalize` in the same thread as `Py_InitializeEx` inside `prepare_freethreaded_python`. [#1355](https://github.com/PyO3/pyo3/pull/1355)
 
 ## [0.13.1] - 2021-01-10
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Add `prepare_freethreaded_python_without_finalizer` to initalize a Python interpreter while avoiding potential finalization issues in C-extensions like SciPy. [#1355](https://github.com/PyO3/pyo3/pull/1355)
+- Add unsafe API `with_embedded_python_interpreter` to initalize a Python interpreter, execute a closure, and finalize the interpreter. [#1355](https://github.com/PyO3/pyo3/pull/1355)
 - Add `serde` feature to support `Serialize/Deserialize` for `Py<T>`. [#1366](https://github.com/PyO3/pyo3/pull/1366)
 
 ### Changed
-- Call `Py_Finalize` in the same thread as `Py_InitializeEx` inside `prepare_freethreaded_python`. [#1355](https://github.com/PyO3/pyo3/pull/1355)
+- `prepare_freethreaded_python` will no longer register an `atexit` handler to call `Py_Finalize`. [#1355](https://github.com/PyO3/pyo3/pull/1355)
 
 ## [0.13.1] - 2021-01-10
 ### Added

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -56,3 +56,26 @@ crate-type = ["cdylib", "rlib"]
 This is because Ctrl-C raises a SIGINT signal, which is handled by the calling Python process by simply setting a flag to action upon later. This flag isn't checked while Rust code called from Python is executing, only once control returns to the Python interpreter.
 
 You can give the Python interpreter a chance to process the signal properly by calling `Python::check_signals`. It's good practice to call this function regularly if you have a long-running Rust function so that your users can cancel it.
+
+## Importing C extensions like Tensorflow and SciPy cause crashes on program exit for my Python embedded in Rust.
+
+This is because deinitialization is extremely sensitive to ordering, and if the sequence is wrong it's easy for C extensions to inadvertently cause errors like double-free. This will lead to crashes like `SIGSEGV` on program exit.
+
+If you are experiencing these errors, the workaround is to make PyO3 not call `Py_Finalize` on program exit. This can be done by the following steps:
+
+1. Disable the `auto-initialize` feature in your `Cargo.toml`:
+
+```toml
+# Cargo.toml
+[dependencies]
+pyo3 = { version = "0.13.0", default-features = false }
+```
+
+2. Call [`pyo3::prepare_freethreaded_python_without_finalizer`] before attempting to call any Python APIs.
+
+   ```rust
+   fn main() {
+       pyo3::call_freethreaded_python_without_finalizer();
+       // Rest of your program to follow.
+   }
+   ```

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -36,6 +36,8 @@ This feature changes [`Python::with_gil`](https://docs.rs/pyo3/latest/pyo3/struc
 
 This feature is not needed for extension modules, but for compatibility it is enabled by default until at least the PyO3 0.14 release.
 
+If you choose not to enable this feature, you should call `pyo3::prepare_freethreaded_python()` before attempting to call any other Python APIs.
+
 > This feature is enabled by default. To disable it, set `default-features = false` for the `pyo3` entry in your Cargo.toml.
 
 ## Advanced Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub use crate::conversion::{
 };
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
 #[cfg(all(Py_SHARED, not(PyPy)))]
-pub use crate::gil::prepare_freethreaded_python;
+pub use crate::gil::{prepare_freethreaded_python, prepare_freethreaded_python_without_finalizer};
 pub use crate::gil::{GILGuard, GILPool};
 pub use crate::instance::{Py, PyNativeType, PyObject};
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub use crate::conversion::{
 };
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
 #[cfg(all(Py_SHARED, not(PyPy)))]
-pub use crate::gil::{prepare_freethreaded_python, prepare_freethreaded_python_without_finalizer};
+pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
 pub use crate::gil::{GILGuard, GILPool};
 pub use crate::instance::{Py, PyNativeType, PyObject};
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};


### PR DESCRIPTION
EDIT: I changed strategy. See https://github.com/PyO3/pyo3/pull/1355#issuecomment-756446786 for the latest design.

This is a follow-up to #1347 which adds some tidy-ups to our finalization behavior:

- Calling `Py_Finalize` in a different thread to `Py_Initialize` will cause an `AssertionError`. (See https://bugs.python.org/issue26693)

  ~~So I changed `prepare_freethreaded_python` to initialize and finalize in a dedicated thread.~~

- We have some C-extensions which have crashes with `Py_Finalize`. ~~So after disabling the `auto-initialize` feature we can ask users with problematic extensions to call the new `prepare_freethreaded_python_without_finalizer` to workaround these. I added this to the FAQ.~~

Closes #1073 
Closes #1261 