### PR TITLE
ffi: fixes to 3.11 bindings

### DIFF
--- a/pyo3-ffi/src/cpython/genobject.rs
+++ b/pyo3-ffi/src/cpython/genobject.rs
@@ -2,6 +2,8 @@ use crate::object::*;
 use crate::PyFrameObject;
 #[cfg(not(PyPy))]
 use crate::_PyErr_StackItem;
+#[cfg(Py_3_11)]
+use std::os::raw::c_char;
 use std::os::raw::c_int;
 
 #[cfg(not(PyPy))]
@@ -9,6 +11,7 @@ use std::os::raw::c_int;
 #[derive(Copy, Clone)]
 pub struct PyGenObject {
     pub ob_base: PyObject,
+    #[cfg(not(Py_3_11))]
     pub gi_frame: *mut PyFrameObject,
     #[cfg(not(Py_3_10))]
     pub gi_running: c_int,
@@ -17,6 +20,18 @@ pub struct PyGenObject {
     pub gi_name: *mut PyObject,
     pub gi_qualname: *mut PyObject,
     pub gi_exc_state: _PyErr_StackItem,
+    #[cfg(Py_3_11)]
+    pub gi_origin_or_finalizer: *mut PyObject,
+    #[cfg(Py_3_11)]
+    pub gi_hooks_inited: c_char,
+    #[cfg(Py_3_11)]
+    pub gi_closed: c_char,
+    #[cfg(Py_3_11)]
+    pub gi_running_async: c_char,
+    #[cfg(Py_3_11)]
+    pub gi_frame_state: i8,
+    #[cfg(Py_3_11)]
+    pub gi_iframe: [*mut PyObject; 1],
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/pyo3-ffi/src/cpython/pystate.rs
+++ b/pyo3-ffi/src/cpython/pystate.rs
@@ -31,8 +31,10 @@ pub const PyTrace_OPCODE: c_int = 7;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct _PyErr_StackItem {
+    #[cfg(not(Py_3_11))]
     pub exc_type: *mut PyObject,
     pub exc_value: *mut PyObject,
+    #[cfg(not(Py_3_11))]
     pub exc_traceback: *mut PyObject,
     pub previous_item: *mut _PyErr_StackItem,
 }


### PR DESCRIPTION
Fixes picked up by `pyo3-ffi-check` for Python 3.11 bindings.