### PR TITLE
ci: run beta clippy as an allowed-to-fail job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,17 @@ jobs:
             rust-target: "i686-pc-windows-msvc",
           },
         ]
+        include:
+          # Run beta clippy as a way to detect any incoming lints which may affect downstream users
+          - rust: beta
+            platform:
+              {
+                os: "ubuntu-latest",
+                python-architecture: "x64",
+                rust-target: "x86_64-unknown-linux-gnu",
+              }
     name: clippy/${{ matrix.platform.rust-target }}/${{ matrix.rust }}
+    continue-on-error: ${{ matrix.platform.rust != 'stable' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -31,7 +31,6 @@ pub(crate) mod pystate;
 pub(crate) mod pythonrun;
 // skipped sysmodule.h
 pub(crate) mod floatobject;
-#[cfg(not(PyPy))]
 pub(crate) mod pyframe;
 pub(crate) mod tupleobject;
 pub(crate) mod unicodeobject;
@@ -60,7 +59,7 @@ pub use self::object::*;
 pub use self::objimpl::*;
 pub use self::pydebug::*;
 pub use self::pyerrors::*;
-#[cfg(not(PyPy))]
+#[cfg(Py_3_11)]
 pub use self::pyframe::*;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub use self::pylifecycle::*;
@@ -69,4 +68,5 @@ pub use self::pystate::*;
 pub use self::pythonrun::*;
 pub use self::tupleobject::*;
 pub use self::unicodeobject::*;
+#[cfg(not(PyPy))]
 pub use self::weakrefobject::*;

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -66,7 +66,7 @@ mod test_serde {
         assert_eq!(user.username, "danya");
         assert!(user.group.is_none());
         assert_eq!(user.friends.len(), 1usize);
-        let friend = user.friends.get(0).unwrap();
+        let friend = user.friends.first().unwrap();
 
         Python::with_gil(|py| {
             assert_eq!(friend.borrow(py).username, "friend");


### PR DESCRIPTION
Following #3561 I thought it might be a good idea to have beta clippy running in our CI as an allowed-to-fail job; this can function as a canary giving us 6 weeks to release a fix before users are impacted by any new clippy failures in macro code.