### PR TITLE
Add additional definitions for `_PyImport_Frozen*`

### DIFF
--- a/pyo3-ffi/src/cpython/import.rs
+++ b/pyo3-ffi/src/cpython/import.rs
@@ -65,4 +65,10 @@ pub struct _frozen {
 extern "C" {
     #[cfg(not(PyPy))]
     pub static mut PyImport_FrozenModules: *const _frozen;
+    #[cfg(all(not(PyPy), Py_3_11))]
+    pub static mut _PyImport_FrozenBootstrap: *const _frozen;
+    #[cfg(all(not(PyPy), Py_3_11))]
+    pub static mut _PyImport_FrozenStdlib: *const _frozen;
+    #[cfg(all(not(PyPy), Py_3_11))]
+    pub static mut _PyImport_FrozenTest: *const _frozen;
 }


### PR DESCRIPTION
These were added in https://github.com/python/cpython/commit/074fa5750640a067d9894c69378a00ceecc3b948, useful in embedding Python interpreter.