### PR TITLE
1506: fixes to macro hygiene

### DIFF
--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -225,17 +225,18 @@ fn function_c_wrapper(
         };
         slf_module = None;
     };
-    let body = impl_arg_params(spec, None, cb)?;
+    let py = syn::Ident::new("_py", Span::call_site());
+    let body = impl_arg_params(spec, None, cb, &py)?;
     Ok(quote! {
         unsafe extern "C" fn #wrapper_ident(
             _slf: *mut pyo3::ffi::PyObject,
             _args: *mut pyo3::ffi::PyObject,
             _kwargs: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
         {
-            pyo3::callback::handle_panic(|_py| {
+            pyo3::callback::handle_panic(|#py| {
                 #slf_module
-                let _args = _py.from_borrowed_ptr::<pyo3::types::PyTuple>(_args);
-                let _kwargs: Option<&pyo3::types::PyDict> = _py.from_borrowed_ptr_or_opt(_kwargs);
+                let _args = #py.from_borrowed_ptr::<pyo3::types::PyTuple>(_args);
+                let _kwargs: Option<&pyo3::types::PyDict> = #py.from_borrowed_ptr_or_opt(_kwargs);
 
                 #body
             })


### PR DESCRIPTION
Fixes #1506 

Introducing `quote_spanned` improved the error messages for a number of common cases, but it came at the downside of changing the span of parts of our generated code.

If not careful, when expanding macros we can get issues where some of the code comes from one context and the rest from another.

This PR makes two changes to resolve some cases identified in #1506:
 - The `_py` ident is created once and shared around the macro code, so that it's not possible to make `_py` expand in two different contexts by accident. Similar for `output`.
 - A few more uses of `quote_spanned!` inside `impl_arg_param`.