### PR TITLE
ci: install prebuilt cargo-careful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
-      - run: cargo install cargo-careful
+      - uses: taiki-e/install-action@cargo-careful
       - run: python -m pip install --upgrade pip && pip install nox
       - run: nox -s test-rust -- careful skip-full
     env:


### PR DESCRIPTION
- use `taiki-e/install-action@cargo-careful` to avoid compiling `cargo-careful`