### PR TITLE
Test proc macro hygiene for `#[pyclass]` macro.

### DIFF
--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -133,21 +133,21 @@ impl SelfType {
         match self {
             SelfType::Receiver { mutable: false } => {
                 quote! {
-                    let _cell = _py.from_borrowed_ptr::<pyo3::PyCell<#cls>>(_slf);
+                    let _cell = _py.from_borrowed_ptr::<::pyo3::PyCell<#cls>>(_slf);
                     let _ref = _cell.try_borrow()?;
                     let _slf = &_ref;
                 }
             }
             SelfType::Receiver { mutable: true } => {
                 quote! {
-                    let _cell = _py.from_borrowed_ptr::<pyo3::PyCell<#cls>>(_slf);
+                    let _cell = _py.from_borrowed_ptr::<::pyo3::PyCell<#cls>>(_slf);
                     let mut _ref = _cell.try_borrow_mut()?;
                     let _slf = &mut _ref;
                 }
             }
             SelfType::TryFromPyCell(span) => {
                 quote_spanned! { *span =>
-                    let _cell = _py.from_borrowed_ptr::<pyo3::PyCell<#cls>>(_slf);
+                    let _cell = _py.from_borrowed_ptr::<::pyo3::PyCell<#cls>>(_slf);
                     #[allow(clippy::useless_conversion)]  // In case _slf is PyCell<Self>
                     let _slf = std::convert::TryFrom::try_from(_cell)?;
                 }

--- a/pyo3-macros-backend/src/proto_method.rs
+++ b/pyo3-macros-backend/src/proto_method.rs
@@ -95,7 +95,7 @@ pub(crate) fn impl_method_proto(
     };
 
     Ok(quote! {
-        impl<'p> #module::#proto<'p> for #cls {
+        impl<'p> ::#module::#proto<'p> for #cls {
             #(#impl_types)*
             #res_type_def
         }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -345,13 +345,13 @@ fn impl_methods_inventory(cls: &syn::Ident) -> TokenStream {
     quote! {
         #[doc(hidden)]
         pub struct #inventory_cls {
-            methods: Vec<pyo3::class::PyMethodDefType>,
+            methods: ::std::vec::Vec<::pyo3::class::PyMethodDefType>,
         }
         impl ::pyo3::class::impl_::PyMethodsInventory for #inventory_cls {
-            fn new(methods: Vec<pyo3::class::PyMethodDefType>) -> Self {
+            fn new(methods: ::std::vec::Vec<::pyo3::class::PyMethodDefType>) -> Self {
                 Self { methods }
             }
-            fn get(&'static self) -> &'static [pyo3::class::PyMethodDefType] {
+            fn get(&'static self) -> &'static [::pyo3::class::PyMethodDefType] {
                 &self.methods
             }
         }

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -102,7 +102,7 @@ pub fn impl_py_method_def(
     };
     let methoddef = spec.get_methoddef(quote! {{ #wrapper_def #wrapper_ident }});
     Ok(quote! {
-        pyo3::class::PyMethodDefType::#methoddef_type(#methoddef #add_flags)
+        ::pyo3::class::PyMethodDefType::#methoddef_type(#methoddef #add_flags)
     })
 }
 
@@ -110,7 +110,7 @@ fn impl_py_method_def_new(cls: &syn::Type, spec: &FnSpec) -> Result<TokenStream>
     let wrapper_ident = syn::Ident::new("__wrap", Span::call_site());
     let wrapper = spec.get_wrapper_function(&wrapper_ident, Some(cls))?;
     Ok(quote! {
-        impl pyo3::class::impl_::PyClassNewImpl<#cls> for pyo3::class::impl_::PyClassImplCollector<#cls> {
+        impl ::pyo3::class::impl_::PyClassNewImpl<#cls> for ::pyo3::class::impl_::PyClassImplCollector<#cls> {
             fn new_impl(self) -> Option<pyo3::ffi::newfunc> {
                 Some({
                     #wrapper
@@ -125,7 +125,7 @@ fn impl_py_method_def_call(cls: &syn::Type, spec: &FnSpec) -> Result<TokenStream
     let wrapper_ident = syn::Ident::new("__wrap", Span::call_site());
     let wrapper = spec.get_wrapper_function(&wrapper_ident, Some(cls))?;
     Ok(quote! {
-        impl pyo3::class::impl_::PyClassCallImpl<#cls> for pyo3::class::impl_::PyClassImplCollector<#cls> {
+        impl ::pyo3::class::impl_::PyClassCallImpl<#cls> for ::pyo3::class::impl_::PyClassImplCollector<#cls> {
             fn call_impl(self) -> Option<pyo3::ffi::PyCFunctionWithKeywords> {
                 Some({
                     #wrapper
@@ -141,13 +141,13 @@ fn impl_py_class_attribute(cls: &syn::Type, spec: &FnSpec) -> TokenStream {
     let deprecations = &spec.deprecations;
     let python_name = spec.null_terminated_python_name();
     quote! {
-        pyo3::class::PyMethodDefType::ClassAttribute({
-            pyo3::class::PyClassAttributeDef::new(
+        ::pyo3::class::PyMethodDefType::ClassAttribute({
+            ::pyo3::class::PyClassAttributeDef::new(
                 #python_name,
-                pyo3::class::methods::PyClassAttributeFactory({
-                    fn __wrap(py: pyo3::Python<'_>) -> pyo3::PyObject {
+                ::pyo3::class::methods::PyClassAttributeFactory({
+                    fn __wrap(py: ::pyo3::Python<'_>) -> ::pyo3::PyObject {
                         #deprecations
-                        pyo3::IntoPy::into_py(#cls::#name(), py)
+                        ::pyo3::IntoPy::into_py(#cls::#name(), py)
                     }
                     __wrap
                 })
@@ -206,26 +206,26 @@ pub fn impl_py_setter_def(cls: &syn::Type, property_type: PropertyType) -> Resul
         PropertyType::Function { self_type, .. } => self_type.receiver(cls),
     };
     Ok(quote! {
-        pyo3::class::PyMethodDefType::Setter({
+        ::pyo3::class::PyMethodDefType::Setter({
             #deprecations
-            pyo3::class::PySetterDef::new(
+            ::pyo3::class::PySetterDef::new(
                 #python_name,
-                pyo3::class::methods::PySetter({
+                ::pyo3::class::methods::PySetter({
                     unsafe extern "C" fn __wrap(
-                        _slf: *mut pyo3::ffi::PyObject,
-                        _value: *mut pyo3::ffi::PyObject,
-                        _: *mut std::os::raw::c_void
-                    ) -> std::os::raw::c_int {
-                        pyo3::callback::handle_panic(|_py| {
+                        _slf: *mut ::pyo3::ffi::PyObject,
+                        _value: *mut ::pyo3::ffi::PyObject,
+                        _: *mut ::std::os::raw::c_void
+                    ) -> ::std::os::raw::c_int {
+                        ::pyo3::callback::handle_panic(|_py| {
                             #slf
                             let _value = _py
                                 .from_borrowed_ptr_or_opt(_value)
                                 .ok_or_else(|| {
-                                    pyo3::exceptions::PyAttributeError::new_err("can't delete attribute")
+                                    ::pyo3::exceptions::PyAttributeError::new_err("can't delete attribute")
                                 })?;
-                            let _val = pyo3::FromPyObject::extract(_value)?;
+                            let _val = ::pyo3::FromPyObject::extract(_value)?;
 
-                            pyo3::callback::convert(_py, #setter_impl)
+                            ::pyo3::callback::convert(_py, #setter_impl)
                         })
                     }
                     __wrap
@@ -266,12 +266,13 @@ pub fn impl_py_getter_def(cls: &syn::Type, property_type: PropertyType) -> Resul
             ..
         } => {
             // named struct field
-            quote!(_slf.#ident.clone())
+            //quote!(_slf.#ident.clone())
+            quote!(::std::clone::Clone::clone(&(_slf.#ident)))
         }
         PropertyType::Descriptor { field_index, .. } => {
             // tuple struct field
             let index = syn::Index::from(field_index);
-            quote!(_slf.#index.clone())
+            quote!(::std::clone::Clone::clone(&(_slf.#index)))
         }
         PropertyType::Function { spec, .. } => impl_call_getter(cls, spec)?,
     };
@@ -281,18 +282,18 @@ pub fn impl_py_getter_def(cls: &syn::Type, property_type: PropertyType) -> Resul
         PropertyType::Function { self_type, .. } => self_type.receiver(cls),
     };
     Ok(quote! {
-        pyo3::class::PyMethodDefType::Getter({
+        ::pyo3::class::PyMethodDefType::Getter({
             #deprecations
-            pyo3::class::PyGetterDef::new(
+            ::pyo3::class::PyGetterDef::new(
                 #python_name,
-                pyo3::class::methods::PyGetter({
+                ::pyo3::class::methods::PyGetter({
                     unsafe extern "C" fn __wrap(
-                        _slf: *mut pyo3::ffi::PyObject,
-                        _: *mut std::os::raw::c_void
-                    ) -> *mut pyo3::ffi::PyObject {
-                        pyo3::callback::handle_panic(|_py| {
+                        _slf: *mut ::pyo3::ffi::PyObject,
+                        _: *mut ::std::os::raw::c_void
+                    ) -> *mut ::pyo3::ffi::PyObject {
+                        ::pyo3::callback::handle_panic(|_py| {
                             #slf
-                            pyo3::callback::convert(_py, #getter_impl)
+                            ::pyo3::callback::convert(_py, #getter_impl)
                         })
                     }
                     __wrap

--- a/pyo3-macros-backend/src/pyproto.rs
+++ b/pyo3-macros-backend/src/pyproto.rs
@@ -68,7 +68,7 @@ fn impl_proto_impl(
 
                 let flags = if m.can_coexist {
                     // We need METH_COEXIST here to prevent __add__  from overriding __radd__
-                    Some(quote!(pyo3::ffi::METH_COEXIST))
+                    Some(quote!(::pyo3::ffi::METH_COEXIST))
                 } else {
                     None
                 };
@@ -106,11 +106,11 @@ fn impl_normal_methods(
     let methods_trait = proto.methods_trait();
     let methods_trait_methods = proto.methods_trait_methods();
     quote! {
-        impl pyo3::class::impl_::#methods_trait<#ty>
-            for pyo3::class::impl_::PyClassImplCollector<#ty>
+        impl ::pyo3::class::impl_::#methods_trait<#ty>
+            for ::pyo3::class::impl_::PyClassImplCollector<#ty>
         {
-            fn #methods_trait_methods(self) -> &'static [pyo3::class::methods::PyMethodDefType] {
-                static METHODS: &[pyo3::class::methods::PyMethodDefType] =
+            fn #methods_trait_methods(self) -> &'static [::pyo3::class::methods::PyMethodDefType] {
+                static METHODS: &[::pyo3::class::methods::PyMethodDefType] =
                     &[#(#py_methods),*];
                 METHODS
             }
@@ -139,14 +139,14 @@ fn impl_proto_methods(
 
     if build_config.version <= PY39 && proto.name == "Buffer" {
         maybe_buffer_methods = Some(quote! {
-            impl pyo3::class::impl_::PyBufferProtocolProcs<#ty>
-                for pyo3::class::impl_::PyClassImplCollector<#ty>
+            impl ::pyo3::class::impl_::PyBufferProtocolProcs<#ty>
+                for ::pyo3::class::impl_::PyClassImplCollector<#ty>
             {
                 fn buffer_procs(
                     self
-                ) -> Option<&'static pyo3::class::impl_::PyBufferProcs> {
-                    static PROCS: pyo3::class::impl_::PyBufferProcs
-                        = pyo3::class::impl_::PyBufferProcs {
+                ) -> Option<&'static ::pyo3::class::impl_::PyBufferProcs> {
+                    static PROCS: ::pyo3::class::impl_::PyBufferProcs
+                        = ::pyo3::class::impl_::PyBufferProcs {
                             bf_getbuffer: Some(pyo3::class::buffer::getbuffer::<#ty>),
                             bf_releasebuffer: Some(pyo3::class::buffer::releasebuffer::<#ty>),
                         };
@@ -162,9 +162,9 @@ fn impl_proto_methods(
             let slot = syn::Ident::new(def.slot, Span::call_site());
             let slot_impl = syn::Ident::new(def.slot_impl, Span::call_site());
             quote! {{
-                pyo3::ffi::PyType_Slot {
-                    slot: pyo3::ffi::#slot,
-                    pfunc: #module::#slot_impl::<#ty> as _
+                ::pyo3::ffi::PyType_Slot {
+                    slot: ::pyo3::ffi::#slot,
+                    pfunc: ::#module::#slot_impl::<#ty> as _
                 }
             }}
         })
@@ -177,10 +177,10 @@ fn impl_proto_methods(
     quote! {
         #maybe_buffer_methods
 
-        impl pyo3::class::impl_::#slots_trait<#ty>
-            for pyo3::class::impl_::PyClassImplCollector<#ty>
+        impl ::pyo3::class::impl_::#slots_trait<#ty>
+            for ::pyo3::class::impl_::PyClassImplCollector<#ty>
         {
-            fn #slots_trait_slots(self) -> &'static [pyo3::ffi::PyType_Slot] {
+            fn #slots_trait_slots(self) -> &'static [::pyo3::ffi::PyType_Slot] {
                 &[#(#tokens),*]
             }
         }

--- a/tests/test_proc_macro_hygiene.rs
+++ b/tests/test_proc_macro_hygiene.rs
@@ -1,22 +1,26 @@
 #![no_implicit_prelude]
-#![allow(non_camel_case_types)]
-#![allow(dead_code)]
 
-trait Use_unambiguous_imports<T> {
-    type Error;
+macro_rules! shadow {
+    ($name: ident) => {
+        ::paste::item! {
+            #[allow(non_camel_case_types, dead_code)]
+            unsafe trait [<NobodyImplsThis_ $name>]  {}
+
+            #[allow(non_camel_case_types, dead_code)]
+            struct [<Shadows_ $name>]<T: [<NobodyImplsThis_ $name>]> {
+                _ty: ::core::marker::PhantomData<T>,
+              }
+
+            #[allow(non_camel_case_types, dead_code)]
+            type $name = [<Shadows_ $name>]<()>;
+        }
+    };
 }
 
-struct Pyo3Shadowed;
-type pyo3 = <Pyo3Shadowed as Use_unambiguous_imports<Pyo3Shadowed>>::Error;
-
-struct CoreShadowed;
-type core = <CoreShadowed as Use_unambiguous_imports<CoreShadowed>>::Error;
-
-struct StdShadowed;
-type std = <StdShadowed as Use_unambiguous_imports<StdShadowed>>::Error;
-
-struct AllocShadowed;
-type alloc = <AllocShadowed as Use_unambiguous_imports<AllocShadowed>>::Error;
+shadow!(std);
+shadow!(alloc);
+shadow!(core);
+shadow!(pyo3);
 
 #[::pyo3::proc_macro::pyclass]
 #[derive(::std::clone::Clone)]

--- a/tests/test_proc_macro_hygiene.rs
+++ b/tests/test_proc_macro_hygiene.rs
@@ -1,27 +1,5 @@
 #![no_implicit_prelude]
 
-macro_rules! shadow {
-    ($name: ident) => {
-        ::paste::item! {
-            #[allow(non_camel_case_types, dead_code)]
-            unsafe trait [<NobodyImplsThis_ $name>]  {}
-
-            #[allow(non_camel_case_types, dead_code)]
-            struct [<Shadows_ $name>]<T: [<NobodyImplsThis_ $name>]> {
-                _ty: ::core::marker::PhantomData<T>,
-              }
-
-            #[allow(non_camel_case_types, dead_code)]
-            type $name = [<Shadows_ $name>]<()>;
-        }
-    };
-}
-
-shadow!(std);
-shadow!(alloc);
-shadow!(core);
-shadow!(pyo3);
-
 #[::pyo3::proc_macro::pyclass]
 #[derive(::std::clone::Clone)]
 pub struct Foo;

--- a/tests/test_proc_macro_hygiene.rs
+++ b/tests/test_proc_macro_hygiene.rs
@@ -1,0 +1,62 @@
+#![no_implicit_prelude]
+#![allow(non_camel_case_types)]
+#![allow(dead_code)]
+
+trait Use_unambiguous_imports<T> {
+    type Error;
+}
+
+struct Pyo3Shadowed;
+type pyo3 = <Pyo3Shadowed as Use_unambiguous_imports<Pyo3Shadowed>>::Error;
+
+struct CoreShadowed;
+type core = <CoreShadowed as Use_unambiguous_imports<CoreShadowed>>::Error;
+
+struct StdShadowed;
+type std = <StdShadowed as Use_unambiguous_imports<StdShadowed>>::Error;
+
+struct AllocShadowed;
+type alloc = <AllocShadowed as Use_unambiguous_imports<AllocShadowed>>::Error;
+
+#[::pyo3::proc_macro::pyclass]
+#[derive(::std::clone::Clone)]
+pub struct Foo;
+
+#[::pyo3::proc_macro::pyclass]
+pub struct Foo2;
+
+#[::pyo3::proc_macro::pyclass(
+    name = "ActuallyBar",
+    freelist = 8,
+    weakref,
+    unsendable,
+    gc,
+    subclass,
+    extends = ::pyo3::types::PyDict,
+    module = "Spam"
+)]
+pub struct Bar {
+    #[pyo3(get, set)]
+    a: u8,
+    #[pyo3(get, set)]
+    b: Foo,
+    #[pyo3(get, set)]
+    c: ::std::option::Option<::pyo3::Py<Foo2>>,
+}
+
+#[::pyo3::proc_macro::pyproto]
+impl ::pyo3::class::gc::PyGCProtocol for Bar {
+    fn __traverse__(
+        &self,
+        visit: ::pyo3::class::gc::PyVisit,
+    ) -> ::std::result::Result<(), ::pyo3::class::gc::PyTraverseError> {
+        if let ::std::option::Option::Some(obj) = &self.c {
+            visit.call(obj)?
+        }
+        ::std::result::Result::Ok(())
+    }
+
+    fn __clear__(&mut self) {
+        self.c = ::std::option::Option::None;
+    }
+}

--- a/tests/test_proc_macro_hygiene.rs
+++ b/tests/test_proc_macro_hygiene.rs
@@ -36,7 +36,7 @@ pub struct Foo2;
     unsendable,
     gc,
     subclass,
-    extends = ::pyo3::types::PyDict,
+    extends = ::pyo3::types::PyAny,
     module = "Spam"
 )]
 pub struct Bar {


### PR DESCRIPTION
This forces unambiguous types in proc macro output, preventing things like https://github.com/PyO3/pyo3/pull/1711

For example, using ` quote! { pyo3::PyAny }` will now fail, and require an explicit use: ` quote! { ::pyo3::PyAny }`.

For example, the error for the above looks like this:

```
error[E0223]: ambiguous associated type
  --> tests\test_proc_macro_hygiene.rs:25:1
   |
25 | #[::pyo3::proc_macro::pyclass]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use fully-qualified syntax: `<Shadows_pyo3<()> as Trait>::PyAny`
   |
   = note: this error originates in the attribute macro `::pyo3::proc_macro::pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
```