### PR TITLE
netlify: fix mdbook update

### DIFF
--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -35,7 +35,7 @@ towncrier build --yes --version Unreleased --date TBC
 MDBOOK_VERSION=$(cargo search mdbook --limit 1 | head -1 | tr -s ' ' | cut -d ' ' -f 3 | tr -d '"')
 INSTALLED_MDBOOK_VERSION=$(mdbook --version || echo "none")
 if [ "${INSTALLED_MDBOOK_VERSION}" != "mdbook v${MDBOOK_VERSION}" ]; then
-    cargo install mdbook@${MDBOOK_VERSION}
+    cargo install mdbook@${MDBOOK_VERSION} --force
 fi
 
 pip install nox


### PR DESCRIPTION
Fixes the following error on netlify builds:

```text
6:34:54 PM: + '[' 'mdbook v0.4.21' '!=' 'mdbook v0.4.22' ']'
6:34:54 PM: + cargo install mdbook@0.4.22
6:34:54 PM:     Updating crates.io index
6:35:00 PM:  Downloading crates ...
6:35:00 PM:   Downloaded mdbook v0.4.22
6:35:00 PM: error: binary `mdbook` already exists in destination
6:35:00 PM: Add --force to overwrite
```