### PR TITLE
ci: defer test-debug to the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,7 @@ jobs:
         run: nox -s test-emscripten
 
   test-debug:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I don't think `test-debug` has caught anything in a while, so I suggest we defer the work to the merge queue.