### PR TITLE
gil: add unsafe variation for obtaining GILGuard without checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add `indexmap` feature to add `ToPyObject`, `IntoPy` and `FromPyObject` implementations for `indexmap::IndexMap`. [#1728](https://github.com/PyO3/pyo3/pull/1728)
 - Add `pyo3_build_config::add_extension_module_link_args()` to use in build scripts to set linker arguments (for macOS). [#1755](https://github.com/PyO3/pyo3/pull/1755)
+- Add `Python::with_gil_unchecked()` unsafe variation of `Python::with_gil()` to allow obtaining a `Python` in scenarios where `Python::with_gil()` would fail.
 
 ### Changed
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -160,6 +160,31 @@ impl Python<'_> {
     {
         f(unsafe { gil::ensure_gil().python() })
     }
+
+    /// Like [Python::with_gil] except Python interpreter state checking is skipped.
+    ///
+    /// Normally when the GIL is acquired, we check that the Python interpreter is an
+    /// appropriate state (e.g. it is fully initialized). This function skips those
+    /// checks.
+    ///
+    /// # Safety
+    ///
+    /// If [Python::with_gil] would succeed, it is safe to call this function.
+    ///
+    /// In most cases, you should use [Python::with_gil].
+    ///
+    /// A justified scenario for calling this function is during multi-phase interpreter
+    /// initialization when [Python::with_gil] would fail before `_Py_InitializeMain()`
+    /// is called because the interpreter is only partially initialized.
+    ///
+    /// Behavior in other scenarios is not documented.
+    #[inline]
+    pub unsafe fn with_gil_unchecked<F, R>(f: F) -> R
+    where
+        F: for<'p> FnOnce(Python<'p>) -> R,
+    {
+        f(gil::ensure_gil_unchecked().python())
+    }
 }
 
 impl<'p> Python<'p> {


### PR DESCRIPTION
GILGuard::acquire() cannot be called during multi-phase Python
interpreter initialization because it calls Py_IsInitialized(),
which doesn't report the interpreter as initialized until all
phases of initialization have completed.

PyOxidizer uses the multi-phase initialization API and needs to
interact with pyo3's high-level APIs (not the FFI bindings) after
partial interpreter initialization, before the interpreter is fully
initialized. Attempts to use GILGuard::acquire() result in a panic
due to the aforementioned Py_IsInitialized() check failing.

This commit introduces an unsafe function to acquire the GILGuard
without performing state checking first. I've tested this with
PyOxidizer and can confirm it allows PyOxidizer to use pyo3 APIs
before interpreter initialization is complete.