### PR TITLE
pypy: re-enable PyFunction on 3.8+

### DIFF
--- a/newsfragments/2838.changed.md
+++ b/newsfragments/2838.changed.md
@@ -1,0 +1,1 @@
+Re-enable `PyFunction` on when building for abi3 or PyPy.

--- a/pyo3-ffi/src/cpython/funcobject.rs
+++ b/pyo3-ffi/src/cpython/funcobject.rs
@@ -53,12 +53,12 @@ pub struct PyFunctionObject {
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
-    #[cfg(not(PyPy))] // broken, see https://foss.heptapod.net/pypy/pypy/-/issues/3776
+    #[cfg(not(all(PyPy, not(Py_3_8))))]
     #[cfg_attr(PyPy, link_name = "PyPyFunction_Type")]
     pub static mut PyFunction_Type: crate::PyTypeObject;
 }
 
-#[cfg(not(PyPy))]
+#[cfg(not(all(PyPy, not(Py_3_8))))]
 #[inline]
 pub unsafe fn PyFunction_Check(op: *mut PyObject) -> c_int {
     (crate::Py_TYPE(op) == addr_of_mut_shim!(PyFunction_Type)) as c_int

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -179,8 +179,8 @@ impl PyCFunction {
 
 /// Represents a Python function object.
 #[repr(transparent)]
-#[cfg(not(any(PyPy, Py_LIMITED_API)))]
+#[cfg(all(not(Py_LIMITED_API), not(all(PyPy, not(Py_3_8)))))]
 pub struct PyFunction(PyAny);
 
-#[cfg(not(any(PyPy, Py_LIMITED_API)))]
+#[cfg(all(not(Py_LIMITED_API), not(all(PyPy, not(Py_3_8)))))]
 pyobject_native_type_core!(PyFunction, ffi::PyFunction_Type, #checkfunction=ffi::PyFunction_Check);


### PR DESCRIPTION
PyPy [fixed the crashes associated with `PyFunction](https://foss.heptapod.net/pypy/pypy/-/issues/3776#note_191626)  in PyPy 7.3.10 (for 3.8+) - which I think is to be released shortly. So I think we should re-enable this API and treat it as a PyPy bug which users can mitigate by updating their PyPy.