### PR TITLE
ci: use older hashbrown and indexmap for MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    continue-on-error: ${{ endsWith(inputs.python-version, '-dev') || contains(fromJSON('["3.7", "pypy3.7"]'), inputs.python-version) || inputs.rust == 'beta' }}
+    continue-on-error: ${{ endsWith(inputs.python-version, '-dev') || contains(fromJSON('["3.7", "pypy3.7"]'), inputs.python-version) || inputs.rust == 'beta' || inputs.rust == 'nightly' }}
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,20 @@ jobs:
               os: "windows-latest",
               python-architecture: "x86",
               rust-target: "i686-pc-windows-msvc",
-            }
+            },
           ]
+        include:
+          # Test nightly Rust on PRs so that PR authors have a chance to fix nightly
+          # failures, as nightly does not block merge.
+          - rust: nightly
+            python-version: "3.12"
+            platform:
+              {
+                os: "ubuntu-latest",
+                python-architecture: "x64",
+                rust-target: "x86_64-unknown-linux-gnu",
+              }
+            extra-features: "nightly multiple-pymethods"
   build-full:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} rust-${{ matrix.rust }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -498,8 +498,8 @@ def set_minimal_package_versions(session: nox.Session):
     min_pkg_versions = {
         "rust_decimal": "1.26.1",
         "csv": "1.1.6",
-        "indexmap": "1.9.3",
-        "hashbrown": "0.12.3",
+        "indexmap": "1.6.2",
+        "hashbrown": "0.9.1",
         "log": "0.4.17",
         "once_cell": "1.17.2",
         "rayon": "1.6.1",


### PR DESCRIPTION
Ok, I think this is the solution which will finally work to resolve the `ahash` break.

If it's good, I'll merge it and push the other PRs through which are blocked on merging by this.