### PR TITLE
Added `PyRefMap` and `PyRefMapMut` for borrowing data nested `PyRef`/`PyRefMut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,6 +494,7 @@ mod macros;
 
 #[cfg(feature = "experimental-inspect")]
 pub mod inspect;
+mod pyref_map;
 
 /// Ths module only contains re-exports of pyo3 deprecation warnings and exists
 /// purely to make compiler error messages nicer.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,6 +19,7 @@ pub use crate::marker::Python;
 #[allow(deprecated)]
 pub use crate::pycell::PyCell;
 pub use crate::pycell::{PyRef, PyRefMut};
+pub use crate::pyref_map::{PyRefMap};
 pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::types::{PyAny, PyModule};
 #[cfg(feature = "gil-refs")]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,7 +19,7 @@ pub use crate::marker::Python;
 #[allow(deprecated)]
 pub use crate::pycell::PyCell;
 pub use crate::pycell::{PyRef, PyRefMut};
-pub use crate::pyref_map::{PyRefMap};
+pub use crate::pyref_map::{PyRefMap, PyRefMapMut};
 pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::types::{PyAny, PyModule};
 #[cfg(feature = "gil-refs")]

--- a/src/pyref_map.rs
+++ b/src/pyref_map.rs
@@ -1,64 +1,98 @@
-#![allow(unused_imports, dead_code)]
 
 use std::ptr::NonNull;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
-use std::convert::{AsRef, AsMut};
 
-use crate::prelude::*;
 use crate::pyclass::PyClass;
+use crate::pycell::{PyRef, PyRefMut};
 use crate::pyclass::boolean_struct::{True, False, private::Boolean};
 
 
+/// Represents a `PyRef` or `PyRefMut` with an opaque pyclass type.
 trait OpaquePyRef<'py>: 'py {}
 
 impl<'py, T: PyClass> OpaquePyRef<'py> for PyRef<'py, T> {}
 impl<'py, T: PyClass<Frozen=False>> OpaquePyRef<'py> for PyRefMut<'py, T> {}
 
 
+/// Base wrapper type for a [`PyRef<'py, T>`] or [`PyRefMut<'py, T>`] that 
+/// dereferences to data of type `U` that is nested within a pyclass `T` 
+/// instead of `T` itself. 
+/// 
+/// See the type aliases [`PyRefMap<'py, U>`] and [`PyRefMapMut<'py, U>`] 
+/// for more information.
 pub struct PyRefMapBase<'py, U: 'py, Mut: Boolean> {
+    // Either `PyRef` or `PyRefMut` guarding the opaque pyclass from which 
+    // the target is borrowed. 
     owner: Box<dyn OpaquePyRef<'py>>,
+    // Pointer to the `Deref` target which is (probably) borrowed from `owner`.
+    // This pointer is derived from either `&U` or `&mut U` as  indicated by 
+    // the `Mut` parameter.
     target: NonNull<U>,
+    // Marks whether mutable methods are supported. If `Mut` is `True` then 
+    // `owner` is a `PyRefMut` and `target` was derived from `&mut U`, so 
+    // the pointer may be mutably dereferenced safely; if `False`, then 
+    // `owner` may be either `PyRef` or `PyRefMut` and `target` was derived 
+    // from `&U` so mutable dereferencing is forbidden.
     _mut: PhantomData<Mut>
 }
 
+/// A wrapper type for an _immutable_ reference to data of type `U` that is 
+/// nested within a [`PyRef<'py, T>`] or [`PyRefMut<'py, T>`].
 pub type PyRefMap<'py, U> = PyRefMapBase<'py, U, False>;
+
+/// A wrapper type for a _mutable_ reference to data of type `U` that is 
+/// nested within a [`PyRefMut<'py, T>`].
 pub type PyRefMapMut<'py, U> = PyRefMapBase<'py, U, True>;
 
 
