### PR TITLE
ffi: cleanup from sysmodule to tupleobject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate FFI definitions `PyParser_SimpleParseStringFlags`, `PyParser_SimpleParseStringFlagsFilename`, `PyParser_SimpleParseFileFlags` when building for Python 3.9. [#1830](https://github.com/PyO3/pyo3/pull/1830)
 - Mark FFI definitions removed in Python 3.10 `PyParser_ASTFromString`, `PyParser_ASTFromStringObject`, `PyParser_ASTFromFile`, `PyParser_ASTFromFileObject`, `PyParser_SimpleParseStringFlags`, `PyParser_SimpleParseStringFlagsFilename`, `PyParser_SimpleParseFileFlags`, `PyParser_SimpleParseString`, `PyParser_SimpleParseFile`, `Py_SymtableString`, and `Py_SymtableStringObject`. [#1830](https://github.com/PyO3/pyo3/pull/1830)
 - `pyo3`'s `Cargo.toml` now advertises `links = "python"` to inform Cargo that it links against *libpython*. [#1819](https://github.com/PyO3/pyo3/pull/1819)
+- Move Py_DecodeLocale from sysmodule to fileutils. [#1887](https://github.com/PyO3/pyo3/pull/1887)
+- Deprecate `PySys_AddWarnOption`, `PySys_AddWarnOptionUnicode` and `PySys_HasWarnOptions`. [#1887](https://github.com/PyO3/pyo3/pull/1887)
+- Remove function PyTuple_ClearFreeList from python 3.9 above. [#1887](https://github.com/PyO3/pyo3/pull/1887)
 
 ### Fixed
 

--- a/src/ffi/cpython/code.rs
+++ b/src/ffi/cpython/code.rs
@@ -90,7 +90,7 @@ pub unsafe fn PyCode_Check(op: *mut PyObject) -> c_int {
 #[inline]
 #[cfg(not(PyPy))]
 pub unsafe fn PyCode_GetNumFree(op: *mut PyCodeObject) -> Py_ssize_t {
-    crate::ffi::tupleobject::PyTuple_GET_SIZE((*op).co_freevars)
+    crate::ffi::PyTuple_GET_SIZE((*op).co_freevars)
 }
 
 extern "C" {

--- a/src/ffi/cpython/mod.rs
+++ b/src/ffi/cpython/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod compile;
 #[cfg(not(PyPy))]
 pub(crate) mod dictobject;
 // skipped fileobject.h
+// skipped fileutils.h
 pub(crate) mod frameobject;
 pub(crate) mod import;
 #[cfg(all(Py_3_8, not(PyPy)))]
@@ -21,6 +22,8 @@ pub(crate) mod pydebug;
 pub(crate) mod pylifecycle;
 pub(crate) mod pystate;
 pub(crate) mod pythonrun;
+// skipped sysmodule.h
+pub(crate) mod tupleobject;
 pub(crate) mod unicodeobject;
 
 pub use self::abstract_::*;
@@ -43,4 +46,5 @@ pub use self::pydebug::*;
 pub use self::pylifecycle::*;
 pub use self::pystate::*;
 pub use self::pythonrun::*;
+pub use self::tupleobject::*;
 pub use self::unicodeobject::*;

--- a/src/ffi/cpython/tupleobject.rs
+++ b/src/ffi/cpython/tupleobject.rs
@@ -1,0 +1,43 @@
+use crate::ffi::object::*;
+#[cfg(not(PyPy))]
+use crate::ffi::pyport::Py_ssize_t;
+
+#[repr(C)]
+pub struct PyTupleObject {
+    pub ob_base: PyVarObject,
+    pub ob_item: [*mut PyObject; 1],
+}
+
+// skipped _PyTuple_Resize
+// skipped _PyTuple_MaybeUntrack
+
+/// Macro, trading safety for speed
+
+// skipped _PyTuple_CAST
+
+#[inline]
+#[cfg(not(PyPy))]
+pub unsafe fn PyTuple_GET_SIZE(op: *mut PyObject) -> Py_ssize_t {
+    Py_SIZE(op)
+}
+
+#[inline]
+#[cfg(not(PyPy))]
+pub unsafe fn PyTuple_GET_ITEM(op: *mut PyObject, i: Py_ssize_t) -> *mut PyObject {
+    *(*(op as *mut PyTupleObject))
+        .ob_item
+        .as_ptr()
+        .offset(i as isize)
+}
+
+/// Macro, *only* to be used to fill in brand new tuples
+#[inline]
+#[cfg(not(PyPy))]
+pub unsafe fn PyTuple_SET_ITEM(op: *mut PyObject, i: Py_ssize_t, v: *mut PyObject) {
+    *(*(op as *mut PyTupleObject))
+        .ob_item
+        .as_mut_ptr()
+        .offset(i as isize) = v;
+}
+
+// skipped _PyTuple_DebugMallocStats

--- a/src/ffi/fileutils.rs
+++ b/src/ffi/fileutils.rs
@@ -1,0 +1,9 @@
+use crate::ffi::pyport::Py_ssize_t;
+use libc::wchar_t;
+use std::os::raw::c_char;
+
+extern "C" {
+    pub fn Py_DecodeLocale(arg1: *const c_char, size: *mut Py_ssize_t) -> *mut wchar_t;
+
+    pub fn Py_EncodeLocale(text: *const wchar_t, error_pos: *mut Py_ssize_t) -> *mut c_char;
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -58,6 +58,7 @@ pub use self::dictobject::*;
 pub use self::enumobject::*;
 pub use self::eval::*;
 pub use self::fileobject::*;
+pub use self::fileutils::*;
 pub use self::floatobject::*;
 #[cfg(not(Py_LIMITED_API))]
 pub use self::funcobject::*;
@@ -131,7 +132,7 @@ mod eval; // TODO supports PEP-384 only
 // skipped exports.h
 mod fileobject; // TODO: incomplete
 
-// skipped fileutils.h
+mod fileutils;
 mod floatobject; // TODO supports PEP-384 only
 
 // skipped empty frameobject.h
@@ -204,6 +205,7 @@ mod pycapsule; // TODO supports PEP-384 only; needs adjustment for Python 3.3 an
 mod sliceobject;
 mod structseq;
 mod traceback; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
+               // skipped tracemalloc.h
 mod warnings; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 mod weakrefobject; // TODO supports PEP-384 only; needs adjustment for Python 3.3 and 3.5
 

--- a/src/ffi/sysmodule.rs
+++ b/src/ffi/sysmodule.rs
@@ -1,27 +1,32 @@
 use crate::ffi::object::PyObject;
-use crate::ffi::pyport::Py_ssize_t;
 use libc::wchar_t;
 use std::os::raw::{c_char, c_int};
 
 extern "C" {
-    pub fn Py_DecodeLocale(arg1: *const c_char, arg2: *mut Py_ssize_t) -> *mut wchar_t;
     #[cfg_attr(PyPy, link_name = "PyPySys_GetObject")]
     pub fn PySys_GetObject(arg1: *const c_char) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPySys_SetObject")]
     pub fn PySys_SetObject(arg1: *const c_char, arg2: *mut PyObject) -> c_int;
+
     pub fn PySys_SetArgv(arg1: c_int, arg2: *mut *mut wchar_t);
     pub fn PySys_SetArgvEx(arg1: c_int, arg2: *mut *mut wchar_t, arg3: c_int);
     pub fn PySys_SetPath(arg1: *const wchar_t);
+
     #[cfg_attr(PyPy, link_name = "PyPySys_WriteStdout")]
     pub fn PySys_WriteStdout(format: *const c_char, ...);
     #[cfg_attr(PyPy, link_name = "PyPySys_WriteStderr")]
     pub fn PySys_WriteStderr(format: *const c_char, ...);
     pub fn PySys_FormatStdout(format: *const c_char, ...);
     pub fn PySys_FormatStderr(format: *const c_char, ...);
+
     pub fn PySys_ResetWarnOptions();
+    #[cfg_attr(Py_3_11, deprecated(note = "Python 3.11"))]
     pub fn PySys_AddWarnOption(arg1: *const wchar_t);
+    #[cfg_attr(Py_3_11, deprecated(note = "Python 3.11"))]
     pub fn PySys_AddWarnOptionUnicode(arg1: *mut PyObject);
+    #[cfg_attr(Py_3_11, deprecated(note = "Python 3.11"))]
     pub fn PySys_HasWarnOptions() -> c_int;
+
     pub fn PySys_AddXOption(arg1: *const wchar_t);
     pub fn PySys_GetXOptions() -> *mut PyObject;
 }

--- a/src/ffi/tupleobject.rs
+++ b/src/ffi/tupleobject.rs
@@ -2,12 +2,6 @@ use crate::ffi::object::*;
 use crate::ffi::pyport::Py_ssize_t;
 use std::os::raw::c_int;
 
-#[repr(C)]
-pub struct PyTupleObject {
-    pub ob_base: PyVarObject,
-    pub ob_item: [*mut PyObject; 1],
-}
-
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyTuple_Type")]
@@ -42,31 +36,6 @@ extern "C" {
     ) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyTuple_Pack")]
     pub fn PyTuple_Pack(arg1: Py_ssize_t, ...) -> *mut PyObject;
+    #[cfg(not(Py_3_9))]
     pub fn PyTuple_ClearFreeList() -> c_int;
-}
-
-/// Macro, trading safety for speed
-#[inline]
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
-pub unsafe fn PyTuple_GET_ITEM(op: *mut PyObject, i: Py_ssize_t) -> *mut PyObject {
-    *(*(op as *mut PyTupleObject))
-        .ob_item
-        .as_ptr()
-        .offset(i as isize)
-}
-
-#[inline]
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
-pub unsafe fn PyTuple_GET_SIZE(op: *mut PyObject) -> Py_ssize_t {
-    Py_SIZE(op)
-}
-
-/// Macro, *only* to be used to fill in brand new tuples
-#[inline]
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
-pub unsafe fn PyTuple_SET_ITEM(op: *mut PyObject, i: Py_ssize_t, v: *mut PyObject) {
-    *(*(op as *mut PyTupleObject))
-        .ob_item
-        .as_mut_ptr()
-        .offset(i as isize) = v;
 }


### PR DESCRIPTION
For #1289

Change list:
* Move `Py_DecodeLocale` from `sysmodule` to `fileutils`
* Add python 3.11 deprecation for `PySys_AddWarnOption`, `PySys_AddWarnOptionUnicode` and `PySys_HasWarnOptions`
* Remove function `PyTuple_ClearFreeList` from python 3.9 above
* Move tupleobject non-limited api into ffi/cpython/
