### PR TITLE
refactor `#[setter]` argument extraction

### DIFF
--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -63,6 +63,10 @@ impl<'a> FnArg<'a> {
             }
         }
     }
+
+    pub fn is_regular(&self) -> bool {
+        !self.py && !self.is_cancel_handle && !self.is_kwargs && !self.is_varargs
+    }
 }
 
 fn handle_argument_error(pat: &syn::Pat) -> syn::Error {

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -223,7 +223,9 @@ pub fn argument_extraction_error(py: Python<'_>, arg_name: &str, error: PyErr) -
 /// `argument` must not be `None`
 #[doc(hidden)]
 #[inline]
-pub unsafe fn unwrap_required_argument(argument: Option<PyArg<'_>>) -> PyArg<'_> {
+pub unsafe fn unwrap_required_argument<'a, 'py>(
+    argument: Option<&'a Bound<'py, PyAny>>,
+) -> &'a Bound<'py, PyAny> {
     match argument {
         Some(value) => value,
         #[cfg(debug_assertions)]

--- a/tests/ui/static_ref.stderr
+++ b/tests/ui/static_ref.stderr
@@ -9,6 +9,18 @@ error: lifetime may not live long enough
   |
   = note: this error originates in the attribute macro `pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)
 
+error[E0597]: `output[_]` does not live long enough
+ --> tests/ui/static_ref.rs:4:1
+  |
+4 | #[pyfunction]
+  | ^^^^^^^^^^^^-
+  | |           |
+  | |           `output[_]` dropped here while still borrowed
+  | borrowed value does not live long enough
+  | argument requires that `output[_]` is borrowed for `'static`
+  |
+  = note: this error originates in the attribute macro `pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0597]: `holder_0` does not live long enough
  --> tests/ui/static_ref.rs:5:15
   |
@@ -20,17 +32,6 @@ error[E0597]: `holder_0` does not live long enough
   | argument requires that `holder_0` is borrowed for `'static`
 5 | fn static_ref(list: &'static Bound<'_, PyList>) -> usize {
   |               ^^^^^^^ borrowed value does not live long enough
-
-error[E0716]: temporary value dropped while borrowed
- --> tests/ui/static_ref.rs:5:21
-  |
-4 | #[pyfunction]
-  | -------------
-  | |           |
-  | |           temporary value is freed at the end of this statement
-  | argument requires that borrow lasts for `'static`
-5 | fn static_ref(list: &'static Bound<'_, PyList>) -> usize {
-  |                     ^ creates a temporary value which is freed while still in use
 
 error: lifetime may not live long enough
  --> tests/ui/static_ref.rs:9:1


### PR DESCRIPTION
I took a shot at the refactoring of the `#[setter]` argument discussed in https://github.com/PyO3/pyo3/pull/3998#discussion_r1540848826.

This tries to decouples `impl_arg_param` from the layout used in regular `#[pyfunction]`/`#[pymethods]` by moving the `args_array` assumption one layer up. I left `PropertyType::Descriptor` untouched because I don't see a good may to integrate that (but since that one is not customizable it seem fine)

The deprecation warning make this still quite noisy, but I think once we can finally (🙏 ) remove them, this should get significantly better.