### PR TITLE
Experiment: Fallible conversion trait

### DIFF
--- a/newsfragments/4060.added.md
+++ b/newsfragments/4060.added.md
@@ -1,0 +1,1 @@
+New `IntoPyObject` (fallible) conversion trait to convert from Rust to Python values.

--- a/newsfragments/4060.changed.md
+++ b/newsfragments/4060.changed.md
@@ -1,0 +1,1 @@
+`#[pyfunction]` and `#[pymethods]` return types will prefer `IntoPyObject` over `IntoPy<PyAny>`

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -696,10 +696,13 @@ impl<'a> FnSpec<'a> {
                         #qualname_prefix,
                         #throw_callback,
                         async move {
-                            #[allow(unused_imports)]
-                            use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
                             let fut = future.await;
-                            (&fut).conversion_kind().wrap(fut)
+                            {
+                                #[allow(unused_imports)]
+                                use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
+                                #[allow(clippy::needless_borrow)]
+                                (&&&fut).conversion_kind().wrap(fut)
+                            }
                         },
                     )
                 }};

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -699,7 +699,7 @@ impl<'a> FnSpec<'a> {
                             #[allow(unused_imports)]
                             use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
                             let fut = future.await;
-                            (&fut).into_py_kind().wrap(fut)
+                            (&fut).conversion_kind().wrap(fut)
                         },
                     )
                 }};

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -697,12 +697,7 @@ impl<'a> FnSpec<'a> {
                         #throw_callback,
                         async move {
                             let fut = future.await;
-                            {
-                                #[allow(unused_imports)]
-                                use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
-                                #[allow(clippy::needless_borrow)]
-                                (&&&fut).conversion_kind().wrap(fut)
-                            }
+                            #pyo3_path::impl_::wrap::converter(&fut).wrap(fut)
                         },
                     )
                 }};

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -695,7 +695,12 @@ impl<'a> FnSpec<'a> {
                         #pyo3_path::intern!(py, stringify!(#python_name)),
                         #qualname_prefix,
                         #throw_callback,
-                        async move { #pyo3_path::impl_::wrap::OkWrap::wrap(future.await) },
+                        async move {
+                            #[allow(unused_imports)]
+                            use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
+                            let fut = future.await;
+                            (&fut).into_py_kind().wrap(fut)
+                        },
                     )
                 }};
                 if cancel_handle.is_some() {

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1060,9 +1060,10 @@ fn impl_complex_enum(
         quote! {
             impl<'py> #pyo3_path::conversion::IntoPyObject<'py> for #cls {
                 type Target = Self;
+                type Output = #pyo3_path::Bound<'py, Self::Target>;
                 type Error = #pyo3_path::PyErr;
 
-                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<#pyo3_path::Bound<'py, Self::Target>, Self::Error> {
+                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<Self::Output, Self::Error> {
                     match self {
                         #(#match_arms)*
                     }
@@ -2118,9 +2119,10 @@ impl<'a> PyClassImplsBuilder<'a> {
 
                 impl<'py> #pyo3_path::conversion::IntoPyObject<'py> for #cls {
                     type Target = Self;
+                    type Output = #pyo3_path::Bound<'py, Self::Target>;
                     type Error = #pyo3_path::PyErr;
 
-                    fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<#pyo3_path::Bound<'py, Self::Target>, Self::Error> {
+                    fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<Self::Output, Self::Error> {
                         #pyo3_path::Bound::new(py, self)
                     }
                 }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1043,10 +1043,39 @@ fn impl_complex_enum(
         }
     };
 
+    let enum_into_pyobject_impl = {
+        let match_arms = variants
+            .iter()
+            .map(|variant| {
+                let variant_ident = variant.get_ident();
+                let variant_cls = gen_complex_enum_variant_class_ident(cls, variant.get_ident());
+                quote! {
+                    #cls::#variant_ident { .. } => {
+                        let pyclass_init = <#pyo3_path::PyClassInitializer<Self> as ::std::convert::From<Self>>::from(self).add_subclass(#variant_cls);
+                        unsafe { #pyo3_path::Bound::new(py, pyclass_init).map(|b| #pyo3_path::types::PyAnyMethods::downcast_into_unchecked(b.into_any())) }
+                    }
+                }
+            });
+
+        quote! {
+            impl<'py> #pyo3_path::conversion::IntoPyObject<'py> for #cls {
+                type Target = Self;
+                type Error = #pyo3_path::PyErr;
+
+                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<#pyo3_path::Bound<'py, Self::Target>, Self::Error> {
+                    match self {
+                        #(#match_arms)*
+                    }
+                }
+            }
+        }
+    };
+
     let pyclass_impls: TokenStream = [
         impl_builder.impl_pyclass(ctx),
         impl_builder.impl_extractext(ctx),
         enum_into_py_impl,
+        enum_into_pyobject_impl,
         impl_builder.impl_pyclassimpl(ctx)?,
         impl_builder.impl_add_to_module(ctx),
         impl_builder.impl_freelist(ctx),
@@ -2084,6 +2113,15 @@ impl<'a> PyClassImplsBuilder<'a> {
                 impl #pyo3_path::IntoPy<#pyo3_path::PyObject> for #cls {
                     fn into_py(self, py: #pyo3_path::Python<'_>) -> #pyo3_path::PyObject {
                         #pyo3_path::IntoPy::into_py(#pyo3_path::Py::new(py, self).unwrap(), py)
+                    }
+                }
+
+                impl<'py> #pyo3_path::conversion::IntoPyObject<'py> for #cls {
+                    type Target = Self;
+                    type Error = #pyo3_path::PyErr;
+
+                    fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<#pyo3_path::Bound<'py, Self::Target>, Self::Error> {
+                        #pyo3_path::Bound::new(py, self)
                     }
                 }
             }

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -503,7 +503,8 @@ fn impl_py_class_attribute(
     let associated_method = quote! {
         fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
             let function = #cls::#name; // Shadow the method name to avoid #3017
-            #pyo3_path::impl_::wrap::map_result_into_py(py, #body)
+            let result = #body;
+            #pyo3_path::impl_::wrap::converter(&result).map_into_pyobject(py, result)
         }
     };
 

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -17,10 +17,7 @@ pub(crate) fn ok_wrap(obj: TokenStream, ctx: &Ctx) -> TokenStream {
     let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
     quote_spanned! { *output_span => {
         let obj = #obj;
-        {
-            use #pyo3_path::impl_::wrap::converter;
-            converter(&obj).wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
-        }
+        #pyo3_path::impl_::wrap::converter(&obj).wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
     }}
 }
 

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -19,7 +19,7 @@ pub(crate) fn ok_wrap(obj: TokenStream, ctx: &Ctx) -> TokenStream {
         #[allow(unused_imports)]
         use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
         let obj = #obj;
-        (&obj).into_py_kind().wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
+        (&obj).conversion_kind().wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
     }}
 }
 
@@ -34,6 +34,6 @@ pub(crate) fn map_result_into_ptr(result: TokenStream, ctx: &Ctx) -> TokenStream
         #[allow(unused_imports)]
         use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
         let result = #result;
-        (&result).into_py_kind().map_into_ptr(#py, result)
+        (&result).conversion_kind().map_into_ptr(#py, result)
     }}
 }

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -18,10 +18,8 @@ pub(crate) fn ok_wrap(obj: TokenStream, ctx: &Ctx) -> TokenStream {
     quote_spanned! { *output_span => {
         let obj = #obj;
         {
-            #[allow(unused_imports)]
-            use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
-            #[allow(clippy::needless_borrow)]
-            (&&&obj).conversion_kind().wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
+            use #pyo3_path::impl_::wrap::converter;
+            converter(&obj).wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
         }
     }}
 }
@@ -35,11 +33,6 @@ pub(crate) fn map_result_into_ptr(result: TokenStream, ctx: &Ctx) -> TokenStream
     let py = syn::Ident::new("py", proc_macro2::Span::call_site());
     quote_spanned! { *output_span => {
         let result = #result;
-        {
-            #[allow(unused_imports)]
-            use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind, IntoPyNoneKind};
-            #[allow(clippy::needless_borrow)]
-            (&&&result).conversion_kind().map_into_ptr(#py, result)
-        }
+        #pyo3_path::impl_::wrap::converter(&result).map_into_ptr(#py, result)
     }}
 }

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -16,10 +16,13 @@ pub(crate) fn ok_wrap(obj: TokenStream, ctx: &Ctx) -> TokenStream {
     } = ctx;
     let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
     quote_spanned! { *output_span => {
-        #[allow(unused_imports)]
-        use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
         let obj = #obj;
-        (&obj).conversion_kind().wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
+        {
+            #[allow(unused_imports)]
+            use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
+            #[allow(clippy::needless_borrow)]
+            (&&&obj).conversion_kind().wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
+        }
     }}
 }
 
@@ -31,9 +34,12 @@ pub(crate) fn map_result_into_ptr(result: TokenStream, ctx: &Ctx) -> TokenStream
     let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
     let py = syn::Ident::new("py", proc_macro2::Span::call_site());
     quote_spanned! { *output_span => {
-        #[allow(unused_imports)]
-        use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
         let result = #result;
-        (&result).conversion_kind().map_into_ptr(#py, result)
+        {
+            #[allow(unused_imports)]
+            use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind, IntoPyNoneKind};
+            #[allow(clippy::needless_borrow)]
+            (&&&result).conversion_kind().map_into_ptr(#py, result)
+        }
     }}
 }

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -15,10 +15,12 @@ pub(crate) fn ok_wrap(obj: TokenStream, ctx: &Ctx) -> TokenStream {
         output_span,
     } = ctx;
     let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
-    quote_spanned! {*output_span=>
-        #pyo3_path::impl_::wrap::OkWrap::wrap(#obj)
-            .map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
-    }
+    quote_spanned! { *output_span => {
+        #[allow(unused_imports)]
+        use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
+        let obj = #obj;
+        (&obj).into_py_kind().wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
+    }}
 }
 
 pub(crate) fn map_result_into_ptr(result: TokenStream, ctx: &Ctx) -> TokenStream {
@@ -28,5 +30,10 @@ pub(crate) fn map_result_into_ptr(result: TokenStream, ctx: &Ctx) -> TokenStream
     } = ctx;
     let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
     let py = syn::Ident::new("py", proc_macro2::Span::call_site());
-    quote_spanned! {*output_span=> #pyo3_path::impl_::wrap::map_result_into_ptr(#py, #result) }
+    quote_spanned! { *output_span => {
+        #[allow(unused_imports)]
+        use #pyo3_path::impl_::wrap::{IntoPyKind, IntoPyObjectKind};
+        let result = #result;
+        (&result).into_py_kind().map_into_ptr(#py, result)
+    }}
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -171,13 +171,21 @@ pub trait IntoPy<T>: Sized {
     }
 }
 
+/// Defines a conversion from a Rust type to a Python object, which may fail.
+///
+/// It functions similarly to std's [`TryInto`] trait, but requires a [GIL token](Python)
+/// as an argument.
 pub trait IntoPyObject<'py, T>: Sized {
+    /// The type returned in the event of a conversion error.
     type Error;
 
+    /// Performs the conversion.
     fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, T>, Self::Error>;
 }
 
+/// Extension of [`IntoPyObject`] which allows type hinting using turbo fish syntax.
 pub trait IntoPyObjectExt: Sized {
+    /// Performs the conversion.
     fn into_pyobject<'py, T, E>(self, py: Python<'py>) -> Result<Bound<'py, T>, E>
     where
         Self: IntoPyObject<'py, T, Error = E>;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -178,6 +178,15 @@ pub trait IntoPy<T>: Sized {
 ///
 /// It functions similarly to std's [`TryInto`] trait, but requires a [GIL token](Python)
 /// as an argument.
