### PR TITLE
use `FromPyObjectBound` for `PyAny::extract`

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -6,7 +6,9 @@ use crate::pyclass::boolean_struct::False;
 use crate::type_object::PyTypeInfo;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
-use crate::{ffi, gil, Bound, Py, PyAny, PyClass, PyNativeType, PyObject, PyRef, PyRefMut, Python};
+use crate::{
+    ffi, gil, Borrowed, Bound, Py, PyAny, PyClass, PyNativeType, PyObject, PyRef, PyRefMut, Python,
+};
 use std::ptr::NonNull;
 
 /// Returns a borrowed pointer to a Python object.
@@ -288,7 +290,7 @@ pub trait FromPyObjectBound<'a, 'py>: Sized + from_py_object_bound_sealed::Seale
     ///
     /// Users are advised against calling this method directly: instead, use this via
     /// [`Bound<'_, PyAny>::extract`] or [`Py::extract`].
-    fn from_py_object_bound(ob: &'a Bound<'py, PyAny>) -> PyResult<Self>;
+    fn from_py_object_bound(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self>;
 
     /// Extracts the type hint information for this type when it appears as an argument.
     ///
@@ -307,8 +309,8 @@ impl<'py, T> FromPyObjectBound<'_, 'py> for T
 where
     T: FromPyObject<'py>,
 {
-    fn from_py_object_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        Self::extract_bound(ob)
+    fn from_py_object_bound(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        Self::extract_bound(&ob)
     }
 
     #[cfg(feature = "experimental-inspect")]

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -128,7 +128,7 @@ impl<'py> FromPyObject<'py> for &'py str {
 
 #[cfg(all(not(feature = "gil-refs"), any(Py_3_10, not(Py_LIMITED_API))))]
 impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a str {
-    fn from_py_object_bound(ob: &'a Bound<'_, PyAny>) -> PyResult<Self> {
+    fn from_py_object_bound(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         ob.downcast::<PyString>()?.to_str()
     }
 
@@ -152,7 +152,7 @@ impl<'py> FromPyObject<'py> for Cow<'py, str> {
 
 #[cfg(not(feature = "gil-refs"))]
 impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for Cow<'a, str> {
-    fn from_py_object_bound(ob: &'a Bound<'_, PyAny>) -> PyResult<Self> {
+    fn from_py_object_bound(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         ob.downcast::<PyString>()?.to_cow()
     }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1,5 +1,5 @@
 use crate::class::basic::CompareOp;
-use crate::conversion::{AsPyPointer, FromPyObject, FromPyObjectBound, IntoPy, ToPyObject};
+use crate::conversion::{AsPyPointer, FromPyObjectBound, IntoPy, ToPyObject};
 use crate::err::{DowncastError, DowncastIntoError, PyDowncastError, PyErr, PyResult};
 use crate::exceptions::{PyAttributeError, PyTypeError};
 use crate::ffi_ptr_ext::FfiPtrExt;
@@ -799,13 +799,14 @@ impl PyAny {
 
     /// Extracts some type from the Python object.
     ///
-    /// This is a wrapper function around [`FromPyObject::extract()`].
+    /// This is a wrapper function around
+    /// [`FromPyObject::extract()`](crate::FromPyObject::extract).
     #[inline]
     pub fn extract<'py, D>(&'py self) -> PyResult<D>
     where
-        D: FromPyObject<'py>,
+        D: FromPyObjectBound<'py, 'py>,
     {
-        FromPyObject::extract(self)
+        FromPyObjectBound::from_py_object_bound(self.as_borrowed())
     }
 
     /// Returns the reference count for the Python object.
@@ -1641,7 +1642,8 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
 
     /// Extracts some type from the Python object.
     ///
-    /// This is a wrapper function around [`FromPyObject::extract()`].
+    /// This is a wrapper function around
+    /// [`FromPyObject::extract()`](crate::FromPyObject::extract).
     fn extract<'a, T>(&'a self) -> PyResult<T>
     where
         T: FromPyObjectBound<'a, 'py>;
@@ -2182,7 +2184,7 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     where
         T: FromPyObjectBound<'a, 'py>,
     {
-        FromPyObjectBound::from_py_object_bound(self)
+        FromPyObjectBound::from_py_object_bound(self.as_borrowed())
     }
 
     fn get_refcnt(&self) -> isize {

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -158,7 +158,7 @@ impl<'py> PyBytesMethods<'py> for Bound<'py, PyBytes> {
 impl<'a> Borrowed<'a, '_, PyBytes> {
     /// Gets the Python string as a byte slice.
     #[allow(clippy::wrong_self_convention)]
-    fn as_bytes(self) -> &'a [u8] {
+    pub(crate) fn as_bytes(self) -> &'a [u8] {
         unsafe {
             let buffer = ffi::PyBytes_AsString(self.as_ptr()) as *const u8;
             let length = ffi::PyBytes_Size(self.as_ptr()) as usize;

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -369,7 +369,7 @@ impl<'a> Borrowed<'a, '_, PyString> {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    fn to_cow(self) -> PyResult<Cow<'a, str>> {
+    pub(crate) fn to_cow(self) -> PyResult<Cow<'a, str>> {
         // TODO: this method can probably be deprecated once Python 3.9 support is dropped,
         // because all versions then support the more efficient `to_str`.
         #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]


### PR DESCRIPTION
This changes the bound of `PyAny::extract` to use `FromPyObjectBound` instead of `FromPyObject`. This allows extracting borrowed types like `&str` or `&[u8]` using the `gil-ref` API, even if the `gil-refs` feature is disabled.

To allow this, `FromPyObjectBound::from_py_object_bound` is switched to take a `Borrowed` instead of `&Bound`. ~This also means that the `FromPyObjectBound` implemetations can now be unconditionally.~ To not break fully qualified syntax (`FromPyObject::extract`) these are kept with `gil-refs` enabled.

Fixes #3958 