### PR TITLE
Add new trait IntoPyObject

### DIFF
--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -737,6 +737,13 @@ impl<'a> PyClassImplsBuilder<'a> {
                         _pyo3::IntoPy::into_py(_pyo3::Py::new(py, self).unwrap(), py)
                     }
                 }
+
+                impl _pyo3::IntoPyObject for #cls {
+                    type Target = #cls;
+                    fn into_py(self, py: _pyo3::Python) -> _pyo3::Py<#cls> {
+                        _pyo3::Py::new(py, self).unwrap()
+                    }
+                }
             }
         } else {
             quote! {}

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -6,8 +6,8 @@ use crate::err::{PyErr, PyResult};
 use crate::exceptions::PyOverflowError;
 use crate::ffi::{self, Py_hash_t};
 use crate::panic::PanicException;
-use crate::{GILPool, IntoPyPointer};
-use crate::{IntoPy, PyObject, Python};
+use crate::{GILPool, IntoPyObject, IntoPyPointer};
+use crate::{PyObject, Python};
 use std::any::Any;
 use std::os::raw::c_int;
 use std::panic::UnwindSafe;
@@ -53,7 +53,7 @@ where
 
 impl<T> IntoPyCallbackOutput<*mut ffi::PyObject> for T
 where
-    T: IntoPy<PyObject>,
+    T: IntoPyObject,
 {
     #[inline]
     fn convert(self, py: Python<'_>) -> PyResult<*mut ffi::PyObject> {
@@ -118,11 +118,11 @@ impl IntoPyCallbackOutput<usize> for usize {
 
 impl<T> IntoPyCallbackOutput<PyObject> for T
 where
-    T: IntoPy<PyObject>,
+    T: IntoPyObject,
 {
     #[inline]
     fn convert(self, py: Python<'_>) -> PyResult<PyObject> {
-        Ok(self.into_py(py))
+        Ok(self.into_object(py))
     }
 }
 

--- a/src/conversions/array.rs
+++ b/src/conversions/array.rs
@@ -3,14 +3,27 @@ use crate::{exceptions, PyErr};
 #[cfg(min_const_generics)]
 mod min_const_generics {
     use super::invalid_sequence_length;
-    use crate::{FromPyObject, IntoPy, PyAny, PyObject, PyResult, PyTryFrom, Python, ToPyObject};
+    use crate::{
+        types::PyList, FromPyObject, IntoPyObject, Py, PyAny, PyObject, PyResult, PyTryFrom,
+        Python, ToPyObject,
+    };
 
-    impl<T, const N: usize> IntoPy<PyObject> for [T; N]
+    impl<T, const N: usize> crate::IntoPy<PyObject> for [T; N]
     where
         T: ToPyObject,
     {
         fn into_py(self, py: Python<'_>) -> PyObject {
             self.as_ref().to_object(py)
+        }
+    }
+
+    impl<T, const N: usize> IntoPyObject for [T; N]
+    where
+        T: ToPyObject,
+    {
+        type Target = PyList;
+        fn into_py(self, py: Python<'_>) -> Py<PyList> {
+            PyList::new(py, self.as_ref()).into()
         }
     }
 

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -52,6 +52,22 @@ where
     }
 }
 
+impl<K, V, H> IntoPyObject for hashbrown::HashMap<K, V, H>
+where
+    K: hash::Hash + cmp::Eq + IntoPyObject,
+    V: IntoPyObject,
+    H: hash::BuildHasher,
+{
+    type Target = PyDict;
+
+    fn into_py(self, py: Python<'_>) -> Py<PyDict> {
+        let iter = self
+            .into_iter()
+            .map(|(k, v)| (k.into_py(py), v.into_py(py)));
+        IntoPyDict::into_py_dict(iter, py)
+    }
+}
+
 impl<'source, K, V, S> FromPyObject<'source> for hashbrown::HashMap<K, V, S>
 where
     K: FromPyObject<'source> + cmp::Eq + hash::Hash,

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -121,6 +121,21 @@ where
     }
 }
 
+impl<K, V, H> IntoPyObject for indexmap::IndexMap<K, V, H>
+where
+    K: hash::Hash + cmp::Eq + IntoPyObject,
+    V: IntoPyObject,
+    H: hash::BuildHasher,
+{
+    type Target = PyDict;
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        let iter = self
+            .into_iter()
+            .map(|(k, v)| (k.into_py(py), v.into_py(py)));
+        IntoPyDict::into_py_dict(iter, py).into()
+    }
+}
+
 impl<'source, K, V, S> FromPyObject<'source> for indexmap::IndexMap<K, V, S>
 where
     K: FromPyObject<'source> + cmp::Eq + hash::Hash,

