### PR TITLE
partially revert changes to `PyTzInfoAccess` trait

### DIFF
--- a/newsfragments/3679.changed.md
+++ b/newsfragments/3679.changed.md
@@ -1,1 +1,1 @@
-Add lifetime parameter to `PyTzInfoAccess` trait and change the return type of `PyTzInfoAccess::get_tzinfo` to `Option<Bound<PyTzInfo>>`. For the deprecated gil-ref API, the trait is now implemented for `&'py PyTime` and `&'py PyDateTime` instead of `PyTime` and `PyDate`.
+Add lifetime parameter to `PyTzInfoAccess` trait. For the deprecated gil-ref API, the trait is now implemented for `&'py PyTime` and `&'py PyDateTime` instead of `PyTime` and `PyDate`.

--- a/pytests/src/datetime.rs
+++ b/pytests/src/datetime.rs
@@ -161,12 +161,12 @@ fn datetime_from_timestamp<'p>(
 
 #[pyfunction]
 fn get_datetime_tzinfo(dt: &PyDateTime) -> Option<Bound<'_, PyTzInfo>> {
-    dt.get_tzinfo()
+    dt.get_tzinfo_bound()
 }
 
 #[pyfunction]
 fn get_time_tzinfo(dt: &PyTime) -> Option<Bound<'_, PyTzInfo>> {
-    dt.get_tzinfo()
+    dt.get_tzinfo_bound()
 }
 
 #[pyclass(extends=PyTzInfo)]

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -248,7 +248,7 @@ impl FromPyObject<'_> for NaiveDateTime {
         // we return a hard error. We could silently remove tzinfo, or assume local timezone
         // and do a conversion, but better leave this decision to the user of the library.
         #[cfg(not(Py_LIMITED_API))]
-        let has_tzinfo = dt.get_tzinfo().is_some();
+        let has_tzinfo = dt.get_tzinfo_bound().is_some();
         #[cfg(Py_LIMITED_API)]
         let has_tzinfo = !dt.getattr(intern!(dt.py(), "tzinfo"))?.is_none();
         if has_tzinfo {
@@ -284,7 +284,7 @@ impl<Tz: TimeZone + for<'a> FromPyObject<'a>> FromPyObject<'_> for DateTime<Tz> 
         check_type(dt, &DatetimeTypes::get(dt.py()).datetime, "PyDateTime")?;
 
         #[cfg(not(Py_LIMITED_API))]
-        let tzinfo = dt.get_tzinfo();
+        let tzinfo = dt.get_tzinfo_bound();
         #[cfg(Py_LIMITED_API)]
         let tzinfo: Option<&PyAny> = dt.getattr(intern!(dt.py(), "tzinfo"))?.extract()?;
 


### PR DESCRIPTION
Following the suggestion to deprecate-and-add-bound-variant, this partially reverts the modification to `PyTzInfoAccess` in #3679 to add `get_tzinfo_bound`.