### PR TITLE
update `#[derive(FromPyObject)]` to use `extract_bound`

### DIFF
--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -298,12 +298,12 @@ impl<'a> Container<'a> {
         let fields = struct_fields.iter().zip(&field_idents).enumerate().map(|(index, (field, ident))| {
             match &field.from_py_with {
                 None => quote!(
-                    _pyo3::impl_::frompyobject::extract_tuple_struct_field(#ident, #struct_name, #index)?
+                    _pyo3::impl_::frompyobject::extract_tuple_struct_field(&#ident, #struct_name, #index)?
                 ),
                 Some(FromPyWithAttribute {
                     value: expr_path, ..
                 }) => quote! (
-                    _pyo3::impl_::frompyobject::extract_tuple_struct_field_with(#expr_path, #ident, #struct_name, #index)?
+                    _pyo3::impl_::frompyobject::extract_tuple_struct_field_with(#expr_path, &#ident, #struct_name, #index)?
                 ),
             }
         });
@@ -339,12 +339,12 @@ impl<'a> Container<'a> {
             };
             let extractor = match &field.from_py_with {
                 None => {
-                    quote!(_pyo3::impl_::frompyobject::extract_struct_field(obj.#getter?, #struct_name, #field_name)?)
+                    quote!(_pyo3::impl_::frompyobject::extract_struct_field(&obj.#getter?, #struct_name, #field_name)?)
                 }
                 Some(FromPyWithAttribute {
                     value: expr_path, ..
                 }) => {
-                    quote! (_pyo3::impl_::frompyobject::extract_struct_field_with(#expr_path, obj.#getter?, #struct_name, #field_name)?)
+                    quote! (_pyo3::impl_::frompyobject::extract_struct_field_with(#expr_path, &obj.#getter?, #struct_name, #field_name)?)
                 }
             };
 
@@ -606,10 +606,11 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
     Ok(quote!(
         const _: () = {
             use #krate as _pyo3;
+            use _pyo3::prelude::PyAnyMethods;
 
             #[automatically_derived]
             impl #trait_generics _pyo3::FromPyObject<#lt_param> for #ident #generics #where_clause {
-                fn extract(obj: &#lt_param _pyo3::PyAny) -> _pyo3::PyResult<Self>  {
+                fn extract_bound(obj: &_pyo3::Bound<#lt_param, _pyo3::PyAny>) -> _pyo3::PyResult<Self>  {
                     #derives
                 }
             }

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -271,7 +271,7 @@ impl<'a> Container<'a> {
                     value: expr_path, ..
                 }) => quote! {
                     Ok(#self_ty {
-                        #ident: _pyo3::impl_::frompyobject::extract_struct_field_with(#expr_path, obj, #struct_name, #field_name)?
+                        #ident: _pyo3::impl_::frompyobject::extract_struct_field_with(#expr_path as fn(_) -> _, obj, #struct_name, #field_name)?
                     })
                 },
             }
@@ -283,7 +283,7 @@ impl<'a> Container<'a> {
                 Some(FromPyWithAttribute {
                     value: expr_path, ..
                 }) => quote! (
-                    _pyo3::impl_::frompyobject::extract_tuple_struct_field_with(#expr_path, obj, #struct_name, 0).map(#self_ty)
+                    _pyo3::impl_::frompyobject::extract_tuple_struct_field_with(#expr_path as fn(_) -> _, obj, #struct_name, 0).map(#self_ty)
                 ),
             }
         }
@@ -303,7 +303,7 @@ impl<'a> Container<'a> {
                 Some(FromPyWithAttribute {
                     value: expr_path, ..
                 }) => quote! (
-                    _pyo3::impl_::frompyobject::extract_tuple_struct_field_with(#expr_path, &#ident, #struct_name, #index)?
+                    _pyo3::impl_::frompyobject::extract_tuple_struct_field_with(#expr_path as fn(_) -> _, &#ident, #struct_name, #index)?
                 ),
             }
         });
@@ -344,7 +344,7 @@ impl<'a> Container<'a> {
                 Some(FromPyWithAttribute {
                     value: expr_path, ..
                 }) => {
-                    quote! (_pyo3::impl_::frompyobject::extract_struct_field_with(#expr_path, &obj.#getter?, #struct_name, #field_name)?)
+                    quote! (_pyo3::impl_::frompyobject::extract_struct_field_with(#expr_path as fn(_) -> _, &obj.#getter?, #struct_name, #field_name)?)
                 }
             };
 

--- a/src/impl_/frompyobject.rs
+++ b/src/impl_/frompyobject.rs
@@ -2,6 +2,32 @@ use crate::types::any::PyAnyMethods;
 use crate::Bound;
 use crate::{exceptions::PyTypeError, FromPyObject, PyAny, PyErr, PyResult, Python};
 
+pub enum Extractor<'a, 'py, T> {
+    Bound(fn(&'a Bound<'py, PyAny>) -> PyResult<T>),
+    GilRef(fn(&'a PyAny) -> PyResult<T>),
+}
+
+impl<'a, 'py, T> From<fn(&'a Bound<'py, PyAny>) -> PyResult<T>> for Extractor<'a, 'py, T> {
+    fn from(value: fn(&'a Bound<'py, PyAny>) -> PyResult<T>) -> Self {
+        Self::Bound(value)
+    }
+}
+
+impl<'a, T> From<fn(&'a PyAny) -> PyResult<T>> for Extractor<'a, '_, T> {
+    fn from(value: fn(&'a PyAny) -> PyResult<T>) -> Self {
+        Self::GilRef(value)
+    }
+}
+
+impl<'a, 'py, T> Extractor<'a, 'py, T> {
+    fn call(self, obj: &'a Bound<'py, PyAny>) -> PyResult<T> {
+        match self {
+            Extractor::Bound(f) => f(obj),
+            Extractor::GilRef(f) => f(obj.as_gil_ref()),
+        }
+    }
+}
+
 #[cold]
 pub fn failed_to_extract_enum(
     py: Python<'_>,
@@ -61,13 +87,13 @@ where
     }
 }
 
-pub fn extract_struct_field_with<'py, T>(
-    extractor: impl FnOnce(&Bound<'py, PyAny>) -> PyResult<T>,
-    obj: &Bound<'py, PyAny>,
+pub fn extract_struct_field_with<'a, 'py, T>(
+    extractor: impl Into<Extractor<'a, 'py, T>>,
+    obj: &'a Bound<'py, PyAny>,
     struct_name: &str,
     field_name: &str,
 ) -> PyResult<T> {
-    match extractor(obj) {
+    match extractor.into().call(obj) {
         Ok(value) => Ok(value),
         Err(err) => Err(failed_to_extract_struct_field(
             obj.py(),
@@ -112,13 +138,13 @@ where
     }
 }
 
-pub fn extract_tuple_struct_field_with<'py, T>(
-    extractor: impl FnOnce(&Bound<'py, PyAny>) -> PyResult<T>,
-    obj: &Bound<'py, PyAny>,
+pub fn extract_tuple_struct_field_with<'a, 'py, T>(
+    extractor: impl Into<Extractor<'a, 'py, T>>,
+    obj: &'a Bound<'py, PyAny>,
     struct_name: &str,
     index: usize,
 ) -> PyResult<T> {
-    match extractor(obj) {
+    match extractor.into().call(obj) {
         Ok(value) => Ok(value),
         Err(err) => Err(failed_to_extract_tuple_struct_field(
             obj.py(),

--- a/src/impl_/frompyobject.rs
+++ b/src/impl_/frompyobject.rs
@@ -1,3 +1,5 @@
+use crate::types::any::PyAnyMethods;
+use crate::Bound;
 use crate::{exceptions::PyTypeError, FromPyObject, PyAny, PyErr, PyResult, Python};
 
 #[cold]
@@ -41,7 +43,7 @@ fn extract_traceback(py: Python<'_>, mut error: PyErr) -> String {
 }
 
 pub fn extract_struct_field<'py, T>(
-    obj: &'py PyAny,
+    obj: &Bound<'py, PyAny>,
     struct_name: &str,
     field_name: &str,
 ) -> PyResult<T>
@@ -60,8 +62,8 @@ where
 }
 
 pub fn extract_struct_field_with<'py, T>(
-    extractor: impl FnOnce(&'py PyAny) -> PyResult<T>,
-    obj: &'py PyAny,
+    extractor: impl FnOnce(&Bound<'py, PyAny>) -> PyResult<T>,
+    obj: &Bound<'py, PyAny>,
     struct_name: &str,
     field_name: &str,
 ) -> PyResult<T> {
@@ -92,7 +94,7 @@ fn failed_to_extract_struct_field(
 }
 
 pub fn extract_tuple_struct_field<'py, T>(
-    obj: &'py PyAny,
+    obj: &Bound<'py, PyAny>,
     struct_name: &str,
     index: usize,
 ) -> PyResult<T>
@@ -111,8 +113,8 @@ where
 }
 
 pub fn extract_tuple_struct_field_with<'py, T>(
-    extractor: impl FnOnce(&'py PyAny) -> PyResult<T>,
-    obj: &'py PyAny,
+    extractor: impl FnOnce(&Bound<'py, PyAny>) -> PyResult<T>,
+    obj: &Bound<'py, PyAny>,
     struct_name: &str,
     index: usize,
 ) -> PyResult<T> {

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -502,7 +502,7 @@ pub struct Zap {
     #[pyo3(item)]
     name: String,
 
-    #[pyo3(from_py_with = "PyAny::len", item("my_object"))]
+    #[pyo3(from_py_with = "PyAnyMethods::len", item("my_object"))]
     some_object_length: usize,
 }
 
@@ -525,7 +525,7 @@ fn test_from_py_with() {
 }
 
 #[derive(Debug, FromPyObject)]
-pub struct ZapTuple(String, #[pyo3(from_py_with = "PyAny::len")] usize);
+pub struct ZapTuple(String, #[pyo3(from_py_with = "PyAnyMethods::len")] usize);
 
 #[test]
 fn test_from_py_with_tuple_struct() {
@@ -560,8 +560,8 @@ fn test_from_py_with_tuple_struct_error() {
 
 #[derive(Debug, FromPyObject, PartialEq, Eq)]
 pub enum ZapEnum {
-    Zip(#[pyo3(from_py_with = "PyAny::len")] usize),
-    Zap(String, #[pyo3(from_py_with = "PyAny::len")] usize),
+    Zip(#[pyo3(from_py_with = "PyAnyMethods::len")] usize),
+    Zap(String, #[pyo3(from_py_with = "PyAnyMethods::len")] usize),
 }
 
 #[test]
@@ -581,7 +581,7 @@ fn test_from_py_with_enum() {
 #[derive(Debug, FromPyObject, PartialEq, Eq)]
 #[pyo3(transparent)]
 pub struct TransparentFromPyWith {
-    #[pyo3(from_py_with = "PyAny::len")]
+    #[pyo3(from_py_with = "PyAnyMethods::len")]
     len: usize,
 }
 

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -502,7 +502,7 @@ pub struct Zap {
     #[pyo3(item)]
     name: String,
 
-    #[pyo3(from_py_with = "PyAnyMethods::len", item("my_object"))]
+    #[pyo3(from_py_with = "Bound::<'_, PyAny>::len", item("my_object"))]
     some_object_length: usize,
 }
 
@@ -525,7 +525,10 @@ fn test_from_py_with() {
 }
 
 #[derive(Debug, FromPyObject)]
-pub struct ZapTuple(String, #[pyo3(from_py_with = "PyAnyMethods::len")] usize);
+pub struct ZapTuple(
+    String,
+    #[pyo3(from_py_with = "Bound::<'_, PyAny>::len")] usize,
+);
 
 #[test]
 fn test_from_py_with_tuple_struct() {
@@ -560,8 +563,11 @@ fn test_from_py_with_tuple_struct_error() {
 
 #[derive(Debug, FromPyObject, PartialEq, Eq)]
 pub enum ZapEnum {
-    Zip(#[pyo3(from_py_with = "PyAnyMethods::len")] usize),
-    Zap(String, #[pyo3(from_py_with = "PyAnyMethods::len")] usize),
+    Zip(#[pyo3(from_py_with = "Bound::<'_, PyAny>::len")] usize),
+    Zap(
+        String,
+        #[pyo3(from_py_with = "Bound::<'_, PyAny>::len")] usize,
+    ),
 }
 
 #[test]
@@ -581,7 +587,7 @@ fn test_from_py_with_enum() {
 #[derive(Debug, FromPyObject, PartialEq, Eq)]
 #[pyo3(transparent)]
 pub struct TransparentFromPyWith {
-    #[pyo3(from_py_with = "PyAnyMethods::len")]
+    #[pyo3(from_py_with = "Bound::<'_, PyAny>::len")]
     len: usize,
 }
 


### PR DESCRIPTION
In this PR I've converted the `FromPyObject` proc-macro to output the new `extract_bound` function. Most of this should be completely invisible to downstream, but one place where this leaks out is the `#[pyo3(from_py_with = ...)]` attribute.

So leaving this as is, would be a breaking change. I don't really see a good way of abstracting over two function types with different signatures. 

I can see two options to avoid the breakage:
1. leave the custom extractor on a gil-ref API for now
2. introduce a new `#[pyo3(from_py_with_bound = ...)]` attribute

Probably option 2 is preferable, so that we can provide an upgrade path. But maybe there is another option which I don't see right now... 🙃 
