### PR TITLE
examples: make `word-count` example comparison fairer

### DIFF
--- a/examples/word-count/src/lib.rs
+++ b/examples/word-count/src/lib.rs
@@ -1,6 +1,3 @@
-// Source adopted from
-// https://github.com/tildeio/helix-website/blob/master/crates/word_count/src/lib.rs
-
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
@@ -24,28 +21,11 @@ fn search_sequential_allow_threads(py: Python, contents: &str, needle: &str) -> 
     py.allow_threads(|| search_sequential(contents, needle))
 }
 
-fn matches(word: &str, needle: &str) -> bool {
-    let mut needle = needle.chars();
-    for ch in word.chars().skip_while(|ch| !ch.is_alphabetic()) {
-        match needle.next() {
-            None => {
-                return !ch.is_alphabetic();
-            }
-            Some(expect) => {
-                if ch.to_lowercase().next() != Some(expect) {
-                    return false;
-                }
-            }
-        }
-    }
-    needle.next().is_none()
-}
-
-/// Count the occurences of needle in line, case insensitive
+/// Count the occurrences of needle in line, case insensitive
 fn count_line(line: &str, needle: &str) -> usize {
     let mut total = 0;
     for word in line.split(' ') {
-        if matches(word, needle) {
+        if word == needle {
             total += 1;
         }
     }

--- a/examples/word-count/tests/test_word_count.py
+++ b/examples/word-count/tests/test_word_count.py
@@ -1,7 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
-
 import word_count
 
 

--- a/examples/word-count/word_count/__init__.py
+++ b/examples/word-count/word_count/__init__.py
@@ -8,11 +8,10 @@ __all__ = [
 ]
 
 
-def search_py(contents, needle):
+def search_py(contents: str, needle: str) -> int:
     total = 0
-    for line in contents.split():
-        words = line.split(" ")
-        for word in words:
+    for line in contents.splitlines():
+        for word in line.split(" "):
             if word == needle:
                 total += 1
     return total


### PR DESCRIPTION
This just tidies up the `word-count` example a bit to make the comparison a bit fairer between the two languages:
- The Rust side was doing some complex string searching, whereas the Python code was just doing `==`. Now both languages just do `==`.
- `.splitlines()` is faster at line-splitting than `.split()`, so it's better choice imo to demonstrate the perf difference