### PR TITLE
docs: Update the guide for `python3-dll-a` v0.2.6

### DIFF
--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -293,9 +293,13 @@ An experimental `pyo3` crate feature `generate-import-lib` enables the user to c
 extension modules for Windows targets without setting the `PYO3_CROSS_LIB_DIR` environment
 variable or providing any Windows Python library files. It uses an external [`python3-dll-a`] crate
 to generate import libraries for the Python DLL for MinGW-w64 and MSVC compile targets.
+`python3-dll-a` uses the binutils `dlltool` program to generate DLL import libraries for MinGW-w64 targets.
+It is possible to override the default `dlltool` command name for the cross target
+by setting `PYO3_MINGW_DLLTOOL` environment variable.
 *Note*: MSVC targets require LLVM binutils or MSVC build tools to be available on the host system.
 More specifically, `python3-dll-a` requires `llvm-dlltool` or `lib.exe` executable to be present in `PATH` when
-targeting `*-pc-windows-msvc`.
+targeting `*-pc-windows-msvc`. Zig compiler executable can be used in place of `llvm-dlltool` when `ZIG_COMMAND`
+environment variable is set to the installed Zig program name (`"zig"` or `"python -m ziglang"`).
 
 An example might look like the following (assuming your target's sysroot is at `/home/pyo3/cross/sysroot` and that your target is `armv7`):
 

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -12,11 +12,11 @@ edition = "2018"
 
 [dependencies]
 once_cell = "1"
-python3-dll-a = { version = "0.2.5", optional = true }
+python3-dll-a = { version = "0.2.6", optional = true }
 target-lexicon = "0.12"
 
 [build-dependencies]
-python3-dll-a = { version = "0.2.5", optional = true }
+python3-dll-a = { version = "0.2.6", optional = true }
 target-lexicon = "0.12"
 
 [features]


### PR DESCRIPTION
Bump the minimum `python3-dll-a` dependency version.

Document the implemented workaround for
https://github.com/PyO3/python3-dll-a/issues/28

It would be nice to have this in PyO3 v0.17.