### PR TITLE
macros-backend: improve error handling ergonomics

### DIFF
--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -3,6 +3,10 @@
 
 #![recursion_limit = "1024"]
 
+// Listed first so that macros in this module are available in the rest of the crate.
+#[macro_use]
+mod utils;
+
 mod defs;
 mod from_pyobject;
 mod konst;
@@ -14,7 +18,6 @@ mod pyfunction;
 mod pyimpl;
 mod pymethod;
 mod pyproto;
-mod utils;
 
 pub use from_pyobject::build_derive_from_pyobject;
 pub use module::{add_fn_to_module, process_functions_in_module, py_init};

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -3,18 +3,16 @@
 use crate::pymethod;
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::spanned::Spanned;
 
 pub fn build_py_methods(ast: &mut syn::ItemImpl) -> syn::Result<TokenStream> {
     if let Some((_, path, _)) = &ast.trait_ {
-        Err(syn::Error::new_spanned(
-            path,
-            "#[pymethods] cannot be used on trait impl blocks",
-        ))
+        bail_spanned!(path.span() => "#[pymethods] cannot be used on trait impl blocks");
     } else if ast.generics != Default::default() {
-        Err(syn::Error::new_spanned(
-            ast.generics.clone(),
-            "#[pymethods] cannot be used with lifetime parameters or generics",
-        ))
+        bail_spanned!(
+            ast.generics.span() =>
+            "#[pymethods] cannot be used with lifetime parameters or generics"
+        );
     } else {
         impl_methods(&ast.self_ty, &mut ast.items)
     }

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -91,7 +91,7 @@ pub fn pyfunction(attr: TokenStream, input: TokenStream) -> TokenStream {
     .into()
 }
 
-#[proc_macro_derive(FromPyObject, attributes(pyo3, extract))]
+#[proc_macro_derive(FromPyObject, attributes(pyo3))]
 pub fn derive_from_py_object(item: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(item as syn::DeriveInput);
     let expanded = build_derive_from_pyobject(&ast).unwrap_or_else(|e| e.to_compile_error());

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -6,6 +6,7 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_need_module_arg_position.rs");
     t.compile_fail("tests/ui/invalid_property_args.rs");
     t.compile_fail("tests/ui/invalid_pyclass_args.rs");
+    t.compile_fail("tests/ui/invalid_pymethods.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
     t.compile_fail("tests/ui/reject_generics.rs");
     t.compile_fail("tests/ui/static_ref.rs");

--- a/tests/ui/invalid_frompy_derive.stderr
+++ b/tests/ui/invalid_frompy_derive.stderr
@@ -1,64 +1,64 @@
-error: Cannot derive FromPyObject for empty structs and variants.
+error: cannot derive FromPyObject for empty structs and variants
  --> $DIR/invalid_frompy_derive.rs:4:11
   |
 4 | struct Foo();
   |           ^^
 
-error: Cannot derive FromPyObject for empty structs and variants.
+error: cannot derive FromPyObject for empty structs and variants
  --> $DIR/invalid_frompy_derive.rs:7:13
   |
 7 | struct Foo2 {}
   |             ^^
 
-error: Cannot derive FromPyObject for empty enum.
+error: cannot derive FromPyObject for empty enum
   --> $DIR/invalid_frompy_derive.rs:10:6
    |
 10 | enum EmptyEnum {}
    |      ^^^^^^^^^
 
-error: Cannot derive FromPyObject for empty structs and variants.
+error: cannot derive FromPyObject for empty structs and variants
   --> $DIR/invalid_frompy_derive.rs:14:15
    |
 14 |     EmptyTuple(),
    |               ^^
 
-error: Cannot derive FromPyObject for empty structs and variants.
+error: cannot derive FromPyObject for empty structs and variants
   --> $DIR/invalid_frompy_derive.rs:20:17
    |
 20 |     EmptyStruct {},
    |                 ^^
 
-error: Cannot derive FromPyObject for empty structs and variants.
+error: cannot derive FromPyObject for empty structs and variants
   --> $DIR/invalid_frompy_derive.rs:26:27
    |
 26 | struct EmptyTransparentTup();
    |                           ^^
 
-error: Cannot derive FromPyObject for empty structs and variants.
+error: cannot derive FromPyObject for empty structs and variants
   --> $DIR/invalid_frompy_derive.rs:30:31
    |
 30 | struct EmptyTransparentStruct {}
    |                               ^^
 
-error: Cannot derive FromPyObject for empty structs and variants.
+error: cannot derive FromPyObject for empty structs and variants
   --> $DIR/invalid_frompy_derive.rs:35:15
    |
 35 |     EmptyTuple(),
    |               ^^
 
-error: Cannot derive FromPyObject for empty structs and variants.
+error: cannot derive FromPyObject for empty structs and variants
   --> $DIR/invalid_frompy_derive.rs:42:17
    |
 42 |     EmptyStruct {},
    |                 ^^
 
-error: Transparent structs and variants can only have 1 field
+error: transparent structs and variants can only have 1 field
   --> $DIR/invalid_frompy_derive.rs:48:35
    |
 48 | struct TransparentTupTooManyFields(String, String);
    |                                   ^^^^^^^^^^^^^^^^
 
-error: Transparent structs and variants can only have 1 field
+error: transparent structs and variants can only have 1 field
   --> $DIR/invalid_frompy_derive.rs:52:39
    |
 52 |   struct TransparentStructTooManyFields {
@@ -68,13 +68,13 @@ error: Transparent structs and variants can only have 1 field
 55 | | }
    | |_^
 
-error: Transparent structs and variants can only have 1 field
+error: transparent structs and variants can only have 1 field
   --> $DIR/invalid_frompy_derive.rs:60:15
    |
 60 |     EmptyTuple(String, String),
    |               ^^^^^^^^^^^^^^^^
 
-error: Transparent structs and variants can only have 1 field
+error: transparent structs and variants can only have 1 field
   --> $DIR/invalid_frompy_derive.rs:67:17
    |
 67 |       EmptyStruct {
@@ -84,87 +84,85 @@ error: Transparent structs and variants can only have 1 field
 70 | |     },
    | |_____^
 
-error: Expected `attribute` or `item`.
+error: expected `attribute` or `item`
   --> $DIR/invalid_frompy_derive.rs:76:12
    |
 76 |     #[pyo3(attr)]
    |            ^^^^
 
-error: Expected a single string literal argument.
-  --> $DIR/invalid_frompy_derive.rs:82:22
+error: expected a single string literal argument
+  --> $DIR/invalid_frompy_derive.rs:82:12
    |
 82 |     #[pyo3(attribute(1))]
-   |                      ^
+   |            ^^^^^^^^^
 
-error: Expected a single string literal argument.
+error: expected a single string literal argument
   --> $DIR/invalid_frompy_derive.rs:88:12
    |
 88 |     #[pyo3(attribute("a", "b"))]
-   |            ^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^
 
-error: Attribute name cannot be empty.
+error: attribute name cannot be empty
   --> $DIR/invalid_frompy_derive.rs:94:22
    |
 94 |     #[pyo3(attribute(""))]
    |                      ^^
 
-error: Expected a single string literal argument.
+error: expected a single string literal argument
    --> $DIR/invalid_frompy_derive.rs:100:12
     |
 100 |     #[pyo3(attribute())]
-    |            ^^^^^^^^^^^
+    |            ^^^^^^^^^
 
-error: Expected a single literal argument.
-   --> $DIR/invalid_frompy_derive.rs:106:17
+error: expected a single literal argument
+   --> $DIR/invalid_frompy_derive.rs:106:12
     |
 106 |     #[pyo3(item("a", "b"))]
-    |                 ^^^^^^^^
+    |            ^^^^
 
-error: Expected a single literal argument.
+error: expected a single literal argument
    --> $DIR/invalid_frompy_derive.rs:112:12
     |
 112 |     #[pyo3(item())]
-    |            ^^^^^^
+    |            ^^^^
 
-error: Only one of `item`, `attribute` can be provided, possibly with an additional argument: `item("key")` or `attribute("name").
+error: only one of `attribute` or `item` can be provided
    --> $DIR/invalid_frompy_derive.rs:118:12
     |
 118 |     #[pyo3(item, attribute)]
-    |            ^^^^^^^^^^^^^^^
+    |            ^^^^
 
-error: Unrecognized `pyo3` container attribute
+error: unknown `pyo3` container attribute
    --> $DIR/invalid_frompy_derive.rs:123:8
     |
 123 | #[pyo3(unknown = "should not work")]
-    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |        ^^^^^^^
 
-error: Annotating error messages for structs is not supported. Remove the annotation attribute.
-   --> $DIR/invalid_frompy_derive.rs:129:1
+error: annotation is not supported for structs
+   --> $DIR/invalid_frompy_derive.rs:129:21
     |
 129 | #[pyo3(annotation = "should not work")]
-    | ^
+    |                     ^^^^^^^^^^^^^^^^^
 
-error: Expected string literal.
+error: expected string literal for annotation
    --> $DIR/invalid_frompy_derive.rs:136:25
     |
 136 |     #[pyo3(annotation = 1)]
     |                         ^
 
-error: FromPyObject can be derived with at most one lifetime parameter.
+error: FromPyObject can be derived with at most one lifetime parameter
    --> $DIR/invalid_frompy_derive.rs:141:22
     |
 141 | enum TooManyLifetimes<'a, 'b> {
-    |                      ^^^^^^^^
+    |                      ^
 
-error: #[derive(FromPyObject)] is not supported for unions.
+error: #[derive(FromPyObject)] is not supported for unions
    --> $DIR/invalid_frompy_derive.rs:147:1
     |
-147 | / union Union {
-148 | |     a: usize,
-149 | | }
-    | |_^
+147 | union Union {
+    | ^^^^^
 
-error: Cannot derive FromPyObject for empty structs and variants.
+error: cannot derive FromPyObject for empty structs and variants
    --> $DIR/invalid_frompy_derive.rs:151:10
     |
 151 | #[derive(FromPyObject)]

--- a/tests/ui/invalid_macro_args.stderr
+++ b/tests/ui/invalid_macro_args.stderr
@@ -1,11 +1,11 @@
-error: Positional argument or varargs(*) is not allowed after keyword arguments
+error: positional argument or varargs(*) not allowed after keyword arguments
  --> $DIR/invalid_macro_args.rs:3:21
   |
 3 | #[pyfunction(a = 5, b)]
   |                     ^
 
-error: Keyword argument or kwargs(**) is not allowed after kwargs(**)
+error: keyword argument or kwargs(**) is not allowed after kwargs(**)
  --> $DIR/invalid_macro_args.rs:8:29
   |
 8 | #[pyfunction(kwargs = "**", a = 5)]
-  |                             ^^^^^
+  |                             ^

--- a/tests/ui/invalid_need_module_arg_position.stderr
+++ b/tests/ui/invalid_need_module_arg_position.stderr
@@ -1,5 +1,5 @@
-error: Expected &PyModule as first argument with `pass_module`.
+error: expected &PyModule as first argument with `pass_module`
  --> $DIR/invalid_need_module_arg_position.rs:6:13
   |
 6 |     fn fail(string: &str, module: &PyModule) -> PyResult<&str> {
-  |             ^^^^^^^^^^^^
+  |             ^^^^^^

--- a/tests/ui/invalid_property_args.stderr
+++ b/tests/ui/invalid_property_args.stderr
@@ -1,16 +1,16 @@
-error: Getter function can only have one argument of type pyo3::Python
+error: getter function can only have one argument (of type pyo3::Python)
  --> $DIR/invalid_property_args.rs:9:50
   |
 9 |     fn getter_with_arg(&self, py: Python, index: u32) {}
   |                                                  ^^^
 
-error: Setter function expected to have one argument
+error: setter function expected to have one argument
   --> $DIR/invalid_property_args.rs:18:8
    |
 18 |     fn setter_with_no_arg(&mut self, py: Python) {}
    |        ^^^^^^^^^^^^^^^^^^
 
-error: Setter function can have at most two arguments: one of pyo3::Python, and one other
+error: setter function can have at most two arguments ([pyo3::Python,] and value)
   --> $DIR/invalid_property_args.rs:24:72
    |
 24 |     fn setter_with_too_many_args(&mut self, py: Python, foo: u32, bar: u32) {}

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -1,20 +1,20 @@
-error: Expected one of freelist/name/extends/module
+error: expected one of freelist/name/extends/module
  --> $DIR/invalid_pyclass_args.rs:3:11
   |
 3 | #[pyclass(extend=pyo3::types::PyDict)]
   |           ^^^^^^
 
-error: Expected type path (e.g., my_mod::BaseClass)
+error: expected type path (e.g., my_mod::BaseClass)
  --> $DIR/invalid_pyclass_args.rs:6:21
   |
 6 | #[pyclass(extends = "PyDict")]
   |                     ^^^^^^^^
 
-error: Expected type name (e.g. "Name")
+error: expected type name (e.g. "Name")
  --> $DIR/invalid_pyclass_args.rs:9:18
   |
 9 | #[pyclass(name = m::MyClass)]
-  |                  ^^^^^^^^^^
+  |                  ^
 
 error: expected a single identifier in double-quotes
   --> $DIR/invalid_pyclass_args.rs:12:18
@@ -28,13 +28,13 @@ error: since PyO3 0.13 a pyclass name should be in double-quotes, e.g. "CustomNa
 15 | #[pyclass(name = CustomName)]
    |                  ^^^^^^^^^^
 
-error: Expected string literal (e.g., "my_mod")
+error: expected string literal (e.g., "my_mod")
   --> $DIR/invalid_pyclass_args.rs:18:20
    |
 18 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
-error: Expected one of gc/weakref/subclass/dict/unsendable
+error: expected one of gc/weakref/subclass/dict/unsendable
   --> $DIR/invalid_pyclass_args.rs:21:11
    |
 21 | #[pyclass(weakrev)]

--- a/tests/ui/invalid_pymethods.rs
+++ b/tests/ui/invalid_pymethods.rs
@@ -1,0 +1,85 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+struct MyClass {}
+
+#[pymethods]
+impl MyClass {
+    #[classattr]
+    fn class_attr_with_args(foo: i32) {}
+}
+
+#[pymethods]
+impl MyClass {
+    fn staticmethod_without_attribute() {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[staticmethod]
+    fn staticmethod_with_receiver(&self) {}
+}
+
+// FIXME: This currently doesn't fail
+// #[pymethods]
+// impl MyClass {
+//     #[classmethod]
+//     fn classmethod_with_receiver(&self) {}
+// }
+
+#[pymethods]
+impl MyClass {
+    #[getter(x)]
+    fn getter_without_receiver() {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[setter(x)]
+    fn setter_without_receiver() {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[new]
+    #[text_signature = "()"]
+    fn text_signature_on_new() {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[call]
+    #[text_signature = "()"]
+    fn text_signature_on_call(&self) {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[getter(x)]
+    #[text_signature = "()"]
+    fn text_signature_on_getter(&self) {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[setter(x)]
+    #[text_signature = "()"]
+    fn text_signature_on_setter(&self) {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[classattr]
+    #[text_signature = "()"]
+    fn text_signature_on_classattr() {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[classattr]
+    #[staticmethod]
+    fn multiple_method_types() {}
+}
+
+
+fn main() {}

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -1,0 +1,65 @@
+error: class attribute methods cannot take arguments
+ --> $DIR/invalid_pymethods.rs:9:29
+  |
+9 |     fn class_attr_with_args(foo: i32) {}
+  |                             ^^^
+
+error: static method needs #[staticmethod] attribute
+  --> $DIR/invalid_pymethods.rs:14:5
+   |
+14 |     fn staticmethod_without_attribute() {}
+   |     ^^
+
+error: unexpected receiver for method
+  --> $DIR/invalid_pymethods.rs:20:35
+   |
+20 |     fn staticmethod_with_receiver(&self) {}
+   |                                   ^
+
+error: expected receiver for #[getter]
+  --> $DIR/invalid_pymethods.rs:33:5
+   |
+33 |     fn getter_without_receiver() {}
+   |     ^^
+
+error: expected receiver for #[setter]
+  --> $DIR/invalid_pymethods.rs:39:5
+   |
+39 |     fn setter_without_receiver() {}
+   |     ^^
+
+error: text_signature not allowed on __new__; if you want to add a signature on __new__, put it on the struct definition instead
+  --> $DIR/invalid_pymethods.rs:45:24
+   |
+45 |     #[text_signature = "()"]
+   |                        ^^^^
+
+error: text_signature not allowed with this method type
+  --> $DIR/invalid_pymethods.rs:52:24
+   |
+52 |     #[text_signature = "()"]
+   |                        ^^^^
+
+error: text_signature not allowed with this method type
+  --> $DIR/invalid_pymethods.rs:59:24
+   |
+59 |     #[text_signature = "()"]
+   |                        ^^^^
+
+error: text_signature not allowed with this method type
+  --> $DIR/invalid_pymethods.rs:66:24
+   |
+66 |     #[text_signature = "()"]
+   |                        ^^^^
+
+error: text_signature not allowed with this method type
+  --> $DIR/invalid_pymethods.rs:73:24
+   |
+73 |     #[text_signature = "()"]
+   |                        ^^^^
+
+error: cannot specify a second method type
+  --> $DIR/invalid_pymethods.rs:80:7
+   |
+80 |     #[staticmethod]
+   |       ^^^^^^^^^^^^

--- a/tests/ui/reject_generics.stderr
+++ b/tests/ui/reject_generics.stderr
@@ -2,4 +2,4 @@ error: #[pyclass] cannot have generic parameters
  --> $DIR/reject_generics.rs:4:25
   |
 4 | struct ClassWithGenerics<A> {
-  |                         ^^^
+  |                         ^


### PR DESCRIPTION
This PR is a refactoring to the error handling code in `pyo3-macros-backend`.

I've made two adjustments:
 - Add macros `ensure_spanned!` and `bail_spanned!` which work similar to `anyhow::ensure!` and `anyhow::bail!`, to reduce boilerplate.
 - Ensure that all error messages do not start with a capital letter or end with a period.

So far I've only made this change to the `#[derive(FromPyObject)]` code. If you think this refactoring is good, I'd like to continue with it for the rest of the `pyo3-macros-backend` crate before we merge this PR.