### PR TITLE
Fix module name in getting started

### DIFF
--- a/guide/src/getting_started.md
+++ b/guide/src/getting_started.md
@@ -153,7 +153,7 @@ fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
 /// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
 /// import the module.
 #[pymodule]
-fn string_sum(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+fn pyo3_example(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(sum_as_string, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
If I'm not missing anything, the docs of this same function seem to say that the function name needs to be the library name in cargo, and the python module that will be exported. But the function name is different from those.
