### PR TITLE
Chrono: allow deprecation warning until upgrading to 0.4.35+

### DIFF
--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -19,6 +19,9 @@
 //! # Example: Convert a `datetime.datetime` to chrono's `DateTime<Utc>`
 //!
 //! ```rust
+//! # // `chrono::Duration` has been renamed to `chrono::TimeDelta` and its constructors changed
+//! # // TODO: upgrade to Chrono 0.4.35+ after upgrading our MSRV to 1.61+
+//! # #![allow(deprecated)]
 //! use chrono::{DateTime, Duration, TimeZone, Utc};
 //! use pyo3::{Python, ToPyObject};
 //!

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -39,6 +39,11 @@
 //!     });
 //! }
 //! ```
+
+// `chrono::Duration` has been renamed to `chrono::TimeDelta` and its constructors changed
+// TODO: upgrade to Chrono 0.4.35+ after upgrading our MSRV to 1.61+
+#![allow(deprecated)]
+
 use crate::exceptions::{PyTypeError, PyUserWarning, PyValueError};
 #[cfg(Py_LIMITED_API)]
 use crate::sync::GILOnceCell;


### PR DESCRIPTION
Requirering 0.4.35 is blocked on MSRV (Chrono: 1.61, PyO3: 1.56)
