### PR TITLE
Hide GILPool behind a feature to test ability to fully avoid it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,9 @@ experimental-inspect = []
 # Enables macros: #[pyclass], #[pymodule], #[pyfunction] etc.
 macros = ["pyo3-macros", "indoc", "unindent"]
 
+# Enables GIL-bound references backed by a thread-local pool
+pool = []
+
 # Enables multiple #[pymethods] per #[pyclass]
 multiple-pymethods = ["inventory", "pyo3-macros/multiple-pymethods"]
 

--- a/src/impl_/not_send.rs
+++ b/src/impl_/not_send.rs
@@ -6,4 +6,5 @@ use crate::Python;
 /// Workaround for lack of !Send on stable (<https://github.com/rust-lang/rust/issues/68318>).
 pub(crate) struct NotSend(PhantomData<*mut Python<'static>>);
 
+#[cfg(feature = "pool")]
 pub(crate) const NOT_SEND: NotSend = NotSend(PhantomData);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,6 +298,7 @@ pub use crate::conversion::{AsPyPointer, FromPyObject, FromPyPointer, IntoPy, To
 #[allow(deprecated)]
 pub use crate::conversion::{PyTryFrom, PyTryInto};
 pub use crate::err::{PyDowncastError, PyErr, PyErrArguments, PyResult};
+#[cfg(feature = "pool")]
 pub use crate::gil::GILPool;
 #[cfg(not(PyPy))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -116,7 +116,9 @@
 //! [`Rc`]: std::rc::Rc
 //! [`Py`]: crate::Py
 use crate::err::{self, PyDowncastError, PyErr, PyResult};
-use crate::gil::{GILGuard, GILPool, SuspendGIL};
+#[cfg(feature = "pool")]
+use crate::gil::GILPool;
+use crate::gil::{GILGuard, SuspendGIL};
 use crate::impl_::not_send::NotSend;
 use crate::type_object::HasPyGilRef;
 use crate::types::{
@@ -967,6 +969,7 @@ impl<'py> Python<'py> {
     ///
     /// [`.python()`]: crate::GILPool::python
     #[inline]
+    #[cfg(feature = "pool")]
     pub unsafe fn new_pool(self) -> GILPool {
         GILPool::new()
     }
@@ -1025,6 +1028,7 @@ impl Python<'_> {
     /// });
     /// ```
     #[inline]
+    #[cfg(feature = "pool")]
     pub fn with_pool<F, R>(&self, f: F) -> R
     where
         F: for<'py> FnOnce(Python<'py>) -> R + Ungil,


### PR DESCRIPTION
Builds even if it obviously doesn't work due to `unimplemented!()` in `register_owned`. cfg'ing this one out and seeing whether we can get the result to compile would be the next after completing the `Py2`-based API.