### PR TITLE
ffi: fix segfault in _GET_TZINFO methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Default to "m" ABI tag when choosing `libpython` link name for CPython 3.7 on Unix. [#2288](https://github.com/PyO3/pyo3/pull/2288)
 
+### Fixed
+
+- Fix segfault when calling FFI methods `PyDateTime_DATE_GET_TZINFO` or `PyDateTime_TIME_GET_TZINFO` on `datetime` or `time` without a tzinfo. [#2289](https://github.com/PyO3/pyo3/pull/2289)
+
 ## [0.16.3] - 2022-04-05
 
 ### Packaging

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -155,7 +155,11 @@ macro_rules! _PyDateTime_GET_FOLD {
 #[cfg(not(PyPy))]
 macro_rules! _PyDateTime_GET_TZINFO {
     ($o: expr) => {
-        (*$o).tzinfo
+        if (*$o).hastzinfo != 0 {
+            (*$o).tzinfo
+        } else {
+            $crate::Py_None()
+        }
     };
 }
 


### PR DESCRIPTION
Looks like datetime types without `tzinfo` set will not have space allocated for the null pointer, so we should check `has_tzinfo` before trying to read it.