### PR TITLE
remove functionality deprecated in 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,6 @@ abi3-py311 = ["abi3", "pyo3-build-config/abi3-py311", "pyo3-ffi/abi3-py311"]
 
 # Automatically generates `python3.dll` import libraries for Windows targets.
 generate-import-lib = ["pyo3-ffi/generate-import-lib"]
-# Deprecated, replaced by `generate-import-lib`
-generate-abi3-import-lib = ["generate-import-lib"]
 
 # Changes `Python::with_gil` and `Python::acquire_gil` to automatically initialize the
 # Python interpreter if needed.

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -56,7 +56,7 @@ assert!(m.as_ref(py).downcast::<PyMapping>().is_ok());
 
 Note that this requirement may go away in the future when a pyclass is able to inherit from the abstract base class directly (see [pyo3/pyo3#991](https://github.com/PyO3/pyo3/issues/991)).
 
-### The `multiple-pymethods` feature now requires Rust 1.62
+### The `multiple-pymethods` feature now requires Rust 1.62
 
 Due to limitations in the `inventory` crate which the `multiple-pymethods` feature depends on, this feature now
 requires Rust 1.62. For more information see [dtolnay/inventory#32](https://github.com/dtolnay/inventory/issues/32).
@@ -841,10 +841,7 @@ impl PySequenceProtocol for ByteSequence {
 ```
 
 After:
-```rust
-# #[allow(deprecated)]
-# #[cfg(feature = "pyproto")]
-# {
+```rust,compile_fail
 # use pyo3::prelude::*;
 # use pyo3::class::PySequenceProtocol;
 #[pyclass]
@@ -858,7 +855,6 @@ impl PySequenceProtocol for ByteSequence {
         elements.extend_from_slice(&other.elements);
         Ok(Self { elements })
     }
-}
 }
 ```
 

--- a/newsfragments/2843.removed.md
+++ b/newsfragments/2843.removed.md
@@ -1,0 +1,1 @@
+Remove all functionality deprecated in PyO3 0.16.

--- a/pyo3-build-config/src/import_lib.rs
+++ b/pyo3-build-config/src/import_lib.rs
@@ -4,10 +4,10 @@ use std::env;
 use std::path::PathBuf;
 
 use python3_dll_a::ImportLibraryGenerator;
+use target_lexicon::{Architecture, OperatingSystem, Triple};
 
+use super::{PythonImplementation, PythonVersion};
 use crate::errors::{Context, Result};
-
-use super::{Architecture, OperatingSystem, PythonImplementation, PythonVersion, Triple};
 
 /// Generates the `python3.dll` or `pythonXY.dll` import library for Windows targets.
 ///

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -21,11 +21,9 @@ use std::{env, process::Command, str::FromStr};
 #[cfg(feature = "resolve-config")]
 use once_cell::sync::OnceCell;
 
-#[allow(deprecated)]
 pub use impl_::{
-    cross_compiling, cross_compiling_from_to, find_all_sysconfigdata, parse_sysconfigdata,
-    BuildFlag, BuildFlags, CrossCompileConfig, InterpreterConfig, PythonImplementation,
-    PythonVersion, Triple,
+    cross_compiling_from_to, find_all_sysconfigdata, parse_sysconfigdata, BuildFlag, BuildFlags,
+    CrossCompileConfig, InterpreterConfig, PythonImplementation, PythonVersion, Triple,
 };
 use target_lexicon::OperatingSystem;
 

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -35,8 +35,6 @@ abi3-py311 = ["abi3", "pyo3-build-config/abi3-py311"]
 
 # Automatically generates `python3.dll` import libraries for Windows targets.
 generate-import-lib = ["pyo3-build-config/python3-dll-a"]
-# Deprecated, replaced by `generate-import-lib`
-generate-abi3-import-lib = ["generate-import-lib"]
 
 
 [build-dependencies]

--- a/pyo3-macros-backend/src/deprecations.rs
+++ b/pyo3-macros-backend/src/deprecations.rs
@@ -4,7 +4,6 @@ use quote::{quote_spanned, ToTokens};
 // Clippy complains all these variants have the same prefix "Py"...
 #[allow(clippy::enum_variant_names)]
 pub enum Deprecation {
-    PyClassGcOption,
     PyFunctionArguments,
     PyMethodArgsAttribute,
 }
@@ -12,7 +11,6 @@ pub enum Deprecation {
 impl Deprecation {
     fn ident(&self, span: Span) -> syn::Ident {
         let string = match self {
-            Deprecation::PyClassGcOption => "PYCLASS_GC_OPTION",
             Deprecation::PyFunctionArguments => "PYFUNCTION_ARGUMENTS",
             Deprecation::PyMethodArgsAttribute => "PYMETHODS_ARGS_ATTRIBUTE",
         };

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -709,7 +709,7 @@ fn parse_method_attributes(
                         deprecated_args.is_none(),
                         nested.span() => "args may only be specified once"
                     );
-                    deprecations.push(Deprecation::PyMethodArgsAttribute, nested.span());
+                    deprecations.push(Deprecation::PyMethodArgsAttribute, path.span());
                     deprecated_args = Some(DeprecatedArgs::from_meta(&nested)?);
                 } else {
                     new_attrs.push(attr)

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -6,7 +6,7 @@ use crate::attributes::{
     self, kw, take_pyo3_options, CrateAttribute, ExtendsAttribute, FreelistAttribute,
     ModuleAttribute, NameAttribute, NameLitStr, TextSignatureAttribute,
 };
-use crate::deprecations::{Deprecation, Deprecations};
+use crate::deprecations::Deprecations;
 use crate::konst::{ConstAttributes, ConstSpec};
 use crate::method::FnSpec;
 use crate::pyfunction::text_signature_or_none;
@@ -93,8 +93,6 @@ enum PyClassPyO3Option {
     TextSignature(TextSignatureAttribute),
     Unsendable(kw::unsendable),
     Weakref(kw::weakref),
-
-    DeprecatedGC(kw::gc),
 }
 
 impl Parse for PyClassPyO3Option {
@@ -130,8 +128,6 @@ impl Parse for PyClassPyO3Option {
             input.parse().map(PyClassPyO3Option::Unsendable)
         } else if lookahead.peek(attributes::kw::weakref) {
             input.parse().map(PyClassPyO3Option::Weakref)
-        } else if lookahead.peek(attributes::kw::gc) {
-            input.parse().map(PyClassPyO3Option::DeprecatedGC)
         } else {
             Err(lookahead.error())
         }
@@ -184,10 +180,6 @@ impl PyClassPyO3Options {
             PyClassPyO3Option::TextSignature(text_signature) => set_option!(text_signature),
             PyClassPyO3Option::Unsendable(unsendable) => set_option!(unsendable),
             PyClassPyO3Option::Weakref(weakref) => set_option!(weakref),
-
-            PyClassPyO3Option::DeprecatedGC(gc) => self
-                .deprecations
-                .push(Deprecation::PyClassGcOption, gc.span()),
         }
         Ok(())
     }

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -661,57 +661,6 @@ impl PyErr {
             }
         }
     }
-
-    /// Deprecated name for [`PyErr::get_type`].
-    #[deprecated(
-        since = "0.16.0",
-        note = "Use err.get_type(py) instead of err.ptype(py)"
-    )]
-    pub fn ptype<'py>(&'py self, py: Python<'py>) -> &'py PyType {
-        self.get_type(py)
-    }
-
-    /// Deprecated name for [`PyErr::value`].
-    #[deprecated(since = "0.16.0", note = "Use err.value(py) instead of err.pvalue(py)")]
-    pub fn pvalue<'py>(&'py self, py: Python<'py>) -> &'py PyBaseException {
-        self.value(py)
-    }
-
-    /// Deprecated name for [`PyErr::traceback`].
-    #[deprecated(
-        since = "0.16.0",
-        note = "Use err.traceback(py) instead of err.ptraceback(py)"
-    )]
-    pub fn ptraceback<'py>(&'py self, py: Python<'py>) -> Option<&'py PyTraceback> {
-        self.traceback(py)
-    }
-
-    /// Deprecated name for [`PyErr::value`].
-    #[deprecated(
-        since = "0.16.0",
-        note = "Use err.value(py) instead of err.instance(py)"
-    )]
-    pub fn instance<'py>(&'py self, py: Python<'py>) -> &'py PyBaseException {
-        self.value(py)
-    }
-
-    /// Deprecated name for [`PyErr::from_value`].
-    #[deprecated(
-        since = "0.16.0",
-        note = "Use err.from_value(py, obj) instead of err.from_instance(py, obj)"
-    )]
-    pub fn from_instance(value: &PyAny) -> PyErr {
-        PyErr::from_value(value)
-    }
-
-    /// Deprecated name for [`PyErr::into_value`].
-    #[deprecated(
-        since = "0.16.0",
-        note = "Use err.into_value(py) instead of err.into_instance(py)"
-    )]
-    pub fn into_instance(self, py: Python<'_>) -> Py<PyBaseException> {
-        self.into_value(py)
-    }
 }
 
 impl std::fmt::Debug for PyErr {
@@ -831,7 +780,7 @@ fn exceptions_must_derive_from_base_exception(py: Python<'_>) -> PyErr {
 mod tests {
     use super::PyErrState;
     use crate::exceptions;
-    use crate::{AsPyPointer, PyErr, Python};
+    use crate::{PyErr, Python};
 
     #[test]
     fn no_error() {
@@ -974,30 +923,6 @@ mod tests {
                 .cause(py)
                 .expect("set_cause should have given us a cause");
             assert_eq!(cause.to_string(), "ValueError: orange");
-        });
-    }
-
-    #[allow(deprecated)]
-    #[test]
-    fn deprecations() {
-        let err = exceptions::PyValueError::new_err("an error");
-        Python::with_gil(|py| {
-            assert_eq!(err.ptype(py).as_ptr(), err.get_type(py).as_ptr());
-            assert_eq!(err.pvalue(py).as_ptr(), err.value(py).as_ptr());
-            assert_eq!(err.instance(py).as_ptr(), err.value(py).as_ptr());
-            assert_eq!(
-                err.ptraceback(py).map(|t| t.as_ptr()),
-                err.traceback(py).map(|t| t.as_ptr())
-            );
-
-            assert_eq!(
-                err.clone_ref(py).into_instance(py).as_ref(py).as_ptr(),
-                err.value(py).as_ptr()
-            );
-            assert_eq!(
-                PyErr::from_instance(err.value(py)).value(py).as_ptr(),
-                err.value(py).as_ptr()
-            );
         });
     }
 

--- a/src/impl_/deprecations.rs
+++ b/src/impl_/deprecations.rs
@@ -1,12 +1,6 @@
 //! Symbols used to denote deprecated usages of PyO3's proc macros.
 
 #[deprecated(
-    since = "0.16.0",
-    note = "implement a `__traverse__` `#[pymethod]` instead of using `gc` option"
-)]
-pub const PYCLASS_GC_OPTION: () = ();
-
-#[deprecated(
     since = "0.18.0",
     note = "passing arbitrary arguments to `#[pyfunction()]` to specify the signature is being replaced by `#[pyo3(signature)]`"
 )]

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -58,19 +58,6 @@ impl PyType {
     {
         self.is_subclass(T::type_object(self.py()))
     }
-
-    #[deprecated(
-        since = "0.16.0",
-        note = "prefer obj.is_instance(type) to typ.is_instance(obj)"
-    )]
-    /// Equivalent to Python's `isinstance(obj, self)`.
-    ///
-    /// This function has been deprecated because it has inverted argument ordering compared to
-    /// other `is_instance` functions in PyO3 such as [`PyAny::is_instance`].
-    pub fn is_instance<T: AsPyPointer>(&self, obj: &T) -> PyResult<bool> {
-        let any: &PyAny = unsafe { self.py().from_borrowed_ptr(obj.as_ptr()) };
-        any.is_instance(self)
-    }
 }
 
 #[cfg(test)]
