### PR TITLE
add `#[track_caller]` to all `Py`/`Bound`/`Borrowed` methods which panic

### DIFF
--- a/newsfragments/4098.changed.md
+++ b/newsfragments/4098.changed.md
@@ -1,0 +1,1 @@
+Add `#[track_caller]` to all `Py<T>`, `Bound<'py, T>` and `Borrowed<'a, 'py, T>` methods which can panic.

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1091,6 +1091,7 @@ fn display_downcast_error(
     )
 }
 
+#[track_caller]
 pub fn panic_after_error(_py: Python<'_>) -> ! {
     unsafe {
         ffi::PyErr_Print();

--- a/src/ffi_ptr_ext.rs
+++ b/src/ffi_ptr_ext.rs
@@ -39,6 +39,7 @@ impl FfiPtrExt for *mut ffi::PyObject {
     }
 
     #[inline]
+    #[track_caller]
     unsafe fn assume_owned(self, py: Python<'_>) -> Bound<'_, PyAny> {
         Bound::from_owned_ptr(py, self)
     }
@@ -57,6 +58,7 @@ impl FfiPtrExt for *mut ffi::PyObject {
     }
 
     #[inline]
+    #[track_caller]
     unsafe fn assume_borrowed<'a>(self, py: Python<'_>) -> Borrowed<'a, '_, PyAny> {
         Borrowed::from_ptr(py, self)
     }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -104,6 +104,7 @@ impl<'py> Bound<'py, PyAny> {
     /// - `ptr` must be a valid pointer to a Python object
     /// - `ptr` must be an owned Python reference, as the `Bound<'py, PyAny>` will assume ownership
     #[inline]
+    #[track_caller]
     pub unsafe fn from_owned_ptr(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
         Self(py, ManuallyDrop::new(Py::from_owned_ptr(py, ptr)))
     }
@@ -141,6 +142,7 @@ impl<'py> Bound<'py, PyAny> {
     ///
     /// - `ptr` must be a valid pointer to a Python object
     #[inline]
+    #[track_caller]
     pub unsafe fn from_borrowed_ptr(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
         Self(py, ManuallyDrop::new(Py::from_borrowed_ptr(py, ptr)))
     }
@@ -242,6 +244,7 @@ where
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
     #[inline]
+    #[track_caller]
     pub fn borrow(&self) -> PyRef<'py, T> {
         PyRef::borrow(self)
     }
@@ -276,6 +279,7 @@ where
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
     #[inline]
+    #[track_caller]
     pub fn borrow_mut(&self) -> PyRefMut<'py, T>
     where
         T: PyClass<Frozen = False>,
@@ -573,6 +577,7 @@ impl<'a, 'py> Borrowed<'a, 'py, PyAny> {
     ///   the caller and it is the caller's responsibility to ensure that the reference this is
     ///   derived from is valid for the lifetime `'a`.
     #[inline]
+    #[track_caller]
     pub unsafe fn from_ptr(py: Python<'py>, ptr: *mut ffi::PyObject) -> Self {
         Self(
             NonNull::new(ptr).unwrap_or_else(|| crate::err::panic_after_error(py)),
@@ -1138,6 +1143,7 @@ where
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
     #[inline]
+    #[track_caller]
     pub fn borrow<'py>(&'py self, py: Python<'py>) -> PyRef<'py, T> {
         self.bind(py).borrow()
     }
@@ -1175,6 +1181,7 @@ where
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
     #[inline]
+    #[track_caller]
     pub fn borrow_mut<'py>(&'py self, py: Python<'py>) -> PyRefMut<'py, T>
     where
         T: PyClass<Frozen = False>,
@@ -1585,6 +1592,7 @@ impl<T> Py<T> {
     /// # Panics
     /// Panics if `ptr` is null.
     #[inline]
+    #[track_caller]
     pub unsafe fn from_owned_ptr(py: Python<'_>, ptr: *mut ffi::PyObject) -> Py<T> {
         match NonNull::new(ptr) {
             Some(nonnull_ptr) => Py(nonnull_ptr, PhantomData),
@@ -1628,6 +1636,7 @@ impl<T> Py<T> {
     /// # Panics
     /// Panics if `ptr` is null.
     #[inline]
+    #[track_caller]
     pub unsafe fn from_borrowed_ptr(py: Python<'_>, ptr: *mut ffi::PyObject) -> Py<T> {
         match Self::from_borrowed_ptr_or_opt(py, ptr) {
             Some(slf) => slf,

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -652,6 +652,7 @@ impl<'py, T: PyClass> PyRef<'py, T> {
         self.inner.clone().into_ptr()
     }
 
+    #[track_caller]
     pub(crate) fn borrow(obj: &Bound<'py, T>) -> Self {
         Self::try_borrow(obj).expect("Already mutably borrowed")
     }
@@ -848,6 +849,7 @@ impl<'py, T: PyClass<Frozen = False>> PyRefMut<'py, T> {
     }
 
     #[inline]
+    #[track_caller]
     pub(crate) fn borrow(obj: &Bound<'py, T>) -> Self {
         Self::try_borrow(obj).expect("Already borrowed")
     }


### PR DESCRIPTION
While debugging https://github.com/pydantic/pydantic/issues/9250 this morning, I realised it would be much more helpful if the panic message originated from the actual source location that attempted to construct the failed pointer, rather than deep in the guts of PyO3.

With this enabled, that reproduction actually panics with:

```
thread '<unnamed>' panicked at /home/david/dev/pydantic/pyo3/src/types/any.rs:2226:18:
```

which is in `PyAnyMethods::dir` - it turns out that `__dir__` can indeed be fallible, so I'll open a separate issue for that now...

