### PR TITLE
Replace as_ref(py) with Bound APIs

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -957,7 +957,7 @@ impl PyErrArguments for PyDowncastErrorArguments {
         format!(
             "'{}' object cannot be converted to '{}'",
             self.from
-                .as_ref(py)
+                .bind(py)
                 .qualname()
                 .as_deref()
                 .unwrap_or("<failed to extract type name>"),

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -11,6 +11,7 @@ use crate::{
         pymethods::{get_doc, get_name, Getter, Setter},
         trampoline::trampoline,
     },
+    types::typeobject::PyTypeMethods,
     types::PyType,
     Py, PyCell, PyClass, PyGetterDef, PyMethodDefType, PyResult, PySetterDef, PyTypeInfo, Python,
 };
@@ -435,7 +436,7 @@ impl PyTypeBuilder {
         bpo_45315_workaround(py, class_name);
 
         for cleanup in std::mem::take(&mut self.cleanup) {
-            cleanup(&self, type_object.as_ref(py).as_type_ptr());
+            cleanup(&self, type_object.bind(py).as_type_ptr());
         }
 
         Ok(PyClassTypeObject {

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -74,7 +74,7 @@ impl ClassMethod {
     #[classmethod]
     /// Test class method.
     fn method(cls: &Bound<'_, PyType>) -> PyResult<String> {
-        Ok(format!("{}.method()!", cls.as_gil_ref().qualname()?))
+        Ok(format!("{}.method()!", cls.qualname()?))
     }
 
     #[classmethod]
@@ -85,10 +85,8 @@ impl ClassMethod {
 
     #[classmethod]
     fn method_owned(cls: Py<PyType>) -> PyResult<String> {
-        Ok(format!(
-            "{}.method_owned()!",
-            Python::with_gil(|gil| cls.as_ref(gil).qualname())?
-        ))
+        let qualname = Python::with_gil(|gil| cls.bind(gil).qualname())?;
+        Ok(format!("{}.method_owned()!", qualname))
     }
 }
 


### PR DESCRIPTION
Following the merge of #3705 we can tidy these up.