### PR TITLE
RFC: Use a capsule-based API with a stable ABI for global, cross-extension functionality.

### DIFF
--- a/src/global_api.rs
+++ b/src/global_api.rs
@@ -1,0 +1,85 @@
+//! TODO
+
+use std::{ffi::CString, mem::forget};
+
+use crate::{
+    conversion::PyTryInto,
+    exceptions::PyTypeError,
+    ffi,
+    sync::GILOnceCell,
+    type_object::PyTypeInfo,
+    types::{PyCapsule, PyDict, PyModule},
+    Py, PyResult, Python,
+};
+
+#[repr(C)]
+pub(crate) struct GlobalApi {
+    version: u64,
+    pub(crate) create_panic_exception:
+        unsafe extern "C" fn(msg_ptr: *const u8, msg_len: usize) -> *mut ffi::PyObject,
+}
+
+pub(crate) fn ensure_global_api(py: Python<'_>) -> PyResult<&GlobalApi> {
+    let api = GLOBAL_API.0.get_or_try_init(py, || init_global_api(py))?;
+
+    // SAFETY: We inserted the capsule if it was missing
+    // and verified that it contains a compatible version.
+    Ok(unsafe { &**api })
+}
+
+struct GlobalApiPtr(GILOnceCell<*const GlobalApi>);
+
+unsafe impl Send for GlobalApiPtr {}
+
+unsafe impl Sync for GlobalApiPtr {}
+
+static GLOBAL_API: GlobalApiPtr = GlobalApiPtr(GILOnceCell::new());
+
+#[cold]
+fn init_global_api(py: Python<'_>) -> PyResult<*const GlobalApi> {
+    let module = match PyModule::import(py, "pyo3") {
+        Ok(module) => module,
+        Err(_err) => {
+            let module = PyModule::new(py, "pyo3")?;
+
+            module.add(
+                "PanicException",
+                crate::panic::PanicException::type_object(py),
+            )?;
+
+            let sys = PyModule::import(py, "sys")?;
+            let modules: &PyDict = sys.getattr("modules")?.downcast()?;
+            modules.set_item("pyo3", module)?;
+
+            module
+        }
+    };
+
+    let capsule: &PyCapsule = match module.getattr("_GLOBAL_API") {
+        Ok(capsule) => PyTryInto::try_into(capsule)?,
+        Err(_err) => {
+            let api = GlobalApi {
+                version: 1,
+                create_panic_exception: crate::panic::create_panic_exception,
+            };
+
+            let capsule = PyCapsule::new(py, api, Some(CString::new("_GLOBAL_API").unwrap()))?;
+            module.setattr("_GLOBAL_API", capsule)?;
+            capsule
+        }
+    };
+
+    // SAFETY: All versions of the global API start with a version field.
+    let version = unsafe { *(capsule.pointer() as *mut u64) };
+    if version < 1 {
+        return Err(PyTypeError::new_err(format!(
+            "Version {} of global API is not supported by this version of PyO3",
+            version
+        )));
+    }
+
+    // Intentionally leak a reference to the capsule so we can safely cache a pointer into its interior.
+    forget(Py::<PyCapsule>::from(capsule));
+
+    Ok(capsule.pointer() as *const GlobalApi)
+}

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -220,7 +220,7 @@ where
     let py_err = match panic_result {
         Ok(Ok(value)) => return value,
         Ok(Err(py_err)) => py_err,
-        Err(payload) => PanicException::from_panic_payload(payload),
+        Err(payload) => PanicException::from_panic_payload(py, payload),
     };
     py_err.restore(py);
     R::ERR_VALUE
@@ -245,7 +245,7 @@ where
     let pool = GILPool::new();
     let py = pool.python();
     if let Err(py_err) = panic::catch_unwind(move || body(py))
-        .unwrap_or_else(|payload| Err(PanicException::from_panic_payload(payload)))
+        .unwrap_or_else(|payload| Err(PanicException::from_panic_payload(py, payload)))
     {
         py_err.write_unraisable(py, py.from_borrowed_ptr_or_opt(ctx));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,6 +410,7 @@ pub mod marker;
 pub mod marshal;
 #[macro_use]
 pub mod sync;
+mod global_api;
 pub mod panic;
 pub mod prelude;
 pub mod pycell;


### PR DESCRIPTION
This does not work (meaning build) due to multiple issues but I wanted to propose something concrete here so we can discuss whether this roundabout way is something we would want to pursue.

As this it is proposed, this should mean that the first extension built using PyO3 that calls `ensure_global_api` creates the module containing its `PanicException` type object and the corresponding capsule API. All other PyO3-based extensions would then use this capsule to create panic exceptions based on the same internals as first one.

Downstream code should then be able to `import pyo3.PanicException` to catch all panic exceptions raised by an PyO3-based extension. (At least if it is new enough to use the capsule API.)