### PR TITLE
pyo3-macros-backend: support macros inside doc attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Add `PyList::get_item_unchecked` and `PyTuple::get_item_unchecked` to get items without bounds checks. [#1733](https://github.com/PyO3/pyo3/pull/1733)
+- Support `#[doc = include_str!(...)]` attributes on Rust 1.54 and up. [#1746](https://github.com/PyO3/pyo3/issues/1746)
 - Add `PyAny::py` as a convenience for `PyNativeType::py`. [#1751](https://github.com/PyO3/pyo3/pull/1751)
 - Add implementation of `std::ops::Index<usize>` for `PyList`, `PyTuple` and `PySequence`. [#1825](https://github.com/PyO3/pyo3/pull/1825)
 - Add range indexing implementations of `std::ops::Index` for `PyList`, `PyTuple` and `PySequence`. [#1829](https://github.com/PyO3/pyo3/pull/1829)

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -5,6 +5,7 @@ use crate::{
     attributes::{self, take_pyo3_options},
     deprecations::Deprecations,
     pyfunction::{impl_wrap_pyfunction, PyFunctionOptions},
+    utils::PythonDoc,
 };
 use crate::{
     attributes::{is_attribute_ident, take_attributes, NameAttribute},
@@ -62,11 +63,10 @@ impl PyModuleOptions {
 
 /// Generates the function that is called by the python interpreter to initialize the native
 /// module
-pub fn py_init(fnname: &Ident, options: PyModuleOptions, doc: syn::LitStr) -> TokenStream {
+pub fn py_init(fnname: &Ident, options: PyModuleOptions, doc: PythonDoc) -> TokenStream {
     let name = options.name.unwrap_or_else(|| fnname.unraw());
     let deprecations = options.deprecations;
     let cb_name = Ident::new(&format!("PyInit_{}", name), Span::call_site());
-    assert!(doc.value().ends_with('\0'));
 
     quote! {
         #[no_mangle]

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -7,7 +7,7 @@ use crate::attributes::{
 use crate::deprecations::Deprecations;
 use crate::pyimpl::PyClassMethodsType;
 use crate::pymethod::{impl_py_getter_def, impl_py_setter_def, PropertyType};
-use crate::utils::{self, unwrap_group};
+use crate::utils::{self, unwrap_group, PythonDoc};
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::ext::IdentExt;
@@ -230,7 +230,7 @@ pub fn build_py_class(
             .text_signature
             .as_ref()
             .map(|attr| (get_class_python_name(&class.ident, args), attr)),
-    )?;
+    );
 
     ensure_spanned!(
         class.generics.params.is_empty(),
@@ -371,7 +371,7 @@ fn get_class_python_name<'a>(cls: &'a syn::Ident, attr: &'a PyClassArgs) -> &'a 
 fn impl_class(
     cls: &syn::Ident,
     attr: &PyClassArgs,
-    doc: syn::LitStr,
+    doc: PythonDoc,
     field_options: Vec<(&syn::Field, FieldPyO3Options)>,
     methods_type: PyClassMethodsType,
     deprecations: Deprecations,

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -406,7 +406,7 @@ pub fn impl_wrap_pyfunction(
             .text_signature
             .as_ref()
             .map(|attr| (&python_name, attr)),
-    )?;
+    );
 
     let function_wrapper_ident = function_wrapper_ident(&func.sig.ident);
 

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use crate::attributes::NameAttribute;
-use crate::utils::ensure_not_async_fn;
+use crate::utils::{ensure_not_async_fn, PythonDoc};
 use crate::{deprecations::Deprecations, utils};
 use crate::{
     method::{FnArg, FnSpec, FnType, SelfType},
@@ -355,12 +355,10 @@ impl PropertyType<'_> {
         }
     }
 
-    fn doc(&self) -> Cow<syn::LitStr> {
+    fn doc(&self) -> Cow<PythonDoc> {
         match self {
             PropertyType::Descriptor { field, .. } => {
-                let doc = utils::get_doc(&field.attrs, None)
-                    .unwrap_or_else(|_| syn::LitStr::new("", Span::call_site()));
-                Cow::Owned(doc)
+                Cow::Owned(utils::get_doc(&field.attrs, None))
             }
             PropertyType::Function { spec, .. } => Cow::Borrowed(&spec.doc),
         }

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -52,10 +52,7 @@ pub fn pymodule(attr: TokenStream, input: TokenStream) -> TokenStream {
         return err.to_compile_error().into();
     }
 
-    let doc = match get_doc(&ast.attrs, None) {
-        Ok(doc) => doc,
-        Err(err) => return err.to_compile_error().into(),
-    };
+    let doc = get_doc(&ast.attrs, None);
 
     let expanded = py_init(&ast.sig.ident, options, doc);
 

--- a/tests/not_msrv/requires_1_54.rs
+++ b/tests/not_msrv/requires_1_54.rs
@@ -1,0 +1,36 @@
+use pyo3::prelude::*;
+use pyo3::types::IntoPyDict;
+
+#[macro_use]
+#[path = "../common.rs"]
+mod common;
+
+#[pyclass]
+/// The MacroDocs class.
+#[doc = concat!("Some macro ", "class ", "docs.")]
+/// A very interesting type!
+struct MacroDocs {}
+
+#[pymethods]
+impl MacroDocs {
+    #[doc = concat!("A macro ", "example.")]
+    /// With mixed doc types.
+    fn macro_doc(&self) {}
+}
+
+#[test]
+fn meth_doc() {
+    Python::with_gil(|py| {
+        let d = [("C", py.get_type::<MacroDocs>())].into_py_dict(py);
+        py_assert!(
+            py,
+            *d,
+            "C.__doc__ == 'The MacroDocs class.\\nSome macro class docs.\\nA very interesting type!'"
+        );
+        py_assert!(
+            py,
+            *d,
+            "C.macro_doc.__doc__ == 'A macro example.\\nWith mixed doc types.'"
+        );
+    });
+}

--- a/tests/test_not_msrv.rs
+++ b/tests/test_not_msrv.rs
@@ -1,0 +1,10 @@
+//! Functionality which is not only not supported on MSRV,
+//! but can't even be cfg-ed out on MSRV because the compiler doesn't support
+//! the syntax.
+
+// TODO(#1782) rustversion attribute can't go on modules until Rust 1.42, so this
+// funky dance has to happen...
+mod requires_1_54 {
+    #[rustversion::since(1.54)]
+    include!("not_msrv/requires_1_54.rs");
+}


### PR DESCRIPTION
~~WIP. (Needs tests, CHANGELOG entry.)~~

In Rust 1.54 it's now valid to write 

```
#![doc = include_str!("README.md")]
struct Foo {}
```

This PR attempts to support these macros-inside-docs for `pyclass` and the other PyO3 macros. It works by collecting all the `#[doc]` attributes into one big `concat!` macro invocation, forwarding all the inner macros through so that `concat!` can evaluate them all and create the final docstring.