### PR TITLE
docs: Document how to represent custom Python-native classes

### DIFF
--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -71,7 +71,7 @@ where
 ///         typ.get_type_ptr()
 ///     }
 /// }
-/// unsafe impl PyNativeType for PyFinalRule {}
+/// unsafe impl PyNativeType for MyPyType {}
 /// ```
 pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
     /// Class name.

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -52,6 +52,27 @@ where
 ///
 /// Implementations must provide an implementation for `type_object_raw` which infallibly produces a
 /// non-null pointer to the corresponding Python type object.
+///
+/// # Example
+///
+/// To use PyTypeInfo to represent a custom Python class that is not implemented in Rust:
+///
+/// ```
+/// struct MyPyType(PyAny);
+/// unsafe impl PyTypeInfo for MyPyType {
+///     const NAME: &'static str = "MyPyType";
+///     const MODULE: Option<&'static str> = Option::Some("my.module");
+///     type AsRefTarget = PyAny;
+///
+///     fn type_object_raw(py: Python<'_>) -> *mut PyTypeObject {
+///         let modu = py.import("my.module").expect("Couldn't import module");
+///         let typ_any = modu.getattr("MyPyType").expect("Couldn't get Python class");
+///         let typ = final_rule.extract::<&PyType>().expect("Couldn't downcast Python class to PyType");
+///         typ.get_type_ptr()
+///     }
+/// }
+/// unsafe impl PyNativeType for PyFinalRule {}
+/// ```
 pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
     /// Class name.
     const NAME: &'static str;

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -60,7 +60,7 @@ where
 /// ```
 /// use pyo3_ffi::PyTypeObject;
 /// use pyo3::types::PyType;
-/// use pyo3::PyNativeType;
+/// use pyo3::{Python, PyNativeType};
 /// 
 /// struct Formatter(PyAny);
 /// unsafe impl PyTypeInfo for Formatter {

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -67,7 +67,7 @@ where
 ///     fn type_object_raw(py: Python<'_>) -> *mut PyTypeObject {
 ///         let modu = py.import("my.module").expect("Couldn't import module");
 ///         let typ_any = modu.getattr("MyPyType").expect("Couldn't get Python class");
-///         let typ = final_rule.extract::<&PyType>().expect("Couldn't downcast Python class to PyType");
+///         let typ = typ_any.extract::<&PyType>().expect("Couldn't downcast Python class to PyType");
 ///         typ.get_type_ptr()
 ///     }
 /// }

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -62,9 +62,9 @@ where
 /// use pyo3::types::PyType;
 /// use pyo3::{Python, PyNativeType};
 /// 
-/// struct Formatter(PyAny);
+/// struct PyFormatter(PyAny);
 /// unsafe impl PyTypeInfo for Formatter {
-///     const NAME: &'static str = "MyPyType";
+///     const NAME: &'static str = "Formatter";
 ///     const MODULE: Option<&'static str> = Option::Some("string");
 ///     type AsRefTarget = PyAny;
 ///
@@ -75,7 +75,7 @@ where
 ///         typ.get_type_ptr()
 ///     }
 /// }
-/// unsafe impl PyNativeType for Formatter {}
+/// unsafe impl PyNativeType for PyFormatter {}
 /// ```
 pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
     /// Class name.

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -62,7 +62,7 @@ where
 /// use pyo3::{Python, PyAny, PyType, PyNativeType};
 /// 
 /// struct PyFormatter(PyAny);
-/// unsafe impl PyTypeInfo for Formatter {
+/// unsafe impl PyTypeInfo for PyFormatter {
 ///     const NAME: &'static str = "Formatter";
 ///     const MODULE: Option<&'static str> = Option::Some("string");
 ///     type AsRefTarget = PyAny;

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -59,13 +59,14 @@ where
 ///
 /// ```
 /// use pyo3_ffi::PyTypeObject;
-/// use pyo3::{Python, PyAny, PyType, PyNativeType, PyTypeInfo};
+/// use pyo3::types::{PyAny, PyType};
+/// use pyo3::{Python, PyNativeType, PyTypeInfo};
 /// 
 /// struct PyFormatter(PyAny);
 /// unsafe impl PyTypeInfo for PyFormatter {
 ///     const NAME: &'static str = "Formatter";
 ///     const MODULE: Option<&'static str> = Option::Some("string");
-///     type AsRefTarget = PyAny;
+///     type AsRefTarget = PyType;
 ///
 ///     fn type_object_raw(py: Python<'_>) -> *mut PyTypeObject {
 ///         let modu = py.import("string").expect("Couldn't import string module");

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -60,7 +60,7 @@ where
 /// ```
 /// use pyo3_ffi::PyTypeObject;
 /// use pyo3::types::PyType;
