### PR TITLE
pymethods: support buffer protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All PyO3 proc-macros except the deprecated `#[pyproto]` now accept a supplemental attribute `#[pyo3(crate = "some::path")]` that specifies
   where to find the `pyo3` crate, in case it has been renamed or is re-exported and not found at the crate root. [#2022](https://github.com/PyO3/pyo3/pull/2022)
 - Expose `pyo3-build-config` APIs for cross-compiling and Python configuration discovery for use in other projects. [#1996](https://github.com/PyO3/pyo3/pull/1996)
+- Add buffer magic methods `__getbuffer__` and `__releasebuffer__` to `#[pymethods]`. [#2067](https://github.com/PyO3/pyo3/pull/2067)
 - Accept paths in `wrap_pyfunction` and `wrap_pymodule`. [#2081](https://github.com/PyO3/pyo3/pull/2081)
 
 ### Changed

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -899,12 +899,6 @@ impl pyo3::class::impl_::PyClassImpl for MyClass {
         visitor(collector.buffer_protocol_slots());
         visitor(collector.methods_protocol_slots());
     }
-
-    fn get_buffer() -> Option<&'static pyo3::class::impl_::PyBufferProcs> {
-        use pyo3::class::impl_::*;
-        let collector = PyClassImplCollector::<Self>::new();
-        collector.buffer_procs()
-    }
 }
 # Python::with_gil(|py| {
 #     let cls = py.get_type::<MyClass>();

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -175,7 +175,8 @@ TODO; see [#1884](https://github.com/PyO3/pyo3/issues/1884)
 
 #### Buffer objects
 
-TODO; see [#1884](https://github.com/PyO3/pyo3/issues/1884)
+  - `__getbuffer__(<self>, *mut ffi::Py_buffer, flags) -> ()`
+  - `__releasebuffer__(<self>, *mut ffi::Py_buffer)` (no return value, not even `PyResult`)
 
 #### Garbage Collector Integration
 

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -229,6 +229,7 @@ pub struct FnSpec<'a> {
     pub convention: CallingConvention,
     pub text_signature: Option<TextSignatureAttribute>,
     pub krate: syn::Path,
+    pub unsafety: Option<syn::Token![unsafe]>,
 }
 
 pub fn get_return_info(output: &syn::ReturnType) -> syn::Type {
@@ -316,6 +317,7 @@ impl<'a> FnSpec<'a> {
             deprecations,
             text_signature,
             krate,
+            unsafety: sig.unsafety,
         })
     }
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -847,12 +847,8 @@ impl<'a> PyClassImplsBuilder<'a> {
                     #methods_protos
                 }
 
-                fn get_buffer() -> ::std::option::Option<&'static _pyo3::class::impl_::PyBufferProcs> {
-                    use _pyo3::class::impl_::*;
-                    let collector = PyClassImplCollector::<Self>::new();
-                    collector.buffer_procs()
-                }
                 #dict_offset
+
                 #weaklist_offset
             }
 

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -431,6 +431,7 @@ pub fn impl_wrap_pyfunction(
         deprecations: options.deprecations,
         text_signature: options.text_signature,
         krate: krate.clone(),
+        unsafety: func.sig.unsafety,
     };
 
     let wrapper_ident = format_ident!("__pyo3_raw_{}", spec.name);

