### PR TITLE
ci: fix windows job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,7 +259,7 @@ jobs:
           components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - run: pip install -U pip nox
+      - run: python -m pip install -U pip nox
       - run: cargo xtask coverage --output-lcov coverage.lcov
       - uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
My guess is that `pip install -U pip` can't replace the currently-running `pip.exe` for some reason on the Windows GitHub runner? 