### PR TITLE
ci: apply correct permissions for cache cleanup job

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - name: Cleanup
         run: |


### PR DESCRIPTION
Followup to #3886 - it looks like the cleanup job I created doesn't have permissions to delete caches, will try this.

Will merge immediately, don't think this needs reviewing.