### PR TITLE
handle clippy `new_without_default` warnings

### DIFF
--- a/newsfragments/3971.added.md
+++ b/newsfragments/3971.added.md
@@ -1,0 +1,1 @@
+Implement `Default` for `GILOnceCell`.

--- a/pyo3-ffi/src/cpython/object.rs
+++ b/pyo3-ffi/src/cpython/object.rs
@@ -46,6 +46,7 @@ mod bufferinfo {
     }
 
     impl Py_buffer {
+        #[allow(clippy::new_without_default)]
         pub const fn new() -> Self {
             Py_buffer {
                 buf: ptr::null_mut(),

--- a/pyo3-ffi/src/pybuffer.rs
+++ b/pyo3-ffi/src/pybuffer.rs
@@ -27,6 +27,7 @@ pub struct Py_buffer {
 }
 
 impl Py_buffer {
+    #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
         Py_buffer {
             buf: ptr::null_mut(),

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -32,6 +32,7 @@ struct LazyTypeObjectInner {
 
 impl<T> LazyTypeObject<T> {
     /// Creates an uninitialized `LazyTypeObject`.
+    #[allow(clippy::new_without_default)]
     pub const fn new() -> Self {
         LazyTypeObject(
             LazyTypeObjectInner {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -90,6 +90,7 @@ unsafe impl<T> Sync for GILProtected<T> where T: Send {}
 /// }
 /// # Python::with_gil(|py| assert_eq!(get_shared_list(py).len(), 0));
 /// ```
+#[derive(Default)]
 pub struct GILOnceCell<T>(UnsafeCell<Option<T>>);
 
 // T: Send is needed for Sync because the thread which drops the GILOnceCell can be different


### PR DESCRIPTION
`clippy` on beta toolchain is failing with warnings about some structs which have `fn new()` but no `Default` implementation.

For the FFI and internal ones I just silenced the warning for now, but for `GILOnceCell` this seemed reasonable to add.