### PR TITLE
Stop leaking in `new_closure`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cfg-if = "1.0"
 libc = "0.2.62"
 parking_lot = ">= 0.11, < 0.13"
 memoffset = "0.6.5"
+memchr = "1"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
 pyo3-ffi = { path = "pyo3-ffi", version = "=0.17.2" }

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -158,7 +158,10 @@ impl PyTypeBuilder {
             }
             PyMethodDefType::Method(def)
             | PyMethodDefType::Class(def)
-            | PyMethodDefType::Static(def) => self.method_defs.push(def.as_method_def().unwrap()),
+            | PyMethodDefType::Static(def) => {
+                let (def, _destructor) = def.as_method_def().unwrap();
+                self.method_defs.push(def);
+            }
             // These class attributes are added after the type gets created by LazyStaticType
             PyMethodDefType::ClassAttribute(_) => {}
         }

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -2,7 +2,7 @@
 //! Python type object information
 
 use crate::impl_::pyclass::PyClassItemsIter;
-use crate::internal_tricks::extract_cstr_or_leak_cstring;
+use crate::internal_tricks::{extract_cstr_or_leak_cstring, MaybeLeaked};
 use crate::once_cell::GILOnceCell;
 use crate::pyclass::create_type_object;
 use crate::pyclass::PyClass;
@@ -221,7 +221,7 @@ impl LazyStaticType {
 fn initialize_tp_dict(
     py: Python<'_>,
     type_object: *mut ffi::PyObject,
-    items: Vec<(&'static std::ffi::CStr, PyObject)>,
+    items: Vec<(MaybeLeaked, PyObject)>,
 ) -> PyResult<()> {
     // We hold the GIL: the dictionary update can be considered atomic from
     // the POV of other threads.


### PR DESCRIPTION
Continues https://github.com/PyO3/pyo3/pull/2686#issuecomment-1279842232

Previously this leaked memory on every call:
```rust
use pyo3::prelude::*;
use pyo3::types::*;

fn main() {
    Python::with_gil(|_py| loop {
        let pool = unsafe { _py.new_pool() };
        let py = pool.python();
        let add_one = |args: &PyTuple, _kwargs: Option<&PyDict>| -> PyResult<_> {
            let i = args.extract::<(i64,)>()?.0;
            Ok(i + 1)
        };
        let closure = PyCFunction::new_closure(add_one, py).unwrap();
    });
}
```

Now it does no more:
- The `PyMethodDef` is cleaned up when the closure gets dropped
- Any Cstrings are deallocated if necessary


I am not sure what the best next step is. I'm leaning towards an api that takes `&'str` (and always allocates a CString) and another api taking `&'static CStr` that does not allocate cstrings.