### PR TITLE
ci: tidy up benchmarks a little

### DIFF
--- a/pyo3-benches/benches/bench_bigint.rs
+++ b/pyo3-benches/benches/bench_bigint.rs
@@ -1,9 +1,10 @@
-use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+use std::hint::black_box;
+
+use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
+use num_bigint::BigInt;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-
-use num_bigint::BigInt;
 
 fn extract_bigint_extract_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
@@ -11,7 +12,7 @@ fn extract_bigint_extract_fail(bench: &mut Bencher<'_>) {
 
         bench.iter(|| match black_box(&d).extract::<BigInt>() {
             Ok(v) => panic!("should err {}", v),
-            Err(e) => black_box(e),
+            Err(e) => e,
         });
     });
 }
@@ -20,10 +21,7 @@ fn extract_bigint_small(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let int = py.eval_bound("-42", None, None).unwrap();
 
-        bench.iter(|| {
-            let v = black_box(&int).extract::<BigInt>().unwrap();
-            black_box(v);
-        });
+        bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());
     });
 }
 
@@ -31,10 +29,7 @@ fn extract_bigint_big_negative(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let int = py.eval_bound("-10**300", None, None).unwrap();
 
-        bench.iter(|| {
-            let v = black_box(&int).extract::<BigInt>().unwrap();
-            black_box(v);
-        });
+        bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());
     });
 }
 
@@ -42,10 +37,7 @@ fn extract_bigint_big_positive(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let int = py.eval_bound("10**300", None, None).unwrap();
 
-        bench.iter(|| {
-            let v = black_box(&int).extract::<BigInt>().unwrap();
-            black_box(v);
-        });
+        bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());
     });
 }
 
@@ -53,10 +45,7 @@ fn extract_bigint_huge_negative(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let int = py.eval_bound("-10**3000", None, None).unwrap();
 
-        bench.iter(|| {
-            let v = black_box(&int).extract::<BigInt>().unwrap();
-            black_box(v);
-        });
+        bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());
     });
 }
 
@@ -64,10 +53,7 @@ fn extract_bigint_huge_positive(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let int = py.eval_bound("10**3000", None, None).unwrap();
 
-        bench.iter(|| {
-            let v = black_box(&int).extract::<BigInt>().unwrap();
-            black_box(v);
-        });
+        bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());
     });
 }
 

--- a/pyo3-benches/benches/bench_decimal.rs
+++ b/pyo3-benches/benches/bench_decimal.rs
@@ -1,8 +1,10 @@
-use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+use std::hint::black_box;
+
+use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
+use rust_decimal::Decimal;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use rust_decimal::Decimal;
 
 fn decimal_via_extract(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
@@ -18,9 +20,7 @@ py_dec = decimal.Decimal("0.0")
         .unwrap();
         let py_dec = locals.get_item("py_dec").unwrap().unwrap();
 
-        b.iter(|| {
-            let _: Decimal = black_box(&py_dec).extract().unwrap();
-        });
+        b.iter(|| black_box(&py_dec).extract::<Decimal>().unwrap());
     })
 }
 

--- a/pyo3-benches/benches/bench_dict.rs
+++ b/pyo3-benches/benches/bench_dict.rs
@@ -1,9 +1,10 @@
+use std::collections::{BTreeMap, HashMap};
+use std::hint::black_box;
+
 use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
 
 use pyo3::types::IntoPyDict;
 use pyo3::{prelude::*, types::PyMapping};
-use std::collections::{BTreeMap, HashMap};
-use std::hint::black_box;
 
 fn iter_dict(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
@@ -69,7 +70,6 @@ fn extract_hashbrown_map(b: &mut Bencher<'_>) {
     });
 }
 
-#[cfg(not(codspeed))]
 fn mapping_from_dict(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
@@ -84,12 +84,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("dict_get_item", dict_get_item);
     c.bench_function("extract_hashmap", extract_hashmap);
     c.bench_function("extract_btreemap", extract_btreemap);
+    c.bench_function("mapping_from_dict", mapping_from_dict);
 
     #[cfg(feature = "hashbrown")]
     c.bench_function("extract_hashbrown_map", extract_hashbrown_map);
-
-    #[cfg(not(codspeed))]
-    c.bench_function("mapping_from_dict", mapping_from_dict);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/pyo3-benches/benches/bench_extract.rs
+++ b/pyo3-benches/benches/bench_extract.rs
@@ -1,4 +1,6 @@
-use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+use std::hint::black_box;
+
+use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
 
 use pyo3::{
     prelude::*,
@@ -7,9 +9,9 @@ use pyo3::{
 
 fn extract_str_extract_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let s = &PyString::new_bound(py, "Hello, World!");
+        let s = PyString::new_bound(py, "Hello, World!").into_any();
 
-        bench.iter(|| black_box(s).extract::<&str>().unwrap());
+        bench.iter(|| black_box(&s).extract::<&str>().unwrap());
     });
 }
 
