### PR TITLE
pyo3_benchmarks: add a benchmark for the "only simple args" case

### DIFF
--- a/examples/pyo3-benchmarks/src/lib.rs
+++ b/examples/pyo3-benchmarks/src/lib.rs
@@ -24,10 +24,16 @@ fn mixed_args<'a>(
 #[pyfunction]
 fn no_args() {}
 
+#[pyfunction(b = 2, "*", c = 4)]
+fn simple_args(a: i32, b: i32, c: i32) -> (i32, i32, i32) {
+    (a, b, c)
+}
+
 #[pymodule]
 fn _pyo3_benchmarks(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(args_and_kwargs, m)?)?;
     m.add_function(wrap_pyfunction!(mixed_args, m)?)?;
     m.add_function(wrap_pyfunction!(no_args, m)?)?;
+    m.add_function(wrap_pyfunction!(simple_args, m)?)?;
     Ok(())
 }

--- a/examples/pyo3-benchmarks/tests/test_benchmarks.py
+++ b/examples/pyo3-benchmarks/tests/test_benchmarks.py
@@ -44,3 +44,18 @@ def test_no_args_py(benchmark):
     py = no_args_py()
     assert rust == py
     benchmark(no_args_py)
+
+
+def test_simple_args(benchmark):
+    benchmark(pyo3_benchmarks.simple_args, 1, 3, c=5)
+
+
+def simple_args_py(a, b=2, *, c=4):
+    return a, b, c
+
+
+def test_simple_args_py(benchmark):
+    rust = pyo3_benchmarks.simple_args(1, 3, c=5)
+    py = simple_args_py(1, 3, c=5)
+    assert rust == py
+    benchmark(simple_args_py, 1, 3, c=5)


### PR DESCRIPTION
This is the case that will be helped by fastcall support,
so add it first as a baseline.

Currently, this benchmark takes about 2x time compared to the Python version.