### PR TITLE
pep 604: use `T | U` instead of `Union[T, U]` in messaging

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -121,7 +121,7 @@ struct RustyTransparentStruct {
 
 The `FromPyObject` derivation for enums generates code that tries to extract the variants in the
 order of the fields. As soon as a variant can be extracted succesfully, that variant is returned.
-This makes it possible to extract Python types like `Union[str, int]`.
+This makes it possible to extract Python union types like `str | int`.
 
 The same customizations and restrictions described for struct derivations apply to enum variants,
 i.e. a tuple variant assumes that the input is a Python tuple, and a struct variant defaults to
@@ -171,7 +171,7 @@ enum RustyEnum {
 ```
 
 If the input is neither a string nor an integer, the error message will be:
-`"'<INPUT_TYPE>' cannot be converted to 'Union[str, int]'"`.
+`"'<INPUT_TYPE>' cannot be converted to 'str | int'"`.
 
 #### `#[derive(FromPyObject)]` Container Attributes
 - `pyo3(transparent)`

--- a/pyo3-macros-backend/src/from_pyobject.rs
+++ b/pyo3-macros-backend/src/from_pyobject.rs
@@ -69,16 +69,11 @@ impl<'a> Enum<'a> {
             );
 
             var_extracts.push(ext);
-            error_names.push_str(&var.err_name);
-            if i < self.variants.len() - 1 {
-                error_names.push_str(", ");
+            if i > 0 {
+                error_names.push_str(" | ");
             }
+            error_names.push_str(&var.err_name);
         }
-        let error_names = if self.variants.len() > 1 {
-            format!("Union[{}]", error_names)
-        } else {
-            error_names
-        };
         let ty_name = self.enum_ident.to_string();
         quote!(
             let mut err_reasons = ::std::string::String::new();

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -409,7 +409,7 @@ fn test_err_rename() {
         assert!(f.is_err());
         assert_eq!(
             f.unwrap_err().to_string(),
-            "TypeError: failed to extract enum Bar (\'Union[str, uint, int]\')\n- variant A (str): \
+            "TypeError: failed to extract enum Bar (\'str | uint | int\')\n- variant A (str): \
          \'dict\' object cannot be converted to \'PyString\'\n- variant B (uint): \'dict\' object \
          cannot be interpreted as an integer\n- variant C (int): \'dict\' object cannot be \
          interpreted as an integer\n"


### PR DESCRIPTION
See #1781 

I think `T | U` is nicer syntax than `Union[T, U]`. Also, we only use it in error messages, so I think we can use this syntax on all Python versions (not just 3.10+).