### PR TITLE
pyo3-build-config: Use "m" ABI tag for libpython 3.7 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Default to "m" ABI tag when choosing `libpython` link name for CPython 3.7 on Unix. [#2288](https://github.com/PyO3/pyo3/pull/2288)
+
 ## [0.16.3] - 2022-04-05
 
 ### Packaging


### PR DESCRIPTION
According to https://bugs.python.org/issue36707, this tag is useless
since version 3.4, but also the default until version 3.8.

For example, Debian 10 ships `libpython3.7m.so`.
