### PR TITLE
Enable `METH_FASTCALL` with abi3 for Python 3.10+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow `#[pyo3(crate = "...", text_signature = "...")]` options to be used directly in `#[pyclass(crate = "...", text_signature = "...")]`. [#2234](https://github.com/PyO3/pyo3/pull/2234)
 - Mark `METH_FASTCALL` calling convention as limited API on Python 3.10. [#2250](https://github.com/PyO3/pyo3/pull/2250)
+- Enable `METH_FASTCALL` with abi3 for Python 3.10+. [#2257](https://github.com/PyO3/pyo3/pull/2257)
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,12 +70,12 @@ pyproto = ["pyo3-macros/pyproto"]
 extension-module = ["pyo3-ffi/extension-module"]
 
 # Use the Python limited API. See https://www.python.org/dev/peps/pep-0384/ for more.
-abi3 = ["pyo3-build-config/abi3", "pyo3-ffi/abi3", "pyo3-macros/abi3"]
+abi3 = ["pyo3-build-config/abi3", "pyo3-ffi/abi3"]
 
 # With abi3, we can manually set the minimum Python version.
 abi3-py37 = ["abi3-py38", "pyo3-build-config/abi3-py37", "pyo3-ffi/abi3-py37"]
 abi3-py38 = ["abi3-py39", "pyo3-build-config/abi3-py38", "pyo3-ffi/abi3-py38"]
-abi3-py39 = ["abi3-py310", "pyo3-build-config/abi3-py39", "pyo3-ffi/abi3-py39"]
+abi3-py39 = ["abi3-py310", "pyo3-build-config/abi3-py39", "pyo3-ffi/abi3-py39", "pyo3-macros/abi3-py39"]
 abi3-py310 = ["abi3", "pyo3-build-config/abi3-py310", "pyo3-ffi/abi3-py310"]
 
 # Changes `Python::with_gil` and `Python::acquire_gil` to automatically initialize the

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -24,4 +24,4 @@ features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-trait
 
 [features]
 pyproto = []
-abi3 = []
+abi3-py39 = []

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -183,7 +183,7 @@ impl SelfType {
 pub enum CallingConvention {
     Noargs,   // METH_NOARGS
     Varargs,  // METH_VARARGS | METH_KEYWORDS
-    Fastcall, // METH_FASTCALL | METH_KEYWORDS (not compatible with `abi3` feature)
+    Fastcall, // METH_FASTCALL | METH_KEYWORDS
     TpNew,    // special convention for tp_new
 }
 
@@ -199,8 +199,8 @@ impl CallingConvention {
         } else if accept_kwargs {
             // for functions that accept **kwargs, always prefer varargs
             Self::Varargs
-        } else if cfg!(not(feature = "abi3")) {
-            // Not available in the Stable ABI as of Python 3.10
+        } else if cfg!(not(feature = "abi3-py39")) {
+            // Not available in the Stable ABI until Python 3.10
             Self::Fastcall
         } else {
             Self::Varargs

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 multiple-pymethods = []
 
 pyproto = ["pyo3-macros-backend/pyproto"]
-abi3 = ["pyo3-macros-backend/abi3"]
+abi3-py39 = ["pyo3-macros-backend/abi3-py39"]
 
 [dependencies]
 proc-macro2 = { version = "1", default-features = false }


### PR DESCRIPTION
Following https://github.com/PyO3/pyo3/commit/23e220985af786bda171f7d2b991e47e00d68b01