### PR TITLE
ci: drop psutil dependency

### DIFF
--- a/pytests/requirements-dev.txt
+++ b/pytests/requirements-dev.txt
@@ -2,5 +2,4 @@ hypothesis>=3.55
 pytest>=6.0
 pytest-asyncio>=0.21
 pytest-benchmark>=3.4
-psutil>=5.6
 typing_extensions>=4.0.0


### PR DESCRIPTION
Not sure why the dependency is needed; it just broke PyPy builds, let's see what breaks if we remove it :)