### PR TITLE
RFC: add error handling to IterOutput types

### DIFF
--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -774,12 +774,12 @@ const __GET__: SlotDef = SlotDef::new("Py_tp_descr_get", "descrgetfunc")
     .arguments(&[Ty::MaybeNullObject, Ty::MaybeNullObject]);
 const __ITER__: SlotDef = SlotDef::new("Py_tp_iter", "getiterfunc");
 const __NEXT__: SlotDef = SlotDef::new("Py_tp_iternext", "iternextfunc").return_conversion(
-    TokenGenerator(|| quote! { _pyo3::class::iter::IterNextOutput::<_, _> }),
+    TokenGenerator(|| quote! { _pyo3::class::iter::IterNextOutput::<_, _, _> }),
 );
 const __AWAIT__: SlotDef = SlotDef::new("Py_am_await", "unaryfunc");
 const __AITER__: SlotDef = SlotDef::new("Py_am_aiter", "unaryfunc");
 const __ANEXT__: SlotDef = SlotDef::new("Py_am_anext", "unaryfunc").return_conversion(
-    TokenGenerator(|| quote! { _pyo3::class::pyasync::IterANextOutput::<_, _> }),
+    TokenGenerator(|| quote! { _pyo3::class::pyasync::IterANextOutput::<_, _, _> }),
 );
 const __LEN__: SlotDef = SlotDef::new("Py_mp_length", "lenfunc").ret_ty(Ty::PySsizeT);
 const __CONTAINS__: SlotDef = SlotDef::new("Py_sq_contains", "objobjproc")


### PR DESCRIPTION
Hello, hoping for comments on the following changes: 
- Addition for IterANextOutput::Err
- Addition for IterNextOutput::Err

In short, this is rationalized by the current error handling by PyO3 for custom iterators leading to unexpected behaviours at runtime. For example: 

```rust
use pyo3::prelude::*;
use pyo3::iter::IterNextOutput;

#[pyclass]
struct PyClassIter {
    count: usize,
}

#[pymethods]
impl PyClassIter {
    #[new]
    pub fn new() -> Self {
        PyClassIter { count: 0 }
    }

    fn __next__(&mut self, py: Python<'_>) -> IterNextOutput<usize, PyObject> {
        if self.count < 5 {
            self.count += 1;
            // Given an instance `counter`, First five `next(counter)` calls yield 1, 2, 3, 4, 5.
            return IterNextOutput::Yield(self.count)
        } else if self.count == 6 {
            return IterNextOutput::Return("the stuff".into_py(py))
       };
        IterNextOutput::Return(pyo3::exceptions::PyRuntimeError::new_err("oh no this shouldn't have happened").into_py(py))
    }
}
```
In this example, we are simply returning the value as `StopIteration(value=value)` - if the user attempts to return a PyError, pyo3 will serialize the <i>actual `PyRuntimeError` exception object</i>.


This is fixed with the `::Err` enum field, where we can:

```rust
use pyo3::prelude::*;
use pyo3::iter::IterNextOutput;

#[pyclass]
struct PyClassIter {
    count: usize,
}

#[pymethods]
impl PyClassIter {
    #[new]
    pub fn new() -> Self {
        PyClassIter { count: 0 }
    }

    fn __next__(&mut self) -> IterNextOutput<usize, &'static str, &'static str> {
        if self.count < 5 {
            self.count += 1;
            // Given an instance `counter`, First five `next(counter)` calls yield 1, 2, 3, 4, 5.
            return IterNextOutput::Yield(self.count)
        } else if self.count > 6 {
            // Runtime error
            return IterNextOutput::Err("exceeded depth")
        };
        IterNextOutput::Return("value")
    }
}
```

This output allows for an actual `RuntimeError` to be raised should `count` > 6 (trivial example, but actual use-cases require handling those race conditions)