### PR TITLE
ci: check and fix s390x build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,37 @@ jobs:
           components: clippy
       - run: make clippy
 
+  check-target:
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # If one platform fails, allow the rest to keep testing.
+      matrix:
+        target: [powerpc64le-unknown-linux-gnu, s390x-unknown-linux-gnu, wasm32-wasi]
+    name: check-${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          default: true
+
+      - name: Run cargo checks
+        run: |
+          set -x
+          VERSIONS=("3.6" "3.7" "3.8" "3.9" "3.10")
+          for VERSION in ${VERSIONS[@]}; do
+            echo "version=$VERSION" > config.txt
+            # TODO suppress linking using config file rather than extension-module feature
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "extension-module"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "extension-module abi3"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "extension-module macros num-bigint num-complex hashbrown indexmap serde multiple-pymethods"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "extension-module abi3 macros num-bigint num-complex hashbrown indexmap serde multiple-pymethods"
+          done
+
   build:
     needs: [fmt] # don't wait for clippy as fails rarely and takes longer
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} ${{ matrix.msrv }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Deprecate FFI definitions `PyParser_SimpleParseStringFlags`, `PyParser_SimpleParseStringFlagsFilename`, `PyParser_SimpleParseFileFlags` when building for Python 3.9. [#1830](https://github.com/PyO3/pyo3/pull/1830)
 - Mark FFI definitions removed in Python 3.10 `PyParser_ASTFromString`, `PyParser_ASTFromStringObject`, `PyParser_ASTFromFile`, `PyParser_ASTFromFileObject`, `PyParser_SimpleParseStringFlags`, `PyParser_SimpleParseStringFlagsFilename`, `PyParser_SimpleParseFileFlags`, `PyParser_SimpleParseString`, `PyParser_SimpleParseFile`, `Py_SymtableString`, and `Py_SymtableStringObject`. [#1830](https://github.com/PyO3/pyo3/pull/1830)
 
+### Fixed
+
+- Fix 0.14.4 compile regression on `s390x-unknown-linux-gnu` target. [#1850](https://github.com/PyO3/pyo3/pull/1850)
+
 ## [0.14.4] - 2021-08-29
 
 ### Changed

--- a/benches/bench_list.rs
+++ b/benches/bench_list.rs
@@ -37,6 +37,7 @@ fn list_get_item(b: &mut Bencher) {
     });
 }
 
+#[cfg(not(Py_LIMITED_API))]
 fn list_get_item_unchecked(b: &mut Bencher) {
     let gil = Python::acquire_gil();
     let py = gil.python();
@@ -56,6 +57,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("iter_list", iter_list);
     c.bench_function("list_new", list_new);
     c.bench_function("list_get_item", list_get_item);
+    #[cfg(not(Py_LIMITED_API))]
     c.bench_function("list_get_item_unchecked", list_get_item_unchecked);
 }
 

--- a/benches/bench_tuple.rs
+++ b/benches/bench_tuple.rs
@@ -37,6 +37,7 @@ fn tuple_get_item(b: &mut Bencher) {
     });
 }
 
+#[cfg(not(Py_LIMITED_API))]
 fn tuple_get_item_unchecked(b: &mut Bencher) {
     let gil = Python::acquire_gil();
     let py = gil.python();
@@ -56,6 +57,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("iter_tuple", iter_tuple);
     c.bench_function("tuple_new", tuple_new);
     c.bench_function("tuple_get_item", tuple_get_item);
+    #[cfg(not(Py_LIMITED_API))]
     c.bench_function("tuple_get_item_unchecked", tuple_get_item_unchecked);
 }
 

