### PR TITLE
reexport `PyAnyMethods` and friends from `pyo3::types`

### DIFF
--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -87,8 +87,6 @@
 //! # if another hash table was used, the order could be random
 //! ```
 
-use crate::types::any::PyAnyMethods;
-use crate::types::dict::PyDictMethods;
 use crate::types::*;
 use crate::{Bound, FromPyObject, IntoPy, PyErr, PyObject, Python, ToPyObject};
 use std::{cmp, hash};
@@ -137,8 +135,6 @@ where
 #[cfg(test)]
 mod test_indexmap {
 
-    use crate::types::any::PyAnyMethods;
-    use crate::types::dict::PyDictMethods;
     use crate::types::*;
     use crate::{IntoPy, PyObject, Python, ToPyObject};
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,6 +39,7 @@ pub use crate::types::mapping::PyMappingMethods;
 pub use crate::types::module::PyModuleMethods;
 pub use crate::types::sequence::PySequenceMethods;
 pub use crate::types::set::PySetMethods;
+pub use crate::types::slice::PySliceMethods;
 pub use crate::types::string::PyStringMethods;
 pub use crate::types::traceback::PyTracebackMethods;
 pub use crate::types::tuple::PyTupleMethods;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,13 +1,13 @@
 //! Various types defined by the Python interpreter such as `int`, `str` and `tuple`.
 
-pub use self::any::PyAny;
-pub use self::boolobject::PyBool;
-pub use self::bytearray::PyByteArray;
-pub use self::bytes::PyBytes;
-pub use self::capsule::PyCapsule;
+pub use self::any::{PyAny, PyAnyMethods};
+pub use self::boolobject::{PyBool, PyBoolMethods};
+pub use self::bytearray::{PyByteArray, PyByteArrayMethods};
+pub use self::bytes::{PyBytes, PyBytesMethods};
+pub use self::capsule::{PyCapsule, PyCapsuleMethods};
 #[cfg(not(Py_LIMITED_API))]
 pub use self::code::PyCode;
-pub use self::complex::PyComplex;
+pub use self::complex::{PyComplex, PyComplexMethods};
 #[allow(deprecated)]
 #[cfg(not(Py_LIMITED_API))]
 pub use self::datetime::timezone_utc;
@@ -16,37 +16,37 @@ pub use self::datetime::{
     timezone_utc_bound, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime,
     PyTimeAccess, PyTzInfo, PyTzInfoAccess,
 };
-pub use self::dict::{IntoPyDict, PyDict};
+pub use self::dict::{IntoPyDict, PyDict, PyDictMethods};
 #[cfg(not(PyPy))]
 pub use self::dict::{PyDictItems, PyDictKeys, PyDictValues};
 pub use self::ellipsis::PyEllipsis;
-pub use self::float::PyFloat;
+pub use self::float::{PyFloat, PyFloatMethods};
 #[cfg(all(not(Py_LIMITED_API), not(PyPy)))]
 pub use self::frame::PyFrame;
-pub use self::frozenset::{PyFrozenSet, PyFrozenSetBuilder};
+pub use self::frozenset::{PyFrozenSet, PyFrozenSetBuilder, PyFrozenSetMethods};
 pub use self::function::PyCFunction;
 #[cfg(all(not(Py_LIMITED_API), not(PyPy)))]
 pub use self::function::PyFunction;
 pub use self::iterator::PyIterator;
-pub use self::list::PyList;
-pub use self::mapping::PyMapping;
+pub use self::list::{PyList, PyListMethods};
+pub use self::mapping::{PyMapping, PyMappingMethods};
 pub use self::memoryview::PyMemoryView;
-pub use self::module::PyModule;
+pub use self::module::{PyModule, PyModuleMethods};
 pub use self::none::PyNone;
 pub use self::notimplemented::PyNotImplemented;
 pub use self::num::PyLong;
 pub use self::num::PyLong as PyInt;
 #[cfg(not(PyPy))]
 pub use self::pysuper::PySuper;
-pub use self::sequence::PySequence;
-pub use self::set::PySet;
-pub use self::slice::{PySlice, PySliceIndices};
+pub use self::sequence::{PySequence, PySequenceMethods};
+pub use self::set::{PySet, PySetMethods};
+pub use self::slice::{PySlice, PySliceIndices, PySliceMethods};
 #[cfg(not(Py_LIMITED_API))]
 pub use self::string::PyStringData;
-pub use self::string::{PyString, PyString as PyUnicode};
-pub use self::traceback::PyTraceback;
-pub use self::tuple::PyTuple;
-pub use self::typeobject::PyType;
+pub use self::string::{PyString, PyString as PyUnicode, PyStringMethods};
+pub use self::traceback::{PyTraceback, PyTracebackMethods};
+pub use self::tuple::{PyTuple, PyTupleMethods};
+pub use self::typeobject::{PyType, PyTypeMethods};
 
 /// Iteration over Python collections.
 ///
@@ -332,7 +332,7 @@ mod num;
 mod pysuper;
 pub(crate) mod sequence;
 pub(crate) mod set;
-mod slice;
+pub(crate) mod slice;
 pub(crate) mod string;
 pub(crate) mod traceback;
 pub(crate) mod tuple;


### PR DESCRIPTION
Part of #3684, following https://github.com/PyO3/pyo3/pull/3832#discussion_r1488668116

This reexports the traits of `Bound` API under the `pyo3::types` namespace in addition to the prelude. The prelude is only really meant for glob import, so this is nicer for targeted imports.

This also adds `PySliceMethods` to the prelude, which was previously missing.