### PR TITLE
ci: updates for Rust 1.75

### DIFF
--- a/guide/src/function/signature.md
+++ b/guide/src/function/signature.md
@@ -2,9 +2,9 @@
 
 The `#[pyfunction]` attribute also accepts parameters to control how the generated Python function accepts arguments. Just like in Python, arguments can be positional-only, keyword-only, or accept either. `*args` lists and `**kwargs` dicts can also be accepted. These parameters also work for `#[pymethods]` which will be introduced in the [Python Classes](../class.md) section of the guide.
 
-Like Python, by default PyO3 accepts all arguments as either positional or keyword arguments. Most arguments are required by default, except for trailing `Option<_>` arguments, which are [implicitly given a default of `None`](#trailing-optional-arguments). There are two ways to modify this behaviour:
-  - The `#[pyo3(signature = (...))]` option which allows writing a signature in Python syntax.
-  - Extra arguments directly to `#[pyfunction]`. (See deprecated form)
+Like Python, by default PyO3 accepts all arguments as either positional or keyword arguments. Most arguments are required by default, except for trailing `Option<_>` arguments, which are [implicitly given a default of `None`](#trailing-optional-arguments). This behaviour can be configured by the `#[pyo3(signature = (...))]` option which allows writing a signature in Python syntax.
+
+This section of the guide goes into detail about use of the `#[pyo3(signature = (...))]` option and its related option `#[pyo3(text_signature = "...")]`
 
 ## Using `#[pyo3(signature = (...))]`
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -3,8 +3,7 @@ use std::borrow::Cow;
 use crate::attributes::kw::frozen;
 use crate::attributes::{
     self, kw, take_pyo3_options, CrateAttribute, ExtendsAttribute, FreelistAttribute,
-    ModuleAttribute, NameAttribute, NameLitStr, RenameAllAttribute, TextSignatureAttribute,
-    TextSignatureAttributeValue,
+    ModuleAttribute, NameAttribute, NameLitStr, RenameAllAttribute,
 };
 use crate::deprecations::Deprecations;
 use crate::konst::{ConstAttributes, ConstSpec};
@@ -68,7 +67,6 @@ pub struct PyClassPyO3Options {
     pub sequence: Option<kw::sequence>,
     pub set_all: Option<kw::set_all>,
     pub subclass: Option<kw::subclass>,
-    pub text_signature: Option<TextSignatureAttribute>,
     pub unsendable: Option<kw::unsendable>,
     pub weakref: Option<kw::weakref>,
 }
@@ -886,18 +884,6 @@ impl<'a> PyClassImplsBuilder<'a> {
     fn impl_pyclassimpl(&self) -> Result<TokenStream> {
         let cls = self.cls;
         let doc = self.doc.as_ref().map_or(quote! {"\0"}, |doc| quote! {#doc});
-        let deprecated_text_signature = match self
-            .attr
-            .options
-            .text_signature
-            .as_ref()
-            .map(|attr| &attr.value)
-        {
-            Some(TextSignatureAttributeValue::Str(s)) => quote!(::std::option::Option::Some(#s)),
-            Some(TextSignatureAttributeValue::Disabled(_)) | None => {
-                quote!(::std::option::Option::None)
-            }
-        };
         let is_basetype = self.attr.options.subclass.is_some();
         let base = self
             .attr
@@ -1040,7 +1026,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     static DOC: _pyo3::sync::GILOnceCell<::std::borrow::Cow<'static, ::std::ffi::CStr>> = _pyo3::sync::GILOnceCell::new();
                     DOC.get_or_try_init(py, || {
                         let collector = PyClassImplCollector::<Self>::new();
-                        build_pyclass_doc(<#cls as _pyo3::PyTypeInfo>::NAME, #doc, #deprecated_text_signature.or_else(|| collector.new_text_signature()))
+                        build_pyclass_doc(<#cls as _pyo3::PyTypeInfo>::NAME, #doc, collector.new_text_signature())
                     }).map(::std::ops::Deref::deref)
                 }
 

--- a/tests/ui/abi3_nativetype_inheritance.stderr
+++ b/tests/ui/abi3_nativetype_inheritance.stderr
@@ -6,6 +6,22 @@ error[E0277]: the trait bound `PyDict: PyClass` is not satisfied
   |
   = help: the following other types implement trait `PyClass`:
             TestClass
-            Coroutine
+            pyo3::coroutine::Coroutine
   = note: required for `PyDict` to implement `PyClassBaseType`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `PyDict: PyClass` is not satisfied
+ --> tests/ui/abi3_nativetype_inheritance.rs:5:19
+  |
+5 | #[pyclass(extends=PyDict)]
+  |                   ^^^^^^ the trait `PyClass` is not implemented for `PyDict`
+  |
+  = help: the following other types implement trait `PyClass`:
+            TestClass
+            pyo3::coroutine::Coroutine
+  = note: required for `PyDict` to implement `PyClassBaseType`
+note: required by a bound in `PyClassImpl::BaseType`
+ --> src/impl_/pyclass.rs
+  |
+  |     type BaseType: PyTypeInfo + PyClassBaseType;
+  |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`

--- a/tests/ui/invalid_argument_attributes.stderr
+++ b/tests/ui/invalid_argument_attributes.stderr
@@ -74,7 +74,7 @@ error[E0277]: the trait bound `CancelHandle: PyClass` is not satisfied
 41 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
    |                                                  ^^^^ the trait `PyClass` is not implemented for `CancelHandle`
    |
-   = help: the trait `PyClass` is implemented for `Coroutine`
+   = help: the trait `PyClass` is implemented for `pyo3::coroutine::Coroutine`
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_>`
 note: required by a bound in `extract_argument`
@@ -93,8 +93,8 @@ error[E0277]: the trait bound `CancelHandle: Clone` is not satisfied
    |                                                  ^^^^ the trait `Clone` is not implemented for `CancelHandle`
    |
    = help: the following other types implement trait `PyFunctionArgument<'a, 'py>`:
-             &'a Coroutine
-             &'a mut Coroutine
+             &'a pyo3::coroutine::Coroutine
+             &'a mut pyo3::coroutine::Coroutine
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_>`
 note: required by a bound in `extract_argument`

--- a/tests/ui/pyclass_send.stderr
+++ b/tests/ui/pyclass_send.stderr
@@ -16,3 +16,24 @@ note: required by a bound in `SendablePyClass`
   | pub struct SendablePyClass<T: Send>(PhantomData<T>);
   |                               ^^^^ required by this bound in `SendablePyClass`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `Rc<i32>` cannot be sent between threads safely
+ --> tests/ui/pyclass_send.rs:4:1
+  |
+4 | #[pyclass]
+  | ^^^^^^^^^^ `Rc<i32>` cannot be sent between threads safely
+  |
+  = help: within `NotThreadSafe`, the trait `Send` is not implemented for `Rc<i32>`
+  = help: the trait `pyo3::impl_::pyclass::PyClassThreadChecker<T>` is implemented for `SendablePyClass<T>`
+note: required because it appears within the type `NotThreadSafe`
+ --> tests/ui/pyclass_send.rs:5:8
+  |
+5 | struct NotThreadSafe {
+  |        ^^^^^^^^^^^^^
+  = note: required for `SendablePyClass<NotThreadSafe>` to implement `pyo3::impl_::pyclass::PyClassThreadChecker<NotThreadSafe>`
+note: required by a bound in `PyClassImpl::ThreadChecker`
+ --> src/impl_/pyclass.rs
+  |
+  |     type ThreadChecker: PyClassThreadChecker<Self>;
+  |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::ThreadChecker`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Updates UI test output for Rust 1.75. There's a slight regression in one of the compiler messages related to `#[pyclass]` requiring Send; I think for now I'm inclined to leave it if we're revisiting that code in the near future to require `Sync` on classes for nogil anyway.

While I was at it, I pushed a tiny second commit which deletes a bit of unused code and guide text which was left behind after deletion of some old features.

Assuming green CI, I'll proceed to merge this as there's nothing particularly worth discussing here, and then I can rebase everything else.