### PR TITLE
fix calling POOL.update_counts() when no `gil-refs` feature

### DIFF
--- a/src/gil.rs
+++ b/src/gil.rs
@@ -219,15 +219,15 @@ impl GILGuard {
             return Self::assume();
         }
 
-        let gstate = unsafe { ffi::PyGILState_Ensure() }; // acquire GIL
+        let gstate = ffi::PyGILState_Ensure(); // acquire GIL
         increment_gil_count();
 
         #[cfg(feature = "gil-refs")]
         #[allow(deprecated)]
-        let pool = unsafe { mem::ManuallyDrop::new(GILPool::new()) };
+        let pool = mem::ManuallyDrop::new(GILPool::new());
 
         #[cfg(not(pyo3_disable_reference_pool))]
-        POOL.update_counts(unsafe { Python::assume_gil_acquired() });
+        POOL.update_counts(Python::assume_gil_acquired());
         GILGuard::Ensured {
             gstate,
             #[cfg(feature = "gil-refs")]

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -587,7 +587,7 @@ mod tests {
             .contains(&unsafe { NonNull::new_unchecked(obj.as_ptr()) })
     }
 
-    #[cfg(all(not(pyo3_disable_reference_pool), not(target_arch = "wasm32")))]
+    #[cfg(all(not(pyo3_disable_reference_pool)))]
     fn pool_dec_refs_contains(obj: &PyObject) -> bool {
         POOL.pending_decrefs
             .lock()

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -587,7 +587,7 @@ mod tests {
             .contains(&unsafe { NonNull::new_unchecked(obj.as_ptr()) })
     }
 
-    #[cfg(all(not(pyo3_disable_reference_pool)))]
+    #[cfg(not(pyo3_disable_reference_pool))]
     fn pool_dec_refs_contains(obj: &PyObject) -> bool {
         POOL.pending_decrefs
             .lock()

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -717,19 +717,19 @@ mod tests {
             assert_eq!(get_gil_count(), 1);
 
             let pool = unsafe { GILGuard::assume() };
-            assert_eq!(get_gil_count(), 1);
+            assert_eq!(get_gil_count(), 2);
 
             let pool2 = unsafe { GILGuard::assume() };
-            assert_eq!(get_gil_count(), 1);
+            assert_eq!(get_gil_count(), 3);
 
             drop(pool);
-            assert_eq!(get_gil_count(), 1);
+            assert_eq!(get_gil_count(), 2);
 
             Python::with_gil(|_| {
-                // nested with_gil doesn't update gil count
-                assert_eq!(get_gil_count(), 1);
+                // nested with_gil updates gil count
+                assert_eq!(get_gil_count(), 3);
             });
-            assert_eq!(get_gil_count(), 1);
+            assert_eq!(get_gil_count(), 2);
 
             drop(pool2);
             assert_eq!(get_gil_count(), 1);

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1282,6 +1282,7 @@ mod tests {
 
         // Before starting the interpreter the state of calling `PyGILState_Check`
         // seems to be undefined, so let's ensure that Python is up.
+        #[cfg(not(any(PyPy, GraalPy)))]
         crate::prepare_freethreaded_python();
 
         let state = unsafe { crate::ffi::PyGILState_Check() };

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1280,6 +1280,10 @@ mod tests {
         const GIL_NOT_HELD: c_int = 0;
         const GIL_HELD: c_int = 1;
 
+        // Before starting the interpreter the state of calling `PyGILState_Check`
+        // seems to be undefined, so let's ensure that Python is up.
+        crate::prepare_freethreaded_python();
+
         let state = unsafe { crate::ffi::PyGILState_Check() };
         assert_eq!(state, GIL_NOT_HELD);
 


### PR DESCRIPTION
While testing #4178 I noticed that it looks like we accidentally stopped calling `POOL.update_counts` without the `gil-refs` feature enabled (probably in #4188).

This rearranges code a little bit so that calling `GILGuard::assume` and `GILGuard::acquire` always call `POOL.update_counts`, and adds a test for this.

cc @alex