### PR TITLE
introduce PyIterator::from_bound_object

### DIFF
--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -2018,7 +2018,7 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     }
 
     fn iter(&self) -> PyResult<Bound<'py, PyIterator>> {
-        PyIterator::from_object2(self)
+        PyIterator::from_bound_object(self)
     }
 
     fn get_type(&self) -> &'py PyType {

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -209,7 +209,7 @@ mod impl_ {
     impl<'py> BoundFrozenSetIterator<'py> {
         pub(super) fn new(frozenset: Bound<'py, PyFrozenSet>) -> Self {
             Self {
-                it: PyIterator::from_object2(&frozenset).unwrap(),
+                it: PyIterator::from_bound_object(&frozenset).unwrap(),
             }
         }
     }

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -289,7 +289,7 @@ mod impl_ {
     impl<'py> BoundSetIterator<'py> {
         pub(super) fn new(set: Bound<'py, PySet>) -> Self {
             Self {
-                it: PyIterator::from_object2(&set).unwrap(),
+                it: PyIterator::from_bound_object(&set).unwrap(),
             }
         }
     }


### PR DESCRIPTION
Follows the standard pattern we're now going for to introduce a new bound constructor while deprecating the old one.

This isn't mergeable until after #3694 