### PR TITLE
remove internal uses of `_Py_NewRef`

### DIFF
--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -510,11 +510,11 @@ macro_rules! define_pyclass_binary_operator_slot {
             #[inline]
             unsafe fn $lhs(
                 self,
-                _py: Python<'_>,
+                py: Python<'_>,
                 _slf: *mut ffi::PyObject,
                 _other: *mut ffi::PyObject,
             ) -> PyResult<*mut ffi::PyObject> {
-                Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+                Ok(py.NotImplemented().into_ptr())
             }
         }
 
@@ -525,11 +525,11 @@ macro_rules! define_pyclass_binary_operator_slot {
             #[inline]
             unsafe fn $rhs(
                 self,
-                _py: Python<'_>,
+                py: Python<'_>,
                 _slf: *mut ffi::PyObject,
                 _other: *mut ffi::PyObject,
             ) -> PyResult<*mut ffi::PyObject> {
-                Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+                Ok(py.NotImplemented().into_ptr())
             }
         }
 
@@ -700,12 +700,12 @@ slot_fragment_trait! {
     #[inline]
     unsafe fn __pow__(
         self,
-        _py: Python<'_>,
+        py: Python<'_>,
         _slf: *mut ffi::PyObject,
         _other: *mut ffi::PyObject,
         _mod: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
-        Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+        Ok(py.NotImplemented().into_ptr())
     }
 }
 
@@ -716,12 +716,12 @@ slot_fragment_trait! {
     #[inline]
     unsafe fn __rpow__(
         self,
-        _py: Python<'_>,
+        py: Python<'_>,
         _slf: *mut ffi::PyObject,
         _other: *mut ffi::PyObject,
         _mod: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
-        Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+        Ok(py.NotImplemented().into_ptr())
     }
 }
 
@@ -761,11 +761,11 @@ slot_fragment_trait! {
     #[inline]
     unsafe fn __lt__(
         self,
-        _py: Python<'_>,
+        py: Python<'_>,
         _slf: *mut ffi::PyObject,
         _other: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
-        Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+        Ok(py.NotImplemented().into_ptr())
     }
 }
 
@@ -776,11 +776,11 @@ slot_fragment_trait! {
     #[inline]
     unsafe fn __le__(
         self,
-        _py: Python<'_>,
+        py: Python<'_>,
         _slf: *mut ffi::PyObject,
         _other: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
-        Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+        Ok(py.NotImplemented().into_ptr())
     }
 }
 
@@ -791,11 +791,11 @@ slot_fragment_trait! {
     #[inline]
     unsafe fn __eq__(
         self,
-        _py: Python<'_>,
+        py: Python<'_>,
         _slf: *mut ffi::PyObject,
         _other: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
-        Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+        Ok(py.NotImplemented().into_ptr())
     }
 }
 
@@ -824,11 +824,11 @@ slot_fragment_trait! {
     #[inline]
     unsafe fn __gt__(
         self,
-        _py: Python<'_>,
+        py: Python<'_>,
         _slf: *mut ffi::PyObject,
         _other: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
-        Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+        Ok(py.NotImplemented().into_ptr())
     }
 }
 
@@ -839,11 +839,11 @@ slot_fragment_trait! {
     #[inline]
     unsafe fn __ge__(
         self,
-        _py: Python<'_>,
+        py: Python<'_>,
         _slf: *mut ffi::PyObject,
         _other: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
-        Ok(ffi::_Py_NewRef(ffi::Py_NotImplemented()))
+        Ok(py.NotImplemented().into_ptr())
     }
 }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -965,7 +965,9 @@ impl PyAny {
     #[inline]
     pub fn into_ptr(&self) -> *mut ffi::PyObject {
         // Safety: self.as_ptr() returns a valid non-null pointer
-        unsafe { ffi::_Py_NewRef(self.as_ptr()) }
+        let ptr = self.as_ptr();
+        unsafe { ffi::Py_INCREF(ptr) };
+        ptr
     }
 
     /// Return a proxy object that delegates method calls to a parent or sibling class of type.

--- a/tests/test_buffer.rs
+++ b/tests/test_buffer.rs
@@ -41,8 +41,6 @@ impl TestBufferErrors {
             return Err(PyBufferError::new_err("Object is not writable"));
         }
 
-        (*view).obj = ffi::_Py_NewRef(slf.as_ptr());
-
         let bytes = &slf.buf;
 
         (*view).buf = bytes.as_ptr() as *mut c_void;
@@ -79,6 +77,8 @@ impl TestBufferErrors {
                 IncorrectAlignment => (*view).buf = (*view).buf.add(1),
             }
         }
+
+        (*view).obj = slf.into_ptr();
 
         Ok(())
     }

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -155,7 +155,7 @@ unsafe fn fill_view_from_readonly_data(
         return Err(PyBufferError::new_err("Object is not writable"));
     }
 
-    (*view).obj = ffi::_Py_NewRef(owner.as_ptr());
+    (*view).obj = owner.into_ptr();
 
     (*view).buf = data.as_ptr() as *mut c_void;
     (*view).len = data.len() as isize;


### PR DESCRIPTION
This is a part of #3762, specifically removing `_Py_NewRef` as something which PyO3 uses internally. It was straightforward to do this using safe APIs.