### PR TITLE
cleans up `PyCFunction::internal_new`

### DIFF
--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -273,7 +273,7 @@ pub fn impl_wrap_pyfunction(
             pub fn add_to_module(module: &#krate::Bound<'_, #krate::types::PyModule>) -> #krate::PyResult<()> {
                 use #krate::prelude::PyModuleMethods;
                 use ::std::convert::Into;
-                module.add_function(#krate::types::PyCFunction::internal_new(&DEF, module.as_gil_ref().into())?)
+                module.add_function(#krate::types::PyCFunction::internal_new(module.py(), &DEF, module.into())?)
             }
         }
 

--- a/src/impl_/pyfunction.rs
+++ b/src/impl_/pyfunction.rs
@@ -1,6 +1,6 @@
 use crate::{
     types::{PyCFunction, PyModule},
-    Borrowed, Bound, PyResult, Python,
+    Borrowed, Bound, PyNativeType, PyResult, Python,
 };
 
 pub use crate::impl_::pymethods::PyMethodDef;
@@ -13,25 +13,25 @@ pub trait WrapPyFunctionArg<'py, T> {
 
 impl<'py> WrapPyFunctionArg<'py, Bound<'py, PyCFunction>> for Bound<'py, PyModule> {
     fn wrap_pyfunction(self, method_def: &PyMethodDef) -> PyResult<Bound<'py, PyCFunction>> {
-        PyCFunction::internal_new_bound(self.py(), method_def, Some(&self))
+        PyCFunction::internal_new(self.py(), method_def, Some(&self))
     }
 }
 
 impl<'py> WrapPyFunctionArg<'py, Bound<'py, PyCFunction>> for &'_ Bound<'py, PyModule> {
     fn wrap_pyfunction(self, method_def: &PyMethodDef) -> PyResult<Bound<'py, PyCFunction>> {
-        PyCFunction::internal_new_bound(self.py(), method_def, Some(self))
+        PyCFunction::internal_new(self.py(), method_def, Some(self))
     }
 }
 
 impl<'py> WrapPyFunctionArg<'py, Bound<'py, PyCFunction>> for Borrowed<'_, 'py, PyModule> {
     fn wrap_pyfunction(self, method_def: &PyMethodDef) -> PyResult<Bound<'py, PyCFunction>> {
-        PyCFunction::internal_new_bound(self.py(), method_def, Some(&self))
+        PyCFunction::internal_new(self.py(), method_def, Some(&self))
     }
 }
 
 impl<'py> WrapPyFunctionArg<'py, Bound<'py, PyCFunction>> for &'_ Borrowed<'_, 'py, PyModule> {
     fn wrap_pyfunction(self, method_def: &PyMethodDef) -> PyResult<Bound<'py, PyCFunction>> {
-        PyCFunction::internal_new_bound(self.py(), method_def, Some(self))
+        PyCFunction::internal_new(self.py(), method_def, Some(self))
     }
 }
 
@@ -39,13 +39,14 @@ impl<'py> WrapPyFunctionArg<'py, Bound<'py, PyCFunction>> for &'_ Borrowed<'_, '
 // The `wrap_pyfunction_bound!` macro is needed for the Bound form.
 impl<'py> WrapPyFunctionArg<'py, &'py PyCFunction> for Python<'py> {
     fn wrap_pyfunction(self, method_def: &PyMethodDef) -> PyResult<&'py PyCFunction> {
-        PyCFunction::internal_new(method_def, self.into()).map(Bound::into_gil_ref)
+        PyCFunction::internal_new(self, method_def, None).map(Bound::into_gil_ref)
     }
 }
 
 impl<'py> WrapPyFunctionArg<'py, &'py PyCFunction> for &'py PyModule {
     fn wrap_pyfunction(self, method_def: &PyMethodDef) -> PyResult<&'py PyCFunction> {
-        PyCFunction::internal_new(method_def, self.into()).map(Bound::into_gil_ref)
+        PyCFunction::internal_new(self.py(), method_def, Some(&self.as_borrowed()))
+            .map(Bound::into_gil_ref)
     }
 }
 
@@ -63,6 +64,6 @@ where
 
 impl<'py> WrapPyFunctionArg<'py, Bound<'py, PyCFunction>> for OnlyBound<Python<'py>> {
     fn wrap_pyfunction(self, method_def: &PyMethodDef) -> PyResult<Bound<'py, PyCFunction>> {
-        PyCFunction::internal_new_bound(self.0, method_def, None)
+        PyCFunction::internal_new(self.0, method_def, None)
     }
 }


### PR DESCRIPTION
Part of #3684, following https://github.com/PyO3/pyo3/pull/3897#discussion_r1504710221

This deduplicates some code around `PyCFunction::internal_new`
