### PR TITLE
Add PyType_GetDict for Python 3.12

### DIFF
--- a/newsfragments/3339.added.md
+++ b/newsfragments/3339.added.md
@@ -1,0 +1,1 @@
+Define `PyType_GetDict()` FFI for CPython 3.12 or later.

--- a/pyo3-ffi/src/cpython/object.rs
+++ b/pyo3-ffi/src/cpython/object.rs
@@ -349,6 +349,9 @@ pub unsafe fn PyHeapType_GET_MEMBERS(
 // skipped _PyType_GetModuleByDef
 
 extern "C" {
+    #[cfg(Py_3_12)]
+    pub fn PyType_GetDict(o: *mut PyTypeObject) -> *mut PyObject;
+
     #[cfg_attr(PyPy, link_name = "PyPyObject_Print")]
     pub fn PyObject_Print(o: *mut PyObject, fp: *mut ::libc::FILE, flags: c_int) -> c_int;
 


### PR DESCRIPTION
`PyType_GetDict` was added in Python 3.12 to safely access `tp_dict`.

```c
PyAPI_FUNC(PyObject *) PyType_GetDict(PyTypeObject *);
```

https://github.com/python/cpython/blob/v3.12.0b4/Include/cpython/object.h#L286
https://github.com/python/cpython/blob/v3.12.0b4/Objects/typeobject.c#L241-L246

https://docs.python.org/3.12/c-api/type.html#c.PyType_GetDict
https://docs.python.org/3.12/c-api/typeobj.html#c.PyTypeObject.tp_dict
https://docs.python.org/3.12/whatsnew/changelog.html?highlight=pytype_getdict#c-api