### PR TITLE
ci: clippy whole workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: pip install black==20.8b1
+      - run: pip install black==21.12b0
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           profile: minimal
           components: rustfmt
       - name: Check python formatting (black)
-        run: black --check .
+        run: make fmt_py
       - name: Check rust formatting (rustfmt)
-        run: cargo fmt --all -- --check
+        run: make fmt_rust
 
   clippy:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test_py publish clippy lint fmt
+.PHONY: test test_py publish clippy lint fmt fmt_py fmt_rust
 
 ALL_ADDITIVE_FEATURES = macros multiple-pymethods num-bigint num-complex hashbrown serde indexmap eyre anyhow
 
@@ -14,9 +14,14 @@ test: lint test_py
 test_py:
 	for example in examples/*/; do TOX_TESTENV_PASSENV=RUSTUP_HOME tox -e py -c $$example || exit 1; done
 
-fmt:
-	cargo fmt --all -- --check
+fmt_py:
 	black . --check
+
+fmt_rust:
+	cargo fmt --all -- --check
+
+fmt: fmt_rust fmt_py
+	@true
 
 clippy:
 	cargo clippy --features="$(ALL_ADDITIVE_FEATURES)" --all-targets --workspace -- -Dwarnings

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ fmt:
 	black . --check
 
 clippy:
-	cargo clippy --features="$(ALL_ADDITIVE_FEATURES)" --tests -- -Dwarnings
-	cargo clippy --features="abi3 $(ALL_ADDITIVE_FEATURES)" --tests -- -Dwarnings
+	cargo clippy --features="$(ALL_ADDITIVE_FEATURES)" --all-targets --workspace -- -Dwarnings
+	cargo clippy --features="abi3 $(ALL_ADDITIVE_FEATURES)" --all-targets --workspace -- -Dwarnings
 	for example in examples/*/; do cargo clippy --manifest-path $$example/Cargo.toml -- -Dwarnings || exit 1; done
 
 lint: fmt clippy

--- a/examples/pyo3-pytests/src/buf_and_str.rs
+++ b/examples/pyo3-pytests/src/buf_and_str.rs
@@ -1,3 +1,5 @@
+#![cfg(not(Py_LIMITED_API))]
+
 //! Objects related to PyBuffer and PyStr
 use pyo3::buffer::PyBuffer;
 use pyo3::prelude::*;

--- a/examples/pyo3-pytests/src/datetime.rs
+++ b/examples/pyo3-pytests/src/datetime.rs
@@ -1,3 +1,5 @@
+#![cfg(not(Py_LIMITED_API))]
+
 use pyo3::prelude::*;
 use pyo3::types::{
     PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess, PyTuple,

--- a/examples/pyo3-pytests/src/lib.rs
+++ b/examples/pyo3-pytests/src/lib.rs
@@ -12,7 +12,9 @@ pub mod path;
 pub mod pyclass_iter;
 pub mod subclassing;
 
+#[cfg(not(Py_LIMITED_API))]
 use buf_and_str::*;
+#[cfg(not(Py_LIMITED_API))]
 use datetime::*;
 use dict_iter::*;
 use misc::*;
@@ -24,7 +26,9 @@ use subclassing::*;
 
 #[pymodule]
 fn pyo3_pytests(py: Python, m: &PyModule) -> PyResult<()> {
+    #[cfg(not(Py_LIMITED_API))]
     m.add_wrapped(wrap_pymodule!(buf_and_str))?;
+    #[cfg(not(Py_LIMITED_API))]
     m.add_wrapped(wrap_pymodule!(datetime))?;
     m.add_wrapped(wrap_pymodule!(dict_iter))?;
     m.add_wrapped(wrap_pymodule!(misc))?;

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1530,11 +1530,11 @@ mod tests {
     fn test_venv_interpreter() {
         let base = OsStr::new("base");
         assert_eq!(
-            venv_interpreter(&base, true),
+            venv_interpreter(base, true),
             PathBuf::from_iter(&["base", "Scripts", "python.exe"])
         );
         assert_eq!(
-            venv_interpreter(&base, false),
+            venv_interpreter(base, false),
             PathBuf::from_iter(&["base", "bin", "python"])
         );
     }
@@ -1543,11 +1543,11 @@ mod tests {
     fn test_conda_env_interpreter() {
         let base = OsStr::new("base");
         assert_eq!(
-            conda_env_interpreter(&base, true),
+            conda_env_interpreter(base, true),
             PathBuf::from_iter(&["base", "python.exe"])
         );
         assert_eq!(
-            conda_env_interpreter(&base, false),
+            conda_env_interpreter(base, false),
             PathBuf::from_iter(&["base", "bin", "python"])
         );
     }


### PR DESCRIPTION
I noticed there were a few things we weren't applying clippy to -- now we do!

Also changed `fmt` CI jobs to directly use the makefile, which might be useful in #2043 if we need to check clippy and formatting for examples / pytest crates outside the workspace.