### PR TITLE
implement `PartialEq<str>` for `Bound<'py, PyString>`

### DIFF
--- a/newsfragments/4245.added.md
+++ b/newsfragments/4245.added.md
@@ -1,0 +1,1 @@
+Implement `PartialEq<str>` for `Bound<'py, PyString>`.

--- a/pyo3-ffi/src/unicodeobject.rs
+++ b/pyo3-ffi/src/unicodeobject.rs
@@ -328,6 +328,15 @@ extern "C" {
     pub fn PyUnicode_Compare(left: *mut PyObject, right: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_CompareWithASCIIString")]
     pub fn PyUnicode_CompareWithASCIIString(left: *mut PyObject, right: *const c_char) -> c_int;
+    #[cfg(Py_3_13)]
+    pub fn PyUnicode_EqualToUTF8(unicode: *mut PyObject, string: *const c_char) -> c_int;
+    #[cfg(Py_3_13)]
+    pub fn PyUnicode_EqualToUTF8AndSize(
+        unicode: *mut PyObject,
+        string: *const c_char,
+        size: Py_ssize_t,
+    ) -> c_int;
+
     pub fn PyUnicode_RichCompare(
         left: *mut PyObject,
         right: *mut PyObject,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2010,9 +2010,7 @@ impl PyObject {
 #[cfg(test)]
 mod tests {
     use super::{Bound, Py, PyObject};
-    use crate::types::any::PyAnyMethods;
-    use crate::types::{dict::IntoPyDict, PyDict, PyString};
-    use crate::types::{PyCapsule, PyStringMethods};
+    use crate::types::{dict::IntoPyDict, PyAnyMethods, PyCapsule, PyDict, PyString};
     use crate::{ffi, Borrowed, PyAny, PyResult, Python, ToPyObject};
 
     #[test]
@@ -2021,7 +2019,7 @@ mod tests {
             let obj = py.get_type_bound::<PyDict>().to_object(py);
 
             let assert_repr = |obj: &Bound<'_, PyAny>, expected: &str| {
-                assert_eq!(obj.repr().unwrap().to_cow().unwrap(), expected);
+                assert_eq!(obj.repr().unwrap(), expected);
             };
 
             assert_repr(obj.call0(py).unwrap().bind(py), "{}");
@@ -2221,7 +2219,7 @@ a = A()
             let obj_unbound: Py<PyString> = obj.unbind();
             let obj: Bound<'_, PyString> = obj_unbound.into_bound(py);
 
-            assert_eq!(obj.to_cow().unwrap(), "hello world");
+            assert_eq!(obj, "hello world");
         });
     }
 

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -515,12 +515,8 @@ impl<'py> TryFrom<&Bound<'py, PyAny>> for Bound<'py, PyByteArray> {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::any::PyAnyMethods;
-    use crate::types::bytearray::PyByteArrayMethods;
-    use crate::types::string::PyStringMethods;
-    use crate::types::PyByteArray;
-    use crate::{exceptions, Bound, PyAny};
-    use crate::{PyObject, Python};
+    use crate::types::{PyAnyMethods, PyByteArray, PyByteArrayMethods};
+    use crate::{exceptions, Bound, PyAny, PyObject, Python};
 
     #[test]
     fn test_len() {
@@ -555,10 +551,7 @@ mod tests {
 
             slice[0..5].copy_from_slice(b"Hi...");
 
-            assert_eq!(
-                bytearray.str().unwrap().to_cow().unwrap(),
-                "bytearray(b'Hi... Python')"
-            );
+            assert_eq!(bytearray.str().unwrap(), "bytearray(b'Hi... Python')");
         });
     }
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -37,7 +37,7 @@ impl PyModule {
     /// Python::with_gil(|py| -> PyResult<()> {
     ///     let module = PyModule::new_bound(py, "my_module")?;
     ///
-    ///     assert_eq!(module.name()?.to_cow()?, "my_module");
+    ///     assert_eq!(module.name()?, "my_module");
     ///     Ok(())
     /// })?;
     /// # Ok(())}
@@ -729,10 +729,7 @@ mod tests {
     fn module_import_and_name() {
         Python::with_gil(|py| {
             let builtins = PyModule::import_bound(py, "builtins").unwrap();
-            assert_eq!(
-                builtins.name().unwrap().to_cow().unwrap().as_ref(),
-                "builtins"
-            );
+            assert_eq!(builtins.name().unwrap(), "builtins");
         })
     }
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -721,7 +721,7 @@ fn __name__(py: Python<'_>) -> &Bound<'_, PyString> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        types::{module::PyModuleMethods, string::PyStringMethods, PyModule},
+        types::{module::PyModuleMethods, PyModule},
         Python,
     };
 
@@ -736,6 +736,7 @@ mod tests {
     #[test]
     #[cfg(not(PyPy))]
     fn module_filename() {
+        use crate::types::string::PyStringMethods;
         Python::with_gil(|py| {
             let site = PyModule::import_bound(py, "site").unwrap();
             assert!(site

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -541,7 +541,7 @@ impl PartialEq<str> for Borrowed<'_, '_, PyString> {
         }
 
         #[cfg(Py_3_13)]
-        {
+        unsafe {
             ffi::PyUnicode_EqualToUTF8AndSize(
                 self.as_ptr(),
                 other.as_ptr().cast(),

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -139,14 +139,15 @@ impl<'a> PyStringData<'a> {
 ///
 /// ```rust
 /// # use pyo3::prelude::*;
+/// use pyo3::types::PyString;
 ///
 /// # Python::with_gil(|py| {
-/// let py_string = PyString::new(py, "foo");
+/// let py_string = PyString::new_bound(py, "foo");
 /// // via PartialEq<str>
 /// assert_eq!(py_string, "foo");
 ///
 /// // via Python equality
-/// assert!(py_string.eq("foo").unwrap());
+/// assert!(py_string.as_any().eq("foo").unwrap());
 /// # });
 /// ```
 #[repr(transparent)]

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -131,7 +131,7 @@ fn test_delattr() {
 fn test_str() {
     Python::with_gil(|py| {
         let example_py = make_example(py);
-        assert_eq!(example_py.str().unwrap().to_cow().unwrap(), "5");
+        assert_eq!(example_py.str().unwrap(), "5");
     })
 }
 
@@ -139,10 +139,7 @@ fn test_str() {
 fn test_repr() {
     Python::with_gil(|py| {
         let example_py = make_example(py);
-        assert_eq!(
-            example_py.repr().unwrap().to_cow().unwrap(),
-            "ExampleClass(value=5)"
-        );
+        assert_eq!(example_py.repr().unwrap(), "ExampleClass(value=5)");
     })
 }
 


### PR DESCRIPTION
Idea spurred by #4020 and also what I've just been doing in #4196.

This PR implements comparison between Python `str` and Rust `&str` by using:
- The new `PyUnicode_EqualToUTF8AndSize` on Python 3.13,
- fallback to converting to a Rust `&str` and doing equality that way on older versions.

`PyUnicode_EqualToUTF8AndSize` can never fail, so similarly the fallback implementations just return `false` on error getting UTF8 data out.