### PR TITLE
pymethods: make inventory optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         id: settings
         shell: bash
         run: |
-          echo "::set-output name=all_additive_features::macros num-bigint num-complex hashbrown serde"
+          echo "::set-output name=all_additive_features::macros num-bigint num-complex hashbrown serde multiple-pymethods"
 
       - name: Build docs
         run: cargo doc --no-default-features --features "${{ steps.settings.outputs.all_additive_features }}"
@@ -155,16 +155,15 @@ jobs:
           toolchain: nightly
           override: true
           profile: minimal
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features "num-bigint num-complex hashbrown serde" --no-fail-fast
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
-          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+      - run: cargo test --no-default-features --no-fail-fast
+      - run: cargo test --no-default-features --no-fail-fast --features "macros num-bigint num-complex hashbrown serde multiple-pymethods"
       - uses: actions-rs/grcov@v0.1
         id: coverage
       - uses: codecov/codecov-action@v1
         with:
           file: ${{ steps.coverage.outputs.report }}
+    env:
+      CARGO_TERM_VERBOSE: true
+      CARGO_INCREMENTAL: 0
+      RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+      RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,10 @@ serde_json = "1.0.61"
 default = ["macros"]
 
 # Enables macros: #[pyclass], #[pymodule], #[pyfunction] etc.
-macros = ["pyo3-macros", "indoc", "inventory", "paste", "unindent"]
+macros = ["pyo3-macros", "indoc", "paste", "unindent"]
+
+# Enables multiple #[pymethods] per #[pyclass]
+multiple-pymethods = ["inventory"]
 
 # Use this feature when building an extension module.
 # It tells the linker to keep the python symbols unresolved,

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1,8 +1,10 @@
 # Python Classes
 
-PyO3 exposes a group of attributes powered by Rust's proc macro system for defining Python classes as Rust structs. This chapter will discuss the functionality and configuration they offer.
+PyO3 exposes a group of attributes powered by Rust's proc macro system for defining Python classes as Rust structs.
 
