### PR TITLE
pyfunction: reject generic functions

### DIFF
--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -63,8 +63,8 @@ pub fn gen_py_method(
     })
 }
 
-fn check_generic(sig: &syn::Signature) -> syn::Result<()> {
-    let err_msg = |typ| format!("a Python method can't have a generic {} parameter", typ);
+pub(crate) fn check_generic(sig: &syn::Signature) -> syn::Result<()> {
+    let err_msg = |typ| format!("Python functions cannot have generic {} parameters", typ);
     for param in &sig.generics.params {
         match param {
             syn::GenericParam::Lifetime(_) => {}

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -6,6 +6,7 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_need_module_arg_position.rs");
     t.compile_fail("tests/ui/invalid_property_args.rs");
     t.compile_fail("tests/ui/invalid_pyclass_args.rs");
+    t.compile_fail("tests/ui/invalid_pyfunctions.rs");
     t.compile_fail("tests/ui/invalid_pymethods.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
     t.compile_fail("tests/ui/invalid_argument_attributes.rs");

--- a/tests/ui/invalid_need_module_arg_position.stderr
+++ b/tests/ui/invalid_need_module_arg_position.stderr
@@ -1,5 +1,5 @@
 error: expected &PyModule as first argument with `pass_module`
- --> $DIR/invalid_need_module_arg_position.rs:6:13
+ --> $DIR/invalid_need_module_arg_position.rs:6:21
   |
 6 |     fn fail(string: &str, module: &PyModule) -> PyResult<&str> {
-  |             ^^^^^^
+  |                     ^

--- a/tests/ui/invalid_pyfunctions.rs
+++ b/tests/ui/invalid_pyfunctions.rs
@@ -1,0 +1,9 @@
+use pyo3::prelude::*;
+
+#[pyfunction]
+fn generic_function<T>(value: T) {}
+
+#[pyfunction]
+fn impl_trait_function(impl_trait: impl AsRef<PyAny>) {}
+
+fn main() {}

--- a/tests/ui/invalid_pyfunctions.stderr
+++ b/tests/ui/invalid_pyfunctions.stderr
@@ -1,0 +1,11 @@
+error: Python functions cannot have generic type parameters
+ --> $DIR/invalid_pyfunctions.rs:4:21
+  |
+4 | fn generic_function<T>(value: T) {}
+  |                     ^
+
+error: Python functions cannot have `impl Trait` arguments
+ --> $DIR/invalid_pyfunctions.rs:7:36
+  |
+7 | fn impl_trait_function(impl_trait: impl AsRef<PyAny>) {}
+  |                                    ^^^^

--- a/tests/ui/invalid_pymethods.rs
+++ b/tests/ui/invalid_pymethods.rs
@@ -81,5 +81,20 @@ impl MyClass {
     fn multiple_method_types() {}
 }
 
+#[pymethods]
+impl MyClass {
+    fn generic_method<T>(value: T) {}
+}
+
+
+#[pymethods]
+impl MyClass {
+    fn impl_trait_method_first_arg(impl_trait: impl AsRef<PyAny>) {}
+}
+
+#[pymethods]
+impl MyClass {
+    fn impl_trait_method_second_arg(&self, impl_trait: impl AsRef<PyAny>) {}
+}
 
 fn main() {}

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -10,7 +10,7 @@ error: static method needs #[staticmethod] attribute
 14 |     fn staticmethod_without_attribute() {}
    |     ^^
 
-error: unexpected receiver for method
+error: unexpected receiver
   --> $DIR/invalid_pymethods.rs:20:35
    |
 20 |     fn staticmethod_with_receiver(&self) {}
@@ -63,3 +63,21 @@ error: cannot specify a second method type
    |
 80 |     #[staticmethod]
    |       ^^^^^^^^^^^^
+
+error: Python functions cannot have generic type parameters
+  --> $DIR/invalid_pymethods.rs:86:23
+   |
+86 |     fn generic_method<T>(value: T) {}
+   |                       ^
+
+error: Python functions cannot have `impl Trait` arguments
+  --> $DIR/invalid_pymethods.rs:92:48
+   |
+92 |     fn impl_trait_method_first_arg(impl_trait: impl AsRef<PyAny>) {}
+   |                                                ^^^^
+
+error: Python functions cannot have `impl Trait` arguments
+  --> $DIR/invalid_pymethods.rs:97:56
+   |
+97 |     fn impl_trait_method_second_arg(&self, impl_trait: impl AsRef<PyAny>) {}
+   |                                                        ^^^^


### PR DESCRIPTION
This improves the error message noted in #1480 when using generics with `#[pyfunction]`.