### PR TITLE
macros-backend: fix raw idents in pymethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `prepare_freethreaded_python` will no longer register an `atexit` handler to call `Py_Finalize`. [#1355](https://github.com/PyO3/pyo3/pull/1355)
 
+### Fixed
+- Fix support for using `r#raw_idents` as argument names in pyfunctions. [#1383](https://github.com/PyO3/pyo3/pull/1383)
+
 ## [0.13.1] - 2021-01-10
 ### Added
 - Add support for `#[pyclass(dict)]` and `#[pyclass(weakref)]` with the `abi3` feature on Python 3.9 and up. [#1342](https://github.com/PyO3/pyo3/pull/1342)

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -215,7 +215,7 @@ impl<'a> FnSpec<'a> {
         }
 
         let ty = get_return_info(&sig.output);
-        let python_name = python_name.unwrap_or_else(|| name.unraw());
+        let python_name = python_name.as_ref().unwrap_or(name).unraw();
 
         let mut parse_erroneous_text_signature = |error_msg: &str| {
             // try to parse anyway to give better error messages

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -392,13 +392,13 @@ pub fn impl_arg_params(
         if arg.py || spec.is_args(&arg.name) || spec.is_kwargs(&arg.name) {
             continue;
         }
-        let name = arg.name;
+        let name = arg.name.unraw().to_string();
         let kwonly = spec.is_kw_only(&arg.name);
         let opt = arg.optional.is_some() || spec.default_value(&arg.name).is_some();
 
         params.push(quote! {
             pyo3::derive_utils::ParamDescription {
-                name: stringify!(#name),
+                name: #name,
                 is_optional: #opt,
                 kw_only: #kwonly
             }


### PR DESCRIPTION
Closes #1382 

I added a comprehensive test and then added some fixes in the code for the cases uncovered by the test.