### PR TITLE
defs: remove dead __unicode__ def

### DIFF
--- a/pyo3-macros-backend/src/defs.rs
+++ b/pyo3-macros-backend/src/defs.rs
@@ -147,7 +147,6 @@ pub const OBJECT: Proto = Proto {
     py_methods: &[
         PyMethod::new("__format__", "FormatProtocolImpl"),
         PyMethod::new("__bytes__", "BytesProtocolImpl"),
-        PyMethod::new("__unicode__", "UnicodeProtocolImpl"),
     ],
     slot_defs: &[
         SlotDef::new(&["__str__"], "Py_tp_str", "str"),


### PR DESCRIPTION
Looks like this is a hangover from old Python 2 support.