### PR TITLE
fix exception handling on Python 3.12

### DIFF
--- a/newsfragments/3306.changed.md
+++ b/newsfragments/3306.changed.md
@@ -1,0 +1,1 @@
+Update `PyErr` for 3.12 betas to avoid deprecated ffi methods.


### PR DESCRIPTION
Reworked exception handling for Python 3.12. Ref #3305 

The simplifications to `PyErrState` result in a ~10-15% perf improvement in the `bench_err` benchmarks on all Python versions. On 3.12 the enum size has been reduced from 32 to 24 bytes, which might have small global perf benefits too.

While working on this I noticed a bug on <3.12 where the original panic message is not retrieved properly in `PyErr::fetch` if the `PanicException` is normalised. I've added that as a second commit.