### PR TITLE
ci: run fmt unconditionally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ env:
 
 jobs:
   fmt:
-    if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -383,6 +382,7 @@ jobs:
   emscripten:
     name: emscripten
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
+    needs: [fmt]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Followup to #3886

My attempts to populate caches on `main` did not work because we gate all ci on `fmt` (because it's a cheap sanity check and no point running rest of CI if the fmt fails), and I had left that job skipped.

This PR fixes that, and at the same time gates `emscripten` job on `fmt` as a drive-by fixup.