### PR TITLE
docs: codeblock labels to `rust,ignore` format

### DIFF
--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -281,7 +281,7 @@ The example below shows:
   imported from `utils/foo.py`
 
 `src/main.rs`:
-```ignore
+```rust,ignore
 use pyo3::prelude::*;
 
 fn main() -> PyResult<()> {
@@ -311,7 +311,7 @@ from anywhere as long as your `app.py` is in the expected directory (in this exa
 that directory is `/usr/share/python_app`).
 
 `src/main.rs`:
-```no_run
+```rust,no_run
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 use std::fs;


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

### Issue
Styling code snippets with colors in `guide/src/python_from_rust.md`

### Changes
Update to `rust,modifier` format to add colors and maintain `no_run` and `ignore` 

