### PR TITLE
readme/contributing: sponsorship notes and minor tweaks

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -2,9 +2,9 @@
 
 Thank you for your interest in contributing to PyO3! All are welcome - please consider reading our [Code of Conduct](Code-of-Conduct.md) to keep our community positive and inclusive.
 
-If you are searching for ideas how to contribute, please read the "Getting started contributing" section. Once you've found an issue to contribute to, you may find the section "Writing pull requests" helpful.
+If you are searching for ideas how to contribute, proceed to the ["Getting started contributing"](#getting-started-contributing) section. If you have found a specific issue to contribute to and need information about the development process, you may find the section ["Writing pull requests"](#writing-pull-requests) helpful.
 
-If you want to become familiar with the codebase, check
+If you want to become familiar with the codebase, see
 [Architecture.md](https://github.com/PyO3/pyo3/tree/master/Architecture.md).
 
 ## Getting started contributing
@@ -78,10 +78,18 @@ CI tests both the most recent stable Rust version and the minimum supported Rust
 
 ## Benchmarking
 
-PyO3 has two sets of benchmarks for evaluating some aspects of its performance. The benchmark suite is currently very small - please feel welcome to open PRs with new benchmarks if you're interested in helping to expand it!
+PyO3 has two sets of benchmarks for evaluating some aspects of its performance. The benchmark suite is currently very small - please open PRs with new benchmarks if you're interested in helping to expand it!
 
 First, there are Rust-based benchmarks located in the `benches` subdirectory. As long as you have a nightly rust compiler available on your system, you can run these benchmarks with:
 
     cargo +nightly bench
 
-Second, there is a Python-based benchmark contained in the `word-count` example. You can read more about it [here](examples/word-count#benchmark).
+Second, there is a Python-based benchmark contained in the `pyo3-benchmarks` example. You can read more about it [here](examples/pyo3-benchmarks).
+
+## Sponsor this project
+
+At the moment there is no official organisation that accepts sponsorship on PyO3's behalf. If you're seeking to provide significant funding to the PyO3 ecosystem, please reach out to us on [Github](https://github.com/PyO3/pyo3/issues/new) or [Gitter](https://gitter.im/PyO3/Lobby) and we can discuss.
+
+In the meanwhile, some of our maintainers have personal Github sponsorship pages and would be grateful for your support:
+
+* [davidhewitt](https://github.com/sponsors/davidhewitt)

--- a/README.md
+++ b/README.md
@@ -2,21 +2,16 @@
 
 [![actions status](https://github.com/PyO3/pyo3/workflows/CI/badge.svg)](https://github.com/PyO3/pyo3/actions)
 [![codecov](https://codecov.io/gh/PyO3/pyo3/branch/main/graph/badge.svg)](https://codecov.io/gh/PyO3/pyo3)
-[![crates.io](http://meritbadge.herokuapp.com/pyo3)](https://crates.io/crates/pyo3)
+[![crates.io](https://meritbadge.herokuapp.com/pyo3)](https://crates.io/crates/pyo3)
 [![minimum rustc 1.41](https://img.shields.io/badge/rustc-1.41+-blue.svg)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![dev chat](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/PyO3/Lobby)
+[![contributing notes](https://img.shields.io/badge/contribute-on%20github-Green)](https://github.com/PyO3/pyo3/blob/main/Contributing.md)
 
-[Rust](http://www.rust-lang.org/) bindings for [Python](https://www.python.org/). This includes running and interacting with Python code from a Rust binary, as well as writing native Python modules.
+[Rust](http://www.rust-lang.org/) bindings for [Python](https://www.python.org/), including tools for creating native Python extension modules. Running and interacting with Python code from a Rust binary is also supported.
 
 * User Guide: [stable](https://pyo3.rs) | [main](https://pyo3.rs/main)
 
 * API Documentation: [stable](https://docs.rs/pyo3/) |  [main](https://pyo3.rs/main/doc)
-
-* Contributing Notes: [github](https://github.com/PyO3/pyo3/blob/main/Contributing.md)
-
-* Architecture Guide: [github](https://github.com/PyO3/pyo3/blob/master/Architecture.md)
-
-A comparison with rust-cpython can be found [in the guide](https://pyo3.rs/main/rust_cpython.html).
 
 ## Usage
 
@@ -154,6 +149,20 @@ about this topic.
  * [css-inline](https://github.com/Stranger6667/css-inline/tree/master/bindings/python) _CSS inlining for Python implemented in Rust_
  * [cryptography](https://github.com/pyca/cryptography/tree/main/src/rust) _Python cryptography library with some functionality in Rust_
  * [polaroid](https://github.com/daggy1234/polaroid) _Hyper Fast and safe image manipulation library for Python written in Rust_
+
+## Contributing
+
+Everyone is welcomed to contribute to PyO3! There are many ways to support the project, such as:
+- help PyO3 users with issues on Github and Gitter
+- improve documentation
+- write features and bugfixes
+- publish blogs and examples of how to use PyO3
+
+Our [contributing notes](https://github.com/PyO3/pyo3/blob/main/Contributing.md) and [architecture guide](https://github.com/PyO3/pyo3/blob/master/Architecture.md) have more resources if you wish to volunteer time for PyO3 and are searching where to start.
+
+If you don't have time to contribute yourself but still wish to support the project's future success, some of our maintainers have Github sponsorship pages:
+
+* [davidhewitt](https://github.com/sponsors/davidhewitt)
 
 ## License
 


### PR DESCRIPTION
I added a little bit about sponsorship to the README and contributing notes, including a link to my recently-set-up Github sponsors page for those who would like to tip me for the time spent working on PyO3. I hope that the community finds it ok if I add a little bit of self-promotion here.

At the same time I updated a few bits and pieces that I think makes the content easier to navigate.