### PR TITLE
remove fallback rewrite for netlify -> gh-pages

### DIFF
--- a/.netlify/_redirects
+++ b/.netlify/_redirects
@@ -69,4 +69,3 @@
 /v0.9.0-alpha.1/doc/* https://docs.rs/pyo3/0.9.0-alpha.1/:splat
 /v0.9.1/doc/* https://docs.rs/pyo3/0.9.1/:splat
 /v0.9.2/doc/* https://docs.rs/pyo3/0.9.2/:splat
-/* https://pyo3.github.io/pyo3/:splat 200

--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -7,7 +7,7 @@ rustup default nightly
 PYO3_VERSION=$(cargo search pyo3 --limit 1 | head -1 | tr -s ' ' | cut -d ' ' -f 3 | tr -d '"')
 
 ## Start from the existing gh-pages content.
-## By servicng it over netlify, we can have better UX for users because
+## By serving it over netlify, we can have better UX for users because
 ## netlify can then redirect e.g. /v0.17.0 to /v0.17.0/
 ## which leads to better loading of CSS assets.
 

--- a/.netlify/create_redirects.py
+++ b/.netlify/create_redirects.py
@@ -14,8 +14,6 @@ def main() -> None:
         version_without_v = version.lstrip("v")
         # redirect doc requests to docs.rs
         print(f"/{version}/doc/* https://docs.rs/pyo3/{version_without_v}/:splat")
-    # fallback to github-pages for content not yet copied to netlify
-    print(f"/* https://pyo3.github.io/pyo3/:splat 200")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of having a rewrite to serve all content in gh-pages but not in netlify, instead I've added a webhook so that netlify will pull and rebuild when there is a push to gh-pages.

Fixes #2850