### PR TITLE
Automated module= field creation in declarative modules

### DIFF
--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -152,8 +152,38 @@ mod my_extension {
 # }
 ```
 
+The `#[pymodule]` macro automatically sets the `module` attribute of the `#[pyclass]` macros declared inside of it with its name.
+For nested modules, the name of the parent module is automatically added.
+In the following example, the `Unit` class will have for `module` `my_extension.submodule` because it is properly nested
+but the `Ext` class will have for `module` the default `builtins` because it not nested.
+```rust
+# #[cfg(feature = "experimental-declarative-modules")]
+# mod declarative_module_module_attr_test {
+use pyo3::prelude::*;
+    
+#[pyclass]
+struct Ext;
+
+    #[pymodule]
+mod my_extension {
+    use super::*;
+
+    #[pymodule_export]
+    use super::Ext;
+
+    #[pymodule]
+    mod submodule {
+        // This is a submodule
+        
+        #[pyclass] // This will be part of the module
+        struct Unit;
+    }
+}
+# }
+```
+It is possible to customize the `module` value for a `#[pymodule]` with the `#[pyo3(module = "MY_MODULE")]` option.
+
 Some changes are planned to this feature before stabilization, like automatically
-filling submodules into `sys.modules` to allow easier imports (see [issue #759](https://github.com/PyO3/pyo3/issues/759))
-and filling the `module` argument of inlined `#[pyclass]` automatically with the proper module name.
+filling submodules into `sys.modules` to allow easier imports (see [issue #759](https://github.com/PyO3/pyo3/issues/759)).
 Macro names might also change.
 See [issue #3900](https://github.com/PyO3/pyo3/issues/3900) to track this feature progress.

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -160,11 +160,11 @@ but the `Ext` class will have for `module` the default `builtins` because it not
 # #[cfg(feature = "experimental-declarative-modules")]
 # mod declarative_module_module_attr_test {
 use pyo3::prelude::*;
-    
+
 #[pyclass]
 struct Ext;
 
-    #[pymodule]
+#[pymodule]
 mod my_extension {
     use super::*;
 
@@ -173,8 +173,9 @@ mod my_extension {
 
     #[pymodule]
     mod submodule {
+        use super::*;
         // This is a submodule
-        
+
         #[pyclass] // This will be part of the module
         struct Unit;
     }

--- a/newsfragments/4213.added.md
+++ b/newsfragments/4213.added.md
@@ -1,0 +1,1 @@
+Properly fills the `module=` attribute of declarative modules child `#[pymodule]` and `#[pyclass]`.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -78,7 +78,7 @@ pub struct PyClassPyO3Options {
     pub weakref: Option<kw::weakref>,
 }
 
-enum PyClassPyO3Option {
+pub enum PyClassPyO3Option {
     Crate(CrateAttribute),
     Dict(kw::dict),
     Eq(kw::eq),


### PR DESCRIPTION
Sets automatically the "module" field of all contained classes and submodules in a declarative module

Adds the "module" field to `#[pymodule]` attributes in order to set the name of the parent module. By default, the module is assumed to be a root module.
