### PR TITLE
fix incorrect raw identifier handling for the `name` attribute of `pyfunction`s

### DIFF
--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -208,7 +208,10 @@ pub fn impl_wrap_pyfunction(
     let ctx = &Ctx::new(&krate);
     let Ctx { pyo3_path } = &ctx;
 
-    let python_name = name.map_or_else(|| func.sig.ident.unraw(), |name| name.value.0);
+    let python_name = name
+        .as_ref()
+        .map_or_else(|| &func.sig.ident, |name| &name.value.0)
+        .unraw();
 
     let tp = if pass_module.is_some() {
         let span = match func.sig.inputs.first() {

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -558,3 +558,30 @@ fn test_reference_to_bound_arguments() {
         py_assert!(py, function, "function(1, 2) == 3");
     })
 }
+
+#[test]
+fn test_pyfunction_raw_ident() {
+    #[pyfunction]
+    fn r#struct() -> bool {
+        true
+    }
+
+    #[pyfunction]
+    #[pyo3(name = "r#enum")]
+    fn raw_ident() -> bool {
+        true
+    }
+
+    #[pymodule]
+    fn m(m: &Bound<'_, PyModule>) -> PyResult<()> {
+        m.add_function(wrap_pyfunction!(r#struct, m)?)?;
+        m.add_function(wrap_pyfunction!(raw_ident, m)?)?;
+        Ok(())
+    }
+
+    Python::with_gil(|py| {
+        let m = pyo3::wrap_pymodule!(m)(py);
+        py_assert!(py, m, "m.struct()");
+        py_assert!(py, m, "m.enum()");
+    })
+}


### PR DESCRIPTION
This fixes the `#[pyo3(name = "...")]` attribute of `#[pyfunction]`s not handling raw identifiers correctly.

Xref: #4225 
