### PR TITLE
Add `extract_bound` method to FromPyObject

### DIFF
--- a/newsfragments/3706.added.md
+++ b/newsfragments/3706.added.md
@@ -1,0 +1,1 @@
+Add `FromPyObject::extract_bound` method, which can be implemented to avoid using the GIL Ref API in `FromPyObject` implementations.

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -93,8 +93,11 @@
 //! result = get_eigenvalues(m11,m12,m21,m22)
 //! assert result == [complex(1,-1), complex(-2,0)]
 //! ```
+#[cfg(any(Py_LIMITED_API, PyPy))]
+use crate::types::any::PyAnyMethods;
 use crate::{
-    ffi, types::PyComplex, FromPyObject, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    ffi, types::PyComplex, Bound, FromPyObject, PyAny, PyErr, PyObject, PyResult, Python,
+    ToPyObject,
 };
 use num_complex::Complex;
 use std::os::raw::c_double;
@@ -131,8 +134,8 @@ macro_rules! complex_conversion {
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
-        impl<'source> FromPyObject<'source> for Complex<$float> {
-            fn extract(obj: &'source PyAny) -> PyResult<Complex<$float>> {
+        impl FromPyObject<'_> for Complex<$float> {
+            fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Complex<$float>> {
                 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
                 unsafe {
                     let val = ffi::PyComplex_AsCComplex(obj.as_ptr());
@@ -146,12 +149,14 @@ macro_rules! complex_conversion {
 
                 #[cfg(any(Py_LIMITED_API, PyPy))]
                 unsafe {
+                    let complex;
                     let obj = if obj.is_instance_of::<PyComplex>() {
                         obj
                     } else if let Some(method) =
                         obj.lookup_special(crate::intern!(obj.py(), "__complex__"))?
                     {
-                        method.call0()?
+                        complex = method.call0()?;
+                        &complex
                     } else {
                         // `obj` might still implement `__float__` or `__index__`, which will be
                         // handled by `PyComplex_{Real,Imag}AsDouble`, including propagating any

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1425,11 +1425,8 @@ where
     T: PyTypeInfo,
 {
     /// Extracts `Self` from the source `PyObject`.
-    fn extract(ob: &'a PyAny) -> PyResult<Self> {
-        ob.as_borrowed()
-            .downcast()
-            .map(Clone::clone)
-            .map_err(Into::into)
+    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+        ob.downcast().map(Clone::clone).map_err(Into::into)
     }
 }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -917,13 +917,13 @@ mod tests {
 
             assert_eq!(iter.size_hint(), (3, Some(3)));
 
-            assert_eq!(1_i32, iter.next().unwrap().extract::<'_, i32>().unwrap());
+            assert_eq!(1, iter.next().unwrap().extract::<i32>().unwrap());
             assert_eq!(iter.size_hint(), (2, Some(2)));
 
-            assert_eq!(2_i32, iter.next().unwrap().extract::<'_, i32>().unwrap());
+            assert_eq!(2, iter.next().unwrap().extract::<i32>().unwrap());
             assert_eq!(iter.size_hint(), (1, Some(1)));
 
-            assert_eq!(3_i32, iter.next().unwrap().extract::<'_, i32>().unwrap());
+            assert_eq!(3, iter.next().unwrap().extract::<i32>().unwrap());
             assert_eq!(iter.size_hint(), (0, Some(0)));
 
             assert!(iter.next().is_none());
@@ -940,13 +940,13 @@ mod tests {
 
             assert_eq!(iter.size_hint(), (3, Some(3)));
 
-            assert_eq!(3_i32, iter.next().unwrap().extract::<'_, i32>().unwrap());
+            assert_eq!(3, iter.next().unwrap().extract::<i32>().unwrap());
             assert_eq!(iter.size_hint(), (2, Some(2)));
 
-            assert_eq!(2_i32, iter.next().unwrap().extract::<'_, i32>().unwrap());
+            assert_eq!(2, iter.next().unwrap().extract::<i32>().unwrap());
             assert_eq!(iter.size_hint(), (1, Some(1)));
 
-            assert_eq!(1_i32, iter.next().unwrap().extract::<'_, i32>().unwrap());
+            assert_eq!(1, iter.next().unwrap().extract::<i32>().unwrap());
             assert_eq!(iter.size_hint(), (0, Some(0)));
 
             assert!(iter.next().is_none());


### PR DESCRIPTION
This PR proposes a way that we can support migration of `FromPyObject` off the GIL Refs API in a backwards-compatible fashion.

It does so by adding a new `extract_bound` method to `FromPyObject<'py>`, which takes `&Bound<'py, PyAny>`. Note that the lifetime `'py` in the trait becomes only the `'py` lifetime and not the lifetime for which the `Bound` smart pointer is alive. This is important for backwards-compatibility; maybe in the future we could have `FromPyObject<'a, 'py>` and the argument could be `&'a Bound<'py, PyAny>`, but let's cross that bridge another time.

Also for backwards-compatibility's sake, both `extract` and `extract_bound` have default implementations in terms of each other. This allows for users to migrate from using one set of implementations to the other at their own pace. The documentation encourages to implement just `extract_bound`, as the default implementation requires a `.into_gil_ref()` call to insert into the pool.

To avoid a huge diff here, I've pushed a second commit which just includes a couple of randomly-selected implementations which I migrate from `extract` to `extract_bound`, to give a feeling for how this works.

If we like this and merge it, I can work on one or more follow-ups which migrate the rest of our internals to `extract_bound` (which will go a long way towards getting PyO3's internals off the pool).