### PR TITLE
macros: emit pymethod associated methods as a single block

### DIFF
--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -7,7 +7,7 @@ use crate::deprecations::Deprecation;
 use crate::params::{accept_args_kwargs, impl_arg_params};
 use crate::pyfunction::PyFunctionOptions;
 use crate::pyfunction::{PyFunctionArgPyO3Attributes, PyFunctionSignature};
-use crate::utils::{self, get_pyo3_crate, PythonDoc};
+use crate::utils::{self, PythonDoc};
 use crate::{deprecations::Deprecations, pyfunction::Argument};
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
@@ -224,7 +224,6 @@ pub struct FnSpec<'a> {
     pub deprecations: Deprecations,
     pub convention: CallingConvention,
     pub text_signature: Option<TextSignatureAttribute>,
-    pub krate: syn::Path,
     pub unsafety: Option<syn::Token![unsafe]>,
 }
 
@@ -266,7 +265,6 @@ impl<'a> FnSpec<'a> {
     ) -> Result<FnSpec<'a>> {
         let PyFunctionOptions {
             text_signature,
-            krate,
             name,
             mut deprecations,
             ..
@@ -285,7 +283,6 @@ impl<'a> FnSpec<'a> {
         let name = &sig.ident;
         let ty = get_return_info(&sig.output);
         let python_name = python_name.as_ref().unwrap_or(name).unraw();
-        let krate = get_pyo3_crate(&krate);
 
         let doc = utils::get_doc(
             meth_attrs,
@@ -321,7 +318,6 @@ impl<'a> FnSpec<'a> {
             doc,
             deprecations,
             text_signature,
-            krate,
             unsafety: sig.unsafety,
         })
     }
@@ -489,16 +485,14 @@ impl<'a> FnSpec<'a> {
             _pyo3::callback::convert(#py, ret)
         };
 
-        let krate = &self.krate;
         Ok(match self.convention {
             CallingConvention::Noargs => {
                 quote! {
                     unsafe extern "C" fn #ident (
-                        _slf: *mut #krate::ffi::PyObject,
-                        _args: *mut #krate::ffi::PyObject,
-                    ) -> *mut #krate::ffi::PyObject
+                        _slf: *mut _pyo3::ffi::PyObject,
+                        _args: *mut _pyo3::ffi::PyObject,
+                    ) -> *mut _pyo3::ffi::PyObject
                     {
-                        use #krate as _pyo3;
                         #deprecations
                         let gil = _pyo3::GILPool::new();
                         let #py = gil.python();
@@ -513,12 +507,11 @@ impl<'a> FnSpec<'a> {
                 let arg_convert = impl_arg_params(self, cls, &py, true)?;
                 quote! {
                     unsafe extern "C" fn #ident (
-                        _slf: *mut #krate::ffi::PyObject,
-                        _args: *const *mut #krate::ffi::PyObject,
-                        _nargs: #krate::ffi::Py_ssize_t,
-                        _kwnames: *mut #krate::ffi::PyObject) -> *mut #krate::ffi::PyObject
+                        _slf: *mut _pyo3::ffi::PyObject,
+                        _args: *const *mut _pyo3::ffi::PyObject,
+                        _nargs: _pyo3::ffi::Py_ssize_t,
+                        _kwnames: *mut _pyo3::ffi::PyObject) -> *mut _pyo3::ffi::PyObject
                     {
-                        use #krate as _pyo3;
                         #deprecations
                         let gil = _pyo3::GILPool::new();
                         let #py = gil.python();
@@ -534,11 +527,10 @@ impl<'a> FnSpec<'a> {
                 let arg_convert = impl_arg_params(self, cls, &py, false)?;
                 quote! {
                     unsafe extern "C" fn #ident (
-                        _slf: *mut #krate::ffi::PyObject,
-                        _args: *mut #krate::ffi::PyObject,
-                        _kwargs: *mut #krate::ffi::PyObject) -> *mut #krate::ffi::PyObject
+                        _slf: *mut _pyo3::ffi::PyObject,
+                        _args: *mut _pyo3::ffi::PyObject,
+                        _kwargs: *mut _pyo3::ffi::PyObject) -> *mut _pyo3::ffi::PyObject
                     {
-                        use #krate as _pyo3;
                         #deprecations
                         let gil = _pyo3::GILPool::new();
                         let #py = gil.python();
@@ -555,11 +547,10 @@ impl<'a> FnSpec<'a> {
                 let arg_convert = impl_arg_params(self, cls, &py, false)?;
                 quote! {
                     unsafe extern "C" fn #ident (
-                        subtype: *mut #krate::ffi::PyTypeObject,
-                        _args: *mut #krate::ffi::PyObject,
-                        _kwargs: *mut #krate::ffi::PyObject) -> *mut #krate::ffi::PyObject
+                        subtype: *mut _pyo3::ffi::PyTypeObject,
+                        _args: *mut _pyo3::ffi::PyObject,
+                        _kwargs: *mut _pyo3::ffi::PyObject) -> *mut _pyo3::ffi::PyObject
                     {
-                        use #krate as _pyo3;
                         #deprecations
                         use _pyo3::callback::IntoPyCallbackOutput;
                         let gil = _pyo3::GILPool::new();

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -430,7 +430,6 @@ pub fn impl_wrap_pyfunction(
         doc,
         deprecations: options.deprecations,
         text_signature: options.text_signature,
-        krate: krate.clone(),
         unsafety: func.sig.unsafety,
     };
 
@@ -442,7 +441,6 @@ pub fn impl_wrap_pyfunction(
     let methoddef = spec.get_methoddef(wrapper_ident);
 
     let wrapped_pyfunction = quote! {
-        #wrapper
 
         // Create a module with the same name as the `#[pyfunction]` - this way `use <the function>`
         // will actually bring both the module and the function into scope.
@@ -461,6 +459,8 @@ pub fn impl_wrap_pyfunction(
             impl #name::MakeDef {
                 const DEF: #krate::impl_::pyfunction::PyMethodDef = #methoddef;
             }
+
+            #wrapper
         };
     };
     Ok(wrapped_pyfunction)

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -109,24 +109,24 @@ error: Python objects are shared, so 'self' cannot be moved out of the Python in
 124 |     fn method_self_by_value(self){}
     |                             ^^^^
 
-error[E0592]: duplicate definitions with name `__pymethod___new____`
+error[E0201]: duplicate definitions with name `__pymethod___new____`:
    --> tests/ui/invalid_pymethods.rs:129:1
     |
 129 | #[pymethods]
     | ^^^^^^^^^^^^
     | |
-    | duplicate definitions for `__pymethod___new____`
-    | other definition for `__pymethod___new____`
+    | previous definition of `__pymethod___new____` here
+    | duplicate definition
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0592]: duplicate definitions with name `__pymethod_func__`
+error[E0201]: duplicate definitions with name `__pymethod_func__`:
    --> tests/ui/invalid_pymethods.rs:140:1
     |
 140 | #[pymethods]
     | ^^^^^^^^^^^^
     | |
-    | duplicate definitions for `__pymethod_func__`
-    | other definition for `__pymethod_func__`
+    | previous definition of `__pymethod_func__` here
+    | duplicate definition
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Had a spare hour this evening; this is a bit of a tidy up so that the generated macro code now spits out associated methods in a single `impl` block.

Roughly, where before the generated code might look like (pseudo-code, not actual output!):

```rust
const METHODS: &[
    PyMethod {
        name: "foo",
        function: { 
            impl SomeClass {
                unsafe extern "C" fn __pymethod_foo__() { }
            }
            SomeClass::__pymethod_foo__
        }
    },
    PyMethod {
        name: "bar",
        function: { 
            impl SomeClass {
                unsafe extern "C" fn __pymethod_bar__() { }
            }
            SomeClass::__pymethod_bar__
        }
    }
];
```

the macro will now generate

```rust
const METHODS: &[
    PyMethod {
        name: "foo",
        function: SomeClass::__pymethod_foo__
    },
    PyMethod {
        name: "bar",
        function: SomeClass::__pymethod_bar__
    }
];

impl SomeClass {
    unsafe extern "C" fn __pymethod_foo__() { }
    unsafe extern "C" fn __pymethod_bar__() { }
}
```

I think this is easier to read for implementers, scales better for `#[pymethods]` with more than item and generates slightly nicer stack traces too!

The necessary refactoring to achieve this was interesting - I had to change some functions to return meaningful structs with the various pieces rather than just `TokenStream` blobs. Opens the way to thinking about some further refactoring, perhaps.