### PR TITLE
add some safety notes

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -401,7 +401,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     ///
     /// # Safety
     ///
-    /// Relies on unsafe fn `from_owned_ptr_or_opt`.
+    /// Relies on [`from_owned_ptr_or_opt`](#method.from_owned_ptr_or_opt).
     unsafe fn from_owned_ptr_or_panic(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         Self::from_owned_ptr_or_opt(py, ptr).unwrap_or_else(|| err::panic_after_error(py))
     }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -411,7 +411,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     ///
     /// # Safety
     ///
-    /// Relies on unsafe fn `from_owned_ptr_or_opt`.
+    /// Relies on [`from_owned_ptr_or_opt`](#method.from_owned_ptr_or_opt).
     unsafe fn from_owned_ptr(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         Self::from_owned_ptr_or_panic(py, ptr)
     }
@@ -419,7 +419,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     ///
     /// # Safety
     ///
-    /// Relies on unsafe fn `from_owned_ptr_or_opt`.
+    /// Relies on [`from_owned_ptr_or_opt`](#method.from_owned_ptr_or_opt).
     unsafe fn from_owned_ptr_or_err(py: Python<'p>, ptr: *mut ffi::PyObject) -> PyResult<&'p Self> {
         Self::from_owned_ptr_or_opt(py, ptr).ok_or_else(|| err::PyErr::fetch(py))
     }
@@ -434,7 +434,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     ///
     /// # Safety
     ///
-    /// Relies on unsafe fn `from_borrowed_ptr_or_opt`.
+    /// Relies on unsafe fn [`from_borrowed_ptr_or_opt`](#method.from_borrowed_ptr_or_opt).
     unsafe fn from_borrowed_ptr_or_panic(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         Self::from_borrowed_ptr_or_opt(py, ptr).unwrap_or_else(|| err::panic_after_error(py))
     }
@@ -442,7 +442,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     ///
     /// # Safety
     ///
-    /// Relies on unsafe fn `from_borrowed_ptr_or_opt`.
+    /// Relies on unsafe fn [`from_borrowed_ptr_or_opt`](#method.from_borrowed_ptr_or_opt).
     unsafe fn from_borrowed_ptr(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         Self::from_borrowed_ptr_or_panic(py, ptr)
     }
@@ -450,7 +450,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     ///
     /// # Safety
     ///
-    /// Relies on unsafe fn `from_borrowed_ptr_or_opt`.
+    /// Relies on unsafe fn [`from_borrowed_ptr_or_opt`](#method.from_borrowed_ptr_or_opt).
     unsafe fn from_borrowed_ptr_or_err(
         py: Python<'p>,
         ptr: *mut ffi::PyObject,

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -395,7 +395,9 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     ///
     /// # Safety
     ///
-    /// Implementations must ensure the object does not get freed during `'p` and avoid type confusion.
+    /// Implementations must ensure the object does not get freed during `'p`
+    /// and ensure that `ptr` is of the correct type.
+    /// Note that it must be safe to decrement the reference count of `ptr`.
     unsafe fn from_owned_ptr_or_opt(py: Python<'p>, ptr: *mut ffi::PyObject) -> Option<&'p Self>;
     /// Convert from an arbitrary `PyObject` or panic.
     ///

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -290,6 +290,10 @@ pub trait PyTryFrom<'v>: Sized + PyNativeType {
 
     /// Cast a PyAny to a specific type of PyObject. The caller must
     /// have already verified the reference is for this type.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that the type is valid or risk type confusion.
     unsafe fn try_from_unchecked<V: Into<&'v PyAny>>(value: V) -> &'v Self;
 }
 
@@ -387,24 +391,64 @@ impl IntoPy<Py<PyTuple>> for () {
 
 /// Raw level conversion between `*mut ffi::PyObject` and PyO3 types.
 pub unsafe trait FromPyPointer<'p>: Sized {
+    /// Convert from an arbitrary `PyObject`.
+    ///
+    /// # Safety
+    ///
+    /// Implementations must ensure the object does not get freed during `'p` and avoid type confusion.
     unsafe fn from_owned_ptr_or_opt(py: Python<'p>, ptr: *mut ffi::PyObject) -> Option<&'p Self>;
+    /// Convert from an arbitrary `PyObject` or panic.
+    ///
+    /// # Safety
+    ///
+    /// Relies on unsafe fn `from_owned_ptr_or_opt`.
     unsafe fn from_owned_ptr_or_panic(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         Self::from_owned_ptr_or_opt(py, ptr).unwrap_or_else(|| err::panic_after_error(py))
     }
+    /// Convert from an arbitrary `PyObject` or panic.
+    ///
+    /// # Safety
+    ///
+    /// Relies on unsafe fn `from_owned_ptr_or_opt`.
     unsafe fn from_owned_ptr(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         Self::from_owned_ptr_or_panic(py, ptr)
     }
+    /// Convert from an arbitrary `PyObject`.
+    ///
+    /// # Safety
+    ///
+    /// Relies on unsafe fn `from_owned_ptr_or_opt`.
     unsafe fn from_owned_ptr_or_err(py: Python<'p>, ptr: *mut ffi::PyObject) -> PyResult<&'p Self> {
         Self::from_owned_ptr_or_opt(py, ptr).ok_or_else(|| err::PyErr::fetch(py))
     }
+    /// Convert from an arbitrary borrowed `PyObject`.
+    ///
+    /// # Safety
+    ///
+    /// Implementations must ensure the object does not get freed during `'p` and avoid type confusion.
     unsafe fn from_borrowed_ptr_or_opt(py: Python<'p>, ptr: *mut ffi::PyObject)
         -> Option<&'p Self>;
+    /// Convert from an arbitrary borrowed `PyObject`.
+    ///
+    /// # Safety
+    ///
+    /// Relies on unsafe fn `from_borrowed_ptr_or_opt`.
     unsafe fn from_borrowed_ptr_or_panic(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         Self::from_borrowed_ptr_or_opt(py, ptr).unwrap_or_else(|| err::panic_after_error(py))
     }
+    /// Convert from an arbitrary borrowed `PyObject`.
+    ///
+    /// # Safety
+    ///
+    /// Relies on unsafe fn `from_borrowed_ptr_or_opt`.
     unsafe fn from_borrowed_ptr(py: Python<'p>, ptr: *mut ffi::PyObject) -> &'p Self {
         Self::from_borrowed_ptr_or_panic(py, ptr)
     }
+    /// Convert from an arbitrary borrowed `PyObject`.
+    ///
+    /// # Safety
+    ///
+    /// Relies on unsafe fn `from_borrowed_ptr_or_opt`.
     unsafe fn from_borrowed_ptr_or_err(
         py: Python<'p>,
         ptr: *mut ffi::PyObject,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -345,6 +345,9 @@ impl<T> Py<T> {
     /// # Safety
     /// `ptr` must be a pointer to a Python object of type T.
     ///
+    /// Callers must own the object referred to by `ptr`, as this function
+    /// implicitly takes ownership of that object.
+    ///
     /// # Panics
     /// Panics if `ptr` is null.
     #[inline]
@@ -359,6 +362,9 @@ impl<T> Py<T> {
     ///
     /// # Safety
     /// `ptr` must be a pointer to a Python object of type T.
+    ///
+    /// Callers must own the object referred to by `ptr`, as this function
+    /// implicitly takes ownership of that object.
     #[inline]
     #[deprecated = "this is a deprecated alias for Py::from_owned_ptr"]
     pub unsafe fn from_owned_ptr_or_panic(py: Python, ptr: *mut ffi::PyObject) -> Py<T> {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -356,6 +356,9 @@ impl<T> Py<T> {
     }
 
     /// Deprecated alias for [`from_owned_ptr`](#method.from_owned_ptr).
+    ///
+    /// # Safety
+    /// `ptr` must be a pointer to a Python object of type T.
     #[inline]
     #[deprecated = "this is a deprecated alias for Py::from_owned_ptr"]
     pub unsafe fn from_owned_ptr_or_panic(py: Python, ptr: *mut ffi::PyObject) -> Py<T> {

--- a/src/python.rs
+++ b/src/python.rs
@@ -448,6 +448,10 @@ impl<'p> Python<'p> {
 
     /// Registers the object in the release pool, and does an unchecked downcast
     /// to the specific type.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that ensure that the cast is valid.
     pub unsafe fn cast_as<T>(self, obj: PyObject) -> &'p T
     where
         T: PyNativeType + PyTypeInfo,
@@ -458,6 +462,10 @@ impl<'p> Python<'p> {
 
     /// Registers the object pointer in the release pool,
     /// and does an unchecked downcast to the specific type.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that ensure that the cast is valid.
     #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_owned_ptr<T>(self, ptr: *mut ffi::PyObject) -> &'p T
     where
@@ -470,6 +478,10 @@ impl<'p> Python<'p> {
     ///
     /// Returns `Err(PyErr)` if the pointer is NULL.
     /// Does an unchecked downcast to the specific type.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that ensure that the cast is valid.
     #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_owned_ptr_or_err<T>(self, ptr: *mut ffi::PyObject) -> PyResult<&'p T>
     where
@@ -482,6 +494,10 @@ impl<'p> Python<'p> {
     ///
     /// Returns `None` if the pointer is NULL.
     /// Does an unchecked downcast to the specific type.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that ensure that the cast is valid.
     #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_owned_ptr_or_opt<T>(self, ptr: *mut ffi::PyObject) -> Option<&'p T>
     where
@@ -493,6 +509,10 @@ impl<'p> Python<'p> {
     /// Does an unchecked downcast to the specific type.
     ///
     /// Panics if the pointer is NULL.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that ensure that the cast is valid.
     #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_borrowed_ptr<T>(self, ptr: *mut ffi::PyObject) -> &'p T
     where
@@ -504,6 +524,10 @@ impl<'p> Python<'p> {
     /// Does an unchecked downcast to the specific type.
     ///
     /// Returns `Err(PyErr)` if the pointer is NULL.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that ensure that the cast is valid.
     #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_borrowed_ptr_or_err<T>(self, ptr: *mut ffi::PyObject) -> PyResult<&'p T>
     where
@@ -515,6 +539,10 @@ impl<'p> Python<'p> {
     /// Does an unchecked downcast to the specific type.
     ///
     /// Returns `None` if the pointer is NULL.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that ensure that the cast is valid.
     #[allow(clippy::wrong_self_convention)]
     pub unsafe fn from_borrowed_ptr_or_opt<T>(self, ptr: *mut ffi::PyObject) -> Option<&'p T>
     where

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -67,6 +67,10 @@ impl PyBytes {
     /// Creates a new Python byte string object from a raw pointer and length.
     ///
     /// Panics if out of memory.
+    ///
+    /// # Safety
+    ///
+    /// Unsafe as it deferences the raw pointer `ptr`.
     pub unsafe fn from_ptr(py: Python<'_>, ptr: *const u8, len: usize) -> &PyBytes {
         py.from_owned_ptr(ffi::PyBytes_FromStringAndSize(
             ptr as *const _,

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -70,7 +70,8 @@ impl PyBytes {
     ///
     /// # Safety
     ///
-    /// Unsafe as it deferences the raw pointer `ptr`.
+    /// This function dereferences the raw pointer `ptr`,
+    /// [which is an unsafe operation](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#unsafe-superpowers).
     pub unsafe fn from_ptr(py: Python<'_>, ptr: *const u8, len: usize) -> &PyBytes {
         py.from_owned_ptr(ffi::PyBytes_FromStringAndSize(
             ptr as *const _,

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -70,8 +70,10 @@ impl PyBytes {
     ///
     /// # Safety
     ///
-    /// This function dereferences the raw pointer `ptr`,
-    /// [which is an unsafe operation](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html#unsafe-superpowers).
+    /// This function dereferences the raw pointer `ptr` as the
+    /// leading pointer of a slice of length `len`. [As with
+    /// `std::slice::from_raw_parts`, this is
+    /// unsafe](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety).
     pub unsafe fn from_ptr(py: Python<'_>, ptr: *const u8, len: usize) -> &PyBytes {
         py.from_owned_ptr(ffi::PyBytes_FromStringAndSize(
             ptr as *const _,


### PR DESCRIPTION
For #698.

I'm not convinced that all the APIs defined should be unsafe. For example:

https://github.com/PyO3/pyo3/blob/b6f595ba018b3be8e14cd398fb347caf067bd1bf/src/type_object.rs#L23

Implemented in:
https://github.com/PyO3/pyo3/blob/b6f595ba018b3be8e14cd398fb347caf067bd1bf/src/pycell.rs#L69

Since `py_init` takes ownership of `value`, it seems the worst thing that could happen is a memory leak, which is generally considered safe. But do correct me if there are other things that could go wrong here.

Likewise, `PyClassDict::clear_dict` seems safe, as all it does is call `PyDict_Clear` on a dict which is (afaik) managed by Python refcounting and doesn't include anything that we own. So it seems to me that there is some scope to reduce the `unsafe` labeling.