--- a/pyo3-macros-backend/src/pyproto.rs
+++ b/pyo3-macros-backend/src/pyproto.rs
@@ -134,31 +134,6 @@ fn impl_proto_methods(
     let slots_trait = proto.slots_trait();
     let slots_trait_slots = proto.slots_trait_slots();
 
-    let mut maybe_buffer_methods = None;
-
-    let build_config = pyo3_build_config::get();
-    const PY39: pyo3_build_config::PythonVersion =
-        pyo3_build_config::PythonVersion { major: 3, minor: 9 };
-
-    if build_config.version <= PY39 && proto.name == "Buffer" {
-        maybe_buffer_methods = Some(quote! {
-            impl _pyo3::class::impl_::PyBufferProtocolProcs<#ty>
-                for _pyo3::class::impl_::PyClassImplCollector<#ty>
-            {
-                fn buffer_procs(
-                    self
-                ) -> ::std::option::Option<&'static _pyo3::class::impl_::PyBufferProcs> {
-                    static PROCS: _pyo3::class::impl_::PyBufferProcs
-                        = _pyo3::class::impl_::PyBufferProcs {
-                            bf_getbuffer: ::std::option::Option::Some(_pyo3::class::buffer::getbuffer::<#ty>),
-                            bf_releasebuffer: ::std::option::Option::Some(_pyo3::class::buffer::releasebuffer::<#ty>),
-                        };
-                    ::std::option::Option::Some(&PROCS)
-                }
-            }
-        });
-    }
-
     let mut tokens = proto
         .slot_defs(method_names)
         .map(|def| {
@@ -178,8 +153,6 @@ fn impl_proto_methods(
     }
 
     quote! {
-        #maybe_buffer_methods
-
         impl _pyo3::class::impl_::#slots_trait<#ty>
             for _pyo3::class::impl_::PyClassImplCollector<#ty>
         {

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -85,9 +85,6 @@ pub trait PyClassImpl: Sized {
     fn get_free() -> Option<ffi::freefunc> {
         None
     }
-    fn get_buffer() -> Option<&'static PyBufferProcs> {
-        None
-    }
     #[inline]
     fn dict_offset() -> Option<ffi::Py_ssize_t> {
         None
@@ -684,25 +681,6 @@ methods_trait!(PyAsyncProtocolMethods, async_protocol_methods);
 methods_trait!(PyDescrProtocolMethods, descr_protocol_methods);
 methods_trait!(PyMappingProtocolMethods, mapping_protocol_methods);
 methods_trait!(PyNumberProtocolMethods, number_protocol_methods);
-
-// On Python < 3.9 setting the buffer protocol using slots doesn't work, so these procs are used
-// on those versions to set the slots manually (on the limited API).
-
-#[cfg(not(Py_LIMITED_API))]
-pub use ffi::PyBufferProcs;
-
-#[cfg(Py_LIMITED_API)]
-pub struct PyBufferProcs;
-
-pub trait PyBufferProtocolProcs<T> {
-    fn buffer_procs(self) -> Option<&'static PyBufferProcs>;
-}
-
-impl<T> PyBufferProtocolProcs<T> for &'_ PyClassImplCollector<T> {
-    fn buffer_procs(self) -> Option<&'static PyBufferProcs> {
-        None
-    }
-}
 
 // Thread checkers
 

--- a/tests/test_buffer_protocol_pyproto.rs
+++ b/tests/test_buffer_protocol_pyproto.rs
@@ -2,12 +2,13 @@
 #![cfg(not(Py_LIMITED_API))]
 
 use pyo3::buffer::PyBuffer;
+use pyo3::class::PyBufferProtocol;
 use pyo3::exceptions::PyBufferError;
 use pyo3::ffi;
 use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 use pyo3::AsPyPointer;
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::os::raw::{c_int, c_void};
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -21,13 +22,9 @@ struct TestBufferClass {
     drop_called: Arc<AtomicBool>,
 }
 
-#[pymethods]
-impl TestBufferClass {
-    unsafe fn __getbuffer__(
-        mut slf: PyRefMut<Self>,
-        view: *mut ffi::Py_buffer,
-        flags: c_int,
-    ) -> PyResult<()> {
+#[pyproto]
+impl PyBufferProtocol for TestBufferClass {
+    fn bf_getbuffer(slf: PyRefMut<Self>, view: *mut ffi::Py_buffer, flags: c_int) -> PyResult<()> {
         if view.is_null() {
             return Err(PyBufferError::new_err("View is null"));
         }
@@ -36,43 +33,43 @@ impl TestBufferClass {
             return Err(PyBufferError::new_err("Object is not writable"));
         }
 
-        (*view).obj = ffi::_Py_NewRef(slf.as_ptr());
+        unsafe {
+            (*view).obj = ffi::_Py_NewRef(slf.as_ptr());
+        }
 
-        (*view).buf = slf.vec.as_mut_ptr() as *mut c_void;
-        (*view).len = slf.vec.len() as isize;
-        (*view).readonly = 1;
-        (*view).itemsize = 1;
+        let bytes = &slf.vec;
 
-        (*view).format = if (flags & ffi::PyBUF_FORMAT) == ffi::PyBUF_FORMAT {
-            let msg = CString::new("B").unwrap();
-            msg.into_raw()
-        } else {
-            ptr::null_mut()
-        };
+        unsafe {
+            (*view).buf = bytes.as_ptr() as *mut c_void;
+            (*view).len = bytes.len() as isize;
+            (*view).readonly = 1;
+            (*view).itemsize = 1;
 
-        (*view).ndim = 1;
-        (*view).shape = if (flags & ffi::PyBUF_ND) == ffi::PyBUF_ND {
-            &mut (*view).len
-        } else {
-            ptr::null_mut()
-        };
+            (*view).format = ptr::null_mut();
+            if (flags & ffi::PyBUF_FORMAT) == ffi::PyBUF_FORMAT {
+                let msg = CStr::from_bytes_with_nul(b"B\0").unwrap();
+                (*view).format = msg.as_ptr() as *mut _;
+            }
 
-        (*view).strides = if (flags & ffi::PyBUF_STRIDES) == ffi::PyBUF_STRIDES {
-            &mut (*view).itemsize
-        } else {
-            ptr::null_mut()
-        };
+            (*view).ndim = 1;
+            (*view).shape = ptr::null_mut();
+            if (flags & ffi::PyBUF_ND) == ffi::PyBUF_ND {
+                (*view).shape = &mut (*view).len;
+            }
 
-        (*view).suboffsets = ptr::null_mut();
-        (*view).internal = ptr::null_mut();
+            (*view).strides = ptr::null_mut();
+            if (flags & ffi::PyBUF_STRIDES) == ffi::PyBUF_STRIDES {
+                (*view).strides = &mut (*view).itemsize;
+            }
+
+            (*view).suboffsets = ptr::null_mut();
+            (*view).internal = ptr::null_mut();
+        }
 
         Ok(())
     }
 
-    unsafe fn __releasebuffer__(&self, view: *mut ffi::Py_buffer) {
-        // Release memory held by the format string
-        drop(CString::from_raw((*view).format));
-    }
+    fn bf_releasebuffer(_slf: PyRefMut<Self>, _view: *mut ffi::Py_buffer) {}
 }
 
 impl Drop for TestBufferClass {

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -25,6 +25,8 @@ fn _test_compile_errors() {
     t.compile_fail("tests/ui/invalid_pyclass_item.rs");
     t.compile_fail("tests/ui/invalid_pyfunctions.rs");
     t.compile_fail("tests/ui/invalid_pymethods.rs");
+    #[cfg(not(Py_LIMITED_API))]
+    t.compile_fail("tests/ui/invalid_pymethods_buffer.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
     t.compile_fail("tests/ui/invalid_pymodule_args.rs");
     t.compile_fail("tests/ui/missing_clone.rs");

--- a/tests/ui/invalid_pymethods_buffer.rs
+++ b/tests/ui/invalid_pymethods_buffer.rs
@@ -1,0 +1,18 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+struct MyClass {}
+
+#[pymethods]
+impl MyClass {
+    #[pyo3(name = "__getbuffer__")]
+    fn getbuffer_must_be_unsafe(&self, _view: *mut pyo3::ffi::Py_buffer, _flags: std::os::raw::c_int) {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[pyo3(name = "__releasebuffer__")]
+    fn releasebuffer_must_be_unsafe(&self, _view: *mut pyo3::ffi::Py_buffer) {}
+}
+
+fn main() {}

--- a/tests/ui/invalid_pymethods_buffer.stderr
+++ b/tests/ui/invalid_pymethods_buffer.stderr
@@ -1,0 +1,11 @@
+error: `__getbuffer__` must be `unsafe fn`
+ --> tests/ui/invalid_pymethods_buffer.rs:9:8
+  |
+9 |     fn getbuffer_must_be_unsafe(&self, _view: *mut pyo3::ffi::Py_buffer, _flags: std::os::raw::c_int) {}
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `__releasebuffer__` must be `unsafe fn`
+  --> tests/ui/invalid_pymethods_buffer.rs:15:8
+   |
+15 |     fn releasebuffer_must_be_unsafe(&self, _view: *mut pyo3::ffi::Py_buffer) {}
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
For #1884 

Implements the buffer protocol via two new methods `__getbuffer__` and `__releasebuffer__`.

They are `unsafe` because they operate on `ffi::Py_buffer` directly. I considered making a "safe" API, however also at this point in time I think it's better if we just get the migration away from `#[pyproto]` complete. We can revisit a safe design later if needed.

Cython implements these methods exactly the same way. https://cython.readthedocs.io/en/latest/src/userguide/buffer.html