### PR TITLE
pyclass: allow `#[pyo3(get, set, name = "foo")]`

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -349,7 +349,7 @@ struct MyClass {
 }
 ```
 
-The above would make the `num` property available for reading and writing from Python code as `self.num`.
+The above would make the `num` field available for reading and writing as a `self.num` Python property. To expose the property with a different name to the field, specify this alongside the rest of the options, e.g. `#[pyo3(get, set, name = "custom_name")]`.
 
 Properties can be readonly or writeonly by using just `#[pyo3(get)]` or `#[pyo3(set)]` respectively.
 

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -12,9 +12,11 @@ pub mod kw {
     syn::custom_keyword!(annotation);
     syn::custom_keyword!(attribute);
     syn::custom_keyword!(from_py_with);
+    syn::custom_keyword!(get);
     syn::custom_keyword!(item);
     syn::custom_keyword!(pass_module);
     syn::custom_keyword!(name);
+    syn::custom_keyword!(set);
     syn::custom_keyword!(signature);
     syn::custom_keyword!(transparent);
 }
@@ -43,9 +45,7 @@ impl Parse for NameAttribute {
     }
 }
 
-pub fn get_pyo3_attributes<T: Parse>(
-    attr: &syn::Attribute,
-) -> Result<Option<Punctuated<T, Comma>>> {
+pub fn get_pyo3_options<T: Parse>(attr: &syn::Attribute) -> Result<Option<Punctuated<T, Comma>>> {
     if is_attribute_ident(attr, "pyo3") {
         attr.parse_args_with(Punctuated::parse_terminated).map(Some)
     } else {
@@ -81,6 +81,19 @@ pub fn take_attributes(
         })
         .collect::<Result<_>>()?;
     Ok(())
+}
+
+pub fn take_pyo3_options<T: Parse>(attrs: &mut Vec<syn::Attribute>) -> Result<Vec<T>> {
+    let mut out = Vec::new();
+    take_attributes(attrs, |attr| {
+        if let Some(options) = get_pyo3_options(attr)? {
+            out.extend(options.into_iter());
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    })?;
+    Ok(out)
 }
 
 pub fn get_deprecated_name_attribute(

--- a/pyo3-macros-backend/src/from_pyobject.rs
+++ b/pyo3-macros-backend/src/from_pyobject.rs
@@ -1,4 +1,4 @@
-use crate::attributes::{self, get_pyo3_attributes, FromPyWithAttribute};
+use crate::attributes::{self, get_pyo3_options, FromPyWithAttribute};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
@@ -290,7 +290,7 @@ impl ContainerOptions {
             annotation: None,
         };
         for attr in attrs {
-            if let Some(pyo3_attrs) = get_pyo3_attributes(attr)? {
+            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
                 for pyo3_attr in pyo3_attrs {
                     match pyo3_attr {
                         ContainerPyO3Attribute::Transparent(kw) => {
@@ -388,7 +388,7 @@ impl FieldPyO3Attributes {
         let mut from_py_with = None;
 
         for attr in attrs {
-            if let Some(pyo3_attrs) = get_pyo3_attributes(attr)? {
+            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
                 for pyo3_attr in pyo3_attrs {
                     match pyo3_attr {
                         FieldPyO3Attribute::Getter(field_getter) => {

--- a/pyo3-macros-backend/src/konst.rs
+++ b/pyo3-macros-backend/src/konst.rs
@@ -1,7 +1,7 @@
 use crate::{
     attributes::{
-        self, get_deprecated_name_attribute, get_pyo3_attributes, is_attribute_ident,
-        take_attributes, NameAttribute,
+        self, get_deprecated_name_attribute, get_pyo3_options, is_attribute_ident, take_attributes,
+        NameAttribute,
     },
     deprecations::Deprecations,
 };
@@ -69,7 +69,7 @@ impl ConstAttributes {
                 );
                 attributes.is_class_attr = true;
                 Ok(true)
-            } else if let Some(pyo3_attributes) = get_pyo3_attributes(attr)? {
+            } else if let Some(pyo3_attributes) = get_pyo3_options(attr)? {
                 for pyo3_attr in pyo3_attributes {
                     match pyo3_attr {
                         PyO3ConstAttribute::Name(name) => attributes.set_name(name)?,

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -220,9 +220,8 @@ impl<'a> FnSpec<'a> {
         })
     }
 
-    pub fn null_terminated_python_name(&self) -> TokenStream {
-        let name = format!("{}\0", self.python_name);
-        quote!({#name})
+    pub fn null_terminated_python_name(&self) -> syn::LitStr {
+        syn::LitStr::new(&format!("{}\0", self.python_name), self.python_name.span())
     }
 
     fn parse_text_signature(

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -114,7 +114,7 @@ fn get_pyfn_attr(attrs: &mut Vec<syn::Attribute>) -> syn::Result<Option<PyFnArgs
     })?;
 
     if let Some(pyfn_args) = &mut pyfn_args {
-        pyfn_args.options.take_pyo3_attributes(attrs)?;
+        pyfn_args.options.take_pyo3_options(attrs)?;
     }
 
     Ok(pyfn_args)

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     attributes::{
-        self, get_deprecated_name_attribute, get_pyo3_attributes, take_attributes,
+        self, get_deprecated_name_attribute, get_pyo3_options, take_attributes,
         FromPyWithAttribute, NameAttribute,
     },
     deprecations::Deprecations,
@@ -62,7 +62,7 @@ impl PyFunctionArgPyO3Attributes {
     pub fn from_attrs(attrs: &mut Vec<syn::Attribute>) -> syn::Result<Self> {
         let mut attributes = PyFunctionArgPyO3Attributes { from_py_with: None };
         take_attributes(attrs, |attr| {
-            if let Some(pyo3_attrs) = get_pyo3_attributes(attr)? {
+            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
                 for attr in pyo3_attrs {
                     match attr {
                         PyFunctionArgPyO3Attribute::FromPyWith(from_py_with) => {
@@ -270,13 +270,13 @@ impl Parse for PyFunctionOption {
 impl PyFunctionOptions {
     pub fn from_attrs(attrs: &mut Vec<syn::Attribute>) -> syn::Result<Self> {
         let mut options = PyFunctionOptions::default();
-        options.take_pyo3_attributes(attrs)?;
+        options.take_pyo3_options(attrs)?;
         Ok(options)
     }
 
-    pub fn take_pyo3_attributes(&mut self, attrs: &mut Vec<syn::Attribute>) -> syn::Result<()> {
+    pub fn take_pyo3_options(&mut self, attrs: &mut Vec<syn::Attribute>) -> syn::Result<()> {
         take_attributes(attrs, |attr| {
-            if let Some(pyo3_attributes) = get_pyo3_attributes(attr)? {
+            if let Some(pyo3_attributes) = get_pyo3_options(attr)? {
                 self.add_attributes(pyo3_attributes)?;
                 Ok(true)
             } else if let Some(name) = get_deprecated_name_attribute(attr, &mut self.deprecations)?
@@ -332,7 +332,7 @@ pub fn build_py_function(
     ast: &mut syn::ItemFn,
     mut options: PyFunctionOptions,
 ) -> syn::Result<TokenStream> {
-    options.take_pyo3_attributes(&mut ast.attrs)?;
+    options.take_pyo3_options(&mut ast.attrs)?;
     Ok(impl_wrap_pyfunction(ast, options)?.1)
 }
 

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -317,7 +317,7 @@ fn test_pymethods_from_py_with() {
 }
 
 #[pyclass]
-struct TupleClass(i32);
+struct TupleClass(#[pyo3(get, set, name = "value")] i32);
 
 #[test]
 fn test_tuple_struct_class() {
@@ -326,5 +326,18 @@ fn test_tuple_struct_class() {
         assert!(typeobj.call((), None).is_err());
 
         py_assert!(py, typeobj, "typeobj.__name__ == 'TupleClass'");
+
+        let instance = Py::new(py, TupleClass(5)).unwrap();
+        py_run!(
+            py,
+            instance,
+            r#"
+        assert instance.value == 5;
+        instance.value = 1234;
+        assert instance.value == 1234;
+        "#
+        );
+
+        assert_eq!(instance.borrow(py).0, 1234);
     });
 }

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -159,7 +159,7 @@ mod inheriting_native_type {
     #[pyclass(extends=PySet)]
     #[derive(Debug)]
     struct SetWithName {
-        #[pyo3(get(name))]
+        #[pyo3(get, name = "name")]
         _name: &'static str,
     }
 
@@ -179,14 +179,14 @@ mod inheriting_native_type {
         py_run!(
             py,
             set_sub,
-            r#"set_sub.add(10); assert list(set_sub) == [10]; assert set_sub._name == "Hello :)""#
+            r#"set_sub.add(10); assert list(set_sub) == [10]; assert set_sub.name == "Hello :)""#
         );
     }
 
     #[pyclass(extends=PyDict)]
     #[derive(Debug)]
     struct DictWithName {
-        #[pyo3(get(name))]
+        #[pyo3(get, name = "name")]
         _name: &'static str,
     }
 
@@ -206,7 +206,7 @@ mod inheriting_native_type {
         py_run!(
             py,
             dict_sub,
-            r#"dict_sub[0] = 1; assert dict_sub[0] == 1; assert dict_sub._name == "Hello :)""#
+            r#"dict_sub[0] = 1; assert dict_sub[0] == 1; assert dict_sub.name == "Hello :)""#
         );
     }
 

--- a/tests/ui/invalid_property_args.rs
+++ b/tests/ui/invalid_property_args.rs
@@ -25,6 +25,18 @@ impl ClassWithSetter {
 }
 
 #[pyclass]
-struct TupleGetterSetter(#[pyo3(get, set)] i32);
+struct TupleGetterSetterNoName(#[pyo3(get, set)] i32);
+
+#[pyclass]
+struct MultipleGet(#[pyo3(get, get)] i32);
+
+#[pyclass]
+struct MultipleSet(#[pyo3(set, set)] i32);
+
+#[pyclass]
+struct MultipleName(#[pyo3(name = "foo", name = "bar")] i32);
+
+#[pyclass]
+struct NameWithoutGetSet(#[pyo3(name = "value")] i32);
 
 fn main() {}

--- a/tests/ui/invalid_property_args.stderr
+++ b/tests/ui/invalid_property_args.stderr
@@ -16,8 +16,32 @@ error: setter function can have at most two arguments ([pyo3::Python,] and value
 24 |     fn setter_with_too_many_args(&mut self, py: Python, foo: u32, bar: u32) {}
    |                                                                        ^^^
 
-error: `#[pyo3(get, set)]` is not supported on tuple struct fields
-  --> $DIR/invalid_property_args.rs:28:44
+error: `get` and `set` with tuple struct fields require `name`
+  --> $DIR/invalid_property_args.rs:28:50
    |
-28 | struct TupleGetterSetter(#[pyo3(get, set)] i32);
-   |                                            ^^^
+28 | struct TupleGetterSetterNoName(#[pyo3(get, set)] i32);
+   |                                                  ^^^
+
+error: `get` may only be specified once
+  --> $DIR/invalid_property_args.rs:31:32
+   |
+31 | struct MultipleGet(#[pyo3(get, get)] i32);
+   |                                ^^^
+
+error: `set` may only be specified once
+  --> $DIR/invalid_property_args.rs:34:32
+   |
+34 | struct MultipleSet(#[pyo3(set, set)] i32);
+   |                                ^^^
+
+error: `name` may only be specified once
+  --> $DIR/invalid_property_args.rs:37:49
+   |
+37 | struct MultipleName(#[pyo3(name = "foo", name = "bar")] i32);
+   |                                                 ^^^^^
+
+error: `name` is useless without `get` or `set`
+  --> $DIR/invalid_property_args.rs:40:40
+   |
+40 | struct NameWithoutGetSet(#[pyo3(name = "value")] i32);
+   |                                        ^^^^^^^


### PR DESCRIPTION
For #1601

This implements `#[pyo3(get, set, name = "...")]` to set the python name of the exposed property.

This enables `#[pyo3(get, set)]` for tuple `#[pyclass]`, by making `name` required in that case. Closes #1593 

