### PR TITLE
feature gate deprecated APIs for `Python`

### DIFF
--- a/guide/src/memory.md
+++ b/guide/src/memory.md
@@ -154,8 +154,7 @@ at the end of each loop iteration, before the `with_gil()` closure ends.
 
 When doing this, you must be very careful to ensure that once the `GILPool` is
 dropped you do not retain access to any owned references created after the
-`GILPool` was created.  Read the
-[documentation for `Python::new_pool()`]({{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.new_pool)
+`GILPool` was created.  Read the documentation for `Python::new_pool()`
 for more information on safety.
 
 This memory management can also be applicable when writing extension modules.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,7 @@
 //! [`Ungil`]: crate::marker::Ungil
 pub use crate::class::*;
 pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPy, ToPyObject};
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 pub use crate::conversion::{FromPyPointer, PyTryFrom, PyTryInto};
 pub use crate::err::{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,6 +9,7 @@
 //! ```
 
 pub use crate::conversion::{FromPyObject, IntoPy, ToPyObject};
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 pub use crate::conversion::{PyTryFrom, PyTryInto};
 pub use crate::err::{PyErr, PyResult};

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -518,6 +518,7 @@ impl<T: PyClass> ToPyObject for &PyCell<T> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 impl<T: PyClass> AsRef<PyAny> for PyCell<T> {
     fn as_ref(&self) -> &PyAny {
@@ -528,6 +529,7 @@ impl<T: PyClass> AsRef<PyAny> for PyCell<T> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 impl<T: PyClass> Deref for PyCell<T> {
     type Target = PyAny;


### PR DESCRIPTION
Part of #3960

This feature gates the rest of the deprecated `Python` APIs
