### PR TITLE
ci: check minimal-versions on MSRV feature powerset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,8 @@ jobs:
         run: echo LD_LIBRARY_PATH=${pythonLocation}/lib >> $GITHUB_ENV
 
       - if: inputs.rust == '1.63.0'
-        name: Prepare minimal package versions (MSRV only)
-        run: nox -s set-minimal-package-versions
+        name: Prepare MSRV package versions
+        run: nox -s set-msrv-package-versions
 
       - if: inputs.rust != 'stable'
         name: Ignore changed error messages when using trybuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ on:
       rust-target:
         required: true
         type: string
-      msrv:
-        default: false
-        type: boolean
+      MSRV:
+        required: true
+        type: string
 
 jobs:
   build:
@@ -54,7 +54,7 @@ jobs:
         name: Prepare LD_LIBRARY_PATH (Ubuntu only)
         run: echo LD_LIBRARY_PATH=${pythonLocation}/lib >> $GITHUB_ENV
 
-      - if: inputs.msrv
+      - if: inputs.rust == inputs.MSRV
         name: Prepare MSRV package versions
         run: nox -s set-msrv-package-versions
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ on:
       rust-target:
         required: true
         type: string
+      msrv:
+        default: false
+        type: boolean
 
 jobs:
   build:
@@ -51,7 +54,7 @@ jobs:
         name: Prepare LD_LIBRARY_PATH (Ubuntu only)
         run: echo LD_LIBRARY_PATH=${pythonLocation}/lib >> $GITHUB_ENV
 
-      - if: inputs.rust == '1.63.0'
+      - if: inputs.msrv
         name: Prepare MSRV package versions
         run: nox -s set-msrv-package-versions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,12 +220,14 @@ jobs:
       python-architecture: ${{ matrix.platform.python-architecture }}
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
+      msrv: ${{ matrix.msrv }}
     secrets: inherit
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
         rust: [stable]
+        msrv: [false]
         python-version: [
           "3.7",
           "3.8",
@@ -265,7 +267,8 @@ jobs:
           ]
         include:
           # Test minimal supported Rust version
-          - rust: ${{ needs.resolve.outputs.MSRV }}
+          - msrv: true
+            rust: ${{ needs.resolve.outputs.MSRV }}
             python-version: "3.12"
             platform:
               {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,18 @@ jobs:
       - name: Check rust formatting (rustfmt)
         run: nox -s rustfmt
 
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      MSRV: ${{ steps.resolve-msrv.outputs.MSRV }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: resolve MSRV
+        id: resolve-msrv
+        run:
+          echo MSRV=`python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["package"]["rust-version"])'` >> $GITHUB_OUTPUT
+
   semver-checks:
     if: github.ref != 'refs/heads/main'
     needs: [fmt]
@@ -41,13 +53,13 @@ jobs:
       - uses: obi1kenobi/cargo-semver-checks-action@v2
 
   check-msrv:
-    needs: [fmt]
+    needs: [fmt, resolve]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63.0
+          toolchain: ${{ needs.resolve.outputs.MSRV }}
           targets: x86_64-unknown-linux-gnu
           components: rust-src
       - uses: actions/setup-python@v5
@@ -57,9 +69,11 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
       - run: python -m pip install --upgrade pip && pip install nox
-      - name: Prepare minimal package versions
-        run: nox -s set-minimal-package-versions
-      - run: nox -s check-all
+      # This is a smoke test to confirm that CI will run on MSRV (including dev dependencies)
+      - name: Check with MSRV package versions
+        run: |
+          nox -s set-msrv-package-versions
+          nox -s check-all
 
     env:
       CARGO_BUILD_TARGET: x86_64-unknown-linux-gnu
@@ -198,7 +212,7 @@ jobs:
   build-full:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} rust-${{ matrix.rust }}
-    needs: [fmt]
+    needs: [fmt, resolve]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.platform.os }}
@@ -251,7 +265,7 @@ jobs:
           ]
         include:
           # Test minimal supported Rust version
