### PR TITLE
fix codecov ignore paths for test folders

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,6 @@ coverage:
         threshold: 0.25%
 
 ignore:
-  - tests/*.rs
-  - pytests/*.rs
+  - tests/
+  - pytests/
   - src/test_hygiene/*.rs


### PR DESCRIPTION
Just noticed that the codecov website includes coverage data for the `pytests` subdirectory. I think the pattern is wrong, should probably have been `pytests/**/*.rs`. I think it's simpler to just do a folder-level `pytests/`.