### PR TITLE
add gh-pages content directly in netlify site

### DIFF
--- a/.netlify/_redirects
+++ b/.netlify/_redirects
@@ -1,143 +1,72 @@
 /0.1.0/doc/* https://docs.rs/pyo3/0.1.0/:splat
-/0.1.0/* https://pyo3.github.io/pyo3/0.1.0/:splat 200
 /0.2.0/doc/* https://docs.rs/pyo3/0.2.0/:splat
-/0.2.0/* https://pyo3.github.io/pyo3/0.2.0/:splat 200
 /0.2.1/doc/* https://docs.rs/pyo3/0.2.1/:splat
-/0.2.1/* https://pyo3.github.io/pyo3/0.2.1/:splat 200
 /0.2.2/doc/* https://docs.rs/pyo3/0.2.2/:splat
-/0.2.2/* https://pyo3.github.io/pyo3/0.2.2/:splat 200
 /pyo3-derive-backend-0.6.0/doc/* https://docs.rs/pyo3/pyo3-derive-backend-0.6.0/:splat
-/pyo3-derive-backend-0.6.0/* https://pyo3.github.io/pyo3/pyo3-derive-backend-0.6.0/:splat 200
 /v0.10.0/doc/* https://docs.rs/pyo3/0.10.0/:splat
-/v0.10.0/* https://pyo3.github.io/pyo3/v0.10.0/:splat 200
 /v0.10.1/doc/* https://docs.rs/pyo3/0.10.1/:splat
-/v0.10.1/* https://pyo3.github.io/pyo3/v0.10.1/:splat 200
 /v0.11.0/doc/* https://docs.rs/pyo3/0.11.0/:splat
-/v0.11.0/* https://pyo3.github.io/pyo3/v0.11.0/:splat 200
 /v0.11.1/doc/* https://docs.rs/pyo3/0.11.1/:splat
-/v0.11.1/* https://pyo3.github.io/pyo3/v0.11.1/:splat 200
 /v0.12.0/doc/* https://docs.rs/pyo3/0.12.0/:splat
-/v0.12.0/* https://pyo3.github.io/pyo3/v0.12.0/:splat 200
 /v0.12.1/doc/* https://docs.rs/pyo3/0.12.1/:splat
-/v0.12.1/* https://pyo3.github.io/pyo3/v0.12.1/:splat 200
 /v0.12.2/doc/* https://docs.rs/pyo3/0.12.2/:splat
-/v0.12.2/* https://pyo3.github.io/pyo3/v0.12.2/:splat 200
 /v0.12.3/doc/* https://docs.rs/pyo3/0.12.3/:splat
-/v0.12.3/* https://pyo3.github.io/pyo3/v0.12.3/:splat 200
 /v0.12.4/doc/* https://docs.rs/pyo3/0.12.4/:splat
-/v0.12.4/* https://pyo3.github.io/pyo3/v0.12.4/:splat 200
 /v0.13.0/doc/* https://docs.rs/pyo3/0.13.0/:splat
-/v0.13.0/* https://pyo3.github.io/pyo3/v0.13.0/:splat 200
 /v0.13.1/doc/* https://docs.rs/pyo3/0.13.1/:splat
-/v0.13.1/* https://pyo3.github.io/pyo3/v0.13.1/:splat 200
 /v0.13.2/doc/* https://docs.rs/pyo3/0.13.2/:splat
-/v0.13.2/* https://pyo3.github.io/pyo3/v0.13.2/:splat 200
 /v0.14.0/doc/* https://docs.rs/pyo3/0.14.0/:splat
-/v0.14.0/* https://pyo3.github.io/pyo3/v0.14.0/:splat 200
 /v0.14.1/doc/* https://docs.rs/pyo3/0.14.1/:splat
-/v0.14.1/* https://pyo3.github.io/pyo3/v0.14.1/:splat 200
 /v0.14.2/doc/* https://docs.rs/pyo3/0.14.2/:splat
-/v0.14.2/* https://pyo3.github.io/pyo3/v0.14.2/:splat 200
 /v0.14.3/doc/* https://docs.rs/pyo3/0.14.3/:splat
-/v0.14.3/* https://pyo3.github.io/pyo3/v0.14.3/:splat 200
 /v0.14.4/doc/* https://docs.rs/pyo3/0.14.4/:splat
-/v0.14.4/* https://pyo3.github.io/pyo3/v0.14.4/:splat 200
 /v0.14.5/doc/* https://docs.rs/pyo3/0.14.5/:splat
-/v0.14.5/* https://pyo3.github.io/pyo3/v0.14.5/:splat 200
 /v0.15.0/doc/* https://docs.rs/pyo3/0.15.0/:splat
-/v0.15.0/* https://pyo3.github.io/pyo3/v0.15.0/:splat 200
 /v0.15.1/doc/* https://docs.rs/pyo3/0.15.1/:splat
-/v0.15.1/* https://pyo3.github.io/pyo3/v0.15.1/:splat 200
 /v0.15.2/doc/* https://docs.rs/pyo3/0.15.2/:splat
-/v0.15.2/* https://pyo3.github.io/pyo3/v0.15.2/:splat 200
 /v0.16.0/doc/* https://docs.rs/pyo3/0.16.0/:splat
-/v0.16.0/* https://pyo3.github.io/pyo3/v0.16.0/:splat 200
 /v0.16.1/doc/* https://docs.rs/pyo3/0.16.1/:splat
-/v0.16.1/* https://pyo3.github.io/pyo3/v0.16.1/:splat 200
 /v0.16.2/doc/* https://docs.rs/pyo3/0.16.2/:splat
-/v0.16.2/* https://pyo3.github.io/pyo3/v0.16.2/:splat 200
 /v0.16.3/doc/* https://docs.rs/pyo3/0.16.3/:splat
-/v0.16.3/* https://pyo3.github.io/pyo3/v0.16.3/:splat 200
 /v0.16.4/doc/* https://docs.rs/pyo3/0.16.4/:splat
-/v0.16.4/* https://pyo3.github.io/pyo3/v0.16.4/:splat 200
 /v0.16.5/doc/* https://docs.rs/pyo3/0.16.5/:splat
-/v0.16.5/* https://pyo3.github.io/pyo3/v0.16.5/:splat 200
 /v0.16.6/doc/* https://docs.rs/pyo3/0.16.6/:splat
-/v0.16.6/* https://pyo3.github.io/pyo3/v0.16.6/:splat 200
 /v0.17.0/doc/* https://docs.rs/pyo3/0.17.0/:splat
-/v0.17.0/* https://pyo3.github.io/pyo3/v0.17.0/:splat 200
 /v0.17.1/doc/* https://docs.rs/pyo3/0.17.1/:splat
-/v0.17.1/* https://pyo3.github.io/pyo3/v0.17.1/:splat 200
 /v0.17.2/doc/* https://docs.rs/pyo3/0.17.2/:splat
-/v0.17.2/* https://pyo3.github.io/pyo3/v0.17.2/:splat 200
 /v0.17.3/doc/* https://docs.rs/pyo3/0.17.3/:splat
-/v0.17.3/* https://pyo3.github.io/pyo3/v0.17.3/:splat 200
 /v0.2.3/doc/* https://docs.rs/pyo3/0.2.3/:splat
-/v0.2.3/* https://pyo3.github.io/pyo3/v0.2.3/:splat 200
 /v0.2.4/doc/* https://docs.rs/pyo3/0.2.4/:splat
-/v0.2.4/* https://pyo3.github.io/pyo3/v0.2.4/:splat 200
 /v0.2.5/doc/* https://docs.rs/pyo3/0.2.5/:splat
-/v0.2.5/* https://pyo3.github.io/pyo3/v0.2.5/:splat 200
 /v0.2.6/doc/* https://docs.rs/pyo3/0.2.6/:splat
-/v0.2.6/* https://pyo3.github.io/pyo3/v0.2.6/:splat 200
 /v0.2.7/doc/* https://docs.rs/pyo3/0.2.7/:splat
-/v0.2.7/* https://pyo3.github.io/pyo3/v0.2.7/:splat 200
 /v0.3.0/doc/* https://docs.rs/pyo3/0.3.0/:splat
-/v0.3.0/* https://pyo3.github.io/pyo3/v0.3.0/:splat 200
 /v0.3.1/doc/* https://docs.rs/pyo3/0.3.1/:splat
-/v0.3.1/* https://pyo3.github.io/pyo3/v0.3.1/:splat 200
 /v0.3.2/doc/* https://docs.rs/pyo3/0.3.2/:splat
-/v0.3.2/* https://pyo3.github.io/pyo3/v0.3.2/:splat 200
 /v0.4.0/doc/* https://docs.rs/pyo3/0.4.0/:splat
-/v0.4.0/* https://pyo3.github.io/pyo3/v0.4.0/:splat 200
 /v0.4.1/doc/* https://docs.rs/pyo3/0.4.1/:splat
-/v0.4.1/* https://pyo3.github.io/pyo3/v0.4.1/:splat 200
 /v0.5.0/doc/* https://docs.rs/pyo3/0.5.0/:splat
-/v0.5.0/* https://pyo3.github.io/pyo3/v0.5.0/:splat 200
 /v0.5.0-alpha.2/doc/* https://docs.rs/pyo3/0.5.0-alpha.2/:splat
-/v0.5.0-alpha.2/* https://pyo3.github.io/pyo3/v0.5.0-alpha.2/:splat 200
 /v0.5.0-alpha.3/doc/* https://docs.rs/pyo3/0.5.0-alpha.3/:splat
-/v0.5.0-alpha.3/* https://pyo3.github.io/pyo3/v0.5.0-alpha.3/:splat 200
 /v0.5.1/doc/* https://docs.rs/pyo3/0.5.1/:splat
-/v0.5.1/* https://pyo3.github.io/pyo3/v0.5.1/:splat 200
 /v0.5.2/doc/* https://docs.rs/pyo3/0.5.2/:splat
-/v0.5.2/* https://pyo3.github.io/pyo3/v0.5.2/:splat 200
 /v0.5.3/doc/* https://docs.rs/pyo3/0.5.3/:splat
-/v0.5.3/* https://pyo3.github.io/pyo3/v0.5.3/:splat 200
 /v0.5.4/doc/* https://docs.rs/pyo3/0.5.4/:splat
-/v0.5.4/* https://pyo3.github.io/pyo3/v0.5.4/:splat 200
 /v0.6.0/doc/* https://docs.rs/pyo3/0.6.0/:splat
-/v0.6.0/* https://pyo3.github.io/pyo3/v0.6.0/:splat 200
 /v0.6.0-alpha.1/doc/* https://docs.rs/pyo3/0.6.0-alpha.1/:splat
-/v0.6.0-alpha.1/* https://pyo3.github.io/pyo3/v0.6.0-alpha.1/:splat 200
 /v0.6.0-alpha.2/doc/* https://docs.rs/pyo3/0.6.0-alpha.2/:splat
-/v0.6.0-alpha.2/* https://pyo3.github.io/pyo3/v0.6.0-alpha.2/:splat 200
 /v0.6.0-alpha.3/doc/* https://docs.rs/pyo3/0.6.0-alpha.3/:splat
-/v0.6.0-alpha.3/* https://pyo3.github.io/pyo3/v0.6.0-alpha.3/:splat 200
 /v0.6.0-alpha.4/doc/* https://docs.rs/pyo3/0.6.0-alpha.4/:splat
-/v0.6.0-alpha.4/* https://pyo3.github.io/pyo3/v0.6.0-alpha.4/:splat 200
 /v0.7.0/doc/* https://docs.rs/pyo3/0.7.0/:splat
-/v0.7.0/* https://pyo3.github.io/pyo3/v0.7.0/:splat 200
 /v0.7.0-alpha.1/doc/* https://docs.rs/pyo3/0.7.0-alpha.1/:splat
-/v0.7.0-alpha.1/* https://pyo3.github.io/pyo3/v0.7.0-alpha.1/:splat 200
 /v0.8.0/doc/* https://docs.rs/pyo3/0.8.0/:splat
-/v0.8.0/* https://pyo3.github.io/pyo3/v0.8.0/:splat 200
 /v0.8.1/doc/* https://docs.rs/pyo3/0.8.1/:splat
-/v0.8.1/* https://pyo3.github.io/pyo3/v0.8.1/:splat 200
 /v0.8.2/doc/* https://docs.rs/pyo3/0.8.2/:splat
-/v0.8.2/* https://pyo3.github.io/pyo3/v0.8.2/:splat 200
 /v0.8.3/doc/* https://docs.rs/pyo3/0.8.3/:splat
-/v0.8.3/* https://pyo3.github.io/pyo3/v0.8.3/:splat 200
 /v0.8.4/doc/* https://docs.rs/pyo3/0.8.4/:splat
-/v0.8.4/* https://pyo3.github.io/pyo3/v0.8.4/:splat 200
 /v0.8.5/doc/* https://docs.rs/pyo3/0.8.5/:splat
-/v0.8.5/* https://pyo3.github.io/pyo3/v0.8.5/:splat 200
 /v0.9.0/doc/* https://docs.rs/pyo3/0.9.0/:splat
-/v0.9.0/* https://pyo3.github.io/pyo3/v0.9.0/:splat 200
 /v0.9.0-alpha.1/doc/* https://docs.rs/pyo3/0.9.0-alpha.1/:splat
-/v0.9.0-alpha.1/* https://pyo3.github.io/pyo3/v0.9.0-alpha.1/:splat 200
 /v0.9.1/doc/* https://docs.rs/pyo3/0.9.1/:splat
-/v0.9.1/* https://pyo3.github.io/pyo3/v0.9.1/:splat 200
 /v0.9.2/doc/* https://docs.rs/pyo3/0.9.2/:splat
-/v0.9.2/* https://pyo3.github.io/pyo3/v0.9.2/:splat 200
-/dev/bench/* https://pyo3.github.io/pyo3/dev/bench/:splat 200
+/* https://pyo3.github.io/pyo3/:splat 200

--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -5,12 +5,19 @@ set -uex
 rustup default nightly
 
 PYO3_VERSION=$(cargo search pyo3 --limit 1 | head -1 | tr -s ' ' | cut -d ' ' -f 3 | tr -d '"')
-mkdir netlify_build
+
+## Start from the existing gh-pages content.
+## By servicng it over netlify, we can have better UX for users because
+## netlify can then redirect e.g. /v0.17.0 to /v0.17.0/
+## which leads to better loading of CSS assets.
+
+wget -qc https://github.com/PyO3/pyo3/archive/gh-pages.tar.gz -O - | tar -xz
+mv pyo3-gh-pages netlify_build
 
 ## Configure netlify _redirects file
 
-# TODO: have some better system to automatically generate this on build rather
-# than check this in to the repo
+# TODO: have some better system to automatically generate this on build rather
+# than check this in to the repo
 cp .netlify/_redirects netlify_build/
 
 # Add latest redirect (proxy)

--- a/.netlify/create_redirects.py
+++ b/.netlify/create_redirects.py
@@ -14,10 +14,8 @@ def main() -> None:
         version_without_v = version.lstrip("v")
         # redirect doc requests to docs.rs
         print(f"/{version}/doc/* https://docs.rs/pyo3/{version_without_v}/:splat")
-        # proxy guide to github-pages hosting
-        print(f"/{version}/* https://pyo3.github.io/pyo3/{version}/:splat 200")
-    # proxy benchmarks to github-pages hosting
-    print(f"/dev/bench/* https://pyo3.github.io/pyo3/dev/bench/:splat 200")
+    # fallback to github-pages for content not yet copied to netlify
+    print(f"/* https://pyo3.github.io/pyo3/:splat 200")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Last attempt to find a solution for #2819.

By adding the GitHub pages content directly to the netlify site during build, netlify should be able to make better URL redirects.