### PR TITLE
ci: use lld on windows and macos

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,6 +1,12 @@
 [alias]
 xtask = "run --package xtask --"
 
+# Faster linking in CI for doctests where lld is available
+[target.'cfg(any(target_os = "windows", target_os = "linux"))']
+rustflags = [
+    "-Clink-arg=-fuse-ld=lld"
+]
+
 [target.'cfg(feature = "cargo-clippy")']
 rustflags = [
     # TODO: remove these allows once msrv increased from 1.48


### PR DESCRIPTION
Closes #2834 

Looks like `lld` is supported by Rust on Windows and Linux only, and `mold` is only available for free on Linux, so I didn't bother investigating `mold`.