### PR TITLE
fix typo DateType -> DateTimeType, fixes #3069

### DIFF
--- a/newsfragments/3071.fixed.md
+++ b/newsfragments/3071.fixed.md
@@ -1,0 +1,1 @@
+Fix isinstance for DateTime (was confused with Date).

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -228,7 +228,7 @@ pub struct PyDateTime(PyAny);
 pyobject_native_type!(
     PyDateTime,
     crate::ffi::PyDateTime_DateTime,
-    *ensure_datetime_api(Python::assume_gil_acquired()).DateType,
+    *ensure_datetime_api(Python::assume_gil_acquired()).DateTimeType,
     #module=Some("datetime"),
     #checkfunction=PyDateTime_Check
 );

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -1,7 +1,7 @@
 #![cfg(not(Py_LIMITED_API))]
 
 use pyo3::prelude::*;
-use pyo3::types::{timezone_utc, IntoPyDict};
+use pyo3::types::{timezone_utc, IntoPyDict, PyDate, PyDateTime, PyTime};
 use pyo3_ffi::PyDateTime_IMPORT;
 
 fn _get_subclasses<'p>(
@@ -61,6 +61,9 @@ fn test_date_check() {
         assert_check_exact!(PyDate_Check, PyDate_CheckExact, obj);
         assert_check_only!(PyDate_Check, PyDate_CheckExact, sub_obj);
         assert_check_only!(PyDate_Check, PyDate_CheckExact, sub_sub_obj);
+        assert!(obj.is_instance_of::<PyDate>().unwrap());
+        assert!(!obj.is_instance_of::<PyTime>().unwrap());
+        assert!(!obj.is_instance_of::<PyDateTime>().unwrap());
     });
 }
 
@@ -73,6 +76,9 @@ fn test_time_check() {
         assert_check_exact!(PyTime_Check, PyTime_CheckExact, obj);
         assert_check_only!(PyTime_Check, PyTime_CheckExact, sub_obj);
         assert_check_only!(PyTime_Check, PyTime_CheckExact, sub_sub_obj);
+        assert!(!obj.is_instance_of::<PyDate>().unwrap());
+        assert!(obj.is_instance_of::<PyTime>().unwrap());
+        assert!(!obj.is_instance_of::<PyDateTime>().unwrap());
     });
 }
 
@@ -88,6 +94,9 @@ fn test_datetime_check() {
         assert_check_exact!(PyDateTime_Check, PyDateTime_CheckExact, obj);
         assert_check_only!(PyDateTime_Check, PyDateTime_CheckExact, sub_obj);
         assert_check_only!(PyDateTime_Check, PyDateTime_CheckExact, sub_sub_obj);
+        assert!(obj.is_instance_of::<PyDate>().unwrap());
+        assert!(!obj.is_instance_of::<PyTime>().unwrap());
+        assert!(obj.is_instance_of::<PyDateTime>().unwrap());
     });
 }
 


### PR DESCRIPTION
This should fix #3069 AKA https://stackoverflow.com/questions/75857300/tell-if-object-isinstance-of-pydatetime-or-pydate. I've added an entry in newsfragments and I've added some regression tests in test_datetime.rs.