### PR TITLE
Add `workflow_dispatch` trigger event to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}


### PR DESCRIPTION
A handy feature to verify whether something is still working or also broken on main, for example https://github.com/PyO3/pyo3/pull/2309#issuecomment-1100612469.

https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/