### PR TITLE
correct ffi definition of PyIter_Check

### DIFF
--- a/newsfragments/2914.changed.md
+++ b/newsfragments/2914.changed.md
@@ -1,0 +1,1 @@
+FFI definition `PyIter_Check` on CPython 3.7 now does the equivalent for `hasattr(type(obj), "__next__")`, which works correctly on all platforms and adds support for `abi3`.

--- a/newsfragments/2914.fixed.md
+++ b/newsfragments/2914.fixed.md
@@ -1,0 +1,1 @@
+Fix downcast to `PyIterator` succeeding for Python classes which did not implement `__next__`.

--- a/pyo3-ffi/src/abstract_.rs
+++ b/pyo3-ffi/src/abstract_.rs
@@ -91,9 +91,12 @@ extern "C" {
     pub fn PyObject_GetIter(arg1: *mut PyObject) -> *mut PyObject;
 }
 
-// Defined as this macro in Python limited API, but relies on
-// non-limited PyTypeObject. Don't expose this since it cannot be used.
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+// Before 3.8 PyIter_Check was defined in CPython as a macro,
+// which uses Py_TYPE so cannot work on the limited ABI.
+//
+// From 3.10 onwards CPython removed the macro completely,
+// so PyO3 only uses this on 3.7 unlimited API.
+#[cfg(not(any(Py_3_8, Py_LIMITED_API, PyPy)))]
 #[inline]
 pub unsafe fn PyIter_Check(o: *mut PyObject) -> c_int {
     (match (*crate::Py_TYPE(o)).tp_iternext {
@@ -105,7 +108,7 @@ pub unsafe fn PyIter_Check(o: *mut PyObject) -> c_int {
 }
 
 extern "C" {
-    #[cfg(any(all(Py_3_8, Py_LIMITED_API), PyPy))]
+    #[cfg(any(Py_3_8, PyPy))]
     #[cfg_attr(PyPy, link_name = "PyPyIter_Check")]
     pub fn PyIter_Check(obj: *mut PyObject) -> c_int;
 

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -3,7 +3,6 @@
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
 use crate::{ffi, AsPyPointer, IntoPyPointer, Py, PyAny, PyErr, PyNativeType, PyResult, Python};
-#[cfg(any(not(Py_LIMITED_API), Py_3_8))]
 use crate::{PyDowncastError, PyTryFrom};
 
 /// A Python iterator object.
@@ -29,7 +28,6 @@ use crate::{PyDowncastError, PyTryFrom};
 #[repr(transparent)]
 pub struct PyIterator(PyAny);
 pyobject_native_type_named!(PyIterator);
-#[cfg(any(not(Py_LIMITED_API), Py_3_8))]
 pyobject_native_type_extract!(PyIterator);
 
 impl PyIterator {
@@ -64,7 +62,6 @@ impl<'p> Iterator for &'p PyIterator {
 }
 
 // PyIter_Check does not exist in the limited API until 3.8
-#[cfg(any(not(Py_LIMITED_API), Py_3_8))]
 impl<'v> PyTryFrom<'v> for PyIterator {
     fn try_from<V: Into<&'v PyAny>>(value: V) -> Result<&'v PyIterator, PyDowncastError<'v>> {
         let value = value.into();
@@ -218,7 +215,7 @@ def fibonacci(target):
     }
 
     #[test]
-    #[cfg(any(not(Py_LIMITED_API), Py_3_8))]
+
     fn iterator_try_from() {
         Python::with_gil(|py| {
             let obj: Py<PyAny> = vec![10, 20].to_object(py).as_ref(py).iter().unwrap().into();
@@ -250,7 +247,6 @@ def fibonacci(target):
     }
 
     #[test]
-    #[cfg(any(not(Py_LIMITED_API), Py_3_8))]
     #[cfg(feature = "macros")]
     fn python_class_not_iterator() {
         use crate::PyErr;
@@ -298,7 +294,6 @@ def fibonacci(target):
     }
 
     #[test]
-    #[cfg(any(not(Py_LIMITED_API), Py_3_8))]
     #[cfg(feature = "macros")]
     fn python_class_iterator() {
         #[crate::pyfunction(crate = "crate")]


### PR DESCRIPTION
Closes #2913 

It looks like what is happening is that PyO3 was relying on an outdated macro form of `PyIter_Check` which is now a CPython implementation detail, which would explain why it was behaving inconsistently on different platforms (likely due to differences in linkers / implementations).

The test I've pushed succeeds, but fails to compile due to a hygiene bug! I'm done for tonight so I'll take a look at that soon and then rebase this after.