### PR TITLE
One more 1.57 compiletest fix.

### DIFF
--- a/tests/ui/invalid_argument_attributes.stderr
+++ b/tests/ui/invalid_argument_attributes.stderr
@@ -5,10 +5,10 @@ error: expected `from_py_with`
   |                             ^^^
 
 error: expected `=`
- --> tests/ui/invalid_argument_attributes.rs:7:45
+ --> tests/ui/invalid_argument_attributes.rs:7:32
   |
 7 | fn from_py_with_no_value(#[pyo3(from_py_with)] param: String) {}
-  |                                             ^
+  |                                ^^^^^^^^^^^^^^
 
 error: expected `from_py_with`
   --> tests/ui/invalid_argument_attributes.rs:10:31

--- a/tests/ui/invalid_frompy_derive.stderr
+++ b/tests/ui/invalid_frompy_derive.stderr
@@ -109,10 +109,10 @@ error: attribute name cannot be empty
    |                      ^^
 
 error: unexpected end of input, expected string literal
-   --> tests/ui/invalid_frompy_derive.rs:100:22
+   --> tests/ui/invalid_frompy_derive.rs:100:21
     |
 100 |     #[pyo3(attribute())]
-    |                      ^
+    |                     ^^
 
 error: expected at most one argument: `item` or `item(key)`
    --> tests/ui/invalid_frompy_derive.rs:106:20
@@ -121,10 +121,10 @@ error: expected at most one argument: `item` or `item(key)`
     |                    ^
 
 error: unexpected end of input, expected literal
-   --> tests/ui/invalid_frompy_derive.rs:112:17
+   --> tests/ui/invalid_frompy_derive.rs:112:16
     |
 112 |     #[pyo3(item())]
-    |                 ^
+    |                ^^
 
 error: only one of `attribute` or `item` can be provided
    --> tests/ui/invalid_frompy_derive.rs:118:5
@@ -171,10 +171,10 @@ error: cannot derive FromPyObject for empty structs and variants
     = note: this error originates in the derive macro `FromPyObject` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected `=`
-   --> tests/ui/invalid_frompy_derive.rs:158:24
+   --> tests/ui/invalid_frompy_derive.rs:158:11
     |
 158 |     #[pyo3(from_py_with)]
-    |                        ^
+    |           ^^^^^^^^^^^^^^
 
 error: expected string literal
    --> tests/ui/invalid_frompy_derive.rs:164:27


### PR DESCRIPTION
Thank you for contributing to pyo3!

Please consider adding the following to your pull request:
 - an entry in CHANGELOG.md
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

Be aware the CI pipeline will check your pull request for the following:
 - Rust tests (Just `cargo test` or `make test` if you need to test examples)
 - Rust lints (`make clippy`)
 - Rust formatting (`cargo fmt`)
 - Python formatting (`black . --check`. You can install black with `pip install black`)
 - Compatibility with all supported Python versions for all examples. This uses `tox`; you can do run it using `make test_py`.

You can run a similar set of checks as the CI pipeline using `make test`.
