### PR TITLE
mangle exported functions for PyPy

### DIFF
--- a/pyo3-ffi/src/sliceobject.rs
+++ b/pyo3-ffi/src/sliceobject.rs
@@ -82,6 +82,7 @@ extern "C" {
         step: *mut Py_ssize_t,
     ) -> c_int;
 
+    #[cfg_attr(PyPy, link_name = "PyPySlice_AdjustIndices")]
     pub fn PySlice_AdjustIndices(
         length: Py_ssize_t,
         start: *mut Py_ssize_t,

--- a/pyo3-ffi/src/sliceobject.rs
+++ b/pyo3-ffi/src/sliceobject.rs
@@ -82,7 +82,7 @@ extern "C" {
         step: *mut Py_ssize_t,
     ) -> c_int;
 
-    #[cfg_attr(PyPy, link_name = "PyPySlice_AdjustIndices")]
+    #[cfg_attr(all(PyPy, Py_3_10), link_name = "PyPySlice_AdjustIndices")]
     pub fn PySlice_AdjustIndices(
         length: Py_ssize_t,
         start: *mut Py_ssize_t,


### PR DESCRIPTION
Continuation of #3031. This [turned up](https://github.com/pypy/binary-testing/actions/runs/4390086363/jobs/7688256133#step:6:179) in the run of PyPy 3.10 HEAD against PyO3 HEAD. Should I add a new news fragment or is the one from #3031 sufficient?