### PR TITLE
docs: remove unneeded cfg, fixup internal banner

### DIFF
--- a/.netlify/build.sh
+++ b/.netlify/build.sh
@@ -60,9 +60,7 @@ echo "<meta http-equiv=refresh content=0;url=pyo3/>" > netlify_build/main/doc/in
 
 ## Build internal docs
 
-echo "<div class='internal-banner' style='position:fixed; z-index: 99999; color:red;border:3px solid red;margin-left: auto; margin-right: auto; width: 430px;left:0;right: 0;'><div style='display: flex; align-items: center; justify-content: center;'> ⚠️ Internal Docs ⚠️ Not Public API 👉 <a href='https://pyo3.rs/main/doc/pyo3/index.html' style='color:red;text-decoration:underline;'>Official Docs Here</a></div></div>" > netlify_build/banner.html
-RUSTDOCFLAGS="--html-before-content netlify_build/banner.html" nox -s docs -- nightly internal
-rm netlify_build/banner.html
+nox -s docs -- nightly internal
 
 mkdir -p netlify_build/internal
 mv target/doc netlify_build/internal/

--- a/.netlify/internal_banner.html
+++ b/.netlify/internal_banner.html
@@ -1,0 +1,47 @@
+<div id='pyo3-internal-banner'>
+    <div style="white-space: nowrap;">
+        ⚠️ Internal Docs ⚠️ Not Public API 👉
+        <a href='https://pyo3.rs/main/doc/pyo3/index.html' style='color:red;text-decoration:underline;'>
+            Official Docs Here
+        </a>
+    </div>
+    <style id="pyo3-noscript-style">
+        body {
+            padding-top: 2em;
+        }
+    </style>
+    <style>
+        #pyo3-internal-banner {
+            position: fixed;
+            display: flex;
+            align-items: center;
+            justify-content:
+                center;
+            z-index: 99999;
+            color: red;
+            left: 0;
+            right: 0;
+            top: 0;
+            height: 2em;
+            border: 3px solid red;
+            width: 100%;
+            overflow-x: hidden;
+            background-color: var(--target-background-color);
+        }
+
+        @media (max-width: 700px) {
+            #pyo3-internal-banner {
+                top: 50px;
+                margin-bottom: 10px;
+            }
+        }
+    </style>
+</div>
+<script>
+    // when javascript is active, splice the banner into a "sticky" location
+    // inside the doc body for best appearance
+    banner = document.getElementById("pyo3-internal-banner")
+    banner.style.position = "sticky"
+    document.getElementsByTagName("main")[0].prepend(banner)
+    document.getElementById("pyo3-noscript-style").remove()
+</script>

--- a/noxfile.py
+++ b/noxfile.py
@@ -305,6 +305,7 @@ def docs(session: nox.Session) -> None:
     if "nightly" in session.posargs and "internal" in session.posargs:
         rustdoc_flags.append("--Z unstable-options")
         rustdoc_flags.append("--document-hidden-items")
