### PR TITLE
build.rs: adjust pypy warning wording

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -806,7 +806,7 @@ fn configure(interpreter_config: &InterpreterConfig) -> Result<()> {
         println!("cargo:rustc-cfg=PyPy");
         if is_abi3 {
             warn!(
-                "PyPy does not yet support abi3 so the resulting wheel will be version-specific. \
+                "PyPy does not yet support abi3 so the build artifacts will be version-specific. \
                 See https://foss.heptapod.net/pypy/pypy/-/issues/3397 for more information."
             )
         }


### PR DESCRIPTION
Strictly speaking, the pyo3 build step just produces a `.so` file - it's up to the packaging tool (`setuptools-rust` or `maturin`, most likely) to name the `.so` file and the wheel, which really determines whether pypi considers it a "version-specific" wheel.

So I think the wording in the pypy abi3 warning could be tweaked slightly.