### PR TITLE
pytuple: deprecate split_from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Change `PyErr::fetch()` to return `Option<PyErr>`. [#1717](https://github.com/PyO3/pyo3/pull/1717)
+- Deprecate `PyTuple::split_from`. [#1804](https://github.com/PyO3/pyo3/pull/1804)
 
 ### Fixed
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -72,6 +72,7 @@ impl PyTuple {
         }
     }
 
+    #[deprecated(since = "0.15.0", note = "use tuple.slice(low, tuple.len()) instead")]
     /// Takes a slice of the tuple from `low` to the end and returns it as a new tuple.
     pub fn split_from(&self, low: usize) -> &PyTuple {
         unsafe {


### PR DESCRIPTION
As per https://github.com/PyO3/pyo3/pull/1802#discussion_r690339328