### PR TITLE
Gather test coverage with stable rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
         continue-on-error: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
           profile: minimal
           components: llvm-tools-preview

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
     ),
     allow(unused_variables, unused_assignments)
 )))]
-#![cfg_attr(coverage, feature(no_coverage))] // used in src/test_hygiene.rs
 
 //! Rust bindings to the Python interpreter.
 //!

--- a/src/test_hygiene/mod.rs
+++ b/src/test_hygiene/mod.rs
@@ -1,9 +1,6 @@
 // The modules in this test are used to check PyO3 macro expansion is hygienic. By locating the test
 // inside the crate the global `::pyo3` namespace is not available, so in combination with
 // #[pyo3(crate = "crate")] this validates that all macro expansion respects the setting.
-//
-// The generated code is never executed (these tests are checking compile time correctness.)
-#![cfg_attr(coverage, no_coverage)]
 
 mod misc;
 mod pyclass;

--- a/xtask/src/llvm_cov.rs
+++ b/xtask/src/llvm_cov.rs
@@ -88,13 +88,5 @@ fn get_coverage_env() -> Result<HashMap<String, String>> {
         env.get("CARGO_LLVM_COV_TARGET_DIR").unwrap().to_owned(),
     );
 
-    // Coverage only works on nightly.
-    let rustc_version =
-        String::from_utf8(get_output(Command::new("rustc").arg("--version"))?.stdout)
-            .context("failed to parse rust version as utf8")?;
-    if !rustc_version.contains("nightly") {
-        env.insert("RUSTUP_TOOLCHAIN".to_owned(), "nightly".to_owned());
-    }
-
     Ok(env)
 }


### PR DESCRIPTION
This will ensure that the test coverage can be determined using the stable rust release.