### PR TITLE
Add Py<T>.setattr method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `indoc` optional dependency to 1.0. [#2004](https://github.com/PyO3/pyo3/pull/2004)
 - Update `paste` optional dependency to 1.0. [#2004](https://github.com/PyO3/pyo3/pull/2004)
 
+### Added
+
+- Add `Py::setattr` method. [#2009](https://github.com/PyO3/pyo3/pull/2009)
+
 ## [0.15.1] - 2021-11-19
 
 ### Added

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -528,6 +528,21 @@ impl<T> Py<T> {
         })
     }
 
+    /// Sets an attribute value.
+    ///
+    /// This is equivalent to the Python expression `self.attr_name = value`.
+    pub fn setattr<N, V>(&self, py: Python, attr_name: N, value: V) -> PyResult<()>
+    where
+        N: ToPyObject,
+        V: ToPyObject,
+    {
+        attr_name.with_borrowed_ptr(py, move |attr_name| {
+            value.with_borrowed_ptr(py, |value| unsafe {
+                err::error_on_minusone(py, ffi::PyObject_SetAttr(self.as_ptr(), attr_name, value))
+            })
+        })
+    }
+
     /// Calls the object.
     ///
     /// This is equivalent to the Python expression `self(*args, **kwargs)`.


### PR DESCRIPTION
`PyAny` exposes a `setattr` method, but `Py<T>` currently doesn't.

TODO:
 - [x] add `Py::setattr` method
 - [x] add an entry in `CHANGELOG.md`
 - [ ] add the corresponding test 
