### PR TITLE
fix compile error for multiple async method arguments

### DIFF
--- a/newsfragments/4035.fixed.md
+++ b/newsfragments/4035.fixed.md
@@ -1,0 +1,1 @@
+Fix compile error for `async fn` in `#[pymethods]` with a `&self` receiver and more than one additional argument.

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -246,39 +246,6 @@ fn coroutine_panic() {
 }
 
 #[test]
-fn test_async_method_receiver_with_other_args() {
-    #[pyclass]
-    struct Value(i32);
-    #[pymethods]
-    impl Value {
-        #[new]
-        fn new() -> Self {
-            Self(0)
-        }
-        async fn get_value_plus_with(&self, v: i32) -> i32 {
-            self.0 + v
-        }
-        async fn set_value(&mut self, new_value: i32) -> i32 {
-            self.0 = new_value;
-            self.0
-        }
-    }
-
-    Python::with_gil(|gil| {
-        let test = r#"
-        import asyncio
-
-        v = Value()
-        assert asyncio.run(v.get_value_plus_with(3)) == 3
-        assert asyncio.run(v.set_value(10)) == 10
-        assert asyncio.run(v.get_value_plus_with(1)) == 11
-        "#;
-        let locals = [("Value", gil.get_type_bound::<Value>())].into_py_dict_bound(gil);
-        py_run!(gil, *locals, test);
-    });
-}
-
-#[test]
 fn test_async_method_receiver() {
     #[pyclass]
     struct Counter(usize);
@@ -340,4 +307,37 @@ fn test_async_method_receiver() {
     });
 
     assert!(IS_DROPPED.load(Ordering::SeqCst));
+}
+
+#[test]
+fn test_async_method_receiver_with_other_args() {
+    #[pyclass]
+    struct Value(i32);
+    #[pymethods]
+    impl Value {
+        #[new]
+        fn new() -> Self {
+            Self(0)
+        }
+        async fn get_value_plus_with(&self, v1: i32, v2: i32) -> i32 {
+            self.0 + v1 + v2
+        }
+        async fn set_value(&mut self, new_value: i32) -> i32 {
+            self.0 = new_value;
+            self.0
+        }
+    }
+
+    Python::with_gil(|gil| {
+        let test = r#"
+        import asyncio
+
+        v = Value()
+        assert asyncio.run(v.get_value_plus_with(3, 0)) == 3
+        assert asyncio.run(v.set_value(10)) == 10
+        assert asyncio.run(v.get_value_plus_with(1, 1)) == 12
+        "#;
+        let locals = [("Value", gil.get_type_bound::<Value>())].into_py_dict_bound(gil);
+        py_run!(gil, *locals, test);
+    });
 }


### PR DESCRIPTION
fixes #4034

I missed in review that the `;` was only being applied once at the end of the `#evaluate_arg` expansion. 

While at it I tidied this implementation up a bit further. I probably should have reviewed #4015 better; it's been a long week 🤦 