-/// use pyo3::{Python, PyNativeType};
+/// use pyo3::{Python, PyAny, PyNativeType};
 /// 
 /// struct PyFormatter(PyAny);
 /// unsafe impl PyTypeInfo for Formatter {

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -59,8 +59,7 @@ where
 ///
 /// ```
 /// use pyo3_ffi::PyTypeObject;
-/// use pyo3::types::PyType;
-/// use pyo3::{Python, PyAny, PyNativeType};
+/// use pyo3::{Python, PyAny, PyType, PyNativeType};
 /// 
 /// struct PyFormatter(PyAny);
 /// unsafe impl PyTypeInfo for Formatter {

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -58,6 +58,10 @@ where
 /// To use PyTypeInfo to represent a custom Python class that is not implemented in Rust:
 ///
 /// ```
+/// use pyo3_ffi::PyTypeObject;
+/// use pyo3::types::PyType;
+/// use pyo3::PyNativeType;
+/// 
 /// struct Formatter(PyAny);
 /// unsafe impl PyTypeInfo for Formatter {
 ///     const NAME: &'static str = "MyPyType";

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -61,7 +61,7 @@ where
 /// use pyo3_ffi::PyTypeObject;
 /// use pyo3::types::PyType;
 /// use pyo3::{Python, PyAny, PyNativeType, PyTypeInfo};
-/// 
+///
 /// struct PyFormatter(PyAny);
 /// unsafe impl PyTypeInfo for PyFormatter {
 ///     const NAME: &'static str = "Formatter";

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -59,7 +59,7 @@ where
 ///
 /// ```
 /// use pyo3_ffi::PyTypeObject;
-/// use pyo3::{Python, PyAny, PyType, PyNativeType};
+/// use pyo3::{Python, PyAny, PyType, PyNativeType, PyTypeInfo};
 /// 
 /// struct PyFormatter(PyAny);
 /// unsafe impl PyTypeInfo for PyFormatter {

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -59,14 +59,13 @@ where
 ///
 /// ```
 /// use pyo3_ffi::PyTypeObject;
-/// use pyo3::types::{PyAny, PyType};
+/// use pyo3::types::PyType;
 /// use pyo3::{Python, PyNativeType, PyTypeInfo};
 /// 
 /// struct PyFormatter(PyAny);
 /// unsafe impl PyTypeInfo for PyFormatter {
 ///     const NAME: &'static str = "Formatter";
 ///     const MODULE: Option<&'static str> = Option::Some("string");
-///     type AsRefTarget = PyType;
 ///
 ///     fn type_object_raw(py: Python<'_>) -> *mut PyTypeObject {
 ///         let modu = py.import("string").expect("Couldn't import string module");
@@ -75,7 +74,9 @@ where
 ///         typ.get_type_ptr()
 ///     }
 /// }
-/// unsafe impl PyNativeType for PyFormatter {}
+/// unsafe impl PyNativeType for PyFormatter {
+///     type AsRefSource = PyFormatter;
+/// }
 /// ```
 pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
     /// Class name.

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -60,7 +60,7 @@ where
 /// ```
 /// use pyo3_ffi::PyTypeObject;
 /// use pyo3::types::PyType;
-/// use pyo3::{Python, PyNativeType, PyTypeInfo};
+/// use pyo3::{Python, PyAny, PyNativeType, PyTypeInfo};
 /// 
 /// struct PyFormatter(PyAny);
 /// unsafe impl PyTypeInfo for PyFormatter {

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -58,20 +58,20 @@ where
 /// To use PyTypeInfo to represent a custom Python class that is not implemented in Rust:
 ///
 /// ```
-/// struct MyPyType(PyAny);
-/// unsafe impl PyTypeInfo for MyPyType {
+/// struct Formatter(PyAny);
+/// unsafe impl PyTypeInfo for Formatter {
 ///     const NAME: &'static str = "MyPyType";
-///     const MODULE: Option<&'static str> = Option::Some("my.module");
+///     const MODULE: Option<&'static str> = Option::Some("string");
 ///     type AsRefTarget = PyAny;
 ///
 ///     fn type_object_raw(py: Python<'_>) -> *mut PyTypeObject {
-///         let modu = py.import("my.module").expect("Couldn't import module");
-///         let typ_any = modu.getattr("MyPyType").expect("Couldn't get Python class");
+///         let modu = py.import("string").expect("Couldn't import string module");
+///         let typ_any = modu.getattr("Formatter").expect("Couldn't get Python class");
 ///         let typ = typ_any.extract::<&PyType>().expect("Couldn't downcast Python class to PyType");
 ///         typ.get_type_ptr()
 ///     }
 /// }
-/// unsafe impl PyNativeType for MyPyType {}
+/// unsafe impl PyNativeType for Formatter {}
 /// ```
 pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
     /// Class name.


### PR DESCRIPTION
I had trouble figuring out how to make my own structs representing my own Python classes that weren't implemented in Rust, so I documented how to do it.
