### PR TITLE
optimize sequence conversion for list and tuple

### DIFF
--- a/benches/bench_list.rs
+++ b/benches/bench_list.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 
 use pyo3::prelude::*;
-use pyo3::types::PyList;
+use pyo3::types::{PyList, PySequence};
 
 fn iter_list(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
@@ -53,12 +53,23 @@ fn list_get_item_unchecked(b: &mut Bencher<'_>) {
     });
 }
 
+fn sequence_from_list(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        const LEN: usize = 50_000;
+        let list = PyList::new(py, 0..LEN).to_object(py);
+        b.iter(|| {
+            let _: &PySequence = list.extract(py).unwrap();
+        });
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("iter_list", iter_list);
     c.bench_function("list_new", list_new);
     c.bench_function("list_get_item", list_get_item);
     #[cfg(not(Py_LIMITED_API))]
     c.bench_function("list_get_item_unchecked", list_get_item_unchecked);
+    c.bench_function("sequence_from_list", sequence_from_list);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/benches/bench_tuple.rs
+++ b/benches/bench_tuple.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 
 use pyo3::prelude::*;
-use pyo3::types::PyTuple;
+use pyo3::types::{PySequence, PyTuple};
 
 fn iter_tuple(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
@@ -53,12 +53,21 @@ fn tuple_get_item_unchecked(b: &mut Bencher<'_>) {
     });
 }
 
+fn sequence_from_tuple(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        const LEN: usize = 50_000;
+        let tuple = PyTuple::new(py, 0..LEN).to_object(py);
+        b.iter(|| tuple.extract::<&PySequence>(py).unwrap());
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("iter_tuple", iter_tuple);
     c.bench_function("tuple_new", tuple_new);
     c.bench_function("tuple_get_item", tuple_get_item);
     #[cfg(not(any(Py_LIMITED_API, PyPy)))]
     c.bench_function("tuple_get_item_unchecked", tuple_get_item_unchecked);
+    c.bench_function("sequence_from_tuple", sequence_from_tuple);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/newsfragments/2944.changed.md
+++ b/newsfragments/2944.changed.md
@@ -1,0 +1,1 @@
+Optimize `PySequence` conversion for `list` and `tuple` inputs.


### PR DESCRIPTION
closes #2943 

Avoid using `PyObject_IsInstance` for checking if lists or tuples are sequences, as we know they are always sequences.