### PR TITLE
pymethods: prevent methods sharing the same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `impl<T, const N: usize> IntoPy<PyObject> for [T; N]` now requires `T: IntoPy` rather than `T: ToPyObject`. [#2326](https://github.com/PyO3/pyo3/pull/2326)
 - Correct `wrap_pymodule` to match normal namespacing rules: it no longer "sees through" glob imports of `use submodule::*` when `submodule::submodule` is a `#[pymodule]`. [#2363](https://github.com/PyO3/pyo3/pull/2363)
 - Allow `#[classattr]` methods to be fallible. [#2385](https://github.com/PyO3/pyo3/pull/2385)
+- Prevent multiple `#[pymethods]` with the same name for a single `#[pyclass]`. [#2399](https://github.com/PyO3/pyo3/pull/2399)
 
 ### Fixed
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -6,9 +6,13 @@ use crate::attributes::{
 };
 use crate::deprecations::{Deprecation, Deprecations};
 use crate::konst::{ConstAttributes, ConstSpec};
-use crate::pyimpl::{gen_default_items, gen_py_const, PyClassMethodsType};
-use crate::pymethod::{impl_py_getter_def, impl_py_setter_def, PropertyType};
+use crate::method::FnSpec;
+use crate::pyimpl::{gen_py_const, PyClassMethodsType};
+use crate::pymethod::{
+    impl_py_getter_def, impl_py_setter_def, PropertyType, SlotDef, __INT__, __REPR__, __RICHCMP__,
+};
 use crate::utils::{self, get_pyo3_crate, PythonDoc};
+use crate::PyFunctionOptions;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::ext::IdentExt;
@@ -418,49 +422,48 @@ fn impl_enum_class(
     krate: syn::Path,
 ) -> TokenStream {
     let cls = enum_.ident;
+    let ty: syn::Type = syn::parse_quote!(#cls);
     let variants = enum_.variants;
     let pytypeinfo = impl_pytypeinfo(cls, args, None);
 
-    let default_repr_impl: syn::ImplItemMethod = {
+    let (default_repr, default_repr_slot) = {
         let variants_repr = variants.iter().map(|variant| {
             let variant_name = variant.ident;
             // Assuming all variants are unit variants because they are the only type we support.
             let repr = format!("{}.{}", cls, variant_name);
             quote! { #cls::#variant_name => #repr, }
         });
-        syn::parse_quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            #[pyo3(name = "__repr__")]
+        let mut repr_impl: syn::ImplItemMethod = syn::parse_quote! {
             fn __pyo3__repr__(&self) -> &'static str {
                 match self {
                     #(#variants_repr)*
                 }
             }
-        }
+        };
+        let repr_slot = generate_default_protocol_slot(&ty, &mut repr_impl, &__REPR__).unwrap();
+        (repr_impl, repr_slot)
     };
 
     let repr_type = &enum_.repr_type;
 
-    let default_int = {
+    let (default_int, default_int_slot) = {
         // This implementation allows us to convert &T to #repr_type without implementing `Copy`
         let variants_to_int = variants.iter().map(|variant| {
             let variant_name = variant.ident;
             quote! { #cls::#variant_name => #cls::#variant_name as #repr_type, }
         });
-        syn::parse_quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            #[pyo3(name = "__int__")]
+        let mut int_impl: syn::ImplItemMethod = syn::parse_quote! {
             fn __pyo3__int__(&self) -> #repr_type {
                 match self {
                     #(#variants_to_int)*
                 }
             }
-        }
+        };
+        let int_slot = generate_default_protocol_slot(&ty, &mut int_impl, &__INT__).unwrap();
+        (int_impl, int_slot)
     };
 
-    let default_richcmp = {
+    let (default_richcmp, default_richcmp_slot) = {
         let variants_eq = variants.iter().map(|variant| {
             let variant_name = variant.ident;
             quote! {
@@ -468,10 +471,7 @@ fn impl_enum_class(
                     Ok(true.to_object(py)),
             }
         });
-        syn::parse_quote! {
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            #[pyo3(name = "__richcmp__")]
+        let mut richcmp_impl: syn::ImplItemMethod = syn::parse_quote! {
             fn __pyo3__richcmp__(
                 &self,
                 py: _pyo3::Python,
@@ -496,17 +496,20 @@ fn impl_enum_class(
                     _ => Ok(py.NotImplemented()),
                 }
             }
-        }
+        };
+        let richcmp_slot =
+            generate_default_protocol_slot(&ty, &mut richcmp_impl, &__RICHCMP__).unwrap();
+        (richcmp_impl, richcmp_slot)
     };
 
-    let mut default_methods = vec![default_repr_impl, default_richcmp, default_int];
+    let default_slots = vec![default_repr_slot, default_int_slot, default_richcmp_slot];
 
     let pyclass_impls = PyClassImplsBuilder::new(
         cls,
         args,
         methods_type,
         enum_default_methods(cls, variants.iter().map(|v| v.ident)),
-        enum_default_slots(cls, &mut default_methods),
+        default_slots,
     )
     .doc(doc)
     .impl_all();
@@ -519,11 +522,34 @@ fn impl_enum_class(
 
             #pyclass_impls
 
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
             impl #cls {
-                #(#default_methods)*
+                #default_repr
+                #default_int
+                #default_richcmp
             }
         };
     }
+}
+
+fn generate_default_protocol_slot(
+    cls: &syn::Type,
+    method: &mut syn::ImplItemMethod,
+    slot: &SlotDef,
+) -> syn::Result<TokenStream> {
+    let spec = FnSpec::parse(
+        &mut method.sig,
+        &mut Vec::new(),
+        PyFunctionOptions::default(),
+    )
+    .unwrap();
+    let name = spec.name.to_string();
+    slot.generate_type_slot(
+        &syn::parse_quote!(#cls),
+        &spec,
+        &format!("__default_{}__", name),
+    )
 }
 
 fn enum_default_methods<'a>(
@@ -546,13 +572,6 @@ fn enum_default_methods<'a>(
         .into_iter()
         .map(|var| gen_py_const(&cls_type, &variant_to_attribute(var)))
         .collect()
-}
-
-fn enum_default_slots(
-    cls: &syn::Ident,
-    default_items: &mut [syn::ImplItemMethod],
-) -> Vec<TokenStream> {
-    gen_default_items(cls, default_items).collect()
 }
 
 fn extract_variant_data(variant: &syn::Variant) -> syn::Result<PyClassEnumVariant<'_>> {

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -169,21 +169,6 @@ pub(crate) fn remove_lifetime(tref: &syn::TypeReference) -> syn::TypeReference {
     tref
 }
 
-/// Replace `Self` keyword in type with `cls`
-pub(crate) fn replace_self(ty: &mut syn::Type, cls: &syn::Type) {
-    match ty {
-        syn::Type::Reference(tref) => replace_self(&mut tref.elem, cls),
-        syn::Type::Path(tpath) => {
-            if let Some(ident) = tpath.path.get_ident() {
-                if ident == "Self" {
-                    *ty = cls.to_owned();
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
 /// Extract the path to the pyo3 crate, or use the default (`::pyo3`).
 pub(crate) fn get_pyo3_crate(attr: &Option<CrateAttribute>) -> syn::Path {
     attr.as_ref()

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -56,7 +56,7 @@
 //! # }
 //! #
 //! // This function is exported to Python.
-//! unsafe extern "C" fn __wrap(
+//! unsafe extern "C" fn __pymethod_increment__(
 //!     _slf: *mut ::pyo3::ffi::PyObject,
 //!     _args: *mut ::pyo3::ffi::PyObject,
 //! ) -> *mut ::pyo3::ffi::PyObject {
@@ -75,7 +75,7 @@
 //!         }),
 //!     )
 //! }
-//!  ```
+//! ```
 //!
 //! # When to use PyCell
 //! ## Using pyclasses from Rust

--- a/tests/ui/invalid_pymethods.rs
+++ b/tests/ui/invalid_pymethods.rs
@@ -135,4 +135,16 @@ impl TwoNew {
     fn new_2() -> Self { Self { } }
 }
 
+struct DuplicateMethod { }
+
+#[pymethods]
+impl DuplicateMethod {
+    #[pyo3(name = "func")]
+    fn func_a(&self) { }
+
+    #[pyo3(name = "func")]
+    fn func_b(&self) { }
+}
+
+
 fn main() {}

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -109,13 +109,24 @@ error: Python objects are shared, so 'self' cannot be moved out of the Python in
 124 |     fn method_self_by_value(self){}
     |                             ^^^^
 
-error[E0592]: duplicate definitions with name `__pymethod__new__`
+error[E0592]: duplicate definitions with name `__pymethod___new____`
    --> tests/ui/invalid_pymethods.rs:129:1
     |
 129 | #[pymethods]
     | ^^^^^^^^^^^^
     | |
-    | duplicate definitions for `__pymethod__new__`
-    | other definition for `__pymethod__new__`
+    | duplicate definitions for `__pymethod___new____`
+    | other definition for `__pymethod___new____`
+    |
+    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0592]: duplicate definitions with name `__pymethod_func__`
+   --> tests/ui/invalid_pymethods.rs:140:1
+    |
+140 | #[pymethods]
+    | ^^^^^^^^^^^^
+    | |
+    | duplicate definitions for `__pymethod_func__`
+    | other definition for `__pymethod_func__`
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR tweaks the `#[pymethods]` code generation so that the generated functions have meaningful names and are members of the associated class.

In general, the structure of generated code has changed from

```rust
unsafe extern "C" fn __wrap(...) { ... }
```

to 

```rust
impl SomeClass {
    unsafe extern "C" fn __pymethod_foo__(...) { ... }
}
```

There are a few nice benefits that this brings:
- As the generated function names are based on their names exposed to Python, and they share the struct's namespace, it's not possible to have multiple pymethods with the same `#[pyo3(name = "foo")]`.
- We have a hack to `replace_self` to remove `Self` from generated code; we don't need this now the generated code is associated with the class.
- Stack traces will be nicer in panic messages etc, because the frames will have meaningful names rather than `__wrap` (that was actually what motivated me to try this today as I was struggling to debug #2302; this idea's been in the back of my mind for a while)