### PR TITLE
Fix bug in default implementation of `__ne__`

### DIFF
--- a/pytests/tests/test_comparisons.py
+++ b/pytests/tests/test_comparisons.py
@@ -23,10 +23,14 @@ def test_eq(ty: Type[Union[Eq, PyEq]]):
     c = ty(1)
 
     assert a == b
+    assert not (a != b)
     assert a != c
+    assert not (a == c)
 
     assert b == a
+    assert not (a != b)
     assert b != c
+    assert not (b == c)
 
     with pytest.raises(TypeError):
         assert a <= b
@@ -49,17 +53,21 @@ class PyEqDefaultNe:
         return self.x == other.x
 
 
-@pytest.mark.parametrize("ty", (Eq, PyEq), ids=("rust", "python"))
+@pytest.mark.parametrize("ty", (EqDefaultNe, PyEqDefaultNe), ids=("rust", "python"))
 def test_eq_default_ne(ty: Type[Union[EqDefaultNe, PyEqDefaultNe]]):
     a = ty(0)
     b = ty(0)
     c = ty(1)
 
     assert a == b
+    assert not (a != b)
     assert a != c
+    assert not (a == c)
 
     assert b == a
+    assert not (a != b)
     assert b != c
+    assert not (b == c)
 
     with pytest.raises(TypeError):
         assert a <= b
@@ -152,19 +160,25 @@ def test_ordered_default_ne(ty: Type[Union[OrderedDefaultNe, PyOrderedDefaultNe]
     c = ty(1)
 
     assert a == b
+    assert not (a != b)
     assert a <= b
     assert a >= b
     assert a != c
+    assert not (a == c)
     assert a <= c
 
     assert b == a
+    assert not (b != a)
     assert b <= a
     assert b >= a
     assert b != c
+    assert not (b == c)
     assert b <= c
 
     assert c != a
+    assert not (c == a)
     assert c != b
+    assert not (c == b)
     assert c > a
     assert c >= a
     assert c > b

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -6,6 +6,7 @@ use crate::{
     internal_tricks::extract_c_string,
     pycell::PyCellLayout,
     pyclass_init::PyObjectInit,
+    types::PyBool,
     Py, PyAny, PyCell, PyClass, PyErr, PyMethodDefType, PyNativeType, PyResult, PyTypeInfo, Python,
 };
 use std::{
@@ -805,11 +806,14 @@ slot_fragment_trait! {
     #[inline]
     unsafe fn __ne__(
         self,
-        _py: Python<'_>,
-        _slf: *mut ffi::PyObject,
-        _other: *mut ffi::PyObject,
+        py: Python<'_>,
+        slf: *mut ffi::PyObject,
+        other: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
-        Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+        // By default `__ne__` will try `__eq__` and invert the result
+        let slf: &PyAny = py.from_borrowed_ptr(slf);
+        let other: &PyAny = py.from_borrowed_ptr(other);
+        slf.eq(other).map(|is_eq| PyBool::new(py, !is_eq).into_ptr())
     }
 }
 


### PR DESCRIPTION
Closes #3417 

While updating the documentation for `__eq__` I fortunately stumbled across an error in the testing for `__eq__` and `__ne__` which caused us to miss the fact that `__ne__` was not defaulting to `__eq__` the same way it does for Python classes.

If anyone is available to give this a quick review (hopefully it's not a difficult review) then I'd be very grateful, as I think this blocks the release.

