### PR TITLE
refactor: use `ptr_from_ref` and ptr `.cast()`

### DIFF
--- a/pyo3-ffi/src/abstract_.rs
+++ b/pyo3-ffi/src/abstract_.rs
@@ -114,10 +114,7 @@ extern "C" {
 #[cfg(not(any(Py_3_8, PyPy)))]
 #[inline]
 pub unsafe fn PyIter_Check(o: *mut PyObject) -> c_int {
-    crate::PyObject_HasAttrString(
-        crate::Py_TYPE(o).cast(),
-        "__next__\0".as_ptr() as *const c_char,
-    )
+    crate::PyObject_HasAttrString(crate::Py_TYPE(o).cast(), "__next__\0".as_ptr().cast())
 }
 
 extern "C" {

--- a/pyo3-ffi/src/cpython/abstract_.rs
+++ b/pyo3-ffi/src/cpython/abstract_.rs
@@ -61,7 +61,7 @@ pub unsafe fn PyVectorcall_Function(callable: *mut PyObject) -> Option<vectorcal
     assert!(PyCallable_Check(callable) > 0);
     let offset = (*tp).tp_vectorcall_offset;
     assert!(offset > 0);
-    let ptr = (callable as *const c_char).offset(offset) as *const Option<vectorcallfunc>;
+    let ptr = callable.cast::<c_char>().offset(offset).cast();
     *ptr
 }
 

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -13,7 +13,9 @@
 use crate::{PyLong_AsLong, PyLong_Check, PyObject_GetAttrString, Py_DecRef};
 use crate::{PyObject, PyObject_TypeCheck, PyTypeObject, Py_TYPE};
 use std::cell::UnsafeCell;
-use std::os::raw::{c_char, c_int};
+#[cfg(not(GraalPy))]
+use std::os::raw::c_char;
+use std::os::raw::c_int;
 use std::ptr;
 #[cfg(not(PyPy))]
 use {crate::PyCapsule_Import, std::ffi::CString};

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -356,7 +356,7 @@ pub unsafe fn PyDateTime_DELTA_GET_MICROSECONDS(o: *mut PyObject) -> c_int {
 #[inline]
 #[cfg(GraalPy)]
 pub unsafe fn _get_attr(obj: *mut PyObject, field: &str) -> c_int {
-    let result = PyObject_GetAttrString(obj, field.as_ptr() as *const c_char);
+    let result = PyObject_GetAttrString(obj, field.as_ptr().cast());
     Py_DecRef(result); // the original macros are borrowing
     if PyLong_Check(result) == 1 {
         PyLong_AsLong(result) as c_int
@@ -416,7 +416,7 @@ pub unsafe fn PyDateTime_DATE_GET_FOLD(o: *mut PyObject) -> c_int {
 #[inline]
 #[cfg(GraalPy)]
 pub unsafe fn PyDateTime_DATE_GET_TZINFO(o: *mut PyObject) -> *mut PyObject {
-    let res = PyObject_GetAttrString(o, "tzinfo\0".as_ptr() as *const c_char);
+    let res = PyObject_GetAttrString(o, "tzinfo\0".as_ptr().cast());
     Py_DecRef(res); // the original macros are borrowing
     res
 }
@@ -454,7 +454,7 @@ pub unsafe fn PyDateTime_TIME_GET_FOLD(o: *mut PyObject) -> c_int {
 #[inline]
 #[cfg(GraalPy)]
 pub unsafe fn PyDateTime_TIME_GET_TZINFO(o: *mut PyObject) -> *mut PyObject {
-    let res = PyObject_GetAttrString(o, "tzinfo\0".as_ptr() as *const c_char);
+    let res = PyObject_GetAttrString(o, "tzinfo\0".as_ptr().cast());
     Py_DecRef(res); // the original macros are borrowing
     res
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -263,7 +263,7 @@ impl<T: Element> PyBuffer<T> {
                 },
                 #[cfg(Py_3_11)]
                 {
-                    indices.as_ptr() as *const ffi::Py_ssize_t
+                    indices.as_ptr().cast()
                 },
                 #[cfg(not(Py_3_11))]
                 {
@@ -317,7 +317,7 @@ impl<T: Element> PyBuffer<T> {
     /// However, dimensions of length 0 are possible and might need special attention.
     #[inline]
     pub fn shape(&self) -> &[usize] {
-        unsafe { slice::from_raw_parts(self.0.shape as *const usize, self.0.ndim as usize) }
+        unsafe { slice::from_raw_parts(self.0.shape.cast(), self.0.ndim as usize) }
     }
 
     /// Returns an array that holds, for each dimension, the number of bytes to skip to get to the next element in the dimension.
@@ -361,23 +361,13 @@ impl<T: Element> PyBuffer<T> {
     /// Gets whether the buffer is contiguous in C-style order (last index varies fastest when visiting items in order of memory address).
     #[inline]
     pub fn is_c_contiguous(&self) -> bool {
-        unsafe {
-            ffi::PyBuffer_IsContiguous(
-                &*self.0 as *const ffi::Py_buffer,
-                b'C' as std::os::raw::c_char,
-            ) != 0
-        }
+        unsafe { ffi::PyBuffer_IsContiguous(&*self.0, b'C' as std::os::raw::c_char) != 0 }
     }
 
     /// Gets whether the buffer is contiguous in Fortran-style order (first index varies fastest when visiting items in order of memory address).
     #[inline]
     pub fn is_fortran_contiguous(&self) -> bool {
-        unsafe {
-            ffi::PyBuffer_IsContiguous(
-                &*self.0 as *const ffi::Py_buffer,
-                b'F' as std::os::raw::c_char,
-            ) != 0
-        }
+        unsafe { ffi::PyBuffer_IsContiguous(&*self.0, b'F' as std::os::raw::c_char) != 0 }
     }
 
     /// Gets the buffer memory as a slice.
@@ -609,7 +599,7 @@ impl<T: Element> PyBuffer<T> {
                 },
                 #[cfg(Py_3_11)]
                 {
-                    source.as_ptr() as *const raw::c_void
+                    source.as_ptr().cast()
                 },
                 #[cfg(not(Py_3_11))]
                 {

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -48,7 +48,6 @@ use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
 use crate::{Bound, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject};
-use std::os::raw::c_char;
 
 #[cfg(feature = "num-bigint")]
 use num_bigint::BigInt;
@@ -68,19 +67,13 @@ macro_rules! rational_conversion {
                 let py_numerator_obj = unsafe {
                     Bound::from_owned_ptr_or_err(
                         py,
-                        ffi::PyObject_GetAttrString(
-                            obj.as_ptr(),
-                            "numerator\0".as_ptr() as *const c_char,
-                        ),
+                        ffi::PyObject_GetAttrString(obj.as_ptr(), "numerator\0".as_ptr().cast()),
                     )
                 };
                 let py_denominator_obj = unsafe {
                     Bound::from_owned_ptr_or_err(
                         py,
-                        ffi::PyObject_GetAttrString(
-                            obj.as_ptr(),
-                            "denominator\0".as_ptr() as *const c_char,
-                        ),
+                        ffi::PyObject_GetAttrString(obj.as_ptr(), "denominator\0".as_ptr().cast()),
                     )
                 };
                 let numerator_owned = unsafe {

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -4,8 +4,6 @@ use crate::types::PyString;
 use crate::{ffi, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
-#[cfg(not(windows))]
-use std::os::raw::c_char;
 
 impl ToPyObject for OsStr {
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -23,7 +21,7 @@ impl ToPyObject for OsStr {
             #[cfg(not(target_os = "wasi"))]
             let bytes = std::os::unix::ffi::OsStrExt::as_bytes(self);
 
-            let ptr = bytes.as_ptr() as *const c_char;
+            let ptr = bytes.as_ptr().cast();
             let len = bytes.len() as ffi::Py_ssize_t;
             unsafe {
                 // DecodeFSDefault automatically chooses an appropriate decoding mechanism to

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -12,7 +12,6 @@
 use crate::{ffi, Bound, PyResult, Python};
 use std::ffi::CStr;
 use std::ops;
-use std::os::raw::c_char;
 
 /// The boilerplate to convert between a Rust type and a Python exception.
 #[doc(hidden)]
@@ -682,7 +681,7 @@ impl PyUnicodeDecodeError {
         unsafe {
             ffi::PyUnicodeDecodeError_Create(
                 encoding.as_ptr(),
-                input.as_ptr() as *const c_char,
+                input.as_ptr().cast(),
                 input.len() as ffi::Py_ssize_t,
                 range.start as ffi::Py_ssize_t,
                 range.end as ffi::Py_ssize_t,

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -318,9 +318,9 @@ impl FunctionDescription {
         let kwnames: Option<Borrowed<'_, '_, PyTuple>> =
             Borrowed::from_ptr_or_opt(py, kwnames).map(|kwnames| kwnames.downcast_unchecked());
         if let Some(kwnames) = kwnames {
-            // Safety: PyArg has the same memory layout as `*mut ffi::PyObject`
             let kwargs = ::std::slice::from_raw_parts(
-                (args as *const PyArg<'py>).offset(nargs),
+                // Safety: PyArg has the same memory layout as `*mut ffi::PyObject`
+                args.offset(nargs).cast::<PyArg<'py>>(),
                 kwnames.len(),
             );
 

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -70,8 +70,8 @@ impl ModuleDef {
         };
 
         let ffi_def = UnsafeCell::new(ffi::PyModuleDef {
-            m_name: name.as_ptr() as *const _,
-            m_doc: doc.as_ptr() as *const _,
+            m_name: name.as_ptr().cast(),
+            m_doc: doc.as_ptr().cast(),
             ..INIT
         });
 

--- a/src/internal_tricks.rs
+++ b/src/internal_tricks.rs
@@ -217,3 +217,9 @@ pub(crate) fn extract_c_string(
     };
     Ok(cow)
 }
+
+// TODO: use ptr::from_ref on MSRV 1.76
+#[inline]
+pub(crate) const fn ptr_from_ref<T>(t: &T) -> *const T {
+    t as *const T
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -214,7 +214,7 @@ macro_rules! append_to_inittab {
                 );
             }
             $crate::ffi::PyImport_AppendInittab(
-                $module::__PYO3_NAME.as_ptr() as *const ::std::os::raw::c_char,
+                $module::__PYO3_NAME.as_ptr().cast(),
                 ::std::option::Option::Some($module::__pyo3_init),
             );
         }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -652,7 +652,7 @@ impl<'py> Python<'py> {
     ) -> PyResult<Bound<'py, PyAny>> {
         let code = CString::new(code)?;
         unsafe {
-            let mptr = ffi::PyImport_AddModule("__main__\0".as_ptr() as *const _);
+            let mptr = ffi::PyImport_AddModule("__main__\0".as_ptr().cast());
             if mptr.is_null() {
                 return Err(PyErr::fetch(self));
             }

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -202,6 +202,7 @@ use crate::types::any::PyAnyMethods;
 use crate::{
     conversion::ToPyObject,
     impl_::pyclass::PyClassImpl,
+    internal_tricks::ptr_from_ref,
     pyclass::boolean_struct::True,
     pyclass_init::PyClassInitializer,
     type_object::{PyLayout, PySizedLayout},
@@ -511,7 +512,7 @@ where
 #[allow(deprecated)]
 unsafe impl<T: PyClass> AsPyPointer for PyCell<T> {
     fn as_ptr(&self) -> *mut ffi::PyObject {
-        (self as *const _) as *mut _
+        ptr_from_ref(self) as *mut _
     }
 }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -4,6 +4,7 @@ use crate::err::{DowncastError, DowncastIntoError, PyErr, PyResult};
 use crate::exceptions::{PyAttributeError, PyTypeError};
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Bound;
+use crate::internal_tricks::ptr_from_ref;
 use crate::py_result_ext::PyResultExt;
 use crate::type_object::{PyTypeCheck, PyTypeInfo};
 #[cfg(not(any(PyPy, GraalPy)))]
@@ -912,7 +913,7 @@ impl PyAny {
     /// when they are finished with the pointer.
     #[inline]
     pub fn as_ptr(&self) -> *mut ffi::PyObject {
-        self as *const PyAny as *mut ffi::PyObject
+        ptr_from_ref(self) as *mut ffi::PyObject
     }
 
     /// Returns an owned raw FFI pointer represented by self.
@@ -2211,7 +2212,7 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     #[inline]
     unsafe fn downcast_unchecked<T>(&self) -> &Bound<'py, T> {
-        &*(self as *const Bound<'py, PyAny>).cast()
+        &*ptr_from_ref(self).cast()
     }
 
     #[inline]

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -6,7 +6,6 @@ use crate::types::any::PyAnyMethods;
 use crate::{ffi, PyAny, Python};
 #[cfg(feature = "gil-refs")]
 use crate::{AsPyPointer, PyNativeType};
-use std::os::raw::c_char;
 use std::slice;
 
 /// Represents a Python `bytearray`.
@@ -20,7 +19,7 @@ impl PyByteArray {
     ///
     /// The byte string is initialized by copying the data from the `&[u8]`.
     pub fn new_bound<'py>(py: Python<'py>, src: &[u8]) -> Bound<'py, PyByteArray> {
-        let ptr = src.as_ptr() as *const c_char;
+        let ptr = src.as_ptr().cast();
         let len = src.len() as ffi::Py_ssize_t;
         unsafe {
             ffi::PyByteArray_FromStringAndSize(ptr, len)

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -5,7 +5,6 @@ use crate::types::any::PyAnyMethods;
 use crate::PyNativeType;
 use crate::{ffi, Py, PyAny, PyResult, Python};
 use std::ops::Index;
-use std::os::raw::c_char;
 use std::slice::SliceIndex;
 use std::str;
 
@@ -23,7 +22,7 @@ impl PyBytes {
     ///
     /// Panics if out of memory.
     pub fn new_bound<'p>(py: Python<'p>, s: &[u8]) -> Bound<'p, PyBytes> {
-        let ptr = s.as_ptr() as *const c_char;
+        let ptr = s.as_ptr().cast();
         let len = s.len() as ffi::Py_ssize_t;
         unsafe {
             ffi::PyBytes_FromStringAndSize(ptr, len)
@@ -85,7 +84,7 @@ impl PyBytes {
     /// `std::slice::from_raw_parts`, this is
     /// unsafe](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety).
     pub unsafe fn bound_from_ptr(py: Python<'_>, ptr: *const u8, len: usize) -> Bound<'_, PyBytes> {
-        ffi::PyBytes_FromStringAndSize(ptr as *const _, len as isize)
+        ffi::PyBytes_FromStringAndSize(ptr.cast(), len as isize)
             .assume_owned(py)
             .downcast_into_unchecked()
     }


### PR DESCRIPTION
Typically these days I like to use `x.cast::<Y>()` instead of `x as *const Y` to perform pointer casting (and in many contexts it's also convenient to let type inference work on just `x.cast()`, which reads a lot nicer than `x as *const _`). It also avoids const <-> mut casting by accident.

I just discovered [`ptr::from_ref`](https://doc.rust-lang.org/std/ptr/fn.from_ref.html) and am now similarly excited to replace `&x as *const X` with `ptr_from_ref(&x)`.

... so this PR is just a few tidy-ups across the codebase!