### PR TITLE
ffi: define _Py_PackageContext

### DIFF
--- a/src/ffi/modsupport.rs
+++ b/src/ffi/modsupport.rs
@@ -146,4 +146,8 @@ pub unsafe fn PyModule_FromDefAndSpec(def: *mut PyModuleDef, spec: *mut PyObject
     )
 }
 
-// skipped non-limited _Py_PackageContext
+#[cfg(not(Py_LIMITED_API))]
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
+    pub static mut _Py_PackageContext: *const c_char;
+}


### PR DESCRIPTION
This is needed for PyOxidizer.