### PR TITLE
convert `&'py PyList` -> `Py2<'py, PyList>`

### DIFF
--- a/examples/decorator/src/lib.rs
+++ b/examples/decorator/src/lib.rs
@@ -41,7 +41,7 @@ impl PyCounter {
         &self,
         py: Python<'_>,
         args: &PyTuple,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<Py2<'_, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
         let old_count = self.count.get();
         let new_count = old_count + 1;
@@ -51,7 +51,7 @@ impl PyCounter {
         println!("{} has been called {} time(s).", name, new_count);
 
         // After doing something, we finally forward the call to the wrapped function
-        let ret = self.wraps.call(py, args, kwargs)?;
+        let ret = self.wraps.call(py, args, kwargs.as_ref())?;
 
         // We could do something with the return value of
         // the function before returning it

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -75,7 +75,7 @@ Python has an [`isinstance`](https://docs.python.org/3/library/functions.html#is
 In PyO3 every object has the [`PyAny::is_instance`] and [`PyAny::is_instance_of`] methods which do the same thing.
 
 ```rust
-use pyo3::Python;
+use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyList};
 
 Python::with_gil(|py| {

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -569,7 +569,7 @@ An additional advantage of using Rust's indexing conventions for these types is
 that these types can now also support Rust's indexing operators as part of a
 consistent API:
 
-```rust
+```rust,compile_fail
 use pyo3::{Python, types::PyList};
 
 Python::with_gil(|py| {

--- a/guide/src/performance.md
+++ b/guide/src/performance.md
@@ -59,7 +59,8 @@ Calling `Python::with_gil` is effectively a no-op when the GIL is already held, 
 
 For example, instead of writing
 
-```rust
+// FIXME this example needs updating for new Py API
+```rust,compile_fail
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
@@ -77,7 +78,8 @@ impl PartialEq<Foo> for FooRef<'_> {
 
 use more efficient
 
-```rust
+// FIXME this example needs updating for new Py API
+```rust,compile_fail
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -406,7 +406,7 @@ fn main() -> PyResult<()> {
     let path = Path::new("/usr/share/python_app");
     let py_app = fs::read_to_string(path.join("app.py"))?;
     let from_python = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
-        let syspath: &PyList = py.import("sys")?.getattr("path")?.downcast()?;
+        let syspath: Py2<'_, PyList> = Py2::borrowed_from_gil_ref(&py.import("sys")?.getattr("path")?).clone().downcast_into()?;
         syspath.insert(0, &path)?;
         let app: Py<PyAny> = PyModule::from_code(py, &py_app, "", "")?
             .getattr("run")?

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -67,7 +67,8 @@ such as `getattr`, `setattr`, and `.call`.
 For a `&PyAny` object reference `any` where the underlying object is a Python-native type such as
 a list:
 
-```rust
+// FIXME this documentation needs updating for the new Py2 API
+```rust,compile_fail
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
 # Python::with_gil(|py| -> PyResult<()> {
@@ -138,14 +139,14 @@ let list = PyList::empty(py);
 // Use methods from PyAny on all Python types with Deref implementation
 let _ = list.repr()?;
 
-// To &PyAny automatically with Deref implementation
-let _: &PyAny = list;
+// To &Py2<PyAny> automatically with Deref implementation
+let _: &Py2<'_, PyAny> = &list;
 
-// To &PyAny explicitly with .as_ref()
-let _: &PyAny = list.as_ref();
+// To &Py2<PyAny> explicitly with .as_ref()
+let _: &Py2<'_, PyAny> = list.as_ref();
 
 // To Py<T> with .into() or Py::from()
-let _: Py<PyList> = list.into();
+let _: Py<PyList> = list.clone().into();
 
 // To PyObject with .into() or .to_object(py)
 let _: PyObject = list.into();

--- a/pyo3-benches/benches/bench_dict.rs
+++ b/pyo3-benches/benches/bench_dict.rs
@@ -10,7 +10,7 @@ fn iter_dict(b: &mut Bencher<'_>) {
         let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
         let mut sum = 0;
         b.iter(|| {
-            for (k, _v) in dict {
+            for (k, _v) in dict.iter() {
                 let i: u64 = k.extract().unwrap();
                 sum += i;
             }
@@ -42,7 +42,7 @@ fn extract_hashmap(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
         let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
-        b.iter(|| HashMap::<u64, u64>::extract(dict));
+        b.iter(|| HashMap::<u64, u64>::extract(dict.as_gil_ref()));
     });
 }
 
@@ -50,7 +50,7 @@ fn extract_btreemap(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
         let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
-        b.iter(|| BTreeMap::<u64, u64>::extract(dict));
+        b.iter(|| BTreeMap::<u64, u64>::extract(dict.as_gil_ref()));
     });
 }
 
@@ -59,7 +59,7 @@ fn extract_hashbrown_map(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
         let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
-        b.iter(|| hashbrown::HashMap::<u64, u64>::extract(dict));
+        b.iter(|| hashbrown::HashMap::<u64, u64>::extract(dict.as_gil_ref()));
     });
 }
 

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -43,7 +43,7 @@ pub fn impl_arg_params(
         return Ok((
             quote! {
                 let _args = py.from_borrowed_ptr::<_pyo3::types::PyTuple>(_args);
-                let _kwargs: ::std::option::Option<&_pyo3::types::PyDict> = py.from_borrowed_ptr_or_opt(_kwargs);
+                let _kwargs: ::std::option::Option<_pyo3::Py2<_pyo3::types::PyDict>> = _pyo3::Py2::from_owned_ptr_or_opt(py, _pyo3::ffi::Py_NewRef(_kwargs)).map(|x| unsafe { _pyo3::prelude::PyAnyMethods::downcast_into_unchecked(x) });
             },
             arg_convert,
         ));
@@ -176,7 +176,7 @@ fn impl_arg_param(
         );
         return Ok(quote_arg_span! {
             _pyo3::impl_::extract_argument::extract_optional_argument(
-                _kwargs.map(::std::convert::AsRef::as_ref),
+                _kwargs.as_ref().map(|dict| -> &_pyo3::PyAny { py.from_borrowed_ptr(dict.as_ptr()) }),
                 &mut { _pyo3::impl_::extract_argument::FunctionArgumentHolder::INIT },
                 #name_str,
                 || ::std::option::Option::None

--- a/pytests/src/dict_iter.rs
+++ b/pytests/src/dict_iter.rs
@@ -20,7 +20,7 @@ impl DictSize {
         DictSize { expected }
     }
 
-    fn iter_dict(&mut self, _py: Python<'_>, dict: &PyDict) -> PyResult<u32> {
+    fn iter_dict(&mut self, _py: Python<'_>, dict: Py2<'_, PyDict>) -> PyResult<u32> {
         let mut seen = 0u32;
         for (sym, values) in dict {
             seen += 1;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -581,7 +581,8 @@ mod tests {
     fn test_try_from() {
         Python::with_gil(|py| {
             let list: &PyAny = vec![3, 6, 5, 4, 7].to_object(py).into_ref(py);
-            let dict: &PyAny = vec![("reverse", true)].into_py_dict(py).as_ref();
+            let dict = vec![("reverse", true)].into_py_dict(py);
+            let dict: &PyAny = dict.as_gil_ref();
 
             assert!(<PyList as PyTryFrom<'_>>::try_from(list).is_ok());
             assert!(<PyDict as PyTryFrom<'_>>::try_from(dict).is_ok());
@@ -595,7 +596,8 @@ mod tests {
     fn test_try_from_exact() {
         Python::with_gil(|py| {
             let list: &PyAny = vec![3, 6, 5, 4, 7].to_object(py).into_ref(py);
-            let dict: &PyAny = vec![("reverse", true)].into_py_dict(py).as_ref();
+            let dict = vec![("reverse", true)].into_py_dict(py);
+            let dict: &PyAny = dict.as_gil_ref();
 
             assert!(PyList::try_from_exact(list).is_ok());
             assert!(PyDict::try_from_exact(dict).is_ok());

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -572,7 +572,7 @@ mod test_no_clone {}
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{IntoPyDict, PyAny, PyDict, PyList};
+    use crate::types::{IntoPyDict, PyAny, PyDict, PyList, PyTuple};
     use crate::{PyObject, Python, ToPyObject};
 
     use super::PyTryFrom;
@@ -608,9 +608,9 @@ mod tests {
     #[test]
     fn test_try_from_unchecked() {
         Python::with_gil(|py| {
-            let list = PyList::new(py, [1, 2, 3]);
-            let val = unsafe { <PyList as PyTryFrom>::try_from_unchecked(list.as_ref()) };
-            assert!(list.is(val));
+            let tuple = PyTuple::new(py, [1, 2, 3]);
+            let val = unsafe { <PyTuple as PyTryFrom>::try_from_unchecked(tuple.as_ref()) };
+            assert!(tuple.is(val));
         });
     }
 

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -148,7 +148,9 @@ mod test_anyhow {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run("raise err", None, Some(locals)).unwrap_err();
+            let pyerr = py
+                .run("raise err", None, Some(locals.as_gil_ref()))
+                .unwrap_err();
             assert_eq!(pyerr.value(py).to_string(), expected_contents);
         })
     }
@@ -165,7 +167,9 @@ mod test_anyhow {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run("raise err", None, Some(locals)).unwrap_err();
+            let pyerr = py
+                .run("raise err", None, Some(locals.as_gil_ref()))
+                .unwrap_err();
             assert_eq!(pyerr.value(py).to_string(), expected_contents);
         })
     }

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -375,6 +375,7 @@ mod tests {
     use std::{cmp::Ordering, panic};
 
     use super::*;
+    use crate::prelude::*;
 
     #[test]
     // Only Python>=3.9 has the zoneinfo package
@@ -387,7 +388,7 @@ mod tests {
             py.run(
                 "import zoneinfo; zi = zoneinfo.ZoneInfo('Europe/London')",
                 None,
-                Some(locals),
+                Some(locals.as_gil_ref()),
             )
             .unwrap();
             let result: PyResult<FixedOffset> = locals.get_item("zi").unwrap().extract();
@@ -856,7 +857,7 @@ mod tests {
 
                     let globals = [("datetime", py.import("datetime").unwrap())].into_py_dict(py);
                     let code = format!("datetime.datetime.fromtimestamp({}).replace(tzinfo=datetime.timezone(datetime.timedelta(seconds={})))", timestamp, timedelta);
-                    let t = py.eval(&code, Some(globals), None).unwrap();
+                    let t = py.eval(&code, Some(globals.as_gil_ref()), None).unwrap();
 
                     // Get ISO 8601 string from python
                     let py_iso_str = t.call_method0("isoformat").unwrap();

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -153,7 +153,9 @@ mod tests {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run("raise err", None, Some(locals)).unwrap_err();
+            let pyerr = py
+                .run("raise err", None, Some(locals.as_gil_ref()))
+                .unwrap_err();
             assert_eq!(pyerr.value(py).to_string(), expected_contents);
         })
     }
@@ -170,7 +172,9 @@ mod tests {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run("raise err", None, Some(locals)).unwrap_err();
+            let pyerr = py
+                .run("raise err", None, Some(locals.as_gil_ref()))
+                .unwrap_err();
             assert_eq!(pyerr.value(py).to_string(), expected_contents);
         })
     }

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -249,6 +249,7 @@ fn int_n_bits(long: &PyLong) -> PyResult<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prelude::*;
     use crate::types::{PyDict, PyModule};
     use indoc::indoc;
 
@@ -329,7 +330,9 @@ mod tests {
             let index = python_index_class(py);
             let locals = PyDict::new(py);
             locals.set_item("index", index).unwrap();
-            let ob = py.eval("index.C(10)", None, Some(locals)).unwrap();
+            let ob = py
+                .eval("index.C(10)", None, Some(locals.as_gil_ref()))
+                .unwrap();
             let _: BigInt = FromPyObject::extract(ob).unwrap();
         });
     }

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -104,6 +104,7 @@ impl IntoPy<PyObject> for Decimal {
 mod test_rust_decimal {
     use super::*;
     use crate::err::PyErr;
+    use crate::prelude::*;
     use crate::types::PyDict;
     use rust_decimal::Decimal;
 
@@ -126,7 +127,7 @@ mod test_rust_decimal {
                             $py
                         ),
                         None,
-                        Some(locals),
+                        Some(locals.as_gil_ref()),
                     )
                     .unwrap();
                     // Checks if Python Decimal -> Rust Decimal conversion is correct
@@ -165,7 +166,7 @@ mod test_rust_decimal {
                     &format!(
                        "import decimal\npy_dec = decimal.Decimal(\"{}\")\nassert py_dec == rs_dec",
                      num),
-                None, Some(locals)).unwrap();
+                None, Some(locals.as_gil_ref())).unwrap();
                 let roundtripped: Decimal = rs_dec.extract(py).unwrap();
                 assert_eq!(num, roundtripped);
             })
@@ -189,7 +190,7 @@ mod test_rust_decimal {
             py.run(
                 "import decimal\npy_dec = decimal.Decimal(\"NaN\")",
                 None,
-                Some(locals),
+                Some(locals.as_gil_ref()),
             )
             .unwrap();
             let py_dec = locals.get_item("py_dec").unwrap();
@@ -205,7 +206,7 @@ mod test_rust_decimal {
             py.run(
                 "import decimal\npy_dec = decimal.Decimal(\"Infinity\")",
                 None,
-                Some(locals),
+                Some(locals.as_gil_ref()),
             )
             .unwrap();
             let py_dec = locals.get_item("py_dec").unwrap();

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -357,8 +357,9 @@ nonzero_int_impl!(NonZeroUsize, usize);
 #[cfg(test)]
 mod test_128bit_integers {
     use super::*;
+
     #[cfg(not(target_arch = "wasm32"))]
-    use crate::types::PyDict;
+    use crate::{prelude::*, types::PyDict};
 
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
@@ -371,7 +372,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run(&format!("assert x_py == {}", x), None, Some(locals)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(locals.as_gil_ref())).unwrap();
                 let roundtripped: i128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -387,7 +388,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run(&format!("assert x_py == {}", x), None, Some(locals)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(locals.as_gil_ref())).unwrap();
                 let roundtripped: NonZeroI128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -402,7 +403,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run(&format!("assert x_py == {}", x), None, Some(locals)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(locals.as_gil_ref())).unwrap();
                 let roundtripped: u128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -418,7 +419,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run(&format!("assert x_py == {}", x), None, Some(locals)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(locals.as_gil_ref())).unwrap();
                 let roundtripped: NonZeroU128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -798,6 +798,7 @@ pub mod socket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prelude::*;
     use crate::types::{IntoPyDict, PyDict};
     use crate::{PyErr, Python};
 
@@ -822,9 +823,13 @@ mod tests {
                 .map_err(|e| e.display(py))
                 .expect("could not setitem");
 
-            py.run("assert isinstance(exc, socket.gaierror)", None, Some(d))
-                .map_err(|e| e.display(py))
-                .expect("assertion failed");
+            py.run(
+                "assert isinstance(exc, socket.gaierror)",
+                None,
+                Some(d.as_gil_ref()),
+            )
+            .map_err(|e| e.display(py))
+            .expect("assertion failed");
         });
     }
 
@@ -848,7 +853,7 @@ mod tests {
             py.run(
                 "assert isinstance(exc, email.errors.MessageError)",
                 None,
-                Some(d),
+                Some(d.as_gil_ref()),
             )
             .map_err(|e| e.display(py))
             .expect("assertion failed");
@@ -863,7 +868,7 @@ mod tests {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
-                .eval("str(CustomError)", None, Some(ctx))
+                .eval("str(CustomError)", None, Some(ctx.as_gil_ref()))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -871,11 +876,15 @@ mod tests {
             py.run(
                 "assert CustomError('oops').args == ('oops',)",
                 None,
-                Some(ctx),
+                Some(ctx.as_gil_ref()),
             )
             .unwrap();
-            py.run("assert CustomError.__doc__ is None", None, Some(ctx))
-                .unwrap();
+            py.run(
+                "assert CustomError.__doc__ is None",
+                None,
+                Some(ctx.as_gil_ref()),
+            )
+            .unwrap();
         });
     }
 
@@ -886,7 +895,7 @@ mod tests {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
-                .eval("str(CustomError)", None, Some(ctx))
+                .eval("str(CustomError)", None, Some(ctx.as_gil_ref()))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -905,7 +914,7 @@ mod tests {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
-                .eval("str(CustomError)", None, Some(ctx))
+                .eval("str(CustomError)", None, Some(ctx.as_gil_ref()))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -913,11 +922,15 @@ mod tests {
             py.run(
                 "assert CustomError('oops').args == ('oops',)",
                 None,
-                Some(ctx),
+                Some(ctx.as_gil_ref()),
             )
             .unwrap();
-            py.run("assert CustomError.__doc__ == 'Some docs'", None, Some(ctx))
-                .unwrap();
+            py.run(
+                "assert CustomError.__doc__ == 'Some docs'",
+                None,
+                Some(ctx.as_gil_ref()),
+            )
+            .unwrap();
         });
     }
 
@@ -934,7 +947,7 @@ mod tests {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
-                .eval("str(CustomError)", None, Some(ctx))
+                .eval("str(CustomError)", None, Some(ctx.as_gil_ref()))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -942,13 +955,13 @@ mod tests {
             py.run(
                 "assert CustomError('oops').args == ('oops',)",
                 None,
-                Some(ctx),
+                Some(ctx.as_gil_ref()),
             )
             .unwrap();
             py.run(
                 "assert CustomError.__doc__ == 'Some more docs'",
                 None,
-                Some(ctx),
+                Some(ctx.as_gil_ref()),
             )
             .unwrap();
         });

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -3,6 +3,7 @@ use crate::Python;
 
 #[cfg(not(Py_LIMITED_API))]
 use crate::{
+    prelude::*,
     types::{PyDict, PyString},
     IntoPy, Py, PyAny,
 };
@@ -24,7 +25,7 @@ fn test_datetime_fromtimestamp() {
         py.run(
             "import datetime; assert dt == datetime.datetime.fromtimestamp(100)",
             None,
-            Some(locals),
+            Some(locals.as_gil_ref()),
         )
         .unwrap();
     })
@@ -45,7 +46,7 @@ fn test_date_fromtimestamp() {
         py.run(
             "import datetime; assert dt == datetime.date.fromtimestamp(100)",
             None,
-            Some(locals),
+            Some(locals.as_gil_ref()),
         )
         .unwrap();
     })
@@ -65,7 +66,7 @@ fn test_utc_timezone() {
         py.run(
             "import datetime; assert utc_timezone is datetime.timezone.utc",
             None,
-            Some(locals),
+            Some(locals.as_gil_ref()),
         )
         .unwrap();
     })
@@ -116,7 +117,7 @@ fn test_timezone_from_offset_and_name() {
 #[test]
 #[cfg(not(Py_LIMITED_API))]
 fn ascii_object_bitfield() {
-    let ob_base: PyObject = unsafe { std::mem::zeroed() };
+    let ob_base: crate::ffi::PyObject = unsafe { std::mem::zeroed() };
 
     let mut o = PyASCIIObject {
         ob_base,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -3,13 +3,15 @@ use crate::err::{self, PyDowncastError, PyErr, PyResult};
 use crate::gil;
 use crate::pycell::{PyBorrowError, PyBorrowMutError, PyCell};
 use crate::pyclass::boolean_struct::{False, True};
+use crate::types::any::PyAnyMethods;
 use crate::types::{PyDict, PyString, PyTuple};
 use crate::{
     ffi, AsPyPointer, FromPyObject, IntoPy, PyAny, PyClass, PyClassInitializer, PyRef, PyRefMut,
     PyTypeInfo, Python, ToPyObject,
 };
 use std::marker::PhantomData;
-use std::mem;
+use std::mem::{self, ManuallyDrop};
+use std::ops::Deref;
 use std::ptr::NonNull;
 
 /// Types that are built into the Python interpreter.
@@ -35,6 +37,190 @@ pub unsafe trait PyNativeType: Sized {
     /// an instance of a type corresponding to `Self`.
     unsafe fn unchecked_downcast(obj: &PyAny) -> &Self {
         &*(obj.as_ptr() as *const Self)
+    }
+}
+
+/// A GIL-attached equivalent to `Py`.
+#[repr(transparent)]
+pub(crate) struct Py2<'py, T>(Python<'py>, ManuallyDrop<Py<T>>);
+
+impl<'py> Py2<'py, PyAny> {
+    /// Constructs a new Py2 from a pointer. Panics if ptr is null.
+    pub(crate) unsafe fn from_owned_ptr(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
+        Self(py, ManuallyDrop::new(Py::from_owned_ptr(py, ptr)))
+    }
+
+    // /// Constructs a new Py2 from a pointer. Returns None if ptr is null.
+    // ///
+    // /// Safety: ptr must be a valid pointer to a Python object, or NULL.
+    // pub unsafe fn from_owned_ptr_or_opt(py: Python<'py>, ptr: *mut ffi::PyObject) -> Option<Self> {
+    //     Py::from_owned_ptr_or_opt(py, ptr).map(|obj| Self(py, ManuallyDrop::new(obj)))
+    // }
+
+    /// Constructs a new Py2 from a pointer. Returns error if ptr is null.
+    pub(crate) unsafe fn from_owned_ptr_or_err(
+        py: Python<'py>,
+        ptr: *mut ffi::PyObject,
+    ) -> PyResult<Self> {
+        Py::from_owned_ptr_or_err(py, ptr).map(|obj| Self(py, ManuallyDrop::new(obj)))
+    }
+}
+
+impl<'py, T> Py2<'py, T> {
+    /// Helper to cast to Py2<'py, T>
+    pub(crate) fn as_any(&self) -> &Py2<'py, PyAny> {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl<'py, T> std::fmt::Debug for Py2<'py, T>
+where
+    Self: Deref<Target = Py2<'py, PyAny>>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let s = self.repr().or(Err(std::fmt::Error))?;
+        f.write_str(&s.as_gil_ref().to_string_lossy())
+    }
+}
+
+impl<'py, T> std::fmt::Display for Py2<'py, T>
+where
+    Self: Deref<Target = Py2<'py, PyAny>>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self.str() {
+            Result::Ok(s) => return f.write_str(&s.as_gil_ref().to_string_lossy()),
+            Result::Err(err) => {
+                err.write_unraisable(self.py(), std::option::Option::Some(self.as_gil_ref()))
+            }
+        }
+
+        match self.get_type().name() {
+            Result::Ok(name) => std::write!(f, "<unprintable {} object>", name),
+            Result::Err(_err) => f.write_str("<unprintable object>"),
+        }
+    }
+}
+
+impl<'py> std::fmt::Display for Py2<'py, PyAny> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        match self.str() {
+            Result::Ok(s) => return f.write_str(&s.as_gil_ref().to_string_lossy()),
+            Result::Err(err) => {
+                err.write_unraisable(self.py(), std::option::Option::Some(self.as_gil_ref()))
+            }
+        }
+
+        match self.get_type().name() {
+            Result::Ok(name) => std::write!(f, "<unprintable {} object>", name),
+            Result::Err(_err) => f.write_str("<unprintable object>"),
+        }
+    }
+}
+
+impl<'py, T> Deref for Py2<'py, T>
+where
+    T: AsRef<PyAny>,
+{
+    type Target = Py2<'py, PyAny>;
+
+    #[inline]
+    fn deref(&self) -> &Py2<'py, PyAny> {
+        ::std::convert::AsRef::as_ref(self)
+    }
+}
+
+impl<'py, T> AsRef<Py2<'py, PyAny>> for Py2<'py, T> {
+    fn as_ref(&self) -> &Py2<'py, PyAny> {
+        // Safety: &Py2<T> has the same layout as &Py2<PyAny>
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl<T> Clone for Py2<'_, T> {
+    fn clone(&self) -> Self {
+        Self(self.0, ManuallyDrop::new(self.1.clone_ref(self.0)))
+    }
+}
+
+impl<T> Drop for Py2<'_, T> {
+    fn drop(&mut self) {
+        unsafe { ffi::Py_DECREF(self.1.as_ptr()) }
+    }
+}
+
+impl<'py, T> Py2<'py, T> {
+    /// Returns the GIL token associated with this object.
+    pub fn py(&self) -> Python<'py> {
+        self.0
+    }
+
+    /// Returns the raw FFI pointer represented by self.
+    ///
+    /// # Safety
+    ///
+    /// Callers are responsible for ensuring that the pointer does not outlive self.
+    ///
+    /// The reference is borrowed; callers should not decrease the reference count
+    /// when they are finished with the pointer.
+    #[inline]
+    pub fn as_ptr(&self) -> *mut ffi::PyObject {
+        self.1.as_ptr()
+    }
+
+    /// Returns an owned raw FFI pointer represented by self.
+    ///
+    /// # Safety
+    ///
+    /// The reference is owned; when finished the caller should either transfer ownership
+    /// of the pointer or decrease the reference count (e.g. with [`pyo3::ffi::Py_DecRef`](crate::ffi::Py_DecRef)).
+    #[inline]
+    pub fn into_ptr(self) -> *mut ffi::PyObject {
+        let ptr = (self.1).0.as_ptr();
+        std::mem::forget(self);
+        ptr
+    }
+
+    /// Internal helper to convert e.g. &'a &'py PyDict to &'a Py2<'py, PyDict> for
+    /// backwards-compatibility during migration to removal of pool.
+    #[doc(hidden)] // public and doc(hidden) to use in examples and tests for now
+    pub fn borrowed_from_gil_ref<'a>(gil_ref: &'a &'py T::AsRefTarget) -> &'a Self
+    where
+        T: PyTypeInfo,
+    {
+        // Safety: &'py T::AsRefTarget is expected to be a Python pointer,
+        // so &'a &'py T::AsRefTarget has the same layout as &'a Py2<'py, T>
+        unsafe { std::mem::transmute(gil_ref) }
+    }
+
+    /// Internal helper to get to pool references for backwards compatibility
+    #[doc(hidden)] // public and doc(hidden) to use in examples and tests for now
+    pub fn as_gil_ref(&'py self) -> &'py T::AsRefTarget
+    where
+        T: PyTypeInfo,
+    {
+        unsafe { self.py().from_borrowed_ptr(self.as_ptr()) }
+    }
+
+    /// Internal helper to get to pool references for backwards compatibility
+    #[doc(hidden)] // public but hidden, to use for tests for now
+    pub fn into_gil_ref(self) -> &'py T::AsRefTarget
+    where
+        T: PyTypeInfo,
+    {
+        unsafe { self.py().from_owned_ptr(self.into_ptr()) }
+    }
+
+    pub(crate) fn into_non_null(self) -> NonNull<ffi::PyObject> {
+        let ptr = (self.1).0;
+        std::mem::forget(self);
+        ptr
+    }
+}
+
+unsafe impl<T> AsPyPointer for Py2<'_, T> {
+    fn as_ptr(&self) -> *mut ffi::PyObject {
+        self.1.as_ptr()
     }
 }
 
@@ -285,8 +471,9 @@ where
     /// #
     /// Python::with_gil(|py| {
     ///     let list: Py<PyList> = PyList::empty(py).into();
-    ///     let list: &PyList = list.as_ref(py);
-    ///     assert_eq!(list.len(), 0);
+    ///     // FIXME as_ref() no longer makes sense with new Py API, remove this doc
+    ///     // let list: &PyList = list.as_ref(py);
+    ///     // assert_eq!(list.len(), 0);
     /// });
     /// ```
     ///
@@ -536,6 +723,17 @@ where
 }
 
 impl<T> Py<T> {
+    /// Attaches this `Py` to the given Python context, allowing access to further Python APIs.
+    pub(crate) fn attach<'py>(&self, _py: Python<'py>) -> &Py2<'py, T> {
+        // Safety: `Py2` has the same layout as `Py`
+        unsafe { &*(self as *const Py<T>).cast() }
+    }
+
+    /// Same as `attach` but takes ownership of `self`.
+    pub(crate) fn attach_into(self, py: Python<'_>) -> Py2<'_, T> {
+        Py2(py, ManuallyDrop::new(self))
+    }
+
     /// Returns whether `self` and `other` point to the same object. To compare
     /// the equality of two objects (the `==` operator), use [`eq`](PyAny::eq).
     ///
@@ -638,14 +836,7 @@ impl<T> Py<T> {
     where
         N: IntoPy<Py<PyString>>,
     {
-        let attr_name = attr_name.into_py(py);
-
-        unsafe {
-            PyObject::from_owned_ptr_or_err(
-                py,
-                ffi::PyObject_GetAttr(self.as_ptr(), attr_name.as_ptr()),
-            )
-        }
+        self.attach(py).as_any().getattr(attr_name).map(Into::into)
     }
 
     /// Sets an attribute value.
@@ -675,12 +866,9 @@ impl<T> Py<T> {
         N: IntoPy<Py<PyString>>,
         V: IntoPy<Py<PyAny>>,
     {
-        let attr_name = attr_name.into_py(py);
-        let value = value.into_py(py);
-
-        err::error_on_minusone(py, unsafe {
-            ffi::PyObject_SetAttr(self.as_ptr(), attr_name.as_ptr(), value.as_ptr())
-        })
+        self.attach(py)
+            .as_any()
+            .setattr(attr_name, value.into_py(py).attach_into(py))
     }
 
     /// Calls the object.
@@ -692,43 +880,21 @@ impl<T> Py<T> {
         args: impl IntoPy<Py<PyTuple>>,
         kwargs: Option<&PyDict>,
     ) -> PyResult<PyObject> {
-        let args = args.into_py(py);
-        let kwargs = kwargs.map_or(std::ptr::null_mut(), |p| p.into_ptr());
-
-        unsafe {
-            let ret = PyObject::from_owned_ptr_or_err(
-                py,
-                ffi::PyObject_Call(self.as_ptr(), args.as_ptr(), kwargs),
-            );
-            ffi::Py_XDECREF(kwargs);
-            ret
-        }
+        self.attach(py).as_any().call(args, kwargs).map(Into::into)
     }
 
     /// Calls the object with only positional arguments.
     ///
     /// This is equivalent to the Python expression `self(*args)`.
     pub fn call1(&self, py: Python<'_>, args: impl IntoPy<Py<PyTuple>>) -> PyResult<PyObject> {
-        self.call(py, args, None)
+        self.attach(py).as_any().call1(args).map(Into::into)
     }
 
     /// Calls the object without arguments.
     ///
     /// This is equivalent to the Python expression `self()`.
     pub fn call0(&self, py: Python<'_>) -> PyResult<PyObject> {
-        cfg_if::cfg_if! {
-            if #[cfg(all(
-                not(PyPy),
-                any(Py_3_10, all(not(Py_LIMITED_API), Py_3_9)) // PyObject_CallNoArgs was added to python in 3.9 but to limited API in 3.10
-            ))] {
-                // Optimized path on python 3.9+
-                unsafe {
-                    PyObject::from_owned_ptr_or_err(py, ffi::PyObject_CallNoArgs(self.as_ptr()))
-                }
-            } else {
-                self.call(py, (), None)
-            }
-        }
+        self.attach(py).as_any().call0().map(Into::into)
     }
 
     /// Calls a method on the object.
@@ -748,18 +914,10 @@ impl<T> Py<T> {
         N: IntoPy<Py<PyString>>,
         A: IntoPy<Py<PyTuple>>,
     {
-        let callee = self.getattr(py, name)?;
-        let args: Py<PyTuple> = args.into_py(py);
-        let kwargs = kwargs.map_or(std::ptr::null_mut(), |p| p.into_ptr());
-
-        unsafe {
-            let result = PyObject::from_owned_ptr_or_err(
-                py,
-                ffi::PyObject_Call(callee.as_ptr(), args.as_ptr(), kwargs),
-            );
-            ffi::Py_XDECREF(kwargs);
-            result
-        }
+        self.attach(py)
+            .as_any()
+            .call_method(name, args, kwargs)
+            .map(Into::into)
     }
 
     /// Calls a method on the object with only positional arguments.
@@ -773,7 +931,10 @@ impl<T> Py<T> {
         N: IntoPy<Py<PyString>>,
         A: IntoPy<Py<PyTuple>>,
     {
-        self.call_method(py, name, args, None)
+        self.attach(py)
+            .as_any()
+            .call_method1(name, args)
+            .map(Into::into)
     }
 
     /// Calls a method on the object with no arguments.
@@ -786,17 +947,7 @@ impl<T> Py<T> {
     where
         N: IntoPy<Py<PyString>>,
     {
-        cfg_if::cfg_if! {
-            if #[cfg(all(Py_3_9, not(any(Py_LIMITED_API, PyPy))))] {
-                // Optimized path on python 3.9+
-                unsafe {
-                    let name: Py<PyString> = name.into_py(py);
-                    PyObject::from_owned_ptr_or_err(py, ffi::PyObject_CallMethodNoArgs(self.as_ptr(), name.as_ptr()))
-                }
-            } else {
-                self.call_method(py, name, (), None)
-            }
-        }
+        self.attach(py).as_any().call_method0(name).map(Into::into)
     }
 
     /// Create a `Py<T>` instance by taking ownership of the given FFI pointer.
@@ -932,6 +1083,31 @@ impl<T> IntoPy<PyObject> for &'_ Py<T> {
     }
 }
 
+impl<T> ToPyObject for Py2<'_, T> {
+    /// Converts `Py` instance -> PyObject.
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        unsafe { PyObject::from_borrowed_ptr(py, self.as_ptr()) }
+    }
+}
+
+impl<T> IntoPy<PyObject> for Py2<'_, T> {
+    /// Converts a `Py` instance to `PyObject`.
+    /// Consumes `self` without calling `Py_DECREF()`.
+    #[inline]
+    fn into_py(self, _py: Python<'_>) -> PyObject {
+        unsafe { PyObject::from_non_null(self.into_non_null()) }
+    }
+}
+
+impl<T> IntoPy<PyObject> for &Py2<'_, T> {
+    /// Converts a `Py` instance to `PyObject`.
+    /// Consumes `self` without calling `Py_DECREF()`.
+    #[inline]
+    fn into_py(self, _py: Python<'_>) -> PyObject {
+        unsafe { PyObject::from_non_null(self.clone().into_non_null()) }
+    }
+}
+
 unsafe impl<T> crate::AsPyPointer for Py<T> {
     /// Gets the underlying FFI pointer, returns a borrowed pointer.
     #[inline]
@@ -961,6 +1137,23 @@ where
 {
     #[inline]
     fn from(other: Py<T>) -> Self {
+        unsafe { Self::from_non_null(other.into_non_null()) }
+    }
+}
+
+impl<T> std::convert::From<Py2<'_, T>> for PyObject
+where
+    T: AsRef<PyAny>,
+{
+    #[inline]
+    fn from(other: Py2<'_, T>) -> Self {
+        unsafe { Self::from_non_null(other.into_non_null()) }
+    }
+}
+
+impl<T> std::convert::From<Py2<'_, T>> for Py<T> {
+    #[inline]
+    fn from(other: Py2<'_, T>) -> Self {
         unsafe { Self::from_non_null(other.into_non_null()) }
     }
 }
