### PR TITLE
Fix Clippy CI job cache to really include the platform.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           architecture: ${{ matrix.platform.python-architecture }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: clippy-${{ matrix.platform.rust-target }}-${{ matrix.os }}-${{ matrix.rust }}
+          key: clippy-${{ matrix.platform.rust-target }}-${{ matrix.platform.os }}-${{ matrix.rust }}
         continue-on-error: true
       - run: python -m pip install --upgrade pip && pip install nox
       - if: matrix.msrv == 'MSRV'


### PR DESCRIPTION
Doesn't really matter since we never build the same target on different platforms, but fixing it will prevent future confusion when reading it. Sorry for the extra lap. 😫