### PR TITLE
Issue/#954 Add PyBuffer to docs

### DIFF
--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -14,7 +14,7 @@ The table below contains the Python type and the corresponding function argument
 | ------------- |:-------------------------------:|:--------------------:|
 | `object`      | -                               | `&PyAny`             |
 | `str`         | `String`, `Cow<str>`, `&str`, `OsString`, `PathBuf` | `&PyUnicode` |
-| `bytes`       | `Vec<u8>`, `&[u8]`              | `&PyBytes`           |
+| `bytes`       | `Vec<u8>`, `&[u8]`              | `&PyBytes`, `PyBuffer` |
 | `bool`        | `bool`                          | `&PyBool`            |
 | `int`         | Any integer type (`i32`, `u32`, `usize`, etc) | `&PyLong` |
 | `float`       | `f32`, `f64`                    | `&PyFloat`           |
@@ -24,8 +24,9 @@ The table below contains the Python type and the corresponding function argument
 | `tuple[T, U]` | `(T, U)`, `Vec<T>`              | `&PyTuple`           |
 | `set[T]`      | `HashSet<T>`, `BTreeSet<T>`, `hashbrown::HashSet<T>`[^2] | `&PySet` |
 | `frozenset[T]` | `HashSet<T>`, `BTreeSet<T>`, `hashbrown::HashSet<T>`[^2] | `&PyFrozenSet` |
-| `bytearray`   | `Vec<u8>`                       | `&PyByteArray`       |
+| `bytearray`   | `Vec<u8>`                       | `&PyByteArray`, `PyBuffer` |
 | `slice`       | -                               | `&PySlice`           |
+| `array.array` | -                               | `PyBuffer`           |
 | `type`        | -                               | `&PyType`            |
 | `module`      | -                               | `&PyModule`          |
 | `datetime.datetime` | -                         | `&PyDateTime`        |

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -182,7 +182,7 @@ impl<'source, T: Element> FromPyObject<'source> for PyBuffer<T> {
 }
 
 impl<T: Element> PyBuffer<T> {
-    /// Get the underlying buffer from the specified python object.
+    /// Gets the underlying buffer from the specified python object.
     pub fn get(obj: &PyAny) -> PyResult<PyBuffer<T>> {
         // TODO: use nightly API Box::new_uninit() once stable
         let mut buf = Box::new(mem::MaybeUninit::uninit());
@@ -575,6 +575,9 @@ impl<T: Element> PyBuffer<T> {
         }
     }
 
+    /// Releases the buffer and decrements the reference count. Note that this will happen
+    /// automatically when the buffer is dropped, so it is not neccessary to call this function.
+    // TODO: Why would we ever want to call this instead of just using `std::mem::drop(buffer)`?
     pub fn release(self, _py: Python) {
         // First move self into a ManuallyDrop, so that PyBuffer::drop will
         // never be called. (It would acquire the GIL and call PyBuffer_Release


### PR DESCRIPTION
Some things I'm not sure about:
- Why are there two types, `PyBuffer` and `PyBufferProtocol`?
- Is it intentional that `PyBuffer` can be used as a function argument for pyfunctions but `&PyBuffer` cannot? I guess `PyBuffer` is just a pointer type, but it confused me for a while since all the other types on that list can be taken as references.
- Why would anyone want to call `PyBuffer::release` explicitly and not just use scopes or `std::mem::drop`?

#954