### PR TITLE
emit `cargo:rustc-check-cfg=CHECK_CFG` for `pyo3`s config names

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -46,6 +46,7 @@ fn configure_pyo3() -> Result<()> {
 }
 
 fn main() {
+    pyo3_build_config::print_expected_cfgs();
     if let Err(e) = configure_pyo3() {
         eprintln!("error: {}", e.report());
         std::process::exit(1)

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -339,12 +339,12 @@ To make PyO3's core functionality continue to work while the GIL Refs API is in 
 
 PyO3 0.21 has introduced the [`PyBackedStr`]({{#PYO3_DOCS_URL}}/pyo3/pybacked/struct.PyBackedStr.html) and [`PyBackedBytes`]({{#PYO3_DOCS_URL}}/pyo3/pybacked/struct.PyBackedBytes.html) types to help with this case. The easiest way to avoid lifetime challenges from extracting `&str` is to use these. For more complex types like `Vec<&str>`, is now impossible to extract directly from a Python object and `Vec<PyBackedStr>` is the recommended upgrade path.
 
-A key thing to note here is because extracting to these types now ties them to the input lifetime, some extremely common patterns may need to be split into multiple Rust lines. For example, the following snippet of calling `.extract::<&str>()` directly on the result of `.getattr()` needs to be adjusted when deactivating the `gil-refs-migration` feature.
+A key thing to note here is because extracting to these types now ties them to the input lifetime, some extremely common patterns may need to be split into multiple Rust lines. For example, the following snippet of calling `.extract::<&str>()` directly on the result of `.getattr()` needs to be adjusted when deactivating the `gil-refs` feature.
 
 Before:
 
 ```rust
-# #[cfg(feature = "gil-refs-migration")] {
+# #[cfg(feature = "gil-refs")] {
 # use pyo3::prelude::*;
 # use pyo3::types::{PyList, PyType};
 # fn example<'py>(py: Python<'py>) -> PyResult<()> {

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 /// Minimum Python version PyO3 supports.
-const MINIMUM_SUPPORTED_VERSION: PythonVersion = PythonVersion { major: 3, minor: 7 };
+pub(crate) const MINIMUM_SUPPORTED_VERSION: PythonVersion = PythonVersion { major: 3, minor: 7 };
 
 /// GraalPy may implement the same CPython version over multiple releases.
 const MINIMUM_SUPPORTED_VERSION_GRAALPY: PythonVersion = PythonVersion {
@@ -39,7 +39,7 @@ const MINIMUM_SUPPORTED_VERSION_GRAALPY: PythonVersion = PythonVersion {
 };
 
 /// Maximum Python version that can be used as minimum required Python version with abi3.
-const ABI3_MAX_MINOR: u8 = 12;
+pub(crate) const ABI3_MAX_MINOR: u8 = 12;
 
 /// Gets an environment variable owned by cargo.
 ///

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -205,6 +205,7 @@ fn print_config_and_exit(config: &InterpreterConfig) {
 }
 
 fn main() {
+    pyo3_build_config::print_expected_cfgs();
     if let Err(e) = configure_pyo3() {
         eprintln!("error: {}", e.report());
         std::process::exit(1)

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -96,7 +96,7 @@
 //! enabled, `Ungil` is defined as the following:
 //!
 //! ```rust
-//! # #[cfg(FALSE)]
+//! # #[cfg(any())]
 //! # {
 //! #![feature(auto_traits, negative_impls)]
 //!

--- a/src/tests/hygiene/pyclass.rs
+++ b/src/tests/hygiene/pyclass.rs
@@ -39,11 +39,11 @@ pub enum Enum {
 #[pyo3(crate = "crate")]
 pub struct Foo3 {
     #[pyo3(get, set)]
-    #[cfg(FALSE)]
+    #[cfg(any())]
     field: i32,
 
     #[pyo3(get, set)]
-    #[cfg(not(FALSE))]
+    #[cfg(not(any()))]
     field: u32,
 }
 
@@ -51,11 +51,11 @@ pub struct Foo3 {
 #[pyo3(crate = "crate")]
 pub struct Foo4 {
     #[pyo3(get, set)]
-    #[cfg(FALSE)]
-    #[cfg(not(FALSE))]
+    #[cfg(any())]
+    #[cfg(not(any()))]
     field: i32,
 
     #[pyo3(get, set)]
-    #[cfg(not(FALSE))]
+    #[cfg(not(any()))]
     field: u32,
 }


### PR DESCRIPTION
Emit build script directives to verify our config names, https://github.com/rust-lang/cargo/pull/13571