### PR TITLE
Add context manager example to user guide

### DIFF
--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -261,7 +261,8 @@ class House(object):
 
         let result = py.eval("undefined_variable + 1", None, None);
         
-        // If the eval threw an exception we'll pass it through to the context manager. Otherwise, __exit__  is called with empty arguments.
+        // If the eval threw an exception we'll pass it through to the context manager. 
+        // Otherwise, __exit__  is called with empty arguments (Python "None").
         match result {
             Ok(_) => {
                 let none = py.None();

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -253,7 +253,7 @@ class House(object):
         else:
             print(f"Thank you for visiting {self.address}, come again soon!")
 
-        "#, "objects.py", "objects").unwrap();
+        "#, "house.py", "house").unwrap();
         
         let house = custom_manager.call_method1("House", ("123 Main Street",)).unwrap();
 

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -255,7 +255,7 @@ class House(object):
 
         "#, "house.py", "house").unwrap();
         
-        let house = custom_manager.call_method1("House", ("123 Main Street",)).unwrap();
+        let house = custom_manager.call_function1("House", ("123 Main Street",)).unwrap();
 
         house.call_method0("__enter__").unwrap();
 
@@ -266,10 +266,10 @@ class House(object):
         match result {
             Ok(_) => {
                 let none = py.None();
-                house.call_method1("__exit__", (&none, &none, &none)).unwrap();
+                house.call_function1("__exit__", (&none, &none, &none)).unwrap();
             },
             Err(e) => {
-                house.call_method1(
+                house.call_function1(
                     "__exit__",
                     (e.ptype(py), e.pvalue(py), e.ptraceback(py))
                 ).unwrap();

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -255,11 +255,13 @@ class House(object):
 
         "#, "objects.py", "objects").unwrap();
         
-        let house = custom_manager.call1("House", ("123 Main Street",)).unwrap();
+        let house = custom_manager.call_method1("House", ("123 Main Street",)).unwrap();
 
         house.call_method0("__enter__").unwrap();
 
         let result = py.eval("undefined_variable + 1", None, None);
+        
+        // If the eval threw an exception we'll pass it through to the context manager. Otherwise, __exit__  is called with empty arguments.
         match result {
             Ok(_) => {
                 let none = py.None();

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -266,10 +266,10 @@ class House(object):
         match result {
             Ok(_) => {
                 let none = py.None();
-                house.call_function1("__exit__", (&none, &none, &none)).unwrap();
+                house.call_method1("__exit__", (&none, &none, &none)).unwrap();
             },
             Err(e) => {
-                house.call_function1(
+                house.call_method1(
                     "__exit__",
                     (e.ptype(py), e.pvalue(py), e.ptraceback(py))
                 ).unwrap();

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -257,7 +257,7 @@ class House(object):
         
         let house = custom_manager.call_function1("House", ("123 Main Street",)).unwrap();
 
-        house.call_method0("__enter__").unwrap();
+        house.call_function0("__enter__").unwrap();
 
         let result = py.eval("undefined_variable + 1", None, None);
         

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -237,11 +237,11 @@ Use context managers by directly invoking `__enter__` and `__exit__`.
 
 ```rust
 use pyo3::prelude::*;
-use pyo3::types::{IntoPyDict, PyModule};
+use pyo3::types::PyModule;
 
 fn main() {   
     Python::with_gil(|py| {
-        let CustomManager = PyModule::from_code(py, r#"
+        let custom_manager = PyModule::from_code(py, r#"
 class House(object):
     def __init__(self, address):
         self.address = address
@@ -251,7 +251,7 @@ class House(object):
         print(f"Thank you for visiting {self.address}, come again soon!")
         "#, "objects.py", "objects").unwrap();
         
-        let house = CustomManager.call1("House", ("123 Main Street",)).unwrap();
+        let house = custom_manager.call1("House", ("123 Main Street",)).unwrap();
         house.call_method0("__enter__").unwrap();
         house.call_method1("__exit__", ("", "", "")).unwrap();
     })

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -248,12 +248,30 @@ class House(object):
     def __enter__(self):
         print(f"Welcome to {self.address}!")
     def __exit__(self, type, value, traceback):
-        print(f"Thank you for visiting {self.address}, come again soon!")
+        if type:
+            print(f"Sorry you had {type} trouble at {self.address}")
+        else:
+            print(f"Thank you for visiting {self.address}, come again soon!")
+
         "#, "objects.py", "objects").unwrap();
         
         let house = custom_manager.call1("House", ("123 Main Street",)).unwrap();
+
         house.call_method0("__enter__").unwrap();
-        house.call_method1("__exit__", ("", "", "")).unwrap();
+
+        let result = py.eval("undefined_variable + 1", None, None);
+        match result {
+            Ok(_) => {
+                let none = py.None();
+                house.call_method1("__exit__", (&none, &none, &none)).unwrap();
+            },
+            Err(e) => {
+                house.call_method1(
+                    "__exit__",
+                    (e.ptype(py), e.pvalue(py), e.ptraceback(py))
+                ).unwrap();
+            }
+        }
     })
 }
 ```

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -230,3 +230,30 @@ def leaky_relu(x, slope=0.01):
 
 [`Python::run`]: https://docs.rs/pyo3/latest/pyo3/struct.Python.html#method.run
 [`py_run!`]: https://docs.rs/pyo3/latest/pyo3/macro.py_run.html
+
+## Need to use a context manager from Rust?
+
+Use context managers by directly invoking `__enter__` and `__exit__`.
+
+```rust
+use pyo3::prelude::*;
+use pyo3::types::{IntoPyDict, PyModule};
+
+fn main() {   
+    Python::with_gil(|py| {
+        let CustomManager = PyModule::from_code(py, r#"
+class House(object):
+    def __init__(self, address):
+        self.address = address
+    def __enter__(self):
+        print(f"Welcome to {self.address}!")
+    def __exit__(self, type, value, traceback):
+        print(f"Thank you for visiting {self.address}, come again soon!")
+        "#, "objects.py", "objects").unwrap();
+        
+        let house = CustomManager.call1("House", ("123 Main Street",)).unwrap();
+        house.call_method0("__enter__").unwrap();
+        house.call_method1("__exit__", ("", "", "")).unwrap();
+    })
+}
+```

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -257,7 +257,7 @@ class House(object):
         
         let house = custom_manager.call_function1("House", ("123 Main Street",)).unwrap();
 
-        house.call_function0("__enter__").unwrap();
+        house.call_method0("__enter__").unwrap();
 
         let result = py.eval("undefined_variable + 1", None, None);
         


### PR DESCRIPTION
A simple illustrative example on how to use context managers. I required this to use pymc3, which relies heavily on the context stack for modelling.

My example has a gap in that it calls `__exit__` with blank arguments. I don't honestly know how to use it without them, or if I even need to call it at all. If anyone wants to add some detail there, I'd appreciate it!
