### PR TITLE
ci: fixup pytests to compile in debug

### DIFF
--- a/pytests/noxfile.py
+++ b/pytests/noxfile.py
@@ -6,14 +6,13 @@ nox.options.sessions = ["test"]
 
 @nox.session
 def test(session: nox.Session):
-    session.install(".[dev]")
+    session.env["MATURIN_PEP517_ARGS"] = "--profile=dev"
+    session.run_always("python", "-m", "pip", "install", "-v", ".[dev]")
     try:
         session.install("--only-binary=numpy", "numpy>=1.16")
     except CommandFailed:
         # No binary wheel for numpy available on this platform
         pass
-    session.install("maturin")
-    session.run_always("maturin", "develop")
     session.run("pytest", *session.posargs)
 
 


### PR DESCRIPTION
Looking at #3627 with fresh eyes I see I was a bit hasty with modifications to the `pytests` and switched the tests from running in debug to release.

This puts them back to debug. Will merge if CI is green, as this is the same pattern we use in #3536 