### PR TITLE
ci: pin parking_lot to 0.11.1 on MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,8 @@ jobs:
           cargo update -p indexmap --precise 1.6.2
           cargo update -p hashbrown:0.11.2 --precise 0.9.1
           cargo update -p bitflags --precise 1.2.1
+          cargo update -p parking_lot --precise 0.11.1
+          cargo update -p parking_lot_core --precise 0.8.3
 
       - name: Build docs
         run: cargo doc --no-deps --no-default-features --features "${{ steps.settings.outputs.all_additive_features }}"


### PR DESCRIPTION
`parking_lot` just released an update which broke MSRV compatibility, so need to tweak CI to still pass...