### PR TITLE
add doc_auto_cfg feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(feature = "nightly", feature(specialization))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(
     docsrs, // rustdoc:: is not supported on msrv
     deny(


### PR DESCRIPTION
This makes the feature flag thingies render again.

See https://github.com/rust-lang/rust/pull/90502
