### PR TITLE
added various std traits for `PyBackedStr` and `PyBackedBytes`

### DIFF
--- a/newsfragments/4020.added.md
+++ b/newsfragments/4020.added.md
@@ -1,0 +1,1 @@
+Adds `Clone`, `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash` implementation for `PyBackedBytes` and `PyBackedStr`, and `Display` for `PyBackedStr`.


### PR DESCRIPTION
Adds `Clone`, `Debug`, `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash` implementation for `PyBackedBytes` and `PyBackedStr`, and `Display` for `PyBackedStr`. The implementations just delegate to `&[u8]` and `&str` respectively. `PartialEq` and `PartialOrd` are also implemented between `Self` and `Deref::Target` respectively.
