### PR TITLE
Automatically generate `__text_signature__` for all functions

### DIFF
--- a/guide/src/function.md
+++ b/guide/src/function.md
@@ -73,39 +73,7 @@ The `#[pyo3]` attribute can be used to modify properties of the generated Python
 
   - <a name="text_signature"></a> `#[pyo3(text_signature = "...")]`
 
-    Sets the function signature visible in Python tooling (such as via [`inspect.signature`]).
-
-    The example below creates a function `add` which has a signature describing two positional-only
-    arguments `a` and `b`.
-
-    ```rust
-    use pyo3::prelude::*;
-
-    /// This function adds two unsigned 64-bit integers.
-    #[pyfunction]
-    #[pyo3(text_signature = "(a, b, /)")]
-    fn add(a: u64, b: u64) -> u64 {
-        a + b
-    }
-    #
-    # fn main() -> PyResult<()> {
-    #     Python::with_gil(|py| {
-    #         let fun = pyo3::wrap_pyfunction!(add, py)?;
-    #
-    #         let doc: String = fun.getattr("__doc__")?.extract()?;
-    #         assert_eq!(doc, "This function adds two unsigned 64-bit integers.");
-    #
-    #         let inspect = PyModule::import(py, "inspect")?.getattr("signature")?;
-    #         let sig: String = inspect
-    #             .call1((fun,))?
-    #             .call_method0("__str__")?
-    #             .extract()?;
-    #         assert_eq!(sig, "(a, b, /)");
-    #
-    #         Ok(())
-    #     })
-    # }
-    ```
+    Overrides the PyO3-generated function signature visible in Python tooling (such as via [`inspect.signature`]). See the [corresponding topic in the Function Signatures subchapter](./function/signature.md#making-the-function-signature-available-to-python).
 
   - <a name="pass_module" ></a> `#[pyo3(pass_module)]`
 
@@ -160,47 +128,6 @@ The `#[pyo3]` attribute can be used on individual arguments to modify properties
     ```
 
 ## Advanced function patterns
-
-### Making the function signature available to Python (old method)
-
-Alternatively, simply make sure the first line of your docstring is
-formatted like in the following example. Please note that the newline after the
-`--` is mandatory. The `/` signifies the end of positional-only arguments.
-
-`#[pyo3(text_signature)]` should be preferred, since it will override automatically
-generated signatures when those are added in a future version of PyO3.
-
-```rust
-# #![allow(dead_code)]
-use pyo3::prelude::*;
-
-/// add(a, b, /)
-/// --
-///
-/// This function adds two unsigned 64-bit integers.
-#[pyfunction]
-fn add(a: u64, b: u64) -> u64 {
-    a + b
-}
-
-// a function with a signature but without docs. Both blank lines after the `--` are mandatory.
-
-/// sub(a, b, /)
-/// --
-#[pyfunction]
-fn sub(a: u64, b: u64) -> u64 {
-    a - b
-}
-```
-
-When annotated like this, signatures are also correctly displayed in IPython.
-
-```text
->>> pyo3_test.add?
-Signature: pyo3_test.add(a, b, /)
-Docstring: This function adds two unsigned 64-bit integers.
-Type:      builtin_function_or_method
-```
 
 ### Calling Python functions in Rust
 

--- a/newsfragments/2784.changed.md
+++ b/newsfragments/2784.changed.md
@@ -1,0 +1,1 @@
+Automatically generate `__text_signature__` for all Python functions created using `#[pyfunction]` and `#[pymethods]`.

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -82,12 +82,12 @@ pub fn impl_arg_params(
         .map(|arg| impl_arg_param(arg, &mut option_pos, py, &args_array))
         .collect::<Result<_>>()?;
 
-    let args_handler = if spec.signature.python_signature.accepts_varargs {
+    let args_handler = if spec.signature.python_signature.varargs.is_some() {
         quote! { _pyo3::impl_::extract_argument::TupleVarargs }
     } else {
         quote! { _pyo3::impl_::extract_argument::NoVarargs }
     };
-    let kwargs_handler = if spec.signature.python_signature.accepts_kwargs {
+    let kwargs_handler = if spec.signature.python_signature.kwargs.is_some() {
         quote! { _pyo3::impl_::extract_argument::DictVarkeywords }
     } else {
         quote! { _pyo3::impl_::extract_argument::NoVarkeywords }

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::{spanned::Spanned, Ident};
 
-use crate::attributes::{CrateAttribute, TextSignatureAttribute};
+use crate::attributes::CrateAttribute;
 
 /// Macro inspired by `anyhow::anyhow!` to create a compiler error with the given span.
 macro_rules! err_spanned {
@@ -68,7 +68,7 @@ pub struct PythonDoc(TokenStream);
 /// e.g. concat!("...", "\n", "\0")
 pub fn get_doc(
     attrs: &[syn::Attribute],
-    text_signature: Option<(Cow<'_, Ident>, &TextSignatureAttribute)>,
+    text_signature: Option<(Cow<'_, Ident>, String)>,
 ) -> PythonDoc {
     let mut tokens = TokenStream::new();
     let comma = syn::token::Comma(Span::call_site());
@@ -79,8 +79,7 @@ pub fn get_doc(
     syn::token::Bracket(Span::call_site()).surround(&mut tokens, |tokens| {
         if let Some((python_name, text_signature)) = text_signature {
             // create special doc string lines to set `__text_signature__`
-            let signature_lines =
-                format!("{}{}\n--\n\n", python_name, text_signature.value.value());
+            let signature_lines = format!("{}{}\n--\n\n", python_name, text_signature);
             signature_lines.to_tokens(tokens);
             comma.to_tokens(tokens);
         }

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "macros")]
 
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
 use pyo3::{types::PyType, wrap_pymodule, PyCell};
 
 mod common;
@@ -114,6 +115,179 @@ fn test_function() {
         let f = wrap_pyfunction!(my_function)(py).unwrap();
 
         py_assert!(py, f, "f.__text_signature__ == '(a, b=None, *, c=42)'");
+    });
+}
+
+#[test]
+fn test_auto_test_signature_function() {
+    #[pyfunction]
+    fn my_function(a: i32, b: Option<i32>, c: i32) {
+        let _ = (a, b, c);
+    }
+
+    #[pyfunction(pass_module)]
+    fn my_function_2(module: &PyModule, a: i32, b: Option<i32>, c: i32) {
+        let _ = (module, a, b, c);
+    }
+
+    #[pyfunction(signature = (a, /, b = None, *, c = 5))]
+    fn my_function_3(a: i32, b: Option<i32>, c: i32) {
+        let _ = (a, b, c);
+    }
+
+    #[pyfunction(signature = (a, /, b = None, *args, c, d=5, **kwargs))]
+    fn my_function_4(
+        a: i32,
+        b: Option<i32>,
+        args: &PyTuple,
+        c: i32,
+        d: i32,
+        kwargs: Option<&PyDict>,
+    ) {
+        let _ = (a, b, args, c, d, kwargs);
+    }
+
+    Python::with_gil(|py| {
+        let f = wrap_pyfunction!(my_function)(py).unwrap();
+        py_assert!(py, f, "f.__text_signature__ == '(a, b, c)'");
+
+        let f = wrap_pyfunction!(my_function_2)(py).unwrap();
+        py_assert!(py, f, "f.__text_signature__ == '($module, a, b, c)'");
+
+        let f = wrap_pyfunction!(my_function_3)(py).unwrap();
+        py_assert!(py, f, "f.__text_signature__ == '(a, /, b=..., *, c=...)'");
+
+        let f = wrap_pyfunction!(my_function_4)(py).unwrap();
+        py_assert!(
+            py,
+            f,
+            "f.__text_signature__ == '(a, /, b=..., *args, c, d=..., **kwargs)'"
+        );
+    });
+}
+
+#[test]
+fn test_auto_test_signature_method() {
+    #[pyclass]
+    struct MyClass {}
+
+    #[pymethods]
+    impl MyClass {
+        fn method(&self, a: i32, b: Option<i32>, c: i32) {
+            let _ = (a, b, c);
+        }
+
+        #[pyo3(signature = (a, /, b = None, *, c = 5))]
+        fn method_2(&self, a: i32, b: Option<i32>, c: i32) {
+            let _ = (a, b, c);
+        }
+
+        #[pyo3(signature = (a, /, b = None, *args, c, d=5, **kwargs))]
+        fn method_3(
+            &self,
+            a: i32,
+            b: Option<i32>,
+            args: &PyTuple,
+            c: i32,
+            d: i32,
+            kwargs: Option<&PyDict>,
+        ) {
+            let _ = (a, b, args, c, d, kwargs);
+        }
+
+        #[staticmethod]
+        fn staticmethod(a: i32, b: Option<i32>, c: i32) {
+            let _ = (a, b, c);
+        }
+
+        #[classmethod]
+        fn classmethod(cls: &PyType, a: i32, b: Option<i32>, c: i32) {
+            let _ = (cls, a, b, c);
+        }
+    }
+
+    Python::with_gil(|py| {
+        let cls = py.get_type::<MyClass>();
+        py_assert!(
+            py,
+            cls,
+            "cls.method.__text_signature__ == '($self, a, b, c)'"
+        );
+        py_assert!(
+            py,
+            cls,
+            "cls.method_2.__text_signature__ == '($self, a, /, b=..., *, c=...)'"
+        );
+        py_assert!(
+            py,
+            cls,
+            "cls.method_3.__text_signature__ == '($self, a, /, b=..., *args, c, d=..., **kwargs)'"
+        );
+        py_assert!(
+            py,
+            cls,
+            "cls.staticmethod.__text_signature__ == '(a, b, c)'"
+        );
+        py_assert!(
+            py,
+            cls,
+            "cls.classmethod.__text_signature__ == '($cls, a, b, c)'"
+        );
+    });
+}
+
+#[test]
+fn test_auto_test_signature_opt_out() {
+    #[pyfunction(text_signature = None)]
+    fn my_function(a: i32, b: Option<i32>, c: i32) {
+        let _ = (a, b, c);
+    }
+
+    #[pyfunction(signature = (a, /, b = None, *, c = 5), text_signature = None)]
+    fn my_function_2(a: i32, b: Option<i32>, c: i32) {
+        let _ = (a, b, c);
+    }
+
+    #[pyclass]
+    struct MyClass {}
+
+    #[pymethods]
+    impl MyClass {
+        #[pyo3(text_signature = None)]
+        fn method(&self, a: i32, b: Option<i32>, c: i32) {
+            let _ = (a, b, c);
+        }
+
+        #[pyo3(signature = (a, /, b = None, *, c = 5), text_signature = None)]
+        fn method_2(&self, a: i32, b: Option<i32>, c: i32) {
+            let _ = (a, b, c);
+        }
+
+        #[staticmethod]
+        #[pyo3(text_signature = None)]
+        fn staticmethod(a: i32, b: Option<i32>, c: i32) {
+            let _ = (a, b, c);
+        }
+
+        #[classmethod]
+        #[pyo3(text_signature = None)]
+        fn classmethod(cls: &PyType, a: i32, b: Option<i32>, c: i32) {
+            let _ = (cls, a, b, c);
+        }
+    }
+
+    Python::with_gil(|py| {
+        let f = wrap_pyfunction!(my_function)(py).unwrap();
+        py_assert!(py, f, "f.__text_signature__ == None");
+
+        let f = wrap_pyfunction!(my_function_2)(py).unwrap();
+        py_assert!(py, f, "f.__text_signature__ == None");
+
+        let cls = py.get_type::<MyClass>();
+        py_assert!(py, cls, "cls.method.__text_signature__ == None");
+        py_assert!(py, cls, "cls.method_2.__text_signature__ == None");
+        py_assert!(py, cls, "cls.staticmethod.__text_signature__ == None");
+        py_assert!(py, cls, "cls.classmethod.__text_signature__ == None");
     });
 }
 

--- a/tests/ui/invalid_pymethods.rs
+++ b/tests/ui/invalid_pymethods.rs
@@ -81,6 +81,19 @@ impl MyClass {
 
 #[pymethods]
 impl MyClass {
+    #[pyo3(text_signature = 1)]
+    fn invalid_text_signature() {}
+}
+
+#[pymethods]
+impl MyClass {
+    #[pyo3(text_signature = "()")]
+    #[pyo3(text_signature = None)]
+    fn duplicate_text_signature() {}
+}
+
+#[pymethods]
+impl MyClass {
     #[getter(x)]
     #[pyo3(signature = ())]
     fn signature_on_getter(&self) {}

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -64,73 +64,85 @@ error: `text_signature` not allowed with `classattr`
 78 |     #[pyo3(text_signature = "()")]
    |            ^^^^^^^^^^^^^^
 
-error: `signature` not allowed with `getter`
-  --> tests/ui/invalid_pymethods.rs:85:12
+error: expected a string literal or `None`
+  --> tests/ui/invalid_pymethods.rs:84:30
    |
-85 |     #[pyo3(signature = ())]
+84 |     #[pyo3(text_signature = 1)]
+   |                              ^
+
+error: `text_signature` may only be specified once
+  --> tests/ui/invalid_pymethods.rs:91:12
+   |
+91 |     #[pyo3(text_signature = None)]
+   |            ^^^^^^^^^^^^^^
+
+error: `signature` not allowed with `getter`
+  --> tests/ui/invalid_pymethods.rs:98:12
+   |
+98 |     #[pyo3(signature = ())]
    |            ^^^^^^^^^
 
 error: `signature` not allowed with `setter`
-  --> tests/ui/invalid_pymethods.rs:92:12
-   |
-92 |     #[pyo3(signature = ())]
-   |            ^^^^^^^^^
+   --> tests/ui/invalid_pymethods.rs:105:12
+    |
+105 |     #[pyo3(signature = ())]
+    |            ^^^^^^^^^
 
 error: `signature` not allowed with `classattr`
-  --> tests/ui/invalid_pymethods.rs:99:12
-   |
-99 |     #[pyo3(signature = ())]
-   |            ^^^^^^^^^
+   --> tests/ui/invalid_pymethods.rs:112:12
+    |
+112 |     #[pyo3(signature = ())]
+    |            ^^^^^^^^^
 
 error: cannot specify a second method type
-   --> tests/ui/invalid_pymethods.rs:106:7
+   --> tests/ui/invalid_pymethods.rs:119:7
     |
-106 |     #[staticmethod]
+119 |     #[staticmethod]
     |       ^^^^^^^^^^^^
 
 error: Python functions cannot have generic type parameters
-   --> tests/ui/invalid_pymethods.rs:112:23
+   --> tests/ui/invalid_pymethods.rs:125:23
     |
-112 |     fn generic_method<T>(value: T) {}
+125 |     fn generic_method<T>(value: T) {}
     |                       ^
 
 error: Python functions cannot have `impl Trait` arguments
-   --> tests/ui/invalid_pymethods.rs:117:48
+   --> tests/ui/invalid_pymethods.rs:130:48
     |
-117 |     fn impl_trait_method_first_arg(impl_trait: impl AsRef<PyAny>) {}
+130 |     fn impl_trait_method_first_arg(impl_trait: impl AsRef<PyAny>) {}
     |                                                ^^^^
 
 error: Python functions cannot have `impl Trait` arguments
-   --> tests/ui/invalid_pymethods.rs:122:56
+   --> tests/ui/invalid_pymethods.rs:135:56
     |
-122 |     fn impl_trait_method_second_arg(&self, impl_trait: impl AsRef<PyAny>) {}
+135 |     fn impl_trait_method_second_arg(&self, impl_trait: impl AsRef<PyAny>) {}
     |                                                        ^^^^
 
 error: `async fn` is not yet supported for Python functions.
 
        Additional crates such as `pyo3-asyncio` can be used to integrate async Rust and Python. For more information, see https://github.com/PyO3/pyo3/issues/1632
-   --> tests/ui/invalid_pymethods.rs:127:5
+   --> tests/ui/invalid_pymethods.rs:140:5
     |
-127 |     async fn async_method(&self) {}
+140 |     async fn async_method(&self) {}
     |     ^^^^^
 
 error: `pass_module` cannot be used on Python methods
-   --> tests/ui/invalid_pymethods.rs:132:12
+   --> tests/ui/invalid_pymethods.rs:145:12
     |
-132 |     #[pyo3(pass_module)]
+145 |     #[pyo3(pass_module)]
     |            ^^^^^^^^^^^
 
 error: Python objects are shared, so 'self' cannot be moved out of the Python interpreter.
        Try `&self`, `&mut self, `slf: PyRef<'_, Self>` or `slf: PyRefMut<'_, Self>`.
-   --> tests/ui/invalid_pymethods.rs:138:29
+   --> tests/ui/invalid_pymethods.rs:151:29
     |
-138 |     fn method_self_by_value(self) {}
+151 |     fn method_self_by_value(self) {}
     |                             ^^^^
 
 error[E0592]: duplicate definitions with name `__pymethod___new____`
-   --> tests/ui/invalid_pymethods.rs:143:1
+   --> tests/ui/invalid_pymethods.rs:156:1
     |
-143 | #[pymethods]
+156 | #[pymethods]
     | ^^^^^^^^^^^^
     | |
     | duplicate definitions for `__pymethod___new____`
@@ -139,9 +151,9 @@ error[E0592]: duplicate definitions with name `__pymethod___new____`
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod_func__`
-   --> tests/ui/invalid_pymethods.rs:158:1
+   --> tests/ui/invalid_pymethods.rs:171:1
     |
-158 | #[pymethods]
+171 | #[pymethods]
     | ^^^^^^^^^^^^
     | |
     | duplicate definitions for `__pymethod_func__`


### PR DESCRIPTION
This PR makes it so that PyO3 generates `__text_signature__` by default for all functions. It also introduces `#[pyo3(text_signature = false)]` to disable the built-in generation.

There are a few limitations which we can improve later:
 - All default values are currently set to `...`. I think this is ok because `.pyi` files often do the same. Maybe for numbers, strings, `None` and `True`/`False` we could render these in a future PR.
 - No support for `#[new]` yet.

Alternative design ideas:
- Only autogenerate for methods with `#[pyo3(signature = (...))]` annotation. I started with this, and then decided it made sense to do it for everything.
- Opt-out with `#[pyo3(text_signature = None)]`. This is slightly harder to parse in the macro, but matches the final result in Python better, so if this looks preferable to others, I can change from `text_signature = false` to `text_signature = None`.

There's some small tidying up / refactoring to do before this merges (happy to take suggestions on this), however the general logic, design and docs are ready for review.
