### PR TITLE
ci: downgrade libc to 0.2.127 for MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,7 @@ jobs:
           PROJECTS=("." "examples/decorator" "examples/maturin-starter" "examples/setuptools-rust-starter" "examples/word-count")
           for PROJ in ${PROJECTS[@]}; do
             cargo update --manifest-path "$PROJ/Cargo.toml" -p parking_lot --precise 0.11.0
+            cargo update --manifest-path "$PROJ/Cargo.toml" -p libc --precise 0.2.127
           done
           cargo update -p plotters --precise 0.3.1
           cargo update -p plotters-svg --precise 0.3.1


### PR DESCRIPTION
Similar workaround as https://github.com/PyO3/pyo3/pull/2539, but for `libc` - hopefully this issue doesn't keep spreading!

See the error here:
https://github.com/PyO3/pyo3/runs/7753898046?check_suite_focus=true

and here, which is why I added this to the example directories as well:
https://github.com/PyO3/pyo3/runs/7754192650?check_suite_focus=true