### PR TITLE
RFC: Add implementation of Iterator::size_hint for PyIterator

### DIFF
--- a/benches/bench_any.rs
+++ b/benches/bench_any.rs
@@ -5,7 +5,7 @@ use pyo3::{
         PyBool, PyByteArray, PyBytes, PyDict, PyFloat, PyFrozenSet, PyInt, PyList, PyMapping,
         PySequence, PySet, PyString, PyTuple,
     },
-    PyAny, Python,
+    PyAny, PyResult, Python,
 };
 
 #[derive(PartialEq, Eq, Debug)]
@@ -71,8 +71,23 @@ fn bench_identify_object_type(b: &mut Bencher<'_>) {
     });
 }
 
+fn bench_collect_generic_iterator(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let collection = py.eval("list(range(1 << 20))", None, None).unwrap();
+
+        b.iter(|| {
+            collection
+                .iter()
+                .unwrap()
+                .collect::<PyResult<Vec<_>>>()
+                .unwrap()
+        });
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("identify_object_type", bench_identify_object_type);
+    c.bench_function("collect_generic_iterator", bench_collect_generic_iterator);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/pyo3-ffi/src/boolobject.rs
+++ b/pyo3-ffi/src/boolobject.rs
@@ -24,12 +24,12 @@ extern "C" {
 
 #[inline]
 pub unsafe fn Py_False() -> *mut PyObject {
-    addr_of_mut!(_Py_FalseStruct) as *mut PyLongObject as *mut PyObject
+    addr_of_mut!(_Py_FalseStruct) as *mut PyObject
 }
 
 #[inline]
 pub unsafe fn Py_True() -> *mut PyObject {
-    addr_of_mut!(_Py_TrueStruct) as *mut PyLongObject as *mut PyObject
+    addr_of_mut!(_Py_TrueStruct) as *mut PyObject
 }
 
 #[inline]

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -179,7 +179,7 @@ pub fn take_pyo3_options<T: Parse>(attrs: &mut Vec<syn::Attribute>) -> Result<Ve
     let mut out = Vec::new();
     take_attributes(attrs, |attr| {
         if let Some(options) = get_pyo3_options(attr)? {
-            out.extend(options.into_iter());
+            out.extend(options);
             Ok(true)
         } else {
             Ok(false)

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -122,7 +122,7 @@ impl<T> Default for PyClassImplCollector<T> {
 
 impl<T> Clone for PyClassImplCollector<T> {
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -196,6 +196,7 @@ macro_rules! pyobject_native_type_info(
             const MODULE: ::std::option::Option<&'static str> = $module;
 
             #[inline]
+            #[allow(clippy::redundant_closure_call)]
             fn type_object_raw(py: $crate::Python<'_>) -> *mut $crate::ffi::PyTypeObject {
                 $typeobject(py)
             }


### PR DESCRIPTION
When the Python iterator backing `PyIterator` has a `__length_hint__` special method, we can use this as a lower bound for Rust's `Iterator::size_hint` to e.g. support pre-allocation of collections.

There are a few complications though:
* The cost of calling `lookup_special` and extracting the length hint might be too high compared to what typical users of `size_hint` expect.
* Python's `operator.length_hint` will first try `__len__` before falling back to `__length_hint__` which would be more robust but worsen the first issue.

Additionally, Python's and Rust's semantics do not really match up as the
single estimate given by `__length_hint__` might be wrong in both directions. To
support the use case of pre-allocating collections, it is used as the lower
bound and correctness should never depend on it being correct, but it might lead
to unnecessary over-allocations.