### PR TITLE
make rust function benchmarks more similar to the Python ones

### DIFF
--- a/pytests/src/pyfunctions.rs
+++ b/pytests/src/pyfunctions.rs
@@ -4,43 +4,52 @@ use pyo3::types::{PyDict, PyTuple};
 #[pyfunction(signature = ())]
 fn none() {}
 
-#[pyfunction(signature = (a, b = "bar", *, c = None))]
-fn simple<'a>(a: i32, b: &'a str, c: Option<&'a PyDict>) -> (i32, &'a str, Option<&'a PyDict>) {
+#[pyfunction(signature = (a, b = None, *, c = None))]
+fn simple<'a>(
+    a: &'a PyAny,
+    b: Option<&'a PyAny>,
+    c: Option<&'a PyAny>,
+) -> (&'a PyAny, Option<&'a PyAny>, Option<&'a PyAny>) {
     (a, b, c)
 }
 
-#[pyfunction(signature = (a, b = "bar", *args, c = None))]
+#[pyfunction(signature = (a, b = None, *args, c = None))]
 fn simple_args<'a>(
-    a: i32,
-    b: &'a str,
+    a: &'a PyAny,
+    b: Option<&'a PyAny>,
     args: &'a PyTuple,
-    c: Option<&'a PyDict>,
-) -> (i32, &'a str, &'a PyTuple, Option<&'a PyDict>) {
+    c: Option<&'a PyAny>,
+) -> (&'a PyAny, Option<&'a PyAny>, &'a PyTuple, Option<&'a PyAny>) {
     (a, b, args, c)
 }
 
-#[pyfunction(signature = (a, b = "bar", c = None, **kwargs))]
+#[pyfunction(signature = (a, b = None, c = None, **kwargs))]
 fn simple_kwargs<'a>(
-    a: i32,
-    b: &'a str,
-    c: Option<&'a PyDict>,
+    a: &'a PyAny,
+    b: Option<&'a PyAny>,
+    c: Option<&'a PyAny>,
     kwargs: Option<&'a PyDict>,
-) -> (i32, &'a str, Option<&'a PyDict>, Option<&'a PyDict>) {
+) -> (
+    &'a PyAny,
+    Option<&'a PyAny>,
+    Option<&'a PyAny>,
+    Option<&'a PyDict>,
+) {
     (a, b, c, kwargs)
 }
 
-#[pyfunction(signature = (a, b = "bar", *args, c = None, **kwargs))]
+#[pyfunction(signature = (a, b = None, *args, c = None, **kwargs))]
 fn simple_args_kwargs<'a>(
-    a: i32,
-    b: &'a str,
+    a: &'a PyAny,
+    b: Option<&'a PyAny>,
     args: &'a PyTuple,
