### PR TITLE
deduplicate pyo3-macros documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ default = ["macros"]
 macros = ["pyo3-macros", "indoc", "paste", "unindent"]
 
 # Enables multiple #[pymethods] per #[pyclass]
-multiple-pymethods = ["inventory"]
+multiple-pymethods = ["inventory", "pyo3-macros/multiple-pymethods"]
 
 # Use this feature when building an extension module.
 # It tells the linker to keep the python symbols unresolved,

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2018"
 [lib]
 proc-macro = true
 
+[features]
+multiple-pymethods = []
+
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -349,17 +349,7 @@ pub mod serde;
 #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 #[cfg(feature = "macros")]
 pub mod proc_macro {
-    pub use pyo3_macros::pymodule;
-
-    pub use pyo3_macros::{pyfunction, pyproto};
-
-    #[cfg(not(feature = "multiple-pymethods"))]
-    pub use pyo3_macros::{pyclass, pymethods};
-
-    #[cfg(feature = "multiple-pymethods")]
-    pub use pyo3_macros::{
-        pyclass_with_inventory as pyclass, pymethods_with_inventory as pymethods,
-    };
+    pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, pyproto};
 }
 
 /// Returns a function that takes a [Python] instance and returns a Python function.


### PR DESCRIPTION
This adds a feature flag to the `pyo3-macros` crate, so that it can be invoked from `pyo3` itself and we can use that feature flag there. This allows unifying the macros there rather than in pyo3/lib.rs itself.

I'm not sure if there are any gotchas I didn't see. Is anyone using `pyo3-macros` directly? Does this count as a breaking change for anyone that does?