### PR TITLE
add maximum Python version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,18 @@ jobs:
           echo PYO3_CONFIG_FILE=$PYO3_CONFIG_FILE >> $GITHUB_ENV
       - run: python3 -m nox -s test
 
+  test-version-limits:
+    needs: [fmt]
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+      - uses: dtolnay/rust-toolchain@stable
+      - run: python3 -m pip install --upgrade pip && pip install nox
+      - run: python3 -m nox -s test-version-limits
+
   conclusion:
     needs:
       - fmt
@@ -480,6 +492,8 @@ jobs:
       - docsrs
       - coverage
       - emscripten
+      - test-debug
+      - test-version-limits
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ multiple-pymethods = ["inventory", "pyo3-macros/multiple-pymethods"]
 extension-module = ["pyo3-ffi/extension-module"]
 
 # Use the Python limited API. See https://www.python.org/dev/peps/pep-0384/ for more.
-abi3 = ["pyo3-build-config/abi3", "pyo3-ffi/abi3", "pyo3-macros/abi3"]
+abi3 = ["pyo3-build-config/abi3", "pyo3-ffi/abi3"]
 
 # With abi3, we can manually set the minimum Python version.
 abi3-py37 = ["abi3-py38", "pyo3-build-config/abi3-py37", "pyo3-ffi/abi3-py37"]

--- a/newsfragments/3821.packaging.md
+++ b/newsfragments/3821.packaging.md
@@ -1,0 +1,1 @@
+Check maximum version of Python at build time and for versions not yet supported require opt-in to the `abi3` stable ABI by the environment variable `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`.

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -701,6 +701,7 @@ fn have_python_interpreter() -> bool {
 /// Must be called from a PyO3 crate build script.
 fn is_abi3() -> bool {
     cargo_env_var("CARGO_FEATURE_ABI3").is_some()
+        || env_var("PYO3_USE_ABI3_FORWARD_COMPATIBILITY").map_or(false, |os_str| os_str == "1")
 }
 
 /// Gets the minimum supported Python version from PyO3 `abi3-py*` features.

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -4,18 +4,76 @@ use pyo3_build_config::{
         cargo_env_var, env_var, errors::Result, is_linking_libpython, resolve_interpreter_config,
         InterpreterConfig, PythonVersion,
     },
+    PythonImplementation,
 };
 
 /// Minimum Python version PyO3 supports.
-const MINIMUM_SUPPORTED_VERSION: PythonVersion = PythonVersion { major: 3, minor: 7 };
+struct SupportedVersions {
+    min: PythonVersion,
+    max: PythonVersion,
+}
+
+const SUPPORTED_VERSIONS_CPYTHON: SupportedVersions = SupportedVersions {
+    min: PythonVersion { major: 3, minor: 7 },
+    max: PythonVersion {
+        major: 3,
+        minor: 12,
+    },
+};
+
+const SUPPORTED_VERSIONS_PYPY: SupportedVersions = SupportedVersions {
+    min: PythonVersion { major: 3, minor: 7 },
+    max: PythonVersion {
+        major: 3,
+        minor: 10,
+    },
+};
 
 fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
-    ensure!(
-        interpreter_config.version >= MINIMUM_SUPPORTED_VERSION,
-        "the configured Python interpreter version ({}) is lower than PyO3's minimum supported version ({})",
-        interpreter_config.version,
-        MINIMUM_SUPPORTED_VERSION,
-    );
+    // This is an undocumented env var which is only really intended to be used in CI / for testing
+    // and development.
+    if std::env::var("UNSAFE_PYO3_SKIP_VERSION_CHECK").as_deref() == Ok("1") {
+        return Ok(());
+    }
+
+    match interpreter_config.implementation {
+        PythonImplementation::CPython => {
+            let versions = SUPPORTED_VERSIONS_CPYTHON;
+            ensure!(
+                interpreter_config.version >= versions.min,
+                "the configured Python interpreter version ({}) is lower than PyO3's minimum supported version ({})",
+                interpreter_config.version,
+                versions.min,
+            );
+            ensure!(
+                interpreter_config.version <= versions.max || env_var("PYO3_USE_ABI3_FORWARD_COMPATIBILITY").map_or(false, |os_str| os_str == "1"),
+                "the configured Python interpreter version ({}) is newer than PyO3's maximum supported version ({})\n\
+                 = help: please check if an updated version of PyO3 is available. Current version: {}\n\
+                 = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI",
+                interpreter_config.version,
+                versions.max,
+                std::env::var("CARGO_PKG_VERSION").unwrap(),
+            );
+        }
+        PythonImplementation::PyPy => {
+            let versions = SUPPORTED_VERSIONS_PYPY;
+            ensure!(
+                interpreter_config.version >= versions.min,
+                "the configured PyPy interpreter version ({}) is lower than PyO3's minimum supported version ({})",
+                interpreter_config.version,
+                versions.min,
+            );
+            // PyO3 does not support abi3, so we cannot offer forward compatibility
+            ensure!(
+                interpreter_config.version <= versions.max,
+                "the configured PyPy interpreter version ({}) is newer than PyO3's maximum supported version ({})\n\
+                 = help: please check if an updated version of PyO3 is available. Current version: {}",
+                interpreter_config.version,
+                versions.max,
+                std::env::var("CARGO_PKG_VERSION").unwrap()
+            );
+        }
+    }
 
     Ok(())
 }

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -14,17 +14,15 @@ edition = "2021"
 # not to depend on proc-macro itself.
 # See https://github.com/PyO3/pyo3/pull/810 for more.
 [dependencies]
