### PR TITLE
pyany: add PyAny::py()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `PyAny::py()` as a convenience for `PyNativeType::py()`. [#1751](https://github.com/PyO3/pyo3/pull/1751)
+
 ### Changed
 
 - Change `PyErr::fetch()` to return `Option<PyErr>`. [#1717](https://github.com/PyO3/pyo3/pull/1717)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -293,7 +293,7 @@ that inherit native types. Even in such cases, you can unsafely get a base class
 # #[cfg(not(Py_LIMITED_API))] {
 # use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use pyo3::{AsPyPointer, PyNativeType};
+use pyo3::AsPyPointer;
 use std::collections::HashMap;
 
 #[pyclass(extends=PyDict)]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -18,8 +18,7 @@
 
 //! `PyBuffer` implementation
 use crate::{
-    err, exceptions::PyBufferError, ffi, AsPyPointer, FromPyObject, PyAny, PyNativeType, PyResult,
-    Python,
+    err, exceptions::PyBufferError, ffi, AsPyPointer, FromPyObject, PyAny, PyResult, Python,
 };
 use std::marker::PhantomData;
 use std::os::raw;

--- a/src/conversions/array.rs
+++ b/src/conversions/array.rs
@@ -35,7 +35,7 @@ mod min_const_generics {
         for<'a> T: Default + FromPyObject<'a> + crate::buffer::Element,
     {
         fn extract(obj: &'source PyAny) -> PyResult<Self> {
-            use crate::{AsPyPointer, PyNativeType};
+            use crate::AsPyPointer;
             // first try buffer protocol
             if unsafe { crate::ffi::PyObject_CheckBuffer(obj.as_ptr()) } == 1 {
                 if let Ok(buf) = crate::buffer::PyBuffer::get(obj) {

--- a/src/conversions/osstr.rs
+++ b/src/conversions/osstr.rs
@@ -1,7 +1,6 @@
 use crate::types::PyString;
 #[cfg(windows)]
 use crate::PyErr;
-use crate::PyNativeType;
 use crate::{
     ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, PyTryFrom, Python,
     ToPyObject,

--- a/src/conversions/path.rs
+++ b/src/conversions/path.rs
@@ -1,5 +1,5 @@
 use crate::types::PyType;
-use crate::{FromPyObject, IntoPy, PyAny, PyNativeType, PyObject, PyResult, Python, ToPyObject};
+use crate::{FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};

--- a/src/derive_utils.rs
+++ b/src/derive_utils.rs
@@ -6,7 +6,6 @@
 
 use crate::err::{PyErr, PyResult};
 use crate::exceptions::PyTypeError;
-use crate::instance::PyNativeType;
 use crate::pyclass::PyClass;
 use crate::types::{PyAny, PyDict, PyModule, PyString, PyTuple};
 use crate::{ffi, PyCell, Python};

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -8,8 +8,7 @@ use crate::{
     ffi,
 };
 use crate::{
-    AsPyPointer, FromPyPointer, IntoPy, Py, PyAny, PyNativeType, PyObject, Python,
-    ToBorrowedObject, ToPyObject,
+    AsPyPointer, FromPyPointer, IntoPy, Py, PyAny, PyObject, Python, ToBorrowedObject, ToPyObject,
 };
 use std::borrow::Cow;
 use std::cell::UnsafeCell;

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -30,7 +30,7 @@ macro_rules! impl_exception_boilerplate {
         impl std::error::Error for $name {
             fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
                 unsafe {
-                    use $crate::{AsPyPointer, PyNativeType};
+                    use $crate::AsPyPointer;
                     let cause: &$crate::exceptions::PyBaseException = self
                         .py()
                         .from_owned_ptr_or_opt($crate::ffi::PyException_GetCause(self.as_ptr()))?;

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -19,6 +19,7 @@ use std::ptr::NonNull;
 /// types.
 pub unsafe trait PyNativeType: Sized {
     /// Returns a GIL marker constrained to the lifetime of this type.
+    #[inline]
     fn py(&self) -> Python {
         unsafe { Python::assume_gil_acquired() }
     }

--- a/src/num_bigint.rs
+++ b/src/num_bigint.rs
@@ -62,8 +62,8 @@
 //! ```
 
 use crate::{
-    err, ffi, types::*, AsPyPointer, FromPyObject, IntoPy, Py, PyAny, PyErr, PyNativeType,
-    PyObject, PyResult, Python, ToPyObject,
+    err, ffi, types::*, AsPyPointer, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult,
+    Python, ToPyObject,
 };
 
 use num_bigint::{BigInt, BigUint};

--- a/src/num_complex.rs
+++ b/src/num_complex.rs
@@ -100,8 +100,8 @@
 //! assert result == [complex(1,-1), complex(-2,0)]
 //! ```
 use crate::{
-    ffi, types::PyComplex, AsPyPointer, FromPyObject, PyAny, PyErr, PyNativeType, PyObject,
-    PyResult, Python, ToPyObject,
+    ffi, types::PyComplex, AsPyPointer, FromPyObject, PyAny, PyErr, PyObject, PyResult, Python,
+    ToPyObject,
 };
 use num_complex::Complex;
 use std::os::raw::c_double;

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -39,7 +39,7 @@ pub unsafe trait PyTypeInfo: Sized {
     const MODULE: Option<&'static str>;
 
     /// Utility type to make Py::as_ref work.
-    type AsRefTarget: crate::PyNativeType;
+    type AsRefTarget: PyNativeType;
 
     /// PyTypeObject instance for this type.
     fn type_object_raw(py: Python) -> *mut ffi::PyTypeObject;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -6,7 +6,7 @@ use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::exceptions::PyTypeError;
 use crate::type_object::PyTypeObject;
 use crate::types::{PyDict, PyIterator, PyList, PyString, PyTuple, PyType};
-use crate::{err, ffi, Py, PyNativeType, PyObject};
+use crate::{err, ffi, Py, PyNativeType, PyObject, Python};
 use std::cell::UnsafeCell;
 use std::cmp::Ordering;
 use std::os::raw::c_int;
@@ -675,6 +675,12 @@ impl PyAny {
     /// This is equivalent to the Python expression `isinstance(self, T)`.
     pub fn is_instance<T: PyTypeObject>(&self) -> PyResult<bool> {
         T::type_object(self.py()).is_instance(self)
+    }
+
+    /// Returns a GIL marker constrained to the lifetime of this type.
+    #[inline]
+    pub fn py(&self) -> Python<'_> {
+        PyNativeType::py(self)
     }
 }
 

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 use crate::err::{PyErr, PyResult};
-use crate::instance::PyNativeType;
 use crate::{ffi, AsPyPointer, Py, PyAny, Python};
 use std::os::raw::c_char;
 use std::slice;

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -40,7 +40,6 @@ impl PyComplex {
 #[cfg_attr(docsrs, doc(cfg(not(any(Py_LIMITED_API, PyPy)))))]
 mod not_limited_impls {
     use super::*;
-    use crate::instance::PyNativeType;
     use std::ops::{Add, Div, Mul, Neg, Sub};
 
     impl PyComplex {

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -5,8 +5,8 @@ use crate::types::{PyAny, PyList};
 #[cfg(not(PyPy))]
 use crate::IntoPyPointer;
 use crate::{
-    ffi, AsPyPointer, FromPyObject, IntoPy, PyNativeType, PyObject, PyTryFrom, Python,
-    ToBorrowedObject, ToPyObject,
+    ffi, AsPyPointer, FromPyObject, IntoPy, PyObject, PyTryFrom, Python, ToBorrowedObject,
+    ToPyObject,
 };
 use std::collections::{BTreeMap, HashMap};
 use std::ptr::NonNull;

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -2,8 +2,7 @@
 //
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 use crate::{
-    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyErr, PyNativeType, PyObject, PyResult, Python,
-    ToPyObject,
+    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
 };
 use std::os::raw::c_double;
 

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -2,7 +2,7 @@
 //
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
-use crate::{ffi, AsPyPointer, PyAny, PyErr, PyNativeType, PyResult, Python};
+use crate::{ffi, AsPyPointer, PyAny, PyErr, PyResult, Python};
 #[cfg(any(not(Py_LIMITED_API), Py_3_8))]
 use crate::{PyDowncastError, PyTryFrom};
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -5,8 +5,7 @@
 use crate::err::{self, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::{
-    AsPyPointer, IntoPy, IntoPyPointer, PyAny, PyNativeType, PyObject, Python, ToBorrowedObject,
-    ToPyObject,
+    AsPyPointer, IntoPy, IntoPyPointer, PyAny, PyObject, Python, ToBorrowedObject, ToPyObject,
 };
 
 /// Represents a Python `list`.

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -6,7 +6,6 @@ use crate::callback::IntoPyCallbackOutput;
 use crate::err::{PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi;
-use crate::instance::PyNativeType;
 use crate::pyclass::PyClass;
 use crate::type_object::PyTypeObject;
 use crate::types::{PyAny, PyDict, PyList};

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -3,8 +3,8 @@
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
 use crate::{
-    exceptions, ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyErr, PyNativeType, PyObject,
-    PyResult, Python, ToPyObject,
+    exceptions, ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
+    ToPyObject,
 };
 use std::convert::TryFrom;
 use std::i64;

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -2,7 +2,6 @@
 
 use crate::err::{self, PyDowncastError, PyErr, PyResult};
 use crate::ffi::{self, Py_ssize_t};
-use crate::instance::PyNativeType;
 use crate::types::{PyAny, PyList, PyTuple};
 use crate::AsPyPointer;
 use crate::{FromPyObject, PyTryFrom, ToBorrowedObject};

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -5,8 +5,7 @@ use crate::err::{self, PyErr, PyResult};
 #[cfg(Py_LIMITED_API)]
 use crate::types::PyIterator;
 use crate::{
-    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyNativeType, PyObject, Python,
-    ToBorrowedObject, ToPyObject,
+    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, Python, ToBorrowedObject, ToPyObject,
 };
 use std::cmp;
 use std::collections::{BTreeSet, HashSet};

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -2,7 +2,6 @@
 
 use crate::err::{PyErr, PyResult};
 use crate::ffi::{self, Py_ssize_t};
-use crate::instance::PyNativeType;
 use crate::{AsPyPointer, PyAny, PyObject, Python, ToPyObject};
 use std::os::raw::c_long;
 

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -2,8 +2,8 @@
 
 use crate::types::PyBytes;
 use crate::{
-    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyNativeType, PyObject, PyResult, PyTryFrom,
-    Python, ToPyObject,
+    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, PyTryFrom, Python,
+    ToPyObject,
 };
 use std::borrow::Cow;
 use std::os::raw::c_char;

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -2,8 +2,8 @@
 
 use crate::ffi::{self, Py_ssize_t};
 use crate::{
-    exceptions, AsPyPointer, FromPyObject, IntoPy, IntoPyPointer, Py, PyAny, PyErr, PyNativeType,
-    PyObject, PyResult, PyTryFrom, Python, ToPyObject,
+    exceptions, AsPyPointer, FromPyObject, IntoPy, IntoPyPointer, Py, PyAny, PyErr, PyObject,
+    PyResult, PyTryFrom, Python, ToPyObject,
 };
 
 /// Represents a Python `tuple` object.

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -3,7 +3,6 @@
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
 use crate::err::{self, PyResult};
-use crate::instance::PyNativeType;
 use crate::type_object::PyTypeObject;
 use crate::{ffi, AsPyPointer, PyAny, Python};
 

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -4,7 +4,6 @@ use pyo3::class::basic::CompareOp;
 use pyo3::class::*;
 use pyo3::prelude::*;
 use pyo3::py_run;
-use pyo3::PyNativeType;
 
 mod common;
 

--- a/tests/ui/wrong_aspyref_lifetimes.rs
+++ b/tests/ui/wrong_aspyref_lifetimes.rs
@@ -1,4 +1,4 @@
-use pyo3::{types::PyDict, Py, PyNativeType, Python};
+use pyo3::{types::PyDict, Py, Python};
 
 fn main() {
     let gil = Python::acquire_gil();


### PR DESCRIPTION
Adds `PyAny::py()` as a shortcut to get the `Python` GIL token without importing the `PyNativeType` trait.

I think this is a nice convenience as well as maybe being more discoverable for users (not many seem to know about the `PyNativeType` trait).

It'll probably make a few "unused import" warnings when users upgrade to a PyO3 containing this, so I wonder if it's nicer if this waits for 0.15?