### PR TITLE
docs: fixups to 0.22 migration guide

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -5,6 +5,15 @@ For a detailed list of all changes, see the [CHANGELOG](changelog.md).
 
 ## from 0.21.* to 0.22
 
+### Deprecation of `gil-refs` feature continues
+<details open>
+<summary><small>Click to expand</small></summary>
+
+Following the introduction of the "Bound" API in PyO3 0.21 and the planned removal of the "GIL Refs" API, all functionality related to GIL Refs is now gated behind the `gil-refs` feature and emits a deprecation warning on use.
+
+See <a href="#from-021-to-022">the 0.21 migration entry</a> for help upgrading.
+</details>
+
 ### Deprecation of implicit default for trailing optional arguments
 <details open>
 <summary><small>Click to expand</small></summary>
@@ -529,6 +538,7 @@ assert_eq!(&*name, "list");
 # }
 # Python::with_gil(example).unwrap();
 ```
+</details>
 
 ## from 0.19.* to 0.20
 


### PR DESCRIPTION
This is two minor adjustments to the 0.22 migration guide:
- Add a tiny note on the GIL Refs removal to remind users of the phases of removal.
- Add a missing `</details>` closing tag which hides all content for 0.20 and older inside the 0.21 section 🤦 