### PR TITLE
feature gate `PyCell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.21.2"
+version = "0.22.0-dev"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -20,10 +20,10 @@ libc = "0.2.62"
 memoffset = "0.9"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.21.2" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.22.0-dev" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.21.2", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.22.0-dev", optional = true }
 indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
@@ -62,7 +62,7 @@ rayon = "1.6.1"
 futures = "0.3.28"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "=0.21.2", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "=0.22.0-dev", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ generate-import-lib = ["pyo3-ffi/generate-import-lib"]
 auto-initialize = []
 
 # Allows use of the deprecated "GIL Refs" APIs.
-gil-refs = []
+gil-refs = ["pyo3-macros/gil-refs"]
 
 # Enables `Clone`ing references to Python objects `Py<T>` which panics if the GIL is not held.
 py-clone = []

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1307,6 +1307,7 @@ struct MyClass {
 impl pyo3::types::DerefToPyAny for MyClass {}
 
 # #[allow(deprecated)]
+# #[cfg(feature = "gil-refs")]
 unsafe impl pyo3::type_object::HasPyGilRef for MyClass {
     type AsRefTarget = pyo3::PyCell<Self>;
 }

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -1609,7 +1609,7 @@ For more, see [the constructor section](class.md#constructor) of this guide.
 <details>
 <summary><small>Click to expand</small></summary>
 
-PyO3 0.9 introduces [`PyCell`], which is a [`RefCell`]-like object wrapper
+PyO3 0.9 introduces `PyCell`, which is a [`RefCell`]-like object wrapper
 for ensuring Rust's rules regarding aliasing of references are upheld.
 For more detail, see the
 [Rust Book's section on Rust's rules of references](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#the-rules-of-references)
@@ -1788,7 +1788,6 @@ impl PySequenceProtocol for ByteSequence {
 
 [`FromPyObject`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.FromPyObject.html
 [`PyAny`]: {{#PYO3_DOCS_URL}}/pyo3/types/struct.PyAny.html
-[`PyCell`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyCell.html
 [`PyBorrowMutError`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyBorrowMutError.html
 [`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
 [`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.22.0-dev"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.22.0-dev"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -38,7 +38,7 @@ abi3-py312 = ["abi3", "pyo3-build-config/abi3-py312"]
 generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.21.2", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.0-dev", features = ["resolve-config"] }
 
 [lints]
 workspace = true

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.22.0-dev"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,7 +16,7 @@ edition = "2021"
 [dependencies]
 heck = "0.5"
 proc-macro2 = { version = "1", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.21.2", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.0-dev", features = ["resolve-config"] }
 quote = { version = "1", default-features = false }
 
 [dependencies.syn]

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -29,3 +29,4 @@ workspace = true
 
 [features]
 experimental-async = []
+gil-refs = []

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1307,11 +1307,19 @@ fn impl_pytypeinfo(
         quote! { ::core::option::Option::None }
     };
 
-    quote! {
+    #[cfg(feature = "gil-refs")]
+    let has_py_gil_ref = quote! {
         #[allow(deprecated)]
         unsafe impl #pyo3_path::type_object::HasPyGilRef for #cls {
             type AsRefTarget = #pyo3_path::PyCell<Self>;
         }
+    };
+
+    #[cfg(not(feature = "gil-refs"))]
+    let has_py_gil_ref = TokenStream::new();
+
+    quote! {
+        #has_py_gil_ref
 
         unsafe impl #pyo3_path::type_object::PyTypeInfo for #cls {
             const NAME: &'static str = #cls_name;

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -17,6 +17,7 @@ proc-macro = true
 multiple-pymethods = []
 experimental-async = ["pyo3-macros-backend/experimental-async"]
 experimental-declarative-modules = []
+gil-refs = ["pyo3-macros-backend/gil-refs"]
 
 [dependencies]
 proc-macro2 = { version = "1", default-features = false }

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.22.0-dev"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -23,7 +23,7 @@ gil-refs = ["pyo3-macros-backend/gil-refs"]
 proc-macro2 = { version = "1", default-features = false }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.21.2" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.22.0-dev" }
 
 [lints]
 workspace = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "0.21.2"
+version = "0.22.0-dev"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -5,14 +5,12 @@ use crate::inspect::types::TypeInfo;
 use crate::pyclass::boolean_struct::False;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
-use crate::{
-    ffi, Borrowed, Bound, Py, PyAny, PyClass, PyNativeType, PyObject, PyRef, PyRefMut, Python,
-};
+use crate::{ffi, Borrowed, Bound, Py, PyAny, PyClass, PyObject, PyRef, PyRefMut, Python};
 #[cfg(feature = "gil-refs")]
 use {
     crate::{
         err::{self, PyDowncastError},
-        gil,
+        gil, PyNativeType,
     },
     std::ptr::NonNull,
 };
@@ -221,6 +219,7 @@ pub trait FromPyObject<'py>: Sized {
     ///
     /// Implementors are encouraged to implement `extract_bound` and leave this method as the
     /// default implementation, which will forward calls to `extract_bound`.
+    #[cfg(feature = "gil-refs")]
     fn extract(ob: &'py PyAny) -> PyResult<Self> {
         Self::extract_bound(&ob.as_borrowed())
     }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -146,6 +146,7 @@ macro_rules! import_exception_bound {
 
         // FIXME remove this: was necessary while `PyTypeInfo` requires `HasPyGilRef`,
         // should change in 0.22.
+        #[cfg(feature = "gil-refs")]
         unsafe impl $crate::type_object::HasPyGilRef for $name {
             type AsRefTarget = $crate::PyAny;
         }

--- a/src/impl_/deprecations.rs
+++ b/src/impl_/deprecations.rs
@@ -19,6 +19,7 @@ pub struct NotAGilRef<T>(std::marker::PhantomData<T>);
 
 pub trait IsGilRef {}
 
+#[cfg(feature = "gil-refs")]
 impl<T: crate::PyNativeType> IsGilRef for &'_ T {}
 
 impl<T> GilRefs<T> {

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "gil-refs")]
+use crate::PyNativeType;
 use crate::{
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError, PyValueError},
     ffi,
@@ -7,8 +9,7 @@ use crate::{
     pyclass_init::PyObjectInit,
     types::any::PyAnyMethods,
     types::PyBool,
-    Borrowed, Py, PyAny, PyClass, PyErr, PyMethodDefType, PyNativeType, PyResult, PyTypeInfo,
-    Python,
+    Borrowed, Py, PyAny, PyClass, PyErr, PyMethodDefType, PyResult, PyTypeInfo, Python,
 };
 use std::{
     borrow::Cow,
@@ -168,7 +169,12 @@ pub trait PyClassImpl: Sized + 'static {
 
     /// The closest native ancestor. This is `PyAny` by default, and when you declare
     /// `#[pyclass(extends=PyDict)]`, it's `PyDict`.
+    #[cfg(feature = "gil-refs")]
     type BaseNativeType: PyTypeInfo + PyNativeType;
+    /// The closest native ancestor. This is `PyAny` by default, and when you declare
+    /// `#[pyclass(extends=PyDict)]`, it's `PyDict`.
+    #[cfg(not(feature = "gil-refs"))]
+    type BaseNativeType: PyTypeInfo;
 
     /// This handles following two situations:
     /// 1. In case `T` is `Send`, stub `ThreadChecker` is used and does nothing.

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2,6 +2,7 @@ use crate::err::{self, PyErr, PyResult};
 use crate::impl_::pycell::PyClassObject;
 use crate::pycell::{PyBorrowError, PyBorrowMutError};
 use crate::pyclass::boolean_struct::{False, True};
+#[cfg(feature = "gil-refs")]
 use crate::type_object::HasPyGilRef;
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
 use crate::types::{DerefToPyAny, PyDict, PyString, PyTuple};
@@ -667,11 +668,11 @@ impl<'a, 'py, T> From<&'a Bound<'py, T>> for Borrowed<'a, 'py, T> {
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<'py, T> Borrowed<'py, 'py, T>
 where
     T: HasPyGilRef,
 {
-    #[cfg(feature = "gil-refs")]
     pub(crate) fn into_gil_ref(self) -> &'py T::AsRefTarget {
         // Safety: self is a borrow over `'py`.
         #[allow(deprecated)]
@@ -954,6 +955,7 @@ where
     }
 }
 
+#[cfg(feature = "gil-refs")]
 impl<T> Py<T>
 where
     T: HasPyGilRef,
@@ -1001,7 +1003,6 @@ where
     ///     assert!(my_class_cell.try_borrow().is_ok());
     /// });
     /// ```
-    #[cfg(feature = "gil-refs")]
     #[deprecated(
         since = "0.21.0",
         note = "use `obj.bind(py)` instead of `obj.as_ref(py)`"
@@ -1054,7 +1055,6 @@ where
     ///     obj.into_ref(py)
     /// }
     /// ```
-    #[cfg(feature = "gil-refs")]
     #[deprecated(
         since = "0.21.0",
         note = "use `obj.into_bound(py)` instead of `obj.into_ref(py)`"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,15 +320,18 @@ pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPy, ToPyObject};
 #[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 pub use crate::conversion::{FromPyPointer, PyTryFrom, PyTryInto};
