### PR TITLE
cargo.toml: don't use a glob for examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,5 +73,7 @@ nightly = []
 members = [
     "pyo3-macros",
     "pyo3-macros-backend",
-    "examples/*"
+    "examples/pyo3_benchmarks",
+    "examples/rustapi_module",
+    "examples/word-count"
 ]


### PR DESCRIPTION
Using a glob `examples/*` for workspace members means that if an additional folder gets created in the `examples` directory such as `.venv` or even macOS's autogenerated `.DS_Store` then `cargo` commands start failing:

```
david@david-laptop:~/dev/pyo3$ mkdir examples/foo
david@david-laptop:~/dev/pyo3$ cargo build
error: failed to read `/home/david/dev/pyo3/examples/foo/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
```

I think this is a footgun for users unfamiliar with the repository, so I just changed this to a hard-coded list.

Closes #1477
Closes #1478 
Closes #723

