### PR TITLE
ffi: expose pymem APIs

### DIFF
--- a/src/ffi/cpython/mod.rs
+++ b/src/ffi/cpython/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod object;
 pub(crate) mod pydebug;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub(crate) mod pylifecycle;
+pub(crate) mod pymem;
 pub(crate) mod pystate;
 pub(crate) mod pythonrun;
 // skipped sysmodule.h
@@ -44,6 +45,7 @@ pub use self::object::*;
 pub use self::pydebug::*;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub use self::pylifecycle::*;
+pub use self::pymem::*;
 pub use self::pystate::*;
 pub use self::pythonrun::*;
 pub use self::tupleobject::*;


### PR DESCRIPTION
These symbols were inadvertently dropped in commit
0a50b42352533ce0b2ce480b7ac90561b8e70e38. I found this when
testing the 0.15 release branch for PyOxidizer.