### PR TITLE
docs: Add lcov / codecov options for nox coverage and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ pip-wheel-metadata
 valgrind-python.supp
 *.pyd
 lcov.info
+coverage.json
 netlify_build/
 .nox/

--- a/Contributing.md
+++ b/Contributing.md
@@ -177,7 +177,11 @@ Second, there is a Python-based benchmark contained in the `pytests` subdirector
 
 You can view what code is and isn't covered by PyO3's tests. We aim to have 100% coverage - please check coverage and add tests if you notice a lack of coverage!
 
-- First, generate a `lcov.info` file with
+- First, ensure the llmv-cov cargo plugin is installed
+```shell
+cargo install cargo-llvm-cov
+```
+- Then, generate a `lcov.info` file with
 ```shell
 nox -s coverage
 ```

--- a/Contributing.md
+++ b/Contributing.md
@@ -177,9 +177,10 @@ Second, there is a Python-based benchmark contained in the `pytests` subdirector
 
 You can view what code is and isn't covered by PyO3's tests. We aim to have 100% coverage - please check coverage and add tests if you notice a lack of coverage!
 
-- First, ensure the llmv-cov cargo plugin is installed
+- First, ensure the llmv-cov cargo plugin is installed. You may need to run the plugin once before using it with `nox`.
 ```shell
 cargo install cargo-llvm-cov
+cargo llvm-cov
 ```
 - Then, generate a `lcov.info` file with
 ```shell

--- a/Contributing.md
+++ b/Contributing.md
@@ -177,7 +177,7 @@ Second, there is a Python-based benchmark contained in the `pytests` subdirector
 
 You can view what code is and isn't covered by PyO3's tests. We aim to have 100% coverage - please check coverage and add tests if you notice a lack of coverage!
 
-- First, ensure the llmv-cov cargo plugin is installed. You may need to run the plugin once before using it with `nox`.
+- First, ensure the llmv-cov cargo plugin is installed. You may need to run the plugin through cargo once before using it with `nox`.
 ```shell
 cargo install cargo-llvm-cov
 cargo llvm-cov

--- a/Contributing.md
+++ b/Contributing.md
@@ -182,9 +182,9 @@ You can view what code is and isn't covered by PyO3's tests. We aim to have 100%
 cargo install cargo-llvm-cov
 cargo llvm-cov
 ```
-- Then, generate a `lcov.info` file with
+- Then, generate an `lcov.info` file with
 ```shell
-nox -s coverage
+nox -s coverage -- lcov
 ```
 You can install an IDE plugin to view the coverage. For example, if you use VSCode:
 - Add the [coverage-gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) plugin.

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,7 +58,7 @@ def coverage(session: nox.Session) -> None:
     output_file = "coverage.json"
 
     if "lcov" in session.posargs:
-        cov_format = "posargs"
+        cov_format = "lcov"
         output_file = "lcov.info"
 
     _run_cargo(

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,6 +53,14 @@ def coverage(session: nox.Session) -> None:
     session.env.update(_get_coverage_env())
     _run_cargo(session, "llvm-cov", "clean", "--workspace")
     test(session)
+
+    cov_format = "codecov"
+    output_file = "coverage.json"
+
+    if "lcov" in session.posargs:
+        cov_format = "posargs"
+        output_file = "lcov.info"
+
     _run_cargo(
         session,
         "llvm-cov",
@@ -62,9 +70,9 @@ def coverage(session: nox.Session) -> None:
         "--package=pyo3-macros",
         "--package=pyo3-ffi",
         "report",
-        "--codecov",
+        f"--{cov_format}",
         "--output-path",
-        "coverage.json",
+        output_file,
     )
 
 


### PR DESCRIPTION
The `llvm-cov` plugin needs to be installed as a cargo plugin (and at least on my system, had to run it manually once to respond to a user input prompt) before it works with nox.

`nox -s coverage` produces a `coverage.json` file and not `lcov.info` as of #3097, so also added an `lcov` option so `nox -s coverage -- lcov` returns the original format.