### PR TITLE
ci: pin pytest < 8.1

### DIFF
--- a/pytests/pyproject.toml
+++ b/pytests/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "hypothesis>=3.55",
     "pytest-asyncio>=0.21",
     "pytest-benchmark>=3.4",
-    "pytest>=6.0",
+    # pinned < 8.1 because https://github.com/CodSpeedHQ/pytest-codspeed/issues/27
+    "pytest>=8,<8.1",
     "typing_extensions>=4.0.0"
 ]


### PR DESCRIPTION
Benches jobs have been failing for a couple days, my guess is that it might be the latest pytest 8.1.1 release.

I'm going to pin back CI and see if the benchmarks job succeeds, if that fixes I'll report upstream.