### PR TITLE
ci: don't isolate venv for benches

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -36,7 +36,7 @@ jobs:
         run: pip install nox
 
       - name: Run the benchmarks
-        uses: CodSpeedHQ/action@v1
+        uses: CodSpeedHQ/action@v2
         with:
-          run: nox -s codspeed
+          run: nox --no-venv -s codspeed
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
Hopefully this can help fix the build errors we are observing in the benchmarks.