### PR TITLE
netlify: fix examples option on latest nightly

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,3 +11,4 @@ pyo3 = { version = "0.17.3", path = "..", features = ["auto-initialize", "extens
 name = "decorator"
 path = "decorator/src/lib.rs"
 crate_type = ["cdylib"]
+doc-scrape-examples = true

--- a/xtask/src/doc.rs
+++ b/xtask/src/doc.rs
@@ -33,12 +33,7 @@ pub fn run(opts: DocOpts) -> anyhow::Result<()> {
             .args(if opts.stable {
                 &[][..]
             } else {
-                &[
-                    "-Z",
-                    "unstable-options",
-                    "-Z",
-                    "rustdoc-scrape-examples=examples",
-                ][..]
+                &["-Z", "unstable-options", "-Z", "rustdoc-scrape-examples"][..]
             })
             .args(if opts.open { Some("--open") } else { None }),
     )?;


### PR DESCRIPTION
Looks like `-Zrustdoc-scrape-examples` no longer needs `=examples` value.