### PR TITLE
Fix being able to call arg-less `#[new]` with any args from Python

### DIFF
--- a/newsfragments/2749.fixed.md
+++ b/newsfragments/2749.fixed.md
@@ -1,0 +1,2 @@
+Fix a bug that allowed `#[new]` pymethods with no arguments to be called from
+Python with any argument list.

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -32,10 +32,6 @@ pub fn impl_arg_params(
     py: &syn::Ident,
     fastcall: bool,
 ) -> Result<(TokenStream, Vec<TokenStream>)> {
-    if spec.signature.arguments.is_empty() {
-        return Ok((TokenStream::new(), vec![]));
-    }
-
     let args_array = syn::Ident::new("output", Span::call_site());
 
     if !fastcall && is_forwarded_args(&spec.signature) {

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -2,6 +2,7 @@
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::IntoPyDict;
 
 #[pyclass]
 struct EmptyClassWithNew {}
@@ -23,6 +24,12 @@ fn empty_class_with_new() {
             .unwrap()
             .downcast::<PyCell<EmptyClassWithNew>>()
             .is_ok());
+
+        // Calling with arbitrary args or kwargs is not ok
+        assert!(typeobj.call(("some", "args"), None).is_err());
+        assert!(typeobj
+            .call((), Some([("some", "kwarg")].into_py_dict(py)))
+            .is_err());
     });
 }
 

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -259,7 +259,7 @@ mod inheriting_native_type {
     #[pymethods]
     impl CustomException {
         #[new]
-        fn new() -> Self {
+        fn new(_exc_arg: &PyAny) -> Self {
             CustomException {
                 context: "Hello :)",
             }


### PR DESCRIPTION
Fixes #2748

Note that the removed check only triggered for `#[new]` anyway, since other arg-less pymethods use the `NOARGS` argument convention which is not available for `tp_new`.

There's some confusion going on with the `py` argument, I'll open an issue for that.
