### PR TITLE
opt: improve handle_panic generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `create_exception!` macro can now take an optional docstring. This docstring, if supplied, is visible to users (with `.__doc__` and `help()`) and
   accompanies your error type in your crate's documentation.
 - Improve performance and error messages for `#[derive(FromPyObject)]` for enums. [#2068](https://github.com/PyO3/pyo3/pull/2068)
+- Tweak LLVM code for compile times for internal `handle_panic` helper. [#2073](https://github.com/PyO3/pyo3/pull/2073)
 
 ### Removed
 

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -8,3 +8,4 @@ pub mod deprecations;
 pub mod freelist;
 #[doc(hidden)]
 pub mod frompyobject;
+pub(crate) mod not_send;

--- a/src/impl_/not_send.rs
+++ b/src/impl_/not_send.rs
@@ -1,0 +1,9 @@
+use std::marker::PhantomData;
+
+use crate::Python;
+
+/// A marker type that makes the type !Send.
+/// Workaround for lack of !Send on stable (https://github.com/rust-lang/rust/issues/68318).
+pub(crate) struct NotSend(PhantomData<*mut Python<'static>>);
+
+pub(crate) const NOT_SEND: NotSend = NotSend(PhantomData);

--- a/src/internal_tricks.rs
+++ b/src/internal_tricks.rs
@@ -1,11 +1,5 @@
 use crate::ffi::{Py_ssize_t, PY_SSIZE_T_MAX};
 use std::ffi::{CStr, CString};
-use std::marker::PhantomData;
-use std::rc::Rc;
-
-/// A marker type that makes the type !Send.
-/// Temporal hack until https://github.com/rust-lang/rust/issues/13231 is resolved.
-pub(crate) type Unsendable = PhantomData<Rc<()>>;
 
 pub struct PrivateMarker;
 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -17,6 +17,7 @@ Python interpreter to exit.
 
 impl PanicException {
     // Try to format the error in the same way panic does
+    #[cold]
     pub(crate) fn from_panic_payload(payload: Box<dyn Any + Send + 'static>) -> PyErr {
         if let Some(string) = payload.downcast_ref::<String>() {
             Self::new_err((string.clone(),))

--- a/src/python.rs
+++ b/src/python.rs
@@ -4,6 +4,7 @@
 
 use crate::err::{self, PyDowncastError, PyErr, PyResult};
 use crate::gil::{self, GILGuard, GILPool};
+use crate::impl_::not_send::NotSend;
 use crate::type_object::{PyTypeInfo, PyTypeObject};
 use crate::types::{PyAny, PyDict, PyModule, PyType};
 use crate::{ffi, AsPyPointer, FromPyPointer, IntoPyPointer, PyNativeType, PyObject, PyTryFrom};
@@ -184,7 +185,7 @@ impl PartialOrd<(u8, u8, u8)> for PythonVersionInfo<'_> {
 /// [`Py::clone_ref`]: crate::Py::clone_ref
 /// [Memory Management]: https://pyo3.rs/main/memory.html#gil-bound-memory
 #[derive(Copy, Clone)]
-pub struct Python<'py>(PhantomData<&'py GILGuard>);
+pub struct Python<'py>(PhantomData<(&'py GILGuard, NotSend)>);
 
 impl Python<'_> {
     /// Acquires the global interpreter lock, allowing access to the Python interpreter. The

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -29,6 +29,7 @@ fn _test_compile_errors() {
     t.compile_fail("tests/ui/invalid_pymodule_args.rs");
     t.compile_fail("tests/ui/missing_clone.rs");
     t.compile_fail("tests/ui/reject_generics.rs");
+    t.compile_fail("tests/ui/not_send.rs");
 
     tests_rust_1_49(&t);
     tests_rust_1_55(&t);

--- a/tests/ui/not_send.rs
+++ b/tests/ui/not_send.rs
@@ -1,0 +1,11 @@
+use pyo3::prelude::*;
+
+fn test_not_send_allow_threads(py: Python) {
+    py.allow_threads(|| { drop(py); });
+}
+
+fn main() {
+    Python::with_gil(|py| {
+        test_not_send_allow_threads(py);
+    })
+}

--- a/tests/ui/not_send.stderr
+++ b/tests/ui/not_send.stderr
@@ -1,0 +1,14 @@
+error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safely
+ --> tests/ui/not_send.rs:4:8
+  |
+4 |     py.allow_threads(|| { drop(py); });
+  |        ^^^^^^^^^^^^^ `*mut pyo3::Python<'static>` cannot be shared between threads safely
+  |
+  = help: within `pyo3::Python<'_>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
+  = note: required because it appears within the type `PhantomData<*mut pyo3::Python<'static>>`
+  = note: required because it appears within the type `pyo3::impl_::not_send::NotSend`
+  = note: required because it appears within the type `(&GILGuard, pyo3::impl_::not_send::NotSend)`
+  = note: required because it appears within the type `PhantomData<(&GILGuard, pyo3::impl_::not_send::NotSend)>`
+  = note: required because it appears within the type `pyo3::Python<'_>`
+  = note: required because of the requirements on the impl of `Send` for `&pyo3::Python<'_>`
+  = note: required because it appears within the type `[closure@$DIR/tests/ui/not_send.rs:4:22: 4:38]`


### PR DESCRIPTION
I've been playing around with `cargo llvm-lines` a bit on the PyO3 codebase to find chunky functions which might want optimizing a bit for compile times.

`pyo3::callback::handle_panic` was an obvious target - it's called in _every_ generated function and it ends up being one of the biggest single contributors to lib size.

Rearranging things a bit, and simplifying the `Unsendable` helper to remove the need for `AssertUnwindSafe` managed to cut the size of this function by about a third. (Renamed `Unsendable` to `NotSend`)

As a bonus, I think I made the `NotSend` error message nicer - see the UI test.