### PR TITLE
Remove some Debug/Eq/PartialEq derives

### DIFF
--- a/pyo3-ffi/src/descrobject.rs
+++ b/pyo3-ffi/src/descrobject.rs
@@ -8,8 +8,13 @@ pub type getter = unsafe extern "C" fn(slf: *mut PyObject, closure: *mut c_void)
 pub type setter =
     unsafe extern "C" fn(slf: *mut PyObject, value: *mut PyObject, closure: *mut c_void) -> c_int;
 
+/// Represents the [PyGetSetDef](https://docs.python.org/3/c-api/structures.html#c.PyGetSetDef)
+/// structure.
+///
+/// Note that CPython may leave fields uninitialized. You must ensure that
+/// `name` != NULL before dereferencing or reading other fields.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct PyGetSetDef {
     pub name: *mut c_char,
     pub get: Option<getter>,

--- a/pyo3-ffi/src/methodobject.rs
+++ b/pyo3-ffi/src/methodobject.rs
@@ -85,8 +85,13 @@ extern "C" {
     ) -> *mut PyObject;
 }
 
+/// Represents the [PyMethodDef](https://docs.python.org/3/c-api/structures.html#c.PyMethodDef)
+/// structure.
+///
+/// Note that CPython may leave fields uninitialized. You must ensure that
+/// `ml_name` != NULL before dereferencing or reading other fields.
 #[repr(C)]
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone)]
 pub struct PyMethodDef {
     pub ml_name: *const c_char,
     pub ml_meth: PyMethodDefPointer,

--- a/pyo3-ffi/src/structmember.rs
+++ b/pyo3-ffi/src/structmember.rs
@@ -3,8 +3,13 @@ use crate::pyport::Py_ssize_t;
 use std::os::raw::{c_char, c_int};
 use std::ptr;
 
+/// Represents the [PyMemberDef](https://docs.python.org/3/c-api/structures.html#c.PyMemberDef)
+/// structure.
+///
+/// Note that CPython may leave fields uninitialized. You must always ensure that
+/// `name` != NULL before dereferencing or reading other fields.
 #[repr(C)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone)]
 pub struct PyMemberDef {
     pub name: *mut c_char,
     pub type_code: c_int,


### PR DESCRIPTION
I'd used them to do `let is_terminator = *(obj.as_ptr()) == PyMemberDef::default();`, which blew up pretty badly. 😆 