### PR TITLE
add pyclass `eq` option

### DIFF
--- a/guide/pyclass-parameters.md
+++ b/guide/pyclass-parameters.md
@@ -5,6 +5,7 @@
 | `constructor` | This is currently only allowed on [variants of complex enums][params-constructor]. It allows customization of the generated class constructor for each variant. It uses the same syntax and supports the same options as the `signature` attribute of functions and methods. |
 | <span style="white-space: pre">`crate = "some::path"`</span>  | Path to import the `pyo3` crate, if it's not accessible at `::pyo3`. |
 | `dict` | Gives instances of this class an empty `__dict__` to store custom attributes. |
+| `eq` | Implements `__eq__` using the `PartialEq` implementation of the underlying Rust datatype. |
 | <span style="white-space: pre">`extends = BaseType`</span>  | Use a custom baseclass. Defaults to [`PyAny`][params-1] |
 | <span style="white-space: pre">`freelist = N`</span> |  Implements a [free list][params-2] of size N. This can improve performance for types that are often created and deleted in quick succession. Profile your code to see whether `freelist` is right for you.  |
 | <span style="white-space: pre">`frozen`</span> | Declares that your pyclass is immutable. It removes the borrow checker overhead when retrieving a shared reference to the Rust struct, but disables the ability to get a mutable reference. |

--- a/guide/pyclass-parameters.md
+++ b/guide/pyclass-parameters.md
@@ -6,6 +6,7 @@
 | <span style="white-space: pre">`crate = "some::path"`</span>  | Path to import the `pyo3` crate, if it's not accessible at `::pyo3`. |
 | `dict` | Gives instances of this class an empty `__dict__` to store custom attributes. |
 | `eq` | Implements `__eq__` using the `PartialEq` implementation of the underlying Rust datatype. |
+| `eq_int` | Implements `__eq__` using `__int__` for simple enums. |
 | <span style="white-space: pre">`extends = BaseType`</span>  | Use a custom baseclass. Defaults to [`PyAny`][params-1] |
 | <span style="white-space: pre">`freelist = N`</span> |  Implements a [free list][params-2] of size N. This can improve performance for types that are often created and deleted in quick succession. Profile your code to see whether `freelist` is right for you.  |
 | <span style="white-space: pre">`frozen`</span> | Declares that your pyclass is immutable. It removes the borrow checker overhead when retrieving a shared reference to the Rust struct, but disables the ability to get a mutable reference. |

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -37,14 +37,16 @@ struct Number(i32);
 
 // PyO3 supports unit-only enums (which contain only unit variants)
 // These simple enums behave similarly to Python's enumerations (enum.Enum)
-#[pyclass]
+#[pyclass(eq)]
+#[derive(PartialEq)]
 enum MyEnum {
     Variant,
     OtherVariant = 30, // PyO3 supports custom discriminants.
 }
 
 // PyO3 supports custom discriminants in unit-only enums
