### PR TITLE
Update paste to 1.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ libc = "0.2.62"
 parking_lot = "0.11.0"
 num-bigint = { version = "0.3", optional = true }
 num-complex = { version = "0.3", optional = true }
-# must stay at 0.1.x for Rust 1.41 compatibility
-paste = { version = "0.1.18", optional = true }
+paste = { version = "1.0.4", optional = true }
 pyo3-macros = { path = "pyo3-macros", version = "=0.13.2", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = "0.9", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub mod proc_macro {
 #[macro_export]
 macro_rules! wrap_pyfunction {
     ($function_name: ident) => {{
-        &pyo3::paste::expr! { [<__pyo3_get_function_ $function_name>] }
+        &pyo3::paste::paste! { [<__pyo3_get_function_ $function_name>] }
     }};
 
     ($function_name: ident, $arg: expr) => {
@@ -258,7 +258,7 @@ macro_rules! wrap_pyfunction {
 #[macro_export]
 macro_rules! raw_pycfunction {
     ($function_name: ident) => {{
-        pyo3::paste::expr! { [<__pyo3_raw_ $function_name>] }
+        pyo3::paste::paste! { [<__pyo3_raw_ $function_name>] }
     }};
 }
 
@@ -268,7 +268,7 @@ macro_rules! raw_pycfunction {
 #[macro_export]
 macro_rules! wrap_pymodule {
     ($module_name:ident) => {{
-        pyo3::paste::expr! {
+        pyo3::paste::paste! {
             &|py| unsafe { pyo3::PyObject::from_owned_ptr(py, [<PyInit_ $module_name>]()) }
         }
     }};

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -38,7 +38,7 @@ macro_rules! assert_check_exact {
         unsafe {
             use pyo3::{AsPyPointer, ffi::*};
             assert!($check_func(($obj).as_ptr()) != 0);
-            assert!(pyo3::paste::expr!([<$check_func Exact>])(($obj).as_ptr()) != 0);
+            assert!(pyo3::paste::paste!([<$check_func Exact>])(($obj).as_ptr()) != 0);
         }
     };
 }
@@ -48,7 +48,7 @@ macro_rules! assert_check_only {
         unsafe {
             use pyo3::{AsPyPointer, ffi::*};
             assert!($check_func(($obj).as_ptr()) != 0);
-            assert!(pyo3::paste::expr!([<$check_func Exact>])(($obj).as_ptr()) == 0);
+            assert!(pyo3::paste::paste!([<$check_func Exact>])(($obj).as_ptr()) == 0);
         }
     };
 }


### PR DESCRIPTION
Updates paste to 1.x release. Paste has an MSRV of 1.31 (see [paste's readme](https://github.com/dtolnay/paste)), so it is unnecessary to stay on the 0.1.x release.