### PR TITLE
remove some of python::acquire_gil usage 

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -828,9 +828,7 @@ where
     T::AsRefTarget: std::fmt::Display,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        Python::with_gil(|py| {
-            std::fmt::Display::fmt(self.as_ref(py), f)
-        })
+        Python::with_gil(|py| std::fmt::Display::fmt(self.as_ref(py), f))
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -828,9 +828,9 @@ where
     T::AsRefTarget: std::fmt::Display,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        std::fmt::Display::fmt(self.as_ref(py), f)
+        Python::with_gil(|py| {
+            std::fmt::Display::fmt(self.as_ref(py), f)
+        })
     }
 }
 

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -15,12 +15,13 @@ use crate::{PyDowncastError, PyTryFrom};
 /// use pyo3::types::PyIterator;
 ///
 /// # fn main() -> PyResult<()> {
-/// let gil = Python::acquire_gil();
-/// let py = gil.python();
-/// let list = py.eval("iter([1, 2, 3, 4])", None, None)?;
-/// let numbers: PyResult<Vec<usize>> = list.iter()?.map(|i| i.and_then(PyAny::extract::<usize>)).collect();
-/// let sum: usize = numbers?.iter().sum();
-/// assert_eq!(sum, 10);
+/// Python::with_gil(|py| ->  PyResult<()> {
+///     let list = py.eval("iter([1, 2, 3, 4])", None, None)?;
+///     let numbers: PyResult<Vec<usize>> = list.iter()?.map(|i| i.and_then(PyAny::extract::<usize>)).collect();
+///     let sum: usize = numbers?.iter().sum();
+///     assert_eq!(sum, 10);
+///     Ok(())
+/// });
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
This addresses every use of `acquire_gil` other than tests.
