### PR TITLE
build-config: Always pass `abi3` flag to `default_lib_name_windows()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix building with a conda environment on Windows. [#1873](https://github.com/PyO3/pyo3/pull/1873)
 - Fix panic on Python 3.6 when calling `Python::with_gil` with Python initialized but threading not initialized. [#1874](https://github.com/PyO3/pyo3/pull/1874)
+- Fix incorrect linking to version-specific DLL instead of `python3.dll` when cross-compiling to Windows with `abi3`. [#1880](https://github.com/PyO3/pyo3/pull/1880)
 
 ## [0.14.5] - 2021-09-05
 

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -982,12 +982,14 @@ fn windows_hardcoded_cross_compile(
     let version = cross_compile_config.version.or_else(get_abi3_version)
         .ok_or("PYO3_CROSS_PYTHON_VERSION or an abi3-py3* feature must be specified when cross-compiling for Windows.")?;
 
+    let abi3 = is_abi3();
+
     Ok(InterpreterConfig {
         implementation: PythonImplementation::CPython,
         version,
         shared: true,
-        abi3: is_abi3(),
-        lib_name: Some(default_lib_name_windows(version, false, false)),
+        abi3,
+        lib_name: Some(default_lib_name_windows(version, abi3, false)),
         lib_dir: cross_compile_config.lib_dir.to_str().map(String::from),
         executable: None,
         pointer_width: None,


### PR DESCRIPTION
Hardcoding `false` here leads to an incorrect abi3 DLL name
when cross-compiling to Windows.