--- a/src/conversions/path.rs
+++ b/src/conversions/path.rs
@@ -1,5 +1,5 @@
-use crate::types::PyType;
-use crate::{FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
+use crate::types::{PyString, PyType};
+use crate::{FromPyObject, IntoPyObject, Py, PyAny, PyObject, PyResult, Python, ToPyObject};
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -32,10 +32,18 @@ impl FromPyObject<'_> for PathBuf {
     }
 }
 
-impl<'a> IntoPy<PyObject> for &'a Path {
+impl<'a> crate::IntoPy<PyObject> for &'a Path {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.as_os_str().to_object(py)
+    }
+}
+
+impl<'a> IntoPyObject for &'a Path {
+    type Target = PyString;
+    #[inline]
+    fn into_py(self, py: Python<'_>) -> Py<PyString> {
+        self.as_os_str().into_py(py)
     }
 }
 
@@ -46,10 +54,18 @@ impl<'a> ToPyObject for Cow<'a, Path> {
     }
 }
 
-impl<'a> IntoPy<PyObject> for Cow<'a, Path> {
+impl<'a> crate::IntoPy<PyObject> for Cow<'a, Path> {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.to_object(py)
+    }
+}
+
+impl<'a> IntoPyObject for Cow<'a, Path> {
+    type Target = PyString;
+    #[inline]
+    fn into_py(self, py: Python<'_>) -> Py<PyString> {
+        (*self).into_py(py)
     }
 }
 
@@ -60,15 +76,29 @@ impl ToPyObject for PathBuf {
     }
 }
 
-impl IntoPy<PyObject> for PathBuf {
+impl crate::IntoPy<PyObject> for PathBuf {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_os_string().to_object(py)
     }
 }
 
-impl<'a> IntoPy<PyObject> for &'a PathBuf {
+impl IntoPyObject for PathBuf {
+    type Target = PyString;
+    fn into_py(self, py: Python<'_>) -> Py<PyString> {
+        self.into_os_string().into_py(py)
+    }
+}
+
+impl<'a> crate::IntoPy<PyObject> for &'a PathBuf {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.as_os_str().to_object(py)
+    }
+}
+
+impl<'a> IntoPyObject for &'a PathBuf {
+    type Target = PyString;
+    fn into_py(self, py: Python<'_>) -> Py<PyString> {
+        self.as_os_str().into_py(py)
     }
 }
 

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -3,7 +3,7 @@ use crate::{
     ffi,
     type_object::PyTypeObject,
     types::{PyTraceback, PyType},
-    AsPyPointer, IntoPy, IntoPyPointer, Py, PyObject, Python,
+    AsPyPointer, IntoPyObject, IntoPyPointer, Py, PyObject, Python,
 };
 
 #[derive(Clone)]
@@ -38,10 +38,10 @@ pub trait PyErrArguments: Send + Sync {
 
 impl<T> PyErrArguments for T
 where
-    T: IntoPy<PyObject> + Send + Sync,
+    T: IntoPyObject + Send + Sync,
 {
     fn arguments(self, py: Python<'_>) -> PyObject {
-        self.into_py(py)
+        self.into_object(py)
     }
 }
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -8,7 +8,8 @@ use crate::{
     ffi,
 };
 use crate::{
-    AsPyPointer, IntoPy, IntoPyPointer, Py, PyAny, PyObject, Python, ToBorrowedObject, ToPyObject,
+    AsPyPointer, IntoPy, IntoPyObject, IntoPyPointer, Py, PyAny, PyObject, Python,
+    ToBorrowedObject, ToPyObject,
 };
 use std::borrow::Cow;
 use std::cell::UnsafeCell;
@@ -651,15 +652,29 @@ impl IntoPy<PyObject> for PyErr {
     }
 }
 
