### PR TITLE
Fix 128-bit int regression on big-endian with Python <3.13

### DIFF
--- a/newsfragments/4291.fixed.md
+++ b/newsfragments/4291.fixed.md
@@ -1,0 +1,1 @@
+Fix 128-bit int regression on big-endian platforms with Python <3.13

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -238,15 +238,18 @@ mod fast_128bit_int_conversion {
                         unsafe { ffi::PyNumber_Index(ob.as_ptr()).assume_owned_or_err(ob.py())? };
                     let mut buffer = [0u8; std::mem::size_of::<$rust_type>()];
                     #[cfg(not(Py_3_13))]
-                    crate::err::error_on_minusone(ob.py(), unsafe {
-                        ffi::_PyLong_AsByteArray(
-                            num.as_ptr() as *mut ffi::PyLongObject,
-                            buffer.as_mut_ptr(),
-                            buffer.len(),
-                            1,
-                            $is_signed.into(),
-                        )
-                    })?;
+                    {
+                        crate::err::error_on_minusone(ob.py(), unsafe {
+                            ffi::_PyLong_AsByteArray(
+                                num.as_ptr() as *mut ffi::PyLongObject,
+                                buffer.as_mut_ptr(),
+                                buffer.len(),
+                                1,
+                                $is_signed.into(),
+                            )
+                        })?;
+                        Ok(<$rust_type>::from_le_bytes(buffer))
+                    }
                     #[cfg(Py_3_13)]
                     {
                         let mut flags = ffi::Py_ASNATIVEBYTES_NATIVE_ENDIAN;
@@ -272,8 +275,8 @@ mod fast_128bit_int_conversion {
                                 "Python int larger than 128 bits",
                             ));
                         }
+                        Ok(<$rust_type>::from_ne_bytes(buffer))
                     }
-                    Ok(<$rust_type>::from_ne_bytes(buffer))
                 }
 
                 #[cfg(feature = "experimental-inspect")]


### PR DESCRIPTION
Fixes #4290.

As described in the issue, a change from `Ok(<$rust_type>::from_le_bytes(buffer))` to `Ok(<$rust_type>::from_ne_bytes(buffer))` was unconditional, but was only appropriate when the preceding Python-3.13-only block was compiled. This PR makes that change conditional on Python version, too.

I tested this as a patch on all Fedora releases and EPEL9 and confirmed the tests now pass on all Fedora primary architectures, for both Python 3.13 and previous interpreter versions.

----

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
