### PR TITLE
Remove non-MIT contributions

### DIFF
--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -2,7 +2,7 @@
 
 ## Defining a new exception
 
-You can use the [`create_exception!`] macro to define a new exception type:
+Use the [`create_exception!`] macro:
 
 ```rust
 use pyo3::create_exception;

--- a/newsfragments/3387.packaging.md
+++ b/newsfragments/3387.packaging.md
@@ -1,0 +1,1 @@
+Drop support for debug builds of Python 3.7.


### PR DESCRIPTION
As per https://github.com/PyO3/pyo3/issues/2339#issuecomment-1678555706

This PR reverts commits by @cecini, @potocpav, and @thanatos, who have been the non-respondents to our intent to relicense.

Mostly these lines have been reworked or replaced already, so the majority of these reverts are empty and purely present for ceremonial purpose.

The one possible change which was meaningful was correct handling of `Py_TRACE_REFS` flag which was part of `Py_DEBUG` up to and including 3.7. Therefore to move forward I propose to drop support for *debug* builds on Python 3.7. @alex I assume that dropping support of 3.7 debug interpreters will not impact cryptography, given debug wheels aren't shipped to PyPI.