### PR TITLE
ffi: remove with_thread cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The deprecated `pyproto` feature is now disabled by default. [#2322](https://github.com/PyO3/pyo3/pull/2322)
 - Deprecate `ToBorrowedObject` trait (it is only used as a wrapper for `ToPyObject`). [#2333](https://github.com/PyO3/pyo3/pull/2333)
 
+### Fixed
+
+- Fixed incorrectly disabled FFI definition `PyThreadState_DeleteCurrent`. [#2357](https://github.com/PyO3/pyo3/pull/2357)
+
 
 ## [0.16.4] - 2022-04-14
 

--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -41,7 +41,8 @@ Caused by:
   lib_dir=/usr/lib
   executable=/usr/bin/python
   pointer_width=64
-  build_flags=WITH_THREAD
+  build_flags=
+  suppress_build_script_link_lines=false
 ```
 
 ### Advanced: config files

--- a/pyo3-ffi/src/cpython/pystate.rs
+++ b/pyo3-ffi/src/cpython/pystate.rs
@@ -53,7 +53,6 @@ extern "C" {
     #[cfg(not(PyPy))]
     pub fn PyThreadState_Next(tstate: *mut PyThreadState) -> *mut PyThreadState;
 
-    #[cfg(py_sys_config = "WITH_THREAD")]
     #[cfg_attr(PyPy, link_name = "PyPyThreadState_DeleteCurrent")]
     pub fn PyThreadState_DeleteCurrent();
 }


### PR DESCRIPTION
Since dropping Python 3.6 there isn't a WITH_THREAD build flag; just noticed this and tidying up.