@@ -92,16 +79,5 @@ mod tests {
         Python::with_gil(|py| {
             assert!(py.get_type::<PyBool>().is_subclass_of::<PyLong>().unwrap());
         });
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn type_is_instance() {
-        Python::with_gil(|py| {
-            let bool_object = PyBool::new(py, false);
-            let bool_type = bool_object.get_type();
-            assert!(bool_type.is_instance(bool_object).unwrap());
-            assert!(bool_object.is_instance(bool_type).unwrap());
-        })
     }
 }

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -2,9 +2,6 @@
 
 use pyo3::prelude::*;
 
-#[pyclass(gc)]
-struct DeprecatedGc;
-
 #[pyfunction(_opt = "None", x = "5")]
 fn function_with_args(_opt: Option<i32>, _x: i32) {}
 

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -1,7 +1,7 @@
 error: use of deprecated constant `pyo3::impl_::deprecations::PYFUNCTION_ARGUMENTS`: passing arbitrary arguments to `#[pyfunction()]` to specify the signature is being replaced by `#[pyo3(signature)]`
- --> tests/ui/deprecations.rs:8:14
+ --> tests/ui/deprecations.rs:5:14
   |
-8 | #[pyfunction(_opt = "None", x = "5")]
+5 | #[pyfunction(_opt = "None", x = "5")]
   |              ^^^^
   |
 note: the lint level is defined here
