### PR TITLE
add missing annotation to PyCounter.__call__

### DIFF
--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -98,7 +98,7 @@ impl PyCounter {
     fn __new__(wraps: Py<PyAny>) -> Self {
         PyCounter { count: 0, wraps }
     }
-
+    #[args(args="*", kwargs="**")]
     fn __call__(
         &mut self,
         py: Python,


### PR DESCRIPTION
This patch annotates the `__call__` method of `PyCounter` in example: callable objects with `#[args(args="*", kwargs="**")]`. Without it (at least in PyO3 0.15.0) the example fails with `TypeError: counter.__call__() missing 1 required positional argument: 'args'`.