### PR TITLE
err: add `PyErr::take`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `abi3-py310` feature. [#1889](https://github.com/PyO3/pyo3/pull/1889)
 - Add `PyCFunction::new_closure` to create a Python function from a Rust closure. [#1901](https://github.com/PyO3/pyo3/pull/1901)
 - Add support for positional-only arguments in `#[pyfunction]` [#1925](https://github.com/PyO3/pyo3/pull/1925)
+- Add `PyErr::take` to attempt to fetch a Python exception if present. [#1957](https://github.com/PyO3/pyo3/pull/1957)
 
 ### Changed
 
-- Change `PyErr::fetch` to return `Option<PyErr>`. [#1717](https://github.com/PyO3/pyo3/pull/1717)
 - `PyList`, `PyTuple` and `PySequence`'s APIs now accepts only `usize` indices instead of `isize`.
   [#1733](https://github.com/PyO3/pyo3/pull/1733), [#1802](https://github.com/PyO3/pyo3/pull/1802),
   [#1803](https://github.com/PyO3/pyo3/pull/1803)
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove function PyTuple_ClearFreeList from python 3.9 above. [#1887](https://github.com/PyO3/pyo3/pull/1887)
 - Deprecate `#[call]` attribute in favor of using `fn __call__`. [#1929](https://github.com/PyO3/pyo3/pull/1929)
 - Fix missing FFI definition `_PyImport_FindExtensionObject` on Python 3.10. [#1942](https://github.com/PyO3/pyo3/pull/1942)
+- Change `PyErr::fetch` to panic in debug mode if no exception is present. [#1957](https://github.com/PyO3/pyo3/pull/1957)
 
 ### Fixed
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -494,7 +494,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
     ///
     /// Relies on [`from_owned_ptr_or_opt`](#method.from_owned_ptr_or_opt).
     unsafe fn from_owned_ptr_or_err(py: Python<'p>, ptr: *mut ffi::PyObject) -> PyResult<&'p Self> {
-        Self::from_owned_ptr_or_opt(py, ptr).ok_or_else(|| err::PyErr::api_call_failed(py))
+        Self::from_owned_ptr_or_opt(py, ptr).ok_or_else(|| err::PyErr::fetch(py))
     }
     /// Convert from an arbitrary borrowed `PyObject`.
     ///
@@ -528,7 +528,7 @@ pub unsafe trait FromPyPointer<'p>: Sized {
         py: Python<'p>,
         ptr: *mut ffi::PyObject,
     ) -> PyResult<&'p Self> {
-        Self::from_borrowed_ptr_or_opt(py, ptr).ok_or_else(|| err::PyErr::api_call_failed(py))
+        Self::from_borrowed_ptr_or_opt(py, ptr).ok_or_else(|| err::PyErr::fetch(py))
     }
 }
 

--- a/src/conversions/osstr.rs
+++ b/src/conversions/osstr.rs
@@ -94,7 +94,7 @@ impl FromPyObject<'_> for OsString {
             let size =
                 unsafe { ffi::PyUnicode_AsWideChar(pystring.as_ptr(), std::ptr::null_mut(), 0) };
             if size == -1 {
-                return Err(PyErr::api_call_failed(ob.py()));
+                return Err(PyErr::fetch(ob.py()));
             }
 
             let mut buffer = vec![0; size as usize];

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -23,7 +23,7 @@ pub(crate) enum PyErrState {
         pvalue: Box<dyn FnOnce(Python) -> PyObject + Send + Sync>,
     },
     FfiTuple {
-        ptype: Option<PyObject>,
+        ptype: PyObject,
         pvalue: Option<PyObject>,
         ptraceback: Option<PyObject>,
     },

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -829,7 +829,7 @@ mod tests {
             e.restore(py);
 
             assert_eq!(
-                PyErr::api_call_failed(py).to_string(),
+                PyErr::fetch(py).to_string(),
                 "UnicodeDecodeError: \'utf-8\' codec can\'t decode byte 0xd8 in position 2: invalid utf-8"
             );
         });

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -589,7 +589,7 @@ impl<T> Py<T> {
             let kwargs = kwargs.into_ptr();
             let ptr = ffi::PyObject_GetAttr(self.as_ptr(), name);
             if ptr.is_null() {
-                return Err(PyErr::api_call_failed(py));
+                return Err(PyErr::fetch(py));
             }
             let result = PyObject::from_owned_ptr_or_err(py, ffi::PyObject_Call(ptr, args, kwargs));
             ffi::Py_DECREF(ptr);
@@ -656,7 +656,7 @@ impl<T> Py<T> {
     pub unsafe fn from_owned_ptr_or_err(py: Python, ptr: *mut ffi::PyObject) -> PyResult<Py<T>> {
         match NonNull::new(ptr) {
             Some(nonnull_ptr) => Ok(Py(nonnull_ptr, PhantomData)),
-            None => Err(PyErr::api_call_failed(py)),
+            None => Err(PyErr::fetch(py)),
         }
     }
 
@@ -694,7 +694,7 @@ impl<T> Py<T> {
     /// `ptr` must be a pointer to a Python object of type T.
     #[inline]
     pub unsafe fn from_borrowed_ptr_or_err(py: Python, ptr: *mut ffi::PyObject) -> PyResult<Self> {
-        Self::from_borrowed_ptr_or_opt(py, ptr).ok_or_else(|| PyErr::api_call_failed(py))
+        Self::from_borrowed_ptr_or_opt(py, ptr).ok_or_else(|| PyErr::fetch(py))
     }
 
     /// Create a `Py<T>` instance by creating a new reference from the given FFI pointer.

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -122,7 +122,7 @@ where
 
     let type_object = unsafe { ffi::PyType_FromSpec(&mut spec) };
     if type_object.is_null() {
-        Err(PyErr::api_call_failed(py))
+        Err(PyErr::fetch(py))
     } else {
         tp_init_additional::<T>(type_object as _);
         Ok(type_object as _)

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -45,7 +45,7 @@ impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
             let alloc = get_tp_alloc(subtype).unwrap_or(ffi::PyType_GenericAlloc);
             let obj = alloc(subtype, 0);
             return if obj.is_null() {
-                Err(PyErr::api_call_failed(py))
+                Err(PyErr::fetch(py))
             } else {
                 Ok(obj)
             };
@@ -61,7 +61,7 @@ impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
                 Some(newfunc) => {
                     let obj = newfunc(subtype, std::ptr::null_mut(), std::ptr::null_mut());
                     if obj.is_null() {
-                        Err(PyErr::api_call_failed(py))
+                        Err(PyErr::fetch(py))
                     } else {
                         Ok(obj)
                     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -428,7 +428,7 @@ impl<'p> Python<'p> {
         unsafe {
             let mptr = ffi::PyImport_AddModule("__main__\0".as_ptr() as *const _);
             if mptr.is_null() {
-                return Err(PyErr::api_call_failed(self));
+                return Err(PyErr::fetch(self));
             }
 
             let globals = globals
@@ -438,7 +438,7 @@ impl<'p> Python<'p> {
 
             let code_obj = ffi::Py_CompileString(code.as_ptr(), "<string>\0".as_ptr() as _, start);
             if code_obj.is_null() {
-                return Err(PyErr::api_call_failed(self));
+                return Err(PyErr::fetch(self));
             }
             let res_ptr = ffi::PyEval_EvalCode(code_obj, globals, locals);
             ffi::Py_DECREF(code_obj);

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -418,7 +418,7 @@ impl PyAny {
             let py = self.py();
             let ptr = ffi::PyObject_GetAttr(self.as_ptr(), name);
             if ptr.is_null() {
-                return Err(PyErr::api_call_failed(py));
+                return Err(PyErr::fetch(py));
             }
             let args = args.into_py(py).into_ptr();
             let kwargs = kwargs.into_ptr();
@@ -639,7 +639,7 @@ impl PyAny {
     pub fn hash(&self) -> PyResult<isize> {
         let v = unsafe { ffi::PyObject_Hash(self.as_ptr()) };
         if v == -1 {
-            Err(PyErr::api_call_failed(self.py()))
+            Err(PyErr::fetch(self.py()))
         } else {
             Ok(v)
         }
@@ -652,7 +652,7 @@ impl PyAny {
     pub fn len(&self) -> PyResult<usize> {
         let v = unsafe { ffi::PyObject_Size(self.as_ptr()) };
         if v == -1 {
-            Err(PyErr::api_call_failed(self.py()))
+            Err(PyErr::fetch(self.py()))
         } else {
             Ok(v as usize)
         }

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -161,7 +161,7 @@ impl PyByteArray {
             if result == 0 {
                 Ok(())
             } else {
-                Err(PyErr::api_call_failed(self.py()))
+                Err(PyErr::fetch(self.py()))
             }
         }
     }

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -88,7 +88,7 @@ impl PyDict {
             match ffi::PyDict_Contains(self.as_ptr(), key) {
                 1 => Ok(true),
                 0 => Ok(false),
-                _ => Err(PyErr::api_call_failed(self.py())),
+                _ => Err(PyErr::fetch(self.py())),
             }
         })
     }

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -53,7 +53,7 @@ impl<'source> FromPyObject<'source> for f64 {
         let v = unsafe { ffi::PyFloat_AsDouble(obj.as_ptr()) };
 
         if v == -1.0 && PyErr::occurred(obj.py()) {
-            Err(PyErr::api_call_failed(obj.py()))
+            Err(PyErr::fetch(obj.py()))
         } else {
             Ok(v)
         }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -60,7 +60,7 @@ impl<'p> Iterator for &'p PyIterator {
             Some(obj) => Some(Ok(obj)),
             None => {
                 if PyErr::occurred(py) {
-                    Some(Err(PyErr::api_call_failed(py)))
+                    Some(Err(PyErr::fetch(py)))
                 } else {
                     None
                 }

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -20,7 +20,7 @@ impl PyMapping {
     pub fn len(&self) -> PyResult<usize> {
         let v = unsafe { ffi::PyMapping_Size(self.as_ptr()) };
         if v == -1 {
-            Err(PyErr::api_call_failed(self.py()))
+            Err(PyErr::fetch(self.py()))
         } else {
             Ok(v as usize)
         }

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -116,13 +116,13 @@ impl PyModule {
         unsafe {
             let cptr = ffi::Py_CompileString(data.as_ptr(), filename.as_ptr(), ffi::Py_file_input);
             if cptr.is_null() {
-                return Err(PyErr::api_call_failed(py));
+                return Err(PyErr::fetch(py));
             }
 
             let mptr = ffi::PyImport_ExecCodeModuleEx(module.as_ptr(), cptr, filename.as_ptr());
             ffi::Py_DECREF(cptr);
             if mptr.is_null() {
-                return Err(PyErr::api_call_failed(py));
+                return Err(PyErr::fetch(py));
             }
 
             <&PyModule as crate::FromPyObject>::extract(py.from_owned_ptr_or_err(mptr)?)
@@ -163,7 +163,7 @@ impl PyModule {
     pub fn name(&self) -> PyResult<&str> {
         let ptr = unsafe { ffi::PyModule_GetName(self.as_ptr()) };
         if ptr.is_null() {
-            Err(PyErr::api_call_failed(self.py()))
+            Err(PyErr::fetch(self.py()))
         } else {
             let name = unsafe { CStr::from_ptr(ptr) }
                 .to_str()

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -16,7 +16,7 @@ fn err_if_invalid_value<T: PartialEq>(
     actual_value: T,
 ) -> PyResult<T> {
     if actual_value == invalid_value && PyErr::occurred(py) {
-        Err(PyErr::api_call_failed(py))
+        Err(PyErr::fetch(py))
     } else {
         Ok(actual_value)
     }
@@ -76,7 +76,7 @@ macro_rules! int_fits_c_long {
                 let val = unsafe {
                     let num = ffi::PyNumber_Index(ptr);
                     if num.is_null() {
-                        Err(PyErr::api_call_failed(obj.py()))
+                        Err(PyErr::fetch(obj.py()))
                     } else {
                         let val = err_if_invalid_value(obj.py(), -1, ffi::PyLong_AsLong(num));
                         ffi::Py_DECREF(num);
@@ -110,7 +110,7 @@ macro_rules! int_convert_u64_or_i64 {
                 unsafe {
                     let num = ffi::PyNumber_Index(ptr);
                     if num.is_null() {
-                        Err(PyErr::api_call_failed(ob.py()))
+                        Err(PyErr::fetch(ob.py()))
                     } else {
                         let result = err_if_invalid_value(ob.py(), !0, $pylong_as_ll_or_ull(num));
                         ffi::Py_DECREF(num);
@@ -189,7 +189,7 @@ mod fast_128bit_int_conversion {
                     unsafe {
                         let num = ffi::PyNumber_Index(ob.as_ptr());
                         if num.is_null() {
-                            return Err(PyErr::api_call_failed(ob.py()));
+                            return Err(PyErr::fetch(ob.py()));
                         }
                         let mut buffer = [0; std::mem::size_of::<$rust_type>()];
                         let ok = ffi::_PyLong_AsByteArray(

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -21,7 +21,7 @@ impl PySequence {
     pub fn len(&self) -> PyResult<usize> {
         let v = unsafe { ffi::PySequence_Size(self.as_ptr()) };
         if v == -1 {
-            Err(PyErr::api_call_failed(self.py()))
+            Err(PyErr::fetch(self.py()))
         } else {
             Ok(v as usize)
         }
@@ -191,7 +191,7 @@ impl PySequence {
             ffi::PySequence_Count(self.as_ptr(), ptr)
         });
         if r == -1 {
-            Err(PyErr::api_call_failed(self.py()))
+            Err(PyErr::fetch(self.py()))
         } else {
             Ok(r as usize)
         }
@@ -211,7 +211,7 @@ impl PySequence {
         match r {
             0 => Ok(false),
             1 => Ok(true),
-            _ => Err(PyErr::api_call_failed(self.py())),
+            _ => Err(PyErr::fetch(self.py())),
         }
     }
 
@@ -227,7 +227,7 @@ impl PySequence {
             ffi::PySequence_Index(self.as_ptr(), ptr)
         });
         if r == -1 {
-            Err(PyErr::api_call_failed(self.py()))
+            Err(PyErr::fetch(self.py()))
         } else {
             Ok(r as usize)
         }

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -73,7 +73,7 @@ impl PySet {
             match ffi::PySet_Contains(self.as_ptr(), key) {
                 1 => Ok(true),
                 0 => Ok(false),
-                _ => Err(PyErr::api_call_failed(self.py())),
+                _ => Err(PyErr::fetch(self.py())),
             }
         })
     }
@@ -309,7 +309,7 @@ impl PyFrozenSet {
             match ffi::PySet_Contains(self.as_ptr(), key) {
                 1 => Ok(true),
                 0 => Ok(false),
-                _ => Err(PyErr::api_call_failed(self.py())),
+                _ => Err(PyErr::fetch(self.py())),
             }
         })
     }

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -77,7 +77,7 @@ impl PySlice {
                     slicelength,
                 })
             } else {
-                Err(PyErr::api_call_failed(self.py()))
+                Err(PyErr::fetch(self.py()))
             }
         }
     }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -171,7 +171,7 @@ impl PyString {
                     let mut size: ffi::Py_ssize_t = 0;
                     let data = unsafe { ffi::PyUnicode_AsUTF8AndSize(self.as_ptr(), &mut size) };
                     if data.is_null() {
-                        return Err(crate::PyErr::api_call_failed(self.py()));
+                        return Err(crate::PyErr::fetch(self.py()));
                     } else {
                         unsafe { std::slice::from_raw_parts(data as *const u8, size as usize) }
                     }
@@ -232,7 +232,7 @@ impl PyString {
             let ready = ffi::PyUnicode_READY(ptr);
             if ready != 0 {
                 // Exception was created on failure.
-                return Err(crate::PyErr::api_call_failed(self.py()));
+                return Err(crate::PyErr::fetch(self.py()));
             }
         }
 


### PR DESCRIPTION
This is a resurrection of #1715.

The PRs I have seen in downstream projects to update PyO3 to 0.15 often have a number of changes around `PyErr::fetch` which add additional panics and would benefit from what we called `api_call_failed`.

This PR changes `PyErr::fetch` to just return `PyErr` again, and adds `PyErr::take` which returns `Option<PyErr>`. I'm not convinced `take` is the perfect name for this function, but I can't think of anything better. (I briefly considered `fetch_if_set`, which is potentially clearer, although not exactly perfect either.) 