### PR TITLE
pyo3-build-config: fix cross compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,33 @@ jobs:
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} ${{ matrix.msrv }}
     runs-on: ${{ matrix.platform.os }}
     strategy:
-      fail-fast: false  # If one platform fails, allow the rest to keep testing.
+      fail-fast: false # If one platform fails, allow the rest to keep testing.
       matrix:
         rust: [stable]
         python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev, pypy-3.6, pypy-3.7]
-        platform: [
-          { os: "macos-latest",   python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
-          { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },
-          { os: "windows-latest", python-architecture: "x64", rust-target: "x86_64-pc-windows-msvc" },
-          { os: "windows-latest", python-architecture: "x86", rust-target: "i686-pc-windows-msvc" },
-        ]
+        platform:
+          [
+            {
+              os: "macos-latest",
+              python-architecture: "x64",
+              rust-target: "x86_64-apple-darwin",
+            },
+            {
+              os: "ubuntu-latest",
+              python-architecture: "x64",
+              rust-target: "x86_64-unknown-linux-gnu",
+            },
+            {
+              os: "windows-latest",
+              python-architecture: "x64",
+              rust-target: "x86_64-pc-windows-msvc",
+            },
+            {
+              os: "windows-latest",
+              python-architecture: "x86",
+              rust-target: "i686-pc-windows-msvc",
+            },
+          ]
         exclude:
           # There is no 64-bit pypy on windows for pypy-3.6
           - python-version: pypy-3.6
@@ -63,7 +80,12 @@ jobs:
           # Test minimal supported Rust version
           - rust: 1.41.1
             python-version: 3.9
-            platform: { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" }
+            platform:
+              {
+                os: "ubuntu-latest",
+                python-architecture: "x64",
+                rust-target: "x86_64-unknown-linux-gnu",
+              }
             msrv: "MSRV"
 
     steps:
@@ -146,6 +168,9 @@ jobs:
       - name: Test proc-macro code
         run: cargo test --manifest-path=pyo3-macros-backend/Cargo.toml
 
+      - name: Test build config
+        run: cargo test --manifest-path=pyo3-build-config/Cargo.toml
+
       - name: Install python test dependencies
         run: python -m pip install -U pip tox
 
@@ -193,8 +218,10 @@ jobs:
           override: true
           profile: minimal
           components: llvm-tools-preview
-      - run: LLVM_PROFILE_FILE="coverage-%p-%m.profraw" cargo test --no-default-features --no-fail-fast
-      - run: LLVM_PROFILE_FILE="coverage-features-%p-%m.profraw" cargo test --no-default-features --no-fail-fast --features "macros num-bigint num-complex hashbrown serde multiple-pymethods"
+      - run: cargo test --no-default-features --no-fail-fast
+      - run: cargo test --no-default-features --no-fail-fast --features "macros num-bigint num-complex hashbrown serde multiple-pymethods"
+      - run: cargo test --manifest-path=pyo3-macros-backend/Cargo.toml
+      - run: cargo test --manifest-path=pyo3-build-config/Cargo.toml
       # can't yet use actions-rs/grcov with source-based coverage: https://github.com/actions-rs/grcov/issues/105
       # - uses: actions-rs/grcov@v0.1
       #   id: coverage
@@ -210,3 +237,4 @@ jobs:
       CARGO_TERM_VERBOSE: true
       RUSTFLAGS: "-Zinstrument-coverage"
       RUSTDOCFLAGS: "-Zinstrument-coverage"
+      LLVM_PROFILE_FILE: "coverage-%p-%m.profraw"

--- a/build.rs
+++ b/build.rs
@@ -185,11 +185,16 @@ fn emit_cargo_configuration(interpreter_config: &InterpreterConfig) -> Result<()
     Ok(())
 }
 
+/// Generates the interpreter config suitable for the host / target / cross-compilation at hand.
+///
+/// The result is written to pyo3_build_config::PATH, which downstream scripts can read from
+/// (including `pyo3-macros-backend` during macro expansion).
 fn configure_pyo3() -> Result<()> {
-    let interpreter_config = pyo3_build_config::get();
+    let interpreter_config = pyo3_build_config::make_interpreter_config()?;
     ensure_python_version(&interpreter_config)?;
     ensure_target_architecture(&interpreter_config)?;
     emit_cargo_configuration(&interpreter_config)?;
+    interpreter_config.to_writer(&mut std::fs::File::create(pyo3_build_config::PATH)?)?;
     interpreter_config.emit_pyo3_cfgs();
 
     // Enable use of const generics on Rust 1.51 and greater

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+once_cell = "1"
 
 [features]
 default = []

--- a/pyo3-build-config/build.rs
+++ b/pyo3-build-config/build.rs
@@ -1,11 +1,3 @@
-#[allow(dead_code)]
-#[path = "src/impl_.rs"]
-mod impl_;
-
 fn main() {
-    // Print out error messages using display, to get nicer formatting.
-    if let Err(e) = impl_::configure() {
-        eprintln!("error: {}", e);
-        std::process::exit(1)
-    }
+    // Empty build script to force cargo to produce the "OUT_DIR" environment variable.
 }

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -16,11 +16,9 @@ edition = "2018"
 [dependencies]
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.14.0-alpha.0" }
 
 [dependencies.syn]
 version = "1"
 default-features = false
 features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits"]
-
-[build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.14.0-alpha.0" }

--- a/pyo3-macros-backend/build.rs
+++ b/pyo3-macros-backend/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    pyo3_build_config::use_pyo3_cfgs();
-}

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -177,12 +177,19 @@ impl CallingConvention {
         } else if accept_kwargs {
             // for functions that accept **kwargs, always prefer varargs
             Self::Varargs
-        } else if cfg!(all(Py_3_7, not(Py_LIMITED_API))) {
+        } else if can_use_fastcall() {
             Self::Fastcall
         } else {
             Self::Varargs
         }
     }
+}
+
+fn can_use_fastcall() -> bool {
+    const PY37: pyo3_build_config::PythonVersion =
+        pyo3_build_config::PythonVersion { major: 3, minor: 7 };
+    let config = pyo3_build_config::get();
+    config.version >= PY37 && !config.abi3
 }
 
 pub struct FnSpec<'a> {

