### PR TITLE
ci: rework GitHub caching strategy

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -23,14 +23,11 @@ jobs:
         with:
           components: rust-src
 
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            pyo3-benches/target
-            target
-          key: cargo-${{ runner.os }}-bench-${{ hashFiles('**/Cargo.toml') }}
+          workspaces: |
+            .
+            pyo3-benches
         continue-on-error: true
 
       - name: Install cargo-codspeed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: cargo-${{ inputs.python-architecture }}
-        continue-on-error: true
+          save-if: ${{ github.event_name != 'merge_group' }}
 
       - if: inputs.os == 'ubuntu-latest'
         name: Prepare LD_LIBRARY_PATH (Ubuntu only)

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,29 @@
+name: CI Cache Cleanup
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
   check-msrv:
     needs: [fmt]
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -57,8 +56,7 @@ jobs:
           architecture: "x64"
       - uses: Swatinem/rust-cache@v2
         with:
-          key: check-msrv-1.56.0
-        continue-on-error: true
+          save-if: ${{ github.event_name != 'merge_group' }}
       - run: python -m pip install --upgrade pip && pip install nox
       - name: Prepare minimal package versions
         run: nox -s set-minimal-package-versions
@@ -70,7 +68,6 @@ jobs:
   clippy:
     needs: [fmt]
     runs-on: ${{ matrix.platform.os }}
-    if: github.ref != 'refs/heads/main'
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
@@ -136,8 +133,7 @@ jobs:
           architecture: ${{ matrix.platform.python-architecture }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: clippy-${{ matrix.platform.rust-target }}-${{ matrix.platform.os }}-${{ matrix.rust }}
-        continue-on-error: true
+          save-if: ${{ github.event_name != 'merge_group' }}
       - run: python -m pip install --upgrade pip && pip install nox
       - run: nox -s clippy-all
     env:
@@ -199,7 +195,7 @@ jobs:
               }
             extra-features: "nightly multiple-pymethods"
   build-full:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} rust-${{ matrix.rust }}
     needs: [fmt]
     uses: ./.github/workflows/build.yml
@@ -293,7 +289,7 @@ jobs:
             extra-features: "multiple-pymethods"
 
   valgrind:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
@@ -301,8 +297,7 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: Swatinem/rust-cache@v2
         with:
-          key: cargo-valgrind
-        continue-on-error: true
+          save-if: ${{ github.event_name != 'merge_group' }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@valgrind
       - run: python -m pip install --upgrade pip && pip install nox
@@ -313,7 +308,7 @@ jobs:
       TRYBUILD: overwrite
 
   careful:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
@@ -321,8 +316,7 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: Swatinem/rust-cache@v2
         with:
-          key: cargo-careful
-        continue-on-error: true
+          save-if: ${{ github.event_name != 'merge_group' }}
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
@@ -334,7 +328,7 @@ jobs:
       TRYBUILD: overwrite
 
   docsrs:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
@@ -342,8 +336,7 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: Swatinem/rust-cache@v2
         with:
-          key: cargo-careful
-        continue-on-error: true
+          save-if: ${{ github.event_name != 'merge_group' }}
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
@@ -368,8 +361,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: steps.should-skip.outputs.skip != 'true'
         with:
-          key: coverage-cargo-${{ matrix.os }}
-        continue-on-error: true
+          save-if: ${{ github.event_name != 'merge_group' }}
       - uses: dtolnay/rust-toolchain@stable
         if: steps.should-skip.outputs.skip != 'true'
         with:
@@ -390,7 +382,7 @@ jobs:
 
   emscripten:
     name: emscripten
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -416,7 +408,7 @@ jobs:
           key: ${{ hashFiles('emscripten/*') }} - ${{ hashFiles('noxfile.py') }} - ${{ steps.setup-python.outputs.python-path }}
       - uses: Swatinem/rust-cache@v2
         with:
-          key: cargo-emscripten-wasm32
+          save-if: ${{ github.event_name != 'merge_group' }}
       - name: Build
         if: steps.cache.outputs.cache-hit != 'true'
         run: nox -s build-emscripten
@@ -425,14 +417,12 @@ jobs:
 
   test-debug:
     needs: [fmt]
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
-          key: cargo-test-debug
-        continue-on-error: true
+          save-if: ${{ github.event_name != 'merge_group' }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src
@@ -470,25 +460,27 @@ jobs:
 
   test-version-limits:
     needs: [fmt]
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-        continue-on-error: true
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
       - uses: dtolnay/rust-toolchain@stable
       - run: python3 -m pip install --upgrade pip && pip install nox
       - run: python3 -m nox -s test-version-limits
 
   check-feature-powerset:
     needs: [fmt]
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || (github.event_name != 'pull_request' && github.ref != 'refs/heads/main') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: Swatinem/rust-cache@v2
-        continue-on-error: true
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src


### PR DESCRIPTION
I realised today that we are facing many cache misses in CI because we skip running workflows on `main`, and GitHub Actions caches only populate from the default branch or the current branch.

So the vast majority of jobs will be cache misses until their branch is populated, because the default branch (`main`) runs nothing.

This PR therefore reworks things in an attempt to put some oomph back into our build times:
- I've set jobs to run on `main` just as they would in the merge queue
- I've removed the hardcoded keys to `Swatinem/rust-cache`, which shouldn't be necessary based on what it uses by default (job ID + OS + rust version)
- I've added two things to reduce cache thrashing:
  - A new `CI Cache Cleanup` workflow which is a direct copy of https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries, to eagerly purge branch caches when a PR gets merged or closed.
  - `save-if` setting to `Swatinem/rust-cache` to avoid uploading caches from the merge queue, as that will produce a bulk of largely useless cache.

If this looks like it builds, I'll probably merge it right away without review and hope it speeds up CI times. If it creates problems we can easily revert.