### PR TITLE
ci: fixes to actions caches

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,6 +1,6 @@
 name: CI Cache Cleanup
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 
@@ -22,7 +22,7 @@ jobs:
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
-              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+              gh actions-cache delete -R $REPO -B $BRANCH --confirm -- $cacheKey
           done
           echo "Done"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,7 @@ jobs:
           workspaces:
             examples/maturin-starter
           save-if: ${{ github.event_name != 'merge_group' }}
+          key: ${{ matrix.target }}
       - name: Setup cross-compiler
         if: ${{ matrix.target == 'x86_64-pc-windows-gnu' }}
         run: sudo apt-get install -y mingw-w64 llvm


### PR DESCRIPTION
This attempts to fix some issues I'm seeing in our CI caches:
- The `cross-compilation` jobs are unintentionally sharing cache for different build targets. I think this has caused the issue we are currently seeing with GLIBC linking in the x86_64 linux job.
- The cache cleanup job is not being granted write permissions to delete caches. If I'm reading [the GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) correctly the `pull_request_target` runs using the base branch (i.e. `main`), so can be trusted to grant write permissions.
- The `cargo-semver-checks` cache key starts with a dash, like `-semver-<whatever>` and the `gh actions-cache delete` command was treating it as a flag, which it did not recognize. Hopefully by passing the key after `--` will force it to treat it positionally.
 
cc @obi1kenobi - you might be interested to know that the leading dash in the `cargo-semver-checks` cache key can be a footgun for automated tooling.

Will proceed straight to merge as I think there's nothing contentious here and it should unblock CI.