### PR TITLE
remove internal APIs from pyo3-ffi

### DIFF
--- a/newsfragments/4201.changed.md
+++ b/newsfragments/4201.changed.md
@@ -1,0 +1,1 @@
+Remove CPython internal ffi call for complex number including: add, sub, mul, div, neg, abs, pow

--- a/newsfragments/4201.changed.md
+++ b/newsfragments/4201.changed.md
@@ -1,1 +1,1 @@
-Remove CPython internal ffi call for complex number including: add, sub, mul, div, neg, abs, pow
+Remove CPython internal ffi call for complex number including: add, sub, mul, div, neg, abs, pow. Added PyAnyMethods::{abs, pos, neg}

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1127,7 +1127,9 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     where
         O: ToPyObject;
 
-    /// Computes the negative of self or `-self`.
+    /// Computes the negative of self.
+    ///
+    /// Equivalent to the Python expression `-self`.
     fn neg(&self) -> PyResult<Bound<'py, PyAny>>;
 
     /// Computes the positive of self.

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1133,9 +1133,13 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     fn neg(&self) -> PyResult<Bound<'py, PyAny>>;
 
     /// Computes the positive of self.
+    ///
+    /// Equivalent to the Python expression `+self`.
     fn pos(&self) -> PyResult<Bound<'py, PyAny>>;
 
-    /// Computes the absolute of self or `|self|`.
+    /// Computes the absolute of self.
+    ///
+    /// Equivalent to the Python expression `abs(self)`.
     fn abs(&self) -> PyResult<Bound<'py, PyAny>>;
 
     /// Tests whether this object is less than another.

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1127,6 +1127,15 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     where
         O: ToPyObject;
 
+    /// Computes the negative of self or `-self`.
+    fn neg(&self) -> PyResult<Bound<'py, PyAny>>;
+
+    /// Computes the positive of self.
+    fn pos(&self) -> PyResult<Bound<'py, PyAny>>;
+
+    /// Computes the absolute of self or `|self|`.
+    fn abs(&self) -> PyResult<Bound<'py, PyAny>>;
+
     /// Tests whether this object is less than another.
     ///
     /// This is equivalent to the Python expression `self < other`.
@@ -1860,6 +1869,30 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
         let py = self.py();
         inner(self, other.to_object(py).into_bound(py), compare_op)
+    }
+
+    fn neg(&self) -> PyResult<Bound<'py, PyAny>> {
+        fn inner<'py>(any: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+            unsafe { ffi::PyNumber_Negative(any.as_ptr()).assume_owned_or_err(any.py()) }
+        }
+
+        inner(self)
+    }
+
+    fn pos(&self) -> PyResult<Bound<'py, PyAny>> {
+        fn inner<'py>(any: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+            unsafe { ffi::PyNumber_Positive(any.as_ptr()).assume_owned_or_err(any.py()) }
+        }
+
+        inner(self)
+    }
+
+    fn abs(&self) -> PyResult<Bound<'py, PyAny>> {
+        fn inner<'py>(any: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+            unsafe { ffi::PyNumber_Absolute(any.as_ptr()).assume_owned_or_err(any.py()) }
+        }
+
+        inner(self)
     }
 
     fn lt<O>(&self, other: O) -> PyResult<bool>

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1872,11 +1872,7 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     }
 
     fn neg(&self) -> PyResult<Bound<'py, PyAny>> {
-        fn inner<'py>(any: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
-            unsafe { ffi::PyNumber_Negative(any.as_ptr()).assume_owned_or_err(any.py()) }
-        }
-
-        inner(self)
+        unsafe { ffi::PyNumber_Negative(self.as_ptr()).assume_owned_or_err(self.py()) }
     }
 
     fn pos(&self) -> PyResult<Bound<'py, PyAny>> {

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -147,9 +147,12 @@ mod not_limited_impls {
         type Output = Bound<'py, PyComplex>;
         fn neg(self) -> Self::Output {
             self.as_borrowed()
-            .getattr("__neg__").expect("Cannot find `__neg__` method.")
-            .call0().expect("Failed to call `__neg__` method.")
-            .downcast_into().expect("Failed to downcast to complex number.")
+                .getattr("__neg__")
+                .expect("Cannot find `__neg__` method.")
+                .call0()
+                .expect("Failed to call `__neg__` method.")
+                .downcast_into()
+                .expect("Failed to downcast to complex number.")
         }
     }
 
@@ -279,17 +282,22 @@ impl<'py> PyComplexMethods<'py> for Bound<'py, PyComplex> {
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn abs(&self) -> c_double {
         self.as_borrowed()
-        .getattr("__abs__").expect("Cannot find `__abs__` method.")
-        .call0().expect("Failed to call `__abs__` method.")
-        .downcast_into().expect("Failed to downcast to complex number.")
-        .extract().expect("Failed to extract to c double.")
+            .getattr("__abs__")
+            .expect("Cannot find `__abs__` method.")
+            .call0()
+            .expect("Failed to call `__abs__` method.")
+            .downcast_into()
+            .expect("Failed to downcast to complex number.")
+            .extract()
+            .expect("Failed to extract to c double.")
     }
 
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn pow(&self, other: &Bound<'py, PyComplex>) -> Bound<'py, PyComplex> {
         Python::with_gil(|py| {
             PyAnyMethods::pow(self.as_any(), other, py.None())
-            .downcast_into().expect("Complex method __pow__ failed.")
+                .downcast_into()
+                .expect("Complex method __pow__ failed.")
         })
     }
 }

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
 use crate::py_result_ext::PyResultExt;
 #[cfg(feature = "gil-refs")]
 use crate::PyNativeType;

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -1,7 +1,7 @@
+use crate::py_result_ext::PyResultExt;
 #[cfg(feature = "gil-refs")]
 use crate::PyNativeType;
 use crate::{ffi, types::any::PyAnyMethods, Bound, PyAny, Python};
-use crate::py_result_ext::PyResultExt;
 use std::os::raw::c_double;
 
 /// Represents a Python [`complex`](https://docs.python.org/3/library/functions.html#complex) object.

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -1,3 +1,4 @@
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
 use crate::py_result_ext::PyResultExt;
 #[cfg(feature = "gil-refs")]
 use crate::PyNativeType;

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -146,13 +146,9 @@ mod not_limited_impls {
     impl<'py> Neg for Borrowed<'_, 'py, PyComplex> {
         type Output = Bound<'py, PyComplex>;
         fn neg(self) -> Self::Output {
-            self.as_borrowed()
-                .getattr("__neg__")
-                .expect("Cannot find `__neg__` method.")
-                .call0()
-                .expect("Failed to call `__neg__` method.")
+            PyAnyMethods::neg(self.as_any())
                 .downcast_into()
-                .expect("Failed to downcast to complex number.")
+                .expect("Complex method __neg__ failed.")
         }
     }
 
@@ -281,13 +277,9 @@ impl<'py> PyComplexMethods<'py> for Bound<'py, PyComplex> {
 
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn abs(&self) -> c_double {
-        self.as_borrowed()
-            .getattr("__abs__")
-            .expect("Cannot find `__abs__` method.")
-            .call0()
-            .expect("Failed to call `__abs__` method.")
+        PyAnyMethods::abs(self.as_any())
             .downcast_into()
-            .expect("Failed to downcast to complex number.")
+            .expect("Complex method __abs__ failed.")
             .extract()
             .expect("Failed to extract to c double.")
     }


### PR DESCRIPTION
Using methods from PyAny to replace calling _Py internal APIS from pyo3-ffi.

see #3762 