### PR TITLE
Consider PYTHONFRAMEWORK when cross-compiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Considered `PYTHONFRAMEWORK` when cross compiling in order that on macos cross compiling against a [Framework bundle](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html) is considered shared. [#2233](https://github.com/PyO3/pyo3/pull/2233)
+
 - Panic during compilation when `PYO3_CROSS_LIB_DIR` is set for some host/target combinations. [#2232](https://github.com/PyO3/pyo3/pull/2232)
 
 ## [0.16.2] - 2022-03-15

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1536,6 +1536,61 @@ mod tests {
     }
 
     #[test]
+    fn config_from_sysconfigdata_framework() {
+        let mut sysconfigdata = Sysconfigdata::new();
+        sysconfigdata.insert("SOABI", "cpython-37m-x86_64-linux-gnu");
+        sysconfigdata.insert("VERSION", "3.7");
+        // PYTHONFRAMEWORK should override Py_ENABLE_SHARED
+        sysconfigdata.insert("Py_ENABLE_SHARED", "0");
+        sysconfigdata.insert("PYTHONFRAMEWORK", "Python");
+        sysconfigdata.insert("LIBDIR", "/usr/lib");
+        sysconfigdata.insert("LDVERSION", "3.7m");
+        sysconfigdata.insert("SIZEOF_VOID_P", "8");
+        assert_eq!(
+            InterpreterConfig::from_sysconfigdata(&sysconfigdata).unwrap(),
+            InterpreterConfig {
+                abi3: false,
+                build_flags: BuildFlags::from_sysconfigdata(&sysconfigdata),
+                pointer_width: Some(64),
+                executable: None,
+                implementation: PythonImplementation::CPython,
+                lib_dir: Some("/usr/lib".into()),
+                lib_name: Some("python3.7m".into()),
+                shared: true,
+                version: PythonVersion::PY37,
+                suppress_build_script_link_lines: false,
+                extra_build_script_lines: vec![],
+            }
+        );
+
+        sysconfigdata = Sysconfigdata::new();
+        sysconfigdata.insert("SOABI", "cpython-37m-x86_64-linux-gnu");
+        sysconfigdata.insert("VERSION", "3.7");
+        // An empty PYTHONFRAMEWORK means it is not a framework
+        sysconfigdata.insert("Py_ENABLE_SHARED", "0");
+        sysconfigdata.insert("PYTHONFRAMEWORK", "");
+        sysconfigdata.insert("LIBDIR", "/usr/lib");
+        sysconfigdata.insert("LDVERSION", "3.7m");
+        sysconfigdata.insert("SIZEOF_VOID_P", "8");
+        assert_eq!(
+            InterpreterConfig::from_sysconfigdata(&sysconfigdata).unwrap(),
+            InterpreterConfig {
+                abi3: false,
+                build_flags: BuildFlags::from_sysconfigdata(&sysconfigdata),
+                pointer_width: Some(64),
+                executable: None,
+                implementation: PythonImplementation::CPython,
+                lib_dir: Some("/usr/lib".into()),
+                lib_name: Some("python3.7m".into()),
+                shared: false,
+                version: PythonVersion::PY37,
+                suppress_build_script_link_lines: false,
+                extra_build_script_lines: vec![],
+            }
+        );
+    }
+
+    #[test]
     fn windows_hardcoded_cross_compile() {
         let cross_config = CrossCompileConfig {
             lib_dir: "C:\\some\\path".into(),

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -299,6 +299,11 @@ print("mingw", get_platform().startswith("mingw"))
             Some("0") | Some("false") | Some("False") => false,
             _ => bail!("expected a bool (1/true/True or 0/false/False) for Py_ENABLE_SHARED"),
         };
+        // macOS framework packages use shared linking (PYTHONFRAMEWORK is the framework name, hence the empty check)
+        let framework = match sysconfigdata.get_value("PYTHONFRAMEWORK") {
+            Some(s) => !s.is_empty(),
+            _ => false,
+        };
         let lib_dir = get_key!(sysconfigdata, "LIBDIR").ok().map(str::to_string);
         let lib_name = Some(default_lib_name_unix(
             version,
@@ -313,7 +318,7 @@ print("mingw", get_platform().startswith("mingw"))
         Ok(InterpreterConfig {
             implementation,
             version,
-            shared,
+            shared: shared || framework,
             abi3: is_abi3(),
             lib_dir,
             lib_name,


### PR DESCRIPTION
When cross compiling on macos the `PYTHONFRAMEWORK` setting wasn't considered, though it is in the regular build process.  

This means that the build system believes it is a static Python when, actually, it's shared.  This adds an extra check to make `from_sysconfigdata` much more similar to `from_interpreter` in that regard. 