### PR TITLE
pyfunction: refactor argument extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 - Fix FFI definition `PyIndex_Check` missing with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 - Fix incorrect `TypeError` raised when keyword-only argument passed along with a positional argument in `*args`. [#1440](https://github.com/PyO3/pyo3/pull/1440)
+- Fix inability to use a named lifetime for `&PyTuple` of `*args` in `#[pyfunction]`. [#1440](https://github.com/PyO3/pyo3/pull/1440)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PYO3_CROSS_LIB_DIR` enviroment variable no long required when compiling for x86-64 Python from macOS arm64 and reverse. [#1428](https://github.com/PyO3/pyo3/pull/1428)
 - Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 - Fix FFI definition `PyIndex_Check` missing with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
+- Fix incorrect `TypeError` raised when keyword-only argument passed along with a positional argument in `*args`. [#1440](https://github.com/PyO3/pyo3/pull/1440)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/examples/pyo3_benchmarks/Cargo.toml
+++ b/examples/pyo3_benchmarks/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors = ["PyO3 Authors"]
+name = "pyo3-benchmarks"
+version = "0.1.0"
+description = "Python-based benchmarks for various PyO3 functionality"
+edition = "2018"
+
+[dependencies]
+
+[dependencies.pyo3]
+path = "../../"
+features = ["extension-module"]
+
+[lib]
+name = "_pyo3_benchmarks"
+crate-type = ["cdylib"]

--- a/examples/pyo3_benchmarks/MANIFEST.in
+++ b/examples/pyo3_benchmarks/MANIFEST.in
@@ -1,0 +1,2 @@
+include pyproject.toml Cargo.toml
+recursive-include src *

--- a/examples/pyo3_benchmarks/README.md
+++ b/examples/pyo3_benchmarks/README.md
@@ -1,0 +1,17 @@
+# rustapi_module
+
+A simple extension module built using PyO3.
+
+## Build
+
+```shell
+python setup.py install
+```
+
+## Testing
+
+To test install tox globally and run
+
+```shell
+tox -e py
+```

--- a/examples/pyo3_benchmarks/pyo3_benchmarks/__init__.py
+++ b/examples/pyo3_benchmarks/pyo3_benchmarks/__init__.py
@@ -1,0 +1,1 @@
+from ._pyo3_benchmarks import *

--- a/examples/pyo3_benchmarks/requirements-dev.txt
+++ b/examples/pyo3_benchmarks/requirements-dev.txt
@@ -1,0 +1,6 @@
+pip>=19.1
+hypothesis>=3.55
+pytest>=3.5.0
+setuptools-rust>=0.10.2
+psutil>=5.6
+pytest-benchmark~=3.2

--- a/examples/pyo3_benchmarks/setup.py
+++ b/examples/pyo3_benchmarks/setup.py
@@ -1,0 +1,44 @@
+import sys
+import platform
+
+from setuptools import setup
+from setuptools_rust import RustExtension
+
+
+def get_py_version_cfgs():
+    # For now each Cfg Py_3_X flag is interpreted as "at least 3.X"
+    version = sys.version_info[0:2]
+    py3_min = 6
+    out_cfg = []
+    for minor in range(py3_min, version[1] + 1):
+        out_cfg.append("--cfg=Py_3_%d" % minor)
+
+    if platform.python_implementation() == "PyPy":
+        out_cfg.append("--cfg=PyPy")
+
+    return out_cfg
+
+
+setup(
+    name="pyo3-benchmarks",
+    version="0.1.0",
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python",
+        "Programming Language :: Rust",
+        "Operating System :: POSIX",
+        "Operating System :: MacOS :: MacOS X",
+    ],
+    packages=["pyo3_benchmarks"],
+    rust_extensions=[
+        RustExtension(
+            "pyo3_benchmarks._pyo3_benchmarks",
+            rustc_flags=get_py_version_cfgs(),
+            debug=False,
+        ),
+    ],
+    include_package_data=True,
+    zip_safe=False,
+)

--- a/examples/pyo3_benchmarks/src/lib.rs
+++ b/examples/pyo3_benchmarks/src/lib.rs
@@ -1,0 +1,33 @@
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
+use pyo3::wrap_pyfunction;
+
+#[pyfunction(args = "*", kwargs = "**")]
+fn args_and_kwargs<'a>(
+    args: &'a PyTuple,
+    kwargs: Option<&'a PyDict>,
+) -> (&'a PyTuple, Option<&'a PyDict>) {
+    (args, kwargs)
+}
+
+#[pyfunction(a, b = 2, args = "*", c = 4, kwargs = "**")]
+fn mixed_args<'a>(
+    a: i32,
+    b: i32,
+    args: &'a PyTuple,
+    c: i32,
+    kwargs: Option<&'a PyDict>,
+) -> (i32, i32, &'a PyTuple, i32, Option<&'a PyDict>) {
+    (a, b, args, c, kwargs)
+}
+
+#[pyfunction]
+fn no_args() {}
+
+#[pymodule]
+fn _pyo3_benchmarks(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(args_and_kwargs, m)?)?;
+    m.add_function(wrap_pyfunction!(mixed_args, m)?)?;
+    m.add_function(wrap_pyfunction!(no_args, m)?)?;
+    Ok(())
+}

