### PR TITLE
introduce trampolines for methods

### DIFF
--- a/newsfragments/2705.changed.md
+++ b/newsfragments/2705.changed.md
@@ -1,0 +1,1 @@
+Change `#[pyfunction]` and `#[pymethods]` to use a common call "trampoline" to slightly reduce generated code size and compile times.

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -84,7 +84,7 @@ pub fn pymodule_impl(
             /// the module.
             #[export_name = #pyinit_symbol]
             pub unsafe extern "C" fn init() -> *mut #krate::ffi::PyObject {
-                DEF.module_init()
+                #krate::impl_::trampoline::module_init(|py| DEF.make_module(py))
             }
         }
 

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -5,14 +5,12 @@
 use crate::err::{PyErr, PyResult};
 use crate::exceptions::PyOverflowError;
 use crate::ffi::{self, Py_hash_t};
-use crate::impl_::panic::PanicTrap;
 use crate::panic::PanicException;
-use crate::{GILPool, IntoPyPointer};
+use crate::IntoPyPointer;
 use crate::{IntoPy, PyObject, Python};
 use std::any::Any;
+use std::isize;
 use std::os::raw::c_int;
-use std::panic::UnwindSafe;
-use std::{isize, panic};
 
 /// A type which can be the return type of a python C-API callback
 pub trait PyCallbackOutput: Copy {
@@ -186,73 +184,6 @@ where
     T: IntoPyCallbackOutput<U>,
 {
     value.convert(py)
-}
-
-/// Use this macro for all internal callback functions which Python will call.
-///
-/// It sets up the GILPool and converts the output into a Python object. It also restores
-/// any python error returned as an Err variant from the body.
-///
-/// Finally, any panics inside the callback body will be caught and translated into PanicExceptions.
-///
-/// # Safety
-/// This macro assumes the GIL is held. (It makes use of unsafe code, so usage of it is only
-/// possible inside unsafe blocks.)
-#[doc(hidden)]
-#[macro_export]
-macro_rules! callback_body {
-    ($py:ident, $body:expr) => {
-        $crate::callback::handle_panic(|$py| $crate::callback::convert($py, $body))
-    };
-}
-
-/// Variant of the above which does not perform the callback conversion. This allows the callback
-/// conversion to be done manually in the case where lifetimes might otherwise cause issue.
-///
-/// For example this pyfunction:
-///
-/// ```no_compile
-/// fn foo(&self) -> &Bar {
-///     &self.bar
-/// }
-/// ```
-///
-/// It is wrapped in proc macros with handle_panic like so:
-///
-/// ```no_compile
-/// pyo3::callback::handle_panic(|_py| {
-///     let _slf = #slf;
-///     pyo3::callback::convert(_py, #foo)
-/// })
-/// ```
-///
-/// If callback_body was used instead:
-///
-/// ```no_compile
-/// pyo3::callback_body!(py, {
-///     let _slf = #slf;
-///     #foo
-/// })
-/// ```
-///
-/// Then this will fail to compile, because the result of #foo borrows _slf, but _slf drops when
-/// the block passed to the macro ends.
-#[doc(hidden)]
-#[inline]
-pub unsafe fn handle_panic<F, R>(body: F) -> R
-where
-    F: for<'py> FnOnce(Python<'py>) -> PyResult<R> + UnwindSafe,
-    R: PyCallbackOutput,
-{
-    let trap = PanicTrap::new("uncaught panic at ffi boundary");
-    let pool = GILPool::new();
-    let py = pool.python();
-    let out = panic_result_into_callback_output(
-        py,
-        panic::catch_unwind(move || -> PyResult<_> { body(py) }),
-    );
-    trap.disarm();
-    out
 }
 
 /// Converts the output of std::panic::catch_unwind into a Python function output, either by raising a Python

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -17,3 +17,5 @@ pub mod pyclass;
 pub mod pyfunction;
 pub mod pymethods;
 pub mod pymodule;
