### PR TITLE
ci: allow failure on 3.7 and pypy nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    continue-on-error: ${{ inputs.python-version == '3.12-dev' }}
+    continue-on-error: ${{ contains(fromJSON('["3.7", "3.12-dev", "pypy3.7", "pypy3.10-nightly"]'), inputs.python-version) }}
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This follows up #2709 to also allow 3.7 jobs to fail as per https://github.com/PyO3/pyo3/pull/3204#issuecomment-1577832966

Also makes pypy nightly allow failures.

This way 3.7 issues and dev versions won't block contributors from merging.