### PR TITLE
fix clippy-beta

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -22,7 +22,7 @@ pub use self::float::{PyFloat, PyFloatMethods};
 pub use self::frame::PyFrame;
 pub use self::frozenset::{PyFrozenSet, PyFrozenSetBuilder, PyFrozenSetMethods};
 pub use self::function::PyCFunction;
-#[cfg(all(not(Py_LIMITED_API), not(PyPy), not(GraalPy)))]
+#[cfg(all(not(Py_LIMITED_API), not(all(PyPy, not(Py_3_8))), not(GraalPy)))]
 pub use self::function::PyFunction;
 pub use self::iterator::PyIterator;
 pub use self::list::{PyList, PyListMethods};


### PR DESCRIPTION
Dead code detection getting better and linted a case where our reexport of `PyFunction` 
https://github.com/PyO3/pyo3/blob/b2b5203ca4fb103e84f1ae8a267ea2d2912d5307/src/types/mod.rs#L25-L26
has a more restrictive gate than its type definition
https://github.com/PyO3/pyo3/blob/b2b5203ca4fb103e84f1ae8a267ea2d2912d5307/src/types/function.rs#L183-L184
So that type is actually not nameable on PyPy 3.8+ but it was actually intended to be.

This updates the cfg on the reexport to reflect the cfgs on the type definition.