### PR TITLE
Support building with Mingw Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix support for using `r#raw_idents` as argument names in pyfunctions. [#1383](https://github.com/PyO3/pyo3/pull/1383)
 - Fix unqualified `Result` usage in `pyobject_native_type_base`. [#1402](https://github.com/PyO3/pyo3/pull/1402)
 - Fix build on systems where the default Python encoding is not UTF-8. [#1405](https://github.com/PyO3/pyo3/pull/1405)
+- Fix build on mingw / MSYS2. [#1423](https://github.com/PyO3/pyo3/pull/1423)
 
 ## [0.13.1] - 2021-01-10
 ### Added

--- a/build.rs
+++ b/build.rs
@@ -598,17 +598,25 @@ fn run_python_script(interpreter: &Path, script: &str) -> Result<String> {
 
 fn get_rustc_link_lib(config: &InterpreterConfig) -> String {
     let link_name = if env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() == "windows" {
-        // Link against python3.lib for the stable ABI on Windows.
-        // See https://www.python.org/dev/peps/pep-0384/#linkage
-        //
-        // This contains only the limited ABI symbols.
-        if env::var_os("CARGO_FEATURE_ABI3").is_some() {
-            "pythonXY:python3".to_owned()
-        } else {
+        if env::var("CARGO_CFG_TARGET_ENV").unwrap().as_str() == "gnu" {
+            // https://packages.msys2.org/base/mingw-w64-python
             format!(
-                "pythonXY:python{}{}",
+                "pythonXY:python{}.{}",
                 config.version.major, config.version.minor
             )
+        } else {
+            // Link against python3.lib for the stable ABI on Windows.
+            // See https://www.python.org/dev/peps/pep-0384/#linkage
+            //
+            // This contains only the limited ABI symbols.
+            if env::var_os("CARGO_FEATURE_ABI3").is_some() {
+                "pythonXY:python3".to_owned()
+            } else {
+                format!(
+                    "pythonXY:python{}{}",
+                    config.version.major, config.version.minor
+                )
+            }
         }
     } else {
         match config.version.implementation {


### PR DESCRIPTION
The DLL of the mingw Python in MSYS2 is named libpython3.8.dll:

$ python3 -m sysconfig | grep LIBPYTHON
        LIBPYTHON = "-lpython3.8"

Add another special case to in get_rustc_link_lib() to handle that case.
Afaik the mingw build doesn't support the limited ABI, so skip that as well.

This makes all tests pass in an MSYS2 environment and lets us build
python-cryptography.