### PR TITLE
split more impl blocks (preparation of `PyCell` feature gate)

### DIFF
--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,9 +1,11 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+#[cfg(feature = "gil-refs")]
+use crate::PyNativeType;
 use crate::{
     exceptions::PyTypeError, ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound,
-    types::typeobject::PyTypeMethods, Borrowed, FromPyObject, IntoPy, PyAny, PyNativeType,
-    PyObject, PyResult, Python, ToPyObject,
+    types::typeobject::PyTypeMethods, Borrowed, FromPyObject, IntoPy, PyAny, PyObject, PyResult,
+    Python, ToPyObject,
 };
 
 use super::any::PyAnyMethods;
@@ -15,20 +17,6 @@ pub struct PyBool(PyAny);
 pyobject_native_type!(PyBool, ffi::PyObject, pyobject_native_static_type_object!(ffi::PyBool_Type), #checkfunction=ffi::PyBool_Check);
 
 impl PyBool {
-    /// Deprecated form of [`PyBool::new_bound`]
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyBool::new` will be replaced by `PyBool::new_bound` in a future PyO3 version"
-    )]
-    #[inline]
-    pub fn new(py: Python<'_>, val: bool) -> &PyBool {
-        #[allow(deprecated)]
-        unsafe {
-            py.from_borrowed_ptr(if val { ffi::Py_True() } else { ffi::Py_False() })
-        }
-    }
-
     /// Depending on `val`, returns `true` or `false`.
     ///
     /// # Note
@@ -40,6 +28,22 @@ impl PyBool {
             if val { ffi::Py_True() } else { ffi::Py_False() }
                 .assume_borrowed(py)
                 .downcast_unchecked()
+        }
+    }
+}
+
+#[cfg(feature = "gil-refs")]
+impl PyBool {
+    /// Deprecated form of [`PyBool::new_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyBool::new` will be replaced by `PyBool::new_bound` in a future PyO3 version"
+    )]
+    #[inline]
+    pub fn new(py: Python<'_>, val: bool) -> &PyBool {
+        #[allow(deprecated)]
+        unsafe {
+            py.from_borrowed_ptr(if val { ffi::Py_True() } else { ffi::Py_False() })
         }
     }
 

--- a/src/types/capsule.rs
+++ b/src/types/capsule.rs
@@ -1,11 +1,12 @@
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
-use crate::{ffi, PyAny, PyNativeType};
+#[cfg(feature = "gil-refs")]
+use crate::PyNativeType;
+use crate::{ffi, PyAny};
 use crate::{Bound, Python};
 use crate::{PyErr, PyResult};
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
-
 /// Represents a Python Capsule
 /// as described in [Capsules](https://docs.python.org/3/c-api/capsule.html#capsules):
 /// > This subtype of PyObject represents an opaque value, useful for C extension
@@ -46,20 +47,6 @@ pub struct PyCapsule(PyAny);
 pyobject_native_type_core!(PyCapsule, pyobject_native_static_type_object!(ffi::PyCapsule_Type), #checkfunction=ffi::PyCapsule_CheckExact);
 
 impl PyCapsule {
-    /// Deprecated form of [`PyCapsule::new_bound`].
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyCapsule::new` will be replaced by `PyCapsule::new_bound` in a future PyO3 version"
-    )]
-    pub fn new<T: 'static + Send + AssertNotZeroSized>(
-        py: Python<'_>,
-        value: T,
-        name: Option<CString>,
-    ) -> PyResult<&Self> {
-        Self::new_bound(py, value, name).map(Bound::into_gil_ref)
-    }
-
     /// Constructs a new capsule whose contents are `value`, associated with `name`.
     /// `name` is the identifier for the capsule; if it is stored as an attribute of a module,
     /// the name should be in the format `"modulename.attribute"`.
@@ -97,24 +84,6 @@ impl PyCapsule {
         name: Option<CString>,
     ) -> PyResult<Bound<'_, Self>> {
         Self::new_bound_with_destructor(py, value, name, |_, _| {})
