### PR TITLE
Add `PyDict.update()` and `PyDict.update_if_missing()`

### DIFF
--- a/newsfragments/2912.added.md
+++ b/newsfragments/2912.added.md
@@ -1,0 +1,1 @@
+Add `PyDict.update()` and `PyDict.update_if_missing()` methods.


### PR DESCRIPTION
Fix #2910

Note, I'd also be happy to remove the `override_` argument from merge and perhaps rename it to `update_missing` or similar to give a cleaner API. LMK what you think.

Please consider adding the following to your pull request:
 - [x] an entry for this PR in newsfragments
 - [x] docs to all new functions and / or detail in the guide
 - [x] tests for all new or changed functions
