### PR TITLE
Update getting_started.md

### DIFF
--- a/guide/src/getting_started.md
+++ b/guide/src/getting_started.md
@@ -43,7 +43,7 @@ pip install maturin
 
 poetry:
 ```bash
-poetry add -D maturin
+poetry add -G dev maturin
 ```
 
 After installation, you can run `maturin --version` to check that you have correctly installed it.


### PR DESCRIPTION
Update Poetry command to Poetry groups syntax (1.2+).
https://python-poetry.org/docs/cli/#options-4:
> `--dev (-D`): Add package as development dependency. (**Deprecated**, use `-G dev` instead)