### PR TITLE
Add from_py_with attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - Add conversions between `OsStr`/`OsString`/`Path`/`PathBuf` and Python strings. [#1379](https://github.com/PyO3/pyo3/pull/1379)
+- Add #[pyo3(from_py_with = "...")]` attribute for function arguments and struct fields to override the default from-Python conversion. [#1411](https://github.com/PyO3/pyo3/pull/1411)
 - Add FFI definition `PyCFunction_CheckExact` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 
 ### Changed

--- a/pyo3-macros-backend/src/attrs.rs
+++ b/pyo3-macros-backend/src/attrs.rs
@@ -1,0 +1,22 @@
+use syn::spanned::Spanned;
+use syn::{ExprPath, Lit, Meta, MetaNameValue, Result};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FromPyWithAttribute(pub ExprPath);
+
+impl FromPyWithAttribute {
+    pub fn from_meta(meta: Meta) -> Result<Self> {
+        let string_literal = match meta {
+            Meta::NameValue(MetaNameValue {
+                lit: Lit::Str(string_literal),
+                ..
+            }) => string_literal,
+            meta => {
+                bail_spanned!(meta.span() => "expected a name-value: `pyo3(from_py_with = \"func\")`")
+            }
+        };
+
+        let expr_path = string_literal.parse::<ExprPath>()?;
+        Ok(FromPyWithAttribute(expr_path))
+    }
+}

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -7,6 +7,7 @@
 #[macro_use]
 mod utils;
 
+mod attrs;
 mod defs;
 mod from_pyobject;
 mod konst;

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -1,11 +1,12 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
 use crate::pyfunction::Argument;
-use crate::pyfunction::{parse_name_attribute, PyFunctionAttr};
+use crate::pyfunction::{parse_name_attribute, PyFunctionArgAttrs, PyFunctionAttr};
 use crate::utils;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use quote::{quote, quote_spanned};
+use std::ops::Deref;
 use syn::ext::IdentExt;
 use syn::spanned::Spanned;
 
@@ -17,6 +18,7 @@ pub struct FnArg<'a> {
     pub ty: &'a syn::Type,
     pub optional: Option<&'a syn::Type>,
     pub py: bool,
+    pub attrs: PyFunctionArgAttrs,
 }
 
 #[derive(Clone, PartialEq, Debug, Copy, Eq)]
@@ -115,111 +117,48 @@ pub fn parse_method_receiver(arg: &syn::FnArg) -> syn::Result<SelfType> {
 
 impl<'a> FnSpec<'a> {
     /// Parser function signature and function attributes
-    #[allow(clippy::manual_strip)] // for strip_prefix replacement supporting rust < 1.45
     pub fn parse(
-        sig: &'a syn::Signature,
+        sig: &'a mut syn::Signature,
         meth_attrs: &mut Vec<syn::Attribute>,
         allow_custom_name: bool,
     ) -> syn::Result<FnSpec<'a>> {
-        let name = &sig.ident;
         let MethodAttributes {
             ty: fn_type_attr,
             args: fn_attrs,
             mut python_name,
         } = parse_method_attributes(meth_attrs, allow_custom_name)?;
 
-        let mut arguments = Vec::new();
-        let mut inputs_iter = sig.inputs.iter();
+        let (fn_type, skip_first_arg) = Self::parse_fn_type(sig, fn_type_attr, &mut python_name)?;
 
-        let mut parse_receiver = |msg: &'static str| {
-            inputs_iter
-                .next()
-                .ok_or_else(|| err_spanned!(sig.span() => msg))
-                .and_then(parse_method_receiver)
-        };
-
-        // strip get_ or set_
-        let strip_fn_name = |prefix: &'static str| {
-            let ident = name.unraw().to_string();
-            if ident.starts_with(prefix) {
-                Some(syn::Ident::new(&ident[prefix.len()..], ident.span()))
-            } else {
-                None
-            }
-        };
-
-        // Parse receiver & function type for various method types
-        let fn_type = match fn_type_attr {
-            Some(MethodTypeAttribute::StaticMethod) => FnType::FnStatic,
-            Some(MethodTypeAttribute::ClassAttribute) => {
-                ensure_spanned!(
-                    sig.inputs.is_empty(),
-                    sig.inputs.span() => "class attribute methods cannot take arguments"
-                );
-                FnType::ClassAttribute
-            }
-            Some(MethodTypeAttribute::New) => FnType::FnNew,
-            Some(MethodTypeAttribute::ClassMethod) => {
-                // Skip first argument for classmethod - always &PyType
-                let _ = inputs_iter.next();
-                FnType::FnClass
-            }
-            Some(MethodTypeAttribute::Call) => {
-                FnType::FnCall(parse_receiver("expected receiver for #[call]")?)
-            }
-            Some(MethodTypeAttribute::Getter) => {
-                // Strip off "get_" prefix if needed
-                if python_name.is_none() {
-                    python_name = strip_fn_name("get_");
-                }
-
-                FnType::Getter(parse_receiver("expected receiver for #[getter]")?)
-            }
-            Some(MethodTypeAttribute::Setter) => {
-                // Strip off "set_" prefix if needed
-                if python_name.is_none() {
-                    python_name = strip_fn_name("set_");
-                }
-
-                FnType::Setter(parse_receiver("expected receiver for #[setter]")?)
-            }
-            None => FnType::Fn(parse_receiver(
-                "static method needs #[staticmethod] attribute",
-            )?),
-        };
-
-        // parse rest of arguments
-        for input in inputs_iter {
-            match input {
-                syn::FnArg::Receiver(recv) => {
-                    bail_spanned!(recv.span() => "unexpected receiver for method")
-                }
-                syn::FnArg::Typed(syn::PatType { pat, ty, .. }) => {
-                    let (ident, by_ref, mutability) = match &**pat {
-                        syn::Pat::Ident(syn::PatIdent {
-                            ident,
-                            by_ref,
-                            mutability,
-                            ..
-                        }) => (ident, by_ref, mutability),
-                        _ => bail_spanned!(pat.span() => "unsupported argument"),
-                    };
-
-                    arguments.push(FnArg {
-                        name: ident,
-                        by_ref,
-                        mutability,
-                        ty,
-                        optional: utils::option_type_argument(ty),
-                        py: utils::is_python(ty),
-                    });
-                }
-            }
-        }
-
+        let name = &sig.ident;
         let ty = get_return_info(&sig.output);
         let python_name = python_name.as_ref().unwrap_or(name).unraw();
 
