### PR TITLE
Build configuration settings to facilitate complete link control

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -152,6 +152,11 @@ fn configure_pyo3() -> Result<()> {
         println!("cargo:rustc-cfg=addr_of");
     }
 
+    // Extra lines come last, to support last write wins.
+    for line in &interpreter_config.extra_build_script_lines {
+        println!("{}", line);
+    }
+
     Ok(())
 }
 

--- a/build.rs
+++ b/build.rs
@@ -84,7 +84,7 @@ fn rustc_minor_version() -> Option<u32> {
     pieces.next()?.parse().ok()
 }
 
-fn emit_cargo_configuration(interpreter_config: &InterpreterConfig) -> Result<()> {
+fn emit_link_config(interpreter_config: &InterpreterConfig) -> Result<()> {
     let target_os = cargo_env_var("CARGO_CFG_TARGET_OS").unwrap();
     let is_extension_module = cargo_env_var("CARGO_FEATURE_EXTENSION_MODULE").is_some();
     if target_os == "windows" || target_os == "android" || !is_extension_module {
@@ -132,7 +132,10 @@ fn configure_pyo3() -> Result<()> {
     ensure_target_pointer_width(&interpreter_config)?;
     ensure_auto_initialize_ok(&interpreter_config)?;
 
-    emit_cargo_configuration(&interpreter_config)?;
+    if !interpreter_config.suppress_build_script_link_lines {
+        emit_link_config(&interpreter_config)?;
+    }
+
     interpreter_config.emit_pyo3_cfgs();
 
     let rustc_minor_version = rustc_minor_version().unwrap_or(0);

--- a/pyo3-build-config/build.rs
+++ b/pyo3-build-config/build.rs
@@ -67,6 +67,7 @@ pub fn abi3_config() -> Option<InterpreterConfig> {
                 pointer_width: None,
                 executable: None,
                 shared: true,
+                suppress_build_script_link_lines: false,
                 extra_build_script_lines: vec![],
             });
         }

--- a/pyo3-build-config/build.rs
+++ b/pyo3-build-config/build.rs
@@ -67,6 +67,7 @@ pub fn abi3_config() -> Option<InterpreterConfig> {
                 pointer_width: None,
                 executable: None,
                 shared: true,
+                extra_build_script_lines: vec![],
             });
         }
     }


### PR DESCRIPTION
This PR makes a handful of changes to the crate build configuration to support advanced control over linking, which is required by PyOxidizer.

I wrote extensive commit messages detailing each change. Please read the commit messages for more context.

I'm creating this as a draft until I have more confidence that these changes are sufficient to support PyOxidizer on all platforms. I figured I'd publish this as a PR in hopes of getting feedback about the general direction sooner.

The first commit is generally useful and could be cherry picked to `main` if you want.