### PR TITLE
Update ModuleInitializer to handle Bound API

### DIFF
--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -93,7 +93,7 @@ pub fn pymodule_impl(
             use #krate::impl_::pymodule as impl_;
             impl #fnname::MakeDef {
                 const fn make_def() -> impl_::ModuleDef {
-                    const INITIALIZER: impl_::ModuleInitializer = impl_::ModuleInitializer(#fnname);
+                    const INITIALIZER: impl_::ModuleInitializer = ::std::convert::Into::into(#fnname);
                     unsafe {
                         impl_::ModuleDef::new(#fnname::NAME, #doc, INITIALIZER)
                     }


### PR DESCRIPTION
This allows us to make progress on deprecating `Py::as_ref` (#3864).