### PR TITLE
Auto generate Windows import libraries when using a pyo3 config file

### DIFF
--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -456,6 +456,27 @@ print("mingw", get_platform().startswith("mingw"))
         })
     }
 
+    pub fn fixup_import_libs(&mut self) -> Result<()> {
+        let target = target_triple_from_env();
+        if self.lib_name.is_none() && target.operating_system == OperatingSystem::Windows {
+            self.lib_name = Some(default_lib_name_windows(
+                self.version,
+                self.implementation,
+                self.abi3,
+                false,
+            ));
+        }
+        // Auto generate python3.dll import libraries for Windows targets.
+        #[cfg(feature = "python3-dll-a")]
+        {
+            if self.lib_dir.is_none() {
+                let py_version = if self.abi3 { None } else { Some(self.version) };
+                self.lib_dir = self::import_lib::generate_import_lib(&target, py_version)?;
+            }
+        }
+        Ok(())
+    }
+
     #[doc(hidden)]
     /// Serialize the `InterpreterConfig` and print it to the environment for Cargo to pass along
     /// to dependent packages during build time.

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -456,6 +456,7 @@ print("mingw", get_platform().startswith("mingw"))
         })
     }
 
+    #[allow(clippy::unnecessary_wraps)]
     pub fn fixup_import_libs(&mut self) -> Result<()> {
         let target = target_triple_from_env();
         if self.lib_name.is_none() && target.operating_system == OperatingSystem::Windows {

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -177,7 +177,9 @@ pub mod pyo3_build_script_impl {
     #[cfg(feature = "resolve-config")]
     pub fn resolve_interpreter_config() -> Result<InterpreterConfig> {
         if !CONFIG_FILE.is_empty() {
-            InterpreterConfig::from_reader(Cursor::new(CONFIG_FILE))
+            let mut interperter_config = InterpreterConfig::from_reader(Cursor::new(CONFIG_FILE))?;
+            interperter_config.fixup_import_libs()?;
+            Ok(interperter_config)
         } else if let Some(interpreter_config) = make_cross_compile_config()? {
             // This is a cross compile and need to write the config file.
             let path = resolve_cross_compile_config_path()


### PR DESCRIPTION
Currently the build script of `pyo3-ffi` calls `pyo3-build-config`'s `resolve_interpreter_config` function

https://github.com/PyO3/pyo3/blob/87bd10c9a33e0a189248f32e46fd1c602ab5606a/pyo3-ffi/build.rs#L79-L80

when `PYO3_CONFIG_FILE` env var is set, it simply read the file using `InterpreterConfig::from_reader` which missed the "generate import library" setup thus no `python3.dll`/`python3y.dll` is generated causing linking errors

https://github.com/PyO3/pyo3/blob/87bd10c9a33e0a189248f32e46fd1c602ab5606a/pyo3-build-config/src/lib.rs#L179-L180