### PR TITLE
refactor: simpler pyclass internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce generated LLVM code size (to improve compile times) for:
   - internal `handle_panic` helper [#2074](https://github.com/PyO3/pyo3/pull/2074)
   - `#[pyfunction]` and `#[pymethods]` argument extraction [#2075](https://github.com/PyO3/pyo3/pull/2075) [#2085](https://github.com/PyO3/pyo3/pull/2085)
-  - `#[pyclass]` type object creation [#2076](https://github.com/PyO3/pyo3/pull/2076) [#2081](https://github.com/PyO3/pyo3/pull/2081)
+  - `#[pyclass]` type object creation [#2076](https://github.com/PyO3/pyo3/pull/2076) [#2081](https://github.com/PyO3/pyo3/pull/2081) [#2157](https://github.com/PyO3/pyo3/pull/2157)
 - `__ipow__` now supports modulo argument on Python 3.8+. [#2083](https://github.com/PyO3/pyo3/pull/2083)
 - `pyo3-macros-backend` is now compiled with PyO3 cfgs to enable different magic method definitions based on version. [#2083](https://github.com/PyO3/pyo3/pull/2083)
 - `_PyCFunctionFast` now correctly reflects the signature defined in the [Python docs](https://docs.python.org/3/c-api/structures.html#c._PyCFunctionFast). [#2126](https://github.com/PyO3/pyo3/pull/2126)

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -986,16 +986,6 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
         let collector = PyClassImplCollector::<Self>::new();
         collector.new_impl()
     }
-    fn get_alloc() -> Option<pyo3::ffi::allocfunc> {
-        use pyo3::impl_::pyclass::*;
-        let collector = PyClassImplCollector::<Self>::new();
-        collector.alloc_impl()
-    }
-    fn get_free() -> Option<pyo3::ffi::freefunc> {
-        use pyo3::impl_::pyclass::*;
-        let collector = PyClassImplCollector::<Self>::new();
-        collector.free_impl()
-    }
 }
 # Python::with_gil(|py| {
 #     let cls = py.get_type::<MyClass>();

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -981,11 +981,6 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
         visitor(&INTRINSIC_ITEMS);
         visitor(collector.py_methods());
     }
-    fn get_new() -> Option<pyo3::ffi::newfunc> {
-        use pyo3::impl_::pyclass::*;
-        let collector = PyClassImplCollector::<Self>::new();
-        collector.new_impl()
-    }
 }
 # Python::with_gil(|py| {
 #     let cls = py.get_type::<MyClass>();

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -927,11 +927,6 @@ impl<'a> PyClassImplsBuilder<'a> {
                     #pymethods_items
                     #pyproto_items
                 }
-                fn get_new() -> ::std::option::Option<_pyo3::ffi::newfunc> {
-                    use _pyo3::impl_::pyclass::*;
-                    let collector = PyClassImplCollector::<Self>::new();
-                    collector.new_impl()
-                }
 
                 #dict_offset
 

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -108,10 +108,6 @@ pub fn impl_methods(
                         let attrs = get_cfg_attributes(&meth.attrs);
                         methods.push(quote!(#(#attrs)* #token_stream));
                     }
-                    GeneratedPyMethod::TraitImpl(token_stream) => {
-                        let attrs = get_cfg_attributes(&meth.attrs);
-                        trait_impls.push(quote!(#(#attrs)* #token_stream));
-                    }
                     GeneratedPyMethod::SlotTraitImpl(method_name, token_stream) => {
                         implemented_proto_fragments.insert(method_name);
                         let attrs = get_cfg_attributes(&meth.attrs);
@@ -204,7 +200,7 @@ pub fn gen_default_items<'a>(
             GeneratedPyMethod::SlotTraitImpl(..) => {
                 panic!("SlotFragment methods cannot have default implementation!")
             }
-            GeneratedPyMethod::Method(_) | GeneratedPyMethod::TraitImpl(_) => {
+            GeneratedPyMethod::Method(_) => {
                 panic!("Only protocol methods can have default implementation!")
             }
         }

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -194,7 +194,7 @@ pub fn gen_default_items<'a>(
     // all succeed.
     let ty: syn::Type = syn::parse_quote!(#cls);
 
-    method_defs.into_iter().map(move |meth| {
+    method_defs.iter_mut().map(move |meth| {
         let options = PyFunctionOptions::from_attrs(&mut meth.attrs).unwrap();
         match pymethod::gen_py_method(&ty, &mut meth.sig, &mut meth.attrs, options).unwrap() {
             GeneratedPyMethod::Proto(token_stream) => {

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -757,9 +757,6 @@ mod pyproto_traits {
 #[cfg(feature = "pyproto")]
 pub use pyproto_traits::*;
 
-// items that PyO3 implements by default, but can be overidden by the users.
-items_trait!(PyClassDefaultItems, pyclass_default_items);
-
 // Protocol slots from #[pymethods] if not using inventory.
 #[cfg(not(feature = "multiple-pymethods"))]
 items_trait!(PyMethodsProtocolItems, methods_protocol_items);

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -179,10 +179,6 @@ pub trait PyClassImpl: Sized {
     fn for_all_items(visitor: &mut dyn FnMut(&PyClassItems));
 
     #[inline]
-    fn get_new() -> Option<ffi::newfunc> {
-        None
-    }
-    #[inline]
     fn dict_offset() -> Option<ffi::Py_ssize_t> {
         None
     }
@@ -193,16 +189,6 @@ pub trait PyClassImpl: Sized {
 }
 
 // Traits describing known special methods.
-
-pub trait PyClassNewImpl<T> {
-    fn new_impl(self) -> Option<ffi::newfunc>;
-}
-
-impl<T> PyClassNewImpl<T> for &'_ PyClassImplCollector<T> {
-    fn new_impl(self) -> Option<ffi::newfunc> {
-        None
-    }
-}
 
 macro_rules! slot_fragment_trait {
     ($trait_name:ident, $($default_method:tt)*) => {
@@ -813,19 +799,6 @@ impl<T: PyClass> PyClassBaseType for T {
     type BaseNativeType = T::BaseNativeType;
     type ThreadChecker = T::ThreadChecker;
     type Initializer = crate::pyclass_init::PyClassInitializer<Self>;
-}
-
-/// Default new implementation
-pub(crate) unsafe extern "C" fn fallback_new(
-    _subtype: *mut ffi::PyTypeObject,
-    _args: *mut ffi::PyObject,
-    _kwds: *mut ffi::PyObject,
-) -> *mut ffi::PyObject {
-    crate::callback_body!(py, {
-        Err::<(), _>(crate::exceptions::PyTypeError::new_err(
-            "No constructor defined",
-        ))
-    })
 }
 
 /// Implementation of tp_dealloc for all pyclasses

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -183,14 +183,6 @@ pub trait PyClassImpl: Sized {
         None
     }
     #[inline]
-    fn get_alloc() -> Option<ffi::allocfunc> {
-        None
-    }
-    #[inline]
-    fn get_free() -> Option<ffi::freefunc> {
-        None
-    }
-    #[inline]
     fn dict_offset() -> Option<ffi::Py_ssize_t> {
         None
     }
@@ -601,26 +593,6 @@ macro_rules! generate_pyclass_pow_slot {
     }};
 }
 pub use generate_pyclass_pow_slot;
-
-pub trait PyClassAllocImpl<T> {
-    fn alloc_impl(self) -> Option<ffi::allocfunc>;
-}
-
-impl<T> PyClassAllocImpl<T> for &'_ PyClassImplCollector<T> {
-    fn alloc_impl(self) -> Option<ffi::allocfunc> {
-        None
-    }
-}
-
-pub trait PyClassFreeImpl<T> {
-    fn free_impl(self) -> Option<ffi::freefunc>;
-}
-
-impl<T> PyClassFreeImpl<T> for &'_ PyClassImplCollector<T> {
-    fn free_impl(self) -> Option<ffi::freefunc> {
-        None
-    }
-}
 
 /// Implements a freelist.
 ///

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -51,8 +51,6 @@ where
             std::mem::size_of::<T::Layout>(),
             T::get_new(),
             tp_dealloc::<T>,
-            T::get_alloc(),
-            T::get_free(),
             T::dict_offset(),
             T::weaklist_offset(),
             &T::for_all_items,
@@ -75,8 +73,6 @@ unsafe fn create_type_object_impl(
     basicsize: usize,
     tp_new: Option<ffi::newfunc>,
     tp_dealloc: ffi::destructor,
-    tp_alloc: Option<ffi::allocfunc>,
-    tp_free: Option<ffi::freefunc>,
     dict_offset: Option<ffi::Py_ssize_t>,
     weaklist_offset: Option<ffi::Py_ssize_t>,
     for_all_items: &dyn Fn(&mut dyn FnMut(&PyClassItems)),
@@ -100,13 +96,6 @@ unsafe fn create_type_object_impl(
         tp_new.unwrap_or(fallback_new) as _,
     );
     push_slot(&mut slots, ffi::Py_tp_dealloc, tp_dealloc as _);
-
-    if let Some(alloc) = tp_alloc {
-        push_slot(&mut slots, ffi::Py_tp_alloc, alloc as _);
-    }
-    if let Some(free) = tp_free {
-        push_slot(&mut slots, ffi::Py_tp_free, free as _);
-    }
 
     #[cfg(Py_3_9)]
     {

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -3,8 +3,8 @@ use crate::{
     callback::IntoPyCallbackOutput,
     ffi,
     impl_::pyclass::{
-        assign_sequence_item_from_mapping, fallback_new, get_sequence_item_from_mapping,
-        tp_dealloc, PyClassDict, PyClassImpl, PyClassItems, PyClassWeakRef,
+        assign_sequence_item_from_mapping, get_sequence_item_from_mapping, tp_dealloc, PyClassDict,
+        PyClassImpl, PyClassItems, PyClassWeakRef,
     },
     IntoPy, IntoPyPointer, PyCell, PyErr, PyMethodDefType, PyNativeType, PyObject, PyResult,
     PyTypeInfo, Python,
@@ -49,7 +49,6 @@ where
             T::NAME,
             T::BaseType::type_object_raw(py),
             std::mem::size_of::<T::Layout>(),
-            T::get_new(),
             tp_dealloc::<T>,
             T::dict_offset(),
             T::weaklist_offset(),
@@ -71,7 +70,6 @@ unsafe fn create_type_object_impl(
     name: &str,
     base_type_object: *mut ffi::PyTypeObject,
     basicsize: usize,
-    tp_new: Option<ffi::newfunc>,
     tp_dealloc: ffi::destructor,
     dict_offset: Option<ffi::Py_ssize_t>,
     weaklist_offset: Option<ffi::Py_ssize_t>,
@@ -90,11 +88,6 @@ unsafe fn create_type_object_impl(
         push_slot(&mut slots, ffi::Py_tp_doc, doc as _);
     }
 
-    push_slot(
-        &mut slots,
-        ffi::Py_tp_new,
-        tp_new.unwrap_or(fallback_new) as _,
-    );
     push_slot(&mut slots, ffi::Py_tp_dealloc, tp_dealloc as _);
 
     #[cfg(Py_3_9)]
@@ -121,6 +114,7 @@ unsafe fn create_type_object_impl(
     }
 
     // protocol methods
+    let mut has_new = false;
     let mut has_getitem = false;
     let mut has_setitem = false;
     let mut has_gc_methods = false;
@@ -131,6 +125,7 @@ unsafe fn create_type_object_impl(
 
     for_all_items(&mut |items| {
         for slot in items.slots {
+            has_new |= slot.slot == ffi::Py_tp_new;
             has_getitem |= slot.slot == ffi::Py_mp_subscript;
             has_setitem |= slot.slot == ffi::Py_mp_ass_subscript;
             has_gc_methods |= slot.slot == ffi::Py_tp_clear || slot.slot == ffi::Py_tp_traverse;
@@ -169,6 +164,10 @@ unsafe fn create_type_object_impl(
             ffi::Py_sq_ass_item,
             assign_sequence_item_from_mapping as _,
         );
+    }
+
+    if !has_new {
+        push_slot(&mut slots, ffi::Py_tp_new, no_constructor_defined as _);
     }
 
     // Add empty sentinel at the end
@@ -549,4 +548,17 @@ where
             None => Ok(PyIterANextOutput::Return(py.None())),
         }
     }
+}
+
+/// Default new implementation
+pub(crate) unsafe extern "C" fn no_constructor_defined(
+    _subtype: *mut ffi::PyTypeObject,
+    _args: *mut ffi::PyObject,
+    _kwds: *mut ffi::PyObject,
+) -> *mut ffi::PyObject {
+    crate::callback_body!(py, {
+        Err::<(), _>(crate::exceptions::PyTypeError::new_err(
+            "No constructor defined",
+        ))
+    })
 }

--- a/tests/ui/invalid_pymethods.rs
+++ b/tests/ui/invalid_pymethods.rs
@@ -119,4 +119,15 @@ impl MyClass {
     fn default_arg_before_required(&self, has_default: isize, required: isize) {}
 }
 
+struct TwoNew { }
+
+#[pymethods]
+impl TwoNew {
+    #[new]
+    fn new_1() -> Self { Self { } }
+
+    #[new]
+    fn new_2() -> Self { Self { } }
+}
+
 fn main() {}

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -101,3 +101,14 @@ error: `pass_module` cannot be used on Python methods
     |
 112 |     #[pyo3(pass_module)]
     |            ^^^^^^^^^^^
+
+error[E0592]: duplicate definitions with name `__pymethod__new__`
+   --> tests/ui/invalid_pymethods.rs:124:1
+    |
+124 | #[pymethods]
+    | ^^^^^^^^^^^^
+    | |
+    | duplicate definitions for `__pymethod__new__`
+    | other definition for `__pymethod__new__`
+    |
+    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Just makes a few cleanups to the `#[pyclass]` internals which I noticed were possible the other day:
- Merges `pyclass_default_items` trait into the inlined items created in #2153
- Changes new / free / alloc to all be passed via slots, rather than using autoref specialization.

Overall seems like a nice simplification; makes the machinery of the pyclass internals a bit more uniform. Also reduces `llvm-lines` count of `pytests` crate by around 1%. So nothing major, still seems nice.
