### PR TITLE
[experimental] make better errors

### DIFF
--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -172,7 +172,7 @@ impl SelfType {
                 quote_spanned! { *span =>
                     let _cell = #cell;
                     #[allow(clippy::useless_conversion)]  // In case _slf is PyCell<Self>
-                    let _slf = ::std::convert::TryFrom::try_from(_cell)?;
+                    let _slf = _pyo3::pycell::Receiver::receive(_cell)?;
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![warn(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(auto_traits, negative_impls))]
+#![cfg_attr(feature = "nightly", feature(auto_traits))]
+#![cfg_attr(better_errors, feature(rustc_attrs))] // for rustc_on_unimplemented
+#![cfg_attr(any(better_errors, feature = "nightly"), feature(negative_impls))]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(
     docsrs, // rustdoc:: is not supported on msrv

--- a/tests/ui/invalid_frompy_derive.stderr
+++ b/tests/ui/invalid_frompy_derive.stderr
@@ -130,7 +130,7 @@ error: only one of `attribute` or `item` can be provided
    --> tests/ui/invalid_frompy_derive.rs:118:5
     |
 118 |     #[pyo3(item, attribute)]
-    |     ^
+    |     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected one of: `transparent`, `annotation`, `crate`
    --> tests/ui/invalid_frompy_derive.rs:123:8
@@ -154,13 +154,15 @@ error: FromPyObject can be derived with at most one lifetime parameter
    --> tests/ui/invalid_frompy_derive.rs:141:22
     |
 141 | enum TooManyLifetimes<'a, 'b> {
-    |                      ^
+    |                      ^^^^^^^^
 
 error: #[derive(FromPyObject)] is not supported for unions
    --> tests/ui/invalid_frompy_derive.rs:147:1
     |
-147 | union Union {
-    | ^^^^^
+147 | / union Union {
+148 | |     a: usize,
+149 | | }
+    | |_^
 
 error: cannot derive FromPyObject for empty structs and variants
    --> tests/ui/invalid_frompy_derive.rs:151:10
@@ -186,7 +188,7 @@ error: `getter` is not permitted on tuple struct elements.
    --> tests/ui/invalid_frompy_derive.rs:169:27
     |
 169 | struct InvalidTupleGetter(#[pyo3(item("foo"))] String);
-    |                           ^
+    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `transparent` structs may not have a `getter` for the inner field
    --> tests/ui/invalid_frompy_derive.rs:175:5

--- a/tests/ui/invalid_frozen_pyclass_borrow.stderr
+++ b/tests/ui/invalid_frozen_pyclass_borrow.stderr
@@ -1,8 +1,10 @@
 error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`
-   --> tests/ui/invalid_frozen_pyclass_borrow.rs:10:33
+   --> tests/ui/invalid_frozen_pyclass_borrow.rs:10:18
     |
 10  |     let borrow = foo.as_ref(py).borrow_mut();
-    |                                 ^^^^^^^^^^ expected struct `False`, found struct `True`
+    |                  ^^^^^^^^^^^^^^ ---------- required by a bound introduced by this call
+    |                  |
+    |                  expected struct `False`, found struct `True`
     |
 note: required by a bound in `PyCell::<T>::borrow_mut`
    --> src/pycell.rs
@@ -11,10 +13,12 @@ note: required by a bound in `PyCell::<T>::borrow_mut`
     |                    ^^^^^^^^^^^^^^ required by this bound in `PyCell::<T>::borrow_mut`
 
 error[E0271]: type mismatch resolving `<ImmutableChild as PyClass>::Frozen == False`
-   --> tests/ui/invalid_frozen_pyclass_borrow.rs:20:35
+   --> tests/ui/invalid_frozen_pyclass_borrow.rs:20:18
     |
 20  |     let borrow = child.as_ref(py).borrow_mut();
-    |                                   ^^^^^^^^^^ expected struct `False`, found struct `True`
+    |                  ^^^^^^^^^^^^^^^^ ---------- required by a bound introduced by this call
+    |                  |
+    |                  expected struct `False`, found struct `True`
     |
 note: required by a bound in `PyCell::<T>::borrow_mut`
    --> src/pycell.rs

--- a/tests/ui/invalid_macro_args.stderr
+++ b/tests/ui/invalid_macro_args.stderr
@@ -8,7 +8,7 @@ error: keyword argument or kwargs(**) is not allowed after kwargs(**)
  --> tests/ui/invalid_macro_args.rs:8:29
   |
 8 | #[pyfunction(kwargs = "**", a = 5)]
-  |                             ^
+  |                             ^^^^^
 
 error: / is not allowed after /, varargs(*), or kwargs(**)
   --> tests/ui/invalid_macro_args.rs:13:25

--- a/tests/ui/invalid_need_module_arg_position.stderr
+++ b/tests/ui/invalid_need_module_arg_position.stderr
@@ -2,4 +2,4 @@ error: expected &PyModule as first argument with `pass_module`
  --> tests/ui/invalid_need_module_arg_position.rs:6:21
   |
 6 |     fn fail(string: &str, module: &PyModule) -> PyResult<&str> {
-  |                     ^
+  |                     ^^^^

--- a/tests/ui/invalid_property_args.stderr
+++ b/tests/ui/invalid_property_args.stderr
@@ -38,10 +38,10 @@ error: `name` may only be specified once
   --> tests/ui/invalid_property_args.rs:37:42
    |
 37 | struct MultipleName(#[pyo3(name = "foo", name = "bar")] i32);
-   |                                          ^^^^
+   |                                          ^^^^^^^^^^^^
 
 error: `name` is useless without `get` or `set`
   --> tests/ui/invalid_property_args.rs:40:33
    |
 40 | struct NameWithoutGetSet(#[pyo3(name = "value")] i32);
-   |                                 ^^^^
+   |                                 ^^^^^^^^^^^^^^

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -8,7 +8,7 @@ error: enums can't extend from other classes
  --> tests/ui/invalid_pyclass_enum.rs:9:11
   |
 9 | #[pyclass(extends = PyList)]
-  |           ^^^^^^^
+  |           ^^^^^^^^^^^^^^^^
 
 error: #[pyclass] can't be used on enums without any variants
   --> tests/ui/invalid_pyclass_enum.rs:16:18

--- a/tests/ui/invalid_pyfunctions.stderr
+++ b/tests/ui/invalid_pyfunctions.stderr
@@ -8,7 +8,7 @@ error: Python functions cannot have `impl Trait` arguments
  --> tests/ui/invalid_pyfunctions.rs:7:36
   |
 7 | fn impl_trait_function(impl_trait: impl AsRef<PyAny>) {}
-  |                                    ^^^^
+  |                                    ^^^^^^^^^^^^^^^^^
 
 error: `async fn` is not yet supported for Python functions.
 

--- a/tests/ui/invalid_pymethod_names.stderr
+++ b/tests/ui/invalid_pymethod_names.stderr
@@ -8,7 +8,7 @@ error: `name` may only be specified once
   --> tests/ui/invalid_pymethod_names.rs:18:12
    |
 18 |     #[pyo3(name = "bar")]
-   |            ^^^^
+   |            ^^^^^^^^^^^^
 
 error: `name` not allowed with `#[new]`
   --> tests/ui/invalid_pymethod_names.rs:24:19

--- a/tests/ui/invalid_pymethod_receiver.rs
+++ b/tests/ui/invalid_pymethod_receiver.rs
@@ -8,4 +8,12 @@ impl MyClass {
     fn method_with_invalid_self_type(slf: i32, py: Python<'_>, index: u32) {}
 }
 
+#[pyclass(frozen)]
+struct MyClass2 {}
+
+#[pymethods]
+impl MyClass2 {
+    fn method_with_invalid_self_type(&mut self, py: Python<'_>, index: u32) {}
+}
+
 fn main() {}

--- a/tests/ui/invalid_pymethod_receiver.stderr
+++ b/tests/ui/invalid_pymethod_receiver.stderr
@@ -1,18 +1,32 @@
-error[E0277]: the trait bound `i32: From<&PyCell<MyClass>>` is not satisfied
+error[E0277]: `i32` is not a valid receiver type for pyo3 methods
  --> tests/ui/invalid_pymethod_receiver.rs:8:43
   |
 8 |     fn method_with_invalid_self_type(slf: i32, py: Python<'_>, index: u32) {}
-  |                                           ^^^ the trait `From<&PyCell<MyClass>>` is not implemented for `i32`
+  |                                           ^^^ the trait `pyo3::pycell::Receiver<&PyCell<MyClass>>` is not implemented for `i32`
   |
-  = help: the following other types implement trait `From<T>`:
-            <f32 as From<i16>>
-            <f32 as From<i8>>
-            <f32 as From<u16>>
-            <f32 as From<u8>>
-            <f64 as From<f32>>
-            <f64 as From<i16>>
-            <f64 as From<i32>>
-            <f64 as From<i8>>
-          and 67 others
-  = note: required because of the requirements on the impl of `Into<i32>` for `&PyCell<MyClass>`
-  = note: required because of the requirements on the impl of `TryFrom<&PyCell<MyClass>>` for `i32`
+  = note: Only `&self`, `&mut self`, `&PyCell<Self>, `&PyRef<'_, Self> and `&PyRefMut<'_, Self> are valid receiver types
+  = help: the following other types implement trait `pyo3::pycell::Receiver<T>`:
+            &'a PyCell<T>
+            PyRef<'a, T>
+            PyRefMut<'a, T>
+
+error[E0271]: type mismatch resolving `<MyClass2 as PyClass>::Frozen == False`
+   --> tests/ui/invalid_pymethod_receiver.rs:14:1
+    |
+14  | #[pymethods]
+    | ^^^^^^^^^^^^ expected struct `False`, found struct `True`
+    |
+note: required by a bound in `PyCell::<T>::try_borrow_mut`
+   --> src/pycell.rs
+    |
+    |         T: PyClass<Frozen = False>,
+    |                    ^^^^^^^^^^^^^^ required by this bound in `PyCell::<T>::try_borrow_mut`
+    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0614]: type `PyRefMut<'_, MyClass2>` cannot be dereferenced
+  --> tests/ui/invalid_pymethod_receiver.rs:14:1
+   |
+14 | #[pymethods]
+   | ^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -8,31 +8,31 @@ error: `#[classattr]` does not take any arguments
   --> tests/ui/invalid_pymethods.rs:14:5
    |
 14 |     #[classattr(foobar)]
-   |     ^
+   |     ^^^^^^^^^^^^^^^^^^^^
 
 error: static method needs #[staticmethod] attribute
   --> tests/ui/invalid_pymethods.rs:20:5
    |
 20 |     fn staticmethod_without_attribute() {}
-   |     ^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: unexpected receiver
   --> tests/ui/invalid_pymethods.rs:26:35
    |
 26 |     fn staticmethod_with_receiver(&self) {}
-   |                                   ^
+   |                                   ^^^^^
 
 error: expected receiver for #[getter]
   --> tests/ui/invalid_pymethods.rs:39:5
    |
 39 |     fn getter_without_receiver() {}
-   |     ^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: expected receiver for #[setter]
   --> tests/ui/invalid_pymethods.rs:45:5
    |
 45 |     fn setter_without_receiver() {}
-   |     ^^
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: text_signature not allowed on __new__; if you want to add a signature on __new__, put it on the struct definition instead
   --> tests/ui/invalid_pymethods.rs:51:12
@@ -80,13 +80,13 @@ error: Python functions cannot have `impl Trait` arguments
   --> tests/ui/invalid_pymethods.rs:97:48
    |
 97 |     fn impl_trait_method_first_arg(impl_trait: impl AsRef<PyAny>) {}
-   |                                                ^^^^
+   |                                                ^^^^^^^^^^^^^^^^^
 
 error: Python functions cannot have `impl Trait` arguments
    --> tests/ui/invalid_pymethods.rs:102:56
     |
 102 |     fn impl_trait_method_second_arg(&self, impl_trait: impl AsRef<PyAny>) {}
-    |                                                        ^^^^
+    |                                                        ^^^^^^^^^^^^^^^^^
 
 error: `async fn` is not yet supported for Python functions.
 

--- a/tests/ui/not_send.stderr
+++ b/tests/ui/not_send.stderr
@@ -1,22 +1,19 @@
-error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safely
-   --> tests/ui/not_send.rs:4:8
+error[E0277]: `pyo3::Python<'_>` cannot be shared between threads safely
+   --> tests/ui/not_send.rs:4:22
     |
 4   |     py.allow_threads(|| { drop(py); });
-    |        ^^^^^^^^^^^^^ `*mut pyo3::Python<'static>` cannot be shared between threads safely
+    |        ------------- ^^^^^^^^^^^^^^^^ `pyo3::Python<'_>` cannot be shared between threads safely
+    |        |
+    |        required by a bound introduced by this call
     |
-    = help: within `pyo3::Python<'_>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
-    = note: required because it appears within the type `PhantomData<*mut pyo3::Python<'static>>`
-    = note: required because it appears within the type `impl_::not_send::NotSend`
-    = note: required because it appears within the type `(&GILGuard, impl_::not_send::NotSend)`
-    = note: required because it appears within the type `PhantomData<(&GILGuard, impl_::not_send::NotSend)>`
-    = note: required because it appears within the type `pyo3::Python<'_>`
-    = note: required because of the requirements on the impl of `Send` for `&pyo3::Python<'_>`
+    = help: the trait `Sync` is not implemented for `pyo3::Python<'_>`
+    = note: required for `&pyo3::Python<'_>` to implement `Send`
 note: required because it's used within this closure
    --> tests/ui/not_send.rs:4:22
     |
 4   |     py.allow_threads(|| { drop(py); });
     |                      ^^
-    = note: required because of the requirements on the impl of `Ungil` for `[closure@$DIR/tests/ui/not_send.rs:4:22: 4:24]`
+    = note: required for `[closure@$DIR/tests/ui/not_send.rs:4:22: 4:24]` to implement `Ungil`
 note: required by a bound in `pyo3::Python::<'py>::allow_threads`
    --> src/marker.rs
     |

--- a/tests/ui/not_send2.stderr
+++ b/tests/ui/not_send2.stderr
@@ -1,20 +1,23 @@
-error[E0277]: `UnsafeCell<PyObject>` cannot be shared between threads safely
-   --> tests/ui/not_send2.rs:8:12
+error[E0277]: `PyString` cannot be shared between threads safely
+   --> tests/ui/not_send2.rs:8:26
     |
-8   |         py.allow_threads(|| {
-    |            ^^^^^^^^^^^^^ `UnsafeCell<PyObject>` cannot be shared between threads safely
+8   |           py.allow_threads(|| {
+    |  ____________-------------_^
+    | |            |
+    | |            required by a bound introduced by this call
+9   | |             println!("{:?}", string);
+10  | |         });
+    | |_________^ `PyString` cannot be shared between threads safely
     |
-    = help: within `&PyString`, the trait `Sync` is not implemented for `UnsafeCell<PyObject>`
-    = note: required because it appears within the type `PyAny`
-    = note: required because it appears within the type `PyString`
+    = help: within `&PyString`, the trait `Sync` is not implemented for `PyString`
     = note: required because it appears within the type `&PyString`
-    = note: required because of the requirements on the impl of `Send` for `&&PyString`
+    = note: required for `&&PyString` to implement `Send`
 note: required because it's used within this closure
    --> tests/ui/not_send2.rs:8:26
     |
 8   |         py.allow_threads(|| {
     |                          ^^
-    = note: required because of the requirements on the impl of `Ungil` for `[closure@$DIR/tests/ui/not_send2.rs:8:26: 8:28]`
+    = note: required for `[closure@$DIR/tests/ui/not_send2.rs:8:26: 8:28]` to implement `Ungil`
 note: required by a bound in `pyo3::Python::<'py>::allow_threads`
    --> src/marker.rs
     |

--- a/tests/ui/not_send3.stderr
+++ b/tests/ui/not_send3.stderr
@@ -1,17 +1,22 @@
 error[E0277]: `Rc<i32>` cannot be shared between threads safely
-   --> tests/ui/not_send3.rs:8:12
+   --> tests/ui/not_send3.rs:8:26
     |
-8   |         py.allow_threads(|| {
-    |            ^^^^^^^^^^^^^ `Rc<i32>` cannot be shared between threads safely
+8   |           py.allow_threads(|| {
+    |  ____________-------------_^
+    | |            |
+    | |            required by a bound introduced by this call
+9   | |             println!("{:?}", rc);
+10  | |         });
+    | |_________^ `Rc<i32>` cannot be shared between threads safely
     |
     = help: the trait `Sync` is not implemented for `Rc<i32>`
-    = note: required because of the requirements on the impl of `Send` for `&Rc<i32>`
+    = note: required for `&Rc<i32>` to implement `Send`
 note: required because it's used within this closure
    --> tests/ui/not_send3.rs:8:26
     |
 8   |         py.allow_threads(|| {
     |                          ^^
-    = note: required because of the requirements on the impl of `Ungil` for `[closure@$DIR/tests/ui/not_send3.rs:8:26: 8:28]`
+    = note: required for `[closure@$DIR/tests/ui/not_send3.rs:8:26: 8:28]` to implement `Ungil`
 note: required by a bound in `pyo3::Python::<'py>::allow_threads`
    --> src/marker.rs
     |

--- a/tests/ui/reject_generics.stderr
+++ b/tests/ui/reject_generics.stderr
@@ -2,7 +2,7 @@ error: #[pyclass] cannot have generic parameters. For an explanation, see https:
  --> tests/ui/reject_generics.rs:4:25
   |
 4 | struct ClassWithGenerics<A> {
-  |                         ^
+  |                         ^^^
 
 error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/latest/class.html#no-lifetime-parameters
  --> tests/ui/reject_generics.rs:9:27


### PR DESCRIPTION
This uses a clever hack to turn on `rustc_on_unimplemented` if available (this seems to be rather brittle, which is how I discovered it. So I'm not a fan of actually doing this).

Still, I'm sharing this to see and share how we can improve errors, and I'm also curious for any ideas you might have.


