### PR TITLE
pymethods: macros tidy-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix FFI definition `PyIndex_Check` missing with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 - Fix incorrect `TypeError` raised when keyword-only argument passed along with a positional argument in `*args`. [#1440](https://github.com/PyO3/pyo3/pull/1440)
 - Fix inability to use a named lifetime for `&PyTuple` of `*args` in `#[pyfunction]`. [#1440](https://github.com/PyO3/pyo3/pull/1440)
+- Fix inability to add `#[text_signature]` to some `#[pyproto]` methods. [#1483](https://github.com/PyO3/pyo3/pull/1483)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -208,7 +208,6 @@ pub fn add_fn_to_module(
                 pyo3::class::methods::PyMethodDef::cfunction_with_keywords(
                     name,
                     pyo3::class::methods::PyCFunctionWithKeywords(#wrapper_ident),
-                    0,
                     #doc,
                 ),
                 args.into(),

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2,9 +2,7 @@
 
 use crate::method::{FnType, SelfType};
 use crate::pyimpl::PyClassMethodsType;
-use crate::pymethod::{
-    impl_py_getter_def, impl_py_setter_def, impl_wrap_getter, impl_wrap_setter, PropertyType,
-};
+use crate::pymethod::{impl_py_getter_def, impl_py_setter_def, PropertyType};
 use crate::utils;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
@@ -508,18 +506,14 @@ fn impl_descriptors(
                     let name = field.ident.as_ref().unwrap().unraw();
                     let doc = utils::get_doc(&field.attrs, None, true)
                         .unwrap_or_else(|_| syn::LitStr::new(&name.to_string(), name.span()));
-
+                    let property_type = PropertyType::Descriptor(&field);
                     match desc {
-                        FnType::Getter(self_ty) => Ok(impl_py_getter_def(
-                            &name,
-                            &doc,
-                            &impl_wrap_getter(&cls, PropertyType::Descriptor(&field), &self_ty)?,
-                        )),
-                        FnType::Setter(self_ty) => Ok(impl_py_setter_def(
-                            &name,
-                            &doc,
-                            &impl_wrap_setter(&cls, PropertyType::Descriptor(&field), &self_ty)?,
-                        )),
+                        FnType::Getter(self_ty) => {
+                            impl_py_getter_def(cls, property_type, self_ty, &name, &doc)
+                        }
+                        FnType::Setter(self_ty) => {
+                            impl_py_setter_def(cls, property_type, self_ty, &name, &doc)
+                        }
                         _ => unreachable!(),
                     }
                 })

--- a/src/class/methods.rs
+++ b/src/class/methods.rs
@@ -82,7 +82,7 @@ unsafe impl Sync for PySetterDef {}
 
 impl PyMethodDef {
     /// Define a function with no `*args` and `**kwargs`.
-    pub const fn cfunction(name: &'static str, cfunction: PyCFunction, doc: &'static str) -> Self {
+    pub const fn noargs(name: &'static str, cfunction: PyCFunction, doc: &'static str) -> Self {
         Self {
             ml_name: name,
             ml_meth: PyMethodType::PyCFunction(cfunction),
@@ -95,15 +95,19 @@ impl PyMethodDef {
     pub const fn cfunction_with_keywords(
         name: &'static str,
         cfunction: PyCFunctionWithKeywords,
-        flags: c_int,
         doc: &'static str,
     ) -> Self {
         Self {
             ml_name: name,
             ml_meth: PyMethodType::PyCFunctionWithKeywords(cfunction),
-            ml_flags: flags | ffi::METH_VARARGS | ffi::METH_KEYWORDS,
+            ml_flags: ffi::METH_VARARGS | ffi::METH_KEYWORDS,
             ml_doc: doc,
         }
+    }
+
+    pub const fn flags(mut self, flags: c_int) -> Self {
+        self.ml_flags |= flags;
+        self
     }
 
     /// Convert `PyMethodDef` to Python method definition struct `ffi::PyMethodDef`

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -23,12 +23,7 @@ impl PyCFunction {
         py_or_module: PyFunctionArguments<'a>,
     ) -> PyResult<&'a Self> {
         Self::internal_new(
-            PyMethodDef::cfunction_with_keywords(
-                name,
-                methods::PyCFunctionWithKeywords(fun),
-                0,
-                doc,
-            ),
+            PyMethodDef::cfunction_with_keywords(name, methods::PyCFunctionWithKeywords(fun), doc),
             py_or_module,
         )
     }
@@ -41,7 +36,7 @@ impl PyCFunction {
         py_or_module: PyFunctionArguments<'a>,
     ) -> PyResult<&'a Self> {
         Self::internal_new(
-            PyMethodDef::cfunction(name, methods::PyCFunction(fun), doc),
+            PyMethodDef::noargs(name, methods::PyCFunction(fun), doc),
             py_or_module,
         )
     }

--- a/tests/test_dunder.rs
+++ b/tests/test_dunder.rs
@@ -109,6 +109,10 @@ fn string_methods() {
     py_assert!(py, obj, "repr(obj) == 'repr'");
     py_assert!(py, obj, "'{0:x}'.format(obj) == 'format(x)'");
     py_assert!(py, obj, "bytes(obj) == b'bytes'");
+
+    // Test that `__bytes__` takes no arguments (should be METH_NOARGS)
+    py_assert!(py, obj, "obj.__bytes__() == b'bytes'");
+    py_expect_exception!(py, obj, "obj.__bytes__('unexpected argument')", PyTypeError);
 }
 
 #[pyclass]


### PR DESCRIPTION
This is just a little bit of refactoring that I spotted could be done in the proc-macro code.

It allows re-use of a little bit more code between `#[pymethods]` and `#[pyproto]`, with the effect that "normal methods" in `#[pyproto]` such as `__bytes__` and `__enter__` can now be generated as `METH_NOARGS`, which I think should be a little bit better for performance.