### PR TITLE
Deprecate the `PySet::empty` gil-ref constructor

### DIFF
--- a/newsfragments/4082.changed.md
+++ b/newsfragments/4082.changed.md
@@ -1,0 +1,1 @@
+Deprecate the `PySet::empty()` gil-ref constructor.

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -58,7 +58,14 @@ impl PySet {
     }
 
     /// Deprecated form of [`PySet::empty_bound`].
-    pub fn empty(py: Python<'_>) -> PyResult<&'_ PySet> {
+    #[cfg_attr(
+        not(feature = "gil-refs"),
+        deprecated(
+            since = "0.21.2",
+            note = "`PySet::empty` will be replaced by `PySet::empty_bound` in a future PyO3 version"
+        )
+    )]
+    pub fn empty(py: Python<'_>) -> PyResult<&PySet> {
         Self::empty_bound(py).map(Bound::into_gil_ref)
     }
 


### PR DESCRIPTION
As per https://github.com/PyO3/pyo3/pull/4037#issuecomment-2054093873

