### PR TITLE
codecov: ignore coverage for pytests directory

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,5 +10,5 @@ coverage:
 
 ignore:
   - tests/*.rs
+  - pytests/*.rs
   - src/test_hygiene/*.rs
-  - src/impl_/ghost.rs


### PR DESCRIPTION
I noticed in the codecov reports we are including the coverage of the `pytests` directory. This isn't really relevant to users as it's just test code (just as we ignore `tests/`), so this PR updates the codecov configuration.