+impl IntoPyObject for PyErr {
+    type Target = PyAny;
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        self.into_value(py).into()
+    }
+}
+
 impl ToPyObject for PyErr {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.clone_ref(py).into_py(py)
+        self.clone_ref(py).into_object(py)
     }
 }
 
 impl<'a> IntoPy<PyObject> for &'a PyErr {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.clone_ref(py).into_py(py)
+        self.clone_ref(py).into_object(py)
+    }
+}
+
+impl<'a> IntoPyObject for &'a PyErr {
+    type Target = PyAny;
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        self.clone_ref(py).into_object(py)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,8 +295,8 @@
 //! [`Ungil`]: crate::marker::Ungil
 pub use crate::class::*;
 pub use crate::conversion::{
-    AsPyPointer, FromPyObject, FromPyPointer, IntoPy, IntoPyPointer, PyTryFrom, PyTryInto,
-    ToBorrowedObject, ToPyObject,
+    AsPyPointer, FromPyObject, FromPyPointer, IntoPy, IntoPyObject, IntoPyPointer, PyTryFrom,
+    PyTryInto, ToBorrowedObject, ToPyObject,
 };
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
 #[cfg(not(PyPy))]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,7 +11,7 @@
 //! ```
 
 pub use crate::conversion::{
-    FromPyObject, IntoPy, IntoPyPointer, PyTryFrom, PyTryInto, ToPyObject,
+    FromPyObject, IntoPyObject, IntoPyPointer, PyTryFrom, PyTryInto, ToPyObject,
 };
 pub use crate::err::{PyErr, PyResult};
 pub use crate::gil::GILGuard;

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -184,7 +184,7 @@ use crate::{
     type_object::get_tp_free,
     PyTypeInfo,
 };
-use crate::{ffi, IntoPy, PyErr, PyNativeType, PyObject, PyResult, Python};
+use crate::{ffi, IntoPyObject, Py, PyErr, PyNativeType, PyObject, PyResult, Python};
 use std::cell::{Cell, UnsafeCell};
 use std::fmt;
 use std::mem::ManuallyDrop;
@@ -504,6 +504,13 @@ impl<T: PyClass> ToPyObject for &PyCell<T> {
     }
 }
 
+impl<T: PyClass> IntoPyObject for &PyCell<T> {
+    type Target = T;
+    fn into_py(self, py: Python<'_>) -> Py<T> {
+        unsafe { Py::from_borrowed_ptr(py, self.as_ptr()) }
+    }
+}
+
 impl<T: PyClass> AsRef<PyAny> for PyCell<T> {
     fn as_ref(&self) -> &PyAny {
         unsafe { self.py().from_borrowed_ptr(self.as_ptr()) }
@@ -677,7 +684,14 @@ impl<'p, T: PyClass> Drop for PyRef<'p, T> {
     }
 }
 
-impl<T: PyClass> IntoPy<PyObject> for PyRef<'_, T> {
+impl<T: PyClass> crate::IntoPy<PyObject> for PyRef<'_, T> {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
+    }
+}
+
+impl<T: PyClass> IntoPyObject for PyRef<'_, T> {
+    type Target = PyAny;
     fn into_py(self, py: Python<'_>) -> PyObject {
         unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
     }
@@ -775,7 +789,14 @@ impl<'p, T: PyClass> Drop for PyRefMut<'p, T> {
     }
 }
 
-impl<T: PyClass> IntoPy<PyObject> for PyRefMut<'_, T> {
+impl<T: PyClass> crate::IntoPy<PyObject> for PyRefMut<'_, T> {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
+    }
+}
+
+impl<T: PyClass> IntoPyObject for PyRefMut<'_, T> {
+    type Target = PyAny;
     fn into_py(self, py: Python<'_>) -> PyObject {
         unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
     }

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -7,7 +7,7 @@ use crate::{
         assign_sequence_item_from_mapping, get_sequence_item_from_mapping, tp_dealloc, PyClassDict,
         PyClassImpl, PyClassItems, PyClassWeakRef,
     },
