### PR TITLE
Apparently, PySet_Add does not steal a reference, hence we should not forget to clean up ours.

### DIFF
--- a/newsfragments/3286.fixed.md
+++ b/newsfragments/3286.fixed.md
@@ -1,0 +1,1 @@
+Fix memory leak when creating `PySet` or `PyFrozenSet` or returning types converted into these internally, e.g. `HashSet` or `BTreeSet`.

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -2,7 +2,7 @@
 use crate::types::PyIterator;
 use crate::{
     err::{self, PyErr, PyResult},
-    IntoPyPointer, Py, PyObject,
+    Py, PyObject,
 };
 use crate::{ffi, AsPyPointer, PyAny, Python, ToPyObject};
 
@@ -209,7 +209,7 @@ pub(crate) fn new_from_iter<T: ToPyObject>(
 
         for obj in elements {
             unsafe {
-                err::error_on_minusone(py, ffi::PySet_Add(ptr, obj.into_ptr()))?;
+                err::error_on_minusone(py, ffi::PySet_Add(ptr, obj.as_ptr()))?;
             }
         }
 

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -2,7 +2,7 @@
 use crate::types::PyIterator;
 use crate::{
     err::{self, PyErr, PyResult},
-    IntoPyPointer, Py,
+    Py,
 };
 use crate::{ffi, AsPyPointer, PyAny, PyObject, Python, ToPyObject};
 use std::ptr;
@@ -260,7 +260,7 @@ pub(crate) fn new_from_iter<T: ToPyObject>(
 
         for obj in elements {
             unsafe {
-                err::error_on_minusone(py, ffi::PySet_Add(ptr, obj.into_ptr()))?;
+                err::error_on_minusone(py, ffi::PySet_Add(ptr, obj.as_ptr()))?;
             }
         }
 


### PR DESCRIPTION
Closes #3285