### PR TITLE
guide: deployment to netlify

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,23 +39,6 @@ jobs:
           TAG_NAME="${GITHUB_REF##*/}"
           echo "::set-output name=tag_name::${TAG_NAME}"
 
-      # Build some internal docs and inject a banner on top of it.
-      - name: Build the internal docs
-        run: |
-          echo "<div class='internal-banner' style='position:fixed; z-index: 99999; color:red;border:3px solid red;margin-left: auto; margin-right: auto; width: 430px;left:0;right: 0;'><div style='display: flex; align-items: center; justify-content: center;'> ⚠️ Internal Docs ⚠️ Not Public API 👉 <a href='https://pyo3.rs/main/doc/pyo3/index.html' style='color:red;text-decoration:underline;'>Official Docs Here</a></div></div>" > banner.html
-          cargo xtask doc --internal
-        env:
-          RUSTDOCFLAGS: "--cfg docsrs --Z unstable-options --document-hidden-items --html-before-content banner.html"
-
-      - name: Deploy internal docs
-        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc
-          destination_dir: internal/doc
-          full_commit_message: "Upload internal documentation"
-
       - name: Clear the extra artefacts created earlier
         run: rm -rf target
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ pip-wheel-metadata
 valgrind-python.supp
 *.pyd
 lcov.info
+netlify_build/

