### PR TITLE
add test which is broken with gevent

### DIFF
--- a/pytests/pyproject.toml
+++ b/pytests/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
+    "gevent>=23.9.1",
     "hypothesis>=3.55",
     "pytest-asyncio>=0.21",
     "pytest-benchmark>=3.4",

--- a/pytests/src/misc.rs
+++ b/pytests/src/misc.rs
@@ -18,7 +18,11 @@ fn accepts_bool(val: bool) -> bool {
 }
 
 #[pyfunction]
-fn get_item_and_run_callback(dict: &PyDict, callback: &PyAny) -> PyResult<()> {
+fn get_item_and_run_callback(dict: Bound<'_, PyDict>, callback: Bound<'_, PyAny>) -> PyResult<()> {
+    // This function gives the opportunity to run a pure-Python callback so that
+    // gevent can instigate a context switch. This had problematic interactions
+    // with PyO3's removed "GIL Pool".
+    // For context, see https://github.com/PyO3/pyo3/issues/3668
     let item = dict.get_item("key")?.expect("key not found in dict");
     let string = item.to_string();
     callback.call0()?;

--- a/pytests/src/misc.rs
+++ b/pytests/src/misc.rs
@@ -1,4 +1,4 @@
-use pyo3::prelude::*;
+use pyo3::{prelude::*, types::PyDict};
 use std::borrow::Cow;
 
 #[pyfunction]
@@ -17,10 +17,20 @@ fn accepts_bool(val: bool) -> bool {
     val
 }
 
+#[pyfunction]
+fn get_item_and_run_callback(dict: &PyDict, callback: &PyAny) -> PyResult<()> {
+    let item = dict.get_item("key")?.expect("key not found in dict");
+    let string = item.to_string();
+    callback.call0()?;
+    assert_eq!(item.to_string(), string);
+    Ok(())
+}
+
 #[pymodule]
 pub fn misc(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(issue_219, m)?)?;
     m.add_function(wrap_pyfunction!(get_type_full_name, m)?)?;
     m.add_function(wrap_pyfunction!(accepts_bool, m)?)?;
+    m.add_function(wrap_pyfunction!(get_item_and_run_callback, m)?)?;
     Ok(())
 }


### PR DESCRIPTION
Minimal reproduction of the case described in #3668 

Here is a pretty typical output from the test:

```
start 0 0
gevent sleep 0 0
start 1 0
gevent sleep 1 0
after gevent sleep 0 0
dropping: ['key', ArbitraryClass(0, 0), 'ArbitraryClass(0, 0)', 'key', ArbitraryClass(1, 0), 'ArbitraryClass(1, 0)', None, 'ArbitraryClass(0, 0)']
del 0 0
del 1 0
end 0 0
start 0 1
gevent sleep 0 1
after gevent sleep 1 0
Fatal Python error: Segmentation fault
```

... i.e. after task 0 completes, task 1's pool of references is also freed. The crash when task 1 resumes is plain and simple UB; I have seen both segfaults and assertion failures.
