### PR TITLE
add `DowncastIntoError::into_inner`

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -97,6 +97,14 @@ impl<'py> DowncastIntoError<'py> {
             to: to.into(),
         }
     }
+
+    /// Consumes this `DowncastIntoError` and returns the original object, allowing continued
+    /// use of it after a failed conversion.
+    ///
+    /// See [`downcast_into`][PyAnyMethods::downcast_into] for an example.
+    pub fn into_inner(self) -> Bound<'py, PyAny> {
+        self.from
+    }
 }
 
 impl PyErr {

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1561,6 +1561,27 @@ pub trait PyAnyMethods<'py> {
         T: PyTypeCheck;
 
     /// Like `downcast` but takes ownership of `self`.
+    ///
+    /// In case of an error, it is possible to retrieve `self` again via [`DowncastIntoError::into_inner`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::{PyDict, PyList};
+    ///
+    /// Python::with_gil(|py| {
+    ///     let obj: Bound<'_, PyAny> = PyDict::new_bound(py).into_any();
+    ///
+    ///     let obj: Bound<'_, PyAny> = match obj.downcast_into::<PyList>() {
+    ///         Ok(_) => panic!("obj should not be a list"),
+    ///         Err(err) => err.into_inner(),
+    ///     };
+    ///
+    ///     // obj is a dictionary
+    ///     assert!(obj.downcast_into::<PyDict>().is_ok());
+    /// })
+    /// ```
     fn downcast_into<T>(self) -> Result<Bound<'py, T>, DowncastIntoError<'py>>
     where
         T: PyTypeCheck;


### PR DESCRIPTION
This PR adds `DowncastIntoError::into_inner`, as a way to get the `Bound` value back if the downcast fails.

The name `into_inner` was chosen to match std, which has several examples of this e.g. `std::sync::PosionError`, `std::io::WriterPanicked`.

Should solve the case in https://github.com/PyO3/pyo3/pull/3820#discussion_r1485697412
