### PR TITLE
convert module initialization to use pep 489 slots

### DIFF
--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -369,8 +369,8 @@ fn module_initialization(options: PyModuleOptions, ident: &syn::Ident) -> TokenS
         /// the module.
         #[doc(hidden)]
         #[export_name = #pyinit_symbol]
-        pub unsafe extern "C" fn __pyo3_init() -> *mut #pyo3_path::ffi::PyObject {
-            #pyo3_path::impl_::trampoline::module_init(|py| _PYO3_DEF.make_module(py))
+        pub unsafe extern "C" fn __pyo3_init() -> *mut #pyo3_path::ffi::PyModuleDef {
+            _PYO3_DEF.make_def()
         }
     }
 }


### PR DESCRIPTION
Supersedes #2245 

This is a very first draft of starting to support PEP 489, which is necessary if we want module state (instead of static state). I expect this to come in handy in particular for supporting freethreaded Python and subinterpreters.

This is very much a draft of some stuff I started fiddling around with a couple of weeks ago, so not at all reviewable yet. I just don't want to forget I started this, so pushing it.