### PR TITLE
use dynamic trampoline for all getters and setters

### DIFF
--- a/newsfragments/3029.changed.md
+++ b/newsfragments/3029.changed.md
@@ -1,0 +1,1 @@
+- Change `#[getter]` and `#[setter]` to use a common call "trampoline" to slightly reduce generated code size and compile times.

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -583,22 +583,7 @@ pub fn impl_py_setter_def(
             #deprecations
             _pyo3::class::PySetterDef::new(
                 #python_name,
-                _pyo3::impl_::pymethods::PySetter({
-                    unsafe extern "C" fn trampoline(
-                        slf: *mut _pyo3::ffi::PyObject,
-                        value: *mut _pyo3::ffi::PyObject,
-                        closure: *mut ::std::os::raw::c_void,
-                    ) -> ::std::os::raw::c_int
-                    {
-                        _pyo3::impl_::trampoline::setter(
-                            slf,
-                            value,
-                            closure,
-                            #cls::#wrapper_ident
-                        )
-                    }
-                    trampoline
-                }),
+                _pyo3::impl_::pymethods::PySetter(#cls::#wrapper_ident),
                 #doc
             )
         })
@@ -719,20 +704,7 @@ pub fn impl_py_getter_def(
             #deprecations
             _pyo3::class::PyGetterDef::new(
                 #python_name,
-                _pyo3::impl_::pymethods::PyGetter({
-                    unsafe extern "C" fn trampoline(
-                        slf: *mut _pyo3::ffi::PyObject,
-                        closure: *mut ::std::os::raw::c_void,
-                    ) -> *mut _pyo3::ffi::PyObject
-                    {
-                        _pyo3::impl_::trampoline::getter(
-                            slf,
-                            closure,
-                            #cls::#wrapper_ident
-                        )
-                    }
-                    trampoline
-                }),
+                _pyo3::impl_::pymethods::PyGetter(#cls::#wrapper_ident),
                 #doc
             )
         })

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -5,7 +5,7 @@
 
 use std::{
     any::Any,
-    os::raw::{c_int, c_void},
+    os::raw::c_int,
     panic::{self, UnwindSafe},
 };
 
@@ -63,29 +63,6 @@ trampolines!(
         kwargs: *mut ffi::PyObject,
     ) -> *mut ffi::PyObject;
 );
-
-#[inline]
-pub unsafe fn getter(
-    slf: *mut ffi::PyObject,
-    closure: *mut c_void,
-    f: for<'py> unsafe fn(Python<'py>, *mut ffi::PyObject) -> PyResult<*mut ffi::PyObject>,
-) -> *mut ffi::PyObject {
-    // PyO3 doesn't use the closure argument at present.
-    debug_assert!(closure.is_null());
-    trampoline_inner(|py| f(py, slf))
-}
-
-#[inline]
-pub unsafe fn setter(
-    slf: *mut ffi::PyObject,
-    value: *mut ffi::PyObject,
-    closure: *mut c_void,
-    f: for<'py> unsafe fn(Python<'py>, *mut ffi::PyObject, *mut ffi::PyObject) -> PyResult<c_int>,
-) -> c_int {
-    // PyO3 doesn't use the closure argument at present.
-    debug_assert!(closure.is_null());
-    trampoline_inner(|py| f(py, slf, value))
-}
 
 // Trampolines used by slot methods
 trampolines!(

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -8,7 +8,7 @@ use std::{cmp::Ordering, os::raw::c_int};
 mod create_type_object;
 mod gc;
 
-pub(crate) use self::create_type_object::create_type_object;
+pub(crate) use self::create_type_object::{create_type_object, PyClassTypeObject};
 pub use self::gc::{PyTraverseError, PyVisit};
 
 /// Types that can be used as Python classes.


### PR DESCRIPTION
This is an extension to the "trampoline" changes made in #2705 to re-use a single trampoline for all `#[getter]`s (and similar for all `#[setters]`). It works by setting the currently-unused `closure` member of the `ffi::PyGetSetDef` structure to point at a new `struct GetSetDefClosure` which contains function pointers to the `getter` / `setter` implementations.

A universal trampoline for all `getter`, for example, then works by reading the actual getter implementation out of the `GetSetDefClosure`.

Advantages of doing this:
- Very minimal simplification to the macro code / generated code size. It made a 4.4% reduction to `test_getter_setter` generated size, which is an exaggerated result as most code will probably have lots of bulk that isn't just the macro code.

Disadvantages:
- Additional level of complexity in the `getter` and `setter` trampolines and accompanying code.
- To keep the `GetSetDefClosure` objects alive, I've added them to the static `LazyTypeObject` inner.
- Very slight performance overhead at runtime (shouldn't be more than an additional pointer read). It's so slight I couldn't measure it.

Overall I'm happy to either merge or close this based on what reviewers think!