### PR TITLE
Clean up doctests, deny some lints

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ use pyo3::types::IntoPyDict;
 fn main() -> PyResult<()> {
     Python::with_gil(|py| {
         let sys = py.import("sys")?;
-        let version: String = sys.get("version")?.extract()?;
+        let version: String = sys.getattr("version")?.extract()?;
 
         let locals = [("os", py.import("os")?)].into_py_dict(py);
         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -78,7 +78,6 @@ For users who are not very familiar with `RefCell`, here is a reminder of Rust's
 
 ```rust
 # use pyo3::prelude::*;
-# use pyo3::types::PyDict;
 #[pyclass]
 struct MyClass {
     #[pyo3(get)]

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -300,7 +300,7 @@ use pyo3::PyIterProtocol;
 
 #[pyclass]
 struct MyIterator {
-    iter: Box<Iterator<Item = PyObject> + Send>,
+    iter: Box<dyn Iterator<Item = PyObject> + Send>,
 }
 
 #[pyproto]

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -199,8 +199,6 @@ mod io {
 }
 
 fn tell(file: &PyAny) -> PyResult<u64> {
-    use pyo3::exceptions::*;
-
     match file.call_method0("tell") {
         Err(_) => Err(io::UnsupportedOperation::new_err("not supported: tell")),
         Ok(x) => x.extract::<u64>(),

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -146,7 +146,7 @@ let result: PyResult<()> = PyErr::new::<TypeError, _>("error message").into();
 
 After (also using the new reworked exception types; see the following section):
 ```rust
-# use pyo3::{PyErr, PyResult, exceptions::PyTypeError};
+# use pyo3::{PyResult, exceptions::PyTypeError};
 let result: PyResult<()> = Err(PyTypeError::new_err("error message"));
 ```
 
@@ -433,6 +433,7 @@ rules of references.
 Here is an example.
 ```rust
 # use pyo3::prelude::*;
+
 #[pyclass]
 struct Names {
     names: Vec<String>

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -24,34 +24,39 @@ The example below shows a calling Python functions behind a `PyObject` (aka `Py<
 
 ```rust
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyTuple};
+use pyo3::types::PyTuple;
 
-struct SomeObject;
-impl SomeObject {
-    fn new(py: Python) -> PyObject {
-        PyDict::new(py).to_object(py)
-    }
-}
-
-fn main() {
+fn main() -> PyResult<()> {
     let arg1 = "arg1";
     let arg2 = "arg2";
     let arg3 = "arg3";
 
     Python::with_gil(|py| {
-        let obj = SomeObject::new(py);
+        let fun: Py<PyAny> = PyModule::from_code(
+            py,
+    "def example(*args, **kwargs):
+		if args != ():
+		    print(\"called with args\", args )
+		if kwargs != {}:
+		    print(\"called with kwargs\", kwargs )
+		if args == () and kwargs == {}:
+		    print(\"called with no arguments\")",
+            "",
+            "",
+        )?.getattr("example")?.into();
 
         // call object without empty arguments
-        obj.call0(py);
+        fun.call0(py)?;
 
         // call object with PyTuple
         let args = PyTuple::new(py, &[arg1, arg2, arg3]);
-        obj.call1(py, args);
+        fun.call1(py, args)?;
 
         // pass arguments as rust tuple
         let args = (arg1, arg2, arg3);
-        obj.call1(py, args);
-    });
+        fun.call1(py, args)?;
+        Ok(())
+    })
 }
 ```
 
@@ -61,39 +66,45 @@ For the `call` and `call_method` APIs, `kwargs` can be `None` or `Some(&PyDict)`
 
 ```rust
 use pyo3::prelude::*;
-use pyo3::types::{IntoPyDict, PyDict};
+use pyo3::types::IntoPyDict;
 use std::collections::HashMap;
 
-struct SomeObject;
-
-impl SomeObject {
-    fn new(py: Python) -> PyObject {
-        PyDict::new(py).to_object(py)
-    }
-}
-
-fn main() {
+fn main() -> PyResult<()> {
     let key1 = "key1";
     let val1 = 1;
     let key2 = "key2";
     let val2 = 2;
 
     Python::with_gil(|py| {
-        let obj = SomeObject::new(py);
+        let fun: Py<PyAny> = PyModule::from_code(
+            py,
+    "def example(*args, **kwargs):
+		if args != ():
+		    print(\"called with args\", args )
+		if kwargs != {}:
+		    print(\"called with kwargs\", kwargs )
+		if args == () and kwargs == {}:
+		    print(\"called with no arguments\")",
+            "",
+            "",
+        )?.getattr("example")?.into();
+
 
         // call object with PyDict
         let kwargs = [(key1, val1)].into_py_dict(py);
-        obj.call(py, (), Some(kwargs));
+        fun.call(py, (), Some(kwargs))?;
 
         // pass arguments as Vec
         let kwargs = vec![(key1, val1), (key2, val2)];
-        obj.call(py, (), Some(kwargs.into_py_dict(py)));
+        fun.call(py, (), Some(kwargs.into_py_dict(py)))?;
 
         // pass arguments as HashMap
         let mut kwargs = HashMap::<&str, i32>::new();
         kwargs.insert(key1, 1);
-        obj.call(py, (), Some(kwargs.into_py_dict(py)));
-   });
+        fun.call(py, (), Some(kwargs.into_py_dict(py)))?;
+
+        Ok(())
+   })
 }
 ```
 
@@ -128,7 +139,6 @@ and return the evaluated value as a `&PyAny` object.
 
 ```rust
 use pyo3::prelude::*;
-use pyo3::types::IntoPyDict;
 
 # fn main() -> Result<(), ()> {
 Python::with_gil(|py| {

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -66,7 +66,7 @@ a list:
 
 ```rust
 # use pyo3::prelude::*;
-# use pyo3::{Py, Python, PyAny, PyResult, types::PyList};
+# use pyo3::types::PyList;
 # Python::with_gil(|py| -> PyResult<()> {
 let obj: &PyAny = PyList::empty(py);
 
@@ -86,7 +86,7 @@ For a `&PyAny` object reference `any` where the underlying object is a `#[pyclas
 
 ```rust
 # use pyo3::prelude::*;
-# use pyo3::{Py, Python, PyAny, PyResult, types::PyList};
+# use pyo3::{Py, Python, PyAny, PyResult};
 # #[pyclass] #[derive(Clone)] struct MyClass { }
 # Python::with_gil(|py| -> PyResult<()> {
 let obj: &PyAny = Py::new(py, MyClass { })?.into_ref(py);
@@ -236,7 +236,6 @@ so it also exposes all of the methods on `PyAny`.
 
 ```rust
 # use pyo3::prelude::*;
-# use pyo3::types::PyList;
 # #[pyclass] struct MyClass { }
 # Python::with_gil(|py| -> PyResult<()> {
 let cell: &PyCell<MyClass> = PyCell::new(py, MyClass { })?;
@@ -257,7 +256,6 @@ let _: &mut MyClass = &mut *py_ref_mut;
 
 ```rust
 # use pyo3::prelude::*;
-# use pyo3::types::PyList;
 # #[pyclass] struct MyClass { }
 # Python::with_gil(|py| -> PyResult<()> {
 let cell: &PyCell<MyClass> = PyCell::new(py, MyClass { })?;

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -160,8 +160,9 @@ impl PyErr {
     /// # Examples
     /// ```rust
     /// use pyo3::{Python, PyErr, exceptions::PyTypeError, types::PyType};
+    ///
     /// Python::with_gil(|py| {
-    ///     let err = PyTypeError::new_err(("some type error",));
+    ///     let err: PyErr = PyTypeError::new_err(("some type error",));
     ///     assert_eq!(err.ptype(py), PyType::new::<PyTypeError>(py));
     /// });
     /// ```
@@ -174,10 +175,12 @@ impl PyErr {
     /// The object will be normalized first if needed.
     ///
     /// # Examples
+    ///
     /// ```rust
-    /// use pyo3::{Python, PyErr, exceptions::PyTypeError, types::PyType};
+    /// use pyo3::{Python, PyErr, exceptions::PyTypeError};
+    ///
     /// Python::with_gil(|py| {
-    ///     let err = PyTypeError::new_err(("some type error",));
+    ///     let err: PyErr = PyTypeError::new_err(("some type error",));
     ///     assert!(err.is_instance::<PyTypeError>(py));
     ///     assert_eq!(err.pvalue(py).to_string(), "some type error");
     /// });
@@ -192,7 +195,8 @@ impl PyErr {
     ///
     /// # Examples
     /// ```rust
-    /// use pyo3::{Python, PyErr, exceptions::PyTypeError, types::PyType};
+    /// use pyo3::{Python, exceptions::PyTypeError};
+    ///
     /// Python::with_gil(|py| {
     ///     let err = PyTypeError::new_err(("some type error",));
     ///     assert_eq!(err.ptraceback(py), None);
@@ -403,9 +407,9 @@ impl PyErr {
     ///
     /// # Examples
     /// ```rust
-    /// use pyo3::{Python, PyErr, exceptions::PyTypeError, types::PyType};
+    /// use pyo3::{Python, PyErr, exceptions::PyTypeError};
     /// Python::with_gil(|py| {
-    ///     let err = PyTypeError::new_err(("some type error",));
+    ///     let err: PyErr = PyTypeError::new_err(("some type error",));
     ///     let err_clone = err.clone_ref(py);
     ///     assert_eq!(err.ptype(py), err_clone.ptype(py));
     ///     assert_eq!(err.pvalue(py), err_clone.pvalue(py));

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -63,13 +63,12 @@ pub(crate) fn gil_is_acquired() -> bool {
 /// ```rust
 /// use pyo3::prelude::*;
 ///
-/// # #[allow(clippy::needless_doctest_main)]
-/// fn main() {
-///     pyo3::prepare_freethreaded_python();
-///     Python::with_gil(|py| {
-///         py.run("print('Hello World')", None, None)
-///     });
-/// }
+/// # fn main() -> PyResult<()>{
+/// pyo3::prepare_freethreaded_python();
+/// Python::with_gil(|py| {
+///     py.run("print('Hello World')", None, None)
+/// })
+/// # }
 /// ```
 #[cfg(not(PyPy))]
 #[cfg_attr(docsrs, doc(cfg(not(PyPy))))]
@@ -131,14 +130,13 @@ pub fn prepare_freethreaded_python() {
 /// ```rust
 /// use pyo3::prelude::*;
 ///
-/// # #[allow(clippy::needless_doctest_main)]
-/// fn main() {
-///     unsafe {
-///         pyo3::with_embedded_python_interpreter(|py| {
-///             py.run("print('Hello World')", None, None)
-///         });
-///     }
+/// # fn main() -> PyResult<()>{
+/// unsafe {
+///     pyo3::with_embedded_python_interpreter(|py| {
+///         py.run("print('Hello World')", None, None)
+///     })
 /// }
+/// # }
 /// ```
 #[cfg(not(PyPy))]
 #[cfg_attr(docsrs, doc(cfg(not(PyPy))))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@
         rustdoc::bare_urls
     )
 )]
+// Deny some lints in doctests.
+// Use `#[allow(...)]` locally to override.
+#![doc(test(attr(deny(deprecated, unused_must_use, unused_imports))))]
 
 //! Rust bindings to the Python interpreter.
 //!
@@ -220,7 +223,7 @@
 //! fn main() -> PyResult<()> {
 //!     Python::with_gil(|py| {
 //!         let sys = py.import("sys")?;
-//!         let version: String = sys.get("version")?.extract()?;
+//!         let version: String = sys.getattr("version")?.extract()?;
 //!
 //!         let locals = [("os", py.import("os")?)].into_py_dict(py);
 //!         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -85,7 +85,6 @@ impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
 /// ```
 /// # use pyo3::prelude::*;
 /// # use pyo3::py_run;
-/// # use pyo3::types::IntoPyDict;
 /// #[pyclass(subclass)]
 /// struct BaseClass {
 ///     #[pyo3(get)]

--- a/src/python.rs
+++ b/src/python.rs
@@ -180,11 +180,14 @@ impl Python<'_> {
     /// # Examples
     /// ```
     /// use pyo3::prelude::*;
+    ///
+    /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
     ///     let x: i32 = py.eval("5", None, None)?.extract()?;
     ///     assert_eq!(x, 5);
     ///     Ok(())
-    /// });
+    /// })
+    /// # }
     /// ```
     #[inline]
     pub fn with_gil<F, R>(f: F) -> R
@@ -250,18 +253,18 @@ impl<'p> Python<'p> {
     /// Temporarily releases the `GIL`, thus allowing other Python threads to run.
     ///
     /// # Examples
+    ///
     /// ```
     /// # use pyo3::prelude::*; use pyo3::types::IntoPyDict;
     /// use pyo3::exceptions::PyRuntimeError;
-    /// use std::sync::Arc;
-    /// use std::thread;
+    ///
     /// #[pyfunction]
     /// fn parallel_count(py: Python<'_>, strings: Vec<String>, query: String) -> PyResult<usize> {
     ///     let query = query.chars().next().unwrap();
     ///     py.allow_threads(move || {
     ///         let threads: Vec<_> = strings
     ///             .into_iter()
-    ///             .map(|s| thread::spawn(move || s.chars().filter(|&c| c == query).count()))
+    ///             .map(|s| std::thread::spawn(move || s.chars().filter(|&c| c == query).count()))
     ///             .collect();
     ///         let mut sum = 0;
     ///         for t in threads {
@@ -341,8 +344,9 @@ impl<'p> Python<'p> {
     /// If `locals` is `None`, it defaults to the value of `globals`.
     ///
     /// # Examples
+    ///
     /// ```
-    /// # use pyo3::{types::{PyBytes, PyDict}, prelude::*};
+    /// # use pyo3::prelude::*;
     /// # Python::with_gil(|py| {
     /// let result = py.eval("[i * 10 for i in range(5)]", None, None).unwrap();
     /// let res: Vec<i64> = result.extract().unwrap();
@@ -699,7 +703,7 @@ impl<'p> Python<'p> {
     ///
     ///         // It is recommended to *always* immediately set py to the pool's Python, to help
     ///         // avoid creating references with invalid lifetimes.
-    ///         let py = unsafe { pool.python() };
+    ///         let py = pool.python();
     ///
     ///         // do stuff...
     /// #       break;  // Exit the loop so that doctest terminates!

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -391,8 +391,7 @@ impl PyAny {
     ///
     /// ```rust
     /// use pyo3::prelude::*;
-    /// use pyo3::types::{PyDict, PyList};
-    /// use crate::pyo3::types::IntoPyDict;
+    /// use pyo3::types::{IntoPyDict, PyList};
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -28,8 +28,11 @@ impl PyByteArray {
     /// * If `init` returns `Ok(())`, `new_with` will return `Ok(&PyByteArray)`.
     ///
     /// # Examples
+    ///
     /// ```
     /// use pyo3::{prelude::*, types::PyByteArray};
+    ///
+    /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
     ///     let py_bytearray = PyByteArray::new_with(py, 10, |bytes: &mut [u8]| {
     ///         bytes.copy_from_slice(b"Hello Rust");
@@ -38,7 +41,8 @@ impl PyByteArray {
     ///     let bytearray: &[u8] = unsafe { py_bytearray.as_bytes() };
     ///     assert_eq!(bytearray, b"Hello Rust");
     ///     Ok(())
-    /// });
+    /// })
+    /// # }
     /// ```
     pub fn new_with<F>(py: Python, len: usize, init: F) -> PyResult<&PyByteArray>
     where

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -34,8 +34,11 @@ impl PyBytes {
     /// * If `init` returns `Ok(())`, `new_with` will return `Ok(&PyBytes)`.
     ///
     /// # Examples
+    ///
     /// ```
     /// use pyo3::{prelude::*, types::PyBytes};
+    ///
+    /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
     ///     let py_bytes = PyBytes::new_with(py, 10, |bytes: &mut [u8]| {
     ///         bytes.copy_from_slice(b"Hello Rust");
@@ -44,7 +47,8 @@ impl PyBytes {
     ///     let bytes: &[u8] = FromPyObject::extract(py_bytes)?;
     ///     assert_eq!(bytes, b"Hello Rust");
     ///     Ok(())
-    /// });
+    /// })
+    /// # }
     /// ```
     pub fn new_with<F>(py: Python, len: usize, init: F) -> PyResult<&PyBytes>
     where

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -11,8 +11,7 @@ use crate::{PyDowncastError, PyTryFrom};
 /// # Examples
 ///
 /// ```rust
-/// # use pyo3::prelude::*;
-/// use pyo3::types::PyIterator;
+///  use pyo3::prelude::*;
 ///
 /// # fn main() -> PyResult<()> {
 /// Python::with_gil(|py| ->  PyResult<()> {
@@ -21,8 +20,7 @@ use crate::{PyDowncastError, PyTryFrom};
 ///     let sum: usize = numbers?.iter().sum();
 ///     assert_eq!(sum, 10);
 ///     Ok(())
-/// });
-/// # Ok(())
+/// })
 /// # }
 /// ```
 #[repr(transparent)]

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -110,13 +110,16 @@ impl PyTuple {
     /// # Example
     /// ```
     /// use pyo3::{prelude::*, types::PyTuple};
+    ///
+    /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
     ///     let ob = (1, 2, 3).to_object(py);
     ///     let tuple = <PyTuple as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
     ///     let obj = tuple.get_item(0);
     ///     assert_eq!(obj.unwrap().extract::<i32>().unwrap(), 1);
     ///     Ok(())
-    /// });
+    /// })
+    /// # }
     /// ```
     pub fn get_item(&self, index: usize) -> PyResult<&PyAny> {
         unsafe {


### PR DESCRIPTION
Resolves #1897

This also fixes a bunch of other tests, two of which were failing unnoticed due to swallowing results 🥵 (in  guide/src/python_from_rust.md)