### PR TITLE
rename examples package to fix dependabot

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples"
+name = "pyo3-examples"
 version = "0.0.0"
 publish = false
 edition = "2021"


### PR DESCRIPTION
At the moment dependabot fails to run on the repo with the following error:

```
Dependabot encountered the following error:

error: failed to load manifest for workspace member `/home/dependabot/dependabot-updater/dependabot_tmp_dir/examples`

Caused by:
  failed to parse manifest at `/home/dependabot/dependabot-updater/dependabot_tmp_dir/examples/Cargo.toml`

Caused by:
  the binary target name `examples` is forbidden, it conflicts with with cargo's build directory names
```

From testing locally using the dependabot CLI, changing the package name to `pyo3-examples` in `examples/Cargo.toml` appears to resolve.