### PR TITLE
Add Blog post in Articles and other media section 

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ about this topic.
 ## Articles and other media
 
 - [How Pydantic V2 leverages Rust's Superpowers](https://fosdem.org/2023/schedule/event/rust_how_pydantic_v2_leverages_rusts_superpowers/) - Feb 4, 2023
+- [How we extended the River stats module with Rust using PyO3](https://boring-guy.sh/posts/river-rust/) - Dec 23, 2022
 - [Nine Rules for Writing Python Extensions in Rust](https://towardsdatascience.com/nine-rules-for-writing-python-extensions-in-rust-d35ea3a4ec29?sk=f8d808d5f414154fdb811e4137011437) - Dec 31, 2021
 - [Calling Rust from Python using PyO3](https://saidvandeklundert.net/learn/2021-11-18-calling-rust-from-python-using-pyo3/) - Nov 18, 2021
 - [davidhewitt's 2021 talk at Rust Manchester meetup](https://www.youtube.com/watch?v=-XyWG_klSAw&t=320s) - Aug 19, 2021


### PR DESCRIPTION
Hi there 👋,

This pull request adds a link to a blog post in the PyO3 README under the "Articles and other media" section. The blog post, titled "How we extended the River stats module with Rust using PyO3," details our experience in utilizing PyO3 to improve the performance of the River library's stats module.


