### PR TITLE
dev: remove self dev dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       # Run tests (except on PyPy, because no embedding API).
       - if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         name: Test (no features)
-        run: cargo test --no-default-features
+        run: cargo test --no-default-features --lib --tests
 
       # --no-default-features when used with `cargo build/test -p` doesn't seem to work!
       - name: Test pyo3-build-config (no features)
@@ -252,6 +252,10 @@ jobs:
       # TODO: this is a hack to workaround compile_error! warnings about auto-initialize on PyPy
       # Once cargo's `resolver = "2"` is stable (~ MSRV Rust 1.52), remove this.
       PYO3_CI: 1
+      # This is a hack to make CARGO_PRIMARY_PACKAGE always set even for the
+      # msrv job. MSRV is currently 1.48, but CARGO_PRIMARY_PACKAGE only came in
+      # 1.49.
+      CARGO_PRIMARY_PACKAGE: 1
 
   coverage:
     needs: [fmt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ rustversion = "1.0"
 proptest = { version = "0.10.1", default-features = false, features = ["std"] }
 serde_json = "1.0.61"
 
-# features needed to run the PyO3 test suite
-pyo3 = { path = ".", default-features = false, features = ["macros", "auto-initialize"] }
-
 [build-dependencies]
 pyo3-build-config = { path = "pyo3-build-config", version = "0.15.1", features = ["resolve-config"] }
 

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -117,8 +117,8 @@ impl From<anyhow::Error> for PyErr {
 
 #[cfg(test)]
 mod test_anyhow {
-    use pyo3::prelude::*;
-    use pyo3::types::IntoPyDict;
+    use crate::prelude::*;
+    use crate::types::IntoPyDict;
 
     use anyhow::{anyhow, bail, Context, Result};
 

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -118,8 +118,8 @@ impl From<eyre::Report> for PyErr {
 
 #[cfg(test)]
 mod tests {
-    use pyo3::prelude::*;
-    use pyo3::types::IntoPyDict;
+    use crate::prelude::*;
+    use crate::types::IntoPyDict;
 
     use eyre::{bail, Result, WrapErr};
 

--- a/src/ffi/datetime.rs
+++ b/src/ffi/datetime.rs
@@ -630,7 +630,7 @@ impl Deref for _PyDateTime_TimeZone_UTC_impl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{py_run, AsPyPointer, IntoPy, Py, PyAny, Python};
+    use crate::{types::PyDict, AsPyPointer, IntoPy, Py, PyAny, Python};
 
     #[test]
     fn test_datetime_fromtimestamp() {
@@ -638,11 +638,14 @@ mod tests {
             let args: Py<PyAny> = (100,).into_py(py);
             unsafe { PyDateTime_IMPORT() };
             let dt: &PyAny = unsafe { py.from_owned_ptr(PyDateTime_FromTimestamp(args.as_ptr())) };
-            py_run!(
-                py,
-                dt,
-                "import datetime; assert dt == datetime.datetime.fromtimestamp(100)"
-            );
+            let locals = PyDict::new(py);
+            locals.set_item("dt", dt).unwrap();
+            py.run(
+                "import datetime; assert dt == datetime.datetime.fromtimestamp(100)",
+                None,
+                Some(locals),
+            )
+            .unwrap();
         })
     }
 
@@ -652,11 +655,14 @@ mod tests {
             let args: Py<PyAny> = (100,).into_py(py);
             unsafe { PyDateTime_IMPORT() };
             let dt: &PyAny = unsafe { py.from_owned_ptr(PyDate_FromTimestamp(args.as_ptr())) };
-            py_run!(
-                py,
-                dt,
-                "import datetime; assert dt == datetime.date.fromtimestamp(100)"
-            );
+            let locals = PyDict::new(py);
+            locals.set_item("dt", dt).unwrap();
+            py.run(
+                "import datetime; assert dt == datetime.date.fromtimestamp(100)",
+                None,
+                Some(locals),
+            )
+            .unwrap();
         })
     }
 
@@ -665,11 +671,14 @@ mod tests {
     fn test_utc_timezone() {
         Python::with_gil(|py| {
             let utc_timezone = PyDateTime_TimeZone_UTC.as_ref(py);
-            py_run!(
-                py,
-                utc_timezone,
-                "import datetime; assert utc_timezone is datetime.timezone.utc"
-            );
+            let locals = PyDict::new(py);
+            locals.set_item("utc_timezone", utc_timezone).unwrap();
+            py.run(
+                "import datetime; assert utc_timezone is datetime.timezone.utc",
+                None,
+                Some(locals),
+            )
+            .unwrap();
         })
     }
 }

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -181,6 +181,14 @@ impl GILGuard {
             if #[cfg(all(feature = "auto-initialize", not(PyPy)))] {
                 prepare_freethreaded_python();
             } else {
+                // This is a "hack" to make running `cargo test` for PyO3 convenient (i.e. no need
+                // to specify `--features auto-initialize` manually. Tests within the crate itself
+                // all depend on the auto-initialize feature for conciseness but Cargo does not
+                // provide a mechanism to specify required features for tests.
+                if option_env!("CARGO_PRIMARY_PACKAGE").is_some() {
+                    prepare_freethreaded_python();
+                }
+
                 START.call_once_force(|_| unsafe {
                     // Use call_once_force because if there is a panic because the interpreter is
                     // not initialized, it's fine for the user to initialize the interpreter and

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -697,13 +697,6 @@ mod tests {
         Python, ToPyObject,
     };
 
-    macro_rules! test_module {
-        ($py:ident, $code:literal) => {
-            PyModule::from_code($py, indoc::indoc!($code), file!(), "test_module")
-                .expect("module creation failed")
-        };
-    }
-
     #[test]
     fn test_call_for_non_existing_method() {
         Python::with_gil(|py| {
@@ -728,14 +721,17 @@ mod tests {
     #[test]
     fn test_call_method0() {
         Python::with_gil(|py| {
-            let module = test_module!(
+            let module = PyModule::from_code(
                 py,
                 r#"
-                class SimpleClass:
-                    def foo(self):
-                        return 42
-            "#
-            );
+class SimpleClass:
+    def foo(self):
+        return 42
+"#,
+                file!(),
+                "test_module",
+            )
+            .expect("module creation failed");
 
             let simple_class = module.getattr("SimpleClass").unwrap().call0().unwrap();
             assert_eq!(

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -113,7 +113,6 @@ mod tests {
     #[cfg(any(not(Py_LIMITED_API), Py_3_8))]
     use crate::PyTryFrom;
     use crate::{Py, PyAny, Python, ToPyObject};
-    use indoc::indoc;
 
     #[test]
     fn vec_iter() {
@@ -177,16 +176,14 @@ mod tests {
 
     #[test]
     fn fibonacci_generator() {
-        let fibonacci_generator = indoc!(
-            r#"
-            def fibonacci(target):
-                a = 1
-                b = 1
-                for _ in range(target):
-                    yield a
-                    a, b = b, a + b
-        "#
-        );
+        let fibonacci_generator = r#"
+def fibonacci(target):
+    a = 1
+    b = 1
+    for _ in range(target):
+        yield a
+        a, b = b, a + b
+"#;
 
         Python::with_gil(|py| {
             let context = PyDict::new(py);

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -278,6 +278,7 @@ fn err_if_invalid_value<T: PartialEq>(
 #[cfg(test)]
 mod test_128bit_intergers {
     use super::*;
+    use crate::types::PyDict;
 
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
@@ -288,7 +289,9 @@ mod test_128bit_intergers {
         fn test_i128_roundtrip(x: i128) {
             Python::with_gil(|py| {
                 let x_py = x.into_py(py);
-                crate::py_run!(py, x_py, &format!("assert x_py == {}", x));
+                let locals = PyDict::new(py);
+                locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(locals)).unwrap();
                 let roundtripped: i128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -301,7 +304,9 @@ mod test_128bit_intergers {
         fn test_u128_roundtrip(x: u128) {
             Python::with_gil(|py| {
                 let x_py = x.into_py(py);
-                crate::py_run!(py, x_py, &format!("assert x_py == {}", x));
+                let locals = PyDict::new(py);
+                locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(locals)).unwrap();
                 let roundtripped: u128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::class::basic::CompareOp;
 use pyo3::prelude::*;
 use pyo3::py_run;

--- a/tests/test_arithmetics_protos.rs
+++ b/tests/test_arithmetics_protos.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated)] // for deprecated protocol methods
+#![cfg(feature = "macros")]
 
 use pyo3::class::basic::CompareOp;
 use pyo3::class::*;

--- a/tests/test_buffer.rs
+++ b/tests/test_buffer.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "macros")]
 #![cfg(not(Py_LIMITED_API))]
 
 use pyo3::{

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "macros")]
 #![cfg(not(Py_LIMITED_API))]
 
 use pyo3::buffer::PyBuffer;

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 
 mod common;

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::types::PyType;
 use pyo3::{py_run, PyClass};

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::ToPyObject;
 

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 #[rustversion::stable]
 #[test]
 fn test_compile_errors() {

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -33,21 +33,21 @@ fn _get_subclasses<'p>(
 }
 
 macro_rules! assert_check_exact {
-    ($check_func:ident, $obj: expr) => {
+    ($check_func:ident, $check_func_exact:ident, $obj: expr) => {
         unsafe {
-            use pyo3::{AsPyPointer, ffi::*};
+            use pyo3::{ffi::*, AsPyPointer};
             assert!($check_func(($obj).as_ptr()) != 0);
-            assert!(pyo3::paste::expr!([<$check_func Exact>])(($obj).as_ptr()) != 0);
+            assert!($check_func_exact(($obj).as_ptr()) != 0);
         }
     };
 }
 
 macro_rules! assert_check_only {
-    ($check_func:ident, $obj: expr) => {
+    ($check_func:ident, $check_func_exact:ident, $obj: expr) => {
         unsafe {
-            use pyo3::{AsPyPointer, ffi::*};
+            use pyo3::{ffi::*, AsPyPointer};
             assert!($check_func(($obj).as_ptr()) != 0);
-            assert!(pyo3::paste::expr!([<$check_func Exact>])(($obj).as_ptr()) == 0);
+            assert!($check_func_exact(($obj).as_ptr()) == 0);
         }
     };
 }
@@ -58,9 +58,9 @@ fn test_date_check() {
     let py = gil.python();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "date", "2018, 1, 1").unwrap();
 
-    assert_check_exact!(PyDate_Check, obj);
-    assert_check_only!(PyDate_Check, sub_obj);
-    assert_check_only!(PyDate_Check, sub_sub_obj);
+    assert_check_exact!(PyDate_Check, PyDate_CheckExact, obj);
+    assert_check_only!(PyDate_Check, PyDate_CheckExact, sub_obj);
+    assert_check_only!(PyDate_Check, PyDate_CheckExact, sub_sub_obj);
 }
 
 #[test]
@@ -69,9 +69,9 @@ fn test_time_check() {
     let py = gil.python();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "time", "12, 30, 15").unwrap();
 
-    assert_check_exact!(PyTime_Check, obj);
-    assert_check_only!(PyTime_Check, sub_obj);
-    assert_check_only!(PyTime_Check, sub_sub_obj);
+    assert_check_exact!(PyTime_Check, PyTime_CheckExact, obj);
+    assert_check_only!(PyTime_Check, PyTime_CheckExact, sub_obj);
+    assert_check_only!(PyTime_Check, PyTime_CheckExact, sub_sub_obj);
 }
 
 #[test]
@@ -82,10 +82,10 @@ fn test_datetime_check() {
         .map_err(|e| e.print(py))
         .unwrap();
 
-    assert_check_only!(PyDate_Check, obj);
-    assert_check_exact!(PyDateTime_Check, obj);
-    assert_check_only!(PyDateTime_Check, sub_obj);
-    assert_check_only!(PyDateTime_Check, sub_sub_obj);
+    assert_check_only!(PyDate_Check, PyDate_CheckExact, obj);
+    assert_check_exact!(PyDateTime_Check, PyDateTime_CheckExact, obj);
+    assert_check_only!(PyDateTime_Check, PyDateTime_CheckExact, sub_obj);
+    assert_check_only!(PyDateTime_Check, PyDateTime_CheckExact, sub_sub_obj);
 }
 
 #[test]
@@ -94,9 +94,9 @@ fn test_delta_check() {
     let py = gil.python();
     let (obj, sub_obj, sub_sub_obj) = _get_subclasses(&py, "timedelta", "1, -3").unwrap();
 
-    assert_check_exact!(PyDelta_Check, obj);
-    assert_check_only!(PyDelta_Check, sub_obj);
-    assert_check_only!(PyDelta_Check, sub_sub_obj);
+    assert_check_exact!(PyDelta_Check, PyDelta_CheckExact, obj);
+    assert_check_only!(PyDelta_Check, PyDelta_CheckExact, sub_obj);
+    assert_check_only!(PyDelta_Check, PyDelta_CheckExact, sub_sub_obj);
 }
 
 #[test]

--- a/tests/test_default_impls.rs
+++ b/tests/test_default_impls.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 
 mod common;

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::{py_run, wrap_pyfunction};
 

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::{exceptions, py_run, PyErr, PyResult};
 use std::error::Error;

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString, PyTuple};

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::class::PyGCProtocol;
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::py_run;
 use pyo3::types::{IntoPyDict, PyList};

--- a/tests/test_hygiene.rs
+++ b/tests/test_hygiene.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 mod hygiene {
     mod misc;
     mod pyclass;

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::py_run;
 use pyo3::type_object::PyTypeObject;

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 //! Ensure that pyo3 macros can be used inside macro_rules!
 
 use pyo3::prelude::*;

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use std::collections::HashMap;
 
 use pyo3::exceptions::PyKeyError;

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::py_run;
 use pyo3::types::{IntoPyDict, PyDict, PyList, PySet, PyString, PyTuple, PyType};

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 
 use pyo3::py_run;

--- a/tests/test_not_msrv.rs
+++ b/tests/test_not_msrv.rs
@@ -1,8 +1,11 @@
+#![cfg(feature = "macros")]
+
 //! Functionality which is not only not supported on MSRV,
 //! but can't even be cfg-ed out on MSRV because the compiler doesn't support
 //! the syntax.
 
 #[rustversion::since(1.54)]
 mod requires_1_54 {
+
     include!("not_msrv/requires_1_54.rs");
 }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::exceptions::PyValueError;
 use pyo3::types::{PyList, PySlice, PyType};
 use pyo3::{exceptions::PyAttributeError, prelude::*};

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 #[cfg(not(Py_LIMITED_API))]
 use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;

--- a/tests/test_pyproto.rs
+++ b/tests/test_pyproto.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::class::{
     PyAsyncProtocol, PyDescrProtocol, PyIterProtocol, PyMappingProtocol, PyObjectProtocol,
     PySequenceProtocol,

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 //! Test slf: PyRef/PyMutRef<Self>(especially, slf.into::<Py>) works
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::class::PySequenceProtocol;
 use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;

--- a/tests/test_string.rs
+++ b/tests/test_string.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 
 mod common;

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::{types::PyType, wrap_pymodule, PyCell};
 

--- a/tests/test_unsendable_dict.rs
+++ b/tests/test_unsendable_dict.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::py_run;
 

--- a/tests/test_variable_arguments.rs
+++ b/tests/test_variable_arguments.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 use pyo3::{py_run, PyCell};

--- a/tests/test_wrap_pyfunction_deduction.rs
+++ b/tests/test_wrap_pyfunction_deduction.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "macros")]
+
 use pyo3::{prelude::*, types::PyCFunction};
 
 #[pyfunction]


### PR DESCRIPTION
Closes #1817 

I thought that it wasn't going to be possible to remove `pyo3` from the dev dependencies and still be able to run plain `cargo test` meaningfully.

As #2022 would be much easier to test without the self dev dep, I took another look.

With `CARGO_PRIMARY_PACKAGE` I was actually able to put some conditional code into `acquire_gil` with the effect of automatically initializing when running the pyo3 test suite.

It does mean that on 1.48, `cargo test --features auto-initialize` is needed, as `CARGO_PRIMARY_PACKAGE` was released in 1.49. However I think that's an acceptable trade-off, and a problem which will eventually go away whenever the next msrv bump is.

This might actually help CI times a fair bit, because the `--no-default-features` steps now don't compile and run any code related to macros.