+#[cfg_attr(
+    diagnostic_namespace,
+    diagnostic::on_unimplemented(
+        message = "`{Self}` cannot be converted to a Python object",
+        note = "`IntoPyObject` is automatically implemented by the `#[pyclass]` macro",
+        note = "if you do not wish to have a corresponding Python type, implement it manually",
+        note = "if you do not own `{Self}` you can perform a manual conversion to one of the types in `pyo3::types::*`"
+    )
+)]
 pub trait IntoPyObject<'py>: Sized {
     /// The Python output type
     type Target;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -171,6 +171,27 @@ pub trait IntoPy<T>: Sized {
     }
 }
 
+pub trait IntoPyObject<'py, T>: Sized {
+    type Error;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, T>, Self::Error>;
+}
+
+pub trait IntoPyObjectExt: Sized {
+    fn into_pyobject<'py, T, E>(self, py: Python<'py>) -> Result<Bound<'py, T>, E>
+    where
+        Self: IntoPyObject<'py, T, Error = E>;
+}
+
+impl<T> IntoPyObjectExt for T {
+    fn into_pyobject<'py, Target, E>(self, py: Python<'py>) -> Result<Bound<'py, Target>, E>
+    where
+        Self: IntoPyObject<'py, Target, Error = E>,
+    {
+        self.into_pyobj(py)
+    }
+}
+
 /// Extract a type from a Python object.
 ///
 ///

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -6,6 +6,7 @@ use crate::pyclass::boolean_struct::False;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
 use crate::{ffi, Borrowed, Bound, Py, PyAny, PyClass, PyObject, PyRef, PyRefMut, Python};
+use std::convert::Infallible;
 
 /// Returns a borrowed pointer to a Python object.
 ///
@@ -380,6 +381,22 @@ where
 impl IntoPy<Py<PyTuple>> for () {
     fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
         PyTuple::empty(py).unbind()
+    }
+}
+
+impl<'py> IntoPyObject<'py, PyAny> for () {
+    type Error = Infallible;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+        self.into_pyobject::<PyTuple, _>(py).map(Bound::into_any)
+    }
+}
+
+impl<'py> IntoPyObject<'py, PyTuple> for () {
+    type Error = Infallible;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyTuple>, Self::Error> {
+        Ok(PyTuple::empty(py))
     }
 }
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -186,15 +186,48 @@ pub trait IntoPyObject<'py>: Sized {
     fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error>;
 }
 
