### PR TITLE
changelog: update for 0.14.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add `PyList::get_item_unchecked()` and `PyTuple::get_item_unchecked()` to get items without bounds checks. [#1733](https://github.com/PyO3/pyo3/pull/1733)
 - Add `PyAny::py()` as a convenience for `PyNativeType::py()`. [#1751](https://github.com/PyO3/pyo3/pull/1751)
-- Implement `PyString.data()` to access the raw bytes storing a Python string. [#1794](https://github.com/PyO3/pyo3/issues/1794)
 
 ### Changed
 
@@ -21,18 +20,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PyList` and `PyTuple`'s `get_item` now return `PyResult<&PyAny> instead of panicking. [#1733](https://github.com/PyO3/pyo3/pull/1733)
 - Deprecate `PyTuple::split_from`. [#1804](https://github.com/PyO3/pyo3/pull/1804)
 
+## [0.14.3] - 2021-08-22
+
+### Added
+
+- Add `PyString::data()` to access the raw bytes stored in a Python string. [#1794](https://github.com/PyO3/pyo3/issues/1794)
+
 ### Fixed
 
-- Restrict FFI definitions `PyGILState_Check` and `Py_tracefunc` to the unlimited API. [#1787](https://github.com/PyO3/pyo3/pull/1787)
 - Raise `AttributeError` to avoid panic when calling `del` on a `#[setter]` defined class property. [#1779](https://github.com/PyO3/pyo3/issues/1779)
+- Restrict FFI definitions `PyGILState_Check` and `Py_tracefunc` to the unlimited API. [#1787](https://github.com/PyO3/pyo3/pull/1787)
 - Add missing `_type` field to `PyStatus` struct definition. [#1791](https://github.com/PyO3/pyo3/pull/1791)
-- Loosened the lower bound on the `num-complex` optional dependency to support
-  interop with `rust-numpy` and `ndarray` when building with the MSRV of 1.41
-  [#1799](https://github.com/PyO3/pyo3/pull/1799)
-- Add missing `Py_DECREF` to `Python::run_code` and `PyModule::from_code` which fixes a memory leak when
-  calling Python from Rust. [#1806](https://github.com/PyO3/pyo3/pull/1806), [#1810](https://github.com/PyO3/pyo3/pull/1810)
-- Use crate:: syntax to refer to current crate in pyo3::types::datetime
-  [#1811](https://github.com/PyO3/pyo3/issues/1811)
+- Reduce lower bound `num-complex` optional dependency to support interop with `rust-numpy` and `ndarray` when building with the MSRV of 1.41 [#1799](https://github.com/PyO3/pyo3/pull/1799)
+- Fix memory leak in `Python::run_code`. [#1806](https://github.com/PyO3/pyo3/pull/1806)
+- Fix memory leak in `PyModule::from_code`. [#1810](https://github.com/PyO3/pyo3/pull/1810)
+- Remove use of `pyo3::` in `pyo3::types::datetime` which broke builds using `-Z avoid-dev-deps` [#1811](https://github.com/PyO3/pyo3/issues/1811)
 
 ## [0.14.2] - 2021-08-09
 
@@ -908,7 +910,8 @@ Yanked
 
 - Initial release
 
-[unreleased]: https://github.com/pyo3/pyo3/compare/v0.14.1...HEAD
+[unreleased]: https://github.com/pyo3/pyo3/compare/v0.14.3...HEAD
+[0.14.3]: https://github.com/pyo3/pyo3/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/pyo3/pyo3/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/pyo3/pyo3/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/pyo3/pyo3/compare/v0.13.2...v0.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.14.2"
+version = "0.14.3"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -24,7 +24,7 @@ num-bigint = { version = "0.4", optional = true }
 num-complex = { version = ">= 0.2, < 0.5", optional = true }
 # must stay at 0.1.x for Rust 1.41 compatibility
 paste = { version = "0.1.18", optional = true }
-pyo3-macros = { path = "pyo3-macros", version = "=0.14.2", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.14.3", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = ">= 0.9, < 0.12", optional = true }
 indexmap = { version = ">= 1.6, < 1.8", optional = true }
@@ -42,7 +42,7 @@ pyo3 = { path = ".", default-features = false, features = ["macros", "auto-initi
 serde_json = "1.0.61"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "0.14.2" }
+pyo3-build-config = { path = "pyo3-build-config", version = "0.14.3" }
 
 [features]
 default = ["macros"]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.14.2"
+version = "0.14.3"
 features = ["extension-module"]
 ```
 
@@ -108,7 +108,7 @@ Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like th
 
 ```toml
 [dependencies.pyo3]
-version = "0.14.2"
+version = "0.14.3"
 features = ["auto-initialize"]
 ```
 

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.14.2"
+version = "0.14.3"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.14.2"
+version = "0.14.3"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "0.14.2" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "0.14.3" }
 
 [dependencies.syn]
 version = "1"

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.14.2"
+version = "0.14.3"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -19,4 +19,4 @@ multiple-pymethods = []
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.14.2" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.14.3" }


### PR DESCRIPTION
Updates changelog and `Cargo.toml` files to take into account the 0.14.3 release (which is located on the 0.14 branch).