### PR TITLE
add `as_tuple()` method to `PyList`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ valgrind-python.supp
 *.pyd
 lcov.info
 netlify_build/
+# pycharm files
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,3 @@ valgrind-python.supp
 *.pyd
 lcov.info
 netlify_build/
-# pycharm files
-/.idea/

--- a/newsfragments/3042.added.md
+++ b/newsfragments/3042.added.md
@@ -1,0 +1,1 @@
+Add `as_tuple()` method to `PyList`, to more efficiently convert a lists to a tuples.


### PR DESCRIPTION
From [benchmarks](https://github.com/samuelcolvin/rust-bench/blob/25fcf98e125e94e46459b2adfbc297b37969e6ba/benches/main.rs#L165-L192), this is significantly faster than `PyTuple::new(py, the_list)`:

```
test list_as_tuple_direct        ... bench:         299 ns/iter (+/- 51)
test list_as_tuple_iterate       ... bench:         521 ns/iter (+/- 41)
```
