### PR TITLE
feature gate `as/into_gil_ref` APIs (Part 3)

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -1614,7 +1614,7 @@ However, for `#[pyproto]` and some functions, you need to manually fix the code.
 In 0.8 object creation was done with `PyRef::new` and `PyRefMut::new`.
 In 0.9 these have both been removed.
 To upgrade code, please use
-[`PyCell::new`]({{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyCell.html#method.new) instead.
+`PyCell::new` instead.
 If you need [`PyRef`] or [`PyRefMut`], just call `.borrow()` or `.borrow_mut()`
 on the newly-created `PyCell`.
 

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -446,8 +446,10 @@ Like PyO3's Python native types, the GIL Ref `&PyCell<T>` implements `Deref<Targ
 `PyCell<T>` was used to access `&T` and `&mut T` via `PyRef<T>` and `PyRefMut<T>` respectively.
 
 ```rust
+#![allow(unused_imports)]
 # use pyo3::prelude::*;
 # #[pyclass] struct MyClass { }
+# #[cfg(feature = "gil-refs")]
 # Python::with_gil(|py| -> PyResult<()> {
 #[allow(deprecated)] // &PyCell is part of the deprecated GIL Refs API
 let cell: &PyCell<MyClass> = PyCell::new(py, MyClass {})?;

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -222,9 +222,7 @@ pub trait FromPyObject<'py>: Sized {
     ///
     /// Implementors are encouraged to implement this method and leave `extract` defaulted, as
     /// this will be most compatible with PyO3's future API.
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        Self::extract(ob.clone().into_gil_ref())
-    }
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self>;
 
     /// Extracts the type hint information for this type when it appears as an argument.
     ///
@@ -350,8 +348,8 @@ impl<'py, T> FromPyObject<'py> for &'py crate::PyCell<T>
 where
     T: PyClass,
 {
-    fn extract(obj: &'py PyAny) -> PyResult<Self> {
-        obj.downcast().map_err(Into::into)
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        obj.clone().into_gil_ref().downcast().map_err(Into::into)
     }
 }
 

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -20,8 +20,8 @@ impl<'a> IntoPy<PyObject> for &'a [u8] {
 
 #[cfg(feature = "gil-refs")]
 impl<'py> crate::FromPyObject<'py> for &'py [u8] {
-    fn extract(obj: &'py PyAny) -> PyResult<Self> {
-        Ok(obj.downcast::<PyBytes>()?.as_bytes())
+    fn extract_bound(obj: &crate::Bound<'py, PyAny>) -> PyResult<Self> {
+        Ok(obj.clone().into_gil_ref().downcast::<PyBytes>()?.as_bytes())
     }
 
     #[cfg(feature = "experimental-inspect")]

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -116,8 +116,8 @@ impl<'a> IntoPy<PyObject> for &'a String {
 /// Accepts Python `str` objects.
 #[cfg(feature = "gil-refs")]
 impl<'py> FromPyObject<'py> for &'py str {
-    fn extract(ob: &'py PyAny) -> PyResult<Self> {
-        ob.downcast::<PyString>()?.to_str()
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        ob.clone().into_gil_ref().downcast::<PyString>()?.to_str()
     }
 
     #[cfg(feature = "experimental-inspect")]

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -492,6 +492,7 @@ impl<'py, T> Bound<'py, T> {
     ///
     /// This is a helper to be used for migration from the deprecated "GIL Refs" API.
     #[inline]
+    #[cfg(feature = "gil-refs")]
     pub fn as_gil_ref(&'py self) -> &'py T::AsRefTarget
     where
         T: HasPyGilRef,
@@ -507,6 +508,7 @@ impl<'py, T> Bound<'py, T> {
     ///
     /// This is a helper to be used for migration from the deprecated "GIL Refs" API.
     #[inline]
+    #[cfg(feature = "gil-refs")]
     pub fn into_gil_ref(self) -> &'py T::AsRefTarget
     where
         T: HasPyGilRef,

--- a/src/tests/hygiene/misc.rs
+++ b/src/tests/hygiene/misc.rs
@@ -41,7 +41,10 @@ fn append_to_inittab() {
     #[crate::pymodule]
     #[pyo3(crate = "crate")]
     #[allow(clippy::unnecessary_wraps)]
-    fn module_for_inittab(_: crate::Python<'_>, _: &crate::types::PyModule) -> crate::PyResult<()> {
+    fn module_for_inittab(
+        _: crate::Python<'_>,
+        _: &crate::Bound<'_, crate::types::PyModule>,
+    ) -> crate::PyResult<()> {
         ::std::result::Result::Ok(())
     }
     crate::append_to_inittab!(module_for_inittab);

--- a/src/tests/hygiene/pymodule.rs
+++ b/src/tests/hygiene/pymodule.rs
@@ -7,10 +7,20 @@ fn do_something(x: i32) -> crate::PyResult<i32> {
     ::std::result::Result::Ok(x)
 }
 
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 #[crate::pymodule]
 #[pyo3(crate = "crate")]
 fn foo(_py: crate::Python<'_>, _m: &crate::types::PyModule) -> crate::PyResult<()> {
+    ::std::result::Result::Ok(())
+}
+
+#[crate::pymodule]
+#[pyo3(crate = "crate")]
+fn foo_bound(
+    _py: crate::Python<'_>,
+    _m: &crate::Bound<'_, crate::types::PyModule>,
+) -> crate::PyResult<()> {
     ::std::result::Result::Ok(())
 }
 
@@ -34,7 +44,7 @@ fn my_module_bound(m: &crate::Bound<'_, crate::types::PyModule>) -> crate::PyRes
     )?;
     <crate::Bound<'_, crate::types::PyModule> as crate::types::PyModuleMethods>::add_wrapped(
         m,
-        crate::wrap_pymodule!(foo),
+        crate::wrap_pymodule!(foo_bound),
     )?;
 
     ::std::result::Result::Ok(())

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -6,7 +6,9 @@ use crate::py_result_ext::PyResultExt;
 use crate::types::any::PyAnyMethods;
 use crate::types::bytes::PyBytesMethods;
 use crate::types::PyBytes;
-use crate::{ffi, Bound, IntoPy, Py, PyAny, PyNativeType, PyResult, Python};
+#[cfg(feature = "gil-refs")]
+use crate::PyNativeType;
+use crate::{ffi, Bound, IntoPy, Py, PyAny, PyResult, Python};
 use std::borrow::Cow;
 use std::os::raw::c_char;
 use std::str;
@@ -135,16 +137,6 @@ pub struct PyString(PyAny);
 pyobject_native_type_core!(PyString, pyobject_native_static_type_object!(ffi::PyUnicode_Type), #checkfunction=ffi::PyUnicode_Check);
 
 impl PyString {
-    /// Deprecated form of [`PyString::new_bound`].
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyString::new` will be replaced by `PyString::new_bound` in a future PyO3 version"
-    )]
-    pub fn new<'py>(py: Python<'py>, s: &str) -> &'py Self {
-        Self::new_bound(py, s).into_gil_ref()
-    }
-
     /// Creates a new Python string object.
     ///
     /// Panics if out of memory.
