### PR TITLE
Allow inline struct, enum, fn and mod inside of declarative modules

### DIFF
--- a/newsfragments/3902.added.md
+++ b/newsfragments/3902.added.md
@@ -1,0 +1,1 @@
+Allow to add `#[pymodule_export]` to elements annotated with `#[pyclass]`, `#[pyfunction]` and `#[pymodule]`.

--- a/newsfragments/3902.added.md
+++ b/newsfragments/3902.added.md
@@ -1,1 +1,0 @@
-Allow to add `#[pymodule_export]` to elements annotated with `#[pyclass]`, `#[pyfunction]` and `#[pymodule]`.

--- a/tests/test_declarative_module.rs
+++ b/tests/test_declarative_module.rs
@@ -15,8 +15,8 @@ struct ValueClass {
 #[pymethods]
 impl ValueClass {
     #[new]
-    fn new(value: usize) -> ValueClass {
-        ValueClass { value }
+    fn new(value: usize) -> Self {
+        Self { value }
     }
 }
 
@@ -48,6 +48,33 @@ mod declarative_module {
     #[pymodule_export]
     use super::{declarative_module2, double, MyError, ValueClass as Value};
 
+    #[pymodule]
+    mod inner {
+        use super::*;
+
+        #[pyfunction]
+        fn triple(x: usize) -> usize {
+            x * 3
+        }
+
+        #[pyclass]
+        struct Struct;
+
+        #[pymethods]
+        impl Struct {
+            #[new]
+            fn new() -> Self {
+                Self
+            }
+        }
+
+        #[pyclass]
+        enum Enum {
+            A,
+            B,
+        }
+    }
+
     #[pymodule_init]
     fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add("double2", m.getattr("double")?)
@@ -65,7 +92,6 @@ mod declarative_submodule {
     use super::{double, double_value};
 }
 
-/// A module written using declarative syntax.
 #[pymodule]
 #[pyo3(name = "declarative_module_renamed")]
 mod declarative_module2 {
@@ -84,7 +110,7 @@ fn test_declarative_module() {
         );
 
         py_assert!(py, m, "m.double(2) == 4");
-        py_assert!(py, m, "m.double2(3) == 6");
+        py_assert!(py, m, "m.inner.triple(3) == 9");
         py_assert!(py, m, "m.declarative_submodule.double(4) == 8");
         py_assert!(
             py,
@@ -97,5 +123,7 @@ fn test_declarative_module() {
         py_assert!(py, m, "not hasattr(m, 'LocatedClass')");
         #[cfg(not(Py_LIMITED_API))]
         py_assert!(py, m, "hasattr(m, 'LocatedClass')");
+        py_assert!(py, m, "isinstance(m.inner.Struct(), m.inner.Struct)");
+        py_assert!(py, m, "isinstance(m.inner.Enum.A, m.inner.Enum)");
     })
 }

--- a/tests/ui/invalid_pymodule_trait.stderr
+++ b/tests/ui/invalid_pymodule_trait.stderr
@@ -1,4 +1,4 @@
-error: only 'use' statements and and pymodule_init functions are allowed in #[pymodule]
+error: `#[pymodule_export]` may only be used on `use` statements
  --> tests/ui/invalid_pymodule_trait.rs:5:5
   |
 5 |     #[pymodule_export]

--- a/tests/ui/invalid_pymodule_two_pymodule_init.stderr
+++ b/tests/ui/invalid_pymodule_two_pymodule_init.stderr
@@ -1,4 +1,4 @@
-error: only one pymodule_init may be specified
+error: only one `#[pymodule_init]` may be specified
   --> tests/ui/invalid_pymodule_two_pymodule_init.rs:11:5
    |
 11 |     fn init2(m: &PyModule) -> PyResult<()> {


### PR DESCRIPTION
This PR lifts restrictions on the content of declarative modules.

It also allows to add `#[pymodule_export]` to:
- `struct` with `#[pyclass]`
- `enum` with `#[pyclass]`
- `fn` with `#[pyfunction]`
- `mod` with `#[pymodule]`

Open question: do we want to require adding  `#[pymodule_export]` to the elements to be exported or do we export automatically all elements with `#[pyclass]`, `#[pyfunction]` or `#[pymodule]`?

Example:

```rust
#[pymodule]
mod declarative_module {
    #[pymodule_export]
    #[pymodule]
    mod inner {
        #[pymodule_export]
        #[pyfunction]
        fn triple(x: usize) -> usize {
            x * 3
        }

        #[pymodule_export]
        #[pyclass]
        struct Struct;

        #[pymethods]
        impl Struct {
            #[new]
            fn new() -> Self {
                Self
            }
        }
    }
}
```