### PR TITLE
docs: clarify --pretty option to expand

### DIFF
--- a/guide/src/debugging.md
+++ b/guide/src/debugging.md
@@ -16,7 +16,7 @@ You can also debug classic `!`-macros by adding `-Z trace-macros`:
 cargo rustc --profile=check -- -Z unstable-options --pretty=expanded -Z trace-macros > expanded.rs; rustfmt expanded.rs
 ```
 
-Note that those commands require using the nightly build of rust and are prone to errors. See [cargo expand](https://github.com/dtolnay/cargo-expand) for a more elaborate and stable version of those commands.
+Note that those commands require using the nightly build of rust and may occasionally have bugs. See [cargo expand](https://github.com/dtolnay/cargo-expand) for a more elaborate and stable version of those commands.
 
 ## Running with Valgrind
 

--- a/guide/src/debugging.md
+++ b/guide/src/debugging.md
@@ -16,7 +16,7 @@ You can also debug classic `!`-macros by adding `-Z trace-macros`:
 cargo rustc --profile=check -- -Z unstable-options --pretty=expanded -Z trace-macros > expanded.rs; rustfmt expanded.rs
 ```
 
-See [cargo expand](https://github.com/dtolnay/cargo-expand) for a more elaborate version of those commands.
+Note that those commands require using the nightly build of rust and are prone to errors. See [cargo expand](https://github.com/dtolnay/cargo-expand) for a more elaborate and stable version of those commands.
 
 ## Running with Valgrind
 


### PR DESCRIPTION
Added clarification. --pretty no longer works, and it breaks even on nightly at least on cargo 1.78.0-nightly (cdf84b69d 2024-02-02) and rustc 1.78.0-nightly (256b6fb19 2024-02-06).

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request. To run its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
