### PR TITLE
workaround an issue that causes function arguments to show up as if they are uncovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix regression in 0.14.0 rejecting usage of `#[doc(hidden)]` on structs and functions annotated with PyO3 macros. [#1722](https://github.com/PyO3/pyo3/pull/1722)
+- Fix regression in 0.14.0 leading to incorrect code coverage being computed for `#[pyfunction]`s. [#1726](https://github.com/PyO3/pyo3/pull/1726)
 
 ## [0.14.1] - 2021-07-04
 

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -208,7 +208,7 @@ fn impl_arg_param(
 
     let ty = arg.ty;
     let name = arg.name;
-    let transform_error = quote_arg_span! {
+    let transform_error = quote! {
         |e| pyo3::derive_utils::argument_extraction_error(#py, stringify!(#name), e)
     };
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/86972 describes this issue in some detail and links to a minimal reproducer

making this change, and this change alone, resolves the coverage issues
