### PR TITLE
Allow `#[pymodule]` functions to take a single module arg

### DIFF
--- a/newsfragments/3905.changed.md
+++ b/newsfragments/3905.changed.md
@@ -1,0 +1,1 @@
+The `#[pymodule]` macro now supports module functions that take a single argument as a `&Bound<'_, PyModule>`.

--- a/src/tests/hygiene/pyfunction.rs
+++ b/src/tests/hygiene/pyfunction.rs
@@ -14,3 +14,11 @@ fn invoke_wrap_pyfunction() {
         crate::py_run!(py, func, r#"func(5)"#);
     });
 }
+
+#[test]
+fn invoke_wrap_pyfunction_bound() {
+    crate::Python::with_gil(|py| {
+        let func = crate::wrap_pyfunction_bound!(do_something, py).unwrap();
+        crate::py_run!(py, func, r#"func(5)"#);
+    });
+}

--- a/src/tests/hygiene/pymodule.rs
+++ b/src/tests/hygiene/pymodule.rs
@@ -21,3 +21,18 @@ fn my_module(_py: crate::Python<'_>, m: &crate::types::PyModule) -> crate::PyRes
 
     ::std::result::Result::Ok(())
 }
+
+#[crate::pymodule]
+#[pyo3(crate = "crate")]
+fn my_module_bound(m: &crate::Bound<'_, crate::types::PyModule>) -> crate::PyResult<()> {
+    <crate::Bound<'_, crate::types::PyModule> as crate::types::PyModuleMethods>::add_function(
+        m,
+        crate::wrap_pyfunction_bound!(do_something, m)?,
+    )?;
+    <crate::Bound<'_, crate::types::PyModule> as crate::types::PyModuleMethods>::add_wrapped(
+        m,
+        crate::wrap_pymodule!(foo),
+    )?;
+
+    ::std::result::Result::Ok(())
+}

--- a/tests/test_no_imports.rs
+++ b/tests/test_no_imports.rs
@@ -22,6 +22,18 @@ fn basic_module(_py: pyo3::Python<'_>, m: &pyo3::types::PyModule) -> pyo3::PyRes
     Ok(())
 }
 
+#[pyo3::pymodule]
+fn basic_module_bound(m: &pyo3::Bound<'_, pyo3::types::PyModule>) -> pyo3::PyResult<()> {
+    #[pyfn(m)]
+    fn answer() -> usize {
+        42
+    }
+
+    m.add_function(pyo3::wrap_pyfunction_bound!(basic_function, m)?)?;
+
+    Ok(())
+}
+
 #[pyo3::pyclass]
 struct BasicClass {
     #[pyo3(get)]


### PR DESCRIPTION
After #3897. This was split off from #3899 and contains just the changes to the `#[pymodule]` macro. 
