### PR TITLE
enable cargo-semver-checks, try 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Check rust formatting (rustfmt)
         run: nox -s rustfmt
 
+  semver-checks:
+    if: github.ref != 'refs/heads/main'
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+
   check-msrv:
     needs: [fmt]
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.20.0"
+version = "0.21.0-dev"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -21,10 +21,10 @@ parking_lot = ">= 0.11, < 0.13"
 memoffset = "0.9"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.20.0" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.21.0-dev" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.20.0", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.21.0-dev", optional = true }
 indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
@@ -56,7 +56,7 @@ rayon = "1.6.1"
 widestring = "0.5.1"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "0.20.0", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "0.21.0-dev", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/Releasing.md
+++ b/Releasing.md
@@ -6,14 +6,16 @@ This is notes for the current process of releasing a new PyO3 version. Replace `
 
 Follow the process below to update all required pieces to bump the version. All these changes are done in a single commit because it makes it clear to git readers what happened to bump the version. It also makes it easy to cherry-pick the version bump onto the `main` branch when tidying up branch history at the end of the release process.
 
-1. Replace all instances of the PyO3 current version with the new version to be released. Places to check:
+1. Replace all instances of the PyO3 current version and the with the new version to be released. Places to check:
    - `Cargo.toml` for all PyO3 crates in the repository.
    - Examples in `README.md`
    - PyO3 version embedded into documentation like the README.
    - `pre-script.rhai` templates for the examples.
    - `[towncrier]` section in `pyproject.toml`.
 
-   Make sure not to modify the CHANGELOG during this step!
+   Some of the above locations may already have the new version with a `-dev` suffix, which needs to be removed.
+
+   **Make sure not to modify the CHANGELOG during this step!**
 
 2. Run `towncrier build` to generate the CHANGELOG. The version used by `towncrier` should automatically be correct because of the update to `pyproject.toml` in step 1.
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dev-dependencies]
-pyo3 = { version = "0.20.0", path = "..", features = ["auto-initialize", "extension-module"] }
+pyo3 = { path = "..", features = ["auto-initialize", "extension-module"] }
 
 [[example]]
 name = "decorator"

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.20.0"
+version = "0.21.0-dev"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.20.0"
+version = "0.21.0-dev"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -37,7 +37,7 @@ abi3-py311 = ["abi3", "pyo3-build-config/abi3-py311"]
 generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "0.20.0", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "0.21.0-dev", features = ["resolve-config"] }
 
 [lints]
 workspace = true

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.20.0"
+version = "0.21.0-dev"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.20.0"
+version = "0.21.0-dev"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -22,7 +22,7 @@ abi3 = ["pyo3-macros-backend/abi3"]
 proc-macro2 = { version = "1", default-features = false }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.20.0" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.21.0-dev" }
 
 [lints]
 workspace = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "0.20.0"
+version = "0.21.0-dev"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"


### PR DESCRIPTION
Closes #2984 

Many thanks @obi1kenobi for completing support of `#[doc(hidden)]` in `cargo-semver-checks`; I tested on 0.17, 0.18 and 0.19 branches and the good news is that all our releases there were semver compliant 🚀 

(I didn't try older branches 😂)