--- a/pyo3-macros-backend/src/pyproto.rs
+++ b/pyo3-macros-backend/src/pyproto.rs
@@ -133,7 +133,11 @@ fn impl_proto_methods(
 
     let mut maybe_buffer_methods = None;
 
-    if cfg!(not(Py_3_9)) && proto.name == "Buffer" {
+    let build_config = pyo3_build_config::get();
+    const PY39: pyo3_build_config::PythonVersion =
+        pyo3_build_config::PythonVersion { major: 3, minor: 9 };
+
+    if build_config.version <= PY39 && proto.name == "Buffer" {
         maybe_buffer_methods = Some(quote! {
             impl pyo3::class::impl_::PyBufferProtocolProcs<#ty>
                 for pyo3::class::impl_::PyClassImplCollector<#ty>


### PR DESCRIPTION
This fixes cross-compilation with the new `pyo3-build-config` crate.

The problem is that `CARGO_CFG_TARGET_OS` (and similar) environment variables are set to the **host** OS when running the `build.rs` in `pyo3-build-config`, because `pyo3-build-config` is used in `build-dependencies`.

The best way I can see to fix this is to evaluate the build configuration in the `build.rs` of the first runtime dependency we control - PyO3's `build.rs`. 

Before:
 - `build.rs` in `pyo3-build-config` runs (incorrectly) and generates config information, which gets baked into the `pyo3-build-config` crate
 - downstream crates (`pyo3`, `pyo3-build-config`) use this baked-in configuration

This PR:
 - `build.rs` in `pyo3-build-config` creates an empty `OUT_DIR`
 - `build.rs` in `pyo3` writes the correct config to that `OUT_DIR`
 - downstream crates can load this configuration in their `build.rs` 
 - `pyo3-macros-backend` can load this configuration at macro runtime and check it

cc @birkenfeld this will slightly change how to check for `METH_FASTCALL` support in #1619 - instead of using `cfg!`, it's now necessary to use `pyo3_build_config::get()` and check the configuration directly. This is necessary because `pyo3-macros-backend` is built _before_ `pyo3`, so the configuration hasn't yet been written when `pyo3-macros-backend` is built.