### PR TITLE
inventory: update to 0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `paste` optional dependency to 1.0. [#2004](https://github.com/PyO3/pyo3/pull/2004)
 - Drop support for Python 3.6, remove `abi3-py36` feature. [#2006](https://github.com/PyO3/pyo3/pull/2006)
 - `pyo3-build-config` no longer enables the `resolve-config` feature by default. [#2008](https://github.com/PyO3/pyo3/pull/2008)
+- Update `inventory` optional dependency to 0.2. [#2019](https://github.com/PyO3/pyo3/pull/2019)
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ paste = { version = "1.0.6", optional = true }
 unindent = { version = "0.1.4", optional = true }
 
 # support crate for multiple-pymethods feature
-# must stay at 0.1.x for Rust 1.41 compatibility
-inventory = { version = "0.1.4", optional = true }
+inventory = { version = "0.2.0", optional = true }
 
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0", optional = true }

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -211,10 +211,8 @@ fn submit_methods_inventory(
 ) -> TokenStream {
     quote! {
         ::pyo3::inventory::submit! {
-            #![crate = ::pyo3] {
-                type Inventory = <#ty as ::pyo3::class::impl_::HasMethodsInventory>::Methods;
-                <Inventory as ::pyo3::class::impl_::PyMethodsInventory>::new(::std::vec![#(#methods),*], ::std::vec![#(#proto_impls),*])
-            }
+            type Inventory = <#ty as ::pyo3::class::impl_::PyClassImpl>::Inventory;
+            Inventory::new(&[#(#methods),*], &[#(#proto_impls),*])
         }
     }
 }

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -67,6 +67,9 @@ pub trait PyClassImpl: Sized {
     ///    can be accessed by multiple threads by `threading` module.
     type ThreadChecker: PyClassThreadChecker<Self>;
 
+    #[cfg(feature = "multiple-pymethods")]
+    type Inventory: PyClassInventory;
+
     fn for_each_method_def(_visitor: &mut dyn FnMut(&[PyMethodDefType])) {}
     fn get_new() -> Option<ffi::newfunc> {
         None
@@ -607,23 +610,13 @@ macro_rules! methods_trait {
 /// Method storage for `#[pyclass]`.
 /// Allows arbitrary `#[pymethod]` blocks to submit their methods,
 /// which are eventually collected by `#[pyclass]`.
-#[cfg(all(feature = "macros", feature = "multiple-pymethods"))]
-pub trait PyMethodsInventory: inventory::Collect {
-    /// Create a new instance
-    fn new(methods: Vec<PyMethodDefType>, slots: Vec<ffi::PyType_Slot>) -> Self;
-
+#[cfg(feature = "multiple-pymethods")]
+pub trait PyClassInventory: inventory::Collect {
     /// Returns the methods for a single `#[pymethods] impl` block
     fn methods(&'static self) -> &'static [PyMethodDefType];
 
     /// Returns the slots for a single `#[pymethods] impl` block
     fn slots(&'static self) -> &'static [ffi::PyType_Slot];
-}
-
-/// Implemented for `#[pyclass]` in our proc macro code.
-/// Indicates that the pyclass has its own method storage.
-#[cfg(all(feature = "macros", feature = "multiple-pymethods"))]
-pub trait HasMethodsInventory {
-    type Methods: PyMethodsInventory;
 }
 
 // Methods from #[pyo3(get, set)] on struct fields.


### PR DESCRIPTION
Reworked things a little bit internally to make inventory 0.2 work. Removed the `HasMethodsInventory` trait and just made it part of `PyClassImpl`.