### PR TITLE
datetime: support timezone bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `timezone_utc()`. [#1588](https://github.com/PyO3/pyo3/pull/1588)
 - Implement `ToPyObject` for `[T; N]`. [#2313](https://github.com/PyO3/pyo3/pull/2313)
 - Added the internal `IntoPyResult` trait to give better error messages when function return types do not implement `IntoPy`. [#2326](https://github.com/PyO3/pyo3/pull/2326)
 - Add `PyDictKeys`, `PyDictValues` and `PyDictItems` Rust types to represent `dict_keys`, `dict_values` and `dict_items` types. [#2358](https://github.com/PyO3/pyo3/pull/2358)
@@ -26,10 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `CompareOp::matches` to easily implement `__richcmp__` as the result of a
   Rust `std::cmp::Ordering` comparison. [#2460](https://github.com/PyO3/pyo3/pull/2460)
 - Supprt `#[pyo3(name)]` on enum variants [#2457](https://github.com/PyO3/pyo3/pull/2457)
-- Add `PySuper` object [#2049](https://github.com/PyO3/pyo3/issues/2049) 
+- Add `PySuper` object [#2049](https://github.com/PyO3/pyo3/issues/2049)
 
 ### Changed
 
+- Change datetime constructors taking a `tzinfo` to take `Option<&PyTzInfo>` instead of `Option<&PyObject>`: `PyDateTime::new()`, `PyDateTime::new_with_fold()`, `PyTime::new()`, and `PyTime::new_with_fold()`. [#1588](https://github.com/PyO3/pyo3/pull/1588)
 - Several methods of `Py` and `PyAny` now accept `impl IntoPy<Py<PyString>>` rather than just `&str` to allow use of the `intern!` macro. [#2312](https://github.com/PyO3/pyo3/pull/2312)
 - Move `PyTypeObject::type_object` method to `PyTypeInfo` trait, and deprecate `PyTypeObject` trait. [#2287](https://github.com/PyO3/pyo3/pull/2287)
 - The deprecated `pyproto` feature is now disabled by default. [#2322](https://github.com/PyO3/pyo3/pull/2322)

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -574,8 +574,17 @@ pub unsafe fn PyTZInfo_CheckExact(op: *mut PyObject) -> c_int {
 // skipped non-limited PyTime_FromTime
 // skipped non-limited PyTime_FromTimeAndFold
 // skipped non-limited PyDelta_FromDSU
-// skipped non-limited PyTimeZone_FromOffset
-// skipped non-limited PyTimeZone_FromOffsetAndName
+
+pub unsafe fn PyTimeZone_FromOffset(offset: *mut PyObject) -> *mut PyObject {
+    ((*PyDateTimeAPI()).TimeZone_FromTimeZone)(offset, std::ptr::null_mut())
+}
+
+pub unsafe fn PyTimeZone_FromOffsetAndName(
+    offset: *mut PyObject,
+    name: *mut PyObject,
+) -> *mut PyObject {
+    ((*PyDateTimeAPI()).TimeZone_FromTimeZone)(offset, name)
+}
 
 #[cfg(not(PyPy))]
 pub unsafe fn PyDateTime_FromTimestamp(args: *mut PyObject) -> *mut PyObject {

--- a/pytests/src/datetime.rs
+++ b/pytests/src/datetime.rs
@@ -33,14 +33,7 @@ fn make_time<'p>(
     microsecond: u32,
     tzinfo: Option<&PyTzInfo>,
 ) -> PyResult<&'p PyTime> {
-    PyTime::new(
-        py,
-        hour,
-        minute,
-        second,
-        microsecond,
-        tzinfo.map(|o| o.to_object(py)).as_ref(),
-    )
+    PyTime::new(py, hour, minute, second, microsecond, tzinfo)
 }
 
 #[pyfunction]
@@ -53,15 +46,7 @@ fn time_with_fold<'p>(
     tzinfo: Option<&PyTzInfo>,
     fold: bool,
 ) -> PyResult<&'p PyTime> {
-    PyTime::new_with_fold(
-        py,
-        hour,
-        minute,
-        second,
-        microsecond,
-        tzinfo.map(|o| o.to_object(py)).as_ref(),
-        fold,
-    )
+    PyTime::new_with_fold(py, hour, minute, second, microsecond, tzinfo, fold)
 }
 
 #[pyfunction]
@@ -130,7 +115,7 @@ fn make_datetime<'p>(
         minute,
         second,
         microsecond,
-        tzinfo.map(|o| (o.to_object(py))).as_ref(),
+        tzinfo,
     )
 }
 

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -21,7 +21,7 @@ use crate::ffi::{
 };
 use crate::instance::PyNativeType;
 use crate::types::PyTuple;
-use crate::{AsPyPointer, PyAny, PyObject, Python, ToPyObject};
+use crate::{AsPyPointer, IntoPy, Py, PyAny, Python};
 use std::os::raw::c_int;
 
 fn ensure_datetime_api(_py: Python<'_>) -> &'static PyDateTime_CAPI {
@@ -244,7 +244,7 @@ impl PyDateTime {
         minute: u8,
         second: u8,
         microsecond: u32,
-        tzinfo: Option<&PyObject>,
+        tzinfo: Option<&PyTzInfo>,
     ) -> PyResult<&'p PyDateTime> {
         let api = ensure_datetime_api(py);
         unsafe {
@@ -280,7 +280,7 @@ impl PyDateTime {
         minute: u8,
         second: u8,
         microsecond: u32,
-        tzinfo: Option<&PyObject>,
+        tzinfo: Option<&PyTzInfo>,
         fold: bool,
     ) -> PyResult<&'p PyDateTime> {
         let api = ensure_datetime_api(py);
@@ -303,20 +303,13 @@ impl PyDateTime {
 
     /// Construct a `datetime` object from a POSIX timestamp
     ///
-    /// This is equivalent to `datetime.datetime.from_timestamp`
+    /// This is equivalent to `datetime.datetime.fromtimestamp`
     pub fn from_timestamp<'p>(
         py: Python<'p>,
         timestamp: f64,
-        time_zone_info: Option<&PyTzInfo>,
+        tzinfo: Option<&PyTzInfo>,
     ) -> PyResult<&'p PyDateTime> {
-        let timestamp: PyObject = timestamp.to_object(py);
-
-        let time_zone_info: PyObject = match time_zone_info {
-            Some(time_zone_info) => time_zone_info.to_object(py),
-            None => py.None(),
-        };
-
-        let args = PyTuple::new(py, &[timestamp, time_zone_info]);
+        let args: Py<PyTuple> = (timestamp, tzinfo).into_py(py);
 
         // safety ensure API is loaded
         let _api = ensure_datetime_api(py);
@@ -396,7 +389,7 @@ impl PyTime {
         minute: u8,
         second: u8,
         microsecond: u32,
-        tzinfo: Option<&PyObject>,
+        tzinfo: Option<&PyTzInfo>,
     ) -> PyResult<&'p PyTime> {
         let api = ensure_datetime_api(py);
         unsafe {
@@ -419,7 +412,7 @@ impl PyTime {
         minute: u8,
         second: u8,
         microsecond: u32,
-        tzinfo: Option<&PyObject>,
+        tzinfo: Option<&PyTzInfo>,
         fold: bool,
     ) -> PyResult<&'p PyTime> {
         let api = ensure_datetime_api(py);
@@ -473,9 +466,11 @@ impl PyTzInfoAccess for PyTime {
     }
 }
 
-/// Bindings for `datetime.tzinfo`
+/// Bindings for `datetime.tzinfo`.
 ///
-/// This is an abstract base class and should not be constructed directly.
+/// This is an abstract base class and cannot be constructed directly.
+/// For concrete time zone implementations, see [`timezone_utc`] and
+/// the [`zoneinfo` module](https://docs.python.org/3/library/zoneinfo.html).
 #[repr(transparent)]
 pub struct PyTzInfo(PyAny);
 pyobject_native_type!(
@@ -485,6 +480,11 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyTZInfo_Check
 );
+
+/// Equivalent to `datetime.timezone.utc`
+pub fn timezone_utc(py: Python<'_>) -> &PyTzInfo {
+    unsafe { &*(ensure_datetime_api(py).TimeZone_UTC as *const PyTzInfo) }
+}
 
 /// Bindings for `datetime.timedelta`
 #[repr(transparent)]
@@ -535,7 +535,7 @@ impl PyDeltaAccess for PyDelta {
 }
 
 // Utility function
-fn opt_to_pyobj(py: Python<'_>, opt: Option<&PyObject>) -> *mut ffi::PyObject {
+fn opt_to_pyobj(py: Python<'_>, opt: Option<&PyTzInfo>) -> *mut ffi::PyObject {
     // Convenience function for unpacking Options to either an Object or None
     match opt {
         Some(tzi) => tzi.as_ptr(),
@@ -545,12 +545,51 @@ fn opt_to_pyobj(py: Python<'_>, opt: Option<&PyObject>) -> *mut ffi::PyObject {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    #[cfg(feature = "macros")]
+    use crate::py_run;
+
+    #[test]
+    #[cfg(feature = "macros")]
+    #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
+    fn test_datetime_fromtimestamp() {
+        Python::with_gil(|py| {
+            let dt = PyDateTime::from_timestamp(py, 100.0, None).unwrap();
+            py_run!(
+                py,
+                dt,
+                "import datetime; assert dt == datetime.datetime.fromtimestamp(100)"
+            );
+
+            {
+                let dt = PyDateTime::from_timestamp(py, 100.0, Some(timezone_utc(py))).unwrap();
+                py_run!(
+                py,
+                dt,
+                "import datetime; assert dt == datetime.datetime.fromtimestamp(100, datetime.timezone.utc)"
+            );
+            }
+        })
+    }
+
+    #[test]
+    #[cfg(feature = "macros")]
+    #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
+    fn test_date_fromtimestamp() {
+        Python::with_gil(|py| {
+            let dt = PyDate::from_timestamp(py, 100).unwrap();
+            py_run!(
+                py,
+                dt,
+                "import datetime; assert dt == datetime.date.fromtimestamp(100)"
+            );
+        })
+    }
+
     #[test]
     #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_new_with_fold() {
-        crate::Python::with_gil(|py| {
-            use crate::types::{PyDateTime, PyTimeAccess};
-
+        Python::with_gil(|py| {
             let a = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, false);
             let b = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, true);
 
@@ -559,29 +598,23 @@ mod tests {
         });
     }
 
-    #[cfg(not(PyPy))]
     #[test]
     #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_get_tzinfo() {
         crate::Python::with_gil(|py| {
-            use crate::conversion::ToPyObject;
-            use crate::types::{PyDateTime, PyTime, PyTzInfoAccess};
+            let utc = timezone_utc(py);
 
-            let datetime = py.import("datetime").map_err(|e| e.print(py)).unwrap();
-            let timezone = datetime.getattr("timezone").unwrap();
-            let utc = timezone.getattr("utc").unwrap().to_object(py);
+            let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(utc)).unwrap();
 
-            let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(&utc)).unwrap();
-
-            assert!(dt.get_tzinfo().unwrap().eq(&utc).unwrap());
+            assert!(dt.get_tzinfo().unwrap().eq(utc).unwrap());
 
             let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, None).unwrap();
 
             assert!(dt.get_tzinfo().is_none());
 
-            let t = PyTime::new(py, 0, 0, 0, 0, Some(&utc)).unwrap();
+            let t = PyTime::new(py, 0, 0, 0, 0, Some(utc)).unwrap();
 
-            assert!(t.get_tzinfo().unwrap().eq(&utc).unwrap());
+            assert!(t.get_tzinfo().unwrap().eq(utc).unwrap());
 
             let t = PyTime::new(py, 0, 0, 0, 0, None).unwrap();
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,8 +12,8 @@ pub use self::code::PyCode;
 pub use self::complex::PyComplex;
 #[cfg(not(Py_LIMITED_API))]
 pub use self::datetime::{
-    PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess, PyTzInfo,
-    PyTzInfoAccess,
+    timezone_utc, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess,
+    PyTzInfo, PyTzInfoAccess,
 };
 pub use self::dict::{IntoPyDict, PyDict};
 pub use self::floatob::PyFloat;

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -1,7 +1,7 @@
 #![cfg(not(Py_LIMITED_API))]
 
 use pyo3::prelude::*;
-use pyo3::types::IntoPyDict;
+use pyo3::types::{timezone_utc, IntoPyDict};
 use pyo3_ffi::PyDateTime_IMPORT;
 
 fn _get_subclasses<'p>(
@@ -110,11 +110,9 @@ fn test_datetime_utc() {
 
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let datetime = py.import("datetime").map_err(|e| e.print(py)).unwrap();
-    let timezone = datetime.getattr("timezone").unwrap();
-    let utc = timezone.getattr("utc").unwrap().to_object(py);
+    let utc = timezone_utc(py);
 
-    let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(&utc)).unwrap();
+    let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(utc)).unwrap();
 
     let locals = [("dt", dt)].into_py_dict(py);
 


### PR DESCRIPTION
This PR implements safe wrappers for the Python 3.7 timezone bindings described in #207.

Rather than try to do anything complicated with a new type representing _exactly_ `datetime.timezone`, I return `&PyTzInfo` from the three new functions `timezone_utc()`, `timezone_from_offset()` and `timezone_from_offset_and_name()`. I think this is good enough to be useful; `datetime.timezone` is a subclass of `datetime.tzinfo` so doing this is correct.

I also adjusted a few constructors taking `tzinfo` arguments to take `Option<&PyTzInfo>` instead of `Option<&PyObject>`.

Finally, I tweaked the ffi symbol `PyDateTime_TimeZone_UTC` I added recently in #1573 to resolve to `&'static *mut ffi::PyObject`, which I think is a more correct representation of the "unsafe ffi" nature of that global.

Closes #207

cc @pganssle in case you might be interested / have an opinion on this.