-    c: Option<&'a PyDict>,
+    c: Option<&'a PyAny>,
     kwargs: Option<&'a PyDict>,
 ) -> (
-    i32,
-    &'a str,
+    &'a PyAny,
+    Option<&'a PyAny>,
     &'a PyTuple,
-    Option<&'a PyDict>,
+    Option<&'a PyAny>,
     Option<&'a PyDict>,
 ) {
     (a, b, args, c, kwargs)

--- a/pytests/tests/test_deprecated_pyfunctions.py
+++ b/pytests/tests/test_deprecated_pyfunctions.py
@@ -5,87 +5,57 @@ def none_py():
     return None
 
 
-def test_none_py(benchmark):
-    benchmark(none_py)
-
-
-def test_none_rs(benchmark):
+def test_none_rs():
     rust = pyfunctions.none()
     py = none_py()
     assert rust == py
-    benchmark(pyfunctions.none)
 
 
 def simple_py(a, b="bar", *, c=None):
     return a, b, c
 
 
-def test_simple_py(benchmark):
-    benchmark(simple_py, 1, "foo", c={1: 2})
-
-
-def test_simple_rs(benchmark):
+def test_simple_rs():
     rust = pyfunctions.simple(1, "foo", c={1: 2})
     py = simple_py(1, "foo", c={1: 2})
     assert rust == py
-    benchmark(pyfunctions.simple, 1, "foo", c={1: 2})
 
 
 def simple_args_py(a, b="bar", *args, c=None):
     return a, b, args, c
 
 
-def test_simple_args_py(benchmark):
-    benchmark(simple_args_py, 1, "foo", 4, 5, 6, c={1: 2})
-
-
-def test_simple_args_rs(benchmark):
+def test_simple_args_rs():
     rust = pyfunctions.simple_args(1, "foo", 4, 5, 6, c={1: 2})
     py = simple_args_py(1, "foo", 4, 5, 6, c={1: 2})
     assert rust == py
-    benchmark(pyfunctions.simple_args, 1, "foo", 4, 5, 6, c={1: 2})
 
 
 def simple_kwargs_py(a, b="bar", c=None, **kwargs):
     return a, b, c, kwargs
 
 
-def test_simple_kwargs_py(benchmark):
-    benchmark(simple_kwargs_py, 1, "foo", c={1: 2}, bar=4, foo=10)
-
-
-def test_simple_kwargs_rs(benchmark):
+def test_simple_kwargs_rs():
     rust = pyfunctions.simple_kwargs(1, "foo", c={1: 2}, bar=4, foo=10)
     py = simple_kwargs_py(1, "foo", c={1: 2}, bar=4, foo=10)
     assert rust == py
-    benchmark(pyfunctions.simple_kwargs, 1, "foo", c={1: 2}, bar=4, foo=10)
 
 
 def simple_args_kwargs_py(a, b="bar", *args, c=None, **kwargs):
     return (a, b, args, c, kwargs)
 
 
-def test_simple_args_kwargs_py(benchmark):
-    benchmark(simple_args_kwargs_py, 1, "foo", "baz", bar=4, foo=10)
-
-
-def test_simple_args_kwargs_rs(benchmark):
+def test_simple_args_kwargs_rs():
     rust = pyfunctions.simple_args_kwargs(1, "foo", "baz", bar=4, foo=10)
     py = simple_args_kwargs_py(1, "foo", "baz", bar=4, foo=10)
     assert rust == py
-    benchmark(pyfunctions.simple_args_kwargs, 1, "foo", "baz", bar=4, foo=10)
 
 
 def args_kwargs_py(*args, **kwargs):
     return (args, kwargs)
 
 
-def test_args_kwargs_py(benchmark):
-    benchmark(args_kwargs_py, 1, "foo", {1: 2}, bar=4, foo=10)
-
-
-def test_args_kwargs_rs(benchmark):
+def test_args_kwargs_rs():
     rust = pyfunctions.args_kwargs(1, "foo", {1: 2}, bar=4, foo=10)
     py = args_kwargs_py(1, "foo", {1: 2}, bar=4, foo=10)
     assert rust == py
-    benchmark(pyfunctions.args_kwargs, 1, "foo", {1: 2}, a=4, foo=10)

--- a/pytests/tests/test_pyfunctions.py
+++ b/pytests/tests/test_pyfunctions.py
@@ -10,13 +10,12 @@ def test_none_py(benchmark):
 
 
 def test_none_rs(benchmark):
-    rust = pyfunctions.none()
+    rust = benchmark(pyfunctions.none)
     py = none_py()
     assert rust == py
-    benchmark(pyfunctions.none)
 
 
-def simple_py(a, b="bar", *, c=None):
+def simple_py(a, b=None, *, c=None):
     return a, b, c
 
 
@@ -25,13 +24,12 @@ def test_simple_py(benchmark):
 
 
 def test_simple_rs(benchmark):
-    rust = pyfunctions.simple(1, "foo", c={1: 2})
+    rust = benchmark(pyfunctions.simple, 1, "foo", c={1: 2})
     py = simple_py(1, "foo", c={1: 2})
     assert rust == py
-    benchmark(pyfunctions.simple, 1, "foo", c={1: 2})
 
 
-def simple_args_py(a, b="bar", *args, c=None):
+def simple_args_py(a, b=None, *args, c=None):
     return a, b, args, c
 
 
@@ -40,13 +38,12 @@ def test_simple_args_py(benchmark):
 
 
 def test_simple_args_rs(benchmark):
-    rust = pyfunctions.simple_args(1, "foo", 4, 5, 6, c={1: 2})
+    rust = benchmark(pyfunctions.simple_args, 1, "foo", 4, 5, 6, c={1: 2})
     py = simple_args_py(1, "foo", 4, 5, 6, c={1: 2})
     assert rust == py
-    benchmark(pyfunctions.simple_args, 1, "foo", 4, 5, 6, c={1: 2})
 
 
-def simple_kwargs_py(a, b="bar", c=None, **kwargs):
+def simple_kwargs_py(a, b=None, c=None, **kwargs):
     return a, b, c, kwargs
 
 
@@ -55,13 +52,12 @@ def test_simple_kwargs_py(benchmark):
 
 
 def test_simple_kwargs_rs(benchmark):
-    rust = pyfunctions.simple_kwargs(1, "foo", c={1: 2}, bar=4, foo=10)
+    rust = benchmark(pyfunctions.simple_kwargs, 1, "foo", c={1: 2}, bar=4, foo=10)
     py = simple_kwargs_py(1, "foo", c={1: 2}, bar=4, foo=10)
     assert rust == py
-    benchmark(pyfunctions.simple_kwargs, 1, "foo", c={1: 2}, bar=4, foo=10)
 
 
-def simple_args_kwargs_py(a, b="bar", *args, c=None, **kwargs):
+def simple_args_kwargs_py(a, b=None, *args, c=None, **kwargs):
     return (a, b, args, c, kwargs)
 
 
@@ -70,10 +66,9 @@ def test_simple_args_kwargs_py(benchmark):
 
 
 def test_simple_args_kwargs_rs(benchmark):
-    rust = pyfunctions.simple_args_kwargs(1, "foo", "baz", bar=4, foo=10)
+    rust = benchmark(pyfunctions.simple_args_kwargs, 1, "foo", "baz", bar=4, foo=10)
     py = simple_args_kwargs_py(1, "foo", "baz", bar=4, foo=10)
     assert rust == py
-    benchmark(pyfunctions.simple_args_kwargs, 1, "foo", "baz", bar=4, foo=10)
 
 
 def args_kwargs_py(*args, **kwargs):
@@ -85,7 +80,6 @@ def test_args_kwargs_py(benchmark):
 
 
 def test_args_kwargs_rs(benchmark):
-    rust = pyfunctions.args_kwargs(1, "foo", {1: 2}, bar=4, foo=10)
+    rust = benchmark(pyfunctions.args_kwargs, 1, "foo", {1: 2}, bar=4, foo=10)
     py = args_kwargs_py(1, "foo", {1: 2}, bar=4, foo=10)
     assert rust == py
-    benchmark(pyfunctions.args_kwargs, 1, "foo", {1: 2}, a=4, foo=10)


### PR DESCRIPTION
We have some benchmarks in `pytests/tests/test_pyfunctions.py` which I occasionally peek at, which compares some `#[pyfunction]` performance with pure-Python equivalents. It's designed purely to measure the overheads.

The existing comparison wasn't exactly fair because it used Rust types such as i32 on the Rust side, meaning there was additional runtime type checking going on compared to the Python implementations.

I've removed that in this PR, making all the input types on the Rust side just `&PyAny` or `Option<&PyAny>`. This does reduce the gap between the Python and Rust ones where we're slower, however it shows there is still some wins we could yet find in overhead reduction.