### PR TITLE
feature gate APIs using `into_gil_ref` (Part 1)

### DIFF
--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -186,11 +186,11 @@ mod tests {
         Python::with_gil(|py| {
             let array: [f32; 4] = [0.0, -16.0, 16.0, 42.0];
             let pyobject = array.to_object(py);
-            let pylist: &PyList = pyobject.extract(py).unwrap();
-            assert_eq!(pylist[0].extract::<f32>().unwrap(), 0.0);
-            assert_eq!(pylist[1].extract::<f32>().unwrap(), -16.0);
-            assert_eq!(pylist[2].extract::<f32>().unwrap(), 16.0);
-            assert_eq!(pylist[3].extract::<f32>().unwrap(), 42.0);
+            let pylist = pyobject.downcast_bound::<PyList>(py).unwrap();
+            assert_eq!(pylist.get_item(0).unwrap().extract::<f32>().unwrap(), 0.0);
+            assert_eq!(pylist.get_item(1).unwrap().extract::<f32>().unwrap(), -16.0);
+            assert_eq!(pylist.get_item(2).unwrap().extract::<f32>().unwrap(), 16.0);
+            assert_eq!(pylist.get_item(3).unwrap().extract::<f32>().unwrap(), 42.0);
         });
     }
 
@@ -213,11 +213,11 @@ mod tests {
         Python::with_gil(|py| {
             let array: [f32; 4] = [0.0, -16.0, 16.0, 42.0];
             let pyobject = array.into_py(py);
-            let pylist: &PyList = pyobject.extract(py).unwrap();
-            assert_eq!(pylist[0].extract::<f32>().unwrap(), 0.0);
-            assert_eq!(pylist[1].extract::<f32>().unwrap(), -16.0);
-            assert_eq!(pylist[2].extract::<f32>().unwrap(), 16.0);
-            assert_eq!(pylist[3].extract::<f32>().unwrap(), 42.0);
+            let pylist = pyobject.downcast_bound::<PyList>(py).unwrap();
+            assert_eq!(pylist.get_item(0).unwrap().extract::<f32>().unwrap(), 0.0);
+            assert_eq!(pylist.get_item(1).unwrap().extract::<f32>().unwrap(), -16.0);
+            assert_eq!(pylist.get_item(2).unwrap().extract::<f32>().unwrap(), 16.0);
+            assert_eq!(pylist.get_item(3).unwrap().extract::<f32>().unwrap(), 42.0);
         });
     }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -667,6 +667,7 @@ impl<'py, T> Borrowed<'py, 'py, T>
 where
     T: HasPyGilRef,
 {
+    #[cfg(feature = "gil-refs")]
     pub(crate) fn into_gil_ref(self) -> &'py T::AsRefTarget {
         // Safety: self is a borrow over `'py`.
         #[allow(deprecated)]

--- a/src/internal_tricks.rs
+++ b/src/internal_tricks.rs
@@ -46,6 +46,7 @@ pub(crate) fn get_ssize_index(index: usize) -> Py_ssize_t {
 }
 
 /// Implementations used for slice indexing PySequence, PyTuple, and PyList
+#[cfg(feature = "gil-refs")]
 macro_rules! index_impls {
     (
         $ty:ty,
@@ -154,6 +155,7 @@ macro_rules! index_impls {
 #[inline(never)]
 #[cold]
 #[track_caller]
+#[cfg(feature = "gil-refs")]
 pub(crate) fn index_len_fail(index: usize, ty_name: &str, len: usize) -> ! {
     panic!(
         "index {} out of range for {} of length {}",
@@ -164,6 +166,7 @@ pub(crate) fn index_len_fail(index: usize, ty_name: &str, len: usize) -> ! {
 #[inline(never)]
 #[cold]
 #[track_caller]
+#[cfg(feature = "gil-refs")]
 pub(crate) fn slice_start_index_len_fail(index: usize, ty_name: &str, len: usize) -> ! {
     panic!(
         "range start index {} out of range for {} of length {}",
@@ -174,6 +177,7 @@ pub(crate) fn slice_start_index_len_fail(index: usize, ty_name: &str, len: usize
 #[inline(never)]
 #[cold]
 #[track_caller]
+#[cfg(feature = "gil-refs")]
 pub(crate) fn slice_end_index_len_fail(index: usize, ty_name: &str, len: usize) -> ! {
     panic!(
         "range end index {} out of range for {} of length {}",
@@ -184,6 +188,7 @@ pub(crate) fn slice_end_index_len_fail(index: usize, ty_name: &str, len: usize) 
 #[inline(never)]
 #[cold]
 #[track_caller]
+#[cfg(feature = "gil-refs")]
 pub(crate) fn slice_index_order_fail(index: usize, end: usize) -> ! {
     panic!("slice index starts at {} but ends at {}", index, end);
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -120,8 +120,8 @@ macro_rules! py_run_impl {
 
 /// Wraps a Rust function annotated with [`#[pyfunction]`](macro@crate::pyfunction).
 ///
-/// This can be used with [`PyModule::add_function`](crate::types::PyModule::add_function) to add free
-/// functions to a [`PyModule`](crate::types::PyModule) - see its documentation for more
+/// This can be used with [`PyModule::add_function`](crate::types::PyModuleMethods::add_function) to
+/// add free functions to a [`PyModule`](crate::types::PyModule) - see its documentation for more
 /// information.
 ///
 /// During the migration from the GIL Ref API to the Bound API, the return type of this macro will
@@ -157,8 +157,9 @@ macro_rules! wrap_pyfunction {
 
 /// Wraps a Rust function annotated with [`#[pyfunction]`](macro@crate::pyfunction).
 ///
-/// This can be used with [`PyModule::add_function`](crate::types::PyModule::add_function) to add free
-/// functions to a [`PyModule`](crate::types::PyModule) - see its documentation for more information.
+/// This can be used with [`PyModule::add_function`](crate::types::PyModuleMethods::add_function) to
+/// add free functions to a [`PyModule`](crate::types::PyModule) - see its documentation for more
+/// information.
 #[macro_export]
 macro_rules! wrap_pyfunction_bound {
     ($function:path) => {
@@ -183,7 +184,7 @@ macro_rules! wrap_pyfunction_bound {
 /// Python module.
 ///
 /// Use this together with [`#[pymodule]`](crate::pymodule) and
-/// [`PyModule::add_wrapped`](crate::types::PyModule::add_wrapped).
+/// [`PyModule::add_wrapped`](crate::types::PyModuleMethods::add_wrapped).
 #[macro_export]
 macro_rules! wrap_pymodule {
     ($module:path) => {

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -114,15 +114,18 @@ mod inner {
     }
 
     impl<'py> CatchWarnings<'py> {
-        pub fn enter<R>(py: Python<'py>, f: impl FnOnce(&PyList) -> PyResult<R>) -> PyResult<R> {
+        pub fn enter<R>(
+            py: Python<'py>,
+            f: impl FnOnce(&Bound<'py, PyList>) -> PyResult<R>,
+        ) -> PyResult<R> {
             let warnings = py.import_bound("warnings")?;
             let kwargs = [("record", true)].into_py_dict_bound(py);
             let catch_warnings = warnings
                 .getattr("catch_warnings")?
                 .call((), Some(&kwargs))?;
-            let list = catch_warnings.call_method0("__enter__")?.extract()?;
+            let list = catch_warnings.call_method0("__enter__")?.downcast_into()?;
             let _guard = Self { catch_warnings };
-            f(list)
+            f(&list)
         }
     }
 
@@ -139,6 +142,7 @@ mod inner {
     macro_rules! assert_warnings {
         ($py:expr, $body:expr, [$(($category:ty, $message:literal)),+] $(,)? ) => {{
             $crate::tests::common::CatchWarnings::enter($py, |w| {
+                use $crate::types::{PyListMethods, PyStringMethods};
                 $body;
                 let expected_warnings = [$((<$category as $crate::type_object::PyTypeInfo>::type_object_bound($py), $message)),+];
                 assert_eq!(w.len(), expected_warnings.len());

--- a/src/tests/hygiene/pymodule.rs
+++ b/src/tests/hygiene/pymodule.rs
@@ -14,6 +14,7 @@ fn foo(_py: crate::Python<'_>, _m: &crate::types::PyModule) -> crate::PyResult<(
     ::std::result::Result::Ok(())
 }
 
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 #[crate::pymodule]
 #[pyo3(crate = "crate")]

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -491,6 +491,7 @@ impl<'a> Borrowed<'a, '_, PyByteArray> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<'py> TryFrom<&'py PyAny> for &'py PyByteArray {
     type Error = crate::PyErr;
 

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -59,6 +59,7 @@ mod not_limited_impls {
     use super::*;
     use std::ops::{Add, Div, Mul, Neg, Sub};
 
+    #[cfg(feature = "gil-refs")]
     impl PyComplex {
         /// Returns `|self|`.
         pub fn abs(&self) -> c_double {
@@ -94,6 +95,7 @@ mod not_limited_impls {
                 }
             }
 
+            #[cfg(feature = "gil-refs")]
             impl<'py> $trait for &'py PyComplex {
                 type Output = &'py PyComplex;
                 fn $fn(self, other: &'py PyComplex) -> &'py PyComplex {
@@ -136,6 +138,7 @@ mod not_limited_impls {
     bin_ops!(Mul, mul, *, ffi::_Py_c_prod);
     bin_ops!(Div, div, /, ffi::_Py_c_quot);
 
+    #[cfg(feature = "gil-refs")]
     impl<'py> Neg for &'py PyComplex {
         type Output = &'py PyComplex;
         fn neg(self) -> &'py PyComplex {

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -1,9 +1,9 @@
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Borrowed;
 use crate::py_result_ext::PyResultExt;
+use crate::{ffi, AsPyPointer, Bound, PyAny, PyErr, PyResult, PyTypeCheck};
 #[cfg(feature = "gil-refs")]
-use crate::PyDowncastError;
-use crate::{ffi, AsPyPointer, Bound, PyAny, PyErr, PyNativeType, PyResult, PyTypeCheck};
+use crate::{PyDowncastError, PyNativeType};
 
 /// A Python iterator object.
 ///
@@ -54,6 +54,7 @@ impl PyIterator {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<'p> Iterator for &'p PyIterator {
     type Item = PyResult<&'p PyAny>;
 

--- a/src/types/memoryview.rs
+++ b/src/types/memoryview.rs
@@ -1,7 +1,9 @@
 use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
-use crate::{ffi, AsPyPointer, Bound, PyAny, PyNativeType};
+#[cfg(feature = "gil-refs")]
+use crate::PyNativeType;
+use crate::{ffi, AsPyPointer, Bound, PyAny};
 
 /// Represents a Python `memoryview`.
 #[repr(transparent)]
@@ -31,6 +33,7 @@ impl PyMemoryView {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<'py> TryFrom<&'py PyAny> for &'py PyMemoryView {
     type Error = crate::PyErr;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -79,11 +79,17 @@ pub use self::typeobject::{PyType, PyTypeMethods};
 /// the Limited API and PyPy, the underlying structures are opaque and that may not be possible.
 /// In these cases the iterators are implemented by forwarding to [`PyIterator`].
 pub mod iter {
-    pub use super::dict::{BoundDictIterator, PyDictIterator};
-    pub use super::frozenset::{BoundFrozenSetIterator, PyFrozenSetIterator};
-    pub use super::list::{BoundListIterator, PyListIterator};
-    pub use super::set::{BoundSetIterator, PySetIterator};
-    pub use super::tuple::{BorrowedTupleIterator, BoundTupleIterator, PyTupleIterator};
+    pub use super::dict::BoundDictIterator;
+    pub use super::frozenset::BoundFrozenSetIterator;
+    pub use super::list::BoundListIterator;
+    pub use super::set::BoundSetIterator;
+    pub use super::tuple::{BorrowedTupleIterator, BoundTupleIterator};
+
+    #[cfg(feature = "gil-refs")]
+    pub use super::{
+        dict::PyDictIterator, frozenset::PyFrozenSetIterator, list::PyListIterator,
+        set::PySetIterator, tuple::PyTupleIterator,
+    };
 }
 
 /// Python objects that have a base type.

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -6,11 +6,12 @@ use crate::pyclass::PyClass;
 use crate::types::{
     any::PyAnyMethods, list::PyListMethods, PyAny, PyCFunction, PyDict, PyList, PyString,
 };
-use crate::{exceptions, ffi, Bound, IntoPy, Py, PyNativeType, PyObject, Python};
+use crate::{exceptions, ffi, Bound, IntoPy, Py, PyObject, Python};
 use std::ffi::CString;
 use std::str;
 
-use super::PyStringMethods;
+#[cfg(feature = "gil-refs")]
+use {super::PyStringMethods, crate::PyNativeType};
 
 /// Represents a Python [`module`][1] object.
 ///
@@ -25,17 +26,6 @@ pub struct PyModule(PyAny);
 pyobject_native_type_core!(PyModule, pyobject_native_static_type_object!(ffi::PyModule_Type), #checkfunction=ffi::PyModule_Check);
 
 impl PyModule {
-    /// Deprecated form of [`PyModule::new_bound`].
-    #[inline]
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyModule::new` will be replaced by `PyModule::new_bound` in a future PyO3 version"
-    )]
-    pub fn new<'py>(py: Python<'py>, name: &str) -> PyResult<&'py PyModule> {
-        Self::new_bound(py, name).map(Bound::into_gil_ref)
-    }
-
     /// Creates a new module object with the `__name__` attribute set to `name`.
     ///
     /// # Examples
@@ -60,20 +50,6 @@ impl PyModule {
                 .assume_owned_or_err(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated form of [`PyModule::import_bound`].
-    #[inline]
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyModule::import` will be replaced by `PyModule::import_bound` in a future PyO3 version"
-    )]
-    pub fn import<N>(py: Python<'_>, name: N) -> PyResult<&PyModule>
-    where
-        N: IntoPy<Py<PyString>>,
-    {
-        Self::import_bound(py, name).map(Bound::into_gil_ref)
     }
 
     /// Imports the Python module with the specified name.
@@ -104,22 +80,6 @@ impl PyModule {
                 .assume_owned_or_err(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated form of [`PyModule::from_code_bound`].
-    #[inline]
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyModule::from_code` will be replaced by `PyModule::from_code_bound` in a future PyO3 version"
-    )]
-    pub fn from_code<'py>(
-        py: Python<'py>,
-        code: &str,
-        file_name: &str,
-        module_name: &str,
-    ) -> PyResult<&'py PyModule> {
-        Self::from_code_bound(py, code, file_name, module_name).map(Bound::into_gil_ref)
     }
 
     /// Creates and loads a module named `module_name`,
@@ -194,6 +154,47 @@ impl PyModule {
                 .assume_owned_or_err(py)
                 .downcast_into()
         }
+    }
+}
+
+#[cfg(feature = "gil-refs")]
+impl PyModule {
+    /// Deprecated form of [`PyModule::new_bound`].
+    #[inline]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyModule::new` will be replaced by `PyModule::new_bound` in a future PyO3 version"
+    )]
+    pub fn new<'py>(py: Python<'py>, name: &str) -> PyResult<&'py PyModule> {
+        Self::new_bound(py, name).map(Bound::into_gil_ref)
+    }
+
+    /// Deprecated form of [`PyModule::import_bound`].
+    #[inline]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyModule::import` will be replaced by `PyModule::import_bound` in a future PyO3 version"
+    )]
+    pub fn import<N>(py: Python<'_>, name: N) -> PyResult<&PyModule>
+    where
+        N: IntoPy<Py<PyString>>,
+    {
+        Self::import_bound(py, name).map(Bound::into_gil_ref)
+    }
+
+    /// Deprecated form of [`PyModule::from_code_bound`].
+    #[inline]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyModule::from_code` will be replaced by `PyModule::from_code_bound` in a future PyO3 version"
+    )]
+    pub fn from_code<'py>(
+        py: Python<'py>,
+        code: &str,
+        file_name: &str,
+        module_name: &str,
+    ) -> PyResult<&'py PyModule> {
+        Self::from_code_bound(py, code, file_name, module_name).map(Bound::into_gil_ref)
     }
 
     /// Returns the module's `__dict__` attribute, which contains the module's symbol table.
@@ -433,8 +434,9 @@ pub trait PyModuleMethods<'py>: crate::sealed::Sealed {
 
     /// Adds an attribute to the module.
     ///
-    /// For adding classes, functions or modules, prefer to use [`PyModule::add_class`],
-    /// [`PyModule::add_function`] or [`PyModule::add_submodule`] instead, respectively.
+    /// For adding classes, functions or modules, prefer to use [`PyModuleMethods::add_class`],
+    /// [`PyModuleMethods::add_function`] or [`PyModuleMethods::add_submodule`] instead,
+    /// respectively.
     ///
     /// # Examples
     ///
@@ -510,7 +512,8 @@ pub trait PyModuleMethods<'py>: crate::sealed::Sealed {
 
     /// Adds a function or a (sub)module to a module, using the functions name as name.
     ///
-    /// Prefer to use [`PyModule::add_function`] and/or [`PyModule::add_submodule`] instead.
+    /// Prefer to use [`PyModuleMethods::add_function`] and/or [`PyModuleMethods::add_submodule`]
+    /// instead.
     fn add_wrapped<T>(&self, wrapper: &impl Fn(Python<'py>) -> T) -> PyResult<()>
     where
         T: IntoPyCallbackOutput<PyObject>;

--- a/tests/test_no_imports.rs
+++ b/tests/test_no_imports.rs
@@ -10,6 +10,7 @@ fn basic_function(py: pyo3::Python<'_>, x: Option<pyo3::PyObject>) -> pyo3::PyOb
     x.unwrap_or_else(|| py.None())
 }
 
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 #[pyo3::pymodule]
 fn basic_module(_py: pyo3::Python<'_>, m: &pyo3::types::PyModule) -> pyo3::PyResult<()> {
@@ -108,7 +109,7 @@ impl BasicClass {
 #[test]
 fn test_basic() {
     pyo3::Python::with_gil(|py| {
-        let module = pyo3::wrap_pymodule!(basic_module)(py);
+        let module = pyo3::wrap_pymodule!(basic_module_bound)(py);
         let cls = py.get_type_bound::<BasicClass>();
         let d = pyo3::types::IntoPyDict::into_py_dict_bound(
             [

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -58,8 +58,8 @@ fn pyfunction_with_module<'py>(module: &Bound<'py, PyModule>) -> PyResult<Bound<
 
 #[pyfunction]
 #[pyo3(pass_module)]
-fn pyfunction_with_module_gil_ref(module: &PyModule) -> PyResult<&str> {
-    module.name()
+fn pyfunction_with_module_gil_ref(_module: &PyModule) -> PyResult<&str> {
+    todo!()
 }
 
 #[pyfunction]
@@ -68,14 +68,12 @@ fn double(x: usize) -> usize {
 }
 
 #[pymodule]
-fn module_gil_ref(m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(double, m)?)?;
+fn module_gil_ref(_m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
 #[pymodule]
-fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(double, m)?)?;
+fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, _m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -53,69 +53,69 @@ error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`
    |                                       ^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:61:43
+  --> tests/ui/deprecations.rs:61:44
    |
-61 | fn pyfunction_with_module_gil_ref(module: &PyModule) -> PyResult<&str> {
-   |                                           ^
+61 | fn pyfunction_with_module_gil_ref(_module: &PyModule) -> PyResult<&str> {
+   |                                            ^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
   --> tests/ui/deprecations.rs:71:19
    |
-71 | fn module_gil_ref(m: &PyModule) -> PyResult<()> {
-   |                   ^
+71 | fn module_gil_ref(_m: &PyModule) -> PyResult<()> {
+   |                   ^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/deprecations.rs:77:57
+  --> tests/ui/deprecations.rs:76:57
    |
-77 | fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
-   |                                                         ^
+76 | fn module_gil_ref_with_explicit_py_arg(_py: Python<'_>, _m: &PyModule) -> PyResult<()> {
+   |                                                         ^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:110:27
+   --> tests/ui/deprecations.rs:108:27
     |
-110 |     #[pyo3(from_py_with = "extract_gil_ref")] _gil_ref: i32,
+108 |     #[pyo3(from_py_with = "extract_gil_ref")] _gil_ref: i32,
     |                           ^^^^^^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-   --> tests/ui/deprecations.rs:116:29
+   --> tests/ui/deprecations.rs:114:29
     |
-116 | fn pyfunction_gil_ref(_any: &PyAny) {}
+114 | fn pyfunction_gil_ref(_any: &PyAny) {}
     |                             ^
 
 error: use of deprecated method `pyo3::deprecations::OptionGilRefs::<std::option::Option<T>>::function_arg`: use `Option<&Bound<'_, T>>` instead for this function argument
-   --> tests/ui/deprecations.rs:119:36
+   --> tests/ui/deprecations.rs:117:36
     |
-119 | fn pyfunction_option_gil_ref(_any: Option<&PyAny>) {}
+117 | fn pyfunction_option_gil_ref(_any: Option<&PyAny>) {}
     |                                    ^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:126:27
+   --> tests/ui/deprecations.rs:124:27
     |
-126 |     #[pyo3(from_py_with = "PyAny::len", item("my_object"))]
+124 |     #[pyo3(from_py_with = "PyAny::len", item("my_object"))]
     |                           ^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:136:27
+   --> tests/ui/deprecations.rs:134:27
     |
-136 |     #[pyo3(from_py_with = "PyAny::len")] usize,
+134 |     #[pyo3(from_py_with = "PyAny::len")] usize,
     |                           ^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:142:31
+   --> tests/ui/deprecations.rs:140:31
     |
-142 |     Zip(#[pyo3(from_py_with = "extract_gil_ref")] i32),
+140 |     Zip(#[pyo3(from_py_with = "extract_gil_ref")] i32),
     |                               ^^^^^^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
-   --> tests/ui/deprecations.rs:149:27
+   --> tests/ui/deprecations.rs:147:27
     |
-149 |     #[pyo3(from_py_with = "extract_gil_ref")]
+147 |     #[pyo3(from_py_with = "extract_gil_ref")]
     |                           ^^^^^^^^^^^^^^^^^
 
 error: use of deprecated method `pyo3::deprecations::GilRefs::<pyo3::Python<'_>>::is_python`: use `wrap_pyfunction_bound!` instead
-   --> tests/ui/deprecations.rs:162:13
+   --> tests/ui/deprecations.rs:160:13
     |
-162 |     let _ = wrap_pyfunction!(double, py);
+160 |     let _ = wrap_pyfunction!(double, py);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: this error originates in the macro `wrap_pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Part of #3960

This prepares for deprecation of `as/into_gil_ref()` (which are needed for proceeding with `Python`) by adding a lot of feature gates and splitting inherent impl blocks.

I was not really sure where to split this one, so this turned out to be a bit larger diff than intended 😇 , hopefully still reviewable (otherwise I can also split again). `PyAny` is left out here, because that reaches into the `impl_` module and type macros and has a long tail by itself.