### PR TITLE
Add PyTypeMethods trait with qualname method

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -946,10 +946,11 @@ struct PyDowncastErrorArguments {
 
 impl PyErrArguments for PyDowncastErrorArguments {
     fn arguments(self, py: Python<'_>) -> PyObject {
+        use crate::types::typeobject::PyTypeMethods;
         format!(
             "'{}' object cannot be converted to '{}'",
             self.from
-                .as_ref(py)
+                .bind(py)
                 .qualname()
                 .as_deref()
                 .unwrap_or("<failed to extract type name>"),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -41,3 +41,4 @@ pub use crate::types::set::PySetMethods;
 pub use crate::types::string::PyStringMethods;
 pub use crate::types::traceback::PyTracebackMethods;
 pub use crate::types::tuple::PyTupleMethods;
+pub use crate::types::typeobject::PyTypeMethods;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -309,4 +309,4 @@ mod slice;
 pub(crate) mod string;
 pub(crate) mod traceback;
 pub(crate) mod tuple;
-mod typeobject;
+pub(crate) mod typeobject;

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -87,7 +87,7 @@ impl ClassMethod {
     fn method_owned(cls: Py<PyType>) -> PyResult<String> {
         Ok(format!(
             "{}.method_owned()!",
-            Python::with_gil(|gil| cls.as_ref(gil).qualname())?
+            Python::with_gil(|gil| cls.bind(gil).qualname())?
         ))
     }
 }


### PR DESCRIPTION
This allows calling `Bound<'py, PyType>::qualname()`.