### PR TITLE
netlify: add badge, use github-pages domain rather than pyo3.rs

### DIFF
--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -14,7 +14,7 @@ mkdir netlify_build
 cp .netlify/_redirects netlify_build/
 
 # Add latest redirect (proxy)
-echo "/latest/* https://pyo3.rs/v${PYO3_VERSION}/:splat 200" >> netlify_build/_redirects
+echo "/latest/* https://pyo3.github.io/pyo3/v${PYO3_VERSION}/:splat 200" >> netlify_build/_redirects
 
 ## Add landing page redirect
 echo "<meta http-equiv=refresh content=0;url=v${PYO3_VERSION}/>" > netlify_build/index.html

--- a/.netlify/create_redirects.py
+++ b/.netlify/create_redirects.py
@@ -13,7 +13,7 @@ def main() -> None:
     for version in versions:
         version_without_v = version.lstrip("v")
         print(f"/{version}/doc/* https://docs.rs/pyo3/{version_without_v}/:splat")
-        print(f"/{version}/* https://pyo3.rs/{version}/:splat 200")
+        print(f"/{version}/* https://pyo3.github.io/pyo3/{version}/:splat 200")
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -233,3 +233,5 @@ If you don't have time to contribute yourself but still wish to support the proj
 
 PyO3 is licensed under the [Apache-2.0 license](https://opensource.org/licenses/APACHE-2.0).
 Python is licensed under the [Python License](https://docs.python.org/3/license.html).
+
+<a href="https://www.netlify.com"> <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Deploys by Netlify" /> </a>


### PR DESCRIPTION
Adds a badge to the README to advertise use of Netlify. This is a requirement of the [Netlify open-source plan](https://www.netlify.com/legal/open-source-policy/).