### PR TITLE
rust: updates for rust 1.52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ fmt:
 	black . --check
 
 clippy:
-	@touch src/lib.rs  # Touching file to ensure that cargo clippy will re-check the project
 	cargo clippy --features="num-bigint num-complex hashbrown serde" --tests -- -Dwarnings
 	cargo clippy --features="abi3 num-bigint num-complex hashbrown serde" --tests -- -Dwarnings
 	for example in examples/*; do cargo clippy --manifest-path $$example/Cargo.toml -- -Dwarnings || exit 1; done

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -380,10 +380,7 @@ impl<T> Py<T> {
     /// If non-null, `ptr` must be a pointer to a Python object of type T.
     #[inline]
     pub unsafe fn from_owned_ptr_or_opt(_py: Python, ptr: *mut ffi::PyObject) -> Option<Self> {
-        match NonNull::new(ptr) {
-            Some(nonnull_ptr) => Some(Py(nonnull_ptr, PhantomData)),
-            None => None,
-        }
+        NonNull::new(ptr).map(|nonnull_ptr| Py(nonnull_ptr, PhantomData))
     }
 
     /// Create a `Py<T>` instance by creating a new reference from the given FFI pointer.

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -459,6 +459,7 @@ impl PyAny {
     /// Returns the length of the sequence or mapping.
     ///
     /// This is equivalent to the Python expression `len(self)`.
+    #[allow(clippy::clippy::len_without_is_empty)]
     pub fn len(&self) -> PyResult<usize> {
         let v = unsafe { ffi::PyObject_Size(self.as_ptr()) };
         if v == -1 {

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -18,6 +18,7 @@ impl PySequence {
     ///
     /// This is equivalent to the Python expression `len(self)`.
     #[inline]
+    #[allow(clippy::clippy::len_without_is_empty)]
     pub fn len(&self) -> PyResult<isize> {
         let v = unsafe { ffi::PySequence_Size(self.as_ptr()) };
         if v == -1 {

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -15,6 +15,7 @@ fn test_compile_errors() {
     tests_rust_1_45(&t);
     tests_rust_1_48(&t);
     tests_rust_1_49(&t);
+    tests_rust_1_52(&t);
 
     #[rustversion::since(1.45)]
     fn tests_rust_1_45(t: &trybuild::TestCases) {
@@ -25,7 +26,6 @@ fn test_compile_errors() {
 
     #[rustversion::since(1.48)]
     fn tests_rust_1_48(t: &trybuild::TestCases) {
-        t.compile_fail("tests/ui/invalid_result_conversion.rs");
         t.compile_fail("tests/ui/missing_clone.rs");
         t.compile_fail("tests/ui/wrong_aspyref_lifetimes.rs");
     }
@@ -43,4 +43,11 @@ fn test_compile_errors() {
     }
     #[rustversion::before(1.49)]
     fn tests_rust_1_49(_t: &trybuild::TestCases) {}
+
+    #[rustversion::since(1.52)]
+    fn tests_rust_1_52(t: &trybuild::TestCases) {
+        t.compile_fail("tests/ui/invalid_result_conversion.rs");
+    }
+    #[rustversion::before(1.52)]
+    fn tests_rust_1_52(_t: &trybuild::TestCases) {}
 }

--- a/tests/ui/invalid_result_conversion.stderr
+++ b/tests/ui/invalid_result_conversion.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `std::result::Result<(), MyError>: IntoPyCallbackOutput<_>` is not satisfied
+error[E0277]: the trait bound `Result<(), MyError>: IntoPyCallbackOutput<_>` is not satisfied
    --> $DIR/invalid_result_conversion.rs:22:1
     |
 22  | #[pyfunction]
-    | ^^^^^^^^^^^^^ the trait `IntoPyCallbackOutput<_>` is not implemented for `std::result::Result<(), MyError>`
+    | ^^^^^^^^^^^^^ the trait `IntoPyCallbackOutput<_>` is not implemented for `Result<(), MyError>`
     |
    ::: $WORKSPACE/src/callback.rs
     |
@@ -10,5 +10,5 @@ error[E0277]: the trait bound `std::result::Result<(), MyError>: IntoPyCallbackO
     |        ----------------------- required by this bound in `pyo3::callback::convert`
     |
     = help: the following implementations were found:
-              <std::result::Result<T, E> as IntoPyCallbackOutput<U>>
+              <Result<T, E> as IntoPyCallbackOutput<U>>
     = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Fixes for clippy updates and compile tests for Rust 1.52 🦀 