### PR TITLE
Some improvements to __richcmp__ on enums

### DIFF
--- a/newsfragments/2622.fixed.md
+++ b/newsfragments/2622.fixed.md
@@ -1,0 +1,1 @@
+Correctly implement `__richcmp__` for enums, fixing `__ne__` returning always returning `True`.

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -52,23 +52,23 @@ fn test_enum_arg() {
 }
 
 #[test]
-fn test_enum_eq() {
+fn test_enum_eq_enum() {
     Python::with_gil(|py| {
         let var1 = Py::new(py, MyEnum::Variant).unwrap();
         let var2 = Py::new(py, MyEnum::Variant).unwrap();
         let other_var = Py::new(py, MyEnum::OtherVariant).unwrap();
         py_assert!(py, var1 var2, "var1 == var2");
         py_assert!(py, var1 other_var, "var1 != other_var");
+        py_assert!(py, var1 var2, "(var1 != var2) == False");
     })
 }
 
 #[test]
-fn test_default_repr_correct() {
+fn test_enum_eq_incomparable() {
     Python::with_gil(|py| {
         let var1 = Py::new(py, MyEnum::Variant).unwrap();
-        let var2 = Py::new(py, MyEnum::OtherVariant).unwrap();
-        py_assert!(py, var1, "repr(var1) == 'MyEnum.Variant'");
-        py_assert!(py, var2, "repr(var2) == 'MyEnum.OtherVariant'");
+        py_assert!(py, var1, "(var1 == 'foo') == False");
+        py_assert!(py, var1, "(var1 != 'foo') == True");
     })
 }
 


### PR DESCRIPTION
 - Implement `__ne__` as well as `__eq__`. Fixes #2618.
 - Return NotImplemented when types cannot be converted, rather than throwing.
 - Compare the integer ids inside the __eq__/__ne__ implementation. Previously a match block was generated - this is now closer to what `#[derive(PartialEq)]` would generate.