### PR TITLE
docs: fixed typo in error_handling.md

### DIFF
--- a/guide/src/function/error_handling.md
+++ b/guide/src/function/error_handling.md
@@ -194,7 +194,7 @@ struct MyOtherError(OtherError);
 
 impl From<MyOtherError> for PyErr {
     fn from(error: MyOtherError) -> Self {
-        PyValueError::new_err(self.0.message())
+        PyValueError::new_err(error.0.message())
     }
 }
 


### PR DESCRIPTION
the sample code currently produces this error:
```
15 |     fn from(error: MyOtherError) -> Self {
   |        ---- this function doesn't have a `self` parameter
16 |         PyValueError::new_err(self.0.message())
   |                               ^^^^ `self` value is a keyword only available in methods with a `self` parameter
```