### PR TITLE
Add `noplayground` annotation to guide snippets

### DIFF
--- a/guide/book.toml
+++ b/guide/book.toml
@@ -9,3 +9,4 @@ command = "python3 guide/pyo3_version.py"
 [output.html]
 git-repository-url = "https://github.com/PyO3/pyo3/tree/main/guide"
 edit-url-template = "https://github.com/PyO3/pyo3/edit/main/guide/{path}"
+playground.runnable = false


### PR DESCRIPTION
None of them can be run in the playground
