### PR TITLE
Fix `clippy::redundant_closure` lint firing for pyfunction defaults

### DIFF
--- a/newsfragments/2990.fixed.md
+++ b/newsfragments/2990.fixed.md
@@ -1,0 +1,1 @@
+Fix `clippy::redundant_closure` lint on default arguments in `#[pyo3(signature = (...))]` annotations.

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -207,7 +207,13 @@ fn impl_arg_param(
     let tokens = if let Some(expr_path) = arg.attrs.from_py_with.as_ref().map(|attr| &attr.value) {
         if let Some(default) = default {
             quote_arg_span! {
-                _pyo3::impl_::extract_argument::from_py_with_with_default(#arg_value, #name_str, #expr_path, || #default)?
+                #[allow(clippy::redundant_closure)]
+                _pyo3::impl_::extract_argument::from_py_with_with_default(
+                    #arg_value,
+                    #name_str,
+                    #expr_path,
+                    || #default
+                )?
             }
         } else {
             quote_arg_span! {
@@ -220,6 +226,7 @@ fn impl_arg_param(
         }
     } else if arg.optional.is_some() {
         quote_arg_span! {
+            #[allow(clippy::redundant_closure)]
             _pyo3::impl_::extract_argument::extract_optional_argument(
                 #arg_value,
                 &mut { _pyo3::impl_::extract_argument::FunctionArgumentHolder::INIT },
@@ -229,6 +236,7 @@ fn impl_arg_param(
         }
     } else if let Some(default) = default {
         quote_arg_span! {
+            #[allow(clippy::redundant_closure)]
             _pyo3::impl_::extract_argument::extract_argument_with_default(
                 #arg_value,
                 &mut { _pyo3::impl_::extract_argument::FunctionArgumentHolder::INIT },

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -1543,3 +1543,20 @@ fn test_option_pyclass_arg() {
             .is_ok());
     })
 }
+
+#[test]
+#[allow(non_snake_case)] // FIXME __pyfunction__foo expanded symbol is not snake case
+fn test_issue_2988() {
+    #[pyfunction]
+    #[pyo3(signature = (
+        _data = vec![],
+        _data2 = vec![],
+    ))]
+    pub fn _foo(
+        _data: Vec<i32>,
+        // The from_py_with here looks a little odd, we just need some way
+        // to encourage the macro to expand the from_py_with default path too
+        #[pyo3(from_py_with = "PyAny::extract")] _data2: Vec<i32>,
+    ) {
+    }
+}


### PR DESCRIPTION
Fixes #2988

I'll push a follow-up for the FIXME as a separate PR.