### PR TITLE
bump maturin version in example files

### DIFF
--- a/examples/decorator/.template/pyproject.toml
+++ b/examples/decorator/.template/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [project]

--- a/examples/decorator/pyproject.toml
+++ b/examples/decorator/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [project]

--- a/examples/maturin-starter/.template/pyproject.toml
+++ b/examples/maturin-starter/.template/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [project]

--- a/examples/maturin-starter/pyproject.toml
+++ b/examples/maturin-starter/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [project]

--- a/examples/plugin/plugin_api/pyproject.toml
+++ b/examples/plugin/plugin_api/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [project]

--- a/examples/word-count/pyproject.toml
+++ b/examples/word-count/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [project]

--- a/guide/src/getting_started.md
+++ b/guide/src/getting_started.md
@@ -123,7 +123,7 @@ You should also create a `pyproject.toml` with the following contents:
 
 ```toml
 [build-system]
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [project]

--- a/pytests/pyproject.toml
+++ b/pytests/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.13,<0.14"]
+requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Just noticed that these were out of sync and trailing behind maturin's 1.0 version. Unless maturin needs a v2 soon then these should stay current for a while!