+        let text_signature = Self::parse_text_signature(meth_attrs, &fn_type, &python_name)?;
+        let doc = utils::get_doc(&meth_attrs, text_signature, true)?;
+
+        let arguments = if skip_first_arg {
+            Self::parse_arguments(&mut sig.inputs.iter_mut().skip(1))?
+        } else {
+            Self::parse_arguments(&mut sig.inputs.iter_mut())?
+        };
+
+        Ok(FnSpec {
+            tp: fn_type,
+            name,
+            python_name,
+            attrs: fn_attrs,
+            args: arguments,
+            output: ty,
+            doc,
+        })
+    }
+
+    fn parse_text_signature(
+        meth_attrs: &mut Vec<syn::Attribute>,
+        fn_type: &FnType,
+        python_name: &syn::Ident,
+    ) -> syn::Result<Option<syn::LitStr>> {
         let mut parse_erroneous_text_signature = |error_msg: &str| {
             // try to parse anyway to give better error messages
             if let Some(text_signature) =
@@ -244,17 +183,117 @@ impl<'a> FnSpec<'a> {
             }
         };
 
-        let doc = utils::get_doc(&meth_attrs, text_signature, true)?;
+        Ok(text_signature)
+    }
 
-        Ok(FnSpec {
-            tp: fn_type,
-            name,
-            python_name,
-            attrs: fn_attrs,
-            args: arguments,
-            output: ty,
-            doc,
-        })
+    fn parse_arguments(
+        // inputs: &'a mut [syn::FnArg],
+        inputs_iter: impl Iterator<Item = &'a mut syn::FnArg>,
+    ) -> syn::Result<Vec<FnArg<'a>>> {
+        let mut arguments = vec![];
+        for input in inputs_iter {
+            match input {
+                syn::FnArg::Receiver(recv) => {
+                    bail_spanned!(recv.span() => "unexpected receiver for method")
+                } // checked in parse_fn_type
+                syn::FnArg::Typed(cap) => {
+                    let arg_attrs = PyFunctionArgAttrs::from_attrs(&mut cap.attrs)?;
+                    let (ident, by_ref, mutability) = match *cap.pat {
+                        syn::Pat::Ident(syn::PatIdent {
+                            ref ident,
+                            ref by_ref,
+                            ref mutability,
+                            ..
+                        }) => (ident, by_ref, mutability),
+                        _ => bail_spanned!(cap.pat.span() => "unsupported argument"),
+                    };
+
+                    arguments.push(FnArg {
+                        name: ident,
+                        by_ref,
+                        mutability,
+                        ty: cap.ty.deref(),
+                        optional: utils::option_type_argument(cap.ty.deref()),
+                        py: utils::is_python(cap.ty.deref()),
+                        attrs: arg_attrs,
+                    });
+                }
+            }
+        }
+
+        Ok(arguments)
+    }
+
+    fn parse_fn_type(
+        sig: &syn::Signature,
+        fn_type_attr: Option<MethodTypeAttribute>,
+        python_name: &mut Option<syn::Ident>,
+    ) -> syn::Result<(FnType, bool)> {
+        let name = &sig.ident;
+        let parse_receiver = |msg: &'static str| {
+            let first_arg = sig
+                .inputs
+                .first()
+                .ok_or_else(|| err_spanned!(sig.span() => msg))?;
+            parse_method_receiver(first_arg)
+        };
+
+        #[allow(clippy::manual_strip)] // for strip_prefix replacement supporting rust < 1.45
+        // strip get_ or set_
+        let strip_fn_name = |prefix: &'static str| {
+            let ident = name.unraw().to_string();
+            if ident.starts_with(prefix) {
+                Some(syn::Ident::new(&ident[prefix.len()..], ident.span()))
+            } else {
+                None
+            }
+        };
+
+        let (fn_type, skip_first_arg) = match fn_type_attr {
+            Some(MethodTypeAttribute::StaticMethod) => (FnType::FnStatic, false),
+            Some(MethodTypeAttribute::ClassAttribute) => {
+                ensure_spanned!(
+                    sig.inputs.is_empty(),
+                    sig.inputs.span() => "class attribute methods cannot take arguments"
+                );
+                (FnType::ClassAttribute, false)
+            }
+            Some(MethodTypeAttribute::New) => (FnType::FnNew, false),
+            Some(MethodTypeAttribute::ClassMethod) => (FnType::FnClass, true),
+            Some(MethodTypeAttribute::Call) => (
+                FnType::FnCall(parse_receiver("expected receiver for #[call]")?),
+                true,
+            ),
+            Some(MethodTypeAttribute::Getter) => {
+                // Strip off "get_" prefix if needed
+                if python_name.is_none() {
+                    *python_name = strip_fn_name("get_");
+                }
+
+                (
+                    FnType::Getter(parse_receiver("expected receiver for #[getter]")?),
+                    true,
+                )
+            }
+            Some(MethodTypeAttribute::Setter) => {
+                // Strip off "set_" prefix if needed
+                if python_name.is_none() {
+                    *python_name = strip_fn_name("set_");
+                }
+
+                (
+                    FnType::Setter(parse_receiver("expected receiver for #[setter]")?),
+                    true,
+                )
+            }
+            None => (
+                FnType::Fn(parse_receiver(
+                    "static method needs #[staticmethod] attribute",
+                )?),
+                true,
+            ),
+        };
+        Ok((fn_type, skip_first_arg))
     }
 
     pub fn is_args(&self, name: &syn::Ident) -> bool {

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
+use crate::attrs::FromPyWithAttribute;
 use crate::konst::ConstSpec;
 use crate::method::{FnArg, FnSpec, FnType, SelfType};
 use crate::utils;
@@ -491,6 +492,12 @@ fn impl_arg_param(
         (None, false) => quote! { panic!("Failed to extract required method argument") },
     };
 
+    let extract = if let Some(FromPyWithAttribute(expr_path)) = &arg.attrs.from_py_with {
+        quote! {#expr_path(_obj).map_err(#transform_error)?}
+    } else {
+        quote! {_obj.extract().map_err(#transform_error)?}
+    };
+
     return if let syn::Type::Reference(tref) = arg.optional.as_ref().unwrap_or(&ty) {
         let (tref, mut_) = preprocess_tref(tref, self_);
         let (target_ty, borrow_tmp) = if arg.optional.is_some() {
@@ -513,7 +520,7 @@ fn impl_arg_param(
 
         quote! {
             let #mut_ _tmp: #target_ty = match #arg_value {
-                Some(_obj) => _obj.extract().map_err(#transform_error)?,
+                Some(_obj) => #extract,
                 None => #default,
             };
             let #arg_name = #borrow_tmp;
@@ -521,7 +528,7 @@ fn impl_arg_param(
     } else {
         quote! {
             let #arg_name = match #arg_value {
-                Some(_obj) => _obj.extract().map_err(#transform_error)?,
+                Some(_obj) => #extract,
                 None => #default,
             };
         }

--- a/pyo3-macros-backend/src/pyproto.rs
+++ b/pyo3-macros-backend/src/pyproto.rs
@@ -62,8 +62,7 @@ fn impl_proto_impl(
             }
             // Add non-slot methods to inventory like `#[pymethods]`
             if let Some(m) = proto.get_method(&met.sig.ident) {
-                let name = &met.sig.ident;
-                let fn_spec = FnSpec::parse(&met.sig, &mut met.attrs, false)?;
+                let fn_spec = FnSpec::parse(&mut met.sig, &mut met.attrs, false)?;
 
                 let method = if let FnType::Fn(self_ty) = &fn_spec.tp {
                     pymethod::impl_proto_wrap(ty, &fn_spec, &self_ty)
@@ -79,6 +78,7 @@ fn impl_proto_impl(
                 } else {
                     quote!(0)
                 };
+                let name = &met.sig.ident;
                 // TODO(kngwyu): Set ml_doc
                 py_methods.push(quote! {
                     pyo3::class::PyMethodDefType::Method({

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -244,3 +244,47 @@ fn panic_unsendable_base() {
 fn panic_unsendable_child() {
     test_unsendable::<UnsendableChild>().unwrap();
 }
+
+fn get_length(obj: &PyAny) -> PyResult<usize> {
+    let length = obj.len()?;
+
+    Ok(length)
+}
+
+#[pyclass]
+struct ClassWithFromPyWithMethods {}
+
+#[pymethods]
+impl ClassWithFromPyWithMethods {
+    fn instance_method(&self, #[pyo3(from_py_with = "get_length")] argument: usize) -> usize {
+        argument
+    }
+    #[classmethod]
+    fn classmethod(_cls: &PyType, #[pyo3(from_py_with = "PyAny::len")] argument: usize) -> usize {
+        argument
+    }
+
+    #[staticmethod]
+    fn staticmethod(#[pyo3(from_py_with = "get_length")] argument: usize) -> usize {
+        argument
+    }
+}
+
+#[test]
+fn test_pymethods_from_py_with() {
+    Python::with_gil(|py| {
+        let instance = Py::new(py, ClassWithFromPyWithMethods {}).unwrap();
+
+        py_run!(
+            py,
+            instance,
+            r#"
+        arg = {1: 1, 2: 3}
+
+        assert instance.instance_method(arg) == 2
+        assert instance.classmethod(arg) == 2
+        assert instance.staticmethod(arg) == 2
+        "#
+        );
+    })
+}

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -8,6 +8,7 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_pyclass_args.rs");
     t.compile_fail("tests/ui/invalid_pymethods.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
+    t.compile_fail("tests/ui/invalid_argument_attributes.rs");
     t.compile_fail("tests/ui/reject_generics.rs");
 
     tests_rust_1_45(&t);

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -299,3 +299,30 @@ fn test_err_rename() {
         "TypeError: 'dict' object cannot be converted to 'Union[str, uint, int]'"
     );
 }
+
+#[derive(Debug, FromPyObject)]
+pub struct Zap {
+    #[pyo3(item)]
+    name: String,
+
+    #[pyo3(from_py_with = "PyAny::len", item("my_object"))]
+    some_object_length: usize,
+}
+
+#[test]
+fn test_from_py_with() {
+    Python::with_gil(|py| {
+        let py_zap = py
+            .eval(
+                r#"{"name": "whatever", "my_object": [1, 2, 3]}"#,
+                None,
+                None,
+            )
+            .expect("failed to create dict");
+
+        let zap = Zap::extract(py_zap).unwrap();
+
+        assert_eq!(zap.name, "whatever");
+        assert_eq!(zap.some_object_length, 3usize);
+    });
+}

--- a/tests/ui/invalid_argument_attributes.rs
+++ b/tests/ui/invalid_argument_attributes.rs
@@ -1,0 +1,15 @@
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn invalid_attribute(#[pyo3(get)] param: String) {}
+
+#[pyfunction]
+fn from_py_with_no_value(#[pyo3(from_py_with)] param: String) {}
+
+#[pyfunction]
+fn from_py_with_string(#[pyo3("from_py_with")] param: String) {}
+
+#[pyfunction]
+fn from_py_with_value_not_a_string(#[pyo3(from_py_with = func)] param: String) {}
+
+fn main() {}

--- a/tests/ui/invalid_argument_attributes.stderr
+++ b/tests/ui/invalid_argument_attributes.stderr
@@ -1,0 +1,23 @@
+error: only `from_py_with` is supported
+ --> $DIR/invalid_argument_attributes.rs:4:29
+  |
+4 | fn invalid_attribute(#[pyo3(get)] param: String) {}
+  |                             ^^^
+
+error: expected a name-value: `pyo3(from_py_with = "func")`
+ --> $DIR/invalid_argument_attributes.rs:7:33
+  |
+7 | fn from_py_with_no_value(#[pyo3(from_py_with)] param: String) {}
+  |                                 ^^^^^^^^^^^^
+
+error: expected `from_py_with`, got a literal
+  --> $DIR/invalid_argument_attributes.rs:10:31
+   |
+10 | fn from_py_with_string(#[pyo3("from_py_with")] param: String) {}
+   |                               ^^^^^^^^^^^^^^
+
+error: expected literal
+  --> $DIR/invalid_argument_attributes.rs:13:58
+   |
+13 | fn from_py_with_value_not_a_string(#[pyo3(from_py_with = func)] param: String) {}
+   |                                                          ^^^^

--- a/tests/ui/invalid_frompy_derive.rs
+++ b/tests/ui/invalid_frompy_derive.rs
@@ -153,4 +153,16 @@ enum UnitEnum {
     Unit,
 }
 
+#[derive(FromPyObject)]
+struct InvalidFromPyWith {
+    #[pyo3(from_py_with)]
+    field: String,
+}
+
+#[derive(FromPyObject)]
+struct InvalidFromPyWithLiteral {
+    #[pyo3(from_py_with = func)]
+    field: String,
+}
+
 fn main() {}

--- a/tests/ui/invalid_frompy_derive.stderr
+++ b/tests/ui/invalid_frompy_derive.stderr
@@ -84,7 +84,7 @@ error: transparent structs and variants can only have 1 field
 70 | |     },
    | |_____^
 
-error: expected `attribute` or `item`
+error: expected `attribute`, `item` or `from_py_with`
   --> $DIR/invalid_frompy_derive.rs:76:12
    |
 76 |     #[pyo3(attr)]
@@ -127,10 +127,10 @@ error: expected a single literal argument
     |            ^^^^
 
 error: only one of `attribute` or `item` can be provided
-   --> $DIR/invalid_frompy_derive.rs:118:12
+   --> $DIR/invalid_frompy_derive.rs:118:18
     |
 118 |     #[pyo3(item, attribute)]
-    |            ^^^^
+    |                  ^^^^^^^^^
 
 error: unknown `pyo3` container attribute
    --> $DIR/invalid_frompy_derive.rs:123:8
@@ -169,3 +169,15 @@ error: cannot derive FromPyObject for empty structs and variants
     |          ^^^^^^^^^^^^
     |
     = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: expected a name-value: `pyo3(from_py_with = "func")`
+   --> $DIR/invalid_frompy_derive.rs:158:12
+    |
+158 |     #[pyo3(from_py_with)]
+    |            ^^^^^^^^^^^^
+
+error: expected literal
+   --> $DIR/invalid_frompy_derive.rs:164:27
+    |
+164 |     #[pyo3(from_py_with = func)]
+    |                           ^^^^


### PR DESCRIPTION
This PR addresses #1239. 

It adds a  `#[pyo3(from_py_with = "function")]` attribute that allows to customize conversion between Python-native and Rust-native types.  
At the moment only argument attributes are supported. I plan on adding support for derive in the near future.

I've made a couple of design decisions along the way, that can be changed if needed:
- I chose `from_py_with` instead of `from_python_with` from the original proposal because it was shorter to type. Also it goes well with the trait name `FromPyObject`.
- The path to the conversion function is quoted instead of being a raw identifier, mainly because [serde does it](https://serde.rs/field-attrs.html#serialize_with). If there are any reasons it shouldn't be quoted, please let me know.


There's still a bunch of stuff left to do:
- [x] support `from_py_with` in `derive(FromPyObject)`
- [x] refactor `parse_arg_attributes` into smaller functions
- [x] add tests with usage in #[pymethods]
- [ ] support `from_py_with` for enums/tuple structs
- [ ] add tests for enums/tuple structs
- [x] add tests for errors
- [x] add a CHANGELOG entry
- [x] add docs (tracking issue #1432)
