### PR TITLE
Fix a crate doc link for IterNextOutput

### DIFF
--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -409,6 +409,6 @@ impl ClassWithGCSupport {
 
 > Note: these methods are part of the C API, PyPy does not necessarily honor them. If you are building for PyPy you should measure memory consumption to make sure you do not have runaway memory growth. See [this issue on the PyPy bug tracker](https://foss.heptapod.net/pypy/pypy/-/issues/3899).
 
-[`IterNextOutput`]: {{#PYO3_DOCS_URL}}/pyo3/class/iter/enum.IterNextOutput.html
+[`IterNextOutput`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/enum.IterNextOutput.html
 [`PySequence`]: {{#PYO3_DOCS_URL}}/pyo3/types/struct.PySequence.html
 [`CompareOp::matches`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/enum.CompareOp.html#method.matches

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -90,7 +90,7 @@ impl CompareOp {
 /// Output of `__next__` which can either `yield` the next value in the iteration, or
 /// `return` a value to raise `StopIteration` in Python.
 ///
-/// See [`PyIterProtocol`](trait.PyIterProtocol.html) for an example.
+/// See [this test](https://github.com/PyO3/pyo3/blob/main/pytests/src/pyclasses.rs#L15-L36) for an example.
 pub enum IterNextOutput<T, U> {
     /// The value yielded by the iterator.
     Yield(T),

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -100,14 +100,14 @@ impl CompareOp {
 /// struct PyClassIter {
 ///     count: usize,
 /// }
-/// 
+///
 /// #[pymethods]
 /// impl PyClassIter {
 ///     #[new]
 ///     pub fn new() -> Self {
 ///         PyClassIter { count: 0 }
 ///     }
-/// 
+///
 ///     fn __next__(&mut self) -> IterNextOutput<usize, &'static str> {
 ///         if self.count < 5 {
 ///             self.count += 1;
@@ -116,7 +116,7 @@ impl CompareOp {
 ///         } else {
 ///             // At the sixth time, we get a `StopIteration` with `'Ended'`.
 ///             //     try:
-///             //         next(couter)
+///             //         next(counter)
 ///             //     except StopIteration as e:
 ///             //         assert e.value == 'Ended'
 ///             IterNextOutput::Return("Ended")
@@ -124,8 +124,6 @@ impl CompareOp {
 ///     }
 /// }
 /// ```
-///
-/// The example above is copied from [this test](https://github.com/PyO3/pyo3/blob/main/pytests/src/pyclasses.rs#L15-L36).
 pub enum IterNextOutput<T, U> {
     /// The value yielded by the iterator.
     Yield(T),

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -90,7 +90,42 @@ impl CompareOp {
 /// Output of `__next__` which can either `yield` the next value in the iteration, or
 /// `return` a value to raise `StopIteration` in Python.
 ///
-/// See [this test](https://github.com/PyO3/pyo3/blob/main/pytests/src/pyclasses.rs#L15-L36) for an example.
+/// Usage example:
+///
+/// ```rust
+/// use pyo3::prelude::*;
+/// use pyo3::iter::IterNextOutput;
+///
+/// #[pyclass]
+/// struct PyClassIter {
+///     count: usize,
+/// }
+/// 
+/// #[pymethods]
+/// impl PyClassIter {
+///     #[new]
+///     pub fn new() -> Self {
+///         PyClassIter { count: 0 }
+///     }
+/// 
+///     fn __next__(&mut self) -> IterNextOutput<usize, &'static str> {
+///         if self.count < 5 {
+///             self.count += 1;
+///             // Given an instance `counter`, First five `next(counter)` calls yield 1, 2, 3, 4, 5.
+///             IterNextOutput::Yield(self.count)
+///         } else {
+///             // At the sixth time, we get a `StopIteration` with `'Ended'`.
+///             //     try:
+///             //         next(couter)
+///             //     except StopIteration as e:
+///             //         assert e.value == 'Ended'
+///             IterNextOutput::Return("Ended")
+///         }
+///     }
+/// }
+/// ```
+///
+/// The example above is copied from [this test](https://github.com/PyO3/pyo3/blob/main/pytests/src/pyclasses.rs#L15-L36).
 pub enum IterNextOutput<T, U> {
     /// The value yielded by the iterator.
     Yield(T),


### PR DESCRIPTION
This should fix the links [1](https://docs.rs/pyo3/0.18.3/pyo3/pyclass/enum.IterNextOutput.html#:~:text=See%20PyIterProtocol%20for%20an%20example.) and [2](https://pyo3.rs/v0.18.3/class/protocols#:~:text=PyO3%20provides%20the-,IterNextOutput,-enum%20to%20both).

They originally point to, which do not exist now:
1. https://docs.rs/pyo3/0.18.3/pyo3/pyclass/trait.PyIterProtocol.html
2. https://docs.rs/pyo3/0.18.3/pyo3/class/iter/enum.IterNextOutput.html