### PR TITLE
store the `FnArg` ident as a `Cow` instead of a reference

### DIFF
--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1153,7 +1153,7 @@ fn complex_enum_struct_variant_new<'a>(
 
         for field in &variant.fields {
             args.push(FnArg::Regular(RegularArg {
-                name: field.ident,
+                name: Cow::Borrowed(field.ident),
                 ty: field.ty,
                 from_py_with: None,
                 default_value: None,


### PR DESCRIPTION
This allow also storing idents that were generated as part of the macro instead of only ones the were present in the source code. This is needed for example in complex enum tuple variants (#4072) to generate idents for (anonymous) tuple fields.

Closes #4156 

