### PR TITLE
re-add emit_pyo3_cfgs for pyo3 0.20.0 compatibility

### DIFF
--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -154,6 +154,13 @@ pub struct InterpreterConfig {
 
 impl InterpreterConfig {
     #[doc(hidden)]
+    pub fn emit_pyo3_cfgs(&self) {
+        for cfg in self.build_script_outputs() {
+            println!("{}", cfg);
+        }
+    }
+
+    #[doc(hidden)]
     pub fn build_script_outputs(&self) -> Vec<String> {
         // This should have been checked during pyo3-build-config build time.
         assert!(self.version >= MINIMUM_SUPPORTED_VERSION);


### PR DESCRIPTION
I tested locally that this makes pyo3 0.20.0 build against a newer pyo3-build-config. So I think if we include this in 0.20.2 then we should resolve #3719 for users doing stuff with `-Z direct-minimal-versions` etc.