### PR TITLE
pypy: enable `PyList::get_item_unchecked`

### DIFF
--- a/newsfragments/2827.added.md
+++ b/newsfragments/2827.added.md
@@ -1,0 +1,1 @@
+Add `PyList::get_item_unchecked` for PyPy.

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -142,7 +142,7 @@ impl PyList {
     /// # Safety
     ///
     /// Caller must verify that the index is within the bounds of the list.
-    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+    #[cfg(not(Py_LIMITED_API))]
     pub unsafe fn get_item_unchecked(&self, index: usize) -> &PyAny {
         let item = ffi::PyList_GET_ITEM(self.as_ptr(), index as Py_ssize_t);
         // PyList_GET_ITEM return borrowed ptr; must make owned for safety (see #890).


### PR DESCRIPTION
Split out from #2826. Approved previously as part of that review.