### PR TITLE
Added `stable_deref_trait::StableDeref` implementation for `PyRef` and `PyRefMut`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ rust-version = "1.63"
 cfg-if = "1.0"
 libc = "0.2.62"
 memoffset = "0.9"
+stable_deref_trait = "1.2.0"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
 pyo3-ffi = { path = "pyo3-ffi", version = "=0.22.0-dev" }

--- a/newsfragments/4195.added.md
+++ b/newsfragments/4195.added.md
@@ -1,0 +1,1 @@
+Added `stable_deref_trait::StableDeref` implementation for `PyRef` and `PyRefMut`.

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -952,6 +952,22 @@ impl<T: PyClass<Frozen = False> + fmt::Debug> fmt::Debug for PyRefMut<'_, T> {
     }
 }
 
+// SAFETY: Moving the `PyRef` does not move the `T` it `deref`s to, and
+// `&mut T` cannot be obtained  while the `PyRef` guard is held.
+unsafe impl<'a, T> stable_deref_trait::StableDeref for PyRef<'a, T>
+where
+    T: PyClass,
+{}
+
+// SAFETY: Moving the `PyRefMut` does not move the `T` it `deref`s or
+// `deref_mut`s to. Even though we could obtain `&mut T` to `mem::swap`
+// out the `T`, there will still be a new `T` at the same address
+// pointed to by the underlying `Py<T>`.
+unsafe impl<'a, T> stable_deref_trait::StableDeref for PyRefMut<'a, T>
+where
+    T: PyClass<Frozen = False>,
+{}
+
 /// An error type returned by [`Bound::try_borrow`].
 ///
 /// If this error is allowed to bubble up into Python code it will raise a `RuntimeError`.


### PR DESCRIPTION
### Introduction
This is a simple change that adds an implementation of the `stable_deref_trait::StableDeref` trait for the `PyRef` and `PyRefMut` RAII guards.  This `unsafe` trait is used by downstream crates as marker for types that `deref` to a stable address that is guaranteed to stay valid for the lifetime of the type (not just the `deref` borrow), which should apply to `PyRef(Mut)`. Implementing this trait enables some powerful synergies with the new `Bound` API, as discussed below.

### Motivation
I have been working a lot with the `Bound` API and the `MyClassMethods` idiom, and I absolutely love it. The `pyclass` macro and related features already provided a powerful interface for using Rust from Python, but the new API has opened up a world of opportunities for using Python from Rust. However, there is one pain point that I have run into in my projects when trying to implement ergonomic Rust interfaces to `PyClass` objects, and this pull request makes it possible to work around it.

Consider the simple case where you want define an extension trait with a method that exposes a reference to a field of your `Bound` pyclass, as discussed in [this section](https://pyo3.rs/v0.21.2/types#using-apis-for-concrete-python-types) of the PyO3 user guide:

```rust
use pyo3::prelude::*;

#[pyclass]
pub struct MyClass {
    data: [i32; 100]
}

pub trait MyClassMethods<'py> {
    fn data(&self) -> &[i32; 100];
}

impl<'py> MyClassMethods<'py> for Bound<'py, MyClass> {
    fn data(&self) -> &[i32; 100] {
        &self.borrow().data
    }
}
```
This is clearly not possible, since the borrowed `PyRef` gets dropped when the function returns and we cannot return a reference to the data it guards. Of course, this is not unique to `Bound`/`PyRef`; the same problem would arise if we tried to return a reference to data borrowed from a `RefCell` which needs the `Ref` guard to stay alive. 

In simple cases like this you could find a way work around it, such as by making the `data` field public and have the `Bound<MyClass>` user explicitly borrow a `PyRef` to access it, but this puts a significant limitation on the API's you can provide in more complex use cases.

The [`owning_ref`](https://docs.rs/owning_ref/latest/owning_ref) crate provides a clever solution to this limitation by packaging the the RAII guard alongside the reference (as `*const T`) in an [`OwningRef`](https://docs.rs/owning_ref/latest/owning_ref/struct.OwningRef.html) struct that `deref`s to the desired reference. By returning this struct instead of a bare `&T`, you are effectively able to return a reference to the field while keeping the `PyRef` guard alive to safely protect it:

```rust
use pyo3::prelude::*;
use owning_ref::OwningRef;

pub type OwningPyRef<'py, C, T> = OwningRef<PyRef<'py, C>, T>;

#[pyclass]
pub struct MyClass {
    data: [i32; 100]
}

pub trait MyClassMethods<'py> {
    fn data(&self) -> OwningPyRef<'py, MyClass, [i32; 100]>;
}

impl<'py> MyClassMethods<'py> for Bound<'py, MyClass> {
    fn data(&self) -> OwningPyRef<'py, MyClass, [i32; 100]> {
        OwningRef::new(self.borrow()).map(|c| &c.data)
    }
}

fn data_sum(obj: Bound<MyClass>) -> i32 {
    obj.data().iter().sum()
}
```
This now works! And the same process can be applied to expose `&mut T` by wrapping `PyRefMuf` in an `OwnedRefMut`.

The only obstacle is that the `OwningRef` methods require `Bound<MyClass>` to implement [`stable_deref_trait::StableDeref`](https://docs.rs/stable_deref_trait/1.2.0/stable_deref_trait/trait.StableDeref.html) (which it reexports as `StableAddress`), which can only be done within the `pyo3` crate thanks to the orphan rule (so I have had to use a newtype wrapper as a workaround). This PR hopes to fix that and make this ergonomic solution possible .

### Safety
Since `StableDeref` is an `unsafe` trait, the safety of implementing it for `PyRef` and `PyRefMut` must be considered. The [contract for implementing this trait](https://docs.rs/stable_deref_trait/1.2.0/stable_deref_trait/trait.StableDeref.html) requires that the `PyRef(Mut)` will dereference to a stable address for the duration of its lifetime even when moved, and that the result of calling `deref` will also stay alive for this duration (not only for the duration of the `&self` lifetime of the `deref` call).

I am fairly certain that this condition is met for `PyRef` and `PyRefMut`, which exist for the sole purpose of guarding access to the underlying `Py` pointer until they are dropped, but please double-check my reasoning in case there are any edge cases that I am missing. For reference, this trait is safely implemented for the `Ref` and `RefMut` guards borrowed from a `RefCell`, which are direct analogues to `PyRef` and `PyRefMut`.

### Considerations 
- Implementing this trait requires adding a dependency on the `stable_deref_trait` crate. This crate is mature (with 62 million downloads on [crates.io](https://crates.io/crates/stable_deref_trait)), dual-licensed under MIT/Apache-2.0, and extremely lightweight (with no other dependencies), so I don't see a problem with adding the dependency. That said, l could put it behind a feature flag if you would prefer,
- As mentioned in the [Safety]() section, this is an `unsafe` trait so the PR reviewer should careful consider whether the contract is met, and whether that could change in the future.
- I did my best at adding SAFETY comments to the new `impl`s to justify the `unsafe`, but there may be better ways to word them. Or the comments _could_ be removed if you think the justification is self-evident and they only add clutter; this seems to be how it was done for many of the other `unsafe impl`s.

Thank you for your time in considering this PR! If you have any question or concerns I would be happy to iterate on a solution.