### PR TITLE
Python 3.7 support for PyCodeObject.

### DIFF
--- a/newsfragments/2726.fixed.md
+++ b/newsfragments/2726.fixed.md
@@ -1,0 +1,1 @@
+`PyCodeObject` is now once again defined with fields on Python 3.7.

--- a/newsfragments/2727.changed.md
+++ b/newsfragments/2727.changed.md
@@ -1,1 +1,0 @@
-`PyCodeObject` is now defined with fields on Python 3.7.

--- a/newsfragments/2727.changed.md
+++ b/newsfragments/2727.changed.md
@@ -1,0 +1,1 @@
+`PyCodeObject` is now defined with fields on Python 3.7.

--- a/pyo3-ffi/src/cpython/code.rs
+++ b/pyo3-ffi/src/cpython/code.rs
@@ -11,8 +11,34 @@ use std::os::raw::{c_char, c_int, c_uchar, c_void};
 #[cfg(all(Py_3_8, not(PyPy), not(Py_3_11)))]
 opaque_struct!(_PyOpcache);
 
-#[cfg(all(not(PyPy), not(Py_3_8)))]
+#[cfg(all(not(PyPy), not(Py_3_7)))]
 opaque_struct!(PyCodeObject);
+
+#[cfg(all(not(PyPy), Py_3_7, not(Py_3_8)))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyCodeObject {
+    pub ob_base: PyObject,
+    pub co_argcount: c_int,
+    pub co_kwonlyargcount: c_int,
+    pub co_nlocals: c_int,
+    pub co_stacksize: c_int,
+    pub co_flags: c_int,
+    pub co_firstlineno: c_int,
+    pub co_code: *mut PyObject,
+    pub co_consts: *mut PyObject,
+    pub co_names: *mut PyObject,
+    pub co_varnames: *mut PyObject,
+    pub co_freevars: *mut PyObject,
+    pub co_cellvars: *mut PyObject,
+    pub co_cell2arg: *mut Py_ssize_t,
+    pub co_filename: *mut PyObject,
+    pub co_name: *mut PyObject,
+    pub co_lnotab: *mut PyObject,
+    pub co_zombieframe: *mut c_void,
+    pub co_weakreflist: *mut PyObject,
+    pub co_extra: *mut c_void,
+}
 
 #[cfg(all(not(PyPy), Py_3_8, not(Py_3_11)))]
 #[repr(C)]


### PR DESCRIPTION
See https://github.com/python/cpython/blob/3.7/Include/code.h#L21 for the original C code for validation.

Fixes #2725 