### PR TITLE
add `#[doc(hidden)]` to the Rust module created by `#[pymodule]`

### DIFF
--- a/newsfragments/4067.fixed.md
+++ b/newsfragments/4067.fixed.md
@@ -1,0 +1,1 @@
+fixes `missing_docs` lint to trigger on documented `#[pymodule]` functions

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -324,6 +324,7 @@ pub fn pymodule_function_impl(mut function: syn::ItemFn) -> Result<TokenStream> 
 
     Ok(quote! {
         #function
+        #[doc(hidden)]
         #vis mod #ident {
             #initialization
         }

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -53,4 +53,5 @@ fn test_compile_errors() {
     #[cfg(feature = "experimental-async")]
     #[cfg(any(not(Py_LIMITED_API), Py_3_10))] // to avoid PyFunctionArgument for &str
     t.compile_fail("tests/ui/invalid_cancel_handle.rs");
+    t.pass("tests/ui/pymodule_missing_docs.rs");
 }

--- a/tests/ui/pymodule_missing_docs.rs
+++ b/tests/ui/pymodule_missing_docs.rs
@@ -1,0 +1,12 @@
+#![deny(missing_docs)]
+//! Some crate docs
+
+use pyo3::prelude::*;
+
+/// Some module documentation
+#[pymodule]
+pub fn python_module(_m: &Bound<'_, PyModule>) -> PyResult<()> {
+    Ok(())
+}
+
+fn main() {}


### PR DESCRIPTION
This adds `#[doc(hidden)]` to the Rust module created by `#[pymodule]`. Given that all items inside of that module already are `#[doc(hidden)]` I thinks it's reasonable to also hide the module itself too.

Fixes #4063 