### PR TITLE
Automatically wrap `str` in a `vec![]` for `Vec<&str>` and `Vec<String>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent multiple `#[pymethods]` with the same name for a single `#[pyclass]`. [#2399](https://github.com/PyO3/pyo3/pull/2399)
 - Fixup `lib_name` when using `PYO3_CONFIG_FILE`. [#2404](https://github.com/PyO3/pyo3/pull/2404)
 - Iterators over `PySet` and `PyDict` will now panic if the underlying collection is mutated during the iteration. [#2380](https://github.com/PyO3/pyo3/pull/2380)
+- `FromPyObject::extract` now raises an error if source type is `PyString` and target type is `Vec<T>`. [#2500](https://github.com/PyO3/pyo3/pull/2500)
 
 ### Fixed
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -367,6 +367,19 @@ mod tests {
             assert!(<PySequence as PyTryFrom>::try_from(v.to_object(py).as_ref(py)).is_ok());
         });
     }
+
+    #[test]
+    fn test_strings_cannot_be_extracted_to_vec() {
+        Python::with_gil(|py| {
+            let v = "London Calling";
+            let ob = v.to_object(py);
+
+            assert!(ob.extract::<Vec<&str>>(py).is_err());
+            assert!(ob.extract::<Vec<String>>(py).is_err());
+            assert!(ob.extract::<Vec<char>>(py).is_err());
+        });
+    }
+
     #[test]
     fn test_seq_empty() {
         Python::with_gil(|py| {

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
-
 use crate::err::{self, PyDowncastError, PyErr, PyResult};
+use crate::exceptions::PyValueError;
 use crate::internal_tricks::get_ssize_index;
-use crate::types::{PyAny, PyList, PyTuple};
+use crate::types::{PyAny, PyList, PyString, PyTuple};
 use crate::{ffi, PyNativeType, ToPyObject};
 use crate::{AsPyPointer, IntoPyPointer, Py, Python};
 use crate::{FromPyObject, PyTryFrom};
@@ -270,6 +270,9 @@ where
     T: FromPyObject<'a>,
 {
     fn extract(obj: &'a PyAny) -> PyResult<Self> {
+        if let Ok(true) = obj.is_instance_of::<PyString>() {
+            return Err(PyValueError::new_err("Can't extract `str` to `Vec`"));
+        }
         extract_sequence(obj)
     }
 }


### PR DESCRIPTION
# EDIT

After few discussions (see below), it was proposed to raise an error in the case when `str` can be split into a `Vec<T>`.
Thus, only a dynamic type checking is done with `PyAny.isinstance_of::<PyString>()`.

# Old proposition

As discussed in #2342, this PR proposes a way to wrap `str` arguments inside a vector to avoid iterating through chars when it is not desired.

Currently, only the `Vec<String>` is working, as I cannot manage to compile for `Vec<&str>` (code was commented out).

This "solution" leverages the use of the `specialization` features, which is currently unstable. As such, it must be compile with `nightly` feature activated as well as the nightly channel for the rust compiler.

Another solution, as discussed in #2342, would be to throw an error instead of wrapping in a vector.

# Demo

```toml
[package]
name = "fromstr"
# ...

[dependencies]
pyo3 = { path = "...", features = ["extension-module", "nightly"] }
```

```rust
use pyo3::prelude::*;   
                                                            
#[pyfunction]   
fn print_strings(strings: Vec<String>) {            
    for s in strings {                                                                          
        println!("{}", s);                       
    }           
}                              
                                        
                          
#[pyfunction]                                                                                   
fn print_str(strings: Vec<&str>) {
    for s in strings {                      
        println!("{}", s);     
    }                                      
}                
         
#[pymodule]              
fn fromstr(_py: Python, m: &PyModule) -> PyResult<()> {
    m.add_function(wrap_pyfunction!(print_strings, m)?)?;
    m.add_function(wrap_pyfunction!(print_str, m)?)?;
    Ok(())                                                           
}   
```

```python
from fromstr import print_strings, print_str
                     
if __name__ == "__main__":
             
    print(1)                            
    print_strings("echo")
    print(2)              
    print_str("echo")
    print(3)
    print_strings(["echo"])
    print(4)
    print_str(["echo"])

# Outputs:
# 1
# echo
# 2
# e
# c
# h
# o
# 3
# echo
# 4
# echo
```