### PR TITLE
fix: export new dict views types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix visibility of `PyDictItems`, `PyDictKeys`, and `PyDictValues` types added in PyO3 0.17.0.
+
 ## [0.17.0] - 2022-08-23
 
 ### Packaging

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -16,6 +16,8 @@ pub use self::datetime::{
     PyTzInfo, PyTzInfoAccess,
 };
 pub use self::dict::{IntoPyDict, PyDict};
+#[cfg(not(PyPy))]
+pub use self::dict::{PyDictItem, PyDictKeys, PyDictValues};
 pub use self::floatob::PyFloat;
 #[cfg(all(not(Py_LIMITED_API), not(PyPy)))]
 pub use self::frame::PyFrame;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,7 +17,7 @@ pub use self::datetime::{
 };
 pub use self::dict::{IntoPyDict, PyDict};
 #[cfg(not(PyPy))]
-pub use self::dict::{PyDictItem, PyDictKeys, PyDictValues};
+pub use self::dict::{PyDictItems, PyDictKeys, PyDictValues};
 pub use self::floatob::PyFloat;
 #[cfg(all(not(Py_LIMITED_API), not(PyPy)))]
 pub use self::frame::PyFrame;


### PR DESCRIPTION
Thank you for v0.17.0, which adds https://github.com/PyO3/pyo3/pull/2358!
Unfortunately we can't use them directly since those new types are not exposed and getting them directly from `dict` doesn't work as well since `dict` module is private

If this is approved, could we add this in a v0.17.1 please?