### PR TITLE
Update class.md - add example of `new` returning a `PyResult`

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -169,7 +169,7 @@ impl MyClass {
 }
 ```
 
-Alternatively, if your `new` method might throw errors you can return `PyResult<Self>`.
+Alternatively, if your `new` method may fail you can return `PyResult<Self>`.
 ```rust
 # use pyo3::prelude::*;
 #[pyclass]

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -169,6 +169,23 @@ impl MyClass {
 }
 ```
 
+Alternatively, if your `new` method might throw errors you can return `PyResult<Self>`.
+```rust
+# use pyo3::prelude::*;
+#[pyclass]
+struct MyClass {
+    num: i32,
+}
+
+#[pymethods]
+impl MyClass {
+    #[new]
+    fn new(num: i32) -> PyResult<Self> {
+        Ok(MyClass { num })
+    }
+}
+```
+
 If no method marked with `#[new]` is declared, object instances can only be
 created from Rust, but not from Python.
 


### PR DESCRIPTION
It took me some time to realize how to return error in the new class API. I think it's better to have explicit documentation to save time for others :)