### PR TITLE
PyBuffer/Py<T>: Data race allowed on T

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -34,8 +34,8 @@ pub struct PyBuffer<T>(Pin<Box<ffi::Py_buffer>>, PhantomData<T>);
 
 // PyBuffer is thread-safe: the shape of the buffer is immutable while a Py_buffer exists.
 // Accessing the buffer contents is protected using the GIL.
-unsafe impl<T> Send for PyBuffer<T> {}
-unsafe impl<T> Sync for PyBuffer<T> {}
+unsafe impl<T: Send> Send for PyBuffer<T> {}
+unsafe impl<T: Sync> Sync for PyBuffer<T> {}
 
 impl<T> Debug for PyBuffer<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -226,8 +226,8 @@ pub struct Py<T>(NonNull<ffi::PyObject>, PhantomData<T>);
 // The inner value is only accessed through ways that require proving the gil is held
 #[cfg(feature = "nightly")]
 unsafe impl<T> crate::marker::Ungil for Py<T> {}
-unsafe impl<T> Send for Py<T> {}
-unsafe impl<T> Sync for Py<T> {}
+unsafe impl<T: Send> Send for Py<T> {}
+unsafe impl<T: Sync> Sync for Py<T> {}
 
 impl<T> Py<T>
 where


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
`PyBuffer<T>` unconditionally implements Sync. This allows users to create data races on `T: !Sync`. Such data races can lead to undefined behavior.

https://github.com/PyO3/pyo3/blob/ae982b8ad0fff71d4d2fdbc2f7055500a6fb450f/src/buffer.rs#L37-L38

same
https://github.com/PyO3/pyo3/blob/ae982b8ad0fff71d4d2fdbc2f7055500a6fb450f/src/instance.rs#L229-L230