### PR TITLE
pymethods: support gc protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wrap_pyfunction!` can now wrap a `#[pyfunction]` which is implemented in a different Rust module or crate. [#2091](https://github.com/PyO3/pyo3/pull/2091)
 - Add `PyAny::contains` method (`in` operator for `PyAny`). [#2115](https://github.com/PyO3/pyo3/pull/2115)
 - Add `PyMapping::contains` method (`in` operator for `PyMapping`). [#2133](https://github.com/PyO3/pyo3/pull/2133)
+- Add garbage collection magic methods `__traverse__` and `__clear__` to `#[pymethods]`. [#2159](https://github.com/PyO3/pyo3/pull/2159)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PyTZInfo_CheckExact`
   - `PyDateTime_FromTimestamp`
   - `PyDate_FromTimestamp`
+- Deprecate the `gc` option for `pyclass` (e.g. `#[pyclass(gc)]`). Just implement a `__traverse__` `#[pymethod]`. [#2159](https://github.com/PyO3/pyo3/pull/2159)
 - The `ml_meth` field of `PyMethodDef` is now represented by the `PyMethodDefPointer` union [2166](https://github.com/PyO3/pyo3/pull/2166)
 
 ### Removed

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -967,7 +967,6 @@ impl pyo3::IntoPy<PyObject> for MyClass {
 
 impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
     const DOC: &'static str = "Class for demonstration\u{0}";
-    const IS_GC: bool = false;
     const IS_BASETYPE: bool = false;
     const IS_SUBCLASS: bool = false;
     type Layout = PyCell<MyClass>;

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -175,7 +175,8 @@ given signatures should be interpreted as follows:
 
 #### Garbage Collector Integration
 
-TODO; see [#1884](https://github.com/PyO3/pyo3/issues/1884)
+  - `__traverse__(<self>, visit: pyo3::class::gc::PyVisit) -> Result<(), pyo3::class::gc::PyTraverseError>`
+  - `__clear__(<self>) -> ()`
 
 ### `#[pyproto]` traits
 

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -445,19 +445,6 @@ impl PyGCProtocol for ClassWithGCSupport {
 }
 ```
 
-Special protocol trait implementations have to be annotated with the `#[pyproto]` attribute.
-
-It is also possible to enable GC for custom classes using the `gc` parameter of the `pyclass` attribute.
-i.e. `#[pyclass(gc)]`. In that case instances of custom class participate in Python garbage
-collection, and it is possible to track them with `gc` module methods. When using the `gc` parameter,
-it is *required* to implement the `PyGCProtocol` trait, failure to do so will result in an error
-at compile time:
-
-```compile_fail
-#[pyclass(gc)]
-struct GCTracked {} // Fails because it does not implement PyGCProtocol
-```
-
 #### Iterator Types
 
 Iterators can be defined using the

--- a/pyo3-macros-backend/src/deprecations.rs
+++ b/pyo3-macros-backend/src/deprecations.rs
@@ -3,12 +3,14 @@ use quote::{quote_spanned, ToTokens};
 
 pub enum Deprecation {
     CallAttribute,
+    PyClassGcOption,
 }
 
 impl Deprecation {
     fn ident(&self, span: Span) -> syn::Ident {
         let string = match self {
             Deprecation::CallAttribute => "CALL_ATTRIBUTE",
+            Deprecation::PyClassGcOption => "PYCLASS_GC_OPTION",
         };
         syn::Ident::new(string, span)
     }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -3,7 +3,7 @@
 use crate::attributes::{
     self, take_pyo3_options, CrateAttribute, NameAttribute, TextSignatureAttribute,
 };
-use crate::deprecations::Deprecations;
+use crate::deprecations::{Deprecation, Deprecations};
 use crate::konst::{ConstAttributes, ConstSpec};
 use crate::pyimpl::{gen_default_items, gen_py_const, PyClassMethodsType};
 use crate::pymethod::{impl_py_getter_def, impl_py_setter_def, PropertyType};
@@ -29,12 +29,12 @@ pub struct PyClassArgs {
     pub base: syn::TypePath,
     pub has_dict: bool,
     pub has_weaklist: bool,
-    pub is_gc: bool,
     pub is_basetype: bool,
     pub has_extends: bool,
     pub has_unsendable: bool,
     pub module: Option<syn::LitStr>,
     pub class_kind: PyClassKind,
+    pub deprecations: Deprecations,
 }
 
 impl PyClassArgs {
@@ -63,11 +63,11 @@ impl PyClassArgs {
             base: parse_quote! { _pyo3::PyAny },
             has_dict: false,
             has_weaklist: false,
-            is_gc: false,
             is_basetype: false,
             has_extends: false,
             has_unsendable: false,
             class_kind,
+            deprecations: Deprecations::new(),
         }
     }
 
@@ -158,9 +158,9 @@ impl PyClassArgs {
     fn add_path(&mut self, exp: &syn::ExprPath) -> syn::Result<()> {
         let flag = exp.path.segments.first().unwrap().ident.to_string();
         match flag.as_str() {
-            "gc" => {
-                self.is_gc = true;
-            }
+            "gc" => self
+                .deprecations
+                .push(Deprecation::PyClassGcOption, exp.span()),
             "weakref" => {
                 self.has_weaklist = true;
             }
@@ -825,7 +825,6 @@ impl<'a> PyClassImplsBuilder<'a> {
     fn impl_pyclassimpl(&self) -> TokenStream {
         let cls = self.cls;
         let doc = self.doc.as_ref().map_or(quote! {"\0"}, |doc| quote! {#doc});
-        let is_gc = self.attr.is_gc;
         let is_basetype = self.attr.is_basetype;
         let base = &self.attr.base;
         let is_subclass = self.attr.has_extends;
@@ -903,10 +902,11 @@ impl<'a> PyClassImplsBuilder<'a> {
         let default_slots = &self.default_slots;
         let freelist_slots = self.freelist_slots();
 
+        let deprecations = &self.attr.deprecations;
+
         quote! {
             impl _pyo3::impl_::pyclass::PyClassImpl for #cls {
                 const DOC: &'static str = #doc;
-                const IS_GC: bool = #is_gc;
                 const IS_BASETYPE: bool = #is_basetype;
                 const IS_SUBCLASS: bool = #is_subclass;
 
@@ -918,6 +918,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                 fn for_all_items(visitor: &mut dyn ::std::ops::FnMut(& _pyo3::impl_::pyclass::PyClassItems)) {
                     use _pyo3::impl_::pyclass::*;
                     let collector = PyClassImplCollector::<Self>::new();
+                    #deprecations;
                     static INTRINSIC_ITEMS: PyClassItems = PyClassItems {
                         methods: &[#(#default_methods),*],
                         slots: &[#(#default_slots),* #(#freelist_slots),*],

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -757,7 +757,6 @@ impl<'a> PyClassImplsBuilder<'a> {
             self.impl_into_py(),
             self.impl_pyclassimpl(),
             self.impl_freelist(),
-            self.impl_gc(),
         ]
         .into_iter()
         .collect()
@@ -979,26 +978,6 @@ impl<'a> PyClassImplsBuilder<'a> {
             ]
         } else {
             Vec::new()
-        }
-    }
-
-    /// Enforce at compile time that PyGCProtocol is implemented
-    fn impl_gc(&self) -> TokenStream {
-        let cls = self.cls;
-        let attr = self.attr;
-        if attr.is_gc {
-            let closure_name = format!("__assertion_closure_{}", cls);
-            let closure_token = syn::Ident::new(&closure_name, Span::call_site());
-            quote! {
-                fn #closure_token() {
-                    use _pyo3::class;
-
-                    fn _assert_implements_protocol<'p, T: _pyo3::class::PyGCProtocol<'p>>() {}
-                    _assert_implements_protocol::<#cls>();
-                }
-            }
-        } else {
-            quote! {}
         }
     }
 }

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -36,14 +36,86 @@ enum PyMethodKind {
 
 impl PyMethodKind {
     fn from_name(name: &str) -> Self {
-        if let Some(slot_def) = pyproto(name) {
-            PyMethodKind::Proto(PyMethodProtoKind::Slot(slot_def))
-        } else if name == "__call__" {
-            PyMethodKind::Proto(PyMethodProtoKind::Call)
-        } else if let Some(slot_fragment_def) = pyproto_fragment(name) {
-            PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(slot_fragment_def))
-        } else {
-            PyMethodKind::Fn
+        match name {
+            // Protocol implemented through slots
+            "__getattr__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__GETATTR__)),
+            "__str__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__STR__)),
+            "__repr__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__REPR__)),
+            "__hash__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__HASH__)),
+            "__richcmp__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__RICHCMP__)),
+            "__get__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__GET__)),
+            "__iter__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__ITER__)),
+            "__next__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__NEXT__)),
+            "__await__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__AWAIT__)),
+            "__aiter__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__AITER__)),
+            "__anext__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__ANEXT__)),
+            "__len__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__LEN__)),
+            "__contains__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__CONTAINS__)),
+            "__getitem__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__GETITEM__)),
+            "__pos__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__POS__)),
+            "__neg__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__NEG__)),
+            "__abs__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__ABS__)),
+            "__invert__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__INVERT__)),
+            "__index__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__INDEX__)),
+            "__int__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__INT__)),
+            "__float__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__FLOAT__)),
+            "__bool__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__BOOL__)),
+            "__iadd__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IADD__)),
+            "__isub__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__ISUB__)),
+            "__imul__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IMUL__)),
+            "__imatmul__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IMATMUL__)),
+            "__itruediv__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__ITRUEDIV__)),
+            "__ifloordiv__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IFLOORDIV__)),
+            "__imod__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IMOD__)),
+            "__ipow__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IPOW__)),
+            "__ilshift__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__ILSHIFT__)),
+            "__irshift__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IRSHIFT__)),
+            "__iand__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IAND__)),
+            "__ixor__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IXOR__)),
+            "__ior__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__IOR__)),
+            "__getbuffer__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__GETBUFFER__)),
+            "__releasebuffer__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__RELEASEBUFFER__)),
+            "__clear__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__CLEAR__)),
+            // Protocols implemented through traits
+            "__setattr__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__SETATTR__)),
+            "__delattr__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__DELATTR__)),
+            "__set__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__SET__)),
+            "__delete__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__DELETE__)),
+            "__setitem__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__SETITEM__)),
+            "__delitem__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__DELITEM__)),
+            "__add__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__ADD__)),
+            "__radd__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RADD__)),
+            "__sub__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__SUB__)),
+            "__rsub__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RSUB__)),
+            "__mul__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__MUL__)),
+            "__rmul__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RMUL__)),
+            "__matmul__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__MATMUL__)),
+            "__rmatmul__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RMATMUL__)),
+            "__floordiv__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__FLOORDIV__)),
+            "__rfloordiv__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RFLOORDIV__)),
+            "__truediv__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__TRUEDIV__)),
+            "__rtruediv__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RTRUEDIV__)),
+            "__divmod__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__DIVMOD__)),
+            "__rdivmod__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RDIVMOD__)),
+            "__mod__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__MOD__)),
+            "__rmod__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RMOD__)),
+            "__lshift__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__LSHIFT__)),
+            "__rlshift__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RLSHIFT__)),
+            "__rshift__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RSHIFT__)),
+            "__rrshift__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RRSHIFT__)),
+            "__and__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__AND__)),
+            "__rand__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RAND__)),
+            "__xor__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__XOR__)),
+            "__rxor__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RXOR__)),
+            "__or__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__OR__)),
+            "__ror__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__ROR__)),
+            "__pow__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__POW__)),
+            "__rpow__" => PyMethodKind::Proto(PyMethodProtoKind::SlotFragment(&__RPOW__)),
+            // Some tricky protocols which don't fit the pattern of the rest
+            "__call__" => PyMethodKind::Proto(PyMethodProtoKind::Call),
+            "__traverse__" => PyMethodKind::Proto(PyMethodProtoKind::Traverse),
+            // Not a proto
+            _ => PyMethodKind::Fn,
         }
     }
 }
@@ -51,6 +123,7 @@ impl PyMethodKind {
 enum PyMethodProtoKind {
     Slot(&'static SlotDef),
     Call,
+    Traverse,
     SlotFragment(&'static SlotFragmentDef),
 }
 
@@ -107,6 +180,9 @@ pub fn gen_py_method(
                 }
                 PyMethodProtoKind::Call => {
                     GeneratedPyMethod::Proto(impl_call_slot(cls, method.spec)?)
+                }
+                PyMethodProtoKind::Traverse => {
+                    GeneratedPyMethod::Proto(impl_traverse_slot(cls, method.spec)?)
                 }
                 PyMethodProtoKind::SlotFragment(slot_fragment_def) => {
                     let proto = slot_fragment_def.generate_pyproto_fragment(cls, spec)?;
@@ -216,6 +292,36 @@ fn impl_call_slot(cls: &syn::Type, mut spec: FnSpec) -> Result<TokenStream> {
         _pyo3::ffi::PyType_Slot {
             slot: _pyo3::ffi::Py_tp_call,
             pfunc: __wrap as _pyo3::ffi::ternaryfunc as _
+        }
+    }})
+}
+
+fn impl_traverse_slot(cls: &syn::Type, spec: FnSpec) -> Result<TokenStream> {
+    let ident = spec.name;
+    Ok(quote! {{
+        pub unsafe extern "C" fn __wrap_(
+            slf: *mut _pyo3::ffi::PyObject,
+            visit: _pyo3::ffi::visitproc,
+            arg: *mut ::std::os::raw::c_void,
+        ) -> ::std::os::raw::c_int
+        {
+            let pool = _pyo3::GILPool::new();
+            let py = pool.python();
+            _pyo3::callback::abort_on_traverse_panic(::std::panic::catch_unwind(move || {
+                let slf = py.from_borrowed_ptr::<_pyo3::PyCell<#cls>>(slf);
+
+                let visit = _pyo3::class::gc::PyVisit::from_raw(visit, arg, py);
+                let borrow = slf.try_borrow();
+                if let ::std::result::Result::Ok(borrow) = borrow {
+                    _pyo3::class::gc::unwrap_traverse_result(borrow.#ident(visit))
+                } else {
+                    0
+                }
+            }))
+        }
+        _pyo3::ffi::PyType_Slot {
+            slot: _pyo3::ffi::Py_tp_traverse,
+            pfunc: __wrap_ as _pyo3::ffi::traverseproc as _
         }
     }})
 }
@@ -567,49 +673,9 @@ const __RELEASEBUFFER__: SlotDef = SlotDef::new("Py_bf_releasebuffer", "releaseb
     .arguments(&[Ty::PyBuffer])
     .ret_ty(Ty::Void)
     .require_unsafe();
-
-fn pyproto(method_name: &str) -> Option<&'static SlotDef> {
-    match method_name {
-        "__getattr__" => Some(&__GETATTR__),
-        "__str__" => Some(&__STR__),
-        "__repr__" => Some(&__REPR__),
-        "__hash__" => Some(&__HASH__),
-        "__richcmp__" => Some(&__RICHCMP__),
-        "__get__" => Some(&__GET__),
-        "__iter__" => Some(&__ITER__),
-        "__next__" => Some(&__NEXT__),
-        "__await__" => Some(&__AWAIT__),
-        "__aiter__" => Some(&__AITER__),
-        "__anext__" => Some(&__ANEXT__),
-        "__len__" => Some(&__LEN__),
-        "__contains__" => Some(&__CONTAINS__),
-        "__getitem__" => Some(&__GETITEM__),
-        "__pos__" => Some(&__POS__),
-        "__neg__" => Some(&__NEG__),
-        "__abs__" => Some(&__ABS__),
-        "__invert__" => Some(&__INVERT__),
-        "__index__" => Some(&__INDEX__),
-        "__int__" => Some(&__INT__),
-        "__float__" => Some(&__FLOAT__),
-        "__bool__" => Some(&__BOOL__),
-        "__iadd__" => Some(&__IADD__),
-        "__isub__" => Some(&__ISUB__),
-        "__imul__" => Some(&__IMUL__),
-        "__imatmul__" => Some(&__IMATMUL__),
-        "__itruediv__" => Some(&__ITRUEDIV__),
-        "__ifloordiv__" => Some(&__IFLOORDIV__),
-        "__imod__" => Some(&__IMOD__),
-        "__ipow__" => Some(&__IPOW__),
-        "__ilshift__" => Some(&__ILSHIFT__),
-        "__irshift__" => Some(&__IRSHIFT__),
-        "__iand__" => Some(&__IAND__),
-        "__ixor__" => Some(&__IXOR__),
-        "__ior__" => Some(&__IOR__),
-        "__getbuffer__" => Some(&__GETBUFFER__),
-        "__releasebuffer__" => Some(&__RELEASEBUFFER__),
-        _ => None,
-    }
-}
+const __CLEAR__: SlotDef = SlotDef::new("Py_tp_clear", "inquiry")
+    .arguments(&[])
+    .ret_ty(Ty::Int);
 
 #[derive(Clone, Copy)]
 enum Ty {
@@ -1044,46 +1110,6 @@ const __POW__: SlotFragmentDef = SlotFragmentDef::new("__pow__", &[Ty::Object, T
 const __RPOW__: SlotFragmentDef = SlotFragmentDef::new("__rpow__", &[Ty::Object, Ty::Object])
     .extract_error_mode(ExtractErrorMode::NotImplemented)
     .ret_ty(Ty::Object);
-
-fn pyproto_fragment(method_name: &str) -> Option<&'static SlotFragmentDef> {
-    match method_name {
-        "__setattr__" => Some(&__SETATTR__),
-        "__delattr__" => Some(&__DELATTR__),
-        "__set__" => Some(&__SET__),
-        "__delete__" => Some(&__DELETE__),
-        "__setitem__" => Some(&__SETITEM__),
-        "__delitem__" => Some(&__DELITEM__),
-        "__add__" => Some(&__ADD__),
-        "__radd__" => Some(&__RADD__),
-        "__sub__" => Some(&__SUB__),
-        "__rsub__" => Some(&__RSUB__),
-        "__mul__" => Some(&__MUL__),
-        "__rmul__" => Some(&__RMUL__),
-        "__matmul__" => Some(&__MATMUL__),
-        "__rmatmul__" => Some(&__RMATMUL__),
-        "__floordiv__" => Some(&__FLOORDIV__),
-        "__rfloordiv__" => Some(&__RFLOORDIV__),
-        "__truediv__" => Some(&__TRUEDIV__),
-        "__rtruediv__" => Some(&__RTRUEDIV__),
-        "__divmod__" => Some(&__DIVMOD__),
-        "__rdivmod__" => Some(&__RDIVMOD__),
-        "__mod__" => Some(&__MOD__),
-        "__rmod__" => Some(&__RMOD__),
-        "__lshift__" => Some(&__LSHIFT__),
-        "__rlshift__" => Some(&__RLSHIFT__),
-        "__rshift__" => Some(&__RSHIFT__),
-        "__rrshift__" => Some(&__RRSHIFT__),
-        "__and__" => Some(&__AND__),
-        "__rand__" => Some(&__RAND__),
-        "__xor__" => Some(&__XOR__),
-        "__rxor__" => Some(&__RXOR__),
-        "__or__" => Some(&__OR__),
-        "__ror__" => Some(&__ROR__),
-        "__pow__" => Some(&__POW__),
-        "__rpow__" => Some(&__RPOW__),
-        _ => None,
-    }
-}
 
 fn extract_proto_arguments(
     cls: &syn::Type,

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -86,12 +86,11 @@ pub fn pyproto(_: TokenStream, input: TokenStream) -> TokenStream {
 /// |  Parameter  |  Description |
 /// | :-  | :- |
 /// | <span style="white-space: pre">`name = "python_name"`</span> | Sets the name that Python sees this class as. Defaults to the name of the Rust struct. |
-/// | <span style="white-space: pre">`freelist = N`</span> |  Implements a [free list][10] of size N. This can improve performance for types that are often created and deleted in quick succession. Profile your code to see whether `freelist` is right for you.  |
-/// | `gc`  | Participate in Python's [garbage collection][5]. Required if your type contains references to other Python objects. If you don't (or incorrectly) implement this, contained Python objects may be hidden from Python's garbage collector and you may leak memory. Note that leaking memory, while undesirable, [is safe behavior][7].|
+/// | <span style="white-space: pre">`freelist = N`</span> |  Implements a [free list][9] of size N. This can improve performance for types that are often created and deleted in quick succession. Profile your code to see whether `freelist` is right for you.  |
 /// | `weakref` | Allows this class to be [weakly referenceable][6]. |
 /// | <span style="white-space: pre">`extends = BaseType`</span>  | Use a custom baseclass. Defaults to [`PyAny`][4] |
 /// | `subclass` | Allows other Python classes and `#[pyclass]` to inherit from this class. Enums cannot be subclassed. |
-/// | `unsendable` | Required if your struct is not [`Send`][3]. Rather than using `unsendable`, consider implementing your struct in a threadsafe way by e.g. substituting [`Rc`][8] with [`Arc`][9]. By using `unsendable`, your class will panic when accessed by another thread.|
+/// | `unsendable` | Required if your struct is not [`Send`][3]. Rather than using `unsendable`, consider implementing your struct in a threadsafe way by e.g. substituting [`Rc`][7] with [`Arc`][8]. By using `unsendable`, your class will panic when accessed by another thread.|
 /// | <span style="white-space: pre">`module = "module_name"`</span> |  Python code will see the class as being defined in this module. Defaults to `builtins`. |
 ///
 /// For more on creating Python classes,
@@ -103,10 +102,9 @@ pub fn pyproto(_: TokenStream, input: TokenStream) -> TokenStream {
 /// [4]: ../prelude/struct.PyAny.html
 /// [5]: https://pyo3.rs/latest/class/protocols.html#garbage-collector-integration
 /// [6]: https://docs.python.org/3/library/weakref.html
-/// [7]: https://doc.rust-lang.org/nomicon/leaking.html
-/// [8]: std::rc::Rc
-/// [9]: std::sync::Arc
-/// [10]: https://en.wikipedia.org/wiki/Free_list
+/// [7]: std::rc::Rc
+/// [8]: std::sync::Arc
+/// [9]: https://en.wikipedia.org/wiki/Free_list
 #[proc_macro_attribute]
 pub fn pyclass(attr: TokenStream, input: TokenStream) -> TokenStream {
     use syn::Item;

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -266,3 +266,18 @@ where
         R::ERR_VALUE
     })
 }
+
+/// Aborts if panic has occurred. Used inside `__traverse__` implementations, where panicking is not possible.
+#[doc(hidden)]
+#[inline]
+pub fn abort_on_traverse_panic(
+    panic_result: Result<c_int, Box<dyn Any + Send + 'static>>,
+) -> c_int {
+    match panic_result {
+        Ok(traverse_result) => traverse_result,
+        Err(_payload) => {
+            eprintln!("FATAL: panic inside __traverse__ handler; aborting.");
+            ::std::process::abort()
+        }
+    }
+}

--- a/src/class/gc.rs
+++ b/src/class/gc.rs
@@ -83,4 +83,20 @@ impl<'p> PyVisit<'p> {
             Err(PyTraverseError(r))
         }
     }
+
+    /// Creates the PyVisit from the arguments to tp_traverse
+    #[doc(hidden)]
+    pub unsafe fn from_raw(visit: ffi::visitproc, arg: *mut c_void, _py: Python<'p>) -> Self {
+        Self { visit, arg, _py }
+    }
+}
+
+/// Unwraps the result of __traverse__ for tp_traverse
+#[doc(hidden)]
+#[inline]
+pub fn unwrap_traverse_result(result: Result<(), PyTraverseError>) -> c_int {
+    match result {
+        Ok(()) => 0,
+        Err(PyTraverseError(value)) => value,
+    }
 }

--- a/src/impl_/deprecations.rs
+++ b/src/impl_/deprecations.rs
@@ -2,3 +2,9 @@
 
 #[deprecated(since = "0.15.0", note = "use `fn __call__` instead of `#[call]`")]
 pub const CALL_ATTRIBUTE: () = ();
+
+#[deprecated(
+    since = "0.16.0",
+    note = "implement a `__traverse__` `#[pymethod]` instead of using `gc` option"
+)]
+pub const PYCLASS_GC_OPTION: () = ();

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -149,9 +149,6 @@ pub trait PyClassImpl: Sized {
     /// Class doc string
     const DOC: &'static str = "\0";
 
-    /// #[pyclass(gc)]
-    const IS_GC: bool = false;
-
     /// #[pyclass(subclass)]
     const IS_BASETYPE: bool = false;
 

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "macros")]
-#![cfg(feature = "pyproto")] // FIXME: #[pymethods] to support gc protocol
 
-use pyo3::class::PyGCProtocol;
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
 use pyo3::prelude::*;
@@ -90,8 +88,8 @@ struct GcIntegration {
     dropped: TestDropCall,
 }
 
-#[pyproto]
-impl PyGCProtocol for GcIntegration {
+#[pymethods]
+impl GcIntegration {
     fn __traverse__(&self, visit: PyVisit) -> Result<(), PyTraverseError> {
         visit.call(&self.self_ref)
     }
@@ -133,8 +131,8 @@ fn gc_integration() {
 #[pyclass(gc)]
 struct GcIntegration2 {}
 
-#[pyproto]
-impl PyGCProtocol for GcIntegration2 {
+#[pymethods]
+impl GcIntegration2 {
     fn __traverse__(&self, _visit: PyVisit) -> Result<(), PyTraverseError> {
         Ok(())
     }
@@ -230,8 +228,8 @@ impl TraversableClass {
     }
 }
 
-#[pyproto]
-impl PyGCProtocol for TraversableClass {
+#[pymethods]
+impl TraversableClass {
     fn __clear__(&mut self) {}
     fn __traverse__(&self, _visit: PyVisit) -> Result<(), PyTraverseError> {
         self.traversed.store(true, Ordering::Relaxed);

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -128,7 +128,7 @@ fn gc_integration() {
     assert!(drop_called.load(Ordering::Relaxed));
 }
 
-#[pyclass(gc)]
+#[pyclass]
 struct GcIntegration2 {}
 
 #[pymethods]
@@ -215,7 +215,7 @@ fn inheritance_with_new_methods_with_drop() {
     assert!(drop_called2.load(Ordering::Relaxed));
 }
 
-#[pyclass(gc)]
+#[pyclass]
 struct TraversableClass {
     traversed: AtomicBool,
 }

--- a/tests/test_gc_pyproto.rs
+++ b/tests/test_gc_pyproto.rs
@@ -130,7 +130,7 @@ fn gc_integration() {
     assert!(drop_called.load(Ordering::Relaxed));
 }
 
-#[pyclass(gc)]
+#[pyclass]
 struct GcIntegration2 {}
 
 #[pyproto]
@@ -217,7 +217,7 @@ fn inheritance_with_new_methods_with_drop() {
     assert!(drop_called2.load(Ordering::Relaxed));
 }
 
-#[pyclass(gc)]
+#[pyclass]
 struct TraversableClass {
     traversed: AtomicBool,
 }

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -11,6 +11,9 @@ impl DeprecatedCall {
     fn deprecated_call(&self) {}
 }
 
+#[pyclass(gc)]
+struct DeprecatedGc;
+
 fn main() {
 
 }

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -9,3 +9,9 @@ note: the lint level is defined here
    |
 1  | #![deny(deprecated)]
    |         ^^^^^^^^^^
+
+error: use of deprecated constant `pyo3::impl_::deprecations::PYCLASS_GC_OPTION`: implement a `__traverse__` `#[pymethod]` instead of using `gc` option
+  --> tests/ui/deprecations.rs:14:11
+   |
+14 | #[pyclass(gc)]
+   |           ^^


### PR DESCRIPTION
This is the last step for #1884. Copies the same design for `__traverse__` and `__clear__` from `PyGCProtocol` onto `#[pymethods]`.

It's not the cleanest implementation, but it works fine. Once merged, we can mark `#[pyproto]` as deprecated and get on with releasing 0.16 😄 