### PR TITLE
PyAny: deprecate cast_as() in favor of downcast()

### DIFF
--- a/benches/bench_frompyobject.rs
+++ b/benches/bench_frompyobject.rs
@@ -21,12 +21,12 @@ fn enum_from_pyobject(b: &mut Bencher<'_>) {
     })
 }
 
-fn list_via_cast_as(b: &mut Bencher<'_>) {
+fn list_via_downcast(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let any: &PyAny = PyList::empty(py).into();
 
         b.iter(|| {
-            let _list: &PyList = black_box(any).cast_as().unwrap();
+            let _list: &PyList = black_box(any).downcast().unwrap();
         });
     })
 }
@@ -41,12 +41,12 @@ fn list_via_extract(b: &mut Bencher<'_>) {
     })
 }
 
-fn not_a_list_via_cast_as(b: &mut Bencher<'_>) {
+fn not_a_list_via_downcast(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let any: &PyAny = PyString::new(py, "foobar").into();
 
         b.iter(|| {
-            black_box(any).cast_as::<PyList>().unwrap_err();
+            black_box(any).downcast::<PyList>().unwrap_err();
         });
     })
 }
@@ -81,9 +81,9 @@ fn not_a_list_via_extract_enum(b: &mut Bencher<'_>) {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("enum_from_pyobject", enum_from_pyobject);
-    c.bench_function("list_via_cast_as", list_via_cast_as);
+    c.bench_function("list_via_downcast", list_via_downcast);
     c.bench_function("list_via_extract", list_via_extract);
-    c.bench_function("not_a_list_via_cast_as", not_a_list_via_cast_as);
+    c.bench_function("not_a_list_via_downcast", not_a_list_via_downcast);
     c.bench_function("not_a_list_via_extract", not_a_list_via_extract);
     c.bench_function("not_a_list_via_extract_enum", not_a_list_via_extract_enum);
 }

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -321,7 +321,7 @@ fn main() -> PyResult<()> {
     let path = Path::new("/usr/share/python_app");
     let py_app = fs::read_to_string(path.join("app.py"))?;
     let from_python = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
-        let syspath: &PyList = py.import("sys")?.getattr("path")?.downcast::<PyList>()?;
+        let syspath: &PyList = py.import("sys")?.getattr("path")?.downcast()?;
         syspath.insert(0, &path)?;
         let app: Py<PyAny> = PyModule::from_code(py, &py_app, "", "")?
             .getattr("run")?

--- a/newsfragments/2734.added.md
+++ b/newsfragments/2734.added.md
@@ -1,0 +1,1 @@
+Added `Py::downcast()` as a companion to `PyAny::downcast()`.

--- a/newsfragments/2734.added.md
+++ b/newsfragments/2734.added.md
@@ -1,1 +1,2 @@
-Added `Py::downcast()` as a companion to `PyAny::downcast()`.
+Added `Py::downcast()` as a companion to `PyAny::downcast()`, as well as
+`downcast_unchecked()` for both types.

--- a/newsfragments/2734.changed.md
+++ b/newsfragments/2734.changed.md
@@ -1,0 +1,2 @@
+`PyAny::cast_as()` and `Py::cast_as()` are now deprecated in favor of
+`PyAny::downcast()` and the new `Py::downcast()`.

--- a/newsfragments/2734.changed.md
+++ b/newsfragments/2734.changed.md
@@ -1,2 +1,3 @@
 `PyAny::cast_as()` and `Py::cast_as()` are now deprecated in favor of
-`PyAny::downcast()` and the new `Py::downcast()`.
+`PyAny::downcast()` and the new `Py::downcast()`. The `PyAny::downcast()`
+lifetime bounds where slightly relaxed.

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -50,9 +50,7 @@ use crate::types::{
     timezone_utc, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess,
     PyTzInfo, PyTzInfoAccess, PyUnicode,
 };
-use crate::{
-    AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
-};
+use crate::{AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
 use chrono::offset::{FixedOffset, Utc};
 use chrono::{
     DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike,

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -36,7 +36,7 @@
 //!     Python::with_gil(|py| {
 //!         // Create an UTC datetime in python
 //!         let py_tz = Utc.to_object(py);
-//!         let py_tz = py_tz.cast_as(py).unwrap();
+//!         let py_tz = py_tz.downcast(py).unwrap();
 //!         let pydatetime = PyDateTime::new(py, 2022, 1, 1, 12, 0, 0, 0, Some(py_tz)).unwrap();
 //!         println!("PyDateTime: {}", pydatetime);
 //!         // Now convert it to chrono's DateTime<Utc>
@@ -237,7 +237,7 @@ impl<Tz: TimeZone> ToPyObject for DateTime<Tz> {
             None => (ns / 1000, false),
         };
         let tz = self.offset().fix().to_object(py);
-        let tz = tz.cast_as(py).unwrap();
+        let tz = tz.downcast(py).unwrap();
         let datetime = PyDateTime::new_with_fold(py, yy, mm, dd, h, m, s, ms, Some(tz), fold)
             .expect("Failed to construct datetime");
         datetime.into()
@@ -577,7 +577,7 @@ mod tests {
                     let datetime = DateTime::<Utc>::from_utc(datetime, Utc).to_object(py);
                     let datetime: &PyDateTime = datetime.extract(py).unwrap();
                     let py_tz = Utc.to_object(py);
-                    let py_tz = py_tz.cast_as(py).unwrap();
+                    let py_tz = py_tz.downcast(py).unwrap();
                     let py_datetime = PyDateTime::new_with_fold(
                         py,
                         year,
@@ -617,7 +617,7 @@ mod tests {
                         DateTime::<FixedOffset>::from_utc(datetime, offset).to_object(py);
                     let datetime: &PyDateTime = datetime.extract(py).unwrap();
                     let py_tz = offset.to_object(py);
-                    let py_tz = py_tz.cast_as(py).unwrap();
+                    let py_tz = py_tz.downcast(py).unwrap();
                     let py_datetime = PyDateTime::new_with_fold(
                         py,
                         year,
@@ -652,7 +652,7 @@ mod tests {
             |name: &'static str, year, month, day, hour, minute, second, ms, py_ms, fold| {
                 Python::with_gil(|py| {
                     let py_tz = Utc.to_object(py);
-                    let py_tz = py_tz.cast_as(py).unwrap();
+                    let py_tz = py_tz.downcast(py).unwrap();
                     let py_datetime = PyDateTime::new_with_fold(
                         py,
                         year,
@@ -688,7 +688,7 @@ mod tests {
                 Python::with_gil(|py| {
                     let offset = FixedOffset::east_opt(3600).unwrap();
                     let py_tz = offset.to_object(py);
-                    let py_tz = py_tz.cast_as(py).unwrap();
+                    let py_tz = py_tz.downcast(py).unwrap();
                     let py_datetime = PyDateTime::new_with_fold(
                         py,
                         year,
@@ -721,14 +721,14 @@ mod tests {
 
         Python::with_gil(|py| {
             let py_tz = Utc.to_object(py);
-            let py_tz = py_tz.cast_as(py).unwrap();
+            let py_tz = py_tz.downcast(py).unwrap();
             let py_datetime =
                 PyDateTime::new_with_fold(py, 2014, 5, 6, 7, 8, 9, 999_999, Some(py_tz), false)
                     .unwrap();
             assert!(py_datetime.extract::<DateTime<FixedOffset>>().is_ok());
             let offset = FixedOffset::east_opt(3600).unwrap();
             let py_tz = offset.to_object(py);
-            let py_tz = py_tz.cast_as(py).unwrap();
+            let py_tz = py_tz.downcast(py).unwrap();
             let py_datetime =
                 PyDateTime::new_with_fold(py, 2014, 5, 6, 7, 8, 9, 999_999, Some(py_tz), false)
                     .unwrap();

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -23,7 +23,7 @@
 //! The required hashbrown version may vary based on the version of PyO3.
 use crate::{
     types::{IntoPyDict, PyDict, PySet},
-    FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, PyTryFrom, Python, ToPyObject,
+    FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
 };
 use std::{cmp, hash};
 
@@ -59,7 +59,7 @@ where
     S: hash::BuildHasher + Default,
 {
     fn extract(ob: &'source PyAny) -> Result<Self, PyErr> {
-        let dict = <PyDict as PyTryFrom>::try_from(ob)?;
+        let dict: &PyDict = ob.downcast()?;
         let mut ret = hashbrown::HashMap::with_capacity_and_hasher(dict.len(), S::default());
         for (k, v) in dict.iter() {
             ret.insert(K::extract(k)?, V::extract(v)?);
@@ -121,7 +121,7 @@ mod tests {
             map.insert(1, 1);
 
             let m = map.to_object(py);
-            let py_map = <PyDict as PyTryFrom>::try_from(m.as_ref(py)).unwrap();
+            let py_map: &PyDict = m.downcast(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(py_map.get_item(1).unwrap().extract::<i32>().unwrap() == 1);
@@ -135,7 +135,7 @@ mod tests {
             map.insert(1, 1);
 
             let m: PyObject = map.into_py(py);
-            let py_map = <PyDict as PyTryFrom>::try_from(m.as_ref(py)).unwrap();
+            let py_map: &PyDict = m.downcast(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(py_map.get_item(1).unwrap().extract::<i32>().unwrap() == 1);

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -93,7 +93,7 @@
 //! ```
 
 use crate::types::*;
-use crate::{FromPyObject, IntoPy, PyErr, PyObject, PyTryFrom, Python, ToPyObject};
+use crate::{FromPyObject, IntoPy, PyErr, PyObject, Python, ToPyObject};
 use std::{cmp, hash};
 
 impl<K, V, H> ToPyObject for indexmap::IndexMap<K, V, H>
@@ -128,7 +128,7 @@ where
     S: hash::BuildHasher + Default,
 {
     fn extract(ob: &'source PyAny) -> Result<Self, PyErr> {
-        let dict = <PyDict as PyTryFrom>::try_from(ob)?;
+        let dict: &PyDict = ob.downcast()?;
         let mut ret = indexmap::IndexMap::with_capacity_and_hasher(dict.len(), S::default());
         for (k, v) in dict.iter() {
             ret.insert(K::extract(k)?, V::extract(v)?);
@@ -141,7 +141,7 @@ where
 mod test_indexmap {
 
     use crate::types::*;
-    use crate::{IntoPy, PyObject, PyTryFrom, Python, ToPyObject};
+    use crate::{IntoPy, PyObject, Python, ToPyObject};
 
     #[test]
     fn test_indexmap_indexmap_to_python() {
@@ -150,7 +150,7 @@ mod test_indexmap {
             map.insert(1, 1);
 
             let m = map.to_object(py);
-            let py_map = <PyDict as PyTryFrom>::try_from(m.as_ref(py)).unwrap();
+            let py_map: &PyDict = m.downcast(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(py_map.get_item(1).unwrap().extract::<i32>().unwrap() == 1);
@@ -168,7 +168,7 @@ mod test_indexmap {
             map.insert(1, 1);
 
             let m: PyObject = map.into_py(py);
-            let py_map = <PyDict as PyTryFrom>::try_from(m.as_ref(py)).unwrap();
+            let py_map: &PyDict = m.downcast(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(py_map.get_item(1).unwrap().extract::<i32>().unwrap() == 1);

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -386,7 +386,7 @@ mod tests {
         Python::with_gil(|py| {
             let array: [Foo; 8] = [Foo, Foo, Foo, Foo, Foo, Foo, Foo, Foo];
             let pyobject = array.into_py(py);
-            let list: &PyList = pyobject.cast_as(py).unwrap();
+            let list: &PyList = pyobject.downcast(py).unwrap();
             let _cell: &crate::PyCell<Foo> = list.get_item(4).unwrap().extract().unwrap();
         });
     }

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -6,8 +6,8 @@ mod min_const_generics {
     use crate::conversion::{AsPyPointer, IntoPyPointer};
     use crate::types::PySequence;
     use crate::{
-        ffi, FromPyObject, IntoPy, Py, PyAny, PyDowncastError, PyObject, PyResult, PyTryFrom,
-        Python, ToPyObject,
+        ffi, FromPyObject, IntoPy, Py, PyAny, PyDowncastError, PyObject, PyResult, Python,
+        ToPyObject,
     };
 
     impl<T, const N: usize> IntoPy<PyObject> for [T; N]
@@ -65,9 +65,9 @@ mod min_const_generics {
     {
         // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
         // to support this function and if not, we will only fail extraction safely.
-        let seq = unsafe {
+        let seq: &PySequence = unsafe {
             if ffi::PySequence_Check(obj.as_ptr()) != 0 {
-                <PySequence as PyTryFrom>::try_from_unchecked(obj)
+                obj.downcast_unchecked()
             } else {
                 return Err(PyDowncastError::new(obj, "Sequence").into());
             }
@@ -187,8 +187,8 @@ mod array_impls {
     use crate::conversion::{AsPyPointer, IntoPyPointer};
     use crate::types::PySequence;
     use crate::{
-        ffi, FromPyObject, IntoPy, Py, PyAny, PyDowncastError, PyObject, PyResult, PyTryFrom,
-        Python, ToPyObject,
+        ffi, FromPyObject, IntoPy, Py, PyAny, PyDowncastError, PyObject, PyResult, Python,
+        ToPyObject,
     };
     use std::mem::{transmute_copy, ManuallyDrop};
 
@@ -288,9 +288,9 @@ mod array_impls {
     {
         // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
         // to support this function and if not, we will only fail extraction safely.
-        let seq = unsafe {
+        let seq: &PySequence = unsafe {
             if ffi::PySequence_Check(obj.as_ptr()) != 0 {
-                <PySequence as PyTryFrom>::try_from_unchecked(obj)
+                obj.downcast_unchecked()
             } else {
                 return Err(PyDowncastError::new(obj, "Sequence").into());
             }

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -3,7 +3,7 @@ use std::{cmp, collections, hash};
 use crate::{
     inspect::types::TypeInfo,
     types::{IntoPyDict, PyDict},
-    FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyTryFrom, Python, ToPyObject,
+    FromPyObject, IntoPy, PyAny, PyErr, PyObject, Python, ToPyObject,
 };
 
 impl<K, V, H> ToPyObject for collections::HashMap<K, V, H>
@@ -69,7 +69,7 @@ where
     S: hash::BuildHasher + Default,
 {
     fn extract(ob: &'source PyAny) -> Result<Self, PyErr> {
-        let dict = <PyDict as PyTryFrom>::try_from(ob)?;
+        let dict: &PyDict = ob.downcast()?;
         let mut ret = collections::HashMap::with_capacity_and_hasher(dict.len(), S::default());
         for (k, v) in dict.iter() {
             ret.insert(K::extract(k)?, V::extract(v)?);
@@ -88,7 +88,7 @@ where
     V: FromPyObject<'source>,
 {
     fn extract(ob: &'source PyAny) -> Result<Self, PyErr> {
-        let dict = <PyDict as PyTryFrom>::try_from(ob)?;
+        let dict: &PyDict = ob.downcast()?;
         let mut ret = collections::BTreeMap::new();
         for (k, v) in dict.iter() {
             ret.insert(K::extract(k)?, V::extract(v)?);
@@ -104,7 +104,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{IntoPy, PyObject, PyTryFrom, Python, ToPyObject};
+    use crate::{IntoPy, PyObject, Python, ToPyObject};
     use std::collections::{BTreeMap, HashMap};
 
     #[test]
@@ -114,7 +114,7 @@ mod tests {
             map.insert(1, 1);
 
             let m = map.to_object(py);
-            let py_map = <PyDict as PyTryFrom>::try_from(m.as_ref(py)).unwrap();
+            let py_map: &PyDict = m.downcast(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(py_map.get_item(1).unwrap().extract::<i32>().unwrap() == 1);
@@ -129,7 +129,7 @@ mod tests {
             map.insert(1, 1);
 
             let m = map.to_object(py);
-            let py_map = <PyDict as PyTryFrom>::try_from(m.as_ref(py)).unwrap();
+            let py_map: &PyDict = m.downcast(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(py_map.get_item(1).unwrap().extract::<i32>().unwrap() == 1);
@@ -144,7 +144,7 @@ mod tests {
             map.insert(1, 1);
 
             let m: PyObject = map.into_py(py);
-            let py_map = <PyDict as PyTryFrom>::try_from(m.as_ref(py)).unwrap();
+            let py_map: &PyDict = m.downcast(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(py_map.get_item(1).unwrap().extract::<i32>().unwrap() == 1);
@@ -158,7 +158,7 @@ mod tests {
             map.insert(1, 1);
 
             let m: PyObject = map.into_py(py);
-            let py_map = <PyDict as PyTryFrom>::try_from(m.as_ref(py)).unwrap();
+            let py_map: &PyDict = m.downcast(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(py_map.get_item(1).unwrap().extract::<i32>().unwrap() == 1);

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -2,8 +2,7 @@ use crate::types::PyString;
 #[cfg(windows)]
 use crate::PyErr;
 use crate::{
-    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, PyTryFrom, Python,
-    ToPyObject,
+    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
 };
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
@@ -57,7 +56,7 @@ impl ToPyObject for OsStr {
 
 impl FromPyObject<'_> for OsString {
     fn extract(ob: &PyAny) -> PyResult<Self> {
-        let pystring = <PyString as PyTryFrom>::try_from(ob)?; // Cast PyAny to PyString
+        let pystring: &PyString = ob.downcast()?;
 
         #[cfg(not(windows))]
         {

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -1,6 +1,6 @@
 use crate::{
     inspect::types::TypeInfo, types::PyBytes, FromPyObject, IntoPy, PyAny, PyObject, PyResult,
-    PyTryFrom, Python, ToPyObject,
+    Python, ToPyObject,
 };
 
 impl<'a> IntoPy<PyObject> for &'a [u8] {
@@ -15,7 +15,7 @@ impl<'a> IntoPy<PyObject> for &'a [u8] {
 
 impl<'a> FromPyObject<'a> for &'a [u8] {
     fn extract(obj: &'a PyAny) -> PyResult<Self> {
-        Ok(<PyBytes as PyTryFrom>::try_from(obj)?.as_bytes())
+        Ok(obj.downcast::<PyBytes>()?.as_bytes())
     }
 
     fn type_input() -> TypeInfo {

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::{
     inspect::types::TypeInfo, types::PyString, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult,
-    PyTryFrom, Python, ToPyObject,
+    Python, ToPyObject,
 };
 
 /// Converts a Rust `str` to a Python object.
@@ -107,7 +107,7 @@ impl<'a> IntoPy<PyObject> for &'a String {
 /// Accepts Python `str` and `unicode` objects.
 impl<'source> FromPyObject<'source> for &'source str {
     fn extract(ob: &'source PyAny) -> PyResult<Self> {
-        <PyString as PyTryFrom>::try_from(ob)?.to_str()
+        ob.downcast::<PyString>()?.to_str()
     }
 
     fn type_input() -> TypeInfo {
@@ -119,9 +119,7 @@ impl<'source> FromPyObject<'source> for &'source str {
 /// Accepts Python `str` and `unicode` objects.
 impl FromPyObject<'_> for String {
     fn extract(obj: &PyAny) -> PyResult<Self> {
-        <PyString as PyTryFrom>::try_from(obj)?
-            .to_str()
-            .map(ToOwned::to_owned)
+        obj.downcast::<PyString>()?.to_str().map(ToOwned::to_owned)
     }
 
     fn type_input() -> TypeInfo {
@@ -131,7 +129,7 @@ impl FromPyObject<'_> for String {
 
 impl FromPyObject<'_> for char {
     fn extract(obj: &PyAny) -> PyResult<Self> {
-        let s = <PyString as PyTryFrom<'_>>::try_from(obj)?.to_str()?;
+        let s = obj.downcast::<PyString>()?.to_str()?;
         let mut iter = s.chars();
         if let (Some(ch), None) = (iter.next(), iter.next()) {
             Ok(ch)

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -113,7 +113,7 @@ pub unsafe trait PyNativeType: Sized {
 /// #         let m = pyo3::types::PyModule::new(py, "test")?;
 /// #         m.add_class::<Foo>()?;
 /// #
-/// #         let foo: &PyCell<Foo> = pyo3::PyTryFrom::try_from(m.getattr("Foo")?.call0()?)?;
+/// #         let foo: &PyCell<Foo> = m.getattr("Foo")?.call0()?.downcast()?;
 /// #         let dict = &foo.borrow().inner;
 /// #         let dict: &PyDict = dict.as_ref(py);
 /// #
@@ -150,7 +150,7 @@ pub unsafe trait PyNativeType: Sized {
 /// #         let m = pyo3::types::PyModule::new(py, "test")?;
 /// #         m.add_class::<Foo>()?;
 /// #
-/// #         let foo: &PyCell<Foo> = pyo3::PyTryFrom::try_from(m.getattr("Foo")?.call0()?)?;
+/// #         let foo: &PyCell<Foo> = m.getattr("Foo")?.call0()?.downcast()?;
 /// #         let bar = &foo.borrow().inner;
 /// #         let bar: &Bar = &*bar.borrow(py);
 /// #

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -995,11 +995,20 @@ impl PyObject {
     ///
     /// This can cast only to native Python types, not types implemented in Rust. For a more
     /// flexible alternative, see [`Py::extract`](struct.Py.html#method.extract).
+    pub fn downcast<'p, T>(&'p self, py: Python<'p>) -> Result<&T, PyDowncastError<'_>>
+    where
+        for<'py> T: PyTryFrom<'py>,
+    {
+        <T as PyTryFrom<'_>>::try_from(self.as_ref(py))
+    }
+
+    /// Casts the PyObject to a concrete Python object type.
+    #[deprecated(since = "0.18.0", note = "use downcast() instead")]
     pub fn cast_as<'p, D>(&'p self, py: Python<'p>) -> Result<&'p D, PyDowncastError<'_>>
     where
         D: PyTryFrom<'p>,
     {
-        <D as PyTryFrom<'_>>::try_from(unsafe { py.from_borrowed_ptr::<PyAny>(self.as_ptr()) })
+        <D as PyTryFrom<'_>>::try_from(self.as_ref(py))
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -997,7 +997,7 @@ impl PyObject {
     /// flexible alternative, see [`Py::extract`](struct.Py.html#method.extract).
     pub fn downcast<'p, T>(&'p self, py: Python<'p>) -> Result<&T, PyDowncastError<'_>>
     where
-        for<'py> T: PyTryFrom<'py>,
+        T: PyTryFrom<'p>,
     {
         <T as PyTryFrom<'_>>::try_from(self.as_ref(py))
     }
@@ -1008,7 +1008,7 @@ impl PyObject {
     where
         D: PyTryFrom<'p>,
     {
-        <D as PyTryFrom<'_>>::try_from(self.as_ref(py))
+        self.downcast(py)
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1002,6 +1002,21 @@ impl PyObject {
         <T as PyTryFrom<'_>>::try_from(self.as_ref(py))
     }
 
+    /// Casts the PyObject to a concrete Python object type without checking validity.
+    ///
+    /// This can cast only to native Python types, not types implemented in Rust. For a more
+    /// flexible alternative, see [`Py::extract`](struct.Py.html#method.extract).
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that the type is valid or risk type confusion.
+    pub unsafe fn downcast_unchecked<'p, T>(&'p self, py: Python<'p>) -> &T
+    where
+        T: PyTryFrom<'p>,
+    {
+        <T as PyTryFrom<'_>>::try_from_unchecked(self.as_ref(py))
+    }
+
     /// Casts the PyObject to a concrete Python object type.
     #[deprecated(since = "0.18.0", note = "use downcast() instead")]
     pub fn cast_as<'p, D>(&'p self, py: Python<'p>) -> Result<&'p D, PyDowncastError<'_>>

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -752,7 +752,7 @@ impl PyAny {
     where
         D: PyTryFrom<'a>,
     {
-        <D as PyTryFrom<'_>>::try_from(self)
+        self.downcast()
     }
 
     /// Converts this `PyAny` to a concrete Python type.
@@ -773,9 +773,9 @@ impl PyAny {
     ///     assert!(any.downcast::<PyList>().is_err());
     /// });
     /// ```
-    pub fn downcast<T>(&self) -> Result<&T, PyDowncastError<'_>>
+    pub fn downcast<'p, T>(&'p self) -> Result<&'p T, PyDowncastError<'_>>
     where
-        for<'py> T: PyTryFrom<'py>,
+        T: PyTryFrom<'p>,
     {
         <T as PyTryFrom>::try_from(self)
     }

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -64,29 +64,6 @@ pyobject_native_type_extract!(PyAny);
 pyobject_native_type_sized!(PyAny, ffi::PyObject);
 
 impl PyAny {
-    /// Converts this `PyAny` to a concrete Python type.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use pyo3::prelude::*;
-    /// use pyo3::types::{PyAny, PyDict, PyList};
-    ///
-    /// Python::with_gil(|py| {
-    ///     let dict = PyDict::new(py);
-    ///     assert!(dict.is_instance_of::<PyAny>().unwrap());
-    ///     let any: &PyAny = dict.as_ref();
-    ///     assert!(any.downcast::<PyDict>().is_ok());
-    ///     assert!(any.downcast::<PyList>().is_err());
-    /// });
-    /// ```
-    pub fn downcast<T>(&self) -> Result<&T, PyDowncastError<'_>>
-    where
-        for<'py> T: PyTryFrom<'py>,
-    {
-        <T as PyTryFrom>::try_from(self)
-    }
-
     /// Returns whether `self` and `other` point to the same object. To compare
     /// the equality of two objects (the `==` operator), use [`eq`](PyAny::eq).
     ///
@@ -769,14 +746,38 @@ impl PyAny {
         unsafe { ffi::Py_TYPE(self.as_ptr()) }
     }
 
-    /// Casts `self` to a concrete Python object type.
-    ///
-    /// This can cast only to native Python types, not types implemented in Rust.
+    /// Converts this `PyAny` to a concrete Python type.
+    #[deprecated(since = "0.18.0", note = "use the equivalent .downcast()")]
     pub fn cast_as<'a, D>(&'a self) -> Result<&'a D, PyDowncastError<'_>>
     where
         D: PyTryFrom<'a>,
     {
         <D as PyTryFrom<'_>>::try_from(self)
+    }
+
+    /// Converts this `PyAny` to a concrete Python type.
+    ///
+    /// This can cast only to native Python types, not types implemented in Rust.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::{PyAny, PyDict, PyList};
+    ///
+    /// Python::with_gil(|py| {
+    ///     let dict = PyDict::new(py);
+    ///     assert!(dict.is_instance_of::<PyAny>().unwrap());
+    ///     let any: &PyAny = dict.as_ref();
+    ///     assert!(any.downcast::<PyDict>().is_ok());
+    ///     assert!(any.downcast::<PyList>().is_err());
+    /// });
+    /// ```
+    pub fn downcast<T>(&self) -> Result<&T, PyDowncastError<'_>>
+    where
+        for<'py> T: PyTryFrom<'py>,
+    {
+        <T as PyTryFrom>::try_from(self)
     }
 
     /// Extracts some type from the Python object.

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -780,6 +780,18 @@ impl PyAny {
         <T as PyTryFrom>::try_from(self)
     }
 
+    /// Converts this `PyAny` to a concrete Python type without checking validity.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that the type is valid or risk type confusion.
+    pub unsafe fn downcast_unchecked<'p, T>(&'p self) -> &'p T
+    where
+        T: PyTryFrom<'p>,
+    {
+        <T as PyTryFrom>::try_from_unchecked(self)
+    }
+
     /// Extracts some type from the Python object.
     ///
     /// This is a wrapper function around [`FromPyObject::extract()`].

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 use crate::inspect::types::TypeInfo;
 use crate::{
-    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, PyTryFrom, Python,
-    ToPyObject,
+    ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
 };
 
 /// Represents a Python `bool`.
@@ -58,7 +57,7 @@ impl IntoPy<PyObject> for bool {
 /// Fails with `TypeError` if the input is not a Python `bool`.
 impl<'source> FromPyObject<'source> for bool {
     fn extract(obj: &'source PyAny) -> PyResult<Self> {
-        Ok(<PyBool as PyTryFrom>::try_from(obj)?.is_true())
+        Ok(obj.downcast::<PyBool>()?.is_true())
     }
 
     fn type_input() -> TypeInfo {

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -4,7 +4,7 @@ use super::PyMapping;
 use crate::err::{self, PyErr, PyResult};
 use crate::ffi::Py_ssize_t;
 use crate::types::{PyAny, PyList};
-use crate::{ffi, AsPyPointer, PyTryFrom, Python, ToPyObject};
+use crate::{ffi, AsPyPointer, Python, ToPyObject};
 #[cfg(not(PyPy))]
 use crate::{IntoPyPointer, PyObject};
 use std::ptr::NonNull;
@@ -255,7 +255,7 @@ impl PyDict {
 
     /// Returns `self` cast as a `PyMapping`.
     pub fn as_mapping(&self) -> &PyMapping {
-        unsafe { PyMapping::try_from_unchecked(self) }
+        unsafe { self.downcast_unchecked() }
     }
 }
 

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -422,7 +422,7 @@ mod tests {
     use crate::exceptions;
     #[cfg(not(PyPy))]
     use crate::{types::PyList, PyTypeInfo};
-    use crate::{types::PyTuple, PyTryFrom, Python, ToPyObject};
+    use crate::{types::PyTuple, Python, ToPyObject};
     use std::collections::{BTreeMap, HashMap};
 
     #[test]
@@ -478,11 +478,11 @@ mod tests {
         Python::with_gil(|py| {
             let mut v = HashMap::new();
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             assert_eq!(0, dict.len());
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let dict2 = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict2: &PyDict = ob.downcast(py).unwrap();
             assert_eq!(1, dict2.len());
         });
     }
@@ -493,7 +493,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             assert!(dict.contains(7i32).unwrap());
             assert!(!dict.contains(8i32).unwrap());
         });
@@ -505,7 +505,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             assert_eq!(32, dict.get_item(7i32).unwrap().extract::<i32>().unwrap());
             assert!(dict.get_item(8i32).is_none());
         });
@@ -518,7 +518,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             assert_eq!(
                 32,
                 dict.get_item_with_error(7i32)
@@ -541,7 +541,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             assert!(dict.set_item(7i32, 42i32).is_ok()); // change
             assert!(dict.set_item(8i32, 123i32).is_ok()); // insert
             assert_eq!(
@@ -577,7 +577,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             assert!(dict.set_item(7i32, 42i32).is_ok()); // change
             assert!(dict.set_item(8i32, 123i32).is_ok()); // insert
             assert_eq!(32i32, v[&7i32]); // not updated!
@@ -591,7 +591,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             assert!(dict.del_item(7i32).is_ok());
             assert_eq!(0, dict.len());
             assert!(dict.get_item(7i32).is_none());
@@ -604,7 +604,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             assert!(dict.del_item(7i32).is_ok()); // change
             assert_eq!(32i32, *v.get(&7i32).unwrap()); // not updated!
         });
@@ -618,7 +618,7 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
             let mut key_sum = 0;
             let mut value_sum = 0;
@@ -640,7 +640,7 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
             let mut key_sum = 0;
             for el in dict.keys().iter() {
@@ -658,7 +658,7 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
             let mut values_sum = 0;
             for el in dict.values().iter() {
@@ -676,7 +676,7 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             let mut key_sum = 0;
             let mut value_sum = 0;
             for (key, value) in dict.iter() {
@@ -697,7 +697,7 @@ mod tests {
             v.insert(9, 123);
 
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
 
             for (key, value) in dict.iter() {
                 dict.set_item(key, value.extract::<i32>().unwrap() + 7)
@@ -715,7 +715,7 @@ mod tests {
                 v.insert(i * 2, i * 2);
             }
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
 
             for (i, (key, value)) in dict.iter().enumerate() {
                 let key = key.extract::<i32>().unwrap();
@@ -740,7 +740,7 @@ mod tests {
                 v.insert(i * 2, i * 2);
             }
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
 
             for (i, (key, value)) in dict.iter().enumerate() {
                 let key = key.extract::<i32>().unwrap();
@@ -764,7 +764,7 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
 
             let mut iter = dict.iter();
             assert_eq!(iter.size_hint(), (v.len(), Some(v.len())));
@@ -790,7 +790,7 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
             let ob = v.to_object(py);
-            let dict = <PyDict as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let dict: &PyDict = ob.downcast(py).unwrap();
             let mut key_sum = 0;
             let mut value_sum = 0;
             for (key, value) in dict {

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -623,7 +623,7 @@ mod tests {
             let mut key_sum = 0;
             let mut value_sum = 0;
             for el in dict.items().iter() {
-                let tuple = el.cast_as::<PyTuple>().unwrap();
+                let tuple = el.downcast::<PyTuple>().unwrap();
                 key_sum += tuple.get_item(0).unwrap().extract::<i32>().unwrap();
                 value_sum += tuple.get_item(1).unwrap().extract::<i32>().unwrap();
             }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -70,7 +70,7 @@ impl<'v> PyTryFrom<'v> for PyIterator {
         let value = value.into();
         unsafe {
             if ffi::PyIter_Check(value.as_ptr()) != 0 {
-                Ok(<PyIterator as PyTryFrom>::try_from_unchecked(value))
+                Ok(value.downcast_unchecked())
             } else {
                 Err(PyDowncastError::new(value, "Iterator"))
             }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -78,7 +78,7 @@ impl<'v> PyTryFrom<'v> for PyIterator {
     }
 
     fn try_from_exact<V: Into<&'v PyAny>>(value: V) -> Result<&'v PyIterator, PyDowncastError<'v>> {
-        <PyIterator as PyTryFrom>::try_from(value)
+        value.into().downcast()
     }
 
     #[inline]
@@ -110,8 +110,6 @@ mod tests {
     use crate::exceptions::PyTypeError;
     use crate::gil::GILPool;
     use crate::types::{PyDict, PyList};
-    #[cfg(any(not(Py_LIMITED_API), Py_3_8))]
-    use crate::PyTryFrom;
     use crate::{Py, PyAny, Python, ToPyObject};
 
     #[test]
@@ -224,8 +222,7 @@ def fibonacci(target):
     fn iterator_try_from() {
         Python::with_gil(|py| {
             let obj: Py<PyAny> = vec![10, 20].to_object(py).as_ref(py).iter().unwrap().into();
-            let iter: &PyIterator =
-                <PyIterator as PyTryFrom<'_>>::try_from(obj.as_ref(py)).unwrap();
+            let iter: &PyIterator = obj.downcast(py).unwrap();
             assert!(obj.is(iter));
         });
     }

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -8,7 +8,7 @@ use crate::err::{self, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::internal_tricks::get_ssize_index;
 use crate::types::PySequence;
-use crate::{AsPyPointer, IntoPyPointer, Py, PyAny, PyObject, PyTryFrom, Python, ToPyObject};
+use crate::{AsPyPointer, IntoPyPointer, Py, PyAny, PyObject, Python, ToPyObject};
 
 /// Represents a Python `list`.
 #[repr(transparent)]
@@ -115,7 +115,7 @@ impl PyList {
 
     /// Returns `self` cast as a `PySequence`.
     pub fn as_sequence(&self) -> &PySequence {
-        unsafe { PySequence::try_from_unchecked(self) }
+        unsafe { self.downcast_unchecked() }
     }
 
     /// Gets the list item at the specified index.

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -343,7 +343,7 @@ impl<'a> std::iter::IntoIterator for &'a PyList {
 mod tests {
     use crate::types::PyList;
     use crate::Python;
-    use crate::{IntoPy, PyObject, PyTryFrom, ToPyObject};
+    use crate::{IntoPy, PyObject, ToPyObject};
 
     #[test]
     fn test_new() {
@@ -407,7 +407,7 @@ mod tests {
                 let _pool = unsafe { crate::GILPool::new() };
                 let v = vec![2];
                 let ob = v.to_object(py);
-                let list = <PyList as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+                let list: &PyList = ob.downcast(py).unwrap();
                 let none = py.None();
                 cnt = none.get_refcnt(py);
                 list.set_item(0, none).unwrap();
@@ -494,7 +494,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = vec![2, 3, 5, 7];
             let ob = v.to_object(py);
-            let list = <PyList as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let list: &PyList = ob.downcast(py).unwrap();
 
             let mut iter = list.iter();
             assert_eq!(iter.size_hint(), (v.len(), Some(v.len())));
@@ -566,7 +566,7 @@ mod tests {
     fn test_array_into_py() {
         Python::with_gil(|py| {
             let array: PyObject = [1, 2].into_py(py);
-            let list = <PyList as PyTryFrom>::try_from(array.as_ref(py)).unwrap();
+            let list: &PyList = array.downcast(py).unwrap();
             assert_eq!(1, list[0].extract::<i32>().unwrap());
             assert_eq!(2, list[1].extract::<i32>().unwrap());
         });

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -142,7 +142,7 @@ impl<'v> PyTryFrom<'v> for PyMapping {
         // TODO: surface specific errors in this chain to the user
         if let Ok(abc) = get_mapping_abc(value.py()) {
             if value.is_instance(abc).unwrap_or(false) {
-                unsafe { return Ok(<PyMapping as PyTryFrom>::try_from_unchecked(value)) }
+                unsafe { return Ok(value.downcast_unchecked()) }
             }
         }
 

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -151,7 +151,7 @@ impl<'v> PyTryFrom<'v> for PyMapping {
 
     #[inline]
     fn try_from_exact<V: Into<&'v PyAny>>(value: V) -> Result<&'v PyMapping, PyDowncastError<'v>> {
-        <PyMapping as PyTryFrom>::try_from(value)
+        value.into().downcast()
     }
 
     #[inline]
@@ -194,13 +194,13 @@ mod tests {
         Python::with_gil(|py| {
             let mut v = HashMap::new();
             let ob = v.to_object(py);
-            let mapping = <PyMapping as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let mapping: &PyMapping = ob.downcast(py).unwrap();
             assert_eq!(0, mapping.len().unwrap());
             assert!(mapping.is_empty().unwrap());
 
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let mapping2 = <PyMapping as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let mapping2: &PyMapping = ob.downcast(py).unwrap();
             assert_eq!(1, mapping2.len().unwrap());
             assert!(!mapping2.is_empty().unwrap());
         });
@@ -212,7 +212,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert("key0", 1234);
             let ob = v.to_object(py);
-            let mapping = <PyMapping as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let mapping: &PyMapping = ob.downcast(py).unwrap();
             mapping.set_item("key1", "foo").unwrap();
 
             assert!(mapping.contains("key0").unwrap());
@@ -227,7 +227,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let mapping = <PyMapping as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let mapping: &PyMapping = ob.downcast(py).unwrap();
             assert_eq!(
                 32,
                 mapping.get_item(7i32).unwrap().extract::<i32>().unwrap()
@@ -245,7 +245,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let mapping = <PyMapping as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let mapping: &PyMapping = ob.downcast(py).unwrap();
             assert!(mapping.set_item(7i32, 42i32).is_ok()); // change
             assert!(mapping.set_item(8i32, 123i32).is_ok()); // insert
             assert_eq!(
@@ -265,7 +265,7 @@ mod tests {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.to_object(py);
-            let mapping = <PyMapping as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let mapping: &PyMapping = ob.downcast(py).unwrap();
             assert!(mapping.del_item(7i32).is_ok());
             assert_eq!(0, mapping.len().unwrap());
             assert!(mapping
@@ -283,7 +283,7 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
             let ob = v.to_object(py);
-            let mapping = <PyMapping as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let mapping: &PyMapping = ob.downcast(py).unwrap();
             // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
             let mut key_sum = 0;
             let mut value_sum = 0;
@@ -305,7 +305,7 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
             let ob = v.to_object(py);
-            let mapping = <PyMapping as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let mapping: &PyMapping = ob.downcast(py).unwrap();
             // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
             let mut key_sum = 0;
             for el in mapping.keys().unwrap().iter().unwrap() {
@@ -323,7 +323,7 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
             let ob = v.to_object(py);
-            let mapping = <PyMapping as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let mapping: &PyMapping = ob.downcast(py).unwrap();
             // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
             let mut values_sum = 0;
             for el in mapping.values().unwrap().iter().unwrap() {

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -288,7 +288,7 @@ mod tests {
             let mut key_sum = 0;
             let mut value_sum = 0;
             for el in mapping.items().unwrap().iter().unwrap() {
-                let tuple = el.unwrap().cast_as::<PyTuple>().unwrap();
+                let tuple = el.unwrap().downcast::<PyTuple>().unwrap();
                 key_sum += tuple.get_item(0).unwrap().extract::<i32>().unwrap();
                 value_sum += tuple.get_item(1).unwrap().extract::<i32>().unwrap();
             }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -213,7 +213,7 @@ macro_rules! pyobject_native_type_extract {
     ($name:ty $(;$generics:ident)*) => {
         impl<'py, $($generics,)*> $crate::FromPyObject<'py> for &'py $name {
             fn extract(obj: &'py $crate::PyAny) -> $crate::PyResult<Self> {
-                $crate::PyTryFrom::try_from(obj).map_err(::std::convert::Into::into)
+                obj.downcast().map_err(::std::convert::Into::into)
             }
         }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -57,7 +57,7 @@ pub use self::typeobject::PyType;
 ///
 /// # pub fn main() -> PyResult<()> {
 /// Python::with_gil(|py| {
-///     let dict: &PyDict = py.eval("{'a':'b', 'c':'d'}", None, None)?.cast_as()?;
+///     let dict: &PyDict = py.eval("{'a':'b', 'c':'d'}", None, None)?.downcast()?;
 ///
 ///     for (key, value) in dict {
 ///         println!("key: {}, value: {}", key, value);

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -347,7 +347,7 @@ impl<'v> PyTryFrom<'v> for PySequence {
     }
 
     fn try_from_exact<V: Into<&'v PyAny>>(value: V) -> Result<&'v PySequence, PyDowncastError<'v>> {
-        <PySequence as PyTryFrom>::try_from(value)
+        value.into().downcast()
     }
 
     #[inline]
@@ -401,7 +401,7 @@ mod tests {
     fn test_numbers_are_not_sequences() {
         Python::with_gil(|py| {
             let v = 42i32;
-            assert!(<PySequence as PyTryFrom>::try_from(v.to_object(py).as_ref(py)).is_err());
+            assert!(v.to_object(py).downcast::<PySequence>(py).is_err());
         });
     }
 
@@ -409,7 +409,7 @@ mod tests {
     fn test_strings_are_sequences() {
         Python::with_gil(|py| {
             let v = "London Calling";
-            assert!(<PySequence as PyTryFrom>::try_from(v.to_object(py).as_ref(py)).is_ok());
+            assert!(v.to_object(py).downcast::<PySequence>(py).is_ok());
         });
     }
 
@@ -809,7 +809,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = "foo";
             let ob = v.to_object(py);
-            let seq = <PySequence as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let seq: &PySequence = ob.downcast(py).unwrap();
             assert!(seq.list().is_ok());
         });
     }

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -430,7 +430,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert_eq!(0, seq.len().unwrap());
 
             let needle = 7i32.to_object(py);
@@ -442,11 +442,11 @@ mod tests {
     fn test_seq_is_empty() {
         Python::with_gil(|py| {
             let list = vec![1].to_object(py);
-            let seq = list.cast_as::<PySequence>(py).unwrap();
+            let seq = list.downcast::<PySequence>(py).unwrap();
             assert!(!seq.is_empty().unwrap());
             let vec: Vec<u32> = Vec::new();
             let empty_list = vec.to_object(py);
-            let empty_seq = empty_list.cast_as::<PySequence>(py).unwrap();
+            let empty_seq = empty_list.downcast::<PySequence>(py).unwrap();
             assert!(empty_seq.is_empty().unwrap());
         });
     }
@@ -456,7 +456,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert_eq!(6, seq.len().unwrap());
 
             let bad_needle = 7i32.to_object(py);
@@ -475,7 +475,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert_eq!(1, seq.get_item(0).unwrap().extract::<i32>().unwrap());
             assert_eq!(1, seq.get_item(1).unwrap().extract::<i32>().unwrap());
             assert_eq!(2, seq.get_item(2).unwrap().extract::<i32>().unwrap());
@@ -491,7 +491,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert_eq!(1, seq[0].extract::<i32>().unwrap());
             assert_eq!(1, seq[1].extract::<i32>().unwrap());
             assert_eq!(2, seq[2].extract::<i32>().unwrap());
@@ -504,7 +504,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             let _ = &seq[7];
         });
     }
@@ -514,7 +514,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert_eq!(vec![1, 2], seq[1..3].extract::<Vec<i32>>().unwrap());
             assert_eq!(Vec::<i32>::new(), seq[3..3].extract::<Vec<i32>>().unwrap());
             assert_eq!(vec![1, 2], seq[1..].extract::<Vec<i32>>().unwrap());
@@ -532,7 +532,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             seq[5..10].extract::<Vec<i32>>().unwrap();
         })
     }
@@ -543,7 +543,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             seq[1..10].extract::<Vec<i32>>().unwrap();
         })
     }
@@ -554,7 +554,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             #[allow(clippy::reversed_empty_ranges)]
             seq[2..1].extract::<Vec<i32>>().unwrap();
         })
@@ -566,7 +566,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             seq[8..].extract::<Vec<i32>>().unwrap();
         })
     }
@@ -576,7 +576,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert!(seq.del_item(10).is_err());
             assert_eq!(1, seq[0].extract::<i32>().unwrap());
             assert!(seq.del_item(0).is_ok());
@@ -600,7 +600,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 2];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert_eq!(2, seq[1].extract::<i32>().unwrap());
             assert!(seq.set_item(1, 10).is_ok());
             assert_eq!(10, seq[1].extract::<i32>().unwrap());
@@ -614,7 +614,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 2];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert!(seq.set_item(1, &obj).is_ok());
             assert!(seq[1].as_ptr() == obj.as_ptr());
         });
@@ -629,7 +629,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert_eq!(
                 [1, 2, 3],
                 seq.get_slice(1, 4).unwrap().extract::<[i32; 3]>().unwrap()
@@ -650,7 +650,7 @@ mod tests {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let w: Vec<i32> = vec![7, 4];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             let ins = w.to_object(py);
             seq.set_slice(1, 4, ins.as_ref(py)).unwrap();
             assert_eq!([1, 7, 4, 5, 8], seq.extract::<[i32; 5]>().unwrap());
@@ -664,7 +664,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             seq.del_slice(1, 4).unwrap();
             assert_eq!([1, 5, 8], seq.extract::<[i32; 3]>().unwrap());
             seq.del_slice(1, 100).unwrap();
@@ -677,7 +677,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert_eq!(0, seq.index(1i32).unwrap());
             assert_eq!(2, seq.index(2i32).unwrap());
             assert_eq!(3, seq.index(3i32).unwrap());
@@ -693,7 +693,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert_eq!(2, seq.count(1i32).unwrap());
             assert_eq!(1, seq.count(2i32).unwrap());
             assert_eq!(1, seq.count(3i32).unwrap());
@@ -708,7 +708,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             let mut idx = 0;
             for el in seq.iter().unwrap() {
                 assert_eq!(v[idx], el.unwrap().extract::<i32>().unwrap());
@@ -723,7 +723,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = vec!["It", "was", "the", "worst", "of", "times"];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
 
             let bad_needle = "blurst".to_object(py);
             assert!(!seq.contains(bad_needle).unwrap());
@@ -738,7 +738,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 2, 3];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             let concat_seq = seq.concat(seq).unwrap();
             assert_eq!(6, concat_seq.len().unwrap());
             let concat_v: Vec<i32> = vec![1, 2, 3, 1, 2, 3];
@@ -753,7 +753,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = "string";
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             let concat_seq = seq.concat(seq).unwrap();
             assert_eq!(12, concat_seq.len().unwrap());
             let concat_v = "stringstring".to_owned();
@@ -768,7 +768,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = vec!["foo", "bar"];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             let repeat_seq = seq.repeat(3).unwrap();
             assert_eq!(6, repeat_seq.len().unwrap());
             let repeated = vec!["foo", "bar", "foo", "bar", "foo", "bar"];
@@ -783,7 +783,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = vec!["foo", "bar"];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             let rep_seq = seq.in_place_repeat(3).unwrap();
             assert_eq!(6, seq.len().unwrap());
             assert!(seq.is(rep_seq));
@@ -799,7 +799,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = vec!["foo", "bar"];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert!(seq.list().is_ok());
         });
     }
@@ -819,7 +819,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = ("foo", "bar");
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert!(seq.tuple().is_ok());
         });
     }
@@ -829,7 +829,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = vec!["foo", "bar"];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             assert!(seq.tuple().is_ok());
         });
     }
@@ -871,7 +871,7 @@ mod tests {
         Python::with_gil(|py| {
             let v = vec!["foo", "bar"];
             let ob = v.to_object(py);
-            let seq = ob.cast_as::<PySequence>(py).unwrap();
+            let seq = ob.downcast::<PySequence>(py).unwrap();
             let type_ptr = seq.as_ref();
             let seq_from = unsafe { <PySequence as PyTryFrom>::try_from_unchecked(type_ptr) };
             assert!(seq_from.list().is_ok());

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -233,7 +233,7 @@ pub use impl_::*;
 #[cfg(test)]
 mod tests {
     use super::PySet;
-    use crate::{PyTryFrom, Python, ToPyObject};
+    use crate::{Python, ToPyObject};
     use std::collections::HashSet;
 
     #[test]
@@ -260,11 +260,11 @@ mod tests {
         Python::with_gil(|py| {
             let mut v = HashSet::new();
             let ob = v.to_object(py);
-            let set = <PySet as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let set: &PySet = ob.downcast(py).unwrap();
             assert_eq!(0, set.len());
             v.insert(7);
             let ob = v.to_object(py);
-            let set2 = <PySet as PyTryFrom>::try_from(ob.as_ref(py)).unwrap();
+            let set2: &PySet = ob.downcast(py).unwrap();
             assert_eq!(1, set2.len());
         });
     }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -285,7 +285,7 @@ mod tests {
     #[cfg(all(not(Py_LIMITED_API), target_endian = "little"))]
     use crate::PyTypeInfo;
     use crate::Python;
-    use crate::{PyObject, PyTryFrom, ToPyObject};
+    use crate::{PyObject, ToPyObject};
     #[cfg(all(not(Py_LIMITED_API), target_endian = "little"))]
     use std::borrow::Cow;
 
@@ -294,7 +294,7 @@ mod tests {
         Python::with_gil(|py| {
             let s = "ascii 🐈";
             let obj: PyObject = PyString::new(py, s).into();
-            let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            let py_string: &PyString = obj.downcast(py).unwrap();
             assert_eq!(s, py_string.to_str().unwrap());
         })
     }
@@ -303,7 +303,7 @@ mod tests {
     fn test_to_str_surrogate() {
         Python::with_gil(|py| {
             let obj: PyObject = py.eval(r#"'\ud800'"#, None, None).unwrap().into();
-            let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            let py_string: &PyString = obj.downcast(py).unwrap();
             assert!(py_string.to_str().is_err());
         })
     }
@@ -313,7 +313,7 @@ mod tests {
         Python::with_gil(|py| {
             let s = "哈哈🐈";
             let obj: PyObject = PyString::new(py, s).into();
-            let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            let py_string: &PyString = obj.downcast(py).unwrap();
             assert_eq!(s, py_string.to_str().unwrap());
         })
     }
@@ -325,7 +325,7 @@ mod tests {
                 .eval(r#"'🐈 Hello \ud800World'"#, None, None)
                 .unwrap()
                 .into();
-            let py_string = <PyString as PyTryFrom>::try_from(obj.as_ref(py)).unwrap();
+            let py_string: &PyString = obj.downcast(py).unwrap();
             assert_eq!(py_string.to_string_lossy(), "🐈 Hello ���World");
         })
     }
@@ -334,7 +334,7 @@ mod tests {
     fn test_debug_string() {
         Python::with_gil(|py| {
             let v = "Hello\n".to_object(py);
-            let s = <PyString as PyTryFrom>::try_from(v.as_ref(py)).unwrap();
+            let s: &PyString = v.downcast(py).unwrap();
             assert_eq!(format!("{:?}", s), "'Hello\\n'");
         })
     }
@@ -343,7 +343,7 @@ mod tests {
     fn test_display_string() {
         Python::with_gil(|py| {
             let v = "Hello\n".to_object(py);
-            let s = <PyString as PyTryFrom>::try_from(v.as_ref(py)).unwrap();
+            let s: &PyString = v.downcast(py).unwrap();
             assert_eq!(format!("{}", s), "Hello\n");
         })
     }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -392,7 +392,7 @@ mod tests {
     fn test_string_data_ucs2() {
         Python::with_gil(|py| {
             let s = py.eval("'foo\\ud800'", None, None).unwrap();
-            let py_string = s.cast_as::<PyString>().unwrap();
+            let py_string = s.downcast::<PyString>().unwrap();
             let data = unsafe { py_string.data().unwrap() };
 
             assert_eq!(data, PyStringData::Ucs2(&[102, 111, 111, 0xd800]));

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -8,7 +8,7 @@ use crate::internal_tricks::get_ssize_index;
 use crate::types::PySequence;
 use crate::{
     exceptions, AsPyPointer, FromPyObject, IntoPy, IntoPyPointer, Py, PyAny, PyErr, PyObject,
-    PyResult, PyTryFrom, Python, ToPyObject,
+    PyResult, Python, ToPyObject,
 };
 
 #[inline]
@@ -120,7 +120,7 @@ impl PyTuple {
 
     /// Returns `self` cast as a `PySequence`.
     pub fn as_sequence(&self) -> &PySequence {
-        unsafe { PySequence::try_from_unchecked(self) }
+        unsafe { self.downcast_unchecked() }
     }
 
     /// Takes the slice `self[low:high]` and returns it as a new tuple.

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -21,7 +21,7 @@ fn empty_class_with_new() {
         assert!(typeobj
             .call((), None)
             .unwrap()
-            .cast_as::<PyCell<EmptyClassWithNew>>()
+            .downcast::<PyCell<EmptyClassWithNew>>()
             .is_ok());
     });
 }
@@ -44,7 +44,7 @@ fn unit_class_with_new() {
         assert!(typeobj
             .call((), None)
             .unwrap()
-            .cast_as::<PyCell<UnitClassWithNew>>()
+            .downcast::<PyCell<UnitClassWithNew>>()
             .is_ok());
     });
 }
@@ -65,7 +65,7 @@ fn tuple_class_with_new() {
     Python::with_gil(|py| {
         let typeobj = py.get_type::<TupleClassWithNew>();
         let wrp = typeobj.call((42,), None).unwrap();
-        let obj = wrp.cast_as::<PyCell<TupleClassWithNew>>().unwrap();
+        let obj = wrp.downcast::<PyCell<TupleClassWithNew>>().unwrap();
         let obj_ref = obj.borrow();
         assert_eq!(obj_ref.0, 42);
     });
@@ -90,7 +90,7 @@ fn new_with_one_arg() {
     Python::with_gil(|py| {
         let typeobj = py.get_type::<NewWithOneArg>();
         let wrp = typeobj.call((42,), None).unwrap();
-        let obj = wrp.cast_as::<PyCell<NewWithOneArg>>().unwrap();
+        let obj = wrp.downcast::<PyCell<NewWithOneArg>>().unwrap();
         let obj_ref = obj.borrow();
         assert_eq!(obj_ref._data, 42);
     });
@@ -121,7 +121,7 @@ fn new_with_two_args() {
             .call((10, 20), None)
             .map_err(|e| e.print(py))
             .unwrap();
-        let obj = wrp.cast_as::<PyCell<NewWithTwoArgs>>().unwrap();
+        let obj = wrp.downcast::<PyCell<NewWithTwoArgs>>().unwrap();
         let obj_ref = obj.borrow();
         assert_eq!(obj_ref._data1, 10);
         assert_eq!(obj_ref._data2, 20);

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -529,7 +529,7 @@ struct GetItem {}
 #[pymethods]
 impl GetItem {
     fn __getitem__(&self, idx: &PyAny) -> PyResult<&'static str> {
-        if let Ok(slice) = idx.cast_as::<PySlice>() {
+        if let Ok(slice) = idx.downcast::<PySlice>() {
             let indices = slice.indices(1000)?;
             if indices.start == 100 && indices.stop == 200 && indices.step == 1 {
                 return Ok("slice");


### PR DESCRIPTION
They are (practically) identical, and `cast_as()` is already present on `Py<...>` as well, so I chose to keep that name for the future, although it reads a bit strange when no turbofished type follows.

If y'all prefer to keep `downcast`, sure, but then we should move to that name on `Py` as well.

There's also a `cast_as` on `Python` which is not quite the same, is unsafe and has a `checked_cast_as` companion...
