### PR TITLE
pyfunction: use METH_NOARGS for no-argument functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ macro_rules! wrap_pyfunction {
 /// use pyo3::raw_pycfunction;
 ///
 /// #[pyfunction]
-/// fn some_fun() -> PyResult<()> {
+/// fn some_fun(arg: i32) -> PyResult<()> {
 ///     Ok(())
 /// }
 ///


### PR DESCRIPTION
As suggested in #1607.
    
If I ran the benchmarks correctly, this shaves only about 5ns from
the noargs case.  But since it's relatively easy to do...
