### PR TITLE
add `Py2` as an internal API for optimization and dogfooding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -312,6 +312,9 @@ pub use crate::type_object::PyTypeInfo;
 pub use crate::types::PyAny;
 pub use crate::version::PythonVersionInfo;
 
+// Expected to become public API in 0.21 under a different name
+pub(crate) use crate::instance::Py2;
+
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///
 /// Prefer using the same content from `pyo3::pyclass`, e.g. `use pyo3::pyclass::CompareOp` instead

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -21,3 +21,7 @@ pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, FromPyObject};
 
 #[cfg(feature = "macros")]
 pub use crate::wrap_pyfunction;
+
+// Expected to become public API in 0.21
+// pub(crate) use crate::instance::Py2; // Will be stabilized with a different name
+// pub(crate) use crate::types::any::PyAnyMethods;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -2,11 +2,12 @@ use crate::class::basic::CompareOp;
 use crate::conversion::{AsPyPointer, FromPyObject, IntoPy, PyTryFrom, ToPyObject};
 use crate::err::{PyDowncastError, PyErr, PyResult};
 use crate::exceptions::{PyAttributeError, PyTypeError};
+use crate::instance::Py2;
 use crate::type_object::PyTypeInfo;
 #[cfg(not(PyPy))]
 use crate::types::PySuper;
 use crate::types::{PyDict, PyIterator, PyList, PyString, PyTuple, PyType};
-use crate::{err, ffi, Py, PyNativeType, PyObject, Python};
+use crate::{err, ffi, Py, PyNativeType, Python};
 use std::cell::UnsafeCell;
 use std::cmp::Ordering;
 use std::os::raw::c_int;
@@ -70,7 +71,7 @@ impl PyAny {
     /// This is equivalent to the Python expression `self is other`.
     #[inline]
     pub fn is<T: AsPyPointer>(&self, other: &T) -> bool {
-        self.as_ptr() == other.as_ptr()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is(other)
     }
 
     /// Determines whether this object has the given attribute.
@@ -99,17 +100,7 @@ impl PyAny {
     where
         N: IntoPy<Py<PyString>>,
     {
-        fn inner(any: &PyAny, attr_name: Py<PyString>) -> PyResult<bool> {
-            // PyObject_HasAttr suppresses all exceptions, which was the behaviour of `hasattr` in Python 2.
-            // Use an implementation which suppresses only AttributeError, which is consistent with `hasattr` in Python 3.
-            match any._getattr(attr_name) {
-                Ok(_) => Ok(true),
-                Err(err) if err.is_instance_of::<PyAttributeError>(any.py()) => Ok(false),
-                Err(e) => Err(e),
-            }
-        }
-
-        inner(self, attr_name.into_py(self.py()))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).hasattr(attr_name)
     }
 
     /// Retrieves an attribute value.
@@ -138,21 +129,9 @@ impl PyAny {
     where
         N: IntoPy<Py<PyString>>,
     {
-        fn inner(any: &PyAny, attr_name: Py<PyString>) -> PyResult<&PyAny> {
-            any._getattr(attr_name)
-                .map(|object| object.into_ref(any.py()))
-        }
-
-        inner(self, attr_name.into_py(self.py()))
-    }
-
-    fn _getattr(&self, attr_name: Py<PyString>) -> PyResult<PyObject> {
-        unsafe {
-            Py::from_owned_ptr_or_err(
-                self.py(),
-                ffi::PyObject_GetAttr(self.as_ptr(), attr_name.as_ptr()),
-            )
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .getattr(attr_name)
+            .map(Py2::into_gil_ref)
     }
 
     /// Retrieve an attribute value, skipping the instance dictionary during the lookup but still
@@ -227,14 +206,7 @@ impl PyAny {
         N: IntoPy<Py<PyString>>,
         V: ToPyObject,
     {
-        fn inner(any: &PyAny, attr_name: Py<PyString>, value: PyObject) -> PyResult<()> {
-            err::error_on_minusone(any.py(), unsafe {
-                ffi::PyObject_SetAttr(any.as_ptr(), attr_name.as_ptr(), value.as_ptr())
-            })
-        }
-
-        let py = self.py();
-        inner(self, attr_name.into_py(py), value.to_object(py))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).setattr(attr_name, value)
     }
 
     /// Deletes an attribute.
@@ -247,13 +219,7 @@ impl PyAny {
     where
         N: IntoPy<Py<PyString>>,
     {
-        fn inner(any: &PyAny, attr_name: Py<PyString>) -> PyResult<()> {
-            err::error_on_minusone(any.py(), unsafe {
-                ffi::PyObject_DelAttr(any.as_ptr(), attr_name.as_ptr())
-            })
-        }
-
-        inner(self, attr_name.into_py(self.py()))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).delattr(attr_name)
     }
 
     /// Returns an [`Ordering`] between `self` and `other`.
@@ -306,29 +272,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self._compare(other.to_object(self.py()))
-    }
-
-    fn _compare(&self, other: PyObject) -> PyResult<Ordering> {
-        let py = self.py();
-        let other = other.as_ptr();
-        // Almost the same as ffi::PyObject_RichCompareBool, but this one doesn't try self == other.
-        // See https://github.com/PyO3/pyo3/issues/985 for more.
-        let do_compare = |other, op| unsafe {
-            PyObject::from_owned_ptr_or_err(py, ffi::PyObject_RichCompare(self.as_ptr(), other, op))
-                .and_then(|obj| obj.is_true(py))
-        };
-        if do_compare(other, ffi::Py_EQ)? {
-            Ok(Ordering::Equal)
-        } else if do_compare(other, ffi::Py_LT)? {
-            Ok(Ordering::Less)
-        } else if do_compare(other, ffi::Py_GT)? {
-            Ok(Ordering::Greater)
-        } else {
-            Err(PyTypeError::new_err(
-                "PyAny::compare(): All comparisons returned false",
-            ))
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).compare(other)
     }
 
     /// Tests whether two Python objects obey a given [`CompareOp`].
@@ -369,17 +313,9 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        fn inner(slf: &PyAny, other: PyObject, compare_op: CompareOp) -> PyResult<&PyAny> {
-            unsafe {
-                slf.py().from_owned_ptr_or_err(ffi::PyObject_RichCompare(
-                    slf.as_ptr(),
-                    other.as_ptr(),
-                    compare_op as c_int,
-                ))
-            }
-        }
-
-        inner(self, other.to_object(self.py()), compare_op)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .rich_compare(other, compare_op)
+            .map(Py2::into_gil_ref)
     }
 
     /// Tests whether this object is less than another.
@@ -389,7 +325,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Lt)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).lt(other)
     }
 
     /// Tests whether this object is less than or equal to another.
@@ -399,7 +335,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Le)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).le(other)
     }
 
     /// Tests whether this object is equal to another.
@@ -409,7 +345,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Eq)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).eq(other)
     }
 
     /// Tests whether this object is not equal to another.
@@ -419,7 +355,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Ne)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).ne(other)
     }
 
     /// Tests whether this object is greater than another.
@@ -429,7 +365,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Gt)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).gt(other)
     }
 
     /// Tests whether this object is greater than or equal to another.
@@ -439,7 +375,7 @@ impl PyAny {
     where
         O: ToPyObject,
     {
-        self.rich_compare(other, CompareOp::Ge)?.is_true()
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).ge(other)
     }
 
     /// Determines whether this object appears callable.
