### PR TITLE
fix const-ness of some FFI name & doc members

### DIFF
--- a/newsfragments/3036.fixed.md
+++ b/newsfragments/3036.fixed.md
@@ -1,0 +1,1 @@
+Correct FFI definitions `PyGetSetDef`, `PyMemberDef`, `PyStructSequence_Field` and `PyStructSequence_Desc` to have `*const c_char` members for `name` and `doc` (not `*mut c_char`).

--- a/pyo3-ffi/src/descrobject.rs
+++ b/pyo3-ffi/src/descrobject.rs
@@ -11,7 +11,7 @@ pub type setter =
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct PyGetSetDef {
-    pub name: *mut c_char,
+    pub name: *const c_char,
     pub get: Option<getter>,
     pub set: Option<setter>,
     pub doc: *const c_char,
@@ -21,7 +21,7 @@ pub struct PyGetSetDef {
 impl Default for PyGetSetDef {
     fn default() -> PyGetSetDef {
         PyGetSetDef {
-            name: ptr::null_mut(),
+            name: ptr::null(),
             get: None,
             set: None,
             doc: ptr::null(),

--- a/pyo3-ffi/src/structmember.rs
+++ b/pyo3-ffi/src/structmember.rs
@@ -6,11 +6,11 @@ use std::ptr;
 #[repr(C)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct PyMemberDef {
-    pub name: *mut c_char,
+    pub name: *const c_char,
     pub type_code: c_int,
     pub offset: Py_ssize_t,
     pub flags: c_int,
-    pub doc: *mut c_char,
+    pub doc: *const c_char,
 }
 
 impl Default for PyMemberDef {

--- a/pyo3-ffi/src/structseq.rs
+++ b/pyo3-ffi/src/structseq.rs
@@ -6,15 +6,15 @@ use std::os::raw::{c_char, c_int};
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyStructSequence_Field {
-    pub name: *mut c_char,
-    pub doc: *mut c_char,
+    pub name: *const c_char,
+    pub doc: *const c_char,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyStructSequence_Desc {
-    pub name: *mut c_char,
-    pub doc: *mut c_char,
+    pub name: *const c_char,
+    pub doc: *const c_char,
     pub fields: *mut PyStructSequence_Field,
     pub n_in_sequence: c_int,
 }


### PR DESCRIPTION
I just noticed that these are [`*const` since Python 3.7](https://github.com/python/cpython/commit/007d7ff73f4e6e65cfafd512f9c23f7b7119b803#diff-830b405713d1c40982ffa918864e39c40c1b318d79b8dd2b523646dc3bd18b52).

This might break existing compiles, so will not include this in 0.18.2.