### PR TITLE
implement `PyDictMethods`

### DIFF
--- a/src/ffi_ptr_ext.rs
+++ b/src/ffi_ptr_ext.rs
@@ -35,6 +35,9 @@ pub(crate) trait FfiPtrExt: Sealed {
 
     /// Same as `assume_borrowed_or_err`, but panics on NULL.
     unsafe fn assume_borrowed<'a>(self, py: Python<'_>) -> Py2Borrowed<'a, '_, PyAny>;
+
+    /// Same as `assume_borrowed_or_err`, but does not check for NULL.
+    unsafe fn assume_borrowed_unchecked<'a>(self, py: Python<'_>) -> Py2Borrowed<'a, '_, PyAny>;
 }
 
 impl FfiPtrExt for *mut ffi::PyObject {
@@ -67,5 +70,10 @@ impl FfiPtrExt for *mut ffi::PyObject {
     #[inline]
     unsafe fn assume_borrowed<'a>(self, py: Python<'_>) -> Py2Borrowed<'a, '_, PyAny> {
         Py2Borrowed::from_ptr(py, self)
+    }
+
+    #[inline]
+    unsafe fn assume_borrowed_unchecked<'a>(self, py: Python<'_>) -> Py2Borrowed<'a, '_, PyAny> {
+        Py2Borrowed::from_ptr_unchecked(py, self)
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -262,6 +262,14 @@ impl<'a, 'py> Py2Borrowed<'a, 'py, PyAny> {
             py,
         )
     }
+
+    /// # Safety
+    /// This is similar to `std::slice::from_raw_parts`, the lifetime `'a` is completely defined by
+    /// the caller and it's the caller's responsibility to ensure that the reference this is
+    /// derived from is valid for the lifetime `'a`.
+    pub(crate) unsafe fn from_ptr_unchecked(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
+        Self(NonNull::new_unchecked(ptr), PhantomData, py)
+    }
 }
 
 impl<'a, 'py, T> From<&'a Py2<'py, T>> for Py2Borrowed<'a, 'py, T> {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,5 +29,6 @@ pub use crate::wrap_pyfunction;
 // pub(crate) use crate::types::boolobject::PyBoolMethods;
 // pub(crate) use crate::types::bytearray::PyByteArrayMethods;
 // pub(crate) use crate::types::bytes::PyBytesMethods;
+// pub(crate) use crate::types::dict::PyDictMethods;
 // pub(crate) use crate::types::float::PyFloatMethods;
 // pub(crate) use crate::types::sequence::PySequenceMethods;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -281,7 +281,7 @@ mod code;
 mod complex;
 #[cfg(not(Py_LIMITED_API))]
 pub(crate) mod datetime;
-mod dict;
+pub(crate) mod dict;
 mod ellipsis;
 pub(crate) mod float;
 #[cfg(all(not(Py_LIMITED_API), not(PyPy)))]


### PR DESCRIPTION
Split from #3606 

Fairly mechanical. Most interesting things to note here:
- I was able to implement the existing gil-ref `PyDictIterator` as a thin wrapper around the new `PyDictIter` 
- I added `PyBorrowed::from_ptr_unchecked` to skip the null check completely in cases where we can make the assumption that a null would be a Python interpreter bug