### PR TITLE
Add issubclass() functionality to Rust code.

### DIFF
--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -295,6 +295,11 @@ pub unsafe fn PyObject_TypeCheck(ob: *mut PyObject, tp: *mut PyTypeObject) -> c_
     (Py_TYPE(ob) == tp || PyType_IsSubtype(Py_TYPE(ob), tp) != 0) as c_int
 }
 
+#[inline]
+pub unsafe fn PyObject_SubTypeCheck(ob: *mut PyObject, tp: *mut PyTypeObject) -> c_int {
+    (PyType_IsSubtype(Py_TYPE(ob), tp) != 0) as c_int
+}
+
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     /// built-in 'type'

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -119,6 +119,12 @@ pub unsafe trait PyTypeInfo: Sized + HasPyGilRef {
         unsafe { ffi::PyObject_TypeCheck(object.as_ptr(), Self::type_object_raw(object.py())) != 0 }
     }
 
+    /// Checks if `object` is a subclass of this type
+    #[inline]
+    fn is_sub_type_of_bound(object: &Bound<'_, PyAny>) -> bool {
+        unsafe { ffi::PyObject_SubTypeCheck(object.as_ptr(), Self::type_object_raw(object.py())) != 0}
+    }
+
     /// Checks if `object` is an instance of this type.
     #[inline]
     #[cfg(feature = "gil-refs")]
@@ -182,6 +188,13 @@ pub unsafe trait PyTypeInfo: Sized {
     #[inline]
     fn is_type_of_bound(object: &Bound<'_, PyAny>) -> bool {
         unsafe { ffi::PyObject_TypeCheck(object.as_ptr(), Self::type_object_raw(object.py())) != 0 }
+    }
+
+
+    /// Checks if `object` is a subclass of this type
+    #[inline]
+    fn is_sub_type_of_bound(object: &Bound<'_, PyAny>) -> bool {
+        unsafe { ffi::PyObject_SubTypeCheck(object.as_ptr(), Self::type_object_raw(object.py())) != 0}
     }
 
     /// Checks if `object` is an instance of this type.

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -741,7 +741,7 @@ impl PyAny {
     /// This is equivalent to the Python expression `issubclass(self, T)`,
     /// if the type `T` is known at compile time.
     #[inline]
-    pub fn is_instance_of<T: PyTypeInfo>(&self) -> bool {
+    pub fn is_sub_class_of<T: PyTypeInfo>(&self) -> bool {
         self.as_borrowed().is_sub_class_of::<T>()
     }
 


### PR DESCRIPTION
Add the ability for checking if a Python objects are subclasses, with a similar interface to `is_instance` and `is_instance_of` for `PyAny` objects as well as add the ability to check `PyInfoObjects` for if the object is a subtype.

Let me know if there is anything else I need to add to the PR.