### PR TITLE
rust-toolchain: add file to require rust-src

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+components = [ "rust-src" ]


### PR DESCRIPTION
This was suggested in https://github.com/dtolnay/trybuild/issues/126 as a way to ensure `rust-src` component is installed for UI tests.

I verified this seems to work locally.