### PR TITLE
refactor: inline pyclass_intrinsic_items

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -861,8 +861,9 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
     fn for_all_items(visitor: &mut dyn FnMut(&pyo3::impl_::pyclass::PyClassItems)) {
         use pyo3::impl_::pyclass::*;
         let collector = PyClassImplCollector::<MyClass>::new();
+        static INTRINSIC_ITEMS: &PyClassItems = PyClassItems { slots: &[], methods: &[] };
+        visitor(&INTRINSIC_ITEMS);
         visitor(collector.py_methods());
-        visitor(collector.pyclass_intrinsic_items());
     }
     fn get_new() -> Option<pyo3::ffi::newfunc> {
         use pyo3::impl_::pyclass::*;

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -736,9 +736,6 @@ pub trait PyClassInventory: inventory::Collect {
     fn items(&'static self) -> &'static PyClassItems;
 }
 
-// Methods from #[pyo3(get, set)] on struct fields.
-items_trait!(PyClassIntrinsicItems, pyclass_intrinsic_items);
-
 // Items from #[pymethods] if not using inventory.
 #[cfg(not(feature = "multiple-pymethods"))]
 items_trait!(PyMethods, py_methods);


### PR DESCRIPTION
Just noticed that the `pyclass_intrinsic_items` are generated as part of the `#[pyclass]` macro so don't need to be wired up via a trait.