### PR TITLE
Add `Py2` variants of `PyDowncastError`

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1,5 +1,7 @@
+use crate::instance::Py2;
 use crate::panic::PanicException;
 use crate::type_object::PyTypeInfo;
+use crate::types::any::PyAnyMethods;
 use crate::types::{PyTraceback, PyType};
 use crate::{
     exceptions::{self, PyBaseException},
@@ -55,6 +57,42 @@ impl<'a> PyDowncastError<'a> {
     /// `from` into the type named in `to`.
     pub fn new(from: &'a PyAny, to: impl Into<Cow<'static, str>>) -> Self {
         PyDowncastError {
+            from,
+            to: to.into(),
+        }
+    }
+}
+
+/// Error that indicates a failure to convert a PyAny to a more specific Python type.
+#[derive(Debug)]
+pub(crate) struct PyDowncastError2<'a, 'py> {
+    from: &'a Py2<'py, PyAny>,
+    to: Cow<'static, str>,
+}
+
+impl<'a, 'py> PyDowncastError2<'a, 'py> {
+    /// Create a new `PyDowncastError` representing a failure to convert the object
+    /// `from` into the type named in `to`.
+    pub fn new(from: &'a Py2<'py, PyAny>, to: impl Into<Cow<'static, str>>) -> Self {
+        PyDowncastError2 {
+            from,
+            to: to.into(),
+        }
+    }
+}
+
+/// Error that indicates a failure to convert a PyAny to a more specific Python type.
+#[derive(Debug)]
+pub(crate) struct PyDowncastIntoError<'py> {
+    from: Py2<'py, PyAny>,
+    to: Cow<'static, str>,
+}
+
+impl<'py> PyDowncastIntoError<'py> {
+    /// Create a new `PyDowncastIntoError` representing a failure to convert the object
+    /// `from` into the type named in `to`.
+    pub fn new(from: Py2<'py, PyAny>, to: impl Into<Cow<'static, str>>) -> Self {
+        PyDowncastIntoError {
             from,
             to: to.into(),
         }
@@ -773,16 +811,61 @@ impl<'a> std::error::Error for PyDowncastError<'a> {}
 
 impl<'a> std::fmt::Display for PyDowncastError<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(
-            f,
-            "'{}' object cannot be converted to '{}'",
-            self.from
-                .get_type()
-                .qualname()
-                .map_err(|_| std::fmt::Error)?,
-            self.to
-        )
+        display_downcast_error(f, Py2::borrowed_from_gil_ref(&self.from), &self.to)
     }
+}
+
+/// Convert `PyDowncastError2` to Python `TypeError`.
+impl std::convert::From<PyDowncastError2<'_, '_>> for PyErr {
+    fn from(err: PyDowncastError2<'_, '_>) -> PyErr {
+        let args = PyDowncastErrorArguments {
+            from: err.from.get_type().into(),
+            to: err.to,
+        };
+
+        exceptions::PyTypeError::new_err(args)
+    }
+}
+
+impl std::error::Error for PyDowncastError2<'_, '_> {}
+
+impl std::fmt::Display for PyDowncastError2<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        display_downcast_error(f, self.from, &self.to)
+    }
+}
+
+/// Convert `PyDowncastIntoError` to Python `TypeError`.
+impl std::convert::From<PyDowncastIntoError<'_>> for PyErr {
+    fn from(err: PyDowncastIntoError<'_>) -> PyErr {
+        let args = PyDowncastErrorArguments {
+            from: err.from.get_type().into(),
+            to: err.to,
+        };
+
+        exceptions::PyTypeError::new_err(args)
+    }
+}
+
+impl std::error::Error for PyDowncastIntoError<'_> {}
+
+impl std::fmt::Display for PyDowncastIntoError<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        display_downcast_error(f, &self.from, &self.to)
+    }
+}
+
+fn display_downcast_error(
+    f: &mut std::fmt::Formatter<'_>,
+    from: &Py2<'_, PyAny>,
+    to: &str,
+) -> std::fmt::Result {
+    write!(
+        f,
+        "'{}' object cannot be converted to '{}'",
+        from.get_type().qualname().map_err(|_| std::fmt::Error)?,
+        to
+    )
 }
 
 pub fn panic_after_error(_py: Python<'_>) -> ! {

--- a/tests/ui/invalid_result_conversion.stderr
+++ b/tests/ui/invalid_result_conversion.stderr
@@ -9,10 +9,10 @@ error[E0277]: the trait bound `PyErr: From<MyError>` is not satisfied
              <PyErr as From<PyBorrowMutError>>
              <PyErr as From<std::io::Error>>
              <PyErr as From<PyDowncastError<'a>>>
+             <PyErr as From<pyo3::err::PyDowncastError2<'_, '_>>>
+             <PyErr as From<pyo3::err::PyDowncastIntoError<'_>>>
              <PyErr as From<NulError>>
              <PyErr as From<IntoStringError>>
-             <PyErr as From<FromUtf8Error>>
-             <PyErr as From<FromUtf16Error>>
            and $N others
    = note: required for `MyError` to implement `Into<PyErr>`
    = note: this error originates in the attribute macro `pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Part of #3382 

To keep `.downcast()` APIs performant in the error case, and also off the pool, this PR introduces two types used by `PyAnyMethods`.

`PyDowncastError2` (name to change later when we make public) is used for `.downcast()` and `.downcast_exact()`.

`PyDowncastIntoError` is used for `.downcast_into()` and `.downcast_into_exact()`.