### PR TITLE
emit compile errors on macros inside `#[pymethods]`

### DIFF
--- a/newsfragments/3491.fixed.md
+++ b/newsfragments/3491.fixed.md
@@ -1,0 +1,1 @@
+Emit compile errors instead of ignoring macro invocations inside `#[pymethods]` blocks.

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -149,7 +149,12 @@ pub fn impl_methods(
                     }
                 }
             }
-            _ => (),
+            syn::ImplItem::Macro(m) => bail_spanned!(
+                m.span() =>
+                "macros cannot be used as items in `#[pymethods]` impl blocks\n\
+                 = note: this was previously accepted and ignored"
+            ),
+            _ => {}
         }
     }
 

--- a/tests/ui/invalid_pymethods.rs
+++ b/tests/ui/invalid_pymethods.rs
@@ -170,4 +170,13 @@ impl DuplicateMethod {
     fn func_b(&self) {}
 }
 
+macro_rules! macro_invocation {
+    () => {};
+}
+
+#[pymethods]
+impl MyClass {
+    macro_invocation!();
+}
+
 fn main() {}

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -133,6 +133,13 @@ error: Python objects are shared, so 'self' cannot be moved out of the Python in
 144 |     fn method_self_by_value(self) {}
     |                             ^^^^
 
+error: macros cannot be used as items in `#[pymethods]` impl blocks
+       = note: this was previously accepted and ignored
+   --> tests/ui/invalid_pymethods.rs:179:5
+    |
+179 |     macro_invocation!();
+    |     ^^^^^^^^^^^^^^^^
+
 error[E0119]: conflicting implementations of trait `pyo3::impl_::pyclass::PyClassNewTextSignature<TwoNew>` for type `pyo3::impl_::pyclass::PyClassImplCollector<TwoNew>`
    --> tests/ui/invalid_pymethods.rs:149:1
     |


### PR DESCRIPTION
Fixes #2862 

This is a small UX improvement to raise an error instead of silently ignoring macro invocations inside `#[pymethods]`.