### PR TITLE
link against pythonXY_d.dll for debug Python on Windows

### DIFF
--- a/newsfragments/2937.fixed.md
+++ b/newsfragments/2937.fixed.md
@@ -1,0 +1,1 @@
+Link against `pythonXY_d.dll` for debug Python builds on Windows.


### PR DESCRIPTION
Closes #2780 

Note that upstream Python issue https://github.com/python/cpython/issues/101614 means linking against `python3_d.dll` is useless, so I've set this to always use the version-specific builds for now.

The heuristic for detecting a Windows debug build is... not great. I check if the `EXT_SUFFIX` starts with `_d.`, which is the only thing that I could see in the sysconfig which suggested a debug build. If this proves to be brittle, we may wish to ask upstream for something better to be added to `sysconfig`.