### PR TITLE
Implement PyErr::get_type_bound

### DIFF
--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -479,7 +479,7 @@ class House(object):
             }
             Err(e) => {
                 house
-                    .call_method1("__exit__", (e.get_type(py), e.value(py), e.traceback_bound(py)))
+                    .call_method1("__exit__", (e.get_type_bound(py), e.value(py), e.traceback_bound(py)))
                     .unwrap();
             }
         }

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -16,12 +16,12 @@ pub(crate) struct PyErrStateNormalized {
 
 impl PyErrStateNormalized {
     #[cfg(not(Py_3_12))]
-    pub(crate) fn ptype<'py>(&'py self, py: Python<'py>) -> Bound<'py, PyType> {
+    pub(crate) fn ptype<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
         self.ptype.bind(py).clone()
     }
 
     #[cfg(Py_3_12)]
-    pub(crate) fn ptype<'py>(&'py self, py: Python<'py>) -> Bound<'py, PyType> {
+    pub(crate) fn ptype<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
         use crate::ffi_ptr_ext::FfiPtrExt;
         use crate::types::any::PyAnyMethods;
         unsafe {

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -22,6 +22,8 @@ impl PyErrStateNormalized {
 
     #[cfg(Py_3_12)]
     pub(crate) fn ptype<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
+        use crate::instance::PyNativeType;
+        use crate::types::any::PyAnyMethods;
         self.pvalue.bind(py).get_type().as_borrowed().to_owned()
     }
 

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -22,13 +22,7 @@ impl PyErrStateNormalized {
 
     #[cfg(Py_3_12)]
     pub(crate) fn ptype<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
-        use crate::ffi_ptr_ext::FfiPtrExt;
-        use crate::types::any::PyAnyMethods;
-        unsafe {
-            ffi::PyExceptionInstance_Class(self.pvalue.as_ptr())
-                .assume_owned(py)
-                .downcast_into_unchecked()
-        }
+        self.pvalue.bind(py).get_type().as_borrowed().to_owned()
     }
 
     #[cfg(not(Py_3_12))]

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -505,8 +505,9 @@ impl PyErr {
             // after the argument got evaluated, leading to call with a dangling
             // pointer.
             let traceback = self.traceback_bound(py);
+            let type_bound = self.get_type_bound(py);
             ffi::PyErr_Display(
-                self.get_type_bound(py).as_ptr(),
+                type_bound.as_ptr(),
                 self.value(py).as_ptr(),
                 traceback
                     .as_ref()
@@ -543,8 +544,8 @@ impl PyErr {
     /// Returns true if the current exception is instance of `T`.
     #[inline]
     pub fn is_instance(&self, py: Python<'_>, ty: &PyAny) -> bool {
-        (unsafe { ffi::PyErr_GivenExceptionMatches(self.get_type_bound(py).as_ptr(), ty.as_ptr()) })
-            != 0
+        let type_bound = self.get_type_bound(py);
+        (unsafe { ffi::PyErr_GivenExceptionMatches(type_bound.as_ptr(), ty.as_ptr()) }) != 0
     }
 
     /// Returns true if the current exception is instance of `T`.

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -248,7 +248,7 @@ impl PyErr {
     ///     assert!(err.get_type_bound(py).is(PyType::new::<PyTypeError>(py)));
     /// });
     /// ```
-    pub fn get_type_bound<'py>(&'py self, py: Python<'py>) -> Bound<'py, PyType> {
+    pub fn get_type_bound<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
         self.normalized(py).ptype(py)
     }
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -241,7 +241,7 @@ impl PyErr {
     ///
     /// # Examples
     /// ```rust
-    /// use pyo3::{exceptions::PyTypeError, types::PyType, PyErr, Python, prelude::PyAnyMethods};
+    /// use pyo3::{prelude::*, exceptions::PyTypeError, types::PyType};
     ///
     /// Python::with_gil(|py| {
     ///     let err: PyErr = PyTypeError::new_err(("some type error",));

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -241,7 +241,7 @@ impl PyErr {
     ///
     /// # Examples
     /// ```rust
-    /// use pyo3::{exceptions::PyTypeError, types::PyType, PyErr, Python};
+    /// use pyo3::{exceptions::PyTypeError, types::PyType, PyErr, Python, prelude::PyAnyMethods};
     ///
     /// Python::with_gil(|py| {
     ///     let err: PyErr = PyTypeError::new_err(("some type error",));
@@ -693,7 +693,7 @@ impl PyErr {
     /// Python::with_gil(|py| {
     ///     let err: PyErr = PyTypeError::new_err(("some type error",));
     ///     let err_clone = err.clone_ref(py);
-    ///     assert!(err.get_type(py).is(err_clone.get_type(py)));
+    ///     assert!(err.get_type_bound(py).is(&err_clone.get_type_bound(py)));
     ///     assert!(err.value(py).is(err_clone.value(py)));
     ///     match err.traceback_bound(py) {
     ///         None => assert!(err_clone.traceback_bound(py).is_none()),

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -165,7 +165,8 @@ pub fn from_py_with_with_default<'py, T>(
 #[doc(hidden)]
 #[cold]
 pub fn argument_extraction_error(py: Python<'_>, arg_name: &str, error: PyErr) -> PyErr {
-    if error.get_type(py).is(py.get_type::<PyTypeError>()) {
+    use crate::types::any::PyAnyMethods;
+    if error.get_type_bound(py).is(py.get_type::<PyTypeError>()) {
         let remapped_error =
             PyTypeError::new_err(format!("argument '{}': {}", arg_name, error.value(py)));
         remapped_error.set_cause(py, error.cause(py));


### PR DESCRIPTION
Implements more of the `Bound` api from #3684.
