### PR TITLE
add PyType::is_subclass_of and PyAny::is_instance_of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add implementations for `Py::as_ref()` and `Py::into_ref()` for `Py<PySequence>`, `Py<PyIterator>` and `Py<PyMapping>`. [#1682](https://github.com/PyO3/pyo3/pull/1682)
 - Add `PyTraceback` type to represent and format Python tracebacks. [#1977](https://github.com/PyO3/pyo3/pull/1977)
 
+### Added
+
+- Add `PyType::is_subclass_of` and `PyAny::is_instance_of` which operate not on
+  a type known at compile-time but a run-time type object. [#1985](https://github.com/PyO3/pyo3/pull/1985)
+
 ### Changed
 
 - `#[classattr]` constants with a known magic method name (which is lowercase) no longer trigger lint warnings expecting constants to be uppercase. [#1969](https://github.com/PyO3/pyo3/pull/1969)
@@ -41,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix build failure on PyPy when abi3 features are activated. [#1991](https://github.com/PyO3/pyo3/pull/1991)
 - Fix mingw platform detection. [#1993](https://github.com/PyO3/pyo3/pull/1993)
 - Fix panic in `__get__` implementation when accessing descriptor on type object. [#1997](https://github.com/PyO3/pyo3/pull/1997)
+
+### Removed
+
+- Remove `PyType::is_instance`, which is unintuitive; instead of `typ.is_instance(obj)`, you should
+  now use `obj.is_instance_of(typ)`. [#1985](https://github.com/PyO3/pyo3/pull/1985)
 
 ## [0.15.0] - 2021-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `Py::setattr` method. [#2009](https://github.com/PyO3/pyo3/pull/2009)
 
-## Removed
+### Changed
 
+- `PyType::is_subclass`, `PyErr::is_instance` and `PyAny::is_instance` now operate run-time type object instead of a type known at compile-time. The old behavior is still available as `PyType::is_subclass_of`, `PyErr::is_instance_of` and `PyAny::is_instance_of`.  [#1985](https://github.com/PyO3/pyo3/pull/1985)
+
+### Removed
+
+- Remove `PyType::is_instance`, which is unintuitive; instead of `typ.is_instance(obj)`, use `obj.is_instance(typ)`. [#1985](https://github.com/PyO3/pyo3/pull/1985)
 - Remove all functionality deprecated in PyO3 0.14. [#2007](https://github.com/PyO3/pyo3/pull/2007)
 
 ## [0.15.1] - 2021-11-19
@@ -29,11 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add implementations for `Py::as_ref()` and `Py::into_ref()` for `Py<PySequence>`, `Py<PyIterator>` and `Py<PyMapping>`. [#1682](https://github.com/PyO3/pyo3/pull/1682)
 - Add `PyTraceback` type to represent and format Python tracebacks. [#1977](https://github.com/PyO3/pyo3/pull/1977)
-
-### Added
-
-- Add `PyType::is_subclass_of` and `PyAny::is_instance_of` which operate not on
-  a type known at compile-time but a run-time type object. [#1985](https://github.com/PyO3/pyo3/pull/1985)
 
 ### Changed
 
@@ -46,11 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix build failure on PyPy when abi3 features are activated. [#1991](https://github.com/PyO3/pyo3/pull/1991)
 - Fix mingw platform detection. [#1993](https://github.com/PyO3/pyo3/pull/1993)
 - Fix panic in `__get__` implementation when accessing descriptor on type object. [#1997](https://github.com/PyO3/pyo3/pull/1997)
-
-### Removed
-
-- Remove `PyType::is_instance`, which is unintuitive; instead of `typ.is_instance(obj)`, you should
-  now use `obj.is_instance_of(typ)`. [#1985](https://github.com/PyO3/pyo3/pull/1985)
 
 ## [0.15.0] - 2021-11-03
 

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -413,7 +413,7 @@ enum RustyEnum {
 #         {
 #             let thing = b"foo".to_object(py);
 #             let error = thing.extract::<RustyEnum>(py).unwrap_err();
-#             assert!(error.is_instance::<pyo3::exceptions::PyTypeError>(py));
+#             assert!(error.is_instance_of::<pyo3::exceptions::PyTypeError>(py));
 #         }
 # 
 #         Ok(())

--- a/guide/src/ecosystem/async-await.md
+++ b/guide/src/ecosystem/async-await.md
@@ -536,12 +536,13 @@ fn main() -> PyResult<()> {
         pyo3_asyncio::async_std::run(py, async move {
             // verify that we are on a uvloop.Loop
             Python::with_gil(|py| -> PyResult<()> {
-                assert!(uvloop
-                    .as_ref(py)
-                    .getattr("Loop")?
-                    .downcast::<PyType>()
-                    .unwrap()
-                    .is_instance(pyo3_asyncio::async_std::get_current_loop(py)?)?);
+                assert!(pyo3_asyncio::async_std::get_current_loop(py)?.is_instance(
+                    uvloop
+                        .as_ref(py)
+                        .getattr("Loop")?
+                        .downcast::<PyType>()
+                        .unwrap()
+                )?);
                 Ok(())
             })?;
 

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -100,21 +100,19 @@ PyErr::from_instance(py, err).restore(py);
 ## Checking exception types
 
 Python has an [`isinstance`](https://docs.python.org/3/library/functions.html#isinstance) method to check an object's type.
-In PyO3 every native type has access to the [`PyAny::is_instance`] method which does the same thing.
+In PyO3 every object has the [`PyAny::is_instance`] and [`PyAny::is_instance_of`] methods which do the same thing.
 
 ```rust
 use pyo3::Python;
 use pyo3::types::{PyBool, PyList};
 
 Python::with_gil(|py| {
-    assert!(PyBool::new(py, true).is_instance::<PyBool>().unwrap());
+    assert!(PyBool::new(py, true).is_instance_of::<PyBool>().unwrap());
     let list = PyList::new(py, &[1, 2, 3, 4]);
-    assert!(!list.is_instance::<PyBool>().unwrap());
-    assert!(list.is_instance::<PyList>().unwrap());
+    assert!(!list.is_instance_of::<PyBool>().unwrap());
+    assert!(list.is_instance_of::<PyList>().unwrap());
 });
 ```
-[`PyAny::is_instance`] calls the underlying [`PyType::is_instance`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyType.html#method.is_instance)
-method to do the actual work.
 
 To check the type of an exception, you can similarly do:
 
@@ -123,7 +121,7 @@ To check the type of an exception, you can similarly do:
 # use pyo3::prelude::*;
 # Python::with_gil(|py| {
 # let err = PyTypeError::new_err(());
-err.is_instance::<PyTypeError>(py);
+err.is_instance_of::<PyTypeError>(py);
 # });
 ```
 
@@ -184,7 +182,7 @@ fn main() {
     Python::with_gil(|py| {
         let fun = pyo3::wrap_pyfunction!(connect, py).unwrap();
         let err = fun.call1(("0.0.0.0",)).unwrap_err();
-        assert!(err.is_instance::<PyOSError>(py));
+        assert!(err.is_instance_of::<PyOSError>(py));
     });
 }
 ```
@@ -201,21 +199,21 @@ fn parse_int(s: String) -> PyResult<usize> {
 }
 #
 # use pyo3::exceptions::PyValueError;
-# 
+#
 # fn main() {
 #     Python::with_gil(|py| {
 #         assert_eq!(parse_int(String::from("1")).unwrap(), 1);
 #         assert_eq!(parse_int(String::from("1337")).unwrap(), 1337);
-# 
+#
 #         assert!(parse_int(String::from("-1"))
 #             .unwrap_err()
-#             .is_instance::<PyValueError>(py));
+#             .is_instance_of::<PyValueError>(py));
 #         assert!(parse_int(String::from("foo"))
 #             .unwrap_err()
-#             .is_instance::<PyValueError>(py));
+#             .is_instance_of::<PyValueError>(py));
 #         assert!(parse_int(String::from("13.37"))
 #             .unwrap_err()
-#             .is_instance::<PyValueError>(py));
+#             .is_instance_of::<PyValueError>(py));
 #     })
 # }
 ```
@@ -257,5 +255,5 @@ defines exceptions for several standard library modules.
 [`PyErr`]: {{#PYO3_DOCS_URL}}/pyo3/struct.PyErr.html
 [`PyResult`]: {{#PYO3_DOCS_URL}}/pyo3/type.PyResult.html
 [`PyErr::from_instance`]: {{#PYO3_DOCS_URL}}/pyo3/struct.PyErr.html#method.from_instance
-[`Python::is_instance`]: {{#PYO3_DOCS_URL}}/pyo3/struct.Python.html#method.is_instance
 [`PyAny::is_instance`]: {{#PYO3_DOCS_URL}}/pyo3/struct.PyAny.html#method.is_instance
+[`PyAny::is_instance_of`]: {{#PYO3_DOCS_URL}}/pyo3/struct.PyAny.html#method.is_instance_of

--- a/src/conversions/path.rs
+++ b/src/conversions/path.rs
@@ -20,7 +20,7 @@ impl FromPyObject<'_> for PathBuf {
                 let py = ob.py();
                 let pathlib = py.import("pathlib")?;
                 let pathlib_path: &PyType = pathlib.getattr("Path")?.downcast()?;
-                if pathlib_path.is_instance(ob)? {
+                if ob.is_instance_of(pathlib_path)? {
                     let path_str = ob.call_method0("__str__")?;
                     OsString::extract(path_str)?
                 } else {

--- a/src/conversions/path.rs
+++ b/src/conversions/path.rs
@@ -20,7 +20,7 @@ impl FromPyObject<'_> for PathBuf {
                 let py = ob.py();
                 let pathlib = py.import("pathlib")?;
                 let pathlib_path: &PyType = pathlib.getattr("Path")?.downcast()?;
-                if ob.is_instance_of(pathlib_path)? {
+                if ob.is_instance(pathlib_path)? {
                     let path_str = ob.call_method0("__str__")?;
                     OsString::extract(path_str)?
                 } else {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -267,7 +267,7 @@ fn always_throws() -> PyResult<()> {
 # Python::with_gil(|py| {
 #     let fun = pyo3::wrap_pyfunction!(always_throws, py).unwrap();
 #     let err = fun.call0().expect_err(\"called a function that should always return an error but the return value was Ok\");
-#     assert!(err.is_instance::<Py", $name, ">(py))
+#     assert!(err.is_instance_of::<Py", $name, ">(py))
 # });
 ```
 
@@ -292,7 +292,7 @@ Python::with_gil(|py| {
 
     let error_type = match result {
         Ok(_) => \"Not an error\",
-        Err(error) if error.is_instance::<Py", $name, ">(py) => \"" , $name, "\",
+        Err(error) if error.is_instance_of::<Py", $name, ">(py) => \"" , $name, "\",
         Err(_) => \"Some other error\",
     };
 
@@ -611,7 +611,7 @@ macro_rules! test_exception {
                         .unwrap_or($exc_ty::new_err("a test exception"))
                 };
 
-                assert!(err.is_instance::<$exc_ty>(py));
+                assert!(err.is_instance_of::<$exc_ty>(py));
 
                 let value: &$exc_ty = err.instance(py).downcast().unwrap();
                 assert!(value.source().is_none());
@@ -619,7 +619,7 @@ macro_rules! test_exception {
                 err.set_cause(py, Some($crate::exceptions::PyValueError::new_err("a cause")));
                 assert!(value.source().is_some());
 
-                assert!($crate::PyErr::from(value).is_instance::<$exc_ty>(py));
+                assert!($crate::PyErr::from(value).is_instance_of::<$exc_ty>(py));
             })
         }
     };

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -241,7 +241,7 @@ mod tests {
     fn test_from_err() {
         Python::with_gil(|py| {
             if let Err(err) = PyByteArray::from(py, &py.None()) {
-                assert!(err.is_instance::<exceptions::PyTypeError>(py));
+                assert!(err.is_instance_of::<exceptions::PyTypeError>(py));
             } else {
                 panic!("error");
             }
@@ -293,7 +293,7 @@ mod tests {
             assert!(py_bytearray_result
                 .err()
                 .unwrap()
-                .is_instance::<PyValueError>(py));
+                .is_instance_of::<PyValueError>(py));
         })
     }
 }

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -174,7 +174,7 @@ mod tests {
             assert!(py_bytes_result
                 .err()
                 .unwrap()
-                .is_instance::<PyValueError>(py));
+                .is_instance_of::<PyValueError>(py));
         });
     }
 }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -206,7 +206,7 @@ mod tests {
             let x = 5.to_object(py);
             let err = PyIterator::from_object(py, &x).unwrap_err();
 
-            assert!(err.is_instance::<PyTypeError>(py));
+            assert!(err.is_instance_of::<PyTypeError>(py));
         });
     }
 

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -180,7 +180,7 @@ mod tests {
             assert!(mapping
                 .get_item(8i32)
                 .unwrap_err()
-                .is_instance::<PyKeyError>(py));
+                .is_instance_of::<PyKeyError>(py));
         });
     }
 
@@ -216,7 +216,7 @@ mod tests {
             assert!(mapping
                 .get_item(7i32)
                 .unwrap_err()
-                .is_instance::<PyKeyError>(py));
+                .is_instance_of::<PyKeyError>(py));
         });
     }
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -146,7 +146,7 @@ impl PyModule {
         match self.getattr("__all__") {
             Ok(idx) => idx.downcast().map_err(PyErr::from),
             Err(err) => {
-                if err.is_instance::<exceptions::PyAttributeError>(self.py()) {
+                if err.is_instance_of::<exceptions::PyAttributeError>(self.py()) {
                     let l = PyList::empty(self.py());
                     self.setattr("__all__", l).map_err(PyErr::from)?;
                     Ok(l)

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -345,7 +345,7 @@ mod test_128bit_intergers {
         Python::with_gil(|py| {
             let obj = py.eval("(1 << 130) * -1", None, None).unwrap();
             let err = obj.extract::<i128>().unwrap_err();
-            assert!(err.is_instance::<crate::exceptions::PyOverflowError>(py));
+            assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
     }
 
@@ -354,7 +354,7 @@ mod test_128bit_intergers {
         Python::with_gil(|py| {
             let obj = py.eval("1 << 130", None, None).unwrap();
             let err = obj.extract::<u128>().unwrap_err();
-            assert!(err.is_instance::<crate::exceptions::PyOverflowError>(py));
+            assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
     }
 }
@@ -421,7 +421,7 @@ mod tests {
 
                     let obj = ("123").to_object(py);
                     let err = obj.extract::<$t>(py).unwrap_err();
-                    assert!(err.is_instance::<exceptions::PyTypeError>(py));
+                    assert!(err.is_instance_of::<exceptions::PyTypeError>(py));
                     });
                 }
 
@@ -431,7 +431,7 @@ mod tests {
 
                     let obj = (12.3).to_object(py);
                     let err = obj.extract::<$t>(py).unwrap_err();
-                    assert!(err.is_instance::<exceptions::PyTypeError>(py));});
+                    assert!(err.is_instance_of::<exceptions::PyTypeError>(py));});
                 }
 
                 #[test]

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -40,25 +40,48 @@ impl PyType {
         self.getattr("__qualname__")?.extract()
     }
 
-    /// Checks whether `self` is subclass of type `T`.
+    /// Checks whether `self` is a subclass of type `T`.
     ///
-    /// Equivalent to Python's `issubclass` function.
+    /// Equivalent to the Python expression `issubclass(self, T)`, if the type
+    /// `T` is known at compile time.
     pub fn is_subclass<T>(&self) -> PyResult<bool>
     where
         T: PyTypeObject,
     {
-        let result =
-            unsafe { ffi::PyObject_IsSubclass(self.as_ptr(), T::type_object(self.py()).as_ptr()) };
+        self.is_subclass_of(T::type_object(self.py()))
+    }
+
+    /// Checks whether `self` is a subclass of `other`.
+    ///
+    /// Equivalent to the Python expression `issubclass(self, other)`.
+    pub fn is_subclass_of(&self, other: &PyType) -> PyResult<bool> {
+        let result = unsafe { ffi::PyObject_IsSubclass(self.as_ptr(), other.as_ptr()) };
         err::error_on_minusone(self.py(), result)?;
         Ok(result == 1)
     }
+}
 
-    /// Check whether `obj` is an instance of `self`.
-    ///
-    /// Equivalent to Python's `isinstance` function.
-    pub fn is_instance<T: AsPyPointer>(&self, obj: &T) -> PyResult<bool> {
-        let result = unsafe { ffi::PyObject_IsInstance(obj.as_ptr(), self.as_ptr()) };
-        err::error_on_minusone(self.py(), result)?;
-        Ok(result == 1)
+#[cfg(test)]
+mod tests {
+    use crate::{
+        type_object::PyTypeObject,
+        types::{PyBool, PyLong},
+        Python,
+    };
+
+    #[test]
+    fn test_type_is_subclass() {
+        Python::with_gil(|py| {
+            assert!(PyBool::type_object(py).is_subclass::<PyLong>().unwrap());
+        });
+    }
+
+    #[test]
+    fn test_type_is_subclass_of() {
+        Python::with_gil(|py| {
+            let bool_type = PyBool::type_object(py);
+            let long_type = PyLong::type_object(py);
+            assert!(bool_type.is_subclass_of(long_type).unwrap());
+        });
     }
 }

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -40,24 +40,24 @@ impl PyType {
         self.getattr("__qualname__")?.extract()
     }
 
+    /// Checks whether `self` is a subclass of `other`.
+    ///
+    /// Equivalent to the Python expression `issubclass(self, other)`.
+    pub fn is_subclass(&self, other: &PyType) -> PyResult<bool> {
+        let result = unsafe { ffi::PyObject_IsSubclass(self.as_ptr(), other.as_ptr()) };
+        err::error_on_minusone(self.py(), result)?;
+        Ok(result == 1)
+    }
+
     /// Checks whether `self` is a subclass of type `T`.
     ///
     /// Equivalent to the Python expression `issubclass(self, T)`, if the type
     /// `T` is known at compile time.
-    pub fn is_subclass<T>(&self) -> PyResult<bool>
+    pub fn is_subclass_of<T>(&self) -> PyResult<bool>
     where
         T: PyTypeObject,
     {
-        self.is_subclass_of(T::type_object(self.py()))
-    }
-
-    /// Checks whether `self` is a subclass of `other`.
-    ///
-    /// Equivalent to the Python expression `issubclass(self, other)`.
-    pub fn is_subclass_of(&self, other: &PyType) -> PyResult<bool> {
-        let result = unsafe { ffi::PyObject_IsSubclass(self.as_ptr(), other.as_ptr()) };
-        err::error_on_minusone(self.py(), result)?;
-        Ok(result == 1)
+        self.is_subclass(T::type_object(self.py()))
     }
 }
 
@@ -72,16 +72,16 @@ mod tests {
     #[test]
     fn test_type_is_subclass() {
         Python::with_gil(|py| {
-            assert!(PyBool::type_object(py).is_subclass::<PyLong>().unwrap());
+            let bool_type = PyBool::type_object(py);
+            let long_type = PyLong::type_object(py);
+            assert!(bool_type.is_subclass(long_type).unwrap());
         });
     }
 
     #[test]
     fn test_type_is_subclass_of() {
         Python::with_gil(|py| {
-            let bool_type = PyBool::type_object(py);
-            let long_type = PyLong::type_object(py);
-            assert!(bool_type.is_subclass_of(long_type).unwrap());
+            assert!(PyBool::type_object(py).is_subclass_of::<PyLong>().unwrap());
         });
     }
 }

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -1,5 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::py_run;
+use pyo3::type_object::PyTypeObject;
 
 use pyo3::types::IntoPyDict;
 
@@ -100,6 +101,23 @@ fn mutation_fails() {
         .run("obj.base_set(lambda: obj.sub_set_and_ret(1))", global, None)
         .unwrap_err();
     assert_eq!(&e.to_string(), "RuntimeError: Already borrowed")
+}
+
+#[test]
+fn is_subclass_and_is_instance() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let sub_ty = SubClass::type_object(py);
+    let base_ty = BaseClass::type_object(py);
+    assert!(sub_ty.is_subclass::<BaseClass>().unwrap());
+    assert!(sub_ty.is_subclass_of(base_ty).unwrap());
+
+    let obj = PyCell::new(py, SubClass::new()).unwrap();
+    assert!(obj.is_instance::<SubClass>().unwrap());
+    assert!(obj.is_instance::<BaseClass>().unwrap());
+    assert!(obj.is_instance_of(sub_ty).unwrap());
+    assert!(obj.is_instance_of(base_ty).unwrap());
 }
 
 #[pyclass(subclass)]

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -110,14 +110,14 @@ fn is_subclass_and_is_instance() {
 
     let sub_ty = SubClass::type_object(py);
     let base_ty = BaseClass::type_object(py);
-    assert!(sub_ty.is_subclass::<BaseClass>().unwrap());
-    assert!(sub_ty.is_subclass_of(base_ty).unwrap());
+    assert!(sub_ty.is_subclass_of::<BaseClass>().unwrap());
+    assert!(sub_ty.is_subclass(base_ty).unwrap());
 
     let obj = PyCell::new(py, SubClass::new()).unwrap();
-    assert!(obj.is_instance::<SubClass>().unwrap());
-    assert!(obj.is_instance::<BaseClass>().unwrap());
-    assert!(obj.is_instance_of(sub_ty).unwrap());
-    assert!(obj.is_instance_of(base_ty).unwrap());
+    assert!(obj.is_instance_of::<SubClass>().unwrap());
+    assert!(obj.is_instance_of::<BaseClass>().unwrap());
+    assert!(obj.is_instance(sub_ty).unwrap());
+    assert!(obj.is_instance(base_ty).unwrap());
 }
 
 #[pyclass(subclass)]

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -97,7 +97,7 @@ fn test_getattr() {
         assert!(example_py
             .getattr("other_attr")
             .unwrap_err()
-            .is_instance::<PyAttributeError>(py));
+            .is_instance_of::<PyAttributeError>(py));
     })
 }
 


### PR DESCRIPTION
which get the type to check against as an arguments, as opposed to a compile-time generic type.

Also added some tests for the instance/subclass methods.

**Question:** is it better to name the new methods like this with `_of`, or to move the current methods to `_of` and name the new methods with the conventional arguments more like in Python?

This would also fix the current (slight) inconsistency between `PyType::is_instance` and `PyAny::is_instance_of`.

Fixes #1984