### PR TITLE
Enable `GILProtected` access via `PyVisit`

### DIFF
--- a/newsfragments/3616.added.md
+++ b/newsfragments/3616.added.md
@@ -1,0 +1,1 @@
+Add `traverse` method to `GILProtected`

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,5 +1,5 @@
 //! Synchronization mechanisms based on the Python GIL.
-use crate::{types::PyString, types::PyType, Py, PyErr, Python};
+use crate::{types::PyString, types::PyType, Py, PyErr, PyVisit, Python};
 use std::cell::UnsafeCell;
 
 /// Value with concurrent access protected by the GIL.
@@ -35,6 +35,11 @@ impl<T> GILProtected<T> {
 
     /// Gain access to the inner value by giving proof of having acquired the GIL.
     pub fn get<'py>(&'py self, _py: Python<'py>) -> &'py T {
+        &self.value
+    }
+
+    /// Gain access to the inner value by giving proof that garbage collection is happening.
+    pub fn traverse<'py>(&'py self, _visit: PyVisit<'py>) -> &'py T {
         &self.value
     }
 }


### PR DESCRIPTION
Closes #3615

This simply adds a new method which uses the existence of a `PyVisit` object as proof that the GIL is held instead of a `Python` object. This allows `GILProtected` to be used in instances where contained Python objects need to participate in garbage collection. Usage in this situation should be valid since no Python calls are made and this does not provide any additional mechanism for accessing a `Python` object.
