### PR TITLE
handle `#[pyo3(from_py_with = "")]` in `#[setter]` methods

### DIFF
--- a/newsfragments/3995.fixed.md
+++ b/newsfragments/3995.fixed.md
@@ -1,0 +1,1 @@
+handle `#[pyo3(from_py_with = "")]` in `#[setter]` methods

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -41,10 +41,19 @@ impl ClassWithProperties {
         self.num = value;
     }
 
+    #[setter]
+    fn set_from_len(&mut self, #[pyo3(from_py_with = "extract_len")] value: i32) {
+        self.num = value;
+    }
+
     #[getter]
     fn get_data_list<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
         PyList::new_bound(py, [self.num])
     }
+}
+
+fn extract_len(any: &Bound<'_, PyAny>) -> PyResult<i32> {
+    any.len().map(|len| len as i32)
 }
 
 #[test]
@@ -63,6 +72,9 @@ fn class_with_properties() {
         py_run!(py, inst, "inst.unwrapped = 42");
         py_run!(py, inst, "assert inst.get_num() == inst.unwrapped == 42");
         py_run!(py, inst, "assert inst.data_list == [42]");
+
+        py_run!(py, inst, "inst.from_len = [0, 0, 0]");
+        py_run!(py, inst, "assert inst.get_num() == 3");
 
         let d = [("C", py.get_type_bound::<ClassWithProperties>())].into_py_dict_bound(py);
         py_assert!(py, *d, "C.DATA.__doc__ == 'a getter for data'");

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -26,6 +26,12 @@ impl MyClass {
 
     #[staticmethod]
     fn static_method_gil_ref(_any: &PyAny) {}
+
+    #[setter]
+    fn set_foo_gil_ref(&self, #[pyo3(from_py_with = "extract_gil_ref")] _value: i32) {}
+
+    #[setter]
+    fn set_foo_bound(&self, #[pyo3(from_py_with = "extract_bound")] _value: i32) {}
 }
 
 fn main() {}

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -34,70 +34,76 @@ error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`
 28 |     fn static_method_gil_ref(_any: &PyAny) {}
    |                                    ^
 
-error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:41:43
+error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
+  --> tests/ui/deprecations.rs:31:53
    |
-41 | fn pyfunction_with_module_gil_ref(module: &PyModule) -> PyResult<&str> {
+31 |     fn set_foo_gil_ref(&self, #[pyo3(from_py_with = "extract_gil_ref")] _value: i32) {}
+   |                                                     ^^^^^^^^^^^^^^^^^
+
+error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
+  --> tests/ui/deprecations.rs:47:43
+   |
+47 | fn pyfunction_with_module_gil_ref(module: &PyModule) -> PyResult<&str> {
    |                                           ^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:51:19
+  --> tests/ui/deprecations.rs:57:19
    |
-51 | fn module_gil_ref(m: &PyModule) -> PyResult<()> {
+57 | fn module_gil_ref(m: &PyModule) -> PyResult<()> {
    |                   ^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:57:57
+  --> tests/ui/deprecations.rs:63:57
    |
-57 | fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+63 | fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
    |                                                         ^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-  --> tests/ui/deprecations.rs:90:27
+  --> tests/ui/deprecations.rs:96:27
    |
-90 |     #[pyo3(from_py_with = "extract_gil_ref")] _gil_ref: i32,
+96 |     #[pyo3(from_py_with = "extract_gil_ref")] _gil_ref: i32,
    |                           ^^^^^^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:96:29
-   |
-96 | fn pyfunction_gil_ref(_any: &PyAny) {}
-   |                             ^
+   --> tests/ui/deprecations.rs:102:29
+    |
+102 | fn pyfunction_gil_ref(_any: &PyAny) {}
+    |                             ^
 
 error: use of deprecated method `pyo3::deprecations::OptionGilRefs::<std::option::Option<T>>::function_arg`: use `Option<&Bound<'_, T>>` instead for this function argument
-  --> tests/ui/deprecations.rs:99:36
-   |
-99 | fn pyfunction_option_gil_ref(_any: Option<&PyAny>) {}
-   |                                    ^^^^^^
+   --> tests/ui/deprecations.rs:105:36
+    |
+105 | fn pyfunction_option_gil_ref(_any: Option<&PyAny>) {}
+    |                                    ^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:106:27
+   --> tests/ui/deprecations.rs:112:27
     |
-106 |     #[pyo3(from_py_with = "PyAny::len", item("my_object"))]
+112 |     #[pyo3(from_py_with = "PyAny::len", item("my_object"))]
     |                           ^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:116:27
+   --> tests/ui/deprecations.rs:122:27
     |
-116 |     #[pyo3(from_py_with = "PyAny::len")] usize,
+122 |     #[pyo3(from_py_with = "PyAny::len")] usize,
     |                           ^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:122:31
+   --> tests/ui/deprecations.rs:128:31
     |
-122 |     Zip(#[pyo3(from_py_with = "extract_gil_ref")] i32),
+128 |     Zip(#[pyo3(from_py_with = "extract_gil_ref")] i32),
     |                               ^^^^^^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:129:27
+   --> tests/ui/deprecations.rs:135:27
     |
-129 |     #[pyo3(from_py_with = "extract_gil_ref")]
+135 |     #[pyo3(from_py_with = "extract_gil_ref")]
     |                           ^^^^^^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<pyo3::Python<'_>>::is_python`: use `wrap_pyfunction_bound!` instead
-   --> tests/ui/deprecations.rs:142:13
+   --> tests/ui/deprecations.rs:148:13
     |
-142 |     let _ = wrap_pyfunction!(double, py);
+148 |     let _ = wrap_pyfunction!(double, py);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: this error originates in the macro `wrap_pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Fixes #3992 

Handle the `#[pyo3(from_py_with = "")]` attribute in `#[setter]` methods instead of silently ignoring it.
