### PR TITLE
fix FFI definition `Py_EnterRecursiveCall`

### DIFF
--- a/newsfragments/3300.fixed.md
+++ b/newsfragments/3300.fixed.md
@@ -1,0 +1,1 @@
+Correct FFI definition `Py_EnterRecursiveCall` to return `c_int` (was incorrectly returning `()`).

--- a/pyo3-ffi/src/ceval.rs
+++ b/pyo3-ffi/src/ceval.rs
@@ -76,7 +76,7 @@ extern "C" {
 extern "C" {
     #[cfg(Py_3_9)]
     #[cfg_attr(PyPy, link_name = "PyPy_EnterRecursiveCall")]
-    pub fn Py_EnterRecursiveCall(arg1: *const c_char);
+    pub fn Py_EnterRecursiveCall(arg1: *const c_char) -> c_int;
     #[cfg(Py_3_9)]
     #[cfg_attr(PyPy, link_name = "PyPy_LeaveRecursiveCall")]
     pub fn Py_LeaveRecursiveCall();


### PR DESCRIPTION
Looks like the return type of `Py_EnterRecursiveCall` has always been `c_int` but we missed this in #2511.