### PR TITLE
Expand wrap_pyfunction!() to a closure to improve deduction.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ pub mod proc_macro {
 #[macro_export]
 macro_rules! wrap_pyfunction {
     ($function_name: ident) => {{
-        &pyo3::paste::expr! { [<__pyo3_get_function_ $function_name>] }
+        &|py| pyo3::paste::expr! { [<__pyo3_get_function_ $function_name>] }(py)
     }};
 
     ($function_name: ident, $arg: expr) => {

--- a/tests/test_wrap_pyfunction_deduction.rs
+++ b/tests/test_wrap_pyfunction_deduction.rs
@@ -1,0 +1,13 @@
+use pyo3::{prelude::*, types::PyCFunction, wrap_pyfunction};
+
+#[pyfunction]
+fn f() {}
+
+pub fn add_wrapped(wrapper: &impl Fn(Python) -> PyResult<&PyCFunction>) {
+    let _ = wrapper;
+}
+
+#[test]
+fn wrap_pyfunction_deduction() {
+    add_wrapped(wrap_pyfunction!(f));
+}


### PR DESCRIPTION
This changes `wrap_pyfunction!()` to expand to a closure, to improve deduction when passed to a function without the GIL lifetime.

The change to wrap_pyfunction!() in #1143 makes it impossible to implement `context.add_wrapped(wrap_pyfunction!(something))` in `inline-python`. `context` does not carry the GIL lifetime, which causes type deduction trouble now that `wrap_pyfunction` results in a generic function.

```
error[E0308]: mismatched types
  --> examples/rust-fn.rs:12:4
   |
12 |     c.add_wrapped(wrap_pyfunction!(rust_print));
   |       ^^^^^^^^^^^ one type is more general than the other
   |
   = note: expected enum `Result<&pyo3::types::PyCFunction, _>`
              found enum `Result<&pyo3::types::PyCFunction, _>`
```

By re-wrapping the function as a closure, we trigger [closure signature deduction](https://github.com/rust-lang/rust/blob/1d99508b52499c9efd213738e71927458c1d394e/compiler/rustc_typeck/src/check/closure.rs#L320-L366) instead of the regular deduction rules when passing `wrap_pyfunction!()` as an argument to a function: Rustc will deduce the signature of the closure from the bounds of the function that closure is passed to. This way, the generic arguments can be deduced in more contexts, fixing the problem.