### PR TITLE
Fix mingw platform detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix creating `#[classattr]` by functions with the name of a known magic method. [#1969](https://github.com/PyO3/pyo3/pull/1969)
+- Fix mingw platform detection. [#1993](https://github.com/PyO3/pyo3/pull/1993)
 
 ## [0.15.0] - 2021-11-03
 

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -202,7 +202,7 @@ print_if_set("libdir", get_config_var("LIBDIR"))
 print_if_set("base_prefix", base_prefix)
 print("executable", sys.executable)
 print("calcsize_pointer", struct.calcsize("P"))
-print("mingw", get_platform() == "mingw")
+print("mingw", get_platform().startswith("mingw"))
 "#;
         let output = run_python_script(interpreter.as_ref(), SCRIPT)?;
         let map: HashMap<String, String> = parse_script_output(&output);


### PR DESCRIPTION
According to https://github.com/PyO3/maturin/issues/676#issuecomment-967083567 , `sysconfig.get_platform()` returns `mingw_x86_64` instead of just `mingw`.

See also https://github.com/msys2/MINGW-packages/blob/c95de6c2045def876948c20fe6185faccff3f576/mingw-w64-python/0083-Change-the-get_platform-method-in-sysconfig.patch