### PR TITLE
move chat discussions to Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: Ask and answer questions about PyO3 on Discussions
   - name: 🔧 Troubleshooting
     url: https://github.com/PyO3/pyo3/discussions
-    about: For troubleshooting help, see the Discussions 
+    about: For troubleshooting help, see the Discussions
   - name: 👋 Chat
-    url: https://gitter.im/PyO3/Lobby
-    about: Engage with PyO3's users and developers on Gitter
+    url: https://discord.gg/c4BwayXQ
+    about: Engage with PyO3's users and developers on Discord

--- a/Contributing.md
+++ b/Contributing.md
@@ -29,7 +29,7 @@ To work and develop PyO3, you need Python & Rust installed on your system.
 
 ### Help users identify bugs
 
-The [PyO3 Gitter channel](https://gitter.im/PyO3/Lobby) is very active with users who are new to PyO3, and often completely new to Rust. Helping them debug is a great way to get experience with the PyO3 codebase.
+The [PyO3 Discord server](https://discord.gg/c4BwayXQ) is very active with users who are new to PyO3, and often completely new to Rust. Helping them debug is a great way to get experience with the PyO3 codebase.
 
 Helping others often reveals bugs, documentation weaknesses, and missing APIs. It's a good idea to open GitHub issues for these immediately so the resolution can be designed and implemented!
 
@@ -203,7 +203,7 @@ You can install an IDE plugin to view the coverage. For example, if you use VSCo
 
 ## Sponsor this project
 
-At the moment there is no official organisation that accepts sponsorship on PyO3's behalf. If you're seeking to provide significant funding to the PyO3 ecosystem, please reach out to us on [GitHub](https://github.com/PyO3/pyo3/issues/new) or [Gitter](https://gitter.im/PyO3/Lobby) and we can discuss.
+At the moment there is no official organisation that accepts sponsorship on PyO3's behalf. If you're seeking to provide significant funding to the PyO3 ecosystem, please reach out to us on [GitHub](https://github.com/PyO3/pyo3/issues/new) or [Discord](https://discord.gg/c4BwayXQ) and we can discuss.
 
 In the meanwhile, some of our maintainers have personal GitHub sponsorship pages and would be grateful for your support:
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://img.shields.io/codecov/c/gh/PyO3/pyo3?logo=codecov)](https://codecov.io/gh/PyO3/pyo3)
 [![crates.io](https://img.shields.io/crates/v/pyo3?logo=rust)](https://crates.io/crates/pyo3)
 [![minimum rustc 1.56](https://img.shields.io/badge/rustc-1.56+-blue?logo=rust)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
-[![dev chat](https://img.shields.io/gitter/room/PyO3/Lobby?logo=gitter)](https://gitter.im/PyO3/Lobby)
+[![discord server](https://img.shields.io/discord/1209263839632424990?logo=discord)](https://discord.gg/c4BwayXQ)
 [![contributing notes](https://img.shields.io/badge/contribute-on%20github-Green?logo=github)](https://github.com/PyO3/pyo3/blob/main/Contributing.md)
 
 [Rust](https://www.rust-lang.org/) bindings for [Python](https://www.python.org/), including tools for creating native Python extension modules. Running and interacting with Python code from a Rust binary is also supported.
@@ -237,7 +237,7 @@ about this topic.
 
 Everyone is welcomed to contribute to PyO3! There are many ways to support the project, such as:
 
-- help PyO3 users with issues on GitHub and Gitter
+- help PyO3 users with issues on GitHub and [Discord](https://discord.gg/c4BwayXQ)
 - improve documentation
 - write features and bugfixes
 - publish blogs and examples of how to use PyO3

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -1,5 +1,7 @@
 # Frequently Asked Questions and troubleshooting
 
+Sorry that you're having trouble using PyO3. If you can't find the answer to your problem in the list below, you can also reach out for help on [GitHub Discussions](https://github.com/PyO3/pyo3/discussions) and on [Discord](https://discord.gg/c4BwayXQ).
+
 ## I'm experiencing deadlocks using PyO3 with lazy_static or once_cell!
 
 `lazy_static` and `once_cell::sync` both use locks to ensure that initialization is performed only by a single thread. Because the Python GIL is an additional lock this can lead to deadlocks in the following way:
@@ -183,7 +185,7 @@ struct MyClass;
 
 ## I'm trying to call Python from Rust but I get `STATUS_DLL_NOT_FOUND` or `STATUS_ENTRYPOINT_NOT_FOUND`!
 
-This happens on Windows when linking to the python DLL fails or the wrong one is linked. The Python DLL on Windows will usually be called something like: 
+This happens on Windows when linking to the python DLL fails or the wrong one is linked. The Python DLL on Windows will usually be called something like:
 - `python3X.dll` for Python 3.X, e.g. `python310.dll` for Python 3.10
 - `python3.dll` when using PyO3's `abi3` feature
 

--- a/guide/src/getting_started.md
+++ b/guide/src/getting_started.md
@@ -2,6 +2,8 @@
 
 To get started using PyO3 you will need three things: a Rust toolchain, a Python environment, and a way to build. We'll cover each of these below.
 
+> If you'd like to chat to the PyO3 maintainers and other PyO3 users, consider joining the [PyO3 Discord server](https://discord.gg/c4BwayXQ). We're keen to hear about your experience getting started, so we can make PyO3 as accessible as possible for everyone!
+
 ## Rust
 
 First, make sure you have Rust installed on your system. If you haven't already done so, try following the instructions [here](https://www.rust-lang.org/tools/install). PyO3 runs on both the `stable` and `nightly` versions so you can choose whichever one fits you best. The minimum required Rust version is 1.56.


### PR DESCRIPTION
As a follow-up to #3857, this proposes to redirect traffic from Gitter to Discord. I'm sufficiently persuaded by the improvement in user experience that I think this is worth doing to help grow the community side of PyO3.