### PR TITLE
ci: tidy up some dev deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,7 @@ proptest = { version = "1.0", default-features = false, features = ["std"] }
 send_wrapper = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
-rayon = "1.0.2"
-rust_decimal = { version = "1.8.0", features = ["std"] }
+rayon = "1.6.1"
 widestring = "0.5.1"
 
 [build-dependencies]


### PR DESCRIPTION
- We're not using `rust_decimal` as a dev-dependency.
- Bump `rayon` dev-dependency to match what we use in `nox -s set-minimal-package-versions`.

Will proceed straight to merge as it changes testing only and might fix the stuck pipeline.