### PR TITLE
update definitions for objimpl.h

### DIFF
--- a/newsfragments/3403.added.md
+++ b/newsfragments/3403.added.md
@@ -1,0 +1,1 @@
+Add FFI definitions `PyObject_GC_IsTracked` and `PyObject_GC_IsFinalized` on Python 3.9 and up (PyPy 3.10 and up).

--- a/newsfragments/3403.fixed.md
+++ b/newsfragments/3403.fixed.md
@@ -1,0 +1,1 @@
+Disable removed FFI definitions `_Py_GetAllocatedBlocks`, `_PyObject_GC_Malloc`, and `_PyObject_GC_Calloc` on Python 3.11 and up.

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod listobject;
 #[cfg(all(Py_3_9, not(PyPy)))]
 pub(crate) mod methodobject;
 pub(crate) mod object;
+pub(crate) mod objimpl;
 pub(crate) mod pydebug;
 pub(crate) mod pyerrors;
 #[cfg(all(Py_3_8, not(PyPy)))]
@@ -54,6 +55,7 @@ pub use self::listobject::*;
 #[cfg(all(Py_3_9, not(PyPy)))]
 pub use self::methodobject::*;
 pub use self::object::*;
+pub use self::objimpl::*;
 pub use self::pydebug::*;
 pub use self::pyerrors::*;
 #[cfg(all(Py_3_8, not(PyPy)))]

--- a/pyo3-ffi/src/cpython/objimpl.rs
+++ b/pyo3-ffi/src/cpython/objimpl.rs
@@ -1,0 +1,71 @@
+use libc::size_t;
+use std::os::raw::c_int;
+
+#[cfg(not(PyPy))]
+use std::os::raw::c_void;
+
+use crate::object::*;
+
+// skipped _PyObject_SIZE
+// skipped _PyObject_VAR_SIZE
+
+#[cfg(not(Py_3_11))]
+extern "C" {
+    pub fn _Py_GetAllocatedBlocks() -> crate::Py_ssize_t;
+}
+
+#[cfg(not(PyPy))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyObjectArenaAllocator {
+    pub ctx: *mut c_void,
+    pub alloc: Option<extern "C" fn(ctx: *mut c_void, size: size_t) -> *mut c_void>,
+    pub free: Option<extern "C" fn(ctx: *mut c_void, ptr: *mut c_void, size: size_t)>,
+}
+
+#[cfg(not(PyPy))]
+impl Default for PyObjectArenaAllocator {
+    #[inline]
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+extern "C" {
+    #[cfg(not(PyPy))]
+    pub fn PyObject_GetArenaAllocator(allocator: *mut PyObjectArenaAllocator);
+    #[cfg(not(PyPy))]
+    pub fn PyObject_SetArenaAllocator(allocator: *mut PyObjectArenaAllocator);
+
+    #[cfg(Py_3_9)]
+    pub fn PyObject_IS_GC(o: *mut PyObject) -> c_int;
+}
+
+#[inline]
+#[cfg(not(Py_3_9))]
+pub unsafe fn PyObject_IS_GC(o: *mut PyObject) -> c_int {
+    (crate::PyType_IS_GC(Py_TYPE(o)) != 0
+        && match (*Py_TYPE(o)).tp_is_gc {
+            Some(tp_is_gc) => tp_is_gc(o) != 0,
+            None => true,
+        }) as c_int
+}
+
+#[cfg(not(Py_3_11))]
+extern "C" {
+    pub fn _PyObject_GC_Malloc(size: size_t) -> *mut PyObject;
+    pub fn _PyObject_GC_Calloc(size: size_t) -> *mut PyObject;
+}
+
+#[inline]
+pub unsafe fn PyType_SUPPORTS_WEAKREFS(t: *mut PyTypeObject) -> c_int {
+    ((*t).tp_weaklistoffset > 0) as c_int
+}
+
+#[inline]
+pub unsafe fn PyObject_GET_WEAKREFS_LISTPTR(o: *mut PyObject) -> *mut *mut PyObject {
+    let weaklistoffset = (*Py_TYPE(o)).tp_weaklistoffset;
+    o.offset(weaklistoffset) as *mut *mut PyObject
+}
+
+// skipped PyUnstable_Object_GC_NewWithExtraData


### PR DESCRIPTION
While looking into #3064 I noticed that our definitions for `objimpl.h` were extremely out of date. (I wanted to use the added symbols for debugging purposes.)

Mostly this is just reshuffling, the API changes are in the newsfragments.