### PR TITLE
ci: fix redundant import warnings on nightly

### DIFF
--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -206,7 +206,6 @@ assert hash_djb2('l50_50') == Number(-1152549421)
 ```rust
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::convert::TryInto;
 
 use pyo3::exceptions::{PyValueError, PyZeroDivisionError};
 use pyo3::prelude::*;

--- a/guide/src/python_from_rust.md
+++ b/guide/src/python_from_rust.md
@@ -181,7 +181,7 @@ quickly testing your Python extensions.
 
 ```rust
 use pyo3::prelude::*;
-use pyo3::{PyCell, py_run};
+use pyo3::py_run;
 
 # fn main() {
 #[pyclass]
@@ -228,7 +228,7 @@ to this function!
 ```rust
 use pyo3::{
     prelude::*,
-    types::{IntoPyDict, PyModule},
+    types::IntoPyDict,
 };
 
 # fn main() -> PyResult<()> {
@@ -437,7 +437,6 @@ Use context managers by directly invoking `__enter__` and `__exit__`.
 
 ```rust
 use pyo3::prelude::*;
-use pyo3::types::PyModule;
 
 fn main() {
     Python::with_gil(|py| {

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -8,7 +8,6 @@ mod import_lib;
 
 use std::{
     collections::{HashMap, HashSet},
-    convert::AsRef,
     env,
     ffi::{OsStr, OsString},
     fmt::Display,
@@ -1785,7 +1784,6 @@ fn unescape(escaped: &str) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::FromIterator;
     use target_lexicon::triple;
 
     use super::*;

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1097,7 +1097,6 @@ mod tests {
     mod proptests {
         use super::*;
         use crate::tests::common::CatchWarnings;
-        use crate::types::any::PyAnyMethods;
         use crate::types::IntoPyDict;
         use proptest::prelude::*;
 

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -112,7 +112,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::any::PyAnyMethods;
 
     #[test]
     fn test_hashbrown_hashmap_to_python() {

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -48,11 +48,11 @@
 //! ```
 
 #[cfg(Py_LIMITED_API)]
-use crate::types::bytes::PyBytesMethods;
+use crate::types::{bytes::PyBytesMethods, PyBytes};
 use crate::{
     ffi,
     instance::Bound,
-    types::{any::PyAnyMethods, *},
+    types::{any::PyAnyMethods, PyLong},
     FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject,
 };
 
@@ -85,7 +85,7 @@ macro_rules! bigint_conversion {
                 let bytes = $to_bytes(self);
                 let bytes_obj = PyBytes::new_bound(py, &bytes);
                 let kwargs = if $is_signed > 0 {
-                    let kwargs = PyDict::new_bound(py);
+                    let kwargs = crate::types::PyDict::new_bound(py);
                     kwargs.set_item(crate::intern!(py, "signed"), true).unwrap();
                     Some(kwargs)
                 } else {
@@ -224,7 +224,7 @@ fn int_to_py_bytes<'py>(
     use crate::intern;
     let py = long.py();
     let kwargs = if is_signed {
-        let kwargs = PyDict::new_bound(py);
+        let kwargs = crate::types::PyDict::new_bound(py);
         kwargs.set_item(intern!(py, "signed"), true)?;
         Some(kwargs)
     } else {
@@ -261,8 +261,6 @@ fn int_n_bits(long: &Bound<'_, PyLong>) -> PyResult<usize> {
 
 #[cfg(test)]
 mod tests {
-    use self::{any::PyAnyMethods, dict::PyDictMethods};
-
     use super::*;
     use crate::types::{PyDict, PyModule};
     use indoc::indoc;

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -108,10 +108,8 @@ impl IntoPy<PyObject> for Decimal {
 mod test_rust_decimal {
     use super::*;
     use crate::err::PyErr;
-    use crate::types::any::PyAnyMethods;
     use crate::types::dict::PyDictMethods;
     use crate::types::PyDict;
-    use rust_decimal::Decimal;
 
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -97,7 +97,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{any::PyAnyMethods, PyDict, PyList};
+    use crate::types::{PyDict, PyList};
 
     #[test]
     fn test_smallvec_into_py() {

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -111,7 +111,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{IntoPy, PyObject, Python, ToPyObject};
     use std::collections::{BTreeMap, HashMap};
 
     #[test]

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -5,7 +5,6 @@ use crate::{
     exceptions, ffi, Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
     ToPyObject,
 };
-use std::convert::TryFrom;
 use std::num::{
     NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
     NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
@@ -371,7 +370,6 @@ nonzero_int_impl!(NonZeroUsize, usize);
 #[cfg(test)]
 mod test_128bit_integers {
     use super::*;
-    use crate::types::any::PyAnyMethods;
 
     #[cfg(not(target_arch = "wasm32"))]
     use crate::types::PyDict;

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -842,7 +842,7 @@ mod tests {
     use super::*;
     use crate::types::any::PyAnyMethods;
     use crate::types::{IntoPyDict, PyDict};
-    use crate::{PyErr, PyNativeType, Python};
+    use crate::{PyErr, PyNativeType};
 
     import_exception!(socket, gaierror);
     import_exception!(email.errors, MessageError);

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1166,7 +1166,7 @@ impl<'unbound> Python<'unbound> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{any::PyAnyMethods, IntoPyDict, PyDict, PyList};
+    use crate::types::{IntoPyDict, PyList};
     use std::sync::Arc;
 
     #[test]

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -17,7 +17,6 @@ use crate::{
 use std::{
     borrow::Cow,
     collections::HashMap,
-    convert::TryInto,
     ffi::{CStr, CString},
     os::raw::{c_char, c_int, c_ulong, c_void},
     ptr,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -275,7 +275,7 @@ impl Interned {
 mod tests {
     use super::*;
 
-    use crate::types::{any::PyAnyMethods, dict::PyDictMethods, PyDict};
+    use crate::types::{dict::PyDictMethods, PyDict};
 
     #[test]
     fn test_intern() {

--- a/src/types/capsule.rs
+++ b/src/types/capsule.rs
@@ -1,8 +1,8 @@
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::{ffi, PyAny, PyNativeType};
-use crate::{pyobject_native_type_core, PyErr, PyResult};
 use crate::{Bound, Python};
+use crate::{PyErr, PyResult};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -735,9 +735,7 @@ mod tests {
     use super::*;
     #[cfg(not(PyPy))]
     use crate::exceptions;
-    #[cfg(not(PyPy))]
-    use crate::types::PyList;
-    use crate::{types::PyTuple, Python, ToPyObject};
+    use crate::types::PyTuple;
     use std::collections::{BTreeMap, HashMap};
 
     #[test]

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -1,7 +1,6 @@
 use crate::derive_utils::PyFunctionArguments;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::methods::PyMethodDefDestructor;
-use crate::prelude::*;
 use crate::py_result_ext::PyResultExt;
 use crate::types::capsule::PyCapsuleMethods;
 use crate::{
@@ -9,6 +8,7 @@ use crate::{
     impl_::pymethods::{self, PyMethodDef},
     types::{PyCapsule, PyDict, PyString, PyTuple},
 };
+use crate::{Bound, IntoPy, Py, PyAny, PyResult, Python};
 use std::cell::UnsafeCell;
 use std::ffi::CStr;
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::iter::FusedIterator;
 
 use crate::err::{self, PyResult};

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -286,11 +286,7 @@ impl<'v> crate::PyTryFrom<'v> for PyMapping {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::{
-        exceptions::PyKeyError,
-        types::{PyDict, PyTuple},
-        Python,
-    };
+    use crate::{exceptions::PyKeyError, types::PyTuple};
 
     use super::*;
 

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -514,10 +514,7 @@ impl IntoPy<Py<PyString>> for &'_ Py<PyString> {
 #[cfg_attr(not(feature = "gil-refs"), allow(deprecated))]
 mod tests {
     use super::*;
-    use crate::Python;
     use crate::{PyObject, ToPyObject};
-    #[cfg(not(Py_LIMITED_API))]
-    use std::borrow::Cow;
 
     #[test]
     fn test_to_str_utf8() {

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -116,8 +116,8 @@ impl<'py> PyTracebackMethods<'py> for Bound<'py, PyTraceback> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        prelude::*,
-        types::{traceback::PyTracebackMethods, PyDict},
+        types::{any::PyAnyMethods, dict::PyDictMethods, traceback::PyTracebackMethods, PyDict},
+        IntoPy, PyErr, Python,
     };
 
     #[test]

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::iter::FusedIterator;
 
 use crate::ffi::{self, Py_ssize_t};

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "macros")]
 
 use pyo3::prelude::*;
-use pyo3::ToPyObject;
 
 #[macro_use]
 #[path = "../src/tests/common.rs"]

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "macros")]
 
 use pyo3::prelude::*;
-use pyo3::{exceptions, py_run, PyErr, PyResult};
+use pyo3::{exceptions, py_run};
 use std::error::Error;
 use std::fmt;
 #[cfg(not(target_os = "windows"))]

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -3,7 +3,7 @@
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
 use pyo3::prelude::*;
-use pyo3::{py_run, PyCell};
+use pyo3::py_run;
 use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -398,6 +398,7 @@ impl HijackedTraverse {
     }
 }
 
+#[allow(dead_code)]
 trait Traversable {
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>;
 }

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -177,7 +177,7 @@ except Exception as e:
 mod inheriting_native_type {
     use super::*;
     use pyo3::exceptions::PyException;
-    use pyo3::types::{IntoPyDict, PyDict};
+    use pyo3::types::PyDict;
 
     #[cfg(not(PyPy))]
     #[test]

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -3,7 +3,6 @@
 use pyo3::prelude::*;
 use pyo3::py_run;
 use pyo3::types::{IntoPyDict, PyDict, PyList, PySet, PyString, PyTuple, PyType};
-use pyo3::PyCell;
 
 #[path = "../src/tests/common.rs"]
 mod common;

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -2,7 +2,7 @@
 
 use pyo3::exceptions::{PyAttributeError, PyIndexError, PyValueError};
 use pyo3::types::{PyDict, PyList, PyMapping, PySequence, PySlice, PyType};
-use pyo3::{prelude::*, py_run, PyCell};
+use pyo3::{prelude::*, py_run};
 use std::{isize, iter};
 
 #[path = "../src/tests/common.rs"]

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -3,7 +3,6 @@
 //! Test slf: PyRef/PyMutRef<Self>(especially, slf.into::<Py>) works
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
-use pyo3::PyCell;
 use std::collections::HashMap;
 
 #[path = "../src/tests/common.rs"]

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -2,7 +2,7 @@
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
-use pyo3::{types::PyType, wrap_pymodule, PyCell};
+use pyo3::{types::PyType, wrap_pymodule};
 
 #[path = "../src/tests/common.rs"]
 mod common;

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "macros")]
 
 use pyo3::prelude::*;
+use pyo3::py_run;
 use pyo3::types::{PyDict, PyTuple};
-use pyo3::{py_run, PyCell};
 
 use std::fmt;
 


### PR DESCRIPTION
Attempt to fix the build failure from redundant imports on nightly.

It's quite a nice new lint, picked up a lot!