### PR TITLE
allow `**kwargs` to take arguments which conflict with positional-only parameters

### DIFF
--- a/newsfragments/2800.fixed.md
+++ b/newsfragments/2800.fixed.md
@@ -1,0 +1,1 @@
+Allow functions taking `**kwargs` to accept keyword arguments which share a name with a positional-only argument (as permitted by PEP 570).

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -711,6 +711,16 @@ impl MethSignature {
         [a.to_object(py), kwargs.to_object(py)].to_object(py)
     }
 
+    #[pyo3(signature = (a=0, /, **kwargs))]
+    fn get_optional_pos_only_with_kwargs(
+        &self,
+        py: Python<'_>,
+        a: i32,
+        kwargs: Option<&PyDict>,
+    ) -> PyObject {
+        [a.to_object(py), kwargs.to_object(py)].to_object(py)
+    }
+
     #[pyo3(signature = (*, a = 2, b = 3))]
     fn get_kwargs_only_with_defaults(&self, a: i32, b: i32) -> i32 {
         a + b
@@ -959,6 +969,22 @@ fn meth_signature() {
             inst,
             "inst.get_pos_only_with_kwargs(a = 10, b = 10)",
             PyTypeError
+        );
+
+        py_run!(
+            py,
+            inst,
+            "assert inst.get_optional_pos_only_with_kwargs() == [0, None]"
+        );
+        py_run!(
+            py,
+            inst,
+            "assert inst.get_optional_pos_only_with_kwargs(10) == [10, None]"
+        );
+        py_run!(
+            py,
+            inst,
+            "assert inst.get_optional_pos_only_with_kwargs(a=10) == [0, {'a': 10}]"
         );
 
         py_run!(py, inst, "assert inst.get_kwargs_only_with_defaults() == 5");


### PR DESCRIPTION
Closes #2799 

I did a little bit of refactoring at the same time, sorry! The bit which changes behaviour is that in the now-factored-out `handle_kwargs` method, if the keyword argument name is found in the positional-only range then the varkeywords handler is now given a chance to accept it. (Lines 387-390 in new `extract_argument.rs`.)