### PR TITLE
implement datetime traits for `Bound`

### DIFF
--- a/newsfragments/3679.changed.md
+++ b/newsfragments/3679.changed.md
@@ -1,0 +1,1 @@
+Add lifetime parameter to `PyTzInfoAccess` trait and change the return type of `PyTzInfoAccess::get_tzinfo` to `Option<Bound<PyTzInfo>>`. For the deprecated gil-ref API, the trait is now implemented for `&'py PyTime` and `&'py PyDateTime` instead of `PyTime` and `PyDate`.

--- a/pytests/src/datetime.rs
+++ b/pytests/src/datetime.rs
@@ -160,12 +160,12 @@ fn datetime_from_timestamp<'p>(
 }
 
 #[pyfunction]
-fn get_datetime_tzinfo(dt: &PyDateTime) -> Option<&PyTzInfo> {
+fn get_datetime_tzinfo(dt: &PyDateTime) -> Option<Bound<'_, PyTzInfo>> {
     dt.get_tzinfo()
 }
 
 #[pyfunction]
-fn get_time_tzinfo(dt: &PyTime) -> Option<&PyTzInfo> {
+fn get_time_tzinfo(dt: &PyTime) -> Option<Bound<'_, PyTzInfo>> {
     dt.get_tzinfo()
 }
 

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -45,6 +45,8 @@ use crate::exceptions::{PyTypeError, PyUserWarning, PyValueError};
 #[cfg(Py_LIMITED_API)]
 use crate::sync::GILOnceCell;
 #[cfg(not(Py_LIMITED_API))]
+use crate::types::any::PyAnyMethods;
+#[cfg(not(Py_LIMITED_API))]
 use crate::types::datetime::timezone_from_offset;
 #[cfg(not(Py_LIMITED_API))]
 use crate::types::{


### PR DESCRIPTION
Split from #3606 

This works a bit differently from the other `PyXMethods` traits, because we already have traits for the datetime types, so we can just implement them for `Bound` types.

The only slight snag is that `PyTzInfoAccess` returns a gil-ref, so ~~for now I've added `PyTzInfoAccess2` (and we can clean that up when we make the new API public)~~ I've had to modify that to return a `Bound` tzinfo instead.