### PR TITLE
Add into_mapping and into_sequence methods to Bound types

### DIFF
--- a/newsfragments/3982.added.md
+++ b/newsfragments/3982.added.md
@@ -1,0 +1,1 @@
+Added `Bound<'py, PyDict>::into_mapping`, `Bound<'py, PyList>::into_sequence` and `Bound<'py, PyTuple>::into_sequence`.

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -365,6 +365,9 @@ pub trait PyDictMethods<'py>: crate::sealed::Sealed {
     /// Returns `self` cast as a `PyMapping`.
     fn as_mapping(&self) -> &Bound<'py, PyMapping>;
 
+    /// Returns `self` cast as a `PyMapping`.
+    fn into_mapping(self) -> Bound<'py, PyMapping>;
+
     /// Update this dictionary with the key/value pairs from another.
     ///
     /// This is equivalent to the Python expression `self.update(other)`. If `other` is a `PyDict`, you may want
@@ -509,6 +512,10 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
 
     fn as_mapping(&self) -> &Bound<'py, PyMapping> {
         unsafe { self.downcast_unchecked() }
+    }
+
+    fn into_mapping(self) -> Bound<'py, PyMapping> {
+        unsafe { self.into_any().downcast_into_unchecked() }
     }
 
     fn update(&self, other: &Bound<'_, PyMapping>) -> PyResult<()> {

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -1374,6 +1374,20 @@ mod tests {
         });
     }
 
+    #[test]
+    fn dict_into_mapping() {
+        Python::with_gil(|py| {
+            let mut map = HashMap::<i32, i32>::new();
+            map.insert(1, 1);
+
+            let py_map = map.into_py_dict_bound(py);
+
+            let py_mapping = py_map.into_mapping();
+            assert_eq!(py_mapping.len().unwrap(), 1);
+            assert_eq!(py_mapping.get_item(1).unwrap().extract::<i32>().unwrap(), 1);
+        });
+    }
+
     #[cfg(not(PyPy))]
     fn abc_dict(py: Python<'_>) -> Bound<'_, PyDict> {
         let mut map = HashMap::<&'static str, i32>::new();

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -295,6 +295,9 @@ pub trait PyListMethods<'py>: crate::sealed::Sealed {
     /// Returns `self` cast as a `PySequence`.
     fn as_sequence(&self) -> &Bound<'py, PySequence>;
 
+    /// Returns `self` cast as a `PySequence`.
+    fn into_sequence(self) -> Bound<'py, PySequence>;
+
     /// Gets the list item at the specified index.
     /// # Example
     /// ```
@@ -406,6 +409,11 @@ impl<'py> PyListMethods<'py> for Bound<'py, PyList> {
     /// Returns `self` cast as a `PySequence`.
     fn as_sequence(&self) -> &Bound<'py, PySequence> {
         unsafe { self.downcast_unchecked() }
+    }
+
+    /// Returns `self` cast as a `PySequence`.
+    fn into_sequence(self) -> Bound<'py, PySequence> {
+        unsafe { self.into_any().downcast_into_unchecked() }
     }
 
     /// Gets the list item at the specified index.

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -723,6 +723,9 @@ impl<'py> IntoIterator for &Bound<'py, PyList> {
 #[cfg(test)]
 #[cfg_attr(not(feature = "gil-refs"), allow(deprecated))]
 mod tests {
+    use crate::types::any::PyAnyMethods;
+    use crate::types::list::PyListMethods;
+    use crate::types::sequence::PySequenceMethods;
     use crate::types::{PyList, PyTuple};
     use crate::Python;
     use crate::{IntoPy, PyObject, ToPyObject};
@@ -939,6 +942,35 @@ mod tests {
                 items.push(item.extract::<i32>().unwrap());
             }
             assert_eq!(items, vec![1, 2, 3, 4]);
+        });
+    }
+
+    #[test]
+    fn test_as_sequence() {
+        Python::with_gil(|py| {
+            let list = PyList::new_bound(py, [1, 2, 3, 4]);
+
+            assert_eq!(list.as_sequence().len().unwrap(), 4);
+            assert_eq!(
+                list.as_sequence()
+                    .get_item(1)
+                    .unwrap()
+                    .extract::<i32>()
+                    .unwrap(),
+                2
+            );
+        });
+    }
+
+    #[test]
+    fn test_into_sequence() {
+        Python::with_gil(|py| {
+            let list = PyList::new_bound(py, [1, 2, 3, 4]);
+
+            let sequence = list.into_sequence();
+
+            assert_eq!(sequence.len().unwrap(), 4);
+            assert_eq!(sequence.get_item(1).unwrap().extract::<i32>().unwrap(), 2);
         });
     }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1422,12 +1422,22 @@ mod tests {
     #[test]
     fn test_tuple_as_sequence() {
         Python::with_gil(|py| {
-            let tuple = PyTuple::new(py, vec![1, 2, 3]);
+            let tuple = PyTuple::new_bound(py, vec![1, 2, 3]);
             let sequence = tuple.as_sequence();
             assert!(tuple.get_item(0).unwrap().eq(1).unwrap());
             assert!(sequence.get_item(0).unwrap().eq(1).unwrap());
 
             assert_eq!(tuple.len(), 3);
+            assert_eq!(sequence.len().unwrap(), 3);
+        })
+    }
+
+    #[test]
+    fn test_tuple_into_sequence() {
+        Python::with_gil(|py| {
+            let tuple = PyTuple::new_bound(py, vec![1, 2, 3]);
+            let sequence = tuple.into_sequence();
+            assert!(sequence.get_item(0).unwrap().eq(1).unwrap());
             assert_eq!(sequence.len().unwrap(), 3);
         })
     }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -258,6 +258,9 @@ pub trait PyTupleMethods<'py>: crate::sealed::Sealed {
     /// Returns `self` cast as a `PySequence`.
     fn as_sequence(&self) -> &Bound<'py, PySequence>;
 
+    /// Returns `self` cast as a `PySequence`.
+    fn into_sequence(self) -> Bound<'py, PySequence>;
+
     /// Takes the slice `self[low:high]` and returns it as a new tuple.
     ///
     /// Indices must be nonnegative, and out-of-range indices are clipped to
@@ -351,6 +354,10 @@ impl<'py> PyTupleMethods<'py> for Bound<'py, PyTuple> {
 
     fn as_sequence(&self) -> &Bound<'py, PySequence> {
         unsafe { self.downcast_unchecked() }
+    }
+
+    fn into_sequence(self) -> Bound<'py, PySequence> {
+        unsafe { self.into_any().downcast_into_unchecked() }
     }
 
     fn get_slice(&self, low: usize, high: usize) -> Bound<'py, PyTuple> {


### PR DESCRIPTION
Fixes #3981.

- [x] an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
- [ ] docs to all new functions and / or detail in the guide
- [x] tests for all new or changed functions