### PR TITLE
call PyObject_GC_Untrack before deallocating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,8 +376,11 @@ jobs:
           components: rust-src
       - name: Install python3 standalone debug build with nox
         run: |
-          wget https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst
-          tar -I zstd -xf cpython-3.11.5+20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst
+          PBS_RELEASE="20230826"
+          PBS_PYTHON_VERSION="3.11.5"
+          PBS_ARCHIVE="cpython-${PBS_PYTHON_VERSION}+${PBS_RELEASE}-x86_64-unknown-linux-gnu-debug-full.tar.zst"
+          wget "https://github.com/indygreg/python-build-standalone/releases/download/${PBS_RELEASE}/${PBS_ARCHIVE}"
+          tar -I zstd -xf "${PBS_ARCHIVE}"
           ls -l $(pwd)/python/install/bin
           ls -l $(pwd)/python/install/lib
           echo PATH=$(pwd)/python/install/bin:$PATH >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,46 @@ jobs:
       - name: Test
         run: nox -s test-emscripten
 
+  test-debug:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: cargo-test-debug
+        continue-on-error: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-src
+      - name: Install python3 standalone debug build with nox
+        run: |
+          wget https://github.com/indygreg/python-build-standalone/releases/download/20230826/cpython-3.11.5+20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst
+          tar -I zstd -xf cpython-3.11.5+20230826-x86_64-unknown-linux-gnu-debug-full.tar.zst
+          ls -l $(pwd)/python/install/bin
+          ls -l $(pwd)/python/install/lib
+          echo PATH=$(pwd)/python/install/bin:$PATH >> $GITHUB_ENV
+          echo LD_LIBRARY_PATH=$(pwd)/python/install/lib:$LD_LIBRARY_PATH >> $GITHUB_ENV
+          echo PYTHONHOME=$(pwd)/python/install >> $GITHUB_ENV
+          echo PYO3_PYTHON=$(pwd)/python/install/bin/python3 >> $GITHUB_ENV
+      - run: python3 -m sysconfig
+      - run: python3 -m pip install --upgrade pip && pip install nox
+      - run: |
+          PYO3_CONFIG_FILE=$(mktemp)
+          cat > $PYO3_CONFIG_FILE << EOF
+          implementation=CPython
+          version=3.11
+          shared=true
+          abi3=false
+          lib_name=python3.11d
+          lib_dir=${{ github.workspace }}/python/install/lib
+          executable=${{ github.workspace }}/python/install/bin/python3
+          pointer_width=64
+          build_flags=Py_DEBUG,Py_REF_DEBUG
+          suppress_build_script_link_lines=false
+          EOF
+          echo PYO3_CONFIG_FILE=$PYO3_CONFIG_FILE >> $GITHUB_ENV
+      - run: python3 -m nox -s test
+
   conclusion:
     needs:
       - fmt

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1136,7 +1136,6 @@ impl pyo3::IntoPy<PyObject> for MyClass {
 impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
     const IS_BASETYPE: bool = false;
     const IS_SUBCLASS: bool = false;
-    type Layout = PyCell<MyClass>;
     type BaseType = PyAny;
     type ThreadChecker = pyo3::impl_::pyclass::SendablePyClass<MyClass>;
     type PyClassMutability = <<pyo3::PyAny as pyo3::impl_::pyclass::PyClassBaseType>::PyClassMutability as pyo3::impl_::pycell::PyClassMutability>::MutableChild;

--- a/newsfragments/3404.fixed.md
+++ b/newsfragments/3404.fixed.md
@@ -1,0 +1,1 @@
+Fix `ResourceWarning` and crashes related to GC when running with debug builds of CPython.

--- a/noxfile.py
+++ b/noxfile.py
@@ -475,6 +475,7 @@ def set_minimal_package_versions(session: nox.Session):
     min_pkg_versions = {
         "rust_decimal": "1.26.1",
         "csv": "1.1.6",
+        "indexmap": "1.9.3",
         "hashbrown": "0.12.3",
         "log": "0.4.17",
         "once_cell": "1.17.2",
@@ -482,7 +483,6 @@ def set_minimal_package_versions(session: nox.Session):
         "rayon-core": "1.10.2",
         "regex": "1.7.3",
         "proptest": "1.0.0",
-        "indexmap": "1.9.3",
         "chrono": "0.4.25",
     }
 

--- a/pyo3-ffi/src/objimpl.rs
+++ b/pyo3-ffi/src/objimpl.rs
@@ -7,6 +7,7 @@ use crate::pyport::Py_ssize_t;
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyObject_Malloc")]
     pub fn PyObject_Malloc(size: size_t) -> *mut c_void;
+    #[cfg_attr(PyPy, link_name = "PyPyObject_Calloc")]
     pub fn PyObject_Calloc(nelem: size_t, elsize: size_t) -> *mut c_void;
     #[cfg_attr(PyPy, link_name = "PyPyObject_Realloc")]
     pub fn PyObject_Realloc(ptr: *mut c_void, new_size: size_t) -> *mut c_void;
@@ -72,7 +73,9 @@ extern "C" {
     pub fn _PyObject_GC_New(arg1: *mut PyTypeObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "_PyPyObject_GC_NewVar")]
     pub fn _PyObject_GC_NewVar(arg1: *mut PyTypeObject, arg2: Py_ssize_t) -> *mut PyVarObject;
+    #[cfg(not(PyPy))]
     pub fn PyObject_GC_Track(arg1: *mut c_void);
+    #[cfg(not(PyPy))]
     pub fn PyObject_GC_UnTrack(arg1: *mut c_void);
     #[cfg_attr(PyPy, link_name = "PyPyObject_GC_Del")]
     pub fn PyObject_GC_Del(arg1: *mut c_void);

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1029,7 +1029,6 @@ impl<'a> PyClassImplsBuilder<'a> {
                 const IS_MAPPING: bool = #is_mapping;
                 const IS_SEQUENCE: bool = #is_sequence;
 
-                type Layout = _pyo3::PyCell<Self>;
                 type BaseType = #base;
                 type ThreadChecker = #thread_checker;
                 #inventory

--- a/src/impl_/freelist.rs
+++ b/src/impl_/freelist.rs
@@ -55,7 +55,7 @@ impl<T> FreeList<T> {
         }
     }
 
-    /// Inserts a value into the list. Returns `None` if the `FreeList` is full.
+    /// Inserts a value into the list. Returns `Some(val)` if the `FreeList` is full.
     pub fn insert(&mut self, val: T) -> Option<T> {
         let next = self.split + 1;
         if next < self.capacity {

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -174,8 +174,7 @@ impl<T: PyClassImpl<PyClassMutability = Self>> GetBorrowChecker<T> for Immutable
 impl<T: PyClassImpl<PyClassMutability = Self>, M: PyClassMutability> GetBorrowChecker<T>
     for ExtendsMutableAncestor<M>
 where
-    T::BaseType: PyClassImpl<Layout = PyCell<T::BaseType>>
-        + PyClassBaseType<LayoutAsBase = PyCell<T::BaseType>>,
+    T::BaseType: PyClassImpl + PyClassBaseType<LayoutAsBase = PyCell<T::BaseType>>,
     <T::BaseType as PyClassImpl>::PyClassMutability: PyClassMutability<Checker = BorrowChecker>,
 {
     fn borrow_checker(cell: &PyCell<T>) -> &BorrowChecker {
@@ -188,7 +187,6 @@ where
 mod tests {
     use super::*;
 
-    use crate::impl_::pyclass::{PyClassBaseType, PyClassImpl};
     use crate::prelude::*;
     use crate::pyclass::boolean_struct::{False, True};
     use crate::PyClass;
@@ -239,25 +237,11 @@ mod tests {
     fn assert_immutable<T: PyClass<Frozen = True, PyClassMutability = ImmutableClass>>() {}
     fn assert_mutable_with_mutable_ancestor<
         T: PyClass<Frozen = False, PyClassMutability = ExtendsMutableAncestor<MutableClass>>,
-    >()
-    // These horrible bounds are necessary for Rust 1.48 but not newer versions
-    where
-        <T as PyClassImpl>::BaseType: PyClassImpl<Layout = PyCell<T::BaseType>>,
-        <<T as PyClassImpl>::BaseType as PyClassImpl>::PyClassMutability:
-            PyClassMutability<Checker = BorrowChecker>,
-        <T as PyClassImpl>::BaseType: PyClassBaseType<LayoutAsBase = PyCell<T::BaseType>>,
-    {
+    >() {
     }
     fn assert_immutable_with_mutable_ancestor<
         T: PyClass<Frozen = True, PyClassMutability = ExtendsMutableAncestor<ImmutableClass>>,
-    >()
-    // These horrible bounds are necessary for Rust 1.48 but not newer versions
-    where
-        <T as PyClassImpl>::BaseType: PyClassImpl<Layout = PyCell<T::BaseType>>,
-        <<T as PyClassImpl>::BaseType as PyClassImpl>::PyClassMutability:
-            PyClassMutability<Checker = BorrowChecker>,
-        <T as PyClassImpl>::BaseType: PyClassBaseType<LayoutAsBase = PyCell<T::BaseType>>,
-    {
+    >() {
     }
 
     #[test]

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -15,9 +15,7 @@ pub use self::gc::{PyTraverseError, PyVisit};
 ///
 /// The `#[pyclass]` attribute implements this trait for your Rust struct -
 /// you shouldn't implement this trait directly.
-pub trait PyClass:
-    PyTypeInfo<AsRefTarget = PyCell<Self>> + PyClassImpl<Layout = PyCell<Self>>
-{
+pub trait PyClass: PyTypeInfo<AsRefTarget = PyCell<Self>> + PyClassImpl {
     /// Whether the pyclass is frozen.
     ///
     /// This can be enabled via `#[pyclass(frozen)]`.


### PR DESCRIPTION
Fixes #3064 
Closes #3416 

~~I verified by hand that this fixes the warning on a debug build of Python. As we don't run debug builds in CI I'm unsure if there's any way we can test this.~~ EDIT: now testing debug build in CI as part of this PR.

As a bit of refactoring here I removed `Layout` from `PyClassImpl` as it's no longer necessary.