-#[pyclass]
+#[pyclass(eq)]
+#[derive(PartialEq)]
 enum HttpResponse {
     Ok = 200,
     NotFound = 404,
@@ -1053,7 +1055,8 @@ PyO3 adds a class attribute for each variant, so you can access them in Python w
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass]
+#[pyclass(eq)]
+#[derive(PartialEq)]
 enum MyEnum {
     Variant,
     OtherVariant,
@@ -1075,7 +1078,8 @@ You can also convert your simple enums into `int`:
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass]
+#[pyclass(eq)]
+#[derive(PartialEq)]
 enum MyEnum {
     Variant,
     OtherVariant = 10,
@@ -1087,8 +1091,6 @@ Python::with_gil(|py| {
     pyo3::py_run!(py, cls x, r#"
         assert int(cls.Variant) == x
         assert int(cls.OtherVariant) == 10
-        assert cls.OtherVariant == 10  # You can also compare against int.
-        assert 10 == cls.OtherVariant
     "#)
 })
 ```
@@ -1097,7 +1099,8 @@ PyO3 also provides `__repr__` for enums:
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass]
+#[pyclass(eq)]
+#[derive(PartialEq)]
 enum MyEnum{
     Variant,
     OtherVariant,
@@ -1117,7 +1120,8 @@ All methods defined by PyO3 can be overridden. For example here's how you overri
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass]
+#[pyclass(eq)]
+#[derive(PartialEq)]
 enum MyEnum {
     Answer = 42,
 }
@@ -1139,7 +1143,8 @@ Enums and their variants can also be renamed using `#[pyo3(name)]`.
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass(name = "RenamedEnum")]
+#[pyclass(eq, name = "RenamedEnum")]
+#[derive(PartialEq)]
 enum MyEnum {
     #[pyo3(name = "UPPERCASE")]
     Variant,

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -37,7 +37,7 @@ struct Number(i32);
 
 // PyO3 supports unit-only enums (which contain only unit variants)
 // These simple enums behave similarly to Python's enumerations (enum.Enum)
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(PartialEq)]
 enum MyEnum {
     Variant,
@@ -45,7 +45,7 @@ enum MyEnum {
 }
 
 // PyO3 supports custom discriminants in unit-only enums
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(PartialEq)]
 enum HttpResponse {
     Ok = 200,
@@ -1055,7 +1055,7 @@ PyO3 adds a class attribute for each variant, so you can access them in Python w
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(PartialEq)]
 enum MyEnum {
     Variant,
@@ -1078,7 +1078,7 @@ You can also convert your simple enums into `int`:
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(PartialEq)]
 enum MyEnum {
     Variant,
@@ -1099,7 +1099,7 @@ PyO3 also provides `__repr__` for enums:
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(PartialEq)]
 enum MyEnum{
     Variant,
@@ -1120,7 +1120,7 @@ All methods defined by PyO3 can be overridden. For example here's how you overri
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(PartialEq)]
 enum MyEnum {
     Answer = 42,
@@ -1143,7 +1143,7 @@ Enums and their variants can also be renamed using `#[pyo3(name)]`.
 
 ```rust
 # use pyo3::prelude::*;
-#[pyclass(eq, name = "RenamedEnum")]
+#[pyclass(eq, eq_int, name = "RenamedEnum")]
 #[derive(PartialEq)]
 enum MyEnum {
     #[pyo3(name = "UPPERCASE")]

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -226,7 +226,7 @@ impl Number {
 # }
 ```
 
-To implement `__eq__` in terms of the `PartialEq` implementation of the underlying datatype, the `eq` option can be used.
+To implement `__eq__` using the Rust [`PartialEq`] trait implementation, the `eq` option can be used.
 
 ```rust
 # use pyo3::prelude::*;
@@ -315,3 +315,4 @@ fn my_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 [`Hasher`]: https://doc.rust-lang.org/std/hash/trait.Hasher.html
 [`DefaultHasher`]: https://doc.rust-lang.org/std/collections/hash_map/struct.DefaultHasher.html
 [SipHash]: https://en.wikipedia.org/wiki/SipHash
+[`PartialEq`]: https://doc.rust-lang.org/stable/std/cmp/trait.PartialEq.html

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -226,6 +226,16 @@ impl Number {
 # }
 ```
 
+To implement `__eq__` in terms of the `PartialEq` implementation of the underlying datatype, the `eq` option can be used.
+
+```rust
+# use pyo3::prelude::*;
+#
+#[pyclass(eq)]
+#[derive(PartialEq)]
+struct Number(i32);
+```
+
 ### Truthyness
 
 We'll consider `Number` to be `True` if it is nonzero:

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -47,6 +47,37 @@ However, take care to note that the behaviour is different from previous version
 Related to this, we also added a `pyo3_disable_reference_pool` conditional compilation flag which removes the infrastructure necessary to apply delayed reference count decrements implied by `impl<T> Drop for Py<T>`. They do not appear to be a soundness hazard as they should lead to memory leaks in the worst case. However, the global synchronization adds significant overhead to cross the Python-Rust boundary. Enabling this feature will remove these costs and make the `Drop` implementation abort the process if called without the GIL being held instead.
 </details>
 
+### Deprecation of implicit integer comparison for simple enums
+<details open>
+<summary><small>Click to expand</small></summary>
+
+With `pyo3` 0.22 the implicit implementation of integer comparison for simple enums using their discriminants is deprecated. To migrate, place a `#[pyo3(eq_int)]` attribute on affected classes. In addition the `#[pyo3(eq)]` option can be used to implement comparison based on the `PartialEq` implementation. If both options are specified, comparing by `PartialEq` and on failure the integer comparision is used as a fallback.
+
+Before:
+
+```rust
+# #![allow(deprecated, dead_code)]
+# use pyo3::prelude::*;
+#[pyclass]
+enum SimpleEnum {
+    VariantA,
+    VariantB = 42,
+}
+```
+
+After:
+
+```rust
+# #![allow(dead_code)]
+# use pyo3::prelude::*;
+#[pyclass(eq_int)]
+enum SimpleEnum {
+    VariantA,
+    VariantB = 42,
+}
+```
+</details>
+
 ## from 0.20.* to 0.21
 <details open>
 <summary><small>Click to expand</small></summary>

--- a/newsfragments/4210.added.md
+++ b/newsfragments/4210.added.md
@@ -1,1 +1,2 @@
 Added `#[pyclass(eq)]` option to generate `__eq__` based on `PartialEq`.
+Added `#[pyclass(eq_int)]` for simple enums to implement equality based on their discriminants.

--- a/newsfragments/4210.added.md
+++ b/newsfragments/4210.added.md
@@ -1,0 +1,1 @@
+Added `#[pyclass(eq)]` option to generate `__eq__` based on `PartialEq`.

--- a/newsfragments/4210.changed.md
+++ b/newsfragments/4210.changed.md
@@ -1,0 +1,1 @@
+Deprecate implicit integer comparision for simple enums in favor of `#[pyclass(eq_int)]`.

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -14,6 +14,7 @@ pub mod kw {
     syn::custom_keyword!(cancel_handle);
     syn::custom_keyword!(constructor);
     syn::custom_keyword!(dict);
+    syn::custom_keyword!(eq);
     syn::custom_keyword!(extends);
     syn::custom_keyword!(freelist);
     syn::custom_keyword!(from_py_with);

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -15,6 +15,7 @@ pub mod kw {
     syn::custom_keyword!(constructor);
     syn::custom_keyword!(dict);
     syn::custom_keyword!(eq);
+    syn::custom_keyword!(eq_int);
     syn::custom_keyword!(extends);
     syn::custom_keyword!(freelist);
     syn::custom_keyword!(from_py_with);

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1682,7 +1682,7 @@ fn pyclass_richcmp_simple_enum(
             quote! {
                 #[deprecated(
                     since = "0.22.0",
-                    note = "Implicit equality for simple enums is deprecated. Use `#[pyclass(eq_int)` to keep the current behavior."
+                    note = "Implicit equality for simple enums is deprecated. Use `#[pyclass(eq, eq_int)` to keep the current behavior."
                 )]
                 const DEPRECATION: () = ();
                 const _: () = DEPRECATION;

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1700,7 +1700,7 @@ fn pyclass_richcmp(
     // TODO: `ord` can be integrated here (#4202)
     if options.eq.is_some() {
         let mut richcmp_impl = parse_quote! {
-            fn __pyo3__richcmp__(
+            fn __pymethod___richcmp____(
                 &self,
                 py: #pyo3_path::Python,
                 other: &#pyo3_path::Bound<'_, #pyo3_path::PyAny>,

--- a/pytests/src/enums.rs
+++ b/pytests/src/enums.rs
@@ -18,7 +18,7 @@ pub fn enums(m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(PartialEq)]
 pub enum SimpleEnum {
     Sunday,

--- a/pytests/src/enums.rs
+++ b/pytests/src/enums.rs
@@ -18,7 +18,8 @@ pub fn enums(m: &Bound<'_, PyModule>) -> PyResult<()> {
     Ok(())
 }
 
-#[pyclass]
+#[pyclass(eq)]
+#[derive(PartialEq)]
 pub enum SimpleEnum {
     Sunday,
     Monday,

--- a/src/tests/hygiene/pyclass.rs
+++ b/src/tests/hygiene/pyclass.rs
@@ -29,8 +29,9 @@ pub struct Bar {
     c: ::std::option::Option<crate::Py<Foo2>>,
 }
 
-#[crate::pyclass]
+#[crate::pyclass(eq)]
 #[pyo3(crate = "crate")]
+#[derive(PartialEq)]
 pub enum Enum {
     Var0,
 }

--- a/src/tests/hygiene/pyclass.rs
+++ b/src/tests/hygiene/pyclass.rs
@@ -29,7 +29,7 @@ pub struct Bar {
     c: ::std::option::Option<crate::Py<Foo2>>,
 }
 
-#[crate::pyclass(eq)]
+#[crate::pyclass(eq, eq_int)]
 #[pyo3(crate = "crate")]
 #[derive(PartialEq)]
 pub enum Enum {

--- a/tests/test_declarative_module.rs
+++ b/tests/test_declarative_module.rs
@@ -89,7 +89,8 @@ mod declarative_module {
             }
         }
 
-        #[pyclass]
+        #[pyclass(eq)]
+        #[derive(PartialEq)]
         enum Enum {
             A,
             B,

--- a/tests/test_declarative_module.rs
+++ b/tests/test_declarative_module.rs
@@ -89,7 +89,7 @@ mod declarative_module {
             }
         }
 
-        #[pyclass(eq)]
+        #[pyclass(eq, eq_int)]
         #[derive(PartialEq)]
         enum Enum {
             A,

--- a/tests/test_default_impls.rs
+++ b/tests/test_default_impls.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 mod common;
 
 // Test default generated __repr__.
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(PartialEq)]
 enum TestDefaultRepr {
     Var,
@@ -24,7 +24,7 @@ fn test_default_slot_exists() {
     })
 }
 
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(PartialEq)]
 enum OverrideSlot {
     Var,

--- a/tests/test_default_impls.rs
+++ b/tests/test_default_impls.rs
@@ -6,7 +6,8 @@ use pyo3::prelude::*;
 mod common;
 
 // Test default generated __repr__.
-#[pyclass]
+#[pyclass(eq)]
+#[derive(PartialEq)]
 enum TestDefaultRepr {
     Var,
 }
@@ -23,7 +24,8 @@ fn test_default_slot_exists() {
     })
 }
 
-#[pyclass]
+#[pyclass(eq)]
+#[derive(PartialEq)]
 enum OverrideSlot {
     Var,
 }

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -6,7 +6,7 @@ use pyo3::py_run;
 #[path = "../src/tests/common.rs"]
 mod common;
 
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MyEnum {
     Variant,
@@ -73,7 +73,7 @@ fn test_enum_eq_incomparable() {
     })
 }
 
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 enum CustomDiscriminant {
     One = 1,
@@ -122,7 +122,7 @@ fn test_enum_compare_int() {
     })
 }
 
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(u8)]
 enum SmallEnum {
@@ -137,7 +137,7 @@ fn test_enum_compare_int_no_throw_when_overflow() {
     })
 }
 
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(usize)]
 #[allow(clippy::enum_clike_unportable_variant)]
@@ -148,18 +148,15 @@ enum BigEnum {
 #[test]
 fn test_big_enum_no_overflow() {
     Python::with_gil(|py| {
-        // use pyo3::types::IntoPyDict;
         let usize_max = usize::MAX;
         let v = Py::new(py, BigEnum::V).unwrap();
 
-        // let env = [("v", v.as_any()), ("usize_max", &usize_max.into_py(py))].into_py_dict_bound(py);
-        // py_run!(py, *env, "print(v)\nprint(usize_max)");
-        // py_assert!(py, usize_max v, "v == usize_max");
+        py_assert!(py, usize_max v, "v == usize_max");
         py_assert!(py, usize_max v, "int(v) == usize_max");
     })
 }
 
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(u16, align(8))]
 enum TestReprParse {
@@ -171,7 +168,7 @@ fn test_repr_parse() {
     assert_eq!(std::mem::align_of::<TestReprParse>(), 8);
 }
 
-#[pyclass(eq, name = "MyEnum")]
+#[pyclass(eq, eq_int, name = "MyEnum")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RenameEnum {
     Variant,
@@ -185,7 +182,7 @@ fn test_rename_enum_repr_correct() {
     })
 }
 
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RenameVariantEnum {
     #[pyo3(name = "VARIANT")]
@@ -200,7 +197,7 @@ fn test_rename_variant_repr_correct() {
     })
 }
 
-#[pyclass(eq, rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[allow(clippy::enum_variant_names)]
 enum RenameAllVariantsEnum {

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -6,7 +6,7 @@ use pyo3::py_run;
 #[path = "../src/tests/common.rs"]
 mod common;
 
-#[pyclass]
+#[pyclass(eq)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MyEnum {
     Variant,
@@ -73,7 +73,8 @@ fn test_enum_eq_incomparable() {
     })
 }
 
