### PR TITLE
xtask: add coverage command

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@ Be aware the CI pipeline will check your pull request for the following:
  - Rust lints (`make clippy`)
  - Rust formatting (`cargo fmt`)
  - Python formatting (`black . --check`. You can install black with `pip install black`)
- - Compatibility with all supported Python versions for all examples. This uses `tox`; you can do run it using `make test_py`.
+ - Compatibility with all supported Python versions for all examples. This uses `tox`; you can do run it using `cargo xtask test-py`.
 
 You can run a similar set of checks as the CI pipeline using `make test`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,7 +213,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install -U pip tox
-          make test_py
+          cargo xtask test-py
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}
           TOX_TESTENV_PASSENV: "CARGO_BUILD_TARGET CARGO_TARGET_DIR"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,8 @@ harness = false
 members = [
     "pyo3-macros",
     "pyo3-macros-backend",
-    "examples"
+    "examples",
+    "xtask"
 ]
 
 [package.metadata.docs.rs]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: test test_py publish clippy lint fmt fmt_py fmt_rust
 
 ALL_ADDITIVE_FEATURES = macros multiple-pymethods num-bigint num-complex hashbrown serde indexmap eyre anyhow
+COVERAGE_PACKAGES = --package pyo3 --package pyo3-build-config --package pyo3-macros-backend --package pyo3-macros
 
 list_all_additive_features:
 	@echo $(ALL_ADDITIVE_FEATURES)
@@ -24,6 +25,21 @@ fmt_rust:
 
 fmt: fmt_rust fmt_py
 	@true
+
+coverage:
+	# cargo llvm-cov clean --workspace
+	# cargo llvm-cov $(COVERAGE_PACKAGES) --no-report
+	# cargo llvm-cov $(COVERAGE_PACKAGES) --no-report --features abi3
+	# cargo llvm-cov $(COVERAGE_PACKAGES) --no-report --features $(ALL_ADDITIVE_FEATURES)
+	# cargo llvm-cov $(COVERAGE_PACKAGES) --no-report --features abi3 $(ALL_ADDITIVE_FEATURES)
+	bash -c "\
+		set -a\
+		source <(cargo llvm-cov show-env)\
+		export TOX_TESTENV_PASSENV=*\
+		make test_py\
+	"
+	cargo llvm-cov $(COVERAGE_PACKAGES) --no-run --summary-only
+
 
 clippy:
 	cargo clippy --features="$(ALL_ADDITIVE_FEATURES)" --all-targets --workspace -- -Dwarnings

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.51"
+clap = { version = "3.0.0-rc.7", features = ["derive"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "xtask"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 anyhow = "1.0.51"
-clap = { version = "3.0.0-rc.7", features = ["derive"] }
+
+# Clap 3 requires MSRV 1.54
+rustversion = "1.0"
+structopt = { version = "0.3", default-features = false }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,57 @@
+use anyhow::Result;
+use clap::Parser;
+use std::{collections::HashMap, process::Command};
+
+#[derive(Parser)]
+enum Subcommand {
+    Coverage,
+}
+
+fn main() -> Result<()> {
+    match Subcommand::parse() {
+        Subcommand::Coverage => {
+            run(&mut llvm_cov_command(&["clean", "--workspace"]))?;
+            // FIXME: run (including with various feature combinations)
+            // run(&mut llvm_cov_command(&["--no-report"]))?;
+            let env = get_coverage_env()?;
+            for entry in std::fs::read_dir("pytests")? {
+                let path = entry?.path();
+                if path.is_dir() {
+                    run(Command::new("tox").arg("-c").arg(path).envs(&env))?;
+                }
+            }
+            // FIXME: also run for examples
+            // FIXME: make it possible to generate lcov report too
+            run(&mut llvm_cov_command(&["--no-run", "--summary-only"]))?;
+        }
+    }
+    Ok(())
+}
+
+fn run(command: &mut Command) -> Result<()> {
+    command.spawn()?.wait()?;
+    Ok(())
+}
+
+fn llvm_cov_command(args: &[&str]) -> Command {
+    let mut command = Command::new("cargo");
+    command.args(["llvm-cov", "--package=pyo3"]).args(args);
+    command
+}
+
+fn get_coverage_env() -> Result<HashMap<String, String>> {
+    let mut env = HashMap::new();
+
+    let output = String::from_utf8(llvm_cov_command(&["show-env"]).output()?.stdout)?;
+
+    for line in output.trim().split('\n') {
+        // TODO use split_once on MSRV 1.52
+        let mut iter = line.splitn(2, '=');
+        env.insert(iter.next().unwrap().into(), iter.next().unwrap().trim_matches('"').into());
+    }
+
+    env.insert("TOX_TESTENV_PASSENV".to_owned(), "*".to_owned());
+    env.insert("RUSTUP_TOOLCHAIN".to_owned(), "nightly".to_owned());
+
+    Ok(env)
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
-use clap::Parser;
 use std::{collections::HashMap, process::Command};
+use structopt::StructOpt;
 
-#[derive(Parser)]
+#[derive(StructOpt)]
 enum Subcommand {
     /// Runs `cargo llvm-cov` for the PyO3 codebase.
     Coverage,
@@ -20,7 +20,7 @@ impl Subcommand {
 }
 
 fn main() -> Result<()> {
-    Subcommand::parse().execute()
+    Subcommand::from_args().execute()
 }
 
 /// Runs `cargo llvm-cov` for the PyO3 codebase.
@@ -42,18 +42,14 @@ fn subcommand_coverage() -> Result<()> {
 }
 
 fn run(command: &mut Command) -> Result<()> {
-    print!("running: {}", command.get_program().to_string_lossy());
-    for arg in command.get_args() {
-        print!(" {}", arg.to_string_lossy());
-    }
-    println!();
+    println!("running: {}", format_command(command));
     command.spawn()?.wait()?;
     Ok(())
 }
 
 fn llvm_cov_command(args: &[&str]) -> Command {
     let mut command = Command::new("cargo");
-    command.args(["llvm-cov", "--package=pyo3"]).args(args);
+    command.args(&["llvm-cov", "--package=pyo3"]).args(args);
     command
 }
 
@@ -92,7 +88,32 @@ fn get_coverage_env() -> Result<HashMap<String, String>> {
 }
 
 // Replacement for str.split_once() on Rust older than 1.52
+#[rustversion::before(1.52)]
 fn split_once(s: &str, pat: char) -> Option<(&str, &str)> {
     let mut iter = s.splitn(2, pat);
     Some((iter.next()?, iter.next()?))
+}
+
+#[rustversion::since(1.52)]
+fn split_once(s: &str, pat: char) -> Option<(&str, &str)> {
+    s.split_once(pat)
+}
+
+#[rustversion::since(1.57)]
+fn format_command(command: &Command) -> String {
+    let mut buf = String::new();
+    buf.push('`');
+    buf.push_str(&command.get_program().to_string_lossy());
+    for arg in command.get_args() {
+        buf.push(' ');
+        buf.push_str(&arg.to_string_lossy());
+    }
+    buf.push('`');
+    buf
+}
+
+#[rustversion::before(1.57)]
+fn format_command(command: &Command) -> String {
+    // Debug impl isn't as nice as the above, but will do on < 1.57
+    format!("{:?}", command)
 }


### PR DESCRIPTION
This is a bit of an experiment to add a `cargo xtask coverage` alias.

Ultimately this will re-implement the coverage recipe in ci. I also was playing around with adding coverage from out examples and python tests. It doesn't seem to be working quite yet; needs upstream support in `cargo-llvm-cov` which I'm still trying to figure out.