### PR TITLE
pyo3-build-config: For `abi3`, link to `libpython3.so` on Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move `PyTypeObject::type_object` method to `PyTypeInfo` trait, and deprecate `PyTypeObject` trait. [#2284](https://github.com/PyO3/pyo3/pull/2284)
 - The deprecated `pyproto` feature is now disabled by default. [#2321](https://github.com/PyO3/pyo3/pull/2321)
+- Link to `libpython3.so` on Unix-like targets when `abi3` feature is enabled. [#2328](https://github.com/PyO3/pyo3/pull/2328)
 
 ## [0.16.4] - 2022-04-14
 


### PR DESCRIPTION
Quoting PEP 384:

 If Python is compiled as a shared library, it is installed as both
 libpython3.so, and libpython3.y.so; applications conforming to this PEP
 should then link to the former (extension modules can continue to link
 with no libpython shared object, but rather rely on runtime linking).

Source: https://peps.python.org/pep-0384/#linkage