### PR TITLE
Prototype: Runtime inspection and Pyi generation

### DIFF
--- a/pyo3-macros-backend/src/inspect.rs
+++ b/pyo3-macros-backend/src/inspect.rs
@@ -28,18 +28,18 @@ pub(crate) fn generate_class_inspection(
     let name = Literal::string(&*get_class_python_name(cls, args).to_string());
 
     quote! {
-        const #class_field_info: [pyo3::interface::FieldInfo; 0] = [
+        const #class_field_info: [&'static _pyo3::inspect::fields::FieldInfo<'static>; 0] = [
             //TODO
         ];
 
-        const #class_info: pyo3::interface::ClassInfo = pyo3::interface::ClassInfo {
+        const #class_info: _pyo3::inspect::classes::ClassStructInfo<'static> = _pyo3::inspect::classes::ClassStructInfo {
             name: #name,
-            base: "", //TODO
+            base: ::std::option::Option::None, //TODO
             fields: &#class_field_info,
         };
 
-        impl pyo3::interface::GetClassInfo for #cls {
-            fn info() -> &'static pyo3::interface::ClassInfo {
+        impl _pyo3::inspect::classes::InspectStruct<'static> for #cls {
+            fn inspect_struct() -> &'static _pyo3::inspect::classes::ClassStructInfo<'static> {
                 &#class_info
             }
         }
@@ -64,12 +64,12 @@ pub(crate) fn generate_impl_inspection(
         .map(|field| quote!(&#field));
 
     quote! {
-        const #fields_info: [&'static pyo3::interface::FieldInfo; #field_size] = [
+        const #fields_info: [&'static _pyo3::inspect::fields::FieldInfo<'static>; #field_size] = [
             #(#fields),*
         ];
 
-        impl pyo3::interface::GetClassFields for #cls {
-            fn fields_info() -> &'static [&'static pyo3::interface::FieldInfo] {
+        impl _pyo3::inspect::classes::InspectImpl<'static> for #cls {
+            fn inspect_impl() -> &'static [&'static _pyo3::inspect::fields::FieldInfo<'static>] {
                 &#fields_info
             }
         }
@@ -92,23 +92,23 @@ pub(crate) fn generate_fields_inspection(
 
     let field_name = TokenTree::Literal(Literal::string(&*field.method_name));
     let field_kind = match &field.spec.tp {
-        FnType::Getter(_) => quote!(pyo3::interface::FieldKind::Getter),
-        FnType::Setter(_) => quote!(pyo3::interface::FieldKind::Setter),
-        FnType::Fn(_) => quote!(pyo3::interface::FieldKind::Function),
-        FnType::FnNew => quote!(pyo3::interface::FieldKind::New),
-        FnType::FnClass => quote!(pyo3::interface::FieldKind::ClassMethod),
-        FnType::FnStatic => quote!(pyo3::interface::FieldKind::StaticMethod),
+        FnType::Getter(_) => quote!(_pyo3::inspect::fields::FieldKind::Getter),
+        FnType::Setter(_) => quote!(_pyo3::inspect::fields::FieldKind::Setter),
+        FnType::Fn(_) => quote!(_pyo3::inspect::fields::FieldKind::Function),
+        FnType::FnNew => quote!(_pyo3::inspect::fields::FieldKind::New),
+        FnType::FnClass => quote!(_pyo3::inspect::fields::FieldKind::ClassMethod),
+        FnType::FnStatic => quote!(_pyo3::inspect::fields::FieldKind::StaticMethod),
         FnType::FnModule => todo!("FnModule is not currently supported"),
-        FnType::ClassAttribute => quote!(pyo3::interface::FieldKind::ClassAttribute),
+        FnType::ClassAttribute => quote!(_pyo3::inspect::fields::FieldKind::ClassAttribute),
     };
 
     let output = quote! {
-        const #field_args_name: [pyo3::interface::ArgumentInfo; 0] = []; //TODO
+        const #field_args_name: [_pyo3::inspect::fields::ArgumentInfo<'static>; 0] = []; //TODO
 
-        const #field_info_name: pyo3::interface::FieldInfo = pyo3::interface::FieldInfo {
+        const #field_info_name: _pyo3::inspect::fields::FieldInfo<'static> = _pyo3::inspect::fields::FieldInfo {
             name: #field_name,
             kind: #field_kind,
-            py_type: None, //TODO
+            py_type: ::std::option::Option::None, //TODO
             arguments: &#field_args_name,
         };
     };

--- a/pyo3-macros-backend/src/inspect.rs
+++ b/pyo3-macros-backend/src/inspect.rs
@@ -1,0 +1,166 @@
+//! Generates static structures for runtime inspection of the Python objects
+//!
+//! The goal is to enable Rust code to implement features similar to Python's `dict(obj)`.
+//! The generated structures are read-only.
+
+use proc_macro2::{Ident, Literal, TokenStream, TokenTree};
+use quote::{format_ident, quote};
+use syn::spanned::Spanned;
+use syn::Type;
+use crate::method::FnType;
+use crate::pyclass::{FieldPyO3Options, get_class_python_name};
+use crate::PyClassArgs;
+use crate::pymethod::PyMethod;
+
+/// Extracts inspection information from the `#[pyclass]` macro.
+///
+/// Extracted information:
+/// - Name of the class
+pub(crate) fn generate_class_inspection(
+    cls: &Ident,
+    args: &PyClassArgs,
+    field_options: &Vec<(&syn::Field, FieldPyO3Options)>,
+) -> TokenStream {
+    let ident_prefix = format_ident!("_path_{}", cls);
+    let class_field_info = format_ident!("{}_struct_field_info", ident_prefix);
+    let class_info = format_ident!("{}_struct_info", ident_prefix);
+
+    let name = Literal::string(&*get_class_python_name(cls, args).to_string());
+
+    quote! {
+        const #class_field_info: [pyo3::interface::FieldInfo; 0] = [
+            //TODO
+        ];
+
+        const #class_info: pyo3::interface::ClassInfo = pyo3::interface::ClassInfo {
+            name: #name,
+            base: "", //TODO
+            fields: &#class_field_info,
+        };
+
+        impl pyo3::interface::GetClassInfo for #cls {
+            fn info() -> &'static pyo3::interface::ClassInfo {
+                &#class_info
+            }
+        }
+    }
+}
+
+/// Extracts information from an impl block annotated with `#[pymethods]`.
+///
+/// Currently, generating information from multiple impl blocks for the same class is not possible
+/// (name collision in the generated structures and trait implementation), which makes inspection incompatible
+/// with `multiple-pymethods`.
+pub(crate) fn generate_impl_inspection(
+    cls: &Type,
+    fields: Vec<Ident>
+) -> TokenStream {
+    let ident_prefix = generate_unique_ident(cls, None);
+    let fields_info = format_ident!("{}_fields_info", ident_prefix);
+
+    let field_size = Literal::usize_suffixed(fields.len());
+
+    let fields = fields.iter()
+        .map(|field| quote!(&#field));
+
+    quote! {
+        const #fields_info: [&'static pyo3::interface::FieldInfo; #field_size] = [
+            #(#fields),*
+        ];
+
+        impl pyo3::interface::GetClassFields for #cls {
+            fn fields_info() -> &'static [&'static pyo3::interface::FieldInfo] {
+                &#fields_info
+            }
+        }
+    }
+}
+
+/// Generates information from a field in a `#[pymethods]` block.
+///
+/// Extracted information:
+/// - Field name
+/// - Field kind (getter / setter / constructor / function / static method / …)
+pub(crate) fn generate_fields_inspection(
+    cls: &Type,
+    field: &PyMethod<'_>
+) -> (TokenStream, Ident) {
+    let ident_prefix = generate_unique_ident(cls, Some(field.spec.name));
+
+    let field_info_name = format_ident!("{}_info", ident_prefix);
+    let field_args_name = format_ident!("{}_args", ident_prefix);
+
+    let field_name = TokenTree::Literal(Literal::string(&*field.method_name));
+    let field_kind = match &field.spec.tp {
+        FnType::Getter(_) => quote!(pyo3::interface::FieldKind::Getter),
+        FnType::Setter(_) => quote!(pyo3::interface::FieldKind::Setter),
+        FnType::Fn(_) => quote!(pyo3::interface::FieldKind::Function),
+        FnType::FnNew => quote!(pyo3::interface::FieldKind::New),
+        FnType::FnClass => quote!(pyo3::interface::FieldKind::ClassMethod),
+        FnType::FnStatic => quote!(pyo3::interface::FieldKind::StaticMethod),
+        FnType::FnModule => todo!("FnModule is not currently supported"),
+        FnType::ClassAttribute => quote!(pyo3::interface::FieldKind::ClassAttribute),
+    };
+
+    let output = quote! {
+        const #field_args_name: [pyo3::interface::ArgumentInfo; 0] = []; //TODO
+
+        const #field_info_name: pyo3::interface::FieldInfo = pyo3::interface::FieldInfo {
+            name: #field_name,
+            kind: #field_kind,
+            py_type: None, //TODO
+            arguments: &#field_args_name,
+        };
+    };
+
+    (output, field_info_name)
+}
+
+/// Generates a unique identifier based on a type and (optionally) a field.
+///
+/// For the same input values, the result should be the same output, and for different input values,
+/// the output should be different. No other guarantees are made (do not try to parse it).
+fn generate_unique_ident(class: &Type, field: Option<&Ident>) -> Ident {
+    let span = if let Some(field) = field {
+        field.span()
+    } else {
+        class.span()
+    };
+
+    let mut result = "".to_string();
+
+    // Attempt to generate something unique for each type
+    // Types that cannot be annotated with #[pyclass] are ignored
+    match class {
+        Type::Array(_) => unreachable!("Cannot generate a unique name for an array: {:?}", class),
+        Type::BareFn(_) => unreachable!("Cannot generate a unique name for a function: {:?}", class),
+        Type::Group(_) => unreachable!("Cannot generate a unique name for a group: {:?}", class),
+        Type::ImplTrait(_) => unreachable!("Cannot generate a unique name for an impl trait: {:?}", class),
+        Type::Infer(_) => unreachable!("Cannot generate a unique name for an inferred type: {:?}", class),
+        Type::Macro(_) => unreachable!("Cannot generate a unique name for a macro: {:?}", class),
+        Type::Never(_) => {
+            result += "_never";
+        },
+        Type::Paren(_) => unreachable!("Cannot generate a unique name for a type in parenthesis: {:?}", class),
+        Type::Path(path) => {
+            result += "_path";
+            for segment in &path.path.segments {
+                result += "_";
+                result += &*segment.ident.to_string();
+            }
+        }
+        Type::Ptr(_) => unreachable!("Cannot generate a unique name for a pointer: {:?}", class),
+        Type::Reference(_) => unreachable!("Cannot generate a unique name for a reference: {:?}", class),
+        Type::Slice(_) => unreachable!("Cannot generate a unique name for a slice: {:?}", class),
+        Type::TraitObject(_) => unreachable!("Cannot generate a unique name for a trait object: {:?}", class),
+        Type::Tuple(_) => unreachable!("Cannot generate a unique name for a tuple: {:?}", class),
+        _ => unreachable!("Cannot generate a unique name for an unknown type: {:?}", class),
+    }
+
+    if let Some(field) = field {
+        result += "_";
+        result += &*field.to_string()
+    }
+
+    Ident::new(&*result, span)
+}

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -26,6 +26,7 @@ mod pyimpl;
 mod pymethod;
 #[cfg(feature = "pyproto")]
 mod pyproto;
