### PR TITLE
Add tzfpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ about this topic.
 - [rust-python-coverage](https://github.com/cjermain/rust-python-coverage) _Example PyO3 project with automated test coverage for Rust and Python._
 - [tiktoken](https://github.com/openai/tiktoken) _A fast BPE tokeniser for use with OpenAI's models._
 - [tokenizers](https://github.com/huggingface/tokenizers/tree/main/bindings/python) _Python bindings to the Hugging Face tokenizers (NLP) written in Rust._
+- [tzfpy](http://github.com/ringsaturn/tzfpy) _A fast package to convert longitude/latitude to timezone name._
 - [wasmer-python](https://github.com/wasmerio/wasmer-python) _Python library to run WebAssembly binaries._
 
 ## Articles and other media


### PR DESCRIPTION
Add [tzfpy](https://github.com/ringsaturn/tzfpy), a simple Python binding of [tzf-rs](https://github.com/ringsaturn/tzf-rs) to convert longitude/latitude to timezone name.

It's also an example project about how to build&publish Rust binding package with maturin and GitHub Actions, since it's core code is [less than 30 lines](https://github.com/ringsaturn/tzfpy/blob/main/src/lib.rs)

