### PR TITLE
pyfunction: fix from_py_with on Option<T> argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix visibility of `PyDictItems`, `PyDictKeys`, and `PyDictValues` types added in PyO3 0.17.0.
+- Fix compile failure when using `#[pyo3(from_py_with = "...")]` attribute on an argument of type `Option<T>`. [#2592](https://github.com/PyO3/pyo3/pull/2592)
 
 ## [0.17.0] - 2022-08-23
 

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -247,7 +247,7 @@ fn impl_arg_param(
             }
             (None, true) => {
                 quote_arg_span! {
-                    _pyo3::impl_::extract_argument::from_py_with_with_default(#arg_value, #name_str, #expr_path, || Some(None))?
+                    _pyo3::impl_::extract_argument::from_py_with_with_default(#arg_value, #name_str, #expr_path, || None)?
                 }
             }
             (None, false) => {


### PR DESCRIPTION
This fixes #2280 by making it do the "obvious" thing - an argument `#[pyo3(from_py_with = "foo")] x: Option<i32>` requires `foo` to be a function with returns `PyResult<Option<i32>>`. Turns out there was just a slight typo in the macro-generated code.
