### PR TITLE
Require Send in addition to Sync on Py::get and PyCell::get

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -211,11 +211,11 @@ Python::with_gil(|py| {
 });
 ```
 
-### frozen classes: Opting out of interior mutability
+### Frozen classes: Opting out of interior mutability
 
 As detailed above, runtime borrow checking is currently enabled by default. But a class can opt of out it by declaring itself `frozen`. It can still use interior mutability via standard Rust types like `RefCell` or `Mutex`, but it is not bound to the implementation provided by PyO3 and can choose the most appropriate strategy on field-by-field basis.
 
-Classes which are `frozen` and also `Sync`, e.g. they do use `Mutex` but not `RefCell`, can be accessed without needing the Python GIL via the `PyCell::get` and `Py::get` methods:
+Classes which are `frozen` and also `Send` and `Sync`, e.g. they do use `Mutex` but not `RefCell`, can be accessed without needing the Python GIL via the `PyCell::get` and `Py::get` methods:
 
 ```rust
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -474,7 +474,7 @@ where
 
     /// Provide an immutable borrow of the value `T` without acquiring the GIL.
     ///
-    /// This is available if the class is [`frozen`][macro@crate::pyclass] and [`Sync`].
+    /// This is available if the class is [`frozen`][macro@crate::pyclass], [`Send`] and [`Sync`].
     ///
     /// # Examples
     ///
@@ -497,10 +497,10 @@ where
     /// ```
     pub fn get(&self) -> &T
     where