-For ease of discovery, below is a list of all custom attributes with links to the relevant section of this chapter:
+The main attribute is `#[pyclass]`, which is placed upon a Rust `struct` to generate a Python type for it. A struct will usually also have *one* `#[pymethods]`-annotated `impl` block for the struct, which is used to define Python methods and constants for the generated Python type. (If the [`multiple-pymethods`] feature is enabled each `#[pyclass]` is allowed to have multiple `#[pymethods]` blocks.) Finally, there may be multiple `#[pyproto]` trait implementations for the struct, which are used to define certain python magic methods such as `__str__`.
+
+This chapter will discuss the functionality and configuration these attributes offer. Below is a list of links to the relevant section of this chapter for each:
 
 - [`#[pyclass]`](#defining-a-new-class)
   - [`#[pyo3(get, set)]`](#object-properties-using-pyo3get-set)
@@ -31,9 +33,9 @@ struct MyClass {
 }
 ```
 
-Because Python objects are freely shared between threads by the Python interpreter, all structs annotated with `#[pyclass]` must implement `Send`.
+Because Python objects are freely shared between threads by the Python interpreter, all structs annotated with `#[pyclass]` must implement `Send` (unless annotated with [`#[pyclass(unsendable)]`](#customizing-the-class)).
 
-The above example generates implementations for [`PyTypeInfo`], [`PyTypeObject`], and [`PyClass`] for `MyClass`. To see these generated implementations, refer to the section [How methods are implemented](#how-methods-are-implemented) at the end of this chapter.
+The above example generates implementations for [`PyTypeInfo`], [`PyTypeObject`], and [`PyClass`] for `MyClass`. To see these generated implementations, refer to the [implementation details](#implementation-details) at the end of this chapter.
 
 ## Adding the class to a module
 
@@ -444,7 +446,8 @@ To define a Python compatible method, an `impl` block for your struct has to be 
 block with some variations, like descriptors, class method static methods, etc.
 
 Since Rust allows any number of `impl` blocks, you can easily split methods
-between those accessible to Python (and Rust) and those accessible only to Rust.
+between those accessible to Python (and Rust) and those accessible only to Rust. However to have multiple
+`#[pymethods]`-annotated `impl` blocks for the same struct you must enable the [`multiple-pymethods`] feature of PyO3.
 
 ```rust
 # use pyo3::prelude::*;
@@ -698,22 +701,21 @@ num=44, debug=false
 num=-1, debug=false
 ```
 
-## How methods are implemented
+## Implementation details
 
-Users should be able to define a `#[pyclass]` with or without `#[pymethods]`, while PyO3 needs a
-trait with a function that returns all methods. Since it's impossible to make the code generation in
-pyclass dependent on whether there is an impl block, we'd need to implement the trait on
-`#[pyclass]` and override the implementation in `#[pymethods]`.
-To enable this, we use a static registry type provided by [inventory](https://github.com/dtolnay/inventory),
-which allows us to collect `impl`s from arbitrary source code by exploiting some binary trick.
-See [inventory: how it works](https://github.com/dtolnay/inventory#how-it-works) and `pyo3_macros_backend::py_class` for more details.
+The `#[pyclass]` macros rely on a lot of conditional code generation: each `#[pyclass]` can optionally have a `#[pymethods]` block as well as several different possible `#[pyproto]` trait implementations.
 
-Specifically, the following implementation is generated:
+To support this flexibility the `#[pyclass]` macro expands to a blob of boilerplate code which sets up the structure for ["dtolnay specialization"](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md). This implementation pattern enables the Rust compiler to use `#[pymethods]` and `#[pyproto]` implementations when they are present, and fall back to default (empty) definitions when they are not.
+
+This simple technique works for the case when there is zero or one implementations. To support multiple `#[pymethods]` for a `#[pyclass]` (in the [`multiple-pymethods`] feature), a registry mechanism provided by the [`inventory`](https://github.com/dtolnay/inventory) crate is used instead. This collects `impl`s at library load time, but isn't supported on all platforms. See [inventory: how it works](https://github.com/dtolnay/inventory#how-it-works) for more details.
+
+The `#[pyclass]` macro expands to roughly the code seen below. The `PyClassImplCollector` is the type used internally by PyO3 for dtolnay specialization:
 
 ```rust
 # #[cfg(not(feature = "multiple-pymethods"))]
-# { // The implementation differs slightly with the multiple-pymethods feature
-use pyo3::prelude::*;
+# {
+# use pyo3::prelude::*;
+// Note: the implementation differs slightly with the `multiple-pymethods` feature enabled.
 
 /// Class for demonstration
 struct MyClass {
@@ -826,3 +828,5 @@ impl pyo3::class::impl_::PyClassImpl for MyClass {
 [`RefCell`]: https://doc.rust-lang.org/std/cell/struct.RefCell.html
 
 [classattr]: https://docs.python.org/3/tutorial/classes.html#class-and-instance-variables
+
+[`multiple-pymethods`]: features.md#multiple-pymethods

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -55,6 +55,14 @@ These macros require a number of dependencies which may not be needed by users w
 
 > This feature is enabled by default. To disable it, set `default-features = false` for the `pyo3` entry in your Cargo.toml.
 
+### `multiple-pymethods`
+
+This feature enables a dependency on `inventory`, which enables each `#[pyclass]` to have more than one `#[pymethods]` block.
+
+Most users should only need a single `#[pymethods]` per `#[pyclass]`. In addition, not all platforms (e.g. Wasm) are supported by `inventory`. For this reason this feature is not enabled by default, meaning fewer dependencies and faster compilation for the majority of users.
+
+See [the `#[pyclass]` implementation details](class.md#implementation-details) for more information.
+
 ### `nightly`
 
 The `nightly` feature needs the nightly Rust compiler. This allows PyO3 to use Rust's unstable specialization feature to apply the following optimizations:

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -9,6 +9,12 @@ For a detailed list of all changes, see the [CHANGELOG](changelog.md).
 
 For projects embedding Python in Rust, PyO3 no longer automatically initalizes a Python interpreter on the first call to `Python::with_gil` (or `Python::acquire_gil`) unless the [`auto-initalize` feature](features.md#auto-initalize) is enabled.
 
+### New `multiple-pymethods` feature
+
+`#[pymethods]` have been reworked with a simpler default implementation which removes the dependency on the `inventory` crate. This reduces dependencies and compile times for the majority of users.
+
+The limitation of the new default implementation is that it cannot support multiple `#[pymethods]` blocks for the same `#[pyclass]`. If you need this functionality, you must enable the `multiple-pymethods` feature which will switch `#[pymethods]` to the inventory-based implementation.
+
 ## from 0.12.* to 0.13
 
 ### Minimum Rust version increased to Rust 1.45

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -24,6 +24,6 @@ pub use from_pyobject::build_derive_from_pyobject;
 pub use module::{add_fn_to_module, process_functions_in_module, py_init};
 pub use pyclass::{build_py_class, PyClassArgs};
 pub use pyfunction::{build_py_function, PyFunctionAttr};
-pub use pyimpl::build_py_methods;
+pub use pyimpl::{build_py_methods, PyClassMethodsType};
 pub use pyproto::build_py_proto;
 pub use utils::get_doc;

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
 use crate::method::{FnType, SelfType};
+use crate::pyimpl::PyClassMethodsType;
 use crate::pymethod::{
     impl_py_getter_def, impl_py_setter_def, impl_wrap_getter, impl_wrap_setter, PropertyType,
 };
@@ -154,7 +155,11 @@ impl PyClassArgs {
     }
 }
 
-pub fn build_py_class(class: &mut syn::ItemStruct, attr: &PyClassArgs) -> syn::Result<TokenStream> {
+pub fn build_py_class(
+    class: &mut syn::ItemStruct,
+    attr: &PyClassArgs,
+    methods_type: PyClassMethodsType,
+) -> syn::Result<TokenStream> {
     let text_signature = utils::parse_text_signature_attrs(
         &mut class.attrs,
         &get_class_python_name(&class.ident, attr),
@@ -178,7 +183,7 @@ pub fn build_py_class(class: &mut syn::ItemStruct, attr: &PyClassArgs) -> syn::R
         bail_spanned!(class.fields.span() => "#[pyclass] can only be used with C-style structs");
     }
 
-    impl_class(&class.ident, &attr, doc, descriptors)
+    impl_class(&class.ident, &attr, doc, descriptors, methods_type)
 }
 
 /// Parses `#[pyo3(get, set)]`
@@ -210,7 +215,7 @@ fn parse_descriptors(item: &mut syn::Field) -> syn::Result<Vec<FnType>> {
     Ok(descs)
 }
 
-/// To allow multiple #[pymethods]/#[pyproto] block, we define inventory types.
+/// To allow multiple #[pymethods] block, we define inventory types.
 fn impl_methods_inventory(cls: &syn::Ident) -> TokenStream {
     // Try to build a unique type for better error messages
     let name = format!("Pyo3MethodsInventoryFor{}", cls.unraw());
@@ -221,7 +226,7 @@ fn impl_methods_inventory(cls: &syn::Ident) -> TokenStream {
         pub struct #inventory_cls {
             methods: Vec<pyo3::class::PyMethodDefType>,
         }
-        impl pyo3::class::methods::PyMethodsInventory for #inventory_cls {
+        impl pyo3::class::impl_::PyMethodsInventory for #inventory_cls {
             fn new(methods: Vec<pyo3::class::PyMethodDefType>) -> Self {
                 Self { methods }
             }
@@ -230,7 +235,7 @@ fn impl_methods_inventory(cls: &syn::Ident) -> TokenStream {
             }
         }
 
-        impl pyo3::class::methods::HasMethodsInventory for #cls {
+        impl pyo3::class::impl_::HasMethodsInventory for #cls {
             type Methods = #inventory_cls;
         }
 
@@ -247,6 +252,7 @@ fn impl_class(
     attr: &PyClassArgs,
     doc: syn::LitStr,
     descriptors: Vec<(syn::Field, Vec<FnType>)>,
+    methods_type: PyClassMethodsType,
 ) -> syn::Result<TokenStream> {
     let cls_name = get_class_python_name(cls, attr).to_string();
 
@@ -338,7 +344,17 @@ fn impl_class(
         quote! {}
     };
 
-    let impl_inventory = impl_methods_inventory(&cls);
+    let (impl_inventory, iter_py_methods) = match methods_type {
+        PyClassMethodsType::Specialization => (None, quote! { collector.py_methods().iter() }),
+        PyClassMethodsType::Inventory => (
+            Some(impl_methods_inventory(&cls)),
+            quote! {
+                pyo3::inventory::iter::<<Self as pyo3::class::impl_::HasMethodsInventory>::Methods>
+                    .into_iter()
+                    .flat_map(pyo3::class::impl_::PyMethodsInventory::get)
+            },
+        ),
+    };
 
     let base = &attr.base;
     let flags = &attr.flags;
@@ -429,9 +445,8 @@ fn impl_class(
             fn for_each_method_def(visitor: impl FnMut(&pyo3::class::PyMethodDefType)) {
                 use pyo3::class::impl_::*;
                 let collector = PyClassImplCollector::<Self>::new();
-                pyo3::inventory::iter::<<Self as pyo3::class::methods::HasMethodsInventory>::Methods>
-                    .into_iter()
-                    .flat_map(pyo3::class::methods::PyMethodsInventory::get)
+                #iter_py_methods
+                    .chain(collector.py_class_descriptors())
                     .chain(collector.object_protocol_methods())
                     .chain(collector.async_protocol_methods())
                     .chain(collector.context_protocol_methods())
@@ -513,10 +528,12 @@ fn impl_descriptors(
         .collect::<syn::Result<_>>()?;
 
     Ok(quote! {
-        pyo3::inventory::submit! {
-            #![crate = pyo3] {
-                type Inventory = <#cls as pyo3::class::methods::HasMethodsInventory>::Methods;
-                <Inventory as pyo3::class::methods::PyMethodsInventory>::new(vec![#(#py_methods),*])
+        impl pyo3::class::impl_::PyClassDescriptors<#cls>
+            for pyo3::class::impl_::PyClassImplCollector<#cls>
+        {
+            fn py_class_descriptors(self) -> &'static [pyo3::class::methods::PyMethodDefType] {
+                static METHODS: &[pyo3::class::methods::PyMethodDefType] = &[#(#py_methods),*];
+                METHODS
             }
         }
     })

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -689,7 +689,10 @@ pub fn impl_py_method_class_attribute(spec: &FnSpec<'_>, wrapper: &TokenStream) 
         pyo3::class::PyMethodDefType::ClassAttribute({
             #wrapper
 
-            pyo3::class::PyClassAttributeDef::new(concat!(stringify!(#python_name), "\0"), __wrap)
+            pyo3::class::PyClassAttributeDef::new(
+                concat!(stringify!(#python_name), "\0"),
+                pyo3::class::methods::PyClassAttributeFactory(__wrap)
+            )
         })
     }
 }
@@ -700,7 +703,10 @@ pub fn impl_py_const_class_attribute(spec: &ConstSpec, wrapper: &TokenStream) ->
         pyo3::class::PyMethodDefType::ClassAttribute({
             #wrapper
 
-            pyo3::class::PyClassAttributeDef::new(concat!(stringify!(#python_name), "\0"), __wrap)
+            pyo3::class::PyClassAttributeDef::new(
+                concat!(stringify!(#python_name), "\0"),
+                pyo3::class::methods::PyClassAttributeFactory(__wrap)
+            )
         })
     }
 }
@@ -726,7 +732,11 @@ pub(crate) fn impl_py_setter_def(
         pyo3::class::PyMethodDefType::Setter({
             #wrapper
 
-            pyo3::class::PySetterDef::new(concat!(stringify!(#python_name), "\0"), __wrap, #doc)
+            pyo3::class::PySetterDef::new(
+                concat!(stringify!(#python_name), "\0"),
+                pyo3::class::methods::PySetter(__wrap),
+                #doc
+            )
         })
     }
 }
@@ -740,7 +750,11 @@ pub(crate) fn impl_py_getter_def(
         pyo3::class::PyMethodDefType::Getter({
             #wrapper
 
-            pyo3::class::PyGetterDef::new(concat!(stringify!(#python_name), "\0"), __wrap, #doc)
+            pyo3::class::PyGetterDef::new(
+                concat!(stringify!(#python_name), "\0"),
+                pyo3::class::methods::PyGetter(__wrap),
+                #doc
+            )
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ pub use {
 };
 
 #[cfg(all(feature = "macros", feature = "multiple-pymethods"))]
-pub use inventory;
+pub use inventory; // Re-exported for `#[pyclass]` and `#[pymethods]` with `multiple-pymethods`.
 
 #[macro_use]
 mod internal_tricks;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,11 +166,13 @@ pub use crate::types::PyAny;
 #[cfg(feature = "macros")]
 #[doc(hidden)]
 pub use {
-    indoc,     // Re-exported for py_run
-    inventory, // Re-exported for pymethods
-    paste,     // Re-exported for wrap_function
-    unindent,  // Re-exported for py_run
+    indoc,    // Re-exported for py_run
+    paste,    // Re-exported for wrap_function
+    unindent, // Re-exported for py_run
 };
+
+#[cfg(all(feature = "macros", feature = "multiple-pymethods"))]
+pub use inventory;
 
 #[macro_use]
 mod internal_tricks;
@@ -216,7 +218,15 @@ pub mod serde;
 pub mod proc_macro {
     pub use pyo3_macros::pymodule;
     /// The proc macro attributes
-    pub use pyo3_macros::{pyclass, pyfunction, pymethods, pyproto};
+    pub use pyo3_macros::{pyfunction, pyproto};
+
+    #[cfg(not(feature = "multiple-pymethods"))]
+    pub use pyo3_macros::{pyclass, pymethods};
+
+    #[cfg(feature = "multiple-pymethods")]
+    pub use pyo3_macros::{
+        pyclass_with_inventory as pyclass, pymethods_with_inventory as pymethods,
+    };
 }
 
 /// Returns a function that takes a [Python] instance and returns a Python function.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,4 +20,4 @@ pub use crate::{FromPyObject, IntoPy, IntoPyPointer, PyTryFrom, PyTryInto, ToPyO
 // PyModule is only part of the prelude because we need it for the pymodule function
 pub use crate::types::{PyAny, PyModule};
 #[cfg(feature = "macros")]
-pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, pyproto, FromPyObject};
+pub use {crate::proc_macro::*, pyo3_macros::FromPyObject};

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -1,10 +1,10 @@
+use crate::derive_utils::PyFunctionArguments;
 use crate::exceptions::PyValueError;
 use crate::prelude::*;
 use crate::{
     class::methods::{self, PyMethodDef},
     ffi, AsPyPointer,
 };
-use crate::{derive_utils::PyFunctionArguments, methods::NulByteInString};
 
 /// Represents a builtin Python function object.
 #[repr(transparent)]
@@ -54,7 +54,7 @@ impl PyCFunction {
         let (py, module) = py_or_module.into_py_and_maybe_module();
         let def = method_def
             .as_method_def()
-            .map_err(|NulByteInString(err)| PyValueError::new_err(err))?;
+            .map_err(|err| PyValueError::new_err(err.0))?;
         let (mod_ptr, module_name) = if let Some(m) = module {
             let mod_ptr = m.as_ptr();
             let name = m.name()?.into_py(py);

--- a/tests/test_multiple_pymethods.rs
+++ b/tests/test_multiple_pymethods.rs
@@ -1,0 +1,77 @@
+#![cfg(feature = "multiple-pymethods")]
+
+use pyo3::prelude::*;
+use pyo3::type_object::PyTypeObject;
+use pyo3::types::PyType;
+
+#[macro_use]
+mod common;
+
+#[pyclass]
+struct PyClassWithMultiplePyMethods {}
+
+#[pymethods]
+impl PyClassWithMultiplePyMethods {
+    #[new]
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+#[pymethods]
+impl PyClassWithMultiplePyMethods {
+    #[call]
+    fn call(&self) -> &'static str {
+        "call"
+    }
+}
+
+#[pymethods]
+impl PyClassWithMultiplePyMethods {
+    fn method(&self) -> &'static str {
+        "method"
+    }
+}
+
+#[pymethods]
+impl PyClassWithMultiplePyMethods {
+    #[classmethod]
+    fn classmethod(_ty: &PyType) -> &'static str {
+        "classmethod"
+    }
+}
+
+#[pymethods]
+impl PyClassWithMultiplePyMethods {
+    #[staticmethod]
+    fn staticmethod() -> &'static str {
+        "staticmethod"
+    }
+}
+
+#[pymethods]
+impl PyClassWithMultiplePyMethods {
+    #[classattr]
+    fn class_attribute() -> &'static str {
+        "class_attribute"
+    }
+}
+
+#[pymethods]
+impl PyClassWithMultiplePyMethods {
+    #[classattr]
+    const CLASS_ATTRIBUTE: &'static str = "CLASS_ATTRIBUTE";
+}
+
+#[test]
+fn test_class_with_multiple_pymethods() {
+    Python::with_gil(|py| {
+        let cls = PyClassWithMultiplePyMethods::type_object(py);
+        py_assert!(py, cls, "cls()() == 'call'");
+        py_assert!(py, cls, "cls().method() == 'method'");
+        py_assert!(py, cls, "cls.classmethod() == 'classmethod'");
+        py_assert!(py, cls, "cls.staticmethod() == 'staticmethod'");
+        py_assert!(py, cls, "cls.class_attribute == 'class_attribute'");
+        py_assert!(py, cls, "cls.CLASS_ATTRIBUTE == 'CLASS_ATTRIBUTE'");
+    })
+}


### PR DESCRIPTION
With this PR, `inventory` is opt-in (via the `multiple-pymethods` feature) and only needed if you want to have multiple `#[pymethods]` for the same `#[pyclass]`.

This is breaking, so we could make it opt-out. However I think most users won't use multiple `#[pymethods]` per class so will enjoy the reduced dependencies & faster compile times without noticing anything changed 😄 

I plan to push a number of updates to the guide before this PR is ready to be merged. (e.g. information about the feature, migration guide etc.)