### PR TITLE
release: 0.14.0

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -17,20 +17,22 @@ protocol traits (e.g., `PyIterProtocol`) for supporting object protocols (i.e., 
 Since implementing `PyClass` requires lots of boilerplate, we have a proc-macro `#[pyclass]`.
 
 To summarize, there are six main parts to the PyO3 codebase.
+
 1. [Low-level bindings of Python/C API.](#1-low-level-bindings-of-python-capi)
-    - [`src/ffi`]
+   - [`src/ffi`]
 2. [Bindings to Python objects.](#2-bindings-to-python-objects)
-    - [`src/instance.rs`] and [`src/types`]
+   - [`src/instance.rs`] and [`src/types`]
 3. [`PyClass` and related functionalities.](#3-pyclass-and-related-functionalities)
-    - [`src/pycell.rs`], [`src/pyclass.rs`], and more
+   - [`src/pycell.rs`], [`src/pyclass.rs`], and more
 4. [Protocol methods like `__getitem__`.](#4-protocol-methods)
-    - [`src/class`]
+   - [`src/class`]
 5. [Procedural macros to simplify usage for users.](#5-procedural-macros-to-simplify-usage-for-users)
-    - [`src/derive_utils.rs`], [`pyo3-macros`] and [`pyo3-macros-backend`]
+   - [`src/derive_utils.rs`], [`pyo3-macros`] and [`pyo3-macros-backend`]
 6. [`build.rs`](#6-buildrs)
-    - [`build.rs`](https://github.com/PyO3/pyo3/tree/master/build.rs)
+   - [`build.rs`](https://github.com/PyO3/pyo3/tree/master/build.rs)
 
 ## 1. Low-level bindings of Python/C API
+
 [`src/ffi`] contains wrappers of [Python/C API].
 
 We aim to provide straight-forward Rust wrappers resembling the file structure of
@@ -44,17 +46,19 @@ In the [`src/ffi`] module, there is lots of conditional compilation such as `#[c
 `#[cfg(Py_37)]`, and `#[cfg(PyPy)]`.
 `Py_LIMITED_API` corresponds to `#define Py_LIMITED_API` macro in Python/C API.
 With `Py_LIMITED_API`, we can build a Python-version-agnostic binary called an
-[abi3 wheel](https://pyo3.rs/v0.13.2/building_and_distribution.html#py_limited_apiabi3).
+[abi3 wheel](https://pyo3.rs/main/building_and_distribution.html#py_limited_apiabi3).
 `Py_37` means that the API is available from Python >= 3.7.
 There are also `Py_38`, `Py_39`, and so on.
 `PyPy` means that the API definition is for PyPy.
 Those flags are set in [`build.rs`](#6-buildrs).
 
 ## 2. Bindings to Python objects
+
 [`src/types`] contains bindings to [built-in types](https://docs.python.org/3/library/stdtypes.html)
 of Python, such as `dict` and `list`.
 For historical reasons, Python's `object` is called `PyAny` in PyO3 and located in [`src/types/any.rs`].
 Currently, `PyAny` is a straightforward wrapper of `ffi::PyObject`, defined as:
+
 ```rust
 #[repr(transparent)]
 pub struct PyAny(UnsafeCell<ffi::PyObject>);
@@ -62,6 +66,7 @@ pub struct PyAny(UnsafeCell<ffi::PyObject>);
 
 All built-in types are defined as a C struct.
 For example, `dict` is defined as:
+
 ```c
 typedef struct {
     /* Base object */
@@ -77,6 +82,7 @@ typedef struct {
 
 However, we cannot access such a specific data structure with `#[cfg(Py_LIMITED_API)]` set.
 Thus, all builtin objects are implemented as opaque types by wrapping `PyAny`, e.g.,:
+
 ```rust
 #[repr(transparent)]
 pub struct PyDict(PyAny);
@@ -92,12 +98,14 @@ Since we need lots of boilerplate for implementing common traits for these types
 [`src/types/mod.rs`].
 
 ## 3. `PyClass` and related functionalities
+
 [`src/pycell.rs`], [`src/pyclass.rs`], and [`src/type_object.rs`] contain types and
 traits to make `#[pyclass]` work.
 Also, [`src/pyclass_init.rs`] and [`src/pyclass_slots.rs`] have related functionalities.
 
 To realize object-oriented programming in C, all Python objects must have the following two fields
 at the beginning.
+
 ```rust
 #[repr(C)]
 pub struct PyObject {
@@ -106,9 +114,11 @@ pub struct PyObject {
     ...
 }
 ```
+
 Thanks to this guarantee, casting `*mut A` to `*mut PyObject` is valid if `A` is a Python object.
 
 To ensure this guarantee, we have a wrapper struct `PyCell<T>` in [`src/pycell.rs`] which is roughly:
+
 ```rust
 #[repr(C)]
 pub struct PyCell<T: PyClass> {
@@ -116,6 +126,7 @@ pub struct PyCell<T: PyClass> {
     inner: T,
 }
 ```
+
 Thus, when copying a Rust struct to a Python object, we first allocate `PyCell` on the Python heap and then
 move `T` into it.
 Also, `PyCell` provides [RefCell](https://doc.rust-lang.org/std/cell/struct.RefCell.html)-like methods
@@ -131,6 +142,7 @@ For example, you can see `type({})` shows `dict` and `type(type({}))` shows `typ
 `T: PyTypeObject` implies that `T` has a corresponding type object.
 
 ## 4. Protocol methods
+
 Python has some built-in special methods called dunder, such as `__iter__`.
 They are called [abstract objects layer](https://docs.python.org/3/c-api/abstract.html) in
 Python/C API.
@@ -147,6 +159,7 @@ Also, [`src/class/methods.rs`] has utilities for `#[pyfunction]` and [`src/class
 some internal tricks for making `#[pyproto]` flexible.
 
 ## 5. Procedural macros to simplify usage for users.
+
 [`pyo3-macros`] provides six proc-macro APIs: `pymodule`, `pyproto`, `pyfunction`, `pyclass`,
 `pymethods`, and `#[derive(FromPyObject)]`.
 [`pyo3-macros-backend`] has the actual implementations of these APIs.
@@ -154,33 +167,42 @@ some internal tricks for making `#[pyproto]` flexible.
 such as parsing function arguments.
 
 ## 6. `build.rs`
+
 PyO3's [`build.rs`](https://github.com/PyO3/pyo3/tree/master/build.rs) is relatively long
 (about 900 lines) to support multiple architectures, interpreters, and usages.
 Below is a non-exhaustive list of its functionality:
+
 - Cross-compiling support.
   - If `TARGET` architecture and `HOST` architecture differ, we find cross compile information
-  from environment variables (`PYO3_CROSS_LIB_DIR` and `PYO3_CROSS_PYTHON_VERSION`) or system files.
+    from environment variables (`PYO3_CROSS_LIB_DIR` and `PYO3_CROSS_PYTHON_VERSION`) or system files.
 - Find the interpreter for build and detect the Python version.
   - We have to set some version flags like `Py_37`.
   - If the interpreter is PyPy, we set `PyPy`.
   - If `PYO3_NO_PYTHON` environment variable is set then the interpreter detection is bypassed
-  entirely and only abi3 extensions can be built.
+    entirely and only abi3 extensions can be built.
 - Check if we are building a Python extension.
   - If we are building an extension (e.g., Python library installable by `pip`),
-  we don't link `libpython`.
-  Currently we use the `extension-module` feature for this purpose. This may change in the future.
-  See [#1123](https://github.com/PyO3/pyo3/pull/1123).
+    we don't link `libpython`.
+    Currently we use the `extension-module` feature for this purpose. This may change in the future.
+    See [#1123](https://github.com/PyO3/pyo3/pull/1123).
 
 <!-- External Links -->
-[Python/C API]: https://docs.python.org/3/c-api/
+
+[python/c api]: https://docs.python.org/3/c-api/
+
 <!-- Crates -->
+
 [`pyo3-macros`]: https://github.com/PyO3/pyo3/tree/master/pyo3-macros
 [`pyo3-macros-backend`]: https://github.com/PyO3/pyo3/tree/master/pyo3-macros-backend
+
 <!-- Directories -->
+
 [`src/class`]: https://github.com/PyO3/pyo3/tree/master/src/class
 [`src/ffi`]: https://github.com/PyO3/pyo3/tree/master/src/ffi
 [`src/types`]: https://github.com/PyO3/pyo3/tree/master/src/types
+
 <!-- Files -->
+
 [`src/derive_utils.rs`]: https://github.com/PyO3/pyo3/tree/master/src/derive_utils.rs
 [`src/instance.rs`]: https://github.com/PyO3/pyo3/tree/master/src/instance.rs
 [`src/pycell.rs`]: https://github.com/PyO3/pyo3/tree/master/src/pycell.rs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/main/migration.h
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.0] - 2021-07-03
 
 ### Packaging
 
@@ -14,38 +14,38 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update `num-complex` optional dependency to 0.4. [#1482](https://github.com/PyO3/pyo3/pull/1482)
 - Extend `hashbrown` optional dependency supported versions to include 0.11. [#1496](https://github.com/PyO3/pyo3/pull/1496)
 - Support PyPy 3.7. [#1538](https://github.com/PyO3/pyo3/pull/1538)
-- Try harder to filter sysconfigdata candidates on arch.config
 
 ### Added
 
-- Add conversions for `[T; N]` for all `N` on Rust 1.51 and up. [#1128](https://github.com/PyO3/pyo3/pull/1128)
-- Add conversions between `OsStr`/`OsString`/`Path`/`PathBuf` and Python strings. [#1379](https://github.com/PyO3/pyo3/pull/1379)
-- Add `#[pyo3(from_py_with = "...")]` attribute for function arguments and struct fields to override the default from-Python conversion. [#1411](https://github.com/PyO3/pyo3/pull/1411)
+- Extend conversions for `[T; N]` to all `N` using const generics (on Rust 1.51 and up). [#1128](https://github.com/PyO3/pyo3/pull/1128)
+- Add conversions between `OsStr`/ `OsString` and Python strings. [#1379](https://github.com/PyO3/pyo3/pull/1379)
+- Add conversions between `Path`/ `PathBuf` and Python strings (and `pathlib.Path` objects). [#1379](https://github.com/PyO3/pyo3/pull/1379) [#1654](https://github.com/PyO3/pyo3/pull/1654)
+- Add a new set of `#[pyo3(...)]` attributes to control various PyO3 macro functionality:
+  - `#[pyo3(from_py_with = "...")]` function arguments and struct fields to override the default from-Python conversion. [#1411](https://github.com/PyO3/pyo3/pull/1411)
+  - `#[pyo3(name = "...")]` for setting Python names. [#1567](https://github.com/PyO3/pyo3/pull/1567)
+  - `#[pyo3(text_signature = "...")]` for setting text signature. [#1658](https://github.com/PyO3/pyo3/pull/1658)
 - Add FFI definition `PyCFunction_CheckExact` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - Add FFI definition `Py_IS_TYPE`. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 - Add FFI definition `_Py_InitializeMain`. [#1473](https://github.com/PyO3/pyo3/pull/1473)
 - Add FFI definitions from `cpython/import.h`.[#1475](https://github.com/PyO3/pyo3/pull/1475)
 - Add tuple and unit struct support for `#[pyclass]` macro. [#1504](https://github.com/PyO3/pyo3/pull/1504)
-- Add `#[pyo3(name = "...")]` syntax for setting Python names. [#1567](https://github.com/PyO3/pyo3/pull/1567)
 - Add FFI definition `PyDateTime_TimeZone_UTC`. [#1572](https://github.com/PyO3/pyo3/pull/1572)
 - Add support for `#[pyclass(extends=Exception)]`. [#1591](https://github.com/PyO3/pyo3/pull/1591)
-- Add support for extracting `PathBuf` from `pathlib.Path`. [#1654](https://github.com/PyO3/pyo3/pull/1654)
-- Add `#[pyo3(text_signature = "...")]` syntax for setting text signature. [#1658](https://github.com/PyO3/pyo3/pull/1658)
-- Add support for setting and retrieving exception cause. [#1679](https://github.com/PyO3/pyo3/pull/1679)
-- Add FFI definitions from `cpython/pystate.h`.[#1687](https://github.com/PyO3/pyo3/pull/1687/)
-- Add `wrap_pyfunction` macro to prelude. [#1695](https://github.com/PyO3/pyo3/pull/1695)
+- Add `PyErr::cause` and `PyErr::set_cause`. [#1679](https://github.com/PyO3/pyo3/pull/1679)
+- Add FFI definitions from `cpython/pystate.h`. [#1687](https://github.com/PyO3/pyo3/pull/1687/)
+- Add `wrap_pyfunction!` macro to `pyo3::prelude`. [#1695](https://github.com/PyO3/pyo3/pull/1695)
 
 ### Changed
 
-- Allow only one `#[pymethods]` block per `#[pyclass]` by default, to simplify the proc macro implementations. Add `multiple-pymethods` feature to opt-in to the more complex full behavior. [#1457](https://github.com/PyO3/pyo3/pull/1457)
-- Change `PyTimeAcces::get_fold()` to return a `bool` instead of a `u8`. [#1397](https://github.com/PyO3/pyo3/pull/1397)
-- Deprecate FFI definition `PyCFunction_Call` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
-- Deprecate FFI definitions `PyModule_GetFilename`. [#1425](https://github.com/PyO3/pyo3/pull/1425)
+- Allow only one `#[pymethods]` block per `#[pyclass]` by default, to remove the dependency on `inventory`. Add a `multiple-pymethods` feature to opt-in the original behavior and dependency on `inventory`. [#1457](https://github.com/PyO3/pyo3/pull/1457)
+- Change `PyTimeAccess::get_fold` to return a `bool` instead of a `u8`. [#1397](https://github.com/PyO3/pyo3/pull/1397)
+- Deprecate FFI definition `PyCFunction_Call` for Python 3.9 and up. [#1425](https://github.com/PyO3/pyo3/pull/1425)
+- Deprecate FFI definition `PyModule_GetFilename`. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - The `auto-initialize` feature is no longer enabled by default. [#1443](https://github.com/PyO3/pyo3/pull/1443)
 - Change `PyCFunction::new()` and `PyCFunction::new_with_keywords()` to take `&'static str` arguments rather than implicitly copying (and leaking) them. [#1450](https://github.com/PyO3/pyo3/pull/1450)
-- Deprecate `PyModule` methods `call`, `call0`, `call1` and `get`. [#1492](https://github.com/PyO3/pyo3/pull/1492)
+- Deprecate `PyModule::call`, `PyModule::call0`, `PyModule::call1` and `PyModule::get`. [#1492](https://github.com/PyO3/pyo3/pull/1492)
 - Add length information to `PyBufferError`s raised from `PyBuffer::copy_to_slice` and `PyBuffer::copy_from_slice`. [#1534](https://github.com/PyO3/pyo3/pull/1534)
-- Automatically provide `-undefined` and `dynamic_lookup` linker arguments on macOS with `extension-module` feature. [#1539](https://github.com/PyO3/pyo3/pull/1539)
+- Automatically set `-undefined` and `dynamic_lookup` linker arguments on macOS with the `extension-module` feature. [#1539](https://github.com/PyO3/pyo3/pull/1539)
 - Deprecate `#[pyproto]` methods which are easier to implement as `#[pymethods]`: [#1560](https://github.com/PyO3/pyo3/pull/1560)
   - `PyBasicProtocol::__bytes__` and `PyBasicProtocol::__format__`
   - `PyContextProtocol::__enter__` and `PyContextProtocol::__exit__`
@@ -53,56 +53,54 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `PyMappingProtocol::__reversed__`
   - `PyNumberProtocol::__complex__` and `PyNumberProtocol::__round__`
   - `PyAsyncProtocol::__aenter__` and `PyAsyncProtocol::__aexit__`
-- Deprecate `#[name = "..."]` attributes in favor of `#[pyo3(name = "...")]`. [#1567](https://github.com/PyO3/pyo3/pull/1567)
+- Deprecate several attributes in favor of the new `#[pyo3(...)]` options:
+  - `#[name = "..."]`, replaced by `#[pyo3(name = "...")]` [#1567](https://github.com/PyO3/pyo3/pull/1567)
+  - `#[pyfn(m, "name")]`, replaced by `#[pyfn(m)] #[pyo3(name = "...")]`. [#1610](https://github.com/PyO3/pyo3/pull/1610)
+  - `#[pymodule(name)]`, replaced by `#[pymodule] #[pyo3(name = "...")]` [#1650](https://github.com/PyO3/pyo3/pull/1650)
+  - `#[text_signature = "..."]`, replaced by `#[pyo3(text_signature = "...")]`. [#1658](https://github.com/PyO3/pyo3/pull/1658)
 - Reduce LLVM line counts to improve compilation times. [#1604](https://github.com/PyO3/pyo3/pull/1604)
-- Deprecate string-literal second argument to `#[pyfn(m, "name")]`. [#1610](https://github.com/PyO3/pyo3/pull/1610)
-- No longer call `PyEval_InitThreads()` in `#[pymodule]` init code. [#1630](https://github.com/PyO3/pyo3/pull/1630)
-- Deprecate `#[pymodule(name)]` option in favor of `#[pyo3(name = "...")]`. [#1650](https://github.com/PyO3/pyo3/pull/1650)
-- Deprecate `#[text_signature = "..."]` attributes in favor of `#[pyo3(text_signature = "...")]`. [#1658](https://github.com/PyO3/pyo3/pull/1658)
+- No longer call `PyEval_InitThreads` in `#[pymodule]` init code. [#1630](https://github.com/PyO3/pyo3/pull/1630)
 - Use `METH_FASTCALL` argument passing convention, when possible, to improve `#[pyfunction]` and method performance.
   [#1619](https://github.com/PyO3/pyo3/pull/1619), [#1660](https://github.com/PyO3/pyo3/pull/1660)
-- Make the `Py_tracefunc` parameter of the `PyEval_SetProfile`/`PyEval_SetTrace` functions optional. [#1692](https://github.com/PyO3/pyo3/pull/1692)
-- Make `ToPyObject` impl for `HashSet` accept non-default hashers. [#1702](https://github.com/PyO3/pyo3/pull/1702)
+- Filter sysconfigdata candidates by architecture when cross-compiling. [#1626](https://github.com/PyO3/pyo3/pull/1626)
 
 ### Removed
 
 - Remove deprecated exception names `BaseException` etc. [#1426](https://github.com/PyO3/pyo3/pull/1426)
-- Remove deprecated redundant methods `Python::is_instance`, `Python::is_subclass`, `Python::release`, `Python::xdecref`, and `Py::from_owned_ptr_or_panic`. [#1426](https://github.com/PyO3/pyo3/pull/1426)
-- Remove many ffi definitions which never existed in the Python C-API:
+- Remove deprecated methods `Python::is_instance`, `Python::is_subclass`, `Python::release`, `Python::xdecref`, and `Py::from_owned_ptr_or_panic`. [#1426](https://github.com/PyO3/pyo3/pull/1426)
+- Remove many FFI definitions which never existed in the Python C-API:
   - (previously deprecated) `PyGetSetDef_INIT`, `PyGetSetDef_DICT`, `PyCoro_Check`, `PyCoroWrapper_Check`, and `PyAsyncGen_Check` [#1426](https://github.com/PyO3/pyo3/pull/1426)
   - `PyMethodDef_INIT` [#1426](https://github.com/PyO3/pyo3/pull/1426)
   - `PyTypeObject_INIT` [#1429](https://github.com/PyO3/pyo3/pull/1429)
   - `PyObject_Check`, `PySuper_Check`, and `FreeFunc` [#1438](https://github.com/PyO3/pyo3/pull/1438)
+  - `PyModuleDef_INIT` [#1630](https://github.com/PyO3/pyo3/pull/1630)
 - Remove pyclass implementation details from `PyTypeInfo`:
   - `Type`, `DESCRIPTION`, and `FLAGS` [#1456](https://github.com/PyO3/pyo3/pull/1456)
   - `BaseType`, `BaseLayout`, `Layout`, `Initializer` [#1596](https://github.com/PyO3/pyo3/pull/1596)
-  - `PyModuleDef_INIT` [#1630](https://github.com/PyO3/pyo3/pull/1630)
-- Remove `__doc__` from module's `__all__`. [#1509](https://github.com/PyO3/pyo3/pull/1509)
 - Remove `PYO3_CROSS_INCLUDE_DIR` environment variable and the associated C header parsing functionality. [#1521](https://github.com/PyO3/pyo3/pull/1521)
 - Remove `raw_pycfunction!` macro. [#1619](https://github.com/PyO3/pyo3/pull/1619)
 - Remove `PyClassAlloc` trait. [#1657](https://github.com/PyO3/pyo3/pull/1657)
 - Remove `PyList::get_parked_item`. [#1664](https://github.com/PyO3/pyo3/pull/1664)
-- Remove the layout of the ffi/ffi::cpython module from the public api [#1687](https://github.com/PyO3/pyo3/pull/1687/). If you were importing things with `pyo3::ffi::<module>::<item>;`, please use `pyo3::ffi::<item>;` instead
-
-
 
 ### Fixed
 
 - Remove FFI definition `PyCFunction_ClearFreeList` for Python 3.9 and later. [#1425](https://github.com/PyO3/pyo3/pull/1425)
 - `PYO3_CROSS_LIB_DIR` enviroment variable no long required when compiling for x86-64 Python from macOS arm64 and reverse. [#1428](https://github.com/PyO3/pyo3/pull/1428)
-- Fix FFI definition `_PyEval_RequestCodeExtraIndex` which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)
+- Fix FFI definition `_PyEval_RequestCodeExtraIndex`, which took an argument of the wrong type. [#1429](https://github.com/PyO3/pyo3/pull/1429)
 - Fix FFI definition `PyIndex_Check` missing with the `abi3` feature. [#1436](https://github.com/PyO3/pyo3/pull/1436)
 - Fix incorrect `TypeError` raised when keyword-only argument passed along with a positional argument in `*args`. [#1440](https://github.com/PyO3/pyo3/pull/1440)
 - Fix inability to use a named lifetime for `&PyTuple` of `*args` in `#[pyfunction]`. [#1440](https://github.com/PyO3/pyo3/pull/1440)
-- Fix inability to add `#[text_signature]` to some `#[pyproto]` methods. [#1483](https://github.com/PyO3/pyo3/pull/1483)
-- Fix use of Python argument for #[pymethods] inside macro expansions. [#1505](https://github.com/PyO3/pyo3/pull/1505)
-- Always use cross-compiling configuration if any of the environment variables are set. [#1514](https://github.com/PyO3/pyo3/pull/1514)
+- Fix use of Python argument for `#[pymethods]` inside macro expansions. [#1505](https://github.com/PyO3/pyo3/pull/1505)
+- No longer include `__doc__` in `__all__` generated for `#[pymodule]`. [#1509](https://github.com/PyO3/pyo3/pull/1509)
+- Always use cross-compiling configuration if any of the `PYO3_CROSS` family of environment variables are set. [#1514](https://github.com/PyO3/pyo3/pull/1514)
 - Support `EnvironmentError`, `IOError`, and `WindowsError` on PyPy. [#1533](https://github.com/PyO3/pyo3/pull/1533)
 - Fix unneccessary rebuilds when cycling between `cargo check` and `cargo clippy` in a Python virtualenv. [#1557](https://github.com/PyO3/pyo3/pull/1557)
 - Fix segfault when dereferencing `ffi::PyDateTimeAPI` without the GIL. [#1563](https://github.com/PyO3/pyo3/pull/1563)
-- Fix memory leak when converting to u128 and i128. [#1638](https://github.com/PyO3/pyo3/pull/1638)
+- Fix memory leak in `FromPyObject` implementations for `u128` and `i128`. [#1638](https://github.com/PyO3/pyo3/pull/1638)
 - Fix `#[pyclass(extends=PyDict)]` leaking the dict contents on drop. [#1657](https://github.com/PyO3/pyo3/pull/1657)
 - Fix segfault when calling `PyList::get_item` with negative indices. [#1668](https://github.com/PyO3/pyo3/pull/1668)
+- Fix FFI definitions of `PyEval_SetProfile`/`PyEval_SetTrace` to take `Option<Py_tracefunc>` parameters. [#1692](https://github.com/PyO3/pyo3/pull/1692)
+- Fix `ToPyObject` impl for `HashSet` to accept non-default hashers. [#1702](https://github.com/PyO3/pyo3/pull/1702)
 
 ## [0.13.2] - 2021-02-12
 
@@ -849,7 +847,8 @@ Yanked
 
 - Initial release
 
-[unreleased]: https://github.com/pyo3/pyo3/compare/v0.13.2...HEAD
+[unreleased]: https://github.com/pyo3/pyo3/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/pyo3/pyo3/compare/v0.13.2...v0.14.0
 [0.13.2]: https://github.com/pyo3/pyo3/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/pyo3/pyo3/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/pyo3/pyo3/compare/v0.12.4...v0.13.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.13.2"
+version = "0.14.0"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -24,7 +24,7 @@ num-bigint = { version = "0.4", optional = true }
 num-complex = { version = "0.4", optional = true }
 # must stay at 0.1.x for Rust 1.41 compatibility
 paste = { version = "0.1.18", optional = true }
-pyo3-macros = { path = "pyo3-macros", version = "=0.13.2", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.14.0", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = ">= 0.9, < 0.12", optional = true }
 serde = {version = "1.0", optional = true}
@@ -40,7 +40,7 @@ pyo3 = { path = ".", default-features = false, features = ["macros", "auto-initi
 serde_json = "1.0.61"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "=0.14.0-alpha.0" }
+pyo3-build-config = { path = "pyo3-build-config", version = "0.14.0" }
 
 [features]
 default = ["macros"]

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 [Rust](http://www.rust-lang.org/) bindings for [Python](https://www.python.org/), including tools for creating native Python extension modules. Running and interacting with Python code from a Rust binary is also supported.
 
-* User Guide: [stable](https://pyo3.rs) | [main](https://pyo3.rs/main)
+- User Guide: [stable](https://pyo3.rs) | [main](https://pyo3.rs/main)
 
-* API Documentation: [stable](https://docs.rs/pyo3/) |  [main](https://pyo3.rs/main/doc)
+- API Documentation: [stable](https://docs.rs/pyo3/) | [main](https://pyo3.rs/main/doc)
 
 ## Usage
 
@@ -22,7 +22,7 @@ PyPy is also supported. Some minor features are unavailable on PyPy - please ref
 
 You can either write a native Python module in Rust, or use Python from a Rust binary.
 
-However, on some OSs, you need some additional packages. E.g. if you are on *Ubuntu 18.04*, please run
+However, on some OSs, you need some additional packages. E.g. if you are on _Ubuntu 18.04_, please run
 
 ```bash
 sudo apt install python3-dev python-dev
@@ -50,7 +50,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.13.2"
+version = "0.14.0"
 features = ["extension-module"]
 ```
 
@@ -85,7 +85,7 @@ use it to run Python code, add `pyo3` to your `Cargo.toml` like this:
 
 ```toml
 [dependencies.pyo3]
-version = "0.13.2"
+version = "0.14.0"
 features = ["auto-initialize"]
 ```
 
@@ -120,40 +120,42 @@ Our guide has [a section](https://pyo3.rs/main/python_from_rust.html) with lots 
 about this topic.
 
 ## Tools and libraries
- * [maturin](https://github.com/PyO3/maturin) _Zero configuration build tool for Rust-made Python extensions_.
- * [setuptools-rust](https://github.com/PyO3/setuptools-rust) _Setuptools plugin for Rust support_.
- * [pyo3-built](https://github.com/PyO3/pyo3-built) _Simple macro to expose metadata obtained with the [`built`](https://crates.io/crates/built) crate as a [`PyDict`](https://docs.rs/pyo3/0.12.0/pyo3/types/struct.PyDict.html)_
- * [rust-numpy](https://github.com/PyO3/rust-numpy) _Rust binding of NumPy C-API_
- * [dict-derive](https://github.com/gperinazzo/dict-derive) _Derive FromPyObject to automatically transform Python dicts into Rust structs_
- * [pyo3-log](https://github.com/vorner/pyo3-log) _Bridge from Rust to Python logging_
- * [pythonize](https://github.com/davidhewitt/pythonize) _Serde serializer for converting Rust objects to JSON-compatible Python objects_
- * [pyo3-asyncio](https://github.com/awestlake87/pyo3-asyncio) Utilities for working with Python's Asyncio library and async functions
+
+- [maturin](https://github.com/PyO3/maturin) _Zero configuration build tool for Rust-made Python extensions_.
+- [setuptools-rust](https://github.com/PyO3/setuptools-rust) _Setuptools plugin for Rust support_.
+- [pyo3-built](https://github.com/PyO3/pyo3-built) _Simple macro to expose metadata obtained with the [`built`](https://crates.io/crates/built) crate as a [`PyDict`](https://docs.rs/pyo3/0.12.0/pyo3/types/struct.PyDict.html)_
+- [rust-numpy](https://github.com/PyO3/rust-numpy) _Rust binding of NumPy C-API_
+- [dict-derive](https://github.com/gperinazzo/dict-derive) _Derive FromPyObject to automatically transform Python dicts into Rust structs_
+- [pyo3-log](https://github.com/vorner/pyo3-log) _Bridge from Rust to Python logging_
+- [pythonize](https://github.com/davidhewitt/pythonize) _Serde serializer for converting Rust objects to JSON-compatible Python objects_
+- [pyo3-asyncio](https://github.com/awestlake87/pyo3-asyncio) Utilities for working with Python's Asyncio library and async functions
 
 ## Examples
 
- * [hyperjson](https://github.com/mre/hyperjson) _A hyper-fast Python module for reading/writing JSON data using Rust's serde-json_
- * [html-py-ever](https://github.com/PyO3/setuptools-rust/tree/main/examples/html-py-ever) _Using [html5ever](https://github.com/servo/html5ever) through [kuchiki](https://github.com/kuchiki-rs/kuchiki) to speed up html parsing and css-selecting._
- * [point-process](https://github.com/ManifoldFR/point-process-rust/tree/master/pylib) _High level API for pointprocesses as a Python library_
- * [autopy](https://github.com/autopilot-rs/autopy) _A simple, cross-platform GUI automation library for Python and Rust._
-   * Contains an example of building wheels on TravisCI and appveyor using [cibuildwheel](https://github.com/joerick/cibuildwheel)
- * [orjson](https://github.com/ijl/orjson)  _Fast Python JSON library_
- * [inline-python](https://github.com/dronesforwork/inline-python) _Inline Python code directly in your Rust code_
- * [Rogue-Gym](https://github.com/kngwyu/rogue-gym) _Customizable rogue-like game for AI experiments_
-   * Contains an example of building wheels on Azure Pipelines
- * [fastuuid](https://github.com/thedrow/fastuuid/) _Python bindings to Rust's UUID library_
- * [wasmer-python](https://github.com/wasmerio/wasmer-python) _Python library to run WebAssembly binaries_
- * [mocpy](https://github.com/cds-astro/mocpy) _Astronomical Python library offering data structures for describing any arbitrary coverage regions on the unit sphere_
- * [tokenizers](https://github.com/huggingface/tokenizers/tree/master/bindings/python) _Python bindings to the Hugging Face tokenizers (NLP) written in Rust_
- * [pyre](https://github.com/Project-Dream-Weaver/Pyre) _Fast Python HTTP server written in Rust_
- * [jsonschema-rs](https://github.com/Stranger6667/jsonschema-rs/tree/master/bindings/python) _Fast JSON Schema validation library_
- * [css-inline](https://github.com/Stranger6667/css-inline/tree/master/bindings/python) _CSS inlining for Python implemented in Rust_
- * [cryptography](https://github.com/pyca/cryptography/tree/main/src/rust) _Python cryptography library with some functionality in Rust_
- * [polaroid](https://github.com/daggy1234/polaroid) _Hyper Fast and safe image manipulation library for Python written in Rust_
- * [ormsgpack](https://github.com/aviramha/ormsgpack) _Fast Python msgpack library_
+- [hyperjson](https://github.com/mre/hyperjson) _A hyper-fast Python module for reading/writing JSON data using Rust's serde-json_
+- [html-py-ever](https://github.com/PyO3/setuptools-rust/tree/main/examples/html-py-ever) _Using [html5ever](https://github.com/servo/html5ever) through [kuchiki](https://github.com/kuchiki-rs/kuchiki) to speed up html parsing and css-selecting._
+- [point-process](https://github.com/ManifoldFR/point-process-rust/tree/master/pylib) _High level API for pointprocesses as a Python library_
+- [autopy](https://github.com/autopilot-rs/autopy) _A simple, cross-platform GUI automation library for Python and Rust._
+  - Contains an example of building wheels on TravisCI and appveyor using [cibuildwheel](https://github.com/joerick/cibuildwheel)
+- [orjson](https://github.com/ijl/orjson) _Fast Python JSON library_
+- [inline-python](https://github.com/dronesforwork/inline-python) _Inline Python code directly in your Rust code_
+- [Rogue-Gym](https://github.com/kngwyu/rogue-gym) _Customizable rogue-like game for AI experiments_
+  - Contains an example of building wheels on Azure Pipelines
+- [fastuuid](https://github.com/thedrow/fastuuid/) _Python bindings to Rust's UUID library_
+- [wasmer-python](https://github.com/wasmerio/wasmer-python) _Python library to run WebAssembly binaries_
+- [mocpy](https://github.com/cds-astro/mocpy) _Astronomical Python library offering data structures for describing any arbitrary coverage regions on the unit sphere_
+- [tokenizers](https://github.com/huggingface/tokenizers/tree/master/bindings/python) _Python bindings to the Hugging Face tokenizers (NLP) written in Rust_
+- [pyre](https://github.com/Project-Dream-Weaver/Pyre) _Fast Python HTTP server written in Rust_
+- [jsonschema-rs](https://github.com/Stranger6667/jsonschema-rs/tree/master/bindings/python) _Fast JSON Schema validation library_
+- [css-inline](https://github.com/Stranger6667/css-inline/tree/master/bindings/python) _CSS inlining for Python implemented in Rust_
+- [cryptography](https://github.com/pyca/cryptography/tree/main/src/rust) _Python cryptography library with some functionality in Rust_
+- [polaroid](https://github.com/daggy1234/polaroid) _Hyper Fast and safe image manipulation library for Python written in Rust_
+- [ormsgpack](https://github.com/aviramha/ormsgpack) _Fast Python msgpack library_
 
 ## Contributing
 
 Everyone is welcomed to contribute to PyO3! There are many ways to support the project, such as:
+
 - help PyO3 users with issues on Github and Gitter
 - improve documentation
 - write features and bugfixes
@@ -163,7 +165,7 @@ Our [contributing notes](https://github.com/PyO3/pyo3/blob/main/Contributing.md)
 
 If you don't have time to contribute yourself but still wish to support the project's future success, some of our maintainers have Github sponsorship pages:
 
-* [davidhewitt](https://github.com/sponsors/davidhewitt)
+- [davidhewitt](https://github.com/sponsors/davidhewitt)
 
 ## License
 

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.14.0-alpha.0"
+version = "0.14.0"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.13.2"
+version = "0.14.0"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.14.0-alpha.0" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "0.14.0" }
 
 [dependencies.syn]
 version = "1"

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.13.2"
+version = "0.14.0"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.13.2" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.14.0" }


### PR DESCRIPTION
As per #1570, I think we are now ready to put the 0.14 release live.

This PR makes some tidy ups to the CHANGELOG and bumps the version numbers around the codebase.

Unless I hear a reason to do otherwise, I plan to put this release live a week from now on Saturday 3rd July. (I'll rebase on any fixes which might come before then.)

I'll comment a proposed set of release notes in this thread in the next day or two.