### PR TITLE
ffi: Add definition for PyType_GetModuleByDef

### DIFF
--- a/newsfragments/3734.added.md
+++ b/newsfragments/3734.added.md
@@ -1,0 +1,1 @@
+Add definition for `PyType_GetModuleByDef` to `pyo3_ffi`.

--- a/pyo3-ffi/src/cpython/object.rs
+++ b/pyo3-ffi/src/cpython/object.rs
@@ -1,5 +1,7 @@
 #[cfg(Py_3_8)]
 use crate::vectorcallfunc;
+#[cfg(Py_3_11)]
+use crate::PyModuleDef;
 use crate::{object, PyGetSetDef, PyMemberDef, PyMethodDef, PyObject, Py_ssize_t};
 use std::mem;
 use std::os::raw::{c_char, c_int, c_uint, c_ulong, c_void};
@@ -339,9 +341,12 @@ pub unsafe fn PyHeapType_GET_MEMBERS(etype: *mut PyHeapTypeObject) -> *mut PyMem
 // skipped _PyType_CalculateMetaclass
 // skipped _PyType_GetDocFromInternalDoc
 // skipped _PyType_GetTextSignatureFromInternalDoc
-// skipped _PyType_GetModuleByDef
 
 extern "C" {
+    #[cfg(Py_3_11)]
+    #[cfg_attr(PyPy, link_name = "PyPyType_GetModuleByDef")]
+    pub fn PyType_GetModuleByDef(ty: *mut PyTypeObject, def: *mut PyModuleDef) -> *mut PyObject;
+
     #[cfg(Py_3_12)]
     pub fn PyType_GetDict(o: *mut PyTypeObject) -> *mut PyObject;
 


### PR DESCRIPTION
This API is available starting in 3.11. It is not part of the Stable ABI.

PyType_GetModuleByDef searches the MRO of the given type for a module matching the given module spec. It can be useful for users use that `pyo3_ffi` directly and want to support multiple interpreters/per interpreter GIL. It is useful to obtain access to the module state from special methods like `tp_new` that can't use the METH_METHOD calling convention.

I am not sure how to check if this API is available on PyPy. If someone could give me a pointer to where to check, that would be great!