### PR TITLE
docs: mention PyBuffer

### DIFF
--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -33,6 +33,7 @@ The table below contains the Python type and the corresponding function argument
 | `datetime.time` | -                             | `&PyTime`            |
 | `datetime.tzinfo` | -                           | `&PyTzInfo`          |
 | `datetime.timedelta` | -                        | `&PyDelta`           |
+| `collections.abc.Buffer` | -                    | `PyBuffer<T>`        |
 | `typing.Optional[T]` | `Option<T>`              | -                    |
 | `typing.Sequence[T]` | `Vec<T>`                 | `&PySequence`        |
 | `typing.Mapping[K, V]` | `HashMap<K, V>`, `BTreeMap<K, V>`, `hashbrown::HashMap<K, V>`[^2], `indexmap::IndexMap<K, V>`[^3] | `&PyMapping` |

--- a/noxfile.py
+++ b/noxfile.py
@@ -452,6 +452,9 @@ def set_minimal_package_versions(session: nox.Session):
         "cxx": "1.0.92",
         "cxxbridge-macro": "1.0.92",
         "cxx-build": "1.0.92",
+        "web-sys": "0.3.61",
+        "js-sys": "0.3.61",
+        "wasm-bindgen": "0.2.84",
         "syn": "1.0.109",
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -189,7 +189,7 @@ impl<'source, T: Element> FromPyObject<'source> for PyBuffer<T> {
 }
 
 impl<T: Element> PyBuffer<T> {
-    /// Get the underlying buffer from the specified python object.
+    /// Gets the underlying buffer from the specified python object.
     pub fn get(obj: &PyAny) -> PyResult<PyBuffer<T>> {
         // TODO: use nightly API Box::new_uninit() once stable
         let mut buf = Box::new(mem::MaybeUninit::uninit());
@@ -616,8 +616,10 @@ impl<T: Element> PyBuffer<T> {
         }
     }
 
-    /// Release the buffer object, freeing the reference to the Python object
+    /// Releases the buffer object, freeing the reference to the Python object
     /// which owns the buffer.
+    ///
+    /// This will automatically be called on drop.
     pub fn release(self, _py: Python<'_>) {
         // First move self into a ManuallyDrop, so that PyBuffer::drop will
         // never be called. (It would acquire the GIL and call PyBuffer_Release


### PR DESCRIPTION
Uses PEP 688 `types.Buffer` to describe `PyBuffer<T>` in the conversion tables. Will leave as draft until PEP 688 is finalised.

Closes #954 