### PR TITLE
docs: close all 0.20->0.21 migration items

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -82,7 +82,7 @@ enum SimpleEnum {
 </details>
 
 ## from 0.20.* to 0.21
-<details open>
+<details>
 <summary><small>Click to expand</small></summary>
 
 PyO3 0.21 introduces a new `Bound<'py, T>` smart pointer which replaces the existing "GIL Refs" API to interact with Python objects. For example, in PyO3 0.20 the reference `&'py PyAny` would be used to interact with Python objects. In PyO3 0.21 the updated type is `Bound<'py, PyAny>`. Making this change moves Rust ownership semantics out of PyO3's internals and into user code. This change fixes [a known soundness edge case of interaction with gevent](https://github.com/PyO3/pyo3/issues/3668) as well as improves CPU and [memory performance](https://github.com/PyO3/pyo3/issues/1056). For a full history of discussion see https://github.com/PyO3/pyo3/issues/3382.
@@ -100,7 +100,7 @@ The following sections are laid out in this order.
 </details>
 
 ### Enable the `gil-refs` feature
-<details open>
+<details>
 <summary><small>Click to expand</small></summary>
 
 To make the transition for the PyO3 ecosystem away from the GIL Refs API as smooth as possible, in PyO3 0.21 no APIs consuming or producing GIL Refs have been altered. Instead, variants using `Bound<T>` smart pointers have been introduced, for example `PyTuple::new_bound` which returns `Bound<PyTuple>` is the replacement form of `PyTuple::new`. The GIL Ref APIs have been deprecated, but to make migration easier it is possible to disable these deprecation warnings by enabling the `gil-refs` feature.
@@ -127,7 +127,7 @@ pyo3 = { version = "0.21", features = ["gil-refs"] }
 </details>
 
 ### `PyTypeInfo` and `PyTryFrom` have been adjusted
-<details open>
+<details>
 <summary><small>Click to expand</small></summary>
 
 The `PyTryFrom` trait has aged poorly, its `try_from` method now conflicts with `TryFrom::try_from` in the 2021 edition prelude. A lot of its functionality was also duplicated with `PyTypeInfo`.
@@ -170,7 +170,7 @@ Python::with_gil(|py| {
 </details>
 
 ### `Iter(A)NextOutput` are deprecated
-<details open>
+<details>
 <summary><small>Click to expand</small></summary>
 
 The `__next__` and `__anext__` magic methods can now return any type convertible into Python objects directly just like all other `#[pymethods]`. The `IterNextOutput` used by `__next__` and `IterANextOutput` used by `__anext__` are subsequently deprecated. Most importantly, this change allows returning an awaitable from `__anext__` without non-sensically wrapping it into `Yield` or `Some`. Only the return types `Option<T>` and `Result<Option<T>, E>` are still handled in a special manner where `Some(val)` yields `val` and `None` stops iteration.
@@ -292,21 +292,21 @@ impl PyClassAsyncIter {
 </details>
 
 ### `PyType::name` has been renamed to `PyType::qualname`
-<details open>
+<details>
 <summary><small>Click to expand</small></summary>
 
 `PyType::name` has been renamed to `PyType::qualname` to indicate that it does indeed return the [qualified name](https://docs.python.org/3/glossary.html#term-qualified-name), matching the `__qualname__` attribute. The newly added `PyType::name` yields the full name including the module name now which corresponds to `__module__.__name__` on the level of attributes.
 </details>
 
 ### `PyCell` has been deprecated
-<details open>
+<details>
 <summary><small>Click to expand</small></summary>
 
 Interactions with Python objects implemented in Rust no longer need to go though `PyCell<T>`. Instead iteractions with Python object now consistently go through `Bound<T>` or `Py<T>` independently of whether `T` is native Python object or a `#[pyclass]` implemented in Rust. Use `Bound::new` or `Py::new` respectively to create and `Bound::borrow(_mut)` / `Py::borrow(_mut)` to borrow the Rust object.
 </details>
 
 ### Migrating from the GIL Refs API to `Bound<T>`
-<details open>
+<details>
 <summary><small>Click to expand</small></summary>
 
 To minimise breakage of code using the GIL Refs API, the `Bound<T>` smart pointer has been introduced by adding complements to all functions which accept or return GIL Refs. This allows code to migrate by replacing the deprecated APIs with the new ones.
@@ -404,7 +404,7 @@ Despite a large amount of deprecations warnings produced by PyO3 to aid with the
 </details>
 
 ### Deactivating the `gil-refs` feature
-<details open>
+<details>
 <summary><small>Click to expand</small></summary>
 
 As a final step of migration, deactivating the `gil-refs` feature will set up code for best performance and is intended to set up a forward-compatible API for PyO3 0.22.


### PR DESCRIPTION
As we approach 0.22 release, collapse all 0.20 -> 0.21 items by default. Will just merge this as trivial.