### PR TITLE
use platform.system to check if it is on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix incorrect platform detection for Windows in `pyo3-build-config`. [#2198](https://github.com/PyO3/pyo3/pull/2198)
+
 ## [0.16.0] - 2022-02-27
 
 ### Packaging

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -188,7 +188,7 @@ def print_if_set(varname, value):
         print(varname, value)
 
 # Windows always uses shared linking
-WINDOWS = hasattr(platform, "win32_ver")
+WINDOWS = platform.system() == "Windows"
 
 # macOS framework packages use shared linking
 FRAMEWORK = bool(get_config_var("PYTHONFRAMEWORK"))


### PR DESCRIPTION
the code ```hasattr(platform, "win32_ver")``` will also be True on other os rather than Windows, this pr replace it by platform.system().
