### PR TITLE
Add error message for trying to store references in pyclasses

### DIFF
--- a/pyo3-macros-backend/src/diagnostics.rs
+++ b/pyo3-macros-backend/src/diagnostics.rs
@@ -1,0 +1,72 @@
+use quote::ToTokens;
+use syn::spanned::Spanned;
+
+/// Returns a `syn::Error` if the struct has any generic parameters,
+/// or its fields have any non-static lifetime parameters
+pub fn check_pyclass_generics_error(class: &syn::ItemStruct) -> Result<(), syn::Error> {
+    if !class.generics.params.is_empty() {
+        let mut base_error = syn::Error::new(
+            class.generics.params.span(),
+            "#[pyclass] cannot have generic parameters.",
+        );
+        if let Err(another) = check_pyclass_field_lifetimes(class) {
+            base_error.combine(another);
+        }
+
+        Err(base_error)
+    } else {
+        check_pyclass_field_lifetimes(class)
+    }
+}
+
+/// Returns a `syn::Error` if any field has any non-static lifetime parameters.
+fn check_pyclass_field_lifetimes(class: &syn::ItemStruct) -> Result<(), syn::Error> {
+    for field in &class.fields {
+        let lifetime = if let syn::Type::Reference(typeref) = &(field.ty) {
+            typeref
+                .lifetime
+                .as_ref()
+                .map(|lifetime| lifetime.ident.to_string())
+        } else {
+            None
+        };
+
+        let (type_name, span) = if let syn::Type::Reference(typeref) = &(field.ty) {
+            if let syn::Type::Path(typepath) = &*(typeref.elem) {
+                let mut s = typepath.path.segments.to_token_stream().to_string();
+                s.retain(|c| !c.is_whitespace());
+                (Some(s), Some(typepath.span()))
+            } else {
+                (None, None)
+            }
+        } else {
+            (None, None)
+        };
+
+        if let (Some(lifetime), Some(type_name)) = (lifetime, type_name) {
+            // a naive attempt to detect python types
+            if lifetime != "static" && (type_name.starts_with("Py") || type_name.starts_with("pyo3::types::Py"))
+                // avoid making this message for something already wrapped in `Py<...>` for some reason
+                && !(type_name.starts_with("Py<") || type_name.starts_with("pyo3::types::Py<"))
+            {
+                // at this point is is known that the pyclass contains a non-static reference,
+                // which is always a compile error because this is never allowed,
+                // therefore it is fine to error ourselves
+                let message = format!(
+                    "#[pyclass] cannot contain borrowed references to other Python objects. 
+
+The lifetime `'{lifetime}` represents the scope during which the GIL is held, therefore
+the reference `&'{lifetime} {type_name}` is only valid until the GIL is released.
+Consider storing an owned reference using the `Py<...>` container: `Py<{type_name}>`.
+
+See https://pyo3.rs/main/doc/pyo3/struct.Py.html for more information.",
+                    lifetime = lifetime,
+                    type_name = type_name,
+                );
+                let e = syn::Error::new(span.unwrap(), message);
+                return Err(e);
+            };
+        }
+    }
+    Ok(())
+}

--- a/pyo3-macros-backend/src/diagnostics.rs
+++ b/pyo3-macros-backend/src/diagnostics.rs
@@ -63,7 +63,7 @@ See https://pyo3.rs/main/doc/pyo3/struct.Py.html for more information.",
                     lifetime = lifetime,
                     type_name = type_name,
                 );
-                let e = syn::Error::new(field.span(), message);
+                let e = syn::Error::new(field.ty.span(), message);
                 return Err(e);
             };
         }

--- a/pyo3-macros-backend/src/diagnostics.rs
+++ b/pyo3-macros-backend/src/diagnostics.rs
@@ -6,8 +6,8 @@ use syn::spanned::Spanned;
 pub fn check_pyclass_generics_error(class: &syn::ItemStruct) -> Result<(), syn::Error> {
     if !class.generics.params.is_empty() {
         let mut base_error = syn::Error::new(
-            class.generics.params.span(),
-            "#[pyclass] cannot have generic parameters.",
+            class.generics.span(),
+            "#[pyclass] cannot have generic parameters",
         );
         if let Err(another) = check_pyclass_field_lifetimes(class) {
             base_error.combine(another);
@@ -31,16 +31,16 @@ fn check_pyclass_field_lifetimes(class: &syn::ItemStruct) -> Result<(), syn::Err
             None
         };
 
-        let (type_name, span) = if let syn::Type::Reference(typeref) = &(field.ty) {
+        let type_name = if let syn::Type::Reference(typeref) = &(field.ty) {
             if let syn::Type::Path(typepath) = &*(typeref.elem) {
                 let mut s = typepath.path.segments.to_token_stream().to_string();
                 s.retain(|c| !c.is_whitespace());
-                (Some(s), Some(typepath.span()))
+                Some(s)
             } else {
-                (None, None)
+                None
             }
         } else {
-            (None, None)
+            None
         };
 
         if let (Some(lifetime), Some(type_name)) = (lifetime, type_name) {
@@ -63,7 +63,7 @@ See https://pyo3.rs/main/doc/pyo3/struct.Py.html for more information.",
                     lifetime = lifetime,
                     type_name = type_name,
                 );
-                let e = syn::Error::new(span.unwrap(), message);
+                let e = syn::Error::new(field.span(), message);
                 return Err(e);
             };
         }

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -11,6 +11,7 @@ mod utils;
 mod attributes;
 mod defs;
 mod deprecations;
+mod diagnostics;
 mod from_pyobject;
 mod konst;
 mod method;

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -232,10 +232,8 @@ pub fn build_py_class(
             .map(|attr| (get_class_python_name(&class.ident, args), attr)),
     )?;
 
-    ensure_spanned!(
-        class.generics.params.is_empty(),
-        class.generics.span() => "#[pyclass] cannot have generic parameters"
-    );
+    // Reject the pyclass if it contains a generic parameter
+    crate::diagnostics::check_pyclass_generics_error(class)?;
 
     let field_options = match &mut class.fields {
         syn::Fields::Named(fields) => fields


### PR DESCRIPTION

People keep getting this wrong, so I figured an error for it is appropriate. Also note that this error can never reject a valid pyclass.

```rust
#[pyclass]
pub struct Foo<'a> {
    field: &'a PyAny,
}
```
creates the following error:

![image](https://user-images.githubusercontent.com/59372212/122625109-b3d10a00-d0a3-11eb-9992-992efd961a40.png)

```rust
#[pyclass]
pub struct Bar {
    field: &'a PyAny,
}
```
creates the following error:

![image](https://user-images.githubusercontent.com/59372212/122625135-d4995f80-d0a3-11eb-819e-15e9e7cec38a.png)

