### PR TITLE
ci: include debug symbols for codspeed profiling

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -134,13 +134,19 @@ def bench(session: nox.Session) -> bool:
 
 @nox.session()
 def codspeed(session: nox.Session) -> bool:
+    # set configuration variables for codspeed flamegraphs to get full symbols
+    build_env = os.environ.copy()
+    build_env["CARGO_PROFILE_RELEASE_DEBUG"] = "true"
+    build_env["CARGO_PROFILE_RELEASE_STRIP"] = "false"
+
     # rust benchmarks
     os.chdir(PYO3_DIR / "pyo3-benches")
-    _run_cargo(session, "codspeed", "build")
+    _run_cargo(session, "codspeed", "build", env=build_env)
     _run_cargo(session, "codspeed", "run")
+
     # python benchmarks
     os.chdir(PYO3_DIR / "pytests")
-    session.install(".[dev]", "pytest-codspeed")
+    session.install(".[dev]", "pytest-codspeed", env=build_env)
     _run(session, "pytest", "--codspeed", external=True)
 
 


### PR DESCRIPTION
This is a repeat of #3758, but I think this time I've actually set the configuration in the right place. In the previous PR, I tried to configure the `bench` profile, but I think codspeed actually uses the `release` profile, both in `pyo3-benches` and in `pytests`.

Let's see if this looks any better...