### PR TITLE
docs: Fix links to ToPyObject in PyLong and PyFloat docs

### DIFF
--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -11,7 +11,7 @@ use std::os::raw::c_double;
 ///
 /// You can usually avoid directly working with this type
 /// by using [`ToPyObject`](crate::conversion::ToPyObject)
-/// and [extract](struct.PyAny.html#method.extract)
+/// and [`extract`](PyAny::extract)
 /// with `f32`/`f64`.
 #[repr(transparent)]
 pub struct PyFloat(PyAny);

--- a/src/types/floatob.rs
+++ b/src/types/floatob.rs
@@ -10,7 +10,7 @@ use std::os::raw::c_double;
 /// Represents a Python `float` object.
 ///
 /// You can usually avoid directly working with this type
-/// by using [`ToPyObject`](trait.ToPyObject.html)
+/// by using [`ToPyObject`](crate::conversion::ToPyObject)
 /// and [extract](struct.PyAny.html#method.extract)
 /// with `f32`/`f64`.
 #[repr(transparent)]

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -46,7 +46,7 @@ macro_rules! int_fits_larger_int {
 /// Represents a Python `int` object.
 ///
 /// You can usually avoid directly working with this type
-/// by using [`ToPyObject`](trait.ToPyObject.html)
+/// by using [`ToPyObject`](crate::conversion::ToPyObject)
 /// and [extract](struct.PyAny.html#method.extract)
 /// with the primitive Rust integer types.
 #[repr(transparent)]

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -47,7 +47,7 @@ macro_rules! int_fits_larger_int {
 ///
 /// You can usually avoid directly working with this type
 /// by using [`ToPyObject`](crate::conversion::ToPyObject)
-/// and [extract](struct.PyAny.html#method.extract)
+/// and [`extract`](PyAny::extract)
 /// with the primitive Rust integer types.
 #[repr(transparent)]
 pub struct PyLong(PyAny);


### PR DESCRIPTION
Links to `ToPyObject` are broken in the [`PyLong`](https://docs.rs/pyo3/latest/pyo3/types/struct.PyLong.html) and [`PyFloat`](https://docs.rs/pyo3/latest/pyo3/types/struct.PyFloat.html) docs. This PR fixes them.