### PR TITLE
ci: ignore coverage for test_hygiene, try 2

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,4 @@ coverage:
 
 ignore:
   - tests/*.rs
+  - src/test_hygiene/*.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 // Deny some lints in doctests.
 // Use `#[allow(...)]` locally to override.
 #![doc(test(attr(deny(warnings), allow(unused_variables, unused_assignments))))]
+#![cfg_attr(coverage, feature(no_coverage))] // used in src/test_hygiene.rs
 
 //! Rust bindings to the Python interpreter.
 //!

--- a/src/test_hygiene/mod.rs
+++ b/src/test_hygiene/mod.rs
@@ -3,7 +3,7 @@
 // #[pyo3(crate = "crate")] this validates that all macro expansion respects the setting.
 //
 // The generated code is never executed (these tests are checking compile time correctness.)
-#![cfg_attr(coverage, feature(no_coverage))]
+#![cfg_attr(coverage, no_coverage)]
 
 mod misc;
 mod pyclass;


### PR DESCRIPTION
Follow up to #2056 

Looks like I can't copy and paste correctly. 😅 

In addition, looks like according to https://github.com/rust-lang/rust/issues/84605 that `#![no_coverage]` doesn't work as a module inner attribute yet, so I added the files to be ignored in `codecov.yml` too.