### PR TITLE
pyfn: deprecate name argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `PyAsyncProtocol::__aenter__` and `PyAsyncProtocol::__aexit__`
 - Deprecate `#[name = "..."]` attributes in favor of `#[pyo3(name = "...")]`. [#1567](https://github.com/PyO3/pyo3/pull/1567)
 - Improve compilation times for projects using PyO3 [#1604](https://github.com/PyO3/pyo3/pull/1604)
+- Deprecate string-literal second argument to `#[pyfn(m, "name")]`.
 
 ### Removed
 - Remove deprecated exception names `BaseException` etc. [#1426](https://github.com/PyO3/pyo3/pull/1426)

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -242,8 +242,6 @@ These correspond to the slots `tp_traverse` and `tp_clear` in the Python C API.
 as every cycle must contain at least one mutable reference.
 Example:
 ```rust
-extern crate pyo3;
-
 use pyo3::prelude::*;
 use pyo3::PyTraverseError;
 use pyo3::gc::{PyGCProtocol, PyVisit};

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -15,7 +15,8 @@ fn rust2py(py: Python, m: &PyModule) -> PyResult<()> {
     // Note that the `#[pyfn()]` annotation automatically converts the arguments from
     // Python objects to Rust values, and the Rust return value back into a Python object.
     // The `_py` argument represents that we're holding the GIL.
-    #[pyfn(m, "sum_as_string")]
+    #[pyfn(m)]
+    #[pyo3(name = "sum_as_string")]
     fn sum_as_string_py(_py: Python, a: i64, b: i64) -> PyResult<String> {
         let out = sum_as_string(a, b);
         Ok(out)
@@ -32,7 +33,7 @@ fn sum_as_string(a: i64, b: i64) -> String {
 # fn main() {}
 ```
 
-The `#[pymodule]` procedural macro attribute takes care of exporting the initialization function of your 
+The `#[pymodule]` procedural macro attribute takes care of exporting the initialization function of your
 module to Python. It can take as an argument the name of your module, which must be the name of the `.so`
 or `.pyd` file; the default is the Rust function's name.
 
@@ -41,7 +42,7 @@ If the name of the module (the default being the function name) does not match t
 `ImportError: dynamic module does not define module export function (PyInit_name_of_your_module)`
 
 To import the module, either copy the shared library as described in [the README](https://github.com/PyO3/pyo3)
-or use a tool, e.g. `maturin develop` with [maturin](https://github.com/PyO3/maturin) or 
+or use a tool, e.g. `maturin develop` with [maturin](https://github.com/PyO3/maturin) or
 `python setup.py develop` with [setuptools-rust](https://github.com/PyO3/setuptools-rust).
 
 ## Documentation

--- a/pyo3-macros-backend/src/deprecations.rs
+++ b/pyo3-macros-backend/src/deprecations.rs
@@ -1,0 +1,43 @@
+use proc_macro2::{Span, TokenStream};
+use quote::{quote_spanned, ToTokens};
+
+pub enum Deprecation {
+    NameAttribute,
+    PyfnNameArgument,
+}
+
+impl Deprecation {
+    fn ident(&self, span: Span) -> syn::Ident {
+        let string = match self {
+            Deprecation::NameAttribute => "NAME_ATTRIBUTE",
+            Deprecation::PyfnNameArgument => "PYFN_NAME_ARGUMENT",
+        };
+        syn::Ident::new(string, span)
+    }
+}
+
+#[derive(Default)]
+pub struct Deprecations(Vec<(Deprecation, Span)>);
+
+impl Deprecations {
+    pub fn new() -> Self {
+        Deprecations(Vec::new())
+    }
+
+    pub fn push(&mut self, deprecation: Deprecation, span: Span) {
+        self.0.push((deprecation, span))
+    }
+}
+
+impl ToTokens for Deprecations {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (deprecation, span) in &self.0 {
+            let ident = deprecation.ident(*span);
+            quote_spanned!(
+                *span =>
+                let _ = pyo3::impl_::deprecations::#ident;
+            )
+            .to_tokens(tokens)
+        }
+    }
+}

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -10,6 +10,7 @@ mod utils;
 
 mod attributes;
 mod defs;
+mod deprecations;
 mod from_pyobject;
 mod konst;
 mod method;

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-use crate::pyfunction::Argument;
 use crate::pyfunction::PyFunctionOptions;
 use crate::pyfunction::{PyFunctionArgPyO3Attributes, PyFunctionSignature};
 use crate::utils;
+use crate::{deprecations::Deprecations, pyfunction::Argument};
 use proc_macro2::TokenStream;
 use quote::ToTokens;
 use quote::{quote, quote_spanned};
@@ -122,7 +122,6 @@ impl SelfType {
     }
 }
 
-#[derive(Clone, Debug)]
 pub struct FnSpec<'a> {
     pub tp: FnType,
     // Rust function name
@@ -134,7 +133,7 @@ pub struct FnSpec<'a> {
     pub args: Vec<FnArg<'a>>,
     pub output: syn::Type,
     pub doc: syn::LitStr,
-    pub name_is_deprecated: bool,
+    pub deprecations: Deprecations,
 }
 
 pub fn get_return_info(output: &syn::ReturnType) -> syn::Type {
@@ -217,15 +216,13 @@ impl<'a> FnSpec<'a> {
             args: arguments,
             output: ty,
             doc,
-            name_is_deprecated: options.name_is_deprecated,
+            deprecations: options.deprecations,
         })
     }
 
-    pub fn python_name_with_deprecation(&self) -> TokenStream {
-        let deprecation =
-            utils::name_deprecation_token(self.python_name.span(), self.name_is_deprecated);
+    pub fn null_terminated_python_name(&self) -> TokenStream {
         let name = format!("{}\0", self.python_name);
-        quote!({#deprecation #name})
+        quote!({#name})
     }
 
     fn parse_text_signature(

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -508,10 +508,10 @@ fn impl_descriptors(
                     );
                     match desc {
                         FnType::Getter(self_ty) => {
-                            impl_py_getter_def(cls, property_type, self_ty, &doc)
+                            impl_py_getter_def(cls, property_type, self_ty, &doc, &Default::default())
                         }
                         FnType::Setter(self_ty) => {
-                            impl_py_setter_def(cls, property_type, self_ty, &doc)
+                            impl_py_setter_def(cls, property_type, self_ty, &doc, &Default::default())
                         }
                         _ => unreachable!(),
                     }

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
-use proc_macro2::{Span, TokenStream};
-use quote::quote_spanned;
+use proc_macro2::Span;
 use syn::spanned::Spanned;
 
 /// Macro inspired by `anyhow::anyhow!` to create a compiler error with the given span.
@@ -164,15 +163,4 @@ pub fn get_doc(
     }
 
     Ok(syn::LitStr::new(&doc, span))
-}
-
-pub fn name_deprecation_token(span: Span, name_is_deprecated: bool) -> Option<TokenStream> {
-    if name_is_deprecated {
-        Some(quote_spanned!(
-            span =>
-            let _ = pyo3::impl_::deprecations::NAME_ATTRIBUTE;
-        ))
-    } else {
-        None
-    }
 }

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -2,12 +2,4 @@
 //! any of these APIs in downstream code is implicitly acknowledging that these APIs may change at
 //! any time without documentation in the CHANGELOG and without breaking semver guarantees.
 
-/// Symbols to represent deprecated uses of PyO3's macros.
-pub mod deprecations {
-    #[doc(hidden)]
-    #[deprecated(
-        since = "0.14.0",
-        note = "use `#[pyo3(name = \"...\")]` instead of `#[name = \"...\"]`"
-    )]
-    pub const NAME_ATTRIBUTE: () = ();
-}
+pub mod deprecations;

--- a/src/impl_/deprecations.rs
+++ b/src/impl_/deprecations.rs
@@ -1,0 +1,13 @@
+//! Symbols used to denote deprecated usages of PyO3's proc macros.
+
+#[deprecated(
+    since = "0.14.0",
+    note = "use `#[pyo3(name = \"...\")]` instead of `#[name = \"...\"]`"
+)]
+pub const NAME_ATTRIBUTE: () = ();
+
+#[deprecated(
+    since = "0.14.0",
+    note = "use `#[pyfn(m)] #[pyo3(name = \"...\")]` instead of `#[pyfn(m, \"...\")]`"
+)]
+pub const PYFN_NAME_ARGUMENT: () = ();

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 
-use pyo3::py_run;
 use pyo3::types::{IntoPyDict, PyDict, PyTuple};
+use pyo3::{py_run, wrap_pyfunction};
 mod common;
 
 #[pyclass]
@@ -36,24 +36,24 @@ fn double(x: usize) -> usize {
 /// This module is implemented in Rust.
 #[pymodule]
 fn module_with_functions(_py: Python, m: &PyModule) -> PyResult<()> {
-    use pyo3::wrap_pyfunction;
-
+    #![allow(deprecated)]
     #[pyfn(m, "sum_as_string")]
-    fn sum_as_string_py(_py: Python, a: i64, b: i64) -> String {
+    fn function_with_deprecated_name(_py: Python, a: i64, b: i64) -> String {
         sum_as_string(a, b)
     }
 
-    #[pyfn(m, "no_parameters")]
-    fn no_parameters() -> usize {
+    #[pyfn(m)]
+    #[pyo3(name = "no_parameters")]
+    fn function_with_name() -> usize {
         42
     }
 
-    #[pyfn(m, "with_module", pass_module)]
+    #[pyfn(m, pass_module)]
     fn with_module(module: &PyModule) -> PyResult<&str> {
         module.name()
     }
 
-    #[pyfn(m, "double_value")]
+    #[pyfn(m)]
     fn double_value(v: &ValueClass) -> usize {
         v.value * 2
     }
@@ -174,8 +174,6 @@ fn r#move() -> usize {
 
 #[pymodule]
 fn raw_ident_module(_py: Python, module: &PyModule) -> PyResult<()> {
-    use pyo3::wrap_pyfunction;
-
     module.add_function(wrap_pyfunction!(r#move, module)?)
 }
 
@@ -199,8 +197,6 @@ fn custom_named_fn() -> usize {
 
 #[pymodule]
 fn foobar_module(_py: Python, m: &PyModule) -> PyResult<()> {
-    use pyo3::wrap_pyfunction;
-
     m.add_function(wrap_pyfunction!(custom_named_fn, m)?)?;
     m.dict().set_item("yay", "me")?;
     Ok(())
@@ -241,16 +237,12 @@ fn subfunction() -> String {
 }
 
 fn submodule(module: &PyModule) -> PyResult<()> {
-    use pyo3::wrap_pyfunction;
-
     module.add_function(wrap_pyfunction!(subfunction, module)?)?;
     Ok(())
 }
 
 #[pymodule]
 fn submodule_with_init_fn(_py: Python, module: &PyModule) -> PyResult<()> {
-    use pyo3::wrap_pyfunction;
-
     module.add_function(wrap_pyfunction!(subfunction, module)?)?;
     Ok(())
 }
@@ -262,8 +254,6 @@ fn superfunction() -> String {
 
 #[pymodule]
 fn supermodule(py: Python, module: &PyModule) -> PyResult<()> {
-    use pyo3::wrap_pyfunction;
-
     module.add_function(wrap_pyfunction!(superfunction, module)?)?;
     let module_to_add = PyModule::new(py, "submodule")?;
     submodule(module_to_add)?;
@@ -308,13 +298,12 @@ fn ext_vararg_fn(py: Python, a: i32, vararg: &PyTuple) -> PyObject {
 
 #[pymodule]
 fn vararg_module(_py: Python, m: &PyModule) -> PyResult<()> {
-    #[pyfn(m, "int_vararg_fn", a = 5, vararg = "*")]
+    #[pyfn(m, a = 5, vararg = "*")]
     fn int_vararg_fn(py: Python, a: i32, vararg: &PyTuple) -> PyObject {
         ext_vararg_fn(py, a, vararg)
     }
 
-    m.add_function(pyo3::wrap_pyfunction!(ext_vararg_fn, m)?)
-        .unwrap();
+    m.add_function(wrap_pyfunction!(ext_vararg_fn, m)?).unwrap();
     Ok(())
 }
 
@@ -390,17 +379,11 @@ fn pyfunction_with_module_and_args_kwargs<'a>(
 
 #[pymodule]
 fn module_with_functions_with_module(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(pyo3::wrap_pyfunction!(pyfunction_with_module, m)?)?;
-    m.add_function(pyo3::wrap_pyfunction!(pyfunction_with_module_and_py, m)?)?;
-    m.add_function(pyo3::wrap_pyfunction!(pyfunction_with_module_and_arg, m)?)?;
-    m.add_function(pyo3::wrap_pyfunction!(
-        pyfunction_with_module_and_default_arg,
-        m
-    )?)?;
-    m.add_function(pyo3::wrap_pyfunction!(
-        pyfunction_with_module_and_args_kwargs,
-        m
-    )?)
+    m.add_function(wrap_pyfunction!(pyfunction_with_module, m)?)?;
+    m.add_function(wrap_pyfunction!(pyfunction_with_module_and_py, m)?)?;
+    m.add_function(wrap_pyfunction!(pyfunction_with_module_and_arg, m)?)?;
+    m.add_function(wrap_pyfunction!(pyfunction_with_module_and_default_arg, m)?)?;
+    m.add_function(wrap_pyfunction!(pyfunction_with_module_and_args_kwargs, m)?)
 }
 
 #[test]

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -119,7 +119,7 @@ fn test_function() {
 fn test_pyfn() {
     #[pymodule]
     fn my_module(_py: Python, m: &PyModule) -> PyResult<()> {
-        #[pyfn(m, "my_function", a, b = "None", "*", c = 42)]
+        #[pyfn(m, a, b = "None", "*", c = 42)]
         #[text_signature = "(a, b=None, *, c=42)"]
         fn my_function(a: i32, b: Option<i32>, c: i32) {
             let _ = (a, b, c);

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -25,6 +25,14 @@ impl TestClass {
 #[name = "foo"]
 fn deprecated_name_pyfunction() { }
 
+#[pymodule]
+fn my_module(_py: Python, m: &PyModule) -> PyResult<()> {
+    #[pyfn(m, "some_name")]
+    fn deprecated_name_pyfn() { }
+
+    Ok(())
+}
+
 fn main() {
 
 }

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -27,3 +27,9 @@ error: use of deprecated constant `pyo3::impl_::deprecations::NAME_ATTRIBUTE`: u
    |
 25 | #[name = "foo"]
    | ^
+
+error: use of deprecated constant `pyo3::impl_::deprecations::PYFN_NAME_ARGUMENT`: use `#[pyfn(m)] #[pyo3(name = "...")]` instead of `#[pyfn(m, "...")]`
+  --> $DIR/deprecations.rs:30:15
+   |
+30 |     #[pyfn(m, "some_name")]
+   |               ^^^^^^^^^^^

--- a/tests/ui/invalid_need_module_arg_position.rs
+++ b/tests/ui/invalid_need_module_arg_position.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 #[pymodule]
 fn module(_py: Python, m: &PyModule) -> PyResult<()> {
-    #[pyfn(m, "with_module", pass_module)]
+    #[pyfn(m, pass_module)]
     fn fail(string: &str, module: &PyModule) -> PyResult<&str> {
         module.name()
     }


### PR DESCRIPTION
This PR makes the second "name" argument to `#[pyfn]` both optional and deprecated in favour of `#[pyo3(name = "...")]`. This is part of #1601 

This has the nice effect that now `#[pyfunction]` and `#[pyfn(m)]` take equivalent options, so I have rewritten the documentation to primarily talk about `#[pyfunction]`, and `#[pyfn]` is introduced as syntax sugar.

Before:

```
#[pymodule]
fn rust2py(py: Python, m: &PyModule) -> PyResult<()> {

    #[pyfn(m, "sum_as_string")]
    fn sum_as_string() { }

    #[pyfn(m, "custom_name")
    fn foobar_to_rename() { }

    Ok(())
}
```

After:

```
#[pymodule]
fn rust2py(py: Python, m: &PyModule) -> PyResult<()> {

    #[pyfn(m)]
    fn sum_as_string() { }

    #[pyfn(m)]
    #[pyo3(name = "custom_name"]
    fn foobar_to_rename() { }

    Ok(())
}
```