### PR TITLE
Add PyDateTime::new_with_fold() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add unsafe API `with_embedded_python_interpreter` to initalize a Python interpreter, execute a closure, and finalize the interpreter. [#1355](https://github.com/PyO3/pyo3/pull/1355)
 - Add `serde` feature to support `Serialize/Deserialize` for `Py<T>`. [#1366](https://github.com/PyO3/pyo3/pull/1366)
 - Add FFI definition `_PyCFunctionFastWithKeywords` on Python 3.7 and up. [#1384](https://github.com/PyO3/pyo3/pull/1384)
+- Add `PyDateTime::new_with_fold()` method. [#1398](https://github.com/PyO3/pyo3/pull/1398)
 
 ### Changed
 - `prepare_freethreaded_python` will no longer register an `atexit` handler to call `Py_Finalize`. [#1355](https://github.com/PyO3/pyo3/pull/1355)

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -158,7 +158,8 @@ impl PyDateTime {
     }
 
     #[cfg(not(PyPy))]
-    /// Alternate constructor that takes a `fold` argument
+    /// Alternate constructor that takes a `fold` parameter. A `true` value for this parameter
+    /// signifies a leap second
     pub fn new_with_fold<'p>(
         py: Python<'p>,
         year: i32,
@@ -407,5 +408,21 @@ unsafe fn opt_to_pyobj(py: Python, opt: Option<&PyObject>) -> *mut ffi::PyObject
     match opt {
         Some(tzi) => tzi.as_ptr(),
         None => py.None().as_ptr(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_new_with_fold() {
+        pyo3::Python::with_gil(|py| {
+            use pyo3::types::{PyDateTime, PyTimeAccess};
+
+            let a = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, false);
+            let b = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, true);
+
+            assert_eq!(a.unwrap().get_fold(), 0);
+            assert_eq!(b.unwrap().get_fold(), 1);
+        });
     }
 }

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -157,6 +157,8 @@ impl PyDateTime {
         }
     }
 
+    #[cfg(not(PyPy))]
+    /// Alternate constructor that takes a `fold` argument
     pub fn new_with_fold<'p>(
         py: Python<'p>,
         year: i32,

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -157,6 +157,35 @@ impl PyDateTime {
         }
     }
 
+    pub fn new_with_fold<'p>(
+        py: Python<'p>,
+        year: i32,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        microsecond: u32,
+        tzinfo: Option<&PyObject>,
+        fold: bool,
+    ) -> PyResult<&'p PyDateTime> {
+        unsafe {
+            let ptr = (PyDateTimeAPI.DateTime_FromDateAndTimeAndFold)(
+                year,
+                c_int::from(month),
+                c_int::from(day),
+                c_int::from(hour),
+                c_int::from(minute),
+                c_int::from(second),
+                microsecond as c_int,
+                opt_to_pyobj(py, tzinfo),
+                c_int::from(fold),
+                PyDateTimeAPI.DateTimeType,
+            );
+            py.from_owned_ptr_or_err(ptr)
+        }
+    }
+
     /// Construct a `datetime` object from a POSIX timestamp
     ///
     /// This is equivalent to `datetime.datetime.from_timestamp`


### PR DESCRIPTION
`PyTime` already has a new_with_fold() method; `PyDateTime` needs one for consistency and, more importantly, to be able to handle leap seconds correctly.