### PR TITLE
pypy: support fast long conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use the Rust function path for `wrap_pymodule!` of a `#[pymodule]` with a `#[pyo3(name = "..")]` attribute, not the Python name. [#2081](https://github.com/PyO3/pyo3/pull/2081)
 - Fix panic in `#[pyfunction]` generated code when a required argument following an `Option` was not provided.  [#2093](https://github.com/PyO3/pyo3/pull/2093)
 - Fixed undefined behaviour caused by incorrect `ExactSizeIterator` implementations. [#2124](https://github.com/PyO3/pyo3/pull/2124)
+- Add missing FFI definitions `_PyLong_NumBits` and `_PyLong_AsByteArray` on PyPy. [#2146](https://github.com/PyO3/pyo3/pull/2146)
 
 ## [0.15.1] - 2021-11-19
 

--- a/pyo3-ffi/src/longobject.rs
+++ b/pyo3-ffi/src/longobject.rs
@@ -96,7 +96,7 @@ extern "C" {
 extern "C" {
     // skipped non-limited _PyLong_Sign
 
-    #[cfg(not(PyPy))]
+    #[cfg_attr(PyPy, link_name = "_PyPyLong_NumBits")]
     pub fn _PyLong_NumBits(obj: *mut PyObject) -> c_int;
 
     // skipped _PyLong_DivmodNear
@@ -109,7 +109,7 @@ extern "C" {
         is_signed: c_int,
     ) -> *mut PyObject;
 
-    #[cfg(not(PyPy))]
+    #[cfg_attr(PyPy, link_name = "_PyPyLong_AsByteArrayO")]
     pub fn _PyLong_AsByteArray(
         v: *mut PyLongObject,
         bytes: *mut c_uchar,

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -143,7 +143,7 @@ int_convert_u64_or_i64!(
     ffi::PyLong_AsUnsignedLongLong
 );
 
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+#[cfg(not(Py_LIMITED_API))]
 mod fast_128bit_int_conversion {
     use super::*;
 
@@ -200,8 +200,8 @@ mod fast_128bit_int_conversion {
     int_convert_128!(u128, 0);
 }
 
-// For ABI3 and PyPy, we implement the conversion manually.
-#[cfg(any(Py_LIMITED_API, PyPy))]
+// For ABI3 we implement the conversion manually.
+#[cfg(Py_LIMITED_API)]
 mod slow_128bit_int_conversion {
     use super::*;
     const SHIFT: usize = 64;
@@ -245,10 +245,10 @@ mod slow_128bit_int_conversion {
                             -1 as _,
                             ffi::PyLong_AsUnsignedLongLongMask(ob.as_ptr()),
                         )? as $rust_type;
-                        let shifted = PyObject::from_owned_ptr(
+                        let shifted = PyObject::from_owned_ptr_or_err(
                             py,
                             ffi::PyNumber_Rshift(ob.as_ptr(), SHIFT.into_py(py).as_ptr()),
-                        );
+                        )?;
                         let upper: $half_type = shifted.extract(py)?;
                         Ok((<$rust_type>::from(upper) << SHIFT) | lower)
                     }
@@ -461,8 +461,6 @@ mod tests {
     test_common!(u64, u64);
     test_common!(isize, isize);
     test_common!(usize, usize);
-    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
     test_common!(i128, i128);
-    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
     test_common!(u128, u128);
 }


### PR DESCRIPTION
Just noticed that `_PyLong_AsByteArray` _does_ exist on PyPy.