### PR TITLE
Add support for extracting Rust set types from `frozenset`

### DIFF
--- a/newsfragments/3632.added.md
+++ b/newsfragments/3632.added.md
@@ -1,0 +1,1 @@
+Add support for extracting Rust set types from `frozenset`.


### PR DESCRIPTION
The conversion table is lying currently...

https://github.com/PyO3/pyo3/blob/07726aefc4fef1a8a68553988b7f05bd4b52ec2e/guide/src/conversions/tables.md#L26

```python
In [4]: nh3.clean("<b><img src='' onerror='alert(\\'hax\\')'>I'm not trying to XSS you</b>", tags=frozenset())
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 nh3.clean("<b><img src='' onerror='alert(\\'hax\\')'>I'm not trying to XSS you</b>", tags=frozenset())

TypeError: argument 'tags': 'frozenset' object cannot be converted to 'PySet'
```