### PR TITLE
macros: fix the check for applying `METH_NOARGS`

### DIFF
--- a/newsfragments/2760.fixed.md
+++ b/newsfragments/2760.fixed.md
@@ -1,0 +1,2 @@
+Also apply the `NOARGS` argument convention to methods that have a single
+`py: Python` argument.

--- a/pyo3-macros-backend/src/pyfunction/signature.rs
+++ b/pyo3-macros-backend/src/pyfunction/signature.rs
@@ -211,6 +211,15 @@ pub struct PythonSignature {
     pub accepts_kwargs: bool,
 }
 
+impl PythonSignature {
+    pub fn has_no_args(&self) -> bool {
+        self.positional_parameters.is_empty()
+            && self.keyword_only_parameters.is_empty()
+            && !self.accepts_varargs
+            && !self.accepts_kwargs
+    }
+}
+
 pub struct FunctionSignature<'a> {
     pub arguments: Vec<FnArg<'a>>,
     pub python_signature: PythonSignature,


### PR DESCRIPTION
to only consider the Python argument list.

Fixes #2750
