### PR TITLE
pyo3-build-config: derive Clone on BuildFlags

### DIFF
--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -628,7 +628,7 @@ impl FromStr for BuildFlag {
 ///
 /// see Misc/SpecialBuilds.txt in the python source for what these mean.
 #[cfg_attr(test, derive(Debug, PartialEq))]
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct BuildFlags(pub HashSet<BuildFlag>);
 
 impl BuildFlags {


### PR DESCRIPTION
This isn't strictly necessary since you can `.0.clone()`. But it is
more ergonomic.

Found this when porting PyOxidizer to the 0.14.5 branch.