### PR TITLE
Revert "ci: pin parking_lot to 0.11.1 on MSRV"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,6 @@ jobs:
           cargo update -p indexmap --precise 1.6.2
           cargo update -p hashbrown:0.11.2 --precise 0.9.1
           cargo update -p bitflags --precise 1.2.1
-          cargo update -p parking_lot --precise 0.11.1
-          cargo update -p parking_lot_core --precise 0.8.3
 
       - name: Build docs
         run: cargo doc --no-deps --no-default-features --features "${{ steps.settings.outputs.all_additive_features }}"


### PR DESCRIPTION
Reverts PyO3/pyo3#1838

Looks like it supports 1.41 now (https://github.com/Amanieu/parking_lot/commit/aecb031e795391025d33f3f26f83ab24102ca42f)