### PR TITLE
add `pyo3::experimental` namespace with new owned `PyAny<'py>`

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -974,7 +974,6 @@ struct MyClass {
     num: i32,
 }
 unsafe impl pyo3::type_object::PyTypeInfo for MyClass {
-    type AsRefTarget = pyo3::PyCell<Self>;
     const NAME: &'static str = "MyClass";
     const MODULE: ::std::option::Option<&'static str> = ::std::option::Option::None;
     #[inline]
@@ -983,6 +982,10 @@ unsafe impl pyo3::type_object::PyTypeInfo for MyClass {
         static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
         TYPE_OBJECT.get_or_init::<Self>(py)
     }
+}
+
+unsafe impl pyo3::HasPyGilBoundRef for MyClass {
+    type AsRefTarget = pyo3::PyCell<Self>;
 }
 
 impl pyo3::PyClass for MyClass {

--- a/newsfragments/2956.changed.md
+++ b/newsfragments/2956.changed.md
@@ -1,0 +1,1 @@
+Move `PyTypeInfo::AsRefTarget` onto new trait `HasPyGilBoundRef`.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -747,8 +747,6 @@ fn impl_pytypeinfo(
 
     quote! {
         unsafe impl _pyo3::type_object::PyTypeInfo for #cls {
-            type AsRefTarget = _pyo3::PyCell<Self>;
-
             const NAME: &'static str = #cls_name;
             const MODULE: ::std::option::Option<&'static str> = #module;
 
@@ -760,6 +758,9 @@ fn impl_pytypeinfo(
                 static TYPE_OBJECT: LazyStaticType = LazyStaticType::new();
                 TYPE_OBJECT.get_or_init::<Self>(py)
             }
+        }
+        unsafe impl _pyo3::HasPyGilBoundRef for #cls {
+            type AsRefTarget = _pyo3::PyCell<Self>;
         }
     }
 }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -841,7 +841,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     type Holder = ::std::option::Option<_pyo3::PyRef<'py, #cls>>;
 
                     #[inline]
-                    fn extract(obj: &'py _pyo3::PyAny, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
+                    fn extract(obj: &'py _pyo3::experimental::PyAny<'py>, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
                         _pyo3::impl_::extract_argument::extract_pyclass_ref(obj, holder)
                     }
                 }
@@ -853,7 +853,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     type Holder = ::std::option::Option<_pyo3::PyRef<'py, #cls>>;
 
                     #[inline]
-                    fn extract(obj: &'py _pyo3::PyAny, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
+                    fn extract(obj: &'py _pyo3::experimental::PyAny<'py>, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
                         _pyo3::impl_::extract_argument::extract_pyclass_ref(obj, holder)
                     }
                 }
@@ -863,7 +863,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     type Holder = ::std::option::Option<_pyo3::PyRefMut<'py, #cls>>;
 
                     #[inline]
-                    fn extract(obj: &'py _pyo3::PyAny, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
+                    fn extract(obj: &'py _pyo3::experimental::PyAny<'py>, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
                         _pyo3::impl_::extract_argument::extract_pyclass_ref_mut(obj, holder)
                     }
                 }

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -211,6 +211,32 @@ fn pymethods_impl(
     .into()
 }
 
