### PR TITLE
Update PyTryFrom for PyMapping and PySequence to more accurately check types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PyCapsule::name` now returns `PyResult<Option<&CStr>>` instead of `&CStr`.
 - `FromPyObject::extract` now raises an error if source type is `PyString` and target type is `Vec<T>`. [#2500](https://github.com/PyO3/pyo3/pull/2500)
 - `pyo3_build_config::add_extension_module_link_args()` now also emits linker arguments for `wasm32-unknown-emscripten`. [#2500](https://github.com/PyO3/pyo3/pull/2500)
+- Downcasting (`PyTryFrom`) behavior has changed for `PySequence` and `PyMapping`: classes are now required to inherit from (or register with) the corresponding Python standard library abstract base class. See the [migration guide](https://pyo3.rs/latest/migration.html) for information on fixing broken downcasts. [#2477](https://github.com/PyO3/pyo3/pull/2477)
 
 ### Removed
 

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -55,7 +55,7 @@ PyMapping::register::<Mapping>(py).unwrap();
 assert!(m.as_ref(py).downcast::<PyMapping>().is_ok());
 ```
 
-Note that this requirement may go away in the future when a pyclass is able to inherit from the abstract base class directly (see [pyo3/pyo3#991](https://github.com/PyO3/pyo3/issues/904)).
+Note that this requirement may go away in the future when a pyclass is able to inherit from the abstract base class directly (see [pyo3/pyo3#991](https://github.com/PyO3/pyo3/issues/991)).
 
 ### The `multiple-pymethods` feature now requires Rust 1.62
 

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -22,10 +22,9 @@ penatly is a problem, you may be able to perform your own checks and use
 
 Another side-effect is that a pyclass defined in Rust with PyO3 will need to
 be _registered_ with the corresponding Python abstract base class for
-downcasting to succeed. `PySequence::register_abc_subclass` and
-`PyMapping:register_abc_subclass` have been added to make it easy to do this
-from Rust code. These are equivalent to calling
-`collections.abc.Mapping.register(MappingPyClass)` or
+downcasting to succeed. `PySequence::register` and `PyMapping:register` have
+been added to make it easy to do this from Rust code. These are equivalent to
+calling `collections.abc.Mapping.register(MappingPyClass)` or
 `collections.abc.Sequence.register(SequencePyClass)` from Python.
 
 For example, for a mapping class defined in Rust:
@@ -52,7 +51,7 @@ You must register the class with `collections.abc.Mapping` before the downcast w
 ```rust,compile_fail
 let m = Py::new(py, Mapping { index }).unwrap();
 assert!(m.as_ref(py).downcast::<PyMapping>().is_err());
-PyMapping::register_abc_subclass::<Mapping>(py).unwrap();
+PyMapping::register::<Mapping>(py).unwrap();
 assert!(m.as_ref(py).downcast::<PyMapping>().is_ok());
 ```
 

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -5,9 +5,9 @@ For a detailed list of all changes, see the [CHANGELOG](changelog.md).
 
 ## from 0.16.* to 0.17
 
-### Downcasting (`PyTryFrom`) has been changed for `PyMapping` and `PySequence` types
+### Type checks have been changed for `PyMapping` and `PySequence` types
 
-Previously the safety checks for downcasting to `PyTryFrom` and `PyMapping`
+Previously the type checks for `PyMapping` and `PySequence` (implemented in `PyTryFrom`)
 used the Python C-API functions `PyMapping_Check` and `PySequence_Check`.
 Unfortunately these functions are not sufficient for distinguishing such types,
 leading to inconsistent behavior (see

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -189,12 +189,7 @@ unsafe fn create_type_object_impl(
         name: py_class_qualified_name(module_name, name)?,
         basicsize: basicsize as c_int,
         itemsize: 0,
-        flags: py_class_flags(
-            has_traverse,
-            is_basetype,
-            #[cfg(all(Py_3_10, not(Py_LIMITED_API)))]
-            is_mapping,
-        ),
+        flags: py_class_flags(has_traverse, is_basetype),
         slots: slots.as_mut_ptr(),
     };
 
@@ -304,11 +299,7 @@ fn py_class_qualified_name(module_name: Option<&str>, class_name: &str) -> PyRes
     .into_raw())
 }
 
-fn py_class_flags(
-    is_gc: bool,
-    is_basetype: bool,
-    #[cfg(all(Py_3_10, not(Py_LIMITED_API)))] is_mapping: bool,
-) -> c_uint {
+fn py_class_flags(is_gc: bool, is_basetype: bool) -> c_uint {
     let mut flags = ffi::Py_TPFLAGS_DEFAULT;
 
     if is_gc {
@@ -317,14 +308,6 @@ fn py_class_flags(
 
     if is_basetype {
         flags |= ffi::Py_TPFLAGS_BASETYPE;
-    }
-
-    #[cfg(all(Py_3_10, not(Py_LIMITED_API)))]
-    {
-        if is_mapping {
-            flags |= ffi::Py_TPFLAGS_MAPPING;
-            flags &= !ffi::Py_TPFLAGS_SEQUENCE;
-        }
     }
 
     // `c_ulong` and `c_uint` have the same size

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -189,7 +189,12 @@ unsafe fn create_type_object_impl(
         name: py_class_qualified_name(module_name, name)?,
         basicsize: basicsize as c_int,
         itemsize: 0,
-        flags: py_class_flags(has_traverse, is_basetype),
+        flags: py_class_flags(
+            has_traverse,
+            is_basetype,
+            #[cfg(all(Py_3_10, not(Py_LIMITED_API)))]
+            is_mapping,
+        ),
         slots: slots.as_mut_ptr(),
     };
 
@@ -299,7 +304,11 @@ fn py_class_qualified_name(module_name: Option<&str>, class_name: &str) -> PyRes
     .into_raw())
 }
 
-fn py_class_flags(is_gc: bool, is_basetype: bool) -> c_uint {
+fn py_class_flags(
+    is_gc: bool,
+    is_basetype: bool,
+    #[cfg(all(Py_3_10, not(Py_LIMITED_API)))] is_mapping: bool,
+) -> c_uint {
     let mut flags = ffi::Py_TPFLAGS_DEFAULT;
 
     if is_gc {
@@ -308,6 +317,14 @@ fn py_class_flags(is_gc: bool, is_basetype: bool) -> c_uint {
 
     if is_basetype {
         flags |= ffi::Py_TPFLAGS_BASETYPE;
+    }
+
+    #[cfg(all(Py_3_10, not(Py_LIMITED_API)))]
+    {
+        if is_mapping {
+            flags |= ffi::Py_TPFLAGS_MAPPING;
+            flags &= !ffi::Py_TPFLAGS_SEQUENCE;
+        }
     }
 
     // `c_ulong` and `c_uint` have the same size

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -111,16 +111,15 @@ impl PyMapping {
 
     /// Register a pyclass as a subclass of `collections.abc.Mapping` (from the Python standard
     /// library). This is equvalent to `collections.abc.Mapping.register(T)` in Python.
-    /// This is required for a class to be downcastable from `PyAny` to `PyMapping`.
-    pub fn register_mapping_abc_subclass<T: PyTypeInfo>(py: Python<'_>) -> PyResult<()> {
+    /// This registration is required for a pyclass to be downcastable from `PyAny` to `PyMapping`.
+    pub fn register_abc_subclass<T: PyTypeInfo>(py: Python<'_>) -> PyResult<()> {
         let ty = T::type_object(py);
-        let mapping_abc = get_mapping_abc(py);
-        mapping_abc.call_method1("register", (ty,))?;
+        get_mapping_abc(py).call_method1("register", (ty,))?;
         Ok(())
     }
 }
 
-fn get_mapping_abc(py: Python<'_>) -> &'_ PyType {
+fn get_mapping_abc(py: Python<'_>) -> &PyType {
     MAPPING_ABC
         .get_or_init(py, || {
             py.import("collections.abc")

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -129,8 +129,7 @@ fn get_mapping_abc(py: Python<'_>) -> Result<&PyType, PyErr> {
                 .into_py(py))
         })
         .as_ref()
-        .map(|t| t.as_ref(py))
-        .map_err(|e| e.clone_ref(py))
+        .map_or_else(|e| Err(e.clone_ref(py)), |t| Ok(t.as_ref(py)))
 }
 
 impl<'v> PyTryFrom<'v> for PyMapping {

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -312,8 +312,7 @@ fn get_sequence_abc(py: Python<'_>) -> Result<&PyType, PyErr> {
                 .into_py(py))
         })
         .as_ref()
-        .map(|t| t.as_ref(py))
-        .map_err(|e| e.clone_ref(py))
+        .map_or_else(|e| Err(e.clone_ref(py)), |t| Ok(t.as_ref(py)))
 }
 
 impl<'v> PyTryFrom<'v> for PySequence {

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -2,10 +2,14 @@
 use crate::err::{self, PyDowncastError, PyErr, PyResult};
 use crate::exceptions::PyValueError;
 use crate::internal_tricks::get_ssize_index;
-use crate::types::{PyAny, PyList, PyString, PyTuple};
+use crate::once_cell::GILOnceCell;
+use crate::type_object::PyTypeInfo;
+use crate::types::{PyAny, PyList, PyString, PyTuple, PyType};
 use crate::{ffi, PyNativeType, ToPyObject};
-use crate::{AsPyPointer, IntoPyPointer, Py, Python};
+use crate::{AsPyPointer, IntoPy, IntoPyPointer, Py, Python};
 use crate::{FromPyObject, PyTryFrom};
+
+static SEQUENCE_ABC: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 
 /// Represents a reference to a Python object supporting the sequence protocol.
 #[repr(transparent)]
@@ -250,6 +254,15 @@ impl PySequence {
                 .from_owned_ptr_or_err(ffi::PySequence_Tuple(self.as_ptr()))
         }
     }
+
+    /// Register a pyclass as a subclass of `collections.abc.Sequence` (from the Python standard
+    /// library). This is equvalent to `collections.abc.Sequence.register(T)` in Python.
+    /// This registration is required for a pyclass to be downcastable from `PyAny` to `PySequence`.
+    pub fn register_abc_subclass<T: PyTypeInfo>(py: Python<'_>) -> PyResult<()> {
+        let ty = T::type_object(py);
+        get_sequence_abc(py).call_method1("register", (ty,))?;
+        Ok(())
+    }
 }
 
 #[inline]
@@ -289,15 +302,33 @@ where
     Ok(v)
 }
 
+fn get_sequence_abc(py: Python<'_>) -> &PyType {
+    SEQUENCE_ABC
+        .get_or_init(py, || {
+            py.import("collections.abc")
+                .expect("coud not import 'collections.abc'")
+                .getattr("Sequence")
+                .expect("coud not access 'Sequence' from 'collections.abc'")
+                .downcast::<PyType>()
+                .expect("could not access 'collections.abc.Sequence'")
+                .into_py(py)
+        })
+        .as_ref(py)
+}
+
 impl<'v> PyTryFrom<'v> for PySequence {
+    /// Downcasting to `PySequence` requires the concrete class to be a subclass (or registered
+    /// subclass) of `collections.abc.Sequence` (from the Python standard library) - i.e.
+    /// `isinstance(<class>, collections.abc.Sequence) == True`.
     fn try_from<V: Into<&'v PyAny>>(value: V) -> Result<&'v PySequence, PyDowncastError<'v>> {
         let value = value.into();
-        unsafe {
-            if ffi::PySequence_Check(value.as_ptr()) != 0 {
-                Ok(<PySequence as PyTryFrom>::try_from_unchecked(value))
-            } else {
-                Err(PyDowncastError::new(value, "Sequence"))
-            }
+        if value
+            .is_instance(get_sequence_abc(value.py()))
+            .unwrap_or(false)
+        {
+            unsafe { Ok(<PySequence as PyTryFrom>::try_from_unchecked(value)) }
+        } else {
+            Err(PyDowncastError::new(value, "Sequence"))
         }
     }
 

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -9,6 +9,7 @@ use pyo3::types::IntoPyDict;
 use pyo3::types::PyList;
 use pyo3::types::PyMapping;
 use pyo3::types::PySequence;
+use pyo3::PyTypeInfo;
 
 mod common;
 
@@ -115,6 +116,16 @@ fn test_delitem() {
 #[test]
 fn mapping_is_not_sequence() {
     Python::with_gil(|py| {
+        // downcast to PyMapping requires isinstance(<cls>, collections.abc.Mapping) to pass, so we
+        // have to register the class first
+        PyModule::import(py, "collections.abc")
+            .unwrap()
+            .getattr("Mapping")
+            .unwrap()
+            .getattr("register")
+            .unwrap()
+            .call1((Mapping::type_object(py),))
+            .unwrap();
         let mut index = HashMap::new();
         index.insert("Foo".into(), 1);
         index.insert("Bar".into(), 2);

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -120,10 +120,8 @@ fn mapping_is_not_sequence() {
         index.insert("Bar".into(), 2);
         let m = Py::new(py, Mapping { index }).unwrap();
 
-        // downcast to PyMapping requires isinstance(<cls>, collections.abc.Mapping) to pass, so we
-        // have to register the class first
-        PyMapping::register_mapping_abc_subclass::<Mapping>(py)
-            .expect("failed to register 'Mapping' as a subclass of 'collections.abc.Mapping'");
+        PyMapping::register_abc_subclass::<Mapping>(py).unwrap();
+
         assert!(m.as_ref(py).downcast::<PyMapping>().is_ok());
         assert!(m.as_ref(py).downcast::<PySequence>().is_err());
     });

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -120,7 +120,7 @@ fn mapping_is_not_sequence() {
         index.insert("Bar".into(), 2);
         let m = Py::new(py, Mapping { index }).unwrap();
 
-        PyMapping::register_abc_subclass::<Mapping>(py).unwrap();
+        PyMapping::register::<Mapping>(py).unwrap();
 
         assert!(m.as_ref(py).downcast::<PyMapping>().is_ok());
         assert!(m.as_ref(py).downcast::<PySequence>().is_err());

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -210,7 +210,7 @@ impl Mapping {
 #[test]
 fn mapping() {
     Python::with_gil(|py| {
-        PyMapping::register_abc_subclass::<Mapping>(py).unwrap();
+        PyMapping::register::<Mapping>(py).unwrap();
 
         let inst = Py::new(
             py,
@@ -318,7 +318,7 @@ impl Sequence {
 #[test]
 fn sequence() {
     Python::with_gil(|py| {
-        PySequence::register_abc_subclass::<Sequence>(py).unwrap();
+        PySequence::register::<Sequence>(py).unwrap();
 
         let inst = Py::new(py, Sequence { values: vec![] }).unwrap();
 

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -210,7 +210,7 @@ impl Mapping {
 #[test]
 fn mapping() {
     Python::with_gil(|py| {
-        PyMapping::register_mapping_abc_subclass::<Mapping>(py).unwrap();
+        PyMapping::register_abc_subclass::<Mapping>(py).unwrap();
 
         let inst = Py::new(
             py,

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -2,7 +2,7 @@
 
 use pyo3::exceptions::{PyAttributeError, PyIndexError, PyValueError};
 use pyo3::types::{PyDict, PyList, PyMapping, PySequence, PySlice, PyType};
-use pyo3::{prelude::*, py_run, PyCell, PyTypeInfo};
+use pyo3::{prelude::*, py_run, PyCell};
 use std::{isize, iter};
 
 mod common;
@@ -210,14 +210,7 @@ impl Mapping {
 #[test]
 fn mapping() {
     Python::with_gil(|py| {
-        PyModule::import(py, "collections.abc")
-            .unwrap()
-            .getattr("Mapping")
-            .unwrap()
-            .getattr("register")
-            .unwrap()
-            .call1((Mapping::type_object(py),))
-            .unwrap();
+        PyMapping::register_mapping_abc_subclass::<Mapping>(py).unwrap();
 
         let inst = Py::new(
             py,

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -318,6 +318,8 @@ impl Sequence {
 #[test]
 fn sequence() {
     Python::with_gil(|py| {
+        PySequence::register_abc_subclass::<Sequence>(py).unwrap();
+
         let inst = Py::new(py, Sequence { values: vec![] }).unwrap();
 
         let sequence: &PySequence = inst.as_ref(py).downcast().unwrap();

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -2,7 +2,7 @@
 
 use pyo3::exceptions::{PyAttributeError, PyIndexError, PyValueError};
 use pyo3::types::{PyDict, PyList, PyMapping, PySequence, PySlice, PyType};
-use pyo3::{prelude::*, py_run, PyCell};
+use pyo3::{prelude::*, py_run, PyCell, PyTypeInfo};
 use std::{isize, iter};
 
 mod common;
@@ -210,6 +210,15 @@ impl Mapping {
 #[test]
 fn mapping() {
     Python::with_gil(|py| {
+        PyModule::import(py, "collections.abc")
+            .unwrap()
+            .getattr("Mapping")
+            .unwrap()
+            .getattr("register")
+            .unwrap()
+            .call1((Mapping::type_object(py),))
+            .unwrap();
+
         let inst = Py::new(
             py,
             Mapping {
@@ -218,7 +227,6 @@ fn mapping() {
         )
         .unwrap();
 
-        //
         let mapping: &PyMapping = inst.as_ref(py).downcast().unwrap();
 
         py_assert!(py, inst, "len(inst) == 0");

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -325,6 +325,9 @@ fn sequence_is_not_mapping() {
         },
     )
     .unwrap();
+
+    PySequence::register_abc_subclass::<OptionList>(py).unwrap();
+
     assert!(list.as_ref().downcast::<PyMapping>().is_err());
     assert!(list.as_ref().downcast::<PySequence>().is_ok());
 }

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -2,7 +2,7 @@
 
 use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{IntoPyDict, PyList};
+use pyo3::types::{IntoPyDict, PyList, PyMapping, PySequence};
 
 use pyo3::py_run;
 
@@ -311,4 +311,20 @@ fn test_option_list_get() {
         py_assert!(py, list, "list[1] == None");
         py_expect_exception!(py, list, "list[2]", PyIndexError);
     });
+}
+
+#[test]
+fn sequence_is_not_mapping() {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let list = PyCell::new(
+        py,
+        OptionList {
+            items: vec![Some(1), None],
+        },
+    )
+    .unwrap();
+    assert!(list.as_ref().downcast::<PyMapping>().is_err());
+    assert!(list.as_ref().downcast::<PySequence>().is_ok());
 }

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -326,7 +326,7 @@ fn sequence_is_not_mapping() {
     )
     .unwrap();
 
-    PySequence::register_abc_subclass::<OptionList>(py).unwrap();
+    PySequence::register::<OptionList>(py).unwrap();
 
     assert!(list.as_ref().downcast::<PyMapping>().is_err());
     assert!(list.as_ref().downcast::<PySequence>().is_ok());


### PR DESCRIPTION
This is intended to fix #2072 - see further discussion in that thread.

The implementation is such that for both `PyMapping` and `PyTryFrom`, they will call into python to check `isinstance(<obj>, collections.abc.Mapping)` before successfully downcasting. Please note this is a breaking change so it is important the documentation and migration guide are clear.

Also note the implementation has changed from the initial draft of this PR. See discussion below and in #2072 for more information.
 
### TODO
- [x]  an entry in CHANGELOG.md
- [x]  docs to all new functions and / or detail in the guide
- [x]  tests for all new or changed functions