### PR TITLE
pyo3-build-config: improve error messaging

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,22 +1,13 @@
 use std::{env, process::Command};
 
-use pyo3_build_config::{InterpreterConfig, PythonImplementation, PythonVersion};
-
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+use pyo3_build_config::{
+    bail, ensure,
+    errors::{Context, Result},
+    InterpreterConfig, PythonImplementation, PythonVersion,
+};
 
 /// Minimum Python version PyO3 supports.
 const MINIMUM_SUPPORTED_VERSION: PythonVersion = PythonVersion { major: 3, minor: 6 };
-
-// A simple macro for returning an error. Resembles anyhow::bail.
-macro_rules! bail {
-    ($msg: expr) => { return Err($msg.into()); };
-    ($fmt: literal $($args: tt)+) => { return Err(format!($fmt $($args)+).into()); };
-}
-
-// A simple macro for checking a condition. Resembles anyhow::ensure.
-macro_rules! ensure {
-    ($condition:expr, $($args: tt)+) => { if !($condition) { bail!($($args)+) } };
-}
 
 fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
     ensure!(
@@ -87,9 +78,7 @@ fn get_rustc_link_lib(config: &InterpreterConfig) -> Result<String> {
         match config.implementation {
             PythonImplementation::CPython => match &config.ld_version {
                 Some(ld_version) => format!("python{}", ld_version),
-                None => {
-                    return Err("failed to configure `ld_version` when compiling for unix".into())
-                }
+                None => bail!("failed to configure `ld_version` when compiling for unix"),
             },
             PythonImplementation::PyPy => format!("pypy{}-c", config.version.major),
         }
@@ -157,7 +146,7 @@ fn emit_cargo_configuration(interpreter_config: &InterpreterConfig) -> Result<()
 
     if env::var_os("CARGO_FEATURE_AUTO_INITIALIZE").is_some() {
         if !interpreter_config.shared {
-            return Err(format!(
+            bail!(
                 "The `auto-initialize` feature is enabled, but your python installation only supports \
                 embedding the Python interpreter statically. If you are attempting to run tests, or a \
                 binary which is okay to link dynamically, install a Python distribution which ships \
@@ -170,15 +159,14 @@ fn emit_cargo_configuration(interpreter_config: &InterpreterConfig) -> Result<()
                 https://pyo3.rs/v{pyo3_version}/\
                     building_and_distribution.html#embedding-python-in-rust",
                 pyo3_version = env::var("CARGO_PKG_VERSION").unwrap()
-            )
-            .into());
+            );
         }
 
         // TODO: PYO3_CI env is a hack to workaround CI with PyPy, where the `dev-dependencies`
         // currently cause `auto-initialize` to be enabled in CI.
         // Once cargo's `resolver = "2"` is stable (~ MSRV Rust 1.52), remove this.
         if interpreter_config.is_pypy() && env::var_os("PYO3_CI").is_none() {
-            return Err("The `auto-initialize` feature is not supported with PyPy.".into());
+            bail!("The `auto-initialize` feature is not supported with PyPy.");
         }
     }
 
@@ -194,7 +182,14 @@ fn configure_pyo3() -> Result<()> {
     ensure_python_version(&interpreter_config)?;
     ensure_target_architecture(&interpreter_config)?;
     emit_cargo_configuration(&interpreter_config)?;
-    interpreter_config.to_writer(&mut std::fs::File::create(pyo3_build_config::PATH)?)?;
+    interpreter_config.to_writer(
+        &mut std::fs::File::create(pyo3_build_config::PATH).with_context(|| {
+            format!(
+                "failed to create config file at {}",
+                pyo3_build_config::PATH
+            )
+        })?,
+    )?;
     interpreter_config.emit_pyo3_cfgs();
 
     // Enable use of const generics on Rust 1.51 and greater
@@ -208,7 +203,18 @@ fn configure_pyo3() -> Result<()> {
 fn main() {
     // Print out error messages using display, to get nicer formatting.
     if let Err(e) = configure_pyo3() {
+        use std::error::Error;
         eprintln!("error: {}", e);
+        let mut source = e.source();
+        if source.is_some() {
+            eprintln!("caused by:");
+            let mut index = 0;
+            while let Some(some_source) = source {
+                eprintln!("  - {}: {}", index, some_source);
+                source = some_source.source();
+                index += 1;
+            }
+        }
         std::process::exit(1)
     }
 }

--- a/pyo3-build-config/src/errors.rs
+++ b/pyo3-build-config/src/errors.rs
@@ -1,0 +1,86 @@
+/// A simple macro for returning an error. Resembles anyhow::bail.
+#[macro_export]
+macro_rules! bail {
+    ($msg: expr) => { return Err($msg.into()); };
+    ($fmt: literal $($args: tt)+) => { return Err(format!($fmt $($args)+).into()); };
+}
+
+/// A simple macro for checking a condition. Resembles anyhow::ensure.
+#[macro_export]
+macro_rules! ensure {
+    ($condition:expr, $($args: tt)+) => { if !($condition) { bail!($($args)+) } };
+}
+
+/// Show warning. If needed, please extend this macro to support arguments.
+#[macro_export]
+macro_rules! warn {
+    ($msg: literal) => {
+        println!(concat!("cargo:warning=", $msg));
+    };
+}
+
+/// A simple error implementation which allows chaining of errors, inspired somewhat by anyhow.
+#[derive(Debug)]
+pub struct Error {
+    value: String,
+    source: Option<Box<dyn std::error::Error>>,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source.as_deref()
+    }
+}
+
+impl From<String> for Error {
+    fn from(value: String) -> Self {
+        Self {
+            value,
+            source: None,
+        }
+    }
+}
+
+impl From<&'_ str> for Error {
+    fn from(value: &str) -> Self {
+        value.to_string().into()
+    }
+}
+
+impl From<std::convert::Infallible> for Error {
+    fn from(_: std::convert::Infallible) -> Self {
+        unreachable!()
+    }
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub trait Context<T> {
+    fn context(self, message: impl Into<String>) -> Result<T>;
+    fn with_context(self, message: impl FnOnce() -> String) -> Result<T>;
+}
+
+impl<T, E> Context<T> for Result<T, E>
+where
+    E: std::error::Error + 'static,
+{
+    fn context(self, message: impl Into<String>) -> Result<T> {
+        self.map_err(|error| Error {
+            value: message.into(),
+            source: Some(Box::new(error)),
+        })
+    }
+
+    fn with_context(self, message: impl FnOnce() -> String) -> Result<T> {
+        self.map_err(|error| Error {
+            value: message(),
+            source: Some(Box::new(error)),
+        })
+    }
+}

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -14,6 +14,8 @@
 //!
 //! For examples of how to use these attributes, [see PyO3's guide](https://pyo3.rs/main/building_and_distribution/multiple_python_versions.html).
 
+#[doc(hidden)]
+pub mod errors;
 mod impl_;
 
 use once_cell::sync::OnceCell;


### PR DESCRIPTION
This PR tweaks the implementation of `Result` in the build scripts to use a simple `Error` type which supports chaining the "source".

I was upgrading a private codebase to 0.14 and hit an unhelpful error message `error: No such file or directory (os error 2)`.

I suspect it was probably caused by this line: https://github.com/PyO3/pyo3/blob/584fc6fe42a8ec6fe7fa55ff98aec8bf8471e134/build.rs#L197

... which is a different problem (I'm worried that it might be caused by a bad interaction with `sccache`).

At least after this PR, this error (and a few others) have a more helpful context message added to the original error.