### PR TITLE
Fix `abi3` conversion of `__complex__` classes

### DIFF
--- a/newsfragments/3185.fixed.md
+++ b/newsfragments/3185.fixed.md
@@ -1,0 +1,1 @@
+Fix conversion of classes implementing `__complex__` to `Complex` when using `abi3` or PyPy.


### PR DESCRIPTION
Python classes that were not `complex` but implemented the `__complex__` magic would have that method called via `PyComplex_AsCComplex` when running against the full API, but the limited-API version `PyComplex_RealAsDouble` does not attempt this conversion.  If the input object is not already complex, we can call the magic before proceeding.

Happy to modify if I've made a mess of testing strategy - I'm not sure I've managed to do it in the same style as other tests.

Fix #3164.
