### PR TITLE
Unwrap the underlying PyErr when converting an io::Error back to a PyErr

### DIFF
--- a/newsfragments/3402.changed.md
+++ b/newsfragments/3402.changed.md
@@ -1,0 +1,1 @@
+`std::io::Error` cast: Reuses the underlying `PyErr` Python error instead of wrapping it again if the `io::Error` has been built using a Python exception


### PR DESCRIPTION
Exposes it directly instead of loosing all information outside the message

This is useful for use cases like "wrap Python I/O in a `io::Read` Rust trait" where the python exception are converted to `io::Error` then converted again to exceptions