+mod inspect;
 
 pub use frompyobject::build_derive_from_pyobject;
 pub use module::{process_functions_in_module, pymodule_impl, PyModuleOptions};

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -15,7 +15,7 @@ use crate::pymethod::{
 };
 use crate::utils::{self, get_pyo3_crate, PythonDoc};
 use crate::PyFunctionOptions;
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::{Literal, Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream};
@@ -1006,13 +1006,15 @@ fn generate_class_info(
     let class_field_info = format_ident!("{}_struct_field_info", ident_prefix);
     let class_info = format_ident!("{}_struct_info", ident_prefix);
 
+    let name = Literal::string(&*get_class_python_name(cls, args).to_string());
+
     quote! {
         const #class_field_info: [pyo3::interface::FieldInfo; 0] = [
             //TODO
         ];
 
         const #class_info: pyo3::interface::ClassInfo = pyo3::interface::ClassInfo {
-            name: "", //TODO
+            name: #name,
             base: "", //TODO
             fields: &#class_field_info,
         };

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -225,9 +225,9 @@ pub fn build_py_class(
 
 /// `#[pyo3()]` options for pyclass fields
 pub(crate) struct FieldPyO3Options {
-    get: bool,
-    set: bool,
-    name: Option<NameAttribute>,
+    pub(crate) get: bool,
+    pub(crate) set: bool,
+    pub(crate) name: Option<NameAttribute>,
 }
 
 enum FieldPyO3Option {

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -9,7 +9,7 @@ use crate::{
     pymethod::{self, is_proto_method},
     utils::get_pyo3_crate,
 };
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::{Ident, Literal, TokenStream};
 use pymethod::GeneratedPyMethod;
 use quote::{format_ident, quote};
 use syn::{parse::{Parse, ParseStream}, spanned::Spanned, Result, Type};
@@ -279,14 +279,17 @@ fn get_cfg_attributes(attrs: &[syn::Attribute]) -> Vec<&syn::Attribute> {
 }
 
 fn generate_impl_info(cls: &Type, fields: Vec<Ident>) -> TokenStream {
-    println!("Generating impl {:?}", cls);
-
     let ident_prefix = generate_unique_ident(cls, None);
     let fields_info = format_ident!("{}_fields_info", ident_prefix);
 
+    let field_size = Literal::usize_suffixed(fields.len());
+
+    let fields = fields.iter()
+        .map(|field| quote!(&#field));
+
     quote! {
-        const #fields_info: [&'static pyo3::interface::FieldInfo; 0] = [
-            //TODO
+        const #fields_info: [&'static pyo3::interface::FieldInfo; #field_size] = [
+            #(#fields),*
         ];
 
         impl pyo3::interface::GetClassFields for #cls {

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -103,7 +103,9 @@ pub fn impl_methods(
             syn::ImplItem::Method(meth) => {
                 let mut fun_options = PyFunctionOptions::from_attrs(&mut meth.attrs)?;
                 fun_options.krate = fun_options.krate.or_else(|| options.krate.clone());
-                match pymethod::gen_py_method(ty, &mut meth.sig, &mut meth.attrs, fun_options)? {
+                let (method, interface) = pymethod::gen_py_method(ty, &mut meth.sig, &mut meth.attrs, fun_options)?;
+                trait_impls.push(interface);
+                match method {
                     GeneratedPyMethod::Method(token_stream) => {
                         let attrs = get_cfg_attributes(&meth.attrs);
                         methods.push(quote!(#(#attrs)* #token_stream));

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1249,13 +1249,23 @@ fn generate_get_field_info(cls: &syn::Type, field: &PyMethod<'_>) -> (TokenStrea
     let field_args_name = format_ident!("{}_args", ident_prefix);
 
     let field_name = TokenTree::Literal(Literal::string(&*field.method_name));
+    let field_kind = match &field.spec.tp {
+        FnType::Getter(_) => quote!(pyo3::interface::FieldKind::Getter),
+        FnType::Setter(_) => quote!(pyo3::interface::FieldKind::Setter),
+        FnType::Fn(_) => quote!(pyo3::interface::FieldKind::Function),
+        FnType::FnNew => quote!(pyo3::interface::FieldKind::New),
+        FnType::FnClass => quote!(pyo3::interface::FieldKind::ClassMethod),
+        FnType::FnStatic => quote!(pyo3::interface::FieldKind::StaticMethod),
+        FnType::FnModule => todo!("FnModule is not currently supported"),
+        FnType::ClassAttribute => quote!(pyo3::interface::FieldKind::ClassAttribute),
+    };
 
     let output = quote! {
         const #field_args_name: [pyo3::interface::ArgumentInfo; 0] = []; //TODO
 
         const #field_info_name: pyo3::interface::FieldInfo = pyo3::interface::FieldInfo {
             name: #field_name,
-            kind: pyo3::interface::FieldKind::New, //TODO
+            kind: #field_kind,
             py_type: None, //TODO
             arguments: &#field_args_name,
         };

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -4,7 +4,6 @@ use std::borrow::Cow;
 
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
-use syn::Type;
 use syn::{spanned::Spanned, Ident};
 
 use crate::attributes::{CrateAttribute, TextSignatureAttribute};
@@ -178,53 +177,4 @@ pub(crate) fn get_pyo3_crate(attr: &Option<CrateAttribute>) -> syn::Path {
     attr.as_ref()
         .map(|p| p.value.0.clone())
         .unwrap_or_else(|| syn::parse_str("::pyo3").unwrap())
-}
-
-/// Generates a unique identifier based on a type and (optionally) a field.
-///
-/// For the same input values, the result should be the same output, and for different input values,
-/// the output should be different. No other guarantees are made (do not try to parse it).
-pub(crate) fn generate_unique_ident(class: &Type, field: Option<&Ident>) -> Ident {
-    let span = if let Some(field) = field {
-        field.span()
-    } else {
-        class.span()
-    };
-
-    let mut result = "".to_string();
-
-    // Attempt to generate something unique for each type
-    // Types that cannot be annotated with #[pyclass] are ignored
-    match class {
-        Type::Array(_) => unreachable!("Cannot generate a unique name for an array: {:?}", class),
-        Type::BareFn(_) => unreachable!("Cannot generate a unique name for a function: {:?}", class),
-        Type::Group(_) => unreachable!("Cannot generate a unique name for a group: {:?}", class),
-        Type::ImplTrait(_) => unreachable!("Cannot generate a unique name for an impl trait: {:?}", class),
-        Type::Infer(_) => unreachable!("Cannot generate a unique name for an inferred type: {:?}", class),
-        Type::Macro(_) => unreachable!("Cannot generate a unique name for a macro: {:?}", class),
-        Type::Never(_) => {
-            result += "_never";
-        },
-        Type::Paren(_) => unreachable!("Cannot generate a unique name for a type in parenthesis: {:?}", class),
-        Type::Path(path) => {
-            result += "_path";
-            for segment in &path.path.segments {
-                result += "_";
-                result += &*segment.ident.to_string();
-            }
-        }
-        Type::Ptr(_) => unreachable!("Cannot generate a unique name for a pointer: {:?}", class),
-        Type::Reference(_) => unreachable!("Cannot generate a unique name for a reference: {:?}", class),
-        Type::Slice(_) => unreachable!("Cannot generate a unique name for a slice: {:?}", class),
-        Type::TraitObject(_) => unreachable!("Cannot generate a unique name for a trait object: {:?}", class),
-        Type::Tuple(_) => unreachable!("Cannot generate a unique name for a tuple: {:?}", class),
-        _ => unreachable!("Cannot generate a unique name for an unknown type: {:?}", class),
-    }
-
-    if let Some(field) = field {
-        result += "_";
-        result += &*field.to_string()
-    }
-
-    Ident::new(&*result, span)
 }

--- a/src/conversions/array.rs
+++ b/src/conversions/array.rs
@@ -7,6 +7,7 @@ mod min_const_generics {
     use crate::{
         ffi, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, PyTryFrom, Python, ToPyObject,
     };
+    use crate::inspect::types::TypeInfo;
 
     impl<T, const N: usize> IntoPy<PyObject> for [T; N]
     where
@@ -37,6 +38,10 @@ mod min_const_generics {
                 list
             }
         }
+
+        fn type_output() -> TypeInfo {
+            TypeInfo::List(Box::new(T::type_output()))
+        }
     }
 
     impl<T, const N: usize> ToPyObject for [T; N]
@@ -54,6 +59,10 @@ mod min_const_generics {
     {
         fn extract(obj: &'a PyAny) -> PyResult<Self> {
             create_array_from_obj(obj)
+        }
+
+        fn type_input() -> TypeInfo {
+            TypeInfo::Sequence(Box::new(T::type_input()))
         }
     }
 
@@ -179,6 +188,7 @@ mod array_impls {
         ffi, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, PyTryFrom, Python, ToPyObject,
     };
     use std::mem::{transmute_copy, ManuallyDrop};
+    use crate::inspect::types::TypeInfo;
 
     macro_rules! array_impls {
         ($($N:expr),+) => {
@@ -238,6 +248,10 @@ mod array_impls {
                             list
                         }
                     }
+
+                    fn type_output() -> TypeInfo {
+                        TypeInfo::List(Box::new(T::type_output()))
+                    }
                 }
 
                 impl<T> ToPyObject for [T; $N]
@@ -257,6 +271,10 @@ mod array_impls {
                         let mut array = [T::default(); $N];
                         extract_sequence_into_slice(obj, &mut array)?;
                         Ok(array)
+                    }
+
+                    fn type_input() -> TypeInfo {
+                        TypeInfo::Sequence(Box::new(T::type_input()))
                     }
                 }
             )+

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -26,6 +26,7 @@ use crate::{
     FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, PyTryFrom, Python, ToPyObject,
 };
 use std::{cmp, hash};
+use crate::inspect::types::TypeInfo;
 
 impl<K, V, H> ToPyObject for hashbrown::HashMap<K, V, H>
 where
@@ -50,6 +51,10 @@ where
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
         IntoPyDict::into_py_dict(iter, py).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Dict(Box::new(K::type_output()), Box::new(V::type_output()))
+    }
 }
 
 impl<'source, K, V, S> FromPyObject<'source> for hashbrown::HashMap<K, V, S>
@@ -65,6 +70,10 @@ where
             ret.insert(K::extract(k)?, V::extract(v)?);
         }
         Ok(ret)
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Mapping(Box::new(K::type_input()), Box::new(V::type_input()))
     }
 }
 
@@ -97,6 +106,10 @@ where
         }
         set.into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Set(Box::new(K::type_output()))
+    }
 }
 
 impl<'source, K, S> FromPyObject<'source> for hashbrown::HashSet<K, S>
@@ -107,6 +120,10 @@ where
     fn extract(ob: &'source PyAny) -> PyResult<Self> {
         let set: &PySet = ob.downcast()?;
         set.iter().map(K::extract).collect()
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Set(Box::new(K::type_input()))
     }
 }
 

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -95,6 +95,7 @@
 use crate::types::*;
 use crate::{FromPyObject, IntoPy, PyErr, PyObject, PyTryFrom, Python, ToPyObject};
 use std::{cmp, hash};
+use crate::inspect::types::TypeInfo;
 
 impl<K, V, H> ToPyObject for indexmap::IndexMap<K, V, H>
 where
@@ -119,6 +120,10 @@ where
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
         IntoPyDict::into_py_dict(iter, py).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Dict(Box::new(K::type_output()), Box::new(V::type_output()))
+    }
 }
 
 impl<'source, K, V, S> FromPyObject<'source> for indexmap::IndexMap<K, V, S>
