### PR TITLE
Enable some Clippy lints

### DIFF
--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -1,6 +1,7 @@
 //! This crate declares only the proc macro attributes, as a crate defining proc macro attributes
 //! must not contain any other public items.
 
+#![deny(clippy::all, clippy::pedantic, clippy::nursery)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
@@ -204,7 +205,7 @@ fn pymethods_impl(
     .into()
 }
 
-fn methods_type() -> PyClassMethodsType {
+const fn methods_type() -> PyClassMethodsType {
     if cfg!(feature = "multiple-pymethods") {
         PyClassMethodsType::Inventory
     } else {
@@ -218,6 +219,6 @@ trait UnwrapOrCompileError {
 
 impl UnwrapOrCompileError for syn::Result<TokenStream2> {
     fn unwrap_or_compile_error(self) -> TokenStream2 {
-        self.unwrap_or_else(|e| e.into_compile_error())
+        self.unwrap_or_else(syn::Error::into_compile_error)
     }
 }

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1194,7 +1194,7 @@ mod tests {
                         let py_time = CatchWarnings::enter(py, |_| Ok(time.to_object(py))).unwrap();
                         let roundtripped: NaiveTime = py_time.extract(py).expect("Round trip");
                         // Leap seconds are not roundtripped
-                        let expected_roundtrip_time = micro.checked_sub(1_000_000).map(|micro| NaiveTime::from_hms_micro_opt(hour, min, sec, micro).unwrap()).unwrap_or(time);
+                        let expected_roundtrip_time = micro.checked_sub(1_000_000).map_or(time, |micro| NaiveTime::from_hms_micro_opt(hour, min, sec, micro).unwrap());
                         assert_eq!(expected_roundtrip_time, roundtripped);
                     }
                 })
@@ -1241,7 +1241,7 @@ mod tests {
                         let py_dt = CatchWarnings::enter(py, |_| Ok(dt.into_py(py))).unwrap();
                         let roundtripped: DateTime<Utc> = py_dt.extract(py).expect("Round trip");
                         // Leap seconds are not roundtripped
-                        let expected_roundtrip_time = micro.checked_sub(1_000_000).map(|micro| NaiveTime::from_hms_micro_opt(hour, min, sec, micro).unwrap()).unwrap_or(time);
+                        let expected_roundtrip_time = micro.checked_sub(1_000_000).map_or(time, |micro| NaiveTime::from_hms_micro_opt(hour, min, sec, micro).unwrap());
                         let expected_roundtrip_dt: DateTime<Utc> = NaiveDateTime::new(date, expected_roundtrip_time).and_utc();
                         assert_eq!(expected_roundtrip_dt, roundtripped);
                     }
@@ -1269,7 +1269,7 @@ mod tests {
                         let py_dt = CatchWarnings::enter(py, |_| Ok(dt.into_py(py))).unwrap();
                         let roundtripped: DateTime<FixedOffset> = py_dt.extract(py).expect("Round trip");
                         // Leap seconds are not roundtripped
-                        let expected_roundtrip_time = micro.checked_sub(1_000_000).map(|micro| NaiveTime::from_hms_micro_opt(hour, min, sec, micro).unwrap()).unwrap_or(time);
+                        let expected_roundtrip_time = micro.checked_sub(1_000_000).map_or(time, |micro| NaiveTime::from_hms_micro_opt(hour, min, sec, micro).unwrap());
                         let expected_roundtrip_dt: DateTime<FixedOffset> = NaiveDateTime::new(date, expected_roundtrip_time).and_local_timezone(offset).unwrap();
                         assert_eq!(expected_roundtrip_dt, roundtripped);
                     }

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -428,9 +428,10 @@ impl PyErr {
             let msg = pvalue
                 .as_ref()
                 .and_then(|obj| obj.bind(py).str().ok())
-                .map(|py_str| py_str.to_string_lossy().into())
-                .unwrap_or_else(|| String::from("Unwrapped panic from Python code"));
-
+                .map_or_else(
+                    || String::from("Unwrapped panic from Python code"),
+                    |py_str| py_str.to_string_lossy().into(),
+                );
             let state = PyErrState::FfiTuple {
                 ptype,
                 pvalue,
@@ -451,10 +452,10 @@ impl PyErr {
         let state = PyErrStateNormalized::take(py)?;
         let pvalue = state.pvalue.bind(py);
         if pvalue.get_type().as_ptr() == PanicException::type_object_raw(py).cast() {
-            let msg: String = pvalue
-                .str()
-                .map(|py_str| py_str.to_string_lossy().into())
-                .unwrap_or_else(|_| String::from("Unwrapped panic from Python code"));
+            let msg: String = pvalue.str().map_or_else(
+                |_| String::from("Unwrapped panic from Python code"),
+                |py_str| py_str.to_string_lossy().into(),
+            );
             Self::print_panic_and_unwind(py, PyErrState::Normalized(state), msg)
         }
 

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -32,7 +32,7 @@ where
     type Holder = ();
 
     #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, _: &'a mut ()) -> PyResult<Self> {
+    fn extract(obj: &'a Bound<'py, PyAny>, (): &'a mut ()) -> PyResult<Self> {
         obj.extract()
     }
 }
@@ -50,7 +50,7 @@ impl<'a, 'py, T: 'py + PyTypeCheck> PyFunctionArgument<'a, 'py> for Option<&'a B
     type Holder = ();
 
     #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, _: &'a mut ()) -> PyResult<Self> {
+    fn extract(obj: &'a Bound<'py, PyAny>, (): &'a mut ()) -> PyResult<Self> {
         if obj.is_none() {
             Ok(None)
         } else {

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -37,10 +37,7 @@ where
     }
 }
 
-impl<'a, 'py, T: 'py> PyFunctionArgument<'a, 'py> for &'a Bound<'py, T>
-where
-    T: PyTypeCheck,
-{
+impl<'a, 'py, T: 'py + PyTypeCheck> PyFunctionArgument<'a, 'py> for &'a Bound<'py, T> {
     type Holder = Option<()>;
 
     #[inline]
@@ -49,10 +46,7 @@ where
     }
 }
 
-impl<'a, 'py, T: 'py> PyFunctionArgument<'a, 'py> for Option<&'a Bound<'py, T>>
-where
-    T: PyTypeCheck,
-{
+impl<'a, 'py, T: 'py + PyTypeCheck> PyFunctionArgument<'a, 'py> for Option<&'a Bound<'py, T>> {
     type Holder = ();
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
     )
 )))]
 #![deny(
