### PR TITLE
add PyString::chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `PyCode` and `PyFrame` high level objects. [#2408](https://github.com/PyO3/pyo3/pull/2408)
 - Add FFI definitions `Py_fstring_input`, `sendfunc`, and `_PyErr_StackItem`. [#2423](https://github.com/PyO3/pyo3/pull/2423)
 - Add `PyDateTime::new_with_fold`, `PyTime::new_with_fold`, `PyTime::get_fold`, `PyDateTime::get_fold` for PyPy. [#2428](https://github.com/PyO3/pyo3/pull/2428)
+- Add `PyString::chars` [#2451](https://github.com/PyO3/pyo3/pull/2451)
 
 ### Changed
 

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -230,7 +230,7 @@ impl PyString {
     /// Returns an iterator over the PyString.
     ///
     /// Does not allocate anything (python or rust heap).
-    pub fn chars<'a>(&'a self) -> impl ExactSizeIterator<Item = PyResult<char>> + 'a {
+    pub fn chars(&self) -> impl ExactSizeIterator<Item = PyResult<char>> + '_{
         unsafe {
             let len = ffi::PyUnicode_GetLength(self.as_ptr());
             (0..len).map(move |i| {

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -230,7 +230,7 @@ impl PyString {
     /// Returns an iterator over the PyString.
     ///
     /// Does not allocate anything (python or rust heap).
-    pub fn chars(&self) -> impl ExactSizeIterator<Item = PyResult<char>> + '_{
+    pub fn chars(&self) -> impl ExactSizeIterator<Item = PyResult<char>> + '_ {
         unsafe {
             let len = ffi::PyUnicode_GetLength(self.as_ptr());
             (0..len).map(move |i| {


### PR DESCRIPTION
Useful helper method to avoid allocating anything while iterating over a PyUnicode string. The AsUTF8 methods will allocate and cache the utf8 str on the python heap.

Please consider adding the following to your pull request:
 - [x] an entry in CHANGELOG.md
 - [x] docs to all new functions and / or detail in the guide
 - [x] tests for all new or changed functions