### PR TITLE
makefile: fix test_py job, add list_all_additive_features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,10 +62,10 @@ jobs:
           for VERSION in ${VERSIONS[@]}; do
             echo "version=$VERSION" > config.txt
             echo "suppress_build_script_link_lines=true" >> config.txt
-            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets
-            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "abi3"
-            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "macros num-bigint num-complex hashbrown indexmap serde multiple-pymethods eyre anyhow"
-            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "abi3 macros num-bigint num-complex hashbrown indexmap serde multiple-pymethods eyre anyhow"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --no-default-features
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --no-default-features --features "abi3"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --no-default-features --features "$(make list_all_additive_features)"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --no-default-features --features "abi3 $(make list_all_additive_features)"
           done
 
   build:
@@ -175,7 +175,7 @@ jobs:
         id: settings
         shell: bash
         run: |
-          echo "::set-output name=all_additive_features::macros num-bigint num-complex hashbrown indexmap serde multiple-pymethods eyre anyhow"
+          echo "::set-output name=all_additive_features::$(make list_all_additive_features)"
 
       - if: matrix.msrv == 'MSRV'
         name: Prepare minimal package versions (MSRV only)
@@ -291,7 +291,8 @@ jobs:
           cargo llvm-cov clean --workspace
           cargo llvm-cov --package $ALL_PACKAGES --no-report
           cargo llvm-cov --package $ALL_PACKAGES --no-report --features abi3
-          cargo llvm-cov --package $ALL_PACKAGES --no-report --features macros num-bigint num-complex hashbrown indexmap serde multiple-pymethods eyre anyhow
+          cargo llvm-cov --package $ALL_PACKAGES --no-report --features $(make list_all_additive_features)
+          cargo llvm-cov --package $ALL_PACKAGES --no-report --features abi3 $(make list_all_additive_features)
           cargo llvm-cov --package $ALL_PACKAGES --no-run --lcov --output-path coverage.lcov
         env:
           ALL_PACKAGES: pyo3 pyo3-build-config pyo3-macros-backend pyo3-macros

--- a/Contributing.md
+++ b/Contributing.md
@@ -37,14 +37,14 @@ There are some specific areas of focus where help is currently needed for the do
 #### Doctests
 
 We use lots of code blocks in our docs. Run `cargo test --doc` when making changes to check that
-the doctests still work, or `cargo test` to run all the tests including doctests. See 
+the doctests still work, or `cargo test` to run all the tests including doctests. See
 https://doc.rust-lang.org/rustdoc/documentation-tests.html for a guide on doctests.
 
 #### Building the guide
 
-You can preview the user guide by building it locally with `mdbook`. 
+You can preview the user guide by building it locally with `mdbook`.
 
-First, [install `mdbook`](https://rust-lang.github.io/mdBook/cli/index.html). Then, run 
+First, [install `mdbook`](https://rust-lang.github.io/mdBook/cli/index.html). Then, run
 `mdbook build -d ../gh-pages-build guide --open`.
 
 ### Help design the next PyO3
@@ -68,6 +68,8 @@ The PyO3 repo uses GitHub Actions. PRs are blocked from merging if CI is not suc
 Formatting, linting and tests are checked for all Rust and Python code. In addition, all warnings in Rust code are disallowed (using `RUSTFLAGS="-D warnings"`).
 
 Tests run with all supported Python versions with the latest stable Rust compiler, as well as for Python 3.9 with the minimum supported Rust version.
+
+If you are adding a new feature, you should add it to the `ALL_ADDITIVE_FEATURES` declaration in the `Makefile` so that it is tested in CI.
 
 ## Python and Rust version support policy
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,26 @@
 .PHONY: test test_py publish clippy lint fmt
 
+ALL_ADDITIVE_FEATURES = macros multiple-pymethods num-bigint num-complex hashbrown serde indexmap eyre anyhow
+
+list_all_additive_features:
+	@echo $(ALL_ADDITIVE_FEATURES)
+
 test: lint test_py
 	cargo test
+	cargo test --features="abi3"
+	cargo test --features="$(ALL_ADDITIVE_FEATURES)"
+	cargo test --features="abi3 $(ALL_ADDITIVE_FEATURES)"
 
 test_py:
-	for example in examples/*; do tox -e py -c $$example || exit 1; done
+	for example in examples/*/; do TOX_TESTENV_PASSENV=RUSTUP_HOME tox -e py -c $$example || exit 1; done
 
 fmt:
 	cargo fmt --all -- --check
 	black . --check
 
 clippy:
-	cargo clippy --features="num-bigint num-complex hashbrown serde indexmap eyre " --tests -- -Dwarnings
-	cargo clippy --features="abi3 num-bigint num-complex hashbrown serde indexmap eyre" --tests -- -Dwarnings
+	cargo clippy --features="$(ALL_ADDITIVE_FEATURES)" --tests -- -Dwarnings
+	cargo clippy --features="abi3 $(ALL_ADDITIVE_FEATURES)" --tests -- -Dwarnings
 	for example in examples/*/; do cargo clippy --manifest-path $$example/Cargo.toml -- -Dwarnings || exit 1; done
 
 lint: fmt clippy


### PR DESCRIPTION
Incorporates the fix identified by @aganders3 in https://github.com/PyO3/pyo3/pull/1925#issuecomment-946834805

Also adds a new `make list_all_additive_features` target, which can be used by our CI to get a list of all features. This should help keep all CI in sync.