### PR TITLE
Add IntoIterator for &Bound types

### DIFF
--- a/pyo3-benches/benches/bench_dict.rs
+++ b/pyo3-benches/benches/bench_dict.rs
@@ -11,7 +11,7 @@ fn iter_dict(b: &mut Bencher<'_>) {
         let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py);
         let mut sum = 0;
         b.iter(|| {
-            for (k, _v) in dict.iter() {
+            for (k, _v) in &dict {
                 let i: u64 = k.extract().unwrap();
                 sum += i;
             }

--- a/pyo3-benches/benches/bench_list.rs
+++ b/pyo3-benches/benches/bench_list.rs
@@ -11,7 +11,7 @@ fn iter_list(b: &mut Bencher<'_>) {
         let list = PyList::new_bound(py, 0..LEN);
         let mut sum = 0;
         b.iter(|| {
-            for x in list.iter() {
+            for x in &list {
                 let i: u64 = x.extract().unwrap();
                 sum += i;
             }

--- a/pyo3-benches/benches/bench_set.rs
+++ b/pyo3-benches/benches/bench_set.rs
@@ -20,7 +20,7 @@ fn iter_set(b: &mut Bencher<'_>) {
         let set = PySet::new_bound(py, &(0..LEN).collect::<Vec<_>>()).unwrap();
         let mut sum = 0;
         b.iter(|| {
-            for x in set.iter() {
+            for x in &set {
                 let i: u64 = x.extract().unwrap();
                 sum += i;
             }

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -60,7 +60,7 @@ where
     fn extract_bound(ob: &Bound<'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.downcast::<PyDict>()?;
         let mut ret = hashbrown::HashMap::with_capacity_and_hasher(dict.len(), S::default());
-        for (k, v) in dict.iter() {
+        for (k, v) in dict {
             ret.insert(k.extract()?, v.extract()?);
         }
         Ok(ret)

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -125,7 +125,7 @@ where
     fn extract_bound(ob: &Bound<'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.downcast::<PyDict>()?;
         let mut ret = indexmap::IndexMap::with_capacity_and_hasher(dict.len(), S::default());
-        for (k, v) in dict.iter() {
+        for (k, v) in dict {
             ret.insert(k.extract()?, v.extract()?);
         }
         Ok(ret)

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -76,7 +76,7 @@ where
     fn extract_bound(ob: &Bound<'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.downcast::<PyDict>()?;
         let mut ret = collections::HashMap::with_capacity_and_hasher(dict.len(), S::default());
-        for (k, v) in dict.iter() {
+        for (k, v) in dict {
             ret.insert(k.extract()?, v.extract()?);
         }
         Ok(ret)
@@ -96,7 +96,7 @@ where
     fn extract_bound(ob: &Bound<'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.downcast::<PyDict>()?;
         let mut ret = collections::BTreeMap::new();
-        for (k, v) in dict.iter() {
+        for (k, v) in dict {
             ret.insert(k.extract()?, v.extract()?);
         }
         Ok(ret)

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -249,6 +249,16 @@ impl<'py> IntoIterator for Bound<'py, PyFrozenSet> {
     }
 }
 
+impl<'py> IntoIterator for &Bound<'py, PyFrozenSet> {
+    type Item = Bound<'py, PyAny>;
+    type IntoIter = BoundFrozenSetIterator<'py>;
+
+    /// Returns an iterator of values in this set.
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 /// PyO3 implementation of an iterator for a Python `frozenset` object.
 pub struct BoundFrozenSetIterator<'p> {
     it: Bound<'p, PyIterator>,
@@ -358,6 +368,17 @@ mod tests {
 
             // intoiterator iteration
             for el in set {
+                assert_eq!(1i32, el.extract::<i32>().unwrap());
+            }
+        });
+    }
+
+    #[test]
+    fn test_frozenset_iter_bound() {
+        Python::with_gil(|py| {
+            let set = PyFrozenSet::new_bound(py, &[1]).unwrap();
+
+            for el in &set {
                 assert_eq!(1i32, el.extract::<i32>().unwrap());
             }
         });

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -111,6 +111,15 @@ impl<'py> Borrowed<'_, 'py, PyIterator> {
     }
 }
 
+impl<'py> IntoIterator for &Bound<'py, PyIterator> {
+    type Item = PyResult<Bound<'py, PyAny>>;
+    type IntoIter = Bound<'py, PyIterator>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.clone()
+    }
+}
+
 impl PyTypeCheck for PyIterator {
     const NAME: &'static str = "Iterator";
 
@@ -243,6 +252,39 @@ def fibonacci(target):
                 let actual = actual.unwrap().extract::<usize>().unwrap();
                 assert_eq!(actual, *expected)
             }
+        });
+    }
+
+    #[test]
+    fn fibonacci_generator_bound() {
+        use crate::types::any::PyAnyMethods;
+        use crate::Bound;
+
+        let fibonacci_generator = r#"
+def fibonacci(target):
+    a = 1
+    b = 1
+    for _ in range(target):
+        yield a
+        a, b = b, a + b
+"#;
+
+        Python::with_gil(|py| {
+            let context = PyDict::new_bound(py);
+            py.run_bound(fibonacci_generator, None, Some(&context))
+                .unwrap();
+
+            let generator: Bound<'_, PyIterator> = py
+                .eval_bound("fibonacci(5)", None, Some(&context))
+                .unwrap()
+                .downcast_into()
+                .unwrap();
+            let mut items = vec![];
+            for actual in &generator {
+                let actual = actual.unwrap().extract::<usize>().unwrap();
+                items.push(actual);
+            }
+            assert_eq!(items, [1, 1, 2, 3, 5]);
         });
     }
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -921,6 +921,20 @@ mod tests {
     }
 
     #[test]
+    fn test_into_iter_bound() {
+        use crate::types::any::PyAnyMethods;
+
+        Python::with_gil(|py| {
+            let list = PyList::new_bound(py, [1, 2, 3, 4]);
+            let mut items = vec![];
+            for item in &list {
+                items.push(item.extract::<i32>().unwrap());
+            }
+            assert_eq!(items, vec![1, 2, 3, 4]);
+        });
+    }
+
+    #[test]
     fn test_extract() {
         Python::with_gil(|py| {
             let v = vec![2, 3, 5, 7];

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -703,6 +703,15 @@ impl<'py> IntoIterator for Bound<'py, PyList> {
     }
 }
 
+impl<'py> IntoIterator for &Bound<'py, PyList> {
+    type Item = Bound<'py, PyAny>;
+    type IntoIter = BoundListIterator<'py>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 #[cfg(test)]
 #[cfg_attr(not(feature = "gil-refs"), allow(deprecated))]
 mod tests {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -64,7 +64,7 @@ pub use self::typeobject::{PyType, PyTypeMethods};
 /// Python::with_gil(|py| {
 ///     let dict = py.eval_bound("{'a':'b', 'c':'d'}", None, None)?.downcast_into::<PyDict>()?;
 ///
-///     for (key, value) in dict.iter() {
+///     for (key, value) in &dict {
 ///         println!("key: {}, value: {}", key, value);
 ///     }
 ///

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -309,6 +309,20 @@ impl<'py> IntoIterator for Bound<'py, PySet> {
     }
 }
 
+impl<'py> IntoIterator for &Bound<'py, PySet> {
+    type Item = Bound<'py, PyAny>;
+    type IntoIter = BoundSetIterator<'py>;
+
+    /// Returns an iterator of values in this set.
+    ///
+    /// # Panics
+    ///
+    /// If PyO3 detects that the set is mutated during iteration, it will panic.
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
 /// PyO3 implementation of an iterator for a Python `set` object.
 pub struct BoundSetIterator<'p> {
     it: Bound<'p, PyIterator>,
@@ -484,6 +498,19 @@ mod tests {
             // intoiterator iteration
             for el in set {
                 assert_eq!(1i32, el.extract::<'_, i32>().unwrap());
+            }
+        });
+    }
+
+    #[test]
+    fn test_set_iter_bound() {
+        use crate::types::any::PyAnyMethods;
+
+        Python::with_gil(|py| {
+            let set = PySet::new_bound(py, &[1]).unwrap();
+
+            for el in &set {
+                assert_eq!(1i32, el.extract::<i32>().unwrap());
             }
         });
     }


### PR DESCRIPTION
This allows using common types like `&Bound<'py, PyList>` in a `for` loop without explicitly calling `iter()`.