### PR TITLE
update ffi structures for PyPy 7.3.15

### DIFF
--- a/newsfragments/3757.fixed.md
+++ b/newsfragments/3757.fixed.md
@@ -1,0 +1,1 @@
+Match PyPy 7.3.14 in removing PyPy-only symbol `Py_MAX_NDIMS` in favour of `PyBUF_MAX_NDIM`.

--- a/pyo3-ffi/src/cpython/object.rs
+++ b/pyo3-ffi/src/cpython/object.rs
@@ -22,9 +22,6 @@ mod bufferinfo {
     use std::os::raw::{c_char, c_int, c_void};
     use std::ptr;
 
-    #[cfg(PyPy)]
-    const Py_MAX_NDIMS: usize = if cfg!(Py_3_9) { 64 } else { 36 };
-
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct Py_buffer {
@@ -43,9 +40,9 @@ mod bufferinfo {
         #[cfg(PyPy)]
         pub flags: c_int,
         #[cfg(PyPy)]
-        pub _strides: [Py_ssize_t; Py_MAX_NDIMS],
+        pub _strides: [Py_ssize_t; PyBUF_MAX_NDIM as usize],
         #[cfg(PyPy)]
-        pub _shape: [Py_ssize_t; Py_MAX_NDIMS],
+        pub _shape: [Py_ssize_t; PyBUF_MAX_NDIM as usize],
     }
 
     impl Py_buffer {
@@ -65,9 +62,9 @@ mod bufferinfo {
                 #[cfg(PyPy)]
                 flags: 0,
                 #[cfg(PyPy)]
-                _strides: [0; Py_MAX_NDIMS],
+                _strides: [0; PyBUF_MAX_NDIM as usize],
                 #[cfg(PyPy)]
-                _shape: [0; Py_MAX_NDIMS],
+                _shape: [0; PyBUF_MAX_NDIM as usize],
             }
         }
     }
@@ -81,7 +78,7 @@ mod bufferinfo {
         unsafe extern "C" fn(arg1: *mut crate::PyObject, arg2: *mut Py_buffer);
 
     /// Maximum number of dimensions
-    pub const PyBUF_MAX_NDIM: c_int = 64;
+    pub const PyBUF_MAX_NDIM: c_int = if cfg!(PyPy) { 36 } else { 64 };
 
     /* Flags for getting buffers */
     pub const PyBUF_SIMPLE: c_int = 0;

--- a/pyo3-ffi/src/pybuffer.rs
+++ b/pyo3-ffi/src/pybuffer.rs
@@ -3,9 +3,6 @@ use crate::pyport::Py_ssize_t;
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
 
-#[cfg(PyPy)]
-const Py_MAX_NDIMS: usize = 36;
-
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Py_buffer {
@@ -24,9 +21,9 @@ pub struct Py_buffer {
     #[cfg(PyPy)]
     pub flags: c_int,
     #[cfg(PyPy)]
-    pub _strides: [Py_ssize_t; Py_MAX_NDIMS],
+    pub _strides: [Py_ssize_t; PyBUF_MAX_NDIM],
     #[cfg(PyPy)]
-    pub _shape: [Py_ssize_t; Py_MAX_NDIMS],
+    pub _shape: [Py_ssize_t; PyBUF_MAX_NDIM],
 }
 
 impl Py_buffer {
@@ -46,9 +43,9 @@ impl Py_buffer {
             #[cfg(PyPy)]
             flags: 0,
             #[cfg(PyPy)]
-            _strides: [0; Py_MAX_NDIMS],
+            _strides: [0; PyBUF_MAX_NDIM],
             #[cfg(PyPy)]
-            _shape: [0; Py_MAX_NDIMS],
+            _shape: [0; PyBUF_MAX_NDIM],
         }
     }
 }
@@ -105,7 +102,7 @@ extern "C" {
 }
 
 /// Maximum number of dimensions
-pub const PyBUF_MAX_NDIM: c_int = 64;
+pub const PyBUF_MAX_NDIM: c_int = if cfg!(PyPy) { 36 } else { 64 };
 
 /* Flags for getting buffers */
 pub const PyBUF_SIMPLE: c_int = 0;


### PR DESCRIPTION
The ABI break in #3739 got reverted in PyPy 7.3.15: https://github.com/pypy/pypy/pull/4825

... however, it looks like the constant also got renamed to match CPython, so I've updated accordingly.