### PR TITLE
pymethods: more tests for magic methods

### DIFF
--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -51,6 +51,8 @@ impl PyMethodKind {
             "__anext__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__ANEXT__)),
             "__len__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__LEN__)),
             "__contains__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__CONTAINS__)),
+            "__concat__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__CONCAT__)),
+            "__repeat__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__REPEAT__)),
             "__getitem__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__GETITEM__)),
             "__pos__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__POS__)),
             "__neg__" => PyMethodKind::Proto(PyMethodProtoKind::Slot(&__NEG__)),
@@ -602,6 +604,8 @@ const __LEN__: SlotDef = SlotDef::new("Py_mp_length", "lenfunc").ret_ty(Ty::PySs
 const __CONTAINS__: SlotDef = SlotDef::new("Py_sq_contains", "objobjproc")
     .arguments(&[Ty::Object])
     .ret_ty(Ty::Int);
+const __CONCAT__: SlotDef = SlotDef::new("Py_sq_concat", "binaryfunc").arguments(&[Ty::Object]);
+const __REPEAT__: SlotDef = SlotDef::new("Py_sq_repeat", "ssizeargfunc").arguments(&[Ty::PySsizeT]);
 const __GETITEM__: SlotDef = SlotDef::new("Py_mp_subscript", "binaryfunc").arguments(&[Ty::Object]);
 
 const __POS__: SlotDef = SlotDef::new("Py_nb_positive", "unaryfunc");

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -53,6 +53,39 @@ fn unary_arithmetic() {
 }
 
 #[pyclass]
+struct Indexable(i32);
+
+#[pymethods]
+impl Indexable {
+    fn __index__(&self) -> i32 {
+        self.0
+    }
+
+    fn __int__(&self) -> i32 {
+        self.0
+    }
+
+    fn __float__(&self) -> f64 {
+        f64::from(self.0)
+    }
+
+    fn __invert__(&self) -> Self {
+        Self(!self.0)
+    }
+}
+
+#[test]
+fn indexable() {
+    Python::with_gil(|py| {
+        let i = PyCell::new(py, Indexable(5)).unwrap();
+        py_run!(py, i, "assert int(i) == 5");
+        py_run!(py, i, "assert [0, 1, 2, 3, 4, 5][i] == 5");
+        py_run!(py, i, "assert float(i) == 5.0");
+        py_run!(py, i, "assert int(~i) == -6");
+    })
+}
+
+#[pyclass]
 struct InPlaceOperations {
     value: u32,
 }


### PR DESCRIPTION
Adds tests for methods listed in #1884 as currently missing tests. Noticed that support was missing in `#[pymethods]` for `__concat__` and `__repeat__` at the same time.