### PR TITLE
Enable cargo-semver-checks to catch accidental breakage of backwards compatibility.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,19 @@ jobs:
       - name: Check rust formatting (rustfmt)
         run: nox -s fmt-rust
 
+  semver-checks:
+    if: github.ref != 'refs/heads/main'
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks
+      - run: cargo semver-checks check-release
+
   clippy:
     needs: [fmt]
     runs-on: ${{ matrix.platform.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.18.1"
+version = "0.19.0"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -20,10 +20,10 @@ parking_lot = ">= 0.11, < 0.13"
 memoffset = "0.8"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.18.1" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.19.0" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.18.1", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.19.0", optional = true }
 indoc = { version = "1.0.3", optional = true }
 unindent = { version = "0.1.4", optional = true }
 
@@ -56,7 +56,7 @@ rayon = "1.0.2"
 widestring = "0.5.1"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "0.18.1", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "0.19.0", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
-pyo3 = { version = "0.18.1", path = "..", features = ["auto-initialize", "extension-module"] }
+pyo3 = { version = "0.19.0", path = "..", features = ["auto-initialize", "extension-module"] }
 
 [[example]]
 name = "decorator"

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.18.1"
+version = "0.19.0"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.18.1"
+version = "0.19.0"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -38,4 +38,4 @@ generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "0.18.1", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "0.19.0", features = ["resolve-config"] }

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.18.1"
+version = "0.19.0"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.18.1"
+version = "0.19.0"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -22,4 +22,4 @@ abi3 = ["pyo3-macros-backend/abi3"]
 proc-macro2 = { version = "1", default-features = false }
 quote = "1"
 syn = { version = "1.0.56", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.18.1" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.19.0" }


### PR DESCRIPTION
If I understand things correctly, we just need to make sure to bump the version on the topic branch and thereby main branch as soon as we make a breaking change?