### PR TITLE
ci: avoid failure to build numpy on 3.12

### DIFF
--- a/pytests/noxfile.py
+++ b/pytests/noxfile.py
@@ -1,21 +1,24 @@
 import nox
-import platform
+from nox.command import CommandFailed
 
 nox.options.sessions = ["test"]
 
 
 @nox.session
-def test(session):
+def test(session: nox.Session):
     session.install("-rrequirements-dev.txt")
-    if platform.system() == "Linux" and platform.python_implementation() == "CPython":
-        session.install("numpy>=1.16")
+    try:
+        session.install("--only-binary=numpy", "numpy>=1.16")
+    except CommandFailed:
+        # No binary wheel for numpy available on this platform
+        pass
     session.install("maturin")
     session.run_always("maturin", "develop")
     session.run("pytest", *session.posargs)
 
 
 @nox.session
-def bench(session):
+def bench(session: nox.Session):
     session.install("-rrequirements-dev.txt")
     session.install(".")
     session.run("pytest", "--benchmark-enable", "--benchmark-only", *session.posargs)

--- a/pytests/tests/test_sequence.py
+++ b/pytests/tests/test_sequence.py
@@ -1,5 +1,4 @@
 import pytest
-import platform
 
 from pyo3_pytests import sequence
 
@@ -21,21 +20,15 @@ def test_vec_from_str():
         sequence.vec_to_vec_pystring("123")
 
 
-@pytest.mark.skipif(
-    platform.system() != "Linux" or platform.python_implementation() != "CPython",
-    reason="Binary NumPy wheels are not available for all platforms and Python implementations",
-)
 def test_vec_from_array():
-    import numpy
+    # binary numpy wheel not available on all platforms
+    numpy = pytest.importorskip("numpy")
 
     assert sequence.vec_to_vec_i32(numpy.array([1, 2, 3])) == [1, 2, 3]
 
 
-@pytest.mark.skipif(
-    platform.system() != "Linux" or platform.python_implementation() != "CPython",
-    reason="Binary NumPy wheels are not available for all platforms and Python implementations",
-)
 def test_rust_array_from_array():
-    import numpy
+    # binary numpy wheel not available on all platforms
+    numpy = pytest.importorskip("numpy")
 
     assert sequence.array_to_array_i32(numpy.array([1, 2, 3])) == [1, 2, 3]


### PR DESCRIPTION
We have a failure in https://github.com/PyO3/pyo3/actions/runs/5630694427/job/15256941839?pr=3335 which is caused because  `numpy` hasn't published binary wheels for 3.12 yet.

This PR reworks the noxfile and corresponding tests a little bit so that `numpy` tests are automatically skipped on platforms without a numpy binary wheel available.