-#[pyclass]
+#[pyclass(eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 enum CustomDiscriminant {
     One = 1,
     Two = 2,
@@ -121,7 +122,8 @@ fn test_enum_compare_int() {
     })
 }
 
-#[pyclass]
+#[pyclass(eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(u8)]
 enum SmallEnum {
     V = 1,
@@ -135,7 +137,8 @@ fn test_enum_compare_int_no_throw_when_overflow() {
     })
 }
 
-#[pyclass]
+#[pyclass(eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(usize)]
 #[allow(clippy::enum_clike_unportable_variant)]
 enum BigEnum {
@@ -145,14 +148,19 @@ enum BigEnum {
 #[test]
 fn test_big_enum_no_overflow() {
     Python::with_gil(|py| {
+        // use pyo3::types::IntoPyDict;
         let usize_max = usize::MAX;
         let v = Py::new(py, BigEnum::V).unwrap();
-        py_assert!(py, usize_max v, "v == usize_max");
+
+        // let env = [("v", v.as_any()), ("usize_max", &usize_max.into_py(py))].into_py_dict_bound(py);
+        // py_run!(py, *env, "print(v)\nprint(usize_max)");
+        // py_assert!(py, usize_max v, "v == usize_max");
         py_assert!(py, usize_max v, "int(v) == usize_max");
     })
 }
 
-#[pyclass]
+#[pyclass(eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(u16, align(8))]
 enum TestReprParse {
     V,
@@ -163,7 +171,7 @@ fn test_repr_parse() {
     assert_eq!(std::mem::align_of::<TestReprParse>(), 8);
 }
 
-#[pyclass(name = "MyEnum")]
+#[pyclass(eq, name = "MyEnum")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RenameEnum {
     Variant,
@@ -177,7 +185,7 @@ fn test_rename_enum_repr_correct() {
     })
 }
 
-#[pyclass]
+#[pyclass(eq)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RenameVariantEnum {
     #[pyo3(name = "VARIANT")]
@@ -192,7 +200,8 @@ fn test_rename_variant_repr_correct() {
     })
 }
 
