### PR TITLE
accept any iterator for `PySet::new` and `PyFrozenSet::new`

### DIFF
--- a/newsfragments/2795.changed.md
+++ b/newsfragments/2795.changed.md
@@ -1,0 +1,1 @@
+Accept any iterator in `PySet::new` and `PyFrozenSet::new`.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -286,7 +286,7 @@ mod num;
 #[cfg(not(PyPy))]
 mod pysuper;
 mod sequence;
-mod set;
+pub(crate) mod set;
 mod slice;
 mod string;
 mod traceback;

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -1,9 +1,12 @@
 // Copyright (c) 2017-present PyO3 Project and Contributors
 //
 
-use crate::err::{self, PyErr, PyResult};
 #[cfg(Py_LIMITED_API)]
 use crate::types::PyIterator;
+use crate::{
+    err::{self, PyErr, PyResult},
+    IntoPyPointer, Py,
+};
 use crate::{ffi, AsPyPointer, PyAny, PyObject, Python, ToPyObject};
 use std::ptr;
 
@@ -30,9 +33,12 @@ impl PySet {
     /// Creates a new set with elements from the given slice.
     ///
     /// Returns an error if some element is not hashable.
-    pub fn new<'p, T: ToPyObject>(py: Python<'p>, elements: &[T]) -> PyResult<&'p PySet> {
-        let list = elements.to_object(py);
-        unsafe { py.from_owned_ptr_or_err(ffi::PySet_New(list.as_ptr())) }
+    #[inline]
+    pub fn new<'a, 'p, T: ToPyObject + 'a>(
+        py: Python<'p>,
+        elements: impl IntoIterator<Item = &'a T>,
+    ) -> PyResult<&'p PySet> {
+        new_from_iter(py, elements).map(|set| set.into_ref(py))
     }
 
     /// Creates a new empty set.
@@ -229,6 +235,34 @@ mod impl_ {
 }
 
 pub use impl_::*;
+
+#[inline]
+pub(crate) fn new_from_iter<T: ToPyObject>(
+    py: Python<'_>,
+    elements: impl IntoIterator<Item = T>,
+) -> PyResult<Py<PySet>> {
+    fn new_from_iter_inner(
+        py: Python<'_>,
+        elements: &mut dyn Iterator<Item = PyObject>,
+    ) -> PyResult<Py<PySet>> {
+        let set: Py<PySet> = unsafe {
+            // We create the  `Py` pointer because its Drop cleans up the set if user code panics.
+            Py::from_owned_ptr_or_err(py, ffi::PySet_New(std::ptr::null_mut()))?
+        };
+        let ptr = set.as_ptr();
+
+        for obj in elements {
+            unsafe {
+                err::error_on_minusone(py, ffi::PySet_Add(ptr, obj.into_ptr()))?;
+            }
+        }
+
+        Ok(set)
+    }
+
+    let mut iter = elements.into_iter().map(|e| e.to_object(py));
+    new_from_iter_inner(py, &mut iter)
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Closes #2789 

Looks like it's about 20% faster in the case I benchmarked to use `PySet_Add` directly without the intermediate list.