### PR TITLE
docs: Example of dynamic return type in the "Python classes" guide

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -337,10 +337,27 @@ impl SubSubClass {
         let super_ = self_.into_super(); // Get PyRef<'_, SubClass>
         SubClass::method2(super_).map(|x| x * v)
     }
+
+    #[staticmethod]
+    fn dynamic_type(py: Python<'_>, val: usize) -> PyResult<PyObject> {
+        let base = PyClassInitializer::from(BaseClass::new());
+        let sub = base.add_subclass(SubClass { val2: val });
+        if val % 2 == 0 {
+            Ok(Py::new(py, sub)?.to_object(py))
+        } else {
+            let sub_sub = sub.add_subclass(SubSubClass { val3: val });
+            Ok(Py::new(py, sub_sub)?.to_object(py))
+        }
+    }
 }
 # Python::with_gil(|py| {
 #     let subsub = pyo3::PyCell::new(py, SubSubClass::new()).unwrap();
-#     pyo3::py_run!(py, subsub, "assert subsub.method3() == 3000")
+#     pyo3::py_run!(py, subsub, "assert subsub.method3() == 3000");
+#     let subsub = SubSubClass::dynamic_type(py, 2).unwrap();
+#     let subsubsub = SubSubClass::dynamic_type(py, 3).unwrap();
+#     let cls = py.get_type::<SubSubClass>();
+#     pyo3::py_run!(py, subsub cls, "assert not isinstance(subsub, cls)");
+#     pyo3::py_run!(py, subsubsub cls, "assert isinstance(subsubsub, cls)");
 # });
 ```
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -353,8 +353,8 @@ impl SubSubClass {
 # Python::with_gil(|py| {
 #     let subsub = pyo3::PyCell::new(py, SubSubClass::new()).unwrap();
 #     pyo3::py_run!(py, subsub, "assert subsub.method3() == 3000");
-#     let subsub = SubSubClass::dynamic_type(py, 2).unwrap();
-#     let subsubsub = SubSubClass::dynamic_type(py, 3).unwrap();
+#     let subsub = SubSubClass::factory_method(py, 2).unwrap();
+#     let subsubsub = SubSubClass::factory_method(py, 3).unwrap();
 #     let cls = py.get_type::<SubSubClass>();
 #     pyo3::py_run!(py, subsub cls, "assert not isinstance(subsub, cls)");
 #     pyo3::py_run!(py, subsubsub cls, "assert isinstance(subsubsub, cls)");

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -339,7 +339,7 @@ impl SubSubClass {
     }
 
     #[staticmethod]
-    fn dynamic_type(py: Python<'_>, val: usize) -> PyResult<PyObject> {
+    fn factory_method(py: Python<'_>, val: usize) -> PyResult<PyObject> {
         let base = PyClassInitializer::from(BaseClass::new());
         let sub = base.add_subclass(SubClass { val2: val });
         if val % 2 == 0 {


### PR DESCRIPTION
This PR is based on the discussion for [this question](https://github.com/PyO3/pyo3/issues/1637). It just adds a single method into the inheritance section of the class guide. 

The purpose of this new example is to show how a sub-type can be instantiated dynamically within a method other than `#[new]`. In other words, how to "instantiate" `PyClassInitializer` into an actual Python object from Rust.

If you know a better way to do this, feel free to suggest an alternative example. But the reactions in the question discussion seem to indicate that the answer is not entirely obvious, hence I considered it worth including.