-#[pyclass(rename_all = "SCREAMING_SNAKE_CASE")]
+#[pyclass(eq, rename_all = "SCREAMING_SNAKE_CASE")]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[allow(clippy::enum_variant_names)]
 enum RenameAllVariantsEnum {
     VariantOne,

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -196,3 +196,9 @@ fn test_wrap_pyfunction(py: Python<'_>, m: &Bound<'_, PyModule>) {
     let _ = wrap_pyfunction_bound!(double, py);
     let _ = wrap_pyfunction_bound!(double)(py);
 }
+
+#[pyclass]
+pub enum SimpleEnumWithoutEq {
+    VariamtA,
+    VariantB,
+}

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -34,7 +34,7 @@ error: use of deprecated constant `__pyfunction_pyfunction_option_4::SIGNATURE`:
 138 | fn pyfunction_option_4(
     |    ^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated constant `SimpleEnumWithoutEq::__pymethod___richcmp____::DEPRECATION`: Implicit equality for simple enums is deprecated. Use `#[pyclass(eq_int)` to keep the current behavior.
+error: use of deprecated constant `SimpleEnumWithoutEq::__pyo3__generated____richcmp__::DEPRECATION`: Implicit equality for simple enums is deprecated. Use `#[pyclass(eq_int)` to keep the current behavior.
    --> tests/ui/deprecations.rs:200:1
     |
 200 | #[pyclass]

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -34,6 +34,14 @@ error: use of deprecated constant `__pyfunction_pyfunction_option_4::SIGNATURE`:
 138 | fn pyfunction_option_4(
     |    ^^^^^^^^^^^^^^^^^^^
 
+error: use of deprecated constant `SimpleEnumWithoutEq::__pyo3__richcmp__::DEPRECATION`: Implicit equality for simple enums in deprecated. Use `#[pyclass(eq)` to opt-in to the new behavior.
+   --> tests/ui/deprecations.rs:200:1
+    |
+200 | #[pyclass]
+    | ^^^^^^^^^^
+    |
+    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error: use of deprecated struct `pyo3::PyCell`: `PyCell` was merged into `Bound`, use that instead; see the migration guide for more info
   --> tests/ui/deprecations.rs:23:30
    |

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -34,7 +34,7 @@ error: use of deprecated constant `__pyfunction_pyfunction_option_4::SIGNATURE`:
 138 | fn pyfunction_option_4(
     |    ^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated constant `SimpleEnumWithoutEq::__pyo3__generated____richcmp__::DEPRECATION`: Implicit equality for simple enums is deprecated. Use `#[pyclass(eq_int)` to keep the current behavior.
+error: use of deprecated constant `SimpleEnumWithoutEq::__pyo3__generated____richcmp__::DEPRECATION`: Implicit equality for simple enums is deprecated. Use `#[pyclass(eq, eq_int)` to keep the current behavior.
    --> tests/ui/deprecations.rs:200:1
     |
 200 | #[pyclass]

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -34,7 +34,7 @@ error: use of deprecated constant `__pyfunction_pyfunction_option_4::SIGNATURE`:
 138 | fn pyfunction_option_4(
     |    ^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated constant `SimpleEnumWithoutEq::__pyo3__richcmp__::DEPRECATION`: Implicit equality for simple enums in deprecated. Use `#[pyclass(eq)` to opt-in to the new behavior.
+error: use of deprecated constant `SimpleEnumWithoutEq::__pymethod___richcmp____::DEPRECATION`: Implicit equality for simple enums is deprecated. Use `#[pyclass(eq_int)` to keep the current behavior.
    --> tests/ui/deprecations.rs:200:1
     |
 200 | #[pyclass]

--- a/tests/ui/invalid_pyclass_args.rs
+++ b/tests/ui/invalid_pyclass_args.rs
@@ -30,4 +30,7 @@ struct InvalidArg {}
 #[pyclass(mapping, sequence)]
 struct CannotBeMappingAndSequence {}
 
+#[pyclass(eq)]
+struct EqOptRequiresEq {}
+
 fn main() {}

--- a/tests/ui/invalid_pyclass_args.rs
+++ b/tests/ui/invalid_pyclass_args.rs
@@ -49,4 +49,7 @@ impl EqOptAndManualRichCmp {
     }
 }
 
+#[pyclass(eq_int)]
+struct NoEqInt {}
+
 fn main() {}

--- a/tests/ui/invalid_pyclass_args.rs
+++ b/tests/ui/invalid_pyclass_args.rs
@@ -33,4 +33,20 @@ struct CannotBeMappingAndSequence {}
 #[pyclass(eq)]
 struct EqOptRequiresEq {}
 
+#[pyclass(eq)]
+#[derive(PartialEq)]
+struct EqOptAndManualRichCmp {}
+
+#[pymethods]
+impl EqOptAndManualRichCmp {
+    fn __richcmp__(
+        &self,
+        _py: Python,
+        _other: Bound<'_, PyAny>,
+        _op: pyo3::pyclass::CompareOp,
+    ) -> PyResult<PyObject> {
+        todo!()
+    }
+}
+
 fn main() {}

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -58,6 +58,17 @@ error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
 31 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
+  --> tests/ui/invalid_pyclass_args.rs:36:1
+   |
+36 | #[pyclass(eq)]
+   | ^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___richcmp____`
+...
+40 | #[pymethods]
+   | ------------ other definition for `__pymethod___richcmp____`
+   |
+   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0369]: binary operation `==` cannot be applied to type `&EqOptRequiresEq`
   --> tests/ui/invalid_pyclass_args.rs:33:11
    |
@@ -91,3 +102,48 @@ help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
 34 + #[derive(PartialEq)]
 35 | struct EqOptRequiresEq {}
    |
+
+error[E0034]: multiple applicable items in scope
+  --> tests/ui/invalid_pyclass_args.rs:36:1
+   |
+36 | #[pyclass(eq)]
+   | ^^^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
+   |
+note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
+  --> tests/ui/invalid_pyclass_args.rs:36:1
+   |
+36 | #[pyclass(eq)]
+   | ^^^^^^^^^^^^^^
+note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
+  --> tests/ui/invalid_pyclass_args.rs:40:1
+   |
+40 | #[pymethods]
+   | ^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
+  --> tests/ui/invalid_pyclass_args.rs:36:1
+   |
+36 | #[pyclass(eq)]
+   | ^^^^^^^^^^^^^^
+   |
+   = note: `#[warn(deprecated)]` on by default
+   = note: this warning originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+  --> tests/ui/invalid_pyclass_args.rs:40:1
+   |
+40 | #[pymethods]
+   | ^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
+   |
+note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
+  --> tests/ui/invalid_pyclass_args.rs:36:1
+   |
+36 | #[pyclass(eq)]
+   | ^^^^^^^^^^^^^^
+note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
+  --> tests/ui/invalid_pyclass_args.rs:40:1
+   |
+40 | #[pymethods]
+   | ^^^^^^^^^^^^
+   = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `crate`, `dict`, `eq`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
+error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
  --> tests/ui/invalid_pyclass_args.rs:3:11
   |
 3 | #[pyclass(extend=pyo3::types::PyDict)]
@@ -46,7 +46,7 @@ error: expected string literal
 24 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
-error: expected one of: `crate`, `dict`, `eq`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
+error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
   --> tests/ui/invalid_pyclass_args.rs:27:11
    |
 27 | #[pyclass(weakrev)]
@@ -57,6 +57,12 @@ error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
    |
 31 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `eq_int` can only be used on simple enums.
+  --> tests/ui/invalid_pyclass_args.rs:52:11
+   |
+52 | #[pyclass(eq_int)]
+   |           ^^^^^^
 
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
   --> tests/ui/invalid_pyclass_args.rs:36:1

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -127,15 +127,6 @@ note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-warning: use of deprecated method `pyo3::deprecations::GilRefs::<T>::function_arg`: use `&Bound<'_, T>` instead for this function argument
-  --> tests/ui/invalid_pyclass_args.rs:36:1
-   |
-36 | #[pyclass(eq)]
-   | ^^^^^^^^^^^^^^
-   |
-   = note: `#[warn(deprecated)]` on by default
-   = note: this warning originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0034]: multiple applicable items in scope
   --> tests/ui/invalid_pyclass_args.rs:40:1
    |

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `crate`, `dict`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
+error: expected one of: `crate`, `dict`, `eq`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
  --> tests/ui/invalid_pyclass_args.rs:3:11
   |
 3 | #[pyclass(extend=pyo3::types::PyDict)]
@@ -46,7 +46,7 @@ error: expected string literal
 24 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
-error: expected one of: `crate`, `dict`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
+error: expected one of: `crate`, `dict`, `eq`, `extends`, `freelist`, `frozen`, `get_all`, `mapping`, `module`, `name`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
   --> tests/ui/invalid_pyclass_args.rs:27:11
    |
 27 | #[pyclass(weakrev)]
@@ -57,3 +57,37 @@ error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
    |
 31 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0369]: binary operation `==` cannot be applied to type `&EqOptRequiresEq`
+  --> tests/ui/invalid_pyclass_args.rs:33:11
+   |
+33 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
+  --> tests/ui/invalid_pyclass_args.rs:34:1
+   |
+34 | struct EqOptRequiresEq {}
+   | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
+   |
+34 + #[derive(PartialEq)]
+35 | struct EqOptRequiresEq {}
+   |
+
+error[E0369]: binary operation `!=` cannot be applied to type `&EqOptRequiresEq`
+  --> tests/ui/invalid_pyclass_args.rs:33:11
+   |
+33 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
+  --> tests/ui/invalid_pyclass_args.rs:34:1
+   |
+34 | struct EqOptRequiresEq {}
+   | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
+   |
+34 + #[derive(PartialEq)]
+35 | struct EqOptRequiresEq {}
+   |

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -28,4 +28,16 @@ enum SimpleNoSignature {
     B,
 }
 
+#[pyclass(eq)]
+enum SimpleEqOptRequiresPartialEq {
+    A,
+    B,
+}
+
+#[pyclass(eq)]
+enum ComplexEqOptRequiresPartialEq {
+    A(i32),
+    B { msg: String },
+}
+
 fn main() {}

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -28,7 +28,7 @@ enum SimpleNoSignature {
     B,
 }
 
-#[pyclass(eq)]
+#[pyclass(eq, eq_int)]
 enum SimpleEqOptRequiresPartialEq {
     A,
     B,
@@ -36,6 +36,12 @@ enum SimpleEqOptRequiresPartialEq {
 
 #[pyclass(eq)]
 enum ComplexEqOptRequiresPartialEq {
+    A(i32),
+    B { msg: String },
+}
+
+#[pyclass(eq_int)]
+enum NoEqInt {
     A(i32),
     B { msg: String },
 }

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -29,3 +29,71 @@ error: `constructor` can't be used on a simple enum variant
    |
 26 |     #[pyo3(constructor = (a, b))]
    |            ^^^^^^^^^^^
+
+error[E0369]: binary operation `==` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:31:11
+   |
+31 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:32:1
+   |
+32 | enum SimpleEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `SimpleEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+32 + #[derive(PartialEq)]
+33 | enum SimpleEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `!=` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:31:11
+   |
+31 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:32:1
+   |
+32 | enum SimpleEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `SimpleEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+32 + #[derive(PartialEq)]
+33 | enum SimpleEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `==` cannot be applied to type `&ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:37:11
+   |
+37 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:38:1
+   |
+38 | enum ComplexEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `ComplexEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+38 + #[derive(PartialEq)]
+39 | enum ComplexEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `!=` cannot be applied to type `&ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:37:11
+   |
+37 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:38:1
+   |
+38 | enum ComplexEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `ComplexEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+38 + #[derive(PartialEq)]
+39 | enum ComplexEqOptRequiresPartialEq {
+   |

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -30,10 +30,16 @@ error: `constructor` can't be used on a simple enum variant
 26 |     #[pyo3(constructor = (a, b))]
    |            ^^^^^^^^^^^
 
+error: `eq_int` can only be used on simple enums.
+  --> tests/ui/invalid_pyclass_enum.rs:43:11
+   |
+43 | #[pyclass(eq_int)]
+   |           ^^^^^^
+
 error[E0369]: binary operation `==` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
   --> tests/ui/invalid_pyclass_enum.rs:31:11
    |
-31 | #[pyclass(eq)]
+31 | #[pyclass(eq, eq_int)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `SimpleEqOptRequiresPartialEq`
@@ -50,7 +56,7 @@ help: consider annotating `SimpleEqOptRequiresPartialEq` with `#[derive(PartialE
 error[E0369]: binary operation `!=` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
   --> tests/ui/invalid_pyclass_enum.rs:31:11
    |
-31 | #[pyclass(eq)]
+31 | #[pyclass(eq, eq_int)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `SimpleEqOptRequiresPartialEq`


### PR DESCRIPTION
In https://github.com/PyO3/pyo3/pull/4206#issuecomment-2132214807 we decided that `#[pyclass(hash)]` should also require
`#[pyclass(eq)]`, so this implements that option.

Special care needs to be taken of simple enums, since they currently always implement equality using their numeric discriminant. This PR keeps that behavior in the absense of the `eq` option, but emits a deprecation warning in that case. The new behavior does not allow direct comparisons between an enum variant and an integer anymore, are we fine with that? (The enum tests still need adapting)