### PR TITLE
build: avoid rebuilds when using clippy in a virtualenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix use of Python argument for #[pymethods] inside macro expansions. [#1505](https://github.com/PyO3/pyo3/pull/1505)
 - Always use cross-compiling configuration if any of the environment variables are set. [#1514](https://github.com/PyO3/pyo3/pull/1514)
 - Support `EnvironmentError`, `IOError`, and `WindowsError` on PyPy. [#1533](https://github.com/PyO3/pyo3/pull/1533)
-- Segfault when dereferencing `ffi::PyDateTimeAPI` without the GIL. [#1563](https://github.com/PyO3/pyo3/pull/1563)
+- Fix unneccessary rebuilds when cycling between `cargo check` and `cargo clippy` in a Python virtualenv. [#1557](https://github.com/PyO3/pyo3/pull/1557)
+- Fix segfault when dereferencing `ffi::PyDateTimeAPI` without the GIL. [#1563](https://github.com/PyO3/pyo3/pull/1563)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -90,6 +90,7 @@ See [github.com/japaric/rust-cross](https://github.com/japaric/rust-cross) for a
 
 After you've obtained the above, you can build a cross compiled PyO3 module by setting a few extra environment variables:
 
+* `PYO3_CROSS`: If present this variable forces PyO3 to configure as a cross-compilation.
 * `PYO3_CROSS_LIB_DIR`: This variable must be set to the directory containing the target's libpython DSO and the associated `_sysconfigdata*.py` file for Unix-like targets, or the Python DLL import libraries for the Windows target.
 * `PYO3_CROSS_PYTHON_VERSION`: Major and minor version (e.g. 3.9) of the target Python installation. This variable is only needed if PyO3 cannot determine the version to target from `abi3-py3*` features, or if there are multiple versions of Python present in `PYO3_CROSS_LIB_DIR`.
 


### PR DESCRIPTION
Closes #1551 

The fix comes in two pieces:
 - I add detection for `VIRTUAL_ENV` and `CONDA_PREFIX` variables as possible ways to detect the Python interpreter; this logic is borrowed from `maturin`.
 - I refactored the environment variable `rerun-if-env-changed` system to ensure we emit _exactly_ the environment variables checked by the current run of the build script. This should avoid issues like #1552 .

~~cc @jameshilliard I took out the (new, undocumented) `PYO3_CROSS` variable - was there a specific need for its creation?~~