### PR TITLE
opt: tidy some generic code bloat

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -47,7 +47,10 @@ where
 {
     #[inline]
     fn convert(self, py: Python<'_>) -> PyResult<U> {
-        self.map_err(Into::into).and_then(|t| t.convert(py))
+        match self {
+            Ok(v) => v.convert(py),
+            Err(e) => Err(e.into()),
+        }
     }
 }
 

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -7,7 +7,6 @@ use crate::{
 
 /// The standard implementation of how PyO3 extracts a `#[pyfunction]` or `#[pymethod]` function argument.
 #[doc(hidden)]
-#[inline]
 pub fn extract_argument<'py, T>(obj: &'py PyAny, arg_name: &str) -> PyResult<T>
 where
     T: FromPyObject<'py>,
@@ -21,7 +20,6 @@ where
 /// Alternative to [`extract_argument`] used for `Option<T>` arguments (because they are implicitly treated
 /// as optional if at the end of the positional parameters).
 #[doc(hidden)]
-#[inline]
 pub fn extract_optional_argument<'py, T>(
     obj: Option<&'py PyAny>,
     arg_name: &str,
@@ -30,17 +28,13 @@ where
     T: FromPyObject<'py>,
 {
     match obj {
-        Some(obj) => match obj.extract() {
-            Ok(value) => Ok(value),
-            Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e)),
-        },
+        Some(obj) => extract_argument(obj, arg_name),
         None => Ok(None),
     }
 }
 
 /// Alternative to [`extract_argument`] used when the argument has a default value provided by an annotation.
 #[doc(hidden)]
-#[inline]
 pub fn extract_argument_with_default<'py, T>(
     obj: Option<&'py PyAny>,
     arg_name: &str,
@@ -50,10 +44,7 @@ where
     T: FromPyObject<'py>,
 {
     match obj {
-        Some(obj) => match obj.extract() {
-            Ok(value) => Ok(value),
-            Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e)),
-        },
+        Some(obj) => extract_argument(obj, arg_name),
         None => Ok(default()),
     }
 }
@@ -63,7 +54,6 @@ where
 /// # Safety
 /// - `obj` must not be None (this helper is only used for required function arguments).
 #[doc(hidden)]
-#[inline]
 pub fn from_py_with<'py, T>(
     obj: &'py PyAny,
     arg_name: &str,
@@ -78,7 +68,6 @@ pub fn from_py_with<'py, T>(
 
 /// Alternative to [`extract_argument`] used when the argument has a `#[pyo3(from_py_with)]` annotation and also a default value.
 #[doc(hidden)]
-#[inline]
 pub fn from_py_with_with_default<'py, T>(
     obj: Option<&'py PyAny>,
     arg_name: &str,
@@ -86,10 +75,7 @@ pub fn from_py_with_with_default<'py, T>(
     default: impl FnOnce() -> T,
 ) -> PyResult<T> {
     match obj {
-        Some(obj) => match extractor(obj) {
-            Ok(value) => Ok(value),
-            Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e)),
-        },
+        Some(obj) => from_py_with(obj, arg_name, extractor),
         None => Ok(default()),
     }
 }

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -300,11 +300,14 @@ impl PyModule {
     where
         T: IntoPyCallbackOutput<PyObject>,
     {
+        self._add_wrapped(wrapper(self.py()).convert(self.py())?)
+    }
+
+    fn _add_wrapped(&self, object: PyObject) -> PyResult<()> {
         let py = self.py();
-        let function = wrapper(py).convert(py)?;
-        let name = function.getattr(py, __name__(py))?;
+        let name = object.getattr(py, __name__(py))?;
         let name = name.extract(py)?;
-        self.add(name, function)
+        self.add(name, object)
     }
 
     /// Adds a submodule to a module.

--- a/tests/ui/invalid_result_conversion.stderr
+++ b/tests/ui/invalid_result_conversion.stderr
@@ -7,8 +7,8 @@ error[E0277]: the trait bound `Result<(), MyError>: IntoPyCallbackOutput<_>` is 
     = help: the following implementations were found:
               <Result<T, E> as IntoPyCallbackOutput<U>>
 note: required by a bound in `pyo3::callback::convert`
-   --> src/callback.rs:182:8
+   --> src/callback.rs
     |
-182 |     T: IntoPyCallbackOutput<U>,
+    |     T: IntoPyCallbackOutput<U>,
     |        ^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `pyo3::callback::convert`
     = note: this error originates in the attribute macro `pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Just some functions which I noticed were pulling large weight of llvm lines for the `pytests` crate. Overall these small tweaks shave 4% off the llvm line count.