### PR TITLE
Add chrono 0.4 integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ widestring = "0.5.1"
 pyo3-build-config = { path = "pyo3-build-config", version = "0.17.1", features = ["resolve-config"] }
 
 [features]
-default = ["macros", "chrono"]
+default = ["macros"]
 
 # Enables macros: #[pyclass], #[pymodule], #[pyfunction] etc.
 macros = ["pyo3-macros", "indoc", "unindent"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ inventory = { version = "0.3.0", optional = true }
 
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0", optional = true }
-chrono = { version = "0.4", path = "../chrono", optional = true }
+chrono = { version = "0.4", optional = true }
 eyre = { version = ">= 0.4, < 0.7", optional = true }
 hashbrown = { version = ">= 0.9, < 0.13", optional = true }
 indexmap = { version = ">= 1.6, < 1.8", optional = true }
@@ -42,7 +42,7 @@ serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
-chrono = { version = "0.4", path = "../chrono" }
+chrono = { version = "0.4" }
 criterion = "0.3.5"
 trybuild = "1.0.49"
 rustversion = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ inventory = { version = "0.3.0", optional = true }
 
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0", optional = true }
+chrono = { version = "0.4", path = "../chrono", optional = true }
 eyre = { version = ">= 0.4, < 0.7", optional = true }
 hashbrown = { version = ">= 0.9, < 0.13", optional = true }
 indexmap = { version = ">= 1.6, < 1.8", optional = true }
@@ -41,6 +42,7 @@ serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
+chrono = { version = "0.4", path = "../chrono" }
 criterion = "0.3.5"
 trybuild = "1.0.49"
 rustversion = "1.0"
@@ -56,7 +58,7 @@ widestring = "0.5.1"
 pyo3-build-config = { path = "pyo3-build-config", version = "0.17.1", features = ["resolve-config"] }
 
 [features]
-default = ["macros"]
+default = ["macros", "chrono"]
 
 # Enables macros: #[pyclass], #[pymodule], #[pyfunction] etc.
 macros = ["pyo3-macros", "indoc", "unindent"]
@@ -95,6 +97,7 @@ nightly = []
 full = [
     "macros",
     # "multiple-pymethods", # TODO re-add this when MSRV is greater than 1.62
+    "chrono",
     "num-bigint",
     "num-complex",
     "hashbrown",
@@ -163,5 +166,5 @@ members = [
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["macros", "num-bigint", "num-complex", "hashbrown", "serde", "multiple-pymethods", "indexmap", "eyre"]
+features = ["macros", "num-bigint", "num-complex", "hashbrown", "serde", "multiple-pymethods", "indexmap", "eyre", "chrono"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -96,12 +96,12 @@ Adds a dependency on [anyhow](https://docs.rs/anyhow). Enables a conversion from
 ### `chrono`
 
 Adds a dependency on [chrono](https://docs.rs/chrono). Enables a conversion from [chrono](https://docs.rs/chrono)'s types to python:
-- [Duration](https://docs.rs/chrono/0.4.22/chrono/struct.Duration.html) -> [`PyDelta`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDelta.html)
-- [FixedOffset](https://docs.rs/chrono/0.4.22/chrono/offset/struct.FixedOffset.html) -> [`PyDelta`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDelta.html)
-- [Utc](https://docs.rs/chrono/0.4.22/chrono/offset/struct.Utc.html) -> [`PyTzInfo`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyTzInfo.html)
-- [NaiveDate](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveDate.html) -> [`PyDate`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDate.html)
-- [NaiveTime](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveTime.html) -> [`PyTime`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyTime.html)
-- [DateTime](https://docs.rs/chrono/0.4.22/chrono/struct.DateTime.html) -> [`PyDateTime`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDateTime.html)
+- [Duration](https://docs.rs/chrono/0.4.22/chrono/struct.Duration.html) -> [`PyDelta`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDelta.html)
+- [FixedOffset](https://docs.rs/chrono/0.4.22/chrono/offset/struct.FixedOffset.html) -> [`PyDelta`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDelta.html)
+- [Utc](https://docs.rs/chrono/0.4.22/chrono/offset/struct.Utc.html) -> [`PyTzInfo`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTzInfo.html)
+- [NaiveDate](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveDate.html) -> [`PyDate`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDate.html)
+- [NaiveTime](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveTime.html) -> [`PyTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTime.html)
+- [DateTime](https://docs.rs/chrono/0.4.22/chrono/struct.DateTime.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
 
 ### `eyre`
 

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -94,6 +94,7 @@ These features enable conversions between Python types and types from other Rust
 Adds a dependency on [anyhow](https://docs.rs/anyhow). Enables a conversion from [anyhow](https://docs.rs/anyhow)’s [`Error`](https://docs.rs/anyhow/latest/anyhow/struct.Error.html) type to [`PyErr`](https://docs.rs/pyo3/latest/pyo3/struct.PyErr.html), for easy error handling.
 
 ### `chrono`
+
 Adds a dependency on [chrono](https://docs.rs/chrono). Enables a conversion from [chrono](https://docs.rs/chrono)'s types to python:
 - [Duration](https://docs.rs/chrono/0.4.22/chrono/struct.Duration.html) -> [`PyDelta`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDelta.html)
 - [FixedOffset](https://docs.rs/chrono/0.4.22/chrono/offset/struct.FixedOffset.html) -> [`PyDelta`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDelta.html)

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -96,12 +96,12 @@ Adds a dependency on [anyhow](https://docs.rs/anyhow). Enables a conversion from
 ### `chrono`
 
 Adds a dependency on [chrono](https://docs.rs/chrono). Enables a conversion from [chrono](https://docs.rs/chrono)'s types to python:
-- [Duration](https://docs.rs/chrono/0.4.22/chrono/struct.Duration.html) -> [`PyDelta`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDelta.html)
-- [FixedOffset](https://docs.rs/chrono/0.4.22/chrono/offset/struct.FixedOffset.html) -> [`PyDelta`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDelta.html)
-- [Utc](https://docs.rs/chrono/0.4.22/chrono/offset/struct.Utc.html) -> [`PyTzInfo`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTzInfo.html)
-- [NaiveDate](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveDate.html) -> [`PyDate`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDate.html)
-- [NaiveTime](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveTime.html) -> [`PyTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTime.html)
-- [DateTime](https://docs.rs/chrono/0.4.22/chrono/struct.DateTime.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
+- [Duration](https://docs.rs/chrono/latest/chrono/struct.Duration.html) -> [`PyDelta`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDelta.html)
+- [FixedOffset](https://docs.rs/chrono/latest/chrono/offset/struct.FixedOffset.html) -> [`PyDelta`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDelta.html)
+- [Utc](https://docs.rs/chrono/latest/chrono/offset/struct.Utc.html) -> [`PyTzInfo`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTzInfo.html)
+- [NaiveDate](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDate.html) -> [`PyDate`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDate.html)
+- [NaiveTime](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveTime.html) -> [`PyTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTime.html)
+- [DateTime](https://docs.rs/chrono/latest/chrono/struct.DateTime.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
 
 ### `eyre`
 

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -93,6 +93,15 @@ These features enable conversions between Python types and types from other Rust
 
 Adds a dependency on [anyhow](https://docs.rs/anyhow). Enables a conversion from [anyhow](https://docs.rs/anyhow)’s [`Error`](https://docs.rs/anyhow/latest/anyhow/struct.Error.html) type to [`PyErr`](https://docs.rs/pyo3/latest/pyo3/struct.PyErr.html), for easy error handling.
 
+### `chrono`
+Adds a dependency on [chrono](https://docs.rs/chrono). Enables a conversion from [chrono](https://docs.rs/chrono)'s types to python:
+- [Duration](https://docs.rs/chrono/0.4.22/chrono/struct.Duration.html) -> [`PyDelta`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDelta.html)
+- [FixedOffset](https://docs.rs/chrono/0.4.22/chrono/offset/struct.FixedOffset.html) -> [`PyDelta`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDelta.html)
+- [Utc](https://docs.rs/chrono/0.4.22/chrono/offset/struct.Utc.html) -> [`PyTzInfo`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyTzInfo.html)
+- [NaiveDate](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveDate.html) -> [`PyDate`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDate.html)
+- [NaiveTime](https://docs.rs/chrono/0.4.22/chrono/naive/struct.NaiveTime.html) -> [`PyTime`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyTime.html)
+- [DateTime](https://docs.rs/chrono/0.4.22/chrono/struct.DateTime.html) -> [`PyDateTime`](https://docs.rs/pyo3/0.17.1/pyo3/types/struct.PyDateTime.html)
+
 ### `eyre`
 
 Adds a dependency on [eyre](https://docs.rs/eyre). Enables a conversion from [eyre](https://docs.rs/eyre)’s [`Report`](https://docs.rs/eyre/latest/eyre/struct.Report.html) type to [`PyErr`](https://docs.rs/pyo3/latest/pyo3/struct.PyErr.html), for easy error handling.

--- a/newsfragments/2612.packaging.md
+++ b/newsfragments/2612.packaging.md
@@ -1,0 +1,1 @@
+Added optional `chrono` feature to convert `chrono` types into types in the `datetime` module.

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -110,7 +110,6 @@ impl FromPyObject<'_> for Duration {
 
 impl ToPyObject for NaiveDate {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        // This cast should be safe, right?
         let month = self.month() as u8;
         let day = self.day() as u8;
         let date = PyDate::new(py, self.year(), month, day).expect("Failed to construct date");
@@ -207,7 +206,7 @@ impl FromPyObject<'_> for DateTime<FixedOffset> {
         let tz = if let Some(tzinfo) = dt.get_tzinfo() {
             tzinfo.extract()?
         } else {
-            return Err(PyTypeError::new_err("Not datetime.timezone.tzinfo"));
+            return Err(PyTypeError::new_err("Not datetime.tzinfo"));
         };
         let dt = NaiveDateTime::new(
             NaiveDate::from_ymd(dt.get_year(), dt.get_month().into(), dt.get_day().into()),
@@ -243,7 +242,7 @@ fn pytimezone_fromoffset<'a>(py: &Python<'a>, td: &PyDelta) -> &'a PyAny {
     // Since we are forcing a &PyDelta as input, the cast should always be valid.
     unsafe {
         PyDateTime_IMPORT();
-        py.from_borrowed_ptr(PyTimeZone_FromOffset(td.as_ptr()))
+        py.from_owned_ptr(PyTimeZone_FromOffset(td.as_ptr()))
     }
 }
 
@@ -423,7 +422,7 @@ mod proptests {
 }
 
 #[cfg(test)]
-mod test_chrono {
+mod tests {
     use crate::chrono::pytimezone_fromoffset;
     use crate::types::*;
     use crate::{Python, ToPyObject};

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "chrono", not(Py_LIMITED_API))]
+#![cfg(all(feature = "chrono", not(Py_LIMITED_API)))]
 
 //! Conversions to and from [chrono](https://docs.rs/chrono/)’s `Duration`,
 //! `NaiveDate`, `NaiveTime`, `DateTime<Tz>`, `FixedOffset`, and `Utc`.

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -12,6 +12,28 @@
 //! # change * to the latest versions
 //! pyo3 = { version = "*", features = ["chrono"] }
 //! chrono = "0.4"
+//! ```
+//!
+//! # Example: Convert a PyDateTime to chrono's DateTime<Utc>
+//!
+//! ```rust
+//! use chrono::{Utc, DateTime};
+//! use pyo3::{Python, ToPyObject, types::PyDateTime};
+//!
+//! fn main() {
+//!     pyo3::prepare_freethreaded_python();
+//!     Python::with_gil(|py| {
+//!         // Create an UTC datetime in python
+//!         let py_tz = Utc.to_object(py);
+//!         let py_tz = py_tz.cast_as(py).unwrap();
+//!         let pydatetime = PyDateTime::new(py, 2022, 1, 1, 12, 0, 0, 0, Some(py_tz)).unwrap();
+//!         println!("PyDateTime:\t{pydatetime}");
+//!         // Now convert it to chrono's DateTime<Utc>
+//!         let chrono_datetime: DateTime<Utc> = pydatetime.extract().unwrap();
+//!         println!("DateTime<Utc>:\t{chrono_datetime}");
+//!     });
+//! }
+//! ```
 // workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
 #![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"chrono\"] }")))]
 #![cfg_attr(

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -202,9 +202,9 @@ impl FromPyObject<'_> for NaiveDateTime {
         // we return a hard error. We could silently remove tzinfo, or assume local timezone
         // and do a conversion, but better leave this decision to the user of the library.
         if dt.get_tzinfo().is_some() {
-            return Err(PyErr::new::<crate::exceptions::PyTypeError, _>(format!(
-                "Trying to convert a timezone aware datetime into a NaiveDateTime."
-            )));
+            return Err(PyErr::new::<crate::exceptions::PyTypeError, _>(
+                "Trying to convert a timezone aware datetime into a NaiveDateTime.",
+            ));
         }
         let h = dt.get_hour().into();
         let m = dt.get_minute().into();

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -386,9 +386,8 @@ mod test_chrono {
             // This panics on PyDelta::new
             assert!(panic::catch_unwind(|| {
                 let pydelta = PyDelta::new(py, low_days, 0, 0, true).unwrap();
-                // So we should never get here
                 if let Ok(_duration) = pydelta.extract::<Duration>() {
-                    ()
+                    // So we should never get here
                 }
             })
             .is_err());
@@ -399,9 +398,8 @@ mod test_chrono {
             // This panics on PyDelta::new
             assert!(panic::catch_unwind(|| {
                 let pydelta = PyDelta::new(py, high_days, 0, 0, true).unwrap();
-                // So we should never get here
                 if let Ok(_duration) = pydelta.extract::<Duration>() {
-                    ()
+                    // So we should never get here
                 }
             })
             .is_err());

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -376,7 +376,9 @@ mod tests {
 
     #[test]
     // Only Python>=3.9 has the zoneinfo package
-    #[cfg(Py_3_9)]
+    // We skip the test on windows too since we'd need to install
+    // tzdata there to make this work.
+    #[cfg(all(Py_3_9, not(target_os = "windows")))]
     fn test_zoneinfo_is_not_fixedoffset() {
         Python::with_gil(|py| {
             let locals = crate::types::PyDict::new(py);

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1,7 +1,9 @@
-#![cfg(feature = "chrono")]
+#![cfg(all(feature = "chrono", not(Py_LIMITED_API))]
 
 //! Conversions to and from [chrono](https://docs.rs/chrono/)’s `Duration`,
 //! `NaiveDate`, `NaiveTime`, `DateTime<Tz>`, `FixedOffset`, and `Utc`.
+//!
+//! Unavailable with the `abi3` feature.
 //!
 //! # Setup
 //!

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -252,7 +252,7 @@ impl ToPyObject for FixedOffset {
         let seconds_offset = self.local_minus_utc();
         let td =
             PyDelta::new(py, 0, seconds_offset, 0, true).expect("Failed to contruct timedelta");
-        pytimezone_fromoffset(&py, &td).into()
+        pytimezone_fromoffset(&py, td).into()
     }
 }
 
@@ -602,7 +602,7 @@ mod test_chrono {
     fn test_pyo3_offset_fixed_frompyobject() {
         Python::with_gil(|py| {
             let py_timedelta = PyDelta::new(py, 0, 3600, 0, true).unwrap();
-            let py_tzinfo = pytimezone_fromoffset(&py, &py_timedelta);
+            let py_tzinfo = pytimezone_fromoffset(&py, py_timedelta);
             let offset: FixedOffset = py_tzinfo.extract().unwrap();
             assert_eq!(FixedOffset::east(3600), offset);
         })
@@ -625,12 +625,12 @@ mod test_chrono {
             assert_eq!(Utc, py_utc);
 
             let py_timedelta = PyDelta::new(py, 0, 0, 0, false).unwrap();
-            let py_timezone_utc = pytimezone_fromoffset(&py, &py_timedelta);
+            let py_timezone_utc = pytimezone_fromoffset(&py, py_timedelta);
             let py_timezone_utc: Utc = py_timezone_utc.extract().unwrap();
             assert_eq!(Utc, py_timezone_utc);
 
             let py_timedelta = PyDelta::new(py, 0, 3600, 0, false).unwrap();
-            let py_timezone = pytimezone_fromoffset(&py, &py_timedelta);
+            let py_timezone = pytimezone_fromoffset(&py, py_timedelta);
             assert!(py_timezone.extract::<Utc>().is_err());
         })
     }

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -38,10 +38,10 @@
 //!         let py_tz = Utc.to_object(py);
 //!         let py_tz = py_tz.cast_as(py).unwrap();
 //!         let pydatetime = PyDateTime::new(py, 2022, 1, 1, 12, 0, 0, 0, Some(py_tz)).unwrap();
-//!         println!("PyDateTime:\t{pydatetime}");
+//!         println!("PyDateTime: {}", pydatetime);
 //!         // Now convert it to chrono's DateTime<Utc>
 //!         let chrono_datetime: DateTime<Utc> = pydatetime.extract().unwrap();
-//!         println!("DateTime<Utc>:\t{chrono_datetime}");
+//!         println!("DateTime<Utc>: {}", chrono_datetime);
 //!     });
 //! }
 //! ```

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -238,7 +238,7 @@ impl FromPyObject<'_> for DateTime<Utc> {
 
 // Utiliy function used to convert PyDelta to timezone
 fn pytimezone_fromoffset<'a>(py: &Python<'a>, td: &PyDelta) -> &'a PyAny {
-    // Safety: py.from_borrowed_ptr needs the cast to be valid.
+    // Safety: py.from_owned_ptr needs the cast to be valid.
     // Since we are forcing a &PyDelta as input, the cast should always be valid.
     unsafe {
         PyDateTime_IMPORT();
@@ -302,134 +302,10 @@ impl FromPyObject<'_> for Utc {
 }
 
 #[cfg(test)]
-mod proptests {
-    use super::*;
-
-    #[cfg(not(target_arch = "wasm32"))]
-    use proptest::prelude::*;
-
-    #[cfg(not(target_arch = "wasm32"))]
-    proptest! {
-        #[test]
-        fn test_duration_roundtrip(days in -999999999i64..=999999999i64) {
-            // Test roundtrip convertion rust->python->rust for all allowed
-            // python values of durations (from -999999999 to 999999999 days),
-            Python::with_gil(|py| {
-                let dur = Duration::days(days);
-                let pydelta = dur.into_py(py);
-                let roundtripped: Duration = pydelta.extract(py).expect("Round trip");
-                assert_eq!(dur, roundtripped);
-            })
-        }
-
-        #[test]
-        fn test_fixedoffset_roundtrip(secs in -86_400i32..=86_400i32) {
-            Python::with_gil(|py| {
-                let offset = FixedOffset::east(secs);
-                let pyoffset = offset.into_py(py);
-                let roundtripped: FixedOffset = pyoffset.extract(py).expect("Round trip");
-                assert_eq!(offset, roundtripped);
-            })
-        }
-
-        #[test]
-        fn test_naivedate_roundtrip(
-            year in 1i32..=9999i32,
-            month in 1u32..=12u32,
-            day in 1u32..=31u32
-        ) {
-            // Test roundtrip convertion rust->python->rust for all allowed
-            // python dates (from year 1 to year 9999)
-            Python::with_gil(|py| {
-                // We use to `from_ymd_opt` constructor so that we only test valid `NaiveDate`s.
-                // This is to skip the test if we are creating an invalid date, like February 31.
-                if let Some(date) = NaiveDate::from_ymd_opt(year, month, day) {
-                    let pydate = date.into_py(py);
-                    let roundtripped: NaiveDate = pydate.extract(py).expect("Round trip");
-                    assert_eq!(date, roundtripped);
-                }
-            })
-        }
-
-        #[test]
-        fn test_naivetime_roundtrip(
-            hour in 0u32..=24u32,
-            min in 0u32..=60u32,
-            sec in 0u32..=60u32,
-            micro in 0u32..=2_000_000u32
-        ) {
-            // Test roundtrip convertion rust->python->rust for naive times.
-            // Python time has a resolution of microseconds, so we only test
-            // NaiveTimes with microseconds resolution, even if NaiveTime has nanosecond
-            // resolution.
-            Python::with_gil(|py| {
-                // We use to `from_hms_micro_opt` constructor so that we only test valid `NaiveTime`s.
-                // This is to skip the test if we are creating an invalid time
-                if let Some(time) = NaiveTime::from_hms_micro_opt(hour, min, sec, micro) {
-                    let pytime = time.into_py(py);
-                    let roundtripped: NaiveTime = pytime.extract(py).expect("Round trip");
-                    assert_eq!(time, roundtripped);
-                }
-            })
-        }
-
-        #[test]
-        fn test_utc_datetime_roundtrip(
-            year in 1i32..=9999i32,
-            month in 1u32..=12u32,
-            day in 1u32..=31u32,
-            hour in 0u32..=24u32,
-            min in 0u32..=60u32,
-            sec in 0u32..=60u32,
-            micro in 0u32..=2_000_000u32
-        ) {
-            Python::with_gil(|py| {
-                let date_opt = NaiveDate::from_ymd_opt(year, month, day);
-                let time_opt = NaiveTime::from_hms_micro_opt(hour, min, sec, micro);
-                if let (Some(date), Some(time)) = (date_opt, time_opt) {
-                    let dt: DateTime<Utc> = DateTime::from_utc(NaiveDateTime::new(date, time), Utc);
-                    let pydt = dt.into_py(py);
-                    let roundtripped: DateTime<Utc> = pydt.extract(py).expect("Round trip");
-                    assert_eq!(dt, roundtripped);
-                }
-            })
-        }
-
-        #[test]
-        fn test_fixedoffset_datetime_roundtrip(
-            year in 1i32..=9999i32,
-            month in 1u32..=12u32,
-            day in 1u32..=31u32,
-            hour in 0u32..=24u32,
-            min in 0u32..=60u32,
-            sec in 0u32..=60u32,
-            micro in 0u32..=2_000_000u32,
-            offset_secs in -86_400i32..=86_400i32
-        ) {
-            Python::with_gil(|py| {
-                let date_opt = NaiveDate::from_ymd_opt(year, month, day);
-                let time_opt = NaiveTime::from_hms_micro_opt(hour, min, sec, micro);
-                let offset = FixedOffset::east(offset_secs);
-                if let (Some(date), Some(time)) = (date_opt, time_opt) {
-                    let dt: DateTime<FixedOffset> = DateTime::from_utc(NaiveDateTime::new(date, time), offset);
-                    let pydt = dt.into_py(py);
-                    let roundtripped: DateTime<FixedOffset> = pydt.extract(py).expect("Round trip");
-                    assert_eq!(dt, roundtripped);
-                }
-            })
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
-    use crate::chrono::pytimezone_fromoffset;
-    use crate::types::*;
-    use crate::{Python, ToPyObject};
-    use chrono::offset::{FixedOffset, Utc};
-    use chrono::{DateTime, Duration, NaiveDate, NaiveTime};
-    use std::cmp::Ordering;
-    use std::panic;
+    use std::{cmp::Ordering, panic};
+
+    use super::*;
 
     #[test]
     fn test_pyo3_timedelta_topyobject() {
@@ -843,5 +719,125 @@ mod tests {
 
         check_time("fold", 3, 5, 7, 1_999_999, 999_999, true);
         check_time("non fold", 3, 5, 7, 999_999, 999_999, false);
+    }
+
+    #[cfg(test)]
+    mod proptests {
+        use super::*;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        use proptest::prelude::*;
+
+        #[cfg(not(target_arch = "wasm32"))]
+        proptest! {
+            #[test]
+            fn test_duration_roundtrip(days in -999999999i64..=999999999i64) {
+                // Test roundtrip convertion rust->python->rust for all allowed
+                // python values of durations (from -999999999 to 999999999 days),
+                Python::with_gil(|py| {
+                    let dur = Duration::days(days);
+                    let pydelta = dur.into_py(py);
+                    let roundtripped: Duration = pydelta.extract(py).expect("Round trip");
+                    assert_eq!(dur, roundtripped);
+                })
+            }
+
+            #[test]
+            fn test_fixedoffset_roundtrip(secs in -86_400i32..=86_400i32) {
+                Python::with_gil(|py| {
+                    let offset = FixedOffset::east(secs);
+                    let pyoffset = offset.into_py(py);
+                    let roundtripped: FixedOffset = pyoffset.extract(py).expect("Round trip");
+                    assert_eq!(offset, roundtripped);
+                })
+            }
+
+            #[test]
+            fn test_naivedate_roundtrip(
+                year in 1i32..=9999i32,
+                month in 1u32..=12u32,
+                day in 1u32..=31u32
+            ) {
+                // Test roundtrip convertion rust->python->rust for all allowed
+                // python dates (from year 1 to year 9999)
+                Python::with_gil(|py| {
+                    // We use to `from_ymd_opt` constructor so that we only test valid `NaiveDate`s.
+                    // This is to skip the test if we are creating an invalid date, like February 31.
+                    if let Some(date) = NaiveDate::from_ymd_opt(year, month, day) {
+                        let pydate = date.into_py(py);
+                        let roundtripped: NaiveDate = pydate.extract(py).expect("Round trip");
+                        assert_eq!(date, roundtripped);
+                    }
+                })
+            }
+
+            #[test]
+            fn test_naivetime_roundtrip(
+                hour in 0u32..=24u32,
+                min in 0u32..=60u32,
+                sec in 0u32..=60u32,
+                micro in 0u32..=2_000_000u32
+            ) {
+                // Test roundtrip convertion rust->python->rust for naive times.
+                // Python time has a resolution of microseconds, so we only test
+                // NaiveTimes with microseconds resolution, even if NaiveTime has nanosecond
+                // resolution.
+                Python::with_gil(|py| {
+                    // We use to `from_hms_micro_opt` constructor so that we only test valid `NaiveTime`s.
+                    // This is to skip the test if we are creating an invalid time
+                    if let Some(time) = NaiveTime::from_hms_micro_opt(hour, min, sec, micro) {
+                        let pytime = time.into_py(py);
+                        let roundtripped: NaiveTime = pytime.extract(py).expect("Round trip");
+                        assert_eq!(time, roundtripped);
+                    }
+                })
+            }
+
+            #[test]
+            fn test_utc_datetime_roundtrip(
+                year in 1i32..=9999i32,
+                month in 1u32..=12u32,
+                day in 1u32..=31u32,
+                hour in 0u32..=24u32,
+                min in 0u32..=60u32,
+                sec in 0u32..=60u32,
+                micro in 0u32..=2_000_000u32
+            ) {
+                Python::with_gil(|py| {
+                    let date_opt = NaiveDate::from_ymd_opt(year, month, day);
+                    let time_opt = NaiveTime::from_hms_micro_opt(hour, min, sec, micro);
+                    if let (Some(date), Some(time)) = (date_opt, time_opt) {
+                        let dt: DateTime<Utc> = DateTime::from_utc(NaiveDateTime::new(date, time), Utc);
+                        let pydt = dt.into_py(py);
+                        let roundtripped: DateTime<Utc> = pydt.extract(py).expect("Round trip");
+                        assert_eq!(dt, roundtripped);
+                    }
+                })
+            }
+
+            #[test]
+            fn test_fixedoffset_datetime_roundtrip(
+                year in 1i32..=9999i32,
+                month in 1u32..=12u32,
+                day in 1u32..=31u32,
+                hour in 0u32..=24u32,
+                min in 0u32..=60u32,
+                sec in 0u32..=60u32,
+                micro in 0u32..=2_000_000u32,
+                offset_secs in -86_400i32..=86_400i32
+            ) {
+                Python::with_gil(|py| {
+                    let date_opt = NaiveDate::from_ymd_opt(year, month, day);
+                    let time_opt = NaiveTime::from_hms_micro_opt(hour, min, sec, micro);
+                    let offset = FixedOffset::east(offset_secs);
+                    if let (Some(date), Some(time)) = (date_opt, time_opt) {
+                        let dt: DateTime<FixedOffset> = DateTime::from_utc(NaiveDateTime::new(date, time), offset);
+                        let pydt = dt.into_py(py);
+                        let roundtripped: DateTime<FixedOffset> = pydt.extract(py).expect("Round trip");
+                        assert_eq!(dt, roundtripped);
+                    }
+                })
+            }
+        }
     }
 }

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -388,7 +388,7 @@ mod test_chrono {
                 let pydelta = PyDelta::new(py, low_days, 0, 0, true).unwrap();
                 // So we should never get here
                 if let Ok(_duration) = pydelta.extract::<Duration>() {
-                    return ();
+                    ()
                 }
             })
             .is_err());
@@ -401,7 +401,7 @@ mod test_chrono {
                 let pydelta = PyDelta::new(py, high_days, 0, 0, true).unwrap();
                 // So we should never get here
                 if let Ok(_duration) = pydelta.extract::<Duration>() {
-                    return ();
+                    ()
                 }
             })
             .is_err());

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -10,7 +10,8 @@
 //! ```toml
 //! [dependencies]
 //! # change * to the latest versions
-//! hashbrown = "*"
+//! pyo3 = { version = "*", features = ["chrono"] }
+//! chrono = "0.4"
 // workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
 #![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"chrono\"] }")))]
 #![cfg_attr(

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1,0 +1,266 @@
+#![cfg(feature = "chrono")]
+
+//! Conversions to and from [chrono](https://docs.rs/chrono/)’s `Duration`,
+//! `NaiveDate`, `NaiveTime`, `DateTime<Tz>`, `FixedOffset`, and `Utc`.
+//!
+//! # Setup
+//!
+//! To use this feature, add this to your **`Cargo.toml`**:
+//!
+//! ```toml
+//! [dependencies]
+//! # change * to the latest versions
+//! hashbrown = "*"
+// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
+#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"chrono\"] }")))]
+#![cfg_attr(
+    not(docsrs),
+    doc = "pyo3 = { version = \"*\", features = [\"chrono\"] }"
+)]
+//! ```
+//!
+//! Note that you must use compatible versions of chrono and PyO3.
+//! The required chrono version may vary based on the version of PyO3.
+use crate::exceptions::PyTypeError;
+use crate::types::{
+    timezone_utc, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess,
+    PyTzInfo, PyTzInfoAccess,
+};
+use crate::{FromPyObject, IntoPy, PyAny, PyObject, PyResult, PyTryFrom, Python, ToPyObject};
+use chrono::offset::{FixedOffset, Utc};
+use chrono::{
+    div_mod_floor_64, DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Offset,
+    TimeZone, Timelike, NANOS_PER_MICRO, SECS_PER_DAY,
+};
+use std::convert::TryInto;
+
+impl ToPyObject for Duration {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        let micros = self.nanos / NANOS_PER_MICRO;
+        let (days, secs) = div_mod_floor_64(self.secs, SECS_PER_DAY);
+        // Python will check overflow so even if we reduce the size
+        // it will still overflow.
+        let days = days.try_into().unwrap_or(i32::MAX);
+        let secs = secs.try_into().unwrap_or(i32::MAX);
+
+        // We do not need to check i64 to i32 cast from rust because
+        // python will panic with OverflowError.
+        // Not sure if we need normalize here.
+        let delta = PyDelta::new(py, days, secs, micros, false).expect("Failed to construct delta");
+        delta.into()
+    }
+}
+
+impl IntoPy<PyObject> for Duration {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        ToPyObject::to_object(&self, py)
+    }
+}
+
+impl FromPyObject<'_> for Duration {
+    fn extract(ob: &PyAny) -> PyResult<Duration> {
+        let delta = <PyDelta as PyTryFrom>::try_from(ob)?;
+        // Python size are much lower than rust size so we do not need bound checks.
+        // 0 <= microseconds < 1000000
+        // 0 <= seconds < 3600*24
+        // -999999999 <= days <= 999999999
+        let secs = delta.get_days() as i64 * SECS_PER_DAY + delta.get_seconds() as i64;
+        let nanos = delta.get_microseconds() * NANOS_PER_MICRO;
+
+        Ok(Duration { secs, nanos })
+    }
+}
+
+impl ToPyObject for NaiveDate {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        let mdf = self.mdf();
+        let date = PyDate::new(py, self.year(), mdf.month() as u8, mdf.day() as u8)
+            .expect("Failed to construct date");
+        date.into()
+    }
+}
+
+impl IntoPy<PyObject> for NaiveDate {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        ToPyObject::to_object(&self, py)
+    }
+}
+
+impl FromPyObject<'_> for NaiveDate {
+    fn extract(ob: &PyAny) -> PyResult<NaiveDate> {
+        let date = <PyDate as PyTryFrom>::try_from(ob)?;
+        Ok(NaiveDate::from_ymd(
+            date.get_year(),
+            date.get_month() as u32,
+            date.get_day() as u32,
+        ))
+    }
+}
+
+impl ToPyObject for NaiveTime {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        let (h, m, s) = self.hms();
+        let ns = self.nanosecond();
+        let (ms, fold) = match ns.checked_sub(1_000_000_000) {
+            Some(ns) => (ns / 1000, true),
+            None => (ns / 1000, false),
+        };
+        let time = PyTime::new_with_fold(py, h as u8, m as u8, s as u8, ms, None, fold)
+            .expect("Failed to construct time");
+        time.into()
+    }
+}
+
+impl IntoPy<PyObject> for NaiveTime {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        ToPyObject::to_object(&self, py)
+    }
+}
+
+impl FromPyObject<'_> for NaiveTime {
+    fn extract(ob: &PyAny) -> PyResult<NaiveTime> {
+        let time = <PyTime as PyTryFrom>::try_from(ob)?;
+        let ms = time.get_fold() as u32 * 1_000_000 + time.get_microsecond();
+        let (h, m, s) = (time.get_hour(), time.get_minute(), time.get_second());
+        Ok(NaiveTime::from_hms_micro(h as u32, m as u32, s as u32, ms))
+    }
+}
+
+impl<Tz: TimeZone> ToPyObject for DateTime<Tz> {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        let (date, time) = (self.naive_utc().date(), self.naive_utc().time());
+        let mdf = date.mdf();
+        let (yy, mm, dd) = (date.year(), mdf.month(), mdf.day());
+        let (h, m, s) = time.hms();
+        let ns = time.nanosecond();
+        let (ms, fold) = match ns.checked_sub(1_000_000_000) {
+            Some(ns) => (ns / 1000, true),
+            None => (ns / 1000, false),
+        };
+        let tz = self.offset().fix().to_object(py);
+        let tz = tz.cast_as(py).unwrap();
+        let datetime = PyDateTime::new_with_fold(
+            py,
+            yy,
+            mm as u8,
+            dd as u8,
+            h as u8,
+            m as u8,
+            s as u8,
+            ms,
+            Some(&tz),
+            fold,
+        )
+        .expect("Failed to construct datetime");
+        datetime.into()
+    }
+}
+
+impl<Tz: TimeZone> IntoPy<PyObject> for DateTime<Tz> {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        ToPyObject::to_object(&self, py)
+    }
+}
+
+impl FromPyObject<'_> for DateTime<FixedOffset> {
+    fn extract(ob: &PyAny) -> PyResult<DateTime<FixedOffset>> {
+        let dt = <PyDateTime as PyTryFrom>::try_from(ob)?;
+        let ms = dt.get_fold() as u32 * 1_000_000 + dt.get_microsecond();
+        let (h, m, s) = (dt.get_hour(), dt.get_minute(), dt.get_second());
+        let tz = if let Some(tzinfo) = dt.get_tzinfo() {
+            tzinfo.extract()?
+        } else {
+            return Err(PyTypeError::new_err("Not datetime.timezone.tzinfo"));
+        };
+        let dt = NaiveDateTime::new(
+            NaiveDate::from_ymd(dt.get_year(), dt.get_month() as u32, dt.get_day() as u32),
+            NaiveTime::from_hms_micro(h as u32, m as u32, s as u32, ms),
+        );
+        Ok(DateTime::from_utc(dt, tz))
+    }
+}
+
+impl FromPyObject<'_> for DateTime<Utc> {
+    fn extract(ob: &PyAny) -> PyResult<DateTime<Utc>> {
+        let dt = <PyDateTime as PyTryFrom>::try_from(ob)?;
+        let ms = dt.get_fold() as u32 * 1_000_000 + dt.get_microsecond();
+        let (h, m, s) = (dt.get_hour(), dt.get_minute(), dt.get_second());
+        let tz = if let Some(tzinfo) = dt.get_tzinfo() {
+            tzinfo.extract()?
+        } else {
+            return Err(PyTypeError::new_err("Not datetime.timezone.utc"));
+        };
+        let dt = NaiveDateTime::new(
+            NaiveDate::from_ymd(dt.get_year(), dt.get_month() as u32, dt.get_day() as u32),
+            NaiveTime::from_hms_micro(h as u32, m as u32, s as u32, ms),
+        );
+        Ok(DateTime::from_utc(dt, tz))
+    }
+}
+
+impl ToPyObject for FixedOffset {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        let dt_module = py.import("datetime").expect("Failed to import datetime");
+        let dt_timezone = dt_module
+            .getattr("timezone")
+            .expect("Failed to getattr timezone");
+        let seconds_offset = self.local_minus_utc();
+        let td =
+            PyDelta::new(py, 0, seconds_offset, 0, true).expect("Failed to contruct timedelta");
+        let offset = dt_timezone
+            .call1((td,))
+            .expect("Failed to call timezone with timedelta");
+        offset.into()
+    }
+}
+
+impl IntoPy<PyObject> for FixedOffset {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        ToPyObject::to_object(&self, py)
+    }
+}
+
+impl FromPyObject<'_> for FixedOffset {
+    /// Convert python tzinfo to rust [`FixedOffset`].
+    ///
+    /// Note that the conversion will result in precision lost in microseconds as chrono offset
+    /// does not supports microseconds.
+    fn extract(ob: &PyAny) -> PyResult<FixedOffset> {
+        let py_tzinfo = <PyTzInfo as PyTryFrom>::try_from(ob)?;
+        let py_timedelta = py_tzinfo.call_method1("utcoffset", (ob.py().None(),))?;
+        let py_timedelta = <PyDelta as PyTryFrom>::try_from(py_timedelta)?;
+        Ok(FixedOffset::east(py_timedelta.get_seconds()))
+    }
+}
+
+impl ToPyObject for Utc {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        timezone_utc(py).to_object(py)
+    }
+}
+
+impl IntoPy<PyObject> for Utc {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        ToPyObject::to_object(&self, py)
+    }
+}
+
+impl FromPyObject<'_> for Utc {
+    fn extract(ob: &PyAny) -> PyResult<Utc> {
+        let py_tzinfo = <PyTzInfo as PyTryFrom>::try_from(ob)?;
+        let py_utc = timezone_utc(ob.py());
+        if py_tzinfo.eq(py_utc)? {
+            Ok(Utc)
+        } else {
+            Err(PyTypeError::new_err("Not datetime.timezone.utc"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_chrono {
+    use crate::types::*;
+    use crate::{IntoPy, PyObject, PyTryFrom, Python, ToPyObject};
+
+    // TODO
+}

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -12,7 +12,13 @@
 //! # change * to the latest versions
 //! pyo3 = { version = "*", features = ["chrono"] }
 //! chrono = "0.4"
+// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
+#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"chrono\"] }")))]
+#![cfg_attr(not(docsrs), doc = "pyo3 = { version = \"*\", features = [\"chrono\"] }")]
 //! ```
+//!
+//! Note that you must use compatible versions of chrono and PyO3.
+//! The required chrono version may vary based on the version of PyO3.
 //!
 //! # Example: Convert a PyDateTime to chrono's DateTime<Utc>
 //!
@@ -34,16 +40,6 @@
 //!     });
 //! }
 //! ```
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"chrono\"] }")))]
-#![cfg_attr(
-    not(docsrs),
-    doc = "pyo3 = { version = \"*\", features = [\"chrono\"] }"
-)]
-//! ```
-//!
-//! Note that you must use compatible versions of chrono and PyO3.
-//! The required chrono version may vary based on the version of PyO3.
 use crate::exceptions::PyTypeError;
 use crate::types::{
     timezone_utc, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess,

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -158,7 +158,7 @@ impl<Tz: TimeZone> ToPyObject for DateTime<Tz> {
         };
         let tz = self.offset().fix().to_object(py);
         let tz = tz.cast_as(py).unwrap();
-        let datetime = PyDateTime::new_with_fold(py, yy, mm, dd, h, m, s, ms, Some(&tz), fold)
+        let datetime = PyDateTime::new_with_fold(py, yy, mm, dd, h, m, s, ms, Some(tz), fold)
             .expect("Failed to construct datetime");
         datetime.into()
     }
