### PR TITLE
Added `ToPyObject` and `IntoPy<PyObject>` impls for `PyBackedStr`.

### DIFF
--- a/newsfragments/4205.added.md
+++ b/newsfragments/4205.added.md
@@ -1,1 +1,1 @@
-Added ToPyObject and IntoPy<PyObject> impls for PyBackedStr.
+Added `ToPyObject` and `IntoPy<PyObject>` impls for `PyBackedStr` and `PyBackedBytes`.

--- a/newsfragments/4205.added.md
+++ b/newsfragments/4205.added.md
@@ -1,0 +1,1 @@
+Added ToPyObject and IntoPy<PyObject> impls for PyBackedStr.

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -85,17 +85,25 @@ impl FromPyObject<'_> for PyBackedStr {
     }
 }
 
-#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 impl ToPyObject for PyBackedStr {
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
         self.storage.clone_ref(py)
     }
+    #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
+    fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
+        PyString::new_bound(py, self).into_any().unbind()
+    }
 }
 
-#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 impl IntoPy<Py<PyAny>> for PyBackedStr {
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
         self.storage
+    }
+    #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
+    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
+        PyString::new_bound(py, &self).into_any().unbind()
     }
 }
 

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -216,9 +216,7 @@ impl IntoPy<Py<PyAny>> for PyBackedBytes {
     fn into_py(self, py: Python<'_>) -> Py<PyAny> {
         match self.storage {
             PyBackedBytesStorage::Python(bytes) => bytes.into_any(),
-            PyBackedBytesStorage::Rust(bytes) => {
-                PyByteArray::new_bound(py, &bytes).into_any().unbind()
-            }
+            PyBackedBytesStorage::Rust(bytes) => PyBytes::new_bound(py, &bytes).into_any().unbind(),
         }
     }
 }
@@ -412,9 +410,9 @@ mod test {
             let to_object = rust_backed_bytes.to_object(py).into_bound(py);
             assert!(&to_object.is_exact_instance_of::<PyBytes>());
             assert_eq!(&to_object.extract::<PyBackedBytes>().unwrap(), b"abcde");
-            let into_py = rust_backed_bytes.into_py(py);
-            assert!(&to_object.is_exact_instance_of::<PyBytes>());
-            assert_eq!(&into_py.extract::<PyBackedBytes>(py).unwrap(), b"abcde");
+            let into_py = rust_backed_bytes.into_py(py).into_bound(py);
+            assert!(&into_py.is_exact_instance_of::<PyBytes>());
+            assert_eq!(&into_py.extract::<PyBackedBytes>().unwrap(), b"abcde");
         });
     }
 

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -7,8 +7,7 @@ use crate::{
         any::PyAnyMethods, bytearray::PyByteArrayMethods, bytes::PyBytesMethods,
         string::PyStringMethods, PyByteArray, PyBytes, PyString,
     },
-    Bound, DowncastError, Py, PyAny, PyErr, PyResult,
-    FromPyObject, ToPyObject, IntoPy, Python
+    Bound, DowncastError, FromPyObject, IntoPy, Py, PyAny, PyErr, PyResult, Python, ToPyObject,
 };
 
 /// A wrapper around `str` where the storage is owned by a Python `bytes` or `str` object.

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -336,7 +336,7 @@ mod test {
             let orig_str = PyString::new_bound(py, "hello");
             let py_backed_str = orig_str.extract::<PyBackedStr>().unwrap();
             let new_str = py_backed_str.to_object(py);
-            assert_eq!(new_str.extract::<&str>(py).unwrap(), "hello");
+            assert_eq!(new_str.extract::<PyBackedStr>(py).unwrap(), "hello");
             #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
             assert!(new_str.is(&orig_str));
         });
@@ -348,7 +348,7 @@ mod test {
             let orig_str = PyString::new_bound(py, "hello");
             let py_backed_str = orig_str.extract::<PyBackedStr>().unwrap();
             let new_str = py_backed_str.into_py(py);
-            assert_eq!(new_str.extract::<&str>(py).unwrap(), "hello");
+            assert_eq!(new_str.extract::<PyBackedStr>(py).unwrap(), "hello");
             #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
             assert!(new_str.is(&orig_str));
         });

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -203,6 +203,28 @@ impl FromPyObject<'_> for PyBackedBytes {
     }
 }
 
