### PR TITLE
gh-pages: don't publish whole target directory

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -54,9 +54,8 @@ jobs:
       - name: Build the doc
         run: |
           cargo xtask doc
+          mv target/doc target/guide/doc
           echo "<meta http-equiv=refresh content=0;url=pyo3/index.html>" > target/guide/doc/index.html
-        env:
-          CARGO_TARGET_DIR: target/guide
 
       - name: Deploy docs and the guide
         if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'release' }}


### PR DESCRIPTION
Looking at https://github.com/PyO3/pyo3/commit/399452a8fa9255e0ab7f3e8160b552a24f171bba it looks like some binary artefacts in the docs build are being accidentally uploaded to the repo. I think this might fix it.

After merge and the docs have built I'll cleanup and squash the gh-pages branch.