### PR TITLE
Add Py::get for GIL-independent access to frozen classes.

### DIFF
--- a/guide/pyclass_parameters.md
+++ b/guide/pyclass_parameters.md
@@ -6,7 +6,7 @@
 | `dict` | Gives instances of this class an empty `__dict__` to store custom attributes. |
 | <span style="white-space: pre">`extends = BaseType`</span>  | Use a custom baseclass. Defaults to [`PyAny`][params-1] |
 | <span style="white-space: pre">`freelist = N`</span> |  Implements a [free list][params-2] of size N. This can improve performance for types that are often created and deleted in quick succession. Profile your code to see whether `freelist` is right for you.  |
-| <span style="white-space: pre">`frozen`</span> | Declares that your pyclass is immutable. It removes the borrowchecker overhead when retrieving a shared reference to the Rust struct, but disables the ability to get a mutable reference. |
+| <span style="white-space: pre">`frozen`</span> | Declares that your pyclass is immutable. It removes the borrow checker overhead when retrieving a shared reference to the Rust struct, but disables the ability to get a mutable reference. |
 | `get_all` | Generates getters for all fields of the pyclass. |
 | `mapping` |  Inform PyO3 that this class is a [`Mapping`][params-mapping], and so leave its implementation of sequence C-API slots empty. |
 | <span style="white-space: pre">`module = "module_name"`</span> |  Python code will see the class as being defined in this module. Defaults to `builtins`. |

--- a/newsfragments/3158.added.md
+++ b/newsfragments/3158.added.md
@@ -1,0 +1,1 @@
+Add `PyClass::get` and `Py::get` for GIL-indepedent access to internally synchronized frozen classes.

--- a/tests/ui/invalid_frozen_pyclass_borrow.rs
+++ b/tests/ui/invalid_frozen_pyclass_borrow.rs
@@ -6,7 +6,7 @@ pub struct Foo {
     field: u32,
 }
 
-fn borrow_mut_fails(foo: Py<Foo>, py: Python){
+fn borrow_mut_fails(foo: Py<Foo>, py: Python) {
     let borrow = foo.as_ref(py).borrow_mut();
 }
 
@@ -16,8 +16,16 @@ struct MutableBase;
 #[pyclass(frozen, extends = MutableBase)]
 struct ImmutableChild;
 
-fn borrow_mut_of_child_fails(child: Py<ImmutableChild>, py: Python){
+fn borrow_mut_of_child_fails(child: Py<ImmutableChild>, py: Python) {
     let borrow = child.as_ref(py).borrow_mut();
 }
 
-fn main(){}
+fn py_get_of_mutable_class_fails(class: Py<MutableBase>) {
+    class.get();
+}
+
+fn pyclass_get_of_mutable_class_fails(class: &PyCell<MutableBase>) {
+    class.get();
+}
+
+fn main() {}

--- a/tests/ui/invalid_frozen_pyclass_borrow.stderr
+++ b/tests/ui/invalid_frozen_pyclass_borrow.stderr
@@ -4,7 +4,7 @@ error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`
 10 |     let borrow = foo.as_ref(py).borrow_mut();
    |                                 ^^^^^^^^^^ expected `False`, found `True`
    |
-note: required by a bound in `PyCell::<T>::borrow_mut`
+note: required by a bound in `pyo3::PyCell::<T>::borrow_mut`
   --> src/pycell.rs
    |
    |         T: PyClass<Frozen = False>,
@@ -16,8 +16,32 @@ error[E0271]: type mismatch resolving `<ImmutableChild as PyClass>::Frozen == Fa
 20 |     let borrow = child.as_ref(py).borrow_mut();
    |                                   ^^^^^^^^^^ expected `False`, found `True`
    |
-note: required by a bound in `PyCell::<T>::borrow_mut`
+note: required by a bound in `pyo3::PyCell::<T>::borrow_mut`
   --> src/pycell.rs
    |
    |         T: PyClass<Frozen = False>,
    |                    ^^^^^^^^^^^^^^ required by this bound in `PyCell::<T>::borrow_mut`
+
+error[E0271]: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
+  --> tests/ui/invalid_frozen_pyclass_borrow.rs:24:11
+   |
+24 |     class.get();
+   |           ^^^ expected `True`, found `False`
+   |
+note: required by a bound in `pyo3::Py::<T>::get`
+  --> src/instance.rs
+   |
+   |         T: PyClass<Frozen = True> + Sync,
+   |                    ^^^^^^^^^^^^^ required by this bound in `Py::<T>::get`
+
+error[E0271]: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
+  --> tests/ui/invalid_frozen_pyclass_borrow.rs:28:11
+   |
+28 |     class.get();
+   |           ^^^ expected `True`, found `False`
+   |
+note: required by a bound in `pyo3::PyCell::<T>::get`
+  --> src/pycell.rs
+   |
+   |         T: PyClass<Frozen = True> + Sync,
+   |                    ^^^^^^^^^^^^^ required by this bound in `PyCell::<T>::get`


### PR DESCRIPTION
@davidhewitt Is this what you had in mind for #3154?

The name is an obvious candidate for bikeshedding.

Trying to write an example, I noticed that making `PyCell::get_frozen` public is most likely not useful as there is no way to safely get a `&PyCell` without acquiring the GIL first?