### PR TITLE
Also relax the PySequence check when extracting fixed-sized arrays.

### DIFF
--- a/newsfragments/2675.fixed.md
+++ b/newsfragments/2675.fixed.md
@@ -1,0 +1,1 @@
+Fix regression of `impl FromPyObject for [T; N]` no longer accepting types passing `PySequence_Check`, e.g. NumPy arrays, since version 0.17.0. This the same fix that was applied `impl FromPyObject for Vec<T>` in version 0.17.1 extended to fixed-size arrays.

--- a/pytests/src/sequence.rs
+++ b/pytests/src/sequence.rs
@@ -7,6 +7,11 @@ fn vec_to_vec_i32(vec: Vec<i32>) -> Vec<i32> {
 }
 
 #[pyfunction]
+fn array_to_array_i32(arr: [i32; 3]) -> [i32; 3] {
+    arr
+}
+
+#[pyfunction]
 fn vec_to_vec_pystring(vec: Vec<&PyString>) -> Vec<&PyString> {
     vec
 }
@@ -14,6 +19,7 @@ fn vec_to_vec_pystring(vec: Vec<&PyString>) -> Vec<&PyString> {
 #[pymodule]
 pub fn sequence(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(vec_to_vec_i32, m)?)?;
+    m.add_function(wrap_pyfunction!(array_to_array_i32, m)?)?;
     m.add_function(wrap_pyfunction!(vec_to_vec_pystring, m)?)?;
     Ok(())
 }

--- a/pytests/tests/test_sequence.py
+++ b/pytests/tests/test_sequence.py
@@ -29,3 +29,13 @@ def test_vec_from_array():
     import numpy
 
     assert sequence.vec_to_vec_i32(numpy.array([1, 2, 3])) == [1, 2, 3]
+
+
+@pytest.mark.skipif(
+    platform.system() != "Linux" or platform.python_implementation() != "CPython",
+    reason="Binary NumPy wheels are not available for all platforms and Python implementations",
+)
+def test_rust_array_from_array():
+    import numpy
+
+    assert sequence.array_to_array_i32(numpy.array([1, 2, 3])) == [1, 2, 3]

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -309,7 +309,7 @@ where
         }
     };
 
-    let mut v = Vec::with_capacity(seq.len().unwrap_or(0) as usize);
+    let mut v = Vec::with_capacity(seq.len().unwrap_or(0));
     for item in seq.iter()? {
         v.push(item?.extract::<T>()?);
     }


### PR DESCRIPTION
Closes #2674 