-          - rust: 1.63.0
+          - rust: ${{ needs.resolve.outputs.MSRV }}
             python-version: "3.12"
             platform:
               {
@@ -487,21 +501,31 @@ jobs:
       - run: python3 -m nox -s test-version-limits
 
   check-feature-powerset:
-    needs: [fmt]
+    needs: [fmt, resolve]
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
+    name: check-feature-powerset ${{ matrix.rust }}
+    strategy:
+      # run on stable and MSRV to check that all combinations of features are expected to build fine on our supported
+      # range of compilers
+      matrix:
+        rust: ["stable"]
+        include:
+          - rust: ${{ needs.resolve.outputs.MSRV }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
-          components: rust-src
-      - uses: taiki-e/install-action@cargo-hack
+          toolchain: stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack,cargo-minimal-versions
       - run: python3 -m pip install --upgrade pip && pip install nox
-      - run: python3 -m nox -s check-feature-powerset
+      - run: python3 -m nox -s check-feature-powerset -- ${{ matrix.rust != 'stable' && 'minimal-versions' || '' }}
 
   test-cross-compilation:
     needs: [fmt]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
   build-pr:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-build-full') && github.event_name == 'pull_request' }}
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} rust-${{ matrix.rust }}
-    needs: [fmt]
+    needs: [fmt, resolve]
     uses: ./.github/workflows/build.yml
     with:
       os: ${{ matrix.platform.os }}
@@ -163,6 +163,7 @@ jobs:
       python-architecture: ${{ matrix.platform.python-architecture }}
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
+      MSRV: ${{ needs.resolve.outputs.MSRV }}
     secrets: inherit
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
@@ -220,14 +221,13 @@ jobs:
       python-architecture: ${{ matrix.platform.python-architecture }}
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
-      msrv: ${{ matrix.msrv }}
+      MSRV: ${{ needs.resolve.outputs.MSRV }}
     secrets: inherit
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
         rust: [stable]
-        msrv: [false]
         python-version: [
           "3.7",
           "3.8",
@@ -267,8 +267,7 @@ jobs:
           ]
         include:
           # Test minimal supported Rust version
-          - msrv: true
-            rust: ${{ needs.resolve.outputs.MSRV }}
+          - rust: ${{ needs.resolve.outputs.MSRV }}
             python-version: "3.12"
             platform:
               {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ either = { version = "1.9", optional = true }
 eyre = { version = ">= 0.4, < 0.7", optional = true }
 hashbrown = { version = ">= 0.9, < 0.15", optional = true }
 indexmap = { version = ">= 1.6, < 3", optional = true }
-num-bigint = { version = "0.4", optional = true }
+num-bigint = { version = "0.4.2", optional = true }
 num-complex = { version = ">= 0.2, < 0.5", optional = true }
 num-rational = {version = "0.4.1", optional = true }
 rust_decimal = { version = "1.15", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.63"
 cfg-if = "1.0"
 libc = "0.2.62"
 memoffset = "0.9"
-once_cell = "1.13.0"
+once_cell = "1.13"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
 pyo3-ffi = { path = "pyo3-ffi", version = "=0.22.0-dev" }
@@ -32,7 +32,7 @@ unindent = { version = "0.2.1", optional = true }
 inventory = { version = "0.3.0", optional = true }
 
 # crate integrations that can be added using the eponymous features
-anyhow = { version = "1.0", optional = true }
+anyhow = { version = "1.0.1", optional = true }
 chrono = { version = "0.4.25", default-features = false, optional = true }
 chrono-tz = { version = ">= 0.6, < 0.10", default-features = false, optional = true }
 either = { version = "1.9", optional = true }
@@ -42,7 +42,7 @@ indexmap = { version = ">= 1.6, < 3", optional = true }
 num-bigint = { version = "0.4", optional = true }
 num-complex = { version = ">= 0.2, < 0.5", optional = true }
 num-rational = {version = "0.4.1", optional = true }
-rust_decimal = { version = "1.0.0", default-features = false, optional = true }
+rust_decimal = { version = "1.15", default-features = false, optional = true }
 serde = { version = "1.0", optional = true }
 smallvec = { version = "1.0", optional = true }
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -543,8 +543,8 @@ def check_changelog(session: nox.Session):
         print(fragment.name)
 
 
-@nox.session(name="set-minimal-package-versions", venv_backend="none")
-def set_minimal_package_versions(session: nox.Session):
+@nox.session(name="set-msrv-package-versions", venv_backend="none")
+def set_msrv_package_versions(session: nox.Session):
     from collections import defaultdict
 
     if toml is None:
@@ -708,10 +708,14 @@ def check_feature_powerset(session: nox.Session):
     rust_flags = env.get("RUSTFLAGS", "")
     env["RUSTFLAGS"] = f"{rust_flags} -Dwarnings"
 
+    subcommand = "hack"
+    if "minimal-versions" in session.posargs:
+        subcommand = "minimal-versions"
+
     comma_join = ",".join
     _run_cargo(
         session,
-        "hack",
+        subcommand,
         "--feature-powerset",
         '--optional-deps=""',
         f'--skip="{comma_join(features_to_skip)}"',


### PR DESCRIPTION
Inspired by #4272 

Using `cargo update -Z direct-minimal-versions` (or `cargo update -Z minimal-versions`) is known to be complicated. I started playing with these and had not much success due to various combinations of dev dependencies and other edge cases.

[`cargo-minimal-versions`](https://github.com/taiki-e/cargo-minimal-versions) worked great, however, and given it's a superset around `cargo-hack` which we already use in the `check-feature-powerset` job, I decided to just upgrade that job a bit to run a minimal-versions check on MSRV.

This caught a few extra cases where our minimal dependencies were too low.

