### PR TITLE
Remove use of unwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate FFI definitions `PyParser_SimpleParseStringFlags`, `PyParser_SimpleParseStringFlagsFilename`, `PyParser_SimpleParseFileFlags` when building for Python 3.9. [#1830](https://github.com/PyO3/pyo3/pull/1830)
 - Mark FFI definitions removed in Python 3.10 `PyParser_ASTFromString`, `PyParser_ASTFromStringObject`, `PyParser_ASTFromFile`, `PyParser_ASTFromFileObject`, `PyParser_SimpleParseStringFlags`, `PyParser_SimpleParseStringFlagsFilename`, `PyParser_SimpleParseFileFlags`, `PyParser_SimpleParseString`, `PyParser_SimpleParseFile`, `Py_SymtableString`, and `Py_SymtableStringObject`. [#1830](https://github.com/PyO3/pyo3/pull/1830)
 - `pyo3`'s `Cargo.toml` now advertises `links = "python"` to inform Cargo that it links against *libpython*. [#1819](https://github.com/PyO3/pyo3/pull/1819)
+- Replace `unwrap` with `?` in derivation body for enums. [#1888](https://github.com/PyO3/pyo3/pull/1888)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move Py_DecodeLocale from sysmodule to fileutils. [#1887](https://github.com/PyO3/pyo3/pull/1887)
 - Deprecate `PySys_AddWarnOption`, `PySys_AddWarnOptionUnicode` and `PySys_HasWarnOptions`. [#1887](https://github.com/PyO3/pyo3/pull/1887)
 - Remove function PyTuple_ClearFreeList from python 3.9 above. [#1887](https://github.com/PyO3/pyo3/pull/1887)
-- Replace `unwrap` with `?` in derivation body for enums. [#1888](https://github.com/PyO3/pyo3/pull/1888)
 
 ### Fixed
 
 - Fix building with a conda environment on Windows. [#1873](https://github.com/PyO3/pyo3/pull/1873)
 - Fix panic on Python 3.6 when calling `Python::with_gil` with Python initialized but threading not initialized. [#1874](https://github.com/PyO3/pyo3/pull/1874)
 - Fix incorrect linking to version-specific DLL instead of `python3.dll` when cross-compiling to Windows with `abi3`. [#1880](https://github.com/PyO3/pyo3/pull/1880)
+- Fix panic in generated `#[derive(FromPyObject)]` for enums. [#1888](https://github.com/PyO3/pyo3/pull/1888)
 
 ## [0.14.5] - 2021-09-05
 

--- a/pyo3-macros-backend/src/from_pyobject.rs
+++ b/pyo3-macros-backend/src/from_pyobject.rs
@@ -63,7 +63,7 @@ impl<'a> Enum<'a> {
                     ok @ ::std::result::Result::Ok(_) => return ok,
                     ::std::result::Result::Err(inner) => {
                         let py = ::pyo3::PyNativeType::py(obj);
-                        err_reasons.push_str(&::std::format!("{}\n", inner.instance(py).str().unwrap()));
+                        err_reasons.push_str(&::std::format!("{}\n", inner.instance(py).str()?));
                     }
                 }
             );


### PR DESCRIPTION
Propagates error back instead of panicking. We had an issue in production when a worker in the process of shutting down returned `SystemExit` when calling `inner.instance(py).str()` on the Python object. This should be propagated back instead of resulting in a `PanicException`. 

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: PyErr { type: <class 'SystemExit'>, value: SystemExit(1), traceback: Some(<traceback object at 0x7fe1bbcacd70>) }'
```