### PR TITLE
disable `marshal.rs` on `Py_LIMITED_API`

### DIFF
--- a/newsfragments/3490.fixed.md
+++ b/newsfragments/3490.fixed.md
@@ -1,0 +1,1 @@
+Disable `PyMarshal_WriteObjectToString` from `PyMarshal_ReadObjectFromString` with the `abi3` feature.

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -281,6 +281,7 @@ pub use self::intrcheck::*;
 pub use self::iterobject::*;
 pub use self::listobject::*;
 pub use self::longobject::*;
+#[cfg(not(Py_LIMITED_API))]
 pub use self::marshal::*;
 pub use self::memoryobject::*;
 pub use self::methodobject::*;
@@ -351,7 +352,8 @@ mod iterobject;
 mod listobject;
 // skipped longintrepr.h
 mod longobject;
-pub(crate) mod marshal;
+#[cfg(not(Py_LIMITED_API))]
+pub mod marshal;
 mod memoryobject;
 mod methodobject;
 mod modsupport;


### PR DESCRIPTION
Since Python 3.11 the C headers have disabled the contents of `marshal.h` with the limited API. https://docs.python.org/3/whatsnew/3.11.html#whatsnew311-c-api-removed

This is classed as a fix because they were never documented as part of the stable API: https://bugs.python.org/issue45474