### PR TITLE
tidy up implementation of pyclass `tp_dealloc`

### DIFF
--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -928,14 +928,7 @@ impl<T: PyClass> PyClassBaseType for T {
 
 /// Implementation of tp_dealloc for all pyclasses
 pub(crate) unsafe extern "C" fn tp_dealloc<T: PyClass>(obj: *mut ffi::PyObject) {
-    /// A wrapper because PyCellLayout::tp_dealloc currently takes the py argument last
-    /// (which is different to the rest of the trampolines which take py first)
-    #[inline]
-    unsafe fn trampoline_dealloc_wrapper<T: PyClass>(py: Python<'_>, slf: *mut ffi::PyObject) {
-        T::Layout::tp_dealloc(slf, py);
-    }
-    // TODO change argument order in PyCellLayout::tp_dealloc so this wrapper isn't needed.
-    crate::impl_::trampoline::dealloc(obj, trampoline_dealloc_wrapper::<T>)
+    crate::impl_::trampoline::dealloc(obj, T::Layout::tp_dealloc)
 }
 
 pub(crate) unsafe extern "C" fn get_sequence_item_from_mapping(


### PR DESCRIPTION
Just carries out a TODO to remove one level from the call stack. No external-facing changes.