### PR TITLE
ci: test MSRV and coverage with Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
Updates MSRV and coverage jobs to test against Python 3.10