### PR TITLE
ci: allow some dead code warnings on nightly

### DIFF
--- a/guide/src/trait_bounds.md
+++ b/guide/src/trait_bounds.md
@@ -64,6 +64,7 @@ class Model:
 The following wrapper will call the Python model from Rust, using a struct to hold the model as a `PyAny` object:
 
 ```rust
+# #![allow(dead_code)]
 use pyo3::prelude::*;
 
 # pub trait Model {
@@ -162,6 +163,7 @@ However, we can write a second wrapper around these functions to call them direc
 This wrapper will also perform the type conversions between Python and Rust.
 
 ```rust
+# #![allow(dead_code)]
 # use pyo3::prelude::*;
 #
 # pub trait Model {
@@ -330,6 +332,7 @@ Let's modify the code performing the type conversion to give a helpful error mes
 We used in our `get_results` method the following call that performs the type conversion:
 
 ```rust
+# #![allow(dead_code)]
 # use pyo3::prelude::*;
 #
 # pub trait Model {
@@ -382,6 +385,7 @@ impl Model for UserModel {
 Let's break it down in order to perform better error handling:
 
 ```rust
+# #![allow(dead_code)]
 # use pyo3::prelude::*;
 #
 # pub trait Model {
@@ -460,6 +464,7 @@ Because of this, we can write a function wrapper that takes the `UserModel`--whi
 It is also required to make the struct public.
 
 ```rust
+# #![allow(dead_code)]
 use pyo3::prelude::*;
 
 pub trait Model {

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -19,6 +19,7 @@
 //! defined as the following:
 //!
 //! ```rust
+//! # #![allow(dead_code)]
 //! pub unsafe trait Ungil {}
 //!
 //! unsafe impl<T: Send> Ungil for T {}

--- a/tests/ui/not_send.stderr
+++ b/tests/ui/not_send.stderr
@@ -7,23 +7,23 @@ error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safe
   |        required by a bound introduced by this call
   |
   = help: within `pyo3::Python<'_>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
-note: required because it appears within the type `PhantomData<*mut Python<'static>>`
+note: required because it appears within the type `PhantomData<*mut pyo3::Python<'static>>`
  --> $RUST/core/src/marker.rs
   |
   | pub struct PhantomData<T: ?Sized>;
   |            ^^^^^^^^^^^
-note: required because it appears within the type `NotSend`
+note: required because it appears within the type `impl_::not_send::NotSend`
  --> src/impl_/not_send.rs
   |
   | pub(crate) struct NotSend(PhantomData<*mut Python<'static>>);
   |                   ^^^^^^^
-  = note: required because it appears within the type `(&GILGuard, NotSend)`
-note: required because it appears within the type `PhantomData<(&GILGuard, NotSend)>`
+  = note: required because it appears within the type `(&pyo3::gil::GILGuard, impl_::not_send::NotSend)`
+note: required because it appears within the type `PhantomData<(&pyo3::gil::GILGuard, impl_::not_send::NotSend)>`
  --> $RUST/core/src/marker.rs
   |
   | pub struct PhantomData<T: ?Sized>;
   |            ^^^^^^^^^^^
-note: required because it appears within the type `Python<'_>`
+note: required because it appears within the type `pyo3::Python<'_>`
  --> src/marker.rs
   |
   | pub struct Python<'py>(PhantomData<(&'py GILGuard, NotSend)>);

--- a/tests/ui/not_send2.stderr
+++ b/tests/ui/not_send2.stderr
@@ -10,28 +10,28 @@ error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safe
    | |_________^ `*mut pyo3::Python<'static>` cannot be shared between threads safely
    |
    = help: within `pyo3::Bound<'_, PyString>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
-note: required because it appears within the type `PhantomData<*mut Python<'static>>`
+note: required because it appears within the type `PhantomData<*mut pyo3::Python<'static>>`
   --> $RUST/core/src/marker.rs
    |
    | pub struct PhantomData<T: ?Sized>;
    |            ^^^^^^^^^^^
-note: required because it appears within the type `NotSend`
+note: required because it appears within the type `impl_::not_send::NotSend`
   --> src/impl_/not_send.rs
    |
    | pub(crate) struct NotSend(PhantomData<*mut Python<'static>>);
    |                   ^^^^^^^
-   = note: required because it appears within the type `(&GILGuard, NotSend)`
-note: required because it appears within the type `PhantomData<(&GILGuard, NotSend)>`
+   = note: required because it appears within the type `(&pyo3::gil::GILGuard, impl_::not_send::NotSend)`
+note: required because it appears within the type `PhantomData<(&pyo3::gil::GILGuard, impl_::not_send::NotSend)>`
   --> $RUST/core/src/marker.rs
    |
    | pub struct PhantomData<T: ?Sized>;
    |            ^^^^^^^^^^^
-note: required because it appears within the type `Python<'_>`
+note: required because it appears within the type `pyo3::Python<'_>`
   --> src/marker.rs
    |
    | pub struct Python<'py>(PhantomData<(&'py GILGuard, NotSend)>);
    |            ^^^^^^
-note: required because it appears within the type `Bound<'_, PyString>`
+note: required because it appears within the type `pyo3::Bound<'_, PyString>`
   --> src/instance.rs
    |
    | pub struct Bound<'py, T>(Python<'py>, ManuallyDrop<Py<T>>);

--- a/tests/ui/traverse.stderr
+++ b/tests/ui/traverse.stderr
@@ -15,7 +15,7 @@ error[E0308]: mismatched types
    | |___________________^ expected fn pointer, found fn item
    |
    = note: expected fn pointer `for<'a, 'b> fn(&'a TraverseTriesToTakePyRef, PyVisit<'b>) -> Result<(), PyTraverseError>`
-                 found fn item `for<'a, 'b> fn(pyo3::PyRef<'a, TraverseTriesToTakePyRef>, PyVisit<'b>) {TraverseTriesToTakePyRef::__traverse__}`
+                 found fn item `for<'a, 'b> fn(pyo3::PyRef<'a, TraverseTriesToTakePyRef, >, PyVisit<'b>) {TraverseTriesToTakePyRef::__traverse__}`
 note: function defined here
   --> src/impl_/pymethods.rs
    |


### PR DESCRIPTION
Looks like the latest nightly has got some better dead code detection for unused trait methods. While that's very welcome, the `careful` job is blocking merges due to this new warning.

On the main nightly job, this is also being emitted as an error:

```
warning: method `downcast_into` is never used
  --> src/py_result_ext.rs:14:8
   |
13 | pub(crate) trait PyResultExt<'py>: Sealed {
   |                  ----------- method in this trait
14 |     fn downcast_into<T: PyTypeCheck>(self) -> PyResult<Bound<'py, T>>;
   |        ^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

I'm pretty sure we'll use that `downcast_into` method soon in #3703 or similar, so I'm going to just leave `nightly` broken in the very short term. I think the PR diff here should be sufficient to fix `careful`.

Will proceed straight to merge to unblock CI.