### PR TITLE
PyList: add more sequence APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `PyAny::py` as a convenience for `PyNativeType::py`. [#1751](https://github.com/PyO3/pyo3/pull/1751)
 - Add implementation of `std::ops::Index<usize>` for `PyList`, `PyTuple` and `PySequence`. [#1825](https://github.com/PyO3/pyo3/pull/1825)
 - Add range indexing implementations of `std::ops::Index` for `PyList`, `PyTuple` and `PySequence`. [#1829](https://github.com/PyO3/pyo3/pull/1829)
+- Add commonly-used sequence methods to `PyList` and `PyTuple`. [#1849](https://github.com/PyO3/pyo3/pull/1849)
 
 ### Changed
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -2,9 +2,10 @@
 
 use crate::ffi::{self, Py_ssize_t};
 use crate::internal_tricks::get_ssize_index;
+use crate::types::PySequence;
 use crate::{
     exceptions, AsPyPointer, FromPyObject, IntoPy, IntoPyPointer, Py, PyAny, PyErr, PyObject,
-    PyResult, PyTryFrom, Python, ToPyObject,
+    PyResult, PyTryFrom, Python, ToBorrowedObject, ToPyObject,
 };
 
 /// Represents a Python `tuple` object.
@@ -142,6 +143,28 @@ impl PyTuple {
             let slice = std::slice::from_raw_parts((*ptr).ob_item.as_ptr(), self.len());
             &*(slice as *const [*mut ffi::PyObject] as *const [&PyAny])
         }
+    }
+
+    /// Determines if self contains `value`.
+    ///
+    /// This is equivalent to the Python expression `value in self`.
+    #[inline]
+    pub fn contains<V>(&self, value: V) -> PyResult<bool>
+    where
+        V: ToBorrowedObject,
+    {
+        unsafe { PySequence::try_from_unchecked(self).contains(value) }
+    }
+
+    /// Returns the first index `i` for which `self[i] == value`.
+    ///
+    /// This is equivalent to the Python expression `self.index(value)`.
+    #[inline]
+    pub fn index<V>(&self, value: V) -> PyResult<usize>
+    where
+        V: ToBorrowedObject,
+    {
+        unsafe { PySequence::try_from_unchecked(self).index(value) }
     }
 
     /// Returns an iterator over the tuple items.
@@ -634,5 +657,37 @@ mod tests {
             let tuple = <PyTuple as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
             tuple[8..].extract::<Vec<i32>>().unwrap();
         })
+    }
+
+    #[test]
+    fn test_tuple_contains() {
+        Python::with_gil(|py| {
+            let ob = (1, 1, 2, 3, 5, 8).to_object(py);
+            let tuple = <PyTuple as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            assert_eq!(6, tuple.len());
+
+            let bad_needle = 7i32.to_object(py);
+            assert!(!tuple.contains(&bad_needle).unwrap());
+
+            let good_needle = 8i32.to_object(py);
+            assert!(tuple.contains(&good_needle).unwrap());
+
+            let type_coerced_needle = 8f32.to_object(py);
+            assert!(tuple.contains(&type_coerced_needle).unwrap());
+        });
+    }
+
+    #[test]
+    fn test_tuple_index() {
+        Python::with_gil(|py| {
+            let ob = (1, 1, 2, 3, 5, 8).to_object(py);
+            let tuple = <PyTuple as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            assert_eq!(0, tuple.index(1i32).unwrap());
+            assert_eq!(2, tuple.index(2i32).unwrap());
+            assert_eq!(3, tuple.index(3i32).unwrap());
+            assert_eq!(4, tuple.index(5i32).unwrap());
+            assert_eq!(5, tuple.index(8i32).unwrap());
+            assert!(tuple.index(42i32).is_err());
+        });
     }
 }


### PR DESCRIPTION
See #1845

Since these are just literal copies of the sequence methods, this makes me think - could `PyList` deref to `PySequence`?
