### PR TITLE
Use 'crate::' to refer to pyo3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [#1799](https://github.com/PyO3/pyo3/pull/1799)
 - Add missing `Py_DECREF` to `Python::run_code` and `PyModule::from_code` which fixes a memory leak when
   calling Python from Rust. [#1806](https://github.com/PyO3/pyo3/pull/1806), [#1810](https://github.com/PyO3/pyo3/pull/1810)
+- Use crate:: syntax to refer to current crate in pyo3::types::datetime
+  [#1811](https://github.com/PyO3/pyo3/issues/1811)
 
 ## [0.14.2] - 2021-08-09
 

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -465,8 +465,8 @@ mod tests {
     #[cfg(not(PyPy))]
     #[test]
     fn test_new_with_fold() {
-        pyo3::Python::with_gil(|py| {
-            use pyo3::types::{PyDateTime, PyTimeAccess};
+        crate::Python::with_gil(|py| {
+            use crate::types::{PyDateTime, PyTimeAccess};
 
             let a = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, false);
             let b = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, true);


### PR DESCRIPTION
Fixes: #1811
Signed-off-by: Christian Heimes <christian@python.org>
