### PR TITLE
Fix a bad span of `_slf` for custom receivers in `#[pymethods]`.

### DIFF
--- a/newsfragments/3178.fixed.md
+++ b/newsfragments/3178.fixed.md
@@ -1,0 +1,1 @@
+Fix a compile error when `#[pymethods]` items come from somewhere else (for example, as a macro argument) and a custom receiver like `Py<Self>` is used.

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -189,10 +189,11 @@ impl SelfType {
                 }
             }
             SelfType::TryFromPyCell(span) => {
+                let _slf = quote! { _slf };
                 quote_spanned! { *span =>
                     let _cell = #cell;
                     #[allow(clippy::useless_conversion)]  // In case _slf is PyCell<Self>
-                    let _slf = ::std::convert::TryFrom::try_from(_cell)?;
+                    let #_slf = ::std::convert::TryFrom::try_from(_cell)?;
                 }
             }
         }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -1470,6 +1470,33 @@ issue_1506!(
         ) {
         }
 
+        fn issue_1506_mut(
+            &mut self,
+            _py: Python<'_>,
+            _arg: &PyAny,
+            _args: &PyTuple,
+            _kwargs: Option<&PyDict>,
+        ) {
+        }
+
+        fn issue_1506_custom_receiver(
+            _slf: Py<Self>,
+            _py: Python<'_>,
+            _arg: &PyAny,
+            _args: &PyTuple,
+            _kwargs: Option<&PyDict>,
+        ) {
+        }
+
+        fn issue_1506_custom_receiver_explicit(
+            _slf: Py<Issue1506>,
+            _py: Python<'_>,
+            _arg: &PyAny,
+            _args: &PyTuple,
+            _kwargs: Option<&PyDict>,
+        ) {
+        }
+
         #[new]
         fn issue_1506_new(
             _py: Python<'_>,


### PR DESCRIPTION
This turned out to be a remnant of #1506. It notably resulted in a very confusing error:

```
error[E0308]: mismatched types
    --> tests\test_methods.rs:1456:9
     |
1456 |           #[pymethods]
     |           ^^^^^^^^^^^^
     |           |
     |           expected `Py<Issue1506>`, found `*mut PyObject`
     |           arguments to this function are incorrect
...
1461 | / issue_1506!(
1462 | |     #[pymethods]
1463 | |     impl Issue1506 {
1464 | |         fn issue_1506(
...    |
1536 | |     }
1537 | | );
     | |_- in this macro invocation
     |
     = note:   expected struct `pyo3::Py<Issue1506>`
             found raw pointer `*mut pyo3::ffi::PyObject`
```

The actual cause is that `SelfType::receiver` is entirely ignored in this case and `_slf` refers to the original argument, but it sounds like that `TryFrom::try_from` somehow resulted in `*mut PyObject`...