### PR TITLE
pystring: use PyUnicode_AsUTF8AndSize always from Python 3.10 and up

### DIFF
--- a/src/ffi/unicodeobject.rs
+++ b/src/ffi/unicodeobject.rs
@@ -143,14 +143,16 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_FromOrdinal")]
     pub fn PyUnicode_FromOrdinal(ordinal: c_int) -> *mut PyObject;
     pub fn PyUnicode_ClearFreeList() -> c_int;
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(any(not(Py_LIMITED_API), Py_3_10))]
     #[cfg(Py_3_7)]
+    #[cfg_attr(PyPy, link_name = "PyPyUnicode_AsUTF8AndSize")]
     pub fn PyUnicode_AsUTF8AndSize(unicode: *mut PyObject, size: *mut Py_ssize_t) -> *const c_char;
     #[cfg(not(Py_3_7))]
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_AsUTF8AndSize")]
     pub fn PyUnicode_AsUTF8AndSize(unicode: *mut PyObject, size: *mut Py_ssize_t) -> *mut c_char;
     #[cfg(not(Py_LIMITED_API))]
     #[cfg(Py_3_7)]
+    #[cfg_attr(PyPy, link_name = "PyPyUnicode_AsUTF8")]
     pub fn PyUnicode_AsUTF8(unicode: *mut PyObject) -> *const c_char;
     #[cfg(not(Py_3_7))]
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_AsUTF8")]


### PR DESCRIPTION
Just a tidy-up I noticed while thinking about `PyString::to_string_lossy` for #1379 