### PR TITLE
ci: updates for cargo-llvm-cov 0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - run: python -m pip install -U pip nox
-      - run: cargo xtask coverage --output-lcov coverage.lcov
+      - run: nox -s coverage
       - uses: codecov/codecov-action@v2
         with:
           file: coverage.lcov

--- a/xtask/src/llvm_cov.rs
+++ b/xtask/src/llvm_cov.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, process::Command};
 pub fn run(opts: CoverageOpts) -> Result<()> {
     let env = get_coverage_env()?;
 
-    cli::run(llvm_cov_command(&["clean", "--workspace"]).envs(&env))?;
+    cli::run(llvm_cov_command(&["clean"]).envs(&env))?;
 
     cli::run(
         Command::new("cargo")
@@ -46,7 +46,7 @@ pub fn run(opts: CoverageOpts) -> Result<()> {
     crate::pytests::run(&env)?;
 
     cli::run(
-        llvm_cov_command(&["--no-run", "--lcov", "--output-path", &opts.output_lcov]).envs(&env),
+        llvm_cov_command(&["report", "--lcov", "--output-path", &opts.output_lcov]).envs(&env),
     )?;
 
     Ok(())


### PR DESCRIPTION
I think the Windows error in #2617 might be because `xtask` binary is running from the directory which `cargo llvm-cov clean` is trying to remove, so as an experiment am trying moving the `coverage` job to `nox` here: