### PR TITLE
feature gate deprecated APIs for `PyEllipsis`, `PyNone` and `PyNotImplemented`

### DIFF
--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -12,12 +12,10 @@ pyobject_native_type_extract!(PyEllipsis);
 
 impl PyEllipsis {
     /// Returns the `Ellipsis` object.
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyEllipsis::get` will be replaced by `PyEllipsis::get_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyEllipsis::get` will be replaced by `PyEllipsis::get_bound` in a future PyO3 version"
     )]
     #[inline]
     pub fn get(py: Python<'_>) -> &PyEllipsis {

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -14,12 +14,10 @@ pyobject_native_type_extract!(PyNone);
 impl PyNone {
     /// Returns the `None` object.
     /// Deprecated form of [`PyNone::get_bound`]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyNone::get` will be replaced by `PyNone::get_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyNone::get` will be replaced by `PyNone::get_bound` in a future PyO3 version"
     )]
     #[inline]
     pub fn get(py: Python<'_>) -> &PyNone {

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -12,12 +12,10 @@ pyobject_native_type_extract!(PyNotImplemented);
 
 impl PyNotImplemented {
     /// Returns the `NotImplemented` object.
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyNotImplemented::get` will be replaced by `PyNotImplemented::get_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyNotImplemented::get` will be replaced by `PyNotImplemented::get_bound` in a future PyO3 version"
     )]
     #[inline]
     pub fn get(py: Python<'_>) -> &PyNotImplemented {


### PR DESCRIPTION
Part of #3960

Move deprecated `PyEllipsis`, `PyNone` and `PyNotImplemented` APIs behind `gil-refs` features gate.