### PR TITLE
remove function pointer wrappers no longer needed for MSRV

### DIFF
--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -828,7 +828,7 @@ impl<'a> FnSpec<'a> {
             CallingConvention::Noargs => quote! {
                 #pyo3_path::impl_::pymethods::PyMethodDef::noargs(
                     #python_name,
-                    #pyo3_path::impl_::pymethods::PyCFunction({
+                    {
                         unsafe extern "C" fn trampoline(
                             _slf: *mut #pyo3_path::ffi::PyObject,
                             _args: *mut #pyo3_path::ffi::PyObject,
@@ -841,14 +841,14 @@ impl<'a> FnSpec<'a> {
                             )
                         }
                         trampoline
-                    }),
+                    },
                     #doc,
                 )
             },
             CallingConvention::Fastcall => quote! {
                 #pyo3_path::impl_::pymethods::PyMethodDef::fastcall_cfunction_with_keywords(
                     #python_name,
-                    #pyo3_path::impl_::pymethods::PyCFunctionFastWithKeywords({
+                    {
                         unsafe extern "C" fn trampoline(
                             _slf: *mut #pyo3_path::ffi::PyObject,
                             _args: *const *mut #pyo3_path::ffi::PyObject,
@@ -865,14 +865,14 @@ impl<'a> FnSpec<'a> {
                             )
                         }
                         trampoline
-                    }),
+                    },
                     #doc,
                 )
             },
             CallingConvention::Varargs => quote! {
                 #pyo3_path::impl_::pymethods::PyMethodDef::cfunction_with_keywords(
                     #python_name,
-                    #pyo3_path::impl_::pymethods::PyCFunctionWithKeywords({
+                    {
                         unsafe extern "C" fn trampoline(
                             _slf: *mut #pyo3_path::ffi::PyObject,
                             _args: *mut #pyo3_path::ffi::PyObject,
@@ -887,7 +887,7 @@ impl<'a> FnSpec<'a> {
                             )
                         }
                         trampoline
-                    }),
+                    },
                     #doc,
                 )
             },

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1107,7 +1107,7 @@ pub fn gen_complex_enum_variant_attr(
         #pyo3_path::class::PyMethodDefType::ClassAttribute({
             #pyo3_path::class::PyClassAttributeDef::new(
                 #python_name,
-                #pyo3_path::impl_::pymethods::PyClassAttributeFactory(#cls_type::#wrapper_ident)
+                #cls_type::#wrapper_ident
             )
         })
     };

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -200,7 +200,7 @@ pub fn gen_py_const(cls: &syn::Type, spec: &ConstSpec<'_>, ctx: &Ctx) -> MethodA
         #pyo3_path::class::PyMethodDefType::ClassAttribute({
             #pyo3_path::class::PyClassAttributeDef::new(
                 #python_name,
-                #pyo3_path::impl_::pymethods::PyClassAttributeFactory(#cls::#wrapper_ident)
+                #cls::#wrapper_ident
             )
         })
     };

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -512,7 +512,7 @@ fn impl_py_class_attribute(
         #pyo3_path::class::PyMethodDefType::ClassAttribute({
             #pyo3_path::class::PyClassAttributeDef::new(
                 #python_name,
-                #pyo3_path::impl_::pymethods::PyClassAttributeFactory(#cls::#wrapper_ident)
+                #cls::#wrapper_ident
             )
         })
     };
@@ -699,7 +699,7 @@ pub fn impl_py_setter_def(
         #pyo3_path::class::PyMethodDefType::Setter(
             #pyo3_path::class::PySetterDef::new(
                 #python_name,
-                #pyo3_path::impl_::pymethods::PySetter(#cls::#wrapper_ident),
+                #cls::#wrapper_ident,
                 #doc
             )
         )
