### PR TITLE
pystring: disable `PyString::data` on big-endian targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PySequence::get_slice` now returns `PyResult<&PySequence>` instead of `PyResult<&PyAny>`. [#1829](https://github.com/PyO3/pyo3/pull/1829)
 - Deprecate `PyTuple::split_from`. [#1804](https://github.com/PyO3/pyo3/pull/1804)
 - Deprecate `PyTuple::slice`, new method `PyTuple::get_slice` added with `usize` indices. [#1828](https://github.com/PyO3/pyo3/pull/1828)
+- Mark `PyString::data` as `unsafe` and disable it and some supporting PyUnicode FFI APIs (which depend on a C bitfield) on big-endian targets. [#1834](https://github.com/PyO3/pyo3/pull/1834)
 
 ## [0.14.3] - 2021-08-22
 


### PR DESCRIPTION
Based on the discussion in #1824, this PR disables the `PyString::data` API on big-endian architectures.

Because of the lack of well-definedness of the underlying C bitfield, I also think it's appropriate to mark the API as `unsafe`. Users are then free to use it as they please; the safety note specifies that they are responsible for confirming it works correctly on their target.

If merged, I'll backport to 0.14 and release a 0.14.4.

cc @indygreg - this allows PyOxidizer to continue to use this API as needed, with explicit acknowledgement of the risks!