### PR TITLE
Allow `#[classattr]` methods to be fallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate `ToBorrowedObject` trait (it is only used as a wrapper for `ToPyObject`). [#2333](https://github.com/PyO3/pyo3/pull/2333)
 - `impl<T, const N: usize> IntoPy<PyObject> for [T; N]` now requires `T: IntoPy` rather than `T: ToPyObject`. [#2326](https://github.com/PyO3/pyo3/pull/2326)
 - Correct `wrap_pymodule` to match normal namespacing rules: it no longer "sees through" glob imports of `use submodule::*` when `submodule::submodule` is a `#[pymodule]`. [#2363](https://github.com/PyO3/pyo3/pull/2363)
+- Allow `#[classattr]` methods to be fallible. [#2385](https://github.com/PyO3/pyo3/pull/2385)
 
 ### Fixed
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -583,8 +583,7 @@ impl MyClass {
 ## Class attributes
 
 To create a class attribute (also called [class variable][classattr]), a method without
-any arguments can be annotated with the `#[classattr]` attribute. The return type must be `T` for
-some `T` that implements `IntoPy<PyObject>`.
+any arguments can be annotated with the `#[classattr]` attribute.
 
 ```rust
 # use pyo3::prelude::*;
@@ -603,6 +602,9 @@ Python::with_gil(|py| {
     pyo3::py_run!(py, my_class, "assert my_class.my_attribute == 'hello'")
 });
 ```
+
+> Note: if the method has a `Result` return type and returns an `Err`, PyO3 will panic during
+class creation.
 
 If the class attribute is defined with `const` code only, one can also annotate associated
 constants:

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -171,9 +171,9 @@ pub fn gen_py_const(cls: &syn::Type, spec: &ConstSpec) -> TokenStream {
             _pyo3::class::PyClassAttributeDef::new(
                 #python_name,
                 _pyo3::impl_::pymethods::PyClassAttributeFactory({
-                    fn __wrap(py: _pyo3::Python<'_>) -> _pyo3::PyObject {
+                    fn __wrap(py: _pyo3::Python<'_>) -> _pyo3::PyResult<_pyo3::PyObject> {
                         #deprecations
-                        _pyo3::IntoPy::into_py(#cls::#member, py)
+                        ::std::result::Result::Ok(_pyo3::IntoPy::into_py(#cls::#member, py))
                     }
                     __wrap
                 })

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -349,9 +349,14 @@ fn impl_py_class_attribute(cls: &syn::Type, spec: &FnSpec<'_>) -> TokenStream {
             _pyo3::class::PyClassAttributeDef::new(
                 #python_name,
                 _pyo3::impl_::pymethods::PyClassAttributeFactory({
-                    fn __wrap(py: _pyo3::Python<'_>) -> _pyo3::PyObject {
+                    fn __wrap(py: _pyo3::Python<'_>) -> _pyo3::PyResult<_pyo3::PyObject> {
                         #deprecations
-                        _pyo3::IntoPy::into_py(#cls::#name(), py)
+                        let mut ret = #cls::#name();
+                        if false {
+                            use _pyo3::impl_::ghost::IntoPyResult;
+                            ret.assert_into_py_result();
+                        }
+                        _pyo3::callback::convert(py, ret)
                     }
                     __wrap
                 })

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -76,7 +76,7 @@ pub struct PyGetter(pub ffi::getter);
 #[derive(Clone, Copy, Debug)]
 pub struct PySetter(pub ffi::setter);
 #[derive(Clone, Copy)]
-pub struct PyClassAttributeFactory(pub for<'p> fn(Python<'p>) -> PyObject);
+pub struct PyClassAttributeFactory(pub for<'p> fn(Python<'p>) -> PyResult<PyObject>);
 
 // TODO: it would be nice to use CStr in these types, but then the constructors can't be const fn
 // until `CStr::from_bytes_with_nul_unchecked` is const fn.


### PR DESCRIPTION
Noticed this morning while looking at #2382 that it's not possible to return `PyResult` from `#[classattr]` methods.

There's not much we can do with them but panic, but it is at least a nice consistency change to match other `#[pymethods]`.