### PR TITLE
Don't raise `TypeError` from generated equality method

### DIFF
--- a/newsfragments/4287.changed.md
+++ b/newsfragments/4287.changed.md
@@ -1,0 +1,1 @@
+Return `NotImplemented` from generated equality method when comparing different types.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1844,9 +1844,13 @@ fn pyclass_richcmp(
                 op: #pyo3_path::pyclass::CompareOp
             ) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
                 let self_val = self;
-                let other = &*#pyo3_path::types::PyAnyMethods::downcast::<Self>(other)?.borrow();
-                match op {
-                    #arms
+                if let Ok(other) = #pyo3_path::types::PyAnyMethods::downcast::<Self>(other) {
+                    let other = &*other.borrow();
+                    match op {
+                        #arms
+                    }
+                } else {
+                    ::std::result::Result::Ok(py.NotImplemented())
                 }
             }
         };

--- a/pytests/src/comparisons.rs
+++ b/pytests/src/comparisons.rs
@@ -34,6 +34,18 @@ impl EqDefaultNe {
     }
 }
 
+#[pyclass(eq)]
+#[derive(PartialEq, Eq)]
+struct EqDerived(i64);
+
+#[pymethods]
+impl EqDerived {
+    #[new]
+    fn new(value: i64) -> Self {
+        Self(value)
+    }
+}
+
 #[pyclass]
 struct Ordered(i64);
 
@@ -104,6 +116,7 @@ impl OrderedDefaultNe {
 pub fn comparisons(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Eq>()?;
     m.add_class::<EqDefaultNe>()?;
+    m.add_class::<EqDerived>()?;
     m.add_class::<Ordered>()?;
     m.add_class::<OrderedDefaultNe>()?;
     Ok(())

--- a/pytests/tests/test_comparisons.py
+++ b/pytests/tests/test_comparisons.py
@@ -1,7 +1,13 @@
 from typing import Type, Union
 
 import pytest
-from pyo3_pytests.comparisons import Eq, EqDefaultNe, Ordered, OrderedDefaultNe
+from pyo3_pytests.comparisons import (
+    Eq,
+    EqDefaultNe,
+    EqDerived,
+    Ordered,
+    OrderedDefaultNe,
+)
 from typing_extensions import Self
 
 
@@ -9,15 +15,23 @@ class PyEq:
     def __init__(self, x: int) -> None:
         self.x = x
 
-    def __eq__(self, other: Self) -> bool:
-        return self.x == other.x
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return self.x == other.x
+        else:
+            return NotImplemented
 
     def __ne__(self, other: Self) -> bool:
-        return self.x != other.x
+        if isinstance(other, self.__class__):
+            return self.x != other.x
+        else:
+            return NotImplemented
 
 
-@pytest.mark.parametrize("ty", (Eq, PyEq), ids=("rust", "python"))
-def test_eq(ty: Type[Union[Eq, PyEq]]):
+@pytest.mark.parametrize(
+    "ty", (Eq, EqDerived, PyEq), ids=("rust", "rust-derived", "python")
+)
+def test_eq(ty: Type[Union[Eq, EqDerived, PyEq]]):
     a = ty(0)
     b = ty(0)
     c = ty(1)
@@ -31,6 +45,13 @@ def test_eq(ty: Type[Union[Eq, PyEq]]):
     assert not (a != b)
     assert b != c
     assert not (b == c)
+
+    assert not a == 0
+    assert a != 0
+    assert not b == 0
+    assert b != 1
+    assert not c == 1
+    assert c != 1
 
     with pytest.raises(TypeError):
         assert a <= b


### PR DESCRIPTION
While updating a project to replace manually-written `__eq__()` methods with the new `#[pyclass(eq)]` option added in 0.22, I found that doing so causes a `TypeError` to be raised when objects of different types are checked for equality. I believe it should return `NotImplemented` instead, to stay consistent with pyclasses that use `__eq__()` and standard Python types.

This PR contains the change, and a test to confirm the comparison behavior.

Please let me know how this looks, particularly the tests -- I'm not sure if I got those in the right spot 🙂 Thanks!