### PR TITLE
Define _PyErr_ChainExceptions() FFI for CPython

### DIFF
--- a/newsfragments/2788.added.md
+++ b/newsfragments/2788.added.md
@@ -1,0 +1,1 @@
+Define `_PyErr_ChainExceptions()` FFI for CPython.

--- a/pyo3-ffi/src/cpython/pyerrors.rs
+++ b/pyo3-ffi/src/cpython/pyerrors.rs
@@ -150,6 +150,11 @@ pub struct PyStopIterationObject {
     pub value: *mut PyObject,
 }
 
+extern "C" {
+    #[cfg(not(PyPy))]
+    pub fn _PyErr_ChainExceptions(typ: *mut PyObject, val: *mut PyObject, tb: *mut PyObject);
+}
+
 // skipped PyNameErrorObject
 // skipped PyAttributeErrorObject
 
@@ -159,8 +164,6 @@ pub struct PyStopIterationObject {
 // skipped _PyErr_SetKeyError
 // skipped _PyErr_GetTopmostException
 // skipped _PyErr_GetExcInfo
-
-// skipped _PyErr_ChainExceptions
 
 // skipped PyErr_SetFromErrnoWithUnicodeFilename
 


### PR DESCRIPTION
This appears to be the only way to chain exceptions via the FFI. It was introduced prior to CPython 3.7. It has some description of usage in PEP 490. There was a discussion of whether it should be made stable in BPO 44938.