### PR TITLE
RFC: Drop EnsureGIL to remove one layer of indirection from the implementation of Python::with_gil

### DIFF
--- a/tests/ui/not_send.stderr
+++ b/tests/ui/not_send.stderr
@@ -9,8 +9,8 @@ error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safe
   = help: within `pyo3::Python<'_>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
   = note: required because it appears within the type `PhantomData<*mut Python<'static>>`
   = note: required because it appears within the type `NotSend`
-  = note: required because it appears within the type `(&EnsureGIL, NotSend)`
-  = note: required because it appears within the type `PhantomData<(&EnsureGIL, NotSend)>`
+  = note: required because it appears within the type `(&GILGuard, NotSend)`
+  = note: required because it appears within the type `PhantomData<(&GILGuard, NotSend)>`
   = note: required because it appears within the type `Python<'_>`
   = note: required for `&pyo3::Python<'_>` to implement `Send`
 note: required because it's used within this closure


### PR DESCRIPTION
I am not sure if other people would consider this a simplification as well, but it helped me to remove one layer of indirection used by the implementation of `Python::with_gil`, especially flattening the `Option<_>` layers in `EnsureGIL` and `GILGuard::pool`. This makes it obvious that we always create `GILPool` when we actually acquire the GIL. (Of course, there still might be extra `GILPool` instances created manually.)