### PR TITLE
testing: use `mod tests` instead of `mod test`

### DIFF
--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -459,7 +459,7 @@ fn type_is_pymodule(ty: &syn::Type) -> bool {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{Argument, PyFunctionSignature};
     use proc_macro2::TokenStream;
     use quote::quote;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -647,7 +647,7 @@ impl_element!(f32, Float);
 impl_element!(f64, Float);
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::PyBuffer;
     use crate::ffi;
     use crate::Python;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -543,7 +543,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::types::{IntoPyDict, PyAny, PyDict, PyList};
     use crate::{Python, ToPyObject};
 

--- a/src/conversions/array.rs
+++ b/src/conversions/array.rs
@@ -107,7 +107,7 @@ mod min_const_generics {
     }
 
     #[cfg(test)]
-    mod test {
+    mod tests {
         use super::*;
         use std::{
             panic,
@@ -257,7 +257,7 @@ fn invalid_sequence_length(expected: usize, actual: usize) -> PyErr {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::{PyResult, Python};
 
     #[test]

--- a/src/conversions/osstr.rs
+++ b/src/conversions/osstr.rs
@@ -152,7 +152,7 @@ impl<'a> IntoPy<PyObject> for &'a OsString {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::{types::PyString, IntoPy, PyObject, Python, ToPyObject};
     use std::fmt::Debug;
     use std::{

--- a/src/conversions/path.rs
+++ b/src/conversions/path.rs
@@ -73,7 +73,7 @@ impl<'a> IntoPy<PyObject> for &'a PathBuf {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::{types::PyString, IntoPy, PyObject, Python, ToPyObject};
     use std::borrow::Cow;
     use std::fmt::Debug;

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -332,7 +332,7 @@ pub mod socket {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{PyException, PyUnicodeDecodeError};
     use crate::types::{IntoPyDict, PyDict};
     use crate::{PyErr, Python};

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -495,7 +495,7 @@ impl EnsureGIL {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{gil_is_acquired, GILPool, GIL_COUNT, OWNED_OBJECTS, POOL};
     use crate::{ffi, gil, AsPyPointer, IntoPyPointer, PyObject, Python, ToPyObject};
     use std::ptr::NonNull;

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -862,7 +862,7 @@ impl PyObject {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{Py, PyObject};
     use crate::types::PyDict;
     use crate::{ffi, AsPyPointer, Python};

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -51,7 +51,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::types::PyDict;
 

--- a/src/num_bigint.rs
+++ b/src/num_bigint.rs
@@ -144,7 +144,7 @@ bigint_conversion!(
 );
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::types::{PyDict, PyModule};
     use indoc::indoc;

--- a/src/num_complex.rs
+++ b/src/num_complex.rs
@@ -168,7 +168,7 @@ complex_conversion!(f32);
 complex_conversion!(f64);
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[allow(clippy::float_cmp)] // The test wants to ensure that no precision was lost on the Python round-trip

--- a/src/python.rs
+++ b/src/python.rs
@@ -678,7 +678,7 @@ impl<'p> Python<'p> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use crate::types::{IntoPyDict, PyList};
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -682,7 +682,7 @@ impl PyAny {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::{
         types::{IntoPyDict, PyList, PyLong, PyModule},
         Python, ToPyObject,

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -58,7 +58,7 @@ impl<'source> FromPyObject<'source> for bool {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::types::{PyAny, PyBool};
     use crate::Python;
     use crate::ToPyObject;

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -165,7 +165,7 @@ impl PyByteArray {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::exceptions;
     use crate::types::PyByteArray;
     use crate::{PyObject, Python};

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -114,7 +114,7 @@ impl<'a> FromPyObject<'a> for &'a [u8] {
     }
 }
 #[cfg(test)]
-mod test {
+mod tests {
     use super::PyBytes;
     use crate::FromPyObject;
     use crate::Python;

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -123,7 +123,7 @@ mod not_limited_impls {
     }
 
     #[cfg(test)]
-    mod test {
+    mod tests {
         use super::PyComplex;
         use crate::Python;
         use assert_approx_eq::assert_approx_eq;
@@ -204,7 +204,7 @@ mod not_limited_impls {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::PyComplex;
     use crate::Python;
     use assert_approx_eq::assert_approx_eq;

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -456,7 +456,7 @@ mod hashbrown_hashmap_conversion {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::conversion::IntoPy;
     use crate::types::dict::IntoPyDict;
     #[cfg(not(PyPy))]

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -80,7 +80,7 @@ impl<'source> FromPyObject<'source> for f32 {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     #[cfg(not(Py_LIMITED_API))]
     use crate::ffi::PyFloat_AS_DOUBLE;
     #[cfg(not(Py_LIMITED_API))]

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -207,7 +207,7 @@ where
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::types::PyList;
     use crate::Python;
     use crate::{IntoPy, PyObject, PyTryFrom, ToPyObject};

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -420,7 +420,7 @@ impl PyModule {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::{types::PyModule, Python};
 
     #[test]

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -358,7 +358,7 @@ mod test_128bit_intergers {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::Python;
     use crate::ToPyObject;
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -330,7 +330,7 @@ impl<'v> PyTryFrom<'v> for PySequence {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::types::PySequence;
     use crate::AsPyPointer;
     use crate::Python;

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -405,7 +405,7 @@ mod hashbrown_hashset_conversion {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::{PyFrozenSet, PySet};
     use crate::{IntoPy, PyObject, PyTryFrom, Python, ToPyObject};
     use std::collections::{BTreeSet, HashSet};

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -191,7 +191,7 @@ impl FromPyObject<'_> for char {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::PyString;
     use crate::Python;
     use crate::{FromPyObject, PyObject, PyTryFrom, ToPyObject};

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -315,7 +315,7 @@ tuple_conversion!(
 );
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::types::{PyAny, PyTuple};
     use crate::{PyTryFrom, Python, ToPyObject};
     use std::collections::HashSet;


### PR DESCRIPTION
At the moment we have a mix of `mod test` and `mod tests` around the codebase. 

`mod tests` is what official docs suggest (e.g. https://doc.rust-lang.org/book/ch11-01-writing-tests.html) 

So just a tiny tidy-up for consistency.