### PR TITLE
pymethods: add support for sequence protocol

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -5,9 +5,41 @@ For a detailed list of all changes, see the [CHANGELOG](changelog.md).
 
 ## from 0.15.* to 0.16
 
-### Drop support for older technogies
+### Drop support for older technologies
 
 PyO3 0.16 has increased minimum Rust version to 1.48 and minimum Python version to 3.7. This enables ore use of newer language features (enabling some of the other additions in 0.16) and simplifies maintenance of the project.
+
+### Container magic methods now match Python behavior
+
+In PyO3 0.15, `__len__`, `__getitem__`, `__setitem__` and `__delitem__` in `#[pymethods]` would generate only the _mapping_ implementation for a `#[pyclass]`. To match the Python behavior, these methods now generate both the _mapping_ **and** _sequence_ implementations.
+
+This means that classes implementing these `#[pymethods]` will now also be treated as sequences, same as a Python `class` would be. Small differences in behavior may result:
+ - PyO3 will allow instances of these classes to be cast to `PySequence` as well as `PyMapping`.
+ - Python will provide a default implementation of `__iter__` (if the class did not have one) which repeatedly calls `__getitem__` with integers (starting at 0) until an `IndexError` is raised.
+
+To disable this behavior, use `#[pyclass(true_mapping)]` to retain the previous behavior of only providing the mapping implementation.
+
+To explain this in detail, consider the following Python class:
+
+```python
+class ExampleContainer:
+
+    def __len__(self):
+        return 5
+
+    def __getitem__(self, idx: int) -> int:
+        if idx < 0 or idx > 5:
+            raise IndexError()
+        return idx
+```
+
+This class implements a Python [sequence](https://docs.python.org/3/glossary.html#term-sequence).
+
+The `__len__` and `__getitem__` methods are also used to implement a Python [mapping](https://docs.python.org/3/glossary.html#term-mapping). In the Python C-API, these methods are not shared: the sequence `__len__` and `__getitem__` are defined by the `sq_len` and `sq_item` slots, and the mapping equivalents are `mp_len` and `mp_subscript`. There are similar distinctions for `__setitem__` and `__delitem__`.
+
+Because there is no such distinction from Python, implementing these methods will fill the mapping and sequence slots simultaneously. A Python class with `__len__` implemented, for example, will have both the `sq_len` and `mp_len` slots filled.
+
+The PyO3 behavior in 0.16 has been changed to match this Python behavior by default. PyO3 also provides ways to implement a pure mapping using the `#[true_mapping]` attribute and a pure sequence using the PyO3-specific `__seqlen__`, `__getseqitem__`, `__setseqitem__`, and `__delseqitem__` methods.
 
 ## from 0.14.* to 0.15
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -35,6 +35,7 @@ pub struct PyClassArgs {
     pub has_unsendable: bool,
     pub module: Option<syn::LitStr>,
     pub class_kind: PyClassKind,
+    pub true_mapping: bool,
 }
 
 impl PyClassArgs {
@@ -68,6 +69,7 @@ impl PyClassArgs {
             has_extends: false,
             has_unsendable: false,
             class_kind,
+            true_mapping: false,
         }
     }
 
@@ -176,8 +178,11 @@ impl PyClassArgs {
             "unsendable" => {
                 self.has_unsendable = true;
             }
+            "true_mapping" => {
+                self.true_mapping = true;
+            }
             _ => bail_spanned!(
-                exp.path.span() => "expected one of gc/weakref/subclass/dict/unsendable"
+                exp.path.span() => "expected one of gc/weakref/subclass/dict/unsendable/true_mapping"
             ),
         };
         Ok(())
@@ -730,6 +735,7 @@ impl<'a> PyClassImplsBuilder<'a> {
         let is_basetype = self.attr.is_basetype;
         let base = &self.attr.base;
         let is_subclass = self.attr.has_extends;
+        let true_mapping = self.attr.true_mapping;
 
         let thread_checker = if self.attr.has_unsendable {
             quote! { _pyo3::class::impl_::ThreadCheckerImpl<#cls> }
@@ -778,6 +784,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                 const IS_GC: bool = #is_gc;
                 const IS_BASETYPE: bool = #is_basetype;
                 const IS_SUBCLASS: bool = #is_subclass;
+                const TRUE_MAPPING: bool = #true_mapping;
 
                 type Layout = _pyo3::PyCell<Self>;
                 type BaseType = #base;

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -274,6 +274,11 @@ fn add_shared_proto_slots(
     try_add_shared_slot!("__setattr__", "__delattr__", generate_pyclass_setattr_slot);
     try_add_shared_slot!("__set__", "__delete__", generate_pyclass_setdescr_slot);
     try_add_shared_slot!("__setitem__", "__delitem__", generate_pyclass_setitem_slot);
+    try_add_shared_slot!(
+        "__setseqitem__",
+        "__delseqitem__",
+        generate_pyclass_setseqitem_slot
+    );
     try_add_shared_slot!("__add__", "__radd__", generate_pyclass_add_slot);
     try_add_shared_slot!("__sub__", "__rsub__", generate_pyclass_sub_slot);
     try_add_shared_slot!("__mul__", "__rmul__", generate_pyclass_mul_slot);
@@ -293,6 +298,8 @@ fn add_shared_proto_slots(
     );
     try_add_shared_slot!("__pow__", "__rpow__", generate_pyclass_pow_slot);
 
+    // if this assertion trips, a slot fragment has been implemented which has not been added in the
+    // list above
     assert!(implemented_proto_fragments.is_empty());
 }
 

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -34,7 +34,7 @@ error: expected string literal (e.g., "my_mod")
 18 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
-error: expected one of gc/weakref/subclass/dict/unsendable
+error: expected one of gc/weakref/subclass/dict/unsendable/true_mapping
   --> tests/ui/invalid_pyclass_args.rs:21:11
    |
 21 | #[pyclass(weakrev)]


### PR DESCRIPTION
For #1884.

This PR implements what I think to be a good way to add sequence protocol support to `#[pymethods]`.

There are two ways this is done:
  - `__len__`, `__getitem__`, `__setitem__`, and `__delitem__` now implement both mapping and sequence slots simultaneously. I think this is correct because a class implemented in pure Python also does exactly this. To get the previous behaviour of these methods just implementing a mapping, use new option `#[pyclass(true_mapping)]`.
  - New sequence-specific methods `__seqlen__`, `__getseqitem__`, `__setseqitem__`, and `__delseqitem__` have been added. These can be used to implement a sequence _without_ implementing any mapping methods. (Note that Python adds the sequence length to negative indices before calling these methods; needs careful documenting.)

Bikeshedding very welcome on names `#[pyclass(true_mapping)]`, `__seqlen__`, `__getseqitem__`, `__setseqitem__`, and `__delseqitem__`. Some alternatives I had:
 - `#[pyclass(no_auto_sequence_methods)]` describes the behaviour better but it's a real mouthful.
 - `#[pyclass(pure_mapping)]`, somehow `true_mapping` felt better to me.
 - `__seqgetitem__`, `__seqsetitem__`, `__setdelitem__`, i.e. "seq" at the front rather than in the middle.

This implementation seems to work nicely. To finish off this PR I'd like to add some guide docs and an example for each of a sequence and mapping, like we have the decorator example.

However, before I spend too much time writing documentation I'd really love to hear folks' opinion on whether they agree with this design choice. I could think of two possible alternatives to this PR:
1. Introduce `__seqlen__`, `__getseqitem__`, `__setseqitem__`, and `__delseqitem__` like this PR. Don't change the existing mapping methods to generate sequence methods (and so don't bother adding `#[pyclass(true_mapping)]`).

   This would lead to a simpler implementation, but then PyO3 has several differences to pure Python, which I think is not a desirable outcome.
   
2. Only have `__len__`, `__getitem__`, `__setitem__`, and `__delitem__`. By default these methods implement both protocols like Python. Attributes `#[pyclass(mapping)]` and `#[pyclass(sequence)]` can be used to restrict the generated implementation to just the one specified.

   I haven't tried to implement this design yet; I'm unsure how hard doing so would be. Main downside is that these methods would change a lot if `#[pyclass(sequence)]` was used: sequences frequently want to support slicing, so `__getitem__`, `__setitem__` and `__delitem__` would need to take some kind of `Either<isize, &PySlice>` when in sequence mode. In addition, Python adding the length to negative indices would only happen for the `isize` variants (the slices are passed unchanged), which could lead to nasty footguns.
   
   In this PR implementation `__XXXseqitem__` methods would only get `isize` indices and `__XXXitem__` (mapping) methods would be used for slicing, so at least the negative-indices behaviour is clearly separated.