### PR TITLE
implement `PyBoolMethods`

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -26,5 +26,6 @@ pub use crate::wrap_pyfunction;
 // Expected to become public API in 0.21
 // pub(crate) use crate::instance::Py2; // Will be stabilized with a different name
 // pub(crate) use crate::types::any::PyAnyMethods;
+// pub(crate) use crate::types::boolobject::PyBoolMethods;
 // pub(crate) use crate::types::float::PyFloatMethods;
 // pub(crate) use crate::types::sequence::PySequenceMethods;

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-use crate::{ffi, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
+use crate::{
+    ffi, instance::Py2, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
+};
 
 /// Represents a Python `bool`.
 #[repr(transparent)]
@@ -18,6 +20,24 @@ impl PyBool {
     /// Gets whether this boolean is `true`.
     #[inline]
     pub fn is_true(&self) -> bool {
+        Py2::borrowed_from_gil_ref(&self).is_true()
+    }
+}
+
+/// Implementation of functionality for [`PyBool`].
+///
+/// These methods are defined for the `Py2<'py, PyBool>` smart pointer, so to use method call
+/// syntax these methods are separated into a trait, because stable Rust does not yet support
+/// `arbitrary_self_types`.
+#[doc(alias = "PyBool")]
+pub trait PyBoolMethods<'py> {
+    /// Gets whether this boolean is `true`.
+    fn is_true(&self) -> bool;
+}
+
+impl<'py> PyBoolMethods<'py> for Py2<'py, PyBool> {
+    #[inline]
+    fn is_true(&self) -> bool {
         self.as_ptr() == unsafe { crate::ffi::Py_True() }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -272,7 +272,7 @@ macro_rules! pyobject_native_type {
 }
 
 pub(crate) mod any;
-mod boolobject;
+pub(crate) mod boolobject;
 mod bytearray;
 mod bytes;
 mod capsule;


### PR DESCRIPTION
Implements `PyBoolMethods` trait as per #3382 

This one will remain in draft, because `Py2::<PyBool>::borrowed_from_gil_ref(&self).is_true()` requires the `PyBool` in the turbofish there to avoid ambiguity. I'm going to open a PR which might offer a way to avoid this.