### PR TITLE
Avoid calling slice::from_raw_parts with a null pointer

### DIFF
--- a/newsfragments/2687.fixed.md
+++ b/newsfragments/2687.fixed.md
@@ -1,0 +1,1 @@
+Fix UB in `FunctionDescription::extract_arguments_fastcall` due to creating slices from a null pointer.


### PR DESCRIPTION
`slice::from_raw_parts` requires that the pointer not be null, even if the length is zero. This is because the pointer is converted into a reference, and references must not be null. This is detected by the standard library debug assertions, which are compiled out in all released toolchains but you can use `cargo careful` if you want to enable them and some other nightly-only opt-in checks.

This is probably the third instance of this bug I've fixed, I think it's pretty common for C libraries to return a pointer and length, and it is very tempting to just convert that to a Rust slice. But unfortunately you need a null check.

I'm not really sure what to do about testing this. I feel like there should be CI to guard against making this mistake again, but I'm not sure how to jam `cargo careful` or `cargo +nightly test -Zbuild-std` into your xtask setup.