### PR TITLE
Emit a better error for bad argument names

### DIFF
--- a/tests/ui/invalid_pyfunctions.rs
+++ b/tests/ui/invalid_pyfunctions.rs
@@ -9,4 +9,10 @@ fn impl_trait_function(impl_trait: impl AsRef<PyAny>) {}
 #[pyfunction]
 async fn async_function() {}
 
+#[pyfunction]
+fn wildcard_argument(_: i32) {}
+
+#[pyfunction]
+fn destructured_argument((a, b): (i32, i32)) {}
+
 fn main() {}

--- a/tests/ui/invalid_pyfunctions.stderr
+++ b/tests/ui/invalid_pyfunctions.stderr
@@ -17,3 +17,15 @@ error: `async fn` is not yet supported for Python functions.
    |
 10 | async fn async_function() {}
    | ^^^^^
+
+error: wildcard argument names are not supported
+  --> tests/ui/invalid_pyfunctions.rs:13:22
+   |
+13 | fn wildcard_argument(_: i32) {}
+   |                      ^
+
+error: destructuring in arguments is not supported
+  --> tests/ui/invalid_pyfunctions.rs:16:26
+   |
+16 | fn destructured_argument((a, b): (i32, i32)) {}
+   |                          ^^^^^^


### PR DESCRIPTION
This will emit a better error for code like 
```rust
#[pyfunction]
fn output([a,b,c]: [u8;3]) {}
```

