### PR TITLE
add `as_sequence()` method on dict views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ pip-wheel-metadata
 valgrind-python.supp
 *.pyd
 lcov.info
+.idea/
+.vscode/
+.python-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `as_sequence()` method on dict views. [#2527](https://github.com/PyO3/pyo3/pull/2527)
 - Add `timezone_utc()`. [#1588](https://github.com/PyO3/pyo3/pull/1588)
 - Implement `ToPyObject` for `[T; N]`. [#2313](https://github.com/PyO3/pyo3/pull/2313)
 - Added the internal `IntoPyResult` trait to give better error messages when function return types do not implement `IntoPy`. [#2326](https://github.com/PyO3/pyo3/pull/2326)

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -3,7 +3,7 @@
 use super::PyMapping;
 use crate::err::{self, PyErr, PyResult};
 use crate::ffi::Py_ssize_t;
-use crate::types::{PyAny, PyList};
+use crate::types::{PyAny, PyList, PySequence};
 #[cfg(not(PyPy))]
 use crate::IntoPyPointer;
 use crate::{ffi, AsPyPointer, FromPyObject, IntoPy, PyObject, PyTryFrom, Python, ToPyObject};
@@ -34,6 +34,13 @@ pyobject_native_type_core!(
     #checkfunction=ffi::PyDictKeys_Check
 );
 
+#[cfg(not(PyPy))]
+impl PyDictKeys {
+    pub fn as_sequence(&self) -> &PySequence {
+        unsafe { PySequence::try_from_unchecked(self) }
+    }
+}
+
 /// Represents a Python `dict_values`.
 #[cfg(not(PyPy))]
 #[repr(transparent)]
@@ -46,6 +53,13 @@ pyobject_native_type_core!(
     #checkfunction=ffi::PyDictValues_Check
 );
 
+#[cfg(not(PyPy))]
+impl PyDictValues {
+    pub fn as_sequence(&self) -> &PySequence {
+        unsafe { PySequence::try_from_unchecked(self) }
+    }
+}
+
 /// Represents a Python `dict_items`.
 #[cfg(not(PyPy))]
 #[repr(transparent)]
@@ -57,6 +71,13 @@ pyobject_native_type_core!(
     ffi::PyDictItems_Type,
     #checkfunction=ffi::PyDictItems_Check
 );
+
+#[cfg(not(PyPy))]
+impl PyDictItems {
+    pub fn as_sequence(&self) -> &PySequence {
+        unsafe { PySequence::try_from_unchecked(self) }
+    }
+}
 
 impl PyDict {
     /// Creates a new empty dictionary.
@@ -972,6 +993,14 @@ mod tests {
             let dict = abc_dict(py);
             let keys = dict.call_method0("keys").unwrap();
             assert!(keys.is_instance(PyDictKeys::type_object(py)).unwrap());
+            assert_eq!(
+                keys.cast_as::<PyDictKeys>()
+                    .unwrap()
+                    .as_sequence()
+                    .len()
+                    .unwrap(),
+                3
+            );
         })
     }
 
@@ -982,6 +1011,15 @@ mod tests {
             let dict = abc_dict(py);
             let values = dict.call_method0("values").unwrap();
             assert!(values.is_instance(PyDictValues::type_object(py)).unwrap());
+            assert_eq!(
+                values
+                    .cast_as::<PyDictValues>()
+                    .unwrap()
+                    .as_sequence()
+                    .len()
+                    .unwrap(),
+                3
+            );
         })
     }
 
@@ -992,6 +1030,15 @@ mod tests {
             let dict = abc_dict(py);
             let items = dict.call_method0("items").unwrap();
             assert!(items.is_instance(PyDictItems::type_object(py)).unwrap());
+            assert_eq!(
+                items
+                    .cast_as::<PyDictItems>()
+                    .unwrap()
+                    .as_sequence()
+                    .len()
+                    .unwrap(),
+                3
+            );
         })
     }
 }

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -3,14 +3,10 @@
 use super::PyMapping;
 use crate::err::{self, PyErr, PyResult};
 use crate::ffi::Py_ssize_t;
-#[cfg(PyPy)]
 use crate::types::{PyAny, PyList};
-#[cfg(not(PyPy))]
-use crate::types::{PyAny, PyList, PySequence};
-
-#[cfg(not(PyPy))]
-use crate::IntoPyPointer;
 use crate::{ffi, AsPyPointer, FromPyObject, IntoPy, PyObject, PyTryFrom, Python, ToPyObject};
+#[cfg(not(PyPy))]
+use crate::{types::PySequence, IntoPyPointer};
 use std::collections::{BTreeMap, HashMap};
 use std::ptr::NonNull;
 use std::{cmp, collections, hash};

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -3,7 +3,11 @@
 use super::PyMapping;
 use crate::err::{self, PyErr, PyResult};
 use crate::ffi::Py_ssize_t;
+#[cfg(PyPy)]
+use crate::types::{PyAny, PyList};
+#[cfg(not(PyPy))]
 use crate::types::{PyAny, PyList, PySequence};
+
 #[cfg(not(PyPy))]
 use crate::IntoPyPointer;
 use crate::{ffi, AsPyPointer, FromPyObject, IntoPy, PyObject, PyTryFrom, Python, ToPyObject};

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -36,6 +36,7 @@ pyobject_native_type_core!(
 
 #[cfg(not(PyPy))]
 impl PyDictKeys {
+    /// Returns `self` cast as a `PySequence`.
     pub fn as_sequence(&self) -> &PySequence {
         unsafe { PySequence::try_from_unchecked(self) }
     }
@@ -55,6 +56,7 @@ pyobject_native_type_core!(
 
 #[cfg(not(PyPy))]
 impl PyDictValues {
+    /// Returns `self` cast as a `PySequence`.
     pub fn as_sequence(&self) -> &PySequence {
         unsafe { PySequence::try_from_unchecked(self) }
     }
@@ -74,6 +76,7 @@ pyobject_native_type_core!(
 
 #[cfg(not(PyPy))]
 impl PyDictItems {
+    /// Returns `self` cast as a `PySequence`.
     pub fn as_sequence(&self) -> &PySequence {
         unsafe { PySequence::try_from_unchecked(self) }
     }


### PR DESCRIPTION
Hi and thank you for this amazing library! I'm trying to help @samuelcolvin on [https://github.com/samuelcolvin/pydantic-core](pydantic-core). Following https://github.com/PyO3/pyo3/pull/2358, it would be great to have at list a `as_sequence()` method on dict views to be able to easily get length, convert them to list, iterate...
I didn't want to add any other methods following @davidhewitt 's comment. Let's keep it simple for now :)

 - [x] an entry in CHANGELOG.md
 - [x] docs to all new functions and / or detail in the guide
 - [x] tests for all new or changed functions