+#[doc(hidden)]
+pub mod trampoline;

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -313,29 +313,24 @@ macro_rules! generate_pyclass_getattro_slot {
             _slf: *mut $crate::ffi::PyObject,
             attr: *mut $crate::ffi::PyObject,
         ) -> *mut $crate::ffi::PyObject {
-            use ::std::result::Result::*;
-            use $crate::impl_::pyclass::*;
-            let gil = $crate::GILPool::new();
-            let py = gil.python();
-            $crate::callback::panic_result_into_callback_output(
-                py,
-                ::std::panic::catch_unwind(move || -> $crate::PyResult<_> {
-                    let collector = PyClassImplCollector::<$cls>::new();
+            $crate::impl_::trampoline::getattrofunc(_slf, attr, |py, _slf, attr| {
+                use ::std::result::Result::*;
+                use $crate::impl_::pyclass::*;
+                let collector = PyClassImplCollector::<$cls>::new();
 
-                    // Strategy:
-                    // - Try __getattribute__ first.  Its default is PyObject_GenericGetAttr.
-                    // - If it returns a result, use it.
-                    // - If it fails with AttributeError, try __getattr__.
-                    // - If it fails otherwise, reraise.
-                    match collector.__getattribute__(py, _slf, attr) {
-                        Ok(obj) => Ok(obj),
-                        Err(e) if e.is_instance_of::<$crate::exceptions::PyAttributeError>(py) => {
-                            collector.__getattr__(py, _slf, attr)
-                        }
-                        Err(e) => Err(e),
+                // Strategy:
+                // - Try __getattribute__ first. Its default is PyObject_GenericGetAttr.
+                // - If it returns a result, use it.
+                // - If it fails with AttributeError, try __getattr__.
+                // - If it fails otherwise, reraise.
+                match collector.__getattribute__(py, _slf, attr) {
+                    Ok(obj) => Ok(obj),
+                    Err(e) if e.is_instance_of::<$crate::exceptions::PyAttributeError>(py) => {
+                        collector.__getattr__(py, _slf, attr)
                     }
-                }),
-            )
+                    Err(e) => Err(e),
+                }
+            })
         }
         $crate::ffi::PyType_Slot {
             slot: $crate::ffi::Py_tp_getattro,
@@ -402,21 +397,21 @@ macro_rules! define_pyclass_setattr_slot {
                     attr: *mut $crate::ffi::PyObject,
                     value: *mut $crate::ffi::PyObject,
                 ) -> ::std::os::raw::c_int {
-                    use ::std::option::Option::*;
-                    use $crate::callback::IntoPyCallbackOutput;
-                    use $crate::impl_::pyclass::*;
-                    let gil = $crate::GILPool::new();
-                    let py = gil.python();
-                    $crate::callback::panic_result_into_callback_output(
-                        py,
-                        ::std::panic::catch_unwind(move || -> $crate::PyResult<_> {
+                    $crate::impl_::trampoline::setattrofunc(
+                        _slf,
+                        attr,
+                        value,
+                        |py, _slf, attr, value| {
+                            use ::std::option::Option::*;
+                            use $crate::callback::IntoPyCallbackOutput;
+                            use $crate::impl_::pyclass::*;
                             let collector = PyClassImplCollector::<$cls>::new();
                             if let Some(value) = ::std::ptr::NonNull::new(value) {
                                 collector.$set(py, _slf, attr, value).convert(py)
                             } else {
                                 collector.$del(py, _slf, attr).convert(py)
                             }
-                        }),
+                        },
                     )
                 }
                 $crate::ffi::PyType_Slot {
@@ -517,22 +512,17 @@ macro_rules! define_pyclass_binary_operator_slot {
                     _slf: *mut $crate::ffi::PyObject,
                     _other: *mut $crate::ffi::PyObject,
                 ) -> *mut $crate::ffi::PyObject {
-                    let gil = $crate::GILPool::new();
-                    let py = gil.python();
-                    $crate::callback::panic_result_into_callback_output(
-                        py,
-                        ::std::panic::catch_unwind(move || -> $crate::PyResult<_> {
-                            use $crate::impl_::pyclass::*;
-                            let collector = PyClassImplCollector::<$cls>::new();
-                            let lhs_result = collector.$lhs(py, _slf, _other)?;
-                            if lhs_result == $crate::ffi::Py_NotImplemented() {
-                                $crate::ffi::Py_DECREF(lhs_result);
-                                collector.$rhs(py, _other, _slf)
-                            } else {
-                                ::std::result::Result::Ok(lhs_result)
-                            }
-                        }),
-                    )
+                    $crate::impl_::trampoline::binaryfunc(_slf, _other, |py, _slf, _other| {
+                        use $crate::impl_::pyclass::*;
+                        let collector = PyClassImplCollector::<$cls>::new();
+                        let lhs_result = collector.$lhs(py, _slf, _other)?;
+                        if lhs_result == $crate::ffi::Py_NotImplemented() {
+                            $crate::ffi::Py_DECREF(lhs_result);
+                            collector.$rhs(py, _other, _slf)
+                        } else {
+                            ::std::result::Result::Ok(lhs_result)
+                        }
+                    })
                 }
                 $crate::ffi::PyType_Slot {
                     slot: $crate::ffi::$slot,
@@ -715,22 +705,17 @@ macro_rules! generate_pyclass_pow_slot {
             _other: *mut $crate::ffi::PyObject,
             _mod: *mut $crate::ffi::PyObject,
         ) -> *mut $crate::ffi::PyObject {
-            let gil = $crate::GILPool::new();
-            let py = gil.python();
-            $crate::callback::panic_result_into_callback_output(
-                py,
-                ::std::panic::catch_unwind(move || -> $crate::PyResult<_> {
-                    use $crate::impl_::pyclass::*;
-                    let collector = PyClassImplCollector::<$cls>::new();
-                    let lhs_result = collector.__pow__(py, _slf, _other, _mod)?;
-                    if lhs_result == $crate::ffi::Py_NotImplemented() {
-                        $crate::ffi::Py_DECREF(lhs_result);
-                        collector.__rpow__(py, _other, _slf, _mod)
-                    } else {
-                        ::std::result::Result::Ok(lhs_result)
-                    }
-                }),
-            )
+            $crate::impl_::trampoline::ternaryfunc(_slf, _other, _mod, |py, _slf, _other, _mod| {
+                use $crate::impl_::pyclass::*;
+                let collector = PyClassImplCollector::<$cls>::new();
+                let lhs_result = collector.__pow__(py, _slf, _other, _mod)?;
+                if lhs_result == $crate::ffi::Py_NotImplemented() {
+                    $crate::ffi::Py_DECREF(lhs_result);
+                    collector.__rpow__(py, _other, _slf, _mod)
+                } else {
+                    ::std::result::Result::Ok(lhs_result)
+                }
+            })
         }
         $crate::ffi::PyType_Slot {
             slot: $crate::ffi::Py_nb_power,

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -946,6 +946,7 @@ pub(crate) unsafe extern "C" fn tp_dealloc<T: PyClass>(obj: *mut ffi::PyObject) 
     /// A wrapper because PyCellLayout::tp_dealloc currently takes the py argument last
     /// (which is different to the rest of the trampolines which take py first)
     #[inline]
+    #[allow(clippy::unnecessary_wraps)]
     unsafe fn trampoline_dealloc_wrapper<T: PyClass>(
         py: Python<'_>,
         slf: *mut ffi::PyObject,

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -134,6 +134,8 @@ trampolines!(
     ) -> *mut ffi::PyObject;
 
     pub fn unaryfunc(slf: *mut ffi::PyObject) -> *mut ffi::PyObject;
+
+    pub fn dealloc(slf: *mut ffi::PyObject) -> ();
 );
 
 #[cfg(any(not(Py_LIMITED_API), Py_3_11))]

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -1,0 +1,155 @@
+//! Trampolines for various pyfunction and pymethod implementations.
+//!
+//! They exist to monomorphise std::panic::catch_unwind once into PyO3, rather than inline in every
+//! function, thus saving a huge amount of compile-time complexity.
+
+use std::os::raw::{c_int, c_void};
+
+use crate::{
+    callback::panic_result_into_callback_output, ffi, methods::IPowModulo, GILPool, PyResult,
+    Python,
+};
+
+#[inline]
+pub unsafe fn noargs(
+    slf: *mut ffi::PyObject,
+    args: *mut ffi::PyObject,
+    f: for<'py> unsafe fn(Python<'py>, *mut ffi::PyObject) -> PyResult<*mut ffi::PyObject>,
+) -> *mut ffi::PyObject {
+    debug_assert!(args.is_null());
+
+    let gil = GILPool::new();
+    let py = gil.python();
+    panic_result_into_callback_output(py, std::panic::catch_unwind(move || f(py, slf)))
+}
+
+macro_rules! trampoline {
+    (pub fn $name:ident($($arg_names:ident: $arg_types:ty),* $(,)?) -> $ret:ty;) => {
+        #[inline]
+        pub unsafe fn $name(
+            $($arg_names: $arg_types,)*
+            f: for<'py> unsafe fn (Python<'py>, $($arg_types),*) -> PyResult<$ret>,
+        ) -> $ret {
+            let gil = GILPool::new();
+            let py = gil.python();
+            panic_result_into_callback_output(
+                py,
+                std::panic::catch_unwind(move || f(py, $($arg_names),*)))
+        }
+    }
+}
+
+macro_rules! trampolines {
+    ($(pub fn $name:ident($($arg_names:ident: $arg_types:ty),* $(,)?) -> $ret:ty);* ;) => {
+        $(trampoline!(pub fn $name($($arg_names: $arg_types),*) -> $ret;));*;
+    }
+}
+
+trampolines!(
+    pub fn fastcall_with_keywords(
+        slf: *mut ffi::PyObject,
+        args: *const *mut ffi::PyObject,
+        nargs: ffi::Py_ssize_t,
+        kwnames: *mut ffi::PyObject,
+    ) -> *mut ffi::PyObject;
+
+    pub fn cfunction_with_keywords(
+        slf: *mut ffi::PyObject,
+        args: *mut ffi::PyObject,
+        kwargs: *mut ffi::PyObject,
+    ) -> *mut ffi::PyObject;
+);
+
+#[inline]
+pub unsafe fn getter(
+    slf: *mut ffi::PyObject,
+    closure: *mut c_void,
+    f: for<'py> unsafe fn(Python<'py>, *mut ffi::PyObject) -> PyResult<*mut ffi::PyObject>,
+) -> *mut ffi::PyObject {
+    // PyO3 doesn't use the closure argument at present.
+    debug_assert!(closure.is_null());
+
+    let gil = GILPool::new();
+    let py = gil.python();
+    panic_result_into_callback_output(py, std::panic::catch_unwind(move || f(py, slf)))
+}
+
+#[inline]
+pub unsafe fn setter(
+    slf: *mut ffi::PyObject,
+    value: *mut ffi::PyObject,
+    closure: *mut c_void,
+    f: for<'py> unsafe fn(Python<'py>, *mut ffi::PyObject, *mut ffi::PyObject) -> PyResult<c_int>,
+) -> c_int {
+    // PyO3 doesn't use the closure argument at present.
+    debug_assert!(closure.is_null());
+
+    let gil = GILPool::new();
+    let py = gil.python();
+    panic_result_into_callback_output(py, std::panic::catch_unwind(move || f(py, slf, value)))
+}
+
+// Trampolines used by slot methods
+trampolines!(
+    pub fn binaryfunc(slf: *mut ffi::PyObject, arg1: *mut ffi::PyObject) -> *mut ffi::PyObject;
+
+    pub fn descrgetfunc(
+        slf: *mut ffi::PyObject,
+        arg1: *mut ffi::PyObject,
+        arg2: *mut ffi::PyObject,
+    ) -> *mut ffi::PyObject;
+
+    pub fn getiterfunc(slf: *mut ffi::PyObject) -> *mut ffi::PyObject;
+
+    pub fn hashfunc(slf: *mut ffi::PyObject) -> ffi::Py_hash_t;
+
+    pub fn inquiry(slf: *mut ffi::PyObject) -> c_int;
+
+    pub fn iternextfunc(slf: *mut ffi::PyObject) -> *mut ffi::PyObject;
+
+    pub fn lenfunc(slf: *mut ffi::PyObject) -> ffi::Py_ssize_t;
+
+    pub fn newfunc(
+        subtype: *mut ffi::PyTypeObject,
+        args: *mut ffi::PyObject,
+        kwargs: *mut ffi::PyObject,
+    ) -> *mut ffi::PyObject;
+
+    pub fn objobjproc(slf: *mut ffi::PyObject, arg1: *mut ffi::PyObject) -> c_int;
+
+    pub fn reprfunc(slf: *mut ffi::PyObject) -> *mut ffi::PyObject;
+
+    pub fn richcmpfunc(
+        slf: *mut ffi::PyObject,
+        other: *mut ffi::PyObject,
+        op: c_int,
+    ) -> *mut ffi::PyObject;
+
+    pub fn ssizeargfunc(arg1: *mut ffi::PyObject, arg2: ffi::Py_ssize_t) -> *mut ffi::PyObject;
+
+    pub fn ternaryfunc(
+        slf: *mut ffi::PyObject,
+        arg1: *mut ffi::PyObject,
+        arg2: *mut ffi::PyObject,
+    ) -> *mut ffi::PyObject;
+
+    pub fn unaryfunc(slf: *mut ffi::PyObject) -> *mut ffi::PyObject;
+);
+
+#[cfg(any(not(Py_LIMITED_API), Py_3_11))]
+trampolines! {
+    pub fn getbufferproc(slf: *mut ffi::PyObject, buf: *mut ffi::Py_buffer, flags: c_int) -> c_int;
+
+    pub fn releasebufferproc(slf: *mut ffi::PyObject, buf: *mut ffi::Py_buffer) -> ();
+}
+
+// Ipowfunc is a unique case where PyO3 has its own type
+// to workaround a problem on 3.7 (see IPowModulo type definition).
+// Once 3.7 support dropped can just remove this.
+trampoline!(
+    pub fn ipowfunc(
+        arg1: *mut ffi::PyObject,
+        arg2: *mut ffi::PyObject,
+        arg3: IPowModulo,
+    ) -> *mut ffi::PyObject;
+);

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -55,25 +55,20 @@
 //! #    }
 //! # }
 //! #
-//! // This function is exported to Python.
+//! // The function which is exported to Python looks roughly like the following
 //! unsafe extern "C" fn __pymethod_increment__(
 //!     _slf: *mut pyo3::ffi::PyObject,
 //!     _args: *mut pyo3::ffi::PyObject,
 //! ) -> *mut pyo3::ffi::PyObject {
 //!     use :: pyo3 as _pyo3;
-//!     let gil = _pyo3::GILPool::new();
-//!     let _py = gil.python();
-//!     _pyo3::callback::panic_result_into_callback_output(
-//!         _py,
-//!         ::std::panic::catch_unwind(move || -> _pyo3::PyResult<_> {
-//!             let _cell = _py
-//!                 .from_borrowed_ptr::<_pyo3::PyAny>(_slf)
-//!                 .downcast::<_pyo3::PyCell<Number>>()?;
-//!             let mut _ref = _cell.try_borrow_mut()?;
-//!             let _slf: &mut Number = &mut *_ref;
-//!             _pyo3::callback::convert(_py, Number::increment(_slf))
-//!         }),
-//!     )
+//!     _pyo3::impl_::trampoline::noargs(_slf, _args, |py, _slf| {
+//!         let _cell = py
+//!             .from_borrowed_ptr::<_pyo3::PyAny>(_slf)
+//!             .downcast::<_pyo3::PyCell<Number>>()?;
+//!         let mut _ref = _cell.try_borrow_mut()?;
+//!         let _slf: &mut Number = &mut *_ref;
+//!         _pyo3::callback::convert(py, Number::increment(_slf))
+//!     })
 //! }
 //! ```
 //!

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -600,8 +600,8 @@ pub(crate) unsafe extern "C" fn no_constructor_defined(
     _args: *mut ffi::PyObject,
     _kwds: *mut ffi::PyObject,
 ) -> *mut ffi::PyObject {
-    crate::callback_body!(py, {
-        Err::<(), _>(crate::exceptions::PyTypeError::new_err(
+    crate::impl_::trampoline::trampoline_inner(|_| {
+        Err(crate::exceptions::PyTypeError::new_err(
             "No constructor defined",
         ))
     })

--- a/tests/ui/static_ref.stderr
+++ b/tests/ui/static_ref.stderr
@@ -1,11 +1,10 @@
-error[E0597]: `gil` does not live long enough
+error: lifetime may not live long enough
  --> tests/ui/static_ref.rs:4:1
   |
 4 | #[pyfunction]
-  | ^^^^^^^^^^^^-
-  | |           |
-  | |           `gil` dropped here while still borrowed
-  | borrowed value does not live long enough
-  | cast requires that `gil` is borrowed for `'static`
+  | ^^^^^^^^^^^^^
+  | |
+  | lifetime `'py` defined here
+  | cast requires that `'py` must outlive `'static`
   |
   = note: this error originates in the attribute macro `pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This is a refactoring to the generated `#[pyfunction]` and `#[pymethods]` with the intention of reducing compile time and binary size.

The motivation for the change is that `cargo llvm-lines` currently reports many monomorphizations of `std::panicking::try::do_call` and friends being instantiated - in fact, it's one per `#[pyfunction]` and every method in `#[pymethods]`, which is quite a lot of instantiations.

The change follows a similar idea to #2478 changing `extract_argument` to make use of "dynamic dispatch". Here, we create "trampoline" wrappers for all possible C-API function pointers we expose to Python. These wrappers take a function pointer to the real implementation of the function in question, and call it after starting the `std::panic::catch_unwind` machiner and creating a `GILPool`.

Much like in #2704 I suspect LLVM can do a pretty good job at optimizing out the dynamic dispatch. I saw no change at all in benchmarks for the `pytests` crate. So overall I believe this should have a compile-time win with little-to-no impact on runtime performance.

For our `pytests` crate I get a 10% reduction in `cargo llvm-lines` count, and for real-world use cases potentially with many small function wrappers (e.g. getters / setters) I suspect the reduction could be even greater. 

Detail-wise, for some method `MyClass::foo`, the generated code change from a single C-ABI symbol:

```rust
unsafe extern "C" fn __pymethod_foo__(
    slf: *mut ffi::PyObject,
    args: *const *mut ffi::PyObject,
    nargs: ffi::Py_ssize_t,
    kwnames: *mut ffi::PyObject,
) -> *mut ffi::PyObject {
    let gil = GILPool::new();
    let py = gil.python();
    pyo3::callback::panic_result_into_callback_output(
        py,
        panic::catch_unwind(move || -> PyResult<_> {
            /* implementation */
        }),
    )
}
```

to an C-ABI symbol which just calls the trampoline wrapper with a pointer to the actual implementation.

```rust
unsafe extern "C" fn trampoline(
    slf: *mut ffi::PyObject,
    args: *const *mut ffi::PyObject,
    nargs: ffi::Py_ssize_t,
    kwnames: *mut ffi::PyObject,
) -> *mut ffi::PyObject
{
    impl_::trampoline::fastcall_with_keywords(
        slf,
        args,
        nargs,
        kwnames,
        MyClass::__pymethod_foo__,
    )
}
unsafe fn __pymethod_foo__<'py>(
    py: Python<'py>,
    slf: *mut ffi::PyObject,
    args: *const *mut ffi::PyObject,
    nargs: ffi::Py_ssize_t,
    kwnames: *mut ffi::PyObject,
) -> PyResult<*mut ffi::PyObject> {
    /* implementation */
}
```