### PR TITLE
pypy/graalpy: set `Py_LIMITED_API` when `abi3` requested

### DIFF
--- a/newsfragments/4237.changed.md
+++ b/newsfragments/4237.changed.md
@@ -1,0 +1,1 @@
+Respect the Python "limited API" when building for the `abi3` feature on PyPy or GraalPy.

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -26,7 +26,7 @@ use target_lexicon::{Environment, OperatingSystem};
 use crate::{
     bail, ensure,
     errors::{Context, Error, Result},
-    format_warn, warn,
+    warn,
 };
 
 /// Minimum Python version PyO3 supports.
@@ -171,20 +171,13 @@ impl InterpreterConfig {
             out.push(format!("cargo:rustc-cfg=Py_3_{}", i));
         }
 
-        if self.implementation.is_pypy() {
-            out.push("cargo:rustc-cfg=PyPy".to_owned());
-            if self.abi3 {
-                out.push(format_warn!(
-                    "PyPy does not yet support abi3 so the build artifacts will be version-specific. \
-                    See https://foss.heptapod.net/pypy/pypy/-/issues/3397 for more information."
-                ));
-            }
-        } else if self.implementation.is_graalpy() {
-            println!("cargo:rustc-cfg=GraalPy");
-            if self.abi3 {
-                warn!("GraalPy does not support abi3 so the build artifacts will be version-specific.");
-            }
-        } else if self.abi3 {
+        match self.implementation {
+            PythonImplementation::CPython => {}
+            PythonImplementation::PyPy => out.push("cargo:rustc-cfg=PyPy".to_owned()),
+            PythonImplementation::GraalPy => out.push("cargo:rustc-cfg=GraalPy".to_owned()),
+        }
+
+        if self.abi3 {
             out.push("cargo:rustc-cfg=Py_LIMITED_API".to_owned());
         }
 
@@ -2722,10 +2715,7 @@ mod tests {
                 "cargo:rustc-cfg=Py_3_6".to_owned(),
                 "cargo:rustc-cfg=Py_3_7".to_owned(),
                 "cargo:rustc-cfg=PyPy".to_owned(),
-                "cargo:warning=PyPy does not yet support abi3 so the build artifacts \
-            will be version-specific. See https://foss.heptapod.net/pypy/pypy/-/issues/3397 \
-            for more information."
-                    .to_owned(),
+                "cargo:rustc-cfg=Py_LIMITED_API".to_owned(),
             ]
         );
     }

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -4,7 +4,7 @@ use pyo3_build_config::{
         cargo_env_var, env_var, errors::Result, is_linking_libpython, resolve_interpreter_config,
         InterpreterConfig, PythonVersion,
     },
-    PythonImplementation,
+    warn, PythonImplementation,
 };
 
 /// Minimum Python version PyO3 supports.
@@ -101,6 +101,19 @@ fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
                 versions.max,
                 std::env::var("CARGO_PKG_VERSION").unwrap()
             );
+        }
+    }
+
+    if interpreter_config.abi3 {
+        match interpreter_config.implementation {
+            PythonImplementation::CPython => {}
+            PythonImplementation::PyPy => warn!(
+                "PyPy does not yet support abi3 so the build artifacts will be version-specific. \
+                See https://foss.heptapod.net/pypy/pypy/-/issues/3397 for more information."
+            ),
+            PythonImplementation::GraalPy => warn!(
+                "GraalPy does not support abi3 so the build artifacts will be version-specific."
+            ),
         }
     }
 

--- a/pyo3-ffi/src/cpython/pythonrun.rs
+++ b/pyo3-ffi/src/cpython/pythonrun.rs
@@ -135,13 +135,9 @@ extern "C" {
 }
 
 #[inline]
-#[cfg(not(GraalPy))]
+#[cfg(not(any(PyPy, GraalPy)))]
 pub unsafe fn Py_CompileString(string: *const c_char, p: *const c_char, s: c_int) -> *mut PyObject {
-    #[cfg(not(PyPy))]
-    return Py_CompileStringExFlags(string, p, s, std::ptr::null_mut(), -1);
-
-    #[cfg(PyPy)]
-    Py_CompileStringFlags(string, p, s, std::ptr::null_mut())
+    Py_CompileStringExFlags(string, p, s, std::ptr::null_mut(), -1)
 }
 
 #[inline]

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -2,10 +2,7 @@ use crate::ffi::*;
 use crate::types::any::PyAnyMethods;
 use crate::Python;
 
-#[cfg(all(PyPy, feature = "macros"))]
-use crate::types::PyString;
-
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+#[cfg(all(not(Py_LIMITED_API), any(not(PyPy), feature = "macros")))]
 use crate::types::PyString;
 
 #[cfg(not(Py_LIMITED_API))]
@@ -164,7 +161,6 @@ fn ascii_object_bitfield() {
 
 #[test]
 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
-#[cfg_attr(Py_3_10, allow(deprecated))]
 fn ascii() {
     Python::with_gil(|py| {
         // This test relies on implementation details of PyString.
@@ -206,7 +202,6 @@ fn ascii() {
 
 #[test]
 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
-#[cfg_attr(Py_3_10, allow(deprecated))]
 fn ucs4() {
     Python::with_gil(|py| {
         let s = "哈哈🐈";


### PR DESCRIPTION
Inspired by the CI failure attempting to merge #4194

This PR changes the `abi3` builds on PyPy and GraalPy so that if the `abi3` feature is set they will still set the `Py_LIMITED_API` config.

Technically speaking this is a bit pointless because neither PyPy nor GraalPy support the `abi3` stable ABI, but it makes it easier for us to reason about feature combinations because this way when the `abi3` feature is set we always build PyO3 to only use the limited API.

I think these same changes would also make sense with #2865 because then the base cfg of the limited API would be the exact same code regardless of what interpreter implementation we're running on.