### PR TITLE
ci: fail ffi-check on pypy failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
 
       - uses: dorny/paths-filter@v2
         # pypy 3.7 and 3.8 are not PEP 3123 compliant so fail checks here
-        if: ${{ inputs.rust == 'stable' && inputs.python-version != 'pypy-3.7' && inputs.python-version != 'pypy-3.8' }}
+        if: ${{ inputs.rust == 'stable' && inputs.python-version != 'pypy3.7' && inputs.python-version != 'pypy3.8' }}
         id: ffi-changes
         with:
           base: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
@@ -136,9 +136,9 @@ jobs:
 
       - name: Run pyo3-ffi-check
         run: nox -s ffi-check
-        # Allow failure on PyPy for now
-        continue-on-error: ${{ startsWith(inputs.python-version, 'pypy') }}
-        if: ${{ steps.ffi-changes.outputs.changed == 'true' && inputs.rust == 'stable' && inputs.python-version != 'pypy-3.7' && inputs.python-version != 'pypy-3.8' }}
+        # pypy 3.7 and 3.8 are not PEP 3123 compliant so fail checks here, nor
+        # is pypy 3.9 on windows
+        if: ${{ steps.ffi-changes.outputs.changed == 'true' && inputs.rust == 'stable' && inputs.python-version != 'pypy3.7' && inputs.python-version != 'pypy3.8' && !(inputs.python-version == 'pypy3.9' && contains(inputs.os, 'windows')) }}
 
 
       - name: Test cross compilation


### PR DESCRIPTION
To try and catch possible issues with upcoming PyPy 3.10 releases.