### PR TITLE
Fixes typo in docs

### DIFF
--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -21,7 +21,7 @@ Currently, [#340](https://github.com/PyO3/pyo3/issues/340) causes `cargo test` t
 
 ```toml
 [dependencies.pyo3]
-version = "{{#PYO3_CRATE_VERSION}}"
+{{#PYO3_CRATE_VERSION}}
 
 [features]
 extension-module = ["pyo3/extension-module"]


### PR DESCRIPTION
It used to be like this:
<img width="770" alt="Снимок экрана 2021-10-21 в 21 25 29" src="https://user-images.githubusercontent.com/4660275/138335517-cd37c38f-35f8-4ee6-a904-21682a6d0664.png">
