### PR TITLE
pymodule: only allow initializing once per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `PyCapsule::set_context` no longer takes a `py: Python<'_>` argument.
   - `PyCapsule::name` now returns `PyResult<Option<&CStr>>` instead of `&CStr`.
 - `FromPyObject::extract` now raises an error if source type is `PyString` and target type is `Vec<T>`. [#2500](https://github.com/PyO3/pyo3/pull/2500)
-- `pyo3_build_config::add_extension_module_link_args()` now also emits linker arguments for `wasm32-unknown-emscripten`. [#2500](https://github.com/PyO3/pyo3/pull/2500)
+- Only allow each `#[pymodule]` to be initialized once. [#2523](https://github.com/PyO3/pyo3/pull/2523)
+- `pyo3_build_config::add_extension_module_link_args()` now also emits linker arguments for `wasm32-unknown-emscripten`. [#2538](https://github.com/PyO3/pyo3/pull/2538)
 
 ### Removed
 

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -77,6 +77,10 @@ fn get_type_object<T: PyTypeInfo>(py: Python<'_>) -> &PyType {
 
 If this leads to errors, simply implement `IntoPy`. Because pyclasses already implement `IntoPy`, you probably don't need to worry about this.
 
+### Each `#[pymodule]` can now only be initialized once per process
+
+To make PyO3 modules sound in the presence of Python sub-interpreters, for now it has been necessary to explicitly disable the ability to initialize a `#[pymodule]` more than once in the same process. Attempting to do this will now raise an `ImportError`.
+
 ## from 0.15.* to 0.16
 
 ### Drop support for older technologies

--- a/pytests/tests/test_misc.py
+++ b/pytests/tests/test_misc.py
@@ -1,6 +1,24 @@
+import importlib
+import platform
+
 import pyo3_pytests.misc
+import pytest
 
 
 def test_issue_219():
     # Should not deadlock
     pyo3_pytests.misc.issue_219()
+
+
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason="PyPy does not reinitialize the module (appears to be some internal caching)",
+)
+def test_second_module_import_fails():
+    spec = importlib.util.find_spec("pyo3_pytests.pyo3_pytests")
+
+    with pytest.raises(
+        ImportError,
+        match="PyO3 modules may only be initialized once per interpreter process",
+    ):
+        importlib.util.module_from_spec(spec)


### PR DESCRIPTION
Following the suggestion in https://github.com/PyO3/pyo3/discussions/2346#discussioncomment-2913833 this changes `#[pymodule]` to raise an `ImportError` if initialised more than once. This seems to be a necessary defence against soundness issues related to sub-interpreters.