### PR TITLE
Move PyTypeInfo::AsRefTarget onto new trait HasPyGilBoundRef

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -974,7 +974,6 @@ struct MyClass {
     num: i32,
 }
 unsafe impl pyo3::type_object::PyTypeInfo for MyClass {
-    type AsRefTarget = pyo3::PyCell<Self>;
     const NAME: &'static str = "MyClass";
     const MODULE: ::std::option::Option<&'static str> = ::std::option::Option::None;
     #[inline]
@@ -983,6 +982,10 @@ unsafe impl pyo3::type_object::PyTypeInfo for MyClass {
         static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
         TYPE_OBJECT.get_or_init::<Self>(py)
     }
+}
+
+unsafe impl pyo3::HasPyGilBoundRef for MyClass {
+    type AsRefTarget = pyo3::PyCell<Self>;
 }
 
 impl pyo3::PyClass for MyClass {

--- a/newsfragments/2956.changed.md
+++ b/newsfragments/2956.changed.md
@@ -1,0 +1,1 @@
+Move `PyTypeInfo::AsRefTarget` onto new trait `HasPyGilBoundRef`.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -747,8 +747,6 @@ fn impl_pytypeinfo(
 
     quote! {
         unsafe impl _pyo3::type_object::PyTypeInfo for #cls {
-            type AsRefTarget = _pyo3::PyCell<Self>;
-
             const NAME: &'static str = #cls_name;
             const MODULE: ::std::option::Option<&'static str> = #module;
 
@@ -760,6 +758,9 @@ fn impl_pytypeinfo(
                 static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
                 TYPE_OBJECT.get_or_init::<Self>(py)
             }
+        }
+        unsafe impl _pyo3::HasPyGilBoundRef for #cls {
+            type AsRefTarget = _pyo3::PyCell<Self>;
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
 #[cfg(not(PyPy))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
 pub use crate::gil::{GILGuard, GILPool};
-pub use crate::instance::{Py, PyNativeType, PyObject};
+pub use crate::instance::{HasPyGilBoundRef, Py, PyNativeType, PyObject};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};
 pub use crate::pyclass::PyClass;

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -1,7 +1,7 @@
 //! `PyClass` and related traits.
 use crate::{
-    callback::IntoPyCallbackOutput, ffi, impl_::pyclass::PyClassImpl, IntoPy, IntoPyPointer,
-    PyCell, PyObject, PyResult, PyTypeInfo, Python,
+    callback::IntoPyCallbackOutput, ffi, impl_::pyclass::PyClassImpl, HasPyGilBoundRef, IntoPy,
+    IntoPyPointer, PyCell, PyObject, PyResult, PyTypeInfo, Python,
 };
 use std::{cmp::Ordering, os::raw::c_int};
 
@@ -16,7 +16,7 @@ pub use self::gc::{PyTraverseError, PyVisit};
 /// The `#[pyclass]` attribute implements this trait for your Rust struct -
 /// you shouldn't implement this trait directly.
 pub trait PyClass:
-    PyTypeInfo<AsRefTarget = PyCell<Self>> + PyClassImpl<Layout = PyCell<Self>>
+    PyTypeInfo + PyClassImpl<Layout = PyCell<Self>> + HasPyGilBoundRef<AsRefTarget = PyCell<Self>>
 {
     /// Whether the pyclass is frozen.
     ///

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -2,7 +2,7 @@
 //! Python type object information
 
 use crate::types::{PyAny, PyType};
-use crate::{ffi, AsPyPointer, PyNativeType, Python};
+use crate::{ffi, AsPyPointer, Python};
 
 /// `T: PyLayout<U>` represents that `T` is a concrete representation of `U` in the Python heap.
 /// E.g., `PyCell` is a concrete representation of all `pyclass`es, and `ffi::PyObject`
@@ -39,9 +39,6 @@ pub unsafe trait PyTypeInfo: Sized {
 
     /// Module name, if any.
     const MODULE: Option<&'static str>;
-
-    /// Utility type to make Py::as_ref work.
-    type AsRefTarget: PyNativeType;
 
     /// Returns the PyTypeObject instance for this type.
     fn type_object_raw(py: Python<'_>) -> *mut ffi::PyTypeObject;

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -2,7 +2,7 @@
 //
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
-use crate::{ffi, AsPyPointer, IntoPyPointer, Py, PyAny, PyErr, PyNativeType, PyResult, Python};
+use crate::{ffi, AsPyPointer, PyAny, PyErr, PyResult, Python};
 use crate::{PyDowncastError, PyTryFrom};
 
 /// A Python iterator object.
@@ -82,22 +82,6 @@ impl<'v> PyTryFrom<'v> for PyIterator {
     unsafe fn try_from_unchecked<V: Into<&'v PyAny>>(value: V) -> &'v PyIterator {
         let ptr = value.into() as *const _ as *const PyIterator;
         &*ptr
-    }
-}
-
-impl Py<PyIterator> {
-    /// Borrows a GIL-bound reference to the PyIterator. By binding to the GIL lifetime, this
-    /// allows the GIL-bound reference to not require `Python` for any of its methods.
-    pub fn as_ref<'py>(&'py self, _py: Python<'py>) -> &'py PyIterator {
-        let any = self.as_ptr() as *const PyAny;
-        unsafe { PyNativeType::unchecked_downcast(&*any) }
-    }
-
-    /// Similar to [`as_ref`](#method.as_ref), and also consumes this `Py` and registers the
-    /// Python object reference in PyO3's object storage. The reference count for the Python
-    /// object will not be decreased until the GIL lifetime ends.
-    pub fn into_ref(self, py: Python<'_>) -> &PyIterator {
-        unsafe { py.from_owned_ptr(self.into_ptr()) }
     }
 }
 

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -4,9 +4,7 @@ use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::once_cell::GILOnceCell;
 use crate::type_object::PyTypeInfo;
 use crate::types::{PyAny, PySequence, PyType};
-use crate::{
-    ffi, AsPyPointer, IntoPy, IntoPyPointer, Py, PyNativeType, PyTryFrom, Python, ToPyObject,
-};
+use crate::{ffi, AsPyPointer, IntoPy, Py, PyNativeType, PyTryFrom, Python, ToPyObject};
 
 static MAPPING_ABC: GILOnceCell<PyResult<Py<PyType>>> = GILOnceCell::new();
 
@@ -158,22 +156,6 @@ impl<'v> PyTryFrom<'v> for PyMapping {
     unsafe fn try_from_unchecked<V: Into<&'v PyAny>>(value: V) -> &'v PyMapping {
         let ptr = value.into() as *const _ as *const PyMapping;
         &*ptr
-    }
-}
-
-impl Py<PyMapping> {
-    /// Borrows a GIL-bound reference to the PyMapping. By binding to the GIL lifetime, this
-    /// allows the GIL-bound reference to not require `Python` for any of its methods.
-    pub fn as_ref<'py>(&'py self, _py: Python<'py>) -> &'py PyMapping {
-        let any = self.as_ptr() as *const PyAny;
-        unsafe { PyNativeType::unchecked_downcast(&*any) }
-    }
-
-    /// Similar to [`as_ref`](#method.as_ref), and also consumes this `Py` and registers the
-    /// Python object reference in PyO3's object storage. The reference count for the Python
-    /// object will not be decreased until the GIL lifetime ends.
-    pub fn into_ref(self, py: Python<'_>) -> &PyMapping {
-        unsafe { py.from_owned_ptr(self.into_ptr()) }
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -86,6 +86,10 @@ macro_rules! pyobject_native_type_base(
     ($name:ty $(;$generics:ident)* ) => {
         unsafe impl<$($generics,)*> $crate::PyNativeType for $name {}
 
+        unsafe impl $crate::HasPyGilBoundRef for $name {
+            type AsRefTarget = Self;
+        }
+
         impl<$($generics,)*> ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>)
                    -> ::std::result::Result<(), ::std::fmt::Error>
@@ -177,8 +181,6 @@ macro_rules! pyobject_native_type_named (
 macro_rules! pyobject_native_type_info(
     ($name:ty, $typeobject:expr, $module:expr $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
         unsafe impl<$($generics,)*> $crate::type_object::PyTypeInfo for $name {
-            type AsRefTarget = Self;
-
             const NAME: &'static str = stringify!($name);
             const MODULE: ::std::option::Option<&'static str> = $module;
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -8,7 +8,7 @@ use crate::once_cell::GILOnceCell;
 use crate::type_object::PyTypeInfo;
 use crate::types::{PyAny, PyList, PyString, PyTuple, PyType};
 use crate::{ffi, PyNativeType, ToPyObject};
-use crate::{AsPyPointer, IntoPy, IntoPyPointer, Py, Python};
+use crate::{AsPyPointer, IntoPy, Py, Python};
 use crate::{FromPyObject, PyTryFrom};
 
 static SEQUENCE_ABC: GILOnceCell<PyResult<Py<PyType>>> = GILOnceCell::new();
@@ -356,32 +356,6 @@ impl<'v> PyTryFrom<'v> for PySequence {
     unsafe fn try_from_unchecked<V: Into<&'v PyAny>>(value: V) -> &'v PySequence {
         let ptr = value.into() as *const _ as *const PySequence;
         &*ptr
-    }
-}
-
-impl Py<PySequence> {
-    /// Borrows a GIL-bound reference to the PySequence. By binding to the GIL lifetime, this
-    /// allows the GIL-bound reference to not require `Python` for any of its methods.
-    ///
-    /// ```
-    /// # use pyo3::prelude::*;
-    /// # use pyo3::types::{PyList, PySequence};
-    /// # Python::with_gil(|py| {
-    /// let seq: Py<PySequence> = PyList::empty(py).as_sequence().into();
-    /// let seq: &PySequence = seq.as_ref(py);
-    /// assert_eq!(seq.len().unwrap(), 0);
-    /// # });
-    /// ```
-    pub fn as_ref<'py>(&'py self, _py: Python<'py>) -> &'py PySequence {
-        let any = self.as_ptr() as *const PyAny;
-        unsafe { PyNativeType::unchecked_downcast(&*any) }
-    }
-
-    /// Similar to [`as_ref`](#method.as_ref), and also consumes this `Py` and registers the
-    /// Python object reference in PyO3's object storage. The reference count for the Python
-    /// object will not be decreased until the GIL lifetime ends.
-    pub fn into_ref(self, py: Python<'_>) -> &PySequence {
-        unsafe { py.from_owned_ptr(self.into_ptr()) }
     }
 }
 


### PR DESCRIPTION
NB This is a breaking change, would be part of 0.19, not any 0.18.x patch release. Despite this, I would generally assume users don't ever refer to this directly, so I don't expect much impact downstream.

This PR moves `PyTypeInfo::AsRefTarget` onto its own trait. There's a couple of reasons for this:
- `PyIterator`, `PySequence` and `PyMapping` can implement the new trait (they can't implement `PyTypeInfo`). This removes the need for them to provide special-cased methods.
- While looking at rebooting #1308, I found that this is the only item in `PyTypeInfo` which the experimental types cannot implement. So if we break this up, I think it will simplify that implementation.

(Maybe we can wait until I push the rebooted #1308 proposal, to see whether we actually like it enough to try to adopt it.)