### PR TITLE
support `text_signature` on `#[new]`

### DIFF
--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -42,7 +42,7 @@ fn wrap(obj: &PyAny) -> Result<i32, PyErr> {
     Ok(val as i32)
 }
 ```
-We also add documentation, via `///` comments and the `#[pyo3(text_signature = "...")]` attribute, both of which are visible to Python users.
+We also add documentation, via `///` comments, which are visible to Python users.
 
 ```rust
 # #![allow(dead_code)]
@@ -57,7 +57,6 @@ fn wrap(obj: &PyAny) -> Result<i32, PyErr> {
 /// Did you ever hear the tragedy of Darth Signed The Overfloweth? I thought not.
 /// It's not a story C would tell you. It's a Rust legend.
 #[pyclass(module = "my_module")]
-#[pyo3(text_signature = "(int)")]
 struct Number(i32);
 
 #[pymethods]
@@ -223,7 +222,6 @@ fn wrap(obj: &PyAny) -> Result<i32, PyErr> {
 /// Did you ever hear the tragedy of Darth Signed The Overfloweth? I thought not.
 /// It's not a story C would tell you. It's a Rust legend.
 #[pyclass(module = "my_module")]
-#[pyo3(text_signature = "(int)")]
 struct Number(i32);
 
 #[pymethods]
@@ -377,7 +375,7 @@ fn my_module(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 # assert Number(12345234523452) == Number(1498514748)
 # try:
 #     import inspect
-#     assert inspect.signature(Number).__str__() == '(int)'
+#     assert inspect.signature(Number).__str__() == '(value)'
 # except ValueError:
 #     # Not supported with `abi3` before Python 3.10
 #     pass

--- a/guide/src/function/signature.md
+++ b/guide/src/function/signature.md
@@ -272,9 +272,7 @@ impl MyClass {
 
 The function signature is exposed to Python via the `__text_signature__` attribute. PyO3 automatically generates this for every `#[pyfunction]` and all `#[pymethods]` directly from the Rust function, taking into account any override done with the `#[pyo3(signature = (...))]` option.
 
