### PR TITLE
ffi: support PyDateTime_TimeZone_UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add FFI definition `Py_IS_TYPE`. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 - Add FFI definition `_Py_InitializeMain`. [#1473](https://github.com/PyO3/pyo3/pull/1473)
 - Add tuple and unit struct support for `#[pyclass]` macro. [#1504](https://github.com/PyO3/pyo3/pull/1504)
+- Add FFI definition `PyDateTime_TimeZone_UTC`. [#1572](https://github.com/PyO3/pyo3/pull/1572)
 
 ### Changed
 - Change `PyTimeAcces::get_fold()` to return a `bool` instead of a `u8`. [#1397](https://github.com/PyO3/pyo3/pull/1397)


### PR DESCRIPTION
This adds a symbol for `PyDateTime_TimeZone_UTC`, as discussed in #207.

I made it work like `PyDateTimeAPI`, where it has a `Deref` impl which in this case yields `&'static PyObject`.  I'm slightly split on whether I like this approach; in particular because it can run a Python import in the background on first use. On the other hand, it's safe and convenient for users.

~~TODO: add a test.~~