### PR TITLE
fix: replace removed `fmt` session by `rustfmt` and `ruff`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import nox
 
-nox.options.sessions = ["test", "clippy", "fmt", "docs"]
+nox.options.sessions = ["test", "clippy", "rustfmt", "ruff", "docs"]
 
 
 PYO3_DIR = Path(__file__).parent


### PR DESCRIPTION
Close #3592 