### PR TITLE
feat: add `take` and `into_inner` methods to `GILOnceCell`

### DIFF
--- a/newsfragments/3556.added.md
+++ b/newsfragments/3556.added.md
@@ -1,0 +1,1 @@
+Add `take` and `into_inner` methods to `GILOnceCell`

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -149,8 +149,7 @@ impl<T> GILOnceCell<T> {
     /// Get the contents of the cell mutably. This is only possible if the reference to the cell is
     /// unique.
     pub fn get_mut(&mut self) -> Option<&mut T> {
-        // Safe because we have &mut self
-        unsafe { &mut *self.0.get() }.as_mut()
+        self.0.get_mut().as_mut()
     }
 
     /// Set the value in the cell.


### PR DESCRIPTION
`take` is used in #3540

Now, `GILOnceCell` has the same methods as standard [`OnceLock`](https://doc.rust-lang.org/std/sync/struct.OnceLock.html), but some traits implementation are still missing, like `Default`. 