### PR TITLE
coverage: also run compile_error tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,38 +215,29 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: coverage-cargo-${{ hashFiles('**/Cargo.toml') }}
         continue-on-error: true
-      - name: install grcov
+      - name: install cargo-llvm-cov
         run: |
-          wget https://github.com/mozilla/grcov/releases/download/v${GRCOV_VERSION}/grcov-linux-x86_64.tar.bz2 -qO- | tar -xjvf -
-          mv grcov ~/.cargo/bin
+          wget https://github.com/taiki-e/cargo-llvm-cov/releases/download/v${CARGO_LLVM_COV_VERSION}/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz -qO- | tar -xzvf -
+          mv cargo-llvm-cov ~/.cargo/bin
         env:
-          GRCOV_VERSION: 0.7.1
+          CARGO_LLVM_COV_VERSION: 0.1.0-alpha.5
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           override: true
           profile: minimal
           components: llvm-tools-preview
-      - run: cargo test --no-default-features --no-fail-fast
-      - run: cargo test --no-default-features --no-fail-fast --features "macros num-bigint num-complex hashbrown indexmap serde multiple-pymethods"
-      - run: cargo test --manifest-path=pyo3-macros-backend/Cargo.toml
-      - run: cargo test --manifest-path=pyo3-build-config/Cargo.toml
-      # can't yet use actions-rs/grcov with source-based coverage: https://github.com/actions-rs/grcov/issues/105
-      # - uses: actions-rs/grcov@v0.1
-      #   id: coverage
-      # - uses: codecov/codecov-action@v1
-      #   with:
-      #     file: ${{ steps.coverage.outputs.report }}
-      - run: grcov . --binary-path target/debug/deps/ -s . -t lcov --branch --ignore-not-existing -o coverage.lcov
+      # TODO: workaround for
+      # https://github.com/taiki-e/cargo-llvm-cov/issues/48, shouldn't be needed
+      # in next cargo-llvm-cov release.
+      - run: cargo clean
+      - run: |
+          cargo llvm-cov \
+            --package pyo3 pyo3-build-config pyo3-macros-backend pyo3-macros \
+            --features "macros num-bigint num-complex hashbrown indexmap serde" \
+            --lcov --output-path coverage.lcov
       - uses: codecov/codecov-action@v1
         with:
           file: coverage.lcov
-
-    env:
-      CARGO_TERM_VERBOSE: true
-      RUSTFLAGS: "-Zinstrument-coverage"
-      RUSTDOCFLAGS: "-Zinstrument-coverage"
-      LLVM_PROFILE_FILE: "coverage-%p-%m.profraw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde = {version = "1.0", optional = true}
 assert_approx_eq = "1.1.0"
 # O.3.5 uses the matches! macro, which isn't compatible with Rust 1.41
 criterion = "=0.3.4"
-trybuild = "1.0.23"
+trybuild = "1.0.44"
 rustversion = "1.0"
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 # features needed to run the PyO3 test suite

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,6 +1,19 @@
 #[rustversion::stable]
 #[test]
 fn test_compile_errors() {
+    // stable - require all tests to pass
+    _test_compile_errors()
+}
+
+#[rustversion::nightly]
+#[test]
+fn test_compile_errors() {
+    // nightly - don't care if test output is potentially wrong, to avoid churn in PyO3's CI thanks
+    // to diagnostics changing on nightly.
+    let _ = std::panic::catch_unwind(_test_compile_errors);
+}
+
+fn _test_compile_errors() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/invalid_macro_args.rs");
     t.compile_fail("tests/ui/invalid_need_module_arg_position.rs");


### PR DESCRIPTION
At the moment the compile errors only get tested on stable Rust, so they aren't included in the coverage job.

This is a little experiment to see if they get enabled - it should improve coverage information for the macros if it worked.