### PR TITLE
ffi cleanup: abstract.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PYO3_CROSS_LIB_DIR` enviroment variable no long required when compiling for x86-64 Python from macOS arm64 and reverse. [#1428](https://github.com/PyO3/pyo3/pull/1428)
 - Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 - Fix FFI definition `PyIter_Check` missing for Python 3.7 and earlier with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
+- Fix FFI definition `PyIndex_Check` missing with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - `PYO3_CROSS_LIB_DIR` enviroment variable no long required when compiling for x86-64 Python from macOS arm64 and reverse. [#1428](https://github.com/PyO3/pyo3/pull/1428)
 - Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)
+- Ensure `PyIter_Check` is available for Python < 3.8 under abi3. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add #[pyo3(from_py_with = "...")]` attribute for function arguments and struct fields to override the default from-Python conversion. [#1411](https://github.com/PyO3/pyo3/pull/1411)
 - Add FFI definition `PyCFunction_CheckExact` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - Add FFI definition `Py_IS_TYPE`. [#1429](https://github.com/PyO3/pyo3/pull/1429)
-- Implement `PyTryFrom` for `PyIterator` for Python 3.7 and earlier with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 
 ### Changed
 - Change `PyTimeAcces::get_fold()` to return a `bool` instead of a `u8`. [#1397](https://github.com/PyO3/pyo3/pull/1397)
@@ -31,7 +30,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - `PYO3_CROSS_LIB_DIR` enviroment variable no long required when compiling for x86-64 Python from macOS arm64 and reverse. [#1428](https://github.com/PyO3/pyo3/pull/1428)
 - Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)
-- Fix FFI definition `PyIter_Check` missing for Python 3.7 and earlier with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 - Fix FFI definition `PyIndex_Check` missing with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 
 ## [0.13.2] - 2021-02-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add #[pyo3(from_py_with = "...")]` attribute for function arguments and struct fields to override the default from-Python conversion. [#1411](https://github.com/PyO3/pyo3/pull/1411)
 - Add FFI definition `PyCFunction_CheckExact` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - Add FFI definition `Py_IS_TYPE`. [#1429](https://github.com/PyO3/pyo3/pull/1429)
+- Implement `PyTryFrom` for `PyIterator` for Python 3.7 and earlier with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 
 ### Changed
 - Change `PyTimeAcces::get_fold()` to return a `bool` instead of a `u8`. [#1397](https://github.com/PyO3/pyo3/pull/1397)
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - `PYO3_CROSS_LIB_DIR` enviroment variable no long required when compiling for x86-64 Python from macOS arm64 and reverse. [#1428](https://github.com/PyO3/pyo3/pull/1428)
 - Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)
-- Ensure `PyIter_Check` is available for Python < 3.8 under abi3. [#1436](https://github.com/PyO3/pyo3/pull/1436)
+- Fix FFI definition `PyIter_Check` missing for Python 3.7 and earlier with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/src/ffi/abstract_.rs
+++ b/src/ffi/abstract_.rs
@@ -89,7 +89,10 @@ extern "C" {
     pub fn PyObject_GetIter(arg1: *mut PyObject) -> *mut PyObject;
 }
 
-#[cfg(not(any(all(Py_3_8, Py_LIMITED_API), PyPy)))]
+// Defined as this macro in Python 3.6, 3.7 limited API, but relies on
+// non-limited PyTypeObject. Don't expose this since it cannot be used.
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+#[inline]
 pub unsafe fn PyIter_Check(o: *mut PyObject) -> c_int {
     (match (*crate::ffi::Py_TYPE(o)).tp_iternext {
         Some(tp_iternext) => {
@@ -150,7 +153,9 @@ extern "C" {
     pub fn PyNumber_Or(o1: *mut PyObject, o2: *mut PyObject) -> *mut PyObject;
 }
 
-#[cfg(not(any(all(Py_3_8, Py_LIMITED_API), PyPy)))]
+// Defined as this macro in Python 3.6, 3.7 limited API, but relies on
+// non-limited PyTypeObject. Don't expose this since it cannot be used.
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
 #[inline]
 pub unsafe fn PyIndex_Check(o: *mut PyObject) -> c_int {
     let tp_as_number = (*Py_TYPE(o)).tp_as_number;

--- a/src/ffi/cpython/abstract_.rs
+++ b/src/ffi/cpython/abstract_.rs
@@ -266,16 +266,11 @@ extern "C" {
     pub fn PyBuffer_Release(view: *mut Py_buffer);
 }
 
-#[inline]
-#[cfg(not(any(all(Py_3_8, Py_LIMITED_API), PyPy)))]
-pub unsafe fn PyIter_Check(o: *mut PyObject) -> c_int {
-    (match (*crate::ffi::Py_TYPE(o)).tp_iternext {
-        Some(tp_iternext) => {
-            tp_iternext as *const c_void != crate::ffi::_PyObject_NextNotImplemented as _
-        }
-        None => false,
-    }) as c_int
-}
+// PyIter_Check defined in ffi/abstract_.rs
+// PyIndex_Check defined in ffi/abstract_.rs
+// Not defined here because this file is not compiled under the
+// limited API, but the macros need to be defined for 3.6, 3.7 which
+// predate the limited API changes.
 
 // skipped PySequence_ITEM
 

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -12,6 +12,7 @@ macro_rules! opaque_struct {
     };
 }
 
+pub use self::abstract_::*;
 pub use self::bltinmodule::*;
 pub use self::boolobject::*;
 pub use self::bytearrayobject::*;
@@ -47,7 +48,6 @@ pub use self::methodobject::*;
 pub use self::modsupport::*;
 pub use self::moduleobject::*;
 pub use self::object::*;
-pub use self::objectabstract::*; // FIXME: no matching objectabstract.h in cpython master
 pub use self::objimpl::*;
 pub use self::osmodule::*;
 pub use self::pyarena::*;
@@ -76,8 +76,7 @@ pub use self::weakrefobject::*;
 
 #[cfg(not(Py_LIMITED_API))]
 pub use self::cpython::*;
-
-// skipped abstract.h
+mod abstract_;
 // skipped asdl.h
 // skipped ast.h
 mod bltinmodule;
@@ -200,8 +199,6 @@ mod pythonrun; // TODO some functions need to be moved to pylifecycle
 mod osmodule;
 mod sysmodule; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 
-mod objectabstract; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
-
 // mod pyctype; TODO excluded by PEP-384
 mod pystrtod; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
               // mod pystrcmp; TODO nothing interesting for Rust?
@@ -212,5 +209,5 @@ mod pystrtod; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and
 // Additional headers that are not exported by Python.h
 pub mod structmember; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(all(Py_3_8, not(Py_LIMITED_API)))]
 mod cpython;

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -209,5 +209,5 @@ mod pystrtod; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and
 // Additional headers that are not exported by Python.h
 pub mod structmember; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 
-#[cfg(all(Py_3_8, not(Py_LIMITED_API)))]
+#[cfg(not(Py_LIMITED_API))]
 mod cpython;

--- a/src/ffi/pyerrors.rs
+++ b/src/ffi/pyerrors.rs
@@ -1,9 +1,5 @@
 use crate::ffi::object::*;
-#[cfg(PyPy)]
-use crate::ffi::objectabstract::PyObject_CallFunction;
 use crate::ffi::pyport::Py_ssize_t;
-#[cfg(PyPy)]
-use std::ffi::CStr;
 use std::os::raw::{c_char, c_int};
 
 #[repr(C)]
@@ -162,9 +158,11 @@ pub unsafe fn PyUnicodeDecodeError_Create(
     end: Py_ssize_t,
     _reason: *const c_char,
 ) -> *mut PyObject {
-    return PyObject_CallFunction(
+    return crate::ffi::PyObject_CallFunction(
         PyExc_UnicodeDecodeError,
-        CStr::from_bytes_with_nul(b"sy#nns\0").unwrap().as_ptr(),
+        std::ffi::CStr::from_bytes_with_nul(b"sy#nns\0")
+            .unwrap()
+            .as_ptr(),
         encoding,
         object,
         length,

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -67,6 +67,8 @@ impl<'p> Iterator for &'p PyIterator {
     }
 }
 
+// PyIter_Check does not exist in the limited API until 3.8
+#[cfg(any(not(Py_LIMITED_API), Py_3_8))]
 impl<'v> PyTryFrom<'v> for PyIterator {
     fn try_from<V: Into<&'v PyAny>>(value: V) -> Result<&'v PyIterator, PyDowncastError<'v>> {
         let value = value.into();

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -67,8 +67,6 @@ impl<'p> Iterator for &'p PyIterator {
     }
 }
 
-// PyIter_Check does not exist in the limited API until 3.8
-#[cfg(any(not(Py_LIMITED_API), Py_3_8))]
 impl<'v> PyTryFrom<'v> for PyIterator {
     fn try_from<V: Into<&'v PyAny>>(value: V) -> Result<&'v PyIterator, PyDowncastError<'v>> {
         let value = value.into();


### PR DESCRIPTION
* This PR makes PyIter_Check available to Python earlier than 3.8 under the limited API.
This was due to some interaction between the `cfg(not(Py_LIMITED_API)` on `ffi::cpython`, and the cfg on PyIter_Check within the `ffi::cpython` module.
However, it's always been in the limited API: as a macro before 3.8, and as a function since 3.8. Under the non-limited API it's always a macro.

* Consequently we can implement PyTryFrom for PyIterator for all versions. I've (speculatively) commented out the cfg preventing that.

* Similar changes for PyIndex_Check.