### PR TITLE
Extend  optional dependency supported versions to include 0.12.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
         name: Prepare minimal package versions (MSRV only)
         run: |
           cargo update -p indexmap --precise 1.6.2
-          cargo update -p hashbrown:0.11.2 --precise 0.9.1
+          cargo update -p hashbrown:0.12.0 --precise 0.9.1
 
       - name: Build docs
         run: cargo doc --no-deps --no-default-features --features "full ${{ matrix.extra_features }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Packaging
+
+- Extend `hashbrown` optional dependency supported versions to include 0.12. [#2197]https://github.com/PyO3/pyo3/pull/2197)
+
 ### Fixed
 
 - Fix incorrect platform detection for Windows in `pyo3-build-config`. [#2198](https://github.com/PyO3/pyo3/pull/2198)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ inventory = { version = "0.2.0", optional = true }
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0", optional = true }
 eyre = { version = ">= 0.4, < 0.7", optional = true }
-hashbrown = { version = ">= 0.9, < 0.12", optional = true }
+hashbrown = { version = ">= 0.9, < 0.13", optional = true }
 indexmap = { version = ">= 1.6, < 1.8", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-complex = { version = ">= 0.2, < 0.5", optional = true }


### PR DESCRIPTION
The tests seem to work when building against `hashbrown` version 0.12 to I opted to just extend the version specification.