### PR TITLE
add `PyStringMethods::encode_utf8`

### DIFF
--- a/newsfragments/3801.added.md
+++ b/newsfragments/3801.added.md
@@ -1,0 +1,1 @@
+Add `PyStringMethods::encode_utf8`.


### PR DESCRIPTION
This PR adds an `encode_utf8()` method to explicitly convert `Bound<PyString>` to `Bound<PyBytes>`, equivalent to the Python `s.encode('utf-8')`.

This turns out to be useful in #3708 and I felt like it made sense for this to be a public API.