@@ -156,16 +148,6 @@ impl PyString {
                 .assume_owned(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated form of [`PyString::intern_bound`].
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyString::intern` will be replaced by `PyString::intern_bound` in a future PyO3 version"
-    )]
-    pub fn intern<'py>(py: Python<'py>, s: &str) -> &'py Self {
-        Self::intern_bound(py, s).into_gil_ref()
     }
 
     /// Intern the given string
@@ -188,16 +170,6 @@ impl PyString {
         }
     }
 
-    /// Deprecated form of [`PyString::from_object_bound`].
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyString::from_object` will be replaced by `PyString::from_object_bound` in a future PyO3 version"
-    )]
-    pub fn from_object<'py>(src: &'py PyAny, encoding: &str, errors: &str) -> PyResult<&'py Self> {
-        Self::from_object_bound(&src.as_borrowed(), encoding, errors).map(Bound::into_gil_ref)
-    }
-
     /// Attempts to create a Python string from a Python [bytes-like object].
     ///
     /// [bytes-like object]: (https://docs.python.org/3/glossary.html#term-bytes-like-object).
@@ -215,6 +187,36 @@ impl PyString {
             .assume_owned_or_err(src.py())
             .downcast_into_unchecked()
         }
+    }
+}
+
+#[cfg(feature = "gil-refs")]
+impl PyString {
+    /// Deprecated form of [`PyString::new_bound`].
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyString::new` will be replaced by `PyString::new_bound` in a future PyO3 version"
+    )]
+    pub fn new<'py>(py: Python<'py>, s: &str) -> &'py Self {
+        Self::new_bound(py, s).into_gil_ref()
+    }
+
+    /// Deprecated form of [`PyString::intern_bound`].
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyString::intern` will be replaced by `PyString::intern_bound` in a future PyO3 version"
+    )]
+    pub fn intern<'py>(py: Python<'py>, s: &str) -> &'py Self {
+        Self::intern_bound(py, s).into_gil_ref()
+    }
+
+    /// Deprecated form of [`PyString::from_object_bound`].
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyString::from_object` will be replaced by `PyString::from_object_bound` in a future PyO3 version"
+    )]
+    pub fn from_object<'py>(src: &'py PyAny, encoding: &str, errors: &str) -> PyResult<&'py Self> {
+        Self::from_object_bound(&src.as_borrowed(), encoding, errors).map(Bound::into_gil_ref)
     }
 
     /// Gets the Python string as a Rust UTF-8 string slice.

--- a/tests/test_wrap_pyfunction_deduction.rs
+++ b/tests/test_wrap_pyfunction_deduction.rs
@@ -5,6 +5,7 @@ use pyo3::{prelude::*, types::PyCFunction};
 #[pyfunction]
 fn f() {}
 
+#[cfg(feature = "gil-refs")]
 pub fn add_wrapped(wrapper: &impl Fn(Python<'_>) -> PyResult<&PyCFunction>) {
     let _ = wrapper;
 }
@@ -12,7 +13,10 @@ pub fn add_wrapped(wrapper: &impl Fn(Python<'_>) -> PyResult<&PyCFunction>) {
 #[test]
 fn wrap_pyfunction_deduction() {
     #[allow(deprecated)]
+    #[cfg(feature = "gil-refs")]
     add_wrapped(wrap_pyfunction!(f));
+    #[cfg(not(feature = "gil-refs"))]
+    add_wrapped_bound(wrap_pyfunction!(f));
 }
 
 pub fn add_wrapped_bound(wrapper: &impl Fn(Python<'_>) -> PyResult<Bound<'_, PyCFunction>>) {


### PR DESCRIPTION
Part of #3960, continuing #4166

This feature gates `as/into_gil_ref()`, removes the `extract_bound` default implementation and switches `wrap_pyfunction!` type deduction if `gil-refs` are not enabled. 