### PR TITLE
Fix `_PyFrameEvalFunction` receives an `_PyInterpreterFrame` since Python 3.11

### DIFF
--- a/newsfragments/3500.fixed.md
+++ b/newsfragments/3500.fixed.md
@@ -1,0 +1,2 @@
+In Python 3.11 the `_PyFrameEvalFunction` receives a `_PyInterpreterFrame` opaque struct.
+

--- a/pyo3-ffi/src/cpython/ceval.rs
+++ b/pyo3-ffi/src/cpython/ceval.rs
@@ -5,7 +5,16 @@ use std::os::raw::c_int;
 extern "C" {
     // skipped non-limited _PyEval_CallTracing
 
+    #[cfg(not(Py_3_11))]
     pub fn _PyEval_EvalFrameDefault(arg1: *mut crate::PyFrameObject, exc: c_int) -> *mut PyObject;
+
+    #[cfg(Py_3_11)]
+    pub fn _PyEval_EvalFrameDefault(
+        tstate: *mut crate::PyThreadState,
+        frame: *mut crate::_PyInterpreterFrame,
+        exc: c_int,
+    ) -> *mut crate::PyObject;
+
     pub fn _PyEval_RequestCodeExtraIndex(func: freefunc) -> c_int;
     pub fn PyEval_SetProfile(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);
     pub fn PyEval_SetTrace(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -31,6 +31,8 @@ pub(crate) mod pystate;
 pub(crate) mod pythonrun;
 // skipped sysmodule.h
 pub(crate) mod floatobject;
+#[cfg(not(PyPy))]
+pub(crate) mod pyframe;
 pub(crate) mod tupleobject;
 pub(crate) mod unicodeobject;
 pub(crate) mod weakrefobject;
@@ -58,6 +60,8 @@ pub use self::object::*;
 pub use self::objimpl::*;
 pub use self::pydebug::*;
 pub use self::pyerrors::*;
+#[cfg(not(PyPy))]
+pub use self::pyframe::*;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub use self::pylifecycle::*;
 pub use self::pymem::*;

--- a/pyo3-ffi/src/cpython/pyframe.rs
+++ b/pyo3-ffi/src/cpython/pyframe.rs
@@ -1,0 +1,2 @@
+#[cfg(Py_3_11)]
+opaque_struct!(_PyInterpreterFrame);

--- a/pyo3-ffi/src/cpython/pystate.rs
+++ b/pyo3-ffi/src/cpython/pystate.rs
@@ -69,10 +69,17 @@ extern "C" {
     pub fn PyThreadState_DeleteCurrent();
 }
 
-#[cfg(Py_3_9)]
+#[cfg(all(Py_3_9, not(Py_3_11)))]
 pub type _PyFrameEvalFunction = extern "C" fn(
     *mut crate::PyThreadState,
     *mut crate::PyFrameObject,
+    c_int,
+) -> *mut crate::object::PyObject;
+
+#[cfg(Py_3_11)]
+pub type _PyFrameEvalFunction = extern "C" fn(
+    *mut crate::PyThreadState,
+    *mut crate::_PyInterpreterFrame,
     c_int,
 ) -> *mut crate::object::PyObject;
 


### PR DESCRIPTION
In Python 3.11 the `_PyFrameEvalFunction` receives a `_PyInterpreterFrame` opaque struct.

Python 3.11.0 (alpha 7) changelog:
> ...
> [bpo-46850](https://bugs.python.org/issue?@action=redirect&bpo=46850): Move the private _PyFrameEvalFunction type, and private _PyInterpreterState_GetEvalFrameFunc() and _PyInterpreterState_SetEvalFrameFunc() functions to the internal C API. The _PyFrameEvalFunction callback function type now uses the _PyInterpreterFrame type which is part of the internal C API. Patch by Victor Stinner.
> [bpo-46850](https://bugs.python.org/issue?@action=redirect&bpo=46850): Move the private undocumented _PyEval_EvalFrameDefault() function to the internal C API. The function now uses the _PyInterpreterFrame type which is part of the internal C API. Patch by Victor Stinner.
> ...

https://docs.python.org/3/whatsnew/changelog.html#id143