### PR TITLE
pyo3-pytests: remove memory leak test

### DIFF
--- a/examples/pyo3-pytests/Cargo.toml
+++ b/examples/pyo3-pytests/Cargo.toml
@@ -25,3 +25,9 @@ classifier=[
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
 ]
+
+# Don't optimize the release build (built by maturin / tox) for this module, as
+# it's a test module.
+[profile.release]
+debug = true
+opt-level = 0

--- a/examples/pyo3-pytests/src/buf_and_str.rs
+++ b/examples/pyo3-pytests/src/buf_and_str.rs
@@ -14,12 +14,12 @@ impl BytesExtractor {
     }
 
     pub fn from_bytes(&mut self, bytes: &PyBytes) -> PyResult<usize> {
-        let byte_vec: Vec<u8> = bytes.extract().unwrap();
+        let byte_vec: Vec<u8> = bytes.extract()?;
         Ok(byte_vec.len())
     }
 
     pub fn from_str(&mut self, string: &PyString) -> PyResult<usize> {
-        let rust_string: String = string.extract().unwrap();
+        let rust_string: String = string.extract()?;
         Ok(rust_string.len())
     }
 

--- a/examples/pyo3-pytests/tests/test_buf_and_str.py
+++ b/examples/pyo3-pytests/tests/test_buf_and_str.py
@@ -1,51 +1,20 @@
-import gc
-import os
-import platform
-
-import psutil
-import pytest
 from pyo3_pytests.buf_and_str import BytesExtractor
 
-PYPY = platform.python_implementation() == "PyPy"
 
-
-@pytest.mark.skipif(
-    PYPY,
-    reason="PyPy has a segfault bug around this area."
-    "See https://github.com/PyO3/pyo3/issues/589 for detail.",
-)
-def test_pybuffer_doesnot_leak_memory():
-    N = 10000
+def test_extract_bytes():
     extractor = BytesExtractor()
-    process = psutil.Process(os.getpid())
+    message = b'\\(-"-;) A message written in bytes'
+    assert extractor.from_bytes(message) == len(message)
 
-    def memory_diff(f):
-        before = process.memory_info().rss
-        gc.collect()  # Trigger Garbage collection
-        for _ in range(N):
-            f()
-        gc.collect()  # Trigger Garbage collection
-        after = process.memory_info().rss
-        return after - before
 
-    message_b = b'\\(-"-;) Praying that memory leak would not happen..'
-    message_s = '\\(-"-;) Praying that memory leak would not happen..'
-    message_surrogate = '\\(-"-;) Praying that memory leak would not happen.. \ud800'
+def test_extract_str():
+    extractor = BytesExtractor()
+    message = '\\(-"-;) A message written as a string'
+    assert extractor.from_str(message) == len(message)
 
-    def from_bytes():
-        extractor.from_bytes(message_b)
 
-    def from_str():
-        extractor.from_str(message_s)
-
-    def from_str_lossy():
-        extractor.from_str_lossy(message_surrogate)
-
-    # Running the memory_diff to warm-up the garbage collector
-    memory_diff(from_bytes)
-    memory_diff(from_str)
-    memory_diff(from_str_lossy)
-
-    assert memory_diff(from_bytes) == 0
-    assert memory_diff(from_str) == 0
-    assert memory_diff(from_str_lossy) == 0
+def test_extract_str_lossy():
+    extractor = BytesExtractor()
+    message = '\\(-"-;) A message written with a trailing surrogate \ud800'
+    rust_surrogate_len = extractor.from_str_lossy("\ud800")
+    assert extractor.from_str_lossy(message) == len(message) - 1 + rust_surrogate_len


### PR DESCRIPTION
I replaced the `test_pybuffer_doesnot_leak_memory` test with just simple tests for the underlying functions, and enabled testing them on PyPy.

In my opinion detecting memory leaks in CI by measuring memory count is _really_ hard. This test was comparing process memory before and after the test. However that doesn't really work because that assumes every call to `alloc` increases actual process memory. Often the allocators used will request memory from the OS in chunks and then re-use that memory smartly.

This test was also occasionally flaky. Closes #1412 