-impl<'py, T> IntoPyObject<'py> for &'_ T
-where
-    T: Copy + IntoPyObject<'py>,
-{
-    type Target = T::Target;
-    type Error = T::Error;
+impl<'py, T> IntoPyObject<'py> for Bound<'py, T> {
+    type Target = T;
+    type Error = Infallible;
+
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl<'py, T> IntoPyObject<'py> for &Bound<'py, T> {
+    type Target = T;
+    type Error = Infallible;
+
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        Ok(self.clone())
+    }
+}
+
+impl<'py, T> IntoPyObject<'py> for Borrowed<'_, 'py, T> {
+    type Target = T;
+    type Error = Infallible;
+
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        Ok(self.to_owned())
+    }
+}
+
+impl<'py, T> IntoPyObject<'py> for Py<T> {
+    type Target = T;
+    type Error = Infallible;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
-        (*self).into_pyobject(py)
+        Ok(self.into_bound(py))
+    }
+}
+
+impl<'py, T> IntoPyObject<'py> for &Py<T> {
+    type Target = T;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        Ok(self.bind(py).clone())
     }
 }
 

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -478,7 +478,7 @@ impl<'py, Tz: TimeZone> IntoPyObject<'py, PyAny> for DateTime<Tz> {
 
         #[cfg(Py_LIMITED_API)]
         {
-            let tz = self.offset().fix().into_pyobject::<PyTzInfo, _>(py)?;
+            let tz = self.offset().fix().into_pyobject::<PyAny, _>(py)?;
             let DateArgs { year, month, day } = (&self.naive_local().date()).into();
             let TimeArgs {
                 hour,

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -112,9 +112,10 @@ impl<'py> IntoPyObject<'py> for Duration {
     type Target = PyAny;
     #[cfg(not(Py_LIMITED_API))]
     type Target = PyDelta;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         // Total number of days
         let days = self.num_days();
         // Remainder of seconds
@@ -213,9 +214,10 @@ impl<'py> IntoPyObject<'py> for NaiveDate {
     type Target = PyAny;
     #[cfg(not(Py_LIMITED_API))]
     type Target = PyDate;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let DateArgs { year, month, day } = (&self).into();
         #[cfg(not(Py_LIMITED_API))]
         {
@@ -280,9 +282,10 @@ impl<'py> IntoPyObject<'py> for NaiveTime {
     type Target = PyAny;
     #[cfg(not(Py_LIMITED_API))]
     type Target = PyTime;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let TimeArgs {
             hour,
             min,
@@ -338,9 +341,10 @@ impl<'py> IntoPyObject<'py> for NaiveDateTime {
     type Target = PyAny;
     #[cfg(not(Py_LIMITED_API))]
     type Target = PyDateTime;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let DateArgs { year, month, day } = (&self.date()).into();
         let TimeArgs {
             hour,
@@ -412,9 +416,10 @@ impl<'py, Tz: TimeZone> IntoPyObject<'py> for DateTime<Tz> {
     type Target = PyAny;
     #[cfg(not(Py_LIMITED_API))]
     type Target = PyDateTime;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let tz = self.offset().fix().into_pyobject(py)?;
         let DateArgs { year, month, day } = (&self.naive_local().date()).into();
         let TimeArgs {
@@ -507,9 +512,10 @@ impl<'py> IntoPyObject<'py> for FixedOffset {
     type Target = PyAny;
     #[cfg(not(Py_LIMITED_API))]
     type Target = PyTzInfo;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let seconds_offset = self.local_minus_utc();
         #[cfg(not(Py_LIMITED_API))]
         {
@@ -573,9 +579,10 @@ impl<'py> IntoPyObject<'py> for Utc {
     type Target = PyAny;
     #[cfg(not(Py_LIMITED_API))]
     type Target = PyTzInfo;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         #[cfg(Py_LIMITED_API)]
         {
             Ok(timezone_utc_bound(py).into_any())

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -62,10 +62,11 @@ impl IntoPy<PyObject> for Tz {
     }
 }
 
-impl<'py> IntoPyObject<'py, PyAny> for Tz {
+impl<'py> IntoPyObject<'py> for Tz {
+    type Target = PyAny;
     type Error = PyErr;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
         static ZONE_INFO: GILOnceCell<Py<PyType>> = GILOnceCell::new();
         ZONE_INFO
             .get_or_try_init_type_ref(py, "zoneinfo", "ZoneInfo")

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -64,9 +64,10 @@ impl IntoPy<PyObject> for Tz {
 
 impl<'py> IntoPyObject<'py> for Tz {
     type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         static ZONE_INFO: GILOnceCell<Py<PyType>> = GILOnceCell::new();
         ZONE_INFO
             .get_or_try_init_type_ref(py, "zoneinfo", "ZoneInfo")

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -43,12 +43,11 @@
 //!
 //! [either](https://docs.rs/either/ "A library for easy idiomatic error handling and reporting in Rust applications")’s
 
-use crate::conversion::AnyBound;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
     conversion::IntoPyObject, exceptions::PyTypeError, types::any::PyAnyMethods, Bound,
-    FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    BoundObject, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
 };
 use either::Either;
 
@@ -83,13 +82,13 @@ where
         match self {
             Either::Left(l) => l
                 .into_pyobject(py)
-                .map(AnyBound::into_any)
-                .map(AnyBound::into_bound)
+                .map(BoundObject::into_any)
+                .map(BoundObject::into_bound)
                 .map_err(Into::into),
             Either::Right(r) => r
                 .into_pyobject(py)
-                .map(AnyBound::into_any)
-                .map(AnyBound::into_bound)
+                .map(BoundObject::into_any)
+                .map(BoundObject::into_bound)
                 .map_err(Into::into),
         }
     }

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -46,8 +46,8 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    exceptions::PyTypeError, types::any::PyAnyMethods, Bound, FromPyObject, IntoPy, PyAny,
-    PyObject, PyResult, Python, ToPyObject,
+    conversion::IntoPyObject, exceptions::PyTypeError, types::any::PyAnyMethods, Bound,
+    FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
 };
 use either::Either;
 
@@ -62,6 +62,23 @@ where
         match self {
             Either::Left(l) => l.into_py(py),
             Either::Right(r) => r.into_py(py),
+        }
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "either")))]
+impl<'py, L, R, T, E> IntoPyObject<'py> for Either<L, R>
+where
+    L: IntoPyObject<'py, Target = T, Error = E>,
+    R: IntoPyObject<'py, Target = T, Error = E>,
+{
+    type Target = T;
+    type Error = E;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        match self {
+            Either::Left(l) => l.into_pyobject(py),
+            Either::Right(r) => r.into_pyobject(py),
         }
     }
 }

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -43,6 +43,7 @@
 //!
 //! [either](https://docs.rs/either/ "A library for easy idiomatic error handling and reporting in Rust applications")’s
 
+use crate::conversion::AnyBound;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
@@ -67,15 +68,17 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "either")))]
-impl<'py, L, R, T, E> IntoPyObject<'py> for Either<L, R>
+impl<'py, L, R, T, E, O> IntoPyObject<'py> for Either<L, R>
 where
-    L: IntoPyObject<'py, Target = T, Error = E>,
-    R: IntoPyObject<'py, Target = T, Error = E>,
+    L: IntoPyObject<'py, Target = T, Error = E, Output = O>,
+    R: IntoPyObject<'py, Target = T, Error = E, Output = O>,
+    O: AnyBound<'py, T>,
 {
     type Target = T;
+    type Output = O;
     type Error = E;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
             Either::Left(l) => l.into_pyobject(py),
             Either::Right(r) => r.into_pyobject(py),

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -66,7 +66,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
                 k.into_pyobject(py)?.into_bound(),

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -17,7 +17,7 @@
 //! Note that you must use compatible versions of hashbrown and PyO3.
 //! The required hashbrown version may vary based on the version of PyO3.
 use crate::{
-    conversion::{AnyBound, IntoPyObject},
+    conversion::IntoPyObject,
     types::{
         any::PyAnyMethods,
         dict::PyDictMethods,
@@ -25,7 +25,7 @@ use crate::{
         set::{new_from_iter, try_new_from_iter, PySetMethods},
         IntoPyDict, PyDict, PyFrozenSet, PySet,
     },
-    Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    Bound, BoundObject, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
 };
 use std::{cmp, hash};
 
@@ -131,8 +131,8 @@ where
             py,
             self.into_iter().map(|item| {
                 item.into_pyobject(py)
-                    .map(AnyBound::into_any)
-                    .map(AnyBound::unbind)
+                    .map(BoundObject::into_any)
+                    .map(BoundObject::unbind)
                     .map_err(Into::into)
             }),
         )

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -87,7 +87,7 @@
 //! # if another hash table was used, the order could be random
 //! ```
 
-use crate::conversion::IntoPyObject;
+use crate::conversion::{AnyBound, IntoPyObject};
 use crate::types::*;
 use crate::{Bound, FromPyObject, IntoPy, PyErr, PyObject, Python, ToPyObject};
 use std::{cmp, hash};
@@ -125,12 +125,16 @@ where
     PyErr: From<K::Error> + From<V::Error>,
 {
     type Target = PyDict;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let dict = PyDict::new_bound(py);
         for (k, v) in self {
-            dict.set_item(k.into_pyobject(py)?, v.into_pyobject(py)?)?;
+            dict.set_item(
+                k.into_pyobject(py)?.into_bound(),
+                v.into_pyobject(py)?.into_bound(),
+            )?;
         }
         Ok(dict)
     }

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -87,9 +87,9 @@
 //! # if another hash table was used, the order could be random
 //! ```
 
-use crate::conversion::{AnyBound, IntoPyObject};
+use crate::conversion::IntoPyObject;
 use crate::types::*;
-use crate::{Bound, FromPyObject, IntoPy, PyErr, PyObject, Python, ToPyObject};
+use crate::{Bound, BoundObject, FromPyObject, IntoPy, PyErr, PyObject, Python, ToPyObject};
 use std::{cmp, hash};
 
 impl<K, V, H> ToPyObject for indexmap::IndexMap<K, V, H>

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -129,7 +129,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
                 k.into_pyobject(py)?.into_bound(),

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -138,13 +138,11 @@ macro_rules! bigint_conversion {
         #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
         impl<'py> IntoPyObject<'py> for $rust_ty {
             type Target = PyInt;
+            type Output = Bound<'py, Self::Target>;
             type Error = PyErr;
 
             #[cfg(not(Py_LIMITED_API))]
-            fn into_pyobject(
-                self,
-                py: Python<'py>,
-            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 use crate::ffi_ptr_ext::FfiPtrExt;
                 let bytes = $to_bytes(&self);
                 unsafe {
@@ -160,10 +158,7 @@ macro_rules! bigint_conversion {
             }
 
             #[cfg(Py_LIMITED_API)]
-            fn into_pyobject(
-                self,
-                py: Python<'py>,
-            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 use $crate::py_result_ext::PyResultExt;
                 let bytes = $to_bytes(&self);
                 let bytes_obj = PyBytes::new_bound(py, &bytes);

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -161,9 +161,9 @@ macro_rules! bigint_conversion {
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 use $crate::py_result_ext::PyResultExt;
                 let bytes = $to_bytes(&self);
-                let bytes_obj = PyBytes::new_bound(py, &bytes);
+                let bytes_obj = PyBytes::new(py, &bytes);
                 let kwargs = if $is_signed {
-                    let kwargs = crate::types::PyDict::new_bound(py);
+                    let kwargs = crate::types::PyDict::new(py);
                     kwargs.set_item(crate::intern!(py, "signed"), true)?;
                     Some(kwargs)
                 } else {

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -52,10 +52,11 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(Py_LIMITED_API)]
 use crate::types::{bytes::PyBytesMethods, PyBytes};
 use crate::{
+    conversion::IntoPyObject,
     ffi,
     instance::Bound,
     types::{any::PyAnyMethods, PyInt},
-    FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject,
+    FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
 };
 
 use num_bigint::{BigInt, BigUint};
@@ -131,6 +132,53 @@ macro_rules! bigint_conversion {
         impl IntoPy<PyObject> for $rust_ty {
             fn into_py(self, py: Python<'_>) -> PyObject {
                 self.to_object(py)
+            }
+        }
+
+        #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
+        impl<'py> IntoPyObject<'py> for $rust_ty {
+            type Target = PyInt;
+            type Error = PyErr;
+
+            #[cfg(not(Py_LIMITED_API))]
+            fn into_pyobject(
+                self,
+                py: Python<'py>,
+            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+                use crate::ffi_ptr_ext::FfiPtrExt;
+                let bytes = $to_bytes(&self);
+                unsafe {
+                    Ok(ffi::_PyLong_FromByteArray(
+                        bytes.as_ptr().cast(),
+                        bytes.len(),
+                        1,
+                        $is_signed.into(),
+                    )
+                    .assume_owned(py)
+                    .downcast_into_unchecked())
+                }
+            }
+
+            #[cfg(Py_LIMITED_API)]
+            fn into_pyobject(
+                self,
+                py: Python<'py>,
+            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+                use $crate::py_result_ext::PyResultExt;
+                let bytes = $to_bytes(&self);
+                let bytes_obj = PyBytes::new_bound(py, &bytes);
+                let kwargs = if $is_signed {
+                    let kwargs = crate::types::PyDict::new_bound(py);
+                    kwargs.set_item(crate::intern!(py, "signed"), true)?;
+                    Some(kwargs)
+                } else {
+                    None
+                };
+                unsafe {
+                    py.get_type_bound::<PyInt>()
+                        .call_method("from_bytes", (bytes_obj, "little"), kwargs.as_ref())
+                        .downcast_into_unchecked()
+                }
             }
         }
     };

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -140,12 +140,10 @@ macro_rules! complex_conversion {
         #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
         impl<'py> crate::conversion::IntoPyObject<'py> for Complex<$float> {
             type Target = PyComplex;
+            type Output = Bound<'py, Self::Target>;
             type Error = std::convert::Infallible;
 
-            fn into_pyobject(
-                self,
-                py: Python<'py>,
-            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 unsafe {
                     Ok(
                         ffi::PyComplex_FromDoubles(self.re as c_double, self.im as c_double)

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -138,6 +138,25 @@ macro_rules! complex_conversion {
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
+        impl<'py> crate::conversion::IntoPyObject<'py> for Complex<$float> {
+            type Target = PyComplex;
+            type Error = std::convert::Infallible;
+
+            fn into_pyobject(
+                self,
+                py: Python<'py>,
+            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+                unsafe {
+                    Ok(
+                        ffi::PyComplex_FromDoubles(self.re as c_double, self.im as c_double)
+                            .assume_owned(py)
+                            .downcast_into_unchecked(),
+                    )
+                }
+            }
+        }
+
+        #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
         impl FromPyObject<'_> for Complex<$float> {
             fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Complex<$float>> {
                 #[cfg(not(any(Py_LIMITED_API, PyPy)))]

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -104,9 +104,10 @@ impl IntoPy<PyObject> for Decimal {
 
 impl<'py> IntoPyObject<'py> for Decimal {
     type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let dec_cls = get_decimal_cls(py)?;
         // now call the constructor with the Rust Decimal string-ified
         // to not be lossy

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -117,7 +117,6 @@ impl<'py> IntoPyObject<'py> for Decimal {
 #[cfg(test)]
 mod test_rust_decimal {
     use super::*;
-    use crate::err::PyErr;
     use crate::types::dict::PyDictMethods;
     use crate::types::PyDict;
 

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -15,12 +15,14 @@
 //!
 //! Note that you must use compatible versions of smallvec and PyO3.
 //! The required smallvec version may vary based on the version of PyO3.
+use crate::conversion::IntoPyObject;
 use crate::exceptions::PyTypeError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::any::PyAnyMethods;
-use crate::types::list::new_from_iter;
-use crate::types::{PySequence, PyString};
+use crate::types::list::{new_from_iter, try_new_from_iter};
+use crate::types::{PyList, PySequence, PyString};
+use crate::PyErr;
 use crate::{
     err::DowncastError, ffi, Bound, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python,
     ToPyObject,
@@ -51,6 +53,26 @@ where
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         TypeInfo::list_of(A::Item::type_output())
+    }
+}
+
+impl<'py, A> IntoPyObject<'py> for SmallVec<A>
+where
+    A: Array,
+    A::Item: IntoPyObject<'py>,
+    PyErr: From<<A::Item as IntoPyObject<'py>>::Error>,
+{
+    type Target = PyList;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        let mut iter = self.into_iter().map(|e| {
+            e.into_pyobject(py)
+                .map(Bound::into_any)
+                .map(Bound::unbind)
+                .map_err(Into::into)
+        });
+        try_new_from_iter(py, &mut iter)
     }
 }
 

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -15,7 +15,7 @@
 //!
 //! Note that you must use compatible versions of smallvec and PyO3.
 //! The required smallvec version may vary based on the version of PyO3.
-use crate::conversion::{AnyBound, IntoPyObject};
+use crate::conversion::IntoPyObject;
 use crate::exceptions::PyTypeError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
@@ -24,8 +24,8 @@ use crate::types::list::{new_from_iter, try_new_from_iter};
 use crate::types::{PyList, PySequence, PyString};
 use crate::PyErr;
 use crate::{
-    err::DowncastError, ffi, Bound, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python,
-    ToPyObject,
+    err::DowncastError, ffi, Bound, BoundObject, FromPyObject, IntoPy, PyAny, PyObject, PyResult,
+    Python, ToPyObject,
 };
 use smallvec::{Array, SmallVec};
 
@@ -69,8 +69,8 @@ where
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let mut iter = self.into_iter().map(|e| {
             e.into_pyobject(py)
-                .map(AnyBound::into_any)
-                .map(AnyBound::unbind)
+                .map(BoundObject::into_any)
+                .map(BoundObject::unbind)
                 .map_err(Into::into)
         });
         try_new_from_iter(py, &mut iter)

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -119,7 +119,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{PyDict, PyList};
+    use crate::types::PyDict;
 
     #[test]
     fn test_smallvec_into_py() {

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -43,9 +43,11 @@ where
     T: IntoPyObject<'py>,
 {
     type Target = PyList;
+    type Output = Bound<'py, Self::Target>;
     type Error = T::Error;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        use crate::conversion::AnyBound;
         unsafe {
             let len = N as ffi::Py_ssize_t;
 

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -1,4 +1,4 @@
-use crate::conversion::{IntoPyObject, IntoPyObjectExt};
+use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Bound;
 use crate::types::any::PyAnyMethods;
@@ -38,13 +38,14 @@ where
     }
 }
 
-impl<'py, T, const N: usize> IntoPyObject<'py, PyList> for [T; N]
+impl<'py, T, const N: usize> IntoPyObject<'py> for [T; N]
 where
-    T: IntoPyObject<'py, PyAny>,
+    T: IntoPyObject<'py>,
 {
+    type Target = PyList;
     type Error = T::Error;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyList>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
         unsafe {
             let len = N as ffi::Py_ssize_t;
 
@@ -66,17 +67,6 @@ where
 
             Ok(list)
         }
-    }
-}
-
-impl<'py, T, const N: usize> IntoPyObject<'py, PyAny> for [T; N]
-where
-    T: IntoPyObject<'py, PyAny>,
-{
-    type Error = T::Error;
-
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-        self.into_pyobject::<PyList, _>(py).map(Bound::into_any)
     }
 }
 

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -47,7 +47,7 @@ where
     type Error = T::Error;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        use crate::conversion::AnyBound;
+        use crate::BoundObject;
         unsafe {
             let len = N as ffi::Py_ssize_t;
 

--- a/src/conversions/std/cell.rs
+++ b/src/conversions/std/cell.rs
@@ -19,9 +19,10 @@ impl<T: Copy + IntoPy<PyObject>> IntoPy<PyObject> for Cell<T> {
 
 impl<'py, T: Copy + IntoPyObject<'py>> IntoPyObject<'py> for Cell<T> {
     type Target = T::Target;
+    type Output = T::Output;
     type Error = T::Error;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.get().into_pyobject(py)
     }
 }

--- a/src/conversions/std/cell.rs
+++ b/src/conversions/std/cell.rs
@@ -1,8 +1,8 @@
 use std::cell::Cell;
 
 use crate::{
-    types::any::PyAnyMethods, Bound, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python,
-    ToPyObject,
+    conversion::IntoPyObject, types::any::PyAnyMethods, Bound, FromPyObject, IntoPy, PyAny,
+    PyObject, PyResult, Python, ToPyObject,
 };
 
 impl<T: Copy + ToPyObject> ToPyObject for Cell<T> {
@@ -14,6 +14,14 @@ impl<T: Copy + ToPyObject> ToPyObject for Cell<T> {
 impl<T: Copy + IntoPy<PyObject>> IntoPy<PyObject> for Cell<T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.get().into_py(py)
+    }
+}
+
+impl<'py, Target, T: Copy + IntoPyObject<'py, Target>> IntoPyObject<'py, Target> for Cell<T> {
+    type Error = T::Error;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, Target>, Self::Error> {
+        self.get().into_pyobj(py)
     }
 }
 

--- a/src/conversions/std/cell.rs
+++ b/src/conversions/std/cell.rs
@@ -17,11 +17,12 @@ impl<T: Copy + IntoPy<PyObject>> IntoPy<PyObject> for Cell<T> {
     }
 }
 
-impl<'py, Target, T: Copy + IntoPyObject<'py, Target>> IntoPyObject<'py, Target> for Cell<T> {
+impl<'py, T: Copy + IntoPyObject<'py>> IntoPyObject<'py> for Cell<T> {
+    type Target = T::Target;
     type Error = T::Error;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, Target>, Self::Error> {
-        self.get().into_pyobj(py)
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        self.get().into_pyobject(py)
     }
 }
 

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -45,9 +45,10 @@ impl ToPyObject for Ipv4Addr {
 
 impl<'py> IntoPyObject<'py> for Ipv4Addr {
     type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         static IPV4_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
         IPV4_ADDRESS
             .get_or_try_init_type_ref(py, "ipaddress", "IPv4Address")?
@@ -69,9 +70,10 @@ impl ToPyObject for Ipv6Addr {
 
 impl<'py> IntoPyObject<'py> for Ipv6Addr {
     type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         static IPV6_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
         IPV6_ADDRESS
             .get_or_try_init_type_ref(py, "ipaddress", "IPv6Address")?
@@ -96,9 +98,10 @@ impl IntoPy<PyObject> for IpAddr {
 
 impl<'py> IntoPyObject<'py> for IpAddr {
     type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
             IpAddr::V4(ip) => ip.into_pyobject(py),
             IpAddr::V6(ip) => ip.into_pyobject(py),

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -43,10 +43,11 @@ impl ToPyObject for Ipv4Addr {
     }
 }
 
-impl<'py> IntoPyObject<'py, PyAny> for Ipv4Addr {
+impl<'py> IntoPyObject<'py> for Ipv4Addr {
+    type Target = PyAny;
     type Error = PyErr;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
         static IPV4_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
         IPV4_ADDRESS
             .get_or_try_init_type_ref(py, "ipaddress", "IPv4Address")?
@@ -66,10 +67,11 @@ impl ToPyObject for Ipv6Addr {
     }
 }
 
-impl<'py> IntoPyObject<'py, PyAny> for Ipv6Addr {
+impl<'py> IntoPyObject<'py> for Ipv6Addr {
+    type Target = PyAny;
     type Error = PyErr;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
         static IPV6_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
         IPV6_ADDRESS
             .get_or_try_init_type_ref(py, "ipaddress", "IPv6Address")?
@@ -92,13 +94,14 @@ impl IntoPy<PyObject> for IpAddr {
     }
 }
 
-impl<'py> IntoPyObject<'py, PyAny> for IpAddr {
+impl<'py> IntoPyObject<'py> for IpAddr {
+    type Target = PyAny;
     type Error = PyErr;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
         match self {
-            IpAddr::V4(ip) => ip.into_pyobj(py),
-            IpAddr::V6(ip) => ip.into_pyobj(py),
+            IpAddr::V4(ip) => ip.into_pyobject(py),
+            IpAddr::V6(ip) => ip.into_pyobject(py),
         }
     }
 }

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -1,12 +1,15 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
+use crate::conversion::IntoPyObject;
 use crate::exceptions::PyValueError;
 use crate::instance::Bound;
 use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::string::PyStringMethods;
 use crate::types::PyType;
-use crate::{intern, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject};
+use crate::{
+    intern, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+};
 
 impl FromPyObject<'_> for IpAddr {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
@@ -40,6 +43,17 @@ impl ToPyObject for Ipv4Addr {
     }
 }
 
+impl<'py> IntoPyObject<'py, PyAny> for Ipv4Addr {
+    type Error = PyErr;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+        static IPV4_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+        IPV4_ADDRESS
+            .get_or_try_init_type_ref(py, "ipaddress", "IPv4Address")?
+            .call1((u32::from_be_bytes(self.octets()),))
+    }
+}
+
 impl ToPyObject for Ipv6Addr {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         static IPV6_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
@@ -49,6 +63,17 @@ impl ToPyObject for Ipv6Addr {
             .call1((u128::from_be_bytes(self.octets()),))
             .expect("failed to construct ipaddress.IPv6Address")
             .unbind()
+    }
+}
+
+impl<'py> IntoPyObject<'py, PyAny> for Ipv6Addr {
+    type Error = PyErr;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+        static IPV6_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+        IPV6_ADDRESS
+            .get_or_try_init_type_ref(py, "ipaddress", "IPv6Address")?
+            .call1((u128::from_be_bytes(self.octets()),))
     }
 }
 
@@ -64,6 +89,17 @@ impl ToPyObject for IpAddr {
 impl IntoPy<PyObject> for IpAddr {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.to_object(py)
+    }
+}
+
+impl<'py> IntoPyObject<'py, PyAny> for IpAddr {
+    type Error = PyErr;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+        match self {
+            IpAddr::V4(ip) => ip.into_pyobj(py),
+            IpAddr::V6(ip) => ip.into_pyobj(py),
+        }
     }
 }
 

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -3,10 +3,10 @@ use std::{cmp, collections, hash};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::{AnyBound, IntoPyObject},
+    conversion::IntoPyObject,
     instance::Bound,
     types::{any::PyAnyMethods, dict::PyDictMethods, IntoPyDict, PyDict},
-    FromPyObject, IntoPy, PyAny, PyErr, PyObject, Python, ToPyObject,
+    BoundObject, FromPyObject, IntoPy, PyAny, PyErr, PyObject, Python, ToPyObject,
 };
 
 impl<K, V, H> ToPyObject for collections::HashMap<K, V, H>

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -3,7 +3,7 @@ use std::{cmp, collections, hash};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::IntoPyObject,
+    conversion::{AnyBound, IntoPyObject},
     instance::Bound,
     types::{any::PyAnyMethods, dict::PyDictMethods, IntoPyDict, PyDict},
     FromPyObject, IntoPy, PyAny, PyErr, PyObject, Python, ToPyObject,
@@ -57,12 +57,16 @@ where
     PyErr: From<K::Error> + From<V::Error>,
 {
     type Target = PyDict;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let dict = PyDict::new_bound(py);
         for (k, v) in self {
-            dict.set_item(k.into_pyobject(py)?, v.into_pyobject(py)?)?;
+            dict.set_item(
+                k.into_pyobject(py)?.into_bound(),
+                v.into_pyobject(py)?.into_bound(),
+            )?;
         }
         Ok(dict)
     }
@@ -93,12 +97,16 @@ where
     PyErr: From<K::Error> + From<V::Error>,
 {
     type Target = PyDict;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, PyDict>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let dict = PyDict::new_bound(py);
         for (k, v) in self {
-            dict.set_item(k.into_pyobject(py)?, v.into_pyobject(py)?)?;
+            dict.set_item(
+                k.into_pyobject(py)?.into_bound(),
+                v.into_pyobject(py)?.into_bound(),
+            )?;
         }
         Ok(dict)
     }

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -3,7 +3,7 @@ use std::{cmp, collections, hash};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::{IntoPyObject, IntoPyObjectExt},
+    conversion::IntoPyObject,
     instance::Bound,
     types::{any::PyAnyMethods, dict::PyDictMethods, IntoPyDict, PyDict},
     FromPyObject, IntoPy, PyAny, PyErr, PyObject, Python, ToPyObject,
@@ -49,35 +49,22 @@ where
     }
 }
 
-impl<'py, K, V, H> IntoPyObject<'py, PyDict> for collections::HashMap<K, V, H>
+impl<'py, K, V, H> IntoPyObject<'py> for collections::HashMap<K, V, H>
 where
-    K: hash::Hash + cmp::Eq + IntoPyObject<'py, PyAny>,
-    V: IntoPyObject<'py, PyAny>,
+    K: hash::Hash + cmp::Eq + IntoPyObject<'py>,
+    V: IntoPyObject<'py>,
     H: hash::BuildHasher,
     PyErr: From<K::Error> + From<V::Error>,
 {
+    type Target = PyDict;
     type Error = PyErr;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyDict>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
         let dict = PyDict::new_bound(py);
         for (k, v) in self {
             dict.set_item(k.into_pyobject(py)?, v.into_pyobject(py)?)?;
         }
         Ok(dict)
-    }
-}
-
-impl<'py, K, V, H> IntoPyObject<'py, PyAny> for collections::HashMap<K, V, H>
-where
-    K: hash::Hash + cmp::Eq + IntoPyObject<'py, PyAny>,
-    V: IntoPyObject<'py, PyAny>,
-    H: hash::BuildHasher,
-    PyErr: From<K::Error> + From<V::Error>,
-{
-    type Error = PyErr;
-
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-        self.into_pyobject::<PyDict, _>(py).map(Bound::into_any)
     }
 }
 
@@ -99,33 +86,21 @@ where
     }
 }
 
-impl<'py, K, V> IntoPyObject<'py, PyDict> for collections::BTreeMap<K, V>
+impl<'py, K, V> IntoPyObject<'py> for collections::BTreeMap<K, V>
 where
-    K: cmp::Eq + IntoPyObject<'py, PyAny>,
-    V: IntoPyObject<'py, PyAny>,
+    K: cmp::Eq + IntoPyObject<'py>,
+    V: IntoPyObject<'py>,
     PyErr: From<K::Error> + From<V::Error>,
 {
+    type Target = PyDict;
     type Error = PyErr;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyDict>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, PyDict>, Self::Error> {
         let dict = PyDict::new_bound(py);
         for (k, v) in self {
             dict.set_item(k.into_pyobject(py)?, v.into_pyobject(py)?)?;
         }
         Ok(dict)
-    }
-}
-
-impl<'py, K, V> IntoPyObject<'py, PyAny> for collections::BTreeMap<K, V>
-where
-    K: cmp::Eq + IntoPyObject<'py, PyAny>,
-    V: IntoPyObject<'py, PyAny>,
-    PyErr: From<K::Error> + From<V::Error>,
-{
-    type Error = PyErr;
-
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-        self.into_pyobject::<PyDict, _>(py).map(Bound::into_any)
     }
 }
 

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -61,7 +61,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
                 k.into_pyobject(py)?.into_bound(),
@@ -101,7 +101,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
                 k.into_pyobject(py)?.into_bound(),

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -1,4 +1,4 @@
-use crate::conversion::{IntoPyObject, IntoPyObjectExt};
+use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
@@ -34,19 +34,15 @@ macro_rules! int_fits_larger_int {
             }
         }
 
-        impl<'py> IntoPyObject<'py, PyLong> for $rust_type {
+        impl<'py> IntoPyObject<'py> for $rust_type {
+            type Target = PyLong;
             type Error = Infallible;
 
-            fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyLong>, Self::Error> {
-                (self as $larger_type).into_pyobj(py)
-            }
-        }
-
-        impl<'py> IntoPyObject<'py, PyAny> for $rust_type {
-            type Error = Infallible;
-
-            fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-                self.into_pyobject::<PyLong, _>(py).map(Bound::into_any)
+            fn into_pyobject(
+                self,
+                py: Python<'py>,
+            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+                (self as $larger_type).into_pyobject(py)
             }
         }
 
@@ -109,22 +105,19 @@ macro_rules! int_convert_u64_or_i64 {
                 TypeInfo::builtin("int")
             }
         }
-        impl<'py> IntoPyObject<'py, PyLong> for $rust_type {
+        impl<'py> IntoPyObject<'py> for $rust_type {
+            type Target = PyLong;
             type Error = Infallible;
 
-            fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyLong>, Self::Error> {
+            fn into_pyobject(
+                self,
+                py: Python<'py>,
+            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
                 unsafe {
                     Ok($pylong_from_ll_or_ull(self)
                         .assume_owned(py)
                         .downcast_into_unchecked())
                 }
-            }
-        }
-        impl<'py> IntoPyObject<'py, PyAny> for $rust_type {
-            type Error = Infallible;
-
-            fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-                self.into_pyobject::<PyLong, _>(py).map(Bound::into_any)
             }
         }
         impl FromPyObject<'_> for $rust_type {
@@ -158,23 +151,19 @@ macro_rules! int_fits_c_long {
             }
         }
 
-        impl<'py> IntoPyObject<'py, PyLong> for $rust_type {
+        impl<'py> IntoPyObject<'py> for $rust_type {
+            type Target = PyLong;
             type Error = Infallible;
 
-            fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyLong>, Self::Error> {
+            fn into_pyobject(
+                self,
+                py: Python<'py>,
+            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
                 unsafe {
                     Ok(ffi::PyLong_FromLong(self as c_long)
                         .assume_owned(py)
                         .downcast_into_unchecked())
                 }
-            }
-        }
-
-        impl<'py> IntoPyObject<'py, PyAny> for $rust_type {
-            type Error = Infallible;
-
-            fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-                self.into_pyobject::<PyLong, _>(py).map(Bound::into_any)
             }
         }
 

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -3,7 +3,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::any::PyAnyMethods;
-use crate::types::PyLong;
+use crate::types::PyInt;
 use crate::{
     exceptions, ffi, Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
     ToPyObject,
@@ -35,7 +35,7 @@ macro_rules! int_fits_larger_int {
         }
 
         impl<'py> IntoPyObject<'py> for $rust_type {
-            type Target = PyLong;
+            type Target = PyInt;
             type Error = Infallible;
 
             fn into_pyobject(
@@ -106,7 +106,7 @@ macro_rules! int_convert_u64_or_i64 {
             }
         }
         impl<'py> IntoPyObject<'py> for $rust_type {
-            type Target = PyLong;
+            type Target = PyInt;
             type Error = Infallible;
 
             fn into_pyobject(
@@ -152,7 +152,7 @@ macro_rules! int_fits_c_long {
         }
 
         impl<'py> IntoPyObject<'py> for $rust_type {
-            type Target = PyLong;
+            type Target = PyInt;
             type Error = Infallible;
 
             fn into_pyobject(

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -36,12 +36,10 @@ macro_rules! int_fits_larger_int {
 
         impl<'py> IntoPyObject<'py> for $rust_type {
             type Target = PyInt;
+            type Output = Bound<'py, Self::Target>;
             type Error = Infallible;
 
-            fn into_pyobject(
-                self,
-                py: Python<'py>,
-            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 (self as $larger_type).into_pyobject(py)
             }
         }
@@ -107,12 +105,10 @@ macro_rules! int_convert_u64_or_i64 {
         }
         impl<'py> IntoPyObject<'py> for $rust_type {
             type Target = PyInt;
+            type Output = Bound<'py, Self::Target>;
             type Error = Infallible;
 
-            fn into_pyobject(
-                self,
-                py: Python<'py>,
-            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 unsafe {
                     Ok($pylong_from_ll_or_ull(self)
                         .assume_owned(py)
@@ -153,12 +149,10 @@ macro_rules! int_fits_c_long {
 
         impl<'py> IntoPyObject<'py> for $rust_type {
             type Target = PyInt;
+            type Output = Bound<'py, Self::Target>;
             type Error = Infallible;
 
-            fn into_pyobject(
-                self,
-                py: Python<'py>,
-            ) -> Result<Bound<'py, Self::Target>, Self::Error> {
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 unsafe {
                     Ok(ffi::PyLong_FromLong(self as c_long)
                         .assume_owned(py)

--- a/src/conversions/std/option.rs
+++ b/src/conversions/std/option.rs
@@ -1,6 +1,6 @@
 use crate::{
-    ffi, types::any::PyAnyMethods, AsPyPointer, Bound, FromPyObject, IntoPy, PyAny, PyObject,
-    PyResult, Python, ToPyObject,
+    conversion::IntoPyObject, ffi, types::any::PyAnyMethods, AsPyPointer, Bound, FromPyObject,
+    IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
 };
 
 /// `Option::Some<T>` is converted like `T`.
@@ -21,6 +21,17 @@ where
 {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.map_or_else(|| py.None(), |val| val.into_py(py))
+    }
+}
+
+impl<'py, T> IntoPyObject<'py, PyAny> for Option<T>
+where
+    T: IntoPyObject<'py, PyAny>,
+{
+    type Error = T::Error;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+        self.map_or_else(|| Ok(py.None().into_bound(py)), |val| val.into_pyobj(py))
     }
 }
 

--- a/src/conversions/std/option.rs
+++ b/src/conversions/std/option.rs
@@ -1,7 +1,6 @@
-use crate::conversion::AnyBound;
 use crate::{
-    conversion::IntoPyObject, ffi, types::any::PyAnyMethods, AsPyPointer, Bound, FromPyObject,
-    IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
+    conversion::IntoPyObject, ffi, types::any::PyAnyMethods, AsPyPointer, Bound, BoundObject,
+    FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
 };
 
 /// `Option::Some<T>` is converted like `T`.
@@ -38,8 +37,8 @@ where
             || Ok(py.None().into_bound(py)),
             |val| {
                 val.into_pyobject(py)
-                    .map(AnyBound::into_any)
-                    .map(AnyBound::into_bound)
+                    .map(BoundObject::into_any)
+                    .map(BoundObject::into_bound)
             },
         )
     }

--- a/src/conversions/std/option.rs
+++ b/src/conversions/std/option.rs
@@ -24,14 +24,18 @@ where
     }
 }
 
-impl<'py, T> IntoPyObject<'py, PyAny> for Option<T>
+impl<'py, T> IntoPyObject<'py> for Option<T>
 where
-    T: IntoPyObject<'py, PyAny>,
+    T: IntoPyObject<'py>,
 {
+    type Target = PyAny;
     type Error = T::Error;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-        self.map_or_else(|| Ok(py.None().into_bound(py)), |val| val.into_pyobj(py))
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        self.map_or_else(
+            || Ok(py.None().into_bound(py)),
+            |val| val.into_pyobject(py).map(Bound::into_any),
+        )
     }
 }
 

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -16,9 +16,10 @@ impl ToPyObject for OsStr {
 
 impl<'py> IntoPyObject<'py> for &OsStr {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         // If the string is UTF-8, take the quick and easy shortcut
         if let Some(valid_utf8_path) = self.to_str() {
             return valid_utf8_path.into_pyobject(py);
@@ -141,9 +142,10 @@ impl IntoPy<PyObject> for Cow<'_, OsStr> {
 
 impl<'py> IntoPyObject<'py> for Cow<'_, OsStr> {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
     }
 }
@@ -163,9 +165,10 @@ impl IntoPy<PyObject> for OsString {
 
 impl<'py> IntoPyObject<'py> for OsString {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
 }
@@ -178,9 +181,10 @@ impl<'a> IntoPy<PyObject> for &'a OsString {
 
 impl<'py> IntoPyObject<'py> for &OsString {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
 }

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -34,9 +34,10 @@ impl<'a> IntoPy<PyObject> for &'a Path {
 
 impl<'py> IntoPyObject<'py> for &Path {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
 }
@@ -57,9 +58,10 @@ impl<'a> IntoPy<PyObject> for Cow<'a, Path> {
 
 impl<'py> IntoPyObject<'py> for Cow<'_, Path> {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
 }
@@ -79,9 +81,10 @@ impl IntoPy<PyObject> for PathBuf {
 
 impl<'py> IntoPyObject<'py> for PathBuf {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
 }
@@ -94,9 +97,10 @@ impl<'a> IntoPy<PyObject> for &'a PathBuf {
 
 impl<'py> IntoPyObject<'py> for &PathBuf {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
 }

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -1,8 +1,11 @@
+use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Bound;
 use crate::types::any::PyAnyMethods;
+use crate::types::PyString;
 use crate::{ffi, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
 use std::borrow::Cow;
+use std::convert::Infallible;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
@@ -29,6 +32,15 @@ impl<'a> IntoPy<PyObject> for &'a Path {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &Path {
+    type Target = PyString;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        self.as_os_str().into_pyobject(py)
+    }
+}
+
 impl<'a> ToPyObject for Cow<'a, Path> {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -40,6 +52,15 @@ impl<'a> IntoPy<PyObject> for Cow<'a, Path> {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.to_object(py)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Cow<'_, Path> {
+    type Target = PyString;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        self.as_os_str().into_pyobject(py)
     }
 }
 
@@ -56,9 +77,27 @@ impl IntoPy<PyObject> for PathBuf {
     }
 }
 
+impl<'py> IntoPyObject<'py> for PathBuf {
+    type Target = PyString;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        self.as_os_str().into_pyobject(py)
+    }
+}
+
 impl<'a> IntoPy<PyObject> for &'a PathBuf {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.as_os_str().to_object(py)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &PathBuf {
+    type Target = PyString;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        self.as_os_str().into_pyobject(py)
     }
 }
 

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -3,7 +3,7 @@ use std::{cmp, collections, hash};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::{AnyBound, IntoPyObject},
+    conversion::IntoPyObject,
     instance::Bound,
     types::{
         any::PyAnyMethods,
@@ -11,7 +11,7 @@ use crate::{
         set::{new_from_iter, try_new_from_iter, PySetMethods},
         PyFrozenSet, PySet,
     },
-    FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    BoundObject, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
 };
 
 impl<T, S> ToPyObject for collections::HashSet<T, S>
@@ -69,8 +69,8 @@ where
             py,
             self.into_iter().map(|item| {
                 item.into_pyobject(py)
-                    .map(AnyBound::into_any)
-                    .map(AnyBound::unbind)
+                    .map(BoundObject::into_any)
+                    .map(BoundObject::unbind)
                     .map_err(Into::into)
             }),
         )
@@ -131,8 +131,8 @@ where
             py,
             self.into_iter().map(|item| {
                 item.into_pyobject(py)
-                    .map(AnyBound::into_any)
-                    .map(AnyBound::unbind)
+                    .map(BoundObject::into_any)
+                    .map(BoundObject::unbind)
                     .map_err(Into::into)
             }),
         )

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -3,7 +3,7 @@ use std::{cmp, collections, hash};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::IntoPyObject,
+    conversion::{AnyBound, IntoPyObject},
     instance::Bound,
     types::{
         any::PyAnyMethods,
@@ -61,15 +61,16 @@ where
     PyErr: From<K::Error>,
 {
     type Target = PySet;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         try_new_from_iter(
             py,
             self.into_iter().map(|item| {
                 item.into_pyobject(py)
-                    .map(Bound::into_any)
-                    .map(Bound::unbind)
+                    .map(AnyBound::into_any)
+                    .map(AnyBound::unbind)
                     .map_err(Into::into)
             }),
         )
@@ -122,15 +123,16 @@ where
     PyErr: From<K::Error>,
 {
     type Target = PySet;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         try_new_from_iter(
             py,
             self.into_iter().map(|item| {
                 item.into_pyobject(py)
-                    .map(Bound::into_any)
-                    .map(Bound::unbind)
+                    .map(AnyBound::into_any)
+                    .map(AnyBound::unbind)
                     .map_err(Into::into)
             }),
         )

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -3,7 +3,7 @@ use std::{cmp, collections, hash};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::{IntoPyObject, IntoPyObjectExt},
+    conversion::IntoPyObject,
     instance::Bound,
     types::{
         any::PyAnyMethods,
@@ -54,15 +54,16 @@ where
     }
 }
 
-impl<'py, K, S> IntoPyObject<'py, PySet> for collections::HashSet<K, S>
+impl<'py, K, S> IntoPyObject<'py> for collections::HashSet<K, S>
 where
-    K: IntoPyObject<'py, PyAny> + Eq + hash::Hash,
+    K: IntoPyObject<'py> + Eq + hash::Hash,
     S: hash::BuildHasher + Default,
     PyErr: From<K::Error>,
 {
+    type Target = PySet;
     type Error = PyErr;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PySet>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
         try_new_from_iter(
             py,
             self.into_iter().map(|item| {
@@ -72,19 +73,6 @@ where
                     .map_err(Into::into)
             }),
         )
-    }
-}
-
-impl<'py, K, S> IntoPyObject<'py, PyAny> for collections::HashSet<K, S>
-where
-    K: IntoPyObject<'py, PyAny> + Eq + hash::Hash,
-    S: hash::BuildHasher + Default,
-    PyErr: From<K::Error>,
-{
-    type Error = PyErr;
-
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-        self.into_pyobject::<PySet, _>(py).map(Bound::into_any)
     }
 }
 
@@ -128,14 +116,15 @@ where
     }
 }
 
-impl<'py, K> IntoPyObject<'py, PySet> for collections::BTreeSet<K>
+impl<'py, K> IntoPyObject<'py> for collections::BTreeSet<K>
 where
-    K: IntoPyObject<'py, PyAny> + Eq + hash::Hash,
+    K: IntoPyObject<'py> + Eq + hash::Hash,
     PyErr: From<K::Error>,
 {
+    type Target = PySet;
     type Error = PyErr;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PySet>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
         try_new_from_iter(
             py,
             self.into_iter().map(|item| {
@@ -145,18 +134,6 @@ where
                     .map_err(Into::into)
             }),
         )
-    }
-}
-
-impl<'py, K> IntoPyObject<'py, PyAny> for collections::BTreeSet<K>
-where
-    K: IntoPyObject<'py, PyAny> + Eq + hash::Hash,
-    PyErr: From<K::Error>,
-{
-    type Error = PyErr;
-
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-        self.into_pyobject::<PySet, _>(py).map(Bound::into_any)
     }
 }
 

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -1,10 +1,11 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, convert::Infallible};
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
+    conversion::IntoPyObject,
     types::{PyByteArray, PyByteArrayMethods, PyBytes},
-    IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject,
+    Bound, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject,
 };
 
 impl<'a> IntoPy<PyObject> for &'a [u8] {
@@ -15,6 +16,15 @@ impl<'a> IntoPy<PyObject> for &'a [u8] {
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         TypeInfo::builtin("bytes")
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &[u8] {
+    type Target = PyBytes;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        Ok(PyBytes::new_bound(py, self))
     }
 }
 
@@ -59,6 +69,15 @@ impl ToPyObject for Cow<'_, [u8]> {
 impl IntoPy<Py<PyAny>> for Cow<'_, [u8]> {
     fn into_py(self, py: Python<'_>) -> Py<PyAny> {
         self.to_object(py)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Cow<'_, [u8]> {
+    type Target = PyBytes;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        Ok(PyBytes::new_bound(py, &self))
     }
 }
 

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -21,9 +21,10 @@ impl<'a> IntoPy<PyObject> for &'a [u8] {
 
 impl<'py> IntoPyObject<'py> for &[u8] {
     type Target = PyBytes;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyBytes::new_bound(py, self))
     }
 }
@@ -74,9 +75,10 @@ impl IntoPy<Py<PyAny>> for Cow<'_, [u8]> {
 
 impl<'py> IntoPyObject<'py> for Cow<'_, [u8]> {
     type Target = PyBytes;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyBytes::new_bound(py, &self))
     }
 }

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -25,7 +25,7 @@ impl<'py> IntoPyObject<'py> for &[u8] {
     type Error = Infallible;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(PyBytes::new_bound(py, self))
+        Ok(PyBytes::new(py, self))
     }
 }
 
@@ -79,7 +79,7 @@ impl<'py> IntoPyObject<'py> for Cow<'_, [u8]> {
     type Error = Infallible;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(PyBytes::new_bound(py, &self))
+        Ok(PyBytes::new(py, &self))
     }
 }
 

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -44,9 +44,10 @@ impl<'a> IntoPy<Py<PyString>> for &'a str {
 
 impl<'py> IntoPyObject<'py> for &str {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyString::new_bound(py, self))
     }
 }
@@ -74,9 +75,10 @@ impl IntoPy<PyObject> for Cow<'_, str> {
 
 impl<'py> IntoPyObject<'py> for Cow<'_, str> {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
     }
 }
@@ -110,9 +112,10 @@ impl IntoPy<PyObject> for char {
 
 impl<'py> IntoPyObject<'py> for char {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let mut bytes = [0u8; 4];
         Ok(PyString::new_bound(py, self.encode_utf8(&mut bytes)))
     }
@@ -131,9 +134,10 @@ impl IntoPy<PyObject> for String {
 
 impl<'py> IntoPyObject<'py> for String {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyString::new_bound(py, &self))
     }
 }
@@ -152,9 +156,10 @@ impl<'a> IntoPy<PyObject> for &'a String {
 
 impl<'py> IntoPyObject<'py> for &String {
     type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyString::new_bound(py, self))
     }
 }

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -1,8 +1,9 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, convert::Infallible};
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
+    conversion::IntoPyObject,
     instance::Bound,
     types::{any::PyAnyMethods, string::PyStringMethods, PyString},
     FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject,
@@ -41,6 +42,15 @@ impl<'a> IntoPy<Py<PyString>> for &'a str {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &str {
+    type Target = PyString;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        Ok(PyString::new_bound(py, self))
+    }
+}
+
 /// Converts a Rust `Cow<'_, str>` to a Python object.
 /// See `PyString::new` for details on the conversion.
 impl ToPyObject for Cow<'_, str> {
@@ -59,6 +69,15 @@ impl IntoPy<PyObject> for Cow<'_, str> {
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         <String>::type_output()
+    }
+}
+
+impl<'py> IntoPyObject<'py> for Cow<'_, str> {
+    type Target = PyString;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 
@@ -89,6 +108,16 @@ impl IntoPy<PyObject> for char {
     }
 }
 
+impl<'py> IntoPyObject<'py> for char {
+    type Target = PyString;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        let mut bytes = [0u8; 4];
+        Ok(PyString::new_bound(py, self.encode_utf8(&mut bytes)))
+    }
+}
+
 impl IntoPy<PyObject> for String {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyString::new_bound(py, &self).into()
@@ -97,6 +126,15 @@ impl IntoPy<PyObject> for String {
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         TypeInfo::builtin("str")
+    }
+}
+
+impl<'py> IntoPyObject<'py> for String {
+    type Target = PyString;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        Ok(PyString::new_bound(py, &self))
     }
 }
 
@@ -109,6 +147,15 @@ impl<'a> IntoPy<PyObject> for &'a String {
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         <String>::type_output()
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &String {
+    type Target = PyString;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        Ok(PyString::new_bound(py, self))
     }
 }
 

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -1,3 +1,4 @@
+use crate::conversion::IntoPyObject;
 use crate::exceptions::{PyOverflowError, PyValueError};
 use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
@@ -89,6 +90,38 @@ impl IntoPy<PyObject> for Duration {
     }
 }
 
+impl<'py> IntoPyObject<'py> for Duration {
+    #[cfg(not(Py_LIMITED_API))]
+    type Target = PyDelta;
+    #[cfg(Py_LIMITED_API)]
+    type Target = PyAny;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        let days = self.as_secs() / SECONDS_PER_DAY;
+        let seconds = self.as_secs() % SECONDS_PER_DAY;
+        let microseconds = self.subsec_micros();
+
+        #[cfg(not(Py_LIMITED_API))]
+        {
+            PyDelta::new_bound(
+                py,
+                days.try_into()?,
+                seconds.try_into().unwrap(),
+                microseconds.try_into().unwrap(),
+                false,
+            )
+        }
+        #[cfg(Py_LIMITED_API)]
+        {
+            static TIMEDELTA: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+            TIMEDELTA
+                .get_or_try_init_type_ref(py, "datetime", "timedelta")?
+                .call1((days, seconds, microseconds))
+        }
+    }
+}
+
 // Conversions between SystemTime and datetime do not rely on the floating point timestamp of the
 // timestamp/fromtimestamp APIs to avoid possible precision loss but goes through the
 // timedelta/std::time::Duration types by taking for reference point the UNIX epoch.
