### PR TITLE
Lazy-initialize the global reference pool to reduce its overhead when unused

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.63"
 cfg-if = "1.0"
 libc = "0.2.62"
 memoffset = "0.9"
+once_cell = "1"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
 pyo3-ffi = { path = "pyo3-ffi", version = "=0.22.0-dev" }

--- a/newsfragments/4178.changed.md
+++ b/newsfragments/4178.changed.md
@@ -1,0 +1,1 @@
+The global reference pool (to track pending reference count decrements) is now initialized lazily to avoid the overhead of taking a mutex upon function entry when the functionality is not actually used.

--- a/pyo3-benches/benches/bench_pyobject.rs
+++ b/pyo3-benches/benches/bench_pyobject.rs
@@ -1,4 +1,12 @@
-use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
+use codspeed_criterion_compat::{criterion_group, criterion_main, BatchSize, Bencher, Criterion};
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    mpsc::channel,
+    Arc, Barrier,
+};
+use std::thread::spawn;
+use std::time::{Duration, Instant};
 
 use pyo3::prelude::*;
 
@@ -6,14 +14,108 @@ fn drop_many_objects(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         b.iter(|| {
             for _ in 0..1000 {
-                std::mem::drop(py.None());
+                drop(py.None());
             }
         });
     });
 }
 
+fn drop_many_objects_without_gil(b: &mut Bencher<'_>) {
+    b.iter_batched(
+        || {
+            Python::with_gil(|py| {
+                (0..1000)
+                    .map(|_| py.None().into_py(py))
+                    .collect::<Vec<PyObject>>()
+            })
+        },
+        |objs| {
+            drop(objs);
+
+            Python::with_gil(|_py| ());
+        },
+        BatchSize::SmallInput,
+    );
+}
+
+fn drop_many_objects_multiple_threads(b: &mut Bencher<'_>) {
+    const THREADS: usize = 5;
+
+    let barrier = Arc::new(Barrier::new(1 + THREADS));
+
+    let done = Arc::new(AtomicUsize::new(0));
+
+    let sender = (0..THREADS)
+        .map(|_| {
+            let (sender, receiver) = channel();
+
+            let barrier = barrier.clone();
+
+            let done = done.clone();
+
+            spawn(move || {
+                for objs in receiver {
+                    barrier.wait();
+
+                    drop(objs);
+
+                    done.fetch_add(1, Ordering::AcqRel);
+                }
+            });
+
+            sender
+        })
+        .collect::<Vec<_>>();
+
+    b.iter_custom(|iters| {
+        let mut duration = Duration::ZERO;
+
+        let mut last_done = done.load(Ordering::Acquire);
+
+        for _ in 0..iters {
+            for sender in &sender {
+                let objs = Python::with_gil(|py| {
+                    (0..1000 / THREADS)
+                        .map(|_| py.None().into_py(py))
+                        .collect::<Vec<PyObject>>()
+                });
+
+                sender.send(objs).unwrap();
+            }
+
+            barrier.wait();
+
+            let start = Instant::now();
+
+            loop {
+                Python::with_gil(|_py| ());
+
+                let done = done.load(Ordering::Acquire);
+                if done - last_done == THREADS {
+                    last_done = done;
+                    break;
+                }
+            }
+
+            Python::with_gil(|_py| ());
+
+            duration += start.elapsed();
+        }
+
+        duration
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("drop_many_objects", drop_many_objects);
+    c.bench_function(
+        "drop_many_objects_without_gil",
+        drop_many_objects_without_gil,
+    );
+    c.bench_function(
+        "drop_many_objects_multiple_threads",
+        drop_many_objects_multiple_threads,
+    );
 }
 
 criterion_group!(benches, criterion_benchmark);


### PR DESCRIPTION
As an alternative approach to the discussion in #4174 to at least have something concrete to discuss w.r.t. lock-free approaches.

This ensures that we never need more than a single atomic access (albeit acquire-release instead of relaxed) to check for a dirty pool without adding dependencies or depending on implementation details of std.

If the pool is never used, this should be as cheap as having a separate flag. However, if the pool is used, this does add costs to each deferred reference count, i.e. allocating the node and also freeing it when applied. This could be alleviated by allocating blocks of pointers instead of boxing them individually, but I think I would want to use a dependency for that. 