### PR TITLE
handle `#[pyo3(from_py_with = ...)]` on dunder (`__magic__`) methods

### DIFF
--- a/newsfragments/4117.fixed.md
+++ b/newsfragments/4117.fixed.md
@@ -1,0 +1,1 @@
+Correctly handle `#[pyo3(from_py_with = ...)]` attribute on dunder (`__magic__`) method arguments instead of silently ignoring it.

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -290,6 +290,10 @@ fn get_length(obj: &Bound<'_, PyAny>) -> PyResult<usize> {
     Ok(length)
 }
 
+fn is_even(obj: &Bound<'_, PyAny>) -> PyResult<bool> {
+    obj.extract::<i32>().map(|i| i % 2 == 0)
+}
+
 #[pyclass]
 struct ClassWithFromPyWithMethods {}
 
@@ -319,6 +323,10 @@ impl ClassWithFromPyWithMethods {
     fn staticmethod(#[pyo3(from_py_with = "get_length")] argument: usize) -> usize {
         argument
     }
+
+    fn __contains__(&self, #[pyo3(from_py_with = "is_even")] obj: bool) -> bool {
+        obj
+    }
 }
 
 #[test]
@@ -339,6 +347,9 @@ fn test_pymethods_from_py_with() {
         if has_gil_refs:
             assert instance.classmethod_gil_ref(arg) == 2
         assert instance.staticmethod(arg) == 2
+
+        assert 42 in instance
+        assert 73 not in instance
         "#
         );
     })

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -38,6 +38,14 @@ impl MyClass {
 
     #[setter]
     fn set_bar_bound(&self, _value: &Bound<'_, PyAny>) {}
+
+    fn __eq__(&self, #[pyo3(from_py_with = "extract_gil_ref")] _other: i32) -> bool {
+        true
+    }
+
+    fn __contains__(&self, #[pyo3(from_py_with = "extract_bound")] _value: i32) -> bool {
+        true
+    }
 }
 
 fn main() {}

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -16,6 +16,12 @@ error: use of deprecated struct `pyo3::PyCell`: `PyCell` was merged into `Bound`
 23 |     fn method_gil_ref(_slf: &PyCell<Self>) {}
    |                              ^^^^^^
 
+error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
+  --> tests/ui/deprecations.rs:42:44
+   |
+42 |     fn __eq__(&self, #[pyo3(from_py_with = "extract_gil_ref")] _other: i32) -> bool {
+   |                                            ^^^^^^^^^^^^^^^^^
+
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
   --> tests/ui/deprecations.rs:18:33
    |
@@ -47,69 +53,69 @@ error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`
    |                                       ^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:53:43
+  --> tests/ui/deprecations.rs:61:43
    |
-53 | fn pyfunction_with_module_gil_ref(module: &PyModule) -> PyResult<&str> {
+61 | fn pyfunction_with_module_gil_ref(module: &PyModule) -> PyResult<&str> {
    |                                           ^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:63:19
+  --> tests/ui/deprecations.rs:71:19
    |
-63 | fn module_gil_ref(m: &PyModule) -> PyResult<()> {
+71 | fn module_gil_ref(m: &PyModule) -> PyResult<()> {
    |                   ^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:69:57
+  --> tests/ui/deprecations.rs:77:57
    |
-69 | fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+77 | fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
    |                                                         ^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:102:27
+   --> tests/ui/deprecations.rs:110:27
     |
-102 |     #[pyo3(from_py_with = "extract_gil_ref")] _gil_ref: i32,
+110 |     #[pyo3(from_py_with = "extract_gil_ref")] _gil_ref: i32,
     |                           ^^^^^^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-   --> tests/ui/deprecations.rs:108:29
+   --> tests/ui/deprecations.rs:116:29
     |
-108 | fn pyfunction_gil_ref(_any: &PyAny) {}
+116 | fn pyfunction_gil_ref(_any: &PyAny) {}
     |                             ^
 
 error: use of deprecated method `pyo3::deprecations::OptionGilRefs::<std::option::Option<T>>::function_arg`: use `Option<&Bound<'_, T>>` instead for this function argument
-   --> tests/ui/deprecations.rs:111:36
+   --> tests/ui/deprecations.rs:119:36
     |
-111 | fn pyfunction_option_gil_ref(_any: Option<&PyAny>) {}
+119 | fn pyfunction_option_gil_ref(_any: Option<&PyAny>) {}
     |                                    ^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:118:27
+   --> tests/ui/deprecations.rs:126:27
     |
-118 |     #[pyo3(from_py_with = "PyAny::len", item("my_object"))]
+126 |     #[pyo3(from_py_with = "PyAny::len", item("my_object"))]
     |                           ^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:128:27
+   --> tests/ui/deprecations.rs:136:27
     |
-128 |     #[pyo3(from_py_with = "PyAny::len")] usize,
+136 |     #[pyo3(from_py_with = "PyAny::len")] usize,
     |                           ^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:134:31
+   --> tests/ui/deprecations.rs:142:31
     |
-134 |     Zip(#[pyo3(from_py_with = "extract_gil_ref")] i32),
+142 |     Zip(#[pyo3(from_py_with = "extract_gil_ref")] i32),
     |                               ^^^^^^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:141:27
+   --> tests/ui/deprecations.rs:149:27
     |
-141 |     #[pyo3(from_py_with = "extract_gil_ref")]
+149 |     #[pyo3(from_py_with = "extract_gil_ref")]
     |                           ^^^^^^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<pyo3::Python<'_>>::is_python`: use `wrap_pyfunction_bound!` instead
-   --> tests/ui/deprecations.rs:154:13
+   --> tests/ui/deprecations.rs:162:13
     |
-154 |     let _ = wrap_pyfunction!(double, py);
+162 |     let _ = wrap_pyfunction!(double, py);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: this error originates in the macro `wrap_pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Handle `#[pyo3(from_py_with = ...)]` attribute on dunder (`__magic__`) method arguments

Closes #4113 