### PR TITLE
remove all functionality deprecated in 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.22.1"
+version = "0.23.0-dev"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -21,10 +21,10 @@ memoffset = "0.9"
 once_cell = "1.13.0"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.22.1" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.23.0-dev" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.22.1", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.23.0-dev", optional = true }
 indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
@@ -63,7 +63,7 @@ rayon = "1.6.1"
 futures = "0.3.28"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "=0.22.1", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/examples/decorator/.template/pre-script.rhai
+++ b/examples/decorator/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.1");
+variable::set("PYO3_VERSION", "0.23.0-dev");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/maturin-starter/.template/pre-script.rhai
+++ b/examples/maturin-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.1");
+variable::set("PYO3_VERSION", "0.23.0-dev");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/plugin/.template/pre-script.rhai
+++ b/examples/plugin/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.1");
+variable::set("PYO3_VERSION", "0.23.0-dev");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/plugin_api/Cargo.toml", "plugin_api/Cargo.toml");
 file::delete(".template");

--- a/examples/setuptools-rust-starter/.template/pre-script.rhai
+++ b/examples/setuptools-rust-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.1");
+variable::set("PYO3_VERSION", "0.23.0-dev");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/setup.cfg", "setup.cfg");
 file::delete(".template");

--- a/examples/word-count/.template/pre-script.rhai
+++ b/examples/word-count/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.1");
+variable::set("PYO3_VERSION", "0.23.0-dev");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/newsfragments/4322.changed.md
+++ b/newsfragments/4322.changed.md
@@ -1,0 +1,1 @@
+Deprecate `PyAnyMethods::is_ellipsis` (`Py::is_ellpsis` was deprecated in PyO3 0.20).

--- a/newsfragments/4322.removed.md
+++ b/newsfragments/4322.removed.md
@@ -1,0 +1,1 @@
+Remove all functionality deprecated in PyO3 0.20.

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.22.1"
+version = "0.23.0-dev"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.22.1"
+version = "0.23.0-dev"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -38,7 +38,7 @@ abi3-py312 = ["abi3", "pyo3-build-config/abi3-py312"]
 generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.1", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }
 
 [lints]
 workspace = true

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.22.1"
+version = "0.23.0-dev"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,7 +16,7 @@ edition = "2021"
 [dependencies]
 heck = "0.5"
 proc-macro2 = { version = "1.0.60", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.1", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }
 quote = { version = "1", default-features = false }
 
 [dependencies.syn]
@@ -25,7 +25,7 @@ default-features = false
 features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits"]
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.1" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.0-dev" }
 
 [lints]
 workspace = true

