### PR TITLE
change PyModule::add_class to return an error if class creation fails

### DIFF
--- a/benches/bench_pyclass.rs
+++ b/benches/bench_pyclass.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use pyo3::{impl_::pyclass::LazyStaticType, prelude::*};
+use pyo3::{impl_::pyclass::LazyTypeObject, prelude::*};
 
 /// This is a feature-rich class instance used to benchmark various parts of the pyclass lifecycle.
 #[pyclass]
@@ -31,8 +31,8 @@ pub fn first_time_init(b: &mut criterion::Bencher<'_>) {
         b.iter(|| {
             // This is using an undocumented internal PyO3 API to measure pyclass performance; please
             // don't use this in your own code!
-            let ty = LazyStaticType::new();
-            ty.get_or_init::<MyClass>(py);
+            let ty = LazyTypeObject::<MyClass>::new();
+            ty.get_or_init(py);
         });
     });
 }

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -979,9 +979,8 @@ unsafe impl pyo3::type_object::PyTypeInfo for MyClass {
     const MODULE: ::std::option::Option<&'static str> = ::std::option::Option::None;
     #[inline]
     fn type_object_raw(py: pyo3::Python<'_>) -> *mut pyo3::ffi::PyTypeObject {
-        use pyo3::impl_::pyclass::LazyStaticType;
-        static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
-        TYPE_OBJECT.get_or_init::<Self>(py)
+        <Self as pyo3::impl_::pyclass::PyClassImpl>::lazy_type_object()
+            .get_or_init(py)
     }
 }
 
@@ -1032,6 +1031,12 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
         let collector = PyClassImplCollector::<MyClass>::new();
         static INTRINSIC_ITEMS: PyClassItems = PyClassItems { slots: &[], methods: &[] };
         PyClassItemsIter::new(&INTRINSIC_ITEMS, collector.py_methods())
+    }
+
+    fn lazy_type_object() -> &'static pyo3::impl_::pyclass::LazyTypeObject<MyClass> {
+        use pyo3::impl_::pyclass::LazyTypeObject;
+        static TYPE_OBJECT: LazyTypeObject<MyClass> = LazyTypeObject::new();
+        &TYPE_OBJECT
     }
 }
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -981,6 +981,7 @@ unsafe impl pyo3::type_object::PyTypeInfo for MyClass {
     fn type_object_raw(py: pyo3::Python<'_>) -> *mut pyo3::ffi::PyTypeObject {
         <Self as pyo3::impl_::pyclass::PyClassImpl>::lazy_type_object()
             .get_or_init(py)
+            .as_type_ptr()
     }
 }
 

--- a/newsfragments/2947.changed.md
+++ b/newsfragments/2947.changed.md
@@ -1,0 +1,1 @@
+Improve exception raised when creating `#[pyclass]` type object fails during module import.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -758,6 +758,7 @@ fn impl_pytypeinfo(
 
                 <#cls as _pyo3::impl_::pyclass::PyClassImpl>::lazy_type_object()
                     .get_or_init(py)
+                    .as_type_ptr()
             }
         }
     }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -756,9 +756,8 @@ fn impl_pytypeinfo(
             fn type_object_raw(py: _pyo3::Python<'_>) -> *mut _pyo3::ffi::PyTypeObject {
                 #deprecations
 
-                use _pyo3::impl_::pyclass::LazyStaticType;
-                static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
-                TYPE_OBJECT.get_or_init::<Self>(py)
+                <#cls as _pyo3::impl_::pyclass::PyClassImpl>::lazy_type_object()
+                    .get_or_init(py)
             }
         }
     }
@@ -1038,6 +1037,12 @@ impl<'a> PyClassImplsBuilder<'a> {
                 #dict_offset
 
                 #weaklist_offset
+
+                fn lazy_type_object() -> &'static _pyo3::impl_::pyclass::LazyTypeObject<Self> {
+                    use _pyo3::impl_::pyclass::LazyTypeObject;
+                    static TYPE_OBJECT: LazyTypeObject<#cls> = LazyTypeObject::new();
+                    &TYPE_OBJECT
+                }
             }
 
             #[doc(hidden)]

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -15,8 +15,8 @@ use std::{
     thread,
 };
 
-mod lazy_static_type;
-pub use lazy_static_type::LazyStaticType;
+mod lazy_type_object;
+pub use lazy_type_object::LazyTypeObject;
 
 /// Gets the offset of the dictionary from the start of the object in bytes.
 #[inline]
@@ -137,7 +137,7 @@ unsafe impl Sync for PyClassItems {}
 ///
 /// Users are discouraged from implementing this trait manually; it is a PyO3 implementation detail
 /// and may be changed at any time.
