### PR TITLE
silence non-local-definitions nightly lint

### DIFF
--- a/newsfragments/3901.fixed.md
+++ b/newsfragments/3901.fixed.md
@@ -1,0 +1,1 @@
+Fix `non_local_definitions` lint warning triggered by many PyO3 macros.

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -604,6 +604,7 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
 
     let ident = &tokens.ident;
     Ok(quote!(
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -604,6 +604,7 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
 
     let ident = &tokens.ident;
     Ok(quote!(
+        #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;
             use _pyo3::prelude::PyAnyMethods;

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -211,6 +211,7 @@ pub fn pymodule_function_impl(mut function: syn::ItemFn) -> Result<TokenStream> 
         // this avoids complications around the fact that the generated module has a different scope
         // (and `super` doesn't always refer to the outer scope, e.g. if the `#[pymodule] is
         // inside a function body)
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate::impl_::pymodule as impl_;

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -211,6 +211,7 @@ pub fn pymodule_function_impl(mut function: syn::ItemFn) -> Result<TokenStream> 
         // this avoids complications around the fact that the generated module has a different scope
         // (and `super` doesn't always refer to the outer scope, e.g. if the `#[pymodule] is
         // inside a function body)
+        #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate::impl_::pymodule as impl_;
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -362,6 +362,7 @@ fn impl_class(
     .impl_all()?;
 
     Ok(quote! {
+        #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;
 
@@ -783,6 +784,7 @@ fn impl_simple_enum(
     .impl_all()?;
 
     Ok(quote! {
+        #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;
 
@@ -917,6 +919,7 @@ fn impl_complex_enum(
     }
 
     Ok(quote! {
+        #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -362,6 +362,7 @@ fn impl_class(
     .impl_all()?;
 
     Ok(quote! {
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;
@@ -784,6 +785,7 @@ fn impl_simple_enum(
     .impl_all()?;
 
     Ok(quote! {
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;
@@ -919,6 +921,7 @@ fn impl_complex_enum(
     }
 
     Ok(quote! {
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -281,8 +281,10 @@ pub fn impl_wrap_pyfunction(
         // this avoids complications around the fact that the generated module has a different scope
         // (and `super` doesn't always refer to the outer scope, e.g. if the `#[pyfunction] is
         // inside a function body)
+        #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;
+
             impl #name::MakeDef {
                 const DEF: #krate::impl_::pyfunction::PyMethodDef = #methoddef;
             }

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -281,6 +281,7 @@ pub fn impl_wrap_pyfunction(
         // this avoids complications around the fact that the generated module has a different scope
         // (and `super` doesn't always refer to the outer scope, e.g. if the `#[pyfunction] is
         // inside a function body)
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -168,6 +168,7 @@ pub fn impl_methods(
     };
 
     Ok(quote! {
+        #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;
 

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -168,6 +168,7 @@ pub fn impl_methods(
     };
 
     Ok(quote! {
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         const _: () = {
             use #krate as _pyo3;

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1241,6 +1241,18 @@ impl SlotFragmentDef {
         )?;
         let ret_ty = ret_ty.ffi_type();
         Ok(quote! {
+            impl #cls {
+                unsafe fn #wrapper_ident(
+                    py: _pyo3::Python,
+                    _raw_slf: *mut _pyo3::ffi::PyObject,
+                    #(#arg_idents: #arg_types),*
+                ) -> _pyo3::PyResult<#ret_ty> {
+                    let _slf = _raw_slf;
+                    #( #holders )*
+                    #body
+                }
+            }
+
             impl _pyo3::impl_::pyclass::#fragment_trait<#cls> for _pyo3::impl_::pyclass::PyClassImplCollector<#cls> {
 
                 #[inline]
@@ -1250,17 +1262,6 @@ impl SlotFragmentDef {
                     _raw_slf: *mut _pyo3::ffi::PyObject,
                     #(#arg_idents: #arg_types),*
                 ) -> _pyo3::PyResult<#ret_ty> {
-                    impl #cls {
-                        unsafe fn #wrapper_ident(
-                            py: _pyo3::Python,
-                            _raw_slf: *mut _pyo3::ffi::PyObject,
-                            #(#arg_idents: #arg_types),*
-                        ) -> _pyo3::PyResult<#ret_ty> {
-                            let _slf = _raw_slf;
-                            #( #holders )*
-                            #body
-                        }
-                    }
                     #cls::#wrapper_ident(py, _raw_slf, #(#arg_idents),*)
                 }
             }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -19,6 +19,7 @@ use std::os::raw::c_char;
 #[macro_export]
 macro_rules! impl_exception_boilerplate {
     ($name: ident) => {
+        #[allow(unknown_lints, non_local_definitions)]
         impl ::std::convert::From<&$name> for $crate::PyErr {
             #[inline]
             fn from(err: &$name) -> $crate::PyErr {

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -19,6 +19,7 @@ use std::os::raw::c_char;
 #[macro_export]
 macro_rules! impl_exception_boilerplate {
     ($name: ident) => {
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         impl ::std::convert::From<&$name> for $crate::PyErr {
             #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,14 @@
         rust_2021_prelude_collisions,
         warnings
     ),
-    allow(unused_variables, unused_assignments, unused_extern_crates)
+    allow(
+        unused_variables,
+        unused_assignments,
+        unused_extern_crates,
+        // FIXME https://github.com/rust-lang/rust/issues/121621#issuecomment-1965156376
+        unknown_lints,
+        non_local_definitions,
+    )
 )))]
 
 //! Rust bindings to the Python interpreter.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -188,6 +188,7 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         impl<$($generics,)*> $crate::IntoPy<$crate::Py<$name>> for &'_ $name {
             #[inline]
@@ -196,6 +197,7 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         impl<$($generics,)*> ::std::convert::From<&'_ $name> for $crate::Py<$name> {
             #[inline]
@@ -205,6 +207,7 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         impl<'a, $($generics,)*> ::std::convert::From<&'a $name> for &'a $crate::PyAny {
             fn from(ob: &'a $name) -> Self {
@@ -255,6 +258,7 @@ macro_rules! pyobject_native_type_info(
 #[macro_export]
 macro_rules! pyobject_native_type_extract {
     ($name:ty $(;$generics:ident)*) => {
+        // FIXME https://github.com/PyO3/pyo3/issues/3903
         #[allow(unknown_lints, non_local_definitions)]
         impl<'py, $($generics,)*> $crate::FromPyObject<'py> for &'py $name {
             #[inline]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -188,6 +188,7 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
+        #[allow(unknown_lints, non_local_definitions)]
         impl<$($generics,)*> $crate::IntoPy<$crate::Py<$name>> for &'_ $name {
             #[inline]
             fn into_py(self, py: $crate::Python<'_>) -> $crate::Py<$name> {
@@ -195,6 +196,7 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
+        #[allow(unknown_lints, non_local_definitions)]
         impl<$($generics,)*> ::std::convert::From<&'_ $name> for $crate::Py<$name> {
             #[inline]
             fn from(other: &$name) -> Self {
@@ -203,6 +205,7 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
+        #[allow(unknown_lints, non_local_definitions)]
         impl<'a, $($generics,)*> ::std::convert::From<&'a $name> for &'a $crate::PyAny {
             fn from(ob: &'a $name) -> Self {
                 unsafe{&*(ob as *const $name as *const $crate::PyAny)}
@@ -252,6 +255,7 @@ macro_rules! pyobject_native_type_info(
 #[macro_export]
 macro_rules! pyobject_native_type_extract {
     ($name:ty $(;$generics:ident)*) => {
+        #[allow(unknown_lints, non_local_definitions)]
         impl<'py, $($generics,)*> $crate::FromPyObject<'py> for &'py $name {
             #[inline]
             fn extract_bound(obj: &$crate::Bound<'py, $crate::PyAny>) -> $crate::PyResult<Self> {


### PR DESCRIPTION
This `non_local_definitions` lint from [RFC 3373](https://rust-lang.github.io/rfcs/3373-avoid-nonlocal-definitions-in-fns.html) has just landed on nightly and hit us hard.

For now let's just add attributes to silence this and unblock nightly, and come up with a FIXME issue to resolve later.

As this is so new there seems to be an open question if it's firing for exactly the right things, probably the consensus is that yes this behaves as expected, we should watch https://github.com/rust-lang/rust/issues/121621 anyway.