### PR TITLE
PyEllipsis and PyNotImplemented new get_bound api

### DIFF
--- a/src/marker.rs
+++ b/src/marker.rs
@@ -713,7 +713,7 @@ impl<'py> Python<'py> {
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]
     pub fn NotImplemented(self) -> PyObject {
-        PyNotImplemented::get(self).into()
+        PyNotImplemented::get_bound(self).into_py(self)
     }
 
     /// Gets the running Python interpreter version as a string.

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -706,7 +706,7 @@ impl<'py> Python<'py> {
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]
     pub fn Ellipsis(self) -> PyObject {
-        PyEllipsis::get(self).into()
+        PyEllipsis::get_bound(self).into_py(self)
     }
 
     /// Gets the Python builtin value `NotImplemented`.

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -18,7 +18,7 @@ impl PyEllipsis {
     )]
     #[inline]
     pub fn get(py: Python<'_>) -> &PyEllipsis {
-        unsafe { py.from_borrowed_ptr(ffi::Py_Ellipsis()) }
+        Self::get_bound(py).into_gil_ref()
     }
 
     /// Returns the `Ellipsis` object.

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -1,4 +1,4 @@
-use crate::{ffi, PyAny, PyTypeInfo, Python};
+use crate::{ffi, ffi_ptr_ext::FfiPtrExt, Borrowed, PyAny, PyTypeInfo, Python};
 
 /// Represents the Python `Ellipsis` object.
 #[repr(transparent)]
@@ -9,9 +9,22 @@ pyobject_native_type_extract!(PyEllipsis);
 
 impl PyEllipsis {
     /// Returns the `Ellipsis` object.
+    #[cfg_attr(
+        not(feature = "gil-refs"),
+        deprecated(
+            since = "0.21.0",
+            note = "`PyEllipsis::get` will be replaced by `PyEllipsis::get_bound` in a future PyO3 version"
+        )
+    )]
     #[inline]
     pub fn get(py: Python<'_>) -> &PyEllipsis {
         unsafe { py.from_borrowed_ptr(ffi::Py_Ellipsis()) }
+    }
+
+    /// Returns the `Ellipsis` object.
+    #[inline]
+    pub fn get_bound(py: Python<'_>) -> Borrowed<'_, '_, PyEllipsis> {
+        unsafe { ffi::Py_Ellipsis().assume_borrowed(py).downcast_unchecked() }
     }
 }
 
@@ -32,27 +45,28 @@ unsafe impl PyTypeInfo for PyEllipsis {
 
     #[inline]
     fn is_exact_type_of(object: &PyAny) -> bool {
-        object.is(Self::get(object.py()))
+        object.is(Self::get_bound(object.py()).as_ref())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::types::any::PyAnyMethods;
     use crate::types::{PyDict, PyEllipsis};
     use crate::{PyTypeInfo, Python};
 
     #[test]
     fn test_ellipsis_is_itself() {
         Python::with_gil(|py| {
-            assert!(PyEllipsis::get(py).is_instance_of::<PyEllipsis>());
-            assert!(PyEllipsis::get(py).is_exact_instance_of::<PyEllipsis>());
+            assert!(PyEllipsis::get_bound(py).is_instance_of::<PyEllipsis>());
+            assert!(PyEllipsis::get_bound(py).is_exact_instance_of::<PyEllipsis>());
         })
     }
 
     #[test]
     fn test_ellipsis_type_object_consistent() {
         Python::with_gil(|py| {
-            assert!(PyEllipsis::get(py)
+            assert!(PyEllipsis::get_bound(py)
                 .get_type()
                 .is(PyEllipsis::type_object(py)));
         })

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -15,12 +15,12 @@ impl PyNone {
         not(feature = "gil-refs"),
         deprecated(
             since = "0.21.0",
-            note = "`PyNone::get` will be replaced by `PyBool::get_bound` in a future PyO3 version"
+            note = "`PyNone::get` will be replaced by `PyNone::get_bound` in a future PyO3 version"
         )
     )]
     #[inline]
     pub fn get(py: Python<'_>) -> &PyNone {
-        unsafe { py.from_borrowed_ptr(ffi::Py_None()) }
+        Self::get_bound(py).into_gil_ref()
     }
 
     /// Returns the `None` object.

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -18,7 +18,7 @@ impl PyNotImplemented {
     )]
     #[inline]
     pub fn get(py: Python<'_>) -> &PyNotImplemented {
-        unsafe { py.from_borrowed_ptr(ffi::Py_NotImplemented()) }
+        Self::get_bound(py).into_gil_ref()
     }
 
     /// Returns the `NotImplemented` object.


### PR DESCRIPTION
Parts of https://github.com/PyO3/pyo3/issues/3684

This adds `get_bound` method to `PyEllipsis`  and `PyNotImplemented`