### PR TITLE
don't reinitialize the interpreter when it is shutting down

### DIFF
--- a/newsfragments/3412.fixed.md
+++ b/newsfragments/3412.fixed.md
@@ -1,0 +1,1 @@
+Fix crash when calling `Python::with_gil` while the interpreter is shutting down if the `auto-initalize` feature is enabled.

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -5,7 +5,10 @@ use std::{
     sync::atomic::{self, AtomicBool},
 };
 
-use crate::{exceptions::PyImportError, ffi, types::PyModule, Py, PyResult, Python};
+use crate::{
+    exceptions::PyImportError, ffi, gil::mark_python_initialized_from_import, types::PyModule, Py,
+    PyResult, Python,
+};
 
 /// `Sync` wrapper of `ffi::PyModuleDef`.
 pub struct ModuleDef {
@@ -56,6 +59,7 @@ impl ModuleDef {
     }
     /// Builds a module using user given initializer. Used for [`#[pymodule]`][crate::pymodule].
     pub fn make_module(&'static self, py: Python<'_>) -> PyResult<Py<PyModule>> {
+        mark_python_initialized_from_import();
         #[cfg(all(PyPy, not(Py_3_8)))]
         {
             const PYPY_GOOD_VERSION: [u8; 3] = [7, 3, 8];


### PR DESCRIPTION
Related to #3386.

If `auto-intialize` is enabled in an extension-module, we can hit a nasty C crash on interpreter shutdown where `auto-initialize` attempts to re-initialize it. I added an internal `mark_python_initialized_from_import` to disable `auto-initalize` when a `#[pymodule]` is imported (as the interpreter must be initialized at that point).

Second I add an assertion that the interpreter is initialized before attempting to acquire the GIL, to avoid odd crashes after the interpreter has been shut down (and just panic).