### PR TITLE
improve deprecation message on implicit trailing optionals

### DIFF
--- a/pyo3-macros-backend/src/deprecations.rs
+++ b/pyo3-macros-backend/src/deprecations.rs
@@ -61,8 +61,9 @@ pub(crate) fn deprecate_trailing_option_default(spec: &FnSpec<'_>) -> TokenStrea
     {
         use std::fmt::Write;
         let mut deprecation_msg = String::from(
-            "This function has implicit defaults for the trailing `Option<T>` arguments. \
-             These implicit defaults are being phased out. Add `#[pyo3(signature = (",
+            "this function has implicit defaults for the trailing `Option<T>` arguments \n\
+             = note: these implicit defaults are being phased out \n\
+             = help: add `#[pyo3(signature = (",
         );
         spec.signature.arguments.iter().for_each(|arg| {
             match arg {
@@ -84,8 +85,9 @@ pub(crate) fn deprecate_trailing_option_default(spec: &FnSpec<'_>) -> TokenStrea
         deprecation_msg.pop();
         deprecation_msg.pop();
 
-        deprecation_msg
-            .push_str(")]` to this function to silence this warning and keep the current behavior");
+        deprecation_msg.push_str(
+            "))]` to this function to silence this warning and keep the current behavior",
+        );
         quote_spanned! { spec.name.span() =>
             #[deprecated(note = #deprecation_msg)]
             #[allow(dead_code)]

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -10,25 +10,33 @@ note: the lint level is defined here
 1  | #![deny(deprecated)]
    |         ^^^^^^^^^^
 
-error: use of deprecated constant `MyClass::__pymethod_set_set_option__::SIGNATURE`: This function has implicit defaults for the trailing `Option<T>` arguments. These implicit defaults are being phased out. Add `#[pyo3(signature = (_value=None)]` to this function to silence this warning and keep the current behavior
+error: use of deprecated constant `MyClass::__pymethod_set_set_option__::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
+       = note: these implicit defaults are being phased out
+       = help: add `#[pyo3(signature = (_value=None))]` to this function to silence this warning and keep the current behavior
   --> tests/ui/deprecations.rs:43:8
    |
 43 |     fn set_option(&self, _value: Option<i32>) {}
    |        ^^^^^^^^^^
 
-error: use of deprecated constant `__pyfunction_pyfunction_option_2::SIGNATURE`: This function has implicit defaults for the trailing `Option<T>` arguments. These implicit defaults are being phased out. Add `#[pyo3(signature = (_i, _any=None)]` to this function to silence this warning and keep the current behavior
+error: use of deprecated constant `__pyfunction_pyfunction_option_2::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
+       = note: these implicit defaults are being phased out
+       = help: add `#[pyo3(signature = (_i, _any=None))]` to this function to silence this warning and keep the current behavior
    --> tests/ui/deprecations.rs:132:4
     |
 132 | fn pyfunction_option_2(_i: u32, _any: Option<i32>) {}
     |    ^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated constant `__pyfunction_pyfunction_option_3::SIGNATURE`: This function has implicit defaults for the trailing `Option<T>` arguments. These implicit defaults are being phased out. Add `#[pyo3(signature = (_i, _any=None, _foo=None)]` to this function to silence this warning and keep the current behavior
+error: use of deprecated constant `__pyfunction_pyfunction_option_3::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
+       = note: these implicit defaults are being phased out
+       = help: add `#[pyo3(signature = (_i, _any=None, _foo=None))]` to this function to silence this warning and keep the current behavior
    --> tests/ui/deprecations.rs:135:4
     |
 135 | fn pyfunction_option_3(_i: u32, _any: Option<i32>, _foo: Option<String>) {}
     |    ^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated constant `__pyfunction_pyfunction_option_4::SIGNATURE`: This function has implicit defaults for the trailing `Option<T>` arguments. These implicit defaults are being phased out. Add `#[pyo3(signature = (_i, _any=None, _foo=None)]` to this function to silence this warning and keep the current behavior
+error: use of deprecated constant `__pyfunction_pyfunction_option_4::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
+       = note: these implicit defaults are being phased out
+       = help: add `#[pyo3(signature = (_i, _any=None, _foo=None))]` to this function to silence this warning and keep the current behavior
    --> tests/ui/deprecations.rs:138:4
     |
 138 | fn pyfunction_option_4(


### PR DESCRIPTION
Testing out 0.22 release branch in `pydantic-core`, I noticed that the error message here generates hints like

```
Add `#[pyo3(signature = (error_type, context=None)]` to this function to silence this warning
```

which is missing a closing `)`.

I also decided to split the message up into multiple lines.

... I'll merge this as a trivial adjustment and rebase the release on it.