### PR TITLE
fix chrono deprecation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
-chrono = { version = "0.4" }
+chrono = { version = "0.4.25" }
 # Required for "and $N others" normalization
 trybuild = ">=1.0.70"
 proptest = { version = "1.0", default-features = false, features = ["std"] }

--- a/newsfragments/3427.packaging.md
+++ b/newsfragments/3427.packaging.md
@@ -1,0 +1,1 @@
+Bump `chrono` optional dependency to require 0.4.25 or newer.

--- a/noxfile.py
+++ b/noxfile.py
@@ -483,6 +483,7 @@ def set_minimal_package_versions(session: nox.Session):
         "regex": "1.7.3",
         "proptest": "1.0.0",
         "indexmap": "1.9.3",
+        "chrono": "0.4.25",
     }
 
     # run cargo update first to ensure that everything is at highest


### PR DESCRIPTION
`DateTime::from_utc` and `DateTime::from_local` are deprecated in `chrono` 0.4.27. MSRV was also bumped...