### PR TITLE
allow downstream overwrite of the `Bound<T>` deref target 

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1224,7 +1224,9 @@ struct MyClass {
     num: i32,
 }
 
-impl pyo3::types::DerefToPyAny for MyClass {}
+impl pyo3::types::DerefToPyAny for MyClass {
+    type Target = pyo3::PyAny;
+}
 
 # #[allow(deprecated)]
 unsafe impl pyo3::type_object::HasPyGilRef for MyClass {

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1224,7 +1224,7 @@ struct MyClass {
     num: i32,
 }
 
-impl pyo3::types::DerefToPyAny for MyClass {
+impl pyo3::types::DerefToTarget for MyClass {
     type Target = pyo3::PyAny;
 }
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -371,7 +371,7 @@ fn impl_class(
     };
 
     Ok(quote! {
-        impl #pyo3_path::types::DerefToPyAny for #cls {
+        impl #pyo3_path::types::DerefToTarget for #cls {
             type Target = #base;
         }
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -365,8 +365,15 @@ fn impl_class(
     .doc(doc)
     .impl_all(ctx)?;
 
+    let base = match &args.options.extends {
+        Some(extends_attr) => extends_attr.value.clone(),
+        None => parse_quote! { #pyo3_path::PyAny },
+    };
+
     Ok(quote! {
-        impl #pyo3_path::types::DerefToPyAny for #cls {}
+        impl #pyo3_path::types::DerefToPyAny for #cls {
+            type Target = #base;
+        }
 
         #pytypeinfo_impl
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -370,11 +370,11 @@ impl<'py, T> Deref for Bound<'py, T>
 where
     T: DerefToPyAny,
 {
-    type Target = Bound<'py, PyAny>;
+    type Target = Bound<'py, T::Target>;
 
     #[inline]
-    fn deref(&self) -> &Bound<'py, PyAny> {
-        self.as_any()
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.as_any().downcast_unchecked() }
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -4,7 +4,7 @@ use crate::pycell::{PyBorrowError, PyBorrowMutError};
 use crate::pyclass::boolean_struct::{False, True};
 use crate::type_object::HasPyGilRef;
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
-use crate::types::{DerefToPyAny, PyDict, PyString, PyTuple};
+use crate::types::{DerefToTarget, PyDict, PyString, PyTuple};
 use crate::{
     ffi, AsPyPointer, DowncastError, FromPyObject, IntoPy, PyAny, PyClass, PyClassInitializer,
     PyRef, PyRefMut, PyTypeInfo, Python, ToPyObject,
@@ -368,7 +368,7 @@ fn python_format(
 // https://github.com/rust-lang/rust/issues/19509
 impl<'py, T> Deref for Bound<'py, T>
 where
-    T: DerefToPyAny,
+    T: DerefToTarget,
 {
     type Target = Bound<'py, T::Target>;
 

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -308,7 +308,7 @@ pub(crate) fn new_from_iter<T: ToPyObject>(
             // We create the  `Py` pointer because its Drop cleans up the set if user code panics.
             ffi::PyFrozenSet_New(std::ptr::null_mut())
                 .assume_owned_or_err(py)?
-                .downcast_into_unchecked()
+                .downcast_into_unchecked::<PyFrozenSet>()
         };
         let ptr = set.as_ptr();
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -110,7 +110,7 @@ pub mod iter {
 /// trait will be removed.
 ///
 /// [1]: https://github.com/rust-lang/rust/issues/19509
-pub trait DerefToPyAny {
+pub trait DerefToTarget {
     /// Target Type
     type Target;
 }
@@ -222,7 +222,7 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
-        impl $crate::types::DerefToPyAny for $name {
+        impl $crate::types::DerefToTarget for $name {
             type Target = $target;
         }
     };

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -373,7 +373,7 @@ pub(crate) fn new_from_iter<T: ToPyObject>(
             // We create the  `Py` pointer because its Drop cleans up the set if user code panics.
             ffi::PySet_New(std::ptr::null_mut())
                 .assume_owned_or_err(py)?
-                .downcast_into_unchecked()
+                .downcast_into_unchecked::<PySet>()
         };
         let ptr = set.as_ptr();
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -68,7 +68,7 @@ impl PyType {
         p: *mut ffi::PyTypeObject,
     ) -> Bound<'_, PyType> {
         Borrowed::from_ptr_unchecked(py, p.cast())
-            .downcast_unchecked()
+            .downcast_unchecked::<PyType>()
             .to_owned()
     }
 


### PR DESCRIPTION
Following https://github.com/PyO3/rust-numpy/pull/411#issuecomment-1990964277 this explores the possibility to allow downstream crates that implement native Python type (like `rust-numpy`) to overwrite the `Deref::Target`.

The approach described here renames `DerefToPyAny` to `DerefToTarget` and adds a `Target` associated type. The blanked `Deref` implementation is adjusted to use that as its target inside `Bound`. `pyo3`s native types use `PyAny` as default, `#[pyclass]`es use their inherited (`#[pyclass(extends = ...]`) class if they have or `PyAny` if not.

# Questions
- Do we want to expose this functionality this way? Are there alternatives?
- Should `DerefToTarget` be an unsafe trait now, that we use `Target` for an unsafe cast?
- I got 3 error messages in `pyo3`s code base of the following type:
  ```
  error[E0055]: reached the recursion limit while auto-dereferencing `instance::Bound<'_, _>`
     --> src/types/frozenset.rs:313:23
      |
  313 |         let ptr = set.as_ptr();
      |                       ^^^^^^ deref recursion limit reached
      |
      = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`pyo3`)
  
  For more information about this error, try `rustc --explain E0055`.
  ```
  I'm not sure why they are triggered, but they could all be fixed using simple type annotations. There is a possibility that this could also be triggered in downstream code and the error message is not really that helpful.... I quickly tested this against my migration branch of `rust-numpy`, it didn't cause anything there.