### PR TITLE
Implement PartialEq for PyFloat with f64 and f32

### DIFF
--- a/newsfragments/4348.added.md
+++ b/newsfragments/4348.added.md
@@ -1,0 +1,1 @@
+Implement `PartialEq<f64>` and `PartialEq<f32>` for `Bound<'py, PyFloat>`.

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -145,100 +145,70 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<$float_type> for Bound<'_, PyFloat> {
             #[inline]
             fn eq(&self, other: &$float_type) -> bool {
-                match self.extract::<$float_type>() {
-                    Ok(val) => val == *other,
-                    Err(_) => false,
-                }
+                self.value() as $float_type == *other
             }
         }
 
         impl PartialEq<$float_type> for &Bound<'_, PyFloat> {
             #[inline]
             fn eq(&self, other: &$float_type) -> bool {
-                match self.extract::<$float_type>() {
-                    Ok(val) => val == *other,
-                    Err(_) => false,
-                }
+                self.value() as $float_type == *other
             }
         }
 
         impl PartialEq<&$float_type> for Bound<'_, PyFloat> {
             #[inline]
             fn eq(&self, other: &&$float_type) -> bool {
-                match self.extract::<$float_type>() {
-                    Ok(val) => val == **other,
-                    Err(_) => false,
-                }
+                self.value() as $float_type == **other
             }
         }
 
         impl PartialEq<Bound<'_, PyFloat>> for $float_type {
             #[inline]
             fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
-                match other.extract::<$float_type>() {
-                    Ok(val) => val == *self,
-                    Err(_) => false,
-                }
+                other.value() as $float_type == *self
             }
         }
 
         impl PartialEq<&'_ Bound<'_, PyFloat>> for $float_type {
             #[inline]
             fn eq(&self, other: &&'_ Bound<'_, PyFloat>) -> bool {
-                match other.extract::<$float_type>() {
-                    Ok(val) => val == *self,
-                    Err(_) => false,
-                }
+                other.value() as $float_type == *self
             }
         }
 
         impl PartialEq<Bound<'_, PyFloat>> for &'_ $float_type {
             #[inline]
             fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
-                match other.extract::<$float_type>() {
-                    Ok(val) => val == **self,
-                    Err(_) => false,
-                }
+                other.value() as $float_type == **self
             }
         }
 
         impl PartialEq<$float_type> for Borrowed<'_, '_, PyFloat> {
             #[inline]
             fn eq(&self, other: &$float_type) -> bool {
-                match self.extract::<$float_type>() {
-                    Ok(val) => val == *other,
-                    Err(_) => false,
-                }
+                self.value() as $float_type == *other
             }
         }
 
         impl PartialEq<&$float_type> for Borrowed<'_, '_, PyFloat> {
             #[inline]
             fn eq(&self, other: &&$float_type) -> bool {
-                match self.extract::<$float_type>() {
-                    Ok(val) => val == **other,
-                    Err(_) => false,
-                }
+                self.value() as $float_type == **other
             }
         }
 
         impl PartialEq<Borrowed<'_, '_, PyFloat>> for $float_type {
             #[inline]
             fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
-                match other.extract::<$float_type>() {
-                    Ok(val) => val == *self,
-                    Err(_) => false,
-                }
+                other.value() as $float_type == *self
             }
         }
 
         impl PartialEq<Borrowed<'_, '_, PyFloat>> for &$float_type {
             #[inline]
             fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
-                match other.extract::<$float_type>() {
-                    Ok(val) => val == **self,
-                    Err(_) => false,
-                }
+                other.value() as $float_type == **self
             }
         }
     };

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -1,7 +1,10 @@
 use super::any::PyAnyMethods;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-use crate::{ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject, Borrowed};
+use crate::{
+    ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, Borrowed, FromPyObject, IntoPy, PyAny, PyErr,
+    PyObject, PyResult, Python, ToPyObject,
+};
 use std::os::raw::c_double;
 
 /// Represents a Python `float` object.