@@ -372,7 +372,7 @@ mod test_chrono {
                     m as u8,
                     s as u8,
                     py_ms,
-                    Some(&py_tz),
+                    Some(py_tz),
                     f,
                 )
                 .unwrap();
@@ -398,7 +398,7 @@ mod test_chrono {
                     m as u8,
                     s as u8,
                     py_ms,
-                    Some(&py_tz),
+                    Some(py_tz),
                     f,
                 )
                 .unwrap();
@@ -425,7 +425,7 @@ mod test_chrono {
                     m as u8,
                     s as u8,
                     py_ms,
-                    Some(&py_tz),
+                    Some(py_tz),
                     f,
                 )
                 .unwrap();
@@ -451,7 +451,7 @@ mod test_chrono {
                     m as u8,
                     s as u8,
                     py_ms,
-                    Some(&py_tz),
+                    Some(py_tz),
                     f,
                 )
                 .unwrap();
@@ -469,14 +469,14 @@ mod test_chrono {
             let py_tz = Utc.to_object(py);
             let py_tz = py_tz.cast_as(py).unwrap();
             let py_datetime =
-                PyDateTime::new_with_fold(py, 2014, 5, 6, 7, 8, 9, 999_999, Some(&py_tz), false)
+                PyDateTime::new_with_fold(py, 2014, 5, 6, 7, 8, 9, 999_999, Some(py_tz), false)
                     .unwrap();
             assert!(py_datetime.extract::<DateTime<FixedOffset>>().is_ok());
             let offset = FixedOffset::east(3600);
             let py_tz = offset.to_object(py);
             let py_tz = py_tz.cast_as(py).unwrap();
             let py_datetime =
-                PyDateTime::new_with_fold(py, 2014, 5, 6, 7, 8, 9, 999_999, Some(&py_tz), false)
+                PyDateTime::new_with_fold(py, 2014, 5, 6, 7, 8, 9, 999_999, Some(py_tz), false)
                     .unwrap();
             assert!(py_datetime.extract::<DateTime<Utc>>().is_err());
         })

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -16,7 +16,10 @@
 //! chrono = "0.4"
 // workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
 #![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"chrono\"] }")))]
