### PR TITLE
[Prototype] Python stubs generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,9 @@ auto-initialize = []
 # Optimizes PyObject to Vec conversion and so on.
 nightly = []
 
+# Generates Python stubs (.pyi) files during compilation
+generate-stubs = ["pyo3-macros/generate-stubs"]
+
 # Activates all additional features
 # This is mostly intended for testing purposes - activating *all* of these isn't particularly useful.
 full = [

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -25,3 +25,4 @@ features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-trait
 [features]
 pyproto = []
 abi3 = []
+generate-stubs = []

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -26,6 +26,7 @@ pub mod kw {
     syn::custom_keyword!(signature);
     syn::custom_keyword!(subclass);
     syn::custom_keyword!(text_signature);
+    syn::custom_keyword!(type_signature);
     syn::custom_keyword!(transparent);
     syn::custom_keyword!(unsendable);
     syn::custom_keyword!(weakref);
@@ -82,6 +83,7 @@ pub type FreelistAttribute = KeywordAttribute<kw::freelist, Box<Expr>>;
 pub type ModuleAttribute = KeywordAttribute<kw::module, LitStr>;
 pub type NameAttribute = KeywordAttribute<kw::name, NameLitStr>;
 pub type TextSignatureAttribute = KeywordAttribute<kw::text_signature, LitStr>;
+pub type TypeSignatureAttribute = KeywordAttribute<kw::type_signature, LitStr>;
 
 impl<K: Parse + std::fmt::Debug, V: Parse> Parse for KeywordAttribute<K, V> {
     fn parse(input: ParseStream<'_>) -> Result<Self> {

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -27,6 +27,7 @@ mod pymethod;
 #[cfg(feature = "pyproto")]
 mod pyproto;
 mod wrap;
+mod stubs;
 
 pub use frompyobject::build_derive_from_pyobject;
 pub use module::{process_functions_in_module, pymodule_impl, PyModuleOptions};

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -999,6 +999,7 @@ fn generate_stub_class(
 ) {
     #[cfg(feature = "generate-stubs")] {
         //TODO: declare inheritance, if required
+        println!("# ID: {}", cls);
         println!("class {}:", get_class_python_name(cls, args).to_string());
 
         let mut is_empty = true; // if the class is empty, it should contain 'pass'
@@ -1060,10 +1061,12 @@ fn generate_stub_class(
                     .unwrap_or(field.ident.as_ref().expect("This field has neither the #[pyo3(name = ...)] macro applied to, nor a Rust name, it's impossible to create a stub for it"))
                     .to_string();
 
-                print!("\t{} = None", name);
+                print!("\t{}", name);
 
                 if let Some(typing) = &options.type_signature {
-                    print!("  # type: {}", typing.value.value())
+                    print!(": {}", typing.value.value())
+                } else {
+                    print!(": Any")
                 }
 
                 println!();

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -18,6 +18,7 @@ use syn::{
     parse::{Parse, ParseBuffer, ParseStream},
     token::Comma,
 };
+use crate::attributes::TypeSignatureAttribute;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Argument {
@@ -238,6 +239,7 @@ pub struct PyFunctionOptions {
     pub name: Option<NameAttribute>,
     pub signature: Option<PyFunctionSignature>,
     pub text_signature: Option<TextSignatureAttribute>,
+    pub type_signature: Option<TypeSignatureAttribute>,
     pub deprecations: Deprecations,
     pub krate: Option<CrateAttribute>,
 }
@@ -278,6 +280,7 @@ pub enum PyFunctionOption {
     PassModule(attributes::kw::pass_module),
     Signature(PyFunctionSignature),
     TextSignature(TextSignatureAttribute),
+    TypeSignature(TypeSignatureAttribute),
     Crate(CrateAttribute),
 }
 
@@ -292,6 +295,8 @@ impl Parse for PyFunctionOption {
             input.parse().map(PyFunctionOption::Signature)
         } else if lookahead.peek(attributes::kw::text_signature) {
             input.parse().map(PyFunctionOption::TextSignature)
+        } else if lookahead.peek(attributes::kw::type_signature) {
+            input.parse().map(PyFunctionOption::TypeSignature)
         } else if lookahead.peek(syn::Token![crate]) {
             input.parse().map(PyFunctionOption::Crate)
         } else {
@@ -335,6 +340,13 @@ impl PyFunctionOptions {
                         text_signature.kw.span() => "`text_signature` may only be specified once"
                     );
                     self.text_signature = Some(text_signature);
+                }
+                PyFunctionOption::TypeSignature(type_signature) => {
+                    ensure_spanned!(
+                        self.type_signature.is_none(),
+                        type_signature.kw.span() => "`type_signature` may only be specified once"
+                    );
+                    self.type_signature = Some(type_signature);
                 }
                 PyFunctionOption::Crate(path) => {
                     ensure_spanned!(

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -268,6 +268,10 @@ fn generate_stub_method(cls: &syn::Type, method: &FnSpec) {
 
             print!("{}: {}", arg.name, map_rust_type_to_python(&arg.ty));
 
+            if arg.optional.is_some() {
+                print!(" = ...");
+            }
+
             comma_required = true;
         }
         println!(") -> {}: ...", map_rust_type_to_python(&method.output));

--- a/pyo3-macros-backend/src/stubs.rs
+++ b/pyo3-macros-backend/src/stubs.rs
@@ -1,0 +1,38 @@
+use syn::Type;
+
+pub fn map_rust_type_to_python(rust: &Type) -> String {
+    let rust_str = match rust {
+        Type::Array(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::BareFn(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::Group(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::ImplTrait(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::Infer(_) => "None".to_string(),
+        Type::Macro(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::Never(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::Paren(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::Path(ref path) => {
+            match &path.path.segments.last() {
+                Some(ref segment) => segment.ident.to_string(),
+                _ => "Any".to_string()
+            }
+        },
+        Type::Reference(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::Slice(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::TraitObject(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::Tuple(_) => todo!("Unknown how to map to Python: {:?}", rust),
+        Type::Verbatim(_) => todo!("Unknown how to map to Python: {:?}", rust),
+
+        #[cfg_attr(test, deny(non_exhaustive_omitted_patterns))]
+        _ => {
+            "Any".to_string()
+        }
+    };
+
+    match rust_str.as_str() {
+        "usize" | "isize" | "u32" | "u64" | "i32" | "i64" => "int".to_string(),
+        "f64" | "f32" => "float".to_string(),
+        "bool" => "bool".to_string(),
+        "None" | "Any" => rust_str,
+        _ => format!("rust_{}", rust_str)
+    }
+}

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 [features]
 multiple-pymethods = []
 
+generate-stubs = ["pyo3-macros-backend/generate-stubs"]
 pyproto = ["pyo3-macros-backend/pyproto"]
 abi3 = ["pyo3-macros-backend/abi3"]
 

--- a/tests/test_hints.rs
+++ b/tests/test_hints.rs
@@ -1,0 +1,61 @@
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+
+mod common;
+
+#[pyclass(text_signature = "(value, /)", type_signature = "(int) -> None")]
+struct CustomNumber(usize);
+
+#[pyclass]
+struct CustomNumber2 {
+    #[pyo3(get, set, name = "value", type_signature = "int")]
+    inner: usize,
+}
+
+#[pyfunction]
+#[pyo3(type_signature = "(float) -> CustomNumber")]
+fn number_from_float(input: f64) -> CustomNumber {
+    CustomNumber::from_double(input)
+}
+
+#[pymethods]
+impl CustomNumber {
+    #[new]
+    fn new(value: usize) -> Self {
+        Self(value)
+    }
+
+    #[pyo3(text_signature = "(new, /)", type_signature = "(int) -> None")]
+    fn set(&mut self, new: usize) {
+        self.0 = new
+    }
+
+    #[pyo3(type_signature = "(int) -> CustomNumber")]
+    fn __add__(&mut self, other: usize) -> Self {
+        Self(self.0 + other)
+    }
+
+    #[getter(value)]
+    #[pyo3(type_signature = "() -> int")]
+    fn get_value(&self) -> usize {
+        self.0
+    }
+
+    #[setter(value)]
+    #[pyo3(type_signature = "(int) -> None")]
+    fn set_value(&mut self, new: usize) {
+        self.0 = new
+    }
+
+    #[classmethod]
+    #[pyo3(text_signature = "(value, /)", type_signature = "(float) -> CustomNumber")]
+    fn from_float(_cls: &PyType, value: f32) -> Self {
+        Self(value as usize)
+    }
+
+    #[staticmethod]
+    #[pyo3(text_signature = "(value, /)", type_signature = "(float) -> CustomNumber")]
+    fn from_double(value: f64) -> Self {
+        Self(value as usize)
+    }
+}

--- a/tests/test_hints.rs
+++ b/tests/test_hints.rs
@@ -3,15 +3,25 @@ use pyo3::types::PyType;
 
 mod common;
 
+// This implementation has a text signature and multiple methods
 #[pyclass(text_signature = "(value, /)", type_signature = "(int) -> None")]
 struct CustomNumber(usize);
 
+// This implementation has documentation
+/// It's basically just a number.
+///
+/// There are multiple documentation lines here.
 #[pyclass]
 struct CustomNumber2 {
     #[pyo3(get, set, name = "value", type_signature = "int")]
     inner: usize,
 }
 
+// This implementation is simply empty, with no documentation, methods nor fields
+#[pyclass]
+struct CustomNumber3(usize);
+
+/// There's documentation here too.
 #[pyfunction]
 #[pyo3(type_signature = "(float) -> CustomNumber")]
 fn number_from_float(input: f64) -> CustomNumber {
@@ -35,6 +45,7 @@ impl CustomNumber {
         Self(self.0 + other)
     }
 
+    /// This is documented.
     #[getter(value)]
     #[pyo3(type_signature = "() -> int")]
     fn get_value(&self) -> usize {
@@ -47,6 +58,10 @@ impl CustomNumber {
         self.0 = new
     }
 
+    /// Converts a `float` into a `CustomNumber`.
+    ///
+    /// :param value: The value we want to convert
+    /// :return: The result of the conversion
     #[classmethod]
     #[pyo3(text_signature = "(value, /)", type_signature = "(float) -> CustomNumber")]
     fn from_float(_cls: &PyType, value: f32) -> Self {

--- a/tests/test_hints.rs
+++ b/tests/test_hints.rs
@@ -73,4 +73,13 @@ impl CustomNumber {
     fn from_double(value: f64) -> Self {
         Self(value as usize)
     }
+
+    fn to_3(&self) -> CustomNumber3 {
+        CustomNumber3(self.0)
+    }
+
+    #[args(n = "None")]
+    fn next(&self, n: Option<usize>) -> Vec<Self> {
+        todo!()
+    }
 }

--- a/tests/test_hints.rs
+++ b/tests/test_hints.rs
@@ -4,7 +4,7 @@ use pyo3::types::PyType;
 mod common;
 
 // This implementation has a text signature and multiple methods
-#[pyclass(text_signature = "(value, /)", type_signature = "(int) -> None")]
+#[pyclass(name = "RustNumber", text_signature = "(value, /)", type_signature = "(int) -> None")]
 struct CustomNumber(usize);
 
 // This implementation has documentation


### PR DESCRIPTION
Hi, this is a prototype to see if it's possible to generate a Python stub (.pyi) automatically from PyO3.

This is a very early prototype and definitely should not be merged as-is, but I'd be grateful for feedback on how to improve it.

The idea would be to generate parts of the stub as PyO3 parses the different classes, then to use an external program (e.g. included in Maturin) to combine the parts into a single file. Currently the parts are printed to stdout for ease of debugging.