### PR TITLE
docs: Precise the abscense of `py: Python` for the #[pyo3(signature)]

### DIFF
--- a/guide/src/function/signature.md
+++ b/guide/src/function/signature.md
@@ -77,6 +77,22 @@ impl MyClass {
     }
 }
 ```
+
+Arguments of type `Python` must not be part of the signature:
+
+```rust
+# #![allow(dead_code)]
+# use pyo3::prelude::*;
+#[pyfunction]
+#[pyo3(signature = (lambda))]
+pub fn simple_python_bound_function(
+    py: Python<'_>,
+    lambda: PyObject,
+) -> PyResult<()> {
+    Ok(())
+}
+```
+
 N.B. the position of the `/` and `*` arguments (if included) control the system of handling positional and keyword arguments. In Python:
 ```python
 import mymodule


### PR DESCRIPTION
Hi,

First, thank you for working on PyO3!

I think this adds a precision which was not obvious when migrating to 0.18.0 conventions.

What do you think? Also, should something be added to [the migration guide](https://pyo3.rs/main/migration) in this regard?

Thank you!