### PR TITLE
macros: optimize generated code for #[derive(FromPyObject)]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `PyErr::new_type` now takes an optional docstring and now returns `PyResult<Py<PyType>>` rather than a `ffi::PyTypeObject` pointer.
 - The `create_exception!` macro can now take an optional docstring. This docstring, if supplied, is visible to users (with `.__doc__` and `help()`) and
   accompanies your error type in your crate's documentation.
-  
+- Improve performance and error messages for `#[derive(FromPyObject)]` for enums. [#2068](https://github.com/PyO3/pyo3/pull/2068)
+
 ### Removed
 
 - Remove all functionality deprecated in PyO3 0.14. [#2007](https://github.com/PyO3/pyo3/pull/2007)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,10 @@ name = "bench_dict"
 harness = false
 
 [[bench]]
+name = "bench_frompyobject"
+harness = false
+
+[[bench]]
 name = "bench_gil"
 harness = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ harness = false
 [[bench]]
 name = "bench_frompyobject"
 harness = false
+required-features = ["macros"]
 
 [[bench]]
 name = "bench_gil"
@@ -106,6 +107,7 @@ harness = false
 [[bench]]
 name = "bench_pyclass"
 harness = false
+required-features = ["macros"]
 
 [[bench]]
 name = "bench_pyobject"

--- a/benches/bench_frompyobject.rs
+++ b/benches/bench_frompyobject.rs
@@ -1,0 +1,26 @@
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+
+use pyo3::{prelude::*, types::PyString};
+
+#[derive(FromPyObject)]
+enum ManyTypes {
+    Int(i32),
+    Bytes(Vec<u8>),
+    String(String)
+}
+
+fn enum_from_pyobject(b: &mut Bencher) {
+    Python::with_gil(|py| {
+        let obj = PyString::new(py, "hello world");
+        b.iter(|| {
+            let _: ManyTypes = obj.extract().unwrap();
+        });
+    })
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("enum_from_pyobject", enum_from_pyobject);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/bench_frompyobject.rs
+++ b/benches/bench_frompyobject.rs
@@ -6,7 +6,7 @@ use pyo3::{prelude::*, types::PyString};
 enum ManyTypes {
     Int(i32),
     Bytes(Vec<u8>),
-    String(String)
+    String(String),
 }
 
 fn enum_from_pyobject(b: &mut Bencher) {

--- a/benches/bench_pyclass.rs
+++ b/benches/bench_pyclass.rs
@@ -1,64 +1,49 @@
-#[cfg(feature = "macros")]
 use criterion::{criterion_group, criterion_main, Criterion};
+use pyo3::{class::PyObjectProtocol, prelude::*, type_object::LazyStaticType};
 
-#[cfg(feature = "macros")]
-mod m {
-    use pyo3::{class::PyObjectProtocol, prelude::*, type_object::LazyStaticType};
+/// This is a feature-rich class instance used to benchmark various parts of the pyclass lifecycle.
+#[pyclass]
+struct MyClass {
+    #[pyo3(get, set)]
+    elements: Vec<i32>,
+}
 
-    /// This is a feature-rich class instance used to benchmark various parts of the pyclass lifecycle.
-    #[pyclass]
-    struct MyClass {
-        #[pyo3(get, set)]
-        elements: Vec<i32>,
+#[pymethods]
+impl MyClass {
+    #[new]
+    fn new(elements: Vec<i32>) -> Self {
+        Self { elements }
     }
 
-    #[pymethods]
-    impl MyClass {
-        #[new]
-        fn new(elements: Vec<i32>) -> Self {
-            Self { elements }
-        }
-
-        fn __call__(&mut self, new_element: i32) -> usize {
-            self.elements.push(new_element);
-            self.elements.len()
-        }
-    }
-
-    #[pyproto]
-    impl PyObjectProtocol for MyClass {
-        /// A basic __str__ implementation.
-        fn __str__(&self) -> &'static str {
-            "MyClass"
-        }
-    }
-
-    pub fn first_time_init(b: &mut criterion::Bencher) {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        b.iter(|| {
-            // This is using an undocumented internal PyO3 API to measure pyclass performance; please
-            // don't use this in your own code!
-            let ty = LazyStaticType::new();
-            ty.get_or_init::<MyClass>(py);
-        });
+    fn __call__(&mut self, new_element: i32) -> usize {
+        self.elements.push(new_element);
+        self.elements.len()
     }
 }
 
-#[cfg(feature = "macros")]
+#[pyproto]
+impl PyObjectProtocol for MyClass {
+    /// A basic __str__ implementation.
+    fn __str__(&self) -> &'static str {
+        "MyClass"
+    }
+}
+
+pub fn first_time_init(b: &mut criterion::Bencher) {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    b.iter(|| {
+        // This is using an undocumented internal PyO3 API to measure pyclass performance; please
+        // don't use this in your own code!
+        let ty = LazyStaticType::new();
+        ty.get_or_init::<MyClass>(py);
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("first_time_init", m::first_time_init);
+    c.bench_function("first_time_init", first_time_init);
 }
 
-#[cfg(feature = "macros")]
 criterion_group!(benches, criterion_benchmark);
 
-#[cfg(feature = "macros")]
 criterion_main!(benches);
-
-#[cfg(not(feature = "macros"))]
-fn main() {
-    unimplemented!(
-        "benchmarking `bench_pyclass` is only available with the `macros` feature enabled"
-    );
-}

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -11,7 +11,7 @@ mod utils;
 mod attributes;
 mod defs;
 mod deprecations;
-mod from_pyobject;
+mod frompyobject;
 mod konst;
 mod method;
 mod module;
@@ -23,7 +23,7 @@ mod pyimpl;
 mod pymethod;
 mod pyproto;
 
-pub use from_pyobject::build_derive_from_pyobject;
+pub use frompyobject::build_derive_from_pyobject;
 pub use module::{process_functions_in_module, py_init, PyModuleOptions};
 pub use pyclass::{build_py_class, build_py_enum, PyClassArgs};
 pub use pyfunction::{build_py_function, PyFunctionOptions};

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -6,3 +6,5 @@
 
 pub mod deprecations;
 pub mod freelist;
+#[doc(hidden)]
+pub mod frompyobject;

--- a/src/impl_/frompyobject.rs
+++ b/src/impl_/frompyobject.rs
@@ -1,0 +1,26 @@
+use crate::{exceptions::PyTypeError, PyErr, Python};
+
+#[cold]
+pub fn failed_to_extract_enum(
+    py: Python,
+    type_name: &str,
+    variant_names: &[&str],
+    error_names: &[&str],
+    errors: &[PyErr],
+) -> PyErr {
+    let mut err_msg = format!(
+        "failed to extract enum {} ('{}')",
+        type_name,
+        error_names.join(" | ")
+    );
+    for ((variant_name, error_name), error) in variant_names.iter().zip(error_names).zip(errors) {
+        err_msg.push('\n');
+        err_msg.push_str(&format!(
+            "- variant {variant_name} ({error_name}): {error_msg}",
+            variant_name = variant_name,
+            error_name = error_name,
+            error_msg = error.value(py).str().unwrap().to_str().unwrap(),
+        ));
+    }
+    PyTypeError::new_err(err_msg)
+}


### PR DESCRIPTION
Inspired by #1966, I decided to take a look at the generated code for `#[derive(FromPyObject)]` for enums.

There seemed to be some pretty easy wins as well as fixes to error messages, so I just went ahead and made them. Mostly what I did is delay all string formatting until creation of the final error message, to avoid intermediate costs when the conversion still ultimately succeeds. To keep generated code smaller I also extracted this into a `#[cold]` helper function that gets re-used for all enum derive implementations.

Added a benchmark for a simple enum case; it shows quite significant wins:

```
enum_from_pyobject      time:   [536.93 ns 541.67 ns 547.81 ns]
                        change: [-69.528% -69.164% -68.793%] (p = 0.00 < 0.05)
                        Performance has improved.
```

... there's probably more that can be done here to improve the other generated code from this macro too; this is enough for today.
                        