### PR TITLE
adding new getter for type obj

### DIFF
--- a/newsfragments/4197.added.md
+++ b/newsfragments/4197.added.md
@@ -1,1 +1,1 @@
-Adding new type getter that works like __mro__ and __bases__ in Python.
+Add `PyTypeMethods::mro` and `PyTypeMethods::bases`.

--- a/newsfragments/4197.added.md
+++ b/newsfragments/4197.added.md
@@ -1,0 +1,1 @@
+Adding new type getter that works like __mro__ and __bases__ in Python.

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -193,7 +193,7 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
 
     fn mro(&self) -> PyResult<Bound<'py, PyTuple>> {
         #[cfg(any(Py_LIMITED_API, PyPy))]
-        let mro = self.getattr(intern!(self.py(), "__mro__"))?.extract();
+        let mro = self.getattr(intern!(self.py(), "__mro__"))?.extract()?;
 
         #[cfg(not(any(Py_LIMITED_API, PyPy)))]
         let mro = unsafe {
@@ -202,14 +202,14 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
                 .assume_borrowed_or_err(self.py())
         }?
         .to_owned()
-        .downcast_into();
+        .downcast_into()?;
 
-        Ok(mro?)
+        Ok(mro)
     }
 
     fn bases(&self) -> PyResult<Bound<'py, PyTuple>> {
         #[cfg(any(Py_LIMITED_API, PyPy))]
-        let bases = self.getattr(intern!(self.py(), "__bases__"))?.extract();
+        let bases = self.getattr(intern!(self.py(), "__bases__"))?.extract()?;
 
         #[cfg(not(any(Py_LIMITED_API, PyPy)))]
         let bases = unsafe {
@@ -218,9 +218,9 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
                 .assume_borrowed_or_err(self.py())
         }?
         .to_owned()
-        .downcast_into();
+        .downcast_into()?;
 
-        Ok(bases?)
+        Ok(bases)
     }
 }
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -131,9 +131,9 @@ pub trait PyTypeMethods<'py>: crate::sealed::Sealed {
     where
         T: PyTypeInfo;
 
-    /// Return Python mro
+    /// Return the method resolution order for this type.
     ///
-    /// Equivalent to the Python expression `__mro__`.
+    /// Equivalent to the Python expression `self.__mro__`.
     fn mro(&self) -> PyResult<Bound<'_, PyTuple>>;
 
     /// Return Python bases

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -134,7 +134,7 @@ pub trait PyTypeMethods<'py>: crate::sealed::Sealed {
     /// Return the method resolution order for this type.
     ///
     /// Equivalent to the Python expression `self.__mro__`.
-    fn mro(&self) -> PyResult<Bound<'_, PyTuple>>;
+    fn mro(&self) -> PyResult<Bound<'py, PyTuple>>;
 
     /// Return Python bases
     ///

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -193,36 +193,40 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
 
     fn mro(&self) -> Bound<'py, PyTuple> {
         #[cfg(any(Py_LIMITED_API, PyPy))]
-        let mro = self.getattr(intern!(self.py(), "__mro__"))
-        .expect("Cannot get `__mro__` from object.")
-        .extract()
-        .expect("Cannot convert to Rust object.");
+        let mro = self
+            .getattr(intern!(self.py(), "__mro__"))
+            .expect("Cannot get `__mro__` from object.")
+            .extract()
+            .expect("Cannot convert to Rust object.");
 
         #[cfg(not(any(Py_LIMITED_API, PyPy)))]
         let mro = unsafe {
             (*self.as_type_ptr())
                 .tp_mro
                 .assume_borrowed(self.py())
-        .to_owned()
-        .downcast_into_unchecked()};
+                .to_owned()
+                .downcast_into_unchecked()
+        };
 
         mro
     }
 
     fn bases(&self) -> Bound<'py, PyTuple> {
         #[cfg(any(Py_LIMITED_API, PyPy))]
