### PR TITLE
pyo3-macros-backend: Replace `pyo3-build-config` with `abi3` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ pyproto = ["pyo3-macros/pyproto"]
 extension-module = ["pyo3-ffi/extension-module"]
 
 # Use the Python limited API. See https://www.python.org/dev/peps/pep-0384/ for more.
-abi3 = ["pyo3-build-config/abi3", "pyo3-ffi/abi3"]
+abi3 = ["pyo3-build-config/abi3", "pyo3-ffi/abi3", "pyo3-macros/abi3"]
 
 # With abi3, we can manually set the minimum Python version.
 abi3-py37 = ["abi3-py38", "pyo3-build-config/abi3-py37", "pyo3-ffi/abi3-py37"]

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2018"
 [dependencies]
 quote = { version = "1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "0.16.2", features = ["resolve-config"] }
 
 [dependencies.syn]
 version = "1.0.56"
@@ -25,3 +24,4 @@ features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-trait
 
 [features]
 pyproto = []
+abi3 = []

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -183,7 +183,7 @@ impl SelfType {
 pub enum CallingConvention {
     Noargs,   // METH_NOARGS
     Varargs,  // METH_VARARGS | METH_KEYWORDS
-    Fastcall, // METH_FASTCALL | METH_KEYWORDS  (Py3.7+ and !abi3)
+    Fastcall, // METH_FASTCALL | METH_KEYWORDS (not compatible with `abi3` feature)
     TpNew,    // special convention for tp_new
 }
 
@@ -199,19 +199,13 @@ impl CallingConvention {
         } else if accept_kwargs {
             // for functions that accept **kwargs, always prefer varargs
             Self::Varargs
-        } else if can_use_fastcall() {
+        } else if cfg!(not(feature = "abi3")) {
+            // Not available in the Stable ABI as of Python 3.10
             Self::Fastcall
         } else {
             Self::Varargs
         }
     }
-}
-
-fn can_use_fastcall() -> bool {
-    const PY37: pyo3_build_config::PythonVersion =
-        pyo3_build_config::PythonVersion { major: 3, minor: 7 };
-    let config = pyo3_build_config::get();
-    config.version >= PY37 && !config.abi3
 }
 
 pub struct FnSpec<'a> {

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 multiple-pymethods = []
 
 pyproto = ["pyo3-macros-backend/pyproto"]
+abi3 = ["pyo3-macros-backend/abi3"]
 
 [dependencies]
 proc-macro2 = { version = "1", default-features = false }


### PR DESCRIPTION
Python 3.6 and older are not supported by the current PyO3 version,
so the removed interpreter version check was a no-op.

`pyo3_build_config::get()` attempts to read a config file from disk
when PyO3 is cross-compiling, which is probably bad for rust-analyzer
and other IDEs that attempt to sandbox the proc macro code.