### PR TITLE
err: don't use with_gil internally in PyErr::new()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add `indexmap` feature to add `ToPyObject`, `IntoPy` and `FromPyObject` implementations for `indexmap::IndexMap`. [#1728](https://github.com/PyO3/pyo3/pull/1728)
 
+### Changed
+
+- `PyErr::new` no longer acquires the Python GIL internally. [#1724](https://github.com/PyO3/pyo3/pull/1724)
+
 ### Fixed
 
 - Fix regression in 0.14.0 rejecting usage of `#[doc(hidden)]` on structs and functions annotated with PyO3 macros. [#1722](https://github.com/PyO3/pyo3/pull/1722)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,10 @@ name = "bench_call"
 harness = false
 
 [[bench]]
+name = "bench_err"
+harness = false
+
+[[bench]]
 name = "bench_dict"
 harness = false
 

--- a/benches/bench_err.rs
+++ b/benches/bench_err.rs
@@ -1,0 +1,24 @@
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+
+use pyo3::{exceptions::PyValueError, prelude::*};
+
+fn err_new_restore_and_fetch(b: &mut Bencher) {
+    Python::with_gil(|py| {
+        b.iter(|| {
+            PyValueError::new_err("some exception message").restore(py);
+            PyErr::fetch(py)
+        })
+    })
+}
+
+fn err_new_without_gil(b: &mut Bencher) {
+    b.iter(|| PyValueError::new_err("some exception message"))
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("err_new_restore_and_fetch", err_new_restore_and_fetch);
+    c.bench_function("err_new_without_gil", err_new_without_gil);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This is a partial follow-on from #1683 

If we're going to remove the optimization of using PyO3's thread-local to check for the GIL being held in `with_gil`, then it seems desirable that `PyErr::new` really doesn't need the GIL at all.

I added a benchmark to accompany the change; it only slightly impacts performance (<2% slower and this is on the error path anyway). It also has the nice side effect that users already creating `PyErr` outside of a GIL will get a significant speedup, because the GIL won't be temporarily acquired.