### PR TITLE
feature gate deprecated APIs for `PyBytes` and `PyPyByteArray`

### DIFF
--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -15,12 +15,10 @@ pyobject_native_type_core!(PyByteArray, pyobject_native_static_type_object!(ffi:
 
 impl PyByteArray {
     /// Deprecated form of [`PyByteArray::new_bound`]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyByteArray::new` will be replaced by `PyByteArray::new_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyByteArray::new` will be replaced by `PyByteArray::new_bound` in a future PyO3 version"
     )]
     pub fn new<'py>(py: Python<'py>, src: &[u8]) -> &'py PyByteArray {
         Self::new_bound(py, src).into_gil_ref()
@@ -40,12 +38,10 @@ impl PyByteArray {
     }
 
     /// Deprecated form of [`PyByteArray::new_bound_with`]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyByteArray::new_with` will be replaced by `PyByteArray::new_bound_with` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyByteArray::new_with` will be replaced by `PyByteArray::new_bound_with` in a future PyO3 version"
     )]
     pub fn new_with<F>(py: Python<'_>, len: usize, init: F) -> PyResult<&PyByteArray>
     where
@@ -104,12 +100,10 @@ impl PyByteArray {
     }
 
     /// Deprecated form of [`PyByteArray::from_bound`]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyByteArray::from` will be replaced by `PyByteArray::from_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyByteArray::from` will be replaced by `PyByteArray::from_bound` in a future PyO3 version"
     )]
     pub fn from(src: &PyAny) -> PyResult<&PyByteArray> {
         PyByteArray::from_bound(&src.as_borrowed()).map(Bound::into_gil_ref)

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -17,12 +17,10 @@ pyobject_native_type_core!(PyBytes, pyobject_native_static_type_object!(ffi::PyB
 
 impl PyBytes {
     /// Deprecated form of [`PyBytes::new_bound`].
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyBytes::new` will be replaced by `PyBytes::new_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyBytes::new` will be replaced by `PyBytes::new_bound` in a future PyO3 version"
     )]
     pub fn new<'p>(py: Python<'p>, s: &[u8]) -> &'p PyBytes {
         Self::new_bound(py, s).into_gil_ref()
@@ -43,12 +41,10 @@ impl PyBytes {
     }
 
     /// Deprecated form of [`PyBytes::new_bound_with`].
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyBytes::new_with` will be replaced by `PyBytes::new_bound_with` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyBytes::new_with` will be replaced by `PyBytes::new_bound_with` in a future PyO3 version"
     )]
     pub fn new_with<F>(py: Python<'_>, len: usize, init: F) -> PyResult<&PyBytes>
     where
@@ -103,12 +99,10 @@ impl PyBytes {
     ///
     /// # Safety
     /// See [`PyBytes::bound_from_ptr`].
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyBytes::from_ptr` will be replaced by `PyBytes::bound_from_ptr` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyBytes::from_ptr` will be replaced by `PyBytes::bound_from_ptr` in a future PyO3 version"
     )]
     pub unsafe fn from_ptr(py: Python<'_>, ptr: *const u8, len: usize) -> &PyBytes {
         Self::bound_from_ptr(py, ptr, len).into_gil_ref()


### PR DESCRIPTION
Part of #3960

Move deprecated `PyBytes` and `PyByteArray` APIs behind `gil-refs` features gate.