### PR TITLE
pyfunction: fix compile error for Option<&T> argument with a default

### DIFF
--- a/newsfragments/2630.fixed.md
+++ b/newsfragments/2630.fixed.md
@@ -1,0 +1,1 @@
+Fix compile error since 0.17.0 with `Option<&SomePyClass>` argument with a default.


### PR DESCRIPTION
This fixes an edge case broken by #2503 which was lacking a test case.

The problematic code is `Option<&T>` argument to a `#[pyfunction]` where the argument has a default set via attribute, e.g.

```rust
#[pyfunction(arg = "None")]
fn foo(arg: Option<&SomePyClass>) { /* ... */ }
```

Noticed this in https://github.com/huggingface/tokenizers/pull/1066