### PR TITLE
macros: simpler expansion for `intern!`

### DIFF
--- a/src/once_cell.rs
+++ b/src/once_cell.rs
@@ -1,5 +1,5 @@
 //! A write-once cell mediated by the Python GIL.
-use crate::Python;
+use crate::{types::PyString, Py, Python};
 use std::cell::UnsafeCell;
 
 /// A write-once cell similar to [`once_cell::OnceCell`](https://docs.rs/once_cell/1.4.0/once_cell/).
@@ -151,22 +151,26 @@ impl<T> GILOnceCell<T> {
 #[macro_export]
 macro_rules! intern {
     ($py: expr, $text: expr) => {{
-        fn isolate_from_dyn_env(py: $crate::Python<'_>) -> &$crate::types::PyString {
-            static INTERNED: $crate::once_cell::GILOnceCell<$crate::Py<$crate::types::PyString>> =
-                $crate::once_cell::GILOnceCell::new();
-
-            INTERNED
-                .get_or_init(py, || {
-                    $crate::conversion::IntoPy::into_py(
-                        $crate::types::PyString::intern(py, $text),
-                        py,
-                    )
-                })
-                .as_ref(py)
-        }
-
-        isolate_from_dyn_env($py)
+        static INTERNED: $crate::once_cell::Interned = $crate::once_cell::Interned::new($text);
+        INTERNED.get($py)
     }};
+}
+
+/// Implementation detail for `intern!` macro.
+#[doc(hidden)]
+pub struct Interned(&'static str, GILOnceCell<Py<PyString>>);
+
+impl Interned {
+    pub const fn new(value: &'static str) -> Self {
+        Interned(value, GILOnceCell::new())
+    }
+
+    #[inline]
+    pub fn get<'py>(&'py self, py: Python<'py>) -> &'py PyString {
+        self.1
+            .get_or_init(py, || PyString::intern(py, self.0).into())
+            .as_ref(py)
+    }
 }
 
 #[cfg(test)]

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -94,6 +94,7 @@ fn _test_compile_errors() {
 
     #[rustversion::since(1.60)]
     fn tests_rust_1_60(t: &trybuild::TestCases) {
+        t.compile_fail("tests/ui/invalid_intern_arg.rs");
         t.compile_fail("tests/ui/invalid_immutable_pyclass_borrow.rs");
         t.compile_fail("tests/ui/invalid_pymethod_receiver.rs");
         t.compile_fail("tests/ui/missing_intopy.rs");

--- a/tests/ui/invalid_intern_arg.rs
+++ b/tests/ui/invalid_intern_arg.rs
@@ -1,0 +1,6 @@
+use pyo3::Python;
+
+fn main() {
+    let foo = if true { "foo" } else { "bar" };
+    Python::with_gil(|py| py.import(pyo3::intern!(py, foo)).unwrap());
+}

--- a/tests/ui/invalid_intern_arg.stderr
+++ b/tests/ui/invalid_intern_arg.stderr
@@ -1,0 +1,8 @@
+error[E0435]: attempt to use a non-constant value in a constant
+ --> tests/ui/invalid_intern_arg.rs:5:55
+  |
+5 |     Python::with_gil(|py| py.import(pyo3::intern!(py, foo)).unwrap());
+  |                                     ------------------^^^-
+  |                                     |                 |
+  |                                     |                 non-constant value
+  |                                     help: consider using `let` instead of `static`: `let INTERNED`


### PR DESCRIPTION
Adds a helper `Interned` struct to contain the implementation of the `intern!` macro. Simplifies the expanded code a little, should allow the compiler to re-use the one monomorphization of `get_or_init`.  