### PR TITLE
Use explicit lifetimes in proc-macro expansion

### DIFF
--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -263,7 +263,7 @@ fn impl_arg_param(
         let (target_ty, borrow_tmp) = if arg.optional.is_some() {
             // Get Option<&T> from Option<PyRef<T>>
             (
-                quote_arg_span! { Option<<#tref as pyo3::derive_utils::ExtractExt>::Target> },
+                quote_arg_span! { Option<<#tref as pyo3::derive_utils::ExtractExt<'_>>::Target> },
                 if mut_.is_some() {
                     quote_arg_span! { _tmp.as_deref_mut() }
                 } else {
@@ -273,7 +273,7 @@ fn impl_arg_param(
         } else {
             // Get &T from PyRef<T>
             (
-                quote_arg_span! { <#tref as pyo3::derive_utils::ExtractExt>::Target },
+                quote_arg_span! { <#tref as pyo3::derive_utils::ExtractExt<'_>>::Target },
                 quote_arg_span! { &#mut_ *_tmp },
             )
         };

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -382,7 +382,7 @@ fn impl_class(
             quote! {
                 impl pyo3::class::impl_::PyClassWithFreeList for #cls {
                     #[inline]
-                    fn get_free_list(_py: pyo3::Python) -> &mut pyo3::impl_::freelist::FreeList<*mut pyo3::ffi::PyObject> {
+                    fn get_free_list(_py: pyo3::Python<'_>) -> &mut pyo3::impl_::freelist::FreeList<*mut pyo3::ffi::PyObject> {
                         static mut FREELIST: *mut pyo3::impl_::freelist::FreeList<*mut pyo3::ffi::PyObject> = 0 as *mut _;
                         unsafe {
                             if FREELIST.is_null() {
@@ -503,7 +503,7 @@ fn impl_class(
             const MODULE: Option<&'static str> = #module;
 
             #[inline]
-            fn type_object_raw(py: pyo3::Python) -> *mut pyo3::ffi::PyTypeObject {
+            fn type_object_raw(py: pyo3::Python<'_>) -> *mut pyo3::ffi::PyTypeObject {
                 #deprecations
 
                 use pyo3::type_object::LazyStaticType;


### PR DESCRIPTION
Otherwise this triggers `#[deny(rust_2018_idioms)]` in projects using it.