### PR TITLE
coverage: ignore tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,6 @@ coverage:
         target: auto
         # Allow a tiny drop of overall project coverage in PR to reduce spurious failures.
         threshold: 0.25%
+
+ignore:
+  - tests/*.rs


### PR DESCRIPTION
It doesn't seem that useful to measure coverage of test files, so let's perhaps not count them?