### PR TITLE
allow `from_py_with` on function args to take a `fn(&Bound) -> PyResult`

### DIFF
--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -217,18 +217,18 @@ fn impl_arg_param(
             quote_arg_span! {
                 #[allow(clippy::redundant_closure)]
                 _pyo3::impl_::extract_argument::from_py_with_with_default(
-                    #arg_value,
+                    #arg_value.map(_pyo3::PyNativeType::as_borrowed).as_deref(),
                     #name_str,
-                    #expr_path,
+                    #expr_path as fn(_) -> _,
                     || #default
                 )?
             }
         } else {
             quote_arg_span! {
                 _pyo3::impl_::extract_argument::from_py_with(
-                    _pyo3::impl_::extract_argument::unwrap_required_argument(#arg_value),
+                    &_pyo3::impl_::extract_argument::unwrap_required_argument(#arg_value).as_borrowed(),
                     #name_str,
-                    #expr_path,
+                    #expr_path as fn(_) -> _,
                 )?
             }
         }

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -133,12 +133,12 @@ where
 
 /// Alternative to [`extract_argument`] used when the argument has a `#[pyo3(from_py_with)]` annotation.
 #[doc(hidden)]
-pub fn from_py_with<'py, T>(
-    obj: &'py PyAny,
+pub fn from_py_with<'a, 'py, T>(
+    obj: &'a Bound<'py, PyAny>,
     arg_name: &str,
-    extractor: fn(&'py PyAny) -> PyResult<T>,
+    extractor: impl Into<super::frompyobject::Extractor<'a, 'py, T>>,
 ) -> PyResult<T> {
-    match extractor(obj) {
+    match extractor.into().call(obj) {
         Ok(value) => Ok(value),
         Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e)),
     }
@@ -146,10 +146,10 @@ pub fn from_py_with<'py, T>(
 
 /// Alternative to [`extract_argument`] used when the argument has a `#[pyo3(from_py_with)]` annotation and also a default value.
 #[doc(hidden)]
-pub fn from_py_with_with_default<'py, T>(
-    obj: Option<&'py PyAny>,
+pub fn from_py_with_with_default<'a, 'py, T>(
+    obj: Option<&'a Bound<'py, PyAny>>,
     arg_name: &str,
-    extractor: fn(&'py PyAny) -> PyResult<T>,
+    extractor: impl Into<super::frompyobject::Extractor<'a, 'py, T>>,
     default: fn() -> T,
 ) -> PyResult<T> {
     match obj {

--- a/src/impl_/frompyobject.rs
+++ b/src/impl_/frompyobject.rs
@@ -20,7 +20,7 @@ impl<'a, T> From<fn(&'a PyAny) -> PyResult<T>> for Extractor<'a, '_, T> {
 }
 
 impl<'a, 'py, T> Extractor<'a, 'py, T> {
-    fn call(self, obj: &'a Bound<'py, PyAny>) -> PyResult<T> {
+    pub(crate) fn call(self, obj: &'a Bound<'py, PyAny>) -> PyResult<T> {
         match self {
             Extractor::Bound(f) => f(obj),
             Extractor::GilRef(f) => f(obj.as_gil_ref()),


### PR DESCRIPTION
Part of #3684 

This allows the `#[pyfunction]` and `#[pymethod]` arguments to use `Bound` API extractors in `#[pyo3(from_py_with = ...)]`. I reused the internal `Extractor` implementation that I recently introduced in #3828. For now I left it where I added it initially, but if we like to move it to a different place or module, I can do that. 

There is still a lot of old APIs surrounding this, but it might be better to tackle them separately.
