### PR TITLE
refactor: remove all 0.15 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing `warn_default_encoding` field to `PyConfig` on 3.10+. The previously missing field could result in incorrect behavior or crashes. [#2370](https://github.com/PyO3/pyo3/pull/2370)
 - Fixed order of `pathconfig_warnings` and `program_name` fields of `PyConfig` on 3.10+. Previously, the order of the fields was swapped and this could lead to incorrect behavior or crashes. [#2370](https://github.com/PyO3/pyo3/pull/2370)
 
+### Removed
+
+- Remove all functionality deprecated in PyO3 0.15. [#2283](https://github.com/PyO3/pyo3/pull/2283)
+
 ## [0.16.4] - 2022-04-14
 
 ### Added

--- a/pyo3-macros-backend/src/deprecations.rs
+++ b/pyo3-macros-backend/src/deprecations.rs
@@ -2,14 +2,12 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
 
 pub enum Deprecation {
-    CallAttribute,
     PyClassGcOption,
 }
 
 impl Deprecation {
     fn ident(&self, span: Span) -> syn::Ident {
         let string = match self {
-            Deprecation::CallAttribute => "CALL_ATTRIBUTE",
             Deprecation::PyClassGcOption => "PYCLASS_GC_OPTION",
         };
         syn::Ident::new(string, span)

--- a/src/impl_/deprecations.rs
+++ b/src/impl_/deprecations.rs
@@ -1,8 +1,5 @@
 //! Symbols used to denote deprecated usages of PyO3's proc macros.
 
-#[deprecated(since = "0.15.0", note = "use `fn __call__` instead of `#[call]`")]
-pub const CALL_ATTRIBUTE: () = ();
-
 #[deprecated(
     since = "0.16.0",
     note = "implement a `__traverse__` `#[pymethod]` instead of using `gc` option"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,18 +390,6 @@ mod version;
 
 pub use crate::conversions::*;
 
-#[doc(hidden)]
-#[deprecated(
-    since = "0.15.0",
-    note = "please import this with `use pyo3::...` or from the prelude instead"
-)]
-#[cfg(feature = "macros")]
-pub mod proc_macro {
-    #[cfg(feature = "pyproto")]
-    pub use pyo3_macros::pyproto;
-    pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule};
-}
-
 #[cfg(all(feature = "macros", feature = "pyproto"))]
 pub use pyo3_macros::pyproto;
 #[cfg(feature = "macros")]

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -136,34 +136,6 @@ impl PyTuple {
         }
     }
 
-    #[deprecated(since = "0.15.0", note = "use self.get_slice instead")]
-    /// Takes the slice `self[low:high]` and returns it as a new tuple.
-    ///
-    /// Indices must be nonnegative, and out-of-range indices are clipped to
-    /// `self.len()`.
-    pub fn slice(&self, low: isize, high: isize) -> &PyTuple {
-        unsafe {
-            self.py()
-                .from_owned_ptr(ffi::PyTuple_GetSlice(self.as_ptr(), low, high))
-        }
-    }
-
-    #[deprecated(
-        since = "0.15.0",
-        note = "use tuple.get_slice(low, tuple.len()) instead"
-    )]
-    /// Takes a slice of the tuple from `low` to the end and returns it as a new tuple.
-    pub fn split_from(&self, low: usize) -> &PyTuple {
-        unsafe {
-            let ptr = ffi::PyTuple_GetSlice(
-                self.as_ptr(),
-                get_ssize_index(low),
-                self.len() as Py_ssize_t,
-            );
-            self.py().from_owned_ptr(ptr)
-        }
-    }
-
     /// Gets the tuple item at the specified index.
     /// # Example
     /// ```

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "macros")]
 
-#[rustversion::stable]
+#[rustversion::not(nightly)]
 #[cfg(not(target_arch = "wasm32"))] // Not possible to invoke compiler from wasm
 #[test]
 fn test_compile_errors() {

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -417,32 +417,6 @@ fn callable() {
     py_assert!(py, nc, "not callable(nc)");
 }
 
-#[allow(deprecated)]
-mod deprecated {
-    use super::*;
-
-    #[pyclass]
-    struct Callable;
-
-    #[pymethods]
-    impl Callable {
-        #[__call__]
-        fn __call__(&self, arg: i32) -> i32 {
-            arg * 6
-        }
-    }
-
-    #[test]
-    fn callable() {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-
-        let c = Py::new(py, Callable).unwrap();
-        py_assert!(py, c, "callable(c)");
-        py_assert!(py, c, "c(7) == 42");
-    }
-}
-
 #[pyclass]
 #[derive(Debug)]
 struct SetItem {

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -2,15 +2,6 @@
 
 use pyo3::prelude::*;
 
-#[pyclass]
-struct DeprecatedCall;
-
-#[pymethods]
-impl DeprecatedCall {
-    #[call]
-    fn deprecated_call(&self) {}
-}
-
 #[pyclass(gc)]
 struct DeprecatedGc;
 

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -1,17 +1,11 @@
-error: use of deprecated constant `pyo3::impl_::deprecations::CALL_ATTRIBUTE`: use `fn __call__` instead of `#[call]`
-  --> tests/ui/deprecations.rs:10:7
-   |
-10 |     #[call]
-   |       ^^^^
-   |
-note: the lint level is defined here
-  --> tests/ui/deprecations.rs:1:9
-   |
-1  | #![deny(deprecated)]
-   |         ^^^^^^^^^^
-
 error: use of deprecated constant `pyo3::impl_::deprecations::PYCLASS_GC_OPTION`: implement a `__traverse__` `#[pymethod]` instead of using `gc` option
-  --> tests/ui/deprecations.rs:14:11
-   |
-14 | #[pyclass(gc)]
-   |           ^^
+ --> tests/ui/deprecations.rs:5:11
+  |
+5 | #[pyclass(gc)]
+  |           ^^
+  |
+note: the lint level is defined here
+ --> tests/ui/deprecations.rs:1:9
+  |
+1 | #![deny(deprecated)]
+  |         ^^^^^^^^^^


### PR DESCRIPTION
For when we're ready to merge other breaking changes.