--- a/.netlify/_redirects
+++ b/.netlify/_redirects
@@ -1,0 +1,132 @@
+/0.1.0/doc/* https://docs.rs/pyo3/0.1.0/:splat
+/0.1.0/* https://pyo3.rs/0.1.0/:splat 200
+/0.2.0/doc/* https://docs.rs/pyo3/0.2.0/:splat
+/0.2.0/* https://pyo3.rs/0.2.0/:splat 200
+/0.2.1/doc/* https://docs.rs/pyo3/0.2.1/:splat
+/0.2.1/* https://pyo3.rs/0.2.1/:splat 200
+/0.2.2/doc/* https://docs.rs/pyo3/0.2.2/:splat
+/0.2.2/* https://pyo3.rs/0.2.2/:splat 200
+/pyo3-derive-backend-0.6.0/doc/* https://docs.rs/pyo3/pyo3-derive-backend-0.6.0/:splat
+/pyo3-derive-backend-0.6.0/* https://pyo3.rs/pyo3-derive-backend-0.6.0/:splat 200
+/v0.10.0/doc/* https://docs.rs/pyo3/0.10.0/:splat
+/v0.10.0/* https://pyo3.rs/v0.10.0/:splat 200
+/v0.10.1/doc/* https://docs.rs/pyo3/0.10.1/:splat
+/v0.10.1/* https://pyo3.rs/v0.10.1/:splat 200
+/v0.11.0/doc/* https://docs.rs/pyo3/0.11.0/:splat
+/v0.11.0/* https://pyo3.rs/v0.11.0/:splat 200
+/v0.11.1/doc/* https://docs.rs/pyo3/0.11.1/:splat
+/v0.11.1/* https://pyo3.rs/v0.11.1/:splat 200
+/v0.12.0/doc/* https://docs.rs/pyo3/0.12.0/:splat
+/v0.12.0/* https://pyo3.rs/v0.12.0/:splat 200
+/v0.12.1/doc/* https://docs.rs/pyo3/0.12.1/:splat
+/v0.12.1/* https://pyo3.rs/v0.12.1/:splat 200
+/v0.12.2/doc/* https://docs.rs/pyo3/0.12.2/:splat
+/v0.12.2/* https://pyo3.rs/v0.12.2/:splat 200
+/v0.12.3/doc/* https://docs.rs/pyo3/0.12.3/:splat
+/v0.12.3/* https://pyo3.rs/v0.12.3/:splat 200
+/v0.12.4/doc/* https://docs.rs/pyo3/0.12.4/:splat
+/v0.12.4/* https://pyo3.rs/v0.12.4/:splat 200
+/v0.13.0/doc/* https://docs.rs/pyo3/0.13.0/:splat
+/v0.13.0/* https://pyo3.rs/v0.13.0/:splat 200
+/v0.13.1/doc/* https://docs.rs/pyo3/0.13.1/:splat
+/v0.13.1/* https://pyo3.rs/v0.13.1/:splat 200
+/v0.13.2/doc/* https://docs.rs/pyo3/0.13.2/:splat
+/v0.13.2/* https://pyo3.rs/v0.13.2/:splat 200
+/v0.14.0/doc/* https://docs.rs/pyo3/0.14.0/:splat
+/v0.14.0/* https://pyo3.rs/v0.14.0/:splat 200
+/v0.14.1/doc/* https://docs.rs/pyo3/0.14.1/:splat
+/v0.14.1/* https://pyo3.rs/v0.14.1/:splat 200
+/v0.14.2/doc/* https://docs.rs/pyo3/0.14.2/:splat
+/v0.14.2/* https://pyo3.rs/v0.14.2/:splat 200
+/v0.14.3/doc/* https://docs.rs/pyo3/0.14.3/:splat
+/v0.14.3/* https://pyo3.rs/v0.14.3/:splat 200
+/v0.14.4/doc/* https://docs.rs/pyo3/0.14.4/:splat
+/v0.14.4/* https://pyo3.rs/v0.14.4/:splat 200
+/v0.14.5/doc/* https://docs.rs/pyo3/0.14.5/:splat
+/v0.14.5/* https://pyo3.rs/v0.14.5/:splat 200
+/v0.15.0/doc/* https://docs.rs/pyo3/0.15.0/:splat
+/v0.15.0/* https://pyo3.rs/v0.15.0/:splat 200
+/v0.15.1/doc/* https://docs.rs/pyo3/0.15.1/:splat
+/v0.15.1/* https://pyo3.rs/v0.15.1/:splat 200
+/v0.15.2/doc/* https://docs.rs/pyo3/0.15.2/:splat
+/v0.15.2/* https://pyo3.rs/v0.15.2/:splat 200
+/v0.16.0/doc/* https://docs.rs/pyo3/0.16.0/:splat
+/v0.16.0/* https://pyo3.rs/v0.16.0/:splat 200
+/v0.16.1/doc/* https://docs.rs/pyo3/0.16.1/:splat
+/v0.16.1/* https://pyo3.rs/v0.16.1/:splat 200
+/v0.16.2/doc/* https://docs.rs/pyo3/0.16.2/:splat
+/v0.16.2/* https://pyo3.rs/v0.16.2/:splat 200
+/v0.16.3/doc/* https://docs.rs/pyo3/0.16.3/:splat
+/v0.16.3/* https://pyo3.rs/v0.16.3/:splat 200
+/v0.16.4/doc/* https://docs.rs/pyo3/0.16.4/:splat
+/v0.16.4/* https://pyo3.rs/v0.16.4/:splat 200
+/v0.16.5/doc/* https://docs.rs/pyo3/0.16.5/:splat
+/v0.16.5/* https://pyo3.rs/v0.16.5/:splat 200
+/v0.2.3/doc/* https://docs.rs/pyo3/0.2.3/:splat
+/v0.2.3/* https://pyo3.rs/v0.2.3/:splat 200
+/v0.2.4/doc/* https://docs.rs/pyo3/0.2.4/:splat
+/v0.2.4/* https://pyo3.rs/v0.2.4/:splat 200
+/v0.2.5/doc/* https://docs.rs/pyo3/0.2.5/:splat
+/v0.2.5/* https://pyo3.rs/v0.2.5/:splat 200
+/v0.2.6/doc/* https://docs.rs/pyo3/0.2.6/:splat
+/v0.2.6/* https://pyo3.rs/v0.2.6/:splat 200
+/v0.2.7/doc/* https://docs.rs/pyo3/0.2.7/:splat
+/v0.2.7/* https://pyo3.rs/v0.2.7/:splat 200
+/v0.3.0/doc/* https://docs.rs/pyo3/0.3.0/:splat
+/v0.3.0/* https://pyo3.rs/v0.3.0/:splat 200
+/v0.3.1/doc/* https://docs.rs/pyo3/0.3.1/:splat
+/v0.3.1/* https://pyo3.rs/v0.3.1/:splat 200
+/v0.3.2/doc/* https://docs.rs/pyo3/0.3.2/:splat
+/v0.3.2/* https://pyo3.rs/v0.3.2/:splat 200
+/v0.4.0/doc/* https://docs.rs/pyo3/0.4.0/:splat
+/v0.4.0/* https://pyo3.rs/v0.4.0/:splat 200
+/v0.4.1/doc/* https://docs.rs/pyo3/0.4.1/:splat
+/v0.4.1/* https://pyo3.rs/v0.4.1/:splat 200
+/v0.5.0/doc/* https://docs.rs/pyo3/0.5.0/:splat
+/v0.5.0/* https://pyo3.rs/v0.5.0/:splat 200
+/v0.5.0-alpha.2/doc/* https://docs.rs/pyo3/0.5.0-alpha.2/:splat
+/v0.5.0-alpha.2/* https://pyo3.rs/v0.5.0-alpha.2/:splat 200
+/v0.5.0-alpha.3/doc/* https://docs.rs/pyo3/0.5.0-alpha.3/:splat
+/v0.5.0-alpha.3/* https://pyo3.rs/v0.5.0-alpha.3/:splat 200
+/v0.5.1/doc/* https://docs.rs/pyo3/0.5.1/:splat
+/v0.5.1/* https://pyo3.rs/v0.5.1/:splat 200
+/v0.5.2/doc/* https://docs.rs/pyo3/0.5.2/:splat
+/v0.5.2/* https://pyo3.rs/v0.5.2/:splat 200
+/v0.5.3/doc/* https://docs.rs/pyo3/0.5.3/:splat
+/v0.5.3/* https://pyo3.rs/v0.5.3/:splat 200
+/v0.5.4/doc/* https://docs.rs/pyo3/0.5.4/:splat
+/v0.5.4/* https://pyo3.rs/v0.5.4/:splat 200
+/v0.6.0/doc/* https://docs.rs/pyo3/0.6.0/:splat
+/v0.6.0/* https://pyo3.rs/v0.6.0/:splat 200
+/v0.6.0-alpha.1/doc/* https://docs.rs/pyo3/0.6.0-alpha.1/:splat
+/v0.6.0-alpha.1/* https://pyo3.rs/v0.6.0-alpha.1/:splat 200
+/v0.6.0-alpha.2/doc/* https://docs.rs/pyo3/0.6.0-alpha.2/:splat
+/v0.6.0-alpha.2/* https://pyo3.rs/v0.6.0-alpha.2/:splat 200
+/v0.6.0-alpha.3/doc/* https://docs.rs/pyo3/0.6.0-alpha.3/:splat
+/v0.6.0-alpha.3/* https://pyo3.rs/v0.6.0-alpha.3/:splat 200
+/v0.6.0-alpha.4/doc/* https://docs.rs/pyo3/0.6.0-alpha.4/:splat
+/v0.6.0-alpha.4/* https://pyo3.rs/v0.6.0-alpha.4/:splat 200
+/v0.7.0/doc/* https://docs.rs/pyo3/0.7.0/:splat
+/v0.7.0/* https://pyo3.rs/v0.7.0/:splat 200
+/v0.7.0-alpha.1/doc/* https://docs.rs/pyo3/0.7.0-alpha.1/:splat
+/v0.7.0-alpha.1/* https://pyo3.rs/v0.7.0-alpha.1/:splat 200
+/v0.8.0/doc/* https://docs.rs/pyo3/0.8.0/:splat
+/v0.8.0/* https://pyo3.rs/v0.8.0/:splat 200
+/v0.8.1/doc/* https://docs.rs/pyo3/0.8.1/:splat
+/v0.8.1/* https://pyo3.rs/v0.8.1/:splat 200
+/v0.8.2/doc/* https://docs.rs/pyo3/0.8.2/:splat
+/v0.8.2/* https://pyo3.rs/v0.8.2/:splat 200
+/v0.8.3/doc/* https://docs.rs/pyo3/0.8.3/:splat
+/v0.8.3/* https://pyo3.rs/v0.8.3/:splat 200
+/v0.8.4/doc/* https://docs.rs/pyo3/0.8.4/:splat
+/v0.8.4/* https://pyo3.rs/v0.8.4/:splat 200
+/v0.8.5/doc/* https://docs.rs/pyo3/0.8.5/:splat
+/v0.8.5/* https://pyo3.rs/v0.8.5/:splat 200
+/v0.9.0/doc/* https://docs.rs/pyo3/0.9.0/:splat
+/v0.9.0/* https://pyo3.rs/v0.9.0/:splat 200
+/v0.9.0-alpha.1/doc/* https://docs.rs/pyo3/0.9.0-alpha.1/:splat
+/v0.9.0-alpha.1/* https://pyo3.rs/v0.9.0-alpha.1/:splat 200
+/v0.9.1/doc/* https://docs.rs/pyo3/0.9.1/:splat
+/v0.9.1/* https://pyo3.rs/v0.9.1/:splat 200
+/v0.9.2/doc/* https://docs.rs/pyo3/0.9.2/:splat
+/v0.9.2/* https://pyo3.rs/v0.9.2/:splat 200

--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -uex
+
+rustup default nightly
+
+# Install latest mdbook. Netlify will cache the cargo bin dir, so this will
+# only build mdbook if needed.
+MDBOOK_VERSION=$(cargo search mdbook --limit 1 | head -1 | tr -s ' ' | cut -d ' ' -f 3 | tr -d '"')
+INSTALLED_MDBOOK_VERSION=$(mdbook --version || echo "none")
+if [ "${INSTALLED_MDBOOK_VERSION}" != "mdbook v${MDBOOK_VERSION}" ]; then
+    cargo install mdbook@${MDBOOK_VERSION}
+fi
+
+pip install nox
+nox -s build-guide
+cargo xtask doc --internal
+
+mkdir -p netlify_build/internal
+mv target/doc netlify_build/internal/
+mv target/guide netlify_build/main/
+
+cargo xtask doc
+mv target/doc netlify_build/main/doc/
+
+PYO3_VERSION=$(cargo search pyo3 --limit 1 | head -1 | tr -s ' ' | cut -d ' ' -f 3 | tr -d '"')
+echo "<meta http-equiv=refresh content=0;url=v${PYO3_VERSION}/>" > netlify_build/index.html
+
+# TODO: have some better system to automatically generate this on build rather
+# than check this in to the repo
+cp .netlify/_redirects netlify_build/
+
+# Add latest redirect
+echo "/latest/* https://pyo3.rs/${PYO3_VERSION}/:splat 200" >> netlify_build/_redirects
+
+ls -l netlify_build/
+
+# TODO:
+# - netlify badges
+# - apply for open source plan

--- a/.netlify/create_redirects.py
+++ b/.netlify/create_redirects.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+"""Generates _redirects file for netlify.
+
+Run this and write output to .netlify/_redirects and check into
+the PyO3 repository.
+"""
+
+import subprocess
+
+
+def main() -> None:
+    versions = subprocess.check_output(["git", "tag"], text=True).splitlines()
+    for version in versions:
+        version_without_v = version.lstrip("v")
+        print(f"/{version}/doc/* https://docs.rs/pyo3/{version_without_v}/:splat")
+        print(f"/{version}/* https://pyo3.rs/{version}/:splat 200")
+
+
+if __name__ == "__main__":
+    main()

--- a/Contributing.md
+++ b/Contributing.md
@@ -11,7 +11,7 @@ If you want to become familiar with the codebase, see
 
 Please join in with any part of PyO3 which interests you. We use GitHub issues to record all bugs and ideas. Feel free to request an issue to be assigned to you if you want to work on it.
 
-You can browse the API of the non-public parts of PyO3 [here](https://pyo3.rs/internal/doc/pyo3/index.html).
+You can browse the API of the non-public parts of PyO3 [here](https://pyo3.netlify.app/internal/doc/pyo3/index.html).
 
 The following sections also contain specific ideas on where to start contributing to PyO3.
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+publish = "netlify_build/"
+command = ".netlify/build.sh"
+
+[build.environment]
+PYTHON_VERSION = "3.8"


### PR DESCRIPTION
See outputs at:
- https://netlify-test--pyo3.netlify.app/ - latest docs (also https://netlify-test--pyo3.netlify.app/latest/)
- https://netlify-test--pyo3.netlify.app/main - main branch (also https://netlify-test--pyo3.netlify.app/main/doc/pyo3)
- https://netlify-test--pyo3.netlify.app/v0.15.0 etc for old versioned docs

The main docs are built and hosted on netlify, the releases are stored on gh-pages and the docs on docs.rs. They are proxied through netlify redirects.

If this is setup we're happy with, I'll reach out to netlify to apply for the open-source plan and we can commit to this. (I've also reached out to @fafhrd91 to get access to the DNS settings so I could move pyo3.rs to point at this.)

When merged, the prefix `netlify-test` will drop and we'll just have https://pyo3.netlify.app working.