### PR TITLE
Prefer to use std::os::raw type definitions

### DIFF
--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -357,7 +357,7 @@ pub(crate) fn impl_wrap_setter(
         #[allow(unused_mut)]
         unsafe extern "C" fn __wrap(
             _slf: *mut pyo3::ffi::PyObject,
-            _value: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> pyo3::libc::c_int
+            _value: *mut pyo3::ffi::PyObject, _: *mut ::std::os::raw::c_void) -> std::os::raw::c_int
         {
             const _LOCATION: &'static str = concat!(stringify!(#cls),".",stringify!(#python_name),"()");
             pyo3::callback_body_without_convert!(_py, {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -300,7 +300,10 @@ impl<T: Element> PyBuffer<T> {
     #[inline]
     pub fn is_c_contiguous(&self) -> bool {
         unsafe {
-            ffi::PyBuffer_IsContiguous(&*self.0 as *const ffi::Py_buffer, b'C' as libc::c_char) != 0
+            ffi::PyBuffer_IsContiguous(
+                &*self.0 as *const ffi::Py_buffer,
+                b'C' as std::os::raw::c_char,
+            ) != 0
         }
     }
 
@@ -308,7 +311,10 @@ impl<T: Element> PyBuffer<T> {
     #[inline]
     pub fn is_fortran_contiguous(&self) -> bool {
         unsafe {
-            ffi::PyBuffer_IsContiguous(&*self.0 as *const ffi::Py_buffer, b'F' as libc::c_char) != 0
+            ffi::PyBuffer_IsContiguous(
+                &*self.0 as *const ffi::Py_buffer,
+                b'F' as std::os::raw::c_char,
+            ) != 0
         }
     }
 
@@ -441,7 +447,7 @@ impl<T: Element> PyBuffer<T> {
                     target.as_ptr() as *mut raw::c_void,
                     &*self.0 as *const ffi::Py_buffer as *mut ffi::Py_buffer,
                     self.0.len,
-                    fort as libc::c_char,
+                    fort as std::os::raw::c_char,
                 ),
             )
         }
@@ -475,7 +481,7 @@ impl<T: Element> PyBuffer<T> {
                     vec.as_mut_ptr() as *mut raw::c_void,
                     &*self.0 as *const ffi::Py_buffer as *mut ffi::Py_buffer,
                     self.0.len,
-                    fort as libc::c_char,
+                    fort as std::os::raw::c_char,
                 ),
             )?;
             // set vector length to mark the now-initialized space as usable
@@ -528,7 +534,7 @@ impl<T: Element> PyBuffer<T> {
                     &*self.0 as *const ffi::Py_buffer as *mut ffi::Py_buffer,
                     source.as_ptr() as *mut raw::c_void,
                     self.0.len,
-                    fort as libc::c_char,
+                    fort as std::os::raw::c_char,
                 ),
             )
         }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -20,7 +20,7 @@ impl PyCallbackOutput for *mut ffi::PyObject {
     const ERR_VALUE: Self = std::ptr::null_mut();
 }
 
-impl PyCallbackOutput for libc::c_int {
+impl PyCallbackOutput for std::os::raw::c_int {
     const ERR_VALUE: Self = -1;
 }
 
@@ -62,14 +62,14 @@ impl IntoPyCallbackOutput<Self> for *mut ffi::PyObject {
     }
 }
 
-impl IntoPyCallbackOutput<libc::c_int> for () {
-    fn convert(self, _: Python) -> PyResult<libc::c_int> {
+impl IntoPyCallbackOutput<std::os::raw::c_int> for () {
+    fn convert(self, _: Python) -> PyResult<std::os::raw::c_int> {
         Ok(0)
     }
 }
 
-impl IntoPyCallbackOutput<libc::c_int> for bool {
-    fn convert(self, _: Python) -> PyResult<libc::c_int> {
+impl IntoPyCallbackOutput<std::os::raw::c_int> for bool {
+    fn convert(self, _: Python) -> PyResult<std::os::raw::c_int> {
         Ok(self as c_int)
     }
 }

--- a/src/class/macros.rs
+++ b/src/class/macros.rs
@@ -231,7 +231,7 @@ macro_rules! py_func_set {
             slf: *mut $crate::ffi::PyObject,
             name: *mut $crate::ffi::PyObject,
             value: *mut $crate::ffi::PyObject,
-        ) -> libc::c_int
+        ) -> std::os::raw::c_int
         where
             T: for<'p> $trait_name<'p>,
         {
@@ -260,7 +260,7 @@ macro_rules! py_func_del {
             slf: *mut $crate::ffi::PyObject,
             name: *mut $crate::ffi::PyObject,
             value: *mut $crate::ffi::PyObject,
-        ) -> libc::c_int
+        ) -> std::os::raw::c_int
         where
             T: for<'p> $trait_name<'p>,
         {
@@ -288,7 +288,7 @@ macro_rules! py_func_set_del {
             slf: *mut $crate::ffi::PyObject,
             name: *mut $crate::ffi::PyObject,
             value: *mut $crate::ffi::PyObject,
-        ) -> libc::c_int
+        ) -> std::os::raw::c_int
         where
             T: for<'p> $trait1<'p> + for<'p> $trait2<'p>,
         {

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
 use crate::{ffi, PyObject, Python};
-use libc::c_int;
 use std::ffi::CStr;
 use std::fmt;
+use std::os::raw::c_int;
 
 /// `PyMethodDefType` represents different types of Python callable objects.
 /// It is used by the `#[pymethods]` and `#[pyproto]` annotations.

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -11,11 +11,11 @@ use crate::{
     AsPyPointer, FromPyPointer, IntoPy, Py, PyAny, PyNativeType, PyObject, Python,
     ToBorrowedObject, ToPyObject,
 };
-use libc::c_int;
 use std::borrow::Cow;
 use std::cell::UnsafeCell;
 use std::ffi::CString;
 use std::os::raw::c_char;
+use std::os::raw::c_int;
 use std::ptr::NonNull;
 
 mod err_state;

--- a/src/ffi/cpython/abstract_.rs
+++ b/src/ffi/cpython/abstract_.rs
@@ -1,5 +1,5 @@
 use crate::ffi::{PyObject, Py_buffer, Py_ssize_t};
-use libc::{c_char, c_int, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 
 #[cfg(all(Py_3_8, not(PyPy)))]
 use crate::ffi::{

--- a/src/ffi/initconfig.rs
+++ b/src/ffi/initconfig.rs
@@ -1,7 +1,8 @@
 /* --- PyStatus ----------------------------------------------- */
 
 use crate::ffi::Py_ssize_t;
-use libc::{c_char, c_int, c_ulong, wchar_t};
+use libc::wchar_t;
+use std::os::raw::{c_char, c_int, c_ulong};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum _PyStatus_TYPE {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,10 +173,6 @@ pub use {
     unindent,  // Re-exported for py_run
 };
 
-// Re-exported for the `__wrap` functions
-#[doc(hidden)]
-pub use libc;
-
 // The CPython stable ABI does not include PyBuffer.
 #[cfg(not(Py_LIMITED_API))]
 pub mod buffer;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -7,9 +7,9 @@ use crate::exceptions::PyTypeError;
 use crate::type_object::PyTypeObject;
 use crate::types::{PyDict, PyIterator, PyList, PyString, PyTuple, PyType};
 use crate::{err, ffi, Py, PyNativeType, PyObject};
-use libc::c_int;
 use std::cell::UnsafeCell;
 use std::cmp::Ordering;
+use std::os::raw::c_int;
 
 /// A Python object with GIL lifetime
 ///


### PR DESCRIPTION
Certain types e.g. c_char are provided by both std::os::raw and libc.  Previously, both are used interchangably. This commit changes all instances to use std::os::raw, which is slightly more portable, since libc is not implemented for all targets (e.g. wasm32-unknown-unknown).