-    }
-
-    /// Deprecated form of [`PyCapsule::new_bound_with_destructor`].
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyCapsule::new_with_destructor` will be replaced by `PyCapsule::new_bound_with_destructor` in a future PyO3 version"
-    )]
-    pub fn new_with_destructor<
-        T: 'static + Send + AssertNotZeroSized,
-        F: FnOnce(T, *mut c_void) + Send,
-    >(
-        py: Python<'_>,
-        value: T,
-        name: Option<CString>,
-        destructor: F,
-    ) -> PyResult<&'_ Self> {
-        Self::new_bound_with_destructor(py, value, name, destructor).map(Bound::into_gil_ref)
     }
 
     /// Constructs a new capsule whose contents are `value`, associated with `name`.
@@ -171,6 +140,39 @@ impl PyCapsule {
         } else {
             Ok(&*ptr.cast::<T>())
         }
+    }
+}
+
+#[cfg(feature = "gil-refs")]
+impl PyCapsule {
+    /// Deprecated form of [`PyCapsule::new_bound`].
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyCapsule::new` will be replaced by `PyCapsule::new_bound` in a future PyO3 version"
+    )]
+    pub fn new<T: 'static + Send + AssertNotZeroSized>(
+        py: Python<'_>,
+        value: T,
+        name: Option<CString>,
+    ) -> PyResult<&Self> {
+        Self::new_bound(py, value, name).map(Bound::into_gil_ref)
+    }
+
+    /// Deprecated form of [`PyCapsule::new_bound_with_destructor`].
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyCapsule::new_with_destructor` will be replaced by `PyCapsule::new_bound_with_destructor` in a future PyO3 version"
+    )]
+    pub fn new_with_destructor<
+        T: 'static + Send + AssertNotZeroSized,
+        F: FnOnce(T, *mut c_void) + Send,
+    >(
+        py: Python<'_>,
+        value: T,
+        name: Option<CString>,
+        destructor: F,
+    ) -> PyResult<&'_ Self> {
+        Self::new_bound_with_destructor(py, value, name, destructor).map(Bound::into_gil_ref)
     }
 
     /// Sets the context pointer in the capsule.

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -1,4 +1,6 @@
-use crate::{ffi, types::any::PyAnyMethods, Bound, PyAny, PyNativeType, Python};
+#[cfg(feature = "gil-refs")]
+use crate::PyNativeType;
+use crate::{ffi, types::any::PyAnyMethods, Bound, PyAny, Python};
 use std::os::raw::c_double;
 
 /// Represents a Python [`complex`](https://docs.python.org/3/library/functions.html#complex) object.
@@ -19,15 +21,6 @@ pyobject_native_type!(
 );
 
 impl PyComplex {
-    /// Deprecated form of [`PyComplex::from_doubles_bound`]
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyComplex::from_doubles` will be replaced by `PyComplex::from_doubles_bound` in a future PyO3 version"
-    )]
-    pub fn from_doubles(py: Python<'_>, real: c_double, imag: c_double) -> &PyComplex {
-        Self::from_doubles_bound(py, real, imag).into_gil_ref()
-    }
     /// Creates a new `PyComplex` from the given real and imaginary values.
     pub fn from_doubles_bound(
         py: Python<'_>,
@@ -41,6 +34,19 @@ impl PyComplex {
                 .downcast_into_unchecked()
         }
     }
