### PR TITLE
ci: cancel in-progress benches job on push

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -9,6 +9,10 @@ on:
   # performance analysis in order to generate initial data.
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}-benches
+  cancel-in-progress: true
+
 jobs:
   benchmarks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Just noticed that this was missing and makes sense to add to avoid tying up resources on multiple pushes to PRs.