### PR TITLE
pymethods: test and document opt-out of protos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `#[classattr]` constants with a known magic method name (which is lowercase) no longer trigger lint warnings expecting constants to be uppercase. [#1969](https://github.com/PyO3/pyo3/pull/1969)
+
+### Fixed
+
+- Fix creating `#[classattr]` by functions with the name of a known magic method. [#1969](https://github.com/PyO3/pyo3/pull/1969)
+
 ## [0.15.0] - 2021-11-03
 
 ### Packaging

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -47,6 +47,25 @@ given signatures should be interpreted as follows:
   - `__str__(<self>) -> object (str)`
   - `__repr__(<self>) -> object (str)`
   - `__hash__(<self>) -> isize`
+    <details>
+    <summary>Disabling Python's default hash</summary>
+
+    By default, all `#[pyclass]` types have a default hash implementation from Python. Types which should not be hashable can override this by setting `__hash__` to `None`. This is the same mechanism as for a pure-Python class. This is done like so:
+
+    ```rust
+    # use pyo3::prelude::*;
+    #
+    #[pyclass]
+    struct NotHashable { }
+
+    #[pymethods]
+    impl NotHashable {
+        #[classattr]
+        const __hash__: Option<PyObject> = None;
+    }
+    ```
+    </details>
+
   - `__richcmp__(<self>, object, pyo3::basic::CompareOp) -> object`
   - `__getattr__(<self>, object) -> object`
   - `__setattr__(<self>, object, object) -> ()`
@@ -140,6 +159,24 @@ TODO; see [#1884](https://github.com/PyO3/pyo3/issues/1884)
 
   - `__len__(<self>) -> usize`
   - `__contains__(<self>, object) -> bool`
+    <details>
+    <summary>Disabling Python's default contains</summary>
+
+    By default, all `#[pyclass]` types with an `__iter__` method support a default implementation of the `in` operator. Types which do not want this can override this by setting `__contains__` to `None`. This is the same mechanism as for a pure-Python class. This is done like so:
+
+    ```rust
+    # use pyo3::prelude::*;
+    #
+    #[pyclass]
+    struct NoContains { }
+
+    #[pymethods]
+    impl NoContains {
+        #[classattr]
+        const __contains__: Option<PyObject> = None;
+    }
+    ```
+    </details>
   - `__getitem__(<self>, object) -> object`
   - `__setitem__(<self>, object, object) -> ()`
   - `__delitem__(<self>, object) -> ()`

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use crate::{
     konst::{ConstAttributes, ConstSpec},
     pyfunction::PyFunctionOptions,
-    pymethod,
+    pymethod::{self, is_proto_method},
 };
 use proc_macro2::TokenStream;
 use pymethod::GeneratedPyMethod;
@@ -79,6 +79,13 @@ pub fn impl_methods(
                     let attrs = get_cfg_attributes(&konst.attrs);
                     let meth = gen_py_const(ty, &spec);
                     methods.push(quote!(#(#attrs)* #meth));
+                    if is_proto_method(&spec.python_name().to_string()) {
+                        // If this is a known protocol method e.g. __contains__, then allow this
+                        // symbol even though it's not an uppercase constant.
+                        konst
+                            .attrs
+                            .push(syn::parse_quote!(#[allow(non_upper_case_globals)]));
+                    }
                 }
             }
             _ => (),


### PR DESCRIPTION
This is inspired by the discussion in #1927.

Some protocol methods such as `__hash__`, `__iter__`, `__contains__`, and `__reversed__` have automatically-generated default implementations which CPython's operators use if other protocols are available:
- `__hash__` always gets a default
- `__iter__` if *sequence* `__getitem__` is implemented (`Py_sq_item` slot)
- `__contains__` if `__iter__` is implemented
- `__reversed__` if `__iter__` and *sequence* length is implemented (`Py_sq_length` slot)

This PR tests and documents the defaults and opt-outs for `__hash__` and `__contains__`. `__iter__` and `__reversed__` require the sequence protocol support in #1884 first.