### PR TITLE
implement `Send` and `Sync` for `PyBackedStr` and `PyBackedBytes`

### DIFF
--- a/newsfragments/4007.fixed.md
+++ b/newsfragments/4007.fixed.md
@@ -1,0 +1,1 @@
+Implement `Send` and `Sync` for `PyBackedStr` and `PyBackedBytes`.


### PR DESCRIPTION
I noticed while working on my PyO3 tutorial today that the `PyBackedStr` and `PyBackedBytes` types do not implement `Send` or `Sync`, because they have a `NonNull` pointer inside them.

I think it should be perfectly safe to implement `Send` and `Sync` here, because these types are immutable and the `Py` smart pointer is already `Send` and `Sync`.