### PR TITLE
refs #4300, adds a `sealedclass` attribute that allows opting into the usage of unit enum variants with complex enums.

### DIFF
--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -41,7 +41,8 @@ pub mod kw {
     syn::custom_keyword!(transparent);
     syn::custom_keyword!(unsendable);
     syn::custom_keyword!(weakref);
-    syn::custom_keyword!(sealedclass);
+    syn::custom_keyword!(unit_variants);
+    syn::custom_keyword!(unit_variant);
 }
 
 #[derive(Clone, Debug)]
@@ -173,12 +174,39 @@ impl ToTokens for TextSignatureAttributeValue {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UnitVariantsAttributeValue {
+    CLike,
+    TupleLike,
+}
+
+impl Parse for UnitVariantsAttributeValue {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let lit = input.parse::<LitStr>()?;
+        Ok(match lit.value().as_str() {
+            "c-like" => Self::CLike,
+            "tuple-like" => Self::TupleLike,
+            _ => bail_spanned!(lit.span() => "unit_variants must be 'c-like' or 'tuple-like'"),
+        })
+    }
+}
+
+impl ToTokens for UnitVariantsAttributeValue {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            UnitVariantsAttributeValue::CLike => "c-like".to_tokens(tokens),
+            UnitVariantsAttributeValue::TupleLike => "tuple-like".to_tokens(tokens),
+        }
+    }
+}
+
 pub type ExtendsAttribute = KeywordAttribute<kw::extends, Path>;
 pub type FreelistAttribute = KeywordAttribute<kw::freelist, Box<Expr>>;
 pub type ModuleAttribute = KeywordAttribute<kw::module, LitStr>;
 pub type NameAttribute = KeywordAttribute<kw::name, NameLitStr>;
 pub type RenameAllAttribute = KeywordAttribute<kw::rename_all, RenamingRuleLitStr>;
 pub type TextSignatureAttribute = KeywordAttribute<kw::text_signature, TextSignatureAttributeValue>;
