### PR TITLE
Fix CI for hashbrown 0.12.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
         run: |
           set -x
           cargo update -p indexmap --precise 1.6.2
-          cargo update -p hashbrown:0.12.0 --precise 0.9.1
+          cargo update -p hashbrown:0.12.1 --precise 0.9.1
           PROJECTS=("." "examples/decorator" "examples/maturin-starter" "examples/setuptools-rust-starter" "examples/word-count")
           for PROJ in ${PROJECTS[@]}; do
             cargo update --manifest-path "$PROJ/Cargo.toml" -p parking_lot --precise 0.11.0


### PR DESCRIPTION
Looks like hashbrown bump from 0.12.0 to 0.12.1 tickled the pipeline.