### PR TITLE
Fix memory leak when converting to u128 and i128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support `EnvironmentError`, `IOError`, and `WindowsError` on PyPy. [#1533](https://github.com/PyO3/pyo3/pull/1533)
 - Fix unneccessary rebuilds when cycling between `cargo check` and `cargo clippy` in a Python virtualenv. [#1557](https://github.com/PyO3/pyo3/pull/1557)
 - Fix segfault when dereferencing `ffi::PyDateTimeAPI` without the GIL. [#1563](https://github.com/PyO3/pyo3/pull/1563)
+- Fix memory leak when converting to u128 and i128. [#1638](https://github.com/PyO3/pyo3/pull/1638)
 
 ## [0.13.2] - 2021-02-12
 ### Packaging

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -199,6 +199,7 @@ mod fast_128bit_int_conversion {
                             1,
                             $is_signed,
                         );
+                        ffi::Py_DECREF(num);
                         if ok == -1 {
                             Err(PyErr::fetch(ob.py()))
                         } else {


### PR DESCRIPTION
I had a quick look at the equivalent `slow_128bit_int_conversion` conversion and I don't think there is a leak there, but I haven't checked.