### PR TITLE
Increasing test coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["api-bindings", "development-tools::ffi"]
 license = "Apache-2.0"
 exclude = ["/.gitignore", ".cargo/config", "/codecov.yml", "/Makefile", "/pyproject.toml", "/noxfile.py"]
 edition = "2018"
-rust-version = "1.48"
 
 [dependencies]
 cfg-if = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["api-bindings", "development-tools::ffi"]
 license = "Apache-2.0"
 exclude = ["/.gitignore", ".cargo/config", "/codecov.yml", "/Makefile", "/pyproject.toml", "/noxfile.py"]
 edition = "2018"
+rust-version = "1.48"
 
 [dependencies]
 cfg-if = "1.0"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -687,37 +687,26 @@ mod tests {
 
     #[test]
     fn test_debug() {
-        // PyBuffer {
-        //    buf: 0x00000001012c65d0,
-        //    obj: 0x00000001012c65b0,
-        //    len: 5,
-        //    itemsize: 1,
-        //    readonly: 1,
-        //    ndim: 1,
-        //    format: 0x00000001016747d8,
-        //    shape: 0x0000600001b74010,
-        //    strides: 0x0000600001b74018,
-        //    suboffsets: 0x0000000000000000,
-        //    internal: 0x0000000000000000,
-        //}
         Python::with_gil(|py| {
             let bytes = py.eval("b'abcde'", None, None).unwrap();
             let buffer: PyBuffer<u8> = PyBuffer::get(bytes).unwrap();
-
-            let dbg = format!("{:?}", buffer);
-
-            assert!(dbg.starts_with("PyBuffer"));
-            assert!(dbg.contains("{ buf: "));
-            assert!(dbg.contains(", obj: "));
-            assert!(dbg.contains(", len: 5"));
-            assert!(dbg.contains(", itemsize: 1"));
-            assert!(dbg.contains(", readonly: 1"));
-            assert!(dbg.contains(", ndim: 1"));
-            assert!(dbg.contains(", format: "));
-            assert!(dbg.contains(", shape: "));
-            assert!(dbg.contains(", strides: "));
-            assert!(dbg.contains(", suboffsets: "));
-            assert!(dbg.contains(", internal: "));
+            let expected = format!(
+                concat!(
+                    "PyBuffer {{ buf: {:?}, obj: {:?}, ",
+                    "len: 5, itemsize: 1, readonly: 1, ",
+                    "ndim: 1, format: {:?}, shape: {:?}, ",
+                    "strides: {:?}, suboffsets: {:?}, internal: {:?} }}",
+                ),
+                buffer.0.buf,
+                buffer.0.obj,
+                buffer.0.format,
+                buffer.0.shape,
+                buffer.0.strides,
+                buffer.0.suboffsets,
+                buffer.0.internal
+            );
+            let debug_repr = format!("{:?}", buffer);
+            assert_eq!(debug_repr, expected);
         });
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -729,7 +729,7 @@ mod tests {
         use std::mem::size_of;
         use std::os::raw;
 
-        for (cstr, expected) in [
+        for (cstr, expected) in &[
             // @ prefix goes to native_element_type_from_type_char
             (
                 "@b\0",
@@ -843,8 +843,9 @@ mod tests {
         ] {
             assert_eq!(
                 ElementType::from_format(CStr::from_bytes_with_nul(cstr.as_bytes()).unwrap()),
-                expected,
-                "element from format &Cstr: {cstr:?}"
+                *expected,
+                "element from format &Cstr: {:?}",
+                cstr,
             );
         }
     }

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -74,7 +74,7 @@ impl PyCFunction {
         )
     }
 
-    /// Create a new built-in function without keywords (no arguments).
+    /// Create a new built-in function which takes no arguments.
     pub fn new<'a>(
         fun: ffi::PyCFunction,
         name: &'static str,

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -57,7 +57,7 @@ where
 }
 
 impl PyCFunction {
-    /// Create a new built-in function with keywords.
+    /// Create a new built-in function with keywords (*args and/or **kwargs).
     pub fn new_with_keywords<'a>(
         fun: ffi::PyCFunctionWithKeywords,
         name: &'static str,
@@ -74,7 +74,7 @@ impl PyCFunction {
         )
     }
 
-    /// Create a new built-in function without keywords.
+    /// Create a new built-in function without keywords (no arguments).
     pub fn new<'a>(
         fun: ffi::PyCFunction,
         name: &'static str,

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -19,6 +19,7 @@ pyobject_native_type!(
 );
 
 /// Represents Python `slice` indices.
+#[derive(Debug, Eq, PartialEq)]
 pub struct PySliceIndices {
     pub start: isize,
     pub stop: isize,
@@ -86,5 +87,65 @@ impl PySlice {
 impl ToPyObject for PySliceIndices {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         PySlice::new(py, self.start, self.stop, self.step).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_py_slice_indices_new() {
+        let start = 0;
+        let stop = 0;
+        let step = 0;
+        assert_eq!(
+            PySliceIndices::new(start, stop, step),
+            PySliceIndices {
+                start,
+                stop,
+                step,
+                slicelength: 0
+            }
+        );
+
+        let start = 0;
+        let stop = 100;
+        let step = 10;
+        assert_eq!(
+            PySliceIndices::new(start, stop, step),
+            PySliceIndices {
+                start,
+                stop,
+                step,
+                slicelength: 0
+            }
+        );
+
+        let start = 0;
+        let stop = -10;
+        let step = -1;
+        assert_eq!(
+            PySliceIndices::new(start, stop, step),
+            PySliceIndices {
+                start,
+                stop,
+                step,
+                slicelength: 0
+            }
+        );
+
+        let start = 0;
+        let stop = -10;
+        let step = 20;
+        assert_eq!(
+            PySliceIndices::new(start, stop, step),
+            PySliceIndices {
+                start,
+                stop,
+                step,
+                slicelength: 0
+            }
+        );
     }
 }

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -307,7 +307,7 @@ fn test_pycfunction_new() {
 fn test_pycfunction_new_with_keywords() {
     use pyo3::ffi;
     use std::ffi::CString;
-    use std::os::raw::c_char;
+    use std::os::raw::{c_char, c_long};
     use std::ptr;
 
     let gil = Python::acquire_gil();
@@ -318,10 +318,10 @@ fn test_pycfunction_new_with_keywords() {
         args: *mut ffi::PyObject,
         kwds: *mut ffi::PyObject,
     ) -> *mut ffi::PyObject {
-        let mut foo = 0_i64;
-        let mut bar = 0_i64;
-        let foo_ptr: *mut i64 = &mut foo;
-        let bar_ptr: *mut i64 = &mut bar;
+        let mut foo: c_long = 0;
+        let mut bar: c_long = 0;
+        let foo_ptr: *mut c_long = &mut foo;
+        let bar_ptr: *mut c_long = &mut bar;
 
         let foo_name = CString::new("foo").unwrap();
         let foo_name_raw: *mut c_char = foo_name.into_raw();

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -274,6 +274,88 @@ fn extract_traceback(py: Python<'_>, mut error: PyErr) -> String {
 }
 
 #[test]
+fn test_pycfunction_new() {
+    use pyo3::ffi;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    unsafe extern "C" fn c_fn(
+        _self: *mut ffi::PyObject,
+        _args: *mut ffi::PyObject,
+    ) -> *mut ffi::PyObject {
+        ffi::PyLong_FromLong(4200)
+    }
+
+    let py_fn = PyCFunction::new(
+        c_fn,
+        "py_fn",
+        "py_fn for test (this is the docstring)",
+        py.into(),
+    )
+    .unwrap();
+
+    py_assert!(py, py_fn, "py_fn() == 4200");
+    py_assert!(
+        py,
+        py_fn,
+        "py_fn.__doc__ == 'py_fn for test (this is the docstring)'"
+    );
+}
+
+#[test]
+fn test_pycfunction_new_with_keywords() {
+    use pyo3::ffi;
+    use std::ffi::CString;
+    use std::os::raw::c_char;
+    use std::ptr;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    unsafe extern "C" fn c_fn(
+        _self: *mut ffi::PyObject,
+        args: *mut ffi::PyObject,
+        kwds: *mut ffi::PyObject,
+    ) -> *mut ffi::PyObject {
+        let mut foo = 0_i64;
+        let mut bar = 0_i64;
+        let foo_ptr: *mut i64 = &mut foo;
+        let bar_ptr: *mut i64 = &mut bar;
+
+        let foo_name = CString::new("foo").unwrap();
+        let foo_name_raw: *mut c_char = foo_name.into_raw();
+        let kw_bar_name = CString::new("kw_bar").unwrap();
+        let kw_bar_name_raw: *mut c_char = kw_bar_name.into_raw();
+
+        let mut arglist = vec![foo_name_raw, kw_bar_name_raw, ptr::null_mut()];
+        let arglist_ptr: *mut *mut c_char = arglist.as_mut_ptr();
+
+        let arg_pattern: *const c_char = CString::new("l|l").unwrap().into_raw();
+
+        ffi::PyArg_ParseTupleAndKeywords(args, kwds, arg_pattern, arglist_ptr, foo_ptr, bar_ptr);
+
+        ffi::PyLong_FromLong(foo * bar)
+    }
+
+    let py_fn = PyCFunction::new_with_keywords(
+        c_fn,
+        "py_fn",
+        "py_fn for test (this is the docstring)",
+        py.into(),
+    )
+    .unwrap();
+
+    py_assert!(py, py_fn, "py_fn(42, kw_bar=100) == 4200");
+    py_assert!(py, py_fn, "py_fn(foo=42, kw_bar=100) == 4200");
+    py_assert!(
+        py,
+        py_fn,
+        "py_fn.__doc__ == 'py_fn for test (this is the docstring)'"
+    );
+}
+
+#[test]
 fn test_closure() {
     let gil = Python::acquire_gil();
     let py = gil.python();


### PR DESCRIPTION
Starting with `src/buffer.rs` - some simple tests in there to exercise the debug code and the type matching functions.

I also added some calls to the fortran-order-specific functions in `test_array_buffer`. These are pretty uninteresting because `array` produces a 1D buffer, but I don't know how to generate a higher-dim buffer with the standard library. Maybe I could just alloc and fill some memory with Rust and create a `PyBuffer` without using `PyBuffer::get()`.