### PR TITLE
ci: adjust test to avoid type inference

### DIFF
--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -291,9 +291,9 @@ mod test {
     #[test]
     fn py_backed_bytes_empty() {
         Python::with_gil(|py| {
-            let b = PyBytes::new_bound(py, &[]);
+            let b = PyBytes::new_bound(py, b"");
             let py_backed_bytes = b.extract::<PyBackedBytes>().unwrap();
-            assert_eq!(&*py_backed_bytes, &[]);
+            assert_eq!(&*py_backed_bytes, b"");
         });
     }
 


### PR DESCRIPTION
Watching new collaborators work at the PyCon sprints this week, this test frequently appears alongside other compile errors with type inference failures. I'm not entirely sure why the compiler only breaks this _sometimes_, but it's clearly unhelpful for new collaborators to see this.

I think changing a test from `&[]` to `b""` is not going to need debate, so I'll merge this immediately.