### PR TITLE
Add BaseExceptionGroup for Python >= 3.11

### DIFF
--- a/newsfragments/3141.added.md
+++ b/newsfragments/3141.added.md
@@ -1,0 +1,1 @@
+Add FFI definition for `BaseExceptionGroup`, which was added in Python 3.11 by [PEP 0654](https://peps.python.org/pep-0654/).

--- a/pyo3-ffi/src/pyerrors.rs
+++ b/pyo3-ffi/src/pyerrors.rs
@@ -103,6 +103,8 @@ pub unsafe fn PyUnicodeDecodeError_Create(
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyExc_BaseException")]
     pub static mut PyExc_BaseException: *mut PyObject;
+    #[cfg(Py_3_11)]
+    pub static mut PyExc_BaseExceptionGroup: *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyExc_Exception")]
     pub static mut PyExc_Exception: *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyExc_StopAsyncIteration")]

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -493,7 +493,7 @@ impl_native_exception!(
     PyExc_UnicodeError,
     native_doc!("UnicodeError")
 );
-// these three errors need arguments, so they're too annoying to write tests for using macros...
+// these four errors need arguments, so they're too annoying to write tests for using macros...
 impl_native_exception!(
     PyUnicodeDecodeError,
     PyExc_UnicodeDecodeError,
@@ -508,6 +508,12 @@ impl_native_exception!(
     PyUnicodeTranslateError,
     PyExc_UnicodeTranslateError,
     native_doc!("UnicodeTranslateError", "")
+);
+#[cfg(Py_3_11)]
+impl_native_exception!(
+    PyBaseExceptionGroup,
+    PyExc_BaseExceptionGroup,
+    native_doc!("BaseExceptionGroup", "")
 );
 impl_native_exception!(PyValueError, PyExc_ValueError, native_doc!("ValueError"));
 impl_native_exception!(
@@ -1028,7 +1034,10 @@ mod tests {
             );
         });
     }
-
+    #[cfg(Py_3_11)]
+    test_exception!(PyBaseExceptionGroup, |_| {
+        PyBaseExceptionGroup::new_err(("msg", vec![PyValueError::new_err("err")]))
+    });
     test_exception!(PyBaseException);
     test_exception!(PyException);
     test_exception!(PyStopAsyncIteration);


### PR DESCRIPTION
Not sure if this is totally off base, but it looks like it may be this easy to add support for ExceptionGroup?