### PR TITLE
pyclass: move flags to PyClassImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `PyMethodDef_INIT` [#1426](https://github.com/PyO3/pyo3/pull/1426)
   - `PyTypeObject_INIT` [#1429](https://github.com/PyO3/pyo3/pull/1429)
   - `PyObject_Check`, `PySuper_Check`, and `FreeFunc` [#1438](https://github.com/PyO3/pyo3/pull/1438)
+- Remove pyclass implementation details `Type`, `DESCRIPTION`, and `FLAGS` from `PyTypeInfo`. [#1456](https://github.com/PyO3/pyo3/pull/1456)
 
 ### Fixed
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -756,7 +756,7 @@ impl pyo3::IntoPy<PyObject> for MyClass {
 }
 
 impl pyo3::class::impl_::PyClassImpl for MyClass {
-    const DESCRIPTION: &'static str = "Class for demonstration";
+    const DOC: &'static str = "Class for demonstration";
     const IS_GC: bool = false;
     const IS_BASETYPE: bool = false;
     const IS_SUBCLASS: bool = false;

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -726,7 +726,6 @@ struct MyClass {
 impl pyo3::pyclass::PyClassAlloc for MyClass {}
 
 unsafe impl pyo3::PyTypeInfo for MyClass {
-    type Type = MyClass;
     type BaseType = PyAny;
     type BaseLayout = pyo3::pycell::PyCellBase<PyAny>;
     type Layout = PyCell<Self>;
@@ -735,8 +734,6 @@ unsafe impl pyo3::PyTypeInfo for MyClass {
 
     const NAME: &'static str = "MyClass";
     const MODULE: Option<&'static str> = None;
-    const DESCRIPTION: &'static str = "Class for demonstration";
-    const FLAGS: usize = 0;
 
     #[inline]
     fn type_object_raw(py: pyo3::Python) -> *mut pyo3::ffi::PyTypeObject {
@@ -759,6 +756,10 @@ impl pyo3::IntoPy<PyObject> for MyClass {
 }
 
 impl pyo3::class::impl_::PyClassImpl for MyClass {
+    const DESCRIPTION: &'static str = "Class for demonstration";
+    const IS_GC: bool = false;
+    const IS_BASETYPE: bool = false;
+    const IS_SUBCLASS: bool = false;
     type ThreadChecker = pyo3::class::impl_::ThreadCheckerStub<MyClass>;
 
     fn for_each_method_def(visitor: impl FnMut(&pyo3::class::PyMethodDefType)) {
@@ -776,18 +777,18 @@ impl pyo3::class::impl_::PyClassImpl for MyClass {
     }
     fn get_new() -> Option<pyo3::ffi::newfunc> {
         use pyo3::class::impl_::*;
-        let collector = PyClassImplCollector::<MyClass>::new();
+        let collector = PyClassImplCollector::<Self>::new();
         collector.new_impl()
     }
     fn get_call() -> Option<pyo3::ffi::PyCFunctionWithKeywords> {
         use pyo3::class::impl_::*;
-        let collector = PyClassImplCollector::<MyClass>::new();
+        let collector = PyClassImplCollector::<Self>::new();
         collector.call_impl()
     }
     fn for_each_proto_slot(visitor: impl FnMut(&pyo3::ffi::PyType_Slot)) {
         // Implementation which uses dtolnay specialization to load all slots.
         use pyo3::class::impl_::*;
-        let collector = PyClassImplCollector::<MyClass>::new();
+        let collector = PyClassImplCollector::<Self>::new();
         collector.object_protocol_slots()
             .iter()
             .chain(collector.number_protocol_slots())
@@ -803,7 +804,7 @@ impl pyo3::class::impl_::PyClassImpl for MyClass {
 
     fn get_buffer() -> Option<&'static pyo3::class::impl_::PyBufferProcs> {
         use pyo3::class::impl_::*;
-        let collector = PyClassImplCollector::<MyClass>::new();
+        let collector = PyClassImplCollector::<Self>::new();
         collector.buffer_procs()
     }
 }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -429,7 +429,7 @@ fn impl_class(
         #impl_inventory
 
         impl pyo3::class::impl_::PyClassImpl for #cls {
-            const DESCRIPTION: &'static str = #doc;
+            const DOC: &'static str = #doc;
             const IS_GC: bool = #is_gc;
             const IS_BASETYPE: bool = #is_basetype;
             const IS_SUBCLASS: bool = #is_subclass;

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-use crate::{derive_utils::PyBaseTypeUtils, ffi, PyMethodDefType, PyNativeType, PyTypeInfo};
+use crate::{derive_utils::PyBaseTypeUtils, ffi, PyMethodDefType, PyNativeType};
 use std::{marker::PhantomData, thread};
 
 /// This type is used as a "dummy" type on which dtolnay specializations are
@@ -31,9 +31,9 @@ impl<T> Copy for PyClassImplCollector<T> {}
 ///
 /// Users are discouraged from implementing this trait manually; it is a PyO3 implementation detail
 /// and may be changed at any time.
-pub trait PyClassImpl: Sized + PyTypeInfo {
+pub trait PyClassImpl: Sized {
     /// Class doc string
-    const DESCRIPTION: &'static str = "\0";
+    const DOC: &'static str = "\0";
 
     /// #[pyclass(gc)]
     const IS_GC: bool = false;

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-use crate::{derive_utils::PyBaseTypeUtils, ffi, PyMethodDefType, PyNativeType};
+use crate::{derive_utils::PyBaseTypeUtils, ffi, PyMethodDefType, PyNativeType, PyTypeInfo};
 use std::{marker::PhantomData, thread};
 
 /// This type is used as a "dummy" type on which dtolnay specializations are
@@ -31,7 +31,19 @@ impl<T> Copy for PyClassImplCollector<T> {}
 ///
 /// Users are discouraged from implementing this trait manually; it is a PyO3 implementation detail
 /// and may be changed at any time.
-pub trait PyClassImpl: Sized {
+pub trait PyClassImpl: Sized + PyTypeInfo {
+    /// Class doc string
+    const DESCRIPTION: &'static str = "\0";
+
+    /// #[pyclass(gc)]
+    const IS_GC: bool = false;
+
+    /// #[pyclass(subclass)]
+    const IS_BASETYPE: bool = false;
+
+    /// #[pyclass(extends=...)]
+    const IS_SUBCLASS: bool = false;
+
     /// This handles following two situations:
     /// 1. In case `T` is `Send`, stub `ThreadChecker` is used and does nothing.
     ///    This implementation is used by default. Compile fails if `T: !Send`.

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -4,7 +4,7 @@
 
 use crate::class::impl_::PyClassImpl;
 use crate::pyclass::{get_type_free, tp_free_fallback, PyClassAlloc};
-use crate::type_object::PyLayout;
+use crate::type_object::{PyLayout, PyTypeInfo};
 use crate::{ffi, AsPyPointer, FromPyPointer, PyAny, Python};
 use std::mem;
 use std::os::raw::c_void;
@@ -70,7 +70,7 @@ impl<T> FreeList<T> {
 
 impl<T> PyClassAlloc for T
 where
-    T: PyClassImpl + PyClassWithFreeList,
+    T: PyTypeInfo + PyClassImpl + PyClassWithFreeList,
 {
     unsafe fn new(py: Python, subtype: *mut ffi::PyTypeObject) -> *mut Self::Layout {
         // if subtype is not equal to this type, we cannot use the freelist

--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -2,8 +2,9 @@
 
 //! Free allocation list
 
+use crate::class::impl_::PyClassImpl;
 use crate::pyclass::{get_type_free, tp_free_fallback, PyClassAlloc};
-use crate::type_object::{PyLayout, PyTypeInfo};
+use crate::type_object::PyLayout;
 use crate::{ffi, AsPyPointer, FromPyPointer, PyAny, Python};
 use std::mem;
 use std::os::raw::c_void;
@@ -69,7 +70,7 @@ impl<T> FreeList<T> {
 
 impl<T> PyClassAlloc for T
 where
-    T: PyTypeInfo + PyClassWithFreeList,
+    T: PyClassImpl + PyClassWithFreeList,
 {
     unsafe fn new(py: Python, subtype: *mut ffi::PyTypeObject) -> *mut Self::Layout {
         // if subtype is not equal to this type, we cannot use the freelist

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub use crate::pycell::{PyCell, PyRef, PyRefMut};
 pub use crate::pyclass::PyClass;
 pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::python::{Python, PythonVersionInfo};
-pub use crate::type_object::{type_flags, PyTypeInfo};
+pub use crate::type_object::PyTypeInfo;
 // Since PyAny is as important as PyObject, we expose it to the top level.
 pub use crate::types::PyAny;
 

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -46,25 +46,6 @@ pub trait PySizedLayout<T: PyTypeInfo>: PyLayout<T> + Sized {}
 /// Otherwise, implementing this trait is undefined behavior.
 pub unsafe trait PyBorrowFlagLayout<T: PyTypeInfo>: PyLayout<T> + Sized {}
 
-/// Our custom type flags
-#[doc(hidden)]
-pub mod type_flags {
-    /// Type object supports Python GC
-    pub const GC: usize = 1;
-
-    /// Type object supports Python weak references
-    pub const WEAKREF: usize = 1 << 1;
-
-    /// Type object can be used as the base type of another type
-    pub const BASETYPE: usize = 1 << 2;
-
-    /// The instances of this type have a dictionary containing instance variables
-    pub const DICT: usize = 1 << 3;
-
-    /// The class declared by #[pyclass(extends=~)]
-    pub const EXTENDED: usize = 1 << 4;
-}
-
 /// Python type information.
 /// All Python native types(e.g., `PyDict`) and `#[pyclass]` structs implement this trait.
 ///
@@ -72,20 +53,11 @@ pub mod type_flags {
 ///  - specifying the incorrect layout can lead to memory errors
 ///  - the return value of type_object must always point to the same PyTypeObject instance
 pub unsafe trait PyTypeInfo: Sized {
-    /// Type of objects to store in PyObject struct
-    type Type;
-
     /// Class name
     const NAME: &'static str;
 
     /// Module name, if any
     const MODULE: Option<&'static str>;
-
-    /// Class doc string
-    const DESCRIPTION: &'static str = "\0";
-
-    /// Type flags (ie PY_TYPE_FLAG_GC, PY_TYPE_FLAG_WEAKREF)
-    const FLAGS: usize = 0;
 
     /// Base class
     type BaseType: PyTypeInfo + PyTypeObject;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -197,7 +197,6 @@ macro_rules! pyobject_native_type_info(
     ($name: ty, $layout: path, $typeobject: expr,
      $module: expr $(, $checkfunction:path)? $(;$generics: ident)*) => {
         unsafe impl<$($generics,)*> $crate::type_object::PyTypeInfo for $name {
-            type Type = ();
             type BaseType = $crate::PyAny;
             type Layout = $layout;
             type BaseLayout = $crate::ffi::PyObject;


### PR DESCRIPTION
This is a (mostly internal) refactoring to move some pieces of `PyTypeInfo` which aren't needed for anything other than `#[pyclass]` onto the `PyClassImpl` trait.

At the same time I cleaned up the old `FLAGS` constant which still had unneeded entries for e.g. weakref.