### PR TITLE
Make `ToPyObject` impl for `HashSet` accept non-default hashers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use `METH_FASTCALL` argument passing convention, when possible, to improve `#[pyfunction]` and method performance.
   [#1619](https://github.com/PyO3/pyo3/pull/1619), [#1660](https://github.com/PyO3/pyo3/pull/1660)
 - Make the `Py_tracefunc` parameter of the `PyEval_SetProfile`/`PyEval_SetTrace` functions optional. [#1692](https://github.com/PyO3/pyo3/pull/1692)
+- Make `ToPyObject` impl for `HashSet` accept non-default hashers. [#1702](https://github.com/PyO3/pyo3/pull/1702)
 
 ### Removed
 

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -183,9 +183,10 @@ impl<'a> std::iter::IntoIterator for &'a PySet {
     }
 }
 
-impl<T> ToPyObject for collections::HashSet<T>
+impl<T, S> ToPyObject for collections::HashSet<T, S>
 where
     T: hash::Hash + Eq + ToPyObject,
+    S: hash::BuildHasher + Default,
 {
     fn to_object(&self, py: Python) -> PyObject {
         let set = PySet::new::<T>(py, &[]).expect("Failed to construct empty set");


### PR DESCRIPTION
I had some code like 
```
let s = HashSet<u32>::new();
s.to_object(py)
```
I switched to `HashSet<_, FxBuildHasher>`, and it stopped working.
So this PR changes the `ToPyObject` impl for `HashSet` to accept non-default hashers.

I didn't add a test since I saw that the other converter impls (for example `HashMap`, `into_py`) don't have tests for non-default `BuildHasher`s, but let me know if you want me to add them anyway :)