### PR TITLE
ci: add coverage for pytests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           python -m pip install -U pip nox
           cargo xtask test-py
         env:
-          CARGO_TARGET_DIR: ${{ github.workspace }}
+          CARGO_TARGET_DIR: ${{ github.workspace }}/target
 
       - name: Test cross compilation
         if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.9' }}
@@ -265,14 +265,10 @@ jobs:
           host=$(rustc -Vv | grep host | sed 's/host: //')
           curl -fsSL https://github.com/taiki-e/cargo-llvm-cov/releases/download/v${CARGO_LLVM_COV_VERSION}/cargo-llvm-cov-"$host".tar.gz | tar xzf - -C ~/.cargo/bin
         env:
-          CARGO_LLVM_COV_VERSION: 0.1.11
+          CARGO_LLVM_COV_VERSION: 0.1.15
+      - run: pip install -U pip nox
       - run: |
-          cargo llvm-cov clean --workspace
-          cargo llvm-cov --package $ALL_PACKAGES --no-report
-          cargo llvm-cov --package $ALL_PACKAGES --no-report --features abi3
-          cargo llvm-cov --package $ALL_PACKAGES --no-report --features full
-          cargo llvm-cov --package $ALL_PACKAGES --no-report --features "abi3 full"
-          cargo llvm-cov --package $ALL_PACKAGES --no-run --lcov --output-path coverage.lcov
+          cargo xtask coverage --output-lcov coverage.lcov
         shell: bash
         env:
           ALL_PACKAGES: pyo3 pyo3-build-config pyo3-macros-backend pyo3-macros

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,8 @@ harness = false
 members = [
     "pyo3-macros",
     "pyo3-macros-backend",
+    "pytests/pyo3-benchmarks",
+    "pytests/pyo3-pytests",
     "examples",
     "xtask"
 ]

--- a/pytests/pyo3-benchmarks/Cargo.toml
+++ b/pytests/pyo3-benchmarks/Cargo.toml
@@ -14,5 +14,3 @@ features = ["extension-module"]
 [lib]
 name = "_pyo3_benchmarks"
 crate-type = ["cdylib"]
-
-[workspace]

--- a/pytests/pyo3-benchmarks/setup.py
+++ b/pytests/pyo3-benchmarks/setup.py
@@ -1,6 +1,7 @@
+import os
+
 from setuptools import setup
 from setuptools_rust import RustExtension
-
 
 setup(
     name="pyo3-benchmarks",
@@ -18,7 +19,8 @@ setup(
     rust_extensions=[
         RustExtension(
             "pyo3_benchmarks._pyo3_benchmarks",
-            debug=False,
+            # build debug when measuring coverage, otherwise release
+            debug="CARGO_LLVM_COV_TARGET_DIR" in os.environ,
         ),
     ],
     include_package_data=True,

--- a/pytests/pyo3-pytests/Cargo.toml
+++ b/pytests/pyo3-pytests/Cargo.toml
@@ -25,5 +25,3 @@ classifier=[
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",
 ]
-
-[workspace]

--- a/pytests/pyo3-pytests/noxfile.py
+++ b/pytests/pyo3-pytests/noxfile.py
@@ -4,5 +4,6 @@ import nox
 @nox.session
 def python(session):
     session.install("-rrequirements-dev.txt")
-    session.install(".", "--no-build-isolation")
+    session.install("maturin")
+    session.run_always("maturin", "develop")
     session.run("pytest")

--- a/pytests/pyo3-pytests/pyproject.toml
+++ b/pytests/pyo3-pytests/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
-requires = ["maturin>=0.10,<0.11"]
+# FIXME: branch is necessary for coverage to work
+requires = ["maturin @ git+https://github.com/davidhewitt/maturin@profile-arg"]
 build-backend = "maturin"

--- a/pytests/pyo3-pytests/requirements-dev.txt
+++ b/pytests/pyo3-pytests/requirements-dev.txt
@@ -2,4 +2,3 @@ hypothesis>=3.55
 pytest>=3.5.0
 psutil>=5.6
 pip>=21.3
-maturin>=0.12,<0.13


### PR DESCRIPTION
This changes the ci job to use `cargo xtask coverage`, which now is able to generate coverage for the `pytests` modules.

Not ready to merge; depends on a branch of `maturin` (which I'll push shortly).