### PR TITLE
ci: stop allowing failure for pypy 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build:
-    continue-on-error: ${{ endsWith(inputs.python-version, '-dev') || contains(fromJSON('["3.7", "pypy3.7", "pypy3.10"]'), inputs.python-version) }}
+    continue-on-error: ${{ endsWith(inputs.python-version, '-dev') || contains(fromJSON('["3.7", "pypy3.7"]'), inputs.python-version) }}
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
While working on #3342 I noticed that we still allow failure for PyPy 3.10 in CI. We declared support for PyPy 3.10 in 0.19.1, so I believe we should now require a corresponding successful job. (CI has been passing so this is mostly to make it blocking for future contributions.)