### PR TITLE
ci: use install-action to download cargo-codspeed binary

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -30,7 +30,9 @@ jobs:
         continue-on-error: true
 
       - name: Install cargo-codspeed
-        run: cargo install cargo-codspeed
+        uses: taiki-e/install-action@v1
+        with:
+          tool: cargo-codspeed
 
       - name: Install nox
         run: pip install nox


### PR DESCRIPTION
Should cut the benchmarks job time by ~5 minutes (as well as reduce the build cache size).