### PR TITLE
Implement ToPyObject for [T; N]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Implement `ToPyObject` for `[T; N]`. [#2313](https://github.com/PyO3/pyo3/pull/2313)
+
 ## [0.16.4] - 2022-04-14
 
 ### Added


### PR DESCRIPTION
It seems like this was forgotten to implement (unless there was a good reason not to implement this, which I did not find in my quick search).

Related: fusion-engineering/inline-python#51