### PR TITLE
bump maturin version in getting_started.md

### DIFF
--- a/guide/src/getting_started.md
+++ b/guide/src/getting_started.md
@@ -123,7 +123,7 @@ You should also create a `pyproject.toml` with the following contents:
 
 ```toml
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
Latest maturin is 0.14.x, so reference that in the docs