### PR TITLE
add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+title: PyO3
+message: >-
+  If you use this software as part of a publication and wish to cite
+  it, please use the metadata from this file.
+type: software
+authors:
+  - name: PyO3 Project and Contributors
+    website: https://github.com/PyO3
+license: Apache-2.0


### PR DESCRIPTION
I was asked in a DM in Gitter how to cite PyO3 today, and I thought it might be helpful to add a `CITATION.cff` file which [GitHub appears to have native support for](https://citation-file-format.github.io).