### PR TITLE
examples: use pip 21.1

### DIFF
--- a/examples/maturin-starter/tox.ini
+++ b/examples/maturin-starter/tox.ini
@@ -4,9 +4,11 @@ skipsdist = true
 
 [testenv]
 description = Run the unit tests under {basepython}
-deps = -rrequirements-dev.txt
+deps =
+    pip>=21.1 # for in-tree-build
+    -rrequirements-dev.txt
 commands =
-    # Use pip master with in-tree-build feature (to be released in pip 21.0)
-    python -m pip install --upgrade git+https://github.com/pypa/pip.git
+    # --use-feature=in-tree-build is necessary because this example is inside
+    # the PyO3 repo.
     python -m pip install . --use-feature=in-tree-build
     pytest {posargs}

--- a/examples/pyo3-benchmarks/requirements-dev.txt
+++ b/examples/pyo3-benchmarks/requirements-dev.txt
@@ -1,4 +1,3 @@
-pip>=19.1
 pytest>=3.5.0
 setuptools-rust>=0.10.2
 pytest-benchmark~=3.2

--- a/examples/pyo3-pytests/requirements-dev.txt
+++ b/examples/pyo3-pytests/requirements-dev.txt
@@ -1,4 +1,3 @@
-pip>=19.1
 hypothesis>=3.55
 pytest>=3.5.0
 psutil>=5.6

--- a/examples/pyo3-pytests/tox.ini
+++ b/examples/pyo3-pytests/tox.ini
@@ -4,9 +4,11 @@ skipsdist = true
 
 [testenv]
 description = Run the unit tests under {basepython}
-deps = -rrequirements-dev.txt
+deps =
+    pip>=21.1 # for in-tree-build
+    -rrequirements-dev.txt
 commands =
-    # Use pip master with in-tree-build feature (to be released in pip 21.1)
-    python -m pip install --upgrade git+https://github.com/pypa/pip.git
+    # --use-feature=in-tree-build is necessary because this example is inside
+    # the PyO3 repo.
     python -m pip install . --use-feature=in-tree-build
     pytest {posargs}

--- a/examples/setuptools-rust-starter/tox.ini
+++ b/examples/setuptools-rust-starter/tox.ini
@@ -6,7 +6,5 @@ skipsdist = true
 description = Run the unit tests under {basepython}
 deps = -rrequirements-dev.txt
 commands =
-    # Use pip master with in-tree-build feature (to be released in pip 21.1)
-    python -m pip install --upgrade git+https://github.com/pypa/pip.git
-    python -m pip install . --use-feature=in-tree-build
+    python setup.py install
     pytest {posargs}

--- a/examples/word-count/requirements-dev.txt
+++ b/examples/word-count/requirements-dev.txt
@@ -1,4 +1,3 @@
-pip>=19.1
 pytest>=3.5.0
 setuptools-rust>=0.10.2
 pytest-benchmark>=3.1.1


### PR DESCRIPTION
pip 21.1 is now released so we can use that instead of master.