### PR TITLE
Remove `libpython.so` from cross compile error message

### DIFF
--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1164,10 +1164,7 @@ fn find_sysconfigdata(cross: &CrossCompileConfig) -> Result<Option<PathBuf>> {
     let mut sysconfig_paths = find_all_sysconfigdata(cross);
     if sysconfig_paths.is_empty() {
         if let Some(lib_dir) = cross.lib_dir.as_ref() {
-            bail!(
-                "Could not find either libpython.so or _sysconfigdata*.py in {}",
-                lib_dir.display()
-            );
+            bail!("Could not find _sysconfigdata*.py in {}", lib_dir.display());
         } else {
             // Continue with the default configuration when PYO3_CROSS_LIB_DIR is not set.
             return Ok(None);


### PR DESCRIPTION
See https://github.com/PyO3/pyo3/discussions/2858.

Same as https://github.com/PyO3/maturin/pull/1389