### PR TITLE
implement iterator for `Bound` iterator

### DIFF
--- a/src/ffi_ptr_ext.rs
+++ b/src/ffi_ptr_ext.rs
@@ -16,6 +16,7 @@ use sealed::Sealed;
 
 pub(crate) trait FfiPtrExt: Sealed {
     unsafe fn assume_owned_or_err(self, py: Python<'_>) -> PyResult<Bound<'_, PyAny>>;
+    unsafe fn assume_owned_or_opt(self, py: Python<'_>) -> Option<Bound<'_, PyAny>>;
     unsafe fn assume_owned(self, py: Python<'_>) -> Bound<'_, PyAny>;
 
     /// Assumes this pointer is borrowed from a parent object.
@@ -39,6 +40,11 @@ impl FfiPtrExt for *mut ffi::PyObject {
     #[inline]
     unsafe fn assume_owned_or_err(self, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
         Bound::from_owned_ptr_or_err(py, self)
+    }
+
+    #[inline]
+    unsafe fn assume_owned_or_opt(self, py: Python<'_>) -> Option<Bound<'_, PyAny>> {
+        Bound::from_owned_ptr_or_opt(py, self)
     }
 
     #[inline]

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -49,18 +49,31 @@ pub struct Bound<'py, T>(Python<'py>, ManuallyDrop<Py<T>>);
 
 impl<'py> Bound<'py, PyAny> {
     /// Constructs a new Bound from a pointer. Panics if ptr is null.
+    ///
+    /// # Safety
+    ///
+    /// `ptr`` must be a valid pointer to a Python object.
     pub(crate) unsafe fn from_owned_ptr(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
         Self(py, ManuallyDrop::new(Py::from_owned_ptr(py, ptr)))
     }
 
-    // /// Constructs a new Bound from a pointer. Returns None if ptr is null.
-    // ///
-    // /// Safety: ptr must be a valid pointer to a Python object, or NULL.
-    // pub unsafe fn from_owned_ptr_or_opt(py: Python<'py>, ptr: *mut ffi::PyObject) -> Option<Self> {
-    //     Py::from_owned_ptr_or_opt(py, ptr).map(|obj| Self(py, ManuallyDrop::new(obj)))
-    // }
+    /// Constructs a new Bound from a pointer. Returns None if ptr is null.
+    ///
+    /// # Safety
+    ///
+    /// `ptr`` must be a valid pointer to a Python object, or NULL.
+    pub(crate) unsafe fn from_owned_ptr_or_opt(
+        py: Python<'py>,
+        ptr: *mut ffi::PyObject,
+    ) -> Option<Self> {
+        Py::from_owned_ptr_or_opt(py, ptr).map(|obj| Self(py, ManuallyDrop::new(obj)))
+    }
 
     /// Constructs a new Bound from a pointer. Returns error if ptr is null.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be a valid pointer to a Python object, or NULL.
     pub(crate) unsafe fn from_owned_ptr_or_err(
         py: Python<'py>,
         ptr: *mut ffi::PyObject,


### PR DESCRIPTION
Implements the ability to iterate `Bound<'_, PyIterator>` and `&Bound<'_, PyIterator>` in the same way that `&'py PyIterator` can already be iterated.