### PR TITLE
allow_threads: switch from `catch_unwind` to guard pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix creating `#[classattr]` by functions with the name of a known magic method. [#1969](https://github.com/PyO3/pyo3/pull/1969)
+- Fix use of `catch_unwind` in `allow_threads` which can cause fatal crashes. [#1989](https://github.com/PyO3/pyo3/pull/1989)
 - Fix build failure on PyPy when abi3 features are activated. [#1991](https://github.com/PyO3/pyo3/pull/1991)
 - Fix mingw platform detection. [#1993](https://github.com/PyO3/pyo3/pull/1993)
 


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/13526#issuecomment-968248522

I think that use of `catch_unwind` in `allow_threads` may currently catch non-Rust exceptions too (it's not particularly clear), leading to nasty crashes.

Switching to a guard pattern might avoid this.

cc @Eric-Arellano can you try your pants PR against this branch and see if it fixes?