### PR TITLE
list/tuple: rename slice -> get_slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PySequence`'s `in_place_repeat` and `in_place_concat` now return the result instead of `()`, which is needed
   in case of immutable sequences. [#1803](https://github.com/PyO3/pyo3/pull/1803)
 - Deprecate `PyTuple::split_from`. [#1804](https://github.com/PyO3/pyo3/pull/1804)
+- `PyTuple`'s `slice` method is now called `get_slice` for consistency. [#](https://github.com/PyO3/pyo3/pull/)
 
 ## [0.14.3] - 2021-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PySequence`'s `in_place_repeat` and `in_place_concat` now return the result instead of `()`, which is needed
   in case of immutable sequences. [#1803](https://github.com/PyO3/pyo3/pull/1803)
 - Deprecate `PyTuple::split_from`. [#1804](https://github.com/PyO3/pyo3/pull/1804)
-- `PyTuple`'s `slice` method is now called `get_slice` for consistency. [#](https://github.com/PyO3/pyo3/pull/)
+- Deprecate `PyTuple::slice`, new method `get_slice` added with proper index types. [#1828](https://github.com/PyO3/pyo3/pull/1828)
 
 ## [0.14.3] - 2021-08-22
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -103,7 +103,7 @@ impl PyList {
     ///
     /// Indices must be nonnegative, and out-of-range indices are clipped to
     /// `self.len()`.
-    pub fn slice(&self, low: usize, high: usize) -> &PyList {
+    pub fn get_slice(&self, low: usize, high: usize) -> &PyList {
         unsafe {
             self.py().from_owned_ptr(ffi::PyList_GetSlice(
                 self.as_ptr(),
@@ -283,12 +283,12 @@ mod tests {
     }
 
     #[test]
-    fn test_slice() {
+    fn test_get_slice() {
         Python::with_gil(|py| {
             let list = PyList::new(py, &[2, 3, 5, 7]);
-            let slice = list.slice(1, 3);
+            let slice = list.get_slice(1, 3);
             assert_eq!(2, slice.len());
-            let slice = list.slice(1, 7);
+            let slice = list.get_slice(1, 7);
             assert_eq!(3, slice.len());
         });
     }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -72,7 +72,22 @@ impl PyTuple {
         }
     }
 
-    #[deprecated(since = "0.15.0", note = "use tuple.get_slice(low, tuple.len()) instead")]
+    #[deprecated(since = "0.15.0", note = "use self.get_slice instead")]
+    /// Takes the slice `self[low:high]` and returns it as a new tuple.
+    ///
+    /// Indices must be nonnegative, and out-of-range indices are clipped to
+    /// `self.len()`.
+    pub fn slice(&self, low: isize, high: isize) -> &PyTuple {
+        unsafe {
+            self.py()
+                .from_owned_ptr(ffi::PyTuple_GetSlice(self.as_ptr(), low, high))
+        }
+    }
+
+    #[deprecated(
+        since = "0.15.0",
+        note = "use tuple.get_slice(low, tuple.len()) instead"
+    )]
     /// Takes a slice of the tuple from `low` to the end and returns it as a new tuple.
     pub fn split_from(&self, low: usize) -> &PyTuple {
         unsafe {

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -62,7 +62,7 @@ impl PyTuple {
     ///
     /// Indices must be nonnegative, and out-of-range indices are clipped to
     /// `self.len()`.
-    pub fn slice(&self, low: usize, high: usize) -> &PyTuple {
+    pub fn get_slice(&self, low: usize, high: usize) -> &PyTuple {
         unsafe {
             self.py().from_owned_ptr(ffi::PyTuple_GetSlice(
                 self.as_ptr(),
@@ -72,7 +72,7 @@ impl PyTuple {
         }
     }
 
-    #[deprecated(since = "0.15.0", note = "use tuple.slice(low, tuple.len()) instead")]
+    #[deprecated(since = "0.15.0", note = "use tuple.get_slice(low, tuple.len()) instead")]
     /// Takes a slice of the tuple from `low` to the end and returns it as a new tuple.
     pub fn split_from(&self, low: usize) -> &PyTuple {
         unsafe {
@@ -383,9 +383,9 @@ mod tests {
     fn test_slice() {
         Python::with_gil(|py| {
             let tup = PyTuple::new(py, &[2, 3, 5, 7]);
-            let slice = tup.slice(1, 3);
+            let slice = tup.get_slice(1, 3);
             assert_eq!(2, slice.len());
-            let slice = tup.slice(1, 7);
+            let slice = tup.get_slice(1, 7);
             assert_eq!(3, slice.len());
         });
     }


### PR DESCRIPTION
Only tuple's method is renamed; list's method is a new API in 0.15.