### PR TITLE
Adding polars and rust-python-coverage PyO3 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ about this topic.
     - Shows Rayon/ndarray::parallel (including capturing errors, controlling thread num), Python types to Rust generics, Github Actions
 - [pyheck](https://github.com/kevinheavey/pyheck) _Fast case conversion library, built by wrapping [heck](https://github.com/withoutboats/heck)_
     - Quite easy to follow as there's not much code.
+- [polars](https://github.com/pola-rs/polars) _Fast multi-threaded DataFrame library in Rust | Python | Node.js_
+- [rust-python-coverage](https://github.com/cjermain/rust-python-coverage) _Example PyO3 project with automated test coverage for Rust and Python_
 
 ## Articles and other media
 


### PR DESCRIPTION
This PR adds 2 example PyO3 projects. The first is a popular DataFrame library. The second is an example project based on the PyO3 coverage CI that aims to make it easier to add coverage to PyO3 projects by providing a simpler starting point.