-pub use crate::err::{
-    DowncastError, DowncastIntoError, PyDowncastError, PyErr, PyErrArguments, PyResult, ToPyErr,
-};
+#[cfg(feature = "gil-refs")]
+pub use crate::err::PyDowncastError;
+pub use crate::err::{DowncastError, DowncastIntoError, PyErr, PyErrArguments, PyResult, ToPyErr};
 #[allow(deprecated)]
 pub use crate::gil::GILPool;
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
-pub use crate::instance::{Borrowed, Bound, Py, PyNativeType, PyObject};
+#[cfg(feature = "gil-refs")]
+pub use crate::instance::PyNativeType;
+pub use crate::instance::{Borrowed, Bound, Py, PyObject};
 pub use crate::marker::Python;
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 pub use crate::pycell::PyCell;
 pub use crate::pycell::{PyRef, PyRefMut};
@@ -443,6 +446,7 @@ mod conversions;
 pub mod coroutine;
 #[macro_use]
 #[doc(hidden)]
+#[cfg(feature = "gil-refs")]
 pub mod derive_utils;
 mod err;
 pub mod exceptions;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -105,6 +105,7 @@ macro_rules! py_run_impl {
     ($py:expr, *$dict:expr, $code:expr) => {{
         use ::std::option::Option::*;
         #[allow(unused_imports)]
+        #[cfg(feature = "gil-refs")]
         use $crate::PyNativeType;
         if let ::std::result::Result::Err(e) = $py.run_bound($code, None, Some(&$dict.as_borrowed())) {
             e.print($py);

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,11 +15,13 @@ pub use crate::conversion::{PyTryFrom, PyTryInto};
 pub use crate::err::{PyErr, PyResult};
 pub use crate::instance::{Borrowed, Bound, Py, PyObject};
 pub use crate::marker::Python;
+#[cfg(feature = "gil-refs")]
 #[allow(deprecated)]
 pub use crate::pycell::PyCell;
 pub use crate::pycell::{PyRef, PyRefMut};
 pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::types::{PyAny, PyModule};
+#[cfg(feature = "gil-refs")]
 pub use crate::PyNativeType;
 
 #[cfg(feature = "macros")]

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -74,6 +74,7 @@ pub trait PyClassBorrowChecker {
     /// Increments immutable borrow count, if possible
     fn try_borrow(&self) -> Result<(), PyBorrowError>;
 
+    #[cfg(feature = "gil-refs")]
     fn try_borrow_unguarded(&self) -> Result<(), PyBorrowError>;
 
     /// Decrements immutable borrow count
@@ -96,6 +97,7 @@ impl PyClassBorrowChecker for EmptySlot {
     }
 
     #[inline]
+    #[cfg(feature = "gil-refs")]
     fn try_borrow_unguarded(&self) -> Result<(), PyBorrowError> {
         Ok(())
     }
@@ -130,6 +132,7 @@ impl PyClassBorrowChecker for BorrowChecker {
         }
     }
 
+    #[cfg(feature = "gil-refs")]
     fn try_borrow_unguarded(&self) -> Result<(), PyBorrowError> {
         let flag = self.0.get();
         if flag != BorrowFlag::HAS_MUTABLE_BORROW {

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -16,7 +16,20 @@ pub use self::gc::{PyTraverseError, PyVisit};
 /// The `#[pyclass]` attribute implements this trait for your Rust struct -
 /// you shouldn't implement this trait directly.
 #[allow(deprecated)]
+#[cfg(feature = "gil-refs")]
 pub trait PyClass: PyTypeInfo<AsRefTarget = crate::PyCell<Self>> + PyClassImpl {
+    /// Whether the pyclass is frozen.
+    ///
+    /// This can be enabled via `#[pyclass(frozen)]`.
+    type Frozen: Frozen;
+}
+
+/// Types that can be used as Python classes.
+///
+/// The `#[pyclass]` attribute implements this trait for your Rust struct -
+/// you shouldn't implement this trait directly.
+#[cfg(not(feature = "gil-refs"))]
+pub trait PyClass: PyTypeInfo + PyClassImpl {
     /// Whether the pyclass is frozen.
     ///
     /// This can be enabled via `#[pyclass(frozen)]`.

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -31,9 +31,9 @@ pub trait PySizedLayout<T>: PyLayout<T> + Sized {}
 ///
 /// - `Py<Self>::as_ref` will hand out references to `Self::AsRefTarget`.
 /// - `Self::AsRefTarget` must have the same layout as `UnsafeCell<ffi::PyAny>`.
+#[cfg(feature = "gil-refs")]
 pub unsafe trait HasPyGilRef {
     /// Utility type to make Py::as_ref work.
-    #[cfg(feature = "gil-refs")]
     type AsRefTarget: PyNativeType;
 }
 
@@ -44,9 +44,6 @@ where
 {
     type AsRefTarget = Self;
 }
-
-#[cfg(not(feature = "gil-refs"))]
-unsafe impl<T> HasPyGilRef for T {}
 
 /// Python type information.
 /// All Python native types (e.g., `PyDict`) and `#[pyclass]` structs implement this trait.
@@ -61,6 +58,7 @@ unsafe impl<T> HasPyGilRef for T {}
 ///
 /// Implementations must provide an implementation for `type_object_raw` which infallibly produces a
 /// non-null pointer to the corresponding Python type object.
+#[cfg(feature = "gil-refs")]
 pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
     /// Class name.
     const NAME: &'static str;
@@ -139,8 +137,75 @@ pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
     }
 }
 
+/// Python type information.
+/// All Python native types (e.g., `PyDict`) and `#[pyclass]` structs implement this trait.
+///
+/// This trait is marked unsafe because:
+///  - specifying the incorrect layout can lead to memory errors
+///  - the return value of type_object must always point to the same PyTypeObject instance
+///
+/// It is safely implemented by the `pyclass` macro.
+///
+/// # Safety
+///
+/// Implementations must provide an implementation for `type_object_raw` which infallibly produces a
+/// non-null pointer to the corresponding Python type object.
+#[cfg(not(feature = "gil-refs"))]
+pub unsafe trait PyTypeInfo: Sized {
+    /// Class name.
+    const NAME: &'static str;
+
+    /// Module name, if any.
+    const MODULE: Option<&'static str>;
+
+    /// Returns the PyTypeObject instance for this type.
+    fn type_object_raw(py: Python<'_>) -> *mut ffi::PyTypeObject;
+
+    /// Returns the safe abstraction over the type object.
+    #[inline]
+    fn type_object_bound(py: Python<'_>) -> Bound<'_, PyType> {
+        // Making the borrowed object `Bound` is necessary for soundness reasons. It's an extreme
+        // edge case, but arbitrary Python code _could_ change the __class__ of an object and cause
+        // the type object to be freed.
+        //
+        // By making `Bound` we assume ownership which is then safe against races.
+        unsafe {
+            Self::type_object_raw(py)
+                .cast::<ffi::PyObject>()
+                .assume_borrowed_unchecked(py)
+                .to_owned()
+                .downcast_into_unchecked()
+        }
+    }
+
+    /// Checks if `object` is an instance of this type or a subclass of this type.
+    #[inline]
+    fn is_type_of_bound(object: &Bound<'_, PyAny>) -> bool {
+        unsafe { ffi::PyObject_TypeCheck(object.as_ptr(), Self::type_object_raw(object.py())) != 0 }
+    }
+
+    /// Checks if `object` is an instance of this type.
+    #[inline]
+    fn is_exact_type_of_bound(object: &Bound<'_, PyAny>) -> bool {
+        unsafe { ffi::Py_TYPE(object.as_ptr()) == Self::type_object_raw(object.py()) }
+    }
+}
+
 /// Implemented by types which can be used as a concrete Python type inside `Py<T>` smart pointers.
+#[cfg(feature = "gil-refs")]
 pub trait PyTypeCheck: HasPyGilRef {
+    /// Name of self. This is used in error messages, for example.
+    const NAME: &'static str;
+
+    /// Checks if `object` is an instance of `Self`, which may include a subtype.
+    ///
+    /// This should be equivalent to the Python expression `isinstance(object, Self)`.
+    fn type_check(object: &Bound<'_, PyAny>) -> bool;
+}
+
+/// Implemented by types which can be used as a concrete Python type inside `Py<T>` smart pointers.
+#[cfg(not(feature = "gil-refs"))]
+pub trait PyTypeCheck {
     /// Name of self. This is used in error messages, for example.
     const NAME: &'static str;
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1646,7 +1646,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// Extracts some type from the Python object.
     ///
     /// This is a wrapper function around
-    /// [`FromPyObject::extract()`](crate::FromPyObject::extract).
+    /// [`FromPyObject::extract_bound()`](crate::FromPyObject::extract_bound).
     fn extract<'a, T>(&'a self) -> PyResult<T>
     where
         T: FromPyObjectBound<'a, 'py>;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -122,10 +122,12 @@ pub trait DerefToPyAny {
 #[macro_export]
 macro_rules! pyobject_native_type_base(
     ($name:ty $(;$generics:ident)* ) => {
+        #[cfg(feature = "gil-refs")]
         unsafe impl<$($generics,)*> $crate::PyNativeType for $name {
             type AsRefSource = Self;
         }
 
+        #[cfg(feature = "gil-refs")]
         impl<$($generics,)*> ::std::fmt::Debug for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>)
                    -> ::std::result::Result<(), ::std::fmt::Error>
@@ -136,6 +138,7 @@ macro_rules! pyobject_native_type_base(
             }
         }
 
+        #[cfg(feature = "gil-refs")]
         impl<$($generics,)*> ::std::fmt::Display for $name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>)
                    -> ::std::result::Result<(), ::std::fmt::Error>

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -14,7 +14,7 @@ fn test_compile_errors() {
     #[cfg(any(not(Py_LIMITED_API), Py_3_11))]
     t.compile_fail("tests/ui/invalid_pymethods_buffer.rs");
     // The output is not stable across abi3 / not abi3 and features
-    #[cfg(all(not(Py_LIMITED_API), feature = "full"))]
+    #[cfg(all(not(Py_LIMITED_API), feature = "full", not(feature = "gil-refs")))]
     t.compile_fail("tests/ui/invalid_pymethods_duplicates.rs");
     t.compile_fail("tests/ui/invalid_pymethod_enum.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
@@ -27,12 +27,14 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_argument_attributes.rs");
     t.compile_fail("tests/ui/invalid_frompy_derive.rs");
     t.compile_fail("tests/ui/static_ref.rs");
+    #[cfg(not(feature = "gil-refs"))]
     t.compile_fail("tests/ui/wrong_aspyref_lifetimes.rs");
     t.compile_fail("tests/ui/invalid_pyfunctions.rs");
     t.compile_fail("tests/ui/invalid_pymethods.rs");
     // output changes with async feature
     #[cfg(all(Py_LIMITED_API, feature = "experimental-async"))]
     t.compile_fail("tests/ui/abi3_nativetype_inheritance.rs");
+    #[cfg(not(feature = "gil-refs"))]
     t.compile_fail("tests/ui/invalid_intern_arg.rs");
     t.compile_fail("tests/ui/invalid_frozen_pyclass_borrow.rs");
     t.compile_fail("tests/ui/invalid_pymethod_receiver.rs");

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -34,6 +34,12 @@ error: use of deprecated constant `__pyfunction_pyfunction_option_4::SIGNATURE`:
 138 | fn pyfunction_option_4(
     |    ^^^^^^^^^^^^^^^^^^^
 
+error: use of deprecated struct `pyo3::PyCell`: `PyCell` was merged into `Bound`, use that instead; see the migration guide for more info
+  --> tests/ui/deprecations.rs:23:30
+   |
+23 |     fn method_gil_ref(_slf: &PyCell<Self>) {}
+   |                              ^^^^^^
+
 error: use of deprecated method `pyo3::deprecations::GilRefs::<T>::from_py_with_arg`: use `&Bound<'_, PyAny>` as the argument for this `from_py_with` extractor
   --> tests/ui/deprecations.rs:45:44
    |

--- a/tests/ui/invalid_intern_arg.stderr
+++ b/tests/ui/invalid_intern_arg.stderr
@@ -13,5 +13,5 @@ error: lifetime may not live long enough
 5 |     Python::with_gil(|py| py.import_bound(pyo3::intern!(py, _foo)).unwrap());
   |                       --- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
   |                       | |
-  |                       | return type of closure is pyo3::Bound<'2, pyo3::prelude::PyModule>
-  |                       has type `pyo3::Python<'1>`
+  |                       | return type of closure is pyo3::Bound<'2, PyModule>
+  |                       has type `Python<'1>`

--- a/tests/ui/invalid_pymethods_duplicates.stderr
+++ b/tests/ui/invalid_pymethods_duplicates.stderr
@@ -26,23 +26,6 @@ error[E0277]: the trait bound `TwoNew: PyTypeInfo` is not satisfied
             PyDate
           and $N others
 
-error[E0277]: the trait bound `TwoNew: HasPyGilRef` is not satisfied
- --> tests/ui/invalid_pymethods_duplicates.rs:9:6
-  |
-9 | impl TwoNew {
-  |      ^^^^^^ the trait `PyNativeType` is not implemented for `TwoNew`, which is required by `TwoNew: HasPyGilRef`
-  |
-  = help: the trait `HasPyGilRef` is implemented for `pyo3::coroutine::Coroutine`
-  = note: required for `TwoNew` to implement `HasPyGilRef`
-note: required by a bound in `pyo3::PyTypeInfo::NAME`
- --> src/type_object.rs
-  |
-  | pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
-  |                                      ^^^^^^^^^^^ required by this bound in `PyTypeInfo::NAME`
-  |     /// Class name.
-  |     const NAME: &'static str;
-  |           ---- required by a bound in this associated constant
-
 error[E0592]: duplicate definitions with name `__pymethod___new____`
  --> tests/ui/invalid_pymethods_duplicates.rs:8:1
   |

--- a/tests/ui/wrong_aspyref_lifetimes.stderr
+++ b/tests/ui/wrong_aspyref_lifetimes.stderr
@@ -5,4 +5,4 @@ error: lifetime may not live long enough
   |                                                      --- ^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
   |                                                      | |
   |                                                      | return type of closure is &'2 pyo3::Bound<'_, PyDict>
-  |                                                      has type `pyo3::Python<'1>`
+  |                                                      has type `Python<'1>`


### PR DESCRIPTION
Part of #3960

This moves the deprecated `PyCell` and its accompanying APIs behind the `gil-refs` feature gate.

- thread feature gate into `pyo3-macros-backend`
- feature gate `PyNativeType`
- ~feature gate `HasPyGilRef::AsRefTarget` (the trait can be fully removed once the `gil-refs` feature is gone)~
- feature gate `HasPyGilRef`
- feature gate `PyCell`
