### PR TITLE
examples: bump edition to 2021

### DIFF
--- a/examples/decorator/.template/Cargo.toml
+++ b/examples/decorator/.template/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["{{authors}}"]
 name = "{{project-name}}"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "decorator"

--- a/examples/maturin-starter/.template/Cargo.toml
+++ b/examples/maturin-starter/.template/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["{{authors}}"]
 name = "{{project-name}}"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "maturin_starter"

--- a/examples/setuptools-rust-starter/.template/Cargo.toml
+++ b/examples/setuptools-rust-starter/.template/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["{{authors}}"]
 name = "{{project-name}}"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "setuptools_rust_starter"

--- a/examples/word-count/.template/Cargo.toml
+++ b/examples/word-count/.template/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["{{authors}}"]
 name = "{{project-name}}"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "word_count"


### PR DESCRIPTION
Had noticed that a couple of examples still used 2018 edition (in their templates) after we did #3215, I suspect this was an innocent omission.