### PR TITLE
pyo3-build-config: add print-config helper

### DIFF
--- a/pyo3-build-config/src/bin/print-config.rs
+++ b/pyo3-build-config/src/bin/print-config.rs
@@ -1,0 +1,16 @@
+use pyo3_build_config::{find_interpreter, get_config_from_interpreter};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = get_config_from_interpreter(&find_interpreter()?)?;
+
+    println!("implementation: {}", config.implementation);
+    println!("interpreter version: {}", config.version);
+    println!("interpreter path: {:?}", config.executable);
+    println!("libdir: {:?}", config.libdir);
+    println!("shared: {}", config.shared);
+    println!("base prefix: {:?}", config.base_prefix);
+    println!("ld_version: {:?}", config.ld_version);
+    println!("pointer width: {:?}", config.calcsize_pointer);
+
+    Ok(())
+}

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -20,10 +20,14 @@ mod impl_;
 
 use once_cell::sync::OnceCell;
 
-#[doc(hidden)]
-pub use crate::impl_::{
-    make_interpreter_config, InterpreterConfig, PythonImplementation, PythonVersion,
+pub use impl_::{
+    find_interpreter, get_config_from_interpreter, InterpreterConfig, PythonImplementation,
+    PythonVersion,
 };
+
+// Used in PyO3's build.rs
+#[doc(hidden)]
+pub use impl_::make_interpreter_config;
 
 /// Reads the configuration written by PyO3's build.rs
 ///


### PR DESCRIPTION
This adds a `print-config` bin to the `pyo3-build-config` crate.

The idea is that we can use this to help debug installation issues, e.g. #1616 

Some example outputs on my machine (Ubuntu 20.04, WSL2):

```
cargo:rerun-if-env-changed=PYO3_PYTHON
cargo:rerun-if-env-changed=VIRTUAL_ENV
cargo:rerun-if-env-changed=CONDA_PREFIX
cargo:rerun-if-env-changed=PATH
implementation: CPython
interpreter version: 3.8
interpreter path: Some("/usr/bin/python")
libdir: Some("/usr/lib")
shared: true
base prefix: Some("/usr")
ld_version: Some("3.8")
pointer width: Some(8)
```

and with a 3.9 virtualenv up:

```
cargo:rerun-if-env-changed=PYO3_PYTHON
cargo:rerun-if-env-changed=VIRTUAL_ENV
cargo:rerun-if-env-changed=CONDA_PREFIX
implementation: CPython
interpreter version: 3.9
interpreter path: Some("/home/david/.virtualenvs/pyo3/bin/python")
libdir: Some("/usr/lib/x86_64-linux-gnu")
shared: true
base prefix: Some("/usr")
ld_version: Some("3.9")
pointer width: Some(8)
```