### PR TITLE
pypy: fix FFI definition of Py_Buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix regression in 0.14.0 rejecting usage of `#[doc(hidden)]` on structs and functions annotated with PyO3 macros. [#1722](https://github.com/PyO3/pyo3/pull/1722)
 - Fix regression in 0.14.0 leading to incorrect code coverage being computed for `#[pyfunction]`s. [#1726](https://github.com/PyO3/pyo3/pull/1726)
+- Fix incorrect FFI definition of `Py_Buffer` on PyPy. [#1737](https://github.com/PyO3/pyo3/pull/1737)
 
 ## [0.14.1] - 2021-07-04
 

--- a/examples/pyo3-pytests/src/buf_and_str.rs
+++ b/examples/pyo3-pytests/src/buf_and_str.rs
@@ -1,4 +1,5 @@
 //! Objects related to PyBuffer and PyStr
+use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
 
@@ -26,6 +27,11 @@ impl BytesExtractor {
     pub fn from_str_lossy(&mut self, string: &PyString) -> PyResult<usize> {
         let rust_string_lossy: String = string.to_string_lossy().to_string();
         Ok(rust_string_lossy.len())
+    }
+
+    pub fn from_buffer(&mut self, buf: &PyAny) -> PyResult<usize> {
+        let buf = PyBuffer::<u8>::get(buf)?;
+        Ok(buf.item_count())
     }
 }
 

--- a/examples/pyo3-pytests/tests/test_buf_and_str.py
+++ b/examples/pyo3-pytests/tests/test_buf_and_str.py
@@ -18,3 +18,12 @@ def test_extract_str_lossy():
     message = '\\(-"-;) A message written with a trailing surrogate \ud800'
     rust_surrogate_len = extractor.from_str_lossy("\ud800")
     assert extractor.from_str_lossy(message) == len(message) - 1 + rust_surrogate_len
+
+
+def test_extract_buffer():
+    extractor = BytesExtractor()
+    message = b'\\(-"-;) A message written in bytes'
+    assert extractor.from_buffer(message) == len(message)
+
+    arr = bytearray(b'\\(-"-;) A message written in bytes')
+    assert extractor.from_buffer(arr) == len(arr)

--- a/src/ffi/cpython/object.rs
+++ b/src/ffi/cpython/object.rs
@@ -16,6 +16,9 @@ mod bufferinfo {
     use std::os::raw::{c_char, c_int, c_void};
     use std::ptr;
 
+    #[cfg(PyPy)]
+    const Py_MAX_NDIMS: usize = 36;
+
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct Py_buffer {
@@ -31,6 +34,12 @@ mod bufferinfo {
         pub strides: *mut Py_ssize_t,
         pub suboffsets: *mut Py_ssize_t,
         pub internal: *mut c_void,
+        #[cfg(PyPy)]
+        pub flags: c_int,
+        #[cfg(PyPy)]
+        pub _strides: [Py_ssize_t; Py_MAX_NDIMS],
+        #[cfg(PyPy)]
+        pub _shape: [Py_ssize_t; Py_MAX_NDIMS],
     }
 
     impl Py_buffer {
@@ -47,6 +56,12 @@ mod bufferinfo {
                 strides: ptr::null_mut(),
                 suboffsets: ptr::null_mut(),
                 internal: ptr::null_mut(),
+                #[cfg(PyPy)]
+                flags: 0,
+                #[cfg(PyPy)]
+                _strides: [0; Py_MAX_NDIMS],
+                #[cfg(PyPy)]
+                _shape: [0; Py_MAX_NDIMS],
             }
         }
     }


### PR DESCRIPTION
Fixes #1736 

Looks like PyPy has extra fields for the `Py_Buffer` struct - https://foss.heptapod.net/pypy/pypy/-/blob/branch/default/pypy/module/cpyext/parse/cpyext_object.h#L78

Needs a `CHANGELOG` entry and also tests (in `pyo3-pytests`, because this is PyPy) before this can be merged. Will write them later, got to go to work now! 💼 