### PR TITLE
Prevent building in GIL-less environment

### DIFF
--- a/newsfragments/4327.packaging.md
+++ b/newsfragments/4327.packaging.md
@@ -1,0 +1,3 @@
+This PR lets PyO3 checks `Py_GIL_DISABLED` build flag and prevents `pyo3-ffi` crate building against GIL-less Python,
+unless
+explicitly opt using the `UNSAFE_PYO3_BUILD_FREE_THREADED` environment flag.

--- a/noxfile.py
+++ b/noxfile.py
@@ -648,7 +648,7 @@ def test_version_limits(session: nox.Session):
         _run_cargo(session, "check", env=env, expect_error=True)
 
         # Python build with GIL disabled should fail building
-        config_file.set("CPython", "3.13", build_flags=['Py_GIL_DISABLED'])
+        config_file.set("CPython", "3.13", build_flags=["Py_GIL_DISABLED"])
         _run_cargo(session, "check", env=env, expect_error=True)
 
         # Python build with GIL disabled should pass with env flag on
@@ -915,7 +915,9 @@ class _ConfigFile:
     def __init__(self, config_file) -> None:
         self._config_file = config_file
 
-    def set(self, implementation: str, version: str, build_flags: Iterable[str] = ()) -> None:
+    def set(
+        self, implementation: str, version: str, build_flags: Iterable[str] = ()
+    ) -> None:
         """Set the contents of this config file to the given implementation and version."""
         self._config_file.seek(0)
         self._config_file.truncate(0)

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ import tempfile
 from functools import lru_cache
 from glob import glob
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple
 
 import nox
 import nox.command
@@ -647,6 +647,14 @@ def test_version_limits(session: nox.Session):
         config_file.set("PyPy", "3.11")
         _run_cargo(session, "check", env=env, expect_error=True)
 
+        # Python build with GIL disabled should fail building
+        config_file.set("CPython", "3.13", build_flags=['Py_GIL_DISABLED'])
+        _run_cargo(session, "check", env=env, expect_error=True)
+
+        # Python build with GIL disabled should pass with env flag on
+        env["UNSAFE_PYO3_BUILD_FREE_THREADED"] = "1"
+        _run_cargo(session, "check", env=env)
+
 
 @nox.session(name="check-feature-powerset", venv_backend="none")
 def check_feature_powerset(session: nox.Session):
@@ -907,7 +915,7 @@ class _ConfigFile:
     def __init__(self, config_file) -> None:
         self._config_file = config_file
 
-    def set(self, implementation: str, version: str) -> None:
+    def set(self, implementation: str, version: str, build_flags: Iterable[str] = ()) -> None:
         """Set the contents of this config file to the given implementation and version."""
         self._config_file.seek(0)
         self._config_file.truncate(0)
@@ -915,6 +923,7 @@ class _ConfigFile:
             f"""\
 implementation={implementation}
 version={version}
+build_flags={','.join(build_flags)}
 suppress_build_script_link_lines=true
 """
         )

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -996,6 +996,7 @@ pub enum BuildFlag {
     Py_DEBUG,
     Py_REF_DEBUG,
     Py_TRACE_REFS,
+    Py_GIL_DISABLED,
     COUNT_ALLOCS,
     Other(String),
 }
@@ -1016,6 +1017,7 @@ impl FromStr for BuildFlag {
             "Py_DEBUG" => Ok(BuildFlag::Py_DEBUG),
             "Py_REF_DEBUG" => Ok(BuildFlag::Py_REF_DEBUG),
             "Py_TRACE_REFS" => Ok(BuildFlag::Py_TRACE_REFS),
+            "Py_GIL_DISABLED" => Ok(BuildFlag::Py_GIL_DISABLED),
             "COUNT_ALLOCS" => Ok(BuildFlag::COUNT_ALLOCS),
             other => Ok(BuildFlag::Other(other.to_owned())),
         }
@@ -1039,10 +1041,11 @@ impl FromStr for BuildFlag {
 pub struct BuildFlags(pub HashSet<BuildFlag>);
 
 impl BuildFlags {
-    const ALL: [BuildFlag; 4] = [
+    const ALL: [BuildFlag; 5] = [
         BuildFlag::Py_DEBUG,
         BuildFlag::Py_REF_DEBUG,
         BuildFlag::Py_TRACE_REFS,
+        BuildFlag::Py_GIL_DISABLED,
         BuildFlag::COUNT_ALLOCS,
     ];
 

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -130,6 +130,7 @@ fn ensure_gil_enabled(interpreter_config: &InterpreterConfig) -> Result<()> {
     ensure!(
         gil_enabled || std::env::var("UNSAFE_PYO3_BUILD_FREE_THREADED").map_or(false, |os_str| os_str == "1"),
         "the Python interpreter was built with the GIL disabled, which is not yet supported by PyO3\n\
+        = help: see https://github.com/PyO3/pyo3/issues/4265 for more information\n\
         = help: please check if an updated version of PyO3 is available. Current version: {}\n\
         = help: set UNSAFE_PYO3_BUILD_FREE_THREADED=1 to suppress this check and build anyway for free-threaded Python",
         std::env::var("CARGO_PKG_VERSION").unwrap()

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -129,7 +129,7 @@ fn ensure_gil_enabled(interpreter_config: &InterpreterConfig) -> Result<()> {
         .not();
     ensure!(
         gil_enabled || std::env::var("UNSAFE_PYO3_BUILD_FREE_THREADED").map_or(false, |os_str| os_str == "1"),
-        "the Python interpreter was built with the GIL disabled, which is not supported by PyO3\n\
+        "the Python interpreter was built with the GIL disabled, which is not yet supported by PyO3\n\
         = help: please check if an updated version of PyO3 is available. Current version: {}\n\
         = help: set UNSAFE_PYO3_BUILD_FREE_THREADED=1 to suppress this check and build anyway for free-threaded Python",
         std::env::var("CARGO_PKG_VERSION").unwrap()


### PR DESCRIPTION
This PR lets PyO3 checks `Py_GIL_DISABLED` build flag and prevents building against GIL-less Python, unless explicitly opt in the `UNSAFE_PYO3_BUILD_FREE_THREADED` flag. 