### PR TITLE
Add support for cross compilation for wasm/wasi

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -536,6 +536,8 @@ fn load_cross_compile_info(cross_compile_config: CrossCompileConfig) -> Result<I
         Some(os) if os == "unix" => load_cross_compile_from_sysconfigdata(cross_compile_config),
         // Use hardcoded interpreter config when targeting Windows
         Some(os) if os == "windows" => windows_hardcoded_cross_compile(cross_compile_config),
+        // sysconfigdata works fine on wasm/wasi
+        Some(os) if os == "wasm" => load_cross_compile_from_sysconfigdata(cross_compile_config),
         // Waiting for users to tell us what they expect on their target platform
         Some(os) => bail!(
             "Unsupported target OS family for cross-compilation: {:?}",

--- a/src/conversions/osstr.rs
+++ b/src/conversions/osstr.rs
@@ -22,6 +22,9 @@ impl ToPyObject for OsStr {
         // https://doc.rust-lang.org/src/std/sys_common/mod.rs.html#59
         #[cfg(not(windows))]
         {
+            #[cfg(target_os = "wasi")]
+            let bytes = std::os::wasi::ffi::OsStrExt::as_bytes(self);
+            #[cfg(not(target_os = "wasi"))]
             let bytes = std::os::unix::ffi::OsStrExt::as_bytes(self);
 
             let ptr = bytes.as_ptr() as *const c_char;
@@ -68,6 +71,11 @@ impl FromPyObject<'_> for OsString {
             };
 
             // Create an OsStr view into the raw bytes from Python
+            #[cfg(target_os = "wasi")]
+            let os_str: &OsStr = std::os::wasi::ffi::OsStrExt::from_bytes(
+                fs_encoded_bytes.as_ref(ob.py()).as_bytes(),
+            );
+            #[cfg(not(target_os = "wasi"))]
             let os_str: &OsStr = std::os::unix::ffi::OsStrExt::from_bytes(
                 fs_encoded_bytes.as_ref(ob.py()).as_bytes(),
             );


### PR DESCRIPTION
When using rust after this commit
https://github.com/rust-lang/rust/commit/1a491e2304387c2a50c5a0ae219e8d5a0ce1bc89
the target family for wasm targets is now set to "wasm". Also fix the
assumption that OsStrExt lives inside std::os::unix for all non-windows
targets.