-impl<'py, T: PyClass> PyRef<'py, T> {
-    pub fn into_map<F, U: 'py>(self, f: F) -> PyRefMap<'py, U>
-        where F: FnOnce(&T) -> &U
-    {
-        let target = NonNull::from(f(&*self));
-        PyRefMap {target, owner: Box::new(self), _mut: PhantomData}
-    }
+impl<'py, T: PyClass> PyRefMap<'py, T> {
     
-    pub fn try_into_map<F, U: 'py, E>(self, f: F) -> Result<PyRefMap<'py, U>, E>
-        where F: FnOnce(&T) -> Result<&U, E>
+    /// Construct a no-op `PyRefMap` that dereferences to the same 
+    /// value as the given [`PyRef`] or [`PyRefMut`].
+    pub fn new<R>(owner: R) -> PyRefMap<'py, T> 
+        where R: OpaquePyRef<'py> + Deref<Target=T>,
     {
-        let target = NonNull::from(f(&*self)?);
-        Ok(PyRefMap {target, owner: Box::new(self), _mut: PhantomData})
+        let target = NonNull::from(&*owner);
+        PyRefMap {target, owner: Box::new(owner), _mut: PhantomData}
     }
 }
 
-impl<'py, T: PyClass<Frozen = False>> PyRefMut<'py, T> {
+impl<'py, T: PyClass<Frozen = False>> PyRefMapMut<'py, T> {
     
-    pub fn into_map<F, U: 'py>(self, f: F) -> PyRefMap<'py, U>
-        where F: FnOnce(&T) -> &U
+    /// Construct a no-op `PyRefMapMut` that dereferences to the same 
+    /// value as the given [`PyRefMut`].
+    pub fn new(mut owner: PyRefMut<'py, T>) -> PyRefMapMut<'py, T> {
+        let target = NonNull::from(&mut *owner);
+        PyRefMapMut {target, owner: Box::new(owner), _mut: PhantomData}
+    }
+}
+
+impl<'py, U: 'py, Mut: Boolean> PyRefMapBase<'py, U, Mut> {
+    
+    /// Applies the given function to the wrapped reference and wrap the 
+    /// return value in a new `PyRefMap`.
+    pub fn map<F, V>(mut self, f: F) -> PyRefMap<'py, V> 
+        where F: FnOnce(&U) -> &V
     {
         let target = NonNull::from(f(&*self));
-        PyRefMap {target, owner: Box::new(self), _mut: PhantomData}
+        PyRefMap {target, owner: self.owner, _mut: PhantomData}
     }
+}
+
+impl<'py, U: 'py> PyRefMapMut<'py, U> {
     
-    pub fn into_map_mut<F, U: 'py>(mut self, f: F) -> PyRefMapMut<'py, U>
-        where F: FnOnce(&mut T) -> &mut U
+    /// Applies the given function to the wrapped mutable reference and 
+    /// wrap the return value in a new `PyRefMapMut`.
+    pub fn map_mut<F, V>(mut self, f: F) -> PyRefMapMut<'py, V> 
+        where F: FnOnce(&mut U) -> &mut V
     {
         let target = NonNull::from(f(&mut *self));
-        PyRefMapMut {target, owner: Box::new(self), _mut: PhantomData}
+        PyRefMapMut {target, owner: self.owner, _mut: PhantomData}
     }
 }
 
+// either flavor can safely implement `Deref`
 impl<'py, U: 'py, Mut: Boolean> Deref for PyRefMapBase<'py, U, Mut> {
     type Target = U;
     fn deref(&self) -> &U {
@@ -67,6 +101,7 @@ impl<'py, U: 'py, Mut: Boolean> Deref for PyRefMapBase<'py, U, Mut> {
     }
 }
 
+// only the `Mut=True` flavor can safely implement `DerefMut`
 impl<'py, U: 'py> DerefMut for PyRefMapMut<'py, U> {
     fn deref_mut(&mut self) -> &mut U {
         // we own the `PyRefMut` that is guarding our exclusive access to `T`
@@ -74,10 +109,34 @@ impl<'py, U: 'py> DerefMut for PyRefMapMut<'py, U> {
     }
 }
 
