### PR TITLE
ci: use codecov coverage format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,7 @@ jobs:
       - uses: codecov/codecov-action@v3
         if: steps.should-skip.outputs.skip != 'true'
         with:
-          file: coverage.lcov
+          file: coverage.json
           name: ${{ matrix.os }}
 
   emscripten:

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,9 +62,9 @@ def coverage(session: nox.Session) -> None:
         "--package=pyo3-macros",
         "--package=pyo3-ffi",
         "report",
-        "--lcov",
+        "--codecov",
         "--output-path",
-        "coverage.lcov",
+        "coverage.json",
         external=True,
     )
 


### PR DESCRIPTION
Newly supported on `cargo-llvm-cov` 0.5.12, might give some more detailed information.