### PR TITLE
ffi: fix PyFrameObject definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix FFI definition `PyGenObject` having multiple incorrect members on various Python versions. [#2423](https://github.com/PyO3/pyo3/pull/2423)
 - Fix FFI definition `PySyntaxErrorObject` missing members `end_lineno` and `end_offset` on Python 3.10 and up. [#2423](https://github.com/PyO3/pyo3/pull/2423)
 - Fix FFI definition `PyHeapTypeObject` missing member `ht_module` on Python 3.9 and up. [#2423](https://github.com/PyO3/pyo3/pull/2423)
+- Fix FFI definition `PyFrameObject` having multiple incorrect members on various Python versions. [#2424](https://github.com/PyO3/pyo3/pull/2424)
 
 ## [0.16.5] - 2022-05-15
 

--- a/pyo3-ffi/src/cpython/frameobject.rs
+++ b/pyo3-ffi/src/cpython/frameobject.rs
@@ -1,10 +1,11 @@
-use crate::cpython::code::{PyCodeObject, CO_MAXBLOCKS};
+use crate::cpython::code::PyCodeObject;
 use crate::object::*;
 use crate::pystate::PyThreadState;
 use std::os::raw::{c_char, c_int};
 
 // skipped _framestate
-// skipped PyFrameState
+
+pub type PyFrameState = c_char;
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -14,40 +15,39 @@ pub struct PyTryBlock {
     pub b_level: c_int,
 }
 
-/// struct _frame as typedef'ed in pyframe.h
 #[repr(C)]
 #[derive(Copy, Clone)]
+#[cfg(not(Py_3_11))]
 pub struct PyFrameObject {
     pub ob_base: PyVarObject,
-    pub f_back: *mut PyFrameObject,       /* previous frame, or NULL */
-    pub f_code: *mut PyCodeObject,        /* code segment */
-    pub f_builtins: *mut PyObject,        /* builtin symbol table (PyDictObject) */
-    pub f_globals: *mut PyObject,         /* global symbol table (PyDictObject) */
-    pub f_locals: *mut PyObject,          /* local symbol table (any mapping) */
-    pub f_valuestack: *mut *mut PyObject, /* points after the last local */
-    /* Next free slot in f_valuestack.  Frame creation sets to f_valuestack.
-    Frame evaluation usually NULLs it, but a frame that yields sets it
-    to the current stack top. */
-    pub f_stacktop: *mut *mut PyObject,
-    pub f_trace: *mut PyObject, /* Trace function */
+    pub f_back: *mut PyFrameObject,
+    pub f_code: *mut PyCodeObject,
+    pub f_builtins: *mut PyObject,
+    pub f_globals: *mut PyObject,
+    pub f_locals: *mut PyObject,
+    pub f_valuestack: *mut *mut PyObject,
 
-    pub f_exc_type: *mut PyObject,
-    pub f_exc_value: *mut PyObject,
-    pub f_exc_traceback: *mut PyObject,
+    #[cfg(not(Py_3_10))]
+    pub f_stacktop: *mut *mut PyObject,
+    pub f_trace: *mut PyObject,
+    pub f_stackdepth: c_int,
+    pub f_trace_lines: c_char,
+    pub f_trace_opcodes: c_char,
+
     pub f_gen: *mut PyObject,
 
-    pub f_lasti: c_int, /* Last instruction if called */
-    /* Call PyFrame_GetLineNumber() instead of reading this field
-     directly.  As of 2.3 f_lineno is only valid when tracing is
-     active (i.e. when f_trace is set).  At other times we use
-     PyCode_Addr2Line to calculate the line from the current
-    bytecode index. */
-    pub f_lineno: c_int,                          /* Current line number */
-    pub f_iblock: c_int,                          /* index in f_blockstack */
-    pub f_executing: c_char,                      /* whether the frame is still executing */
-    pub f_blockstack: [PyTryBlock; CO_MAXBLOCKS], /* for try and loop blocks */
-    pub f_localsplus: [*mut PyObject; 1],         /* locals+stack, dynamically sized */
+    pub f_lasti: c_int,
+    pub f_lineno: c_int,
+    pub f_iblock: c_int,
+    #[cfg(not(Py_3_10))]
+    pub f_executing: c_char,
+    pub f_state: PyFrameState,
+    pub f_blockstack: [PyTryBlock; crate::CO_MAXBLOCKS],
+    pub f_localsplus: [*mut PyObject; 1],
 }
+
+#[cfg(Py_3_11)]
+opaque_struct!(PyFrameObject);
 
 // skipped _PyFrame_IsRunnable
 // skipped _PyFrame_IsExecuting


### PR DESCRIPTION
Closes #2411 

@alex - could be worth noting that in Python 3.11 this structure is moved to the "internal" API it looks like; which we haven't been exposing in PyO3 (and probably shouldn't be). Might need to add some of the accessor functions for you to use instead?