### PR TITLE
Correct `# Examples` in documents

### DIFF
--- a/src/class/iter.rs
+++ b/src/class/iter.rs
@@ -12,7 +12,7 @@ use crate::{ffi, IntoPy, IntoPyPointer, PyClass, PyObject, Python};
 /// Check [CPython doc](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_iter)
 /// for more.
 ///
-/// # Example
+/// # Examples
 /// The following example shows how to implement a simple Python iterator in Rust which yields
 /// the integers 1 to 5, before raising `StopIteration("Ended")`.
 ///

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -14,7 +14,7 @@ use std::ptr::NonNull;
 ///
 /// This trait is implemented for types that internally wrap a pointer to a Python object.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use pyo3::{AsPyPointer, prelude::*};

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -110,7 +110,7 @@ impl PyErr {
     /// instance of that type.
     /// Otherwise, a `TypeError` is created instead.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use pyo3::{Python, PyErr, IntoPy, exceptions::PyTypeError, types::PyType};
     /// Python::with_gil(|py| {
@@ -155,7 +155,7 @@ impl PyErr {
     ///
     /// The object will be normalized first if needed.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use pyo3::{Python, PyErr, exceptions::PyTypeError, types::PyType};
     /// Python::with_gil(|py| {
@@ -171,7 +171,7 @@ impl PyErr {
     ///
     /// The object will be normalized first if needed.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use pyo3::{Python, PyErr, exceptions::PyTypeError, types::PyType};
     /// Python::with_gil(|py| {
@@ -188,7 +188,7 @@ impl PyErr {
     ///
     /// The object will be normalized first if needed.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use pyo3::{Python, PyErr, exceptions::PyTypeError, types::PyType};
     /// Python::with_gil(|py| {
@@ -375,7 +375,7 @@ impl PyErr {
 
     /// Clone the PyErr. This requires the GIL, which is why PyErr does not implement Clone.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use pyo3::{Python, PyErr, exceptions::PyTypeError, types::PyType};
     /// Python::with_gil(|py| {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -51,7 +51,7 @@ macro_rules! impl_exception_boilerplate {
 /// * `module` is the name of the containing module.
 /// * `MyError` is the name of the new exception type.
 ///
-/// # Example
+/// # Examples
 /// ```
 /// use pyo3::import_exception;
 /// use pyo3::types::IntoPyDict;
@@ -127,7 +127,7 @@ macro_rules! import_exception {
 /// * `MyError` is the name of the new exception type.
 /// * `BaseException` is the superclass of `MyError`, usually `pyo3::exceptions::PyException`.
 ///
-/// # Example
+/// # Examples
 /// ```
 /// use pyo3::prelude::*;
 /// use pyo3::create_exception;

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -58,7 +58,7 @@ pub(crate) fn gil_is_acquired() -> bool {
 ///   thread (the thread which originally initialized Python) also initializes
 ///   threading.
 ///
-/// # Example
+/// # Examples
 /// ```rust
 /// use pyo3::prelude::*;
 ///
@@ -124,7 +124,7 @@ pub fn prepare_freethreaded_python() {
 /// - No Python APIs can be used after this function has finished executing.
 /// - The return value of the closure must not contain any Python value, _including_ `PyResult`.
 ///
-/// # Example
+/// # Examples
 /// ```rust
 /// use pyo3::prelude::*;
 ///
@@ -181,7 +181,7 @@ where
 /// RAII type that represents the Global Interpreter Lock acquisition. To get hold of a value of
 /// this type, see [`Python::acquire_gil`](struct.Python.html#method.acquire_gil).
 ///
-/// # Example
+/// # Examples
 /// ```
 /// use pyo3::Python;
 ///

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -113,7 +113,7 @@ where
     /// Python object reference in PyO3's object storage. The reference count for the Python
     /// object will not be decreased until the GIL lifetime ends.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// Useful when returning GIL-bound references from functions. In the snippet below, note that
     /// the `'py` lifetime of the input GIL lifetime is also given to the returned reference:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! A `PyErr` represents a Python exception. Errors within the `PyO3` library are
 //! also exposed as Python exceptions.
 //!
-//! # Example
+//! # Examples
 //!
 //! ## Using Rust from Python
 //!
@@ -286,7 +286,7 @@ macro_rules! wrap_pymodule {
 
 /// A convenient macro to execute a Python code snippet, with some local variables set.
 ///
-/// # Example
+/// # Examples
 /// ```
 /// use pyo3::{prelude::*, py_run, types::PyList};
 /// Python::with_gil(|py| {
@@ -297,7 +297,7 @@ macro_rules! wrap_pymodule {
 ///
 /// You can use this macro to test pyfunctions or pyclasses quickly.
 ///
-/// # Example
+/// # Examples
 /// ```
 /// use pyo3::{prelude::*, py_run, PyCell};
 /// #[pyclass]

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -18,7 +18,7 @@ pub const VERSION: i32 = 4;
 ///
 /// See the [Python documentation](https://docs.python.org/3/library/marshal.html) for more details.
 ///
-/// # Example:
+/// # Examples
 /// ```
 /// # use pyo3::{marshal, types::PyDict};
 /// # let gil = pyo3::Python::acquire_gil();

--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -8,7 +8,7 @@ use std::cell::UnsafeCell;
 /// `lazy_static`'s synchronization strategy can lead to deadlocks when interacting with the Python
 /// GIL. For an example, see [the FAQ section](https://pyo3.rs/main/faq.html) of the guide.
 ///
-/// # Example
+/// # Examples
 ///
 /// The following example shows how to use `GILOnceCell` to share a reference to a Python list
 /// between threads:

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -456,7 +456,7 @@ impl<T: PyClass + fmt::Debug> fmt::Debug for PyCell<T> {
 /// Wraps a borrowed reference to a value in a `PyCell<T>`.
 ///
 /// See the [`PyCell`](struct.PyCell.html) documentation for more.
-/// # Example
+/// # Examples
 /// You can use `PyRef` as an alternative of `&self` receiver when
 /// - You need to access the pointer of `PyCell`.
 /// - You want to get super class.

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -25,7 +25,7 @@ impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
 ///
 /// You can use this type to initalize complicatedly nested `#[pyclass]`.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// # use pyo3::prelude::*;
@@ -79,7 +79,7 @@ impl<T: PyClass> PyClassInitializer<T> {
 
     /// Constructs a new initializer from base class' initializer.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use pyo3::prelude::*;
     /// #[pyclass]

--- a/src/python.rs
+++ b/src/python.rs
@@ -140,7 +140,7 @@ impl Python<'_> {
     /// - If the `auto-initialize` feature is not enabled and the Python interpreter is not
     ///   initialized.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use pyo3::prelude::*;
     /// Python::with_gil(|py| -> PyResult<()> {
@@ -187,7 +187,7 @@ impl<'p> Python<'p> {
 
     /// Temporarily releases the `GIL`, thus allowing other Python threads to run.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use pyo3::prelude::*; use pyo3::types::IntoPyDict; use pyo3::wrap_pyfunction;
     /// use pyo3::exceptions::PyRuntimeError;
@@ -234,7 +234,7 @@ impl<'p> Python<'p> {
     /// do much with those without a `Python<'p>` token, for which you'd need to
     /// reacquire the GIL.
     ///
-    /// # Example
+    /// # Examples
     /// ```compile_fail
     /// # use pyo3::prelude::*;
     /// # use pyo3::types::PyString;
@@ -277,7 +277,7 @@ impl<'p> Python<'p> {
     /// If `globals` is `None`, it defaults to Python module `__main__`.
     /// If `locals` is `None`, it defaults to the value of `globals`.
     ///
-    /// # Example:
+    /// # Examples
     /// ```
     /// # use pyo3::{types::{PyBytes, PyDict}, prelude::*};
     /// # let gil = pyo3::Python::acquire_gil();
@@ -300,7 +300,7 @@ impl<'p> Python<'p> {
     /// If `globals` is `None`, it defaults to Python module `__main__`.
     /// If `locals` is `None`, it defaults to the value of `globals`.
     ///
-    /// # Example:
+    /// # Examples
     /// ```
     /// use pyo3::{types::{PyBytes, PyDict}, prelude::*};
     /// let gil = pyo3::Python::acquire_gil();
@@ -398,7 +398,7 @@ impl<'p> Python<'p> {
     ///
     /// This is a wrapper around the ffi call Py_GetVersion.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// # use pyo3::Python;
     /// Python::with_gil(|py| {
@@ -418,7 +418,7 @@ impl<'p> Python<'p> {
     /// Gets the running Python interpreter version as a struct similar to
     /// `sys.version_info`.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// # use pyo3::Python;
     /// Python::with_gil(|py| {
@@ -599,7 +599,7 @@ impl<'p> Python<'p> {
     /// to use this API to clear memory, as PyO3 usually does not clear memory until the GIL is
     /// released.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// # use pyo3::prelude::*;
     /// let gil = Python::acquire_gil();

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -23,7 +23,7 @@ use std::os::raw::c_int;
 /// See [the guide](https://pyo3.rs/main/types.html) for an explanation
 /// of the different Python object types.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use pyo3::prelude::*;
@@ -250,7 +250,7 @@ impl PyAny {
     ///
     /// This is equivalent to the Python expression `self.name(*args, **kwargs)`.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// # use pyo3::prelude::*;
     /// use pyo3::types::IntoPyDict;

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -28,7 +28,7 @@ impl PyByteArray {
     /// * If `init` returns `Err(e)`, `new_with` will return `Err(e)`.
     /// * If `init` returns `Ok(())`, `new_with` will return `Ok(&PyByteArray)`.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use pyo3::{prelude::*, types::PyByteArray};
     /// Python::with_gil(|py| -> PyResult<()> {
@@ -128,7 +128,7 @@ impl PyByteArray {
 
     /// Copies the contents of the bytearray to a Rust vector.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// # use pyo3::prelude::*;

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -33,7 +33,7 @@ impl PyBytes {
     /// * If `init` returns `Err(e)`, `new_with` will return `Err(e)`.
     /// * If `init` returns `Ok(())`, `new_with` will return `Ok(&PyBytes)`.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use pyo3::{prelude::*, types::PyBytes};
     /// Python::with_gil(|py| -> PyResult<()> {

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -8,7 +8,7 @@ use crate::{PyDowncastError, PyTryFrom};
 
 /// A Python iterator object.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```rust
 /// # use pyo3::prelude::*;


### PR DESCRIPTION
https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html#documenting-components

It looks like that `# Examples` is recommended even for an example.