### PR TITLE
allow `create_exception!` to place the exception in a `dotted.module`

### DIFF
--- a/newsfragments/2979.changed.md
+++ b/newsfragments/2979.changed.md
@@ -1,0 +1,1 @@
+Allow `create_exception!` to take a `dotted.module` to place the exception in a submodule.


### PR DESCRIPTION
Closes #2946 

Credit fully to @BlueGlassBlock