### PR TITLE
Allow `#[name]` with `#[getter]` and `#[setter]`

### DIFF
--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -78,6 +78,12 @@ impl EmptyClass2 {
     #[staticmethod]
     #[name = "custom_static"]
     fn bar_static() {}
+
+    #[getter]
+    #[name = "custom_getter"]
+    fn foo(&self) -> i32 {
+        5
+    }
 }
 
 #[test]
@@ -92,8 +98,14 @@ fn custom_names() {
         typeobj,
         "typeobj.custom_static.__name__ == 'custom_static'"
     );
+    py_assert!(
+        py,
+        typeobj,
+        "typeobj.custom_getter.__name__ == 'custom_getter'"
+    );
     py_assert!(py, typeobj, "not hasattr(typeobj, 'bar')");
     py_assert!(py, typeobj, "not hasattr(typeobj, 'bar_static')");
+    py_assert!(py, typeobj, "not hasattr(typeobj, 'foo')");
 }
 
 #[pyclass]

--- a/tests/ui/invalid_pymethod_names.stderr
+++ b/tests/ui/invalid_pymethod_names.stderr
@@ -1,4 +1,4 @@
-error: name not allowed with this method type
+error: name cannot be specified twice
   --> $DIR/invalid_pymethod_names.rs:10:5
    |
 10 |     #[name = "num"]


### PR DESCRIPTION
A custom name can now be specified either via `#[getter(custom_name)]` or `#[name = "custom_name"]` like normal methods.

It's easier to have this kind of uniformity when dealing with code generation.
