### PR TITLE
Relax indexmap dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ anyhow = { version = "1.0", optional = true }
 chrono = { version = "0.4", optional = true }
 eyre = { version = ">= 0.4, < 0.7", optional = true }
 hashbrown = { version = ">= 0.9, < 0.13", optional = true }
-indexmap = { version = ">= 1.6, < 1.8", optional = true }
+indexmap = { version = "1.6", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-complex = { version = ">= 0.2, < 0.5", optional = true }
 serde = { version = "1.0", optional = true }

--- a/newsfragments/2849.packaging.md
+++ b/newsfragments/2849.packaging.md
@@ -1,0 +1,1 @@
+Relax dependency on Rust crate `indexmap` to cover `>= 1.6, < 2`


### PR DESCRIPTION
Halloo,

Noticed some version resolve errors when trying to use the `indexmap` features.
```bash
❯ cargo add pyo3 --features indexmap
❯ cargo add serde_yaml
    Updating crates.io index
      Adding serde_yaml v0.9.16 to dependencies.
error: failed to select a version for `indexmap`.
    ... required by package `pyo3 v0.17.3`
    ... which satisfies dependency `pyo3 = "^0.17.3"` of package `pyo3-indexmap v0.1.0 (/home/dn/repos/pyo3-indexmap)`
versions that meet the requirements `>=1.6, <1.8` are: 1.7.0, 1.6.2, 1.6.1, 1.6.0

all possible versions conflict with previously selected packages.

  previously selected package `indexmap v1.9.0`
    ... which satisfies dependency `indexmap = "^1.9"` of package `serde_yaml v0.9.16`
    ... which satisfies dependency `serde_yaml = "^0.9.16"` of package `pyo3-indexmap v0.1.0 (/home/dn/repos/pyo3-indexmap)`

failed to select a version for `indexmap` which could resolve this conflict
```

Couldn't find a specific reason for this limitation so I tried upgrading the dependency and running the tests.
Ran the tests locally with `indexmap==v1.9.2`:
```
❯ cargo test --features indexmap conversions::indexmap
...
running 4 tests
test conversions::indexmap::test_indexmap::test_indexmap_indexmap_insertion_order_round_trip ... ok
test conversions::indexmap::test_indexmap::test_indexmap_indexmap_to_python ... ok
test conversions::indexmap::test_indexmap::test_indexmap_indexmap_into_python ... ok
test conversions::indexmap::test_indexmap::test_indexmap_indexmap_into_dict ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 536 filtered out; finished in 0.03s
```

(Tried running `cargo xtask ci` but it failed on some warnings in the generated FFI code)

This relaxes the restrictions on `indexmap` so that the latest version is also supported,
hope that's okay.

Cheers,
Gilad