### PR TITLE
port `IntoPyDict` to `Bound` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ fn main() -> PyResult<()> {
         let sys = py.import("sys")?;
         let version: String = sys.getattr("version")?.extract()?;
 
-        let locals = [("os", py.import("os")?)].into_py_dict(py).as_borrowed();
+        let locals = [("os", py.import("os")?)].into_py_dict_bound(py);
         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
         let user: String = py.eval_bound(code, None, Some(&locals))?.extract()?;
 

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -24,7 +24,7 @@ use pyo3::exceptions::PyException;
 create_exception!(mymodule, CustomError, PyException);
 
 Python::with_gil(|py| {
-    let ctx = [("CustomError", py.get_type::<CustomError>())].into_py_dict(py);
+    let ctx = [("CustomError", py.get_type::<CustomError>())].into_py_dict_bound(py);
     pyo3::py_run!(
         py,
         *ctx,

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -283,7 +283,7 @@ Python::with_gil(|py| {
 
 After:
 
-```rust
+```rust,ignore
 use pyo3::prelude::*;
 use pyo3::exceptions::PyTypeError;
 use pyo3::types::{PyDict, IntoPyDict};

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -93,7 +93,7 @@ fn func() -> String {
 #    use pyo3::wrap_pymodule;
 #    use pyo3::types::IntoPyDict;
 #    let parent_module = wrap_pymodule!(parent_module)(py);
-#    let ctx = [("parent_module", parent_module)].into_py_dict(py).as_borrowed();
+#    let ctx = [("parent_module", parent_module)].into_py_dict_bound(py);
 #
 #    py.run_bound("assert parent_module.child_module.func() == 'func'", None, Some(&ctx)).unwrap();
 # })

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -94,17 +94,17 @@ fn main() -> PyResult<()> {
         .into();
 
         // call object with PyDict
-        let kwargs = [(key1, val1)].into_py_dict(py);
-        fun.call_bound(py, (), Some(&kwargs.as_borrowed()))?;
+        let kwargs = [(key1, val1)].into_py_dict_bound(py);
+        fun.call_bound(py, (), Some(&kwargs))?;
 
         // pass arguments as Vec
         let kwargs = vec![(key1, val1), (key2, val2)];
-        fun.call_bound(py, (), Some(&kwargs.into_py_dict(py).as_borrowed()))?;
+        fun.call_bound(py, (), Some(&kwargs.into_py_dict_bound(py)))?;
 
         // pass arguments as HashMap
         let mut kwargs = HashMap::<&str, i32>::new();
         kwargs.insert(key1, 1);
-        fun.call_bound(py, (), Some(&kwargs.into_py_dict(py).as_borrowed()))?;
+        fun.call_bound(py, (), Some(&kwargs.into_py_dict_bound(py)))?;
 
         Ok(())
     })
@@ -250,10 +250,10 @@ def leaky_relu(x, slope=0.01):
     let relu_result: f64 = activators.getattr("relu")?.call1((-1.0,))?.extract()?;
     assert_eq!(relu_result, 0.0);
 
-    let kwargs = [("slope", 0.2)].into_py_dict(py);
+    let kwargs = [("slope", 0.2)].into_py_dict_bound(py);
     let lrelu_result: f64 = activators
         .getattr("leaky_relu")?
-        .call((-1.0,), Some(kwargs))?
+        .call((-1.0,), Some(kwargs.as_gil_ref()))?
         .extract()?;
     assert_eq!(lrelu_result, -0.2);
 #    Ok(())

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -147,7 +147,7 @@ mod test_anyhow {
         let pyerr = PyErr::from(err);
 
         Python::with_gil(|py| {
-            let locals = [("err", pyerr)].into_py_dict(py).as_borrowed();
+            let locals = [("err", pyerr)].into_py_dict_bound(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value(py).to_string(), expected_contents);
         })
@@ -164,7 +164,7 @@ mod test_anyhow {
         let pyerr = PyErr::from(err);
 
         Python::with_gil(|py| {
-            let locals = [("err", pyerr)].into_py_dict(py).as_borrowed();
+            let locals = [("err", pyerr)].into_py_dict_bound(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value(py).to_string(), expected_contents);
         })

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1109,7 +1109,7 @@ mod tests {
             fn test_pyo3_offset_fixed_frompyobject_created_in_python(timestamp in 0..(i32::MAX as i64), timedelta in -86399i32..=86399i32) {
                 Python::with_gil(|py| {
 
-                    let globals = [("datetime", py.import("datetime").unwrap())].into_py_dict(py).as_borrowed();
+                    let globals = [("datetime", py.import("datetime").unwrap())].into_py_dict_bound(py);
                     let code = format!("datetime.datetime.fromtimestamp({}).replace(tzinfo=datetime.timezone(datetime.timedelta(seconds={})))", timestamp, timedelta);
                     let t = py.eval_bound(&code, Some(&globals), None).unwrap();
 

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -152,7 +152,7 @@ mod tests {
         let pyerr = PyErr::from(err);
 
         Python::with_gil(|py| {
-            let locals = [("err", pyerr)].into_py_dict(py).as_borrowed();
+            let locals = [("err", pyerr)].into_py_dict_bound(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value(py).to_string(), expected_contents);
         })
@@ -169,7 +169,7 @@ mod tests {
         let pyerr = PyErr::from(err);
 
         Python::with_gil(|py| {
-            let locals = [("err", pyerr)].into_py_dict(py).as_borrowed();
+            let locals = [("err", pyerr)].into_py_dict_bound(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value(py).to_string(), expected_contents);
         })

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -33,7 +33,7 @@ where
     H: hash::BuildHasher,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        IntoPyDict::into_py_dict(self, py).into()
+        IntoPyDict::into_py_dict_bound(self, py).into()
     }
 }
 
@@ -47,7 +47,7 @@ where
         let iter = self
             .into_iter()
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
-        IntoPyDict::into_py_dict(iter, py).into()
+        IntoPyDict::into_py_dict_bound(iter, py).into()
     }
 }
 
@@ -164,7 +164,7 @@ mod tests {
             let mut map = hashbrown::HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let py_map = map.into_py_dict(py);
+            let py_map = map.into_py_dict_bound(py);
 
             assert_eq!(py_map.len(), 1);
             assert_eq!(

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -100,7 +100,7 @@ where
     H: hash::BuildHasher,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        IntoPyDict::into_py_dict(self, py).into()
+        IntoPyDict::into_py_dict_bound(self, py).into()
     }
 }
 
@@ -114,7 +114,7 @@ where
         let iter = self
             .into_iter()
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
-        IntoPyDict::into_py_dict(iter, py).into()
+        IntoPyDict::into_py_dict_bound(iter, py).into()
     }
 }
 
@@ -137,6 +137,8 @@ where
 #[cfg(test)]
 mod test_indexmap {
 
+    use crate::types::any::PyAnyMethods;
+    use crate::types::dict::PyDictMethods;
     use crate::types::*;
     use crate::{IntoPy, PyObject, Python, ToPyObject};
 
@@ -194,7 +196,7 @@ mod test_indexmap {
             let mut map = indexmap::IndexMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let py_map = map.into_py_dict(py);
+            let py_map = map.into_py_dict_bound(py);
 
             assert_eq!(py_map.len(), 1);
             assert_eq!(
@@ -223,7 +225,7 @@ mod test_indexmap {
                 }
             }
 
-            let py_map = map.clone().into_py_dict(py);
+            let py_map = map.clone().into_py_dict_bound(py);
 
             let trip_map = py_map.extract::<indexmap::IndexMap<i32, i32>>().unwrap();
 

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -16,7 +16,7 @@ where
     H: hash::BuildHasher,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        IntoPyDict::into_py_dict(self, py).into()
+        IntoPyDict::into_py_dict_bound(self, py).into()
     }
 }
 
@@ -26,7 +26,7 @@ where
     V: ToPyObject,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        IntoPyDict::into_py_dict(self, py).into()
+        IntoPyDict::into_py_dict_bound(self, py).into()
     }
 }
 
@@ -40,7 +40,7 @@ where
         let iter = self
             .into_iter()
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
-        IntoPyDict::into_py_dict(iter, py).into()
+        IntoPyDict::into_py_dict_bound(iter, py).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -58,7 +58,7 @@ where
         let iter = self
             .into_iter()
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
-        IntoPyDict::into_py_dict(iter, py).into()
+        IntoPyDict::into_py_dict_bound(iter, py).into()
     }
 
     #[cfg(feature = "experimental-inspect")]

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -71,7 +71,7 @@ macro_rules! impl_exception_boilerplate {
 /// import_exception!(socket, gaierror);
 ///
 /// Python::with_gil(|py| {
-///     let ctx = [("gaierror", py.get_type::<gaierror>())].into_py_dict(py);
+///     let ctx = [("gaierror", py.get_type::<gaierror>())].into_py_dict_bound(py);
 ///     pyo3::py_run!(py, *ctx, "import socket; assert gaierror is socket.gaierror");
 /// });
 ///
@@ -864,7 +864,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let error_type = py.get_type::<CustomError>();
-            let ctx = [("CustomError", error_type)].into_py_dict(py).as_borrowed();
+            let ctx = [("CustomError", error_type)].into_py_dict_bound(py);
             let type_description: String = py
                 .eval_bound("str(CustomError)", None, Some(&ctx))
                 .unwrap()
@@ -887,7 +887,7 @@ mod tests {
         create_exception!(mymodule.exceptions, CustomError, PyException);
         Python::with_gil(|py| {
             let error_type = py.get_type::<CustomError>();
-            let ctx = [("CustomError", error_type)].into_py_dict(py).as_borrowed();
+            let ctx = [("CustomError", error_type)].into_py_dict_bound(py);
             let type_description: String = py
                 .eval_bound("str(CustomError)", None, Some(&ctx))
                 .unwrap()
@@ -906,7 +906,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let error_type = py.get_type::<CustomError>();
-            let ctx = [("CustomError", error_type)].into_py_dict(py).as_borrowed();
+            let ctx = [("CustomError", error_type)].into_py_dict_bound(py);
             let type_description: String = py
                 .eval_bound("str(CustomError)", None, Some(&ctx))
                 .unwrap()
@@ -939,7 +939,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let error_type = py.get_type::<CustomError>();
-            let ctx = [("CustomError", error_type)].into_py_dict(py).as_borrowed();
+            let ctx = [("CustomError", error_type)].into_py_dict_bound(py);
             let type_description: String = py
                 .eval_bound("str(CustomError)", None, Some(&ctx))
                 .unwrap()

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -727,7 +727,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let args = PyTuple::new_bound(py, Vec::<&PyAny>::new());
-            let kwargs = [("foo", 0u8)].into_py_dict(py);
+            let kwargs = [("foo", 0u8)].into_py_dict_bound(py);
             let err = unsafe {
                 function_description
                     .extract_arguments_tuple_dict::<NoVarargs, NoVarkeywords>(
@@ -758,7 +758,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let args = PyTuple::new_bound(py, Vec::<&PyAny>::new());
-            let kwargs = [(1u8, 1u8)].into_py_dict(py);
+            let kwargs = [(1u8, 1u8)].into_py_dict_bound(py);
             let err = unsafe {
                 function_description
                     .extract_arguments_tuple_dict::<NoVarargs, NoVarkeywords>(

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1765,7 +1765,7 @@ mod tests {
                 "{'x': 1}",
             );
             assert_repr(
-                obj.call(py, (), Some([('x', 1)].into_py_dict(py)))
+                obj.call_bound(py, (), Some(&[('x', 1)].into_py_dict_bound(py)))
                     .unwrap()
                     .as_ref(py),
                 "{'x': 1}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@
 //!         let sys = py.import("sys")?;
 //!         let version: String = sys.getattr("version")?.extract()?;
 //!
-//!         let locals = [("os", py.import("os")?)].into_py_dict(py).as_borrowed();
+//!         let locals = [("os", py.import("os")?)].into_py_dict_bound(py);
 //!         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
 //!         let user: String = py.eval_bound(code, None, Some(&locals))?.extract()?;
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,7 +73,7 @@
 /// }
 ///
 /// Python::with_gil(|py| {
-///     let locals = [("C", py.get_type::<MyClass>())].into_py_dict(py);
+///     let locals = [("C", py.get_type::<MyClass>())].into_py_dict_bound(py);
 ///     pyo3::py_run!(py, *locals, "c = C()");
 /// });
 /// ```
@@ -99,11 +99,12 @@ macro_rules! py_run_impl {
     ($py:expr, $($val:ident)+, $code:expr) => {{
         use $crate::types::IntoPyDict;
         use $crate::ToPyObject;
-        let d = [$((stringify!($val), $val.to_object($py)),)+].into_py_dict($py);
+        let d = [$((stringify!($val), $val.to_object($py)),)+].into_py_dict_bound($py);
         $crate::py_run_impl!($py, *d, $code)
     }};
     ($py:expr, *$dict:expr, $code:expr) => {{
         use ::std::option::Option::*;
+        #[allow(unused_imports)]
         use $crate::PyNativeType;
         if let ::std::result::Result::Err(e) = $py.run_bound($code, None, Some(&$dict.as_borrowed())) {
             e.print($py);

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1132,7 +1132,7 @@ mod tests {
                 .unwrap();
             assert_eq!(v, 1);
 
-            let d = [("foo", 13)].into_py_dict(py).as_borrowed();
+            let d = [("foo", 13)].into_py_dict_bound(py);
 
             // Inject our own global namespace
             let v: i32 = py

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -2400,8 +2400,8 @@ class NonHeapNonDescriptorInt:
     fn test_call_with_kwargs() {
         Python::with_gil(|py| {
             let list = vec![3, 6, 5, 4, 7].to_object(py);
-            let dict = vec![("reverse", true)].into_py_dict(py);
-            list.call_method(py, "sort", (), Some(dict)).unwrap();
+            let dict = vec![("reverse", true)].into_py_dict_bound(py);
+            list.call_method_bound(py, "sort", (), Some(&dict)).unwrap();
             assert_eq!(list.extract::<Vec<i32>>(py).unwrap(), vec![7, 6, 5, 4, 3]);
         });
     }

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -57,7 +57,7 @@ fn test_buffer() {
             },
         )
         .unwrap();
-        let env = [("ob", instance)].into_py_dict(py);
+        let env = [("ob", instance)].into_py_dict_bound(py);
         py_assert!(py, *env, "bytes(ob) == b' 23'");
     });
 
@@ -122,7 +122,7 @@ fn test_releasebuffer_unraisable_error() {
         let capture = UnraisableCapture::install(py);
 
         let instance = Py::new(py, ReleaseBufferError {}).unwrap();
-        let env = [("ob", instance.clone())].into_py_dict(py);
+        let env = [("ob", instance.clone())].into_py_dict_bound(py);
 
         assert!(capture.borrow(py).capture.is_none());
 

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -29,7 +29,10 @@ fn empty_class_with_new() {
         // Calling with arbitrary args or kwargs is not ok
         assert!(typeobj.call(("some", "args"), None).is_err());
         assert!(typeobj
-            .call((), Some([("some", "kwarg")].into_py_dict(py)))
+            .call(
+                (),
+                Some([("some", "kwarg")].into_py_dict_bound(py).as_gil_ref())
+            )
             .is_err());
     });
 }

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -68,7 +68,7 @@ fn test_coroutine_qualname() {
             ("my_fn", wrap_pyfunction!(my_fn, gil).unwrap().deref()),
             ("MyClass", gil.get_type::<MyClass>()),
         ]
-        .into_py_dict(gil);
+        .into_py_dict_bound(gil);
         py_run!(gil, *locals, &handle_windows(test));
     })
 }
@@ -286,7 +286,7 @@ fn test_async_method_receiver() {
             assert False
         assert asyncio.run(coro3) == 1
         "#;
-        let locals = [("Counter", gil.get_type::<Counter>())].into_py_dict(gil);
+        let locals = [("Counter", gil.get_type::<Counter>())].into_py_dict_bound(gil);
         py_run!(gil, *locals, test);
     })
 }

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -12,9 +12,7 @@ fn _get_subclasses<'py>(
     // Import the class from Python and create some subclasses
     let datetime = py.import("datetime")?;
 
-    let locals = [(py_type, datetime.getattr(py_type)?)]
-        .into_py_dict(py)
-        .as_borrowed();
+    let locals = [(py_type, datetime.getattr(py_type)?)].into_py_dict_bound(py);
 
     let make_subclass_py = format!("class Subklass({}):\n    pass", py_type);
 
@@ -23,7 +21,6 @@ fn _get_subclasses<'py>(
     py.run_bound(&make_subclass_py, None, Some(&locals))?;
     py.run_bound(make_sub_subclass_py, None, Some(&locals))?;
 
-    let locals = locals.as_borrowed();
     // Construct an instance of the base class
     let obj = py.eval_bound(&format!("{}({})", py_type, args), None, Some(&locals))?;
 
@@ -125,7 +122,7 @@ fn test_datetime_utc() {
 
         let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(utc)).unwrap();
 
-        let locals = [("dt", dt)].into_py_dict(py).as_borrowed();
+        let locals = [("dt", dt)].into_py_dict_bound(py);
 
         let offset: f32 = py
             .eval_bound("dt.utcoffset().total_seconds()", None, Some(&locals))

--- a/tests/test_dict_iter.rs
+++ b/tests/test_dict_iter.rs
@@ -6,7 +6,7 @@ use pyo3::types::IntoPyDict;
 fn iter_dict_nosegv() {
     Python::with_gil(|py| {
         const LEN: usize = 10_000_000;
-        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
+        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py);
         let mut sum = 0;
         for (k, _v) in dict {
             let i: u64 = k.extract().unwrap();

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -64,7 +64,7 @@ fn class_with_properties() {
         py_run!(py, inst, "assert inst.get_num() == inst.unwrapped == 42");
         py_run!(py, inst, "assert inst.data_list == [42]");
 
-        let d = [("C", py.get_type::<ClassWithProperties>())].into_py_dict(py);
+        let d = [("C", py.get_type::<ClassWithProperties>())].into_py_dict_bound(py);
         py_assert!(py, *d, "C.DATA.__doc__ == 'a getter for data'");
     });
 }

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -20,9 +20,7 @@ struct SubclassAble {}
 #[test]
 fn subclass() {
     Python::with_gil(|py| {
-        let d = [("SubclassAble", py.get_type::<SubclassAble>())]
-            .into_py_dict(py)
-            .as_borrowed();
+        let d = [("SubclassAble", py.get_type::<SubclassAble>())].into_py_dict_bound(py);
 
         py.run_bound(
             "class A(SubclassAble): pass\nassert issubclass(A, SubclassAble)",
@@ -99,7 +97,7 @@ fn call_base_and_sub_methods() {
 fn mutation_fails() {
     Python::with_gil(|py| {
         let obj = PyCell::new(py, SubClass::new()).unwrap();
-        let global = [("obj", obj)].into_py_dict(py).as_borrowed();
+        let global = [("obj", obj)].into_py_dict_bound(py);
         let e = py
             .run_bound(
                 "obj.base_set(lambda: obj.sub_set_and_ret(1))",
@@ -277,7 +275,7 @@ mod inheriting_native_type {
     fn custom_exception() {
         Python::with_gil(|py| {
             let cls = py.get_type::<CustomException>();
-            let dict = [("cls", cls)].into_py_dict(py).as_borrowed();
+            let dict = [("cls", cls)].into_py_dict_bound(py);
             let res = py.run_bound(
             "e = cls('hello'); assert str(e) == 'hello'; assert e.context == 'Hello :)'; raise e",
             None,

--- a/tests/test_macro_docs.rs
+++ b/tests/test_macro_docs.rs
@@ -23,7 +23,7 @@ impl MacroDocs {
 #[test]
 fn meth_doc() {
     Python::with_gil(|py| {
-        let d = [("C", py.get_type::<MacroDocs>())].into_py_dict(py);
+        let d = [("C", py.get_type::<MacroDocs>())].into_py_dict_bound(py);
         py_assert!(
             py,
             *d,

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -68,8 +68,8 @@ impl Mapping {
 }
 
 /// Return a dict with `m = Mapping(['1', '2', '3'])`.
-fn map_dict(py: Python<'_>) -> &pyo3::types::PyDict {
-    let d = [("Mapping", py.get_type::<Mapping>())].into_py_dict(py);
+fn map_dict(py: Python<'_>) -> Bound<'_, pyo3::types::PyDict> {
+    let d = [("Mapping", py.get_type::<Mapping>())].into_py_dict_bound(py);
     py_run!(py, *d, "m = Mapping(['1', '2', '3'])");
     d
 }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -89,7 +89,7 @@ impl ClassMethod {
 #[test]
 fn class_method() {
     Python::with_gil(|py| {
-        let d = [("C", py.get_type::<ClassMethod>())].into_py_dict(py);
+        let d = [("C", py.get_type::<ClassMethod>())].into_py_dict_bound(py);
         py_assert!(py, *d, "C.method() == 'ClassMethod.method()!'");
         py_assert!(py, *d, "C().method() == 'ClassMethod.method()!'");
         py_assert!(
@@ -116,7 +116,7 @@ impl ClassMethodWithArgs {
 #[test]
 fn class_method_with_args() {
     Python::with_gil(|py| {
-        let d = [("C", py.get_type::<ClassMethodWithArgs>())].into_py_dict(py);
+        let d = [("C", py.get_type::<ClassMethodWithArgs>())].into_py_dict_bound(py);
         py_assert!(
             py,
             *d,
@@ -147,7 +147,7 @@ fn static_method() {
     Python::with_gil(|py| {
         assert_eq!(StaticMethod::method(py), "StaticMethod.method()!");
 
-        let d = [("C", py.get_type::<StaticMethod>())].into_py_dict(py);
+        let d = [("C", py.get_type::<StaticMethod>())].into_py_dict_bound(py);
         py_assert!(py, *d, "C.method() == 'StaticMethod.method()!'");
         py_assert!(py, *d, "C().method() == 'StaticMethod.method()!'");
         py_assert!(py, *d, "C.method.__doc__ == 'Test static method.'");
@@ -171,7 +171,7 @@ fn static_method_with_args() {
     Python::with_gil(|py| {
         assert_eq!(StaticMethodWithArgs::method(py, 1234), "0x4d2");
 
-        let d = [("C", py.get_type::<StaticMethodWithArgs>())].into_py_dict(py);
+        let d = [("C", py.get_type::<StaticMethodWithArgs>())].into_py_dict_bound(py);
         py_assert!(py, *d, "C.method(1337) == '0x539'");
     });
 }
@@ -669,7 +669,7 @@ impl MethDocs {
 #[test]
 fn meth_doc() {
     Python::with_gil(|py| {
-        let d = [("C", py.get_type::<MethDocs>())].into_py_dict(py);
+        let d = [("C", py.get_type::<MethDocs>())].into_py_dict_bound(py);
         py_assert!(py, *d, "C.__doc__ == 'A class with \"documentation\".'");
         py_assert!(
             py,
@@ -753,7 +753,7 @@ fn method_with_pyclassarg() {
     Python::with_gil(|py| {
         let obj1 = PyCell::new(py, MethodWithPyClassArg { value: 10 }).unwrap();
         let obj2 = PyCell::new(py, MethodWithPyClassArg { value: 10 }).unwrap();
-        let d = [("obj1", obj1), ("obj2", obj2)].into_py_dict(py);
+        let d = [("obj1", obj1), ("obj2", obj2)].into_py_dict_bound(py);
         py_run!(py, *d, "obj = obj1.add(obj2); assert obj.value == 20");
         py_run!(py, *d, "obj = obj1.add_pyref(obj2); assert obj.value == 20");
         py_run!(py, *d, "obj = obj1.optional_add(); assert obj.value == 20");

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -74,7 +74,7 @@ fn test_module_with_functions() {
             "module_with_functions",
             wrap_pymodule!(module_with_functions)(py),
         )]
-        .into_py_dict(py);
+        .into_py_dict_bound(py);
 
         py_assert!(
             py,
@@ -127,7 +127,7 @@ fn test_module_renaming() {
     use pyo3::wrap_pymodule;
 
     Python::with_gil(|py| {
-        let d = [("different_name", wrap_pymodule!(some_name)(py))].into_py_dict(py);
+        let d = [("different_name", wrap_pymodule!(some_name)(py))].into_py_dict_bound(py);
 
         py_run!(py, *d, "assert different_name.__name__ == 'other_name'");
     });

--- a/tests/test_no_imports.rs
+++ b/tests/test_no_imports.rs
@@ -90,7 +90,7 @@ fn test_basic() {
     pyo3::Python::with_gil(|py| {
         let module = pyo3::wrap_pymodule!(basic_module)(py);
         let cls = py.get_type::<BasicClass>();
-        let d = pyo3::types::IntoPyDict::into_py_dict(
+        let d = pyo3::types::IntoPyDict::into_py_dict_bound(
             [
                 ("mod", module.as_ref(py).as_ref()),
                 ("cls", cls.as_ref()),

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -105,8 +105,8 @@ impl ByteSequence {
 }
 
 /// Return a dict with `s = ByteSequence([1, 2, 3])`.
-fn seq_dict(py: Python<'_>) -> &pyo3::types::PyDict {
-    let d = [("ByteSequence", py.get_type::<ByteSequence>())].into_py_dict(py);
+fn seq_dict(py: Python<'_>) -> Bound<'_, pyo3::types::PyDict> {
+    let d = [("ByteSequence", py.get_type::<ByteSequence>())].into_py_dict_bound(py);
     // Though we can construct `s` in Rust, let's test `__new__` works.
     py_run!(py, *d, "s = ByteSequence([1, 2, 3])");
     d
@@ -138,7 +138,7 @@ fn test_setitem() {
 #[test]
 fn test_delitem() {
     Python::with_gil(|py| {
-        let d = [("ByteSequence", py.get_type::<ByteSequence>())].into_py_dict(py);
+        let d = [("ByteSequence", py.get_type::<ByteSequence>())].into_py_dict_bound(py);
 
         py_run!(
             py,
@@ -234,7 +234,7 @@ fn test_repeat() {
 #[test]
 fn test_inplace_repeat() {
     Python::with_gil(|py| {
-        let d = [("ByteSequence", py.get_type::<ByteSequence>())].into_py_dict(py);
+        let d = [("ByteSequence", py.get_type::<ByteSequence>())].into_py_dict_bound(py);
 
         py_run!(
             py,

--- a/tests/test_static_slots.rs
+++ b/tests/test_static_slots.rs
@@ -37,8 +37,8 @@ impl Count5 {
 }
 
 /// Return a dict with `s = Count5()`.
-fn test_dict(py: Python<'_>) -> &pyo3::types::PyDict {
-    let d = [("Count5", py.get_type::<Count5>())].into_py_dict(py);
+fn test_dict(py: Python<'_>) -> Bound<'_, pyo3::types::PyDict> {
+    let d = [("Count5", py.get_type::<Count5>())].into_py_dict_bound(py);
     // Though we can construct `s` in Rust, let's test `__new__` works.
     py_run!(py, *d, "s = Count5()");
     d


### PR DESCRIPTION
Part of #3684, split from #3716

This introduces the `into_py_dict_bound` API on the `IntoPyDict` trait, and deprecates the old gil-ref API.

Because the diff is already quite large, I kept the deprecation of `PyDict::new` for a followup PR.