### PR TITLE
Update dict.get_item binding to use PyDict_GetItemRef

### DIFF
--- a/newsfragments/4355.added.md
+++ b/newsfragments/4355.added.md
@@ -1,0 +1,10 @@
+* Added an `ffi::compat` namespace to store compatibility shims for C API
+  functions added in recent versions of Python.
+
+* Added bindings for `PyDict_GetItemRef` on Python 3.13 and newer. Also added
+  `ffi::compat::PyDict_GetItemRef` which re-exports the FFI binding on Python
+  3.13 or newer and defines a compatibility version on older versions of
+  Python. This function is inherently safer to use than `PyDict_GetItem` and has
+  an API that is easier to use than `PyDict_GetItemWithError`. It returns a
+  strong reference to value, as opposed to the two older functions which return
+  a possibly unsafe borrowed reference.

--- a/newsfragments/4355.fixed.md
+++ b/newsfragments/4355.fixed.md
@@ -1,0 +1,2 @@
+Avoid creating temporary borrowed reference in dict.get_item bindings. Borrowed
+references like this are unsafe in the free-threading build.

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 //! C API Compatibility Shims
 //!
 //! Some CPython C API functions added in recent versions of Python are
@@ -5,6 +7,9 @@
 //! exposes functions available on all Python versions that wrap the
 //! old C API on old Python versions and wrap the function directly
 //! on newer Python versions.
+
+// Unless otherwise noted, the compatibility shims are adapted from
+// the pythoncapi-compat project: https://github.com/python/pythoncapi-compat
 
 use crate::object::PyObject;
 use std::os::raw::c_int;
