### PR TITLE
ci: add `update-ui-tests` nox session

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -101,10 +101,17 @@ Tests run with all supported Python versions with the latest stable Rust compile
 If you are adding a new feature, you should add it to the `full` feature in our *Cargo.toml** so that it is tested in CI.
 
 You can run these tests yourself with
-```nox```
-and
-```nox -l```
-lists further commands you can run.
+`nox`. Use  `nox -l` to list the full set of subcommands you can run.
+
+#### UI Tests
+
+PyO3 uses [`trybuild`][trybuild] to develop UI tests to capture error messages from the Rust compiler for some of the macro functionality.
+
+Because there are several feature combinations for these UI tests, when updating them all (e.g. for a new Rust compiler version) it may be helpful to use the `update-ui-tests` nox session:
+
+```bash
+nox -s update-ui-tests
+```
 
 ### Documenting changes
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -395,8 +395,8 @@ def check_guide(session: nox.Session):
     session.posargs.extend(posargs)
 
     remaps = {
-        f"file://{PYO3_GUIDE_SRC}/([^/]*/)*?%7B%7B#PYO3_DOCS_URL\}}\}}": f"file://{PYO3_DOCS_TARGET}",
-        "%7B%7B#PYO3_DOCS_VERSION\}\}": "latest",
+        f"file://{PYO3_GUIDE_SRC}/([^/]*/)*?%7B%7B#PYO3_DOCS_URL}}}}": f"file://{PYO3_DOCS_TARGET}",
+        "%7B%7B#PYO3_DOCS_VERSION}}": "latest",
     }
     remap_args = []
     for key, value in remaps.items():


### PR DESCRIPTION
A new `nox` session to update UI tests for all relevant feature combinations. I built this while working on #3978 after I made the mistake of not updating them all several times.

At the same time, I tweaked the `nox` output on GitHub Actions to hopefully make it slightly easier to spot where errors occur in things like the `clippy` jobs.