-        let bases = self.getattr(intern!(self.py(), "__bases__"))
-        .expect("Cannot get `__bases__` from object.")
-        .extract()
-        .expect("Cannot convert to Rust object.");
+        let bases = self
+            .getattr(intern!(self.py(), "__bases__"))
+            .expect("Cannot get `__bases__` from object.")
+            .extract()
+            .expect("Cannot convert to Rust object.");
 
         #[cfg(not(any(Py_LIMITED_API, PyPy)))]
         let bases = unsafe {
             (*self.as_type_ptr())
                 .tp_bases
                 .assume_borrowed(self.py())
-        .to_owned()
-        .downcast_into_unchecked()};
+                .to_owned()
+                .downcast_into_unchecked()
+        };
 
         bases
     }

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -216,7 +216,7 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
             .getattr(intern!(self.py(), "__bases__"))
             .expect("Cannot get `__bases__` from object.")
             .extract()
-            .expect("Cannot convert to Rust object.");
+            .expect("Unexpected type in `__bases__` attribute.");
 
         #[cfg(not(any(Py_LIMITED_API, PyPy)))]
         let bases = unsafe {

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -138,7 +138,7 @@ pub trait PyTypeMethods<'py>: crate::sealed::Sealed {
 
     /// Return Python bases
     ///
-    /// Equivalent to the Python expression `__bases__`.
+    /// Equivalent to the Python expression `self.__bases__`.
     fn bases(&self) -> PyResult<Bound<'py, PyTuple>>;
 }
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -195,7 +195,7 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
             .getattr(intern!(self.py(), "__mro__"))
             .expect("Cannot get `__mro__` from object.")
             .extract()
-            .expect("Cannot convert to Rust object.");
+            .expect("Unexpected type in `__mro__` attribute.");
 
         #[cfg(not(any(Py_LIMITED_API, PyPy)))]
         let mro = unsafe {

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -1,4 +1,5 @@
 use crate::err::{self, PyResult};
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Borrowed;
 use crate::types::any::PyAnyMethods;
@@ -201,9 +202,9 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
                 .assume_borrowed_or_err(self.py())
         }?
         .to_owned()
-        .downcast_into()?;
+        .downcast_into();
 
-        Ok(mro)
+        Ok(mro?)
     }
 
     fn bases(&self) -> PyResult<Bound<'py, PyTuple>> {
@@ -217,9 +218,9 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
                 .assume_borrowed_or_err(self.py())
         }?
         .to_owned()
-        .downcast_into()?;
+        .downcast_into();
 
-        Ok(bases)
+        Ok(bases?)
     }
 }
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -1,6 +1,8 @@
 use crate::err::{self, PyResult};
+use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Borrowed;
 use crate::types::any::PyAnyMethods;
+use crate::types::PyTuple;
 #[cfg(feature = "gil-refs")]
 use crate::PyNativeType;
 use crate::{ffi, Bound, PyAny, PyTypeInfo, Python};
@@ -127,6 +129,16 @@ pub trait PyTypeMethods<'py>: crate::sealed::Sealed {
     fn is_subclass_of<T>(&self) -> PyResult<bool>
     where
         T: PyTypeInfo;
+
+    /// Return Python mro
+    ///
+    /// Equivalent to the Python expression `__mro__`.
+    fn mro(&self) -> PyResult<Bound<'_, PyTuple>>;
+
+    /// Return Python bases
+    ///
+    /// Equivalent to the Python expression `__bases__`.
+    fn bases(&self) -> PyResult<Bound<'_, PyTuple>>;
 }
 
 impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
@@ -177,6 +189,38 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
     {
         self.is_subclass(&T::type_object_bound(self.py()))
     }
