### PR TITLE
ci: disable some benchmarks volatile on codspeed

### DIFF
--- a/pyo3-benches/benches/bench_dict.rs
+++ b/pyo3-benches/benches/bench_dict.rs
@@ -69,6 +69,7 @@ fn extract_hashbrown_map(b: &mut Bencher<'_>) {
     });
 }
 
+#[cfg(not(codspeed))]
 fn mapping_from_dict(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
@@ -87,6 +88,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     #[cfg(feature = "hashbrown")]
     c.bench_function("extract_hashbrown_map", extract_hashbrown_map);
 
+    #[cfg(not(codspeed))]
     c.bench_function("mapping_from_dict", mapping_from_dict);
 }
 

--- a/pyo3-benches/benches/bench_extract.rs
+++ b/pyo3-benches/benches/bench_extract.rs
@@ -70,6 +70,7 @@ fn extract_int_extract_fail(bench: &mut Bencher<'_>) {
     });
 }
 
+#[cfg(not(codspeed))]
 fn extract_int_downcast_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let int_obj: PyObject = 123.into_py(py);
@@ -83,6 +84,7 @@ fn extract_int_downcast_success(bench: &mut Bencher<'_>) {
     });
 }
 
+#[cfg(not(codspeed))]
 fn extract_int_downcast_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let d = PyDict::new_bound(py).into_any();
@@ -94,6 +96,7 @@ fn extract_int_downcast_fail(bench: &mut Bencher<'_>) {
     });
 }
 
+#[cfg(not(codspeed))]
 fn extract_float_extract_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let float_obj: PyObject = 23.42.into_py(py);
@@ -117,6 +120,7 @@ fn extract_float_extract_fail(bench: &mut Bencher<'_>) {
     });
 }
 
+#[cfg(not(codspeed))]
 fn extract_float_downcast_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let float_obj: PyObject = 23.42.into_py(py);
@@ -147,15 +151,20 @@ fn criterion_benchmark(c: &mut Criterion) {
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     c.bench_function("extract_str_downcast_success", extract_str_downcast_success);
     c.bench_function("extract_str_downcast_fail", extract_str_downcast_fail);
+    #[cfg(not(codspeed))]
     c.bench_function("extract_int_extract_success", extract_int_extract_success);
     c.bench_function("extract_int_extract_fail", extract_int_extract_fail);
+    #[cfg(not(codspeed))]
     c.bench_function("extract_int_downcast_success", extract_int_downcast_success);
+    #[cfg(not(codspeed))]
     c.bench_function("extract_int_downcast_fail", extract_int_downcast_fail);
+    #[cfg(not(codspeed))]
     c.bench_function(
         "extract_float_extract_success",
         extract_float_extract_success,
     );
     c.bench_function("extract_float_extract_fail", extract_float_extract_fail);
+    #[cfg(not(codspeed))]
     c.bench_function(
         "extract_float_downcast_success",
         extract_float_downcast_success,

--- a/pyo3-benches/benches/bench_frompyobject.rs
+++ b/pyo3-benches/benches/bench_frompyobject.rs
@@ -20,6 +20,7 @@ fn enum_from_pyobject(b: &mut Bencher<'_>) {
     })
 }
 
+#[cfg(not(codspeed))]
 fn list_via_downcast(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let any: &Bound<'_, PyAny> = &PyList::empty_bound(py);
@@ -28,6 +29,7 @@ fn list_via_downcast(b: &mut Bencher<'_>) {
     })
 }
 
+#[cfg(not(codspeed))]
 fn list_via_extract(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let any: &Bound<'_, PyAny> = &PyList::empty_bound(py);
@@ -36,6 +38,7 @@ fn list_via_extract(b: &mut Bencher<'_>) {
     })
 }
 
+#[cfg(not(codspeed))]
 fn not_a_list_via_downcast(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let any: &Bound<'_, PyAny> = &PyString::new_bound(py, "foobar");
@@ -70,6 +73,7 @@ fn not_a_list_via_extract_enum(b: &mut Bencher<'_>) {
     })
 }
 
+#[cfg(not(codspeed))]
 fn f64_from_pyobject(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let obj = &PyFloat::new_bound(py, 1.234);
@@ -79,11 +83,15 @@ fn f64_from_pyobject(b: &mut Bencher<'_>) {
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("enum_from_pyobject", enum_from_pyobject);
+    #[cfg(not(codspeed))]
     c.bench_function("list_via_downcast", list_via_downcast);
+    #[cfg(not(codspeed))]
     c.bench_function("list_via_extract", list_via_extract);
+    #[cfg(not(codspeed))]
     c.bench_function("not_a_list_via_downcast", not_a_list_via_downcast);
     c.bench_function("not_a_list_via_extract", not_a_list_via_extract);
     c.bench_function("not_a_list_via_extract_enum", not_a_list_via_extract_enum);
+    #[cfg(not(codspeed))]
     c.bench_function("f64_from_pyobject", f64_from_pyobject);
 }
 

--- a/pyo3-benches/benches/bench_list.rs
+++ b/pyo3-benches/benches/bench_list.rs
@@ -55,6 +55,7 @@ fn list_get_item_unchecked(b: &mut Bencher<'_>) {
     });
 }
 
+#[cfg(not(codspeed))]
 fn sequence_from_list(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
@@ -69,6 +70,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("list_get_item", list_get_item);
     #[cfg(not(Py_LIMITED_API))]
     c.bench_function("list_get_item_unchecked", list_get_item_unchecked);
+    #[cfg(not(codspeed))]
     c.bench_function("sequence_from_list", sequence_from_list);
 }
 

--- a/pyo3-benches/benches/bench_tuple.rs
+++ b/pyo3-benches/benches/bench_tuple.rs
@@ -89,6 +89,7 @@ fn tuple_get_borrowed_item_unchecked(b: &mut Bencher<'_>) {
     });
 }
 
+#[cfg(not(codspeed))]
 fn sequence_from_tuple(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
@@ -131,6 +132,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         "tuple_get_borrowed_item_unchecked",
         tuple_get_borrowed_item_unchecked,
     );
+    #[cfg(not(codspeed))]
     c.bench_function("sequence_from_tuple", sequence_from_tuple);
     c.bench_function("tuple_new_list", tuple_new_list);
     c.bench_function("tuple_to_list", tuple_to_list);


### PR DESCRIPTION
To reduce noise on PRs which might deter or distract contributors, I propose to switch off some benchmarks from codspeed which produce a lot of volatility.

One day maybe we get to the bottom of a cause. Also I understand from @art049 a possible future feature for codspeed would be configurable volatility allowance per benchmark, which would let us reenable these but with a high volatility expected.