### PR TITLE
ffi: add new 3.11 fields to PyConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed incorrectly disabled FFI definition `PyThreadState_DeleteCurrent`. [#2357](https://github.com/PyO3/pyo3/pull/2357)
 - Correct FFI definition `PyEval_EvalCodeEx` to take `*const *mut PyObject` array arguments instead of `*mut *mut PyObject` (this was changed in CPython 3.6). [#2368](https://github.com/PyO3/pyo3/pull/2368)
-
+- Added missing `warn_default_encoding` field to `PyConfig` on 3.10+. The previously missing field could result in incorrect behavior or crashes. [#2370](https://github.com/PyO3/pyo3/pull/2370)
+- Fixed order of `pathconfig_warnings` and `program_name` fields of `PyConfig` on 3.10+. Previously, the order of the fields was swapped and this could lead to incorrect behavior or crashes. [#2370](https://github.com/PyO3/pyo3/pull/2370)
 
 ## [0.16.4] - 2022-04-14
 

--- a/pyo3-ffi/src/cpython/initconfig.rs
+++ b/pyo3-ffi/src/cpython/initconfig.rs
@@ -110,6 +110,8 @@ pub struct PyConfig {
     pub warnoptions: PyWideStringList,
     pub site_import: c_int,
     pub bytes_warning: c_int,
+    #[cfg(Py_3_10)]
+    pub warn_default_encoding: c_int,
     pub inspect: c_int,
     pub interactive: c_int,
     pub optimization_level: c_int,
@@ -127,9 +129,9 @@ pub struct PyConfig {
     pub legacy_windows_stdio: c_int,
 
     pub check_hash_pycs_mode: *mut wchar_t,
+    pub pathconfig_warnings: c_int,
     #[cfg(Py_3_10)]
     pub program_name: *mut wchar_t,
-    pub pathconfig_warnings: c_int,
     pub pythonpath_env: *mut wchar_t,
     pub home: *mut wchar_t,
     #[cfg(Py_3_10)]

--- a/pyo3-ffi/src/cpython/initconfig.rs
+++ b/pyo3-ffi/src/cpython/initconfig.rs
@@ -92,10 +92,14 @@ pub struct PyConfig {
     pub _use_peg_parser: c_int,
     pub tracemalloc: c_int,
     pub import_time: c_int,
+    #[cfg(Py_3_11)]
+    pub code_debug_ranges: c_int,
     pub show_ref_count: c_int,
     #[cfg(not(Py_3_9))]
     pub show_alloc_count: c_int,
     pub dump_refs: c_int,
+    #[cfg(Py_3_11)]
+    pub dump_refs_file: *mut wchar_t,
     pub malloc_stats: c_int,
     pub filesystem_encoding: *mut wchar_t,
     pub filesystem_errors: *mut wchar_t,
@@ -129,6 +133,10 @@ pub struct PyConfig {
     pub legacy_windows_stdio: c_int,
 
     pub check_hash_pycs_mode: *mut wchar_t,
+    #[cfg(Py_3_11)]
+    pub use_frozen_modules: c_int,
+    #[cfg(Py_3_11)]
+    pub safe_path: c_int,
     pub pathconfig_warnings: c_int,
     #[cfg(Py_3_10)]
     pub program_name: *mut wchar_t,
@@ -139,6 +147,8 @@ pub struct PyConfig {
 
     pub module_search_paths_set: c_int,
     pub module_search_paths: PyWideStringList,
+    #[cfg(Py_3_11)]
+    pub stdlib_dir: *mut wchar_t,
     pub executable: *mut wchar_t,
     pub base_executable: *mut wchar_t,
     pub prefix: *mut wchar_t,
@@ -155,6 +165,8 @@ pub struct PyConfig {
     pub _init_main: c_int,
     #[cfg(Py_3_9)]
     pub _isolated_interpreter: c_int,
+    #[cfg(Py_3_11)]
+    pub _is_python_build: c_int,
     #[cfg(all(Py_3_9, not(Py_3_10)))]
     pub orig_argv: PyWideStringList,
 }


### PR DESCRIPTION
This hopefully makes PyConfig compatible with 3.11. I haven't tested this though.

This is based on top of #2370 and should probably be rebased once that PR merges. Only the 2nd commit is unique to this PR. I wish GitHub let you chain stacks of commits together more easily...