### PR TITLE
ci: enable full builds with a label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       CARGO_BUILD_TARGET: ${{ matrix.platform.rust-target }}
 
   build-pr:
-    if: github.event_name == 'pull_request'
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-build-full') && github.event_name == 'pull_request' }}
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} rust-${{ matrix.rust }}
     needs: [fmt]
     uses: ./.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
             }
           ]
   build-full:
-    if: ${{ github.event_name != 'pull_request' && github.ref != 'refs/heads/main' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} rust-${{ matrix.rust }}
     needs: [fmt]
     uses: ./.github/workflows/build.yml


### PR DESCRIPTION
As a replacement for `bors try`, this PR adds a `CI-build-full` label which, when present, should trigger the full build instead of just the 3.11 runs.