### PR TITLE
pyo3-build-config: Build "abi3" extensions without an interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow to compile "abi3" extensions without a working build host Python interpreter. [#2293](https://github.com/PyO3/pyo3/pull/2293)
 - Default to "m" ABI tag when choosing `libpython` link name for CPython 3.7 on Unix. [#2288](https://github.com/PyO3/pyo3/pull/2288)
 - Improved performance of failing calls to `FromPyObject::extract` which is common when functions accept multiple distinct types. [#2279](https://github.com/PyO3/pyo3/pull/2279)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ pyproto = ["pyo3-macros/pyproto"]
 # Use this feature when building an extension module.
 # It tells the linker to keep the python symbols unresolved,
 # so that the module can also be used with statically linked python interpreters.
-extension-module = ["pyo3-ffi/extension-module"]
+extension-module = ["pyo3-build-config/extension-module", "pyo3-ffi/extension-module"]
 
 # Use the Python limited API. See https://www.python.org/dev/peps/pep-0384/ for more.
 abi3 = ["pyo3-build-config/abi3", "pyo3-ffi/abi3", "pyo3-macros/abi3"]

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -157,6 +157,8 @@ PyO3 is only able to link your extension module to api3 version up to and includ
 #### Building `abi3` extensions without a Python interpreter
 
 As an advanced feature, you can build PyO3 wheel without calling Python interpreter with the environment variable `PYO3_NO_PYTHON` set.
+Also, if the build host Python interpreter is not found or is too old or otherwise unusable,
+PyO3 will still attempt to compile `abi3` extension modules after displaying a warning message.
 On Unix-like systems this works unconditionally; on Windows you must also set the `RUSTFLAGS` environment variable
 to contain `-L native=/path/to/python/libs` so that the linker can find `python3.lib`.
 

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -26,6 +26,10 @@ default = []
 # script. If this feature isn't enabled, the build script no-ops.
 resolve-config = []
 
+# This feature is enabled by pyo3 when building an extension module.
+extension-module = []
+
+# These features are enabled by pyo3 when building Stable ABI extension modules.
 abi3 = []
 abi3-py37 = ["abi3-py38"]
 abi3-py38 = ["abi3-py39"]


### PR DESCRIPTION
Ignore the build host Python interpreter configuration when
compiling portable "abi3" extension modules.
Such extensions should not depend on a concrete Python version
or build configuration by design.

Maturin already does this when building "abi3" extension wheels
by defining `PYO3_NO_PYTHON=1` for Cargo when an `abi3-py3*`
feature is detected.

Closes #2292
