### PR TITLE
Add `GILOnceCell::get_or_try_init`

### DIFF
--- a/newsfragments/2398.added.md
+++ b/newsfragments/2398.added.md
@@ -1,0 +1,1 @@
+Add `GILOnceCell::get_or_try_init` for fallible `GILOnceCell` initialization.


### PR DESCRIPTION
This is similar to [`OnceCell::get_or_try_init`](https://docs.rs/once_cell/latest/once_cell/sync/struct.OnceCell.html#method.get_or_try_init) and is very useful for fallible initialization.