+#[proc_macro]
+#[allow(non_snake_case)]
+pub fn py_wrapper(ty: TokenStream) -> TokenStream {
+    let PyWrapperOptions { krate, ty, .. } = parse_macro_input!(ty as PyWrapperOptions);
+    quote!(
+        #krate::experimental::instance::PyDetached<<#ty as #krate::experimental::PyTypeInfo>::PyMarkerType>
+    )
+    .into()
+}
+
+struct PyWrapperOptions {
+    krate: syn::Path,
+    _comma: syn::Token![,],
+    ty: syn::Type,
+}
+
+impl syn::parse::Parse for PyWrapperOptions {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            krate: input.parse()?,
+            _comma: input.parse()?,
+            ty: input.parse()?,
+        })
+    }
+}
+
 fn methods_type() -> PyClassMethodsType {
     if cfg!(feature = "multiple-pymethods") {
         PyClassMethodsType::Inventory

--- a/src/experimental/conversion.rs
+++ b/src/experimental/conversion.rs
@@ -1,0 +1,285 @@
+// Copyright (c) 2017-present PyO3 Project and Contributors
+
+//! Defines conversions between Rust and Python types.
+use crate::err::{PyDowncastError, PyResult};
+use crate::experimental::PyAny;
+#[cfg(feature = "experimental-inspect")]
+use crate::inspect::types::TypeInfo;
+use crate::pyclass::boolean_struct::False;
+use crate::type_object::PyTypeInfo;
+use crate::{ffi, AsPyPointer, PyCell, PyClass, PyNativeType, PyRef, PyRefMut};
+
+/// Extract a type from a Python object.
+///
+///
+/// Normal usage is through the `extract` methods on [`Py`] and  [`PyAny`], which forward to this trait.
+///
+/// # Examples
+///
+/// ```rust
+/// use pyo3::prelude::*;
+/// use pyo3::types::PyString;
+///
+/// # fn main() -> PyResult<()> {
+/// Python::with_gil(|py| {
+///     let obj: Py<PyString> = PyString::new(py, "blah").into();
+///
+///     // Straight from an owned reference
+///     let s: &str = obj.extract(py)?;
+/// #   assert_eq!(s, "blah");
+///
+///     // Or from a borrowed reference
+///     let obj: &PyString = obj.as_ref(py);
+///     let s: &str = obj.extract()?;
+/// #   assert_eq!(s, "blah");
+/// #   Ok(())
+/// })
+/// # }
+/// ```
+///
+/// Note: depending on the implementation, the lifetime of the extracted result may
+/// depend on the lifetime of the `obj` or the `prepared` variable.
+///
+/// For example, when extracting `&str` from a Python byte string, the resulting string slice will
+/// point to the existing string data (lifetime: `'source`).
+/// On the other hand, when extracting `&str` from a Python Unicode string, the preparation step
+/// will convert the string to UTF-8, and the resulting string slice will have lifetime `'prepared`.
+/// Since which case applies depends on the runtime type of the Python object,
+/// both the `obj` and `prepared` variables must outlive the resulting string slice.
+///
+/// The trait's conversion method takes a `&PyAny` argument but is called
+/// `FromPyObject` for historical reasons.
+pub trait FromPyObject<'source, 'py>: Sized {
+    /// Extracts `Self` from the source `PyObject`.
+    fn extract(ob: &'source PyAny<'py>) -> PyResult<Self>;
+
+    /// Extracts the type hint information for this type when it appears as an argument.
+    ///
+    /// For example, `Vec<u32>` would return `Sequence[int]`.
+    /// The default implementation returns `Any`, which is correct for any type.
+    ///
+    /// For most types, the return value for this method will be identical to that of [`IntoPy::type_output`].
+    /// It may be different for some types, such as `Dict`, to allow duck-typing: functions return `Dict` but take `Mapping` as argument.
+    #[cfg(feature = "experimental-inspect")]
+    fn type_input() -> TypeInfo {
+        TypeInfo::Any
+    }
+}
+
+impl<'py, T> FromPyObject<'py, 'py> for &'py PyCell<T>
+where
+    T: PyClass,
+{
+    fn extract(obj: &'py PyAny<'py>) -> PyResult<Self> {
+        PyTryFrom::try_from(obj).map_err(Into::into)
+    }
+}
+
+impl<T> FromPyObject<'_, '_> for T
+where
+    T: PyClass + Clone,
+{
+    fn extract(obj: &PyAny<'_>) -> PyResult<Self> {
+        let cell: &PyCell<Self> = PyTryFrom::try_from(obj)?;
+        Ok(unsafe { cell.try_borrow_unguarded()?.clone() })
+    }
+}
+
+impl<'py, T> FromPyObject<'py, 'py> for PyRef<'py, T>
+where
+    T: PyClass,
+{
+    fn extract(obj: &'py PyAny<'py>) -> PyResult<Self> {
+        let cell: &PyCell<T> = PyTryFrom::try_from(obj)?;
+        cell.try_borrow().map_err(Into::into)
+    }
+}
+
+impl<'py, T> FromPyObject<'py, 'py> for PyRefMut<'py, T>
+where
+    T: PyClass<Frozen = False>,
+{
+    fn extract(obj: &'py PyAny<'py>) -> PyResult<Self> {
+        let cell: &PyCell<T> = PyTryFrom::try_from(obj)?;
+        cell.try_borrow_mut().map_err(Into::into)
+    }
+}
+
+impl<'source, 'py, T> FromPyObject<'source, 'py> for Option<T>
+where
+    T: FromPyObject<'source, 'py>,
+{
+    fn extract(obj: &'source PyAny<'py>) -> PyResult<Self> {
+        if obj.as_ptr() == unsafe { ffi::Py_None() } {
+            Ok(None)
+        } else {
+            T::extract(obj).map(Some)
+        }
+    }
+}
+
+/// Trait implemented by Python object types that allow a checked downcast.
+/// If `T` implements `PyTryFrom`, we can convert `&PyAny` to `&T`.
+///
+/// This trait is similar to `std::convert::TryFrom`
+pub trait PyTryFrom<'py>: Sized + PyNativeType + 'py {
+    /// Cast from a concrete Python object type to PyObject.
+    fn try_from<'a>(value: &'a PyAny<'py>) -> Result<&'a Self, PyDowncastError<'py>>;
+
+    /// Cast from a concrete Python object type to PyObject. With exact type check.
+    fn try_from_exact<'a>(value: &'a PyAny<'py>) -> Result<&'a Self, PyDowncastError<'py>>;
+
+    /// Cast a PyAny to a specific type of PyObject. The caller must
+    /// have already verified the reference is for this type.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that the type is valid or risk type confusion.
+    unsafe fn try_from_unchecked<'a>(value: &'a PyAny<'py>) -> &'a Self;
+}
+
+/// Trait implemented by Python object types that allow a checked downcast.
+/// This trait is similar to `std::convert::TryInto`
+pub trait PyTryInto<T>: Sized {
+    /// Cast from PyObject to a concrete Python object type.
+    fn try_into(&self) -> Result<&T, PyDowncastError<'_>>;
+
+    /// Cast from PyObject to a concrete Python object type. With exact type check.
+    fn try_into_exact(&self) -> Result<&T, PyDowncastError<'_>>;
+}
+
+// TryFrom implies TryInto
+impl<'py, U> PyTryInto<U> for PyAny<'py>
+where
+    U: PyTryFrom<'py>,
+{
+    fn try_into(&self) -> Result<&U, PyDowncastError<'_>> {
+        <U as PyTryFrom<'_>>::try_from(self)
+    }
+    fn try_into_exact(&self) -> Result<&U, PyDowncastError<'_>> {
+        U::try_from_exact(self)
+    }
+}
+
+impl<'py, T> PyTryFrom<'py> for T
+where
+    T: 'py + PyTypeInfo + PyNativeType,
+{
+    fn try_from<'a>(value: &'a PyAny<'py>) -> Result<&'a Self, PyDowncastError<'py>> {
+        unsafe {
+            if T::is_type_of(value.as_gil_ref()) {
+                Ok(Self::try_from_unchecked(value))
+            } else {
+                Err(PyDowncastError::new(value.to_gil_ref(), T::NAME))
+            }
+        }
+    }
+
+    fn try_from_exact<'a>(value: &'a PyAny<'py>) -> Result<&'a Self, PyDowncastError<'py>> {
+        unsafe {
+            if T::is_exact_type_of(value.as_gil_ref()) {
+                Ok(Self::try_from_unchecked(value))
+            } else {
+                Err(PyDowncastError::new(value.to_gil_ref(), T::NAME))
+            }
+        }
+    }
+
+    #[inline]
+    unsafe fn try_from_unchecked<'a>(value: &'a PyAny<'py>) -> &'a Self {
+        Self::unchecked_downcast(value.as_gil_ref())
+    }
+}
+
+impl<'py, T> PyTryFrom<'py> for PyCell<T>
+where
+    T: 'py + PyClass,
+{
+    fn try_from<'a>(value: &'a PyAny<'py>) -> Result<&'a Self, PyDowncastError<'py>> {
+        unsafe {
+            if T::is_type_of(value.as_gil_ref()) {
+                Ok(Self::try_from_unchecked(value))
+            } else {
+                Err(PyDowncastError::new(value.to_gil_ref(), T::NAME))
+            }
+        }
+    }
+    fn try_from_exact<'a>(value: &'a PyAny<'py>) -> Result<&'a Self, PyDowncastError<'py>> {
+        unsafe {
+            if T::is_exact_type_of(value.as_gil_ref()) {
+                Ok(Self::try_from_unchecked(value))
+            } else {
+                Err(PyDowncastError::new(value.to_gil_ref(), T::NAME))
+            }
+        }
+    }
+    #[inline]
+    unsafe fn try_from_unchecked<'a>(value: &'a PyAny<'py>) -> &'a Self {
+        Self::unchecked_downcast(value.as_gil_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::experimental::PyAny;
+    use crate::types::{IntoPyDict, PyDict, PyList};
+    use crate::{AsPyPointer, PyObject, Python, ToPyObject};
+
+    use super::PyTryFrom;
+
+    #[test]
+    fn test_try_from() {
+        Python::with_gil(|py| {
+            let list = PyAny::from_gil_ref(&vec![3, 6, 5, 4, 7].to_object(py).into_ref(py)).clone();
+            let dict =
+                PyAny::from_gil_ref(&vec![("reverse", true)].into_py_dict(py).as_ref()).clone();
+
+            assert!(<PyList as PyTryFrom<'_>>::try_from(&list).is_ok());
+            assert!(<PyDict as PyTryFrom<'_>>::try_from(&dict).is_ok());
+
+            assert!(<PyAny<'_> as PyTryFrom<'_>>::try_from(&list).is_ok());
+            assert!(<PyAny<'_> as PyTryFrom<'_>>::try_from(&dict).is_ok());
+        });
+    }
+
+    #[test]
+    fn test_try_from_exact() {
+        Python::with_gil(|py| {
+            let list = PyAny::from_gil_ref(&vec![3, 6, 5, 4, 7].to_object(py).into_ref(py)).clone();
+            let dict =
+                PyAny::from_gil_ref(&vec![("reverse", true)].into_py_dict(py).as_ref()).clone();
+
+            assert!(PyList::try_from_exact(&list).is_ok());
+            assert!(PyDict::try_from_exact(&dict).is_ok());
+
+            assert!(PyAny::try_from_exact(&list).is_err());
+            assert!(PyAny::try_from_exact(&dict).is_err());
+        });
+    }
+
+    #[test]
+    fn test_try_from_unchecked() {
+        Python::with_gil(|py| {
+            let list = PyAny::from_gil_ref(&PyList::new(py, &[1, 2, 3]).as_ref()).clone();
+            let val = unsafe { <PyList as PyTryFrom>::try_from_unchecked(&list) };
+            assert!(list.is(val));
+        });
+    }
+
+    #[test]
+    fn test_option_as_ptr() {
+        Python::with_gil(|py| {
+            let mut option: Option<PyObject> = None;
+            assert_eq!(option.as_ptr(), std::ptr::null_mut());
+
+            let none = py.None();
+            option = Some(none.clone());
+
+            let ref_cnt = none.get_refcnt(py);
+            assert_eq!(option.as_ptr(), none.as_ptr());
+
+            // Ensure ref count not changed by as_ptr call
+            assert_eq!(none.get_refcnt(py), ref_cnt);
+        });
+    }
+}

--- a/src/experimental/conversion.rs
+++ b/src/experimental/conversion.rs
@@ -5,9 +5,7 @@ use crate::err::{PyDowncastError, PyResult};
 use crate::experimental::PyAny;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-use crate::pyclass::boolean_struct::False;
-use crate::type_object::PyTypeInfo;
-use crate::{ffi, AsPyPointer, PyCell, PyClass, PyNativeType, PyRef, PyRefMut};
+use crate::{PyCell, PyClass, PyNativeType, PyTypeInfo};
 
 /// Extract a type from a Python object.
 ///
@@ -66,63 +64,31 @@ pub trait FromPyObject<'source, 'py>: Sized {
     }
 }
 
-impl<'py, T> FromPyObject<'py, 'py> for &'py PyCell<T>
+// FIXME: this is a temporary hack to enable compatible conversions in the short term
+impl<'py, T> FromPyObject<'py, 'py> for T
 where
-    T: PyClass,
+    T: crate::FromPyObject<'py>,
 {
     fn extract(obj: &'py PyAny<'py>) -> PyResult<Self> {
-        PyTryFrom::try_from(obj).map_err(Into::into)
+        obj.as_gil_ref().extract()
     }
 }
 
-impl<T> FromPyObject<'_, '_> for T
-where
-    T: PyClass + Clone,
-{
-    fn extract(obj: &PyAny<'_>) -> PyResult<Self> {
-        let cell: &PyCell<Self> = PyTryFrom::try_from(obj)?;
-        Ok(unsafe { cell.try_borrow_unguarded()?.clone() })
-    }
-}
-
-impl<'py, T> FromPyObject<'py, 'py> for PyRef<'py, T>
-where
-    T: PyClass,
-{
-    fn extract(obj: &'py PyAny<'py>) -> PyResult<Self> {
-        let cell: &PyCell<T> = PyTryFrom::try_from(obj)?;
-        cell.try_borrow().map_err(Into::into)
-    }
-}
-
-impl<'py, T> FromPyObject<'py, 'py> for PyRefMut<'py, T>
-where
-    T: PyClass<Frozen = False>,
-{
-    fn extract(obj: &'py PyAny<'py>) -> PyResult<Self> {
-        let cell: &PyCell<T> = PyTryFrom::try_from(obj)?;
-        cell.try_borrow_mut().map_err(Into::into)
-    }
-}
-
-impl<'source, 'py, T> FromPyObject<'source, 'py> for Option<T>
-where
-    T: FromPyObject<'source, 'py>,
-{
-    fn extract(obj: &'source PyAny<'py>) -> PyResult<Self> {
-        if obj.as_ptr() == unsafe { ffi::Py_None() } {
-            Ok(None)
-        } else {
-            T::extract(obj).map(Some)
-        }
-    }
+/// Cast from PyAny to a concrete type
+pub unsafe trait PyUncheckedDowncast<'py>: 'py {
+    /// Cast `&PyAny` to `&Self` with no type checking.
+    ///
+    /// # Safety
+    ///
+    /// obj must be an instance of a type corresponding to `Self`.
+    unsafe fn unchecked_downcast<'a>(obj: &'a PyAny<'py>) -> &'a Self;
 }
 
 /// Trait implemented by Python object types that allow a checked downcast.
 /// If `T` implements `PyTryFrom`, we can convert `&PyAny` to `&T`.
 ///
 /// This trait is similar to `std::convert::TryFrom`
-pub trait PyTryFrom<'py>: Sized + PyNativeType + 'py {
+pub trait PyTryFrom<'py> {
     /// Cast from a concrete Python object type to PyObject.
     fn try_from<'a>(value: &'a PyAny<'py>) -> Result<&'a Self, PyDowncastError<'py>>;
 
@@ -163,7 +129,7 @@ where
 
 impl<'py, T> PyTryFrom<'py> for T
 where
-    T: 'py + PyTypeInfo + PyNativeType,
+    T: 'py + PyTypeInfo + PyUncheckedDowncast<'py>,
 {
     fn try_from<'a>(value: &'a PyAny<'py>) -> Result<&'a Self, PyDowncastError<'py>> {
         unsafe {
@@ -187,7 +153,7 @@ where
 
     #[inline]
     unsafe fn try_from_unchecked<'a>(value: &'a PyAny<'py>) -> &'a Self {
-        Self::unchecked_downcast(value.as_gil_ref())
+        Self::unchecked_downcast(value)
     }
 }
 
@@ -221,21 +187,19 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::experimental::PyAny;
-    use crate::types::{IntoPyDict, PyDict, PyList};
-    use crate::{AsPyPointer, PyObject, Python, ToPyObject};
+    use crate::experimental::types::{IntoPyDict, PyAny, PyDict, PyList};
+    use crate::{AsPyPointer, PyObject, Python};
 
     use super::PyTryFrom;
 
     #[test]
     fn test_try_from() {
         Python::with_gil(|py| {
-            let list = PyAny::from_gil_ref(&vec![3, 6, 5, 4, 7].to_object(py).into_ref(py)).clone();
-            let dict =
-                PyAny::from_gil_ref(&vec![("reverse", true)].into_py_dict(py).as_ref()).clone();
+            let list = PyList::new(py, &[3, 6, 5, 4, 7]);
+            let dict = vec![("reverse", true)].into_py_dict(py);
 
-            assert!(<PyList as PyTryFrom<'_>>::try_from(&list).is_ok());
-            assert!(<PyDict as PyTryFrom<'_>>::try_from(&dict).is_ok());
+            assert!(<PyList<'_> as PyTryFrom<'_>>::try_from(&list).is_ok());
+            assert!(<PyDict<'_> as PyTryFrom<'_>>::try_from(&dict).is_ok());
 
             assert!(<PyAny<'_> as PyTryFrom<'_>>::try_from(&list).is_ok());
             assert!(<PyAny<'_> as PyTryFrom<'_>>::try_from(&dict).is_ok());
@@ -245,9 +209,8 @@ mod tests {
     #[test]
     fn test_try_from_exact() {
         Python::with_gil(|py| {
-            let list = PyAny::from_gil_ref(&vec![3, 6, 5, 4, 7].to_object(py).into_ref(py)).clone();
-            let dict =
-                PyAny::from_gil_ref(&vec![("reverse", true)].into_py_dict(py).as_ref()).clone();
+            let list = PyList::new(py, &vec![3, 6, 5, 4, 7]);
+            let dict = vec![("reverse", true)].into_py_dict(py);
 
             assert!(PyList::try_from_exact(&list).is_ok());
             assert!(PyDict::try_from_exact(&dict).is_ok());
@@ -260,8 +223,8 @@ mod tests {
     #[test]
     fn test_try_from_unchecked() {
         Python::with_gil(|py| {
-            let list = PyAny::from_gil_ref(&PyList::new(py, &[1, 2, 3]).as_ref()).clone();
-            let val = unsafe { <PyList as PyTryFrom>::try_from_unchecked(&list) };
+            let list = PyList::new(py, &[1, 2, 3]);
+            let val = unsafe { <PyList<'_> as PyTryFrom>::try_from_unchecked(&list) };
             assert!(list.is(val));
         });
     }

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -1,0 +1,6 @@
+pub mod conversion;
+pub mod types;
+
+pub use types::PyAny;
+
+pub use self::conversion::{FromPyObject, PyTryFrom, PyTryInto};

--- a/src/experimental/mod.rs
+++ b/src/experimental/mod.rs
@@ -1,6 +1,5 @@
 pub mod conversion;
 pub mod types;
 
+pub use conversion::{FromPyObject, PyTryFrom, PyTryInto, PyUncheckedDowncast};
 pub use types::PyAny;
-
-pub use self::conversion::{FromPyObject, PyTryFrom, PyTryInto};

--- a/src/experimental/types/detached.rs
+++ b/src/experimental/types/detached.rs
@@ -1,0 +1,24 @@
+use std::ptr::NonNull;
+
+use crate::experimental::types as attached;
+use crate::ffi;
+
+/// FIXME: this design is horrible, instead call this
+/// DetachedPyAny and export it from the types module
+
+#[repr(transparent)]
+pub struct PyAny(NonNull<ffi::PyObject>);
+
+pub trait PyAttachedType<'py>: 'py + Sized {
+    type Detached: From<Self>;
+}
+
+impl<'py> PyAttachedType<'py> for attached::PyAny<'py> {
+    type Detached = PyAny;
+}
+
+impl From<attached::PyAny<'_>> for PyAny {
+    fn from(other: attached::PyAny<'_>) -> Self {
+        Self(other.into_non_null())
+    }
+}

--- a/src/experimental/types/detached.rs
+++ b/src/experimental/types/detached.rs
@@ -19,6 +19,6 @@ impl<'py> PyAttachedType<'py> for attached::PyAny<'py> {
 
 impl From<attached::PyAny<'_>> for PyAny {
     fn from(other: attached::PyAny<'_>) -> Self {
-        Self(other.into_non_null())
+        Self(other.into_owned_non_null())
     }
 }

--- a/src/experimental/types/dict.rs
+++ b/src/experimental/types/dict.rs
@@ -1,0 +1,1013 @@
+// Copyright (c) 2017-present PyO3 Project and Contributors
+
+use crate::err::{self, PyErr, PyResult};
+use crate::experimental::types::PyAny;
+use crate::ffi::Py_ssize_t;
+use crate::types::{PyList, PyMapping};
+use crate::{ffi, AsPyPointer, Python, ToPyObject};
+
+/// Represents a Python `dict`.
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyDict<'py>(PyAny<'py>);
+
+pyobject_native_type_experimental!(
+    impl<'py> PyDict<'py>,
+    ffi::PyDictObject,
+    ffi::PyDict_Type,
+    #checkfunction=ffi::PyDict_Check
+);
+
+/// Represents a Python `dict_keys`.
+#[cfg(not(PyPy))]
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyDictKeys<'py>(PyAny<'py>);
+
+#[cfg(not(PyPy))]
+pyobject_native_type_core_experimental!(
+    impl<'py> PyDictKeys<'py>,
+    ffi::PyDictKeys_Type,
+    #checkfunction=ffi::PyDictKeys_Check
+);
+
+/// Represents a Python `dict_values`.
+#[cfg(not(PyPy))]
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyDictValues<'py>(PyAny<'py>);
+
+#[cfg(not(PyPy))]
+pyobject_native_type_core_experimental!(
+    impl<'py> PyDictValues<'py>,
+    ffi::PyDictValues_Type,
+    #checkfunction=ffi::PyDictValues_Check
+);
+
+/// Represents a Python `dict_items`.
+#[cfg(not(PyPy))]
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyDictItems<'py>(PyAny<'py>);
+
+#[cfg(not(PyPy))]
+pyobject_native_type_core_experimental!(
+    impl<'py> PyDictItems<'py>,
+    ffi::PyDictItems_Type,
+    #checkfunction=ffi::PyDictItems_Check
+);
+
+impl<'py> PyDict<'py> {
+    /// Creates a new empty dictionary.
+    pub fn new(py: Python<'py>) -> Self {
+        unsafe { Self(PyAny::from_owned_ptr_or_panic(py, ffi::PyDict_New())) }
+    }
+
+    /// Creates a new dictionary from the sequence given.
+    ///
+    /// The sequence must consist of `(PyObject, PyObject)`. This is
+    /// equivalent to `dict([("a", 1), ("b", 2)])`.
+    ///
+    /// Returns an error on invalid input. In the case of key collisions,
+    /// this keeps the last entry seen.
+    #[cfg(not(PyPy))]
+    pub fn from_sequence(seq: &PyAny<'py>) -> PyResult<Self> {
+        let py = seq.py();
+        let dict = Self::new(py);
+        unsafe {
+            err::error_on_minusone(
+                py,
+                ffi::PyDict_MergeFromSeq2(dict.as_ptr(), seq.as_ptr(), 1),
+            )?;
+        }
+        Ok(dict)
+    }
+
+    /// Returns a new dictionary that contains the same key-value pairs as self.
+    ///
+    /// This is equivalent to the Python expression `self.copy()`.
+    pub fn copy(&self) -> PyResult<Self> {
+        unsafe { Self::from_owned_ptr_or_err(self.py(), ffi::PyDict_Copy(self.as_ptr())) }
+    }
+
+    /// Empties an existing dictionary of all key-value pairs.
+    pub fn clear(&self) {
+        unsafe { ffi::PyDict_Clear(self.as_ptr()) }
+    }
+
+    /// Return the number of items in the dictionary.
+    ///
+    /// This is equivalent to the Python expression `len(self)`.
+    pub fn len(&self) -> usize {
+        self._len() as usize
+    }
+
+    fn _len(&self) -> Py_ssize_t {
+        #[cfg(any(not(Py_3_8), PyPy, Py_LIMITED_API))]
+        unsafe {
+            ffi::PyDict_Size(self.as_ptr())
+        }
+
+        #[cfg(all(Py_3_8, not(PyPy), not(Py_LIMITED_API)))]
+        unsafe {
+            (*self.as_ptr().cast::<ffi::PyDictObject>()).ma_used
+        }
+    }
+
+    /// Checks if the dict is empty, i.e. `len(self) == 0`.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Determines if the dictionary contains the specified key.
+    ///
+    /// This is equivalent to the Python expression `key in self`.
+    pub fn contains<K>(&self, key: K) -> PyResult<bool>
+    where
+        K: ToPyObject,
+    {
+        unsafe {
+            match ffi::PyDict_Contains(self.as_ptr(), key.to_object(self.py()).as_ptr()) {
+                1 => Ok(true),
+                0 => Ok(false),
+                _ => Err(PyErr::fetch(self.py())),
+            }
+        }
+    }
+
+    /// Gets an item from the dictionary.
+    ///
+    /// Returns `None` if the item is not present, or if an error occurs.
+    ///
+    /// To get a `KeyError` for non-existing keys, use `PyAny::get_item`.
+    pub fn get_item<K>(&self, key: K) -> Option<PyAny<'py>>
+    where
+        K: ToPyObject,
+    {
+        let py = self.py();
+        unsafe {
+            let ptr = ffi::PyDict_GetItem(self.as_ptr(), key.to_object(py).as_ptr());
+            PyAny::from_borrowed_ptr_or_opt(py, ptr)
+        }
+    }
+
+    /// Gets an item from the dictionary,
+    ///
+    /// returns `Ok(None)` if item is not present, or `Err(PyErr)` if an error occurs.
+    ///
+    /// To get a `KeyError` for non-existing keys, use `PyAny::get_item_with_error`.
+    #[cfg(not(PyPy))]
+    pub fn get_item_with_error<K>(&self, key: K) -> PyResult<Option<PyAny<'py>>>
+    where
+        K: ToPyObject,
+    {
+        let py = self.py();
+        let ptr =
+            unsafe { ffi::PyDict_GetItemWithError(self.as_ptr(), key.to_object(py).as_ptr()) };
+        if let Some(err) = PyErr::take(py) {
+            return Err(err);
+        }
+        Ok(unsafe { PyAny::from_borrowed_ptr_or_opt(py, ptr) })
+    }
+
+    /// Sets an item value.
+    ///
+    /// This is equivalent to the Python statement `self[key] = value`.
+    pub fn set_item<K, V>(&self, key: K, value: V) -> PyResult<()>
+    where
+        K: ToPyObject,
+        V: ToPyObject,
+    {
+        let py = self.py();
+        unsafe {
+            err::error_on_minusone(
+                py,
+                ffi::PyDict_SetItem(
+                    self.as_ptr(),
+                    key.to_object(py).as_ptr(),
+                    value.to_object(py).as_ptr(),
+                ),
+            )
+        }
+    }
+
+    /// Deletes an item.
+    ///
+    /// This is equivalent to the Python statement `del self[key]`.
+    pub fn del_item<K>(&self, key: K) -> PyResult<()>
+    where
+        K: ToPyObject,
+    {
+        let py = self.py();
+        dbg!(self, key.to_object(py));
+        unsafe {
+            err::error_on_minusone(
+                py,
+                ffi::PyDict_DelItem(self.as_ptr(), key.to_object(py).as_ptr()),
+            )
+        }
+    }
+
+    /// Returns a list of dict keys.
+    ///
+    /// This is equivalent to the Python expression `list(dict.keys())`.
+    pub fn keys(&'py self) -> &'py PyList {
+        unsafe {
+            self.py()
+                .from_owned_ptr::<PyList>(ffi::PyDict_Keys(self.as_ptr()))
+        }
+    }
+
+    /// Returns a list of dict values.
+    ///
+    /// This is equivalent to the Python expression `list(dict.values())`.
+    pub fn values(&'py self) -> &'py PyList {
+        unsafe {
+            self.py()
+                .from_owned_ptr::<PyList>(ffi::PyDict_Values(self.as_ptr()))
+        }
+    }
+
+    /// Returns a list of dict items.
+    ///
+    /// This is equivalent to the Python expression `list(dict.items())`.
+    pub fn items(&'py self) -> &'py PyList {
+        unsafe {
+            self.py()
+                .from_owned_ptr::<PyList>(ffi::PyDict_Items(self.as_ptr()))
+        }
+    }
+
+    /// Returns an iterator of `(key, value)` pairs in this dictionary.
+    ///
+    /// # Panics
+    ///
+    /// If PyO3 detects that the dictionary is mutated during iteration, it will panic.
+    /// It is allowed to modify values as you iterate over the dictionary, but only
+    /// so long as the set of keys does not change.
+    pub fn iter(&self) -> PyDictIterator<'py> {
+        IntoIterator::into_iter(self.clone())
+    }
+
+    /// Returns `self` cast as a `PyMapping`.
+    pub fn as_mapping(&'py self) -> &'py PyMapping {
+        unsafe { self.as_gil_ref().downcast_unchecked() }
+    }
+
+    /// Update this dictionary with the key/value pairs from another.
+    ///
+    /// This is equivalent to the Python expression `self.update(other)`. If `other` is a `PyDict`, you may want
+    /// to use `self.update(other.as_mapping())`, note: `PyDict::as_mapping` is a zero-cost conversion.
+    pub fn update(&self, other: &PyMapping) -> PyResult<()> {
+        let py = self.py();
+        unsafe { err::error_on_minusone(py, ffi::PyDict_Update(self.as_ptr(), other.as_ptr())) }
+    }
+
+    /// Add key/value pairs from another dictionary to this one only when they do not exist in this.
+    ///
+    /// This is equivalent to the Python expression `self.update({k: v for k, v in other.items() if k not in self})`.
+    /// If `other` is a `PyDict`, you may want to use `self.update_if_missing(other.as_mapping())`,
+    /// note: `PyDict::as_mapping` is a zero-cost conversion.
+    ///
+    /// This method uses [`PyDict_Merge`](https://docs.python.org/3/c-api/dict.html#c.PyDict_Merge) internally,
+    /// so should have the same performance as `update`.
+    pub fn update_if_missing(&self, other: &PyMapping) -> PyResult<()> {
+        let py = self.py();
+        unsafe { err::error_on_minusone(py, ffi::PyDict_Merge(self.as_ptr(), other.as_ptr(), 0)) }
+    }
+
+    /// Create a new `PyDict` from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be an owned non-null pointer to a PyDict object.
+    #[inline]
+    pub(crate) unsafe fn from_owned_ptr_or_err(
+        py: Python<'py>,
+        ptr: *mut ffi::PyObject,
+    ) -> PyResult<Self> {
+        PyAny::from_owned_ptr_or_err(py, ptr).map(Self)
+    }
+
+    /// Create a new `PyDict` from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be an owned non-null pointer to a PyDict object.
+    #[inline]
+    pub(crate) unsafe fn from_owned_ptr_or_panic(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
+        Self(PyAny::from_owned_ptr_or_panic(py, ptr))
+    }
+}
+
+/// PyO3 implementation of an iterator for a Python `dict` object.
+pub struct PyDictIterator<'py> {
+    dict: PyDict<'py>,
+    ppos: ffi::Py_ssize_t,
+    di_used: ffi::Py_ssize_t,
+    len: ffi::Py_ssize_t,
+}
+
+impl<'py> Iterator for PyDictIterator<'py> {
+    type Item = (PyAny<'py>, PyAny<'py>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let ma_used = self.dict._len();
+
+        // These checks are similar to what CPython does.
+        //
+        // If the dimension of the dict changes e.g. key-value pairs are removed
+        // or added during iteration, this will panic next time when `next` is called
+        if self.di_used != ma_used {
+            self.di_used = -1;
+            panic!("dictionary changed size during iteration");
+        };
+
+        // If the dict is changed in such a way that the length remains constant
+        // then this will panic at the end of iteration - similar to this:
+        //
+        // d = {"a":1, "b":2, "c": 3}
+        //
+        // for k, v in d.items():
+        //     d[f"{k}_"] = 4
+        //     del d[k]
+        //     print(k)
+        //
+        if self.len == -1 {
+            self.di_used = -1;
+            panic!("dictionary keys changed during iteration");
+        };
+
+        let ret = unsafe { self.next_unchecked() };
+        if ret.is_some() {
+            self.len -= 1
+        }
+        ret
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<'py> ExactSizeIterator for PyDictIterator<'py> {
+    fn len(&self) -> usize {
+        self.len as usize
+    }
+}
+
+impl<'py> std::iter::IntoIterator for PyDict<'py> {
+    type Item = (PyAny<'py>, PyAny<'py>);
+    type IntoIter = PyDictIterator<'py>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let len = self._len();
+        PyDictIterator {
+            dict: self,
+            ppos: 0,
+            di_used: len,
+            len,
+        }
+    }
+}
+
+impl<'py> std::iter::IntoIterator for &PyDict<'py> {
+    type Item = (PyAny<'py>, PyAny<'py>);
+    type IntoIter = PyDictIterator<'py>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'py> PyDictIterator<'py> {
+    /// Advances the iterator without checking for concurrent modification.
+    ///
+    /// See [`PyDict_Next`](https://docs.python.org/3/c-api/dict.html#c.PyDict_Next)
+    /// for more information.
+    unsafe fn next_unchecked(&mut self) -> Option<(PyAny<'py>, PyAny<'py>)> {
+        let mut key: *mut ffi::PyObject = std::ptr::null_mut();
+        let mut value: *mut ffi::PyObject = std::ptr::null_mut();
+
+        if ffi::PyDict_Next(self.dict.as_ptr(), &mut self.ppos, &mut key, &mut value) != 0 {
+            let py = self.dict.py();
+            Some((
+                PyAny::from_borrowed_ptr_unchecked(py, key),
+                PyAny::from_borrowed_ptr_unchecked(py, value),
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+/// Conversion trait that allows a sequence of tuples to be converted into `PyDict`
+/// Primary use case for this trait is `call` and `call_method` methods as keywords argument.
+pub trait IntoPyDict {
+    /// Converts self into a `PyDict` object pointer. Whether pointer owned or borrowed
+    /// depends on implementation.
+    fn into_py_dict<'py>(self, py: Python<'py>) -> PyDict<'py>;
+}
+
+impl<T, I> IntoPyDict for I
+where
+    T: PyDictItem,
+    I: IntoIterator<Item = T>,
+{
+    fn into_py_dict<'py>(self, py: Python<'py>) -> PyDict<'py> {
+        let dict = PyDict::new(py);
+        for item in self {
+            dict.set_item(item.key(), item.value())
+                .expect("Failed to set_item on dict");
+        }
+        dict
+    }
+}
+
+/// Represents a tuple which can be used as a PyDict item.
+pub trait PyDictItem {
+    type K: ToPyObject;
+    type V: ToPyObject;
+    fn key(&self) -> &Self::K;
+    fn value(&self) -> &Self::V;
+}
+
+impl<K, V> PyDictItem for (K, V)
+where
+    K: ToPyObject,
+    V: ToPyObject,
+{
+    type K = K;
+    type V = V;
+    fn key(&self) -> &Self::K {
+        &self.0
+    }
+    fn value(&self) -> &Self::V {
+        &self.1
+    }
+}
+
+impl<K, V> PyDictItem for &(K, V)
+where
+    K: ToPyObject,
+    V: ToPyObject,
+{
+    type K = K;
+    type V = V;
+    fn key(&self) -> &Self::K {
+        &self.0
+    }
+    fn value(&self) -> &Self::V {
+        &self.1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(not(PyPy))]
+    use crate::exceptions;
+    #[cfg(not(PyPy))]
+    use crate::types::PyList;
+    use crate::{types::PyTuple, Python, ToPyObject};
+    use std::collections::{BTreeMap, HashMap};
+
+    #[test]
+    fn test_new() {
+        Python::with_gil(|py| {
+            let dict = [(7, 32)].into_py_dict(py);
+            assert_eq!(32, dict.get_item(7i32).unwrap().extract::<i32>().unwrap());
+            assert!(dict.get_item(8i32).is_none());
+            let map: HashMap<i32, i32> = [(7, 32)].iter().cloned().collect();
+            assert_eq!(map, dict.extract().unwrap());
+            let map: BTreeMap<i32, i32> = [(7, 32)].iter().cloned().collect();
+            assert_eq!(map, dict.extract().unwrap());
+        });
+    }
+
+    #[test]
+    #[cfg(not(PyPy))]
+    fn test_from_sequence() {
+        Python::with_gil(|py| {
+            let items = PyList::new(py, &vec![("a", 1), ("b", 2)]);
+            let dict = PyDict::from_sequence(PyAny::from_gil_ref(&items.as_ref())).unwrap();
+            assert_eq!(1, dict.get_item("a").unwrap().extract::<i32>().unwrap());
+            assert_eq!(2, dict.get_item("b").unwrap().extract::<i32>().unwrap());
+            let map: HashMap<&str, i32> = [("a", 1), ("b", 2)].iter().cloned().collect();
+            assert_eq!(map, dict.extract().unwrap());
+            let map: BTreeMap<&str, i32> = [("a", 1), ("b", 2)].iter().cloned().collect();
+            assert_eq!(map, dict.extract().unwrap());
+        });
+    }
+
+    #[test]
+    #[cfg(not(PyPy))]
+    fn test_from_sequence_err() {
+        Python::with_gil(|py| {
+            let items = PyList::new(py, &vec!["a", "b"]);
+            assert!(PyDict::from_sequence(PyAny::from_gil_ref(&items.as_ref())).is_err());
+        });
+    }
+
+    #[test]
+    fn test_copy() {
+        Python::with_gil(|py| {
+            let dict = [(7, 32)].into_py_dict(py);
+
+            let ndict = dict.copy().unwrap();
+            assert_eq!(32, ndict.get_item(7i32).unwrap().extract::<i32>().unwrap());
+            assert!(ndict.get_item(8i32).is_none());
+        });
+    }
+
+    #[test]
+    fn test_len() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            assert_eq!(0, dict.len());
+            v.insert(7, 32);
+            let ob = v.to_object(py);
+            let dict2: &PyDict<'_> = ob.downcast2(py).unwrap();
+            assert_eq!(1, dict2.len());
+        });
+    }
+
+    #[test]
+    fn test_contains() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            assert!(dict.contains(7i32).unwrap());
+            assert!(!dict.contains(8i32).unwrap());
+        });
+    }
+
+    #[test]
+    fn test_get_item() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            assert_eq!(32, dict.get_item(7i32).unwrap().extract::<i32>().unwrap());
+            assert!(dict.get_item(8i32).is_none());
+        });
+    }
+
+    #[test]
+    #[cfg(not(PyPy))]
+    fn test_get_item_with_error() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            assert_eq!(
+                32,
+                dict.get_item_with_error(7i32)
+                    .unwrap()
+                    .unwrap()
+                    .extract::<i32>()
+                    .unwrap()
+            );
+            assert!(dict.get_item_with_error(8i32).unwrap().is_none());
+            assert!(dict
+                .get_item_with_error(dict)
+                .unwrap_err()
+                .is_instance_of::<exceptions::PyTypeError>(py));
+        });
+    }
+
+    #[test]
+    fn test_set_item() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            assert!(dict.set_item(7i32, 42i32).is_ok()); // change
+            assert!(dict.set_item(8i32, 123i32).is_ok()); // insert
+            assert_eq!(
+                42i32,
+                dict.get_item(7i32).unwrap().extract::<i32>().unwrap()
+            );
+            assert_eq!(
+                123i32,
+                dict.get_item(8i32).unwrap().extract::<i32>().unwrap()
+            );
+        });
+    }
+
+    #[test]
+    fn test_set_item_refcnt() {
+        Python::with_gil(|py| {
+            let cnt;
+            {
+                let _pool = unsafe { crate::GILPool::new() };
+                let none = py.None();
+                cnt = none.get_refcnt(py);
+                let _dict = [(10, none)].into_py_dict(py);
+            }
+            {
+                assert_eq!(cnt, py.None().get_refcnt(py));
+            }
+        });
+    }
+
+    #[test]
+    fn test_set_item_does_not_update_original_object() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            assert!(dict.set_item(7i32, 42i32).is_ok()); // change
+            assert!(dict.set_item(8i32, 123i32).is_ok()); // insert
+            assert_eq!(32i32, v[&7i32]); // not updated!
+            assert_eq!(None, v.get(&8i32));
+        });
+    }
+
+    #[test]
+    fn test_del_item() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            assert!(dict.del_item(7i32).is_ok());
+            assert_eq!(0, dict.len());
+            assert!(dict.get_item(7i32).is_none());
+        });
+    }
+
+    #[test]
+    fn test_del_item_does_not_update_original_object() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            dbg!(ob.get_refcnt(py), dict.get_refcnt());
+            assert!(dict.del_item(7i32).is_ok()); // change
+            assert_eq!(32i32, *v.get(&7i32).unwrap()); // not updated!
+        });
+    }
+
+    #[test]
+    fn test_items() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            v.insert(8, 42);
+            v.insert(9, 123);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
+            let mut key_sum = 0;
+            let mut value_sum = 0;
+            for el in dict.items().iter() {
+                let tuple = el.downcast::<PyTuple>().unwrap();
+                key_sum += tuple.get_item(0).unwrap().extract::<i32>().unwrap();
+                value_sum += tuple.get_item(1).unwrap().extract::<i32>().unwrap();
+            }
+            assert_eq!(7 + 8 + 9, key_sum);
+            assert_eq!(32 + 42 + 123, value_sum);
+        });
+    }
+
+    #[test]
+    fn test_keys() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            v.insert(8, 42);
+            v.insert(9, 123);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
+            let mut key_sum = 0;
+            for el in dict.keys().iter() {
+                key_sum += el.extract::<i32>().unwrap();
+            }
+            assert_eq!(7 + 8 + 9, key_sum);
+        });
+    }
+
+    #[test]
+    fn test_values() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            v.insert(8, 42);
+            v.insert(9, 123);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
+            let mut values_sum = 0;
+            for el in dict.values().iter() {
+                values_sum += el.extract::<i32>().unwrap();
+            }
+            assert_eq!(32 + 42 + 123, values_sum);
+        });
+    }
+
+    #[test]
+    fn test_iter() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            v.insert(8, 42);
+            v.insert(9, 123);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            let mut key_sum = 0;
+            let mut value_sum = 0;
+            for (key, value) in dict.iter() {
+                key_sum += key.extract::<i32>().unwrap();
+                value_sum += value.extract::<i32>().unwrap();
+            }
+            assert_eq!(7 + 8 + 9, key_sum);
+            assert_eq!(32 + 42 + 123, value_sum);
+        });
+    }
+
+    #[test]
+    fn test_iter_value_mutated() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            v.insert(8, 42);
+            v.insert(9, 123);
+
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+
+            for (key, value) in dict.iter() {
+                dict.set_item(key, value.extract::<i32>().unwrap() + 7)
+                    .unwrap();
+            }
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_iter_key_mutated() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            for i in 0..10 {
+                v.insert(i * 2, i * 2);
+            }
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+
+            for (i, (key, value)) in dict.iter().enumerate() {
+                let key = key.extract::<i32>().unwrap();
+                let value = value.extract::<i32>().unwrap();
+
+                dict.set_item(key + 1, value + 1).unwrap();
+
+                if i > 1000 {
+                    // avoid this test just running out of memory if it fails
+                    break;
+                };
+            }
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_iter_key_mutated_constant_len() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            for i in 0..10 {
+                v.insert(i * 2, i * 2);
+            }
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+
+            for (i, (key, value)) in dict.iter().enumerate() {
+                let key = key.extract::<i32>().unwrap();
+                let value = value.extract::<i32>().unwrap();
+                dict.del_item(key).unwrap();
+                dict.set_item(key + 1, value + 1).unwrap();
+
+                if i > 1000 {
+                    // avoid this test just running out of memory if it fails
+                    break;
+                };
+            }
+        });
+    }
+
+    #[test]
+    fn test_iter_size_hint() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            v.insert(8, 42);
+            v.insert(9, 123);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+
+            let mut iter = dict.iter();
+            assert_eq!(iter.size_hint(), (v.len(), Some(v.len())));
+            iter.next();
+            assert_eq!(iter.size_hint(), (v.len() - 1, Some(v.len() - 1)));
+
+            // Exhaust iterator.
+            for _ in &mut iter {}
+
+            assert_eq!(iter.size_hint(), (0, Some(0)));
+
+            assert!(iter.next().is_none());
+
+            assert_eq!(iter.size_hint(), (0, Some(0)));
+        });
+    }
+
+    #[test]
+    fn test_into_iter() {
+        Python::with_gil(|py| {
+            let mut v = HashMap::new();
+            v.insert(7, 32);
+            v.insert(8, 42);
+            v.insert(9, 123);
+            let ob = v.to_object(py);
+            let dict: &PyDict<'_> = ob.downcast2(py).unwrap();
+            let mut key_sum = 0;
+            let mut value_sum = 0;
+            for (key, value) in dict {
+                key_sum += key.extract::<i32>().unwrap();
+                value_sum += value.extract::<i32>().unwrap();
+            }
+            assert_eq!(7 + 8 + 9, key_sum);
+            assert_eq!(32 + 42 + 123, value_sum);
+        });
+    }
+
+    #[test]
+    fn test_hashmap_into_dict() {
+        Python::with_gil(|py| {
+            let mut map = HashMap::<i32, i32>::new();
+            map.insert(1, 1);
+
+            let py_map = map.into_py_dict(py);
+
+            assert_eq!(py_map.len(), 1);
+            assert_eq!(py_map.get_item(1).unwrap().extract::<i32>().unwrap(), 1);
+        });
+    }
+
+    #[test]
+    fn test_btreemap_into_dict() {
+        Python::with_gil(|py| {
+            let mut map = BTreeMap::<i32, i32>::new();
+            map.insert(1, 1);
+
+            let py_map = map.into_py_dict(py);
+
+            assert_eq!(py_map.len(), 1);
+            assert_eq!(py_map.get_item(1).unwrap().extract::<i32>().unwrap(), 1);
+        });
+    }
+
+    #[test]
+    fn test_vec_into_dict() {
+        Python::with_gil(|py| {
+            let vec = vec![("a", 1), ("b", 2), ("c", 3)];
+            let py_map = vec.into_py_dict(py);
+
+            assert_eq!(py_map.len(), 3);
+            assert_eq!(py_map.get_item("b").unwrap().extract::<i32>().unwrap(), 2);
+        });
+    }
+
+    #[test]
+    fn test_slice_into_dict() {
+        Python::with_gil(|py| {
+            let arr = [("a", 1), ("b", 2), ("c", 3)];
+            let py_map = arr.into_py_dict(py);
+
+            assert_eq!(py_map.len(), 3);
+            assert_eq!(py_map.get_item("b").unwrap().extract::<i32>().unwrap(), 2);
+        });
+    }
+
+    #[test]
+    fn dict_as_mapping() {
+        Python::with_gil(|py| {
+            let mut map = HashMap::<i32, i32>::new();
+            map.insert(1, 1);
+
+            let py_map = map.into_py_dict(py);
+
+            assert_eq!(py_map.as_mapping().len().unwrap(), 1);
+            assert_eq!(
+                py_map
+                    .as_mapping()
+                    .get_item(1)
+                    .unwrap()
+                    .extract::<i32>()
+                    .unwrap(),
+                1
+            );
+        });
+    }
+
+    #[cfg(not(PyPy))]
+    fn abc_dict(py: Python<'_>) -> PyDict<'_> {
+        let mut map = HashMap::<&'static str, i32>::new();
+        map.insert("a", 1);
+        map.insert("b", 2);
+        map.insert("c", 3);
+        map.into_py_dict(py)
+    }
+
+    #[test]
+    #[cfg(not(PyPy))]
+    fn dict_keys_view() {
+        Python::with_gil(|py| {
+            let dict = abc_dict(py);
+            let keys = dict.call_method0("keys").unwrap();
+            assert!(keys
+                .is_instance(PyAny::from_gil_ref(
+                    &py.get_type::<PyDictKeys<'_>>().as_ref()
+                ))
+                .unwrap());
+        })
+    }
+
+    #[test]
+    #[cfg(not(PyPy))]
+    fn dict_values_view() {
+        Python::with_gil(|py| {
+            let dict = abc_dict(py);
+            let values = dict.call_method0("values").unwrap();
+            assert!(values
+                .is_instance(PyAny::from_gil_ref(
+                    &py.get_type::<PyDictValues<'_>>().as_ref()
+                ))
+                .unwrap());
+        })
+    }
+
+    #[test]
+    #[cfg(not(PyPy))]
+    fn dict_items_view() {
+        Python::with_gil(|py| {
+            let dict = abc_dict(py);
+            let items = dict.call_method0("items").unwrap();
+            assert!(items
+                .is_instance(PyAny::from_gil_ref(
+                    &py.get_type::<PyDictItems<'_>>().as_ref()
+                ))
+                .unwrap());
+        })
+    }
+
+    #[test]
+    fn dict_update() {
+        Python::with_gil(|py| {
+            let dict = [("a", 1), ("b", 2), ("c", 3)].into_py_dict(py);
+            let other = [("b", 4), ("c", 5), ("d", 6)].into_py_dict(py);
+            dict.update(other.as_mapping()).unwrap();
+            assert_eq!(dict.len(), 4);
+            assert_eq!(dict.get_item("a").unwrap().extract::<i32>().unwrap(), 1);
+            assert_eq!(dict.get_item("b").unwrap().extract::<i32>().unwrap(), 4);
+            assert_eq!(dict.get_item("c").unwrap().extract::<i32>().unwrap(), 5);
+            assert_eq!(dict.get_item("d").unwrap().extract::<i32>().unwrap(), 6);
+
+            assert_eq!(other.len(), 3);
+            assert_eq!(other.get_item("b").unwrap().extract::<i32>().unwrap(), 4);
+            assert_eq!(other.get_item("c").unwrap().extract::<i32>().unwrap(), 5);
+            assert_eq!(other.get_item("d").unwrap().extract::<i32>().unwrap(), 6);
+        })
+    }
+
+    #[test]
+    fn dict_update_if_missing() {
+        Python::with_gil(|py| {
+            let dict = [("a", 1), ("b", 2), ("c", 3)].into_py_dict(py);
+            let other = [("b", 4), ("c", 5), ("d", 6)].into_py_dict(py);
+            dict.update_if_missing(other.as_mapping()).unwrap();
+            assert_eq!(dict.len(), 4);
+            assert_eq!(dict.get_item("a").unwrap().extract::<i32>().unwrap(), 1);
+            assert_eq!(dict.get_item("b").unwrap().extract::<i32>().unwrap(), 2);
+            assert_eq!(dict.get_item("c").unwrap().extract::<i32>().unwrap(), 3);
+            assert_eq!(dict.get_item("d").unwrap().extract::<i32>().unwrap(), 6);
+
+            assert_eq!(other.len(), 3);
+            assert_eq!(other.get_item("b").unwrap().extract::<i32>().unwrap(), 4);
+            assert_eq!(other.get_item("c").unwrap().extract::<i32>().unwrap(), 5);
+            assert_eq!(other.get_item("d").unwrap().extract::<i32>().unwrap(), 6);
+        })
+    }
+}

