### PR TITLE
pyclass: add !Send compile_error test

### DIFF
--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -26,6 +26,7 @@ fn test_compile_errors() {
     fn tests_rust_1_49(t: &trybuild::TestCases) {
         t.compile_fail("tests/ui/invalid_frompy_derive.rs");
         t.compile_fail("tests/ui/invalid_pymethod_receiver.rs");
+        t.compile_fail("tests/ui/pyclass_send.rs");
 
         #[cfg(Py_LIMITED_API)]
         t.compile_fail("tests/ui/abi3_nativetype_inheritance.rs");

--- a/tests/ui/pyclass_send.rs
+++ b/tests/ui/pyclass_send.rs
@@ -1,0 +1,25 @@
+use pyo3::prelude::*;
+use std::rc::Rc;
+
+#[pyclass]
+struct NotThreadSafe {
+    data: Rc<i32>
+}
+
+fn main() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let obj = PyCell::new(py, NotThreadSafe { data: Rc::new(5) }).unwrap().to_object(py);
+    drop(gil);
+
+    std::thread::spawn(move || {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        // Uh oh, moved Rc to a new thread!
+        let c: &PyCell<NotThreadSafe> = obj.as_ref(py).downcast().unwrap();
+
+        assert_eq!(*c.borrow().data, 5);
+    }).join().unwrap();
+}

--- a/tests/ui/pyclass_send.stderr
+++ b/tests/ui/pyclass_send.stderr
@@ -1,0 +1,14 @@
+error[E0277]: `Rc<i32>` cannot be sent between threads safely
+   --> $DIR/pyclass_send.rs:4:1
+    |
+4   | #[pyclass]
+    | ^^^^^^^^^^ `Rc<i32>` cannot be sent between threads safely
+    |
+   ::: $WORKSPACE/src/pyclass.rs
+    |
+    | pub struct ThreadCheckerStub<T: Send>(PhantomData<T>);
+    |                                 ---- required by this bound in `ThreadCheckerStub`
+    |
+    = help: within `NotThreadSafe`, the trait `Send` is not implemented for `Rc<i32>`
+    = note: required because it appears within the type `NotThreadSafe`
+    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Repeat of #948 because `trybuild` has fixed support now (I think)...