### PR TITLE
macros: refactor codegen to remove PyMethodDefType

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -983,7 +983,13 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
     fn for_all_items(visitor: &mut dyn FnMut(&pyo3::impl_::pyclass::PyClassItems)) {
         use pyo3::impl_::pyclass::*;
         let collector = PyClassImplCollector::<MyClass>::new();
-        static INTRINSIC_ITEMS: PyClassItems = PyClassItems { slots: &[], methods: &[] };
+        static INTRINSIC_ITEMS: PyClassItems = PyClassItems {
+            slots: &[],
+            methods: &[],
+            class_attributes: &[],
+            getters: &[],
+            setters: &[]
+        };
         visitor(&INTRINSIC_ITEMS);
         visitor(collector.py_methods());
     }

--- a/src/class/mod.rs
+++ b/src/class/mod.rs
@@ -27,9 +27,7 @@ pub use self::gc::{PyGCProtocol, PyTraverseError, PyVisit};
 pub use self::iter::PyIterProtocol;
 pub use self::mapping::PyMappingProtocol;
 #[doc(hidden)]
-pub use self::methods::{
-    PyClassAttributeDef, PyGetterDef, PyMethodDef, PyMethodDefType, PyMethodType, PySetterDef,
-};
+pub use self::methods::{PyClassAttributeDef, PyGetterDef, PyMethodDef, PyMethodType, PySetterDef};
 pub use self::number::PyNumberProtocol;
 pub use self::pyasync::PyAsyncProtocol;
 pub use self::sequence::PySequenceProtocol;

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -5,7 +5,8 @@ use crate::{
     pycell::{GetBorrowChecker, Mutability, PyCellLayout, PyClassMutability},
     pyclass_init::PyObjectInit,
     type_object::PyLayout,
-    Py, PyAny, PyCell, PyClass, PyErr, PyMethodDefType, PyNativeType, PyResult, PyTypeInfo, Python,
+    Py, PyAny, PyCell, PyClass, PyClassAttributeDef, PyErr, PyGetterDef, PyMethodDef, PyNativeType,
+    PyResult, PySetterDef, PyTypeInfo, Python,
 };
 use std::{
     marker::PhantomData,
@@ -134,8 +135,11 @@ impl<T> Clone for PyClassImplCollector<T> {
 impl<T> Copy for PyClassImplCollector<T> {}
 
 pub struct PyClassItems {
-    pub methods: &'static [PyMethodDefType],
+    pub methods: &'static [PyMethodDef],
     pub slots: &'static [ffi::PyType_Slot],
+    pub class_attributes: &'static [PyClassAttributeDef],
+    pub getters: &'static [PyGetterDef],
+    pub setters: &'static [PySetterDef],
 }
 
 // Allow PyClassItems in statics
@@ -787,6 +791,9 @@ macro_rules! items_trait {
                 &PyClassItems {
                     methods: &[],
                     slots: &[],
+                    class_attributes: &[],
+                    getters: &[],
+                    setters: &[],
                 }
             }
         }
@@ -823,10 +830,6 @@ mod pyproto_traits {
 }
 #[cfg(feature = "pyproto")]
 pub use pyproto_traits::*;
-
-// Protocol slots from #[pymethods] if not using inventory.
-#[cfg(not(feature = "multiple-pymethods"))]
-items_trait!(PyMethodsProtocolItems, methods_protocol_items);
 
 // Thread checkers
 

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -36,24 +36,6 @@ impl IPowModulo {
     }
 }
 
-/// `PyMethodDefType` represents different types of Python callable objects.
-/// It is used by the `#[pymethods]` and `#[pyproto]` annotations.
-#[derive(Debug)]
-pub enum PyMethodDefType {
-    /// Represents class method
-    Class(PyMethodDef),
-    /// Represents static method
-    Static(PyMethodDef),
-    /// Represents normal method
-    Method(PyMethodDef),
-    /// Represents class attribute, used by `#[attribute]`
-    ClassAttribute(PyClassAttributeDef),
-    /// Represents getter descriptor, used by `#[getter]`
-    Getter(PyGetterDef),
-    /// Represents setter descriptor, used by `#[setter]`
-    Setter(PySetterDef),
-}
-
 #[derive(Copy, Clone, Debug)]
 pub enum PyMethodType {
     PyCFunction(PyCFunction),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,7 @@ pub mod class {
 
     #[doc(hidden)]
     pub use self::methods::{
-        PyClassAttributeDef, PyGetterDef, PyMethodDef, PyMethodDefType, PyMethodType, PySetterDef,
+        PyClassAttributeDef, PyGetterDef, PyMethodDef, PyMethodType, PySetterDef,
     };
 
     pub mod basic {


### PR DESCRIPTION
Just a bit of playing around to remove `PyMethodDefType` by making types in `pyo3-macros-backend` a bit more concrete and growing the `PyClassItems` struct to have explicit `class_attributes`, `getters` and `setters` fields. Think overall it leads to simpler generated code which is always nice.

As it is, the macro code changes on this branch are a bit messy - introduces a lot of types which are almost the same and the `Vec<(Vec<&'a syn::Attribute>, MethodAndMethodDef)>` having tuples feels a bit untidy.

Don't think this is very important to proceed with at all as it was primarily a refactor, so just pushing in case it's interesting for the future. Might close it again before long.