### PR TITLE
security: fix use-after-free in PyCapsule implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use `memoffset` for computing PyCell offsets [#2450](https://github.com/PyO3/pyo3/pull/2450)
 - Fix incorrect enum names being returned by `repr` for enums renamed by `#[pyclass(name)]` [#2457](https://github.com/PyO3/pyo3/pull/2457)
 - Fix incorrect Python version cfg definition on `PyObject_CallNoArgs`[#2476](https://github.com/PyO3/pyo3/pull/2476)
+- Fix use-after-free in `PyCapsule` type. [#2481](https://github.com/PyO3/pyo3/pull/2481)
 
 ## [0.16.5] - 2022-05-15
 

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -48,9 +48,10 @@ fn test_utc_timezone() {
     Python::with_gil(|py| {
         let utc_timezone = unsafe {
             PyDateTime_IMPORT();
-            &*(&PyDateTime_TimeZone_UTC() as *const *mut crate::ffi::PyObject
-                as *const crate::PyObject)
+            PyDateTime_TimeZone_UTC()
         };
+        let utc_timezone =
+            unsafe { &*((&utc_timezone) as *const *mut PyObject as *const Py<PyAny>) };
         let locals = PyDict::new(py);
         locals.set_item("utc_timezone", utc_timezone).unwrap();
         py.run(


### PR DESCRIPTION
Thanks to @saethlin for alerting me to this issue.

The current implementation of `PyCapsule::new` does not require a specific lifetime on the `name: &CStr` argument. This is a fundamental flaw; the argument is converted to a pointer and handed over to CPython, which simply stores the pointer.

This means that as soon as `PyCapsule::new` is complete, current implementations can deallocate the name and any subsequent calls to `PyCapsule_GetName` will read from freed memory (including our safe `PyCapsule::name` wrapper).

A snippet as simple as this is enough to achieve this:

```rust
let capsule: Py<PyCapsule> = Python::with_gil(|py| {
    let name = CString::new("foo").unwrap();
    PyCapsule::new(py, 5usize, &name).unwrap().into()
});

Python::with_gil(|py| {
    let name = capsule.as_ref(py).name();  // <-- No guarantee
});
```

The fix without any API change is to take a copy of the name as a `CString` and store that where we place the rest of the capsule data. We can then pass CPython the pointer from there, which guarantees that the name will outlive the capsule.

----

Given this is a reasonably clear-cut soundness error, I think we should file a RustSec advisory and also yank versions 0.16.0 -> 0.16.5 (after publishing this as a 0.16.6).