### PR TITLE
pyo3-macros-backend: benchmark some parsing

### DIFF
--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -24,3 +24,10 @@ features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-trait
 
 [features]
 abi3 = []
+
+[dev-dependencies]
+criterion = "0.3.5"
+
+[[bench]]
+name = "bench_cfg_attr"
+harness = false

--- a/pyo3-macros-backend/benches/bench_cfg_attr.rs
+++ b/pyo3-macros-backend/benches/bench_cfg_attr.rs
@@ -1,0 +1,59 @@
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use pyo3_macros_backend::PyClassArgs;
+use quote::quote;
+use syn::parse_quote;
+
+fn bench_parse_base(b: &mut Bencher<'_>) {
+    let attrs: Vec<syn::Attribute> = vec![parse_quote! {#[pyo3(name = "Foo")]}];
+    b.iter(|| {
+        let mut args =
+            syn::parse::Parser::parse2(PyClassArgs::parse_struct_args, quote! {}).unwrap();
+        let mut attrs = attrs.clone();
+        args.options.take_pyo3_options(&mut attrs).unwrap();
+    });
+}
+
+fn bench_parse_cfg_attr(b: &mut Bencher<'_>) {
+    let attrs: Vec<syn::Attribute> =
+        vec![parse_quote! {#[cfg_attr(feature = "pyo3", (name = "Foo"))]}];
+    b.iter(|| {
+        let mut args =
+            syn::parse::Parser::parse2(PyClassArgs::parse_struct_args, quote! {}).unwrap();
+        let mut attrs = attrs.clone();
+        args.options.take_pyo3_options(&mut attrs).unwrap();
+    });
+}
+
+fn bench_parse_null_cfg_attr(b: &mut Bencher<'_>) {
+    let attrs: Vec<syn::Attribute> =
+        vec![parse_quote! {#[cfg_attr(feature = "something_else", (name = "Foo"))]}];
+    b.iter(|| {
+        let mut args =
+            syn::parse::Parser::parse2(PyClassArgs::parse_struct_args, quote! {}).unwrap();
+        let mut attrs = attrs.clone();
+        args.options.take_pyo3_options(&mut attrs).unwrap();
+    });
+}
+
+fn bench_parse_irrelevant_attribute(b: &mut Bencher<'_>) {
+    let attrs: Vec<syn::Attribute> = vec![parse_quote! {#[foobar(bar = "baz")]}];
+    b.iter(|| {
+        let mut args =
+            syn::parse::Parser::parse2(PyClassArgs::parse_struct_args, quote! {}).unwrap();
+        let mut attrs = attrs.clone();
+        args.options.take_pyo3_options(&mut attrs).unwrap();
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("bench_parse_base", bench_parse_base);
+    c.bench_function("bench_parse_cfg_attr", bench_parse_cfg_attr);
+    c.bench_function("bench_parse_null_cfg_attr", bench_parse_null_cfg_attr);
+    c.bench_function(
+        "bench_parse_irrelevant_attribute",
+        bench_parse_irrelevant_attribute,
+    );
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -46,7 +46,7 @@ impl PyClassArgs {
         })
     }
 
-    pub fn parse_stuct_args(input: ParseStream<'_>) -> syn::Result<Self> {
+    pub fn parse_struct_args(input: ParseStream<'_>) -> syn::Result<Self> {
         Self::parse(input, PyClassKind::Struct)
     }
 

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -166,7 +166,7 @@ fn pyclass_impl(
     mut ast: syn::ItemStruct,
     methods_type: PyClassMethodsType,
 ) -> TokenStream {
-    let args = parse_macro_input!(attrs with PyClassArgs::parse_stuct_args);
+    let args = parse_macro_input!(attrs with PyClassArgs::parse_struct_args);
     let expanded = build_py_class(&mut ast, args, methods_type).unwrap_or_compile_error();
 
     quote!(


### PR DESCRIPTION
 To support #2786 

I've been meaning to try out benchmarking the macros for a while, looks like this approach of building up fake token trees and then interacting with them can work.