### PR TITLE
docs: fixup docs for smallvec feature

### DIFF
--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -159,3 +159,7 @@ struct User {
 }
 # }
 ```
+
+### `smallvec`
+
+Adds a dependency on [smallvec](https://docs.rs/smallvec) and enables conversions into its [`SmallVec`](https://docs.rs/smallvec/latest/smallvec/struct.SmallVec.html) type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,6 @@
 //! - [`eyre`]: Enables a conversion from [eyre]’s [`Report`] type to [`PyErr`].
 //! - [`hashbrown`]: Enables conversions between Python objects and [hashbrown]'s [`HashMap`] and
 //! [`HashSet`] types.
-//! - [`smallvec`][smallvec]: Enables conversions between Python list and [smallvec]'s [`SmallVec`].
 //! - [`indexmap`][indexmap_feature]: Enables conversions between Python dictionary and [indexmap]'s [`IndexMap`].
 //! - [`num-bigint`]: Enables conversions between Python objects and [num-bigint]'s [`BigInt`] and
 //! [`BigUint`] types.
@@ -95,6 +94,7 @@
 //! [`Decimal`] type.
 //! - [`serde`]: Allows implementing [serde]'s [`Serialize`] and [`Deserialize`] traits for
 //! [`Py`]`<T>` for all `T` that implement [`Serialize`] and [`Deserialize`].
+//! - [`smallvec`][smallvec]: Enables conversions between Python list and [smallvec]'s [`SmallVec`].
 //!
 //! ## Unstable features
 //!


### PR DESCRIPTION
While rebasing #3456 just now I noticed the `smallvec` docs were missing from the guide, and not in alphabetical order in the `lib.rs` docs.