### PR TITLE
Simplify code generated for for_each_method_def and for_each_proto_slot

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -757,18 +757,17 @@ impl pyo3::class::impl_::PyClassImpl for MyClass {
     type BaseType = PyAny;
     type ThreadChecker = pyo3::class::impl_::ThreadCheckerStub<MyClass>;
 
-    fn for_each_method_def(visitor: &mut dyn FnMut(&pyo3::class::PyMethodDefType)) {
+    fn for_each_method_def(visitor: &mut dyn FnMut(&[pyo3::class::PyMethodDefType])) {
         use pyo3::class::impl_::*;
         let collector = PyClassImplCollector::<MyClass>::new();
-        collector.py_methods().iter()
-            .chain(collector.py_class_descriptors())
-            .chain(collector.object_protocol_methods())
-            .chain(collector.async_protocol_methods())
-            .chain(collector.context_protocol_methods())
-            .chain(collector.descr_protocol_methods())
-            .chain(collector.mapping_protocol_methods())
-            .chain(collector.number_protocol_methods())
-            .for_each(visitor)
+        visitor(collector.py_methods());
+        visitor(collector.py_class_descriptors());
+        visitor(collector.object_protocol_methods());
+        visitor(collector.async_protocol_methods());
+        visitor(collector.context_protocol_methods());
+        visitor(collector.descr_protocol_methods());
+        visitor(collector.mapping_protocol_methods());
+        visitor(collector.number_protocol_methods());
     }
     fn get_new() -> Option<pyo3::ffi::newfunc> {
         use pyo3::class::impl_::*;
@@ -780,21 +779,19 @@ impl pyo3::class::impl_::PyClassImpl for MyClass {
         let collector = PyClassImplCollector::<Self>::new();
         collector.call_impl()
     }
-    fn for_each_proto_slot(visitor: &mut dyn FnMut(&pyo3::ffi::PyType_Slot)) {
+    fn for_each_proto_slot(visitor: &mut dyn FnMut(&[pyo3::ffi::PyType_Slot])) {
         // Implementation which uses dtolnay specialization to load all slots.
         use pyo3::class::impl_::*;
         let collector = PyClassImplCollector::<Self>::new();
-        collector.object_protocol_slots()
-            .iter()
-            .chain(collector.number_protocol_slots())
-            .chain(collector.iter_protocol_slots())
-            .chain(collector.gc_protocol_slots())
-            .chain(collector.descr_protocol_slots())
-            .chain(collector.mapping_protocol_slots())
-            .chain(collector.sequence_protocol_slots())
-            .chain(collector.async_protocol_slots())
-            .chain(collector.buffer_protocol_slots())
-            .for_each(visitor);
+        visitor(collector.object_protocol_slots());
+        visitor(collector.number_protocol_slots());
+        visitor(collector.iter_protocol_slots());
+        visitor(collector.gc_protocol_slots());
+        visitor(collector.descr_protocol_slots());
+        visitor(collector.mapping_protocol_slots());
+        visitor(collector.sequence_protocol_slots());
+        visitor(collector.async_protocol_slots());
+        visitor(collector.buffer_protocol_slots());
     }
 
     fn get_buffer() -> Option<&'static pyo3::class::impl_::PyBufferProcs> {

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -345,24 +345,16 @@ fn impl_class(
         quote! {}
     };
 
-    let impl_inventory = match methods_type {
-        PyClassMethodsType::Specialization => None,
-        PyClassMethodsType::Inventory => Some(impl_methods_inventory(&cls)),
-    };
-
-    let for_each_py_method = match methods_type {
-        PyClassMethodsType::Specialization => quote! {
-            for method_def in collector.py_methods().iter() {
-                visitor(method_def);
-            }
-        },
-        PyClassMethodsType::Inventory => quote! {
-            for inventory in pyo3::inventory::iter::<<Self as pyo3::class::impl_::HasMethodsInventory>::Methods> {
-                for method_def in pyo3::class::impl_::PyMethodsInventory::get(inventory) {
-                    visitor(method_def);
+    let (impl_inventory, for_each_py_method) = match methods_type {
+        PyClassMethodsType::Specialization => (None, quote! { visitor(collector.py_methods()); }),
+        PyClassMethodsType::Inventory => (
+            Some(impl_methods_inventory(&cls)),
+            quote! {
+                for inventory in pyo3::inventory::iter::<<Self as pyo3::class::impl_::HasMethodsInventory>::Methods>() {
+                    visitor(pyo3::class::impl_::PyMethodsInventory::get(inventory));
                 }
-            }
-        },
+            },
+        ),
     };
 
     let base = &attr.base;
@@ -444,38 +436,17 @@ fn impl_class(
             type BaseType = #base;
             type ThreadChecker = #thread_checker;
 
-            fn for_each_method_def(visitor: &mut dyn FnMut(&pyo3::class::PyMethodDefType)) {
+            fn for_each_method_def(visitor: &mut dyn FnMut(&[pyo3::class::PyMethodDefType])) {
                 use pyo3::class::impl_::*;
                 let collector = PyClassImplCollector::<Self>::new();
                 #for_each_py_method;
-
-                for method_def in collector.py_class_descriptors() {
-                    visitor(method_def);
-                }
-
-                for method_def in collector.object_protocol_methods() {
-                    visitor(method_def);
-                }
-
-                for method_def in collector.async_protocol_methods() {
-                    visitor(method_def);
-                }
-
-                for method_def in collector.context_protocol_methods() {
-                    visitor(method_def);
-                }
-
-                for method_def in collector.descr_protocol_methods() {
-                    visitor(method_def);
-                }
-
-                for method_def in collector.mapping_protocol_methods() {
-                    visitor(method_def);
-                }
-
-                for method_def in collector.number_protocol_methods() {
-                    visitor(method_def);
-                }
+                visitor(collector.py_class_descriptors());
+                visitor(collector.object_protocol_methods());
+                visitor(collector.async_protocol_methods());
+                visitor(collector.context_protocol_methods());
+                visitor(collector.descr_protocol_methods());
+                visitor(collector.mapping_protocol_methods());
+                visitor(collector.number_protocol_methods());
             }
             fn get_new() -> Option<pyo3::ffi::newfunc> {
                 use pyo3::class::impl_::*;
@@ -488,45 +459,19 @@ fn impl_class(
                 collector.call_impl()
             }
 
-            fn for_each_proto_slot(visitor: &mut dyn FnMut(&pyo3::ffi::PyType_Slot)) {
+            fn for_each_proto_slot(visitor: &mut dyn FnMut(&[pyo3::ffi::PyType_Slot])) {
                 // Implementation which uses dtolnay specialization to load all slots.
                 use pyo3::class::impl_::*;
                 let collector = PyClassImplCollector::<Self>::new();
-                for slot in collector.object_protocol_slots().iter() {
-                    visitor(slot);
-                }
-
-                for slot in collector.number_protocol_slots() {
-                    visitor(slot);
-                }
-
-                for slot in collector.iter_protocol_slots() {
-                    visitor(slot);
-                }
-
-                for slot in collector.gc_protocol_slots() {
-                    visitor(slot);
-                }
-
-                for slot in collector.descr_protocol_slots() {
-                    visitor(slot);
-                }
-
-                for slot in collector.mapping_protocol_slots() {
-                    visitor(slot);
-                }
-
-                for slot in collector.sequence_protocol_slots() {
-                    visitor(slot);
-                }
-
-                for slot in collector.async_protocol_slots() {
-                    visitor(slot);
-                }
-
-                for slot in collector.buffer_protocol_slots() {
-                    visitor(slot);
-                }
+                visitor(collector.object_protocol_slots());
+                visitor(collector.number_protocol_slots());
+                visitor(collector.iter_protocol_slots());
+                visitor(collector.gc_protocol_slots());
+                visitor(collector.descr_protocol_slots());
+                visitor(collector.mapping_protocol_slots());
+                visitor(collector.sequence_protocol_slots());
+                visitor(collector.async_protocol_slots());
+                visitor(collector.buffer_protocol_slots());
             }
 
             fn get_buffer() -> Option<&'static pyo3::class::impl_::PyBufferProcs> {

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -65,14 +65,14 @@ pub trait PyClassImpl: Sized {
     ///    can be accessed by multiple threads by `threading` module.
     type ThreadChecker: PyClassThreadChecker<Self>;
 
-    fn for_each_method_def(_visitor: &mut dyn FnMut(&PyMethodDefType)) {}
+    fn for_each_method_def(_visitor: &mut dyn FnMut(&[PyMethodDefType])) {}
     fn get_new() -> Option<ffi::newfunc> {
         None
     }
     fn get_call() -> Option<ffi::PyCFunctionWithKeywords> {
         None
     }
-    fn for_each_proto_slot(_visitor: &mut dyn FnMut(&ffi::PyType_Slot)) {}
+    fn for_each_proto_slot(_visitor: &mut dyn FnMut(&[ffi::PyType_Slot])) {}
     fn get_buffer() -> Option<&'static PyBufferProcs> {
         None
     }


### PR DESCRIPTION
This change replaces `slice1.iter().chain(slice2)....chain(sliceN).for_each(f)` with `f(slice1); f(slice2); ... f(sliceN);`.

On a real-world project it significantly reduces number of lines of LLVM code generated by the compiler, with a similar improvement in compilation time.

I adapted the word_count example to add a `#[pyclass]`:
```rust
#[pyclass]
struct WordCount {
    contents: String,
}

#[pymethods]
impl WordCount {
    #[new]
    fn new(contents: String) -> Self {
        Self { contents }
    }

    fn search(&self, needle: &str) -> usize {
        search(&self.contents, needle)
    }

    fn search_sequential(&self, needle: &str) -> usize {
        search_sequential(&self.contents, needle)
    }

    fn search_sequential_allow_threads(&self, py: Python, needle: &str) -> usize {
        search_sequential_allow_threads(py, &self.contents, needle)
    }
}
...
m.add_class::<WordCount>()?;
```

According to `cargo llvm-lines --release`, before this change the top 10 functions in the word_count example, by number of LLVM lines, are:

```
  Lines         Copies       Function name
  -----         ------       -------------
  50562 (100%)  2257 (100%)  (TOTAL)
   2323 (4.6%)    16 (0.7%)  <core::iter::adapters::chain::Chain<A,B> as core::iter::traits::iterator::Iterator>::fold
   2125 (4.2%)    24 (1.1%)  core::iter::traits::iterator::Iterator::fold
   1255 (2.5%)    21 (0.9%)  alloc::alloc::box_free
   1026 (2.0%)    16 (0.7%)  core::result::Result<T,E>::map_err
    844 (1.7%)    12 (0.5%)  std::panicking::try
    789 (1.6%)     8 (0.4%)  pyo3::callback::handle_panic
    753 (1.5%)     3 (0.1%)  word_count::<impl pyo3::class::impl_::PyMethods<word_count::WordCount> for pyo3::class::impl_::PyClassImplCollector<word_count::WordCount>>::py_methods::METHODS::__wrap::{{closure}}
    665 (1.3%)    16 (0.7%)  core::iter::adapters::chain::Chain<A,B>::new
    648 (1.3%)    16 (0.7%)  core::iter::traits::iterator::Iterator::chain
    598 (1.2%)    30 (1.3%)  core::ptr::read
```

And after:
```
  Lines         Copies       Function name
  -----         ------       -------------
  45552 (100%)  2168 (100%)  (TOTAL)
   1255 (2.8%)    21 (1.0%)  alloc::alloc::box_free
   1026 (2.3%)    16 (0.7%)  core::result::Result<T,E>::map_err
    844 (1.9%)    12 (0.6%)  std::panicking::try
    789 (1.7%)     8 (0.4%)  pyo3::callback::handle_panic
    753 (1.7%)     3 (0.1%)  word_count::<impl pyo3::class::impl_::PyMethods<word_count::WordCount> for pyo3::class::impl_::PyClassImplCollector<word_count::WordCount>>::py_methods::METHODS::__wrap::{{closure}}
    657 (1.4%)     7 (0.3%)  core::iter::traits::iterator::Iterator::fold
    598 (1.3%)    30 (1.4%)  core::ptr::read
    570 (1.3%)    10 (0.5%)  alloc::raw_vec::RawVec<T,A>::current_memory
    558 (1.2%)     8 (0.4%)  alloc::boxed::Box<T,A>::into_unique
    546 (1.2%)     7 (0.3%)  std::thread::local::LocalKey<T>::try_with
    490 (1.1%)    11 (0.5%)  core::mem::replace
    485 (1.1%)    11 (0.5%)  core::option::Option<T>::map
    447 (1.0%)     3 (0.1%)  alloc::raw_vec::RawVec<T,A>::shrink
    441 (1.0%)     1 (0.0%)  pyo3::pyclass::create_type_object
    434 (1.0%)    14 (0.6%)  core::ptr::metadata::from_raw_parts_mut
    434 (1.0%)    13 (0.6%)  alloc::boxed::Box<T,A>::from_raw_in
    409 (0.9%)     1 (0.0%)  rayon::iter::plumbing::bridge_unindexed_producer_consumer
    408 (0.9%)    37 (1.7%)  core::mem::manually_drop::ManuallyDrop<T>::new
    400 (0.9%)     1 (0.0%)  word_count::<impl pyo3::class::impl_::PyClassNewImpl<word_count::WordCount> for pyo3::class::impl_::PyClassImplCollector<word_count::WordCount>>::new_impl::__wrap::{{closure}}
    394 (0.9%)     1 (0.0%)  word_count::word_count
```