### PR TITLE
guide: allow using newer gh-actions-pages version

### DIFF
--- a/.github/workflows/guide.yml
+++ b/.github/workflows/guide.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Deploy
         if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
-        uses: peaceiris/actions-gh-pages@v3.7.0-8
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages-build/
@@ -71,7 +71,7 @@ jobs:
           ln -sfT $TAG_NAME public/latest
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3.7.0-8
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public/


### PR DESCRIPTION
Possibly a fix for #1773 - see https://github.com/peaceiris/actions-gh-pages/issues/643