### PR TITLE
Pymethod args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add implementations for `Py::as_ref()` and `Py::into_ref()` for `Py<PySequence>`, `Py<PyIterator>` and `Py<PyMapping>`. [#1682](https://github.com/PyO3/pyo3/pull/1682)
 - Add `PyTraceback` type to represent and format Python tracebacks. [#1977](https://github.com/PyO3/pyo3/pull/1977)
+- Add condition to check the missing Argument in methods_args. [#2012](https://github.com/PyO3/pyo3/pull/2012)
 
 ### Changed
 

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1031,19 +1031,23 @@ fn extract_proto_arguments(
     let mut non_python_args = 0;
 
     let mut args_conversions = Vec::with_capacity(proto_args.len());
-
-    for arg in method_args {
-        if arg.py {
-            arg_idents.push(py.clone());
-        } else {
-            let ident = syn::Ident::new(&format!("arg{}", non_python_args), Span::call_site());
-            let conversions = proto_args.get(non_python_args)
-                .ok_or_else(|| err_spanned!(arg.ty.span() => format!("Expected at most {} non-python arguments", proto_args.len())))?
-                .extract(cls, py, &ident, arg, extract_error_mode);
-            non_python_args += 1;
-            args_conversions.push(conversions);
-            arg_idents.push(ident);
+    if(method_args.len()!=0){
+        for arg in method_args {
+            if arg.py {
+                arg_idents.push(py.clone());
+            } else {
+                let ident = syn::Ident::new(&format!("arg{}", non_python_args), Span::call_site());
+                let conversions = proto_args.get(non_python_args)
+                    .ok_or_else(|| err_spanned!(arg.ty.span() => format!("Expected at most {} non-python arguments", proto_args.len())))?
+                    .extract(cls, py, &ident, arg, extract_error_mode);
+                non_python_args += 1;
+                args_conversions.push(conversions);
+                arg_idents.push(ident);
+            }
         }
+    }
+    else{
+        println("Arguments missing");
     }
 
     let conversions = quote!(#(#args_conversions)*);


### PR DESCRIPTION
Fixed issue #2010. Added a condition to check the `methods_arg` if passed then continue iterating. <br>  logs are added in the `CHANGELOG.md` file.
