### PR TITLE
Implement `PyTypeInfo` for `PyEllipsis`, `PyNone`, and `PyNotImplemented`

### DIFF
--- a/newsfragments/3577.added.md
+++ b/newsfragments/3577.added.md
@@ -1,0 +1,1 @@
+Implement `PyTypeInfo` for `PyEllipsis`, `PyNone` and `PyNotImplemented`.

--- a/newsfragments/3577.changed.md
+++ b/newsfragments/3577.changed.md
@@ -1,0 +1,1 @@
+Deprecate `Py::is_ellipsis` and `PyAny::is_ellipsis` in favour of `any.is(py.Ellipsis())`.

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -776,6 +776,7 @@ impl<T> Py<T> {
     /// Returns whether the object is Ellipsis, e.g. `...`.
     ///
     /// This is equivalent to the Python expression `self is ...`.
+    #[deprecated(since = "0.20.0", note = "use `.is(py.Ellipsis())` instead")]
     pub fn is_ellipsis(&self) -> bool {
         unsafe { ffi::Py_Ellipsis() == self.as_ptr() }
     }
@@ -1474,6 +1475,7 @@ a = A()
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_is_ellipsis() {
         Python::with_gil(|py| {
             let v = py

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -653,6 +653,7 @@ impl PyAny {
     /// Returns whether the object is Ellipsis, e.g. `...`.
     ///
     /// This is equivalent to the Python expression `self is ...`.
+    #[deprecated(since = "0.20.0", note = "use `.is(py.Ellipsis())` instead")]
     pub fn is_ellipsis(&self) -> bool {
         Py2::<PyAny>::borrowed_from_gil_ref(&self).is_ellipsis()
     }
@@ -2557,6 +2558,7 @@ class SimpleClass:
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_is_ellipsis() {
         Python::with_gil(|py| {
             let v = py


### PR DESCRIPTION
Playing around with options to solve #3516, I noticed that we can implement `PyTypeInfo` without complication for the three singletons `Ellipsis`, `None`, and `PyNotImplemented`. So, here's the PR 😄 