### PR TITLE
Remove useless allow(lint)'s

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -34,7 +34,6 @@ pub struct PyBuffer<T>(Pin<Box<ffi::Py_buffer>>, PhantomData<T>);
 
 // PyBuffer is thread-safe: the shape of the buffer is immutable while a Py_buffer exists.
 // Accessing the buffer contents is protected using the GIL.
-#[allow(clippy::non_send_fields_in_send_ty)]
 unsafe impl<T> Send for PyBuffer<T> {}
 unsafe impl<T> Sync for PyBuffer<T> {}
 
@@ -689,7 +688,6 @@ mod tests {
         });
     }
 
-    #[allow(clippy::float_cmp)] // The test wants to ensure that no precision was lost on the Python round-trip
     #[test]
     fn test_array_buffer() {
         Python::with_gil(|py| {

--- a/src/class/gc.rs
+++ b/src/class/gc.rs
@@ -9,16 +9,13 @@ use std::os::raw::{c_int, c_void};
 pub struct PyTraverseError(c_int);
 
 /// GC support
-#[allow(clippy::upper_case_acronyms)]
 pub trait PyGCProtocol<'p>: PyClass {
     fn __traverse__(&'p self, visit: PyVisit) -> Result<(), PyTraverseError>;
     fn __clear__(&'p mut self);
 }
 
-#[allow(clippy::upper_case_acronyms)]
 pub trait PyGCTraverseProtocol<'p>: PyGCProtocol<'p> {}
 
-#[allow(clippy::upper_case_acronyms)]
 pub trait PyGCClearProtocol<'p>: PyGCProtocol<'p> {}
 
 #[doc(hidden)]

--- a/src/class/impl_.rs
+++ b/src/class/impl_.rs
@@ -646,7 +646,6 @@ methods_trait!(PyMethods, py_methods);
 
 macro_rules! slots_trait {
     ($name:ident, $function_name: ident) => {
-        #[allow(clippy::upper_case_acronyms)]
         pub trait $name<T> {
             fn $function_name(self) -> &'static [ffi::PyType_Slot];
         }

--- a/src/class/number.rs
+++ b/src/class/number.rs
@@ -434,13 +434,11 @@ pub trait PyNumberRPowProtocol<'p>: PyNumberProtocol<'p> {
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
-#[allow(clippy::upper_case_acronyms)]
 pub trait PyNumberRLShiftProtocol<'p>: PyNumberProtocol<'p> {
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
 }
 
-#[allow(clippy::upper_case_acronyms)]
 pub trait PyNumberRRShiftProtocol<'p>: PyNumberProtocol<'p> {
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<PyObject>;
@@ -508,13 +506,11 @@ pub trait PyNumberIPowProtocol<'p>: PyNumberProtocol<'p> {
     type Modulo: FromPyObject<'p>;
 }
 
-#[allow(clippy::upper_case_acronyms)]
 pub trait PyNumberILShiftProtocol<'p>: PyNumberProtocol<'p> {
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;
 }
 
-#[allow(clippy::upper_case_acronyms)]
 pub trait PyNumberIRShiftProtocol<'p>: PyNumberProtocol<'p> {
     type Other: FromPyObject<'p>;
     type Result: IntoPyCallbackOutput<()>;

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -137,7 +137,6 @@ macro_rules! complex_conversion {
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
-        #[allow(clippy::float_cmp)] // The comparison is for an error value
         impl<'source> FromPyObject<'source> for Complex<$float> {
             fn extract(obj: &'source PyAny) -> PyResult<Complex<$float>> {
                 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
@@ -174,7 +173,6 @@ complex_conversion!(f64);
 mod tests {
     use super::*;
 
-    #[allow(clippy::float_cmp)] // The test wants to ensure that no precision was lost on the Python round-trip
     #[test]
     fn from_complex() {
         Python::with_gil(|py| {

--- a/src/ffi/objimpl.rs
+++ b/src/ffi/objimpl.rs
@@ -63,7 +63,6 @@ extern "C" {
 
 /// Test if a type has a GC head
 #[inline]
-#[allow(unused_parens)]
 pub unsafe fn PyType_IS_GC(t: *mut PyTypeObject) -> c_int {
     PyType_HasFeature(t, Py_TPFLAGS_HAVE_GC)
 }

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -153,7 +153,7 @@ where
 ///     let py = gil_guard.python();
 /// } // GIL is released when gil_guard is dropped
 /// ```
-#[allow(clippy::upper_case_acronyms)]
+
 #[must_use]
 pub struct GILGuard {
     gstate: ffi::PyGILState_STATE,
@@ -330,7 +330,6 @@ static POOL: ReferencePool = ReferencePool::new();
 
 ///
 /// [Memory Management]: https://pyo3.rs/main/memory.html#gil-bound-memory
-#[allow(clippy::upper_case_acronyms)]
 pub struct GILPool {
     /// Initial length of owned objects and anys.
     /// `Option` is used since TSL can be broken when `new` is called from `atexit`.
@@ -473,7 +472,6 @@ pub(crate) fn ensure_gil_unchecked() -> EnsureGIL {
 }
 
 /// Struct used internally which avoids acquiring the GIL where it's not necessary.
-#[allow(clippy::upper_case_acronyms)]
 pub(crate) struct EnsureGIL(Option<GILGuard>);
 
 impl EnsureGIL {

--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -28,7 +28,6 @@ use std::cell::UnsafeCell;
 /// }
 /// # Python::with_gil(|py| assert_eq!(get_shared_list(py).len(), 0));
 /// ```
-#[allow(clippy::upper_case_acronyms)]
 pub struct GILOnceCell<T>(UnsafeCell<Option<T>>);
 
 // T: Send is needed for Sync because the thread which drops the GILOnceCell can be different

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -648,7 +648,6 @@ impl PyAny {
     /// Returns the length of the sequence or mapping.
     ///
     /// This is equivalent to the Python expression `len(self)`.
-    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> PyResult<usize> {
         let v = unsafe { ffi::PyObject_Size(self.as_ptr()) };
         if v == -1 {


### PR DESCRIPTION
Now that 1.58.1 is out, the send in not send lint can be removed.

Also removes some old allows that are no longer necessary.