### PR TITLE
add github merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
       # for bors try
       - trying
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Ref #3132 

I think this is all that is needed to start running CI on Github merge queues; I can then update the repository settings to use a merge queue if we want to give this a go?