### PR TITLE
readme: comment about lib.name field

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ version = "0.1.0"
 edition = "2018"
 
 [lib]
+# The name of the native library. This is the name which will be used in Python to import the
+# library (i.e. `import string_sum`). If you change this, you must also change the name of the
+# `#[pymodule]` in `src/lib.rs`.
 name = "string_sum"
 # "cdylib" is necessary to produce a shared library for Python to import from.
 #


### PR DESCRIPTION
To warn users who want to rename the library as per https://github.com/PyO3/pyo3/pull/2167#issuecomment-1039277082 that they must also rename the `#[pymodule]`.