### PR TITLE
Bump minimum Python version to 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,12 +191,10 @@ jobs:
         extra-features: ["multiple-pymethods"]  # Because MSRV doesn't support this
         rust: [stable]
         python-version: [
-          "3.7",
           "3.8",
           "3.9",
           "3.10",
           "3.11",
-          "pypy-3.7",
           "pypy-3.8",
           "pypy-3.9"
         ]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Usage
 
 PyO3 supports the following software versions:
-  - Python 3.7 and up (CPython and PyPy)
+  - Python 3.8 and up (CPython and PyPy)
   - Rust 1.56 and up
 
 You can use PyO3 to write a native Python module in Rust, or to embed Python in a Rust binary. The following sections explain each of these in turn.

--- a/examples/plugin/plugin_api/pyproject.toml
+++ b/examples/plugin/plugin_api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "plugin_api"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/guide/src/getting_started.md
+++ b/guide/src/getting_started.md
@@ -10,7 +10,7 @@ If you can run `rustc --version` and the version is new enough you're good to go
 
 ## Python
 
-To use PyO3, you need at least Python 3.7. While you can simply use the default Python interpreter on your system, it is recommended to use a virtual environment.
+To use PyO3, you need at least Python 3.8. While you can simply use the default Python interpreter on your system, it is recommended to use a virtual environment.
 
 ## Virtualenvs
 
@@ -128,7 +128,7 @@ build-backend = "maturin"
 
 [project]
 name = "pyo3_example"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -7,7 +7,7 @@ For a detailed list of all changes, see the [CHANGELOG](changelog.md).
 
 ### Drop support for older technologies
 
-PyO3 0.20 has increased minimum Rust version to 1.56. This enables use of newer language features and simplifies maintenance of the project.
+PyO3 0.20 has increased minimum Rust version to 1.56 and minimum Python version to 3.8. This enables use of newer language features and simplifies maintenance of the project.
 
 ## from 0.18.* to 0.19
 

--- a/newsfragments/3204.changed.md
+++ b/newsfragments/3204.changed.md
@@ -1,0 +1,1 @@
+Update the minimum Python version to 3.8.

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,8 +16,8 @@ nox.options.sessions = ["test", "clippy", "fmt"]
 
 
 PYO3_DIR = Path(__file__).parent
-PY_VERSIONS = ("3.7", "3.8", "3.9", "3.10", "3.11")
-PYPY_VERSIONS = ("3.7", "3.8", "3.9")
+PY_VERSIONS = ("3.8", "3.9", "3.10", "3.11")
+PYPY_VERSIONS = ("3.8", "3.9")
 
 
 @nox.session(venv_backend="none")

--- a/pyo3-ffi/README.md
+++ b/pyo3-ffi/README.md
@@ -2,7 +2,6 @@
 
 This crate provides [Rust](https://www.rust-lang.org/) FFI declarations for Python 3.
 It supports both the stable and the unstable component of the ABI through the use of cfg flags.
-Python Versions 3.7+ are supported.
 It is meant for advanced users only - regular PyO3 users shouldn't
 need to interact with this crate at all.
 
@@ -13,7 +12,7 @@ Manual][capi] for up-to-date documentation.
 # Minimum supported Rust and Python versions
 
 PyO3 supports the following software versions:
-  - Python 3.7 and up (CPython and PyPy)
+  - Python 3.8 and up (CPython and PyPy)
   - Rust 1.56 and up
 
 # Example: Building Python Native modules

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -50,7 +50,7 @@
 //! # Minimum supported Rust and Python versions
 //!
 //! PyO3 supports the following software versions:
-//!   - Python 3.7 and up (CPython and PyPy)
+//!   - Python 3.8 and up (CPython and PyPy)
 //!   - Rust 1.56 and up
 //!
 //! # Example: Building Python Native modules

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 //! # Minimum supported Rust and Python versions
 //!
 //! PyO3 supports the following software versions:
-//!   - Python 3.7 and up (CPython and PyPy)
+//!   - Python 3.8 and up (CPython and PyPy)
 //!   - Rust 1.56 and up
 //!
 //! # Example: Building a native Python module


### PR DESCRIPTION
This is not trying to reap any of the benefits of making that change yet, just the minimum amount of bureaucracy to make it happen.