@@ -470,7 +406,7 @@ impl PyAny {
     ///
     /// [1]: https://docs.python.org/3/library/functions.html#callable
     pub fn is_callable(&self) -> bool {
-        unsafe { ffi::PyCallable_Check(self.as_ptr()) != 0 }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_callable()
     }
 
     /// Calls the object.
@@ -508,16 +444,9 @@ impl PyAny {
         args: impl IntoPy<Py<PyTuple>>,
         kwargs: Option<&PyDict>,
     ) -> PyResult<&PyAny> {
-        let py = self.py();
-
-        let args = args.into_py(py);
-        let kwargs = kwargs.map_or(std::ptr::null_mut(), |kwargs| kwargs.as_ptr());
-
-        unsafe {
-            let return_value = ffi::PyObject_Call(self.as_ptr(), args.as_ptr(), kwargs);
-            let ret = py.from_owned_ptr_or_err(return_value);
-            ret
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call(args, kwargs)
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls the object without arguments.
@@ -541,19 +470,9 @@ impl PyAny {
     ///
     /// This is equivalent to the Python expression `help()`.
     pub fn call0(&self) -> PyResult<&PyAny> {
-        cfg_if::cfg_if! {
-            if #[cfg(all(
-                not(PyPy),
-                any(Py_3_10, all(not(Py_LIMITED_API), Py_3_9)) // PyObject_CallNoArgs was added to python in 3.9 but to limited API in 3.10
-            ))] {
-                // Optimized path on python 3.9+
-                unsafe {
-                    self.py().from_owned_ptr_or_err(ffi::PyObject_CallNoArgs(self.as_ptr()))
-                }
-            } else {
-                self.call((), None)
-            }
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call0()
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls the object with only positional arguments.
@@ -584,7 +503,9 @@ impl PyAny {
     /// # }
     /// ```
     pub fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<&PyAny> {
-        self.call(args, None)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call1(args)
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls a method on the object.
@@ -627,17 +548,9 @@ impl PyAny {
         N: IntoPy<Py<PyString>>,
         A: IntoPy<Py<PyTuple>>,
     {
-        let py = self.py();
-
-        let callee = self.getattr(name)?;
-        let args: Py<PyTuple> = args.into_py(py);
-        let kwargs = kwargs.map_or(std::ptr::null_mut(), |kwargs| kwargs.as_ptr());
-
-        unsafe {
-            let result_ptr = ffi::PyObject_Call(callee.as_ptr(), args.as_ptr(), kwargs);
-            let result = py.from_owned_ptr_or_err(result_ptr);
-            result
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call_method(name, args, kwargs)
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls a method on the object without arguments.
@@ -675,20 +588,9 @@ impl PyAny {
     where
         N: IntoPy<Py<PyString>>,
     {
-        cfg_if::cfg_if! {
-            if #[cfg(all(Py_3_9, not(any(Py_LIMITED_API, PyPy))))] {
-                let py = self.py();
-
-                // Optimized path on python 3.9+
-                unsafe {
-                    let name: Py<PyString> = name.into_py(py);
-                    let ptr = ffi::PyObject_CallMethodNoArgs(self.as_ptr(), name.as_ptr());
-                    py.from_owned_ptr_or_err(ptr)
-                }
-            } else {
-                self.call_method(name, (), None)
-            }
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call_method0(name)
+            .map(Py2::into_gil_ref)
     }
 
     /// Calls a method on the object with only positional arguments.
@@ -728,16 +630,16 @@ impl PyAny {
         N: IntoPy<Py<PyString>>,
         A: IntoPy<Py<PyTuple>>,
     {
-        self.call_method(name, args, None)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .call_method1(name, args)
+            .map(Py2::into_gil_ref)
     }
 
     /// Returns whether the object is considered to be true.
     ///
     /// This is equivalent to the Python expression `bool(self)`.
     pub fn is_true(&self) -> PyResult<bool> {
-        let v = unsafe { ffi::PyObject_IsTrue(self.as_ptr()) };
-        err::error_on_minusone(self.py(), v)?;
-        Ok(v != 0)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_true()
     }
 
     /// Returns whether the object is considered to be None.
@@ -745,21 +647,21 @@ impl PyAny {
     /// This is equivalent to the Python expression `self is None`.
     #[inline]
     pub fn is_none(&self) -> bool {
-        unsafe { ffi::Py_None() == self.as_ptr() }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_none()
     }
 
     /// Returns whether the object is Ellipsis, e.g. `...`.
     ///
     /// This is equivalent to the Python expression `self is ...`.
     pub fn is_ellipsis(&self) -> bool {
-        unsafe { ffi::Py_Ellipsis() == self.as_ptr() }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_ellipsis()
     }
 
     /// Returns true if the sequence or mapping has a length of 0.
     ///
     /// This is equivalent to the Python expression `len(self) == 0`.
     pub fn is_empty(&self) -> PyResult<bool> {
-        self.len().map(|l| l == 0)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_empty()
     }
 
     /// Gets an item from the collection.
@@ -769,14 +671,9 @@ impl PyAny {
     where
         K: ToPyObject,
     {
-        fn inner(slf: &PyAny, key: PyObject) -> PyResult<&PyAny> {
-            unsafe {
-                slf.py()
-                    .from_owned_ptr_or_err(ffi::PyObject_GetItem(slf.as_ptr(), key.as_ptr()))
-            }
-        }
-
-        inner(self, key.to_object(self.py()))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .get_item(key)
+            .map(Py2::into_gil_ref)
     }
 
     /// Sets a collection item value.
@@ -787,14 +684,7 @@ impl PyAny {
         K: ToPyObject,
         V: ToPyObject,
     {
-        fn inner(slf: &PyAny, key: PyObject, value: PyObject) -> PyResult<()> {
-            err::error_on_minusone(slf.py(), unsafe {
-                ffi::PyObject_SetItem(slf.as_ptr(), key.as_ptr(), value.as_ptr())
-            })
-        }
-
-        let py = self.py();
-        inner(self, key.to_object(py), value.to_object(py))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).set_item(key, value)
     }
 
     /// Deletes an item from the collection.
@@ -804,13 +694,7 @@ impl PyAny {
     where
         K: ToPyObject,
     {
-        fn inner(slf: &PyAny, key: PyObject) -> PyResult<()> {
-            err::error_on_minusone(slf.py(), unsafe {
-                ffi::PyObject_DelItem(slf.as_ptr(), key.as_ptr())
-            })
-        }
-
-        inner(self, key.to_object(self.py()))
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).del_item(key)
     }
 
     /// Takes an object and returns an iterator for it.
@@ -818,18 +702,24 @@ impl PyAny {
     /// This is typically a new iterator but if the argument is an iterator,
     /// this returns itself.
     pub fn iter(&self) -> PyResult<&PyIterator> {
-        PyIterator::from_object(self)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .iter()
+            .map(|py2| {
+                // Can't use into_gil_ref here because T: PyTypeInfo bound is not satisfied
+                // Safety: into_ptr produces a valid pointer to PyIterator object
+                unsafe { self.py().from_owned_ptr(py2.into_ptr()) }
+            })
     }
 
     /// Returns the Python type object for this object's type.
     pub fn get_type(&self) -> &PyType {
-        unsafe { PyType::from_type_ptr(self.py(), ffi::Py_TYPE(self.as_ptr())) }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).get_type()
     }
 
     /// Returns the Python type pointer for this object.
     #[inline]
     pub fn get_type_ptr(&self) -> *mut ffi::PyTypeObject {
-        unsafe { ffi::Py_TYPE(self.as_ptr()) }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).get_type_ptr()
     }
 
     /// Downcast this `PyAny` to a concrete Python type or pyclass.
@@ -955,52 +845,48 @@ impl PyAny {
 
     /// Returns the reference count for the Python object.
     pub fn get_refcnt(&self) -> isize {
-        unsafe { ffi::Py_REFCNT(self.as_ptr()) }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).get_refcnt()
     }
 
     /// Computes the "repr" representation of self.
     ///
     /// This is equivalent to the Python expression `repr(self)`.
     pub fn repr(&self) -> PyResult<&PyString> {
-        unsafe {
-            self.py()
-                .from_owned_ptr_or_err(ffi::PyObject_Repr(self.as_ptr()))
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .repr()
+            .map(Py2::into_gil_ref)
     }
 
     /// Computes the "str" representation of self.
     ///
     /// This is equivalent to the Python expression `str(self)`.
     pub fn str(&self) -> PyResult<&PyString> {
-        unsafe {
-            self.py()
-                .from_owned_ptr_or_err(ffi::PyObject_Str(self.as_ptr()))
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .str()
+            .map(Py2::into_gil_ref)
     }
 
     /// Retrieves the hash code of self.
     ///
     /// This is equivalent to the Python expression `hash(self)`.
     pub fn hash(&self) -> PyResult<isize> {
-        let v = unsafe { ffi::PyObject_Hash(self.as_ptr()) };
-        crate::err::error_on_minusone(self.py(), v)?;
-        Ok(v)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).hash()
     }
 
     /// Returns the length of the sequence or mapping.
     ///
     /// This is equivalent to the Python expression `len(self)`.
     pub fn len(&self) -> PyResult<usize> {
-        let v = unsafe { ffi::PyObject_Size(self.as_ptr()) };
-        crate::err::error_on_minusone(self.py(), v)?;
-        Ok(v as usize)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).len()
     }
 
     /// Returns the list of attributes of this object.
     ///
     /// This is equivalent to the Python expression `dir(self)`.
     pub fn dir(&self) -> &PyList {
-        unsafe { self.py().from_owned_ptr(ffi::PyObject_Dir(self.as_ptr())) }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .dir()
+            .into_gil_ref()
     }
 
     /// Checks whether this object is an instance of type `ty`.
@@ -1008,9 +894,7 @@ impl PyAny {
     /// This is equivalent to the Python expression `isinstance(self, ty)`.
     #[inline]
     pub fn is_instance(&self, ty: &PyAny) -> PyResult<bool> {
-        let result = unsafe { ffi::PyObject_IsInstance(self.as_ptr(), ty.as_ptr()) };
-        err::error_on_minusone(self.py(), result)?;
-        Ok(result == 1)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_instance(Py2::borrowed_from_gil_ref(&ty))
     }
 
     /// Checks whether this object is an instance of exactly type `ty` (not a subclass).
@@ -1018,7 +902,8 @@ impl PyAny {
     /// This is equivalent to the Python expression `type(self) is ty`.
     #[inline]
     pub fn is_exact_instance(&self, ty: &PyAny) -> bool {
-        self.get_type().is(ty)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .is_exact_instance(Py2::borrowed_from_gil_ref(&ty))
     }
 
     /// Checks whether this object is an instance of type `T`.
@@ -1027,7 +912,7 @@ impl PyAny {
     /// if the type `T` is known at compile time.
     #[inline]
     pub fn is_instance_of<T: PyTypeInfo>(&self) -> bool {
-        T::is_type_of(self)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_instance_of::<T>()
     }
 
     /// Checks whether this object is an instance of exactly type `T`.
@@ -1036,7 +921,7 @@ impl PyAny {
     /// if the type `T` is known at compile time.
     #[inline]
     pub fn is_exact_instance_of<T: PyTypeInfo>(&self) -> bool {
-        T::is_exact_type_of(self)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).is_exact_instance_of::<T>()
     }
 
     /// Determines if self contains `value`.
@@ -1046,15 +931,7 @@ impl PyAny {
     where
         V: ToPyObject,
     {
-        self._contains(value.to_object(self.py()))
-    }
-
-    fn _contains(&self, value: PyObject) -> PyResult<bool> {
-        match unsafe { ffi::PySequence_Contains(self.as_ptr(), value.as_ptr()) } {
-            0 => Ok(false),
-            1 => Ok(true),
-            _ => Err(PyErr::fetch(self.py())),
-        }
+        Py2::<PyAny>::borrowed_from_gil_ref(&self).contains(value)
     }
 
     /// Returns a GIL marker constrained to the lifetime of this type.
@@ -1093,15 +970,1219 @@ impl PyAny {
     /// This is equivalent to the Python expression `super()`
     #[cfg(not(PyPy))]
     pub fn py_super(&self) -> PyResult<&PySuper> {
-        PySuper::new(self.get_type(), self)
+        Py2::<PyAny>::borrowed_from_gil_ref(&self)
+            .py_super()
+            .map(Py2::into_gil_ref)
+    }
+}
+
+/// This trait represents the Python APIs which are usable on all Python objects.
+///
+/// It is recommended you import this trait via `use pyo3::prelude::*` rather than
+/// by importing this trait directly.
+#[doc(alias = "PyAny")]
+pub(crate) trait PyAnyMethods<'py> {
+    /// Returns whether `self` and `other` point to the same object. To compare
+    /// the equality of two objects (the `==` operator), use [`eq`](PyAny::eq).
+    ///
+    /// This is equivalent to the Python expression `self is other`.
+    fn is<T: AsPyPointer>(&self, other: &T) -> bool;
+
+    /// Determines whether this object has the given attribute.
+    ///
+    /// This is equivalent to the Python expression `hasattr(self, attr_name)`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `attr_name`.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, Python, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn has_version(sys: &PyModule) -> PyResult<bool> {
+    ///     sys.hasattr(intern!(sys.py(), "version"))
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let sys = py.import("sys").unwrap();
+    /// #    has_version(sys).unwrap();
+    /// # });
+    /// ```
+    fn hasattr<N>(&self, attr_name: N) -> PyResult<bool>
+    where
+        N: IntoPy<Py<PyString>>;
+
+    /// Retrieves an attribute value.
+    ///
+    /// This is equivalent to the Python expression `self.attr_name`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `attr_name`.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, PyAny, Python, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn version(sys: &PyModule) -> PyResult<&PyAny> {
+    ///     sys.getattr(intern!(sys.py(), "version"))
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let sys = py.import("sys").unwrap();
+    /// #    version(sys).unwrap();
+    /// # });
+    /// ```
+    fn getattr<N>(&self, attr_name: N) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>;
+
+    /// Sets an attribute value.
+    ///
+    /// This is equivalent to the Python expression `self.attr_name = value`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `name`.
+    ///
+    /// # Example: `intern!`ing the attribute name
+    ///
+    /// ```
+    /// # use pyo3::{intern, pyfunction, types::PyModule, PyAny, Python, PyResult};
+    /// #
+    /// #[pyfunction]
+    /// fn set_answer(ob: &PyAny) -> PyResult<()> {
+    ///     ob.setattr(intern!(ob.py(), "answer"), 42)
+    /// }
+    /// #
+    /// # Python::with_gil(|py| {
+    /// #    let ob = PyModule::new(py, "empty").unwrap();
+    /// #    set_answer(ob).unwrap();
+    /// # });
+    /// ```
+    fn setattr<N, V>(&self, attr_name: N, value: V) -> PyResult<()>
+    where
+        N: IntoPy<Py<PyString>>,
+        V: ToPyObject;
+
+    /// Deletes an attribute.
+    ///
+    /// This is equivalent to the Python statement `del self.attr_name`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `attr_name`.
+    fn delattr<N>(&self, attr_name: N) -> PyResult<()>
+    where
+        N: IntoPy<Py<PyString>>;
+
+    /// Returns an [`Ordering`] between `self` and `other`.
+    ///
+    /// This is equivalent to the following Python code:
+    /// ```python
+    /// if self == other:
+    ///     return Equal
+    /// elif a < b:
+    ///     return Less
+    /// elif a > b:
+    ///     return Greater
+    /// else:
+    ///     raise TypeError("PyAny::compare(): All comparisons returned false")
+    /// ```
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyFloat;
+    /// use std::cmp::Ordering;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let a = PyFloat::new(py, 0_f64);
+    ///     let b = PyFloat::new(py, 42_f64);
+    ///     assert_eq!(a.compare(b)?, Ordering::Less);
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    ///
+    /// It will return `PyErr` for values that cannot be compared:
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::{PyFloat, PyString};
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let a = PyFloat::new(py, 0_f64);
+    ///     let b = PyString::new(py, "zero");
+    ///     assert!(a.compare(b).is_err());
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    fn compare<O>(&self, other: O) -> PyResult<Ordering>
+    where
+        O: ToPyObject;
+
+    /// Tests whether two Python objects obey a given [`CompareOp`].
+    ///
+    /// [`lt`](Self::lt), [`le`](Self::le), [`eq`](Self::eq), [`ne`](Self::ne),
+    /// [`gt`](Self::gt) and [`ge`](Self::ge) are the specialized versions
+    /// of this function.
+    ///
+    /// Depending on the value of `compare_op`, this is equivalent to one of the
+    /// following Python expressions:
+    ///
+    /// | `compare_op` | Python expression |
+    /// | :---: | :----: |
+    /// | [`CompareOp::Eq`] | `self == other` |
+    /// | [`CompareOp::Ne`] | `self != other` |
+    /// | [`CompareOp::Lt`] | `self < other` |
+    /// | [`CompareOp::Le`] | `self <= other` |
+    /// | [`CompareOp::Gt`] | `self > other` |
+    /// | [`CompareOp::Ge`] | `self >= other` |
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::class::basic::CompareOp;
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyInt;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let a: &PyInt = 0_u8.into_py(py).into_ref(py).downcast()?;
+    ///     let b: &PyInt = 42_u8.into_py(py).into_ref(py).downcast()?;
+    ///     assert!(a.rich_compare(b, CompareOp::Le)?.is_true()?);
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    fn rich_compare<O>(&self, other: O, compare_op: CompareOp) -> PyResult<Py2<'py, PyAny>>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is less than another.
+    ///
+    /// This is equivalent to the Python expression `self < other`.
+    fn lt<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is less than or equal to another.
+    ///
+    /// This is equivalent to the Python expression `self <= other`.
+    fn le<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is equal to another.
+    ///
+    /// This is equivalent to the Python expression `self == other`.
+    fn eq<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is not equal to another.
+    ///
+    /// This is equivalent to the Python expression `self != other`.
+    fn ne<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is greater than another.
+    ///
+    /// This is equivalent to the Python expression `self > other`.
+    fn gt<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Tests whether this object is greater than or equal to another.
+    ///
+    /// This is equivalent to the Python expression `self >= other`.
+    fn ge<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject;
+
+    /// Determines whether this object appears callable.
+    ///
+    /// This is equivalent to Python's [`callable()`][1] function.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let builtins = PyModule::import(py, "builtins")?;
+    ///     let print = builtins.getattr("print")?;
+    ///     assert!(print.is_callable());
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    ///
+    /// This is equivalent to the Python statement `assert callable(print)`.
+    ///
+    /// Note that unless an API needs to distinguish between callable and
+    /// non-callable objects, there is no point in checking for callability.
+    /// Instead, it is better to just do the call and handle potential
+    /// exceptions.
+    ///
+    /// [1]: https://docs.python.org/3/library/functions.html#callable
+    fn is_callable(&self) -> bool;
+
+    /// Calls the object.
+    ///
+    /// This is equivalent to the Python expression `self(*args, **kwargs)`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyDict;
+    ///
+    /// const CODE: &str = r#"
+    /// def function(*args, **kwargs):
+    ///     assert args == ("hello",)
+    ///     assert kwargs == {"cruel": "world"}
+    ///     return "called with args and kwargs"
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let fun = module.getattr("function")?;
+    ///     let args = ("hello",);
+    ///     let kwargs = PyDict::new(py);
+    ///     kwargs.set_item("cruel", "world")?;
+    ///     let result = fun.call(args, Some(kwargs))?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with args and kwargs");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call(
+        &self,
+        args: impl IntoPy<Py<PyTuple>>,
+        kwargs: Option<&PyDict>,
+    ) -> PyResult<Py2<'py, PyAny>>;
+
+    /// Calls the object without arguments.
+    ///
+    /// This is equivalent to the Python expression `self()`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use pyo3::prelude::*;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| -> PyResult<()> {
+    ///     let module = PyModule::import(py, "builtins")?;
+    ///     let help = module.getattr("help")?;
+    ///     help.call0()?;
+    ///     Ok(())
+    /// })?;
+    /// # Ok(())}
+    /// ```
+    ///
+    /// This is equivalent to the Python expression `help()`.
+    fn call0(&self) -> PyResult<Py2<'py, PyAny>>;
+
+    /// Calls the object with only positional arguments.
+    ///
+    /// This is equivalent to the Python expression `self(*args)`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    ///
+    /// const CODE: &str = r#"
+    /// def function(*args, **kwargs):
+    ///     assert args == ("hello",)
+    ///     assert kwargs == {}
+    ///     return "called with args"
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let fun = module.getattr("function")?;
+    ///     let args = ("hello",);
+    ///     let result = fun.call1(args)?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with args");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<Py2<'py, PyAny>>;
+
+    /// Calls a method on the object.
+    ///
+    /// This is equivalent to the Python expression `self.name(*args, **kwargs)`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `name`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyDict;
+    ///
+    /// const CODE: &str = r#"
+    /// class A:
+    ///     def method(self, *args, **kwargs):
+    ///         assert args == ("hello",)
+    ///         assert kwargs == {"cruel": "world"}
+    ///         return "called with args and kwargs"
+    /// a = A()
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let instance = module.getattr("a")?;
+    ///     let args = ("hello",);
+    ///     let kwargs = PyDict::new(py);
+    ///     kwargs.set_item("cruel", "world")?;
+    ///     let result = instance.call_method("method", args, Some(kwargs))?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with args and kwargs");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call_method<N, A>(
+        &self,
+        name: N,
+        args: A,
+        kwargs: Option<&PyDict>,
+    ) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+        A: IntoPy<Py<PyTuple>>;
+
+    /// Calls a method on the object without arguments.
+    ///
+    /// This is equivalent to the Python expression `self.name()`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `name`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    ///
+    /// const CODE: &str = r#"
+    /// class A:
+    ///     def method(self, *args, **kwargs):
+    ///         assert args == ()
+    ///         assert kwargs == {}
+    ///         return "called with no arguments"
+    /// a = A()
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let instance = module.getattr("a")?;
+    ///     let result = instance.call_method0("method")?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with no arguments");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call_method0<N>(&self, name: N) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>;
+
+    /// Calls a method on the object with only positional arguments.
+    ///
+    /// This is equivalent to the Python expression `self.name(*args)`.
+    ///
+    /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
+    /// to intern `name`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    ///
+    /// const CODE: &str = r#"
+    /// class A:
+    ///     def method(self, *args, **kwargs):
+    ///         assert args == ("hello",)
+    ///         assert kwargs == {}
+    ///         return "called with args"
+    /// a = A()
+    /// "#;
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let module = PyModule::from_code(py, CODE, "", "")?;
+    ///     let instance = module.getattr("a")?;
+    ///     let args = ("hello",);
+    ///     let result = instance.call_method1("method", args)?;
+    ///     assert_eq!(result.extract::<&str>()?, "called with args");
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn call_method1<N, A>(&self, name: N, args: A) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+        A: IntoPy<Py<PyTuple>>;
+
+    /// Returns whether the object is considered to be true.
+    ///
+    /// This is equivalent to the Python expression `bool(self)`.
+    fn is_true(&self) -> PyResult<bool>;
+
+    /// Returns whether the object is considered to be None.
+    ///
+    /// This is equivalent to the Python expression `self is None`.
+    fn is_none(&self) -> bool;
+
+    /// Returns whether the object is Ellipsis, e.g. `...`.
+    ///
+    /// This is equivalent to the Python expression `self is ...`.
+    fn is_ellipsis(&self) -> bool;
+
+    /// Returns true if the sequence or mapping has a length of 0.
+    ///
+    /// This is equivalent to the Python expression `len(self) == 0`.
+    fn is_empty(&self) -> PyResult<bool>;
+
+    /// Gets an item from the collection.
+    ///
+    /// This is equivalent to the Python expression `self[key]`.
+    fn get_item<K>(&self, key: K) -> PyResult<Py2<'py, PyAny>>
+    where
+        K: ToPyObject;
+
+    /// Sets a collection item value.
+    ///
+    /// This is equivalent to the Python expression `self[key] = value`.
+    fn set_item<K, V>(&self, key: K, value: V) -> PyResult<()>
+    where
+        K: ToPyObject,
+        V: ToPyObject;
+
+    /// Deletes an item from the collection.
+    ///
+    /// This is equivalent to the Python expression `del self[key]`.
+    fn del_item<K>(&self, key: K) -> PyResult<()>
+    where
+        K: ToPyObject;
+
+    /// Takes an object and returns an iterator for it.
+    ///
+    /// This is typically a new iterator but if the argument is an iterator,
+    /// this returns itself.
+    fn iter(&self) -> PyResult<Py2<'py, PyIterator>>;
+
+    /// Returns the Python type object for this object's type.
+    fn get_type(&self) -> &'py PyType;
+
+    /// Returns the Python type pointer for this object.
+    fn get_type_ptr(&self) -> *mut ffi::PyTypeObject;
+
+    /// Downcast this `PyAny` to a concrete Python type or pyclass.
+    ///
+    /// Note that you can often avoid downcasting yourself by just specifying
+    /// the desired type in function or method signatures.
+    /// However, manual downcasting is sometimes necessary.
+    ///
+    /// For extracting a Rust-only type, see [`PyAny::extract`](struct.PyAny.html#method.extract).
+    ///
+    /// # Example: Downcasting to a specific Python object
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::{PyDict, PyList};
+    ///
+    /// Python::with_gil(|py| {
+    ///     let dict = PyDict::new(py);
+    ///     assert!(dict.is_instance_of::<PyAny>());
+    ///     let any: &PyAny = dict.as_ref();
+    ///
+    ///     assert!(any.downcast::<PyDict>().is_ok());
+    ///     assert!(any.downcast::<PyList>().is_err());
+    /// });
+    /// ```
+    ///
+    /// # Example: Getting a reference to a pyclass
+    ///
+    /// This is useful if you want to mutate a `PyObject` that
+    /// might actually be a pyclass.
+    ///
+    /// ```rust
+    /// # fn main() -> Result<(), pyo3::PyErr> {
+    /// use pyo3::prelude::*;
+    ///
+    /// #[pyclass]
+    /// struct Class {
+    ///     i: i32,
+    /// }
+    ///
+    /// Python::with_gil(|py| {
+    ///     let class: &PyAny = Py::new(py, Class { i: 0 }).unwrap().into_ref(py);
+    ///
+    ///     let class_cell: &PyCell<Class> = class.downcast()?;
+    ///
+    ///     class_cell.borrow_mut().i += 1;
+    ///
+    ///     // Alternatively you can get a `PyRefMut` directly
+    ///     let class_ref: PyRefMut<'_, Class> = class.extract()?;
+    ///     assert_eq!(class_ref.i, 1);
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    fn downcast<T>(&self) -> Result<&Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo;
+
+    /// Like `downcast` but takes ownership of `self`.
+    fn downcast_into<T>(self) -> Result<Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo;
+
+    /// Downcast this `PyAny` to a concrete Python type or pyclass (but not a subclass of it).
+    ///
+    /// It is almost always better to use [`PyAny::downcast`] because it accounts for Python
+    /// subtyping. Use this method only when you do not want to allow subtypes.
+    ///
+    /// The advantage of this method over [`PyAny::downcast`] is that it is faster. The implementation
+    /// of `downcast_exact` uses the equivalent of the Python expression `type(self) is T`, whereas
+    /// `downcast` uses `isinstance(self, T)`.
+    ///
+    /// For extracting a Rust-only type, see [`PyAny::extract`](struct.PyAny.html#method.extract).
+    ///
+    /// # Example: Downcasting to a specific Python object but not a subtype
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::{PyBool, PyLong};
+    ///
+    /// Python::with_gil(|py| {
+    ///     let b = PyBool::new(py, true);
+    ///     assert!(b.is_instance_of::<PyBool>());
+    ///     let any: &PyAny = b.as_ref();
+    ///
+    ///     // `bool` is a subtype of `int`, so `downcast` will accept a `bool` as an `int`
+    ///     // but `downcast_exact` will not.
+    ///     assert!(any.downcast::<PyLong>().is_ok());
+    ///     assert!(any.downcast_exact::<PyLong>().is_err());
+    ///
+    ///     assert!(any.downcast_exact::<PyBool>().is_ok());
+    /// });
+    /// ```
+    fn downcast_exact<T>(&self) -> Result<&Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo;
+
+    /// Like `downcast_exact` but takes ownership of `self`.
+    fn downcast_into_exact<T>(self) -> Result<Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo;
+
+    /// Converts this `PyAny` to a concrete Python type without checking validity.
+    ///
+    /// # Safety
+    ///
+    /// Callers must ensure that the type is valid or risk type confusion.
+    unsafe fn downcast_unchecked<T>(&self) -> &Py2<'py, T>;
+
+    /// Like `downcast_unchecked` but takes ownership of `self`.
+    unsafe fn downcast_into_unchecked<T>(self) -> Py2<'py, T>;
+
+    /// Extracts some type from the Python object.
+    ///
+    /// This is a wrapper function around [`FromPyObject::extract()`].
+    fn extract<'a, D>(&'a self) -> PyResult<D>
+    where
+        D: FromPyObject<'a>;
+
+    /// Returns the reference count for the Python object.
+    fn get_refcnt(&self) -> isize;
+
+    /// Computes the "repr" representation of self.
+    ///
+    /// This is equivalent to the Python expression `repr(self)`.
+    fn repr(&self) -> PyResult<Py2<'py, PyString>>;
+
+    /// Computes the "str" representation of self.
+    ///
+    /// This is equivalent to the Python expression `str(self)`.
+    fn str(&self) -> PyResult<Py2<'py, PyString>>;
+
+    /// Retrieves the hash code of self.
+    ///
+    /// This is equivalent to the Python expression `hash(self)`.
+    fn hash(&self) -> PyResult<isize>;
+
+    /// Returns the length of the sequence or mapping.
+    ///
+    /// This is equivalent to the Python expression `len(self)`.
+    fn len(&self) -> PyResult<usize>;
+
+    /// Returns the list of attributes of this object.
+    ///
+    /// This is equivalent to the Python expression `dir(self)`.
+    fn dir(&self) -> Py2<'py, PyList>;
+
+    /// Checks whether this object is an instance of type `ty`.
+    ///
+    /// This is equivalent to the Python expression `isinstance(self, ty)`.
+    fn is_instance(&self, ty: &Py2<'py, PyAny>) -> PyResult<bool>;
+
+    /// Checks whether this object is an instance of exactly type `ty` (not a subclass).
+    ///
+    /// This is equivalent to the Python expression `type(self) is ty`.
+    fn is_exact_instance(&self, ty: &Py2<'py, PyAny>) -> bool;
+
+    /// Checks whether this object is an instance of type `T`.
+    ///
+    /// This is equivalent to the Python expression `isinstance(self, T)`,
+    /// if the type `T` is known at compile time.
+    fn is_instance_of<T: PyTypeInfo>(&self) -> bool;
+
+    /// Checks whether this object is an instance of exactly type `T`.
+    ///
+    /// This is equivalent to the Python expression `type(self) is T`,
+    /// if the type `T` is known at compile time.
+    fn is_exact_instance_of<T: PyTypeInfo>(&self) -> bool;
+
+    /// Determines if self contains `value`.
+    ///
+    /// This is equivalent to the Python expression `value in self`.
+    fn contains<V>(&self, value: V) -> PyResult<bool>
+    where
+        V: ToPyObject;
+
+    /// Return a proxy object that delegates method calls to a parent or sibling class of type.
+    ///
+    /// This is equivalent to the Python expression `super()`
+    #[cfg(not(PyPy))]
+    fn py_super(&self) -> PyResult<Py2<'py, PySuper>>;
+}
+
+impl<'py> PyAnyMethods<'py> for Py2<'py, PyAny> {
+    #[inline]
+    fn is<T: AsPyPointer>(&self, other: &T) -> bool {
+        self.as_ptr() == other.as_ptr()
+    }
+
+    fn hasattr<N>(&self, attr_name: N) -> PyResult<bool>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        // PyObject_HasAttr suppresses all exceptions, which was the behaviour of `hasattr` in Python 2.
+        // Use an implementation which suppresses only AttributeError, which is consistent with `hasattr` in Python 3.
+        fn inner(py: Python<'_>, getattr_result: PyResult<Py2<'_, PyAny>>) -> PyResult<bool> {
+            match getattr_result {
+                Ok(_) => Ok(true),
+                Err(err) if err.is_instance_of::<PyAttributeError>(py) => Ok(false),
+                Err(e) => Err(e),
+            }
+        }
+
+        inner(self.py(), self.getattr(attr_name))
+    }
+
+    fn getattr<N>(&self, attr_name: N) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        fn inner<'py>(
+            any: &Py2<'py, PyAny>,
+            attr_name: Py2<'_, PyString>,
+        ) -> PyResult<Py2<'py, PyAny>> {
+            unsafe {
+                Py2::from_owned_ptr_or_err(
+                    any.py(),
+                    ffi::PyObject_GetAttr(any.as_ptr(), attr_name.as_ptr()),
+                )
+            }
+        }
+
+        let py = self.py();
+        inner(self, attr_name.into_py(self.py()).attach_into(py))
+    }
+
+    fn setattr<N, V>(&self, attr_name: N, value: V) -> PyResult<()>
+    where
+        N: IntoPy<Py<PyString>>,
+        V: ToPyObject,
+    {
+        fn inner(
+            any: &Py2<'_, PyAny>,
+            attr_name: Py2<'_, PyString>,
+            value: Py2<'_, PyAny>,
+        ) -> PyResult<()> {
+            err::error_on_minusone(any.py(), unsafe {
+                ffi::PyObject_SetAttr(any.as_ptr(), attr_name.as_ptr(), value.as_ptr())
+            })
+        }
+
+        let py = self.py();
+        inner(
+            self,
+            attr_name.into_py(py).attach_into(py),
+            value.to_object(py).attach_into(py),
+        )
+    }
+
+    fn delattr<N>(&self, attr_name: N) -> PyResult<()>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        fn inner(any: &Py2<'_, PyAny>, attr_name: Py2<'_, PyString>) -> PyResult<()> {
+            err::error_on_minusone(any.py(), unsafe {
+                ffi::PyObject_DelAttr(any.as_ptr(), attr_name.as_ptr())
+            })
+        }
+
+        let py = self.py();
+        inner(self, attr_name.into_py(py).attach_into(py))
+    }
+
+    fn compare<O>(&self, other: O) -> PyResult<Ordering>
+    where
+        O: ToPyObject,
+    {
+        fn inner(any: &Py2<'_, PyAny>, other: Py2<'_, PyAny>) -> PyResult<Ordering> {
+            let py = any.py();
+            let other = other.as_ptr();
+            // Almost the same as ffi::PyObject_RichCompareBool, but this one doesn't try self == other.
+            // See https://github.com/PyO3/pyo3/issues/985 for more.
+            let do_compare = |other, op| unsafe {
+                Py2::from_owned_ptr_or_err(py, ffi::PyObject_RichCompare(any.as_ptr(), other, op))
+                    .and_then(|obj| obj.is_true())
+            };
+            if do_compare(other, ffi::Py_EQ)? {
+                Ok(Ordering::Equal)
+            } else if do_compare(other, ffi::Py_LT)? {
+                Ok(Ordering::Less)
+            } else if do_compare(other, ffi::Py_GT)? {
+                Ok(Ordering::Greater)
+            } else {
+                Err(PyTypeError::new_err(
+                    "PyAny::compare(): All comparisons returned false",
+                ))
+            }
+        }
+
+        let py = self.py();
+        inner(self, other.to_object(py).attach_into(py))
+    }
+
+    fn rich_compare<O>(&self, other: O, compare_op: CompareOp) -> PyResult<Py2<'py, PyAny>>
+    where
+        O: ToPyObject,
+    {
+        fn inner<'py>(
+            any: &Py2<'py, PyAny>,
+            other: Py2<'_, PyAny>,
+            compare_op: CompareOp,
+        ) -> PyResult<Py2<'py, PyAny>> {
+            unsafe {
+                Py2::from_owned_ptr_or_err(
+                    any.py(),
+                    ffi::PyObject_RichCompare(any.as_ptr(), other.as_ptr(), compare_op as c_int),
+                )
+            }
+        }
+
+        let py = self.py();
+        inner(self, other.to_object(py).attach_into(py), compare_op)
+    }
+
+    fn lt<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Lt)
+            .and_then(|any| any.is_true())
+    }
+
+    fn le<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Le)
+            .and_then(|any| any.is_true())
+    }
+
+    fn eq<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Eq)
+            .and_then(|any| any.is_true())
+    }
+
+    fn ne<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Ne)
+            .and_then(|any| any.is_true())
+    }
+
+    fn gt<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Gt)
+            .and_then(|any| any.is_true())
+    }
+
+    fn ge<O>(&self, other: O) -> PyResult<bool>
+    where
+        O: ToPyObject,
+    {
+        self.rich_compare(other, CompareOp::Ge)
+            .and_then(|any| any.is_true())
+    }
+
+    fn is_callable(&self) -> bool {
+        unsafe { ffi::PyCallable_Check(self.as_ptr()) != 0 }
+    }
+
+    fn call(
+        &self,
+        args: impl IntoPy<Py<PyTuple>>,
+        kwargs: Option<&PyDict>,
+    ) -> PyResult<Py2<'py, PyAny>> {
+        fn inner<'py>(
+            any: &Py2<'py, PyAny>,
+            args: Py2<'_, PyTuple>,
+            kwargs: Option<&PyDict>,
+        ) -> PyResult<Py2<'py, PyAny>> {
+            unsafe {
+                Py2::from_owned_ptr_or_err(
+                    any.py(),
+                    ffi::PyObject_Call(
+                        any.as_ptr(),
+                        args.as_ptr(),
+                        kwargs.map_or(std::ptr::null_mut(), |dict| dict.as_ptr()),
+                    ),
+                )
+            }
+        }
+
+        let py = self.py();
+        inner(self, args.into_py(py).attach_into(py), kwargs)
+    }
+
+    fn call0(&self) -> PyResult<Py2<'py, PyAny>> {
+        cfg_if::cfg_if! {
+            if #[cfg(all(
+                not(PyPy),
+                any(Py_3_10, all(not(Py_LIMITED_API), Py_3_9)) // PyObject_CallNoArgs was added to python in 3.9 but to limited API in 3.10
+            ))] {
+                // Optimized path on python 3.9+
+                unsafe {
+                    Py2::from_owned_ptr_or_err(self.py(), ffi::PyObject_CallNoArgs(self.as_ptr()))
+                }
+            } else {
+                self.call((), None)
+            }
+        }
+    }
+
+    fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<Py2<'py, PyAny>> {
+        self.call(args, None)
+    }
+
+    fn call_method<N, A>(
+        &self,
+        name: N,
+        args: A,
+        kwargs: Option<&PyDict>,
+    ) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+        A: IntoPy<Py<PyTuple>>,
+    {
+        self.getattr(name)
+            .and_then(|method| method.call(args, kwargs))
+    }
+
+    fn call_method0<N>(&self, name: N) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        cfg_if::cfg_if! {
+            if #[cfg(all(Py_3_9, not(any(Py_LIMITED_API, PyPy))))] {
+                let py = self.py();
+
+                // Optimized path on python 3.9+
+                unsafe {
+                    let name = name.into_py(py).attach_into(py);
+                    Py2::from_owned_ptr_or_err(py, ffi::PyObject_CallMethodNoArgs(self.as_ptr(), name.as_ptr()))
+                }
+            } else {
+                self.call_method(name, (), None)
+            }
+        }
+    }
+
+    fn call_method1<N, A>(&self, name: N, args: A) -> PyResult<Py2<'py, PyAny>>
+    where
+        N: IntoPy<Py<PyString>>,
+        A: IntoPy<Py<PyTuple>>,
+    {
+        self.call_method(name, args, None)
+    }
+
+    fn is_true(&self) -> PyResult<bool> {
+        let v = unsafe { ffi::PyObject_IsTrue(self.as_ptr()) };
+        err::error_on_minusone(self.py(), v)?;
+        Ok(v != 0)
+    }
+
+    #[inline]
+    fn is_none(&self) -> bool {
+        unsafe { ffi::Py_None() == self.as_ptr() }
+    }
+
+    fn is_ellipsis(&self) -> bool {
+        unsafe { ffi::Py_Ellipsis() == self.as_ptr() }
+    }
+
+    fn is_empty(&self) -> PyResult<bool> {
+        self.len().map(|l| l == 0)
+    }
+
+    fn get_item<K>(&self, key: K) -> PyResult<Py2<'py, PyAny>>
+    where
+        K: ToPyObject,
+    {
+        fn inner<'py>(any: &Py2<'py, PyAny>, key: Py2<'_, PyAny>) -> PyResult<Py2<'py, PyAny>> {
+            unsafe {
+                Py2::from_owned_ptr_or_err(
+                    any.py(),
+                    ffi::PyObject_GetItem(any.as_ptr(), key.as_ptr()),
+                )
+            }
+        }
+
+        let py = self.py();
+        inner(self, key.to_object(py).attach_into(py))
+    }
+
+    fn set_item<K, V>(&self, key: K, value: V) -> PyResult<()>
+    where
+        K: ToPyObject,
+        V: ToPyObject,
+    {
+        fn inner(any: &Py2<'_, PyAny>, key: Py2<'_, PyAny>, value: Py2<'_, PyAny>) -> PyResult<()> {
+            err::error_on_minusone(any.py(), unsafe {
+                ffi::PyObject_SetItem(any.as_ptr(), key.as_ptr(), value.as_ptr())
+            })
+        }
+
+        let py = self.py();
+        inner(
+            self,
+            key.to_object(py).attach_into(py),
+            value.to_object(py).attach_into(py),
+        )
+    }
+
+    fn del_item<K>(&self, key: K) -> PyResult<()>
+    where
+        K: ToPyObject,
+    {
+        fn inner(any: &Py2<'_, PyAny>, key: Py2<'_, PyAny>) -> PyResult<()> {
+            err::error_on_minusone(any.py(), unsafe {
+                ffi::PyObject_DelItem(any.as_ptr(), key.as_ptr())
+            })
+        }
+
+        let py = self.py();
+        inner(self, key.to_object(py).attach_into(py))
+    }
+
+    fn iter(&self) -> PyResult<Py2<'py, PyIterator>> {
+        PyIterator::from_object2(self)
+    }
+
+    fn get_type(&self) -> &'py PyType {
+        unsafe { PyType::from_type_ptr(self.py(), ffi::Py_TYPE(self.as_ptr())) }
+    }
+
+    #[inline]
+    fn get_type_ptr(&self) -> *mut ffi::PyTypeObject {
+        unsafe { ffi::Py_TYPE(self.as_ptr()) }
+    }
+
+    #[inline]
+    fn downcast<T>(&self) -> Result<&Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo,
+    {
+        if self.is_instance_of::<T>() {
+            // Safety: is_instance_of is responsible for ensuring that the type is correct
+            Ok(unsafe { self.downcast_unchecked() })
+        } else {
+            Err(PyDowncastError::new(self.clone().into_gil_ref(), T::NAME))
+        }
+    }
+
+    #[inline]
+    fn downcast_into<T>(self) -> Result<Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo,
+    {
+        if self.is_instance_of::<T>() {
+            // Safety: is_instance_of is responsible for ensuring that the type is correct
+            Ok(unsafe { self.downcast_into_unchecked() })
+        } else {
+            Err(PyDowncastError::new(self.clone().into_gil_ref(), T::NAME))
+        }
+    }
+
+    #[inline]
+    fn downcast_exact<T>(&self) -> Result<&Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo,
+    {
+        if self.is_exact_instance_of::<T>() {
+            // Safety: is_exact_instance_of is responsible for ensuring that the type is correct
+            Ok(unsafe { self.downcast_unchecked() })
+        } else {
+            Err(PyDowncastError::new(self.clone().into_gil_ref(), T::NAME))
+        }
+    }
+
+    #[inline]
+    fn downcast_into_exact<T>(self) -> Result<Py2<'py, T>, PyDowncastError<'py>>
+    where
+        T: PyTypeInfo,
+    {
+        if self.is_exact_instance_of::<T>() {
+            // Safety: is_exact_instance_of is responsible for ensuring that the type is correct
+            Ok(unsafe { self.downcast_into_unchecked() })
+        } else {
+            Err(PyDowncastError::new(self.into_gil_ref(), T::NAME))
+        }
+    }
+
+    #[inline]
+    unsafe fn downcast_unchecked<T>(&self) -> &Py2<'py, T> {
+        &*(self as *const Py2<'py, PyAny>).cast()
+    }
+
+    #[inline]
+    unsafe fn downcast_into_unchecked<T>(self) -> Py2<'py, T> {
+        std::mem::transmute(self)
+    }
+
+    fn extract<'a, D>(&'a self) -> PyResult<D>
+    where
+        D: FromPyObject<'a>,
+    {
+        FromPyObject::extract(self.as_gil_ref())
+    }
+
+    fn get_refcnt(&self) -> isize {
+        unsafe { ffi::Py_REFCNT(self.as_ptr()) }
+    }
+
+    fn repr(&self) -> PyResult<Py2<'py, PyString>> {
+        unsafe {
+            Py2::from_owned_ptr_or_err(self.py(), ffi::PyObject_Repr(self.as_ptr()))
+                .map(|any| any.downcast_into_unchecked())
+        }
+    }
+
+    fn str(&self) -> PyResult<Py2<'py, PyString>> {
+        unsafe {
+            Py2::from_owned_ptr_or_err(self.py(), ffi::PyObject_Str(self.as_ptr()))
+                .map(|any| any.downcast_into_unchecked())
+        }
+    }
+
+    fn hash(&self) -> PyResult<isize> {
+        let v = unsafe { ffi::PyObject_Hash(self.as_ptr()) };
+        crate::err::error_on_minusone(self.py(), v)?;
+        Ok(v)
+    }
+
+    fn len(&self) -> PyResult<usize> {
+        let v = unsafe { ffi::PyObject_Size(self.as_ptr()) };
+        crate::err::error_on_minusone(self.py(), v)?;
+        Ok(v as usize)
+    }
+
+    fn dir(&self) -> Py2<'py, PyList> {
+        unsafe {
+            Py2::from_owned_ptr(self.py(), ffi::PyObject_Dir(self.as_ptr()))
+                .downcast_into_unchecked()
+        }
+    }
+
+    #[inline]
+    fn is_instance(&self, ty: &Py2<'py, PyAny>) -> PyResult<bool> {
+        let result = unsafe { ffi::PyObject_IsInstance(self.as_ptr(), ty.as_ptr()) };
+        err::error_on_minusone(self.py(), result)?;
+        Ok(result == 1)
+    }
+
+    #[inline]
+    fn is_exact_instance(&self, ty: &Py2<'py, PyAny>) -> bool {
+        self.get_type().is(ty)
+    }
+
+    #[inline]
+    fn is_instance_of<T: PyTypeInfo>(&self) -> bool {
+        T::is_type_of(self.as_gil_ref())
+    }
+
+    #[inline]
+    fn is_exact_instance_of<T: PyTypeInfo>(&self) -> bool {
+        T::is_exact_type_of(self.as_gil_ref())
+    }
+
+    fn contains<V>(&self, value: V) -> PyResult<bool>
+    where
+        V: ToPyObject,
+    {
+        fn inner(any: &Py2<'_, PyAny>, value: Py2<'_, PyAny>) -> PyResult<bool> {
+            match unsafe { ffi::PySequence_Contains(any.as_ptr(), value.as_ptr()) } {
+                0 => Ok(false),
+                1 => Ok(true),
+                _ => Err(PyErr::fetch(any.py())),
+            }
+        }
+
+        let py = self.py();
+        inner(self, value.to_object(py).attach_into(py))
+    }
+
+    #[cfg(not(PyPy))]
+    fn py_super(&self) -> PyResult<Py2<'py, PySuper>> {
+        PySuper::new2(Py2::borrowed_from_gil_ref(&self.get_type()), self)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
+        basic::CompareOp,
         types::{IntoPyDict, PyAny, PyBool, PyList, PyLong, PyModule},
