### PR TITLE
build: add hint when PYO3_PRINT_CONFIG is set

### DIFF
--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -111,6 +111,7 @@ fn print_config_and_exit(config: &InterpreterConfig) {
     config
         .to_writer(&mut std::io::stdout())
         .expect("failed to print config to stdout");
+    println!("\nnote: unset the PYO3_PRINT_CONFIG environment variable and retry to compile with the above config");
     std::process::exit(101);
 }
 


### PR DESCRIPTION
Sometimes when users have used `PYO3_PRINT_CONFIG` to help us diagnose issues they've seemed to miss the point that it needs to be unset again to continue with compiling, so this just adds a little note.

Sample output on my laptop:

```
   Compiling pyo3-ffi v0.16.3 (/Users/david/Dev/pyo3/pyo3-ffi)
error: failed to run custom build command for `pyo3-ffi v0.16.3 (/Users/david/Dev/pyo3/pyo3-ffi)`

Caused by:
  process didn't exit successfully: `/Users/david/Dev/pyo3/target/debug/build/pyo3-ffi-bc4736f64f1457ce/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=PYO3_CROSS
  cargo:rerun-if-env-changed=PYO3_CROSS_LIB_DIR
  cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_VERSION
  cargo:rerun-if-env-changed=PYO3_CROSS_PYTHON_IMPLEMENTATION
  cargo:rerun-if-env-changed=PYO3_PRINT_CONFIG

  -- PYO3_PRINT_CONFIG=1 is set, printing configuration and halting compile --
  implementation=CPython
  version=3.10
  shared=true
  abi3=false
  lib_name=python3.10
  lib_dir=/opt/homebrew/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/lib
  executable=/opt/homebrew/opt/python@3.10/bin/python3.10
  pointer_width=64
  build_flags=
  suppress_build_script_link_lines=false

  note: unset the PYO3_PRINT_CONFIG environment variable and retry to compile with the above config
```