### PR TITLE
add `PyString::new_bound`

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -236,7 +236,7 @@ struct RustyTransparentStruct {
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
 #     Python::with_gil(|py| -> PyResult<()> {
-#         let s = PyString::new(py, "test");
+#         let s = PyString::new_bound(py, "test");
 #
 #         let tup: RustyTransparentTupleStruct = s.extract()?;
 #         assert_eq!(tup.0, "test");
@@ -303,7 +303,7 @@ enum RustyEnum<'a> {
 #             );
 #         }
 #         {
-#             let thing = PyString::new(py, "text");
+#             let thing = PyString::new_bound(py, "text");
 #             let rust_thing: RustyEnum<'_> = thing.extract()?;
 #
 #             assert_eq!(

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -190,7 +190,7 @@ pub trait IntoPy<T>: Sized {
 ///
 /// # fn main() -> PyResult<()> {
 /// Python::with_gil(|py| {
-///     let obj: Py<PyString> = PyString::new(py, "blah").into();
+///     let obj: Py<PyString> = PyString::new_bound(py, "blah").into();
 ///
 ///     // Straight from an owned reference
 ///     let s: &str = obj.extract(py)?;

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -99,11 +99,11 @@ mod test_ipaddr {
     #[test]
     fn test_from_pystring() {
         Python::with_gil(|py| {
-            let py_str = PyString::new(py, "0:0:0:0:0:0:0:1");
+            let py_str = PyString::new_bound(py, "0:0:0:0:0:0:0:1");
             let ip: IpAddr = py_str.to_object(py).extract(py).unwrap();
             assert_eq!(ip, IpAddr::from_str("::1").unwrap());
 
-            let py_str = PyString::new(py, "invalid");
+            let py_str = PyString::new_bound(py, "invalid");
             assert!(py_str.to_object(py).extract::<IpAddr>(py).is_err());
         });
     }

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -11,14 +11,14 @@ use crate::{
 impl ToPyObject for str {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        PyString::new_bound(py, self).into()
     }
 }
 
 impl<'a> IntoPy<PyObject> for &'a str {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        PyString::new_bound(py, self).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -30,7 +30,7 @@ impl<'a> IntoPy<PyObject> for &'a str {
 impl<'a> IntoPy<Py<PyString>> for &'a str {
     #[inline]
     fn into_py(self, py: Python<'_>) -> Py<PyString> {
-        PyString::new(py, self).into()
+        PyString::new_bound(py, self).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -44,7 +44,7 @@ impl<'a> IntoPy<Py<PyString>> for &'a str {
 impl ToPyObject for Cow<'_, str> {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        PyString::new_bound(py, self).into()
     }
 }
 
@@ -65,7 +65,7 @@ impl IntoPy<PyObject> for Cow<'_, str> {
 impl ToPyObject for String {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        PyString::new_bound(py, self).into()
     }
 }
 
@@ -78,7 +78,7 @@ impl ToPyObject for char {
 impl IntoPy<PyObject> for char {
     fn into_py(self, py: Python<'_>) -> PyObject {
         let mut bytes = [0u8; 4];
-        PyString::new(py, self.encode_utf8(&mut bytes)).into()
+        PyString::new_bound(py, self.encode_utf8(&mut bytes)).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -89,7 +89,7 @@ impl IntoPy<PyObject> for char {
 
 impl IntoPy<PyObject> for String {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyString::new(py, &self).into()
+        PyString::new_bound(py, &self).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -101,7 +101,7 @@ impl IntoPy<PyObject> for String {
 impl<'a> IntoPy<PyObject> for &'a String {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        PyString::new_bound(py, self).into()
     }
 
     #[cfg(feature = "experimental-inspect")]

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -206,7 +206,7 @@ impl PyErr {
     ///     assert_eq!(err.to_string(), "TypeError: ");
     ///
     ///     // Case #3: Invalid exception value
-    ///     let err = PyErr::from_value(PyString::new(py, "foo").into());
+    ///     let err = PyErr::from_value(PyString::new_bound(py, "foo").as_gil_ref());
     ///     assert_eq!(
     ///         err.to_string(),
     ///         "TypeError: exceptions must derive from BaseException"

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -3,7 +3,7 @@ use crate::Python;
 
 #[cfg(not(Py_LIMITED_API))]
 use crate::{
-    types::{PyDict, PyString},
+    types::{any::PyAnyMethods, PyDict, PyString},
     IntoPy, Py, PyAny,
 };
 #[cfg(not(any(Py_3_12, Py_LIMITED_API)))]
@@ -98,7 +98,7 @@ fn test_timezone_from_offset_and_name() {
 
     Python::with_gil(|py| {
         let delta = PyDelta::new(py, 0, 100, 0, false).unwrap();
-        let tzname = PyString::new(py, "testtz");
+        let tzname = PyString::new_bound(py, "testtz");
         let tz: &PyAny = unsafe {
             py.from_borrowed_ptr(PyTimeZone_FromOffsetAndName(
                 delta.as_ptr(),
@@ -167,7 +167,7 @@ fn ascii_object_bitfield() {
 fn ascii() {
     Python::with_gil(|py| {
         // This test relies on implementation details of PyString.
-        let s = PyString::new(py, "hello, world");
+        let s = PyString::new_bound(py, "hello, world");
         let ptr = s.as_ptr();
 
         unsafe {
@@ -209,7 +209,7 @@ fn ascii() {
 fn ucs4() {
     Python::with_gil(|py| {
         let s = "哈哈🐈";
-        let py_string = PyString::new(py, s);
+        let py_string = PyString::new_bound(py, s);
         let ptr = py_string.as_ptr();
 
         unsafe {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1624,7 +1624,7 @@ a = A()
             assert!(instance
                 .getattr(py, "foo")?
                 .as_ref(py)
-                .eq(PyString::new(py, "bar"))?);
+                .eq(PyString::new_bound(py, "bar"))?);
 
             instance.getattr(py, "foo")?;
             Ok(())

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -72,7 +72,7 @@
 //! use send_wrapper::SendWrapper;
 //!
 //! Python::with_gil(|py| {
-//!     let string = PyString::new(py, "foo");
+//!     let string = PyString::new_bound(py, "foo");
 //!
 //!     let wrapped = SendWrapper::new(string);
 //!
@@ -80,7 +80,7 @@
 //! # #[cfg(not(feature = "nightly"))]
 //! # {
 //!         // 💥 Unsound! 💥
-//!         let smuggled: &PyString = *wrapped;
+//!         let smuggled: &Bound<'_, PyString> = &*wrapped;
 //!         println!("{:?}", smuggled);
 //! # }
 //!     });
@@ -164,12 +164,12 @@ use std::os::raw::c_int;
 /// use send_wrapper::SendWrapper;
 ///
 /// Python::with_gil(|py| {
-///     let string = PyString::new(py, "foo");
+///     let string = PyString::new_bound(py, "foo");
 ///
 ///     let wrapped = SendWrapper::new(string);
 ///
 ///     py.allow_threads(|| {
-///         let sneaky: &PyString = *wrapped;
+///         let sneaky: &Bound<'_, PyString> = &*wrapped;
 ///
 ///         println!("{:?}", sneaky);
 ///     });
@@ -210,7 +210,7 @@ mod nightly {
         /// # use pyo3::prelude::*;
         /// # use pyo3::types::PyString;
         /// Python::with_gil(|py| {
-        ///     let string = PyString::new(py, "foo");
+        ///     let string = PyString::new_bound(py, "foo");
         ///
         ///     py.allow_threads(|| {
         ///         println!("{:?}", string);
@@ -238,7 +238,7 @@ mod nightly {
         /// use send_wrapper::SendWrapper;
         ///
         /// Python::with_gil(|py| {
-        ///     let string = PyString::new(py, "foo");
+        ///     let string = PyString::new_bound(py, "foo");
         ///
         ///     let wrapped = SendWrapper::new(string);
         ///
@@ -521,7 +521,7 @@ impl<'py> Python<'py> {
     /// use pyo3::types::PyString;
     ///
     /// fn parallel_print(py: Python<'_>) {
-    ///     let s = PyString::new(py, "This object cannot be accessed without holding the GIL >_<");
+    ///     let s = PyString::new_bound(py, "This object cannot be accessed without holding the GIL >_<");
     ///     py.allow_threads(move || {
     ///         println!("{:?}", s); // This causes a compile error.
     ///     });
@@ -1004,6 +1004,7 @@ impl Python<'_> {
     /// The `Ungil` bound on the closure does prevent hanging on to existing GIL-bound references
     ///
     /// ```compile_fail
+    /// # #![allow(deprecated)]
     /// # use pyo3::prelude::*;
     /// # use pyo3::types::PyString;
     ///

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -219,7 +219,7 @@ impl PyAny {
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
     ///     let a = PyFloat::new_bound(py, 0_f64);
-    ///     let b = PyString::new(py, "zero");
+    ///     let b = PyString::new_bound(py, "zero");
     ///     assert!(a.compare(b).is_err());
     ///     Ok(())
     /// })?;
@@ -1075,7 +1075,7 @@ pub trait PyAnyMethods<'py> {
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
     ///     let a = PyFloat::new_bound(py, 0_f64);
-    ///     let b = PyString::new(py, "zero");
+    ///     let b = PyString::new_bound(py, "zero");
     ///     assert!(a.compare(b).is_err());
     ///     Ok(())
     /// })?;

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -73,7 +73,7 @@ impl Iter {
                 let res = reader_ref
                     .inner
                     .get(&b)
-                    .map(|s| PyString::new(py, s).into());
+                    .map(|s| PyString::new_bound(py, s).into());
                 Ok(res)
             }
             None => Ok(None),

--- a/tests/ui/not_send2.rs
+++ b/tests/ui/not_send2.rs
@@ -3,7 +3,7 @@ use pyo3::types::PyString;
 
 fn main() {
     Python::with_gil(|py| {
-        let string = PyString::new(py, "foo");
+        let string = PyString::new_bound(py, "foo");
 
         py.allow_threads(|| {
             println!("{:?}", string);

--- a/tests/ui/not_send2.stderr
+++ b/tests/ui/not_send2.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `UnsafeCell<PyObject>` cannot be shared between threads safely
+error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safely
   --> tests/ui/not_send2.rs:8:26
    |
 8  |           py.allow_threads(|| {
@@ -7,21 +7,36 @@ error[E0277]: `UnsafeCell<PyObject>` cannot be shared between threads safely
    | |            required by a bound introduced by this call
 9  | |             println!("{:?}", string);
 10 | |         });
-   | |_________^ `UnsafeCell<PyObject>` cannot be shared between threads safely
+   | |_________^ `*mut pyo3::Python<'static>` cannot be shared between threads safely
    |
-   = help: within `&PyString`, the trait `Sync` is not implemented for `UnsafeCell<PyObject>`
-note: required because it appears within the type `PyAny`
-  --> src/types/any.rs
+   = help: within `pyo3::Bound<'_, PyString>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
+note: required because it appears within the type `PhantomData<*mut Python<'static>>`
+  --> $RUST/core/src/marker.rs
    |
-   | pub struct PyAny(UnsafeCell<ffi::PyObject>);
+   | pub struct PhantomData<T: ?Sized>;
+   |            ^^^^^^^^^^^
+note: required because it appears within the type `NotSend`
+  --> src/impl_/not_send.rs
+   |
+   | pub(crate) struct NotSend(PhantomData<*mut Python<'static>>);
+   |                   ^^^^^^^
+   = note: required because it appears within the type `(&GILGuard, NotSend)`
+note: required because it appears within the type `PhantomData<(&GILGuard, NotSend)>`
+  --> $RUST/core/src/marker.rs
+   |
+   | pub struct PhantomData<T: ?Sized>;
+   |            ^^^^^^^^^^^
+note: required because it appears within the type `Python<'_>`
+  --> src/marker.rs
+   |
+   | pub struct Python<'py>(PhantomData<(&'py GILGuard, NotSend)>);
+   |            ^^^^^^
+note: required because it appears within the type `Bound<'_, PyString>`
+  --> src/instance.rs
+   |
+   | pub struct Bound<'py, T>(Python<'py>, ManuallyDrop<Py<T>>);
    |            ^^^^^
-note: required because it appears within the type `PyString`
-  --> src/types/string.rs
-   |
-   | pub struct PyString(PyAny);
-   |            ^^^^^^^^
-   = note: required because it appears within the type `&PyString`
-   = note: required for `&&PyString` to implement `Send`
+   = note: required for `&pyo3::Bound<'_, PyString>` to implement `Send`
 note: required because it's used within this closure
   --> tests/ui/not_send2.rs:8:26
    |


### PR DESCRIPTION
Part of #3684

This implements `PyString::new_bound` and deprecates `PyString::new` as per the established pattern, updating internal code.

There are other constructors on `PyString`, particularly `PyString::intern`, which I will cover in a separate PR to keep the diff smaller.