-    IntoPy, IntoPyPointer, PyCell, PyErr, PyMethodDefType, PyNativeType, PyObject, PyResult,
+    IntoPyObject, IntoPyPointer, PyCell, PyErr, PyMethodDefType, PyNativeType, PyObject, PyResult,
     PyTypeInfo, Python,
 };
 use std::{
@@ -495,24 +495,24 @@ impl IntoPyCallbackOutput<*mut ffi::PyObject> for PyIterNextOutput {
 
 impl<T, U> IntoPyCallbackOutput<PyIterNextOutput> for IterNextOutput<T, U>
 where
-    T: IntoPy<PyObject>,
-    U: IntoPy<PyObject>,
+    T: IntoPyObject,
+    U: IntoPyObject,
 {
     fn convert(self, py: Python<'_>) -> PyResult<PyIterNextOutput> {
         match self {
-            IterNextOutput::Yield(o) => Ok(IterNextOutput::Yield(o.into_py(py))),
-            IterNextOutput::Return(o) => Ok(IterNextOutput::Return(o.into_py(py))),
+            IterNextOutput::Yield(o) => Ok(IterNextOutput::Yield(o.into_object(py))),
+            IterNextOutput::Return(o) => Ok(IterNextOutput::Return(o.into_object(py))),
         }
     }
 }
 
 impl<T> IntoPyCallbackOutput<PyIterNextOutput> for Option<T>
 where
-    T: IntoPy<PyObject>,
+    T: IntoPyObject,
 {
     fn convert(self, py: Python<'_>) -> PyResult<PyIterNextOutput> {
         match self {
-            Some(o) => Ok(PyIterNextOutput::Yield(o.into_py(py))),
+            Some(o) => Ok(PyIterNextOutput::Yield(o.into_object(py))),
             None => Ok(PyIterNextOutput::Return(py.None())),
         }
     }
@@ -544,24 +544,24 @@ impl IntoPyCallbackOutput<*mut ffi::PyObject> for PyIterANextOutput {
 
 impl<T, U> IntoPyCallbackOutput<PyIterANextOutput> for IterANextOutput<T, U>
 where
-    T: IntoPy<PyObject>,
-    U: IntoPy<PyObject>,
+    T: IntoPyObject,
+    U: IntoPyObject,
 {
     fn convert(self, py: Python<'_>) -> PyResult<PyIterANextOutput> {
         match self {
-            IterANextOutput::Yield(o) => Ok(IterANextOutput::Yield(o.into_py(py))),
-            IterANextOutput::Return(o) => Ok(IterANextOutput::Return(o.into_py(py))),
+            IterANextOutput::Yield(o) => Ok(IterANextOutput::Yield(o.into_object(py))),
+            IterANextOutput::Return(o) => Ok(IterANextOutput::Return(o.into_object(py))),
         }
     }
 }
 
 impl<T> IntoPyCallbackOutput<PyIterANextOutput> for Option<T>
 where
-    T: IntoPy<PyObject>,
+    T: IntoPyObject,
 {
     fn convert(self, py: Python<'_>) -> PyResult<PyIterANextOutput> {
         match self {
-            Some(o) => Ok(PyIterANextOutput::Yield(o.into_py(py))),
+            Some(o) => Ok(PyIterANextOutput::Yield(o.into_object(py))),
             None => Ok(PyIterANextOutput::Return(py.None())),
         }
     }

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1,12 +1,12 @@
 use crate::class::basic::CompareOp;
 use crate::conversion::{
-    AsPyPointer, FromPyObject, IntoPy, IntoPyPointer, PyTryFrom, ToBorrowedObject, ToPyObject,
+    AsPyPointer, FromPyObject, IntoPyPointer, PyTryFrom, ToBorrowedObject, ToPyObject,
 };
 use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::exceptions::PyTypeError;
 use crate::type_object::PyTypeObject;
 use crate::types::{PyDict, PyIterator, PyList, PyString, PyTuple, PyType};
-use crate::{err, ffi, Py, PyNativeType, PyObject, Python};
+use crate::{err, ffi, IntoPyObject, PyNativeType, PyObject, Python};
 use std::cell::UnsafeCell;
 use std::cmp::Ordering;
 use std::os::raw::c_int;
@@ -402,7 +402,7 @@ impl PyAny {
     /// This is equivalent to the Python expression `self(*args, **kwargs)`.
     pub fn call(
         &self,
-        args: impl IntoPy<Py<PyTuple>>,
+        args: impl IntoPyObject<Target = PyTuple>,
         kwargs: Option<&PyDict>,
     ) -> PyResult<&PyAny> {
         let args = args.into_py(self.py()).into_ptr();
@@ -480,7 +480,7 @@ impl PyAny {
     /// value = add(1,2)
     /// assert value == 3
     /// ```
-    pub fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<&PyAny> {
+    pub fn call1(&self, args: impl IntoPyObject<Target = PyTuple>) -> PyResult<&PyAny> {
         self.call(args, None)
     }
 
@@ -516,7 +516,7 @@ impl PyAny {
     pub fn call_method(
         &self,
         name: &str,
-        args: impl IntoPy<Py<PyTuple>>,
+        args: impl IntoPyObject<Target = PyTuple>,
         kwargs: Option<&PyDict>,
     ) -> PyResult<&PyAny> {
         name.with_borrowed_ptr(self.py(), |name| unsafe {
@@ -607,7 +607,11 @@ impl PyAny {
     /// list_.insert(1,2)
     /// assert list_ == [1,2,3,4]
     /// ```
-    pub fn call_method1(&self, name: &str, args: impl IntoPy<Py<PyTuple>>) -> PyResult<&PyAny> {
+    pub fn call_method1(
+        &self,
+        name: &str,
+        args: impl IntoPyObject<Target = PyTuple>,
+    ) -> PyResult<&PyAny> {
         self.call_method(name, args, None)
     }
 

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 use crate::{
-    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, PyTryFrom, Python,
-    ToPyObject,
+    ffi, AsPyPointer, FromPyObject, IntoPy, IntoPyObject, Py, PyAny, PyObject, PyResult, PyTryFrom,
+    Python, ToPyObject,
 };
 
 /// Represents a Python `bool`.
@@ -44,6 +44,14 @@ impl ToPyObject for bool {
 impl IntoPy<PyObject> for bool {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
+        PyBool::new(py, self).into()
+    }
+}
+
+impl IntoPyObject for bool {
+    type Target = PyBool;
+    #[inline]
+    fn into_py(self, py: Python<'_>) -> Py<PyBool> {
         PyBool::new(py, self).into()
     }
 }

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ffi, AsPyPointer, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, PyTryFrom, Python,
+    ffi, AsPyPointer, FromPyObject, IntoPyObject, Py, PyAny, PyObject, PyResult, PyTryFrom, Python,
     ToPyObject,
 };
 use std::ops::Index;
@@ -124,9 +124,16 @@ impl<I: SliceIndex<[u8]>> Index<I> for PyBytes {
     }
 }
 
-impl<'a> IntoPy<PyObject> for &'a [u8] {
+impl<'a> crate::IntoPy<PyObject> for &'a [u8] {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyBytes::new(py, self).to_object(py)
+    }
+}
+
+impl<'a> IntoPyObject for &'a [u8] {
+    type Target = PyBytes;
+    fn into_py(self, py: Python<'_>) -> Py<PyBytes> {
+        PyBytes::new(py, self).into()
     }
 }
 

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -2,7 +2,8 @@
 //
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 use crate::{
-    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    ffi, AsPyPointer, FromPyObject, IntoPy, IntoPyObject, Py, PyAny, PyErr, PyObject, PyResult,
+    Python, ToPyObject,
 };
 use std::os::raw::c_double;
 
@@ -46,6 +47,13 @@ impl IntoPy<PyObject> for f64 {
     }
 }
 
+impl IntoPyObject for f64 {
+    type Target = PyFloat;
+    fn into_py(self, py: Python<'_>) -> Py<PyFloat> {
+        PyFloat::new(py, self).into()
+    }
+}
+
 impl<'source> FromPyObject<'source> for f64 {
     // PyFloat_AsDouble returns -1.0 upon failure
     #![allow(clippy::float_cmp)]
@@ -70,6 +78,13 @@ impl ToPyObject for f32 {
 
 impl IntoPy<PyObject> for f32 {
     fn into_py(self, py: Python<'_>) -> PyObject {
+        PyFloat::new(py, f64::from(self)).into()
+    }
+}
+
+impl IntoPyObject for f32 {
+    type Target = PyFloat;
+    fn into_py(self, py: Python<'_>) -> Py<PyFloat> {
         PyFloat::new(py, f64::from(self)).into()
     }
 }

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -9,8 +9,8 @@ use crate::ffi::{self, Py_ssize_t};
 use crate::internal_tricks::get_ssize_index;
 use crate::types::PySequence;
 use crate::{
-    AsPyPointer, IntoPy, IntoPyPointer, Py, PyAny, PyObject, PyTryFrom, Python, ToBorrowedObject,
-    ToPyObject,
+    AsPyPointer, IntoPy, IntoPyObject, IntoPyPointer, Py, PyAny, PyObject, PyTryFrom, Python,
+    ToBorrowedObject, ToPyObject,
 };
 
 /// Represents a Python `list`.
@@ -356,6 +356,18 @@ where
 {
     fn into_py(self, py: Python<'_>) -> PyObject {
         let mut iter = self.into_iter().map(|e| e.into_py(py));
+        let list = new_from_iter(py, &mut iter);
+        list.into()
+    }
+}
+
+impl<T> IntoPyObject for Vec<T>
+where
+    T: IntoPyObject,
+{
+    type Target = PyList;
+    fn into_py(self, py: Python<'_>) -> Py<PyList> {
+        let mut iter = self.into_iter().map(|e| e.into_object(py));
         let list = new_from_iter(py, &mut iter);
         list.into()
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -65,6 +65,15 @@ macro_rules! pyobject_native_type_base(
                 unsafe { $crate::PyObject::from_borrowed_ptr(py, self.as_ptr()) }
             }
         }
+
+        impl<$($generics,)*> $crate::IntoPyObject for &'_ $name {
+            type Target = $name;
+            #[inline]
+            fn into_py(self, py: $crate::Python<'_>) -> $crate::Py<$name> {
+                use $crate::AsPyPointer;
+                unsafe { $crate::Py::from_borrowed_ptr(py, self.as_ptr()) }
+            }
+        }
     };
 );
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -4,12 +4,12 @@
 
 use crate::callback::IntoPyCallbackOutput;
 use crate::err::{PyErr, PyResult};
-use crate::exceptions;
 use crate::ffi;
 use crate::pyclass::PyClass;
 use crate::type_object::PyTypeObject;
 use crate::types::{PyAny, PyCFunction, PyDict, PyList, PyString};
-use crate::{AsPyPointer, IntoPy, PyObject, Python};
+use crate::{exceptions, IntoPyObject};
+use crate::{AsPyPointer, PyObject, Python};
 use std::ffi::{CStr, CString};
 use std::str;
 
@@ -67,7 +67,7 @@ impl PyModule {
     /// import antigravity
     /// ```
     pub fn import<'p>(py: Python<'p>, name: &str) -> PyResult<&'p PyModule> {
-        let name: PyObject = name.into_py(py);
+        let name = name.into_py(py);
         unsafe { py.from_owned_ptr_or_err(ffi::PyImport_Import(name.as_ptr())) }
     }
 
@@ -241,12 +241,12 @@ impl PyModule {
     /// ```
     pub fn add<V>(&self, name: &str, value: V) -> PyResult<()>
     where
-        V: IntoPy<PyObject>,
+        V: IntoPyObject,
     {
         self.index()?
             .append(name)
             .expect("could not append __name__ to __all__");
-        self.setattr(name, value.into_py(self.py()))
+        self.setattr(name, value.into_object(self.py()))
     }
 
     /// Adds a new class to the module.

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -6,8 +6,8 @@ use crate::ffi::{self, Py_ssize_t};
 use crate::internal_tricks::get_ssize_index;
 use crate::types::PySequence;
 use crate::{
-    exceptions, AsPyPointer, FromPyObject, IntoPy, IntoPyPointer, Py, PyAny, PyErr, PyObject,
-    PyResult, PyTryFrom, Python, ToBorrowedObject, ToPyObject,
+    exceptions, AsPyPointer, FromPyObject, IntoPy, IntoPyObject, IntoPyPointer, Py, PyAny, PyErr,
+    PyObject, PyResult, PyTryFrom, Python, ToBorrowedObject, ToPyObject,
 };
 
 #[inline]
@@ -329,6 +329,18 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
                 let ret = Py::from_owned_ptr(py, ptr);
                 $(ffi::PyTuple_SetItem(ptr, $n, self.$n.into_py(py).into_ptr());)+
                 ret
+            }
+        }
+    }
+
+    impl <$($T: IntoPy<PyObject>),+> IntoPyObject for ($($T,)+) {
+        type Target = PyTuple;
+        fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
+            unsafe {
+                let ptr = ffi::PyTuple_New($length);
+                let ret =  Py::from_owned_ptr(py, ptr);
+                $(ffi::PyTuple_SetItem(ptr, $n, self.$n.into_py(py).into_ptr());)+
+               ret
             }
         }
     }

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -471,8 +471,8 @@ impl RichComparisons2 {
 
     fn __richcmp__(&self, other: &PyAny, op: CompareOp) -> PyObject {
         match op {
-            CompareOp::Eq => true.into_py(other.py()),
-            CompareOp::Ne => false.into_py(other.py()),
+            CompareOp::Eq => true.into_object(other.py()),
+            CompareOp::Ne => false.into_object(other.py()),
             _ => other.py().NotImplemented(),
         }
     }

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -112,7 +112,7 @@ fn test_buffer_referenced() {
         let input = vec![b' ', b'2', b'3'];
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let instance: PyObject = TestBufferClass {
+        let instance = TestBufferClass {
             vec: input.clone(),
             drop_called: drop_called.clone(),
         }

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -122,9 +122,9 @@ fn test_polymorphic_container_does_not_accept_other_types() {
 
     let setattr = |value: PyObject| p.as_ref(py).setattr("inner", value);
 
-    assert!(setattr(1i32.into_py(py)).is_err());
+    assert!(setattr(1i32.into_object(py)).is_err());
     assert!(setattr(py.None()).is_err());
-    assert!(setattr((1i32, 2i32).into_py(py)).is_err());
+    assert!(setattr((1i32, 2i32).into_object(py)).is_err());
 }
 
 #[test]

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -77,7 +77,7 @@ fn test_transparent_named_field_struct() {
         let test = "test".into_py(py);
         let b: B = FromPyObject::extract(test.as_ref(py)).expect("Failed to extract B from String");
         assert_eq!(b.test, "test");
-        let test: PyObject = 1.into_py(py);
+        let test = 1i32.into_py(py);
         let b = B::extract(test.as_ref(py));
         assert!(b.is_err());
     });
@@ -161,10 +161,10 @@ pub struct Tuple(String, usize);
 #[test]
 fn test_tuple_struct() {
     Python::with_gil(|py| {
-        let tup = PyTuple::new(py, &[1.into_py(py), "test".into_py(py)]);
+        let tup = PyTuple::new(py, &[1i32.into_object(py), "test".into_object(py)]);
         let tup = Tuple::extract(tup.as_ref());
         assert!(tup.is_err());
-        let tup = PyTuple::new(py, &["test".into_py(py), 1.into_py(py)]);
+        let tup = PyTuple::new(py, &["test".into_object(py), 1i32.into_object(py)]);
         let tup = Tuple::extract(tup.as_ref()).expect("Failed to extract Tuple from PyTuple");
         assert_eq!(tup.0, "test");
         assert_eq!(tup.1, 1);
@@ -177,7 +177,7 @@ pub struct TransparentTuple(String);
 #[test]
 fn test_transparent_tuple_struct() {
     Python::with_gil(|py| {
-        let tup: PyObject = 1.into_py(py);
+        let tup = 1i32.into_py(py);
         let tup = TransparentTuple::extract(tup.as_ref(py));
         assert!(tup.is_err());
         let test = "test".into_py(py);
@@ -249,7 +249,7 @@ fn test_struct_nested_type_errors_with_generics() {
 #[test]
 fn test_transparent_struct_error_message() {
     Python::with_gil(|py| {
-        let tup: PyObject = 1.into_py(py);
+        let tup = 1i32.into_py(py);
         let tup = B::extract(tup.as_ref(py));
         assert!(tup.is_err());
         assert_eq!(
@@ -263,7 +263,7 @@ fn test_transparent_struct_error_message() {
 #[test]
 fn test_tuple_struct_error_message() {
     Python::with_gil(|py| {
-        let tup: PyObject = (1, "test").into_py(py);
+        let tup = (1, "test").into_py(py);
         let tup = Tuple::extract(tup.as_ref(py));
         assert!(tup.is_err());
         assert_eq!(
@@ -277,7 +277,7 @@ fn test_tuple_struct_error_message() {
 #[test]
 fn test_transparent_tuple_error_message() {
     Python::with_gil(|py| {
-        let tup: PyObject = 1.into_py(py);
+        let tup = 1i32.into_py(py);
         let tup = TransparentTuple::extract(tup.as_ref(py));
         assert!(tup.is_err());
         assert_eq!(
@@ -323,7 +323,7 @@ pub struct PyBool {
 #[test]
 fn test_enum() {
     Python::with_gil(|py| {
-        let tup = PyTuple::new(py, &[1.into_py(py), "test".into_py(py)]);
+        let tup = PyTuple::new(py, &[1i32.into_object(py), "test".into_object(py)]);
         let f = Foo::extract(tup.as_ref()).expect("Failed to extract Foo from tuple");
         match f {
             Foo::TupleVar(test, test2) => {
@@ -344,7 +344,7 @@ fn test_enum() {
             _ => panic!("Expected extracting Foo::StructVar, got {:?}", f),
         }
 
-        let int: PyObject = 1.into_py(py);
+        let int = 1i32.into_py(py);
         let f = Foo::extract(int.as_ref(py)).expect("Failed to extract Foo from int");
         match f {
             Foo::TransparentTuple(test) => assert_eq!(test, 1),

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -61,7 +61,7 @@ impl Mapping {
     fn get(&self, py: Python<'_>, key: &str, default: Option<PyObject>) -> Option<PyObject> {
         self.index
             .get(key)
-            .map(|value| value.into_py(py))
+            .map(|value| value.into_object(py))
             .or(default)
     }
 }

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -285,12 +285,12 @@ fn test_closure() {
             .iter()
             .map(|elem| {
                 if let Ok(i) = elem.extract::<i64>() {
-                    (i + 1).into_py(py)
+                    (i + 1).into_object(py)
                 } else if let Ok(f) = elem.extract::<f64>() {
-                    (2. * f).into_py(py)
+                    (2. * f).into_object(py)
                 } else if let Ok(mut s) = elem.extract::<String>() {
                     s.push_str("-py");
-                    s.into_py(py)
+                    s.into_object(py)
                 } else {
                     panic!("unexpected argument type for {:?}", elem)
                 }

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -91,7 +91,7 @@ fn reader() -> Reader {
 fn test_nested_iter() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let reader: PyObject = reader().into_py(py);
+    let reader = reader().into_py(py);
     py_assert!(
         py,
         reader,
@@ -103,7 +103,7 @@ fn test_nested_iter() {
 fn test_clone_ref() {
     let gil = Python::acquire_gil();
     let py = gil.python();
-    let reader: PyObject = reader().into_py(py);
+    let reader = reader().into_py(py);
     py_assert!(py, reader, "reader == reader.clone_ref()");
     py_assert!(py, reader, "reader == reader.clone_ref_with_py()");
 }

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -263,7 +263,7 @@ fn test_generic_list_get() {
     let gil = Python::acquire_gil();
     let py = gil.python();
 
-    let list: PyObject = GenericList {
+    let list = GenericList {
         items: [1, 2, 3].iter().map(|i| i.to_object(py)).collect(),
     }
     .into_py(py);


### PR DESCRIPTION
This is throwing out a concept that I've been pondering for a while to progress with the design of the to-python conversion traits.

It replaces `IntoPy<T>` generic trait with a trait `IntoPyObject` which has an associated type defined as follows:

```rust
pub trait IntoPyObject: Sized {
    type Target;

    /// Converts to the known target Python type.
    fn into_py(self, py: Python<'_>) -> Py<Self::Target>;

    /// Converts to a generic Python type. Equivalent to `self.into_py().into()`.
    fn into_object(self, py: Python<'_>) -> PyObject;
}
```

The names are intended to line up with the `ToPyObject` trait which has the `to_object` method. We could also have `TryIntoPyObject` trait, potentially, with a similar design.

The advantages I see of doing this:
- Users can call `into_py()` and get `Py<T>` rather than `Py<PyAny>`, helping avoid to need an immediate cast to work with the Python object.
- Avoids inference errors caused when multiple implementations of `IntoPy<T>` exist for a given type.
- Opens the way for us to have `#[derive(IntoPyObject)]`.