### PR TITLE
Add support for nogil Python

### DIFF
--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -225,7 +225,7 @@ FRAMEWORK = bool(get_config_var("PYTHONFRAMEWORK"))
 SHARED = bool(get_config_var("Py_ENABLE_SHARED"))
 
 implementation = platform.python_implementation()
-if get_config_var("SOABI").startswith("nogil"):
+if sys.implementation.name == "nogil":
     implementation = "NoGIL"
 
 print("implementation", implementation)

--- a/pyo3-ffi/src/listobject.rs
+++ b/pyo3-ffi/src/listobject.rs
@@ -27,6 +27,8 @@ extern "C" {
     pub fn PyList_Size(arg1: *mut PyObject) -> Py_ssize_t;
     #[cfg_attr(PyPy, link_name = "PyPyList_GetItem")]
     pub fn PyList_GetItem(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject;
+    #[cfg_attr(Py_NOGIL, link_name = "PyList_Item")]
+    pub fn _PyList_FetchItem(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyList_SetItem")]
     pub fn PyList_SetItem(arg1: *mut PyObject, arg2: Py_ssize_t, arg3: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyList_Insert")]
@@ -63,4 +65,16 @@ extern "C" {
     #[cfg(PyPy)]
     #[cfg_attr(PyPy, link_name = "PyPyList_SET_ITEM")]
     pub fn PyList_SET_ITEM(arg1: *mut PyObject, arg2: Py_ssize_t, arg3: *mut PyObject);
+}
+
+#[inline]
+#[cfg(not(Py_NOGIL))]
+pub unsafe fn PyList_FetchItem(list: *mut PyObject, index: Py_ssize_t) -> *mut PyObject {
+    _Py_XNewRef(PyList_GetItem(list, index))
+}
+
+#[inline]
+#[cfg(Py_NOGIL)]
+pub unsafe fn PyList_FetchItem(list: *mut PyObject, index: Py_ssize_t) -> *mut PyObject {
+    _PyList_FetchItem(list, index)
 }

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -85,9 +85,7 @@ pub unsafe fn Py_REFCNT(ob: *mut PyObject) -> Py_ssize_t {
 #[inline]
 #[cfg(Py_NOGIL)]
 pub unsafe fn Py_REFCNT(ob: *mut PyObject) -> Py_ssize_t {
-    if ob.is_null() {
-        panic!();
-    }
+    assert!(!ob.is_null());
     Py_RefCnt(ob)
 }
 

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -146,10 +146,10 @@ impl PyDict {
         K: ToPyObject,
     {
         unsafe {
-            let ptr = ffi::PyDict_GetItem(self.as_ptr(), key.to_object(self.py()).as_ptr());
+            let ptr = ffi::PyDict_FetchItem(self.as_ptr(), key.to_object(self.py()).as_ptr());
             NonNull::new(ptr).map(|p| {
                 // PyDict_GetItem return s borrowed ptr, must make it owned for safety (see #890).
-                self.py().from_owned_ptr(ffi::_Py_NewRef(p.as_ptr()))
+                self.py().from_owned_ptr(p.as_ptr())
             })
         }
     }
@@ -166,12 +166,12 @@ impl PyDict {
     {
         unsafe {
             let ptr =
-                ffi::PyDict_GetItemWithError(self.as_ptr(), key.to_object(self.py()).as_ptr());
+                ffi::PyDict_FetchItemWithError(self.as_ptr(), key.to_object(self.py()).as_ptr());
             if !ffi::PyErr_Occurred().is_null() {
                 return Err(PyErr::fetch(self.py()));
             }
 
-            Ok(NonNull::new(ptr).map(|p| self.py().from_owned_ptr(ffi::_Py_NewRef(p.as_ptr()))))
+            Ok(NonNull::new(ptr).map(|p| self.py().from_owned_ptr(p.as_ptr())))
         }
     }
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -130,9 +130,7 @@ impl PyList {
     /// ```
     pub fn get_item(&self, index: usize) -> PyResult<&PyAny> {
         unsafe {
-            let item = ffi::PyList_GetItem(self.as_ptr(), index as Py_ssize_t);
-            // PyList_GetItem return borrowed ptr; must make owned for safety (see #890).
-            ffi::Py_XINCREF(item);
+            let item = ffi::PyList_FetchItem(self.as_ptr(), index as Py_ssize_t);
             self.py().from_owned_ptr_or_err(item)
         }
     }
@@ -141,7 +139,8 @@ impl PyList {
     ///
     /// # Safety
     ///
-    /// Caller must verify that the index is within the bounds of the list.
+    /// Caller must verify that the index is within the bounds of the list and that no other
+    /// thread is concurrently modifying the list.
     #[cfg(not(Py_LIMITED_API))]
     pub unsafe fn get_item_unchecked(&self, index: usize) -> &PyAny {
         let item = ffi::PyList_GET_ITEM(self.as_ptr(), index as Py_ssize_t);


### PR DESCRIPTION
Per the discussion in [Discourse](https://discuss.python.org/t/pep-703-making-the-global-interpreter-lock-optional/22606), these are the changes to PyO3 to work with the [nogil](https://github.com/colesbury/nogil) proof-of-concept implementation. I've rebased these changes from 0.15.2 and done some light testing locally.

* The primary purpose of this PR is to discuss the changes PyO3 would need to support PEP 703. Those changes would be slightly different because the PEP proposes an ABI flag like "cp312n" whereas the "nogil" fork currently looks something like "nogil39". Additionally, the reference count fields are slightly different sizes in the PEP vs. in the "nogil" fork (basically `Py_ssize_t` in the PEP and `u32` in the fork). Otherwise, I think the changes would be similar.

* Additionally, if you're interested, it would be great for PyO3 to support the "nogil" fork (i.e., to get this PR in a state where it can be merged). That would make it easier to support projects that depend on PyO3 in "nogil" Python (and may help the PEP too). We've done something similar in https://github.com/cython/cython/pull/4914. (Of course, if it ever feels like too much of a maintenance burden in the future, you should feel free to drop it.)