--- a/src/experimental/types/list.rs
+++ b/src/experimental/types/list.rs
@@ -1,0 +1,905 @@
+// Copyright (c) 2017-present PyO3 Project and Contributors
+//
+// based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
+
+use std::convert::TryInto;
+
+use crate::err::{self, PyResult};
+use crate::experimental::PyAny;
+use crate::ffi::{self, Py_ssize_t};
+use crate::internal_tricks::get_ssize_index;
+use crate::types::PySequence;
+use crate::{AsPyPointer, IntoPyPointer, PyObject, Python, ToPyObject};
+
+/// Represents a Python `list`.
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyList<'py>(PyAny<'py>);
+
+pyobject_native_type_core_experimental!(impl<'py> PyList<'py>, ffi::PyList_Type, #checkfunction=ffi::PyList_Check);
+
+#[inline]
+#[track_caller]
+pub(crate) fn new_from_iter<'py>(
+    py: Python<'py>,
+    elements: &mut dyn ExactSizeIterator<Item = PyObject>,
+) -> PyList<'py> {
+    unsafe {
+        // PyList_New checks for overflow but has a bad error message, so we check ourselves
+        let len: Py_ssize_t = elements
+            .len()
+            .try_into()
+            .expect("out of range integral type conversion attempted on `elements.len()`");
+
+        let ptr = ffi::PyList_New(len);
+
+        // We create the  `PyList` here for two reasons:
+        // - panics if the ptr is null
+        // - its Drop cleans up the list if user code or the asserts panic.
+        let list = PyList::from_owned_ptr_or_panic(py, ptr);
+
+        let mut counter: Py_ssize_t = 0;
+
+        for obj in elements.take(len as usize) {
+            #[cfg(not(Py_LIMITED_API))]
+            ffi::PyList_SET_ITEM(ptr, counter, obj.into_ptr());
+            #[cfg(Py_LIMITED_API)]
+            ffi::PyList_SetItem(ptr, counter, obj.into_ptr());
+            counter += 1;
+        }
+
+        assert!(elements.next().is_none(), "Attempted to create PyList but `elements` was larger than reported by its `ExactSizeIterator` implementation.");
+        assert_eq!(len, counter, "Attempted to create PyList but `elements` was smaller than reported by its `ExactSizeIterator` implementation.");
+
+        list
+    }
+}
+
+impl<'py> PyList<'py> {
+    /// Constructs a new list with the given elements.
+    ///
+    /// If you want to create a [`PyList`] with elements of different or unknown types, or from an
+    /// iterable that doesn't implement [`ExactSizeIterator`], use [`PyList::append`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyList;
+    ///
+    /// # fn main() {
+    /// Python::with_gil(|py| {
+    ///     let elements: Vec<i32> = vec![0, 1, 2, 3, 4, 5];
+    ///     let list: &PyList = PyList::new(py, elements);
+    ///     assert_eq!(format!("{:?}", list), "[0, 1, 2, 3, 4, 5]");
+    /// });
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `element`'s [`ExactSizeIterator`] implementation is incorrect.
+    /// All standard library structures implement this trait correctly, if they do, so calling this
+    /// function with (for example) [`Vec`]`<T>` or `&[T]` will always succeed.
+    #[track_caller]
+    pub fn new<T, U>(py: Python<'py>, elements: impl IntoIterator<Item = T, IntoIter = U>) -> Self
+    where
+        T: ToPyObject,
+        U: ExactSizeIterator<Item = T>,
+    {
+        let mut iter = elements.into_iter().map(|e| e.to_object(py));
+        new_from_iter(py, &mut iter)
+    }
+
+    /// Constructs a new empty list.
+    pub fn empty(py: Python<'py>) -> Self {
+        unsafe { Self::from_owned_ptr_or_panic(py, ffi::PyList_New(0)) }
+    }
+
+    /// Returns the length of the list.
+    pub fn len(&self) -> usize {
+        unsafe {
+            #[cfg(not(Py_LIMITED_API))]
+            let size = ffi::PyList_GET_SIZE(self.as_ptr());
+            #[cfg(Py_LIMITED_API)]
+            let size = ffi::PyList_Size(self.as_ptr());
+
+            // non-negative Py_ssize_t should always fit into Rust usize
+            size as usize
+        }
+    }
+
+    /// Checks if the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns `self` cast as a `PySequence`.
+    pub fn as_sequence(&'py self) -> &'py PySequence {
+        unsafe { self.as_gil_ref().downcast_unchecked() }
+    }
+
+    /// Gets the list item at the specified index.
+    /// # Example
+    /// ```
+    /// use pyo3::{prelude::*, types::PyList};
+    /// Python::with_gil(|py| {
+    ///     let list = PyList::new(py, &[2, 3, 5, 7]);
+    ///     let obj = list.get_item(0);
+    ///     assert_eq!(obj.unwrap().extract::<i32>().unwrap(), 2);
+    /// });
+    /// ```
+    pub fn get_item(&self, index: usize) -> PyResult<PyAny<'py>> {
+        unsafe {
+            let item = ffi::PyList_GetItem(self.as_ptr(), index as Py_ssize_t);
+            PyAny::from_borrowed_ptr_or_err(self.py(), item)
+        }
+    }
+
+    /// Gets the list item at the specified index. Undefined behavior on bad index. Use with caution.
+    ///
+    /// # Safety
+    ///
+    /// Caller must verify that the index is within the bounds of the list.
+    #[cfg(not(Py_LIMITED_API))]
+    pub unsafe fn get_item_unchecked(&self, index: usize) -> PyAny<'py> {
+        let item = ffi::PyList_GET_ITEM(self.as_ptr(), index as Py_ssize_t);
+        PyAny::from_borrowed_ptr_unchecked(self.py(), item)
+    }
+
+    /// Takes the slice `self[low:high]` and returns it as a new list.
+    ///
+    /// Indices must be nonnegative, and out-of-range indices are clipped to
+    /// `self.len()`.
+    pub fn get_slice(&self, low: usize, high: usize) -> Self {
+        unsafe {
+            Self::from_owned_ptr_or_panic(
+                self.py(),
+                ffi::PyList_GetSlice(self.as_ptr(), get_ssize_index(low), get_ssize_index(high)),
+            )
+        }
+    }
+
+    /// Sets the item at the specified index.
+    ///
+    /// Raises `IndexError` if the index is out of range.
+    pub fn set_item<I>(&self, index: usize, item: I) -> PyResult<()>
+    where
+        I: ToPyObject,
+    {
+        unsafe {
+            err::error_on_minusone(
+                self.py(),
+                ffi::PyList_SetItem(
+                    self.as_ptr(),
+                    get_ssize_index(index),
+                    item.to_object(self.py()).into_ptr(),
+                ),
+            )
+        }
+    }
+
+    /// Deletes the `index`th element of self.
+    ///
+    /// This is equivalent to the Python statement `del self[i]`.
+    #[inline]
+    pub fn del_item(&self, index: usize) -> PyResult<()> {
+        self.as_sequence().del_item(index)
+    }
+
+    /// Assigns the sequence `seq` to the slice of `self` from `low` to `high`.
+    ///
+    /// This is equivalent to the Python statement `self[low:high] = v`.
+    #[inline]
+    pub fn set_slice(&self, low: usize, high: usize, seq: &PyAny<'_>) -> PyResult<()> {
+        unsafe {
+            err::error_on_minusone(
+                self.py(),
+                ffi::PyList_SetSlice(
+                    self.as_ptr(),
+                    get_ssize_index(low),
+                    get_ssize_index(high),
+                    seq.as_ptr(),
+                ),
+            )
+        }
+    }
+
+    /// Deletes the slice from `low` to `high` from `self`.
+    ///
+    /// This is equivalent to the Python statement `del self[low:high]`.
+    #[inline]
+    pub fn del_slice(&self, low: usize, high: usize) -> PyResult<()> {
+        self.as_sequence().del_slice(low, high)
+    }
+
+    /// Appends an item to the list.
+    pub fn append<I>(&self, item: I) -> PyResult<()>
+    where
+        I: ToPyObject,
+    {
+        let py = self.py();
+        unsafe {
+            err::error_on_minusone(
+                py,
+                ffi::PyList_Append(self.as_ptr(), item.to_object(py).as_ptr()),
+            )
+        }
+    }
+
+    /// Inserts an item at the specified index.
+    ///
+    /// If `index >= self.len()`, inserts at the end.
+    pub fn insert<I>(&self, index: usize, item: I) -> PyResult<()>
+    where
+        I: ToPyObject,
+    {
+        let py = self.py();
+        unsafe {
+            err::error_on_minusone(
+                py,
+                ffi::PyList_Insert(
+                    self.as_ptr(),
+                    get_ssize_index(index),
+                    item.to_object(py).as_ptr(),
+                ),
+            )
+        }
+    }
+
+    /// Determines if self contains `value`.
+    ///
+    /// This is equivalent to the Python expression `value in self`.
+    #[inline]
+    pub fn contains<V>(&self, value: V) -> PyResult<bool>
+    where
+        V: ToPyObject,
+    {
+        self.as_sequence().contains(value)
+    }
+
+    /// Returns the first index `i` for which `self[i] == value`.
+    ///
+    /// This is equivalent to the Python expression `self.index(value)`.
+    #[inline]
+    pub fn index<V>(&self, value: V) -> PyResult<usize>
+    where
+        V: ToPyObject,
+    {
+        self.as_sequence().index(value)
+    }
+
+    /// Returns an iterator over this list's items.
+    pub fn iter(&self) -> PyListIterator<'py> {
+        PyListIterator {
+            list: self.clone(),
+            index: 0,
+        }
+    }
+
+    /// Sorts the list in-place. Equivalent to the Python expression `l.sort()`.
+    pub fn sort(&self) -> PyResult<()> {
+        unsafe { err::error_on_minusone(self.py(), ffi::PyList_Sort(self.as_ptr())) }
+    }
+
+    /// Reverses the list in-place. Equivalent to the Python expression `l.reverse()`.
+    pub fn reverse(&self) -> PyResult<()> {
+        unsafe { err::error_on_minusone(self.py(), ffi::PyList_Reverse(self.as_ptr())) }
+    }
+
+    /// Create a new `PyList` from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be an owned non-null pointer to a PyList object.
+    #[inline]
+    pub(crate) unsafe fn from_owned_ptr_or_err(
+        py: Python<'py>,
+        ptr: *mut ffi::PyObject,
+    ) -> PyResult<Self> {
+        PyAny::from_owned_ptr_or_err(py, ptr).map(Self)
+    }
+
+    /// Create a new `PyList` from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be an owned non-null pointer to a PyList object.
+    #[inline]
+    pub(crate) unsafe fn from_owned_ptr_or_panic(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
+        Self(PyAny::from_owned_ptr_or_panic(py, ptr))
+    }
+}
+
+// FIXME: not clear how to implement this!
+// e.g. std::ops::Index should return a reference, but there's no reference
+// it can safely return
+// index_impls!(PyList, "list", PyList::len, PyList::get_slice);
+
+/// Used by `PyList::iter()`.
+pub struct PyListIterator<'py> {
+    list: PyList<'py>,
+    index: usize,
+}
+
+impl<'py> Iterator for PyListIterator<'py> {
+    type Item = PyAny<'py>;
+
+    #[inline]
+    fn next(&mut self) -> Option<PyAny<'py>> {
+        if self.index < self.list.len() {
+            #[cfg(any(Py_LIMITED_API, PyPy))]
+            let item = self.list.get_item(self.index).expect("list.get failed");
+            #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+            let item = unsafe { self.list.get_item_unchecked(self.index) };
+            self.index += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<'a> ExactSizeIterator for PyListIterator<'a> {
+    fn len(&self) -> usize {
+        self.list.len().saturating_sub(self.index)
+    }
+}
+
+impl<'py> std::iter::IntoIterator for PyList<'py> {
+    type Item = PyAny<'py>;
+    type IntoIter = PyListIterator<'py>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'py> std::iter::IntoIterator for &PyList<'py> {
+    type Item = PyAny<'py>;
+    type IntoIter = PyListIterator<'py>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PyList;
+    use crate::Python;
+    use crate::{IntoPy, ToPyObject};
+
+    // #[test]
+    // fn test_new() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5, 7]);
+    //         assert_eq!(2, list[0].extract::<i32>().unwrap());
+    //         assert_eq!(3, list[1].extract::<i32>().unwrap());
+    //         assert_eq!(5, list[2].extract::<i32>().unwrap());
+    //         assert_eq!(7, list[3].extract::<i32>().unwrap());
+    //     });
+    // }
+
+    #[test]
+    fn test_len() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[1, 2, 3, 4]);
+            assert_eq!(4, list.len());
+        });
+    }
+
+    #[test]
+    fn test_get_item() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[2, 3, 5, 7]);
+            assert_eq!(2, list.get_item(0).unwrap().extract::<i32>().unwrap());
+            assert_eq!(3, list.get_item(1).unwrap().extract::<i32>().unwrap());
+            assert_eq!(5, list.get_item(2).unwrap().extract::<i32>().unwrap());
+            assert_eq!(7, list.get_item(3).unwrap().extract::<i32>().unwrap());
+        });
+    }
+
+    #[test]
+    fn test_get_slice() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[2, 3, 5, 7]);
+            let slice = list.get_slice(1, 3);
+            assert_eq!(2, slice.len());
+            let slice = list.get_slice(1, 7);
+            assert_eq!(3, slice.len());
+        });
+    }
+
+    // #[test]
+    // fn test_set_item() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5, 7]);
+    //         let val = 42i32.to_object(py);
+    //         let val2 = 42i32.to_object(py);
+    //         assert_eq!(2, list[0].extract::<i32>().unwrap());
+    //         list.set_item(0, val).unwrap();
+    //         assert_eq!(42, list[0].extract::<i32>().unwrap());
+    //         assert!(list.set_item(10, val2).is_err());
+    //     });
+    // }
+
+    #[test]
+    fn test_set_item_refcnt() {
+        Python::with_gil(|py| {
+            let cnt;
+            {
+                let _pool = unsafe { crate::GILPool::new() };
+                let v = vec![2];
+                let ob = v.to_object(py);
+                let list: &PyList<'_> = ob.downcast2(py).unwrap();
+                let none = py.None();
+                cnt = none.get_refcnt(py);
+                list.set_item(0, none).unwrap();
+            }
+
+            assert_eq!(cnt, py.None().get_refcnt(py));
+        });
+    }
+
+    // #[test]
+    // fn test_insert() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5, 7]);
+    //         let val = 42i32.to_object(py);
+    //         let val2 = 43i32.to_object(py);
+    //         assert_eq!(4, list.len());
+    //         assert_eq!(2, list[0].extract::<i32>().unwrap());
+    //         list.insert(0, val).unwrap();
+    //         list.insert(1000, val2).unwrap();
+    //         assert_eq!(6, list.len());
+    //         assert_eq!(42, list[0].extract::<i32>().unwrap());
+    //         assert_eq!(2, list[1].extract::<i32>().unwrap());
+    //         assert_eq!(43, list[5].extract::<i32>().unwrap());
+    //     });
+    // }
+
+    #[test]
+    fn test_insert_refcnt() {
+        Python::with_gil(|py| {
+            let cnt;
+            {
+                let _pool = unsafe { crate::GILPool::new() };
+                let list = PyList::empty(py);
+                let none = py.None();
+                cnt = none.get_refcnt(py);
+                list.insert(0, none).unwrap();
+            }
+
+            assert_eq!(cnt, py.None().get_refcnt(py));
+        });
+    }
+
+    // #[test]
+    // fn test_append() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2]);
+    //         list.append(3).unwrap();
+    //         assert_eq!(2, list[0].extract::<i32>().unwrap());
+    //         assert_eq!(3, list[1].extract::<i32>().unwrap());
+    //     });
+    // }
+
+    #[test]
+    fn test_append_refcnt() {
+        Python::with_gil(|py| {
+            let cnt;
+            {
+                let _pool = unsafe { crate::GILPool::new() };
+                let list = PyList::empty(py);
+                let none = py.None();
+                cnt = none.get_refcnt(py);
+                list.append(none).unwrap();
+            }
+            assert_eq!(cnt, py.None().get_refcnt(py));
+        });
+    }
+
+    #[test]
+    fn test_iter() {
+        Python::with_gil(|py| {
+            let v = vec![2, 3, 5, 7];
+            let list = PyList::new(py, &v);
+            let mut idx = 0;
+            for el in list.iter() {
+                assert_eq!(v[idx], el.extract::<i32>().unwrap());
+                idx += 1;
+            }
+            assert_eq!(idx, v.len());
+        });
+    }
+
+    #[test]
+    fn test_iter_size_hint() {
+        Python::with_gil(|py| {
+            let v = vec![2, 3, 5, 7];
+            let ob = v.to_object(py);
+            let list: &PyList<'_> = ob.downcast2(py).unwrap();
+
+            let mut iter = list.iter();
+            assert_eq!(iter.size_hint(), (v.len(), Some(v.len())));
+            iter.next();
+            assert_eq!(iter.size_hint(), (v.len() - 1, Some(v.len() - 1)));
+
+            // Exhust iterator.
+            for _ in &mut iter {}
+
+            assert_eq!(iter.size_hint(), (0, Some(0)));
+        });
+    }
+
+    #[test]
+    fn test_into_iter() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[1, 2, 3, 4]);
+            for (i, item) in list.iter().enumerate() {
+                assert_eq!((i + 1) as i32, item.extract::<i32>().unwrap());
+            }
+        });
+    }
+
+    #[test]
+    fn test_extract() {
+        Python::with_gil(|py| {
+            let v = vec![2, 3, 5, 7];
+            let list = PyList::new(py, &v);
+            let v2 = list.as_ref().extract::<Vec<i32>>().unwrap();
+            assert_eq!(v, v2);
+        });
+    }
+
+    // #[test]
+    // fn test_sort() {
+    //     Python::with_gil(|py| {
+    //         let v = vec![7, 3, 2, 5];
+    //         let list = PyList::new(py, &v);
+    //         assert_eq!(7, list[0].extract::<i32>().unwrap());
+    //         assert_eq!(3, list[1].extract::<i32>().unwrap());
+    //         assert_eq!(2, list[2].extract::<i32>().unwrap());
+    //         assert_eq!(5, list[3].extract::<i32>().unwrap());
+    //         list.sort().unwrap();
+    //         assert_eq!(2, list[0].extract::<i32>().unwrap());
+    //         assert_eq!(3, list[1].extract::<i32>().unwrap());
+    //         assert_eq!(5, list[2].extract::<i32>().unwrap());
+    //         assert_eq!(7, list[3].extract::<i32>().unwrap());
+    //     });
+    // }
+
+    // #[test]
+    // fn test_reverse() {
+    //     Python::with_gil(|py| {
+    //         let v = vec![2, 3, 5, 7];
+    //         let list = PyList::new(py, &v);
+    //         assert_eq!(2, list[0].extract::<i32>().unwrap());
+    //         assert_eq!(3, list[1].extract::<i32>().unwrap());
+    //         assert_eq!(5, list[2].extract::<i32>().unwrap());
+    //         assert_eq!(7, list[3].extract::<i32>().unwrap());
+    //         list.reverse().unwrap();
+    //         assert_eq!(7, list[0].extract::<i32>().unwrap());
+    //         assert_eq!(5, list[1].extract::<i32>().unwrap());
+    //         assert_eq!(3, list[2].extract::<i32>().unwrap());
+    //         assert_eq!(2, list[3].extract::<i32>().unwrap());
+    //     });
+    // }
+
+    // #[test]
+    // fn test_array_into_py() {
+    //     Python::with_gil(|py| {
+    //         let array: PyObject = [1, 2].into_py(py);
+    //         let list: &PyList = array.downcast(py).unwrap();
+    //         assert_eq!(1, list[0].extract::<i32>().unwrap());
+    //         assert_eq!(2, list[1].extract::<i32>().unwrap());
+    //     });
+    // }
+
+    #[test]
+    fn test_list_get_item_invalid_index() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[2, 3, 5, 7]);
+            let obj = list.get_item(5);
+            assert!(obj.is_err());
+            assert_eq!(
+                obj.unwrap_err().to_string(),
+                "IndexError: list index out of range"
+            );
+        });
+    }
+
+    #[test]
+    fn test_list_get_item_sanity() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[2, 3, 5, 7]);
+            let obj = list.get_item(0);
+            assert_eq!(obj.unwrap().extract::<i32>().unwrap(), 2);
+        });
+    }
+
+    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+    #[test]
+    fn test_list_get_item_unchecked_sanity() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[2, 3, 5, 7]);
+            let obj = unsafe { list.get_item_unchecked(0) };
+            assert_eq!(obj.extract::<i32>().unwrap(), 2);
+        });
+    }
+
+    // #[test]
+    // fn test_list_index_trait() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5]);
+    //         assert_eq!(2, list[0].extract::<i32>().unwrap());
+    //         assert_eq!(3, list[1].extract::<i32>().unwrap());
+    //         assert_eq!(5, list[2].extract::<i32>().unwrap());
+    //     });
+    // }
+
+    // #[test]
+    // #[should_panic]
+    // fn test_list_index_trait_panic() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5]);
+    //         let _ = &list[7];
+    //     });
+    // }
+
+    // #[test]
+    // fn test_list_index_trait_ranges() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5]);
+    //         assert_eq!(vec![3, 5], list[1..3].extract::<Vec<i32>>().unwrap());
+    //         assert_eq!(Vec::<i32>::new(), list[3..3].extract::<Vec<i32>>().unwrap());
+    //         assert_eq!(vec![3, 5], list[1..].extract::<Vec<i32>>().unwrap());
+    //         assert_eq!(Vec::<i32>::new(), list[3..].extract::<Vec<i32>>().unwrap());
+    //         assert_eq!(vec![2, 3, 5], list[..].extract::<Vec<i32>>().unwrap());
+    //         assert_eq!(vec![3, 5], list[1..=2].extract::<Vec<i32>>().unwrap());
+    //         assert_eq!(vec![2, 3], list[..2].extract::<Vec<i32>>().unwrap());
+    //         assert_eq!(vec![2, 3], list[..=1].extract::<Vec<i32>>().unwrap());
+    //     })
+    // }
+
+    // #[test]
+    // #[should_panic = "range start index 5 out of range for list of length 3"]
+    // fn test_list_index_trait_range_panic_start() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5]);
+    //         list[5..10].extract::<Vec<i32>>().unwrap();
+    //     })
+    // }
+
+    // #[test]
+    // #[should_panic = "range end index 10 out of range for list of length 3"]
+    // fn test_list_index_trait_range_panic_end() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5]);
+    //         list[1..10].extract::<Vec<i32>>().unwrap();
+    //     })
+    // }
+
+    // #[test]
+    // #[should_panic = "slice index starts at 2 but ends at 1"]
+    // fn test_list_index_trait_range_panic_wrong_order() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5]);
+    //         #[allow(clippy::reversed_empty_ranges)]
+    //         list[2..1].extract::<Vec<i32>>().unwrap();
+    //     })
+    // }
+
+    // #[test]
+    // #[should_panic = "range start index 8 out of range for list of length 3"]
+    // fn test_list_index_trait_range_from_panic() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[2, 3, 5]);
+    //         list[8..].extract::<Vec<i32>>().unwrap();
+    //     })
+    // }
+
+    // #[test]
+    // fn test_list_del_item() {
+    //     Python::with_gil(|py| {
+    //         let list = PyList::new(py, &[1, 1, 2, 3, 5, 8]);
+    //         assert!(list.del_item(10).is_err());
+    //         assert_eq!(1, list[0].extract::<i32>().unwrap());
+    //         assert!(list.del_item(0).is_ok());
+    //         assert_eq!(1, list[0].extract::<i32>().unwrap());
+    //         assert!(list.del_item(0).is_ok());
+    //         assert_eq!(2, list[0].extract::<i32>().unwrap());
+    //         assert!(list.del_item(0).is_ok());
+    //         assert_eq!(3, list[0].extract::<i32>().unwrap());
+    //         assert!(list.del_item(0).is_ok());
+    //         assert_eq!(5, list[0].extract::<i32>().unwrap());
+    //         assert!(list.del_item(0).is_ok());
+    //         assert_eq!(8, list[0].extract::<i32>().unwrap());
+    //         assert!(list.del_item(0).is_ok());
+    //         assert_eq!(0, list.len());
+    //         assert!(list.del_item(0).is_err());
+    //     });
+    // }
+
+    #[test]
+    fn test_list_set_slice() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[1, 1, 2, 3, 5, 8]);
+            let ins = PyList::new(py, &[7, 4]);
+            list.set_slice(1, 4, &ins).unwrap();
+            assert_eq!([1, 7, 4, 5, 8], list.extract::<[i32; 5]>().unwrap());
+            list.set_slice(3, 100, &PyList::empty(py)).unwrap();
+            assert_eq!([1, 7, 4], list.extract::<[i32; 3]>().unwrap());
+        });
+    }
+
+    #[test]
+    fn test_list_del_slice() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[1, 1, 2, 3, 5, 8]);
+            list.del_slice(1, 4).unwrap();
+            assert_eq!([1, 5, 8], list.extract::<[i32; 3]>().unwrap());
+            list.del_slice(1, 100).unwrap();
+            assert_eq!([1], list.extract::<[i32; 1]>().unwrap());
+        });
+    }
+
+    #[test]
+    fn test_list_contains() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[1, 1, 2, 3, 5, 8]);
+            assert_eq!(6, list.len());
+
+            let bad_needle = 7i32.to_object(py);
+            assert!(!list.contains(&bad_needle).unwrap());
+
+            let good_needle = 8i32.to_object(py);
+            assert!(list.contains(&good_needle).unwrap());
+
+            let type_coerced_needle = 8f32.to_object(py);
+            assert!(list.contains(&type_coerced_needle).unwrap());
+        });
+    }
+
+    #[test]
+    fn test_list_index() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, &[1, 1, 2, 3, 5, 8]);
+            assert_eq!(0, list.index(1i32).unwrap());
+            assert_eq!(2, list.index(2i32).unwrap());
+            assert_eq!(3, list.index(3i32).unwrap());
+            assert_eq!(4, list.index(5i32).unwrap());
+            assert_eq!(5, list.index(8i32).unwrap());
+            assert!(list.index(42i32).is_err());
+        });
+    }
+
+    use std::ops::Range;
+
+    // An iterator that lies about its `ExactSizeIterator` implementation.
+    // See https://github.com/PyO3/pyo3/issues/2118
+    struct FaultyIter(Range<usize>, usize);
+
+    impl Iterator for FaultyIter {
+        type Item = usize;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.0.next()
+        }
+    }
+
+    impl ExactSizeIterator for FaultyIter {
+        fn len(&self) -> usize {
+            self.1
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Attempted to create PyList but `elements` was larger than reported by its `ExactSizeIterator` implementation."
+    )]
+    fn too_long_iterator() {
+        Python::with_gil(|py| {
+            let iter = FaultyIter(0..usize::MAX, 73);
+            let _list = PyList::new(py, iter);
+        })
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Attempted to create PyList but `elements` was smaller than reported by its `ExactSizeIterator` implementation."
+    )]
+    fn too_short_iterator() {
+        Python::with_gil(|py| {
+            let iter = FaultyIter(0..35, 73);
+            let _list = PyList::new(py, iter);
+        })
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "out of range integral type conversion attempted on `elements.len()`"
+    )]
+    fn overflowing_size() {
+        Python::with_gil(|py| {
+            let iter = FaultyIter(0..0, usize::MAX);
+
+            let _list = PyList::new(py, iter);
+        })
+    }
+
+    #[cfg(feature = "macros")]
+    #[test]
+    fn bad_clone_mem_leaks() {
+        use crate::{Py, PyAny};
+        use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+        static NEEDS_DESTRUCTING_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+        #[crate::pyclass]
+        #[pyo3(crate = "crate")]
+        struct Bad(usize);
+
+        impl Clone for Bad {
+            fn clone(&self) -> Self {
+                if self.0 == 42 {
+                    // This panic should not lead to a memory leak
+                    panic!()
+                };
+                NEEDS_DESTRUCTING_COUNT.fetch_add(1, SeqCst);
+
+                Bad(self.0)
+            }
+        }
+
+        impl Drop for Bad {
+            fn drop(&mut self) {
+                NEEDS_DESTRUCTING_COUNT.fetch_sub(1, SeqCst);
+            }
+        }
+
+        impl ToPyObject for Bad {
+            fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
+                self.to_owned().into_py(py)
+            }
+        }
+
+        struct FaultyIter(Range<usize>, usize);
+
+        impl Iterator for FaultyIter {
+            type Item = Bad;
+
+            fn next(&mut self) -> Option<Self::Item> {
+                self.0.next().map(|i| {
+                    NEEDS_DESTRUCTING_COUNT.fetch_add(1, SeqCst);
+                    Bad(i)
+                })
+            }
+        }
+
+        impl ExactSizeIterator for FaultyIter {
+            fn len(&self) -> usize {
+                self.1
+            }
+        }
+
+        Python::with_gil(|py| {
+            let _ = std::panic::catch_unwind(|| {
+                let iter = FaultyIter(0..50, 50);
+                let _list = PyList::new(py, iter);
+            });
+        });
+
+        assert_eq!(
+            NEEDS_DESTRUCTING_COUNT.load(SeqCst),
+            0,
+            "Some destructors did not run"
+        );
+    }
+}

