### PR TITLE
benches: add benchmarks for container creation

### DIFF
--- a/benches/bench_dict.rs
+++ b/benches/bench_dict.rs
@@ -18,6 +18,13 @@ fn iter_dict(b: &mut Bencher) {
     });
 }
 
+fn dict_new(b: &mut Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    const LEN: usize = 50_000;
+    b.iter(|| (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py));
+}
+
 fn dict_get_item(b: &mut Bencher) {
     let gil = Python::acquire_gil();
     let py = gil.python();
@@ -58,6 +65,7 @@ fn extract_hashbrown_map(b: &mut Bencher) {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("iter_dict", iter_dict);
+    c.bench_function("dict_new", dict_new);
     c.bench_function("dict_get_item", dict_get_item);
     c.bench_function("extract_hashmap", extract_hashmap);
     c.bench_function("extract_btreemap", extract_btreemap);

--- a/benches/bench_list.rs
+++ b/benches/bench_list.rs
@@ -17,6 +17,13 @@ fn iter_list(b: &mut Bencher) {
     });
 }
 
+fn list_new(b: &mut Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    const LEN: usize = 50_000;
+    b.iter(|| PyList::new(py, 0..LEN));
+}
+
 fn list_get_item(b: &mut Bencher) {
     let gil = Python::acquire_gil();
     let py = gil.python();
@@ -32,6 +39,7 @@ fn list_get_item(b: &mut Bencher) {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("iter_list", iter_list);
+    c.bench_function("list_new", list_new);
     c.bench_function("list_get_item", list_get_item);
 }
 


### PR DESCRIPTION
Just wrote these while testing #1664 

I couldn't find any cheap wins with `PyDict` in the same way, however I kept the benchmark anyway in case we can find future speedups.