### PR TITLE
Fix memory leak in `PyTypeBuilder::build`

### DIFF
--- a/newsfragments/3401.fixed.md
+++ b/newsfragments/3401.fixed.md
@@ -1,0 +1,1 @@
+Fix memory leak in `PyTypeBuilder::build`.


### PR DESCRIPTION
Fixes #3400 