### PR TITLE
Use _PYTHON_SYSCONFIGDATA_NAME in find_sysconfigdata when cross-compiling

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -407,12 +407,18 @@ fn find_sysconfigdata(cross: &CrossCompileConfig) -> Result<PathBuf> {
             "Could not find either libpython.so or _sysconfigdata*.py in {}",
             cross.lib_dir.display()
         );
-    } else if sysconfig_paths.len() > 1 {
-        bail!(
-            "Detected multiple possible python versions, please set the PYO3_PYTHON_VERSION \
-            variable to the wanted version on your system\nsysconfigdata paths = {:?}",
-            sysconfig_paths
-        )
+    } else {
+        if let Some(sysconfig_name) = env::var_os("_PYTHON_SYSCONFIGDATA_NAME") {
+            sysconfig_paths.retain(|p| *p == Path::new(&sysconfig_name).with_extension("py"));
+        }
+        if sysconfig_paths.len() > 1 {
+            bail!(
+                "Detected multiple possible python versions, please set the PYO3_PYTHON_VERSION \
+                variable to the wanted version on your system or set the _PYTHON_SYSCONFIGDATA_NAME \
+                variable to the wanted sysconfigdata file name\nsysconfigdata paths = {:?}",
+                sysconfig_paths
+            )
+        }
     }
 
     Ok(sysconfig_paths.remove(0))

--- a/build.rs
+++ b/build.rs
@@ -401,9 +401,11 @@ fn find_sysconfigdata(cross: &CrossCompileConfig) -> Result<PathBuf> {
     let mut sysconfig_paths = sysconfig_paths
         .iter()
         .filter_map(|p| {
-            fs::canonicalize(p)
-                .ok()
-                .filter(|p| p.file_stem() == sysconfig_name.as_deref())
+            let canonical = fs::canonicalize(p).ok();
+            match &sysconfig_name {
+                Some(_) => canonical.filter(|p| p.file_stem() == sysconfig_name.as_deref()),
+                None => canonical,
+            }
         })
         .collect::<Vec<PathBuf>>();
     sysconfig_paths.dedup();


### PR DESCRIPTION
Fixes #1484 

CPython reference code: 
1. https://hg.python.org/cpython/rev/04b679dd11eb
2. https://github.com/python/cpython/blob/b4f9089d4aa787c5b74134c98e5f0f11d9e63095/Lib/sysconfig.py#L366-L372