-        T: PyClass<Frozen = True> + Sync,
+        T: PyClass<Frozen = True> + Send + Sync,
     {
         let any = self.as_ptr() as *const PyAny;
-        // SAFETY: The class itself is frozen and `Sync` and we do not access anything but `cell.contents.value`.
+        // SAFETY: The class itself is frozen, `Send` and `Sync` and we do not access anything but `cell.contents.value`.
         unsafe {
             let cell: &PyCell<T> = PyNativeType::unchecked_downcast(&*any);
             &*cell.get_ptr()

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -419,7 +419,7 @@ impl<T: PyClass> PyCell<T> {
 
     /// Provide an immutable borrow of the value `T` without acquiring the GIL.
     ///
-    /// This is available if the class is [`frozen`][macro@crate::pyclass] and [`Sync`].
+    /// This is available if the class is [`frozen`][macro@crate::pyclass], [`Send`] and [`Sync`].
     ///
     /// While the GIL is usually required to get access to `&PyCell<T>`,
     /// compared to [`borrow`][Self::borrow] or [`try_borrow`][Self::try_borrow]
@@ -446,9 +446,9 @@ impl<T: PyClass> PyCell<T> {
     /// ```
     pub fn get(&self) -> &T
     where
-        T: PyClass<Frozen = True> + Sync,
+        T: PyClass<Frozen = True> + Send + Sync,
     {
-        // SAFETY: The class itself is frozen and `Sync` and we do not access anything but `self.contents.value`.
+        // SAFETY: The class itself is frozen, `Send` and `Sync` and we do not access anything but `self.contents.value`.
         unsafe { &*self.get_ptr() }
     }
 

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -117,6 +117,7 @@ fn _test_compile_errors() {
         t.compile_fail("tests/ui/not_send.rs");
         t.compile_fail("tests/ui/not_send2.rs");
         t.compile_fail("tests/ui/not_send3.rs");
+        t.compile_fail("tests/ui/not_send_get.rs");
         t.compile_fail("tests/ui/get_set_all.rs");
     }
 

--- a/tests/ui/invalid_frozen_pyclass_borrow.stderr
+++ b/tests/ui/invalid_frozen_pyclass_borrow.stderr
@@ -31,7 +31,7 @@ error[E0271]: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
 note: required by a bound in `pyo3::Py::<T>::get`
   --> src/instance.rs
    |
-   |         T: PyClass<Frozen = True> + Sync,
+   |         T: PyClass<Frozen = True> + Send + Sync,
    |                    ^^^^^^^^^^^^^ required by this bound in `Py::<T>::get`
 
 error[E0271]: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
@@ -43,5 +43,5 @@ error[E0271]: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
 note: required by a bound in `pyo3::PyCell::<T>::get`
   --> src/pycell.rs
    |
-   |         T: PyClass<Frozen = True> + Sync,
+   |         T: PyClass<Frozen = True> + Send + Sync,
    |                    ^^^^^^^^^^^^^ required by this bound in `PyCell::<T>::get`

--- a/tests/ui/not_send_get.rs
+++ b/tests/ui/not_send_get.rs
@@ -1,0 +1,36 @@
+use pyo3::prelude::*;
+
+#[pyclass(frozen, unsendable)]
+struct ClassThatIsSyncButNotSend {
+    ptr: *mut (),
+}
+
+unsafe impl Sync for ClassThatIsSyncButNotSend {}
+
+fn test_py_get_class_that_is_not_send_on_different_thread() {
+    let class = Python::with_gil(|py| {
+        Py::new(py, ClassThatIsSyncButNotSend { ptr: &mut () }).unwrap()
+    });
+
+    std::thread::spawn(move || {
+        let _ptr = class.get().ptr;
+    });
+}
+
+
+fn test_pycell_get_class_that_is_not_send_on_different_thread() {
+    let class = Python::with_gil(|py| {
+        Py::new(py, ClassThatIsSyncButNotSend { ptr: &mut () }).unwrap()
+    });
+
+    std::thread::spawn(move || {
+        Python::with_gil(|py| {
+            let _ptr = class.as_ref(py).get().ptr;
+        });
+    });
+}
+
+fn main() {
+    test_py_get_class_that_is_not_send_on_different_thread();
+    test_pycell_get_class_that_is_not_send_on_different_thread();
+}

--- a/tests/ui/not_send_get.stderr
+++ b/tests/ui/not_send_get.stderr
@@ -1,0 +1,35 @@
+error[E0277]: `*mut ()` cannot be sent between threads safely
+  --> tests/ui/not_send_get.rs:16:26
+   |
+16 |         let _ptr = class.get().ptr;
+   |                          ^^^ `*mut ()` cannot be sent between threads safely
+   |
+   = help: within `ClassThatIsSyncButNotSend`, the trait `Send` is not implemented for `*mut ()`
+note: required because it appears within the type `ClassThatIsSyncButNotSend`
+  --> tests/ui/not_send_get.rs:4:8
+   |
+4  | struct ClassThatIsSyncButNotSend {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `pyo3::Py::<T>::get`
+  --> src/instance.rs
+   |
+   |         T: PyClass<Frozen = True> + Send + Sync,
+   |                                     ^^^^ required by this bound in `Py::<T>::get`
+
+error[E0277]: `*mut ()` cannot be sent between threads safely
+  --> tests/ui/not_send_get.rs:28:41
+   |
+28 |             let _ptr = class.as_ref(py).get().ptr;
+   |                                         ^^^ `*mut ()` cannot be sent between threads safely
+   |
+   = help: within `ClassThatIsSyncButNotSend`, the trait `Send` is not implemented for `*mut ()`
+note: required because it appears within the type `ClassThatIsSyncButNotSend`
+  --> tests/ui/not_send_get.rs:4:8
+   |
+4  | struct ClassThatIsSyncButNotSend {
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `PyCell::<T>::get`
+  --> src/pycell.rs
+   |
+   |         T: PyClass<Frozen = True> + Send + Sync,
+   |                                     ^^^^ required by this bound in `PyCell::<T>::get`


### PR DESCRIPTION
While the unsendable parameter and the thread checker help us detect accesses to unsendable types at runtime, they do not prevent sending such types to other threads in the first place where `Py::get` and `PyCell::get` provide direct access without checking thread affinity.

So we could either call the thread checker for both methods or we add the additional Send bound. I opted for the latter to keep the zero overhead approach of the methods intact.