### PR TITLE
ci: fix beta clippy `map_clone` warning

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1443,6 +1443,9 @@ where
 {
     /// Extracts `Self` from the source `PyObject`.
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        // TODO update MSRV past 1.59 and use .cloned() to make
+        // clippy happy
+        #[allow(clippy::map_clone)]
         ob.downcast().map(Clone::clone).map_err(Into::into)
     }
 }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -264,13 +264,13 @@ impl Sequence {
         self.values.len()
     }
 
-    fn __getitem__(&self, index: SequenceIndex<'_>) -> PyResult<PyObject> {
+    fn __getitem__(&self, index: SequenceIndex<'_>, py: Python<'_>) -> PyResult<PyObject> {
         match index {
             SequenceIndex::Integer(index) => {
                 let uindex = self.usize_index(index)?;
                 self.values
                     .get(uindex)
-                    .map(Clone::clone)
+                    .map(|o| o.clone_ref(py))
                     .ok_or_else(|| PyIndexError::new_err(index))
             }
             // Just to prove that slicing can be implemented


### PR DESCRIPTION
`clippy` on the beta toolchain has started complaining about `.map(Clone::clone)` for `Result`, but to carry out the recommended fix we need `Result::cloned` from 1.59.

For now I just added an `#[allow]` with a TODO to tidy up when we bump MSRV later.