### PR TITLE
Add `PyErr::take` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Implement `IntoPy<PyObject>` for `&PathBuf` and `&OsString`. [#1721](https://github.com/PyO3/pyo3/pull/1712)
+- Add `PyErr::take`. [#1715](https://github.com/PyO3/pyo3/pull/1715)
 
 ## [0.14.0] - 2021-07-03
 


### PR DESCRIPTION
Just like [`Option::take`](https://doc.rust-lang.org/stable/std/option/enum.Option.html#method.take).

If no error is set, the existing `PyError::fetch`method  returns a `SystemError` makes it inconvenient to use in Rust side for example when setting the cause for `PyErr`: https://github.com/messense/rjsonnet-py/blob/e144e9c08621135e03d06c8d0fc53af51ff51b3c/src/lib.rs#L224-L233