### PR TITLE
Fixup `lib_name` when using `PYO3_CONFIG_FILE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct `wrap_pymodule` to match normal namespacing rules: it no longer "sees through" glob imports of `use submodule::*` when `submodule::submodule` is a `#[pymodule]`. [#2363](https://github.com/PyO3/pyo3/pull/2363)
 - Allow `#[classattr]` methods to be fallible. [#2385](https://github.com/PyO3/pyo3/pull/2385)
 - Prevent multiple `#[pymethods]` with the same name for a single `#[pyclass]`. [#2399](https://github.com/PyO3/pyo3/pull/2399)
+- Fixup `lib_name` when using `PYO3_CONFIG_FILE`. [#2404](https://github.com/PyO3/pyo3/pull/2404)
 
 ### Fixed
 

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -464,17 +464,21 @@ print("mingw", get_platform().startswith("mingw"))
         })
     }
 
+    #[cfg(feature = "python3-dll-a")]
     #[allow(clippy::unnecessary_wraps)]
-    pub fn fixup_import_libs(&mut self) -> Result<()> {
+    pub fn generate_import_libs(&mut self) -> Result<()> {
         // Auto generate python3.dll import libraries for Windows targets.
-        #[cfg(feature = "python3-dll-a")]
-        {
-            if self.lib_dir.is_none() {
-                let target = target_triple_from_env();
-                let py_version = if self.abi3 { None } else { Some(self.version) };
-                self.lib_dir = self::import_lib::generate_import_lib(&target, py_version)?;
-            }
+        if self.lib_dir.is_none() {
+            let target = target_triple_from_env();
+            let py_version = if self.abi3 { None } else { Some(self.version) };
+            self.lib_dir = import_lib::generate_import_lib(&target, py_version)?;
         }
+        Ok(())
+    }
+
+    #[cfg(not(feature = "python3-dll-a"))]
+    #[allow(clippy::unnecessary_wraps)]
+    pub fn generate_import_libs(&mut self) -> Result<()> {
         Ok(())
     }
 

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -178,7 +178,7 @@ pub mod pyo3_build_script_impl {
     pub fn resolve_interpreter_config() -> Result<InterpreterConfig> {
         if !CONFIG_FILE.is_empty() {
             let mut interperter_config = InterpreterConfig::from_reader(Cursor::new(CONFIG_FILE))?;
-            interperter_config.fixup_import_libs()?;
+            interperter_config.generate_import_libs()?;
             Ok(interperter_config)
         } else if let Some(interpreter_config) = make_cross_compile_config()? {
             // This is a cross compile and need to write the config file.


### PR DESCRIPTION
This matches the logic in `default_cross_compile`: https://github.com/PyO3/pyo3/blob/eafbbc54170e46c6b16067dabcf849a3864d6198/pyo3-build-config/src/impl_.rs#L1415-L1426