### PR TITLE
docs: better document `FromPyObject` for `&str` changes in migration guide

### DIFF
--- a/guide/src/index.md
+++ b/guide/src/index.md
@@ -11,6 +11,7 @@ The rough order of material in this user guide is as follows:
 Please choose from the chapters on the left to jump to individual topics, or continue below to start with PyO3's README.
 
 <div class="warning">
+
 ⚠️ Warning: API update in progress 🛠️
 
 PyO3 0.21 has introduced a significant new API, termed the "Bound" API after the new smart pointer `Bound<T>`.

--- a/guide/src/memory.md
+++ b/guide/src/memory.md
@@ -1,6 +1,7 @@
 # Memory management
 
 <div class="warning">
+
 ⚠️ Warning: API update in progress 🛠️
 
 PyO3 0.21 has introduced a significant new API, termed the "Bound" API after the new smart pointer `Bound<T>`.
@@ -84,6 +85,7 @@ the end of the `with_gil()` closure, at which point the 10 copies of `hello`
 are finally released to the Python garbage collector.
 
 <div class="warning">
+
 ⚠️ Warning: `GILPool` is no longer the preferred way to manage memory with PyO3 🛠️
 
 PyO3 0.21 has introduced a new API known as the Bound API, which doesn't have the same surprising results. Instead, each `Bound<T>` smart pointer releases the Python reference immediately on drop. See [the smart pointer types](./types.md#pyo3s-smart-pointers) for more details.
@@ -121,7 +123,7 @@ this is unsafe.
 # fn main() -> PyResult<()> {
 Python::with_gil(|py| -> PyResult<()> {
     for _ in 0..10 {
-        #[allow(deprecated)]  // `new_pool` is not needed in code not using the GIL Refs API
+        #[allow(deprecated)] // `new_pool` is not needed in code not using the GIL Refs API
         let pool = unsafe { py.new_pool() };
         let py = pool.python();
         #[allow(deprecated)] // py.eval() is part of the GIL Refs API
@@ -155,6 +157,7 @@ a few objects, meaning this doesn't have a significant impact. Occasionally func
 with long complex loops may need to use `Python::new_pool` as shown above.
 
 <div class="warning">
+
 ⚠️ Warning: `GILPool` is no longer the preferred way to manage memory with PyO3 🛠️
 
 PyO3 0.21 has introduced a new API known as the Bound API, which doesn't have the same surprising results. Instead, each `Bound<T>` smart pointer releases the Python reference immediately on drop. See [the smart pointer types](./types.md#pyo3s-smart-pointers) for more details.


### PR DESCRIPTION
Closes #3958 