### PR TITLE
Use a TypeError, rather than a ValueError, when refusing to treat a str as a Vec

### DIFF
--- a/newsfragments/2685.changed.md
+++ b/newsfragments/2685.changed.md
@@ -1,0 +1,1 @@
+Use a TypeError, rather than a ValueError, when refusing to treat a str as a Vec

--- a/pytests/tests/test_sequence.py
+++ b/pytests/tests/test_sequence.py
@@ -17,7 +17,7 @@ def test_vec_from_bytes():
 
 
 def test_vec_from_str():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         sequence.vec_to_vec_pystring("123")
 
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 use crate::err::{self, PyDowncastError, PyErr, PyResult};
-use crate::exceptions::PyValueError;
+use crate::exceptions::PyTypeError;
 use crate::inspect::types::TypeInfo;
 use crate::internal_tricks::get_ssize_index;
 use crate::once_cell::GILOnceCell;
@@ -285,7 +285,7 @@ where
 {
     fn extract(obj: &'a PyAny) -> PyResult<Self> {
         if let Ok(true) = obj.is_instance_of::<PyString>() {
-            return Err(PyValueError::new_err("Can't extract `str` to `Vec`"));
+            return Err(PyTypeError::new_err("Can't extract `str` to `Vec`"));
         }
         extract_sequence(obj)
     }


### PR DESCRIPTION
This is far more consistent with how these exceptions are usually used
