### PR TITLE
benches: include debuginfo for codspeed / flamegraphs

### DIFF
--- a/pyo3-benches/Cargo.toml
+++ b/pyo3-benches/Cargo.toml
@@ -15,6 +15,10 @@ criterion = "0.5.1"
 num-bigint = "0.4.3"
 rust_decimal = { version = "1.0.0", default-features = false }
 
+[profile.bench]
+debug = true
+strip = false
+
 [[bench]]
 name = "bench_any"
 harness = false


### PR DESCRIPTION
Changes the `bench` profile so that debug info is included, which should allow codspeed benchmarks to gather execution traces...