### PR TITLE
fix compile failure for getter with return lifetime of self

### DIFF
--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -19,6 +19,7 @@ mod pyclass;
 mod pyfunction;
 mod pyimpl;
 mod pymethod;
+mod quotes;
 
 pub use frompyobject::build_derive_from_pyobject;
 pub use module::{process_functions_in_module, pymodule_impl, PyModuleOptions};

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -2,6 +2,7 @@ use crate::attributes::{TextSignatureAttribute, TextSignatureAttributeValue};
 use crate::params::impl_arg_params;
 use crate::pyfunction::{FunctionSignature, PyFunctionArgPyO3Attributes};
 use crate::pyfunction::{PyFunctionOptions, SignatureAttribute};
+use crate::quotes;
 use crate::utils::{self, PythonDoc};
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
@@ -413,11 +414,7 @@ impl<'a> FnSpec<'a> {
         let func_name = &self.name;
 
         let rust_call = |args: Vec<TokenStream>| {
-            quote! {
-                _pyo3::impl_::pymethods::OkWrap::wrap(function(#self_arg #(#args),*), #py)
-                    .map(|obj| _pyo3::conversion::IntoPyPointer::into_ptr(obj))
-                    .map_err(::core::convert::Into::into)
-            }
+            quotes::map_result_into_ptr(quotes::ok_wrap(quote! { function(#self_arg #(#args),*) }))
         };
 
         let rust_name = if let Some(cls) = cls {

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -115,12 +115,12 @@ impl FnType {
             }
             FnType::FnClass | FnType::FnNewClass => {
                 quote! {
-                    _pyo3::types::PyType::from_type_ptr(_py, _slf as *mut _pyo3::ffi::PyTypeObject),
+                    _pyo3::types::PyType::from_type_ptr(py, _slf as *mut _pyo3::ffi::PyTypeObject),
                 }
             }
             FnType::FnModule => {
                 quote! {
-                    _py.from_borrowed_ptr::<_pyo3::types::PyModule>(_slf),
+                    py.from_borrowed_ptr::<_pyo3::types::PyModule>(_slf),
                 }
             }
         }
@@ -155,7 +155,7 @@ impl ExtractErrorMode {
 
 impl SelfType {
     pub fn receiver(&self, cls: &syn::Type, error_mode: ExtractErrorMode) -> TokenStream {
-        let py = syn::Ident::new("_py", Span::call_site());
+        let py = syn::Ident::new("py", Span::call_site());
         let slf = syn::Ident::new("_slf", Span::call_site());
         match self {
             SelfType::Receiver { span, mutable } => {
@@ -409,7 +409,7 @@ impl<'a> FnSpec<'a> {
         cls: Option<&syn::Type>,
     ) -> Result<TokenStream> {
         let self_arg = self.tp.self_arg(cls, ExtractErrorMode::Raise);
-        let py = syn::Ident::new("_py", Span::call_site());
+        let py = syn::Ident::new("py", Span::call_site());
         let func_name = &self.name;
 
         let rust_call = |args: Vec<TokenStream>| {

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1070,7 +1070,7 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote! {
                 impl _pyo3::impl_::pyclass::PyClassWithFreeList for #cls {
                     #[inline]
-                    fn get_free_list(_py: _pyo3::Python<'_>) -> &mut _pyo3::impl_::freelist::FreeList<*mut _pyo3::ffi::PyObject> {
+                    fn get_free_list(py: _pyo3::Python<'_>) -> &mut _pyo3::impl_::freelist::FreeList<*mut _pyo3::ffi::PyObject> {
                         static mut FREELIST: *mut _pyo3::impl_::freelist::FreeList<*mut _pyo3::ffi::PyObject> = 0 as *mut _;
                         unsafe {
                             if FREELIST.is_null() {

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -625,7 +625,7 @@ pub fn impl_py_getter_def(
     let python_name = property_type.null_terminated_python_name()?;
     let doc = property_type.doc();
 
-    let getter_impl = match property_type {
+    let body = match property_type {
         PropertyType::Descriptor {
             field_index, field, ..
         } => {
@@ -634,31 +634,28 @@ pub fn impl_py_getter_def(
                 span: Span::call_site(),
             }
             .receiver(cls, ExtractErrorMode::Raise);
-            if let Some(ident) = &field.ident {
+            let field_token = if let Some(ident) = &field.ident {
                 // named struct field
-                quote!(::std::clone::Clone::clone(&(#slf.#ident)))
+                ident.to_token_stream()
             } else {
                 // tuple struct field
-                let index = syn::Index::from(field_index);
-                quote!(::std::clone::Clone::clone(&(#slf.#index)))
-            }
-        }
-        PropertyType::Function {
-            spec, self_type, ..
-        } => impl_call_getter(cls, spec, self_type)?,
-    };
-
-    let conversion = match property_type {
-        PropertyType::Descriptor { .. } => {
+                syn::Index::from(field_index).to_token_stream()
+            };
             quote! {
-                let item: _pyo3::Py<_pyo3::PyAny> = _pyo3::IntoPy::into_py(item, _py);
-                ::std::result::Result::Ok(_pyo3::conversion::IntoPyPointer::into_ptr(item))
+                ::std::result::Result::Ok(
+                    _pyo3::conversion::IntoPyPointer::into_ptr(
+                        _pyo3::IntoPy::<_pyo3::Py<_pyo3::PyAny>>::into_py(::std::clone::Clone::clone(&(#slf.#field_token)), _py)
+                    )
+                )
             }
         }
         // Forward to `IntoPyCallbackOutput`, to handle `#[getter]`s returning results.
-        PropertyType::Function { .. } => {
+        PropertyType::Function {
+            spec, self_type, ..
+        } => {
+            let call = impl_call_getter(cls, spec, self_type)?;
             quote! {
-                _pyo3::callback::convert(_py, item)
+                _pyo3::callback::convert(_py, #call)
             }
         }
     };
@@ -697,8 +694,7 @@ pub fn impl_py_getter_def(
             _py: _pyo3::Python<'_>,
             _slf: *mut _pyo3::ffi::PyObject
         ) -> _pyo3::PyResult<*mut _pyo3::ffi::PyObject> {
-            let item = #getter_impl;
-            #conversion
+            #body
         }
     };
 

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -1,0 +1,15 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub(crate) fn ok_wrap(obj: TokenStream) -> TokenStream {
+    quote! {
+        _pyo3::impl_::pymethods::OkWrap::wrap(#obj, py)
+            .map_err(::core::convert::Into::into)
+    }
+}
+
+pub(crate) fn map_result_into_ptr(result: TokenStream) -> TokenStream {
+    quote! {
+        #result.map(_pyo3::IntoPyPointer::into_ptr)
+    }
+}

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -216,3 +216,23 @@ fn cell_getter_setter() {
         );
     });
 }
+
+#[test]
+fn borrowed_value_with_lifetime_of_self() {
+    #[pyclass]
+    struct BorrowedValue {}
+
+    #[pymethods]
+    impl BorrowedValue {
+        #[getter]
+        fn value(&self) -> &str {
+            "value"
+        }
+    }
+
+    Python::with_gil(|py| {
+        let inst = Py::new(py, BorrowedValue {}).unwrap().to_object(py);
+
+        py_run!(py, inst, "assert inst.value == 'value'");
+    });
+}


### PR DESCRIPTION
While testing `main` downstream I noticed a compile failure caused by #3318, when the value returned from a `#[getter]` has the same lifetime as the `&self` receiver.

This PR adds a corresponding test and fixes it. The solution is the usual trend for the macro function bodies towards expressions; there is a sequence of statements along the lines of `let item = ...; return convert(item)`, the PR changes this to just be `convert(...)`.

This doesn't need a changelog entry as the compile failure never hit a released version.