### PR TITLE
bump hashbrown minimal version to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ inventory = { version = "0.3.0", optional = true }
 anyhow = { version = "1.0", optional = true }
 chrono = { version = "0.4.25", default-features = false, optional = true }
 eyre = { version = ">= 0.4, < 0.7", optional = true }
-hashbrown = { version = ">= 0.9, < 0.15", optional = true }
+hashbrown = { version = ">= 0.12, < 0.15", optional = true }
 indexmap = { version = ">= 1.6, < 3", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-complex = { version = ">= 0.2, < 0.5", optional = true }

--- a/newsfragments/3544.packaging.md
+++ b/newsfragments/3544.packaging.md
@@ -1,0 +1,1 @@
+Bump lower bound of optional `hashbrown` dependency to 0.12.


### PR DESCRIPTION
`hashbrown` 0.12 is now two years old, and I'm hoping this might fix the break in CI related to `ahash` versions...