### PR TITLE
Call the right cargo binary

### DIFF
--- a/xtask/src/doc.rs
+++ b/xtask/src/doc.rs
@@ -17,7 +17,7 @@ pub fn run(opts: DocOpts) -> anyhow::Result<()> {
 
     std::env::set_var("RUSTDOCFLAGS", flags.join(" "));
     cli::run(
-        Command::new("cargo")
+        Command::new(concat!(env!("CARGO_HOME"), "/bin/cargo"))
             .args(if opts.stable { None } else { Some("+nightly") })
             .arg("doc")
             .arg("--lib")

--- a/xtask/src/test.rs
+++ b/xtask/src/test.rs
@@ -37,7 +37,7 @@ pub fn run() -> anyhow::Result<()> {
 
     // Test MSRV
     cli::run(
-        Command::new("cargo")
+        Command::new(concat!(env!("CARGO_HOME"), "/bin/cargo"))
             .arg(format!("+{}", MSRV))
             .arg("test")
             .arg("--no-default-features")
@@ -54,7 +54,7 @@ pub fn run() -> anyhow::Result<()> {
     )?;
 
     cli::run(
-        Command::new("cargo")
+        Command::new(concat!(env!("CARGO_HOME"), "/bin/cargo"))
             .arg("+nightly")
             .arg("test")
             .arg("--no-default-features")


### PR DESCRIPTION
For some reason it calls the wrong cargo binary, resulting in this error:

```
error: no such subcommand: `+nightly`
```
