### PR TITLE
Define missing import APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add FFI definition `PyCFunction_CheckExact` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - Add FFI definition `Py_IS_TYPE`. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 - Add FFI definition `_Py_InitializeMain`. [#1473](https://github.com/PyO3/pyo3/pull/1473)
+- Add FFI definitions from `cpython/import.h`.[#1475](https://github.com/PyO3/pyo3/pull/1475)
 - Add tuple and unit struct support for `#[pyclass]` macro. [#1504](https://github.com/PyO3/pyo3/pull/1504)
 
 ### Changed

--- a/src/ffi/cpython/import.rs
+++ b/src/ffi/cpython/import.rs
@@ -1,0 +1,71 @@
+use crate::ffi::{PyInterpreterState, PyObject};
+use std::os::raw::{c_char, c_int, c_uchar};
+
+// skipped PyInit__imp
+
+extern "C" {
+    pub fn _PyImport_IsInitialized(state: *mut PyInterpreterState) -> c_int;
+    // skipped _PyImport_GetModuleId
+    #[cfg(Py_3_7)]
+    pub fn _PyImport_SetModule(name: *mut PyObject, module: *mut PyObject) -> c_int;
+    #[cfg(Py_3_7)]
+    pub fn _PyImport_SetModuleString(name: *const c_char, module: *mut PyObject) -> c_int;
+    pub fn _PyImport_AcquireLock();
+    pub fn _PyImport_ReleaseLock() -> c_int;
+    #[cfg(not(Py_3_7))]
+    pub fn _PyImport_FindBuiltin(name: *const c_char) -> *mut PyObject;
+    #[cfg(all(Py_3_7, not(Py_3_9)))]
+    pub fn _PyImport_FindBuiltin(name: *const c_char, modules: *mut PyObject) -> *mut PyObject;
+    #[cfg(not(Py_3_10))]
+    pub fn _PyImport_FindExtensionObject(a: *mut PyObject, b: *mut PyObject) -> *mut PyObject;
+    #[cfg(not(Py_3_7))]
+    pub fn _PyImport_FixupBuiltin(module: *mut PyObject, name: *const c_char) -> c_int;
+    #[cfg(Py_3_7)]
+    pub fn _PyImport_FixupBuiltin(
+        module: *mut PyObject,
+        name: *const c_char,
+        modules: *mut PyObject,
+    ) -> c_int;
+    #[cfg(not(Py_3_7))]
+    pub fn _PyImport_FixupExtensionObject(
+        a: *mut PyObject,
+        b: *mut PyObject,
+        c: *mut PyObject,
+    ) -> c_int;
+    #[cfg(Py_3_7)]
+    pub fn _PyImport_FixupExtensionObject(
+        a: *mut PyObject,
+        b: *mut PyObject,
+        c: *mut PyObject,
+        d: *mut PyObject,
+    ) -> c_int;
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _inittab {
+    pub name: *const c_char,
+    pub initfun: Option<unsafe extern "C" fn() -> *mut PyObject>,
+}
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
+    pub static mut PyImport_Inittab: *mut _inittab;
+}
+
+extern "C" {
+    pub fn PyImport_ExtendInittab(newtab: *mut _inittab) -> c_int;
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _frozen {
+    name: *const c_char,
+    code: *const c_uchar,
+    size: c_int,
+}
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
+    pub static mut PyImport_FrozenModules: *const _frozen;
+}

--- a/src/ffi/cpython/mod.rs
+++ b/src/ffi/cpython/mod.rs
@@ -9,7 +9,7 @@ pub mod compile;
 pub mod dictobject;
 // skipped fileobject.h
 pub mod frameobject;
-// skipped import.h
+pub mod import;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub mod initconfig;
 // skipped interpreteridobject.h
@@ -28,6 +28,7 @@ pub use self::compile::*;
 #[cfg(not(PyPy))]
 pub use self::dictobject::*;
 pub use self::frameobject::*;
+pub use self::import::*;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub use self::initconfig::*;
 pub use self::listobject::*;


### PR DESCRIPTION
I need some of these APIs for the pyembed crate (used as part of
PyOxidizer). I figured I might as well define them all.

All these APIs are limited.

I don't have a PyPy install with a shared library to test. We may need to disable these when targeting PyPy.