### PR TITLE
Add a `PySlice::full()` constructor for `::`

### DIFF
--- a/newsfragments/3353.added.md
+++ b/newsfragments/3353.added.md
@@ -1,0 +1,1 @@
+Add `PySlice::full()` to construct a full slice (`::`).

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -54,6 +54,14 @@ impl PySlice {
         }
     }
 
+    /// Constructs a new full slice that is equivalent to `::`.
+    pub fn full(py: Python<'_>) -> &PySlice {
+        unsafe {
+            let ptr = ffi::PySlice_New(ffi::Py_None(), ffi::Py_None(), ffi::Py_None());
+            py.from_owned_ptr(ptr)
+        }
+    }
+
     /// Retrieves the start, stop, and step indices from the slice object,
     /// assuming a sequence of length `length`, and stores the length of the
     /// slice in its `slicelength` member.
@@ -112,6 +120,34 @@ mod tests {
             assert_eq!(
                 slice.getattr("step").unwrap().extract::<isize>().unwrap(),
                 1
+            );
+        });
+    }
+
+    #[test]
+    fn test_py_slice_full() {
+        Python::with_gil(|py| {
+            let slice = PySlice::full(py);
+            assert!(slice.getattr("start").unwrap().is_none(),);
+            assert!(slice.getattr("stop").unwrap().is_none(),);
+            assert!(slice.getattr("step").unwrap().is_none(),);
+            assert_eq!(
+                slice.indices(0).unwrap(),
+                PySliceIndices {
+                    start: 0,
+                    stop: 0,
+                    step: 1,
+                    slicelength: 0,
+                },
+            );
+            assert_eq!(
+                slice.indices(42).unwrap(),
+                PySliceIndices {
+                    start: 0,
+                    stop: 42,
+                    step: 1,
+                    slicelength: 42,
+                },
             );
         });
     }


### PR DESCRIPTION
Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be licensed under PyO3's [Apache-2.0 license](https://github.com/PyO3/pyo3#license).

PyO3 is currently undergoing a relicensing process to match Rust's dual-license under `Apache-2.0` and `MIT` licenses. While that process is ongoing, if you are a first-time contributor please add your agreement as a comment in [#3108](https://github.com/PyO3/pyo3/pull/3108).

Please consider adding the following to your pull request:
 - [x] an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
 - [x] docs to all new functions and / or detail in the guide
 - [x] tests for all new or changed functions

PyO3's CI pipeline will check your pull request. To run its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
