### PR TITLE
Use portable-atomic for targets which lack 64-bit atomics used to check interpreter ID.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ cfg-if = "1.0"
 libc = "0.2.62"
 parking_lot = ">= 0.11, < 0.13"
 memoffset = "0.9"
+portable-atomic = "1.0"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
 pyo3-ffi = { path = "pyo3-ffi", version = "=0.21.0-dev" }

--- a/newsfragments/3619.fixed.md
+++ b/newsfragments/3619.fixed.md
@@ -1,0 +1,1 @@
+Use portable-atomic to support platforms without 64-bit atomics

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -3,7 +3,7 @@
 use std::cell::UnsafeCell;
 
 #[cfg(all(not(PyPy), Py_3_9, not(all(windows, Py_LIMITED_API, not(Py_3_10)))))]
-use std::sync::atomic::{AtomicI64, Ordering};
+use portable_atomic::{AtomicI64, Ordering};
 
 #[cfg(not(PyPy))]
 use crate::exceptions::PyImportError;


### PR DESCRIPTION
I chose to make the dependency mandatory instead of optional as portable-atomic itself just forwards to the native atomics when they are available so making that choice part of our build system is not really necessary. Personally, I was unable to perceive any noticeable compile-time hit from adding it.

Closes #3614 