### PR TITLE
Improve compilation times for projects using PyO3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `PyNumberProtocol::__complex__` and `PyNumberProtocol::__round__`
   - `PyAsyncProtocol::__aenter__` and `PyAsyncProtocol::__aexit__`
 - Deprecate `#[name = "..."]` attributes in favor of `#[pyo3(name = "...")]`. [#1567](https://github.com/PyO3/pyo3/pull/1567)
+- Improve compilation times for projects using PyO3 [#1604](https://github.com/PyO3/pyo3/pull/1604)
+
 
 ### Removed
 - Remove deprecated exception names `BaseException` etc. [#1426](https://github.com/PyO3/pyo3/pull/1426)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Deprecate `#[name = "..."]` attributes in favor of `#[pyo3(name = "...")]`. [#1567](https://github.com/PyO3/pyo3/pull/1567)
 - Improve compilation times for projects using PyO3 [#1604](https://github.com/PyO3/pyo3/pull/1604)
 
-
 ### Removed
 - Remove deprecated exception names `BaseException` etc. [#1426](https://github.com/PyO3/pyo3/pull/1426)
 - Remove deprecated redundant methods `Python::is_instance`, `Python::is_subclass`, `Python::release`, `Python::xdecref`, and `Py::from_owned_ptr_or_panic`. [#1426](https://github.com/PyO3/pyo3/pull/1426)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -757,7 +757,7 @@ impl pyo3::class::impl_::PyClassImpl for MyClass {
     type BaseType = PyAny;
     type ThreadChecker = pyo3::class::impl_::ThreadCheckerStub<MyClass>;
 
-    fn for_each_method_def(visitor: impl FnMut(&pyo3::class::PyMethodDefType)) {
+    fn for_each_method_def(visitor: &mut dyn FnMut(&pyo3::class::PyMethodDefType)) {
         use pyo3::class::impl_::*;
         let collector = PyClassImplCollector::<MyClass>::new();
         collector.py_methods().iter()

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -780,7 +780,7 @@ impl pyo3::class::impl_::PyClassImpl for MyClass {
         let collector = PyClassImplCollector::<Self>::new();
         collector.call_impl()
     }
-    fn for_each_proto_slot(visitor: impl FnMut(&pyo3::ffi::PyType_Slot)) {
+    fn for_each_proto_slot(visitor: &mut dyn FnMut(&pyo3::ffi::PyType_Slot)) {
         // Implementation which uses dtolnay specialization to load all slots.
         use pyo3::class::impl_::*;
         let collector = PyClassImplCollector::<Self>::new();

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -436,7 +436,7 @@ fn impl_class(
             type BaseType = #base;
             type ThreadChecker = #thread_checker;
 
-            fn for_each_method_def(visitor: impl FnMut(&pyo3::class::PyMethodDefType)) {
+            fn for_each_method_def(visitor: &mut dyn FnMut(&pyo3::class::PyMethodDefType)) {
                 use pyo3::class::impl_::*;
                 let collector = PyClassImplCollector::<Self>::new();
                 #iter_py_methods

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -460,7 +460,7 @@ fn impl_class(
                 collector.call_impl()
             }
 
-            fn for_each_proto_slot(visitor: impl FnMut(&pyo3::ffi::PyType_Slot)) {
+            fn for_each_proto_slot(visitor: &mut dyn FnMut(&pyo3::ffi::PyType_Slot)) {
                 // Implementation which uses dtolnay specialization to load all slots.
                 use pyo3::class::impl_::*;
                 let collector = PyClassImplCollector::<Self>::new();

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -175,15 +175,6 @@ where
     value.convert(py)
 }
 
-#[doc(hidden)]
-#[inline]
-pub fn callback_error<T>() -> T
-where
-    T: PyCallbackOutput,
-{
-    T::ERR_VALUE
-}
-
 /// Use this macro for all internal callback functions which Python will call.
 ///
 /// It sets up the GILPool and converts the output into a Python object. It also restores
@@ -258,7 +249,7 @@ where
 {
     let py_result = match panic_result {
         Ok(py_result) => py_result,
-        Err(panic_err) => Err(PanicException::from_panic(panic_err)),
+        Err(payload) => Err(PanicException::from_panic_payload(payload)),
     };
 
     py_result.unwrap_or_else(|py_err| {

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -65,7 +65,7 @@ pub trait PyClassImpl: Sized {
     ///    can be accessed by multiple threads by `threading` module.
     type ThreadChecker: PyClassThreadChecker<Self>;
 
-    fn for_each_method_def(_visitor: impl FnMut(&PyMethodDefType)) {}
+    fn for_each_method_def(_visitor: &mut dyn FnMut(&PyMethodDefType)) {}
     fn get_new() -> Option<ffi::newfunc> {
         None
     }

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -72,7 +72,7 @@ pub trait PyClassImpl: Sized {
     fn get_call() -> Option<ffi::PyCFunctionWithKeywords> {
         None
     }
-    fn for_each_proto_slot(_visitor: impl FnMut(&ffi::PyType_Slot)) {}
+    fn for_each_proto_slot(_visitor: &mut dyn FnMut(&ffi::PyType_Slot)) {}
     fn get_buffer() -> Option<&'static PyBufferProcs> {
         None
     }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -16,10 +16,10 @@ pyo3_exception!(
 
 impl PanicException {
     // Try to format the error in the same way panic does
-    pub(crate) fn from_panic(e: Box<dyn Any + Send + 'static>) -> PyErr {
-        if let Some(string) = e.downcast_ref::<String>() {
+    pub(crate) fn from_panic_payload(payload: Box<dyn Any + Send + 'static>) -> PyErr {
+        if let Some(string) = payload.downcast_ref::<String>() {
             Self::new_err((string.clone(),))
-        } else if let Some(s) = e.downcast_ref::<&str>() {
+        } else if let Some(s) = payload.downcast_ref::<&str>() {
             Self::new_err((s.to_string(),))
         } else {
             Self::new_err(("panic from Rust code",))

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,4 +1,6 @@
 use crate::exceptions::PyBaseException;
+use crate::PyErr;
+use std::any::Any;
 
 pyo3_exception!(
     "
@@ -11,3 +13,16 @@ pyo3_exception!(
     PanicException,
     PyBaseException
 );
+
+impl PanicException {
+    // Try to format the error in the same way panic does
+    pub(crate) fn from_panic(e: Box<dyn Any + Send + 'static>) -> PyErr {
+        if let Some(string) = e.downcast_ref::<String>() {
+            Self::new_err((string.clone(),))
+        } else if let Some(s) = e.downcast_ref::<&str>() {
+            Self::new_err((s.to_string(),))
+        } else {
+            Self::new_err(("panic from Rust code",))
+        }
+    }
+}

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -219,7 +219,7 @@ where
 
     // protocol methods
     let mut has_gc_methods = false;
-    T::for_each_proto_slot(|slot| {
+    T::for_each_proto_slot(&mut |slot| {
         has_gc_methods |= slot.slot == ffi::Py_tp_clear;
         has_gc_methods |= slot.slot == ffi::Py_tp_traverse;
         slots.0.push(*slot);

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -206,13 +206,13 @@ where
     }
 
     // normal methods
-    let methods = py_class_method_defs::<T>();
+    let methods = py_class_method_defs(&T::for_each_method_def);
     if !methods.is_empty() {
         slots.push(ffi::Py_tp_methods, into_raw(methods));
     }
 
     // properties
-    let props = py_class_properties::<T>();
+    let props = py_class_properties(T::Dict::IS_DUMMY, &T::for_each_method_def);
     if !props.is_empty() {
         slots.push(ffi::Py_tp_getset, into_raw(props));
     }
@@ -230,7 +230,7 @@ where
         name: get_type_name::<T>(module_name)?,
         basicsize: std::mem::size_of::<T::Layout>() as c_int,
         itemsize: 0,
-        flags: py_class_flags::<T>(has_gc_methods),
+        flags: py_class_flags(has_gc_methods, T::IS_GC, T::IS_BASETYPE),
         slots: slots.0.as_mut_ptr(),
     };
 
@@ -299,22 +299,24 @@ fn tp_init_additional<T: PyClass>(type_object: *mut ffi::PyTypeObject) {
 #[cfg(any(Py_LIMITED_API, Py_3_10))]
 fn tp_init_additional<T: PyClass>(_type_object: *mut ffi::PyTypeObject) {}
 
-fn py_class_flags<T: PyClass + PyTypeInfo>(has_gc_methods: bool) -> c_uint {
-    let mut flags = if has_gc_methods || T::IS_GC {
+fn py_class_flags(has_gc_methods: bool, is_gc: bool, is_basetype: bool) -> c_uint {
+    let mut flags = if has_gc_methods || is_gc {
         ffi::Py_TPFLAGS_DEFAULT | ffi::Py_TPFLAGS_HAVE_GC
     } else {
         ffi::Py_TPFLAGS_DEFAULT
     };
-    if T::IS_BASETYPE {
+    if is_basetype {
         flags |= ffi::Py_TPFLAGS_BASETYPE;
     }
     flags.try_into().unwrap()
 }
 
-fn py_class_method_defs<T: PyClassImpl>() -> Vec<ffi::PyMethodDef> {
+fn py_class_method_defs(
+    for_each_method_def: &dyn Fn(&mut dyn FnMut(&PyMethodDefType)),
+) -> Vec<ffi::PyMethodDef> {
     let mut defs = Vec::new();
 
-    T::for_each_method_def(|def| match def {
+    for_each_method_def(&mut |def| match def {
         PyMethodDefType::Method(def)
         | PyMethodDefType::Class(def)
         | PyMethodDefType::Static(def) => {
@@ -381,10 +383,13 @@ const PY_GET_SET_DEF_INIT: ffi::PyGetSetDef = ffi::PyGetSetDef {
 };
 
 #[allow(clippy::clippy::collapsible_if)] // for if cfg!
-fn py_class_properties<T: PyClass>() -> Vec<ffi::PyGetSetDef> {
+fn py_class_properties(
+    is_dummy: bool,
+    for_each_method_def: &dyn Fn(&mut dyn FnMut(&PyMethodDefType)),
+) -> Vec<ffi::PyGetSetDef> {
     let mut defs = std::collections::HashMap::new();
 
-    T::for_each_method_def(|def| match def {
+    for_each_method_def(&mut |def| match def {
         PyMethodDefType::Getter(getter) => {
             getter.copy_to(defs.entry(getter.name).or_insert(PY_GET_SET_DEF_INIT));
         }
@@ -398,7 +403,7 @@ fn py_class_properties<T: PyClass>() -> Vec<ffi::PyGetSetDef> {
 
     // PyPy doesn't automatically adds __dict__ getter / setter.
     // PyObject_GenericGetDict not in the limited API until Python 3.10.
-    push_dict_getset::<T>(&mut props);
+    push_dict_getset(&mut props, is_dummy);
 
     if !props.is_empty() {
         props.push(unsafe { std::mem::zeroed() });
@@ -407,8 +412,8 @@ fn py_class_properties<T: PyClass>() -> Vec<ffi::PyGetSetDef> {
 }
 
 #[cfg(not(any(PyPy, all(Py_LIMITED_API, not(Py_3_10)))))]
-fn push_dict_getset<T: PyClass>(props: &mut Vec<ffi::PyGetSetDef>) {
-    if !T::Dict::IS_DUMMY {
+fn push_dict_getset(props: &mut Vec<ffi::PyGetSetDef>, is_dummy: bool) {
+    if !is_dummy {
         props.push(ffi::PyGetSetDef {
             name: "__dict__\0".as_ptr() as *mut c_char,
             get: Some(ffi::PyObject_GenericGetDict),
@@ -420,4 +425,4 @@ fn push_dict_getset<T: PyClass>(props: &mut Vec<ffi::PyGetSetDef>) {
 }
 
 #[cfg(any(PyPy, all(Py_LIMITED_API, not(Py_3_10))))]
-fn push_dict_getset<T: PyClass>(_: &mut Vec<ffi::PyGetSetDef>) {}
+fn push_dict_getset(_: &mut Vec<ffi::PyGetSetDef>, _is_dummy: bool) {}


### PR DESCRIPTION
These changes reduce the number of lines of LLVM code on the word-count example from 29,299 to 24,980.

Top 10 biggest functions in the binary, as reported by `cargo llvm-lines --release`:

```
Before
======
Lines         Copies       Function name
  -----         ------       -------------
  29299 (100%)  1294 (100%)  (TOTAL)
   1205 (4.1%)     4 (0.3%)  pyo3::callback::handle_panic
    546 (1.9%)     7 (0.5%)  std::thread::local::LocalKey<T>::try_with
    530 (1.8%)     8 (0.6%)  core::result::Result<T,E>::map_err
    528 (1.8%)     8 (0.6%)  std::panicking::try
    467 (1.6%)     5 (0.4%)  core::iter::traits::iterator::Iterator::fold
    439 (1.5%)    10 (0.8%)  core::option::Option<T>::map
    421 (1.4%)     9 (0.7%)  core::ptr::swap_nonoverlapping_one
    409 (1.4%)     1 (0.1%)  rayon::iter::plumbing::bridge_unindexed_producer_consumer
    394 (1.3%)    20 (1.5%)  core::ptr::read
    353 (1.2%)    11 (0.9%)  core::option::Option<T>::ok_or

After
=====
  Lines         Copies       Function name
  -----         ------       -------------
  24980 (100%)  1116 (100%)  (TOTAL)
    546 (2.2%)     7 (0.6%)  std::thread::local::LocalKey<T>::try_with
    528 (2.1%)     8 (0.7%)  std::panicking::try
    467 (1.9%)     5 (0.4%)  core::iter::traits::iterator::Iterator::fold
    432 (1.7%)     6 (0.5%)  core::result::Result<T,E>::map_err
    409 (1.6%)     1 (0.1%)  rayon::iter::plumbing::bridge_unindexed_producer_consumer
    397 (1.6%)     4 (0.4%)  pyo3::callback::handle_panic
    376 (1.5%)     8 (0.7%)  core::ptr::swap_nonoverlapping_one
    371 (1.5%)    19 (1.7%)  core::ptr::read
    368 (1.5%)     8 (0.7%)  core::option::Option<T>::map
    345 (1.4%)     1 (0.1%)  word_count::word_count
```

Here I am using number of lines of LLVM code as an indicator of overall compilation time. I have a large real-world project that sees a 22% improvement in compilation time on its release build due to these changes.