### PR TITLE
fix clippy

### DIFF
--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -669,6 +669,7 @@ mod tests {
                         let result = result
                             & (err.value_bound(py).to_string()
                                 == format!("{} object is not callable", CLASS_NAME));
+                        #[allow(clippy::let_and_return)]
                         result
                     }));
 
@@ -693,6 +694,7 @@ mod tests {
                         let result = result
                             & (err.value_bound(py).to_string()
                                 == format!("{} object is not callable", CLASS_NAME));
+                        #[allow(clippy::let_and_return)]
                         result
                     }));
 
@@ -943,6 +945,7 @@ mod tests {
                         let result = result
                             & (err.value_bound(py).to_string()
                                 == format!("{} object is not callable", CLASS_NAME));
+                        #[allow(clippy::let_and_return)]
                         result
                     }));
 
@@ -967,6 +970,7 @@ mod tests {
                         let result = result
                             & (err.value_bound(py).to_string()
                                 == format!("{} object is not callable", CLASS_NAME));
+                        #[allow(clippy::let_and_return)]
                         result
                     }));
 


### PR DESCRIPTION
Currently I get clippy failures on the two runs with `abi3` when running `nox -s clippy` on `main` locally. It looks like they originate from #3835. Looking at the feature flags, it seems correct to me that they trigger, but I'm not sure why CI (on main and PRs) does not seem to care...
