### PR TITLE
pyo3-build-config: Add `python3-dll-a` crate support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,17 +272,17 @@ jobs:
           args: --release -i python3.9 --no-sdist -m examples/maturin-starter/Cargo.toml
 
       - name: Test cross compile to Windows
-        if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+        if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
         run: |
           sudo apt-get install -y mingw-w64
           rustup target add x86_64-pc-windows-gnu
           cargo build --manifest-path examples/maturin-starter/Cargo.toml --features abi3 --target x86_64-pc-windows-gnu
       - name: Test cross compile to Windows with maturin
-        if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+        if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
         uses: messense/maturin-action@v1
         with:
           target: x86_64-pc-windows-gnu
-          args: --no-sdist -m examples/maturin-starter/Cargo.toml --cargo-extra-args="--features abi3"
+          args: -i python3.8 --no-sdist -m examples/maturin-starter/Cargo.toml --cargo-extra-args="--features abi3"
 
     env:
       CARGO_TERM_VERBOSE: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,12 +274,13 @@ jobs:
       - name: Test cross compile to Windows
         if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
         env:
-          CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: rust-lld
+          XWIN_ARCH: x86_64
         run: |
           sudo apt-get install -y mingw-w64 llvm
           rustup target add x86_64-pc-windows-gnu x86_64-pc-windows-msvc
+          which cargo-xwin > /dev/null || cargo install cargo-xwin
           cargo build --manifest-path examples/maturin-starter/Cargo.toml --features abi3 --target x86_64-pc-windows-gnu
-          cargo build --manifest-path examples/maturin-starter/Cargo.toml --features abi3 --target x86_64-pc-windows-msvc
+          cargo xwin build --manifest-path examples/maturin-starter/Cargo.toml --features abi3 --target x86_64-pc-windows-msvc
       - name: Test cross compile to Windows with maturin
         if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
         uses: messense/maturin-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,10 +273,13 @@ jobs:
 
       - name: Test cross compile to Windows
         if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
+        env:
+          CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: rust-lld
         run: |
-          sudo apt-get install -y mingw-w64
-          rustup target add x86_64-pc-windows-gnu
+          sudo apt-get install -y mingw-w64 llvm
+          rustup target add x86_64-pc-windows-gnu x86_64-pc-windows-msvc
           cargo build --manifest-path examples/maturin-starter/Cargo.toml --features abi3 --target x86_64-pc-windows-gnu
+          cargo build --manifest-path examples/maturin-starter/Cargo.toml --features abi3 --target x86_64-pc-windows-msvc
       - name: Test cross compile to Windows with maturin
         if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
         uses: messense/maturin-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,19 @@ jobs:
           target: aarch64-apple-darwin
           args: --release -i python3.9 --no-sdist -m examples/maturin-starter/Cargo.toml
 
+      - name: Test cross compile to Windows
+        if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+        run: |
+          sudo apt-get install -y mingw-w64
+          rustup target add x86_64-pc-windows-gnu
+          cargo build --manifest-path examples/maturin-starter/Cargo.toml --features abi3 --target x86_64-pc-windows-gnu
+      - name: Test cross compile to Windows with maturin
+        if: ${{ matrix.platform.os == 'ubuntu-latest' && matrix.python-version == '3.10' }}
+        uses: messense/maturin-action@v1
+        with:
+          target: x86_64-pc-windows-gnu
+          args: --no-sdist -m examples/maturin-starter/Cargo.toml --cargo-extra-args="--features abi3"
+
     env:
       CARGO_TERM_VERBOSE: true
       CARGO_BUILD_TARGET: ${{ matrix.platform.rust-target }}