@@ -831,7 +831,7 @@ pub fn impl_py_getter_def(
         #pyo3_path::class::PyMethodDefType::Getter(
             #pyo3_path::class::PyGetterDef::new(
                 #python_name,
-                #pyo3_path::impl_::pymethods::PyGetter(#cls::#wrapper_ident),
+                #cls::#wrapper_ident,
                 #doc
             )
         )

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -153,7 +153,7 @@ impl LazyTypeObjectInner {
                 if let PyMethodDefType::ClassAttribute(attr) = def {
                     let key = attr.attribute_c_string().unwrap();
 
-                    match (attr.meth.0)(py) {
+                    match (attr.meth)(py) {
                         Ok(val) => items.push((key, val)),
                         Err(err) => {
                             return Err(wrap_in_runtime_error(

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -69,27 +69,13 @@ pub enum PyMethodDefType {
 
 #[derive(Copy, Clone, Debug)]
 pub enum PyMethodType {
-    PyCFunction(PyCFunction),
-    PyCFunctionWithKeywords(PyCFunctionWithKeywords),
+    PyCFunction(ffi::PyCFunction),
+    PyCFunctionWithKeywords(ffi::PyCFunctionWithKeywords),
     #[cfg(not(Py_LIMITED_API))]
-    PyCFunctionFastWithKeywords(PyCFunctionFastWithKeywords),
+    PyCFunctionFastWithKeywords(ffi::_PyCFunctionFastWithKeywords),
 }
 
-// These newtype structs serve no purpose other than wrapping which are function pointers - because
-// function pointers aren't allowed in const fn, but types wrapping them are!
-#[derive(Clone, Copy, Debug)]
-pub struct PyCFunction(pub ffi::PyCFunction);
-#[derive(Clone, Copy, Debug)]
-pub struct PyCFunctionWithKeywords(pub ffi::PyCFunctionWithKeywords);
-#[cfg(not(Py_LIMITED_API))]
-#[derive(Clone, Copy, Debug)]
-pub struct PyCFunctionFastWithKeywords(pub ffi::_PyCFunctionFastWithKeywords);
-#[derive(Clone, Copy)]
-pub struct PyGetter(pub Getter);
-#[derive(Clone, Copy)]
-pub struct PySetter(pub Setter);
-#[derive(Clone, Copy)]
-pub struct PyClassAttributeFactory(pub for<'p> fn(Python<'p>) -> PyResult<PyObject>);
+pub type PyClassAttributeFactory = for<'p> fn(Python<'p>) -> PyResult<PyObject>;
 
 // TODO: it would be nice to use CStr in these types, but then the constructors can't be const fn
 // until `CStr::from_bytes_with_nul_unchecked` is const fn.
@@ -117,14 +103,14 @@ impl PyClassAttributeDef {
 #[derive(Clone)]
 pub struct PyGetterDef {
     pub(crate) name: &'static str,
-    pub(crate) meth: PyGetter,
+    pub(crate) meth: Getter,
     pub(crate) doc: &'static str,
 }
 
 #[derive(Clone)]
 pub struct PySetterDef {
     pub(crate) name: &'static str,
-    pub(crate) meth: PySetter,
+    pub(crate) meth: Setter,
     pub(crate) doc: &'static str,
 }
 
@@ -136,7 +122,11 @@ unsafe impl Sync for PySetterDef {}
 
 impl PyMethodDef {
     /// Define a function with no `*args` and `**kwargs`.
-    pub const fn noargs(name: &'static str, cfunction: PyCFunction, doc: &'static str) -> Self {
+    pub const fn noargs(
+        name: &'static str,
+        cfunction: ffi::PyCFunction,
+        doc: &'static str,
+    ) -> Self {
         Self {
             ml_name: name,
             ml_meth: PyMethodType::PyCFunction(cfunction),
@@ -148,7 +138,7 @@ impl PyMethodDef {
     /// Define a function that can take `*args` and `**kwargs`.
     pub const fn cfunction_with_keywords(
         name: &'static str,
-        cfunction: PyCFunctionWithKeywords,
+        cfunction: ffi::PyCFunctionWithKeywords,
         doc: &'static str,
     ) -> Self {
         Self {
@@ -163,7 +153,7 @@ impl PyMethodDef {
     #[cfg(not(Py_LIMITED_API))]
     pub const fn fastcall_cfunction_with_keywords(
         name: &'static str,
-        cfunction: PyCFunctionFastWithKeywords,
+        cfunction: ffi::_PyCFunctionFastWithKeywords,
         doc: &'static str,
     ) -> Self {
         Self {
@@ -182,15 +172,13 @@ impl PyMethodDef {
     /// Convert `PyMethodDef` to Python method definition struct `ffi::PyMethodDef`
     pub(crate) fn as_method_def(&self) -> PyResult<(ffi::PyMethodDef, PyMethodDefDestructor)> {
         let meth = match self.ml_meth {
-            PyMethodType::PyCFunction(meth) => ffi::PyMethodDefPointer {
-                PyCFunction: meth.0,
-            },
+            PyMethodType::PyCFunction(meth) => ffi::PyMethodDefPointer { PyCFunction: meth },
             PyMethodType::PyCFunctionWithKeywords(meth) => ffi::PyMethodDefPointer {
-                PyCFunctionWithKeywords: meth.0,
+                PyCFunctionWithKeywords: meth,
             },
             #[cfg(not(Py_LIMITED_API))]
             PyMethodType::PyCFunctionFastWithKeywords(meth) => ffi::PyMethodDefPointer {
-                _PyCFunctionFastWithKeywords: meth.0,
+                _PyCFunctionFastWithKeywords: meth,
             },
         };
 
@@ -232,7 +220,7 @@ pub(crate) type Setter =
 
 impl PyGetterDef {
     /// Define a getter.
-    pub const fn new(name: &'static str, getter: PyGetter, doc: &'static str) -> Self {
+    pub const fn new(name: &'static str, getter: Getter, doc: &'static str) -> Self {
         Self {
             name,
             meth: getter,
@@ -243,7 +231,7 @@ impl PyGetterDef {
 
 impl PySetterDef {
     /// Define a setter.
-    pub const fn new(name: &'static str, setter: PySetter, doc: &'static str) -> Self {
+    pub const fn new(name: &'static str, setter: Setter, doc: &'static str) -> Self {
         Self {
             name,
             meth: setter,

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -508,7 +508,7 @@ impl GetSetDefBuilder {
             self.doc = Some(getter.doc);
         }
         // TODO: return an error if getter already defined?
-        self.getter = Some(getter.meth.0)
+        self.getter = Some(getter.meth)
     }
 
     fn add_setter(&mut self, setter: &PySetterDef) {
@@ -517,7 +517,7 @@ impl GetSetDefBuilder {
             self.doc = Some(setter.doc);
         }
         // TODO: return an error if setter already defined?
-        self.setter = Some(setter.meth.0)
+        self.setter = Some(setter.meth)
     }
 
     fn as_get_set_def(

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -37,11 +37,7 @@ impl PyCFunction {
         let (py, module) = py_or_module.into_py_and_maybe_module();
         Self::internal_new(
             py,
-            &PyMethodDef::cfunction_with_keywords(
-                name,
-                pymethods::PyCFunctionWithKeywords(fun),
-                doc,
-            ),
+            &PyMethodDef::cfunction_with_keywords(name, fun, doc),
             module.map(PyNativeType::as_borrowed).as_deref(),
         )
         .map(Bound::into_gil_ref)
@@ -57,11 +53,7 @@ impl PyCFunction {
     ) -> PyResult<Bound<'py, Self>> {
         Self::internal_new(
             py,
-            &PyMethodDef::cfunction_with_keywords(
-                name,
-                pymethods::PyCFunctionWithKeywords(fun),
-                doc,
-            ),
+            &PyMethodDef::cfunction_with_keywords(name, fun, doc),
             module,
         )
     }
@@ -81,7 +73,7 @@ impl PyCFunction {
         let (py, module) = py_or_module.into_py_and_maybe_module();
         Self::internal_new(
             py,
-            &PyMethodDef::noargs(name, pymethods::PyCFunction(fun), doc),
+            &PyMethodDef::noargs(name, fun, doc),
             module.map(PyNativeType::as_borrowed).as_deref(),
         )
         .map(Bound::into_gil_ref)
@@ -95,11 +87,7 @@ impl PyCFunction {
         doc: &'static str,
         module: Option<&Bound<'py, PyModule>>,
     ) -> PyResult<Bound<'py, Self>> {
-        Self::internal_new(
-            py,
-            &PyMethodDef::noargs(name, pymethods::PyCFunction(fun), doc),
-            module,
-        )
+        Self::internal_new(py, &PyMethodDef::noargs(name, fun, doc), module)
     }
 
     /// Deprecated form of [`PyCFunction::new_closure`]
@@ -153,7 +141,7 @@ impl PyCFunction {
     {
         let method_def = pymethods::PyMethodDef::cfunction_with_keywords(
             name.unwrap_or("pyo3-closure\0"),
-            pymethods::PyCFunctionWithKeywords(run_closure::<F, R>),
+            run_closure::<F, R>,
             doc.unwrap_or("\0"),
         );
         let (def, def_destructor) = method_def.as_method_def()?;


### PR DESCRIPTION
With the version bump to MSRV 1.63 we should be able to handle function pointers in `const fn` without needing to wrap them.

This should be a purely internal refactoring.