### PR TITLE
clean up hygiene tests

### DIFF
--- a/newsfragments/4328.fixed.md
+++ b/newsfragments/4328.fixed.md
@@ -1,0 +1,1 @@
+Fix compile failure in declarative `#[pymodule]` under presence of `#![no_implicit_prelude]`.

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -373,7 +373,7 @@ pub fn pymodule_module_impl(
                     #module_items::_PYO3_DEF.add_to_module(module)?;
                 )*
                 #pymodule_init
-                Ok(())
+                ::std::result::Result::Ok(())
             }
         }
     ))

--- a/src/tests/hygiene/misc.rs
+++ b/src/tests/hygiene/misc.rs
@@ -1,17 +1,13 @@
-#![no_implicit_prelude]
+#[derive(crate::FromPyObject)]
+#[pyo3(crate = "crate")]
+struct Derive1(i32); // newtype case
 
 #[derive(crate::FromPyObject)]
 #[pyo3(crate = "crate")]
-struct Derive1(#[allow(dead_code)] i32); // newtype case
-
-#[derive(crate::FromPyObject)]
-#[pyo3(crate = "crate")]
-#[allow(dead_code)]
 struct Derive2(i32, i32); // tuple case
 
 #[derive(crate::FromPyObject)]
 #[pyo3(crate = "crate")]
-#[allow(dead_code)]
 struct Derive3 {
     f: i32,
     #[pyo3(item(42))]
@@ -20,7 +16,6 @@ struct Derive3 {
 
 #[derive(crate::FromPyObject)]
 #[pyo3(crate = "crate")]
-#[allow(dead_code)]
 enum Derive4 {
     A(i32),
     B { f: i32 },
@@ -29,23 +24,16 @@ enum Derive4 {
 crate::create_exception!(mymodule, CustomError, crate::exceptions::PyException);
 crate::import_exception!(socket, gaierror);
 
-#[allow(dead_code)]
 fn intern(py: crate::Python<'_>) {
     let _foo = crate::intern!(py, "foo");
     let _bar = crate::intern!(py, stringify!(bar));
 }
 
-#[allow(dead_code)]
 #[cfg(not(PyPy))]
 fn append_to_inittab() {
     #[crate::pymodule]
     #[pyo3(crate = "crate")]
-    #[allow(clippy::unnecessary_wraps)]
-    fn module_for_inittab(
-        _: crate::Python<'_>,
-        _: &crate::Bound<'_, crate::types::PyModule>,
-    ) -> crate::PyResult<()> {
-        ::std::result::Result::Ok(())
-    }
+    mod module_for_inittab {}
+
     crate::append_to_inittab!(module_for_inittab);
 }

--- a/src/tests/hygiene/mod.rs
+++ b/src/tests/hygiene/mod.rs
@@ -1,3 +1,6 @@
+#![no_implicit_prelude]
+#![allow(dead_code, unused_variables, clippy::unnecessary_wraps)]
+
 // The modules in this test are used to check PyO3 macro expansion is hygienic. By locating the test
 // inside the crate the global `::pyo3` namespace is not available, so in combination with
 // #[pyo3(crate = "crate")] this validates that all macro expansion respects the setting.

--- a/src/tests/hygiene/pyclass.rs
+++ b/src/tests/hygiene/pyclass.rs
@@ -1,6 +1,3 @@
-#![no_implicit_prelude]
-#![allow(unused_variables)]
-
 #[crate::pyclass]
 #[pyo3(crate = "crate")]
 #[derive(::std::clone::Clone)]

--- a/src/tests/hygiene/pyfunction.rs
+++ b/src/tests/hygiene/pyfunction.rs
@@ -1,6 +1,3 @@
-#![no_implicit_prelude]
-#![allow(unused_variables, clippy::unnecessary_wraps)]
-
 #[crate::pyfunction]
 #[pyo3(crate = "crate")]
 fn do_something(x: i32) -> crate::PyResult<i32> {
@@ -8,19 +5,9 @@ fn do_something(x: i32) -> crate::PyResult<i32> {
 }
 
 #[test]
-#[cfg(feature = "gil-refs")]
 fn invoke_wrap_pyfunction() {
     crate::Python::with_gil(|py| {
-        #[allow(deprecated)]
-        let func = crate::wrap_pyfunction!(do_something)(py).unwrap();
-        crate::py_run!(py, func, r#"func(5)"#);
-    });
-}
-
-#[test]
-fn invoke_wrap_pyfunction_bound() {
-    crate::Python::with_gil(|py| {
-        let func = crate::wrap_pyfunction_bound!(do_something, py).unwrap();
+        let func = crate::wrap_pyfunction!(do_something, py).unwrap();
         crate::py_run!(py, func, r#"func(5)"#);
     });
 }

--- a/src/tests/hygiene/pymethods.rs
+++ b/src/tests/hygiene/pymethods.rs
@@ -1,6 +1,3 @@
-#![no_implicit_prelude]
-#![allow(unused_variables, clippy::unnecessary_wraps)]
-
 #[crate::pyclass]
 #[pyo3(crate = "crate")]
 pub struct Dummy;

--- a/src/tests/hygiene/pymodule.rs
+++ b/src/tests/hygiene/pymodule.rs
@@ -1,51 +1,36 @@
-#![no_implicit_prelude]
-#![allow(unused_variables, clippy::unnecessary_wraps)]
-
 #[crate::pyfunction]
 #[pyo3(crate = "crate")]
 fn do_something(x: i32) -> crate::PyResult<i32> {
     ::std::result::Result::Ok(x)
 }
 
-#[cfg(feature = "gil-refs")]
-#[allow(deprecated)]
 #[crate::pymodule]
 #[pyo3(crate = "crate")]
-fn foo(_py: crate::Python<'_>, _m: &crate::types::PyModule) -> crate::PyResult<()> {
-    ::std::result::Result::Ok(())
-}
-
-#[crate::pymodule]
-#[pyo3(crate = "crate")]
-fn foo_bound(
+fn foo(
     _py: crate::Python<'_>,
     _m: &crate::Bound<'_, crate::types::PyModule>,
 ) -> crate::PyResult<()> {
     ::std::result::Result::Ok(())
 }
 
-#[cfg(feature = "gil-refs")]
-#[allow(deprecated)]
 #[crate::pymodule]
 #[pyo3(crate = "crate")]
-fn my_module(_py: crate::Python<'_>, m: &crate::types::PyModule) -> crate::PyResult<()> {
-    m.add_function(crate::wrap_pyfunction!(do_something, m)?)?;
-    m.add_wrapped(crate::wrap_pymodule!(foo))?;
-
-    ::std::result::Result::Ok(())
-}
-
-#[crate::pymodule]
-#[pyo3(crate = "crate")]
-fn my_module_bound(m: &crate::Bound<'_, crate::types::PyModule>) -> crate::PyResult<()> {
+fn my_module(m: &crate::Bound<'_, crate::types::PyModule>) -> crate::PyResult<()> {
     <crate::Bound<'_, crate::types::PyModule> as crate::types::PyModuleMethods>::add_function(
         m,
         crate::wrap_pyfunction_bound!(do_something, m)?,
     )?;
     <crate::Bound<'_, crate::types::PyModule> as crate::types::PyModuleMethods>::add_wrapped(
         m,
-        crate::wrap_pymodule!(foo_bound),
+        crate::wrap_pymodule!(foo),
     )?;
 
     ::std::result::Result::Ok(())
+}
+
+#[crate::pymodule(submodule)]
+#[pyo3(crate = "crate")]
+mod my_module_declarative {
+    #[pymodule_export]
+    use super::{do_something, foo};
 }


### PR DESCRIPTION
This should fix the nightly build failure on the hygiene tests, by moving some of the lint allows to the top-level `tests/hygiene/mod.rs` file.

While updating this I noticed a test for declarative modules was missing; when I added it I immediately hit a failure which I fix also in this PR :)