### PR TITLE
Add `CI-skip-changelog` label automatically for dependabot github actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      # dependabot default labels
+      - "dependencies"
+      - "github-actions"
+      # additional labels
+      - "CI-skip-changelog"


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#setting-custom-labels