### PR TITLE
Add support for `from_py_with` on struct tuples and enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `PyAny::contains` method (`in` operator for `PyAny`). [#2115](https://github.com/PyO3/pyo3/pull/2115)
 - Add `PyMapping::contains` method (`in` operator for `PyMapping`). [#2133](https://github.com/PyO3/pyo3/pull/2133)
 - Add garbage collection magic methods `__traverse__` and `__clear__` to `#[pymethods]`. [#2159](https://github.com/PyO3/pyo3/pull/2159)
+- Add support for `from_py_with` on struct tuples and enums to override the default from-Python conversion. [#2181](https://github.com/PyO3/pyo3/pull/2181)
 
 ### Changed
 

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -442,6 +442,10 @@ If the input is neither a string nor an integer, the error message will be:
 - `pyo3(item)`, `pyo3(item("key"))`
     - retrieve the field from a mapping, possibly with the custom key specified as an argument.
     - can be any literal that implements `ToBorrowedObject`
+- `pyo3(from_py_with = "...")`
+    - apply a custom function to convert the field from Python the desired Rust type. 
+    - the argument must be the name of the function as a string.
+    - the function signature must be `fn(&PyAny) -> PyResult<T>` where `T` is the Rust type of the argument.
 
 ### `IntoPy<T>`
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -71,7 +71,7 @@ impl PyClassArgs {
         }
     }
 
-    /// Adda single expression from the comma separated list in the attribute, which is
+    /// Add a single expression from the comma separated list in the attribute, which is
     /// either a single word or an assignment expression
     fn add_expr(&mut self, expr: &Expr) -> Result<()> {
         match expr {

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -481,3 +481,23 @@ fn test_from_py_with() {
         assert_eq!(zap.some_object_length, 3usize);
     });
 }
+
+#[derive(Debug, FromPyObject)]
+pub struct ZapTuple(
+    #[pyo3(item)] String,
+    #[pyo3(from_py_with = "PyAny::len")] usize,
+);
+
+#[test]
+fn test_from_py_with_tuple_struct() {
+    Python::with_gil(|py| {
+        let py_zap = py
+            .eval(r#"("whatever", [1, 2, 3])"#, None, None)
+            .expect("failed to create dict");
+
+        let zap = ZapTuple::extract(py_zap).unwrap();
+
+        assert_eq!(zap.0, "whatever");
+        assert_eq!(zap.1, 3usize);
+    });
+}

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -483,10 +483,7 @@ fn test_from_py_with() {
 }
 
 #[derive(Debug, FromPyObject)]
-pub struct ZapTuple(
-    String,
-    #[pyo3(from_py_with = "PyAny::len")] usize,
-);
+pub struct ZapTuple(String, #[pyo3(from_py_with = "PyAny::len")] usize);
 
 #[test]
 fn test_from_py_with_tuple_struct() {

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -501,3 +501,23 @@ fn test_from_py_with_tuple_struct() {
         assert_eq!(zap.1, 3usize);
     });
 }
+
+#[derive(Debug, FromPyObject, PartialEq)]
+pub enum ZapEnum {
+    Zip(#[pyo3(from_py_with = "PyAny::len")] usize),
+    Zap(String, #[pyo3(from_py_with = "PyAny::len")] usize),
+}
+
+#[test]
+fn test_from_py_with_enum() {
+    Python::with_gil(|py| {
+        let py_zap = py
+            .eval(r#"("whatever", [1, 2, 3])"#, None, None)
+            .expect("failed to create dict");
+
+        let zap = ZapEnum::extract(py_zap).unwrap();
+        let expected_zap = ZapEnum::Zap(String::from("whatever"), 3usize);
+
+        assert_eq!(zap, expected_zap);
+    });
+}

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -493,7 +493,7 @@ fn test_from_py_with_tuple_struct() {
     Python::with_gil(|py| {
         let py_zap = py
             .eval(r#"("whatever", [1, 2, 3])"#, None, None)
-            .expect("failed to create dict");
+            .expect("failed to create tuple");
 
         let zap = ZapTuple::extract(py_zap).unwrap();
 
@@ -513,7 +513,7 @@ fn test_from_py_with_enum() {
     Python::with_gil(|py| {
         let py_zap = py
             .eval(r#"("whatever", [1, 2, 3])"#, None, None)
-            .expect("failed to create dict");
+            .expect("failed to create tuple");
 
         let zap = ZapEnum::extract(py_zap).unwrap();
         let expected_zap = ZapEnum::Zap(String::from("whatever"), 3usize);

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -484,7 +484,7 @@ fn test_from_py_with() {
 
 #[derive(Debug, FromPyObject)]
 pub struct ZapTuple(
-    #[pyo3(item)] String,
+    String,
     #[pyo3(from_py_with = "PyAny::len")] usize,
 );
 


### PR DESCRIPTION
Fixes https://github.com/PyO3/pyo3/issues/1441 by introducing `from_py_with` for tuple structs and enum.