### PR TITLE
handle exceptions properly in `PySet::discard`

### DIFF
--- a/newsfragments/3281.changed.md
+++ b/newsfragments/3281.changed.md
@@ -1,0 +1,1 @@
+Change `PySet::discard` to return `PyResult<bool>` (previously returned nothing).

--- a/newsfragments/3281.fixed.md
+++ b/newsfragments/3281.fixed.md
@@ -1,0 +1,1 @@
+Handle exceptions properly in `PySet::discard`.


### PR DESCRIPTION
While applying tidy ups in #3273 I realised `PySet::discard` has a broken implementation which doesn't check for errors. So I pulled this out into its own fix.