### PR TITLE
decouple pyo3-ffi-check from MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,10 +136,10 @@ jobs:
               - '.github/workflows/build.yml'
 
       - name: Run pyo3-ffi-check
-        run: nox -s ffi-check
         # pypy 3.7 and 3.8 are not PEP 3123 compliant so fail checks here, nor
         # is pypy 3.9 on windows
         if: ${{ steps.ffi-changes.outputs.changed == 'true' && inputs.rust == 'stable' && inputs.python-version != 'pypy3.7' && inputs.python-version != 'pypy3.8' && !(inputs.python-version == 'pypy3.9' && contains(inputs.os, 'windows')) }}
+        run: nox -s ffi-check
 
 
       - name: Test cross compilation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,8 +179,6 @@ harness = false
 [workspace]
 members = [
     "pyo3-ffi",
-    "pyo3-ffi-check",
-    "pyo3-ffi-check/macro",
     "pyo3-build-config",
     "pyo3-macros",
     "pyo3-macros-backend",

--- a/noxfile.py
+++ b/noxfile.py
@@ -34,7 +34,7 @@ def test_rust(session: nox.Session):
 
     _run_cargo_test(session)
     _run_cargo_test(session, features="abi3")
-    if not "skip-full" in session.posargs:
+    if "skip-full" not in session.posargs:
         _run_cargo_test(session, features="full")
         _run_cargo_test(session, features="abi3 full")
 
@@ -76,7 +76,8 @@ def fmt(session: nox.Session):
 
 @nox.session(name="fmt-rust", venv_backend="none")
 def fmt_rust(session: nox.Session):
-    _run(session, "cargo", "fmt", "--all", "--check", external=True)
+    _run_cargo(session, "fmt", "--all", "--check")
+    _run_cargo(session, "fmt", *_FFI_CHECK, "--all", "--check")
 
 
 @nox.session(name="fmt-py")
@@ -103,9 +104,6 @@ def _clippy(session: nox.Session, *, env: Dict[str, str] = None) -> bool:
                 *feature_set,
                 "--all-targets",
                 "--workspace",
-                # linting pyo3-ffi-check requires docs to have been built or
-                # the macros will error; doesn't seem worth it on CI
-                "--exclude=pyo3-ffi-check",
                 "--",
                 "--deny=warnings",
                 external=True,
@@ -146,9 +144,6 @@ def check_all(session: nox.Session) -> None:
                     *feature_set,
                     "--all-targets",
                     "--workspace",
-                    # linting pyo3-ffi-check requires docs to have been built or
-                    # the macros will error; doesn't seem worth it on CI
-                    "--exclude=pyo3-ffi-check",
                     external=True,
                     env=env,
                 )
@@ -339,8 +334,6 @@ def format_guide(session: nox.Session):
 
     for path in Path("guide").glob("**/*.md"):
         session.log("Working on %s", path)
-        content = path.read_text()
-
         lines = iter(path.read_text().splitlines(True))
         new_lines = []
 
@@ -534,8 +527,9 @@ def set_minimal_package_versions(session: nox.Session):
 
 @nox.session(name="ffi-check")
 def ffi_check(session: nox.Session):
-    session.run("cargo", "doc", "-p", "pyo3-ffi", "--no-deps", external=True)
-    _run(session, "cargo", "run", "-p", "pyo3-ffi-check", external=True)
+    _run_cargo(session, "doc", *_FFI_CHECK, "-p", "pyo3-ffi", "--no-deps")
+    _run_cargo(session, "clippy", "--workspace", "--all-targets", *_FFI_CHECK)
+    _run_cargo(session, "run", *_FFI_CHECK)
 
 
 @lru_cache()
@@ -617,6 +611,10 @@ def _run(session: nox.Session, *args: str, **kwargs: Any) -> None:
         print("::endgroup::", file=sys.stderr)
 
 
+def _run_cargo(session: nox.Session, *args: str, **kwargs: Any) -> None:
+    _run(session, "cargo", *args, **kwargs, external=True)
+
+
 def _run_cargo_test(
     session: nox.Session,
     *,
@@ -685,3 +683,6 @@ suppress_build_script_link_lines=true
 
         for version in PYPY_VERSIONS:
             _job_with_config("PyPy", version)
+
+
+_FFI_CHECK = ("--manifest-path", "pyo3-ffi-check/Cargo.toml")

--- a/pyo3-ffi-check/Cargo.toml
+++ b/pyo3-ffi-check/Cargo.toml
@@ -13,5 +13,10 @@ path = "../pyo3-ffi"
 features = ["extension-module"]  # A lazy way of skipping linking in most cases (as we don't use any runtime symbols)
 
 [build-dependencies]
-bindgen = "0.65.1"
+bindgen = "0.66.1"
 pyo3-build-config = { path = "../pyo3-build-config" }
+
+[workspace]
+members = [
+    "macro"
+]

--- a/pyo3-ffi-check/macro/Cargo.toml
+++ b/pyo3-ffi-check/macro/Cargo.toml
@@ -11,4 +11,4 @@ proc-macro = true
 glob = "0.3"
 quote = "1"
 proc-macro2 = "1"
-scraper = "0.12"
+scraper = "0.17"

--- a/pyo3-ffi-check/src/main.rs
+++ b/pyo3-ffi-check/src/main.rs
@@ -78,7 +78,8 @@ fn main() {
     non_camel_case_types,
     non_upper_case_globals,
     dead_code,
-    improper_ctypes
+    improper_ctypes,
+    clippy::all
 )]
 mod bindings {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
Inspired by #3276, I figured we should perhaps just exclude pyo3-ffi-check from the workspace during MSRV jobs. It's only an internal tool, we already don't run it on MSRV, and hopefully dependabot version bumps for its deps can then be trivially merged.