### PR TITLE
Make use of intern! macro for attribute names used internally

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -534,6 +534,25 @@ impl<T> Py<T> {
     /// Retrieves an attribute value.
     ///
     /// This is equivalent to the Python expression `self.attr_name`.
+    ///
+    /// If calling this method becomes performance-critical, the [`intern!`] macro can be used
+    /// to intern `attr_name`, thereby avoiding repeated temporary allocations of Python strings.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, IntoPy, Py, Python, PyObject, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn version(sys: Py<PyModule>, py: Python<'_>) -> PyResult<PyObject> {
+    ///     sys.getattr(py, intern!(py, "version"))
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let sys = py.import("sys").unwrap().into_py(py);
+    /// #    version(sys, py).unwrap();
+    /// # });
+    /// ```
     pub fn getattr<N>(&self, py: Python<'_>, attr_name: N) -> PyResult<PyObject>
     where
         N: ToPyObject,
@@ -546,6 +565,25 @@ impl<T> Py<T> {
     /// Sets an attribute value.
     ///
     /// This is equivalent to the Python expression `self.attr_name = value`.
+    ///
+    /// If calling this method becomes performance-critical, the [`intern!`] macro can be used
+    /// to intern `attr_name`, thereby avoiding repeated temporary allocations of Python strings.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, IntoPy, PyObject, Python, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn set_answer(ob: PyObject, py: Python<'_>) -> PyResult<()> {
+    ///     ob.setattr(py, intern!(py, "answer"), 42)
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let ob = PyModule::new(py, "empty").unwrap().into_py(py);
+    /// #    set_answer(ob, py).unwrap();
+    /// # });
+    /// ```
     pub fn setattr<N, V>(&self, py: Python<'_>, attr_name: N, value: V) -> PyResult<()>
     where
         N: ToPyObject,

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -111,6 +111,25 @@ impl PyAny {
     /// Retrieves an attribute value.
     ///
     /// This is equivalent to the Python expression `self.attr_name`.
+    ///
+    /// If calling this method becomes performance-critical, the [`intern!`] macro can be used
+    /// to intern `attr_name`, thereby avoiding repeated temporary allocations of Python strings.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, PyAny, Python, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn version(sys: &PyModule) -> PyResult<&PyAny> {
+    ///     sys.getattr(intern!(sys.py(), "version"))
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let sys = py.import("sys").unwrap();
+    /// #    version(sys).unwrap();
+    /// # });
+    /// ```
     pub fn getattr<N>(&self, attr_name: N) -> PyResult<&PyAny>
     where
         N: ToPyObject,
@@ -124,6 +143,25 @@ impl PyAny {
     /// Sets an attribute value.
     ///
     /// This is equivalent to the Python expression `self.attr_name = value`.
+    ///
+    /// If calling this method becomes performance-critical, the [`intern!`] macro can be used
+    /// to intern `attr_name`, thereby avoiding repeated temporary allocations of Python strings.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, PyAny, Python, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn set_answer(ob: &PyAny) -> PyResult<()> {
+    ///     ob.setattr(intern!(ob.py(), "answer"), 42)
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let ob = PyModule::new(py, "empty").unwrap();
+    /// #    set_answer(ob).unwrap();
+    /// # });
+    /// ```
     pub fn setattr<N, V>(&self, attr_name: N, value: V) -> PyResult<()>
     where
         N: ToBorrowedObject,

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -37,7 +37,7 @@ impl PyType {
 
     /// Gets the name of the `PyType`.
     pub fn name(&self) -> PyResult<&str> {
-        self.getattr("__qualname__")?.extract()
+        self.getattr(intern!(self.py(), "__qualname__"))?.extract()
     }
 
     /// Checks whether `self` is a subclass of `other`.


### PR DESCRIPTION
Since we do use several attribute names internally, I looked into whether some of them could be candidates for interning. Personally, I do not think this is obvious as while identifiers like `__name__` will most likely already be part of Python's string interner dictionary, they do not seem to be used in a hot path of PyO3.

I therefore split this into separate commits to solicit feedback on whether we want to include any of them:
1. `__qualname__` used in `PyType::name`. Here, I am not sure how often production code using PyO3 actually calls this.
2. `__all__` and `__name__` used in the implementation of `PyModule`. This seems to be limited to initialization, but the strings are almost surely interned already by other code.
3. The the attribute names used in `getattr` calls emitted by the `FromPyObject` derive macro. I think this has the largest possible benefit as this could end up being used in every Python-to-Rust call. But I am also not sure whether enabling this unconditionally is a good idea. (Since the names are given via code and not generated dynamically, this should be ok?)