### PR TITLE
relax multiple-import check to only prevent subinterpreters

### DIFF
--- a/guide/src/building_and_distribution.md
+++ b/guide/src/building_and_distribution.md
@@ -276,7 +276,7 @@ If you encounter these or other complications when linking the interpreter stati
 
 ### Import your module when embedding the Python interpreter
 
-When you run your Rust binary with an embedded interpreter, any `#[pymodule]` created modules won't be accessible to import unless added to a table called `PyImport_Inittab` before the embedded interpreter is initialized. This will cause Python statements in your embedded interpreter such as `import your_new_module` to fail. You can call the macro [`append_to_inittab`]({{#PYO3_DOCS_URL}}/pyo3/macro.append_to_inittab.html) with your module before initializing the Python interpreter to add the module function into that table. (The Python interpreter will be initialized by calling `prepare_freethreaded_python`, `with_embedded_interpreter`, or `Python::with_gil` with the [`auto-initialize`](features.md#auto-initialize) feature enabled.)
+When you run your Rust binary with an embedded interpreter, any `#[pymodule]` created modules won't be accessible to import unless added to a table called `PyImport_Inittab` before the embedded interpreter is initialized. This will cause Python statements in your embedded interpreter such as `import your_new_module` to fail. You can call the macro [`append_to_inittab`]({{#PYO3_DOCS_URL}}/pyo3/macro.append_to_inittab.html) with your module before initializing the Python interpreter to add the module function into that table. (The Python interpreter will be initialized by calling `prepare_freethreaded_python`, `with_embedded_python_interpreter`, or `Python::with_gil` with the [`auto-initialize`](features.md#auto-initialize) feature enabled.)
 
 ## Cross Compiling
 

--- a/newsfragments/3446.changed.md
+++ b/newsfragments/3446.changed.md
@@ -1,1 +1,1 @@
-Relax multiple import check to only prevent use of subinterpreters.
+`#[pymodule]` will now return the same module object on repeated import by the same Python interpreter, on Python 3.9 and up.

--- a/newsfragments/3446.changed.md
+++ b/newsfragments/3446.changed.md
@@ -1,0 +1,1 @@
+Relax multiple import check to only prevent use of subinterpreters.

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -146,6 +146,11 @@ pub fn print_feature_cfgs() {
     if rustc_minor_version >= 59 {
         println!("cargo:rustc-cfg=thread_local_const_init");
     }
+
+    // Enable use of OnceLock on Rust 1.70 and greater
+    if rustc_minor_version >= 70 {
+        println!("cargo:rustc-cfg=once_lock");
+    }
 }
 
 /// Private exports used in PyO3's build.rs

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -146,11 +146,6 @@ pub fn print_feature_cfgs() {
     if rustc_minor_version >= 59 {
         println!("cargo:rustc-cfg=thread_local_const_init");
     }
-
-    // Enable use of OnceLock on Rust 1.70 and greater
-    if rustc_minor_version >= 70 {
-        println!("cargo:rustc-cfg=once_lock");
-    }
 }
 
 /// Private exports used in PyO3's build.rs

--- a/pytests/tests/test_misc.py
+++ b/pytests/tests/test_misc.py
@@ -33,10 +33,15 @@ def test_multiple_imports_same_interpreter_ok():
 def test_import_in_subinterpreter_forbidden():
     import _xxsubinterpreters
 
+    if sys.version_info < (3, 12):
+        expected_error = "PyO3 modules do not yet support subinterpreters, see https://github.com/PyO3/pyo3/issues/576"
+    else:
+        expected_error = "module pyo3_pytests.pyo3_pytests does not support loading in subinterpreters"
+
     sub_interpreter = _xxsubinterpreters.create()
     with pytest.raises(
         _xxsubinterpreters.RunFailedError,
-        match="PyO3 modules do not yet support subinterpreters, see https://github.com/PyO3/pyo3/issues/576",
+        match=expected_error,
     ):
         _xxsubinterpreters.run_string(
             sub_interpreter, "import pyo3_pytests.pyo3_pytests"

--- a/pytests/tests/test_misc.py
+++ b/pytests/tests/test_misc.py
@@ -1,5 +1,6 @@
 import importlib
 import platform
+import sys
 
 import pyo3_pytests.misc
 import pytest
@@ -10,6 +11,10 @@ def test_issue_219():
     pyo3_pytests.misc.issue_219()
 
 
+@pytest.mark.xfail(
+    platform.python_implementation() == "CPython" and sys.version_info < (3, 9),
+    reason="Cannot identify subinterpreters on Python older than 3.9",
+)
 def test_multiple_imports_same_interpreter_ok():
     spec = importlib.util.find_spec("pyo3_pytests.pyo3_pytests")
 
@@ -17,6 +22,10 @@ def test_multiple_imports_same_interpreter_ok():
     assert dir(module) == dir(pyo3_pytests.pyo3_pytests)
 
 
+@pytest.mark.xfail(
+    platform.python_implementation() == "CPython" and sys.version_info < (3, 9),
+    reason="Cannot identify subinterpreters on Python older than 3.9",
+)
 @pytest.mark.skipif(
     platform.python_implementation() == "PyPy",
     reason="PyPy does not support subinterpreters",

--- a/pytests/tests/test_misc.py
+++ b/pytests/tests/test_misc.py
@@ -10,15 +10,27 @@ def test_issue_219():
     pyo3_pytests.misc.issue_219()
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy",
-    reason="PyPy does not reinitialize the module (appears to be some internal caching)",
-)
-def test_second_module_import_fails():
+def test_multiple_imports_same_interpreter_ok():
     spec = importlib.util.find_spec("pyo3_pytests.pyo3_pytests")
 
+    module = importlib.util.module_from_spec(spec)
+    assert dir(module) == dir(pyo3_pytests.pyo3_pytests)
+
+
+@pytest.mark.skipif(
+    platform.python_implementation() == "PyPy",
+    reason="PyPy does not support subinterpreters",
+)
+def test_import_in_subinterpreter_forbidden():
+    import _xxsubinterpreters
+
+    sub_interpreter = _xxsubinterpreters.create()
     with pytest.raises(
-        ImportError,
-        match="PyO3 modules may only be initialized once per interpreter process",
+        _xxsubinterpreters.RunFailedError,
+        match="PyO3 modules do not yet support subinterpreters, see https://github.com/PyO3/pyo3/issues/576",
     ):
-        importlib.util.module_from_spec(spec)
+        _xxsubinterpreters.run_string(
+            sub_interpreter, "import pyo3_pytests.pyo3_pytests"
+        )
+
+    _xxsubinterpreters.destroy(sub_interpreter)


### PR DESCRIPTION
Some issues observed in the wild from the current implementation of the multiple-import check:
- https://github.com/sphinx-doc/sphinx/issues/11662
- https://github.com/pydantic/pydantic/issues/6584

The motivation for the check is from https://github.com/PyO3/pyo3/discussions/2346#discussioncomment-2913833 - it's to prevent use of PyO3 modules in sub-interpreters, which we are definitely not ready for yet.

Given the issues above don't actually use sub-interpreters, it seemed worth trying to fix them. This PR does so by storing the current interpreter ID when initializing a `#[pymodule]`, and checking that does not change on subsequent imports.

I've also updated the error message to point at #576 so that discussion on the community can at least be centralized here.