### PR TITLE
Improve error messages for #[pyfunction] defined inside #[pymethods]

### DIFF
--- a/newsfragments/4349.fixed.md
+++ b/newsfragments/4349.fixed.md
@@ -1,0 +1,1 @@
+Improve error messages for `#[pyfunction]` defined inside `#[pymethods]`

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -291,3 +291,39 @@ pub fn apply_renaming_rule(rule: RenamingRule, name: &str) -> String {
 pub(crate) fn is_abi3() -> bool {
     pyo3_build_config::get().abi3
 }
+
+pub(crate) enum IdentOrStr<'a> {
+    Str(&'a str),
+    Ident(syn::Ident),
+}
+
+pub(crate) fn has_attribute(attrs: &[syn::Attribute], ident: &str) -> bool {
+    has_attribute_with_namespace(attrs, None, &[ident])
+}
+
+pub(crate) fn has_attribute_with_namespace(
+    attrs: &[syn::Attribute],
+    crate_path: Option<&PyO3CratePath>,
+    idents: &[&str],
+) -> bool {
+    let mut segments = vec![];
+    if let Some(c) = crate_path {
+        match c {
+            PyO3CratePath::Given(paths) => {
+                for p in &paths.segments {
+                    segments.push(IdentOrStr::Ident(p.ident.clone()));
+                }
+            }
+            PyO3CratePath::Default => segments.push(IdentOrStr::Str("pyo3")),
+        }
+    };
+    for i in idents {
+        segments.push(IdentOrStr::Str(i));
+    }
+
+    attrs.iter().any(|attr| {
+        segments
+            .iter()
+            .eq(attr.path().segments.iter().map(|v| &v.ident))
+    })
+}

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -11,6 +11,7 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_pyclass_enum.rs");
     t.compile_fail("tests/ui/invalid_pyclass_item.rs");
     t.compile_fail("tests/ui/invalid_pyfunction_signatures.rs");
+    t.compile_fail("tests/ui/invalid_pyfunction_definition.rs");
     #[cfg(any(not(Py_LIMITED_API), Py_3_11))]
     t.compile_fail("tests/ui/invalid_pymethods_buffer.rs");
     // The output is not stable across abi3 / not abi3 and features

--- a/tests/ui/invalid_pyfunction_definition.rs
+++ b/tests/ui/invalid_pyfunction_definition.rs
@@ -1,0 +1,15 @@
+
+
+#[pyo3::pymodule]
+mod pyo3_scratch {
+    use pyo3::prelude::*;
+
+    #[pyclass]
+    struct Foo {}
+
+    #[pymethods]
+    impl Foo {
+        #[pyfunction]
+        fn bug() {}
+    }
+}

--- a/tests/ui/invalid_pyfunction_definition.rs
+++ b/tests/ui/invalid_pyfunction_definition.rs
@@ -1,5 +1,3 @@
-
-
 #[pyo3::pymodule]
 mod pyo3_scratch {
     use pyo3::prelude::*;
@@ -13,3 +11,5 @@ mod pyo3_scratch {
         fn bug() {}
     }
 }
+
+fn main() {}

--- a/tests/ui/invalid_pyfunction_definition.stderr
+++ b/tests/ui/invalid_pyfunction_definition.stderr
@@ -1,0 +1,11 @@
+error: functions inside #[pymethods] do not need to be annotated with #[pyfunction]
+  --> tests/ui/invalid_pyfunction_definition.rs:13:9
+   |
+13 |         fn bug() {}
+   |         ^^
+
+error[E0601]: `main` function not found in crate `$CRATE`
+  --> tests/ui/invalid_pyfunction_definition.rs:15:2
+   |
+15 | }
+   |  ^ consider adding a `main` function to `$DIR/tests/ui/invalid_pyfunction_definition.rs`

--- a/tests/ui/invalid_pyfunction_definition.stderr
+++ b/tests/ui/invalid_pyfunction_definition.stderr
@@ -1,11 +1,5 @@
 error: functions inside #[pymethods] do not need to be annotated with #[pyfunction]
-  --> tests/ui/invalid_pyfunction_definition.rs:13:9
+  --> tests/ui/invalid_pyfunction_definition.rs:11:9
    |
-13 |         fn bug() {}
+11 |         fn bug() {}
    |         ^^
-
-error[E0601]: `main` function not found in crate `$CRATE`
-  --> tests/ui/invalid_pyfunction_definition.rs:15:2
-   |
-15 | }
-   |  ^ consider adding a `main` function to `$DIR/tests/ui/invalid_pyfunction_definition.rs`


### PR DESCRIPTION
Make error message more specific when `#[pyfunction]` is used in `#[pymethods]`.

Effectively, this replaces the error message:

```
error: static method needs #[staticmethod] attribute
```

To:
```
functions inside #[pymethods] do not need to be annotated with #[pyfunction]
```

Fixes #4340
