### PR TITLE
Fix memory leak when calling Python from Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Loosened the lower bound on the `num-complex` optional dependency to support
   interop with `rust-numpy` and `ndarray` when building with the MSRV of 1.41
   [#1799](https://github.com/PyO3/pyo3/pull/1799)
+- Add missing `Py_DECREF` to fix memory leak when calling Python from Rust. [#1806](https://github.com/PyO3/pyo3/pull/1806)
 
 ## [0.14.2] - 2021-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Loosened the lower bound on the `num-complex` optional dependency to support
   interop with `rust-numpy` and `ndarray` when building with the MSRV of 1.41
   [#1799](https://github.com/PyO3/pyo3/pull/1799)
-- Add missing `Py_DECREF` to fix memory leak when calling Python from Rust. [#1806](https://github.com/PyO3/pyo3/pull/1806)
+- Add missing `Py_DECREF` to `Python::run_code` which fixes a memory leak when
+  calling Python from Rust. [#1806](https://github.com/PyO3/pyo3/pull/1806)
 
 ## [0.14.2] - 2021-08-09
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -396,6 +396,7 @@ impl<'p> Python<'p> {
                 return Err(PyErr::api_call_failed(self));
             }
             let res_ptr = ffi::PyEval_EvalCode(code_obj, globals, locals);
+            ffi::Py_DECREF(code_obj);
 
             self.from_owned_ptr_or_err(res_ptr)
         }


### PR DESCRIPTION
`Python::run_code` transforms the Rust code string to an owned pointer. The reference count to the owned pointer isn't decremented, which results in a memory leak when calling Python from Rust.

This PR adds a missing `Py_DECREF` call on the owned pointer which fixes the memory leak.

Fixes #1801.

Thanks to @mejrs for the tip on the fix.