### PR TITLE
Add FFI definitions for PEP 573 functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow dependent crates to access config values from `pyo3-build-config` via cargo link dep env vars. [#2092](https://github.com/PyO3/pyo3/pull/2092)
 - Added methods on `InterpreterConfig` to run Python scripts using the configured executable. [#2092](https://github.com/PyO3/pyo3/pull/2092)
+- Added FFI definitions for `PyType_FromModuleAndSpec`, `PyType_GetModule`, `PyType_GetModuleState` and `PyModule_AddType`. [#2250](https://github.com/PyO3/pyo3/pull/2250)
 
 ### Changed
 
 - Allow `#[pyo3(crate = "...", text_signature = "...")]` options to be used directly in `#[pyclass(crate = "...", text_signature = "...")]`. [#2234](https://github.com/PyO3/pyo3/pull/2234)
+- Mark `METH_FASTCALL` calling convention as limited API on Python 3.10. [#2250](https://github.com/PyO3/pyo3/pull/2250)
 
 ### Fixed
 

--- a/pyo3-ffi/src/methodobject.rs
+++ b/pyo3-ffi/src/methodobject.rs
@@ -179,7 +179,7 @@ pub const METH_COEXIST: c_int = 0x0040;
 
 /* METH_FASTCALL indicates the PEP 590 Vectorcall calling format. It may
 be specified alone or with METH_KEYWORDS. */
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 pub const METH_FASTCALL: c_int = 0x0080;
 
 // skipped METH_STACKLESS

--- a/pyo3-ffi/src/modsupport.rs
+++ b/pyo3-ffi/src/modsupport.rs
@@ -77,7 +77,12 @@ extern "C" {
         name: *const c_char,
         value: *const c_char,
     ) -> c_int;
-    // skipped non-limited / 3.9 PyModule_AddType
+    #[cfg(any(Py_3_10, all(Py_3_9, not(Py_LIMITED_API))))]
+    #[cfg_attr(PyPy, link_name = "PyPyModule_AddType")]
+    pub fn PyModule_AddType(
+        module: *mut PyObject,
+        type_: *mut crate::object::PyTypeObject,
+    ) -> c_int;
     // skipped PyModule_AddIntMacro
     // skipped PyModule_AddStringMacro
     pub fn PyModule_SetDocString(arg1: *mut PyObject, arg2: *const c_char) -> c_int;

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -205,9 +205,21 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyType_GetSlot")]
     pub fn PyType_GetSlot(arg1: *mut PyTypeObject, arg2: c_int) -> *mut c_void;
 
-    // skipped non-limited / 3.9 PyType_FromModuleAndSpec
-    // skipped non-limited / 3.9 PyType_GetModule
-    // skipped non-limited / 3.9 PyType_GetModuleState
+    #[cfg(any(Py_3_10, all(Py_3_9, not(Py_LIMITED_API))))]
+    #[cfg_attr(PyPy, link_name = "PyPyType_FromModuleAndSpec")]
+    pub fn PyType_FromModuleAndSpec(
+        module: *mut PyObject,
+        spec: *mut PyType_Spec,
+        bases: *mut PyObject,
+    ) -> *mut PyObject;
+
+    #[cfg(any(Py_3_10, all(Py_3_9, not(Py_LIMITED_API))))]
+    #[cfg_attr(PyPy, link_name = "PyPyType_GetModule")]
+    pub fn PyType_GetModule(arg1: *mut PyTypeObject) -> *mut PyObject;
+
+    #[cfg(any(Py_3_10, all(Py_3_9, not(Py_LIMITED_API))))]
+    #[cfg_attr(PyPy, link_name = "PyPyType_GetModuleState")]
+    pub fn PyType_GetModuleState(arg1: *mut PyTypeObject) -> *mut c_void;
 }
 
 extern "C" {


### PR DESCRIPTION
1. PEP 573: https://peps.python.org/pep-0573/#summary-of-api-changes-and-additions
2. https://bugs.python.org/issue42171
3. `PyType_FromModuleAndSpec`: https://docs.python.org/3/c-api/type.html#c.PyType_FromModuleAndSpec
4. `PyType_GetModule`: https://docs.python.org/3/c-api/type.html#c.PyType_GetModule
5. `PyType_GetModuleState`: https://docs.python.org/3/c-api/type.html#c.PyType_GetModuleState
6. `PyModule_AddType`: https://docs.python.org/3/c-api/module.html#c.PyModule_AddType