### PR TITLE
Refactoring of `FnArg`

### DIFF
--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -29,14 +29,12 @@ pub struct RegularArg<'a> {
 pub struct VarArg<'a> {
     pub name: &'a syn::Ident,
     pub ty: &'a syn::Type,
-    pub attrs: PyFunctionArgPyO3Attributes,
 }
 
 #[derive(Clone, Debug)]
 pub struct KwArg<'a> {
     pub name: &'a syn::Ident,
     pub ty: &'a syn::Type,
-    pub attrs: PyFunctionArgPyO3Attributes,
 }
 
 #[derive(Clone, Debug)]
@@ -94,19 +92,11 @@ impl<'a> FnArg<'a> {
         if let Self::Regular(RegularArg {
             name,
             ty,
-            attrs,
             option_wrapped_type: None,
             ..
         }) = self
         {
-            let attrs = std::mem::replace(
-                attrs,
-                PyFunctionArgPyO3Attributes {
-                    from_py_with: None,
-                    cancel_handle: None,
-                },
-            );
-            *self = Self::VarArgs(VarArg { name, ty, attrs });
+            *self = Self::VarArgs(VarArg { name, ty });
             Ok(self)
         } else {
             bail_spanned!(self.name().span() => "args cannot be optional")
@@ -117,19 +107,11 @@ impl<'a> FnArg<'a> {
         if let Self::Regular(RegularArg {
             name,
             ty,
-            attrs,
             option_wrapped_type: Some(..),
             ..
         }) = self
         {
-            let attrs = std::mem::replace(
-                attrs,
-                PyFunctionArgPyO3Attributes {
-                    from_py_with: None,
-                    cancel_handle: None,
-                },
-            );
-            *self = Self::KwArgs(KwArg { name, ty, attrs });
+            *self = Self::KwArgs(KwArg { name, ty });
             Ok(self)
         } else {
             bail_spanned!(self.name().span() => "kwargs must be Option<_>")

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -731,7 +731,7 @@ impl<'a> FnSpec<'a> {
                     .map(|arg| match arg {
                         FnArg::Py(..) => quote!(py),
                         FnArg::CancelHandle(..) => quote!(__cancel_handle),
-                        _ => unreachable!(),
+                        _ => unreachable!("`CallingConvention::Noargs` should not contain any arguments (reaching Python) except for `self`, which is handled below."),
                     })
                     .collect();
                 let call = rust_call(args, &mut holders);

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -90,7 +90,7 @@ pub fn impl_arg_params(
         .iter()
         .enumerate()
         .filter_map(|(i, arg)| {
-            let from_py_with = &arg.from_py_with().as_ref()?.value;
+            let from_py_with = &arg.from_py_with()?.value;
             let from_py_with_holder = format_ident!("from_py_with_{}", i);
             Some(quote_spanned! { from_py_with.span() =>
                 let e = #pyo3_path::impl_::deprecations::GilRefs::new();
@@ -285,13 +285,7 @@ pub(crate) fn impl_regular_arg_param(
         ));
     }
 
-    if arg
-        .attrs
-        .from_py_with
-        .as_ref()
-        .map(|attr| &attr.value)
-        .is_some()
-    {
+    if arg.from_py_with.is_some() {
         if let Some(default) = default {
             quote_arg_span! {
                 #pyo3_path::impl_::extract_argument::from_py_with_with_default(

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1143,9 +1143,6 @@ fn complex_enum_struct_variant_new<'a>(
     let arg_py_type: syn::Type = parse_quote!(#pyo3_path::Python<'_>);
 
     let args = {
-        let mut no_pyo3_attrs = vec![];
-        let attrs = crate::pyfunction::PyFunctionArgPyO3Attributes::from_attrs(&mut no_pyo3_attrs)?;
-
         let mut args = vec![
             // py: Python<'_>
             FnArg::Py(PyArg {
@@ -1158,7 +1155,7 @@ fn complex_enum_struct_variant_new<'a>(
             args.push(FnArg::Regular(RegularArg {
                 name: field.ident,
                 ty: field.ty,
-                attrs: attrs.clone(),
+                from_py_with: None,
                 default_value: None,
                 option_wrapped_type: None,
             }));

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -7,7 +7,7 @@ use crate::attributes::{
 };
 use crate::deprecations::Deprecations;
 use crate::konst::{ConstAttributes, ConstSpec};
-use crate::method::{FnArg, FnSpec};
+use crate::method::{FnArg, FnArgKind, FnSpec};
 use crate::pyimpl::{gen_py_const, PyClassMethodsType};
 use crate::pymethod::{
     impl_py_getter_def, impl_py_setter_def, MethodAndMethodDef, MethodAndSlotDef, PropertyType,
@@ -1151,13 +1151,8 @@ fn complex_enum_struct_variant_new<'a>(
             FnArg {
                 name: &arg_py_ident,
                 ty: &arg_py_type,
-                optional: None,
-                default: None,
-                py: true,
                 attrs: attrs.clone(),
-                is_varargs: false,
-                is_kwargs: false,
-                is_cancel_handle: false,
+                kind: FnArgKind::Py,
             },
         ];
 
@@ -1165,13 +1160,11 @@ fn complex_enum_struct_variant_new<'a>(
             args.push(FnArg {
                 name: field.ident,
                 ty: field.ty,
-                optional: None,
-                default: None,
-                py: false,
                 attrs: attrs.clone(),
-                is_varargs: false,
-                is_kwargs: false,
-                is_cancel_handle: false,
+                kind: FnArgKind::Regular {
+                    default: None,
+                    ty_opt: None,
+                },
             });
         }
         args

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -7,7 +7,7 @@ use crate::attributes::{
 };
 use crate::deprecations::Deprecations;
 use crate::konst::{ConstAttributes, ConstSpec};
-use crate::method::{FnArg, FnArgKind, FnSpec};
+use crate::method::{FnArg, FnSpec, PyArg, RegularArg};
 use crate::pyimpl::{gen_py_const, PyClassMethodsType};
 use crate::pymethod::{
     impl_py_getter_def, impl_py_setter_def, MethodAndMethodDef, MethodAndSlotDef, PropertyType,
@@ -1148,24 +1148,20 @@ fn complex_enum_struct_variant_new<'a>(
 
         let mut args = vec![
             // py: Python<'_>
-            FnArg {
+            FnArg::Py(PyArg {
                 name: &arg_py_ident,
                 ty: &arg_py_type,
-                attrs: attrs.clone(),
-                kind: FnArgKind::Py,
-            },
+            }),
         ];
 
         for field in &variant.fields {
-            args.push(FnArg {
+            args.push(FnArg::Regular(RegularArg {
                 name: field.ident,
                 ty: field.ty,
                 attrs: attrs.clone(),
-                kind: FnArgKind::Regular {
-                    default: None,
-                    ty_opt: None,
-                },
-            });
+                default_value: None,
+                option_wrapped_type: None,
+            }));
         }
         args
     };

--- a/pyo3-macros-backend/src/pyfunction/signature.rs
+++ b/pyo3-macros-backend/src/pyfunction/signature.rs
@@ -404,10 +404,11 @@ impl<'a> FunctionSignature<'a> {
                         if let FnArg::Regular(arg) = fn_arg {
                             arg.default_value = Some(default.clone());
                         } else {
-                            // FIXME: In what case can this happen? What should the error message be?
-                            bail_spanned!(
-                                default.span() => "todo"
-                            )
+                            unreachable!(
+                                "`Python` and `CancelHandle` are already handled above and `*args`/`**kwargs` are \
+                                parsed and transformed below. Because the have to come last and are only allowed \
+                                once, this has to be a regular argument."
+                            );
                         }
                     }
                 }

--- a/pyo3-macros-backend/src/pyfunction/signature.rs
+++ b/pyo3-macros-backend/src/pyfunction/signature.rs
@@ -416,7 +416,6 @@ impl<'a> FunctionSignature<'a> {
                 }
                 SignatureItem::Varargs(varargs) => {
                     let fn_arg = next_non_py_argument_checked(&varargs.ident)?;
-                    // FIXME: This needs a ui test covering it
                     ensure_spanned!(
                         matches!(fn_arg.kind, FnArgKind::Regular { ty_opt: None, .. }),
                         fn_arg.name.span() => "args cannot be optional"
@@ -426,7 +425,6 @@ impl<'a> FunctionSignature<'a> {
                 }
                 SignatureItem::Kwargs(kwargs) => {
                     let fn_arg = next_non_py_argument_checked(&kwargs.ident)?;
-                    // FIXME: This needs ui test covering it
                     ensure_spanned!(
                         matches!(fn_arg.kind, FnArgKind::Regular { ty_opt: Some(_), .. }),
                         fn_arg.name.span() => "kwargs must be Option<_>"

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use crate::attributes::{NameAttribute, RenamingRule};
-use crate::method::{CallingConvention, ExtractErrorMode, FnArgKind};
+use crate::method::{CallingConvention, ExtractErrorMode, PyArg};
 use crate::params::{check_arg_for_gil_refs, impl_regular_arg_param, Holders};
 use crate::utils::Ctx;
 use crate::utils::PythonDoc;
@@ -471,7 +471,7 @@ fn impl_py_class_attribute(
     let (py_arg, args) = split_off_python_arg(&spec.signature.arguments);
     ensure_spanned!(
         args.is_empty(),
-        args[0].ty.span() => "#[classattr] can only have one argument (of type pyo3::Python)"
+        args[0].ty().span() => "#[classattr] can only have one argument (of type pyo3::Python)"
     );
 
     let name = &spec.name;
@@ -521,7 +521,7 @@ fn impl_call_setter(
         bail_spanned!(spec.name.span() => "setter function expected to have one argument");
     } else if args.len() > 1 {
         bail_spanned!(
-            args[1].ty.span() =>
+            args[1].ty().span() =>
             "setter function can have at most two arguments ([pyo3::Python,] and value)"
         );
     }
@@ -591,7 +591,7 @@ pub fn impl_py_setter_def(
             let (_, args) = split_off_python_arg(&spec.signature.arguments);
             let value_arg = &args[0];
             let (from_py_with, ident) = if let Some(from_py_with) =
-                &value_arg.attrs.from_py_with.as_ref().map(|f| &f.value)
+                &value_arg.from_py_with().as_ref().map(|f| &f.value)
             {
                 let ident = syn::Ident::new("from_py_with", from_py_with.span());
                 (
@@ -606,18 +606,21 @@ pub fn impl_py_setter_def(
                 (quote!(), syn::Ident::new("dummy", Span::call_site()))
             };
 
+            let arg = if let FnArg::Regular(arg) = &value_arg {
+                arg
+            } else {
+                bail_spanned!(value_arg.name().span() => "The #[setter] value argument can't be *args or **kwargs");
+            };
+
             let tokens = impl_regular_arg_param(
-                &args[0],
+                arg,
                 ident,
                 quote!(::std::option::Option::Some(_value.into())),
                 &mut holders,
                 ctx,
             );
-            let extract = check_arg_for_gil_refs(
-                tokens,
-                holders.push_gil_refs_checker(value_arg.ty.span()),
-                ctx,
-            );
+            let extract =
+                check_arg_for_gil_refs(tokens, holders.push_gil_refs_checker(arg.ty.span()), ctx);
             quote! {
                 #from_py_with
                 let _val = #extract;
@@ -703,7 +706,7 @@ fn impl_call_getter(
     let slf = self_type.receiver(cls, ExtractErrorMode::Raise, holders, ctx);
     ensure_spanned!(
         args.is_empty(),
-        args[0].ty.span() => "getter function can only have one argument (of type pyo3::Python)"
+        args[0].ty().span() => "getter function can only have one argument (of type pyo3::Python)"
     );
 
     let name = &spec.name;
@@ -825,9 +828,9 @@ pub fn impl_py_getter_def(
 }
 
 /// Split an argument of pyo3::Python from the front of the arg list, if present
-fn split_off_python_arg<'a>(args: &'a [FnArg<'a>]) -> (Option<&FnArg<'_>>, &[FnArg<'_>]) {
+fn split_off_python_arg<'a>(args: &'a [FnArg<'a>]) -> (Option<&PyArg<'_>>, &[FnArg<'_>]) {
     match args {
-        [py, args @ ..] if utils::is_python(py.ty) => (Some(py), args),
+        [FnArg::Py(py), args @ ..] => (Some(py), args),
         args => (None, args),
     }
 }
@@ -1034,14 +1037,14 @@ impl Ty {
         ctx: &Ctx,
     ) -> TokenStream {
         let Ctx { pyo3_path } = ctx;
-        let name_str = arg.name.unraw().to_string();
+        let name_str = arg.name().unraw().to_string();
         match self {
             Ty::Object => extract_object(
                 extract_error_mode,
                 holders,
                 &name_str,
                 quote! { #ident },
-                arg.ty.span(),
+                arg.ty().span(),
                 ctx
             ),
             Ty::MaybeNullObject => extract_object(
@@ -1055,7 +1058,7 @@ impl Ty {
                         #ident
                     }
                 },
-                arg.ty.span(),
+                arg.ty().span(),
                 ctx
             ),
             Ty::NonNullObject => extract_object(
@@ -1063,7 +1066,7 @@ impl Ty {
                 holders,
                 &name_str,
                 quote! { #ident.as_ptr() },
-                arg.ty.span(),
+                arg.ty().span(),
                 ctx
             ),
             Ty::IPowModulo => extract_object(
@@ -1071,7 +1074,7 @@ impl Ty {
                 holders,
                 &name_str,
                 quote! { #ident.as_ptr() },
-                arg.ty.span(),
+                arg.ty().span(),
                 ctx
             ),
             Ty::CompareOp => extract_error_mode.handle_error(
@@ -1082,7 +1085,7 @@ impl Ty {
                 ctx
             ),
             Ty::PySsizeT => {
-                let ty = arg.ty;
+                let ty = arg.ty();
                 extract_error_mode.handle_error(
                     quote! {
                             ::std::convert::TryInto::<#ty>::try_into(#ident).map_err(|e| #pyo3_path::exceptions::PyValueError::new_err(e.to_string()))
@@ -1505,12 +1508,12 @@ fn extract_proto_arguments(
     let mut non_python_args = 0;
 
     for arg in &spec.signature.arguments {
-        if let FnArgKind::Py = arg.kind {
+        if let FnArg::Py(..) = arg {
             args.push(quote! { py });
         } else {
             let ident = syn::Ident::new(&format!("arg{}", non_python_args), Span::call_site());
             let conversions = proto_args.get(non_python_args)
-                .ok_or_else(|| err_spanned!(arg.ty.span() => format!("Expected at most {} non-python arguments", proto_args.len())))?
+                .ok_or_else(|| err_spanned!(arg.ty().span() => format!("Expected at most {} non-python arguments", proto_args.len())))?
                 .extract(&ident, arg, extract_error_mode, holders, ctx);
             non_python_args += 1;
             args.push(conversions);

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -609,7 +609,7 @@ pub fn impl_py_setter_def(
             let arg = if let FnArg::Regular(arg) = &value_arg {
                 arg
             } else {
-                bail_spanned!(value_arg.name().span() => "The #[setter] value argument can't be *args or **kwargs");
+                bail_spanned!(value_arg.name().span() => "The #[setter] value argument can't be *args, **kwargs or `cancel_handle`.");
             };
 
             let tokens = impl_regular_arg_param(

--- a/tests/ui/invalid_cancel_handle.rs
+++ b/tests/ui/invalid_cancel_handle.rs
@@ -19,4 +19,10 @@ async fn cancel_handle_wrong_type(#[pyo3(cancel_handle)] _param: String) {}
 #[pyfunction]
 async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
 
+#[pyfunction]
+async fn cancel_handle_and_from_py_with(
+    #[pyo3(cancel_handle, from_py_with = "cancel_handle")] _param: pyo3::coroutine::CancelHandle,
+) {
+}
+
 fn main() {}

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -16,6 +16,12 @@ error: `cancel_handle` attribute can only be used with `async fn`
 14 | fn cancel_handle_synchronous(#[pyo3(cancel_handle)] _param: String) {}
    |                                                     ^^^^^^
 
+error: `from_py_with` and `cancel_handle` cannot be specified together
+  --> tests/ui/invalid_cancel_handle.rs:24:12
+   |
+24 |     #[pyo3(cancel_handle, from_py_with = "cancel_handle")] _param: pyo3::coroutine::CancelHandle,
+   |            ^^^^^^^^^^^^^
+
 error[E0308]: mismatched types
   --> tests/ui/invalid_cancel_handle.rs:16:1
    |

--- a/tests/ui/invalid_pyfunctions.rs
+++ b/tests/ui/invalid_pyfunctions.rs
@@ -1,5 +1,5 @@
 use pyo3::prelude::*;
-use pyo3::types::PyString;
+use pyo3::types::{PyDict, PyString, PyTuple};
 
 #[pyfunction]
 fn generic_function<T>(value: T) {}
@@ -15,6 +15,14 @@ fn destructured_argument((a, b): (i32, i32)) {}
 
 #[pyfunction]
 fn function_with_required_after_option(_opt: Option<i32>, _x: i32) {}
+
+#[pyfunction]
+#[pyo3(signature=(*args))]
+fn function_with_optional_args(args: Option<Bound<'_, PyTuple>>) {}
+
+#[pyfunction]
+#[pyo3(signature=(**kwargs))]
+fn function_with_required_kwargs(kwargs: Bound<'_, PyDict>) {}
 
 #[pyfunction(pass_module)]
 fn pass_module_but_no_arguments<'py>() {}

--- a/tests/ui/invalid_pyfunctions.stderr
+++ b/tests/ui/invalid_pyfunctions.stderr
@@ -29,16 +29,28 @@ error: required arguments after an `Option<_>` argument are ambiguous
 17 | fn function_with_required_after_option(_opt: Option<i32>, _x: i32) {}
    |                                                               ^^^
 
-error: expected `&PyModule` or `Py<PyModule>` as first argument with `pass_module`
-  --> tests/ui/invalid_pyfunctions.rs:20:37
+error: args cannot be optional
+  --> tests/ui/invalid_pyfunctions.rs:21:32
    |
-20 | fn pass_module_but_no_arguments<'py>() {}
+21 | fn function_with_optional_args(args: Option<Bound<'_, PyTuple>>) {}
+   |                                ^^^^
+
+error: kwargs must be Option<_>
+  --> tests/ui/invalid_pyfunctions.rs:25:34
+   |
+25 | fn function_with_required_kwargs(kwargs: Bound<'_, PyDict>) {}
+   |                                  ^^^^^^
+
+error: expected `&PyModule` or `Py<PyModule>` as first argument with `pass_module`
+  --> tests/ui/invalid_pyfunctions.rs:28:37
+   |
+28 | fn pass_module_but_no_arguments<'py>() {}
    |                                     ^^
 
 error[E0277]: the trait bound `&str: From<BoundRef<'_, '_, pyo3::prelude::PyModule>>` is not satisfied
-  --> tests/ui/invalid_pyfunctions.rs:24:13
+  --> tests/ui/invalid_pyfunctions.rs:32:13
    |
-24 |     string: &str,
+32 |     string: &str,
    |             ^ the trait `From<BoundRef<'_, '_, pyo3::prelude::PyModule>>` is not implemented for `&str`, which is required by `BoundRef<'_, '_, pyo3::prelude::PyModule>: Into<_>`
    |
    = help: the following other types implement trait `From<T>`:


### PR DESCRIPTION
Following the discussion from https://github.com/PyO3/pyo3/pull/4002#discussion_r1544410044

This reworks the `FnArg` type in our macro codegen to contain a `FnArgKind` enum instead of a bunch of booleans. This is done to make much clearer which branches there are, depending on the argument kind. It also makes weird combinations (like optional py/varargs, required kwargs, ...) unrepresentable. As a consequence the error checking for those cases are now at construction/parsing side instead of usage side, which also feels more appropriate.

I left a few FIXMEs, so I leave this as a draft for now, but feedback is welcome 😄 