### PR TITLE
pymethods: seq methods from mapping methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PyErr::new_type` now takes an optional docstring and now returns `PyResult<Py<PyType>>` rather than a `ffi::PyTypeObject` pointer.
 - The `create_exception!` macro can now take an optional docstring. This docstring, if supplied, is visible to users (with `.__doc__` and `help()`) and
   accompanies your error type in your crate's documentation.
+- `__getitem__`, `__setitem__` and `__delitem__` in `#[pymethods]` now implement both a Python mapping and sequence by default. [#2065](https://github.com/PyO3/pyo3/pull/2065)
 - Improve performance and error messages for `#[derive(FromPyObject)]` for enums. [#2068](https://github.com/PyO3/pyo3/pull/2068)
 - Reduce generated LLVM code size (to improve compile times) for:
   - internal `handle_panic` helper [#2074](https://github.com/PyO3/pyo3/pull/2074)

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -18,7 +18,6 @@ In PyO3 0.15, if a function name in `#[pymethods]` is a recognised magic method,
 The magic methods handled by PyO3 are very similar to the standard Python ones on [this page](https://docs.python.org/3/reference/datamodel.html#special-method-names) - in particular they are the the subset which have slots as [defined here](https://docs.python.org/3/c-api/typeobj.html). Some of the slots do not have a magic method in Python, which leads to a few additional magic methods defined only in PyO3:
  - Magic methods for garbage collection
  - Magic methods for the buffer protocol
- - Magic methods for the sequence protocol
 
 When PyO3 handles a magic method, a couple of changes apply compared to other `#[pymethods]`:
  - The `#[pyo3(text_signature = "...")]` attribute is not allowed
@@ -86,11 +85,7 @@ given signatures should be interpreted as follows:
   - `__aiter__(<self>) -> object`
   - `__anext__(<self>) -> Option<object> or IterANextOutput`
 
-#### Sequence types
-
-TODO; see [#1884](https://github.com/PyO3/pyo3/issues/1884)
-
-#### Mapping types
+#### Mapping & Sequence types
 
   - `__len__(<self>) -> usize`
   - `__contains__(<self>, object) -> bool`

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -293,6 +293,8 @@ fn add_shared_proto_slots(
     );
     try_add_shared_slot!("__pow__", "__rpow__", generate_pyclass_pow_slot);
 
+    // if this assertion trips, a slot fragment has been implemented which has not been added in the
+    // list above
     assert!(implemented_proto_fragments.is_empty());
 }
 

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -704,8 +704,21 @@ impl Ty {
                     let #ident = #extract;
                 }
             }
+            Ty::PySsizeT => {
+                let ty = arg.ty;
+                let extract = handle_error(
+                    extract_error_mode,
+                    py,
+                    quote! {
+                            ::std::convert::TryInto::<#ty>::try_into(#ident).map_err(|e| _pyo3::exceptions::PyValueError::new_err(e.to_string()))
+                    },
+                );
+                quote! {
+                    let #ident = #extract;
+                }
+            }
             // Just pass other types through unmodified
-            Ty::PyBuffer | Ty::Int | Ty::PyHashT | Ty::PySsizeT | Ty::Void => quote! {},
+            Ty::PyBuffer | Ty::Int | Ty::PyHashT | Ty::Void => quote! {},
         }
     }
 }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "macros")]
 
-use pyo3::exceptions::PyValueError;
-use pyo3::types::{PyList, PySlice, PyType};
+use pyo3::exceptions::{PyIndexError, PyValueError};
+use pyo3::types::{PyDict, PyList, PyMapping, PySequence, PySlice, PyType};
 use pyo3::{exceptions::PyAttributeError, prelude::*};
-use pyo3::{ffi, py_run, AsPyPointer, PyCell};
+use pyo3::{py_run, PyCell};
 use std::{isize, iter};
 
 mod common;
@@ -166,37 +166,198 @@ fn test_bool() {
 }
 
 #[pyclass]
-pub struct Len {
-    l: usize,
-}
+pub struct LenOverflow;
 
 #[pymethods]
