### PR TITLE
Allow use of scientific notation on rust decimal

### DIFF
--- a/newsfragments/4079.added.md
+++ b/newsfragments/4079.added.md
@@ -1,0 +1,1 @@
+Added support for scientific notation in `Decimal` conversion

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -61,12 +61,13 @@ use std::str::FromStr;
 impl FromPyObject<'_> for Decimal {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         // use the string representation to not be lossy
+        let py_str = &obj.str()?;
+        let rs_str = &py_str.to_cow()?;
         if let Ok(val) = obj.extract() {
             Ok(Decimal::new(val, 0))
         } else {
-            Decimal::from_str(&obj.str()?.to_cow()?).or_else(|_| {
-                Decimal::from_scientific(&obj.str()?.to_cow()?)
-                    .map_err(|e| PyValueError::new_err(e.to_string()))
+            Decimal::from_str(&rs_str).or_else(|_| {
+                Decimal::from_scientific(&rs_str).map_err(|e| PyValueError::new_err(e.to_string()))
             })
         }
     }

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -61,11 +61,11 @@ use std::str::FromStr;
 impl FromPyObject<'_> for Decimal {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         // use the string representation to not be lossy
-        let py_str = &obj.str()?;
-        let rs_str = &py_str.to_cow()?;
         if let Ok(val) = obj.extract() {
             Ok(Decimal::new(val, 0))
         } else {
+            let py_str = &obj.str()?;
+            let rs_str = &py_str.to_cow()?;
             Decimal::from_str(rs_str).or_else(|_| {
                 Decimal::from_scientific(rs_str).map_err(|e| PyValueError::new_err(e.to_string()))
             })

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -66,8 +66,8 @@ impl FromPyObject<'_> for Decimal {
         if let Ok(val) = obj.extract() {
             Ok(Decimal::new(val, 0))
         } else {
-            Decimal::from_str(&rs_str).or_else(|_| {
-                Decimal::from_scientific(&rs_str).map_err(|e| PyValueError::new_err(e.to_string()))
+            Decimal::from_str(rs_str).or_else(|_| {
+                Decimal::from_scientific(rs_str).map_err(|e| PyValueError::new_err(e.to_string()))
             })
         }
     }


### PR DESCRIPTION
Fixes #3530 which allows uses of scientific notation on `Decimal`. 
