### PR TITLE
hygiene: fix `#[pymethods(crate = "...")]`

### DIFF
--- a/newsfragments/2923.fixed.md
+++ b/newsfragments/2923.fixed.md
@@ -1,0 +1,1 @@
+Fix `#[pymethods(crate = "...")]` option being ignored.

--- a/src/test_hygiene/pymethods.rs
+++ b/src/test_hygiene/pymethods.rs
@@ -807,3 +807,11 @@ impl Dummy {
     // PyGcProtocol
     // Buffer protocol?
 }
+
+// Ensure that crate argument is also accepted inline
+
+#[crate::pyclass(crate = "crate")]
+struct Dummy2;
+
+#[crate::pymethods(crate = "crate")]
+impl Dummy2 {}


### PR DESCRIPTION
Got to the bottom of the hygiene issue in test of #2914 

Turns out that `#[pymethods] #[pyo3(crate = "...")]` works, but `#[pymethods(crate = "...")]` was ignoring the argument.

Added a tweak to fix this and a snippet in the hygiene test (which fails on `main`). 