+    clippy::implicit_clone,
     clippy::inefficient_to_string,
     clippy::map_unwrap_or,
     clippy::type_repetition_in_bounds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,11 @@
         non_local_definitions,
     )
 )))]
-#![deny(clippy::inefficient_to_string, clippy::type_repetition_in_bounds)]
+#![deny(
+    clippy::inefficient_to_string,
+    clippy::map_unwrap_or,
+    clippy::type_repetition_in_bounds
+)]
 
 //! Rust bindings to the Python interpreter.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
     clippy::implicit_clone,
     clippy::inefficient_to_string,
     clippy::map_unwrap_or,
+    clippy::redundant_else,
     clippy::type_repetition_in_bounds
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
     )
 )))]
 #![deny(
+    clippy::ignored_unit_patterns,
     clippy::implicit_clone,
     clippy::inefficient_to_string,
     clippy::map_unwrap_or,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
         non_local_definitions,
     )
 )))]
-#![deny(clippy::inefficient_to_string)]
+#![deny(clippy::inefficient_to_string, clippy::type_repetition_in_bounds)]
 
 //! Rust bindings to the Python interpreter.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
         non_local_definitions,
     )
 )))]
+#![deny(clippy::inefficient_to_string)]
 
 //! Rust bindings to the Python interpreter.
 //!

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -688,10 +688,8 @@ impl<'py> Python<'py> {
                 return Err(PyErr::fetch(self));
             }
 
