### PR TITLE
docs: fix typo in getting-started.md

### DIFF
--- a/guide/src/getting-started.md
+++ b/guide/src/getting-started.md
@@ -33,7 +33,7 @@ You can read more about `pyenv`'s configuration options [here](https://github.co
 
 ### Building
 
-There are a number of build and Python package management systems such as [`setuptools-rust`](https://github.com/PyO3/setuptools-rust) or [manually](./building-and-distribution.md#manual-builds). We recommend the use of `maturin`, which you can install [here](https://maturin.rs/installation.html). It is developed to work with PyO3 and provides the most "batteries included" experience, especially if you are aiming to publish to PyPI. `maturin` is just a Python package, so you can add it in the same you already install Python packages.
+There are a number of build and Python package management systems such as [`setuptools-rust`](https://github.com/PyO3/setuptools-rust) or [manually](./building-and-distribution.md#manual-builds). We recommend the use of `maturin`, which you can install [here](https://maturin.rs/installation.html). It is developed to work with PyO3 and provides the most "batteries included" experience, especially if you are aiming to publish to PyPI. `maturin` is just a Python package, so you can add it in the same way you already install Python packages.
 
 System Python:
 ```bash


### PR DESCRIPTION
Missing word, `s/same you already install/same way you already install`

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request. To run its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
