### PR TITLE
Add weakref Python types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ valgrind-python.supp
 lcov.info
 netlify_build/
 .nox/
+.vscode/

--- a/newsfragments/3835.added.md
+++ b/newsfragments/3835.added.md
@@ -1,0 +1,1 @@
+Add `PyWeakRef`, `PyWeakProxy` and `PyWeakCallableProxy`.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -41,3 +41,4 @@ pub use crate::types::set::PySetMethods;
 pub use crate::types::string::PyStringMethods;
 pub use crate::types::traceback::PyTracebackMethods;
 pub use crate::types::tuple::PyTupleMethods;
+pub use crate::types::weakref::PyWeakRefMethods;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -44,7 +44,7 @@ pub use self::string::{PyString, PyString as PyUnicode};
 pub use self::traceback::PyTraceback;
 pub use self::tuple::PyTuple;
 pub use self::typeobject::PyType;
-pub use self::weakref::{PyWeakProxy, PyWeakRef};
+pub use self::weakref::{PyWeakCallableProxy, PyWeakProxy, PyWeakRef};
 
 /// Iteration over Python collections.
 ///

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -44,6 +44,7 @@ pub use self::string::{PyString, PyString as PyUnicode};
 pub use self::traceback::PyTraceback;
 pub use self::tuple::PyTuple;
 pub use self::typeobject::PyType;
+pub use self::weakref::PyWeakRef;
 
 /// Iteration over Python collections.
 ///
@@ -307,3 +308,4 @@ pub(crate) mod string;
 pub(crate) mod traceback;
 pub(crate) mod tuple;
 mod typeobject;
+pub(crate) mod weakref;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -44,7 +44,7 @@ pub use self::string::{PyString, PyString as PyUnicode};
 pub use self::traceback::PyTraceback;
 pub use self::tuple::PyTuple;
 pub use self::typeobject::PyType;
-pub use self::weakref::PyWeakRef;
+pub use self::weakref::{PyWeakProxy, PyWeakRef};
 
 /// Iteration over Python collections.
 ///

