### PR TITLE
automagically update pyo3 version in toml examples

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,9 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies.pyo3]
-//! version = "0.13.2"
+// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
+#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("version = \"", env!("CARGO_PKG_VERSION"),  "\"")))]
+#![cfg_attr(not(docsrs), doc = "version = \"*\"")]
 //! features = ["extension-module"]
 //! ```
 //!
@@ -202,7 +204,9 @@
 //!
 //! ```toml
 //! [dependencies.pyo3]
-//! version = "0.13.2"
+// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
+#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("version = \"", env!("CARGO_PKG_VERSION"),  "\"")))]
+#![cfg_attr(not(docsrs), doc = "version = \"*\"")]
 //! # this is necessary to automatically initialize the Python interpreter
 //! features = ["auto-initialize"]
 //! ```

--- a/src/num_bigint.rs
+++ b/src/num_bigint.rs
@@ -17,9 +17,13 @@
 //!
 //! ```toml
 //! [dependencies]
-//! # change * to the latest versions
 //! num-bigint = "*"
-//! pyo3 = { version = "*", features = ["num-bigint"] }
+// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
+#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"num-bigint\"] }")))]
+#![cfg_attr(
+    not(docsrs),
+    doc = "pyo3 = { version = \"*\", features = [\"num-bigint\"] }"
+)]
 //! ```
 //!
 //! Note that you must use compatible versions of num-bigint and PyO3.

--- a/src/num_complex.rs
+++ b/src/num_complex.rs
@@ -14,7 +14,12 @@
 //! [dependencies]
 //! # change * to the latest versions
 //! num-complex = "*"
-//! pyo3 = { version = "*", features = ["num-complex"] }
+// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
+#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"num-complex\"] }")))]
+#![cfg_attr(
+    not(docsrs),
+    doc = "pyo3 = { version = \"*\", features = [\"num-complex\"] }"
+)]
 //! ```
 //!
 //! Note that you must use compatible versions of num-complex and PyO3.


### PR DESCRIPTION
I figured out how to automagically update the pyo3 version used in doc examples: see https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
