### PR TITLE
PyModule: rename call* to call_function*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Deprecate FFI definitions `PyModule_GetFilename`. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - The `auto-initialize` feature is no longer enabled by default. [#1443](https://github.com/PyO3/pyo3/pull/1443)
 - Change `PyCFunction::new()` and `PyCFunction::new_with_keywords()` to take `&'static str` arguments rather than implicitly copying (and leaking) them. [#1450](https://github.com/PyO3/pyo3/pull/1450)
+- The `call/call0/call1` methods of `PyModule` have been renamed to `call_function` etc. for consistency with `call` and `call_method` on `PyAny`. The old names are still present, but deprecated. [#1467](https://github.com/PyO3/pyo3/pull/1467)
 
 ### Removed
 - Remove deprecated exception names `BaseException` etc. [#1426](https://github.com/PyO3/pyo3/pull/1426)

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -115,7 +115,7 @@ use pyo3::prelude::*;
 fn main() -> PyResult<()> {
     Python::with_gil(|py| {
         let builtins = PyModule::import(py, "builtins")?;
-        let total: i32 = builtins.call1("sum", (vec![1, 2, 3],))?.extract()?;
+        let total: i32 = builtins.call_function1("sum", (vec![1, 2, 3],))?.extract()?;
         assert_eq!(total, 6);
         Ok(())
     })
@@ -215,12 +215,12 @@ def leaky_relu(x, slope=0.01):
     return x if x >= 0 else x * slope
     "#, "activators.py", "activators")?;
 
-    let relu_result: f64 = activators.call1("relu", (-1.0,))?.extract()?;
+    let relu_result: f64 = activators.call_function1("relu", (-1.0,))?.extract()?;
     assert_eq!(relu_result, 0.0);
 
     let kwargs = [("slope", 0.2)].into_py_dict(py);
     let lrelu_result: f64 = activators
-        .call("leaky_relu", (-1.0,), Some(kwargs))?
+        .call_function("leaky_relu", (-1.0,), Some(kwargs))?
         .extract()?;
     assert_eq!(lrelu_result, -0.2);
 #    Ok(())

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -132,7 +132,7 @@ impl PyModule {
     /// Calls a function in the module.
     ///
     /// This is equivalent to the Python expression `module.name(*args, **kwargs)`.
-    pub fn call(
+    pub fn call_function(
         &self,
         name: &str,
         args: impl IntoPy<Py<PyTuple>>,
@@ -144,15 +144,41 @@ impl PyModule {
     /// Calls a function in the module with only positional arguments.
     ///
     /// This is equivalent to the Python expression `module.name(*args)`.
-    pub fn call1(&self, name: &str, args: impl IntoPy<Py<PyTuple>>) -> PyResult<&PyAny> {
+    pub fn call_function1(&self, name: &str, args: impl IntoPy<Py<PyTuple>>) -> PyResult<&PyAny> {
         self.getattr(name)?.call1(args)
     }
 
     /// Calls a function in the module without arguments.
     ///
     /// This is equivalent to the Python expression `module.name()`.
-    pub fn call0(&self, name: &str) -> PyResult<&PyAny> {
+    pub fn call_function0(&self, name: &str) -> PyResult<&PyAny> {
         self.getattr(name)?.call0()
+    }
+
+    #[deprecated(since = "0.14.0", note = "Renamed to call_function() for consistency.")]
+    pub fn call(
+        &self,
+        name: &str,
+        args: impl IntoPy<Py<PyTuple>>,
+        kwargs: Option<&PyDict>,
+    ) -> PyResult<&PyAny> {
+        self.call_function(name, args, kwargs)
+    }
+
+    #[deprecated(
+        since = "0.14.0",
+        note = "Renamed to call_function1() for consistency."
+    )]
+    pub fn call1(&self, name: &str, args: impl IntoPy<Py<PyTuple>>) -> PyResult<&PyAny> {
+        self.call_function1(name, args)
+    }
+
+    #[deprecated(
+        since = "0.14.0",
+        note = "Renamed to call_function0() for consistency."
+    )]
+    pub fn call0(&self, name: &str) -> PyResult<&PyAny> {
+        self.call_function0(name)
     }
 
     /// Gets a member from the module.

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -489,12 +489,12 @@ mod bigint_conversion {
                 .unwrap();
             // Checks if Python Long -> Rust BigUint conversion is correct if N is small
             let py_result: BigUint =
-                FromPyObject::extract(fib.call1("fib", (400,)).unwrap()).unwrap();
+                FromPyObject::extract(fib.call_function1("fib", (400,)).unwrap()).unwrap();
             assert_eq!(rs_result, py_result);
             // Checks if Python Long -> Rust BigUint conversion is correct if N is large
             let rs_result: BigUint = rust_fib(2000);
             let py_result: BigUint =
-                FromPyObject::extract(fib.call1("fib", (2000,)).unwrap()).unwrap();
+                FromPyObject::extract(fib.call_function1("fib", (2000,)).unwrap()).unwrap();
             assert_eq!(rs_result, py_result);
         }
 
@@ -512,12 +512,12 @@ mod bigint_conversion {
                 .unwrap();
             // Checks if Python Long -> Rust BigInt conversion is correct if N is small
             let py_result: BigInt =
-                FromPyObject::extract(fib.call1("fib_neg", (400,)).unwrap()).unwrap();
+                FromPyObject::extract(fib.call_function1("fib_neg", (400,)).unwrap()).unwrap();
             assert_eq!(rs_result, py_result);
             // Checks if Python Long -> Rust BigInt conversion is correct if N is large
             let rs_result = rust_fib::<BigInt>(2000) * -1;
             let py_result: BigInt =
-                FromPyObject::extract(fib.call1("fib_neg", (2000,)).unwrap()).unwrap();
+                FromPyObject::extract(fib.call_function1("fib_neg", (2000,)).unwrap()).unwrap();
             assert_eq!(rs_result, py_result);
         }
 
@@ -550,7 +550,8 @@ mod bigint_conversion {
             let gil = Python::acquire_gil();
             let py = gil.python();
             let fib = python_fib(py);
-            let zero: BigInt = FromPyObject::extract(fib.call1("fib", (0,)).unwrap()).unwrap();
+            let zero: BigInt =
+                FromPyObject::extract(fib.call_function1("fib", (0,)).unwrap()).unwrap();
             assert_eq!(zero, BigInt::from(0));
         }
 


### PR DESCRIPTION
For consistency with PyObject/PyAny, where call() means to call the object itself.

