### PR TITLE
Add js_string field when in Pyodide >0.25

### DIFF
--- a/pyo3-ffi/src/cpython/unicodeobject.rs
+++ b/pyo3-ffi/src/cpython/unicodeobject.rs
@@ -244,6 +244,8 @@ pub struct PyASCIIObject {
     pub length: Py_ssize_t,
     #[cfg(not(PyPy))]
     pub hash: Py_hash_t,
+    #[cfg(pyodide_0_25)]
+    pub js_string: usize,
     /// A bit field with various properties.
     ///
     /// Rust doesn't expose bitfields. So we have accessor functions for


### PR DESCRIPTION
I'm hoping to add an extra `js_string` field to `Py_Unicode` in Pyodide to allow us to cache Python to js string conversions. This updates pyo3-ffi to know about this field. See https://github.com/pyodide/pyodide/pull/4130
