### PR TITLE
add better error message for Python in signature

### DIFF
--- a/tests/ui/invalid_pyfunction_signatures.rs
+++ b/tests/ui/invalid_pyfunction_signatures.rs
@@ -44,6 +44,11 @@ fn function_with_kwargs_after_kwargs(kwargs_a: Option<&PyDict>, kwargs_b: Option
     let _ = kwargs_b;
 }
 
+#[pyfunction(signature = (py))]
+fn signature_contains_py(py: Python<'_>) {
+    let _ = py;
+}
+
 #[pyclass]
 struct MyClass;
 

--- a/tests/ui/invalid_pyfunction_signatures.stderr
+++ b/tests/ui/invalid_pyfunction_signatures.stderr
@@ -46,8 +46,14 @@ error: `**kwargs_b` not allowed after `**kwargs_a`
 41 | #[pyo3(signature = (**kwargs_a, **kwargs_b))]
    |                                 ^
 
-error: cannot define both function signature and legacy arguments
-  --> tests/ui/invalid_pyfunction_signatures.rs:53:12
+error: arguments of type `Python` must not be part of the signature
+  --> tests/ui/invalid_pyfunction_signatures.rs:47:27
    |
-53 |     #[pyo3(signature = (x))]
+47 | #[pyfunction(signature = (py))]
+   |                           ^^
+
+error: cannot define both function signature and legacy arguments
+  --> tests/ui/invalid_pyfunction_signatures.rs:58:12
+   |
+58 |     #[pyo3(signature = (x))]
    |            ^^^^^^^^^


### PR DESCRIPTION
Inspired by #2929, this just adds a better error message when `Python` arguments are accidentally included in the signature.