### PR TITLE
fix: allow impl of Ungil for deprecated PyCell in nightly

### DIFF
--- a/src/marker.rs
+++ b/src/marker.rs
@@ -280,6 +280,7 @@ mod nightly {
     impl !Ungil for crate::PyAny {}
 
     // All the borrowing wrappers
+    #[allow(deprecated)]
     impl<T> !Ungil for crate::PyCell<T> {}
     impl<T> !Ungil for crate::PyRef<'_, T> {}
     impl<T> !Ungil for crate::PyRefMut<'_, T> {}


### PR DESCRIPTION
I don't think a changelog entry is needed for that.