### PR TITLE
implement `Py2Borrowed`

### DIFF
--- a/src/ffi_ptr_ext.rs
+++ b/src/ffi_ptr_ext.rs
@@ -1,4 +1,8 @@
-use crate::{ffi, instance::Py2, PyAny, PyResult, Python};
+use crate::{
+    ffi,
+    instance::{Py2, Py2Borrowed},
+    PyAny, PyResult, Python,
+};
 
 mod sealed {
     use super::*;
@@ -13,6 +17,24 @@ use sealed::Sealed;
 pub(crate) trait FfiPtrExt: Sealed {
     unsafe fn assume_owned_or_err(self, py: Python<'_>) -> PyResult<Py2<'_, PyAny>>;
     unsafe fn assume_owned(self, py: Python<'_>) -> Py2<'_, PyAny>;
+
+    /// Assumes this pointer is borrowed from a parent object.
+    ///
+    /// Warning: the lifetime `'a` is not bounded by the function arguments; the caller is
+    /// responsible to ensure this is tied to some appropriate lifetime.
+    unsafe fn assume_borrowed_or_err<'a, 'py>(
+        self,
+        py: Python<'py>,
+    ) -> PyResult<Py2Borrowed<'a, 'py, PyAny>>;
+
+    /// Same as `assume_borrowed_or_err`, but doesn't fetch an error on NULL.
+    unsafe fn assume_borrowed_or_opt<'a, 'py>(
+        self,
+        py: Python<'py>,
+    ) -> Option<Py2Borrowed<'a, 'py, PyAny>>;
+
+    /// Same as `assume_borrowed_or_err`, but panics on NULL.
+    unsafe fn assume_borrowed<'a, 'py>(self, py: Python<'py>) -> Py2Borrowed<'a, 'py, PyAny>;
 }
 
 impl FfiPtrExt for *mut ffi::PyObject {
@@ -24,5 +46,26 @@ impl FfiPtrExt for *mut ffi::PyObject {
     #[inline]
     unsafe fn assume_owned(self, py: Python<'_>) -> Py2<'_, PyAny> {
         Py2::from_owned_ptr(py, self)
+    }
+
+    #[inline]
+    unsafe fn assume_borrowed_or_err<'a, 'py>(
+        self,
+        py: Python<'py>,
+    ) -> PyResult<Py2Borrowed<'a, 'py, PyAny>> {
+        Py2Borrowed::from_ptr_or_err(py, self)
+    }
+
+    #[inline]
+    unsafe fn assume_borrowed_or_opt<'a, 'py>(
+        self,
+        py: Python<'py>,
+    ) -> Option<Py2Borrowed<'a, 'py, PyAny>> {
+        Py2Borrowed::from_ptr_or_opt(py, self)
+    }
+
+    #[inline]
+    unsafe fn assume_borrowed<'a, 'py>(self, py: Python<'py>) -> Py2Borrowed<'a, 'py, PyAny> {
+        Py2Borrowed::from_ptr(py, self)
     }
 }


### PR DESCRIPTION
This PR adds `Py2Borrowed<'a, 'py, T>` which is similar to `&'a Py2<'py, T>` but directly stores `NonNull<ffi::PyObject>`, making it possible to transmute gil-refs to it (see discussion in #3651).

Additionally this is necessary if we want `PyTupleMethods::get_item` to return a borrowed object, which is safe as tuples are immutable.

Finally, in #3606 I am able to leverage this type in our `extract_argument` logic to avoid needing to manipulate reference counts, which gives quite a significant performance improvement.