+impl ToPyObject for PyBackedBytes {
+    fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
+        match &self.storage {
+            PyBackedBytesStorage::Python(bytes) => bytes.to_object(py),
+            PyBackedBytesStorage::Rust(bytes) => {
+                PyByteArray::new_bound(py, bytes).into_any().unbind()
+            }
+        }
+    }
+}
+
+impl IntoPy<Py<PyAny>> for PyBackedBytes {
+    fn into_py(self, py: Python<'_>) -> Py<PyAny> {
+        match self.storage {
+            PyBackedBytesStorage::Python(bytes) => bytes.into_any(),
+            PyBackedBytesStorage::Rust(bytes) => {
+                PyByteArray::new_bound(py, &bytes).into_any().unbind()
+            }
+        }
+    }
+}
+
 macro_rules! impl_traits {
     ($slf:ty, $equiv:ty) => {
         impl std::fmt::Debug for $slf {

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -7,7 +7,8 @@ use crate::{
         any::PyAnyMethods, bytearray::PyByteArrayMethods, bytes::PyBytesMethods,
         string::PyStringMethods, PyByteArray, PyBytes, PyString,
     },
-    Bound, DowncastError, FromPyObject, Py, PyAny, PyErr, PyResult,
+    Bound, DowncastError, Py, PyAny, PyErr, PyResult,
+    FromPyObject, ToPyObject, IntoPy, Python
 };
 
 /// A wrapper around `str` where the storage is owned by a Python `bytes` or `str` object.
@@ -82,6 +83,18 @@ impl FromPyObject<'_> for PyBackedStr {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         let py_string = obj.downcast::<PyString>()?.to_owned();
         Self::try_from(py_string)
+    }
+}
+
+impl ToPyObject for PyBackedStr {
+    fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
+        self.storage.clone_ref(py)
+    }
+}
+
+impl IntoPy<Py<PyAny>> for PyBackedStr {
+    fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
+        self.storage
     }
 }
 

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -333,6 +333,30 @@ mod test {
     }
 
     #[test]
+    fn py_backed_str_to_object() {
+        Python::with_gil(|py| {
+            let orig_str = PyString::new_bound(py, "hello");
+            let py_backed_str = orig_str.extract::<PyBackedStr>().unwrap();
+            let new_str = py_backed_str.to_object(py);
+            assert_eq!(new_str.extract::<&str>(py).unwrap(), "hello");
+            #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+            assert!(new_str.is(&orig_str));
+        });
+    }
+
+    #[test]
+    fn py_backed_str_into_py() {
+        Python::with_gil(|py| {
+            let orig_str = PyString::new_bound(py, "hello");
+            let py_backed_str = orig_str.extract::<PyBackedStr>().unwrap();
+            let new_str = py_backed_str.into_py(py);
+            assert_eq!(new_str.extract::<&str>(py).unwrap(), "hello");
+            #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+            assert!(new_str.is(&orig_str));
+        });
+    }
+
+    #[test]
     fn py_backed_bytes_empty() {
         Python::with_gil(|py| {
             let b = PyBytes::new_bound(py, &[]);
@@ -365,6 +389,28 @@ mod test {
             let b = PyByteArray::new_bound(py, b"abcde");
             let py_backed_bytes = PyBackedBytes::from(b);
             assert_eq!(&*py_backed_bytes, b"abcde");
+        });
+    }
+
+    #[test]
+    fn py_backed_bytes_to_bytes() {
+        Python::with_gil(|py| {
+            let orig_bytes = PyBytes::new_bound(py, b"abcde");
+            let py_backed_bytes = PyBackedBytes::from(orig_bytes.clone());
+            assert!(py_backed_bytes.to_object(py).is(&orig_bytes));
+            assert!(py_backed_bytes.into_py(py).is(&orig_bytes));
+        });
+    }
+
+    #[test]
+    fn py_backed_bytes_to_bytearray() {
+        Python::with_gil(|py| {
+            let orig_bytes = PyByteArray::new_bound(py, b"abcde");
+            let py_backed_bytes = PyBackedBytes::from(orig_bytes);
+            let to_object = py_backed_bytes.to_object(py);
+            let into_py = py_backed_bytes.into_py(py);
+            assert_eq!(&to_object.extract::<PyBackedBytes>(py).unwrap(), b"abcde");
+            assert_eq!(&into_py.extract::<PyBackedBytes>(py).unwrap(), b"abcde");
         });
     }
 

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -86,12 +86,14 @@ impl FromPyObject<'_> for PyBackedStr {
     }
 }
 
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 impl ToPyObject for PyBackedStr {
     fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
         self.storage.clone_ref(py)
     }
 }
 
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 impl IntoPy<Py<PyAny>> for PyBackedStr {
     fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
         self.storage


### PR DESCRIPTION
I have a `PyBackedStr` that I extracted from a `PyObject`, and would like to pass it back to Python through another method call. However, `PyBackedStr` currently does not implement the conversion traits necessary to do so without cloning. This PR simply adds these conversion methods, which is trivial since the `PyBackedStr` is already storing a pointer to the Python string as a `PyObject`.