### PR TITLE
guide: python_from_rust: fix typo for call0

### DIFF
--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -45,7 +45,7 @@ fn main() -> PyResult<()> {
             "",
         )?.getattr("example")?.into();
 
-        // call object without empty arguments
+        // call object without any arguments
         fun.call0(py)?;
 
         // call object with PyTuple


### PR DESCRIPTION
Corrected what I believe to be a typo in the documentation.
`call0` is used to call python functions without any arguments.
The doc stated "... without empty arguments."


PS: This is my first contribution. I cecided not to include any changes to changelog.md for this minor issue. Feel free to critique. Thank you for your time!