### PR TITLE
Add benchmark highlighting the costs of failed calls to FromPyObject::extract.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Default to "m" ABI tag when choosing `libpython` link name for CPython 3.7 on Unix. [#2288](https://github.com/PyO3/pyo3/pull/2288)
+- Improved performance of failing calls to `FromPyObject::extract` which is common when functions accept multiple distinct types. [#2279](https://github.com/PyO3/pyo3/pull/2279)
 
 ## [0.16.3] - 2022-04-05
 

--- a/benches/bench_frompyobject.rs
+++ b/benches/bench_frompyobject.rs
@@ -1,6 +1,9 @@
-use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 
-use pyo3::{prelude::*, types::PyString};
+use pyo3::{
+    prelude::*,
+    types::{PyList, PyString},
+};
 
 #[derive(FromPyObject)]
 enum ManyTypes {
@@ -18,8 +21,71 @@ fn enum_from_pyobject(b: &mut Bencher<'_>) {
     })
 }
 
+fn list_via_cast_as(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let any: &PyAny = PyList::empty(py).into();
+
+        b.iter(|| {
+            let _list: &PyList = black_box(any).cast_as().unwrap();
+        });
+    })
+}
+
+fn list_via_extract(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let any: &PyAny = PyList::empty(py).into();
+
+        b.iter(|| {
+            let _list: &PyList = black_box(any).extract().unwrap();
+        });
+    })
+}
+
+fn not_a_list_via_cast_as(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let any: &PyAny = PyString::new(py, "foobar").into();
+
+        b.iter(|| {
+            black_box(any).cast_as::<PyList>().unwrap_err();
+        });
+    })
+}
+
+fn not_a_list_via_extract(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let any: &PyAny = PyString::new(py, "foobar").into();
+
+        b.iter(|| {
+            black_box(any).extract::<&PyList>().unwrap_err();
+        });
+    })
+}
+
+#[derive(FromPyObject)]
+enum ListOrNotList<'a> {
+    List(&'a PyList),
+    NotList(&'a PyAny),
+}
+
+fn not_a_list_via_extract_enum(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let any: &PyAny = PyString::new(py, "foobar").into();
+
+        b.iter(|| match black_box(any).extract::<ListOrNotList<'_>>() {
+            Ok(ListOrNotList::List(_list)) => panic!(),
+            Ok(ListOrNotList::NotList(_any)) => (),
+            Err(_) => panic!(),
+        });
+    })
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("enum_from_pyobject", enum_from_pyobject);
+    c.bench_function("list_via_cast_as", list_via_cast_as);
+    c.bench_function("list_via_extract", list_via_extract);
+    c.bench_function("not_a_list_via_cast_as", not_a_list_via_cast_as);
+    c.bench_function("not_a_list_via_extract", not_a_list_via_extract);
+    c.bench_function("not_a_list_via_extract_enum", not_a_list_via_extract_enum);
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
This was brought up in #2278 and probably affects quite a bit of code that does a case-by-case analysis of argument types:

```
enum_from_pyobject      time:   [644.87 ns 648.64 ns 653.16 ns]                                
list_via_cast_as        time:   [3.4474 ns 3.4668 ns 3.4808 ns]                              
list_via_extract        time:   [4.3715 ns 4.3785 ns 4.3896 ns]                              
not_a_list_via_cast_as  time:   [3.4952 ns 3.5034 ns 3.5094 ns]                                    
not_a_list_via_extract  time:   [284.42 ns 284.79 ns 285.12 ns]                                   
not_a_list_via_extract_enum                                                                            
                        time:   [289.56 ns 289.78 ns 289.98 ns]
```

The overhead itself mostly comes from this

```rust
/// Convert `PyDowncastError` to Python `TypeError`.
impl<'a> std::convert::From<PyDowncastError<'a>> for PyErr {
    fn from(err: PyDowncastError<'_>) -> PyErr {
        exceptions::PyTypeError::new_err(err.to_string())
    }
}
```

conversion.

I find it especially troubling that the rather nice way of using an enum is also affected.