### PR TITLE
Make clippy happy with code emitted by impl_arg_param 

### DIFF
--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -20,7 +20,7 @@ proc-macro2 = { version = "1", default-features = false }
 [dependencies.syn]
 version = "1.0.56"
 default-features = false
-features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits"]
+features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits", "visit"]
 
 [features]
 pyproto = []

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -34,4 +34,4 @@ pub use pyfunction::{build_py_function, PyFunctionOptions};
 pub use pyimpl::{build_py_methods, PyClassMethodsType};
 #[cfg(feature = "pyproto")]
 pub use pyproto::build_py_proto;
-pub use utils::get_doc;
+pub use utils::{get_doc, has_named_lifetime};

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -240,7 +240,6 @@ fn impl_arg_param(
                 }
             }
             (Some(default), _) => {
-                
                 quote_arg_span! {
                     _pyo3::impl_::extract_argument::from_py_with_with_default(#arg_value, #name_str, #expr_path, || #default)
                 }
@@ -263,7 +262,6 @@ fn impl_arg_param(
     } else {
         match (spec.default_value(name), arg.optional.is_some()) {
             (Some(default), true) if default.to_string() != "None" => {
-
                 quote_arg_span! {
                     _pyo3::impl_::extract_argument::extract_argument_with_default(#arg_value, #name_str, || Some(#default))
                 }
@@ -312,7 +310,7 @@ fn impl_arg_param(
 
         Ok(quote_arg_span! {
             let #mut_ _tmp: #target_ty = #arg_value_or_default?;
-            #[allow(clippy::needless_option_as_deref)]
+            #[allow(clippy::needless_option_as_deref, clippy::borrow_deref_ref)]
             let #arg_name = #borrow_tmp;
         })
     } else {

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -240,6 +240,7 @@ fn impl_arg_param(
                 }
             }
             (Some(default), _) => {
+                
                 quote_arg_span! {
                     _pyo3::impl_::extract_argument::from_py_with_with_default(#arg_value, #name_str, #expr_path, || #default)
                 }
@@ -262,6 +263,7 @@ fn impl_arg_param(
     } else {
         match (spec.default_value(name), arg.optional.is_some()) {
             (Some(default), true) if default.to_string() != "None" => {
+
                 quote_arg_span! {
                     _pyo3::impl_::extract_argument::extract_argument_with_default(#arg_value, #name_str, || Some(#default))
                 }
@@ -314,8 +316,9 @@ fn impl_arg_param(
             let #arg_name = #borrow_tmp;
         })
     } else {
+        let ty = arg.ty;
         Ok(quote_arg_span! {
-            let #arg_name = #arg_value_or_default?;
+            let #arg_name: #ty = #arg_value_or_default?;
         })
     };
 }

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -313,6 +313,11 @@ fn impl_arg_param(
             #[allow(clippy::needless_option_as_deref, clippy::borrow_deref_ref)]
             let #arg_name = #borrow_tmp;
         })
+    } else if cfg!(feature = "pyproto") {
+        // arg.ty is kinda weird
+        Ok(quote_arg_span! {
+            let #arg_name = #arg_value_or_default?;
+        })
     } else {
         let ty = arg.ty;
         Ok(quote_arg_span! {

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -164,6 +164,32 @@ pub fn unwrap_ty_group(mut ty: &syn::Type) -> &syn::Type {
     ty
 }
 
+/// Check if a type has a named lifetime
+///
+/// ```rust
+/// use pyo3_macros_backend::has_named_lifetime;
+///
+/// let with_lifetime = syn::parse_str::<syn::Type>("Foo::<'a>::BAR").unwrap();
+/// assert!(has_named_lifetime(&with_lifetime));
+/// let without_lifetime = syn::parse_str::<syn::Type>("Foo::BAR").unwrap();
+/// assert!(!has_named_lifetime(&without_lifetime));
+/// ```
+pub fn has_named_lifetime(ty: &syn::Type) -> bool {
+    use syn::visit::Visit;
+
+    struct WhetherLifetime(bool);
+
+    impl<'a> Visit<'a> for WhetherLifetime {
+        fn visit_lifetime(&mut self, _: &'a syn::Lifetime) {
+            self.0 = true;
+        }
+    }
+
+    let mut visitor = WhetherLifetime(false);
+    visitor.visit_type(&ty);
+    visitor.0
+}
+
 /// Remove lifetime from reference
 pub(crate) fn remove_lifetime(tref: &syn::TypeReference) -> syn::TypeReference {
     let mut tref = tref.to_owned();

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -470,3 +470,17 @@ fn required_argument_after_option() {
         py_assert!(py, f, "f(x=None, y=5) == 5");
     })
 }
+
+#[test]
+fn call_named_lifetime() {
+    #[pyfunction]
+    fn with_lifetime<'named>(_x: &'named PyAny) -> bool {
+        true
+    }
+
+    Python::with_gil(|py| {
+        let f = wrap_pyfunction!(with_lifetime, py).unwrap();
+
+        py_assert!(py, f, "f(42)");
+    })
+}


### PR DESCRIPTION
### Fixes some bad error message when Rust can't find a type:

```rust
// missing PathBuf import
use pyo3::prelude::*;

#[pyclass]
pub struct S;

#[pymethods]
impl S {
    #[new]
    #[args(path = "None")]
    fn new(path: Option<PathBuf>) -> PyResult<Self> {
        todo!()
    }
}
```

```
-- snip --

error[E0282]: type annotations needed for `Option<T>`
 --> src\lib.rs:7:1
  |
7 | #[pymethods]
  | ^^^^^^^^^^^^ consider giving `arg0` the explicit type `Option<T>`, where the type parameter `T` is specified
  |
  = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)

Some errors have detailed explanations: E0282, E0412.
For more information about an error, try `rustc --explain E0282`.
```


### Fixes https://github.com/rust-lang/rust-clippy/issues/8971


```rust
#[pyo3::pyfunction]
pub fn hash_djb2(_s: &str) -> i32 {
    0
}
```
```
warning: deref on an immutable reference
 --> src\lib.rs:3:22
  |
3 | pub fn hash_djb2(_s: &str) -> i32 {
  |                      ^^^^ help: if you would like to reborrow, try removing `&*`: `&str`
  |
  = note: `#[warn(clippy::borrow_deref_ref)]` on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref

warning: `my_module` (lib) generated 1 warning
```