--- a/src/types/weakref.rs
+++ b/src/types/weakref.rs
@@ -1,0 +1,365 @@
+use crate::err::PyResult;
+use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::type_object::PyTypeCheck;
+use crate::types::any::PyAnyMethods;
+use crate::{ffi, Borrowed, Bound, PyAny, PyNativeType, Python, ToPyObject};
+
+/// Represents a Python `weakref.ReferenceType`.
+///
+/// In Python this is created by calling `weakref.ref`.
+#[repr(transparent)]
+pub struct PyWeakRef(PyAny);
+
+pyobject_native_type!(
+    PyWeakRef,
+    ffi::PyWeakReference,
+    pyobject_native_static_type_object!(ffi::_PyWeakref_RefType),
+    #module=Some("weakref"),
+    #checkfunction=ffi::PyWeakref_CheckRef
+);
+
+impl PyWeakRef {
+    /// Deprecated form of [`PyWeakRef::new_bound`].
+    #[inline]
+    #[track_caller]
+    #[cfg_attr(
+        not(feature = "gil-refs"),
+        deprecated(
+            since = "0.21.0",
+            note = "`PyWeakRef::new` will be replaced by `PyWeakRef::new_bound` in a future PyO3 version"
+        )
+    )]
+    pub fn new<T>(py: Python<'_>, object: T) -> PyResult<&'_ PyWeakRef>
+    where
+        T: ToPyObject,
+    {
+        Self::new_bound(py, object).map(Bound::into_gil_ref)
+    }
+
+    /// Constructs a new Weak Reference (weakref.ref) for the given object.
+    ///
+    /// Returns a `TypeError` if `object` is not subclassable (Most native types and PyClasses without `weakref` flag).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyWeakRef;
+    ///
+    /// #[pyclass(weakref)]
+    /// struct Foo { /* fields omitted */ }
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let foo = Py::new(py, Foo {})?;
+    ///     let weakref = PyWeakRef::new_bound(py, foo.clone_ref(py))?;
+    ///     assert!(weakref.call0()?.is(&foo));
+    ///     
+    ///     let weakref2 = PyWeakRef::new_bound(py, foo.clone_ref(py))?;
+    ///     assert!(weakref.is(&weakref2));
+    ///
+    ///     drop(foo);
+    ///
+    ///     assert!(weakref.call0()?.is(&py.None()));
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ````
+    #[track_caller]
+    pub fn new_bound<T>(py: Python<'_>, object: T) -> PyResult<Bound<'_, PyWeakRef>>
+    where
+        T: ToPyObject,
+    {
+        unsafe {
+            Bound::from_owned_ptr_or_err(
+                py,
+                ffi::PyWeakref_NewRef(object.to_object(py).as_ptr(), ffi::Py_None()),
+            )
+            .map(|obj| obj.downcast_into_unchecked())
+        }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[cfg_attr(
+        not(feature = "gil-refs"),
+        deprecated(
+            since = "0.21.0",
+            note = "`PyWeakRef::new_with` will be replaced by `PyWeakRef::new_bound_with` in a future PyO3 version"
+        )
+    )]
+    pub fn new_with<'py, T, C>(py: Python<'py>, object: T, callback: C) -> PyResult<&'py PyWeakRef>
+    where
+        T: ToPyObject,
+        C: ToPyObject,
+    {
+        Self::new_bound_with(py, object, callback).map(Bound::into_gil_ref)
+    }
+
+    /// Constructs a new Weak Reference (weakref.ref) for the given object with a callback.
+    ///
+    /// Returns a `TypeError` if `object` is not subclassable (Most native types and PyClasses without `weakref` flag) or if the `callback` is not callable or None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyWeakRef;
+    ///
+    /// #[pyclass(weakref)]
+    /// struct Foo { /* fields omitted */ }
+    ///
+    /// #[pymethods]
+    /// impl Foo {
+    ///     #[staticmethod]
+    ///     fn finalizer(slf_ref: Bound<'_, PyWeakRef>) -> PyResult<()> {
+    ///         let py = slf_ref.py();
+    ///         assert!(slf_ref.call0()?.is(&py.None()));
+    ///         py.run("counter = 1", None, None)?;
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     py.run("counter = 0", None, None)?;
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
+    ///     let foo = Bound::new(py, Foo { } )?;
+    ///
+    ///     // This is fine.
+    ///     let weakref = PyWeakRef::new_bound_with(py, foo.clone(), py.None())?;
+    ///     assert!(weakref.call0()?.is(&foo));
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
+    ///     
+    ///     let weakref2 = PyWeakRef::new_bound_with(py, foo.clone(), py.get_type::<Foo>().getattr("finalizer")?)?;
+    ///     assert!(!weakref.is(&weakref2)); // Not the same weakref
+    ///     assert!(weakref.eq(&weakref2)?);  // But Equal, since they point to the same object
+    ///
+    ///     drop(foo);
+    ///
+    ///     assert!(weakref.call0()?.is(&py.None()));
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 1);
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ````
+    #[track_caller]
+    pub fn new_bound_with<'py, T, C>(
+        py: Python<'py>,
+        object: T,
+        callback: C,
+    ) -> PyResult<Bound<'py, PyWeakRef>>
+    where
+        T: ToPyObject,
+        C: ToPyObject,
+    {
+        unsafe {
+            Bound::from_owned_ptr_or_err(
+                py,
+                ffi::PyWeakref_NewRef(
+                    object.to_object(py).as_ptr(),
+                    callback.to_object(py).as_ptr(),
+                ),
+            )
+            .map(|obj| obj.downcast_into_unchecked())
+        }
+    }
+
+    pub fn upgrade<T>(&self) -> PyResult<Option<&T::AsRefTarget>>
+    where
+        T: PyTypeCheck,
+    {
+        Ok(self.as_borrowed().upgrade::<T>()?.map(Bound::into_gil_ref))
+    }
+
+    pub fn get_object(&self) -> PyResult<Option<&'_ PyAny>> {
+        Ok(self.as_borrowed().get_object()?.map(Bound::into_gil_ref))
+    }
+
+    pub fn get_object_raw(&self) -> PyResult<&'_ PyAny> {
+        self.as_borrowed().get_object_raw().map(Bound::into_gil_ref)
+    }
+}
+
+/// Implementation of functionality for [`PyWeakRef`].
+///
+/// These methods are defined for the `Bound<'py, PyWeakRef>` smart pointer, so to use method call
+/// syntax these methods are separated into a trait, because stable Rust does not yet support
+/// `arbitrary_self_types`.
+#[doc(alias = "PyWeakRef")]
+pub trait PyWeakRefMethods<'py> {
+    // Named it upgrade to allign with rust's Weak::upgrade.
+    fn upgrade<T>(&self) -> PyResult<Option<Bound<'py, T>>>
+    where
+        T: PyTypeCheck;
+    // fn borrowed_upgrade<T: PyTypeCheck>(&self) -> PyResult<Option<Borrowed<'_, 'py, T>>>;
+
+    // TODO: NAMING
+    // maybe upgrade_any
+    fn get_object(&self) -> PyResult<Option<Bound<'py, PyAny>>>;
+    // maybe upgrade_any_borrowed
+    fn borrow_object(&self) -> PyResult<Option<Borrowed<'_, 'py, PyAny>>>;
+
+    // TODO: NAMING
+    // get_any
+    fn get_object_raw(&self) -> PyResult<Bound<'py, PyAny>>;
+    // get_any_borrowed
+    fn borrow_object_raw(&self) -> PyResult<Borrowed<'_, 'py, PyAny>>;
+}
+
+impl<'py> PyWeakRefMethods<'py> for Bound<'py, PyWeakRef> {
+    fn upgrade<T>(&self) -> PyResult<Option<Bound<'py, T>>>
+    where
+        T: PyTypeCheck,
+    {
+        Ok(self.get_object()?.map(|obj| obj.downcast_into::<T>().expect(
+                    format!("The `weakref.ReferenceType` (`PyWeakRef`) does not refer to the requested type `{}`", T::NAME).as_str(),
+                )))
+    }
+
+    /*
+    fn borrowed_upgrade<T: PyTypeCheck>(&self) -> PyResult<Option<Borrowed<'_, 'py, T>>> {
+        Ok(self.borrow_object()?.map(|obj| obj.downcast_into::<T>().expect(
+                    format!("The `weakref.ReferenceType` (`PyWeakRef`) does not refer to the requested type `{}`", T::NAME).as_str(),
+                )))
+    }
+    */
+
+    fn get_object(&self) -> PyResult<Option<Bound<'py, PyAny>>> {
+        let object = self.get_object_raw()?;
+
+        Ok(if object.is_none() { None } else { Some(object) })
+    }
+
+    fn borrow_object(&self) -> PyResult<Option<Borrowed<'_, 'py, PyAny>>> {
+        let object = self.borrow_object_raw()?;
+
+        Ok(if object.is_none() { None } else { Some(object) })
+    }
+
+    fn get_object_raw(&self) -> PyResult<Bound<'py, PyAny>> {
+        // Bound<'_, PyAny>::call0 could also be used in situations where ffi::PyWeakref_GetObject is not available.
+        self.borrow_object_raw().map(Borrowed::to_owned)
+    }
+
+    fn borrow_object_raw(&self) -> PyResult<Borrowed<'_, 'py, PyAny>> {
+        // &PyAny::call0 could also be used in situations where ffi::PyWeakref_GetObject is not available.
+        unsafe { ffi::PyWeakref_GetObject(self.as_ptr()).assume_borrowed_or_err(self.py()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::prelude::{pyclass, Python};
+    use crate::types::any::PyAnyMethods;
+    use crate::types::weakref::{PyWeakRef, PyWeakRefMethods};
+    use crate::Py;
+
+    #[pyclass(weakref, crate = "crate")]
+    struct WeakrefablePyClass {}
+
+    #[test]
+    fn test_reference_upgrade() {
+        Python::with_gil(|py| {
+            let foo = Py::new(py, WeakrefablePyClass {}).unwrap();
+            let reference = PyWeakRef::new_bound(py, foo.clone_ref(py)).unwrap();
+
+            {
+                let obj = reference.upgrade::<WeakrefablePyClass>();
+
+                assert!(obj.is_ok());
+                let obj = obj.unwrap();
+
+                assert!(obj.is_some());
+                assert!(obj.is_some_and(|obj| obj.as_ptr() == foo.as_ptr()));
+            }
+
+            drop(foo);
+
+            {
+                let obj = reference.upgrade::<WeakrefablePyClass>();
+
+                assert!(obj.is_ok());
+                let obj = obj.unwrap();
+
+                assert!(obj.is_none());
+            }
+        })
+    }
+
+    #[test]
+    fn test_reference_get_object() {
+        Python::with_gil(|py| {
+            let foo = Py::new(py, WeakrefablePyClass {}).unwrap();
+            let reference = PyWeakRef::new_bound(py, foo.clone_ref(py)).ok().unwrap();
+
+            assert!(reference.call0().unwrap().is(&foo));
+            assert!(reference.get_object().unwrap().is_some());
+            assert!(reference
+                .get_object()
+                .unwrap()
+                .is_some_and(|obj| obj.is(&foo)));
+
+            drop(foo);
+
+            assert!(reference.call0().unwrap().is_none());
+            assert!(reference.get_object().unwrap().is_none());
+        })
+    }
+
+    #[test]
+    fn test_reference_borrrow_object() {
+        Python::with_gil(|py| {
+            let foo = Py::new(py, WeakrefablePyClass {}).unwrap();
+            let reference = PyWeakRef::new_bound(py, foo.clone_ref(py)).ok().unwrap();
+
+            assert!(reference.call0().unwrap().is(&foo));
+            assert!(reference.borrow_object().unwrap().is_some());
+            assert!(reference
+                .borrow_object()
+                .unwrap()
+                .is_some_and(|obj| obj.is(&foo)));
+
+            drop(foo);
+
+            assert!(reference.call0().unwrap().is_none());
+            assert!(reference.borrow_object().unwrap().is_none());
+        })
+    }
+
+    #[test]
+    fn test_reference_get_object_raw() {
+        Python::with_gil(|py| {
+            let foo = Py::new(py, WeakrefablePyClass {}).unwrap();
+            let reference = PyWeakRef::new_bound(py, foo.clone_ref(py)).ok().unwrap();
+
+            assert!(reference.call0().unwrap().is(&foo));
+            assert!(reference.get_object_raw().unwrap().is(&foo));
+
+            drop(foo);
+
+            assert!(reference
+                .call0()
+                .unwrap()
+                .is(&reference.get_object_raw().unwrap()));
+            assert!(reference.call0().unwrap().is_none());
+            assert!(reference.get_object_raw().unwrap().is_none());
+        });
+    }
+
+    #[test]
+    fn test_reference_borrow_object_raw() {
+        Python::with_gil(|py| {
+            let foo = Py::new(py, WeakrefablePyClass {}).unwrap();
+            let reference = PyWeakRef::new_bound(py, foo.clone_ref(py)).ok().unwrap();
+
+            assert!(reference.call0().unwrap().is(&foo));
+            assert!(reference.borrow_object_raw().unwrap().is(&foo));
+
+            drop(foo);
+
+            assert!(reference.call0().unwrap().is_none());
+            assert!(reference.borrow_object_raw().unwrap().is_none());
+        });
+    }
+}

--- a/src/types/weakref/callableproxy.rs
+++ b/src/types/weakref/callableproxy.rs
@@ -11,83 +11,95 @@ use super::PyWeakRefMethods;
 ///
 /// In Python this is created by calling `weakref.proxy`.
 #[repr(transparent)]
-pub struct PyWeakProxy(PyAny);
+pub struct PyWeakCallableProxy(PyAny);
 
 pyobject_native_type!(
-    PyWeakProxy,
+    PyWeakCallableProxy,
     ffi::PyWeakReference,
-    pyobject_native_static_type_object!(ffi::_PyWeakref_ProxyType),
+    pyobject_native_static_type_object!(ffi::_PyWeakref_CallableProxyType),
     #module=Some("weakref"),
     #checkfunction=ffi::PyWeakref_CheckProxy
 );
 
-impl PyWeakProxy {
-    /// Deprecated form of [`PyWeakProxy::new_bound`].
+impl PyWeakCallableProxy {
+    /// Deprecated form of [`PyWeakCallableProxy::new_bound`].
     #[inline]
     #[track_caller]
     #[cfg_attr(
         not(feature = "gil-refs"),
         deprecated(
             since = "0.21.0",
-            note = "`PyWeakProxy::new` will be replaced by `PyWeakProxy::new_bound` in a future PyO3 version"
+            note = "`PyWeakCallableProxy::new` will be replaced by `PyWeakCallableProxy::new_bound` in a future PyO3 version"
         )
     )]
-    pub fn new<T>(py: Python<'_>, object: T) -> PyResult<&'_ PyWeakProxy>
+    pub fn new<T>(py: Python<'_>, object: T) -> PyResult<&'_ PyWeakCallableProxy>
     where
         T: ToPyObject,
     {
         Self::new_bound(py, object).map(Bound::into_gil_ref)
     }
 
-    /// Constructs a new Weak Reference (`weakref.proxy`/`weakref.ProxyType`) for the given object.
+    /// Constructs a new Weak callable Reference (`weakref.proxy`/`weakref.CallableProxyType`) for the given object.
     ///
     /// Returns a `TypeError` if `object` is not weak referenceable (Most native types and PyClasses without `weakref` flag).
-    /// The object should also not be callable. For a callable weakref proxy see [`PyWeakCallableProxy`](crate::types::weakref::PyWeakCallableProxy).
+    /// The object should also be callable. For a non-callable weakref proxy see [`PyWeakProxy`](crate::types::weakref::PyWeakProxy).
     ///
     /// # Examples
     ///
     /// ```rust
     /// use pyo3::prelude::*;
-    /// use pyo3::types::PyWeakProxy;
+    /// use pyo3::types::PyWeakCallableProxy;
+    /// use pyo3::exceptions::PyReferenceError;
     ///
     /// #[pyclass(weakref)]
     /// struct Foo { /* fields omitted */ }
     ///
+    /// #[pymethods]
+    /// impl Foo {
+    ///     fn __call__(&self) -> &str {
+    ///         "This class is callable"
+    ///     }
+    /// }
+    ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
     ///     let foo = Bound::new(py, Foo {})?;
-    ///     let weakref = PyWeakProxy::new_bound(py, foo.clone())?;
+    ///     let weakref = PyWeakCallableProxy::new_bound(py, foo.clone())?;
     ///     assert!(
     ///         // In normal situations where a direct `Bound<'py, Foo>` is required use `upgrade::<Foo>`
     ///         weakref.get_object()?
     ///             .is_some_and(|obj| obj.is(&foo))
     ///     );
     ///
-    ///     let weakref2 = PyWeakProxy::new_bound(py, foo.clone())?;
+    ///     let weakref2 = PyWeakCallableProxy::new_bound(py, foo.clone())?;
     ///     assert!(weakref.is(&weakref2));
+    ///
+    ///     assert_eq!(weakref.call0()?.to_string(), "This class is callable");
     ///
     ///     drop(foo);
     ///
     ///     assert!(weakref.get_object()?.is_none());
+    ///     assert!(weakref.call0().is_err_and(|err| err.is_instance_of::<PyReferenceError>(py)));
+    ///
     ///     Ok(())
     /// })
     /// # }
     /// ```
     ///
     /// # Panics
-    /// This function panics if the provided object is callable.
+    /// This function panics if the provided object is not callable.
     ///
     #[inline]
     #[track_caller]
-    pub fn new_bound<T>(py: Python<'_>, object: T) -> PyResult<Bound<'_, PyWeakProxy>>
+    pub fn new_bound<T>(py: Python<'_>, object: T) -> PyResult<Bound<'_, PyWeakCallableProxy>>
     where
         T: ToPyObject,
     {
         unsafe {
             let ptr = object.to_object(py).as_ptr();
             assert_eq!(
-                ffi::PyCallable_Check(ptr), 0,
-                "An object to be referenced by a PyWeakProxy should not be callable. Use PyWeakCallableProxy instead."
+                ffi::PyCallable_Check(ptr), 1,
+                "An object to be referenced by a PyWeakCallableProxy should be callable. Use PyWeakProxy instead."
             );
 
             Bound::from_owned_ptr_or_err(py, ffi::PyWeakref_NewProxy(ptr, ffi::Py_None()))
@@ -95,17 +107,21 @@ impl PyWeakProxy {
         }
     }
 
-    /// Deprecated form of [`PyWeakProxy::new_bound_with`].
+    /// Deprecated form of [`PyWeakCallableProxy::new_bound_with`].
     #[inline]
     #[track_caller]
     #[cfg_attr(
         not(feature = "gil-refs"),
         deprecated(
             since = "0.21.0",
-            note = "`PyWeakProxy::new_with` will be replaced by `PyWeakProxy::new_bound_with` in a future PyO3 version"
+            note = "`PyWeakCallableProxy::new_with` will be replaced by `PyWeakCallableProxy::new_bound_with` in a future PyO3 version"
         )
     )]
-    pub fn new_with<T, C>(py: Python<'_>, object: T, callback: C) -> PyResult<&'_ PyWeakProxy>
+    pub fn new_with<T, C>(
+        py: Python<'_>,
+        object: T,
+        callback: C,
+    ) -> PyResult<&'_ PyWeakCallableProxy>
     where
         T: ToPyObject,
         C: ToPyObject,
@@ -113,22 +129,29 @@ impl PyWeakProxy {
         Self::new_bound_with(py, object, callback).map(Bound::into_gil_ref)
     }
 
-    /// Constructs a new Weak Reference (`weakref.proxy`/`weakref.ProxyType`) for the given object with a callback.
+    /// Constructs a new Weak Reference (`weakref.proxy`/`weakref.CallableProxyType`) for the given object with a callback.
     ///
     /// Returns a `TypeError` if `object` is not weak referenceable (Most native types and PyClasses without `weakref` flag) or if the `callback` is not callable or None.
-    /// The object should also not be callable. For a callable weakref proxy see [`PyWeakCallableProxy`](crate::types::weakref::PyWeakCallableProxy).
+    /// The object should also be callable. For a non-callable weakref proxy see [`PyWeakProxy`](crate::types::weakref::PyWeakProxy).
     ///
     /// # Examples
     ///
     /// ```rust
     /// use pyo3::prelude::*;
-    /// use pyo3::types::PyWeakProxy;
+    /// use pyo3::types::PyWeakCallableProxy;
     ///
     /// #[pyclass(weakref)]
     /// struct Foo { /* fields omitted */ }
     ///
+    /// #[pymethods]
+    /// impl Foo {
+    ///     fn __call__(&self) -> &str {
+    ///         "This class is callable"
+    ///     }
+    /// }
+    ///
     /// #[pyfunction]
-    /// fn callback(wref: Bound<'_, PyWeakProxy>) -> PyResult<()> {
+    /// fn callback(wref: Bound<'_, PyWeakCallableProxy>) -> PyResult<()> {
     ///         let py = wref.py();
     ///         assert!(wref.upgrade::<Foo>()?.is_none());
     ///         py.run("counter = 1", None, None)
@@ -141,7 +164,7 @@ impl PyWeakProxy {
     ///     let foo = Bound::new(py, Foo{})?;
     ///
     ///     // This is fine.
-    ///     let weakref = PyWeakProxy::new_bound_with(py, foo.clone(), py.None())?;
+    ///     let weakref = PyWeakCallableProxy::new_bound_with(py, foo.clone(), py.None())?;
     ///     assert!(weakref.upgrade::<Foo>()?.is_some());
     ///     assert!(
     ///         // In normal situations where a direct `Bound<'py, Foo>` is required use `upgrade::<Foo>`
@@ -150,9 +173,11 @@ impl PyWeakProxy {
     ///     );
     ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
     ///     
-    ///     let weakref2 = PyWeakProxy::new_bound_with(py, foo.clone(), wrap_pyfunction!(callback, py)?)?;
+    ///     let weakref2 = PyWeakCallableProxy::new_bound_with(py, foo.clone(), wrap_pyfunction!(callback, py)?)?;
     ///     assert!(!weakref.is(&weakref2)); // Not the same weakref
     ///     assert!(weakref.eq(&weakref2)?);  // But Equal, since they point to the same object
+    ///
+    ///     assert_eq!(weakref.call0()?.to_string(), "This class is callable");
     ///
     ///     drop(foo);
     ///
@@ -163,13 +188,13 @@ impl PyWeakProxy {
     /// # }
     /// ```
     /// # Panics
-    /// This function panics if the provided object is callable.
+    /// This function panics if the provided object is not callable.
     #[track_caller]
     pub fn new_bound_with<T, C>(
         py: Python<'_>,
         object: T,
         callback: C,
-    ) -> PyResult<Bound<'_, PyWeakProxy>>
+    ) -> PyResult<Bound<'_, PyWeakCallableProxy>>
     where
         T: ToPyObject,
         C: ToPyObject,
@@ -177,8 +202,8 @@ impl PyWeakProxy {
         unsafe {
             let ptr = object.to_object(py).as_ptr();
             assert_eq!(
-                ffi::PyCallable_Check(ptr), 0,
-                "An object to be referenced by a PyWeakProxy should not be callable. Use PyWeakCallableProxy instead."
+                ffi::PyCallable_Check(ptr), 1,
+                "An object to be referenced by a PyWeakCallableProxy should be callable. Use PyWeakProxy instead."
             );
 
             Bound::from_owned_ptr_or_err(
@@ -197,19 +222,23 @@ impl PyWeakProxy {
     /// # Example
     /// ```rust
     /// use pyo3::prelude::*;
-    /// use pyo3::types::PyWeakProxy;
+    /// use pyo3::types::PyWeakCallableProxy;
     ///
     /// #[pyclass(weakref)]
     /// struct Foo { /* fields omitted */ }
     ///
     /// #[pymethods]
     /// impl Foo {
+    ///     fn __call__(&self) -> &str {
+    ///         "This class is callable"
+    ///     }
+    ///
     ///     fn get_data(&self) -> (&str, u32) {
     ///         ("Dave", 10)
     ///     }
     /// }
     ///
-    /// fn parse_data(reference: Borrowed<'_, '_, PyWeakProxy>) -> PyResult<String> {
+    /// fn parse_data(reference: Borrowed<'_, '_, PyWeakCallableProxy>) -> PyResult<String> {
     ///     if let Some(data_src) = reference.upgrade::<Foo>()? {
     ///         let data = data_src.borrow();
     ///         let (name, score) = data.get_data();
@@ -222,13 +251,15 @@ impl PyWeakProxy {
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
     ///     let data = Bound::new(py, Foo{})?;
-    ///     let reference = PyWeakProxy::new_bound(py, data.clone())?;
+    ///     let reference = PyWeakCallableProxy::new_bound(py, data.clone())?;
     ///     
     ///     assert_eq!(
     ///         parse_data(reference.as_borrowed())?,
     ///         "Processing 'Dave': score = 10"
     ///     );
-    ///
+    ///     
+    ///     assert_eq!(reference.call0()?.to_string(), "This class is callable");
+    ///     
     ///     drop(data);
     ///
     ///     assert_eq!(
@@ -242,10 +273,10 @@ impl PyWeakProxy {
     /// ```
     ///
     /// # Panics
-    /// This function panics if the requested type `T` is not the the type of the instance refered to by this `weakref.ProxyType`.
+    /// This function panics if the requested type `T` is not the the type of the instance refered to by this `weakref.CallableProxyType`.
     ///
     /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
-    /// [`weakref.ProxyType`]: https://docs.python.org/3/library/weakref.html#weakref.ProxyType
+    /// [`weakref.CallableProxyType`]: https://docs.python.org/3/library/weakref.html#weakref.CallableProxyType
     /// [`weakref.proxy`]: https://docs.python.org/3/library/weakref.html#weakref.proxy
     pub fn upgrade<T>(&self) -> PyResult<Option<&T::AsRefTarget>>
     where
@@ -258,18 +289,25 @@ impl PyWeakProxy {
     ///
     /// This function returns `Some(&'py PyAny)` if the reference still exists, otherwise `None` will be returned.
     ///
-    /// This function gets the optional target of this [`weakref.ProxyType`] (result of calling [`weakref.proxy`]).
-    /// It produces similair results using [`PyWeakref_GetObject`] in the C api.
+    /// This function gets the optional target of this [`weakref.CallableProxyType`] (result of calling [`weakref.proxy`]).
+    /// It produces similair results to using [`PyWeakref_GetObject`] in the C api.
     ///
     /// # Example
     /// ```rust
     /// use pyo3::prelude::*;
-    /// use pyo3::types::PyWeakProxy;
+    /// use pyo3::types::PyWeakCallableProxy;
     ///
     /// #[pyclass(weakref)]
     /// struct Foo { /* fields omitted */ }
     ///
-    /// fn parse_data(reference: Borrowed<'_, '_, PyWeakProxy>) -> PyResult<String> {
+    /// #[pymethods]
+    /// impl Foo {
+    ///     fn __call__(&self) -> &str {
+    ///         "This class is callable"
+    ///     }
+    /// }
+    ///
+    /// fn parse_data(reference: Borrowed<'_, '_, PyWeakCallableProxy>) -> PyResult<String> {
     ///     if let Some(object) = reference.get_object()? {
     ///         Ok(format!("The object '{}' refered by this reference still exists.", object.getattr("__class__")?.getattr("__qualname__")?))
     ///     } else {
@@ -280,12 +318,14 @@ impl PyWeakProxy {
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
     ///     let data = Bound::new(py, Foo{})?;
-    ///     let reference = PyWeakProxy::new_bound(py, data.clone())?;
+    ///     let reference = PyWeakCallableProxy::new_bound(py, data.clone())?;
     ///     
     ///     assert_eq!(
     ///         parse_data(reference.as_borrowed())?,
     ///         "The object 'Foo' refered by this reference still exists."
     ///     );
+    ///     
+    ///     assert_eq!(reference.call0()?.to_string(), "This class is callable");
     ///
     ///     drop(data);
     ///
@@ -300,7 +340,7 @@ impl PyWeakProxy {
     /// ```
     ///
     /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
-    /// [`weakref.ProxyType`]: https://docs.python.org/3/library/weakref.html#weakref.ProxyType
+    /// [`weakref.ProxyCallableType`]: https://docs.python.org/3/library/weakref.html#weakref.CallableProxyType
     /// [`weakref.proxy`]: https://docs.python.org/3/library/weakref.html#weakref.proxy
     pub fn get_object(&self) -> PyResult<Option<&'_ PyAny>> {
         Ok(self.as_borrowed().get_object()?.map(Bound::into_gil_ref))
@@ -310,18 +350,25 @@ impl PyWeakProxy {
     ///
     /// This function returns `&'py PyAny`, which is either the object if it still exists, otherwise it will refer to [`PyNone`](crate::types::none::PyNone).
     ///
-    /// This function gets the optional target of this [`weakref.ProxyType`] (result of calling [`weakref.proxy`]).
-    /// It produces similair results using [`PyWeakref_GetObject`] in the C api.
+    /// This function gets the optional target of this [`weakref.CallableProxyType`] (result of calling [`weakref.proxy`]).
+    /// It produces similair results to using [`PyWeakref_GetObject`] in the C api.
     ///
     /// # Example
     /// ```rust
     /// use pyo3::prelude::*;
-    /// use pyo3::types::PyWeakProxy;
+    /// use pyo3::types::PyWeakCallableProxy;
     ///
     /// #[pyclass(weakref)]
     /// struct Foo { /* fields omitted */ }
     ///
-    /// fn get_class(reference: Borrowed<'_, '_, PyWeakProxy>) -> PyResult<String> {
+    /// #[pymethods]
+    /// impl Foo {
+    ///     fn __call__(&self) -> &str {
+    ///         "This class is callable"
+    ///     }
+    /// }
+    ///
+    /// fn get_class(reference: Borrowed<'_, '_, PyWeakCallableProxy>) -> PyResult<String> {
     ///     reference
     ///         .get_object_raw()?
     ///         .getattr("__class__")?
@@ -333,12 +380,14 @@ impl PyWeakProxy {
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
     ///     let object = Bound::new(py, Foo{})?;
-    ///     let reference = PyWeakProxy::new_bound(py, object.clone())?;
+    ///     let reference = PyWeakCallableProxy::new_bound(py, object.clone())?;
     ///     
     ///     assert_eq!(
     ///         get_class(reference.as_borrowed())?,
     ///         "<class 'builtins.Foo'>"
     ///     );
+    ///
+    ///     assert_eq!(reference.call0()?.to_string(), "This class is callable");
     ///
     ///     drop(object);
     ///
@@ -350,14 +399,14 @@ impl PyWeakProxy {
     /// ```
     ///
     /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
-    /// [`weakref.ProxyType`]: https://docs.python.org/3/library/weakref.html#weakref.ProxyType
+    /// [`weakref.CallableProxyType`]: https://docs.python.org/3/library/weakref.html#weakref.CallableProxyType
     /// [`weakref.proxy`]: https://docs.python.org/3/library/weakref.html#weakref.proxy
     pub fn get_object_raw(&self) -> PyResult<&'_ PyAny> {
         self.as_borrowed().get_object_raw().map(Bound::into_gil_ref)
     }
 }
 
-impl<'py> PyWeakRefMethods<'py> for Bound<'py, PyWeakProxy> {
+impl<'py> PyWeakRefMethods<'py> for Bound<'py, PyWeakCallableProxy> {
     fn borrow_object_raw(&self) -> PyResult<Borrowed<'_, 'py, PyAny>> {
         unsafe { ffi::PyWeakref_GetObject(self.as_ptr()).assume_borrowed_or_err(self.py()) }
     }
@@ -365,26 +414,33 @@ impl<'py> PyWeakRefMethods<'py> for Bound<'py, PyWeakProxy> {
 
 #[cfg(test)]
 mod tests {
-    use crate::exceptions::{PyAttributeError, PyReferenceError, PyTypeError};
-    use crate::prelude::{pyclass, Py, PyResult, Python};
+    use crate::exceptions::{PyAttributeError, PyReferenceError};
+    use crate::prelude::{pyclass, pymethods, Py, PyResult, Python};
     use crate::types::any::PyAnyMethods;
-    use crate::types::weakref::{PyWeakProxy, PyWeakRefMethods};
+    use crate::types::weakref::{PyWeakCallableProxy, PyWeakRefMethods};
     use crate::Bound;
 
     #[pyclass(weakref, crate = "crate")]
     struct WeakrefablePyClass {}
 
+    #[pymethods(crate = "crate")]
+    impl WeakrefablePyClass {
+        fn __call__(&self) -> &str {
+            "This class is callable!"
+        }
+    }
+
     #[test]
     fn test_weakref_proxy_behavior() -> PyResult<()> {
         Python::with_gil(|py| {
             let object = Bound::new(py, WeakrefablePyClass {})?;
-            let reference = PyWeakProxy::new_bound(py, object.clone())?;
+            let reference = PyWeakCallableProxy::new_bound(py, object.clone())?;
 
             assert!(!reference.is(&object));
             assert!(reference.get_object_raw()?.is(&object));
             assert_eq!(
                 reference.get_type().to_string(),
-                "<class 'weakref.ProxyType'>"
+                "<class 'weakref.CallableProxyType'>"
             );
 
             assert_eq!(
@@ -404,10 +460,7 @@ mod tests {
                 .getattr("__callback__")
                 .is_err_and(|err| err.is_instance_of::<PyAttributeError>(py)));
 
-            assert!(reference
-                .call0()
-                .is_err_and(|err| err.is_instance_of::<PyTypeError>(py)
-                    & (err.value(py).to_string() == "'weakref.ProxyType' object is not callable")));
+            assert_eq!(reference.call0()?.to_string(), "This class is callable!");
 
             drop(object);
 
@@ -430,8 +483,8 @@ mod tests {
 
             assert!(reference
                 .call0()
-                .is_err_and(|err| err.is_instance_of::<PyTypeError>(py)
-                    & (err.value(py).to_string() == "'weakref.ProxyType' object is not callable")));
+                .is_err_and(|err| err.is_instance_of::<PyReferenceError>(py)
+                    & (err.value(py).to_string() == "weakly-referenced object no longer exists")));
 
             Ok(())
         })
@@ -441,7 +494,7 @@ mod tests {
     fn test_weakref_upgrade() -> PyResult<()> {
         Python::with_gil(|py| {
             let object = Py::new(py, WeakrefablePyClass {})?;
-            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+            let reference = PyWeakCallableProxy::new_bound(py, object.clone_ref(py))?;
 
             {
                 let obj = reference.upgrade::<WeakrefablePyClass>();
@@ -472,7 +525,7 @@ mod tests {
     fn test_weakref_get_object() -> PyResult<()> {
         Python::with_gil(|py| {
             let object = Py::new(py, WeakrefablePyClass {})?;
-            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+            let reference = PyWeakCallableProxy::new_bound(py, object.clone_ref(py))?;
 
             assert!(reference.get_object()?.is_some());
             assert!(reference.get_object()?.is_some_and(|obj| obj.is(&object)));
@@ -489,7 +542,7 @@ mod tests {
     fn test_weakref_borrrow_object() -> PyResult<()> {
         Python::with_gil(|py| {
             let object = Py::new(py, WeakrefablePyClass {})?;
-            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+            let reference = PyWeakCallableProxy::new_bound(py, object.clone_ref(py))?;
 
             assert!(reference.borrow_object()?.is_some());
             assert!(reference
@@ -508,7 +561,7 @@ mod tests {
     fn test_weakref_get_object_raw() -> PyResult<()> {
         Python::with_gil(|py| {
             let object = Py::new(py, WeakrefablePyClass {})?;
-            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+            let reference = PyWeakCallableProxy::new_bound(py, object.clone_ref(py))?;
 
             assert!(reference.get_object_raw()?.is(&object));
 
@@ -524,7 +577,7 @@ mod tests {
     fn test_weakref_borrow_object_raw() -> PyResult<()> {
         Python::with_gil(|py| {
             let object = Py::new(py, WeakrefablePyClass {})?;
-            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+            let reference = PyWeakCallableProxy::new_bound(py, object.clone_ref(py))?;
 
             assert!(reference.borrow_object_raw()?.is(&object));
 

--- a/src/types/weakref/mod.rs
+++ b/src/types/weakref/mod.rs
@@ -1,5 +1,7 @@
+pub use callableproxy::PyWeakCallableProxy;
 pub use proxy::PyWeakProxy;
 pub use reference::{PyWeakRef, PyWeakRefMethods};
 
+pub(crate) mod callableproxy;
 pub(crate) mod proxy;
 pub(crate) mod reference;

--- a/src/types/weakref/mod.rs
+++ b/src/types/weakref/mod.rs
@@ -1,0 +1,5 @@
+pub use proxy::PyWeakProxy;
+pub use reference::{PyWeakRef, PyWeakRefMethods};
+
+pub(crate) mod proxy;
+pub(crate) mod reference;

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -1,0 +1,540 @@
+#[cfg(feature = "experimental-any-proxy")]
+use std::cmp::Ordering;
+
+#[cfg(feature = "experimental-any-proxy")]
+use crate::{
+    basic::CompareOp,
+    exceptions::PyReferenceError,
+    type_object::PyTypeCheck,
+    types::{PyDict, PyIterator, PyList, PyString, PySuper, PyTuple, PyType},
+    DowncastError, DowncastIntoError, FromPyObject, IntoPy, Py, PyTypeInfo,
+};
+
+use crate::err::PyResult;
+use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::types::any::PyAnyMethods;
+use crate::{
+    ffi, AsPyPointer, Borrowed, Bound, PyAny, PyNativeType, PyTypeCheck, Python, ToPyObject,
+};
+
+use super::PyWeakRefMethods;
+
+/// Represents a Python `weakref.ProxyType`.
+///
+/// In Python this is created by calling `weakref.proxy`.
+#[repr(transparent)]
+pub struct PyWeakProxy(PyAny);
+
+pyobject_native_type!(
+    PyWeakProxy,
+    ffi::PyWeakReference,
+    pyobject_native_static_type_object!(ffi::_PyWeakref_ProxyType),
+    #module=Some("weakref"),
+    #checkfunction=ffi::PyWeakref_CheckProxy
+);
+
+impl PyWeakProxy {
+    /// Deprecated form of [`PyWeakProxy::new_bound`].
+    #[inline]
+    #[track_caller]
+    #[cfg_attr(
+        not(feature = "gil-refs"),
+        deprecated(
+            since = "0.21.0",
+            note = "`PyWeakProxy::new` will be replaced by `PyWeakProxy::new_bound` in a future PyO3 version"
+        )
+    )]
+    pub fn new<T>(py: Python<'_>, object: T) -> PyResult<&'_ PyWeakProxy>
+    where
+        T: ToPyObject,
+    {
+        Self::new_bound(py, object).map(Bound::into_gil_ref)
+    }
+
+    /// Constructs a new Weak Reference (`weakref.proxy`/`weakref.ProxyType`) for the given object.
+    ///
+    /// Returns a `TypeError` if `object` is not weak referenceable (Most native types and PyClasses without `weakref` flag).
+    /// The object should also not be callable. For a callable weakref proxy see [`PyWeakCallableProxy`](crate::types::weakref::PyWeakCallableProxy).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyWeakProxy;
+    ///
+    /// #[pyclass(weakref)]
+    /// struct Foo { /* fields omitted */ }
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let foo = Bound::new(py, Foo {})?;
+    ///     let weakref = PyWeakProxy::new_bound(py, foo.clone())?;
+    ///     assert!(
+    ///         // In normal situations where a direct `Bound<'py, Foo>` is required use `upgrade::<Foo>`
+    ///         weakref.get_object()?
+    ///             .is_some_and(|obj| obj.is(&foo))
+    ///     );
+    ///
+    ///     let weakref2 = PyWeakProxy::new_bound(py, foo.clone())?;
+    ///     assert!(weakref.is(&weakref2));
+    ///
+    ///     drop(foo);
+    ///
+    ///     assert!(weakref.get_object()?.is_none());
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    /// This function panics if the provided object is callable.
+    ///
+    #[inline]
+    #[track_caller]
+    pub fn new_bound<T>(py: Python<'_>, object: T) -> PyResult<Bound<'_, PyWeakProxy>>
+    where
+        T: ToPyObject,
+    {
+        unsafe {
+            let ptr = object.to_object(py).as_ptr();
+            assert_eq!(
+                ffi::PyCallable_Check(ptr), 0,
+                "An object to be referenced by a PyWeakProxy should not be callable. Use PyWeakCallableProxy instead."
+            );
+
+            Bound::from_owned_ptr_or_err(py, ffi::PyWeakref_NewProxy(ptr, ffi::Py_None()))
+                .map(|obj| obj.downcast_into_unchecked())
+        }
+    }
+
+    /// Deprecated form of [`PyWeakProxy::new_bound_with`].
+    #[inline]
+    #[track_caller]
+    #[cfg_attr(
+        not(feature = "gil-refs"),
+        deprecated(
+            since = "0.21.0",
+            note = "`PyWeakProxy::new_with` will be replaced by `PyWeakProxy::new_bound_with` in a future PyO3 version"
+        )
+    )]
+    pub fn new_with<T, C>(py: Python<'_>, object: T, callback: C) -> PyResult<&'_ PyWeakProxy>
+    where
+        T: ToPyObject,
+        C: ToPyObject,
+    {
+        Self::new_bound_with(py, object, callback).map(Bound::into_gil_ref)
+    }
+
+    /// Constructs a new Weak Reference (`weakref.proxy`/`weakref.ProxyType`) for the given object with a callback.
+    ///
+    /// Returns a `TypeError` if `object` is not weak referenceable (Most native types and PyClasses without `weakref` flag) or if the `callback` is not callable or None.
+    /// The object should also not be callable. For a callable weakref proxy see [`PyWeakCallableProxy`](crate::types::weakref::PyWeakCallableProxy).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyWeakProxy;
+    ///
+    /// #[pyclass(weakref)]
+    /// struct Foo { /* fields omitted */ }
+    ///
+    /// #[pyfunction]
+    /// fn callback(wref: Bound<'_, PyWeakProxy>) -> PyResult<()> {
+    ///         let py = wref.py();
+    ///         assert!(wref.upgrade::<Foo>()?.is_none());
+    ///         py.run("counter = 1", None, None)
+    /// }
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     py.run("counter = 0", None, None)?;
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
+    ///     let foo = Bound::new(py, Foo{})?;
+    ///
+    ///     // This is fine.
+    ///     let weakref = PyWeakProxy::new_bound_with(py, foo.clone(), py.None())?;
+    ///     assert!(weakref.upgrade::<Foo>()?.is_some());
+    ///     assert!(
+    ///         // In normal situations where a direct `Bound<'py, Foo>` is required use `upgrade::<Foo>`
+    ///         weakref.get_object()?
+    ///             .is_some_and(|obj| obj.is(&foo))
+    ///     );
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
+    ///     
+    ///     let weakref2 = PyWeakProxy::new_bound_with(py, foo.clone(), wrap_pyfunction!(callback, py)?)?;
+    ///     assert!(!weakref.is(&weakref2)); // Not the same weakref
+    ///     assert!(weakref.eq(&weakref2)?);  // But Equal, since they point to the same object
+    ///
+    ///     drop(foo);
+    ///
+    ///     assert!(weakref.upgrade::<Foo>()?.is_none());
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 1);
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    /// # Panics
+    /// This function panics if the provided object is callable.
+    #[track_caller]
+    pub fn new_bound_with<T, C>(
+        py: Python<'_>,
+        object: T,
+        callback: C,
+    ) -> PyResult<Bound<'_, PyWeakProxy>>
+    where
+        T: ToPyObject,
+        C: ToPyObject,
+    {
+        unsafe {
+            let ptr = object.to_object(py).as_ptr();
+            assert_eq!(
+                ffi::PyCallable_Check(ptr), 0,
+                "An object to be referenced by a PyWeakProxy should not be callable. Use PyWeakCallableProxy instead."
+            );
+
+            Bound::from_owned_ptr_or_err(
+                py,
+                ffi::PyWeakref_NewProxy(ptr, callback.to_object(py).as_ptr()),
+            )
+            .map(|obj| obj.downcast_into_unchecked())
+        }
+    }
+
+    /// Upgrade the weakref to a direct object reference.
+    ///
+    /// It is named `upgrade` to be inline with [rust's `Weak::upgrade`](std::rc::Weak::upgrade).
+    /// In Python it would be equivalent to [`PyWeakref_GetObject`] or calling the [`weakref.ProxyType`] (result of calling [`weakref.proxy`]).
+    ///
+    /// # Example
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyWeakProxy;
+    ///
+    /// #[pyclass(weakref)]
+    /// struct Foo { /* fields omitted */ }
+    ///
+    /// #[pymethods]
+    /// impl Foo {
+    ///     fn get_data(&self) -> (&str, u32) {
+    ///         ("Dave", 10)
+    ///     }
+    /// }
+    ///
+    /// fn parse_data(reference: Borrowed<'_, '_, PyWeakProxy>) -> PyResult<String> {
+    ///     if let Some(data_src) = reference.upgrade::<Foo>()? {
+    ///         let data = data_src.borrow();
+    ///         let (name, score) = data.get_data();
+    ///         Ok(format!("Processing '{}': score = {}", name, score))
+    ///     } else {
+    ///         Ok("The supplied data reference is nolonger relavent.".to_owned())
+    ///     }
+    /// }
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let data = Bound::new(py, Foo{})?;
+    ///     let reference = PyWeakProxy::new_bound(py, data.clone())?;
+    ///     
+    ///     assert_eq!(
+    ///         parse_data(reference.as_borrowed())?,
+    ///         "Processing 'Dave': score = 10"
+    ///     );
+    ///
+    ///     drop(data);
+    ///
+    ///     assert_eq!(
+    ///         parse_data(reference.as_borrowed())?,
+    ///         "The supplied data reference is nolonger relavent."
+    ///     );
+    ///
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    /// This function panics if the requested type `T` is not the the type of the instance refered to by this `weakref.ProxyType`.
+    ///
+    /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
+    /// [`weakref.ProxyType`]: https://docs.python.org/3/library/weakref.html#weakref.ProxyType
+    /// [`weakref.proxy`]: https://docs.python.org/3/library/weakref.html#weakref.proxy
+    pub fn upgrade<T>(&self) -> PyResult<Option<&T::AsRefTarget>>
+    where
+        T: PyTypeCheck,
+    {
+        Ok(self.as_borrowed().upgrade::<T>()?.map(Bound::into_gil_ref))
+    }
+
+    /// Upgrade the weakref to a [`PyAny`] reference to the target if possible.
+    ///
+    /// This function returns `Some(&'py PyAny)` if the reference still exists, otherwise `None` will be returned.
+    ///
+    /// This function gets the optional target of this [`weakref.ProxyType`] (result of calling [`weakref.proxy`]).
+    /// It produces similair results to calling the `weakref.ProxyType` or using [`PyWeakref_GetObject`] in the C api.
+    ///
+    /// # Example
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyWeakProxy;
+    ///
+    /// #[pyclass(weakref)]
+    /// struct Foo { /* fields omitted */ }
+    ///
+    /// fn parse_data(reference: Borrowed<'_, '_, PyWeakProxy>) -> PyResult<String> {
+    ///     if let Some(object) = reference.get_object()? {
+    ///         Ok(format!("The object '{}' refered by this reference still exists.", object.getattr("__class__")?.getattr("__qualname__")?))
+    ///     } else {
+    ///         Ok("The object, which this reference refered to, no longer exists".to_owned())
+    ///     }
+    /// }
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let data = Bound::new(py, Foo{})?;
+    ///     let reference = PyWeakProxy::new_bound(py, data.clone())?;
+    ///     
+    ///     assert_eq!(
+    ///         parse_data(reference.as_borrowed())?,
+    ///         "The object 'Foo' refered by this reference still exists."
+    ///     );
+    ///
+    ///     drop(data);
+    ///
+    ///     assert_eq!(
+    ///         parse_data(reference.as_borrowed())?,
+    ///         "The object, which this reference refered to, no longer exists"
+    ///     );
+    ///
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    ///
+    /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
+    /// [`weakref.ProxyType`]: https://docs.python.org/3/library/weakref.html#weakref.ProxyType
+    /// [`weakref.proxy`]: https://docs.python.org/3/library/weakref.html#weakref.proxy
+    pub fn get_object(&self) -> PyResult<Option<&'_ PyAny>> {
+        Ok(self.as_borrowed().get_object()?.map(Bound::into_gil_ref))
+    }
+
+    /// Retrieve to a object pointed to by the weakref.
+    ///
+    /// This function returns `&'py PyAny`, which is either the object if it still exists, otherwise it will refer to [`PyNone`](crate::types::none::PyNone).
+    ///
+    /// This function gets the optional target of this [`weakref.ProxyType`] (result of calling [`weakref.proxy`]).
+    /// It produces similair results to calling the `weakref.ProxyType` or using [`PyWeakref_GetObject`] in the C api.
+    ///
+    /// # Example
+    /// ```rust
+    /// use pyo3::prelude::*;
+    /// use pyo3::types::PyWeakProxy;
+    ///
+    /// #[pyclass(weakref)]
+    /// struct Foo { /* fields omitted */ }
+    ///
+    /// fn get_class(reference: Borrowed<'_, '_, PyWeakProxy>) -> PyResult<String> {
+    ///     reference
+    ///         .get_object_raw()?
+    ///         .getattr("__class__")?
+    ///         .repr()?
+    ///         .to_str()
+    ///         .map(ToOwned::to_owned)
+    /// }
+    ///
+    /// # fn main() -> PyResult<()> {
+    /// Python::with_gil(|py| {
+    ///     let object = Bound::new(py, Foo{})?;
+    ///     let reference = PyWeakProxy::new_bound(py, object.clone())?;
+    ///     
+    ///     assert_eq!(
+    ///         get_class(reference.as_borrowed())?,
+    ///         "<class 'builtins.Foo'>"
+    ///     );
+    ///
+    ///     drop(object);
+    ///
+    ///     assert_eq!(get_class(reference.as_borrowed())?, "<class 'NoneType'>");
+    ///
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    ///
+    /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
+    /// [`weakref.ProxyType`]: https://docs.python.org/3/library/weakref.html#weakref.ProxyType
+    /// [`weakref.proxy`]: https://docs.python.org/3/library/weakref.html#weakref.proxy
+    pub fn get_object_raw(&self) -> PyResult<&'_ PyAny> {
+        self.as_borrowed().get_object_raw().map(Bound::into_gil_ref)
+    }
+}
+
+impl<'py> PyWeakRefMethods<'py> for Bound<'py, PyWeakProxy> {
+    fn borrow_object_raw(&self) -> PyResult<Borrowed<'_, 'py, PyAny>> {
+        unsafe { ffi::PyWeakref_GetObject(self.as_ptr()).assume_borrowed_or_err(self.py()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::exceptions::{PyAttributeError, PyReferenceError};
+    use crate::prelude::{pyclass, Py, PyResult, Python};
+    use crate::types::any::PyAnyMethods;
+    use crate::types::weakref::{PyWeakProxy, PyWeakRefMethods};
+    use crate::Bound;
+
+    #[pyclass(weakref, crate = "crate")]
+    struct WeakrefablePyClass {}
+
+    #[test]
+    fn test_weakref_proxy_behavior() -> PyResult<()> {
+        Python::with_gil(|py| {
+            let object = Bound::new(py, WeakrefablePyClass {})?;
+            let reference = PyWeakProxy::new_bound(py, object.clone())?;
+
+            assert!(!reference.is(&object));
+            assert!(reference.get_object_raw()?.is(&object));
+            assert_eq!(
+                reference.get_type().to_string(),
+                "<class 'weakref.ProxyType'>"
+            );
+
+            assert_eq!(
+                reference.getattr("__class__")?.to_string(),
+                "<class 'builtins.WeakrefablePyClass'>"
+            );
+            assert_eq!(
+                reference.repr()?.to_string(),
+                format!(
+                    "<weakproxy at {:x?} to builtins.WeakrefablePyClass at {:x?}>",
+                    reference.as_ptr(),
+                    object.as_ptr()
+                )
+            );
+
+            assert!(reference
+                .getattr("__callback__")
+                .is_err_and(|err| err.is_instance_of::<PyAttributeError>(py)));
+
+            drop(object);
+
+            assert!(reference.get_object_raw()?.is_none());
+            assert!(reference
+                .getattr("__class__")
+                .is_err_and(|err| err.is_instance_of::<PyReferenceError>(py)));
+            assert_eq!(
+                reference.repr()?.to_string(),
+                format!(
+                    "<weakproxy at {:x?} to NoneType at {:x?}>",
+                    reference.as_ptr(),
+                    py.None().as_ptr()
+                )
+            );
+
+            assert!(reference
+                .getattr("__callback__")
+                .is_err_and(|err| err.is_instance_of::<PyReferenceError>(py)));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_weakref_upgrade() -> PyResult<()> {
+        Python::with_gil(|py| {
+            let object = Py::new(py, WeakrefablePyClass {})?;
+            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+
+            {
+                let obj = reference.upgrade::<WeakrefablePyClass>();
+
+                assert!(obj.is_ok());
+                let obj = obj.unwrap();
+
+                assert!(obj.is_some());
+                assert!(obj.is_some_and(|obj| obj.as_ptr() == object.as_ptr()));
+            }
+
+            drop(object);
+
+            {
+                let obj = reference.upgrade::<WeakrefablePyClass>();
+
+                assert!(obj.is_ok());
+                let obj = obj.unwrap();
+
+                assert!(obj.is_none());
+            }
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_weakref_get_object() -> PyResult<()> {
+        Python::with_gil(|py| {
+            let object = Py::new(py, WeakrefablePyClass {})?;
+            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+
+            assert!(reference.get_object()?.is_some());
+            assert!(reference.get_object()?.is_some_and(|obj| obj.is(&object)));
+
+            drop(object);
+
+            assert!(reference.get_object()?.is_none());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_weakref_borrrow_object() -> PyResult<()> {
+        Python::with_gil(|py| {
+            let object = Py::new(py, WeakrefablePyClass {})?;
+            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+
+            assert!(reference.borrow_object()?.is_some());
+            assert!(reference
+                .borrow_object()?
+                .is_some_and(|obj| obj.is(&object)));
+
+            drop(object);
+
+            assert!(reference.borrow_object()?.is_none());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_weakref_get_object_raw() -> PyResult<()> {
+        Python::with_gil(|py| {
+            let object = Py::new(py, WeakrefablePyClass {})?;
+            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+
+            assert!(reference.get_object_raw()?.is(&object));
+
+            drop(object);
+
+            assert!(reference.get_object_raw()?.is_none());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_weakref_borrow_object_raw() -> PyResult<()> {
+        Python::with_gil(|py| {
+            let object = Py::new(py, WeakrefablePyClass {})?;
+            let reference = PyWeakProxy::new_bound(py, object.clone_ref(py))?;
+
+            assert!(reference.borrow_object_raw()?.is(&object));
+
+            drop(object);
+
+            assert!(reference.borrow_object_raw()?.is_none());
+
+            Ok(())
+        })
+    }
+}

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -15,7 +15,7 @@ pyobject_native_type!(
     ffi::PyWeakReference,
     pyobject_native_static_type_object!(ffi::_PyWeakref_RefType),
     #module=Some("weakref"),
-    #checkfunction=ffi::PyWeakref_CheckRef
+    #checkfunction=ffi::PyWeakref_CheckRefExact
 );
 
 impl PyWeakRef {
@@ -349,7 +349,7 @@ pub trait PyWeakRefMethods<'py> {
     /// Upgrade the weakref to a direct Bound object reference.
     ///
     /// It is named `upgrade` to be inline with [rust's `Weak::upgrade`](std::rc::Weak::upgrade).
-    /// In Python it would be equivalent to [`PyWeakref_GetObject`] or calling the [`weakref.ReferenceType`] (result of calling [`weakref.ref`]).
+    /// In Python it would be equivalent to [`PyWeakref_GetObject`].
     ///
     /// # Example
     /// ```rust
@@ -424,7 +424,7 @@ pub trait PyWeakRefMethods<'py> {
     /// This function returns `Some(Bound<'py, PyAny>)` if the reference still exists, otherwise `None` will be returned.
     ///
     /// This function gets the optional target of this [`weakref.ReferenceType`] (result of calling [`weakref.ref`]).
-    /// It produces similair results to calling the `weakref.ReferenceType` or using [`PyWeakref_GetObject`] in the C api.
+    /// It produces similair results to using [`PyWeakref_GetObject`] in the C api.
     ///
     /// # Example
     /// ```rust
@@ -479,7 +479,7 @@ pub trait PyWeakRefMethods<'py> {
     /// This function returns `Some(Borrowed<'_, 'py, PyAny>)` if the reference still exists, otherwise `None` will be returned.
     ///
     /// This function gets the optional target of this [`weakref.ReferenceType`] (result of calling [`weakref.ref`]).
-    /// It produces similair results to calling the `weakref.ReferenceType` or using [`PyWeakref_GetObject`] in the C api.
+    /// It produces similair results to using [`PyWeakref_GetObject`] in the C api.
     ///
     /// # Example
     /// ```rust
@@ -534,7 +534,7 @@ pub trait PyWeakRefMethods<'py> {
     /// This function returns `Bound<'py, PyAny>`, which is either the object if it still exists, otherwise it will refer to [`PyNone`](crate::types::none::PyNone).
     ///
     /// This function gets the optional target of this [`weakref.ReferenceType`] (result of calling [`weakref.ref`]).
-    /// It produces similair results to calling the `weakref.ReferenceType` or using [`PyWeakref_GetObject`] in the C api.
+    /// It produces similair results to using [`PyWeakref_GetObject`] in the C api.
     ///
     /// # Example
     /// ```rust
@@ -587,7 +587,7 @@ pub trait PyWeakRefMethods<'py> {
     /// This function returns `Borrowed<'py, PyAny>`, which is either the object if it still exists, otherwise it will refer to [`PyNone`](crate::types::none::PyNone).
     ///
     /// This function gets the optional target of this [`weakref.ReferenceType`] (result of calling [`weakref.ref`]).
-    /// It produces similair results to calling the `weakref.ReferenceType` or using [`PyWeakref_GetObject`] in the C api.
+    /// It produces similair results to  using [`PyWeakref_GetObject`] in the C api.
     ///
     /// # Example
     /// ```rust
@@ -698,6 +698,8 @@ mod tests {
                 .getattr("__callback__")
                 .is_ok_and(|result| result.is_none()));
 
+            assert!(reference.call0()?.is(&object));
+
             drop(object);
 
             assert!(reference.get_object_raw()?.is_none());
@@ -713,6 +715,8 @@ mod tests {
             assert!(reference
                 .getattr("__callback__")
                 .is_ok_and(|result| result.is_none()));
+
+            assert!(reference.call0()?.is_none());
 
             Ok(())
         })


### PR DESCRIPTION
#3134 Add `PyWeakRef`, `PyWeakProxy` and `PyWeakCallableProxy` types, corresponding to Python's `weakref.ReferenceType`, `weakref.ProxyType` and `weakref.CallableProxyType`.