### PR TITLE
pycfunction: take &'static str arguments to new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Deprecate FFI definition `PyCFunction_Call` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - Deprecate FFI definitions `PyModule_GetFilename`. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - The `auto-initialize` feature is no longer enabled by default. [#1443](https://github.com/PyO3/pyo3/pull/1443)
+- Change `PyCFunction::new()` and `PyCFunction::new_with_keywords()` to take `&'static str` arguments rather than implicitly copying (and leaking) them. [#1450](https://github.com/PyO3/pyo3/pull/1450)
 
 ### Removed
 - Remove deprecated exception names `BaseException` etc. [#1426](https://github.com/PyO3/pyo3/pull/1426)

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -192,8 +192,7 @@ pub fn add_fn_to_module(
         doc,
     };
 
-    let doc = syn::LitByteStr::new(spec.doc.value().as_bytes(), spec.doc.span());
-
+    let doc = &spec.doc;
     let python_name = &spec.python_name;
 
     let name = &func.sig.ident;
@@ -205,13 +204,13 @@ pub fn add_fn_to_module(
             args: impl Into<pyo3::derive_utils::PyFunctionArguments<'a>>
         ) -> pyo3::PyResult<&'a pyo3::types::PyCFunction> {
             let name = concat!(stringify!(#python_name), "\0");
-            let name = std::ffi::CStr::from_bytes_with_nul(name.as_bytes()).unwrap();
-            let doc = std::ffi::CStr::from_bytes_with_nul(#doc).unwrap();
             pyo3::types::PyCFunction::internal_new(
-                name,
-                doc,
-                unsafe { std::mem::transmute(#wrapper_ident as *const std::os::raw::c_void) },
-                pyo3::ffi::METH_VARARGS | pyo3::ffi::METH_KEYWORDS,
+                pyo3::class::methods::PyMethodDef::cfunction_with_keywords(
+                    name,
+                    pyo3::class::methods::PyCFunctionWithKeywords(#wrapper_ident),
+                    0,
+                    #doc,
+                ),
                 args.into(),
             )
         }

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -318,7 +318,7 @@ fn py_class_method_defs<T: PyClassImpl>() -> Vec<ffi::PyMethodDef> {
         PyMethodDefType::Method(def)
         | PyMethodDefType::Class(def)
         | PyMethodDefType::Static(def) => {
-            defs.push(def.as_method_def());
+            defs.push(def.as_method_def().unwrap());
         }
         _ => (),
     });


### PR DESCRIPTION
This is a follow-up to #1446 to refactor `PyCFunction` a little bit to re-use code and get rid of one `transmute` call at the same time.

I had to change the `name` and `doc` arguments to `PyCFunction::new()` to take `&'static str` instead of just `&str`. This is a good change in my opinion because the underlying Python APIs need `'static` data anyway. Previously we always had to copy the string and leak the copy; now we can forward the pointer to the underlying string (as long as it's a valid c-string).