--- a/pyo3-macros-backend/src/deprecations.rs
+++ b/pyo3-macros-backend/src/deprecations.rs
@@ -1,53 +1,6 @@
-use crate::{
-    method::{FnArg, FnSpec},
-    utils::Ctx,
-};
-use proc_macro2::{Span, TokenStream};
-use quote::{quote_spanned, ToTokens};
-
-pub enum Deprecation {
-    PyMethodsNewDeprecatedForm,
-}
-
-impl Deprecation {
-    fn ident(&self, span: Span) -> syn::Ident {
-        let string = match self {
-            Deprecation::PyMethodsNewDeprecatedForm => "PYMETHODS_NEW_DEPRECATED_FORM",
-        };
-        syn::Ident::new(string, span)
-    }
-}
-
-pub struct Deprecations<'ctx>(Vec<(Deprecation, Span)>, &'ctx Ctx);
-
-impl<'ctx> Deprecations<'ctx> {
-    pub fn new(ctx: &'ctx Ctx) -> Self {
-        Deprecations(Vec::new(), ctx)
-    }
-
-    pub fn push(&mut self, deprecation: Deprecation, span: Span) {
-        self.0.push((deprecation, span))
-    }
-}
-
-impl<'ctx> ToTokens for Deprecations<'ctx> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let Self(deprecations, Ctx { pyo3_path, .. }) = self;
-
-        for (deprecation, span) in deprecations {
-            let pyo3_path = pyo3_path.to_tokens_spanned(*span);
-            let ident = deprecation.ident(*span);
-            quote_spanned!(
-                *span =>
-                #[allow(clippy::let_unit_value)]
-                {
-                    let _ = #pyo3_path::impl_::deprecations::#ident;
-                }
-            )
-            .to_tokens(tokens)
-        }
-    }
-}
+use crate::method::{FnArg, FnSpec};
+use proc_macro2::TokenStream;
+use quote::quote_spanned;
 
 pub(crate) fn deprecate_trailing_option_default(spec: &FnSpec<'_>) -> TokenStream {
     if spec.signature.attribute.is_none()

--- a/pyo3-macros-backend/src/konst.rs
+++ b/pyo3-macros-backend/src/konst.rs
@@ -1,11 +1,8 @@
 use std::borrow::Cow;
 use std::ffi::CString;
 
+use crate::attributes::{self, get_pyo3_options, take_attributes, NameAttribute};
 use crate::utils::{Ctx, LitCStr};
-use crate::{
-    attributes::{self, get_pyo3_options, take_attributes, NameAttribute},
-    deprecations::Deprecations,
-};
 use proc_macro2::{Ident, Span};
 use syn::{
     ext::IdentExt,
@@ -14,12 +11,12 @@ use syn::{
     Result,
 };
 
-pub struct ConstSpec<'ctx> {
+pub struct ConstSpec {
     pub rust_ident: syn::Ident,
-    pub attributes: ConstAttributes<'ctx>,
+    pub attributes: ConstAttributes,
 }
 
-impl ConstSpec<'_> {
+impl ConstSpec {
     pub fn python_name(&self) -> Cow<'_, Ident> {
         if let Some(name) = &self.attributes.name {
             Cow::Borrowed(&name.value.0)
@@ -35,10 +32,9 @@ impl ConstSpec<'_> {
     }
 }
 
-pub struct ConstAttributes<'ctx> {
+pub struct ConstAttributes {
     pub is_class_attr: bool,
     pub name: Option<NameAttribute>,
-    pub deprecations: Deprecations<'ctx>,
 }
 
 pub enum PyO3ConstAttribute {
@@ -56,12 +52,11 @@ impl Parse for PyO3ConstAttribute {
     }
 }
 
-impl<'ctx> ConstAttributes<'ctx> {
-    pub fn from_attrs(attrs: &mut Vec<syn::Attribute>, ctx: &'ctx Ctx) -> syn::Result<Self> {
+impl ConstAttributes {
+    pub fn from_attrs(attrs: &mut Vec<syn::Attribute>) -> syn::Result<Self> {
         let mut attributes = ConstAttributes {
             is_class_attr: false,
             name: None,
-            deprecations: Deprecations::new(ctx),
         };
 
         take_attributes(attrs, |attr| {

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -10,7 +10,6 @@ use crate::deprecations::deprecate_trailing_option_default;
 use crate::utils::{Ctx, LitCStr};
 use crate::{
     attributes::{FromPyWithAttribute, TextSignatureAttribute, TextSignatureAttributeValue},
-    deprecations::{Deprecation, Deprecations},
     params::{impl_arg_params, Holders},
     pyfunction::{
         FunctionSignature, PyFunctionArgPyO3Attributes, PyFunctionOptions, SignatureAttribute,
@@ -411,7 +410,6 @@ pub struct FnSpec<'a> {
     pub text_signature: Option<TextSignatureAttribute>,
     pub asyncness: Option<syn::Token![async]>,
     pub unsafety: Option<syn::Token![unsafe]>,
-    pub deprecations: Deprecations<'a>,
 }
 
 pub fn parse_method_receiver(arg: &syn::FnArg) -> Result<SelfType> {
@@ -443,7 +441,6 @@ impl<'a> FnSpec<'a> {
         sig: &'a mut syn::Signature,
         meth_attrs: &mut Vec<syn::Attribute>,
         options: PyFunctionOptions,
-        ctx: &'a Ctx,
     ) -> Result<FnSpec<'a>> {
         let PyFunctionOptions {
             text_signature,
@@ -453,9 +450,8 @@ impl<'a> FnSpec<'a> {
         } = options;
 
         let mut python_name = name.map(|name| name.value.0);
-        let mut deprecations = Deprecations::new(ctx);
 
-        let fn_type = Self::parse_fn_type(sig, meth_attrs, &mut python_name, &mut deprecations)?;
+        let fn_type = Self::parse_fn_type(sig, meth_attrs, &mut python_name)?;
         ensure_signatures_on_valid_method(&fn_type, signature.as_ref(), text_signature.as_ref())?;
 
         let name = &sig.ident;
@@ -493,7 +489,6 @@ impl<'a> FnSpec<'a> {
             text_signature,
             asyncness: sig.asyncness,
             unsafety: sig.unsafety,
-            deprecations,
         })
     }
 
@@ -507,9 +502,8 @@ impl<'a> FnSpec<'a> {
         sig: &syn::Signature,
         meth_attrs: &mut Vec<syn::Attribute>,
         python_name: &mut Option<syn::Ident>,
-        deprecations: &mut Deprecations<'_>,
     ) -> Result<FnType> {
-        let mut method_attributes = parse_method_attributes(meth_attrs, deprecations)?;
+        let mut method_attributes = parse_method_attributes(meth_attrs)?;
 
         let name = &sig.ident;
         let parse_receiver = |msg: &'static str| {
@@ -982,10 +976,7 @@ impl MethodTypeAttribute {
     /// If the attribute does not match one of the attribute names, returns `Ok(None)`.
     ///
     /// Otherwise will either return a parse error or the attribute.
-    fn parse_if_matching_attribute(
-        attr: &syn::Attribute,
-        deprecations: &mut Deprecations<'_>,
-    ) -> Result<Option<Self>> {
+    fn parse_if_matching_attribute(attr: &syn::Attribute) -> Result<Option<Self>> {
         fn ensure_no_arguments(meta: &syn::Meta, ident: &str) -> syn::Result<()> {
             match meta {
                 syn::Meta::Path(_) => Ok(()),
@@ -1029,11 +1020,6 @@ impl MethodTypeAttribute {
         if path.is_ident("new") {
             ensure_no_arguments(meta, "new")?;
             Ok(Some(MethodTypeAttribute::New(path.span())))
-        } else if path.is_ident("__new__") {
-            let span = path.span();
-            deprecations.push(Deprecation::PyMethodsNewDeprecatedForm, span);
-            ensure_no_arguments(meta, "__new__")?;
-            Ok(Some(MethodTypeAttribute::New(span)))
         } else if path.is_ident("classmethod") {
             ensure_no_arguments(meta, "classmethod")?;
             Ok(Some(MethodTypeAttribute::ClassMethod(path.span())))
@@ -1068,15 +1054,12 @@ impl Display for MethodTypeAttribute {
     }
 }
 
-fn parse_method_attributes(
-    attrs: &mut Vec<syn::Attribute>,
-    deprecations: &mut Deprecations<'_>,
-) -> Result<Vec<MethodTypeAttribute>> {
+fn parse_method_attributes(attrs: &mut Vec<syn::Attribute>) -> Result<Vec<MethodTypeAttribute>> {
     let mut new_attrs = Vec::new();
     let mut found_attrs = Vec::new();
 
     for attr in attrs.drain(..) {
-        match MethodTypeAttribute::parse_if_matching_attribute(&attr, deprecations)? {
+        match MethodTypeAttribute::parse_if_matching_attribute(&attr)? {
             Some(attr) => found_attrs.push(attr),
             None => new_attrs.push(attr),
         }

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -4,7 +4,6 @@ use crate::{
         self, get_pyo3_options, take_attributes, take_pyo3_options, CrateAttribute,
         FromPyWithAttribute, NameAttribute, TextSignatureAttribute,
     },
-    deprecations::Deprecations,
     method::{self, CallingConvention, FnArg},
     pymethod::check_generic,
 };
@@ -252,7 +251,6 @@ pub fn impl_wrap_pyfunction(
         text_signature,
         asyncness: func.sig.asyncness,
         unsafety: func.sig.unsafety,
-        deprecations: Deprecations::new(ctx),
     };
 
     let vis = &func.vis;

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -130,7 +130,7 @@ pub fn impl_methods(
             }
             syn::ImplItem::Const(konst) => {
                 let ctx = &Ctx::new(&options.krate, None);
-                let attributes = ConstAttributes::from_attrs(&mut konst.attrs, ctx)?;
+                let attributes = ConstAttributes::from_attrs(&mut konst.attrs)?;
                 if attributes.is_class_attr {
                     let spec = ConstSpec {
                         rust_ident: konst.ident.clone(),
@@ -182,16 +182,14 @@ pub fn impl_methods(
     })
 }
 
-pub fn gen_py_const(cls: &syn::Type, spec: &ConstSpec<'_>, ctx: &Ctx) -> MethodAndMethodDef {
+pub fn gen_py_const(cls: &syn::Type, spec: &ConstSpec, ctx: &Ctx) -> MethodAndMethodDef {
     let member = &spec.rust_ident;
     let wrapper_ident = format_ident!("__pymethod_{}__", member);
-    let deprecations = &spec.attributes.deprecations;
     let python_name = spec.null_terminated_python_name(ctx);
     let Ctx { pyo3_path, .. } = ctx;
 
     let associated_method = quote! {
         fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
-            #deprecations
             ::std::result::Result::Ok(#pyo3_path::IntoPy::into_py(#cls::#member, py))
         }
     };

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.22.1"
+version = "0.23.0-dev"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -22,7 +22,7 @@ gil-refs = ["pyo3-macros-backend/gil-refs"]
 proc-macro2 = { version = "1.0.60", default-features = false }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.22.1" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.23.0-dev" }
 
 [lints]
 workspace = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "0.22.1"
+version = "0.23.0-dev"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -8,7 +8,6 @@
 
 #[cfg(feature = "experimental-async")]
 pub mod coroutine;
-pub mod deprecations;
 pub mod exceptions;
 pub mod extract_argument;
 pub mod freelist;

--- a/src/impl_/deprecations.rs
+++ b/src/impl_/deprecations.rs
@@ -1,4 +1,0 @@
-//! Symbols used to denote deprecated usages of PyO3's proc macros.
-
-#[deprecated(since = "0.20.0", note = "use `#[new]` instead of `#[__new__]`")]
-pub const PYMETHODS_NEW_DEPRECATED_FORM: () = ();

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1329,8 +1329,11 @@ impl<T> Py<T> {
     /// # }
     /// ```
     #[inline]
-    pub fn clone_ref(&self, py: Python<'_>) -> Py<T> {
-        unsafe { Py::from_borrowed_ptr(py, self.0.as_ptr()) }
+    pub fn clone_ref(&self, _py: Python<'_>) -> Py<T> {
+        unsafe {
+            ffi::Py_INCREF(self.as_ptr());
+            Self::from_non_null(self.0)
+        }
     }
 
     /// Drops `self` and immediately decreases its reference count.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,16 +495,6 @@ mod macros;
 #[cfg(feature = "experimental-inspect")]
 pub mod inspect;
 
-/// Ths module only contains re-exports of pyo3 deprecation warnings and exists
-/// purely to make compiler error messages nicer.
-///
-/// (The compiler uses this module in error messages, probably because it's a public
-/// re-export at a shorter path than `pyo3::impl_::deprecations`.)
-#[doc(hidden)]
-pub mod deprecations {
-    pub use crate::impl_::deprecations::*;
-}
-
 /// Test readme and user guide
 #[cfg(doctest)]
 pub mod doc_test {

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -615,14 +615,6 @@ impl PyAny {
         self.as_borrowed().is_none()
     }
 
-    /// Returns whether the object is Ellipsis, e.g. `...`.
-    ///
-    /// This is equivalent to the Python expression `self is ...`.
-    #[deprecated(since = "0.20.0", note = "use `.is(py.Ellipsis())` instead")]
-    pub fn is_ellipsis(&self) -> bool {
-        self.as_borrowed().is_ellipsis()
-    }
-
     /// Returns true if the sequence or mapping has a length of 0.
     ///
     /// This is equivalent to the Python expression `len(self) == 0`.
@@ -1506,6 +1498,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// Returns whether the object is Ellipsis, e.g. `...`.
     ///
     /// This is equivalent to the Python expression `self is ...`.
+    #[deprecated(since = "0.23.0", note = "use `.is(py.Ellipsis())` instead")]
     fn is_ellipsis(&self) -> bool;
 
     /// Returns true if the sequence or mapping has a length of 0.
@@ -2796,6 +2789,7 @@ class SimpleClass:
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_is_ellipsis() {
         Python::with_gil(|py| {
             let v = py

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -191,19 +191,6 @@ impl PyDict {
         }
     }
 
-    /// Deprecated version of `get_item`.
-    #[deprecated(
-        since = "0.20.0",
-        note = "this is now equivalent to `PyDict::get_item`"
-    )]
-    #[inline]
-    pub fn get_item_with_error<K>(&self, key: K) -> PyResult<Option<&PyAny>>
-    where
-        K: ToPyObject,
-    {
-        self.get_item(key)
-    }
-
     /// Sets an item value.
     ///
     /// This is equivalent to the Python statement `self[key] = value`.
@@ -948,31 +935,6 @@ mod tests {
                     .unwrap()
             );
             assert!(dict.get_item(8i32).unwrap().is_none());
-        });
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    #[cfg(all(not(any(PyPy, GraalPy)), feature = "gil-refs"))]
-    fn test_get_item_with_error() {
-        Python::with_gil(|py| {
-            let mut v = HashMap::new();
-            v.insert(7, 32);
-            let ob = v.to_object(py);
-            let dict = ob.downcast::<PyDict>(py).unwrap();
-            assert_eq!(
-                32,
-                dict.get_item_with_error(7i32)
-                    .unwrap()
-                    .unwrap()
-                    .extract::<i32>()
-                    .unwrap()
-            );
-            assert!(dict.get_item_with_error(8i32).unwrap().is_none());
-            assert!(dict
-                .get_item_with_error(dict)
-                .unwrap_err()
-                .is_instance_of::<crate::exceptions::PyTypeError>(py));
         });
     }
 

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -1,4 +1,5 @@
 #![deny(deprecated)]
+#![allow(dead_code)]
 
 use pyo3::prelude::*;
 

--- a/tests/ui/deprecations.rs
+++ b/tests/ui/deprecations.rs
@@ -1,20 +1,6 @@
 #![deny(deprecated)]
-#![allow(dead_code)]
 
 use pyo3::prelude::*;
-
-#[pyclass]
-struct MyClass;
-
-#[pymethods]
-impl MyClass {
-    #[__new__]
-    fn new() -> Self {
-        Self
-    }
-}
-
-fn main() {}
 
 fn extract_options(obj: &Bound<'_, PyAny>) -> PyResult<Option<i32>> {
     obj.extract()
@@ -43,3 +29,5 @@ pub enum SimpleEnumWithoutEq {
     VariamtA,
     VariantB,
 }
+
+fn main() {}

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -1,8 +1,10 @@
-error: use of deprecated constant `pyo3::deprecations::PYMETHODS_NEW_DEPRECATED_FORM`: use `#[new]` instead of `#[__new__]`
-  --> tests/ui/deprecations.rs:11:7
+error: use of deprecated constant `__pyfunction_pyfunction_option_2::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
+       = note: these implicit defaults are being phased out
+       = help: add `#[pyo3(signature = (_i, _any=None))]` to this function to silence this warning and keep the current behavior
+  --> tests/ui/deprecations.rs:14:4
    |
-11 |     #[__new__]
-   |       ^^^^^^^
+14 | fn pyfunction_option_2(_i: u32, _any: Option<i32>) {}
+   |    ^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> tests/ui/deprecations.rs:1:9
@@ -10,34 +12,58 @@ note: the lint level is defined here
 1  | #![deny(deprecated)]
    |         ^^^^^^^^^^
 
-error: use of deprecated constant `__pyfunction_pyfunction_option_2::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
-       = note: these implicit defaults are being phased out
-       = help: add `#[pyo3(signature = (_i, _any=None))]` to this function to silence this warning and keep the current behavior
-  --> tests/ui/deprecations.rs:28:4
-   |
-28 | fn pyfunction_option_2(_i: u32, _any: Option<i32>) {}
-   |    ^^^^^^^^^^^^^^^^^^^
-
 error: use of deprecated constant `__pyfunction_pyfunction_option_3::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
        = note: these implicit defaults are being phased out
        = help: add `#[pyo3(signature = (_i, _any=None, _foo=None))]` to this function to silence this warning and keep the current behavior
-  --> tests/ui/deprecations.rs:31:4
+  --> tests/ui/deprecations.rs:17:4
    |
-31 | fn pyfunction_option_3(_i: u32, _any: Option<i32>, _foo: Option<String>) {}
+17 | fn pyfunction_option_3(_i: u32, _any: Option<i32>, _foo: Option<String>) {}
    |    ^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated constant `__pyfunction_pyfunction_option_4::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
        = note: these implicit defaults are being phased out
        = help: add `#[pyo3(signature = (_i, _any=None, _foo=None))]` to this function to silence this warning and keep the current behavior
-  --> tests/ui/deprecations.rs:34:4
+  --> tests/ui/deprecations.rs:20:4
    |
-34 | fn pyfunction_option_4(
+20 | fn pyfunction_option_4(
    |    ^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated constant `SimpleEnumWithoutEq::__pyo3__generated____richcmp__::DEPRECATION`: Implicit equality for simple enums is deprecated. Use `#[pyclass(eq, eq_int)` to keep the current behavior.
-  --> tests/ui/deprecations.rs:41:1
+  --> tests/ui/deprecations.rs:27:1
    |
-41 | #[pyclass]
+27 | #[pyclass]
    | ^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+warning: function `extract_options` is never used
+ --> tests/ui/deprecations.rs:5:4
+  |
+5 | fn extract_options(obj: &Bound<'_, PyAny>) -> PyResult<Option<i32>> {
+  |    ^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(dead_code)]` on by default
+
+warning: function `pyfunction_option_1` is never used
+  --> tests/ui/deprecations.rs:11:4
+   |
+11 | fn pyfunction_option_1(_i: u32, _any: Option<i32>) {}
+   |    ^^^^^^^^^^^^^^^^^^^
+
+warning: function `pyfunction_option_2` is never used
+  --> tests/ui/deprecations.rs:14:4
+   |
+14 | fn pyfunction_option_2(_i: u32, _any: Option<i32>) {}
+   |    ^^^^^^^^^^^^^^^^^^^
+
+warning: function `pyfunction_option_3` is never used
+  --> tests/ui/deprecations.rs:17:4
+   |
+17 | fn pyfunction_option_3(_i: u32, _any: Option<i32>, _foo: Option<String>) {}
+   |    ^^^^^^^^^^^^^^^^^^^
+
+warning: function `pyfunction_option_4` is never used
+  --> tests/ui/deprecations.rs:20:4
+   |
+20 | fn pyfunction_option_4(
+   |    ^^^^^^^^^^^^^^^^^^^

--- a/tests/ui/deprecations.stderr
+++ b/tests/ui/deprecations.stderr
@@ -1,9 +1,9 @@
 error: use of deprecated constant `__pyfunction_pyfunction_option_2::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
        = note: these implicit defaults are being phased out
        = help: add `#[pyo3(signature = (_i, _any=None))]` to this function to silence this warning and keep the current behavior
-  --> tests/ui/deprecations.rs:14:4
+  --> tests/ui/deprecations.rs:15:4
    |
-14 | fn pyfunction_option_2(_i: u32, _any: Option<i32>) {}
+15 | fn pyfunction_option_2(_i: u32, _any: Option<i32>) {}
    |    ^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
@@ -15,55 +15,23 @@ note: the lint level is defined here
 error: use of deprecated constant `__pyfunction_pyfunction_option_3::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
        = note: these implicit defaults are being phased out
        = help: add `#[pyo3(signature = (_i, _any=None, _foo=None))]` to this function to silence this warning and keep the current behavior
-  --> tests/ui/deprecations.rs:17:4
+  --> tests/ui/deprecations.rs:18:4
    |
-17 | fn pyfunction_option_3(_i: u32, _any: Option<i32>, _foo: Option<String>) {}
+18 | fn pyfunction_option_3(_i: u32, _any: Option<i32>, _foo: Option<String>) {}
    |    ^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated constant `__pyfunction_pyfunction_option_4::SIGNATURE`: this function has implicit defaults for the trailing `Option<T>` arguments
        = note: these implicit defaults are being phased out
        = help: add `#[pyo3(signature = (_i, _any=None, _foo=None))]` to this function to silence this warning and keep the current behavior
-  --> tests/ui/deprecations.rs:20:4
+  --> tests/ui/deprecations.rs:21:4
    |
-20 | fn pyfunction_option_4(
+21 | fn pyfunction_option_4(
    |    ^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated constant `SimpleEnumWithoutEq::__pyo3__generated____richcmp__::DEPRECATION`: Implicit equality for simple enums is deprecated. Use `#[pyclass(eq, eq_int)` to keep the current behavior.
-  --> tests/ui/deprecations.rs:27:1
+  --> tests/ui/deprecations.rs:28:1
    |
-27 | #[pyclass]
+28 | #[pyclass]
    | ^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-warning: function `extract_options` is never used
- --> tests/ui/deprecations.rs:5:4
-  |
-5 | fn extract_options(obj: &Bound<'_, PyAny>) -> PyResult<Option<i32>> {
-  |    ^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(dead_code)]` on by default
-
-warning: function `pyfunction_option_1` is never used
-  --> tests/ui/deprecations.rs:11:4
-   |
-11 | fn pyfunction_option_1(_i: u32, _any: Option<i32>) {}
-   |    ^^^^^^^^^^^^^^^^^^^
-
-warning: function `pyfunction_option_2` is never used
-  --> tests/ui/deprecations.rs:14:4
-   |
-14 | fn pyfunction_option_2(_i: u32, _any: Option<i32>) {}
-   |    ^^^^^^^^^^^^^^^^^^^
-
-warning: function `pyfunction_option_3` is never used
-  --> tests/ui/deprecations.rs:17:4
-   |
-17 | fn pyfunction_option_3(_i: u32, _any: Option<i32>, _foo: Option<String>) {}
-   |    ^^^^^^^^^^^^^^^^^^^
-
-warning: function `pyfunction_option_4` is never used
-  --> tests/ui/deprecations.rs:20:4
-   |
-20 | fn pyfunction_option_4(
-   |    ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This removes all functionality which was deprecated in PyO3 0.20.

Following our norms we could have removed these bits in 0.22, but things were quite busy my side so I just forgot to get around to this!

I'll open a follow-up PR now to also remove 0.21's deprecations.