### PR TITLE
Let #[pyclass] reject empty enums.

### DIFF
--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -386,6 +386,9 @@ pub fn build_py_enum(
     args: PyClassArgs,
     method_type: PyClassMethodsType,
 ) -> syn::Result<TokenStream> {
+    if enum_.variants.is_empty() {
+        bail_spanned!(enum_.brace_token.span => "Empty enums can't be #[pyclass].");
+    }
     let variants: Vec<PyClassEnumVariant> = enum_
         .variants
         .iter()

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -12,4 +12,7 @@ enum NotDrivedClass {
     y,
 }
 
+#[pyclass]
+enum NoEmptyEnum {}
+
 fn main() {}

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -9,3 +9,9 @@ error: enums cannot extend from other classes
   |
 9 | #[pyclass(extends = PyList)]
   |           ^^^^^^^
+
+error: Empty enums can't be #[pyclass].
+  --> tests/ui/invalid_pyclass_enum.rs:16:18
+   |
+16 | enum NoEmptyEnum {}
+   |                  ^^


### PR DESCRIPTION
You can't instantiate them, it makes no sense in Python.
Rejecting them makes it easier to write default methods.