### PR TITLE
ffi: swap field order in PyCodeObject for 3.11

### DIFF
--- a/pyo3-ffi/src/cpython/code.rs
+++ b/pyo3-ffi/src/cpython/code.rs
@@ -76,8 +76,8 @@ pub struct PyCodeObject {
     pub co_linetable: *mut PyObject,
     pub co_weakreflist: *mut PyObject,
     pub _co_code: *mut PyObject,
-    pub _co_firsttraceable: c_int,
     pub _co_linearray: *mut c_char,
+    pub _co_firsttraceable: c_int,
     pub co_extra: *mut c_void,
     pub co_code_adaptive: [c_char; 1],
 }


### PR DESCRIPTION
Looks like I took the 3.12 definition of this object by mistake; `pyo3-ffi-check` rightly pointed this out in. https://github.com/PyO3/pyo3-ffi-check/pull/5