-        Python, ToPyObject,
+        PyTypeInfo, Python, ToPyObject,
     };
 
     #[test]
@@ -1461,6 +2542,21 @@ class SimpleClass:
     }
 
     #[test]
+    fn test_rich_compare_type_error() {
+        Python::with_gil(|py| {
+            let py_int = 1.to_object(py).into_ref(py);
+            let py_str = "1".to_object(py).into_ref(py);
+
+            assert!(py_int.rich_compare(py_str, CompareOp::Lt).is_err());
+            assert!(!py_int
+                .rich_compare(py_str, CompareOp::Eq)
+                .unwrap()
+                .is_true()
+                .unwrap());
+        })
+    }
+
+    #[test]
     fn test_is_ellipsis() {
         Python::with_gil(|py| {
             let v = py
@@ -1472,6 +2568,30 @@ class SimpleClass:
 
             let not_ellipsis = 5.to_object(py).into_ref(py);
             assert!(!not_ellipsis.is_ellipsis());
+        });
+    }
+
+    #[test]
+    fn test_is_callable() {
+        Python::with_gil(|py| {
+            assert!(PyList::type_object(py).is_callable());
+
+            let not_callable = 5.to_object(py).into_ref(py);
+            assert!(!not_callable.is_callable());
+        });
+    }
+
+    #[test]
+    fn test_is_empty() {
+        Python::with_gil(|py| {
+            let empty_list: &PyAny = PyList::empty(py);
+            assert!(empty_list.is_empty().unwrap());
+
+            let list: &PyAny = PyList::new(py, vec![1, 2, 3]);
+            assert!(!list.is_empty().unwrap());
+
+            let not_container = 5.to_object(py).into_ref(py);
+            assert!(not_container.is_empty().is_err());
         });
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -269,7 +269,7 @@ macro_rules! pyobject_native_type {
     };
 }
 
