### PR TITLE
Add FFI definitions for `Py_EnterRecursiveCall` and `Py_LeaveRecursiveCall`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Supprt `#[pyo3(name)]` on enum variants [#2457](https://github.com/PyO3/pyo3/pull/2457)
 - Add `PySuper` object [#2049](https://github.com/PyO3/pyo3/issues/2049)
 - Add support for generating PyPy Windows import library. [#2506](https://github.com/PyO3/pyo3/pull/2506)
+- Add FFI definitions for `Py_EnterRecursiveCall` and `Py_LeaveRecursiveCall`. [#2511](https://github.com/PyO3/pyo3/pull/2511)
 
 ### Changed
 

--- a/pyo3-ffi/src/ceval.rs
+++ b/pyo3-ffi/src/ceval.rs
@@ -74,9 +74,11 @@ extern "C" {
 }
 
 extern "C" {
-    #[cfg(any(Py_3_9, not(Py_LIMITED_API)))]
+    #[cfg(Py_3_9)]
+    #[cfg_attr(PyPy, link_name = "PyPy_EnterRecursiveCall")]
     pub fn Py_EnterRecursiveCall(arg1: *const c_char);
-    #[cfg(any(Py_3_9, not(Py_LIMITED_API)))]
+    #[cfg(Py_3_9)]
+    #[cfg_attr(PyPy, link_name = "PyPy_LeaveRecursiveCall")]
     pub fn Py_LeaveRecursiveCall();
 }
 

--- a/pyo3-ffi/src/ceval.rs
+++ b/pyo3-ffi/src/ceval.rs
@@ -73,8 +73,12 @@ extern "C" {
     fn _Py_CheckRecursiveCall(_where: *mut c_char) -> c_int;
 }
 
-// skipped Py_EnterRecursiveCall
-// skipped Py_LeaveRecursiveCall
+extern "C" {
+    #[cfg(any(Py_3_9, not(Py_LIMITED_API)))]
+    pub fn Py_EnterRecursiveCall(arg1: *const c_char);
+    #[cfg(any(Py_3_9, not(Py_LIMITED_API)))]
+    pub fn Py_LeaveRecursiveCall();
+}
 
 extern "C" {
     pub fn PyEval_GetFuncName(arg1: *mut PyObject) -> *const c_char;


### PR DESCRIPTION
https://docs.python.org/3/c-api/exceptions.html#recursion-control

#2510 cc @samuelcolvin