### PR TITLE
feature gate deprecated APIs for `Py`

### DIFF
--- a/guide/src/memory.md
+++ b/guide/src/memory.md
@@ -177,9 +177,11 @@ What happens to the memory when the last `Py<PyAny>` is dropped and its
 reference count reaches zero?  It depends whether or not we are holding the GIL.
 
 ```rust
+# #![allow(unused_imports)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
+# #[cfg(feature = "gil-refs")]
 Python::with_gil(|py| -> PyResult<()> {
     #[allow(deprecated)] // py.eval() is part of the GIL Refs API
     let hello: Py<PyString> = py.eval("\"Hello World!\"", None, None)?.extract()?;
@@ -203,9 +205,12 @@ This example wasn't very interesting.  We could have just used a GIL-bound
 we are *not* holding the GIL?
 
 ```rust
+# #![allow(unused_imports)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
+# #[cfg(feature = "gil-refs")]
+# {
 let hello: Py<PyString> = Python::with_gil(|py| {
     #[allow(deprecated)] // py.eval() is part of the GIL Refs API
     py.eval("\"Hello World!\"", None, None)?.extract()
@@ -224,6 +229,7 @@ Python::with_gil(|py|
     // Memory for `hello` is released here.
 # ()
 );
+# }
 # Ok(())
 # }
 ```
@@ -237,9 +243,12 @@ We can avoid the delay in releasing memory if we are careful to drop the
 `Py<Any>` while the GIL is held.
 
 ```rust
+# #![allow(unused_imports)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
+# #[cfg(feature = "gil-refs")]
+# {
 #[allow(deprecated)] // py.eval() is part of the GIL Refs API
 let hello: Py<PyString> =
     Python::with_gil(|py| py.eval("\"Hello World!\"", None, None)?.extract())?;
@@ -252,6 +261,7 @@ Python::with_gil(|py| {
     }
     drop(hello); // Memory released here.
 });
+# }
 # Ok(())
 # }
 ```
@@ -263,9 +273,12 @@ that rather than being released immediately, the memory will not be released
 until the GIL is dropped.
 
 ```rust
+# #![allow(unused_imports)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
+# #[cfg(feature = "gil-refs")]
+# {
 #[allow(deprecated)] // py.eval() is part of the GIL Refs API
 let hello: Py<PyString> =
     Python::with_gil(|py| py.eval("\"Hello World!\"", None, None)?.extract())?;
@@ -280,6 +293,7 @@ Python::with_gil(|py| {
     // Do more stuff...
     // Memory released here at end of `with_gil()` closure.
 });
+# }
 # Ok(())
 # }
 ```

--- a/guide/src/python-from-rust/function-calls.md
+++ b/guide/src/python-from-rust/function-calls.md
@@ -107,7 +107,7 @@ fn main() -> PyResult<()> {
 
 <div class="warning">
 
-During PyO3's [migration from "GIL Refs" to the `Bound<T>` smart pointer](../migration.md#migrating-from-the-gil-refs-api-to-boundt), [`Py<T>::call`]({{#PYO3_DOCS_URL}}/pyo3/struct.Py.html#method.call) is temporarily named `call_bound` (and `call_method` is temporarily `call_method_bound`).
+During PyO3's [migration from "GIL Refs" to the `Bound<T>` smart pointer](../migration.md#migrating-from-the-gil-refs-api-to-boundt), `Py<T>::call` is temporarily named [`Py<T>::call_bound`]({{#PYO3_DOCS_URL}}/pyo3/struct.Py.html#method.call_bound) (and `call_method` is temporarily `call_method_bound`).
 
 (This temporary naming is only the case for the `Py<T>` smart pointer. The methods on the `&PyAny` GIL Ref such as `call` have not been given replacements, and the methods on the `Bound<PyAny>` smart pointer such as [`Bound<PyAny>::call`]({{#PYO3_DOCS_URL}}/pyo3/types/trait.PyAnyMethods.html#tymethod.call) already use follow the newest API conventions.)
 

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -353,8 +353,10 @@ let _: Py<PyList> = obj.extract()?;
 For a `&PyAny` object reference `any` where the underlying object is a `#[pyclass]`:
 
 ```rust
+# #![allow(unused_imports)]
 # use pyo3::prelude::*;
 # #[pyclass] #[derive(Clone)] struct MyClass { }
+# #[cfg(feature = "gil-refs")]
 # Python::with_gil(|py| -> PyResult<()> {
 #[allow(deprecated)] // into_ref is part of the deprecated GIL Refs API
 let obj: &PyAny = Py::new(py, MyClass {})?.into_ref(py);

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -64,6 +64,7 @@ impl<'a> PyDowncastError<'a> {
 
     /// Compatibility API to convert the Bound variant `DowncastError` into the
     /// gil-ref variant
+    #[cfg(feature = "gil-refs")]
     pub(crate) fn from_downcast_err(DowncastError { from, to }: DowncastError<'a, 'a>) -> Self {
         #[allow(deprecated)]
         let from = unsafe { from.py().from_borrowed_ptr(from.as_ptr()) };

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -2705,17 +2705,16 @@ class SimpleClass:
     }
 
     #[test]
-    #[allow(deprecated)]
     fn test_is_ellipsis() {
         Python::with_gil(|py| {
             let v = py
-                .eval("...", None, None)
+                .eval_bound("...", None, None)
                 .map_err(|e| e.display(py))
                 .unwrap();
 
             assert!(v.is_ellipsis());
 
-            let not_ellipsis = 5.to_object(py).into_ref(py);
+            let not_ellipsis = 5.to_object(py).into_bound(py);
             assert!(!not_ellipsis.is_ellipsis());
         });
     }

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -817,8 +817,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(not(any(PyPy, GraalPy)))]
-    use crate::exceptions;
     use crate::types::PyTuple;
     use std::collections::{BTreeMap, HashMap};
 
@@ -948,7 +946,7 @@ mod tests {
 
     #[test]
     #[allow(deprecated)]
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(all(not(any(PyPy, GraalPy)), feature = "gil-refs"))]
     fn test_get_item_with_error() {
         Python::with_gil(|py| {
             let mut v = HashMap::new();
@@ -967,7 +965,7 @@ mod tests {
             assert!(dict
                 .get_item_with_error(dict)
                 .unwrap_err()
-                .is_instance_of::<exceptions::PyTypeError>(py));
+                .is_instance_of::<crate::exceptions::PyTypeError>(py));
         });
     }
 


### PR DESCRIPTION
Part of #3960

Move deprecated `Py` APIs behind `gil-refs` features gate.