### PR TITLE
normalize exception in `PyErr::matches` and `PyErr::is_instance`

### DIFF
--- a/newsfragments/3313.fixed.md
+++ b/newsfragments/3313.fixed.md
@@ -1,0 +1,1 @@
+Fix case where `PyErr::matches` and `PyErr::is_instance` returned results inconsistent with `PyErr::get_type`.

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -68,11 +68,17 @@ impl PyErrState {
                     )
                 }
             }
-            PyErrState::LazyValue { ptype, pvalue } => (
-                ptype.into_ptr(),
-                pvalue(py).into_ptr(),
-                std::ptr::null_mut(),
-            ),
+            PyErrState::LazyValue { ptype, pvalue } => {
+                if unsafe { ffi::PyExceptionClass_Check(ptype.as_ptr()) } == 0 {
+                    Self::exceptions_must_derive_from_base_exception(py).into_ffi_tuple(py)
+                } else {
+                    (
+                        ptype.into_ptr(),
+                        pvalue(py).into_ptr(),
+                        std::ptr::null_mut(),
+                    )
+                }
+            }
             PyErrState::FfiTuple {
                 ptype,
                 pvalue,


### PR DESCRIPTION
Split off from #3306 

This fixes a case where `PyErr::matches` and `PyErr::is_instance` could return results inconsistent with `PyErr::get_type` due to the first two methods not ensuring the exception was normalised.