### PR TITLE
Add PyString::intern to enable access to Python's built-in string interning.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow dependent crates to access config values from `pyo3-build-config` via cargo link dep env vars. [#2092](https://github.com/PyO3/pyo3/pull/2092)
 - Added methods on `InterpreterConfig` to run Python scripts using the configured executable. [#2092](https://github.com/PyO3/pyo3/pull/2092)
 - Added FFI definitions for `PyType_FromModuleAndSpec`, `PyType_GetModule`, `PyType_GetModuleState` and `PyModule_AddType`. [#2250](https://github.com/PyO3/pyo3/pull/2250)
+- Add `PyString::intern` to enable usage of the Python's built-in string interning. [#2268](https://github.com/PyO3/pyo3/pull/2268)
 
 ### Changed
 

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -88,7 +88,7 @@ pub fn build_py_methods(
 
 pub fn impl_methods(
     ty: &syn::Type,
-    impls: &mut Vec<syn::ImplItem>,
+    impls: &mut [syn::ImplItem],
     methods_type: PyClassMethodsType,
     options: PyImplOptions,
 ) -> syn::Result<TokenStream> {

--- a/pyo3-macros-backend/src/pyproto.rs
+++ b/pyo3-macros-backend/src/pyproto.rs
@@ -44,7 +44,7 @@ pub fn build_py_proto(ast: &mut syn::ItemImpl) -> syn::Result<TokenStream> {
 
 fn impl_proto_impl(
     ty: &syn::Type,
-    impls: &mut Vec<syn::ImplItem>,
+    impls: &mut [syn::ImplItem],
     proto: &defs::Proto,
 ) -> syn::Result<TokenStream> {
     let mut trait_impls = TokenStream::new();


### PR DESCRIPTION
I think the API is somewhat unfortunate but I am not sure how to get around the requirement for a null-terminated string without the cost of the allocation that this API is supposed to avoid in the first place. At least not without a `PyUnicode_InternFromStringAndSize`.