### PR TITLE
Bump diagnostic_namespace rust version

### DIFF
--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -141,7 +141,9 @@ pub fn print_feature_cfgs() {
         println!("cargo:rustc-cfg=invalid_from_utf8_lint");
     }
 
-    if rustc_minor_version >= 78 {
+    // Actually this is available on 1.78, but we should avoid
+    // https://github.com/rust-lang/rust/issues/124651 just in case
+    if rustc_minor_version >= 79 {
         println!("cargo:rustc-cfg=diagnostic_namespace");
     }
 }


### PR DESCRIPTION
Now that rust 1.79 is out, I'd like to avoid using `diagnostic_namespace` on 1.78. Because we don't test CI for 1.78 it seems prudent to not use it for that version.
