### PR TITLE
docs: use pyo3.rs/latest instead of pyo3.rs/main

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -46,7 +46,7 @@ In the [`src/ffi`] module, there is lots of conditional compilation such as `#[c
 `#[cfg(Py_37)]`, and `#[cfg(PyPy)]`.
 `Py_LIMITED_API` corresponds to `#define Py_LIMITED_API` macro in Python/C API.
 With `Py_LIMITED_API`, we can build a Python-version-agnostic binary called an
-[abi3 wheel](https://pyo3.rs/main/building_and_distribution.html#py_limited_apiabi3).
+[abi3 wheel](https://pyo3.rs/latest/building_and_distribution.html#py_limited_apiabi3).
 `Py_37` means that the API is available from Python >= 3.7.
 There are also `Py_38`, `Py_39`, and so on.
 `PyPy` means that the API definition is for PyPy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file. For help with updating to new
-PyO3 versions, please see the [migration guide](https://pyo3.rs/main/migration.html).
+PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration.html).
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 PyO3 supports Python 3.6 and up. The minimum required Rust version is 1.41.
 
-PyPy is also supported. Some minor features are unavailable on PyPy - please refer to the [pypy section in the guide](https://pyo3.rs/main/building_and_distribution/pypy.html) for more information.
+PyPy is also supported. Some minor features are unavailable on PyPy - please refer to the [pypy section in the guide](https://pyo3.rs/latest/building_and_distribution/pypy.html) for more information.
 
 You can either write a native Python module in Rust, or use Python from a Rust binary.
 
@@ -116,7 +116,7 @@ fn main_(py: Python) -> PyResult<()> {
 }
 ```
 
-Our guide has [a section](https://pyo3.rs/main/python_from_rust.html) with lots of examples
+Our guide has [a section](https://pyo3.rs/latest/python_from_rust.html) with lots of examples
 about this topic.
 
 ## Tools and libraries

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -12,7 +12,7 @@
 //! | `#[cfg(Py_LIMITED_API)]` | This marks code which is run when compiling with PyO3's `abi3` feature enabled. |
 //! | `#[cfg(PyPy)]` | This marks code which is run when compiling for PyPy. |
 //!
-//! For examples of how to use these attributes, [see PyO3's guide](https://pyo3.rs/main/building_and_distribution/multiple_python_versions.html).
+//! For examples of how to use these attributes, [see PyO3's guide](https://pyo3.rs/latest/building_and_distribution/multiple_python_versions.html).
 
 #[doc(hidden)]
 pub mod errors;

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -29,7 +29,7 @@ use syn::parse_macro_input;
 ///
 /// For more on creating Python modules see the [module section of the guide][1].
 ///
-/// [1]: https://pyo3.rs/main/module.html
+/// [1]: https://pyo3.rs/latest/module.html
 #[proc_macro_attribute]
 pub fn pymodule(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as syn::ItemFn);
@@ -106,11 +106,11 @@ pub fn pyproto(_: TokenStream, input: TokenStream) -> TokenStream {
 /// For more on creating Python classes,
 /// see the [class section of the guide][1].
 ///
-/// [1]: https://pyo3.rs/main/class.html
-/// [2]: https://pyo3.rs/main/class.html#customizing-the-class
+/// [1]: https://pyo3.rs/latest/class.html
+/// [2]: https://pyo3.rs/latest/class.html#customizing-the-class
 /// [3]: std::marker::Send
 /// [4]: ../prelude/struct.PyAny.html
-/// [5]: https://pyo3.rs/main/class/protocols.html#garbage-collector-integration
+/// [5]: https://pyo3.rs/latest/class/protocols.html#garbage-collector-integration
 /// [6]: https://docs.python.org/3/library/weakref.html
 /// [7]: https://doc.rust-lang.org/nomicon/leaking.html
 /// [8]: std::rc::Rc
@@ -139,11 +139,11 @@ pub fn pyclass(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// For more on creating Python classes,
 /// see the [class section of the guide][1].
 ///
-/// [1]: https://pyo3.rs/main/class.html
-/// [2]: https://pyo3.rs/main/class.html#customizing-the-class
+/// [1]: https://pyo3.rs/latest/class.html
+/// [2]: https://pyo3.rs/latest/class.html#customizing-the-class
 /// [3]: std::marker::Send
 /// [4]: ../prelude/struct.PyAny.html
-/// [5]: https://pyo3.rs/main/class/protocols.html#garbage-collector-integration
+/// [5]: https://pyo3.rs/latest/class/protocols.html#garbage-collector-integration
 /// [6]: https://docs.python.org/3/library/weakref.html
 /// [7]: https://doc.rust-lang.org/nomicon/leaking.html
 /// [8]: std::rc::Rc
@@ -175,17 +175,17 @@ pub fn pyclass_with_inventory(attr: TokenStream, input: TokenStream) -> TokenStr
 /// multiple `#[pymethods]` blocks for a single `#[pyclass]`.
 /// This will add a transitive dependency on the [`inventory`][3] crate.
 ///
-/// [1]: https://pyo3.rs/main/class.html#instance-methods
-/// [2]: https://pyo3.rs/main/features.html#multiple-pymethods
+/// [1]: https://pyo3.rs/latest/class.html#instance-methods
+/// [2]: https://pyo3.rs/latest/features.html#multiple-pymethods
 /// [3]: https://docs.rs/inventory/
-/// [4]: https://pyo3.rs/main/class.html#constructor
-/// [5]: https://pyo3.rs/main/class.html#object-properties-using-getter-and-setter
-/// [6]: https://pyo3.rs/main/class.html#static-methods
-/// [7]: https://pyo3.rs/main/class.html#class-methods
-/// [8]: https://pyo3.rs/main/class.html#callable-objects
-/// [9]: https://pyo3.rs/main/class.html#class-attributes
-/// [10]: https://pyo3.rs/main/class.html#method-arguments
-/// [11]: https://pyo3.rs/main/class.html#object-properties-using-pyo3get-set
+/// [4]: https://pyo3.rs/latest/class.html#constructor
+/// [5]: https://pyo3.rs/latest/class.html#object-properties-using-getter-and-setter
+/// [6]: https://pyo3.rs/latest/class.html#static-methods
+/// [7]: https://pyo3.rs/latest/class.html#class-methods
+/// [8]: https://pyo3.rs/latest/class.html#callable-objects
+/// [9]: https://pyo3.rs/latest/class.html#class-attributes
+/// [10]: https://pyo3.rs/latest/class.html#method-arguments
+/// [11]: https://pyo3.rs/latest/class.html#object-properties-using-pyo3get-set
 #[proc_macro_attribute]
 pub fn pymethods(_: TokenStream, input: TokenStream) -> TokenStream {
     pymethods_impl(input, PyClassMethodsType::Specialization)
@@ -214,17 +214,17 @@ pub fn pymethods(_: TokenStream, input: TokenStream) -> TokenStream {
 /// multiple `#[pymethods]` blocks for a single `#[pyclass]`.
 /// This will add a transitive dependency on the [`inventory`][3] crate.
 ///
-/// [1]: https://pyo3.rs/main/class.html#instance-methods
-/// [2]: https://pyo3.rs/main/features.html#multiple-pymethods
+/// [1]: https://pyo3.rs/latest/class.html#instance-methods
+/// [2]: https://pyo3.rs/latest/features.html#multiple-pymethods
 /// [3]: https://docs.rs/inventory/
-/// [4]: https://pyo3.rs/main/class.html#constructor
-/// [5]: https://pyo3.rs/main/class.html#object-properties-using-getter-and-setter
-/// [6]: https://pyo3.rs/main/class.html#static-methods
-/// [7]: https://pyo3.rs/main/class.html#class-methods
-/// [8]: https://pyo3.rs/main/class.html#callable-objects
-/// [9]: https://pyo3.rs/main/class.html#class-attributes
-/// [10]: https://pyo3.rs/main/class.html#method-arguments
-/// [11]: https://pyo3.rs/main/class.html#object-properties-using-pyo3get-set
+/// [4]: https://pyo3.rs/latest/class.html#constructor
+/// [5]: https://pyo3.rs/latest/class.html#object-properties-using-getter-and-setter
+/// [6]: https://pyo3.rs/latest/class.html#static-methods
+/// [7]: https://pyo3.rs/latest/class.html#class-methods
+/// [8]: https://pyo3.rs/latest/class.html#callable-objects
+/// [9]: https://pyo3.rs/latest/class.html#class-attributes
+/// [10]: https://pyo3.rs/latest/class.html#method-arguments
+/// [11]: https://pyo3.rs/latest/class.html#object-properties-using-pyo3get-set
 #[proc_macro_attribute]
 pub fn pymethods_with_inventory(_: TokenStream, input: TokenStream) -> TokenStream {
     pymethods_impl(input, PyClassMethodsType::Inventory)
@@ -242,7 +242,7 @@ pub fn pymethods_with_inventory(_: TokenStream, input: TokenStream) -> TokenStre
 ///
 /// For more on exposing functions see the [function section of the guide][1].
 ///
-/// [1]: https://pyo3.rs/main/function.html
+/// [1]: https://pyo3.rs/latest/function.html
 #[proc_macro_attribute]
 pub fn pyfunction(attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as syn::ItemFn);

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -40,7 +40,7 @@ pub unsafe trait PyNativeType: Sized {
 ///  - [`Py::as_ref`], to borrow a GIL-bound reference to the contained object.
 ///  - [`Py::borrow`], [`Py::try_borrow`], [`Py::borrow_mut`], or [`Py::try_borrow_mut`],
 /// to get a (mutable) reference to a contained pyclass, using a scheme similar to std's [`RefCell`].
-/// See the [`PyCell` guide entry](https://pyo3.rs/main/class.html#pycell-and-interior-mutability)
+/// See the [`PyCell` guide entry](https://pyo3.rs/latest/class.html#pycell-and-interior-mutability)
 /// for more information.
 ///  - You can call methods directly on `Py` with [`Py::call`], [`Py::call_method`] and friends.
 /// These require passing in the [`Python<'py>`](crate::Python) token but are otherwise similar to the corresponding
@@ -66,7 +66,7 @@ pub unsafe trait PyNativeType: Sized {
 ///             // `py` will only last for this scope.
 ///
 ///             // `&PyDict` derives its lifetime from `py` and
-///             // so won't be able to outlive this closure.           
+///             // so won't be able to outlive this closure.
 ///             let dict: &PyDict = PyDict::new(py);
 ///
 ///             // because `Foo` contains `dict` its lifetime

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! as the GIL is held, which is why using them doesn't require a  [`Python<'py>`](crate::Python) token.
 //!  The underlying Python object, if mutable, can be mutated through any reference.
 //!
-//! See the [guide](https://pyo3.rs/main/types.html) for an explanation of the different Python object types.
+//! See the [guide](https://pyo3.rs/latest/types.html) for an explanation of the different Python object types.
 //!
 //! ## The GIL-independent types
 //!
@@ -48,7 +48,7 @@
 //!
 //! PyO3 uses [feature flags](https://doc.rust-lang.org/cargo/reference/features.html)
 //! to enable you to opt-in to additional functionality. For a detailed description, see
-//! the [Features Reference chapter of the guide](https://pyo3.rs/main/features.html#features-reference).
+//! the [Features Reference chapter of the guide](https://pyo3.rs/latest/features.html#features-reference).
 //!
 //! ## Default feature flags
 //!
@@ -122,7 +122,7 @@
 //!
 //! Building with PyPy is also possible (via cpyext) for Python 3.6,
 //! targeted PyPy version is 7.3+. Please refer to the
-//! [pypy section](https://pyo3.rs/main/building_and_distribution/pypy.html)
+//! [pypy section](https://pyo3.rs/latest/building_and_distribution/pypy.html)
 //! in the guide for more information.
 //!
 //! # Example: Building a native Python module
@@ -130,7 +130,7 @@
 //! To build, test and publish your crate as a Python module, it is recommended that you use
 //! [maturin](https://github.com/PyO3/maturin) or
 //! [setuptools-rust](https://github.com/PyO3/setuptools-rust). You can also do this manually. See the
-//! [Building and Distribution chapter of the guide](https://pyo3.rs/main/building_and_distribution.html)
+//! [Building and Distribution chapter of the guide](https://pyo3.rs/latest/building_and_distribution.html)
 //! for more information.
 //!
 //! Add these files to your crate's root:

--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -7,7 +7,7 @@ use std::cell::UnsafeCell;
 /// Unlike `once_cell::sync` which blocks threads to achieve thread safety, this implementation
 /// uses the Python GIL to mediate concurrent access. This helps in cases where `once_sync` or
 /// `lazy_static`'s synchronization strategy can lead to deadlocks when interacting with the Python
-/// GIL. For an example, see [the FAQ section](https://pyo3.rs/main/faq.html) of the guide.
+/// GIL. For an example, see [the FAQ section](https://pyo3.rs/latest/faq.html) of the guide.
 ///
 /// # Examples
 ///

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -11,7 +11,7 @@ use std::cell::UnsafeCell;
 use std::cmp::Ordering;
 use std::os::raw::c_int;
 
-/// Represents any Python object.  
+/// Represents any Python object.
 ///
 /// It currently only appears as a *reference*, `&PyAny`,
 /// with a lifetime that represents the scope during which the GIL is held.
@@ -31,7 +31,7 @@ use std::os::raw::c_int;
 /// It can be cast to a concrete type with PyAny::downcast (for native Python types only)
 /// and FromPyObject::extract. See their documentation for more information.
 ///
-/// See [the guide](https://pyo3.rs/main/types.html) for an explanation
+/// See [the guide](https://pyo3.rs/latest/types.html) for an explanation
 /// of the different Python object types.
 #[repr(transparent)]
 pub struct PyAny(UnsafeCell<ffi::PyObject>);
@@ -378,7 +378,7 @@ impl PyAny {
     ///
     /// value = add(1,2)
     /// assert value == 3
-    /// ```   
+    /// ```
     pub fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<&PyAny> {
         self.call(args, None)
     }

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -272,7 +272,7 @@ impl PyModule {
     /// make an *instance* of `Foo` (or *get* one for that matter, as we haven't exported
     /// anything that can return instances of `Foo`).
     ///
-    /// [1]: https://pyo3.rs/main/class.html#constructor
+    /// [1]: https://pyo3.rs/latest/class.html#constructor
     pub fn add_class<T>(&self) -> PyResult<()>
     where
         T: PyClass,


### PR DESCRIPTION
After #1734 I think it's desirable to link to `pyo3.rs/latest` (i.e. most recent released guide) instead of `pyo3.rs/main` within crate documentation. I guess we could also use the `#[doc]` attributes, but that's quite painful to maintain for a lot of these links.

cc @mejrs - I'd be interested to hear what you think about doing this?