### PR TITLE
Improve derive(FromPyObject) to apply intern! when applicable to get_item

### DIFF
--- a/newsfragments/2879.changed.md
+++ b/newsfragments/2879.changed.md
@@ -1,0 +1,1 @@
+Improve `derive(FromPyObject)` to apply `intern!` when applicable to `#[pyo3(item)]`.

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -315,8 +315,13 @@ impl<'a> Container<'a> {
                 FieldGetter::GetAttr(None) => {
                     quote!(getattr(_pyo3::intern!(obj.py(), #field_name)))
                 }
+                FieldGetter::GetItem(Some(syn::Lit::Str(key))) => {
+                    quote!(get_item(_pyo3::intern!(obj.py(), #key)))
+                }
                 FieldGetter::GetItem(Some(key)) => quote!(get_item(#key)),
-                FieldGetter::GetItem(None) => quote!(get_item(#field_name)),
+                FieldGetter::GetItem(None) => {
+                    quote!(get_item(_pyo3::intern!(obj.py(), #field_name)))
+                }
             };
             let extractor = match &field.from_py_with {
                 None => {


### PR DESCRIPTION
This PR adds more `intern!`s to FromPyObject derive macro implementation. This should improve performance when using `#[pyo3(item)]`.
