### PR TITLE
release: 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,25 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/master/migration
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.13.2] - 2021-02-12
+### Packaging
+- Lower minimum supported Rust version to 1.41. [#1421](https://github.com/PyO3/pyo3/pull/1421)
+
 ### Added
-- Add unsafe API `with_embedded_python_interpreter` to initalize a Python interpreter, execute a closure, and finalize the interpreter. [#1355](https://github.com/PyO3/pyo3/pull/1355)
-- Add `serde` feature to support `Serialize/Deserialize` for `Py<T>`. [#1366](https://github.com/PyO3/pyo3/pull/1366)
+- Add unsafe API `with_embedded_python_interpreter` to  initalize a Python interpreter, execute a closure, and finalize the interpreter. [#1355](https://github.com/PyO3/pyo3/pull/1355)
+- Add `serde` feature which provides implementations of `Serialize` and `Deserialize` for `Py<T>`. [#1366](https://github.com/PyO3/pyo3/pull/1366)
 - Add FFI definition `_PyCFunctionFastWithKeywords` on Python 3.7 and up. [#1384](https://github.com/PyO3/pyo3/pull/1384)
 - Add `PyDateTime::new_with_fold()` method. [#1398](https://github.com/PyO3/pyo3/pull/1398)
 
 ### Changed
-- `prepare_freethreaded_python` will no longer register an `atexit` handler to call `Py_Finalize`. [#1355](https://github.com/PyO3/pyo3/pull/1355)
-- Mark FFI definitions `PyMarshal_WriteObjectToString`, `PyMarshal_ReadObjectFromString` as available in limited API.
-- Mark FFI definitions `PyListObject` and those from `funcobject.h` as requiring non-limited API.  [#1387](https://github.com/PyO3/pyo3/pull/1387)
-- Fix typo in FFI definition `PyFunction_Code` to `PyFunction_GetCode`. [#1387](https://github.com/PyO3/pyo3/pull/1387)
+- `prepare_freethreaded_python` will no longer register an `atexit` handler to call `Py_Finalize`. This resolves a number of issues with incompatible C extensions causing crashes at finalization. [#1355](https://github.com/PyO3/pyo3/pull/1355)
 - Mark `PyLayout::py_init`, `PyClassDict::clear_dict`, and `opt_to_pyobj` safe, as they do not perform any unsafe operations. [#1404](https://github.com/PyO3/pyo3/pull/1404)
 
 ### Fixed
 - Fix support for using `r#raw_idents` as argument names in pyfunctions. [#1383](https://github.com/PyO3/pyo3/pull/1383)
+- Fix typo in FFI definition for `PyFunction_GetCode` (was incorrectly `PyFunction_Code`). [#1387](https://github.com/PyO3/pyo3/pull/1387)
+- Fix FFI definitions `PyMarshal_WriteObjectToString` and `PyMarshal_ReadObjectFromString` as available in limited API. [#1387](https://github.com/PyO3/pyo3/pull/1387)
+- Fix FFI definitions `PyListObject` and those from `funcobject.h` as requiring non-limited API. [#1387](https://github.com/PyO3/pyo3/pull/1387)
 - Fix unqualified `Result` usage in `pyobject_native_type_base`. [#1402](https://github.com/PyO3/pyo3/pull/1402)
 - Fix build on systems where the default Python encoding is not UTF-8. [#1405](https://github.com/PyO3/pyo3/pull/1405)
 - Fix build on mingw / MSYS2. [#1423](https://github.com/PyO3/pyo3/pull/1423)
@@ -614,7 +617,8 @@ Yanked
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/pyo3/pyo3/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/pyo3/pyo3/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/pyo3/pyo3/compare/v0.12.4...v0.13.0
 [0.12.4]: https://github.com/pyo3/pyo3/compare/v0.12.3...v0.12.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.13.1"
+version = "0.13.2"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -26,7 +26,7 @@ num-bigint = { version = "0.3", optional = true }
 num-complex = { version = "0.3", optional = true }
 # must stay at 0.1.x for Rust 1.41 compatibility
 paste = { version = "0.1.18", optional = true }
-pyo3-macros = { path = "pyo3-macros", version = "=0.13.1", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.13.2", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = "0.9", optional = true }
 serde = {version = "1.0", optional = true}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.13.1"
+version = "0.13.2"
 features = ["extension-module"]
 ```
 
@@ -105,7 +105,7 @@ use it to run Python code, add `pyo3` to your `Cargo.toml` like this:
 
 ```toml
 [dependencies.pyo3]
-version = "0.13.1"
+version = "0.13.2"
 features = ["auto-initialize"]
 ```
 

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.13.1"
+version = "0.13.2"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.13.1"
+version = "0.13.2"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.13.1" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.13.2" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies.pyo3]
-//! version = "0.13.1"
+//! version = "0.13.2"
 //! features = ["extension-module"]
 //! ```
 //!
@@ -120,7 +120,7 @@
 //!
 //! ```toml
 //! [dependencies.pyo3]
-//! version = "0.13.1"
+//! version = "0.13.2"
 //! features = ["auto-initialize"]
 //! ```
 //!


### PR DESCRIPTION
cc @kngwyu 

This is the last release I think we need to make for the 0.13 series before we merge a number of breaking changes and start developing for 0.14. We already have breaking changes #1354 #1391 and #1398 waiting to be merged, as well as many `#[deprecated]` methods we could begin cleaning up.

Making this release will fix the issues with finalization which is blocking `pyo3-asyncio` from making a first release.

I'll try to release this on Tuesday if I don't hear otherwise. Though I think it'd be nice to merge #1393 and #1379 before we release this, so I might wait if needed.

I suggest the following release text:

----

This release contains small improvements over PyO3 0.13.1. The minimum supported Rust version has been lowered to Rust 1.41. A `serde` feature has been added which provides implementations of `Serialize` and `Deserialize` for types inside the `Py<T>` smart pointer.

Of note is that this release disables automatic finalization of the Python interpreter at program exit for Rust binaries embedding the Python interpreter. This was found to cause a number of issues with C extensions such as Tensorflow and Scipy which were sensitive to the deinitialization order. For the vast majority of users this should cause no impact or fix a number of problem cases. For the minority who did depend on finalization, the unsafe method `with_embedded_python_interpreter` has been added to manually control the interpreter lifecycle.

For full details of all changes, see the [CHANGELOG](https://pyo3.rs/v0.13.2/changelog.html).

Thank you to everyone who contributed code, documentation fixes, design ideas, bug reports, and feedback. The following users' commits are included in this release:

@alex 
@awestlake87 
@birkenfeld 
@cfbolz 
@daniil-konovalenko 
@davidhewitt 
@decathorpe 
@ijl 
@kangalioo 
@kngwyu 
@lazka 
@nw0 
@tdamsma 