### PR TITLE
ci: use trybuild branch which strips rust-src lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,3 +127,7 @@ members = [
 no-default-features = true
 features = ["macros", "num-bigint", "num-complex", "hashbrown", "serde", "multiple-pymethods", "indexmap", "eyre", "chrono", "rust_decimal"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+# workaround for issue installing rust-src on GitHub actions, see https://github.com/dtolnay/trybuild/pull/247
+[patch.crates-io]
+trybuild = { git = "https://github.com/davidhewitt/trybuild", branch = "strip-rust-src" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-components = [ "rust-src" ]

--- a/tests/ui/not_send.stderr
+++ b/tests/ui/not_send.stderr
@@ -9,9 +9,6 @@ error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safe
   = help: within `pyo3::Python<'_>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
 note: required because it appears within the type `PhantomData<*mut Python<'static>>`
  --> $RUST/core/src/marker.rs
-  |
-  | pub struct PhantomData<T: ?Sized>;
-  |            ^^^^^^^^^^^
 note: required because it appears within the type `NotSend`
  --> src/impl_/not_send.rs
   |
@@ -20,9 +17,6 @@ note: required because it appears within the type `NotSend`
   = note: required because it appears within the type `(&GILGuard, NotSend)`
 note: required because it appears within the type `PhantomData<(&GILGuard, NotSend)>`
  --> $RUST/core/src/marker.rs
-  |
-  | pub struct PhantomData<T: ?Sized>;
-  |            ^^^^^^^^^^^
 note: required because it appears within the type `Python<'_>`
  --> src/marker.rs
   |


### PR DESCRIPTION
This PR adds a temporary patch to our `trybuild` dependency which strips out rust standard library src lines from error messages. This removes our need to install `rust-src` in CI, hopefully resolving our `rustup` issue which has blocked CI.

See https://github.com/dtolnay/trybuild/pull/247