### PR TITLE
propagate exception context from pyfunctions

### DIFF
--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -58,10 +58,14 @@ impl AssertingBaseClass {
     }
 }
 
+#[pyclass]
+struct ClassWithoutConstructor;
+
 #[pymodule]
 pub fn pyclasses(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<EmptyClass>()?;
     m.add_class::<PyClassIter>()?;
     m.add_class::<AssertingBaseClass>()?;
+    m.add_class::<ClassWithoutConstructor>()?;
     Ok(())
 }


### PR DESCRIPTION
Fixes #3432 

Our current implementation of `PyErr::restore` (before 3.12) doesn't propagate exception context when inside of an `except` block. This appears to be the root cause of #3432.

This PR attempts to resolve that and make the code paths between 3.12 and older versions more similar. I think there's more tidying up to do and might even be worth splitting into separate PRs to make motivations clear. Pushing this here so the code doesn't get forgotten while I multitask. Don't think it's necessarily worth reviewing yet.