### PR TITLE
change latest URL from netlify proxy to redirect

### DIFF
--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -20,8 +20,8 @@ mv pyo3-gh-pages netlify_build
 # than check this in to the repo
 cp .netlify/_redirects netlify_build/
 
-# Add latest redirect (proxy)
-echo "/latest/* https://pyo3.github.io/pyo3/v${PYO3_VERSION}/:splat 200" >> netlify_build/_redirects
+# Add latest redirect
+echo "/latest/* /v${PYO3_VERSION}/:splat" >> netlify_build/_redirects
 
 ## Add landing page redirect
 if [ "${CONTEXT}" == "deploy-preview" ]; then


### PR DESCRIPTION
Now that we serve all gh-pages content in netlify, it's nicer to have this as a proper redirect rather than a rewrite. Then the user can see what version of the docs they have landed on.

Closes #2867 