### PR TITLE
fix `non_snake_case` lint for `#[pyfunction]` generated code

### DIFF
--- a/newsfragments/2993.fixed.md
+++ b/newsfragments/2993.fixed.md
@@ -1,0 +1,1 @@
+Fix `non_snake_case` lint fired by generated code in `#[pyfunction]` macro.

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -457,6 +457,7 @@ pub fn impl_wrap_pyfunction(
                 const DEF: #krate::impl_::pyfunction::PyMethodDef = #methoddef;
             }
 
+            #[allow(non_snake_case)]
             #wrapper
         };
     };

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -1545,7 +1545,6 @@ fn test_option_pyclass_arg() {
 }
 
 #[test]
-#[allow(non_snake_case)] // FIXME __pyfunction__foo expanded symbol is not snake case
 fn test_issue_2988() {
     #[pyfunction]
     #[pyo3(signature = (


### PR DESCRIPTION
As promised in #2990 