### PR TITLE
docs: show pattern for self.__class__.__name__ in __repr__

### DIFF
--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -233,8 +233,10 @@ impl Number {
         Self(value)
     }
 
-    fn __repr__(&self) -> String {
-        format!("Number({})", self.0)
+    fn __repr__(slf: &PyCell<Self>) -> PyResult<String> {
+       // Get the class name dynamically in case `Number` is subclassed
+       let class_name: &str = slf.get_type().name()?;
+        Ok(format!("{}({})", class_name, slf.borrow().0))
     }
 
     fn __str__(&self) -> String {


### PR DESCRIPTION
It took me a little while to figure out this pattern in PyO3, so I thought it would be a good addition to the guide.

It's not the cleanest pattern, so would welcome suggestions on how to make it shorter or easier.