### PR TITLE
Implement `IntoPy<PyObject>` for `&PathBuf` and `&OsString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/main/migration.h
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Implement `IntoPy<PyObject>` for `&PathBuf` and `&OsString`. [#1721](https://github.com/PyO3/pyo3/pull/1712)
+
 ## [0.14.0] - 2021-07-03
 
 ### Packaging

--- a/src/conversions/osstr.rs
+++ b/src/conversions/osstr.rs
@@ -145,6 +145,12 @@ impl IntoPy<PyObject> for OsString {
     }
 }
 
+impl<'a> IntoPy<PyObject> for &'a OsString {
+    fn into_py(self, py: Python) -> PyObject {
+        self.to_object(py)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{types::PyString, IntoPy, PyObject, Python, ToPyObject};
@@ -205,6 +211,7 @@ mod test {
             let os_str = OsStr::new("Hello\0\n🐍");
             test_roundtrip::<&OsStr>(py, os_str);
             test_roundtrip::<OsString>(py, os_str.to_os_string());
+            test_roundtrip::<&OsString>(py, &os_str.to_os_string());
         })
     }
 }

--- a/src/conversions/path.rs
+++ b/src/conversions/path.rs
@@ -66,6 +66,12 @@ impl IntoPy<PyObject> for PathBuf {
     }
 }
 
+impl<'a> IntoPy<PyObject> for &'a PathBuf {
+    fn into_py(self, py: Python) -> PyObject {
+        self.as_os_str().to_object(py)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::{types::PyString, IntoPy, PyObject, Python, ToPyObject};
@@ -120,11 +126,12 @@ mod test {
                 let pystring: &PyString = pyobject.extract(py).unwrap();
                 assert_eq!(pystring.to_string_lossy(), obj.as_ref().to_string_lossy());
                 let roundtripped_obj: PathBuf = pystring.extract().unwrap();
-                assert!(obj.as_ref() == roundtripped_obj.as_path());
+                assert_eq!(obj.as_ref(), roundtripped_obj.as_path());
             }
             let path = Path::new("Hello\0\n🐍");
             test_roundtrip::<&Path>(py, path);
             test_roundtrip::<PathBuf>(py, path.to_path_buf());
+            test_roundtrip::<&PathBuf>(py, &path.to_path_buf());
         })
     }
 }


### PR DESCRIPTION
Without this impl users need to call `as_path()` to convert a `&PathBuf` to a `&Path`, for example https://github.com/messense/rjsonnet-py/commit/b29e161a37e0f9642dca8b5e3b4836c816615647

Otherwise the error message is not easy to understand:

```rust
error[E0277]: the trait bound `PathBuf: AsPyPointer` is not satisfied
  --> src/lib.rs:34:55
   |
34 |             Python::with_gil(|py| match self.callback.call(py, (from, path), None) {
   |                                                       ^^^^ the trait `AsPyPointer` is not implemented for `PathBuf`
   |
   = note: required because of the requirements on the impl of `pyo3::IntoPy<Py<PyAny>>` for `&PathBuf`
   = note: 1 redundant requirements hidden
   = note: required because of the requirements on the impl of `pyo3::IntoPy<Py<PyTuple>>` for `(&PathBuf, &PathBuf)`
```