+pub type UnitVariantsAttribute = KeywordAttribute<kw::unit_variants, UnitVariantsAttributeValue>;
 
 impl<K: Parse + std::fmt::Debug, V: Parse> Parse for KeywordAttribute<K, V> {
     fn parse(input: ParseStream<'_>) -> Result<Self> {

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -41,6 +41,7 @@ pub mod kw {
     syn::custom_keyword!(transparent);
     syn::custom_keyword!(unsendable);
     syn::custom_keyword!(weakref);
+    syn::custom_keyword!(sealedclass);
 }
 
 #[derive(Clone, Debug)]

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -561,8 +561,10 @@ impl<'a> PyClassComplexEnum<'a> {
 
                 let variant = match &variant.fields {
                     Fields::Unit => {
-                        let witness = witness.as_ref().expect("complex enum has a non-unit variant");
                         if args.options.sealedclass.is_none() {
+                            let witness = witness
+                                .as_ref()
+                                .expect("complex enum has a non-unit variant");
                             bail_spanned!(variant.span() => format!(
                             "Unit variant `{ident}` is not yet supported in a complex enum\n\
                             = help: change to an empty tuple variant instead: `{ident}()`\n\

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1029,20 +1029,7 @@ fn impl_complex_enum(
             impl_complex_enum_variant_cls(cls, &variant, ctx)?;
         variant_cls_impls.push(variant_cls_impl);
 
-        let has_new_fn = !matches!(variant, PyClassEnumVariant::Unit(_)) || {
-            let field_is_tuple = variant
-                .get_options()
-                .unit_variant
-                .as_ref()
-                .map(|opt| matches!(opt.value, UnitVariantAttributeValue::TupleLike));
-            let default_is_tuple = args
-                .options
-                .unit_variants
-                .as_ref()
-                .is_some_and(|opt| matches!(opt.value, UnitVariantsAttributeValue::TupleLike));
-            field_is_tuple.unwrap_or(default_is_tuple)
-        };
-
+        let has_new_fn = !matches!(variant, PyClassEnumVariant::Unit(PyClassEnumUnitVariant { tuple_like: false, .. }));
         if has_new_fn {
             let variant_new = complex_enum_variant_new(cls, variant, ctx)?;
             slots.push(variant_new);

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -556,11 +556,19 @@ impl<'a> PyClassComplexEnum<'a> {
                 let variant = match &variant.fields {
                     Fields::Unit => {
                         if args.options.sealedclass.is_none() {
+                            let witness = enum_
+                                .variants
+                                .iter()
+                                .find(|variant| !matches!(variant, syn::Fields::Unit))
+                                .expect("complex enum has a non-unit variant")
+                                .ident
+                                .to_owned();
+
                             bail_spanned!(variant.span() => format!(
                             "Unit variant `{ident}` is not yet supported in a complex enum\n\
                             = help: change to an empty tuple variant instead: `{ident}()`\n\
                             = note: the enum is complex because of non-unit variant `{witness}`",
-                            ident=ident, witness=variant.ident))
+                            ident=ident, witness=witness))
                         } else {
                             PyClassEnumVariant::Unit(PyClassEnumUnitVariant { ident, options })
                         }

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -18,7 +18,10 @@ use syn::{
 
 mod signature;
 
-pub use self::signature::{ConstructorAttribute, FunctionSignature, SignatureAttribute};
+pub use self::signature::{
+    ConstructorAttribute, FunctionSignature, SignatureAttribute, UnitVariantAttribute,
+    UnitVariantAttributeValue,
+};
 
 #[derive(Clone, Debug)]
 pub struct PyFunctionArgPyO3Attributes {

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -152,7 +152,7 @@ fn pyclass_impl(
     mut ast: syn::ItemStruct,
     methods_type: PyClassMethodsType,
 ) -> TokenStream {
-    let args = parse_macro_input!(attrs with PyClassArgs::parse_stuct_args);
+    let args = parse_macro_input!(attrs with PyClassArgs::parse_struct_args);
     let expanded = build_py_class(&mut ast, args, methods_type).unwrap_or_compile_error();
 
     quote!(

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
+error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`, `sealedclass`
  --> tests/ui/invalid_pyclass_args.rs:3:11
   |
 3 | #[pyclass(extend=pyo3::types::PyDict)]
@@ -46,7 +46,7 @@ error: expected string literal
 24 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
-error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`
+error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`, `sealedclass`
   --> tests/ui/invalid_pyclass_args.rs:27:11
    |
 27 | #[pyclass(weakrev)]

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`, `sealedclass`
+error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`, `unit_variants`
  --> tests/ui/invalid_pyclass_args.rs:3:11
   |
 3 | #[pyclass(extend=pyo3::types::PyDict)]
@@ -46,7 +46,7 @@ error: expected string literal
 24 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
-error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`, `sealedclass`
+error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `subclass`, `unsendable`, `weakref`, `unit_variants`
   --> tests/ui/invalid_pyclass_args.rs:27:11
    |
 27 | #[pyclass(weakrev)]

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -93,4 +93,10 @@ enum InvalidOrderedComplexEnum2 {
     VariantB { msg: String }
 }
 
+#[pyclass(sealedclass)]
+enum AllowedUnitVariants {
+    StructVariant { field: u64 },
+    UnitVariant,
+}
+
 fn main() {}

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -93,10 +93,27 @@ enum InvalidOrderedComplexEnum2 {
     VariantB { msg: String }
 }
 
-#[pyclass(sealedclass)]
-enum AllowedUnitVariants {
+#[pyclass(unit_variants="c-like")]
+enum CLikeUnitVariants {
     StructVariant { field: u64 },
-    UnitVariant,
+    UnitVariantA,
+    UnitVariantB,
+}
+
+#[pyclass(unit_variants="tuple-like")]
+enum TupleLikeUnitVariants {
+    StructVariant { field: u64 },
+    UnitVariantA,
+    UnitVariantB,
+}
+
+#[pyclass]
+enum MixedUnitVariants {
+    StructVariant { field: u64 },
+    #[pyo3(unit_variant="c-like")]
+    CLike,
+    #[pyo3(unit_variant="tuple-like")]
+    TupleLike,
 }
 
 fn main() {}

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -18,7 +18,7 @@ error: #[pyclass] can't be used on enums without any variants
 
 error: Unit variant `UnitVariant` is not yet supported in a complex enum
        = help: change to an empty tuple variant instead: `UnitVariant()`
-       = note: the enum is complex because of non-unit variant `UnitVariant`
+       = note: the enum is complex because of non-unit variant `StructVariant`
   --> tests/ui/invalid_pyclass_enum.rs:21:5
    |
 21 |     UnitVariant,

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -18,7 +18,7 @@ error: #[pyclass] can't be used on enums without any variants
 
 error: Unit variant `UnitVariant` is not yet supported in a complex enum
        = help: change to an empty tuple variant instead: `UnitVariant()`
-       = note: the enum is complex because of non-unit variant `StructVariant`
+       = note: the enum is complex because of non-unit variant `UnitVariant`
   --> tests/ui/invalid_pyclass_enum.rs:21:5
    |
 21 |     UnitVariant,


### PR DESCRIPTION
https://github.com/PyO3/pyo3/issues/4300