### PR TITLE
complex: fix a rustdoc warning and fix crate name

### DIFF
--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -4,8 +4,8 @@ use std::os::raw::c_double;
 /// Represents a Python [`complex`](https://docs.python.org/3/library/functions.html#complex) object.
 ///
 /// Note that `PyComplex` supports only basic operations. For advanced operations
-/// consider using [num-bigint](https://docs.rs/num-bigint)'s [`Complex`] type instead.
-/// This requires the [`num-complex`](crate::num_complex) feature flag.
+/// consider using [num-complex](https://docs.rs/num-complex)'s [`Complex`] type instead.
+/// This optional dependency can be activated with the `num-complex` feature flag.
 ///
 /// [`Complex`]: https://docs.rs/num-complex/latest/num_complex/struct.Complex.html
 #[repr(transparent)]


### PR DESCRIPTION
Thank you for contributing to pyo3!

Please consider adding the following to your pull request:
 - an entry in CHANGELOG.md
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

Be aware the CI pipeline will check your pull request for the following:
 - Rust tests (Just `cargo test` or `make test` if you need to test examples)
 - Rust lints (`make clippy`)
 - Rust formatting (`cargo fmt`)
 - Python formatting (`black . --check`. You can install black with `pip install black`)
 - Compatibility with all supported Python versions for all examples. This uses `tox`; you can do run it using `make test_py`.

You can run a similar set of checks as the CI pipeline using `make test`.
