### PR TITLE
PyCFunction bound api

### DIFF
--- a/src/impl_/pyfunction.rs
+++ b/src/impl_/pyfunction.rs
@@ -6,5 +6,5 @@ pub fn _wrap_pyfunction<'a>(
     method_def: &PyMethodDef,
     py_or_module: impl Into<PyFunctionArguments<'a>>,
 ) -> PyResult<&'a PyCFunction> {
-    PyCFunction::internal_new(method_def, py_or_module.into())
+    PyCFunction::internal_new(method_def, py_or_module.into()).map(|x| x.into_gil_ref())
 }

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -323,7 +323,7 @@ fn test_pycfunction_new() {
             ffi::PyLong_FromLong(4200)
         }
 
-        let py_fn = PyCFunction::new(
+        let py_fn = PyCFunction::new_bound(
             c_fn,
             "py_fn",
             "py_fn for test (this is the docstring)",
@@ -380,7 +380,7 @@ fn test_pycfunction_new_with_keywords() {
             ffi::PyLong_FromLong(foo * bar)
         }
 
-        let py_fn = PyCFunction::new_with_keywords(
+        let py_fn = PyCFunction::new_with_keywords_bound(
             c_fn,
             "py_fn",
             "py_fn for test (this is the docstring)",
@@ -422,7 +422,7 @@ fn test_closure() {
             })
         };
         let closure_py =
-            PyCFunction::new_closure(py, Some("test_fn"), Some("test_fn doc"), f).unwrap();
+            PyCFunction::new_closure_bound(py, Some("test_fn"), Some("test_fn doc"), f).unwrap();
 
         py_assert!(py, closure_py, "closure_py(42) == [43]");
         py_assert!(py, closure_py, "closure_py.__name__ == 'test_fn'");
@@ -445,7 +445,7 @@ fn test_closure_counter() {
                 *counter += 1;
                 Ok(*counter)
             };
-        let counter_py = PyCFunction::new_closure(py, None, None, counter_fn).unwrap();
+        let counter_py = PyCFunction::new_closure_bound(py, None, None, counter_fn).unwrap();
 
         py_assert!(py, counter_py, "counter_py() == 1");
         py_assert!(py, counter_py, "counter_py() == 2");

--- a/tests/ui/invalid_closure.rs
+++ b/tests/ui/invalid_closure.rs
@@ -10,7 +10,9 @@ fn main() {
             println!("This is five: {:?}", ref_.len());
             Ok(())
         };
-        PyCFunction::new_closure(py, None, None, closure_fn).unwrap().into()
+        PyCFunction::new_closure_bound(py, None, None, closure_fn)
+            .unwrap()
+            .into()
     });
 
     Python::with_gil(|py| {

--- a/tests/ui/invalid_closure.stderr
+++ b/tests/ui/invalid_closure.stderr
@@ -6,7 +6,8 @@ error[E0597]: `local_data` does not live long enough
 7  |         let ref_: &[u8] = &local_data;
    |                           ^^^^^^^^^^^ borrowed value does not live long enough
 ...
-13 |         PyCFunction::new_closure(py, None, None, closure_fn).unwrap().into()
-   |         ---------------------------------------------------- argument requires that `local_data` is borrowed for `'static`
-14 |     });
+13 |         PyCFunction::new_closure_bound(py, None, None, closure_fn)
+   |         ---------------------------------------------------------- argument requires that `local_data` is borrowed for `'static`
+...
+16 |     });
    |     - `local_data` dropped here while still borrowed


### PR DESCRIPTION
Part of https://github.com/PyO3/pyo3/issues/3684

Adds `_bound` versions of `PyCFunction` constructors.

@davidhewitt Any suggestions what to do with `wrap_pyfunction`? The change to update it to Bound is pretty minimal, but potentially breaking if people are using it outside the standard `m.add_function(wrap_pyfunction!...)` scenario