### PR TITLE
Fixing Flaky Datetime Test with Hypothesis

### DIFF
--- a/pytests/tests/test_datetime.py
+++ b/pytests/tests/test_datetime.py
@@ -6,7 +6,7 @@ import sys
 
 import pyo3_pytests.datetime as rdt
 import pytest
-from hypothesis import example, given
+from hypothesis import given
 from hypothesis import strategies as st
 
 
@@ -227,7 +227,6 @@ def test_datetime_typeerror():
 
 
 @given(dt=st.datetimes(MIN_DATETIME, MAX_DATETIME))
-@example(dt=pdt.datetime(1971, 1, 2, 0, 0))
 def test_datetime_from_timestamp(dt):
     if PYPY and dt < pdt.datetime(1900, 1, 1):
         pytest.xfail("pdt.datetime.timestamp will raise on PyPy with dates before 1900")

--- a/pytests/tests/test_datetime.py
+++ b/pytests/tests/test_datetime.py
@@ -56,11 +56,11 @@ else:
 IS_WINDOWS = sys.platform == "win32"
 
 if IS_WINDOWS:
-    MIN_DATETIME = pdt.datetime(1971, 1, 2, 0, 0)
+    MIN_DATETIME = pdt.datetime(1970, 1, 1, 0, 0, 0)
     if IS_32_BIT:
-        MAX_DATETIME = pdt.datetime(3001, 1, 19, 4, 59, 59)
+        MAX_DATETIME = pdt.datetime(2038, 1, 18, 23, 59, 59)
     else:
-        MAX_DATETIME = pdt.datetime(3001, 1, 19, 7, 59, 59)
+        MAX_DATETIME = pdt.datetime(3000, 12, 31, 23, 59, 59)
 else:
     if IS_32_BIT:
         # TS ±2147483648 (2**31)

--- a/pytests/tests/test_datetime.py
+++ b/pytests/tests/test_datetime.py
@@ -96,7 +96,11 @@ def test_date_from_timestamp(d):
     if PYPY and d < pdt.date(1900, 1, 1):
         pytest.xfail("pdt.datetime.timestamp will raise on PyPy with dates before 1900")
 
-    ts = pdt.datetime.timestamp(pdt.datetime.combine(d, pdt.time(0)))
+    ts = pdt.datetime.timestamp(
+        pdt.datetime.combine(d, pdt.time(0)).replace(
+            tzinfo=pdt.timezone(pdt.timedelta(0))
+        )
+    )
     assert rdt.date_from_timestamp(int(ts)) == pdt.date.fromtimestamp(ts)
 
 
@@ -231,7 +235,7 @@ def test_datetime_from_timestamp(dt):
     if PYPY and dt < pdt.datetime(1900, 1, 1):
         pytest.xfail("pdt.datetime.timestamp will raise on PyPy with dates before 1900")
 
-    ts = pdt.datetime.timestamp(dt)
+    ts = pdt.datetime.timestamp(dt.replace(tzinfo=pdt.timezone(pdt.timedelta(0))))
     assert rdt.datetime_from_timestamp(ts) == pdt.datetime.fromtimestamp(ts)
 
 


### PR DESCRIPTION
Attempt to close #3922

According to this: https://stackoverflow.com/a/78163597

`mktime` in C library on Windows can produce unexpected results if the local timezone is in DST. If we generate test cases from Hypothesis with a range, we should fix the timezone to UTC. Separate tests can be created with multiple timezones with reduced ranges. 