+        rustdoc_flags.extend(("--html-after-content", ".netlify/internal_banner.html"))
         cargo_flags.append("--document-private-items")
     else:
         cargo_flags.extend(["--exclude=pyo3-macros", "--exclude=pyo3-macros-backend"])

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -75,9 +75,7 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies.pyo3-ffi]
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("version = \"", env!("CARGO_PKG_VERSION"),  "\"")))]
-#![cfg_attr(not(docsrs), doc = "version = \"*\"")]
+#![doc = concat!("version = \"", env!("CARGO_PKG_VERSION"),  "\"")]
 //! features = ["extension-module"]
 //! ```
 //!

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -212,7 +212,7 @@ pub trait ToPyObject {
 /// # }
 /// ```
 /// Python code will see this as any of the `int`, `string` or `None` objects.
-#[cfg_attr(docsrs, doc(alias = "IntoPyCallbackOutput"))]
+#[doc(alias = "IntoPyCallbackOutput")]
 pub trait IntoPy<T>: Sized {
     /// Performs the conversion.
     fn into_py(self, py: Python<'_>) -> T;

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -25,12 +25,7 @@
 //! [dependencies]
 //! ## change * to the version you want to use, ideally the latest.
 //! anyhow = "*"
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"anyhow\"] }")))]
-#![cfg_attr(
-    not(docsrs),
-    doc = "pyo3 = { version = \"*\", features = [\"anyhow\"] }"
-)]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"anyhow\"] }")]
 //! ```
 //!
 //! Note that you must use compatible versions of anyhow and PyO3.

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -14,12 +14,7 @@
 //! # change * to the latest versions
 //! pyo3 = { version = "*", features = ["chrono"] }
 //! chrono = "0.4"
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"chrono\"] }")))]
-#![cfg_attr(
-    not(docsrs),
-    doc = "pyo3 = { version = \"*\", features = [\"chrono\"] }"
-)]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"chrono\"] }")]
 //! ```
 //!
 //! Note that you must use compatible versions of chrono and PyO3.

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -24,9 +24,7 @@
 //! [dependencies]
 //! ## change * to the version you want to use, ideally the latest.
 //! eyre = "*"
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"eyre\"] }")))]
-#![cfg_attr(not(docsrs), doc = "pyo3 = { version = \"*\", features = [\"eyre\"] }")]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"eyre\"] }")]
 //! ```
 //!
 //! Note that you must use compatible versions of eyre and PyO3.

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -11,12 +11,7 @@
 //! [dependencies]
 //! # change * to the latest versions
 //! hashbrown = "*"
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"hashbrown\"] }")))]
-#![cfg_attr(
-    not(docsrs),
-    doc = "pyo3 = { version = \"*\", features = [\"hashbrown\"] }"
-)]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"hashbrown\"] }")]
 //! ```
 //!
 //! Note that you must use compatible versions of hashbrown and PyO3.

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -18,12 +18,7 @@
 //! [dependencies]
 //! # change * to the latest versions
 //! indexmap = "*"
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"indexmap\"] }")))]
-#![cfg_attr(
-    not(docsrs),
-    doc = "pyo3 = { version = \"*\", features = [\"indexmap\"] }"
-)]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"indexmap\"] }")]
 //! ```
 //!
 //! Note that you must use compatible versions of indexmap and PyO3.

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -10,12 +10,7 @@
 //! ```toml
 //! [dependencies]
 //! num-bigint = "*"
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"num-bigint\"] }")))]
-#![cfg_attr(
-    not(docsrs),
-    doc = "pyo3 = { version = \"*\", features = [\"num-bigint\"] }"
-)]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"num-bigint\"] }")]
 //! ```
 //!
 //! Note that you must use compatible versions of num-bigint and PyO3.

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -14,12 +14,7 @@
 //! [dependencies]
 //! # change * to the latest versions
 //! num-complex = "*"
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"num-complex\"] }")))]
-#![cfg_attr(
-    not(docsrs),
-    doc = "pyo3 = { version = \"*\", features = [\"num-complex\"] }"
-)]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"num-complex\"] }")]
 //! ```
 //!
 //! Note that you must use compatible versions of num-complex and PyO3.

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -9,13 +9,8 @@
 //!
 //! ```toml
 //! [dependencies]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"rust_decimal\"] }")]
 //! rust_decimal = "1.0"
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"rust_decimal\"] }")))]
-#![cfg_attr(
-    not(docsrs),
-    doc = "pyo3 = { version = ..., features = [\"rust_decimal\"] }"
-)]
 //! ```
 //!
 //! Note that you must use a compatible version of rust_decimal and PyO3.

--- a/src/conversions/serde.rs
+++ b/src/conversions/serde.rs
@@ -8,13 +8,8 @@
 //!
 //! ```toml
 //! [dependencies]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"serde\"] }")]
 //! serde = "1.0"
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"serde\"] }")))]
-#![cfg_attr(
-    not(docsrs),
-    doc = "pyo3 = { version = \"*\", features = [\"serde\"] }"
-)]
 //! ```
 
 use crate::{Py, PyAny, PyClass, Python};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,9 +151,7 @@
 //! crate-type = ["cdylib"]
 //!
 //! [dependencies.pyo3]
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("version = \"", env!("CARGO_PKG_VERSION"),  "\"")))]
-#![cfg_attr(not(docsrs), doc = "version = \"*\"")]
+#![doc = concat!("version = \"", env!("CARGO_PKG_VERSION"),  "\"")]
 //! features = ["extension-module"]
 //! ```
 //!
@@ -214,9 +212,7 @@
 //! Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like this:
 //! ```toml
 //! [dependencies.pyo3]
-// workaround for `extended_key_value_attributes`: https://github.com/rust-lang/rust/issues/82768#issuecomment-803935643
-#![cfg_attr(docsrs, cfg_attr(docsrs, doc = concat!("version = \"", env!("CARGO_PKG_VERSION"),  "\"")))]
-#![cfg_attr(not(docsrs), doc = "version = \"*\"")]
+#![doc = concat!("version = \"", env!("CARGO_PKG_VERSION"),  "\"")]
 //! # this is necessary to automatically initialize the Python interpreter
 //! features = ["auto-initialize"]
 //! ```
@@ -439,7 +435,7 @@ pub use pyo3_macros::{pyfunction, pymethods, pymodule, FromPyObject};
 
 /// A proc macro used to expose Rust structs and fieldless enums as Python objects.
 ///
-#[cfg_attr(docsrs, cfg_attr(docsrs, doc = include_str!("../guide/pyclass_parameters.md")))]
+#[doc = include_str!("../guide/pyclass_parameters.md")]
 ///
 /// For more on creating Python classes,
 /// see the [class section of the guide][1].


### PR DESCRIPTION
Removes some `cfg_attr` attributes from docs which are no longer needed.

Also fixes up the internal banner as agreed in #3210 