### PR TITLE
fix `SystemError` raised from `PyUnicodeDecodeError_Create` on PyPy 3.10

### DIFF
--- a/newsfragments/3297.added.md
+++ b/newsfragments/3297.added.md
@@ -1,0 +1,1 @@
+Add FFI definitions `_PyObject_CallFunction_SizeT` and `_PyObject_CallMethod_SizeT`.

--- a/newsfragments/3297.fixed.md
+++ b/newsfragments/3297.fixed.md
@@ -1,0 +1,1 @@
+Fix `SystemError` raised in `PyUnicodeDecodeError_Create` on PyPy 3.10.

--- a/pyo3-ffi/src/abstract_.rs
+++ b/pyo3-ffi/src/abstract_.rs
@@ -52,8 +52,21 @@ extern "C" {
         ...
     ) -> *mut PyObject;
 
-    // skipped _PyObject_CallFunction_SizeT
-    // skipped _PyObject_CallMethod_SizeT
+    #[cfg(not(Py_3_13))]
+    #[cfg_attr(PyPy, link_name = "_PyPyObject_CallFunction_SizeT")]
+    pub fn _PyObject_CallFunction_SizeT(
+        callable_object: *mut PyObject,
+        format: *const c_char,
+        ...
+    ) -> *mut PyObject;
+    #[cfg(not(Py_3_13))]
+    #[cfg_attr(PyPy, link_name = "_PyPyObject_CallMethod_SizeT")]
+    pub fn _PyObject_CallMethod_SizeT(
+        o: *mut PyObject,
+        method: *const c_char,
+        format: *const c_char,
+        ...
+    ) -> *mut PyObject;
 
     #[cfg_attr(PyPy, link_name = "PyPyObject_CallFunctionObjArgs")]
     pub fn PyObject_CallFunctionObjArgs(callable: *mut PyObject, ...) -> *mut PyObject;

--- a/pyo3-ffi/src/pyerrors.rs
+++ b/pyo3-ffi/src/pyerrors.rs
@@ -99,7 +99,7 @@ pub unsafe fn PyUnicodeDecodeError_Create(
     end: Py_ssize_t,
     reason: *const c_char,
 ) -> *mut PyObject {
-    crate::PyObject_CallFunction(
+    crate::_PyObject_CallFunction_SizeT(
         PyExc_UnicodeDecodeError,
         b"sy#nns\0".as_ptr().cast::<c_char>(),
         encoding,


### PR DESCRIPTION
In https://github.com/pydantic/pydantic-core/issues/659 a `SystemError` is reported in the Pydantic test suite for PyPy 3.10:

```
_____________________________________________________ test_bytes_invalid_cpython ______________________________________________________

    def test_bytes_invalid_cpython():
        # PyO3/pyo3#2770 is now fixed
        s = SchemaSerializer(core_schema.bytes_schema())
    
        with pytest.raises(UnicodeDecodeError, match="'utf-8' codec can't decode byte 0x81 in position 0: invalid utf-8"):
>           s.to_python(b'\x81', mode='json')
E           SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
```

Turns out that this is down to our PyPy implementation of `PyUnicodeDecodeError_Create`. Looks like there's a behavioural change in Python 3.10 to error when calling `PyObject_CallFunction` with a `#`.

There's a `PY_SSIZE_T_CLEAN` macro which must be defined to enable these formats, which has the effect in the C header of redirecting `PyObject_CallFunction` to `_PyObject_CallFunction_SizeT`.

I don't think we can do this automatic redirection, because it's a breaking change that leads to UB as `PyObject_CallFunction` on Python 3.9 and older would accept `#` formats but treat the length as `c_int` instead of `Py_ssize_t`. So I've opted to just expose `_PyObject_CallFunction_SizeT` and change our implementation to use that. I verified by hand this fixes the Pydantic test suite on PyPy 3.10, and continues to work on PyPy 3.9.

A further note - it looks like on Python 3.13 the differences between `PyObject_CallFunction` and `_PyObject_CallFunction_SizeT` will be removed (and the latter symbol removed from the header, but kept in the ABI). That's a problem for the future though 😄 