### PR TITLE
Use fully-qualified Result in pyobject_native_type_base

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -35,7 +35,7 @@ macro_rules! pyobject_native_type_base(
 
         impl<$($generics,)*> std::fmt::Debug for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter)
-                   -> Result<(), std::fmt::Error>
+                   -> std::result::Result<(), std::fmt::Error>
             {
                 let s = self.repr().map_err(|_| std::fmt::Error)?;
                 f.write_str(&s.to_string_lossy())
@@ -44,7 +44,7 @@ macro_rules! pyobject_native_type_base(
 
         impl<$($generics,)*> std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter)
-                   -> Result<(), std::fmt::Error>
+                   -> std::result::Result<(), std::fmt::Error>
             {
                 let s = self.str().map_err(|_| std::fmt::Error)?;
                 f.write_str(&s.to_string_lossy())


### PR DESCRIPTION
This allows using macros such as `create_exception!` in modules where `Result` has been aliased, for example to a single-parameter type with a module-specific error type. And in any event, seems like good macro hygiene to use fully-qualified names wherever possible.