@@ -19,7 +21,7 @@ fn extract_str_extract_fail(bench: &mut Bencher<'_>) {
 
         bench.iter(|| match black_box(&d).extract::<&str>() {
             Ok(v) => panic!("should err {}", v),
-            Err(e) => black_box(e),
+            Err(e) => e,
         });
     });
 }
@@ -27,10 +29,10 @@ fn extract_str_extract_fail(bench: &mut Bencher<'_>) {
 #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 fn extract_str_downcast_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let s = &PyString::new_bound(py, "Hello, World!");
+        let s = PyString::new_bound(py, "Hello, World!").into_any();
 
         bench.iter(|| {
-            let py_str = black_box(s).downcast::<PyString>().unwrap();
+            let py_str = black_box(&s).downcast::<PyString>().unwrap();
             py_str.to_str().unwrap()
         });
     });
@@ -42,20 +44,16 @@ fn extract_str_downcast_fail(bench: &mut Bencher<'_>) {
 
         bench.iter(|| match black_box(&d).downcast::<PyString>() {
             Ok(v) => panic!("should err {}", v),
-            Err(e) => black_box(e),
+            Err(e) => e,
         });
     });
 }
 
 fn extract_int_extract_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let int_obj: PyObject = 123.into_py(py);
-        let int = int_obj.as_ref(py);
+        let int = 123.to_object(py).into_bound(py);
 
-        bench.iter(|| {
-            let v = black_box(int).extract::<i64>().unwrap();
-            black_box(v);
-        });
+        bench.iter(|| black_box(&int).extract::<i64>().unwrap());
     });
 }
 
@@ -65,26 +63,22 @@ fn extract_int_extract_fail(bench: &mut Bencher<'_>) {
 
         bench.iter(|| match black_box(&d).extract::<i64>() {
             Ok(v) => panic!("should err {}", v),
-            Err(e) => black_box(e),
+            Err(e) => e,
         });
     });
 }
 
-#[cfg(not(codspeed))]
 fn extract_int_downcast_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let int_obj: PyObject = 123.into_py(py);
-        let int = int_obj.as_ref(py);
+        let int = 123.to_object(py).into_bound(py);
 
         bench.iter(|| {
-            let py_int = black_box(int).downcast::<PyInt>().unwrap();
-            let v = py_int.extract::<i64>().unwrap();
-            black_box(v);
+            let py_int = black_box(&int).downcast::<PyInt>().unwrap();
+            py_int.extract::<i64>().unwrap()
         });
     });
 }
 
-#[cfg(not(codspeed))]
 fn extract_int_downcast_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         let d = PyDict::new_bound(py).into_any();
@@ -96,16 +90,11 @@ fn extract_int_downcast_fail(bench: &mut Bencher<'_>) {
     });
 }
 
-#[cfg(not(codspeed))]
 fn extract_float_extract_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let float_obj: PyObject = 23.42.into_py(py);
-        let float = float_obj.as_ref(py);
+        let float = 23.42.to_object(py).into_bound(py);
 
-        bench.iter(|| {
-            let v = black_box(float).extract::<f64>().unwrap();
-            black_box(v);
-        });
+        bench.iter(|| black_box(&float).extract::<f64>().unwrap());
     });
 }
 
@@ -115,21 +104,18 @@ fn extract_float_extract_fail(bench: &mut Bencher<'_>) {
 
         bench.iter(|| match black_box(&d).extract::<f64>() {
             Ok(v) => panic!("should err {}", v),
-            Err(e) => black_box(e),
+            Err(e) => e,
         });
     });
 }
 
-#[cfg(not(codspeed))]
 fn extract_float_downcast_success(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let float_obj: PyObject = 23.42.into_py(py);
-        let float = float_obj.as_ref(py);
+        let float = 23.42.to_object(py).into_bound(py);
 
         bench.iter(|| {
-            let py_int = black_box(float).downcast::<PyFloat>().unwrap();
-            let v = py_int.extract::<f64>().unwrap();
-            black_box(v);
+            let py_float = black_box(&float).downcast::<PyFloat>().unwrap();
+            py_float.value()
         });
     });
 }
@@ -140,7 +126,7 @@ fn extract_float_downcast_fail(bench: &mut Bencher<'_>) {
 
         bench.iter(|| match black_box(&d).downcast::<PyFloat>() {
             Ok(v) => panic!("should err {}", v),
-            Err(e) => black_box(e),
+            Err(e) => e,
         });
     });
 }
