### PR TITLE
Delete duplicate test code

### DIFF
--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -351,12 +351,6 @@ mod tests {
         Python::with_gil(|py| {
             let set = PyFrozenSet::new(py, &[1]).unwrap();
 
-            // iter method
-            for el in set {
-                assert_eq!(1i32, el.extract::<i32>().unwrap());
-            }
-
-            // intoiterator iteration
             for el in set {
                 assert_eq!(1i32, el.extract::<i32>().unwrap());
             }

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -476,12 +476,6 @@ mod tests {
         Python::with_gil(|py| {
             let set = PySet::new(py, &[1]).unwrap();
 
-            // iter method
-            for el in set {
-                assert_eq!(1i32, el.extract::<'_, i32>().unwrap());
-            }
-
-            // intoiterator iteration
             for el in set {
                 assert_eq!(1i32, el.extract::<'_, i32>().unwrap());
             }


### PR DESCRIPTION
These used to explicitly call `.iter()`, but that was removed in b65cbb9 to resolve lint warnings.