### PR TITLE
Fix a new-in-nightly clippy warning

### DIFF
--- a/src/freelist.rs
+++ b/src/freelist.rs
@@ -95,7 +95,7 @@ where
         crate::pyclass::default_new::<Self>(py, subtype) as _
     }
 
-    #[allow(clippy::clippy::collapsible_if)] // for if cfg!
+    #[allow(clippy::collapsible_if)] // for if cfg!
     unsafe fn dealloc(py: Python, self_: *mut Self::Layout) {
         (*self_).py_drop(py);
         let obj = PyAny::from_borrowed_ptr_or_panic(py, self_ as _);

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -70,7 +70,7 @@ pub(crate) fn gil_is_acquired() -> bool {
 /// ```
 #[cfg(not(PyPy))]
 #[cfg_attr(docsrs, doc(cfg(not(PyPy))))]
-#[allow(clippy::clippy::collapsible_if)] // for if cfg!
+#[allow(clippy::collapsible_if)] // for if cfg!
 pub fn prepare_freethreaded_python() {
     // Protect against race conditions when Python is not yet initialized and multiple threads
     // concurrently call 'prepare_freethreaded_python()'. Note that we do not protect against
@@ -132,7 +132,7 @@ pub fn prepare_freethreaded_python() {
 /// ```
 #[cfg(not(PyPy))]
 #[cfg_attr(docsrs, doc(cfg(not(PyPy))))]
-#[allow(clippy::clippy::collapsible_if)] // for if cfg!
+#[allow(clippy::collapsible_if)] // for if cfg!
 pub unsafe fn with_embedded_python_interpreter<F, R>(f: F) -> R
 where
     F: for<'p> FnOnce(Python<'p>) -> R,

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -83,7 +83,7 @@ pub trait PyClassAlloc: PyTypeInfo + PyClassImpl {
     ///
     /// # Safety
     /// `self_` must be a valid pointer to the Python heap.
-    #[allow(clippy::clippy::collapsible_if)] // for if cfg!
+    #[allow(clippy::collapsible_if)] // for if cfg!
     unsafe fn dealloc(py: Python, self_: *mut Self::Layout) {
         (*self_).py_drop(py);
         let obj = self_ as *mut ffi::PyObject;
@@ -382,7 +382,7 @@ const PY_GET_SET_DEF_INIT: ffi::PyGetSetDef = ffi::PyGetSetDef {
     closure: ptr::null_mut(),
 };
 
-#[allow(clippy::clippy::collapsible_if)] // for if cfg!
+#[allow(clippy::collapsible_if)] // for if cfg!
 fn py_class_properties(
     is_dummy: bool,
     for_each_method_def: &dyn Fn(&mut dyn FnMut(&PyMethodDefType)),

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -600,7 +600,7 @@ impl PyAny {
     /// Returns the length of the sequence or mapping.
     ///
     /// This is equivalent to the Python expression `len(self)`.
-    #[allow(clippy::clippy::len_without_is_empty)]
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> PyResult<usize> {
         let v = unsafe { ffi::PyObject_Size(self.as_ptr()) };
         if v == -1 {

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -69,7 +69,7 @@ mod test {
         let py = gil.python();
         assert!(PyBool::new(py, true).is_true());
         let t: &PyAny = PyBool::new(py, true).into();
-        assert_eq!(true, t.extract().unwrap());
+        assert!(t.extract::<bool>().unwrap());
         assert_eq!(true.to_object(py), PyBool::new(py, true).into());
     }
 
@@ -79,7 +79,7 @@ mod test {
         let py = gil.python();
         assert!(!PyBool::new(py, false).is_true());
         let t: &PyAny = PyBool::new(py, false).into();
-        assert_eq!(false, t.extract().unwrap());
+        assert!(!t.extract::<bool>().unwrap());
         assert_eq!(false.to_object(py), PyBool::new(py, false).into());
     }
 }

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -422,8 +422,8 @@ mod tests {
             let a = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, false);
             let b = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, true);
 
-            assert_eq!(a.unwrap().get_fold(), false);
-            assert_eq!(b.unwrap().get_fold(), true);
+            assert!(!a.unwrap().get_fold());
+            assert!(b.unwrap().get_fold());
         });
     }
 }

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -128,7 +128,7 @@ pyobject_native_type!(
 );
 
 impl PyDateTime {
-    #[allow(clippy::clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new<'p>(
         py: Python<'p>,
         year: i32,
@@ -159,7 +159,7 @@ impl PyDateTime {
     /// Alternate constructor that takes a `fold` parameter. A `true` value for this parameter
     /// signifies a leap second
     #[cfg(not(PyPy))]
-    #[allow(clippy::clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_fold<'p>(
         py: Python<'p>,
         year: i32,

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -528,8 +528,8 @@ mod test {
         v.insert(7, 32);
         let ob = v.to_object(py);
         let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
-        assert_eq!(true, dict.contains(7i32).unwrap());
-        assert_eq!(false, dict.contains(8i32).unwrap());
+        assert!(dict.contains(7i32).unwrap());
+        assert!(!dict.contains(8i32).unwrap());
     }
 
     #[test]

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -18,7 +18,7 @@ impl PySequence {
     ///
     /// This is equivalent to the Python expression `len(self)`.
     #[inline]
-    #[allow(clippy::clippy::len_without_is_empty)]
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> PyResult<isize> {
         let v = unsafe { ffi::PySequence_Size(self.as_ptr()) };
         if v == -1 {

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -370,7 +370,7 @@ mod test {
         assert_eq!(0, seq.len().unwrap());
 
         let needle = 7i32.to_object(py);
-        assert_eq!(false, seq.contains(&needle).unwrap());
+        assert!(!seq.contains(&needle).unwrap());
     }
 
     #[test]
@@ -383,13 +383,13 @@ mod test {
         assert_eq!(6, seq.len().unwrap());
 
         let bad_needle = 7i32.to_object(py);
-        assert_eq!(false, seq.contains(&bad_needle).unwrap());
+        assert!(!seq.contains(&bad_needle).unwrap());
 
         let good_needle = 8i32.to_object(py);
-        assert_eq!(true, seq.contains(&good_needle).unwrap());
+        assert!(seq.contains(&good_needle).unwrap());
 
         let type_coerced_needle = 8f32.to_object(py);
-        assert_eq!(true, seq.contains(&type_coerced_needle).unwrap());
+        assert!(seq.contains(&type_coerced_needle).unwrap());
     }
 
     #[test]
@@ -527,10 +527,10 @@ mod test {
         let seq = ob.cast_as::<PySequence>(py).unwrap();
 
         let bad_needle = "blurst".to_object(py);
-        assert_eq!(false, seq.contains(bad_needle).unwrap());
+        assert!(!seq.contains(bad_needle).unwrap());
 
         let good_needle = "worst".to_object(py);
-        assert_eq!(true, seq.contains(good_needle).unwrap());
+        assert!(seq.contains(good_needle).unwrap());
     }
 
     #[test]
@@ -668,10 +668,10 @@ mod test {
         let py = gil.python();
         let list = vec![1].to_object(py);
         let seq = list.cast_as::<PySequence>(py).unwrap();
-        assert_eq!(seq.is_empty().unwrap(), false);
+        assert!(!seq.is_empty().unwrap());
         let vec: Vec<u32> = Vec::new();
         let empty_list = vec.to_object(py);
         let empty_seq = empty_list.cast_as::<PySequence>(py).unwrap();
-        assert_eq!(empty_seq.is_empty().unwrap(), true);
+        assert!(empty_seq.is_empty().unwrap());
     }
 }

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -240,7 +240,7 @@ fn test_unsendable<T: PyClass + 'static>() -> PyResult<()> {
                 }))
                 .is_err();
 
-            assert_eq!(caught_panic, false);
+            assert!(!caught_panic);
             Ok(obj)
         })
     })


### PR DESCRIPTION
(based on previous PR, merge after that)

Example:

```
error: used `assert_eq!` with a literal bool
   --> src/types/sequence.rs:675:9
    |
675 |         assert_eq!(empty_seq.is_empty().unwrap(), true);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
    |
    = help: for further information visit rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison
```