### PR TITLE
Don't require PYO3_CROSS_LIB_DIR when compiling for x86_64 from macOS arm64 and reverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
+- `PYO3_CROSS_LIB_DIR` enviroment variable no long required when compiling for x86-64 Python from macOS arm64 and reverse. [#1428](https://github.com/PyO3/pyo3/pull/1428)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/build.rs
+++ b/build.rs
@@ -142,6 +142,15 @@ fn cross_compiling() -> Result<Option<CrossCompileConfig>> {
         return Ok(None);
     }
 
+    if target == "x86_64-apple-darwin" && host == "aarch64-apple-darwin" {
+        // Not cross-compiling to compile for x86-64 Python from macOS arm64
+        return Ok(None);
+    }
+    if target == "aarch64-apple-darwin" && host == "x86_64-apple-darwin" {
+        // Not cross-compiling to compile for arm64 Python from macOS x86_64
+        return Ok(None);
+    }
+
     if host.starts_with(&format!(
         "{}-{}-{}",
         env::var("CARGO_CFG_TARGET_ARCH")?,


### PR DESCRIPTION
Big Sur nows ships universal2 binary for Python and Xcode, no need to use `PYO3_CROSS_LIB_DIR` when compiling for x86_64 from macOS arm64.

I think it's also the same when compiling for arm64 from x86-64 macOS but it would require checking Xcode version(at least 12.2? I'm not sure).

cc https://github.com/PyO3/maturin/pull/405#discussion_r565061767