@@ -139,116 +142,117 @@ impl<'py> FromPyObject<'py> for f32 {
 
 macro_rules! impl_partial_eq_for_float {
     ($float_type: ty) => {
-    impl PartialEq<$float_type> for Bound<'_, PyFloat> {
-        #[inline]
-        fn eq(&self, other: &$float_type) -> bool {
-            if let Ok(val) = self.extract::<$float_type>(){
-                val == *other
-            } else {
-                false
+        impl PartialEq<$float_type> for Bound<'_, PyFloat> {
+            #[inline]
+            fn eq(&self, other: &$float_type) -> bool {
+                if let Ok(val) = self.extract::<$float_type>() {
+                    val == *other
+                } else {
+                    false
+                }
             }
         }
-    }
 
-    impl PartialEq<$float_type> for &Bound<'_, PyFloat> {
-        #[inline]
-        fn eq(&self, other: &$float_type) -> bool {
-            if let Ok(val) = self.extract::<$float_type>(){
-                val == *other
-            } else {
-                false
+        impl PartialEq<$float_type> for &Bound<'_, PyFloat> {
+            #[inline]
+            fn eq(&self, other: &$float_type) -> bool {
+                if let Ok(val) = self.extract::<$float_type>() {
+                    val == *other
+                } else {
+                    false
+                }
             }
         }
-    }
 
-    impl PartialEq<&$float_type> for Bound<'_, PyFloat> {
-        #[inline]
-        fn eq(&self, other: &&$float_type) -> bool {
-            if let Ok(val) = self.extract::<$float_type>(){
-                val == **other
-            } else {
-                false
+        impl PartialEq<&$float_type> for Bound<'_, PyFloat> {
+            #[inline]
+            fn eq(&self, other: &&$float_type) -> bool {
+                if let Ok(val) = self.extract::<$float_type>() {
+                    val == **other
+                } else {
+                    false
+                }
             }
         }
-    }
 
-    impl PartialEq<Bound<'_, PyFloat>> for $float_type {
-        #[inline]
-        fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
-            if let Ok(val) = other.extract::<$float_type>() {
-                val == *self
-            } else {
-                false
+        impl PartialEq<Bound<'_, PyFloat>> for $float_type {
+            #[inline]
+            fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
+                if let Ok(val) = other.extract::<$float_type>() {
+                    val == *self
+                } else {
+                    false
+                }
             }
         }
-    }
 
-    impl PartialEq<&'_ Bound<'_, PyFloat>> for $float_type {
-        #[inline]
-        fn eq(&self, other: &&'_ Bound<'_, PyFloat>) -> bool {
-            if let Ok(val) = other.extract::<$float_type>() {
-                val == *self
-            } else {
-                false
+        impl PartialEq<&'_ Bound<'_, PyFloat>> for $float_type {
+            #[inline]
+            fn eq(&self, other: &&'_ Bound<'_, PyFloat>) -> bool {
+                if let Ok(val) = other.extract::<$float_type>() {
+                    val == *self
+                } else {
+                    false
+                }
             }
         }
-    }
 
-    impl PartialEq<Bound<'_, PyFloat>> for &'_ $float_type {
-        #[inline]
-        fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
-            if let Ok(val) = other.extract::<$float_type>() {
-                val == **self
-            } else {
-                false
+        impl PartialEq<Bound<'_, PyFloat>> for &'_ $float_type {
+            #[inline]
+            fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
+                if let Ok(val) = other.extract::<$float_type>() {
+                    val == **self
+                } else {
+                    false
+                }
             }
         }
-    }
 
-    impl PartialEq<$float_type> for Borrowed<'_, '_, PyFloat> {
-        #[inline]
-        fn eq(&self, other: &$float_type) -> bool {
-            if let Ok(val) = self.extract::<$float_type>(){
-                val == *other
-            } else {
-                false
+        impl PartialEq<$float_type> for Borrowed<'_, '_, PyFloat> {
+            #[inline]
+            fn eq(&self, other: &$float_type) -> bool {
+                if let Ok(val) = self.extract::<$float_type>() {
+                    val == *other
+                } else {
+                    false
+                }
             }
         }
-    }
 
-    impl PartialEq<&$float_type> for Borrowed<'_, '_, PyFloat> {
-        #[inline]
-        fn eq(&self, other: &&$float_type) -> bool {
-            if let Ok(val) = self.extract::<$float_type>(){
-                val == **other
-            } else {
-                false
+        impl PartialEq<&$float_type> for Borrowed<'_, '_, PyFloat> {
+            #[inline]
+            fn eq(&self, other: &&$float_type) -> bool {
+                if let Ok(val) = self.extract::<$float_type>() {
+                    val == **other
+                } else {
+                    false
+                }
             }
         }
-    }
 
-    impl PartialEq<Borrowed<'_, '_, PyFloat>> for $float_type {
-        #[inline]
-        fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
-            if let Ok(val) = other.extract::<$float_type>() {
-                val == *self
-            } else {
-                false
+        impl PartialEq<Borrowed<'_, '_, PyFloat>> for $float_type {
+            #[inline]
+            fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
+                if let Ok(val) = other.extract::<$float_type>() {
+                    val == *self
+                } else {
+                    false
+                }
             }
         }
-    }
 
-    impl PartialEq<Borrowed<'_, '_, PyFloat>> for &$float_type {
-        #[inline]
-        fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
-            if let Ok(val) = other.extract::<$float_type>() {
-                val == **self
-            } else {
-                false
+        impl PartialEq<Borrowed<'_, '_, PyFloat>> for &$float_type {
+            #[inline]
+            fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
+                if let Ok(val) = other.extract::<$float_type>() {
+                    val == **self
+                } else {
+                    false
+                }
             }
         }
-    }
-}}
+    };
+}
 
 impl_partial_eq_for_float!(f64);
 impl_partial_eq_for_float!(f32);

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -1,10 +1,7 @@
 use super::any::PyAnyMethods;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-use crate::{
-    ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject,
-    PyResult, Python, ToPyObject,
-};
+use crate::{ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject, Borrowed};
 use std::os::raw::c_double;
 
 /// Represents a Python `float` object.
@@ -140,6 +137,122 @@ impl<'py> FromPyObject<'py> for f32 {
     }
 }
 
+macro_rules! impl_partial_eq_for_float {
+    ($float_type: ty) => {
+    impl PartialEq<$float_type> for Bound<'_, PyFloat> {
+        #[inline]
+        fn eq(&self, other: &$float_type) -> bool {
+            if let Ok(val) = self.extract::<$float_type>(){
+                val == *other
+            } else {
+                false
+            }
+        }
+    }
+
+    impl PartialEq<$float_type> for &Bound<'_, PyFloat> {
+        #[inline]
+        fn eq(&self, other: &$float_type) -> bool {
+            if let Ok(val) = self.extract::<$float_type>(){
+                val == *other
+            } else {
+                false
+            }
+        }
+    }
+
+    impl PartialEq<&$float_type> for Bound<'_, PyFloat> {
+        #[inline]
+        fn eq(&self, other: &&$float_type) -> bool {
+            if let Ok(val) = self.extract::<$float_type>(){
+                val == **other
+            } else {
+                false
+            }
+        }
+    }
+
+    impl PartialEq<Bound<'_, PyFloat>> for $float_type {
+        #[inline]
+        fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
+            if let Ok(val) = other.extract::<$float_type>() {
+                val == *self
+            } else {
+                false
+            }
+        }
+    }
+
+    impl PartialEq<&'_ Bound<'_, PyFloat>> for $float_type {
+        #[inline]
+        fn eq(&self, other: &&'_ Bound<'_, PyFloat>) -> bool {
+            if let Ok(val) = other.extract::<$float_type>() {
+                val == *self
+            } else {
+                false
+            }
+        }
+    }
+
+    impl PartialEq<Bound<'_, PyFloat>> for &'_ $float_type {
+        #[inline]
+        fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
+            if let Ok(val) = other.extract::<$float_type>() {
+                val == **self
+            } else {
+                false
+            }
+        }
+    }
+
+    impl PartialEq<$float_type> for Borrowed<'_, '_, PyFloat> {
+        #[inline]
+        fn eq(&self, other: &$float_type) -> bool {
+            if let Ok(val) = self.extract::<$float_type>(){
+                val == *other
+            } else {
+                false
+            }
+        }
+    }
+
+    impl PartialEq<&$float_type> for Borrowed<'_, '_, PyFloat> {
+        #[inline]
+        fn eq(&self, other: &&$float_type) -> bool {
+            if let Ok(val) = self.extract::<$float_type>(){
+                val == **other
+            } else {
+                false
+            }
+        }
+    }
+
+    impl PartialEq<Borrowed<'_, '_, PyFloat>> for $float_type {
+        #[inline]
+        fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
+            if let Ok(val) = other.extract::<$float_type>() {
+                val == *self
+            } else {
+                false
+            }
+        }
+    }
+
+    impl PartialEq<Borrowed<'_, '_, PyFloat>> for &$float_type {
+        #[inline]
+        fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
+            if let Ok(val) = other.extract::<$float_type>() {
+                val == **self
+            } else {
+                false
+            }
+        }
+    }
+}}
+
+impl_partial_eq_for_float!(f64);
+impl_partial_eq_for_float!(f32);
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -175,6 +288,69 @@ mod tests {
             let v = 1.23f64;
             let obj = PyFloat::new_bound(py, 1.23);
             assert_approx_eq!(v, obj.value());
+        });
+    }
+
+    #[test]
+    fn test_pyfloat_comparisons() {
+        Python::with_gil(|py| {
+            let f_64 = 1.01f64;
+            let py_f64 = PyFloat::new_bound(py, 1.01);
+            let py_f64_ref = &py_f64;
+            let py_f64_borrowed = py_f64.as_borrowed();
+
+            // Bound<'_, PyFloat> == f64 and vice versa
+            assert_eq!(py_f64, f_64);
+            assert_eq!(f_64, py_f64);
+
+            // Bound<'_, PyFloat> == &f64 and vice versa
+            assert_eq!(py_f64, &f_64);
+            assert_eq!(&f_64, py_f64);
+
+            // &Bound<'_, PyFloat> == &f64 and vice versa
+            assert_eq!(py_f64_ref, f_64);
+            assert_eq!(f_64, py_f64_ref);
+
+            // &Bound<'_, PyFloat> == &f64 and vice versa
+            assert_eq!(py_f64_ref, &f_64);
+            assert_eq!(&f_64, py_f64_ref);
+
+            // Borrowed<'_, '_, PyFloat> == f64 and vice versa
+            assert_eq!(py_f64_borrowed, f_64);
+            assert_eq!(f_64, py_f64_borrowed);
+
+            // Borrowed<'_, '_, PyFloat> == &f64 and vice versa
+            assert_eq!(py_f64_borrowed, &f_64);
+            assert_eq!(&f_64, py_f64_borrowed);
+
+            let f_32 = 2.02f32;
+            let py_f32 = PyFloat::new_bound(py, 2.02);
+            let py_f32_ref = &py_f32;
+            let py_f32_borrowed = py_f32.as_borrowed();
+
+            // Bound<'_, PyFloat> == f32 and vice versa
+            assert_eq!(py_f32, f_32);
+            assert_eq!(f_32, py_f32);
+
+            // Bound<'_, PyFloat> == &f32 and vice versa
+            assert_eq!(py_f32, &f_32);
+            assert_eq!(&f_32, py_f32);
+
+            // &Bound<'_, PyFloat> == &f32 and vice versa
+            assert_eq!(py_f32_ref, f_32);
+            assert_eq!(f_32, py_f32_ref);
+
+            // &Bound<'_, PyFloat> == &f32 and vice versa
+            assert_eq!(py_f32_ref, &f_32);
+            assert_eq!(&f_32, py_f32_ref);
+
+            // Borrowed<'_, '_, PyFloat> == f32 and vice versa
+            assert_eq!(py_f32_borrowed, f_32);
+            assert_eq!(f_32, py_f32_borrowed);
+
+            // Borrowed<'_, '_, PyFloat> == &f32 and vice versa
+            assert_eq!(py_f32_borrowed, &f_32);
+            assert_eq!(&f_32, py_f32_borrowed);
         });
     }
 }

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -145,10 +145,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<$float_type> for Bound<'_, PyFloat> {
             #[inline]
             fn eq(&self, other: &$float_type) -> bool {
-                if let Ok(val) = self.extract::<$float_type>() {
-                    val == *other
-                } else {
-                    false
+                match self.extract::<$float_type>() {
+                    Ok(val) => val == *other,
+                    Err(_) => false,
                 }
             }
         }
