### PR TITLE
add --no-fail-fast to cargo test in CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -643,7 +643,7 @@ def _run_cargo_test(
     command = ["cargo"]
     if "careful" in session.posargs:
         command.append("careful")
-    command.append("test")
+    command.extend(("test", "--no-fail-fast"))
     if "release" in session.posargs:
         command.append("--release")
     if package:


### PR DESCRIPTION
This might be helpful when changes break multiple tests, or e.g. in #3430 when adding a new test job I'd like to see everything that is broken.

Upside is that all test failures are reported, so fewer pushes & CI runs may be needed overall to fix them.

Downside is that the failures are higher up the log, so scrolling needed to see the test break.

On balance I think this is worth it.