+
+    fn mro(&self) -> PyResult<Bound<'py, PyTuple>> {
+        #[cfg(any(Py_LIMITED_API, PyPy))]
+        let mro = self.getattr(intern!(self.py(), "__mro__"))?.extract();
+
+        #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+        let mro = unsafe {
+            (*self.as_type_ptr())
+                .tp_mro
+                .assume_borrowed_or_err(self.py())
+        }?
+        .to_owned()
+        .downcast_into()?;
+
+        Ok(mro)
+    }
+
+    fn bases(&self) -> PyResult<Bound<'py, PyTuple>> {
+        #[cfg(any(Py_LIMITED_API, PyPy))]
+        let bases = self.getattr(intern!(self.py(), "__bases__"))?.extract();
+
+        #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+        let bases = unsafe {
+            (*self.as_type_ptr())
+                .tp_bases
+                .assume_borrowed_or_err(self.py())
+        }?
+        .to_owned()
+        .downcast_into()?;
+
+        Ok(bases)
+    }
 }
 
 impl<'a> Borrowed<'a, '_, PyType> {
@@ -215,8 +259,8 @@ impl<'a> Borrowed<'a, '_, PyType> {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::typeobject::PyTypeMethods;
-    use crate::types::{PyBool, PyLong};
+    use crate::types::{PyAnyMethods, PyBool, PyInt, PyLong, PyTuple, PyTypeMethods};
+    use crate::PyAny;
     use crate::Python;
 
     #[test]
@@ -234,6 +278,49 @@ mod tests {
             assert!(py
                 .get_type_bound::<PyBool>()
                 .is_subclass_of::<PyLong>()
+                .unwrap());
+        });
+    }
+
+    #[test]
+    fn test_mro() {
+        Python::with_gil(|py| {
+            assert!(py
+                .get_type_bound::<PyBool>()
+                .mro()
+                .unwrap()
+                .eq(PyTuple::new_bound(
+                    py,
+                    [
+                        py.get_type_bound::<PyBool>(),
+                        py.get_type_bound::<PyInt>(),
+                        py.get_type_bound::<PyAny>()
+                    ]
+                ))
+                .unwrap());
+        });
+    }
+
+    #[test]
+    fn test_bases_bool() {
+        Python::with_gil(|py| {
+            assert!(py
+                .get_type_bound::<PyBool>()
+                .bases()
+                .unwrap()
+                .eq(PyTuple::new_bound(py, [py.get_type_bound::<PyInt>()]))
+                .unwrap());
+        });
+    }
+
+    #[test]
+    fn test_bases_object() {
+        Python::with_gil(|py| {
+            assert!(py
+                .get_type_bound::<PyAny>()
+                .bases()
+                .unwrap()
+                .eq(PyTuple::empty_bound(py))
                 .unwrap());
         });
     }

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -139,7 +139,7 @@ pub trait PyTypeMethods<'py>: crate::sealed::Sealed {
     /// Return Python bases
     ///
     /// Equivalent to the Python expression `__bases__`.
-    fn bases(&self) -> PyResult<Bound<'_, PyTuple>>;
+    fn bases(&self) -> PyResult<Bound<'py, PyTuple>>;
 }
 
 impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -1,6 +1,4 @@
 use crate::err::{self, PyResult};
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
-use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Borrowed;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
@@ -201,6 +199,7 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
 
         #[cfg(not(any(Py_LIMITED_API, PyPy)))]
         let mro = unsafe {
+            use crate::ffi_ptr_ext::FfiPtrExt;
             (*self.as_type_ptr())
                 .tp_mro
                 .assume_borrowed(self.py())
@@ -221,6 +220,7 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
 
         #[cfg(not(any(Py_LIMITED_API, PyPy)))]
         let bases = unsafe {
+            use crate::ffi_ptr_ext::FfiPtrExt;
             (*self.as_type_ptr())
                 .tp_bases
                 .assume_borrowed(self.py())


### PR DESCRIPTION
Adding new getter that works like `__mro__` and `__bases__` in Python. 

closes #4192 