### PR TITLE
Improve `PyModule::from_code` examples

### DIFF
--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -98,7 +98,7 @@ impl PyModule {
     /// let code = include_str!("../../assets/script.py");
     ///
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     PyModule::from_code(py, code, "example", "example")?;
+    ///     PyModule::from_code(py, code, "example.py", "example")?;
     ///     Ok(())
     /// })?;
     /// # Ok(())
@@ -117,7 +117,7 @@ impl PyModule {
     /// let code = std::fs::read_to_string("assets/script.py")?;
     ///
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     PyModule::from_code(py, &code, "example", "example")?;
+    ///     PyModule::from_code(py, &code, "example.py", "example")?;
     ///     Ok(())
     /// })?;
     /// Ok(())


### PR DESCRIPTION
Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be licensed under PyO3's [Apache-2.0 license](https://github.com/PyO3/pyo3#license).

PyO3 is currently undergoing a relicensing process to match Rust's dual-license under `Apache-2.0` and `MIT` licenses. While that process is ongoing, if you are a first-time contributor please add your agreement as a comment in [#3108](https://github.com/PyO3/pyo3/pull/3108).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request. To run its tests
locally, you can run ```cargo xtask ci```. See its documentation
 [here](https://github.com/PyO3/pyo3/tree/main/xtask#readme).
