### PR TITLE
main: tweaks from rename

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -9,7 +9,7 @@ When reporting a bug, please provide the following information. If this is not a
  - How did you install python (e.g. apt or pyenv)? Did you use a virtualenv?:
  - Your Rust version (`rustc --version`):
  - Your PyO3 version:
- - Have you tried using latest PyO3 master (replace `version = "0.x.y"` with `git = "https://github.com/PyO3/pyo3")?`:
+ - Have you tried using latest PyO3 main (replace `version = "0.x.y"` with `git = "https://github.com/PyO3/pyo3")?`:
 
 ### 💥 Reproducing
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 env:

--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -3,7 +3,7 @@ name: gh-pages
 on:
   push:
     branches:
-      - master
+      - main
   release:
     types: [published]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file. For help with updating to new
-PyO3 versions, please see the [migration guide](https://pyo3.rs/master/migration.html).
+PyO3 versions, please see the [migration guide](https://pyo3.rs/main/migration.html).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # PyO3
 
 [![Actions Status](https://github.com/PyO3/pyo3/workflows/Test/badge.svg)](https://github.com/PyO3/pyo3/actions)
-[![codecov](https://codecov.io/gh/PyO3/pyo3/branch/master/graph/badge.svg)](https://codecov.io/gh/PyO3/pyo3)
+[![codecov](https://codecov.io/gh/PyO3/pyo3/branch/main/graph/badge.svg)](https://codecov.io/gh/PyO3/pyo3)
 [![crates.io](http://meritbadge.herokuapp.com/pyo3)](https://crates.io/crates/pyo3)
 [![minimum rustc 1.41](https://img.shields.io/badge/rustc-1.41+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![Join the dev chat](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/PyO3/Lobby)
 
 [Rust](http://www.rust-lang.org/) bindings for [Python](https://www.python.org/). This includes running and interacting with Python code from a Rust binary, as well as writing native Python modules.
 
-* User Guide: [stable](https://pyo3.rs) | [master](https://pyo3.rs/master)
+* User Guide: [stable](https://pyo3.rs) | [main](https://pyo3.rs/main)
 
-* API Documentation: [stable](https://docs.rs/pyo3/) |  [master](https://pyo3.rs/master/doc)
+* API Documentation: [stable](https://docs.rs/pyo3/) |  [main](https://pyo3.rs/main/doc)
 
-* Contributing Notes: [github](https://github.com/PyO3/pyo3/blob/master/Contributing.md)
+* Contributing Notes: [github](https://github.com/PyO3/pyo3/blob/main/Contributing.md)
 
-A comparison with rust-cpython can be found [in the guide](https://pyo3.rs/master/rust_cpython.html).
+A comparison with rust-cpython can be found [in the guide](https://pyo3.rs/main/rust_cpython.html).
 
 ## Usage
 
 PyO3 supports Python 3.6 and up. The minimum required Rust version is 1.41.
 
 Building with PyPy is also possible (via cpyext) for Python 3.6, targeted PyPy version is 7.3+.
-Please refer to the [pypy section in the guide](https://pyo3.rs/master/building_and_distribution/pypy.html).
+Please refer to the [pypy section in the guide](https://pyo3.rs/main/building_and_distribution/pypy.html).
 
 You can either write a native Python module in Rust, or use Python from a Rust binary.
 
@@ -96,7 +96,7 @@ rustflags = [
 
 While developing, you can symlink (or copy) and rename the shared library from the target folder: On MacOS, rename `libstring_sum.dylib` to `string_sum.so`, on Windows `libstring_sum.dll` to `string_sum.pyd`, and on Linux `libstring_sum.so` to `string_sum.so`. Then open a Python shell in the same folder and you'll be able to `import string_sum`.
 
-To build, test and publish your crate as a Python module, you can use [maturin](https://github.com/PyO3/maturin) or [setuptools-rust](https://github.com/PyO3/setuptools-rust). You can find an example for setuptools-rust in [examples/word-count](https://github.com/PyO3/pyo3/tree/master/examples/word-count), while maturin should work on your crate without any configuration.
+To build, test and publish your crate as a Python module, you can use [maturin](https://github.com/PyO3/maturin) or [setuptools-rust](https://github.com/PyO3/setuptools-rust). You can find an example for setuptools-rust in [examples/word-count](https://github.com/PyO3/pyo3/tree/main/examples/word-count), while maturin should work on your crate without any configuration.
 
 ## Using Python from Rust
 
@@ -136,7 +136,7 @@ fn main_(py: Python) -> PyResult<()> {
 }
 ```
 
-Our guide has [a section](https://pyo3.rs/master/python_from_rust.html) with lots of examples
+Our guide has [a section](https://pyo3.rs/main/python_from_rust.html) with lots of examples
 about this topic.
 
 ## Tools and libraries
@@ -152,7 +152,7 @@ about this topic.
 ## Examples
 
  * [hyperjson](https://github.com/mre/hyperjson) _A hyper-fast Python module for reading/writing JSON data using Rust's serde-json_
- * [html-py-ever](https://github.com/PyO3/setuptools-rust/tree/master/examples/html-py-ever) _Using [html5ever](https://github.com/servo/html5ever) through [kuchiki](https://github.com/kuchiki-rs/kuchiki) to speed up html parsing and css-selecting._
+ * [html-py-ever](https://github.com/PyO3/setuptools-rust/tree/main/examples/html-py-ever) _Using [html5ever](https://github.com/servo/html5ever) through [kuchiki](https://github.com/kuchiki-rs/kuchiki) to speed up html parsing and css-selecting._
  * [point-process](https://github.com/ManifoldFR/point-process-rust/tree/master/pylib) _High level API for pointprocesses as a Python library_
  * [autopy](https://github.com/autopilot-rs/autopy) _A simple, cross-platform GUI automation library for Python and Rust._
    * Contains an example of building wheels on TravisCI and appveyor using [cibuildwheel](https://github.com/joerick/cibuildwheel)
@@ -167,7 +167,7 @@ about this topic.
  * [pyre](https://github.com/Project-Dream-Weaver/Pyre) _Fast Python HTTP server written in Rust_
  * [jsonschema-rs](https://github.com/Stranger6667/jsonschema-rs/tree/master/bindings/python) _Fast JSON Schema validation library_
  * [css-inline](https://github.com/Stranger6667/css-inline/tree/master/bindings/python) _CSS inlining for Python implemented in Rust_
- * [cryptography](https://github.com/pyca/cryptography/tree/master/src/rust) _Python cryptography library with some functionality in Rust_
+ * [cryptography](https://github.com/pyca/cryptography/tree/main/src/rust) _Python cryptography library with some functionality in Rust_
  * [polaroid](https://github.com/daggy1234/polaroid) _Hyper Fast and safe image manipulation library for Python written in Rust_
 
 ## License

--- a/guide/src/parallelism.md
+++ b/guide/src/parallelism.md
@@ -2,7 +2,7 @@
 
 CPython has the infamous [Global Interpreter Lock](https://docs.python.org/3/glossary.html#term-global-interpreter-lock), which prevents several threads from executing Python bytecode in parallel. This makes threading in Python a bad fit for [CPU-bound](https://stackoverflow.com/questions/868568/) tasks and often forces developers to accept the overhead of multiprocessing.
 
-In PyO3 parallelism can be easily achieved in Rust-only code. Let's take a look at our [word-count](https://github.com/PyO3/pyo3/blob/master/examples/word-count/src/lib.rs) example, where we have a `search` function that utilizes the [rayon](https://github.com/nikomatsakis/rayon) crate to count words in parallel.
+In PyO3 parallelism can be easily achieved in Rust-only code. Let's take a look at our [word-count](https://github.com/PyO3/pyo3/blob/main/examples/word-count/src/lib.rs) example, where we have a `search` function that utilizes the [rayon](https://github.com/nikomatsakis/rayon) crate to count words in parallel.
 ```rust, ignore
 #[pyfunction]
 fn search(contents: &str, needle: &str) -> usize {
@@ -56,7 +56,7 @@ We are using `pytest-benchmark` to benchmark four word count functions:
 3. Rust sequential version
 4. Rust sequential version executed twice with two Python threads
 
-The benchmark script can be found [here](https://github.com/PyO3/pyo3/blob/master/examples/word-count/tests/test_word_count.py), and we can run `tox` in the `word-count` folder to benchmark these functions.
+The benchmark script can be found [here](https://github.com/PyO3/pyo3/blob/main/examples/word-count/tests/test_word_count.py), and we can run `tox` in the `word-count` folder to benchmark these functions.
 
 While the results of the benchmark of course depend on your machine, the relative results should be similar to this (mid 2020):
 ```ignore

--- a/guide/src/parallelism.md
+++ b/guide/src/parallelism.md
@@ -2,7 +2,7 @@
 
 CPython has the infamous [Global Interpreter Lock](https://docs.python.org/3/glossary.html#term-global-interpreter-lock), which prevents several threads from executing Python bytecode in parallel. This makes threading in Python a bad fit for [CPU-bound](https://stackoverflow.com/questions/868568/) tasks and often forces developers to accept the overhead of multiprocessing.
 
-In PyO3 parallelism can be easily achieved in Rust-only code. Let's take a look at our [word-count](https://github.com/PyO3/pyo3/blob/main/examples/word-count/src/lib.rs) example, where we have a `search` function that utilizes the [rayon](https://github.com/nikomatsakis/rayon) crate to count words in parallel.
+In PyO3 parallelism can be easily achieved in Rust-only code. Let's take a look at our [word-count](https://github.com/PyO3/pyo3/blob/main/examples/word-count/src/lib.rs) example, where we have a `search` function that utilizes the [rayon](https://github.com/rayon-rs/rayon) crate to count words in parallel.
 ```rust, ignore
 #[pyfunction]
 fn search(contents: &str, needle: &str) -> usize {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -41,12 +41,12 @@ pub unsafe trait PyNativeType: Sized {
 ///  - [`Py::borrow`](#method.borrow), [`Py::try_borrow`](#method.try_borrow),
 ///    [`Py::borrow_mut`](#method.borrow_mut), or [`Py::try_borrow_mut`](#method.try_borrow_mut),
 ///    to directly access a `#[pyclass]` value (which has RefCell-like behavior, see
-///    [the `PyCell` guide entry](https://pyo3.rs/master/class.html#pycell-and-interior-mutability)
+///    [the `PyCell` guide entry](https://pyo3.rs/main/class.html#pycell-and-interior-mutability)
 ///    ).
 ///  - Use methods directly on `Py`, such as [`Py::call`](#method.call) and
 ///    [`Py::call_method`](#method.call_method).
 ///
-/// See [the guide](https://pyo3.rs/master/types.html) for an explanation
+/// See [the guide](https://pyo3.rs/main/types.html) for an explanation
 /// of the different Python object types.
 #[repr(transparent)]
 pub struct Py<T>(NonNull<ffi::PyObject>, PhantomData<T>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! a function can assume that the GIL is held.  In Rust, we use different types
 //! to represent a reference to a Python object, depending on whether we know
 //! the GIL is held, and depending on whether we know the underlying type.  See
-//! [the guide](https://pyo3.rs/master/types.html) for an explanation of
+//! [the guide](https://pyo3.rs/main/types.html) for an explanation of
 //! the different Python object types.
 //!
 //! A `Python` instance is either obtained explicitly by acquiring the GIL,

--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -6,7 +6,7 @@ use std::cell::UnsafeCell;
 /// Unlike `once_cell::sync` which blocks threads to achieve thread safety, this implementation
 /// uses the Python GIL to mediate concurrent access. This helps in cases where `once_sync` or
 /// `lazy_static`'s synchronization strategy can lead to deadlocks when interacting with the Python
-/// GIL. For an example, see [the FAQ section](https://pyo3.rs/master/faq.html) of the guide.
+/// GIL. For an example, see [the FAQ section](https://pyo3.rs/main/faq.html) of the guide.
 ///
 /// # Example
 ///

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -20,7 +20,7 @@ use std::os::raw::c_int;
 /// `PyAny` is used as a reference with a lifetime that represents that the GIL
 /// is held, therefore its API does not require a `Python<'py>` token.
 ///
-/// See [the guide](https://pyo3.rs/master/types.html) for an explanation
+/// See [the guide](https://pyo3.rs/main/types.html) for an explanation
 /// of the different Python object types.
 ///
 /// # Example


### PR DESCRIPTION
Following the rename of `master` to `main`, this PR just adjusts some documentation, CI etc.

Closes #1130 