### PR TITLE
docs: Make contributing.md slightly more clear for newer contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,6 @@ Please consider adding the following to your pull request:
  - docs to all new functions and / or detail in the guide
  - tests for all new or changed functions
 
-PyO3's CI pipeline will check your pull request. To run its tests
+PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
 locally, you can run ```nox```. See ```nox --list-sessions```
 for a list of supported actions.

--- a/Contributing.md
+++ b/Contributing.md
@@ -116,6 +116,9 @@ You can run these tests yourself with
 #### Tests
 `cargo test --features full`
 
+#### Check all conditional compilation
+`nox -s check-feature-powerset`
+
 #### UI Tests
 
 PyO3 uses [`trybuild`][trybuild] to develop UI tests to capture error messages from the Rust compiler for some of the macro functionality.

--- a/Contributing.md
+++ b/Contributing.md
@@ -92,9 +92,23 @@ Here are a few things to note when you are writing PRs.
 
 ### Continuous Integration
 
-The PyO3 repo uses GitHub Actions. PRs are blocked from merging if CI is not successful.
+The PyO3 repo uses GitHub Actions. PRs are blocked from merging if CI is not successful. Formatting, linting and tests are checked for all Rust and Python code. In addition, all warnings in Rust code are disallowed (using `RUSTFLAGS="-D warnings"`).
 
-Formatting, linting and tests are checked for all Rust and Python code. In addition, all warnings in Rust code are disallowed (using `RUSTFLAGS="-D warnings"`).
+#### Linting Python code
+`nox -s ruff`
+
+#### Linting Rust code
+`nox -s rustfmt`
+
+#### Semver checks
+`cargo semver-checks check-release`
+
+#### Clippy
+`nox -s clippy-all`
+
+#### Tests
+`cargo test --features full`
+```
 
 Tests run with all supported Python versions with the latest stable Rust compiler, as well as for Python 3.9 with the minimum supported Rust version.
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -94,6 +94,10 @@ Here are a few things to note when you are writing PRs.
 
 The PyO3 repo uses GitHub Actions. PRs are blocked from merging if CI is not successful. Formatting, linting and tests are checked for all Rust and Python code. In addition, all warnings in Rust code are disallowed (using `RUSTFLAGS="-D warnings"`).
 
+Tests run with all supported Python versions with the latest stable Rust compiler, as well as for Python 3.9 with the minimum supported Rust version.
+
+If you are adding a new feature, you should add it to the `full` feature in our *Cargo.toml** so that it is tested in CI.
+
 #### Linting Python code
 `nox -s ruff`
 
@@ -108,11 +112,7 @@ The PyO3 repo uses GitHub Actions. PRs are blocked from merging if CI is not suc
 
 #### Tests
 `cargo test --features full`
-```
 
-Tests run with all supported Python versions with the latest stable Rust compiler, as well as for Python 3.9 with the minimum supported Rust version.
-
-If you are adding a new feature, you should add it to the `full` feature in our *Cargo.toml** so that it is tested in CI.
 
 You can run these tests yourself with
 `nox`. Use  `nox -l` to list the full set of subcommands you can run.

--- a/Contributing.md
+++ b/Contributing.md
@@ -98,6 +98,9 @@ Tests run with all supported Python versions with the latest stable Rust compile
 
 If you are adding a new feature, you should add it to the `full` feature in our *Cargo.toml** so that it is tested in CI.
 
+You can run these tests yourself with
+`nox`. Use  `nox -l` to list the full set of subcommands you can run.
+
 #### Linting Python code
 `nox -s ruff`
 
@@ -112,10 +115,6 @@ If you are adding a new feature, you should add it to the `full` feature in our 
 
 #### Tests
 `cargo test --features full`
-
-
-You can run these tests yourself with
-`nox`. Use  `nox -l` to list the full set of subcommands you can run.
 
 #### UI Tests
 


### PR DESCRIPTION
Hello dear maintainers: 

Based on my new experience contributing for the 1-2 time, I think the following additions on the `Contributing.md` could help newer contributors to know exactly what commands they should execute to sort of check their PR before `CI` flags it. Being more explicit over just waiting for the `CI` to tell you has the advantage of:
* More PRs not failing tests + linting
* Make contributor aware of specifically what tools the repo is using to check for correctness. 
* Making sure their new/change feature does not break current functionality. Specifically, i mean that just running `nox` or `cargo test` doesnt run test code for `--features`, but the `CI` does, thus a contributor would assume everything goes alright until its flagged by `CI` and the "angry" maintainer checks that such a basic check wasn't done by the contributor. :).

These are just my 2 cents, thanks for the great repo :). 

Edit: Since I am not familiar at all with the repo, I assume there are other tips and tricks that are checked in `CI` and for the code, so I could gladly add them if pointed out that its missed. 