### PR TITLE
Shortcut macros for collections

### DIFF
--- a/pyo3-macros-backend/src/dict.rs
+++ b/pyo3-macros-backend/src/dict.rs
@@ -15,7 +15,6 @@ pub struct PyDictLiteral {
 #[derive(Debug)]
 pub struct KeyValue {
     key: syn::Expr,
-    sep: Token![:],
     value: syn::Expr,
 }
 
@@ -40,14 +39,10 @@ impl Parse for Key {
 impl Parse for KeyValue {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let key: Key = input.parse()?;
-        let sep: Token![:] = input.parse()?;
+        let _sep: Token![:] = input.parse()?;
         let value: syn::Expr = input.parse()?;
 
-        Ok(Self {
-            key: key.0,
-            sep,
-            value,
-        })
+        Ok(Self { key: key.0, value })
     }
 }
 

--- a/pyo3-macros-backend/src/dict.rs
+++ b/pyo3-macros-backend/src/dict.rs
@@ -1,0 +1,78 @@
+use proc_macro2::{Ident, TokenStream, TokenTree};
+use quote::{quote, ToTokens};
+use std::iter::FromIterator;
+use syn::parse::{Parse, ParseBuffer, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::Token;
+use syn::{braced, Expr};
+
+#[derive(Debug)]
+pub struct PyDictLiteral {
+    pub py: Ident,
+    pub items: Vec<KeyValue>,
+}
+
+#[derive(Debug)]
+pub struct KeyValue {
+    key: syn::Expr,
+    sep: Token![:],
+    value: syn::Expr,
+}
+
+#[derive(Debug)]
+struct Key(syn::Expr);
+
+impl Parse for Key {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut tokens = vec![];
+
+        while !input.peek(Token![:]) || input.peek(Token![::]) {
+            let tt = input.parse::<TokenTree>()?;
+            tokens.push(tt);
+        }
+        let stream = TokenStream::from_iter(tokens.into_iter());
+
+        let expr = syn::parse2::<Expr>(stream)?;
+        Ok(Self(expr))
+    }
+}
+
+impl Parse for KeyValue {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let key: Key = input.parse()?;
+        let sep: Token![:] = input.parse()?;
+        let value: syn::Expr = input.parse()?;
+
+        Ok(Self {
+            key: key.0,
+            sep,
+            value,
+        })
+    }
+}
+
+impl Parse for PyDictLiteral {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let py: Ident = input.parse()?;
+        let _arrow: Token![=>] = input.parse()?;
+
+        let body: ParseBuffer;
+        braced!(body in input);
+
+        let items: Punctuated<KeyValue, Token![,]> = Punctuated::parse_terminated(&body)?;
+
+        Ok(Self {
+            py,
+            items: items.into_iter().collect(),
+        })
+    }
+}
+
+impl ToTokens for KeyValue {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let key = &self.key;
+        let value = &self.value;
+        let ts = quote! {(#key, #value)};
+        tokens.extend(ts);
+    }
+}

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -11,6 +11,7 @@ mod utils;
 mod attributes;
 mod defs;
 mod deprecations;
+mod dict;
 mod from_pyobject;
 mod konst;
 mod method;
@@ -23,6 +24,7 @@ mod pyimpl;
 mod pymethod;
 mod pyproto;
 
+pub use dict::PyDictLiteral;
 pub use from_pyobject::build_derive_from_pyobject;
 pub use module::{process_functions_in_module, py_init, PyModuleOptions};
 pub use pyclass::{build_py_class, build_py_enum, PyClassArgs};

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -204,9 +204,11 @@ pub fn py_dict(input: proc_macro::TokenStream) -> TokenStream {
     let PyDictLiteral { items, py } = parse_macro_input!(input as PyDictLiteral);
     let stream = quote! {
             (|| {
-                let dict = ::pyo3::types::PyDict::new(#py);
+                use pyo3 as _pyo3;
+
+                let dict = _pyo3::types::PyDict::new(#py);
                 #(dict.set_item#items?;)*
-                ::pyo3::prelude::PyResult::Ok(dict)
+                _pyo3::PyResult::Ok(dict)
             })()
     };
     stream.into()

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -9,7 +9,7 @@ use proc_macro::TokenStream;
 use pyo3_macros_backend::{
     build_derive_from_pyobject, build_py_class, build_py_enum, build_py_function, build_py_methods,
     build_py_proto, get_doc, process_functions_in_module, py_init, PyClassArgs, PyClassMethodsType,
-    PyFunctionOptions, PyModuleOptions,
+    PyDictLiteral, PyFunctionOptions, PyModuleOptions,
 };
 use quote::quote;
 use syn::{parse::Nothing, parse_macro_input};
@@ -197,6 +197,19 @@ pub fn derive_from_py_object(item: TokenStream) -> TokenStream {
         #expanded
     )
     .into()
+}
+
+#[proc_macro]
+pub fn py_dict(input: proc_macro::TokenStream) -> TokenStream {
+    let PyDictLiteral { items, py } = parse_macro_input!(input as PyDictLiteral);
+    let stream = quote! {
+            (|| {
+                let dict = ::pyo3::types::PyDict::new(#py);
+                #(dict.set_item#items?;)*
+                ::pyo3::prelude::PyResult::Ok(dict)
+            })()
+    };
+    stream.into()
 }
 
 fn pyclass_impl(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ pub mod proc_macro {
 }
 
 #[cfg(feature = "macros")]
-pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, pyproto, FromPyObject};
+pub use pyo3_macros::{py_dict, pyclass, pyfunction, pymethods, pymodule, pyproto, FromPyObject};
 
 #[macro_use]
 mod macros;

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -369,17 +369,6 @@ where
         Ok(ret)
     }
 }
-macro_rules! py_dict {
-    ($py:ident, {$key:literal : $value:expr}) => {
-        [($key, $value)].into_py_dict($py)
-    };
-
-    ($py:ident, {$key:literal : $value:expr, $($keys:literal : $values:expr),+}) => {{
-        let dct = py_dict!($py, {$($keys : $values),+});
-        dct.set_item($key, $value).expect("failed to set item on dict");
-        dct
-    }};
-}
 
 #[cfg(test)]
 mod tests {
@@ -392,41 +381,6 @@ mod tests {
     use crate::Python;
     use crate::{PyTryFrom, ToPyObject};
     use std::collections::{BTreeMap, HashMap};
-
-    #[test]
-    fn test_dict_macro() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-
-        let single_elem_dict = py_dict!(py, { "a": 2 });
-        assert_eq!(
-            2,
-            single_elem_dict
-                .get_item("a")
-                .unwrap()
-                .extract::<i32>()
-                .unwrap()
-        );
-
-        let value = "value";
-        let multi_elem_dict = py_dict!(py, {"key1": value, 143: "abcde"});
-        assert_eq!(
-            "value",
-            multi_elem_dict
-                .get_item("key1")
-                .unwrap()
-                .extract::<&str>()
-                .unwrap()
-        );
-        assert_eq!(
-            "abcde",
-            multi_elem_dict
-                .get_item(143)
-                .unwrap()
-                .extract::<&str>()
-                .unwrap()
-        );
-    }
 
     #[test]
     fn test_new() {

--- a/src/types/macros.rs
+++ b/src/types/macros.rs
@@ -2,10 +2,8 @@
 #[macro_export]
 macro_rules! py_object_vec {
     ($py:ident, [$($item:expr),+]) => {{
-        let mut items_vec: Vec<$crate::instance::PyObject> = vec![];
-        $(
-            items_vec.push($crate::conversion::IntoPy::into_py($item, $py));
-        )+
+        let items_vec: Vec<$crate::instance::PyObject> =
+            vec![$($crate::conversion::IntoPy::into_py($item, $py)),+];
         items_vec
     }};
 }

--- a/src/types/macros.rs
+++ b/src/types/macros.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "macros")]
 pub use pyo3_macros::py_dict;
 
 #[doc(hidden)]

--- a/src/types/macros.rs
+++ b/src/types/macros.rs
@@ -1,3 +1,5 @@
+#[doc(hidden)]
+#[macro_export]
 macro_rules! py_object_vec {
     ($py:ident, [$($items:expr),+]) => {{
         let mut items_vec: Vec<$crate::instance::PyObject> = py_object_vec!(impl ($py, [$($items),+]));
@@ -17,6 +19,7 @@ macro_rules! py_object_vec {
 
 }
 
+#[macro_export]
 macro_rules! py_dict {
     ($py:ident, {$($keys:literal : $values:expr),+}) => {{
         let items: $crate::instance::PyObject = py_list!($py, [$(($keys, $values)),+]).into();
@@ -25,6 +28,7 @@ macro_rules! py_dict {
     }};
 }
 
+#[macro_export]
 macro_rules! py_list {
     ($py:ident, [$($items:expr),+]) => {{
         let items_vec = py_object_vec!($py, [$($items),+]);
@@ -32,6 +36,7 @@ macro_rules! py_list {
     }};
 }
 
+#[macro_export]
 macro_rules! py_tuple {
     ($py:ident, ($($items:expr),+)) => {{
         let items_vec = py_object_vec!($py, [$($items),+]);
@@ -39,6 +44,7 @@ macro_rules! py_tuple {
     }};
 }
 
+#[macro_export]
 macro_rules! py_set {
     ($py:ident, {$($items:expr),+}) => {{
         let items_vec = py_object_vec!($py, [$($items),+]);
@@ -46,6 +52,7 @@ macro_rules! py_set {
     }};
 }
 
+#[macro_export]
 macro_rules! py_frozenset {
     ($py:ident, {$($items:expr),+}) => {{
         let items_vec = py_object_vec!($py, [$($items),+]);

--- a/src/types/macros.rs
+++ b/src/types/macros.rs
@@ -175,7 +175,7 @@ mod test {
         )
         .expect("failed to update set");
 
-        for expected_elem in vec!["set_elem", "new_elem1", "new_elem2"] {
+        for &expected_elem in &["set_elem", "new_elem1", "new_elem2"] {
             assert!(set.contains(expected_elem).unwrap());
         }
     }

--- a/src/types/macros.rs
+++ b/src/types/macros.rs
@@ -44,7 +44,6 @@ macro_rules! py_frozenset {
 
 #[cfg(test)]
 mod test {
-    use crate::py_dict;
     use crate::types::PyFrozenSet;
     use crate::Python;
 
@@ -63,13 +62,10 @@ mod test {
                 .unwrap()
         );
 
-        let multi_item_list = py_list!(
-            py,
-            ["elem1", "elem2", 3, 4, py_dict!({"type": "user"}).unwrap()]
-        );
+        let multi_item_list = py_list!(py, ["elem1", "elem2", 3, 4]);
 
         assert_eq!(
-            "['elem1', 'elem2', 3, 4, {'type': 'user'}]",
+            "['elem1', 'elem2', 3, 4]",
             multi_item_list.str().unwrap().extract::<&str>().unwrap()
         );
     }
@@ -89,13 +85,10 @@ mod test {
                 .unwrap()
         );
 
-        let multi_item_tuple = py_tuple!(
-            py,
-            ("elem1", "elem2", 3, 4, py_dict!({"type": "user"}).unwrap())
-        );
+        let multi_item_tuple = py_tuple!(py, ("elem1", "elem2", 3, 4));
 
         assert_eq!(
-            "('elem1', 'elem2', 3, 4, {'type': 'user'})",
+            "('elem1', 'elem2', 3, 4)",
             multi_item_tuple.str().unwrap().extract::<&str>().unwrap()
         );
     }

--- a/src/types/macros.rs
+++ b/src/types/macros.rs
@@ -1,0 +1,126 @@
+macro_rules! py_dict {
+    ($py:ident, {$key:literal : $value:expr}) => {
+        $crate::types::dict::IntoPyDict::into_py_dict(&[($key, $value)], $py)
+    };
+
+    ($py:ident, {$key:literal : $value:expr, $($keys:literal : $values:expr),+}) => {{
+        let dict = py_dict!($py, {$($keys : $values),+});
+        dict.set_item($key, $value).expect("failed to set item on dict");
+        dict
+    }};
+}
+
+macro_rules! py_list {
+    ($py:ident, [$($items:expr),+]) => {{
+        let list = py_list!(impl ($py, [$($items),+]));
+        list.reverse().expect("failed to reverse list");
+        list
+    }};
+
+    (impl ($py:ident, [$item:expr])) => {
+        $crate::types::list::PyList::new($py, &[$item])
+    };
+
+    (impl ($py:ident, [$head:expr, $($rest:expr),+])) => {{
+        let list = py_list!(impl ($py, [$($rest),+]));
+        list.append($head).expect("failed to append item");
+        list
+    }};
+}
+
+macro_rules! py_tuple {
+    ($py:ident, ($($items:expr),+)) => {{
+        let items_vec = py_tuple!(impl ($py, ($($items),+)));
+
+        $crate::types::tuple::PyTuple::new($py, items_vec.iter().rev())
+    }};
+
+    (impl ($py:ident, ($item:expr))) => {
+        vec![$crate::conversion::IntoPy::into_py($item, $py)]
+    };
+
+    (impl ($py:ident, ($head:expr, $($rest:expr),+))) => {{
+        let mut items_vec = py_tuple!(impl ($py, ($($rest),+)));
+        items_vec.push($crate::conversion::IntoPy::into_py($head, $py));
+        items_vec
+    }};
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Python;
+    #[test]
+    fn test_dict_macro() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        let single_elem_dict = py_dict!(py, { "a": 2 });
+        assert_eq!(
+            2,
+            single_elem_dict
+                .get_item("a")
+                .unwrap()
+                .extract::<i32>()
+                .unwrap()
+        );
+
+        let value = "value";
+        let multi_elem_dict = py_dict!(py, {"key1": value, 143: "abcde", "name": "Даня"});
+        assert_eq!(
+            "value",
+            multi_elem_dict
+                .get_item("key1")
+                .unwrap()
+                .extract::<&str>()
+                .unwrap()
+        );
+        assert_eq!(
+            "abcde",
+            multi_elem_dict
+                .get_item(143)
+                .unwrap()
+                .extract::<&str>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn test_list_macro() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        let single_item_list = py_list!(py, ["elem"]);
+        assert_eq!(
+            "elem",
+            single_item_list.get_item(0).extract::<&str>().unwrap()
+        );
+
+        let multi_item_list =
+            py_list!(py, ["elem1", "elem2", 3, 4, py_dict!(py, {"type": "user"})]);
+
+        assert_eq!(
+            "['elem1', 'elem2', 3, 4, {'type': 'user'}]",
+            multi_item_list.str().unwrap().extract::<&str>().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_tuple_macro() {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+
+        let single_item_tuple = py_tuple!(py, ("elem"));
+        assert_eq!(
+            "elem",
+            single_item_tuple.get_item(0).extract::<&str>().unwrap()
+        );
+
+        let multi_item_tuple =
+            py_tuple!(py, ("elem1", "elem2", 3, 4, py_dict!(py, {"type": "user"})));
+
+        assert_eq!(
+            "('elem1', 'elem2', 3, 4, {'type': 'user'})",
+            multi_item_tuple.str().unwrap().extract::<&str>().unwrap()
+        );
+    }
+}

--- a/src/types/macros.rs
+++ b/src/types/macros.rs
@@ -1,22 +1,13 @@
 #[doc(hidden)]
 #[macro_export]
 macro_rules! py_object_vec {
-    ($py:ident, [$($items:expr),+]) => {{
-        let mut items_vec: Vec<$crate::instance::PyObject> = py_object_vec!(impl ($py, [$($items),+]));
-        items_vec.reverse();
+    ($py:ident, [$($item:expr),+]) => {{
+        let mut items_vec: Vec<$crate::instance::PyObject> = vec![];
+        $(
+            items_vec.push($crate::conversion::IntoPy::into_py($item, $py));
+        )+
         items_vec
     }};
-
-    (impl ($py:ident, [$item:expr])) => {
-        vec![$crate::conversion::IntoPy::into_py($item, $py)]
-    };
-
-    (impl ($py:ident, [$head:expr, $($rest:expr),+])) => {{
-        let mut items_vec = py_object_vec!(impl ($py, [$($rest),+]));
-        items_vec.push($crate::conversion::IntoPy::into_py($head, $py));
-        items_vec
-    }};
-
 }
 
 #[macro_export]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -233,6 +233,7 @@ mod floatob;
 mod function;
 mod iterator;
 mod list;
+mod macros;
 mod mapping;
 mod module;
 mod num;

--- a/tests/test_literals.rs
+++ b/tests/test_literals.rs
@@ -34,13 +34,17 @@ fn test_dict_literal() {
 
     let keys = &["key1", "key2"];
 
-    let expr_dict =
-        py_dict!(py => { keys[0]: "value1", keys[1]: "value2", 3-7: py_tuple!(py, ("elem1", "elem2", 3)) })
-            .expect("failed to create dict");
+    let expr_dict = py_dict!(py => {
+        keys[0]: "value1",
+        keys[1]: "value2",
+        3-7: py_tuple!(py, ("elem1", "elem2", 3)),
+        "KeY".to_lowercase(): 100 * 2,
+    })
+    .expect("failed to create dict");
 
     py_run!(
         py,
         expr_dict,
-        "assert expr_dict == {'key1': 'value1', 'key2': 'value2', -4: ('elem1', 'elem2', 3)}"
+        "assert expr_dict == {'key1': 'value1', 'key2': 'value2', -4: ('elem1', 'elem2', 3), 'key': 200}"
     );
 }

--- a/tests/test_literals.rs
+++ b/tests/test_literals.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::{py_dict, py_run, py_tuple};
 

--- a/tests/test_literals.rs
+++ b/tests/test_literals.rs
@@ -1,0 +1,46 @@
+use pyo3::prelude::*;
+use pyo3::{py_dict, py_run, py_tuple};
+
+#[test]
+fn test_dict_literal() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let dict = py_dict!(py => {"key": "value"}).expect("failed to create dict");
+    assert_eq!(
+        "value",
+        dict.get_item("key").unwrap().extract::<String>().unwrap()
+    );
+
+    let value = "value";
+    let multi_elem_dict =
+        py_dict!(py => {"key1": value, 143: "abcde"}).expect("failed to create dict");
+    assert_eq!(
+        "value",
+        multi_elem_dict
+            .get_item("key1")
+            .unwrap()
+            .extract::<&str>()
+            .unwrap()
+    );
+    assert_eq!(
+        "abcde",
+        multi_elem_dict
+            .get_item(143)
+            .unwrap()
+            .extract::<&str>()
+            .unwrap()
+    );
+
+    let keys = &["key1", "key2"];
+
+    let expr_dict =
+        py_dict!(py => { keys[0]: "value1", keys[1]: "value2", 3-7: py_tuple!(py, ("elem1", "elem2", 3)) })
+            .expect("failed to create dict");
+
+    py_run!(
+        py,
+        expr_dict,
+        "assert expr_dict == {'key1': 'value1', 'key2': 'value2', -4: ('elem1', 'elem2', 3)}"
+    );
+}


### PR DESCRIPTION
This is an implementation of #1463
It currently provides the following macros:
- `py_list!(py, [1, 2, 3]) → &PyList`
- `py_tuple!(py, (1, 2, 3)) → &PyTuple`
- `py_dict!(py, {"key": value}) → PyResult<&PyDict>`
- `py_set!(py, {"item1", "item2", 1, 2, 3}) → PyResult<&PySet>`
- `py_frozenset!(py, {"item1", "item2", 1, 2, 3}) → PyResult<&PyFrozenSet>`

`py_dict!` only supports literals as keys because we use colons `:` as key-value separators, and colons are not allowed after `expr` fragments. If we would like to use expressions as keys, we have to use `=>` as a separator.


TODO:
- [ ] `:` vs `=>` for key-value separator
- [x] proc macro for py_dict!
- [x] PyDict::from_sequence doesn't exist on PyPy
 - [ ] an entry in CHANGELOG.md
 - [ ] docs to all new macros and details in the guide
 - [ ] more tests probably 
