### PR TITLE
add `import_exception_bound!` macro

### DIFF
--- a/newsfragments/4027.added.md
+++ b/newsfragments/4027.added.md
@@ -1,0 +1,1 @@
+Add `import_exception_bound!` macro to import exception types without generating GIL Ref functionality for them.

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -9,6 +9,7 @@
 #[cfg(feature = "experimental-async")]
 pub mod coroutine;
 pub mod deprecations;
+pub mod exceptions;
 pub mod extract_argument;
 pub mod freelist;
 pub mod frompyobject;

--- a/src/impl_/exceptions.rs
+++ b/src/impl_/exceptions.rs
@@ -1,8 +1,4 @@
-use crate::{
-    sync::GILOnceCell,
-    types::{PyAnyMethods, PyTracebackMethods, PyType},
-    Bound, Py, Python,
-};
+use crate::{sync::GILOnceCell, types::PyType, Bound, Py, Python};
 
 pub struct ImportedExceptionTypeObject {
     imported_value: GILOnceCell<Py<PyType>>,
@@ -21,27 +17,12 @@ impl ImportedExceptionTypeObject {
 
     pub fn get<'py>(&self, py: Python<'py>) -> &Bound<'py, PyType> {
         self.imported_value
-            .get_or_init(py, || {
-                let imp = py.import_bound(self.module).unwrap_or_else(|err| {
-                    let traceback = err
-                        .traceback_bound(py)
-                        .map(|tb| tb.format().expect("raised exception will have a traceback"))
-                        .unwrap_or_default();
-                    panic!(
-                        "Can not import module {}: {}\n{}",
-                        self.module, err, traceback
-                    );
-                });
-                let cls = imp.getattr(self.name).unwrap_or_else(|_| {
-                    panic!(
-                        "Can not load exception class: {}.{}",
-                        self.module, self.name
-                    )
-                });
-
-                cls.extract()
-                    .expect("Imported exception should be a type object")
+            .get_or_try_init_type_ref(py, self.module, self.name)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "failed to import exception {}.{}: {}",
+                    self.module, self.name, e
+                )
             })
-            .bind(py)
     }
 }

--- a/src/impl_/exceptions.rs
+++ b/src/impl_/exceptions.rs
@@ -1,0 +1,47 @@
+use crate::{
+    sync::GILOnceCell,
+    types::{PyAnyMethods, PyTracebackMethods, PyType},
+    Bound, Py, Python,
+};
+
+pub struct ImportedExceptionTypeObject {
+    imported_value: GILOnceCell<Py<PyType>>,
+    module: &'static str,
+    name: &'static str,
+}
+
+impl ImportedExceptionTypeObject {
+    pub const fn new(module: &'static str, name: &'static str) -> Self {
+        Self {
+            imported_value: GILOnceCell::new(),
+            module,
+            name,
+        }
+    }
+
+    pub fn get<'py>(&self, py: Python<'py>) -> &Bound<'py, PyType> {
+        self.imported_value
+            .get_or_init(py, || {
+                let imp = py.import_bound(self.module).unwrap_or_else(|err| {
+                    let traceback = err
+                        .traceback_bound(py)
+                        .map(|tb| tb.format().expect("raised exception will have a traceback"))
+                        .unwrap_or_default();
+                    panic!(
+                        "Can not import module {}: {}\n{}",
+                        self.module, err, traceback
+                    );
+                });
+                let cls = imp.getattr(self.name).unwrap_or_else(|_| {
+                    panic!(
+                        "Can not load exception class: {}.{}",
+                        self.module, self.name
+                    )
+                });
+
+                cls.extract()
+                    .expect("Imported exception should be a type object")
+            })
+            .bind(py)
+    }
+}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -201,13 +201,17 @@ impl GILOnceCell<Py<PyType>> {
     ///
     /// This is a shorthand method for `get_or_init` which imports the type from Python on init.
     pub(crate) fn get_or_try_init_type_ref<'py>(
-        &'py self,
+        &self,
         py: Python<'py>,
         module_name: &str,
         attr_name: &str,
     ) -> PyResult<&Bound<'py, PyType>> {
         self.get_or_try_init(py, || {
-            py.import_bound(module_name)?.getattr(attr_name)?.extract()
+            let type_object = py
+                .import_bound(module_name)?
+                .getattr(attr_name)?
+                .downcast_into()?;
+            Ok(type_object.unbind())
         })
         .map(|ty| ty.bind(py))
     }


### PR DESCRIPTION
For #3989 

The idea here is that this macro implements only the traits needed to use an imported exception inside a `Bound` (and not as a GIL Ref). This should help with coverage.

cc @alex - want to give this a try?