### PR TITLE
ci: switch from black to ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - name: Check python formatting (black)
-        run: nox -s fmt-py
+      - name: Check python formatting and lints (ruff)
+        run: nox -s ruff
       - name: Check rust formatting (rustfmt)
-        run: nox -s fmt-rust
+        run: nox -s rustfmt
 
   check-msrv:
     needs: [fmt]

--- a/examples/decorator/tests/example.py
+++ b/examples/decorator/tests/example.py
@@ -1,3 +1,6 @@
+from decorator import Counter
+
+
 @Counter
 def say_hello():
     print("hello")

--- a/examples/decorator/tests/test_.py
+++ b/examples/decorator/tests/test_.py
@@ -45,7 +45,7 @@ def test_discussion_2598():
     @Counter
     def say_hello():
         if say_hello.count < 2:
-            print(f"hello from decorator")
+            print("hello from decorator")
 
     say_hello()
     say_hello()

--- a/examples/maturin-starter/maturin_starter/__init__.py
+++ b/examples/maturin-starter/maturin_starter/__init__.py
@@ -1,7 +1,9 @@
 # import the contents of the Rust library into the Python extension
-# optional: include the documentation from the Rust module
 from .maturin_starter import *
-from .maturin_starter import __all__, __doc__
+from .maturin_starter import __all__
+
+# optional: include the documentation from the Rust module
+from .maturin_starter import __doc__  # noqa: F401
 
 __all__ = __all__ + ["PythonClass"]
 

--- a/examples/plugin/plugin_api/tests/test_import.py
+++ b/examples/plugin/plugin_api/tests/test_import.py
@@ -1,2 +1,2 @@
 def test_import():
-    import plugin_api
+    import plugin_api  # noqa: F401

--- a/examples/setuptools-rust-starter/setuptools_rust_starter/__init__.py
+++ b/examples/setuptools-rust-starter/setuptools_rust_starter/__init__.py
@@ -1,7 +1,9 @@
 # import the contents of the Rust library into the Python extension
-# optional: include the documentation from the Rust module
 from ._setuptools_rust_starter import *
-from ._setuptools_rust_starter import __all__, __doc__
+from ._setuptools_rust_starter import __all__
+
+# optional: include the documentation from the Rust module
+from ._setuptools_rust_starter import __doc__  # noqa: F401
 
 __all__ = __all__ + ["PythonClass"]
 

--- a/examples/string-sum/tests/test_.py
+++ b/examples/string-sum/tests/test_.py
@@ -14,7 +14,7 @@ def test_err1():
 
     with pytest.raises(
         TypeError, match="sum_as_string expected an int for positional argument 1"
-    ) as e:
+    ):
         sum_as_string(a, b)
 
 
@@ -23,19 +23,19 @@ def test_err2():
 
     with pytest.raises(
         TypeError, match="sum_as_string expected an int for positional argument 2"
-    ) as e:
+    ):
         sum_as_string(a, b)
 
 
 def test_overflow1():
     a, b = 0, 1 << 43
 
-    with pytest.raises(OverflowError, match="cannot fit 8796093022208 in 32 bits") as e:
+    with pytest.raises(OverflowError, match="cannot fit 8796093022208 in 32 bits"):
         sum_as_string(a, b)
 
 
 def test_overflow2():
     a, b = 1 << 30, 1 << 30
 
-    with pytest.raises(OverflowError, match="arguments too large to add") as e:
+    with pytest.raises(OverflowError, match="arguments too large to add"):
         sum_as_string(a, b)

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,22 +66,17 @@ def coverage(session: nox.Session) -> None:
     )
 
 
-@nox.session
-def fmt(session: nox.Session):
-    fmt_rust(session)
-    fmt_py(session)
-
-
-@nox.session(name="fmt-rust", venv_backend="none")
-def fmt_rust(session: nox.Session):
+@nox.session(venv_backend="none")
+def rustfmt(session: nox.Session):
     _run_cargo(session, "fmt", "--all", "--check")
     _run_cargo(session, "fmt", _FFI_CHECK, "--all", "--check")
 
 
-@nox.session(name="fmt-py")
-def fmt_py(session: nox.Session):
-    session.install("black==22.3.0")
-    _run(session, "black", ".", "--check")
+@nox.session(name="ruff")
+def ruff(session: nox.Session):
+    session.install("ruff")
+    _run(session, "ruff", "format", ".", "--check")
+    _run(session, "ruff", "check", ".")
 
 
 @nox.session(name="clippy", venv_backend="none")
@@ -234,7 +229,7 @@ def contributors(session: nox.Session) -> None:
         for commit in body["commits"]:
             try:
                 authors.add(commit["author"]["login"])
-            except:
+            except Exception:
                 continue
 
         if "next" in resp.links:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,5 @@
-[tool.black]
-target_version = ['py35']
-include = '\.pyi?$'
-exclude = '''
-
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.mypy_cache
-    | \.tox
-    | \.nox
-    | \.venv
-    | venv
-    | target
-    | dist
-  )/
-)
-'''
+[tool.ruff.extend-per-file-ignores]
+"__init__.py" = ["F403"]
 
 [tool.towncrier]
 filename = "CHANGELOG.md"

--- a/pytests/tests/test_datetime.py
+++ b/pytests/tests/test_datetime.py
@@ -118,16 +118,15 @@ def test_time(args, kwargs):
 
 
 @given(t=st.times())
-def test_time(t):
+def test_time_hypothesis(t):
     act = rdt.get_time_tuple(t)
     exp = (t.hour, t.minute, t.second, t.microsecond)
 
     assert act == exp
 
 
-@pytest.mark.xfail(PYPY, reason="Feature not available on PyPy")
 @given(t=st.times())
-def test_time_fold(t):
+def test_time_tuple_fold(t):
     t_nofold = t.replace(fold=0)
     t_fold = t.replace(fold=1)
 
@@ -138,9 +137,8 @@ def test_time_fold(t):
         assert act == exp
 
 
-@pytest.mark.xfail(PYPY, reason="Feature not available on PyPy")
 @pytest.mark.parametrize("fold", [False, True])
-def test_time_fold(fold):
+def test_time_with_fold(fold):
     t = rdt.time_with_fold(0, 0, 0, 0, None, fold)
     assert t.fold == fold
 
@@ -206,7 +204,6 @@ def test_datetime_tuple(dt):
     assert act == exp
 
 
-@pytest.mark.xfail(PYPY, reason="Feature not available on PyPy")
 @given(dt=st.datetimes())
 def test_datetime_tuple_fold(dt):
     dt_fold = dt.replace(fold=1)

--- a/pytests/tests/test_objstore.py
+++ b/pytests/tests/test_objstore.py
@@ -1,8 +1,6 @@
 import gc
-import platform
 import sys
 
-import pytest
 from pyo3_pytests.objstore import ObjStore
 
 

--- a/pytests/tests/test_subclassing.py
+++ b/pytests/tests/test_subclassing.py
@@ -1,5 +1,3 @@
-import platform
-
 from pyo3_pytests.subclassing import Subclassable
 
 


### PR DESCRIPTION
Everyone is celebrating the new `ruff format` command, and also by adopting `ruff` we get some linting on our Python examples, which seems like a good thing.