-impl Len {
+impl LenOverflow {
     fn __len__(&self) -> usize {
-        self.l
+        (isize::MAX as usize) + 1
     }
 }
 
 #[test]
-fn len() {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
+fn len_overflow() {
+    Python::with_gil(|py| {
+        let inst = Py::new(py, LenOverflow).unwrap();
+        py_expect_exception!(py, inst, "len(inst)", PyOverflowError);
+    });
+}
 
-    let inst = Py::new(py, Len { l: 10 }).unwrap();
-    py_assert!(py, inst, "len(inst) == 10");
-    unsafe {
-        assert_eq!(ffi::PyObject_Size(inst.as_ptr()), 10);
-        assert_eq!(ffi::PyMapping_Size(inst.as_ptr()), 10);
+#[pyclass]
+pub struct Mapping {
+    values: Py<PyDict>,
+}
+
+#[pymethods]
+impl Mapping {
+    fn __len__(&self, py: Python) -> usize {
+        self.values.as_ref(py).len()
     }
 
-    let inst = Py::new(
-        py,
-        Len {
-            l: (isize::MAX as usize) + 1,
-        },
-    )
-    .unwrap();
-    py_expect_exception!(py, inst, "len(inst)", PyOverflowError);
+    fn __getitem__<'a>(&'a self, key: &'a PyAny) -> PyResult<&'a PyAny> {
+        let any: &PyAny = self.values.as_ref(key.py()).as_ref();
+        any.get_item(key)
+    }
+
+    fn __setitem__(&self, key: &PyAny, value: &PyAny) -> PyResult<()> {
+        self.values.as_ref(key.py()).set_item(key, value)
+    }
+
+    fn __delitem__(&self, key: &PyAny) -> PyResult<()> {
+        self.values.as_ref(key.py()).del_item(key)
+    }
+}
+
+#[test]
+fn mapping() {
+    Python::with_gil(|py| {
+        let inst = Py::new(
+            py,
+            Mapping {
+                values: PyDict::new(py).into(),
+            },
+        )
+        .unwrap();
+
+        //
+        let mapping: &PyMapping = inst.as_ref(py).downcast().unwrap();
+
+        py_assert!(py, inst, "len(inst) == 0");
+
+        py_run!(py, inst, "inst['foo'] = 'foo'");
+        py_assert!(py, inst, "inst['foo'] == 'foo'");
+        py_run!(py, inst, "del inst['foo']");
+        py_expect_exception!(py, inst, "inst['foo']", PyKeyError);
+
+        // Default iteration will call __getitem__ with integer indices
+        // which fails with a KeyError
+        py_expect_exception!(py, inst, "[*inst] == []", PyKeyError, "0");
+
+        // check mapping protocol
+        assert_eq!(mapping.len().unwrap(), 0);
+
+        mapping.set_item(0, 5).unwrap();
+        assert_eq!(mapping.len().unwrap(), 1);
+
+        assert_eq!(mapping.get_item(0).unwrap().extract::<u8>().unwrap(), 5);
+
+        mapping.del_item(0).unwrap();
+        assert_eq!(mapping.len().unwrap(), 0);
+    });
+}
+
+#[derive(FromPyObject)]
+enum SequenceIndex<'a> {
+    Integer(isize),
+    Slice(&'a PySlice),
+}
+
+#[pyclass]
+pub struct Sequence {
+    values: Vec<PyObject>,
+}
+
+#[pymethods]
+impl Sequence {
+    fn __len__(&self) -> usize {
+        self.values.len()
+    }
+
+    fn __getitem__(&self, index: SequenceIndex) -> PyResult<PyObject> {
+        match index {
+            SequenceIndex::Integer(index) => {
+                let uindex = self.usize_index(index)?;
+                self.values
+                    .get(uindex)
+                    .map(Clone::clone)
+                    .ok_or_else(|| PyIndexError::new_err(index))
+            }
+            // Just to prove that slicing can be implemented
+            SequenceIndex::Slice(s) => Ok(s.into()),
+        }
+    }
+
+    fn __setitem__(&mut self, index: isize, value: PyObject) -> PyResult<()> {
+        let uindex = self.usize_index(index)?;
+        self.values
+            .get_mut(uindex)
+            .map(|place| *place = value)
+            .ok_or_else(|| PyIndexError::new_err(index))
+    }
+
+    fn __delitem__(&mut self, index: isize) -> PyResult<()> {
+        let uindex = self.usize_index(index)?;
+        if uindex >= self.values.len() {
+            Err(PyIndexError::new_err(index))
+        } else {
+            self.values.remove(uindex);
+            Ok(())
+        }
+    }
+
+    fn append(&mut self, value: PyObject) {
+        self.values.push(value);
+    }
+}
+
+impl Sequence {
+    fn usize_index(&self, index: isize) -> PyResult<usize> {
+        if index < 0 {
+            let corrected_index = index + self.values.len() as isize;
+            if corrected_index < 0 {
+                Err(PyIndexError::new_err(index))
+            } else {
+                Ok(corrected_index as usize)
+            }
+        } else {
+            Ok(index as usize)
+        }
+    }
+}
+
+#[test]
+fn sequence() {
+    Python::with_gil(|py| {
+        let inst = Py::new(py, Sequence { values: vec![] }).unwrap();
+
+        let sequence: &PySequence = inst.as_ref(py).downcast().unwrap();
+
+        py_assert!(py, inst, "len(inst) == 0");
+
+        py_expect_exception!(py, inst, "inst[0]", PyIndexError);
+        py_run!(py, inst, "inst.append('foo')");
+
+        py_assert!(py, inst, "inst[0] == 'foo'");
+        py_assert!(py, inst, "inst[-1] == 'foo'");
+
+        py_expect_exception!(py, inst, "inst[1]", PyIndexError);
+        py_expect_exception!(py, inst, "inst[-2]", PyIndexError);
+
+        py_assert!(py, inst, "[*inst] == ['foo']");
+
+        py_run!(py, inst, "del inst[0]");
+
+        py_expect_exception!(py, inst, "inst['foo']", PyTypeError);
+
+        py_assert!(py, inst, "inst[0:2] == slice(0, 2)");
+
+        // check sequence protocol
+
+        // we don't implement sequence length so that CPython doesn't attempt to correct negative
+        // indices.
+        assert!(sequence.len().is_err());
+        // however regular python len() works thanks to mp_len slot
+        assert_eq!(inst.as_ref(py).len().unwrap(), 0);
+
+        py_run!(py, inst, "inst.append(0)");
+        sequence.set_item(0, 5).unwrap();
+        assert_eq!(inst.as_ref(py).len().unwrap(), 1);
+
+        assert_eq!(sequence.get_item(0).unwrap().extract::<u8>().unwrap(), 5);
+        sequence.del_item(0).unwrap();
+
+        assert_eq!(inst.as_ref(py).len().unwrap(), 0);
+    });
 }
 
 #[pyclass]


### PR DESCRIPTION
Cut out from #2060

This is the part of that PR which changes `__getitem__`, `__setitem__`, and `__delitem__` to implement the sequence slots as well as the mapping slots.

I think it's reasonably clear that this design makes sense, because it matches pure-Python behavior. It defers how to solve "pure-sequence" and "pure-mapping" classes to #2060 - which might either be the `__seqlen__` (etc.) methods or attributes like `#[pyo3(sequence)]` and `#[pyo3(mapping)]`.

Note that I ended up making the decision to _not_ implement `sq_length` from `__len__`, because this way Python won't automatically try to convert negative indices to positive ones by adding the sequence length. This behaviour is inconsistent, because it only applies to calls to `__getitem__` etc from the sequence slot (not the mapping slot). We can't reverse it on the PyO3 side either, because if we get a positive index to the sequence slot we don't know whether the original index was actually a negative one but had the length added. From searching the CPython source I don't see any downsides to not implementing `sq_length` except that `PySequence::len()` will fail for pyclasses.

I'm tempted to submit a PR to upstream CPython to see if there can be a different way to opt out of this length-correcting behaviour so that we can implement `sq_length` too.