### PR TITLE
Don't check target architecture if cross-compiling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -733,7 +733,9 @@ fn configure(interpreter_config: &InterpreterConfig) -> Result<()> {
         );
     }
 
-    check_target_architecture(interpreter_config)?;
+    if cross_compiling()?.is_none() {
+        check_target_architecture(interpreter_config)?;
+    }
     let target_os = env::var_os("CARGO_CFG_TARGET_OS").unwrap();
 
     let is_extension_module = env::var_os("CARGO_FEATURE_EXTENSION_MODULE").is_some();


### PR DESCRIPTION
Part of the point of cross-compiling is to be able to compile to other architectures.

This is needed in order to compile to wasm32-unknown-unknown: see #1221
