### PR TITLE
Support documentation when creating a python function from a closure.

### DIFF
--- a/newsfragments/2689.added.md
+++ b/newsfragments/2689.added.md
@@ -1,0 +1,1 @@
+Add a `new_closure_with_doc` function so that one can specify some documentation when wrapping a Rust closure.

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -448,6 +448,19 @@ fn test_closure_counter() {
 }
 
 #[test]
+fn test_closure_doc() {
+    Python::with_gil(|py| {
+        let py_fn = move |_args: &types::PyTuple,
+                          _kwargs: Option<&types::PyDict>|
+              -> PyResult<i32> { Ok(0) };
+        let py_fn = PyCFunction::new_closure_with_doc(py_fn, py, "some doc").unwrap();
+
+        py_assert!(py, py_fn, "py_fn() == 0");
+        py_assert!(py, py_fn, "py_fn.__doc__ == 'some doc'");
+    });
+}
+
+#[test]
 fn use_pyfunction() {
     mod function_in_module {
         use pyo3::prelude::*;


### PR DESCRIPTION
This adds a new function similar to `new_closure` but that lets the user specify the Python function documentation, this is not done by just adding an argument to `new_closure` so as to avoid breaking the current api but maybe would it be simpler to always require this argument.

A dedicated test has been added checking that the proper documentation can then be seen from the Python side.