-This automatic generation has some limitations, which may be improved in the future:
-- It will not include the value of default arguments, replacing them all with `...`. (`.pyi` type stub files commonly also use `...` for all default arguments in the same way.)
-- Nothing is generated for the `#[new]` method of a `#[pyclass]`.
+This automatic generation can only display the value of default arguments for strings, integers, boolean types, and `None`. Any other default arguments will be displayed as `...`. (`.pyi` type stub files commonly also use `...` for default arguments in the same way.)
 
 In cases where the automatically-generated signature needs adjusting, it can [be overridden](#overriding-the-generated-signature) using the `#[pyo3(text_signature)]` option.)
 

--- a/newsfragments/2980.added.md
+++ b/newsfragments/2980.added.md
@@ -1,0 +1,1 @@
+Support `text_signature` option (and automatically generate signature) for `#[new]` in `#[pymethods]`.

--- a/newsfragments/2980.changed.md
+++ b/newsfragments/2980.changed.md
@@ -1,0 +1,1 @@
+Deprecate `text_signature` option on `#[pyclass]`.

--- a/pyo3-macros-backend/src/deprecations.rs
+++ b/pyo3-macros-backend/src/deprecations.rs
@@ -2,6 +2,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote_spanned, ToTokens};
 
 pub enum Deprecation {
+    PyClassTextSignature,
     PyFunctionArguments,
     PyMethodArgsAttribute,
     RequiredArgumentAfterOption,
@@ -10,6 +11,7 @@ pub enum Deprecation {
 impl Deprecation {
     fn ident(&self, span: Span) -> syn::Ident {
         let string = match self {
+            Deprecation::PyClassTextSignature => "PYCLASS_TEXT_SIGNATURE",
             Deprecation::PyFunctionArguments => "PYFUNCTION_ARGUMENTS",
             Deprecation::PyMethodArgsAttribute => "PYMETHODS_ARGS_ATTRIBUTE",
             Deprecation::RequiredArgumentAfterOption => "REQUIRED_ARGUMENT_AFTER_OPTION",

--- a/pyo3-macros-backend/src/pyfunction/signature.rs
+++ b/pyo3-macros-backend/src/pyfunction/signature.rs
@@ -13,7 +13,7 @@ use syn::{
 use crate::{
     attributes::{kw, KeywordAttribute},
     deprecations::{Deprecation, Deprecations},
-    method::{FnArg, FnType},
+    method::FnArg,
     pyfunction::Argument,
 };
 
@@ -623,18 +623,7 @@ impl<'a> FunctionSignature<'a> {
         default
     }
 
-    pub fn text_signature(&self, fn_type: &FnType) -> String {
-        // automatic text signature generation
-        let self_argument = match fn_type {
-            FnType::FnNew | FnType::Getter(_) | FnType::Setter(_) | FnType::ClassAttribute => {
-                unreachable!()
-            }
-            FnType::Fn(_) => Some("self"),
-            FnType::FnModule => Some("module"),
-            FnType::FnClass => Some("cls"),
-            FnType::FnStatic => None,
-        };
-
+    pub fn text_signature(&self, self_argument: Option<&str>) -> String {
         let mut output = String::new();
         output.push('(');
 

--- a/src/impl_/deprecations.rs
+++ b/src/impl_/deprecations.rs
@@ -17,3 +17,9 @@ pub const PYMETHODS_ARGS_ATTRIBUTE: () = ();
     note = "required arguments after an `Option<_>` argument are ambiguous and being phased out\n= help: add a `#[pyo3(signature)]` annotation on this function to unambiguously specify the default values for all optional parameters"
 )]
 pub const REQUIRED_ARGUMENT_AFTER_OPTION: () = ();
+
+#[deprecated(
+    since = "0.19.0",
+    note = "put `text_signature` on `#[new]` instead of `#[pyclass]`"
+)]
+pub const PYCLASS_TEXT_SIGNATURE: () = ();

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -238,6 +238,7 @@ fn test_auto_test_signature_method() {
 
     Python::with_gil(|py| {
         let cls = py.get_type::<MyClass>();
+        #[cfg(any(not(Py_LIMITED_API), Py_3_10))]
         py_assert!(py, cls, "cls.__text_signature__ == '(a, b, c)'");
         py_assert!(
             py,

--- a/tests/ui/invalid_pymethods.rs
+++ b/tests/ui/invalid_pymethods.rs
@@ -47,13 +47,6 @@ impl MyClass {
 
 #[pymethods]
 impl MyClass {
-    #[new]
-    #[pyo3(text_signature = "()")]
-    fn text_signature_on_new() {}
-}
-
-#[pymethods]
-impl MyClass {
     #[pyo3(name = "__call__", text_signature = "()")]
     fn text_signature_on_call() {}
 }

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -34,115 +34,120 @@ error: expected receiver for #[setter]
 45 |     fn setter_without_receiver() {}
    |     ^^
 
-error: `text_signature` not allowed on `__new__`; if you want to add a signature on `__new__`, put it on the struct definition instead
-  --> tests/ui/invalid_pymethods.rs:51:12
-   |
-51 |     #[pyo3(text_signature = "()")]
-   |            ^^^^^^^^^^^^^^
-
 error: static method needs #[staticmethod] attribute
-  --> tests/ui/invalid_pymethods.rs:58:5
+  --> tests/ui/invalid_pymethods.rs:51:5
    |
-58 |     fn text_signature_on_call() {}
+51 |     fn text_signature_on_call() {}
    |     ^^
 
 error: `text_signature` not allowed with `getter`
+  --> tests/ui/invalid_pymethods.rs:57:12
+   |
+57 |     #[pyo3(text_signature = "()")]
+   |            ^^^^^^^^^^^^^^
+
+error: `text_signature` not allowed with `setter`
   --> tests/ui/invalid_pymethods.rs:64:12
    |
 64 |     #[pyo3(text_signature = "()")]
    |            ^^^^^^^^^^^^^^
 
-error: `text_signature` not allowed with `setter`
+error: `text_signature` not allowed with `classattr`
   --> tests/ui/invalid_pymethods.rs:71:12
    |
 71 |     #[pyo3(text_signature = "()")]
    |            ^^^^^^^^^^^^^^
 
-error: `text_signature` not allowed with `classattr`
-  --> tests/ui/invalid_pymethods.rs:78:12
-   |
-78 |     #[pyo3(text_signature = "()")]
-   |            ^^^^^^^^^^^^^^
-
 error: expected a string literal or `None`
-  --> tests/ui/invalid_pymethods.rs:84:30
+  --> tests/ui/invalid_pymethods.rs:77:30
    |
-84 |     #[pyo3(text_signature = 1)]
+77 |     #[pyo3(text_signature = 1)]
    |                              ^
 
 error: `text_signature` may only be specified once
-  --> tests/ui/invalid_pymethods.rs:91:12
+  --> tests/ui/invalid_pymethods.rs:84:12
    |
-91 |     #[pyo3(text_signature = None)]
+84 |     #[pyo3(text_signature = None)]
    |            ^^^^^^^^^^^^^^
 
 error: `signature` not allowed with `getter`
+  --> tests/ui/invalid_pymethods.rs:91:12
+   |
+91 |     #[pyo3(signature = ())]
+   |            ^^^^^^^^^
+
+error: `signature` not allowed with `setter`
   --> tests/ui/invalid_pymethods.rs:98:12
    |
 98 |     #[pyo3(signature = ())]
    |            ^^^^^^^^^
 
-error: `signature` not allowed with `setter`
+error: `signature` not allowed with `classattr`
    --> tests/ui/invalid_pymethods.rs:105:12
     |
 105 |     #[pyo3(signature = ())]
     |            ^^^^^^^^^
 
-error: `signature` not allowed with `classattr`
-   --> tests/ui/invalid_pymethods.rs:112:12
-    |
-112 |     #[pyo3(signature = ())]
-    |            ^^^^^^^^^
-
 error: cannot specify a second method type
-   --> tests/ui/invalid_pymethods.rs:119:7
+   --> tests/ui/invalid_pymethods.rs:112:7
     |
-119 |     #[staticmethod]
+112 |     #[staticmethod]
     |       ^^^^^^^^^^^^
 
 error: Python functions cannot have generic type parameters
-   --> tests/ui/invalid_pymethods.rs:125:23
+   --> tests/ui/invalid_pymethods.rs:118:23
     |
-125 |     fn generic_method<T>(value: T) {}
+118 |     fn generic_method<T>(value: T) {}
     |                       ^
 
 error: Python functions cannot have `impl Trait` arguments
-   --> tests/ui/invalid_pymethods.rs:130:48
+   --> tests/ui/invalid_pymethods.rs:123:48
     |
-130 |     fn impl_trait_method_first_arg(impl_trait: impl AsRef<PyAny>) {}
+123 |     fn impl_trait_method_first_arg(impl_trait: impl AsRef<PyAny>) {}
     |                                                ^^^^
 
 error: Python functions cannot have `impl Trait` arguments
-   --> tests/ui/invalid_pymethods.rs:135:56
+   --> tests/ui/invalid_pymethods.rs:128:56
     |
-135 |     fn impl_trait_method_second_arg(&self, impl_trait: impl AsRef<PyAny>) {}
+128 |     fn impl_trait_method_second_arg(&self, impl_trait: impl AsRef<PyAny>) {}
     |                                                        ^^^^
 
 error: `async fn` is not yet supported for Python functions.
 
        Additional crates such as `pyo3-asyncio` can be used to integrate async Rust and Python. For more information, see https://github.com/PyO3/pyo3/issues/1632
-   --> tests/ui/invalid_pymethods.rs:140:5
+   --> tests/ui/invalid_pymethods.rs:133:5
     |
-140 |     async fn async_method(&self) {}
+133 |     async fn async_method(&self) {}
     |     ^^^^^
 
 error: `pass_module` cannot be used on Python methods
-   --> tests/ui/invalid_pymethods.rs:145:12
+   --> tests/ui/invalid_pymethods.rs:138:12
     |
-145 |     #[pyo3(pass_module)]
+138 |     #[pyo3(pass_module)]
     |            ^^^^^^^^^^^
 
 error: Python objects are shared, so 'self' cannot be moved out of the Python interpreter.
        Try `&self`, `&mut self, `slf: PyRef<'_, Self>` or `slf: PyRefMut<'_, Self>`.
-   --> tests/ui/invalid_pymethods.rs:151:29
+   --> tests/ui/invalid_pymethods.rs:144:29
     |
-151 |     fn method_self_by_value(self) {}
+144 |     fn method_self_by_value(self) {}
     |                             ^^^^
 
-error[E0592]: duplicate definitions with name `__pymethod___new____`
-   --> tests/ui/invalid_pymethods.rs:156:1
+error[E0119]: conflicting implementations of trait `pyo3::impl_::pyclass::PyClassNewTextSignature<TwoNew>` for type `pyo3::impl_::pyclass::PyClassImplCollector<TwoNew>`
+   --> tests/ui/invalid_pymethods.rs:149:1
     |
-156 | #[pymethods]
+149 | #[pymethods]
+    | ^^^^^^^^^^^^
+    | |
+    | first implementation here
+    | conflicting implementation for `pyo3::impl_::pyclass::PyClassImplCollector<TwoNew>`
+    |
+    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0592]: duplicate definitions with name `__pymethod___new____`
+   --> tests/ui/invalid_pymethods.rs:149:1
+    |
+149 | #[pymethods]
     | ^^^^^^^^^^^^
     | |
     | duplicate definitions for `__pymethod___new____`
@@ -151,9 +156,9 @@ error[E0592]: duplicate definitions with name `__pymethod___new____`
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod_func__`
-   --> tests/ui/invalid_pymethods.rs:171:1
+   --> tests/ui/invalid_pymethods.rs:164:1
     |
-171 | #[pymethods]
+164 | #[pymethods]
     | ^^^^^^^^^^^^
     | |
     | duplicate definitions for `__pymethod_func__`


### PR DESCRIPTION
Closes #2866 

This is a breaking change for 0.19.0, because it starts autogenerating `text_signature` for `#[new]`. This could affect runtime behaviour if the user is relying on the class docs at runtime for some reason.

Guide & tests all updated accordingly.

`#[pyclass(text_signature = "...")]` is deprecated by this PR, however if it's set, it will be used in preference to `#[new]`.

(The signature / `text_signature` from `#[new]` will simply be ignored in this case. I figure that when users fix their deprecation warnings by removing `#[pyclass(text_signature = "...")]` then the `#[new]` signatures will start flowing properly, and this is good enough.)