### PR TITLE
callback: add `#[inline]` to callback conversion code

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -45,6 +45,7 @@ where
     T: IntoPyCallbackOutput<U>,
     E: Into<PyErr>,
 {
+    #[inline]
     fn convert(self, py: Python) -> PyResult<U> {
         self.map_err(Into::into).and_then(|t| t.convert(py))
     }
@@ -54,30 +55,35 @@ impl<T> IntoPyCallbackOutput<*mut ffi::PyObject> for T
 where
     T: IntoPy<PyObject>,
 {
+    #[inline]
     fn convert(self, py: Python) -> PyResult<*mut ffi::PyObject> {
         Ok(self.into_py(py).into_ptr())
     }
 }
 
 impl IntoPyCallbackOutput<Self> for *mut ffi::PyObject {
+    #[inline]
     fn convert(self, _: Python) -> PyResult<Self> {
         Ok(self)
     }
 }
 
 impl IntoPyCallbackOutput<std::os::raw::c_int> for () {
+    #[inline]
     fn convert(self, _: Python) -> PyResult<std::os::raw::c_int> {
         Ok(0)
     }
 }
 
 impl IntoPyCallbackOutput<std::os::raw::c_int> for bool {
+    #[inline]
     fn convert(self, _: Python) -> PyResult<std::os::raw::c_int> {
         Ok(self as c_int)
     }
 }
 
 impl IntoPyCallbackOutput<()> for () {
+    #[inline]
     fn convert(self, _: Python) -> PyResult<()> {
         Ok(())
     }
@@ -97,12 +103,14 @@ impl IntoPyCallbackOutput<ffi::Py_ssize_t> for usize {
 // Converters needed for `#[pyproto]` implementations
 
 impl IntoPyCallbackOutput<bool> for bool {
+    #[inline]
     fn convert(self, _: Python) -> PyResult<bool> {
         Ok(self)
     }
 }
 
 impl IntoPyCallbackOutput<usize> for usize {
+    #[inline]
     fn convert(self, _: Python) -> PyResult<usize> {
         Ok(self)
     }
@@ -112,6 +120,7 @@ impl<T> IntoPyCallbackOutput<PyObject> for T
 where
     T: IntoPy<PyObject>,
 {
+    #[inline]
     fn convert(self, py: Python) -> PyResult<PyObject> {
         Ok(self.into_py(py))
     }
@@ -225,6 +234,7 @@ macro_rules! callback_body {
 /// Then this will fail to compile, because the result of #foo borrows _slf, but _slf drops when
 /// the block passed to the macro ends.
 #[doc(hidden)]
+#[inline]
 pub unsafe fn handle_panic<F, R>(body: F) -> R
 where
     F: FnOnce(Python) -> PyResult<R> + UnwindSafe,


### PR DESCRIPTION
These are a bunch of tiny functions which are great candidates for inlining. 

Relevant benchmarks after:

```
------------------------------------------------------------------------------------------- benchmark: 6 tests -------------------------------------------------------------------------------------------
Name (time in ns)                Min                    Max                Mean              StdDev              Median                IQR            Outliers  OPS (Mops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_no_args                 54.0000 (1.0)       1,208.0000 (1.22)      60.1653 (1.0)       22.7841 (1.0)       58.0000 (1.0)       1.0000 (1.0)    2334;19846       16.6209 (1.0)      153847         100
test_args_and_kwargs        299.9996 (5.56)     46,200.0003 (46.67)    409.9357 (6.81)     699.6652 (30.71)    399.9999 (6.90)     99.9999 (100.00)   732;2775        2.4394 (0.15)     158731           1
test_mixed_args             325.0000 (6.02)      5,660.0000 (5.72)     365.7867 (6.08)     148.2067 (6.50)     345.0000 (5.95)     10.0000 (10.00)  3189;12868        2.7338 (0.16)     144928          20
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Before:

```
--------------------------------------------------------------------------------------------- benchmark: 6 tests ---------------------------------------------------------------------------------------------
Name (time in ns)                Min                     Max                Mean                StdDev              Median                IQR             Outliers  OPS (Mops/s)            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_no_args                 56.0000 (1.0)          949.0000 (1.0)       63.3486 (1.0)         24.5340 (1.0)       60.0000 (1.0)       2.0000 (>1000.0) 3557;12693       15.7857 (1.0)      156250         100
test_args_and_kwargs        299.9996 (5.36)     258,300.0000 (272.18)   471.2334 (7.44)     1,315.7918 (53.63)    399.9999 (6.67)      0.0005 (1.0)      641;36802        2.1221 (0.13)     161291           1
test_mixed_args             340.0000 (6.07)       3,850.0000 (4.06)     388.1539 (6.13)       153.7473 (6.27)     360.0000 (6.00)     10.0000 (>1000.0)  1362;5019        2.5763 (0.16)      46297          20
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

The two bottom benchmarks have very wide stdev so it's hard to conclude much from them, but I'm tempted to at least claim there's a small positive improvement from doing this.