### PR TITLE
feature gate deprecated APIs for `PyFloat` and `PyComplex`

### DIFF
--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -104,12 +104,10 @@ use std::os::raw::c_double;
 
 impl PyComplex {
     /// Deprecated form of [`PyComplex::from_complex_bound`]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyComplex::from_complex` will be replaced by `PyComplex::from_complex_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyComplex::from_complex` will be replaced by `PyComplex::from_complex_bound` in a future PyO3 version"
     )]
     pub fn from_complex<F: Into<c_double>>(py: Python<'_>, complex: Complex<F>) -> &PyComplex {
         Self::from_complex_bound(py, complex).into_gil_ref()

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -20,12 +20,10 @@ pyobject_native_type!(
 
 impl PyComplex {
     /// Deprecated form of [`PyComplex::from_doubles_bound`]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyComplex::from_doubles` will be replaced by `PyComplex::from_doubles_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyComplex::from_doubles` will be replaced by `PyComplex::from_doubles_bound` in a future PyO3 version"
     )]
     pub fn from_doubles(py: Python<'_>, real: c_double, imag: c_double) -> &PyComplex {
         Self::from_doubles_bound(py, real, imag).into_gil_ref()

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -26,12 +26,10 @@ pyobject_native_type!(
 impl PyFloat {
     /// Deprecated form of [`PyFloat::new_bound`].
     #[inline]
-    #[cfg_attr(
-        not(feature = "gil-refs"),
-        deprecated(
-            since = "0.21.0",
-            note = "`PyFloat::new` will be replaced by `PyFloat::new_bound` in a future PyO3 version"
-        )
+    #[cfg(feature = "gil-refs")]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyFloat::new` will be replaced by `PyFloat::new_bound` in a future PyO3 version"
     )]
     pub fn new(py: Python<'_>, val: f64) -> &'_ Self {
         Self::new_bound(py, val).into_gil_ref()
@@ -154,9 +152,11 @@ impl<'py> FromPyObject<'py> for f32 {
 }
 
 #[cfg(test)]
-#[cfg_attr(not(feature = "gil-refs"), allow(deprecated))]
 mod tests {
-    use crate::{types::PyFloat, Python, ToPyObject};
+    use crate::{
+        types::{PyFloat, PyFloatMethods},
+        Python, ToPyObject,
+    };
 
     macro_rules! num_to_py_object_and_back (
         ($func_name:ident, $t1:ty, $t2:ty) => (
@@ -184,7 +184,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let v = 1.23f64;
-            let obj = PyFloat::new(py, 1.23);
+            let obj = PyFloat::new_bound(py, 1.23);
             assert_approx_eq!(v, obj.value());
         });
     }


### PR DESCRIPTION
Part of #3960

Move deprecated `PyFloat` and `PyComplex` behind `gil-refs` features gate.