-            let globals = globals
-                .map(|dict| dict.as_ptr())
-                .unwrap_or_else(|| ffi::PyModule_GetDict(mptr));
-            let locals = locals.map(|dict| dict.as_ptr()).unwrap_or(globals);
+            let globals = globals.map_or_else(|| ffi::PyModule_GetDict(mptr), |dict| dict.as_ptr());
+            let locals = locals.map_or(globals, |dict| dict.as_ptr());
 
             // If `globals` don't provide `__builtins__`, most of the code will fail if Python
             // version is <3.10. That's probably not what user intended, so insert `__builtins__`

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -23,7 +23,7 @@ impl PanicException {
     pub(crate) fn from_panic_payload(payload: Box<dyn Any + Send + 'static>) -> PyErr {
         if let Some(string) = payload.downcast_ref::<String>() {
             Self::new_err((string.clone(),))
-        } else if let Some(s) = payload.downcast_ref::<&str>() {
+        } else if let Ok(s) = payload.downcast::<&str>() {
             Self::new_err((s.to_string(),))
         } else {
             Self::new_err(("panic from Rust code",))

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -152,7 +152,7 @@ impl From<Bound<'_, PyBytes>> for PyBackedBytes {
         let b = py_bytes.as_bytes();
         let data = NonNull::from(b);
         Self {
-            storage: PyBackedBytesStorage::Python(py_bytes.to_owned().unbind()),
+            storage: PyBackedBytesStorage::Python(py_bytes.clone().unbind()),
             data,
         }
     }

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -404,7 +404,7 @@ impl<T: PyClass> PyCell<T> {
         self.0
             .borrow_checker()
             .try_borrow_unguarded()
-            .map(|_: ()| &*self.0.get_ptr())
+            .map(|()| &*self.0.get_ptr())
     }
 
     /// Provide an immutable borrow of the value `T` without acquiring the GIL.
@@ -662,7 +662,7 @@ impl<'py, T: PyClass> PyRef<'py, T> {
         cell.ensure_threadsafe();
         cell.borrow_checker()
             .try_borrow()
-            .map(|_| Self { inner: obj.clone() })
+            .map(|()| Self { inner: obj.clone() })
     }
 
     pub(crate) fn try_borrow_threadsafe(obj: &Bound<'py, T>) -> Result<Self, PyBorrowError> {
@@ -670,7 +670,7 @@ impl<'py, T: PyClass> PyRef<'py, T> {
         cell.check_threadsafe()?;
         cell.borrow_checker()
             .try_borrow()
-            .map(|_| Self { inner: obj.clone() })
+            .map(|()| Self { inner: obj.clone() })
     }
 }
 
@@ -859,7 +859,7 @@ impl<'py, T: PyClass<Frozen = False>> PyRefMut<'py, T> {
         cell.ensure_threadsafe();
         cell.borrow_checker()
             .try_borrow_mut()
-            .map(|_| Self { inner: obj.clone() })
+            .map(|()| Self { inner: obj.clone() })
     }
 }
 

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -95,7 +95,7 @@ impl PyByteArray {
             std::ptr::write_bytes(buffer, 0u8, len);
             // (Further) Initialise the bytearray in init
             // If init returns an Err, pypybytearray will automatically deallocate the buffer
-            init(std::slice::from_raw_parts_mut(buffer, len)).map(|_| pybytearray)
+            init(std::slice::from_raw_parts_mut(buffer, len)).map(|()| pybytearray)
         }
     }
 

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -91,7 +91,7 @@ impl PyBytes {
             std::ptr::write_bytes(buffer, 0u8, len);
             // (Further) Initialise the bytestring in init
             // If init returns an Err, pypybytearray will automatically deallocate the buffer
-            init(std::slice::from_raw_parts_mut(buffer, len)).map(|_| pybytes)
+            init(std::slice::from_raw_parts_mut(buffer, len)).map(|()| pybytes)
         }
     }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -691,14 +691,14 @@ fn type_output() -> TypeInfo {
         fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self>
         {
             let t = obj.downcast::<PyTuple>()?;
-            if t.len() == $length {
+            if t.len() != $length {
+                Err(wrong_tuple_length(t, $length))
+            } else {
                 #[cfg(any(Py_LIMITED_API, PyPy, GraalPy))]
                 return Ok(($(t.get_borrowed_item($n)?.extract::<$T>()?,)+));
 
                 #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
                 unsafe {return Ok(($(t.get_borrowed_item_unchecked($n).extract::<$T>()?,)+));}
-            } else {
-                Err(wrong_tuple_length(t, $length))
             }
         }
 


### PR DESCRIPTION
Hello! This PR enables some Clippy lints and fixes all the warnings. There is one lint enabled per commit (except for the `pyo3-macros`) one, so I would suggest reviewing the commits one at a time. The changes all seem reasonable, and hopefully not too intrusive. It doesn't do `pyo3-macros-backend`, but I can add that too if that's wanted.