### PR TITLE
pin CI to 3.11.0 as workaround for 2817

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,8 @@ jobs:
       matrix:
         extra-features: ["multiple-pymethods"]
         rust: [stable]
-        python-version: ["3.11"]
+        # FIXME - pinned to 3.11.0 because 3.11.1 breaks CI on windows, see PyO3 issue 2817
+        python-version: ["3.11.0"]
         platform:
           [
             {
@@ -140,7 +141,8 @@ jobs:
           "3.8",
           "3.9",
           "3.10",
-          "3.11",
+          # FIXME - pinned to 3.11.0 because 3.11.1 breaks CI on windows, see PyO3 issue 2817
+          "3.11.0",
           "pypy-3.7",
           "pypy-3.8",
           "pypy-3.9"


### PR DESCRIPTION
While we have issues with 3.11.1, let's run 3.11.0 for now in tests so that we can make progress.