### PR TITLE
Remove `unsafe` for some safe functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Mark FFI definitions `PyMarshal_WriteObjectToString`, `PyMarshal_ReadObjectFromString` as available in limited API.
 - Mark FFI definitions `PyListObject` and those from `funcobject.h` as requiring non-limited API.  [#1387](https://github.com/PyO3/pyo3/pull/1387)
 - Fix typo in FFI definition `PyFunction_Code` to `PyFunction_GetCode`. [#1387](https://github.com/PyO3/pyo3/pull/1387)
+- Mark `PyLayout::py_init`, `PyClassDict::clear_dict`, and `opt_to_pyobj` safe, as they do not perform any unsafe operations. [#1404](https://github.com/PyO3/pyo3/pull/1404)
 
 
 ### Fixed

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -66,7 +66,7 @@ unsafe impl<T: PyClass> PyLayout<T> for PyCellInner<T> {
     fn get_super(&mut self) -> Option<&mut T::BaseLayout> {
         Some(&mut self.ob_base)
     }
-    unsafe fn py_init(&mut self, value: T) {
+    fn py_init(&mut self, value: T) {
         self.value = ManuallyDrop::new(UnsafeCell::new(value));
     }
     unsafe fn py_drop(&mut self, py: Python) {
@@ -396,7 +396,7 @@ unsafe impl<T: PyClass> PyLayout<T> for PyCell<T> {
     fn get_super(&mut self) -> Option<&mut T::BaseLayout> {
         Some(&mut self.inner.ob_base)
     }
-    unsafe fn py_init(&mut self, value: T) {
+    fn py_init(&mut self, value: T) {
         self.inner.value = ManuallyDrop::new(UnsafeCell::new(value));
     }
     unsafe fn py_drop(&mut self, py: Python) {

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -149,9 +149,7 @@ impl<T: PyClass> PyClassInitializer<T> {
 impl<T: PyClass> PyObjectInit<T> for PyClassInitializer<T> {
     fn init_class<L: PyLayout<T>>(self, layout: &mut L) {
         let Self { init, super_init } = self;
-        unsafe {
-            layout.py_init(init);
-        }
+        layout.py_init(init);
         if let Some(super_obj) = layout.get_super() {
             super_init.init_class(super_obj);
         }

--- a/src/pyclass_slots.rs
+++ b/src/pyclass_slots.rs
@@ -6,7 +6,7 @@ use crate::{ffi, Python};
 pub trait PyClassDict {
     const IS_DUMMY: bool = true;
     fn new() -> Self;
-    unsafe fn clear_dict(&mut self, _py: Python) {}
+    fn clear_dict(&mut self, _py: Python) {}
     private_decl! {}
 }
 
@@ -47,9 +47,9 @@ impl PyClassDict for PyClassDictSlot {
     fn new() -> Self {
         Self(std::ptr::null_mut())
     }
-    unsafe fn clear_dict(&mut self, _py: Python) {
+    fn clear_dict(&mut self, _py: Python) {
         if !self.0.is_null() {
-            ffi::PyDict_Clear(self.0)
+            unsafe { ffi::PyDict_Clear(self.0) }
         }
     }
 }

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -20,7 +20,7 @@ pub unsafe trait PyLayout<T: PyTypeInfo> {
     fn get_super(&mut self) -> Option<&mut T::BaseLayout> {
         None
     }
-    unsafe fn py_init(&mut self, _value: T) {}
+    fn py_init(&mut self, _value: T) {}
     unsafe fn py_drop(&mut self, _py: Python) {}
 }
 

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -403,7 +403,7 @@ impl PyDeltaAccess for PyDelta {
 }
 
 // Utility function
-unsafe fn opt_to_pyobj(py: Python, opt: Option<&PyObject>) -> *mut ffi::PyObject {
+fn opt_to_pyobj(py: Python, opt: Option<&PyObject>) -> *mut ffi::PyObject {
     // Convenience function for unpacking Options to either an Object or None
     match opt {
         Some(tzi) => tzi.as_ptr(),


### PR DESCRIPTION
Closes #1389, which noted that some safe functions are marked `unsafe`.

Noted that this is a breaking change.