### PR TITLE
Add `PyFrozenSetBuilder`

### DIFF
--- a/newsfragments/3156.added.md
+++ b/newsfragments/3156.added.md
@@ -1,0 +1,1 @@
+Add `pyo3::types::PyFrozenSetBuilder` to allow building a `PyFrozenSet` item by item.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -19,7 +19,7 @@ pub use self::dict::{PyDictItems, PyDictKeys, PyDictValues};
 pub use self::floatob::PyFloat;
 #[cfg(all(not(Py_LIMITED_API), not(PyPy)))]
 pub use self::frame::PyFrame;
-pub use self::frozenset::PyFrozenSet;
+pub use self::frozenset::{PyFrozenSet, PyFrozenSetBuilder};
 pub use self::function::PyCFunction;
 #[cfg(all(not(Py_LIMITED_API), not(PyPy)))]
 pub use self::function::PyFunction;


### PR DESCRIPTION
These are actually available via the C ABI. Since the distinction between set and frozenset means nothing to Rust safety, we should make these available