### PR TITLE
allow constructor customization of complex enum variants

### DIFF
--- a/guide/pyclass-parameters.md
+++ b/guide/pyclass-parameters.md
@@ -2,6 +2,7 @@
 
 |  Parameter  |  Description |
 | :-  | :- |
+| `constructor` | This is currently only allowed on [variants of complex enums][params-constructor]. It allows customization of the generated class constructor for each variant. It uses the same syntax and supports the same options as the `signature` attribute of functions and methods. |
 | <span style="white-space: pre">`crate = "some::path"`</span>  | Path to import the `pyo3` crate, if it's not accessible at `::pyo3`. |
 | `dict` | Gives instances of this class an empty `__dict__` to store custom attributes. |
 | <span style="white-space: pre">`extends = BaseType`</span>  | Use a custom baseclass. Defaults to [`PyAny`][params-1] |
@@ -39,5 +40,6 @@ struct MyClass {}
 [params-4]: https://doc.rust-lang.org/std/rc/struct.Rc.html
 [params-5]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 [params-6]: https://docs.python.org/3/library/weakref.html
+[params-constructor]: https://pyo3.rs/latest/class.html#complex-enums
 [params-mapping]: https://pyo3.rs/latest/class/protocols.html#mapping--sequence-types
 [params-sequence]: https://pyo3.rs/latest/class/protocols.html#mapping--sequence-types

--- a/newsfragments/4158.added.md
+++ b/newsfragments/4158.added.md
@@ -1,0 +1,1 @@
+Added `#[pyo3(constructor = (...))]` to customize the generated constructors for complex enum variants

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -12,6 +12,7 @@ pub mod kw {
     syn::custom_keyword!(annotation);
     syn::custom_keyword!(attribute);
     syn::custom_keyword!(cancel_handle);
+    syn::custom_keyword!(constructor);
     syn::custom_keyword!(dict);
     syn::custom_keyword!(extends);
     syn::custom_keyword!(freelist);

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -18,7 +18,7 @@ use syn::{
 
 mod signature;
 
-pub use self::signature::{FunctionSignature, SignatureAttribute};
+pub use self::signature::{ConstructorAttribute, FunctionSignature, SignatureAttribute};
 
 #[derive(Clone, Debug)]
 pub struct PyFunctionArgPyO3Attributes {

--- a/pyo3-macros-backend/src/pyfunction/signature.rs
+++ b/pyo3-macros-backend/src/pyfunction/signature.rs
@@ -195,6 +195,16 @@ impl ToTokens for SignatureItemPosargsSep {
 }
 
 pub type SignatureAttribute = KeywordAttribute<kw::signature, Signature>;
+pub type ConstructorAttribute = KeywordAttribute<kw::constructor, Signature>;
+
+impl ConstructorAttribute {
+    pub fn into_signature(self) -> SignatureAttribute {
+        SignatureAttribute {
+            kw: kw::signature(self.kw.span),
+            value: self.value,
+        }
+    }
+}
 
 #[derive(Default)]
 pub struct PythonSignature {

--- a/pytests/src/enums.rs
+++ b/pytests/src/enums.rs
@@ -39,11 +39,26 @@ pub fn do_simple_stuff(thing: &SimpleEnum) -> SimpleEnum {
 
 #[pyclass]
 pub enum ComplexEnum {
-    Int { i: i32 },
-    Float { f: f64 },
-    Str { s: String },
+    Int {
+        i: i32,
+    },
+    Float {
+        f: f64,
+    },
+    Str {
+        s: String,
+    },
     EmptyStruct {},
-    MultiFieldStruct { a: i32, b: f64, c: bool },
+    MultiFieldStruct {
+        a: i32,
+        b: f64,
+        c: bool,
+    },
+    #[pyo3(signature = (a = 42, b = None))]
+    VariantWithDefault {
+        a: i32,
+        b: Option<String>,
+    },
 }
 
 #[pyfunction]
@@ -57,6 +72,10 @@ pub fn do_complex_stuff(thing: &ComplexEnum) -> ComplexEnum {
             a: *a,
             b: *b,
             c: *c,
+        },
+        ComplexEnum::VariantWithDefault { a, b } => ComplexEnum::VariantWithDefault {
+            a: 2 * a,
+            b: b.as_ref().map(|s| s.to_uppercase()),
         },
     }
 }

--- a/pytests/src/enums.rs
+++ b/pytests/src/enums.rs
@@ -54,7 +54,7 @@ pub enum ComplexEnum {
         b: f64,
         c: bool,
     },
-    #[pyo3(signature = (a = 42, b = None))]
+    #[pyo3(constructor = (a = 42, b = None))]
     VariantWithDefault {
         a: i32,
         b: Option<String>,

--- a/pytests/tests/test_enums.py
+++ b/pytests/tests/test_enums.py
@@ -18,6 +18,12 @@ def test_complex_enum_variant_constructors():
     multi_field_struct_variant = enums.ComplexEnum.MultiFieldStruct(42, 3.14, True)
     assert isinstance(multi_field_struct_variant, enums.ComplexEnum.MultiFieldStruct)
 
+    variant_with_default_1 = enums.ComplexEnum.VariantWithDefault()
+    assert isinstance(variant_with_default_1, enums.ComplexEnum.VariantWithDefault)
+
+    variant_with_default_2 = enums.ComplexEnum.VariantWithDefault(25, "Hello")
+    assert isinstance(variant_with_default_2, enums.ComplexEnum.VariantWithDefault)
+
 
 @pytest.mark.parametrize(
     "variant",
@@ -27,6 +33,7 @@ def test_complex_enum_variant_constructors():
         enums.ComplexEnum.Str("hello"),
         enums.ComplexEnum.EmptyStruct(),
         enums.ComplexEnum.MultiFieldStruct(42, 3.14, True),
+        enums.ComplexEnum.VariantWithDefault(),
     ],
 )
 def test_complex_enum_variant_subclasses(variant: enums.ComplexEnum):
@@ -48,6 +55,10 @@ def test_complex_enum_field_getters():
     assert multi_field_struct_variant.b == 3.14
     assert multi_field_struct_variant.c is True
 
+    variant_with_default = enums.ComplexEnum.VariantWithDefault()
+    assert variant_with_default.a == 42
+    assert variant_with_default.b is None
+
 
 @pytest.mark.parametrize(
     "variant",
@@ -57,6 +68,7 @@ def test_complex_enum_field_getters():
         enums.ComplexEnum.Str("hello"),
         enums.ComplexEnum.EmptyStruct(),
         enums.ComplexEnum.MultiFieldStruct(42, 3.14, True),
+        enums.ComplexEnum.VariantWithDefault(),
     ],
 )
 def test_complex_enum_desugared_match(variant: enums.ComplexEnum):
@@ -78,6 +90,11 @@ def test_complex_enum_desugared_match(variant: enums.ComplexEnum):
         assert x == 42
         assert y == 3.14
         assert z is True
+    elif isinstance(variant, enums.ComplexEnum.VariantWithDefault):
+        x = variant.a
+        y = variant.b
+        assert x == 42
+        assert y is None
     else:
         assert False
 
@@ -90,6 +107,7 @@ def test_complex_enum_desugared_match(variant: enums.ComplexEnum):
         enums.ComplexEnum.Str("hello"),
         enums.ComplexEnum.EmptyStruct(),
         enums.ComplexEnum.MultiFieldStruct(42, 3.14, True),
+        enums.ComplexEnum.VariantWithDefault(b="hello"),
     ],
 )
 def test_complex_enum_pyfunction_in_out_desugared_match(variant: enums.ComplexEnum):
