### PR TITLE
update PR template to detail state of licensing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,8 @@
-Thank you for contributing to pyo3!
+Thank you for contributing to PyO3!
+
+By submitting these contributions you agree for them to be licensed under PyO3's [Apache-2.0 license](https://github.com/PyO3/pyo3#license).
+
+PyO3 is currently undergoing a relicensing process to match Rust's dual-license under `Apache-2.0` and `MIT` licenses. While that process is ongoing, if you are a first-time contributor please add your agreement as a comment in [#3108](https://github.com/PyO3/pyo3/pull/3108).
 
 Please consider adding the following to your pull request:
  - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]

--- a/README.md
+++ b/README.md
@@ -244,7 +244,8 @@ If you don't have time to contribute yourself but still wish to support the proj
 
 ## License
 
-PyO3 is licensed under the [Apache-2.0 license](https://opensource.org/licenses/APACHE-2.0).
+PyO3 is licensed under the [Apache-2.0 license](https://opensource.org/licenses/APACHE-2.0). (The PyO3 project is in the process of collecting permission from past contributors to additionally license under the [MIT license](https://opensource.org/license/mit/), see [#3108](https://github.com/PyO3/pyo3/pull/3108). Once complete, PyO3 will additionally be licensed under the MIT license, the same as the Rust language itself is both Apache and MIT licensed.)
+
 Python is licensed under the [Python License](https://docs.python.org/3/license.html).
 
 <a href="https://www.netlify.com"> <img src="https://www.netlify.com/v3/img/components/netlify-color-accent.svg" alt="Deploys by Netlify" /> </a>


### PR DESCRIPTION
Adds detail about #3108 to the README and the PR template.

@DataTriny - I thought that adding this would help encourage new contributors to be aware of the licensing terms and also that they would need to explicitly accept the future license.