### PR TITLE
release: 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.2] - 2021-08-09
 
 ### Added
 
@@ -881,6 +881,7 @@ Yanked
 - Initial release
 
 [unreleased]: https://github.com/pyo3/pyo3/compare/v0.14.1...HEAD
+[0.14.2]: https://github.com/pyo3/pyo3/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/pyo3/pyo3/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/pyo3/pyo3/compare/v0.13.2...v0.14.0
 [0.13.2]: https://github.com/pyo3/pyo3/compare/v0.13.1...v0.13.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.14.1"
+version = "0.14.2"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -24,7 +24,7 @@ num-bigint = { version = "0.4", optional = true }
 num-complex = { version = "0.4", optional = true }
 # must stay at 0.1.x for Rust 1.41 compatibility
 paste = { version = "0.1.18", optional = true }
-pyo3-macros = { path = "pyo3-macros", version = "=0.14.1", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.14.2", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = ">= 0.9, < 0.12", optional = true }
 indexmap = { version = ">= 1.6, < 1.8", optional = true }
@@ -42,7 +42,7 @@ pyo3 = { path = ".", default-features = false, features = ["macros", "auto-initi
 serde_json = "1.0.61"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "0.14.1" }
+pyo3-build-config = { path = "pyo3-build-config", version = "0.14.2" }
 
 [features]
 default = ["macros"]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.14.1"
+version = "0.14.2"
 features = ["extension-module"]
 ```
 
@@ -108,7 +108,7 @@ Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like th
 
 ```toml
 [dependencies.pyo3]
-version = "0.14.1"
+version = "0.14.2"
 features = ["auto-initialize"]
 ```
 

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.14.1"
+version = "0.14.2"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.14.1"
+version = "0.14.2"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "0.14.1" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "0.14.2" }
 
 [dependencies.syn]
 version = "1"

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.14.1"
+version = "0.14.2"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.14.1" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.14.2" }


### PR DESCRIPTION
This bumps versions for 0.14.2. I think the dust has mostly settled on the 0.14 releases now, so I'd be happy to start merging breaking changes for the 0.15 release (which we already have a fair few of).

I'll put this live tomorrow unless I hear a reason to do otherwise.

Proposed release notes below.

----

This release is a small quality-of-life update for the PyO3 0.14 release series. Optional support for the `indexmap` crate has been added. In addition, there have been a number of bugfixes for regressions and incorrect FFI definitions.

Users who removed macOS cargo configuration from their setup after updating to PyO3 0.14 will unfortunately have to once again add configuration to their compilation after updating to this release. This is because PyO3 was using functionality which [Cargo had erroneously allowed](https://github.com/rust-lang/cargo/issues/9562).

The recommended way to restore configuration for macOS is to add a build script which invokes [`pyo3_build_config::add_extension_module_link_args()`](https://docs.rs/pyo3-build-config/0.14.2/pyo3_build_config/fn.add_extension_module_link_args.html). The [cargo configuration previously recommended](https://pyo3.rs/v0.14.2/building_and_distribution.html#macos) is also still an option.