@@ -1026,6 +1219,19 @@ where
             ob.extract::<&T::AsRefTarget>()
                 .map(|val| Py::from_borrowed_ptr(ob.py(), val.as_ptr()))
         }
+    }
+}
+
+impl<'a, T> FromPyObject<'a> for Py2<'a, T>
+where
+    T: PyTypeInfo,
+{
+    /// Extracts `Self` from the source `PyObject`.
+    fn extract(ob: &'a PyAny) -> PyResult<Self> {
+        Py2::<PyAny>::borrowed_from_gil_ref(&ob)
+            .downcast()
+            .map(Clone::clone)
+            .map_err(Into::into)
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -42,7 +42,7 @@ pub unsafe trait PyNativeType: Sized {
 
 /// A GIL-attached equivalent to `Py`.
 #[repr(transparent)]
-pub(crate) struct Py2<'py, T>(Python<'py>, ManuallyDrop<Py<T>>);
+pub struct Py2<'py, T>(Python<'py>, ManuallyDrop<Py<T>>);
 
 impl<'py> Py2<'py, PyAny> {
     /// Constructs a new Py2 from a pointer. Panics if ptr is null.
@@ -714,13 +714,13 @@ where
 
 impl<T> Py<T> {
     /// Attaches this `Py` to the given Python context, allowing access to further Python APIs.
-    pub(crate) fn attach<'py>(&self, _py: Python<'py>) -> &Py2<'py, T> {
+    pub fn attach<'py>(&self, _py: Python<'py>) -> &Py2<'py, T> {
         // Safety: `Py2` has the same layout as `Py`
         unsafe { &*(self as *const Py<T>).cast() }
     }
 
     /// Same as `attach` but takes ownership of `self`.
