### PR TITLE
Expand supported num-complex versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Restrict FFI definitions `PyGILState_Check` and `Py_tracefunc` to the unlimited API. [#1787](https://github.com/PyO3/pyo3/pull/1787)
 - Raise `AttributeError` to avoid panic when calling `del` on a `#[setter]` defined class property. [#1779](https://github.com/PyO3/pyo3/issues/1779)
 - Add missing `_type` field to `PyStatus` struct definition. [#1791](https://github.com/PyO3/pyo3/pull/1791)
+- Loosened the lower bound on the `num-complex` optional dependency to support
+  interop with `rust-numpy` and `ndarray` when building with the MSRV of 1.41
+  [#1799](https://github.com/PyO3/pyo3/pull/1799)
 
 ## [0.14.2] - 2021-08-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ inventory = { version = "0.1.4", optional = true }
 libc = "0.2.62"
 parking_lot = "0.11.0"
 num-bigint = { version = "0.4", optional = true }
-num-complex = { version = ">= 0.2, <= 0.4", optional = true }
+num-complex = { version = ">= 0.2, < 0.5", optional = true }
 # must stay at 0.1.x for Rust 1.41 compatibility
 paste = { version = "0.1.18", optional = true }
 pyo3-macros = { path = "pyo3-macros", version = "=0.14.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ inventory = { version = "0.1.4", optional = true }
 libc = "0.2.62"
 parking_lot = "0.11.0"
 num-bigint = { version = "0.4", optional = true }
-num-complex = { version = "0.4", optional = true }
+num-complex = { version = ">= 0.2, <= 0.4", optional = true }
 # must stay at 0.1.x for Rust 1.41 compatibility
 paste = { version = "0.1.18", optional = true }
 pyo3-macros = { path = "pyo3-macros", version = "=0.14.2", optional = true }


### PR DESCRIPTION
When building an extension with rust-numpy and ndarray on the MSRV of
1.41 with complex numbers. The num-complex crate version needs to be
0.2 which was the pinned version as of ndarray 0.13.1 which was the last
release of ndarray that supported building with rust 1.41. However, the
pyo3 pinned version of 0.4 is incompatible with this and will cause an
error when building because of the version mismatch. To fix this This
commit expands the supported versions for num-complex to match what
rust-numpy uses [1] so that we can build pyo3, numpy, ndarray, and
num-complex in an extension with rust 1.41.

Fixes #1798

[1] https://github.com/PyO3/rust-numpy/blob/v0.14.1/Cargo.toml#L19