### PR TITLE
feature gate deprecated APIs for `PyType`, `PyTypeInfo` and `PySuper`

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -60,7 +60,7 @@ To migrate, switch all type casts to use `obj.downcast()` instead of `try_from(o
 
 Before:
 
-```rust
+```rust,ignore
 # #![allow(deprecated)]
 # use pyo3::prelude::*;
 # use pyo3::types::{PyInt, PyList};

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -3,7 +3,6 @@ use crate::err::{self, PyDowncastError, PyResult};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::pyclass::boolean_struct::False;
-use crate::type_object::PyTypeInfo;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
 use crate::{
@@ -435,9 +434,11 @@ pub trait PyTryInto<T>: Sized {
     fn try_into_exact(&self) -> Result<&T, PyDowncastError<'_>>;
 }
 
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 mod implementations {
     use super::*;
+    use crate::type_object::PyTypeInfo;
 
     // TryFrom implies TryInto
     impl<U> PyTryInto<U> for PyAny

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2310,8 +2310,6 @@ a = A()
 
     #[cfg(feature = "macros")]
     mod using_macros {
-        use crate::PyCell;
-
         use super::*;
 
         #[crate::pyclass(crate = "crate")]
@@ -2371,9 +2369,10 @@ a = A()
         }
 
         #[test]
+        #[cfg(feature = "gil-refs")]
         #[allow(deprecated)]
         fn cell_tryfrom() {
-            use crate::PyTryInto;
+            use crate::{PyCell, PyTryInto};
             // More detailed tests of the underlying semantics in pycell.rs
             Python::with_gil(|py| {
                 let instance: &PyAny = Py::new(py, SomeClass(0)).unwrap().into_ref(py);

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -66,12 +66,10 @@ pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
 
     /// Returns the safe abstraction over the type object.
     #[inline]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyTypeInfo::type_object` will be replaced by `PyTypeInfo::type_object_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyTypeInfo::type_object` will be replaced by `PyTypeInfo::type_object_bound` in a future PyO3 version"
     )]
     fn type_object(py: Python<'_>) -> &PyType {
         // This isn't implemented in terms of `type_object_bound` because this just borrowed the
@@ -101,12 +99,10 @@ pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
 
     /// Checks if `object` is an instance of this type or a subclass of this type.
     #[inline]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyTypeInfo::is_type_of` will be replaced by `PyTypeInfo::is_type_of_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyTypeInfo::is_type_of` will be replaced by `PyTypeInfo::is_type_of_bound` in a future PyO3 version"
     )]
     fn is_type_of(object: &PyAny) -> bool {
         Self::is_type_of_bound(&object.as_borrowed())
@@ -120,12 +116,10 @@ pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
 
     /// Checks if `object` is an instance of this type.
     #[inline]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyTypeInfo::is_exact_type_of` will be replaced by `PyTypeInfo::is_exact_type_of_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyTypeInfo::is_exact_type_of` will be replaced by `PyTypeInfo::is_exact_type_of_bound` in a future PyO3 version"
     )]
     fn is_exact_type_of(object: &PyAny) -> bool {
         Self::is_exact_type_of_bound(&object.as_borrowed())

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -2726,9 +2726,9 @@ class SimpleClass:
     #[test]
     fn test_is_callable() {
         Python::with_gil(|py| {
-            assert!(PyList::type_object(py).is_callable());
+            assert!(PyList::type_object_bound(py).is_callable());
 
-            let not_callable = 5.to_object(py).into_ref(py);
+            let not_callable = 5.to_object(py).into_bound(py);
             assert!(!not_callable.is_callable());
         });
     }

--- a/src/types/pysuper.rs
+++ b/src/types/pysuper.rs
@@ -1,7 +1,7 @@
 use crate::instance::Bound;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
-use crate::{ffi, PyNativeType, PyTypeInfo};
+use crate::{ffi, PyTypeInfo};
 use crate::{PyAny, PyResult};
 
 /// Represents a Python `super` object.
@@ -17,14 +17,13 @@ pyobject_native_type_core!(
 
 impl PySuper {
     /// Deprecated form of `PySuper::new_bound`.
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PySuper::new` will be replaced by `PySuper::new_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PySuper::new` will be replaced by `PySuper::new_bound` in a future PyO3 version"
     )]
     pub fn new<'py>(ty: &'py PyType, obj: &'py PyAny) -> PyResult<&'py PySuper> {
+        use crate::PyNativeType;
         Self::new_bound(&ty.as_borrowed(), &obj.as_borrowed()).map(Bound::into_gil_ref)
     }
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -15,12 +15,10 @@ pyobject_native_type_core!(PyType, pyobject_native_static_type_object!(ffi::PyTy
 impl PyType {
     /// Deprecated form of [`PyType::new_bound`].
     #[inline]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyType::new` will be replaced by `PyType::new_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyType::new` will be replaced by `PyType::new_bound` in a future PyO3 version"
     )]
     pub fn new<T: PyTypeInfo>(py: Python<'_>) -> &PyType {
         T::type_object_bound(py).into_gil_ref()
@@ -44,12 +42,10 @@ impl PyType {
     ///
     /// - The pointer must a valid non-null reference to a `PyTypeObject`.
     #[inline]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "Use `PyType::from_borrowed_type_ptr` instead"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "Use `PyType::from_borrowed_type_ptr` instead"
     )]
     pub unsafe fn from_type_ptr(py: Python<'_>, p: *mut ffi::PyTypeObject) -> &PyType {
         Self::from_borrowed_type_ptr(py, p).into_gil_ref()


### PR DESCRIPTION
Part of #3960

Move deprecated `PyType`, `PyTypeInfo` and `PySuper` behind `gil-refs` features gate.
