### PR TITLE
release: 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,72 @@ To see unreleased changes, please see the [CHANGELOG on the main branch guide](h
 
 <!-- towncrier release notes start -->
 
+## [0.20.0] - 2023-10-11
+
+### Packaging
+
+- Dual-license PyO3 under either the Apache 2.0 OR the MIT license. This makes the project GPLv2 compatible. [#3108](https://github.com/PyO3/pyo3/pull/3108)
+- Update MSRV to Rust 1.56. [#3208](https://github.com/PyO3/pyo3/pull/3208)
+- Bump `indoc` dependency to 2.0 and `unindent` dependency to 0.2. [#3237](https://github.com/PyO3/pyo3/pull/3237)
+- Bump `syn` dependency to 2.0. [#3239](https://github.com/PyO3/pyo3/pull/3239)
+- Drop support for debug builds of Python 3.7. [#3387](https://github.com/PyO3/pyo3/pull/3387)
+- Bump `chrono` optional dependency to require 0.4.25 or newer. [#3427](https://github.com/PyO3/pyo3/pull/3427)
+- Support Python 3.12. [#3488](https://github.com/PyO3/pyo3/pull/3488)
+
+### Added
+
+- Support `__lt__`, `__le__`, `__eq__`, `__ne__`, `__gt__` and `__ge__` in `#[pymethods]`. [#3203](https://github.com/PyO3/pyo3/pull/3203)
+- Add FFI definition `Py_GETENV`. [#3336](https://github.com/PyO3/pyo3/pull/3336)
+- Add `as_ptr` and `into_ptr` inherent methods for `Py`, `PyAny`, `PyRef`, and `PyRefMut`. [#3359](https://github.com/PyO3/pyo3/pull/3359)
+- Implement `DoubleEndedIterator` for `PyTupleIterator` and `PyListIterator`. [#3366](https://github.com/PyO3/pyo3/pull/3366)
+- Add `#[pyclass(rename_all = "...")]` option: this allows renaming all getters and setters of a struct, or all variants of an enum. Available renaming rules are: `"camelCase"`, `"kebab-case"`, `"lowercase"`, `"PascalCase"`, `"SCREAMING-KEBAB-CASE"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"UPPERCASE"`. [#3384](https://github.com/PyO3/pyo3/pull/3384)
+- Add FFI definitions `PyObject_GC_IsTracked` and `PyObject_GC_IsFinalized` on Python 3.9 and up (PyPy 3.10 and up). [#3403](https://github.com/PyO3/pyo3/pull/3403)
+- Add types for `None`, `Ellipsis`, and `NotImplemented`. [#3408](https://github.com/PyO3/pyo3/pull/3408)
+- Add FFI definitions for the `Py_mod_multiple_interpreters` constant and its possible values. [#3494](https://github.com/PyO3/pyo3/pull/3494)
+- Add FFI definitions for `PyInterpreterConfig` struct, its constants and `Py_NewInterpreterFromConfig`. [#3502](https://github.com/PyO3/pyo3/pull/3502)
+
+### Changed
+
+- Change `PySet::discard` to return `PyResult<bool>` (previously returned nothing). [#3281](https://github.com/PyO3/pyo3/pull/3281)
+- Optimize implmentation of `IntoPy` for Rust tuples to Python tuples. [#3321](https://github.com/PyO3/pyo3/pull/3321)
+- Change `PyDict::get_item` to no longer suppress arbitrary exceptions (the return type is now `PyResult<Option<&PyAny>>` instead of `Option<&PyAny>`), and deprecate `PyDict::get_item_with_error`. [#3330](https://github.com/PyO3/pyo3/pull/3330)
+- Deprecate FFI definitions which are deprecated in Python 3.12. [#3336](https://github.com/PyO3/pyo3/pull/3336)
+- `AsPyPointer` is now an `unsafe trait`. [#3358](https://github.com/PyO3/pyo3/pull/3358)
+- Accept all `os.PathLike` values in implementation of `FromPyObject` for `PathBuf`. [#3374](https://github.com/PyO3/pyo3/pull/3374)
+- Add `__builtins__` to globals in `py.run()` and `py.eval()` if they're missing. [#3378](https://github.com/PyO3/pyo3/pull/3378)
+- Optimize implementation of `FromPyObject` for `BigInt` and `BigUint`. [#3379](https://github.com/PyO3/pyo3/pull/3379)
+- `PyIterator::from_object` and `PyByteArray::from` now take a single argument of type `&PyAny` (previously took two arguments `Python` and `AsPyPointer`). [#3389](https://github.com/PyO3/pyo3/pull/3389)
+- Replace `AsPyPointer` with `AsRef<PyAny>` as a bound in the blanket implementation of `From<&T> for PyObject`. [#3391](https://github.com/PyO3/pyo3/pull/3391)
+- Replace blanket `impl IntoPy<PyObject> for &T where T: AsPyPointer` with implementations of `impl IntoPy<PyObject>` for `&PyAny`, `&T where T: AsRef<PyAny>`, and `&Py<T>`. [#3393](https://github.com/PyO3/pyo3/pull/3393)
+- Preserve `std::io::Error` kind in implementation of `From<std::io::IntoInnerError>` for `PyErr` [#3396](https://github.com/PyO3/pyo3/pull/3396)
+- Try to select a relevant `ErrorKind` in implementation of `From<PyErr>` for `OSError` subclass. [#3397](https://github.com/PyO3/pyo3/pull/3397)
+- Retrieve the original `PyErr` in implementation of `From<std::io::Error>` for `PyErr` if the `std::io::Error` has been built using a Python exception (previously would create a new exception wrapping the `std::io::Error`). [#3402](https://github.com/PyO3/pyo3/pull/3402)
+- `#[pymodule]` will now return the same module object on repeated import by the same Python interpreter, on Python 3.9 and up. [#3446](https://github.com/PyO3/pyo3/pull/3446)
+- Truncate leap-seconds and warn when converting `chrono` types to Python `datetime` types (`datetime` cannot represent leap-seconds). [#3458](https://github.com/PyO3/pyo3/pull/3458)
+- `Err` returned from `#[pyfunction]` will now have a non-None `__context__` if called from inside a `catch` block. [#3455](https://github.com/PyO3/pyo3/pull/3455)
+- Deprecate undocumented `#[__new__]` form of `#[new]` attribute. [#3505](https://github.com/PyO3/pyo3/pull/3505)
+
+### Removed
+
+- Remove all functionality deprecated in PyO3 0.18, including `#[args]` attribute for `#[pymethods]`. [#3232](https://github.com/PyO3/pyo3/pull/3232)
+- Remove `IntoPyPointer` trait in favour of `into_ptr` inherent methods. [#3385](https://github.com/PyO3/pyo3/pull/3385)
+
+### Fixed
+
+- Handle exceptions properly in `PySet::discard`. [#3281](https://github.com/PyO3/pyo3/pull/3281)
+- The `PyTupleIterator` type returned by `PyTuple::iter` is now public and hence can be named by downstream crates. [#3366](https://github.com/PyO3/pyo3/pull/3366)
+- Linking of `PyOS_FSPath` on PyPy. [#3374](https://github.com/PyO3/pyo3/pull/3374)
+- Fix memory leak in `PyTypeBuilder::build`. [#3401](https://github.com/PyO3/pyo3/pull/3401)
+- Disable removed FFI definitions `_Py_GetAllocatedBlocks`, `_PyObject_GC_Malloc`, and `_PyObject_GC_Calloc` on Python 3.11 and up. [#3403](https://github.com/PyO3/pyo3/pull/3403)
+- Fix `ResourceWarning` and crashes related to GC when running with debug builds of CPython. [#3404](https://github.com/PyO3/pyo3/pull/3404)
+- Some-wrapping of `Option<T>` default arguments will no longer re-wrap `Some(T)` or expressions evaluating to `None`. [#3461](https://github.com/PyO3/pyo3/pull/3461)
+- Fix `IterNextOutput::Return` not returning a value on PyPy. [#3471](https://github.com/PyO3/pyo3/pull/3471)
+- Emit compile errors instead of ignoring macro invocations inside `#[pymethods]` blocks. [#3491](https://github.com/PyO3/pyo3/pull/3491)
+- Emit error on invalid arguments to `#[new]`, `#[classmethod]`, `#[staticmethod]`, and `#[classattr]`. [#3484](https://github.com/PyO3/pyo3/pull/3484)
+- Disable `PyMarshal_WriteObjectToString` from `PyMarshal_ReadObjectFromString` with the `abi3` feature. [#3490](https://github.com/PyO3/pyo3/pull/3490)
+- Fix FFI definitions for `_PyFrameEvalFunction` on Python 3.11 and up (it now receives a `_PyInterpreterFrame` opaque struct). [#3500](https://github.com/PyO3/pyo3/pull/3500)
+
+
 ## [0.19.2] - 2023-08-01
 
 ### Added
@@ -1533,7 +1599,8 @@ Yanked
 
 - Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.19.2...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/pyo3/pyo3/compare/v0.19.2...v0.20.0
 [0.19.2]: https://github.com/pyo3/pyo3/compare/v0.19.1...v0.19.2
 [0.19.1]: https://github.com/pyo3/pyo3/compare/v0.19.0...v0.19.1
 [0.19.0]: https://github.com/pyo3/pyo3/compare/v0.18.3...v0.19.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.19.2"
+version = "0.20.0"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -21,10 +21,10 @@ parking_lot = ">= 0.11, < 0.13"
 memoffset = "0.9"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.19.2" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.20.0" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.19.2", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.20.0", optional = true }
 indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
@@ -56,7 +56,7 @@ rust_decimal = { version = "1.8.0", features = ["std"] }
 widestring = "0.5.1"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "0.19.2", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "0.20.0", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.19.2", features = ["extension-module"] }
+pyo3 = { version = "0.20.0", features = ["extension-module"] }
 ```
 
 **`src/lib.rs`**
@@ -137,7 +137,7 @@ Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like th
 
 ```toml
 [dependencies.pyo3]
-version = "0.19.2"
+version = "0.20.0"
 features = ["auto-initialize"]
 ```
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dev-dependencies]
-pyo3 = { version = "0.19.2", path = "..", features = ["auto-initialize", "extension-module"] }
+pyo3 = { version = "0.20.0", path = "..", features = ["auto-initialize", "extension-module"] }
 
 [[example]]
 name = "decorator"

--- a/examples/decorator/.template/pre-script.rhai
+++ b/examples/decorator/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.19.2");
+variable::set("PYO3_VERSION", "0.20.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/maturin-starter/.template/pre-script.rhai
+++ b/examples/maturin-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.19.2");
+variable::set("PYO3_VERSION", "0.20.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/plugin/.template/pre-script.rhai
+++ b/examples/plugin/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.19.2");
+variable::set("PYO3_VERSION", "0.20.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/plugin_api/Cargo.toml", "plugin_api/Cargo.toml");
 file::delete(".template");

--- a/examples/setuptools-rust-starter/.template/pre-script.rhai
+++ b/examples/setuptools-rust-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.19.2");
+variable::set("PYO3_VERSION", "0.20.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/setup.cfg", "setup.cfg");
 file::delete(".template");

--- a/examples/word-count/.template/pre-script.rhai
+++ b/examples/word-count/.template/pre-script.rhai
@@ -1,3 +1,3 @@
-variable::set("PYO3_VERSION", "0.19.2");
+variable::set("PYO3_VERSION", "0.20.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::delete(".template");

--- a/newsfragments/3108.packaging.md
+++ b/newsfragments/3108.packaging.md
@@ -1,1 +1,0 @@
-Dual-license PyO3 under either the Apache 2.0 OR the MIT license. This makes the project GPLv2 compatible.

--- a/newsfragments/3203.added.md
+++ b/newsfragments/3203.added.md
@@ -1,1 +1,0 @@
-Support `__lt__`, `__le__`, `__eq__`, `__ne__`, `__gt__` and `__ge__` in `#[pymethods]`

--- a/newsfragments/3208.packaging.md
+++ b/newsfragments/3208.packaging.md
@@ -1,1 +1,0 @@
-Update MSRV to Rust 1.56.

--- a/newsfragments/3222.added.md
+++ b/newsfragments/3222.added.md
@@ -1,1 +1,0 @@
-Simple getitem example showing type-check for possible attribute types

--- a/newsfragments/3232.removed.md
+++ b/newsfragments/3232.removed.md
@@ -1,1 +1,0 @@
-Remove all functionality deprecated in PyO3 0.18, including `#[args]` attribute for `#[pymethods]`.

--- a/newsfragments/3237.packaging.md
+++ b/newsfragments/3237.packaging.md
@@ -1,1 +1,0 @@
-Bump `indoc` dependency to 2.0 and `unindent` to 0.2.

--- a/newsfragments/3239.packaging.md
+++ b/newsfragments/3239.packaging.md
@@ -1,1 +1,0 @@
-Switched from syn 1.x to syn 2.x

--- a/newsfragments/3281.changed.md
+++ b/newsfragments/3281.changed.md
@@ -1,1 +1,0 @@
-Change `PySet::discard` to return `PyResult<bool>` (previously returned nothing).

--- a/newsfragments/3281.fixed.md
+++ b/newsfragments/3281.fixed.md
@@ -1,1 +1,0 @@
-Handle exceptions properly in `PySet::discard`.

--- a/newsfragments/3321.changed.md
+++ b/newsfragments/3321.changed.md
@@ -1,1 +1,0 @@
-Optimize conversion of Rust tuples to Python tuples.

--- a/newsfragments/3330.changed.md
+++ b/newsfragments/3330.changed.md
@@ -1,1 +1,0 @@
-Change `PyDict::get_item` to no longer suppress arbitrary exceptions (the return type is now `PyResult<Option<&PyAny>>` instead of `Option<&PyAny>`), and deprecate `PyDict::get_item_with_error`.

--- a/newsfragments/3336.added.md
+++ b/newsfragments/3336.added.md
@@ -1,1 +1,0 @@
-Add FFI symbol `Py_GETENV`.

--- a/newsfragments/3336.changed.md
+++ b/newsfragments/3336.changed.md
@@ -1,1 +1,0 @@
-Deprecate FFI definitions which are deprecated in Python 3.12.

--- a/newsfragments/3358.changed.md
+++ b/newsfragments/3358.changed.md
@@ -1,1 +1,0 @@
-`AsPyPointer` is now `unsafe trait`.

--- a/newsfragments/3359.added.md
+++ b/newsfragments/3359.added.md
@@ -1,1 +1,0 @@
-Add `as_ptr` and `into_ptr` inherent methods for `Py`, `PyAny`, `PyRef`, and `PyRefMut`.

--- a/newsfragments/3366.added.md
+++ b/newsfragments/3366.added.md
@@ -1,1 +1,0 @@
-Add implementations `DoubleEndedIterator` for `PyTupleIterator` and `PyListIterator`.

--- a/newsfragments/3366.fixed.md
+++ b/newsfragments/3366.fixed.md
@@ -1,1 +1,0 @@
-The `PyTupleIterator` type returned by `PyTuple::iter` is now public and hence can be named by downstream crates.

--- a/newsfragments/3374.added.md
+++ b/newsfragments/3374.added.md
@@ -1,1 +1,0 @@
-`PathBuf` `FromPyObject` implementation now works on all `os.PathLike` values.

--- a/newsfragments/3374.fixed.md
+++ b/newsfragments/3374.fixed.md
@@ -1,1 +1,0 @@
-Linking of `PyOS_FSPath` on PyPy.

--- a/newsfragments/3378.changed.md
+++ b/newsfragments/3378.changed.md
@@ -1,1 +1,0 @@
-Add `__builtins__` to globals in `py.run()` and `py.eval()` if they're missing.

--- a/newsfragments/3379.changed.md
+++ b/newsfragments/3379.changed.md
@@ -1,1 +1,0 @@
-Sped up FromPyObject::extract for BigInt and BigUint by up to 43% (although mileage may vary depending on int size and sign)

--- a/newsfragments/3384.added.md
+++ b/newsfragments/3384.added.md
@@ -1,1 +1,0 @@
-`#[pyclass]` now accepts `rename_all = "renaming_rule"`: this allows renaming all getters and setters of a struct, or all variants of an enum. Available renaming rules are: `"camelCase"`, `"kebab-case"`, `"lowercase"`, `"PascalCase"`, `"SCREAMING-KEBAB-CASE"`, `"SCREAMING_SNAKE_CASE"`, `"snake_case"`, `"UPPERCASE"`.

--- a/newsfragments/3385.removed.md
+++ b/newsfragments/3385.removed.md
@@ -1,1 +1,0 @@
-Removed `IntoPyPointer` trait, `into_ptr` is now an inherent method on most types representing Python objects

--- a/newsfragments/3387.packaging.md
+++ b/newsfragments/3387.packaging.md
@@ -1,1 +1,0 @@
-Drop support for debug builds of Python 3.7.

--- a/newsfragments/3389.changed.md
+++ b/newsfragments/3389.changed.md
@@ -1,1 +1,0 @@
-`PyIterator::from_object` and `PyByteArray::from` now take a single argument of type `&PyAny`, rather than two arguments, `Python` and `AsPyPointer`

--- a/newsfragments/3391.changed.md
+++ b/newsfragments/3391.changed.md
@@ -1,1 +1,0 @@
-Replace `AsPyPointer` with `AsRef<PyAny>` as a bound in the blanket implementation of `From<&T> for PyObject`

--- a/newsfragments/3393.changed.md
+++ b/newsfragments/3393.changed.md
@@ -1,1 +1,0 @@
-Replace blanket `impl IntoPy<PyObject> for &T where T: AsPyPointer` with implementations of `impl IntoPy<PyObject>` for `&PyAny`, `&T where T: AsRef<PyAny>`, and `&Py<T>`.

--- a/newsfragments/3396.changed.md
+++ b/newsfragments/3396.changed.md
@@ -1,1 +1,0 @@
-Reuses `std::io::Error` conversion code when converting `std::io::IntoInnerError` to `PyErr` 

--- a/newsfragments/3397.changed.md
+++ b/newsfragments/3397.changed.md
@@ -1,1 +1,0 @@
-Pick a relevant `ErrorKind` when building an `io::Error` from a `OSError` subclass.

--- a/newsfragments/3401.fixed.md
+++ b/newsfragments/3401.fixed.md
@@ -1,1 +1,0 @@
-Fix memory leak in `PyTypeBuilder::build`.

--- a/newsfragments/3402.changed.md
+++ b/newsfragments/3402.changed.md
@@ -1,1 +1,0 @@
-`std::io::Error` cast: Reuses the underlying `PyErr` Python error instead of wrapping it again if the `io::Error` has been built using a Python exception

--- a/newsfragments/3403.added.md
+++ b/newsfragments/3403.added.md
@@ -1,1 +1,0 @@
-Add FFI definitions `PyObject_GC_IsTracked` and `PyObject_GC_IsFinalized` on Python 3.9 and up (PyPy 3.10 and up).

--- a/newsfragments/3403.fixed.md
+++ b/newsfragments/3403.fixed.md
@@ -1,1 +1,0 @@
-Disable removed FFI definitions `_Py_GetAllocatedBlocks`, `_PyObject_GC_Malloc`, and `_PyObject_GC_Calloc` on Python 3.11 and up.

--- a/newsfragments/3404.fixed.md
+++ b/newsfragments/3404.fixed.md
@@ -1,1 +1,0 @@
-Fix `ResourceWarning` and crashes related to GC when running with debug builds of CPython.

--- a/newsfragments/3405.fixed.md
+++ b/newsfragments/3405.fixed.md
@@ -1,1 +1,0 @@
-Fix compile warning for unreachable expression on debug builds before 3.12.

--- a/newsfragments/3408.added.md
+++ b/newsfragments/3408.added.md
@@ -1,1 +1,0 @@
-Add types for `None`, `Ellipsis`, and `NotImplemented`

--- a/newsfragments/3427.packaging.md
+++ b/newsfragments/3427.packaging.md
@@ -1,1 +1,0 @@
-Bump `chrono` optional dependency to require 0.4.25 or newer.

--- a/newsfragments/3446.changed.md
+++ b/newsfragments/3446.changed.md
@@ -1,1 +1,0 @@
-`#[pymodule]` will now return the same module object on repeated import by the same Python interpreter, on Python 3.9 and up.

--- a/newsfragments/3455.changed.md
+++ b/newsfragments/3455.changed.md
@@ -1,1 +1,0 @@
-`Err` returned from `#[pyfunction]` will now have a non-None `__context__` if called from inside a `catch` block.

--- a/newsfragments/3458.changed.md
+++ b/newsfragments/3458.changed.md
@@ -1,1 +1,0 @@
-Truncate leap-seconds and warn when converting `chrono` types to Python `datetime` types (`datetime` cannot represent leap-seconds).

--- a/newsfragments/3461.fixed.md
+++ b/newsfragments/3461.fixed.md
@@ -1,1 +1,0 @@
-Some-wrapping of `Option<T>` default arguments will no longer re-wrap `Some(T)` or expressions evaluating to `None`.

--- a/newsfragments/3471.fixed.md
+++ b/newsfragments/3471.fixed.md
@@ -1,1 +1,0 @@
-Fix `IterNextOutput::Return` not returning a value on PyPy.

--- a/newsfragments/3484.fixed.md
+++ b/newsfragments/3484.fixed.md
@@ -1,1 +1,0 @@
-Emit error on invalid arguments to `#[new]`, `#[classmethod]`, `#[staticmethod]`, and `#[classattr]`.

--- a/newsfragments/3488.packaging.md
+++ b/newsfragments/3488.packaging.md
@@ -1,1 +1,0 @@
-Support Python 3.12.

--- a/newsfragments/3490.fixed.md
+++ b/newsfragments/3490.fixed.md
@@ -1,1 +1,0 @@
-Disable `PyMarshal_WriteObjectToString` from `PyMarshal_ReadObjectFromString` with the `abi3` feature.

--- a/newsfragments/3491.fixed.md
+++ b/newsfragments/3491.fixed.md
@@ -1,1 +1,0 @@
-Emit compile errors instead of ignoring macro invocations inside `#[pymethods]` blocks.

--- a/newsfragments/3494.added.md
+++ b/newsfragments/3494.added.md
@@ -1,1 +1,0 @@
-Added the Py_mod_multiple_interpreters constant and its possible values.

--- a/newsfragments/3500.fixed.md
+++ b/newsfragments/3500.fixed.md
@@ -1,2 +1,0 @@
-In Python 3.11 the `_PyFrameEvalFunction` receives a `_PyInterpreterFrame` opaque struct.
-

--- a/newsfragments/3502.added.md
+++ b/newsfragments/3502.added.md
@@ -1,1 +1,0 @@
-Added the `PyInterpreterConfig` struct, its constants and `Py_NewInterpreterFromConfig`.

--- a/newsfragments/3505.changed.md
+++ b/newsfragments/3505.changed.md
@@ -1,1 +1,0 @@
-Deprecate undocumented `#[__new__]` form of `#[new]` attribute.

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.19.2"
+version = "0.20.0"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.19.2"
+version = "0.20.0"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -38,4 +38,4 @@ generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "0.19.2", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "0.20.0", features = ["resolve-config"] }

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.19.2"
+version = "0.20.0"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.19.2"
+version = "0.20.0"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -22,4 +22,4 @@ abi3 = ["pyo3-macros-backend/abi3"]
 proc-macro2 = { version = "1", default-features = false }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.19.2" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.20.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ exclude = '''
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "0.19.2"
+version = "0.20.0"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"


### PR DESCRIPTION
With Python 3.12 out the door and so many improvements ready to ship on our end, I think it's time to push 0.20 live.

There are still a few PRs which I would like to see merged before we release:
- #3490 - trivial bugfix
- #3488 
- #3484 - small UX improvement which is technically breaking
- #3455 - a bugfix which makes exceptions chain so I'd prefer ship in a feature release rather than a follow-up patch

Once we have either merged or closed those PRs I will rebase this and prepare to ship.

Closes #3246 