### PR TITLE
pyo3-pytests: don't set profile in Cargo.toml

### DIFF
--- a/examples/pyo3-pytests/Cargo.toml
+++ b/examples/pyo3-pytests/Cargo.toml
@@ -25,9 +25,3 @@ classifier=[
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
 ]
-
-# Don't optimize the release build (built by maturin / tox) for this module, as
-# it's a test module.
-[profile.release]
-debug = true
-opt-level = 0


### PR DESCRIPTION
I added this in #1731 but Cargo actually warns me that it's not supported, so removing it again.