### PR TITLE
Disallow positional arguments after optional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `from_instance` -> `from_value`
   - `into_instance` -> `into_value`
 - Deprecate `PyType::is_instance`; it is inconsistent with other `is_instance` methods in PyO3. Instead of `typ.is_instance(obj)`, use `obj.is_instance(typ)`. [#2031](https://github.com/PyO3/pyo3/pull/2031)
+- Optional parameters of `#[pymethods]` and `#[pyfunction]`s cannot be followed by required parameters, i.e. `fn opt_first(a: Option<i32>, b: i32) {}` is not allowed, while `fn opt_last(a:i32, b: Option<i32>) {}` is. [#2041](https://github.com/PyO3/pyo3/pull/2041)
 
 ### Removed
 

--- a/examples/pyo3-pytests/src/datetime.rs
+++ b/examples/pyo3-pytests/src/datetime.rs
@@ -49,8 +49,8 @@ fn time_with_fold<'p>(
     minute: u8,
     second: u8,
     microsecond: u32,
-    tzinfo: Option<&PyTzInfo>,
     fold: bool,
+    tzinfo: Option<&PyTzInfo>,
 ) -> PyResult<&'p PyTime> {
     PyTime::new_with_fold(
         py,

--- a/examples/pyo3-pytests/tests/test_datetime.py
+++ b/examples/pyo3-pytests/tests/test_datetime.py
@@ -139,7 +139,7 @@ def test_time_fold(t):
 @pytest.mark.xfail(PYPY, reason="Feature not available on PyPy")
 @pytest.mark.parametrize("fold", [False, True])
 def test_time_fold(fold):
-    t = rdt.time_with_fold(0, 0, 0, 0, None, fold)
+    t = rdt.time_with_fold(0, 0, 0, 0, fold, None)
     assert t.fold == fold
 
 

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -82,6 +82,8 @@ pub fn impl_arg_params(
     let mut required_positional_parameters = 0usize;
     let mut keyword_only_parameters = Vec::new();
 
+    let mut all_positional_required = true;
+
     for arg in spec.args.iter() {
         if arg.py || is_args(&spec.attrs, arg.name) || is_kwargs(&spec.attrs, arg.name) {
             continue;
@@ -100,7 +102,13 @@ pub fn impl_arg_params(
             });
         } else {
             if required {
+                ensure_spanned!(
+                    all_positional_required,
+                    arg.name.span() => "Required positional parameters cannot come after optional parameters"
+                );
                 required_positional_parameters += 1;
+            } else {
+                all_positional_required = false;
             }
             if posonly {
                 positional_only_parameters += 1;

--- a/tests/ui/invalid_pyfunctions.rs
+++ b/tests/ui/invalid_pyfunctions.rs
@@ -9,4 +9,7 @@ fn impl_trait_function(impl_trait: impl AsRef<PyAny>) {}
 #[pyfunction]
 async fn async_function() {}
 
+#[pyfunction]
+fn required_arg_after_optional(optional: Option<isize>, required: isize) {}
+
 fn main() {}

--- a/tests/ui/invalid_pyfunctions.stderr
+++ b/tests/ui/invalid_pyfunctions.stderr
@@ -17,3 +17,9 @@ Additional crates such as `pyo3-asyncio` can be used to integrate async Rust and
    |
 10 | async fn async_function() {}
    | ^^^^^
+
+error: Required positional parameters cannot come after optional parameters
+  --> tests/ui/invalid_pyfunctions.rs:13:57
+   |
+13 | fn required_arg_after_optional(optional: Option<isize>, required: isize) {}
+   |                                                         ^^^^^^^^

--- a/tests/ui/invalid_pymethods.rs
+++ b/tests/ui/invalid_pymethods.rs
@@ -113,4 +113,15 @@ impl MyClass {
     fn method_cannot_pass_module(&self, m: &PyModule) {}
 }
 
+#[pymethods]
+impl MyClass {
+    fn required_arg_after_optional(&self, optional: Option<isize>, required: isize) {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[args(has_default = "1")]
+    fn default_arg_before_required(&self, has_default: isize, required: isize) {}
+}
+
 fn main() {}

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -101,3 +101,15 @@ error: `pass_module` cannot be used on Python methods
     |
 112 |     #[pyo3(pass_module)]
     |            ^^^^^^^^^^^
+
+error: Required positional parameters cannot come after optional parameters
+   --> tests/ui/invalid_pymethods.rs:118:68
+    |
+118 |     fn required_arg_after_optional(&self, optional: Option<isize>, required: isize) {}
+    |                                                                    ^^^^^^^^
+
+error: Required positional parameters cannot come after optional parameters
+   --> tests/ui/invalid_pymethods.rs:124:63
+    |
+124 |     fn default_arg_before_required(&self, has_default: isize, required: isize) {}
+    |                                                               ^^^^^^^^


### PR DESCRIPTION
Thank you for contributing to pyo3!

Please consider adding the following to your pull request:
 - an entry in CHANGELOG.md
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

Be aware the CI pipeline will check your pull request for the following:
 - Rust tests (Just `cargo test` or `make test` if you need to test examples)
 - Rust lints (`make clippy`)
 - Rust formatting (`cargo fmt`)
 - Python formatting (`black . --check`. You can install black with `pip install black`)
 - Compatibility with all supported Python versions for all examples. This uses `tox`; you can do run it using `make test_py`.

You can run a similar set of checks as the CI pipeline using `make test`.

When a rust binding has an optional parameter followed by a required parameter it may cause a hard to follow panic in python.
To reproduce:
```
use pyo3::prelude::*;

#[pyclass]
struct Foo {
    #[pyo3(get, set)]
    pub a: i32
}

#[pymethods]
impl Foo {
    #[new]
    fn new() -> Self {
        Self { a: 0 }
    }

    fn opt_first(&mut self, a: Option<i32>, b: i32) {
        self.a = a.unwrap_or(b)
    }
}

#[pymodule]
fn pyo3test(_py: Python, m: &PyModule) -> PyResult<()> {
    m.add_class::<Foo>()?;
    Ok(())
}
```
```
>>> import pyo3test
>>> foo = pyo3test.Foo()
>>> foo.opt_first()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Foo.opt_first() missing 1 required positional argument: 'a'
>>> foo.opt_first(1)
thread '<unnamed>' panicked at 'Failed to extract required method argument', src/lib.rs:24:48
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
pyo3_runtime.PanicException: Failed to extract required method argument
>>> foo.opt_first(1, 2)
>>> foo.a
1
>>> foo.opt_first(None, 1)
>>> foo.a
1
>>>
```
While the python type hinting states that there is only one required positional argument, the function behaves as if there are two required arguments, and even if one were optional, it would be 'a', not 'b'. Additionally, this behavior leads to illegal python, as `def opt_first(a: Optional[int]=None, b: int)` triggers the "non-default argument follows default argument" syntax error.

Reworking the proc-macro so that an `Option` followed by a required positional parameter *must* be provided would make the behavior of `Option`s inconsistent, so we should explicitly disallow required parameters that follow optional parameters.

Both of the following now fail at compile time rather than runtime,
```
#[pymethods]
impl Foo {
    fn opt_first(&mut self, a: Option<i32>, b: i32) {
        self.a = a.unwrap_or(b)
    }

    #[args(a = "1")]
    fn default_first_provided(&mut self, a: i32, b: i32) {
        self.a = a + b;
    }
}
```

While these still compile and work as expected,
```
#[pymethods]
impl Foo {
    #[args(b = "5")]
    fn default_last_provided(&mut self, a: Option<i32>, b: i32) {
        self.a = a.unwrap_or(b)
    }

    fn opt_last(&mut self, a:i32, b: Option<i32>) {
        self.a = b.unwrap_or(a)
    }
}
```