### PR TITLE
fix vectorcall argument handling

### DIFF
--- a/newsfragments/4104.fixed.md
+++ b/newsfragments/4104.fixed.md
@@ -1,0 +1,1 @@
+Changes definitions of `PY_VECTORCALL_ARGUMENTS_OFFSET` and `PyVectorcall_NARGS` to fix a false-positive assertion.


### PR DESCRIPTION
Fixes #4093

- Make PY_VECTORCALL_ARGUMENTS_OFFSET a size_t like on CPython
- Change the assert in PyVectorcall_NARGS to check the recovered number, not the original value (which is > PY_SSIZE_T_MAX on purpose)
