### PR TITLE
mangle exported functions for PyPy

### DIFF
--- a/newsfragments/3031.fixed.md
+++ b/newsfragments/3031.fixed.md
@@ -1,0 +1,1 @@
+Mangle exported function names for PyPy

--- a/pyo3-ffi/src/abstract_.rs
+++ b/pyo3-ffi/src/abstract_.rs
@@ -25,6 +25,7 @@ extern "C" {
         not(PyPy),
         any(Py_3_10, all(not(Py_LIMITED_API), Py_3_9)) // Added to python in 3.9 but to limited API in 3.10
     ))]
+    #[cfg_attr(PyPy, link_name = "PyPyObject_CallNoArgs")]
     pub fn PyObject_CallNoArgs(func: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyObject_Call")]
     pub fn PyObject_Call(
@@ -113,6 +114,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyIter_Next")]
     pub fn PyIter_Next(arg1: *mut PyObject) -> *mut PyObject;
     #[cfg(all(not(PyPy), Py_3_10))]
+    #[cfg_attr(PyPy, link_name = "PyPyIter_Send")]
     pub fn PyIter_Send(iter: *mut PyObject, arg: *mut PyObject, presult: *mut *mut PyObject);
 
     #[cfg_attr(PyPy, link_name = "PyPyNumber_Check")]

--- a/pyo3-ffi/src/modsupport.rs
+++ b/pyo3-ffi/src/modsupport.rs
@@ -54,6 +54,7 @@ extern "C" {
     // skipped non-limited _PyArg_Fini
 
     #[cfg(Py_3_10)]
+    #[cfg_attr(PyPy, link_name = "PyPyModule_AddObjectRef")]
     pub fn PyModule_AddObjectRef(
         module: *mut PyObject,
         name: *const c_char,

--- a/pyo3-ffi/src/objimpl.rs
+++ b/pyo3-ffi/src/objimpl.rs
@@ -30,12 +30,15 @@ extern "C" {
     pub fn PyGC_Collect() -> Py_ssize_t;
 
     #[cfg(Py_3_10)]
+    #[cfg_attr(PyPy, link_name = "PyPyGC_Enable")]
     pub fn PyGC_Enable() -> c_int;
 
     #[cfg(Py_3_10)]
+    #[cfg_attr(PyPy, link_name = "PyPyGC_Disable")]
     pub fn PyGC_Disable() -> c_int;
 
     #[cfg(Py_3_10)]
+    #[cfg_attr(PyPy, link_name = "PyPyGC_IsEnabled")]
     pub fn PyGC_IsEnabled() -> c_int;
 }
 

--- a/pyo3-ffi/src/pyerrors.rs
+++ b/pyo3-ffi/src/pyerrors.rs
@@ -245,6 +245,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyExc_ResourceWarning")]
     pub static mut PyExc_ResourceWarning: *mut PyObject;
     #[cfg(Py_3_10)]
+    #[cfg_attr(PyPy, link_name = "PyPyExc_EncodingWarning")]
     pub static mut PyExc_EncodingWarning: *mut PyObject;
 }
 
@@ -305,9 +306,13 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyErr_SetInterrupt")]
     pub fn PyErr_SetInterrupt();
     #[cfg(Py_3_10)]
+    #[cfg_attr(PyPy, link_name = "PyPyErr_SetInterruptEx")]
     pub fn PyErr_SetInterruptEx(signum: c_int);
+    #[cfg_attr(PyPy, link_name = "PyPyErr_SyntaxLocation")]
     pub fn PyErr_SyntaxLocation(filename: *const c_char, lineno: c_int);
+    #[cfg_attr(PyPy, link_name = "PyPyErr_SyntaxLocationEx")]
     pub fn PyErr_SyntaxLocationEx(filename: *const c_char, lineno: c_int, col_offset: c_int);
+    #[cfg_attr(PyPy, link_name = "PyPyErr_ProgramText")]
     pub fn PyErr_ProgramText(filename: *const c_char, lineno: c_int) -> *mut PyObject;
     #[cfg(not(PyPy))]
     pub fn PyUnicodeDecodeError_Create(


### PR DESCRIPTION
I run HEAD of PyO3 with HEAD of some PyPy branches, and noticed that the py3.10 branch (which implements python3.10) [fails to properly build](https://github.com/pypy/binary-testing/actions/runs/4334873617/jobs/7569059852#step:6:179). The failure was a missing export:
```
 /home/runner/work/binary-testing/binary-testing/pyo3/src/exceptions.rs:715: \
    undefined reference to `PyExc_EncodingWarning'
          collect2: error: ld returned 1 exit status
```

So I grepped around in the code for `Py_3_10` to see what new functions were added and found a few that needed PyPy-specific exports.