### PR TITLE
docs: deny warnings in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
       CARGO_BUILD_TARGET: ${{ matrix.platform.rust-target }}
       RUST_BACKTRACE: 1
       RUSTFLAGS: "-D warnings"
+      RUSTDOCFLAGS: "-D warnings"
       # TODO: this is a hack to workaround compile_error! warnings about auto-initialize on PyPy
       # Once cargo's `resolver = "2"` is stable (~ MSRV Rust 1.52), remove this.
       PYO3_CI: 1

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -299,5 +299,5 @@ In Python a generator can also return a value. To express this in Rust, PyO3 pro
 both `Yield` values and `Return` a final value - see its docs for further details and an example.
 
 [`PyGCProtocol`]: https://docs.rs/pyo3/latest/pyo3/class/gc/trait.PyGCProtocol.html
-[`PyGCProtocol`]: https://docs.rs/pyo3/latest/pyo3/class/number/trait.PyNumberProtocol.html
+[`PyNumberProtocol`]: https://docs.rs/pyo3/latest/pyo3/class/number/trait.PyNumberProtocol.html
 [`PyObjectProtocol`]: https://docs.rs/pyo3/latest/pyo3/class/basic/trait.PyObjectProtocol.html

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -4,7 +4,7 @@ use crate::{derive_utils::PyBaseTypeUtils, ffi, PyMethodDefType, PyNativeType};
 use std::{marker::PhantomData, thread};
 
 /// This type is used as a "dummy" type on which dtolnay specializations are
-/// applied to apply implementations from #[pymethods] & #[pyproto]
+/// applied to apply implementations from `#[pymethods]` & `#[pyproto]`
 pub struct PyClassImplCollector<T>(PhantomData<T>);
 
 impl<T> PyClassImplCollector<T> {

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -19,7 +19,7 @@ pub struct KeywordOnlyParameterDescription {
     pub required: bool,
 }
 
-/// Function argument specification for a #[pyfunction] or #[pymethod].
+/// Function argument specification for a `#[pyfunction]` or `#[pymethod]`.
 #[derive(Debug)]
 pub struct FunctionDescription {
     pub fname: &'static str,


### PR DESCRIPTION
I added `RUSTDOCFLAGS="-D warnings"` and fixed a couple of docs issues I discovered from it.