-pub trait PyClassImpl: Sized {
+pub trait PyClassImpl: Sized + 'static {
     /// Class doc string
     const DOC: &'static str = "\0";
 
@@ -194,6 +194,8 @@ pub trait PyClassImpl: Sized {
     fn weaklist_offset() -> Option<ffi::Py_ssize_t> {
         None
     }
+
+    fn lazy_type_object() -> &'static LazyTypeObject<Self>;
 }
 
 /// Iterator used to process all class items during type instantiation.

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -7,7 +7,7 @@ use crate::err::{PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi;
 use crate::pyclass::PyClass;
-use crate::types::{PyAny, PyCFunction, PyDict, PyList, PyString};
+use crate::types::{PyAny, PyCFunction, PyDict, PyList, PyString, PyType};
 use crate::{AsPyPointer, IntoPy, Py, PyObject, Python};
 use std::ffi::{CStr, CString};
 use std::str;
@@ -294,7 +294,10 @@ impl PyModule {
     where
         T: PyClass,
     {
-        self.add(T::NAME, T::type_object(self.py()))
+        let py = self.py();
+        self.add(T::NAME, unsafe {
+            PyType::from_type_ptr(py, T::lazy_type_object().get_or_try_init(py)?)
+        })
     }
 
     /// Adds a function or a (sub)module to a module, using the functions name as name.

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -7,7 +7,7 @@ use crate::err::{PyErr, PyResult};
 use crate::exceptions;
 use crate::ffi;
 use crate::pyclass::PyClass;
-use crate::types::{PyAny, PyCFunction, PyDict, PyList, PyString, PyType};
+use crate::types::{PyAny, PyCFunction, PyDict, PyList, PyString};
 use crate::{AsPyPointer, IntoPy, Py, PyObject, Python};
 use std::ffi::{CStr, CString};
 use std::str;
@@ -295,9 +295,7 @@ impl PyModule {
         T: PyClass,
     {
         let py = self.py();
-        self.add(T::NAME, unsafe {
-            PyType::from_type_ptr(py, T::lazy_type_object().get_or_try_init(py)?)
-        })
+        self.add(T::NAME, T::lazy_type_object().get_or_try_init(py)?)
     }
 
     /// Adds a function or a (sub)module to a module, using the functions name as name.

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "macros")]
 
-use pyo3::{exceptions::PyValueError, prelude::*, types::PyString};
+use pyo3::{prelude::*, types::PyString};
 
 mod common;
 
@@ -98,6 +98,8 @@ fn recursive_class_attributes() {
 #[test]
 #[cfg(panic = "unwind")]
 fn test_fallible_class_attribute() {
+    use pyo3::exceptions::PyValueError;
+
     #[pyclass]
     struct BrokenClass;
 

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -339,3 +339,26 @@ fn test_subclass_ref_counts() {
         );
     })
 }
+
+#[test]
+#[cfg(not(Py_LIMITED_API))]
+fn module_add_class_inherit_bool_fails() {
+    use pyo3::types::PyBool;
+
+    #[pyclass(extends = PyBool)]
+    struct ExtendsBool;
+
+    Python::with_gil(|py| {
+        let m = PyModule::new(py, "test_module").unwrap();
+
+        let err = m.add_class::<ExtendsBool>().unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "RuntimeError: An error occurred while initializing class ExtendsBool"
+        );
+        assert_eq!(
+            err.cause(py).unwrap().to_string(),
+            "TypeError: type 'bool' is not an acceptable base type"
+        );
+    })
+}


### PR DESCRIPTION
Related to #2942 

At the moment there are panics deep in the `#[pyclass]` machinery when initialising the type fails. This PR adjusts a number of these functions to return `PyResult` instead, so that we can handle the error more appropriately further down the pipeline.

For example, take the following snippet:

```rust
#[pyclass(extends = PyBool)]
struct ExtendsBool;

#[pymodule]
fn pyo3_scratch(_py: Python, m: &PyModule) -> PyResult<()> {
    m.add_class::<ExtendsBool>()?;
    Ok(())
}
```

Currently, importing this module will fail with a panic:

```
TypeError: type 'bool' is not an acceptable base type
thread '<unnamed>' panicked at 'An error occurred while initializing class ExtendsBool', /Users/david/Dev/pyo3/src/pyclass.rs:412:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/david/.virtualenvs/pyo3/lib/python3.10/site-packages/pyo3_scratch/__init__.py", line 1, in <module>
    from .pyo3_scratch import *
pyo3_runtime.PanicException: An error occurred while initializing class ExtendsBool
```

After this PR, this import still fails, but with a slightly cleaner, more Pythonic error:

```
TypeError: type 'bool' is not an acceptable base type

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/david/.virtualenvs/pyo3/lib/python3.10/site-packages/pyo3_scratch/__init__.py", line 1, in <module>
    from .pyo3_scratch import *
RuntimeError: An error occurred while initializing class ExtendsBool
```