### PR TITLE
CI: Pin `inventory` to `0.3.4` in MSRV job

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -424,6 +424,7 @@ def set_minimal_package_versions(session: nox.Session, venv_backend="none"):
     min_pkg_versions = {
         "csv": "1.1.6",
         "indexmap": "1.6.2",
+        "inventory": "0.3.4",
         "hashbrown": "0.9.1",
         "plotters": "0.3.1",
         "plotters-svg": "0.3.1",


### PR DESCRIPTION
Newer `inventory` requires `ctor` 0.2.0.