### PR TITLE
review sysconfigdata filename match rules to support cp37m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix panic on Python 3.6 when calling `Python::with_gil` with Python initialized but threading not initialized. [#1874](https://github.com/PyO3/pyo3/pull/1874)
 - Fix incorrect linking to version-specific DLL instead of `python3.dll` when cross-compiling to Windows with `abi3`. [#1880](https://github.com/PyO3/pyo3/pull/1880)
 - Fix panic in generated `#[derive(FromPyObject)]` for enums. [#1888](https://github.com/PyO3/pyo3/pull/1888)
+- Fix cross-compiling to Python 3.7 builds with the "m" abi flag. [#1908](https://github.com/PyO3/pyo3/pull/1908)
 
 ## [0.14.5] - 2021-09-05
 

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -913,7 +913,7 @@ fn search_lib_dir(path: impl AsRef<Path>, cross: &CrossCompileConfig) -> Vec<Pat
             // Python 3.6 sysconfigdata without platform specifics
             Ok(f) if f.file_name() == "_sysconfigdata.py" => vec![f.path()],
             // Python 3.7+ sysconfigdata with platform specifics
-            Ok(f) if starts_with(f, "_sysconfigdata__") && ends_with(f, "py") => vec![f.path()],
+            Ok(f) if starts_with(f, "_sysconfigdata_") && ends_with(f, "py") => vec![f.path()],
             Ok(f) if f.metadata().map_or(false, |metadata| metadata.is_dir()) => {
                 let file_name = f.file_name();
                 let file_name = file_name.to_string_lossy();


### PR DESCRIPTION
As per title, on cp37-cp37m sysconfigdata file name is in the form `_sysconfigdata_m_linux_x86_64-linux-gnu.py`.

This review the change introduced with https://github.com/PyO3/pyo3/commit/4a6ea17959ba7da1c9bc35aace738fc893686cf4#diff-5f4a9955ffbc1038032f0905b2fb70e7dbd991e489532e4529fe14a576aa0a25R915, allowing also sysconfigdata files in the form `_sysconfigdata_m_*` rather than forcing only the modern `_sysconfigdata__`.
