### PR TITLE
Set up CI for wasm32-emscripten target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,3 +339,35 @@ jobs:
         with:
           file: coverage.lcov
           name: ${{ matrix.os }}
+
+  emscripten:
+    name: emscripten
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.11.0-beta.1
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-emscripten
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - run: pip install nox
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            .nox/emscripten
+          key: ${{ hashFiles('emscripten/*') }} -  ${{ hashFiles('noxfile.py') }}
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: cargo-emscripten-wasm32
+      - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: nox -s build_emscripten
+      - name: Test
+        run: nox -s test_emscripten

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,3 +168,8 @@ members = [
 no-default-features = true
 features = ["macros", "num-bigint", "num-complex", "hashbrown", "serde", "multiple-pymethods", "indexmap", "eyre"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[patch.crates-io]
+# Instant misspells emscripten_get_now by including a leading underscore.
+# https://github.com/sebcrozet/instant/pull/47
+instant = { git = 'https://github.com/hoodmane/instant/', branch= 'emscripten-no-leading-underscore' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,8 +168,3 @@ members = [
 no-default-features = true
 features = ["macros", "num-bigint", "num-complex", "hashbrown", "serde", "multiple-pymethods", "indexmap", "eyre"]
 rustdoc-args = ["--cfg", "docsrs"]
-
-[patch.crates-io]
-# Instant misspells emscripten_get_now by including a leading underscore.
-# https://github.com/sebcrozet/instant/pull/47
-instant = { git = 'https://github.com/hoodmane/instant/', branch= 'emscripten-no-leading-underscore' }

--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -1,0 +1,81 @@
+CURDIR=$(abspath .)
+
+BUILDROOT ?= $(CURDIR)/builddir
+export EMSDKDIR = $(BUILDROOT)/emsdk
+
+PLATFORM=wasm32_emscripten
+SYSCONFIGDATA_NAME=_sysconfigdata__$(PLATFORM)
+
+# BASH_ENV tells bash to run pyodide_env.sh on startup, which sets various
+# environment variables. The next line instructs make to use bash to run each
+# command.
+export BASH_ENV := $(CURDIR)/env.sh
+SHELL := /bin/bash
+
+EMSCRIPTEN_VERSION=3.1.13
+
+PYMAJORMINORMICRO ?= 3.11.0
+PYPRERELEASE ?= b1
+
+version_tuple := $(subst ., ,$(PYMAJORMINORMICRO:v%=%))
+export PYMAJOR=$(word 1,$(version_tuple))
+export PYMINOR=$(word 2,$(version_tuple))
+export PYMICRO=$(word 3,$(version_tuple))
+PYVERSION=$(PYMAJORMINORMICRO)$(PYPRERELEASE)
+PYMAJORMINOR=$(PYMAJOR).$(PYMINOR)
+
+
+PYTHONURL=https://www.python.org/ftp/python/$(PYMAJORMINORMICRO)/Python-$(PYVERSION).tgz
+PYTHONTARBALL=$(BUILDROOT)/downloads/Python-$(PYVERSION).tgz
+PYTHONBUILD=$(BUILDROOT)/build/Python-$(PYVERSION)
+
+export PYTHONLIBDIR=$(BUILDROOT)/install/Python-$(PYVERSION)/lib
+
+all: $(PYTHONLIBDIR)/libpython$(PYMAJORMINOR).a
+
+$(BUILDROOT)/.exists: 
+	mkdir -p $(BUILDROOT)
+	touch $@
+
+
+$(EMSDKDIR): $(CURDIR)/emscripten_patches/* $(BUILDROOT)/.exists
+	git clone https://github.com/emscripten-core/emsdk.git --depth 1 --branch $(EMSCRIPTEN_VERSION) $(EMSDKDIR)
+	$(EMSDKDIR)/emsdk install $(EMSCRIPTEN_VERSION)
+	cd $(EMSDKDIR)/upstream/emscripten && cat $(CURDIR)/emscripten_patches/* | patch -p1
+	$(EMSDKDIR)/emsdk activate $(EMSCRIPTEN_VERSION)
+
+
+$(PYTHONTARBALL):
+	[ -d $(BUILDROOT)/downloads ] || mkdir -p $(BUILDROOT)/downloads
+	wget -q -O $@ $(PYTHONURL)
+
+$(PYTHONBUILD)/.patched: $(PYTHONTARBALL)
+	[ -d $(PYTHONBUILD) ] || ( \
+		mkdir -p $(dir $(PYTHONBUILD));\
+		tar -C $(dir $(PYTHONBUILD)) -xf $(PYTHONTARBALL) \
+	)
+	touch $@
+
+$(PYTHONBUILD)/Makefile: $(PYTHONBUILD)/.patched $(BUILDROOT)/emsdk
+	cd $(PYTHONBUILD) && \
+	CONFIG_SITE=Tools/wasm/config.site-wasm32-emscripten \
+  	emconfigure ./configure -C \
+		--host=wasm32-unknown-emscripten \
+		--build=$(shell $(PYTHONBUILD)/config.guess) \
+		--with-emscripten-target=browser \
+		--enable-wasm-dynamic-linking \
+		--with-build-python=python3.11
+
+$(PYTHONLIBDIR)/libpython$(PYMAJORMINOR).a : $(PYTHONBUILD)/Makefile
+	cd $(PYTHONBUILD) && \
+		emmake make -j3 libpython$(PYMAJORMINOR).a
+
+	_PYTHON_SYSCONFIGDATA_NAME=$(SYSCONFIGDATA_NAME) _PYTHON_PROJECT_BASE=$(PYTHONBUILD) python3.11 -m sysconfig --generate-posix-vars
+	cp `cat pybuilddir.txt`/$(SYSCONFIGDATA_NAME).py $(PYTHONBUILD)/Lib
+
+	mkdir -p $(PYTHONLIBDIR)
+	find $(PYTHONBUILD) -name '*.a' -exec cp {} $(PYTHONLIBDIR) \;
+	cp -r $(PYTHONBUILD)/Lib $(PYTHONLIBDIR)/python$(PYMAJORMINOR)
+
+clean:
+	rm -rf $(BUILDROOT)

--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -1,26 +1,28 @@
 CURDIR=$(abspath .)
 
+# These three are passed in from nox.
 BUILDROOT ?= $(CURDIR)/builddir
+PYMAJORMINORMICRO ?= 3.11.0
+PYPRERELEASE ?= b1 # I'm not sure how to split 3.11.0b1 in Make.
+
+EMSCRIPTEN_VERSION=3.1.13
+
 export EMSDKDIR = $(BUILDROOT)/emsdk
 
 PLATFORM=wasm32_emscripten
 SYSCONFIGDATA_NAME=_sysconfigdata__$(PLATFORM)
 
-# BASH_ENV tells bash to run pyodide_env.sh on startup, which sets various
-# environment variables. The next line instructs make to use bash to run each
-# command.
+# BASH_ENV tells bash to source emsdk_env.sh on startup.
 export BASH_ENV := $(CURDIR)/env.sh
+# Use bash to run each command so that env.sh will be used.
 SHELL := /bin/bash
 
-EMSCRIPTEN_VERSION=3.1.13
 
-PYMAJORMINORMICRO ?= 3.11.0
-PYPRERELEASE ?= b1
-
+# Set version variables.
 version_tuple := $(subst ., ,$(PYMAJORMINORMICRO:v%=%))
-export PYMAJOR=$(word 1,$(version_tuple))
-export PYMINOR=$(word 2,$(version_tuple))
-export PYMICRO=$(word 3,$(version_tuple))
+PYMAJOR=$(word 1,$(version_tuple))
+PYMINOR=$(word 2,$(version_tuple))
+PYMICRO=$(word 3,$(version_tuple))
 PYVERSION=$(PYMAJORMINORMICRO)$(PYPRERELEASE)
 PYMAJORMINOR=$(PYMAJOR).$(PYMINOR)
 
@@ -29,7 +31,7 @@ PYTHONURL=https://www.python.org/ftp/python/$(PYMAJORMINORMICRO)/Python-$(PYVERS
 PYTHONTARBALL=$(BUILDROOT)/downloads/Python-$(PYVERSION).tgz
 PYTHONBUILD=$(BUILDROOT)/build/Python-$(PYVERSION)
 
-export PYTHONLIBDIR=$(BUILDROOT)/install/Python-$(PYVERSION)/lib
+PYTHONLIBDIR=$(BUILDROOT)/install/Python-$(PYVERSION)/lib
 
 all: $(PYTHONLIBDIR)/libpython$(PYMAJORMINOR).a
 
@@ -38,6 +40,7 @@ $(BUILDROOT)/.exists:
 	touch $@
 
 
+# Install emscripten
 $(EMSDKDIR): $(CURDIR)/emscripten_patches/* $(BUILDROOT)/.exists
 	git clone https://github.com/emscripten-core/emsdk.git --depth 1 --branch $(EMSCRIPTEN_VERSION) $(EMSDKDIR)
 	$(EMSDKDIR)/emsdk install $(EMSCRIPTEN_VERSION)
@@ -70,11 +73,15 @@ $(PYTHONLIBDIR)/libpython$(PYMAJORMINOR).a : $(PYTHONBUILD)/Makefile
 	cd $(PYTHONBUILD) && \
 		emmake make -j3 libpython$(PYMAJORMINOR).a
 
+	# Generate sysconfigdata
 	_PYTHON_SYSCONFIGDATA_NAME=$(SYSCONFIGDATA_NAME) _PYTHON_PROJECT_BASE=$(PYTHONBUILD) python3.11 -m sysconfig --generate-posix-vars
 	cp `cat pybuilddir.txt`/$(SYSCONFIGDATA_NAME).py $(PYTHONBUILD)/Lib
 
 	mkdir -p $(PYTHONLIBDIR)
+	# Copy libexpat.a, libmpdec.a, and libpython3.11.a
+	# In noxfile, we explicitly link libexpat and libmpdec via RUSTFLAGS
 	find $(PYTHONBUILD) -name '*.a' -exec cp {} $(PYTHONLIBDIR) \;
+	# Install Python stdlib
 	cp -r $(PYTHONBUILD)/Lib $(PYTHONLIBDIR)/python$(PYMAJORMINOR)
 
 clean:

--- a/emscripten/emscripten_patches/0001-Add-_gxx_personality_v0-stub-to-library.js.patch
+++ b/emscripten/emscripten_patches/0001-Add-_gxx_personality_v0-stub-to-library.js.patch
@@ -1,0 +1,28 @@
+From 4b56f37c3dc9185a235a8314086c4d7a6239b2f8 Mon Sep 17 00:00:00 2001
+From: Hood Chatham <roberthoodchatham@gmail.com>
+Date: Sat, 4 Jun 2022 19:19:47 -0700
+Subject: [PATCH] Add _gxx_personality_v0 stub to library.js
+
+Mitigation for an incompatibility between Rust and Emscripten:
+https://github.com/rust-lang/rust/issues/85821
+https://github.com/emscripten-core/emscripten/issues/17128
+---
+ src/library.js | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/library.js b/src/library.js
+index e7bb4c38e..7d01744df 100644
+--- a/src/library.js
++++ b/src/library.js
+@@ -403,6 +403,8 @@ mergeInto(LibraryManager.library, {
+     abort('Assertion failed: ' + UTF8ToString(condition) + ', at: ' + [filename ? UTF8ToString(filename) : 'unknown filename', line, func ? UTF8ToString(func) : 'unknown function']);
+   },
+ 
++  __gxx_personality_v0: function() {},
++
+   // ==========================================================================
+   // time.h
+   // ==========================================================================
+-- 
+2.25.1
+

--- a/emscripten/env.sh
+++ b/emscripten/env.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+
+# emsdk_env.sh is fairly noisy, and suppress error message if the file doesn't
+# exist yet (i.e. before building emsdk)
+# shellcheck source=/dev/null
+source "$EMSDKDIR/emsdk_env.sh" 2> /dev/null || true
+EMCC_PATH=$(which emcc.py || echo ".")
+EM_DIR=$(dirname "$EMCC_PATH")
+export EM_DIR

--- a/emscripten/env.sh
+++ b/emscripten/env.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-
-# emsdk_env.sh is fairly noisy, and suppress error message if the file doesn't
-# exist yet (i.e. before building emsdk)
-# shellcheck source=/dev/null
+# Activate emsdk environment. emsdk_env.sh writes a lot to stderr so we suppress
+# the output. This also prevents it from complaining when emscripten isn't yet
+# installed.
 source "$EMSDKDIR/emsdk_env.sh" 2> /dev/null || true
-EMCC_PATH=$(which emcc.py || echo ".")
-EM_DIR=$(dirname "$EMCC_PATH")
-export EM_DIR

--- a/emscripten/pybuilddir.txt
+++ b/emscripten/pybuilddir.txt
@@ -1,0 +1,1 @@
+build/lib.linux-x86_64-3.11

--- a/emscripten/runner.py
+++ b/emscripten/runner.py
@@ -1,0 +1,8 @@
+#!/usr/local/bin/python
+import pathlib
+import sys
+import subprocess
+
+p = pathlib.Path(sys.argv[1])
+
+sys.exit(subprocess.call(["node", p.name], cwd=p.parent))

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -6,7 +6,7 @@ use crate::types::PyString;
 #[cfg(target_endian = "little")]
 use libc::wchar_t;
 
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
 #[test]
 fn test_datetime_fromtimestamp() {
     Python::with_gil(|py| {
@@ -24,7 +24,7 @@ fn test_datetime_fromtimestamp() {
     })
 }
 
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
 #[test]
 fn test_date_fromtimestamp() {
     Python::with_gil(|py| {
@@ -42,7 +42,7 @@ fn test_date_fromtimestamp() {
     })
 }
 
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
 #[test]
 fn test_utc_timezone() {
     Python::with_gil(|py| {
@@ -186,7 +186,7 @@ fn ucs4() {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
 #[cfg(not(PyPy))]
 fn test_get_tzinfo() {
     crate::Python::with_gil(|py| {

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -6,6 +6,7 @@ use crate::types::PyString;
 #[cfg(target_endian = "little")]
 use libc::wchar_t;
 
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[test]
 fn test_datetime_fromtimestamp() {
     Python::with_gil(|py| {
@@ -23,6 +24,7 @@ fn test_datetime_fromtimestamp() {
     })
 }
 
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[test]
 fn test_date_fromtimestamp() {
     Python::with_gil(|py| {
@@ -40,6 +42,7 @@ fn test_date_fromtimestamp() {
     })
 }
 
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[test]
 fn test_utc_timezone() {
     Python::with_gil(|py| {
@@ -183,6 +186,7 @@ fn ucs4() {
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[cfg(not(PyPy))]
 fn test_get_tzinfo() {
     crate::Python::with_gil(|py| {

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -729,6 +729,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     fn test_clone_without_gil() {
         use crate::{Py, PyAny};
         use std::{sync::Arc, thread};
@@ -799,6 +800,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     fn test_clone_in_other_thread() {
         use crate::Py;
         use std::{sync::Arc, thread};

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -729,7 +729,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", ignore)]
+    #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
     fn test_clone_without_gil() {
         use crate::{Py, PyAny};
         use std::{sync::Arc, thread};
@@ -800,7 +800,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", ignore)]
+    #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
     fn test_clone_in_other_thread() {
         use crate::Py;
         use std::{sync::Arc, thread};

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -942,6 +942,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     fn test_allow_threads_releases_and_acquires_gil() {
         Python::with_gil(|py| {
             let b = std::sync::Arc::new(std::sync::Barrier::new(2));

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -942,7 +942,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target_arch = "wasm32", ignore)]
+    #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
     fn test_allow_threads_releases_and_acquires_gil() {
         Python::with_gil(|py| {
             let b = std::sync::Arc::new(std::sync::Barrier::new(2));

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -546,7 +546,7 @@ fn opt_to_pyobj(py: Python<'_>, opt: Option<&PyObject>) -> *mut ffi::PyObject {
 #[cfg(test)]
 mod tests {
     #[test]
-    #[cfg_attr(target_arch = "wasm32", ignore)]
+    #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_new_with_fold() {
         crate::Python::with_gil(|py| {
             use crate::types::{PyDateTime, PyTimeAccess};
@@ -561,7 +561,7 @@ mod tests {
 
     #[cfg(not(PyPy))]
     #[test]
-    #[cfg_attr(target_arch = "wasm32", ignore)]
+    #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_get_tzinfo() {
         crate::Python::with_gil(|py| {
             use crate::conversion::ToPyObject;

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -546,6 +546,7 @@ fn opt_to_pyobj(py: Python<'_>, opt: Option<&PyObject>) -> *mut ffi::PyObject {
 #[cfg(test)]
 mod tests {
     #[test]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     fn test_new_with_fold() {
         crate::Python::with_gil(|py| {
             use crate::types::{PyDateTime, PyTimeAccess};
@@ -560,6 +561,7 @@ mod tests {
 
     #[cfg(not(PyPy))]
     #[test]
+    #[cfg_attr(target_arch = "wasm32", ignore)]
     fn test_get_tzinfo() {
         crate::Python::with_gil(|py| {
             use crate::conversion::ToPyObject;

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -229,7 +229,6 @@ impl UnsendableChild {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", ignore)]
 fn test_unsendable<T: PyClass + 'static>() -> PyResult<()> {
     let obj = std::thread::spawn(|| -> PyResult<_> {
         Python::with_gil(|py| {

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -229,6 +229,7 @@ impl UnsendableChild {
     }
 }
 
+#[cfg_attr(target_arch = "wasm32", ignore)]
 fn test_unsendable<T: PyClass + 'static>() -> PyResult<()> {
     let obj = std::thread::spawn(|| -> PyResult<_> {
         Python::with_gil(|py| {
@@ -259,6 +260,7 @@ fn test_unsendable<T: PyClass + 'static>() -> PyResult<()> {
 
 /// If a class is marked as `unsendable`, it panics when accessed by another thread.
 #[test]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[should_panic(
     expected = "test_class_basics::UnsendableBase is unsendable, but sent to another thread!"
 )]
@@ -267,6 +269,7 @@ fn panic_unsendable_base() {
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[should_panic(
     expected = "test_class_basics::UnsendableBase is unsendable, but sent to another thread!"
 )]

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "macros")]
 
 #[rustversion::stable]
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg(not(target_arch = "wasm32"))] // Not possible to invoke compiler from wasm
 #[test]
 fn test_compile_errors() {
     // stable - require all tests to pass
@@ -9,7 +9,7 @@ fn test_compile_errors() {
 }
 
 #[cfg(not(feature = "nightly"))]
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
 #[rustversion::nightly]
 #[test]
 fn test_compile_errors() {
@@ -19,7 +19,7 @@ fn test_compile_errors() {
 }
 
 #[cfg(feature = "nightly")]
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg(not(target_arch = "wasm32"))] // Not possible to invoke compiler from wasm
 #[rustversion::nightly]
 #[test]
 fn test_compile_errors() {

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "macros")]
 
 #[rustversion::stable]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[test]
 fn test_compile_errors() {
     // stable - require all tests to pass
@@ -8,6 +9,7 @@ fn test_compile_errors() {
 }
 
 #[cfg(not(feature = "nightly"))]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[rustversion::nightly]
 #[test]
 fn test_compile_errors() {
@@ -17,6 +19,7 @@ fn test_compile_errors() {
 }
 
 #[cfg(feature = "nightly")]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[rustversion::nightly]
 #[test]
 fn test_compile_errors() {

--- a/tests/test_dict_iter.rs
+++ b/tests/test_dict_iter.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 fn iter_dict_nosegv() {
     let gil = Python::acquire_gil();
     let py = gil.python();

--- a/tests/test_dict_iter.rs
+++ b/tests/test_dict_iter.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg_attr(target_arch = "wasm32", ignore)] // Not sure why this fails.
 fn iter_dict_nosegv() {
     let gil = Python::acquire_gil();
     let py = gil.python();

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -17,7 +17,7 @@ fn fail_to_open_file() -> PyResult<()> {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg_attr(target_arch = "wasm32", ignore)] // Not sure why this fails.
 #[cfg(not(target_os = "windows"))]
 fn test_filenotfounderror() {
     let gil = Python::acquire_gil();

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -17,6 +17,7 @@ fn fail_to_open_file() -> PyResult<()> {
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 #[cfg(not(target_os = "windows"))]
 fn test_filenotfounderror() {
     let gil = Python::acquire_gil();

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -698,6 +698,7 @@ impl OnceFuture {
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 fn test_await() {
     let gil = Python::acquire_gil();
     let py = gil.python();
@@ -747,6 +748,7 @@ impl AsyncIterator {
 }
 
 #[test]
+#[cfg_attr(target_arch = "wasm32", ignore)]
 fn test_anext_aiter() {
     let gil = Python::acquire_gil();
     let py = gil.python();

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -698,7 +698,7 @@ impl OnceFuture {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg(not(target_arch = "wasm32"))] // Won't work without wasm32 event loop (e.g., Pyodide has WebLoop)
 fn test_await() {
     let gil = Python::acquire_gil();
     let py = gil.python();
@@ -748,7 +748,7 @@ impl AsyncIterator {
 }
 
 #[test]
-#[cfg_attr(target_arch = "wasm32", ignore)]
+#[cfg(not(target_arch = "wasm32"))] // Won't work without wasm32 event loop (e.g., Pyodide has WebLoop)
 fn test_anext_aiter() {
     let gil = Python::acquire_gil();
     let py = gil.python();


### PR DESCRIPTION
This adds CI tests for wasm32-emscripten target. CI run builds `libpython3.11.a` for the wasm32-emscripten target and then runs `cargo test` against it.
Resolves #2412.

- [x] fix or xfail broken tests
