### PR TITLE
Add several missing wrappers to PyAnyMethods

### DIFF
--- a/newsfragments/4264.changed.md
+++ b/newsfragments/4264.changed.md
@@ -1,0 +1,1 @@
+Added `PyAnyMethods::{bitnot, matmul, floor_div, rem, divmod}` for completeness.


### PR DESCRIPTION
I discovered these missing bits when I was working on a `starlark-rust` binding -- I had to forward between Python and Starlark most magic methods but some are missing in `PyAnyMethods`, for example those for [`//` and `%`](https://github.com/xen0n/xingque/blob/0.1.0/src/py2sl/slpyobject.rs#L308), among a couple of others.

I have consulted [the Python C API Number protocol](https://docs.python.org/3.12/c-api/number.html) and this seems complete. Please review and thanks for maintaining this great framework!