### PR TITLE
move set-minimal-package-versions to nox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
           python-version: ${{ inputs.python-version }}
           architecture: ${{ inputs.python-architecture }}
 
+      - name: Install nox
+        run: python -m pip install -U pip nox
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -54,24 +57,7 @@ jobs:
 
       - if: inputs.msrv == 'MSRV'
         name: Prepare minimal package versions (MSRV only)
-        run: |
-          set -x
-          cargo update -p indexmap --precise 1.6.2
-          cargo update -p hashbrown:0.12.3 --precise 0.9.1
-          PROJECTS=("." "examples/decorator" "examples/maturin-starter" "examples/setuptools-rust-starter" "examples/word-count")
-          for PROJ in ${PROJECTS[@]}; do
-            cargo update --manifest-path "$PROJ/Cargo.toml" -p parking_lot --precise 0.11.0
-            cargo update --manifest-path "$PROJ/Cargo.toml" -p once_cell --precise 1.14.0
-          done
-          cargo update --manifest-path "examples/word-count/Cargo.toml" -p rayon --precise 1.5.3
-          cargo update --manifest-path "examples/word-count/Cargo.toml" -p rayon-core --precise 1.9.3
-          cargo update -p plotters --precise 0.3.1
-          cargo update -p plotters-svg --precise 0.3.1
-          cargo update -p plotters-backend --precise 0.3.2
-          cargo update -p bumpalo --precise 3.10.0
-          cargo update -p once_cell --precise 1.14.0
-          cargo update -p rayon --precise 1.5.3
-          cargo update -p rayon-core --precise 1.9.3
+        run: nox -s set-minimal-package-versions
 
       - name: Build docs
         run: cargo doc --no-deps --no-default-features --features "full ${{ inputs.extra-features }}"
@@ -126,12 +112,10 @@ jobs:
 
       - name: Test python examples and tests
         shell: bash
-        run: |
-          python -m pip install -U pip nox
-          nox -s test-py
+        run: nox -s test-py
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/target
-      
+
       - uses: dorny/paths-filter@v2
         # pypy 3.7 and 3.8 are not PEP 3123 compliant so fail checks here
         if: ${{ inputs.rust == 'stable' && inputs.python-version != 'pypy-3.7' && inputs.python-version != 'pypy-3.8' }}
@@ -143,7 +127,7 @@ jobs:
               - 'pyo3-ffi-check/**'
               - '.github/workflows/ci.yml'
               - '.github/workflows/build.yml'
-      
+
       - run: cargo doc -p pyo3-ffi
         working-directory: pyo3-ffi-check
         if: ${{ steps.ffi-changes.outputs.changed == 'true' && inputs.rust == 'stable' && inputs.python-version != 'pypy-3.7' && inputs.python-version != 'pypy-3.8' }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -348,6 +348,54 @@ def check_changelog(session: nox.Session):
         print(fragment.name)
 
 
+@nox.session(name="set-minimal-package-versions")
+def set_minimal_package_versions(session: nox.Session):
+    # run cargo update first to ensure that everything is at highest
+    # possible version, so that this matches what CI will resolve to.
+    _run(session, "cargo", "update", external=True)
+
+    _run_cargo_set_package_version(session, "indexmap", "1.6.2")
+    _run_cargo_set_package_version(session, "hashbrown:0.12.3", "0.9.1")
+    _run_cargo_set_package_version(session, "plotters", "0.3.1")
+    _run_cargo_set_package_version(session, "plotters-svg", "0.3.1")
+    _run_cargo_set_package_version(session, "plotters-backend", "0.3.2")
+    _run_cargo_set_package_version(session, "bumpalo", "3.10.0")
+    _run_cargo_set_package_version(session, "once_cell", "1.14.0")
+    _run_cargo_set_package_version(session, "rayon", "1.5.3")
+    _run_cargo_set_package_version(session, "rayon-core", "1.9.3")
+
+    # 1.15.0 depends on hermit-abi 0.2.6 which has edition 2021 and breaks 1.48.0
+    _run_cargo_set_package_version(session, "num_cpus", "1.14.0")
+    _run_cargo_set_package_version(
+        session, "num_cpus", "1.14.0", project="examples/word-count"
+    )
+
+    projects = (
+        None,
+        "examples/decorator",
+        "examples/maturin-starter",
+        "examples/setuptools-rust-starter",
+        "examples/word-count",
+    )
+    for project in projects:
+        _run_cargo_set_package_version(
+            session, "parking_lot", "0.11.0", project=project
+        )
+        _run_cargo_set_package_version(session, "once_cell", "1.14.0", project=project)
+
+    _run_cargo_set_package_version(
+        session, "rayon", "1.5.3", project="examples/word-count"
+    )
+    _run_cargo_set_package_version(
+        session, "rayon-core", "1.9.3", project="examples/word-count"
+    )
+
+    # As a smoke test, cargo metadata solves all dependencies, so
+    # will break if any crates rely on cargo features not
+    # supported on MSRV
+    _run(session, "cargo", "metadata", silent=True, external=True)
+
+
 def _get_rust_target() -> str:
     output = _get_output("rustc", "-vV")
 
@@ -406,6 +454,19 @@ def _run_cargo_test(
 
 def _run_cargo_publish(session: nox.Session, *, package: str) -> None:
     _run(session, "cargo", "publish", f"--package={package}", external=True)
+
+
+def _run_cargo_set_package_version(
+    session: nox.Session,
+    package: str,
+    version: str,
+    *,
+    project: Optional[str] = None,
+) -> None:
+    command = ["cargo", "update", "-p", package, "--precise", version]
+    if project:
+        command.append(f"--manifest-path={project}/Cargo.toml")
+    _run(session, *command, external=True)
 
 
 def _get_output(*args: str) -> str:


### PR DESCRIPTION
Split from #2826 because #2827 couldn't merge due to `hermit-abi` MSRV break, which this PR also fixes (by pinning its dependent `num_cpus` back). 