### PR TITLE
Py_CompileString decref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Loosened the lower bound on the `num-complex` optional dependency to support
   interop with `rust-numpy` and `ndarray` when building with the MSRV of 1.41
   [#1799](https://github.com/PyO3/pyo3/pull/1799)
-- Add missing `Py_DECREF` to `Python::run_code` which fixes a memory leak when
+- Add missing `Py_DECREF` to `Python::run_code` and `PyModule::from_code` which fixes a memory leak when
   calling Python from Rust. [#1806](https://github.com/PyO3/pyo3/pull/1806)
 
 ## [0.14.2] - 2021-08-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   interop with `rust-numpy` and `ndarray` when building with the MSRV of 1.41
   [#1799](https://github.com/PyO3/pyo3/pull/1799)
 - Add missing `Py_DECREF` to `Python::run_code` and `PyModule::from_code` which fixes a memory leak when
-  calling Python from Rust. [#1806](https://github.com/PyO3/pyo3/pull/1806)
+  calling Python from Rust. [#1806](https://github.com/PyO3/pyo3/pull/1806), [#1810](https://github.com/PyO3/pyo3/pull/1810)
 
 ## [0.14.2] - 2021-08-09
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -130,6 +130,7 @@ impl PyModule {
                 return Err(PyErr::api_call_failed(py));
             }
 
+            ffi::Py_DECREF(cptr);
             <&PyModule as crate::FromPyObject>::extract(py.from_owned_ptr_or_err(mptr)?)
         }
     }

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -127,6 +127,7 @@ impl PyModule {
 
             let mptr = ffi::PyImport_ExecCodeModuleEx(module.as_ptr(), cptr, filename.as_ptr());
             if mptr.is_null() {
+                ffi::Py_DECREF(cptr);
                 return Err(PyErr::api_call_failed(py));
             }
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -126,12 +126,11 @@ impl PyModule {
             }
 
             let mptr = ffi::PyImport_ExecCodeModuleEx(module.as_ptr(), cptr, filename.as_ptr());
+            ffi::Py_DECREF(cptr);
             if mptr.is_null() {
-                ffi::Py_DECREF(cptr);
                 return Err(PyErr::api_call_failed(py));
             }
 
-            ffi::Py_DECREF(cptr);
             <&PyModule as crate::FromPyObject>::extract(py.from_owned_ptr_or_err(mptr)?)
         }
     }


### PR DESCRIPTION
This PR adds the missing `Py_DECREF` to `PyModule::from_code` similar to #1806. `Py_CompileString` returns a new owned pointer, and its reference count should be decremented, thus it's deallocated corretly.

This should close #1801.