### PR TITLE
Don't try to run the gevent tests on py37

### DIFF
--- a/pytests/pyproject.toml
+++ b/pytests/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "gevent>=23.9.1",
+    "gevent>=22.10.2",
     "hypothesis>=3.55",
     "pytest-asyncio>=0.21",
     "pytest-benchmark>=3.4",


### PR DESCRIPTION
The version of gevent we require is 3.8+ only