-    pub(crate) fn attach_into(self, py: Python<'_>) -> Py2<'_, T> {
+    pub fn attach_into(self, py: Python<'_>) -> Py2<'_, T> {
         Py2(py, ManuallyDrop::new(self))
     }
 

--- a/src/internal_tricks.rs
+++ b/src/internal_tricks.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
     exceptions::PyValueError,
     ffi::{Py_ssize_t, PY_SSIZE_T_MAX},
-    PyResult,
+    Py2, PyAny, PyResult, Python, ToPyObject,
 };
 pub struct PrivateMarker;
 
@@ -211,4 +211,14 @@ pub(crate) fn extract_c_string(
         }
     };
     Ok(cow)
+}
+
+pub(crate) trait ToPy2<'py>: ToPyObject {
+    fn to_py2(&self, py: Python<'py>) -> Py2<'py, PyAny>;
+}
+
+impl<'py, T: ToPyObject> ToPy2<'py> for T {
+    fn to_py2(&self, py: Python<'py>) -> Py2<'py, PyAny> {
+        self.to_object(py).attach_into(py)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
 pub use crate::gil::GILPool;
 #[cfg(not(PyPy))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
-pub use crate::instance::{Py, PyNativeType, PyObject};
+pub use crate::instance::{Py, Py2, PyNativeType, PyObject};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};
 pub use crate::pyclass::PyClass;
@@ -311,9 +311,6 @@ pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::type_object::PyTypeInfo;
 pub use crate::types::PyAny;
 pub use crate::version::PythonVersionInfo;
-
-// Expected to become public API in 0.21 under a different name
-pub(crate) use crate::instance::Py2;
 
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,9 @@ pub use crate::type_object::PyTypeInfo;
 pub use crate::types::PyAny;
 pub use crate::version::PythonVersionInfo;
 
+// Expected to become public API in 0.21 under a different name
+pub(crate) use crate::instance::Py2;
+
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///
 /// Prefer using the same content from `pyo3::pyclass`, e.g. `use pyo3::pyclass::CompareOp` instead

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -104,7 +104,7 @@ macro_rules! py_run_impl {
     }};
     ($py:expr, *$dict:expr, $code:expr) => {{
         use ::std::option::Option::*;
-        if let ::std::result::Result::Err(e) = $py.run($code, None, Some($dict)) {
+        if let ::std::result::Result::Err(e) = $py.run($code, None, Some($dict.as_gil_ref())) {
             e.print($py);
             // So when this c api function the last line called printed the error to stderr,
             // the output is only written into a buffer which is never flushed because we

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1059,6 +1059,7 @@ impl<'unbound> Python<'unbound> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prelude::*;
     use crate::types::{IntoPyDict, PyDict, PyList};
     use crate::Py;
     use std::sync::Arc;

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1080,7 +1080,7 @@ mod tests {
 
             // Inject our own global namespace
             let v: i32 = py
-                .eval("foo + 29", Some(d), None)
+                .eval("foo + 29", Some(d.as_gil_ref()), None)
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -1088,7 +1088,7 @@ mod tests {
 
             // Inject our own local namespace
             let v: i32 = py
-                .eval("foo + 29", None, Some(d))
+                .eval("foo + 29", None, Some(d.as_gil_ref()))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -1096,7 +1096,7 @@ mod tests {
 
             // Make sure builtin names are still accessible when using a local namespace
             let v: i32 = py
-                .eval("min(foo, 2)", None, Some(d))
+                .eval("min(foo, 2)", None, Some(d.as_gil_ref()))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -1200,8 +1200,12 @@ mod tests {
     fn test_py_run_inserts_globals() {
         Python::with_gil(|py| {
             let namespace = PyDict::new(py);
-            py.run("class Foo: pass", Some(namespace), Some(namespace))
-                .unwrap();
+            py.run(
+                "class Foo: pass",
+                Some(namespace.as_gil_ref()),
+                Some(namespace.as_gil_ref()),
+            )
+            .unwrap();
             assert!(namespace.get_item("Foo").is_some());
             assert!(namespace.get_item("__builtins__").is_some());
         })

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -53,6 +53,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prelude::*;
     use crate::types::PyDict;
 
     #[test]
@@ -63,12 +64,12 @@ mod tests {
             dict.set_item("mies", "wim").unwrap();
             dict.set_item("zus", "jet").unwrap();
 
-            let bytes = dumps(py, dict, VERSION)
+            let bytes = dumps(py, &dict, VERSION)
                 .expect("marshalling failed")
                 .as_bytes();
             let deserialized = loads(py, bytes).expect("unmarshalling failed");
 
-            assert!(equal(py, dict, deserialized));
+            assert!(equal(py, &dict, deserialized));
         });
     }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,3 +21,7 @@ pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, FromPyObject};
 
 #[cfg(feature = "macros")]
 pub use crate::wrap_pyfunction;
+
+// Expected to become public API in 0.21
+// pub(crate) use crate::instance::Py2; // Will be stabilized with a different name
+// pub(crate) use crate::types::any::PyAnyMethods;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,7 +10,7 @@
 
 pub use crate::conversion::{FromPyObject, IntoPy, PyTryFrom, PyTryInto, ToPyObject};
 pub use crate::err::{PyErr, PyResult};
-pub use crate::instance::{Py, PyObject};
+pub use crate::instance::{Py, Py2, PyObject};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};
 pub use crate::pyclass_init::PyClassInitializer;
@@ -22,6 +22,5 @@ pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, FromPyObject};
 #[cfg(feature = "macros")]
 pub use crate::wrap_pyfunction;
 
-// Expected to become public API in 0.21
-// pub(crate) use crate::instance::Py2; // Will be stabilized with a different name
-// pub(crate) use crate::types::any::PyAnyMethods;
+pub use crate::types::any::PyAnyMethods;
+pub use crate::types::list::PyListMethods;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -23,4 +23,5 @@ pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, FromPyObject};
 pub use crate::wrap_pyfunction;
 
 pub use crate::types::any::PyAnyMethods;
+pub use crate::types::dict::PyDictMethods;
 pub use crate::types::list::PyListMethods;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -252,6 +252,7 @@ impl Interned {
 mod tests {
     use super::*;
 
+    use crate::prelude::*;
     use crate::types::PyDict;
 
     #[test]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -70,10 +70,10 @@ unsafe impl<T> Sync for GILProtected<T> where T: Send {}
 ///
 /// static LIST_CELL: GILOnceCell<Py<PyList>> = GILOnceCell::new();
 ///
-/// pub fn get_shared_list(py: Python<'_>) -> &PyList {
+/// pub fn get_shared_list(py: Python<'_>) -> &Py2<'_, PyList> {
 ///     LIST_CELL
 ///         .get_or_init(py, || PyList::empty(py).into())
-///         .as_ref(py)
+///         .attach(py)
 /// }
 /// # Python::with_gil(|py| assert_eq!(get_shared_list(py).len(), 0));
 /// ```

--- a/src/test_hygiene/pymethods.rs
+++ b/src/test_hygiene/pymethods.rs
@@ -76,7 +76,7 @@ impl Dummy {
 
     fn __delattr__(&mut self, name: ::std::string::String) {}
 
-    fn __dir__<'py>(&self, py: crate::Python<'py>) -> &'py crate::types::PyList {
+    fn __dir__<'py>(&self, py: crate::Python<'py>) -> crate::Py2<'py, crate::types::PyList> {
         crate::types::PyList::new(py, ::std::vec![0_u8])
     }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -2,11 +2,12 @@ use crate::class::basic::CompareOp;
 use crate::conversion::{AsPyPointer, FromPyObject, IntoPy, PyTryFrom, ToPyObject};
 use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::exceptions::{PyAttributeError, PyTypeError};
+use crate::instance::Py2;
 use crate::type_object::PyTypeInfo;
 #[cfg(not(PyPy))]
 use crate::types::PySuper;
 use crate::types::{PyDict, PyIterator, PyList, PyString, PyTuple, PyType};
-use crate::{err, ffi, Py, PyNativeType, PyObject, Python};
+use crate::{err, ffi, Py, PyNativeType, Python};
 use std::cell::UnsafeCell;
 use std::cmp::Ordering;
 use std::os::raw::c_int;
@@ -70,7 +71,7 @@ impl PyAny {
     /// This is equivalent to the Python expression `self is other`.
     #[inline]
     pub fn is<T: AsPyPointer>(&self, other: &T) -> bool {
-        self.as_ptr() == other.as_ptr()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is(other)
     }
 
     /// Determines whether this object has the given attribute.
@@ -99,17 +100,7 @@ impl PyAny {
     where
         N: IntoPy<Py<PyString>>,
     {
-        fn inner(any: &PyAny, attr_name: Py<PyString>) -> PyResult<bool> {
-            // PyObject_HasAttr suppresses all exceptions, which was the behaviour of `hasattr` in Python 2.
-            // Use an implementation which suppresses only AttributeError, which is consistent with `hasattr` in Python 3.
-            match any._getattr(attr_name) {
-                Ok(_) => Ok(true),
-                Err(err) if err.is_instance_of::<PyAttributeError>(any.py()) => Ok(false),
-                Err(e) => Err(e),
-            }
-        }
-
-        inner(self, attr_name.into_py(self.py()))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).hasattr(attr_name)
     }
 
     /// Retrieves an attribute value.
@@ -138,21 +129,9 @@ impl PyAny {
     where
         N: IntoPy<Py<PyString>>,
     {
-        fn inner(any: &PyAny, attr_name: Py<PyString>) -> PyResult<&PyAny> {
-            any._getattr(attr_name)
-                .map(|object| object.into_ref(any.py()))
-        }
-
-        inner(self, attr_name.into_py(self.py()))
-    }
-
-    fn _getattr(&self, attr_name: Py<PyString>) -> PyResult<PyObject> {
-        unsafe {
-            Py::from_owned_ptr_or_err(
-                self.py(),
-                ffi::PyObject_GetAttr(self.as_ptr(), attr_name.as_ptr()),
-            )
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .getattr(attr_name)
+            .map(Py2::into_gil_ref)
     }
 
     /// Retrieve an attribute value, skipping the instance dictionary during the lookup but still
@@ -227,14 +206,7 @@ impl PyAny {
         N: IntoPy<Py<PyString>>,
         V: ToPyObject,
     {
-        fn inner(any: &PyAny, attr_name: Py<PyString>, value: PyObject) -> PyResult<()> {
-            err::error_on_minusone(any.py(), unsafe {
-                ffi::PyObject_SetAttr(any.as_ptr(), attr_name.as_ptr(), value.as_ptr())
-            })
-        }
-
-        let py = self.py();
-        inner(self, attr_name.into_py(py), value.to_object(py))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).setattr(attr_name, value)
     }
 
     /// Deletes an attribute.
@@ -247,13 +219,7 @@ impl PyAny {
     where
         N: IntoPy<Py<PyString>>,
     {
-        fn inner(any: &PyAny, attr_name: Py<PyString>) -> PyResult<()> {
-            err::error_on_minusone(any.py(), unsafe {
-                ffi::PyObject_DelAttr(any.as_ptr(), attr_name.as_ptr())
-            })
-        }
-
-        inner(self, attr_name.into_py(self.py()))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).delattr(attr_name)
     }
 
     /// Returns an [`Ordering`] between `self` and `other`.
@@ -306,29 +272,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self._compare(other.to_object(self.py()))
-    }
-
-    fn _compare(&self, other: PyObject) -> PyResult<Ordering> {
-        let py = self.py();
-        let other = other.as_ptr();
-        // Almost the same as ffi::PyObject_RichCompareBool, but this one doesn't try self == other.
-        // See https://github.com/PyO3/pyo3/issues/985 for more.
-        let do_compare = |other, op| unsafe {
-            PyObject::from_owned_ptr_or_err(py, ffi::PyObject_RichCompare(self.as_ptr(), other, op))
-                .and_then(|obj| obj.is_true(py))
-        };
-        if do_compare(other, ffi::Py_EQ)? {
-            Ok(Ordering::Equal)
-        } else if do_compare(other, ffi::Py_LT)? {
-            Ok(Ordering::Less)
-        } else if do_compare(other, ffi::Py_GT)? {
-            Ok(Ordering::Greater)
-        } else {
-            Err(PyTypeError::new_err(
-                "PyAny::compare(): All comparisons returned false",
-            ))
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).compare(other)
     }
 
     /// Tests whether two Python objects obey a given [`CompareOp`].
@@ -369,17 +313,9 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        fn inner(slf: &PyAny, other: PyObject, compare_op: CompareOp) -> PyResult<&PyAny> {
-            unsafe {
-                slf.py().from_owned_ptr_or_err(ffi::PyObject_RichCompare(
-                    slf.as_ptr(),
-                    other.as_ptr(),
-                    compare_op as c_int,
-                ))
-            }
-        }
-
-        inner(self, other.to_object(self.py()), compare_op)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .rich_compare(other, compare_op)
+            .map(Py2::into_gil_ref)
     }
 
     /// Tests whether this object is less than another.
@@ -389,7 +325,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Lt)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).lt(other)
     }
 
     /// Tests whether this object is less than or equal to another.
@@ -399,7 +335,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Le)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).le(other)
     }
 
     /// Tests whether this object is equal to another.
@@ -409,7 +345,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Eq)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).eq(other)
     }
 
     /// Tests whether this object is not equal to another.
@@ -419,7 +355,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Ne)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).ne(other)
     }
 
     /// Tests whether this object is greater than another.
@@ -429,7 +365,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Gt)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).gt(other)
     }
 
     /// Tests whether this object is greater than or equal to another.
@@ -439,7 +375,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Ge)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).ge(other)
     }
 
     /// Determines whether this object appears callable.
