### PR TITLE
netlify: remove trailing slash rewrites

### DIFF
--- a/.netlify/_redirects
+++ b/.netlify/_redirects
@@ -1,215 +1,143 @@
 /0.1.0/doc/* https://docs.rs/pyo3/0.1.0/:splat
-/0.1.0 /0.1.0/
 /0.1.0/* https://pyo3.github.io/pyo3/0.1.0/:splat 200
 /0.2.0/doc/* https://docs.rs/pyo3/0.2.0/:splat
-/0.2.0 /0.2.0/
 /0.2.0/* https://pyo3.github.io/pyo3/0.2.0/:splat 200
 /0.2.1/doc/* https://docs.rs/pyo3/0.2.1/:splat
-/0.2.1 /0.2.1/
 /0.2.1/* https://pyo3.github.io/pyo3/0.2.1/:splat 200
 /0.2.2/doc/* https://docs.rs/pyo3/0.2.2/:splat
-/0.2.2 /0.2.2/
 /0.2.2/* https://pyo3.github.io/pyo3/0.2.2/:splat 200
 /pyo3-derive-backend-0.6.0/doc/* https://docs.rs/pyo3/pyo3-derive-backend-0.6.0/:splat
-/pyo3-derive-backend-0.6.0 /pyo3-derive-backend-0.6.0/
 /pyo3-derive-backend-0.6.0/* https://pyo3.github.io/pyo3/pyo3-derive-backend-0.6.0/:splat 200
 /v0.10.0/doc/* https://docs.rs/pyo3/0.10.0/:splat
-/v0.10.0 /v0.10.0/
 /v0.10.0/* https://pyo3.github.io/pyo3/v0.10.0/:splat 200
 /v0.10.1/doc/* https://docs.rs/pyo3/0.10.1/:splat
-/v0.10.1 /v0.10.1/
 /v0.10.1/* https://pyo3.github.io/pyo3/v0.10.1/:splat 200
 /v0.11.0/doc/* https://docs.rs/pyo3/0.11.0/:splat
-/v0.11.0 /v0.11.0/
 /v0.11.0/* https://pyo3.github.io/pyo3/v0.11.0/:splat 200
 /v0.11.1/doc/* https://docs.rs/pyo3/0.11.1/:splat
-/v0.11.1 /v0.11.1/
 /v0.11.1/* https://pyo3.github.io/pyo3/v0.11.1/:splat 200
 /v0.12.0/doc/* https://docs.rs/pyo3/0.12.0/:splat
-/v0.12.0 /v0.12.0/
 /v0.12.0/* https://pyo3.github.io/pyo3/v0.12.0/:splat 200
 /v0.12.1/doc/* https://docs.rs/pyo3/0.12.1/:splat
-/v0.12.1 /v0.12.1/
 /v0.12.1/* https://pyo3.github.io/pyo3/v0.12.1/:splat 200
 /v0.12.2/doc/* https://docs.rs/pyo3/0.12.2/:splat
-/v0.12.2 /v0.12.2/
 /v0.12.2/* https://pyo3.github.io/pyo3/v0.12.2/:splat 200
 /v0.12.3/doc/* https://docs.rs/pyo3/0.12.3/:splat
-/v0.12.3 /v0.12.3/
 /v0.12.3/* https://pyo3.github.io/pyo3/v0.12.3/:splat 200
 /v0.12.4/doc/* https://docs.rs/pyo3/0.12.4/:splat
-/v0.12.4 /v0.12.4/
 /v0.12.4/* https://pyo3.github.io/pyo3/v0.12.4/:splat 200
 /v0.13.0/doc/* https://docs.rs/pyo3/0.13.0/:splat
-/v0.13.0 /v0.13.0/
 /v0.13.0/* https://pyo3.github.io/pyo3/v0.13.0/:splat 200
 /v0.13.1/doc/* https://docs.rs/pyo3/0.13.1/:splat
-/v0.13.1 /v0.13.1/
 /v0.13.1/* https://pyo3.github.io/pyo3/v0.13.1/:splat 200
 /v0.13.2/doc/* https://docs.rs/pyo3/0.13.2/:splat
-/v0.13.2 /v0.13.2/
 /v0.13.2/* https://pyo3.github.io/pyo3/v0.13.2/:splat 200
 /v0.14.0/doc/* https://docs.rs/pyo3/0.14.0/:splat
-/v0.14.0 /v0.14.0/
 /v0.14.0/* https://pyo3.github.io/pyo3/v0.14.0/:splat 200
 /v0.14.1/doc/* https://docs.rs/pyo3/0.14.1/:splat
-/v0.14.1 /v0.14.1/
 /v0.14.1/* https://pyo3.github.io/pyo3/v0.14.1/:splat 200
 /v0.14.2/doc/* https://docs.rs/pyo3/0.14.2/:splat
-/v0.14.2 /v0.14.2/
 /v0.14.2/* https://pyo3.github.io/pyo3/v0.14.2/:splat 200
 /v0.14.3/doc/* https://docs.rs/pyo3/0.14.3/:splat
-/v0.14.3 /v0.14.3/
 /v0.14.3/* https://pyo3.github.io/pyo3/v0.14.3/:splat 200
 /v0.14.4/doc/* https://docs.rs/pyo3/0.14.4/:splat
-/v0.14.4 /v0.14.4/
 /v0.14.4/* https://pyo3.github.io/pyo3/v0.14.4/:splat 200
 /v0.14.5/doc/* https://docs.rs/pyo3/0.14.5/:splat
-/v0.14.5 /v0.14.5/
 /v0.14.5/* https://pyo3.github.io/pyo3/v0.14.5/:splat 200
 /v0.15.0/doc/* https://docs.rs/pyo3/0.15.0/:splat
-/v0.15.0 /v0.15.0/
 /v0.15.0/* https://pyo3.github.io/pyo3/v0.15.0/:splat 200
 /v0.15.1/doc/* https://docs.rs/pyo3/0.15.1/:splat
-/v0.15.1 /v0.15.1/
 /v0.15.1/* https://pyo3.github.io/pyo3/v0.15.1/:splat 200
 /v0.15.2/doc/* https://docs.rs/pyo3/0.15.2/:splat
-/v0.15.2 /v0.15.2/
 /v0.15.2/* https://pyo3.github.io/pyo3/v0.15.2/:splat 200
 /v0.16.0/doc/* https://docs.rs/pyo3/0.16.0/:splat
-/v0.16.0 /v0.16.0/
 /v0.16.0/* https://pyo3.github.io/pyo3/v0.16.0/:splat 200
 /v0.16.1/doc/* https://docs.rs/pyo3/0.16.1/:splat
-/v0.16.1 /v0.16.1/
 /v0.16.1/* https://pyo3.github.io/pyo3/v0.16.1/:splat 200
 /v0.16.2/doc/* https://docs.rs/pyo3/0.16.2/:splat
-/v0.16.2 /v0.16.2/
 /v0.16.2/* https://pyo3.github.io/pyo3/v0.16.2/:splat 200
 /v0.16.3/doc/* https://docs.rs/pyo3/0.16.3/:splat
-/v0.16.3 /v0.16.3/
 /v0.16.3/* https://pyo3.github.io/pyo3/v0.16.3/:splat 200
 /v0.16.4/doc/* https://docs.rs/pyo3/0.16.4/:splat
-/v0.16.4 /v0.16.4/
 /v0.16.4/* https://pyo3.github.io/pyo3/v0.16.4/:splat 200
 /v0.16.5/doc/* https://docs.rs/pyo3/0.16.5/:splat
-/v0.16.5 /v0.16.5/
 /v0.16.5/* https://pyo3.github.io/pyo3/v0.16.5/:splat 200
 /v0.16.6/doc/* https://docs.rs/pyo3/0.16.6/:splat
-/v0.16.6 /v0.16.6/
 /v0.16.6/* https://pyo3.github.io/pyo3/v0.16.6/:splat 200
 /v0.17.0/doc/* https://docs.rs/pyo3/0.17.0/:splat
-/v0.17.0 /v0.17.0/
 /v0.17.0/* https://pyo3.github.io/pyo3/v0.17.0/:splat 200
 /v0.17.1/doc/* https://docs.rs/pyo3/0.17.1/:splat
-/v0.17.1 /v0.17.1/
 /v0.17.1/* https://pyo3.github.io/pyo3/v0.17.1/:splat 200
 /v0.17.2/doc/* https://docs.rs/pyo3/0.17.2/:splat
-/v0.17.2 /v0.17.2/
 /v0.17.2/* https://pyo3.github.io/pyo3/v0.17.2/:splat 200
 /v0.17.3/doc/* https://docs.rs/pyo3/0.17.3/:splat
-/v0.17.3 /v0.17.3/
 /v0.17.3/* https://pyo3.github.io/pyo3/v0.17.3/:splat 200
 /v0.2.3/doc/* https://docs.rs/pyo3/0.2.3/:splat
-/v0.2.3 /v0.2.3/
 /v0.2.3/* https://pyo3.github.io/pyo3/v0.2.3/:splat 200
 /v0.2.4/doc/* https://docs.rs/pyo3/0.2.4/:splat
-/v0.2.4 /v0.2.4/
 /v0.2.4/* https://pyo3.github.io/pyo3/v0.2.4/:splat 200
 /v0.2.5/doc/* https://docs.rs/pyo3/0.2.5/:splat
-/v0.2.5 /v0.2.5/
 /v0.2.5/* https://pyo3.github.io/pyo3/v0.2.5/:splat 200
 /v0.2.6/doc/* https://docs.rs/pyo3/0.2.6/:splat
-/v0.2.6 /v0.2.6/
 /v0.2.6/* https://pyo3.github.io/pyo3/v0.2.6/:splat 200
 /v0.2.7/doc/* https://docs.rs/pyo3/0.2.7/:splat
-/v0.2.7 /v0.2.7/
 /v0.2.7/* https://pyo3.github.io/pyo3/v0.2.7/:splat 200
 /v0.3.0/doc/* https://docs.rs/pyo3/0.3.0/:splat
-/v0.3.0 /v0.3.0/
 /v0.3.0/* https://pyo3.github.io/pyo3/v0.3.0/:splat 200
 /v0.3.1/doc/* https://docs.rs/pyo3/0.3.1/:splat
-/v0.3.1 /v0.3.1/
 /v0.3.1/* https://pyo3.github.io/pyo3/v0.3.1/:splat 200
 /v0.3.2/doc/* https://docs.rs/pyo3/0.3.2/:splat
-/v0.3.2 /v0.3.2/
 /v0.3.2/* https://pyo3.github.io/pyo3/v0.3.2/:splat 200
 /v0.4.0/doc/* https://docs.rs/pyo3/0.4.0/:splat
-/v0.4.0 /v0.4.0/
 /v0.4.0/* https://pyo3.github.io/pyo3/v0.4.0/:splat 200
 /v0.4.1/doc/* https://docs.rs/pyo3/0.4.1/:splat
-/v0.4.1 /v0.4.1/
 /v0.4.1/* https://pyo3.github.io/pyo3/v0.4.1/:splat 200
 /v0.5.0/doc/* https://docs.rs/pyo3/0.5.0/:splat
-/v0.5.0 /v0.5.0/
 /v0.5.0/* https://pyo3.github.io/pyo3/v0.5.0/:splat 200
 /v0.5.0-alpha.2/doc/* https://docs.rs/pyo3/0.5.0-alpha.2/:splat
-/v0.5.0-alpha.2 /v0.5.0-alpha.2/
 /v0.5.0-alpha.2/* https://pyo3.github.io/pyo3/v0.5.0-alpha.2/:splat 200
 /v0.5.0-alpha.3/doc/* https://docs.rs/pyo3/0.5.0-alpha.3/:splat
-/v0.5.0-alpha.3 /v0.5.0-alpha.3/
 /v0.5.0-alpha.3/* https://pyo3.github.io/pyo3/v0.5.0-alpha.3/:splat 200
 /v0.5.1/doc/* https://docs.rs/pyo3/0.5.1/:splat
-/v0.5.1 /v0.5.1/
 /v0.5.1/* https://pyo3.github.io/pyo3/v0.5.1/:splat 200
 /v0.5.2/doc/* https://docs.rs/pyo3/0.5.2/:splat
-/v0.5.2 /v0.5.2/
 /v0.5.2/* https://pyo3.github.io/pyo3/v0.5.2/:splat 200
 /v0.5.3/doc/* https://docs.rs/pyo3/0.5.3/:splat
-/v0.5.3 /v0.5.3/
 /v0.5.3/* https://pyo3.github.io/pyo3/v0.5.3/:splat 200
 /v0.5.4/doc/* https://docs.rs/pyo3/0.5.4/:splat
-/v0.5.4 /v0.5.4/
 /v0.5.4/* https://pyo3.github.io/pyo3/v0.5.4/:splat 200
 /v0.6.0/doc/* https://docs.rs/pyo3/0.6.0/:splat
-/v0.6.0 /v0.6.0/
 /v0.6.0/* https://pyo3.github.io/pyo3/v0.6.0/:splat 200
 /v0.6.0-alpha.1/doc/* https://docs.rs/pyo3/0.6.0-alpha.1/:splat
-/v0.6.0-alpha.1 /v0.6.0-alpha.1/
 /v0.6.0-alpha.1/* https://pyo3.github.io/pyo3/v0.6.0-alpha.1/:splat 200
 /v0.6.0-alpha.2/doc/* https://docs.rs/pyo3/0.6.0-alpha.2/:splat
-/v0.6.0-alpha.2 /v0.6.0-alpha.2/
 /v0.6.0-alpha.2/* https://pyo3.github.io/pyo3/v0.6.0-alpha.2/:splat 200
 /v0.6.0-alpha.3/doc/* https://docs.rs/pyo3/0.6.0-alpha.3/:splat
-/v0.6.0-alpha.3 /v0.6.0-alpha.3/
 /v0.6.0-alpha.3/* https://pyo3.github.io/pyo3/v0.6.0-alpha.3/:splat 200
 /v0.6.0-alpha.4/doc/* https://docs.rs/pyo3/0.6.0-alpha.4/:splat
-/v0.6.0-alpha.4 /v0.6.0-alpha.4/
 /v0.6.0-alpha.4/* https://pyo3.github.io/pyo3/v0.6.0-alpha.4/:splat 200
 /v0.7.0/doc/* https://docs.rs/pyo3/0.7.0/:splat
-/v0.7.0 /v0.7.0/
 /v0.7.0/* https://pyo3.github.io/pyo3/v0.7.0/:splat 200
 /v0.7.0-alpha.1/doc/* https://docs.rs/pyo3/0.7.0-alpha.1/:splat
-/v0.7.0-alpha.1 /v0.7.0-alpha.1/
 /v0.7.0-alpha.1/* https://pyo3.github.io/pyo3/v0.7.0-alpha.1/:splat 200
 /v0.8.0/doc/* https://docs.rs/pyo3/0.8.0/:splat
-/v0.8.0 /v0.8.0/
 /v0.8.0/* https://pyo3.github.io/pyo3/v0.8.0/:splat 200
 /v0.8.1/doc/* https://docs.rs/pyo3/0.8.1/:splat
-/v0.8.1 /v0.8.1/
 /v0.8.1/* https://pyo3.github.io/pyo3/v0.8.1/:splat 200
 /v0.8.2/doc/* https://docs.rs/pyo3/0.8.2/:splat
-/v0.8.2 /v0.8.2/
 /v0.8.2/* https://pyo3.github.io/pyo3/v0.8.2/:splat 200
 /v0.8.3/doc/* https://docs.rs/pyo3/0.8.3/:splat
-/v0.8.3 /v0.8.3/
 /v0.8.3/* https://pyo3.github.io/pyo3/v0.8.3/:splat 200
 /v0.8.4/doc/* https://docs.rs/pyo3/0.8.4/:splat
-/v0.8.4 /v0.8.4/
 /v0.8.4/* https://pyo3.github.io/pyo3/v0.8.4/:splat 200
 /v0.8.5/doc/* https://docs.rs/pyo3/0.8.5/:splat
-/v0.8.5 /v0.8.5/
 /v0.8.5/* https://pyo3.github.io/pyo3/v0.8.5/:splat 200
 /v0.9.0/doc/* https://docs.rs/pyo3/0.9.0/:splat
-/v0.9.0 /v0.9.0/
 /v0.9.0/* https://pyo3.github.io/pyo3/v0.9.0/:splat 200
 /v0.9.0-alpha.1/doc/* https://docs.rs/pyo3/0.9.0-alpha.1/:splat
-/v0.9.0-alpha.1 /v0.9.0-alpha.1/
 /v0.9.0-alpha.1/* https://pyo3.github.io/pyo3/v0.9.0-alpha.1/:splat 200
 /v0.9.1/doc/* https://docs.rs/pyo3/0.9.1/:splat
-/v0.9.1 /v0.9.1/
 /v0.9.1/* https://pyo3.github.io/pyo3/v0.9.1/:splat 200
 /v0.9.2/doc/* https://docs.rs/pyo3/0.9.2/:splat
-/v0.9.2 /v0.9.2/
 /v0.9.2/* https://pyo3.github.io/pyo3/v0.9.2/:splat 200
-/dev/bench /dev/bench/
 /dev/bench/* https://pyo3.github.io/pyo3/dev/bench/:splat 200

--- a/.netlify/create_redirects.py
+++ b/.netlify/create_redirects.py
@@ -14,13 +14,9 @@ def main() -> None:
         version_without_v = version.lstrip("v")
         # redirect doc requests to docs.rs
         print(f"/{version}/doc/* https://docs.rs/pyo3/{version_without_v}/:splat")
-        # guide doesn't render nicely if trailing slash missing
-        print(f"/{version} /{version}/")
         # proxy guide to github-pages hosting
         print(f"/{version}/* https://pyo3.github.io/pyo3/{version}/:splat 200")
-    # similar to guide, proxy benchmarks to github-pages hosting, add trailing
-    # slash.
-    print(f"/dev/bench /dev/bench/")
+    # proxy benchmarks to github-pages hosting
     print(f"/dev/bench/* https://pyo3.github.io/pyo3/dev/bench/:splat 200")
 
 


### PR DESCRIPTION
So adding rewrite rules in #2819 didn't work, created infinite redirect loops. Instead I've enabled the pretty URLs at https://docs.netlify.com/routing/redirects/redirect-options/#trailing-slash, let's see if that works.