### PR TITLE
opt: reduce class creation generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `create_exception!` macro can now take an optional docstring. This docstring, if supplied, is visible to users (with `.__doc__` and `help()`) and
   accompanies your error type in your crate's documentation.
 - Improve performance and error messages for `#[derive(FromPyObject)]` for enums. [#2068](https://github.com/PyO3/pyo3/pull/2068)
-- Tweak LLVM code for compile times for internal `handle_panic` helper. [#2073](https://github.com/PyO3/pyo3/pull/2073)
+- Reduce generated LLVM code size (to improve compile times) for:
+  - internal `handle_panic` helper [#2073](https://github.com/PyO3/pyo3/pull/2073)
+  - `#[pyclass]` type object creation [#2075](https://github.com/PyO3/pyo3/pull/2075)
 
 ### Removed
 


### PR DESCRIPTION
Reduces the amount of LLVM code generated per `#[pyclass]`, by changing generic methods `tp_doc`, `get_type_name` and `py_class_members` to concrete forms with values passed from `T::create_type_object`.

Gave about a 5% reduction to the LLVM lines on the `pyo3-pytests` lib.