### PR TITLE
Exclude more files from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/pyo3/pyo3"
 documentation = "https://docs.rs/crate/pyo3/"
 categories = ["api-bindings", "development-tools::ffi"]
 license = "Apache-2.0"
-exclude = ["/.gitignore", ".cargo/config"]
+exclude = ["/.gitignore", ".cargo/config", "/codecov.yml", "/Makefile", "/pyproject.toml", "/tox.ini"]
 build = "build.rs"
 edition = "2018"
 


### PR DESCRIPTION
Exclude files that are only useful for CI or development, but not in the crates published on crates.io.