--- a/src/experimental/types/mod.rs
+++ b/src/experimental/types/mod.rs
@@ -1,6 +1,7 @@
 pub use self::any::PyAny;
 pub use self::dict::{IntoPyDict, PyDict};
 pub use self::list::PyList;
+pub use self::tuple::PyTuple;
 
 // Implementations core to all native types
 #[doc(hidden)]
@@ -195,3 +196,4 @@ mod any;
 pub mod detached;
 mod dict;
 mod list;
+mod tuple;

--- a/src/experimental/types/mod.rs
+++ b/src/experimental/types/mod.rs
@@ -1,0 +1,187 @@
+pub use self::any::PyAny;
+
+// Implementations core to all native types
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_native_type_base_experimental {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty) => {
+        unsafe impl<$py $(,$generics)*> $crate::PyNativeType for $name {}
+
+        impl<$py $(,$generics)*> ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>)
+                   -> ::std::result::Result<(), ::std::fmt::Error>
+            {
+                let s = self.repr().or(::std::result::Result::Err(::std::fmt::Error))?;
+                f.write_str(&s.to_string_lossy())
+            }
+        }
+
+        impl<$py $(,$generics)*> ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>)
+                   -> ::std::result::Result<(), ::std::fmt::Error>
+            {
+                let s = self.str().or(::std::result::Result::Err(::std::fmt::Error))?;
+                f.write_str(&s.to_string_lossy())
+            }
+        }
+
+        impl<$py $(,$generics)*> $crate::ToPyObject for $name
+        {
+            #[inline]
+            fn to_object(&self, py: $crate::Python<'_>) -> $crate::PyObject {
+                use $crate::AsPyPointer;
+                unsafe { $crate::PyObject::from_borrowed_ptr(py, self.as_ptr()) }
+            }
+        }
+    };
+}
+
+// Implementations core to all native types except for PyAny (because they don't
+// make sense on PyAny / have different implementations).
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_native_type_named_experimental {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty) => {
+        $crate::pyobject_native_type_base!($name $(;$generics)*);
+
+        impl<$py $(,$generics)*> ::std::convert::AsRef<$crate::PyAny> for $name {
+            #[inline]
+            fn as_ref(&self) -> &$crate::PyAny {
+                &self.0
+            }
+        }
+
+        impl<$py $(,$generics)*> ::std::ops::Deref for $name {
+            type Target = $crate::PyAny;
+
+            #[inline]
+            fn deref(&self) -> &$crate::PyAny {
+                &self.0
+            }
+        }
+
+        impl<$py $(,$generics)*> $crate::AsPyPointer for $name {
+            /// Gets the underlying FFI pointer, returns a borrowed pointer.
+            #[inline]
+            fn as_ptr(&self) -> *mut $crate::ffi::PyObject {
+                self.0.as_ptr()
+            }
+        }
+
+        impl<$py $(,$generics)*> $crate::IntoPy<$crate::Py<$name>> for &'_ $name {
+            #[inline]
+            fn into_py(self, py: $crate::Python<'_>) -> $crate::Py<$name> {
+                use $crate::AsPyPointer;
+                unsafe { $crate::Py::from_borrowed_ptr(py, self.as_ptr()) }
+            }
+        }
+
+        impl<$py $(,$generics)*> ::std::convert::From<&'_ $name> for $crate::Py<$name> {
+            #[inline]
+            fn from(other: &$name) -> Self {
+                use $crate::AsPyPointer;
+                use $crate::PyNativeType;
+                unsafe { $crate::Py::from_borrowed_ptr(other.py(), other.as_ptr()) }
+            }
+        }
+
+        impl<'a, $py $(,$generics)*> ::std::convert::From<&'a $name> for &'a $crate::PyAny {
+            fn from(ob: &'a $name) -> Self {
+                unsafe{&*(ob as *const $name as *const $crate::PyAny)}
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_native_type_info_experimental {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty, $typeobject:expr, $module:expr $(, #checkfunction=$checkfunction:path)?) => {
+        unsafe impl<$py $(,$generics)*> $crate::type_object::PyTypeInfo for $name {
+            type AsRefTarget = Self;
+
+            const NAME: &'static str = stringify!($name);
+            const MODULE: ::std::option::Option<&'static str> = $module;
+
+            #[inline]
+            fn type_object_raw(_py: $crate::Python<'_>) -> *mut $crate::ffi::PyTypeObject {
+                // Create a very short lived mutable reference and directly
+                // cast it to a pointer: no mutable references can be aliasing
+                // because we hold the GIL.
+                #[cfg(not(addr_of))]
+                unsafe { &mut $typeobject }
+
+                #[cfg(addr_of)]
+                unsafe { ::std::ptr::addr_of_mut!($typeobject) }
+            }
+
+            $(
+                fn is_type_of(ptr: &$crate::PyAny) -> bool {
+                    use $crate::AsPyPointer;
+                    #[allow(unused_unsafe)]
+                    unsafe { $checkfunction(ptr.as_ptr()) > 0 }
+                }
+            )?
+        }
+    };
+}
+
+// NOTE: This macro is not included in pyobject_native_type_base!
+// because rust-numpy has a special implementation.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_native_type_extract_experimental {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty) => {
+        impl<$py $(,$generics)*> $crate::FromPyObject<$py> for &$py $name {
+            fn extract(obj: &'py $crate::PyAny) -> $crate::PyResult<Self> {
+                obj.downcast().map_err(::std::convert::Into::into)
+            }
+        }
+    }
+}
+
+/// Declares all of the boilerplate for Python types.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_native_type_core_experimental {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty, $typeobject:expr, #module=$module:expr $(, #checkfunction=$checkfunction:path)?) => {
+        $crate::pyobject_native_type_named!(impl<$py $(,$generics)*> $name $(;$generics)*);
+        $crate::pyobject_native_type_info!(impl<$py $(,$generics)*> $name, $typeobject, $module $(, #checkfunction=$checkfunction)? $(;$generics)*);
+        $crate::pyobject_native_type_extract!(impl<$py $(,$generics)*> $name $(;$generics)*);
+    };
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty, $typeobject:expr $(, #checkfunction=$checkfunction:path)?) => {
+        $crate::pyobject_native_type_core!(impl<$py $(,$generics)*> $name, $typeobject, #module=::std::option::Option::Some("builtins") $(, #checkfunction=$checkfunction)? $(;$generics)*);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_native_type_sized_experimental {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty, $layout:path) => {
+        unsafe impl<$py $(,$generics)*> $crate::type_object::PyLayout<$name> for $layout {}
+        impl<$py $(,$generics)*> $crate::type_object::PySizedLayout<$name> for $layout {}
+        impl<$py $(,$generics)*> $crate::impl_::pyclass::PyClassBaseType for $name {
+            type LayoutAsBase = $crate::pycell::PyCellBase<$layout>;
+            type BaseNativeType = $name;
+            type ThreadChecker = $crate::impl_::pyclass::ThreadCheckerStub<$crate::PyObject>;
+            type Initializer = $crate::pyclass_init::PyNativeTypeInitializer<Self>;
+            type PyClassMutability = $crate::pycell::impl_::ImmutableClass;
+        }
+    }
+}
+
+/// Declares all of the boilerplate for Python types which can be inherited from (because the exact
+/// Python layout is known).
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_native_type_experimental {
+    ($name:ty, $layout:path, $typeobject:expr $(, #module=$module:expr)? $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
+        $crate::pyobject_native_type_core!($name, $typeobject $(, #module=$module)? $(, #checkfunction=$checkfunction)? $(;$generics)*);
+        // To prevent inheriting native types with ABI3
+        #[cfg(not(Py_LIMITED_API))]
+        $crate::pyobject_native_type_sized!($name, $layout $(;$generics)*);
+    };
+}
+
+mod any;
+pub mod detached;

--- a/src/experimental/types/tuple.rs
+++ b/src/experimental/types/tuple.rs
@@ -1,0 +1,942 @@
+// Copyright (c) 2017-present PyO3 Project and Contributors
+
+use std::convert::TryInto;
+
+use crate::experimental::types::PyAny;
+use crate::ffi::{self, Py_ssize_t};
+#[cfg(feature = "experimental-inspect")]
+use crate::inspect::types::TypeInfo;
+use crate::internal_tricks::get_ssize_index;
+use crate::types::PySequence;
+use crate::{
+    exceptions, AsPyPointer, IntoPyPointer, PyErr, PyObject, PyResult, Python, ToPyObject,
+};
+
+#[inline]
+#[track_caller]
+fn new_from_iter<'py>(
+    py: Python<'py>,
+    elements: &mut dyn ExactSizeIterator<Item = PyObject>,
+) -> PyTuple<'py> {
+    unsafe {
+        // PyTuple_New checks for overflow but has a bad error message, so we check ourselves
+        let len: Py_ssize_t = elements
+            .len()
+            .try_into()
+            .expect("out of range integral type conversion attempted on `elements.len()`");
+
+        let ptr = ffi::PyTuple_New(len);
+
+        // - Panics if the ptr is null
+        // - Cleans up the tuple if `convert` or the asserts panic
+        let tup = PyTuple::from_owned_ptr_or_panic(py, ptr);
+
+        let mut counter: Py_ssize_t = 0;
+
+        for obj in elements.take(len as usize) {
+            #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+            ffi::PyTuple_SET_ITEM(ptr, counter, obj.into_ptr());
+            #[cfg(any(Py_LIMITED_API, PyPy))]
+            ffi::PyTuple_SetItem(ptr, counter, obj.into_ptr());
+            counter += 1;
+        }
+
+        assert!(elements.next().is_none(), "Attempted to create PyTuple but `elements` was larger than reported by its `ExactSizeIterator` implementation.");
+        assert_eq!(len, counter, "Attempted to create PyTuple but `elements` was smaller than reported by its `ExactSizeIterator` implementation.");
+
+        tup
+    }
+}
+
+/// Represents a Python `tuple` object.
+///
+/// This type is immutable.
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyTuple<'py>(PyAny<'py>);
+
+pyobject_native_type_core_experimental!(impl<'py> PyTuple<'py>, ffi::PyTuple_Type, #checkfunction=ffi::PyTuple_Check);
+
+impl<'py> PyTuple<'py> {
+    /// Constructs a new tuple with the given elements.
+    ///
+    /// If you want to create a [`PyTuple`] with elements of different or unknown types, or from an
+    /// iterable that doesn't implement [`ExactSizeIterator`], create a Rust tuple with the given
+    /// elements and convert it at once using `into_py`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyTuple;
+    ///
+    /// # fn main() {
+    /// Python::with_gil(|py| {
+    ///     let elements: Vec<i32> = vec![0, 1, 2, 3, 4, 5];
+    ///     let tuple: &PyTuple = PyTuple::new(py, elements);
+    ///     assert_eq!(format!("{:?}", tuple), "(0, 1, 2, 3, 4, 5)");
+    /// });
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `element`'s [`ExactSizeIterator`] implementation is incorrect.
+    /// All standard library structures implement this trait correctly, if they do, so calling this
+    /// function using [`Vec`]`<T>` or `&[T]` will always succeed.
+    #[track_caller]
+    pub fn new<T, U>(py: Python<'py>, elements: impl IntoIterator<Item = T, IntoIter = U>) -> Self
+    where
+        T: ToPyObject,
+        U: ExactSizeIterator<Item = T>,
+    {
+        let mut elements = elements.into_iter().map(|e| e.to_object(py));
+        new_from_iter(py, &mut elements)
+    }
+
+    /// Constructs an empty tuple (on the Python side, a singleton object).
+    pub fn empty(py: Python<'py>) -> Self {
+        unsafe { Self::from_owned_ptr_or_panic(py, ffi::PyTuple_New(0)) }
+    }
+
+    /// Gets the length of the tuple.
+    pub fn len(&self) -> usize {
+        unsafe {
+            #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+            let size = ffi::PyTuple_GET_SIZE(self.as_ptr());
+            #[cfg(any(Py_LIMITED_API, PyPy))]
+            let size = ffi::PyTuple_Size(self.as_ptr());
+            // non-negative Py_ssize_t should always fit into Rust uint
+            size as usize
+        }
+    }
+
+    /// Checks if the tuple is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns `self` cast as a `PySequence`.
+    pub fn as_sequence(&'py self) -> &'py PySequence {
+        unsafe { self.as_gil_ref().downcast_unchecked() }
+    }
+
+    /// Takes the slice `self[low:high]` and returns it as a new tuple.
+    ///
+    /// Indices must be nonnegative, and out-of-range indices are clipped to
+    /// `self.len()`.
+    pub fn get_slice(&self, low: usize, high: usize) -> Self {
+        unsafe {
+            Self::from_owned_ptr_or_panic(
+                self.py(),
+                ffi::PyTuple_GetSlice(self.as_ptr(), get_ssize_index(low), get_ssize_index(high)),
+            )
+        }
+    }
+
+    /// Gets the tuple item at the specified index.
+    /// # Example
+    /// ```
+    /// use pyo3::{prelude::*, types::PyTuple};
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let ob = (1, 2, 3).to_object(py);
+    ///     let tuple: &PyTuple = ob.downcast(py).unwrap();
+    ///     let obj = tuple.get_item(0);
+    ///     assert_eq!(obj.unwrap().extract::<i32>().unwrap(), 1);
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    pub fn get_item(&self, index: usize) -> PyResult<PyAny<'py>> {
+        unsafe {
+            let item = ffi::PyTuple_GetItem(self.as_ptr(), index as Py_ssize_t);
+            PyAny::from_borrowed_ptr_or_err(self.py(), item)
+        }
+    }
+
+    /// Gets the tuple item at the specified index. Undefined behavior on bad index. Use with caution.
+    ///
+    /// # Safety
+    ///
+    /// Caller must verify that the index is within the bounds of the tuple.
+    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+    pub unsafe fn get_item_unchecked(&self, index: usize) -> PyAny<'py> {
+        let item = ffi::PyTuple_GET_ITEM(self.as_ptr(), index as Py_ssize_t);
+        PyAny::from_borrowed_ptr_unchecked(self.py(), item)
+    }
+
+    /// Returns `self` as a slice of objects.
+    #[cfg(not(Py_LIMITED_API))]
+    pub fn as_slice(&self) -> &[PyAny<'py>] {
+        // This is safe because &PyAny has the same memory layout as *mut ffi::PyObject,
+        // and because tuples are immutable.
+        unsafe {
+            let ptr = self.as_ptr() as *mut ffi::PyTupleObject;
+            let slice = std::slice::from_raw_parts((*ptr).ob_item.as_ptr(), self.len());
+            &*(slice as *const [*mut ffi::PyObject] as *const [PyAny<'py>])
+        }
+    }
+
+    /// Determines if self contains `value`.
+    ///
+    /// This is equivalent to the Python expression `value in self`.
+    #[inline]
+    pub fn contains<V>(&self, value: V) -> PyResult<bool>
+    where
+        V: ToPyObject,
+    {
+        self.as_sequence().contains(value)
+    }
+
+    /// Returns the first index `i` for which `self[i] == value`.
+    ///
+    /// This is equivalent to the Python expression `self.index(value)`.
+    #[inline]
+    pub fn index<V>(&self, value: V) -> PyResult<usize>
+    where
+        V: ToPyObject,
+    {
+        self.as_sequence().index(value)
+    }
+
+    /// Returns an iterator over the tuple items.
+    pub fn iter(&self) -> PyTupleIterator<'py> {
+        PyTupleIterator {
+            tuple: self.clone(),
+            index: 0,
+            length: self.len(),
+        }
+    }
+
+    /// Create a new `PyTuple` from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be an owned non-null pointer to a PyTuple object.
+    #[inline]
+    pub(crate) unsafe fn from_owned_ptr_or_err(
+        py: Python<'py>,
+        ptr: *mut ffi::PyObject,
+    ) -> PyResult<Self> {
+        PyAny::from_owned_ptr_or_err(py, ptr).map(Self)
+    }
+
+    /// Create a new `PyTuple` from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be an owned non-null pointer to a PyTuple object.
+    #[inline]
+    pub(crate) unsafe fn from_owned_ptr_or_panic(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
+        Self(PyAny::from_owned_ptr_or_panic(py, ptr))
+    }
+}
+
+// FIXME: to address before long
+// index_impls!(PyTuple, "tuple", PyTuple::len, PyTuple::get_slice);
+
+/// Used by `PyTuple::iter()`.
+pub struct PyTupleIterator<'py> {
+    tuple: PyTuple<'py>,
+    index: usize,
+    length: usize,
+}
+
+impl<'py> Iterator for PyTupleIterator<'py> {
+    type Item = PyAny<'py>;
+
+    #[inline]
+    fn next(&mut self) -> Option<PyAny<'py>> {
+        if self.index < self.length {
+            #[cfg(any(Py_LIMITED_API, PyPy))]
+            let item = self.tuple.get_item(self.index).expect("tuple.get failed");
+            #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+            let item = unsafe { self.tuple.get_item_unchecked(self.index) };
+            self.index += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl<'a> ExactSizeIterator for PyTupleIterator<'a> {
+    fn len(&self) -> usize {
+        self.length.saturating_sub(self.index)
+    }
+}
+
+impl<'py> IntoIterator for PyTuple<'py> {
+    type Item = PyAny<'py>;
+    type IntoIter = PyTupleIterator<'py>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[cold]
+fn wrong_tuple_length(t: &PyTuple<'_>, expected_length: usize) -> PyErr {
+    let msg = format!(
+        "expected tuple of length {}, but got tuple of length {}",
+        expected_length,
+        t.len()
+    );
+    exceptions::PyValueError::new_err(msg)
+}
+
+// macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+} => {
+//     impl <$($T: ToPyObject),+> ToPyObject for ($($T,)+) {
+//         fn to_object(&self, py: Python<'_>) -> PyObject {
+//             unsafe {
+//                 let ptr = ffi::PyTuple_New($length);
+//                 let ret = PyObject::from_owned_ptr(py, ptr);
+//                 $(ffi::PyTuple_SetItem(ptr, $n, self.$n.to_object(py).into_ptr());)+
+//                 ret
+//             }
+//         }
+//     }
+//     impl <$($T: IntoPy<PyObject>),+> IntoPy<PyObject> for ($($T,)+) {
+//         fn into_py(self, py: Python<'_>) -> PyObject {
+//             unsafe {
+//                 let ptr = ffi::PyTuple_New($length);
+//                 let ret =  PyObject::from_owned_ptr(py, ptr);
+//                 $(ffi::PyTuple_SetItem(ptr, $n, self.$n.into_py(py).into_ptr());)+
+//                ret
+//             }
+//         }
+
+//         #[cfg(feature = "experimental-inspect")]
+// fn type_output() -> TypeInfo {
+//             TypeInfo::Tuple(Some(vec![$( $T::type_output() ),+]))
+//         }
+//     }
+
+//     impl <$($T: IntoPy<PyObject>),+> IntoPy<Py<PyTuple>> for ($($T,)+) {
+//         fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
+//             unsafe {
+//                 let ptr = ffi::PyTuple_New($length);
+//                 let ret = Py::from_owned_ptr(py, ptr);
+//                 $(ffi::PyTuple_SetItem(ptr, $n, self.$n.into_py(py).into_ptr());)+
+//                 ret
+//             }
+//         }
+
+//         #[cfg(feature = "experimental-inspect")]
+//         fn type_output() -> TypeInfo {
+//             TypeInfo::Tuple(Some(vec![$( $T::type_output() ),+]))
+//         }
+//     }
+
+//     impl<'s, $($T: FromPyObject<'s>),+> FromPyObject<'s> for ($($T,)+) {
+//         fn extract(obj: &'s PyAny) -> PyResult<Self>
+//         {
+//             let t: &PyTuple = obj.downcast()?;
+//             if t.len() == $length {
+//                 #[cfg(any(Py_LIMITED_API, PyPy))]
+//                 return Ok(($(t.get_item($n)?.extract::<$T>()?,)+));
+
+//                 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+//                 unsafe {return Ok(($(t.get_item_unchecked($n).extract::<$T>()?,)+));}
+//             } else {
+//                 Err(wrong_tuple_length(t, $length))
+//             }
+//         }
+
+//         #[cfg(feature = "experimental-inspect")]
+// fn type_input() -> TypeInfo {
+//             TypeInfo::Tuple(Some(vec![$( $T::type_input() ),+]))
+//         }
+//     }
+// });
+
+// tuple_conversion!(1, (ref0, 0, T0));
+// tuple_conversion!(2, (ref0, 0, T0), (ref1, 1, T1));
+// tuple_conversion!(3, (ref0, 0, T0), (ref1, 1, T1), (ref2, 2, T2));
+// tuple_conversion!(
+//     4,
+//     (ref0, 0, T0),
+//     (ref1, 1, T1),
+//     (ref2, 2, T2),
+//     (ref3, 3, T3)
+// );
+// tuple_conversion!(
+//     5,
+//     (ref0, 0, T0),
+//     (ref1, 1, T1),
+//     (ref2, 2, T2),
+//     (ref3, 3, T3),
+//     (ref4, 4, T4)
+// );
+// tuple_conversion!(
+//     6,
+//     (ref0, 0, T0),
+//     (ref1, 1, T1),
+//     (ref2, 2, T2),
+//     (ref3, 3, T3),
+//     (ref4, 4, T4),
+//     (ref5, 5, T5)
+// );
+// tuple_conversion!(
+//     7,
+//     (ref0, 0, T0),
+//     (ref1, 1, T1),
+//     (ref2, 2, T2),
+//     (ref3, 3, T3),
+//     (ref4, 4, T4),
+//     (ref5, 5, T5),
+//     (ref6, 6, T6)
+// );
+// tuple_conversion!(
+//     8,
+//     (ref0, 0, T0),
+//     (ref1, 1, T1),
+//     (ref2, 2, T2),
+//     (ref3, 3, T3),
+//     (ref4, 4, T4),
+//     (ref5, 5, T5),
+//     (ref6, 6, T6),
+//     (ref7, 7, T7)
+// );
+// tuple_conversion!(
+//     9,
+//     (ref0, 0, T0),
+//     (ref1, 1, T1),
+//     (ref2, 2, T2),
+//     (ref3, 3, T3),
+//     (ref4, 4, T4),
+//     (ref5, 5, T5),
+//     (ref6, 6, T6),
+//     (ref7, 7, T7),
+//     (ref8, 8, T8)
+// );
+// tuple_conversion!(
+//     10,
+//     (ref0, 0, T0),
+//     (ref1, 1, T1),
+//     (ref2, 2, T2),
+//     (ref3, 3, T3),
+//     (ref4, 4, T4),
+//     (ref5, 5, T5),
+//     (ref6, 6, T6),
+//     (ref7, 7, T7),
+//     (ref8, 8, T8),
+//     (ref9, 9, T9)
+// );
+// tuple_conversion!(
+//     11,
+//     (ref0, 0, T0),
+//     (ref1, 1, T1),
+//     (ref2, 2, T2),
+//     (ref3, 3, T3),
+//     (ref4, 4, T4),
+//     (ref5, 5, T5),
+//     (ref6, 6, T6),
+//     (ref7, 7, T7),
+//     (ref8, 8, T8),
+//     (ref9, 9, T9),
+//     (ref10, 10, T10)
+// );
+
+// tuple_conversion!(
+//     12,
+//     (ref0, 0, T0),
+//     (ref1, 1, T1),
+//     (ref2, 2, T2),
+//     (ref3, 3, T3),
+//     (ref4, 4, T4),
+//     (ref5, 5, T5),
+//     (ref6, 6, T6),
+//     (ref7, 7, T7),
+//     (ref8, 8, T8),
+//     (ref9, 9, T9),
+//     (ref10, 10, T10),
+//     (ref11, 11, T11)
+// );
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::types::{PyAny, PyTuple};
+//     use crate::{Python, ToPyObject};
+//     use std::collections::HashSet;
+
+//     #[test]
+//     fn test_new() {
+//         Python::with_gil(|py| {
+//             let ob = PyTuple::new(py, &[1, 2, 3]);
+//             assert_eq!(3, ob.len());
+//             let ob: &PyAny = ob.into();
+//             assert_eq!((1, 2, 3), ob.extract().unwrap());
+
+//             let mut map = HashSet::new();
+//             map.insert(1);
+//             map.insert(2);
+//             PyTuple::new(py, &map);
+//         });
+//     }
+
+//     #[test]
+//     fn test_len() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             assert_eq!(3, tuple.len());
+//             let ob: &PyAny = tuple.into();
+//             assert_eq!((1, 2, 3), ob.extract().unwrap());
+//         });
+//     }
+
+//     #[test]
+//     fn test_slice() {
+//         Python::with_gil(|py| {
+//             let tup = PyTuple::new(py, &[2, 3, 5, 7]);
+//             let slice = tup.get_slice(1, 3);
+//             assert_eq!(2, slice.len());
+//             let slice = tup.get_slice(1, 7);
+//             assert_eq!(3, slice.len());
+//         });
+//     }
+
+//     #[test]
+//     fn test_iter() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             assert_eq!(3, tuple.len());
+//             let mut iter = tuple.iter();
+
+//             assert_eq!(iter.size_hint(), (3, Some(3)));
+
+//             assert_eq!(1_i32, iter.next().unwrap().extract::<'_, i32>().unwrap());
+//             assert_eq!(iter.size_hint(), (2, Some(2)));
+
+//             assert_eq!(2_i32, iter.next().unwrap().extract::<'_, i32>().unwrap());
+//             assert_eq!(iter.size_hint(), (1, Some(1)));
+
+//             assert_eq!(3_i32, iter.next().unwrap().extract::<'_, i32>().unwrap());
+//             assert_eq!(iter.size_hint(), (0, Some(0)));
+//         });
+//     }
+
+//     #[test]
+//     fn test_into_iter() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             assert_eq!(3, tuple.len());
+
+//             for (i, item) in tuple.iter().enumerate() {
+//                 assert_eq!(i + 1, item.extract::<'_, usize>().unwrap());
+//             }
+//         });
+//     }
+
+//     #[test]
+//     #[cfg(not(Py_LIMITED_API))]
+//     fn test_as_slice() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+
+//             let slice = tuple.as_slice();
+//             assert_eq!(3, slice.len());
+//             assert_eq!(1_i32, slice[0].extract::<'_, i32>().unwrap());
+//             assert_eq!(2_i32, slice[1].extract::<'_, i32>().unwrap());
+//             assert_eq!(3_i32, slice[2].extract::<'_, i32>().unwrap());
+//         });
+//     }
+
+//     #[test]
+//     fn test_tuple_lengths_up_to_12() {
+//         Python::with_gil(|py| {
+//             let t0 = (0,).to_object(py);
+//             let t1 = (0, 1).to_object(py);
+//             let t2 = (0, 1, 2).to_object(py);
+//             let t3 = (0, 1, 2, 3).to_object(py);
+//             let t4 = (0, 1, 2, 3, 4).to_object(py);
+//             let t5 = (0, 1, 2, 3, 4, 5).to_object(py);
+//             let t6 = (0, 1, 2, 3, 4, 5, 6).to_object(py);
+//             let t7 = (0, 1, 2, 3, 4, 5, 6, 7).to_object(py);
+//             let t8 = (0, 1, 2, 3, 4, 5, 6, 7, 8).to_object(py);
+//             let t9 = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9).to_object(py);
+//             let t10 = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10).to_object(py);
+//             let t11 = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11).to_object(py);
+
+//             assert_eq!(t0.extract::<(i32,)>(py).unwrap(), (0,));
+//             assert_eq!(t1.extract::<(i32, i32)>(py).unwrap(), (0, 1,));
+//             assert_eq!(t2.extract::<(i32, i32, i32)>(py).unwrap(), (0, 1, 2,));
+//             assert_eq!(
+//                 t3.extract::<(i32, i32, i32, i32,)>(py).unwrap(),
+//                 (0, 1, 2, 3,)
+//             );
+//             assert_eq!(
+//                 t4.extract::<(i32, i32, i32, i32, i32,)>(py).unwrap(),
+//                 (0, 1, 2, 3, 4,)
+//             );
+//             assert_eq!(
+//                 t5.extract::<(i32, i32, i32, i32, i32, i32,)>(py).unwrap(),
+//                 (0, 1, 2, 3, 4, 5,)
+//             );
+//             assert_eq!(
+//                 t6.extract::<(i32, i32, i32, i32, i32, i32, i32,)>(py)
+//                     .unwrap(),
+//                 (0, 1, 2, 3, 4, 5, 6,)
+//             );
+//             assert_eq!(
+//                 t7.extract::<(i32, i32, i32, i32, i32, i32, i32, i32,)>(py)
+//                     .unwrap(),
+//                 (0, 1, 2, 3, 4, 5, 6, 7,)
+//             );
+//             assert_eq!(
+//                 t8.extract::<(i32, i32, i32, i32, i32, i32, i32, i32, i32,)>(py)
+//                     .unwrap(),
+//                 (0, 1, 2, 3, 4, 5, 6, 7, 8,)
+//             );
+//             assert_eq!(
+//                 t9.extract::<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32,)>(py)
+//                     .unwrap(),
+//                 (0, 1, 2, 3, 4, 5, 6, 7, 8, 9,)
+//             );
+//             assert_eq!(
+//                 t10.extract::<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32,)>(py)
+//                     .unwrap(),
+//                 (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,)
+//             );
+//             assert_eq!(
+//                 t11.extract::<(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32,)>(py)
+//                     .unwrap(),
+//                 (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,)
+//             );
+//         })
+//     }
+
+//     #[test]
+//     fn test_tuple_get_item_invalid_index() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             let obj = tuple.get_item(5);
+//             assert!(obj.is_err());
+//             assert_eq!(
+//                 obj.unwrap_err().to_string(),
+//                 "IndexError: tuple index out of range"
+//             );
+//         });
+//     }
+
+//     #[test]
+//     fn test_tuple_get_item_sanity() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             let obj = tuple.get_item(0);
+//             assert_eq!(obj.unwrap().extract::<i32>().unwrap(), 1);
+//         });
+//     }
+
+//     #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+//     #[test]
+//     fn test_tuple_get_item_unchecked_sanity() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             let obj = unsafe { tuple.get_item_unchecked(0) };
+//             assert_eq!(obj.extract::<i32>().unwrap(), 1);
+//         });
+//     }
+
+//     #[test]
+//     fn test_tuple_index_trait() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             assert_eq!(1, tuple[0].extract::<i32>().unwrap());
+//             assert_eq!(2, tuple[1].extract::<i32>().unwrap());
+//             assert_eq!(3, tuple[2].extract::<i32>().unwrap());
+//         });
+//     }
+
+//     #[test]
+//     #[should_panic]
+//     fn test_tuple_index_trait_panic() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             let _ = &tuple[7];
+//         });
+//     }
+
+//     #[test]
+//     fn test_tuple_index_trait_ranges() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             assert_eq!(vec![2, 3], tuple[1..3].extract::<Vec<i32>>().unwrap());
+//             assert_eq!(
+//                 Vec::<i32>::new(),
+//                 tuple[3..3].extract::<Vec<i32>>().unwrap()
+//             );
+//             assert_eq!(vec![2, 3], tuple[1..].extract::<Vec<i32>>().unwrap());
+//             assert_eq!(Vec::<i32>::new(), tuple[3..].extract::<Vec<i32>>().unwrap());
+//             assert_eq!(vec![1, 2, 3], tuple[..].extract::<Vec<i32>>().unwrap());
+//             assert_eq!(vec![2, 3], tuple[1..=2].extract::<Vec<i32>>().unwrap());
+//             assert_eq!(vec![1, 2], tuple[..2].extract::<Vec<i32>>().unwrap());
+//             assert_eq!(vec![1, 2], tuple[..=1].extract::<Vec<i32>>().unwrap());
+//         })
+//     }
+
+//     #[test]
+//     #[should_panic = "range start index 5 out of range for tuple of length 3"]
+//     fn test_tuple_index_trait_range_panic_start() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             tuple[5..10].extract::<Vec<i32>>().unwrap();
+//         })
+//     }
+
+//     #[test]
+//     #[should_panic = "range end index 10 out of range for tuple of length 3"]
+//     fn test_tuple_index_trait_range_panic_end() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             tuple[1..10].extract::<Vec<i32>>().unwrap();
+//         })
+//     }
+
+//     #[test]
+//     #[should_panic = "slice index starts at 2 but ends at 1"]
+//     fn test_tuple_index_trait_range_panic_wrong_order() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             #[allow(clippy::reversed_empty_ranges)]
+//             tuple[2..1].extract::<Vec<i32>>().unwrap();
+//         })
+//     }
+
+//     #[test]
+//     #[should_panic = "range start index 8 out of range for tuple of length 3"]
+//     fn test_tuple_index_trait_range_from_panic() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 2, 3).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             tuple[8..].extract::<Vec<i32>>().unwrap();
+//         })
+//     }
+
+//     #[test]
+//     fn test_tuple_contains() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 1, 2, 3, 5, 8).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             assert_eq!(6, tuple.len());
+
+//             let bad_needle = 7i32.to_object(py);
+//             assert!(!tuple.contains(&bad_needle).unwrap());
+
+//             let good_needle = 8i32.to_object(py);
+//             assert!(tuple.contains(&good_needle).unwrap());
+
+//             let type_coerced_needle = 8f32.to_object(py);
+//             assert!(tuple.contains(&type_coerced_needle).unwrap());
+//         });
+//     }
+
+//     #[test]
+//     fn test_tuple_index() {
+//         Python::with_gil(|py| {
+//             let ob = (1, 1, 2, 3, 5, 8).to_object(py);
+//             let tuple: &PyTuple = ob.downcast(py).unwrap();
+//             assert_eq!(0, tuple.index(1i32).unwrap());
+//             assert_eq!(2, tuple.index(2i32).unwrap());
+//             assert_eq!(3, tuple.index(3i32).unwrap());
+//             assert_eq!(4, tuple.index(5i32).unwrap());
+//             assert_eq!(5, tuple.index(8i32).unwrap());
+//             assert!(tuple.index(42i32).is_err());
+//         });
+//     }
+
+//     use std::ops::Range;
+
+//     // An iterator that lies about its `ExactSizeIterator` implementation.
+//     // See https://github.com/PyO3/pyo3/issues/2118
+//     struct FaultyIter(Range<usize>, usize);
+
+//     impl Iterator for FaultyIter {
+//         type Item = usize;
+
+//         fn next(&mut self) -> Option<Self::Item> {
+//             self.0.next()
+//         }
+//     }
+
+//     impl ExactSizeIterator for FaultyIter {
+//         fn len(&self) -> usize {
+//             self.1
+//         }
+//     }
+
+//     #[test]
+//     #[should_panic(
+//         expected = "Attempted to create PyTuple but `elements` was larger than reported by its `ExactSizeIterator` implementation."
+//     )]
+//     fn too_long_iterator() {
+//         Python::with_gil(|py| {
+//             let iter = FaultyIter(0..usize::MAX, 73);
+//             let _tuple = PyTuple::new(py, iter);
+//         })
+//     }
+
+//     #[test]
+//     #[should_panic(
+//         expected = "Attempted to create PyTuple but `elements` was smaller than reported by its `ExactSizeIterator` implementation."
+//     )]
+//     fn too_short_iterator() {
+//         Python::with_gil(|py| {
+//             let iter = FaultyIter(0..35, 73);
+//             let _tuple = PyTuple::new(py, iter);
+//         })
+//     }
+
+//     #[test]
+//     #[should_panic(
+//         expected = "out of range integral type conversion attempted on `elements.len()`"
+//     )]
+//     fn overflowing_size() {
+//         Python::with_gil(|py| {
+//             let iter = FaultyIter(0..0, usize::MAX);
+
+//             let _tuple = PyTuple::new(py, iter);
+//         })
+//     }
+
+//     #[cfg(feature = "macros")]
+//     #[test]
+//     fn bad_clone_mem_leaks() {
+//         use crate::{IntoPy, Py};
+//         use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+//         static NEEDS_DESTRUCTING_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+//         #[crate::pyclass]
+//         #[pyo3(crate = "crate")]
+//         struct Bad(usize);
+
+//         impl Clone for Bad {
+//             fn clone(&self) -> Self {
+//                 if self.0 == 42 {
+//                     panic!()
+//                 };
+//                 NEEDS_DESTRUCTING_COUNT.fetch_add(1, SeqCst);
+
+//                 Bad(self.0)
+//             }
+//         }
+
+//         impl Drop for Bad {
+//             fn drop(&mut self) {
+//                 NEEDS_DESTRUCTING_COUNT.fetch_sub(1, SeqCst);
+//             }
+//         }
+
+//         impl ToPyObject for Bad {
+//             fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
+//                 self.to_owned().into_py(py)
+//             }
+//         }
+
+//         struct FaultyIter(Range<usize>, usize);
+
+//         impl Iterator for FaultyIter {
+//             type Item = Bad;
+
+//             fn next(&mut self) -> Option<Self::Item> {
+//                 self.0.next().map(|i| {
+//                     NEEDS_DESTRUCTING_COUNT.fetch_add(1, SeqCst);
+//                     Bad(i)
+//                 })
+//             }
+//         }
+
+//         impl ExactSizeIterator for FaultyIter {
+//             fn len(&self) -> usize {
+//                 self.1
+//             }
+//         }
+
+//         Python::with_gil(|py| {
+//             let _ = std::panic::catch_unwind(|| {
+//                 let iter = FaultyIter(0..50, 50);
+//                 let _tuple = PyTuple::new(py, iter);
+//             });
+//         });
+
+//         assert_eq!(
+//             NEEDS_DESTRUCTING_COUNT.load(SeqCst),
+//             0,
+//             "Some destructors did not run"
+//         );
+//     }
+
+//     #[cfg(feature = "macros")]
+//     #[test]
+//     fn bad_clone_mem_leaks_2() {
+//         use crate::{IntoPy, Py};
+//         use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+
+//         static NEEDS_DESTRUCTING_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+//         #[crate::pyclass]
+//         #[pyo3(crate = "crate")]
+//         struct Bad(usize);
+
+//         impl Clone for Bad {
+//             fn clone(&self) -> Self {
+//                 if self.0 == 3 {
+//                     // This panic should not lead to a memory leak
+//                     panic!()
+//                 };
+//                 NEEDS_DESTRUCTING_COUNT.fetch_add(1, SeqCst);
+
+//                 Bad(self.0)
+//             }
+//         }
+
+//         impl Drop for Bad {
+//             fn drop(&mut self) {
+//                 NEEDS_DESTRUCTING_COUNT.fetch_sub(1, SeqCst);
+//             }
+//         }
+
+//         impl ToPyObject for Bad {
+//             fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
+//                 self.to_owned().into_py(py)
+//             }
+//         }
+
+//         let s = (Bad(1), Bad(2), Bad(3), Bad(4));
+//         NEEDS_DESTRUCTING_COUNT.store(4, SeqCst);
+//         Python::with_gil(|py| {
+//             let _ = std::panic::catch_unwind(|| {
+//                 let _tuple: Py<PyAny> = s.to_object(py);
+//             });
+//         });
+//         drop(s);
+
+//         assert_eq!(
+//             NEEDS_DESTRUCTING_COUNT.load(SeqCst),
+//             0,
+//             "Some destructors did not run"
+//         );
+//     }
+// }

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -860,11 +860,15 @@ impl<T: Send> PyClassThreadChecker<T> for ThreadCheckerStub<T> {
     private_impl! {}
 }
 
-impl<T: PyNativeType> PyClassThreadChecker<T> for ThreadCheckerStub<crate::PyObject> {
+/// Stub checker for `Send` types.
+#[doc(hidden)]
+pub struct NativeTypeThreadCheckerStub;
+
+impl<T> PyClassThreadChecker<T> for NativeTypeThreadCheckerStub {
     fn ensure(&self) {}
     #[inline]
     fn new() -> Self {
-        ThreadCheckerStub(PhantomData)
+        NativeTypeThreadCheckerStub
     }
     private_impl! {}
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1087,6 +1087,17 @@ impl PyObject {
     {
         self.downcast(py)
     }
+
+    #[inline]
+    pub(crate) fn downcast2<'a, 'py: 'a, T>(
+        &'a self,
+        _py: Python<'py>,
+    ) -> Result<&'a T, PyDowncastError<'_>>
+    where
+        T: crate::experimental::PyTryFrom<'py>,
+    {
+        <T as crate::experimental::PyTryFrom<'py>>::try_from(unsafe { std::mem::transmute(self) })
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,7 @@ mod conversions;
 pub mod derive_utils;
 mod err;
 pub mod exceptions;
+pub mod experimental;
 pub mod ffi;
 mod gil;
 #[doc(hidden)]
@@ -419,6 +420,9 @@ pub mod pyclass_init;
 pub mod type_object;
 pub mod types;
 mod version;
+
+#[doc(hidden)]
+pub use pyo3_macros;
 
 pub use crate::conversions::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,7 +305,7 @@ pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
 #[cfg(not(PyPy))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
 pub use crate::gil::{GILGuard, GILPool};
-pub use crate::instance::{Py, PyNativeType, PyObject};
+pub use crate::instance::{HasPyGilBoundRef, Py, PyNativeType, PyObject};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};
 pub use crate::pyclass::PyClass;

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -1,7 +1,7 @@
 //! `PyClass` and related traits.
 use crate::{
-    callback::IntoPyCallbackOutput, ffi, impl_::pyclass::PyClassImpl, IntoPy, IntoPyPointer,
-    PyCell, PyObject, PyResult, PyTypeInfo, Python,
+    callback::IntoPyCallbackOutput, ffi, impl_::pyclass::PyClassImpl, HasPyGilBoundRef, IntoPy,
+    IntoPyPointer, PyCell, PyObject, PyResult, PyTypeInfo, Python,
 };
 use std::{cmp::Ordering, os::raw::c_int};
 
@@ -16,7 +16,7 @@ pub use self::gc::{PyTraverseError, PyVisit};
 /// The `#[pyclass]` attribute implements this trait for your Rust struct -
 /// you shouldn't implement this trait directly.
 pub trait PyClass:
-    PyTypeInfo<AsRefTarget = PyCell<Self>> + PyClassImpl<Layout = PyCell<Self>>
+    PyTypeInfo + PyClassImpl<Layout = PyCell<Self>> + HasPyGilBoundRef<AsRefTarget = PyCell<Self>>
 {
     /// Whether the pyclass is frozen.
     ///

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -2,7 +2,7 @@
 //! Python type object information
 
 use crate::types::{PyAny, PyType};
-use crate::{ffi, AsPyPointer, PyNativeType, Python};
+use crate::{ffi, AsPyPointer, Python};
 
 /// `T: PyLayout<U>` represents that `T` is a concrete representation of `U` in the Python heap.
 /// E.g., `PyCell` is a concrete representation of all `pyclass`es, and `ffi::PyObject`
@@ -39,9 +39,6 @@ pub unsafe trait PyTypeInfo: Sized {
 
     /// Module name, if any.
     const MODULE: Option<&'static str>;
-
-    /// Utility type to make Py::as_ref work.
-    type AsRefTarget: PyNativeType;
 
     /// Returns the PyTypeObject instance for this type.
     fn type_object_raw(py: Python<'_>) -> *mut ffi::PyTypeObject;

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -2,7 +2,7 @@
 //
 // based on Daniel Grunwald's https://github.com/dgrunwald/rust-cpython
 
-use crate::{ffi, AsPyPointer, IntoPyPointer, Py, PyAny, PyErr, PyNativeType, PyResult, Python};
+use crate::{ffi, AsPyPointer, PyAny, PyErr, PyResult, Python};
 use crate::{PyDowncastError, PyTryFrom};
 
 /// A Python iterator object.
@@ -82,22 +82,6 @@ impl<'v> PyTryFrom<'v> for PyIterator {
     unsafe fn try_from_unchecked<V: Into<&'v PyAny>>(value: V) -> &'v PyIterator {
         let ptr = value.into() as *const _ as *const PyIterator;
         &*ptr
-    }
-}
-
-impl Py<PyIterator> {
-    /// Borrows a GIL-bound reference to the PyIterator. By binding to the GIL lifetime, this
-    /// allows the GIL-bound reference to not require `Python` for any of its methods.
-    pub fn as_ref<'py>(&'py self, _py: Python<'py>) -> &'py PyIterator {
-        let any = self.as_ptr() as *const PyAny;
-        unsafe { PyNativeType::unchecked_downcast(&*any) }
-    }
-
-    /// Similar to [`as_ref`](#method.as_ref), and also consumes this `Py` and registers the
-    /// Python object reference in PyO3's object storage. The reference count for the Python
-    /// object will not be decreased until the GIL lifetime ends.
-    pub fn into_ref(self, py: Python<'_>) -> &PyIterator {
-        unsafe { py.from_owned_ptr(self.into_ptr()) }
     }
 }
 

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -4,9 +4,7 @@ use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::once_cell::GILOnceCell;
 use crate::type_object::PyTypeInfo;
 use crate::types::{PyAny, PySequence, PyType};
-use crate::{
-    ffi, AsPyPointer, IntoPy, IntoPyPointer, Py, PyNativeType, PyTryFrom, Python, ToPyObject,
-};
+use crate::{ffi, AsPyPointer, IntoPy, Py, PyNativeType, PyTryFrom, Python, ToPyObject};
 
 static MAPPING_ABC: GILOnceCell<PyResult<Py<PyType>>> = GILOnceCell::new();
 
@@ -158,22 +156,6 @@ impl<'v> PyTryFrom<'v> for PyMapping {
     unsafe fn try_from_unchecked<V: Into<&'v PyAny>>(value: V) -> &'v PyMapping {
         let ptr = value.into() as *const _ as *const PyMapping;
         &*ptr
-    }
-}
-
-impl Py<PyMapping> {
-    /// Borrows a GIL-bound reference to the PyMapping. By binding to the GIL lifetime, this
-    /// allows the GIL-bound reference to not require `Python` for any of its methods.
-    pub fn as_ref<'py>(&'py self, _py: Python<'py>) -> &'py PyMapping {
-        let any = self.as_ptr() as *const PyAny;
-        unsafe { PyNativeType::unchecked_downcast(&*any) }
-    }
-
-    /// Similar to [`as_ref`](#method.as_ref), and also consumes this `Py` and registers the
-    /// Python object reference in PyO3's object storage. The reference count for the Python
-    /// object will not be decreased until the GIL lifetime ends.
-    pub fn into_ref(self, py: Python<'_>) -> &PyMapping {
-        unsafe { py.from_owned_ptr(self.into_ptr()) }
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -244,7 +244,7 @@ macro_rules! pyobject_native_type_sized {
         impl<$($generics,)*> $crate::impl_::pyclass::PyClassBaseType for $name {
             type LayoutAsBase = $crate::pycell::PyCellBase<$layout>;
             type BaseNativeType = $name;
-            type ThreadChecker = $crate::impl_::pyclass::ThreadCheckerStub<$crate::PyObject>;
+            type ThreadChecker = $crate::impl_::pyclass::NativeTypeThreadCheckerStub;
             type Initializer = $crate::pyclass_init::PyNativeTypeInitializer<Self>;
             type PyClassMutability = $crate::pycell::impl_::ImmutableClass;
         }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -86,6 +86,10 @@ macro_rules! pyobject_native_type_base(
     ($name:ty $(;$generics:ident)* ) => {
         unsafe impl<$($generics,)*> $crate::PyNativeType for $name {}
 
+        unsafe impl $crate::HasPyGilBoundRef for $name {
+            type AsRefTarget = Self;
+        }
+
         impl<$($generics,)*> ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>)
                    -> ::std::result::Result<(), ::std::fmt::Error>
@@ -177,8 +181,6 @@ macro_rules! pyobject_native_type_named (
 macro_rules! pyobject_native_type_info(
     ($name:ty, $typeobject:expr, $module:expr $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
         unsafe impl<$($generics,)*> $crate::type_object::PyTypeInfo for $name {
-            type AsRefTarget = Self;
-
             const NAME: &'static str = stringify!($name);
             const MODULE: ::std::option::Option<&'static str> = $module;
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -8,7 +8,7 @@ use crate::once_cell::GILOnceCell;
 use crate::type_object::PyTypeInfo;
 use crate::types::{PyAny, PyList, PyString, PyTuple, PyType};
 use crate::{ffi, PyNativeType, ToPyObject};
-use crate::{AsPyPointer, IntoPy, IntoPyPointer, Py, Python};
+use crate::{AsPyPointer, IntoPy, Py, Python};
 use crate::{FromPyObject, PyTryFrom};
 
 static SEQUENCE_ABC: GILOnceCell<PyResult<Py<PyType>>> = GILOnceCell::new();
@@ -356,32 +356,6 @@ impl<'v> PyTryFrom<'v> for PySequence {
     unsafe fn try_from_unchecked<V: Into<&'v PyAny>>(value: V) -> &'v PySequence {
         let ptr = value.into() as *const _ as *const PySequence;
         &*ptr
-    }
-}
-
-impl Py<PySequence> {
-    /// Borrows a GIL-bound reference to the PySequence. By binding to the GIL lifetime, this
-    /// allows the GIL-bound reference to not require `Python` for any of its methods.
-    ///
-    /// ```
-    /// # use pyo3::prelude::*;
-    /// # use pyo3::types::{PyList, PySequence};
-    /// # Python::with_gil(|py| {
-    /// let seq: Py<PySequence> = PyList::empty(py).as_sequence().into();
-    /// let seq: &PySequence = seq.as_ref(py);
-    /// assert_eq!(seq.len().unwrap(), 0);
-    /// # });
-    /// ```
-    pub fn as_ref<'py>(&'py self, _py: Python<'py>) -> &'py PySequence {
-        let any = self.as_ptr() as *const PyAny;
-        unsafe { PyNativeType::unchecked_downcast(&*any) }
-    }
-
-    /// Similar to [`as_ref`](#method.as_ref), and also consumes this `Py` and registers the
-    /// Python object reference in PyO3's object storage. The reference count for the Python
-    /// object will not be decreased until the GIL lifetime ends.
-    pub fn into_ref(self, py: Python<'_>) -> &PySequence {
-        unsafe { py.from_owned_ptr(self.into_ptr()) }
     }
 }
 


### PR DESCRIPTION
This is my leading proposal for how we might solve #1056 and remove the idea of the "pool" from the `Python` marker.

From my benchmarking here, this can net up to 30% wins in performance for PyO3 interactions with Python objects as well as avoid the memory growth related to the object pool. I rewrote the argument extraction logic using this new API to demonstrate the potential. Will post benchmarks below when I have a moment.

The fundamental idea is that the gil-bound reference types like `&'py PyAny` which frequently reside in the pool are replaced by `PyAny<'py>` owned types with a lifetime attached. They provide an almost identical API with the difference being ownership semantics which can essentially be thought of as `Rc`.

The new type is added as `pyo3::experimental::PyAny`, along with accompanying implementations of `PyDict` and `PyList`. We also need to have replacements of the existing conversion traits e.g. `pyo3::experimental::FromPyObject`.

What I'd like to do if we like this direction is to make `pyo3::experimental` a public API which we state is a possible future direction of PyO3 which we are using for research, so may change fast. Ideally users can import `pyo3::experimental::prelude::*` and just use the "new PyO3" without much challenge. Eventually we could make this `pyo3::v2::prelude::*` and then go through a deprecation / removal cycle of the old stuff. 

We can implement the bulk of PyO3 using the new API to learn about it and get the maximum performance speedup internally, though we have to be aware this does create quite a lot of maintenance overhead. 

There are downsides of adopting this new API (this list is incomplete and we can fill this out in this PR and eventually in the docs):
  - I think this might be harder for users to learn, because of the `PyAny<'py>` lifetime being attached everywhere.
  - By losing the pool there are a few edge cases where conversions are no longer possible. E.g. I think `&PyAny` -> `Vec<&str>` is unsupported because the `&str` needs to be owned by a Rust type. At the moment the intermediate `&PyString` references go in the pool.
    - Maybe we solve this in time.
  - *I don't have a perfect answer what to do with `Py<PyAny>` and friends for storage without lifetimes. `Py<PyAny<'static>>` is nonsensical because `'static` GIL lifetime is kinda meaningless.*
    - I am considering `PyDetachedAny`, `PyDetachedDict` etc as the types to replace `Py<PyAny>`, `Py<PyDict>` etc. I don't love this but maybe it's the best choice. Also with PEP 630 as a possible thing to aim for we probably want to be making static storage less ergonomic anyway.

Also the branch is currently out-of-date and unfinished, this is posted here to invite discussion. Sorry if you are reading the code 😆 

With apologies I have to dash now, will do my best to add and explain any thoughts here as questions come in.