### PR TITLE
fix compile warning on pre-3.12 debug builds

### DIFF
--- a/newsfragments/3405.fixed.md
+++ b/newsfragments/3405.fixed.md
@@ -1,0 +1,1 @@
+Fix compile warning for unreachable expression on debug builds before 3.12.

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -500,9 +500,14 @@ pub unsafe fn Py_INCREF(op: *mut PyObject) {
     }
 
     #[cfg(any(
-        not(Py_LIMITED_API),
         all(Py_LIMITED_API, not(Py_3_12)),
-        all(py_sys_config = "Py_REF_DEBUG", Py_3_12, not(Py_LIMITED_API))
+        all(
+            not(Py_LIMITED_API),
+            any(
+                not(py_sys_config = "Py_REF_DEBUG"),
+                all(py_sys_config = "Py_REF_DEBUG", Py_3_12),
+            )
+        ),
     ))]
     {
         #[cfg(all(Py_3_12, target_pointer_width = "64"))]
@@ -560,9 +565,14 @@ pub unsafe fn Py_DECREF(op: *mut PyObject) {
     }
 
     #[cfg(any(
-        not(Py_LIMITED_API),
         all(Py_LIMITED_API, not(Py_3_12)),
-        all(py_sys_config = "Py_REF_DEBUG", Py_3_12, not(Py_LIMITED_API))
+        all(
+            not(Py_LIMITED_API),
+            any(
+                not(py_sys_config = "Py_REF_DEBUG"),
+                all(py_sys_config = "Py_REF_DEBUG", Py_3_12),
+            )
+        ),
     ))]
     {
         #[cfg(Py_3_12)]


### PR DESCRIPTION
Fixes the following warnings which I hit while testing #3404 

```
warning: unreachable expression
   --> pyo3-ffi/src/object.rs:507:5
    |
494 |           return _Py_IncRef(op);
    |           --------------------- any code following this expression is unreachable
...
507 | /     {
508 | |         #[cfg(all(Py_3_12, target_pointer_width = "64"))]
509 | |         {
510 | |             let cur_refcnt = (*op).ob_refcnt.ob_refcnt_split[crate::PY_BIG_ENDIAN];
...   |
535 | |         _Py_INC_REFTOTAL();
536 | |     }
    | |_____^ unreachable expression
    |
    = note: `#[warn(unreachable_code)]` on by default

warning: unreachable expression
   --> pyo3-ffi/src/object.rs:567:5
    |
554 |           return _Py_DecRef(op);
    |           --------------------- any code following this expression is unreachable
...
567 | /     {
568 | |         #[cfg(Py_3_12)]
569 | |         if _Py_IsImmortal(op) != 0 {
570 | |             return;
...   |
601 | |         }
602 | |     }
    | |_____^ unreachable expression
```