### PR TITLE
Fix allow_threads segfault

### DIFF
--- a/newsfragments/2952.fixed.md
+++ b/newsfragments/2952.fixed.md
@@ -1,0 +1,1 @@
+Fix a reference counting race condition affecting `PyObject`s cloned in `allow_threads` blocks.

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -478,6 +478,8 @@ impl<'py> Python<'py> {
                 gil::GIL_COUNT.with(|c| c.set(self.count));
                 unsafe {
                     ffi::PyEval_RestoreThread(self.tstate);
+                    // Update counts of PyObjects / Py that were cloned or dropped during `f`.
+                    gil::POOL.update_counts(Python::assume_gil_acquired());
                 }
             }
         }


### PR DESCRIPTION
Please see the corresponding issue **#2951** for details. This PR adds the failing test from the issue and then a fix for it. The fix simply calls `ReferencePool::update_counts` at the end of `allow_threads` to ensure objects aren't accidentally deleted too soon.