### PR TITLE
docs: update `Python classes` section of the guide

### DIFF
--- a/examples/decorator/src/lib.rs
+++ b/examples/decorator/src/lib.rs
@@ -40,8 +40,8 @@ impl PyCounter {
     fn __call__(
         &self,
         py: Python<'_>,
-        args: &PyTuple,
-        kwargs: Option<Bound<'_, PyDict>>,
+        args: &Bound<'_, PyTuple>,
+        kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
         let old_count = self.count.get();
         let new_count = old_count + 1;
@@ -51,7 +51,7 @@ impl PyCounter {
         println!("{} has been called {} time(s).", name, new_count);
 
         // After doing something, we finally forward the call to the wrapped function
-        let ret = self.wraps.call_bound(py, args, kwargs.as_ref())?;
+        let ret = self.wraps.call_bound(py, args, kwargs)?;
 
         // We could do something with the return value of
         // the function before returning it

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -798,20 +798,20 @@ struct MyClass {
     my_field: i32,
 }
 
-// Take a GIL-bound reference when the underlying `Bound` is irrelevant.
+// Take a reference when the underlying `Bound` is irrelevant.
 #[pyfunction]
 fn increment_field(my_class: &mut MyClass) {
     my_class.my_field += 1;
 }
 
-// Take a GIL-bound reference wrapper when borrowing should be automatic,
+// Take a reference wrapper when borrowing should be automatic,
 // but interaction with the underlying `Bound` is desired.
 #[pyfunction]
 fn print_field(my_class: PyRef<'_, MyClass>) {
     println!("{}", my_class.my_field);
 }
 
-// Take a GIL-bound reference to the underlying Bound
+// Take a reference to the underlying Bound
 // when borrowing needs to be managed manually.
 #[pyfunction]
 fn increment_then_print_field(my_class: &Bound<'_, MyClass>) {

--- a/guide/src/class/call.md
+++ b/guide/src/class/call.md
@@ -75,8 +75,8 @@ A [previous implementation] used a normal `u64`, which meant it required a `&mut
 fn __call__(
     &mut self,
     py: Python<'_>,
-    args: &PyTuple,
-    kwargs: Option<&PyDict>,
+    args: &Bound<'_, PyTuple>,
+    kwargs: Option<&Bound<'_, PyDict>>,
 ) -> PyResult<Py<PyAny>> {
     self.count += 1;
     let name = self.wraps.getattr(py, "__name__")?;

--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -35,7 +35,7 @@ and cast it to an `i32`.
 # #![allow(dead_code)]
 use pyo3::prelude::*;
 
-fn wrap(obj: &PyAny) -> Result<i32, PyErr> {
+fn wrap(obj: &Bound<'_, PyAny>) -> PyResult<i32> {
     let val = obj.call_method1("__and__", (0xFFFFFFFF_u32,))?;
     let val: u32 = val.extract()?;
     //     👇 This intentionally overflows!
@@ -48,7 +48,7 @@ We also add documentation, via `///` comments, which are visible to Python users
 # #![allow(dead_code)]
 use pyo3::prelude::*;
 
-fn wrap(obj: &PyAny) -> Result<i32, PyErr> {
+fn wrap(obj: &Bound<'_, PyAny>) -> PyResult<i32> {
     let val = obj.call_method1("__and__", (0xFFFFFFFF_u32,))?;
     let val: u32 = val.extract()?;
     Ok(val as i32)
@@ -212,7 +212,7 @@ use pyo3::prelude::*;
 use pyo3::class::basic::CompareOp;
 use pyo3::types::PyComplex;
 
-fn wrap(obj: &PyAny) -> Result<i32, PyErr> {
+fn wrap(obj: &Bound<'_, PyAny>) -> PyResult<i32> {
     let val = obj.call_method1("__and__", (0xFFFFFFFF_u32,))?;
     let val: u32 = val.extract()?;
     Ok(val as i32)
@@ -229,7 +229,7 @@ impl Number {
         Self(value)
     }
 
-    fn __repr__(slf: &PyCell<Self>) -> PyResult<String> {
+    fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
        // Get the class name dynamically in case `Number` is subclassed
        let class_name: String = slf.get_type().qualname()?;
         Ok(format!("{}({})", class_name, slf.borrow().0))
@@ -411,8 +411,8 @@ the contracts of this function. Let's review those contracts:
 - The GIL must be held. If it's not, calling this function causes a data race.
 - The pointer must be valid, i.e. it must be properly aligned and point to a valid Python object.
 
-Let's create that helper function. The signature has to be `fn(&PyAny) -> PyResult<T>`.
-- `&PyAny` represents a checked borrowed reference, so the pointer derived from it is valid (and not null).
+Let's create that helper function. The signature has to be `fn(&Bound<'_, PyAny>) -> PyResult<T>`.
+- `&Bound<'_, PyAny>` represents a checked borrowed reference, so the pointer derived from it is valid (and not null).
 - Whenever we have borrowed references to Python objects in scope, it is guaranteed that the GIL is held. This reference is also where we can get a [`Python`] token to use in our call to [`PyErr::take`].
 
 ```rust
@@ -421,7 +421,7 @@ use std::os::raw::c_ulong;
 use pyo3::prelude::*;
 use pyo3::ffi;
 
-fn wrap(obj: &PyAny) -> Result<i32, PyErr> {
+fn wrap(obj: &Bound<'_, PyAny>) -> Result<i32, PyErr> {
     let py: Python<'_> = obj.py();
 
     unsafe {

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -76,7 +76,7 @@ In the `__repr__`, we used a hard-coded class name. This is sometimes not ideal,
 because if the class is subclassed in Python, we would like the repr to reflect
 the subclass name. This is typically done in Python code by accessing
 `self.__class__.__name__`. In order to be able to access the Python type information
-*and* the Rust struct, we need to use a `PyCell` as the `self` argument.
+*and* the Rust struct, we need to use a `Bound` as the `self` argument.
 
 ```rust
 # use pyo3::prelude::*;
@@ -86,7 +86,7 @@ the subclass name. This is typically done in Python code by accessing
 #
 #[pymethods]
 impl Number {
-    fn __repr__(slf: &PyCell<Self>) -> PyResult<String> {
+    fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
         // This is the equivalent of `self.__class__.__name__` in Python.
         let class_name: String = slf.get_type().qualname()?;
         // To access fields of the Rust struct, we need to borrow the `PyCell`.
@@ -263,7 +263,7 @@ impl Number {
         Self(value)
     }
 
-    fn __repr__(slf: &PyCell<Self>) -> PyResult<String> {
+    fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
         let class_name: String = slf.get_type().qualname()?;
         Ok(format!("{}({})", class_name, slf.borrow().0))
     }

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -17,7 +17,7 @@ When PyO3 handles a magic method, a couple of changes apply compared to other `#
 The following sections list of all magic methods PyO3 currently handles.  The
 given signatures should be interpreted as follows:
  - All methods take a receiver as first argument, shown as `<self>`. It can be
-   `&self`, `&mut self` or a `PyCell` reference like `self_: PyRef<'_, Self>` and
+   `&self`, `&mut self` or a `Bound` reference like `self_: PyRef<'_, Self>` and
    `self_: PyRefMut<'_, Self>`, as described [here](../class.md#inheritance).
  - An optional `Python<'py>` argument is always allowed as the first argument.
  - Return values can be optionally wrapped in `PyResult`.

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -203,6 +203,10 @@ impl PyClassAsyncIter {
 
 `PyType::name` has been renamed to `PyType::qualname` to indicate that it does indeed return the [qualified name](https://docs.python.org/3/glossary.html#term-qualified-name), matching the `__qualname__` attribute. The newly added `PyType::name` yields the full name including the module name now which corresponds to `__module__.__name__` on the level of attributes.
 
+### `PyCell` has been deprecated
+
+Interactions with Python objects implemented in Rust no longer need to go though `PyCell<T>`. Instead iteractions with Python object now consistently go through `Bound<T>` or `Py<T>` independently of whether `T` is native Python object or a `#[pyclass]` implemented in Rust. Use `Bound::new` or `Py::new` respectively to create and `Bound::borrow(_mut)` / `Py::borrow(_mut)` to borrow the Rust object.
+
 ### Migrating from the GIL-Refs API to `Bound<T>`
 
 To minimise breakage of code using the GIL-Refs API, the `Bound<T>` smart pointer has been introduced by adding complements to all functions which accept or return GIL Refs. This allows code to migrate by replacing the deprecated APIs with the new ones.

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -631,6 +631,12 @@ impl IntoPy<Py<PyTuple>> for Bound<'_, PyTuple> {
     }
 }
 
+impl IntoPy<Py<PyTuple>> for &'_ Bound<'_, PyTuple> {
+    fn into_py(self, _: Python<'_>) -> Py<PyTuple> {
+        self.clone().unbind()
+    }
+}
+
 #[cold]
 fn wrong_tuple_length(t: &Bound<'_, PyTuple>, expected_length: usize) -> PyErr {
     let msg = format!(


### PR DESCRIPTION
Part of #3684 

This adapts the "Python classes" section of the guide to the new `Bound` API.