### PR TITLE
ci: updates for Rust 1.79

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ used_underscore_binding = "warn"
 [workspace.lints.rust]
 elided_lifetimes_in_paths = "warn"
 invalid_doc_attributes = "warn"
-rust_2018_idioms = "warn"
+rust_2018_idioms = { level = "warn", priority = -1 }
 rust_2021_prelude_collisions = "warn"
 unused_lifetimes = "warn"
 

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -959,11 +959,11 @@ impl CrossCompileEnvVars {
 ///
 /// This function relies on PyO3 cross-compiling environment variables:
 ///
-///   * `PYO3_CROSS`: If present, forces PyO3 to configure as a cross-compilation.
-///   * `PYO3_CROSS_LIB_DIR`: If present, must be set to the directory containing
+/// * `PYO3_CROSS`: If present, forces PyO3 to configure as a cross-compilation.
+/// * `PYO3_CROSS_LIB_DIR`: If present, must be set to the directory containing
 ///   the target's libpython DSO and the associated `_sysconfigdata*.py` file for
 ///   Unix-like targets, or the Python DLL import libraries for the Windows target.
-///   * `PYO3_CROSS_PYTHON_VERSION`: Major and minor version (e.g. 3.9) of the target Python
+/// * `PYO3_CROSS_PYTHON_VERSION`: Major and minor version (e.g. 3.9) of the target Python
 ///   installation. This variable is only needed if PyO3 cannnot determine the version to target
 ///   from `abi3-py3*` features, or if there are multiple versions of Python present in
 ///   `PYO3_CROSS_LIB_DIR`.
@@ -1056,7 +1056,7 @@ impl BuildFlags {
                 .iter()
                 .filter(|flag| {
                     config_map
-                        .get_value(&flag.to_string())
+                        .get_value(flag.to_string())
                         .map_or(false, |value| value == "1")
                 })
                 .cloned()

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -180,6 +180,7 @@ macro_rules! import_exception_bound {
 /// * `name` is the name of the new exception type.
 /// * `base` is the base class of `MyError`, usually [`PyException`].
 /// * `doc` (optional) is the docstring visible to users (with `.__doc__` and `help()`) and
+///
 /// accompanies your error type in your crate's documentation.
 ///
 /// # Examples

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -13,11 +13,10 @@
 //! The functions in this module lack individual safety documentation, but
 //! generally the following apply:
 //! - Pointer arguments have to point to a valid Python object of the correct type,
-//! although null pointers are sometimes valid input.
+//!   although null pointers are sometimes valid input.
 //! - The vast majority can only be used safely while the GIL is held.
 //! - Some functions have additional safety requirements, consult the
-//! [Python/C API Reference Manual][capi]
-//! for more information.
+//!   [Python/C API Reference Manual][capi] for more information.
 //!
 //! [capi]: https://docs.python.org/3/c-api/index.html
 

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -76,6 +76,7 @@ impl PyClassWeakRef for PyClassDummySlot {
 ///
 /// `#[pyclass(dict)]` automatically adds this.
 #[repr(transparent)]
+#[allow(dead_code)] // These are constructed in INIT and used by the macro code
 pub struct PyClassDictSlot(*mut ffi::PyObject);
 
 impl PyClassDict for PyClassDictSlot {
@@ -93,6 +94,7 @@ impl PyClassDict for PyClassDictSlot {
 ///
 /// `#[pyclass(weakref)]` automatically adds this.
 #[repr(transparent)]
+#[allow(dead_code)] // These are constructed in INIT and used by the macro code
 pub struct PyClassWeakRefSlot(*mut ffi::PyObject);
 
 impl PyClassWeakRef for PyClassWeakRefSlot {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -730,10 +730,12 @@ impl<T> IntoPy<PyObject> for Borrowed<'_, '_, T> {
 /// Instead, call one of its methods to access the inner object:
 ///  - [`Py::bind`] or [`Py::into_bound`], to borrow a GIL-bound reference to the contained object.
 ///  - [`Py::borrow`], [`Py::try_borrow`], [`Py::borrow_mut`], or [`Py::try_borrow_mut`],
+///
 /// to get a (mutable) reference to a contained pyclass, using a scheme similar to std's [`RefCell`].
 /// See the [guide entry](https://pyo3.rs/latest/class.html#bound-and-interior-mutability)
 /// for more information.
 ///  - You can call methods directly on `Py` with [`Py::call_bound`], [`Py::call_method_bound`] and friends.
+///
 /// These require passing in the [`Python<'py>`](crate::Python) token but are otherwise similar to the corresponding
 /// methods on [`PyAny`].
 ///

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -11,7 +11,7 @@
 //! It also supports this pattern that many extension modules employ:
 //! - Drop the GIL, so that other Python threads can acquire it and make progress themselves
 //! - Do something independently of the Python interpreter, like IO, a long running calculation or
-//! awaiting a future
+//!   awaiting a future
 //! - Once that is done, reacquire the GIL
 //!
 //! That API is provided by [`Python::allow_threads`] and enforced via the [`Ungil`] bound on the
@@ -308,9 +308,9 @@ pub use nightly::Ungil;
 /// It serves three main purposes:
 /// - It provides a global API for the Python interpreter, such as [`Python::eval_bound`].
 /// - It can be passed to functions that require a proof of holding the GIL, such as
-/// [`Py::clone_ref`].
+///   [`Py::clone_ref`].
 /// - Its lifetime represents the scope of holding the GIL which can be used to create Rust
-/// references that are bound to it, such as `&`[`PyAny`].
+///   references that are bound to it, such as `&`[`PyAny`].
 ///
 /// Note that there are some caveats to using it that you might need to be aware of. See the
 /// [Deadlocks](#deadlocks) and [Releasing and freeing memory](#releasing-and-freeing-memory)
@@ -320,11 +320,11 @@ pub use nightly::Ungil;
 ///
 /// The following are the recommended ways to obtain a [`Python`] token, in order of preference:
 /// - In a function or method annotated with [`#[pyfunction]`](crate::pyfunction) or [`#[pymethods]`](crate::pymethods) you can declare it
-/// as a parameter, and PyO3 will pass in the token when Python code calls it.
+///   as a parameter, and PyO3 will pass in the token when Python code calls it.
 /// - If you already have something with a lifetime bound to the GIL, such as `&`[`PyAny`], you can
-/// use its `.py()` method to get a token.
+///   use its `.py()` method to get a token.
 /// - When you need to acquire the GIL yourself, such as when calling Python code from Rust, you
-/// should call [`Python::with_gil`] to do that and pass your code as a closure to it.
+///   should call [`Python::with_gil`] to do that and pass your code as a closure to it.
 ///
 /// # Deadlocks
 ///
@@ -1157,12 +1157,12 @@ impl<'unbound> Python<'unbound> {
     /// # Safety
     ///
     /// - This token and any borrowed Python references derived from it can only be safely used
-    /// whilst the currently executing thread is actually holding the GIL.
+    ///   whilst the currently executing thread is actually holding the GIL.
     /// - This function creates a token with an *unbounded* lifetime. Safe code can assume that
-    /// holding a `Python<'py>` token means the GIL is and stays acquired for the lifetime `'py`.
-    /// If you let it or borrowed Python references escape to safe code you are
-    /// responsible for bounding the lifetime `'unbound` appropriately. For more on unbounded
-    /// lifetimes, see the [nomicon].
+    ///   holding a `Python<'py>` token means the GIL is and stays acquired for the lifetime `'py`.
+    ///   If you let it or borrowed Python references escape to safe code you are
+    ///   responsible for bounding the lifetime `'unbound` appropriately. For more on unbounded
+    ///   lifetimes, see the [nomicon].
     ///
     /// [nomicon]: https://doc.rust-lang.org/nomicon/unbounded-lifetimes.html
     #[inline]

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -8,14 +8,14 @@
 //! pattern. This requires that PyO3 enforces the borrowing rules and it has two mechanisms for
 //! doing so:
 //! - Statically it can enforce threadsafe access with the [`Python<'py>`](crate::Python) token.
-//! All Rust code holding that token, or anything derived from it, can assume that they have
-//! safe access to the Python interpreter's state. For this reason all the native Python objects
-//! can be mutated through shared references.
+//!   All Rust code holding that token, or anything derived from it, can assume that they have
+//!   safe access to the Python interpreter's state. For this reason all the native Python objects
+//!   can be mutated through shared references.
 //! - However, methods and functions in Rust usually *do* need `&mut` references. While PyO3 can
-//! use the [`Python<'py>`](crate::Python) token to guarantee thread-safe access to them, it cannot
-//! statically guarantee uniqueness of `&mut` references. As such those references have to be tracked
-//! dynamically at runtime, using `PyCell` and the other types defined in this module. This works
-//! similar to std's [`RefCell`](std::cell::RefCell) type.
+//!   use the [`Python<'py>`](crate::Python) token to guarantee thread-safe access to them, it cannot
+//!   statically guarantee uniqueness of `&mut` references. As such those references have to be tracked
+//!   dynamically at runtime, using `PyCell` and the other types defined in this module. This works
+//!   similar to std's [`RefCell`](std::cell::RefCell) type.
 //!
 //! # When *not* to use PyCell
 //!

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -67,8 +67,8 @@ unsafe impl<T> Sync for GILProtected<T> where T: Send {}
 ///  2) If the initialization function `f` provided to `get_or_init` (or `get_or_try_init`)
 ///     temporarily releases the GIL (e.g. by calling `Python::import`) then it is possible
 ///     for a second thread to also begin initializing the `GITOnceCell`. Even when this
-///     happens `GILOnceCell` guarantees that only **one** write to the cell ever occurs
-///     - this is treated as a race, other threads will discard the value they compute and
+///     happens `GILOnceCell` guarantees that only **one** write to the cell ever occurs -
+///     this is treated as a race, other threads will discard the value they compute and
 ///     return the result of the first complete computation.
 ///
 /// # Examples

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -26,13 +26,13 @@ use std::os::raw::c_int;
 /// with the other [native Python types](crate::types):
 ///
 /// - It can only be obtained and used while the GIL is held,
-/// therefore its API does not require a [`Python<'py>`](crate::Python) token.
+///   therefore its API does not require a [`Python<'py>`](crate::Python) token.
 /// - It can't be used in situations where the GIL is temporarily released,
-/// such as [`Python::allow_threads`](crate::Python::allow_threads)'s closure.
+///   such as [`Python::allow_threads`](crate::Python::allow_threads)'s closure.
 /// - The underlying Python object, if mutable, can be mutated through any reference.
 /// - It can be converted to the GIL-independent [`Py`]`<`[`PyAny`]`>`,
-/// allowing it to outlive the GIL scope. However, using [`Py`]`<`[`PyAny`]`>`'s API
-/// *does* require a [`Python<'py>`](crate::Python) token.
+///   allowing it to outlive the GIL scope. However, using [`Py`]`<`[`PyAny`]`>`'s API
+///   *does* require a [`Python<'py>`](crate::Python) token.
 ///
 /// It can be cast to a concrete type with PyAny::downcast (for native Python types only)
 /// and FromPyObject::extract. See their documentation for more information.

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -149,11 +149,11 @@ impl PyByteArray {
     ///
     /// These mutations may occur in Python code as well as from Rust:
     /// - Calling methods like [`PyByteArray::as_bytes_mut`] and [`PyByteArray::resize`] will
-    /// invalidate the slice.
+    ///   invalidate the slice.
     /// - Actions like dropping objects or raising exceptions can invoke `__del__`methods or signal
-    /// handlers, which may execute arbitrary Python code. This means that if Python code has a
-    /// reference to the `bytearray` you cannot safely use the vast majority of PyO3's API whilst
-    /// using the slice.
+    ///   handlers, which may execute arbitrary Python code. This means that if Python code has a
+    ///   reference to the `bytearray` you cannot safely use the vast majority of PyO3's API whilst
+    ///   using the slice.
     ///
     /// As a result, this slice should only be used for short-lived operations without executing any
     /// Python code, such as copying into a Vec.
@@ -311,11 +311,11 @@ pub trait PyByteArrayMethods<'py>: crate::sealed::Sealed {
     ///
     /// These mutations may occur in Python code as well as from Rust:
     /// - Calling methods like [`PyByteArrayMethods::as_bytes_mut`] and [`PyByteArrayMethods::resize`] will
-    /// invalidate the slice.
+    ///   invalidate the slice.
     /// - Actions like dropping objects or raising exceptions can invoke `__del__`methods or signal
-    /// handlers, which may execute arbitrary Python code. This means that if Python code has a
-    /// reference to the `bytearray` you cannot safely use the vast majority of PyO3's API whilst
-    /// using the slice.
+    ///   handlers, which may execute arbitrary Python code. This means that if Python code has a
+    ///   reference to the `bytearray` you cannot safely use the vast majority of PyO3's API whilst
+    ///   using the slice.
     ///
     /// As a result, this slice should only be used for short-lived operations without executing any
     /// Python code, such as copying into a Vec.

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -851,7 +851,7 @@ mod tests {
     #[cfg(not(any(PyPy, GraalPy)))]
     fn test_from_sequence() {
         Python::with_gil(|py| {
-            let items = PyList::new_bound(py, &vec![("a", 1), ("b", 2)]);
+            let items = PyList::new_bound(py, vec![("a", 1), ("b", 2)]);
             let dict = PyDict::from_sequence_bound(&items).unwrap();
             assert_eq!(
                 1,
@@ -882,7 +882,7 @@ mod tests {
     #[cfg(not(any(PyPy, GraalPy)))]
     fn test_from_sequence_err() {
         Python::with_gil(|py| {
-            let items = PyList::new_bound(py, &vec!["a", "b"]);
+            let items = PyList::new_bound(py, vec!["a", "b"]);
             assert!(PyDict::from_sequence_bound(&items).is_err());
         });
     }

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -280,7 +280,7 @@ fn test_generic_list_set() {
             .items
             .iter()
             .zip(&[1u32, 2, 3])
-            .all(|(a, b)| a.bind(py).eq(&b.into_py(py)).unwrap()));
+            .all(|(a, b)| a.bind(py).eq(b.into_py(py)).unwrap()));
     });
 }
 

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -45,10 +45,10 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_>` is not 
    |                                                  ^^^^ the trait `PyClass` is not implemented for `CancelHandle`, which is required by `CancelHandle: PyFunctionArgument<'_, '_>`
    |
    = help: the following other types implement trait `PyFunctionArgument<'a, 'py>`:
-             Option<&'a pyo3::Bound<'py, T>>
+             &'a mut pyo3::coroutine::Coroutine
              &'a pyo3::Bound<'py, T>
              &'a pyo3::coroutine::Coroutine
-             &'a mut pyo3::coroutine::Coroutine
+             Option<&'a pyo3::Bound<'py, T>>
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_>`
@@ -68,10 +68,10 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_>` is not 
    |                                                  ^^^^ the trait `Clone` is not implemented for `CancelHandle`, which is required by `CancelHandle: PyFunctionArgument<'_, '_>`
    |
    = help: the following other types implement trait `PyFunctionArgument<'a, 'py>`:
-             Option<&'a pyo3::Bound<'py, T>>
+             &'a mut pyo3::coroutine::Coroutine
              &'a pyo3::Bound<'py, T>
              &'a pyo3::coroutine::Coroutine
-             &'a mut pyo3::coroutine::Coroutine
+             Option<&'a pyo3::Bound<'py, T>>
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_>`

--- a/tests/ui/invalid_pyfunctions.stderr
+++ b/tests/ui/invalid_pyfunctions.stderr
@@ -54,10 +54,10 @@ error[E0277]: the trait bound `&str: From<BoundRef<'_, '_, pyo3::prelude::PyModu
    |              ^ the trait `From<BoundRef<'_, '_, pyo3::prelude::PyModule>>` is not implemented for `&str`, which is required by `BoundRef<'_, '_, pyo3::prelude::PyModule>: Into<_>`
    |
    = help: the following other types implement trait `From<T>`:
-             <String as From<char>>
+             <String as From<&String>>
+             <String as From<&mut str>>
+             <String as From<&str>>
              <String as From<Box<str>>>
              <String as From<Cow<'a, str>>>
-             <String as From<&str>>
-             <String as From<&mut str>>
-             <String as From<&String>>
+             <String as From<char>>
    = note: required for `BoundRef<'_, '_, pyo3::prelude::PyModule>` to implement `Into<&str>`

--- a/tests/ui/invalid_pymethod_receiver.stderr
+++ b/tests/ui/invalid_pymethod_receiver.stderr
@@ -6,9 +6,9 @@ error[E0277]: the trait bound `i32: TryFrom<BoundRef<'_, '_, MyClass>>` is not s
   |
   = help: the following other types implement trait `From<T>`:
             <i32 as From<bool>>
-            <i32 as From<i8>>
             <i32 as From<i16>>
-            <i32 as From<u8>>
+            <i32 as From<i8>>
             <i32 as From<u16>>
+            <i32 as From<u8>>
   = note: required for `BoundRef<'_, '_, MyClass>` to implement `Into<i32>`
   = note: required for `i32` to implement `TryFrom<BoundRef<'_, '_, MyClass>>`

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -187,8 +187,8 @@ error[E0277]: the trait bound `i32: From<BoundRef<'_, '_, PyType>>` is not satis
    |
    = help: the following other types implement trait `From<T>`:
              <i32 as From<bool>>
-             <i32 as From<i8>>
              <i32 as From<i16>>
-             <i32 as From<u8>>
+             <i32 as From<i8>>
              <i32 as From<u16>>
+             <i32 as From<u8>>
    = note: required for `BoundRef<'_, '_, PyType>` to implement `Into<i32>`

--- a/tests/ui/invalid_pymethods_duplicates.stderr
+++ b/tests/ui/invalid_pymethods_duplicates.stderr
@@ -16,14 +16,14 @@ error[E0277]: the trait bound `TwoNew: PyTypeInfo` is not satisfied
   |      ^^^^^^ the trait `PyTypeInfo` is not implemented for `TwoNew`
   |
   = help: the following other types implement trait `PyTypeInfo`:
+            CancelledError
+            IncompleteReadError
+            InvalidStateError
+            LimitOverrunError
+            PanicException
             PyAny
-            PyBool
-            PyByteArray
-            PyBytes
-            PyCapsule
-            PyCode
-            PyComplex
-            PyDate
+            PyArithmeticError
+            PyAssertionError
           and $N others
 
 error[E0592]: duplicate definitions with name `__pymethod___new____`

--- a/tests/ui/invalid_result_conversion.stderr
+++ b/tests/ui/invalid_result_conversion.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `PyErr: From<MyError>` is not satisfied
    | ^^^^^^^^^^^^^ the trait `From<MyError>` is not implemented for `PyErr`, which is required by `MyError: Into<PyErr>`
    |
    = help: the following other types implement trait `From<T>`:
-             <PyErr as From<pyo3::Bound<'py, T>>>
-             <PyErr as From<std::io::Error>>
-             <PyErr as From<PyBorrowError>>
-             <PyErr as From<PyBorrowMutError>>
+             <PyErr as From<AddrParseError>>
+             <PyErr as From<DecodeUtf16Error>>
              <PyErr as From<DowncastError<'_, '_>>>
              <PyErr as From<DowncastIntoError<'_>>>
-             <PyErr as From<NulError>>
-             <PyErr as From<IntoStringError>>
+             <PyErr as From<FromUtf16Error>>
+             <PyErr as From<FromUtf8Error>>
+             <PyErr as From<Infallible>>
+             <PyErr as From<IntoInnerError<W>>>
            and $N others
    = note: required for `MyError` to implement `Into<PyErr>`
    = note: this error originates in the attribute macro `pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/static_ref.stderr
+++ b/tests/ui/static_ref.stderr
@@ -29,9 +29,11 @@ error[E0597]: `holder_0` does not live long enough
   | |           |
   | |           `holder_0` dropped here while still borrowed
   | binding `holder_0` declared here
-  | argument requires that `holder_0` is borrowed for `'static`
 5 | fn static_ref(list: &'static Bound<'_, PyList>) -> usize {
-  |               ^^^^^^^ borrowed value does not live long enough
+  |               ^^^^^^-
+  |               |     |
+  |               |     argument requires that `holder_0` is borrowed for `'static`
+  |               borrowed value does not live long enough
 
 error: lifetime may not live long enough
  --> tests/ui/static_ref.rs:9:1


### PR DESCRIPTION
UI test updates for Rust 1.79

I've also addressed the clippy-beta and nightly failures in separate commits, we can also split them out if desirable.