### PR TITLE
feature gate deprecated APIs for `PyDict`

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -674,6 +674,7 @@ mod test_no_clone {}
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "gil-refs")]
     #[allow(deprecated)]
     mod deprecated {
         use super::super::PyTryFrom;

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2034,7 +2034,7 @@ mod tests {
     #[test]
     fn test_call_for_non_existing_method() {
         Python::with_gil(|py| {
-            let obj: PyObject = PyDict::new(py).into();
+            let obj: PyObject = PyDict::new_bound(py).into();
             assert!(obj.call_method0(py, "asdf").is_err());
             assert!(obj
                 .call_method(py, "nonexistent_method", (1,), None)
@@ -2047,7 +2047,7 @@ mod tests {
     #[test]
     fn py_from_dict() {
         let dict: Py<PyDict> = Python::with_gil(|py| {
-            let native = PyDict::new(py);
+            let native = PyDict::new_bound(py);
             Py::from(native)
         });
 
@@ -2057,7 +2057,7 @@ mod tests {
     #[test]
     fn pyobject_from_py() {
         Python::with_gil(|py| {
-            let dict: Py<PyDict> = PyDict::new(py).into();
+            let dict: Py<PyDict> = PyDict::new_bound(py).unbind();
             let cnt = dict.get_refcnt(py);
             let p: PyObject = dict.into();
             assert_eq!(p.get_refcnt(py), cnt);

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -158,7 +158,7 @@ mod tests {
     use super::PyIterator;
     use crate::exceptions::PyTypeError;
     use crate::gil::GILPool;
-    use crate::types::{PyDict, PyList};
+    use crate::types::{PyAnyMethods, PyDict, PyList};
     use crate::{Py, PyAny, Python, ToPyObject};
 
     #[test]
@@ -244,10 +244,11 @@ def fibonacci(target):
 "#;
 
         Python::with_gil(|py| {
-            let context = PyDict::new(py);
-            py.run(fibonacci_generator, None, Some(context)).unwrap();
+            let context = PyDict::new_bound(py);
+            py.run_bound(fibonacci_generator, None, Some(&context))
+                .unwrap();
 
-            let generator = py.eval("fibonacci(5)", None, Some(context)).unwrap();
+            let generator = py.eval_bound("fibonacci(5)", None, Some(&context)).unwrap();
             for (actual, expected) in generator.iter().unwrap().zip(&[1, 1, 2, 3, 5]) {
                 let actual = actual.unwrap().extract::<usize>().unwrap();
                 assert_eq!(actual, *expected)

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -435,6 +435,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "gil-refs")]
     #[allow(deprecated)]
     fn test_mapping_try_from() {
         use crate::PyTryFrom;


### PR DESCRIPTION
Part of #3960

Move deprecated `PyDict` APIs behind `gil-refs` features gate.