@@ -156,10 +155,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<$float_type> for &Bound<'_, PyFloat> {
             #[inline]
             fn eq(&self, other: &$float_type) -> bool {
-                if let Ok(val) = self.extract::<$float_type>() {
-                    val == *other
-                } else {
-                    false
+                match self.extract::<$float_type>() {
+                    Ok(val) => val == *other,
+                    Err(_) => false,
                 }
             }
         }
@@ -167,10 +165,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<&$float_type> for Bound<'_, PyFloat> {
             #[inline]
             fn eq(&self, other: &&$float_type) -> bool {
-                if let Ok(val) = self.extract::<$float_type>() {
-                    val == **other
-                } else {
-                    false
+                match self.extract::<$float_type>() {
+                    Ok(val) => val == **other,
+                    Err(_) => false,
                 }
             }
         }
@@ -178,10 +175,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<Bound<'_, PyFloat>> for $float_type {
             #[inline]
             fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
-                if let Ok(val) = other.extract::<$float_type>() {
-                    val == *self
-                } else {
-                    false
+                match other.extract::<$float_type>() {
+                    Ok(val) => val == *self,
+                    Err(_) => false,
                 }
             }
         }
@@ -189,10 +185,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<&'_ Bound<'_, PyFloat>> for $float_type {
             #[inline]
             fn eq(&self, other: &&'_ Bound<'_, PyFloat>) -> bool {
-                if let Ok(val) = other.extract::<$float_type>() {
-                    val == *self
-                } else {
-                    false
+                match other.extract::<$float_type>() {
+                    Ok(val) => val == *self,
+                    Err(_) => false,
                 }
             }
         }
@@ -200,10 +195,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<Bound<'_, PyFloat>> for &'_ $float_type {
             #[inline]
             fn eq(&self, other: &Bound<'_, PyFloat>) -> bool {
-                if let Ok(val) = other.extract::<$float_type>() {
-                    val == **self
-                } else {
-                    false
+                match other.extract::<$float_type>() {
+                    Ok(val) => val == **self,
+                    Err(_) => false,
                 }
             }
         }
@@ -211,10 +205,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<$float_type> for Borrowed<'_, '_, PyFloat> {
             #[inline]
             fn eq(&self, other: &$float_type) -> bool {
-                if let Ok(val) = self.extract::<$float_type>() {
-                    val == *other
-                } else {
-                    false
+                match self.extract::<$float_type>() {
+                    Ok(val) => val == *other,
+                    Err(_) => false,
                 }
             }
         }
@@ -222,10 +215,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<&$float_type> for Borrowed<'_, '_, PyFloat> {
             #[inline]
             fn eq(&self, other: &&$float_type) -> bool {
-                if let Ok(val) = self.extract::<$float_type>() {
-                    val == **other
-                } else {
-                    false
+                match self.extract::<$float_type>() {
+                    Ok(val) => val == **other,
+                    Err(_) => false,
                 }
             }
         }
@@ -233,10 +225,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<Borrowed<'_, '_, PyFloat>> for $float_type {
             #[inline]
             fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
-                if let Ok(val) = other.extract::<$float_type>() {
-                    val == *self
-                } else {
-                    false
+                match other.extract::<$float_type>() {
+                    Ok(val) => val == *self,
+                    Err(_) => false,
                 }
             }
         }
@@ -244,10 +235,9 @@ macro_rules! impl_partial_eq_for_float {
         impl PartialEq<Borrowed<'_, '_, PyFloat>> for &$float_type {
             #[inline]
             fn eq(&self, other: &Borrowed<'_, '_, PyFloat>) -> bool {
-                if let Ok(val) = other.extract::<$float_type>() {
-                    val == **self
-                } else {
-                    false
+                match other.extract::<$float_type>() {
+                    Ok(val) => val == **self,
+                    Err(_) => false,
                 }
             }
         }


### PR DESCRIPTION
This PR implements `PartialEq` for `PyFloat` with `f64` and `f32`. See https://github.com/PyO3/pyo3/issues/4250
