### PR TITLE
Let pyconfig.h not define Py_ENABLE_SHARED

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -488,7 +488,7 @@ fn load_cross_compile_from_headers(
     let interpreter_config = InterpreterConfig {
         version: python_version,
         libdir: cross_compile_config.lib_dir.to_str().map(String::from),
-        shared: config_data.get_bool("Py_ENABLE_SHARED")?,
+        shared: config_data.get_bool("Py_ENABLE_SHARED").unwrap_or(false),
         ld_version: format!("{}.{}", major, minor),
         base_prefix: "".to_string(),
         executable: PathBuf::new(),


### PR DESCRIPTION
If there is no line that defines Py_ENABLE_SHARED in `pyconfig.h`, then it is false

This fixes an issue described in #1221