### PR TITLE
build.rs: if found more than one candidate, filter on arch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `num-complex` optional dependency to 0.4. [#1482](https://github.com/PyO3/pyo3/pull/1482)
 - Extend `hashbrown` optional dependency supported versions to include 0.11. [#1496](https://github.com/PyO3/pyo3/pull/1496)
 - Support PyPy 3.7. [#1538](https://github.com/PyO3/pyo3/pull/1538)
+- Try harder to filter sysconfigdata candidates on arch.config
 
 ### Added
 - Add conversions for `[T; N]` for all `N` on Rust 1.51 and up. [#1128](https://github.com/PyO3/pyo3/pull/1128)


### PR DESCRIPTION
Hi,

 This is my first RP on pyo3. Thanks for the great work, I'm using this right now to convert a library from python to rust for a raspberry pi running in 32 bit mode, that is armhf architecture, using ubuntu 20.04 as the target distribution. I have both the host x86_64 python3.8 sysconfigdata and the foreign architecture armhf in /usr/lib/python3.8, which results in more than one candidate during search_lib_dir, and an error of "Detected multiple possible python versions".

 I've conservatively added a filter in that case to keep only the paths with cross.arch in their name (to_lossy_string.contains(&config.arch))

 There is already an existing filter on config.arch but only in another branch, so I didn't want to pull it in to the first branch (Ok(f) if starts_with(f, "_sysconfigdata") && ends_with(f, "py")).

 I added a line in CHANGELOG, I think this is a bug so it should not change the documentation.

 I've run clippy (no errors), run fmt (no changes), "cargo test" fails but on unrelated code (I can attach, fails in examples).

Alon
