### PR TITLE
Generate less code

### DIFF
--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -428,8 +428,8 @@ fn impl_class(
 
             fn for_each_method_def(visitor: impl FnMut(&pyo3::class::PyMethodDefType)) {
                 use pyo3::class::impl_::*;
-                let collector = PyClassImplCollector::<#cls>::new();
-                pyo3::inventory::iter::<<#cls as pyo3::class::methods::HasMethodsInventory>::Methods>
+                let collector = PyClassImplCollector::<Self>::new();
+                pyo3::inventory::iter::<<Self as pyo3::class::methods::HasMethodsInventory>::Methods>
                     .into_iter()
                     .flat_map(pyo3::class::methods::PyMethodsInventory::get)
                     .chain(collector.object_protocol_methods())
@@ -442,19 +442,19 @@ fn impl_class(
             }
             fn get_new() -> Option<pyo3::ffi::newfunc> {
                 use pyo3::class::impl_::*;
-                let collector = PyClassImplCollector::<#cls>::new();
+                let collector = PyClassImplCollector::<Self>::new();
                 collector.new_impl()
             }
             fn get_call() -> Option<pyo3::ffi::PyCFunctionWithKeywords> {
                 use pyo3::class::impl_::*;
-                let collector = PyClassImplCollector::<#cls>::new();
+                let collector = PyClassImplCollector::<Self>::new();
                 collector.call_impl()
             }
 
             fn for_each_proto_slot(visitor: impl FnMut(&pyo3::ffi::PyType_Slot)) {
                 // Implementation which uses dtolnay specialization to load all slots.
                 use pyo3::class::impl_::*;
-                let collector = PyClassImplCollector::<#cls>::new();
+                let collector = PyClassImplCollector::<Self>::new();
                 collector.object_protocol_slots()
                     .iter()
                     .chain(collector.number_protocol_slots())
@@ -470,7 +470,7 @@ fn impl_class(
 
             fn get_buffer() -> Option<&'static pyo3::class::impl_::PyBufferProcs> {
                 use pyo3::class::impl_::*;
-                let collector = PyClassImplCollector::<#cls>::new();
+                let collector = PyClassImplCollector::<Self>::new();
                 collector.buffer_procs()
             }
         }

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -216,7 +216,7 @@ macro_rules! callback_body {
 /// ```ignore
 /// pyo3::callback::handle_panic(|_py| {
 ///     let _slf = #slf;
-///     pyo3::callback::convert(py, #foo)
+///     pyo3::callback::convert(_py, #foo)
 /// })
 /// ```
 ///
@@ -232,12 +232,11 @@ macro_rules! callback_body {
 /// Then this will fail to compile, because the result of #foo borrows _slf, but _slf drops when
 /// the block passed to the macro ends.
 #[doc(hidden)]
-pub unsafe fn handle_panic<
-    R: PyCallbackOutput,
+pub unsafe fn handle_panic<F, R>(body: F) -> R
+where
     F: FnOnce(Python) -> crate::PyResult<R> + UnwindSafe,
->(
-    body: F,
-) -> R {
+    R: PyCallbackOutput,
+{
     let pool = crate::GILPool::new();
     let unwind_safe_py = std::panic::AssertUnwindSafe(pool.python());
     let result =

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -9,6 +9,7 @@ use crate::IntoPyPointer;
 use crate::{IntoPy, PyObject, Python};
 use std::isize;
 use std::os::raw::c_int;
+use std::panic::UnwindSafe;
 
 /// A type which can be the return type of a python C-API callback
 pub trait PyCallbackOutput: Copy {
@@ -194,9 +195,9 @@ where
 #[doc(hidden)]
 #[macro_export]
 macro_rules! callback_body {
-    ($py:ident, $body:expr) => {{
-        $crate::callback_body_without_convert!($py, $crate::callback::convert($py, $body))
-    }};
+    ($py:ident, $body:expr) => {
+        $crate::callback::handle_panic(|$py| $crate::callback::convert($py, $body))
+    };
 }
 
 /// Variant of the above which does not perform the callback conversion. This allows the callback
@@ -210,10 +211,10 @@ macro_rules! callback_body {
 /// }
 /// ```
 ///
-/// It is wrapped in proc macros with callback_body_without_convert like so:
+/// It is wrapped in proc macros with handle_panic like so:
 ///
 /// ```ignore
-/// pyo3::callback_body_without_convert!(py, {
+/// pyo3::callback::handle_panic(|_py| {
 ///     let _slf = #slf;
 ///     pyo3::callback::convert(py, #foo)
 /// })
@@ -231,33 +232,33 @@ macro_rules! callback_body {
 /// Then this will fail to compile, because the result of #foo borrows _slf, but _slf drops when
 /// the block passed to the macro ends.
 #[doc(hidden)]
-#[macro_export]
-macro_rules! callback_body_without_convert {
-    ($py:ident, $body:expr) => {{
-        let pool = $crate::GILPool::new();
-        let unwind_safe_py = std::panic::AssertUnwindSafe(pool.python());
-        let result = match std::panic::catch_unwind(move || -> $crate::PyResult<_> {
-            let $py = *unwind_safe_py;
-            $body
-        }) {
+pub unsafe fn handle_panic<
+    R: PyCallbackOutput,
+    F: FnOnce(Python) -> crate::PyResult<R> + UnwindSafe,
+>(
+    body: F,
+) -> R {
+    let pool = crate::GILPool::new();
+    let unwind_safe_py = std::panic::AssertUnwindSafe(pool.python());
+    let result =
+        match std::panic::catch_unwind(move || -> crate::PyResult<_> { body(*unwind_safe_py) }) {
             Ok(result) => result,
             Err(e) => {
                 // Try to format the error in the same way panic does
                 if let Some(string) = e.downcast_ref::<String>() {
-                    Err($crate::panic::PanicException::new_err((string.clone(),)))
+                    Err(crate::panic::PanicException::new_err((string.clone(),)))
                 } else if let Some(s) = e.downcast_ref::<&str>() {
-                    Err($crate::panic::PanicException::new_err((s.to_string(),)))
+                    Err(crate::panic::PanicException::new_err((s.to_string(),)))
                 } else {
-                    Err($crate::panic::PanicException::new_err((
+                    Err(crate::panic::PanicException::new_err((
                         "panic from Rust code",
                     )))
                 }
             }
         };
 
-        result.unwrap_or_else(|e| {
-            e.restore(pool.python());
-            $crate::callback::callback_error()
-        })
-    }};
+    result.unwrap_or_else(|e| {
+        e.restore(pool.python());
+        crate::callback::callback_error()
+    })
 }

--- a/tests/ui/static_ref.stderr
+++ b/tests/ui/static_ref.stderr
@@ -1,11 +1,25 @@
-error[E0597]: `pool` does not live long enough
+error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'p` due to conflicting requirements
  --> $DIR/static_ref.rs:4:1
   |
 4 | #[pyfunction]
   | ^^^^^^^^^^^^^
-  | |
-  | borrowed value does not live long enough
-  | `pool` dropped here while still borrowed
-  | cast requires that `pool` is borrowed for `'static`
   |
-  = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
+note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the body at 4:1...
+ --> $DIR/static_ref.rs:4:1
+  |
+4 | #[pyfunction]
+  | ^^^^^^^^^^^^^
+note: ...so that the types are compatible
+ --> $DIR/static_ref.rs:4:1
+  |
+4 | #[pyfunction]
+  | ^^^^^^^^^^^^^
+  = note: expected `pyo3::Python<'_>`
+             found `pyo3::Python<'_>`
+  = note: but, the lifetime must be valid for the static lifetime...
+note: ...so that reference does not outlive borrowed content
+ --> $DIR/static_ref.rs:4:1
+  |
+4 | #[pyfunction]
+  | ^^^^^^^^^^^^^
+  = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
When building a test crate without the macros feature for maturin, I saw that pyo3 generates a lot of identical boilerplate code. This removes a bunch of it, mainly by turning `callback_body_without_convert` into a function. 

I've used this code to test:

```rust
use pyo3::prelude::*;
use pyo3::wrap_pyfunction;

#[pyfunction]
fn add(x: usize, y: usize) -> usize {
    x + y
}

#[pyclass]
struct Data {
    pub x: usize,
}

#[pymodule]
fn minimal(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
    m.add_function(wrap_pyfunction!(add, m)?)?;
    m.add_class::<Data>()?;

    Ok(())
}
```

And this is the resulting diff: https://gist.github.com/konstin/3c9e6b9047e2aa06a4cc47d6a235cff4 (with `cargo +nightly rustc -- -Zunstable-options --pretty=expanded` and after rustfmt)