+}
+
+#[cfg(feature = "gil-refs")]
+impl PyComplex {
+    /// Deprecated form of [`PyComplex::from_doubles_bound`]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyComplex::from_doubles` will be replaced by `PyComplex::from_doubles_bound` in a future PyO3 version"
+    )]
+    pub fn from_doubles(py: Python<'_>, real: c_double, imag: c_double) -> &PyComplex {
+        Self::from_doubles_bound(py, real, imag).into_gil_ref()
+    }
+
     /// Returns the real part of the complex number.
     pub fn real(&self) -> c_double {
         self.as_borrowed().real()

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -22,6 +22,7 @@ use crate::ffi::{
     PyDateTime_TIME_GET_MINUTE, PyDateTime_TIME_GET_SECOND,
 };
 use crate::ffi_ptr_ext::FfiPtrExt;
+#[cfg(feature = "gil-refs")]
 use crate::instance::PyNativeType;
 use crate::py_result_ext::PyResultExt;
 use crate::types::any::PyAnyMethods;
@@ -249,6 +250,7 @@ impl PyDate {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl PyDateAccess for PyDate {
     fn get_year(&self) -> i32 {
         self.as_borrowed().get_year()
@@ -461,6 +463,7 @@ impl PyDateTime {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl PyDateAccess for PyDateTime {
     fn get_year(&self) -> i32 {
         self.as_borrowed().get_year()
@@ -489,6 +492,7 @@ impl PyDateAccess for Bound<'_, PyDateTime> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl PyTimeAccess for PyDateTime {
     fn get_hour(&self) -> u8 {
         self.as_borrowed().get_hour()
@@ -533,6 +537,7 @@ impl PyTimeAccess for Bound<'_, PyDateTime> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<'py> PyTzInfoAccess<'py> for &'py PyDateTime {
     fn get_tzinfo_bound(&self) -> Option<Bound<'py, PyTzInfo>> {
         self.as_borrowed().get_tzinfo_bound()
@@ -688,6 +693,7 @@ impl PyTime {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl PyTimeAccess for PyTime {
     fn get_hour(&self) -> u8 {
         self.as_borrowed().get_hour()
@@ -732,6 +738,7 @@ impl PyTimeAccess for Bound<'_, PyTime> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<'py> PyTzInfoAccess<'py> for &'py PyTime {
     fn get_tzinfo_bound(&self) -> Option<Bound<'py, PyTzInfo>> {
         self.as_borrowed().get_tzinfo_bound()
@@ -878,6 +885,7 @@ impl PyDelta {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl PyDeltaAccess for PyDelta {
     fn get_days(&self) -> i32 {
         self.as_borrowed().get_days()

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -1,12 +1,13 @@
+use super::any::PyAnyMethods;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+#[cfg(feature = "gil-refs")]
+use crate::PyNativeType;
 use crate::{
-    ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, FromPyObject, IntoPy, PyAny, PyErr, PyNativeType,
-    PyObject, PyResult, Python, ToPyObject,
+    ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject,
+    PyResult, Python, ToPyObject,
 };
 use std::os::raw::c_double;
-
-use super::any::PyAnyMethods;
 
 /// Represents a Python `float` object.
 ///
@@ -24,17 +25,6 @@ pyobject_native_type!(
 );
 
 impl PyFloat {
-    /// Deprecated form of [`PyFloat::new_bound`].
-    #[inline]
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PyFloat::new` will be replaced by `PyFloat::new_bound` in a future PyO3 version"
-    )]
-    pub fn new(py: Python<'_>, val: f64) -> &'_ Self {
-        Self::new_bound(py, val).into_gil_ref()
-    }
-
     /// Creates a new Python `float` object.
     pub fn new_bound(py: Python<'_>, val: c_double) -> Bound<'_, PyFloat> {
         unsafe {
@@ -42,6 +32,19 @@ impl PyFloat {
                 .assume_owned(py)
                 .downcast_into_unchecked()
         }
+    }
+}
+
+#[cfg(feature = "gil-refs")]
+impl PyFloat {
+    /// Deprecated form of [`PyFloat::new_bound`].
+    #[inline]
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PyFloat::new` will be replaced by `PyFloat::new_bound` in a future PyO3 version"
+    )]
+    pub fn new(py: Python<'_>, val: f64) -> &'_ Self {
+        Self::new_bound(py, val).into_gil_ref()
     }
 
     /// Gets the value of this float.

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -2,7 +2,9 @@ use crate::err::{PyErr, PyResult};
 use crate::ffi;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::types::any::PyAnyMethods;
-use crate::{Bound, PyAny, PyNativeType, PyObject, Python, ToPyObject};
+#[cfg(feature = "gil-refs")]
+use crate::PyNativeType;
+use crate::{Bound, PyAny, PyObject, Python, ToPyObject};
 
 /// Represents a Python `slice`.
 ///
@@ -17,7 +19,7 @@ pyobject_native_type!(
     #checkfunction=ffi::PySlice_Check
 );
 
-/// Return value from [`PySlice::indices`].
+/// Return value from [`PySliceMethods::indices`].
 #[derive(Debug, Eq, PartialEq)]
 pub struct PySliceIndices {
     /// Start of the slice
@@ -47,16 +49,6 @@ impl PySliceIndices {
 }
 
 impl PySlice {
-    /// Deprecated form of `PySlice::new_bound`.
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PySlice::new` will be replaced by `PySlice::new_bound` in a future PyO3 version"
-    )]
-    pub fn new(py: Python<'_>, start: isize, stop: isize, step: isize) -> &PySlice {
-        Self::new_bound(py, start, stop, step).into_gil_ref()
-    }
-
     /// Constructs a new slice with the given elements.
     pub fn new_bound(py: Python<'_>, start: isize, stop: isize, step: isize) -> Bound<'_, PySlice> {
         unsafe {
@@ -70,16 +62,6 @@ impl PySlice {
         }
     }
 
-    /// Deprecated form of `PySlice::full_bound`.
-    #[cfg(feature = "gil-refs")]
-    #[deprecated(
-        since = "0.21.0",
-        note = "`PySlice::full` will be replaced by `PySlice::full_bound` in a future PyO3 version"
-    )]
-    pub fn full(py: Python<'_>) -> &PySlice {
-        PySlice::full_bound(py).into_gil_ref()
-    }
-
     /// Constructs a new full slice that is equivalent to `::`.
     pub fn full_bound(py: Python<'_>) -> Bound<'_, PySlice> {
         unsafe {
@@ -87,6 +69,27 @@ impl PySlice {
                 .assume_owned(py)
                 .downcast_into_unchecked()
         }
+    }
+}
+
+#[cfg(feature = "gil-refs")]
+impl PySlice {
+    /// Deprecated form of `PySlice::new_bound`.
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PySlice::new` will be replaced by `PySlice::new_bound` in a future PyO3 version"
+    )]
+    pub fn new(py: Python<'_>, start: isize, stop: isize, step: isize) -> &PySlice {
+        Self::new_bound(py, start, stop, step).into_gil_ref()
+    }
+
+    /// Deprecated form of `PySlice::full_bound`.
+    #[deprecated(
+        since = "0.21.0",
+        note = "`PySlice::full` will be replaced by `PySlice::full_bound` in a future PyO3 version"
+    )]
+    pub fn full(py: Python<'_>) -> &PySlice {
+        PySlice::full_bound(py).into_gil_ref()
     }
 
     /// Retrieves the start, stop, and step indices from the slice object,

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -1,7 +1,8 @@
 use crate::err::{error_on_minusone, PyResult};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, PyString};
-use crate::{ffi, Bound};
-use crate::{PyAny, PyNativeType};
+#[cfg(feature = "gil-refs")]
+use crate::PyNativeType;
+use crate::{ffi, Bound, PyAny};
 
 /// Represents a Python traceback.
 #[repr(transparent)]
@@ -13,6 +14,7 @@ pyobject_native_type_core!(
     #checkfunction=ffi::PyTraceBack_Check
 );
 
+#[cfg(feature = "gil-refs")]
 impl PyTraceback {
     /// Formats the traceback as a string.
     ///


### PR DESCRIPTION
Part of #3960

This splits more impl blocks in preparation of `PyCell` feature gate (which will feature gate `HasPyGilRef` and `PyNativeType`). 