### PR TITLE
convert &'py PyList -> PyList<'py>

### DIFF
--- a/examples/plugin/src/main.rs
+++ b/examples/plugin/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //do useful work
     Python::with_gil(|py| {
         //add the current directory to import path of Python (do not use this in production!)
-        let syspath: &PyList = py.import("sys")?.getattr("path")?.extract()?;
+        let syspath: PyList<'_> = py.import("sys")?.getattr("path")?.extract()?;
         syspath.insert(0, &path)?;
         println!("Import path is: {:?}", syspath);
 

--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -19,7 +19,7 @@ The table below contains the Python type and the corresponding function argument
 | `int`         | Any integer type (`i32`, `u32`, `usize`, etc) | `&PyLong` |
 | `float`       | `f32`, `f64`                    | `&PyFloat`           |
 | `complex`     | `num_complex::Complex`[^1]      | `&PyComplex`         |
-| `list[T]`     | `Vec<T>`                        | `&PyList`            |
+| `list[T]`     | `Vec<T>`                        | `PyList<'py>`        |
 | `dict[K, V]`  | `HashMap<K, V>`, `BTreeMap<K, V>`, `hashbrown::HashMap<K, V>`[^2], `indexmap::IndexMap<K, V>`[^3] | `&PyDict` |
 | `tuple[T, U]` | `(T, U)`, `Vec<T>`              | `&PyTuple`           |
 | `set[T]`      | `HashSet<T>`, `BTreeSet<T>`, `hashbrown::HashSet<T>`[^2] | `&PySet` |

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -406,7 +406,7 @@ fn main() -> PyResult<()> {
     let path = Path::new("/usr/share/python_app");
     let py_app = fs::read_to_string(path.join("app.py"))?;
     let from_python = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
-        let syspath: &PyList = py.import("sys")?.getattr("path")?.downcast()?;
+        let syspath: PyList<'_> = py.import("sys")?.getattr("path")?.downcast()?;
         syspath.insert(0, &path)?;
         let app: Py<PyAny> = PyModule::from_code(py, &py_app, "", "")?
             .getattr("run")?

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -642,7 +642,7 @@ mod tests {
             let list: &PyAny = vec![3, 6, 5, 4, 7].to_object(py).into_ref(py);
             let dict: &PyAny = vec![("reverse", true)].into_py_dict(py).as_ref();
 
-            assert!(<PyList as PyTryFrom<'_>>::try_from(list).is_ok());
+            assert!(<PyList<'_> as PyTryFrom<'_>>::try_from(list).is_ok());
             assert!(<PyDict as PyTryFrom<'_>>::try_from(dict).is_ok());
 
             assert!(<PyAny as PyTryFrom<'_>>::try_from(list).is_ok());
@@ -656,7 +656,7 @@ mod tests {
             let list: &PyAny = vec![3, 6, 5, 4, 7].to_object(py).into_ref(py);
             let dict: &PyAny = vec![("reverse", true)].into_py_dict(py).as_ref();
 
-            assert!(PyList::try_from_exact(list).is_ok());
+            assert!(PyList::<'_>::try_from_exact(list).is_ok());
             assert!(PyDict::try_from_exact(dict).is_ok());
 
             assert!(PyAny::try_from_exact(list).is_err());
@@ -668,7 +668,7 @@ mod tests {
     fn test_try_from_unchecked() {
         Python::with_gil(|py| {
             let list = PyList::new(py, [1, 2, 3]);
-            let val = unsafe { <PyList as PyTryFrom>::try_from_unchecked(list.as_ref()) };
+            let val = unsafe { <PyList<'_> as PyTryFrom>::try_from_unchecked(list.as_ref()) };
             assert!(list.is(val));
         });
     }

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -185,11 +185,11 @@ mod tests {
         Python::with_gil(|py| {
             let array: [f32; 4] = [0.0, -16.0, 16.0, 42.0];
             let pyobject = array.to_object(py);
-            let pylist: &PyList = pyobject.extract(py).unwrap();
-            assert_eq!(pylist[0].extract::<f32>().unwrap(), 0.0);
-            assert_eq!(pylist[1].extract::<f32>().unwrap(), -16.0);
-            assert_eq!(pylist[2].extract::<f32>().unwrap(), 16.0);
-            assert_eq!(pylist[3].extract::<f32>().unwrap(), 42.0);
+            let pylist: PyList<'_> = pyobject.extract(py).unwrap();
+            assert_eq!(pylist.get_item(0).unwrap().extract::<f32>().unwrap(), 0.0);
+            assert_eq!(pylist.get_item(1).unwrap().extract::<f32>().unwrap(), -16.0);
+            assert_eq!(pylist.get_item(2).unwrap().extract::<f32>().unwrap(), 16.0);
+            assert_eq!(pylist.get_item(3).unwrap().extract::<f32>().unwrap(), 42.0);
         });
     }
 
@@ -212,11 +212,11 @@ mod tests {
         Python::with_gil(|py| {
             let array: [f32; 4] = [0.0, -16.0, 16.0, 42.0];
             let pyobject = array.into_py(py);
-            let pylist: &PyList = pyobject.extract(py).unwrap();
-            assert_eq!(pylist[0].extract::<f32>().unwrap(), 0.0);
-            assert_eq!(pylist[1].extract::<f32>().unwrap(), -16.0);
-            assert_eq!(pylist[2].extract::<f32>().unwrap(), 16.0);
-            assert_eq!(pylist[3].extract::<f32>().unwrap(), 42.0);
+            let pylist: PyList<'_> = pyobject.extract(py).unwrap();
+            assert_eq!(pylist.get_item(0).unwrap().extract::<f32>().unwrap(), 0.0);
+            assert_eq!(pylist.get_item(1).unwrap().extract::<f32>().unwrap(), -16.0);
+            assert_eq!(pylist.get_item(2).unwrap().extract::<f32>().unwrap(), 16.0);
+            assert_eq!(pylist.get_item(3).unwrap().extract::<f32>().unwrap(), 42.0);
         });
     }
 
@@ -237,8 +237,8 @@ mod tests {
 
         Python::with_gil(|py| {
             let array: [Foo; 8] = [Foo, Foo, Foo, Foo, Foo, Foo, Foo, Foo];
-            let pyobject = array.into_py(py);
-            let list: &PyList = pyobject.downcast(py).unwrap();
+            let pyobject = array.into_py(py).into_owned(py);
+            let list: &PyList<'_> = pyobject.downcast().unwrap();
             let _cell: &crate::PyCell<Foo> = list.get_item(4).unwrap().extract().unwrap();
         });
     }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1056,7 +1056,7 @@ mod tests {
 
     #[test]
     fn test_allow_threads_pass_stuff_in() {
-        let list: Py<PyList> = Python::with_gil(|py| {
+        let list: Py<PyList<'static>> = Python::with_gil(|py| {
             let list = PyList::new(py, vec!["foo", "bar"]);
             list.into()
         });

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -70,7 +70,7 @@ unsafe impl<T> Sync for GILProtected<T> where T: Send {}
 ///
 /// static LIST_CELL: GILOnceCell<Py<PyList>> = GILOnceCell::new();
 ///
-/// pub fn get_shared_list(py: Python<'_>) -> &PyList {
+/// pub fn get_shared_list(py: Python<'_>) -> &PyList<'_> {
 ///     LIST_CELL
 ///         .get_or_init(py, || PyList::empty(py).into())
 ///         .as_ref(py)

--- a/src/test_hygiene/pymethods.rs
+++ b/src/test_hygiene/pymethods.rs
@@ -76,7 +76,7 @@ impl Dummy {
 
     fn __delattr__(&mut self, name: ::std::string::String) {}
 
-    fn __dir__<'py>(&self, py: crate::Python<'py>) -> &'py crate::types::PyList {
+    fn __dir__<'py>(&self, py: crate::Python<'py>) -> crate::types::PyList<'py> {
         crate::types::PyList::new(py, ::std::vec![0_u8])
     }
 

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -213,31 +213,22 @@ impl PyDict {
     /// Returns a list of dict keys.
     ///
     /// This is equivalent to the Python expression `list(dict.keys())`.
-    pub fn keys(&self) -> &PyList {
-        unsafe {
-            self.py()
-                .from_owned_ptr::<PyList>(ffi::PyDict_Keys(self.as_ptr()))
-        }
+    pub fn keys(&self) -> PyList<'_> {
+        unsafe { PyList::from_owned_ptr(self.py(), ffi::PyDict_Keys(self.as_ptr())) }
     }
 
     /// Returns a list of dict values.
     ///
     /// This is equivalent to the Python expression `list(dict.values())`.
-    pub fn values(&self) -> &PyList {
-        unsafe {
-            self.py()
-                .from_owned_ptr::<PyList>(ffi::PyDict_Values(self.as_ptr()))
-        }
+    pub fn values(&self) -> PyList<'_> {
+        unsafe { PyList::from_owned_ptr(self.py(), ffi::PyDict_Values(self.as_ptr())) }
     }
 
     /// Returns a list of dict items.
     ///
     /// This is equivalent to the Python expression `list(dict.items())`.
-    pub fn items(&self) -> &PyList {
-        unsafe {
-            self.py()
-                .from_owned_ptr::<PyList>(ffi::PyDict_Items(self.as_ptr()))
-        }
+    pub fn items(&self) -> PyList<'_> {
+        unsafe { PyList::from_owned_ptr(self.py(), ffi::PyDict_Items(self.as_ptr())) }
     }
 
     /// Returns an iterator of `(key, value)` pairs in this dictionary.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -41,6 +41,11 @@ pub use self::traceback::PyTraceback;
 pub use self::tuple::PyTuple;
 pub use self::typeobject::PyType;
 
+pub(crate) use self::any::PyAnyOwned;
+
+#[macro_use]
+mod type_macros;
+
 /// Iteration over Python collections.
 ///
 /// When working with a Python collection, one approach is to convert it to a Rust collection such

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -165,14 +165,14 @@ impl PyModule {
     /// creating one if needed.
     ///
     /// `__all__` declares the items that will be imported with `from my_module import *`.
-    pub fn index(&self) -> PyResult<&PyList> {
+    pub fn index(&self) -> PyResult<PyList<'_>> {
         let __all__ = __all__(self.py());
         match self.getattr(__all__) {
-            Ok(idx) => idx.downcast().map_err(PyErr::from),
+            Ok(idx) => idx.extract(),
             Err(err) => {
                 if err.is_instance_of::<exceptions::PyAttributeError>(self.py()) {
                     let l = PyList::empty(self.py());
-                    self.setattr(__all__, l).map_err(PyErr::from)?;
+                    self.setattr(__all__, l)?;
                     Ok(l)
                 } else {
                     Err(err)

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -238,17 +238,14 @@ impl PySequence {
 
     /// Returns a fresh list based on the Sequence.
     #[inline]
-    pub fn to_list(&self) -> PyResult<&PyList> {
-        unsafe {
-            self.py()
-                .from_owned_ptr_or_err(ffi::PySequence_List(self.as_ptr()))
-        }
+    pub fn to_list(&self) -> PyResult<PyList<'_>> {
+        unsafe { PyList::from_owned_ptr_or_err(self.py(), ffi::PySequence_List(self.as_ptr())) }
     }
 
     /// Returns a fresh list based on the Sequence.
     #[inline]
     #[deprecated(since = "0.19.0", note = "renamed to .to_list()")]
-    pub fn list(&self) -> PyResult<&PyList> {
+    pub fn list(&self) -> PyResult<PyList<'_>> {
         self.to_list()
     }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -216,7 +216,7 @@ impl PyTuple {
     /// Return a new list containing the contents of this tuple; equivalent to the Python expression `list(tuple)`.
     ///
     /// This method is equivalent to `self.as_sequence().to_list()` and faster than `PyList::new(py, self)`.
-    pub fn to_list(&self) -> &PyList {
+    pub fn to_list(&self) -> PyList<'_> {
         self.as_sequence()
             .to_list()
             .expect("failed to convert tuple to list")

--- a/src/types/type_macros.rs
+++ b/src/types/type_macros.rs
@@ -1,0 +1,185 @@
+// Implementations core to all native types
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_owned_native_type_base {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty) => {
+        impl<$py $(,$generics)*> ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>)
+                   -> ::std::result::Result<(), ::std::fmt::Error>
+            {
+                let s = self.repr().or(::std::result::Result::Err(::std::fmt::Error))?;
+                f.write_str(&s.to_string_lossy())
+            }
+        }
+
+        impl<$py $(,$generics)*> ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>)
+                   -> ::std::result::Result<(), ::std::fmt::Error>
+            {
+                let s = self.str().or(::std::result::Result::Err(::std::fmt::Error))?;
+                f.write_str(&s.to_string_lossy())
+            }
+        }
+
+        impl<$py $(,$generics)*> $crate::ToPyObject for $name
+        {
+            #[inline]
+            fn to_object(&self, py: $crate::Python<'_>) -> $crate::PyObject {
+                use $crate::AsPyPointer;
+                unsafe { $crate::PyObject::from_borrowed_ptr(py, self.as_ptr()) }
+            }
+        }
+    };
+}
+
+// Implementations core to all native types except for PyAny (because they don't
+// make sense on PyAny / have different implementations).
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_owned_native_type_named {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty) => {
+        $crate::pyobject_owned_native_type_base!(impl<$py $(,$generics)*> $name);
+
+        impl<$py $(,$generics)*> ::std::convert::AsRef<$crate::types::PyAnyOwned<$py>> for $name {
+            #[inline]
+            fn as_ref(&self) -> &$crate::types::PyAnyOwned<$py> {
+                &self.0
+            }
+        }
+
+        impl<$py $(,$generics)*> ::std::ops::Deref for $name {
+            type Target = $crate::types::PyAnyOwned<$py>;
+
+            #[inline]
+            fn deref(&self) -> &$crate::types::PyAnyOwned<$py> {
+                &self.0
+            }
+        }
+
+        impl<$py $(,$generics)*> $crate::AsPyPointer for $name {
+            /// Gets the underlying FFI pointer, returns a borrowed pointer.
+            #[inline]
+            fn as_ptr(&self) -> *mut $crate::ffi::PyObject {
+                self.0.as_ptr()
+            }
+        }
+
+        impl<$py $(,$generics)*> $crate::IntoPy<$crate::PyObject> for $name {
+            #[inline]
+            fn into_py(self, py: $crate::Python<'_>) -> $crate::PyObject {
+                unsafe { $crate::Py::from_non_null(self.into_non_null()) }
+            }
+        }
+
+        impl<$py $(,$generics)*> From<$name> for $crate::PyObject {
+            #[inline]
+            fn from(other: $name) -> $crate::PyObject {
+                unsafe { $crate::Py::from_non_null(other.into_non_null()) }
+            }
+        }
+
+        impl<$py $(,$generics)*> ::std::convert::From<&'_ $name> for $crate::Py<$name> {
+            #[inline]
+            fn from(other: &$name) -> Self {
+                use $crate::AsPyPointer;
+                unsafe { $crate::Py::from_borrowed_ptr(other.py(), other.as_ptr()) }
+            }
+        }
+
+        impl<'a, $py $(,$generics)*> ::std::convert::From<&'a $name> for &'a $crate::PyAny {
+            fn from(ob: &'a $name) -> Self {
+                unsafe{&*(ob as *const $name as *const $crate::PyAny)}
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_owned_native_type_info {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty, $typeobject:expr, $module:expr $(, #checkfunction=$checkfunction:path)?) => {
+        unsafe impl<$py $(,$generics)*> $crate::type_object::PyTypeInfo for $name {
+            const NAME: &'static str = stringify!($name);
+            const MODULE: ::std::option::Option<&'static str> = $module;
+            type AsRefTarget = $crate::PyAny;  // FIXME: this is wrong, needs to be the type in question with <'py> bound e.g. PyDict<'py>
+
+            #[inline]
+            fn type_object_raw(_py: $crate::Python<'_>) -> *mut $crate::ffi::PyTypeObject {
+                // Create a very short lived mutable reference and directly
+                // cast it to a pointer: no mutable references can be aliasing
+                // because we hold the GIL.
+                #[cfg(not(addr_of))]
+                unsafe { &mut $typeobject }
+
+                #[cfg(addr_of)]
+                unsafe { ::std::ptr::addr_of_mut!($typeobject) }
+            }
+
+            $(
+                fn is_type_of(ptr: &$crate::PyAny) -> bool {
+                    use $crate::AsPyPointer;
+                    #[allow(unused_unsafe)]
+                    unsafe { $checkfunction(ptr.as_ptr()) > 0 }
+                }
+            )?
+        }
+    };
+}
+
+// NOTE: This macro is not included in pyobject_native_type_base!
+// because rust-numpy has a special implementation.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_owned_native_type_extract {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty) => {
+        impl<$py $(,$generics)*> $crate::FromPyObject<$py> for $name {
+            fn extract(obj: &'py $crate::PyAny) -> $crate::PyResult<Self> {
+                let reference: &Self = $crate::types::PyAnyOwned::from_gil_ref(&obj).downcast()?;
+                Ok(reference.clone())
+            }
+        }
+    }
+}
+
+/// Declares all of the boilerplate for Python types.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_owned_native_type_core {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty, $typeobject:expr, #module=$module:expr $(, #checkfunction=$checkfunction:path)?) => {
+        $crate::pyobject_owned_native_type_named!(impl<$py $(,$generics)*> $name);
+        $crate::pyobject_owned_native_type_info!(impl<$py $(,$generics)*> $name, $typeobject, $module $(, #checkfunction=$checkfunction)?);
+        $crate::pyobject_owned_native_type_extract!(impl<$py $(,$generics)*> $name);
+    };
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty, $typeobject:expr $(, #checkfunction=$checkfunction:path)?) => {
+        $crate::pyobject_owned_native_type_core!(impl<$py $(,$generics)*> $name, $typeobject, #module=::std::option::Option::Some("builtins") $(, #checkfunction=$checkfunction)?);
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_owned_native_type_sized {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty, $layout:path) => {
+        unsafe impl<$py $(,$generics)*> $crate::type_object::PyLayout<$name> for $layout {}
+        impl<$py $(,$generics)*> $crate::type_object::PySizedLayout<$name> for $layout {}
+        impl<$py $(,$generics)*> $crate::impl_::pyclass::PyClassBaseType for $name {
+            type LayoutAsBase = $crate::pycell::PyCellBase<$layout>;
+            type BaseNativeType = $name;
+            type ThreadChecker = $crate::impl_::pyclass::ThreadCheckerStub;
+            type Initializer = $crate::pyclass_init::PyNativeTypeInitializer<Self>;
+            type PyClassMutability = $crate::pycell::impl_::ImmutableClass;
+        }
+    }
+}
+
+/// Declares all of the boilerplate for Python types which can be inherited from (because the exact
+/// Python layout is known).
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_owned_native_type {
+    (impl<$py:lifetime $(,$generics:ident)* $(,)?> $name:ty, $layout:path, $typeobject:expr $(, #module=$module:expr)? $(, #checkfunction=$checkfunction:path)?) => {
+        $crate::pyobject_owned_native_type_core!(impl<$py $(,$generics)*> $name, $typeobject $(, #module=$module)? $(, #checkfunction=$checkfunction)?);
+        // To prevent inheriting native types with ABI3
+        #[cfg(not(Py_LIMITED_API))]
+        $crate::pyobject_owned_native_type_sized!(impl<$py $(,$generics)*> $name, $layout);
+    };
+}


### PR DESCRIPTION
This is a branch to continue the conversation from https://github.com/PyO3/pyo3/pull/3205#issuecomment-1596068254

It adds an (internal for now) `PyAnyOwned<'py>`, which could eventually become `PyAny<'py>`, and attempts to gauge fallout by replacing `&'py PyList` with `PyList<'py>` implemented on top of `PyAnyOwned<'py>`.

Because of the scale of the churn, I think it's more realistic to implement migration of each type in individual PRs. I think a single branch and PR to rebuild the entirety of PyO3 would be unreviewable. Probably `&PyAny` needs to be migrated first, although I want us to understand what changes look like for the core collection types (list, dict, tuple) before we commit to this road for definite.

Doesn't compile yet because a lot of the conversion traits aren't implemented properly for `PyList<'py>`. I might try to refine further later if we think this is worth pursuing.

Already we see the following migration efforts:
- Ownership changes (not a suprise)
- Proliferation of `from_owned_ptr` methods etc.
  - These can probably be refactored into a trait or a macro
- List index operators have to be removed if the pool is removed, because the index operators can't return owned values
  - This would be true of any other solution which removes the pool.
- Addition of the lifetime to `PyList<'py>` has interesting consequences for `is_instance` and similar generic methods.
  - `x.is_instance_of::<PyList<'_>>()`
  - `x.downcast::<PyList<'_>>()`

Of these, I think only the fourth bullet needs further consideration. If users don't have the `elided_lifetimes_in_paths` lint enabled, then I believe they can continue writing `x.is_instance_of<PyList>()` without the lifetime. However, the papercut is still notable. I think this would just have to be noted as part of syntactical drawbacks which we could describe as things which would go away if `arbitrary_self_types` stabilised (any PyO3 migrated to it).