### PR TITLE
RFC: Add intern! macro which can be used to amortize the cost of creating Python objects by storing them inside a GILOnceCell.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added methods on `InterpreterConfig` to run Python scripts using the configured executable. [#2092](https://github.com/PyO3/pyo3/pull/2092)
 - Added FFI definitions for `PyType_FromModuleAndSpec`, `PyType_GetModule`, `PyType_GetModuleState` and `PyModule_AddType`. [#2250](https://github.com/PyO3/pyo3/pull/2250)
 - Add `PyString::intern` to enable usage of the Python's built-in string interning. [#2268](https://github.com/PyO3/pyo3/pull/2268)
+- Add `intern!` macro which can be used to amortize the cost of creating Python objects by storing them inside a `GILOnceCell`. [#2269](https://github.com/PyO3/pyo3/pull/2269)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added methods on `InterpreterConfig` to run Python scripts using the configured executable. [#2092](https://github.com/PyO3/pyo3/pull/2092)
 - Added FFI definitions for `PyType_FromModuleAndSpec`, `PyType_GetModule`, `PyType_GetModuleState` and `PyModule_AddType`. [#2250](https://github.com/PyO3/pyo3/pull/2250)
 - Add `PyString::intern` to enable usage of the Python's built-in string interning. [#2268](https://github.com/PyO3/pyo3/pull/2268)
-- Add `intern!` macro which can be used to amortize the cost of creating Python objects by storing them inside a `GILOnceCell`. [#2269](https://github.com/PyO3/pyo3/pull/2269)
+- Add `intern!` macro which can be used to amortize the cost of creating Python strings by storing them inside a `GILOnceCell`. [#2269](https://github.com/PyO3/pyo3/pull/2269)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,10 @@ harness = false
 name = "bench_tuple"
 harness = false
 
+[[bench]]
+name = "bench_intern"
+harness = false
+
 [workspace]
 members = [
     "pyo3-ffi",

--- a/benches/bench_intern.rs
+++ b/benches/bench_intern.rs
@@ -1,0 +1,33 @@
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+
+use pyo3::prelude::*;
+
+use pyo3::{intern, prepare_freethreaded_python};
+
+fn getattr_direct(b: &mut Bencher<'_>) {
+    prepare_freethreaded_python();
+
+    Python::with_gil(|py| {
+        let sys = py.import("sys").unwrap();
+
+        b.iter(|| sys.getattr("version").unwrap());
+    });
+}
+
+fn getattr_intern(b: &mut Bencher<'_>) {
+    prepare_freethreaded_python();
+
+    Python::with_gil(|py| {
+        let sys = py.import("sys").unwrap();
+
+        b.iter(|| sys.getattr(intern!(py, "version")).unwrap());
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("getattr_direct", getattr_direct);
+    c.bench_function("getattr_intern", getattr_intern);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,6 +375,7 @@ pub mod impl_;
 mod instance;
 pub mod marker;
 pub mod marshal;
+#[macro_use]
 pub mod once_cell;
 pub mod panic;
 pub mod prelude;

--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -148,17 +148,21 @@ impl<T> GILOnceCell<T> {
 #[macro_export]
 macro_rules! intern {
     ($py: expr, $text: expr) => {{
-        static INTERNED: $crate::once_cell::GILOnceCell<$crate::Py<$crate::types::PyString>> =
-            $crate::once_cell::GILOnceCell::new();
+        fn isolate_from_dyn_env(py: $crate::Python<'_>) -> &$crate::types::PyString {
+            static INTERNED: $crate::once_cell::GILOnceCell<$crate::Py<$crate::types::PyString>> =
+                $crate::once_cell::GILOnceCell::new();
 
-        INTERNED
-            .get_or_init($py, || {
-                $crate::conversion::IntoPy::into_py(
-                    $crate::types::PyString::intern($py, $text),
-                    $py,
-                )
-            })
-            .as_ref($py)
+            INTERNED
+                .get_or_init(py, || {
+                    $crate::conversion::IntoPy::into_py(
+                        $crate::types::PyString::intern(py, $text),
+                        py,
+                    )
+                })
+                .as_ref(py)
+        }
+
+        isolate_from_dyn_env($py)
     }};
 }
 

--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -119,7 +119,7 @@ impl<T> GILOnceCell<T> {
 ///
 /// ```
 /// use pyo3::intern;
-/// # use pyo3::{pyfunction, types::PyDict, PyResult, Python};
+/// # use pyo3::{pyfunction, types::PyDict, wrap_pyfunction, PyResult, Python};
 ///
 /// #[pyfunction]
 /// fn create_dict(py: Python<'_>) -> PyResult<&PyDict> {
@@ -138,6 +138,12 @@ impl<T> GILOnceCell<T> {
 ///    dict.set_item(intern!(py, "foo"), 42)?;
 ///    Ok(dict)
 /// }
+/// #
+/// # Python::with_gil(|py| {
+/// #     let fun = wrap_pyfunction!(create_dict_faster, py).unwrap();
+/// #     let dict = fun.call0().unwrap();
+/// #     assert!(dict.contains("foo").unwrap());
+/// # });
 /// ```
 #[macro_export]
 macro_rules! intern {

--- a/src/test_hygiene/misc.rs
+++ b/src/test_hygiene/misc.rs
@@ -27,3 +27,9 @@ enum Derive4 {
 
 crate::create_exception!(mymodule, CustomError, crate::exceptions::PyException);
 crate::import_exception!(socket, gaierror);
+
+#[allow(dead_code)]
+fn intern(py: crate::Python<'_>) {
+    let _foo = crate::intern!(py, "foo");
+    let _bar = crate::intern!(py, stringify!(bar));
+}


### PR DESCRIPTION
Basically turns the proposed solution of https://github.com/PyO3/pyo3/discussions/2266 into a discoverable/reusable macro.

I think this should be mentioned in the guide to actually be discoverable, but I am not sure where.

Closes #2223 