### PR TITLE
ci: unpin nightly for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,9 +253,7 @@ jobs:
         continue-on-error: true
       - uses: actions-rs/toolchain@v1
         with:
-          # TODO: this is pinned to work around a rustc bug in instrumented coverage
-          # https://github.com/taiki-e/cargo-llvm-cov/issues/128
-          toolchain: nightly-2022-01-14
+          toolchain: nightly
           override: true
           profile: minimal
           components: llvm-tools-preview


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/issues/79645, latest nightly should hopefully be working for coverage again...