@@ -14,18 +19,19 @@ pub unsafe fn PyDict_GetItemRef(
     key: *mut PyObject,
     result: *mut *mut PyObject,
 ) -> c_int {
+    #[cfg_attr(docsrs, doc(cfg()))]
     #[cfg(Py_3_13)]
     {
         crate::PyDict_GetItemRef(dp, key, result)
     }
 
+    #[cfg_attr(docsrs, doc(cfg()))]
     #[cfg(not(Py_3_13))]
     {
         use crate::dictobject::PyDict_GetItemWithError;
         use crate::object::_Py_NewRef;
         use crate::pyerrors::PyErr_Occurred;
 
-        // adapted from pythoncapi-compat
         let item: *mut PyObject = PyDict_GetItemWithError(dp, key);
         if !item.is_null() {
             *result = _Py_NewRef(item);

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -11,7 +11,7 @@
 
 #[cfg(Py_3_13)]
 mod py313_compat {
-    use crate::dictobject::PyDict_GetItemRef;
+    pub use crate::dictobject::PyDict_GetItemRef;
 }
 #[cfg(not(Py_3_13))]
 mod py313_compat {

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-
 //! C API Compatibility Shims
 //!
 //! Some CPython C API functions added in recent versions of Python are
@@ -14,11 +12,11 @@
 use crate::object::PyObject;
 use std::os::raw::c_int;
 
-#[cfg_attr(docsrs, doc(cfg()))]
+#[cfg_attr(docsrs, doc(cfg(Py_3_13)))]
 #[cfg(Py_3_13)]
 pub use crate::dictobject::PyDict_GetItemRef;
 
-#[cfg_attr(docsrs, doc(cfg()))]
+#[cfg_attr(docsrs, doc(cfg(not(Py_3_13))))]
 #[cfg(not(Py_3_13))]
 pub unsafe fn PyDict_GetItemRef(
     dp: *mut PyObject,

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -1,0 +1,42 @@
+//! C API Compatibility Shims
+//!
+//! Some CPython C API functions added in recent versions of Python are
+//! inherently safer to use than older C API constructs. This module
+//! exposes versions of these safer functions for older python versions
+//! and on newer versions simply re-exports the function from the FFI
+//! bindings.
+//!
+//! This compatibility module makes it easier to use safer C API
+//! constructs without writing your own compatibility shims.
+
+#[cfg(Py_3_13)]
+mod py313_compat {
+    use crate::dictobject::PyDict_GetItemRef;
+}
+#[cfg(not(Py_3_13))]
+mod py313_compat {
+    use crate::object::{PyObject, _Py_NewRef};
+    use std::os::raw::c_int;
+
+    use crate::dictobject::PyDict_GetItemWithError;
+    use crate::pyerrors::PyErr_Occurred;
+
+    pub unsafe fn PyDict_GetItemRef(
+        dp: *mut PyObject,
+        key: *mut PyObject,
+        result: *mut *mut PyObject,
+    ) -> c_int {
+        let item: *mut PyObject = PyDict_GetItemWithError(dp, key);
+        if !item.is_null() {
+            *result = _Py_NewRef(item);
+            return 1; // found
+        }
+        *result = std::ptr::null_mut();
+        if PyErr_Occurred().is_null() {
+            return 0; // not found
+        }
+        -1
+    }
+}
+
+pub use py313_compat::PyDict_GetItemRef;

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -14,11 +14,11 @@ use crate::object::PyObject;
 #[cfg(not(Py_3_13))]
 use std::os::raw::c_int;
 
-#[cfg_attr(docsrs, doc(cfg(Py_3_13)))]
+#[cfg_attr(docsrs, doc(cfg(all)))]
 #[cfg(Py_3_13)]
 pub use crate::dictobject::PyDict_GetItemRef;
 
-#[cfg_attr(docsrs, doc(cfg(not(Py_3_13))))]
+#[cfg_attr(docsrs, doc(cfg(all)))]
 #[cfg(not(Py_3_13))]
 pub unsafe fn PyDict_GetItemRef(
     dp: *mut PyObject,

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -2,30 +2,30 @@
 //!
 //! Some CPython C API functions added in recent versions of Python are
 //! inherently safer to use than older C API constructs. This module
-//! exposes versions of these safer functions for older python versions
-//! and on newer versions simply re-exports the function from the FFI
-//! bindings.
-//!
-//! This compatibility module makes it easier to use safer C API
-//! constructs without writing your own compatibility shims.
+//! exposes functions available on all Python versions that wrap the
+//! old C API on old Python versions and wrap the function directly
+//! on newer Python versions.
 
-#[cfg(Py_3_13)]
-mod py313_compat {
-    pub use crate::dictobject::PyDict_GetItemRef;
-}
-#[cfg(not(Py_3_13))]
-mod py313_compat {
-    use crate::object::{PyObject, _Py_NewRef};
-    use std::os::raw::c_int;
+use crate::object::PyObject;
+use std::os::raw::c_int;
 
-    use crate::dictobject::PyDict_GetItemWithError;
-    use crate::pyerrors::PyErr_Occurred;
+pub unsafe fn PyDict_GetItemRef(
+    dp: *mut PyObject,
+    key: *mut PyObject,
+    result: *mut *mut PyObject,
+) -> c_int {
+    #[cfg(Py_3_13)]
+    {
+        crate::PyDict_GetItemRef(dp, key, result)
+    }
 
-    pub unsafe fn PyDict_GetItemRef(
-        dp: *mut PyObject,
-        key: *mut PyObject,
-        result: *mut *mut PyObject,
-    ) -> c_int {
+    #[cfg(not(Py_3_13))]
+    {
+        use crate::dictobject::PyDict_GetItemWithError;
+        use crate::object::_Py_NewRef;
+        use crate::pyerrors::PyErr_Occurred;
+
+        // adapted from pythoncapi-compat
         let item: *mut PyObject = PyDict_GetItemWithError(dp, key);
         if !item.is_null() {
             *result = _Py_NewRef(item);
@@ -38,5 +38,3 @@ mod py313_compat {
         -1
     }
 }
-
-pub use py313_compat::PyDict_GetItemRef;

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -14,19 +14,17 @@
 use crate::object::PyObject;
 use std::os::raw::c_int;
 
+#[cfg_attr(docsrs, doc(cfg()))]
+#[cfg(Py_3_13)]
+pub use crate::dictobject::PyDict_GetItemRef;
+
+#[cfg_attr(docsrs, doc(cfg()))]
+#[cfg(not(Py_3_13))]
 pub unsafe fn PyDict_GetItemRef(
     dp: *mut PyObject,
     key: *mut PyObject,
     result: *mut *mut PyObject,
 ) -> c_int {
-    #[cfg_attr(docsrs, doc(cfg()))]
-    #[cfg(Py_3_13)]
-    {
-        crate::PyDict_GetItemRef(dp, key, result)
-    }
-
-    #[cfg_attr(docsrs, doc(cfg()))]
-    #[cfg(not(Py_3_13))]
     {
         use crate::dictobject::PyDict_GetItemWithError;
         use crate::object::_Py_NewRef;

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -9,7 +9,9 @@
 // Unless otherwise noted, the compatibility shims are adapted from
 // the pythoncapi-compat project: https://github.com/python/pythoncapi-compat
 
+#[cfg(not(Py_3_13))]
 use crate::object::PyObject;
+#[cfg(not(Py_3_13))]
 use std::os::raw::c_int;
 
 #[cfg_attr(docsrs, doc(cfg(Py_3_13)))]

--- a/pyo3-ffi/src/dictobject.rs
+++ b/pyo3-ffi/src/dictobject.rs
@@ -1,6 +1,4 @@
 use crate::object::*;
-#[cfg(not(Py_3_13))]
-use crate::pyerrors::PyErr_Occurred;
 use crate::pyport::Py_ssize_t;
 use std::os::raw::{c_char, c_int};
 use std::ptr::addr_of_mut;
@@ -102,24 +100,6 @@ pub unsafe fn PyDictItems_Check(op: *mut PyObject) -> c_int {
 #[inline]
 pub unsafe fn PyDictViewSet_Check(op: *mut PyObject) -> c_int {
     (PyDictKeys_Check(op) != 0 || PyDictItems_Check(op) != 0) as c_int
-}
-
-#[cfg(not(Py_3_13))]
-pub unsafe fn PyDict_GetItemRef(
-    dp: *mut PyObject,
-    key: *mut PyObject,
-    result: *mut *mut PyObject,
-) -> c_int {
-    let item: *mut PyObject = PyDict_GetItemWithError(dp, key);
-    if !item.is_null() {
-        *result = _Py_NewRef(item);
-        return 1; // found
-    }
-    *result = std::ptr::null_mut();
-    if PyErr_Occurred().is_null() {
-        return 0; // not found
-    }
-    -1
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/pyo3-ffi/src/dictobject.rs
+++ b/pyo3-ffi/src/dictobject.rs
@@ -116,7 +116,7 @@ pub unsafe fn PyDict_GetItemRef(
         return 1; // found
     }
     *result = std::ptr::null_mut();
-    if !PyErr_Occurred().is_null() {
+    if PyErr_Occurred().is_null() {
         return 0; // not found
     }
     -1

--- a/pyo3-ffi/src/dictobject.rs
+++ b/pyo3-ffi/src/dictobject.rs
@@ -58,12 +58,6 @@ extern "C" {
     pub fn PyDict_MergeFromSeq2(d: *mut PyObject, seq2: *mut PyObject, _override: c_int) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyDict_GetItemString")]
     pub fn PyDict_GetItemString(dp: *mut PyObject, key: *const c_char) -> *mut PyObject;
-    #[cfg(Py_3_13)]
-    pub fn PyDict_GetItemRef(
-        dp: *mut PyObject,
-        key: *mut PyObject,
-        result: *mut *mut PyObject,
-    ) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyDict_SetItemString")]
     pub fn PyDict_SetItemString(
         dp: *mut PyObject,
@@ -72,6 +66,12 @@ extern "C" {
     ) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyDict_DelItemString")]
     pub fn PyDict_DelItemString(dp: *mut PyObject, key: *const c_char) -> c_int;
+    #[cfg(Py_3_13)]
+    pub fn PyDict_GetItemRef(
+        dp: *mut PyObject,
+        key: *mut PyObject,
+        result: *mut *mut PyObject,
+    ) -> c_int;
     // skipped 3.10 / ex-non-limited PyObject_GenericGetDict
 }
 

--- a/pyo3-ffi/src/dictobject.rs
+++ b/pyo3-ffi/src/dictobject.rs
@@ -1,4 +1,6 @@
 use crate::object::*;
+#[cfg(not(Py_3_13))]
+use crate::pyerrors::PyErr_Occurred;
 use crate::pyport::Py_ssize_t;
 use std::os::raw::{c_char, c_int};
 use std::ptr::addr_of_mut;
@@ -58,6 +60,12 @@ extern "C" {
     pub fn PyDict_MergeFromSeq2(d: *mut PyObject, seq2: *mut PyObject, _override: c_int) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyDict_GetItemString")]
     pub fn PyDict_GetItemString(dp: *mut PyObject, key: *const c_char) -> *mut PyObject;
+    #[cfg(Py_3_13)]
+    pub fn PyDict_GetItemRef(
+        dp: *mut PyObject,
+        key: *mut PyObject,
+        result: *mut *mut PyObject,
+    ) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyDict_SetItemString")]
     pub fn PyDict_SetItemString(
         dp: *mut PyObject,
@@ -94,6 +102,24 @@ pub unsafe fn PyDictItems_Check(op: *mut PyObject) -> c_int {
 #[inline]
 pub unsafe fn PyDictViewSet_Check(op: *mut PyObject) -> c_int {
     (PyDictKeys_Check(op) != 0 || PyDictItems_Check(op) != 0) as c_int
+}
+
+#[cfg(not(Py_3_13))]
+pub unsafe fn PyDict_GetItemRef(
+    dp: *mut PyObject,
+    key: *mut PyObject,
+    result: *mut *mut PyObject,
+) -> c_int {
+    let item: *mut PyObject = PyDict_GetItemWithError(dp, key);
+    if !item.is_null() {
+        *result = _Py_NewRef(item);
+        return 1; // found
+    }
+    *result = std::ptr::null_mut();
+    if !PyErr_Occurred().is_null() {
+        return 0; // not found
+    }
+    -1
 }
 
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 //! Raw FFI declarations for Python's C API.
 //!
 //! PyO3 can be used to write native Python modules or run Python code and modules from Rust.

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -290,6 +290,8 @@ pub const fn _cstr_from_utf8_with_nul_checked(s: &str) -> &CStr {
 
 use std::ffi::CStr;
 
+pub mod compat;
+
 pub use self::abstract_::*;
 pub use self::bltinmodule::*;
 pub use self::boolobject::*;
@@ -364,7 +366,6 @@ mod ceval;
 #[cfg(Py_LIMITED_API)]
 mod code;
 mod codecs;
-pub mod compat;
 mod compile;
 mod complexobject;
 #[cfg(all(Py_3_8, not(Py_LIMITED_API)))]

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -364,6 +364,7 @@ mod ceval;
 #[cfg(Py_LIMITED_API)]
 mod code;
 mod codecs;
+pub mod compat;
 mod compile;
 mod complexobject;
 #[cfg(all(Py_3_8, not(Py_LIMITED_API)))]

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -750,7 +750,7 @@ mod tests {
         Python::with_gil(|py| {
             let class = py.get_type_bound::<HashErrors>();
             let instance = class.call0().unwrap();
-            let d = PyDict::new_bound(py);
+            let d = PyDict::new(py);
             match d.get_item(instance) {
                 Ok(_) => {
                     panic!("this get_item call should always error")

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -735,11 +735,6 @@ mod tests {
 
         #[crate::pymethods(crate = "crate")]
         impl HashErrors {
-            #[new]
-            fn new() -> PyResult<Self> {
-                Ok(HashErrors {})
-            }
-
             fn __hash__(&self) -> PyResult<isize> {
                 Err(PyTypeError::new_err("Error from __hash__"))
             }

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -248,7 +248,9 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
         ) -> PyResult<Option<Bound<'py, PyAny>>> {
             let py = dict.py();
             let mut result: *mut ffi::PyObject = std::ptr::null_mut();
-            match unsafe { ffi::PyDict_GetItemRef(dict.as_ptr(), key.as_ptr(), &mut result) } {
+            match unsafe {
+                ffi::compat::PyDict_GetItemRef(dict.as_ptr(), key.as_ptr(), &mut result)
+            } {
                 std::os::raw::c_int::MIN..=-1 => Err(PyErr::fetch(py)),
                 0 => Ok(None),
                 1..=std::os::raw::c_int::MAX => Ok(Some(unsafe { result.assume_owned(py) })),

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -600,7 +600,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::exceptions::PyTypeError;
     use crate::types::PyTuple;
     use std::collections::{BTreeMap, HashMap};
 
@@ -731,6 +730,8 @@ mod tests {
     #[cfg(feature = "macros")]
     #[test]
     fn test_get_item_error_path() {
+        use crate::exceptions::PyTypeError;
+
         #[crate::pyclass(crate = "crate")]
         struct HashErrors;
 

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -738,8 +738,8 @@ mod tests {
         #[crate::pymethods(crate = "crate")]
         impl HashErrors {
             #[new]
-            fn new() -> PyResult<Self> {
-                Ok(HashErrors {})
+            fn new() -> Self {
+                HashErrors {}
             }
 
             fn __hash__(&self) -> PyResult<isize> {

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -735,6 +735,11 @@ mod tests {
 
         #[crate::pymethods(crate = "crate")]
         impl HashErrors {
+            #[new]
+            fn new() -> PyResult<Self> {
+                Ok(HashErrors {})
+            }
+
             fn __hash__(&self) -> PyResult<isize> {
                 Err(PyTypeError::new_err("Error from __hash__"))
             }


### PR DESCRIPTION
Refs #4265

See [the CPython C API docs](https://docs.python.org/3.13/c-api/dict.html#c.PyDict_GetItemRef) for this new function. Also see PEP 703 for how this relates to free-threading support.