@@ -10,14 +10,8 @@ note: the lint level is defined here
 1 | #![deny(deprecated)]
   |         ^^^^^^^^^^
 
-error: use of deprecated constant `pyo3::impl_::deprecations::PYCLASS_GC_OPTION`: implement a `__traverse__` `#[pymethod]` instead of using `gc` option
- --> tests/ui/deprecations.rs:5:11
-  |
-5 | #[pyclass(gc)]
-  |           ^^
-
 error: use of deprecated constant `pyo3::impl_::deprecations::PYMETHODS_ARGS_ATTRIBUTE`: the `#[args]` attribute for `#[methods]` is being replaced by `#[pyo3(signature)]`
-  --> tests/ui/deprecations.rs:16:12
+  --> tests/ui/deprecations.rs:13:7
    |
-16 |     #[args(_opt = "None", x = "5")]
-   |            ^^^^
+13 |     #[args(_opt = "None", x = "5")]
+   |       ^^^^

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `crate`, `dict`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `sequence`, `set_all`, `subclass`, `text_signature`, `unsendable`, `weakref`, `gc`
+error: expected one of: `crate`, `dict`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `sequence`, `set_all`, `subclass`, `text_signature`, `unsendable`, `weakref`
  --> tests/ui/invalid_pyclass_args.rs:3:11
   |
 3 | #[pyclass(extend=pyo3::types::PyDict)]
@@ -34,7 +34,7 @@ error: expected string literal
 18 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
-error: expected one of: `crate`, `dict`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `sequence`, `set_all`, `subclass`, `text_signature`, `unsendable`, `weakref`, `gc`
+error: expected one of: `crate`, `dict`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `sequence`, `set_all`, `subclass`, `text_signature`, `unsendable`, `weakref`
   --> tests/ui/invalid_pyclass_args.rs:21:11
    |
 21 | #[pyclass(weakrev)]


### PR DESCRIPTION
Simple cleanup to remove all functionality marked deprecated in the 0.16 releases.