### PR TITLE
Optimize f(*args, **kwds) function argument "parsing"

### DIFF
--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -417,7 +417,7 @@ pub fn impl_wrap_pyfunction(
             method::FnType::FnStatic
         },
         name: &func.sig.ident,
-        convention: CallingConvention::from_args(&arguments),
+        convention: CallingConvention::from_args(&arguments, &signature.arguments),
         python_name,
         attrs: signature.arguments,
         args: arguments,


### PR DESCRIPTION
by using the VARARGS convention and not parsing anything.

Based on #1660.

Benchmark result:

before
```
---------------------------------------------------------------------------------------------- benchmark: 8 tests ---------------------------------------------------------------------------------------------
Name (time in ns)                Min                    Max                  Mean              StdDev                Median                IQR             Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_args_and_kwargs_py     541.0999 (5.50)      1,644.1001 (6.12)       584.9937 (5.36)      36.0946 (4.95)       588.0007 (5.35)     23.1012 (3.61)     5401;4727    1,709.4200 (0.19)     150603          10
test_args_and_kwargs        919.9866 (9.35)      7,811.0024 (29.07)    1,011.1348 (9.26)     121.0042 (16.61)    1,009.9902 (9.20)     58.9935 (9.22)     4374;4426      988.9878 (0.11)     130532           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
after
```
---------------------------------------------------------------------------------------------- benchmark: 8 tests ---------------------------------------------------------------------------------------------
Name (time in ns)                Min                    Max                  Mean              StdDev                Median                IQR             Outliers  OPS (Kops/s)            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_args_and_kwargs        258.0004 (2.61)     11,361.5504 (43.15)      283.3001 (2.62)      69.7288 (9.09)       282.9998 (2.64)     15.4498 (2.38)     1571;9116    3,529.8262 (0.38)     176026          20
test_args_and_kwargs_py     536.9991 (5.44)     15,384.3997 (58.42)      590.1359 (5.46)      93.3103 (12.16)      589.0994 (5.49)     26.9996 (4.15)     6864;7489    1,694.5248 (0.18)     148810          10
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```