### PR TITLE
Support default method implementation

### DIFF
--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -657,6 +657,9 @@ slots_trait!(PyAsyncProtocolSlots, async_protocol_slots);
 slots_trait!(PySequenceProtocolSlots, sequence_protocol_slots);
 slots_trait!(PyBufferProtocolSlots, buffer_protocol_slots);
 
+// slots that PyO3 implements by default, but can be overidden by the users.
+slots_trait!(PyClassDefaultSlots, py_class_default_slots);
+
 // Protocol slots from #[pymethods] if not using inventory.
 #[cfg(not(feature = "multiple-pymethods"))]
 slots_trait!(PyMethodsProtocolSlots, methods_protocol_slots);

--- a/tests/test_default_impls.rs
+++ b/tests/test_default_impls.rs
@@ -1,0 +1,41 @@
+use pyo3::prelude::*;
+
+mod common;
+
+// Test default generated __repr__.
+#[pyclass]
+enum TestDefaultRepr {
+    Var,
+}
+
+#[test]
+fn test_default_slot_exists() {
+    Python::with_gil(|py| {
+        let test_object = Py::new(py, TestDefaultRepr::Var).unwrap();
+        py_assert!(
+            py,
+            test_object,
+            "repr(test_object) == 'TestDefaultRepr.Var'"
+        );
+    })
+}
+
+#[pyclass]
+enum OverrideSlot {
+    Var,
+}
+
+#[pymethods]
+impl OverrideSlot {
+    fn __repr__(&self) -> &str {
+        "overriden"
+    }
+}
+
+#[test]
+fn test_override_slot() {
+    Python::with_gil(|py| {
+        let test_object = Py::new(py, OverrideSlot::Var).unwrap();
+        py_assert!(py, test_object, "repr(test_object) == 'overriden'");
+    })
+}

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -51,3 +51,13 @@ fn test_enum_arg() {
 
     py_run!(py, f mynum, "f(mynum.Variant)")
 }
+
+#[test]
+fn test_default_repr_correct() {
+    Python::with_gil(|py| {
+        let var1 = Py::new(py, MyEnum::Variant).unwrap();
+        let var2 = Py::new(py, MyEnum::OtherVariant).unwrap();
+        py_assert!(py, var1, "repr(var1) == 'MyEnum.Variant'");
+        py_assert!(py, var2, "repr(var2) == 'MyEnum.OtherVariant'");
+    })
+}


### PR DESCRIPTION
Precursor to #2013. This allows us to inject default implementation of slot methods.

Add a trait (`PyClassDefaultSlots`) to support default methods.
Add `pyimpl::gen_default_slot_impls` to help generate definition of default methods in the macro backend.
Add default implementation of `__repr__` for `#[pyclass]` enums.