### PR TITLE
collect arrays of objects prior to filling tuple in fixed-size conversions

### DIFF
--- a/benches/bench_tuple.rs
+++ b/benches/bench_tuple.rs
@@ -83,6 +83,12 @@ fn tuple_to_list(b: &mut Bencher<'_>) {
     });
 }
 
+fn tuple_into_py(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        b.iter(|| -> PyObject { (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12).into_py(py) });
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("iter_tuple", iter_tuple);
     c.bench_function("tuple_new", tuple_new);
@@ -92,6 +98,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("sequence_from_tuple", sequence_from_tuple);
     c.bench_function("tuple_new_list", tuple_new_list);
     c.bench_function("tuple_to_list", tuple_to_list);
+    c.bench_function("tuple_into_py", tuple_into_py);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/newsfragments/3321.changed.md
+++ b/newsfragments/3321.changed.md
@@ -1,0 +1,1 @@
+Optimize conversion of Rust tuples to Python tuples.

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -284,22 +284,12 @@ fn wrong_tuple_length(t: &PyTuple, expected_length: usize) -> PyErr {
 macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+} => {
     impl <$($T: ToPyObject),+> ToPyObject for ($($T,)+) {
         fn to_object(&self, py: Python<'_>) -> PyObject {
-            unsafe {
-                let ptr = ffi::PyTuple_New($length);
-                let ret = PyObject::from_owned_ptr(py, ptr);
-                $(ffi::PyTuple_SetItem(ptr, $n, self.$n.to_object(py).into_ptr());)+
-                ret
-            }
+            array_into_tuple(py, [$(self.$n.to_object(py)),+]).into()
         }
     }
     impl <$($T: IntoPy<PyObject>),+> IntoPy<PyObject> for ($($T,)+) {
         fn into_py(self, py: Python<'_>) -> PyObject {
-            unsafe {
-                let ptr = ffi::PyTuple_New($length);
-                let ret =  PyObject::from_owned_ptr(py, ptr);
-                $(ffi::PyTuple_SetItem(ptr, $n, self.$n.into_py(py).into_ptr());)+
-               ret
-            }
+            array_into_tuple(py, [$(self.$n.into_py(py)),+]).into()
         }
 
         #[cfg(feature = "experimental-inspect")]
@@ -310,12 +300,7 @@ fn type_output() -> TypeInfo {
 
     impl <$($T: IntoPy<PyObject>),+> IntoPy<Py<PyTuple>> for ($($T,)+) {
         fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
-            unsafe {
-                let ptr = ffi::PyTuple_New($length);
-                let ret = Py::from_owned_ptr(py, ptr);
-                $(ffi::PyTuple_SetItem(ptr, $n, self.$n.into_py(py).into_ptr());)+
-                ret
-            }
+            array_into_tuple(py, [$(self.$n.into_py(py)),+])
         }
 
         #[cfg(feature = "experimental-inspect")]
@@ -345,6 +330,20 @@ fn type_input() -> TypeInfo {
         }
     }
 });
+
+fn array_into_tuple<const N: usize>(py: Python<'_>, array: [PyObject; N]) -> Py<PyTuple> {
+    unsafe {
+        let ptr = ffi::PyTuple_New(N.try_into().expect("0 < N <= 12"));
+        let tup = Py::from_owned_ptr(py, ptr);
+        for (index, obj) in array.into_iter().enumerate() {
+            #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+            ffi::PyTuple_SET_ITEM(ptr, index as ffi::Py_ssize_t, obj.into_ptr());
+            #[cfg(any(Py_LIMITED_API, PyPy))]
+            ffi::PyTuple_SetItem(ptr, index as ffi::Py_ssize_t, obj.into_ptr());
+        }
+        tup
+    }
+}
 
 tuple_conversion!(1, (ref0, 0, T0));
 tuple_conversion!(2, (ref0, 0, T0), (ref1, 1, T1));


### PR DESCRIPTION
Replacement to #3296.

As discussed there, we believe it's safe to use `PyTuple_New` when there is confidence of no Python code running while filling the uninitialized tuple.

Therefore in this PR I adjust the fixed-size conversions to collect into an array and then fill the tuple. I also happened to manage to optimize this by use of a const-generic helper which uses `PyTuple_SET_ITEM` (on the stable abi).

Benchmark shows this is ~20% faster than `main`, and should be safer too:

```
main
tuple_into_py           time:   [59.337 ns 59.947 ns 60.588 ns]

safer-tuple-into-py
tuple_into_py           time:   [46.143 ns 46.567 ns 47.005 ns]
```

I tried the same thing for `PyTuple::new` (the variable sized constructor) with a `Vec`, but that worked out around 20% slower, so I haven't included that here for now.