### PR TITLE
add `call_bound` and `call_method_bound`

### DIFF
--- a/examples/decorator/src/lib.rs
+++ b/examples/decorator/src/lib.rs
@@ -41,7 +41,7 @@ impl PyCounter {
         &self,
         py: Python<'_>,
         args: &PyTuple,
-        kwargs: Option<&PyDict>,
+        kwargs: Option<Bound<'_, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
         let old_count = self.count.get();
         let new_count = old_count + 1;
@@ -51,7 +51,7 @@ impl PyCounter {
         println!("{} has been called {} time(s).", name, new_count);
 
         // After doing something, we finally forward the call to the wrapped function
-        let ret = self.wraps.call(py, args, kwargs)?;
+        let ret = self.wraps.call_bound(py, args, kwargs.as_ref())?;
 
         // We could do something with the return value of
         // the function before returning it

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -10,13 +10,13 @@ Any Python-native object reference (such as `&PyAny`, `&PyList`, or `&PyCell<MyC
 
 PyO3 offers two APIs to make function calls:
 
-* [`call`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyAny.html#method.call) - call any callable Python object.
-* [`call_method`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyAny.html#method.call_method) - call a method on the Python object.
+* [`call`]({{#PYO3_DOCS_URL}}/pyo3/prelude/trait.PyAnyMethods#tymethod.call) - call any callable Python object.
+* [`call_method`]({{#PYO3_DOCS_URL}}/pyo3/prelude/trait.PyAnyMethods#tymethod.call_method) - call a method on the Python object.
 
 Both of these APIs take `args` and `kwargs` arguments (for positional and keyword arguments respectively). There are variants for less complex calls:
 
-* [`call1`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyAny.html#method.call1) and [`call_method1`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyAny.html#method.call_method1) to call only with positional `args`.
-* [`call0`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyAny.html#method.call0) and [`call_method0`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyAny.html#method.call_method0) to call with no arguments.
+* [`call1`]({{#PYO3_DOCS_URL}}/pyo3/prelude/trait.PyAnyMethods#tymethod.call1) and [`call_method1`]({{#PYO3_DOCS_URL}}/pyo3/prelude/trait.PyAnyMethods#tymethod.call_method1) to call only with positional `args`.
+* [`call0`]({{#PYO3_DOCS_URL}}/pyo3/prelude/trait.PyAnyMethods#tymethod.call0) and [`call_method0`]({{#PYO3_DOCS_URL}}/pyo3/prelude/trait.PyAnyMethods#tymethod.call_method0) to call with no arguments.
 
 For convenience the [`Py<T>`](types.html#pyt-and-pyobject) smart pointer also exposes these same six API methods, but needs a `Python` token as an additional first argument to prove the GIL is held.
 
@@ -95,21 +95,29 @@ fn main() -> PyResult<()> {
 
         // call object with PyDict
         let kwargs = [(key1, val1)].into_py_dict(py);
-        fun.call(py, (), Some(kwargs))?;
+        fun.call_bound(py, (), Some(&kwargs.as_borrowed()))?;
 
         // pass arguments as Vec
         let kwargs = vec![(key1, val1), (key2, val2)];
-        fun.call(py, (), Some(kwargs.into_py_dict(py)))?;
+        fun.call_bound(py, (), Some(&kwargs.into_py_dict(py).as_borrowed()))?;
 
         // pass arguments as HashMap
         let mut kwargs = HashMap::<&str, i32>::new();
         kwargs.insert(key1, 1);
-        fun.call(py, (), Some(kwargs.into_py_dict(py)))?;
+        fun.call_bound(py, (), Some(&kwargs.into_py_dict(py).as_borrowed()))?;
 
         Ok(())
     })
 }
 ```
+
+<div class="warning">
+
+During PyO3's [migration from "GIL Refs" to the `Bound<T>` smart pointer](./migration.md#migrating-from-the-gil-refs-api-to-boundt), [`Py<T>::call`]({{#PYO3_DOCS_URL}}/pyo3/struct.py#method.call) is temporarily named `call_bound` (and `call_method` is temporarily `call_method_bound`).
+
+(This temporary naming is only the case for the `Py<T>` smart pointer. The methods on the `&PyAny` GIL Ref such as `call` have not been given replacements, and the methods on the `Bound<PyAny>` smart pointer such as [`Bound<PyAny>::call`]({#PYO3_DOCS_URL}}/pyo3/prelude/trait.pyanymethods#tymethod.call) already use follow the newest API conventions.)
+
+</div>
 
 ## Executing existing Python code
 

--- a/tests/ui/invalid_result_conversion.stderr
+++ b/tests/ui/invalid_result_conversion.stderr
@@ -6,8 +6,8 @@ error[E0277]: the trait bound `PyErr: From<MyError>` is not satisfied
    |
    = help: the following other types implement trait `From<T>`:
              <PyErr as From<PyBorrowError>>
-             <PyErr as From<PyBorrowMutError>>
              <PyErr as From<std::io::Error>>
+             <PyErr as From<PyBorrowMutError>>
              <PyErr as From<PyDowncastError<'a>>>
              <PyErr as From<DowncastError<'_, '_>>>
              <PyErr as From<DowncastIntoError<'_>>>


### PR DESCRIPTION
Adds `Py::call_bound` and `Py::call_method_bound`, which take `kwargs: Option<&Bound<'_, PyDict>>`.

For `&PyAny`, I decided not to add these new variants as instead the correct change should be to switch to `Bound<'_, PyAny>`.

Similarly I changed the argument in `PyAnyMethods::call` and `PyAnyMethods::call_method` without introducing new variants.

The other functions like `call0` don't need changing as they don't take an `Option<&PyDict>` argument.