### PR TITLE
replace `PyTryFrom` by splitting `PyTypeInfo`

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1108,8 +1108,10 @@ struct MyClass {
     # #[allow(dead_code)]
     num: i32,
 }
-unsafe impl pyo3::type_object::PyTypeInfo for MyClass {
+unsafe impl pyo3::type_object::HasPyGilRef for MyClass {
     type AsRefTarget = pyo3::PyCell<Self>;
+}
+unsafe impl pyo3::type_object::PyTypeInfo for MyClass {
     const NAME: &'static str = "MyClass";
     const MODULE: ::std::option::Option<&'static str> = ::std::option::Option::None;
     #[inline]

--- a/newsfragments/3600.changed.md
+++ b/newsfragments/3600.changed.md
@@ -1,0 +1,1 @@
+Split some `PyTypeInfo` functionality into new traits `HasPyGilRef` and `PyTypeCheck`.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -741,9 +741,11 @@ fn impl_pytypeinfo(
     };
 
     quote! {
-        unsafe impl _pyo3::type_object::PyTypeInfo for #cls {
+        unsafe impl _pyo3::type_object::HasPyGilRef for #cls {
             type AsRefTarget = _pyo3::PyCell<Self>;
+        }
 
+        unsafe impl _pyo3::type_object::PyTypeInfo for #cls {
             const NAME: &'static str = #cls_name;
             const MODULE: ::std::option::Option<&'static str> = #module;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,9 +294,8 @@
 //! [Features chapter of the guide]: https://pyo3.rs/latest/features.html#features-reference "Features Reference - PyO3 user guide"
 //! [`Ungil`]: crate::marker::Ungil
 pub use crate::class::*;
-pub use crate::conversion::{
-    AsPyPointer, FromPyObject, FromPyPointer, IntoPy, PyTryFrom, PyTryInto, ToPyObject,
-};
+pub use crate::conversion::{AsPyPointer, FromPyObject, FromPyPointer, IntoPy, ToPyObject};
+pub use crate::conversion::{PyTryFrom, PyTryInto};
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
 pub use crate::gil::GILPool;
 #[cfg(not(PyPy))]
@@ -306,7 +305,7 @@ pub use crate::marker::Python;
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};
 pub use crate::pyclass::PyClass;
 pub use crate::pyclass_init::PyClassInitializer;
-pub use crate::type_object::PyTypeInfo;
+pub use crate::type_object::{PyTypeCheck, PyTypeInfo};
 pub use crate::types::PyAny;
 pub use crate::version::PythonVersionInfo;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,7 +8,8 @@
 //! use pyo3::prelude::*;
 //! ```
 
-pub use crate::conversion::{FromPyObject, IntoPy, PyTryFrom, PyTryInto, ToPyObject};
+pub use crate::conversion::{FromPyObject, IntoPy, ToPyObject};
+pub use crate::conversion::{PyTryFrom, PyTryInto};
 pub use crate::err::{PyErr, PyResult};
 pub use crate::instance::{Py, PyObject};
 pub use crate::marker::Python;

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -207,7 +207,7 @@ use crate::{
     type_object::get_tp_free,
     PyTypeInfo,
 };
-use crate::{ffi, IntoPy, PyErr, PyNativeType, PyObject, PyResult, Python};
+use crate::{ffi, IntoPy, PyErr, PyNativeType, PyObject, PyResult, PyTypeCheck, Python};
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::mem::ManuallyDrop;
@@ -526,6 +526,17 @@ impl<T: PyClassImpl> PyCell<T> {
 
 unsafe impl<T: PyClassImpl> PyLayout<T> for PyCell<T> {}
 impl<T: PyClass> PySizedLayout<T> for PyCell<T> {}
+
+impl<T> PyTypeCheck for PyCell<T>
+where
+    T: PyClass,
+{
+    const NAME: &'static str = <T as PyTypeCheck>::NAME;
+
+    fn type_check(object: &PyAny) -> bool {
+        <T as PyTypeCheck>::type_check(object)
+    }
+}
 
 unsafe impl<T: PyClass> AsPyPointer for PyCell<T> {
     fn as_ptr(&self) -> *mut ffi::PyObject {

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -20,8 +20,6 @@ unsafe impl PyTypeInfo for PyEllipsis {
 
     const MODULE: Option<&'static str> = None;
 
-    type AsRefTarget = PyEllipsis;
-
     fn type_object_raw(_py: Python<'_>) -> *mut ffi::PyTypeObject {
         unsafe { ffi::Py_TYPE(ffi::Py_Ellipsis()) }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -192,8 +192,6 @@ macro_rules! pyobject_native_static_type_object(
 macro_rules! pyobject_native_type_info(
     ($name:ty, $typeobject:expr, $module:expr $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
         unsafe impl<$($generics,)*> $crate::type_object::PyTypeInfo for $name {
-            type AsRefTarget = Self;
-
             const NAME: &'static str = stringify!($name);
             const MODULE: ::std::option::Option<&'static str> = $module;
 
@@ -221,6 +219,7 @@ macro_rules! pyobject_native_type_info(
 macro_rules! pyobject_native_type_extract {
     ($name:ty $(;$generics:ident)*) => {
         impl<'py, $($generics,)*> $crate::FromPyObject<'py> for &'py $name {
+            #[inline]
             fn extract(obj: &'py $crate::PyAny) -> $crate::PyResult<Self> {
                 obj.downcast().map_err(::std::convert::Into::into)
             }

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -20,8 +20,6 @@ unsafe impl PyTypeInfo for PyNone {
 
     const MODULE: Option<&'static str> = None;
 
-    type AsRefTarget = PyNone;
-
     fn type_object_raw(_py: Python<'_>) -> *mut ffi::PyTypeObject {
         unsafe { ffi::Py_TYPE(ffi::Py_None()) }
     }

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -17,10 +17,7 @@ impl PyNotImplemented {
 
 unsafe impl PyTypeInfo for PyNotImplemented {
     const NAME: &'static str = "NotImplementedType";
-
     const MODULE: Option<&'static str> = None;
-
-    type AsRefTarget = PyNotImplemented;
 
     fn type_object_raw(_py: Python<'_>) -> *mut ffi::PyTypeObject {
         unsafe { ffi::Py_TYPE(ffi::Py_NotImplemented()) }

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -3,7 +3,7 @@
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
 use pyo3::prelude::*;
-use pyo3::{py_run, PyCell, PyTryInto};
+use pyo3::{py_run, PyCell};
 use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -215,7 +215,7 @@ fn inheritance_with_new_methods_with_drop() {
         let typeobj = py.get_type::<SubClassWithDrop>();
         let inst = typeobj.call((), None).unwrap();
 
-        let obj: &PyCell<SubClassWithDrop> = PyTryInto::try_into(inst).unwrap();
+        let obj: &PyCell<SubClassWithDrop> = inst.downcast().unwrap();
         let mut obj_ref_mut = obj.borrow_mut();
         obj_ref_mut.data = Some(Arc::clone(&drop_called1));
         let base: &mut BaseClassWithDrop = obj_ref_mut.as_mut();


### PR DESCRIPTION
This is a proposed resolution to #3516 and overall I think a positive incremental cleanup to our traits setup.

This PR splits `PyTypeInfo` into three traits:
 - `HasPyGilRef`, which can be removed in the near future when we get rid of the GIL refs, but will be useful in the short term. It defines the `AsRefTarget` associated type.
 - `PyTypeCheck`, which is used for types like `PyIterator`, `PySequence`, and `PyMapping`, as these can't implement `PyTypeInfo` as they don't have concrete type objects.
 - `PyTypeInfo`, which retains its existing API.

This then removes PyO3's internal dependency on `PyTryFrom`:
- `PyAny::downcast()` and `PyAnyMethods::downcast` use `PyTypeCheck`.
- `PyAny::downcast_exact()` and `PyAnyMethods::downcast_exact` to use `PyTypeInfo`.
- `PyAny::downcast_unchecked()` uses `HasPyGilRef`. (`PyAnyMethods::downcast_unchecked` needs no helper trait.)

From my experience playing around with #3382, e.g. in #3531, having this adjustment makes it much easier to work with `PyIterator`, `PySequence`, and `PyMapping` in code which is migrating between the two APIs. 