### PR TITLE
truncate leap seconds on `chrono` to `datetime` conversions

### DIFF
--- a/newsfragments/3458.changed.md
+++ b/newsfragments/3458.changed.md
@@ -1,0 +1,1 @@
+Truncate leap-seconds and warn when converting `chrono` types to Python `datetime` types (`datetime` cannot represent leap-seconds).

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,2 @@
+use crate as pyo3;
+include!("../tests/common.rs");


### PR DESCRIPTION
Fixes #3424 

As discussed in that issue, I decided to proceed to truncate leap-seconds and emit a warning when doing so.

Most the diff is adjustment to test code to adjust for the logic, check the warning is raised and also deal with increased strictness of when leap-seconds are allowed in `chrono` 0.4.31. 