### PR TITLE
clippy: deny / fix used-underscope-binding lint

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -13,6 +13,7 @@ rustflags = [
     "-Dclippy::todo",
     "-Dclippy::unnecessary_wraps",
     "-Dclippy::useless_transmute",
+    "-Dclippy::used_underscore_binding",
     "-Delided_lifetimes_in_paths",
     "-Dunused_lifetimes",
     "-Drust_2021_prelude_collisions"

--- a/pyo3-ffi/src/cpython/abstract_.rs
+++ b/pyo3-ffi/src/cpython/abstract_.rs
@@ -177,8 +177,8 @@ extern "C" {
 #[inline(always)]
 pub unsafe fn PyObject_CallOneArg(func: *mut PyObject, arg: *mut PyObject) -> *mut PyObject {
     assert!(!arg.is_null());
-    let _args = [std::ptr::null_mut(), arg];
-    let args = _args.as_ptr().offset(1); // For PY_VECTORCALL_ARGUMENTS_OFFSET
+    let args_array = [std::ptr::null_mut(), arg];
+    let args = args_array.as_ptr().offset(1); // For PY_VECTORCALL_ARGUMENTS_OFFSET
     let tstate = PyThreadState_GET();
     let nargsf = 1 | PY_VECTORCALL_ARGUMENTS_OFFSET;
     _PyObject_VectorcallTstate(tstate, func, args, nargsf as size_t, std::ptr::null_mut())

--- a/pyo3-ffi/src/cpython/unicodeobject.rs
+++ b/pyo3-ffi/src/cpython/unicodeobject.rs
@@ -148,8 +148,8 @@ const STATE_READY_WIDTH: u8 = 1;
 #[repr(C)]
 #[repr(align(4))]
 struct PyASCIIObjectState {
-    _bitfield_align: [u8; 0],
-    _bitfield: BitfieldUnit<[u8; 4usize]>,
+    bitfield_align: [u8; 0],
+    bitfield: BitfieldUnit<[u8; 4usize]>,
 }
 
 // c_uint and u32 are not necessarily the same type on all targets / architectures
@@ -158,7 +158,7 @@ impl PyASCIIObjectState {
     #[inline]
     unsafe fn interned(&self) -> c_uint {
         std::mem::transmute(
-            self._bitfield
+            self.bitfield
                 .get(STATE_INTERNED_INDEX, STATE_INTERNED_WIDTH) as u32,
         )
     }
@@ -166,57 +166,57 @@ impl PyASCIIObjectState {
     #[inline]
     unsafe fn set_interned(&mut self, val: c_uint) {
         let val: u32 = std::mem::transmute(val);
-        self._bitfield
+        self.bitfield
             .set(STATE_INTERNED_INDEX, STATE_INTERNED_WIDTH, val as u64)
     }
 
     #[inline]
     unsafe fn kind(&self) -> c_uint {
-        std::mem::transmute(self._bitfield.get(STATE_KIND_INDEX, STATE_KIND_WIDTH) as u32)
+        std::mem::transmute(self.bitfield.get(STATE_KIND_INDEX, STATE_KIND_WIDTH) as u32)
     }
 
     #[inline]
     unsafe fn set_kind(&mut self, val: c_uint) {
         let val: u32 = std::mem::transmute(val);
-        self._bitfield
+        self.bitfield
             .set(STATE_KIND_INDEX, STATE_KIND_WIDTH, val as u64)
     }
 
     #[inline]
     unsafe fn compact(&self) -> c_uint {
-        std::mem::transmute(self._bitfield.get(STATE_COMPACT_INDEX, STATE_COMPACT_WIDTH) as u32)
+        std::mem::transmute(self.bitfield.get(STATE_COMPACT_INDEX, STATE_COMPACT_WIDTH) as u32)
     }
 
     #[inline]
     unsafe fn set_compact(&mut self, val: c_uint) {
         let val: u32 = std::mem::transmute(val);
-        self._bitfield
+        self.bitfield
             .set(STATE_COMPACT_INDEX, STATE_COMPACT_WIDTH, val as u64)
     }
 
     #[inline]
     unsafe fn ascii(&self) -> c_uint {
-        std::mem::transmute(self._bitfield.get(STATE_ASCII_INDEX, STATE_ASCII_WIDTH) as u32)
+        std::mem::transmute(self.bitfield.get(STATE_ASCII_INDEX, STATE_ASCII_WIDTH) as u32)
     }
 
     #[inline]
     unsafe fn set_ascii(&mut self, val: c_uint) {
         let val: u32 = std::mem::transmute(val);
-        self._bitfield
+        self.bitfield
             .set(STATE_ASCII_INDEX, STATE_ASCII_WIDTH, val as u64)
     }
 
     #[cfg(not(Py_3_12))]
     #[inline]
     unsafe fn ready(&self) -> c_uint {
-        std::mem::transmute(self._bitfield.get(STATE_READY_INDEX, STATE_READY_WIDTH) as u32)
+        std::mem::transmute(self.bitfield.get(STATE_READY_INDEX, STATE_READY_WIDTH) as u32)
     }
 
     #[cfg(not(Py_3_12))]
     #[inline]
     unsafe fn set_ready(&mut self, val: c_uint) {
         let val: u32 = std::mem::transmute(val);
-        self._bitfield
+        self.bitfield
             .set(STATE_READY_INDEX, STATE_READY_WIDTH, val as u64)
     }
 }
@@ -225,8 +225,8 @@ impl From<u32> for PyASCIIObjectState {
     #[inline]
     fn from(value: u32) -> Self {
         PyASCIIObjectState {
-            _bitfield_align: [],
-            _bitfield: BitfieldUnit::new(value.to_ne_bytes()),
+            bitfield_align: [],
+            bitfield: BitfieldUnit::new(value.to_ne_bytes()),
         }
     }
 }
@@ -234,7 +234,7 @@ impl From<u32> for PyASCIIObjectState {
 impl From<PyASCIIObjectState> for u32 {
     #[inline]
     fn from(value: PyASCIIObjectState) -> Self {
-        u32::from_ne_bytes(value._bitfield.storage)
+        u32::from_ne_bytes(value.bitfield.storage)
     }
 }
 

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -156,7 +156,7 @@ impl ExtractErrorMode {
 impl SelfType {
     pub fn receiver(&self, cls: &syn::Type, error_mode: ExtractErrorMode) -> TokenStream {
         let py = syn::Ident::new("_py", Span::call_site());
-        let _slf = syn::Ident::new("_slf", Span::call_site());
+        let slf = syn::Ident::new("_slf", Span::call_site());
         match self {
             SelfType::Receiver { span, mutable } => {
                 let method = if *mutable {
@@ -168,7 +168,7 @@ impl SelfType {
                     &py,
                     quote_spanned! { *span =>
                         _pyo3::impl_::extract_argument::#method::<#cls>(
-                            #py.from_borrowed_ptr::<_pyo3::PyAny>(#_slf),
+                            #py.from_borrowed_ptr::<_pyo3::PyAny>(#slf),
                             &mut { _pyo3::impl_::extract_argument::FunctionArgumentHolder::INIT },
                         )
                     },
@@ -178,10 +178,10 @@ impl SelfType {
                 error_mode.handle_error(
                     &py,
                     quote_spanned! { *span =>
-                        #py.from_borrowed_ptr::<_pyo3::PyAny>(#_slf).downcast::<_pyo3::PyCell<#cls>>()
+                        #py.from_borrowed_ptr::<_pyo3::PyAny>(#slf).downcast::<_pyo3::PyCell<#cls>>()
                             .map_err(::std::convert::Into::<_pyo3::PyErr>::into)
                             .and_then(
-                                #[allow(clippy::useless_conversion)]  // In case _slf is PyCell<Self>
+                                #[allow(clippy::useless_conversion)]  // In case slf is PyCell<Self>
                                 |cell| ::std::convert::TryFrom::try_from(cell).map_err(::std::convert::Into::into)
                             )
 

--- a/src/pyclass/gc.rs
+++ b/src/pyclass/gc.rs
@@ -38,7 +38,11 @@ impl<'p> PyVisit<'p> {
 
     /// Creates the PyVisit from the arguments to tp_traverse
     #[doc(hidden)]
-    pub unsafe fn from_raw(visit: ffi::visitproc, arg: *mut c_void, _py: Python<'p>) -> Self {
-        Self { visit, arg, _py }
+    pub unsafe fn from_raw(visit: ffi::visitproc, arg: *mut c_void, py: Python<'p>) -> Self {
+        Self {
+            visit,
+            arg,
+            _py: py,
+        }
     }
 }

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -82,14 +82,14 @@ fn tuple_class_with_new() {
 #[pyclass]
 #[derive(Debug)]
 struct NewWithOneArg {
-    _data: i32,
+    data: i32,
 }
 
 #[pymethods]
 impl NewWithOneArg {
     #[new]
     fn new(arg: i32) -> NewWithOneArg {
-        NewWithOneArg { _data: arg }
+        NewWithOneArg { data: arg }
     }
 }
 
@@ -100,14 +100,14 @@ fn new_with_one_arg() {
         let wrp = typeobj.call((42,), None).unwrap();
         let obj = wrp.downcast::<PyCell<NewWithOneArg>>().unwrap();
         let obj_ref = obj.borrow();
-        assert_eq!(obj_ref._data, 42);
+        assert_eq!(obj_ref.data, 42);
     });
 }
 
 #[pyclass]
 struct NewWithTwoArgs {
-    _data1: i32,
-    _data2: i32,
+    data1: i32,
+    data2: i32,
 }
 
 #[pymethods]
@@ -115,8 +115,8 @@ impl NewWithTwoArgs {
     #[new]
     fn new(arg1: i32, arg2: i32) -> Self {
         NewWithTwoArgs {
-            _data1: arg1,
-            _data2: arg2,
+            data1: arg1,
+            data2: arg2,
         }
     }
 }
@@ -131,8 +131,8 @@ fn new_with_two_args() {
             .unwrap();
         let obj = wrp.downcast::<PyCell<NewWithTwoArgs>>().unwrap();
         let obj_ref = obj.borrow();
-        assert_eq!(obj_ref._data1, 10);
-        assert_eq!(obj_ref._data2, 20);
+        assert_eq!(obj_ref.data1, 10);
+        assert_eq!(obj_ref.data2, 20);
     });
 }
 

--- a/tests/test_pep_587.rs
+++ b/tests/test_pep_587.rs
@@ -29,7 +29,10 @@ fn test_default_interpreter() {
     unsafe { ffi::PyConfig_InitPythonConfig(&mut config) };
 
     // Require manually calling _Py_InitializeMain to exercise more ffi code
-    config._init_main = 0;
+    #[allow(clippy::used_underscore_binding)]
+    {
+        config._init_main = 0;
+    }
 
     #[cfg(Py_3_10)]
     unsafe {

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -14,14 +14,14 @@ struct EmptyClass;
 struct ExampleClass {
     #[pyo3(get, set)]
     value: i32,
-    _custom_attr: Option<i32>,
+    custom_attr: Option<i32>,
 }
 
 #[pymethods]
 impl ExampleClass {
     fn __getattr__(&self, py: Python<'_>, attr: &str) -> PyResult<PyObject> {
         if attr == "special_custom_attr" {
-            Ok(self._custom_attr.into_py(py))
+            Ok(self.custom_attr.into_py(py))
         } else {
             Err(PyAttributeError::new_err(attr.to_string()))
         }
@@ -29,7 +29,7 @@ impl ExampleClass {
 
     fn __setattr__(&mut self, attr: &str, value: &PyAny) -> PyResult<()> {
         if attr == "special_custom_attr" {
-            self._custom_attr = Some(value.extract()?);
+            self.custom_attr = Some(value.extract()?);
             Ok(())
         } else {
             Err(PyAttributeError::new_err(attr.to_string()))
@@ -38,7 +38,7 @@ impl ExampleClass {
 
     fn __delattr__(&mut self, attr: &str) -> PyResult<()> {
         if attr == "special_custom_attr" {
-            self._custom_attr = None;
+            self.custom_attr = None;
             Ok(())
         } else {
             Err(PyAttributeError::new_err(attr.to_string()))
@@ -68,7 +68,7 @@ fn make_example(py: Python<'_>) -> &PyCell<ExampleClass> {
         py,
         ExampleClass {
             value: 5,
-            _custom_attr: Some(20),
+            custom_attr: Some(20),
         },
     )
     .unwrap()


### PR DESCRIPTION
When trying to deny the `clippy::used-underscore-binding` lint in some downstream code, I hit errors originating from PyO3's macros which couldn't be silenced without putting an `#![allow(clippy::used-underscore-binding)]` in the containing module.

Draft for now because #3318 will affect the same code and I don't feel a need to create a merge conflict with myself. 😂 