### PR TITLE
fix declarative-modules compile error

### DIFF
--- a/newsfragments/4054.fixed.md
+++ b/newsfragments/4054.fixed.md
@@ -1,0 +1,1 @@
+Fixes a compile error when exporting a `#[pyclass]` living in a different Rust module using the declarative-module feature.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1614,7 +1614,7 @@ impl<'a> PyClassImplsBuilder<'a> {
         quote! {
             impl #cls {
                 #[doc(hidden)]
-                const _PYO3_DEF: #pyo3_path::impl_::pymodule::AddClassToModule<Self> = #pyo3_path::impl_::pymodule::AddClassToModule::new();
+                pub const _PYO3_DEF: #pyo3_path::impl_::pymodule::AddClassToModule<Self> = #pyo3_path::impl_::pymodule::AddClassToModule::new();
             }
         }
     }

--- a/tests/test_declarative_module.rs
+++ b/tests/test_declarative_module.rs
@@ -9,6 +9,13 @@ use pyo3::types::PyBool;
 #[path = "../src/tests/common.rs"]
 mod common;
 
+mod some_module {
+    use pyo3::prelude::*;
+
+    #[pyclass]
+    pub struct SomePyClass;
+}
+
 #[pyclass]
 struct ValueClass {
     value: usize,
@@ -49,6 +56,10 @@ mod declarative_module {
     use super::*;
     #[pymodule_export]
     use super::{declarative_module2, double, MyError, ValueClass as Value};
+
+    // test for #4036
+    #[pymodule_export]
+    use super::some_module::SomePyClass;
 
     #[pymodule]
     mod inner {


### PR DESCRIPTION
This fixes a compile error when exporting a `#[pyclass]` living in a different Rust module using the `declarative-module` feature.

Fixes #4036 
