### PR TITLE
readme: slightly improve getting started notes

### DIFF
--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -46,7 +46,7 @@ You can also symlink (or copy) and rename the shared library from the `target` f
 - on Windows, rename  `libyour_module.dll` to `your_module.pyd`.
 - on Linux, rename `libyour_module.so` to `your_module.so`.
 
-You can then open a Python shell in the same folder and you'll be able to use `import your_module`.
+You can then open a Python shell in the same folder and you'll be able to run `import your_module`.
 
 ## `Py_LIMITED_API`/`abi3`
 


### PR DESCRIPTION
This PR tweaks the README a bit to prefer `maturin` to a manual build for users getting started with PyO3 for the first time.

Especially if we have to require users to add macOS config for manual `extension-module` builds (as per #1719), I think it's nice to give users something simple like `maturin` for their first experiments with PyO3.