### PR TITLE
docs: Clarify the requirement to install nox before building documentation

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -48,7 +48,7 @@ There are some specific areas of focus where help is currently needed for the do
 - Issues requesting documentation improvements are tracked with the [documentation](https://github.com/PyO3/pyo3/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation) label.
 - Not all APIs had docs or examples when they were made. The goal is to have documentation on all PyO3 APIs ([#306](https://github.com/PyO3/pyo3/issues/306)). If you see an API lacking a doc, please write one and open a PR!
 
-You can build the docs (including all features) with
+To build the docs (including all features), install [`nox`][nox] and then run
 
 ```shell
 nox -s docs -- open


### PR DESCRIPTION
Installing nox was mentioned in a later section when building the user guide but not at this point earlier in the guide where nox was needed for the first time.

I ran into this when I was first attempting to build the docs and it took me a moment to realize I had to install it as a global tool, separate from the dependencies of this project.