### PR TITLE
Preserve panic message after exception is normalized

### DIFF
--- a/newsfragments/3326.fixed.md
+++ b/newsfragments/3326.fixed.md
@@ -1,0 +1,1 @@
+Fix loss of panic message in `PanicException` when unwinding after the exception was "normalized".


### PR DESCRIPTION
Split off from #3306 

This was a bug I noticed on pre-3.12 Pythons where the panic message would not be extracted correctly if the `PanicException` had been normalised. After being fetched by PyO3 the `PanicException` would have its message reset to "Unwrapped panic from Python code".