@@ -120,6 +153,19 @@ impl ToPyObject for SystemTime {
 impl IntoPy<PyObject> for SystemTime {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.to_object(py)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for SystemTime {
+    type Target = PyAny;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+        let duration_since_unix_epoch =
+            self.duration_since(UNIX_EPOCH).unwrap().into_pyobject(py)?;
+        unix_epoch_py(py)
+            .bind(py)
+            .call_method1(intern!(py, "__add__"), (duration_since_unix_epoch,))
     }
 }
 

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -95,9 +95,10 @@ impl<'py> IntoPyObject<'py> for Duration {
     type Target = PyDelta;
     #[cfg(Py_LIMITED_API)]
     type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let days = self.as_secs() / SECONDS_PER_DAY;
         let seconds = self.as_secs() % SECONDS_PER_DAY;
         let microseconds = self.subsec_micros();
@@ -158,9 +159,10 @@ impl IntoPy<PyObject> for SystemTime {
 
 impl<'py> IntoPyObject<'py> for SystemTime {
     type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let duration_since_unix_epoch =
             self.duration_since(UNIX_EPOCH).unwrap().into_pyobject(py)?;
         unix_epoch_py(py)

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -1,9 +1,9 @@
-use crate::conversion::{AnyBound, IntoPyObject};
+use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::list::{new_from_iter, try_new_from_iter};
 use crate::types::PyList;
-use crate::{Bound, IntoPy, PyErr, PyObject, Python, ToPyObject};
+use crate::{Bound, BoundObject, IntoPy, PyErr, PyObject, Python, ToPyObject};
 
 impl<T> ToPyObject for [T]
 where
@@ -53,8 +53,8 @@ where
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let mut iter = self.into_iter().map(|e| {
             e.into_pyobject(py)
-                .map(AnyBound::into_any)
-                .map(AnyBound::unbind)
+                .map(BoundObject::into_any)
+                .map(BoundObject::unbind)
                 .map_err(Into::into)
         });
 

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -1,9 +1,9 @@
-use crate::conversion::{IntoPyObject, IntoPyObjectExt};
+use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::list::{new_from_iter, try_new_from_iter};
 use crate::types::PyList;
-use crate::{Bound, IntoPy, PyAny, PyErr, PyObject, Python, ToPyObject};
+use crate::{Bound, IntoPy, PyErr, PyObject, Python, ToPyObject};
 
 impl<T> ToPyObject for [T]
 where
@@ -41,14 +41,15 @@ where
     }
 }
 
-impl<'py, T> IntoPyObject<'py, PyList> for Vec<T>
+impl<'py, T> IntoPyObject<'py> for Vec<T>
 where
-    T: IntoPyObject<'py, PyAny>,
+    T: IntoPyObject<'py>,
     PyErr: From<T::Error>,
 {
+    type Target = PyList;
     type Error = PyErr;
 
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyList>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
         let mut iter = self.into_iter().map(|e| {
             e.into_pyobject(py)
                 .map(Bound::into_any)
@@ -57,17 +58,5 @@ where
         });
 
         try_new_from_iter(py, &mut iter)
-    }
-}
-
-impl<'py, T> IntoPyObject<'py, PyAny> for Vec<T>
-where
-    T: IntoPyObject<'py, PyAny>,
-    PyErr: From<T::Error>,
-{
-    type Error = PyErr;
-
-    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
-        self.into_pyobject::<PyList, _>(py).map(Bound::into_any)
     }
 }

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -1,7 +1,9 @@
+use crate::conversion::{IntoPyObject, IntoPyObjectExt};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-use crate::types::list::new_from_iter;
-use crate::{IntoPy, PyObject, Python, ToPyObject};
+use crate::types::list::{new_from_iter, try_new_from_iter};
+use crate::types::PyList;
+use crate::{Bound, IntoPy, PyAny, PyErr, PyObject, Python, ToPyObject};
 
 impl<T> ToPyObject for [T]
 where
