### PR TITLE
port `PyErr::warn` to `Bound` API

### DIFF
--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -52,7 +52,9 @@ use crate::types::{
 };
 #[cfg(Py_LIMITED_API)]
 use crate::{intern, DowncastError};
-use crate::{Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject};
+use crate::{
+    Bound, FromPyObject, IntoPy, PyAny, PyErr, PyNativeType, PyObject, PyResult, Python, ToPyObject,
+};
 use chrono::offset::{FixedOffset, Utc};
 use chrono::{
     DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike,
@@ -457,9 +459,9 @@ fn naive_datetime_to_py_datetime(
 
 fn warn_truncated_leap_second(obj: &Bound<'_, PyAny>) {
     let py = obj.py();
-    if let Err(e) = PyErr::warn(
+    if let Err(e) = PyErr::warn_bound(
         py,
-        py.get_type::<PyUserWarning>(),
+        &py.get_type::<PyUserWarning>().as_borrowed(),
         "ignored leap-second, `datetime` does not support leap-seconds",
         0,
     ) {

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -445,6 +445,30 @@ impl PyErr {
         }
     }
 
+    /// Deprecated form of [`PyErr::new_type_bound`]
+    #[cfg_attr(
+        not(feature = "gil-refs"),
+        deprecated(
+            since = "0.21.0",
+            note = "`PyErr::new_type` will be replaced by `PyErr::new_type_bound` in a future PyO3 version"
+        )
+    )]
+    pub fn new_type(
+        py: Python<'_>,
+        name: &str,
+        doc: Option<&str>,
+        base: Option<&PyType>,
+        dict: Option<PyObject>,
+    ) -> PyResult<Py<PyType>> {
+        Self::new_type_bound(
+            py,
+            name,
+            doc,
+            base.map(PyNativeType::as_borrowed).as_deref(),
+            dict,
+        )
+    }
+
     /// Creates a new exception type with the given name and docstring.
     ///
     /// - `base` can be an existing exception type to subclass, or a tuple of classes.
@@ -459,11 +483,11 @@ impl PyErr {
     /// # Panics
     ///
     /// This function will panic if  `name` or `doc` cannot be converted to [`CString`]s.
-    pub fn new_type(
-        py: Python<'_>,
+    pub fn new_type_bound<'py>(
+        py: Python<'py>,
         name: &str,
         doc: Option<&str>,
-        base: Option<&PyType>,
+        base: Option<&Bound<'py, PyType>>,
         dict: Option<PyObject>,
     ) -> PyResult<Py<PyType>> {
         let base: *mut ffi::PyObject = match base {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -240,16 +240,17 @@ macro_rules! create_exception_type_object {
         impl $name {
             fn type_object_raw(py: $crate::Python<'_>) -> *mut $crate::ffi::PyTypeObject {
                 use $crate::sync::GILOnceCell;
+                use $crate::PyNativeType;
                 static TYPE_OBJECT: GILOnceCell<$crate::Py<$crate::types::PyType>> =
                     GILOnceCell::new();
 
                 TYPE_OBJECT
                     .get_or_init(py, ||
-                        $crate::PyErr::new_type(
+                        $crate::PyErr::new_type_bound(
                             py,
                             concat!(stringify!($module), ".", stringify!($name)),
                             $doc,
-                            ::std::option::Option::Some(py.get_type::<$base>()),
+                            ::std::option::Option::Some(&py.get_type::<$base>().as_borrowed()),
                             ::std::option::Option::None,
                         ).expect("Failed to initialize new exception type.")
                 ).as_ptr() as *mut $crate::ffi::PyTypeObject


### PR DESCRIPTION
Part of #3684 

This ports `PyErr::warn`, `PyErr::warn_explicit` and `PyErr::new_type` to the `Bound` API.