@@ -134,6 +139,10 @@ where
             ret.insert(K::extract(k)?, V::extract(v)?);
         }
         Ok(ret)
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Dict(Box::new(K::type_input()), Box::new(V::type_input()))
     }
 }
 

--- a/src/conversions/osstr.rs
+++ b/src/conversions/osstr.rs
@@ -9,6 +9,7 @@ use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
 #[cfg(not(windows))]
 use std::os::raw::c_char;
+use crate::inspect::types::TypeInfo;
 
 impl ToPyObject for OsStr {
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -115,6 +116,10 @@ impl IntoPy<PyObject> for &'_ OsStr {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.to_object(py)
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("str")
+    }
 }
 
 impl ToPyObject for Cow<'_, OsStr> {
@@ -129,6 +134,10 @@ impl IntoPy<PyObject> for Cow<'_, OsStr> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.to_object(py)
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("str")
+    }
 }
 
 impl ToPyObject for OsString {
@@ -142,11 +151,19 @@ impl IntoPy<PyObject> for OsString {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.to_object(py)
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("str")
+    }
 }
 
 impl<'a> IntoPy<PyObject> for &'a OsString {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.to_object(py)
+    }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("str")
     }
 }
 

--- a/src/conversions/path.rs
+++ b/src/conversions/path.rs
@@ -2,8 +2,9 @@ use crate::intern;
 use crate::types::PyType;
 use crate::{FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
 use std::borrow::Cow;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
+use crate::inspect::types::TypeInfo;
 
 impl ToPyObject for Path {
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -38,6 +39,10 @@ impl<'a> IntoPy<PyObject> for &'a Path {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.as_os_str().to_object(py)
     }
+
+    fn type_output() -> TypeInfo {
+        <&OsStr>::type_output()
+    }
 }
 
 impl<'a> ToPyObject for Cow<'a, Path> {
@@ -52,6 +57,10 @@ impl<'a> IntoPy<PyObject> for Cow<'a, Path> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.to_object(py)
     }
+
+    fn type_output() -> TypeInfo {
+        <&OsStr>::type_output()
+    }
 }
 
 impl ToPyObject for PathBuf {
@@ -65,11 +74,19 @@ impl IntoPy<PyObject> for PathBuf {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_os_string().to_object(py)
     }
+
+    fn type_output() -> TypeInfo {
+        <OsString>::type_output()
+    }
 }
 
 impl<'a> IntoPy<PyObject> for &'a PathBuf {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.as_os_str().to_object(py)
+    }
+
+    fn type_output() -> TypeInfo {
+        <&OsStr>::type_output()
     }
 }
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -18,6 +18,7 @@ mod impls;
 
 pub use err_state::PyErrArguments;
 use err_state::{boxed_args, PyErrState, PyErrStateNormalized};
+use crate::inspect::types::TypeInfo;
 
 /// Represents a Python exception.
 ///
@@ -675,6 +676,10 @@ impl IntoPy<PyObject> for PyErr {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_value(py).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("Exception")
+    }
 }
 
 impl ToPyObject for PyErr {
@@ -686,6 +691,10 @@ impl ToPyObject for PyErr {
 impl<'a> IntoPy<PyObject> for &'a PyErr {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.clone_ref(py).into_py(py)
+    }
+
+    fn type_output() -> TypeInfo {
+        <PyErr>::type_output()
     }
 }
 

--- a/src/inspect/classes.rs
+++ b/src/inspect/classes.rs
@@ -1,0 +1,66 @@
+use crate::inspect::fields::FieldInfo;
+
+/// Information about a Python class.
+#[derive(Debug)]
+pub struct ClassInfo<'a> {
+    /// Base information about the class.
+    pub class: &'a ClassStructInfo<'a>,
+
+    /// Information found in `#[pymethods]`.
+    pub fields: &'a [&'a FieldInfo<'a>],
+}
+
+/// Subset of available information about a Python class, including only what is available by parsing the `#[pyclass]`
+/// block (methods are missing).
+#[derive(Debug)]
+pub struct ClassStructInfo<'a> {
+    pub name: &'a str,
+    pub base: Option<&'a str>,
+    pub fields: &'a [&'a FieldInfo<'a>],
+}
+
+impl<'a> ClassInfo<'a> {
+    /// The Python name of this class.
+    pub fn name(&'a self) -> &'a str {
+        self.class.name
+    }
+
+    /// The Python's base class.
+    pub fn base(&'a self) -> Option<&'a str> {
+        self.class.base
+    }
+
+    /// All fields of the class.
+    ///
+    /// This includes:
+    /// - struct attributes annotated with `#[getter]` or `#[setter]`
+    /// - methods that appear in a `#[pymethods]` block
+    pub fn fields(&'a self) -> impl Iterator<Item=&'a &'a FieldInfo<'a>> + 'a {
+        self.class.fields
+            .iter()
+            .chain(self.fields)
+    }
+}
+
+pub trait InspectClass<'a> {
+    fn inspect() -> ClassInfo<'a>;
+}
+
+pub trait InspectStruct<'a> {
+    fn inspect_struct() -> &'a ClassStructInfo<'a>;
+}
+
+pub trait InspectImpl<'a> {
+    fn inspect_impl() -> &'a [&'a FieldInfo<'a>];
+}
+
+impl<'a, T> InspectClass<'a> for T
+    where T: InspectStruct<'a>, T: InspectImpl<'a>
+{
+    fn inspect() -> ClassInfo<'a> {
+        ClassInfo {
+            class: Self::inspect_struct(),
+            fields: Self::inspect_impl(),
+        }
+    }
+}

--- a/src/inspect/fields.rs
+++ b/src/inspect/fields.rs
@@ -5,7 +5,7 @@ use crate::inspect::types::TypeInfo;
 pub struct FieldInfo<'a> {
     pub name: &'a str,
     pub kind: FieldKind,
-    pub py_type: Option<&'a TypeInfo<'a>>,
+    pub py_type: Option<fn() -> TypeInfo>,
     pub arguments: &'a [ArgumentInfo<'a>],
 }
 
@@ -33,7 +33,7 @@ pub enum FieldKind {
 pub struct ArgumentInfo<'a> {
     pub name: &'a str,
     pub kind: ArgumentKind,
-    pub py_type: Option<&'a TypeInfo<'a>>,
+    pub py_type: Option<fn() -> TypeInfo>,
     pub default_value: bool,
     pub is_modified: bool,
 }

--- a/src/inspect/fields.rs
+++ b/src/inspect/fields.rs
@@ -13,8 +13,6 @@ pub struct FieldInfo<'a> {
 pub enum FieldKind {
     /// The special 'new' method
     New,
-    /// A top-level or instance attribute
-    Attribute,
     /// A top-level or instance getter
     Getter,
     /// A top-level or instance setter
@@ -41,12 +39,14 @@ pub struct ArgumentInfo<'a> {
 #[derive(Debug)]
 pub enum ArgumentKind {
     /// A normal argument, that can be passed positionally or by keyword.
-    Regular,
+    PositionOrKeyword,
     /// A normal argument that can only be passed positionally (not by keyword).
-    PositionalOnly,
+    Position,
+    /// A normal argument that can only be passed by keyword (not positionally).
+    Keyword,
     /// An argument that represents all positional arguments that were provided on the call-site
     /// but do not match any declared regular argument.
-    Vararg,
+    VarArg,
     /// An argument that represents all keyword arguments that were provided on the call-site
     /// but do not match any declared regular argument.
     KeywordArg,

--- a/src/inspect/fields.rs
+++ b/src/inspect/fields.rs
@@ -1,0 +1,53 @@
+use crate::inspect::types::TypeInfo;
+
+/// Python Interface information for a field (attribute, function, method…).
+#[derive(Debug)]
+pub struct FieldInfo<'a> {
+    pub name: &'a str,
+    pub kind: FieldKind,
+    pub py_type: Option<&'a TypeInfo<'a>>,
+    pub arguments: &'a [ArgumentInfo<'a>],
+}
+
+#[derive(Debug)]
+pub enum FieldKind {
+    /// The special 'new' method
+    New,
+    /// A top-level or instance attribute
+    Attribute,
+    /// A top-level or instance getter
+    Getter,
+    /// A top-level or instance setter
+    Setter,
+    /// A top-level function or an instance method
+    Function,
+    /// A class method
+    ClassMethod,
+    /// A class attribute
+    ClassAttribute,
+    /// A static method
+    StaticMethod,
+}
+
+#[derive(Debug)]
+pub struct ArgumentInfo<'a> {
+    pub name: &'a str,
+    pub kind: ArgumentKind,
+    pub py_type: Option<&'a TypeInfo<'a>>,
+    pub default_value: bool,
+    pub is_modified: bool,
+}
+
+#[derive(Debug)]
+pub enum ArgumentKind {
+    /// A normal argument, that can be passed positionally or by keyword.
+    Regular,
+    /// A normal argument that can only be passed positionally (not by keyword).
+    PositionalOnly,
+    /// An argument that represents all positional arguments that were provided on the call-site
+    /// but do not match any declared regular argument.
+    Vararg,
+    /// An argument that represents all keyword arguments that were provided on the call-site
+    /// but do not match any declared regular argument.
+    KeywordArg,
+}