--- a/examples/pyo3_benchmarks/tests/test_benchmarks.py
+++ b/examples/pyo3_benchmarks/tests/test_benchmarks.py
@@ -1,0 +1,46 @@
+import pyo3_benchmarks
+
+
+def test_args_and_kwargs(benchmark):
+    benchmark(pyo3_benchmarks.args_and_kwargs, 1, 2, 3, a=4, foo=10)
+
+
+def args_and_kwargs_py(*args, **kwargs):
+    return (args, kwargs)
+
+
+def test_args_and_kwargs_py(benchmark):
+    rust = pyo3_benchmarks.args_and_kwargs(1, 2, 3, bar=4, foo=10)
+    py = args_and_kwargs_py(1, 2, 3, bar=4, foo=10)
+    assert rust == py
+    benchmark(args_and_kwargs_py, 1, 2, 3, bar=4, foo=10)
+
+
+def test_mixed_args(benchmark):
+    benchmark(pyo3_benchmarks.mixed_args, 1, 2, 3, bar=4, foo=10)
+
+
+def mixed_args_py(a, b=2, *args, c=4, **kwargs):
+    return (a, b, args, c, kwargs)
+
+
+def test_mixed_args_py(benchmark):
+    rust = pyo3_benchmarks.mixed_args(1, 2, 3, bar=4, foo=10)
+    py = mixed_args_py(1, 2, 3, bar=4, foo=10)
+    assert rust == py
+    benchmark(mixed_args_py, 1, 2, 3, bar=4, foo=10)
+
+
+def test_no_args(benchmark):
+    benchmark(pyo3_benchmarks.no_args)
+
+
+def no_args_py():
+    return None
+
+
+def test_no_args_py(benchmark):
+    rust = pyo3_benchmarks.no_args()
+    py = no_args_py()
+    assert rust == py
+    benchmark(no_args_py)

--- a/examples/pyo3_benchmarks/tox.ini
+++ b/examples/pyo3_benchmarks/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+# can't install from sdist because local pyo3 repo can't be included in the sdist
+skipsdist = true
+
+[testenv]
+description = Run the unit tests under {basepython}
+deps = -rrequirements-dev.txt
+commands =
+    python setup.py install
+    pytest {posargs}

--- a/examples/rustapi_module/tests/test_datetime.py
+++ b/examples/rustapi_module/tests/test_datetime.py
@@ -143,12 +143,11 @@ def test_time_fold(fold):
     assert t.fold == fold
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "args", [(-1, 0, 0, 0), (0, -1, 0, 0), (0, 0, -1, 0), (0, 0, 0, -1)]
 )
-def test_invalid_time_fails_xfail(args):
-    with pytest.raises(ValueError):
+def test_invalid_time_fails_overflow(args):
+    with pytest.raises(OverflowError):
         rdt.make_time(*args)
 
 

--- a/pyo3-macros-backend/src/pyproto.rs
+++ b/pyo3-macros-backend/src/pyproto.rs
@@ -65,7 +65,7 @@ fn impl_proto_impl(
                 let fn_spec = FnSpec::parse(&mut met.sig, &mut met.attrs, false)?;
 
                 let method = if let FnType::Fn(self_ty) = &fn_spec.tp {
-                    pymethod::impl_proto_wrap(ty, &fn_spec, &self_ty)
+                    pymethod::impl_proto_wrap(ty, &fn_spec, &self_ty)?
                 } else {
                     bail_spanned!(
                         met.sig.span() => "expected method with receiver for #[pyproto] method"

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -49,7 +49,6 @@ impl InstanceMethodWithArgs {
 }
 
 #[test]
-#[allow(dead_code)]
 fn instance_method_with_args() {
     let gil = Python::acquire_gil();
     let py = gil.python();

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -245,6 +245,11 @@ impl MethArgs {
         a + b
     }
 
+    #[args(args = "*", a)]
+    fn get_args_and_required_keyword(&self, py: Python, args: &PyTuple, a: i32) -> PyObject {
+        (args, a).to_object(py)
+    }
+
     #[args(a, b = 2, "*", c = 3)]
     fn get_pos_arg_kw_sep1(&self, a: i32, b: i32, c: i32) -> i32 {
         a + b + c
@@ -362,6 +367,23 @@ fn meth_args() {
         py,
         inst,
         "inst.get_kwargs_only_with_some_default()",
+        PyTypeError
+    );
+
+    py_run!(
+        py,
+        inst,
+        "assert inst.get_args_and_required_keyword(1, 2, a=3) == ((1, 2), 3)"
+    );
+    py_run!(
+        py,
+        inst,
+        "assert inst.get_args_and_required_keyword(a=1) == ((), 1)"
+    );
+    py_expect_exception!(
+        py,
+        inst,
+        "inst.get_args_and_required_keyword()",
         PyTypeError
     );
 


### PR DESCRIPTION
This PR fixes a bug in `#[pyfunction]` where a keyword-only argument is incorrectly rejected when used in combination with `*args`:

This is an example of the problem code:

```
#[pyfunction(args = "*", param)]
fn my_func(
    args: &PyTuple,
    param: bool,
) -> PyResult<(&PyTuple, bool)> {
    Ok((args, param))
}
```

And this is the call which didn't work:
```
>>> my_func(1, param=True)
TypeError: my_func() got multiple values for argument: param
```

At the same time I also changed error messages from `argument: foo` to `argument 'foo'`, so that they match what CPython errors look like.