--- a/src/conversions/osstr.rs
+++ b/src/conversions/osstr.rs
@@ -163,7 +163,10 @@ mod tests {
     #[cfg(not(windows))]
     fn test_non_utf8_conversion() {
         Python::with_gil(|py| {
+            #[cfg(not(target_os = "wasi"))]
             use std::os::unix::ffi::OsStrExt;
+            #[cfg(target_os = "wasi")]
+            use std::os::wasi::ffi::OsStrExt;
 
             // this is not valid UTF-8
             let payload = &[250, 251, 252, 253, 254, 255, 0, 255];

--- a/src/conversions/path.rs
+++ b/src/conversions/path.rs
@@ -84,7 +84,10 @@ mod tests {
     fn test_non_utf8_conversion() {
         Python::with_gil(|py| {
             use std::ffi::OsStr;
+            #[cfg(not(target_os = "wasi"))]
             use std::os::unix::ffi::OsStrExt;
+            #[cfg(target_os = "wasi")]
+            use std::os::wasi::ffi::OsStrExt;
 
             // this is not valid UTF-8
             let payload = &[250, 251, 252, 253, 254, 255, 0, 255];

--- a/src/ffi/cpython/unicodeobject.rs
+++ b/src/ffi/cpython/unicodeobject.rs
@@ -1,6 +1,4 @@
-use crate::ffi::{
-    PyObject, PyUnicode_Check, Py_UCS1, Py_UCS2, Py_UCS4, Py_UNICODE, Py_hash_t, Py_ssize_t,
-};
+use crate::ffi::{PyObject, Py_UCS1, Py_UCS2, Py_UCS4, Py_UNICODE, Py_hash_t, Py_ssize_t};
 use libc::wchar_t;
 use std::os::raw::{c_char, c_int, c_uint, c_void};
 
@@ -121,7 +119,7 @@ pub const SSTATE_INTERNED_IMMORTAL: c_uint = 2;
 #[inline]
 #[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_IS_ASCII(op: *mut PyObject) -> c_uint {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
     debug_assert!(PyUnicode_IS_READY(op) != 0);
 
     (*(op as *mut PyASCIIObject)).ascii()
@@ -172,7 +170,7 @@ pub unsafe fn PyUnicode_4BYTE_DATA(op: *mut PyObject) -> *mut Py_UCS4 {
 #[inline]
 #[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_KIND(op: *mut PyObject) -> c_uint {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
     debug_assert!(PyUnicode_IS_READY(op) != 0);
 
     (*(op as *mut PyASCIIObject)).kind()
@@ -199,7 +197,7 @@ pub unsafe fn _PyUnicode_NONCOMPACT_DATA(op: *mut PyObject) -> *mut c_void {
 #[inline]
 #[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_DATA(op: *mut PyObject) -> *mut c_void {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
 
     if PyUnicode_IS_COMPACT(op) != 0 {
         _PyUnicode_COMPACT_DATA(op)
@@ -213,8 +211,9 @@ pub unsafe fn PyUnicode_DATA(op: *mut PyObject) -> *mut c_void {
 // skipped PyUnicode_READ_CHAR
 
 #[inline]
+#[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_GET_LENGTH(op: *mut PyObject) -> Py_ssize_t {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
     debug_assert!(PyUnicode_IS_READY(op) != 0);
 
     (*(op as *mut PyASCIIObject)).length
@@ -231,7 +230,7 @@ pub unsafe fn PyUnicode_IS_READY(op: *mut PyObject) -> c_uint {
 #[inline]
 #[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_READY(op: *mut PyObject) -> c_int {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
 
     if PyUnicode_IS_READY(op) != 0 {
         0

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -23,7 +23,7 @@ pub use self::num::PyLong as PyInt;
 pub use self::sequence::PySequence;
 pub use self::set::{PyFrozenSet, PySet};
 pub use self::slice::{PySlice, PySliceIndices};
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(not(any(Py_LIMITED_API, target_endian = "big")))]
 pub use self::string::PyStringData;
 pub use self::string::{PyString, PyString as PyUnicode};
 pub use self::tuple::PyTuple;

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -277,8 +277,10 @@ mod slow_128bit_int_conversion {
 mod test_128bit_intergers {
     use super::*;
 
+    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #[test]
         fn test_i128_roundtrip(x: i128) {
@@ -291,6 +293,7 @@ mod test_128bit_intergers {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #[test]
         fn test_u128_roundtrip(x: u128) {

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(not(any(Py_LIMITED_API, target_endian = "big")))]
 use crate::exceptions::PyUnicodeDecodeError;
 use crate::types::PyBytes;
 use crate::{
@@ -8,8 +8,6 @@ use crate::{
     ToPyObject,
 };
 use std::borrow::Cow;
-#[cfg(not(Py_LIMITED_API))]
-use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::str;
 
@@ -72,6 +70,7 @@ impl<'a> PyStringData<'a> {
     /// C APIs that skip input validation (like `PyUnicode_FromKindAndData`) and should
     /// never occur for strings that were created from Python code.
     pub fn to_string(self, py: Python) -> PyResult<Cow<'a, str>> {
+        use std::ffi::CStr;
         match self {
             Self::Ucs1(data) => match str::from_utf8(data) {
                 Ok(s) => Ok(Cow::Borrowed(s)),
@@ -365,16 +364,12 @@ impl FromPyObject<'_> for char {
 
 #[cfg(test)]
 mod tests {
-    use super::PyString;
-    #[cfg(not(Py_LIMITED_API))]
-    use super::PyStringData;
-    #[cfg(not(Py_LIMITED_API))]
-    use crate::exceptions::PyUnicodeDecodeError;
-    #[cfg(not(Py_LIMITED_API))]
+    use super::*;
+    #[cfg(not(any(Py_LIMITED_API, target_endian = "big")))]
     use crate::type_object::PyTypeObject;
     use crate::Python;
     use crate::{FromPyObject, PyObject, PyTryFrom, ToPyObject};
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(not(any(Py_LIMITED_API, target_endian = "big")))]
     use std::borrow::Cow;
 
     #[test]


### PR DESCRIPTION
Fixes the regressions for s390x reported in #1824, and adds some crude CI jobs which should prevent this happening again. Adds the same CI coverage for the `wasm32-wasi` target.

I don't actually try and run the tests on either platform, however I do at least check the build. If there are other targets we're aware are in use but are hard to actually test in CI, we could cover them too.