### PR TITLE
ffi: tidy descrobject.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix FFI definition `_inittab` field `initfunc` typo'd as `initfun`. [#2431](https://github.com/PyO3/pyo3/pull/2431)
 - Fix FFI definitions `_PyDateTime_BaseTime` and `_PyDateTime_BaseDateTime` incorrectly having `fold` member. [#2432](https://github.com/PyO3/pyo3/pull/2432)
 - Fix FFI definitions `PyTypeObject`. `PyHeapTypeObject`, and `PyCFunctionObject` having incorrect members on PyPy 3.9. [#2428](https://github.com/PyO3/pyo3/pull/2428)
+- Fix FFI definition `PyGetSetDef` to have `*const c_char` for `doc` member (not `*mut c_char`). [#2439](https://github.com/PyO3/pyo3/pull/2439)
 
 ## [0.16.5] - 2022-05-15
 

--- a/pyo3-ffi/src/cpython/descrobject.rs
+++ b/pyo3-ffi/src/cpython/descrobject.rs
@@ -1,0 +1,78 @@
+use crate::{PyGetSetDef, PyMethodDef, PyObject, PyTypeObject};
+use std::os::raw::{c_char, c_int, c_void};
+
+pub type wrapperfunc = Option<
+    unsafe extern "C" fn(
+        slf: *mut PyObject,
+        args: *mut PyObject,
+        wrapped: *mut c_void,
+    ) -> *mut PyObject,
+>;
+
+pub type wrapperfunc_kwds = Option<
+    unsafe extern "C" fn(
+        slf: *mut PyObject,
+        args: *mut PyObject,
+        wrapped: *mut c_void,
+        kwds: *mut PyObject,
+    ) -> *mut PyObject,
+>;
+
+#[repr(C)]
+pub struct wrapperbase {
+    pub name: *const c_char,
+    pub offset: c_int,
+    pub function: *mut c_void,
+    pub wrapper: wrapperfunc,
+    pub doc: *const c_char,
+    pub flags: c_int,
+    pub name_strobj: *mut PyObject,
+}
+
+pub const PyWrapperFlag_KEYWORDS: c_int = 1;
+
+#[repr(C)]
+pub struct PyDescrObject {
+    pub ob_base: PyObject,
+    pub d_type: *mut PyTypeObject,
+    pub d_name: *mut PyObject,
+    pub d_qualname: *mut PyObject,
+}
+
+// skipped non-limited PyDescr_TYPE
+// skipped non-limited PyDescr_NAME
+
+#[repr(C)]
+pub struct PyMethodDescrObject {
+    pub d_common: PyDescrObject,
+    pub d_method: *mut PyMethodDef,
+    #[cfg(all(not(PyPy), Py_3_8))]
+    pub vectorcall: Option<crate::vectorcallfunc>,
+}
+
+#[repr(C)]
+pub struct PyMemberDescrObject {
+    pub d_common: PyDescrObject,
+    pub d_member: *mut PyGetSetDef,
+}
+
+#[repr(C)]
+pub struct PyGetSetDescrObject {
+    pub d_common: PyDescrObject,
+    pub d_getset: *mut PyGetSetDef,
+}
+
+#[repr(C)]
+pub struct PyWrapperDescrObject {
+    pub d_common: PyDescrObject,
+    pub d_base: *mut wrapperbase,
+    pub d_wrapped: *mut c_void,
+}
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
+    pub static mut _PyMethodWrapper_Type: PyTypeObject;
+}
+
+// skipped non-limited PyDescr_NewWrapper
+// skipped non-limited PyDescr_IsData

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod bytesobject;
 pub(crate) mod ceval;
 pub(crate) mod code;
 pub(crate) mod compile;
+pub(crate) mod descrobject;
 #[cfg(not(PyPy))]
 pub(crate) mod dictobject;
 // skipped fileobject.h
@@ -39,6 +40,7 @@ pub use self::bytesobject::*;
 pub use self::ceval::*;
 pub use self::code::*;
 pub use self::compile::*;
+pub use self::descrobject::*;
 #[cfg(not(PyPy))]
 pub use self::dictobject::*;
 pub use self::frameobject::*;

--- a/pyo3-ffi/src/descrobject.rs
+++ b/pyo3-ffi/src/descrobject.rs
@@ -14,7 +14,7 @@ pub struct PyGetSetDef {
     pub name: *mut c_char,
     pub get: Option<getter>,
     pub set: Option<setter>,
-    pub doc: *mut c_char,
+    pub doc: *const c_char,
     pub closure: *mut c_void,
 }
 
@@ -24,87 +24,10 @@ impl Default for PyGetSetDef {
             name: ptr::null_mut(),
             get: None,
             set: None,
-            doc: ptr::null_mut(),
+            doc: ptr::null(),
             closure: ptr::null_mut(),
         }
     }
-}
-
-#[cfg(not(Py_LIMITED_API))]
-pub type wrapperfunc = Option<
-    unsafe extern "C" fn(
-        slf: *mut PyObject,
-        args: *mut PyObject,
-        wrapped: *mut c_void,
-    ) -> *mut PyObject,
->;
-
-#[cfg(not(Py_LIMITED_API))]
-pub type wrapperfunc_kwds = Option<
-    unsafe extern "C" fn(
-        slf: *mut PyObject,
-        args: *mut PyObject,
-        wrapped: *mut c_void,
-        kwds: *mut PyObject,
-    ) -> *mut PyObject,
->;
-
-#[cfg(not(Py_LIMITED_API))]
-#[repr(C)]
-pub struct wrapperbase {
-    pub name: *const c_char,
-    pub offset: c_int,
-    pub function: *mut c_void,
-    pub wrapper: wrapperfunc,
-    pub doc: *const c_char,
-    pub flags: c_int,
-    pub name_strobj: *mut PyObject,
-}
-
-#[cfg(not(Py_LIMITED_API))]
-pub const PyWrapperFlag_KEYWORDS: c_int = 1;
-
-#[cfg(not(Py_LIMITED_API))]
-#[repr(C)]
-pub struct PyDescrObject {
-    pub ob_base: PyObject,
-    pub d_type: *mut PyTypeObject,
-    pub d_name: *mut PyObject,
-    pub d_qualname: *mut PyObject,
-}
-
-// skipped non-limited PyDescr_TYPE
-// skipped non-limited PyDescr_NAME
-
-#[cfg(not(Py_LIMITED_API))]
-#[repr(C)]
-pub struct PyMethodDescrObject {
-    pub d_common: PyDescrObject,
-    pub d_method: *mut PyMethodDef,
-    #[cfg(all(not(PyPy), Py_3_8))]
-    pub vectorcall: Option<crate::vectorcallfunc>,
-}
-
-#[cfg(not(Py_LIMITED_API))]
-#[repr(C)]
-pub struct PyMemberDescrObject {
-    pub d_common: PyDescrObject,
-    pub d_member: *mut PyGetSetDef,
-}
-
-#[cfg(not(Py_LIMITED_API))]
-#[repr(C)]
-pub struct PyGetSetDescrObject {
-    pub d_common: PyDescrObject,
-    pub d_getset: *mut PyGetSetDef,
-}
-
-#[cfg(not(Py_LIMITED_API))]
-#[repr(C)]
-pub struct PyWrapperDescrObject {
-    pub d_common: PyDescrObject,
-    pub d_base: *mut wrapperbase,
-    pub d_wrapped: *mut c_void,
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
@@ -121,7 +44,8 @@ extern "C" {
     pub static mut PyWrapperDescr_Type: PyTypeObject;
     #[cfg_attr(PyPy, link_name = "PyPyDictProxy_Type")]
     pub static mut PyDictProxy_Type: PyTypeObject;
-    // skipped non-limited _PyMethodWrapper_Type
+    #[cfg_attr(PyPy, link_name = "PyPyProperty_Type")]
+    pub static mut PyProperty_Type: PyTypeObject;
 }
 
 extern "C" {
@@ -129,14 +53,12 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyDescr_NewClassMethod")]
     pub fn PyDescr_NewClassMethod(arg1: *mut PyTypeObject, arg2: *mut PyMethodDef)
         -> *mut PyObject;
+    #[cfg_attr(PyPy, link_name = "PyPyDescr_NewMember")]
     pub fn PyDescr_NewMember(arg1: *mut PyTypeObject, arg2: *mut PyMemberDef) -> *mut PyObject;
+    #[cfg_attr(PyPy, link_name = "PyPyDescr_NewGetSet")]
     pub fn PyDescr_NewGetSet(arg1: *mut PyTypeObject, arg2: *mut PyGetSetDef) -> *mut PyObject;
-    // skipped non-limited PyDescr_NewWrapper
-    // skipped non-limited PyDescr_IsData
+
     #[cfg_attr(PyPy, link_name = "PyPyDictProxy_New")]
     pub fn PyDictProxy_New(arg1: *mut PyObject) -> *mut PyObject;
     pub fn PyWrapper_New(arg1: *mut PyObject, arg2: *mut PyObject) -> *mut PyObject;
-
-    #[cfg_attr(PyPy, link_name = "PyPyProperty_Type")]
-    pub static mut PyProperty_Type: PyTypeObject;
 }

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -375,7 +375,7 @@ fn method_defs_to_pyclass_info(
             name: "__dict__\0".as_ptr() as *mut c_char,
             get: Some(ffi::PyObject_GenericGetDict),
             set: Some(ffi::PyObject_GenericSetDict),
-            doc: ptr::null_mut(),
+            doc: ptr::null(),
             closure: ptr::null_mut(),
         });
     }
@@ -435,7 +435,7 @@ const PY_GET_SET_DEF_INIT: ffi::PyGetSetDef = ffi::PyGetSetDef {
     name: ptr::null_mut(),
     get: None,
     set: None,
-    doc: ptr::null_mut(),
+    doc: ptr::null(),
     closure: ptr::null_mut(),
 };
 


### PR DESCRIPTION
Just noticed earlier that upstream CPython now splits this in the typical `include/` and `include/cpython` way, so thought I'd mirror here.