### PR TITLE
pytype: resurrect (deprecated) PyType::is_instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ptraceback` -> `traceback`
   - `from_instance` -> `from_value`
   - `into_instance` -> `into_value`
+- Deprecate `PyType::is_instance`; it is inconsistent with other `is_instance` methods in PyO3. Instead of `typ.is_instance(obj)`, use `obj.is_instance(typ)`. [#2031](https://github.com/PyO3/pyo3/pull/2031)
 
 ### Removed
 
-- Remove `PyType::is_instance`, which is unintuitive; instead of `typ.is_instance(obj)`, use `obj.is_instance(typ)`. [#1985](https://github.com/PyO3/pyo3/pull/1985)
 - Remove all functionality deprecated in PyO3 0.14. [#2007](https://github.com/PyO3/pyo3/pull/2007)
 
 ### Fixed

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -59,6 +59,19 @@ impl PyType {
     {
         self.is_subclass(T::type_object(self.py()))
     }
+
+    #[deprecated(
+        since = "0.16.0",
+        note = "prefer obj.is_instance(type) to typ.is_instance(obj)"
+    )]
+    /// Equivalent to Python's `isinstance(obj, self)`.
+    ///
+    /// This function has been deprecated because it has inverted argument ordering compared to
+    /// other `is_instance` functions in PyO3 such as [`PyAny::is_instance`].
+    pub fn is_instance<T: AsPyPointer>(&self, obj: &T) -> PyResult<bool> {
+        let any: &PyAny = unsafe { self.py().from_borrowed_ptr(obj.as_ptr()) };
+        any.is_instance(self)
+    }
 }
 
 #[cfg(test)]
@@ -83,5 +96,16 @@ mod tests {
         Python::with_gil(|py| {
             assert!(PyBool::type_object(py).is_subclass_of::<PyLong>().unwrap());
         });
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn type_is_instance() {
+        Python::with_gil(|py| {
+            let bool_object = PyBool::new(py, false);
+            let bool_type = bool_object.get_type();
+            assert!(bool_type.is_instance(bool_object).unwrap());
+            assert!(bool_object.is_instance(bool_type).unwrap());
+        })
     }
 }


### PR DESCRIPTION
This change is a follow-up to #1985 to restore `PyType::is_instance` in a deprecated state.

I realised that if we just straight-up remove this method without a deprecation cycle, users will likely experience runtime failures because `type.is_instance(obj)` will continue to compile but select `PyAny::is_instance` instead thanks to `PyType` dereferencing to `PyAny`.

Hence this PR resurrects `PyType::is_instance` in a deprecated state so that users have some time to migrate away.