+impl<'py, T: PyClass> PyRef<'py, T> {
+    pub fn into_map<F, U: 'py>(self, f: F) -> PyRefMap<'py, U>
+        where F: FnOnce(&T) -> &U
+    {
+        PyRefMap::new(self).map(f)
+    }
+}
+
+impl<'py, T: PyClass<Frozen = False>> PyRefMut<'py, T> {
+    
+    pub fn into_map<F, U: 'py>(self, f: F) -> PyRefMap<'py, U>
+        where F: FnOnce(&T) -> &U
+    {
+        PyRefMap::new(self).map(f)
+    }
+    
+    pub fn into_map_mut<F, U: 'py>(self, f: F) -> PyRefMapMut<'py, U>
+        where F: FnOnce(&mut T) -> &mut U
+    {
+        PyRefMapMut::new(self).map_mut(f)
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prelude::*;
     use crate::types::PyString;
     
     #[pyclass]

--- a/src/pyref_map.rs
+++ b/src/pyref_map.rs
@@ -1,0 +1,150 @@
+#![allow(unused_imports, dead_code)]
+
+use std::ptr::NonNull;
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::convert::{AsRef, AsMut};
+
+use crate::prelude::*;
+use crate::pyclass::PyClass;
+use crate::pyclass::boolean_struct::{True, False, private::Boolean};
+
+
+pub struct PyRefMap<'py, T: PyClass, U: 'py> {
+    owner: PyRef<'py, T>,
+    target: *const U,
+}
+
+impl<'py, T: PyClass> PyRef<'py, T> {
+    pub fn into_map<F, U: 'py>(self, f: F) -> PyRefMap<'py, T, U>
+        where F: FnOnce(&T) -> &U
+    {
+        PyRefMap {target: f(&*self), owner: self}
+    }
+    
+    pub fn try_into_map<F, U: 'py, E>(self, f: F) -> Result<PyRefMap<'py, T, U>, E>
+        where F: FnOnce(&T) -> Result<&U, E>
+    {
+        Ok(PyRefMap {target: f(&*self)?, owner: self})
+    }
+}
+
+impl<'p, T: PyClass, U> Deref for PyRefMap<'p, T, U> {
+    type Target = U;
+    fn deref(&self) -> &U {
+        // we own the `PyRef` that is guarding our shared access to `T`
+        unsafe { &*self.target }
+    }
+}
+
+
+pub struct PyRefMutMap<'py, T, U: 'py, Mut = True> 
+where   
+    T: PyClass<Frozen = False>, 
+    Mut: Boolean // tags whether `U` comes from `&U` or `&mut U`
+{
+    owner: PyRefMut<'py, T>,
+    target: NonNull<U>,
+    _mut: PhantomData<Mut>,  
+}
+
+impl<'py, T: PyClass<Frozen = False>> PyRefMut<'py, T> {
+    
+    pub fn into_map<F, U: 'py>(self, f: F) -> PyRefMutMap<'py, T, U, False>
+        where F: FnOnce(&T) -> &U
+    {
+        let target = NonNull::from(f(&*self));
+        PyRefMutMap {target, owner: self, _mut: PhantomData}
+    }
+    
+    pub fn into_map_mut<F, U: 'py>(mut self, f: F) -> PyRefMutMap<'py, T, U, True>
+        where F: FnOnce(&mut T) -> &mut U
+    {
+        let target = NonNull::from(f(&mut *self));
+        PyRefMutMap {target, owner: self, _mut: PhantomData}
+    }
+}
+
+impl<'py, T, U, Mut> Deref for PyRefMutMap<'py, T, U, Mut> 
+where   
+    U: 'py, 
+    T: PyClass<Frozen = False>, 
+    Mut: Boolean
+{
+    type Target = U;
+    fn deref(&self) -> &U {
+        // we own the `PyRef` that is guarding our access to `T`
+        unsafe { self.target.as_ref() }
+    }
+}
+
+impl<'py, T, U> DerefMut for PyRefMutMap<'py, T, U, True>
+where   
+    U: 'py, 
+    T: PyClass<Frozen = False>,
+{
+    fn deref_mut(&mut self) -> &mut U {
+        // we own the `PyRef` that is guarding our exclusive access to `T`
+        unsafe { self.target.as_mut() }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::PyString;
+    
+    #[pyclass]
+    #[pyo3(crate = "crate")]
+    pub struct MyClass {
+        data: [i32; 100]
+    }
+
+    #[test]
+    fn pyref_map() -> PyResult<()> {
+        Python::with_gil(|py| -> PyResult<()> {
+            let bound = Bound::new(py, MyClass{data: [0; 100]})?;
+            let data = bound.try_borrow()?.into_map(|c| &c.data);
+            assert_eq!(data[0], 0);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn pyrefmut_map() -> PyResult<()> {
+        Python::with_gil(|py| -> PyResult<()> {
+            let bound = Bound::new(py, MyClass{data: [0; 100]})?;
+            let data = bound.try_borrow_mut()?.into_map(|c| &c.data);
+            assert_eq!(data[0], 0);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn pyrefmut_map_mut() -> PyResult<()> {
+        Python::with_gil(|py| -> PyResult<()> {
+            let bound = Bound::new(py, MyClass{data: [0; 100]})?;
+            let mut data = bound
+                .try_borrow_mut()?
+                .into_map_mut(|c| &mut c.data);
+            data[0] = 5;
+            assert_eq!(data[0], 5);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn pyref_map_unrelated() -> PyResult<()> {
+        Python::with_gil(|py| -> PyResult<()> {
+            let bound = Bound::new(py, MyClass{data: [0; 100]})?;
+            let string = PyString::new_bound(py, "pyo3");
+            // there is nothing stopping the user from returning something not
+            // borrowing from the pyref, but that shouldn't matter. The borrow 
+            // checker still enforces the `'py` lifetime
+            let refmap = bound.try_borrow()?.into_map(|_| &string);
+            assert_eq!(refmap.to_str()?, "pyo3");
+            Ok(())
+        })
+    }
+}


### PR DESCRIPTION
This draft PR proposes a possible solution for issue #2300 and PR #4195, which involves adding a `Ref::map`-like mechanism for borrowing data nested within a `PyRef` or `PyRefMut`. 

Unlike some of the approaches proposed in #2300 which attempt to create a `PyRef<U>` to some type `U` nested within a `PyRef<T: PyClass>`, this implementation instead defines a wrapper type that encapsulates the original `PyRef` alongside a raw pointer to `U` which it then dereferences to. This has the benefit of not relying on any of the `pyo3` internals that may be in flux, and makes the safety relative easy to reason about since there is nothing magic going on.

### Simplified version
In the simplest case of supporting only immutable borrows from immutable `PyRef`'s, the approach boils down to this:

```rust
pub struct PyRefMap<'py, T: PyClass, U> {
    owner: PyRef<'py, T>,
    reference: *const U,
}

impl<'py, T: PyClass> PyRef<'py, T> {
    pub fn into_map<F, U>(self, f: F) -> PyRefMap<'py, T, U>
        where F: FnOnce(&T) -> &U 
    {
        PyRefMap {reference: f(&*self), owner: self}
    }
}

impl<'py, T: PyClass, U> Deref for PyRefMap<'py, T, U> {
    type Target = U;

    fn deref(&self) -> &U {
        // we own the `PyRef` that is guarding our (shared) access to `T`
        unsafe { &*self.reference }
    }
}
```
This can then be used like so:
```rust
let bound = Bound::new(py, MyClass{data: [0i32; 100]};
let data = bound.try_borrow()?.into_map(|c| &c.data);
assert_eq!(data[0], 0);
```

### Full version
The above method should extend seamlessly to mutable borrows through `PyRefMut`, however this requires adding another wrapper type (e.g. `PyRefMutMap`) and all the associated `impl`'s. Then another wrapper may be needed if you want to support shared borrows from a `PyRefMut`... this could be somewhat be avoided by making a single wrapper with some extra generic parameters, but then naming the types gets tedious. So, I ultimately decided to use a single base wrapper type `PyRefMapBase<'py, U, Mut>` where the contained `PyRef<'py, T>` or `PyRefMut<'py, T>` is stored as an opaque trait object `Box<dyn OpaquePyRef<'py>>` and the pointer is stored as `NonNull<U>` (which can be derived from either `&U` or `&mut U`). The mutability is then handled with the generic parameter `Mut: Boolean` which is used in type bounds to statically enforce that mutable dereferences only occur when derived from `PyRefMut<T>` and `&mut U`. Finally, two type aliases `PyRefMap<'py, U>` and `PyRefMapMut<'py, U>` are defined for the _immutable_ and _mutable_ cases, which are the actual names that users will reference (instead of `PyRefMapBase` directly).

 This approach of `Box`ing the `PyRef`/`PyRefMut` has the added benefit of allowing the pyclass type `T` to be erased from the type name so that only the lifetime and the target type need to be included in signatures (i.e. instead of `PyRefMap<'py, MyClass, [i32; 100]>` you simply have `PyRefMap<'py, [i32; 100]>`. This comes at the cost of a pointer-sized `Box` allocation when the `PyRef`/`PyRefMut` is converted to a `PyRefMap`/`PyRefMapMut`, but I would imagine that is negligible in the context of interfacing with Python. 

### ToDo
- Make sure it is sound when concurrency is involved.
- Make sure it is sound when interior mutability is involved. 
- Settle on type/method names.
- Decide where to put everything. I put it all in a new module for now just out of simplicity, but most/all of it should probably be moved to the `pycell` module.
- Decide whether the `PyRef`->`PyRefMap` conversions should be associated methods; I know they probably should due to deref conflicts, but I am in denial because standard methods are just so much nicer.
- Improve the docstrings and add examples.
- Add more tests, including `compile_fail` tests to make sure it can't be abused.
- Add `AsRef`/`AsMut` impls

