### PR TITLE
use `PyTuple_Pack` in fixed-size tuple conversions

### DIFF
--- a/benches/bench_tuple.rs
+++ b/benches/bench_tuple.rs
@@ -83,6 +83,12 @@ fn tuple_to_list(b: &mut Bencher<'_>) {
     });
 }
 
+fn tuple_into_py(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        b.iter(|| -> PyObject { (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).into_py(py) });
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("iter_tuple", iter_tuple);
     c.bench_function("tuple_new", tuple_new);
@@ -92,6 +98,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("sequence_from_tuple", sequence_from_tuple);
     c.bench_function("tuple_new_list", tuple_new_list);
     c.bench_function("tuple_to_list", tuple_to_list);
+    c.bench_function("tuple_into_py", tuple_into_py);
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
Ref https://github.com/capi-workgroup/problems/issues/56

`PyTuple_Pack` is preferred over `PyTuple_New` to avoid partially uninitialised tuples.

I was curious about the performance impact so benchmarked it; this PR using `PyTuple_Pack` is about 10% slower. I think we just have to eat that slowdown for the correctness.

```
main
tuple_into_py           time:   [54.670 ns 54.775 ns 54.906 ns]

this PR
tuple_into_py           time:   [59.857 ns 59.868 ns 59.883 ns]
                        change: [+9.2827% +9.4570% +9.6517%] (p = 0.00 < 0.05)

```