### PR TITLE
ci: pin to pypy 7.3.7 for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       fail-fast: false # If one platform fails, allow the rest to keep testing.
       matrix:
         rust: [stable]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-3.7", "pypy-3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev", "pypy-3.7-v7.3.7", "pypy-3.8"]
         platform:
           [
             {
@@ -104,7 +104,7 @@ jobs:
           ]
         exclude:
           # PyPy doesn't release 32-bit Windows builds any more
-          - python-version: pypy-3.7
+          - python-version: pypy-3.7-v7.3.7
             platform: { os: "windows-latest", python-architecture: "x86" }
           - python-version: pypy-3.8
             platform: { os: "windows-latest", python-architecture: "x86" }


### PR DESCRIPTION
Seems to me that PyPy 7.3.8 has broken compatibility again for Python 3.7, so let's pin to 7.3.7 for now.

https://foss.heptapod.net/pypy/pypy/-/issues/3688