### PR TITLE
Add full path for PyCell

### DIFF
--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -538,7 +538,7 @@ fn impl_class(
             const IS_BASETYPE: bool = #is_basetype;
             const IS_SUBCLASS: bool = #is_subclass;
 
-            type Layout = PyCell<Self>;
+            type Layout = pyo3::PyCell<Self>;
             type BaseType = #base;
             type ThreadChecker = #thread_checker;
 

--- a/tests/ui/invalid_pymethod_receiver.stderr
+++ b/tests/ui/invalid_pymethod_receiver.stderr
@@ -1,8 +1,8 @@
-error[E0277]: the trait bound `i32: From<&pyo3::PyCell<MyClass>>` is not satisfied
+error[E0277]: the trait bound `i32: From<&PyCell<MyClass>>` is not satisfied
  --> $DIR/invalid_pymethod_receiver.rs:8:43
   |
 8 |     fn method_with_invalid_self_type(slf: i32, py: Python, index: u32) {}
-  |                                           ^^^ the trait `From<&pyo3::PyCell<MyClass>>` is not implemented for `i32`
+  |                                           ^^^ the trait `From<&PyCell<MyClass>>` is not implemented for `i32`
   |
   = help: the following implementations were found:
             <i32 as From<NonZeroI32>>
@@ -10,6 +10,6 @@ error[E0277]: the trait bound `i32: From<&pyo3::PyCell<MyClass>>` is not satisfi
             <i32 as From<i16>>
             <i32 as From<i8>>
           and 2 others
-  = note: required because of the requirements on the impl of `Into<i32>` for `&pyo3::PyCell<MyClass>`
-  = note: required because of the requirements on the impl of `TryFrom<&pyo3::PyCell<MyClass>>` for `i32`
+  = note: required because of the requirements on the impl of `Into<i32>` for `&PyCell<MyClass>`
+  = note: required because of the requirements on the impl of `TryFrom<&PyCell<MyClass>>` for `i32`
   = note: required by `std::convert::TryFrom::try_from`


### PR DESCRIPTION
This makes it so that users no longer have to bring  `PyCell` into scope to make the `#[pyclass]` macro work (either with the prelude or explicit import).
