### PR TITLE
ffi cleanup: object.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - Add FFI definition `PyCFunction_CheckExact` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
+- Add FFI definition `Py_IS_TYPE`.
 
 ### Changed
 - Deprecate FFI definition `PyCFunction_Call` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - Deprecate FFI definitions `PyModule_GetFilename`, `PyMethodDef_INIT`. [#1425](https://github.com/PyO3/pyo3/pull/1425)
+- Deprecate FFI definitions `PyObject_Check`, `PySuper_Check`, `FreeFunc`.
 
 ### Fixed
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
+- Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type.
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - Add FFI definition `PyCFunction_CheckExact` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
-- Add FFI definition `Py_IS_TYPE`.
+- Add FFI definition `Py_IS_TYPE`. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 
 ### Changed
 - Deprecate FFI definition `PyCFunction_Call` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - Deprecate FFI definitions `PyModule_GetFilename`, `PyMethodDef_INIT`. [#1425](https://github.com/PyO3/pyo3/pull/1425)
-- Deprecate FFI definitions `PyObject_Check`, `PySuper_Check`, `FreeFunc`.
+- Deprecate FFI definitions `PyObject_Check`, `PySuper_Check`, `FreeFunc`. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 
 ### Fixed
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
-- Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type.
+- Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove deprecated ffi definitions `PyGetSetDef_INIT`, `PyGetSetDef_DICT`, `PyCoro_Check`, `PyCoroWrapper_Check`, and `PyAsyncGen_Check`. [#1426](https://github.com/PyO3/pyo3/pull/1426)
 - Remove deprecated redundant methods `Python::is_instance`, `Python::is_subclass`, `Python::release`, `Python::xdecref`, and `Py::from_owned_ptr_or_panic`. [#1426](https://github.com/PyO3/pyo3/pull/1426)
 - Remove ffi definition ``PyMethodDef_INIT`. [#1426](https://github.com/PyO3/pyo3/pull/1426)
+- Remove FFI definition `PyTypeObject_INIT`. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 
 ### Fixed
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)

--- a/src/ffi/cpython/abstract_.rs
+++ b/src/ffi/cpython/abstract_.rs
@@ -1,4 +1,4 @@
-use crate::ffi::{PyObject, Py_buffer, Py_ssize_t, _PyObject_NextNotImplemented};
+use crate::ffi::{PyObject, Py_buffer, Py_ssize_t};
 use std::os::raw::{c_char, c_int, c_void};
 
 #[cfg(all(Py_3_8, not(PyPy)))]
@@ -270,7 +270,9 @@ extern "C" {
 #[cfg(not(any(all(Py_3_8, Py_LIMITED_API), PyPy)))]
 pub unsafe fn PyIter_Check(o: *mut PyObject) -> c_int {
     (match (*crate::ffi::Py_TYPE(o)).tp_iternext {
-        Some(tp_iternext) => tp_iternext as *const c_void != _PyObject_NextNotImplemented as _,
+        Some(tp_iternext) => {
+            tp_iternext as *const c_void != crate::ffi::_PyObject_NextNotImplemented as _
+        }
         None => false,
     }) as c_int
 }

--- a/src/ffi/cpython/abstract_.rs
+++ b/src/ffi/cpython/abstract_.rs
@@ -1,4 +1,4 @@
-use crate::ffi::{PyObject, Py_buffer, Py_ssize_t};
+use crate::ffi::{PyObject, Py_buffer, Py_ssize_t, _PyObject_NextNotImplemented};
 use std::os::raw::{c_char, c_int, c_void};
 
 #[cfg(all(Py_3_8, not(PyPy)))]
@@ -270,9 +270,7 @@ extern "C" {
 #[cfg(not(any(all(Py_3_8, Py_LIMITED_API), PyPy)))]
 pub unsafe fn PyIter_Check(o: *mut PyObject) -> c_int {
     (match (*crate::ffi::Py_TYPE(o)).tp_iternext {
-        Some(tp_iternext) => {
-            tp_iternext as *const c_void != crate::ffi::object::_PyObject_NextNotImplemented as _
-        }
+        Some(tp_iternext) => tp_iternext as *const c_void != _PyObject_NextNotImplemented as _,
         None => false,
     }) as c_int
 }

--- a/src/ffi/cpython/ceval.rs
+++ b/src/ffi/cpython/ceval.rs
@@ -1,6 +1,4 @@
-#[cfg(not(Py_LIMITED_API))]
-use crate::ffi::object::FreeFunc;
-use crate::ffi::object::PyObject;
+use crate::ffi::object::{freefunc, PyObject};
 use crate::ffi::pystate::Py_tracefunc;
 use std::os::raw::c_int;
 
@@ -9,8 +7,7 @@ extern "C" {
         arg1: *mut crate::ffi::PyFrameObject,
         exc: c_int,
     ) -> *mut PyObject;
-    #[cfg(not(Py_LIMITED_API))]
-    pub fn _PyEval_RequestCodeExtraIndex(func: FreeFunc) -> c_int;
+    pub fn _PyEval_RequestCodeExtraIndex(func: freefunc) -> c_int;
     pub fn PyEval_SetProfile(trace_func: Py_tracefunc, arg1: *mut PyObject);
     pub fn PyEval_SetTrace(trace_func: Py_tracefunc, arg1: *mut PyObject);
 }

--- a/src/ffi/cpython/mod.rs
+++ b/src/ffi/cpython/mod.rs
@@ -12,6 +12,7 @@ pub mod frameobject;
 // skipped initconfig.h
 // skipped interpreteridobject.h
 pub mod listobject;
+pub mod object;
 
 pub use self::abstract_::*;
 #[cfg(not(PyPy))]
@@ -22,3 +23,4 @@ pub use self::code::*;
 pub use self::dictobject::*;
 pub use self::frameobject::*;
 pub use self::listobject::*;
+pub use self::object::*;

--- a/src/ffi/cpython/object.rs
+++ b/src/ffi/cpython/object.rs
@@ -1,0 +1,483 @@
+use crate::ffi::PyObject;
+use std::os::raw::c_int;
+
+// skipped _Py_NewReference
+// skipped _Py_ForgetReference
+// skipped _Py_GetRefTotal
+
+// skipped _Py_Identifier
+
+// skipped _Py_static_string_init
+// skipped _Py_static_string
+// skipped _Py_IDENTIFIER
+
+mod bufferinfo {
+    use crate::ffi::Py_ssize_t;
+    use std::os::raw::{c_char, c_int, c_void};
+    use std::ptr;
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct Py_buffer {
+        pub buf: *mut c_void,
+        /// Owned reference
+        pub obj: *mut crate::ffi::PyObject,
+        pub len: Py_ssize_t,
+        pub itemsize: Py_ssize_t,
+        pub readonly: c_int,
+        pub ndim: c_int,
+        pub format: *mut c_char,
+        pub shape: *mut Py_ssize_t,
+        pub strides: *mut Py_ssize_t,
+        pub suboffsets: *mut Py_ssize_t,
+        pub internal: *mut c_void,
+    }
+
+    impl Py_buffer {
+        pub const fn new() -> Self {
+            Py_buffer {
+                buf: ptr::null_mut(),
+                obj: ptr::null_mut(),
+                len: 0,
+                itemsize: 0,
+                readonly: 0,
+                ndim: 0,
+                format: ptr::null_mut(),
+                shape: ptr::null_mut(),
+                strides: ptr::null_mut(),
+                suboffsets: ptr::null_mut(),
+                internal: ptr::null_mut(),
+            }
+        }
+    }
+
+    pub type getbufferproc = unsafe extern "C" fn(
+        arg1: *mut crate::ffi::PyObject,
+        arg2: *mut Py_buffer,
+        arg3: c_int,
+    ) -> c_int;
+    pub type releasebufferproc =
+        unsafe extern "C" fn(arg1: *mut crate::ffi::PyObject, arg2: *mut Py_buffer);
+
+    /// Maximum number of dimensions
+    pub const PyBUF_MAX_NDIM: c_int = 64;
+
+    /* Flags for getting buffers */
+    pub const PyBUF_SIMPLE: c_int = 0;
+    pub const PyBUF_WRITABLE: c_int = 0x0001;
+    /*  we used to include an E, backwards compatible alias  */
+    pub const PyBUF_WRITEABLE: c_int = PyBUF_WRITABLE;
+    pub const PyBUF_FORMAT: c_int = 0x0004;
+    pub const PyBUF_ND: c_int = 0x0008;
+    pub const PyBUF_STRIDES: c_int = 0x0010 | PyBUF_ND;
+    pub const PyBUF_C_CONTIGUOUS: c_int = 0x0020 | PyBUF_STRIDES;
+    pub const PyBUF_F_CONTIGUOUS: c_int = 0x0040 | PyBUF_STRIDES;
+    pub const PyBUF_ANY_CONTIGUOUS: c_int = 0x0080 | PyBUF_STRIDES;
+    pub const PyBUF_INDIRECT: c_int = 0x0100 | PyBUF_STRIDES;
+
+    pub const PyBUF_CONTIG: c_int = PyBUF_ND | PyBUF_WRITABLE;
+    pub const PyBUF_CONTIG_RO: c_int = PyBUF_ND;
+
+    pub const PyBUF_STRIDED: c_int = PyBUF_STRIDES | PyBUF_WRITABLE;
+    pub const PyBUF_STRIDED_RO: c_int = PyBUF_STRIDES;
+
+    pub const PyBUF_RECORDS: c_int = PyBUF_STRIDES | PyBUF_WRITABLE | PyBUF_FORMAT;
+    pub const PyBUF_RECORDS_RO: c_int = PyBUF_STRIDES | PyBUF_FORMAT;
+
+    pub const PyBUF_FULL: c_int = PyBUF_INDIRECT | PyBUF_WRITABLE | PyBUF_FORMAT;
+    pub const PyBUF_FULL_RO: c_int = PyBUF_INDIRECT | PyBUF_FORMAT;
+
+    pub const PyBUF_READ: c_int = 0x100;
+    pub const PyBUF_WRITE: c_int = 0x200;
+}
+
+pub use self::bufferinfo::*;
+
+#[cfg(Py_3_8)]
+pub type vectorcallfunc = unsafe extern "C" fn(
+    callable: *mut PyObject,
+    args: *const *mut PyObject,
+    nargsf: libc::size_t,
+    kwnames: *mut PyObject,
+) -> *mut PyObject;
+
+mod typeobject {
+    use crate::ffi::{self, object};
+    use crate::ffi::{PyObject, Py_ssize_t};
+    use std::mem;
+    use std::os::raw::{c_char, c_int, c_uint, c_ulong, c_void};
+    use std::ptr;
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct PyNumberMethods {
+        pub nb_add: Option<object::binaryfunc>,
+        pub nb_subtract: Option<object::binaryfunc>,
+        pub nb_multiply: Option<object::binaryfunc>,
+        pub nb_remainder: Option<object::binaryfunc>,
+        pub nb_divmod: Option<object::binaryfunc>,
+        pub nb_power: Option<object::ternaryfunc>,
+        pub nb_negative: Option<object::unaryfunc>,
+        pub nb_positive: Option<object::unaryfunc>,
+        pub nb_absolute: Option<object::unaryfunc>,
+        pub nb_bool: Option<object::inquiry>,
+        pub nb_invert: Option<object::unaryfunc>,
+        pub nb_lshift: Option<object::binaryfunc>,
+        pub nb_rshift: Option<object::binaryfunc>,
+        pub nb_and: Option<object::binaryfunc>,
+        pub nb_xor: Option<object::binaryfunc>,
+        pub nb_or: Option<object::binaryfunc>,
+        pub nb_int: Option<object::unaryfunc>,
+        pub nb_reserved: *mut c_void,
+        pub nb_float: Option<object::unaryfunc>,
+        pub nb_inplace_add: Option<object::binaryfunc>,
+        pub nb_inplace_subtract: Option<object::binaryfunc>,
+        pub nb_inplace_multiply: Option<object::binaryfunc>,
+        pub nb_inplace_remainder: Option<object::binaryfunc>,
+        pub nb_inplace_power: Option<object::ternaryfunc>,
+        pub nb_inplace_lshift: Option<object::binaryfunc>,
+        pub nb_inplace_rshift: Option<object::binaryfunc>,
+        pub nb_inplace_and: Option<object::binaryfunc>,
+        pub nb_inplace_xor: Option<object::binaryfunc>,
+        pub nb_inplace_or: Option<object::binaryfunc>,
+        pub nb_floor_divide: Option<object::binaryfunc>,
+        pub nb_true_divide: Option<object::binaryfunc>,
+        pub nb_inplace_floor_divide: Option<object::binaryfunc>,
+        pub nb_inplace_true_divide: Option<object::binaryfunc>,
+        pub nb_index: Option<object::unaryfunc>,
+        pub nb_matrix_multiply: Option<object::binaryfunc>,
+        pub nb_inplace_matrix_multiply: Option<object::binaryfunc>,
+    }
+
+    macro_rules! as_expr {
+        ($e:expr) => {
+            $e
+        };
+    }
+
+    #[repr(C)]
+    #[derive(Clone)]
+    pub struct PySequenceMethods {
+        pub sq_length: Option<object::lenfunc>,
+        pub sq_concat: Option<object::binaryfunc>,
+        pub sq_repeat: Option<object::ssizeargfunc>,
+        pub sq_item: Option<object::ssizeargfunc>,
+        pub was_sq_slice: *mut c_void,
+        pub sq_ass_item: Option<object::ssizeobjargproc>,
+        pub was_sq_ass_slice: *mut c_void,
+        pub sq_contains: Option<object::objobjproc>,
+        pub sq_inplace_concat: Option<object::binaryfunc>,
+        pub sq_inplace_repeat: Option<object::ssizeargfunc>,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Default)]
+    pub struct PyMappingMethods {
+        pub mp_length: Option<object::lenfunc>,
+        pub mp_subscript: Option<object::binaryfunc>,
+        pub mp_ass_subscript: Option<object::objobjargproc>,
+    }
+
+    // skipped PySendResult
+
+    #[repr(C)]
+    #[derive(Clone, Default)]
+    pub struct PyAsyncMethods {
+        pub am_await: Option<object::unaryfunc>,
+        pub am_aiter: Option<object::unaryfunc>,
+        pub am_anext: Option<object::unaryfunc>,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Default)]
+    pub struct PyBufferProcs {
+        pub bf_getbuffer: Option<super::getbufferproc>,
+        pub bf_releasebuffer: Option<super::releasebufferproc>,
+    }
+
+    pub type printfunc =
+        unsafe extern "C" fn(arg1: *mut PyObject, arg2: *mut ::libc::FILE, arg3: c_int) -> c_int;
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    pub struct PyTypeObject {
+        #[cfg(PyPy)]
+        pub ob_refcnt: Py_ssize_t,
+        #[cfg(PyPy)]
+        pub ob_pypy_link: Py_ssize_t,
+        #[cfg(PyPy)]
+        pub ob_type: *mut PyTypeObject,
+        #[cfg(PyPy)]
+        pub ob_size: Py_ssize_t,
+        #[cfg(not(PyPy))]
+        pub ob_base: object::PyVarObject,
+        pub tp_name: *const c_char,
+        pub tp_basicsize: Py_ssize_t,
+        pub tp_itemsize: Py_ssize_t,
+        pub tp_dealloc: Option<object::destructor>,
+        #[cfg(not(Py_3_8))]
+        pub tp_print: Option<object::printfunc>,
+        #[cfg(Py_3_8)]
+        pub tp_vectorcall_offset: Py_ssize_t,
+        pub tp_getattr: Option<object::getattrfunc>,
+        pub tp_setattr: Option<object::setattrfunc>,
+        pub tp_as_async: *mut PyAsyncMethods,
+        pub tp_repr: Option<object::reprfunc>,
+        pub tp_as_number: *mut PyNumberMethods,
+        pub tp_as_sequence: *mut PySequenceMethods,
+        pub tp_as_mapping: *mut PyMappingMethods,
+        pub tp_hash: Option<object::hashfunc>,
+        pub tp_call: Option<object::ternaryfunc>,
+        pub tp_str: Option<object::reprfunc>,
+        pub tp_getattro: Option<object::getattrofunc>,
+        pub tp_setattro: Option<object::setattrofunc>,
+        pub tp_as_buffer: *mut PyBufferProcs,
+        pub tp_flags: c_ulong,
+        pub tp_doc: *const c_char,
+        pub tp_traverse: Option<object::traverseproc>,
+        pub tp_clear: Option<object::inquiry>,
+        pub tp_richcompare: Option<object::richcmpfunc>,
+        pub tp_weaklistoffset: Py_ssize_t,
+        pub tp_iter: Option<object::getiterfunc>,
+        pub tp_iternext: Option<object::iternextfunc>,
+        pub tp_methods: *mut ffi::methodobject::PyMethodDef,
+        pub tp_members: *mut ffi::structmember::PyMemberDef,
+        pub tp_getset: *mut ffi::descrobject::PyGetSetDef,
+        pub tp_base: *mut PyTypeObject,
+        pub tp_dict: *mut object::PyObject,
+        pub tp_descr_get: Option<object::descrgetfunc>,
+        pub tp_descr_set: Option<object::descrsetfunc>,
+        pub tp_dictoffset: Py_ssize_t,
+        pub tp_init: Option<object::initproc>,
+        pub tp_alloc: Option<object::allocfunc>,
+        pub tp_new: Option<object::newfunc>,
+        pub tp_free: Option<object::freefunc>,
+        pub tp_is_gc: Option<object::inquiry>,
+        pub tp_bases: *mut object::PyObject,
+        pub tp_mro: *mut object::PyObject,
+        pub tp_cache: *mut object::PyObject,
+        pub tp_subclasses: *mut object::PyObject,
+        pub tp_weaklist: *mut object::PyObject,
+        pub tp_del: Option<object::destructor>,
+        pub tp_version_tag: c_uint,
+        pub tp_finalize: Option<object::destructor>,
+        #[cfg(Py_3_8)]
+        pub tp_vectorcall: Option<super::vectorcallfunc>,
+        #[cfg(PyPy)]
+        pub tp_pypy_flags: std::os::raw::c_long,
+        #[cfg(py_sys_config = "COUNT_ALLOCS")]
+        pub tp_allocs: Py_ssize_t,
+        #[cfg(py_sys_config = "COUNT_ALLOCS")]
+        pub tp_frees: Py_ssize_t,
+        #[cfg(py_sys_config = "COUNT_ALLOCS")]
+        pub tp_maxalloc: Py_ssize_t,
+        #[cfg(py_sys_config = "COUNT_ALLOCS")]
+        pub tp_prev: *mut PyTypeObject,
+        #[cfg(py_sys_config = "COUNT_ALLOCS")]
+        pub tp_next: *mut PyTypeObject,
+    }
+
+    macro_rules! _type_object_init {
+        ({$($head:tt)*}, $($tail:tt)*) => {
+            as_expr! {
+                PyTypeObject {
+                    $($head)*
+                    tp_name: ptr::null(),
+                    tp_basicsize: 0,
+                    tp_itemsize: 0,
+                    tp_dealloc: None,
+                    #[cfg(not(Py_3_8))]
+                    tp_print: None,
+                    #[cfg(Py_3_8)]
+                    tp_vectorcall_offset: 0,
+                    tp_getattr: None,
+                    tp_setattr: None,
+                    tp_as_async: ptr::null_mut(),
+                    tp_repr: None,
+                    tp_as_number: ptr::null_mut(),
+                    tp_as_sequence: ptr::null_mut(),
+                    tp_as_mapping: ptr::null_mut(),
+                    tp_hash: None,
+                    tp_call: None,
+                    tp_str: None,
+                    tp_getattro: None,
+                    tp_setattro: None,
+                    tp_as_buffer: ptr::null_mut(),
+                    tp_flags: object::Py_TPFLAGS_DEFAULT,
+                    tp_doc: ptr::null(),
+                    tp_traverse: None,
+                    tp_clear: None,
+                    tp_richcompare: None,
+                    tp_weaklistoffset: 0,
+                    tp_iter: None,
+                    tp_iternext: None,
+                    tp_methods: ptr::null_mut(),
+                    tp_members: ptr::null_mut(),
+                    tp_getset: ptr::null_mut(),
+                    tp_base: ptr::null_mut(),
+                    tp_dict: ptr::null_mut(),
+                    tp_descr_get: None,
+                    tp_descr_set: None,
+                    tp_dictoffset: 0,
+                    tp_init: None,
+                    tp_alloc: None,
+                    tp_new: None,
+                    tp_free: None,
+                    tp_is_gc: None,
+                    tp_bases: ptr::null_mut(),
+                    tp_mro: ptr::null_mut(),
+                    tp_cache: ptr::null_mut(),
+                    tp_subclasses: ptr::null_mut(),
+                    tp_weaklist: ptr::null_mut(),
+                    tp_del: None,
+                    tp_version_tag: 0,
+                    tp_finalize: None,
+                    #[cfg(Py_3_8)]
+                    tp_vectorcall: None,
+                    $($tail)*
+                }
+            }
+        }
+    }
+
+    #[cfg(PyPy)]
+    macro_rules! type_object_init {
+        ($($tail:tt)*) => {
+            _type_object_init!({
+                    ob_refcnt: 1,
+                    ob_pypy_link: 0,
+                    ob_type: ptr::null_mut(),
+                    ob_size: 0,
+                },
+                tp_pypy_flags: 0,
+                $($tail)*
+            )
+        }
+    }
+
+    #[cfg(not(PyPy))]
+    macro_rules! type_object_init {
+        ($($tail:tt)*) => {
+            _type_object_init!({
+                ob_base: object::PyVarObject {
+                    ob_base: object::PyObject_HEAD_INIT,
+                    ob_size: 0
+                },},
+                $($tail)*
+            )
+        }
+    }
+
+    #[cfg(py_sys_config = "COUNT_ALLOCS")]
+    #[deprecated(note = "not present in Python headers; to be removed")]
+    pub const PyTypeObject_INIT: PyTypeObject = type_object_init! {
+        tp_allocs: 0,
+        tp_frees: 0,
+        tp_maxalloc: 0,
+        tp_prev: ptr::null_mut(),
+        tp_next: ptr::null_mut(),
+    };
+
+    #[cfg(not(py_sys_config = "COUNT_ALLOCS"))]
+    #[deprecated(note = "not present in Python headers; to be removed")]
+    pub const PyTypeObject_INIT: PyTypeObject = type_object_init!();
+
+    #[repr(C)]
+    #[derive(Clone)]
+    pub struct PyHeapTypeObject {
+        pub ht_type: PyTypeObject,
+        pub as_async: PyAsyncMethods,
+        pub as_number: PyNumberMethods,
+        pub as_mapping: PyMappingMethods,
+        pub as_sequence: PySequenceMethods,
+        pub as_buffer: PyBufferProcs,
+        pub ht_name: *mut object::PyObject,
+        pub ht_slots: *mut object::PyObject,
+        pub ht_qualname: *mut object::PyObject,
+        pub ht_cached_keys: *mut c_void,
+    }
+
+    impl Default for PyHeapTypeObject {
+        #[inline]
+        fn default() -> Self {
+            unsafe { mem::zeroed() }
+        }
+    }
+
+    #[inline]
+    pub unsafe fn PyHeapType_GET_MEMBERS(
+        etype: *mut PyHeapTypeObject,
+    ) -> *mut ffi::structmember::PyMemberDef {
+        let py_type = object::Py_TYPE(etype as *mut object::PyObject);
+        let ptr = etype.offset((*py_type).tp_basicsize);
+        ptr as *mut ffi::structmember::PyMemberDef
+    }
+}
+
+// The exported types depend on whether Py_LIMITED_API is set
+pub use self::typeobject::*;
+
+// skipped _PyType_Name
+// skipped _PyType_Lookup
+// skipped _PyType_LookupId
+// skipped _PyObject_LookupSpecial
+// skipped _PyType_CalculateMetaclass
+// skipped _PyType_GetDocFromInternalDoc
+// skipped _PyType_GetTextSignatureFromInternalDoc
+// skipped _PyType_GetModuleByDef
+
+extern "C" {
+    #[cfg_attr(PyPy, link_name = "PyPyObject_Print")]
+    pub fn PyObject_Print(o: *mut PyObject, fp: *mut ::libc::FILE, flags: c_int) -> c_int;
+
+    // skipped _Py_BreakPoint
+    // skipped _PyObject_Dump
+    // skipped _PyObject_IsFreed
+    // skipped _PyObject_IsAbstract
+    // skipped _PyObject_GetAttrId
+    // skipped _PyObject_SetAttrId
+    // skipped _PyObject_LookupAttr
+    // skipped _PyObject_LookupAttrId
+    // skipped _PyObject_GetMethod
+
+    #[cfg(not(PyPy))]
+    pub fn _PyObject_GetDictPtr(obj: *mut PyObject) -> *mut *mut PyObject;
+    #[cfg(not(PyPy))]
+    pub fn _PyObject_NextNotImplemented(arg1: *mut PyObject) -> *mut PyObject;
+    pub fn PyObject_CallFinalizer(arg1: *mut PyObject);
+    #[cfg_attr(PyPy, link_name = "PyPyObject_CallFinalizerFromDealloc")]
+    pub fn PyObject_CallFinalizerFromDealloc(arg1: *mut PyObject) -> c_int;
+
+    // skipped _PyObject_GenericGetAttrWithDict
+    // skipped _PyObject_GenericSetAttrWithDict
+    // skipped _PyObject_FunctionStr
+}
+
+// skipped Py_SETREF
+// skipped Py_XSETREF
+
+// skipped _PyNone_Type
+// skipped _PyNotImplemented_Type
+
+// skipped _Py_SwappedOp
+
+// skipped _PyDebugAllocatorStats
+// skipped _PyObject_DebugTypeStats
+// skipped _PyObject_ASSERT_FROM
+// skipped _PyObject_ASSERT_WITH_MSG
+// skipped _PyObject_ASSERT
+// skipped _PyObject_ASSERT_FAILED_MSG
+// skipped _PyObject_AssertFailed
+// skipped _PyObject_CheckConsistency
+
+// skipped _PyTrash_thread_deposit_object
+// skipped _PyTrash_thread_destroy_chain
+// skipped _PyTrash_begin
+// skipped _PyTrash_end
+// skipped _PyTrash_cond
+// skipped PyTrash_UNWIND_LEVEL
+// skipped Py_TRASHCAN_BEGIN_CONDITION
+// skipped Py_TRASHCAN_END
+// skipped Py_TRASHCAN_BEGIN
+// skipped Py_TRASHCAN_SAFE_BEGIN
+// skipped Py_TRASHCAN_SAFE_END

--- a/src/ffi/cpython/object.rs
+++ b/src/ffi/cpython/object.rs
@@ -216,7 +216,7 @@ mod typeobject {
         pub tp_itemsize: Py_ssize_t,
         pub tp_dealloc: Option<object::destructor>,
         #[cfg(not(Py_3_8))]
-        pub tp_print: Option<object::printfunc>,
+        pub tp_print: Option<printfunc>,
         #[cfg(Py_3_8)]
         pub tp_vectorcall_offset: Py_ssize_t,
         pub tp_getattr: Option<object::getattrfunc>,

--- a/src/ffi/cpython/object.rs
+++ b/src/ffi/cpython/object.rs
@@ -106,7 +106,6 @@ mod typeobject {
     use crate::ffi::{PyObject, Py_ssize_t};
     use std::mem;
     use std::os::raw::{c_char, c_int, c_uint, c_ulong, c_void};
-    use std::ptr;
 
     #[repr(C)]
     #[derive(Copy, Clone)]
@@ -147,12 +146,6 @@ mod typeobject {
         pub nb_index: Option<object::unaryfunc>,
         pub nb_matrix_multiply: Option<object::binaryfunc>,
         pub nb_inplace_matrix_multiply: Option<object::binaryfunc>,
-    }
-
-    macro_rules! as_expr {
-        ($e:expr) => {
-            $e
-        };
     }
 
     #[repr(C)]
@@ -276,111 +269,6 @@ mod typeobject {
         #[cfg(py_sys_config = "COUNT_ALLOCS")]
         pub tp_next: *mut PyTypeObject,
     }
-
-    macro_rules! _type_object_init {
-        ({$($head:tt)*}, $($tail:tt)*) => {
-            as_expr! {
-                PyTypeObject {
-                    $($head)*
-                    tp_name: ptr::null(),
-                    tp_basicsize: 0,
-                    tp_itemsize: 0,
-                    tp_dealloc: None,
-                    #[cfg(not(Py_3_8))]
-                    tp_print: None,
-                    #[cfg(Py_3_8)]
-                    tp_vectorcall_offset: 0,
-                    tp_getattr: None,
-                    tp_setattr: None,
-                    tp_as_async: ptr::null_mut(),
-                    tp_repr: None,
-                    tp_as_number: ptr::null_mut(),
-                    tp_as_sequence: ptr::null_mut(),
-                    tp_as_mapping: ptr::null_mut(),
-                    tp_hash: None,
-                    tp_call: None,
-                    tp_str: None,
-                    tp_getattro: None,
-                    tp_setattro: None,
-                    tp_as_buffer: ptr::null_mut(),
-                    tp_flags: object::Py_TPFLAGS_DEFAULT,
-                    tp_doc: ptr::null(),
-                    tp_traverse: None,
-                    tp_clear: None,
-                    tp_richcompare: None,
-                    tp_weaklistoffset: 0,
-                    tp_iter: None,
-                    tp_iternext: None,
-                    tp_methods: ptr::null_mut(),
-                    tp_members: ptr::null_mut(),
-                    tp_getset: ptr::null_mut(),
-                    tp_base: ptr::null_mut(),
-                    tp_dict: ptr::null_mut(),
-                    tp_descr_get: None,
-                    tp_descr_set: None,
-                    tp_dictoffset: 0,
-                    tp_init: None,
-                    tp_alloc: None,
-                    tp_new: None,
-                    tp_free: None,
-                    tp_is_gc: None,
-                    tp_bases: ptr::null_mut(),
-                    tp_mro: ptr::null_mut(),
-                    tp_cache: ptr::null_mut(),
-                    tp_subclasses: ptr::null_mut(),
-                    tp_weaklist: ptr::null_mut(),
-                    tp_del: None,
-                    tp_version_tag: 0,
-                    tp_finalize: None,
-                    #[cfg(Py_3_8)]
-                    tp_vectorcall: None,
-                    $($tail)*
-                }
-            }
-        }
-    }
-
-    #[cfg(PyPy)]
-    macro_rules! type_object_init {
-        ($($tail:tt)*) => {
-            _type_object_init!({
-                    ob_refcnt: 1,
-                    ob_pypy_link: 0,
-                    ob_type: ptr::null_mut(),
-                    ob_size: 0,
-                },
-                tp_pypy_flags: 0,
-                $($tail)*
-            )
-        }
-    }
-
-    #[cfg(not(PyPy))]
-    macro_rules! type_object_init {
-        ($($tail:tt)*) => {
-            _type_object_init!({
-                ob_base: object::PyVarObject {
-                    ob_base: object::PyObject_HEAD_INIT,
-                    ob_size: 0
-                },},
-                $($tail)*
-            )
-        }
-    }
-
-    #[cfg(py_sys_config = "COUNT_ALLOCS")]
-    #[deprecated(note = "not present in Python headers; to be removed")]
-    pub const PyTypeObject_INIT: PyTypeObject = type_object_init! {
-        tp_allocs: 0,
-        tp_frees: 0,
-        tp_maxalloc: 0,
-        tp_prev: ptr::null_mut(),
-        tp_next: ptr::null_mut(),
-    };
-
-    #[cfg(not(py_sys_config = "COUNT_ALLOCS"))]
-    #[deprecated(note = "not present in Python headers; to be removed")]
-    pub const PyTypeObject_INIT: PyTypeObject = type_object_init!();
 
     #[repr(C)]
     #[derive(Clone)]

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -132,6 +132,7 @@ mod modsupport; // TODO: incomplete
 mod moduleobject; // TODO: incomplete
 
 // skipped namespaceobject.h
+mod object;
 // skipped odictobject.h
 // skipped opcode.h
 // skipped osdefs.h
@@ -166,7 +167,6 @@ mod pyport;
 
 #[cfg(all(Py_3_8, not(any(PY_LIMITED_API, PyPy))))]
 mod initconfig;
-mod object;
 mod objimpl;
 mod pydebug;
 mod pyhash;

--- a/src/ffi/object.rs
+++ b/src/ffi/object.rs
@@ -526,16 +526,16 @@ pub unsafe fn PyType_CheckExact(op: *mut PyObject) -> c_int {
 }
 
 #[inline]
-// #[deprecated(note = "not present in Python headers; to be removed")]
+#[deprecated(note = "not present in Python headers; to be removed")]
 pub fn PyObject_Check(_arg1: *mut PyObject) -> c_int {
     1
 }
 
 #[inline]
-// #[deprecated(note = "not present in Python headers; to be removed")]
+#[deprecated(note = "not present in Python headers; to be removed")]
 pub fn PySuper_Check(_arg1: *mut PyObject) -> c_int {
     0
 }
 
-// #[deprecated(note = "not present in Python headers; to be removed")]
+#[deprecated(note = "not present in Python headers; to be removed")]
 pub type FreeFunc = extern "C" fn(*mut c_void) -> c_void;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -48,12 +48,19 @@ impl crate::AsPyPointer for PyAny {
 unsafe impl crate::type_object::PyLayout<PyAny> for ffi::PyObject {}
 impl crate::type_object::PySizedLayout<PyAny> for ffi::PyObject {}
 
+#[allow(non_snake_case)]
+// Copied here as the macro does not accept deprecated functions.
+// Originally ffi::object::PyObject_Check, but this is not in the Python C API.
+fn PyObject_Check(_: *mut ffi::PyObject) -> c_int {
+    1
+}
+
 pyobject_native_type_info!(
     PyAny,
     ffi::PyObject,
     ffi::PyBaseObject_Type,
     Some("builtins"),
-    ffi::PyObject_Check
+    PyObject_Check
 );
 
 pyobject_native_type_extract!(PyAny);


### PR DESCRIPTION
This one's a fairly big change to account for the new `cpython/object.h` file.

Deprecate some FFI definitions which are not in the API
- PyObject_Check
- PySuper_Check
- FreeFunc (note: there's also a `freefunc` which is subtly different -- fixed `_PyEval_RequestCodeExtraIndex`, which takes a `freefunc` as an argument)

I thought the INCREF, DECREF, ... methods were a bit off. ~~See review (soon).~~ EDIT: ~~will open new issue~~ this is fine