--- a/Architecture.md
+++ b/Architecture.md
@@ -189,13 +189,19 @@ Some of the functionality of `pyo3-build-config`:
     See [#1123](https://github.com/PyO3/pyo3/pull/1123).
 - Cross-compiling configuration
   - If `TARGET` architecture and `HOST` architecture differ, we can find cross compile information
-    from environment variables (`PYO3_CROSS_LIB_DIR` and `PYO3_CROSS_PYTHON_VERSION`) or system files.
+    from environment variables (`PYO3_CROSS_LIB_DIR`, `PYO3_CROSS_PYTHON_VERSION` and
+    `PYO3_CROSS_PYTHON_IMPLEMENTATION`) or system files.
     When cross compiling extension modules it is often possible to make it work without any
     additional user input.
+  - When an experimental feature `generate-abi3-import-lib` is enabled, the `pyo3-ffi` build script can
+    generate `python3.dll` import libraries for Windows targets automatically via an external
+    [`python3-dll-a`] crate. This enables the users to cross compile abi3 extensions for Windows without
+    having to install any Windows Python libraries.
 
 <!-- External Links -->
 
 [python/c api]: https://docs.python.org/3/c-api/
+[`python3-dll-a`]: https://docs.rs/python3-dll-a/latest/python3_dll_a/
 
 <!-- Crates -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add an experimental `generate-abi3-import-lib` feature to auto-generate `python3.dll` import libraries for Windows. [#2282](https://github.com/PyO3/pyo3/pull/2282)
+
 ### Changed
 
 - Default to "m" ABI tag when choosing `libpython` link name for CPython 3.7 on Unix. [#2288](https://github.com/PyO3/pyo3/pull/2288)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ abi3-py38 = ["abi3-py39", "pyo3-build-config/abi3-py38", "pyo3-ffi/abi3-py38"]
 abi3-py39 = ["abi3-py310", "pyo3-build-config/abi3-py39", "pyo3-ffi/abi3-py39"]
 abi3-py310 = ["abi3", "pyo3-build-config/abi3-py310", "pyo3-ffi/abi3-py310"]
 
+# Automatically generates `python3.dll` import libraries for Windows targets.
+generate-abi3-import-lib = ["pyo3-build-config/python3-dll-a"]
+
 # Changes `Python::with_gil` and `Python::acquire_gil` to automatically initialize the
 # Python interpreter if needed.
 auto-initialize = []

--- a/examples/maturin-starter/Cargo.toml
+++ b/examples/maturin-starter/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 pyo3 = { path = "../../", features = ["extension-module"] }
 
 [features]
-abi3 = ["pyo3/abi3-py37"]
+abi3 = ["pyo3/abi3-py37", "pyo3/generate-abi3-import-lib"]
 
 [workspace]

--- a/examples/maturin-starter/Cargo.toml
+++ b/examples/maturin-starter/Cargo.toml
@@ -10,4 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { path = "../../", features = ["extension-module"] }
 
+[features]
+abi3 = ["pyo3/abi3-py37"]
+
 [workspace]

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -30,6 +30,17 @@ These features are extensions of the `abi3` feature to specify the exact minimum
 
 See the [building and distribution](building_and_distribution.md#minimum-python-version-for-abi3) section for further detail.
 
+### `generate-abi3-import-lib`
+
+This experimental feature is used to generate import libraries for the Stable ABI Python DLL
+for MinGW-w64 and MSVC (cross-)compile targets.
+
+Enabling it allows to (cross-)compile `abi3` extension modules to any Windows targets
+without having to install the Windows Python distribution files for the target.
+
+See the [building and distribution](building_and_distribution.md#building-abi3-extensions-without-a-python-interpreter)
+section for further detail.
+
 ## Features for embedding Python in Rust
 
 ### `auto-initialize`

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -12,9 +12,11 @@ edition = "2018"
 
 [dependencies]
 once_cell = "1"
+python3-dll-a = { version = "0.2", optional = true }
 target-lexicon = "0.12"
 
 [build-dependencies]
+python3-dll-a = { version = "0.2", optional = true }
 target-lexicon = "0.12"
 
 [features]

--- a/pyo3-build-config/src/abi3_import_lib.rs
+++ b/pyo3-build-config/src/abi3_import_lib.rs
@@ -1,0 +1,48 @@
+//! Optional `python3.dll` import library generator for Windows
+
+use std::env;
+use std::path::PathBuf;
+
+use python3_dll_a::generate_implib_for_target;
+
+use crate::errors::{Context, Result};
+
+use super::{Architecture, OperatingSystem, Triple};
+
+/// Generates the `python3.dll` import library for Windows targets.
+///
+/// Places the generated import library into the build script output directory
+/// and returns the full library directory path.
+///
+/// Does nothing if the target OS is not Windows.
+pub(super) fn generate_abi3_import_lib(target: &Triple) -> Result<Option<String>> {
+    if target.operating_system != OperatingSystem::Windows {
+        return Ok(None);
+    }
+
+    let out_dir = env::var_os("OUT_DIR")
+        .expect("generate_abi3_import_lib() must be called from a build script");
+
+    // Put the newly created import library into the build script output directory.
+    let mut out_lib_dir = PathBuf::from(out_dir);
+    out_lib_dir.push("lib");
+
+    // Convert `Architecture` enum to rustc `target_arch` option format.
+    let arch = match target.architecture {
+        // i686, i586, etc.
+        Architecture::X86_32(_) => "x86".to_string(),
+        other => other.to_string(),
+    };
+
+    let env = target.environment.to_string();
+
+    generate_implib_for_target(&out_lib_dir, &arch, &env)
+        .context("failed to generate python3.dll import library")?;
+
+    let out_lib_dir_string = out_lib_dir
+        .to_str()
+        .ok_or("build directory is not a valid UTF-8 string")?
+        .to_owned();
+
+    Ok(Some(out_lib_dir_string))
+}


### PR DESCRIPTION
Automatically generate `python3.dll` import libraries
for Windows compile targets in the build script.

Adds a new PyO3 crate feature `auto-abi3-import-lib` enabling
automatic import library generation.

Closes #2231

WIP: The documentation is still a TODO