### PR TITLE
docs: fix typo in method name

### DIFF
--- a/guide/src/function.md
+++ b/guide/src/function.md
@@ -148,7 +148,7 @@ The ways to convert a Rust function into a Python object vary depending on the f
 - Named functions, e.g. `fn foo()`: add `#[pyfunction]` and then use [`wrap_pyfunction!`] to get the corresponding [`PyCFunction`].
 - Anonymous functions (or closures), e.g. `foo: fn()` either:
   - use a `#[pyclass]` struct which stores the function as a field and implement `__call__` to call the stored function.
-  - use `PyFunction::new_closure` to create an object directly from the function.
+  - use `PyCFunction::new_closure` to create an object directly from the function.
 
 [`PyAny::is_callable`]: {{#PYO3_DOCS_URL}}/pyo3/struct.PyAny.html#tymethod.is_callable
 [`PyAny::call`]: {{#PYO3_DOCS_URL}}/pyo3/struct.PyAny.html#tymethod.call

--- a/newsfragments/2961.fixed.md
+++ b/newsfragments/2961.fixed.md
@@ -1,0 +1,1 @@
+Fix docs about creating `Python` function from `Rust` one.


### PR DESCRIPTION
There's no `PyFunction::new_closure`, but there is [`PyCFunction::new_closure`](https://github.com/PyO3/pyo3/blob/3b2c175f8d0afa86c95c7de89fb136d5f5a51517/src/types/function.rs#L50-L104), so I guess it's a typo in docs.