### PR TITLE
RFC: automatically implement equality and ordering using Eq and Ord

### DIFF
--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1049,6 +1049,12 @@ impl<'a> PyClassImplsBuilder<'a> {
                     static TYPE_OBJECT: LazyTypeObject<#cls> = LazyTypeObject::new();
                     &TYPE_OBJECT
                 }
+
+                fn default_tp_richcompare() -> ::std::option::Option<_pyo3::ffi::richcmpfunc> {
+                    use _pyo3::impl_::pyclass::*;
+                    let collector = EqOrdCollector::<Self>::new();
+                    collector.default_tp_richcompare()
+                }
             }
 
             #[doc(hidden)]


### PR DESCRIPTION
I had a sudden insight today that we can automatically generate implementations of equality and ordering based on the presence of `Eq` and `Ord` implementations for `#[pyclass]`. (Note that `Ord: Eq`.) The implementation selects for these traits using autoderef specialization.

I think this could be very convenient, but it has the potential to be breaking because existing types will suddenly have new behaviour in Python. If we went with this automatic implementation, we could land it in 0.20 with appropriate documentation.

I think at the very least we should have `#[pyclass(eq = false)]` and `#[pyclass(order = false)]` opt-outs (names matching the same functionality in Python `@dataclass`, although note the defaults here are not `True` and `False` respectively but instead based on whether `T` implements `Eq` or `Ord`).

Design discussions:
- Alternative would be to always default to `false`, and require `eq = true` (and `order = true`) to opt-in to adding these implementations. This would be non-breaking but I think is not as nice for future usage.
  - Maybe we can use this as an opt-in over a deprecation period?
- What to do with interactions around subclasses and extensions? I am certain the default implementations I have currently written do the wrong thing for `#[pyclass(extends = ...)]` and also if `T` is subclassed.
- Also there may be an interaction between this and the implementation for #2089. Maybe it's better to land that first?
