### PR TITLE
Install wheel for the setuptools-rust-starter example

### DIFF
--- a/examples/setuptools-rust-starter/requirements-dev.txt
+++ b/examples/setuptools-rust-starter/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest>=3.5.0
 setuptools_rust~=1.0.0
 pip>=21.3
+wheel


### PR DESCRIPTION
Seems to be needed on python 3.12
