### PR TITLE
pyo3-build-config: don't enable resolve-config by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update MSRV to Rust 1.48. [#2004](https://github.com/PyO3/pyo3/pull/2004)
 - Update `indoc` optional dependency to 1.0. [#2004](https://github.com/PyO3/pyo3/pull/2004)
 - Update `paste` optional dependency to 1.0. [#2004](https://github.com/PyO3/pyo3/pull/2004)
+- `pyo3-build-config` no longer enables the `resolve-config` feature by default. [#2008](https://github.com/PyO3/pyo3/pull/2008)
 
 ## [0.15.1] - 2021-11-19
 

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -74,10 +74,8 @@ The `nightly` feature needs the nightly Rust compiler. This allows PyO3 to use R
 ### `resolve-config`
 
 The `resolve-config` feature of the `pyo3-build-config` crate controls whether that crate's
-build script automatically resolves a Python interpreter / build configuration. Disabling
-this feature enables this crate to be used in *library mode*. This may be desirable for
-use cases where you want to read or write PyO3 build configuration files or resolve
-metadata about a Python interpreter.
+build script automatically resolves a Python interpreter / build configuration. This feature is primarily useful when building PyO3
+itself. By default this feature is not enabled, meaning you can freely use `pyo3-build-config` as a standalone library to read or write PyO3 build configuration files or resolve metadata about a Python interpreter.
 
 ## Optional Dependencies
 
@@ -127,5 +125,3 @@ struct User {
     permissions: Vec<Py<Permission>>
 }
 ```
-
-

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 once_cell = "1"
 
 [features]
-default = ["resolve-config"]
+default = []
 
 # Attempt to resolve a Python interpreter config for building in the build
 # script. If this feature isn't enabled, the build script no-ops.


### PR DESCRIPTION
As per https://github.com/indygreg/PyOxidizer/pull/433#issuecomment-910048561 I meant to remove the `resolve-config` feature from `pyo3-build-config` default features in 0.15, but I forgot, so let's do it in 0.16!