-quote = { version = "1", default-features = false }
-proc-macro2 = { version = "1", default-features = false }
 heck = "0.4"
+proc-macro2 = { version = "1", default-features = false }
+pyo3-build-config = { path = "../pyo3-build-config", version = "0.21.0-dev", features = ["resolve-config"] }
+quote = { version = "1", default-features = false }
 
 [dependencies.syn]
 version = "2"
 default-features = false
 features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits"]
-
-[features]
-abi3 = []
 
 [lints]
 workspace = true

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -12,7 +12,7 @@ use crate::{
         FunctionSignature, PyFunctionArgPyO3Attributes, PyFunctionOptions, SignatureAttribute,
     },
     quotes,
-    utils::{self, PythonDoc},
+    utils::{self, is_abi3, PythonDoc},
 };
 
 #[derive(Clone, Debug)]
@@ -234,8 +234,8 @@ impl CallingConvention {
         } else if signature.python_signature.kwargs.is_some() {
             // for functions that accept **kwargs, always prefer varargs
             Self::Varargs
-        } else if cfg!(not(feature = "abi3")) {
-            // Not available in the Stable ABI as of Python 3.10
+        } else if !is_abi3() {
+            // FIXME: available in the stable ABI since 3.10
             Self::Fastcall
         } else {
             Self::Varargs

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -166,3 +166,9 @@ pub fn apply_renaming_rule(rule: RenamingRule, name: &str) -> String {
         RenamingRule::Uppercase => name.to_uppercase(),
     }
 }
+
+pub(crate) fn is_abi3() -> bool {
+    cfg!(feature = "abi3")
+        || std::env::var_os("PYO3_USE_ABI3_FORWARD_COMPATIBILITY")
+            .map_or(false, |os_str| os_str == "1")
+}

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -168,7 +168,5 @@ pub fn apply_renaming_rule(rule: RenamingRule, name: &str) -> String {
 }
 
 pub(crate) fn is_abi3() -> bool {
-    cfg!(feature = "abi3")
-        || std::env::var_os("PYO3_USE_ABI3_FORWARD_COMPATIBILITY")
-            .map_or(false, |os_str| os_str == "1")
+    pyo3_build_config::get().abi3
 }

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -16,8 +16,6 @@ proc-macro = true
 [features]
 multiple-pymethods = []
 
-abi3 = ["pyo3-macros-backend/abi3"]
-
 [dependencies]
 proc-macro2 = { version = "1", default-features = false }
 quote = "1"


### PR DESCRIPTION
Closes #3555 

This PR seeks to protect users from compiling PyO3 against Python versions not yet supported, and the undefined behaviour that might result from doing so. There are two groups of people who might do this, and how they are protected is slightly different:

- ***People installing an outdated package from PyPI who end up building from source against too new a Python version.***
  These users will see an error that their Python version is not yet supported by PyO3 and see a hint to use `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` to opt-in to using the stable ABI's for forward compatibility.

  ```
  error: failed to run custom build command for `pyo3-ffi v0.21.0-dev (/Users/david/Dev/pyo3/pyo3-ffi)`

  Caused by:
    process didn't exit successfully: `/Users/david/Dev/pyo3/target/debug/build/pyo3-ffi-e3e7d0d040c4f908/build-script-build` (exit status: 1)
    --- stdout
    cargo:rerun-if-env-changed=PYO3_PRINT_CONFIG
    cargo:rerun-if-env-changed=PYO3_USE_ABI3_FORWARD_COMPATIBILITY

    --- stderr
    error: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)
    = help: please check if an updated version of PyO3 is available. Current version: 0.21.0-dev
    = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI
  ```

  By setting the environment variable, we will build as if the `abi3` feature was enabled.
  
- ***People testing an in-development Python version and/or PyO3 and willing to accept the risks of broken stuff.***
  These users can turn off the check with `UNSAFE_PYO3_SKIP_VERSION_CHECK=1`.

Some worthwhile points of discussion:
 - Do we need to bother checking this works in CI? I felt it didn't hurt, but I can revert the CI changes if needed.
 - Should we document `UNSAFE_PYO3_SKIP_VERSION_CHECK`? I decided to punt on that for now.