### PR TITLE
send errors in `__releasebuffer__` to `sys.unraisablehook`

### DIFF
--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -362,7 +362,8 @@ Coercions:
 ### Buffer objects
 
   - `__getbuffer__(<self>, *mut ffi::Py_buffer, flags) -> ()`
-  - `__releasebuffer__(<self>, *mut ffi::Py_buffer)` (no return value, not even `PyResult`)
+  - `__releasebuffer__(<self>, *mut ffi::Py_buffer) -> ()`
+    Errors returned from `__releasebuffer__` will be sent to `sys.unraiseablehook`. It is strongly advised to never return an error from `__releasebuffer__`, and if it really is necessary, to make best effort to perform any required freeing operations before returning. `__releasebuffer__` will not be called a second time; anything not freed will be leaked.
 
 ### Garbage Collector Integration
 

--- a/newsfragments/2886.fixed.md
+++ b/newsfragments/2886.fixed.md
@@ -1,0 +1,1 @@
+Send errors returned by `__releasebuffer__` to `sys.unraisablehook` rather than causing `SystemError`.

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -28,10 +28,6 @@ impl PyCallbackOutput for ffi::Py_ssize_t {
     const ERR_VALUE: Self = -1;
 }
 
-impl PyCallbackOutput for () {
-    const ERR_VALUE: Self = ();
-}
-
 /// Convert the result of callback function into the appropriate return value.
 pub trait IntoPyCallbackOutput<Target> {
     fn convert(self, py: Python<'_>) -> PyResult<Target>;

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -931,13 +931,8 @@ pub(crate) unsafe extern "C" fn tp_dealloc<T: PyClass>(obj: *mut ffi::PyObject) 
     /// A wrapper because PyCellLayout::tp_dealloc currently takes the py argument last
     /// (which is different to the rest of the trampolines which take py first)
     #[inline]
-    #[allow(clippy::unnecessary_wraps)]
-    unsafe fn trampoline_dealloc_wrapper<T: PyClass>(
-        py: Python<'_>,
-        slf: *mut ffi::PyObject,
-    ) -> PyResult<()> {
+    unsafe fn trampoline_dealloc_wrapper<T: PyClass>(py: Python<'_>, slf: *mut ffi::PyObject) {
         T::Layout::tp_dealloc(slf, py);
-        Ok(())
     }
     // TODO change argument order in PyCellLayout::tp_dealloc so this wrapper isn't needed.
     crate::impl_::trampoline::dealloc(obj, trampoline_dealloc_wrapper::<T>)

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -140,15 +140,39 @@ trampolines!(
     ) -> *mut ffi::PyObject;
 
     pub fn unaryfunc(slf: *mut ffi::PyObject) -> *mut ffi::PyObject;
-
-    pub fn dealloc(slf: *mut ffi::PyObject) -> ();
 );
 
 #[cfg(any(not(Py_LIMITED_API), Py_3_11))]
-trampolines! {
+trampoline! {
     pub fn getbufferproc(slf: *mut ffi::PyObject, buf: *mut ffi::Py_buffer, flags: c_int) -> c_int;
+}
 
-    pub fn releasebufferproc(slf: *mut ffi::PyObject, buf: *mut ffi::Py_buffer) -> ();
+#[cfg(any(not(Py_LIMITED_API), Py_3_11))]
+#[inline]
+pub unsafe fn releasebufferproc(
+    slf: *mut ffi::PyObject,
+    buf: *mut ffi::Py_buffer,
+    f: for<'py> unsafe fn(Python<'py>, *mut ffi::PyObject, *mut ffi::Py_buffer) -> PyResult<()>,
+) {
+    trampoline_inner_unraisable(|py| f(py, slf, buf), slf)
+}
+
+#[inline]
+pub(crate) unsafe fn dealloc(
+    slf: *mut ffi::PyObject,
+    f: for<'py> unsafe fn(Python<'py>, *mut ffi::PyObject) -> (),
+) {
+    // After calling tp_dealloc the object is no longer valid,
+    // so pass null_mut() to the context.
+    //
+    // (Note that we don't allow the implementation `f` to fail.)
+    trampoline_inner_unraisable(
+        |py| {
+            f(py, slf);
+            Ok(())
+        },
+        std::ptr::null_mut(),
+    )
 }
 
 // Ipowfunc is a unique case where PyO3 has its own type
@@ -200,4 +224,31 @@ where
     };
     py_err.restore(py);
     R::ERR_VALUE
+}
+
+/// Implementation of trampoline for functions which can't return an error.
+///
+/// Panics during execution are trapped so that they don't propagate through any
+/// outer FFI boundary.
+///
+/// Exceptions produced are sent to `sys.unraisablehook`.
+///
+/// # Safety
+///
+/// ctx must be either a valid ffi::PyObject or NULL
+#[inline]
+unsafe fn trampoline_inner_unraisable<F>(body: F, ctx: *mut ffi::PyObject)
+where
+    F: for<'py> FnOnce(Python<'py>) -> PyResult<()> + UnwindSafe,
+{
+    let trap = PanicTrap::new("uncaught panic at ffi boundary");
+    let pool = GILPool::new();
+    let py = pool.python();
+    if let Err(py_err) = panic::catch_unwind(move || body(py))
+        .unwrap_or_else(|payload| Err(PanicException::from_panic_payload(payload)))
+    {
+        py_err.restore(py);
+        ffi::PyErr_WriteUnraisable(ctx);
+    }
+    trap.disarm();
 }


### PR DESCRIPTION
I noticed that in the `__releasebuffer__` implementation we currently diverge from documentation by allowing `-> PyResult<()>` return values, but they cause crashes later down the line.

e.g. without the other changes in this PR, the new test case would crash with the following message:

```
ValueError: oh dear

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
SystemError: <class 'bytes'> returned a result with an exception set
```

After some deliberation I decided to allow `-> PyResult<()>` returns because:
 - it keeps the macro implementation and usage simpler
 - errors might be produced by the `__releasebuffer__` internals anyway (e.g. due to `PyCell` locking, or invalid self type passed)

As a result, this PR cleans up the case discussed to send errors to `sys.unraisablehook`, and updates the documentation to be clearer on the allowed behaviour.