### PR TITLE
ci: no coverage necessary for hygiene tests

### DIFF
--- a/src/test_hygiene/mod.rs
+++ b/src/test_hygiene/mod.rs
@@ -1,3 +1,10 @@
+// The modules in this test are used to check PyO3 macro expansion is hygienic. By locating the test
+// inside the crate the global `::pyo3` namespace is not available, so in combination with
+// #[pyo3(crate = "crate")] this validates that all macro expansion respects the setting.
+//
+// The generated code is never executed (these tests are checking compile time correctness.)
+#![cfg_attr(coverage, feature(no_coverage))]
+
 mod misc;
 mod pyclass;
 mod pyfunction;


### PR DESCRIPTION
I think that `#[no_coverage]` is an attribute to be used only very sparingly - generally my thinking is that it's better to be honest to users and prefer lower coverage number to slapping this attribute all over the place to get coverage to 100%.

However in this case I do think that the hygiene tests, which are only compile-time checks (never executed) and not relevant for user code, really do qualify for this attribute.