### PR TITLE
ffi: restore _PyImport_FindExtensionObject on Python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate `PySys_AddWarnOption`, `PySys_AddWarnOptionUnicode` and `PySys_HasWarnOptions`. [#1887](https://github.com/PyO3/pyo3/pull/1887)
 - Remove function PyTuple_ClearFreeList from python 3.9 above. [#1887](https://github.com/PyO3/pyo3/pull/1887)
 - Deprecate `#[call]` attribute in favor of using `fn __call__`. [#1929](https://github.com/PyO3/pyo3/pull/1929)
+- Fix missing FFI definition `_PyImport_FindExtensionObject` on Python 3.10. [#1942](https://github.com/PyO3/pyo3/pull/1942)
 
 ### Fixed
 

--- a/src/ffi/cpython/import.rs
+++ b/src/ffi/cpython/import.rs
@@ -16,7 +16,7 @@ extern "C" {
     pub fn _PyImport_FindBuiltin(name: *const c_char) -> *mut PyObject;
     #[cfg(all(Py_3_7, not(Py_3_9)))]
     pub fn _PyImport_FindBuiltin(name: *const c_char, modules: *mut PyObject) -> *mut PyObject;
-    #[cfg(not(Py_3_10))]
+    #[cfg(not(Py_3_11))]
     pub fn _PyImport_FindExtensionObject(a: *mut PyObject, b: *mut PyObject) -> *mut PyObject;
     #[cfg(not(Py_3_7))]
     pub fn _PyImport_FixupBuiltin(module: *mut PyObject, name: *const c_char) -> c_int;


### PR DESCRIPTION
This symbol was initially removed from 3.10. But it was restored
late in the 3.10 development cycle in time for 3.10.0. See
https://bugs.python.org/issue45307.
