### PR TITLE
Rename `Py<T>` to `PyDetached<T>`

### DIFF
--- a/examples/decorator/src/lib.rs
+++ b/examples/decorator/src/lib.rs
@@ -13,7 +13,7 @@ pub struct PyCounter {
     count: Cell<u64>,
 
     // This is the actual function being wrapped.
-    wraps: Py<PyAny>,
+    wraps: PyDetached<PyAny>,
 }
 
 #[pymethods]
@@ -24,7 +24,7 @@ impl PyCounter {
     //    1. It doesn't guarantee the object can actually be called successfully
     //    2. We still need to handle any exceptions that the function might raise
     #[new]
-    fn __new__(wraps: Py<PyAny>) -> Self {
+    fn __new__(wraps: PyDetached<PyAny>) -> Self {
         PyCounter {
             count: Cell::new(0),
             wraps,
@@ -42,7 +42,7 @@ impl PyCounter {
         py: Python<'_>,
         args: &PyTuple,
         kwargs: Option<&PyDict>,
-    ) -> PyResult<Py<PyAny>> {
+    ) -> PyResult<PyDetached<PyAny>> {
         let old_count = self.count.get();
         let new_count = old_count + 1;
         self.count.set(new_count);

--- a/guide/src/class/call.md
+++ b/guide/src/class/call.md
@@ -77,7 +77,7 @@ fn __call__(
     py: Python<'_>,
     args: &PyTuple,
     kwargs: Option<&PyDict>,
-) -> PyResult<Py<PyAny>> {
+) -> PyResult<PyDetached<PyAny>> {
     self.count += 1;
     let name = self.wraps.getattr(py, "__name__")?;
 

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -143,7 +143,7 @@ impl Number {
 > #[pymethods]
 > impl NotHashable {
 >     #[classattr]
->     const __hash__: Option<Py<PyAny>> = None;
+>     const __hash__: Option<PyDetached<PyAny>> = None;
 > }
 > ```
 

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -197,11 +197,11 @@ struct Container {
 
 #[pymethods]
 impl Container {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyResult<Py<Iter>> {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyResult<PyDetached<Iter>> {
         let iter = Iter {
             inner: slf.iter.clone().into_iter(),
         };
-        Py::new(slf.py(), iter)
+        PyDetached::new(slf.py(), iter)
     }
 }
 

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -131,7 +131,7 @@ struct Inner {/* fields omitted */}
 #[pyclass]
 struct Outer {
     #[pyo3(get)]
-    inner: Py<Inner>,
+    inner: PyDetached<Inner>,
 }
 
 #[pymethods]
@@ -139,7 +139,7 @@ impl Outer {
     #[new]
     fn __new__(py: Python<'_>) -> PyResult<Self> {
         Ok(Self {
-            inner: Py::new(py, Inner {})?,
+            inner: PyDetached::new(py, Inner {})?,
         })
     }
 }
@@ -183,7 +183,7 @@ struct MyClass;
 
 ## I'm trying to call Python from Rust but I get `STATUS_DLL_NOT_FOUND` or `STATUS_ENTRYPOINT_NOT_FOUND`!
 
-This happens on Windows when linking to the python DLL fails or the wrong one is linked. The Python DLL on Windows will usually be called something like: 
+This happens on Windows when linking to the python DLL fails or the wrong one is linked. The Python DLL on Windows will usually be called something like:
 - `python3X.dll` for Python 3.X, e.g. `python310.dll` for Python 3.10
 - `python3.dll` when using PyO3's `abi3` feature
 

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -159,7 +159,7 @@ struct Permission {
 #[derive(Serialize, Deserialize)]
 struct User {
     username: String,
-    permissions: Vec<Py<Permission>>,
+    permissions: Vec<PyDetached<Permission>>,
 }
 # }
 ```

--- a/guide/src/memory.md
+++ b/guide/src/memory.md
@@ -144,7 +144,7 @@ reference count reaches zero?  It depends whether or not we are holding the GIL.
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
 Python::with_gil(|py| -> PyResult<()> {
-    let hello: Py<PyString> = py.eval("\"Hello World!\"", None, None)?.extract()?;
+    let hello: PyDetached<PyString> = py.eval("\"Hello World!\"", None, None)?.extract()?;
     println!("Python says: {}", hello.as_ref(py));
     Ok(())
 })?;
@@ -165,7 +165,7 @@ we are *not* holding the GIL?
 # use pyo3::prelude::*;
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
-let hello: Py<PyString> = Python::with_gil(|py| {
+let hello: PyDetached<PyString> = Python::with_gil(|py| {
     py.eval("\"Hello World!\"", None, None)?.extract()
 })?;
 // Do some stuff...
@@ -196,7 +196,7 @@ We can avoid the delay in releasing memory if we are careful to drop the
 # use pyo3::prelude::*;
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
-let hello: Py<PyString> =
+let hello: PyDetached<PyString> =
     Python::with_gil(|py| py.eval("\"Hello World!\"", None, None)?.extract())?;
 // Do some stuff...
 // Now sometime later in the program:
@@ -218,7 +218,7 @@ until the GIL is dropped.
 # use pyo3::prelude::*;
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
-let hello: Py<PyString> =
+let hello: PyDetached<PyString> =
     Python::with_gil(|py| py.eval("\"Hello World!\"", None, None)?.extract())?;
 // Do some stuff...
 // Now sometime later in the program:

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -288,7 +288,7 @@ drop(second);
 
 The replacement is [`Python::with_gil`]() which is more cumbersome but enforces the proper nesting by design, e.g.
 
-```rust
+```rust,ignore
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 
@@ -464,7 +464,7 @@ Python::with_gil(|py| {
 
 After, some type annotations may be necessary:
 
-```rust
+```rust,ignore
 # use pyo3::prelude::*;
 #
 # fn main() {
@@ -579,7 +579,7 @@ impl MyClass {
 
 ### Removed `PartialEq` for object wrappers
 
-The Python object wrappers `Py` and `PyAny` had implementations of `PartialEq`
+The Python object wrappers `PyDetached` and `PyAny` had implementations of `PartialEq`
 so that `object_a == object_b` would compare the Python objects for pointer
 equality, which corresponds to the `is` operator, not the `==` operator in
 Python.  This has been removed in favor of a new method: use
@@ -921,7 +921,7 @@ let list_ref: &PyList = list_py.as_ref(py);
 ```
 
 After:
-```rust
+```rust,ignore
 use pyo3::{Py, types::PyList};
 # pyo3::Python::with_gil(|py| {
 let list_py: Py<PyList> = PyList::empty(py).into();

--- a/guide/src/performance.md
+++ b/guide/src/performance.md
@@ -64,7 +64,7 @@ For example, instead of writing
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
 
-struct Foo(Py<PyList>);
+struct Foo(PyDetached<PyList>);
 
 struct FooRef<'a>(&'a PyList);
 
@@ -81,7 +81,7 @@ use more efficient
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
-# struct Foo(Py<PyList>);
+# struct Foo(PyDetached<PyList>);
 # struct FooRef<'a>(&'a PyList);
 #
 impl PartialEq<Foo> for FooRef<'_> {

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -32,7 +32,7 @@ fn main() -> PyResult<()> {
     let arg3 = "arg3";
 
     Python::with_gil(|py| {
-        let fun: Py<PyAny> = PyModule::from_code(
+        let fun: PyDetached<PyAny> = PyModule::from_code(
             py,
             "def example(*args, **kwargs):
                 if args != ():
@@ -78,7 +78,7 @@ fn main() -> PyResult<()> {
     let val2 = 2;
 
     Python::with_gil(|py| {
-        let fun: Py<PyAny> = PyModule::from_code(
+        let fun: PyDetached<PyAny> = PyModule::from_code(
             py,
             "def example(*args, **kwargs):
                 if args != ():
@@ -372,9 +372,9 @@ fn main() -> PyResult<()> {
         "/python_app/utils/foo.py"
     ));
     let py_app = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/python_app/app.py"));
-    let from_python = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+    let from_python = Python::with_gil(|py| -> PyResult<PyDetached<PyAny>> {
         PyModule::from_code(py, py_foo, "utils.foo", "utils.foo")?;
-        let app: Py<PyAny> = PyModule::from_code(py, py_app, "", "")?
+        let app: PyDetached<PyAny> = PyModule::from_code(py, py_app, "", "")?
             .getattr("run")?
             .into();
         app.call0(py)
@@ -405,10 +405,10 @@ use std::path::Path;
 fn main() -> PyResult<()> {
     let path = Path::new("/usr/share/python_app");
     let py_app = fs::read_to_string(path.join("app.py"))?;
-    let from_python = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+    let from_python = Python::with_gil(|py| -> PyResult<PyDetached<PyAny>> {
         let syspath: &PyList = py.import("sys")?.getattr("path")?.downcast()?;
         syspath.insert(0, &path)?;
-        let app: Py<PyAny> = PyModule::from_code(py, &py_app, "", "")?
+        let app: PyDetached<PyAny> = PyModule::from_code(py, &py_app, "", "")?
             .getattr("run")?
             .into();
         app.call0(py)

--- a/guide/src/trait_bounds.md
+++ b/guide/src/trait_bounds.md
@@ -73,7 +73,7 @@ use pyo3::prelude::*;
 # }
 
 struct UserModel {
-    model: Py<PyAny>,
+    model: PyDetached<PyAny>,
 }
 
 impl Model for UserModel {
@@ -127,7 +127,7 @@ Let's add the PyO3 annotations and add a constructor:
 
 #[pyclass]
 struct UserModel {
-    model: Py<PyAny>,
+    model: PyDetached<PyAny>,
 }
 
 #[pymodule]
@@ -139,7 +139,7 @@ fn trait_exposure(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 #[pymethods]
 impl UserModel {
     #[new]
-    pub fn new(model: Py<PyAny>) -> Self {
+    pub fn new(model: PyDetached<PyAny>) -> Self {
         UserModel { model }
     }
 }
@@ -172,7 +172,7 @@ This wrapper will also perform the type conversions between Python and Rust.
 #
 # #[pyclass]
 # struct UserModel {
-#     model: Py<PyAny>,
+#     model: PyDetached<PyAny>,
 # }
 #
 # impl Model for UserModel {
@@ -316,7 +316,7 @@ class Model:
 This call results in the following panic:
 
 ```block
-pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: PyErr { type: Py(0x10dcf79f0, PhantomData) }
+pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: PyErr { type: PyDetached(0x10dcf79f0, PhantomData) }
 ```
 
 This error code is not helpful for a Python user that does not know anything about Rust, or someone that does not know PyO3 was used to interface the Rust code.
@@ -340,7 +340,7 @@ We used in our `get_results` method the following call that performs the type co
 #
 # #[pyclass]
 # struct UserModel {
-#     model: Py<PyAny>,
+#     model: PyDetached<PyAny>,
 # }
 
 impl Model for UserModel {
@@ -392,7 +392,7 @@ Let's break it down in order to perform better error handling:
 #
 # #[pyclass]
 # struct UserModel {
-#     model: Py<PyAny>,
+#     model: PyDetached<PyAny>,
 # }
 
 impl Model for UserModel {
@@ -480,7 +480,7 @@ pub fn solve_wrapper(model: &mut UserModel) {
 
 #[pyclass]
 pub struct UserModel {
-    model: Py<PyAny>,
+    model: PyDetached<PyAny>,
 }
 
 #[pymodule]
@@ -493,7 +493,7 @@ fn trait_exposure(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 #[pymethods]
 impl UserModel {
     #[new]
-    pub fn new(model: Py<PyAny>) -> Self {
+    pub fn new(model: PyDetached<PyAny>) -> Self {
         UserModel { model }
     }
 

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -76,11 +76,11 @@ let obj: &PyAny = PyList::empty(py);
 // To &PyList with PyAny::downcast
 let _: &PyList = obj.downcast()?;
 
-// To Py<PyAny> (aka PyObject) with .into()
-let _: Py<PyAny> = obj.into();
+// To PyDetached<PyAny> (aka PyObject) with .into()
+let _: PyDetached<PyAny> = obj.into();
 
-// To Py<PyList> with PyAny::extract
-let _: Py<PyList> = obj.extract()?;
+// To PyDetached<PyList> with PyAny::extract
+let _: PyDetached<PyList> = obj.extract()?;
 # Ok(())
 # }).unwrap();
 ```
@@ -91,16 +91,16 @@ For a `&PyAny` object reference `any` where the underlying object is a `#[pyclas
 # use pyo3::prelude::*;
 # #[pyclass] #[derive(Clone)] struct MyClass { }
 # Python::with_gil(|py| -> PyResult<()> {
-let obj: &PyAny = Py::new(py, MyClass {})?.into_ref(py);
+let obj: &PyAny = PyDetached::new(py, MyClass {})?.into_ref(py);
 
 // To &PyCell<MyClass> with PyAny::downcast
 let _: &PyCell<MyClass> = obj.downcast()?;
 
-// To Py<PyAny> (aka PyObject) with .into()
-let _: Py<PyAny> = obj.into();
+// To PyDetached<PyAny> (aka PyObject) with .into()
+let _: PyDetached<PyAny> = obj.into();
 
-// To Py<MyClass> with PyAny::extract
-let _: Py<MyClass> = obj.extract()?;
+// To PyDetached<MyClass> with PyAny::extract
+let _: PyDetached<MyClass> = obj.extract()?;
 
 // To MyClass with PyAny::extract, if MyClass: Clone
 let _: MyClass = obj.extract()?;
@@ -144,8 +144,8 @@ let _: &PyAny = list;
 // To &PyAny explicitly with .as_ref()
 let _: &PyAny = list.as_ref();
 
-// To Py<T> with .into() or Py::from()
-let _: Py<PyList> = list.into();
+// To PyDetached<T> with .into() or PyDetached::from()
+let _: PyDetached<PyList> = list.into();
 
 // To PyObject with .into() or .to_object(py)
 let _: PyObject = list.into();
@@ -173,18 +173,18 @@ For a `Py<PyList>`, the conversions are as below:
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
 # Python::with_gil(|py| {
-let list: Py<PyList> = PyList::empty(py).into();
+let list: PyDetached<PyList> = PyList::empty(py).into();
 
-// To &PyList with Py::as_ref() (borrows from the Py)
+// To &PyList with PyDetached::as_ref() (borrows from the Py)
 let _: &PyList = list.as_ref(py);
 
 # let list_clone = list.clone(); // Because `.into_ref()` will consume `list`.
-// To &PyList with Py::into_ref() (moves the pointer into PyO3's object storage)
+// To &PyList with PyDetached::into_ref() (moves the pointer into PyO3's object storage)
 let _: &PyList = list.into_ref(py);
 
 # let list = list_clone;
-// To Py<PyAny> (aka PyObject) with .into()
-let _: Py<PyAny> = list.into();
+// To PyDetached<PyAny> (aka PyObject) with .into()
+let _: PyDetached<PyAny> = list.into();
 # })
 ```
 
@@ -195,24 +195,24 @@ For a `#[pyclass] struct MyClass`, the conversions for `Py<MyClass>` are below:
 # Python::with_gil(|py| {
 # #[pyclass] struct MyClass { }
 # Python::with_gil(|py| -> PyResult<()> {
-let my_class: Py<MyClass> = Py::new(py, MyClass { })?;
+let my_class: PyDetached<MyClass> = PyDetached::new(py, MyClass { })?;
 
-// To &PyCell<MyClass> with Py::as_ref() (borrows from the Py)
+// To &PyCell<MyClass> with PyDetached::as_ref() (borrows from the Py)
 let _: &PyCell<MyClass> = my_class.as_ref(py);
 
 # let my_class_clone = my_class.clone(); // Because `.into_ref()` will consume `my_class`.
-// To &PyCell<MyClass> with Py::into_ref() (moves the pointer into PyO3's object storage)
+// To &PyCell<MyClass> with PyDetached::into_ref() (moves the pointer into PyO3's object storage)
 let _: &PyCell<MyClass> = my_class.into_ref(py);
 
 # let my_class = my_class_clone.clone();
-// To Py<PyAny> (aka PyObject) with .into_py(py)
-let _: Py<PyAny> = my_class.into_py(py);
+// To PyDetached<PyAny> (aka PyObject) with .into_py(py)
+let _: PyDetached<PyAny> = my_class.into_py(py);
 
 # let my_class = my_class_clone;
-// To PyRef<'_, MyClass> with Py::borrow or Py::try_borrow
+// To PyRef<'_, MyClass> with PyDetached::borrow or PyDetached::try_borrow
 let _: PyRef<'_, MyClass> = my_class.try_borrow(py)?;
 
-// To PyRefMut<'_, MyClass> with Py::borrow_mut or Py::try_borrow_mut
+// To PyRefMut<'_, MyClass> with PyDetached::borrow_mut or PyDetached::try_borrow_mut
 let _: PyRefMut<'_, MyClass> = my_class.try_borrow_mut(py)?;
 # Ok(())
 # }).unwrap();

--- a/newsfragments/3655.changed.md
+++ b/newsfragments/3655.changed.md
@@ -1,0 +1,1 @@
+Rename `Py<T>` to `PyDetached<T>`.

--- a/pyo3-benches/benches/bench_comparisons.rs
+++ b/pyo3-benches/benches/bench_comparisons.rs
@@ -45,8 +45,12 @@ impl OrderedRichcmp {
 
 fn bench_ordered_dunder_methods(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let obj1 = Py::new(py, OrderedDunderMethods(0)).unwrap().into_ref(py);
-        let obj2 = Py::new(py, OrderedDunderMethods(1)).unwrap().into_ref(py);
+        let obj1 = PyDetached::new(py, OrderedDunderMethods(0))
+            .unwrap()
+            .into_ref(py);
+        let obj2 = PyDetached::new(py, OrderedDunderMethods(1))
+            .unwrap()
+            .into_ref(py);
 
         b.iter(|| obj2.gt(obj1).unwrap());
     });
@@ -54,8 +58,8 @@ fn bench_ordered_dunder_methods(b: &mut Bencher<'_>) {
 
 fn bench_ordered_richcmp(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let obj1 = Py::new(py, OrderedRichcmp(0)).unwrap().into_ref(py);
-        let obj2 = Py::new(py, OrderedRichcmp(1)).unwrap().into_ref(py);
+        let obj1 = PyDetached::new(py, OrderedRichcmp(0)).unwrap().into_ref(py);
+        let obj2 = PyDetached::new(py, OrderedRichcmp(1)).unwrap().into_ref(py);
 
         b.iter(|| obj2.gt(obj1).unwrap());
     });

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -187,7 +187,7 @@ impl SelfType {
                             .map_err(::std::convert::Into::<_pyo3::PyErr>::into)
                             .and_then(
                                 #[allow(clippy::useless_conversion)]  // In case slf is PyCell<Self>
-                                #[allow(unknown_lints, clippy::unnecessary_fallible_conversions)]  // In case slf is Py<Self> (unknown_lints can be removed when MSRV is 1.75+)
+                                #[allow(unknown_lints, clippy::unnecessary_fallible_conversions)]  // In case slf is PyDetached<Self> (unknown_lints can be removed when MSRV is 1.75+)
                                 |cell| ::std::convert::TryFrom::try_from(cell).map_err(::std::convert::Into::into)
                             )
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -875,7 +875,7 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote! {
                 impl _pyo3::IntoPy<_pyo3::PyObject> for #cls {
                     fn into_py(self, py: _pyo3::Python) -> _pyo3::PyObject {
-                        _pyo3::IntoPy::into_py(_pyo3::Py::new(py, self).unwrap(), py)
+                        _pyo3::IntoPy::into_py(_pyo3::PyDetached::new(py, self).unwrap(), py)
                     }
                 }
             }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -6,7 +6,7 @@ use crate::pyclass::boolean_struct::False;
 use crate::type_object::PyTypeInfo;
 use crate::types::PyTuple;
 use crate::{
-    ffi, gil, Py, PyAny, PyCell, PyClass, PyNativeType, PyObject, PyRef, PyRefMut, Python,
+    ffi, gil, PyAny, PyCell, PyClass, PyDetached, PyNativeType, PyObject, PyRef, PyRefMut, Python,
 };
 use std::cell::Cell;
 use std::ptr::NonNull;
@@ -24,7 +24,7 @@ use std::ptr::NonNull;
 /// use pyo3::ffi;
 ///
 /// Python::with_gil(|py| {
-///     let s: Py<PyString> = "foo".into_py(py);
+///     let s: PyDetached<PyString> = "foo".into_py(py);
 ///     let ptr = s.as_ptr();
 ///
 ///     let is_really_a_pystring = unsafe { ffi::PyUnicode_CheckExact(ptr) };
@@ -180,7 +180,7 @@ pub trait IntoPy<T>: Sized {
 /// Extract a type from a Python object.
 ///
 ///
-/// Normal usage is through the `extract` methods on [`Py`] and  [`PyAny`], which forward to this trait.
+/// Normal usage is through the `extract` methods on [`PyDetached`] and  [`PyAny`], which forward to this trait.
 ///
 /// # Examples
 ///
@@ -190,7 +190,7 @@ pub trait IntoPy<T>: Sized {
 ///
 /// # fn main() -> PyResult<()> {
 /// Python::with_gil(|py| {
-///     let obj: Py<PyString> = PyString::new(py, "blah").into();
+///     let obj: PyDetached<PyString> = PyString::new(py, "blah").into();
 ///
 ///     // Straight from an owned reference
 ///     let s: &str = obj.extract(py)?;
@@ -440,8 +440,8 @@ mod implementations {
 }
 
 /// Converts `()` to an empty Python tuple.
-impl IntoPy<Py<PyTuple>> for () {
-    fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
+impl IntoPy<PyDetached<PyTuple>> for () {
+    fn into_py(self, py: Python<'_>) -> PyDetached<PyTuple> {
         PyTuple::empty(py).into()
     }
 }
@@ -547,7 +547,7 @@ where
 /// let t = TestClass { num: 10 };
 ///
 /// Python::with_gil(|py| {
-///     let pyvalue = Py::new(py, t).unwrap().to_object(py);
+///     let pyvalue = PyDetached::new(py, t).unwrap().to_object(py);
 ///     let t: TestClass = pyvalue.extract(py).unwrap();
 /// })
 /// ```

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -48,7 +48,7 @@
 //! ```
 
 use crate::{
-    ffi, types::*, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject,
+    ffi, types::*, FromPyObject, IntoPy, PyAny, PyDetached, PyObject, PyResult, Python, ToPyObject,
 };
 
 use num_bigint::{BigInt, BigUint};
@@ -110,11 +110,12 @@ impl<'source> FromPyObject<'source> for BigInt {
     fn extract(ob: &'source PyAny) -> PyResult<BigInt> {
         let py = ob.py();
         // fast path - checking for subclass of `int` just checks a bit in the type object
-        let num_owned: Py<PyLong>;
+        let num_owned: PyDetached<PyLong>;
         let num = if let Ok(long) = ob.downcast::<PyLong>() {
             long
         } else {
-            num_owned = unsafe { Py::from_owned_ptr_or_err(py, ffi::PyNumber_Index(ob.as_ptr()))? };
+            num_owned =
+                unsafe { PyDetached::from_owned_ptr_or_err(py, ffi::PyNumber_Index(ob.as_ptr()))? };
             num_owned.as_ref(py)
         };
         let n_bits = int_n_bits(num)?;
@@ -158,11 +159,12 @@ impl<'source> FromPyObject<'source> for BigUint {
     fn extract(ob: &'source PyAny) -> PyResult<BigUint> {
         let py = ob.py();
         // fast path - checking for subclass of `int` just checks a bit in the type object
-        let num_owned: Py<PyLong>;
+        let num_owned: PyDetached<PyLong>;
         let num = if let Ok(long) = ob.downcast::<PyLong>() {
             long
         } else {
-            num_owned = unsafe { Py::from_owned_ptr_or_err(py, ffi::PyNumber_Index(ob.as_ptr()))? };
+            num_owned =
+                unsafe { PyDetached::from_owned_ptr_or_err(py, ffi::PyNumber_Index(ob.as_ptr()))? };
             num_owned.as_ref(py)
         };
         let n_bits = int_n_bits(num)?;

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -52,7 +52,9 @@
 use crate::exceptions::PyValueError;
 use crate::sync::GILOnceCell;
 use crate::types::PyType;
-use crate::{intern, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject};
+use crate::{
+    intern, FromPyObject, IntoPy, PyAny, PyDetached, PyObject, PyResult, Python, ToPyObject,
+};
 use rust_decimal::Decimal;
 use std::str::FromStr;
 
@@ -68,7 +70,7 @@ impl FromPyObject<'_> for Decimal {
     }
 }
 
-static DECIMAL_CLS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+static DECIMAL_CLS: GILOnceCell<PyDetached<PyType>> = GILOnceCell::new();
 
 fn get_decimal_cls(py: Python<'_>) -> PyResult<&PyType> {
     DECIMAL_CLS

--- a/src/conversions/serde.rs
+++ b/src/conversions/serde.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "serde")]
 
-//! Enables (de)serialization of [`Py`]`<T>` objects via [serde](https://docs.rs/serde).
+//! Enables (de)serialization of [`PyDetached`]`<T>` objects via [serde](https://docs.rs/serde).
 //!
 //! # Setup
 //!
@@ -12,10 +12,10 @@
 //! serde = "1.0"
 //! ```
 
-use crate::{Py, PyAny, PyClass, Python};
+use crate::{PyAny, PyClass, PyDetached, Python};
 use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 
-impl<T> Serialize for Py<T>
+impl<T> Serialize for PyDetached<T>
 where
     T: Serialize + PyClass,
 {
@@ -31,18 +31,18 @@ where
     }
 }
 
-impl<'de, T> Deserialize<'de> for Py<T>
+impl<'de, T> Deserialize<'de> for PyDetached<T>
 where
     T: PyClass<BaseType = PyAny> + Deserialize<'de>,
 {
-    fn deserialize<D>(deserializer: D) -> Result<Py<T>, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<PyDetached<T>, D::Error>
     where
         D: Deserializer<'de>,
     {
         let deserialized = T::deserialize(deserializer)?;
 
         Python::with_gil(|py| {
-            Py::new(py, deserialized).map_err(|e| de::Error::custom(e.to_string()))
+            PyDetached::new(py, deserialized).map_err(|e| de::Error::custom(e.to_string()))
         })
     }
 }

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -1,7 +1,8 @@
 use crate::types::PySequence;
 use crate::{exceptions, PyErr};
 use crate::{
-    ffi, FromPyObject, IntoPy, Py, PyAny, PyDowncastError, PyObject, PyResult, Python, ToPyObject,
+    ffi, FromPyObject, IntoPy, PyAny, PyDetached, PyDowncastError, PyObject, PyResult, Python,
+    ToPyObject,
 };
 
 impl<T, const N: usize> IntoPy<PyObject> for [T; N]
@@ -14,10 +15,10 @@ where
 
             let ptr = ffi::PyList_New(len);
 
-            // We create the  `Py` pointer here for two reasons:
+            // We create the  `PyDetached` pointer here for two reasons:
             // - panics if the ptr is null
             // - its Drop cleans up the list if user code panics.
-            let list: Py<PyAny> = Py::from_owned_ptr(py, ptr);
+            let list: PyDetached<PyAny> = PyDetached::from_owned_ptr(py, ptr);
 
             for (i, obj) in (0..len).zip(self) {
                 let obj = obj.into_py(py).into_ptr();

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -3,7 +3,9 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use crate::exceptions::PyValueError;
 use crate::sync::GILOnceCell;
 use crate::types::PyType;
-use crate::{intern, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject};
+use crate::{
+    intern, FromPyObject, IntoPy, PyAny, PyDetached, PyObject, PyResult, Python, ToPyObject,
+};
 
 impl FromPyObject<'_> for IpAddr {
     fn extract(obj: &PyAny) -> PyResult<Self> {
@@ -27,7 +29,7 @@ impl FromPyObject<'_> for IpAddr {
 
 impl ToPyObject for Ipv4Addr {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        static IPV4_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+        static IPV4_ADDRESS: GILOnceCell<PyDetached<PyType>> = GILOnceCell::new();
         IPV4_ADDRESS
             .get_or_try_init_type_ref(py, "ipaddress", "IPv4Address")
             .expect("failed to load ipaddress.IPv4Address")
@@ -39,7 +41,7 @@ impl ToPyObject for Ipv4Addr {
 
 impl ToPyObject for Ipv6Addr {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        static IPV6_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+        static IPV6_ADDRESS: GILOnceCell<PyDetached<PyType>> = GILOnceCell::new();
         IPV6_ADDRESS
             .get_or_try_init_type_ref(py, "ipaddress", "IPv6Address")
             .expect("failed to load ipaddress.IPv6Address")

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -58,7 +58,7 @@ impl FromPyObject<'_> for OsString {
         {
             // Decode from Python's lossless bytes string representation back into raw bytes
             let fs_encoded_bytes = unsafe {
-                crate::Py::<crate::types::PyBytes>::from_owned_ptr(
+                crate::PyDetached::<crate::types::PyBytes>::from_owned_ptr(
                     ob.py(),
                     ffi::PyUnicode_EncodeFSDefault(pystring.as_ptr()),
                 )

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -3,7 +3,8 @@ use std::borrow::Cow;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    types::PyString, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject,
+    types::PyString, FromPyObject, IntoPy, PyAny, PyDetached, PyObject, PyResult, Python,
+    ToPyObject,
 };
 
 /// Converts a Rust `str` to a Python object.
@@ -27,9 +28,9 @@ impl<'a> IntoPy<PyObject> for &'a str {
     }
 }
 
-impl<'a> IntoPy<Py<PyString>> for &'a str {
+impl<'a> IntoPy<PyDetached<PyString>> for &'a str {
     #[inline]
-    fn into_py(self, py: Python<'_>) -> Py<PyString> {
+    fn into_py(self, py: Python<'_>) -> PyDetached<PyString> {
         PyString::new(py, self).into()
     }
 

--- a/src/coroutine/waker.rs
+++ b/src/coroutine/waker.rs
@@ -1,6 +1,6 @@
 use crate::sync::GILOnceCell;
 use crate::types::PyCFunction;
-use crate::{intern, wrap_pyfunction, Py, PyAny, PyObject, PyResult, Python};
+use crate::{intern, wrap_pyfunction, PyAny, PyDetached, PyObject, PyResult, Python};
 use pyo3_macros::pyfunction;
 use std::sync::Arc;
 use std::task::Wake;
@@ -65,7 +65,7 @@ impl LoopAndFuture {
     }
 
     fn set_result(&self, py: Python<'_>) -> PyResult<()> {
-        static RELEASE_WAITER: GILOnceCell<Py<PyCFunction>> = GILOnceCell::new();
+        static RELEASE_WAITER: GILOnceCell<PyDetached<PyCFunction>> = GILOnceCell::new();
         let release_waiter = RELEASE_WAITER
             .get_or_try_init(py, || wrap_pyfunction!(release_waiter, py).map(Into::into))?;
         // `Future.set_result` must be called in event loop thread,

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -100,7 +100,7 @@ macro_rules! import_exception {
         impl $name {
             fn type_object_raw(py: $crate::Python<'_>) -> *mut $crate::ffi::PyTypeObject {
                 use $crate::sync::GILOnceCell;
-                static TYPE_OBJECT: GILOnceCell<$crate::Py<$crate::types::PyType>> =
+                static TYPE_OBJECT: GILOnceCell<$crate::PyDetached<$crate::types::PyType>> =
                     GILOnceCell::new();
 
                 TYPE_OBJECT
@@ -238,7 +238,7 @@ macro_rules! create_exception_type_object {
         impl $name {
             fn type_object_raw(py: $crate::Python<'_>) -> *mut $crate::ffi::PyTypeObject {
                 use $crate::sync::GILOnceCell;
-                static TYPE_OBJECT: GILOnceCell<$crate::Py<$crate::types::PyType>> =
+                static TYPE_OBJECT: GILOnceCell<$crate::PyDetached<$crate::types::PyType>> =
                     GILOnceCell::new();
 
                 TYPE_OBJECT

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -4,7 +4,7 @@ use crate::Python;
 #[cfg(not(Py_LIMITED_API))]
 use crate::{
     types::{PyDict, PyString},
-    IntoPy, Py, PyAny,
+    IntoPy, PyAny, PyDetached,
 };
 #[cfg(not(any(Py_3_12, Py_LIMITED_API)))]
 use libc::wchar_t;
@@ -14,7 +14,7 @@ use libc::wchar_t;
 #[test]
 fn test_datetime_fromtimestamp() {
     Python::with_gil(|py| {
-        let args: Py<PyAny> = (100,).into_py(py);
+        let args: PyDetached<PyAny> = (100,).into_py(py);
         let dt: &PyAny = unsafe {
             PyDateTime_IMPORT();
             py.from_owned_ptr(PyDateTime_FromTimestamp(args.as_ptr()))
@@ -35,7 +35,7 @@ fn test_datetime_fromtimestamp() {
 #[test]
 fn test_date_fromtimestamp() {
     Python::with_gil(|py| {
-        let args: Py<PyAny> = (100,).into_py(py);
+        let args: PyDetached<PyAny> = (100,).into_py(py);
         let dt: &PyAny = unsafe {
             PyDateTime_IMPORT();
             py.from_owned_ptr(PyDate_FromTimestamp(args.as_ptr()))

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -786,7 +786,7 @@ mod tests {
     #[test]
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
     fn test_clone_without_gil() {
-        use crate::{Py, PyAny};
+        use crate::{PyAny, PyDetached};
         use std::{sync::Arc, thread};
 
         // Some events for synchronizing
@@ -795,7 +795,7 @@ mod tests {
         static REFCNT_CHECKED: Event = Event::new();
 
         Python::with_gil(|py| {
-            let obj: Arc<Py<PyAny>> = Arc::new(get_object(py));
+            let obj: Arc<PyDetached<PyAny>> = Arc::new(get_object(py));
             let thread_obj = Arc::clone(&obj);
 
             let count = obj.get_refcnt(py);
@@ -826,7 +826,7 @@ mod tests {
 
                 println!("4. The other thread is now hogging the GIL, we clone without it held");
                 // Cloning without GIL should not update reference count
-                let cloned = Py::clone(&*obj);
+                let cloned = PyDetached::clone(&*obj);
                 OBJECT_CLONED.set();
                 cloned
             });
@@ -851,7 +851,7 @@ mod tests {
     #[test]
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
     fn test_clone_in_other_thread() {
-        use crate::Py;
+        use crate::PyDetached;
         use std::{sync::Arc, thread};
 
         // Some events for synchronizing
@@ -866,7 +866,7 @@ mod tests {
             let t = thread::spawn(move || {
                 // Cloning without GIL should not update reference count
                 #[allow(clippy::redundant_clone)]
-                let _ = Py::clone(&*thread_obj);
+                let _ = PyDetached::clone(&*thread_obj);
                 OBJECT_CLONED.set();
             });
 

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -7,7 +7,8 @@ use crate::{
     pycell::PyCellLayout,
     pyclass_init::PyObjectInit,
     types::PyBool,
-    Py, PyAny, PyCell, PyClass, PyErr, PyMethodDefType, PyNativeType, PyResult, PyTypeInfo, Python,
+    PyAny, PyCell, PyClass, PyDetached, PyErr, PyMethodDefType, PyNativeType, PyResult, PyTypeInfo,
+    Python,
 };
 use std::{
     borrow::Cow,
@@ -329,7 +330,7 @@ slot_fragment_trait! {
         attr: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
         Err(PyErr::new::<PyAttributeError, _>(
-            (Py::<PyAny>::from_borrowed_ptr(py, attr),)
+            (PyDetached::<PyAny>::from_borrowed_ptr(py, attr),)
         ))
     }
 }

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -61,7 +61,7 @@ impl<T: PyClass> LazyTypeObject<T> {
 }
 
 impl LazyTypeObjectInner {
-    // Uses dynamically dispatched fn(Python<'py>) -> PyResult<Py<PyType>
+    // Uses dynamically dispatched fn(Python<'py>) -> PyResult<PyDetached<PyType>
     // so that this code is only instantiated once, instead of for every T
     // like the generic LazyTypeObject<T> methods above.
     fn get_or_try_init<'py>(

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -11,12 +11,12 @@ use std::{
 
 use crate::{
     callback::PyCallbackOutput, ffi, impl_::panic::PanicTrap, methods::IPowModulo,
-    panic::PanicException, types::PyModule, GILPool, Py, PyResult, Python,
+    panic::PanicException, types::PyModule, GILPool, PyDetached, PyResult, Python,
 };
 
 #[inline]
 pub unsafe fn module_init(
-    f: for<'py> unsafe fn(Python<'py>) -> PyResult<Py<PyModule>>,
+    f: for<'py> unsafe fn(Python<'py>) -> PyResult<PyDetached<PyModule>>,
 ) -> *mut ffi::PyObject {
     trampoline(|py| f(py).map(|module| module.into_ptr()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! ## The GIL-independent types
 //!
-//! When wrapped in [`Py`]`<...>`, like with [`Py`]`<`[`PyAny`]`>` or [`Py`]`<SomePyClass>`, Python
+//! When wrapped in [`PyDetached`]`<...>`, like with [`PyDetached`]`<`[`PyAny`]`>` or [`PyDetached`]`<SomePyClass>`, Python
 //! objects no longer have a limited lifetime which makes them easier to store in structs and pass
 //! between functions. However, you cannot do much with them without a
 //! [`Python<'py>`](crate::Python) token, for which you’d need to reacquire the GIL.
@@ -94,7 +94,7 @@
 //! - [`rust_decimal`]: Enables conversions between Python's decimal.Decimal and [rust_decimal]'s
 //! [`Decimal`] type.
 //! - [`serde`]: Allows implementing [serde]'s [`Serialize`] and [`Deserialize`] traits for
-//! [`Py`]`<T>` for all `T` that implement [`Serialize`] and [`Deserialize`].
+//! [`PyDetached`]`<T>` for all `T` that implement [`Serialize`] and [`Deserialize`].
 //! - [`smallvec`][smallvec]: Enables conversions between Python list and [smallvec]'s [`SmallVec`].
 //!
 //! ## Unstable features
@@ -300,7 +300,7 @@ pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
 pub use crate::gil::GILPool;
 #[cfg(not(PyPy))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
-pub use crate::instance::{Py, PyNativeType, PyObject};
+pub use crate::instance::{PyDetached, PyNativeType, PyObject};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};
 pub use crate::pyclass::PyClass;
@@ -308,6 +308,9 @@ pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::type_object::{PyTypeCheck, PyTypeInfo};
 pub use crate::types::PyAny;
 pub use crate::version::PythonVersionInfo;
+
+#[allow(deprecated)]
+pub use crate::instance::Py;
 
 // Expected to become public API in 0.21 under a different name
 pub(crate) use crate::instance::Py2;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,11 +11,14 @@
 pub use crate::conversion::{FromPyObject, IntoPy, ToPyObject};
 pub use crate::conversion::{PyTryFrom, PyTryInto};
 pub use crate::err::{PyErr, PyResult};
-pub use crate::instance::{Py, PyObject};
+pub use crate::instance::{PyDetached, PyObject};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyCell, PyRef, PyRefMut};
 pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::types::{PyAny, PyModule};
+
+#[allow(deprecated)]
+pub use crate::Py;
 
 #[cfg(feature = "macros")]
 pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, FromPyObject};

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -92,7 +92,7 @@
 //! # }
 //! # fn main() -> PyResult<()> {
 //! Python::with_gil(|py| {
-//!     let n = Py::new(py, Number { inner: 0 })?;
+//!     let n = PyDetached::new(py, Number { inner: 0 })?;
 //!
 //!     // We borrow the guard and then dereference
 //!     // it to get a mutable reference to Number
@@ -128,7 +128,7 @@
 //! }
 //! # fn main() {
 //! #     Python::with_gil(|py| {
-//! #         let n = Py::new(py, Number{inner: 35}).unwrap();
+//! #         let n = PyDetached::new(py, Number{inner: 35}).unwrap();
 //! #         let n2 = n.clone_ref(py);
 //! #         assert!(n.is(&n2));
 //! #         let fun = pyo3::wrap_pyfunction!(swap_numbers, py).unwrap();
@@ -165,7 +165,7 @@
 //! # fn main() {
 //! #     // With duplicate numbers
 //! #     Python::with_gil(|py| {
-//! #         let n = Py::new(py, Number{inner: 35}).unwrap();
+//! #         let n = PyDetached::new(py, Number{inner: 35}).unwrap();
 //! #         let n2 = n.clone_ref(py);
 //! #         assert!(n.is(&n2));
 //! #         let fun = pyo3::wrap_pyfunction!(swap_numbers, py).unwrap();
@@ -174,8 +174,8 @@
 //! #
 //! #     // With two different numbers
 //! #     Python::with_gil(|py| {
-//! #         let n = Py::new(py, Number{inner: 35}).unwrap();
-//! #         let n2 = Py::new(py, Number{inner: 42}).unwrap();
+//! #         let n = PyDetached::new(py, Number{inner: 35}).unwrap();
+//! #         let n2 = PyDetached::new(py, Number{inner: 42}).unwrap();
 //! #         assert!(!n.is(&n2));
 //! #         let fun = pyo3::wrap_pyfunction!(swap_numbers, py).unwrap();
 //! #         fun.call1((&n, &n2)).unwrap();
@@ -283,7 +283,7 @@ impl<T: PyClass> PyCell<T> {
     /// Makes a new `PyCell` on the Python heap and return the reference to it.
     ///
     /// In cases where the value in the cell does not need to be accessed immediately after
-    /// creation, consider [`Py::new`](crate::Py::new) as a more efficient alternative.
+    /// creation, consider [`Py::new`](crate::PyDetached::new) as a more efficient alternative.
     pub fn new(py: Python<'_>, value: impl Into<PyClassInitializer<T>>) -> PyResult<&Self> {
         unsafe {
             let initializer = value.into();

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn test_mutable_borrow_prevents_further_borrows() {
         Python::with_gil(|py| {
-            let mmm = Py::new(
+            let mmm = PyDetached::new(
                 py,
                 PyClassInitializer::from(MutableBase)
                     .add_subclass(MutableChildOfMutableBase)
@@ -327,7 +327,7 @@ mod tests {
     #[test]
     fn test_immutable_borrows_prevent_mutable_borrows() {
         Python::with_gil(|py| {
-            let mmm = Py::new(
+            let mmm = PyDetached::new(
                 py,
                 PyClassInitializer::from(MutableBase)
                     .add_subclass(MutableChildOfMutableBase)

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -12,7 +12,8 @@ use crate::{
         trampoline::trampoline,
     },
     types::PyType,
-    Py, PyCell, PyClass, PyGetterDef, PyMethodDefType, PyResult, PySetterDef, PyTypeInfo, Python,
+    PyCell, PyClass, PyDetached, PyGetterDef, PyMethodDefType, PyResult, PySetterDef, PyTypeInfo,
+    Python,
 };
 use std::{
     borrow::Cow,
@@ -24,7 +25,7 @@ use std::{
 };
 
 pub(crate) struct PyClassTypeObject {
-    pub type_object: Py<PyType>,
+    pub type_object: PyDetached<PyType>,
     #[allow(dead_code)] // This is purely a cache that must live as long as the type object
     getset_destructors: Vec<GetSetDefDestructor>,
 }
@@ -428,8 +429,8 @@ impl PyTypeBuilder {
         };
 
         // Safety: We've correctly setup the PyType_Spec at this point
-        let type_object: Py<PyType> =
-            unsafe { Py::from_owned_ptr_or_err(py, ffi::PyType_FromSpec(&mut spec))? };
+        let type_object: PyDetached<PyType> =
+            unsafe { PyDetached::from_owned_ptr_or_err(py, ffi::PyType_FromSpec(&mut spec))? };
 
         #[cfg(not(Py_3_11))]
         bpo_45315_workaround(py, class_name);

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -1,7 +1,7 @@
 //! Contains initialization utilities for `#[pyclass]`.
 use crate::callback::IntoPyCallbackOutput;
 use crate::impl_::pyclass::{PyClassBaseType, PyClassDict, PyClassThreadChecker, PyClassWeakRef};
-use crate::{ffi, Py, PyCell, PyClass, PyErr, PyResult, Python};
+use crate::{ffi, PyCell, PyClass, PyDetached, PyErr, PyResult, Python};
 use crate::{
     ffi::PyTypeObject,
     pycell::{
@@ -137,7 +137,7 @@ impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
 pub struct PyClassInitializer<T: PyClass>(PyClassInitializerImpl<T>);
 
 enum PyClassInitializerImpl<T: PyClass> {
-    Existing(Py<T>),
+    Existing(PyDetached<T>),
     New {
         init: T,
         super_init: <T::BaseType as PyClassBaseType>::Initializer,
@@ -294,9 +294,9 @@ where
     }
 }
 
-impl<T: PyClass> From<Py<T>> for PyClassInitializer<T> {
+impl<T: PyClass> From<PyDetached<T>> for PyClassInitializer<T> {
     #[inline]
-    fn from(value: Py<T>) -> PyClassInitializer<T> {
+    fn from(value: PyDetached<T>) -> PyClassInitializer<T> {
         PyClassInitializer(PyClassInitializerImpl::Existing(value))
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,5 +1,5 @@
 //! Synchronization mechanisms based on the Python GIL.
-use crate::{types::PyString, types::PyType, Py, PyErr, PyVisit, Python};
+use crate::{types::PyString, types::PyType, PyDetached, PyErr, PyVisit, Python};
 use std::cell::UnsafeCell;
 
 /// Value with concurrent access protected by the GIL.
@@ -73,7 +73,7 @@ unsafe impl<T> Sync for GILProtected<T> where T: Send {}
 /// use pyo3::prelude::*;
 /// use pyo3::types::PyList;
 ///
-/// static LIST_CELL: GILOnceCell<Py<PyList>> = GILOnceCell::new();
+/// static LIST_CELL: GILOnceCell<PyDetached<PyList>> = GILOnceCell::new();
 ///
 /// pub fn get_shared_list(py: Python<'_>) -> &PyList {
 ///     LIST_CELL
@@ -187,7 +187,7 @@ impl<T> GILOnceCell<T> {
     }
 }
 
-impl GILOnceCell<Py<PyType>> {
+impl GILOnceCell<PyDetached<PyType>> {
     /// Get a reference to the contained Python type, initializing it if needed.
     ///
     /// This is a shorthand method for `get_or_init` which imports the type from Python on init.
@@ -249,7 +249,7 @@ macro_rules! intern {
 
 /// Implementation detail for `intern!` macro.
 #[doc(hidden)]
-pub struct Interned(&'static str, GILOnceCell<Py<PyString>>);
+pub struct Interned(&'static str, GILOnceCell<PyDetached<PyString>>);
 
 impl Interned {
     /// Creates an empty holder for an interned `str`.

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -75,11 +75,11 @@ mod inner {
 
     #[cfg(all(feature = "macros", Py_3_8))]
     impl UnraisableCapture {
-        pub fn install(py: Python<'_>) -> Py<Self> {
+        pub fn install(py: Python<'_>) -> PyDetached<Self> {
             let sys = py.import("sys").unwrap();
             let old_hook = sys.getattr("unraisablehook").unwrap().into();
 
-            let capture = Py::new(
+            let capture = PyDetached::new(
                 py,
                 UnraisableCapture {
                     capture: None,

--- a/src/tests/hygiene/pyclass.rs
+++ b/src/tests/hygiene/pyclass.rs
@@ -26,7 +26,7 @@ pub struct Bar {
     #[pyo3(get, set)]
     b: Foo,
     #[pyo3(get, set)]
-    c: ::std::option::Option<crate::Py<Foo2>>,
+    c: ::std::option::Option<crate::PyDetached<Foo2>>,
 }
 
 #[crate::pyclass]

--- a/src/tests/hygiene/pymethods.rs
+++ b/src/tests/hygiene/pymethods.rs
@@ -114,8 +114,11 @@ impl Dummy {
 
     fn __delitem__(&self, key: u32) {}
 
-    fn __iter__(_: crate::pycell::PyRef<'_, Self>, py: crate::Python<'_>) -> crate::Py<DummyIter> {
-        crate::Py::new(py, DummyIter {}).unwrap()
+    fn __iter__(
+        _: crate::pycell::PyRef<'_, Self>,
+        py: crate::Python<'_>,
+    ) -> crate::PyDetached<DummyIter> {
+        crate::PyDetached::new(py, DummyIter {}).unwrap()
     }
 
     fn __next__(&mut self) -> ::std::option::Option<()> {
@@ -125,8 +128,8 @@ impl Dummy {
     fn __reversed__(
         slf: crate::pycell::PyRef<'_, Self>,
         py: crate::Python<'_>,
-    ) -> crate::Py<DummyIter> {
-        crate::Py::new(py, DummyIter {}).unwrap()
+    ) -> crate::PyDetached<DummyIter> {
+        crate::PyDetached::new(py, DummyIter {}).unwrap()
     }
 
     fn __contains__(&self, item: u32) -> bool {
@@ -343,8 +346,8 @@ impl Dummy {
     fn __aiter__(
         slf: crate::pycell::PyRef<'_, Self>,
         py: crate::Python<'_>,
-    ) -> crate::Py<DummyIter> {
-        crate::Py::new(py, DummyIter {}).unwrap()
+    ) -> crate::PyDetached<DummyIter> {
+        crate::PyDetached::new(py, DummyIter {}).unwrap()
     }
 
     fn __anext__(&mut self) -> ::std::option::Option<()> {
@@ -507,8 +510,11 @@ impl Dummy {
 
     fn __delitem__(&self, key: u32) {}
 
-    fn __iter__(_: crate::pycell::PyRef<'_, Self>, py: crate::Python<'_>) -> crate::Py<DummyIter> {
-        crate::Py::new(py, DummyIter {}).unwrap()
+    fn __iter__(
+        _: crate::pycell::PyRef<'_, Self>,
+        py: crate::Python<'_>,
+    ) -> crate::PyDetached<DummyIter> {
+        crate::PyDetached::new(py, DummyIter {}).unwrap()
     }
 
     fn __next__(&mut self) -> ::std::option::Option<()> {
@@ -518,8 +524,8 @@ impl Dummy {
     fn __reversed__(
         slf: crate::pycell::PyRef<'_, Self>,
         py: crate::Python<'_>,
-    ) -> crate::Py<DummyIter> {
-        crate::Py::new(py, DummyIter {}).unwrap()
+    ) -> crate::PyDetached<DummyIter> {
+        crate::PyDetached::new(py, DummyIter {}).unwrap()
     }
 
     fn __contains__(&self, item: u32) -> bool {
@@ -735,8 +741,8 @@ impl Dummy {
     fn __aiter__(
         slf: crate::pycell::PyRef<'_, Self>,
         py: crate::Python<'_>,
-    ) -> crate::Py<DummyIter> {
-        crate::Py::new(py, DummyIter {}).unwrap()
+    ) -> crate::PyDetached<DummyIter> {
+        crate::PyDetached::new(py, DummyIter {}).unwrap()
     }
 
     fn __anext__(&mut self) -> ::std::option::Option<()> {

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -29,7 +29,7 @@ pub trait PySizedLayout<T>: PyLayout<T> + Sized {}
 /// - `Py<Self>::as_ref` will hand out references to `Self::AsRefTarget`.
 /// - `Self::AsRefTarget` must have the same layout as `UnsafeCell<ffi::PyAny>`.
 pub unsafe trait HasPyGilRef {
-    /// Utility type to make Py::as_ref work.
+    /// Utility type to make PyDetached::as_ref work.
     type AsRefTarget: PyNativeType;
 }
 

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -1,5 +1,5 @@
 use crate::err::{PyErr, PyResult};
-use crate::{ffi, AsPyPointer, Py, PyAny, Python};
+use crate::{ffi, AsPyPointer, PyAny, PyDetached, Python};
 use std::os::raw::c_char;
 use std::slice;
 
@@ -51,7 +51,8 @@ impl PyByteArray {
             let pyptr =
                 ffi::PyByteArray_FromStringAndSize(std::ptr::null(), len as ffi::Py_ssize_t);
             // Check for an allocation error and return it
-            let pypybytearray: Py<PyByteArray> = Py::from_owned_ptr_or_err(py, pyptr)?;
+            let pypybytearray: PyDetached<PyByteArray> =
+                PyDetached::from_owned_ptr_or_err(py, pyptr)?;
             let buffer: *mut u8 = ffi::PyByteArray_AsString(pyptr).cast();
             debug_assert!(!buffer.is_null());
             // Zero-initialise the uninitialised bytearray

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,4 +1,4 @@
-use crate::{ffi, FromPyObject, IntoPy, Py, PyAny, PyResult, Python, ToPyObject};
+use crate::{ffi, FromPyObject, IntoPy, PyAny, PyDetached, PyResult, Python, ToPyObject};
 use std::borrow::Cow;
 use std::ops::Index;
 use std::os::raw::c_char;
@@ -57,7 +57,7 @@ impl PyBytes {
         unsafe {
             let pyptr = ffi::PyBytes_FromStringAndSize(std::ptr::null(), len as ffi::Py_ssize_t);
             // Check for an allocation error and return it
-            let pypybytes: Py<PyBytes> = Py::from_owned_ptr_or_err(py, pyptr)?;
+            let pypybytes: PyDetached<PyBytes> = PyDetached::from_owned_ptr_or_err(py, pyptr)?;
             let buffer: *mut u8 = ffi::PyBytes_AsString(pyptr).cast();
             debug_assert!(!buffer.is_null());
             // Zero-initialise the uninitialised bytestring
@@ -97,7 +97,7 @@ impl PyBytes {
     }
 }
 
-impl Py<PyBytes> {
+impl PyDetached<PyBytes> {
     /// Gets the Python bytes as a byte slice. Because Python bytes are
     /// immutable, the result may be used for as long as the reference to
     /// `self` is held, including when the GIL is released.
@@ -141,13 +141,13 @@ impl<'source> FromPyObject<'source> for Cow<'source, [u8]> {
 }
 
 impl ToPyObject for Cow<'_, [u8]> {
-    fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
+    fn to_object(&self, py: Python<'_>) -> PyDetached<PyAny> {
         PyBytes::new(py, self.as_ref()).into()
     }
 }
 
-impl IntoPy<Py<PyAny>> for Cow<'_, [u8]> {
-    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
+impl IntoPy<PyDetached<PyAny>> for Cow<'_, [u8]> {
+    fn into_py(self, py: Python<'_>) -> PyDetached<PyAny> {
         self.to_object(py)
     }
 }

--- a/src/types/capsule.rs
+++ b/src/types/capsule.rs
@@ -309,7 +309,7 @@ mod tests {
     use libc::c_void;
 
     use crate::prelude::PyModule;
-    use crate::{types::PyCapsule, Py, PyResult, Python};
+    use crate::{types::PyCapsule, PyDetached, PyResult, Python};
     use std::ffi::CString;
     use std::sync::mpsc::{channel, Sender};
 
@@ -347,7 +347,7 @@ mod tests {
             x
         }
 
-        let cap: Py<PyCapsule> = Python::with_gil(|py| {
+        let cap: PyDetached<PyCapsule> = Python::with_gil(|py| {
             let name = CString::new("foo").unwrap();
             let cap = PyCapsule::new(py, foo as fn(u32) -> u32, Some(name)).unwrap();
             cap.into()
@@ -408,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_vec_storage() {
-        let cap: Py<PyCapsule> = Python::with_gil(|py| {
+        let cap: PyDetached<PyCapsule> = Python::with_gil(|py| {
             let name = CString::new("foo").unwrap();
 
             let stuff: Vec<u8> = vec![1, 2, 3, 4];
@@ -427,7 +427,7 @@ mod tests {
     fn test_vec_context() {
         let context: Vec<u8> = vec![1, 2, 3, 4];
 
-        let cap: Py<PyCapsule> = Python::with_gil(|py| {
+        let cap: PyDetached<PyCapsule> = Python::with_gil(|py| {
             let name = CString::new("foo").unwrap();
             let cap = PyCapsule::new(py, 0, Some(name)).unwrap();
             cap.set_context(Box::into_raw(Box::new(&context)) as _)

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -21,7 +21,7 @@ use crate::ffi::{
 };
 use crate::instance::PyNativeType;
 use crate::types::PyTuple;
-use crate::{AsPyPointer, IntoPy, Py, PyAny, Python};
+use crate::{AsPyPointer, IntoPy, PyAny, PyDetached, Python};
 use std::os::raw::c_int;
 #[cfg(feature = "chrono")]
 use std::ptr;
@@ -312,7 +312,7 @@ impl PyDateTime {
         timestamp: f64,
         tzinfo: Option<&PyTzInfo>,
     ) -> PyResult<&'p PyDateTime> {
-        let args: Py<PyTuple> = (timestamp, tzinfo).into_py(py);
+        let args: PyDetached<PyTuple> = (timestamp, tzinfo).into_py(py);
 
         // safety ensure API is loaded
         let _api = ensure_datetime_api(py);

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -2,7 +2,7 @@
 use crate::types::PyIterator;
 use crate::{
     err::{self, PyErr, PyResult},
-    Py, PyObject,
+    PyDetached, PyObject,
 };
 use crate::{ffi, PyAny, Python, ToPyObject};
 
@@ -201,14 +201,14 @@ pub use impl_::*;
 pub(crate) fn new_from_iter<T: ToPyObject>(
     py: Python<'_>,
     elements: impl IntoIterator<Item = T>,
-) -> PyResult<Py<PyFrozenSet>> {
+) -> PyResult<PyDetached<PyFrozenSet>> {
     fn inner(
         py: Python<'_>,
         elements: &mut dyn Iterator<Item = PyObject>,
-    ) -> PyResult<Py<PyFrozenSet>> {
-        let set: Py<PyFrozenSet> = unsafe {
-            // We create the  `Py` pointer because its Drop cleans up the set if user code panics.
-            Py::from_owned_ptr_or_err(py, ffi::PyFrozenSet_New(std::ptr::null_mut()))?
+    ) -> PyResult<PyDetached<PyFrozenSet>> {
+        let set: PyDetached<PyFrozenSet> = unsafe {
+            // We create the  `PyDetached` pointer because its Drop cleans up the set if user code panics.
+            PyDetached::from_owned_ptr_or_err(py, ffi::PyFrozenSet_New(std::ptr::null_mut()))?
         };
         let ptr = set.as_ptr();
 

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -108,7 +108,7 @@ impl PyCFunction {
         py_or_module: PyFunctionArguments<'py>,
     ) -> PyResult<&'py Self> {
         let (py, module) = py_or_module.into_py_and_maybe_module();
-        let (mod_ptr, module_name): (_, Option<Py<PyString>>) = if let Some(m) = module {
+        let (mod_ptr, module_name): (_, Option<PyDetached<PyString>>) = if let Some(m) = module {
             let mod_ptr = m.as_ptr();
             (mod_ptr, Some(m.name()?.into_py(py)))
         } else {
@@ -122,7 +122,7 @@ impl PyCFunction {
 
         let module_name_ptr = module_name
             .as_ref()
-            .map_or(std::ptr::null_mut(), Py::as_ptr);
+            .map_or(std::ptr::null_mut(), PyDetached::as_ptr);
 
         unsafe {
             py.from_owned_ptr_or_err::<PyCFunction>(ffi::PyCFunction_NewEx(

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -108,7 +108,7 @@ mod tests {
     use crate::exceptions::PyTypeError;
     use crate::gil::GILPool;
     use crate::types::{PyDict, PyList};
-    use crate::{Py, PyAny, Python, ToPyObject};
+    use crate::{PyAny, PyDetached, Python, ToPyObject};
 
     #[test]
     fn vec_iter() {
@@ -218,7 +218,8 @@ def fibonacci(target):
 
     fn iterator_try_from() {
         Python::with_gil(|py| {
-            let obj: Py<PyAny> = vec![10, 20].to_object(py).as_ref(py).iter().unwrap().into();
+            let obj: PyDetached<PyAny> =
+                vec![10, 20].to_object(py).as_ref(py).iter().unwrap().into();
             let iter: &PyIterator = obj.downcast(py).unwrap();
             assert!(obj.is(iter));
         });
@@ -243,7 +244,7 @@ def fibonacci(target):
 
         // Regression test for 2913
         Python::with_gil(|py| {
-            let downcaster = Py::new(py, Downcaster { failed: None }).unwrap();
+            let downcaster = PyDetached::new(py, Downcaster { failed: None }).unwrap();
             crate::py_run!(
                 py,
                 downcaster,

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -2,7 +2,7 @@ use crate::err::{PyDowncastError, PyResult};
 use crate::sync::GILOnceCell;
 use crate::type_object::PyTypeInfo;
 use crate::types::{PyAny, PyDict, PySequence, PyType};
-use crate::{ffi, Py, PyNativeType, PyTypeCheck, Python, ToPyObject};
+use crate::{ffi, PyDetached, PyNativeType, PyTypeCheck, Python, ToPyObject};
 
 /// Represents a reference to a Python object supporting the mapping protocol.
 #[repr(transparent)]
@@ -110,7 +110,7 @@ impl PyMapping {
     }
 }
 
-static MAPPING_ABC: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+static MAPPING_ABC: GILOnceCell<PyDetached<PyType>> = GILOnceCell::new();
 
 fn get_mapping_abc(py: Python<'_>) -> PyResult<&PyType> {
     MAPPING_ABC

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -158,18 +158,18 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
-        impl<$($generics,)*> $crate::IntoPy<$crate::Py<$name>> for &'_ $name {
+        impl<$($generics,)*> $crate::IntoPy<$crate::PyDetached<$name>> for &'_ $name {
             #[inline]
-            fn into_py(self, py: $crate::Python<'_>) -> $crate::Py<$name> {
-                unsafe { $crate::Py::from_borrowed_ptr(py, self.as_ptr()) }
+            fn into_py(self, py: $crate::Python<'_>) -> $crate::PyDetached<$name> {
+                unsafe { $crate::PyDetached::from_borrowed_ptr(py, self.as_ptr()) }
             }
         }
 
-        impl<$($generics,)*> ::std::convert::From<&'_ $name> for $crate::Py<$name> {
+        impl<$($generics,)*> ::std::convert::From<&'_ $name> for $crate::PyDetached<$name> {
             #[inline]
             fn from(other: &$name) -> Self {
                 use $crate::PyNativeType;
-                unsafe { $crate::Py::from_borrowed_ptr(other.py(), other.as_ptr()) }
+                unsafe { $crate::PyDetached::from_borrowed_ptr(other.py(), other.as_ptr()) }
             }
         }
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -4,7 +4,7 @@ use crate::exceptions;
 use crate::ffi;
 use crate::pyclass::PyClass;
 use crate::types::{PyAny, PyCFunction, PyDict, PyList, PyString};
-use crate::{IntoPy, Py, PyObject, Python};
+use crate::{IntoPy, PyDetached, PyObject, Python};
 use std::ffi::{CStr, CString};
 use std::str;
 
@@ -63,9 +63,9 @@ impl PyModule {
     /// ```
     pub fn import<N>(py: Python<'_>, name: N) -> PyResult<&PyModule>
     where
-        N: IntoPy<Py<PyString>>,
+        N: IntoPy<PyDetached<PyString>>,
     {
-        let name: Py<PyString> = name.into_py(py);
+        let name: PyDetached<PyString> = name.into_py(py);
         unsafe { py.from_owned_ptr_or_err(ffi::PyImport_Import(name.as_ptr())) }
     }
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -9,7 +9,7 @@ use crate::py_result_ext::PyResultExt;
 use crate::sync::GILOnceCell;
 use crate::type_object::PyTypeInfo;
 use crate::types::{PyAny, PyList, PyString, PyTuple, PyType};
-use crate::{ffi, FromPyObject, Py, PyNativeType, PyTypeCheck, Python, ToPyObject};
+use crate::{ffi, FromPyObject, PyDetached, PyNativeType, PyTypeCheck, Python, ToPyObject};
 
 /// Represents a reference to a Python object supporting the sequence protocol.
 #[repr(transparent)]
@@ -523,7 +523,7 @@ where
     Ok(v)
 }
 
-static SEQUENCE_ABC: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+static SEQUENCE_ABC: GILOnceCell<PyDetached<PyType>> = GILOnceCell::new();
 
 fn get_sequence_abc(py: Python<'_>) -> PyResult<&PyType> {
     SEQUENCE_ABC

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -2,7 +2,7 @@
 use crate::types::PyIterator;
 use crate::{
     err::{self, PyErr, PyResult},
-    Py,
+    PyDetached,
 };
 use crate::{ffi, PyAny, PyObject, Python, ToPyObject};
 use std::ptr;
@@ -248,11 +248,14 @@ pub use impl_::*;
 pub(crate) fn new_from_iter<T: ToPyObject>(
     py: Python<'_>,
     elements: impl IntoIterator<Item = T>,
-) -> PyResult<Py<PySet>> {
-    fn inner(py: Python<'_>, elements: &mut dyn Iterator<Item = PyObject>) -> PyResult<Py<PySet>> {
-        let set: Py<PySet> = unsafe {
-            // We create the  `Py` pointer because its Drop cleans up the set if user code panics.
-            Py::from_owned_ptr_or_err(py, ffi::PySet_New(std::ptr::null_mut()))?
+) -> PyResult<PyDetached<PySet>> {
+    fn inner(
+        py: Python<'_>,
+        elements: &mut dyn Iterator<Item = PyObject>,
+    ) -> PyResult<PyDetached<PySet>> {
+        let set: PyDetached<PySet> = unsafe {
+            // We create the  `PyDetached` pointer because its Drop cleans up the set if user code panics.
+            PyDetached::from_owned_ptr_or_err(py, ffi::PySet_New(std::ptr::null_mut()))?
         };
         let ptr = set.as_ptr();
 

--- a/tests/test_buffer.rs
+++ b/tests/test_buffer.rs
@@ -87,7 +87,7 @@ impl TestBufferErrors {
 #[test]
 fn test_get_buffer_errors() {
     Python::with_gil(|py| {
-        let instance = Py::new(
+        let instance = PyDetached::new(
             py,
             TestBufferErrors {
                 buf: vec![0, 1, 2, 3],

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -49,7 +49,7 @@ fn test_buffer() {
     let drop_called = Arc::new(AtomicBool::new(false));
 
     Python::with_gil(|py| {
-        let instance = Py::new(
+        let instance = PyDetached::new(
             py,
             TestBufferClass {
                 vec: vec![b' ', b'2', b'3'],
@@ -121,7 +121,7 @@ fn test_releasebuffer_unraisable_error() {
     Python::with_gil(|py| {
         let capture = UnraisableCapture::install(py);
 
-        let instance = Py::new(py, ReleaseBufferError {}).unwrap();
+        let instance = PyDetached::new(py, ReleaseBufferError {}).unwrap();
         let env = [("ob", instance.clone())].into_py_dict(py);
 
         assert!(capture.borrow(py).capture.is_none());

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -42,7 +42,7 @@ fn test_bytearray_vec_conversion() {
 
 #[test]
 fn test_py_as_bytes() {
-    let pyobj: pyo3::Py<pyo3::types::PyBytes> =
+    let pyobj: pyo3::PyDetached<pyo3::types::PyBytes> =
         Python::with_gil(|py| pyo3::types::PyBytes::new(py, b"abc").into_py(py));
 
     let data = Python::with_gil(|py| pyobj.as_bytes(py));

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -48,8 +48,8 @@ impl Foo {
     }
 
     #[classattr]
-    fn a_foo_with_py(py: Python<'_>) -> Py<Foo> {
-        Py::new(py, Foo { x: 1 }).unwrap()
+    fn a_foo_with_py(py: Python<'_>) -> PyDetached<Foo> {
+        PyDetached::new(py, Foo { x: 1 }).unwrap()
     }
 }
 

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -230,7 +230,7 @@ impl UnsendableChild {
 
 fn test_unsendable<T: PyClass + 'static>() -> PyResult<()> {
     let obj = Python::with_gil(|py| -> PyResult<_> {
-        let obj: Py<T> = PyType::new::<T>(py).call1((5,))?.extract()?;
+        let obj: PyDetached<T> = PyType::new::<T>(py).call1((5,))?.extract()?;
 
         // Accessing the value inside this thread should not panic
         let caught_panic =
@@ -312,7 +312,7 @@ impl ClassWithFromPyWithMethods {
 #[test]
 fn test_pymethods_from_py_with() {
     Python::with_gil(|py| {
-        let instance = Py::new(py, ClassWithFromPyWithMethods {}).unwrap();
+        let instance = PyDetached::new(py, ClassWithFromPyWithMethods {}).unwrap();
 
         py_run!(
             py,
@@ -339,7 +339,7 @@ fn test_tuple_struct_class() {
 
         py_assert!(py, typeobj, "typeobj.__name__ == 'TupleClass'");
 
-        let instance = Py::new(py, TupleClass(5)).unwrap();
+        let instance = PyDetached::new(py, TupleClass(5)).unwrap();
         py_run!(
             py,
             instance,
@@ -522,7 +522,7 @@ fn access_frozen_class_without_gil() {
         value: AtomicUsize,
     }
 
-    let py_counter: Py<FrozenCounter> = Python::with_gil(|py| {
+    let py_counter: PyDetached<FrozenCounter> = Python::with_gil(|py| {
         let counter = FrozenCounter {
             value: AtomicUsize::new(0),
         };
@@ -564,7 +564,7 @@ fn drop_unsendable_elsewhere() {
 
         let dropped = Arc::new(AtomicBool::new(false));
 
-        let unsendable = Py::new(
+        let unsendable = PyDetached::new(
             py,
             Unsendable {
                 dropped: dropped.clone(),

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -18,7 +18,7 @@ fn test_cloneable_pyclass() {
     let c = Cloneable { x: 10 };
 
     Python::with_gil(|py| {
-        let py_c = Py::new(py, c.clone()).unwrap().to_object(py);
+        let py_c = PyDetached::new(py, c.clone()).unwrap().to_object(py);
 
         let c2: Cloneable = py_c.extract(py).unwrap();
         assert_eq!(c, c2);
@@ -58,7 +58,7 @@ impl SubClass {
 #[pyclass]
 struct PolymorphicContainer {
     #[pyo3(get, set)]
-    inner: Py<BaseClass>,
+    inner: PyDetached<BaseClass>,
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn test_polymorphic_container_stores_base_class() {
         let p = PyCell::new(
             py,
             PolymorphicContainer {
-                inner: Py::new(py, BaseClass::default()).unwrap(),
+                inner: PyDetached::new(py, BaseClass::default()).unwrap(),
             },
         )
         .unwrap()
@@ -83,7 +83,7 @@ fn test_polymorphic_container_stores_sub_class() {
         let p = PyCell::new(
             py,
             PolymorphicContainer {
-                inner: Py::new(py, BaseClass::default()).unwrap(),
+                inner: PyDetached::new(py, BaseClass::default()).unwrap(),
             },
         )
         .unwrap()
@@ -110,7 +110,7 @@ fn test_polymorphic_container_does_not_accept_other_types() {
         let p = PyCell::new(
             py,
             PolymorphicContainer {
-                inner: Py::new(py, BaseClass::default()).unwrap(),
+                inner: PyDetached::new(py, BaseClass::default()).unwrap(),
             },
         )
         .unwrap()

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -215,8 +215,8 @@ struct NewExisting {
 #[pymethods]
 impl NewExisting {
     #[new]
-    fn new(py: pyo3::Python<'_>, val: usize) -> pyo3::Py<NewExisting> {
-        static PRE_BUILT: GILOnceCell<[pyo3::Py<NewExisting>; 2]> = GILOnceCell::new();
+    fn new(py: pyo3::Python<'_>, val: usize) -> pyo3::PyDetached<NewExisting> {
+        static PRE_BUILT: GILOnceCell<[pyo3::PyDetached<NewExisting>; 2]> = GILOnceCell::new();
         let existing = PRE_BUILT.get_or_init(py, || {
             [
                 pyo3::PyCell::new(py, NewExisting { num: 0 })

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -48,9 +48,9 @@ fn test_coroutine_qualname() {
             Self
         }
         // TODO use &self when possible
-        async fn my_method(_self: Py<Self>) {}
+        async fn my_method(_self: PyDetached<Self>) {}
         #[classmethod]
-        async fn my_classmethod(_cls: Py<PyType>) {}
+        async fn my_classmethod(_cls: PyDetached<PyType>) {}
         #[staticmethod]
         async fn my_staticmethod() {}
     }
@@ -256,7 +256,7 @@ fn test_async_method_receiver() {
     Python::with_gil(|gil| {
         let test = r#"
         import asyncio
-        
+
         obj = Counter()
         coro1 = obj.get()
         coro2 = obj.get()

--- a/tests/test_default_impls.rs
+++ b/tests/test_default_impls.rs
@@ -14,7 +14,7 @@ enum TestDefaultRepr {
 #[test]
 fn test_default_slot_exists() {
     Python::with_gil(|py| {
-        let test_object = Py::new(py, TestDefaultRepr::Var).unwrap();
+        let test_object = PyDetached::new(py, TestDefaultRepr::Var).unwrap();
         py_assert!(
             py,
             test_object,
@@ -38,7 +38,7 @@ impl OverrideSlot {
 #[test]
 fn test_override_slot() {
     Python::with_gil(|py| {
-        let test_object = Py::new(py, OverrideSlot::Var).unwrap();
+        let test_object = PyDetached::new(py, OverrideSlot::Var).unwrap();
         py_assert!(py, test_object, "repr(test_object) == 'overridden'");
     })
 }

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -17,7 +17,7 @@ pub enum MyEnum {
 fn test_enum_class_attr() {
     Python::with_gil(|py| {
         let my_enum = py.get_type::<MyEnum>();
-        let var = Py::new(py, MyEnum::Variant).unwrap();
+        let var = PyDetached::new(py, MyEnum::Variant).unwrap();
         py_assert!(py, my_enum var, "my_enum.Variant == var");
     })
 }
@@ -55,9 +55,9 @@ fn test_enum_arg() {
 #[test]
 fn test_enum_eq_enum() {
     Python::with_gil(|py| {
-        let var1 = Py::new(py, MyEnum::Variant).unwrap();
-        let var2 = Py::new(py, MyEnum::Variant).unwrap();
-        let other_var = Py::new(py, MyEnum::OtherVariant).unwrap();
+        let var1 = PyDetached::new(py, MyEnum::Variant).unwrap();
+        let var2 = PyDetached::new(py, MyEnum::Variant).unwrap();
+        let other_var = PyDetached::new(py, MyEnum::OtherVariant).unwrap();
         py_assert!(py, var1 var2, "var1 == var2");
         py_assert!(py, var1 other_var, "var1 != other_var");
         py_assert!(py, var1 var2, "(var1 != var2) == False");
@@ -67,7 +67,7 @@ fn test_enum_eq_enum() {
 #[test]
 fn test_enum_eq_incomparable() {
     Python::with_gil(|py| {
-        let var1 = Py::new(py, MyEnum::Variant).unwrap();
+        let var1 = PyDetached::new(py, MyEnum::Variant).unwrap();
         py_assert!(py, var1, "(var1 == 'foo') == False");
         py_assert!(py, var1, "(var1 != 'foo') == True");
     })
@@ -84,8 +84,8 @@ fn test_custom_discriminant() {
     Python::with_gil(|py| {
         #[allow(non_snake_case)]
         let CustomDiscriminant = py.get_type::<CustomDiscriminant>();
-        let one = Py::new(py, CustomDiscriminant::One).unwrap();
-        let two = Py::new(py, CustomDiscriminant::Two).unwrap();
+        let one = PyDetached::new(py, CustomDiscriminant::One).unwrap();
+        let two = PyDetached::new(py, CustomDiscriminant::Two).unwrap();
         py_run!(py, CustomDiscriminant one two, r#"
         assert CustomDiscriminant.One == one
         assert CustomDiscriminant.Two == two
@@ -97,9 +97,9 @@ fn test_custom_discriminant() {
 #[test]
 fn test_enum_to_int() {
     Python::with_gil(|py| {
-        let one = Py::new(py, CustomDiscriminant::One).unwrap();
+        let one = PyDetached::new(py, CustomDiscriminant::One).unwrap();
         py_assert!(py, one, "int(one) == 1");
-        let v = Py::new(py, MyEnum::Variant).unwrap();
+        let v = PyDetached::new(py, MyEnum::Variant).unwrap();
         let v_value = MyEnum::Variant as isize;
         py_run!(py, v v_value, "int(v) == v_value");
     })
@@ -108,7 +108,7 @@ fn test_enum_to_int() {
 #[test]
 fn test_enum_compare_int() {
     Python::with_gil(|py| {
-        let one = Py::new(py, CustomDiscriminant::One).unwrap();
+        let one = PyDetached::new(py, CustomDiscriminant::One).unwrap();
         py_run!(
             py,
             one,
@@ -130,7 +130,7 @@ enum SmallEnum {
 #[test]
 fn test_enum_compare_int_no_throw_when_overflow() {
     Python::with_gil(|py| {
-        let v = Py::new(py, SmallEnum::V).unwrap();
+        let v = PyDetached::new(py, SmallEnum::V).unwrap();
         py_assert!(py, v, "v != 1<<30")
     })
 }
@@ -146,7 +146,7 @@ enum BigEnum {
 fn test_big_enum_no_overflow() {
     Python::with_gil(|py| {
         let usize_max = usize::MAX;
-        let v = Py::new(py, BigEnum::V).unwrap();
+        let v = PyDetached::new(py, BigEnum::V).unwrap();
         py_assert!(py, usize_max v, "v == usize_max");
         py_assert!(py, usize_max v, "int(v) == usize_max");
     })
@@ -172,7 +172,7 @@ pub enum RenameEnum {
 #[test]
 fn test_rename_enum_repr_correct() {
     Python::with_gil(|py| {
-        let var1 = Py::new(py, RenameEnum::Variant).unwrap();
+        let var1 = PyDetached::new(py, RenameEnum::Variant).unwrap();
         py_assert!(py, var1, "repr(var1) == 'MyEnum.Variant'");
     })
 }
@@ -187,7 +187,7 @@ pub enum RenameVariantEnum {
 #[test]
 fn test_rename_variant_repr_correct() {
     Python::with_gil(|py| {
-        let var1 = Py::new(py, RenameVariantEnum::Variant).unwrap();
+        let var1 = PyDetached::new(py, RenameVariantEnum::Variant).unwrap();
         py_assert!(py, var1, "repr(var1) == 'RenameVariantEnum.VARIANT'");
     })
 }

--- a/tests/test_field_cfg.rs
+++ b/tests/test_field_cfg.rs
@@ -21,7 +21,7 @@ struct CfgClass {
 fn test_cfg() {
     Python::with_gil(|py| {
         let cfg = CfgClass { b: 3 };
-        let py_cfg = Py::new(py, cfg).unwrap();
+        let py_cfg = PyDetached::new(py, cfg).unwrap();
         assert!(py_cfg.as_ref(py).getattr("a").is_err());
         let b: u32 = py_cfg.as_ref(py).getattr("b").unwrap().extract().unwrap();
         assert_eq!(b, 3);

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -57,7 +57,7 @@ fn test_named_fields_struct() {
             s: "foo".into(),
             foo: None,
         };
-        let py_c = Py::new(py, pya).unwrap();
+        let py_c = PyDetached::new(py, pya).unwrap();
         let a: A<'_> =
             FromPyObject::extract(py_c.as_ref(py)).expect("Failed to extract A from PyA");
         assert_eq!(a.s, "foo");

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -50,7 +50,7 @@ impl ClassWithProperties {
 #[test]
 fn class_with_properties() {
     Python::with_gil(|py| {
-        let inst = Py::new(py, ClassWithProperties { num: 10 }).unwrap();
+        let inst = PyDetached::new(py, ClassWithProperties { num: 10 }).unwrap();
 
         py_run!(py, inst, "assert inst.get_num() == 10");
         py_run!(py, inst, "assert inst.get_num() == inst.DATA");
@@ -87,7 +87,7 @@ impl GetterSetter {
 #[test]
 fn getter_setter_autogen() {
     Python::with_gil(|py| {
-        let inst = Py::new(
+        let inst = PyDetached::new(
             py,
             GetterSetter {
                 num: 10,
@@ -128,7 +128,7 @@ impl RefGetterSetter {
 fn ref_getter_setter() {
     // Regression test for #837
     Python::with_gil(|py| {
-        let inst = Py::new(py, RefGetterSetter { num: 10 }).unwrap();
+        let inst = PyDetached::new(py, RefGetterSetter { num: 10 }).unwrap();
 
         py_run!(py, inst, "assert inst.num == 10");
         py_run!(py, inst, "inst.num = 20; assert inst.num == 20");
@@ -154,7 +154,7 @@ impl TupleClassGetterSetter {
 #[test]
 fn tuple_struct_getter_setter() {
     Python::with_gil(|py| {
-        let inst = Py::new(py, TupleClassGetterSetter(10)).unwrap();
+        let inst = PyDetached::new(py, TupleClassGetterSetter(10)).unwrap();
 
         py_assert!(py, inst, "inst.num == 10");
         py_run!(py, inst, "inst.num = 20");
@@ -170,7 +170,7 @@ struct All {
 #[test]
 fn get_set_all() {
     Python::with_gil(|py| {
-        let inst = Py::new(py, All { num: 10 }).unwrap();
+        let inst = PyDetached::new(py, All { num: 10 }).unwrap();
 
         py_run!(py, inst, "assert inst.num == 10");
         py_run!(py, inst, "inst.num = 20; assert inst.num == 20");
@@ -186,7 +186,7 @@ struct All2 {
 #[test]
 fn get_all_and_set() {
     Python::with_gil(|py| {
-        let inst = Py::new(py, All2 { num: 10 }).unwrap();
+        let inst = PyDetached::new(py, All2 { num: 10 }).unwrap();
 
         py_run!(py, inst, "assert inst.num == 10");
         py_run!(py, inst, "inst.num = 20; assert inst.num == 20");
@@ -205,7 +205,7 @@ fn cell_getter_setter() {
         cell_inner: Cell::new(10),
     };
     Python::with_gil(|py| {
-        let inst = Py::new(py, c).unwrap().to_object(py);
+        let inst = PyDetached::new(py, c).unwrap().to_object(py);
         let cell = Cell::new(20).to_object(py);
 
         py_run!(py, cell, "assert cell == 20");
@@ -232,7 +232,7 @@ fn borrowed_value_with_lifetime_of_self() {
     }
 
     Python::with_gil(|py| {
-        let inst = Py::new(py, BorrowedValue {}).unwrap().to_object(py);
+        let inst = PyDetached::new(py, BorrowedValue {}).unwrap().to_object(py);
 
         py_run!(py, inst, "assert inst.value == 'value'");
     });

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -237,7 +237,7 @@ mod inheriting_native_type {
     #[test]
     fn inherit_dict_drop() {
         Python::with_gil(|py| {
-            let dict_sub = pyo3::Py::new(py, DictWithName::new()).unwrap();
+            let dict_sub = pyo3::PyDetached::new(py, DictWithName::new()).unwrap();
             assert_eq!(dict_sub.get_refcnt(py), 1);
 
             let item = py.eval("object()", None, None).unwrap();

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -119,7 +119,7 @@ fn mapping_is_not_sequence() {
         let mut index = HashMap::new();
         index.insert("Foo".into(), 1);
         index.insert("Bar".into(), 2);
-        let m = Py::new(py, Mapping { index }).unwrap();
+        let m = PyDetached::new(py, Mapping { index }).unwrap();
 
         PyMapping::register::<Mapping>(py).unwrap();
 

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -78,7 +78,7 @@ impl ClassMethod {
     }
 
     #[classmethod]
-    fn method_owned(cls: Py<PyType>) -> PyResult<String> {
+    fn method_owned(cls: PyDetached<PyType>) -> PyResult<String> {
         Ok(format!(
             "{}.method_owned()!",
             Python::with_gil(|gil| cls.as_ref(gil).name().map(ToString::to_string))?
@@ -322,7 +322,7 @@ impl MethSignature {
 #[test]
 fn meth_signature() {
     Python::with_gil(|py| {
-        let inst = Py::new(py, MethSignature {}).unwrap();
+        let inst = PyDetached::new(py, MethSignature {}).unwrap();
 
         py_run!(py, inst, "assert inst.get_optional() == 10");
         py_run!(py, inst, "assert inst.get_optional(100) == 100");
@@ -814,7 +814,7 @@ impl CfgStruct {
 #[test]
 fn test_cfg_attrs() {
     Python::with_gil(|py| {
-        let inst = Py::new(py, CfgStruct {}).unwrap();
+        let inst = PyDetached::new(py, CfgStruct {}).unwrap();
 
         #[cfg(unix)]
         {
@@ -1036,7 +1036,7 @@ issue_1506!(
         }
 
         fn issue_1506_custom_receiver(
-            _slf: Py<Self>,
+            _slf: PyDetached<Self>,
             _py: Python<'_>,
             _arg: &PyAny,
             _args: &PyTuple,
@@ -1045,7 +1045,7 @@ issue_1506!(
         }
 
         fn issue_1506_custom_receiver_explicit(
-            _slf: Py<Issue1506>,
+            _slf: PyDetached<Issue1506>,
             _py: Python<'_>,
             _arg: &PyAny,
             _args: &PyTuple,
@@ -1118,11 +1118,11 @@ fn test_option_pyclass_arg() {
     Python::with_gil(|py| {
         let f = wrap_pyfunction!(option_class_arg, py).unwrap();
         assert!(f.call0().unwrap().is_none());
-        let obj = Py::new(py, SomePyClass {}).unwrap();
+        let obj = PyDetached::new(py, SomePyClass {}).unwrap();
         assert!(f
             .call1((obj,))
             .unwrap()
-            .extract::<Py<SomePyClass>>()
+            .extract::<PyDetached<SomePyClass>>()
             .is_ok());
     })
 }

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -350,7 +350,7 @@ fn pyfunction_with_module(module: &PyModule) -> PyResult<&str> {
 
 #[pyfunction]
 #[pyo3(pass_module)]
-fn pyfunction_with_module_owned(module: Py<PyModule>) -> PyResult<String> {
+fn pyfunction_with_module_owned(module: PyDetached<PyModule>) -> PyResult<String> {
     Python::with_gil(|gil| module.as_ref(gil).name().map(Into::into))
 }
 

--- a/tests/test_no_imports.rs
+++ b/tests/test_no_imports.rs
@@ -65,7 +65,7 @@ impl BasicClass {
     }
 
     #[staticmethod]
-    fn staticmethod(py: pyo3::Python<'_>, v: usize) -> pyo3::Py<pyo3::PyAny> {
+    fn staticmethod(py: pyo3::Python<'_>, v: usize) -> pyo3::PyDetached<pyo3::PyAny> {
         use pyo3::IntoPy;
         v.to_string().into_py(py)
     }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -65,7 +65,7 @@ impl ExampleClass {
 }
 
 fn make_example(py: Python<'_>) -> &PyCell<ExampleClass> {
-    Py::new(
+    PyDetached::new(
         py,
         ExampleClass {
             value: 5,
@@ -178,14 +178,14 @@ impl LenOverflow {
 #[test]
 fn len_overflow() {
     Python::with_gil(|py| {
-        let inst = Py::new(py, LenOverflow).unwrap();
+        let inst = PyDetached::new(py, LenOverflow).unwrap();
         py_expect_exception!(py, inst, "len(inst)", PyOverflowError);
     });
 }
 
 #[pyclass]
 pub struct Mapping {
-    values: Py<PyDict>,
+    values: PyDetached<PyDict>,
 }
 
 #[pymethods]
@@ -213,7 +213,7 @@ fn mapping() {
     Python::with_gil(|py| {
         PyMapping::register::<Mapping>(py).unwrap();
 
-        let inst = Py::new(
+        let inst = PyDetached::new(
             py,
             Mapping {
                 values: PyDict::new(py).into(),
@@ -321,7 +321,7 @@ fn sequence() {
     Python::with_gil(|py| {
         PySequence::register::<Sequence>(py).unwrap();
 
-        let inst = Py::new(py, Sequence { values: vec![] }).unwrap();
+        let inst = PyDetached::new(py, Sequence { values: vec![] }).unwrap();
 
         let sequence: &PySequence = inst.as_ref(py).downcast().unwrap();
 
@@ -382,7 +382,7 @@ impl Iterator {
 #[test]
 fn iterator() {
     Python::with_gil(|py| {
-        let inst = Py::new(
+        let inst = PyDetached::new(
             py,
             Iterator {
                 iter: Box::new(5..8),
@@ -410,11 +410,11 @@ struct NotCallable;
 #[test]
 fn callable() {
     Python::with_gil(|py| {
-        let c = Py::new(py, Callable).unwrap();
+        let c = PyDetached::new(py, Callable).unwrap();
         py_assert!(py, c, "callable(c)");
         py_assert!(py, c, "c(7) == 42");
 
-        let nc = Py::new(py, NotCallable).unwrap();
+        let nc = PyDetached::new(py, NotCallable).unwrap();
         py_assert!(py, nc, "not callable(nc)");
     });
 }
@@ -517,7 +517,7 @@ impl Contains {
 #[test]
 fn contains() {
     Python::with_gil(|py| {
-        let c = Py::new(py, Contains {}).unwrap();
+        let c = PyDetached::new(py, Contains {}).unwrap();
         py_run!(py, c, "assert 1 in c");
         py_run!(py, c, "assert -1 not in c");
         py_expect_exception!(py, c, "assert 'wrong type' not in c", PyTypeError);
@@ -547,7 +547,7 @@ impl GetItem {
 #[test]
 fn test_getitem() {
     Python::with_gil(|py| {
-        let ob = Py::new(py, GetItem {}).unwrap();
+        let ob = PyDetached::new(py, GetItem {}).unwrap();
 
         py_assert!(py, ob, "ob[1] == 'int'");
         py_assert!(py, ob, "ob[100:200:1] == 'slice'");
@@ -697,13 +697,13 @@ asyncio.run(main())
 
 #[pyclass]
 struct AsyncIterator {
-    future: Option<Py<OnceFuture>>,
+    future: Option<PyDetached<OnceFuture>>,
 }
 
 #[pymethods]
 impl AsyncIterator {
     #[new]
-    fn new(future: Py<OnceFuture>) -> Self {
+    fn new(future: PyDetached<OnceFuture>) -> Self {
         Self {
             future: Some(future),
         }
@@ -713,7 +713,7 @@ impl AsyncIterator {
         slf
     }
 
-    fn __anext__(&mut self) -> Option<Py<OnceFuture>> {
+    fn __anext__(&mut self) -> Option<PyDetached<OnceFuture>> {
         self.future.take()
     }
 }
@@ -835,10 +835,10 @@ fn test_hash_opt_out() {
     // By default Python provides a hash implementation, which can be disabled by setting __hash__
     // to None.
     Python::with_gil(|py| {
-        let empty = Py::new(py, EmptyClass).unwrap();
+        let empty = PyDetached::new(py, EmptyClass).unwrap();
         py_assert!(py, empty, "hash(empty) is not None");
 
-        let not_hashable = Py::new(py, NotHashable).unwrap();
+        let not_hashable = PyDetached::new(py, NotHashable).unwrap();
         py_expect_exception!(py, not_hashable, "hash(not_hashable)", PyTypeError);
     })
 }
@@ -882,10 +882,10 @@ impl NoContains {
 #[test]
 fn test_contains_opt_out() {
     Python::with_gil(|py| {
-        let defaulted_contains = Py::new(py, DefaultedContains).unwrap();
+        let defaulted_contains = PyDetached::new(py, DefaultedContains).unwrap();
         py_assert!(py, defaulted_contains, "'a' in defaulted_contains");
 
-        let no_contains = Py::new(py, NoContains).unwrap();
+        let no_contains = PyDetached::new(py, NoContains).unwrap();
         py_expect_exception!(py, no_contains, "'a' in no_contains", PyTypeError);
     })
 }

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -503,8 +503,8 @@ fn test_return_value_borrows_from_arguments() {
     Python::with_gil(|py| {
         let function = wrap_pyfunction!(return_value_borrows_from_arguments, py).unwrap();
 
-        let key = Py::new(py, Key("key".to_owned())).unwrap();
-        let value = Py::new(py, Value(42)).unwrap();
+        let key = PyDetached::new(py, Key("key".to_owned())).unwrap();
+        let value = PyDetached::new(py, Value(42)).unwrap();
 
         py_assert!(py, function key value, "function(key, value) == { \"key\": 42 }");
     });

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -25,7 +25,7 @@ impl Reader {
     fn clone_ref_with_py<'py>(slf: &'py PyCell<Self>, _py: Python<'py>) -> &'py PyCell<Self> {
         slf
     }
-    fn get_iter(slf: &PyCell<Self>, keys: Py<PyBytes>) -> Iter {
+    fn get_iter(slf: &PyCell<Self>, keys: PyDetached<PyBytes>) -> Iter {
         Iter {
             reader: slf.into(),
             keys,
@@ -34,10 +34,10 @@ impl Reader {
     }
     fn get_iter_and_reset(
         mut slf: PyRefMut<'_, Self>,
-        keys: Py<PyBytes>,
+        keys: PyDetached<PyBytes>,
         py: Python<'_>,
     ) -> PyResult<Iter> {
-        let reader = Py::new(py, slf.clone())?;
+        let reader = PyDetached::new(py, slf.clone())?;
         slf.inner.clear();
         Ok(Iter {
             reader,
@@ -50,8 +50,8 @@ impl Reader {
 #[pyclass]
 #[derive(Debug)]
 struct Iter {
-    reader: Py<Reader>,
-    keys: Py<PyBytes>,
+    reader: PyDetached<Reader>,
+    keys: PyDetached<PyBytes>,
     idx: usize,
 }
 

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -73,7 +73,7 @@ impl ByteSequence {
         Self { elements }
     }
 
-    fn __inplace_concat__(mut slf: PyRefMut<'_, Self>, other: &Self) -> Py<Self> {
+    fn __inplace_concat__(mut slf: PyRefMut<'_, Self>, other: &Self) -> PyDetached<Self> {
         slf.elements.extend_from_slice(&other.elements);
         slf.into()
     }
@@ -90,7 +90,7 @@ impl ByteSequence {
         }
     }
 
-    fn __inplace_repeat__(mut slf: PyRefMut<'_, Self>, count: isize) -> PyResult<Py<Self>> {
+    fn __inplace_repeat__(mut slf: PyRefMut<'_, Self>, count: isize) -> PyResult<PyDetached<Self>> {
         if count >= 0 {
             let mut elements = Vec::with_capacity(slf.elements.len() * count as usize);
             for _ in 0..count {

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -14,8 +14,8 @@ mod test_serde {
     #[derive(Debug, Clone, Serialize, Deserialize)]
     struct User {
         username: String,
-        group: Option<Py<Group>>,
-        friends: Vec<Py<User>>,
+        group: Option<PyDetached<Group>>,
+        friends: Vec<PyDetached<User>>,
     }
 
     #[test]
@@ -31,11 +31,11 @@ mod test_serde {
         };
 
         let user = Python::with_gil(|py| {
-            let py_friend1 = Py::new(py, friend1).expect("failed to create friend 1");
-            let py_friend2 = Py::new(py, friend2).expect("failed to create friend 2");
+            let py_friend1 = PyDetached::new(py, friend1).expect("failed to create friend 1");
+            let py_friend2 = PyDetached::new(py, friend2).expect("failed to create friend 2");
 
             let friends = vec![py_friend1, py_friend2];
-            let py_group = Py::new(
+            let py_group = PyDetached::new(
                 py,
                 Group {
                     name: "group name".into(),

--- a/tests/test_unsendable_dict.rs
+++ b/tests/test_unsendable_dict.rs
@@ -18,7 +18,7 @@ impl UnsendableDictClass {
 #[cfg_attr(all(Py_LIMITED_API, not(Py_3_10)), ignore)]
 fn test_unsendable_dict() {
     Python::with_gil(|py| {
-        let inst = Py::new(py, UnsendableDictClass {}).unwrap();
+        let inst = PyDetached::new(py, UnsendableDictClass {}).unwrap();
         py_run!(py, inst, "assert inst.__dict__ == {}");
     });
 }
@@ -38,7 +38,7 @@ impl UnsendableDictClassWithWeakRef {
 #[cfg_attr(all(Py_LIMITED_API, not(Py_3_10)), ignore)]
 fn test_unsendable_dict_with_weakref() {
     Python::with_gil(|py| {
-        let inst = Py::new(py, UnsendableDictClassWithWeakRef {}).unwrap();
+        let inst = PyDetached::new(py, UnsendableDictClassWithWeakRef {}).unwrap();
         py_run!(py, inst, "assert inst.__dict__ == {}");
         py_run!(
             py,

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -27,8 +27,8 @@ impl MutRefArg {
 #[test]
 fn mut_ref_arg() {
     Python::with_gil(|py| {
-        let inst1 = Py::new(py, MutRefArg { n: 0 }).unwrap();
-        let inst2 = Py::new(py, MutRefArg { n: 0 }).unwrap();
+        let inst1 = PyDetached::new(py, MutRefArg { n: 0 }).unwrap();
+        let inst2 = PyDetached::new(py, MutRefArg { n: 0 }).unwrap();
 
         py_run!(py, inst1 inst2, "inst1.set_other(inst2)");
         let inst2 = inst2.as_ref(py).borrow();

--- a/tests/ui/invalid_closure.rs
+++ b/tests/ui/invalid_closure.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyCFunction, PyDict, PyTuple};
 
 fn main() {
-    let fun: Py<PyCFunction> = Python::with_gil(|py| {
+    let fun: PyDetached<PyCFunction> = Python::with_gil(|py| {
         let local_data = vec![0, 1, 2, 3, 4];
         let ref_: &[u8] = &local_data;
 
@@ -10,7 +10,9 @@ fn main() {
             println!("This is five: {:?}", ref_.len());
             Ok(())
         };
-        PyCFunction::new_closure(py, None, None, closure_fn).unwrap().into()
+        PyCFunction::new_closure(py, None, None, closure_fn)
+            .unwrap()
+            .into()
     });
 
     Python::with_gil(|py| {

--- a/tests/ui/invalid_closure.stderr
+++ b/tests/ui/invalid_closure.stderr
@@ -6,7 +6,8 @@ error[E0597]: `local_data` does not live long enough
 7  |         let ref_: &[u8] = &local_data;
    |                           ^^^^^^^^^^^ borrowed value does not live long enough
 ...
-13 |         PyCFunction::new_closure(py, None, None, closure_fn).unwrap().into()
+13 |         PyCFunction::new_closure(py, None, None, closure_fn)
    |         ---------------------------------------------------- argument requires that `local_data` is borrowed for `'static`
-14 |     });
+...
+16 |     });
    |     - `local_data` dropped here while still borrowed

--- a/tests/ui/invalid_frozen_pyclass_borrow.rs
+++ b/tests/ui/invalid_frozen_pyclass_borrow.rs
@@ -11,7 +11,7 @@ impl Foo {
     fn mut_method(&mut self) {}
 }
 
-fn borrow_mut_fails(foo: Py<Foo>, py: Python) {
+fn borrow_mut_fails(foo: PyDetached<Foo>, py: Python) {
     let borrow = foo.as_ref(py).borrow_mut();
 }
 
@@ -21,11 +21,11 @@ struct MutableBase;
 #[pyclass(frozen, extends = MutableBase)]
 struct ImmutableChild;
 
-fn borrow_mut_of_child_fails(child: Py<ImmutableChild>, py: Python) {
+fn borrow_mut_of_child_fails(child: PyDetached<ImmutableChild>, py: Python) {
     let borrow = child.as_ref(py).borrow_mut();
 }
 
-fn py_get_of_mutable_class_fails(class: Py<MutableBase>) {
+fn py_get_of_mutable_class_fails(class: PyDetached<MutableBase>) {
     class.get();
 }
 

--- a/tests/ui/invalid_frozen_pyclass_borrow.stderr
+++ b/tests/ui/invalid_frozen_pyclass_borrow.stderr
@@ -52,14 +52,14 @@ error[E0271]: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
 29 |     class.get();
    |           ^^^ expected `True`, found `False`
    |
-note: required by a bound in `pyo3::Py::<T>::get`
+note: required by a bound in `pyo3::PyDetached::<T>::get`
   --> src/instance.rs
    |
    |     pub fn get(&self) -> &T
    |            --- required by a bound in this associated function
    |     where
    |         T: PyClass<Frozen = True> + Sync,
-   |                    ^^^^^^^^^^^^^ required by this bound in `Py::<T>::get`
+   |                    ^^^^^^^^^^^^^ required by this bound in `PyDetached::<T>::get`
 
 error[E0271]: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
   --> tests/ui/invalid_frozen_pyclass_borrow.rs:33:11

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -1,18 +1,18 @@
-error[E0277]: the trait bound `Blah: IntoPy<Py<PyAny>>` is not satisfied
+error[E0277]: the trait bound `Blah: IntoPy<PyDetached<PyAny>>` is not satisfied
  --> tests/ui/missing_intopy.rs:3:1
   |
 3 | #[pyo3::pyfunction]
-  | ^^^^^^^^^^^^^^^^^^^ the trait `IntoPy<Py<PyAny>>` is not implemented for `Blah`
+  | ^^^^^^^^^^^^^^^^^^^ the trait `IntoPy<PyDetached<PyAny>>` is not implemented for `Blah`
   |
   = help: the following other types implement trait `IntoPy<T>`:
-            <bool as IntoPy<Py<PyAny>>>
-            <char as IntoPy<Py<PyAny>>>
-            <isize as IntoPy<Py<PyAny>>>
-            <i8 as IntoPy<Py<PyAny>>>
-            <i16 as IntoPy<Py<PyAny>>>
-            <i32 as IntoPy<Py<PyAny>>>
-            <i64 as IntoPy<Py<PyAny>>>
-            <i128 as IntoPy<Py<PyAny>>>
+            <bool as IntoPy<PyDetached<PyAny>>>
+            <char as IntoPy<PyDetached<PyAny>>>
+            <isize as IntoPy<PyDetached<PyAny>>>
+            <i8 as IntoPy<PyDetached<PyAny>>>
+            <i16 as IntoPy<PyDetached<PyAny>>>
+            <i32 as IntoPy<PyDetached<PyAny>>>
+            <i64 as IntoPy<PyDetached<PyAny>>>
+            <i128 as IntoPy<PyDetached<PyAny>>>
           and $N others
   = note: required for `Blah` to implement `OkWrap<Blah>`
   = note: this error originates in the attribute macro `pyo3::pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/wrong_aspyref_lifetimes.rs
+++ b/tests/ui/wrong_aspyref_lifetimes.rs
@@ -1,7 +1,7 @@
-use pyo3::{types::PyDict, Py, Python};
+use pyo3::{types::PyDict, PyDetached, Python};
 
 fn main() {
-    let dict: Py<PyDict> = Python::with_gil(|py| PyDict::new(py).into());
+    let dict: PyDetached<PyDict> = Python::with_gil(|py| PyDict::new(py).into());
 
     // Should not be able to get access to Py contents outside of with_gil.
     let dict: &PyDict = Python::with_gil(|py| dict.as_ref(py));


### PR DESCRIPTION
To make space for my preferred name of `Py<'py, T>` for the new API in #3382, this PR proposes renaming `Py<T>` to `PyDetached<T>`. (Other ideas are `PySend<T>` and `PyUngil<T>`.)

Benefit of opening a PR is so we can see how painful it looks to do this rename. (And maybe so that internally we can stop writing `Py2<...>` everywhere.)

I'm split on whether it makes sense to land this rename in 0.21 and then the new `Py<'py, T>` in 0.22, or land both at the same time.