### PR TITLE
ci: pin log for msrv

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -465,6 +465,7 @@ def set_minimal_package_versions(session: nox.Session):
         "rust_decimal": "1.26.1",
         "csv": "1.1.6",
         "hashbrown": "0.12.3",
+        "log": "0.4.17",
         "once_cell": "1.17.2",
         "rayon": "1.6.1",
         "rayon-core": "1.10.2",


### PR DESCRIPTION
Looks like newer log versions require Rust 1.60