### PR TITLE
Enable the resolve-config feature of pyo3-build-config on docs.rs to make the dependent functionality visible.

### DIFF
--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -25,3 +25,6 @@ abi3-py37 = ["abi3-py38"]
 abi3-py38 = ["abi3-py39"]
 abi3-py39 = ["abi3-py310"]
 abi3-py310 = ["abi3"]
+
+[package.metadata.docs.rs]
+features = ["resolve-config"]


### PR DESCRIPTION
Noticed this while discussing how to handle https://github.com/PyO3/rust-numpy/pull/283 even though I am not sure if this is the correct way to resolve it, i.e. if the build environment on docs.rs does actually contain a Python interpreter?