### PR TITLE
pyproto: don't use inventory for methods

### DIFF
--- a/benches/bench_pyclass.rs
+++ b/benches/bench_pyclass.rs
@@ -31,6 +31,10 @@ impl PyObjectProtocol for MyClass {
     fn __str__(&self) -> &'static str {
         "MyClass"
     }
+
+    fn __bytes__(&self) -> &'static [u8] {
+        b"MyClass"
+    }
 }
 
 #[bench]

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -210,7 +210,7 @@ pub fn add_fn_to_module(
             pyo3::types::PyCFunction::internal_new(
                 name,
                 doc,
-                pyo3::class::PyMethodType::PyCFunctionWithKeywords(#wrapper_ident),
+                unsafe { std::mem::transmute(#wrapper_ident as *const std::os::raw::c_void) },
                 pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS,
                 args.into(),
             )

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -427,9 +427,17 @@ fn impl_class(
             type ThreadChecker = #thread_checker;
 
             fn for_each_method_def(visitor: impl FnMut(&pyo3::class::PyMethodDefType)) {
+                use pyo3::class::impl_::*;
+                let collector = PyClassImplCollector::<#cls>::new();
                 pyo3::inventory::iter::<<#cls as pyo3::class::methods::HasMethodsInventory>::Methods>
                     .into_iter()
                     .flat_map(pyo3::class::methods::PyMethodsInventory::get)
+                    .chain(collector.object_protocol_methods())
+                    .chain(collector.async_protocol_methods())
+                    .chain(collector.context_protocol_methods())
+                    .chain(collector.descr_protocol_methods())
+                    .chain(collector.mapping_protocol_methods())
+                    .chain(collector.number_protocol_methods())
                     .for_each(visitor)
             }
             fn get_new() -> Option<pyo3::ffi::newfunc> {

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -593,7 +593,7 @@ pub fn impl_py_method_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
 
                 pyo3::class::PyMethodDef::cfunction(
                     concat!(stringify!(#python_name), "\0"),
-                    __wrap,
+                    pyo3::class::methods::PyCFunction(__wrap),
                     #doc
                 )
             })
@@ -605,7 +605,7 @@ pub fn impl_py_method_def(spec: &FnSpec, wrapper: &TokenStream) -> TokenStream {
 
                 pyo3::class::PyMethodDef::cfunction_with_keywords(
                     concat!(stringify!(#python_name), "\0"),
-                    __wrap,
+                    pyo3::class::methods::PyCFunctionWithKeywords(__wrap),
                     0,
                     #doc
                 )
@@ -635,7 +635,7 @@ pub fn impl_py_method_def_class(spec: &FnSpec, wrapper: &TokenStream) -> TokenSt
 
             pyo3::class::PyMethodDef::cfunction_with_keywords(
                 concat!(stringify!(#python_name), "\0"),
-                __wrap,
+                pyo3::class::methods::PyCFunctionWithKeywords(__wrap),
                 pyo3::ffi::METH_CLASS,
                 #doc
             )
@@ -652,7 +652,7 @@ pub fn impl_py_method_def_static(spec: &FnSpec, wrapper: &TokenStream) -> TokenS
 
             pyo3::class::PyMethodDef::cfunction_with_keywords(
                 concat!(stringify!(#python_name), "\0"),
-                __wrap,
+                pyo3::class::methods::PyCFunctionWithKeywords(__wrap),
                 pyo3::ffi::METH_STATIC,
                 #doc
             )

--- a/pyo3-macros-backend/src/pyproto.rs
+++ b/pyo3-macros-backend/src/pyproto.rs
@@ -81,20 +81,20 @@ fn impl_proto_impl(
                 let name = &met.sig.ident;
                 // TODO(kngwyu): Set ml_doc
                 py_methods.push(quote! {
-                    pyo3::class::PyMethodDefType::Method({
-                        #method
-                        pyo3::class::PyMethodDef::cfunction_with_keywords(
-                            concat!(stringify!(#name), "\0"),
-                            __wrap,
-                            #coexist,
-                            "\0"
-                        )
-                    })
+                    pyo3::class::PyMethodDef::cfunction_with_keywords(
+                        concat!(stringify!(#name), "\0"),
+                        {
+                            #method
+                            pyo3::class::methods::PyCFunctionWithKeywords(__wrap)
+                        },
+                        #coexist,
+                        "\0"
+                    )
                 });
             }
         }
     }
-    let normal_methods = submit_normal_methods(py_methods, ty);
+    let normal_methods = impl_normal_methods(py_methods, ty, proto);
     let protocol_methods = impl_proto_methods(method_names, ty, proto);
     Ok(quote! {
         #trait_impls
@@ -103,15 +103,25 @@ fn impl_proto_impl(
     })
 }
 
-fn submit_normal_methods(py_methods: Vec<TokenStream>, ty: &syn::Type) -> TokenStream {
+fn impl_normal_methods(
+    py_methods: Vec<TokenStream>,
+    ty: &syn::Type,
+    proto: &defs::Proto,
+) -> TokenStream {
     if py_methods.is_empty() {
-        return quote! {};
+        return TokenStream::default();
     }
+
+    let methods_trait = proto.methods_trait();
+    let methods_trait_methods = proto.methods_trait_methods();
     quote! {
-        pyo3::inventory::submit! {
-            #![crate = pyo3] {
-                type Inventory = <#ty as pyo3::class::methods::HasMethodsInventory>::Methods;
-                <Inventory as pyo3::class::methods::PyMethodsInventory>::new(vec![#(#py_methods),*])
+        impl pyo3::class::impl_::#methods_trait<#ty>
+            for pyo3::class::impl_::PyClassImplCollector<#ty>
+        {
+            fn #methods_trait_methods(self) -> &'static [pyo3::class::methods::PyMethodDefType] {
+                static METHODS: &[pyo3::class::methods::PyMethodDefType] =
+                    &[#(pyo3::class::methods::PyMethodDefType::Method(#py_methods)),*];
+                METHODS
             }
         }
     }
@@ -122,13 +132,13 @@ fn impl_proto_methods(
     ty: &syn::Type,
     proto: &defs::Proto,
 ) -> TokenStream {
-    if proto.slots_trait.is_empty() {
+    if method_names.is_empty() {
         return TokenStream::default();
     }
 
     let module = proto.module();
-    let slots_trait = syn::Ident::new(proto.slots_trait, Span::call_site());
-    let slots_trait_slots = syn::Ident::new(proto.slots_trait_slots, Span::call_site());
+    let slots_trait = proto.slots_trait();
+    let slots_trait_slots = proto.slots_trait_slots();
 
     let mut maybe_buffer_methods = None;
     if proto.name == "Buffer" {

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -78,99 +78,54 @@ impl<T> PyClassCallImpl<T> for &'_ PyClassImplCollector<T> {
 
 // All traits describing slots, as well as the fallback implementations for unimplemented protos
 //
-// Protos which are implented use dtolnay specialization to implement for PyClassImplCollector<T>.
+// Protos which are implemented use dtolnay specialization to implement for PyClassImplCollector<T>.
 //
 // See https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md
 
-pub trait PyObjectProtocolSlots<T> {
-    fn object_protocol_slots(self) -> &'static [ffi::PyType_Slot];
+macro_rules! slots_trait {
+    ($name:ident, $function_name: ident) => {
+        pub trait $name<T> {
+            fn $function_name(self) -> &'static [ffi::PyType_Slot];
+        }
+
+        impl<T> $name<T> for &'_ PyClassImplCollector<T> {
+            fn $function_name(self) -> &'static [ffi::PyType_Slot] {
+                &[]
+            }
+        }
+    };
 }
 
-impl<T> PyObjectProtocolSlots<T> for &'_ PyClassImplCollector<T> {
-    fn object_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
-        &[]
-    }
+slots_trait!(PyObjectProtocolSlots, object_protocol_slots);
+slots_trait!(PyDescrProtocolSlots, descr_protocol_slots);
+slots_trait!(PyGCProtocolSlots, gc_protocol_slots);
+slots_trait!(PyIterProtocolSlots, iter_protocol_slots);
+slots_trait!(PyMappingProtocolSlots, mapping_protocol_slots);
+slots_trait!(PyNumberProtocolSlots, number_protocol_slots);
+slots_trait!(PyAsyncProtocolSlots, async_protocol_slots);
+slots_trait!(PySequenceProtocolSlots, sequence_protocol_slots);
+slots_trait!(PyBufferProtocolSlots, buffer_protocol_slots);
+
+macro_rules! methods_trait {
+    ($name:ident, $function_name: ident) => {
+        pub trait $name<T> {
+            fn $function_name(self) -> &'static [PyMethodDefType];
+        }
+
+        impl<T> $name<T> for &'_ PyClassImplCollector<T> {
+            fn $function_name(self) -> &'static [PyMethodDefType] {
+                &[]
+            }
+        }
+    };
 }
 
-pub trait PyDescrProtocolSlots<T> {
-    fn descr_protocol_slots(self) -> &'static [ffi::PyType_Slot];
-}
-
-impl<T> PyDescrProtocolSlots<T> for &'_ PyClassImplCollector<T> {
-    fn descr_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
-        &[]
-    }
-}
-
-pub trait PyGCProtocolSlots<T> {
-    fn gc_protocol_slots(self) -> &'static [ffi::PyType_Slot];
-}
-
-impl<T> PyGCProtocolSlots<T> for &'_ PyClassImplCollector<T> {
-    fn gc_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
-        &[]
-    }
-}
-
-pub trait PyIterProtocolSlots<T> {
-    fn iter_protocol_slots(self) -> &'static [ffi::PyType_Slot];
-}
-
-impl<T> PyIterProtocolSlots<T> for &'_ PyClassImplCollector<T> {
-    fn iter_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
-        &[]
-    }
-}
-
-pub trait PyMappingProtocolSlots<T> {
-    fn mapping_protocol_slots(self) -> &'static [ffi::PyType_Slot];
-}
-
-impl<T> PyMappingProtocolSlots<T> for &'_ PyClassImplCollector<T> {
-    fn mapping_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
-        &[]
-    }
-}
-
-pub trait PyNumberProtocolSlots<T> {
-    fn number_protocol_slots(self) -> &'static [ffi::PyType_Slot];
-}
-
-impl<T> PyNumberProtocolSlots<T> for &'_ PyClassImplCollector<T> {
-    fn number_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
-        &[]
-    }
-}
-
-pub trait PyAsyncProtocolSlots<T> {
-    fn async_protocol_slots(self) -> &'static [ffi::PyType_Slot];
-}
-
-impl<T> PyAsyncProtocolSlots<T> for &'_ PyClassImplCollector<T> {
-    fn async_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
-        &[]
-    }
-}
-
-pub trait PySequenceProtocolSlots<T> {
-    fn sequence_protocol_slots(self) -> &'static [ffi::PyType_Slot];
-}
-
-impl<T> PySequenceProtocolSlots<T> for &'_ PyClassImplCollector<T> {
-    fn sequence_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
-        &[]
-    }
-}
-
-pub trait PyBufferProtocolSlots<T> {
-    fn buffer_protocol_slots(self) -> &'static [ffi::PyType_Slot];
-}
-
-impl<T> PyBufferProtocolSlots<T> for &'_ PyClassImplCollector<T> {
-    fn buffer_protocol_slots(self) -> &'static [ffi::PyType_Slot] {
-        &[]
-    }
-}
+methods_trait!(PyObjectProtocolMethods, object_protocol_methods);
+methods_trait!(PyAsyncProtocolMethods, async_protocol_methods);
+methods_trait!(PyContextProtocolMethods, context_protocol_methods);
+methods_trait!(PyDescrProtocolMethods, descr_protocol_methods);
+methods_trait!(PyMappingProtocolMethods, mapping_protocol_methods);
+methods_trait!(PyNumberProtocolMethods, number_protocol_methods);
 
 // On Python < 3.9 setting the buffer protocol using slots doesn't work, so these procs are used
 // on those versions to set the slots manually (on the limited API).


### PR DESCRIPTION
This is the next step in making inventory optional, by changing `#[pyproto]` methods which use inventory to also use dtolnay specialization.

It works very similarly to #1328.

From a very basic benchmark, this doesn't appear to change performance of type object initialization at all. (Perf doesn't matter very much here anyway, as this is only something that runs once on library startup.)

The next (and final) PR in this series will make it so that `inventory` is optional. Without inventory, you will only be allowed one `#[pymethods]` for each `#[pyclass]`. However you will get faster compile times and support on platforms where inventory isn't available :)