### PR TITLE
Added `size_hint` impls for `{PyDict,PyList,PySet,PyTuple}Iterator`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `serde` feature which provides implementations of `Serialize` and `Deserialize` for `Py<T>`. [#1366](https://github.com/PyO3/pyo3/pull/1366)
 - Add FFI definition `_PyCFunctionFastWithKeywords` on Python 3.7 and up. [#1384](https://github.com/PyO3/pyo3/pull/1384)
 - Add `PyDateTime::new_with_fold()` method. [#1398](https://github.com/PyO3/pyo3/pull/1398)
+- Add `size_hint` impls for `{PyDict,PyList,PySet,PyTuple}Iterator`s. [#1699](https://github.com/PyO3/pyo3/pull/1699)
 
 ### Changed
 

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -172,6 +172,15 @@ impl<'py> Iterator for PySetIterator<'py> {
             }
         }
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.set.len().unwrap_or_default();
+        (
+            len.saturating_sub(self.pos as usize),
+            Some(len.saturating_sub(self.pos as usize)),
+        )
+    }
 }
 
 impl<'a> std::iter::IntoIterator for &'a PySet {
@@ -502,6 +511,24 @@ mod test {
         // intoiterator iteration
         for el in set {
             assert_eq!(1i32, el.extract().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_set_iter_size_hint() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        let set = PySet::new(py, &[1]).unwrap();
+
+        let mut iter = set.iter();
+
+        if cfg!(Py_LIMITED_API) {
+            assert_eq!(iter.size_hint(), (0, None));
+        } else {
+            assert_eq!(iter.size_hint(), (1, Some(1)));
+            iter.next();
+            assert_eq!(iter.size_hint(), (0, Some(0)));
         }
     }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -131,6 +131,14 @@ impl<'a> Iterator for PyTupleIterator<'a> {
             None
         }
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.length.saturating_sub(self.index as usize),
+            Some(self.length.saturating_sub(self.index as usize)),
+        )
+    }
 }
 
 impl<'a> ExactSizeIterator for PyTupleIterator<'a> {
@@ -346,9 +354,17 @@ mod test {
         let tuple = <PyTuple as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
         assert_eq!(3, tuple.len());
         let mut iter = tuple.iter();
+
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+
         assert_eq!(1, iter.next().unwrap().extract().unwrap());
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+
         assert_eq!(2, iter.next().unwrap().extract().unwrap());
+        assert_eq!(iter.size_hint(), (1, Some(1)));
+
         assert_eq!(3, iter.next().unwrap().extract().unwrap());
+        assert_eq!(iter.size_hint(), (0, Some(0)));
     }
 
     #[test]


### PR DESCRIPTION
Hi!

I've added `size_hint` impls for the iterators which can support it (while defaulting to 0 on Python-related errors).
Should make `some_py_dict.iter().map(...).collect()` faster by avoiding allocations!