### PR TITLE
pypy: support 7.3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           "3.9",
           "3.10",
           "3.11-dev",
-          "pypy-3.7-v7.3.7",
+          "pypy-3.7",
           "pypy-3.8",
           "pypy-3.9"
         ]
@@ -113,7 +113,7 @@ jobs:
           ]
         exclude:
           # PyPy doesn't release 32-bit Windows builds any more
-          - python-version: pypy-3.7-v7.3.7
+          - python-version: pypy-3.7
             platform: { os: "windows-latest", python-architecture: "x86" }
           - python-version: pypy-3.8
             platform: { os: "windows-latest", python-architecture: "x86" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Packaging
+
+- Warn when modules are imported on PyPy 3.7 versions older than PyPy 7.3.8, as they are known to have binary compatibility issues. [#2217](https://github.com/PyO3/pyo3/pull/2217)
+
 ## [0.16.1] - 2022-03-05
 
 ### Packaging

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -359,7 +359,6 @@ pub struct PyDateTime_CAPI {
     pub TimeType: *mut PyTypeObject,
     pub DeltaType: *mut PyTypeObject,
     pub TZInfoType: *mut PyTypeObject,
-    #[cfg(not(all(PyPy, not(Py_3_8))))]
     pub TimeZone_UTC: *mut PyObject,
     pub Date_FromDate: unsafe extern "C" fn(
         year: c_int,
@@ -393,7 +392,6 @@ pub struct PyDateTime_CAPI {
         normalize: c_int,
         cls: *mut PyTypeObject,
     ) -> *mut PyObject,
-    #[cfg(not(all(PyPy, not(Py_3_8))))]
     pub TimeZone_FromTimeZone:
         unsafe extern "C" fn(offset: *mut PyObject, name: *mut PyObject) -> *mut PyObject,
 
@@ -442,7 +440,6 @@ pub unsafe fn PyDateTimeAPI() -> *mut PyDateTime_CAPI {
     *PyDateTimeAPI_impl.0.get()
 }
 
-#[cfg(not(all(PyPy, not(Py_3_8))))]
 #[inline]
 pub unsafe fn PyDateTime_TimeZone_UTC() -> *mut PyObject {
     (*PyDateTimeAPI()).TimeZone_UTC

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -41,7 +41,6 @@ fn test_date_fromtimestamp() {
 }
 
 #[test]
-#[cfg(not(all(PyPy, not(Py_3_8))))]
 fn test_utc_timezone() {
     Python::with_gil(|py| {
         let utc_timezone = unsafe {


### PR DESCRIPTION
According to https://foss.heptapod.net/pypy/pypy/-/issues/3688#note_181074 the official PyPy line will be that PyPy 3.7 versions older than 7.3.8 should be treated as bugged.

Hence here I'm updating definitions to support 7.3.8 and add a warning if a user tries to import a PyO3 module with an older PyPy version.

```
  /Users/david/tools/pypy3.7-v7.3.8-osx64/lib-python/3/importlib/_bootstrap.py:228: UserWarning: PyPy 3.7
versions older than 7.3.8 are known to have binary compatibility issues which may cause segfaults. Please
upgrade.
```