### PR TITLE
auto-initialize: better error messages and embedding docs

### DIFF
--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -30,7 +30,7 @@ See the [building and distribution](building_and_distribution.md#minimum-python-
 
 ## Features for embedding Python in Rust
 
-### `auto-initalize`
+### `auto-initialize`
 
 This feature changes [`Python::with_gil`]({{#PYO3_DOCS_URL}}/pyo3/struct.Python.html#method.with_gil) and [`Python::acquire_gil`]({{#PYO3_DOCS_URL}}/pyo3/struct.Python.html#method.acquire_gil) to automatically initialize a Python interpreter (by calling [`prepare_freethreaded_python`]({{#PYO3_DOCS_URL}}/pyo3/fn.prepare_freethreaded_python.html)) if needed.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub use crate::conversion::{
     ToBorrowedObject, ToPyObject,
 };
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
-#[cfg(all(Py_SHARED, not(PyPy)))]
+#[cfg(not(PyPy))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
 pub use crate::gil::{GILGuard, GILPool};
 pub use crate::instance::{Py, PyNativeType, PyObject};


### PR DESCRIPTION
This commit removes the restriction that `prepare_freethreaded_python` cannot be called when linking statically.

I keep the error when `auto-initialize` is enabled with static linking, because it's usually an accidental bug which leads to confusing linker errors at runtime (e.g. #762). However I move it to `build.rs` and improve the error message contents a lot.

To improve the error message context further, I've added a section discussing dynamic and static embedding to the guide.

cc @kngwyu @ravenexp - follow-up from https://github.com/PyO3/pyo3/pull/1532#issuecomment-810607813