### PR TITLE
Make PyTimeAccess::get_fold() return bool instead of u8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add FFI definition `PyCFunction_CheckExact` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 
 ### Changed
+- Change `PyTimeAcces::get_fold()` to return a `bool` instead of a `u8`. [#1397](https://github.com/PyO3/pyo3/pull/1397)
 - Deprecate FFI definition `PyCFunction_Call` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - Deprecate FFI definitions `PyModule_GetFilename`, `PyMethodDef_INIT`. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -58,7 +58,7 @@ pub trait PyTimeAccess {
     fn get_second(&self) -> u8;
     fn get_microsecond(&self) -> u32;
     #[cfg(not(PyPy))]
-    fn get_fold(&self) -> u8;
+    fn get_fold(&self) -> bool;
 }
 
 /// Bindings around `datetime.date`
@@ -256,8 +256,8 @@ impl PyTimeAccess for PyDateTime {
     }
 
     #[cfg(not(PyPy))]
-    fn get_fold(&self) -> u8 {
-        unsafe { PyDateTime_DATE_GET_FOLD(self.as_ptr()) as u8 }
+    fn get_fold(&self) -> bool {
+        unsafe { PyDateTime_DATE_GET_FOLD(self.as_ptr()) > 0 }
     }
 }
 
@@ -338,8 +338,8 @@ impl PyTimeAccess for PyTime {
     }
 
     #[cfg(not(PyPy))]
-    fn get_fold(&self) -> u8 {
-        unsafe { PyDateTime_TIME_GET_FOLD(self.as_ptr()) as u8 }
+    fn get_fold(&self) -> bool {
+        unsafe { PyDateTime_TIME_GET_FOLD(self.as_ptr()) != 0 }
     }
 }
 
@@ -421,8 +421,8 @@ mod tests {
             let a = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, false);
             let b = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, true);
 
-            assert_eq!(a.unwrap().get_fold(), 0);
-            assert_eq!(b.unwrap().get_fold(), 1);
+            assert_eq!(a.unwrap().get_fold(), false);
+            assert_eq!(b.unwrap().get_fold(), true);
         });
     }
 }


### PR DESCRIPTION
The fold property of a Python datetime stores whether the datetime lies on a leap second or not. The only allowed values are 0 and 1 ([source](https://docs.python.org/3/library/datetime.html#datetime.datetime.fold)). Therefore, the [`PyTimeAccess::get_fold()`](https://docs.rs/pyo3/0.13.1/pyo3/types/trait.PyTimeAccess.html#tymethod.get_fold) method should expose this property as a `bool`.

Coincidentally, the [`PyTime::new_with_fold()`](https://docs.rs/pyo3/0.13.1/pyo3/types/struct.PyTime.html) already uses bool as the type of fold.

In a later PR, I will add the currently missing `PyDateTime::new_with_fold()` method, which is also going to accept bool for the fold parameter.

This is a breaking change