### PR TITLE
inventory: update to 0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
             echo "suppress_build_script_link_lines=true" >> config.txt
             PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --no-default-features
             PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --no-default-features --features "abi3"
-            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features full
-            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "abi3 full"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "full multiple-pymethods"
+            PYO3_BUILD_CONFIG=$(pwd)/config.txt cargo check --all-targets --features "abi3 full multiple-pymethods"
           done
 
   build:
@@ -84,6 +84,7 @@ jobs:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
+        extra_features: ["multiple-pymethods"]  # Because MSRV doesn't support this
         rust: [stable]
         python-version: [
           "3.7",
@@ -124,6 +125,7 @@ jobs:
                 rust-target: "x86_64-unknown-linux-gnu",
               }
             msrv: "MSRV"
+            extra_features: ""
 
           # Test the `nightly` feature
           - rust: nightly
@@ -134,7 +136,7 @@ jobs:
                 python-architecture: "x64",
                 rust-target: "x86_64-unknown-linux-gnu",
               }
-            extra_features: "nightly"
+            extra_features: "nightly multiple-pymethods"
 
           # Test 32-bit Windows only with the latest Python version
           - rust: stable
@@ -145,6 +147,7 @@ jobs:
                 python-architecture: "x86",
                 rust-target: "i686-pc-windows-msvc",
               }
+            extra_features: "multiple-pymethods"
     steps:
       - uses: actions/checkout@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Packaging
+
+- Update inventory dependency to `0.3` (the `multiple-pymethods` feature now requires Rust 1.62 for correctness). [#2492](https://github.com/PyO3/pyo3/pull/2492)
+
 ### Added
 
 - Implement `ToPyObject` for `[T; N]`. [#2313](https://github.com/PyO3/pyo3/pull/2313)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ indoc = { version = "1.0.3", optional = true }
 unindent = { version = "0.1.4", optional = true }
 
 # support crate for multiple-pymethods feature
-inventory = { version = "0.2.0", optional = true }
+inventory = { version = "0.3.0", optional = true }
 
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0", optional = true }
@@ -98,7 +98,7 @@ nightly = []
 full = [
     "macros",
     "pyproto",
-    "multiple-pymethods",
+    # "multiple-pymethods", # TODO re-add this when MSRV is greater than 1.62
     "num-bigint",
     "num-complex",
     "hashbrown",

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -944,9 +944,9 @@ This simple technique works for the case when there is zero or one implementatio
 The `#[pyclass]` macro expands to roughly the code seen below. The `PyClassImplCollector` is the type used internally by PyO3 for dtolnay specialization:
 
 ```rust
-# #[cfg(not(feature = "multiple-pymethods"))] {
+# #[cfg(not(any(feature = "multiple-pymethods", feature = "pyproto")))] {
 # use pyo3::prelude::*;
-// Note: the implementation differs slightly with the `multiple-pymethods` feature enabled.
+// Note: the implementation differs slightly with the `pyproto` or `multiple-pymethods` features enabled.
 struct MyClass {
     # #[allow(dead_code)]
     num: i32,

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -69,7 +69,7 @@ These macros require a number of dependencies which may not be needed by users w
 
 ### `multiple-pymethods`
 
-This feature enables a dependency on `inventory`, which enables each `#[pyclass]` to have more than one `#[pymethods]` block.
+This feature enables a dependency on `inventory`, which enables each `#[pyclass]` to have more than one `#[pymethods]` block. This feature also requires a minimum Rust version of 1.62 due to limitations in the `inventory` crate.
 
 Most users should only need a single `#[pymethods]` per `#[pyclass]`. In addition, not all platforms (e.g. Wasm) are supported by `inventory`. For this reason this feature is not enabled by default, meaning fewer dependencies and faster compilation for the majority of users.
 

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -5,6 +5,10 @@ For a detailed list of all changes, see the [CHANGELOG](changelog.md).
 
 ## from 0.16.* to 0.17
 
+### The `multiple-pymethods` feature now requires Rust 1.62
+
+Due to limitations in the `inventory` crate which the `multiple-pymethods` feature depends on, this feature now
+requires Rust 1.62. For more information see [dtolnay/inventory#32](https://github.com/dtolnay/inventory/issues/32).
 
 ### Added `impl IntoPy<Py<PyString>> for &str`
 


### PR DESCRIPTION
Closes #2210 

This updates `inventory` to 0.3. This means that `multiple-pymethods` feature will require Rust 1.62, however for correctness reasons I think this is a defensible choice.

Users can use a `[patch.crates-io]` section in their cargo configuration if they want to manually override to `inventory` 0.2 and use older Rust compilers; they would do this knowing that they could encounter issues with the feature due to https://github.com/dtolnay/inventory/issues/32.