### PR TITLE
add `gil-refs-migration` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,11 @@ generate-import-lib = ["pyo3-ffi/generate-import-lib"]
 auto-initialize = []
 
 # Allows use of the deprecated "GIL Refs" APIs.
-gil-refs = []
+gil-refs = ["gil-refs-migration"]
+
+# Subset of the "GIL Refs" feature. As much code as possible will emit
+# deprecation warnings, with breaking changes avoided.
+gil-refs-migration = []
 
 # Optimizes PyObject to Vec conversion and so on.
 nightly = []

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -59,7 +59,7 @@ The feature has some unfinished refinements and performance improvements. To hel
 
 ### `experimental-declarative-modules`
 
-This feature allows to declare Python modules using `#[pymodule] mod my_module { ... }` syntax. 
+This feature allows to declare Python modules using `#[pymodule] mod my_module { ... }` syntax.
 
 The feature has some unfinished refinements and edge cases. To help finish this off, see [issue #3900](https://github.com/PyO3/pyo3/issues/3900).
 
@@ -73,7 +73,15 @@ This is a first step towards adding first-class support for generating type anno
 
 This feature is a backwards-compatibility feature to allow continued use of the "GIL Refs" APIs deprecated in PyO3 0.21. These APIs have performance drawbacks and soundness edge cases which the newer `Bound<T>` smart pointer and accompanying APIs resolve.
 
-This feature and the APIs it enables is expected to be removed in a future PyO3 version.
+This feature and the APIs it enables are expected to be removed in a future PyO3 version. This feature is a superset of the `gil-refs-migration` feature which also suppresses deprecation warnings related to these APIs.
+
+### `gil-refs-migration`
+
+This feature is a temporary feature for PyO3 0.21 to assist with migration off the "GIL Refs" APIs. Unlike the `gil-refs` feature, using this feature will emit deprecation warnings for uses of "GIL Refs" APIs.
+
+Disabling this feature will opt-in to a few breaking changes which cannot be hinted by deprecation warnings. See the [migration guide](./migration.md#deactivating-the-gil-refs-features) for details.
+
+This feature is expected to be removed in PyO3 0.22.
 
 ### `macros`
 

--- a/guide/src/index.md
+++ b/guide/src/index.md
@@ -11,6 +11,7 @@ The rough order of material in this user guide is as follows:
 Please choose from the chapters on the left to jump to individual topics, or continue below to start with PyO3's README.
 
 <div class="warning">
+
 ⚠️ Warning: API update in progress 🛠️
 
 PyO3 0.21 has introduced a significant new API, termed the "Bound" API after the new smart pointer `Bound<T>`.

--- a/guide/src/memory.md
+++ b/guide/src/memory.md
@@ -1,6 +1,7 @@
 # Memory management
 
 <div class="warning">
+
 ⚠️ Warning: API update in progress 🛠️
 
 PyO3 0.21 has introduced a significant new API, termed the "Bound" API after the new smart pointer `Bound<T>`.
@@ -84,6 +85,7 @@ the end of the `with_gil()` closure, at which point the 10 copies of `hello`
 are finally released to the Python garbage collector.
 
 <div class="warning">
+
 ⚠️ Warning: `GILPool` is no longer the preferred way to manage memory with PyO3 🛠️
 
 PyO3 0.21 has introduced a new API known as the Bound API, which doesn't have the same surprising results. Instead, each `Bound<T>` smart pointer releases the Python reference immediately on drop. See [the smart pointer types](./types.md#pyo3s-smart-pointers) for more details.
@@ -155,6 +157,7 @@ a few objects, meaning this doesn't have a significant impact. Occasionally func
 with long complex loops may need to use `Python::new_pool` as shown above.
 
 <div class="warning">
+
 ⚠️ Warning: `GILPool` is no longer the preferred way to manage memory with PyO3 🛠️
 
 PyO3 0.21 has introduced a new API known as the Bound API, which doesn't have the same surprising results. Instead, each `Bound<T>` smart pointer releases the Python reference immediately on drop. See [the smart pointer types](./types.md#pyo3s-smart-pointers) for more details.

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -349,6 +349,7 @@ assert_eq!(name, "list");
 After:
 
 ```rust
+# #[cfg(any(not(Py_LIMITED_API), Py_3_10))] {
 # use pyo3::prelude::*;
 # use pyo3::types::{PyList, PyType};
 # fn example<'py>(py: Python<'py>) -> PyResult<()> {
@@ -361,6 +362,7 @@ assert_eq!(name, "list");
 # Ok(())
 # }
 # Python::with_gil(example).unwrap();
+# }
 ```
 
 An alternative is to use the new `PyBackedStr` type, which stores a reference to the Python `str` without a lifetime attachment:

--- a/newsfragments/3962.added.md
+++ b/newsfragments/3962.added.md
@@ -1,0 +1,1 @@
+Add `gil-refs-migration` feature.

--- a/noxfile.py
+++ b/noxfile.py
@@ -668,6 +668,7 @@ def check_feature_powerset(session: nox.Session):
     EXCLUDED_FROM_FULL = {
         "nightly",
         "gil-refs",
+        "gil-refs-migration",
         "extension-module",
         "full",
         "default",
@@ -709,7 +710,9 @@ def check_feature_powerset(session: nox.Session):
         session.error("no experimental features exist; please simplify the noxfile")
 
     features_to_skip = [
-        *(EXCLUDED_FROM_FULL - {"gil-refs"}),
+        # For 0.21's migration, the two gil-refs compatibility features need to
+        # be checked separately to ensure that cfgs are in alignment.
+        *(EXCLUDED_FROM_FULL - {"gil-refs", "gil-refs-migration"}),
         *abi3_version_features,
     ]
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -250,13 +250,13 @@ mod from_py_object_bound_sealed {
     // This generic implementation is why the seal is separate from
     // `crate::sealed::Sealed`.
     impl<'py, T> Sealed for T where T: super::FromPyObject<'py> {}
-    #[cfg(not(feature = "gil-refs"))]
+    #[cfg(not(feature = "gil-refs-migration"))]
     impl Sealed for &'_ str {}
-    #[cfg(not(feature = "gil-refs"))]
+    #[cfg(not(feature = "gil-refs-migration"))]
     impl Sealed for std::borrow::Cow<'_, str> {}
-    #[cfg(not(feature = "gil-refs"))]
+    #[cfg(not(feature = "gil-refs-migration"))]
     impl Sealed for &'_ [u8] {}
-    #[cfg(not(feature = "gil-refs"))]
+    #[cfg(not(feature = "gil-refs-migration"))]
     impl Sealed for std::borrow::Cow<'_, [u8]> {}
 }
 

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -18,7 +18,7 @@ impl<'a> IntoPy<PyObject> for &'a [u8] {
     }
 }
 
-#[cfg(feature = "gil-refs")]
+#[cfg(feature = "gil-refs-migration")]
 impl<'py> crate::FromPyObject<'py> for &'py [u8] {
     fn extract(obj: &'py PyAny) -> PyResult<Self> {
         Ok(obj.downcast::<PyBytes>()?.as_bytes())
@@ -30,7 +30,7 @@ impl<'py> crate::FromPyObject<'py> for &'py [u8] {
     }
 }
 
-#[cfg(not(feature = "gil-refs"))]
+#[cfg(not(feature = "gil-refs-migration"))]
 impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a [u8] {
     fn from_py_object_bound(obj: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         Ok(obj.downcast::<PyBytes>()?.as_bytes())
@@ -47,7 +47,7 @@ impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a [u8] {
 /// If the source object is a `bytes` object, the `Cow` will be borrowed and
 /// pointing into the source object, and no copying or heap allocations will happen.
 /// If it is a `bytearray`, its contents will be copied to an owned `Cow`.
-#[cfg(feature = "gil-refs")]
+#[cfg(feature = "gil-refs-migration")]
 impl<'py> crate::FromPyObject<'py> for Cow<'py, [u8]> {
     fn extract_bound(ob: &crate::Bound<'py, PyAny>) -> PyResult<Self> {
         use crate::types::PyAnyMethods;
@@ -60,7 +60,7 @@ impl<'py> crate::FromPyObject<'py> for Cow<'py, [u8]> {
     }
 }
 
-#[cfg(not(feature = "gil-refs"))]
+#[cfg(not(feature = "gil-refs-migration"))]
 impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for Cow<'a, [u8]> {
     fn from_py_object_bound(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         if let Ok(bytes) = ob.downcast::<PyBytes>() {

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -114,7 +114,7 @@ impl<'a> IntoPy<PyObject> for &'a String {
 
 /// Allows extracting strings from Python objects.
 /// Accepts Python `str` objects.
-#[cfg(feature = "gil-refs")]
+#[cfg(feature = "gil-refs-migration")]
 impl<'py> FromPyObject<'py> for &'py str {
     fn extract(ob: &'py PyAny) -> PyResult<Self> {
         ob.downcast::<PyString>()?.to_str()
@@ -126,7 +126,7 @@ impl<'py> FromPyObject<'py> for &'py str {
     }
 }
 
-#[cfg(all(not(feature = "gil-refs"), any(Py_3_10, not(Py_LIMITED_API))))]
+#[cfg(all(not(feature = "gil-refs-migration"), any(Py_3_10, not(Py_LIMITED_API))))]
 impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a str {
     fn from_py_object_bound(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         ob.downcast::<PyString>()?.to_str()
@@ -138,7 +138,7 @@ impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a str {
     }
 }
 
-#[cfg(feature = "gil-refs")]
+#[cfg(feature = "gil-refs-migration")]
 impl<'py> FromPyObject<'py> for Cow<'py, str> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         ob.extract().map(Cow::Owned)
@@ -150,7 +150,7 @@ impl<'py> FromPyObject<'py> for Cow<'py, str> {
     }
 }
 
-#[cfg(not(feature = "gil-refs"))]
+#[cfg(not(feature = "gil-refs-migration"))]
 impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for Cow<'a, str> {
     fn from_py_object_bound(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         ob.downcast::<PyString>()?.to_cow()

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -87,7 +87,7 @@ impl<'a, 'py> DowncastError<'a, 'py> {
             to: to.into(),
         }
     }
-    #[cfg(not(feature = "gil-refs"))]
+    #[cfg(not(feature = "gil-refs-migration"))]
     pub(crate) fn new_from_borrowed(
         from: Borrowed<'a, 'py, PyAny>,
         to: impl Into<Cow<'static, str>>,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -580,7 +580,7 @@ impl<'a, 'py> Borrowed<'a, 'py, PyAny> {
     }
 
     #[inline]
-    #[cfg(not(feature = "gil-refs"))]
+    #[cfg(not(feature = "gil-refs-migration"))]
     pub(crate) fn downcast<T>(self) -> Result<Borrowed<'a, 'py, T>, DowncastError<'a, 'py>>
     where
         T: PyTypeCheck,


### PR DESCRIPTION
Closes #3958 

This PR implements the `gil-refs-migration` feature as proposed in that issue, and moves the `FromPyObjectBound` implementations to be gated on that feature.

This way users can migrate the rest of the Bound API deprecations without immediately being broken by the extract changes.

I also added open-by-default details tags to the 0.21 migration guide as per #3961.