### PR TITLE
bench: don't alert on CI benchmark changes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -47,18 +47,11 @@ jobs:
         with:
           name: pyo3-bench
           # What benchmark tool the output.txt came from
-          tool: 'cargo'
+          tool: "cargo"
           # Where the output from the benchmark tool is stored
           output-file-path: output.txt
-          # # Where the previous data file is stored
-          # external-data-json-path: ./cache/benchmark-data.json
-          # Workflow will fail when an alert happens
-          fail-on-alert: true
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Enable alert commit comment
-          comment-on-alert: true
-          alert-comment-cc-users: '@PyO3/pyo3'
           auto-push: ${{ github.event_name != 'pull_request' }}
 
   pytest-benchmark:
@@ -98,10 +91,7 @@ jobs:
         uses: rhysd/github-action-benchmark@v1
         with:
           name: pytest-bench
-          tool: 'pytest'
+          tool: "pytest"
           output-file-path: output.json
-          fail-on-alert: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
-          alert-comment-cc-users: '@PyO3/pyo3'
           auto-push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
I think the benchmarks on CI are cool, but in practice they're very volatile so I don't think it's worth alerting on performance changes. So far I think all the alerts I've seen have been flaky. I also hope we would spot potential major perf issues in code review!

cc @messense 