### PR TITLE
"full" implementation of new `Py2` API

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1253,7 +1253,7 @@ impl<'a, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'py> for &'a
     type Holder = ::std::option::Option<pyo3::PyRef<'py, MyClass>>;
 
     #[inline]
-    fn extract(obj: &'py pyo3::PyAny, holder: &'a mut Self::Holder) -> pyo3::PyResult<Self> {
+    fn extract(obj: pyo3::impl_::extract_argument::PyArg<'py>, holder: &'a mut Self::Holder) -> pyo3::PyResult<Self> {
         pyo3::impl_::extract_argument::extract_pyclass_ref(obj, holder)
     }
 }
@@ -1263,7 +1263,7 @@ impl<'a, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'py> for &'a
     type Holder = ::std::option::Option<pyo3::PyRefMut<'py, MyClass>>;
 
     #[inline]
-    fn extract(obj: &'py pyo3::PyAny, holder: &'a mut Self::Holder) -> pyo3::PyResult<Self> {
+    fn extract(obj: pyo3::impl_::extract_argument::PyArg<'py>, holder: &'a mut Self::Holder) -> pyo3::PyResult<Self> {
         pyo3::impl_::extract_argument::extract_pyclass_ref_mut(obj, holder)
     }
 }

--- a/pyo3-benches/benches/bench_call.rs
+++ b/pyo3-benches/benches/bench_call.rs
@@ -13,6 +13,7 @@ fn bench_call_0(b: &mut Bencher<'_>) {
         let module = test_module!(py, "def foo(): pass");
 
         let foo_module = module.getattr("foo").unwrap();
+        let foo_module = &foo_module.as_borrowed();
 
         b.iter(|| {
             for _ in 0..1000 {
@@ -34,6 +35,7 @@ class Foo:
         );
 
         let foo_module = module.getattr("Foo").unwrap().call0().unwrap();
+        let foo_module = &foo_module.as_borrowed();
 
         b.iter(|| {
             for _ in 0..1000 {

--- a/pyo3-benches/benches/bench_comparisons.rs
+++ b/pyo3-benches/benches/bench_comparisons.rs
@@ -45,8 +45,8 @@ impl OrderedRichcmp {
 
 fn bench_ordered_dunder_methods(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let obj1 = Py::new(py, OrderedDunderMethods(0)).unwrap().into_ref(py);
-        let obj2 = Py::new(py, OrderedDunderMethods(1)).unwrap().into_ref(py);
+        let obj1 = &Bound::new(py, OrderedDunderMethods(0)).unwrap().into_any();
+        let obj2 = &Bound::new(py, OrderedDunderMethods(1)).unwrap().into_any();
 
         b.iter(|| obj2.gt(obj1).unwrap());
     });
@@ -54,8 +54,8 @@ fn bench_ordered_dunder_methods(b: &mut Bencher<'_>) {
 
 fn bench_ordered_richcmp(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let obj1 = Py::new(py, OrderedRichcmp(0)).unwrap().into_ref(py);
-        let obj2 = Py::new(py, OrderedRichcmp(1)).unwrap().into_ref(py);
+        let obj1 = &Bound::new(py, OrderedRichcmp(0)).unwrap().into_any();
+        let obj2 = &Bound::new(py, OrderedRichcmp(1)).unwrap().into_any();
 
         b.iter(|| obj2.gt(obj1).unwrap());
     });

--- a/pyo3-benches/benches/bench_decimal.rs
+++ b/pyo3-benches/benches/bench_decimal.rs
@@ -17,6 +17,7 @@ py_dec = decimal.Decimal("0.0")
         )
         .unwrap();
         let py_dec = locals.get_item("py_dec").unwrap().unwrap();
+        let py_dec = &py_dec.as_borrowed();
 
         b.iter(|| {
             let _: Decimal = black_box(&py_dec).extract().unwrap();

--- a/pyo3-benches/benches/bench_extract.rs
+++ b/pyo3-benches/benches/bench_extract.rs
@@ -50,7 +50,7 @@ fn extract_str_downcast_fail(bench: &mut Bencher<'_>) {
 fn extract_int_extract_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let int_obj: PyObject = 123.into_py(py);
-        let int = int_obj.as_ref(py);
+        let int = int_obj.bind(py);
 
         bench.iter(|| {
             let v = black_box(int).extract::<i64>().unwrap();
@@ -73,7 +73,7 @@ fn extract_int_extract_fail(bench: &mut Bencher<'_>) {
 fn extract_int_downcast_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let int_obj: PyObject = 123.into_py(py);
-        let int = int_obj.as_ref(py);
+        let int = int_obj.bind(py);
 
         bench.iter(|| {
             let py_int = black_box(int).downcast::<PyInt>().unwrap();
@@ -97,7 +97,7 @@ fn extract_int_downcast_fail(bench: &mut Bencher<'_>) {
 fn extract_float_extract_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let float_obj: PyObject = 23.42.into_py(py);
-        let float = float_obj.as_ref(py);
+        let float = float_obj.bind(py);
 
         bench.iter(|| {
             let v = black_box(float).extract::<f64>().unwrap();
@@ -120,7 +120,7 @@ fn extract_float_extract_fail(bench: &mut Bencher<'_>) {
 fn extract_float_downcast_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let float_obj: PyObject = 23.42.into_py(py);
-        let float = float_obj.as_ref(py);
+        let float = float_obj.bind(py);
 
         bench.iter(|| {
             let py_int = black_box(float).downcast::<PyFloat>().unwrap();

--- a/pyo3-benches/benches/bench_frompyobject.rs
+++ b/pyo3-benches/benches/bench_frompyobject.rs
@@ -62,7 +62,7 @@ fn not_a_list_via_extract_enum(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let any: &Bound<'_, PyAny> = &PyString::new_bound(py, "foobar");
 
-        b.iter(|| match black_box(any).extract::<ListOrNotList<'_>>() {
+        b.iter(|| match black_box(&any).extract::<ListOrNotList<'_>>() {
             Ok(ListOrNotList::List(_list)) => panic!(),
             Ok(ListOrNotList::NotList(any)) => any,
             Err(_) => panic!(),

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -191,7 +191,7 @@ impl SelfType {
                 });
                 error_mode.handle_error(quote_spanned! { *span =>
                     _pyo3::impl_::extract_argument::#method::<#cls>(
-                        #py.from_borrowed_ptr::<_pyo3::PyAny>(#slf),
+                        _pyo3::impl_::extract_argument::PyArg::from_ptr(#py, #slf),
                         &mut #holder,
                     )
                 })

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -44,8 +44,8 @@ pub fn impl_arg_params(
             .collect::<Result<_>>()?;
         return Ok((
             quote! {
-                let _args = py.from_borrowed_ptr::<_pyo3::types::PyTuple>(_args);
-                let _kwargs: ::std::option::Option<&_pyo3::types::PyDict> = py.from_borrowed_ptr_or_opt(_kwargs);
+                let _args = _pyo3::impl_::extract_argument::PyArg::from_ptr(py, _args);
+                let _kwargs = _pyo3::impl_::extract_argument::PyArg::from_ptr_or_opt(py, _kwargs);
             },
             arg_convert,
         ));
@@ -132,7 +132,7 @@ pub fn impl_arg_params(
                     keyword_only_parameters: &[#(#keyword_only_parameters),*],
                 };
                 let mut #args_array = [::std::option::Option::None; #num_params];
-                let (_args, _kwargs) = #extract_expression;
+                let (_args, _kwargs) = &#extract_expression;
         },
         param_conversion,
     ))
@@ -180,7 +180,8 @@ fn impl_arg_param(
         let holder = push_holder();
         return Ok(quote_arg_span! {
             _pyo3::impl_::extract_argument::extract_argument(
-                _args,
+                #[allow(clippy::useless_conversion)]
+                ::std::convert::From::from(_args),
                 &mut #holder,
                 #name_str
             )?
@@ -193,7 +194,8 @@ fn impl_arg_param(
         let holder = push_holder();
         return Ok(quote_arg_span! {
             _pyo3::impl_::extract_argument::extract_optional_argument(
-                _kwargs.map(::std::convert::AsRef::as_ref),
+                #[allow(clippy::useless_conversion, clippy::redundant_closure)]
+                _kwargs.as_ref().map(|kwargs| ::std::convert::From::from(kwargs)),
                 &mut #holder,
                 #name_str,
                 || ::std::option::Option::None

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1369,7 +1369,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     type Holder = ::std::option::Option<_pyo3::PyRef<'py, #cls>>;
 
                     #[inline]
-                    fn extract(obj: &'py _pyo3::PyAny, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
+                    fn extract(obj: _pyo3::impl_::extract_argument::PyArg<'py>, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
                         _pyo3::impl_::extract_argument::extract_pyclass_ref(obj, holder)
                     }
                 }
@@ -1381,7 +1381,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     type Holder = ::std::option::Option<_pyo3::PyRef<'py, #cls>>;
 
                     #[inline]
-                    fn extract(obj: &'py _pyo3::PyAny, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
+                    fn extract(obj: _pyo3::impl_::extract_argument::PyArg<'py>, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
                         _pyo3::impl_::extract_argument::extract_pyclass_ref(obj, holder)
                     }
                 }
@@ -1391,7 +1391,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     type Holder = ::std::option::Option<_pyo3::PyRefMut<'py, #cls>>;
 
                     #[inline]
-                    fn extract(obj: &'py _pyo3::PyAny, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
+                    fn extract(obj: _pyo3::impl_::extract_argument::PyArg<'py>, holder: &'a mut Self::Holder) -> _pyo3::PyResult<Self> {
                         _pyo3::impl_::extract_argument::extract_pyclass_ref_mut(obj, holder)
                     }
                 }

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -16,6 +16,7 @@ pub(crate) fn ok_wrap(obj: TokenStream) -> TokenStream {
 
 pub(crate) fn map_result_into_ptr(result: TokenStream) -> TokenStream {
     quote! {
-        _pyo3::impl_::wrap::map_result_into_ptr(py, #result)
+        let result = _pyo3::impl_::wrap::map_result_into_ptr(py, #result);
+        result
     }
 }

--- a/pytests/src/pyfunctions.rs
+++ b/pytests/src/pyfunctions.rs
@@ -4,62 +4,66 @@ use pyo3::types::{PyDict, PyTuple};
 #[pyfunction(signature = ())]
 fn none() {}
 
+type Any<'py> = Bound<'py, PyAny>;
+type Dict<'py> = Bound<'py, PyDict>;
+type Tuple<'py> = Bound<'py, PyTuple>;
+
 #[pyfunction(signature = (a, b = None, *, c = None))]
-fn simple<'a>(
-    a: &'a PyAny,
-    b: Option<&'a PyAny>,
-    c: Option<&'a PyAny>,
-) -> (&'a PyAny, Option<&'a PyAny>, Option<&'a PyAny>) {
+fn simple<'py>(
+    a: Any<'py>,
+    b: Option<Any<'py>>,
+    c: Option<Any<'py>>,
+) -> (Any<'py>, Option<Any<'py>>, Option<Any<'py>>) {
     (a, b, c)
 }
 
 #[pyfunction(signature = (a, b = None, *args, c = None))]
-fn simple_args<'a>(
-    a: &'a PyAny,
-    b: Option<&'a PyAny>,
-    args: &'a PyTuple,
-    c: Option<&'a PyAny>,
-) -> (&'a PyAny, Option<&'a PyAny>, &'a PyTuple, Option<&'a PyAny>) {
+fn simple_args<'py>(
+    a: Any<'py>,
+    b: Option<Any<'py>>,
+    args: Tuple<'py>,
+    c: Option<Any<'py>>,
+) -> (Any<'py>, Option<Any<'py>>, Tuple<'py>, Option<Any<'py>>) {
     (a, b, args, c)
 }
 
 #[pyfunction(signature = (a, b = None, c = None, **kwargs))]
-fn simple_kwargs<'a>(
-    a: &'a PyAny,
-    b: Option<&'a PyAny>,
-    c: Option<&'a PyAny>,
-    kwargs: Option<&'a PyDict>,
+fn simple_kwargs<'py>(
+    a: Any<'py>,
+    b: Option<Any<'py>>,
+    c: Option<Any<'py>>,
+    kwargs: Option<Dict<'py>>,
 ) -> (
-    &'a PyAny,
-    Option<&'a PyAny>,
-    Option<&'a PyAny>,
-    Option<&'a PyDict>,
+    Any<'py>,
+    Option<Any<'py>>,
+    Option<Any<'py>>,
+    Option<Dict<'py>>,
 ) {
     (a, b, c, kwargs)
 }
 
 #[pyfunction(signature = (a, b = None, *args, c = None, **kwargs))]
-fn simple_args_kwargs<'a>(
-    a: &'a PyAny,
-    b: Option<&'a PyAny>,
-    args: &'a PyTuple,
-    c: Option<&'a PyAny>,
-    kwargs: Option<&'a PyDict>,
+fn simple_args_kwargs<'py>(
+    a: Any<'py>,
+    b: Option<Any<'py>>,
+    args: Tuple<'py>,
+    c: Option<Any<'py>>,
+    kwargs: Option<Dict<'py>>,
 ) -> (
-    &'a PyAny,
-    Option<&'a PyAny>,
-    &'a PyTuple,
-    Option<&'a PyAny>,
-    Option<&'a PyDict>,
+    Any<'py>,
+    Option<Any<'py>>,
+    Tuple<'py>,
+    Option<Any<'py>>,
+    Option<Dict<'py>>,
 ) {
     (a, b, args, c, kwargs)
 }
 
 #[pyfunction(signature = (*args, **kwargs))]
-fn args_kwargs<'a>(
-    args: &'a PyTuple,
-    kwargs: Option<&'a PyDict>,
-) -> (&'a PyTuple, Option<&'a PyDict>) {
+fn args_kwargs<'py>(
+    args: Tuple<'py>,
+    kwargs: Option<Dict<'py>>,
+) -> (Tuple<'py>, Option<Dict<'py>>) {
     (args, kwargs)
 }
 

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -151,7 +151,7 @@ macro_rules! complex_conversion {
                 unsafe {
                     let complex;
                     let obj = if obj.is_instance_of::<PyComplex>() {
-                        obj
+                        obj.clone()
                     } else if let Some(method) =
                         obj.lookup_special(crate::intern!(obj.py(), "__complex__"))?
                     {
@@ -161,7 +161,7 @@ macro_rules! complex_conversion {
                         // `obj` might still implement `__float__` or `__index__`, which will be
                         // handled by `PyComplex_{Real,Imag}AsDouble`, including propagating any
                         // errors if those methods don't exist / raise exceptions.
-                        obj
+                        obj.clone()
                     };
                     let ptr = obj.as_ptr();
                     let real = ffi::PyComplex_RealAsDouble(ptr);

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -151,7 +151,7 @@ macro_rules! complex_conversion {
                 unsafe {
                     let complex;
                     let obj = if obj.is_instance_of::<PyComplex>() {
-                        obj.clone()
+                        obj
                     } else if let Some(method) =
                         obj.lookup_special(crate::intern!(obj.py(), "__complex__"))?
                     {
@@ -161,7 +161,7 @@ macro_rules! complex_conversion {
                         // `obj` might still implement `__float__` or `__index__`, which will be
                         // handled by `PyComplex_{Real,Imag}AsDouble`, including propagating any
                         // errors if those methods don't exist / raise exceptions.
-                        obj.clone()
+                        obj
                     };
                     let ptr = obj.as_ptr();
                     let real = ffi::PyComplex_RealAsDouble(ptr);

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -875,15 +875,15 @@ impl PyErrArguments for PyDowncastErrorArguments {
 }
 
 /// Convert `PyDowncastError` to Python `TypeError`.
-impl<'a> std::convert::From<PyDowncastError<'a>> for PyErr {
+impl std::convert::From<PyDowncastError<'_>> for PyErr {
     fn from(err: PyDowncastError<'_>) -> PyErr {
         PyErr::from(err.0)
     }
 }
 
-impl<'a> std::error::Error for PyDowncastError<'a> {}
+impl std::error::Error for PyDowncastError<'_> {}
 
-impl<'a> std::fmt::Display for PyDowncastError<'a> {
+impl std::fmt::Display for PyDowncastError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         self.0.fmt(f)
     }

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -2,7 +2,7 @@ use crate::instance::Bound;
 use crate::panic::PanicException;
 use crate::type_object::PyTypeInfo;
 use crate::types::any::PyAnyMethods;
-use crate::types::{PyTraceback, PyType};
+use crate::types::{typeobject::PyTypeMethods, PyTraceback, PyType};
 use crate::{
     exceptions::{self, PyBaseException},
     ffi,

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     exceptions::{self, PyBaseException},
     ffi,
 };
-use crate::{IntoPy, Py, PyAny, PyNativeType, PyObject, Python, ToPyObject};
+use crate::{Borrowed, IntoPy, Py, PyAny, PyNativeType, PyObject, Python, ToPyObject};
 use std::borrow::Cow;
 use std::cell::UnsafeCell;
 use std::ffi::CString;
@@ -46,27 +46,29 @@ unsafe impl Sync for PyErr {}
 pub type PyResult<T> = Result<T, PyErr>;
 
 /// Error that indicates a failure to convert a PyAny to a more specific Python type.
-#[derive(Debug)]
-pub struct PyDowncastError<'a> {
-    from: &'a PyAny,
-    to: Cow<'static, str>,
-}
+pub struct PyDowncastError<'py>(DowncastError<'py, 'py>);
 
 impl<'a> PyDowncastError<'a> {
     /// Create a new `PyDowncastError` representing a failure to convert the object
     /// `from` into the type named in `to`.
     pub fn new(from: &'a PyAny, to: impl Into<Cow<'static, str>>) -> Self {
-        PyDowncastError {
-            from,
-            to: to.into(),
-        }
+        PyDowncastError(DowncastError::new_from_borrowed(from.as_borrowed(), to))
+    }
+}
+
+impl std::fmt::Debug for PyDowncastError<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PyDowncastError")
+            .field("from", &self.0.from)
+            .field("to", &self.0.to)
+            .finish()
     }
 }
 
 /// Error that indicates a failure to convert a PyAny to a more specific Python type.
 #[derive(Debug)]
 pub struct DowncastError<'a, 'py> {
-    from: &'a Bound<'py, PyAny>,
+    from: Borrowed<'a, 'py, PyAny>,
     to: Cow<'static, str>,
 }
 
@@ -74,6 +76,17 @@ impl<'a, 'py> DowncastError<'a, 'py> {
     /// Create a new `PyDowncastError` representing a failure to convert the object
     /// `from` into the type named in `to`.
     pub fn new(from: &'a Bound<'py, PyAny>, to: impl Into<Cow<'static, str>>) -> Self {
+        DowncastError {
+            from: from.as_borrowed(),
+            to: to.into(),
+        }
+    }
+
+    /// Similar to [`DowncastError::new`], but from a `Borrowed` instead of a `Bound`.
+    pub(crate) fn new_from_borrowed(
+        from: Borrowed<'a, 'py, PyAny>,
+        to: impl Into<Cow<'static, str>>,
+    ) -> Self {
         DowncastError {
             from,
             to: to.into(),
@@ -864,12 +877,7 @@ impl PyErrArguments for PyDowncastErrorArguments {
 /// Convert `PyDowncastError` to Python `TypeError`.
 impl<'a> std::convert::From<PyDowncastError<'a>> for PyErr {
     fn from(err: PyDowncastError<'_>) -> PyErr {
-        let args = PyDowncastErrorArguments {
-            from: err.from.get_type().into(),
-            to: err.to,
-        };
-
-        exceptions::PyTypeError::new_err(args)
+        PyErr::from(err.0)
     }
 }
 
@@ -877,7 +885,7 @@ impl<'a> std::error::Error for PyDowncastError<'a> {}
 
 impl<'a> std::fmt::Display for PyDowncastError<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        display_downcast_error(f, &self.from.as_borrowed(), &self.to)
+        self.0.fmt(f)
     }
 }
 
@@ -917,13 +925,13 @@ impl std::error::Error for DowncastIntoError<'_> {}
 
 impl std::fmt::Display for DowncastIntoError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        display_downcast_error(f, &self.from, &self.to)
+        display_downcast_error(f, self.from.as_borrowed(), &self.to)
     }
 }
 
 fn display_downcast_error(
     f: &mut std::fmt::Formatter<'_>,
-    from: &Bound<'_, PyAny>,
+    from: Borrowed<'_, '_, PyAny>,
     to: &str,
 ) -> std::fmt::Result {
     write!(

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -1,10 +1,54 @@
 use crate::{
     exceptions::PyTypeError,
     ffi,
+    ffi_ptr_ext::FfiPtrExt,
     pyclass::boolean_struct::False,
-    types::{PyDict, PyString, PyTuple},
-    Bound, FromPyObject, PyAny, PyClass, PyErr, PyRef, PyRefMut, PyResult, PyTypeCheck, Python,
+    types::{any::PyAnyMethods, dict::PyDictMethods, tuple::PyTupleMethods, PyDict, PyTuple},
+    Borrowed, Bound, FromPyObject, PyAny, PyClass, PyErr, PyRef, PyRefMut, PyResult, PyTypeCheck,
+    Python,
 };
+use crate::{PyObject, ToPyObject};
+
+/// Function argument extraction borrows input arguments.
+///
+/// This might potentially be removed in favour of just using `Borrowed` directly in future,
+/// for now it's used just to control the traits and methods available while the `Bound` API
+/// is being rounded out.
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct PyArg<'py>(Borrowed<'py, 'py, PyAny>);
+
+impl<'py> PyArg<'py> {
+    #[inline]
+    pub unsafe fn from_ptr_or_opt(py: Python<'py>, ptr: *mut ffi::PyObject) -> Option<Self> {
+        ptr.assume_borrowed_or_opt(py).map(Self)
+    }
+
+    #[inline]
+    pub unsafe fn from_ptr(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
+        Self(ptr.assume_borrowed(py))
+    }
+}
+
+// These two `From` implementations help make various macro code pieces compile
+impl<'py, T> From<&'py Bound<'py, T>> for PyArg<'py> {
+    fn from(other: &'py Bound<'py, T>) -> Self {
+        Self(Borrowed::from(other.as_any()))
+    }
+}
+
+impl<'py> From<&'_ Self> for PyArg<'py> {
+    fn from(other: &'_ Self) -> Self {
+        Self(other.0)
+    }
+}
+
+impl ToPyObject for PyArg<'_> {
+    #[inline]
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        self.0.to_object(py)
+    }
+}
 
 /// A trait which is used to help PyO3 macros extract function arguments.
 ///
@@ -16,7 +60,7 @@ use crate::{
 /// There exists a trivial blanket implementation for `T: FromPyObject` with `Holder = ()`.
 pub trait PyFunctionArgument<'a, 'py>: Sized + 'a {
     type Holder: FunctionArgumentHolder;
-    fn extract(obj: &'py PyAny, holder: &'a mut Self::Holder) -> PyResult<Self>;
+    fn extract(obj: PyArg<'py>, holder: &'a mut Self::Holder) -> PyResult<Self>;
 }
 
 impl<'a, 'py, T> PyFunctionArgument<'a, 'py> for T
@@ -26,20 +70,20 @@ where
     type Holder = ();
 
     #[inline]
-    fn extract(obj: &'py PyAny, _: &'a mut ()) -> PyResult<Self> {
-        obj.extract()
+    fn extract(obj: PyArg<'py>, _: &'a mut ()) -> PyResult<Self> {
+        obj.0.extract()
     }
 }
 
-impl<'a, 'py, T> PyFunctionArgument<'a, 'py> for &'a Bound<'py, T>
+impl<'a, 'py, T: 'py> PyFunctionArgument<'a, 'py> for &'a Bound<'py, T>
 where
     T: PyTypeCheck,
 {
-    type Holder = Option<Bound<'py, T>>;
+    type Holder = Option<Borrowed<'py, 'py, T>>;
 
     #[inline]
-    fn extract(obj: &'py PyAny, holder: &'a mut Option<Bound<'py, T>>) -> PyResult<Self> {
-        Ok(&*holder.insert(obj.extract()?))
+    fn extract(obj: PyArg<'py>, holder: &'a mut Option<Borrowed<'py, 'py, T>>) -> PyResult<Self> {
+        Ok(&*holder.insert(obj.0.downcast()?))
     }
 }
 
@@ -59,24 +103,24 @@ impl<T> FunctionArgumentHolder for Option<T> {
 
 #[inline]
 pub fn extract_pyclass_ref<'a, 'py: 'a, T: PyClass>(
-    obj: &'py PyAny,
+    obj: PyArg<'py>,
     holder: &'a mut Option<PyRef<'py, T>>,
 ) -> PyResult<&'a T> {
-    Ok(&*holder.insert(obj.extract()?))
+    Ok(&*holder.insert(obj.0.extract()?))
 }
 
 #[inline]
 pub fn extract_pyclass_ref_mut<'a, 'py: 'a, T: PyClass<Frozen = False>>(
-    obj: &'py PyAny,
+    obj: PyArg<'py>,
     holder: &'a mut Option<PyRefMut<'py, T>>,
 ) -> PyResult<&'a mut T> {
-    Ok(&mut *holder.insert(obj.extract()?))
+    Ok(&mut *holder.insert(obj.0.extract()?))
 }
 
 /// The standard implementation of how PyO3 extracts a `#[pyfunction]` or `#[pymethod]` function argument.
 #[doc(hidden)]
 pub fn extract_argument<'a, 'py, T>(
-    obj: &'py PyAny,
+    obj: PyArg<'py>,
     holder: &'a mut T::Holder,
     arg_name: &str,
 ) -> PyResult<T>
@@ -85,7 +129,7 @@ where
 {
     match PyFunctionArgument::extract(obj, holder) {
         Ok(value) => Ok(value),
-        Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e)),
+        Err(e) => Err(argument_extraction_error(obj.0.py(), arg_name, e)),
     }
 }
 
@@ -93,7 +137,7 @@ where
 /// does not implement `PyFunctionArgument` for `T: PyClass`.
 #[doc(hidden)]
 pub fn extract_optional_argument<'a, 'py, T>(
-    obj: Option<&'py PyAny>,
+    obj: Option<PyArg<'py>>,
     holder: &'a mut T::Holder,
     arg_name: &str,
     default: fn() -> Option<T>,
@@ -103,7 +147,7 @@ where
 {
     match obj {
         Some(obj) => {
-            if obj.is_none() {
+            if obj.0.is_none() {
                 // Explicit `None` will result in None being used as the function argument
                 Ok(None)
             } else {
@@ -117,7 +161,7 @@ where
 /// Alternative to [`extract_argument`] used when the argument has a default value provided by an annotation.
 #[doc(hidden)]
 pub fn extract_argument_with_default<'a, 'py, T>(
-    obj: Option<&'py PyAny>,
+    obj: Option<PyArg<'py>>,
     holder: &'a mut T::Holder,
     arg_name: &str,
     default: fn() -> T,
@@ -134,20 +178,20 @@ where
 /// Alternative to [`extract_argument`] used when the argument has a `#[pyo3(from_py_with)]` annotation.
 #[doc(hidden)]
 pub fn from_py_with<'py, T>(
-    obj: &'py PyAny,
+    obj: PyArg<'py>,
     arg_name: &str,
     extractor: fn(&'py PyAny) -> PyResult<T>,
 ) -> PyResult<T> {
-    match extractor(obj) {
+    match extractor(obj.0.into_gil_ref()) {
         Ok(value) => Ok(value),
-        Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e)),
+        Err(e) => Err(argument_extraction_error(obj.0.py(), arg_name, e)),
     }
 }
 
 /// Alternative to [`extract_argument`] used when the argument has a `#[pyo3(from_py_with)]` annotation and also a default value.
 #[doc(hidden)]
 pub fn from_py_with_with_default<'py, T>(
-    obj: Option<&'py PyAny>,
+    obj: Option<PyArg<'py>>,
     arg_name: &str,
     extractor: fn(&'py PyAny) -> PyResult<T>,
     default: fn() -> T,
@@ -165,7 +209,6 @@ pub fn from_py_with_with_default<'py, T>(
 #[doc(hidden)]
 #[cold]
 pub fn argument_extraction_error(py: Python<'_>, arg_name: &str, error: PyErr) -> PyErr {
-    use crate::types::any::PyAnyMethods;
     if error.get_type_bound(py).is(py.get_type::<PyTypeError>()) {
         let remapped_error =
             PyTypeError::new_err(format!("argument '{}': {}", arg_name, error.value(py)));
@@ -183,7 +226,7 @@ pub fn argument_extraction_error(py: Python<'_>, arg_name: &str, error: PyErr) -
 /// `argument` must not be `None`
 #[doc(hidden)]
 #[inline]
-pub unsafe fn unwrap_required_argument(argument: Option<&PyAny>) -> &PyAny {
+pub unsafe fn unwrap_required_argument(argument: Option<PyArg<'_>>) -> PyArg<'_> {
     match argument {
         Some(value) => value,
         #[cfg(debug_assertions)]
@@ -230,7 +273,7 @@ impl FunctionDescription {
         args: *const *mut ffi::PyObject,
         nargs: ffi::Py_ssize_t,
         kwnames: *mut ffi::PyObject,
-        output: &mut [Option<&'py PyAny>],
+        output: &mut [Option<PyArg<'py>>],
     ) -> PyResult<(V::Varargs, K::Varkeywords)>
     where
         V: VarargsHandler<'py>,
@@ -247,8 +290,8 @@ impl FunctionDescription {
         );
 
         // Handle positional arguments
-        // Safety: Option<&PyAny> has the same memory layout as `*mut ffi::PyObject`
-        let args: *const Option<&PyAny> = args.cast();
+        // Safety: Option<PyArg> has the same memory layout as `*mut ffi::PyObject`
+        let args: *const Option<PyArg<'py>> = args.cast();
         let positional_args_provided = nargs as usize;
         let remaining_positional_args = if args.is_null() {
             debug_assert_eq!(positional_args_provided, 0);
@@ -268,13 +311,21 @@ impl FunctionDescription {
 
         // Handle keyword arguments
         let mut varkeywords = K::Varkeywords::default();
-        if let Some(kwnames) = py.from_borrowed_ptr_or_opt::<PyTuple>(kwnames) {
+
+        // Safety: kwnames is known to be a pointer to a tuple, or null
+        let kwnames: &'py Option<Bound<'py, PyTuple>> = std::mem::transmute(&kwnames);
+        if let Some(kwnames) = kwnames.as_ref() {
             // Safety: &PyAny has the same memory layout as `*mut ffi::PyObject`
-            let kwargs =
-                ::std::slice::from_raw_parts((args as *const &PyAny).offset(nargs), kwnames.len());
+            let kwargs = ::std::slice::from_raw_parts(
+                (args as *const PyArg<'py>).offset(nargs),
+                kwnames.len(),
+            );
 
             self.handle_kwargs::<K, _>(
-                kwnames.iter().zip(kwargs.iter().copied()),
+                kwnames
+                    .iter_borrowed()
+                    .map(PyArg)
+                    .zip(kwargs.iter().copied()),
                 &mut varkeywords,
                 num_positional_parameters,
                 output,
@@ -303,17 +354,20 @@ impl FunctionDescription {
     /// - `kwargs` must be a pointer to a PyDict, or NULL.
     pub unsafe fn extract_arguments_tuple_dict<'py, V, K>(
         &self,
-        py: Python<'py>,
+        _py: Python<'py>,
         args: *mut ffi::PyObject,
         kwargs: *mut ffi::PyObject,
-        output: &mut [Option<&'py PyAny>],
+        output: &mut [Option<PyArg<'py>>],
     ) -> PyResult<(V::Varargs, K::Varkeywords)>
     where
         V: VarargsHandler<'py>,
         K: VarkeywordsHandler<'py>,
     {
-        let args = py.from_borrowed_ptr::<PyTuple>(args);
-        let kwargs: ::std::option::Option<&PyDict> = py.from_borrowed_ptr_or_opt(kwargs);
+        // Safety: Bound has the same layout as a raw pointer, and reference is known to be
+        // borrowed for 'py.
+        let args: &'py Bound<'py, PyTuple> = std::mem::transmute(&args);
+        let kwargs: &'py Option<Bound<'py, PyDict>> = std::mem::transmute(&kwargs);
+        let kwargs = kwargs.as_ref();
 
         let num_positional_parameters = self.positional_parameter_names.len();
 
@@ -325,8 +379,12 @@ impl FunctionDescription {
         );
 
         // Copy positional arguments into output
-        for (i, arg) in args.iter().take(num_positional_parameters).enumerate() {
-            output[i] = Some(arg);
+        for (i, arg) in args
+            .iter_borrowed()
+            .take(num_positional_parameters)
+            .enumerate()
+        {
+            output[i] = Some(PyArg(arg));
         }
 
         // If any arguments remain, push them to varargs (if possible) or error
@@ -335,7 +393,12 @@ impl FunctionDescription {
         // Handle keyword arguments
         let mut varkeywords = K::Varkeywords::default();
         if let Some(kwargs) = kwargs {
-            self.handle_kwargs::<K, _>(kwargs, &mut varkeywords, num_positional_parameters, output)?
+            self.handle_kwargs::<K, _>(
+                kwargs.iter_borrowed().map(|(k, v)| (PyArg(k), PyArg(v))),
+                &mut varkeywords,
+                num_positional_parameters,
+                output,
+            )?
         }
 
         // Once all inputs have been processed, check that all required arguments have been provided.
@@ -352,11 +415,11 @@ impl FunctionDescription {
         kwargs: I,
         varkeywords: &mut K::Varkeywords,
         num_positional_parameters: usize,
-        output: &mut [Option<&'py PyAny>],
+        output: &mut [Option<PyArg<'py>>],
     ) -> PyResult<()>
     where
         K: VarkeywordsHandler<'py>,
-        I: IntoIterator<Item = (&'py PyAny, &'py PyAny)>,
+        I: IntoIterator<Item = (PyArg<'py>, PyArg<'py>)>,
     {
         debug_assert_eq!(
             num_positional_parameters,
@@ -368,11 +431,25 @@ impl FunctionDescription {
         );
         let mut positional_only_keyword_arguments = Vec::new();
         for (kwarg_name_py, value) in kwargs {
-            // All keyword arguments should be UTF-8 strings, but we'll check, just in case.
-            // If it isn't, then it will be handled below as a varkeyword (which may raise an
-            // error if this function doesn't accept **kwargs). Rust source is always UTF-8
-            // and so all argument names in `#[pyfunction]` signature must be UTF-8.
-            if let Ok(kwarg_name) = kwarg_name_py.downcast::<PyString>()?.to_str() {
+            // Safety: All keyword arguments should be UTF-8 strings, but if it's not, `.to_str()`
+            // will return an error anyway.
+            #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+            let kwarg_name = unsafe {
+                kwarg_name_py
+                    .0
+                    .downcast_unchecked::<crate::types::PyString>()
+            }
+            .to_str();
+
+            #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
+            let kwarg_name = kwarg_name_py.0.extract::<crate::py_backed::PyBackedStr>();
+
+            if let Ok(kwarg_name_owned) = kwarg_name {
+                #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+                let kwarg_name = kwarg_name_owned;
+                #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
+                let kwarg_name: &str = &kwarg_name_owned;
+
                 // Try to place parameter in keyword only parameters
                 if let Some(i) = self.find_keyword_parameter_in_keyword_only(kwarg_name) {
                     if output[i + num_positional_parameters]
@@ -391,7 +468,7 @@ impl FunctionDescription {
                         // kwarg to conflict with a postional-only argument - the value
                         // will go into **kwargs anyway.
                         if K::handle_varkeyword(varkeywords, kwarg_name_py, value, self).is_err() {
-                            positional_only_keyword_arguments.push(kwarg_name);
+                            positional_only_keyword_arguments.push(kwarg_name_owned);
                         }
                     } else if output[i].replace(value).is_some() {
                         return Err(self.multiple_values_for_argument(kwarg_name));
@@ -404,6 +481,11 @@ impl FunctionDescription {
         }
 
         if !positional_only_keyword_arguments.is_empty() {
+            #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
+            let positional_only_keyword_arguments: Vec<_> = positional_only_keyword_arguments
+                .iter()
+                .map(std::ops::Deref::deref)
+                .collect();
             return Err(self.positional_only_keyword_arguments(&positional_only_keyword_arguments));
         }
 
@@ -430,7 +512,7 @@ impl FunctionDescription {
     #[inline]
     fn ensure_no_missing_required_positional_arguments(
         &self,
-        output: &[Option<&PyAny>],
+        output: &[Option<PyArg<'_>>],
         positional_args_provided: usize,
     ) -> PyResult<()> {
         if positional_args_provided < self.required_positional_parameters {
@@ -446,7 +528,7 @@ impl FunctionDescription {
     #[inline]
     fn ensure_no_missing_required_keyword_arguments(
         &self,
-        output: &[Option<&PyAny>],
+        output: &[Option<PyArg<'_>>],
     ) -> PyResult<()> {
         let keyword_output = &output[self.positional_parameter_names.len()..];
         for (param, out) in self.keyword_only_parameters.iter().zip(keyword_output) {
@@ -491,11 +573,11 @@ impl FunctionDescription {
     }
 
     #[cold]
-    fn unexpected_keyword_argument(&self, argument: &PyAny) -> PyErr {
+    fn unexpected_keyword_argument(&self, argument: PyArg<'_>) -> PyErr {
         PyTypeError::new_err(format!(
             "{} got an unexpected keyword argument '{}'",
             self.full_name(),
-            argument
+            argument.0.as_any()
         ))
     }
 
@@ -528,7 +610,7 @@ impl FunctionDescription {
     }
 
     #[cold]
-    fn missing_required_keyword_arguments(&self, keyword_outputs: &[Option<&PyAny>]) -> PyErr {
+    fn missing_required_keyword_arguments(&self, keyword_outputs: &[Option<PyArg<'_>>]) -> PyErr {
         debug_assert_eq!(self.keyword_only_parameters.len(), keyword_outputs.len());
 
         let missing_keyword_only_arguments: Vec<_> = self
@@ -549,7 +631,7 @@ impl FunctionDescription {
     }
 
     #[cold]
-    fn missing_required_positional_arguments(&self, output: &[Option<&PyAny>]) -> PyErr {
+    fn missing_required_positional_arguments(&self, output: &[Option<PyArg<'_>>]) -> PyErr {
         let missing_positional_arguments: Vec<_> = self
             .positional_parameter_names
             .iter()
@@ -569,14 +651,14 @@ pub trait VarargsHandler<'py> {
     /// Called by `FunctionDescription::extract_arguments_fastcall` with any additional arguments.
     fn handle_varargs_fastcall(
         py: Python<'py>,
-        varargs: &[Option<&PyAny>],
+        varargs: &[Option<PyArg<'py>>],
         function_description: &FunctionDescription,
     ) -> PyResult<Self::Varargs>;
     /// Called by `FunctionDescription::extract_arguments_tuple_dict` with the original tuple.
     ///
     /// Additional arguments are those in the tuple slice starting from `function_description.positional_parameter_names.len()`.
     fn handle_varargs_tuple(
-        args: &'py PyTuple,
+        args: &Bound<'py, PyTuple>,
         function_description: &FunctionDescription,
     ) -> PyResult<Self::Varargs>;
 }
@@ -590,7 +672,7 @@ impl<'py> VarargsHandler<'py> for NoVarargs {
     #[inline]
     fn handle_varargs_fastcall(
         _py: Python<'py>,
-        varargs: &[Option<&PyAny>],
+        varargs: &[Option<PyArg<'py>>],
         function_description: &FunctionDescription,
     ) -> PyResult<Self::Varargs> {
         let extra_arguments = varargs.len();
@@ -604,7 +686,7 @@ impl<'py> VarargsHandler<'py> for NoVarargs {
 
     #[inline]
     fn handle_varargs_tuple(
-        args: &'py PyTuple,
+        args: &Bound<'py, PyTuple>,
         function_description: &FunctionDescription,
     ) -> PyResult<Self::Varargs> {
         let positional_parameter_count = function_description.positional_parameter_names.len();
@@ -621,19 +703,19 @@ impl<'py> VarargsHandler<'py> for NoVarargs {
 pub struct TupleVarargs;
 
 impl<'py> VarargsHandler<'py> for TupleVarargs {
-    type Varargs = &'py PyTuple;
+    type Varargs = Bound<'py, PyTuple>;
     #[inline]
     fn handle_varargs_fastcall(
         py: Python<'py>,
-        varargs: &[Option<&PyAny>],
+        varargs: &[Option<PyArg<'py>>],
         _function_description: &FunctionDescription,
     ) -> PyResult<Self::Varargs> {
-        Ok(PyTuple::new_bound(py, varargs).into_gil_ref())
+        Ok(PyTuple::new_bound(py, varargs))
     }
 
     #[inline]
     fn handle_varargs_tuple(
-        args: &'py PyTuple,
+        args: &Bound<'py, PyTuple>,
         function_description: &FunctionDescription,
     ) -> PyResult<Self::Varargs> {
         let positional_parameters = function_description.positional_parameter_names.len();
@@ -646,8 +728,8 @@ pub trait VarkeywordsHandler<'py> {
     type Varkeywords: Default;
     fn handle_varkeyword(
         varkeywords: &mut Self::Varkeywords,
-        name: &'py PyAny,
-        value: &'py PyAny,
+        name: PyArg<'py>,
+        value: PyArg<'py>,
         function_description: &FunctionDescription,
     ) -> PyResult<()>;
 }
@@ -660,8 +742,8 @@ impl<'py> VarkeywordsHandler<'py> for NoVarkeywords {
     #[inline]
     fn handle_varkeyword(
         _varkeywords: &mut Self::Varkeywords,
-        name: &'py PyAny,
-        _value: &'py PyAny,
+        name: PyArg<'py>,
+        _value: PyArg<'py>,
         function_description: &FunctionDescription,
     ) -> PyResult<()> {
         Err(function_description.unexpected_keyword_argument(name))
@@ -672,28 +754,29 @@ impl<'py> VarkeywordsHandler<'py> for NoVarkeywords {
 pub struct DictVarkeywords;
 
 impl<'py> VarkeywordsHandler<'py> for DictVarkeywords {
-    type Varkeywords = Option<&'py PyDict>;
+    type Varkeywords = Option<Bound<'py, PyDict>>;
     #[inline]
     fn handle_varkeyword(
         varkeywords: &mut Self::Varkeywords,
-        name: &'py PyAny,
-        value: &'py PyAny,
+        name: PyArg<'py>,
+        value: PyArg<'py>,
         _function_description: &FunctionDescription,
     ) -> PyResult<()> {
         varkeywords
-            .get_or_insert_with(|| PyDict::new_bound(name.py()).into_gil_ref())
+            .get_or_insert_with(|| PyDict::new_bound(name.0.py()))
             .set_item(name, value)
     }
 }
 
 fn push_parameter_list(msg: &mut String, parameter_names: &[&str]) {
+    let len = parameter_names.len();
     for (i, parameter) in parameter_names.iter().enumerate() {
         if i != 0 {
-            if parameter_names.len() > 2 {
+            if len > 2 {
                 msg.push(',');
             }
 
-            if i == parameter_names.len() - 1 {
+            if i == len - 1 {
                 msg.push_str(" and ")
             } else {
                 msg.push(' ')
@@ -772,7 +855,7 @@ mod tests {
             };
             assert_eq!(
                 err.to_string(),
-                "TypeError: 'int' object cannot be converted to 'PyString'"
+                "TypeError: example() got an unexpected keyword argument '1'"
             );
         })
     }

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -3,9 +3,7 @@ use crate::exceptions::PyStopAsyncIteration;
 use crate::gil::LockGIL;
 use crate::impl_::panic::PanicTrap;
 use crate::internal_tricks::extract_c_string;
-use crate::{
-    ffi, PyAny, PyCell, PyClass, PyErr, PyObject, PyResult, PyTraverseError, PyVisit, Python,
-};
+use crate::{ffi, PyCell, PyClass, PyErr, PyObject, PyResult, PyTraverseError, PyVisit, Python};
 use std::borrow::Cow;
 use std::ffi::CStr;
 use std::fmt;
@@ -34,14 +32,15 @@ pub type ipowfunc = unsafe extern "C" fn(
 impl IPowModulo {
     #[cfg(Py_3_8)]
     #[inline]
-    pub fn to_borrowed_any(self, py: Python<'_>) -> &PyAny {
-        unsafe { py.from_borrowed_ptr::<PyAny>(self.0) }
+    pub fn as_ptr(self) -> *mut ffi::PyObject {
+        self.0
     }
 
     #[cfg(not(Py_3_8))]
     #[inline]
-    pub fn to_borrowed_any(self, py: Python<'_>) -> &PyAny {
-        unsafe { py.from_borrowed_ptr::<PyAny>(ffi::Py_None()) }
+    pub fn as_ptr(self) -> *mut ffi::PyObject {
+        // Safety: returning a borrowed pointer to Python `None` singleton
+        unsafe { ffi::Py_None() }
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -137,6 +137,18 @@ impl<'py> Bound<'py, PyAny> {
     ) -> PyResult<Self> {
         Py::from_owned_ptr_or_err(py, ptr).map(|obj| Self(py, ManuallyDrop::new(obj)))
     }
+
+    /// Constructs a new Bound from a borrowed pointer, incrementing the reference count.
+    /// Returns None if ptr is null.
+    ///
+    /// # Safety
+    /// ptr must be a valid pointer to a Python object, or NULL.
+    pub unsafe fn from_borrowed_ptr_or_opt(
+        py: Python<'py>,
+        ptr: *mut ffi::PyObject,
+    ) -> Option<Self> {
+        Py::from_borrowed_ptr_or_opt(py, ptr).map(|obj| Self(py, ManuallyDrop::new(obj)))
+    }
 }
 
 impl<'py, T> Bound<'py, T>
@@ -1194,7 +1206,7 @@ impl<T> Py<T> {
     where
         D: FromPyObject<'py>,
     {
-        FromPyObject::extract(unsafe { py.from_borrowed_ptr(self.as_ptr()) })
+        self.bind(py).as_any().extract()
     }
 
     /// Retrieves an attribute value.

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -3,8 +3,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::pycell::{PyBorrowError, PyBorrowMutError, PyCell};
 use crate::pyclass::boolean_struct::{False, True};
 use crate::type_object::HasPyGilRef;
-use crate::types::any::PyAnyMethods;
-use crate::types::string::PyStringMethods;
+use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
 use crate::types::{PyDict, PyString, PyTuple};
 use crate::{
     ffi, AsPyPointer, DowncastError, FromPyObject, IntoPy, PyAny, PyClass, PyClassInitializer,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -149,6 +149,14 @@ impl<'py> Bound<'py, PyAny> {
     ) -> Option<Self> {
         Py::from_borrowed_ptr_or_opt(py, ptr).map(|obj| Self(py, ManuallyDrop::new(obj)))
     }
+
+    /// Constructs a new Bound from a borrowed pointer, incrementing the reference count.
+    ///
+    /// # Safety
+    /// ptr must be a valid pointer to a Python object.
+    pub unsafe fn from_borrowed_ptr_unchecked(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
+        Self::from_borrowed_ptr_or_opt(py, ptr).unwrap()
+    }
 }
 
 impl<'py, T> Bound<'py, T>
@@ -511,7 +519,8 @@ impl<'a, 'py> Borrowed<'a, 'py, PyAny> {
     /// This is similar to `std::slice::from_raw_parts`, the lifetime `'a` is completely defined by
     /// the caller and it's the caller's responsibility to ensure that the reference this is
     /// derived from is valid for the lifetime `'a`.
-    pub(crate) unsafe fn from_ptr_unchecked(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
+    #[doc(hidden)] // Used in macro code.
+    pub unsafe fn from_ptr_unchecked(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
         Self(NonNull::new_unchecked(ptr), PhantomData, py)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,6 +426,7 @@ pub mod marshal;
 pub mod sync;
 pub mod panic;
 pub mod prelude;
+pub mod py_backed;
 pub mod pycell;
 pub mod pyclass;
 pub mod pyclass_init;

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -744,6 +744,14 @@ impl<'py> Python<'py> {
         PyModule::import(self, name)
     }
 
+    /// Imports the Python module with the specified name.
+    pub fn import_bound<N>(self, name: N) -> PyResult<Bound<'py, PyModule>>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        PyModule::import_bound(self, name)
+    }
+
     /// Gets the Python builtin value `None`.
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -41,3 +41,4 @@ pub use crate::types::set::PySetMethods;
 pub use crate::types::string::PyStringMethods;
 pub use crate::types::traceback::PyTracebackMethods;
 pub use crate::types::tuple::PyTupleMethods;
+pub use crate::types::typeobject::PyTypeMethods;

--- a/src/py_backed.rs
+++ b/src/py_backed.rs
@@ -1,0 +1,121 @@
+//! This module provides some wrappers around `str` and `[u8]` where the storage is owned by a Python `str` or `bytes` object.
+//!
+//! This can help avoid copying text or byte data sourced from Python.
+
+use std::ops::Deref;
+
+use crate::{
+    types::{
+        any::PyAnyMethods, bytearray::PyByteArrayMethods, bytes::PyBytesMethods,
+        string::PyStringMethods, PyByteArray, PyBytes, PyString,
+    },
+    Bound, DowncastError, FromPyObject, Py, PyAny, PyResult,
+};
+
+/// A wrapper around `str` where the storage is owned by a Python `bytes` or `str` object.
+///
+/// This type gives access to the underlying data via a `Deref` implementation.
+pub struct PyBackedStr {
+    #[allow(dead_code)]
+    storage: PyBackedStrStorage,
+    data: *const u8,
+    length: usize,
+}
+
+#[allow(dead_code)]
+enum PyBackedStrStorage {
+    String(Py<PyString>),
+    Bytes(Py<PyBytes>),
+}
+
+impl Deref for PyBackedStr {
+    type Target = str;
+    fn deref(&self) -> &str {
+        unsafe {
+            // Safety: `data` is a pointer to the start of a valid UTF-8 string of length `length`.
+            std::str::from_utf8_unchecked(std::slice::from_raw_parts(self.data, self.length))
+        }
+    }
+}
+
+impl FromPyObject<'_> for PyBackedStr {
+    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let py_string = obj.downcast::<PyString>()?;
+        #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+        {
+            let s = py_string.to_str()?;
+            let data = s.as_ptr();
+            let length = s.len();
+            Ok(Self {
+                storage: PyBackedStrStorage::String(py_string.to_owned().unbind()),
+                data,
+                length,
+            })
+        }
+        #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
+        {
+            let bytes = py_string.encode_utf8()?;
+            let b = bytes.as_bytes();
+            let data = b.as_ptr();
+            let length = b.len();
+            Ok(Self {
+                storage: PyBackedStrStorage::Bytes(bytes.unbind()),
+                data,
+                length,
+            })
+        }
+    }
+}
+
+/// A wrapper around `[u8]` where the storage is either owned by a Python `bytes` object, or a Rust `Vec<u8>`.
+///
+/// This type gives access to the underlying data via a `Deref` implementation.
+pub struct PyBackedBytes {
+    #[allow(dead_code)] // only held so that the storage is not dropped
+    storage: PyBackedBytesStorage,
+    data: *const u8,
+    length: usize,
+}
+
+enum PyBackedBytesStorage {
+    Python(Py<PyBytes>),
+    Rust(Vec<u8>),
+}
+
+impl Deref for PyBackedBytes {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        unsafe {
+            // Safety: `data` is a pointer to the start of a buffer of length `length`.
+            std::slice::from_raw_parts(self.data, self.length)
+        }
+    }
+}
+
+impl FromPyObject<'_> for PyBackedBytes {
+    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        if let Ok(bytes) = obj.downcast::<PyBytes>() {
+            let b = bytes.as_bytes();
+            let data = b.as_ptr();
+            let len = b.len();
+            return Ok(Self {
+                storage: PyBackedBytesStorage::Python(bytes.to_owned().unbind()),
+                data,
+                length: len,
+            });
+        }
+
+        if let Ok(bytearray) = obj.downcast::<PyByteArray>() {
+            let s = bytearray.to_vec();
+            let data = s.as_ptr();
+            let len = s.len();
+            return Ok(Self {
+                storage: PyBackedBytesStorage::Rust(s),
+                data,
+                length: len,
+            });
+        }
+
+        return Err(DowncastError::new(obj, "`bytes` or `bytearray`").into());
+    }
+}

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -196,7 +196,6 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::impl_::pyclass::{
     PyClassBaseType, PyClassDict, PyClassImpl, PyClassThreadChecker, PyClassWeakRef,
 };
-use crate::instance::Bound;
 use crate::pyclass::{
     boolean_struct::{False, True},
     PyClass,

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -192,15 +192,18 @@
 //! [Interior Mutability]: https://doc.rust-lang.org/book/ch15-05-interior-mutability.html "RefCell<T> and the Interior Mutability Pattern - The Rust Programming Language"
 
 use crate::exceptions::PyRuntimeError;
+use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::impl_::pyclass::{
     PyClassBaseType, PyClassDict, PyClassImpl, PyClassThreadChecker, PyClassWeakRef,
 };
+use crate::instance::Bound;
 use crate::pyclass::{
     boolean_struct::{False, True},
     PyClass,
 };
 use crate::pyclass_init::PyClassInitializer;
 use crate::type_object::{PyLayout, PySizedLayout};
+use crate::types::any::PyAnyMethods;
 use crate::types::PyAny;
 use crate::{
     conversion::{AsPyPointer, FromPyPointer, ToPyObject},
@@ -346,17 +349,17 @@ impl<T: PyClass> PyCell<T> {
     /// ```
     pub fn try_borrow(&self) -> Result<PyRef<'_, T>, PyBorrowError> {
         self.ensure_threadsafe();
-        self.borrow_checker()
-            .try_borrow()
-            .map(|_| PyRef { inner: self })
+        self.borrow_checker().try_borrow().map(|_| PyRef {
+            inner: self.as_borrowed().to_owned(),
+        })
     }
 
     /// Variant of [`try_borrow`][Self::try_borrow] which fails instead of panicking if called from the wrong thread
     pub(crate) fn try_borrow_threadsafe(&self) -> Result<PyRef<'_, T>, PyBorrowError> {
         self.check_threadsafe()?;
-        self.borrow_checker()
-            .try_borrow()
-            .map(|_| PyRef { inner: self })
+        self.borrow_checker().try_borrow().map(|_| PyRef {
+            inner: self.as_borrowed().to_owned(),
+        })
     }
 
     /// Mutably borrows the value `T`, returning an error if the value is currently borrowed.
@@ -385,9 +388,9 @@ impl<T: PyClass> PyCell<T> {
         T: PyClass<Frozen = False>,
     {
         self.ensure_threadsafe();
-        self.borrow_checker()
-            .try_borrow_mut()
-            .map(|_| PyRefMut { inner: self })
+        self.borrow_checker().try_borrow_mut().map(|_| PyRefMut {
+            inner: self.as_borrowed().to_owned(),
+        })
     }
 
     /// Immutably borrows the value `T`, returning an error if the value is
@@ -641,13 +644,13 @@ impl<T: PyClass + fmt::Debug> fmt::Debug for PyCell<T> {
 /// }
 /// # Python::with_gil(|py| {
 /// #     let sub = PyCell::new(py, Child::new()).unwrap();
-/// #     pyo3::py_run!(py, sub, "assert sub.format() == 'Caterpillar(base: Butterfly, cnt: 3)'");
+/// #     pyo3::py_run!(py, sub, "assert sub.format() == 'Caterpillar(base: Butterfly, cnt: 4)', sub.format()");
 /// # });
 /// ```
 ///
 /// See the [module-level documentation](self) for more information.
 pub struct PyRef<'p, T: PyClass> {
-    inner: &'p PyCell<T>,
+    inner: Bound<'p, T>,
 }
 
 impl<'p, T: PyClass> PyRef<'p, T> {
@@ -663,7 +666,7 @@ where
     U: PyClass,
 {
     fn as_ref(&self) -> &T::BaseType {
-        unsafe { &*self.inner.ob_base.get_ptr() }
+        unsafe { &*self.inner.as_gil_ref().ob_base.get_ptr() }
     }
 }
 
@@ -689,7 +692,7 @@ impl<'p, T: PyClass> PyRef<'p, T> {
     /// of the pointer or decrease the reference count (e.g. with [`pyo3::ffi::Py_DecRef`](crate::ffi::Py_DecRef)).
     #[inline]
     pub fn into_ptr(self) -> *mut ffi::PyObject {
-        self.inner.into_ptr()
+        self.inner.clone().into_ptr()
     }
 }
 
@@ -744,10 +747,14 @@ where
     /// # });
     /// ```
     pub fn into_super(self) -> PyRef<'p, U> {
-        let PyRef { inner } = self;
-        std::mem::forget(self);
+        let py = self.py();
         PyRef {
-            inner: &inner.ob_base,
+            inner: unsafe {
+                ManuallyDrop::new(self)
+                    .as_ptr()
+                    .assume_owned(py)
+                    .downcast_into_unchecked()
+            },
         }
     }
 }
@@ -757,13 +764,13 @@ impl<'p, T: PyClass> Deref for PyRef<'p, T> {
 
     #[inline]
     fn deref(&self) -> &T {
-        unsafe { &*self.inner.get_ptr() }
+        unsafe { &*self.inner.as_gil_ref().get_ptr() }
     }
 }
 
 impl<'p, T: PyClass> Drop for PyRef<'p, T> {
     fn drop(&mut self) {
-        self.inner.borrow_checker().release_borrow()
+        self.inner.as_gil_ref().borrow_checker().release_borrow()
     }
 }
 
@@ -775,7 +782,7 @@ impl<T: PyClass> IntoPy<PyObject> for PyRef<'_, T> {
 
 impl<T: PyClass> IntoPy<PyObject> for &'_ PyRef<'_, T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.inner.into_py(py)
+        unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
     }
 }
 
@@ -802,7 +809,7 @@ impl<T: PyClass + fmt::Debug> fmt::Debug for PyRef<'_, T> {
 ///
 /// See the [module-level documentation](self) for more information.
 pub struct PyRefMut<'p, T: PyClass<Frozen = False>> {
-    inner: &'p PyCell<T>,
+    inner: Bound<'p, T>,
 }
 
 impl<'p, T: PyClass<Frozen = False>> PyRefMut<'p, T> {
@@ -818,7 +825,7 @@ where
     U: PyClass<Frozen = False>,
 {
     fn as_ref(&self) -> &T::BaseType {
-        unsafe { &*self.inner.ob_base.get_ptr() }
+        unsafe { &*self.inner.as_gil_ref().ob_base.get_ptr() }
     }
 }
 
@@ -828,7 +835,7 @@ where
     U: PyClass<Frozen = False>,
 {
     fn as_mut(&mut self) -> &mut T::BaseType {
-        unsafe { &mut *self.inner.ob_base.get_ptr() }
+        unsafe { &mut *self.inner.as_gil_ref().ob_base.get_ptr() }
     }
 }
 
@@ -854,7 +861,7 @@ impl<'p, T: PyClass<Frozen = False>> PyRefMut<'p, T> {
     /// of the pointer or decrease the reference count (e.g. with [`pyo3::ffi::Py_DecRef`](crate::ffi::Py_DecRef)).
     #[inline]
     pub fn into_ptr(self) -> *mut ffi::PyObject {
-        self.inner.into_ptr()
+        self.inner.clone().into_ptr()
     }
 }
 
@@ -867,10 +874,14 @@ where
     ///
     /// See [`PyRef::into_super`] for more.
     pub fn into_super(self) -> PyRefMut<'p, U> {
-        let PyRefMut { inner } = self;
-        std::mem::forget(self);
+        let py = self.py();
         PyRefMut {
-            inner: &inner.ob_base,
+            inner: unsafe {
+                ManuallyDrop::new(self)
+                    .as_ptr()
+                    .assume_owned(py)
+                    .downcast_into_unchecked()
+            },
         }
     }
 }
@@ -880,20 +891,23 @@ impl<'p, T: PyClass<Frozen = False>> Deref for PyRefMut<'p, T> {
 
     #[inline]
     fn deref(&self) -> &T {
-        unsafe { &*self.inner.get_ptr() }
+        unsafe { &*self.inner.as_gil_ref().get_ptr() }
     }
 }
 
 impl<'p, T: PyClass<Frozen = False>> DerefMut for PyRefMut<'p, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
-        unsafe { &mut *self.inner.get_ptr() }
+        unsafe { &mut *self.inner.as_gil_ref().get_ptr() }
     }
 }
 
 impl<'p, T: PyClass<Frozen = False>> Drop for PyRefMut<'p, T> {
     fn drop(&mut self) {
-        self.inner.borrow_checker().release_borrow_mut()
+        self.inner
+            .as_gil_ref()
+            .borrow_checker()
+            .release_borrow_mut()
     }
 }
 
@@ -905,7 +919,7 @@ impl<T: PyClass<Frozen = False>> IntoPy<PyObject> for PyRefMut<'_, T> {
 
 impl<T: PyClass<Frozen = False>> IntoPy<PyObject> for &'_ PyRefMut<'_, T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.inner.into_py(py)
+        self.inner.clone().into_py(py)
     }
 }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -667,7 +667,7 @@ impl PyAny {
 
     /// Returns the Python type object for this object's type.
     pub fn get_type(&self) -> &PyType {
-        self.as_borrowed().get_type()
+        self.as_borrowed().get_type().into_gil_ref()
     }
 
     /// Returns the Python type pointer for this object.
@@ -1499,7 +1499,7 @@ pub trait PyAnyMethods<'py> {
     fn iter(&self) -> PyResult<Bound<'py, PyIterator>>;
 
     /// Returns the Python type object for this object's type.
-    fn get_type(&self) -> &'py PyType;
+    fn get_type(&self) -> Bound<'py, PyType>;
 
     /// Returns the Python type pointer for this object.
     fn get_type_ptr(&self) -> *mut ffi::PyTypeObject;
@@ -2107,8 +2107,8 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         PyIterator::from_bound_object(self)
     }
 
-    fn get_type(&self) -> &'py PyType {
-        unsafe { PyType::from_type_ptr(self.py(), ffi::Py_TYPE(self.as_ptr())) }
+    fn get_type(&self) -> Bound<'py, PyType> {
+        unsafe { PyType::from_type_ptr_bound(self.py(), ffi::Py_TYPE(self.as_ptr())) }
     }
 
     #[inline]
@@ -2265,7 +2265,7 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     #[cfg(not(PyPy))]
     fn py_super(&self) -> PyResult<Bound<'py, PySuper>> {
-        PySuper::new_bound(&self.get_type().as_borrowed(), self)
+        PySuper::new_bound(&self.get_type(), self)
     }
 }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -2286,7 +2286,7 @@ impl<'py> Bound<'py, PyAny> {
         N: IntoPy<Py<PyString>>,
     {
         let py = self.py();
-        let self_type = self.get_type().as_borrowed();
+        let self_type = self.get_type();
         let attr = if let Ok(attr) = self_type.getattr(attr_name) {
             attr
         } else {
@@ -2308,11 +2308,7 @@ impl<'py> Bound<'py, PyAny> {
                 let ret = descr_get(attr.as_ptr(), self.as_ptr(), self_type.as_ptr());
                 ret.assume_owned_or_err(py).map(Some)
             }
-        } else if let Ok(descr_get) = attr
-            .get_type()
-            .as_borrowed()
-            .getattr(crate::intern!(py, "__get__"))
-        {
+        } else if let Ok(descr_get) = attr.get_type().getattr(crate::intern!(py, "__get__")) {
             descr_get.call1((attr, self, self_type)).map(Some)
         } else {
             Ok(Some(attr))

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,11 +1,11 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+use crate::types::any::PyAnyMethods;
+use crate::types::typeobject::PyTypeMethods;
 use crate::{
     exceptions::PyTypeError, ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, Borrowed, FromPyObject,
     IntoPy, PyAny, PyNativeType, PyObject, PyResult, Python, ToPyObject,
 };
-
-use super::any::PyAnyMethods;
 
 /// Represents a Python `bool`.
 #[repr(transparent)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -309,4 +309,4 @@ mod slice;
 pub(crate) mod string;
 pub(crate) mod traceback;
 pub(crate) mod tuple;
-mod typeobject;
+pub(crate) mod typeobject;

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -357,7 +357,7 @@ impl<'py> PyStringMethods<'py> for Bound<'py, PyString> {
 impl<'a> Borrowed<'a, '_, PyString> {
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     #[allow(clippy::wrong_self_convention)]
-    fn to_str(self) -> PyResult<&'a str> {
+    pub(crate) fn to_str(self) -> PyResult<&'a str> {
         // PyUnicode_AsUTF8AndSize only available on limited API starting with 3.10.
         let mut size: ffi::Py_ssize_t = 0;
         let data: *const u8 =

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -36,6 +36,21 @@ impl PyType {
         py.from_borrowed_ptr(p as *mut ffi::PyObject)
     }
 
+    /// Retrieves the `PyType` instance for the given FFI pointer.
+    ///
+    /// # Safety
+    /// - The pointer must be non-null.
+    #[inline]
+    pub unsafe fn from_type_ptr_bound(
+        py: Python<'_>,
+        p: *mut ffi::PyTypeObject,
+    ) -> Bound<'_, PyType> {
+        p.cast::<ffi::PyObject>()
+            .assume_borrowed(py)
+            .downcast_unchecked()
+            .clone()
+    }
+
     /// Gets the [qualified name](https://docs.python.org/3/glossary.html#term-qualified-name) of the `PyType`.
     pub fn qualname(&self) -> PyResult<String> {
         self.as_borrowed().qualname()

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -48,7 +48,7 @@ impl PyType {
         p.cast::<ffi::PyObject>()
             .assume_borrowed(py)
             .downcast_unchecked()
-            .clone()
+            .to_owned()
     }
 
     /// Gets the [qualified name](https://docs.python.org/3/glossary.html#term-qualified-name) of the `PyType`.

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -25,7 +25,7 @@ impl Mapping {
         if let Some(pylist) = elements {
             let mut elems = HashMap::with_capacity(pylist.len());
             for (i, pyelem) in pylist.into_iter().enumerate() {
-                let elem = String::extract(pyelem)?;
+                let elem = pyelem.extract()?;
                 elems.insert(elem, i);
             }
             Ok(Self { index: elems })

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -215,7 +215,7 @@ struct ValueClass {
 fn conversion_error(
     str_arg: &str,
     int_arg: i64,
-    tuple_arg: (&str, f64),
+    tuple_arg: (String, f64),
     option_arg: Option<i64>,
     struct_arg: Option<ValueClass>,
 ) {

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -21,7 +21,7 @@ impl ByteSequence {
         if let Some(pylist) = elements {
             let mut elems = Vec::with_capacity(pylist.len());
             for pyelem in pylist {
-                let elem = u8::extract(pyelem)?;
+                let elem = pyelem.extract()?;
                 elems.push(elem);
             }
             Ok(Self { elements: elems })
@@ -61,7 +61,7 @@ impl ByteSequence {
     }
 
     fn __contains__(&self, other: &PyAny) -> bool {
-        match u8::extract(other) {
+        match other.extract::<u8>() {
             Ok(x) => self.elements.contains(&x),
             Err(_) => false,
         }

--- a/tests/ui/invalid_result_conversion.stderr
+++ b/tests/ui/invalid_result_conversion.stderr
@@ -8,7 +8,7 @@ error[E0277]: the trait bound `PyErr: From<MyError>` is not satisfied
              <PyErr as From<std::io::Error>>
              <PyErr as From<PyBorrowError>>
              <PyErr as From<PyBorrowMutError>>
-             <PyErr as From<PyDowncastError<'a>>>
+             <PyErr as From<PyDowncastError<'_>>>
              <PyErr as From<DowncastError<'_, '_>>>
              <PyErr as From<DowncastIntoError<'_>>>
              <PyErr as From<NulError>>

--- a/tests/ui/invalid_result_conversion.stderr
+++ b/tests/ui/invalid_result_conversion.stderr
@@ -5,10 +5,10 @@ error[E0277]: the trait bound `PyErr: From<MyError>` is not satisfied
    | ^^^^^^^^^^^^^ the trait `From<MyError>` is not implemented for `PyErr`
    |
    = help: the following other types implement trait `From<T>`:
+             <PyErr as From<PyDowncastError<'_>>>
              <PyErr as From<std::io::Error>>
              <PyErr as From<PyBorrowError>>
              <PyErr as From<PyBorrowMutError>>
-             <PyErr as From<PyDowncastError<'_>>>
              <PyErr as From<DowncastError<'_, '_>>>
              <PyErr as From<DowncastIntoError<'_>>>
              <PyErr as From<NulError>>


### PR DESCRIPTION
Closes #3382 

This branch has been used to implement https://github.com/pydantic/pydantic-core/pull/1085 

It's based on top of #3572, and also includes #3600 as well as updated forms of most of the other PRs introducing Py2 types.

I feel like this strikes a good balance of introducing the new `Py2` API without breaking much of the existing gil refs API. The only thing which really needed to change was the `FromPyObject` trait, to take `&Py2<'py, PyAny>` instead of `&'py PyAny`. I don't think I'd want to land this amongst other breaking changes. I do think this might be releasable as an 0.22 release with both APIs still present (maybe gate the GIL refs API with a `backcompat` feature), with a view to dropping the gil refs API in 0.24 maybe.

Next steps:

- We want to release `pydantic-core` against a form of this branch in the near future. Any opinions if I should release this as a fork of PyO3, or we release this as an 0.22 alpha?

- I plan to start splitting this out into reviewable PRs and keep this one rebased as we move forwards.

- This also needs further cleanup / documentation etc.