### PR TITLE
docs: Fix pyo3-build-config dependency advice in guide

### DIFF
--- a/guide/src/building_and_distribution/multiple_python_versions.md
+++ b/guide/src/building_and_distribution/multiple_python_versions.md
@@ -31,11 +31,11 @@ To see a full reference of all the `#[cfg]` flags provided, see the [`pyo3-build
 
 You can use the `#[cfg]` flags in just two steps:
 
-1. Add `pyo3-build-config` it to your crate's build dependencies in `Cargo.toml`:
+1. Add `pyo3-build-config` with the [`resolve-config`](../features.md#resolve-config) feature enabled to your crate's build dependencies in `Cargo.toml`:
 
    ```toml
    [build-dependencies]
-   pyo3-build-config = { {{#PYO3_CRATE_VERSION}} }
+   pyo3-build-config = { {{#PYO3_CRATE_VERSION}}, features = ["resolve-config"] }
    ```
 
 2. Add a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html) file to your crate with the following contents:

--- a/guide/src/building_and_distribution/multiple_python_versions.md
+++ b/guide/src/building_and_distribution/multiple_python_versions.md
@@ -35,7 +35,7 @@ You can use the `#[cfg]` flags in just two steps:
 
    ```toml
    [build-dependencies]
-   pyo3-build-config = "{{#PYO3_CRATE_VERSION}}"
+   pyo3-build-config = { {{#PYO3_CRATE_VERSION}} }
    ```
 
 2. Add a [`build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html) file to your crate with the following contents:


### PR DESCRIPTION
Two things are wrong with the [guide's advice on how to get `#[cfg]` flags from `pyo3-build-config`](https://pyo3.rs/v0.17.1/building_and_distribution/multiple_python_versions.html#using-pyo3-build-config):

1. The dependency's `version = ...` specification to be put in `Cargo.toml` is enclosed in double quotes instead of curly braces.
2. Since https://github.com/PyO3/pyo3/pull/1856, [`use_pyo3_cfgs()` is only available if the `resolve-config` feature is enabled](https://github.com/PyO3/pyo3/blob/86ce4d1a137d6d62df84c7be2935078e08e46750/pyo3-build-config/src/lib.rs#L45), which isn't mentioned.

This PR fixes both of these.