### PR TITLE
pyproto: no self receivers

### DIFF
--- a/pyo3-macros-backend/src/defs.rs
+++ b/pyo3-macros-backend/src/defs.rs
@@ -145,26 +145,18 @@ pub const OBJECT: Proto = Proto {
     name: "Object",
     module: "pyo3::class::basic",
     methods: &[
-        MethodProto::new("__getattr__", "PyObjectGetAttrProtocol")
-            .args(&["Name"])
-            .has_self(),
-        MethodProto::new("__setattr__", "PyObjectSetAttrProtocol")
-            .args(&["Name", "Value"])
-            .has_self(),
-        MethodProto::new("__delattr__", "PyObjectDelAttrProtocol")
-            .args(&["Name"])
-            .has_self(),
-        MethodProto::new("__str__", "PyObjectStrProtocol").has_self(),
-        MethodProto::new("__repr__", "PyObjectReprProtocol").has_self(),
-        MethodProto::new("__format__", "PyObjectFormatProtocol")
-            .args(&["Format"])
-            .has_self(),
-        MethodProto::new("__hash__", "PyObjectHashProtocol").has_self(),
-        MethodProto::new("__bytes__", "PyObjectBytesProtocol").has_self(),
+        MethodProto::new("__getattr__", "PyObjectGetAttrProtocol").args(&["Name"]),
+        MethodProto::new("__setattr__", "PyObjectSetAttrProtocol").args(&["Name", "Value"]),
+        MethodProto::new("__delattr__", "PyObjectDelAttrProtocol").args(&["Name"]),
+        MethodProto::new("__str__", "PyObjectStrProtocol"),
+        MethodProto::new("__repr__", "PyObjectReprProtocol"),
+        MethodProto::new("__format__", "PyObjectFormatProtocol").args(&["Format"]),
+        MethodProto::new("__hash__", "PyObjectHashProtocol"),
+        MethodProto::new("__bytes__", "PyObjectBytesProtocol"),
         MethodProto::new("__richcmp__", "PyObjectRichcmpProtocol")
             .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__bool__", "PyObjectBoolProtocol").has_self(),
+            .fixed_args(&["Op"]),
+        MethodProto::new("__bool__", "PyObjectBoolProtocol"),
     ],
     py_methods: &[
         PyMethod::new("__format__", "FormatProtocolImpl"),
@@ -191,13 +183,15 @@ pub const ASYNC: Proto = Proto {
     name: "Async",
     module: "pyo3::class::pyasync",
     methods: &[
-        MethodProto::new("__await__", "PyAsyncAwaitProtocol").args(&["Receiver"]),
-        MethodProto::new("__aiter__", "PyAsyncAiterProtocol").args(&["Receiver"]),
-        MethodProto::new("__anext__", "PyAsyncAnextProtocol").args(&["Receiver"]),
-        MethodProto::new("__aenter__", "PyAsyncAenterProtocol").has_self(),
-        MethodProto::new("__aexit__", "PyAsyncAexitProtocol")
-            .args(&["ExcType", "ExcValue", "Traceback"])
-            .has_self(),
+        MethodProto::new("__await__", "PyAsyncAwaitProtocol"),
+        MethodProto::new("__aiter__", "PyAsyncAiterProtocol"),
+        MethodProto::new("__anext__", "PyAsyncAnextProtocol"),
+        MethodProto::new("__aenter__", "PyAsyncAenterProtocol"),
+        MethodProto::new("__aexit__", "PyAsyncAexitProtocol").args(&[
+            "ExcType",
+            "ExcValue",
+            "Traceback",
+        ]),
     ],
     py_methods: &[
         PyMethod::new("__aenter__", "PyAsyncAenterProtocolImpl"),
@@ -214,8 +208,9 @@ pub const BUFFER: Proto = Proto {
     name: "Buffer",
     module: "pyo3::class::buffer",
     methods: &[
-        MethodProto::new("bf_getbuffer", "PyBufferGetBufferProtocol").has_self(),
-        MethodProto::new("bf_releasebuffer", "PyBufferReleaseBufferProtocol").has_self(),
+        MethodProto::new("bf_getbuffer", "PyBufferGetBufferProtocol")
+            .fixed_args(&["view", "flags"]),
+        MethodProto::new("bf_releasebuffer", "PyBufferReleaseBufferProtocol").fixed_args(&["view"]),
     ],
     py_methods: &[],
     slot_defs: &[
@@ -232,10 +227,12 @@ pub const CONTEXT: Proto = Proto {
     name: "Context",
     module: "pyo3::class::context",
     methods: &[
-        MethodProto::new("__enter__", "PyContextEnterProtocol").has_self(),
-        MethodProto::new("__exit__", "PyContextExitProtocol")
-            .args(&["ExcType", "ExcValue", "Traceback"])
-            .has_self(),
+        MethodProto::new("__enter__", "PyContextEnterProtocol"),
+        MethodProto::new("__exit__", "PyContextExitProtocol").args(&[
+            "ExcType",
+            "ExcValue",
+            "Traceback",
+        ]),
     ],
     py_methods: &[
         PyMethod::new("__enter__", "PyContextEnterProtocolImpl"),
@@ -249,11 +246,9 @@ pub const GC: Proto = Proto {
     module: "pyo3::class::gc",
     methods: &[
         MethodProto::new("__traverse__", "PyGCTraverseProtocol")
-            .has_self()
+            .fixed_args(&["visit"])
             .no_result(),
-        MethodProto::new("__clear__", "PyGCClearProtocol")
-            .has_self()
-            .no_result(),
+        MethodProto::new("__clear__", "PyGCClearProtocol").no_result(),
     ],
     py_methods: &[],
     slot_defs: &[
@@ -266,14 +261,10 @@ pub const DESCR: Proto = Proto {
     name: "Descr",
     module: "pyo3::class::descr",
     methods: &[
-        MethodProto::new("__get__", "PyDescrGetProtocol").args(&["Receiver", "Inst", "Owner"]),
-        MethodProto::new("__set__", "PyDescrSetProtocol").args(&["Receiver", "Inst", "Value"]),
-        MethodProto::new("__det__", "PyDescrDelProtocol")
-            .args(&["Inst"])
-            .has_self(),
-        MethodProto::new("__set_name__", "PyDescrSetNameProtocol")
-            .args(&["Inst"])
-            .has_self(),
+        MethodProto::new("__get__", "PyDescrGetProtocol").args(&["Inst", "Owner"]),
+        MethodProto::new("__set__", "PyDescrSetProtocol").args(&["Inst", "Value"]),
+        MethodProto::new("__det__", "PyDescrDelProtocol").args(&["Inst"]),
+        MethodProto::new("__set_name__", "PyDescrSetNameProtocol").args(&["Inst"]),
     ],
     py_methods: &[
         PyMethod::new("__del__", "PyDescrDelProtocolImpl"),
@@ -290,8 +281,8 @@ pub const ITER: Proto = Proto {
     module: "pyo3::class::iter",
     py_methods: &[],
     methods: &[
-        MethodProto::new("__iter__", "PyIterIterProtocol").args(&["Receiver"]),
-        MethodProto::new("__next__", "PyIterNextProtocol").args(&["Receiver"]),
+        MethodProto::new("__iter__", "PyIterIterProtocol"),
+        MethodProto::new("__next__", "PyIterNextProtocol"),
     ],
     slot_defs: &[
         SlotDef::new(&["__iter__"], "Py_tp_iter", "iter"),
@@ -303,17 +294,11 @@ pub const MAPPING: Proto = Proto {
     name: "Mapping",
     module: "pyo3::class::mapping",
     methods: &[
-        MethodProto::new("__len__", "PyMappingLenProtocol").has_self(),
-        MethodProto::new("__getitem__", "PyMappingGetItemProtocol")
-            .args(&["Key"])
-            .has_self(),
-        MethodProto::new("__setitem__", "PyMappingSetItemProtocol")
-            .args(&["Key", "Value"])
-            .has_self(),
-        MethodProto::new("__delitem__", "PyMappingDelItemProtocol")
-            .args(&["Key"])
-            .has_self(),
-        MethodProto::new("__reversed__", "PyMappingReversedProtocol").has_self(),
+        MethodProto::new("__len__", "PyMappingLenProtocol"),
+        MethodProto::new("__getitem__", "PyMappingGetItemProtocol").args(&["Key"]),
+        MethodProto::new("__setitem__", "PyMappingSetItemProtocol").args(&["Key", "Value"]),
+        MethodProto::new("__delitem__", "PyMappingDelItemProtocol").args(&["Key"]),
+        MethodProto::new("__reversed__", "PyMappingReversedProtocol"),
     ],
     py_methods: &[PyMethod::new(
         "__reversed__",
@@ -336,31 +321,15 @@ pub const SEQ: Proto = Proto {
     name: "Sequence",
     module: "pyo3::class::sequence",
     methods: &[
-        MethodProto::new("__len__", "PySequenceLenProtocol").has_self(),
-        MethodProto::new("__getitem__", "PySequenceGetItemProtocol")
-            .args(&["Index"])
-            .has_self(),
-        MethodProto::new("__setitem__", "PySequenceSetItemProtocol")
-            .args(&["Index", "Value"])
-            .has_self(),
-        MethodProto::new("__delitem__", "PySequenceDelItemProtocol")
-            .args(&["Index"])
-            .has_self(),
-        MethodProto::new("__contains__", "PySequenceContainsProtocol")
-            .args(&["Item"])
-            .has_self(),
-        MethodProto::new("__concat__", "PySequenceConcatProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__repeat__", "PySequenceRepeatProtocol")
-            .args(&["Index"])
-            .has_self(),
-        MethodProto::new("__inplace_concat__", "PySequenceInplaceConcatProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__inplace_repeat__", "PySequenceInplaceRepeatProtocol")
-            .args(&["Index"])
-            .has_self(),
+        MethodProto::new("__len__", "PySequenceLenProtocol"),
+        MethodProto::new("__getitem__", "PySequenceGetItemProtocol").args(&["Index"]),
+        MethodProto::new("__setitem__", "PySequenceSetItemProtocol").args(&["Index", "Value"]),
+        MethodProto::new("__delitem__", "PySequenceDelItemProtocol").args(&["Index"]),
+        MethodProto::new("__contains__", "PySequenceContainsProtocol").args(&["Item"]),
+        MethodProto::new("__concat__", "PySequenceConcatProtocol").args(&["Other"]),
+        MethodProto::new("__repeat__", "PySequenceRepeatProtocol").args(&["Index"]),
+        MethodProto::new("__inplace_concat__", "PySequenceInplaceConcatProtocol").args(&["Other"]),
+        MethodProto::new("__inplace_repeat__", "PySequenceInplaceRepeatProtocol").args(&["Index"]),
     ],
     py_methods: &[],
     slot_defs: &[
@@ -393,112 +362,84 @@ pub const NUM: Proto = Proto {
     name: "Number",
     module: "pyo3::class::number",
     methods: &[
-        MethodProto::new("__add__", "PyNumberAddProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__sub__", "PyNumberSubProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__mul__", "PyNumberMulProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__matmul__", "PyNumberMatmulProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__truediv__", "PyNumberTruedivProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__floordiv__", "PyNumberFloordivProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__mod__", "PyNumberModProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__divmod__", "PyNumberDivmodProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__pow__", "PyNumberPowProtocol").args(&["Left", "Right", "Modulo"]),
-        MethodProto::new("__lshift__", "PyNumberLShiftProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__rshift__", "PyNumberRShiftProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__and__", "PyNumberAndProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__xor__", "PyNumberXorProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__or__", "PyNumberOrProtocol").args(&["Left", "Right"]),
-        MethodProto::new("__radd__", "PyNumberRAddProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rsub__", "PyNumberRSubProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rmul__", "PyNumberRMulProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rmatmul__", "PyNumberRMatmulProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rtruediv__", "PyNumberRTruedivProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rfloordiv__", "PyNumberRFloordivProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rmod__", "PyNumberRModProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rdivmod__", "PyNumberRDivmodProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rpow__", "PyNumberRPowProtocol")
-            .args(&["Other", "Modulo"])
-            .has_self(),
-        MethodProto::new("__rlshift__", "PyNumberRLShiftProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rrshift__", "PyNumberRRShiftProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rand__", "PyNumberRAndProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__rxor__", "PyNumberRXorProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__ror__", "PyNumberROrProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__iadd__", "PyNumberIAddProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__isub__", "PyNumberISubProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__imul__", "PyNumberIMulProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__imatmul__", "PyNumberIMatmulProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__itruediv__", "PyNumberITruedivProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__ifloordiv__", "PyNumberIFloordivProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__imod__", "PyNumberIModProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__ipow__", "PyNumberIPowProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__ilshift__", "PyNumberILShiftProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__irshift__", "PyNumberIRShiftProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__iand__", "PyNumberIAndProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__ixor__", "PyNumberIXorProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__ior__", "PyNumberIOrProtocol")
-            .args(&["Other"])
-            .has_self(),
-        MethodProto::new("__neg__", "PyNumberNegProtocol").has_self(),
-        MethodProto::new("__pos__", "PyNumberPosProtocol").has_self(),
-        MethodProto::new("__abs__", "PyNumberAbsProtocol").has_self(),
-        MethodProto::new("__invert__", "PyNumberInvertProtocol").has_self(),
-        MethodProto::new("__complex__", "PyNumberComplexProtocol").has_self(),
-        MethodProto::new("__int__", "PyNumberIntProtocol").has_self(),
-        MethodProto::new("__float__", "PyNumberFloatProtocol").has_self(),
-        MethodProto::new("__index__", "PyNumberIndexProtocol").has_self(),
-        MethodProto::new("__round__", "PyNumberRoundProtocol")
-            .args(&["NDigits"])
-            .has_self(),
+        MethodProto::new("__add__", "PyNumberAddProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__sub__", "PyNumberSubProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__mul__", "PyNumberMulProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__matmul__", "PyNumberMatmulProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__truediv__", "PyNumberTruedivProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__floordiv__", "PyNumberFloordivProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__mod__", "PyNumberModProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__divmod__", "PyNumberDivmodProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__pow__", "PyNumberPowProtocol")
+            .args(&["Left", "Right", "Modulo"])
+            .no_receiver(),
+        MethodProto::new("__lshift__", "PyNumberLShiftProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__rshift__", "PyNumberRShiftProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__and__", "PyNumberAndProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__xor__", "PyNumberXorProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__or__", "PyNumberOrProtocol")
+            .args(&["Left", "Right"])
+            .no_receiver(),
+        MethodProto::new("__radd__", "PyNumberRAddProtocol").args(&["Other"]),
+        MethodProto::new("__rsub__", "PyNumberRSubProtocol").args(&["Other"]),
+        MethodProto::new("__rmul__", "PyNumberRMulProtocol").args(&["Other"]),
+        MethodProto::new("__rmatmul__", "PyNumberRMatmulProtocol").args(&["Other"]),
+        MethodProto::new("__rtruediv__", "PyNumberRTruedivProtocol").args(&["Other"]),
+        MethodProto::new("__rfloordiv__", "PyNumberRFloordivProtocol").args(&["Other"]),
+        MethodProto::new("__rmod__", "PyNumberRModProtocol").args(&["Other"]),
+        MethodProto::new("__rdivmod__", "PyNumberRDivmodProtocol").args(&["Other"]),
+        MethodProto::new("__rpow__", "PyNumberRPowProtocol").args(&["Other", "Modulo"]),
+        MethodProto::new("__rlshift__", "PyNumberRLShiftProtocol").args(&["Other"]),
+        MethodProto::new("__rrshift__", "PyNumberRRShiftProtocol").args(&["Other"]),
+        MethodProto::new("__rand__", "PyNumberRAndProtocol").args(&["Other"]),
+        MethodProto::new("__rxor__", "PyNumberRXorProtocol").args(&["Other"]),
+        MethodProto::new("__ror__", "PyNumberROrProtocol").args(&["Other"]),
+        MethodProto::new("__iadd__", "PyNumberIAddProtocol").args(&["Other"]),
+        MethodProto::new("__isub__", "PyNumberISubProtocol").args(&["Other"]),
+        MethodProto::new("__imul__", "PyNumberIMulProtocol").args(&["Other"]),
+        MethodProto::new("__imatmul__", "PyNumberIMatmulProtocol").args(&["Other"]),
+        MethodProto::new("__itruediv__", "PyNumberITruedivProtocol").args(&["Other"]),
+        MethodProto::new("__ifloordiv__", "PyNumberIFloordivProtocol").args(&["Other"]),
+        MethodProto::new("__imod__", "PyNumberIModProtocol").args(&["Other"]),
+        MethodProto::new("__ipow__", "PyNumberIPowProtocol").args(&["Other"]),
+        MethodProto::new("__ilshift__", "PyNumberILShiftProtocol").args(&["Other"]),
+        MethodProto::new("__irshift__", "PyNumberIRShiftProtocol").args(&["Other"]),
+        MethodProto::new("__iand__", "PyNumberIAndProtocol").args(&["Other"]),
+        MethodProto::new("__ixor__", "PyNumberIXorProtocol").args(&["Other"]),
+        MethodProto::new("__ior__", "PyNumberIOrProtocol").args(&["Other"]),
+        MethodProto::new("__neg__", "PyNumberNegProtocol"),
+        MethodProto::new("__pos__", "PyNumberPosProtocol"),
+        MethodProto::new("__abs__", "PyNumberAbsProtocol"),
+        MethodProto::new("__invert__", "PyNumberInvertProtocol"),
+        MethodProto::new("__complex__", "PyNumberComplexProtocol"),
+        MethodProto::new("__int__", "PyNumberIntProtocol"),
+        MethodProto::new("__float__", "PyNumberFloatProtocol"),
+        MethodProto::new("__index__", "PyNumberIndexProtocol"),
+        MethodProto::new("__round__", "PyNumberRoundProtocol").args(&["NDigits"]),
     ],
     py_methods: &[
         PyMethod::coexist("__radd__", "PyNumberRAddProtocolImpl"),

--- a/src/class/buffer.rs
+++ b/src/class/buffer.rs
@@ -4,8 +4,8 @@
 //!
 //! For more information check [buffer protocol](https://docs.python.org/3/c-api/buffer.html)
 //! c-api
-use crate::callback::IntoPyCallbackOutput;
-use crate::{ffi, PyCell, PyClass, PyRefMut};
+use crate::{callback::IntoPyCallbackOutput, derive_utils::TryFromPyCell};
+use crate::{ffi, PyCell, PyClass};
 use std::os::raw::c_int;
 
 /// Buffer protocol interface
@@ -16,20 +16,22 @@ use std::os::raw::c_int;
 pub trait PyBufferProtocol<'p>: PyClass {
     // No default implementations so that implementors of this trait provide both methods.
 
-    fn bf_getbuffer(slf: PyRefMut<Self>, view: *mut ffi::Py_buffer, flags: c_int) -> Self::Result
+    fn bf_getbuffer(slf: Self::Receiver, view: *mut ffi::Py_buffer, flags: c_int) -> Self::Result
     where
         Self: PyBufferGetBufferProtocol<'p>;
 
-    fn bf_releasebuffer(slf: PyRefMut<Self>, view: *mut ffi::Py_buffer) -> Self::Result
+    fn bf_releasebuffer(slf: Self::Receiver, view: *mut ffi::Py_buffer) -> Self::Result
     where
         Self: PyBufferReleaseBufferProtocol<'p>;
 }
 
 pub trait PyBufferGetBufferProtocol<'p>: PyBufferProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyBufferReleaseBufferProtocol<'p>: PyBufferProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
@@ -44,7 +46,9 @@ where
 {
     crate::callback_body!(py, {
         let slf = py.from_borrowed_ptr::<PyCell<T>>(slf);
-        T::bf_getbuffer(slf.try_borrow_mut()?, arg1, arg2).convert(py)
+        let borrow =
+            <T::Receiver as TryFromPyCell<_>>::try_from_pycell(slf).map_err(|e| e.into())?;
+        T::bf_getbuffer(borrow, arg1, arg2).convert(py)
     })
 }
 
@@ -55,6 +59,8 @@ where
 {
     crate::callback_body!(py, {
         let slf = py.from_borrowed_ptr::<crate::PyCell<T>>(slf);
-        T::bf_releasebuffer(slf.try_borrow_mut()?, arg1).convert(py)
+        let borrow =
+            <T::Receiver as TryFromPyCell<_>>::try_from_pycell(slf).map_err(|e| e.into())?;
+        T::bf_releasebuffer(borrow, arg1).convert(py)
     })
 }

--- a/src/class/context.rs
+++ b/src/class/context.rs
@@ -4,13 +4,13 @@
 //! Trait and support implementation for context manager api
 //!
 
-use crate::callback::IntoPyCallbackOutput;
+use crate::{callback::IntoPyCallbackOutput, derive_utils::TryFromPyCell};
 use crate::{PyClass, PyObject};
 
 /// Context manager interface
 #[allow(unused_variables)]
 pub trait PyContextProtocol<'p>: PyClass {
-    fn __enter__(&'p mut self) -> Self::Result
+    fn __enter__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyContextEnterProtocol<'p>,
     {
@@ -18,7 +18,7 @@ pub trait PyContextProtocol<'p>: PyClass {
     }
 
     fn __exit__(
-        &'p mut self,
+        slf: Self::Receiver,
         exc_type: Option<Self::ExcType>,
         exc_value: Option<Self::ExcValue>,
         traceback: Option<Self::Traceback>,
@@ -31,10 +31,12 @@ pub trait PyContextProtocol<'p>: PyClass {
 }
 
 pub trait PyContextEnterProtocol<'p>: PyContextProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyContextExitProtocol<'p>: PyContextProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type ExcType: crate::FromPyObject<'p>;
     type ExcValue: crate::FromPyObject<'p>;
     type Traceback: crate::FromPyObject<'p>;

--- a/src/class/descr.rs
+++ b/src/class/descr.rs
@@ -5,8 +5,8 @@
 //! [Python information](
 //! https://docs.python.org/3/reference/datamodel.html#implementing-descriptors)
 
-use crate::callback::IntoPyCallbackOutput;
 use crate::types::PyAny;
+use crate::{callback::IntoPyCallbackOutput, derive_utils::TryFromPyCell};
 use crate::{FromPyObject, PyClass, PyObject};
 use std::os::raw::c_int;
 
@@ -31,14 +31,14 @@ pub trait PyDescrProtocol<'p>: PyClass {
         unimplemented!()
     }
 
-    fn __delete__(&'p self, instance: &'p PyAny) -> Self::Result
+    fn __delete__(slf: Self::Receiver, instance: &'p PyAny) -> Self::Result
     where
         Self: PyDescrDeleteProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __set_name__(&'p self, instance: &'p PyAny) -> Self::Result
+    fn __set_name__(slf: Self::Receiver, instance: &'p PyAny) -> Self::Result
     where
         Self: PyDescrSetNameProtocol<'p>,
     {
@@ -61,11 +61,13 @@ pub trait PyDescrSetProtocol<'p>: PyDescrProtocol<'p> {
 }
 
 pub trait PyDescrDeleteProtocol<'p>: PyDescrProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Inst: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyDescrSetNameProtocol<'p>: PyDescrProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Inst: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }

--- a/src/class/iter.rs
+++ b/src/class/iter.rs
@@ -70,8 +70,8 @@ pub trait PyIterNextProtocol<'p>: PyIterProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyIterNextOutput>;
 }
 
-py_unarys_func!(iter, PyIterIterProtocol, Self::__iter__);
-py_unarys_func!(iternext, PyIterNextProtocol, Self::__next__);
+py_unary_func!(iter, PyIterIterProtocol, Self::__iter__);
+py_unary_func!(iternext, PyIterNextProtocol, Self::__next__);
 
 /// Output of `__next__` which can either `yield` the next value in the iteration, or
 /// `return` a value to raise `StopIteration` in Python.

--- a/src/class/mapping.rs
+++ b/src/class/mapping.rs
@@ -3,41 +3,41 @@
 //! Python Mapping Interface
 //! Trait and support implementation for implementing mapping support
 
-use crate::callback::IntoPyCallbackOutput;
+use crate::{callback::IntoPyCallbackOutput, derive_utils::TryFromPyCell};
 use crate::{exceptions, ffi, FromPyObject, PyClass, PyObject};
 
 /// Mapping interface
 #[allow(unused_variables)]
 pub trait PyMappingProtocol<'p>: PyClass {
-    fn __len__(&'p self) -> Self::Result
+    fn __len__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyMappingLenProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __getitem__(&'p self, key: Self::Key) -> Self::Result
+    fn __getitem__(slf: Self::Receiver, key: Self::Key) -> Self::Result
     where
         Self: PyMappingGetItemProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __setitem__(&'p mut self, key: Self::Key, value: Self::Value) -> Self::Result
+    fn __setitem__(slf: Self::Receiver, key: Self::Key, value: Self::Value) -> Self::Result
     where
         Self: PyMappingSetItemProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __delitem__(&'p mut self, key: Self::Key) -> Self::Result
+    fn __delitem__(slf: Self::Receiver, key: Self::Key) -> Self::Result
     where
         Self: PyMappingDelItemProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __reversed__(&'p self) -> Self::Result
+    fn __reversed__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyMappingReversedProtocol<'p>,
     {
@@ -49,26 +49,31 @@ pub trait PyMappingProtocol<'p>: PyClass {
 // the existance of a slotted method.
 
 pub trait PyMappingLenProtocol<'p>: PyMappingProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<usize>;
 }
 
 pub trait PyMappingGetItemProtocol<'p>: PyMappingProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Key: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyMappingSetItemProtocol<'p>: PyMappingProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Key: FromPyObject<'p>;
     type Value: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyMappingDelItemProtocol<'p>: PyMappingProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Key: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyMappingReversedProtocol<'p>: PyMappingProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -2,8 +2,8 @@
 
 //! Python Number Interface
 //! Trait and support implementation for implementing number protocol
-use crate::callback::IntoPyCallbackOutput;
 use crate::err::PyErr;
+use crate::{callback::IntoPyCallbackOutput, derive_utils::TryFromPyCell};
 use crate::{ffi, FromPyObject, PyClass, PyObject};
 
 /// Number interface
@@ -94,164 +94,168 @@ pub trait PyNumberProtocol<'p>: PyClass {
         unimplemented!()
     }
 
-    fn __radd__(&'p self, other: Self::Other) -> Self::Result
+    fn __radd__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRAddProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rsub__(&'p self, other: Self::Other) -> Self::Result
+    fn __rsub__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRSubProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rmul__(&'p self, other: Self::Other) -> Self::Result
+    fn __rmul__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRMulProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rmatmul__(&'p self, other: Self::Other) -> Self::Result
+    fn __rmatmul__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRMatmulProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rtruediv__(&'p self, other: Self::Other) -> Self::Result
+    fn __rtruediv__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRTruedivProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rfloordiv__(&'p self, other: Self::Other) -> Self::Result
+    fn __rfloordiv__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRFloordivProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rmod__(&'p self, other: Self::Other) -> Self::Result
+    fn __rmod__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRModProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rdivmod__(&'p self, other: Self::Other) -> Self::Result
+    fn __rdivmod__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRDivmodProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rpow__(&'p self, other: Self::Other, modulo: Option<Self::Modulo>) -> Self::Result
+    fn __rpow__(
+        slf: Self::Receiver,
+        other: Self::Other,
+        modulo: Option<Self::Modulo>,
+    ) -> Self::Result
     where
         Self: PyNumberRPowProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rlshift__(&'p self, other: Self::Other) -> Self::Result
+    fn __rlshift__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRLShiftProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rrshift__(&'p self, other: Self::Other) -> Self::Result
+    fn __rrshift__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRRShiftProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rand__(&'p self, other: Self::Other) -> Self::Result
+    fn __rand__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRAndProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __rxor__(&'p self, other: Self::Other) -> Self::Result
+    fn __rxor__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberRXorProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __ror__(&'p self, other: Self::Other) -> Self::Result
+    fn __ror__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberROrProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __iadd__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __iadd__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIAddProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __isub__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __isub__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberISubProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __imul__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __imul__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIMulProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __imatmul__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __imatmul__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIMatmulProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __itruediv__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __itruediv__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberITruedivProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __ifloordiv__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __ifloordiv__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIFloordivProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __imod__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __imod__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIModProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __ipow__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __ipow__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIPowProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __ilshift__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __ilshift__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberILShiftProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __irshift__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __irshift__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIRShiftProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __iand__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __iand__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIAndProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __ixor__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __ixor__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIXorProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __ior__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __ior__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PyNumberIOrProtocol<'p>,
     {
@@ -259,55 +263,55 @@ pub trait PyNumberProtocol<'p>: PyClass {
     }
 
     // Unary arithmetic
-    fn __neg__(&'p self) -> Self::Result
+    fn __neg__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyNumberNegProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __pos__(&'p self) -> Self::Result
+    fn __pos__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyNumberPosProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __abs__(&'p self) -> Self::Result
+    fn __abs__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyNumberAbsProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __invert__(&'p self) -> Self::Result
+    fn __invert__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyNumberInvertProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __complex__(&'p self) -> Self::Result
+    fn __complex__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyNumberComplexProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __int__(&'p self) -> Self::Result
+    fn __int__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyNumberIntProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __float__(&'p self) -> Self::Result
+    fn __float__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyNumberFloatProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __index__(&'p self) -> Self::Result
+    fn __index__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyNumberIndexProtocol<'p>,
     {
         unimplemented!()
     }
-    fn __round__(&'p self, ndigits: Option<Self::NDigits>) -> Self::Result
+    fn __round__(slf: Self::Receiver, ndigits: Option<Self::NDigits>) -> Self::Result
     where
         Self: PyNumberRoundProtocol<'p>,
     {
@@ -401,46 +405,55 @@ pub trait PyNumberOrProtocol<'p>: PyNumberProtocol<'p> {
 }
 
 pub trait PyNumberRAddProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRSubProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRMulProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRMatmulProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRTruedivProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRFloordivProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRModProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRDivmodProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRPowProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Modulo: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
@@ -448,137 +461,165 @@ pub trait PyNumberRPowProtocol<'p>: PyNumberProtocol<'p> {
 
 #[allow(clippy::upper_case_acronyms)]
 pub trait PyNumberRLShiftProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 #[allow(clippy::upper_case_acronyms)]
 pub trait PyNumberRRShiftProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRAndProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRXorProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberROrProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberIAddProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberISubProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberIMulProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberIMatmulProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberITruedivProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberIFloordivProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberIModProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberIDivmodProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberIPowProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 #[allow(clippy::upper_case_acronyms)]
 pub trait PyNumberILShiftProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 #[allow(clippy::upper_case_acronyms)]
 pub trait PyNumberIRShiftProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberIAndProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberIXorProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberIOrProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PyNumberNegProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberPosProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberAbsProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberInvertProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberComplexProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberIntProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberFloatProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberRoundProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type NDigits: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyNumberIndexProtocol<'p>: PyNumberProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
@@ -637,7 +678,14 @@ where
                 let slf: &crate::PyCell<T> = extract_or_return_not_implemented!(rhs);
                 let arg = extract_or_return_not_implemented!(lhs);
                 let modulo = extract_or_return_not_implemented!(modulo);
-                slf.try_borrow()?.__rpow__(arg, modulo).convert(py)
+
+                let borrow =
+                    <<T as PyNumberRPowProtocol>::Receiver as TryFromPyCell<_>>::try_from_pycell(
+                        slf,
+                    )
+                    .map_err(|e| e.into())?;
+
+                T::__rpow__(borrow, arg, modulo).convert(py)
             }
         }
     })
@@ -673,7 +721,9 @@ where
         let slf: &crate::PyCell<T> = extract_or_return_not_implemented!(py, slf);
         let arg = extract_or_return_not_implemented!(py, arg);
         let modulo = extract_or_return_not_implemented!(py, modulo);
-        slf.try_borrow()?.__rpow__(arg, modulo).convert(py)
+        let borrow =
+            <T::Receiver as TryFromPyCell<_>>::try_from_pycell(slf).map_err(|e| e.into())?;
+        T::__rpow__(borrow, arg, modulo).convert(py)
     })
 }
 
@@ -723,10 +773,10 @@ py_binary_num_func!(or, PyNumberOrProtocol, T::__or__);
 py_binary_reversed_num_func!(ror, PyNumberROrProtocol, T::__ror__);
 py_unary_func!(int, PyNumberIntProtocol, T::__int__);
 py_unary_func!(float, PyNumberFloatProtocol, T::__float__);
-py_binary_self_func!(iadd, PyNumberIAddProtocol, T::__iadd__);
-py_binary_self_func!(isub, PyNumberISubProtocol, T::__isub__);
-py_binary_self_func!(imul, PyNumberIMulProtocol, T::__imul__);
-py_binary_self_func!(imod, PyNumberIModProtocol, T::__imod__);
+py_binary_inplace_func!(iadd, PyNumberIAddProtocol, T::__iadd__);
+py_binary_inplace_func!(isub, PyNumberISubProtocol, T::__isub__);
+py_binary_inplace_func!(imul, PyNumberIMulProtocol, T::__imul__);
+py_binary_inplace_func!(imod, PyNumberIModProtocol, T::__imod__);
 
 #[doc(hidden)]
 pub unsafe extern "C" fn ipow<T>(
@@ -742,17 +792,19 @@ where
     crate::callback_body!(py, {
         let slf_cell = py.from_borrowed_ptr::<crate::PyCell<T>>(slf);
         let other = py.from_borrowed_ptr::<crate::PyAny>(other);
-        call_operator_mut!(py, slf_cell, __ipow__, other).convert(py)?;
+        let borrow =
+            <T::Receiver as TryFromPyCell<_>>::try_from_pycell(slf_cell).map_err(|e| e.into())?;
+        T::__ipow__(borrow, extract_or_return_not_implemented!(other)).convert(py)?;
         ffi::Py_INCREF(slf);
         Ok::<_, PyErr>(slf)
     })
 }
 
-py_binary_self_func!(ilshift, PyNumberILShiftProtocol, T::__ilshift__);
-py_binary_self_func!(irshift, PyNumberIRShiftProtocol, T::__irshift__);
-py_binary_self_func!(iand, PyNumberIAndProtocol, T::__iand__);
-py_binary_self_func!(ixor, PyNumberIXorProtocol, T::__ixor__);
-py_binary_self_func!(ior, PyNumberIOrProtocol, T::__ior__);
+py_binary_inplace_func!(ilshift, PyNumberILShiftProtocol, T::__ilshift__);
+py_binary_inplace_func!(irshift, PyNumberIRShiftProtocol, T::__irshift__);
+py_binary_inplace_func!(iand, PyNumberIAndProtocol, T::__iand__);
+py_binary_inplace_func!(ixor, PyNumberIXorProtocol, T::__ixor__);
+py_binary_inplace_func!(ior, PyNumberIOrProtocol, T::__ior__);
 py_binary_fallback_num_func!(
     floordiv_rfloordiv,
     T,
@@ -769,8 +821,8 @@ py_binary_fallback_num_func!(
 );
 py_binary_num_func!(truediv, PyNumberTruedivProtocol, T::__truediv__);
 py_binary_reversed_num_func!(rtruediv, PyNumberRTruedivProtocol, T::__rtruediv__);
-py_binary_self_func!(ifloordiv, PyNumberIFloordivProtocol, T::__ifloordiv__);
-py_binary_self_func!(itruediv, PyNumberITruedivProtocol, T::__itruediv__);
+py_binary_inplace_func!(ifloordiv, PyNumberIFloordivProtocol, T::__ifloordiv__);
+py_binary_inplace_func!(itruediv, PyNumberITruedivProtocol, T::__itruediv__);
 py_unary_func!(index, PyNumberIndexProtocol, T::__index__);
 py_binary_fallback_num_func!(
     matmul_rmatmul,
@@ -780,4 +832,4 @@ py_binary_fallback_num_func!(
 );
 py_binary_num_func!(matmul, PyNumberMatmulProtocol, T::__matmul__);
 py_binary_reversed_num_func!(rmatmul, PyNumberRMatmulProtocol, T::__rmatmul__);
-py_binary_self_func!(imatmul, PyNumberIMatmulProtocol, T::__imatmul__);
+py_binary_inplace_func!(imatmul, PyNumberIMatmulProtocol, T::__imatmul__);

--- a/src/class/pyasync.rs
+++ b/src/class/pyasync.rs
@@ -39,7 +39,7 @@ pub trait PyAsyncProtocol<'p>: PyClass {
         unimplemented!()
     }
 
-    fn __aenter__(&'p mut self) -> Self::Result
+    fn __aenter__(slf: Self::Receiver) -> Self::Result
     where
         Self: PyAsyncAenterProtocol<'p>,
     {
@@ -47,7 +47,7 @@ pub trait PyAsyncProtocol<'p>: PyClass {
     }
 
     fn __aexit__(
-        &'p mut self,
+        slf: Self::Receiver,
         exc_type: Option<Self::ExcType>,
         exc_value: Option<Self::ExcValue>,
         traceback: Option<Self::Traceback>,
@@ -75,19 +75,21 @@ pub trait PyAsyncAnextProtocol<'p>: PyAsyncProtocol<'p> {
 }
 
 pub trait PyAsyncAenterProtocol<'p>: PyAsyncProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PyAsyncAexitProtocol<'p>: PyAsyncProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type ExcType: crate::FromPyObject<'p>;
     type ExcValue: crate::FromPyObject<'p>;
     type Traceback: crate::FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
-py_unarys_func!(await_, PyAsyncAwaitProtocol, Self::__await__);
-py_unarys_func!(aiter, PyAsyncAiterProtocol, Self::__aiter__);
-py_unarys_func!(anext, PyAsyncAnextProtocol, Self::__anext__);
+py_unary_func!(await_, PyAsyncAwaitProtocol, Self::__await__);
+py_unary_func!(aiter, PyAsyncAiterProtocol, Self::__aiter__);
+py_unary_func!(anext, PyAsyncAnextProtocol, Self::__anext__);
 
 /// Output of `__anext__`.
 pub enum IterANextOutput<T, U> {

--- a/src/class/sequence.rs
+++ b/src/class/sequence.rs
@@ -3,72 +3,72 @@
 //! Python Sequence Interface
 //! Trait and support implementation for implementing sequence
 
-use crate::callback::IntoPyCallbackOutput;
 use crate::conversion::{FromPyObject, IntoPy};
 use crate::err::PyErr;
+use crate::{callback::IntoPyCallbackOutput, derive_utils::TryFromPyCell};
 use crate::{exceptions, ffi, PyAny, PyCell, PyClass, PyObject};
 use std::os::raw::c_int;
 
 /// Sequence interface
 #[allow(unused_variables)]
 pub trait PySequenceProtocol<'p>: PyClass + Sized {
-    fn __len__(&'p self) -> Self::Result
+    fn __len__(slf: Self::Receiver) -> Self::Result
     where
         Self: PySequenceLenProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __getitem__(&'p self, idx: Self::Index) -> Self::Result
+    fn __getitem__(slf: Self::Receiver, idx: Self::Index) -> Self::Result
     where
         Self: PySequenceGetItemProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __setitem__(&'p mut self, idx: Self::Index, value: Self::Value) -> Self::Result
+    fn __setitem__(slf: Self::Receiver, idx: Self::Index, value: Self::Value) -> Self::Result
     where
         Self: PySequenceSetItemProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __delitem__(&'p mut self, idx: Self::Index) -> Self::Result
+    fn __delitem__(slf: Self::Receiver, idx: Self::Index) -> Self::Result
     where
         Self: PySequenceDelItemProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __contains__(&'p self, item: Self::Item) -> Self::Result
+    fn __contains__(slf: Self::Receiver, item: Self::Item) -> Self::Result
     where
         Self: PySequenceContainsProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __concat__(&'p self, other: Self::Other) -> Self::Result
+    fn __concat__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PySequenceConcatProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __repeat__(&'p self, count: Self::Index) -> Self::Result
+    fn __repeat__(slf: Self::Receiver, count: Self::Index) -> Self::Result
     where
         Self: PySequenceRepeatProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __inplace_concat__(&'p mut self, other: Self::Other) -> Self::Result
+    fn __inplace_concat__(slf: Self::Receiver, other: Self::Other) -> Self::Result
     where
         Self: PySequenceInplaceConcatProtocol<'p>,
     {
         unimplemented!()
     }
 
-    fn __inplace_repeat__(&'p mut self, count: Self::Index) -> Self::Result
+    fn __inplace_repeat__(slf: Self::Receiver, count: Self::Index) -> Self::Result
     where
         Self: PySequenceInplaceRepeatProtocol<'p>,
     {
@@ -80,36 +80,43 @@ pub trait PySequenceProtocol<'p>: PyClass + Sized {
 // the existance of a slotted method.
 
 pub trait PySequenceLenProtocol<'p>: PySequenceProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Result: IntoPyCallbackOutput<usize>;
 }
 
 pub trait PySequenceGetItemProtocol<'p>: PySequenceProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Index: FromPyObject<'p> + From<isize>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PySequenceSetItemProtocol<'p>: PySequenceProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Index: FromPyObject<'p> + From<isize>;
     type Value: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PySequenceDelItemProtocol<'p>: PySequenceProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Index: FromPyObject<'p> + From<isize>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
 pub trait PySequenceContainsProtocol<'p>: PySequenceProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Item: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<bool>;
 }
 
 pub trait PySequenceConcatProtocol<'p>: PySequenceProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
 pub trait PySequenceRepeatProtocol<'p>: PySequenceProtocol<'p> {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Index: FromPyObject<'p> + From<isize>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
@@ -117,6 +124,7 @@ pub trait PySequenceRepeatProtocol<'p>: PySequenceProtocol<'p> {
 pub trait PySequenceInplaceConcatProtocol<'p>:
     PySequenceProtocol<'p> + IntoPy<PyObject> + 'p
 {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<Self>;
 }
@@ -124,6 +132,7 @@ pub trait PySequenceInplaceConcatProtocol<'p>:
 pub trait PySequenceInplaceRepeatProtocol<'p>:
     PySequenceProtocol<'p> + IntoPy<PyObject> + 'p
 {
+    type Receiver: TryFromPyCell<'p, Self>;
     type Index: FromPyObject<'p> + From<isize>;
     type Result: IntoPyCallbackOutput<Self>;
 }
@@ -152,10 +161,11 @@ where
             )));
         }
 
-        let mut slf = slf.try_borrow_mut()?;
+        let borrow =
+            <T::Receiver as TryFromPyCell<_>>::try_from_pycell(slf).map_err(|e| e.into())?;
         let value = py.from_borrowed_ptr::<PyAny>(value);
         let value = value.extract()?;
-        crate::callback::convert(py, slf.__setitem__(key.into(), value))
+        crate::callback::convert(py, T::__setitem__(borrow, key.into(), value))
     })
 }
 
@@ -172,7 +182,9 @@ where
         let slf = py.from_borrowed_ptr::<PyCell<T>>(slf);
 
         if value.is_null() {
-            crate::callback::convert(py, slf.borrow_mut().__delitem__(key.into()))
+            let borrow =
+                <T::Receiver as TryFromPyCell<_>>::try_from_pycell(slf).map_err(|e| e.into())?;
+            crate::callback::convert(py, T::__delitem__(borrow, key.into()))
         } else {
             Err(PyErr::new::<exceptions::PyNotImplementedError, _>(format!(
                 "Item assignment not supported by {:?}",
@@ -195,12 +207,21 @@ where
         let slf = py.from_borrowed_ptr::<PyCell<T>>(slf);
 
         if value.is_null() {
-            call_mut!(slf, __delitem__; key.into()).convert(py)
+            let borrow =
+                <<T as PySequenceDelItemProtocol>::Receiver as TryFromPyCell<_>>::try_from_pycell(
+                    slf,
+                )
+                .map_err(|e| e.into())?;
+            T::__delitem__(borrow, key.into()).convert(py)
         } else {
             let value = py.from_borrowed_ptr::<PyAny>(value);
-            let mut slf_ = slf.try_borrow_mut()?;
             let value = value.extract()?;
-            slf_.__setitem__(key.into(), value).convert(py)
+            let borrow =
+                <<T as PySequenceSetItemProtocol>::Receiver as TryFromPyCell<_>>::try_from_pycell(
+                    slf,
+                )
+                .map_err(|e| e.into())?;
+            T::__setitem__(borrow, key.into(), value).convert(py)
         }
     })
 }
@@ -215,12 +236,10 @@ py_binary_func!(
     inplace_concat,
     PySequenceInplaceConcatProtocol,
     Self::__inplace_concat__,
-    *mut ffi::PyObject,
-    call_mut
+    *mut ffi::PyObject
 );
 py_ssizearg_func!(
     inplace_repeat,
     PySequenceInplaceRepeatProtocol,
-    Self::__inplace_repeat__,
-    call_mut
+    Self::__inplace_repeat__
 );

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -19,27 +19,27 @@ impl UnaryArithmetic {
 
 #[pyproto]
 impl PyObjectProtocol for UnaryArithmetic {
-    fn __repr__(&self) -> String {
-        format!("UA({})", self.inner)
+    fn __repr__(slf: PyRef<Self>) -> String {
+        format!("UA({})", slf.inner)
     }
 }
 
 #[pyproto]
 impl PyNumberProtocol for UnaryArithmetic {
-    fn __neg__(&self) -> Self {
-        Self::new(-self.inner)
+    fn __neg__(slf: PyRef<Self>) -> Self {
+        Self::new(-slf.inner)
     }
 
-    fn __pos__(&self) -> Self {
-        Self::new(self.inner)
+    fn __pos__(slf: PyRef<Self>) -> Self {
+        Self::new(slf.inner)
     }
 
-    fn __abs__(&self) -> Self {
-        Self::new(self.inner.abs())
+    fn __abs__(slf: PyRef<Self>) -> Self {
+        Self::new(slf.inner.abs())
     }
 
-    fn __round__(&self, _ndigits: Option<u32>) -> Self {
-        Self::new(self.inner.round())
+    fn __round__(slf: PyRef<Self>, _ndigits: Option<u32>) -> Self {
+        Self::new(slf.inner.round())
     }
 }
 
@@ -61,7 +61,7 @@ struct BinaryArithmetic {}
 
 #[pyproto]
 impl PyObjectProtocol for BinaryArithmetic {
-    fn __repr__(&self) -> &'static str {
+    fn __repr__(_slf: PyRef<Self>) -> &'static str {
         "BA"
     }
 }
@@ -73,47 +73,47 @@ struct InPlaceOperations {
 
 #[pyproto]
 impl PyObjectProtocol for InPlaceOperations {
-    fn __repr__(&self) -> String {
-        format!("IPO({:?})", self.value)
+    fn __repr__(slf: PyRef<Self>) -> String {
+        format!("IPO({:?})", slf.value)
     }
 }
 
 #[pyproto]
 impl PyNumberProtocol for InPlaceOperations {
-    fn __iadd__(&mut self, other: u32) {
-        self.value += other;
+    fn __iadd__(mut slf: PyRefMut<Self>, other: u32) {
+        slf.value += other;
     }
 
-    fn __isub__(&mut self, other: u32) {
-        self.value -= other;
+    fn __isub__(mut slf: PyRefMut<Self>, other: u32) {
+        slf.value -= other;
     }
 
-    fn __imul__(&mut self, other: u32) {
-        self.value *= other;
+    fn __imul__(mut slf: PyRefMut<Self>, other: u32) {
+        slf.value *= other;
     }
 
-    fn __ilshift__(&mut self, other: u32) {
-        self.value <<= other;
+    fn __ilshift__(mut slf: PyRefMut<Self>, other: u32) {
+        slf.value <<= other;
     }
 
-    fn __irshift__(&mut self, other: u32) {
-        self.value >>= other;
+    fn __irshift__(mut slf: PyRefMut<Self>, other: u32) {
+        slf.value >>= other;
     }
 
-    fn __iand__(&mut self, other: u32) {
-        self.value &= other;
+    fn __iand__(mut slf: PyRefMut<Self>, other: u32) {
+        slf.value &= other;
     }
 
-    fn __ixor__(&mut self, other: u32) {
-        self.value ^= other;
+    fn __ixor__(mut slf: PyRefMut<Self>, other: u32) {
+        slf.value ^= other;
     }
 
-    fn __ior__(&mut self, other: u32) {
-        self.value |= other;
+    fn __ior__(mut slf: PyRefMut<Self>, other: u32) {
+        slf.value |= other;
     }
 
-    fn __ipow__(&mut self, other: u32) {
-        self.value = self.value.pow(other);
+    fn __ipow__(mut slf: PyRefMut<Self>, other: u32) {
+        slf.value = slf.value.pow(other);
     }
 }
 
@@ -216,39 +216,39 @@ struct RhsArithmetic {}
 
 #[pyproto]
 impl PyNumberProtocol for RhsArithmetic {
-    fn __radd__(&self, other: &PyAny) -> String {
+    fn __radd__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} + RA", other)
     }
 
-    fn __rsub__(&self, other: &PyAny) -> String {
+    fn __rsub__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} - RA", other)
     }
 
-    fn __rmul__(&self, other: &PyAny) -> String {
+    fn __rmul__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} * RA", other)
     }
 
-    fn __rlshift__(&self, other: &PyAny) -> String {
+    fn __rlshift__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} << RA", other)
     }
 
-    fn __rrshift__(&self, other: &PyAny) -> String {
+    fn __rrshift__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} >> RA", other)
     }
 
-    fn __rand__(&self, other: &PyAny) -> String {
+    fn __rand__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} & RA", other)
     }
 
-    fn __rxor__(&self, other: &PyAny) -> String {
+    fn __rxor__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} ^ RA", other)
     }
 
-    fn __ror__(&self, other: &PyAny) -> String {
+    fn __ror__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} | RA", other)
     }
 
-    fn __rpow__(&self, other: &PyAny, _mod: Option<&'p PyAny>) -> String {
+    fn __rpow__(_slf: PyRef<Self>, other: &PyAny, _mod: Option<&'p PyAny>) -> String {
         format!("{:?} ** RA", other)
     }
 }
@@ -330,50 +330,50 @@ impl PyNumberProtocol for LhsAndRhs {
         format!("{:?} @ {:?}", lhs, rhs)
     }
 
-    fn __radd__(&self, other: &PyAny) -> String {
+    fn __radd__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} + RA", other)
     }
 
-    fn __rsub__(&self, other: &PyAny) -> String {
+    fn __rsub__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} - RA", other)
     }
 
-    fn __rmul__(&self, other: &PyAny) -> String {
+    fn __rmul__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} * RA", other)
     }
 
-    fn __rlshift__(&self, other: &PyAny) -> String {
+    fn __rlshift__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} << RA", other)
     }
 
-    fn __rrshift__(&self, other: &PyAny) -> String {
+    fn __rrshift__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} >> RA", other)
     }
 
-    fn __rand__(&self, other: &PyAny) -> String {
+    fn __rand__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} & RA", other)
     }
 
-    fn __rxor__(&self, other: &PyAny) -> String {
+    fn __rxor__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} ^ RA", other)
     }
 
-    fn __ror__(&self, other: &PyAny) -> String {
+    fn __ror__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} | RA", other)
     }
 
-    fn __rpow__(&self, other: &PyAny, _mod: Option<&'p PyAny>) -> String {
+    fn __rpow__(_slf: PyRef<Self>, other: &PyAny, _mod: Option<&'p PyAny>) -> String {
         format!("{:?} ** RA", other)
     }
 
-    fn __rmatmul__(&self, other: &PyAny) -> String {
+    fn __rmatmul__(_slf: PyRef<Self>, other: &PyAny) -> String {
         format!("{:?} @ RA", other)
     }
 }
 
 #[pyproto]
 impl PyObjectProtocol for LhsAndRhs {
-    fn __repr__(&self) -> &'static str {
+    fn __repr__(_slf: PyRef<Self>) -> &'static str {
         "BA"
     }
 }
@@ -413,18 +413,18 @@ struct RichComparisons {}
 
 #[pyproto]
 impl PyObjectProtocol for RichComparisons {
-    fn __repr__(&self) -> &'static str {
+    fn __repr__(_slf: PyRef<Self>) -> &'static str {
         "RC"
     }
 
-    fn __richcmp__(&self, other: &PyAny, op: CompareOp) -> String {
+    fn __richcmp__(slf: PyRef<Self>, other: &PyAny, op: CompareOp) -> String {
         match op {
-            CompareOp::Lt => format!("{} < {:?}", self.__repr__(), other),
-            CompareOp::Le => format!("{} <= {:?}", self.__repr__(), other),
-            CompareOp::Eq => format!("{} == {:?}", self.__repr__(), other),
-            CompareOp::Ne => format!("{} != {:?}", self.__repr__(), other),
-            CompareOp::Gt => format!("{} > {:?}", self.__repr__(), other),
-            CompareOp::Ge => format!("{} >= {:?}", self.__repr__(), other),
+            CompareOp::Lt => format!("{} < {:?}", RichComparisons::__repr__(slf), other),
+            CompareOp::Le => format!("{} <= {:?}", RichComparisons::__repr__(slf), other),
+            CompareOp::Eq => format!("{} == {:?}", RichComparisons::__repr__(slf), other),
+            CompareOp::Ne => format!("{} != {:?}", RichComparisons::__repr__(slf), other),
+            CompareOp::Gt => format!("{} > {:?}", RichComparisons::__repr__(slf), other),
+            CompareOp::Ge => format!("{} >= {:?}", RichComparisons::__repr__(slf), other),
         }
     }
 }
@@ -434,11 +434,11 @@ struct RichComparisons2 {}
 
 #[pyproto]
 impl PyObjectProtocol for RichComparisons2 {
-    fn __repr__(&self) -> &'static str {
+    fn __repr__(_slf: PyRef<Self>) -> &'static str {
         "RC2"
     }
 
-    fn __richcmp__(&self, other: &PyAny, op: CompareOp) -> PyObject {
+    fn __richcmp__(_slf: PyRef<Self>, other: &PyAny, op: CompareOp) -> PyObject {
         match op {
             CompareOp::Eq => true.into_py(other.py()),
             CompareOp::Ne => false.into_py(other.py()),
@@ -509,11 +509,11 @@ mod return_not_implemented {
 
     #[pyproto]
     impl<'p> PyObjectProtocol<'p> for RichComparisonToSelf {
-        fn __repr__(&self) -> &'static str {
+        fn __repr__(_slf: PyRef<Self>) -> &'static str {
             "RC_Self"
         }
 
-        fn __richcmp__(&self, other: PyRef<'p, Self>, _op: CompareOp) -> PyObject {
+        fn __richcmp__(_slf: PyRef<Self>, other: PyRef<'p, Self>, _op: CompareOp) -> PyObject {
             other.py().None()
         }
     }
@@ -564,19 +564,19 @@ mod return_not_implemented {
         }
 
         // Inplace assignments
-        fn __iadd__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __isub__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __imul__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __imatmul__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __itruediv__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __ifloordiv__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __imod__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __ipow__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __ilshift__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __irshift__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __iand__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __ior__(&'p mut self, _other: PyRef<'p, Self>) {}
-        fn __ixor__(&'p mut self, _other: PyRef<'p, Self>) {}
+        fn __iadd__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __isub__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __imul__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __imatmul__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __itruediv__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __ifloordiv__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __imod__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __ipow__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __ilshift__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __irshift__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __iand__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __ior__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
+        fn __ixor__(mut _slf: PyRefMut<Self>, _other: PyRef<'p, Self>) {}
     }
 
     fn _test_binary_dunder(dunder: &str) {

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -8,6 +8,7 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_pyclass_args.rs");
     t.compile_fail("tests/ui/invalid_pyfunctions.rs");
     t.compile_fail("tests/ui/invalid_pymethods.rs");
+    t.compile_fail("tests/ui/invalid_pyproto_receiver.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
     t.compile_fail("tests/ui/invalid_argument_attributes.rs");
     t.compile_fail("tests/ui/reject_generics.rs");

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -26,7 +26,7 @@ pub struct PyA {
 
 #[pyproto]
 impl PyMappingProtocol for PyA {
-    fn __getitem__(&self, key: String) -> pyo3::PyResult<String> {
+    fn __getitem__(_slf: PyRef<Self>, key: String) -> pyo3::PyResult<String> {
         if key == "t" {
             Ok("bar".into())
         } else {

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -35,23 +35,23 @@ impl Mapping {
 
 #[pyproto]
 impl PyMappingProtocol for Mapping {
-    fn __len__(&self) -> usize {
-        self.index.len()
+    fn __len__(slf: PyRef<Self>) -> usize {
+        slf.index.len()
     }
 
-    fn __getitem__(&self, query: String) -> PyResult<usize> {
-        self.index
+    fn __getitem__(slf: PyRef<Self>, query: String) -> PyResult<usize> {
+        slf.index
             .get(&query)
             .copied()
             .ok_or_else(|| PyKeyError::new_err("unknown key"))
     }
 
-    fn __setitem__(&mut self, key: String, value: usize) {
-        self.index.insert(key, value);
+    fn __setitem__(mut slf: PyRefMut<Self>, key: String, value: usize) {
+        slf.index.insert(key, value);
     }
 
-    fn __delitem__(&mut self, key: String) -> PyResult<()> {
-        if self.index.remove(&key).is_none() {
+    fn __delitem__(mut slf: PyRefMut<Self>, key: String) -> PyResult<()> {
+        if slf.index.remove(&key).is_none() {
             Err(PyKeyError::new_err("unknown key"))
         } else {
             Ok(())
@@ -59,9 +59,9 @@ impl PyMappingProtocol for Mapping {
     }
 
     /// not an actual reversed implementation, just to demonstrate that the method is callable.
-    fn __reversed__(&self) -> PyObject {
+    fn __reversed__(slf: PyRef<Self>) -> PyObject {
         let gil = Python::acquire_gil();
-        self.index
+        slf.index
             .keys()
             .cloned()
             .collect::<Vec<String>>()

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -33,48 +33,48 @@ impl ByteSequence {
 
 #[pyproto]
 impl PySequenceProtocol for ByteSequence {
-    fn __len__(&self) -> usize {
-        self.elements.len()
+    fn __len__(slf: PyRef<Self>) -> usize {
+        slf.elements.len()
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<u8> {
-        self.elements
+    fn __getitem__(slf: PyRef<Self>, idx: isize) -> PyResult<u8> {
+        slf.elements
             .get(idx as usize)
             .copied()
             .ok_or_else(|| PyIndexError::new_err("list index out of range"))
     }
 
-    fn __setitem__(&mut self, idx: isize, value: u8) {
-        self.elements[idx as usize] = value;
+    fn __setitem__(mut slf: PyRefMut<Self>, idx: isize, value: u8) {
+        slf.elements[idx as usize] = value;
     }
 
-    fn __delitem__(&mut self, idx: isize) -> PyResult<()> {
-        if (idx < self.elements.len() as isize) && (idx >= 0) {
-            self.elements.remove(idx as usize);
+    fn __delitem__(mut slf: PyRefMut<Self>, idx: isize) -> PyResult<()> {
+        if (idx < slf.elements.len() as isize) && (idx >= 0) {
+            slf.elements.remove(idx as usize);
             Ok(())
         } else {
             Err(PyIndexError::new_err("list index out of range"))
         }
     }
 
-    fn __contains__(&self, other: &PyAny) -> bool {
+    fn __contains__(slf: PyRef<Self>, other: &PyAny) -> bool {
         match u8::extract(other) {
-            Ok(x) => self.elements.contains(&x),
+            Ok(x) => slf.elements.contains(&x),
             Err(_) => false,
         }
     }
 
-    fn __concat__(&self, other: PyRef<'p, Self>) -> Self {
-        let mut elements = self.elements.clone();
+    fn __concat__(slf: PyRef<Self>, other: PyRef<'p, Self>) -> Self {
+        let mut elements = slf.elements.clone();
         elements.extend_from_slice(&other.elements);
         Self { elements }
     }
 
-    fn __repeat__(&self, count: isize) -> PyResult<Self> {
+    fn __repeat__(slf: PyRef<Self>, count: isize) -> PyResult<Self> {
         if count >= 0 {
-            let mut elements = Vec::with_capacity(self.elements.len() * count as usize);
+            let mut elements = Vec::with_capacity(slf.elements.len() * count as usize);
             for _ in 0..count {
-                elements.extend(&self.elements);
+                elements.extend(&slf.elements);
             }
             Ok(Self { elements })
         } else {
@@ -273,8 +273,8 @@ struct OptionList {
 
 #[pyproto]
 impl PySequenceProtocol for OptionList {
-    fn __getitem__(&self, idx: isize) -> PyResult<Option<i64>> {
-        match self.items.get(idx as usize) {
+    fn __getitem__(slf: PyRef<Self>, idx: isize) -> PyResult<Option<i64>> {
+        match slf.items.get(idx as usize) {
             Some(x) => Ok(*x),
             None => Err(PyIndexError::new_err("Index out of bounds")),
         }

--- a/tests/ui/invalid_pyproto_receiver.rs
+++ b/tests/ui/invalid_pyproto_receiver.rs
@@ -1,0 +1,21 @@
+use pyo3::prelude::*;
+use pyo3::class::basic::PyObjectProtocol;
+use pyo3::class::mapping::PyMappingProtocol;
+
+#[pyclass]
+struct MyClass {}
+
+// Before PyO3 0.14 #[pyproto] allowed receivers. Now only `TryFromPyCell` types (e.g.
+// `PyRef<Self>` etc.) are allowed.
+
+#[pyproto]
+impl PyObjectProtocol for MyClass {
+    fn __str__(&self) -> &'static str {  "hello, world" }
+}
+
+#[pyproto]
+impl PyMappingProtocol for MyClass {
+    fn __delitem__(&mut self, item: &PyAny) { }
+}
+
+fn main() {}

--- a/tests/ui/invalid_pyproto_receiver.stderr
+++ b/tests/ui/invalid_pyproto_receiver.stderr
@@ -1,0 +1,25 @@
+error: since PyO3 0.14 receivers cannot be used in `#[pyproto]`. Replace `&self` with `slf: PyRef<Self>`.
+  --> $DIR/invalid_pyproto_receiver.rs:13:16
+   |
+13 |     fn __str__(&self) -> &'static str {  "hello, world" }
+   |                ^
+
+error: since PyO3 0.14 receivers cannot be used in `#[pyproto]`. Replace `&mut self` with `mut slf: PyRefMut<Self>`.
+  --> $DIR/invalid_pyproto_receiver.rs:18:20
+   |
+18 |     fn __delitem__(&mut self, item: &PyAny) { }
+   |                    ^
+
+warning: unused import: `pyo3::class::basic::PyObjectProtocol`
+ --> $DIR/invalid_pyproto_receiver.rs:2:5
+  |
+2 | use pyo3::class::basic::PyObjectProtocol;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
+warning: unused import: `pyo3::class::mapping::PyMappingProtocol`
+ --> $DIR/invalid_pyproto_receiver.rs:3:5
+  |
+3 | use pyo3::class::mapping::PyMappingProtocol;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #1205 

This PR changes all `#[pyproto]` methods to use `TryFromPyCell` trait instead of having `&self` or `&mut self` receivers, as proposed as option 1 in https://github.com/PyO3/pyo3/issues/1206#issuecomment-760549473

Needs a lot of documenting before this can merge - it's a pretty tedious breaking change for users to have to migrate from. It's so annoying that I'm not sure the advantages are worth the migration costs for most users. For users that have problems noted in #1206, this PR enables access to `self.py()` and base classes - `PyRef` can do these things, `&self` can't.

I'd welcome feedback on whether this is worth merging, or we should consider instead the more drastic option 2 in https://github.com/PyO3/pyo3/issues/1206#issuecomment-760549473 and remove `#[pyproto]` completely.

Moving all `#[pyproto]` methods to `#[pymethods]` might be a much easier migration for users than having to change all `&self` to `PyRef<Self>`.