### PR TITLE
macos: automatically provide required linker arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `auto-initialize` feature is no longer enabled by default. [#1443](https://github.com/PyO3/pyo3/pull/1443)
 - Change `PyCFunction::new()` and `PyCFunction::new_with_keywords()` to take `&'static str` arguments rather than implicitly copying (and leaking) them. [#1450](https://github.com/PyO3/pyo3/pull/1450)
 - Deprecate `PyModule` methods `call`, `call0`, `call1` and `get`. [#1492](https://github.com/PyO3/pyo3/pull/1492)
+- Automatically provide `-undefined` and `dynamic_lookup` linker arguments on macOS with `extension-module` feature. [#1539](https://github.com/PyO3/pyo3/pull/1539)
 
 ### Removed
 - Remove deprecated exception names `BaseException` etc. [#1426](https://github.com/PyO3/pyo3/pull/1426)

--- a/README.md
+++ b/README.md
@@ -80,22 +80,6 @@ fn string_sum(py: Python, m: &PyModule) -> PyResult<()> {
 }
 ```
 
-On Windows and Linux, you can build normally with `cargo build --release`. On macOS, you need to set additional linker arguments. One option is to compile with `cargo rustc --release -- -C link-arg=-undefined -C link-arg=dynamic_lookup`, the other is to create a `.cargo/config` with the following content:
-
-```toml
-[target.x86_64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
-
-[target.aarch64-apple-darwin]
-rustflags = [
-  "-C", "link-arg=-undefined",
-  "-C", "link-arg=dynamic_lookup",
-]
-```
-
 While developing, you can symlink (or copy) and rename the shared library from the target folder: On MacOS, rename `libstring_sum.dylib` to `string_sum.so`, on Windows `libstring_sum.dll` to `string_sum.pyd`, and on Linux `libstring_sum.so` to `string_sum.so`. Then open a Python shell in the same folder and you'll be able to `import string_sum`.
 
 To build, test and publish your crate as a Python module, you can use [maturin](https://github.com/PyO3/maturin) or [setuptools-rust](https://github.com/PyO3/setuptools-rust). You can find an example for setuptools-rust in [examples/word-count](https://github.com/PyO3/pyo3/tree/main/examples/word-count), while maturin should work on your crate without any configuration.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,26 +82,6 @@
 //! }
 //! ```
 //!
-//! On Windows and linux, you can build normally with `cargo build
-//! --release`. On macOS, you need to set additional linker arguments. One
-//! option is to compile with `cargo rustc --release -- -C link-arg=-undefined
-//! -C link-arg=dynamic_lookup`, the other is to create a `.cargo/config` with
-//! the following content:
-//!
-//! ```toml
-//! [target.x86_64-apple-darwin]
-//! rustflags = [
-//!   "-C", "link-arg=-undefined",
-//!   "-C", "link-arg=dynamic_lookup",
-//! ]
-//!
-//! [target.aarch64-apple-darwin]
-//! rustflags = [
-//!   "-C", "link-arg=-undefined",
-//!   "-C", "link-arg=dynamic_lookup",
-//! ]
-//! ```
-//!
 //! While developing, you symlink (or copy) and rename the shared library from
 //! the target folder: On macOS, rename `libstring_sum.dylib` to
 //! `string_sum.so`, on Windows `libstring_sum.dll` to `string_sum.pyd` and on


### PR DESCRIPTION
This PR removes the need for specifying macOS linker arguments in `.cargo/config` - we can feed them in directly in the build script.

I tested this on my wife's macbook air, and it seems to work. According to the cargo changelog, the `rustc-cdylib-link-arg` key has been supported since Rust 1.35: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-135-2019-05-23

cc @messense I think you might have a macOS computer if you're interested in verifying whether this also works for you?

Because `setuptools_rust` and `maturin` set this config automatically you'll have to run plain `cargo build` inside a project which contains a pyo3 extension module to confirm (once removing any relevant config).