### PR TITLE
ci: fix nightly warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,7 +353,7 @@ macro_rules! py_run_impl {
             // panic before flushing. This is where this hack comes into place
             $py.run("import sys; sys.stderr.flush()", None, None)
                 .unwrap();
-            panic!($code.to_string())
+            panic!("{}", $code)
         }
     }};
 }

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -34,6 +34,7 @@ struct ClassWithDocs {
 
     /// Write-only property field
     #[pyo3(set)]
+    #[allow(dead_code)] // Rust detects field is never read
     writeonly: i32,
 }
 


### PR DESCRIPTION
This PR fixes the warnings seen in the coverage job, but doesn't fix the one test failure.

It looks like an upstream Rust bug; I was able to isolate the issue to an example which doesn't involve PyO3. https://github.com/rust-lang/rust/issues/82833

I think we might have to just accept the coverage job will be failing for a little while until upstream resolves.