### PR TITLE
remove `gil-refs` feature from `full` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,6 @@ nightly = []
 # This is mostly intended for testing purposes - activating *all* of these isn't particularly useful.
 full = [
     "macros",
-    "gil-refs",
     # "multiple-pymethods", # TODO re-add this when MSRV is greater than 1.62
     "anyhow",
     "chrono",
@@ -140,7 +139,7 @@ members = [
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["full"]
+features = ["full", "gil-refs"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.lints.clippy]

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -980,13 +980,13 @@ mod tests {
             let td = new_py_datetime_ob(py, "timedelta", (0, 3600, 0));
             let py_timedelta = new_py_datetime_ob(py, "timezone", (td,));
             // Should be equal
-            assert!(offset.as_ref(py).eq(py_timedelta).unwrap());
+            assert!(offset.bind(py).eq(py_timedelta).unwrap());
 
             // Same but with negative values
             let offset = FixedOffset::east_opt(-3600).unwrap().to_object(py);
             let td = new_py_datetime_ob(py, "timedelta", (0, -3600, 0));
             let py_timedelta = new_py_datetime_ob(py, "timezone", (td,));
-            assert!(offset.as_ref(py).eq(py_timedelta).unwrap());
+            assert!(offset.bind(py).eq(py_timedelta).unwrap());
         })
     }
 

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -282,7 +282,7 @@ mod tests {
         let mut f0 = 1.to_object(py);
         let mut f1 = 1.to_object(py);
         std::iter::from_fn(move || {
-            let f2 = f0.call_method1(py, "__add__", (f1.as_ref(py),)).unwrap();
+            let f2 = f0.call_method1(py, "__add__", (f1.bind(py),)).unwrap();
             Some(std::mem::replace(&mut f0, std::mem::replace(&mut f1, f2)))
         })
     }
@@ -295,7 +295,7 @@ mod tests {
                 // Python -> Rust
                 assert_eq!(py_result.extract::<BigUint>(py).unwrap(), rs_result);
                 // Rust -> Python
-                assert!(py_result.as_ref(py).eq(rs_result).unwrap());
+                assert!(py_result.bind(py).eq(rs_result).unwrap());
             }
         });
     }
@@ -308,7 +308,7 @@ mod tests {
                 // Python -> Rust
                 assert_eq!(py_result.extract::<BigInt>(py).unwrap(), rs_result);
                 // Rust -> Python
-                assert!(py_result.as_ref(py).eq(&rs_result).unwrap());
+                assert!(py_result.bind(py).eq(&rs_result).unwrap());
 
                 // negate
 
@@ -318,7 +318,7 @@ mod tests {
                 // Python -> Rust
                 assert_eq!(py_result.extract::<BigInt>(py).unwrap(), rs_result);
                 // Rust -> Python
-                assert!(py_result.as_ref(py).eq(rs_result).unwrap());
+                assert!(py_result.bind(py).eq(rs_result).unwrap());
             }
         });
     }

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -54,9 +54,7 @@ use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::string::PyStringMethods;
 use crate::types::PyType;
-use crate::{
-    intern, Bound, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject,
-};
+use crate::{Bound, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject};
 use rust_decimal::Decimal;
 use std::str::FromStr;
 
@@ -74,14 +72,8 @@ impl FromPyObject<'_> for Decimal {
 
 static DECIMAL_CLS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 
-fn get_decimal_cls(py: Python<'_>) -> PyResult<&PyType> {
-    DECIMAL_CLS
-        .get_or_try_init(py, || {
-            py.import_bound(intern!(py, "decimal"))?
-                .getattr(intern!(py, "Decimal"))?
-                .extract()
-        })
-        .map(|ty| ty.as_ref(py))
+fn get_decimal_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    DECIMAL_CLS.get_or_try_init_type_ref(py, "decimal", "Decimal")
 }
 
 impl ToPyObject for Decimal {


### PR DESCRIPTION
This PR removes the `gil-refs` feature from the `full` feature. This makes it possible to test the `full` feature with and without the `gil-refs` enabled, which I think is a meaningful thing to do while we're in the migration phase, even if it makes our CI longer for the mid term.

Because the `gil-refs` feature is large and expected to get complicated I've also enabled this as an additional dimension to the `check-feature-powerset` job.

I'm hoping that between enabling tests with `full` (but not with `abi3`, for sake of not going too heavy on CI) and using the powerset check to exercise all compile combinations, we should be in a good place for things to work well with and without the feature.