### PR TITLE
allow dead_code in `IPowModulo`

### DIFF
--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -21,7 +21,7 @@ pub struct IPowModulo(*mut ffi::PyObject);
 /// Python 3.7 and older - __ipow__ does not have modulo argument correctly populated.
 #[cfg(not(Py_3_8))]
 #[repr(transparent)]
-pub struct IPowModulo(std::mem::MaybeUninit<*mut ffi::PyObject>);
+pub struct IPowModulo(#[allow(dead_code)] std::mem::MaybeUninit<*mut ffi::PyObject>);
 
 /// Helper to use as pymethod ffi definition
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
More fixes to follow up #3738; this field is never read on 3.7.