### PR TITLE
ci: run PR coverage only on macos arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,34 +369,24 @@ jobs:
     name: coverage ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["windows-latest", "macos-14", "ubuntu-latest"]  # first available arm macos runner
+        # macos-14 is first available arm macos runner
+        # it's the fastest job so use it on PR instead of ubuntu to get faster feedback
+        os: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI-build-full')) && fromJson('["macos-14"]') || fromJson('["windows-latest", "macos-14", "ubuntu-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
-      - if: ${{ github.event_name == 'pull_request' && matrix.os != 'ubuntu-latest' }}
-        id: should-skip
-        shell: bash
-        run: echo 'skip=true' >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
-        if: steps.should-skip.outputs.skip != 'true'
       - uses: actions/setup-python@v5
-        if: steps.should-skip.outputs.skip != 'true'
       - uses: Swatinem/rust-cache@v2
-        if: steps.should-skip.outputs.skip != 'true'
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.should-skip.outputs.skip != 'true'
         with:
           components: llvm-tools-preview,rust-src
       - name: Install cargo-llvm-cov
-        if: steps.should-skip.outputs.skip != 'true'
         uses: taiki-e/install-action@cargo-llvm-cov
       - run: python -m pip install --upgrade pip && pip install nox
-        if: steps.should-skip.outputs.skip != 'true'
       - run: nox -s coverage
-        if: steps.should-skip.outputs.skip != 'true'
       - uses: codecov/codecov-action@v4
-        if: steps.should-skip.outputs.skip != 'true'
         with:
           file: coverage.json
           name: ${{ matrix.os }}


### PR DESCRIPTION
Related to #4017 

macOS arm runners seem to be faster than ubuntu runners at present. Also our CI bottleneck is ubuntu runners, not macos arm runners.

I propose we move the coverage run on PR to macOS. I feel a little dirty doing this as it feels more pure to measure on linux, but we don't actually enforce coverage (it's just a heuristic) so overall reducing the load on CI seems reasonable.