### PR TITLE
add 3.12 and PyPy 3.10 to clippy jobs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -15,8 +15,8 @@ nox.options.sessions = ["test", "clippy", "fmt", "docs"]
 
 
 PYO3_DIR = Path(__file__).parent
-PY_VERSIONS = ("3.7", "3.8", "3.9", "3.10", "3.11")
-PYPY_VERSIONS = ("3.7", "3.8", "3.9")
+PY_VERSIONS = ("3.7", "3.8", "3.9", "3.10", "3.11", "3.12")
+PYPY_VERSIONS = ("3.7", "3.8", "3.9", "3.10")
 
 
 @nox.session(venv_backend="none")


### PR DESCRIPTION
To help CI catch compile errors.