@@ -36,5 +38,36 @@ where
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         TypeInfo::list_of(T::type_output())
+    }
+}
+
+impl<'py, T> IntoPyObject<'py, PyList> for Vec<T>
+where
+    T: IntoPyObject<'py, PyAny>,
+    PyErr: From<T::Error>,
+{
+    type Error = PyErr;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyList>, Self::Error> {
+        let mut iter = self.into_iter().map(|e| {
+            e.into_pyobject(py)
+                .map(Bound::into_any)
+                .map(Bound::unbind)
+                .map_err(Into::into)
+        });
+
+        try_new_from_iter(py, &mut iter)
+    }
+}
+
+impl<'py, T> IntoPyObject<'py, PyAny> for Vec<T>
+where
+    T: IntoPyObject<'py, PyAny>,
+    PyErr: From<T::Error>,
+{
+    type Error = PyErr;
+
+    fn into_pyobj(self, py: Python<'py>) -> Result<Bound<'py, PyAny>, Self::Error> {
+        self.into_pyobject::<PyList, _>(py).map(Bound::into_any)
     }
 }

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -1,4 +1,4 @@
-use crate::conversion::IntoPyObject;
+use crate::conversion::{AnyBound, IntoPyObject};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::list::{new_from_iter, try_new_from_iter};
@@ -47,13 +47,14 @@ where
     PyErr: From<T::Error>,
 {
     type Target = PyList;
+    type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
-    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let mut iter = self.into_iter().map(|e| {
             e.into_pyobject(py)
-                .map(Bound::into_any)
-                .map(Bound::unbind)
+                .map(AnyBound::into_any)
+                .map(AnyBound::unbind)
                 .map_err(Into::into)
         });
 

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -1,5 +1,6 @@
 use std::convert::Infallible;
 
+use crate::conversion::AnyBound;
 use crate::{
     conversion::IntoPyObject, ffi, types::PyNone, Bound, IntoPy, PyErr, PyObject, PyResult, Python,
 };
@@ -128,6 +129,7 @@ impl IntoPyObjectTag {
         PyErr: From<T::Error>,
     {
         obj.and_then(|obj| obj.into_pyobject(py).map_err(Into::into))
+            .map(AnyBound::into_bound)
             .map(Bound::into_ptr)
     }
 

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -1,8 +1,7 @@
 use std::convert::Infallible;
 
 use crate::{
-    conversion::IntoPyObject, ffi, types::PyNone, Bound, IntoPy, PyAny, PyErr, PyObject, PyResult,
-    Python,
+    conversion::IntoPyObject, ffi, types::PyNone, Bound, IntoPy, PyErr, PyObject, PyResult, Python,
 };
 
 /// Used to wrap values in `Option<T>` for default arguments.
@@ -71,7 +70,7 @@ pub trait OkWrapIntoPyObject<T> {
 // implementation for Result<T, E> from conflicting
 impl<'py, T> OkWrapIntoPyObject<T> for T
 where
-    T: IntoPyObject<'py, PyAny>,
+    T: IntoPyObject<'py>,
 {
     type Error = Infallible;
     #[inline]
@@ -82,7 +81,7 @@ where
 
 impl<'py, T, E> OkWrapIntoPyObject<T> for Result<T, E>
 where
-    T: IntoPyObject<'py, PyAny>,
+    T: IntoPyObject<'py>,
 {
     type Error = E;
     #[inline]
@@ -125,10 +124,10 @@ impl IntoPyObjectTag {
         obj: PyResult<T>,
     ) -> PyResult<*mut ffi::PyObject>
     where
-        T: IntoPyObject<'py, PyAny>,
+        T: IntoPyObject<'py>,
         PyErr: From<T::Error>,
     {
-        obj.and_then(|obj| obj.into_pyobj(py).map_err(Into::into))
+        obj.and_then(|obj| obj.into_pyobject(py).map_err(Into::into))
             .map(Bound::into_ptr)
     }
 
@@ -143,8 +142,8 @@ pub trait IntoPyObjectKind {
         IntoPyObjectTag
     }
 }
-impl<'py, T: IntoPyObject<'py, PyAny>> IntoPyObjectKind for &T {}
-impl<'py, T: IntoPyObject<'py, PyAny>, E> IntoPyObjectKind for &Result<T, E> {}
+impl<'py, T: IntoPyObject<'py>> IntoPyObjectKind for &T {}
+impl<'py, T: IntoPyObject<'py>, E> IntoPyObjectKind for &Result<T, E> {}
 
 pub struct IntoPyNoneTag;
 impl IntoPyNoneTag {

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -1,8 +1,8 @@
 use std::convert::Infallible;
 
-use crate::conversion::AnyBound;
 use crate::{
-    conversion::IntoPyObject, ffi, types::PyNone, Bound, IntoPy, PyErr, PyObject, PyResult, Python,
+    conversion::IntoPyObject, ffi, types::PyNone, Bound, BoundObject, IntoPy, PyErr, PyObject,
+    PyResult, Python,
 };
 
 /// Used to wrap values in `Option<T>` for default arguments.
@@ -129,7 +129,7 @@ impl IntoPyObjectTag {
         PyErr: From<T::Error>,
     {
         obj.and_then(|obj| obj.into_pyobject(py).map_err(Into::into))
-            .map(AnyBound::into_bound)
+            .map(BoundObject::into_bound)
             .map(Bound::into_ptr)
     }
 

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -108,7 +108,7 @@ impl IntoPyTag {
 }
 pub trait IntoPyKind {
     #[inline]
-    fn into_py_kind(&self) -> IntoPyTag {
+    fn conversion_kind(&self) -> IntoPyTag {
         IntoPyTag
     }
 }
@@ -138,7 +138,7 @@ impl IntoPyObjectTag {
 }
 pub trait IntoPyObjectKind {
     #[inline]
-    fn into_py_kind(&self) -> IntoPyObjectTag {
+    fn conversion_kind(&self) -> IntoPyObjectTag {
         IntoPyObjectTag
     }
 }

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -118,12 +118,17 @@ impl<T: IntoPy<PyObject>, E> IntoPyKind for &Result<T, E> {} // required autoref
 pub struct IntoPyObjectTag;
 impl IntoPyObjectTag {
     #[inline]
-    pub fn map_into_ptr<'py, T: IntoPyObject<'py, PyAny, Error = PyErr>>(
+    pub fn map_into_ptr<'py, T>(
         self,
         py: Python<'py>,
         obj: PyResult<T>,
-    ) -> PyResult<*mut ffi::PyObject> {
-        obj.and_then(|obj| obj.into_pyobj(py)).map(Bound::into_ptr)
+    ) -> PyResult<*mut ffi::PyObject>
+    where
+        T: IntoPyObject<'py, PyAny>,
+        PyErr: From<T::Error>,
+    {
+        obj.and_then(|obj| obj.into_pyobj(py).map_err(Into::into))
+            .map(Bound::into_ptr)
     }
 
     #[inline]

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -575,7 +575,7 @@ unsafe impl<T> AsPyPointer for Bound<'_, T> {
 #[repr(transparent)]
 pub struct Borrowed<'a, 'py, T>(NonNull<ffi::PyObject>, PhantomData<&'a Py<T>>, Python<'py>);
 
-impl<'py, T> Borrowed<'_, 'py, T> {
+impl<'a, 'py, T> Borrowed<'a, 'py, T> {
     /// Creates a new owned [`Bound<T>`] from this borrowed reference by
     /// increasing the reference count.
     ///
@@ -602,6 +602,10 @@ impl<'py, T> Borrowed<'_, 'py, T> {
     /// # }
     pub fn to_owned(self) -> Bound<'py, T> {
         (*self).clone()
+    }
+
+    pub(crate) fn to_any(self) -> Borrowed<'a, 'py, PyAny> {
+        Borrowed(self.0, PhantomData, self.2)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,7 @@ pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPy, ToPyObject};
 pub use crate::err::{DowncastError, DowncastIntoError, PyErr, PyErrArguments, PyResult, ToPyErr};
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
-pub use crate::instance::{Borrowed, Bound, Py, PyObject};
+pub use crate::instance::{Borrowed, Bound, BoundObject, Py, PyObject};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyRef, PyRefMut};
 pub use crate::pyclass::PyClass;

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -469,19 +469,21 @@ impl<T: PyClass> IntoPy<PyObject> for &'_ PyRef<'_, T> {
 
 impl<'py, T: PyClass> IntoPyObject<'py> for PyRef<'py, T> {
     type Target = T;
+    type Output = Bound<'py, T>;
     type Error = Infallible;
 
-    fn into_pyobject(self, _py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(self.inner.clone())
     }
 }
 
-impl<'py, T: PyClass> IntoPyObject<'py> for &PyRef<'py, T> {
+impl<'a, 'py, T: PyClass> IntoPyObject<'py> for &'a PyRef<'py, T> {
     type Target = T;
+    type Output = &'a Bound<'py, T>;
     type Error = Infallible;
 
-    fn into_pyobject(self, _py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
-        Ok(self.inner.clone())
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(&self.inner)
     }
 }
 
@@ -656,19 +658,21 @@ impl<T: PyClass<Frozen = False>> IntoPy<PyObject> for &'_ PyRefMut<'_, T> {
 
 impl<'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for PyRefMut<'py, T> {
     type Target = T;
+    type Output = Bound<'py, T>;
     type Error = Infallible;
 
-    fn into_pyobject(self, _py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(self.inner.clone())
     }
 }
 
-impl<'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for &PyRefMut<'py, T> {
+impl<'a, 'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for &'a PyRefMut<'py, T> {
     type Target = T;
+    type Output = &'a Bound<'py, T>;
     type Error = Infallible;
 
-    fn into_pyobject(self, _py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error> {
-        Ok(self.inner.clone())
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(&self.inner)
     }
 }
 

--- a/tests/ui/missing_intopy.rs
+++ b/tests/ui/missing_intopy.rs
@@ -1,8 +1,8 @@
 struct Blah;
 
 #[pyo3::pyfunction]
-fn blah() -> Blah{
+fn blah() -> Blah {
     Blah
 }
 
-fn main(){}
+fn main() {}

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -2,7 +2,7 @@ error[E0599]: the method `conversion_kind` exists for reference `&&&Blah`, but i
  --> tests/ui/missing_intopy.rs:4:14
   |
 1 | struct Blah;
-  | ----------- doesn't satisfy `Blah: IntoPy<Py<PyAny>>`, `Blah: IntoPyKind` or `Blah: IntoPyObject<'_, PyAny>`
+  | ----------- doesn't satisfy `Blah: IntoPy<Py<PyAny>>`, `Blah: IntoPyKind` or `Blah: IntoPyObject<'_>`
 ...
 4 | fn blah() -> Blah{
   |              ^^^^ method cannot be called on `&&&Blah` due to unsatisfied trait bounds
@@ -10,15 +10,15 @@ error[E0599]: the method `conversion_kind` exists for reference `&&&Blah`, but i
   = note: the following trait bounds were not satisfied:
           `&&Blah: IntoPy<Py<PyAny>>`
           which is required by `&&Blah: IntoPyKind`
-          `&Blah: IntoPyObject<'_, PyAny>`
+          `&Blah: IntoPyObject<'_>`
           which is required by `&&Blah: IntoPyObjectKind`
           `&&&Blah: IntoPy<Py<PyAny>>`
           which is required by `&&&Blah: IntoPyKind`
-          `&&Blah: IntoPyObject<'_, PyAny>`
+          `&&Blah: IntoPyObject<'_>`
           which is required by `&&&Blah: IntoPyObjectKind`
           `&Blah: IntoPy<Py<PyAny>>`
           which is required by `&Blah: IntoPyKind`
-          `Blah: IntoPyObject<'_, PyAny>`
+          `Blah: IntoPyObject<'_>`
           which is required by `&Blah: IntoPyObjectKind`
           `Blah: IntoPy<Py<PyAny>>`
           which is required by `Blah: IntoPyKind`
@@ -28,8 +28,8 @@ note: the traits `IntoPy` and `IntoPyObject` must be implemented
   | pub trait IntoPy<T>: Sized {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ...
-  | pub trait IntoPyObject<'py, T>: Sized {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  | pub trait IntoPyObject<'py>: Sized {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following traits define an item `conversion_kind`, perhaps you need to implement one of them:
           candidate #1: `IntoPyKind`

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -1,4 +1,4 @@
-error[E0599]: the method `into_py_kind` exists for reference `&Blah`, but its trait bounds were not satisfied
+error[E0599]: the method `conversion_kind` exists for reference `&Blah`, but its trait bounds were not satisfied
  --> tests/ui/missing_intopy.rs:4:14
   |
 1 | struct Blah;
@@ -23,6 +23,6 @@ note: the traits `IntoPy` and `IntoPyObject` must be implemented
   | pub trait IntoPyObject<'py, T>: Sized {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: items from traits can only be used if the trait is implemented and in scope
-  = note: the following traits define an item `into_py_kind`, perhaps you need to implement one of them:
+  = note: the following traits define an item `conversion_kind`, perhaps you need to implement one of them:
           candidate #1: `IntoPyKind`
           candidate #2: `IntoPyObjectKind`

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -1,19 +1,27 @@
-error[E0599]: the method `conversion_kind` exists for reference `&Blah`, but its trait bounds were not satisfied
+error[E0599]: the method `conversion_kind` exists for reference `&&&Blah`, but its trait bounds were not satisfied
  --> tests/ui/missing_intopy.rs:4:14
   |
 1 | struct Blah;
-  | ----------- doesn't satisfy `Blah: IntoPy<Py<PyAny>>`, `Blah: IntoPyObject<'_, PyAny>` or `Blah: IntoPyObjectKind`
+  | ----------- doesn't satisfy `Blah: IntoPy<Py<PyAny>>`, `Blah: IntoPyKind` or `Blah: IntoPyObject<'_, PyAny>`
 ...
 4 | fn blah() -> Blah{
-  |              ^^^^ method cannot be called on `&Blah` due to unsatisfied trait bounds
+  |              ^^^^ method cannot be called on `&&&Blah` due to unsatisfied trait bounds
   |
   = note: the following trait bounds were not satisfied:
-          `Blah: IntoPyObject<'_, PyAny>`
-          which is required by `Blah: IntoPyObjectKind`
-          `Blah: IntoPy<Py<PyAny>>`
-          which is required by `&Blah: IntoPyKind`
+          `&&Blah: IntoPy<Py<PyAny>>`
+          which is required by `&&Blah: IntoPyKind`
           `&Blah: IntoPyObject<'_, PyAny>`
+          which is required by `&&Blah: IntoPyObjectKind`
+          `&&&Blah: IntoPy<Py<PyAny>>`
+          which is required by `&&&Blah: IntoPyKind`
+          `&&Blah: IntoPyObject<'_, PyAny>`
+          which is required by `&&&Blah: IntoPyObjectKind`
+          `&Blah: IntoPy<Py<PyAny>>`
+          which is required by `&Blah: IntoPyKind`
+          `Blah: IntoPyObject<'_, PyAny>`
           which is required by `&Blah: IntoPyObjectKind`
+          `Blah: IntoPy<Py<PyAny>>`
+          which is required by `Blah: IntoPyKind`
 note: the traits `IntoPy` and `IntoPyObject` must be implemented
  --> src/conversion.rs
   |
@@ -25,4 +33,5 @@ note: the traits `IntoPy` and `IntoPyObject` must be implemented
   = help: items from traits can only be used if the trait is implemented and in scope
   = note: the following traits define an item `conversion_kind`, perhaps you need to implement one of them:
           candidate #1: `IntoPyKind`
-          candidate #2: `IntoPyObjectKind`
+          candidate #2: `IntoPyNoneKind`
+          candidate #3: `IntoPyObjectKind`

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -1,37 +1,36 @@
-error[E0599]: the method `conversion_kind` exists for reference `&&&Blah`, but its trait bounds were not satisfied
+error[E0277]: `Blah` cannot be converted to a Python object
+ --> tests/ui/missing_intopy.rs:4:14
+  |
+4 | fn blah() -> Blah {
+  |              ^^^^ the trait `IntoPyObject<'_>` is not implemented for `Blah`
+  |
+  = note: `IntoPyObject` is automatically implemented by the `#[pyclass]` macro
+  = note: if you do not wish to have a corresponding Python type, implement it manually
+  = note: if you do not own `Blah` you can perform a manual conversion to one of the types in `pyo3::types::*`
+  = help: the following other types implement trait `IntoPyObject<'py>`:
+            &'a Py<T>
+            &'a PyRef<'py, T>
+            &'a PyRefMut<'py, T>
+            &'a pyo3::Bound<'py, T>
+            &OsStr
+            &OsString
+            &Path
+            &PathBuf
+          and $N others
+note: required by a bound in `UnknownReturnType::<T>::wrap`
+ --> src/impl_/wrap.rs
+  |
+  |     pub fn wrap<'py>(&self, _: T) -> T
+  |            ---- required by a bound in this associated function
+  |     where
+  |         T: IntoPyObject<'py>,
+  |            ^^^^^^^^^^^^^^^^^ required by this bound in `UnknownReturnType::<T>::wrap`
+
+error[E0599]: no method named `map_err` found for struct `Blah` in the current scope
  --> tests/ui/missing_intopy.rs:4:14
   |
 1 | struct Blah;
-  | ----------- doesn't satisfy `Blah: IntoPy<Py<PyAny>>`, `Blah: IntoPyKind` or `Blah: IntoPyObject<'_>`
+  | ----------- method `map_err` not found for this struct
 ...
-4 | fn blah() -> Blah{
-  |              ^^^^ method cannot be called on `&&&Blah` due to unsatisfied trait bounds
-  |
-  = note: the following trait bounds were not satisfied:
-          `&&Blah: IntoPy<Py<PyAny>>`
-          which is required by `&&Blah: IntoPyKind`
-          `&Blah: IntoPyObject<'_>`
-          which is required by `&&Blah: IntoPyObjectKind`
-          `&&&Blah: IntoPy<Py<PyAny>>`
-          which is required by `&&&Blah: IntoPyKind`
-          `&&Blah: IntoPyObject<'_>`
-          which is required by `&&&Blah: IntoPyObjectKind`
-          `&Blah: IntoPy<Py<PyAny>>`
-          which is required by `&Blah: IntoPyKind`
-          `Blah: IntoPyObject<'_>`
-          which is required by `&Blah: IntoPyObjectKind`
-          `Blah: IntoPy<Py<PyAny>>`
-          which is required by `Blah: IntoPyKind`
-note: the traits `IntoPy` and `IntoPyObject` must be implemented
- --> src/conversion.rs
-  |
-  | pub trait IntoPy<T>: Sized {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-...
-  | pub trait IntoPyObject<'py>: Sized {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  = help: items from traits can only be used if the trait is implemented and in scope
-  = note: the following traits define an item `conversion_kind`, perhaps you need to implement one of them:
-          candidate #1: `IntoPyKind`
-          candidate #2: `IntoPyNoneKind`
-          candidate #3: `IntoPyObjectKind`
+4 | fn blah() -> Blah {
+  |              ^^^^ method not found in `Blah`

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -1,11 +1,28 @@
-error[E0277]: `Blah` cannot be converted to a Python object
+error[E0599]: the method `into_py_kind` exists for reference `&Blah`, but its trait bounds were not satisfied
  --> tests/ui/missing_intopy.rs:4:14
   |
+1 | struct Blah;
+  | ----------- doesn't satisfy `Blah: IntoPy<Py<PyAny>>`, `Blah: IntoPyObject<'_, PyAny>` or `Blah: IntoPyObjectKind`
+...
 4 | fn blah() -> Blah{
-  |              ^^^^ the trait `IntoPy<Py<PyAny>>` is not implemented for `Blah`, which is required by `Blah: OkWrap<_>`
+  |              ^^^^ method cannot be called on `&Blah` due to unsatisfied trait bounds
   |
-  = note: `IntoPy` is automatically implemented by the `#[pyclass]` macro
-  = note: if you do not wish to have a corresponding Python type, implement `IntoPy` manually
-  = note: if you do not own `Blah` you can perform a manual conversion to one of the types in `pyo3::types::*`
-  = help: the trait `OkWrap<T>` is implemented for `Result<T, E>`
-  = note: required for `Blah` to implement `OkWrap<Blah>`
+  = note: the following trait bounds were not satisfied:
+          `Blah: IntoPyObject<'_, PyAny>`
+          which is required by `Blah: IntoPyObjectKind`
+          `Blah: IntoPy<Py<PyAny>>`
+          which is required by `&Blah: IntoPyKind`
+          `&Blah: IntoPyObject<'_, PyAny>`
+          which is required by `&Blah: IntoPyObjectKind`
+note: the traits `IntoPy` and `IntoPyObject` must be implemented
+ --> src/conversion.rs
+  |
+  | pub trait IntoPy<T>: Sized {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+...
+  | pub trait IntoPyObject<'py, T>: Sized {
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = help: items from traits can only be used if the trait is implemented and in scope
+  = note: the following traits define an item `into_py_kind`, perhaps you need to implement one of them:
+          candidate #1: `IntoPyKind`
+          candidate #2: `IntoPyObjectKind`


### PR DESCRIPTION
This implements a proof of concept of a new fallible conversion trait.

---

# Design
## IntoPyObject
This introduces a new trait `IntoPyObject` to perform the conversion of implemented type into Python. ~Currently the trait is generic so that the same type can have multiple conversions to different Python types. In this version I used it to provide an additional typed conversion for the `chrono` types when the unlimited API is enabled. There might be more situations where this could be useful.~ I changed the generic to an associated type as outlined in https://github.com/PyO3/pyo3/pull/4060#issuecomment-2057805498

The `Error` is specified as an associated type, since every conversion should have a single applicable error (or `Infallible` if it can't fail).

The return type is specified to `Bound<T>` to guarantee that we convert to a Python type.
```rust
pub trait IntoPyObject<'py>: Sized {
    type Target;
    type Error;

    fn into_pyobject(self, py: Python<'py>) -> Result<Bound<'py, Self::Target>, Self::Error>;
}
```
## ~IntoPyObjectExt~
Additionally to `IntoPyObject` this also adds `IntoPyObjectExt`. The sole purpose of this trait is to allow specifying the desired output type using the turbo fish syntax:
```rust
obj.into_pyobject::<PyDateTime, _>(py)
```
~This makes it much nicer to work with types that implement multiple conversions and need type hinting. This would probably be the API most users would interact with.~ This is only beneficial in the case of a generic trait. 

## Macros
To use the new conversion on return values of `#[pyfunction]` and friends _without_ breaking current code, a variant of ~autoref~ deref specialization is implemented. It prefers the implementation of `IntoPyObject` over `IntoPy<PyObject>`. (~Similar to the current approach the conversion to `PyAny` needs to be available.~) This means there should be no changes required by users. The macros will pick up the fallible `IntoPyObject` implementation automatically, if available. For the migration we could then just deprecate `IntoPy` (and `ToPyObject`) and advise to implement `IntoPyObject` instead, removing the old conversions in a future release. Additionally there is another layer of specialization for the `()` return type in `#[pymethods]` and `#[pyfunctions]`. This allows converting them into `PyNone` as part of the macro code, because that's the  Python equivalent of a function returning "nothing", while still using `PyTuple` as the `IntoPyObject::Target`.

# Open Questions
- Do we need `IntoPyObject` be generic, or would an associated type also work? Maybe implementing it on some more types will give us more insight whether the generic is needed.
  From my initial implementation I have the feeling that the generic version introduces a lot of complexity while not really providing a big benefit.
- What to do with APIs that are generic over `IntoPy` and `ToPyObject`? I assume we need to introduce new variants that are generic over `IntoPyObject`, similar to what we did with the `_bound` constructors.
---

There are probably some edge cases that don't work correctly, but I thought I'll gather some feedback first whether this goes into the right direction before I chase those down.

# TODOs
- [x] rename and seal `AnyBound`, possible candidates:
  - `BoundObject`
  - ~`BoundType`~
  - ~`IntoPyObjectOutput`~
  - ~`BoundMethods`~
- [x] lift type restrictions of `Either` impl 

# Followups
- add implementation to references of container types like `&HashMap`, `&BTreeSet` or `&Vec`
- optimize implementation for `PyRef`/`PyRefMut`, possibly by storing a `Borrowed` in them
- work out the migration of `IntoPy<PyObject>` and `ToPyObject`
  - rework implementations that currently rely on APIs with the old bounds
  - we can only provide a blanket impl for one of them...
- work out `PyBytes` specialization (#4182)
- add `BoundObject` to the prelude?
 


Xref #4041