### PR TITLE
pyo3-build-config: Replace `TargetInfo` with `target_lexicon::Triple`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add new public `pyo3-build-config` API using the types from `target_lexicon` crate. Deprecate `cross_compiling()`. [#2253](https://github.com/PyO3/pyo3/pull/2253)
 - Allow dependent crates to access config values from `pyo3-build-config` via cargo link dep env vars. [#2092](https://github.com/PyO3/pyo3/pull/2092)
 - Added methods on `InterpreterConfig` to run Python scripts using the configured executable. [#2092](https://github.com/PyO3/pyo3/pull/2092)
 - Added FFI definitions for `PyType_FromModuleAndSpec`, `PyType_GetModule`, `PyType_GetModuleState` and `PyModule_AddType`. [#2250](https://github.com/PyO3/pyo3/pull/2250)

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -12,6 +12,10 @@ edition = "2018"
 
 [dependencies]
 once_cell = "1"
+target-lexicon = "0.12"
+
+[build-dependencies]
+target-lexicon = "0.12"
 
 [features]
 default = []

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -17,9 +17,11 @@ use std::{env, process::Command};
 #[cfg(feature = "resolve-config")]
 use once_cell::sync::OnceCell;
 
+#[allow(deprecated)]
 pub use impl_::{
-    cross_compiling, find_all_sysconfigdata, parse_sysconfigdata, BuildFlag, BuildFlags,
-    CrossCompileConfig, InterpreterConfig, PythonImplementation, PythonVersion,
+    cross_compiling, cross_compiling_from_to, find_all_sysconfigdata, parse_sysconfigdata,
+    BuildFlag, BuildFlags, CrossCompileConfig, InterpreterConfig, PythonImplementation,
+    PythonVersion, Triple,
 };
 
 /// Adds all the [`#[cfg]` flags](index.html) to the current compilation.
@@ -166,7 +168,8 @@ pub mod pyo3_build_script_impl {
         pub use crate::errors::*;
     }
     pub use crate::impl_::{
-        cargo_env_var, env_var, make_cross_compile_config, InterpreterConfig, PythonVersion,
+        cargo_env_var, env_var, is_linking_libpython, make_cross_compile_config, InterpreterConfig,
+        PythonVersion,
     };
 
     /// Gets the configuration for use from PyO3's build script.
@@ -180,7 +183,7 @@ pub mod pyo3_build_script_impl {
             InterpreterConfig::from_reader(Cursor::new(CONFIG_FILE))
         } else if !ABI3_CONFIG.is_empty() {
             Ok(abi3_config())
-        } else if let Some(interpreter_config) = impl_::make_cross_compile_config()? {
+        } else if let Some(interpreter_config) = make_cross_compile_config()? {
             // This is a cross compile and need to write the config file.
             let path = Path::new(DEFAULT_CROSS_COMPILE_CONFIG_PATH);
             let parent_dir = path.parent().ok_or_else(|| {

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -1,8 +1,8 @@
 use pyo3_build_config::{
     bail, ensure, print_feature_cfgs,
     pyo3_build_script_impl::{
-        cargo_env_var, env_var, errors::Result, resolve_interpreter_config, InterpreterConfig,
-        PythonVersion,
+        cargo_env_var, env_var, errors::Result, is_linking_libpython, resolve_interpreter_config,
+        InterpreterConfig, PythonVersion,
     },
 };
 
@@ -44,33 +44,27 @@ fn ensure_target_pointer_width(interpreter_config: &InterpreterConfig) -> Result
 
 fn emit_link_config(interpreter_config: &InterpreterConfig) -> Result<()> {
     let target_os = cargo_env_var("CARGO_CFG_TARGET_OS").unwrap();
-    let is_extension_module = cargo_env_var("CARGO_FEATURE_EXTENSION_MODULE").is_some();
-    if target_os == "windows" || target_os == "android" || !is_extension_module {
-        // windows and android - always link
-        // other systems - only link if not extension module
-        println!(
-            "cargo:rustc-link-lib={link_model}{alias}{lib_name}",
-            link_model = if interpreter_config.shared {
-                ""
-            } else {
-                "static="
-            },
-            alias = if target_os == "windows" {
-                "pythonXY:"
-            } else {
-                ""
-            },
-            lib_name = interpreter_config.lib_name.as_ref().ok_or(
-                "attempted to link to Python shared library but config does not contain lib_name"
-            )?,
-        );
-        if let Some(lib_dir) = &interpreter_config.lib_dir {
-            println!("cargo:rustc-link-search=native={}", lib_dir);
-        }
-    }
 
-    // serialize the whole interpreter config in DEP_PYTHON_PYO3_CONFIG
-    interpreter_config.to_cargo_dep_env()?;
+    println!(
+        "cargo:rustc-link-lib={link_model}{alias}{lib_name}",
+        link_model = if interpreter_config.shared {
+            ""
+        } else {
+            "static="
+        },
+        alias = if target_os == "windows" {
+            "pythonXY:"
+        } else {
+            ""
+        },
+        lib_name = interpreter_config.lib_name.as_ref().ok_or(
+            "attempted to link to Python shared library but config does not contain lib_name"
+        )?,
+    );
+
+    if let Some(lib_dir) = &interpreter_config.lib_dir {
+        println!("cargo:rustc-link-search=native={}", lib_dir);
+    }
 
     Ok(())
 }
@@ -92,7 +86,10 @@ fn configure_pyo3() -> Result<()> {
     ensure_python_version(&interpreter_config)?;
     ensure_target_pointer_width(&interpreter_config)?;
 
-    if !interpreter_config.suppress_build_script_link_lines {
+    // Serialize the whole interpreter config into DEP_PYTHON_PYO3_CONFIG env var.
+    interpreter_config.to_cargo_dep_env()?;
+
+    if is_linking_libpython() && !interpreter_config.suppress_build_script_link_lines {
         emit_link_config(&interpreter_config)?;
     }
 


### PR DESCRIPTION
Add a new public crate function `cross_compile_from_to()` using
`target_lexicon::Triple` arguments instead of plain strings
used in `cross_compile()`.

Attempt to extract common code patterns into methods and standalone
helper functions. Add docstrings to private items.
Make some of the new helper functions public within the PyO3 crate
and reuse them in the build scripts.

No user visible functionality change.
