### PR TITLE
Remove 0.17 deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           targets: ${{ matrix.platform.rust-target }}
-          components: clippy
+          components: clippy,rust-src
       - uses: actions/setup-python@v4
         with:
           architecture: ${{ matrix.platform.python-architecture }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,8 +91,7 @@ abi3-py311 = ["abi3", "pyo3-build-config/abi3-py311", "pyo3-ffi/abi3-py311"]
 # Automatically generates `python3.dll` import libraries for Windows targets.
 generate-import-lib = ["pyo3-ffi/generate-import-lib"]
 
-# Changes `Python::with_gil` and `Python::acquire_gil` to automatically initialize the
-# Python interpreter if needed.
+# Changes `Python::with_gil` to automatically initialize the Python interpreter if needed.
 auto-initialize = []
 
 # Optimizes PyObject to Vec conversion and so on.

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -45,7 +45,7 @@ section for further detail.
 
 ### `auto-initialize`
 
-This feature changes [`Python::with_gil`]({{#PYO3_DOCS_URL}}/pyo3/struct.Python.html#method.with_gil) and [`Python::acquire_gil`]({{#PYO3_DOCS_URL}}/pyo3/struct.Python.html#method.acquire_gil) to automatically initialize a Python interpreter (by calling [`prepare_freethreaded_python`]({{#PYO3_DOCS_URL}}/pyo3/fn.prepare_freethreaded_python.html)) if needed.
+This feature changes [`Python::with_gil`]({{#PYO3_DOCS_URL}}/pyo3/struct.Python.html#method.with_gil) to automatically initialize a Python interpreter (by calling [`prepare_freethreaded_python`]({{#PYO3_DOCS_URL}}/pyo3/fn.prepare_freethreaded_python.html)) if needed.
 
 If you do not enable this feature, you should call `pyo3::prepare_freethreaded_python()` before attempting to call any other Python APIs.
 

--- a/guide/src/memory.md
+++ b/guide/src/memory.md
@@ -35,10 +35,9 @@ Python::with_gil(|py| -> PyResult<()> {
 # }
 ```
 
-Internally, calling `Python::with_gil()` or `Python::acquire_gil()` creates a
-`GILPool` which owns the memory pointed to by the reference.  In the example
-above, the lifetime of the reference `hello` is bound to the `GILPool`.  When
-the `with_gil()` closure ends or the `GILGuard` from `acquire_gil()` is dropped,
+Internally, calling `Python::with_gil()` creates a `GILPool` which owns the
+memory pointed to by the reference.  In the example above, the lifetime of the
+reference `hello` is bound to the `GILPool`.  When the `with_gil()` closure ends
 the `GILPool` is also dropped and the Python reference counts of the variables
 it owns are decreased, releasing them to the Python garbage collector.  Most
 of the time we don't have to think about this, but consider the following:

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -44,7 +44,7 @@ However, if the `anyhow::Error` or `eyre::Report` has a source, then the origina
 
 While the API provided by [`Python::acquire_gil`](https://docs.rs/pyo3/0.18.3/pyo3/marker/struct.Python.html#method.acquire_gil) seems convenient, it is somewhat brittle as the design of the GIL token [`Python`](https://docs.rs/pyo3/0.18.3/pyo3/marker/struct.Python.html) relies on proper nesting and panics if not used correctly, e.g.
 
-```rust,should_panic
+```rust,ignore
 # #![allow(dead_code, deprecated)]
 # use pyo3::prelude::*;
 

--- a/newsfragments/2981.removed.md
+++ b/newsfragments/2981.removed.md
@@ -1,0 +1,1 @@
+Remove all functionality deprecated in PyO3 0.17, most prominently `Python::acquire_gil` is replaced by `Python::with_gil`.

--- a/pytests/src/misc.rs
+++ b/pytests/src/misc.rs
@@ -3,20 +3,11 @@ use pyo3::prelude::*;
 #[pyfunction]
 fn issue_219() {
     // issue 219: acquiring GIL inside #[pyfunction] deadlocks.
-    #[allow(deprecated)]
-    let gil = Python::acquire_gil();
-    let _py = gil.python();
-}
-
-#[pyfunction]
-fn issue_219_2() {
-    // issue 219: acquiring GIL inside #[pyfunction] deadlocks.
     Python::with_gil(|_| {});
 }
 
 #[pymodule]
 pub fn misc(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(issue_219, m)?)?;
-    m.add_function(wrap_pyfunction!(issue_219_2, m)?)?;
     Ok(())
 }

--- a/pytests/tests/test_misc.py
+++ b/pytests/tests/test_misc.py
@@ -8,7 +8,6 @@ import pytest
 def test_issue_219():
     # Should not deadlock
     pyo3_pytests.misc.issue_219()
-    pyo3_pytests.misc.issue_219_2()
 
 
 @pytest.mark.skipif(

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -135,34 +135,6 @@ pub trait ToPyObject {
     fn to_object(&self, py: Python<'_>) -> PyObject;
 }
 
-/// A deprecated conversion trait which relied on the unstable `specialization` feature
-/// of the Rust language.
-#[deprecated(
-    since = "0.17.0",
-    note = "this trait is no longer used by PyO3, use ToPyObject or IntoPy<PyObject>"
-)]
-pub trait ToBorrowedObject: ToPyObject {
-    /// Converts self into a Python object and calls the specified closure
-    /// on the native FFI pointer underlying the Python object.
-    ///
-    /// May be more efficient than `to_object` because it does not need
-    /// to touch any reference counts when the input object already is a Python object.
-    fn with_borrowed_ptr<F, R>(&self, py: Python<'_>, f: F) -> R
-    where
-        F: FnOnce(*mut ffi::PyObject) -> R,
-    {
-        let ptr = self.to_object(py).into_ptr();
-        let result = f(ptr);
-        unsafe {
-            ffi::Py_XDECREF(ptr);
-        }
-        result
-    }
-}
-
-#[allow(deprecated)]
-impl<T> ToBorrowedObject for T where T: ToPyObject {}
-
 /// Defines a conversion from a Rust type to a Python object.
 ///
 /// It functions similarly to std's [`Into`](std::convert::Into) trait,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,8 @@
 //!
 //! - `abi3`: Restricts PyO3's API to a subset of the full Python API which is guaranteed by
 //! [PEP 384] to be forward-compatible with future Python versions.
-//! - `auto-initialize`: Changes [`Python::with_gil`] and [`Python::acquire_gil`] to automatically
-//! initialize the Python interpreter if needed.
+//! - `auto-initialize`: Changes [`Python::with_gil`] to automatically initialize the Python
+//! interpreter if needed.
 //! - `extension-module`: This will tell the linker to keep the Python symbols unresolved, so that
 //! your module can also be used with statically linked Python interpreters. Use this feature when
 //! building an extension module.
@@ -307,9 +307,9 @@ pub use crate::conversion::{
     ToPyObject,
 };
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
+pub use crate::gil::GILPool;
 #[cfg(not(PyPy))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
-pub use crate::gil::{GILGuard, GILPool};
 pub use crate::instance::{Py, PyNativeType, PyObject};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,8 +300,6 @@
 //! [Features chapter of the guide]: https://pyo3.rs/latest/features.html#features-reference "Features Reference - PyO3 user guide"
 //! [`Ungil`]: crate::marker::Ungil
 pub use crate::class::*;
-#[allow(deprecated)]
-pub use crate::conversion::ToBorrowedObject;
 pub use crate::conversion::{
     AsPyPointer, FromPyObject, FromPyPointer, IntoPy, IntoPyPointer, PyTryFrom, PyTryInto,
     ToPyObject,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -14,7 +14,6 @@ pub use crate::conversion::{
     FromPyObject, IntoPy, IntoPyPointer, PyTryFrom, PyTryInto, ToPyObject,
 };
 pub use crate::err::{PyErr, PyResult};
-pub use crate::gil::GILGuard;
 pub use crate::instance::{Py, PyObject};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};

--- a/src/types/capsule.rs
+++ b/src/types/capsule.rs
@@ -198,12 +198,6 @@ impl PyCapsule {
         Ok(ctx)
     }
 
-    /// Deprecated form of `.context()`.
-    #[deprecated(since = "0.17.0", note = "replaced with .context()")]
-    pub fn get_context(&self, _: Python<'_>) -> PyResult<*mut c_void> {
-        self.context()
-    }
-
     /// Obtains a reference to the value of this capsule.
     ///
     /// # Safety

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -319,22 +319,20 @@ fn test_option_list_get() {
 
 #[test]
 fn sequence_is_not_mapping() {
-    #[allow(deprecated)]
-    let gil = Python::acquire_gil();
-    let py = gil.python();
+    Python::with_gil(|py| {
+        let list = PyCell::new(
+            py,
+            OptionList {
+                items: vec![Some(1), None],
+            },
+        )
+        .unwrap();
 
-    let list = PyCell::new(
-        py,
-        OptionList {
-            items: vec![Some(1), None],
-        },
-    )
-    .unwrap();
+        PySequence::register::<OptionList>(py).unwrap();
 
-    PySequence::register::<OptionList>(py).unwrap();
-
-    assert!(list.as_ref().downcast::<PyMapping>().is_err());
-    assert!(list.as_ref().downcast::<PySequence>().is_ok());
+        assert!(list.as_ref().downcast::<PyMapping>().is_err());
+        assert!(list.as_ref().downcast::<PySequence>().is_ok());
+    })
 }
 
 #[test]

--- a/tests/ui/not_send.stderr
+++ b/tests/ui/not_send.stderr
@@ -9,8 +9,8 @@ error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safe
   = help: within `pyo3::Python<'_>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
   = note: required because it appears within the type `PhantomData<*mut Python<'static>>`
   = note: required because it appears within the type `NotSend`
-  = note: required because it appears within the type `(&GILGuard, NotSend)`
-  = note: required because it appears within the type `PhantomData<(&GILGuard, NotSend)>`
+  = note: required because it appears within the type `(&EnsureGIL, NotSend)`
+  = note: required because it appears within the type `PhantomData<(&EnsureGIL, NotSend)>`
   = note: required because it appears within the type `Python<'_>`
   = note: required for `&pyo3::Python<'_>` to implement `Send`
 note: required because it's used within this closure

--- a/tests/ui/pyclass_send.rs
+++ b/tests/ui/pyclass_send.rs
@@ -3,23 +3,24 @@ use std::rc::Rc;
 
 #[pyclass]
 struct NotThreadSafe {
-    data: Rc<i32>
+    data: Rc<i32>,
 }
 
 fn main() {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-
-    let obj = PyCell::new(py, NotThreadSafe { data: Rc::new(5) }).unwrap().to_object(py);
-    drop(gil);
+    let obj = Python::with_gil(|py| {
+        PyCell::new(py, NotThreadSafe { data: Rc::new(5) })
+            .unwrap()
+            .to_object(py)
+    });
 
     std::thread::spawn(move || {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
+        Python::with_gil(|py| {
+            // Uh oh, moved Rc to a new thread!
+            let c: &PyCell<NotThreadSafe> = obj.as_ref(py).downcast().unwrap();
 
-        // Uh oh, moved Rc to a new thread!
-        let c: &PyCell<NotThreadSafe> = obj.as_ref(py).downcast().unwrap();
-
-        assert_eq!(*c.borrow().data, 5);
-    }).join().unwrap();
+            assert_eq!(*c.borrow().data, 5);
+        })
+    })
+    .join()
+    .unwrap();
 }

--- a/tests/ui/wrong_aspyref_lifetimes.rs
+++ b/tests/ui/wrong_aspyref_lifetimes.rs
@@ -1,11 +1,10 @@
 use pyo3::{types::PyDict, Py, Python};
 
 fn main() {
-    #[allow(deprecated)]
-    let gil = Python::acquire_gil();
-    let dict: Py<PyDict> = PyDict::new(gil.python()).into();
-    let dict: &PyDict = dict.as_ref(gil.python());
-    drop(gil);
+    let dict: Py<PyDict> = Python::with_gil(|py| PyDict::new(py).into());
+
+    // Should not be able to get access to Py contents outside of with_gil.
+    let dict: &PyDict = Python::with_gil(|py| dict.as_ref(py));
 
     let _py: Python = dict.py(); // Obtain a Python<'p> without GIL.
 }

--- a/tests/ui/wrong_aspyref_lifetimes.stderr
+++ b/tests/ui/wrong_aspyref_lifetimes.stderr
@@ -1,13 +1,8 @@
-error[E0505]: cannot move out of `gil` because it is borrowed
-  --> tests/ui/wrong_aspyref_lifetimes.rs:8:10
-   |
-5  |     let gil = Python::acquire_gil();
-   |         --- binding `gil` declared here
-6  |     let dict: Py<PyDict> = PyDict::new(gil.python()).into();
-7  |     let dict: &PyDict = dict.as_ref(gil.python());
-   |                                     ------------ borrow of `gil` occurs here
-8  |     drop(gil);
-   |          ^^^ move out of `gil` occurs here
-9  |
-10 |     let _py: Python = dict.py(); // Obtain a Python<'p> without GIL.
-   |                       --------- borrow later used here
+error: lifetime may not live long enough
+ --> tests/ui/wrong_aspyref_lifetimes.rs:7:47
+  |
+7 |     let dict: &PyDict = Python::with_gil(|py| dict.as_ref(py));
+  |                                           --- ^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+  |                                           | |
+  |                                           | return type of closure is &'2 PyDict
+  |                                           has type `pyo3::Python<'1>`


### PR DESCRIPTION
Since #2980 starts a breaking change for 0.19, let's also clean up all 0.17's deprecations.

I've removed `Python::acquire_gil` in its own commit, as that was a reasonably chunky removal.