### PR TITLE
ci: downgrade trybuild to 1.0.43

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ serde = {version = "1.0", optional = true}
 assert_approx_eq = "1.1.0"
 # O.3.5 uses the matches! macro, which isn't compatible with Rust 1.41
 criterion = "=0.3.4"
-trybuild = "1.0.44"
+# Pinned for cargo-llvm-cov, see https://github.com/taiki-e/cargo-llvm-cov/issues/32
+trybuild = "1.0.43"
 rustversion = "1.0"
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 # features needed to run the PyO3 test suite


### PR DESCRIPTION
See https://github.com/taiki-e/cargo-llvm-cov/issues/32

I couldn't get `trybuild` 1.0.34 or older to work, because I think we must be depending on other bugfixes.

For now I think if we use a trybuild incompatible with cargo-llvm-cov, CI will still be green but we just won't measure the macros coverage again. Hopefully things will resolve in future versions of those packages.🤞 