### PR TITLE
Pyerr value bound

### DIFF
--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -479,7 +479,7 @@ class House(object):
             }
             Err(e) => {
                 house
-                    .call_method1("__exit__", (e.get_type_bound(py), e.value(py), e.traceback_bound(py)))
+                    .call_method1("__exit__", (e.get_type_bound(py), e.value_bound(py), e.traceback_bound(py)))
                     .unwrap();
             }
         }

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -149,7 +149,7 @@ mod test_anyhow {
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict_bound(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
-            assert_eq!(pyerr.value(py).to_string(), expected_contents);
+            assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }
 
@@ -166,7 +166,7 @@ mod test_anyhow {
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict_bound(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
-            assert_eq!(pyerr.value(py).to_string(), expected_contents);
+            assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }
 

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -590,7 +590,7 @@ mod tests {
             assert!(result.is_err());
             let res = result.err().unwrap();
             // Also check the error message is what we expect
-            let msg = res.value(py).repr().unwrap().to_string();
+            let msg = res.value_bound(py).repr().unwrap().to_string();
             assert_eq!(msg, "TypeError(\"zoneinfo.ZoneInfo(key='Europe/London') is not a fixed offset timezone\")");
         });
     }
@@ -605,7 +605,7 @@ mod tests {
             // Now test that converting a PyDateTime with tzinfo to a NaiveDateTime fails
             let res: PyResult<NaiveDateTime> = py_datetime.extract();
             assert_eq!(
-                res.unwrap_err().value(py).repr().unwrap().to_string(),
+                res.unwrap_err().value_bound(py).repr().unwrap().to_string(),
                 "TypeError('expected a datetime without tzinfo')"
             );
         });
