### PR TITLE
Enable wasm32 compilation by wrapping libc

### DIFF
--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -357,7 +357,7 @@ pub(crate) fn impl_wrap_setter(
         #[allow(unused_mut)]
         unsafe extern "C" fn __wrap(
             _slf: *mut pyo3::ffi::PyObject,
-            _value: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> ::std::os::raw:c_int
+            _value: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int
         {
             const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#python_name),"()");
             pyo3::callback_body_without_convert!(_py, {

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -357,7 +357,7 @@ pub(crate) fn impl_wrap_setter(
         #[allow(unused_mut)]
         unsafe extern "C" fn __wrap(
             _slf: *mut pyo3::ffi::PyObject,
-            _value: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> pyo3::libc::c_int
+            _value: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> ::std::os::raw:c_int
         {
             const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#python_name),"()");
             pyo3::callback_body_without_convert!(_py, {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -300,10 +300,7 @@ impl<T: Element> PyBuffer<T> {
     #[inline]
     pub fn is_c_contiguous(&self) -> bool {
         unsafe {
-            ffi::PyBuffer_IsContiguous(
-                &*self.0 as *const ffi::Py_buffer,
-                b'C' as crate::libc::c_char,
-            ) != 0
+            ffi::PyBuffer_IsContiguous(&*self.0 as *const ffi::Py_buffer, b'C' as raw::c_char) != 0
         }
     }
 
@@ -311,10 +308,7 @@ impl<T: Element> PyBuffer<T> {
     #[inline]
     pub fn is_fortran_contiguous(&self) -> bool {
         unsafe {
-            ffi::PyBuffer_IsContiguous(
-                &*self.0 as *const ffi::Py_buffer,
-                b'F' as crate::libc::c_char,
-            ) != 0
+            ffi::PyBuffer_IsContiguous(&*self.0 as *const ffi::Py_buffer, b'F' as raw::c_char) != 0
         }
     }
 
@@ -447,7 +441,7 @@ impl<T: Element> PyBuffer<T> {
                     target.as_ptr() as *mut raw::c_void,
                     &*self.0 as *const ffi::Py_buffer as *mut ffi::Py_buffer,
                     self.0.len,
-                    fort as crate::libc::c_char,
+                    fort as raw::c_char,
                 ),
             )
         }
@@ -481,7 +475,7 @@ impl<T: Element> PyBuffer<T> {
                     vec.as_mut_ptr() as *mut raw::c_void,
                     &*self.0 as *const ffi::Py_buffer as *mut ffi::Py_buffer,
                     self.0.len,
-                    fort as crate::libc::c_char,
+                    fort as raw::c_char,
                 ),
             )?;
             // set vector length to mark the now-initialized space as usable
@@ -534,7 +528,7 @@ impl<T: Element> PyBuffer<T> {
                     &*self.0 as *const ffi::Py_buffer as *mut ffi::Py_buffer,
                     source.as_ptr() as *mut raw::c_void,
                     self.0.len,
-                    fort as crate::libc::c_char,
+                    fort as raw::c_char,
                 ),
             )
         }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -94,10 +94,10 @@ fn native_element_type_from_type_char(type_char: u8) -> ElementType {
             bytes: mem::size_of::<raw::c_ulonglong>(),
         },
         b'n' => SignedInteger {
-            bytes: mem::size_of::<libc::ssize_t>(),
+            bytes: mem::size_of::<crate::libc::ssize_t>(),
         },
         b'N' => UnsignedInteger {
-            bytes: mem::size_of::<libc::size_t>(),
+            bytes: mem::size_of::<crate::libc::size_t>(),
         },
         b'e' => Float { bytes: 2 },
         b'f' => Float { bytes: 4 },
@@ -300,7 +300,10 @@ impl<T: Element> PyBuffer<T> {
     #[inline]
     pub fn is_c_contiguous(&self) -> bool {
         unsafe {
-            ffi::PyBuffer_IsContiguous(&*self.0 as *const ffi::Py_buffer, b'C' as libc::c_char) != 0
+            ffi::PyBuffer_IsContiguous(
+                &*self.0 as *const ffi::Py_buffer,
+                b'C' as crate::libc::c_char,
+            ) != 0
         }
     }
 
@@ -308,7 +311,10 @@ impl<T: Element> PyBuffer<T> {
     #[inline]
     pub fn is_fortran_contiguous(&self) -> bool {
         unsafe {
-            ffi::PyBuffer_IsContiguous(&*self.0 as *const ffi::Py_buffer, b'F' as libc::c_char) != 0
+            ffi::PyBuffer_IsContiguous(
+                &*self.0 as *const ffi::Py_buffer,
+                b'F' as crate::libc::c_char,
+            ) != 0
         }
     }
 
@@ -441,7 +447,7 @@ impl<T: Element> PyBuffer<T> {
                     target.as_ptr() as *mut raw::c_void,
                     &*self.0 as *const ffi::Py_buffer as *mut ffi::Py_buffer,
                     self.0.len,
-                    fort as libc::c_char,
+                    fort as crate::libc::c_char,
                 ),
             )
         }
@@ -475,7 +481,7 @@ impl<T: Element> PyBuffer<T> {
                     vec.as_mut_ptr() as *mut raw::c_void,
                     &*self.0 as *const ffi::Py_buffer as *mut ffi::Py_buffer,
                     self.0.len,
-                    fort as libc::c_char,
+                    fort as crate::libc::c_char,
                 ),
             )?;
             // set vector length to mark the now-initialized space as usable
@@ -528,7 +534,7 @@ impl<T: Element> PyBuffer<T> {
                     &*self.0 as *const ffi::Py_buffer as *mut ffi::Py_buffer,
                     source.as_ptr() as *mut raw::c_void,
                     self.0.len,
-                    fort as libc::c_char,
+                    fort as crate::libc::c_char,
                 ),
             )
         }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -20,7 +20,7 @@ impl PyCallbackOutput for *mut ffi::PyObject {
     const ERR_VALUE: Self = std::ptr::null_mut();
 }
 
-impl PyCallbackOutput for crate::libc::c_int {
+impl PyCallbackOutput for c_int {
     const ERR_VALUE: Self = -1;
 }
 
@@ -62,14 +62,14 @@ impl IntoPyCallbackOutput<Self> for *mut ffi::PyObject {
     }
 }
 
-impl IntoPyCallbackOutput<crate::libc::c_int> for () {
-    fn convert(self, _: Python) -> PyResult<crate::libc::c_int> {
+impl IntoPyCallbackOutput<c_int> for () {
+    fn convert(self, _: Python) -> PyResult<c_int> {
         Ok(0)
     }
 }
 
-impl IntoPyCallbackOutput<crate::libc::c_int> for bool {
-    fn convert(self, _: Python) -> PyResult<crate::libc::c_int> {
+impl IntoPyCallbackOutput<c_int> for bool {
+    fn convert(self, _: Python) -> PyResult<c_int> {
         Ok(self as c_int)
     }
 }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -20,7 +20,7 @@ impl PyCallbackOutput for *mut ffi::PyObject {
     const ERR_VALUE: Self = std::ptr::null_mut();
 }
 
-impl PyCallbackOutput for libc::c_int {
+impl PyCallbackOutput for crate::libc::c_int {
     const ERR_VALUE: Self = -1;
 }
 
@@ -62,14 +62,14 @@ impl IntoPyCallbackOutput<Self> for *mut ffi::PyObject {
     }
 }
 
-impl IntoPyCallbackOutput<libc::c_int> for () {
-    fn convert(self, _: Python) -> PyResult<libc::c_int> {
+impl IntoPyCallbackOutput<crate::libc::c_int> for () {
+    fn convert(self, _: Python) -> PyResult<crate::libc::c_int> {
         Ok(0)
     }
 }
 
-impl IntoPyCallbackOutput<libc::c_int> for bool {
-    fn convert(self, _: Python) -> PyResult<libc::c_int> {
+impl IntoPyCallbackOutput<crate::libc::c_int> for bool {
+    fn convert(self, _: Python) -> PyResult<crate::libc::c_int> {
         Ok(self as c_int)
     }
 }

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -231,7 +231,7 @@ macro_rules! py_func_set {
             slf: *mut $crate::ffi::PyObject,
             name: *mut $crate::ffi::PyObject,
             value: *mut $crate::ffi::PyObject,
-        ) -> libc::c_int
+        ) -> crate::libc::c_int
         where
             T: for<'p> $trait_name<'p>,
         {
@@ -260,7 +260,7 @@ macro_rules! py_func_del {
             slf: *mut $crate::ffi::PyObject,
             name: *mut $crate::ffi::PyObject,
             value: *mut $crate::ffi::PyObject,
-        ) -> libc::c_int
+        ) -> crate::libc::c_int
         where
             T: for<'p> $trait_name<'p>,
         {
@@ -288,7 +288,7 @@ macro_rules! py_func_set_del {
             slf: *mut $crate::ffi::PyObject,
             name: *mut $crate::ffi::PyObject,
             value: *mut $crate::ffi::PyObject,
-        ) -> libc::c_int
+        ) -> crate::libc::c_int
         where
             T: for<'p> $trait1<'p> + for<'p> $trait2<'p>,
         {

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -231,7 +231,7 @@ macro_rules! py_func_set {
             slf: *mut $crate::ffi::PyObject,
             name: *mut $crate::ffi::PyObject,
             value: *mut $crate::ffi::PyObject,
-        ) -> crate::libc::c_int
+        ) -> std::os::raw::c_int
         where
             T: for<'p> $trait_name<'p>,
         {
@@ -260,7 +260,7 @@ macro_rules! py_func_del {
             slf: *mut $crate::ffi::PyObject,
             name: *mut $crate::ffi::PyObject,
             value: *mut $crate::ffi::PyObject,
-        ) -> crate::libc::c_int
+        ) -> std::os::raw::c_int
         where
             T: for<'p> $trait_name<'p>,
         {
@@ -288,7 +288,7 @@ macro_rules! py_func_set_del {
             slf: *mut $crate::ffi::PyObject,
             name: *mut $crate::ffi::PyObject,
             value: *mut $crate::ffi::PyObject,
-        ) -> crate::libc::c_int
+        ) -> std::os::raw::c_int
         where
             T: for<'p> $trait1<'p> + for<'p> $trait2<'p>,
         {

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-use crate::libc::c_int;
 use crate::{ffi, PyObject, Python};
 use std::ffi::CStr;
 use std::fmt;
+use std::os::raw::c_int;
 
 /// `PyMethodDefType` represents different types of Python callable objects.
 /// It is used by the `#[pymethods]` and `#[pyproto]` annotations.

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
+use crate::libc::c_int;
 use crate::{ffi, PyObject, Python};
-use libc::c_int;
 use std::ffi::CStr;
 use std::fmt;
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-use crate::libc::c_int;
 use crate::panic::PanicException;
 use crate::type_object::PyTypeObject;
 use crate::types::PyType;
@@ -16,6 +15,7 @@ use std::borrow::Cow;
 use std::cell::UnsafeCell;
 use std::ffi::CString;
 use std::os::raw::c_char;
+use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 mod err_state;

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
+use crate::libc::c_int;
 use crate::panic::PanicException;
 use crate::type_object::PyTypeObject;
 use crate::types::PyType;
@@ -11,7 +12,6 @@ use crate::{
     AsPyPointer, FromPyPointer, IntoPy, Py, PyAny, PyNativeType, PyObject, Python,
     ToBorrowedObject, ToPyObject,
 };
-use libc::c_int;
 use std::borrow::Cow;
 use std::cell::UnsafeCell;
 use std::ffi::CString;

--- a/src/ffi/cpython/abstract_.rs
+++ b/src/ffi/cpython/abstract_.rs
@@ -1,5 +1,5 @@
 use crate::ffi::{PyObject, Py_buffer, Py_ssize_t};
-use libc::{c_char, c_int, c_void};
+use crate::libc::{c_char, c_int, c_void};
 
 #[cfg(all(Py_3_8, not(PyPy)))]
 use crate::ffi::{
@@ -7,7 +7,7 @@ use crate::ffi::{
     PyType_HasFeature, Py_TPFLAGS_HAVE_VECTORCALL,
 };
 #[cfg(all(Py_3_8, not(PyPy)))]
-use libc::size_t;
+use crate::libc::size_t;
 
 extern "C" {
     #[cfg(all(Py_3_8, not(PyPy)))]

--- a/src/ffi/cpython/abstract_.rs
+++ b/src/ffi/cpython/abstract_.rs
@@ -1,5 +1,6 @@
 use crate::ffi::{PyObject, Py_buffer, Py_ssize_t};
-use crate::libc::{c_char, c_int, c_void};
+use std::ffi::c_void;
+use std::os::raw::{c_char, c_int};
 
 #[cfg(all(Py_3_8, not(PyPy)))]
 use crate::ffi::{

--- a/src/ffi/initconfig.rs
+++ b/src/ffi/initconfig.rs
@@ -1,7 +1,8 @@
 /* --- PyStatus ----------------------------------------------- */
 
 use crate::ffi::Py_ssize_t;
-use crate::libc::{c_char, c_int, c_ulong, wchar_t};
+use crate::libc::wchar_t;
+use std::os::raw::{c_char, c_int, c_ulong};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum _PyStatus_TYPE {

--- a/src/ffi/initconfig.rs
+++ b/src/ffi/initconfig.rs
@@ -1,7 +1,7 @@
 /* --- PyStatus ----------------------------------------------- */
 
 use crate::ffi::Py_ssize_t;
-use libc::{c_char, c_int, c_ulong, wchar_t};
+use crate::libc::{c_char, c_int, c_ulong, wchar_t};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum _PyStatus_TYPE {

--- a/src/ffi/longobject.rs
+++ b/src/ffi/longobject.rs
@@ -1,6 +1,6 @@
 use crate::ffi::object::*;
 use crate::ffi::pyport::Py_ssize_t;
-use libc::size_t;
+use crate::libc::size_t;
 use std::os::raw::{
     c_char, c_double, c_int, c_long, c_longlong, c_uchar, c_ulong, c_ulonglong, c_void,
 };

--- a/src/ffi/object.rs
+++ b/src/ffi/object.rs
@@ -210,7 +210,7 @@ pub type freefunc = unsafe extern "C" fn(arg1: *mut c_void);
 pub type destructor = unsafe extern "C" fn(arg1: *mut PyObject);
 #[cfg(not(Py_LIMITED_API))]
 pub type printfunc =
-    unsafe extern "C" fn(arg1: *mut PyObject, arg2: *mut ::libc::FILE, arg3: c_int) -> c_int;
+    unsafe extern "C" fn(arg1: *mut PyObject, arg2: *mut crate::libc::FILE, arg3: c_int) -> c_int;
 pub type getattrfunc =
     unsafe extern "C" fn(arg1: *mut PyObject, arg2: *mut c_char) -> *mut PyObject;
 pub type getattrofunc =
@@ -245,7 +245,7 @@ pub type allocfunc =
 pub type vectorcallfunc = unsafe extern "C" fn(
     callable: *mut PyObject,
     args: *const *mut PyObject,
-    nargsf: libc::size_t,
+    nargsf: crate::libc::size_t,
     kwnames: *mut PyObject,
 ) -> *mut PyObject;
 
@@ -657,7 +657,7 @@ extern "C" {
 
     #[cfg(not(Py_LIMITED_API))]
     #[cfg_attr(PyPy, link_name = "PyPyObject_Print")]
-    pub fn PyObject_Print(o: *mut PyObject, fp: *mut ::libc::FILE, flags: c_int) -> c_int;
+    pub fn PyObject_Print(o: *mut PyObject, fp: *mut crate::libc::FILE, flags: c_int) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyObject_Repr")]
     pub fn PyObject_Repr(o: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyObject_Str")]

--- a/src/ffi/objimpl.rs
+++ b/src/ffi/objimpl.rs
@@ -1,6 +1,6 @@
 use crate::ffi::object::*;
 use crate::ffi::pyport::Py_ssize_t;
-use libc::size_t;
+use crate::libc::size_t;
 use std::os::raw::{c_int, c_void};
 
 extern "C" {

--- a/src/ffi/pylifecycle.rs
+++ b/src/ffi/pylifecycle.rs
@@ -2,7 +2,7 @@ use crate::ffi::pystate::PyThreadState;
 #[cfg(all(Py_3_8, not(any(PY_LIMITED_API, PyPy))))]
 use crate::ffi::{PyConfig, PyPreConfig, PyStatus, Py_ssize_t};
 
-use libc::wchar_t;
+use crate::libc::wchar_t;
 use std::os::raw::{c_char, c_int};
 
 extern "C" {

--- a/src/ffi/pymem.rs
+++ b/src/ffi/pymem.rs
@@ -1,4 +1,4 @@
-use libc::size_t;
+use crate::libc::size_t;
 use std::os::raw::c_void;
 
 #[cfg(not(Py_LIMITED_API))]

--- a/src/ffi/pyport.rs
+++ b/src/ffi/pyport.rs
@@ -1,9 +1,9 @@
-pub type Py_uintptr_t = ::libc::uintptr_t;
-pub type Py_intptr_t = ::libc::intptr_t;
-pub type Py_ssize_t = ::libc::ssize_t;
+pub type Py_uintptr_t = crate::libc::uintptr_t;
+pub type Py_intptr_t = crate::libc::intptr_t;
+pub type Py_ssize_t = crate::libc::ssize_t;
 
 pub type Py_hash_t = Py_ssize_t;
-pub type Py_uhash_t = ::libc::size_t;
+pub type Py_uhash_t = crate::libc::size_t;
 
 pub const PY_SSIZE_T_MIN: Py_ssize_t = ::std::isize::MIN as Py_ssize_t;
 pub const PY_SSIZE_T_MAX: Py_ssize_t = ::std::isize::MAX as Py_ssize_t;

--- a/src/ffi/pythonrun.rs
+++ b/src/ffi/pythonrun.rs
@@ -1,7 +1,7 @@
 use crate::ffi::object::*;
 #[cfg(not(Py_LIMITED_API))]
 use crate::ffi::pyarena::PyArena;
-use libc::FILE;
+use crate::libc::FILE;
 use std::os::raw::{c_char, c_int};
 use std::ptr;
 

--- a/src/ffi/sysmodule.rs
+++ b/src/ffi/sysmodule.rs
@@ -1,6 +1,6 @@
 use crate::ffi::object::PyObject;
 use crate::ffi::pyport::Py_ssize_t;
-use libc::wchar_t;
+use crate::libc::wchar_t;
 use std::os::raw::{c_char, c_int};
 
 extern "C" {

--- a/src/ffi/unicodeobject.rs
+++ b/src/ffi/unicodeobject.rs
@@ -1,6 +1,6 @@
 use crate::ffi::object::*;
 use crate::ffi::pyport::Py_ssize_t;
-use libc::wchar_t;
+use crate::libc::wchar_t;
 use std::os::raw::{c_char, c_int, c_void};
 
 #[cfg(not(Py_LIMITED_API))]

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -87,7 +87,7 @@ pub fn prepare_freethreaded_python() {
                     }
                 }
             }
-            libc::atexit(finalize);
+            crate::libc::atexit(finalize);
 
             // > Changed in version 3.7: This function is now called by Py_Initialize(), so you don’t have
             // > to call it yourself anymore.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,8 +168,7 @@ pub use {
     unindent,  // Re-exported for py_run
 };
 
-// Re-exported for the `__wrap` functions
-pub use crate::libc_wrapper::libc;
+use crate::libc_wrapper::libc;
 
 // The CPython stable ABI does not include PyBuffer.
 #[cfg(not(Py_LIMITED_API))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,8 +169,7 @@ pub use {
 };
 
 // Re-exported for the `__wrap` functions
-#[doc(hidden)]
-pub use libc;
+pub use crate::libc_wrapper::libc;
 
 // The CPython stable ABI does not include PyBuffer.
 #[cfg(not(Py_LIMITED_API))]
@@ -193,6 +192,7 @@ mod gil;
 mod instance;
 #[macro_use]
 mod internal_tricks;
+mod libc_wrapper;
 #[cfg(not(Py_LIMITED_API))]
 pub mod marshal;
 pub mod once_cell;

--- a/src/libc_wrapper.rs
+++ b/src/libc_wrapper.rs
@@ -8,12 +8,8 @@
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod libc {
     extern "C" {
-        pub fn atexit(cb: extern "C" fn()) -> c_int;
+        pub fn atexit(cb: extern "C" fn()) -> std::os::raw::c_int;
     }
-    pub type c_char = i8;
-    pub type c_int = i32;
-    pub type c_ulong = u32;
-    pub type c_void = std::ffi::c_void;
     pub type intptr_t = isize;
     pub type size_t = usize;
     pub type ssize_t = isize;
@@ -25,10 +21,6 @@ pub mod libc {
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub mod libc {
     pub use libc::atexit;
-    pub use libc::c_char;
-    pub use libc::c_int;
-    pub use libc::c_ulong;
-    pub use libc::c_void;
     pub use libc::intptr_t;
     pub use libc::size_t;
     pub use libc::ssize_t;

--- a/src/libc_wrapper.rs
+++ b/src/libc_wrapper.rs
@@ -1,0 +1,38 @@
+//! This file re-exports various libc functions and types, and adds a custom libc implementation
+//! for wasm32-unknown-unknown, since libc does not support wasm32-unknown-unknown.
+//!
+//! When compiled for wasm32-unknown-unknown, this is expected to be used in an
+//! emscripten environment, and the definitions are chosen accordingly.
+
+#![allow(non_camel_case_types)]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub mod libc {
+    extern "C" {
+        pub fn atexit(cb: extern "C" fn()) -> c_int;
+    }
+    pub type c_char = i8;
+    pub type c_int = i32;
+    pub type c_ulong = u32;
+    pub type c_void = std::ffi::c_void;
+    pub type intptr_t = isize;
+    pub type size_t = usize;
+    pub type ssize_t = isize;
+    pub type uintptr_t = usize;
+    pub type wchar_t = u32;
+    pub enum FILE {}
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+pub mod libc {
+    pub use libc::atexit;
+    pub use libc::c_char;
+    pub use libc::c_int;
+    pub use libc::c_ulong;
+    pub use libc::c_void;
+    pub use libc::intptr_t;
+    pub use libc::size_t;
+    pub use libc::ssize_t;
+    pub use libc::uintptr_t;
+    pub use libc::wchar_t;
+    pub use libc::FILE;
+}

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -4,10 +4,10 @@ use crate::conversion::{
 };
 use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::exceptions::PyTypeError;
+use crate::libc::c_int;
 use crate::type_object::PyTypeObject;
 use crate::types::{PyDict, PyIterator, PyList, PyString, PyTuple, PyType};
 use crate::{err, ffi, Py, PyNativeType, PyObject};
-use libc::c_int;
 use std::cell::UnsafeCell;
 use std::cmp::Ordering;
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -4,12 +4,12 @@ use crate::conversion::{
 };
 use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::exceptions::PyTypeError;
-use crate::libc::c_int;
 use crate::type_object::PyTypeObject;
 use crate::types::{PyDict, PyIterator, PyList, PyString, PyTuple, PyType};
 use crate::{err, ffi, Py, PyNativeType, PyObject};
 use std::cell::UnsafeCell;
 use std::cmp::Ordering;
+use std::os::raw::c_int;
 
 /// A Python object with GIL lifetime
 ///


### PR DESCRIPTION
My plan is to use this with [pyodide](https://github.com/iodide-project/pyodide).

It is unclear how to test this at the moment. I think a reasonable solution is to make sure it compiles with `--target wasm32-unknown-unknown` after supplying suitable header files, possibly copying from pyodide, and run no tests. When/if things get ready with pyodide, we can consider running integration tests with it, but that would require a very different setup. Due to the nature of the builds, I also think it is unlikely that it can be usable without nightly in the near future.

I'm also happy to leave this as a PR until then. See also #1221