### PR TITLE
add coverage for `emit_pyo3_cfgs`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,9 +33,11 @@ fn ensure_auto_initialize_ok(interpreter_config: &InterpreterConfig) -> Result<(
 fn configure_pyo3() -> Result<()> {
     let interpreter_config = pyo3_build_config::get();
 
-    interpreter_config.emit_pyo3_cfgs();
-
     ensure_auto_initialize_ok(interpreter_config)?;
+
+    for cfg in interpreter_config.build_script_outputs() {
+        println!("{}", cfg)
+    }
 
     // Emit cfgs like `thread_local_const_init`
     print_feature_cfgs();

--- a/pyo3-build-config/src/errors.rs
+++ b/pyo3-build-config/src/errors.rs
@@ -12,15 +12,21 @@ macro_rules! ensure {
     ($condition:expr, $($args: tt)+) => { if !($condition) { bail!($($args)+) } };
 }
 
-/// Show warning. If needed, please extend this macro to support arguments.
+/// Show warning.
 #[macro_export]
 #[doc(hidden)]
 macro_rules! warn {
-    ($msg: literal) => {
-        println!(concat!("cargo:warning=", $msg))
+    ($($args: tt)+) => {
+        println!("{}", $crate::format_warn!($($args)+))
     };
-    ($fmt: expr, $($args: tt)+) => {
-        println!("cargo:warning={}", format_args!($fmt, $($args)+))
+}
+
+/// Format warning into string.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! format_warn {
+    ($($args: tt)+) => {
+        format!("cargo:warning={}", format_args!($($args)+))
     };
 }
 

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -42,7 +42,9 @@ use target_lexicon::OperatingSystem;
 /// For examples of how to use these attributes, [see PyO3's guide](https://pyo3.rs/latest/building_and_distribution/multiple_python_versions.html).
 #[cfg(feature = "resolve-config")]
 pub fn use_pyo3_cfgs() {
-    get().emit_pyo3_cfgs();
+    for cargo_command in get().build_script_outputs() {
+        println!("{}", cargo_command)
+    }
 }
 
 /// Adds linker arguments suitable for PyO3's `extension-module` feature.

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -93,7 +93,9 @@ fn configure_pyo3() -> Result<()> {
         emit_link_config(&interpreter_config)?;
     }
 
-    interpreter_config.emit_pyo3_cfgs();
+    for cfg in interpreter_config.build_script_outputs() {
+        println!("{}", cfg)
+    }
 
     // Extra lines come last, to support last write wins.
     for line in &interpreter_config.extra_build_script_lines {
@@ -109,7 +111,7 @@ fn configure_pyo3() -> Result<()> {
 fn print_config_and_exit(config: &InterpreterConfig) {
     println!("\n-- PYO3_PRINT_CONFIG=1 is set, printing configuration and halting compile --");
     config
-        .to_writer(&mut std::io::stdout())
+        .to_writer(std::io::stdout())
         .expect("failed to print config to stdout");
     println!("\nnote: unset the PYO3_PRINT_CONFIG environment variable and retry to compile with the above config");
     std::process::exit(101);


### PR DESCRIPTION
While experimenting with https://github.com/PyO3/pyo3/pull/3247#discussion_r1367511468 I improved the test coverage for `pyo3-build-config` slightly. Might as well push this!