@@ -151,20 +137,15 @@ fn criterion_benchmark(c: &mut Criterion) {
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     c.bench_function("extract_str_downcast_success", extract_str_downcast_success);
     c.bench_function("extract_str_downcast_fail", extract_str_downcast_fail);
-    #[cfg(not(codspeed))]
     c.bench_function("extract_int_extract_success", extract_int_extract_success);
     c.bench_function("extract_int_extract_fail", extract_int_extract_fail);
-    #[cfg(not(codspeed))]
     c.bench_function("extract_int_downcast_success", extract_int_downcast_success);
-    #[cfg(not(codspeed))]
     c.bench_function("extract_int_downcast_fail", extract_int_downcast_fail);
-    #[cfg(not(codspeed))]
     c.bench_function(
         "extract_float_extract_success",
         extract_float_extract_success,
     );
     c.bench_function("extract_float_extract_fail", extract_float_extract_fail);
-    #[cfg(not(codspeed))]
     c.bench_function(
         "extract_float_downcast_success",
         extract_float_downcast_success,

--- a/pyo3-benches/benches/bench_list.rs
+++ b/pyo3-benches/benches/bench_list.rs
@@ -55,7 +55,6 @@ fn list_get_item_unchecked(b: &mut Bencher<'_>) {
     });
 }
 
-#[cfg(not(codspeed))]
 fn sequence_from_list(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
@@ -70,7 +69,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("list_get_item", list_get_item);
     #[cfg(not(Py_LIMITED_API))]
     c.bench_function("list_get_item_unchecked", list_get_item_unchecked);
-    #[cfg(not(codspeed))]
     c.bench_function("sequence_from_list", sequence_from_list);
 }
 

--- a/pyo3-benches/benches/bench_set.rs
+++ b/pyo3-benches/benches/bench_set.rs
@@ -2,7 +2,10 @@ use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criter
 
 use pyo3::prelude::*;
 use pyo3::types::PySet;
-use std::collections::{BTreeSet, HashSet};
+use std::{
+    collections::{BTreeSet, HashSet},
+    hint::black_box,
+};
 
 fn set_new(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
@@ -31,16 +34,20 @@ fn iter_set(b: &mut Bencher<'_>) {
 fn extract_hashset(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
-        let set = PySet::new_bound(py, &(0..LEN).collect::<Vec<_>>()).unwrap();
-        b.iter_with_large_drop(|| HashSet::<u64>::extract(set.as_gil_ref()));
+        let any = PySet::new_bound(py, &(0..LEN).collect::<Vec<_>>())
+            .unwrap()
+            .into_any();
+        b.iter_with_large_drop(|| black_box(&any).extract::<HashSet<u64>>());
     });
 }
 
 fn extract_btreeset(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
-        let set = PySet::new_bound(py, &(0..LEN).collect::<Vec<_>>()).unwrap();
-        b.iter_with_large_drop(|| BTreeSet::<u64>::extract(set.as_gil_ref()));
+        let any = PySet::new_bound(py, &(0..LEN).collect::<Vec<_>>())
+            .unwrap()
+            .into_any();
+        b.iter_with_large_drop(|| black_box(&any).extract::<BTreeSet<u64>>());
     });
 }
 
@@ -48,8 +55,10 @@ fn extract_btreeset(b: &mut Bencher<'_>) {
 fn extract_hashbrown_set(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
-        let set = PySet::new_bound(py, &(0..LEN).collect::<Vec<_>>()).unwrap();
-        b.iter_with_large_drop(|| hashbrown::HashSet::<u64>::extract(set.as_gil_ref()));
+        let any = PySet::new_bound(py, &(0..LEN).collect::<Vec<_>>())
+            .unwrap()
+            .into_any();
+        b.iter_with_large_drop(|| black_box(&any).extract::<hashbrown::HashSet<u64>>());
     });
 }
 

--- a/pyo3-benches/benches/bench_tuple.rs
+++ b/pyo3-benches/benches/bench_tuple.rs
@@ -1,3 +1,5 @@
+use std::hint::black_box;
+
 use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
 
 use pyo3::prelude::*;
@@ -89,12 +91,11 @@ fn tuple_get_borrowed_item_unchecked(b: &mut Bencher<'_>) {
     });
 }
 
-#[cfg(not(codspeed))]
 fn sequence_from_tuple(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
-        let tuple = PyTuple::new_bound(py, 0..LEN).to_object(py);
-        b.iter(|| tuple.downcast::<PySequence>(py).unwrap());
+        let tuple = PyTuple::new_bound(py, 0..LEN).into_any();
+        b.iter(|| black_box(&tuple).downcast::<PySequence>().unwrap());
     });
 }
 
@@ -132,7 +133,6 @@ fn criterion_benchmark(c: &mut Criterion) {
         "tuple_get_borrowed_item_unchecked",
         tuple_get_borrowed_item_unchecked,
     );
-    #[cfg(not(codspeed))]
     c.bench_function("sequence_from_tuple", sequence_from_tuple);
     c.bench_function("tuple_new_list", tuple_new_list);
     c.bench_function("tuple_to_list", tuple_to_list);


### PR DESCRIPTION
Codspeed has a new feature to ignore benchmarks which are volatile, so we can resume running them here (and collecting their history) but not get annoying messages on PRs.

Also, some other tiny tidy ups at the same time:
- Use `std::hint::black_box` rather than the one from `criterion`.
- Remove some remaining uses of gil-refs 👀 
- Be a little bit more consistent about just black-boxing the input and returning output.