-mod any;
+pub(crate) mod any;
 mod boolobject;
 mod bytearray;
 mod bytes;

--- a/tests/test_super.rs
+++ b/tests/test_super.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "macros", not(PyPy)))]
 
-use pyo3::prelude::*;
+use pyo3::{prelude::*, types::PySuper};
 
 #[pyclass(subclass)]
 struct BaseClass {
@@ -33,6 +33,11 @@ impl SubClass {
         let super_ = self_.py_super()?;
         super_.call_method("method", (), None)
     }
+
+    fn method_super_new(self_: &PyCell<Self>) -> PyResult<&PyAny> {
+        let super_ = PySuper::new(self_.get_type(), self_)?;
+        super_.call_method("method", (), None)
+    }
 }
 
 #[test]
@@ -45,6 +50,7 @@ fn test_call_super_method() {
             r#"
         obj = cls()
         assert obj.method() == 10
+        assert obj.method_super_new() == 10
     "#
         )
     });


### PR DESCRIPTION
This PR adds the `Py2` struct and `PyAnyMethods` trait from #3361 as private APIs which we can use internally.

The idea is that:
- we can still benefit from the performance advantages of not touching the pool where possible internally
- this lets us start learning about this API so that we can completely satisfy ourselves it's the right API for users
- it lets us start making incremental progress with migrating to the new API in reviewable steps