### PR TITLE
ffi: prevent segfault with datetime bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix use of Python argument for #[pymethods] inside macro expansions. [#1505](https://github.com/PyO3/pyo3/pull/1505)
 - Always use cross-compiling configuration if any of the environment variables are set. [#1514](https://github.com/PyO3/pyo3/pull/1514)
 - Support `EnvironmentError`, `IOError`, and `WindowsError` on PyPy. [#1533](https://github.com/PyO3/pyo3/pull/1533)
+- Segfault when dereferencing `ffi::PyDateTimeAPI` without the GIL. [#1563](https://github.com/PyO3/pyo3/pull/1563)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging


### PR DESCRIPTION
This fixes a segfault achievable entirely in safe Rust:

```
fn main() {
    assert!(pyo3::ffi::PyDateTimeAPI.DateType == std::ptr::null_mut())
}
```

The `Deref` implementation for `PyDateTimeAPI` can call Python APIs, but before this PR it didn't check whether the GIL is actually held.