### PR TITLE
add flag to skip reference pool mutex if the program doesn't use the pool

### DIFF
--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -12,8 +12,9 @@ use std::{
 #[allow(deprecated)]
 use crate::gil::GILPool;
 use crate::{
-    callback::PyCallbackOutput, ffi, ffi_ptr_ext::FfiPtrExt, impl_::panic::PanicTrap,
-    methods::IPowModulo, panic::PanicException, types::PyModule, Py, PyResult, Python,
+    callback::PyCallbackOutput, ffi, ffi_ptr_ext::FfiPtrExt, gil::update_deferred_reference_counts,
+    impl_::panic::PanicTrap, methods::IPowModulo, panic::PanicException, types::PyModule, Py,
+    PyResult, Python,
 };
 
 #[inline]
@@ -182,6 +183,7 @@ where
     #[allow(deprecated)]
     let pool = unsafe { GILPool::new() };
     let py = pool.python();
+    update_deferred_reference_counts(py);
     let out = panic_result_into_callback_output(
         py,
         panic::catch_unwind(move || -> PyResult<_> { body(py) }),
@@ -229,6 +231,7 @@ where
     #[allow(deprecated)]
     let pool = GILPool::new();
     let py = pool.python();
+    update_deferred_reference_counts(py);
     if let Err(py_err) = panic::catch_unwind(move || body(py))
         .unwrap_or_else(|payload| Err(PanicException::from_panic_payload(payload)))
     {


### PR DESCRIPTION
This is a tiny idea I had to try to move `ReferencePool` work off the critical path for programs which have avoided using the reference pool.

The idea is that after #4095 we end up with the reference pool only containing deferred drops. We can use a boolean flag without any atomic synchronization to record if we ever wrote to the pool. If this flag is false, we skip the work. This should hopefully be extremely friendly to branch prediction - if the program never touches the pool then the branch predictor should elide the (more heavy) mutex work.

I wonder if this might be a more gentle alternative to the config-flag in #4095 which might be good enough for most users. I would also support keeping the flag but make it abort-only as a debugging tool to get to the never-touches-pool state for this PR. cc @adamreichold 

Measuring the same sample from https://github.com/PyO3/pyo3/issues/3787#issuecomment-1918721168 on my machine, this feature does indeed make quite a marked improvement:

```
# before - rust noop is slower
$ python test.py
py 2.3021166001853998e-08
rust 3.136266599904047e-08

# after - rust noop is slightly faster
$ python test.py
py 2.5457915995502846e-08
rust 2.360866600065492e-08
```