### PR TITLE
expose `Bound::from_owned_ptr` etc

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -105,33 +105,34 @@ where
 }
 
 impl<'py> Bound<'py, PyAny> {
-    /// Constructs a new Bound from a pointer. Panics if ptr is null.
+    /// Constructs a new `Bound<'py, PyAny>` from a pointer. Panics if `ptr` is null.
     ///
     /// # Safety
     ///
-    /// `ptr` must be a valid pointer to a Python object.
-    pub(crate) unsafe fn from_owned_ptr(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
+    /// - `ptr` must be a valid pointer to a Python object
+    /// - `ptr` must be an owned Python reference, as the `Bound<'py, PyAny>` will assume ownership
+    pub unsafe fn from_owned_ptr(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
         Self(py, ManuallyDrop::new(Py::from_owned_ptr(py, ptr)))
     }
 
-    /// Constructs a new Bound from a pointer. Returns None if ptr is null.
+    /// Constructs a new `Bound<'py, PyAny>` from a pointer. Returns `None`` if `ptr` is null.
     ///
     /// # Safety
     ///
-    /// `ptr` must be a valid pointer to a Python object, or NULL.
-    pub(crate) unsafe fn from_owned_ptr_or_opt(
-        py: Python<'py>,
-        ptr: *mut ffi::PyObject,
-    ) -> Option<Self> {
+    /// - `ptr` must be a valid pointer to a Python object, or null
+    /// - `ptr` must be an owned Python reference, as the `Bound<'py, PyAny>` will assume ownership
+    pub unsafe fn from_owned_ptr_or_opt(py: Python<'py>, ptr: *mut ffi::PyObject) -> Option<Self> {
         Py::from_owned_ptr_or_opt(py, ptr).map(|obj| Self(py, ManuallyDrop::new(obj)))
     }
 
-    /// Constructs a new Bound from a pointer. Returns error if ptr is null.
+    /// Constructs a new `Bound<'py, PyAny>` from a pointer. Returns an `Err` by calling `PyErr::fetch`
+    /// if `ptr` is null.
     ///
     /// # Safety
     ///
-    /// `ptr` must be a valid pointer to a Python object, or NULL.
-    pub(crate) unsafe fn from_owned_ptr_or_err(
+    /// - `ptr` must be a valid pointer to a Python object, or null
+    /// - `ptr` must be an owned Python reference, as the `Bound<'py, PyAny>` will assume ownership
+    pub unsafe fn from_owned_ptr_or_err(
         py: Python<'py>,
         ptr: *mut ffi::PyObject,
     ) -> PyResult<Self> {


### PR DESCRIPTION
Split from #3606 

This makes `Bound::from_owned_ptr` and variants part of the public API, instead of `pub(crate)`.

This is useful for the occasional use case outside of PyO3 which deals with raw FFI. These APIs also have equivalents with the same names which already exist on `Py<T>`, so it seems to me that we might as well have these.