### PR TITLE
Deprecate PyUnicode

### DIFF
--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -13,7 +13,7 @@ The table below contains the Python type and the corresponding function argument
 | Python        | Rust                            | Rust (Python-native) |
 | ------------- |:-------------------------------:|:--------------------:|
 | `object`      | -                               | `PyAny`             |
-| `str`         | `String`, `Cow<str>`, `&str`, `char`, `OsString`, `PathBuf`, `Path` | `PyString`, `PyUnicode` |
+| `str`         | `String`, `Cow<str>`, `&str`, `char`, `OsString`, `PathBuf`, `Path` | `PyString` |
 | `bytes`       | `Vec<u8>`, `&[u8]`, `Cow<[u8]>` | `PyBytes`           |
 | `bool`        | `bool`                          | `PyBool`            |
 | `int`         | `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`, `num_bigint::BigInt`[^1], `num_bigint::BigUint`[^1] | `PyInt` |
@@ -38,8 +38,8 @@ The table below contains the Python type and the corresponding function argument
 | `decimal.Decimal` | `rust_decimal::Decimal`[^7] | -                    |
 | `ipaddress.IPv4Address` | `std::net::IpAddr`, `std::net::IpV4Addr` | - |
 | `ipaddress.IPv6Address` | `std::net::IpAddr`, `std::net::IpV6Addr` | - |
-| `os.PathLike ` | `PathBuf`, `Path`              | `PyString`, `PyUnicode` |
-| `pathlib.Path` | `PathBuf`, `Path`              | `PyString`, `PyUnicode` |
+| `os.PathLike ` | `PathBuf`, `Path`              | `PyString` |
+| `pathlib.Path` | `PathBuf`, `Path`              | `PyString` |
 | `typing.Optional[T]` | `Option<T>`              | -                    |
 | `typing.Sequence[T]` | `Vec<T>`                 | `PySequence`        |
 | `typing.Mapping[K, V]` | `HashMap<K, V>`, `BTreeMap<K, V>`, `hashbrown::HashMap<K, V>`[^3], `indexmap::IndexMap<K, V>`[^4] | `&PyMapping` |

--- a/newsfragments/4370.removed.md
+++ b/newsfragments/4370.removed.md
@@ -1,0 +1,1 @@
+Deprecated PyUnicode in favour of PyString.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -40,7 +40,8 @@ pub use self::set::{PySet, PySetMethods};
 pub use self::slice::{PySlice, PySliceIndices, PySliceMethods};
 #[cfg(not(Py_LIMITED_API))]
 pub use self::string::PyStringData;
-pub use self::string::{PyString, PyStringMethods};
+#[allow(deprecated)]
+pub use self::string::{PyString, PyStringMethods, PyUnicode};
 pub use self::traceback::{PyTraceback, PyTracebackMethods};
 pub use self::tuple::{PyTuple, PyTupleMethods};
 pub use self::typeobject::{PyType, PyTypeMethods};

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -40,7 +40,7 @@ pub use self::set::{PySet, PySetMethods};
 pub use self::slice::{PySlice, PySliceIndices, PySliceMethods};
 #[cfg(not(Py_LIMITED_API))]
 pub use self::string::PyStringData;
-pub use self::string::{PyString, PyString as PyUnicode, PyStringMethods};
+pub use self::string::{PyString, PyStringMethods};
 pub use self::traceback::{PyTraceback, PyTracebackMethods};
 pub use self::tuple::{PyTuple, PyTupleMethods};
 pub use self::typeobject::{PyType, PyTypeMethods};

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -10,6 +10,10 @@ use crate::{ffi, Bound, IntoPy, Py, PyAny, PyResult, Python};
 use std::borrow::Cow;
 use std::str;
 
+/// Deprecated alias for [`PyUnicode`].
+#[deprecated(since = "0.23.0", note = "use `PyString` instead")]
+pub type PyUnicode = PyString;
+
 /// Represents raw data backing a Python `str`.
 ///
 /// Python internally stores strings in various representations. This enumeration

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -10,7 +10,7 @@ use crate::{ffi, Bound, IntoPy, Py, PyAny, PyResult, Python};
 use std::borrow::Cow;
 use std::str;
 
-/// Deprecated alias for [`PyUnicode`].
+/// Deprecated alias for [`PyString`].
 #[deprecated(since = "0.23.0", note = "use `PyString` instead")]
 pub type PyUnicode = PyString;
 


### PR DESCRIPTION
Attempt to close #4260 by deprecating `PyUnicode`.

I am not sure if it is this simple, seems `PyUnicode` is mainly used internally in the ffi.