### PR TITLE
Further relax extract_sequence for the upcoming release 0.18

### DIFF
--- a/newsfragments/2632.changed.md
+++ b/newsfragments/2632.changed.md
@@ -1,0 +1,11 @@
+`impl FromPyObject for Vec<T>` will accept any Python object that can be turned into an iterator via Python's built-in `iter` function. It will also not reject `str` anymore which can be iterated as a sequence of `str` objects, i.e. [#2500](https://github.com/PyO3/pyo3/pull/2500) was reverted. Please use a type like
+
+```rust
+#[derive(FromPyObject)]
+pub enum OneOrMany<'py> {
+    One(&'py PyString),
+    Many(Vec<&'py PyString>),
+}
+```
+
+if you would like to work around this edge case for callers of your API.

--- a/pytests/tests/test_sequence.py
+++ b/pytests/tests/test_sequence.py
@@ -17,8 +17,7 @@ def test_vec_from_bytes():
 
 
 def test_vec_from_str():
-    with pytest.raises(TypeError):
-        sequence.vec_to_vec_pystring("123")
+    assert sequence.vec_to_vec_pystring("123") == ["1", "2", "3"]
 
 
 @pytest.mark.skipif(

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -299,18 +299,9 @@ fn extract_sequence<'s, T>(obj: &'s PyAny) -> PyResult<Vec<T>>
 where
     T: FromPyObject<'s>,
 {
-    // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
-    // to support this function and if not, we will only fail extraction safely.
-    let seq = unsafe {
-        if ffi::PySequence_Check(obj.as_ptr()) != 0 {
-            <PySequence as PyTryFrom>::try_from_unchecked(obj)
-        } else {
-            return Err(PyDowncastError::new(obj, "Sequence").into());
-        }
-    };
-
-    let mut v = Vec::with_capacity(seq.len().unwrap_or(0));
-    for item in seq.iter()? {
+    let iter = obj.iter()?;
+    let mut v = Vec::with_capacity(obj.len().unwrap_or(0));
+    for item in iter {
         v.push(item?.extract::<T>()?);
     }
     Ok(v)


### PR DESCRIPTION
These are the two ~~less~~ more controversial parts, i.e. turning anything that can be iterated into a `Vec` whether it calls itself a sequence or not and also accepting `str` where the changelog entry gives a concrete hint on how to handle the `str`-as-`Vec<String>` edge case ergonomically as is common in Python API.