### PR TITLE
Try harder by looking for a __bool__ magic method when extracing bool values from Python objects.

### DIFF
--- a/newsfragments/3638.changed.md
+++ b/newsfragments/3638.changed.md
@@ -1,1 +1,1 @@
-Values of type `bool` can now be extracted from all Python values defining a `__bool__` magic method.
+Values of type `bool` can now be extracted from NumPy's `bool_`.

--- a/newsfragments/3638.changed.md
+++ b/newsfragments/3638.changed.md
@@ -1,0 +1,1 @@
+Values of type `bool` can now be extracted from all Python values defining a `__bool__` magic method.

--- a/pytests/src/misc.rs
+++ b/pytests/src/misc.rs
@@ -12,9 +12,15 @@ fn get_type_full_name(obj: &PyAny) -> PyResult<Cow<'_, str>> {
     obj.get_type().name()
 }
 
+#[pyfunction]
+fn accepts_bool(val: bool) -> bool {
+    val
+}
+
 #[pymodule]
 pub fn misc(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(issue_219, m)?)?;
     m.add_function(wrap_pyfunction!(get_type_full_name, m)?)?;
+    m.add_function(wrap_pyfunction!(accepts_bool, m)?)?;
     Ok(())
 }

--- a/pytests/tests/test_misc.py
+++ b/pytests/tests/test_misc.py
@@ -54,3 +54,13 @@ def test_type_full_name_includes_module():
     numpy = pytest.importorskip("numpy")
 
     assert pyo3_pytests.misc.get_type_full_name(numpy.bool_(True)) == "numpy.bool_"
+
+
+def test_accepts_numpy_bool():
+    # binary numpy wheel not available on all platforms
+    numpy = pytest.importorskip("numpy")
+
+    assert pyo3_pytests.misc.accepts_bool(True) is True
+    assert pyo3_pytests.misc.accepts_bool(False) is False
+    assert pyo3_pytests.misc.accepts_bool(numpy.bool_(True)) is True
+    assert pyo3_pytests.misc.accepts_bool(numpy.bool_(False)) is False

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -146,7 +146,6 @@ impl PyAny {
     ///
     /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
     /// to intern `attr_name`.
-    #[allow(dead_code)] // Currently only used with num-complex+abi3, so dead without that.
     pub(crate) fn lookup_special<N>(&self, attr_name: N) -> PyResult<Option<&PyAny>>
     where
         N: IntoPy<Py<PyString>>,

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -146,6 +146,7 @@ impl PyAny {
     ///
     /// To avoid repeated temporary allocations of Python strings, the [`intern!`] macro can be used
     /// to intern `attr_name`.
+    #[allow(dead_code)] // Currently only used with num-complex+abi3, so dead without that.
     pub(crate) fn lookup_special<N>(&self, attr_name: N) -> PyResult<Option<&PyAny>>
     where
         N: IntoPy<Py<PyString>>,

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    ffi, instance::Py2, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
+    exceptions::PyTypeError, ffi, instance::Py2, FromPyObject, IntoPy, PyAny, PyObject, PyResult,
+    Python, ToPyObject,
 };
 
 /// Represents a Python `bool`.
@@ -76,7 +77,16 @@ impl IntoPy<PyObject> for bool {
 /// Fails with `TypeError` if the input is not a Python `bool`.
 impl<'source> FromPyObject<'source> for bool {
     fn extract(obj: &'source PyAny) -> PyResult<Self> {
-        Ok(obj.downcast::<PyBool>()?.is_true())
+        if let Ok(obj) = obj.downcast::<PyBool>() {
+            return Ok(obj.is_true());
+        }
+
+        let meth = obj
+            .lookup_special(intern!(obj.py(), "__bool__"))?
+            .ok_or_else(|| PyTypeError::new_err("object has no __bool__ magic method"))?;
+
+        let obj = meth.call0()?.downcast::<PyBool>()?;
+        Ok(obj.is_true())
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -87,7 +97,7 @@ impl<'source> FromPyObject<'source> for bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{PyAny, PyBool};
+    use crate::types::{PyAny, PyBool, PyModule};
     use crate::Python;
     use crate::ToPyObject;
 
@@ -108,6 +118,49 @@ mod tests {
             let t: &PyAny = PyBool::new(py, false).into();
             assert!(!t.extract::<bool>().unwrap());
             assert!(false.to_object(py).is(PyBool::new(py, false)));
+        });
+    }
+
+    #[test]
+    fn test_magic_method() {
+        Python::with_gil(|py| {
+            let module = PyModule::from_code(
+                py,
+                r#"
+class A:
+    def __bool__(self): return True
+class B:
+    def __bool__(self): return "not a bool"
+class C:
+    def __len__(self): return 23
+class D:
+    pass
+                "#,
+                "test.py",
+                "test",
+            )
+            .unwrap();
+
+            let a = module.getattr("A").unwrap().call0().unwrap();
+            assert!(a.extract::<bool>().unwrap());
+
+            let b = module.getattr("B").unwrap().call0().unwrap();
+            assert_eq!(
+                b.extract::<bool>().unwrap_err().to_string(),
+                "TypeError: 'str' object cannot be converted to 'PyBool'",
+            );
+
+            let c = module.getattr("C").unwrap().call0().unwrap();
+            assert_eq!(
+                c.extract::<bool>().unwrap_err().to_string(),
+                "TypeError: object has no __bool__ magic method",
+            );
+
+            let d = module.getattr("D").unwrap().call0().unwrap();
+            assert_eq!(
+                d.extract::<bool>().unwrap_err().to_string(),
+                "TypeError: object has no __bool__ magic method",
+            );
         });
     }
 }


### PR DESCRIPTION
I decided to not implement the full protocol for [truth value testing](https://docs.python.org/3/library/stdtypes.html#truth) as it seems confusing in the context of function arguments if basically any instance of custom classes or non-empty collections turns into `true`.

Closes #3637 