### PR TITLE
Pin `plotters` to preserve MSRV (Take 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,9 @@ jobs:
           for PROJ in ${PROJECTS[@]}; do
             cargo update --manifest-path "$PROJ/Cargo.toml" -p parking_lot --precise 0.11.0
           done
+          cargo update -p plotters --precise 0.3.1
+          cargo update -p plotters-svg --precise 0.3.1
+          cargo update -p plotters-backend --precise 0.3.2
 
       - name: Build docs
         run: cargo doc --no-deps --no-default-features --features "full ${{ matrix.extra_features }}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
 rayon = "1.0.2"
 widestring = "0.5.1"
-# plotters via criterion, 0.3.2 requires edition: 2021 (Rust 1.56)
-plotters = { version = "=0.3.1", default-features = false }
-plotters-backend = { version = "=0.3.2", default-features = false }
-plotters-svg = { version = "=0.3.1", default-features = false }
 
 [build-dependencies]
 pyo3-build-config = { path = "pyo3-build-config", version = "0.16.5", features = ["resolve-config"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
 rayon = "1.0.2"
 widestring = "0.5.1"
+# plotters via criterion, 0.3.2 requires edition: 2021 (Rust 1.56)
+plotters = { version = "=0.3.1", default-features = false }
+plotters-backend = { version = "=0.3.2", default-features = false }
+plotters-svg = { version = "=0.3.1", default-features = false }
 
 [build-dependencies]
 pyo3-build-config = { path = "pyo3-build-config", version = "0.16.5", features = ["resolve-config"] }


### PR DESCRIPTION
I noticed on my PR that the MSRV check was failing as criterion does not strictly pin plotters and it was updated with a MSRV-busting change.

Hopefully this is the right fix/workaround for this, though it's a bit ugly.