### PR TITLE
guide: add latest symlink

### DIFF
--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -62,12 +62,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'release' }}
     steps:
-      - name: Create latest tag redirect
+      - name: Create latest tag redirects
         env:
           TAG_NAME: ${{ needs.build.outputs.tag_name }}
         run: |
           mkdir public
           echo "<meta http-equiv=refresh content=0;url='$TAG_NAME/'>" > public/index.html
+          ln -sfT $TAG_NAME public/latest
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3.7.0-8


### PR DESCRIPTION
This add a symlink to the `gh-pages` branch so that the latest released guide will always be available underneath `https://pyo3.rs/latest/`.

E.g. `https://pyo3.rs/latest/changelog.html` would be the link to the latest released changelog.

If approved, I'll also add this manually now to make `https://pyo3.rs/latest/` symlink to `https://pyo3.rs/v0.14.1/`.