### PR TITLE
release: 0.14.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,37 @@ jobs:
           components: clippy
       - run: make clippy
 
+  check-target:
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # If one platform fails, allow the rest to keep testing.
+      matrix:
+        target: [powerpc64le-unknown-linux-gnu, s390x-unknown-linux-gnu, wasm32-wasi]
+    name: check-${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          profile: minimal
+          default: true
+
+      - name: Run cargo checks
+        run: |
+          set -x
+          VERSIONS=("3.6" "3.7" "3.8" "3.9" "3.10")
+          for VERSION in ${VERSIONS[@]}; do
+            echo "version=$VERSION" > config.txt
+            # TODO suppress linking using config file rather than extension-module feature
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "extension-module"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "extension-module abi3"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "extension-module macros num-bigint num-complex hashbrown indexmap serde multiple-pymethods"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "extension-module abi3 macros num-bigint num-complex hashbrown indexmap serde multiple-pymethods"
+          done
+
   build:
     needs: [fmt] # don't wait for clippy as fails rarely and takes longer
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} ${{ matrix.msrv }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,10 +178,22 @@ jobs:
       - name: Build (no features)
         run: cargo build --lib --tests --no-default-features
 
+      # --no-default-features when used with `cargo build/test -p` doesn't seem to work!
+      - name: Build pyo3-build-config (no features)
+        run: |
+          cd pyo3-build-config
+          cargo build --no-default-features
+
       # Run tests (except on PyPy, because no embedding API).
       - if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         name: Test (no features)
         run: cargo test --no-default-features
+
+      # --no-default-features when used with `cargo build/test -p` doesn't seem to work!
+      - name: Test pyo3-build-config (no features)
+        run: |
+          cd pyo3-build-config
+          cargo test --no-default-features
 
       - name: Build (all additive features)
         run: cargo build --lib --tests --no-default-features --features "${{ steps.settings.outputs.all_additive_features }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `resolve-config` feature to the `pyo3-build-config` to control whether its build script does anything. [#1856](https://github.com/PyO3/pyo3/pull/1856)
+
+### Changed
+
+- Make `pyo3-build-config::InterpreterConfig` and subfields public. [#1848](https://github.com/PyO3/pyo3/pull/1848)
+
 ### Fixed
 
 - Fix 0.14.4 compile regression on `s390x-unknown-linux-gnu` target. [#1850](https://github.com/PyO3/pyo3/pull/1850)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.5] - 2021-09-05
+
+## Added
+
+- Make `pyo3-build-config::InterpreterConfig` and subfields public. [#1848](https://github.com/PyO3/pyo3/pull/1848)
 
 ### Added
 
@@ -916,7 +920,8 @@ Yanked
 
 - Initial release
 
-[unreleased]: https://github.com/pyo3/pyo3/compare/v0.14.4...HEAD
+[unreleased]: https://github.com/pyo3/pyo3/compare/v0.14.5...HEAD
+[0.14.5]: https://github.com/pyo3/pyo3/compare/v0.14.4...v0.14.5
 [0.14.4]: https://github.com/pyo3/pyo3/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/pyo3/pyo3/compare/v0.14.2...v0.14.3
 [0.14.2]: https://github.com/pyo3/pyo3/compare/v0.14.1...v0.14.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix 0.14.4 compile regression on `s390x-unknown-linux-gnu` target. [#1850](https://github.com/PyO3/pyo3/pull/1850)
+
 ## [0.14.4] - 2021-08-29
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.14.4"
+version = "0.14.5"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -24,7 +24,7 @@ num-bigint = { version = "0.4", optional = true }
 num-complex = { version = ">= 0.2, < 0.5", optional = true }
 # must stay at 0.1.x for Rust 1.41 compatibility
 paste = { version = "0.1.18", optional = true }
-pyo3-macros = { path = "pyo3-macros", version = "=0.14.4", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.14.5", optional = true }
 unindent = { version = "0.1.4", optional = true }
 hashbrown = { version = ">= 0.9, < 0.12", optional = true }
 indexmap = { version = ">= 1.6, < 1.8", optional = true }
@@ -42,7 +42,7 @@ pyo3 = { path = ".", default-features = false, features = ["macros", "auto-initi
 serde_json = "1.0.61"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "0.14.4", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "0.14.5", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ pyo3 = { path = ".", default-features = false, features = ["macros", "auto-initi
 serde_json = "1.0.61"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "0.14.4" }
+pyo3-build-config = { path = "pyo3-build-config", version = "0.14.4", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3]
-version = "0.14.4"
+version = "0.14.5"
 features = ["extension-module"]
 ```
 
@@ -108,7 +108,7 @@ Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like th
 
 ```toml
 [dependencies.pyo3]
-version = "0.14.4"
+version = "0.14.5"
 features = ["auto-initialize"]
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -84,7 +84,7 @@ fn rustc_minor_version() -> Option<u32> {
     pieces.next()?.parse().ok()
 }
 
-fn emit_cargo_configuration(interpreter_config: &InterpreterConfig) -> Result<()> {
+fn emit_link_config(interpreter_config: &InterpreterConfig) -> Result<()> {
     let target_os = cargo_env_var("CARGO_CFG_TARGET_OS").unwrap();
     let is_extension_module = cargo_env_var("CARGO_FEATURE_EXTENSION_MODULE").is_some();
     if target_os == "windows" || target_os == "android" || !is_extension_module {
@@ -132,7 +132,10 @@ fn configure_pyo3() -> Result<()> {
     ensure_target_pointer_width(&interpreter_config)?;
     ensure_auto_initialize_ok(&interpreter_config)?;
 
-    emit_cargo_configuration(&interpreter_config)?;
+    if !interpreter_config.suppress_build_script_link_lines {
+        emit_link_config(&interpreter_config)?;
+    }
+
     interpreter_config.emit_pyo3_cfgs();
 
     let rustc_minor_version = rustc_minor_version().unwrap_or(0);

--- a/build.rs
+++ b/build.rs
@@ -147,6 +147,11 @@ fn configure_pyo3() -> Result<()> {
         println!("cargo:rustc-cfg=addr_of");
     }
 
+    // Extra lines come last, to support last write wins.
+    for line in &interpreter_config.extra_build_script_lines {
+        println!("{}", line);
+    }
+
     Ok(())
 }
 

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -69,6 +69,26 @@ The `nightly` feature needs the nightly Rust compiler. This allows PyO3 to use R
 - `FromPyObject` for `Vec` and `[T;N]` can perform a `memcpy` when the object supports the Python buffer protocol.
 - `ToBorrowedObject` can skip a reference count increase when the provided object is a Python native type.
 
+### `resolve-config`
+
+The `resolve-config` feature of the `pyo3-build-config` crate controls whether that crate's
+build script automatically resolves a Python interpreter / build configuration. Disabling
+this feature enables this crate to be used in *library mode*. This may be desirable for
+use cases where you want to read or write PyO3 build configuration files or resolve
+metadata about a Python interpreter.
+
+## Optional Dependencies
+
+These features enable conversions between Python types and types from other Rust crates, enabling easy access to the rest of the Rust ecosystem.
+
+### `hashbrown`
+
+Adds a dependency on [hashbrown](https://docs.rs/hashbrown) and enables conversions into its [`HashMap`](https://docs.rs/hashbrown/latest/hashbrown/struct.HashMap.html) and [`HashSet`](https://docs.rs/hashbrown/latest/hashbrown/struct.HashSet.html) types.
+
+### `indexmap`
+
+Adds a dependency on [indexmap](https://docs.rs/indexmap) and enables conversions into its [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html) type.
+
 ### `num-bigint`
 
 This feature adds a dependency on [num-bigint](https://docs.rs/num-bigint) and enables conversions into its [`BigInt`](https://docs.rs/num-bigint/latest/num_bigint/struct.BigInt.html) and [`BigUint`](https://docs.rs/num-bigint/latest/num_bigint/struct.BigUInt.html) types.

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.14.4"
+version = "0.14.5"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -14,7 +14,11 @@ edition = "2018"
 once_cell = "1"
 
 [features]
-default = []
+default = ["resolve-config"]
+
+# Attempt to resolve a Python interpreter config for building in the build
+# script. If this feature isn't enabled, the build script no-ops.
+resolve-config = []
 
 abi3 = []
 abi3-py36 = ["abi3-py37"]

--- a/pyo3-build-config/build.rs
+++ b/pyo3-build-config/build.rs
@@ -67,6 +67,7 @@ pub fn abi3_config() -> Option<InterpreterConfig> {
                 pointer_width: None,
                 executable: None,
                 shared: true,
+                suppress_build_script_link_lines: false,
                 extra_build_script_lines: vec![],
             });
         }

--- a/pyo3-build-config/build.rs
+++ b/pyo3-build-config/build.rs
@@ -91,8 +91,12 @@ fn generate_build_configs() -> Result<()> {
 }
 
 fn main() {
-    if let Err(e) = generate_build_configs() {
-        eprintln!("error: {}", e.report());
-        std::process::exit(1)
+    if std::env::var("CARGO_FEATURE_RESOLVE_CONFIG").is_ok() {
+        if let Err(e) = generate_build_configs() {
+            eprintln!("error: {}", e.report());
+            std::process::exit(1)
+        }
+    } else {
+        eprintln!("resolve-config feature not enabled; build script in no-op mode");
     }
 }

--- a/pyo3-build-config/build.rs
+++ b/pyo3-build-config/build.rs
@@ -67,6 +67,7 @@ pub fn abi3_config() -> Option<InterpreterConfig> {
                 pointer_width: None,
                 executable: None,
                 shared: true,
+                extra_build_script_lines: vec![],
             });
         }
     }

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -510,6 +510,7 @@ struct CrossCompileConfig {
     arch: String,
 }
 
+#[allow(unused)]
 pub fn any_cross_compiling_env_vars_set() -> bool {
     env::var_os("PYO3_CROSS").is_some()
         || env::var_os("PYO3_CROSS_LIB_DIR").is_some()

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -628,7 +628,7 @@ impl FromStr for BuildFlag {
 ///
 /// see Misc/SpecialBuilds.txt in the python source for what these mean.
 #[cfg_attr(test, derive(Debug, PartialEq))]
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct BuildFlags(pub HashSet<BuildFlag>);
 
 impl BuildFlags {

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -13,11 +13,7 @@ use std::io::Cursor;
 
 use once_cell::sync::OnceCell;
 
-use impl_::InterpreterConfig;
-
-// Used in `pyo3-macros-backend`; may expose this in a future release.
-#[doc(hidden)]
-pub use impl_::PythonVersion;
+pub use impl_::{BuildFlag, BuildFlags, InterpreterConfig, PythonImplementation, PythonVersion};
 
 /// Adds all the [`#[cfg]` flags](index.html) to the current compilation.
 ///

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -9,8 +9,10 @@
 mod errors;
 mod impl_;
 
+#[cfg(feature = "resolve-config")]
 use std::io::Cursor;
 
+#[cfg(feature = "resolve-config")]
 use once_cell::sync::OnceCell;
 
 pub use impl_::{BuildFlag, BuildFlags, InterpreterConfig, PythonImplementation, PythonVersion};
@@ -28,6 +30,7 @@ pub use impl_::{BuildFlag, BuildFlags, InterpreterConfig, PythonImplementation, 
 /// | `#[cfg(PyPy)]` | This marks code which is run when compiling for PyPy. |
 ///
 /// For examples of how to use these attributes, [see PyO3's guide](https://pyo3.rs/latest/building_and_distribution/multiple_python_versions.html).
+#[cfg(feature = "resolve-config")]
 pub fn use_pyo3_cfgs() {
     get().emit_pyo3_cfgs();
 }
@@ -56,6 +59,7 @@ fn _add_extension_module_link_args(target_os: &str, mut writer: impl std::io::Wr
 ///
 /// Because this will never change in a given compilation run, this is cached in a `once_cell`.
 #[doc(hidden)]
+#[cfg(feature = "resolve-config")]
 pub fn get() -> &'static InterpreterConfig {
     static CONFIG: OnceCell<InterpreterConfig> = OnceCell::new();
     CONFIG.get_or_init(|| {
@@ -74,23 +78,28 @@ pub fn get() -> &'static InterpreterConfig {
 
 /// Path where PyO3's build.rs will write configuration by default.
 #[doc(hidden)]
+#[cfg(feature = "resolve-config")]
 const DEFAULT_CROSS_COMPILE_CONFIG_PATH: &str =
     concat!(env!("OUT_DIR"), "/pyo3-cross-compile-config.txt");
 
 /// Build configuration provided by `PYO3_CONFIG_FILE`. May be empty if env var not set.
 #[doc(hidden)]
+#[cfg(feature = "resolve-config")]
 const CONFIG_FILE: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config-file.txt"));
 
 /// Build configuration set if abi3 features enabled and `PYO3_NO_PYTHON` env var present. Empty if
 /// not both present.
 #[doc(hidden)]
+#[cfg(feature = "resolve-config")]
 const ABI3_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config-abi3.txt"));
 
 /// Build configuration discovered by `pyo3-build-config` build script. Not aware of
 /// cross-compilation settings.
 #[doc(hidden)]
+#[cfg(feature = "resolve-config")]
 const HOST_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config.txt"));
 
+#[cfg(feature = "resolve-config")]
 fn abi3_config() -> InterpreterConfig {
     let mut interpreter_config = InterpreterConfig::from_reader(Cursor::new(ABI3_CONFIG))
         .expect("failed to parse hardcoded PyO3 abi3 config");
@@ -109,9 +118,12 @@ fn abi3_config() -> InterpreterConfig {
 /// Please don't use these - they could change at any time.
 #[doc(hidden)]
 pub mod pyo3_build_script_impl {
+    #[cfg(feature = "resolve-config")]
     use crate::errors::{Context, Result};
+    #[cfg(feature = "resolve-config")]
     use std::path::Path;
 
+    #[cfg(feature = "resolve-config")]
     use super::*;
 
     pub mod errors {
@@ -126,6 +138,7 @@ pub mod pyo3_build_script_impl {
     /// Differs from .get() above only in the cross-compile case, where PyO3's build script is
     /// required to generate a new config (as it's the first build script which has access to the
     /// correct value for CARGO_CFG_TARGET_OS).
+    #[cfg(feature = "resolve-config")]
     pub fn resolve_interpreter_config() -> Result<InterpreterConfig> {
         if !CONFIG_FILE.is_empty() {
             InterpreterConfig::from_reader(Cursor::new(CONFIG_FILE))

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.14.4"
+version = "0.14.5"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "0.14.4", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "0.14.5", features = ["resolve-config"] }
 
 [dependencies.syn]
 version = "1"

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 [dependencies]
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "0.14.4" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "0.14.4", features = ["resolve-config"] }
 
 [dependencies.syn]
 version = "1"

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.14.4"
+version = "0.14.5"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,4 +16,4 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.14.4" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.14.5" }

--- a/src/conversions/osstr.rs
+++ b/src/conversions/osstr.rs
@@ -164,7 +164,10 @@ mod tests {
     #[cfg(not(windows))]
     fn test_non_utf8_conversion() {
         Python::with_gil(|py| {
+            #[cfg(not(target_os = "wasi"))]
             use std::os::unix::ffi::OsStrExt;
+            #[cfg(target_os = "wasi")]
+            use std::os::wasi::ffi::OsStrExt;
 
             // this is not valid UTF-8
             let payload = &[250, 251, 252, 253, 254, 255, 0, 255];

--- a/src/conversions/path.rs
+++ b/src/conversions/path.rs
@@ -84,7 +84,10 @@ mod tests {
     fn test_non_utf8_conversion() {
         Python::with_gil(|py| {
             use std::ffi::OsStr;
+            #[cfg(not(target_os = "wasi"))]
             use std::os::unix::ffi::OsStrExt;
+            #[cfg(target_os = "wasi")]
+            use std::os::wasi::ffi::OsStrExt;
 
             // this is not valid UTF-8
             let payload = &[250, 251, 252, 253, 254, 255, 0, 255];

--- a/src/ffi/cpython/unicodeobject.rs
+++ b/src/ffi/cpython/unicodeobject.rs
@@ -1,6 +1,4 @@
-use crate::ffi::{
-    PyObject, PyUnicode_Check, Py_UCS1, Py_UCS2, Py_UCS4, Py_UNICODE, Py_hash_t, Py_ssize_t,
-};
+use crate::ffi::{PyObject, Py_UCS1, Py_UCS2, Py_UCS4, Py_UNICODE, Py_hash_t, Py_ssize_t};
 use libc::wchar_t;
 use std::os::raw::{c_char, c_int, c_uint, c_void};
 
@@ -121,7 +119,7 @@ pub const SSTATE_INTERNED_IMMORTAL: c_uint = 2;
 #[inline]
 #[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_IS_ASCII(op: *mut PyObject) -> c_uint {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
     debug_assert!(PyUnicode_IS_READY(op) != 0);
 
     (*(op as *mut PyASCIIObject)).ascii()
@@ -172,7 +170,7 @@ pub unsafe fn PyUnicode_4BYTE_DATA(op: *mut PyObject) -> *mut Py_UCS4 {
 #[inline]
 #[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_KIND(op: *mut PyObject) -> c_uint {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
     debug_assert!(PyUnicode_IS_READY(op) != 0);
 
     (*(op as *mut PyASCIIObject)).kind()
@@ -199,7 +197,7 @@ pub unsafe fn _PyUnicode_NONCOMPACT_DATA(op: *mut PyObject) -> *mut c_void {
 #[inline]
 #[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_DATA(op: *mut PyObject) -> *mut c_void {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
 
     if PyUnicode_IS_COMPACT(op) != 0 {
         _PyUnicode_COMPACT_DATA(op)
@@ -213,8 +211,9 @@ pub unsafe fn PyUnicode_DATA(op: *mut PyObject) -> *mut c_void {
 // skipped PyUnicode_READ_CHAR
 
 #[inline]
+#[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_GET_LENGTH(op: *mut PyObject) -> Py_ssize_t {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
     debug_assert!(PyUnicode_IS_READY(op) != 0);
 
     (*(op as *mut PyASCIIObject)).length
@@ -231,7 +230,7 @@ pub unsafe fn PyUnicode_IS_READY(op: *mut PyObject) -> c_uint {
 #[inline]
 #[cfg(not(target_endian = "big"))]
 pub unsafe fn PyUnicode_READY(op: *mut PyObject) -> c_int {
-    debug_assert!(PyUnicode_Check(op) != 0);
+    debug_assert!(crate::ffi::PyUnicode_Check(op) != 0);
 
     if PyUnicode_IS_READY(op) != 0 {
         0

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -23,7 +23,7 @@ pub use self::num::PyLong as PyInt;
 pub use self::sequence::PySequence;
 pub use self::set::{PyFrozenSet, PySet};
 pub use self::slice::{PySlice, PySliceIndices};
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(not(any(Py_LIMITED_API, target_endian = "big")))]
 pub use self::string::PyStringData;
 pub use self::string::{PyString, PyString as PyUnicode};
 pub use self::tuple::PyTuple;

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -280,8 +280,10 @@ mod slow_128bit_int_conversion {
 mod test_128bit_intergers {
     use super::*;
 
+    #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #[test]
         fn test_i128_roundtrip(x: i128) {
@@ -294,6 +296,7 @@ mod test_128bit_intergers {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #[test]
         fn test_u128_roundtrip(x: u128) {

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(not(any(Py_LIMITED_API, target_endian = "big")))]
 use crate::exceptions::PyUnicodeDecodeError;
 use crate::types::PyBytes;
 use crate::{
@@ -8,8 +8,6 @@ use crate::{
     Python, ToPyObject,
 };
 use std::borrow::Cow;
-#[cfg(not(Py_LIMITED_API))]
-use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::str;
 
@@ -72,6 +70,7 @@ impl<'a> PyStringData<'a> {
     /// C APIs that skip input validation (like `PyUnicode_FromKindAndData`) and should
     /// never occur for strings that were created from Python code.
     pub fn to_string(self, py: Python) -> PyResult<Cow<'a, str>> {
+        use std::ffi::CStr;
         match self {
             Self::Ucs1(data) => match str::from_utf8(data) {
                 Ok(s) => Ok(Cow::Borrowed(s)),
@@ -365,16 +364,12 @@ impl FromPyObject<'_> for char {
 
 #[cfg(test)]
 mod tests {
-    use super::PyString;
-    #[cfg(not(Py_LIMITED_API))]
-    use super::PyStringData;
-    #[cfg(not(Py_LIMITED_API))]
-    use crate::exceptions::PyUnicodeDecodeError;
-    #[cfg(not(Py_LIMITED_API))]
+    use super::*;
+    #[cfg(not(any(Py_LIMITED_API, target_endian = "big")))]
     use crate::type_object::PyTypeObject;
     use crate::Python;
     use crate::{FromPyObject, PyObject, PyTryFrom, ToPyObject};
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(not(any(Py_LIMITED_API, target_endian = "big")))]
     use std::borrow::Cow;
 
     #[test]


### PR DESCRIPTION
This cherry-picks #1793, #1848, and #1850 for the 0.14 series.

As well as releasing the fix for the fedora packaging issue on s390x (#1824), my hope is that PyOxidizer will be able to use this release. cc @indygreg it'd be great if you're able to test PyOxidizer against this branch!

I propose I put this live on Sunday.