### PR TITLE
Remove usage of `AsPyPointer` in traits for convergint to PyObject

### DIFF
--- a/newsfragments/3391.changed.md
+++ b/newsfragments/3391.changed.md
@@ -1,0 +1,1 @@
+Replace `AsPyPointer` with `AsRef<PyAny>` as a bound in the blanket implementation of `From<&T> for PyObject`

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -933,12 +933,18 @@ impl<T> crate::AsPyPointer for Py<T> {
     }
 }
 
+impl std::convert::From<&'_ PyAny> for PyObject {
+    fn from(obj: &PyAny) -> Self {
+        unsafe { Py::from_borrowed_ptr(obj.py(), obj.as_ptr()) }
+    }
+}
+
 impl<T> std::convert::From<&'_ T> for PyObject
 where
-    T: AsPyPointer + PyNativeType,
+    T: PyNativeType + AsRef<PyAny>,
 {
     fn from(obj: &T) -> Self {
-        unsafe { Py::from_borrowed_ptr(obj.py(), obj.as_ptr()) }
+        unsafe { Py::from_borrowed_ptr(obj.py(), obj.as_ref().as_ptr()) }
     }
 }
 


### PR DESCRIPTION
Refs #3358