@@ -112,5 +130,10 @@ def test_complex_enum_pyfunction_in_out_desugared_match(variant: enums.ComplexEn
         assert x == 42
         assert y == 3.14
         assert z is True
+    elif isinstance(variant, enums.ComplexEnum.VariantWithDefault):
+        x = variant.a
+        y = variant.b
+        assert x == 84
+        assert y == "HELLO"
     else:
         assert False

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -29,7 +29,7 @@ enum NoTupleVariants {
 
 #[pyclass]
 enum SimpleNoSignature {
-    #[pyo3(signature = (a, b))]
+    #[pyo3(constructor = (a, b))]
     A,
     B,
 }

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -27,4 +27,11 @@ enum NoTupleVariants {
     TupleVariant(i32),
 }
 
+#[pyclass]
+enum SimpleNoSignature {
+    #[pyo3(signature = (a, b))]
+    A,
+    B,
+}
+
 fn main() {}

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -32,8 +32,8 @@ error: Tuple variant `TupleVariant` is not yet supported in a complex enum
 27 |     TupleVariant(i32),
    |     ^^^^^^^^^^^^
 
-error: `signature` can't be used on a simple enum variant
+error: `constructor` can't be used on a simple enum variant
   --> tests/ui/invalid_pyclass_enum.rs:32:12
    |
-32 |     #[pyo3(signature = (a, b))]
-   |            ^^^^^^^^^
+32 |     #[pyo3(constructor = (a, b))]
+   |            ^^^^^^^^^^^

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -31,3 +31,9 @@ error: Tuple variant `TupleVariant` is not yet supported in a complex enum
    |
 27 |     TupleVariant(i32),
    |     ^^^^^^^^^^^^
+
+error: `signature` can't be used on a simple enum variant
+  --> tests/ui/invalid_pyclass_enum.rs:32:12
+   |
+32 |     #[pyo3(signature = (a, b))]
+   |            ^^^^^^^^^


### PR DESCRIPTION
This is an (experimental) idea I had to support customization of the macro generated constructors for complex enum variants.

This allow placing the the `#[pyo3(signature = ...)]` attribute on complex enum variants and applies it to the generated constructor.
This way all the normal functionality of signature customization can also be applied for these generated constructors. 

What I'm not completely sure about is whether we should reuse the `signature` name here, or whether we should have have some kind of alias like `#[pyo3(constructor = ...)]`. On one hand people are already familiar with how `signature` works, but using it on an enum variant (or anything that's not a function for that matter) is not so intuitive.

Closes #4109
