### PR TITLE
CHANGELOG: add link for unreleased changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ PyO3 versions, please see the [migration guide](https://pyo3.rs/latest/migration
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+To see unreleased changes, please see the [CHANGELOG on the main branch guide](https://pyo3.rs/main/changelog.html).
+
 <!-- towncrier release notes start -->
 
 ## [0.17.1] - 2022-08-28


### PR DESCRIPTION
After moving unreleased changes to `newsfragments` (for towncrier) I thought it'd be helpful to add a link to the CHANGELOG to see the unreleased changes.