### PR TITLE
migrate `FromPyObject` for `Bound` and `Py` to new APIs

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -247,6 +247,7 @@ Because the new `Bound<T>` API brings ownership out of the PyO3 framework and in
 - Code will need to add the occasional `&` to borrow the new smart pointer as `&Bound<T>` to pass these types around (or use `.clone()` at the very small cost of increasing the Python reference count)
 - `Bound<PyList>` and `Bound<PyTuple>` cannot support indexing with `list[0]`, you should use `list.get_item(0)` instead.
 - `Bound<PyTuple>::iter_borrowed` is slightly more efficient than `Bound<PyTuple>::iter`. The default iteration of `Bound<PyTuple>` cannot return borrowed references because Rust does not (yet) have "lending iterators". Similarly `Bound<PyTuple>::get_borrowed_item` is more efficient than `Bound<PyTuple>::get_item` for the same reason.
+- `&Bound<T>` does not implement `FromPyObject` (although it might be possible to do this in the future once the GIL Refs API is completely removed). Use `bound_any.downcast::<T>()` instead of `bound_any.extract::<&Bound<T>>()`.
 
 #### Migrating `FromPyObject` implementations
 

--- a/newsfragments/3776.changed.md
+++ b/newsfragments/3776.changed.md
@@ -1,0 +1,1 @@
+Relax bound of `FromPyObject` for `Py<T>` to just `T: PyTypeCheck`.

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -3,7 +3,7 @@ use crate::{
     ffi,
     pyclass::boolean_struct::False,
     types::{PyDict, PyString, PyTuple},
-    FromPyObject, PyAny, PyClass, PyErr, PyRef, PyRefMut, PyResult, Python,
+    Bound, FromPyObject, PyAny, PyClass, PyErr, PyRef, PyRefMut, PyResult, PyTypeCheck, Python,
 };
 
 /// A trait which is used to help PyO3 macros extract function arguments.
@@ -28,6 +28,18 @@ where
     #[inline]
     fn extract(obj: &'py PyAny, _: &'a mut ()) -> PyResult<Self> {
         obj.extract()
+    }
+}
+
+impl<'a, 'py, T> PyFunctionArgument<'a, 'py> for &'a Bound<'py, T>
+where
+    T: PyTypeCheck,
+{
+    type Holder = Option<Bound<'py, T>>;
+
+    #[inline]
+    fn extract(obj: &'py PyAny, holder: &'a mut Option<Bound<'py, T>>) -> PyResult<Self> {
+        Ok(&*holder.insert(obj.extract()?))
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1405,27 +1405,22 @@ impl<T> Drop for Py<T> {
     }
 }
 
-impl<'a, T> FromPyObject<'a> for Py<T>
+impl<T> FromPyObject<'_> for Py<T>
 where
-    T: PyTypeInfo,
-    &'a T::AsRefTarget: FromPyObject<'a>,
-    T::AsRefTarget: 'a + AsPyPointer,
+    T: PyTypeCheck,
 {
     /// Extracts `Self` from the source `PyObject`.
-    fn extract(ob: &'a PyAny) -> PyResult<Self> {
-        unsafe {
-            ob.extract::<&T::AsRefTarget>()
-                .map(|val| Py::from_borrowed_ptr(ob.py(), val.as_ptr()))
-        }
+    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+        ob.extract::<Bound<'_, T>>().map(Bound::unbind)
     }
 }
 
-impl<'a, T> FromPyObject<'a> for Bound<'a, T>
+impl<'py, T> FromPyObject<'py> for Bound<'py, T>
 where
-    T: PyTypeInfo,
+    T: PyTypeCheck,
 {
     /// Extracts `Self` from the source `PyObject`.
-    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         ob.downcast().map(Clone::clone).map_err(Into::into)
     }
 }

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -529,3 +529,20 @@ fn test_some_wrap_arguments() {
         py_assert!(py, function, "function() == [1, 2, None, None]");
     })
 }
+
+#[test]
+fn test_reference_to_bound_arguments() {
+    #[pyfunction]
+    fn reference_args<'py>(
+        x: &Bound<'py, PyAny>,
+        y: Option<&Bound<'py, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        y.map_or_else(|| Ok(x.clone()), |y| y.add(x))
+    }
+
+    Python::with_gil(|py| {
+        let function = wrap_pyfunction!(reference_args, py).unwrap();
+        py_assert!(py, function, "function(1) == 1");
+        py_assert!(py, function, "function(1, 2) == 3");
+    })
+}

--- a/tests/ui/invalid_argument_attributes.stderr
+++ b/tests/ui/invalid_argument_attributes.stderr
@@ -93,6 +93,7 @@ error[E0277]: the trait bound `CancelHandle: Clone` is not satisfied
    |                                                  ^^^^ the trait `Clone` is not implemented for `CancelHandle`
    |
    = help: the following other types implement trait `PyFunctionArgument<'a, 'py>`:
+             &'a pyo3::Bound<'py, T>
              &'a pyo3::coroutine::Coroutine
              &'a mut pyo3::coroutine::Coroutine
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`


### PR DESCRIPTION
This PR is two commits which refine `FromPyObject` for our smart pointers:

 - the first adjusts the bound of `FromPyObject` for both `Bound<T>` and `Py<T>` to just be `T: PyTypeCheck`, while migrating to `extract_bound` at the same time. This is loosely a follow-up from #3706 
 - the second implements `PyFunctionArgument for &Bound<T>`, allowing `#[pyfunction]` and `#[pymethods]` to accept `&Bound<T>`. I think it's desirable to allow this, and it's not possible to implement `FromPyObject for &Bound<T>` because while the backwards-compatible definition of `FromPyObject` for the GIL-ref API can't express that lifetime of the reference correctly. In the future we could potentially have `FromPyObject<'a, 'py> for &'a Bound<'py, T>` if we introduce a second lifetime to `FromPyObject`.

(I think that second lifetime is necessary if we also wanted `FromPyObject<'a, 'py> for Borrowed<'a, 'py, T>` too, but I'm less motivated for that and similarly would like to skip adding `PyFunctionArgument` for `Borrowed<T>` unless users are reporting it as a useful addition.)