### PR TITLE
noxfile: sort authors case-insensitively

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -124,7 +124,7 @@ def contributors(session: nox.Session) -> None:
         else:
             break
 
-    authors = sorted(list(authors))
+    authors = sorted(list(authors), key=lambda author: author.lower())
 
     for author in authors:
         print(f"@{author}")


### PR DESCRIPTION
I've typically sorted contributors case-insensitively in release notes; just tweaking the noxfile to match this.