### PR TITLE
ci: run valgrind and careful with 'CI-build-full' label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
             extra-features: "multiple-pymethods"
 
   valgrind:
-    if: ${{ github.event_name != 'pull_request' && github.ref != 'refs/heads/main' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
@@ -274,7 +274,7 @@ jobs:
       TRYBUILD: overwrite
 
   careful:
-    if: ${{ github.event_name != 'pull_request' && github.ref != 'refs/heads/main' }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I noticed that `valgrind` and `careful` jobs don't run with `CI-build-full` label, I think it would be nice if they did... :)