### PR TITLE
Don't let auto trait syntax bleed through on stable Rust

### DIFF
--- a/src/marker.rs
+++ b/src/marker.rs
@@ -185,80 +185,90 @@ pub unsafe trait Ungil {}
 #[cfg(not(feature = "nightly"))]
 unsafe impl<T: Send> Ungil for T {}
 
-/// Types that are safe to access while the GIL is not held.
-///
-/// # Safety
-///
-/// The type must not carry borrowed Python references or, if it does, not allow access to them if
-/// the GIL is not held.
-///
-/// See the [module-level documentation](self) for more information.
-///
-/// # Examples
-///
-/// Types which are `Ungil` cannot be used in contexts where the GIL was released, e.g.
-///
-/// ```compile_fail
-/// # use pyo3::prelude::*;
-/// # use pyo3::types::PyString;
-/// Python::with_gil(|py| {
-///     let string = PyString::new(py, "foo");
-///
-///     py.allow_threads(|| {
-///         println!("{:?}", string);
-///     });
-/// });
-/// ```
-///
-/// This applies to the GIL token `Python` itself as well, e.g.
-///
-/// ```compile_fail
-/// # use pyo3::prelude::*;
-/// Python::with_gil(|py| {
-///     py.allow_threads(|| {
-///         drop(py);
-///     });
-/// });
-/// ```
-///
-/// On nightly Rust, this is not based on the [`Send`] auto trait and hence we are able
-/// to prevent incorrectly circumventing it using e.g. the [`send_wrapper`](https://docs.rs/send_wrapper/) crate:
-///
-/// ```compile_fail
-/// # use pyo3::prelude::*;
-/// # use pyo3::types::PyString;
-/// use send_wrapper::SendWrapper;
-///
-/// Python::with_gil(|py| {
-///     let string = PyString::new(py, "foo");
-///
-///     let wrapped = SendWrapper::new(string);
-///
-///     py.allow_threads(|| {
-///         let sneaky: &PyString = *wrapped;
-///
-///         println!("{:?}", sneaky);
-///     });
-/// });
-/// ```
-///
-/// This also enables using non-[`Send`] types in `allow_threads`,
-/// at least if they are not also bound to the GIL:
-///
-/// ```rust
-/// # use pyo3::prelude::*;
-/// use std::rc::Rc;
-///
-/// Python::with_gil(|py| {
-///     let rc = Rc::new(42);
-///
-///     py.allow_threads(|| {
-///         println!("{:?}", rc);
-///     });
-/// });
-/// ```
 #[cfg(feature = "nightly")]
-pub unsafe auto trait Ungil {}
+macro_rules! define {
+  ($($tt:tt)*) => { $($tt)* }
+}
+#[cfg(not(feature = "nightly"))]
+macro_rules! define {
+    ($($tt:tt)*) => {};
+}
+
+define! {
+    /// Types that are safe to access while the GIL is not held.
+    ///
+    /// # Safety
+    ///
+    /// The type must not carry borrowed Python references or, if it does, not allow access to them if
+    /// the GIL is not held.
+    ///
+    /// See the [module-level documentation](self) for more information.
+    ///
+    /// # Examples
+    ///
+    /// Types which are `Ungil` cannot be used in contexts where the GIL was released, e.g.
+    ///
+    /// ```compile_fail
+    /// # use pyo3::prelude::*;
+    /// # use pyo3::types::PyString;
+    /// Python::with_gil(|py| {
+    ///     let string = PyString::new(py, "foo");
+    ///
+    ///     py.allow_threads(|| {
+    ///         println!("{:?}", string);
+    ///     });
+    /// });
+    /// ```
+    ///
+    /// This applies to the GIL token `Python` itself as well, e.g.
+    ///
+    /// ```compile_fail
+    /// # use pyo3::prelude::*;
+    /// Python::with_gil(|py| {
+    ///     py.allow_threads(|| {
+    ///         drop(py);
+    ///     });
+    /// });
+    /// ```
+    ///
+    /// On nightly Rust, this is not based on the [`Send`] auto trait and hence we are able
+    /// to prevent incorrectly circumventing it using e.g. the [`send_wrapper`](https://docs.rs/send_wrapper/) crate:
+    ///
+    /// ```compile_fail
+    /// # use pyo3::prelude::*;
+    /// # use pyo3::types::PyString;
+    /// use send_wrapper::SendWrapper;
+    ///
+    /// Python::with_gil(|py| {
+    ///     let string = PyString::new(py, "foo");
+    ///
+    ///     let wrapped = SendWrapper::new(string);
+    ///
+    ///     py.allow_threads(|| {
+    ///         let sneaky: &PyString = *wrapped;
+    ///
+    ///         println!("{:?}", sneaky);
+    ///     });
+    /// });
+    /// ```
+    ///
+    /// This also enables using non-[`Send`] types in `allow_threads`,
+    /// at least if they are not also bound to the GIL:
+    ///
+    /// ```rust
+    /// # use pyo3::prelude::*;
+    /// use std::rc::Rc;
+    ///
+    /// Python::with_gil(|py| {
+    ///     let rc = Rc::new(42);
+    ///
+    ///     py.allow_threads(|| {
+    ///         println!("{:?}", rc);
+    ///     });
+    /// });
+    /// ```
+    pub unsafe auto trait Ungil {}
+}
 
 #[cfg(feature = "nightly")]
 mod negative_impls {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/116121 and https://github.com/rust-lang/rust/pull/116126 for context.

I've skipped the changelog because this this is an invisible change, for now.