### PR TITLE
implement `PyStringMethods`

### DIFF
--- a/newsfragments/3677.added.md
+++ b/newsfragments/3677.added.md
@@ -1,0 +1,1 @@
+Add `PyString::to_cow`. Add `Py<PyString>::to_str`, `Py<PyString>::to_cow`, and `Py<PyString>::to_string_lossy`, as ways to access Python string data safely beyond the GIL lifetime.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -32,3 +32,4 @@ pub use crate::wrap_pyfunction;
 // pub(crate) use crate::types::bytes::PyBytesMethods;
 // pub(crate) use crate::types::float::PyFloatMethods;
 // pub(crate) use crate::types::sequence::PySequenceMethods;
+// pub(crate) use crate::types::string::PyStringMethods;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -301,7 +301,7 @@ mod pysuper;
 pub(crate) mod sequence;
 pub(crate) mod set;
 mod slice;
-mod string;
+pub(crate) mod string;
 mod traceback;
 mod tuple;
 mod typeobject;


### PR DESCRIPTION
For #3382 

There are some interesting bits going on in this PR:
- `to_str` needs the GILPool to work for abi3 before Python 3.10, so I have added a `#[cfg]` on the corresponding `PyStringMethods` API.
- I've introduced `to_cow` as a new API in `PyStringMethods` which is an alternative for users on abi3 before 3.10 (cc @alex)
- I've added `Py::to_str`, `Py::to_cow` and `Py::to_string_lossy` as reads which can outlast the GIL lifetime, like we did for bytes (cf #2275)