### PR TITLE
[RFC] standardize PyBytes <-> Vec<u8> or &[u8] or Cow<[u8]>

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -4,6 +4,7 @@ use crate::err::PyResult;
 use crate::inspect::types::TypeInfo;
 use crate::pyclass::boolean_struct::False;
 use crate::types::any::PyAnyMethods;
+use crate::types::list::new_from_iter;
 use crate::types::PyTuple;
 use crate::{ffi, Borrowed, Bound, Py, PyAny, PyClass, PyObject, PyRef, PyRefMut, Python};
 #[cfg(feature = "gil-refs")]
@@ -71,6 +72,16 @@ pub unsafe trait AsPyPointer {
 pub trait ToPyObject {
     /// Converts self into a Python object.
     fn to_object(&self, py: Python<'_>) -> PyObject;
+
+    /// Converts slice of self into a Python object
+    fn slice_to_object(slice: &[Self], py: Python<'_>) -> PyObject
+    where
+        Self: Sized,
+    {
+        let mut iter = slice.iter().map(|e| e.to_object(py));
+        let list = new_from_iter(py, &mut iter);
+        list.into()
+    }
 }
 
 /// Defines a conversion from a Rust type to a Python object.

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::any::PyAnyMethods;
+use crate::types::PyBytes;
 use crate::{
     exceptions, ffi, Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
     ToPyObject,
@@ -142,10 +143,42 @@ macro_rules! int_fits_c_long {
 }
 
 int_fits_c_long!(i8);
-int_fits_c_long!(u8);
 int_fits_c_long!(i16);
 int_fits_c_long!(u16);
 int_fits_c_long!(i32);
+
+impl ToPyObject for u8 {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        unsafe { PyObject::from_owned_ptr(py, ffi::PyLong_FromLong(*self as c_long)) }
+    }
+
+    fn slice_to_object(bytes: &[Self], py: Python<'_>) -> PyObject {
+        PyBytes::new_bound(py, bytes).into()
+    }
+}
+
+impl IntoPy<PyObject> for u8 {
+    fn into_py(self, py: Python<'_>) -> PyObject {
+        unsafe { PyObject::from_owned_ptr(py, ffi::PyLong_FromLong(self as c_long)) }
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("int")
+    }
+}
+
+impl<'py> FromPyObject<'py> for u8 {
+    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let val: c_long = extract_int!(obj, -1, ffi::PyLong_AsLong)?;
+        u8::try_from(val).map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_input() -> TypeInfo {
+        Self::type_output()
+    }
+}
 
 // If c_long is 64-bits, we can use more types with int_fits_c_long!:
 #[cfg(all(target_pointer_width = "64", not(target_os = "windows")))]

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -77,13 +77,19 @@ impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for Cow<'a, [u8]> {
     }
 }
 
-impl ToPyObject for Cow<'_, [u8]> {
+impl<T> ToPyObject for Cow<'_, [T]>
+where
+    T: ToPyObject + Clone,
+{
     fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
-        PyBytes::new_bound(py, self.as_ref()).into()
+        T::slice_to_object(self, py)
     }
 }
 
-impl IntoPy<Py<PyAny>> for Cow<'_, [u8]> {
+impl<T> IntoPy<Py<PyAny>> for Cow<'_, [T]>
+where
+    T: ToPyObject + Clone,
+{
     fn into_py(self, py: Python<'_>) -> Py<PyAny> {
         self.to_object(py)
     }

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -8,9 +8,7 @@ where
     T: ToPyObject,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        let mut iter = self.iter().map(|e| e.to_object(py));
-        let list = new_from_iter(py, &mut iter);
-        list.into()
+        T::slice_to_object(self, py)
     }
 }
 
@@ -19,7 +17,7 @@ where
     T: ToPyObject,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.as_slice().to_object(py)
+        T::slice_to_object(self, py)
     }
 }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -2542,7 +2542,7 @@ class SimpleClass:
     #[test]
     fn test_any_is_instance() {
         Python::with_gil(|py| {
-            let l = vec![1u8, 2].to_object(py).into_bound(py);
+            let l = vec![1u16, 2].to_object(py).into_bound(py);
             assert!(l.is_instance(&py.get_type_bound::<PyList>()).unwrap());
         });
     }


### PR DESCRIPTION
When generating `PyBytes` from `Vec<u8>` or `&[u8]` or `Cow<[u8]>` somewhat different behaviors are observed:

```rust
Python::with_gil(|py| {
    let bytes_py = PyBytes::new_bound(py, b"foobar");
    dbg!(&bytes_py);  // &bytes_py = b'foobar'

    let bytes_vec = bytes_py.extract::<Vec<u8>>().unwrap();
    let py_obj = bytes_vec.to_object(py);
    let maybe_py_bytes = py_obj.downcast_bound::<PyBytes>(py);
    dbg!(maybe_py_bytes);  // Err(DowncastError { from: [102, 111, 111, 98, 97, 114], to: "PyBytes" })

    let bytes_slice = bytes_py.extract::<&[u8]>().unwrap();
    let py_obj = bytes_slice.into_py(py);  // to_object(py) does not work!
    let maybe_py_bytes = py_obj.downcast_bound::<PyBytes>(py);
    dbg!(maybe_py_bytes);  // Ok(b'foobar')

    let bytes_cow = bytes_py.extract::<Cow<'_, [u8]>>().unwrap();
    let py_obj = bytes_cow.to_object(py);
    let maybe_py_bytes = py_obj.downcast_bound::<PyBytes>(py);
    dbg!(maybe_py_bytes);  // Ok(b'foobar')

    Ok(())
})
```
Ideally, I would like to be able to handle all 3 convesions the same way, with either `into_py` and/or `to_object`.  I'm not 100% what the best approach would be but I took a stab at `ToPyObject` to showcase how that might work. Would love some feedback on the approach as well as pointers on how to best proceed to address `IntoPy` and `FromPyObject`, assuming all this doable. 

