### PR TITLE
set csv minimal package version for 1.48 CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -422,6 +422,7 @@ def set_minimal_package_versions(session: nox.Session, venv_backend="none"):
         "examples/word-count",
     )
     min_pkg_versions = {
+        "csv": "1.1.6",
         "indexmap": "1.6.2",
         "hashbrown": "0.9.1",
         "plotters": "0.3.1",


### PR DESCRIPTION
New `csv 1.2.0` requires Rust 1.60.