### PR TITLE
only emit c-string literals on Rust 1.79 and later (#4352)

### DIFF
--- a/newsfragments/4353.fixed.md
+++ b/newsfragments/4353.fixed.md
@@ -1,0 +1,1 @@
+fixed compile error due to c-string literals on Rust < 1.79

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -143,7 +143,7 @@ pub fn print_feature_cfgs() {
         println!("cargo:rustc-cfg=invalid_from_utf8_lint");
     }
 
-    if rustc_minor_version >= 77 {
+    if rustc_minor_version >= 79 {
         println!("cargo:rustc-cfg=c_str_lit");
     }
 


### PR DESCRIPTION
See https://github.com/PyO3/pyo3/issues/4352#issuecomment-2228951037

Closes #4352 
