### PR TITLE
docs: skip changelog check for docs-only PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@ By submitting these contributions you agree for them to be dual-licensed under P
 
 Please consider adding the following to your pull request:
  - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
+   - or start the PR title with `docs:` if this is a docs-only change to skip the check
  - docs to all new functions and / or detail in the guide
  - tests for all new or changed functions
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,7 +2,7 @@ name: changelog
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled, unlabeled]
+    types: [opened, synchronize, labeled, unlabeled, edited]
 
 jobs:
   check:

--- a/Contributing.md
+++ b/Contributing.md
@@ -111,6 +111,8 @@ To include your changes in the release notes, you should create one (or more) ne
 - `removed` - for features which have been removed
 - `fixed` - for "changed" features which were classed as a bugfix
 
+Docs-only PRs do not need news items; start your PR title with `docs:` to skip the check.
+
 ### Style guide
 
 #### Generic code

--- a/noxfile.py
+++ b/noxfile.py
@@ -416,6 +416,12 @@ def address_sanitizer(session: nox.Session):
     )
 
 
+_IGNORE_CHANGELOG_PR_CATEGORIES = (
+    "release",
+    "docs",
+)
+
+
 @nox.session(name="check-changelog")
 def check_changelog(session: nox.Session):
     event_path = os.environ.get("GITHUB_EVENT_PATH")
@@ -425,8 +431,9 @@ def check_changelog(session: nox.Session):
     with open(event_path) as event_file:
         event = json.load(event_file)
 
-    if event["pull_request"]["title"].startswith("release:"):
-        session.skip("PR title starts with release")
+    for category in _IGNORE_CHANGELOG_PR_CATEGORIES:
+        if event["pull_request"]["title"].startswith(f"{category}:"):
+            session.skip(f"PR title starts with {category}")
 
     for label in event["pull_request"]["labels"]:
         if label["name"] == "CI-skip-changelog":
@@ -448,7 +455,9 @@ def check_changelog(session: nox.Session):
 
     if not fragments:
         session.error(
-            "Changelog entry not found, please add one (or more) to `newsfragments` directory. For more information see https://github.com/PyO3/pyo3/blob/main/Contributing.md#documenting-changes"
+            "Changelog entry not found, please add one (or more) to the `newsfragments` directory.\n"
+            "Alternatively, start the PR title with `docs:` if this PR is a docs-only PR.\n"
+            "See https://github.com/PyO3/pyo3/blob/main/Contributing.md#documenting-changes for more information."
         )
 
     print("Found newsfragments:")

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -146,6 +146,11 @@ pub fn print_feature_cfgs() {
     if rustc_minor_version >= 59 {
         println!("cargo:rustc-cfg=thread_local_const_init");
     }
+
+    // invalid_from_utf8 lint was added in Rust 1.74
+    if rustc_minor_version >= 74 {
+        println!("cargo:rustc-cfg=invalid_from_utf8_lint");
+    }
 }
 
 /// Private exports used in PyO3's build.rs

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -635,6 +635,7 @@ impl PyUnicodeDecodeError {
     /// # Examples
     ///
     /// ```
+    /// #![cfg_attr(invalid_from_utf8_lint, allow(invalid_from_utf8))]
     /// use pyo3::prelude::*;
     /// use pyo3::exceptions::PyUnicodeDecodeError;
     ///
@@ -1013,6 +1014,7 @@ mod tests {
     #[test]
     fn unicode_decode_error() {
         let invalid_utf8 = b"fo\xd8o";
+        #[cfg_attr(invalid_from_utf8_lint, allow(invalid_from_utf8))]
         let err = std::str::from_utf8(invalid_utf8).expect_err("should be invalid utf8");
         Python::with_gil(|py| {
             let decode_err = PyUnicodeDecodeError::new_utf8(py, invalid_utf8, err).unwrap();
@@ -1069,6 +1071,7 @@ mod tests {
     test_exception!(PyUnicodeError);
     test_exception!(PyUnicodeDecodeError, |py| {
         let invalid_utf8 = b"fo\xd8o";
+        #[cfg_attr(invalid_from_utf8_lint, allow(invalid_from_utf8))]
         let err = std::str::from_utf8(invalid_utf8).expect_err("should be invalid utf8");
         PyErr::from_value(PyUnicodeDecodeError::new_utf8(py, invalid_utf8, err).unwrap())
     });


### PR DESCRIPTION
Recently we've had a few contributors submit docs-only PRs and go through the trouble of submitting a newsfragment.

This PR adds the ability for PRs with `docs:` as the start of the title to skip the changelog check. IMO this is a nice ergonomics improvement for non-maintainers because they cannot apply the `CI-skip-changelog` label.