### PR TITLE
Ignore `syn::Type::Group` in `is_python`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix incorrect `TypeError` raised when keyword-only argument passed along with a positional argument in `*args`. [#1440](https://github.com/PyO3/pyo3/pull/1440)
 - Fix inability to use a named lifetime for `&PyTuple` of `*args` in `#[pyfunction]`. [#1440](https://github.com/PyO3/pyo3/pull/1440)
 - Fix inability to add `#[text_signature]` to some `#[pyproto]` methods. [#1483](https://github.com/PyO3/pyo3/pull/1483)
+- Fix use of Python argument for #[pymethods] inside macro expansions. [#1505](https://github.com/PyO3/pyo3/pull/1505)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -27,7 +27,11 @@ macro_rules! ensure_spanned {
 }
 
 /// Check if the given type `ty` is `pyo3::Python`.
-pub fn is_python(ty: &syn::Type) -> bool {
+pub fn is_python(mut ty: &syn::Type) -> bool {
+    while let syn::Type::Group(group) = ty {
+        // Macros can create invisible delimiters around types.
+        ty = &*group.elem;
+    }
     match ty {
         syn::Type::Path(typath) => typath
             .path

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -727,3 +727,29 @@ fn test_raw_idents() {
         );
     })
 }
+
+// Regression test for issue 1505 - Python argument not detected correctly when inside a macro.
+
+#[pyclass]
+struct Issue1505 {}
+
+macro_rules! issue_1505 {
+    (
+        #[pymethods]
+        impl $ty: ty {
+            fn $fn:ident (&self, $arg:ident : $arg_ty:ty) {}
+        }
+    ) => {
+        #[pymethods]
+        impl $ty {
+            fn $fn(&self, $arg: $arg_ty) {}
+        }
+    };
+}
+
+issue_1505!(
+    #[pymethods]
+    impl Issue1505 {
+        fn issue_1505(&self, _py: Python<'_>) {}
+    }
+);


### PR DESCRIPTION
Macro expansion can add invisible delimiters around types, modelled by `syn::Type::Group` in `syn`. This causes the following code to fail to compile:
```rust
#[pyclass]
struct Foo {}

macro_rules! foo {
    (
        #[pymethods]
        impl $ty: ty {
            fn $fn:ident (&self, $arg:ident : $arg_ty:ty) {}
        }
    ) => {
        #[pymethods]
        impl $ty {
            fn $fn(&self, $arg: $arg_ty) {}
        }
    };
}

foo!(
    #[pymethods]
    impl Foo {
        fn foo(&self, py: Python<'_>) {}
    }
);
```

> error[E0277]: the trait bound `pyo3::Python<'_>: PyClass` is not satisfied

because `pyo3` does not "see" the special `py` argument.
