### PR TITLE
ci: include beta as an allowed-to-fail job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,13 @@ on:
       rust-target:
         required: true
         type: string
-      msrv:
-        required: false
-        type: string
       extra-features:
         required: true
         type: string
 
 jobs:
   build:
-    continue-on-error: ${{ endsWith(inputs.python-version, '-dev') || contains(fromJSON('["3.7", "pypy3.7"]'), inputs.python-version) }}
+    continue-on-error: ${{ endsWith(inputs.python-version, '-dev') || contains(fromJSON('["3.7", "pypy3.7"]'), inputs.python-version) || inputs.rust == 'beta' }}
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4
@@ -49,18 +46,18 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: cargo-${{ inputs.python-architecture }}-${{ inputs.os }}-${{ inputs.msrv }}
+          key: cargo-${{ inputs.python-architecture }}
         continue-on-error: true
 
       - if: inputs.os == 'ubuntu-latest'
         name: Prepare LD_LIBRARY_PATH (Ubuntu only)
         run: echo LD_LIBRARY_PATH=${pythonLocation}/lib >> $GITHUB_ENV
 
-      - if: inputs.msrv == 'MSRV'
+      - if: inputs.rust == '1.56.0'
         name: Prepare minimal package versions (MSRV only)
         run: nox -s set-minimal-package-versions
 
-      - if: inputs.rust == 'nightly' || inputs.msrv == 'MSRV'
+      - if: inputs.rust != 'stable'
         name: Ignore changed error messages when using trybuild
         run: echo "TRYBUILD=overwrite" >> "$GITHUB_ENV"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,6 @@ jobs:
       python-architecture: ${{ matrix.platform.python-architecture }}
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
-      msrv: ${{ matrix.msrv }}
       extra-features: ${{ matrix.platform.extra-features }}
     secrets: inherit
     strategy:
@@ -179,7 +178,6 @@ jobs:
       python-architecture: ${{ matrix.platform.python-architecture }}
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
-      msrv: ${{ matrix.msrv }}
       extra-features: ${{ matrix.platform.extra-features }}
     secrets: inherit
     strategy:
@@ -228,7 +226,6 @@ jobs:
                 python-architecture: "x64",
                 rust-target: "x86_64-unknown-linux-gnu",
               }
-            msrv: "MSRV"
             extra-features: ""
 
           # Test the `nightly` feature
@@ -241,6 +238,17 @@ jobs:
                 rust-target: "x86_64-unknown-linux-gnu",
               }
             extra-features: "nightly multiple-pymethods"
+
+          # Run rust beta to help catch toolchain regressions
+          - rust: beta
+            python-version: "3.12"
+            platform:
+              {
+                os: "ubuntu-latest",
+                python-architecture: "x64",
+                rust-target: "x86_64-unknown-linux-gnu",
+              }
+            extra-features: "multiple-pymethods"
 
           # Test 32-bit Windows only with the latest Python version
           - rust: stable


### PR DESCRIPTION
I heard at EuroRust that rust's distribution team would love to see more testers of beta before the stable release. I figured it wouldn't be that hard for us to add beta as an additional allowed-to-fail job.