### PR TITLE
deprecate undocumented `#[__new__]` form of `#[new]`

### DIFF
--- a/newsfragments/3505.changed.md
+++ b/newsfragments/3505.changed.md
@@ -1,0 +1,1 @@
+Deprecate undocumented `#[__new__]` form of `#[new]` attribute.

--- a/pyo3-macros-backend/src/deprecations.rs
+++ b/pyo3-macros-backend/src/deprecations.rs
@@ -3,12 +3,14 @@ use quote::{quote_spanned, ToTokens};
 
 pub enum Deprecation {
     PyClassTextSignature,
+    PyMethodsNewDeprecatedForm,
 }
 
 impl Deprecation {
     fn ident(&self, span: Span) -> syn::Ident {
         let string = match self {
             Deprecation::PyClassTextSignature => "PYCLASS_TEXT_SIGNATURE",
+            Deprecation::PyMethodsNewDeprecatedForm => "PYMETHODS_NEW_DEPRECATED_FORM",
         };
         syn::Ident::new(string, span)
     }

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -3,6 +3,7 @@ use crate::{
         self, get_pyo3_options, take_attributes, take_pyo3_options, CrateAttribute,
         FromPyWithAttribute, NameAttribute, TextSignatureAttribute,
     },
+    deprecations::Deprecations,
     method::{self, CallingConvention, FnArg},
     pymethod::check_generic,
     utils::{ensure_not_async_fn, get_pyo3_crate},
@@ -230,6 +231,7 @@ pub fn impl_wrap_pyfunction(
         output: ty,
         text_signature,
         unsafety: func.sig.unsafety,
+        deprecations: Deprecations::new(),
     };
 
     let krate = get_pyo3_crate(&krate);

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -335,6 +335,7 @@ fn impl_py_method_def_new(cls: &syn::Type, spec: &FnSpec<'_>) -> Result<MethodAn
         || quote!(::std::option::Option::None),
         |text_signature| quote!(::std::option::Option::Some(#text_signature)),
     );
+    let deprecations = &spec.deprecations;
     let slot_def = quote! {
         _pyo3::ffi::PyType_Slot {
             slot: _pyo3::ffi::Py_tp_new,
@@ -345,6 +346,8 @@ fn impl_py_method_def_new(cls: &syn::Type, spec: &FnSpec<'_>) -> Result<MethodAn
                     kwargs: *mut _pyo3::ffi::PyObject,
                 ) -> *mut _pyo3::ffi::PyObject
                 {
+                    #deprecations
+
                     use _pyo3::impl_::pyclass::*;
                     impl PyClassNewTextSignature<#cls> for PyClassImplCollector<#cls> {
                         #[inline]

--- a/src/impl_/deprecations.rs
+++ b/src/impl_/deprecations.rs
@@ -5,3 +5,6 @@
     note = "put `text_signature` on `#[new]` instead of `#[pyclass]`"
 )]
 pub const PYCLASS_TEXT_SIGNATURE: () = ();
+
+#[deprecated(since = "0.20.0", note = "use `#[new]` instead of `#[__new__]`")]
+pub const PYMETHODS_NEW_DEPRECATED_FORM: () = ();

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -6,4 +6,12 @@ use pyo3::prelude::*;
 #[pyo3(text_signature = "()")]
 struct MyClass;
 
+#[pymethods]
+impl MyClass {
+    #[__new__]
+    fn new() -> Self {
+        Self
+    }
+}
+
 fn main() {}

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -1,11 +1,17 @@
+error: use of deprecated constant `pyo3::impl_::deprecations::PYMETHODS_NEW_DEPRECATED_FORM`: use `#[new]` instead of `#[__new__]`
+  --> tests/ui/deprecations.rs:11:7
+   |
+11 |     #[__new__]
+   |       ^^^^^^^
+   |
+note: the lint level is defined here
+  --> tests/ui/deprecations.rs:1:9
+   |
+1  | #![deny(deprecated)]
+   |         ^^^^^^^^^^
+
 error: use of deprecated constant `pyo3::impl_::deprecations::PYCLASS_TEXT_SIGNATURE`: put `text_signature` on `#[new]` instead of `#[pyclass]`
  --> tests/ui/deprecations.rs:6:8
   |
 6 | #[pyo3(text_signature = "()")]
   |        ^^^^^^^^^^^^^^
-  |
-note: the lint level is defined here
- --> tests/ui/deprecations.rs:1:9
-  |
-1 | #![deny(deprecated)]
-  |         ^^^^^^^^^^


### PR DESCRIPTION
This PR deprecates `#[__new__]` (which is never mentioned in documentation) as we always use it as its documented form `#[new]`.