### PR TITLE
ci: allow coverage cache to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
             ~/.cargo/git
             target
           key: coverage-cargo-${{ hashFiles('**/Cargo.toml') }}
+        continue-on-error: true
       - name: install grcov
         run: |
           wget https://github.com/mozilla/grcov/releases/download/v${GRCOV_VERSION}/grcov-linux-x86_64.tar.bz2 -qO- | tar -xjvf -


### PR DESCRIPTION
Same as #1564 but for the `coverage` job.