### PR TITLE
macros: fix panic in __get__ implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix use of `catch_unwind` in `allow_threads` which can cause fatal crashes. [#1989](https://github.com/PyO3/pyo3/pull/1989)
 - Fix build failure on PyPy when abi3 features are activated. [#1991](https://github.com/PyO3/pyo3/pull/1991)
 - Fix mingw platform detection. [#1993](https://github.com/PyO3/pyo3/pull/1993)
+- Fix panic in `__get__` implementation when accessing descriptor on type object. [#1997](https://github.com/PyO3/pyo3/pull/1997)
 
 ## [0.15.0] - 2021-11-03
 

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -548,11 +548,23 @@ fn descr_getset() {
         r#"
 class Class:
     counter = Counter()
+
+# access via type
+counter = Class.counter
+assert counter.count == 1
+
+# access with instance directly
+assert Counter.__get__(counter, Class()).count == 2
+
+# access via instance
 c = Class()
-c.counter # count += 1
-assert c.counter.count == 2
-c.counter = Counter()
 assert c.counter.count == 3
+
+# __set__
+c.counter = Counter()
+assert c.counter.count == 4
+
+# __delete__
 del c.counter
 assert c.counter.count == 1
 "#


### PR DESCRIPTION
Closes #1994 

It looks like either argument to the function can be a null pointer depending on usage. In these cases I substitute with None before reaching the extraction code.