### PR TITLE
Specify higher target-lexicon version

### DIFF
--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2021"
 [dependencies]
 once_cell = "1"
 python3-dll-a = { version = "0.2.6", optional = true }
-target-lexicon = "0.12"
+target-lexicon = "0.12.14"
 
 [build-dependencies]
 python3-dll-a = { version = "0.2.6", optional = true }
-target-lexicon = "0.12"
+target-lexicon = "0.12.14"
 
 [features]
 default = []


### PR DESCRIPTION
This fixes the following error:

```
error[E0599]: no variant or associated item named `Aix` found for enum `OperatingSystem` in the current scope
   --> C:\Users\bruno\.cargo\registry\src\index.crates.io-6f17d22bba15001f\pyo3-build-config-0.21.2\src\impl_.rs:779:56
    |
779 |         || target.operating_system == OperatingSystem::Aix
    |                                                        ^^^ variant or associated item not found in `OperatingSystem`
    |
note: if you're trying to build a new `OperatingSystem`, consider using `target_lexicon::host::<impl OperatingSystem>::host` which returns `OperatingSystem`
   --> C:\Users\bruno\Rust\my_module\target\debug\build\target-lexicon-12b61036834cd904\out/host.rs:43:5
    |
43  |     pub const fn host() -> Self {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0599`.
```