### PR TITLE
Make abi3 linking work on windows

### DIFF
--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -65,8 +65,7 @@ For example, if you set the `abi3-py36` feature, your extension wheel can be use
 If you set more that one of these api version feature flags the highest version always wins. For example, with both `abi3-py36` and `abi3-py38` set, PyO3 would build a wheel which supports Python 3.8 and up.
 PyO3 is only able to link your extension module to api3 version up to and including your host Python version. E.g., if you set `abi3-py38` and try to compile the crate with a host of Python 3.6, the build will fail.
 
-As an advanced feature, you can build PyO3 wheel without calling Python interpreter with
-the environment variable `PYO3_NO_PYTHON` set, but this only works on \*NIX.
+As an advanced feature, you can build PyO3 wheel without calling Python interpreter with the environment variable `PYO3_NO_PYTHON` set. On unix systems this works unconditionally; on Windows you must also set the `RUSTFLAGS` evironment variable to contain `-L native=/path/to/python/libs` so that the linker can find `python3.lib`.
 
 ### Missing features
 


### PR DESCRIPTION
On mac and linux, you can build abi3 wheels without the python interpreter being present. On windows however, we still need to tell the linker how to find a .lib matching the `extern` blocks in pyo3. First, pyo3 tells the linker that we're looking for definitions in a collection we call `pythonXY` with `#[cfg_attr(windows, link(name = "pythonXY"))]`. Then we use `rustc-link-lib` (or `-l`) to tell the linker that the `pythonXY` is actually a file called `python3.lib`. This part needs to be done by pyo3 itself, as [cargo rejects doing this as a rustc option](https://github.com/PyO3/maturin/runs/1670164610?check_suite_focus=true#step:9:409). This pull request adds this part. Finally, maturin needs to tell the linker the directory containing `python3.lib` (with `-L`).

The advantage is that the pyo3 build script doesn't need to call python anymore and becomes independent of most environment variables.

I've also tried to use `/FORCE:UNDEFINED` to avoid the library completely but then python crashes with exit code 0xc0000005.

This pull request is the pyo3 part of https://github.com/PyO3/maturin/pull/399.