### PR TITLE
RFC: Fix #2615 by relaxing the type check in extract_sequence.

### DIFF
--- a/pytests/noxfile.py
+++ b/pytests/noxfile.py
@@ -1,4 +1,5 @@
 import nox
+import platform
 
 nox.options.sessions = ["test"]
 
@@ -6,6 +7,8 @@ nox.options.sessions = ["test"]
 @nox.session
 def test(session):
     session.install("-rrequirements-dev.txt")
+    if platform.system() == "Linux" and platform.python_implementation() == "CPython":
+        session.install("numpy>=1.16")
     session.install("maturin")
     session.run_always("maturin", "develop")
     session.run("pytest")

--- a/pytests/src/lib.rs
+++ b/pytests/src/lib.rs
@@ -11,6 +11,7 @@ pub mod othermod;
 pub mod path;
 pub mod pyclasses;
 pub mod pyfunctions;
+pub mod sequence;
 pub mod subclassing;
 
 #[pymodule]
@@ -26,6 +27,7 @@ fn pyo3_pytests(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pymodule!(path::path))?;
     m.add_wrapped(wrap_pymodule!(pyclasses::pyclasses))?;
     m.add_wrapped(wrap_pymodule!(pyfunctions::pyfunctions))?;
+    m.add_wrapped(wrap_pymodule!(sequence::sequence))?;
     m.add_wrapped(wrap_pymodule!(subclassing::subclassing))?;
 
     // Inserting to sys.modules allows importing submodules nicely from Python
@@ -42,6 +44,7 @@ fn pyo3_pytests(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     sys_modules.set_item("pyo3_pytests.path", m.getattr("path")?)?;
     sys_modules.set_item("pyo3_pytests.pyclasses", m.getattr("pyclasses")?)?;
     sys_modules.set_item("pyo3_pytests.pyfunctions", m.getattr("pyfunctions")?)?;
+    sys_modules.set_item("pyo3_pytests.sequence", m.getattr("sequence")?)?;
     sys_modules.set_item("pyo3_pytests.subclassing", m.getattr("subclassing")?)?;
 
     Ok(())

--- a/pytests/src/sequence.rs
+++ b/pytests/src/sequence.rs
@@ -1,0 +1,19 @@
+use pyo3::prelude::*;
+use pyo3::types::PyString;
+
+#[pyfunction]
+fn vec_to_vec_i32(vec: Vec<i32>) -> Vec<i32> {
+    vec
+}
+
+#[pyfunction]
+fn vec_to_vec_pystring(vec: Vec<&PyString>) -> Vec<&PyString> {
+    vec
+}
+
+#[pymodule]
+pub fn sequence(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(vec_to_vec_i32, m)?)?;
+    m.add_function(wrap_pyfunction!(vec_to_vec_pystring, m)?)?;
+    Ok(())
+}

--- a/pytests/tests/test_sequence.py
+++ b/pytests/tests/test_sequence.py
@@ -1,0 +1,31 @@
+import pytest
+import platform
+
+from pyo3_pytests import sequence
+
+
+def test_vec_from_list_i32():
+    assert sequence.vec_to_vec_i32([1, 2, 3]) == [1, 2, 3]
+
+
+def test_vec_from_list_pystring():
+    assert sequence.vec_to_vec_pystring(["1", "2", "3"]) == ["1", "2", "3"]
+
+
+def test_vec_from_bytes():
+    assert sequence.vec_to_vec_i32(b"123") == [49, 50, 51]
+
+
+def test_vec_from_str():
+    with pytest.raises(ValueError):
+        sequence.vec_to_vec_pystring("123")
+
+
+@pytest.mark.skipif(
+    platform.system() != "Linux" or platform.python_implementation() != "CPython",
+    reason="Binary NumPy wheels are not available for all platforms and Python implementations",
+)
+def test_vec_from_array():
+    import numpy
+
+    assert sequence.vec_to_vec_i32(numpy.array([1, 2, 3])) == [1, 2, 3]

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -299,7 +299,16 @@ fn extract_sequence<'s, T>(obj: &'s PyAny) -> PyResult<Vec<T>>
 where
     T: FromPyObject<'s>,
 {
-    let seq = <PySequence as PyTryFrom>::try_from(obj)?;
+    // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
+    // to support this function and if not, we will only fail extraction safely.
+    let seq = unsafe {
+        if ffi::PySequence_Check(obj.as_ptr()) != 0 {
+            <PySequence as PyTryFrom>::try_from_unchecked(obj)
+        } else {
+            return Err(PyDowncastError::new(obj, "Sequence").into());
+        }
+    };
+
     let mut v = Vec::with_capacity(seq.len().unwrap_or(0) as usize);
     for item in seq.iter()? {
         v.push(item?.extract::<T>()?);

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -299,18 +299,9 @@ fn extract_sequence<'s, T>(obj: &'s PyAny) -> PyResult<Vec<T>>
 where
     T: FromPyObject<'s>,
 {
-    // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
-    // to support this function and if not, we will only fail extraction safely.
-    let seq = unsafe {
-        if ffi::PySequence_Check(obj.as_ptr()) != 0 {
-            <PySequence as PyTryFrom>::try_from_unchecked(obj)
-        } else {
-            return Err(PyDowncastError::new(obj, "Sequence").into());
-        }
-    };
-
-    let mut v = Vec::with_capacity(seq.len().unwrap_or(0) as usize);
-    for item in seq.iter()? {
+    let iter = obj.iter()?;
+    let mut v = Vec::with_capacity(obj.len().unwrap_or(0) as usize);
+    for item in iter {
         v.push(item?.extract::<T>()?);
     }
     Ok(v)


### PR DESCRIPTION
I am somewhat at a loss on how to properly test this without adding NumPy as a Python-side dependency and would be grateful for any advice here? (Maybe writing a custom Python class that implements only `PySequence_Length` and `PySequence_Length` and `PyObject_GetIter`?)

I am also not sure whether `PyMapping` needs a similar treatment but the conversions for `HashMap` seem to go through `PyDict` instead?