### PR TITLE
add `PyFloat::new_bound`

### DIFF
--- a/pyo3-benches/benches/bench_frompyobject.rs
+++ b/pyo3-benches/benches/bench_frompyobject.rs
@@ -73,10 +73,8 @@ fn not_a_list_via_extract_enum(b: &mut Bencher<'_>) {
 
 fn f64_from_pyobject(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let obj = PyFloat::new(py, 1.234);
-        b.iter(|| {
-            let _: f64 = obj.extract().unwrap();
-        });
+        let obj = &PyFloat::new_bound(py, 1.234);
+        b.iter(|| black_box(obj).extract::<f64>().unwrap());
     })
 }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -202,8 +202,8 @@ impl PyAny {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let a = PyFloat::new(py, 0_f64);
-    ///     let b = PyFloat::new(py, 42_f64);
+    ///     let a = PyFloat::new_bound(py, 0_f64);
+    ///     let b = PyFloat::new_bound(py, 42_f64);
     ///     assert_eq!(a.compare(b)?, Ordering::Less);
     ///     Ok(())
     /// })?;
@@ -218,7 +218,7 @@ impl PyAny {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let a = PyFloat::new(py, 0_f64);
+    ///     let a = PyFloat::new_bound(py, 0_f64);
     ///     let b = PyString::new(py, "zero");
     ///     assert!(a.compare(b).is_err());
     ///     Ok(())
@@ -1058,8 +1058,8 @@ pub trait PyAnyMethods<'py> {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let a = PyFloat::new(py, 0_f64);
-    ///     let b = PyFloat::new(py, 42_f64);
+    ///     let a = PyFloat::new_bound(py, 0_f64);
+    ///     let b = PyFloat::new_bound(py, 42_f64);
     ///     assert_eq!(a.compare(b)?, Ordering::Less);
     ///     Ok(())
     /// })?;
@@ -1074,7 +1074,7 @@ pub trait PyAnyMethods<'py> {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let a = PyFloat::new(py, 0_f64);
+    ///     let a = PyFloat::new_bound(py, 0_f64);
     ///     let b = PyString::new(py, "zero");
     ///     assert!(a.compare(b).is_err());
     ///     Ok(())

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -1,10 +1,12 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    ffi, instance::Bound, FromPyObject, IntoPy, PyAny, PyErr, PyNativeType, PyObject, PyResult,
-    Python, ToPyObject,
+    ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, FromPyObject, IntoPy, PyAny, PyErr, PyNativeType,
+    PyObject, PyResult, Python, ToPyObject,
 };
 use std::os::raw::c_double;
+
+use super::any::PyAnyMethods;
 
 /// Represents a Python `float` object.
 ///
@@ -22,9 +24,26 @@ pyobject_native_type!(
 );
 
 impl PyFloat {
+    /// Deprecated form of [`PyFloat::new_bound`].
+    #[inline]
+    #[cfg_attr(
+        not(feature = "gil-refs"),
+        deprecated(
+            since = "0.21.0",
+            note = "`PyFloat::new` will be replaced by `PyFloat::new_bound` in a future PyO3 version"
+        )
+    )]
+    pub fn new(py: Python<'_>, val: f64) -> &'_ Self {
+        Self::new_bound(py, val).into_gil_ref()
+    }
+
     /// Creates a new Python `float` object.
-    pub fn new(py: Python<'_>, val: c_double) -> &PyFloat {
-        unsafe { py.from_owned_ptr(ffi::PyFloat_FromDouble(val)) }
+    pub fn new_bound(py: Python<'_>, val: c_double) -> Bound<'_, PyFloat> {
+        unsafe {
+            ffi::PyFloat_FromDouble(val)
+                .assume_owned(py)
+                .downcast_into_unchecked()
+        }
     }
 
     /// Gets the value of this float.
@@ -61,13 +80,13 @@ impl<'py> PyFloatMethods<'py> for Bound<'py, PyFloat> {
 
 impl ToPyObject for f64 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyFloat::new(py, *self).into()
+        PyFloat::new_bound(py, *self).into()
     }
 }
 
 impl IntoPy<PyObject> for f64 {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyFloat::new(py, self).into()
+        PyFloat::new_bound(py, self).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -108,13 +127,13 @@ impl<'source> FromPyObject<'source> for f64 {
 
 impl ToPyObject for f32 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyFloat::new(py, f64::from(*self)).into()
+        PyFloat::new_bound(py, f64::from(*self)).into()
     }
 }
 
 impl IntoPy<PyObject> for f32 {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyFloat::new(py, f64::from(self)).into()
+        PyFloat::new_bound(py, f64::from(self)).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -135,6 +154,7 @@ impl<'source> FromPyObject<'source> for f32 {
 }
 
 #[cfg(test)]
+#[cfg_attr(not(feature = "gil-refs"), allow(deprecated))]
 mod tests {
     use crate::{types::PyFloat, Python, ToPyObject};
 


### PR DESCRIPTION
Part of #3684.

This implements `PyFloat::new_bound`, adds the deprecation warning to `PyFloat::new`, and migrates PyO3 code over to the new API.