### PR TITLE
Implement METH_FASTCALL for pyfunctions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Reduce LLVM line counts to improve compilation times. [#1604](https://github.com/PyO3/pyo3/pull/1604)
 - Deprecate string-literal second argument to `#[pyfn(m, "name")]`. [#1610](https://github.com/PyO3/pyo3/pull/1610)
 - No longer call `PyEval_InitThreads()` in `#[pymodule]` init code. [#1630](https://github.com/PyO3/pyo3/pull/1630)
+- Use `METH_FASTCALL` argument passing convention, when possible, to improve `#[pyfunction]` performance. [#1619](https://github.com/PyO3/pyo3/pull/1619)
 
 ### Removed
 - Remove deprecated exception names `BaseException` etc. [#1426](https://github.com/PyO3/pyo3/pull/1426)
@@ -61,6 +62,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `PyModuleDef_INIT` [#1630](https://github.com/PyO3/pyo3/pull/1630)
 - Remove `__doc__` from module's `__all__`. [#1509](https://github.com/PyO3/pyo3/pull/1509)
 - Remove `PYO3_CROSS_INCLUDE_DIR` environment variable and the associated C header parsing functionality. [#1521](https://github.com/PyO3/pyo3/pull/1521)
+- Remove `raw_pycfunction!` macro. [#1619](https://github.com/PyO3/pyo3/pull/1619)
 
 ### Fixed
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)

--- a/guide/src/function.md
+++ b/guide/src/function.md
@@ -279,12 +279,11 @@ in the function body.
 
 ## Accessing the FFI functions
 
-In order to make Rust functions callable from Python, PyO3 generates a
-`extern "C" Fn(slf: *mut PyObject, args: *mut PyObject, kwargs: *mut PyObject) -> *mut Pyobject`
-function and embeds the call to the Rust function inside this FFI-wrapper function. This
-wrapper handles extraction of the regular arguments and the keyword arguments from the input
-`PyObjects`. Since this function is not user-defined but required to build a `PyCFunction`, PyO3
-offers the `raw_pycfunction!()` macro to get the identifier of this generated wrapper.
+In order to make Rust functions callable from Python, PyO3 generates an `extern "C"`
+function whose exact signature depends on the Rust signature.  (PyO3 chooses the optimal
+Python argument passing convention.) It then embeds the call to the Rust function inside this
+FFI-wrapper function. This wrapper handles extraction of the regular arguments and the keyword
+arguments from the input `PyObject`s.
 
 The `wrap_pyfunction` macro can be used to directly get a `PyCFunction` given a
 `#[pyfunction]` and a `PyModule`: `wrap_pyfunction!(rust_fun, module)`.

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -401,25 +401,29 @@ pub fn impl_wrap_pyfunction(
     let name = &func.sig.ident;
     let wrapper_ident = format_ident!("__pyo3_raw_{}", name);
     let wrapper = function_c_wrapper(name, &wrapper_ident, &spec, options.pass_module)?;
-    let methoddef = if spec.args.is_empty() {
-        quote!(noargs)
+    let (methoddef_meth, cfunc_variant) = if spec.args.is_empty() {
+        (quote!(noargs), quote!(PyCFunction))
+    } else if spec.can_use_fastcall() {
+        (
+            quote!(fastcall_cfunction_with_keywords),
+            quote!(PyCFunctionFastWithKeywords),
+        )
     } else {
-        quote!(cfunction_with_keywords)
+        (
+            quote!(cfunction_with_keywords),
+            quote!(PyCFunctionWithKeywords),
+        )
     };
-    let cfunc = if spec.args.is_empty() {
-        quote!(PyCFunction)
-    } else {
-        quote!(PyCFunctionWithKeywords)
-    };
+
     let wrapped_pyfunction = quote! {
         #wrapper
         pub(crate) fn #function_wrapper_ident<'a>(
             args: impl Into<pyo3::derive_utils::PyFunctionArguments<'a>>
         ) -> pyo3::PyResult<&'a pyo3::types::PyCFunction> {
             pyo3::types::PyCFunction::internal_new(
-                pyo3::class::methods::PyMethodDef:: #methoddef (
+                pyo3::class::methods::PyMethodDef:: #methoddef_meth (
                     #python_name,
-                    pyo3::class::methods:: #cfunc (#wrapper_ident),
+                    pyo3::class::methods:: #cfunc_variant (#wrapper_ident),
                     #doc,
                 ),
                 args.into(),
@@ -469,8 +473,36 @@ fn function_c_wrapper(
                 })
             }
         })
+    } else if spec.can_use_fastcall() {
+        let body = impl_arg_params(spec, None, cb, &py, true)?;
+        Ok(quote! {
+            unsafe extern "C" fn #wrapper_ident(
+                _slf: *mut pyo3::ffi::PyObject,
+                _args: *const *mut pyo3::ffi::PyObject,
+                _nargs: pyo3::ffi::Py_ssize_t,
+                _kwnames: *mut pyo3::ffi::PyObject) -> *mut pyo3::ffi::PyObject
+            {
+                pyo3::callback::handle_panic(|#py| {
+                    #slf_module
+                    // _nargs is the number of positional arguments in the _args array,
+                    // the number of KW args is given by the length of _kwnames
+                    let _kwnames: Option<&pyo3::types::PyTuple> = #py.from_borrowed_ptr_or_opt(_kwnames);
+                    // Safety: &PyAny has the same memory layout as `*mut ffi::PyObject`
+                    let _args = _args as *const &pyo3::PyAny;
+                    let _kwargs = if let Some(kwnames) = _kwnames {
+                        std::slice::from_raw_parts(_args.offset(_nargs), kwnames.len())
+                    } else {
+                        &[]
+                    };
+                    let _args = std::slice::from_raw_parts(_args, _nargs as usize);
+
+                    #body
+                })
+            }
+
+        })
     } else {
-        let body = impl_arg_params(spec, None, cb, &py)?;
+        let body = impl_arg_params(spec, None, cb, &py, false)?;
         Ok(quote! {
             unsafe extern "C" fn #wrapper_ident(
                 _slf: *mut pyo3::ffi::PyObject,
@@ -482,7 +514,6 @@ fn function_c_wrapper(
                     #slf_module
                     let _args = #py.from_borrowed_ptr::<pyo3::types::PyTuple>(_args);
                     let _kwargs: Option<&pyo3::types::PyDict> = #py.from_borrowed_ptr_or_opt(_kwargs);
-
                     #body
                 })
             }

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -39,6 +39,7 @@ impl FunctionDescription {
             format!("{}()", self.func_name)
         }
     }
+
     /// Extracts the `args` and `kwargs` provided into `output`, according to this function
     /// definition.
     ///
@@ -52,8 +53,9 @@ impl FunctionDescription {
     /// Unexpected, duplicate or invalid arguments will cause this function to return `TypeError`.
     pub fn extract_arguments<'p>(
         &self,
-        args: &'p PyTuple,
-        kwargs: Option<&'p PyDict>,
+        py: Python<'p>,
+        mut args: impl ExactSizeIterator<Item = &'p PyAny>,
+        kwargs: Option<impl Iterator<Item = (&'p PyAny, &'p PyAny)>>,
         output: &mut [Option<&'p PyAny>],
     ) -> PyResult<(Option<&'p PyTuple>, Option<&'p PyDict>)> {
         let num_positional_parameters = self.positional_parameter_names.len();
@@ -66,25 +68,28 @@ impl FunctionDescription {
         );
 
         // Handle positional arguments
-        let (args_provided, varargs) = {
+        let args_provided = {
             let args_provided = args.len();
-
             if self.accept_varargs {
-                (
-                    std::cmp::min(num_positional_parameters, args_provided),
-                    Some(args.slice(num_positional_parameters as isize, args_provided as isize)),
-                )
+                std::cmp::min(num_positional_parameters, args_provided)
             } else if args_provided > num_positional_parameters {
                 return Err(self.too_many_positional_arguments(args_provided));
             } else {
-                (args_provided, None)
+                args_provided
             }
         };
 
         // Copy positional arguments into output
-        for (out, arg) in output[..args_provided].iter_mut().zip(args) {
+        for (out, arg) in output[..args_provided].iter_mut().zip(args.by_ref()) {
             *out = Some(arg);
         }
+
+        // Collect varargs into tuple
+        let varargs = if self.accept_varargs {
+            Some(PyTuple::new(py, args))
+        } else {
+            None
+        };
 
         // Handle keyword arguments
         let varkeywords = match (kwargs, self.accept_varkeywords) {
@@ -92,7 +97,7 @@ impl FunctionDescription {
                 let mut varkeywords = None;
                 self.extract_keyword_arguments(kwargs, output, |name, value| {
                     varkeywords
-                        .get_or_insert_with(|| PyDict::new(kwargs.py()))
+                        .get_or_insert_with(|| PyDict::new(py))
                         .set_item(name, value)
                 })?;
                 varkeywords
@@ -146,7 +151,7 @@ impl FunctionDescription {
     #[inline]
     fn extract_keyword_arguments<'p>(
         &self,
-        kwargs: &'p PyDict,
+        kwargs: impl Iterator<Item = (&'p PyAny, &'p PyAny)>,
         output: &mut [Option<&'p PyAny>],
         mut unexpected_keyword_handler: impl FnMut(&'p PyAny, &'p PyAny) -> PyResult<()>,
     ) -> PyResult<()> {

--- a/src/ffi/methodobject.rs
+++ b/src/ffi/methodobject.rs
@@ -45,7 +45,7 @@ pub type PyCFunctionWithKeywords = unsafe extern "C" fn(
     kwds: *mut PyObject,
 ) -> *mut PyObject;
 
-#[cfg(Py_3_7)]
+#[cfg(all(Py_3_7, not(Py_LIMITED_API)))]
 pub type _PyCFunctionFastWithKeywords = unsafe extern "C" fn(
     slf: *mut PyObject,
     args: *const *mut PyObject,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,35 +335,6 @@ macro_rules! wrap_pyfunction {
     };
 }
 
-/// Returns the function that is called in the C-FFI.
-///
-/// Use this together with `#[pyfunction]` and [types::PyCFunction].
-/// ```
-/// use pyo3::prelude::*;
-/// use pyo3::types::PyCFunction;
-/// use pyo3::raw_pycfunction;
-///
-/// #[pyfunction]
-/// fn some_fun(arg: i32) -> PyResult<()> {
-///     Ok(())
-/// }
-///
-/// #[pymodule]
-/// fn module(_py: Python, module: &PyModule) -> PyResult<()> {
-///     let ffi_wrapper_fun = raw_pycfunction!(some_fun);
-///     let docs = "Some documentation string with null-termination\0";
-///     let py_cfunction =
-///         PyCFunction::new_with_keywords(ffi_wrapper_fun, "function_name", docs, module.into())?;
-///     module.add_function(py_cfunction)
-/// }
-/// ```
-#[macro_export]
-macro_rules! raw_pycfunction {
-    ($function_name: ident) => {{
-        pyo3::paste::expr! { [<__pyo3_raw_ $function_name>] }
-    }};
-}
-
 /// Returns a function that takes a [Python] instance and returns a Python module.
 ///
 /// Use this together with `#[pymodule]` and [types::PyModule::add_wrapped].

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -14,8 +14,6 @@ pyobject_native_type_core!(PyCFunction, ffi::PyCFunction_Type, #checkfunction=ff
 
 impl PyCFunction {
     /// Create a new built-in function with keywords.
-    ///
-    /// See [raw_pycfunction] for documentation on how to get the `fun` argument.
     pub fn new_with_keywords<'a>(
         fun: ffi::PyCFunctionWithKeywords,
         name: &'static str,

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -122,6 +122,12 @@ impl<'a> Iterator for PyTupleIterator<'a> {
     }
 }
 
+impl<'a> ExactSizeIterator for PyTupleIterator<'a> {
+    fn len(&self) -> usize {
+        self.length - self.index
+    }
+}
+
 impl<'a> IntoIterator for &'a PyTuple {
     type Item = &'a PyAny;
     type IntoIter = PyTupleIterator<'a>;

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -4,7 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyCFunction;
 #[cfg(not(Py_LIMITED_API))]
 use pyo3::types::{PyDateTime, PyFunction};
-use pyo3::{raw_pycfunction, wrap_pyfunction};
+use pyo3::wrap_pyfunction;
 
 mod common;
 
@@ -162,31 +162,6 @@ fn test_function_with_custom_conversion_error() {
         PyTypeError,
         "argument 'timestamp': 'list' object cannot be converted to 'PyDateTime'"
     );
-}
-
-#[test]
-fn test_raw_function() {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    let raw_func = raw_pycfunction!(optional_bool);
-    let fun = PyCFunction::new_with_keywords(raw_func, "fun", "", py.into()).unwrap();
-    let res = fun.call((), None).unwrap().extract::<&str>().unwrap();
-    assert_eq!(res, "Some(true)");
-    let res = fun.call((false,), None).unwrap().extract::<&str>().unwrap();
-    assert_eq!(res, "Some(false)");
-    let no_module = fun.getattr("__module__").unwrap().is_none();
-    assert!(no_module);
-
-    let module = PyModule::new(py, "cool_module").unwrap();
-    module.add_function(fun).unwrap();
-    let res = module
-        .getattr("fun")
-        .unwrap()
-        .call((), None)
-        .unwrap()
-        .extract::<&str>()
-        .unwrap();
-    assert_eq!(res, "Some(true)");
 }
 
 #[pyfunction]


### PR DESCRIPTION
This is now for all not-NOARGS functions, with the change suggested to make `extract_arguments` take iterators.

Unfortunately this seems to slow down the cases where `*args` or `**kwargs` are present: on my machine, the benchmarks show

```
       before  after
simple    844    786
mixed    1043   1168
arg_kw    901   1019
```

This is even without the fact that with the old code, they could even be optimized: for `**kwargs` a new dict is created, while it is possible to keep the dict with all arguments given by name, and remove those args which match named parameters.

And the "only *args and **kwds" case can be heavily optimized by just passing through the tuple and dict already gotten from METH_VARARGS.