--- a/src/inspect/interface.rs
+++ b/src/inspect/interface.rs
@@ -1,7 +1,6 @@
 //! Generates a Python interface file (.pyi) using the inspected elements.
 
 use std::fmt::{Display, Formatter};
-use libc::write;
 use crate::inspect::classes::ClassInfo;
 use crate::inspect::fields::{ArgumentInfo, ArgumentKind, FieldInfo, FieldKind};
 

--- a/src/inspect/interface.rs
+++ b/src/inspect/interface.rs
@@ -1,0 +1,150 @@
+//! Generates a Python interface file (.pyi) using the inspected elements.
+
+use std::fmt::{Display, Formatter};
+use libc::write;
+use crate::inspect::classes::ClassInfo;
+use crate::inspect::fields::{ArgumentInfo, ArgumentKind, FieldInfo, FieldKind};
+
+/// Interface generator for a Python class.
+///
+/// Instances are created with [`InterfaceGenerator::new`].
+/// The documentation is generated via the [`Display`] implementation.
+pub struct InterfaceGenerator<'a> {
+    info: ClassInfo<'a>
+}
+
+impl<'a> InterfaceGenerator<'a> {
+    pub fn new(info: ClassInfo<'a>) -> Self {
+        Self {
+            info
+        }
+    }
+
+    fn class_header(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // class ClassName(BaseClassName):
+
+        write!(f, "class {}", self.info.name())?;
+        if let Some(base) = self.info.base() {
+            write!(f, "({})", base)?;
+        }
+        write!(f, ":")
+    }
+
+    fn field(field: &FieldInfo, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match field.kind {
+            FieldKind::New => {
+                write!(f, "    def __new__(cls")?;
+                Self::arguments(field.arguments, true, f)?;
+                write!(f, ") -> None")?;
+            },
+            FieldKind::Getter => {
+                writeln!(f, "    @property")?;
+                write!(f, "    def {}(self", field.name)?;
+                Self::signature_end(field, false, f)?;
+            },
+            FieldKind::Setter => {
+                writeln!(f, "    @{}.setter", field.name)?;
+                write!(f, "    def {}(self", field.name)?;
+                Self::signature_end(field, true, f)?;
+            },
+            FieldKind::Function => {
+                write!(f, "    def {}(self", field.name)?;
+                Self::signature_end(field, true, f)?;
+            },
+            FieldKind::ClassMethod => {
+                writeln!(f, "    @classmethod")?;
+                write!(f, "    def {}(cls", field.name)?;
+                Self::signature_end(field, true, f)?;
+            },
+            FieldKind::ClassAttribute => {
+                write!(f, "    {}", field.name)?;
+                if let Some(output_type) = field.py_type {
+                    write!(f, ": {}", (output_type)())?;
+                }
+                return writeln!(f, " = ...");
+            },
+            FieldKind::StaticMethod => {
+                writeln!(f, "    @staticmethod")?;
+                write!(f, "    def {}(", field.name)?;
+                Self::signature_end(field, false, f)?;
+            },
+        };
+
+        writeln!(f, ": ...")
+    }
+
+    fn signature_end(field: &FieldInfo, start_with_comma: bool, f: &mut Formatter<'_>) -> std::fmt::Result {
+        // def whatever(self [THIS FUNCTION]
+
+        Self::arguments(field.arguments, start_with_comma, f)?;
+        if let Some(output_type) = field.py_type {
+            write!(f, ") -> {}", (output_type)())
+        } else {
+            write!(f, ")")
+        }
+    }
+
+    fn arguments(arguments: &[ArgumentInfo], start_with_comma: bool, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut add_comma = start_with_comma;
+        let mut positional_only = true;
+        let mut keyword_only = false;
+
+        for argument in arguments {
+            if add_comma {
+                write!(f, ", ")?;
+            }
+
+            if positional_only && !matches!(argument.kind, ArgumentKind::Position) {
+                // PEP570
+                if add_comma {
+                    write!(f, "/, ")?;
+                }
+                positional_only = false
+            }
+
+            if !keyword_only && matches!(argument.kind, ArgumentKind::Keyword) {
+                // PEP3102
+                write!(f, "*, ")?;
+                keyword_only = true
+            }
+
+            match argument.kind {
+                ArgumentKind::VarArg => write!(f, "*")?,
+                ArgumentKind::KeywordArg => write!(f, "**")?,
+                _ => {},
+            };
+
+            write!(f, "{}", argument.name)?;
+
+            if let Some(py_type) = argument.py_type {
+                write!(f, ": {}", (py_type)())?;
+            }
+
+            if argument.default_value {
+                write!(f, " = ...")?;
+            }
+
+            add_comma = true;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Display for InterfaceGenerator<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.class_header(f)?;
+
+        if self.info.fields.is_empty() && self.info.class.fields.is_empty() {
+            writeln!(f, " ...")?;
+        } else {
+            writeln!(f)?;
+        }
+
+        for field in self.info.fields() {
+            Self::field(*field, f)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -1,0 +1,9 @@
+//! Runtime inspection of Python data structures.
+//!
+//! This module provides APIs to access information on Python data structures (classes, builtins) at runtime from Rust.
+//! These APIs can be used to generate documentation, interface files (.pyi), etc.
+
+pub mod types;
+pub mod fields;
+pub mod classes;
+pub mod modules;

--- a/src/inspect/mod.rs
+++ b/src/inspect/mod.rs
@@ -7,3 +7,4 @@ pub mod types;
 pub mod fields;
 pub mod classes;
 pub mod modules;
+pub mod interface;

--- a/src/inspect/modules.rs
+++ b/src/inspect/modules.rs
@@ -1,0 +1,6 @@
+
+/// Information about a module.
+#[derive(Debug)]
+pub struct ModuleInfo {
+    //TODO
+}

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -1,72 +1,4 @@
-//! Data required for Python Interface files (.pyi, also called 'stub files').
-//!
-//! This module creates three data structures, [`ModuleInfo`], [`ClassInfo`] and [`FieldInfo`],
-//! which are responsible for generating parts of the interface files.
-
 use std::fmt::{Display, Formatter};
-
-/// Python Interface information for a module.
-#[derive(Debug)]
-pub struct ModuleInfo {}
-
-#[derive(Debug)]
-pub struct ClassInfo<'a> {
-    pub name: &'a str,
-    pub base: &'a str,
-    pub fields: &'a [FieldInfo<'a>],
-}
-
-/// Python Interface information for a field (attribute, function, method…).
-#[derive(Debug)]
-pub struct FieldInfo<'a> {
-    pub name: &'a str,
-    pub kind: FieldKind,
-    pub py_type: Option<&'a TypeInfo<'a>>,
-    pub arguments: &'a [ArgumentInfo<'a>],
-}
-
-#[derive(Debug)]
-pub enum FieldKind {
-    /// The special 'new' method
-    New,
-    /// A top-level or instance attribute
-    Attribute,
-    /// A top-level or instance getter
-    Getter,
-    /// A top-level or instance setter
-    Setter,
-    /// A top-level function or an instance method
-    Function,
-    /// A class method
-    ClassMethod,
-    /// A class attribute
-    ClassAttribute,
-    /// A static method
-    StaticMethod,
-}
-
-#[derive(Debug)]
-pub struct ArgumentInfo<'a> {
-    pub name: &'a str,
-    pub kind: ArgumentKind,
-    pub py_type: Option<&'a TypeInfo<'a>>,
-    pub default_value: bool,
-    pub is_modified: bool,
-}
-
-#[derive(Debug)]
-pub enum ArgumentKind {
-    /// A normal argument, that can be passed positionally or by keyword.
-    Regular,
-    /// A normal argument that can only be passed positionally (not by keyword).
-    PositionalOnly,
-    /// An argument that represents all positional arguments that were provided on the call-site
-    /// but do not match any declared regular argument.
-    Vararg,
-    /// An argument that represents all keyword arguments that were provided on the call-site
-    /// but do not match any declared regular argument.
-    KeywordArg,
-}
 
 /// The various Python types handled by PyO3.
 ///
@@ -243,12 +175,4 @@ fn type_info_display() {
             ),
         )),
     );
