### PR TITLE
Add `Py::drop_ref` method

### DIFF
--- a/newsfragments/3871.added.md
+++ b/newsfragments/3871.added.md
@@ -1,0 +1,1 @@
+Add `Py::drop_ref` to explicitly drop a `Py`` and immediately decrease the Python reference count if the GIL is already held.

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2162,6 +2162,22 @@ a = A()
         })
     }
 
+    #[test]
+    fn explicit_drop_ref() {
+        Python::with_gil(|py| {
+            let object: Py<PyDict> = PyDict::new_bound(py).unbind();
+            let object2 = object.clone_ref(py);
+
+            assert_eq!(object.get_refcnt(), 2);
+
+            object.drop_ref(py);
+
+            assert_eq!(object.get_refcnt(), 1);
+
+            object2.drop_ref(py);
+        });
+    }
+
     #[cfg(feature = "macros")]
     mod using_macros {
         use crate::PyCell;

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2168,11 +2168,12 @@ a = A()
             let object: Py<PyDict> = PyDict::new_bound(py).unbind();
             let object2 = object.clone_ref(py);
 
+            assert_eq!(object.as_ptr(), object2.as_ptr());
             assert_eq!(object.get_refcnt(py), 2);
 
             object.drop_ref(py);
 
-            assert_eq!(object.get_refcnt(py), 1);
+            assert_eq!(object2.get_refcnt(py), 1);
 
             object2.drop_ref(py);
         });

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1224,6 +1224,9 @@ impl<T> Py<T> {
     /// This method is a micro-optimisation over [`Drop`] if you happen to be holding the GIL
     /// already.
     ///
+    /// Note that if you are using [`Bound`], you do not need to use [`Self::drop_ref`] since
+    /// [`Bound`] guarantees that the GIL is held.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1242,10 +1245,7 @@ impl<T> Py<T> {
     /// ```
     #[inline]
     pub fn drop_ref(self, py: Python<'_>) {
-        let _py = py;
-
-        // Safety: we hold the GIL and forget `self` to not trigger a double free
-        unsafe { ffi::Py_DECREF(self.into_ptr()) };
+        let _ = self.into_bound(py);
     }
 
     /// Returns whether the object is considered to be None.

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2168,11 +2168,11 @@ a = A()
             let object: Py<PyDict> = PyDict::new_bound(py).unbind();
             let object2 = object.clone_ref(py);
 
-            assert_eq!(object.get_refcnt(), 2);
+            assert_eq!(object.get_refcnt(py), 2);
 
             object.drop_ref(py);
 
-            assert_eq!(object.get_refcnt(), 1);
+            assert_eq!(object.get_refcnt(py), 1);
 
             object2.drop_ref(py);
         });

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1245,7 +1245,7 @@ impl<T> Py<T> {
         let _py = py;
 
         // Safety: we hold the GIL and forget `self` to not trigger a double free
-        unsafe { pyo3::ffi::Py_DECREF(self.into_ptr()) };
+        unsafe { ffi::Py_DECREF(self.into_ptr()) };
     }
 
     /// Returns whether the object is considered to be None.


### PR DESCRIPTION
Adds the `Py::drop_ref` method to explicitly drop a `Py` and immediately decrease the Python reference count if the GIL is already held.

Fixes #3870 