### PR TITLE
deprecate gil-refs in "self" position

### DIFF
--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -133,7 +133,7 @@ impl FnType {
                 quote_spanned! { *span =>
                     #[allow(clippy::useless_conversion)]
                     ::std::convert::Into::into(
-                        #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(#py, &*::std::ptr::from_ref(#slf).cast())
+                        #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(#py, &*(#slf as *const _ as *const *mut _))
                             .downcast_unchecked::<#pyo3_path::types::PyType>()
                     ),
                 }
@@ -145,7 +145,7 @@ impl FnType {
                 quote_spanned! { *span =>
                     #[allow(clippy::useless_conversion)]
                     ::std::convert::Into::into(
-                        #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(#py, &*::std::ptr::from_ref(#slf).cast())
+                        #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(#py, &*(#slf as *const _ as *const *mut _))
                             .downcast_unchecked::<#pyo3_path::types::PyModule>()
                     ),
                 }

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -590,8 +590,7 @@ impl<'a> FnSpec<'a> {
                 quote! {{
                     #self_e = #pyo3_path::impl_::pymethods::Extractor::<()>::new();
                     function(#(#args),*)
-                }
-                }
+                }}
             } else {
                 quote! {
                     function({

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -78,6 +78,7 @@ impl ClassMethod {
 
     #[classmethod]
     /// Test class method.
+    #[cfg(feature = "gil-refs")]
     fn method_gil_ref(cls: &PyType) -> PyResult<String> {
         Ok(format!("{}.method()!", cls.qualname()?))
     }

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -45,7 +45,7 @@ fn module_with_functions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     #[pyfn(m)]
     #[pyo3(pass_module)]
-    fn with_module(module: &PyModule) -> PyResult<&str> {
+    fn with_module<'py>(module: &Bound<'py, PyModule>) -> PyResult<Bound<'py, PyString>> {
         module.name()
     }
 
@@ -373,6 +373,7 @@ fn pyfunction_with_module<'py>(module: &Bound<'py, PyModule>) -> PyResult<Bound<
 
 #[pyfunction]
 #[pyo3(pass_module)]
+#[cfg(feature = "gil-refs")]
 fn pyfunction_with_module_gil_ref(module: &PyModule) -> PyResult<&str> {
     module.name()
 }
@@ -427,6 +428,7 @@ fn pyfunction_with_module_and_args_kwargs<'py>(
 
 #[pyfunction]
 #[pyo3(pass_module)]
+#[cfg(feature = "gil-refs")]
 fn pyfunction_with_pass_module_in_attribute(module: &PyModule) -> PyResult<&str> {
     module.name()
 }
@@ -434,12 +436,14 @@ fn pyfunction_with_pass_module_in_attribute(module: &PyModule) -> PyResult<&str>
 #[pymodule]
 fn module_with_functions_with_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(pyfunction_with_module, m)?)?;
+    #[cfg(feature = "gil-refs")]
     m.add_function(wrap_pyfunction!(pyfunction_with_module_gil_ref, m)?)?;
     m.add_function(wrap_pyfunction!(pyfunction_with_module_owned, m)?)?;
     m.add_function(wrap_pyfunction!(pyfunction_with_module_and_py, m)?)?;
     m.add_function(wrap_pyfunction!(pyfunction_with_module_and_arg, m)?)?;
     m.add_function(wrap_pyfunction!(pyfunction_with_module_and_default_arg, m)?)?;
     m.add_function(wrap_pyfunction!(pyfunction_with_module_and_args_kwargs, m)?)?;
+    #[cfg(feature = "gil-refs")]
     m.add_function(wrap_pyfunction!(
         pyfunction_with_pass_module_in_attribute,
         m
@@ -457,6 +461,7 @@ fn test_module_functions_with_module() {
             m,
             "m.pyfunction_with_module() == 'module_with_functions_with_module'"
         );
+        #[cfg(feature = "gil-refs")]
         py_assert!(
             py,
             m,
@@ -484,6 +489,7 @@ fn test_module_functions_with_module() {
             "m.pyfunction_with_module_and_args_kwargs(1, x=1, y=2) \
                         == ('module_with_functions_with_module', 1, 2)"
         );
+        #[cfg(feature = "gil-refs")]
         py_assert!(
             py,
             m,

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -1,6 +1,7 @@
 #![deny(deprecated)]
 
 use pyo3::prelude::*;
+use pyo3::types::{PyString, PyType};
 
 #[pyclass]
 struct MyClass;
@@ -11,9 +12,31 @@ impl MyClass {
     fn new() -> Self {
         Self
     }
+
+    #[classmethod]
+    fn cls_method_gil_ref(_cls: &PyType) {}
+
+    #[classmethod]
+    fn cls_method_bound(_cls: &Bound<'_, PyType>) {}
+
+    fn method_gil_ref(_slf: &PyCell<Self>) {}
+
+    fn method_bound(_slf: &Bound<'_, Self>) {}
 }
 
 fn main() {}
+
+#[pyfunction]
+#[pyo3(pass_module)]
+fn pyfunction_with_module<'py>(module: &Bound<'py, PyModule>) -> PyResult<Bound<'py, PyString>> {
+    module.name()
+}
+
+#[pyfunction]
+#[pyo3(pass_module)]
+fn pyfunction_with_module_gil_ref(module: &PyModule) -> PyResult<&str> {
+    module.name()
+}
 
 #[pyfunction]
 fn double(x: usize) -> usize {

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -1,7 +1,7 @@
 error: use of deprecated constant `pyo3::impl_::deprecations::PYMETHODS_NEW_DEPRECATED_FORM`: use `#[new]` instead of `#[__new__]`
-  --> tests/ui/deprecations.rs:10:7
+  --> tests/ui/deprecations.rs:11:7
    |
-10 |     #[__new__]
+11 |     #[__new__]
    |       ^^^^^^^
    |
 note: the lint level is defined here
@@ -10,14 +10,38 @@ note: the lint level is defined here
 1  | #![deny(deprecated)]
    |         ^^^^^^^^^^
 
-error: use of deprecated method `pyo3::methods::Extractor::<T>::extract_gil_ref`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:24:19
+error: use of deprecated struct `pyo3::PyCell`: `PyCell` was merged into `Bound`, use that instead; see the migration guide for more info
+  --> tests/ui/deprecations.rs:22:30
    |
-24 | fn module_gil_ref(m: &PyModule) -> PyResult<()> {
+22 |     fn method_gil_ref(_slf: &PyCell<Self>) {}
+   |                              ^^^^^^
+
+error: use of deprecated method `pyo3::methods::Extractor::<T>::extract_gil_ref`: use `&Bound<'_, T>` instead for this function argument
+  --> tests/ui/deprecations.rs:17:33
+   |
+17 |     fn cls_method_gil_ref(_cls: &PyType) {}
+   |                                 ^
+
+error: use of deprecated method `pyo3::methods::Extractor::<T>::extract_gil_ref`: use `&Bound<'_, T>` instead for this function argument
+  --> tests/ui/deprecations.rs:22:29
+   |
+22 |     fn method_gil_ref(_slf: &PyCell<Self>) {}
+   |                             ^
+
+error: use of deprecated method `pyo3::methods::Extractor::<T>::extract_gil_ref`: use `&Bound<'_, T>` instead for this function argument
+  --> tests/ui/deprecations.rs:37:43
+   |
+37 | fn pyfunction_with_module_gil_ref(module: &PyModule) -> PyResult<&str> {
+   |                                           ^
+
+error: use of deprecated method `pyo3::methods::Extractor::<T>::extract_gil_ref`: use `&Bound<'_, T>` instead for this function argument
+  --> tests/ui/deprecations.rs:47:19
+   |
+47 | fn module_gil_ref(m: &PyModule) -> PyResult<()> {
    |                   ^
 
 error: use of deprecated method `pyo3::methods::Extractor::<T>::extract_gil_ref`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:30:57
+  --> tests/ui/deprecations.rs:53:57
    |
-30 | fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+53 | fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
    |                                                         ^


### PR DESCRIPTION
Following #3936 / #3847 

This deprecates the use of gil-ref types in "self" argument position. This includes `#[pyfunction]` with `pass_module`, the `cls` argument of `#[classmethod]` and `&PyCell<Self>` for normal `#[pymethods]`. (It seems like `#[getter]` and `#[setter]` use a different mechanism)
