### PR TITLE
Enable rust-cache on clippy CI jobs as we do for build CI jobs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           architecture: ${{ matrix.platform.python-architecture }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: clippy-${{ matrix.platform.rust-target }}-${{ matrix.os }}-${{ matrix.rust }}
+        continue-on-error: true
       - run: python -m pip install --upgrade pip && pip install nox
       - if: matrix.msrv == 'MSRV'
         name: Prepare minimal package versions (MSRV only)


### PR DESCRIPTION
Not sure if there was a reason we did not enable this for the Clippy jobs?