### PR TITLE
simplify thread checker implementation

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1138,7 +1138,7 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
     const IS_SUBCLASS: bool = false;
     type Layout = PyCell<MyClass>;
     type BaseType = PyAny;
-    type ThreadChecker = pyo3::impl_::pyclass::ThreadCheckerStub<MyClass>;
+    type ThreadChecker = pyo3::impl_::pyclass::SendablePyClass<MyClass>;
     type PyClassMutability = <<pyo3::PyAny as pyo3::impl_::pyclass::PyClassBaseType>::PyClassMutability as pyo3::impl_::pycell::PyClassMutability>::MutableChild;
     type Dict = pyo3::impl_::pyclass::PyClassDummySlot;
     type WeakRef = pyo3::impl_::pyclass::PyClassDummySlot;

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -947,13 +947,9 @@ impl<'a> PyClassImplsBuilder<'a> {
         };
 
         let thread_checker = if self.attr.options.unsendable.is_some() {
-            quote! { _pyo3::impl_::pyclass::ThreadCheckerImpl<#cls> }
-        } else if self.attr.options.extends.is_some() {
-            quote! {
-                _pyo3::impl_::pyclass::ThreadCheckerInherited<#cls, <#cls as _pyo3::impl_::pyclass::PyClassImpl>::BaseType>
-            }
+            quote! { _pyo3::impl_::pyclass::ThreadCheckerImpl }
         } else {
-            quote! { _pyo3::impl_::pyclass::ThreadCheckerStub<#cls> }
+            quote! { _pyo3::impl_::pyclass::SendablePyClass<#cls> }
         };
 
         let (pymethods_items, inventory, inventory_class) = match self.methods_type {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -250,7 +250,6 @@ macro_rules! pyobject_native_type_sized {
         impl<$($generics,)*> $crate::impl_::pyclass::PyClassBaseType for $name {
             type LayoutAsBase = $crate::pycell::PyCellBase<$layout>;
             type BaseNativeType = $name;
-            type ThreadChecker = $crate::impl_::pyclass::ThreadCheckerStub<$crate::PyObject>;
             type Initializer = $crate::pyclass_init::PyNativeTypeInitializer<Self>;
             type PyClassMutability = $crate::pycell::impl_::ImmutableClass;
         }

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -268,7 +268,7 @@ fn test_unsendable<T: PyClass + 'static>() -> PyResult<()> {
 #[test]
 #[cfg_attr(target_arch = "wasm32", ignore)]
 #[should_panic(
-    expected = "test_class_basics::UnsendableBase is unsendable, but sent to another thread!"
+    expected = "test_class_basics::UnsendableBase is unsendable, but sent to another thread"
 )]
 fn panic_unsendable_base() {
     test_unsendable::<UnsendableBase>().unwrap();
@@ -277,7 +277,7 @@ fn panic_unsendable_base() {
 #[test]
 #[cfg_attr(target_arch = "wasm32", ignore)]
 #[should_panic(
-    expected = "test_class_basics::UnsendableBase is unsendable, but sent to another thread!"
+    expected = "test_class_basics::UnsendableBase is unsendable, but sent to another thread"
 )]
 fn panic_unsendable_child() {
     test_unsendable::<UnsendableChild>().unwrap();
@@ -584,7 +584,7 @@ fn drop_unsendable_elsewhere() {
         assert!(!dropped.load(Ordering::SeqCst));
 
         let (err, object) = capture.borrow_mut(py).capture.take().unwrap();
-        assert_eq!(err.to_string(), "RuntimeError: test_class_basics::drop_unsendable_elsewhere::Unsendable is unsendbale, but is dropped on another thread!");
+        assert_eq!(err.to_string(), "RuntimeError: test_class_basics::drop_unsendable_elsewhere::Unsendable is unsendable, but is being dropped on another thread");
         assert!(object.is_none(py));
 
         capture.borrow_mut(py).uninstall(py);

--- a/tests/ui/abi3_nativetype_inheritance.stderr
+++ b/tests/ui/abi3_nativetype_inheritance.stderr
@@ -6,19 +6,4 @@ error[E0277]: the trait bound `PyDict: PyClass` is not satisfied
   |
   = help: the trait `PyClass` is implemented for `TestClass`
   = note: required for `PyDict` to implement `PyClassBaseType`
-note: required by a bound in `ThreadCheckerInherited`
- --> src/impl_/pyclass.rs
-  |
-  | pub struct ThreadCheckerInherited<T: PyClass + Send, U: PyClassBaseType>(
-  |                                                         ^^^^^^^^^^^^^^^ required by this bound in `ThreadCheckerInherited`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: the trait bound `PyDict: PyClass` is not satisfied
- --> tests/ui/abi3_nativetype_inheritance.rs:5:1
-  |
-5 | #[pyclass(extends=PyDict)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyClass` is not implemented for `PyDict`
-  |
-  = help: the trait `PyClass` is implemented for `TestClass`
-  = note: required for `PyDict` to implement `PyClassBaseType`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/pyclass_send.stderr
+++ b/tests/ui/pyclass_send.stderr
@@ -10,9 +10,9 @@ note: required because it appears within the type `NotThreadSafe`
   |
 5 | struct NotThreadSafe {
   |        ^^^^^^^^^^^^^
-note: required by a bound in `ThreadCheckerStub`
+note: required by a bound in `SendablePyClass`
  --> src/impl_/pyclass.rs
   |
-  | pub struct ThreadCheckerStub<T: Send>(PhantomData<T>);
-  |                                 ^^^^ required by this bound in `ThreadCheckerStub`
+  | pub struct SendablePyClass<T: Send>(PhantomData<T>);
+  |                               ^^^^ required by this bound in `SendablePyClass`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
I noticed that we don't need `ThreadCheckerInherited` because `PyCellLayout`'s `ensure_threadsafe` method already checks the whole inheritance tree.

At the same time I adjusted the implementation a little bit to reduce generic code and tidy up the error messages.