### PR TITLE
Fix the signature of _PyLong_NumBits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed undefined behaviour caused by incorrect `ExactSizeIterator` implementations. [#2124](https://github.com/PyO3/pyo3/pull/2124)
 - Add missing FFI definitions `_PyLong_NumBits` and `_PyLong_AsByteArray` on PyPy. [#2146](https://github.com/PyO3/pyo3/pull/2146)
 - Fix memory leak in implementation of `AsPyPointer` for `Option<T>`. [#2160](https://github.com/PyO3/pyo3/pull/2160)
+- Fix the signature of `_PyLong_NumBits` [#2161](https://github.com/PyO3/pyo3/pull/2161)
 
 ## [0.15.1] - 2021-11-19
 

--- a/pyo3-ffi/src/longobject.rs
+++ b/pyo3-ffi/src/longobject.rs
@@ -97,7 +97,7 @@ extern "C" {
     // skipped non-limited _PyLong_Sign
 
     #[cfg_attr(PyPy, link_name = "_PyPyLong_NumBits")]
-    pub fn _PyLong_NumBits(obj: *mut PyObject) -> c_int;
+    pub fn _PyLong_NumBits(obj: *mut PyObject) -> size_t;
 
     // skipped _PyLong_DivmodNear
 

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -111,7 +111,7 @@ macro_rules! bigint_conversion {
                     let num: Py<PyLong> =
                         Py::from_owned_ptr_or_err(py, ffi::PyNumber_Index(ob.as_ptr()))?;
                     let n_bits = ffi::_PyLong_NumBits(num.as_ptr());
-                    let n_bytes = if n_bits == usize::MAX {
+                    let n_bytes = if n_bits == (-1isize as usize) {
                         return Err(PyErr::fetch(py));
                     } else if n_bits == 0 {
                         0

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -111,12 +111,12 @@ macro_rules! bigint_conversion {
                     let num: Py<PyLong> =
                         Py::from_owned_ptr_or_err(py, ffi::PyNumber_Index(ob.as_ptr()))?;
                     let n_bits = ffi::_PyLong_NumBits(num.as_ptr());
-                    let n_bytes = if n_bits == -1 {
+                    let n_bytes = if n_bits == usize::MAX {
                         return Err(PyErr::fetch(py));
                     } else if n_bits == 0 {
                         0
                     } else {
-                        (n_bits as usize - 1 + $is_signed) / 8 + 1
+                        (n_bits - 1 + $is_signed) / 8 + 1
                     };
                     if n_bytes <= 128 {
                         let mut buffer = [0; 128];


### PR DESCRIPTION
This commit is a simple fix of the signature of _PyLong_NumBits. It's correct C signature in [`longobject.h`](https://github.com/python/cpython/blob/47290e7642dd41d94437dd0e2c0f6bfceb0281b5/Include/longobject.h#L117) is
```c
PyAPI_FUNC(size_t) _PyLong_NumBits(PyObject *v);
```