### PR TITLE
update `py.import` -> `py.import_bound` in benches

### DIFF
--- a/pyo3-benches/benches/bench_intern.rs
+++ b/pyo3-benches/benches/bench_intern.rs
@@ -6,7 +6,7 @@ use pyo3::intern;
 
 fn getattr_direct(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let sys = py.import("sys").unwrap();
+        let sys = py.import_bound("sys").unwrap();
 
         b.iter(|| sys.getattr("version").unwrap());
     });
@@ -14,7 +14,7 @@ fn getattr_direct(b: &mut Bencher<'_>) {
 
 fn getattr_intern(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let sys = py.import("sys").unwrap();
+        let sys = py.import_bound("sys").unwrap();
 
         b.iter(|| sys.getattr(intern!(py, "version")).unwrap());
     });


### PR DESCRIPTION
Just noticed this while fixing #3861 