### PR TITLE
Add rustimport to tools section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ about this topic.
 - [dict-derive](https://github.com/gperinazzo/dict-derive) _Derive FromPyObject to automatically transform Python dicts into Rust structs_
 - [pyo3-log](https://github.com/vorner/pyo3-log) _Bridge from Rust to Python logging_
 - [pythonize](https://github.com/davidhewitt/pythonize) _Serde serializer for converting Rust objects to JSON-compatible Python objects_
-- [pyo3-asyncio](https://github.com/awestlake87/pyo3-asyncio) Utilities for working with Python's Asyncio library and async functions
+- [pyo3-asyncio](https://github.com/awestlake87/pyo3-asyncio) _Utilities for working with Python's Asyncio library and async functions_
+- [rustimport](https://github.com/mityax/rustimport) _Directly import Rust files or crates from Python, without manual compilation steps. Provides pyo3 integration by default and generates pyo3 binding code automaically._
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ about this topic.
 - [pyo3-log](https://github.com/vorner/pyo3-log) _Bridge from Rust to Python logging_
 - [pythonize](https://github.com/davidhewitt/pythonize) _Serde serializer for converting Rust objects to JSON-compatible Python objects_
 - [pyo3-asyncio](https://github.com/awestlake87/pyo3-asyncio) _Utilities for working with Python's Asyncio library and async functions_
-- [rustimport](https://github.com/mityax/rustimport) _Directly import Rust files or crates from Python, without manual compilation steps. Provides pyo3 integration by default and generates pyo3 binding code automaically._
+- [rustimport](https://github.com/mityax/rustimport) _Directly import Rust files or crates from Python, without manual compilation step. Provides pyo3 integration by default and generates pyo3 binding code automatically._
 
 ## Examples
 


### PR DESCRIPTION
I created a python module called "[rustimport](https://github.com/mityax/rustimport)" which simplifies development workflow when creating Python extensions with pyo3.

This PR adds it to the list in the readme, so others might profit from it too :)