### PR TITLE
remove bench of `GILPool::new`

### DIFF
--- a/pyo3-benches/benches/bench_gil.rs
+++ b/pyo3-benches/benches/bench_gil.rs
@@ -1,14 +1,6 @@
 use codspeed_criterion_compat::{criterion_group, criterion_main, BatchSize, Bencher, Criterion};
 
-use pyo3::{prelude::*, GILPool};
-
-fn bench_clean_gilpool_new(b: &mut Bencher<'_>) {
-    Python::with_gil(|_py| {
-        b.iter(|| {
-            let _ = unsafe { GILPool::new() };
-        });
-    });
-}
+use pyo3::prelude::*;
 
 fn bench_clean_acquire_gil(b: &mut Bencher<'_>) {
     // Acquiring first GIL will also create a "clean" GILPool, so this measures the Python overhead.
@@ -28,7 +20,6 @@ fn bench_dirty_acquire_gil(b: &mut Bencher<'_>) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("clean_gilpool_new", bench_clean_gilpool_new);
     c.bench_function("clean_acquire_gil", bench_clean_acquire_gil);
     c.bench_function("dirty_acquire_gil", bench_dirty_acquire_gil);
 }


### PR DESCRIPTION
This benchmark has shown some volatility in codspeed, I'm also not interested in this benchmark any more as we'll be removing the API eventually and we know that the GILPool is not good for performance.

I suggest we just save the CPU cycles and remove it now.