### PR TITLE
Added `From<Bound<'py, T>>` impl for `PyClassInitializer<T>`.

### DIFF
--- a/newsfragments/4214.added.md
+++ b/newsfragments/4214.added.md
@@ -1,0 +1,1 @@
+Added `From<Bound<'py, T>>` impl for `PyClassInitializer<T>`.

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -301,6 +301,13 @@ impl<T: PyClass> From<Py<T>> for PyClassInitializer<T> {
     }
 }
 
+impl<'py, T: PyClass> From<Bound<'py, T>> for PyClassInitializer<T> {
+    #[inline]
+    fn from(value: Bound<'py, T>) -> PyClassInitializer<T> {
+        PyClassInitializer::from(value.unbind())
+    }
+}
+
 // Implementation used by proc macros to allow anything convertible to PyClassInitializer<T> to be
 // the return value of pyclass #[new] method (optionally wrapped in `Result<U, E>`).
 impl<T, U> IntoPyCallbackOutput<PyClassInitializer<T>> for U

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -265,7 +265,7 @@ struct NewReturnsPy;
 #[pymethods]
 impl NewReturnsPy {
     #[new]
-    fn new(py: Python) -> PyResult<Py<NewReturnsPy>> {
+    fn new(py: Python<'_>) -> PyResult<Py<NewReturnsPy>> {
         Py::new(py, NewReturnsPy)
     }
 }
@@ -284,8 +284,8 @@ struct NewReturnsBound;
 #[pymethods]
 impl NewReturnsBound {
     #[new]
-    fn new(py: Python) -> PyResult<Bound<NewReturnsPy>> {
-        Bound::new(py, NewReturnsPy)
+    fn new(py: Python<'_>) -> PyResult<Bound<'_, NewReturnsBound>> {
+        Bound::new(py, NewReturnsBound)
     }
 }
 

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -258,3 +258,41 @@ fn test_new_existing() {
         assert!(!obj5.is(&obj6));
     });
 }
+
+#[pyclass]
+struct NewReturnsPy;
+
+#[pymethods]
+impl NewReturnsPy {
+    #[new]
+    fn new(py: Python) -> PyResult<Py<NewReturnsPy>> {
+        Py::new(py, NewReturnsPy)
+    }
+}
+
+#[test]
+fn test_new_returns_py() {
+    Python::with_gil(|py| {
+        let obj = NewReturnsPy::new(py).unwrap();
+        assert!(obj.into_bound(py).is_exact_instance_of::<NewReturnsPy>());
+    })
+}
+
+#[pyclass]
+struct NewReturnsBound;
+
+#[pymethods]
+impl NewReturnsBound {
+    #[new]
+    fn new(py: Python) -> PyResult<Bound<NewReturnsPy>> {
+        Bound::new(py, NewReturnsPy)
+    }
+}
+
+#[test]
+fn test_new_returns_bound() {
+    Python::with_gil(|py| {
+        let obj = NewReturnsBound::new(py).unwrap();
+        assert!(obj.is_exact_instance_of::<NewReturnsBound>());
+    })
+}

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -273,8 +273,9 @@ impl NewReturnsPy {
 #[test]
 fn test_new_returns_py() {
     Python::with_gil(|py| {
-        let obj = NewReturnsPy::new(py).unwrap();
-        assert!(obj.into_bound(py).is_exact_instance_of::<NewReturnsPy>());
+        let type_ = py.get_type_bound::<NewReturnsPy>();
+        let obj = type_.call0().unwrap();
+        assert!(obj.is_exact_instance_of::<NewReturnsPy>());
     })
 }
 
@@ -292,7 +293,8 @@ impl NewReturnsBound {
 #[test]
 fn test_new_returns_bound() {
     Python::with_gil(|py| {
-        let obj = NewReturnsBound::new(py).unwrap();
+        let type_ = py.get_type_bound::<NewReturnsBound>();
+        let obj = type_.call0().unwrap();
         assert!(obj.is_exact_instance_of::<NewReturnsBound>());
     })
 }


### PR DESCRIPTION
This is a tiny change that allows `Bound<T>` to be returned from a pyclass's `#[new]` method, as is already supported for `Py<T>`. 

This flexibility would be convenient in certain cases; for example, it is often desirable to have a constructor for use on the Rust-side that returns the type as a Python object (`Py<T>` or `Bound<T>`) instead of `T` directly (e.g. when you want to be able to `downcast` into `T::BaseClass`). And as long your desired arguments are the same as for your `#[new]` method, you can just reuse the same constructor for use from both Python and Rust. However, you are currently limited to getting a `Py<T>` from this, which usually has to be followed by `.into_bound(py)` if you want to do anything useful with it. But if you could have the `#[new]` method return `Bound<T>` instead, as implemented by this PR, then it would be more ergonomic to call from Rust (while making no difference on the Python side). I also think it just makes sense intuitively, since `Bound<T>` is essentially just `Py<T>` with superpowers. 

In my opinion this change is too trivial to warrant adding tests, but let me know if you disagree and I can add some.
