### PR TITLE
pyo3-build-config: support "config files"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix regression in 0.14.0 leading to incorrect code coverage being computed for `#[pyfunction]`s. [#1726](https://github.com/PyO3/pyo3/pull/1726)
 - Fix incorrect FFI definition of `Py_Buffer` on PyPy. [#1737](https://github.com/PyO3/pyo3/pull/1737)
 - Fix incorrect calculation of `dictoffset` on 32-bit Windows. [#1475](https://github.com/PyO3/pyo3/pull/1475)
+- Fix regression in 0.13.2 leading to linking to incorrect Python library on Windows "gnu" targets. [#1759](https://github.com/PyO3/pyo3/pull/1759)
 
 ## [0.14.1] - 2021-07-04
 

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
-use std::{env, process::Command};
+use std::{env, ffi::OsString, path::Path, process::Command};
 
 use pyo3_build_config::{
     bail, cargo_env_var, ensure, env_var,
     errors::{Context, Result},
-    InterpreterConfig, PythonImplementation, PythonVersion,
+    InterpreterConfig, PythonVersion,
 };
 
 /// Minimum Python version PyO3 supports.
@@ -20,78 +20,25 @@ fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
     Ok(())
 }
 
-fn ensure_target_architecture(interpreter_config: &InterpreterConfig) -> Result<()> {
+fn ensure_target_pointer_width(pointer_width: u32) -> Result<()> {
     // Try to check whether the target architecture matches the python library
     let rust_target = match cargo_env_var("CARGO_CFG_TARGET_POINTER_WIDTH")
         .unwrap()
         .as_str()
     {
-        "64" => "64-bit",
-        "32" => "32-bit",
+        "64" => 64,
+        "32" => 32,
         x => bail!("unexpected Rust target pointer width: {}", x),
     };
 
-    // The reason we don't use platform.architecture() here is that it's not
-    // reliable on macOS. See https://stackoverflow.com/a/1405971/823869.
-    // Similarly, sys.maxsize is not reliable on Windows. See
-    // https://stackoverflow.com/questions/1405913/how-do-i-determine-if-my-python-shell-is-executing-in-32bit-or-64bit-mode-on-os/1405971#comment6209952_1405971
-    // and https://stackoverflow.com/a/3411134/823869.
-    let python_target = match interpreter_config.calcsize_pointer {
-        Some(8) => "64-bit",
-        Some(4) => "32-bit",
-        None => {
-            // Unset, e.g. because we're cross-compiling. Don't check anything
-            // in this case.
-            return Ok(());
-        }
-        Some(n) => bail!("unexpected Python calcsize_pointer value: {}", n),
-    };
-
     ensure!(
-        rust_target == python_target,
-        "Your Rust target architecture ({}) does not match your python interpreter ({})",
+        rust_target == pointer_width,
+        "your Rust target architecture ({}-bit) does not match your python interpreter ({}-bit)",
         rust_target,
-        python_target
+        pointer_width
     );
 
     Ok(())
-}
-
-fn get_rustc_link_lib(config: &InterpreterConfig) -> Result<String> {
-    let link_name = if cargo_env_var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
-        if config.abi3 {
-            // Link against python3.lib for the stable ABI on Windows.
-            // See https://www.python.org/dev/peps/pep-0384/#linkage
-            //
-            // This contains only the limited ABI symbols.
-            "pythonXY:python3".to_owned()
-        } else if cargo_env_var("CARGO_CFG_TARGET_ENV").unwrap() == "gnu" {
-            // https://packages.msys2.org/base/mingw-w64-python
-            format!(
-                "pythonXY:python{}.{}",
-                config.version.major, config.version.minor
-            )
-        } else {
-            format!(
-                "pythonXY:python{}{}",
-                config.version.major, config.version.minor
-            )
-        }
-    } else {
-        match config.implementation {
-            PythonImplementation::CPython => match &config.ld_version {
-                Some(ld_version) => format!("python{}", ld_version),
-                None => bail!("failed to configure `ld_version` when compiling for unix"),
-            },
-            PythonImplementation::PyPy => format!("pypy{}-c", config.version.major),
-        }
-    };
-
-    Ok(format!(
-        "cargo:rustc-link-lib={link_model}{link_name}",
-        link_model = if config.shared { "" } else { "static=" },
-        link_name = link_name
-    ))
 }
 
 fn rustc_minor_version() -> Option<u32> {
@@ -108,28 +55,29 @@ fn rustc_minor_version() -> Option<u32> {
 fn emit_cargo_configuration(interpreter_config: &InterpreterConfig) -> Result<()> {
     let target_os = cargo_env_var("CARGO_CFG_TARGET_OS").unwrap();
     let is_extension_module = cargo_env_var("CARGO_FEATURE_EXTENSION_MODULE").is_some();
-    match (is_extension_module, target_os.as_str()) {
-        (_, "windows") => {
-            // always link on windows, even with extension module
-            println!("{}", get_rustc_link_lib(interpreter_config)?);
-            // Set during cross-compiling.
-            if let Some(libdir) = &interpreter_config.libdir {
-                println!("cargo:rustc-link-search=native={}", libdir);
-            }
-            // Set if we have an interpreter to use.
-            if let Some(base_prefix) = &interpreter_config.base_prefix {
-                println!("cargo:rustc-link-search=native={}\\libs", base_prefix);
-            }
+    if target_os == "windows" || target_os == "android" || !is_extension_module {
+        // windows and android - always link
+        // other systems - only link if not extension module
+        println!(
+            "cargo:rustc-link-lib={link_model}{alias}{lib_name}",
+            link_model = if interpreter_config.shared {
+                ""
+            } else {
+                "static="
+            },
+            alias = if target_os == "windows" {
+                "pythonXY:"
+            } else {
+                ""
+            },
+            lib_name = interpreter_config
+                .lib_name
+                .as_ref()
+                .ok_or("config does not contain lib_name")?,
+        );
+        if let Some(lib_dir) = &interpreter_config.lib_dir {
+            println!("cargo:rustc-link-search=native={}", lib_dir);
         }
-        (false, _) | (_, "android") => {
-            // other systems, only link libs if not extension module
-            // android always link.
-            println!("{}", get_rustc_link_lib(interpreter_config)?);
-            if let Some(libdir) = &interpreter_config.libdir {
-                println!("cargo:rustc-link-search=native={}", libdir);
-            }
-        }
-        _ => {}
     }
 
     if cargo_env_var("CARGO_FEATURE_AUTO_INITIALIZE").is_some() {
@@ -152,9 +100,9 @@ fn emit_cargo_configuration(interpreter_config: &InterpreterConfig) -> Result<()
 
         // TODO: PYO3_CI env is a hack to workaround CI with PyPy, where the `dev-dependencies`
         // currently cause `auto-initialize` to be enabled in CI.
-        // Once cargo's `resolver = "2"` is stable (~ MSRV Rust 1.52), remove this.
+        // Once MSRV is 1.51 or higher, use cargo's `resolver = "2"` instead.
         if interpreter_config.is_pypy() && env::var_os("PYO3_CI").is_none() {
-            bail!("The `auto-initialize` feature is not supported with PyPy.");
+            bail!("the `auto-initialize` feature is not supported with PyPy");
         }
     }
 
@@ -166,21 +114,56 @@ fn emit_cargo_configuration(interpreter_config: &InterpreterConfig) -> Result<()
 /// The result is written to pyo3_build_config::PATH, which downstream scripts can read from
 /// (including `pyo3-macros-backend` during macro expansion).
 fn configure_pyo3() -> Result<()> {
-    let interpreter_config = pyo3_build_config::make_interpreter_config()?;
+    let write_config_file = env_var("PYO3_WRITE_CONFIG_FILE").map_or(false, |os_str| os_str == "1");
+    let custom_config_file_path = env_var("PYO3_CONFIG_FILE");
+    if let Some(path) = &custom_config_file_path {
+        ensure!(
+            Path::new(path).is_absolute(),
+            "PYO3_CONFIG_FILE must be absolute"
+        );
+    }
+    let (interpreter_config, path_to_write) = match (write_config_file, custom_config_file_path) {
+        (true, Some(path)) => {
+            // Create new interpreter config and write it to config file
+            (pyo3_build_config::make_interpreter_config()?, Some(path))
+        }
+        (true, None) => bail!("PYO3_CONFIG_FILE must be set when PYO3_WRITE_CONFIG_FILE is set"),
+        (false, Some(path)) => {
+            // Read custom config file
+            let path = Path::new(&path);
+            println!("cargo:rerun-if-changed={}", path.display());
+            let config_file = std::fs::File::open(path)
+                .with_context(|| format!("failed to read config file at {}", path.display()))?;
+            let reader = std::io::BufReader::new(config_file);
+            (
+                pyo3_build_config::InterpreterConfig::from_reader(reader)?,
+                None,
+            )
+        }
+        (false, None) => (
+            // Create new interpreter config and write it to the default location
+            pyo3_build_config::make_interpreter_config()?,
+            Some(OsString::from(pyo3_build_config::DEFAULT_CONFIG_PATH)),
+        ),
+    };
+
+    if let Some(path) = path_to_write {
+        interpreter_config.to_writer(&mut std::fs::File::create(&path).with_context(|| {
+            format!(
+                "failed to create config file at {}",
+                Path::new(&path).display()
+            )
+        })?)?;
+    }
     if env_var("PYO3_PRINT_CONFIG").map_or(false, |os_str| os_str == "1") {
         print_config_and_exit(&interpreter_config);
     }
+
     ensure_python_version(&interpreter_config)?;
-    ensure_target_architecture(&interpreter_config)?;
+    if let Some(pointer_width) = interpreter_config.pointer_width {
+        ensure_target_pointer_width(pointer_width)?;
+    }
     emit_cargo_configuration(&interpreter_config)?;
-    interpreter_config.to_writer(
-        &mut std::fs::File::create(pyo3_build_config::PATH).with_context(|| {
-            format!(
-                "failed to create config file at {}",
-                pyo3_build_config::PATH
-            )
-        })?,
-    )?;
     interpreter_config.emit_pyo3_cfgs();
 
     let rustc_minor_version = rustc_minor_version().unwrap_or(0);
@@ -200,15 +183,9 @@ fn configure_pyo3() -> Result<()> {
 
 fn print_config_and_exit(config: &InterpreterConfig) {
     println!("\n-- PYO3_PRINT_CONFIG=1 is set, printing configuration and halting compile --");
-    println!("implementation: {}", config.implementation);
-    println!("interpreter version: {}", config.version);
-    println!("interpreter path: {:?}", config.executable);
-    println!("libdir: {:?}", config.libdir);
-    println!("shared: {}", config.shared);
-    println!("base prefix: {:?}", config.base_prefix);
-    println!("ld_version: {:?}", config.ld_version);
-    println!("pointer width: {:?}", config.calcsize_pointer);
-
+    config
+        .to_writer(&mut std::io::stdout())
+        .expect("failed to print config to stdout");
     std::process::exit(101);
 }
 

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -30,22 +30,21 @@ Caused by:
   cargo:rerun-if-env-changed=PYO3_CROSS
   cargo:rerun-if-env-changed=PYO3_CROSS_LIB_DIR
   cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_VERSION
-  cargo:rerun-if-env-changed=PYO3_PYTHON
-  cargo:rerun-if-env-changed=VIRTUAL_ENV
-  cargo:rerun-if-env-changed=CONDA_PREFIX
-  cargo:rerun-if-env-changed=PATH
   cargo:rerun-if-env-changed=PYO3_PRINT_CONFIG
 
   -- PYO3_PRINT_CONFIG=1 is set, printing configuration and halting compile --
-  implementation: CPython
-  interpreter version: 3.8
-  interpreter path: Some("/usr/bin/python")
-  libdir: Some("/usr/lib")
-  shared: true
-  base prefix: Some("/usr")
-  ld_version: Some("3.8")
-  pointer width: Some(8)
+  implementation=CPython
+  version=3.8
+  shared=true
+  abi3=false
+  lib_name=python3.8
+  lib_dir=/usr/lib
+  executable=/usr/bin/python
+  pointer_width=64
+  build_flags=WITH_THREAD
 ```
+
+> Note: if you safe the output config to a file, it is possible to manually override the and feed it back into PyO3 using the `PYO3_CONFIG_FILE` env var. For now, this is an advanced feature that should not be needed for most users. The format of the config file and its contents are deliberately unstable and undocumented. If you have a production use-case for this config file, please file an issue and help us stabilize it!
 
 ## Building Python extension modules
 

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -44,7 +44,7 @@ Caused by:
   build_flags=WITH_THREAD
 ```
 
-> Note: if you safe the output config to a file, it is possible to manually override the and feed it back into PyO3 using the `PYO3_CONFIG_FILE` env var. For now, this is an advanced feature that should not be needed for most users. The format of the config file and its contents are deliberately unstable and undocumented. If you have a production use-case for this config file, please file an issue and help us stabilize it!
+> Note: if you save the output config to a file, it is possible to manually override the contents and feed it back into PyO3 using the `PYO3_CONFIG_FILE` env var. For now, this is an advanced feature that should not be needed for most users. The format of the config file and its contents are deliberately unstable and undocumented. If you have a production use-case for this config file, please file an issue and help us stabilize it!
 
 ## Building Python extension modules
 

--- a/pyo3-build-config/build.rs
+++ b/pyo3-build-config/build.rs
@@ -1,3 +1,32 @@
+// Import some modules from this crate inline to generate the build config.
+// Allow dead code because not all code in the modules is used in this build script.
+
+#[path = "src/impl_.rs"]
+#[allow(dead_code)]
+mod impl_;
+
+#[path = "src/errors.rs"]
+#[allow(dead_code)]
+mod errors;
+
+use std::{env, path::Path};
+
+use errors::{Result, Context};
+
+fn generate_build_config() -> Result<()> {
+    // Create new interpreter config and write it to the default location
+    let interpreter_config = impl_::make_interpreter_config()?;
+
+    let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("pyo3-build-config.txt");
+    interpreter_config
+        .to_writer(&mut std::fs::File::create(&path).with_context(|| {
+            format!("failed to create config file at {}", path.display())
+        })?)
+}
+
 fn main() {
-    // Empty build script to force cargo to produce the "OUT_DIR" environment variable.
+    if let Err(e) = generate_build_config() {
+        eprintln!("error: {}", e.report());
+        std::process::exit(1)
+    }
 }

--- a/pyo3-build-config/build.rs
+++ b/pyo3-build-config/build.rs
@@ -11,21 +11,85 @@ mod errors;
 
 use std::{env, path::Path};
 
-use errors::{Result, Context};
+use errors::{Context, Result};
+use impl_::{
+    env_var, get_abi3_version, make_interpreter_config, BuildFlags, InterpreterConfig,
+    PythonImplementation,
+};
 
-fn generate_build_config() -> Result<()> {
-    // Create new interpreter config and write it to the default location
-    let interpreter_config = impl_::make_interpreter_config()?;
+fn configure(interpreter_config: Option<InterpreterConfig>, name: &str) -> Result<bool> {
+    let target = Path::new(&env::var_os("OUT_DIR").unwrap()).join(name);
+    if let Some(config) = interpreter_config {
+        config
+            .to_writer(&mut std::fs::File::create(&target).with_context(|| {
+                format!("failed to write config file at {}", target.display())
+            })?)?;
+        Ok(true)
+    } else {
+        std::fs::File::create(&target)
+            .with_context(|| format!("failed to create new file at {}", target.display()))?;
+        Ok(false)
+    }
+}
 
-    let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("pyo3-build-config.txt");
-    interpreter_config
-        .to_writer(&mut std::fs::File::create(&path).with_context(|| {
-            format!("failed to create config file at {}", path.display())
-        })?)
+/// If PYO3_CONFIG_FILE is set, copy it into the crate.
+fn config_file() -> Result<Option<InterpreterConfig>> {
+    if let Some(path) = env_var("PYO3_CONFIG_FILE") {
+        let path = Path::new(&path);
+        println!("cargo:rerun-if-changed={}", path.display());
+        // Absolute path is necessary because this build script is run with a cwd different to the
+        // original `cargo build` instruction.
+        ensure!(
+            path.is_absolute(),
+            "PYO3_CONFIG_FILE must be an absolute path"
+        );
+
+        let interpreter_config = InterpreterConfig::from_path(path)
+            .context("failed to parse contents of PYO3_CONFIG_FILE")?;
+        Ok(Some(interpreter_config))
+    } else {
+        Ok(None)
+    }
+}
+
+/// If PYO3_NO_PYTHON is set with abi3, use standard abi3 settings.
+pub fn abi3_config() -> Option<InterpreterConfig> {
+    if let Some(version) = get_abi3_version() {
+        if env_var("PYO3_NO_PYTHON").is_some() {
+            return Some(InterpreterConfig {
+                version,
+                // NB PyPy doesn't support abi3 yet
+                implementation: PythonImplementation::CPython,
+                abi3: true,
+                lib_name: None,
+                lib_dir: None,
+                build_flags: BuildFlags::abi3(),
+                pointer_width: None,
+                executable: None,
+                shared: true,
+            });
+        }
+    }
+    None
+}
+
+fn generate_build_configs() -> Result<()> {
+    let mut configured = false;
+    configured |= configure(config_file()?, "pyo3-build-config-file.txt")?;
+    configured |= configure(abi3_config(), "pyo3-build-config-abi3.txt")?;
+
+    if configured {
+        // Don't bother trying to find an interpreter on the host system if at least one of the
+        // config file or abi3 settings are present
+        configure(None, "pyo3-build-config.txt")?;
+    } else {
+        configure(Some(make_interpreter_config()?), "pyo3-build-config.txt")?;
+    }
+    Ok(())
 }
 
 fn main() {
-    if let Err(e) = generate_build_config() {
+    if let Err(e) = generate_build_configs() {
         eprintln!("error: {}", e.report());
         std::process::exit(1)
     }

--- a/pyo3-build-config/src/errors.rs
+++ b/pyo3-build-config/src/errors.rs
@@ -26,6 +26,16 @@ pub struct Error {
     source: Option<Box<dyn std::error::Error>>,
 }
 
+/// Error report inspired by
+/// https://blog.rust-lang.org/inside-rust/2021/07/01/What-the-error-handling-project-group-is-working-towards.html#2-error-reporter
+pub struct ErrorReport<'a>(&'a Error);
+
+impl Error {
+    pub fn report(&self) -> ErrorReport<'_> {
+        ErrorReport(self)
+    }
+}
+
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.value)
@@ -35,6 +45,24 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.source.as_deref()
+    }
+}
+
+impl std::fmt::Display for ErrorReport<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use std::error::Error;
+        self.0.fmt(f)?;
+        let mut source = self.0.source();
+        if source.is_some() {
+            writeln!(f, "\ncaused by:")?;
+            let mut index = 0;
+            while let Some(some_source) = source {
+                writeln!(f, "  - {}: {}", index, some_source)?;
+                source = some_source.source();
+                index += 1;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/pyo3-build-config/src/errors.rs
+++ b/pyo3-build-config/src/errors.rs
@@ -115,3 +115,31 @@ where
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_report() {
+        let error: Result<()> = Err(Error::from("there was an internal error"))
+            .with_context(|| format!("failed to do {}", "something difficult"))
+            .context("things went wrong");
+
+        assert_eq!(
+            error
+                .unwrap_err()
+                .report()
+                .to_string()
+                .split('\n')
+                .collect::<Vec<&str>>(),
+            vec![
+                "things went wrong",
+                "caused by:",
+                "  - 0: failed to do something difficult",
+                "  - 1: there was an internal error",
+                ""
+            ]
+        );
+    }
+}

--- a/pyo3-build-config/src/errors.rs
+++ b/pyo3-build-config/src/errors.rs
@@ -1,5 +1,6 @@
 /// A simple macro for returning an error. Resembles anyhow::bail.
 #[macro_export]
+#[doc(hidden)]
 macro_rules! bail {
     ($msg: expr) => { return Err($msg.into()); };
     ($fmt: literal $($args: tt)+) => { return Err(format!($fmt $($args)+).into()); };
@@ -7,12 +8,14 @@ macro_rules! bail {
 
 /// A simple macro for checking a condition. Resembles anyhow::ensure.
 #[macro_export]
+#[doc(hidden)]
 macro_rules! ensure {
     ($condition:expr, $($args: tt)+) => { if !($condition) { bail!($($args)+) } };
 }
 
 /// Show warning. If needed, please extend this macro to support arguments.
 #[macro_export]
+#[doc(hidden)]
 macro_rules! warn {
     ($msg: literal) => {
         println!(concat!("cargo:warning=", $msg));
@@ -27,7 +30,7 @@ pub struct Error {
 }
 
 /// Error report inspired by
-/// https://blog.rust-lang.org/inside-rust/2021/07/01/What-the-error-handling-project-group-is-working-towards.html#2-error-reporter
+/// <https://blog.rust-lang.org/inside-rust/2021/07/01/What-the-error-handling-project-group-is-working-towards.html#2-error-reporter>
 pub struct ErrorReport<'a>(&'a Error);
 
 impl Error {

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -94,7 +94,7 @@ import os.path
 import platform
 import struct
 import sys
-from sysconfig import get_config_var
+from sysconfig import get_config_var, get_platform
 
 PYPY = platform.python_implementation() == "PyPy"
 
@@ -132,6 +132,7 @@ print_if_set("libdir", get_config_var("LIBDIR"))
 print_if_set("base_prefix", base_prefix)
 print("executable", sys.executable)
 print("calcsize_pointer", struct.calcsize("P"))
+print("mingw", get_platform() == "mingw")
 "#;
         let output = run_python_script(interpreter.as_ref(), SCRIPT)?;
         let map: HashMap<String, String> = parse_script_output(&output);
@@ -150,11 +151,7 @@ print("calcsize_pointer", struct.calcsize("P"))
         let implementation = map["implementation"].parse()?;
 
         let lib_name = if cfg!(windows) {
-            default_lib_name_windows(
-                version,
-                abi3,
-                &cargo_env_var("CARGO_CFG_TARGET_ENV").unwrap(),
-            )
+            default_lib_name_windows(version, abi3, map["mingw"].as_str() == "True")
         } else {
             default_lib_name_unix(
                 version,
@@ -899,7 +896,7 @@ fn windows_hardcoded_cross_compile(
         version,
         shared: true,
         abi3: is_abi3(),
-        lib_name: Some(default_lib_name_windows(version, false, "msvc")),
+        lib_name: Some(default_lib_name_windows(version, false, false)),
         lib_dir: cross_compile_config.lib_dir.to_str().map(String::from),
         executable: None,
         pointer_width: None,
@@ -936,10 +933,10 @@ fn load_cross_compile_config(
 // This contains only the limited ABI symbols.
 const WINDOWS_ABI3_LIB_NAME: &str = "python3";
 
-fn default_lib_name_windows(version: PythonVersion, abi3: bool, target_env: &str) -> String {
+fn default_lib_name_windows(version: PythonVersion, abi3: bool, mingw: bool) -> String {
     if abi3 {
         WINDOWS_ABI3_LIB_NAME.to_owned()
-    } else if target_env == "gnu" {
+    } else if mingw {
         // https://packages.msys2.org/base/mingw-w64-python
         format!("python{}.{}", version.major, version.minor)
     } else {
@@ -1278,19 +1275,19 @@ mod tests {
     #[test]
     fn default_lib_name_windows() {
         assert_eq!(
-            super::default_lib_name_windows(PythonVersion { major: 3, minor: 6 }, false, "mvsc"),
+            super::default_lib_name_windows(PythonVersion { major: 3, minor: 6 }, false, false),
             "python36",
         );
         assert_eq!(
-            super::default_lib_name_windows(PythonVersion { major: 3, minor: 6 }, true, "mvsc"),
+            super::default_lib_name_windows(PythonVersion { major: 3, minor: 6 }, true, false),
             "python3",
         );
         assert_eq!(
-            super::default_lib_name_windows(PythonVersion { major: 3, minor: 6 }, false, "gnu"),
+            super::default_lib_name_windows(PythonVersion { major: 3, minor: 6 }, false, true),
             "python3.6",
         );
         assert_eq!(
-            super::default_lib_name_windows(PythonVersion { major: 3, minor: 6 }, true, "gnu"),
+            super::default_lib_name_windows(PythonVersion { major: 3, minor: 6 }, true, true),
             "python3",
         );
     }

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -1,48 +1,23 @@
 //! Configuration used by PyO3 for conditional support of varying Python versions.
 //!
-//! The public APIs exposed, [`use_pyo3_cfgs`] and [`add_extension_module_link_args`] are intended
-//! to be called from build scripts to simplify building crates which depend on PyO3.
+//! This crate exposes two functions, [`use_pyo3_cfgs`] and [`add_extension_module_link_args`],
+//! which are intended to be called from build scripts to simplify building crates which depend on
+//! PyO3.
+//!
+//! It used internally by the PyO3 crate's build script to apply the same configuration.
 
-#[doc(hidden)]
-pub mod errors;
+mod errors;
 mod impl_;
 
 use std::io::Cursor;
 
 use once_cell::sync::OnceCell;
 
-// Used in PyO3's build.rs
-#[doc(hidden)]
-pub use impl_::{
-    cargo_env_var, env_var, find_interpreter, get_config_from_interpreter, make_interpreter_config, make_cross_compile_config,
-    InterpreterConfig, PythonImplementation, PythonVersion,
-};
+use impl_::InterpreterConfig;
 
-/// Reads the configuration written by PyO3's build.rs
-///
-/// Because this will never change in a given compilation run, this is cached in a `once_cell`.
+// Used in `pyo3-macros-backend`; may expose this in a future release.
 #[doc(hidden)]
-pub fn get() -> &'static InterpreterConfig {
-    static CONFIG: OnceCell<InterpreterConfig> = OnceCell::new();
-    CONFIG.get_or_init(|| {
-        if let Some(path) = std::env::var_os("PYO3_CONFIG_FILE") {
-            // Config file set - use that
-            InterpreterConfig::from_path(path)
-        } else if impl_::any_cross_compiling_env_vars_set() {
-            InterpreterConfig::from_path(DEFAULT_CROSS_COMPILE_CONFIG_PATH)
-        } else {
-            InterpreterConfig::from_reader(Cursor::new(HOST_CONFIG))
-        }.expect("failed to parse PyO3 config file")
-    })
-}
-
-/// Path where PyO3's build.rs will write configuration by default.
-#[doc(hidden)]
-pub const DEFAULT_CROSS_COMPILE_CONFIG_PATH: &str = concat!(env!("OUT_DIR"), "/pyo3-cross-compile-config.txt");
-
-/// Build configuration discovered by `pyo3-build-config` build script. Not aware of
-/// cross-compilation settings.
-pub const HOST_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config.txt"));
+pub use impl_::PythonVersion;
 
 /// Adds all the [`#[cfg]` flags](index.html) to the current compilation.
 ///
@@ -68,8 +43,112 @@ pub fn use_pyo3_cfgs() {
 /// This is currently a no-op on non-macOS platforms, however may emit additional linker arguments
 /// in future if deemed necessarys.
 pub fn add_extension_module_link_args() {
-    if cargo_env_var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
+    if impl_::cargo_env_var("CARGO_CFG_TARGET_OS").unwrap() == "macos" {
         println!("cargo:rustc-cdylib-link-arg=-undefined");
         println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+    }
+}
+
+/// Loads the configuration determined from the build environment.
+///
+/// Because this will never change in a given compilation run, this is cached in a `once_cell`.
+#[doc(hidden)]
+pub fn get() -> &'static InterpreterConfig {
+    static CONFIG: OnceCell<InterpreterConfig> = OnceCell::new();
+    CONFIG.get_or_init(|| {
+        if !CONFIG_FILE.is_empty() {
+            InterpreterConfig::from_reader(Cursor::new(CONFIG_FILE))
+        } else if !ABI3_CONFIG.is_empty() {
+            Ok(abi3_config())
+        } else if impl_::any_cross_compiling_env_vars_set() {
+            InterpreterConfig::from_path(DEFAULT_CROSS_COMPILE_CONFIG_PATH)
+        } else {
+            InterpreterConfig::from_reader(Cursor::new(HOST_CONFIG))
+        }
+        .expect("failed to parse PyO3 config file")
+    })
+}
+
+/// Path where PyO3's build.rs will write configuration by default.
+#[doc(hidden)]
+const DEFAULT_CROSS_COMPILE_CONFIG_PATH: &str =
+    concat!(env!("OUT_DIR"), "/pyo3-cross-compile-config.txt");
+
+/// Build configuration provided by `PYO3_CONFIG_FILE`. May be empty if env var not set.
+#[doc(hidden)]
+const CONFIG_FILE: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config-file.txt"));
+
+/// Build configuration set if abi3 features enabled and `PYO3_NO_PYTHON` env var present. Empty if
+/// not both present.
+#[doc(hidden)]
+const ABI3_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config-abi3.txt"));
+
+/// Build configuration discovered by `pyo3-build-config` build script. Not aware of
+/// cross-compilation settings.
+#[doc(hidden)]
+const HOST_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config.txt"));
+
+fn abi3_config() -> InterpreterConfig {
+    let mut interpreter_config = InterpreterConfig::from_reader(Cursor::new(ABI3_CONFIG))
+        .expect("failed to parse hardcoded PyO3 abi3 config");
+    // If running from a build script on Windows, tweak the hardcoded abi3 config to contain
+    // the standard lib name (this is necessary so that abi3 extension modules using
+    // PYO3_NO_PYTHON on Windows can link)
+    if std::env::var("CARGO_CFG_TARGET_OS").map_or(false, |target_os| target_os == "windows") {
+        assert_eq!(interpreter_config.lib_name, None);
+        interpreter_config.lib_name = Some("python3".to_owned())
+    }
+    interpreter_config
+}
+
+/// Private exports used in PyO3's build.rs
+///
+/// Please don't use these - they could change at any time.
+#[doc(hidden)]
+pub mod pyo3_build_script_impl {
+    use crate::errors::{Context, Result};
+    use std::path::Path;
+
+    use super::*;
+
+    pub mod errors {
+        pub use crate::errors::*;
+    }
+    pub use crate::impl_::{
+        cargo_env_var, env_var, make_cross_compile_config, InterpreterConfig, PythonVersion,
+    };
+
+    /// Gets the configuration for use from PyO3's build script.
+    ///
+    /// Differs from .get() above only in the cross-compile case, where PyO3's build script is
+    /// required to generate a new config (as it's the first build script which has access to the
+    /// correct value for CARGO_CFG_TARGET_OS).
+    pub fn resolve_interpreter_config() -> Result<InterpreterConfig> {
+        if !CONFIG_FILE.is_empty() {
+            InterpreterConfig::from_reader(Cursor::new(CONFIG_FILE))
+        } else if !ABI3_CONFIG.is_empty() {
+            Ok(abi3_config())
+        } else if let Some(interpreter_config) = impl_::make_cross_compile_config()? {
+            // This is a cross compile and need to write the config file.
+            let path = Path::new(DEFAULT_CROSS_COMPILE_CONFIG_PATH);
+            let parent_dir = path.parent().ok_or_else(|| {
+                format!(
+                    "failed to resolve parent directory of config file {}",
+                    path.display()
+                )
+            })?;
+            std::fs::create_dir_all(&parent_dir).with_context(|| {
+                format!(
+                    "failed to create config file directory {}",
+                    parent_dir.display()
+                )
+            })?;
+            interpreter_config.to_writer(&mut std::fs::File::create(&path).with_context(
+                || format!("failed to create config file at {}", path.display()),
+            )?)?;
+            Ok(interpreter_config)
+        } else {
+            InterpreterConfig::from_reader(Cursor::new(HOST_CONFIG))
+        }
     }
 }


### PR DESCRIPTION
This is a final change which I'd like to put into PyO3 0.14.2.

When testing out 0.14.1 at work, I ran into problems building in our CI environment where we use `sccache`. It turns out the strategy in #1648 of generating a config file is problematic with `sccache`, as it doesn't know about this file and can't cache it.

This convinced me that it's better to go with the original strategy in #1622 which generated the configuration inside the `pyo3-build-config` build script and inlined it into that crate. Because it then becomes part of the compiled code, this works fine with `sccache`.

The only situation where inling the configuration doesn't work is in cross-compile scenarios. In this case we still need to let PyO3's build script read the right env vars and generate a cross-compile config file. 

To at least alleviate the pain of config files with `sccache`, I've added a `PYO3_CONFIG_FILE` env var which users can set to specify a hard-coded config file location. Moving it outside of the build script in this way means that users won't run into issues with caching tools. The output of `PYO3_PRINT_CONFIG` is valid to be put straight into a config file which users can save.

The `PYO3_CONFIG_FILE` env var may also prove useful for other users where PyO3's build scripts don't generate the right configuration. I'm thinking in this case that users can use it to override whatever environment we got wrong.

cc @indygreg I'm wondering if this config file might eventually be suitable for use by PyOxidizer.

With this patch, I was able to get PyO3 0.14 into production at Re:infer. 🚀 