### PR TITLE
Pin `plotters` to preserve MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1.0", optional = true }
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 criterion = "0.3.5"
+plotters = "=0.3.1"  # via criterion, 0.3.2 requires edition: 2021 (Rust 1.56)
 trybuild = "1.0.49"
 rustversion = "1.0"
 # 1.0.0 requires Rust 1.50


### PR DESCRIPTION
Hopefully this is the right fix/workaround for this. I noticed on my PR that the MSRV check was failing as `criterion` does not strictly pin `plotters` and it was updated with a MSRV-busting change.