### PR TITLE
Problems with the new Async/Await guide

### DIFF
--- a/guide/src/ecosystem/async-await.md
+++ b/guide/src/ecosystem/async-await.md
@@ -498,4 +498,4 @@ fn main() -> PyResult<()> {
 
 ## Additional Information
 - Managing event loop references can be tricky with pyo3-asyncio. See [Event Loop References](https://docs.rs/pyo3-asyncio/#event-loop-references) in the API docs to get a better intuition for how event loop references are managed in this library.
-- Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://docs.rs/pyo3-asyncio/testing)
+- Testing pyo3-asyncio libraries and applications requires a custom test harness since Python requires control over the main thread. You can find a testing guide in the [API docs for the `testing` module](https://docs.rs/pyo3-asyncio/latest/pyo3_asyncio/testing)


### PR DESCRIPTION
Hey, looks like we've got some issues with the async/await guide after that update. I took a look at https://pyo3.rs/v0.14.2/ecosystem/async-await.html this morning to check the links. The link to the testing module appears to be busted and this PR fixes that.

Aside from that, it looks like someone's been trying to integrate it into the rustdoc tests since I see some main functions that shouldn't be visible, and the syntax highlighting is missing on some code sections. Also the README.md still points to 0.14.1 (but that might be by design). Idk if that's a WIP or not, but those changes don't seem to be on the `main` branch, so I wasn't sure where to find them. My README contains most of this guide, and its integrated into rustdoc as well if you want to take a look at how I did it.

My advice for integrating them into the rustdoc tests is to mark the problematic code sections with `rust compile_fail` even though it may seem like a bit of a cop-out. 
- `rust no_run` is also a good idea for tests that require external deps like `uvloop`, but it will still fail to compile some sections without a hidden main (or not-so-hidden in markdown code sections).
- `rust ignore` will still try to build a test for it, it just won't run it by default.