### PR TITLE
opt: make argument extraction code smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   accompanies your error type in your crate's documentation.
 - Improve performance and error messages for `#[derive(FromPyObject)]` for enums. [#2068](https://github.com/PyO3/pyo3/pull/2068)
 - Reduce generated LLVM code size (to improve compile times) for:
-  - internal `handle_panic` helper [#2073](https://github.com/PyO3/pyo3/pull/2073)
-  - `#[pyclass]` type object creation [#2075](https://github.com/PyO3/pyo3/pull/2075)
+  - internal `handle_panic` helper [#2074](https://github.com/PyO3/pyo3/pull/2074)
+  - `#[pyfunction]` and `#[pymethods]` argument extraction [#2075](https://github.com/PyO3/pyo3/pull/2075)
+  - `#[pyclass]` type object creation [#2076](https://github.com/PyO3/pyo3/pull/2076)
 
 ### Removed
 

--- a/pytests/pyo3-benchmarks/tox.ini
+++ b/pytests/pyo3-benchmarks/tox.ini
@@ -3,3 +3,6 @@ usedevelop = True
 description = Run the unit tests under {basepython}
 deps = -rrequirements-dev.txt
 commands = pytest --benchmark-sort=name {posargs}
+# Use recreate so that tox always rebuilds, otherwise changes to Rust are not
+# picked up.
+recreate = True

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -5,6 +5,7 @@
 //! breaking semver guarantees.
 
 pub mod deprecations;
+pub mod extract_argument;
 pub mod freelist;
 #[doc(hidden)]
 pub mod frompyobject;

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -1,0 +1,30 @@
+use crate::{
+    exceptions::PyTypeError, type_object::PyTypeObject, FromPyObject, PyAny, PyErr, PyResult,
+    Python,
+};
+
+#[doc(hidden)]
+#[inline]
+pub fn extract_argument<'py, T>(obj: &'py PyAny, arg_name: &str) -> PyResult<T>
+where
+    T: FromPyObject<'py>,
+{
+    match obj.extract() {
+        Ok(e) => Ok(e),
+        Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e)),
+    }
+}
+
+/// Adds the argument name to the error message of an error which occurred during argument extraction.
+///
+/// Only modifies TypeError. (Cannot guarantee all exceptions have constructors from
+/// single string.)
+#[doc(hidden)]
+#[cold]
+pub fn argument_extraction_error(py: Python, arg_name: &str, error: PyErr) -> PyErr {
+    if error.get_type(py) == PyTypeError::type_object(py) {
+        PyTypeError::new_err(format!("argument '{}': {}", arg_name, error.value(py)))
+    } else {
+        error
+    }
+}


### PR DESCRIPTION
Similar to #2074, I found that the `#[pyfunction]` argument extraction code also had a fairly chunky LLVM line count.

Although not a perfect metric, is definitely linked to compile times.

Overall makes the LLVM line count of `pyo3-pytests` about 10% smaller, which seems pretty decent!