### PR TITLE
Fix typos in Architecture and Contributing docs

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -36,7 +36,7 @@ To summarize, there are six main parts to the PyO3 codebase.
 We aim to provide straight-forward Rust wrappers resembling the file structure of
 [`cpython/Include`](https://github.com/python/cpython/tree/v3.9.2/Include).
 
-However, we still lack some APIs and are continuously updating the the module to match
+However, we still lack some APIs and are continuously updating the module to match
 the file contents upstream in CPython.
 The tracking issue is [#1289](https://github.com/PyO3/pyo3/issues/1289), and contribution is welcome.
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -66,7 +66,7 @@ Below are guidelines on what compatibility all PRs are expected to deliver for e
 
 ### Python
 
-PyO3 supports all oficially supported Python versions, as well as the latest PyPy3 release. All of these versions are tested in CI.
+PyO3 supports all officially supported Python versions, as well as the latest PyPy3 release. All of these versions are tested in CI.
 
 ### Rust
 


### PR DESCRIPTION
Fixed some typos that I noticed while reading through the docs.