### PR TITLE
coverage: try again to merge all OS coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,4 +320,4 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           file: coverage.lcov
-          name: ${{ matrix.os }}
+          flags: ${{ matrix.os }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,16 @@ coverage:
         target: auto
         # Allow a tiny drop of overall project coverage in PR to reduce spurious failures.
         threshold: 0.25%
+        flags:
+          - windows
+          - macos
+          - ubuntu
+    patch:
+      default:
+        flags:
+          - windows
+          - macos
+          - ubuntu
 
 ignore:
   - tests/*.rs


### PR DESCRIPTION
After #1975 the three OS jobs run but don't seem to be giving reliable numbers at the project level. I suspect that first job to finish and upload is what gets reported on the PR. I'm going to try tweaking settings like this to see if it improves things...