### PR TITLE
docs: remove reference to `IterNextOutput`

### DIFF
--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -225,15 +225,15 @@ documentation](https://docs.python.org/library/stdtypes.html#iterator-types).
 #### Returning a value from iteration
 
 This guide has so far shown how to use `Option<T>` to implement yielding values
-during iteration.  In Python a generator can also return a value. To express
-this in Rust, PyO3 provides the [`IterNextOutput`] enum to both `Yield` values
-and `Return` a final value - see its docs for further details and an example.
+during iteration.  In Python a generator can also return a value. This is done by
+raising a `StopIteration` exception. To express this in Rust, return `PyResult::Err`
+with a `PyStopIteration` as the error.
 
 ### Awaitable objects
 
   - `__await__(<self>) -> object`
   - `__aiter__(<self>) -> object`
-  - `__anext__(<self>) -> Option<object> or IterANextOutput`
+  - `__anext__(<self>) -> Option<object>`
 
 ### Mapping & Sequence types
 
@@ -458,6 +458,5 @@ i.e. `Python::with_gil` will panic.
 
 > Note: these methods are part of the C API, PyPy does not necessarily honor them. If you are building for PyPy you should measure memory consumption to make sure you do not have runaway memory growth. See [this issue on the PyPy bug tracker](https://github.com/pypy/pypy/issues/3848).
 
-[`IterNextOutput`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/enum.IterNextOutput.html
 [`PySequence`]: {{#PYO3_DOCS_URL}}/pyo3/types/struct.PySequence.html
 [`CompareOp::matches`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/enum.CompareOp.html#method.matches


### PR DESCRIPTION
Hangover from #4323 

Will merge as trivial.