### PR TITLE
pypy: remove workaround for 7.3.4

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -133,16 +133,6 @@ fn emit_cargo_configuration(interpreter_config: &InterpreterConfig) -> Result<()
             if let Some(libdir) = &interpreter_config.libdir {
                 println!("cargo:rustc-link-search=native={}", libdir);
             }
-            if interpreter_config.implementation == PythonImplementation::PyPy {
-                // PyPy 7.3.4 changed LIBDIR to point to base_prefix/lib as a regression, so need
-                // to hard-code /bin search path too: https://foss.heptapod.net/pypy/pypy/-/issues/3442
-                //
-                // TODO: this workaround can probably be removed when PyPy 7.3.5 is released (and we
-                // can call it a PyPy bug).
-                if let Some(base_prefix) = &interpreter_config.base_prefix {
-                    println!("cargo:rustc-link-search=native={}/bin", base_prefix);
-                }
-            }
         }
         _ => {}
     }


### PR DESCRIPTION
Removes a workaround to locate libpypy-c on PyPy 7.3.4 from our build script. PyPy 7.3.5 has been released for a while and resolved the regression.

As extension modules don't link to libpypy-c and PyPy doesn't support embedding, I think that this was unlikely to be used by anyone other than our CI.