### PR TITLE
Fix emscripten test and pin python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
       - uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: 3.11-dev
+          python-version: 3.11.0-beta.5
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,7 +354,7 @@ jobs:
       - uses: actions/setup-python@v4
         id: setup-python
         with:
-          python-version: 3.11.0-beta.5
+          python-version: 3.11.0-beta.4
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -3,9 +3,9 @@ CURDIR=$(abspath .)
 # These three are passed in from nox.
 BUILDROOT ?= $(CURDIR)/builddir
 PYMAJORMINORMICRO ?= 3.11.0
-PYPRERELEASE ?= b5 # I'm not sure how to split 3.11.0b5 in Make.
+PYPRERELEASE ?= b4 # I'm not sure how to split 3.11.0b4 in Make.
 
-EMSCRIPTEN_VERSION=3.1.17
+EMSCRIPTEN_VERSION=3.1.13
 
 export EMSDKDIR = $(BUILDROOT)/emsdk
 

--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -5,7 +5,7 @@ BUILDROOT ?= $(CURDIR)/builddir
 PYMAJORMINORMICRO ?= 3.11.0
 PYPRERELEASE ?= b5 # I'm not sure how to split 3.11.0b5 in Make.
 
-EMSCRIPTEN_VERSION=3.1.14
+EMSCRIPTEN_VERSION=3.1.17
 
 export EMSDKDIR = $(BUILDROOT)/emsdk
 

--- a/emscripten/Makefile
+++ b/emscripten/Makefile
@@ -3,9 +3,9 @@ CURDIR=$(abspath .)
 # These three are passed in from nox.
 BUILDROOT ?= $(CURDIR)/builddir
 PYMAJORMINORMICRO ?= 3.11.0
-PYPRERELEASE ?= b4 # I'm not sure how to split 3.11.0b4 in Make.
+PYPRERELEASE ?= b5 # I'm not sure how to split 3.11.0b5 in Make.
 
-EMSCRIPTEN_VERSION=3.1.13
+EMSCRIPTEN_VERSION=3.1.14
 
 export EMSDKDIR = $(BUILDROOT)/emsdk
 


### PR DESCRIPTION
I think it needs to be keeped in sync, otherwise every new 3.11 beta release breaks the test.