### PR TITLE
opt: remove some generic code bloat

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1001,12 +1001,11 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
     type WeakRef = ::pyo3::impl_::pyclass::PyClassDummySlot;
     type BaseNativeType = ::pyo3::PyAny;
 
-    fn for_all_items(visitor: &mut dyn FnMut(&pyo3::impl_::pyclass::PyClassItems)) {
+    fn items_iter() -> pyo3::impl_::pyclass::PyClassItemsIter {
         use pyo3::impl_::pyclass::*;
         let collector = PyClassImplCollector::<MyClass>::new();
         static INTRINSIC_ITEMS: PyClassItems = PyClassItems { slots: &[], methods: &[] };
-        visitor(&INTRINSIC_ITEMS);
-        visitor(collector.py_methods());
+        PyClassItemsIter::new(&INTRINSIC_ITEMS, collector.py_methods())
     }
 }
 

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -38,7 +38,7 @@ where
 pub fn extract_argument_with_default<'py, T>(
     obj: Option<&'py PyAny>,
     arg_name: &str,
-    default: impl FnOnce() -> T,
+    default: fn() -> T,
 ) -> PyResult<T>
 where
     T: FromPyObject<'py>,
@@ -57,7 +57,7 @@ where
 pub fn from_py_with<'py, T>(
     obj: &'py PyAny,
     arg_name: &str,
-    extractor: impl FnOnce(&'py PyAny) -> PyResult<T>,
+    extractor: fn(&'py PyAny) -> PyResult<T>,
 ) -> PyResult<T> {
     // Safety: obj is not None (see safety
     match extractor(obj) {
@@ -71,8 +71,8 @@ pub fn from_py_with<'py, T>(
 pub fn from_py_with_with_default<'py, T>(
     obj: Option<&'py PyAny>,
     arg_name: &str,
-    extractor: impl FnOnce(&'py PyAny) -> PyResult<T>,
-    default: impl FnOnce() -> T,
+    extractor: fn(&'py PyAny) -> PyResult<T>,
+    default: fn() -> T,
 ) -> PyResult<T> {
     match obj {
         Some(obj) => from_py_with(obj, arg_name, extractor),

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -105,7 +105,15 @@ impl LazyStaticType {
     }
 
     pub fn get_or_init<T: PyClass>(&self, py: Python<'_>) -> *mut ffi::PyTypeObject {
-        let type_object = *self.value.get_or_init(py, || create_type_object::<T>(py));
+        fn inner<T: PyClass>() -> *mut ffi::PyTypeObject {
+            // Safety: `py` is held by the caller of `get_or_init`.
+            let py = unsafe { Python::assume_gil_acquired() };
+            create_type_object::<T>(py)
+        }
+
+        // Uses explicit GILOnceCell::get_or_init::<fn() -> *mut ffi::PyTypeObject> monomorphization
+        // so that only this one monomorphization is instantiated (instead of one closure monormization for each T).
+        let type_object = *self.value.get_or_init::<fn() -> *mut ffi::PyTypeObject>(py, inner::<T>);
         self.ensure_init(py, type_object, T::NAME, &T::for_all_items);
         type_object
     }

--- a/tests/ui/abi3_nativetype_inheritance.stderr
+++ b/tests/ui/abi3_nativetype_inheritance.stderr
@@ -22,15 +22,15 @@ note: required by a bound in `PyRefMut`
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `PyDict: PyClass` is not satisfied
-   --> tests/ui/abi3_nativetype_inheritance.rs:5:1
-    |
-5   | #[pyclass(extends=PyDict)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyClass` is not implemented for `PyDict`
-    |
-    = note: required because of the requirements on the impl of `PyClassBaseType` for `PyDict`
+    --> tests/ui/abi3_nativetype_inheritance.rs:5:1
+     |
+5    | #[pyclass(extends=PyDict)]
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyClass` is not implemented for `PyDict`
+     |
+     = note: required because of the requirements on the impl of `PyClassBaseType` for `PyDict`
 note: required by a bound in `ThreadCheckerInherited`
-   --> src/impl_/pyclass.rs
-    |
-    | pub struct ThreadCheckerInherited<T: PyClass + Send, U: PyClassBaseType>(
-    |                                                         ^^^^^^^^^^^^^^^ required by this bound in `ThreadCheckerInherited`
-    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+    --> src/impl_/pyclass.rs
+     |
+     | pub struct ThreadCheckerInherited<T: PyClass + Send, U: PyClassBaseType>(
+     |                                                         ^^^^^^^^^^^^^^^ required by this bound in `ThreadCheckerInherited`
+     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/pyclass_send.stderr
+++ b/tests/ui/pyclass_send.stderr
@@ -1,18 +1,18 @@
 error[E0277]: `Rc<i32>` cannot be sent between threads safely
-   --> tests/ui/pyclass_send.rs:4:1
-    |
-4   | #[pyclass]
-    | ^^^^^^^^^^ `Rc<i32>` cannot be sent between threads safely
-    |
-    = help: within `NotThreadSafe`, the trait `Send` is not implemented for `Rc<i32>`
+    --> tests/ui/pyclass_send.rs:4:1
+     |
+4    | #[pyclass]
+     | ^^^^^^^^^^ `Rc<i32>` cannot be sent between threads safely
+     |
+     = help: within `NotThreadSafe`, the trait `Send` is not implemented for `Rc<i32>`
 note: required because it appears within the type `NotThreadSafe`
-   --> tests/ui/pyclass_send.rs:5:8
-    |
-5   | struct NotThreadSafe {
-    |        ^^^^^^^^^^^^^
+    --> tests/ui/pyclass_send.rs:5:8
+     |
+5    | struct NotThreadSafe {
+     |        ^^^^^^^^^^^^^
 note: required by a bound in `ThreadCheckerStub`
-   --> src/impl_/pyclass.rs
-    |
-    | pub struct ThreadCheckerStub<T: Send>(PhantomData<T>);
-    |                                 ^^^^ required by this bound in `ThreadCheckerStub`
-    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+    --> src/impl_/pyclass.rs
+     |
+     | pub struct ThreadCheckerStub<T: Send>(PhantomData<T>);
+     |                                 ^^^^ required by this bound in `ThreadCheckerStub`
+     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Comprised of three commits when just playing around this morning:
- Use `fn` instead of closure in `LazyStaticType::get_or_init` to avoid creating a new monomorphization of `GILOnceCell::get_or_init` for each PyClass
- Use `fn()` instead of `impl FnOnce` in `extract_argument` default / from_py_with arguments, reducing number of monomorphizations of those functions. I think this is more correct anyway (we don't need to support capturing closures).
- Change `#[pyclass]` machinery to create an iterator of `PyClassItems` instead of relying on a "visitor" closure. I think it's tidier, and again reduces the amount of code that needs to be generated per PyClass.

Overall this reduced llvm lines by about 2% in the `pytests` crate.