### PR TITLE
Make the `Py_tracefunc` parameters optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Deprecate `#[text_signature = "..."]` attributes in favor of `#[pyo3(text_signature = "...")]`. [#1658](https://github.com/PyO3/pyo3/pull/1658)
 - Use `METH_FASTCALL` argument passing convention, when possible, to improve `#[pyfunction]` and method performance.
   [#1619](https://github.com/PyO3/pyo3/pull/1619), [#1660](https://github.com/PyO3/pyo3/pull/1660)
+- Make the `Py_tracefunc` parameter of the `PyEval_SetProfile`/`PyEval_SetTrace` functions optional. [#1692](https://github.com/PyO3/pyo3/pull/1692)
 
 ### Removed
 

--- a/src/ffi/cpython/ceval.rs
+++ b/src/ffi/cpython/ceval.rs
@@ -8,6 +8,6 @@ extern "C" {
         exc: c_int,
     ) -> *mut PyObject;
     pub fn _PyEval_RequestCodeExtraIndex(func: freefunc) -> c_int;
-    pub fn PyEval_SetProfile(trace_func: Py_tracefunc, arg1: *mut PyObject);
-    pub fn PyEval_SetTrace(trace_func: Py_tracefunc, arg1: *mut PyObject);
+    pub fn PyEval_SetProfile(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);
+    pub fn PyEval_SetTrace(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);
 }


### PR DESCRIPTION
The `PyEval_SetProfile`/`SetTrace` methods [support receiving `NULL`](https://docs.python.org/3/c-api/init.html#c.PyEval_SetProfile) for the `Py_tracefunc` parameter, in order to disable profiling/tracing. However, the only way to safely pass `NULL` as a function pointer in Rust is by wrapping it in an `Option<>`.

This PR updates the respective functions to make it easier for developers to disable profiling/tracing hooks, without having to resort to `transmute` or `zeroed`.