### PR TITLE
fix compiler warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix incorrect FFI definition of `Py_Buffer` on PyPy. [#1737](https://github.com/PyO3/pyo3/pull/1737)
 - Fix incorrect calculation of `dictoffset` on 32-bit Windows. [#1475](https://github.com/PyO3/pyo3/pull/1475)
 - Fix regression in 0.13.2 leading to linking to incorrect Python library on Windows "gnu" targets. [#1759](https://github.com/PyO3/pyo3/pull/1759)
+- Fix compiler warning: deny trailing semicolons in expression macro. [#1762](https://github.com/PyO3/pyo3/pull/1762)
 
 ## [0.14.1] - 2021-07-04
 

--- a/pyo3-build-config/src/errors.rs
+++ b/pyo3-build-config/src/errors.rs
@@ -2,8 +2,8 @@
 #[macro_export]
 #[doc(hidden)]
 macro_rules! bail {
-    ($msg: expr) => { return Err($msg.into()); };
-    ($fmt: literal $($args: tt)+) => { return Err(format!($fmt $($args)+).into()); };
+    ($msg: expr) => { return Err($msg.into()) };
+    ($fmt: literal $($args: tt)+) => { return Err(format!($fmt $($args)+).into()) };
 }
 
 /// A simple macro for checking a condition. Resembles anyhow::ensure.
@@ -18,7 +18,7 @@ macro_rules! ensure {
 #[doc(hidden)]
 macro_rules! warn {
     ($msg: literal) => {
-        println!(concat!("cargo:warning=", $msg));
+        println!(concat!("cargo:warning=", $msg))
     };
 }
 

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -75,7 +75,7 @@ impl InterpreterConfig {
                 warn!(
                     "PyPy does not yet support abi3 so the build artifacts will be version-specific. \
                     See https://foss.heptapod.net/pypy/pypy/-/issues/3397 for more information."
-                )
+                );
             }
         };
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -84,7 +84,7 @@ impl PyClassArgs {
                 expected!($expected, right.span())
             };
             ($expected: literal, $span: expr) => {
-                bail_spanned!($span => concat!("expected ", $expected));
+                bail_spanned!($span => concat!("expected ", $expected))
             };
         }
 

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -81,7 +81,7 @@ pub fn check_generic(sig: &syn::Signature) -> syn::Result<()> {
 
 fn ensure_function_options_valid(options: &PyFunctionOptions) -> syn::Result<()> {
     if let Some(pass_module) = &options.pass_module {
-        bail_spanned!(pass_module.span() => "`pass_module` cannot be used on Python methods")
+        bail_spanned!(pass_module.span() => "`pass_module` cannot be used on Python methods");
     }
     Ok(())
 }
@@ -334,7 +334,7 @@ impl PropertyType<'_> {
                     (Some(name), _) => name.0.to_string(),
                     (None, Some(field_name)) => format!("{}\0", field_name.unraw()),
                     (None, None) => {
-                        bail_spanned!(field.span() => "`get` and `set` with tuple struct fields require `name`")
+                        bail_spanned!(field.span() => "`get` and `set` with tuple struct fields require `name`");
                     }
                 };
                 Ok(syn::LitStr::new(&name, field.span()))

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -14,7 +14,7 @@ macro_rules! err_spanned {
 /// Macro inspired by `anyhow::bail!` to return a compiler error with the given span.
 macro_rules! bail_spanned {
     ($span:expr => $msg:expr) => {
-        return Err(err_spanned!($span => $msg));
+        return Err(err_spanned!($span => $msg))
     };
 }
 


### PR DESCRIPTION
Fix issue [link](https://github.com/rust-lang/rust/issues/79813) which will eventually deny trailing semicolons in expression macro in rust compiler.
