### PR TITLE
RFC: Add Python::with_pool as a safe alternative to GILPool usage.

### DIFF
--- a/guide/src/memory.md
+++ b/guide/src/memory.md
@@ -95,10 +95,11 @@ this is unsafe.
 # fn main() -> PyResult<()> {
 Python::with_gil(|py| -> PyResult<()> {
     for _ in 0..10 {
-        let pool = unsafe { py.new_pool() };
-        let py = pool.python();
-        let hello: &PyString = py.eval("\"Hello World!\"", None, None)?.extract()?;
-        println!("Python says: {}", hello);
+        py.with_pool(|py| {
+            let hello: &PyString = py.eval("\"Hello World!\"", None, None)?.extract()?;
+            println!("Python says: {}", hello);
+            Ok::<_, PyErr>(())
+        })?;
     }
     Ok(())
 })?;

--- a/newsfragments/3167.added.md
+++ b/newsfragments/3167.added.md
@@ -1,0 +1,1 @@
+Add `Python::with_pool` as a safe alternative to `Python::new_pool`

--- a/newsfragments/3167.changed.md
+++ b/newsfragments/3167.changed.md
@@ -1,0 +1,1 @@
+Deprecate `Python::new_pool` as the safe alternative `Python::with_pool` was added.

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -38,4 +38,5 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/not_send2.rs");
     t.compile_fail("tests/ui/get_set_all.rs");
     t.compile_fail("tests/ui/traverse_bare_self.rs");
+    t.compile_fail("tests/ui/with_pool.rs");
 }

--- a/tests/ui/with_pool.rs
+++ b/tests/ui/with_pool.rs
@@ -1,0 +1,11 @@
+use pyo3::prelude::*;
+
+fn reuse_old_token_in_with_pool(old_py: Python<'_>) {
+    old_py.with_pool(|new_py| { drop(old_py); });
+}
+
+fn main() {
+    Python::with_gil(|py| {
+        reuse_old_token_in_with_pool(py);
+    })
+}

--- a/tests/ui/with_pool.stderr
+++ b/tests/ui/with_pool.stderr
@@ -1,0 +1,26 @@
+error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safely
+ --> tests/ui/with_pool.rs:4:22
+  |
+4 |     old_py.with_pool(|new_py| { drop(old_py); });
+  |            --------- ^^^^^^^^^^^^^^^^^^^^^^^^^^ `*mut pyo3::Python<'static>` cannot be shared between threads safely
+  |            |
+  |            required by a bound introduced by this call
+  |
+  = help: within `pyo3::Python<'_>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
+  = note: required because it appears within the type `PhantomData<*mut Python<'static>>`
+  = note: required because it appears within the type `NotSend`
+  = note: required because it appears within the type `(&EnsureGIL, NotSend)`
+  = note: required because it appears within the type `PhantomData<(&EnsureGIL, NotSend)>`
+  = note: required because it appears within the type `Python<'_>`
+  = note: required for `&pyo3::Python<'_>` to implement `Send`
+note: required because it's used within this closure
+ --> tests/ui/with_pool.rs:4:22
+  |
+4 |     old_py.with_pool(|new_py| { drop(old_py); });
+  |                      ^^^^^^^^
+  = note: required for `[closure@$DIR/tests/ui/with_pool.rs:4:22: 4:30]` to implement `Ungil`
+note: required by a bound in `pyo3::Python::<'_>::with_pool`
+ --> src/marker.rs
+  |
+  |         F: for<'py> FnOnce(Python<'py>) -> R + Ungil,
+  |                                                ^^^^^ required by this bound in `Python::<'_>::with_pool`


### PR DESCRIPTION
The `Ungil` bound is required to prevent the closure from reusing the outer GIL token via captures which does give this a limited applicability compared to direct usage of `GILPool`, but nevertheless I think it should be safe.

Obviously only draft as this would require a deprecation cycle and an extensive update of the documentation.