### PR TITLE
ci: don't test gevent on pypy

### DIFF
--- a/pytests/pyproject.toml
+++ b/pytests/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "gevent>=22.10.2",
+    "gevent>=22.10.2; implementation_name == 'cpython'",
     "hypothesis>=3.55",
     "pytest-asyncio>=0.21",
     "pytest-benchmark>=3.4",

--- a/pytests/tests/test_misc.py
+++ b/pytests/tests/test_misc.py
@@ -2,7 +2,6 @@ import importlib
 import platform
 import sys
 
-import gevent
 import pyo3_pytests.misc
 import pytest
 
@@ -83,6 +82,8 @@ class ArbitraryClass:
 
 
 def test_gevent():
+    gevent = pytest.importorskip("gevent")
+
     def worker(worker_id: int) -> None:
         for iteration in range(2):
             d = {"key": ArbitraryClass(worker_id, iteration)}


### PR DESCRIPTION
`gevent` doesn't ship PyPy wheels; I noticed we're wasting a fair few CPU cycles building it. I think it's enough to just skip this test on PyPy.