### PR TITLE
RFC: use bors squash merges

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -5,3 +5,4 @@ status = [
     "conclusion",
 ]
 timeout_sec = 21600
+use_squash_merge = true


### PR DESCRIPTION
This turns on bors' "squash merge" option.

Previously if a PR had a number of small revisions which were only really meaningful during the review process, I would use Github's squash-and-merge button. Now, with bors, I find myself occasionally force-pushing to flatten PRs, which slows me down as I can't do it until I get to a laptop.

By making bors do this, we will always get a squashed PR, which helps keep a clean git history while also speeding me up. The downside is that occasionally it can be nice to keep several commits separate; with this setting doing so would require separate PRs. (Which might be a good thing anyway?)

What do you folks think of enabling this setting?