### PR TITLE
skip type check of method receivers where unnecessary

### DIFF
--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::attributes::{NameAttribute, RenamingRule};
-use crate::method::{CallingConvention, ExtractErrorMode};
+use crate::method::{AssumeCorrectReceiverType, CallingConvention, ExtractErrorMode};
 use crate::params::Holders;
 use crate::utils::Ctx;
 use crate::utils::PythonDoc;
@@ -515,7 +515,13 @@ fn impl_call_setter(
     ctx: &Ctx,
 ) -> syn::Result<TokenStream> {
     let (py_arg, args) = split_off_python_arg(&spec.signature.arguments);
-    let slf = self_type.receiver(cls, ExtractErrorMode::Raise, holders, ctx);
+    let slf = self_type.receiver(
+        cls,
+        ExtractErrorMode::Raise,
+        holders,
+        AssumeCorrectReceiverType::Yes,
+        ctx,
+    );
 
     if args.is_empty() {
         bail_spanned!(spec.name.span() => "setter function expected to have one argument");
@@ -554,7 +560,13 @@ pub fn impl_py_setter_def(
                 mutable: true,
                 span: Span::call_site(),
             }
-            .receiver(cls, ExtractErrorMode::Raise, &mut holders, ctx);
+            .receiver(
+                cls,
+                ExtractErrorMode::Raise,
+                &mut holders,
+                AssumeCorrectReceiverType::Yes,
+                ctx,
+            );
             if let Some(ident) = &field.ident {
                 // named struct field
                 quote!({ #slf.#ident = _val; })
@@ -687,7 +699,13 @@ fn impl_call_getter(
     ctx: &Ctx,
 ) -> syn::Result<TokenStream> {
     let (py_arg, args) = split_off_python_arg(&spec.signature.arguments);
-    let slf = self_type.receiver(cls, ExtractErrorMode::Raise, holders, ctx);
+    let slf = self_type.receiver(
+        cls,
+        ExtractErrorMode::Raise,
+        holders,
+        AssumeCorrectReceiverType::Yes,
+        ctx,
+    );
     ensure_spanned!(
         args.is_empty(),
         args[0].ty.span() => "getter function can only have one argument (of type pyo3::Python)"
@@ -722,7 +740,13 @@ pub fn impl_py_getter_def(
                 mutable: false,
                 span: Span::call_site(),
             }
-            .receiver(cls, ExtractErrorMode::Raise, &mut holders, ctx);
+            .receiver(
+                cls,
+                ExtractErrorMode::Raise,
+                &mut holders,
+                AssumeCorrectReceiverType::Yes,
+                ctx,
+            );
             let field_token = if let Some(ident) = &field.ident {
                 // named struct field
                 ident.to_token_stream()
@@ -1250,6 +1274,7 @@ impl SlotDef {
             *extract_error_mode,
             &mut holders,
             return_mode.as_ref(),
+            AssumeCorrectReceiverType::Yes,
             ctx,
         )?;
         let name = spec.name;
@@ -1298,12 +1323,17 @@ fn generate_method_body(
     extract_error_mode: ExtractErrorMode,
     holders: &mut Holders,
     return_mode: Option<&ReturnMode>,
+    assume_correct_receiver_type: AssumeCorrectReceiverType,
     ctx: &Ctx,
 ) -> Result<TokenStream> {
     let Ctx { pyo3_path } = ctx;
-    let self_arg = spec
-        .tp
-        .self_arg(Some(cls), extract_error_mode, holders, ctx);
+    let self_arg = spec.tp.self_arg(
+        Some(cls),
+        extract_error_mode,
+        holders,
+        assume_correct_receiver_type,
+        ctx,
+    );
     let rust_name = spec.name;
     let args = extract_proto_arguments(spec, arguments, extract_error_mode, holders, ctx)?;
     let call = quote! { #cls::#rust_name(#self_arg #(#args),*) };
@@ -1323,6 +1353,7 @@ struct SlotFragmentDef {
     fragment: &'static str,
     arguments: &'static [Ty],
     extract_error_mode: ExtractErrorMode,
+    assume_correct_receiver_type: AssumeCorrectReceiverType,
     ret_ty: Ty,
 }
 
@@ -1332,12 +1363,18 @@ impl SlotFragmentDef {
             fragment,
             arguments,
             extract_error_mode: ExtractErrorMode::Raise,
+            assume_correct_receiver_type: AssumeCorrectReceiverType::Yes,
             ret_ty: Ty::Void,
         }
     }
 
     const fn extract_error_mode(mut self, extract_error_mode: ExtractErrorMode) -> Self {
         self.extract_error_mode = extract_error_mode;
+        self
+    }
+
+    const fn no_assume_correct_receiver_type(mut self) -> Self {
+        self.assume_correct_receiver_type = AssumeCorrectReceiverType::No;
         self
     }
 
@@ -1357,6 +1394,7 @@ impl SlotFragmentDef {
             fragment,
             arguments,
             extract_error_mode,
+            assume_correct_receiver_type,
             ret_ty,
         } = self;
         let fragment_trait = format_ident!("PyClass{}SlotFragment", fragment);
@@ -1374,6 +1412,7 @@ impl SlotFragmentDef {
             *extract_error_mode,
             &mut holders,
             None,
+            *assume_correct_receiver_type,
             ctx,
         )?;
         let ret_ty = ret_ty.ffi_type(ctx);
@@ -1424,6 +1463,7 @@ macro_rules! binary_num_slot_fragment_def {
     ($ident:ident, $name:literal) => {
         const $ident: SlotFragmentDef = SlotFragmentDef::new($name, &[Ty::Object])
             .extract_error_mode(ExtractErrorMode::NotImplemented)
+            .no_assume_correct_receiver_type()
             .ret_ty(Ty::Object);
     };
 }
@@ -1457,28 +1497,36 @@ binary_num_slot_fragment_def!(__ROR__, "__ror__");
 
 const __POW__: SlotFragmentDef = SlotFragmentDef::new("__pow__", &[Ty::Object, Ty::Object])
     .extract_error_mode(ExtractErrorMode::NotImplemented)
+    .no_assume_correct_receiver_type()
     .ret_ty(Ty::Object);
 const __RPOW__: SlotFragmentDef = SlotFragmentDef::new("__rpow__", &[Ty::Object, Ty::Object])
     .extract_error_mode(ExtractErrorMode::NotImplemented)
+    .no_assume_correct_receiver_type()
     .ret_ty(Ty::Object);
 
 const __LT__: SlotFragmentDef = SlotFragmentDef::new("__lt__", &[Ty::Object])
     .extract_error_mode(ExtractErrorMode::NotImplemented)
+    .no_assume_correct_receiver_type()
     .ret_ty(Ty::Object);
 const __LE__: SlotFragmentDef = SlotFragmentDef::new("__le__", &[Ty::Object])
     .extract_error_mode(ExtractErrorMode::NotImplemented)
+    .no_assume_correct_receiver_type()
     .ret_ty(Ty::Object);
 const __EQ__: SlotFragmentDef = SlotFragmentDef::new("__eq__", &[Ty::Object])
     .extract_error_mode(ExtractErrorMode::NotImplemented)
+    .no_assume_correct_receiver_type()
     .ret_ty(Ty::Object);
 const __NE__: SlotFragmentDef = SlotFragmentDef::new("__ne__", &[Ty::Object])
     .extract_error_mode(ExtractErrorMode::NotImplemented)
+    .no_assume_correct_receiver_type()
     .ret_ty(Ty::Object);
 const __GT__: SlotFragmentDef = SlotFragmentDef::new("__gt__", &[Ty::Object])
     .extract_error_mode(ExtractErrorMode::NotImplemented)
+    .no_assume_correct_receiver_type()
     .ret_ty(Ty::Object);
 const __GE__: SlotFragmentDef = SlotFragmentDef::new("__ge__", &[Ty::Object])
     .extract_error_mode(ExtractErrorMode::NotImplemented)
+    .no_assume_correct_receiver_type()
     .ret_ty(Ty::Object);
 
 fn extract_proto_arguments(

--- a/tests/ui/invalid_frozen_pyclass_borrow.stderr
+++ b/tests/ui/invalid_frozen_pyclass_borrow.stderr
@@ -10,11 +10,11 @@ error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`
 11 |     fn mut_method(&mut self) {}
    |                   ^ expected `False`, found `True`
    |
-note: required by a bound in `extract_pyclass_ref_mut`
-  --> src/impl_/extract_argument.rs
+note: required by a bound in `receive_pyclass_mut`
+  --> src/impl_/pymethods.rs
    |
-   | pub fn extract_pyclass_ref_mut<'a, 'py: 'a, T: PyClass<Frozen = False>>(
-   |                                                        ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
+   | pub unsafe fn receive_pyclass_mut<'a, 'py: 'a, T: PyClass<Frozen = False>>(
+   |                                                           ^^^^^^^^^^^^^^ required by this bound in `receive_pyclass_mut`
 
 error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`
  --> tests/ui/invalid_frozen_pyclass_borrow.rs:9:1

--- a/tests/ui/invalid_pymethod_enum.stderr
+++ b/tests/ui/invalid_pymethod_enum.stderr
@@ -4,11 +4,11 @@ error[E0271]: type mismatch resolving `<ComplexEnum as PyClass>::Frozen == False
 11 |     fn mutate_in_place(&mut self) {
    |                        ^ expected `False`, found `True`
    |
-note: required by a bound in `extract_pyclass_ref_mut`
-  --> src/impl_/extract_argument.rs
+note: required by a bound in `receive_pyclass_mut`
+  --> src/impl_/pymethods.rs
    |
-   | pub fn extract_pyclass_ref_mut<'a, 'py: 'a, T: PyClass<Frozen = False>>(
-   |                                                        ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
+   | pub unsafe fn receive_pyclass_mut<'a, 'py: 'a, T: PyClass<Frozen = False>>(
+   |                                                           ^^^^^^^^^^^^^^ required by this bound in `receive_pyclass_mut`
 
 error[E0271]: type mismatch resolving `<ComplexEnum as PyClass>::Frozen == False`
  --> tests/ui/invalid_pymethod_enum.rs:9:1


### PR DESCRIPTION
Attempt to fix #3843 

The idea is that the Python interpreter already type-checks the `self` passed for many methods and slots, so we don't need to do this for receivers where we know the interpreter does the check.

There is precedent in CPython for this assumption to be used, for example `tuple.__hash__()` assumes it gets a tuple object: https://github.com/python/cpython/blob/bfc57d43d8766120ba0c8f3f6d7b2ac681a81d8a/Objects/tupleobject.c#L321

Similarly for tuple methods such as `tuple.index()`: https://github.com/python/cpython/blob/bfc57d43d8766120ba0c8f3f6d7b2ac681a81d8a/Objects/clinic/tupleobject.c.h#L23

The only case where this seemed to be problematic was in the binary operators, where they can be called in reverse and that breaks the assumption that the type is correct. This might be our fault inside the implementation, so possibly something to check.

I thought that first I'd see how this implementation affects benchmarks...