-#![cfg_attr(not(docsrs), doc = "pyo3 = { version = \"*\", features = [\"chrono\"] }")]
+#![cfg_attr(
+    not(docsrs),
+    doc = "pyo3 = { version = \"*\", features = [\"chrono\"] }"
+)]
 //! ```
 //!
 //! Note that you must use compatible versions of chrono and PyO3.

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod anyhow;
 mod array;
-mod chrono;
+pub mod chrono;
 pub mod eyre;
 pub mod hashbrown;
 pub mod indexmap;

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod anyhow;
 mod array;
+mod chrono;
 pub mod eyre;
 pub mod hashbrown;
 pub mod indexmap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@
 //!
 //! The following features enable interactions with other crates in the Rust ecosystem:
 //! - [`anyhow`]: Enables a conversion from [anyhow]’s [`Error`][anyhow_error] type to [`PyErr`].
+//! - [`chrono`]: Enables a conversion from [chrono]'s structures to the equivalent Python ones.
 //! - [`eyre`]: Enables a conversion from [eyre]’s [`Report`] type to [`PyErr`].
 //! - [`hashbrown`]: Enables conversions between Python objects and [hashbrown]'s [`HashMap`] and
 //! [`HashSet`] types.

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -473,7 +473,7 @@ impl PyTzInfoAccess for PyTime {
 /// For concrete time zone implementations, see [`timezone_utc`] and
 /// the [`zoneinfo` module](https://docs.python.org/3/library/zoneinfo.html).
 #[repr(transparent)]
-pub struct PyTzInfo(pub(crate) PyAny);
+pub struct PyTzInfo(PyAny);
 pyobject_native_type!(
     PyTzInfo,
     crate::ffi::PyObject,
@@ -486,39 +486,6 @@ pyobject_native_type!(
 pub fn timezone_utc(py: Python<'_>) -> &PyTzInfo {
     unsafe { &*(ensure_datetime_api(py).TimeZone_UTC as *const PyTzInfo) }
 }
-
-/// Equivalent to `datetime.timezone`
-// Not making this public yet as the implementation is slightly different from
-// original cpython.
-// #[crate::pyclass]
-// pub(crate) struct PyTimeZone {
-//     offset: PyDelta,
-//     // name
-// }
-//
-// #[crate::pymethods]
-// impl PyTimeZone {
-//     #[new]
-//     fn new(offset: PyDelta) -> Self {
-//         PyTimeZone { offset }
-//     }
-//
-//     fn utcoffset(&self, dt: &PyDateTime) -> PyDelta {
-//         self.offset
-//     }
-//
-//     fn tzname(&self, dt: &PyDateTime) -> PyString {
-//         todo!("_name_from_offset")
-//     }
-//
-//     fn dst(&self, py: Python<'_>, dt: &PyDateTime) {
-//         py.None()
-//     }
-//
-//     fn fromutc(&self, dt: &PyDateTime) -> PyDelta {
-//         dt.get_tzinfo() + self.offset
-//     }
-// }
 
 /// Bindings for `datetime.timedelta`
 #[repr(transparent)]

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -473,7 +473,7 @@ impl PyTzInfoAccess for PyTime {
 /// For concrete time zone implementations, see [`timezone_utc`] and
 /// the [`zoneinfo` module](https://docs.python.org/3/library/zoneinfo.html).
 #[repr(transparent)]
-pub struct PyTzInfo(PyAny);
+pub struct PyTzInfo(pub(crate) PyAny);
 pyobject_native_type!(
     PyTzInfo,
     crate::ffi::PyObject,
@@ -486,6 +486,39 @@ pyobject_native_type!(
 pub fn timezone_utc(py: Python<'_>) -> &PyTzInfo {
     unsafe { &*(ensure_datetime_api(py).TimeZone_UTC as *const PyTzInfo) }
 }
+
+/// Equivalent to `datetime.timezone`
+// Not making this public yet as the implementation is slightly different from
+// original cpython.
+// #[crate::pyclass]
+// pub(crate) struct PyTimeZone {
+//     offset: PyDelta,
+//     // name
+// }
+//
+// #[crate::pymethods]
+// impl PyTimeZone {
+//     #[new]
+//     fn new(offset: PyDelta) -> Self {
+//         PyTimeZone { offset }
+//     }
+//
+//     fn utcoffset(&self, dt: &PyDateTime) -> PyDelta {
+//         self.offset
+//     }
+//
+//     fn tzname(&self, dt: &PyDateTime) -> PyString {
+//         todo!("_name_from_offset")
+//     }
+//
+//     fn dst(&self, py: Python<'_>, dt: &PyDateTime) {
+//         py.None()
+//     }
+//
+//     fn fromutc(&self, dt: &PyDateTime) -> PyDelta {
+//         dt.get_tzinfo() + self.offset
+//     }
+// }
 
 /// Bindings for `datetime.timedelta`
 #[repr(transparent)]


### PR DESCRIPTION
This PR adds the integration for chrono 0.4, and it supersedes https://github.com/PyO3/pyo3/pull/2604
Most of the work here was done by @pickfire , I just adapted it to work with the published version of chrono.

Here the list of PR that brought us here:
https://github.com/chronotope/chrono/pull/542
https://github.com/PyO3/pyo3/pull/2604
https://github.com/pickfire/pyo3/pull/1
https://github.com/chronotope/chrono/pull/812

Thanks to @pickfire for doing the hard work, and to @djc and @davidhewitt for the reviews and help during the whole process.

Closes #2604