@@ -470,7 +406,7 @@ impl PyAny {
     ///
     /// [1]: https://docs.python.org/3/library/functions.html#callable
     pub fn is_callable(&self) -> bool {
-        unsafe { ffi::PyCallable_Check(self.as_ptr()) != 0 }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_callable()
     }
 
     /// Calls the object.
@@ -508,16 +444,9 @@ impl PyAny {
         args: impl IntoPy<Py<PyTuple>>,
         kwargs: Option<&PyDict>,
     ) -> PyResult<&PyAny> {
-        let py = self.py();
-
-        let args = args.into_py(py);
-        let kwargs = kwargs.map_or(std::ptr::null_mut(), |kwargs| kwargs.as_ptr());
-
-        unsafe {
-            let return_value = ffi::PyObject_Call(self.as_ptr(), args.as_ptr(), kwargs);
-            let ret = py.from_owned_ptr_or_err(return_value);
-            ret
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call(args, kwargs)
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls the object without arguments.
@@ -541,19 +470,9 @@ impl PyAny {
     ///
     /// This is equivalent to the Python expression `help()`.
     pub fn call0(&self) -> PyResult<&PyAny> {
-        cfg_if::cfg_if! {
-            if #[cfg(all(
-                not(PyPy),
-                any(Py_3_10, all(not(Py_LIMITED_API), Py_3_9)) // PyObject_CallNoArgs was added to python in 3.9 but to limited API in 3.10
-            ))] {
-                // Optimized path on python 3.9+
-                unsafe {
-                    self.py().from_owned_ptr_or_err(ffi::PyObject_CallNoArgs(self.as_ptr()))
-                }
-            } else {
-                self.call((), None)
-            }
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call0()
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls the object with only positional arguments.
@@ -584,7 +503,9 @@ impl PyAny {
     /// # }
     /// ```
     pub fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<&PyAny> {
-        self.call(args, None)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call1(args)
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls a method on the object.
@@ -627,17 +548,9 @@ impl PyAny {
         N: IntoPy<Py<PyString>>,
         A: IntoPy<Py<PyTuple>>,
     {
-        let py = self.py();
-
-        let callee = self.getattr(name)?;
-        let args: Py<PyTuple> = args.into_py(py);
-        let kwargs = kwargs.map_or(std::ptr::null_mut(), |kwargs| kwargs.as_ptr());
-
-        unsafe {
-            let result_ptr = ffi::PyObject_Call(callee.as_ptr(), args.as_ptr(), kwargs);
-            let result = py.from_owned_ptr_or_err(result_ptr);
-            result
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call_method(name, args, kwargs)
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls a method on the object without arguments.
@@ -675,20 +588,9 @@ impl PyAny {
     where
         N: IntoPy<Py<PyString>>,
     {
-        cfg_if::cfg_if! {
-            if #[cfg(all(Py_3_9, not(any(Py_LIMITED_API, PyPy))))] {
-                let py = self.py();
-
-                // Optimized path on python 3.9+
-                unsafe {
-                    let name: Py<PyString> = name.into_py(py);
-                    let ptr = ffi::PyObject_CallMethodNoArgs(self.as_ptr(), name.as_ptr());
-                    py.from_owned_ptr_or_err(ptr)
-                }
-            } else {
-                self.call_method(name, (), None)
-            }
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call_method0(name)
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls a method on the object with only positional arguments.
@@ -728,16 +630,16 @@ impl PyAny {
         N: IntoPy<Py<PyString>>,
         A: IntoPy<Py<PyTuple>>,
     {
-        self.call_method(name, args, None)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call_method1(name, args)
+            .map(Py2::into_gil_ref)
     }
 
     /// Returns whether the object is considered to be true.
     ///
     /// This is equivalent to the Python expression `bool(self)`.
     pub fn is_true(&self) -> PyResult<bool> {
-        let v = unsafe { ffi::PyObject_IsTrue(self.as_ptr()) };
-        err::error_on_minusone(self.py(), v)?;
-        Ok(v != 0)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_true()
     }
 
     /// Returns whether the object is considered to be None.
@@ -745,21 +647,21 @@ impl PyAny {
     /// This is equivalent to the Python expression `self is None`.
     #[inline]
     pub fn is_none(&self) -> bool {
-        unsafe { ffi::Py_None() == self.as_ptr() }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_none()
     }
 
     /// Returns whether the object is Ellipsis, e.g. `...`.
     ///
     /// This is equivalent to the Python expression `self is ...`.
     pub fn is_ellipsis(&self) -> bool {
-        unsafe { ffi::Py_Ellipsis() == self.as_ptr() }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_ellipsis()
     }
 
     /// Returns true if the sequence or mapping has a length of 0.
     ///
     /// This is equivalent to the Python expression `len(self) == 0`.
     pub fn is_empty(&self) -> PyResult<bool> {
-        self.len().map(|l| l == 0)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_empty()
     }
 
     /// Gets an item from the collection.
@@ -769,14 +671,9 @@ impl PyAny {
     where
         K: ToPyObject,
     {
-        fn inner(slf: &PyAny, key: PyObject) -> PyResult<&PyAny> {
-            unsafe {
-                slf.py()
-                    .from_owned_ptr_or_err(ffi::PyObject_GetItem(slf.as_ptr(), key.as_ptr()))
-            }
-        }
-
-        inner(self, key.to_object(self.py()))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .get_item(key)
+            .map(Py2::into_gil_ref)
     }
 
     /// Sets a collection item value.
@@ -787,14 +684,7 @@ impl PyAny {
         K: ToPyObject,
         V: ToPyObject,
     {
-        fn inner(slf: &PyAny, key: PyObject, value: PyObject) -> PyResult<()> {
-            err::error_on_minusone(slf.py(), unsafe {
-                ffi::PyObject_SetItem(slf.as_ptr(), key.as_ptr(), value.as_ptr())
-            })
-        }
-
-        let py = self.py();
-        inner(self, key.to_object(py), value.to_object(py))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).set_item(key, value)
     }
 
     /// Deletes an item from the collection.
@@ -804,13 +694,7 @@ impl PyAny {
     where
         K: ToPyObject,
     {
-        fn inner(slf: &PyAny, key: PyObject) -> PyResult<()> {
-            err::error_on_minusone(slf.py(), unsafe {
-                ffi::PyObject_DelItem(slf.as_ptr(), key.as_ptr())
-            })
-        }
-
-        inner(self, key.to_object(self.py()))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).del_item(key)
     }
 
     /// Takes an object and returns an iterator for it.
@@ -823,13 +707,13 @@ impl PyAny {
 
     /// Returns the Python type object for this object's type.
     pub fn get_type(&self) -> &PyType {
-        unsafe { PyType::from_type_ptr(self.py(), ffi::Py_TYPE(self.as_ptr())) }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).get_type()
     }
 
     /// Returns the Python type pointer for this object.
     #[inline]
     pub fn get_type_ptr(&self) -> *mut ffi::PyTypeObject {
-        unsafe { ffi::Py_TYPE(self.as_ptr()) }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).get_type_ptr()
     }
 
     /// Downcast this `PyAny` to a concrete Python type or pyclass.
@@ -955,52 +839,48 @@ impl PyAny {
 
     /// Returns the reference count for the Python object.
     pub fn get_refcnt(&self) -> isize {
-        unsafe { ffi::Py_REFCNT(self.as_ptr()) }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).get_refcnt()
     }
 
     /// Computes the "repr" representation of self.
     ///
     /// This is equivalent to the Python expression `repr(self)`.
     pub fn repr(&self) -> PyResult<&PyString> {
-        unsafe {
-            self.py()
-                .from_owned_ptr_or_err(ffi::PyObject_Repr(self.as_ptr()))
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .repr()
+            .map(Py2::into_gil_ref)
     }
 
     /// Computes the "str" representation of self.
     ///
     /// This is equivalent to the Python expression `str(self)`.
     pub fn str(&self) -> PyResult<&PyString> {
-        unsafe {
-            self.py()
-                .from_owned_ptr_or_err(ffi::PyObject_Str(self.as_ptr()))
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .str()
+            .map(Py2::into_gil_ref)
     }
 
     /// Retrieves the hash code of self.
     ///
     /// This is equivalent to the Python expression `hash(self)`.
     pub fn hash(&self) -> PyResult<isize> {
-        let v = unsafe { ffi::PyObject_Hash(self.as_ptr()) };
-        crate::err::error_on_minusone(self.py(), v)?;
-        Ok(v)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).hash()
     }
 
     /// Returns the length of the sequence or mapping.
     ///
     /// This is equivalent to the Python expression `len(self)`.
     pub fn len(&self) -> PyResult<usize> {
-        let v = unsafe { ffi::PyObject_Size(self.as_ptr()) };
-        crate::err::error_on_minusone(self.py(), v)?;
-        Ok(v as usize)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).len()
     }
 
     /// Returns the list of attributes of this object.
     ///
     /// This is equivalent to the Python expression `dir(self)`.
     pub fn dir(&self) -> &PyList {
-        unsafe { self.py().from_owned_ptr(ffi::PyObject_Dir(self.as_ptr())) }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .dir()
+            .into_gil_ref()
     }
 
     /// Checks whether this object is an instance of type `ty`.
@@ -1008,9 +888,7 @@ impl PyAny {
     /// This is equivalent to the Python expression `isinstance(self, ty)`.
     #[inline]
     pub fn is_instance(&self, ty: &PyAny) -> PyResult<bool> {
-        let result = unsafe { ffi::PyObject_IsInstance(self.as_ptr(), ty.as_ptr()) };
-        err::error_on_minusone(self.py(), result)?;
-        Ok(result == 1)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_instance(Py2::borrowed_from_gil_ref(&ty))
     }
 
     /// Checks whether this object is an instance of exactly type `ty` (not a subclass).
@@ -1018,7 +896,8 @@ impl PyAny {
     /// This is equivalent to the Python expression `type(self) is ty`.
     #[inline]
     pub fn is_exact_instance(&self, ty: &PyAny) -> bool {
-        self.get_type().is(ty)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .is_exact_instance(Py2::borrowed_from_gil_ref(&ty))
     }
 
     /// Checks whether this object is an instance of type `T`.
@@ -1027,7 +906,7 @@ impl PyAny {
     /// if the type `T` is known at compile time.
     #[inline]
     pub fn is_instance_of<T: PyTypeInfo>(&self) -> bool {
-        T::is_type_of(self)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_instance_of::<T>()
     }
 
     /// Checks whether this object is an instance of exactly type `T`.
@@ -1036,7 +915,7 @@ impl PyAny {
     /// if the type `T` is known at compile time.
     #[inline]
     pub fn is_exact_instance_of<T: PyTypeInfo>(&self) -> bool {
-        T::is_exact_type_of(self)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_exact_instance_of::<T>()
     }
 
     /// Determines if self contains `value`.
@@ -1046,15 +925,7 @@ impl PyAny {
     where
         V: ToPyObject,
     {
-        self._contains(value.to_object(self.py()))
-    }
-
-    fn _contains(&self, value: PyObject) -> PyResult<bool> {
-        match unsafe { ffi::PySequence_Contains(self.as_ptr(), value.as_ptr()) } {
-            0 => Ok(false),
-            1 => Ok(true),
-            _ => Err(PyErr::fetch(self.py())),
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).contains(value)
     }
 
     /// Returns a GIL marker constrained to the lifetime of this type.
@@ -1093,7 +964,1204 @@ impl PyAny {
     /// This is equivalent to the Python expression `super()`
     #[cfg(not(PyPy))]
     pub fn py_super(&self) -> PyResult<&PySuper> {
-        PySuper::new(self.get_type(), self)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .py_super()
+            .map(Py2::into_gil_ref)
+    }
+}
+
+/// This trait represents the Python APIs which are usable on all Python objects.
+///
+/// It is recommended you import this trait via `use pyo3::prelude::*` rather than
+/// by importing this trait directly.
+#[doc(alias = "PyAny")]
+pub(crate) trait PyAnyMethods<'py> {
+    /// Returns whether `self` and `other` point to the same object. To compare
+    /// the equality of two objects (the `==` operator), use [`eq`](PyAny::eq).
+    ///
+    /// This is equivalent to the Python expression `self is other`.
+    fn is<T: AsPyPointer>(&self, other: &T) -> bool;
+
+    /// Determines whether this object has the given attribute.
+    ///
+    /// This is equivalent to the Python expression `hasattr(self, attr_name)`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `attr_name`.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, Python, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn has_version(sys: &PyModule) -> PyResult<bool> {
+    ///     sys.hasattr(intern!(sys.py(), "version"))
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let sys = py.import("sys").unwrap();
+    /// #    has_version(sys).unwrap();
+    /// # });
+    /// ```
+    fn hasattr<N>(&self, attr_name: N) -> PyResult<bool>
+    where
+        N: IntoPy<Py<PyString>>;
+
+    /// Retrieves an attribute value.
+    ///
+    /// This is equivalent to the Python expression `self.attr_name`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `attr_name`.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, PyAny, Python, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn version(sys: &PyModule) -> PyResult<&PyAny> {
+    ///     sys.getattr(intern!(sys.py(), "version"))
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let sys = py.import("sys").unwrap();
+    /// #    version(sys).unwrap();
+    /// # });
+    /// ```
+    fn getattr<N>(&self, attr_name: N) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>;
+
+    /// Sets an attribute value.
+    ///
+    /// This is equivalent to the Python expression `self.attr_name = value`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `name`.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, PyAny, Python, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn set_answer(ob: &PyAny) -> PyResult<()> {
+    ///     ob.setattr(intern!(ob.py(), "answer"), 42)
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let ob = PyModule::new(py, "empty").unwrap();
+    /// #    set_answer(ob).unwrap();
+    /// # });
+    /// ```
+    fn setattr<N, V>(&self, attr_name: N, value: V) -> PyResult<()>
+    where
+        N: IntoPy<Py<PyString>>,
+        V: ToPyObject;
+
+    /// Deletes an attribute.
+    ///
+    /// This is equivalent to the Python statement `del self.attr_name`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `attr_name`.
+    fn delattr<N>(&self, attr_name: N) -> PyResult<()>
+    where
+        N: IntoPy<Py<PyString>>;
+
+    /// Returns an [`Ordering`] between `self` and `other`.
+    ///
+    /// This is equivalent to the following Python code:
+    /// ```python
+    /// if self == other:
+    ///     return Equal
+    /// elif a < b:
+    ///     return Less
+    /// elif a > b:
+    ///     return Greater
+    /// else:
+    ///     raise TypeError("PyAny::compare(): All comparisons returned false")
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyFloat;
+    /// use std::cmp::Ordering;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let a = PyFloat::new(py, 0_f64);
+    ///     let b = PyFloat::new(py, 42_f64);
+    ///     assert_eq!(a.compare(b)?, Ordering::Less);
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    ///
+    /// It will return `PyErr` for values that cannot be compared:
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::{PyFloat, PyString};
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let a = PyFloat::new(py, 0_f64);
+    ///     let b = PyString::new(py, "zero");
+    ///     assert!(a.compare(b).is_err());
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    fn compare<O>(&self, other: O) -> PyResult<Ordering>
+    where
+        O: ToPyObject;
+
+    /// Tests whether two Python objects obey a given [`CompareOp`].
+    ///
+    /// [`lt`](Self::lt), [`le`](Self::le), [`eq`](Self::eq), [`ne`](Self::ne),
+    /// [`gt`](Self::gt) and [`ge`](Self::ge) are the specialized versions
+    /// of this function.
+    ///
+    /// Depending on the value of `compare_op`, this is equivalent to one of the
+    /// following Python expressions:
+    ///
+    /// | `compare_op` | Python expression |
+    /// | :---: | :----: |
+    /// | [`CompareOp::Eq`] | `self == other` |
+    /// | [`CompareOp::Ne`] | `self != other` |
+    /// | [`CompareOp::Lt`] | `self < other` |
+    /// | [`CompareOp::Le`] | `self <= other` |
+    /// | [`CompareOp::Gt`] | `self > other` |
+    /// | [`CompareOp::Ge`] | `self >= other` |
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::class::basic::CompareOp;
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyInt;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let a: &PyInt = 0_u8.into_py(py).into_ref(py).downcast()?;
+    ///     let b: &PyInt = 42_u8.into_py(py).into_ref(py).downcast()?;
+    ///     assert!(a.rich_compare(b, CompareOp::Le)?.is_true()?);
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    fn rich_compare<O>(&self, other: O, compare_op: CompareOp) -> PyResult<Py2<'py, PyAny>>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is less than another.
+    ///
+    /// This is equivalent to the Python expression `self < other`.
+    fn lt<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is less than or equal to another.
+    ///
+    /// This is equivalent to the Python expression `self <= other`.
+    fn le<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is equal to another.
+    ///
+    /// This is equivalent to the Python expression `self == other`.
+    fn eq<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is not equal to another.
+    ///
+    /// This is equivalent to the Python expression `self != other`.
+    fn ne<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is greater than another.
+    ///
+    /// This is equivalent to the Python expression `self > other`.
+    fn gt<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is greater than or equal to another.
+    ///
+    /// This is equivalent to the Python expression `self >= other`.
+    fn ge<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Determines whether this object appears callable.
+    ///
+    /// This is equivalent to Python's [`callable()`][1] function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let builtins = PyModule::import(py, "builtins")?;
+    ///     let print = builtins.getattr("print")?;
+    ///     assert!(print.is_callable());
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    ///
+    /// This is equivalent to the Python statement `assert callable(print)`.
+    ///
+    /// Note that unless an API needs to distinguish between callable and
+    /// non-callable objects, there is no point in checking for callability.
+    /// Instead, it is better to just do the call and handle potential
+    /// exceptions.
+    ///
+    /// [1]: https://docs.python.org/3/library/functions.html#callable
+    fn is_callable(&self) -> bool;
+
+    /// Calls the object.
+    ///
+    /// This is equivalent to the Python expression `self(*args, **kwargs)`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyDict;
+    ///
+    /// const CODE: &str = r#"
+    /// def function(*args, **kwargs):
+    ///     assert args == ("hello",)
+    ///     assert kwargs == {"cruel": "world"}
+    ///     return "called with args and kwargs"
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let fun = module.getattr("function")?;
+    ///     let args = ("hello",);
+    ///     let kwargs = PyDict::new(py);
+    ///     kwargs.set_item("cruel", "world")?;
+    ///     let result = fun.call(args, Some(kwargs))?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with args and kwargs");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call(
+        &self,
+        args: impl IntoPy<Py<PyTuple>>,
+        kwargs: Option<&PyDict>,
+    ) -> PyResult<Py2<'py, PyAny>>;
+
+    /// Calls the object without arguments.
+    ///
+    /// This is equivalent to the Python expression `self()`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use pyo3::prelude::*;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let module = PyModule::import(py, "builtins")?;
+    ///     let help = module.getattr("help")?;
+    ///     help.call0()?;
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    ///
+    /// This is equivalent to the Python expression `help()`.
+    fn call0(&self) -> PyResult<Py2<'py, PyAny>>;
+
+    /// Calls the object with only positional arguments.
+    ///
+    /// This is equivalent to the Python expression `self(*args)`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    ///
+    /// const CODE: &str = r#"
+    /// def function(*args, **kwargs):
+    ///     assert args == ("hello",)
+    ///     assert kwargs == {}
+    ///     return "called with args"
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let fun = module.getattr("function")?;
+    ///     let args = ("hello",);
+    ///     let result = fun.call1(args)?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with args");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<Py2<'py, PyAny>>;
+
+    /// Calls a method on the object.
+    ///
+    /// This is equivalent to the Python expression `self.name(*args, **kwargs)`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `name`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyDict;
+    ///
+    /// const CODE: &str = r#"
+    /// class A:
+    ///     def method(self, *args, **kwargs):
+    ///         assert args == ("hello",)
+    ///         assert kwargs == {"cruel": "world"}
+    ///         return "called with args and kwargs"
+    /// a = A()
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let instance = module.getattr("a")?;
+    ///     let args = ("hello",);
+    ///     let kwargs = PyDict::new(py);
+    ///     kwargs.set_item("cruel", "world")?;
+    ///     let result = instance.call_method("method", args, Some(kwargs))?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with args and kwargs");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call_method<N, A>(
+        &self,
+        name: N,
+        args: A,
+        kwargs: Option<&PyDict>,
+    ) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+        A: IntoPy<Py<PyTuple>>;
+
+    /// Calls a method on the object without arguments.
+    ///
+    /// This is equivalent to the Python expression `self.name()`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `name`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    ///
+    /// const CODE: &str = r#"
+    /// class A:
+    ///     def method(self, *args, **kwargs):
+    ///         assert args == ()
+    ///         assert kwargs == {}
+    ///         return "called with no arguments"
+    /// a = A()
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let instance = module.getattr("a")?;
+    ///     let result = instance.call_method0("method")?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with no arguments");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call_method0<N>(&self, name: N) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>;
+
+    /// Calls a method on the object with only positional arguments.
+    ///
+    /// This is equivalent to the Python expression `self.name(*args)`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `name`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    ///
+    /// const CODE: &str = r#"
+    /// class A:
+    ///     def method(self, *args, **kwargs):
+    ///         assert args == ("hello",)
+    ///         assert kwargs == {}
+    ///         return "called with args"
+    /// a = A()
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let instance = module.getattr("a")?;
+    ///     let args = ("hello",);
+    ///     let result = instance.call_method1("method", args)?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with args");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call_method1<N, A>(&self, name: N, args: A) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+        A: IntoPy<Py<PyTuple>>;
+
+    /// Returns whether the object is considered to be true.
+    ///
+    /// This is equivalent to the Python expression `bool(self)`.
+    fn is_true(&self) -> PyResult<bool>;
+
+    /// Returns whether the object is considered to be None.
+    ///
+    /// This is equivalent to the Python expression `self is None`.
+    fn is_none(&self) -> bool;
+
+    /// Returns whether the object is Ellipsis, e.g. `...`.
+    ///
+    /// This is equivalent to the Python expression `self is ...`.
+    fn is_ellipsis(&self) -> bool;
+
+    /// Returns true if the sequence or mapping has a length of 0.
+    ///
+    /// This is equivalent to the Python expression `len(self) == 0`.
+    fn is_empty(&self) -> PyResult<bool>;
+
+    /// Gets an item from the collection.
+    ///
+    /// This is equivalent to the Python expression `self[key]`.
+    fn get_item<K>(&self, key: K) -> PyResult<Py2<'py, PyAny>>
+    where
+        K: ToPyObject;
+
+    /// Sets a collection item value.
+    ///
+    /// This is equivalent to the Python expression `self[key] = value`.
+    fn set_item<K, V>(&self, key: K, value: V) -> PyResult<()>
+    where
+        K: ToPyObject,
+        V: ToPyObject;
+
+    /// Deletes an item from the collection.
+    ///
+    /// This is equivalent to the Python expression `del self[key]`.
+    fn del_item<K>(&self, key: K) -> PyResult<()>
+    where
+        K: ToPyObject;
+
+    /// Takes an object and returns an iterator for it.
+    ///
+    /// This is typically a new iterator but if the argument is an iterator,
+    /// this returns itself.
+    fn iter(&self) -> PyResult<Py2<'py, PyIterator>>;
+
+    /// Returns the Python type object for this object's type.
+    fn get_type(&self) -> &'py PyType;
+
+    /// Returns the Python type pointer for this object.
+    fn get_type_ptr(&self) -> *mut ffi::PyTypeObject;
+
+    /// Downcast this `PyAny` to a concrete Python type or pyclass.
+    ///
+    /// Note that you can often avoid downcasting yourself by just specifying
+    /// the desired type in function or method signatures.
+    /// However, manual downcasting is sometimes necessary.
+    ///
+    /// For extracting a Rust-only type, see [`PyAny::extract`](struct.PyAny.html#method.extract).
+    ///
+    /// # Example: Downcasting to a specific Python object
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::{PyDict, PyList};
+    ///
+    /// Python::with_gil(|py| {
+    ///     let dict = PyDict::new(py);
+    ///     assert!(dict.is_instance_of::<PyAny>());
+    ///     let any: &PyAny = dict.as_ref();
+    ///
+    ///     assert!(any.downcast::<PyDict>().is_ok());
+    ///     assert!(any.downcast::<PyList>().is_err());
+    /// });
+    /// ```
+    ///
+    /// # Example: Getting a reference to a pyclass
+    ///
+    /// This is useful if you want to mutate a `PyObject` that
+    /// might actually be a pyclass.
+    ///
+    /// ```rust
+    /// # fn main() -> Result<(), pyo3::PyErr> {
+    /// use pyo3::prelude::*;
+    ///
+    /// #[pyclass]
+    /// struct Class {
+    ///     i: i32,
+    /// }
+    ///
+    /// Python::with_gil(|py| {
+    ///     let class: &PyAny = Py::new(py, Class { i: 0 }).unwrap().into_ref(py);
+    ///
+    ///     let class_cell: &PyCell<Class> = class.downcast()?;
+    ///
+    ///     class_cell.borrow_mut().i += 1;
+    ///
+    ///     // Alternatively you can get a `PyRefMut` directly
+    ///     let class_ref: PyRefMut<'_, Class> = class.extract()?;
+    ///     assert_eq!(class_ref.i, 1);
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn downcast<T>(&self) -> Result<&Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo;
+
+    /// Like `downcast` but takes ownership of `self`.
+    fn downcast_into<T>(self) -> Result<Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo;
+
+    /// Downcast this `PyAny` to a concrete Python type or pyclass (but not a subclass of it).
+    ///
+    /// It is almost always better to use [`PyAny::downcast`] because it accounts for Python
+    /// subtyping. Use this method only when you do not want to allow subtypes.
+    ///
+    /// The advantage of this method over [`PyAny::downcast`] is that it is faster. The implementation
+    /// of `downcast_exact` uses the equivalent of the Python expression `type(self) is T`, whereas
+    /// `downcast` uses `isinstance(self, T)`.
+    ///
+    /// For extracting a Rust-only type, see [`PyAny::extract`](struct.PyAny.html#method.extract).
+    ///
+    /// # Example: Downcasting to a specific Python object but not a subtype
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::{PyBool, PyLong};
+    ///
+    /// Python::with_gil(|py| {
+    ///     let b = PyBool::new(py, true);
+    ///     assert!(b.is_instance_of::<PyBool>());
+    ///     let any: &PyAny = b.as_ref();
+    ///
+    ///     // `bool` is a subtype of `int`, so `downcast` will accept a `bool` as an `int`
+    ///     // but `downcast_exact` will not.
+    ///     assert!(any.downcast::<PyLong>().is_ok());
+    ///     assert!(any.downcast_exact::<PyLong>().is_err());
+    ///
+    ///     assert!(any.downcast_exact::<PyBool>().is_ok());
+    /// });
+    /// ```
+    fn downcast_exact<T>(&self) -> Result<&Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo;
+
+    /// Like `downcast_exact` but takes ownership of `self`.
+    fn downcast_into_exact<T>(self) -> Result<Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo;
+
+    /// Converts this `PyAny` to a concrete Python type without checking validity.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that the type is valid or risk type confusion.
+    unsafe fn downcast_unchecked<T>(&self) -> &Py2<'py, T>;
+
+    /// Like `downcast_unchecked` but takes ownership of `self`.
+    unsafe fn downcast_into_unchecked<T>(self) -> Py2<'py, T>;
+
+    /// Extracts some type from the Python object.
+    ///
+    /// This is a wrapper function around [`FromPyObject::extract()`].
+    fn extract<'a, D>(&'a self) -> PyResult<D>
+    where
+        D: FromPyObject<'a>;
+
+    /// Returns the reference count for the Python object.
+    fn get_refcnt(&self) -> isize;
+
+    /// Computes the "repr" representation of self.
+    ///
+    /// This is equivalent to the Python expression `repr(self)`.
+    fn repr(&self) -> PyResult<Py2<'py, PyString>>;
+
+    /// Computes the "str" representation of self.
+    ///
+    /// This is equivalent to the Python expression `str(self)`.
+    fn str(&self) -> PyResult<Py2<'py, PyString>>;
+
+    /// Retrieves the hash code of self.
+    ///
+    /// This is equivalent to the Python expression `hash(self)`.
+    fn hash(&self) -> PyResult<isize>;
+
+    /// Returns the length of the sequence or mapping.
+    ///
+    /// This is equivalent to the Python expression `len(self)`.
+    fn len(&self) -> PyResult<usize>;
+
+    /// Returns the list of attributes of this object.
+    ///
+    /// This is equivalent to the Python expression `dir(self)`.
+    fn dir(&self) -> Py2<'py, PyList>;
+
+    /// Checks whether this object is an instance of type `ty`.
+    ///
+    /// This is equivalent to the Python expression `isinstance(self, ty)`.
+    fn is_instance(&self, ty: &Py2<'py, PyAny>) -> PyResult<bool>;
+
+    /// Checks whether this object is an instance of exactly type `ty` (not a subclass).
+    ///
+    /// This is equivalent to the Python expression `type(self) is ty`.
+    fn is_exact_instance(&self, ty: &Py2<'py, PyAny>) -> bool;
+
+    /// Checks whether this object is an instance of type `T`.
+    ///
+    /// This is equivalent to the Python expression `isinstance(self, T)`,
+    /// if the type `T` is known at compile time.
+    fn is_instance_of<T: PyTypeInfo>(&self) -> bool;
+
+    /// Checks whether this object is an instance of exactly type `T`.
+    ///
+    /// This is equivalent to the Python expression `type(self) is T`,
+    /// if the type `T` is known at compile time.
+    fn is_exact_instance_of<T: PyTypeInfo>(&self) -> bool;
+
+    /// Determines if self contains `value`.
+    ///
+    /// This is equivalent to the Python expression `value in self`.
+    fn contains<V>(&self, value: V) -> PyResult<bool>
+    where
+        V: ToPyObject;
+
+    /// Return a proxy object that delegates method calls to a parent or sibling class of type.
+    ///
+    /// This is equivalent to the Python expression `super()`
+    #[cfg(not(PyPy))]
+    fn py_super(&self) -> PyResult<Py2<'py, PySuper>>;
+}
+
+impl<'py> PyAnyMethods<'py> for Py2<'py, PyAny> {
+    #[inline]
+    fn is<T: AsPyPointer>(&self, other: &T) -> bool {
+        self.as_ptr() == other.as_ptr()
+    }
+
+    fn hasattr<N>(&self, attr_name: N) -> PyResult<bool>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        // PyObject_HasAttr suppresses all exceptions, which was the behaviour of `hasattr` in Python 2.
+        // Use an implementation which suppresses only AttributeError, which is consistent with `hasattr` in Python 3.
+        fn inner(py: Python<'_>, getattr_result: PyResult<Py2<'_, PyAny>>) -> PyResult<bool> {
+            match getattr_result {
+                Ok(_) => Ok(true),
+                Err(err) if err.is_instance_of::<PyAttributeError>(py) => Ok(false),
+                Err(e) => Err(e),
+            }
+        }
+
+        inner(self.py(), self.getattr(attr_name))
+    }
+
+    fn getattr<N>(&self, attr_name: N) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        fn inner<'py>(
+            any: &Py2<'py, PyAny>,
+            attr_name: Py2<'_, PyString>,
+        ) -> PyResult<Py2<'py, PyAny>> {
+            unsafe {
+                Py2::from_owned_ptr_or_err(
+                    any.py(),
+                    ffi::PyObject_GetAttr(any.as_ptr(), attr_name.as_ptr()),
+                )
+            }
+        }
+
+        let py = self.py();
+        inner(self, attr_name.into_py(self.py()).attach_into(py))
+    }
+
+    fn setattr<N, V>(&self, attr_name: N, value: V) -> PyResult<()>
+    where
+        N: IntoPy<Py<PyString>>,
+        V: ToPyObject,
+    {
+        fn inner(
+            any: &Py2<'_, PyAny>,
+            attr_name: Py2<'_, PyString>,
+            value: Py2<'_, PyAny>,
+        ) -> PyResult<()> {
+            err::error_on_minusone(any.py(), unsafe {
+                ffi::PyObject_SetAttr(any.as_ptr(), attr_name.as_ptr(), value.as_ptr())
+            })
+        }
+
+        let py = self.py();
+        inner(
+            self,
+            attr_name.into_py(py).attach_into(py),
+            value.to_object(py).attach_into(py),
+        )
+    }
+
+    fn delattr<N>(&self, attr_name: N) -> PyResult<()>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        fn inner(any: &Py2<'_, PyAny>, attr_name: Py2<'_, PyString>) -> PyResult<()> {
+            err::error_on_minusone(any.py(), unsafe {
+                ffi::PyObject_DelAttr(any.as_ptr(), attr_name.as_ptr())
+            })
+        }
+
+        let py = self.py();
+        inner(self, attr_name.into_py(py).attach_into(py))
+    }
+
+    fn compare<O>(&self, other: O) -> PyResult<Ordering>
+    where
+        O: ToPyObject,
+    {
+        fn inner(any: &Py2<'_, PyAny>, other: Py2<'_, PyAny>) -> PyResult<Ordering> {
+            let py = any.py();
+            let other = other.as_ptr();
+            // Almost the same as ffi::PyObject_RichCompareBool, but this one doesn't try self == other.
+            // See https://github.com/PyO3/pyo3/issues/985 for more.
+            let do_compare = |other, op| unsafe {
+                Py2::from_owned_ptr_or_err(py, ffi::PyObject_RichCompare(any.as_ptr(), other, op))
+                    .and_then(|obj| obj.is_true())
+            };
+            if do_compare(other, ffi::Py_EQ)? {
+                Ok(Ordering::Equal)
+            } else if do_compare(other, ffi::Py_LT)? {
+                Ok(Ordering::Less)
+            } else if do_compare(other, ffi::Py_GT)? {
+                Ok(Ordering::Greater)
+            } else {
+                Err(PyTypeError::new_err(
+                    "PyAny::compare(): All comparisons returned false",
+                ))
+            }
+        }
+
+        let py = self.py();
+        inner(self, other.to_object(py).attach_into(py))
+    }
+
+    fn rich_compare<O>(&self, other: O, compare_op: CompareOp) -> PyResult<Py2<'py, PyAny>>
+    where
+        O: ToPyObject,
+    {
+        fn inner<'py>(
+            any: &Py2<'py, PyAny>,
+            other: Py2<'_, PyAny>,
+            compare_op: CompareOp,
+        ) -> PyResult<Py2<'py, PyAny>> {
+            unsafe {
+                Py2::from_owned_ptr_or_err(
+                    any.py(),
+                    ffi::PyObject_RichCompare(any.as_ptr(), other.as_ptr(), compare_op as c_int),
+                )
+            }
+        }
+
+        let py = self.py();
+        inner(self, other.to_object(py).attach_into(py), compare_op)
+    }
+
+    fn lt<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Lt)?.is_true()
+    }
+
+    fn le<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Le)?.is_true()
+    }
+
+    fn eq<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Eq)?.is_true()
+    }
+
+    fn ne<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Ne)?.is_true()
+    }
+
+    fn gt<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Gt)?.is_true()
+    }
+
+    fn ge<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Ge)?.is_true()
+    }
+
+    fn is_callable(&self) -> bool {
+        unsafe { ffi::PyCallable_Check(self.as_ptr()) != 0 }
+    }
+
+    fn call(
+        &self,
+        args: impl IntoPy<Py<PyTuple>>,
+        kwargs: Option<&PyDict>,
+    ) -> PyResult<Py2<'py, PyAny>> {
+        fn inner<'py>(
+            any: &Py2<'py, PyAny>,
+            args: Py2<'_, PyTuple>,
+            kwargs: Option<&PyDict>,
+        ) -> PyResult<Py2<'py, PyAny>> {
+            unsafe {
+                Py2::from_owned_ptr_or_err(
+                    any.py(),
+                    ffi::PyObject_Call(
+                        any.as_ptr(),
+                        args.as_ptr(),
+                        kwargs.map_or(std::ptr::null_mut(), |dict| dict.as_ptr()),
+                    ),
+                )
+            }
+        }
+
+        let py = self.py();
+        inner(self, args.into_py(py).attach_into(py), kwargs)
+    }
+
+    fn call0(&self) -> PyResult<Py2<'py, PyAny>> {
+        cfg_if::cfg_if! {
+            if #[cfg(all(
+                not(PyPy),
+                any(Py_3_10, all(not(Py_LIMITED_API), Py_3_9)) // PyObject_CallNoArgs was added to python in 3.9 but to limited API in 3.10
+            ))] {
+                // Optimized path on python 3.9+
+                unsafe {
+                    Py2::from_owned_ptr_or_err(self.py(), ffi::PyObject_CallNoArgs(self.as_ptr()))
+                }
+            } else {
+                self.call((), None)
+            }
+        }
+    }
+
+    fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<Py2<'py, PyAny>> {
+        self.call(args, None)
+    }
+
+    fn call_method<N, A>(
+        &self,
+        name: N,
+        args: A,
+        kwargs: Option<&PyDict>,
+    ) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+        A: IntoPy<Py<PyTuple>>,
+    {
+        self.getattr(name)
+            .and_then(|method| method.call(args, kwargs))
+    }
+
+    fn call_method0<N>(&self, name: N) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        cfg_if::cfg_if! {
+            if #[cfg(all(Py_3_9, not(any(Py_LIMITED_API, PyPy))))] {
+                let py = self.py();
+
+                // Optimized path on python 3.9+
+                unsafe {
+                    let name = name.into_py(py).attach_into(py);
+                    Py2::from_owned_ptr_or_err(py, ffi::PyObject_CallMethodNoArgs(self.as_ptr(), name.as_ptr()))
+                }
+            } else {
+                self.call_method(name, (), None)
+            }
+        }
+    }
+
+    fn call_method1<N, A>(&self, name: N, args: A) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+        A: IntoPy<Py<PyTuple>>,
+    {
+        self.call_method(name, args, None)
+    }
+
+    fn is_true(&self) -> PyResult<bool> {
+        let v = unsafe { ffi::PyObject_IsTrue(self.as_ptr()) };
+        err::error_on_minusone(self.py(), v)?;
+        Ok(v != 0)
+    }
+
+    #[inline]
+    fn is_none(&self) -> bool {
+        unsafe { ffi::Py_None() == self.as_ptr() }
+    }
+
+    fn is_ellipsis(&self) -> bool {
+        unsafe { ffi::Py_Ellipsis() == self.as_ptr() }
+    }
+
+    fn is_empty(&self) -> PyResult<bool> {
+        self.len().map(|l| l == 0)
+    }
+
+    fn get_item<K>(&self, key: K) -> PyResult<Py2<'py, PyAny>>
+    where
+        K: ToPyObject,
+    {
+        fn inner<'py>(any: &Py2<'py, PyAny>, key: Py2<'_, PyAny>) -> PyResult<Py2<'py, PyAny>> {
+            unsafe {
+                Py2::from_owned_ptr_or_err(
+                    any.py(),
+                    ffi::PyObject_GetItem(any.as_ptr(), key.as_ptr()),
+                )
+            }
+        }
+
+        let py = self.py();
+        inner(self, key.to_object(py).attach_into(py))
+    }
+
+    fn set_item<K, V>(&self, key: K, value: V) -> PyResult<()>
+    where
+        K: ToPyObject,
+        V: ToPyObject,
+    {
+        fn inner(any: &Py2<'_, PyAny>, key: Py2<'_, PyAny>, value: Py2<'_, PyAny>) -> PyResult<()> {
+            err::error_on_minusone(any.py(), unsafe {
+                ffi::PyObject_SetItem(any.as_ptr(), key.as_ptr(), value.as_ptr())
+            })
+        }
+
+        let py = self.py();
+        inner(
+            self,
+            key.to_object(py).attach_into(py),
+            value.to_object(py).attach_into(py),
+        )
+    }
+
+    fn del_item<K>(&self, key: K) -> PyResult<()>
+    where
+        K: ToPyObject,
+    {
+        fn inner(any: &Py2<'_, PyAny>, key: Py2<'_, PyAny>) -> PyResult<()> {
+            err::error_on_minusone(any.py(), unsafe {
+                ffi::PyObject_DelItem(any.as_ptr(), key.as_ptr())
+            })
+        }
+
+        let py = self.py();
+        inner(self, key.to_object(py).attach_into(py))
+    }
+
+    fn iter(&self) -> PyResult<Py2<'py, PyIterator>> {
+        PyIterator::from_object2(self)
+    }
+
+    fn get_type(&self) -> &'py PyType {
+        unsafe { PyType::from_type_ptr(self.py(), ffi::Py_TYPE(self.as_ptr())) }
+    }
+
+    #[inline]
+    fn get_type_ptr(&self) -> *mut ffi::PyTypeObject {
+        unsafe { ffi::Py_TYPE(self.as_ptr()) }
+    }
+
+    #[inline]
+    fn downcast<T>(&self) -> Result<&Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo,
+    {
+        if self.is_instance_of::<T>() {
+            // Safety: is_instance_of is responsible for ensuring that the type is correct
+            Ok(unsafe { self.downcast_unchecked() })
+        } else {
+            Err(PyDowncastError::new(self.clone().into_gil_ref(), T::NAME))
+        }
+    }
+
+    #[inline]
+    fn downcast_into<T>(self) -> Result<Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo,
+    {
+        if self.is_instance_of::<T>() {
+            // Safety: is_instance_of is responsible for ensuring that the type is correct
+            Ok(unsafe { self.downcast_into_unchecked() })
+        } else {
+            Err(PyDowncastError::new(self.clone().into_gil_ref(), T::NAME))
+        }
+    }
+
+    #[inline]
+    fn downcast_exact<T>(&self) -> Result<&Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo,
+    {
+        if self.is_exact_instance_of::<T>() {
+            // Safety: is_exact_instance_of is responsible for ensuring that the type is correct
+            Ok(unsafe { self.downcast_unchecked() })
+        } else {
+            Err(PyDowncastError::new(self.clone().into_gil_ref(), T::NAME))
+        }
+    }
+
+    #[inline]
+    fn downcast_into_exact<T>(self) -> Result<Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo,
+    {
+        if self.is_exact_instance_of::<T>() {
+            // Safety: is_exact_instance_of is responsible for ensuring that the type is correct
+            Ok(unsafe { self.downcast_into_unchecked() })
+        } else {
+            Err(PyDowncastError::new(self.into_gil_ref(), T::NAME))
+        }
+    }
+
+    #[inline]
+    unsafe fn downcast_unchecked<T>(&self) -> &Py2<'py, T> {
+        unsafe { &*(self as *const Py2<'py, PyAny>).cast() }
+    }
+
+    #[inline]
+    unsafe fn downcast_into_unchecked<T>(self) -> Py2<'py, T> {
+        unsafe { std::mem::transmute(self) }
+    }
+
+    fn extract<'a, D>(&'a self) -> PyResult<D>
+    where
+        D: FromPyObject<'a>,
+    {
+        FromPyObject::extract(self.as_gil_ref())
+    }
+
+    fn get_refcnt(&self) -> isize {
+        unsafe { ffi::Py_REFCNT(self.as_ptr()) }
+    }
+
+    fn repr(&self) -> PyResult<Py2<'py, PyString>> {
+        unsafe {
+            Py2::from_owned_ptr_or_err(self.py(), ffi::PyObject_Repr(self.as_ptr()))
+                .map(|any| any.downcast_into_unchecked())
+        }
+    }
+
+    fn str(&self) -> PyResult<Py2<'py, PyString>> {
+        unsafe {
+            Py2::from_owned_ptr_or_err(self.py(), ffi::PyObject_Str(self.as_ptr()))
+                .map(|any| any.downcast_into_unchecked())
+        }
+    }
+
+    fn hash(&self) -> PyResult<isize> {
+        let v = unsafe { ffi::PyObject_Hash(self.as_ptr()) };
+        crate::err::error_on_minusone(self.py(), v)?;
+        Ok(v)
+    }
+
+    fn len(&self) -> PyResult<usize> {
+        let v = unsafe { ffi::PyObject_Size(self.as_ptr()) };
+        crate::err::error_on_minusone(self.py(), v)?;
+        Ok(v as usize)
+    }
+
+    fn dir(&self) -> Py2<'py, PyList> {
+        unsafe {
+            Py2::from_owned_ptr(self.py(), ffi::PyObject_Dir(self.as_ptr()))
+                .downcast_into_unchecked()
+        }
+    }
+
+    #[inline]
+    fn is_instance(&self, ty: &Py2<'py, PyAny>) -> PyResult<bool> {
+        let result = unsafe { ffi::PyObject_IsInstance(self.as_ptr(), ty.as_ptr()) };
+        err::error_on_minusone(self.py(), result)?;
+        Ok(result == 1)
+    }
+
+    #[inline]
+    fn is_exact_instance(&self, ty: &Py2<'py, PyAny>) -> bool {
+        self.get_type().is(ty)
+    }
+
+    #[inline]
+    fn is_instance_of<T: PyTypeInfo>(&self) -> bool {
+        T::is_type_of(self.as_gil_ref())
+    }
+
+    #[inline]
+    fn is_exact_instance_of<T: PyTypeInfo>(&self) -> bool {
+        T::is_exact_type_of(self.as_gil_ref())
+    }
+
+    fn contains<V>(&self, value: V) -> PyResult<bool>
+    where
+        V: ToPyObject,
+    {
+        fn inner(any: &Py2<'_, PyAny>, value: Py2<'_, PyAny>) -> PyResult<bool> {
+            match unsafe { ffi::PySequence_Contains(any.as_ptr(), value.as_ptr()) } {
+                0 => Ok(false),
+                1 => Ok(true),
+                _ => Err(PyErr::fetch(any.py())),
+            }
+        }
+
+        let py = self.py();
+        inner(self, value.to_object(py).attach_into(py))
+    }
+
+    #[cfg(not(PyPy))]
+    fn py_super(&self) -> PyResult<Py2<'py, PySuper>> {
+        PySuper::new2(Py2::borrowed_from_gil_ref(&self.get_type()), self)
     }
 }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -442,7 +442,7 @@ impl PyAny {
     pub fn call(
         &self,
         args: impl IntoPy<Py<PyTuple>>,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<&Py2<'_, PyDict>>,
     ) -> PyResult<&PyAny> {
         Py2::<PyAny>::borrowed_from_gil_ref(&self)
             .call(args, kwargs)
@@ -543,7 +543,7 @@ impl PyAny {
     /// })
     /// # }
     /// ```
-    pub fn call_method<N, A>(&self, name: N, args: A, kwargs: Option<&PyDict>) -> PyResult<&PyAny>
+    pub fn call_method<N, A>(&self, name: N, args: A, kwargs: Option<&Py2<'_, PyDict>>) -> PyResult<&PyAny>
     where
         N: IntoPy<Py<PyString>>,
         A: IntoPy<Py<PyTuple>>,
@@ -1269,7 +1269,7 @@ pub trait PyAnyMethods<'py> {
     fn call(
         &self,
         args: impl IntoPy<Py<PyTuple>>,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<&Py2<'_, PyDict>>,
     ) -> PyResult<Py2<'py, PyAny>>;
 
     /// Calls the object without arguments.
@@ -1362,7 +1362,7 @@ pub trait PyAnyMethods<'py> {
         &self,
         name: N,
         args: A,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<&Py2<'_, PyDict>>,
     ) -> PyResult<Py2<'py, PyAny>>
     where
         N: IntoPy<Py<PyString>>,
@@ -1861,12 +1861,12 @@ impl<'py> PyAnyMethods<'py> for Py2<'py, PyAny> {
     fn call(
         &self,
         args: impl IntoPy<Py<PyTuple>>,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<&Py2<'_, PyDict>>,
     ) -> PyResult<Py2<'py, PyAny>> {
         fn inner<'py>(
             any: &Py2<'py, PyAny>,
             args: Py2<'_, PyTuple>,
-            kwargs: Option<&PyDict>,
+            kwargs: Option<&Py2<'_, PyDict>>,
         ) -> PyResult<Py2<'py, PyAny>> {
             unsafe {
                 Py2::from_owned_ptr_or_err(
@@ -1908,7 +1908,7 @@ impl<'py> PyAnyMethods<'py> for Py2<'py, PyAny> {
         &self,
         name: N,
         args: A,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<&Py2<'_, PyDict>>,
     ) -> PyResult<Py2<'py, PyAny>>
     where
         N: IntoPy<Py<PyString>>,
@@ -2274,7 +2274,7 @@ class NonHeapNonDescriptorInt:
         Python::with_gil(|py| {
             let list = vec![3, 6, 5, 4, 7].to_object(py);
             let dict = vec![("reverse", true)].into_py_dict(py);
-            list.call_method(py, "sort", (), Some(dict)).unwrap();
+            list.call_method(py, "sort", (), Some(&dict)).unwrap();
             assert_eq!(list.extract::<Vec<i32>>(py).unwrap(), vec![7, 6, 5, 4, 3]);
         });
     }

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -153,7 +153,7 @@ impl PyByteArray {
     /// # except RuntimeError as e:
     /// #     assert str(e) == 'input is not long enough'"#,
     /// #             None,
-    /// #             Some(locals),
+    /// #             Some(locals.as_gil_ref()),
     /// #         )?;
     /// #
     /// #         Ok(())

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -1,6 +1,7 @@
 use super::PyMapping;
 use crate::err::{self, PyErr, PyResult};
 use crate::ffi::Py_ssize_t;
+use crate::prelude::*;
 use crate::types::{PyAny, PyList};
 use crate::{ffi, PyObject, Python, ToPyObject};
 
@@ -219,30 +220,30 @@ impl PyDict {
     /// Returns a list of dict keys.
     ///
     /// This is equivalent to the Python expression `list(dict.keys())`.
-    pub fn keys(&self) -> &PyList {
+    pub fn keys<'py>(&'py self) -> Py2<'py, PyList> {
         unsafe {
-            self.py()
-                .from_owned_ptr::<PyList>(ffi::PyDict_Keys(self.as_ptr()))
+            Py2::from_owned_ptr(self.py(), ffi::PyDict_Keys(self.as_ptr()))
+                .downcast_into_unchecked()
         }
     }
 
     /// Returns a list of dict values.
     ///
     /// This is equivalent to the Python expression `list(dict.values())`.
-    pub fn values(&self) -> &PyList {
+    pub fn values<'py>(&'py self) -> Py2<'py, PyList> {
         unsafe {
-            self.py()
-                .from_owned_ptr::<PyList>(ffi::PyDict_Values(self.as_ptr()))
+            Py2::from_owned_ptr(self.py(), ffi::PyDict_Values(self.as_ptr()))
+                .downcast_into_unchecked()
         }
     }
 
     /// Returns a list of dict items.
     ///
     /// This is equivalent to the Python expression `list(dict.items())`.
-    pub fn items(&self) -> &PyList {
+    pub fn items<'py>(&'py self) -> Py2<'py, PyList> {
         unsafe {
-            self.py()
-                .from_owned_ptr::<PyList>(ffi::PyDict_Items(self.as_ptr()))
+            Py2::from_owned_ptr(self.py(), ffi::PyDict_Items(self.as_ptr()))
+                .downcast_into_unchecked()
         }
     }
 

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -54,7 +54,10 @@ mod tests {
     #[test]
     fn test_dict_is_not_ellipsis() {
         Python::with_gil(|py| {
-            assert!(PyDict::new(py).downcast::<PyEllipsis>().is_err());
+            assert!(PyDict::new(py)
+                .as_gil_ref()
+                .downcast::<PyEllipsis>()
+                .is_err());
         })
     }
 }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -118,6 +118,7 @@ mod tests {
     use super::PyIterator;
     use crate::exceptions::PyTypeError;
     use crate::gil::GILPool;
+    use crate::prelude::*;
     use crate::types::{PyDict, PyList};
     use crate::{Py, PyAny, Python, ToPyObject};
 
@@ -238,7 +239,7 @@ def fibonacci(target):
     #[test]
     fn test_as_ref() {
         Python::with_gil(|py| {
-            let iter: Py<PyIterator> = PyAny::iter(PyList::empty(py)).unwrap().into();
+            let iter: Py<PyIterator> = PyAny::iter(PyList::empty(py).as_gil_ref()).unwrap().into();
             let mut iter_ref: &PyIterator = iter.as_ref(py);
             assert!(iter_ref.next().is_none());
         })
@@ -247,7 +248,7 @@ def fibonacci(target):
     #[test]
     fn test_into_ref() {
         Python::with_gil(|py| {
-            let bare_iter = PyAny::iter(PyList::empty(py)).unwrap();
+            let bare_iter = PyAny::iter(PyList::empty(py).into_gil_ref()).unwrap();
             assert_eq!(bare_iter.get_refcnt(), 1);
             let iter: Py<PyIterator> = bare_iter.into();
             assert_eq!(bare_iter.get_refcnt(), 2);

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -206,9 +206,12 @@ def fibonacci(target):
 
         Python::with_gil(|py| {
             let context = PyDict::new(py);
-            py.run(fibonacci_generator, None, Some(context)).unwrap();
+            py.run(fibonacci_generator, None, Some(context.as_gil_ref()))
+                .unwrap();
 
-            let generator = py.eval("fibonacci(5)", None, Some(context)).unwrap();
+            let generator = py
+                .eval("fibonacci(5)", None, Some(context.as_gil_ref()))
+                .unwrap();
             for (actual, expected) in generator.iter().unwrap().zip(&[1, 1, 2, 3, 5]) {
                 let actual = actual.unwrap().extract::<usize>().unwrap();
                 assert_eq!(actual, *expected)

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -33,10 +33,11 @@ impl PyIterator {
     ///
     /// Equivalent to Python's built-in `iter` function.
     pub fn from_object(obj: &PyAny) -> PyResult<&PyIterator> {
-        unsafe {
-            obj.py()
-                .from_owned_ptr_or_err(ffi::PyObject_GetIter(obj.as_ptr()))
-        }
+        Self::from_object2(Py2::borrowed_from_gil_ref(&obj)).map(|py2| {
+            // Can't use into_gil_ref here because T: PyTypeInfo bound is not satisfied
+            // Safety: into_ptr produces a valid pointer to PyIterator object
+            unsafe { obj.py().from_owned_ptr(py2.into_ptr()) }
+        })
     }
 
     pub(crate) fn from_object2<'py>(obj: &Py2<'py, PyAny>) -> PyResult<Py2<'py, PyIterator>> {

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -1,5 +1,7 @@
-use crate::{ffi, AsPyPointer, Py, PyAny, PyErr, PyNativeType, PyResult, Python};
+use crate::{ffi, AsPyPointer, Py, Py2, PyAny, PyErr, PyNativeType, PyResult, Python};
 use crate::{PyDowncastError, PyTryFrom};
+
+use super::any::PyAnyMethods;
 
 /// A Python iterator object.
 ///
@@ -34,6 +36,13 @@ impl PyIterator {
         unsafe {
             obj.py()
                 .from_owned_ptr_or_err(ffi::PyObject_GetIter(obj.as_ptr()))
+        }
+    }
+
+    pub(crate) fn from_object2<'py>(obj: &Py2<'py, PyAny>) -> PyResult<Py2<'py, PyIterator>> {
+        unsafe {
+            Py2::from_owned_ptr_or_err(obj.py(), ffi::PyObject_GetIter(obj.as_ptr()))
+                .map(|any| any.downcast_into_unchecked())
         }
     }
 }

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -103,6 +103,7 @@ impl PyList {
 /// These methods are defined for the `Py2<'py, PyList>` smart pointer, so to use method call
 /// syntax these methods are separated into a trait, because stable Rust does not yet support
 /// `arbitrary_self_types`.
+#[doc(alias = "PyList")]
 pub trait PyListMethods<'py> {
     /// Returns the length of the list.
     fn len(&self) -> usize;

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -175,6 +175,7 @@ mod tests {
 
     use crate::{
         exceptions::PyKeyError,
+        prelude::*,
         types::{PyDict, PyTuple},
         Python,
     };
@@ -337,7 +338,8 @@ mod tests {
     #[test]
     fn test_into_ref() {
         Python::with_gil(|py| {
-            let bare_mapping = PyDict::new(py).as_mapping();
+            let dict = PyDict::new(py);
+            let bare_mapping = dict.as_mapping();
             assert_eq!(bare_mapping.get_refcnt(), 1);
             let mapping: Py<PyMapping> = bare_mapping.into();
             assert_eq!(bare_mapping.get_refcnt(), 2);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -269,7 +269,7 @@ macro_rules! pyobject_native_type {
     };
 }
 
-mod any;
+pub(crate) mod any;
 mod boolobject;
 mod bytearray;
 mod bytes;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -58,7 +58,7 @@ pub use self::typeobject::PyType;
 ///
 /// # pub fn main() -> PyResult<()> {
 /// Python::with_gil(|py| {
-///     let dict: &PyDict = py.eval("{'a':'b', 'c':'d'}", None, None)?.downcast()?;
+///     let dict = Py2::borrowed_from_gil_ref(py.eval("{'a':'b', 'c':'d'}", None, None)?.downcast::<PyDict>())?;
 ///
 ///     for (key, value) in dict {
 ///         println!("key: {}, value: {}", key, value);
@@ -279,7 +279,7 @@ mod code;
 mod complex;
 #[cfg(not(Py_LIMITED_API))]
 mod datetime;
-mod dict;
+pub(crate) mod dict;
 mod ellipsis;
 mod floatob;
 #[cfg(all(not(Py_LIMITED_API), not(PyPy)))]

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -80,7 +80,7 @@ mod tests {
     #[test]
     fn test_dict_is_not_none() {
         Python::with_gil(|py| {
-            assert!(PyDict::new(py).downcast::<PyNone>().is_err());
+            assert!(PyDict::new(py).as_gil_ref().downcast::<PyNone>().is_err());
         })
     }
 }

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -54,7 +54,10 @@ mod tests {
     #[test]
     fn test_dict_is_not_notimplemented() {
         Python::with_gil(|py| {
-            assert!(PyDict::new(py).downcast::<PyNotImplemented>().is_err());
+            assert!(PyDict::new(py)
+                .as_gil_ref()
+                .downcast::<PyNotImplemented>()
+                .is_err());
         })
     }
 }

--- a/src/types/pysuper.rs
+++ b/src/types/pysuper.rs
@@ -1,4 +1,6 @@
 use crate::ffi;
+use crate::instance::Py2;
+use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
 use crate::{PyAny, PyResult};
 
@@ -58,6 +60,17 @@ impl PySuper {
         let py = ty.py();
         let super_ = py.get_type::<PySuper>().call1((ty, obj))?;
         let super_ = super_.downcast::<PySuper>()?;
+        Ok(super_)
+    }
+
+    pub(crate) fn new2<'py>(
+        ty: &Py2<'py, PyType>,
+        obj: &Py2<'py, PyAny>,
+    ) -> PyResult<Py2<'py, PySuper>> {
+        let py = ty.py();
+        let super_ =
+            Py2::<PyType>::borrowed_from_gil_ref(&py.get_type::<PySuper>()).call1((ty, obj))?;
+        let super_ = super_.downcast_into::<PySuper>()?;
         Ok(super_)
     }
 }

--- a/src/types/pysuper.rs
+++ b/src/types/pysuper.rs
@@ -1,7 +1,7 @@
-use crate::ffi;
 use crate::instance::Py2;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
+use crate::{ffi, PyTypeInfo};
 use crate::{PyAny, PyResult};
 
 /// Represents a Python `super` object.
@@ -57,20 +57,22 @@ impl PySuper {
     /// }
     /// ```
     pub fn new<'py>(ty: &'py PyType, obj: &'py PyAny) -> PyResult<&'py PySuper> {
-        let py = ty.py();
-        let super_ = py.get_type::<PySuper>().call1((ty, obj))?;
-        let super_ = super_.downcast::<PySuper>()?;
-        Ok(super_)
+        Self::new2(
+            Py2::borrowed_from_gil_ref(&ty),
+            Py2::borrowed_from_gil_ref(&obj),
+        )
+        .map(Py2::into_gil_ref)
     }
 
     pub(crate) fn new2<'py>(
         ty: &Py2<'py, PyType>,
         obj: &Py2<'py, PyAny>,
     ) -> PyResult<Py2<'py, PySuper>> {
-        let py = ty.py();
-        let super_ =
-            Py2::<PyType>::borrowed_from_gil_ref(&py.get_type::<PySuper>()).call1((ty, obj))?;
-        let super_ = super_.downcast_into::<PySuper>()?;
-        Ok(super_)
+        Py2::<PyType>::borrowed_from_gil_ref(&PySuper::type_object(ty.py()))
+            .call1((ty, obj))
+            .map(|any| {
+                // Safety: super() always returns instance of super
+                unsafe { any.downcast_into_unchecked() }
+            })
     }
 }

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -388,7 +388,7 @@ impl Py<PySequence> {
 #[cfg(test)]
 mod tests {
     use crate::types::{PyList, PySequence, PyTuple};
-    use crate::{Py, PyObject, Python, ToPyObject};
+    use crate::{prelude::*, Py, PyObject, Python, ToPyObject};
 
     fn get_object() -> PyObject {
         // Convenience function for getting a single unique object
@@ -656,7 +656,8 @@ mod tests {
             let ins = w.to_object(py);
             seq.set_slice(1, 4, ins.as_ref(py)).unwrap();
             assert_eq!([1, 7, 4, 5, 8], seq.extract::<[i32; 5]>().unwrap());
-            seq.set_slice(3, 100, PyList::empty(py)).unwrap();
+            seq.set_slice(3, 100, PyList::empty(py).as_gil_ref())
+                .unwrap();
             assert_eq!([1, 7, 4], seq.extract::<[i32; 3]>().unwrap());
         });
     }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -1,7 +1,9 @@
 #[cfg(not(Py_LIMITED_API))]
 use crate::exceptions::PyUnicodeDecodeError;
+#[cfg(feature = "experimental-inspect")]
+use crate::inspect::types::TypeInfo;
 use crate::types::PyBytes;
-use crate::{ffi, PyAny, PyResult, Python};
+use crate::{ffi, IntoPy, Py, PyAny, PyResult, Python};
 use std::borrow::Cow;
 use std::os::raw::c_char;
 use std::str;
@@ -272,6 +274,18 @@ impl PyString {
             ))),
             _ => unreachable!(),
         }
+    }
+}
+
+impl IntoPy<Py<PyString>> for Py<PyString> {
+    #[inline]
+    fn into_py(self, _: Python<'_>) -> Py<PyString> {
+        self
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        <String>::type_output()
     }
 }
 

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -94,7 +94,7 @@ except Exception as e:
     err = e
 ",
                 None,
-                Some(locals),
+                Some(locals.as_gil_ref()),
             )
             .unwrap();
             let err = PyErr::from_value(locals.get_item("err").unwrap());
@@ -114,7 +114,7 @@ def f():
     raise ValueError('raised exception')
 ",
                 None,
-                Some(locals),
+                Some(locals.as_gil_ref()),
             )
             .unwrap();
             let f = locals.get_item("f").unwrap();

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -23,7 +23,7 @@ macro_rules! py_expect_exception {
     }};
     // Case2: dict & no err_msg
     ($py:expr, *$dict:expr, $code:expr, $err:ident) => {{
-        let res = $py.run($code, None, Some($dict));
+        let res = $py.run($code, None, Some($dict.as_gil_ref()));
         let err = res.expect_err(&format!("Did not raise {}", stringify!($err)));
         if !err.matches($py, $py.get_type::<pyo3::exceptions::$err>()) {
             panic!("Expected {} but got {:?}", stringify!($err), err)

--- a/tests/test_anyhow.rs
+++ b/tests/test_anyhow.rs
@@ -1,9 +1,10 @@
 #![cfg(feature = "anyhow")]
 
+use pyo3::prelude::*;
+use pyo3::{py_run, pyfunction, types::PyDict, wrap_pyfunction, Python};
+
 #[test]
 fn test_anyhow_py_function_ok_result() {
-    use pyo3::{py_run, pyfunction, wrap_pyfunction, Python};
-
     #[pyfunction]
     #[allow(clippy::unnecessary_wraps)]
     fn produce_ok_result() -> anyhow::Result<String> {
@@ -25,8 +26,6 @@ fn test_anyhow_py_function_ok_result() {
 
 #[test]
 fn test_anyhow_py_function_err_result() {
-    use pyo3::{pyfunction, types::PyDict, wrap_pyfunction, Python};
-
     #[pyfunction]
     fn produce_err_result() -> anyhow::Result<String> {
         anyhow::bail!("error time")
@@ -42,7 +41,7 @@ fn test_anyhow_py_function_err_result() {
             func()
             "#,
             None,
-            Some(locals),
+            Some(locals.as_gil_ref()),
         )
         .unwrap_err();
     });

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -29,7 +29,7 @@ fn empty_class_with_new() {
         // Calling with arbitrary args or kwargs is not ok
         assert!(typeobj.call(("some", "args"), None).is_err());
         assert!(typeobj
-            .call((), Some([("some", "kwarg")].into_py_dict(py)))
+            .call((), Some(&[("some", "kwarg")].into_py_dict(py)))
             .is_err());
     });
 }

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -18,17 +18,29 @@ fn _get_subclasses<'p>(
 
     let make_sub_subclass_py = "class SubSubklass(Subklass):\n    pass";
 
-    py.run(&make_subclass_py, None, Some(locals))?;
-    py.run(make_sub_subclass_py, None, Some(locals))?;
+    py.run(&make_subclass_py, None, Some(locals.as_gil_ref()))?;
+    py.run(make_sub_subclass_py, None, Some(locals.as_gil_ref()))?;
 
     // Construct an instance of the base class
-    let obj = py.eval(&format!("{}({})", py_type, args), None, Some(locals))?;
+    let obj = py.eval(
+        &format!("{}({})", py_type, args),
+        None,
+        Some(locals.as_gil_ref()),
+    )?;
 
     // Construct an instance of the subclass
-    let sub_obj = py.eval(&format!("Subklass({})", args), None, Some(locals))?;
+    let sub_obj = py.eval(
+        &format!("Subklass({})", args),
+        None,
+        Some(locals.as_gil_ref()),
+    )?;
 
     // Construct an instance of the sub-subclass
-    let sub_sub_obj = py.eval(&format!("SubSubklass({})", args), None, Some(locals))?;
+    let sub_sub_obj = py.eval(
+        &format!("SubSubklass({})", args),
+        None,
+        Some(locals.as_gil_ref()),
+    )?;
 
     Ok((obj, sub_obj, sub_sub_obj))
 }
@@ -125,7 +137,11 @@ fn test_datetime_utc() {
         let locals = [("dt", dt)].into_py_dict(py);
 
         let offset: f32 = py
-            .eval("dt.utcoffset().total_seconds()", None, Some(locals))
+            .eval(
+                "dt.utcoffset().total_seconds()",
+                None,
+                Some(locals.as_gil_ref()),
+            )
             .unwrap()
             .extract()
             .unwrap();

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -366,7 +366,7 @@ fn test_enum() {
 
         let dict = PyDict::new(py);
         dict.set_item("a", "test").expect("Failed to set item");
-        let f = Foo::extract(dict.as_ref()).expect("Failed to extract Foo from dict");
+        let f = Foo::extract(dict.as_gil_ref()).expect("Failed to extract Foo from dict");
         match f {
             Foo::StructWithGetItem { a } => assert_eq!(a, "test"),
             _ => panic!("Expected extracting Foo::StructWithGetItem, got {:?}", f),
@@ -374,7 +374,7 @@ fn test_enum() {
 
         let dict = PyDict::new(py);
         dict.set_item("foo", "test").expect("Failed to set item");
-        let f = Foo::extract(dict.as_ref()).expect("Failed to extract Foo from dict");
+        let f = Foo::extract(dict.as_gil_ref()).expect("Failed to extract Foo from dict");
         match f {
             Foo::StructWithGetItemArg { a } => assert_eq!(a, "test"),
             _ => panic!("Expected extracting Foo::StructWithGetItemArg, got {:?}", f),
@@ -386,7 +386,7 @@ fn test_enum() {
 fn test_enum_error() {
     Python::with_gil(|py| {
         let dict = PyDict::new(py);
-        let err = Foo::extract(dict.as_ref()).unwrap_err();
+        let err = Foo::extract(dict.as_gil_ref()).unwrap_err();
         assert_eq!(
             err.to_string(),
             "\
@@ -429,11 +429,11 @@ enum EnumWithCatchAll<'a> {
 fn test_enum_catch_all() {
     Python::with_gil(|py| {
         let dict = PyDict::new(py);
-        let f = EnumWithCatchAll::extract(dict.as_ref())
+        let f = EnumWithCatchAll::extract(dict.as_gil_ref())
             .expect("Failed to extract EnumWithCatchAll from dict");
         match f {
             EnumWithCatchAll::CatchAll(any) => {
-                let d = <&PyDict>::extract(any).expect("Expected pydict");
+                let d = <Py2<'_, PyDict>>::extract(any).expect("Expected pydict");
                 assert!(d.is_empty());
             }
             _ => panic!(
@@ -458,7 +458,7 @@ pub enum Bar {
 fn test_err_rename() {
     Python::with_gil(|py| {
         let dict = PyDict::new(py);
-        let f = Bar::extract(dict.as_ref());
+        let f = Bar::extract(dict.as_gil_ref());
         assert!(f.is_err());
         assert_eq!(
             f.unwrap_err().to_string(),

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -562,7 +562,8 @@ pub struct TransparentFromPyWith {
 #[test]
 fn test_transparent_from_py_with() {
     Python::with_gil(|py| {
-        let result = TransparentFromPyWith::extract(PyList::new(py, [1, 2, 3])).unwrap();
+        let result =
+            TransparentFromPyWith::extract(PyList::new(py, [1, 2, 3]).into_gil_ref()).unwrap();
         let expected = TransparentFromPyWith { len: 3 };
 
         assert_eq!(result, expected);

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -5,6 +5,7 @@ use std::cell::Cell;
 use pyo3::prelude::*;
 use pyo3::py_run;
 use pyo3::types::{IntoPyDict, PyList};
+use pyo3::Py2;
 
 mod common;
 
@@ -41,7 +42,7 @@ impl ClassWithProperties {
     }
 
     #[getter]
-    fn get_data_list<'py>(&self, py: Python<'py>) -> &'py PyList {
+    fn get_data_list<'py>(&self, py: Python<'py>) -> Py2<'py, PyList> {
         PyList::new(py, [self.num])
     }
 }

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -9,6 +9,7 @@ use pyo3::types::IntoPyDict;
 use pyo3::types::PyList;
 use pyo3::types::PyMapping;
 use pyo3::types::PySequence;
+use pyo3::Py2;
 
 mod common;
 
@@ -20,7 +21,7 @@ struct Mapping {
 #[pymethods]
 impl Mapping {
     #[new]
-    fn new(elements: Option<&PyList>) -> PyResult<Self> {
+    fn new(elements: Option<Py2<'_, PyList>>) -> PyResult<Self> {
         if let Some(pylist) = elements {
             let mut elems = HashMap::with_capacity(pylist.len());
             for (i, pyelem) in pylist.into_iter().enumerate() {

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -6,6 +6,7 @@ use pyo3::exceptions::PyKeyError;
 use pyo3::prelude::*;
 use pyo3::py_run;
 use pyo3::types::IntoPyDict;
+use pyo3::types::PyDict;
 use pyo3::types::PyList;
 use pyo3::types::PyMapping;
 use pyo3::types::PySequence;
@@ -68,7 +69,7 @@ impl Mapping {
 }
 
 /// Return a dict with `m = Mapping(['1', '2', '3'])`.
-fn map_dict(py: Python<'_>) -> &pyo3::types::PyDict {
+fn map_dict(py: Python<'_>) -> Py2<'_, PyDict> {
     let d = [("Mapping", py.get_type::<Mapping>())].into_py_dict(py);
     py_run!(py, *d, "m = Mapping(['1', '2', '3'])");
     d

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -194,7 +194,12 @@ impl MethSignature {
         test
     }
     #[pyo3(signature = (*args, **kwargs))]
-    fn get_kwargs(&self, py: Python<'_>, args: &PyTuple, kwargs: Option<&PyDict>) -> PyObject {
+    fn get_kwargs(
+        &self,
+        py: Python<'_>,
+        args: &PyTuple,
+        kwargs: Option<Py2<'_, PyDict>>,
+    ) -> PyObject {
         [args.into(), kwargs.to_object(py)].to_object(py)
     }
 
@@ -204,7 +209,7 @@ impl MethSignature {
         py: Python<'_>,
         a: i32,
         args: &PyTuple,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<Py2<'_, PyDict>>,
     ) -> PyObject {
         [a.to_object(py), args.into(), kwargs.to_object(py)].to_object(py)
     }
@@ -249,7 +254,7 @@ impl MethSignature {
         &self,
         py: Python<'_>,
         a: i32,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<Py2<'_, PyDict>>,
     ) -> PyObject {
         [a.to_object(py), kwargs.to_object(py)].to_object(py)
     }
@@ -259,7 +264,7 @@ impl MethSignature {
         &self,
         py: Python<'_>,
         a: i32,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<Py2<'_, PyDict>>,
     ) -> PyObject {
         [a.to_object(py), kwargs.to_object(py)].to_object(py)
     }
@@ -295,7 +300,7 @@ impl MethSignature {
     }
 
     #[pyo3(signature = (a, **kwargs))]
-    fn get_pos_kw(&self, py: Python<'_>, a: i32, kwargs: Option<&PyDict>) -> PyObject {
+    fn get_pos_kw(&self, py: Python<'_>, a: i32, kwargs: Option<Py2<'_, PyDict>>) -> PyObject {
         [a.to_object(py), kwargs.to_object(py)].to_object(py)
     }
 
@@ -1009,7 +1014,7 @@ issue_1506!(
             _py: Python<'_>,
             _arg: &PyAny,
             _args: &PyTuple,
-            _kwargs: Option<&PyDict>,
+            _kwargs: Option<Py2<'_, PyDict>>,
         ) {
         }
 
@@ -1018,7 +1023,7 @@ issue_1506!(
             _py: Python<'_>,
             _arg: &PyAny,
             _args: &PyTuple,
-            _kwargs: Option<&PyDict>,
+            _kwargs: Option<Py2<'_, PyDict>>,
         ) {
         }
 
@@ -1027,7 +1032,7 @@ issue_1506!(
             _py: Python<'_>,
             _arg: &PyAny,
             _args: &PyTuple,
-            _kwargs: Option<&PyDict>,
+            _kwargs: Option<Py2<'_, PyDict>>,
         ) {
         }
 
@@ -1036,7 +1041,7 @@ issue_1506!(
             _py: Python<'_>,
             _arg: &PyAny,
             _args: &PyTuple,
-            _kwargs: Option<&PyDict>,
+            _kwargs: Option<Py2<'_, PyDict>>,
         ) {
         }
 
@@ -1045,7 +1050,7 @@ issue_1506!(
             _py: Python<'_>,
             _arg: &PyAny,
             _args: &PyTuple,
-            _kwargs: Option<&PyDict>,
+            _kwargs: Option<Py2<'_, PyDict>>,
         ) -> Self {
             Issue1506 {}
         }
@@ -1063,7 +1068,7 @@ issue_1506!(
             _py: Python<'_>,
             _arg: &PyAny,
             _args: &PyTuple,
-            _kwargs: Option<&PyDict>,
+            _kwargs: Option<Py2<'_, PyDict>>,
         ) {
         }
 
@@ -1073,7 +1078,7 @@ issue_1506!(
             _py: Python<'_>,
             _arg: &PyAny,
             _args: &PyTuple,
-            _kwargs: Option<&PyDict>,
+            _kwargs: Option<Py2<'_, PyDict>>,
         ) {
         }
     }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -3,6 +3,7 @@
 use pyo3::prelude::*;
 use pyo3::py_run;
 use pyo3::types::{IntoPyDict, PyDict, PyList, PySet, PyString, PyTuple, PyType};
+use pyo3::Py2;
 use pyo3::PyCell;
 
 mod common;
@@ -675,7 +676,7 @@ struct MethodWithLifeTime {}
 
 #[pymethods]
 impl MethodWithLifeTime {
-    fn set_to_list<'py>(&self, py: Python<'py>, set: &'py PySet) -> PyResult<&'py PyList> {
+    fn set_to_list<'py>(&self, py: Python<'py>, set: &'py PySet) -> PyResult<Py2<'py, PyList>> {
         let mut items = vec![];
         for _ in 0..set.len() {
             items.push(set.pop().unwrap());

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -375,7 +375,7 @@ fn pyfunction_with_module_and_default_arg<'a>(
 fn pyfunction_with_module_and_args_kwargs<'a>(
     module: &'a PyModule,
     args: &PyTuple,
-    kwargs: Option<&PyDict>,
+    kwargs: Option<Py2<'_, PyDict>>,
 ) -> PyResult<(&'a str, usize, Option<usize>)> {
     module
         .name()

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -190,7 +190,7 @@ pub struct Mapping {
 #[pymethods]
 impl Mapping {
     fn __len__(&self, py: Python<'_>) -> usize {
-        self.values.as_ref(py).len()
+        self.values.attach(py).len()
     }
 
     fn __getitem__<'a>(&'a self, key: &'a PyAny) -> PyResult<&'a PyAny> {

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "macros")]
 
 use pyo3::exceptions::{PyIndexError, PyValueError};
-use pyo3::types::{IntoPyDict, PyList, PyMapping, PySequence};
+use pyo3::types::{IntoPyDict, PyDict, PyList, PyMapping, PySequence};
 use pyo3::{ffi, prelude::*, Py2};
 
 use pyo3::py_run;
@@ -104,7 +104,7 @@ impl ByteSequence {
 }
 
 /// Return a dict with `s = ByteSequence([1, 2, 3])`.
-fn seq_dict(py: Python<'_>) -> &pyo3::types::PyDict {
+fn seq_dict(py: Python<'_>) -> Py2<'_, PyDict> {
     let d = [("ByteSequence", py.get_type::<ByteSequence>())].into_py_dict(py);
     // Though we can construct `s` in Rust, let's test `__new__` works.
     py_run!(py, *d, "s = ByteSequence([1, 2, 3])");

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -2,7 +2,7 @@
 
 use pyo3::exceptions::{PyIndexError, PyValueError};
 use pyo3::types::{IntoPyDict, PyList, PyMapping, PySequence};
-use pyo3::{ffi, prelude::*};
+use pyo3::{ffi, prelude::*, Py2};
 
 use pyo3::py_run;
 
@@ -16,7 +16,7 @@ struct ByteSequence {
 #[pymethods]
 impl ByteSequence {
     #[new]
-    fn new(elements: Option<&PyList>) -> PyResult<Self> {
+    fn new(elements: Option<Py2<'_, PyList>>) -> PyResult<Self> {
         if let Some(pylist) = elements {
             let mut elems = Vec::with_capacity(pylist.len());
             for pyelem in pylist {

--- a/tests/test_static_slots.rs
+++ b/tests/test_static_slots.rs
@@ -2,7 +2,7 @@
 
 use pyo3::exceptions::PyIndexError;
 use pyo3::prelude::*;
-use pyo3::types::IntoPyDict;
+use pyo3::types::{IntoPyDict, PyDict};
 
 use pyo3::py_run;
 
@@ -36,7 +36,7 @@ impl Count5 {
 }
 
 /// Return a dict with `s = Count5()`.
-fn test_dict(py: Python<'_>) -> &pyo3::types::PyDict {
+fn test_dict(py: Python<'_>) -> Py2<'_, PyDict> {
     let d = [("Count5", py.get_type::<Count5>())].into_py_dict(py);
     // Though we can construct `s` in Rust, let's test `__new__` works.
     py_run!(py, *d, "s = Count5()");

--- a/tests/test_super.rs
+++ b/tests/test_super.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "macros", not(PyPy)))]
 
-use pyo3::prelude::*;
+use pyo3::{prelude::*, types::PySuper};
 
 #[pyclass(subclass)]
 struct BaseClass {
@@ -33,6 +33,11 @@ impl SubClass {
         let super_ = self_.py_super()?;
         super_.call_method("method", (), None)
     }
+
+    fn method_super_new(self_: &PyCell<Self>) -> PyResult<&PyAny> {
+        let super_ = PySuper::new(self_.get_type(), self_)?;
+        super_.call_method("method", (), None)
+    }
 }
 
 #[test]
@@ -45,6 +50,7 @@ fn test_call_super_method() {
             r#"
         obj = cls()
         assert obj.method() == 10
+        assert obj.method_super_new() == 10
     "#
         )
     });

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -130,7 +130,7 @@ fn test_auto_test_signature_function() {
         args: &PyTuple,
         c: i32,
         d: i32,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<Py2<'_, PyDict>>,
     ) {
         let _ = (a, b, args, c, d, kwargs);
     }
@@ -220,7 +220,7 @@ fn test_auto_test_signature_method() {
             args: &PyTuple,
             c: i32,
             d: i32,
-            kwargs: Option<&PyDict>,
+            kwargs: Option<Py2<'_, PyDict>>,
         ) {
             let _ = (a, b, args, c, d, kwargs);
         }

--- a/tests/test_variable_arguments.rs
+++ b/tests/test_variable_arguments.rs
@@ -18,7 +18,7 @@ impl MyClass {
 
     #[staticmethod]
     #[pyo3(signature = (**kwargs))]
-    fn test_kwargs(kwargs: Option<&PyDict>) -> Option<&PyDict> {
+    fn test_kwargs(kwargs: Option<Py2<'_, PyDict>>) -> Option<Py2<'_, PyDict>> {
         kwargs
     }
 }

--- a/tests/ui/static_ref.rs
+++ b/tests/ui/static_ref.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyList;
 
 #[pyfunction]
-fn static_ref(list: &'static PyList) -> usize {
+fn static_ref(list: Py2<'static, PyList>) -> usize {
     list.len()
 }
 


### PR DESCRIPTION
This is a kind of "what if" experiment to run with the idea of a `GIL<'py, PyAny>` smart pointer as discussed in https://github.com/PyO3/pyo3/pull/3205#issuecomment-1595703463

Here I've called it `Py2<'py, PyAny>` instead of `GIL<'py, PyAny>` because ultimately I think if we go down this route it should be called `Py<'py, PyAny>` and we should rename the existing "gil-free" `Py` to something like `PyUngil` or `PyDetached`.

The main challenge with these `Py2` smart-pointer APIs as noted in https://github.com/PyO3/pyo3/pull/3205#issuecomment-1595703463 is that without `arbitrary_self_types` we cannot have inherent methods for `T` which accept `&Py2<T>` as the receiver.

The way I propose we would workaround this problem is by putting the type's methods behind a trait, and then including that trait in `pyo3::prelude`. For example, there is `PyAny` and `impl PyAnyMethods for Py2<'py, PyAny>`. This PR also adds `PyList` and `impl PyListMethods for Py2<'py, PyAny>`. While this split looks a bit unusual at first, it's actually quite easy to document and a repeatable convention that downstream crates like `rust_numpy` could also follow (potentially with their own `rust_numpy::prelude` if they wanted to bundle all their trades).

This also has the great property that I expect a future PyO3 with an MSRV with stable `arbitrary_self_types` to require no changes to user code, because we'd just fold the traits into inherent methods and delete the trait imports from the prelude.

I'm quite pumped about this possibility for a pool-free API. Even better, I think because this doesn't change the fundamental types at all (`PyAny`, `PyDict`, `PyList` etc all continue to exist with no definition changes) I think it's possible we could ship a `pyo3-pool` crate with its own `pyo3_pool::prelude` and macro compatibility e.g. `#[pyfunction(crate = "pyo3_pool")]` for users to use during their upgrade cycle to get fully backwards-compatible behaviour while removing the pool from the main API.

Personally, I now like this significantly more than the corresponding experiment in #3253 with `PyList<'py>`.
