### PR TITLE
ci: pin bitflags for MSRV job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
         run: |
           cargo update -p indexmap --precise 1.6.2
           cargo update -p hashbrown:0.11.2 --precise 0.9.1
+          cargo update -p bitflags --precise 1.2.1
 
       - name: Build docs
         run: cargo doc --no-deps --no-default-features --features "${{ steps.settings.outputs.all_additive_features }}"


### PR DESCRIPTION
Looks like bitflags 1.3.0 and greater breaks MSRV in CI.

(bitflags 1.3.0 was just yanked, but at least this change makes it ready for whenever 1.3.1 comes.)