-}
-
-pub trait GetClassInfo {
-    fn info() -> &'static ClassInfo<'static>;
-}
-
-pub trait GetClassFields {
-    fn fields_info() -> &'static [&'static FieldInfo<'static>];
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -11,6 +11,7 @@ use crate::{
 use std::marker::PhantomData;
 use std::mem;
 use std::ptr::NonNull;
+use crate::inspect::types::TypeInfo;
 
 /// Types that are built into the Python interpreter.
 ///
@@ -947,6 +948,13 @@ where
         unsafe {
             ob.extract::<&T::AsRefTarget>()
                 .map(|val| Py::from_borrowed_ptr(ob.py(), val.as_ptr()))
+        }
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Class {
+            module: T::MODULE,
+            name: T::NAME,
         }
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,108 @@
+//! Data required for Python Interface files (.pyi, also called 'stub files').
+//!
+//! This module creates three data structures, [`ModuleInfo`], [`ClassInfo`] and [`FieldInfo`],
+//! which are responsible for generating parts of the interface files.
+
+/// Python Interface information for a module.
+pub struct ModuleInfo {}
+
+/// Python Interface information for a class.
+pub struct ClassInfo {}
+
+/// Python Interface information for a field (attribute, function, method…).
+pub struct FieldInfo {
+    pub name: &'static str,
+    pub kind: FieldKind,
+    pub py_type: Option<&'static TypeInfo>,
+    pub arguments: &'static [ArgumentInfo],
+}
+
+pub enum FieldKind {
+    /// The special 'new' method
+    New,
+    /// A top-level or instance attribute
+    Attribute,
+    /// A top-level or instance getter
+    Getter,
+    /// A top-level or instance setter
+    Setter,
+    /// A top-level function or an instance method
+    Function,
+    /// A class method
+    ClassMethod,
+    /// A class attribute
+    ClassAttribute,
+    /// A static method
+    StaticMethod,
+}
+
+pub struct ArgumentInfo {
+    pub name: &'static str,
+    pub kind: ArgumentKind,
+    pub py_type: Option<&'static TypeInfo>,
+    pub default_value: bool,
+    pub is_modified: bool,
+}
+
+pub enum ArgumentKind {
+    /// A normal argument, that can be passed positionally or by keyword.
+    Regular,
+    /// A normal argument that can only be passed positionally (not by keyword).
+    PositionalOnly,
+    /// An argument that represents all positional arguments that were provided on the call-site
+    /// but do not match any declared regular argument.
+    Vararg,
+    /// An argument that represents all keyword arguments that were provided on the call-site
+    /// but do not match any declared regular argument.
+    KeywordArg,
+}
+
+/// The various Python types handled by PyO3.
+///
+/// The current implementation is not able to generate custom generics.
+/// All generic types can only be hardcoded in PyO3.
+pub enum TypeInfo {
+    /// The type `typing.Any`, which represents a dynamically-typed value (unknown type).
+    Any,
+
+    /// The type `typing.None`.
+    None,
+
+    /// The type `typing.Callable`, which represents a function-like object.
+    Callable(Option<&'static [&'static TypeInfo]>, &'static TypeInfo),
+
+    /// The type `typing.NoReturn`, which represents a function that never returns.
+    NoReturn,
+
+    /// A tuple of any value and size: `typing.Tuple[...]`.
+    AnyTuple,
+
+    /// A tuple of the specified types.
+    Tuple(&'static [&'static TypeInfo]),
+
+    /// A tuple of unknown size, in which all elements have the same type.
+    UnsizedTuple(&'static TypeInfo),
+
+    /// A union of multiple types.
+    Union(&'static [&'static TypeInfo]),
+
+    /// An optional value.
+    Optional(&'static TypeInfo),
+
+    Dict(&'static TypeInfo, &'static TypeInfo),
+
+    Mapping(&'static TypeInfo, &'static TypeInfo),
+
+    List(&'static TypeInfo),
+
+    Set(&'static TypeInfo),
+
+    FrozenSet(&'static TypeInfo),
+
+    Sequence(&'static TypeInfo),
+
+    Iterator(&'static TypeInfo),
+
+    /// Any type that doesn't receive special treatment from PyO3.
+    Other(&'static str),
+}

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -4,12 +4,14 @@
 //! which are responsible for generating parts of the interface files.
 
 /// Python Interface information for a module.
+#[derive(Debug)]
 pub struct ModuleInfo {}
 
 /// Python Interface information for a class.
 pub struct ClassInfo {}
 
 /// Python Interface information for a field (attribute, function, method…).
+#[derive(Debug)]
 pub struct FieldInfo {
     pub name: &'static str,
     pub kind: FieldKind,
@@ -17,6 +19,7 @@ pub struct FieldInfo {
     pub arguments: &'static [ArgumentInfo],
 }
 
+#[derive(Debug)]
 pub enum FieldKind {
     /// The special 'new' method
     New,
@@ -36,6 +39,7 @@ pub enum FieldKind {
     StaticMethod,
 }
 
+#[derive(Debug)]
 pub struct ArgumentInfo {
     pub name: &'static str,
     pub kind: ArgumentKind,
@@ -44,6 +48,7 @@ pub struct ArgumentInfo {
     pub is_modified: bool,
 }
 
+#[derive(Debug)]
 pub enum ArgumentKind {
     /// A normal argument, that can be passed positionally or by keyword.
     Regular,
@@ -61,6 +66,7 @@ pub enum ArgumentKind {
 ///
 /// The current implementation is not able to generate custom generics.
 /// All generic types can only be hardcoded in PyO3.
+#[derive(Debug)]
 pub enum TypeInfo {
     /// The type `typing.Any`, which represents a dynamically-typed value (unknown type).
     Any,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -3,6 +3,8 @@
 //! This module creates three data structures, [`ModuleInfo`], [`ClassInfo`] and [`FieldInfo`],
 //! which are responsible for generating parts of the interface files.
 
+use std::fmt::{Display, Formatter};
+
 /// Python Interface information for a module.
 #[derive(Debug)]
 pub struct ModuleInfo {}
@@ -118,10 +120,129 @@ pub enum TypeInfo<'a> {
     Builtin(&'a str),
 
     /// Any type that doesn't receive special treatment from PyO3.
-    Other {
+    Class {
         module: &'a str,
         name: &'a str,
     },
+}
+
+impl<'a> TypeInfo<'a> {
+    pub fn module_name(&self) -> Option<&'a str> {
+        match self {
+            TypeInfo::Class { module, .. } => { Some(module) }
+            TypeInfo::Builtin(_) => None,
+            _ => Some("typing"),
+        }
+    }
+}
+
+impl<'a> Display for TypeInfo<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TypeInfo::Any => write!(f, "Any"),
+            TypeInfo::None => write!(f, "None"),
+            TypeInfo::Callable(args, output) => {
+                if let Some(args) = args {
+                    write!(f, "Callable[[")?;
+                    let mut is_first = true;
+                    for arg in *args {
+                        if !is_first {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", arg)?;
+                        is_first = false
+                    }
+                    write!(f, "], {}]", output)
+                } else {
+                    write!(f, "Callable[..., {}]", output)
+                }
+            }
+            TypeInfo::NoReturn => write!(f, "NoReturn"),
+            TypeInfo::AnyTuple => write!(f, "Tuple[...]"),
+            TypeInfo::Tuple(args) => {
+                write!(f, "Tuple[")?;
+                let mut is_first = true;
+                for arg in *args {
+                    if !is_first {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", arg)?;
+                    is_first = false;
+                }
+                if args.is_empty() {
+                    write!(f, "()")?;
+                }
+                write!(f, "]")
+            }
+            TypeInfo::UnsizedTuple(arg) => write!(f, "Tuple[{arg}, ...]"),
+            TypeInfo::Union(args) => {
+                write!(f, "Union[")?;
+                let mut is_first = true;
+                for arg in *args {
+                    if !is_first {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", arg)?;
+                    is_first = false;
+                }
+                write!(f, "]")
+            }
+            TypeInfo::Optional(arg) => write!(f, "Optional[{arg}]"),
+            TypeInfo::Dict(key, value) => write!(f, "Dict[{key}, {value}]"),
+            TypeInfo::Mapping(key, value) => write!(f, "Mapping[{key}, {value}]"),
+            TypeInfo::List(arg) => write!(f, "List[{arg}]"),
+            TypeInfo::Set(arg) => write!(f, "Set[{arg}]"),
+            TypeInfo::FrozenSet(arg) => write!(f, "FrozenSet[{arg}]"),
+            TypeInfo::Sequence(arg) => write!(f, "Sequence[{arg}]"),
+            TypeInfo::Iterator(arg) => write!(f, "Iterator[{arg}]"),
+            TypeInfo::Iterable(arg) => write!(f, "Iterable[{arg}]"),
+            TypeInfo::Builtin(name) => write!(f, "{}", name),
+            TypeInfo::Class { name, .. } => write!(f, "{}", name),
+        }
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn type_info_display() {
+    // Ensure the type infos follow the syntax defined in PEP484
+    assert_eq!("Any", format!("{}", TypeInfo::Any));
+    assert_eq!("None", format!("{}", TypeInfo::None));
+    assert_eq!("int", format!("{}", TypeInfo::Builtin("int")));
+    assert_eq!("Callable[..., int]", format!("{}", TypeInfo::Callable(None, &TypeInfo::Builtin("int"))));
+    assert_eq!("Callable[[int, bool], int]", format!("{}", TypeInfo::Callable(Some(&[&TypeInfo::Builtin("int"), &TypeInfo::Builtin("bool")]), &TypeInfo::Builtin("int"))));
+    assert_eq!("NoReturn", format!("{}", TypeInfo::NoReturn));
+    assert_eq!("Tuple[...]", format!("{}", TypeInfo::AnyTuple));
+    assert_eq!("Tuple[int, bool, int]", format!("{}", TypeInfo::Tuple(&[&TypeInfo::Builtin("int"), &TypeInfo::Builtin("bool"), &TypeInfo::Builtin("int")])));
+    assert_eq!("Tuple[()]", format!("{}", TypeInfo::Tuple(&[])));
+    assert_eq!("Tuple[int, ...]", format!("{}", TypeInfo::UnsizedTuple(&TypeInfo::Builtin("int"))));
+    assert_eq!("Union[int, bool]", format!("{}", TypeInfo::Union(&[&TypeInfo::Builtin("int"), &TypeInfo::Builtin("bool")])));
+    assert_eq!("Optional[int]", format!("{}", TypeInfo::Optional(&TypeInfo::Builtin("int"))));
+    assert_eq!("Optional[Any]", format!("{}", TypeInfo::Optional(&TypeInfo::Any)));
+    assert_eq!("Dict[str, int]", format!("{}", TypeInfo::Dict(&TypeInfo::Builtin("str"), &TypeInfo::Builtin("int"))));
+    assert_eq!("Mapping[str, int]", format!("{}", TypeInfo::Mapping(&TypeInfo::Builtin("str"), &TypeInfo::Builtin("int"))));
+    assert_eq!("List[str]", format!("{}", TypeInfo::List(&TypeInfo::Builtin("str"))));
+    assert_eq!("Set[str]", format!("{}", TypeInfo::Set(&TypeInfo::Builtin("str"))));
+    assert_eq!("FrozenSet[str]", format!("{}", TypeInfo::FrozenSet(&TypeInfo::Builtin("str"))));
+    assert_eq!("Sequence[str]", format!("{}", TypeInfo::Sequence(&TypeInfo::Builtin("str"))));
+    assert_eq!("Iterable[str]", format!("{}", TypeInfo::Iterable(&TypeInfo::Builtin("str"))));
+    assert_eq!("Iterator[str]", format!("{}", TypeInfo::Iterator(&TypeInfo::Builtin("str"))));
+    assert_eq!("MyClass", format!("{}", TypeInfo::Class { module: "whatever", name: "MyClass" }));
+
+    // Just to be sure, a complicated (real life!) example
+    assert_eq!(
+        "List[Callable[[Common, Common], List[List[Tuple[Common, Common]]]]]",
+        format!("{}", TypeInfo::List(
+            &TypeInfo::Callable(
+                Some(&[&TypeInfo::Class { module: "foo", name: "Common" }, &TypeInfo::Class { module: "foo", name: "Common" }]),
+                &TypeInfo::List(
+                    &TypeInfo::List(
+                        &TypeInfo::Tuple(&[&TypeInfo::Class { module: "foo", name: "Common" }, &TypeInfo::Class { module: "foo", name: "Common" }])
+                    )
+                ),
+            ),
+        )),
+    );
 }
 
 pub trait GetClassInfo {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -7,8 +7,12 @@
 #[derive(Debug)]
 pub struct ModuleInfo {}
 
-/// Python Interface information for a class.
-pub struct ClassInfo {}
+#[derive(Debug)]
+pub struct ClassInfo {
+    pub name: &'static str,
+    pub base: &'static str,
+    pub fields: &'static [FieldInfo],
+}
 
 /// Python Interface information for a field (attribute, function, method…).
 #[derive(Debug)]
@@ -111,4 +115,12 @@ pub enum TypeInfo {
 
     /// Any type that doesn't receive special treatment from PyO3.
     Other(&'static str),
+}
+
+pub trait GetClassInfo {
+    fn info() -> &'static ClassInfo;
+}
+
+pub trait GetClassFields {
+    fn fields_info() -> &'static [&'static FieldInfo];
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -113,8 +113,13 @@ pub enum TypeInfo {
 
     Iterator(&'static TypeInfo),
 
+    Builtin(&'static str),
+
     /// Any type that doesn't receive special treatment from PyO3.
-    Other(&'static str),
+    Other {
+        module: &'static str,
+        name: &'static str,
+    },
 }
 
 pub trait GetClassInfo {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -8,19 +8,19 @@
 pub struct ModuleInfo {}
 
 #[derive(Debug)]
-pub struct ClassInfo {
-    pub name: &'static str,
-    pub base: &'static str,
-    pub fields: &'static [FieldInfo],
+pub struct ClassInfo<'a> {
+    pub name: &'a str,
+    pub base: &'a str,
+    pub fields: &'a [FieldInfo<'a>],
 }
 
 /// Python Interface information for a field (attribute, function, method…).
 #[derive(Debug)]
-pub struct FieldInfo {
-    pub name: &'static str,
+pub struct FieldInfo<'a> {
+    pub name: &'a str,
     pub kind: FieldKind,
-    pub py_type: Option<&'static TypeInfo>,
-    pub arguments: &'static [ArgumentInfo],
+    pub py_type: Option<&'a TypeInfo<'a>>,
+    pub arguments: &'a [ArgumentInfo<'a>],
 }
 
 #[derive(Debug)]
@@ -44,10 +44,10 @@ pub enum FieldKind {
 }
 
 #[derive(Debug)]
-pub struct ArgumentInfo {
-    pub name: &'static str,
+pub struct ArgumentInfo<'a> {
+    pub name: &'a str,
     pub kind: ArgumentKind,
-    pub py_type: Option<&'static TypeInfo>,
+    pub py_type: Option<&'a TypeInfo<'a>>,
     pub default_value: bool,
     pub is_modified: bool,
 }
@@ -71,7 +71,7 @@ pub enum ArgumentKind {
 /// The current implementation is not able to generate custom generics.
 /// All generic types can only be hardcoded in PyO3.
 #[derive(Debug)]
-pub enum TypeInfo {
+pub enum TypeInfo<'a> {
     /// The type `typing.Any`, which represents a dynamically-typed value (unknown type).
     Any,
 
@@ -79,7 +79,7 @@ pub enum TypeInfo {
     None,
 
     /// The type `typing.Callable`, which represents a function-like object.
-    Callable(Option<&'static [&'static TypeInfo]>, &'static TypeInfo),
+    Callable(Option<&'a [&'a TypeInfo<'a>]>, &'a TypeInfo<'a>),
 
     /// The type `typing.NoReturn`, which represents a function that never returns.
     NoReturn,
@@ -88,44 +88,46 @@ pub enum TypeInfo {
     AnyTuple,
 
     /// A tuple of the specified types.
-    Tuple(&'static [&'static TypeInfo]),
+    Tuple(&'a [&'a TypeInfo<'a>]),
 
     /// A tuple of unknown size, in which all elements have the same type.
-    UnsizedTuple(&'static TypeInfo),
+    UnsizedTuple(&'a TypeInfo<'a>),
 
     /// A union of multiple types.
-    Union(&'static [&'static TypeInfo]),
+    Union(&'a [&'a TypeInfo<'a>]),
 
     /// An optional value.
-    Optional(&'static TypeInfo),
+    Optional(&'a TypeInfo<'a>),
 
-    Dict(&'static TypeInfo, &'static TypeInfo),
+    Dict(&'a TypeInfo<'a>, &'a TypeInfo<'a>),
 
-    Mapping(&'static TypeInfo, &'static TypeInfo),
+    Mapping(&'a TypeInfo<'a>, &'a TypeInfo<'a>),
 
-    List(&'static TypeInfo),
+    List(&'a TypeInfo<'a>),
 
-    Set(&'static TypeInfo),
+    Set(&'a TypeInfo<'a>),
 
-    FrozenSet(&'static TypeInfo),
+    FrozenSet(&'a TypeInfo<'a>),
 
-    Sequence(&'static TypeInfo),
+    Sequence(&'a TypeInfo<'a>),
 
-    Iterator(&'static TypeInfo),
+    Iterable(&'a TypeInfo<'a>),
 
-    Builtin(&'static str),
+    Iterator(&'a TypeInfo<'a>),
+
+    Builtin(&'a str),
 
     /// Any type that doesn't receive special treatment from PyO3.
     Other {
-        module: &'static str,
-        name: &'static str,
+        module: &'a str,
+        name: &'a str,
     },
 }
 
 pub trait GetClassInfo {
-    fn info() -> &'static ClassInfo;
+    fn info() -> &'static ClassInfo<'static>;
 }
 
 pub trait GetClassFields {
-    fn fields_info() -> &'static [&'static FieldInfo];
+    fn fields_info() -> &'static [&'static FieldInfo<'static>];
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,7 @@ mod macros;
 #[cfg(all(test, feature = "macros"))]
 mod test_hygiene;
 
-pub mod interface;
+pub mod inspect;
 
 /// Test readme and user guide
 #[cfg(doctest)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,6 +416,8 @@ mod macros;
 #[cfg(all(test, feature = "macros"))]
 mod test_hygiene;
 
+pub mod interface;
+
 /// Test readme and user guide
 #[cfg(doctest)]
 pub mod doc_test {

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -216,6 +216,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
+use crate::inspect::types::TypeInfo;
 
 pub struct EmptySlot(());
 pub struct BorrowChecker(Cell<BorrowFlag>);
@@ -887,6 +888,13 @@ impl<T: PyClass> IntoPy<PyObject> for PyRef<'_, T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Class {
+            module: T::MODULE,
+            name: T::NAME,
+        }
+    }
 }
 
 impl<'a, T: PyClass> std::convert::TryFrom<&'a PyCell<T>> for crate::PyRef<'a, T> {
@@ -984,6 +992,13 @@ impl<'p, T: MutablePyClass> Drop for PyRefMut<'p, T> {
 impl<T: MutablePyClass> IntoPy<PyObject> for PyRefMut<'_, T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
+    }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Class {
+            module: T::MODULE,
+            name: T::NAME,
+        }
     }
 }
 

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -3,6 +3,7 @@ use crate::{
     ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, PyTryFrom, Python,
     ToPyObject,
 };
+use crate::inspect::types::TypeInfo;
 
 /// Represents a Python `bool`.
 #[repr(transparent)]
@@ -46,6 +47,10 @@ impl IntoPy<PyObject> for bool {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyBool::new(py, self).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("bool")
+    }
 }
 
 /// Converts a Python `bool` to a Rust `bool`.
@@ -54,6 +59,10 @@ impl IntoPy<PyObject> for bool {
 impl<'source> FromPyObject<'source> for bool {
     fn extract(obj: &'source PyAny) -> PyResult<Self> {
         Ok(<PyBool as PyTryFrom>::try_from(obj)?.is_true())
+    }
+
+    fn type_input() -> TypeInfo {
+        Self::type_output()
     }
 }
 

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -6,6 +6,7 @@ use std::ops::Index;
 use std::os::raw::c_char;
 use std::slice::SliceIndex;
 use std::str;
+use crate::inspect::types::TypeInfo;
 
 /// Represents a Python `bytes` object.
 ///
@@ -128,13 +129,22 @@ impl<'a> IntoPy<PyObject> for &'a [u8] {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyBytes::new(py, self).to_object(py)
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("bytes")
+    }
 }
 
 impl<'a> FromPyObject<'a> for &'a [u8] {
     fn extract(obj: &'a PyAny) -> PyResult<Self> {
         Ok(<PyBytes as PyTryFrom>::try_from(obj)?.as_bytes())
     }
+
+    fn type_input() -> TypeInfo {
+        Self::type_output()
+    }
 }
+
 #[cfg(test)]
 mod tests {
     use super::PyBytes;

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -10,6 +10,7 @@ use crate::{ffi, AsPyPointer, FromPyObject, IntoPy, PyObject, PyTryFrom, Python,
 use std::collections::{BTreeMap, HashMap};
 use std::ptr::NonNull;
 use std::{cmp, collections, hash};
+use crate::inspect::types::TypeInfo;
 
 /// Represents a Python `dict`.
 #[repr(transparent)]
@@ -361,6 +362,10 @@ where
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
         IntoPyDict::into_py_dict(iter, py).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Dict(Box::new(K::type_output()), Box::new(V::type_output()))
+    }
 }
 
 impl<K, V> IntoPy<PyObject> for collections::BTreeMap<K, V>
@@ -373,6 +378,10 @@ where
             .into_iter()
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
         IntoPyDict::into_py_dict(iter, py).into()
+    }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Dict(Box::new(K::type_output()), Box::new(V::type_output()))
     }
 }
 
@@ -451,6 +460,10 @@ where
         }
         Ok(ret)
     }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Mapping(Box::new(K::type_input()), Box::new(V::type_input()))
+    }
 }
 
 impl<'source, K, V> FromPyObject<'source> for BTreeMap<K, V>
@@ -465,6 +478,10 @@ where
             ret.insert(K::extract(k)?, V::extract(v)?);
         }
         Ok(ret)
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Mapping(Box::new(K::type_input()), Box::new(V::type_input()))
     }
 }
 

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -5,6 +5,7 @@ use crate::{
     ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
 };
 use std::os::raw::c_double;
+use crate::inspect::types::TypeInfo;
 
 /// Represents a Python `float` object.
 ///
@@ -44,6 +45,10 @@ impl IntoPy<PyObject> for f64 {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyFloat::new(py, self).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("float")
+    }
 }
 
 impl<'source> FromPyObject<'source> for f64 {
@@ -60,6 +65,10 @@ impl<'source> FromPyObject<'source> for f64 {
 
         Ok(v)
     }
+
+    fn type_input() -> TypeInfo {
+        <f64>::type_output()
+    }
 }
 
 impl ToPyObject for f32 {
@@ -72,11 +81,19 @@ impl IntoPy<PyObject> for f32 {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyFloat::new(py, f64::from(self)).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("float")
+    }
 }
 
 impl<'source> FromPyObject<'source> for f32 {
     fn extract(obj: &'source PyAny) -> PyResult<Self> {
         Ok(obj.extract::<f64>()? as f32)
+    }
+
+    fn type_input() -> TypeInfo {
+        <f32>::type_output()
     }
 }
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -11,6 +11,7 @@ use crate::types::PySequence;
 use crate::{
     AsPyPointer, IntoPy, IntoPyPointer, Py, PyAny, PyObject, PyTryFrom, Python, ToPyObject,
 };
+use crate::inspect::types::TypeInfo;
 
 /// Represents a Python `list`.
 #[repr(transparent)]
@@ -367,6 +368,10 @@ where
         let mut iter = self.into_iter().map(|e| e.into_py(py));
         let list = new_from_iter(py, &mut iter);
         list.into()
+    }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::List(Box::new(T::type_output()))
     }
 }
 

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -9,6 +9,7 @@ use crate::{
 use std::convert::TryFrom;
 use std::i64;
 use std::os::raw::c_long;
+use crate::inspect::types::TypeInfo;
 
 macro_rules! int_fits_larger_int {
     ($rust_type:ty, $larger_type:ty) => {
@@ -22,6 +23,10 @@ macro_rules! int_fits_larger_int {
             fn into_py(self, py: Python<'_>) -> PyObject {
                 (self as $larger_type).into_py(py)
             }
+
+            fn type_output() -> TypeInfo {
+                TypeInfo::Builtin("int")
+            }
         }
 
         impl<'source> FromPyObject<'source> for $rust_type {
@@ -29,6 +34,10 @@ macro_rules! int_fits_larger_int {
                 let val: $larger_type = obj.extract()?;
                 <$rust_type>::try_from(val)
                     .map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
+            }
+
+            fn type_input() -> TypeInfo {
+                TypeInfo::Builtin("int")
             }
         }
     };

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -6,6 +6,7 @@ use crate::types::{PyAny, PyList, PyTuple};
 use crate::{ffi, PyNativeType, ToPyObject};
 use crate::{AsPyPointer, IntoPyPointer, Py, Python};
 use crate::{FromPyObject, PyTryFrom};
+use crate::inspect::types::TypeInfo;
 
 /// Represents a reference to a Python object supporting the sequence protocol.
 #[repr(transparent)]
@@ -271,6 +272,10 @@ where
 {
     fn extract(obj: &'a PyAny) -> PyResult<Self> {
         extract_sequence(obj)
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Sequence(Box::new(T::type_input()))
     }
 }
 

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -225,6 +225,7 @@ mod impl_ {
 }
 
 pub use impl_::*;
+use crate::inspect::types::TypeInfo;
 
 impl<T, S> ToPyObject for collections::HashSet<T, S>
 where
@@ -271,6 +272,10 @@ where
         }
         set.into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Set(Box::new(K::type_output()))
+    }
 }
 
 impl<'source, K, S> FromPyObject<'source> for HashSet<K, S>
@@ -281,6 +286,10 @@ where
     fn extract(ob: &'source PyAny) -> PyResult<Self> {
         let set: &PySet = ob.downcast()?;
         set.iter().map(K::extract).collect()
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Set(Box::new(K::type_input()))
     }
 }
 
@@ -297,6 +306,10 @@ where
         }
         set.into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Set(Box::new(K::type_output()))
+    }
 }
 
 impl<'source, K> FromPyObject<'source> for BTreeSet<K>
@@ -306,6 +319,10 @@ where
     fn extract(ob: &'source PyAny) -> PyResult<Self> {
         let set: &PySet = ob.downcast()?;
         set.iter().map(K::extract).collect()
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Set(Box::new(K::type_input()))
     }
 }
 

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -10,6 +10,7 @@ use crate::{
 use std::borrow::Cow;
 use std::os::raw::c_char;
 use std::str;
+use crate::inspect::types::TypeInfo;
 
 /// Represents raw data backing a Python `str`.
 ///
@@ -296,12 +297,20 @@ impl<'a> IntoPy<PyObject> for &'a str {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyString::new(py, self).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("str")
+    }
 }
 
 impl<'a> IntoPy<Py<PyString>> for &'a str {
     #[inline]
     fn into_py(self, py: Python<'_>) -> Py<PyString> {
         PyString::new(py, self).into()
+    }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("str")
     }
 }
 
@@ -341,11 +350,19 @@ impl IntoPy<PyObject> for char {
         let mut bytes = [0u8; 4];
         PyString::new(py, self.encode_utf8(&mut bytes)).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("str")
+    }
 }
 
 impl IntoPy<PyObject> for String {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyString::new(py, &self).into()
+    }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("str")
     }
 }
 
@@ -354,6 +371,10 @@ impl<'a> IntoPy<PyObject> for &'a String {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyString::new(py, self).into()
     }
+
+    fn type_output() -> TypeInfo {
+        TypeInfo::Builtin("str")
+    }
 }
 
 /// Allows extracting strings from Python objects.
@@ -361,6 +382,10 @@ impl<'a> IntoPy<PyObject> for &'a String {
 impl<'source> FromPyObject<'source> for &'source str {
     fn extract(ob: &'source PyAny) -> PyResult<Self> {
         <PyString as PyTryFrom>::try_from(ob)?.to_str()
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Builtin("str")
     }
 }
 
@@ -371,6 +396,10 @@ impl FromPyObject<'_> for String {
         <PyString as PyTryFrom>::try_from(obj)?
             .to_str()
             .map(ToOwned::to_owned)
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Builtin("str")
     }
 }
 
