### PR TITLE
fix declarative module compile error with `create_exception!`

### DIFF
--- a/newsfragments/4086.fixed.md
+++ b/newsfragments/4086.fixed.md
@@ -1,0 +1,1 @@
+Fixes a compile error when exporting an exception created with `create_exception!` living in a different Rust module using the `declarative-module` feature.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -252,7 +252,7 @@ macro_rules! pyobject_native_type_info(
 
         impl $name {
             #[doc(hidden)]
-            const _PYO3_DEF: $crate::impl_::pymodule::AddTypeToModule<Self> = $crate::impl_::pymodule::AddTypeToModule::new();
+            pub const _PYO3_DEF: $crate::impl_::pymodule::AddTypeToModule<Self> = $crate::impl_::pymodule::AddTypeToModule::new();
         }
     };
 );

--- a/tests/test_declarative_module.rs
+++ b/tests/test_declarative_module.rs
@@ -10,10 +10,14 @@ use pyo3::types::PyBool;
 mod common;
 
 mod some_module {
+    use pyo3::create_exception;
+    use pyo3::exceptions::PyException;
     use pyo3::prelude::*;
 
     #[pyclass]
     pub struct SomePyClass;
+
+    create_exception!(some_module, SomeException, PyException);
 }
 
 #[pyclass]
@@ -60,6 +64,10 @@ mod declarative_module {
     // test for #4036
     #[pymodule_export]
     use super::some_module::SomePyClass;
+
+    // test for #4036
+    #[pymodule_export]
+    use super::some_module::SomeException;
 
     #[pymodule]
     mod inner {


### PR DESCRIPTION
Fixes a compile error when exporting an exception created with `create_exception!` living in a different Rust module using the `declarative-module` feature.

Fixes #4036 