### PR TITLE
Fix typos and add punctuation recommended by grammarly in Class.md

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -61,7 +61,7 @@ To integrate Rust types with Python, PyO3 needs to place some restrictions on th
 
 Rust lifetimes are used by the Rust compiler to reason about a program's memory safety. They are a compile-time only concept; there is no way to access Rust lifetimes at runtime from a dynamic language like Python.
 
-As soon as Rust data is exposed to Python, there is no guarantee which the Rust compiler can make on how long the data will live. Python is a reference-counted language and those references can be held for an arbitrarily long time which is untraceable by the Rust compiler. The only possible way to express this correctly is to require that any `#[pyclass]` does not borrow data for any lifetime shorter than the `'static` lifetime, i.e. the `#[pyclass]` cannot have any lifetime parameters.
+As soon as Rust data is exposed to Python, there is no guarantee that the Rust compiler can make on how long the data will live. Python is a reference-counted language and those references can be held for an arbitrarily long time which is untraceable by the Rust compiler. The only possible way to express this correctly is to require that any `#[pyclass]` does not borrow data for any lifetime shorter than the `'static` lifetime, i.e. the `#[pyclass]` cannot have any lifetime parameters.
 
 When you need to share ownership of data between Python and Rust, instead of using borrowed references with lifetimes consider using reference-counted smart pointers such as [`Arc`] or [`Py`].
 
@@ -75,7 +75,7 @@ Because Python objects are freely shared between threads by the Python interpret
 
 ## Constructor
 
-By default it is not possible to create an instance of a custom class from Python code.
+By default, it is not possible to create an instance of a custom class from Python code.
 To declare a constructor, you need to define a method and annotate it with the `#[new]`
 attribute. Only Python's `__new__` method can be specified, `__init__` is not available.
 
@@ -115,7 +115,7 @@ impl Nonzero {
 ```
 
 As you can see, the Rust method name is not important here; this way you can
-still use `new()` for a Rust-level constructor.
+still, use `new()` for a Rust-level constructor.
 
 If no method marked with `#[new]` is declared, object instances can only be
 created from Rust, but not from Python.
@@ -267,7 +267,7 @@ use the `extends` parameter for `pyclass` with the full path to the base class.
 
 For convenience, `(T, U)` implements `Into<PyClassInitializer<T>>` where `U` is the
 base class of `T`.
-But for more deeply nested inheritance, you have to return `PyClassInitializer<T>`
+But for a more deeply nested inheritance, you have to return `PyClassInitializer<T>`
 explicitly.
 
 To get a parent class from a child, use [`PyRef`] instead of `&self` for methods,
@@ -745,7 +745,7 @@ fn print_field(my_class: PyRef<'_, MyClass>) {
 }
 
 // Take a GIL-bound reference to the underlying cell
-// when borrowing needs to be managed manaually.
+// when borrowing needs to be managed manually.
 #[pyfunction]
 fn increment_then_print_field(my_class: &PyCell<MyClass>) {
     my_class.borrow_mut().my_field += 1;
@@ -760,7 +760,7 @@ fn print_refcnt(my_class: Py<MyClass>, py: Python<'_>) {
 }
 ```
 
-Classes can also be passed by value if they can be be cloned, i.e. they automatically implement `FromPyObject` if they implement `Clone`, e.g. via `#[derive(Clone)]`:
+Classes can also be passed by value if they can be cloned, i.e. they automatically implement `FromPyObject` if they implement `Clone`, e.g. via `#[derive(Clone)]`:
 
 ```rust
 # #![allow(dead_code)]
@@ -784,7 +784,7 @@ Note that `#[derive(FromPyObject)]` on a class is usually not useful as it tries
 
 Similar to `#[pyfunction]`, the `#[pyo3(signature = (...))]` attribute can be used to specify the way that `#[pymethods]` accept arguments. Consult the documentation for [`function signatures`](./function/signature.md) to see the parameters this attribute accepts.
 
-The following example defines a class `MyClass` with a method `method`. This method has a signature which sets default values for `num` and `name`, and indicates that `py_args` should collect all extra positional arguments and `py_kwargs` all extra keyword arguments:
+The following example defines a class `MyClass` with a method `method`. This method has a signature that sets default values for `num` and `name`, and indicates that `py_args` should collect all extra positional arguments and `py_kwargs` all extra keyword arguments:
 
 ```rust
 # use pyo3::prelude::*;
@@ -820,7 +820,7 @@ impl MyClass {
 }
 ```
 
-In Python this might be used like:
+In Python, this might be used like:
 
 ```python
 >>> import mymodule


### PR DESCRIPTION
Hi Everyone!

Nothing exciting in this pr. I just found a typo in the Documentation and added a few suggested changes by Grammarly as well.