@@ -385,6 +414,10 @@ impl FromPyObject<'_> for char {
                 "expected a string of length 1",
             ))
         }
+    }
+
+    fn type_input() -> TypeInfo {
+        TypeInfo::Builtin("str")
     }
 }
 

--- a/tests/test_interface.rs
+++ b/tests/test_interface.rs
@@ -1,0 +1,25 @@
+#![cfg(feature = "macros")]
+
+use pyo3::prelude::*;
+
+mod common;
+
+#[pyclass]
+struct Simple {}
+
+#[pymethods]
+impl Simple {
+    #[new]
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn plus_one(&self, a: usize) -> usize {
+        a + 1
+    }
+}
+
+#[test]
+fn compiles() {
+    // Nothing to do: if we reach this point, the compilation was successful :)
+}

--- a/tests/test_interface.rs
+++ b/tests/test_interface.rs
@@ -229,6 +229,7 @@ struct Complicated {
 #[allow(unused_variables)]
 #[pymethods]
 impl Complicated {
+    #[new]
     fn new(foo: PyObject, parent: PyObject) -> Self {
         unreachable!("This is just a stub")
     }

--- a/tests/test_interface.rs
+++ b/tests/test_interface.rs
@@ -39,6 +39,7 @@ fn simple_info() {
 #[test]
 fn types() {
     assert_eq!("bool", format!("{}", <bool>::type_output()));
+    assert_eq!("bool", format!("{}", <bool as IntoPy<_>>::type_output()));
     assert_eq!("bytes", format!("{}", <&[u8]>::type_output()));
     assert_eq!("str", format!("{}", <String>::type_output()));
     assert_eq!("str", format!("{}", <char>::type_output()));

--- a/tests/test_interface.rs
+++ b/tests/test_interface.rs
@@ -6,6 +6,7 @@ use pyo3::inspect::classes::InspectClass;
 mod common;
 
 #[pyclass]
+#[derive(Clone)]
 struct Simple {}
 
 #[pymethods]
@@ -28,7 +29,19 @@ fn compiles() {
 #[test]
 fn simple_info() {
     let class_info = Simple::inspect();
+    println!("Type of usize: {:?}", usize::type_input());
+    println!("Type of class: {:?}", Simple::type_output());
     println!("Class:  {:?}", class_info);
 
     assert!(false)
+}
+
+#[test]
+fn types() {
+    assert_eq!("bool", format!("{}", <bool>::type_output()));
+    assert_eq!("bytes", format!("{}", <&[u8]>::type_output()));
+    assert_eq!("str", format!("{}", <String>::type_output()));
+    assert_eq!("str", format!("{}", <char>::type_output()));
+    assert_eq!("Optional[str]", format!("{}", <Option<String>>::type_output()));
+    assert_eq!("Simple", format!("{}", <&PyCell<Simple>>::type_input()));
 }

--- a/tests/test_interface.rs
+++ b/tests/test_interface.rs
@@ -1,9 +1,95 @@
 #![cfg(feature = "macros")]
 
 use pyo3::prelude::*;
-use pyo3::inspect::classes::InspectClass;
+use pyo3::inspect::classes::{ClassInfo, ClassStructInfo, InspectClass};
+use pyo3::inspect::fields::{ArgumentInfo, ArgumentKind, FieldInfo, FieldKind};
+use pyo3::inspect::interface::InterfaceGenerator;
+use pyo3::inspect::types::TypeInfo;
 
 mod common;
+
+#[test]
+fn types() {
+    assert_eq!("bool", format!("{}", <bool>::type_output()));
+    assert_eq!("bool", format!("{}", <bool as IntoPy<_>>::type_output()));
+    assert_eq!("bytes", format!("{}", <&[u8]>::type_output()));
+    assert_eq!("str", format!("{}", <String>::type_output()));
+    assert_eq!("str", format!("{}", <char>::type_output()));
+    assert_eq!("Optional[str]", format!("{}", <Option<String>>::type_output()));
+    assert_eq!("Simple", format!("{}", <&PyCell<Simple>>::type_input()));
+}
+
+//region Empty class
+
+const EXPECTED_EMPTY: &str = "class Empty: ...\n";
+
+#[test]
+fn empty_manual() {
+    let class = ClassInfo {
+        class: &ClassStructInfo {
+            name: "Empty",
+            base: None,
+            fields: &[],
+        },
+        fields: &[],
+    };
+
+    assert_eq!(EXPECTED_EMPTY, format!("{}", InterfaceGenerator::new(class)))
+}
+
+#[pyclass]
+struct Empty {}
+
+#[pymethods]
+impl Empty {}
+
+#[test]
+fn empty_derived() {
+    assert_eq!(EXPECTED_EMPTY, format!("{}", InterfaceGenerator::new(Empty::inspect())))
+}
+
+//endregion
+//region Constructor
+
+const EXPECTED_SIMPLE: &str = r#"class Simple:
+    def __new__(cls) -> None: ...
+    def plus_one(self, /, a: int) -> int: ...
+"#;
+
+#[test]
+fn simple_manual() {
+    let class = ClassInfo {
+        class: &ClassStructInfo {
+            name: "Simple",
+            base: None,
+            fields: &[],
+        },
+        fields: &[
+            &FieldInfo {
+                name: "__new__",
+                kind: FieldKind::New,
+                py_type: None,
+                arguments: &[],
+            },
+            &FieldInfo {
+                name: "plus_one",
+                kind: FieldKind::Function,
+                py_type: Some(|| TypeInfo::Builtin("int")),
+                arguments: &[
+                    ArgumentInfo {
+                        name: "a",
+                        kind: ArgumentKind::PositionOrKeyword,
+                        py_type: Some(|| TypeInfo::Builtin("int")),
+                        default_value: false,
+                        is_modified: false,
+                    }
+                ],
+            }
+        ],
+    };
+
+    assert_eq!(EXPECTED_SIMPLE, format!("{}", InterfaceGenerator::new(class)))
+}
 
 #[pyclass]
 #[derive(Clone)]
@@ -22,27 +108,115 @@ impl Simple {
 }
 
 #[test]
-fn compiles() {
-    // Nothing to do: if we reach this point, the compilation was successful :)
+fn simple_derived() {
+    assert_eq!(EXPECTED_SIMPLE, format!("{}", InterfaceGenerator::new(Simple::inspect())))
 }
+
+//endregion
+//region Complicated
+
+const EXPECTED_COMPLICATED: &str = r#"class Complicated(Simple):
+    @property
+    def value(self) -> int: ...
+    @value.setter
+    def value(self, value: int) -> None: ...
+    def __new__(cls, /, foo: str = ..., **parent: Any) -> None: ...
+    @staticmethod
+    def static(input: Complicated) -> Complicated: ...
+    @classmethod
+    def classmeth(cls, /, input: Union[Complicated, str, int]) -> Complicated: ...
+    counter: int = ...
+"#;
 
 #[test]
-fn simple_info() {
-    let class_info = Simple::inspect();
-    println!("Type of usize: {:?}", usize::type_input());
-    println!("Type of class: {:?}", Simple::type_output());
-    println!("Class:  {:?}", class_info);
+fn complicated_manual() {
+    let class = ClassInfo {
+        class: &ClassStructInfo {
+            name: "Complicated",
+            base: Some("Simple"),
+            fields: &[
+                &FieldInfo {
+                    name: "value",
+                    kind: FieldKind::Getter,
+                    py_type: Some(|| TypeInfo::Builtin("int")),
+                    arguments: &[],
+                },
+                &FieldInfo {
+                    name: "value",
+                    kind: FieldKind::Setter,
+                    py_type: Some(|| TypeInfo::None),
+                    arguments: &[
+                        ArgumentInfo {
+                            name: "value",
+                            kind: ArgumentKind::Position,
+                            py_type: Some(|| TypeInfo::Builtin("int")),
+                            default_value: false,
+                            is_modified: false
+                        }
+                    ],
+                }
+            ],
+        },
+        fields: &[
+            &FieldInfo {
+                name: "__new__",
+                kind: FieldKind::New,
+                py_type: None,
+                arguments: &[
+                    ArgumentInfo {
+                        name: "foo",
+                        kind: ArgumentKind::PositionOrKeyword,
+                        py_type: Some(|| TypeInfo::Builtin("str")),
+                        default_value: true,
+                        is_modified: false,
+                    },
+                    ArgumentInfo {
+                        name: "parent",
+                        kind: ArgumentKind::KeywordArg,
+                        py_type: Some(|| TypeInfo::Any),
+                        default_value: false,
+                        is_modified: false,
+                    }
+                ],
+            },
+            &FieldInfo {
+                name: "static",
+                kind: FieldKind::StaticMethod,
+                py_type: Some(|| TypeInfo::Class { module: None, name: "Complicated" }),
+                arguments: &[
+                    ArgumentInfo {
+                        name: "input",
+                        kind: ArgumentKind::PositionOrKeyword,
+                        py_type: Some(|| TypeInfo::Class { module: None, name: "Complicated" }),
+                        default_value: false,
+                        is_modified: false,
+                    }
+                ],
+            },
+            &FieldInfo {
+                name: "classmeth",
+                kind: FieldKind::ClassMethod,
+                py_type: Some(|| TypeInfo::Class { module: None, name: "Complicated" }),
+                arguments: &[
+                    ArgumentInfo {
+                        name: "input",
+                        kind: ArgumentKind::PositionOrKeyword,
+                        py_type: Some(|| TypeInfo::Union(vec![TypeInfo::Class { module: None, name: "Complicated" }, TypeInfo::Builtin("str"), TypeInfo::Builtin("int")])),
+                        default_value: false,
+                        is_modified: false
+                    }
+                ]
+            },
+            &FieldInfo {
+                name: "counter",
+                kind: FieldKind::ClassAttribute,
+                py_type: Some(|| TypeInfo::Builtin("int")),
+                arguments: &[]
+            }
+        ],
+    };
 
-    assert!(false)
+    assert_eq!(EXPECTED_COMPLICATED, format!("{}", InterfaceGenerator::new(class)))
 }
 
-#[test]
-fn types() {
-    assert_eq!("bool", format!("{}", <bool>::type_output()));
-    assert_eq!("bool", format!("{}", <bool as IntoPy<_>>::type_output()));
-    assert_eq!("bytes", format!("{}", <&[u8]>::type_output()));
-    assert_eq!("str", format!("{}", <String>::type_output()));
-    assert_eq!("str", format!("{}", <char>::type_output()));
-    assert_eq!("Optional[str]", format!("{}", <Option<String>>::type_output()));
-    assert_eq!("Simple", format!("{}", <&PyCell<Simple>>::type_input()));
-}
+//endregion

--- a/tests/test_interface.rs
+++ b/tests/test_interface.rs
@@ -1,8 +1,7 @@
 #![cfg(feature = "macros")]
 
 use pyo3::prelude::*;
-use pyo3::interface::GetClassInfo;
-use pyo3::interface::GetClassFields;
+use pyo3::inspect::classes::InspectClass;
 
 mod common;
 
@@ -28,8 +27,8 @@ fn compiles() {
 
 #[test]
 fn simple_info() {
-    let class_info = Simple::info();
-    let fields_info = Simple::fields_info();
+    let class_info = Simple::inspect();
     println!("Class:  {:?}", class_info);
-    println!("Fields: {:?}", fields_info);
+
+    assert!(false)
 }

--- a/tests/test_interface.rs
+++ b/tests/test_interface.rs
@@ -1,6 +1,8 @@
 #![cfg(feature = "macros")]
 
 use pyo3::prelude::*;
+use pyo3::interface::GetClassInfo;
+use pyo3::interface::GetClassFields;
 
 mod common;
 
@@ -22,4 +24,12 @@ impl Simple {
 #[test]
 fn compiles() {
     // Nothing to do: if we reach this point, the compilation was successful :)
+}
+
+#[test]
+fn simple_info() {
+    let class_info = Simple::info();
+    let fields_info = Simple::fields_info();
+    println!("Class:  {:?}", class_info);
+    println!("Fields: {:?}", fields_info);
 }


### PR DESCRIPTION
The goal of this PR is to add a new `inspect` feature to PyO3.
When this feature is enabled, the PyO3 macros extract information about the Python data structures.
The generated information can be accessed at runtime.

This feature can be used to implement Rust functions that behave the same as `dict(...)`, etc.
In particular, this feature enables the automatic generation of Interface files (.pyi) which can be used for type checking (via MyPy, PyCharm…) or documentation (after small modifications, they can be fed to Sphinx or other tools).

Current status:
- [ ] collect data for modules:
  - [ ] name
  - [ ] classes
  - [ ] top-level fields
  - [ ] submodules?
- [ ] collect data for classes:
  - [x] name
  - [ ] base class
  - [x] direct fields
  - [x] fields in impl blocks
- [ ] collect data for fields:
  - [x] name
  - [x] kind (method, static method, …)
  - [ ] parameters
    - [x] name
    - [ ] kind (regular, positional-only, vararg, keyword arg)
    - [ ] has a default value
    - [x] type
  - [x] return type
- [x] convert types from Rust to Python
  - [x] for PyO3 builtins (`PyDict` -> `dict`, `PyAny` -> `Any`…) (no generics information available)
  - [x] for Rust stdlib builtins (`Vec<Foo>` -> `List[Foo]`, `u16` -> `int`…) (generic information is available)
- [x] merge information from the `#[pyclass]` and the `#[pymethods]` blocks at runtime into a single `inspect()` method
- [ ] entry in CHANGELOG.md
- [ ] docs to all new functions and / or detail in the guide
- [ ] tests for all new or changed functions
- [ ] create the `inspect` feature and gate all new behaviors behind it
- [ ] interface generation
  - [ ] generate a valid syntax for a .pyi file for each module
  - [ ] example in the documentation to write a build script / unit test that generates it
- [x] replace the `&'static` lifetimes with normal lifetimes, so objects can be constructed at runtime (useful for editing the .pyi?)

Future possible enhancements:
- Include the documentation in the extracted information, so the interface files can be used for HTML documentation via Sphinx or other
- Find a way to make this compatible with `multiple-pymethods` (the current implementation only works for a single `#[pymethods]` block)
- Is there a way to have Maturin transparently handle the PyI generation?