### PR TITLE
Disable default features of `chrono`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ inventory = { version = "0.3.0", optional = true }
 
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0", optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", default-features = false, optional = true }
 eyre = { version = ">= 0.4, < 0.7", optional = true }
 hashbrown = { version = ">= 0.9, < 0.14", optional = true }
 indexmap = { version = "1.6", optional = true }

--- a/newsfragments/2939.changed.md
+++ b/newsfragments/2939.changed.md
@@ -1,0 +1,1 @@
+Disable default features of `chrono` to avoid depending on `time` v0.1.x.


### PR DESCRIPTION
To avoid bringing `time` v0.1.x into dependency graph, see https://github.com/time-rs/time/issues/293