### PR TITLE
add comments to ffi def structures

### DIFF
--- a/pyo3-ffi/src/descrobject.rs
+++ b/pyo3-ffi/src/descrobject.rs
@@ -8,6 +8,11 @@ pub type getter = unsafe extern "C" fn(slf: *mut PyObject, closure: *mut c_void)
 pub type setter =
     unsafe extern "C" fn(slf: *mut PyObject, value: *mut PyObject, closure: *mut c_void) -> c_int;
 
+/// Represents the [PyGetSetDef](https://docs.python.org/3/c-api/structures.html#c.PyGetSetDef)
+/// structure.
+///
+/// Note that CPython may leave fields uninitialized. You must ensure that
+/// `name` != NULL before dereferencing or reading other fields.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct PyGetSetDef {
@@ -63,6 +68,11 @@ extern "C" {
     pub fn PyWrapper_New(arg1: *mut PyObject, arg2: *mut PyObject) -> *mut PyObject;
 }
 
+/// Represents the [PyMemberDef](https://docs.python.org/3/c-api/structures.html#c.PyMemberDef)
+/// structure.
+///
+/// Note that CPython may leave fields uninitialized. You must always ensure that
+/// `name` != NULL before dereferencing or reading other fields.
 #[repr(C)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct PyMemberDef {

--- a/pyo3-ffi/src/methodobject.rs
+++ b/pyo3-ffi/src/methodobject.rs
@@ -85,6 +85,11 @@ extern "C" {
     ) -> *mut PyObject;
 }
 
+/// Represents the [PyMethodDef](https://docs.python.org/3/c-api/structures.html#c.PyMethodDef)
+/// structure.
+///
+/// Note that CPython may leave fields uninitialized. You must ensure that
+/// `ml_name` != NULL before dereferencing or reading other fields.
 #[repr(C)]
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct PyMethodDef {


### PR DESCRIPTION
Closes #2918 

Pulls the comments from that PR out for merging. I think we're not entirely convinced removing the derives is necessary, so I propose we just merge the documentation additions for now and close the other PR.

Full credit to @mejrs for the documentation!