### PR TITLE
deprecate PySizedLayout

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -340,8 +340,8 @@ impl SubSubClass {
 # });
 ```
 
-You can also inherit native types such as `PyDict`, if they implement
-[`PySizedLayout`]({{#PYO3_DOCS_URL}}/pyo3/type_object/trait.PySizedLayout.html).
+You can also inherit native types such as `PyDict`, if they implement `PyClassBaseType` (this
+trait is currently an implementation detail of PyO3).
 This is not supported when building for the Python limited API (aka the `abi3` feature of PyO3).
 
 However, because of some technical problems, we don't currently provide safe upcasting methods for types

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1006,7 +1006,7 @@ impl<T> PyClassNewTextSignature<T> for &'_ PyClassImplCollector<T> {
 // Thread checkers
 
 #[doc(hidden)]
-pub trait PyClassThreadChecker<T>: Sized {
+pub trait PyClassThreadChecker<T: ?Sized>: Sized {
     fn ensure(&self);
     fn can_drop(&self, py: Python<'_>) -> bool;
     fn new() -> Self;
@@ -1097,7 +1097,7 @@ impl<T: PyClass + Send, U: PyClassBaseType> PyClassThreadChecker<T>
 }
 
 /// Trait denoting that this class is suitable to be used as a base type for PyClass.
-pub trait PyClassBaseType: Sized {
+pub trait PyClassBaseType {
     type LayoutAsBase: PyCellLayout<Self>;
     type BaseNativeType;
     type ThreadChecker: PyClassThreadChecker<Self>;

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -20,7 +20,7 @@ use std::{
 ///
 /// This trait is intended to use internally for distinguishing `#[pyclass]` and
 /// Python native types.
-pub trait PyObjectInit<T>: Sized {
+pub trait PyObjectInit<T: ?Sized>: Sized {
     /// # Safety
     /// - `subtype` must be a valid pointer to a type object of T or a subclass.
     unsafe fn into_new_object(

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -12,11 +12,15 @@ use crate::{ffi, AsPyPointer, PyNativeType, Python};
 /// # Safety
 ///
 /// This trait must only be implemented for types which represent valid layouts of Python objects.
-pub unsafe trait PyLayout<T> {}
+pub unsafe trait PyLayout<T: ?Sized> {}
 
 /// `T: PySizedLayout<U>` represents that `T` is not a instance of
 /// [`PyVarObject`](https://docs.python.org/3.8/c-api/structures.html?highlight=pyvarobject#c.PyVarObject).
 /// In addition, that `T` is a concrete representation of `U`.
+#[deprecated(
+    since = "0.20.0",
+    note = "this trait is no longer used by PyO3 and scheduled for removal"
+)]
 pub trait PySizedLayout<T>: PyLayout<T> + Sized {}
 
 /// Python type information.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -245,6 +245,7 @@ macro_rules! pyobject_native_type_core {
 macro_rules! pyobject_native_type_sized {
     ($name:ty, $layout:path $(;$generics:ident)*) => {
         unsafe impl $crate::type_object::PyLayout<$name> for $layout {}
+        #[allow(deprecated)]
         impl $crate::type_object::PySizedLayout<$name> for $layout {}
         impl<$($generics,)*> $crate::impl_::pyclass::PyClassBaseType for $name {
             type LayoutAsBase = $crate::pycell::PyCellBase<$layout>;


### PR DESCRIPTION
I noticed that with the long-term existence of `PyClassBaseType`, there was a section in the guide about `PySizedLayout` which wasn't helpful, as the compiler errors refer to `PyClassBaseType` (if you try to insert from a class which doesn't implement `PyClassBaseType`).

`PySizedLayout` is not actually necessary so I removed it from the constraints in the `PyCell` machinery and updated the guide. I've deprecated the trait so we can get rid of it as a cleanup later.

An interesting effect of this is that a few traits now wanted `T: ?Sized` bounds. I think there was no harm in adding this bounds, all of these traits are implementation details in my opinion.

(Just not placed inside `impl_` modules; should really consider doing that. Maybe I should add that as a separate commit?)