### PR TITLE
Hide some macros

### DIFF
--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -8,6 +8,7 @@ use std::ops;
 use std::os::raw::c_char;
 
 /// The boilerplate to convert between a Rust type and a Python exception.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_exception_boilerplate {
     ($name: ident) => {
@@ -158,6 +159,7 @@ macro_rules! create_exception {
 
 /// `impl $crate::type_object::PyTypeObject for $name` where `$name` is an
 /// exception newly defined in Rust code.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! create_exception_type_object {
     ($module: ident, $name: ident, $base: ty) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,9 @@
 //!
 //! ## Unstable features
 //!
-//! - `nightly`: Gates some optimizations that rely on [`#![feature(specialization)]`], for which
-//! you'd also need nightly Rust. You should not use this feature.
+//! - `nightly`: Gates some optimizations that rely on
+//! [`#![feature(specialization)]`](https://github.com/rust-lang/rfcs/blob/master/text/1210-impl-specialization.md),
+//! for which you'd also need nightly Rust. You should not use this feature.
 //
 //! ## `rustc` environment flags
 //!
@@ -276,8 +277,7 @@
 //! [PEP 384]: https://www.python.org/dev/peps/pep-0384 "PEP 384 -- Defining a Stable ABI"
 //! [Python from Rust]: https://github.com/PyO3/pyo3#using-python-from-rust
 //! [Rust from Python]: https://github.com/PyO3/pyo3#using-rust-from-python
-//! [`#![feature(specialization)]`]: <https://github.com/rust-lang/rfcs/blob/master/text/1210-impl-specialization.md>
-//! [Features chapter of the guide]: <https://pyo3.rs/latest/features.html#features-reference> "Features Reference - PyO3 user guide"
+//! [Features chapter of the guide]: https://pyo3.rs/latest/features.html#features-reference "Features Reference - PyO3 user guide"
 pub use crate::class::*;
 pub use crate::conversion::{
     AsPyPointer, FromPyObject, FromPyPointer, IntoPy, IntoPyPointer, PyTryFrom, PyTryInto,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -30,6 +30,7 @@ pub use self::tuple::PyTuple;
 pub use self::typeobject::PyType;
 
 // Implementations core to all native types
+#[doc(hidden)]
 #[macro_export]
 macro_rules! pyobject_native_type_base(
     ($name:ty $(;$generics:ident)* ) => {
@@ -75,6 +76,7 @@ macro_rules! pyobject_native_type_base(
 
 // Implementations core to all native types except for PyAny (because they don't
 // make sense on PyAny / have different implementations).
+#[doc(hidden)]
 #[macro_export]
 macro_rules! pyobject_native_type_named (
     ($name:ty $(;$generics:ident)*) => {
@@ -129,6 +131,7 @@ macro_rules! pyobject_native_type_named (
     };
 );
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! pyobject_native_type_info(
     ($name:ty, $typeobject:expr, $module:expr $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
@@ -159,6 +162,7 @@ macro_rules! pyobject_native_type_info(
 
 // NOTE: This macro is not included in pyobject_native_type_base!
 // because rust-numpy has a special implementation.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! pyobject_native_type_extract {
     ($name:ty $(;$generics:ident)*) => {
@@ -171,6 +175,7 @@ macro_rules! pyobject_native_type_extract {
 }
 
 /// Declares all of the boilerplate for Python types.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! pyobject_native_type_core {
     ($name:ty, $typeobject:expr, #module=$module:expr $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
@@ -183,6 +188,7 @@ macro_rules! pyobject_native_type_core {
     };
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! pyobject_native_type_sized {
     ($name:ty, $layout:path $(;$generics:ident)*) => {
@@ -201,6 +207,7 @@ macro_rules! pyobject_native_type_sized {
 
 /// Declares all of the boilerplate for Python types which can be inherited from (because the exact
 /// Python layout is known).
+#[doc(hidden)]
 #[macro_export]
 macro_rules! pyobject_native_type {
     ($name:ty, $layout:path, $typeobject:expr $(, #module=$module:expr)? $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {


### PR DESCRIPTION
Adds #[doc(hidden)] on a bunch of implementation detail-y macros.

Resolves #1869 
