### PR TITLE
support PyPy 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    continue-on-error: ${{ contains(fromJSON('["3.7", "3.12-dev", "pypy3.7", "pypy3.10-nightly"]'), inputs.python-version) }}
+    continue-on-error: ${{ contains(fromJSON('["3.7", "3.12-dev", "pypy3.7", "pypy3.10"]'), inputs.python-version) }}
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           "pypy3.7",
           "pypy3.8",
           "pypy3.9",
-          "pypy3.10-nightly",
+          "pypy3.10",
         ]
         platform:
           [

--- a/newsfragments/3289.packaging.md
+++ b/newsfragments/3289.packaging.md
@@ -1,0 +1,1 @@
+Support PyPy 3.10.


### PR DESCRIPTION
Figure it makes sense to include official PyPy 3.10 support in 0.19.1.

If CI is green I will proceed to merge this so I can rebase #3288.