### PR TITLE
async method should allow args not only receiver

### DIFF
--- a/newsfragments/4015.fixed.md
+++ b/newsfragments/4015.fixed.md
@@ -1,0 +1,1 @@
+Fix the bug that an async `#[pymethod]` with receiver can't have any other args.

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::{ext::IdentExt, spanned::Spanned, Ident, Result};
 
 use crate::utils::Ctx;
@@ -528,17 +528,33 @@ impl<'a> FnSpec<'a> {
                     Some(cls) => quote!(Some(<#cls as #pyo3_path::PyTypeInfo>::NAME)),
                     None => quote!(None),
                 };
+                let evaluate_args = || -> (Vec<Ident>, TokenStream) {
+                    let mut arg_names = Vec::with_capacity(args.len());
+                    let mut evaluate_arg = quote! {};
+                    for arg in &args {
+                        let arg_name = format_ident!("arg_{}", arg_names.len());
+                        arg_names.push(arg_name.clone());
+                        evaluate_arg.extend(quote! {
+                            let #arg_name = #arg
+                        });
+                    }
+                    (arg_names, evaluate_arg)
+                };
                 let future = match self.tp {
                     FnType::Fn(SelfType::Receiver { mutable: false, .. }) => {
+                        let (arg_name, evaluate_arg) = evaluate_args();
                         quote! {{
+                            #evaluate_arg;
                             let __guard = #pyo3_path::impl_::coroutine::RefGuard::<#cls>::new(&#pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(py, &_slf))?;
-                            async move { function(&__guard, #(#args),*).await }
+                            async move { function(&__guard, #(#arg_name),*).await }
                         }}
                     }
                     FnType::Fn(SelfType::Receiver { mutable: true, .. }) => {
+                        let (arg_name, evaluate_arg) = evaluate_args();
                         quote! {{
+                            #evaluate_arg;
                             let mut __guard = #pyo3_path::impl_::coroutine::RefMutGuard::<#cls>::new(&#pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(py, &_slf))?;
-                            async move { function(&mut __guard, #(#args),*).await }
+                            async move { function(&mut __guard, #(#arg_name),*).await }
                         }}
                     }
                     _ => {


### PR DESCRIPTION
Playing with procedural macros for the first time, so any comments/suggestions are welcome.

This fixes #4005.