### PR TITLE
deps: loosen trybuild requirement to allow versions newer than 1.0.49

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,14 @@ criterion = "=0.3.4"
 # half and bitflags use if/match in const fn, which isn't compatible with Rust 1.41
 half = "=1.7.1"
 bitflags = "=1.2.1"
-# Pin the minor version to avoid local/CI conflicts.
-trybuild = "=1.0.49"
+trybuild = "1.0.49"
 rustversion = "1.0"
+# 1.0.0 requires Rust 1.50
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
+serde_json = "1.0.61"
+
 # features needed to run the PyO3 test suite
 pyo3 = { path = ".", default-features = false, features = ["macros", "auto-initialize"] }
-serde_json = "1.0.61"
 
 [build-dependencies]
 pyo3-build-config = { path = "pyo3-build-config", version = "0.14.5", features = ["resolve-config"] }


### PR DESCRIPTION
Replaces #1931 - any trybuild version 1.0.49 or newer should be fine.