### PR TITLE
Ensure all arguments to _run are strings

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -406,7 +406,7 @@ def check_guide(session: nox.Session):
         session,
         "lychee",
         "--include-fragments",
-        PYO3_GUIDE_SRC,
+        str(PYO3_GUIDE_SRC),
         *remap_args,
         *session.posargs,
     )


### PR DESCRIPTION
Otherwise you get errors like https://github.com/PyO3/pyo3/actions/runs/8480723060/job/23236947935?pr=4012
