### PR TITLE
pyo3-build-config: make InterpreterConfig public

### DIFF
--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -13,11 +13,7 @@ use std::io::Cursor;
 
 use once_cell::sync::OnceCell;
 
-use impl_::InterpreterConfig;
-
-// Used in `pyo3-macros-backend`; may expose this in a future release.
-#[doc(hidden)]
-pub use impl_::PythonVersion;
+pub use impl_::{BuildFlag, BuildFlags, InterpreterConfig, PythonImplementation, PythonVersion};
 
 /// Adds all the [`#[cfg]` flags](index.html) to the current compilation.
 ///


### PR DESCRIPTION
PyOxidizer will want to create interpreter config files. Rather
than reinvent the logic for reading/writing these files, I think
it makes sense to consume the `pyo3-build-config` crate so we can
use the `InterpreterConfig` type directly. But the symbol needs
to be public to allow us to do that.

(Strictly speaking I could probably hack my way into getting an
instance of `InterpreterConfig` via `get()` and use that. But that
is exceptionally hacky.)