@@ -620,14 +620,14 @@ mod tests {
             // Now test that converting a PyDateTime with tzinfo to a NaiveDateTime fails
             let res: PyResult<DateTime<Utc>> = py_datetime.extract();
             assert_eq!(
-                res.unwrap_err().value(py).repr().unwrap().to_string(),
+                res.unwrap_err().value_bound(py).repr().unwrap().to_string(),
                 "TypeError('expected a datetime with non-None tzinfo')"
             );
 
             // Now test that converting a PyDateTime with tzinfo to a NaiveDateTime fails
             let res: PyResult<DateTime<FixedOffset>> = py_datetime.extract();
             assert_eq!(
-                res.unwrap_err().value(py).repr().unwrap().to_string(),
+                res.unwrap_err().value_bound(py).repr().unwrap().to_string(),
                 "TypeError('expected a datetime with non-None tzinfo')"
             );
         });

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -154,7 +154,7 @@ mod tests {
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict_bound(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
-            assert_eq!(pyerr.value(py).to_string(), expected_contents);
+            assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }
 
@@ -171,7 +171,7 @@ mod tests {
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict_bound(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
-            assert_eq!(pyerr.value(py).to_string(), expected_contents);
+            assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }
 

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -78,7 +78,7 @@ impl Coroutine {
             (Some(exc), Some(cb)) => cb.throw(exc.as_ref(py)),
             (Some(exc), None) => {
                 self.close();
-                return Err(PyErr::from_value(exc.as_ref(py)));
+                return Err(PyErr::from_value_bound(exc.bind(py)));
             }
             (None, _) => {}
         }

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -78,7 +78,7 @@ impl Coroutine {
             (Some(exc), Some(cb)) => cb.throw(exc.as_ref(py)),
             (Some(exc), None) => {
                 self.close();
-                return Err(PyErr::from_value_bound(exc.bind(py)));
+                return Err(PyErr::from_value_bound(exc.into_bound(py)));
             }
             (None, _) => {}
         }

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -124,7 +124,6 @@ impl PyErrState {
         Self::Normalized(PyErrStateNormalized {
             #[cfg(not(Py_3_12))]
             ptype: pvalue.get_type().into(),
-            pvalue: pvalue.clone().into(),
             #[cfg(not(Py_3_12))]
             ptraceback: unsafe {
                 Py::from_owned_ptr_or_opt(
@@ -132,6 +131,7 @@ impl PyErrState {
                     ffi::PyException_GetTraceback(pvalue.as_ptr()),
                 )
             },
+            pvalue: pvalue.into(),
         })
     }
 

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -101,19 +101,7 @@ where
 }
 
 impl PyErrState {
-    pub(crate) fn lazy(ptype: &PyAny, args: impl PyErrArguments + 'static) -> Self {
-        let ptype = ptype.into();
-        PyErrState::Lazy(Box::new(move |py| PyErrStateLazyFnOutput {
-            ptype,
-            pvalue: args.arguments(py),
-        }))
-    }
-
-    pub(crate) fn lazy_bound(
-        ptype: &Bound<'_, PyAny>,
-        args: impl PyErrArguments + 'static,
-    ) -> Self {
-        let ptype = (*ptype).clone().into();
+    pub(crate) fn lazy(ptype: Py<PyAny>, args: impl PyErrArguments + 'static) -> Self {
         PyErrState::Lazy(Box::new(move |py| PyErrStateLazyFnOutput {
             ptype,
             pvalue: args.arguments(py),

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -109,11 +109,22 @@ impl PyErrState {
         }))
     }
 
-    pub(crate) fn normalized(pvalue: &PyBaseException) -> Self {
+    pub(crate) fn lazy_bound(ptype: Bound<'_, PyAny>, args: impl PyErrArguments + 'static) -> Self {
+        let ptype = ptype.into();
+        PyErrState::Lazy(Box::new(move |py| PyErrStateLazyFnOutput {
+            ptype,
+            pvalue: args.arguments(py),
+        }))
+    }
+
+    pub(crate) fn normalized(pvalue: Bound<'_, PyBaseException>) -> Self {
+        #[cfg(not(Py_3_12))]
+        use crate::types::any::PyAnyMethods;
+
         Self::Normalized(PyErrStateNormalized {
             #[cfg(not(Py_3_12))]
             ptype: pvalue.get_type().into(),
-            pvalue: pvalue.into(),
+            pvalue: pvalue.clone().into(),
             #[cfg(not(Py_3_12))]
             ptraceback: unsafe {
                 Py::from_owned_ptr_or_opt(

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -109,8 +109,11 @@ impl PyErrState {
         }))
     }
 
-    pub(crate) fn lazy_bound(ptype: Bound<'_, PyAny>, args: impl PyErrArguments + 'static) -> Self {
-        let ptype = ptype.into();
+    pub(crate) fn lazy_bound(
+        ptype: &Bound<'_, PyAny>,
+        args: impl PyErrArguments + 'static,
+    ) -> Self {
+        let ptype = (*ptype).clone().into();
         PyErrState::Lazy(Box::new(move |py| PyErrStateLazyFnOutput {
             ptype,
             pvalue: args.arguments(py),

--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -142,7 +142,7 @@ mod tests {
                 let py_err_recovered_from_rust_err: PyErr = rust_err_from_py_err.into();
                 assert!(py_err_recovered_from_rust_err
                     .value_bound(py)
-                    .is(&py_error_clone.value_bound(py))); // It should be the same exception
+                    .is(py_error_clone.value_bound(py))); // It should be the same exception
             })
         };
 

--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -124,6 +124,8 @@ mod tests {
 
     #[test]
     fn io_errors() {
+        use crate::types::any::PyAnyMethods;
+
         let check_err = |kind, expected_ty| {
             Python::with_gil(|py| {
                 let rust_err = io::Error::new(kind, "some error msg");
@@ -139,8 +141,8 @@ mod tests {
 
                 let py_err_recovered_from_rust_err: PyErr = rust_err_from_py_err.into();
                 assert!(py_err_recovered_from_rust_err
-                    .value(py)
-                    .is(py_error_clone.value(py))); // It should be the same exception
+                    .value_bound(py)
+                    .is(&py_error_clone.value_bound(py))); // It should be the same exception
             })
         };
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1073,7 +1073,6 @@ impl_signed_integer!(isize);
 mod tests {
     use super::PyErrState;
     use crate::exceptions::{self, PyTypeError, PyValueError};
-    use crate::types::any::PyAnyMethods;
     use crate::{PyErr, PyNativeType, PyTypeInfo, Python};
 
     #[test]

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -242,7 +242,8 @@ impl PyErr {
         } else {
             // Assume obj is Type[Exception]; let later normalization handle if this
             // is not the case
-            PyErrState::lazy_bound(obj.clone(), obj.py().None())
+            let none = obj.py().None();
+            PyErrState::lazy_bound(obj, none)
         };
 
         PyErr::from_state(state)

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -829,13 +829,9 @@ impl PyErr {
     /// Return the cause (either an exception instance, or None, set by `raise ... from ...`)
     /// associated with the exception, as accessible from Python through `__cause__`.
     pub fn cause(&self, py: Python<'_>) -> Option<PyErr> {
-        let obj = unsafe {
-            Bound::from_owned_ptr_or_opt(
-                py,
-                ffi::PyException_GetCause(self.value_bound(py).as_ptr()),
-            )
-        };
-        obj.map(|inner| Self::from_value_bound(inner))
+        use crate::ffi_ptr_ext::FfiPtrExt;
+        unsafe { ffi::PyException_GetCause(self.value_bound(py).as_ptr()).assume_owned_or_opt(py) }
+            .map(Self::from_value_bound)
     }
 
     /// Set the cause associated with the exception, pass `None` to clear it.

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -187,7 +187,7 @@ impl PyErr {
     where
         A: PyErrArguments + Send + Sync + 'static,
     {
-        PyErr::from_state(PyErrState::lazy(ty, args))
+        PyErr::from_state(PyErrState::lazy(ty.into(), args))
     }
 
     /// Deprecated form of [`PyErr::from_value_bound`].
@@ -241,8 +241,8 @@ impl PyErr {
         } else {
             // Assume obj is Type[Exception]; let later normalization handle if this
             // is not the case
-            let none = obj.py().None();
-            PyErrState::lazy_bound(obj, none)
+            let py = obj.py();
+            PyErrState::lazy(obj.into_py(py), py.None())
         };
 
         PyErr::from_state(state)

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -828,11 +828,12 @@ impl PyErr {
     /// associated with the exception, as accessible from Python through `__cause__`.
     pub fn cause(&self, py: Python<'_>) -> Option<PyErr> {
         let obj = unsafe {
-            py.from_owned_ptr_or_opt::<PyAny>(ffi::PyException_GetCause(
-                self.value_bound(py).as_ptr(),
-            ))
+            Bound::from_owned_ptr_or_opt(
+                py,
+                ffi::PyException_GetCause(self.value_bound(py).as_ptr()),
+            )
         };
-        obj.map(|inner| Self::from_value_bound(&inner.as_borrowed()))
+        obj.map(|inner| Self::from_value_bound(&inner))
     }
 
     /// Set the cause associated with the exception, pass `None` to clear it.

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -286,7 +286,7 @@ impl PyErr {
         )
     )]
     pub fn value<'py>(&'py self, py: Python<'py>) -> &'py PyBaseException {
-        self.value_bound(py).clone().into_gil_ref()
+        self.value_bound(py).as_gil_ref()
     }
 
     /// Returns the value of this exception.

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -220,15 +220,15 @@ impl PyErr {
     /// Python::with_gil(|py| {
     ///     // Case #1: Exception object
     ///     let err = PyErr::from_value_bound(&PyTypeError::new_err("some type error")
-    ///         .value_bound(py).as_borrowed());
+    ///         .value_bound(py));
     ///     assert_eq!(err.to_string(), "TypeError: some type error");
     ///
     ///     // Case #2: Exception type
-    ///     let err = PyErr::from_value_bound(&PyTypeError::type_object_bound(py).as_borrowed());
+    ///     let err = PyErr::from_value_bound(&PyTypeError::type_object_bound(py));
     ///     assert_eq!(err.to_string(), "TypeError: ");
     ///
     ///     // Case #3: Invalid exception value
-    ///     let err = PyErr::from_value_bound(&PyString::new_bound(py, "foo").as_borrowed());
+    ///     let err = PyErr::from_value_bound(&PyString::new_bound(py, "foo"));
     ///     assert_eq!(
     ///         err.to_string(),
     ///         "TypeError: exceptions must derive from BaseException"

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -199,8 +199,7 @@ impl PyErr {
         )
     )]
     pub fn from_value(obj: &PyAny) -> PyErr {
-        let py = obj.py();
-        PyErr::from_value_bound(obj.into_py(py).into_bound(py))
+        PyErr::from_value_bound(obj.as_borrowed().to_owned())
     }
 
     /// Creates a new PyErr.

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -900,7 +900,7 @@ impl std::fmt::Debug for PyErr {
         Python::with_gil(|py| {
             f.debug_struct("PyErr")
                 .field("type", &self.get_type_bound(py))
-                .field("value", &self.value_bound(py))
+                .field("value", self.value_bound(py))
                 .field("traceback", &self.traceback_bound(py))
                 .finish()
         })

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -9,7 +9,6 @@
 //! yourself to import Python classes that are ultimately derived from
 //! `BaseException`.
 
-use crate::types::any::PyAnyMethods;
 use crate::{ffi, Bound, PyResult, Python};
 use std::ffi::CStr;
 use std::ops;
@@ -641,20 +640,20 @@ impl PyUnicodeDecodeError {
         range: ops::Range<usize>,
         reason: &CStr,
     ) -> PyResult<Bound<'p, PyUnicodeDecodeError>> {
-        let bound = unsafe {
-            Bound::from_owned_ptr_or_err(
-                py,
-                ffi::PyUnicodeDecodeError_Create(
-                    encoding.as_ptr(),
-                    input.as_ptr() as *const c_char,
-                    input.len() as ffi::Py_ssize_t,
-                    range.start as ffi::Py_ssize_t,
-                    range.end as ffi::Py_ssize_t,
-                    reason.as_ptr(),
-                ),
+        use crate::ffi_ptr_ext::FfiPtrExt;
+        use crate::py_result_ext::PyResultExt;
+        unsafe {
+            ffi::PyUnicodeDecodeError_Create(
+                encoding.as_ptr(),
+                input.as_ptr() as *const c_char,
+                input.len() as ffi::Py_ssize_t,
+                range.start as ffi::Py_ssize_t,
+                range.end as ffi::Py_ssize_t,
+                reason.as_ptr(),
             )
-        };
-        Ok(bound?.downcast_into()?)
+            .assume_owned_or_err(py)
+        }
+        .downcast_into()
     }
 
     /// Deprecated form of [`PyUnicodeDecodeError::new_utf8_bound`].

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -23,8 +23,8 @@ macro_rules! impl_exception_boilerplate {
         impl ::std::convert::From<&$name> for $crate::PyErr {
             #[inline]
             fn from(err: &$name) -> $crate::PyErr {
-                use $crate::PyNativeType;
-                $crate::PyErr::from_value_bound(&err.as_borrowed())
+                #[allow(deprecated)]
+                $crate::PyErr::from_value(err)
             }
         }
 
@@ -1072,7 +1072,7 @@ mod tests {
             );
 
             // Restoring should preserve the same error
-            let e = PyErr::from_value_bound(&decode_err);
+            let e = PyErr::from_value_bound(decode_err.into_any());
             e.restore(py);
 
             assert_eq!(
@@ -1124,7 +1124,7 @@ mod tests {
         PyErr::from_value_bound(
             PyUnicodeDecodeError::new_utf8_bound(py, invalid_utf8, err)
                 .unwrap()
-                .as_any(),
+                .into_any(),
         )
     });
     test_exception!(PyUnicodeEncodeError, |py| py

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -22,7 +22,8 @@ macro_rules! impl_exception_boilerplate {
         impl ::std::convert::From<&$name> for $crate::PyErr {
             #[inline]
             fn from(err: &$name) -> $crate::PyErr {
-                $crate::PyErr::from_value(err)
+                use $crate::PyNativeType;
+                $crate::PyErr::from_value_bound(&err.as_borrowed())
             }
         }
 
@@ -1081,7 +1082,11 @@ mod tests {
         let invalid_utf8 = b"fo\xd8o";
         #[cfg_attr(invalid_from_utf8_lint, allow(invalid_from_utf8))]
         let err = std::str::from_utf8(invalid_utf8).expect_err("should be invalid utf8");
-        PyErr::from_value(PyUnicodeDecodeError::new_utf8(py, invalid_utf8, err).unwrap())
+        PyErr::from_value_bound(
+            &PyUnicodeDecodeError::new_utf8(py, invalid_utf8, err)
+                .unwrap()
+                .as_borrowed(),
+        )
     });
     test_exception!(PyUnicodeEncodeError, |py| py
         .eval_bound("chr(40960).encode('ascii')", None, None)

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -745,7 +745,7 @@ macro_rules! test_exception {
 
                 assert!(err.is_instance_of::<$exc_ty>(py));
 
-                let value: &$exc_ty = err.value_bound(py).into_gil_ref().downcast().unwrap();
+                let value: &$exc_ty = err.value_bound(py).clone().into_gil_ref().downcast().unwrap();
                 assert!(value.source().is_none());
 
                 err.set_cause(py, Some($crate::exceptions::PyValueError::new_err("a cause")));

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -745,7 +745,7 @@ macro_rules! test_exception {
 
                 assert!(err.is_instance_of::<$exc_ty>(py));
 
-                let value: &$exc_ty = err.value(py).downcast().unwrap();
+                let value: &$exc_ty = err.value_bound(py).into_gil_ref().downcast().unwrap();
                 assert!(value.source().is_none());
 
                 err.set_cause(py, Some($crate::exceptions::PyValueError::new_err("a cause")));

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -167,8 +167,11 @@ pub fn from_py_with_with_default<'a, 'py, T>(
 pub fn argument_extraction_error(py: Python<'_>, arg_name: &str, error: PyErr) -> PyErr {
     use crate::types::any::PyAnyMethods;
     if error.get_type_bound(py).is(py.get_type::<PyTypeError>()) {
-        let remapped_error =
-            PyTypeError::new_err(format!("argument '{}': {}", arg_name, error.value(py)));
+        let remapped_error = PyTypeError::new_err(format!(
+            "argument '{}': {}",
+            arg_name,
+            error.value_bound(py)
+        ));
         remapped_error.set_cause(py, error.cause(py));
         remapped_error
     } else {

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -74,7 +74,7 @@ mod inner {
     #[pymethods(crate = "pyo3")]
     impl UnraisableCapture {
         pub fn hook(&mut self, unraisable: Bound<'_, PyAny>) {
-            let err = PyErr::from_value_bound(&unraisable.getattr("exc_value").unwrap());
+            let err = PyErr::from_value_bound(unraisable.getattr("exc_value").unwrap());
             let instance = unraisable.getattr("object").unwrap();
             self.capture = Some((err, instance.into()));
         }

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -73,9 +73,8 @@ mod inner {
     #[cfg(all(feature = "macros", Py_3_8))]
     #[pymethods(crate = "pyo3")]
     impl UnraisableCapture {
-        pub fn hook(&mut self, unraisable: &PyAny) {
-            let err =
-                PyErr::from_value_bound(&unraisable.getattr("exc_value").unwrap().as_borrowed());
+        pub fn hook(&mut self, unraisable: Bound<'_, PyAny>) {
+            let err = PyErr::from_value_bound(&unraisable.getattr("exc_value").unwrap());
             let instance = unraisable.getattr("object").unwrap();
             self.capture = Some((err, instance.into()));
         }

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -74,7 +74,8 @@ mod inner {
     #[pymethods(crate = "pyo3")]
     impl UnraisableCapture {
         pub fn hook(&mut self, unraisable: &PyAny) {
-            let err = PyErr::from_value(unraisable.getattr("exc_value").unwrap());
+            let err =
+                PyErr::from_value_bound(&unraisable.getattr("exc_value").unwrap().as_borrowed());
             let instance = unraisable.getattr("object").unwrap();
             self.capture = Some((err, instance.into()));
         }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -74,7 +74,7 @@ impl<'a> PyStringData<'a> {
             Self::Ucs1(data) => match str::from_utf8(data) {
                 Ok(s) => Ok(Cow::Borrowed(s)),
                 Err(e) => Err(crate::PyErr::from_value_bound(
-                    &PyUnicodeDecodeError::new_utf8(py, data, e)?.as_borrowed(),
+                    PyUnicodeDecodeError::new_utf8_bound(py, data, e)?.as_any(),
                 )),
             },
             Self::Ucs2(data) => match String::from_utf16(data) {
@@ -84,28 +84,28 @@ impl<'a> PyStringData<'a> {
                     message.push(0);
 
                     Err(crate::PyErr::from_value_bound(
-                        &PyUnicodeDecodeError::new(
+                        PyUnicodeDecodeError::new_bound(
                             py,
                             CStr::from_bytes_with_nul(b"utf-16\0").unwrap(),
                             self.as_bytes(),
                             0..self.as_bytes().len(),
                             CStr::from_bytes_with_nul(&message).unwrap(),
                         )?
-                        .as_borrowed(),
+                        .as_any(),
                     ))
                 }
             },
             Self::Ucs4(data) => match data.iter().map(|&c| std::char::from_u32(c)).collect() {
                 Some(s) => Ok(Cow::Owned(s)),
                 None => Err(crate::PyErr::from_value_bound(
-                    &PyUnicodeDecodeError::new(
+                    PyUnicodeDecodeError::new_bound(
                         py,
                         CStr::from_bytes_with_nul(b"utf-32\0").unwrap(),
                         self.as_bytes(),
                         0..self.as_bytes().len(),
                         CStr::from_bytes_with_nul(b"error converting utf-32\0").unwrap(),
                     )?
-                    .as_borrowed(),
+                    .as_any(),
                 )),
             },
         }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -74,7 +74,7 @@ impl<'a> PyStringData<'a> {
             Self::Ucs1(data) => match str::from_utf8(data) {
                 Ok(s) => Ok(Cow::Borrowed(s)),
                 Err(e) => Err(crate::PyErr::from_value_bound(
-                    PyUnicodeDecodeError::new_utf8_bound(py, data, e)?.as_any(),
+                    PyUnicodeDecodeError::new_utf8_bound(py, data, e)?.into_any(),
                 )),
             },
             Self::Ucs2(data) => match String::from_utf16(data) {
@@ -91,7 +91,7 @@ impl<'a> PyStringData<'a> {
                             0..self.as_bytes().len(),
                             CStr::from_bytes_with_nul(&message).unwrap(),
                         )?
-                        .as_any(),
+                        .into_any(),
                     ))
                 }
             },
@@ -105,7 +105,7 @@ impl<'a> PyStringData<'a> {
                         0..self.as_bytes().len(),
                         CStr::from_bytes_with_nul(b"error converting utf-32\0").unwrap(),
                     )?
-                    .as_any(),
+                    .into_any(),
                 )),
             },
         }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -73,9 +73,9 @@ impl<'a> PyStringData<'a> {
         match self {
             Self::Ucs1(data) => match str::from_utf8(data) {
                 Ok(s) => Ok(Cow::Borrowed(s)),
-                Err(e) => Err(crate::PyErr::from_value(PyUnicodeDecodeError::new_utf8(
-                    py, data, e,
-                )?)),
+                Err(e) => Err(crate::PyErr::from_value_bound(
+                    &PyUnicodeDecodeError::new_utf8(py, data, e)?.as_borrowed(),
+                )),
             },
             Self::Ucs2(data) => match String::from_utf16(data) {
                 Ok(s) => Ok(Cow::Owned(s)),
@@ -83,24 +83,30 @@ impl<'a> PyStringData<'a> {
                     let mut message = e.to_string().as_bytes().to_vec();
                     message.push(0);
 
-                    Err(crate::PyErr::from_value(PyUnicodeDecodeError::new(
-                        py,
-                        CStr::from_bytes_with_nul(b"utf-16\0").unwrap(),
-                        self.as_bytes(),
-                        0..self.as_bytes().len(),
-                        CStr::from_bytes_with_nul(&message).unwrap(),
-                    )?))
+                    Err(crate::PyErr::from_value_bound(
+                        &PyUnicodeDecodeError::new(
+                            py,
+                            CStr::from_bytes_with_nul(b"utf-16\0").unwrap(),
+                            self.as_bytes(),
+                            0..self.as_bytes().len(),
+                            CStr::from_bytes_with_nul(&message).unwrap(),
+                        )?
+                        .as_borrowed(),
+                    ))
                 }
             },
             Self::Ucs4(data) => match data.iter().map(|&c| std::char::from_u32(c)).collect() {
                 Some(s) => Ok(Cow::Owned(s)),
-                None => Err(crate::PyErr::from_value(PyUnicodeDecodeError::new(
-                    py,
-                    CStr::from_bytes_with_nul(b"utf-32\0").unwrap(),
-                    self.as_bytes(),
-                    0..self.as_bytes().len(),
-                    CStr::from_bytes_with_nul(b"error converting utf-32\0").unwrap(),
-                )?)),
+                None => Err(crate::PyErr::from_value_bound(
+                    &PyUnicodeDecodeError::new(
+                        py,
+                        CStr::from_bytes_with_nul(b"utf-32\0").unwrap(),
+                        self.as_bytes(),
+                        0..self.as_bytes().len(),
+                        CStr::from_bytes_with_nul(b"error converting utf-32\0").unwrap(),
+                    )?
+                    .as_borrowed(),
+                )),
             },
         }
     }

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -150,7 +150,7 @@ except Exception as e:
                 Some(&locals),
             )
             .unwrap();
-            let err = PyErr::from_value_bound(&locals.get_item("err").unwrap().unwrap());
+            let err = PyErr::from_value_bound(locals.get_item("err").unwrap().unwrap());
             let traceback = err.value_bound(py).getattr("__traceback__").unwrap();
             assert!(err.traceback_bound(py).unwrap().is(&traceback));
         })

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -150,7 +150,7 @@ except Exception as e:
                 Some(&locals),
             )
             .unwrap();
-            let err = PyErr::from_value(locals.get_item("err").unwrap().unwrap().into_gil_ref());
+            let err = PyErr::from_value_bound(&locals.get_item("err").unwrap().unwrap());
             let traceback = err.value_bound(py).getattr("__traceback__").unwrap();
             assert!(err.traceback_bound(py).unwrap().is(&traceback));
         })

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -151,8 +151,8 @@ except Exception as e:
             )
             .unwrap();
             let err = PyErr::from_value(locals.get_item("err").unwrap().unwrap().into_gil_ref());
-            let traceback = err.value(py).getattr("__traceback__").unwrap();
-            assert!(err.traceback_bound(py).unwrap().is(traceback));
+            let traceback = err.value_bound(py).getattr("__traceback__").unwrap();
+            assert!(err.traceback_bound(py).unwrap().is(&traceback));
         })
     }
 

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -137,7 +137,7 @@ fn cancelled_coroutine() {
             )
             .unwrap_err();
         assert_eq!(
-            err.value(gil).get_type().qualname().unwrap(),
+            err.value_bound(gil).get_type().qualname().unwrap(),
             "CancelledError"
         );
     })


### PR DESCRIPTION
Implements more of the `Bound` api from #3684.

Follows on from #3819.