### PR TITLE
RFC: remove private `_Py` symbols from `pyo3-ffi`

### DIFF
--- a/pyo3-ffi/README.md
+++ b/pyo3-ffi/README.md
@@ -65,7 +65,7 @@ static mut METHODS: [PyMethodDef; 2] = [
     PyMethodDef {
         ml_name: c_str!("sum_as_string").as_ptr(),
         ml_meth: PyMethodDefPointer {
-            _PyCFunctionFast: sum_as_string,
+            PyCFunctionFast: sum_as_string,
         },
         ml_flags: METH_FASTCALL,
         ml_doc: c_str!("returns the sum of two integers as a string").as_ptr(),

--- a/pyo3-ffi/src/abstract_.rs
+++ b/pyo3-ffi/src/abstract_.rs
@@ -1,5 +1,7 @@
 use crate::object::*;
 use crate::pyport::Py_ssize_t;
+#[cfg(any(Py_3_12, all(Py_3_9, not(Py_LIMITED_API))))]
+use libc::size_t;
 use std::os::raw::{c_char, c_int};
 use std::ptr;
 
@@ -53,22 +55,6 @@ extern "C" {
         ...
     ) -> *mut PyObject;
 
-    #[cfg(not(Py_3_13))]
-    #[cfg_attr(PyPy, link_name = "_PyPyObject_CallFunction_SizeT")]
-    pub fn _PyObject_CallFunction_SizeT(
-        callable_object: *mut PyObject,
-        format: *const c_char,
-        ...
-    ) -> *mut PyObject;
-    #[cfg(not(Py_3_13))]
-    #[cfg_attr(PyPy, link_name = "_PyPyObject_CallMethod_SizeT")]
-    pub fn _PyObject_CallMethod_SizeT(
-        o: *mut PyObject,
-        method: *const c_char,
-        format: *const c_char,
-        ...
-    ) -> *mut PyObject;
-
     #[cfg_attr(PyPy, link_name = "PyPyObject_CallFunctionObjArgs")]
     pub fn PyObject_CallFunctionObjArgs(callable: *mut PyObject, ...) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyObject_CallMethodObjArgs")]
@@ -77,6 +63,41 @@ extern "C" {
         method: *mut PyObject,
         ...
     ) -> *mut PyObject;
+
+    #[cfg(all(Py_3_12, Py_LIMITED_API))] // used as a function on the stable abi
+    pub fn PyVectorcall_NARGS(nargsf: libc::size_t) -> Py_ssize_t;
+
+    #[cfg(any(Py_3_12, all(Py_3_9, not(Py_LIMITED_API))))]
+    #[cfg_attr(PyPy, link_name = "PyPyVectorcall_Call")]
+    pub fn PyVectorcall_Call(
+        callable: *mut PyObject,
+        tuple: *mut PyObject,
+        dict: *mut PyObject,
+    ) -> *mut PyObject;
+}
+
+#[cfg(Py_3_12)]
+pub const PY_VECTORCALL_ARGUMENTS_OFFSET: size_t =
+    1 << (8 * std::mem::size_of::<size_t>() as size_t - 1);
+
+extern "C" {
+    #[cfg_attr(Py_3_9, link_name = "PyPyObject_Vectorcall")]
+    #[cfg(any(Py_3_12, all(Py_3_9, not(Py_LIMITED_API))))]
+    pub fn PyObject_Vectorcall(
+        callable: *mut PyObject,
+        args: *const *mut PyObject,
+        nargsf: size_t,
+        kwnames: *mut PyObject,
+    ) -> *mut PyObject;
+
+    #[cfg(any(Py_3_12, all(Py_3_9, not(any(Py_LIMITED_API, PyPy, GraalPy)))))]
+    pub fn PyObject_VectorcallMethod(
+        name: *mut PyObject,
+        args: *const *mut PyObject,
+        nargsf: size_t,
+        kwnames: *mut PyObject,
+    ) -> *mut PyObject;
+
     #[cfg_attr(PyPy, link_name = "PyPyObject_Type")]
     pub fn PyObject_Type(o: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyObject_Size")]

--- a/pyo3-ffi/src/ceval.rs
+++ b/pyo3-ffi/src/ceval.rs
@@ -70,7 +70,6 @@ extern "C" {
     pub fn Py_SetRecursionLimit(arg1: c_int);
     #[cfg_attr(PyPy, link_name = "PyPy_GetRecursionLimit")]
     pub fn Py_GetRecursionLimit() -> c_int;
-    fn _Py_CheckRecursiveCall(_where: *mut c_char) -> c_int;
 }
 
 extern "C" {

--- a/pyo3-ffi/src/codecs.rs
+++ b/pyo3-ffi/src/codecs.rs
@@ -1,13 +1,12 @@
 use crate::object::PyObject;
 use std::os::raw::{c_char, c_int};
 
+#[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub fn PyCodec_Register(search_function: *mut PyObject) -> c_int;
     #[cfg(Py_3_10)]
     #[cfg(not(PyPy))]
     pub fn PyCodec_Unregister(search_function: *mut PyObject) -> c_int;
-    // skipped non-limited _PyCodec_Lookup from Include/codecs.h
-    // skipped non-limited _PyCodec_Forget from Include/codecs.h
     pub fn PyCodec_KnownEncoding(encoding: *const c_char) -> c_int;
     pub fn PyCodec_Encode(
         object: *mut PyObject,
@@ -19,11 +18,6 @@ extern "C" {
         encoding: *const c_char,
         errors: *const c_char,
     ) -> *mut PyObject;
-    // skipped non-limited _PyCodec_LookupTextEncoding from Include/codecs.h
-    // skipped non-limited _PyCodec_EncodeText from Include/codecs.h
-    // skipped non-limited _PyCodec_DecodeText from Include/codecs.h
-    // skipped non-limited _PyCodecInfo_GetIncrementalDecoder from Include/codecs.h
-    // skipped non-limited _PyCodecInfo_GetIncrementalEncoder from Include/codecs.h
     pub fn PyCodec_Encoder(encoding: *const c_char) -> *mut PyObject;
     pub fn PyCodec_Decoder(encoding: *const c_char) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyCodec_IncrementalEncoder")]
@@ -53,6 +47,8 @@ extern "C" {
     pub fn PyCodec_ReplaceErrors(exc: *mut PyObject) -> *mut PyObject;
     pub fn PyCodec_XMLCharRefReplaceErrors(exc: *mut PyObject) -> *mut PyObject;
     pub fn PyCodec_BackslashReplaceErrors(exc: *mut PyObject) -> *mut PyObject;
-    // skipped non-limited PyCodec_NameReplaceErrors from Include/codecs.h
-    // skipped non-limited Py_hexdigits from Include/codecs.h
+    pub fn PyCodec_NameReplaceErrors(exc: *mut PyObject) -> *mut PyObject;
+
+    #[cfg(not(Py_LIMITED_API))]
+    pub static mut Py_hexdigits: *const c_char;
 }

--- a/pyo3-ffi/src/complexobject.rs
+++ b/pyo3-ffi/src/complexobject.rs
@@ -2,38 +2,6 @@ use crate::object::*;
 use std::os::raw::{c_double, c_int};
 use std::ptr::addr_of_mut;
 
-#[repr(C)]
-#[derive(Copy, Clone)]
-// non-limited
-pub struct Py_complex {
-    pub real: c_double,
-    pub imag: c_double,
-}
-
-#[cfg(not(Py_LIMITED_API))]
-extern "C" {
-    pub fn _Py_c_sum(left: Py_complex, right: Py_complex) -> Py_complex;
-    pub fn _Py_c_diff(left: Py_complex, right: Py_complex) -> Py_complex;
-    pub fn _Py_c_neg(complex: Py_complex) -> Py_complex;
-    pub fn _Py_c_prod(left: Py_complex, right: Py_complex) -> Py_complex;
-    pub fn _Py_c_quot(dividend: Py_complex, divisor: Py_complex) -> Py_complex;
-    pub fn _Py_c_pow(num: Py_complex, exp: Py_complex) -> Py_complex;
-    pub fn _Py_c_abs(arg: Py_complex) -> c_double;
-    #[cfg_attr(PyPy, link_name = "PyPyComplex_FromCComplex")]
-    pub fn PyComplex_FromCComplex(v: Py_complex) -> *mut PyObject;
-    #[cfg_attr(PyPy, link_name = "PyPyComplex_AsCComplex")]
-    pub fn PyComplex_AsCComplex(op: *mut PyObject) -> Py_complex;
-}
-
-#[repr(C)]
-#[derive(Copy, Clone)]
-// non-limited
-pub struct PyComplexObject {
-    pub ob_base: PyObject,
-    #[cfg(not(GraalPy))]
-    pub cval: Py_complex,
-}
-
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyComplex_Type")]
@@ -54,10 +22,9 @@ extern "C" {
     // skipped non-limited PyComplex_FromCComplex
     #[cfg_attr(PyPy, link_name = "PyPyComplex_FromDoubles")]
     pub fn PyComplex_FromDoubles(real: c_double, imag: c_double) -> *mut PyObject;
+
     #[cfg_attr(PyPy, link_name = "PyPyComplex_RealAsDouble")]
     pub fn PyComplex_RealAsDouble(op: *mut PyObject) -> c_double;
     #[cfg_attr(PyPy, link_name = "PyPyComplex_ImagAsDouble")]
     pub fn PyComplex_ImagAsDouble(op: *mut PyObject) -> c_double;
-    // skipped non-limited PyComplex_AsCComplex
-    // skipped non-limited _PyComplex_FormatAdvancedWriter
 }

--- a/pyo3-ffi/src/cpython/abstract_.rs
+++ b/pyo3-ffi/src/cpython/abstract_.rs
@@ -1,10 +1,14 @@
 use crate::{PyObject, Py_ssize_t};
+#[cfg(not(Py_3_11))]
 use std::os::raw::{c_char, c_int};
+
+#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
+use crate::vectorcallfunc;
 
 #[cfg(not(Py_3_11))]
 use crate::Py_buffer;
 
-#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
+#[cfg(all(Py_3_8, not(any(PyPy, GraalPy, Py_3_9))))]
 use crate::{
     vectorcallfunc, PyCallable_Check, PyThreadState, PyThreadState_GET, PyTuple_Check,
     PyType_HasFeature, Py_TPFLAGS_HAVE_VECTORCALL,
@@ -17,20 +21,17 @@ extern "C" {
     pub fn _PyStack_AsDict(values: *const *mut PyObject, kwnames: *mut PyObject) -> *mut PyObject;
 }
 
-#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
-const _PY_FASTCALL_SMALL_STACK: size_t = 5;
-
 extern "C" {
-    #[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
-    pub fn _Py_CheckFunctionResult(
+    #[cfg(all(Py_3_8, not(any(PyPy, GraalPy, Py_3_9))))]
+    fn _Py_CheckFunctionResult(
         tstate: *mut PyThreadState,
         callable: *mut PyObject,
         result: *mut PyObject,
         where_: *const c_char,
     ) -> *mut PyObject;
 
-    #[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
-    pub fn _PyObject_MakeTpCall(
+    #[cfg(all(Py_3_8, not(any(PyPy, GraalPy, Py_3_9))))]
+    fn _PyObject_MakeTpCall(
         tstate: *mut PyThreadState,
         callable: *mut PyObject,
         args: *const *mut PyObject,
@@ -39,7 +40,7 @@ extern "C" {
     ) -> *mut PyObject;
 }
 
-#[cfg(Py_3_8)]
+#[cfg(Py_3_8)] // NB exported as public in abstract.rs from 3.12
 const PY_VECTORCALL_ARGUMENTS_OFFSET: size_t =
     1 << (8 * std::mem::size_of::<size_t>() as size_t - 1);
 
@@ -50,9 +51,14 @@ pub unsafe fn PyVectorcall_NARGS(n: size_t) -> Py_ssize_t {
     n.try_into().expect("cannot fail due to mask")
 }
 
-#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
+extern "C" {
+    #[cfg(all(Py_3_9, not(any(PyPy, GraalPy))))]
+    pub fn PyVectorcall_Function(callable: *mut PyObject) -> Option<vectorcallfunc>;
+}
+
+#[cfg(all(Py_3_8, not(any(PyPy, GraalPy, Py_3_9))))]
 #[inline(always)]
-pub unsafe fn PyVectorcall_Function(callable: *mut PyObject) -> Option<vectorcallfunc> {
+pub fn PyVectorcall_Function(callable: *mut PyObject) -> Option<vectorcallfunc> {
     assert!(!callable.is_null());
     let tp = crate::Py_TYPE(callable);
     if PyType_HasFeature(tp, Py_TPFLAGS_HAVE_VECTORCALL) == 0 {
@@ -65,9 +71,9 @@ pub unsafe fn PyVectorcall_Function(callable: *mut PyObject) -> Option<vectorcal
     *ptr
 }
 
-#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
+#[cfg(all(Py_3_8, not(any(PyPy, GraalPy, Py_3_9))))]
 #[inline(always)]
-pub unsafe fn _PyObject_VectorcallTstate(
+unsafe fn _PyObject_VectorcallTstate(
     tstate: *mut PyThreadState,
     callable: *mut PyObject,
     args: *const *mut PyObject,
@@ -89,7 +95,7 @@ pub unsafe fn _PyObject_VectorcallTstate(
     }
 }
 
-#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
+#[cfg(all(Py_3_8, not(any(PyPy, GraalPy, Py_3_9))))] // exported as a function from 3.9, see abstract.rs
 #[inline(always)]
 pub unsafe fn PyObject_Vectorcall(
     callable: *mut PyObject,
@@ -101,16 +107,6 @@ pub unsafe fn PyObject_Vectorcall(
 }
 
 extern "C" {
-    #[cfg(all(PyPy, Py_3_8))]
-    #[cfg_attr(not(Py_3_9), link_name = "_PyPyObject_Vectorcall")]
-    #[cfg_attr(Py_3_9, link_name = "PyPyObject_Vectorcall")]
-    pub fn PyObject_Vectorcall(
-        callable: *mut PyObject,
-        args: *const *mut PyObject,
-        nargsf: size_t,
-        kwnames: *mut PyObject,
-    ) -> *mut PyObject;
-
     #[cfg(Py_3_8)]
     #[cfg_attr(
         all(not(any(PyPy, GraalPy)), not(Py_3_9)),
@@ -125,7 +121,10 @@ extern "C" {
         kwdict: *mut PyObject,
     ) -> *mut PyObject;
 
-    #[cfg(Py_3_8)]
+    #[cfg(all(Py_3_9, not(any(PyPy, GraalPy))))]
+    pub fn PyObject_CallOneArg(func: *mut PyObject, arg: *mut PyObject) -> *mut PyObject;
+
+    #[cfg(all(Py_3_8, not(Py_3_9)))] // definition located in src/abstract.rs from 3.9
     #[cfg_attr(not(any(Py_3_9, PyPy)), link_name = "_PyVectorcall_Call")]
     #[cfg_attr(PyPy, link_name = "PyPyVectorcall_Call")]
     pub fn PyVectorcall_Call(
@@ -135,46 +134,7 @@ extern "C" {
     ) -> *mut PyObject;
 }
 
-#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
-#[inline(always)]
-pub unsafe fn _PyObject_FastCallTstate(
-    tstate: *mut PyThreadState,
-    func: *mut PyObject,
-    args: *const *mut PyObject,
-    nargs: Py_ssize_t,
-) -> *mut PyObject {
-    _PyObject_VectorcallTstate(tstate, func, args, nargs as size_t, std::ptr::null_mut())
-}
-
-#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
-#[inline(always)]
-pub unsafe fn _PyObject_FastCall(
-    func: *mut PyObject,
-    args: *const *mut PyObject,
-    nargs: Py_ssize_t,
-) -> *mut PyObject {
-    _PyObject_FastCallTstate(PyThreadState_GET(), func, args, nargs)
-}
-
-#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
-#[inline(always)]
-pub unsafe fn _PyObject_CallNoArg(func: *mut PyObject) -> *mut PyObject {
-    _PyObject_VectorcallTstate(
-        PyThreadState_GET(),
-        func,
-        std::ptr::null_mut(),
-        0,
-        std::ptr::null_mut(),
-    )
-}
-
-extern "C" {
-    #[cfg(PyPy)]
-    #[link_name = "_PyPyObject_CallNoArg"]
-    pub fn _PyObject_CallNoArg(func: *mut PyObject) -> *mut PyObject;
-}
-
-#[cfg(all(Py_3_8, not(any(PyPy, GraalPy))))]
+#[cfg(all(Py_3_8, not(any(PyPy, GraalPy, Py_3_9))))] // exported as a function from 3.9, see abstract.rs
 #[inline(always)]
 pub unsafe fn PyObject_CallOneArg(func: *mut PyObject, arg: *mut PyObject) -> *mut PyObject {
     assert!(!arg.is_null());
@@ -185,23 +145,13 @@ pub unsafe fn PyObject_CallOneArg(func: *mut PyObject, arg: *mut PyObject) -> *m
     _PyObject_VectorcallTstate(tstate, func, args, nargsf, std::ptr::null_mut())
 }
 
-extern "C" {
-    #[cfg(all(Py_3_9, not(any(PyPy, GraalPy))))]
-    pub fn PyObject_VectorcallMethod(
-        name: *mut PyObject,
-        args: *const *mut PyObject,
-        nargsf: size_t,
-        kwnames: *mut PyObject,
-    ) -> *mut PyObject;
-}
-
 #[cfg(all(Py_3_9, not(any(PyPy, GraalPy))))]
 #[inline(always)]
 pub unsafe fn PyObject_CallMethodNoArgs(
     self_: *mut PyObject,
     name: *mut PyObject,
 ) -> *mut PyObject {
-    PyObject_VectorcallMethod(
+    crate::PyObject_VectorcallMethod(
         name,
         &self_,
         1 | PY_VECTORCALL_ARGUMENTS_OFFSET,
@@ -218,19 +168,13 @@ pub unsafe fn PyObject_CallMethodOneArg(
 ) -> *mut PyObject {
     let args = [self_, arg];
     assert!(!arg.is_null());
-    PyObject_VectorcallMethod(
+    crate::PyObject_VectorcallMethod(
         name,
         args.as_ptr(),
         2 | PY_VECTORCALL_ARGUMENTS_OFFSET,
         std::ptr::null_mut(),
     )
 }
-
-// skipped _PyObject_VectorcallMethodId
-// skipped _PyObject_CallMethodIdNoArgs
-// skipped _PyObject_CallMethodIdOneArg
-
-// skipped _PyObject_HasLen
 
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyObject_LengthHint")]
@@ -303,30 +247,3 @@ extern "C" {
 // predate the limited API changes.
 
 // skipped PySequence_ITEM
-
-pub const PY_ITERSEARCH_COUNT: c_int = 1;
-pub const PY_ITERSEARCH_INDEX: c_int = 2;
-pub const PY_ITERSEARCH_CONTAINS: c_int = 3;
-
-extern "C" {
-    #[cfg(not(any(PyPy, GraalPy)))]
-    pub fn _PySequence_IterSearch(
-        seq: *mut PyObject,
-        obj: *mut PyObject,
-        operation: c_int,
-    ) -> Py_ssize_t;
-}
-
-// skipped _PyObject_RealIsInstance
-// skipped _PyObject_RealIsSubclass
-
-// skipped _PySequence_BytesToCharpArray
-
-// skipped _Py_FreeCharPArray
-
-// skipped _Py_add_one_to_index_F
-// skipped _Py_add_one_to_index_C
-
-// skipped _Py_convert_optional_to_ssize_t
-
-// skipped _PyNumber_Index(*mut PyObject o)

--- a/pyo3-ffi/src/cpython/ceval.rs
+++ b/pyo3-ffi/src/cpython/ceval.rs
@@ -3,7 +3,13 @@ use crate::object::{freefunc, PyObject};
 use std::os::raw::c_int;
 
 extern "C" {
-    // skipped non-limited _PyEval_CallTracing
+    pub fn PyEval_SetProfile(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);
+    #[cfg(Py_3_12)]
+    pub fn PyEval_SetProfileAllThreads(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);
+    pub fn PyEval_SetTrace(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);
+    pub fn PyEval_SetTraceAllThreads(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);
+
+    // skipped PyEval_MergeCompilerFlags
 
     #[cfg(not(Py_3_11))]
     pub fn _PyEval_EvalFrameDefault(arg1: *mut crate::PyFrameObject, exc: c_int) -> *mut PyObject;
@@ -15,7 +21,10 @@ extern "C" {
         exc: c_int,
     ) -> *mut crate::PyObject;
 
+    // skipped PyUnstable_Eval_RequestCodeExtraIndex
+    #[cfg(not(Py_3_13))]
     pub fn _PyEval_RequestCodeExtraIndex(func: freefunc) -> c_int;
-    pub fn PyEval_SetProfile(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);
-    pub fn PyEval_SetTrace(trace_func: Option<Py_tracefunc>, arg1: *mut PyObject);
+
+    // skipped private _PyEval_SliceIndex
+    // skipped private _PyEval_SliceIndexNotNone
 }

--- a/pyo3-ffi/src/cpython/complexobject.rs
+++ b/pyo3-ffi/src/cpython/complexobject.rs
@@ -1,0 +1,34 @@
+use crate::PyObject;
+use std::os::raw::c_double;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+// non-limited
+pub struct Py_complex {
+    pub real: c_double,
+    pub imag: c_double,
+}
+
+// skipped private function _Py_c_sum
+// skipped private function _Py_c_diff
+// skipped private function _Py_c_neg
+// skipped private function _Py_c_prod
+// skipped private function _Py_c_quot
+// skipped private function _Py_c_pow
+// skipped private function _Py_c_abs
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyComplexObject {
+    pub ob_base: PyObject,
+    #[cfg(not(GraalPy))]
+    pub cval: Py_complex,
+}
+
+#[cfg(not(Py_LIMITED_API))]
+extern "C" {
+    #[cfg_attr(PyPy, link_name = "PyPyComplex_FromCComplex")]
+    pub fn PyComplex_FromCComplex(v: Py_complex) -> *mut PyObject;
+    #[cfg_attr(PyPy, link_name = "PyPyComplex_AsCComplex")]
+    pub fn PyComplex_AsCComplex(op: *mut PyObject) -> Py_complex;
+}

--- a/pyo3-ffi/src/cpython/descrobject.rs
+++ b/pyo3-ffi/src/cpython/descrobject.rs
@@ -69,10 +69,5 @@ pub struct PyWrapperDescrObject {
     pub d_wrapped: *mut c_void,
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
-extern "C" {
-    pub static mut _PyMethodWrapper_Type: PyTypeObject;
-}
-
 // skipped non-limited PyDescr_NewWrapper
 // skipped non-limited PyDescr_IsData

--- a/pyo3-ffi/src/cpython/dictobject.rs
+++ b/pyo3-ffi/src/cpython/dictobject.rs
@@ -1,6 +1,5 @@
 use crate::object::*;
 use crate::pyport::Py_ssize_t;
-use std::os::raw::c_int;
 
 opaque_struct!(PyDictKeysObject);
 
@@ -22,55 +21,27 @@ pub struct PyDictObject {
 }
 
 extern "C" {
-    // skipped _PyDict_GetItem_KnownHash
-    // skipped _PyDict_GetItemIdWithError
-    // skipped _PyDict_GetItemStringWithError
+    // skipped private _PyDict_GetItem_KnownHash
+    // skipped private _PyDict_GetItemStringWithError
     // skipped PyDict_SetDefault
-    pub fn _PyDict_SetItem_KnownHash(
-        mp: *mut PyObject,
-        key: *mut PyObject,
-        item: *mut PyObject,
-        hash: crate::Py_hash_t,
-    ) -> c_int;
-    // skipped _PyDict_DelItem_KnownHash
-    // skipped _PyDict_DelItemIf
-    // skipped _PyDict_NewKeysForClass
-    pub fn _PyDict_Next(
-        mp: *mut PyObject,
-        pos: *mut Py_ssize_t,
-        key: *mut *mut PyObject,
-        value: *mut *mut PyObject,
-        hash: *mut crate::Py_hash_t,
-    ) -> c_int;
+    // skipped PyDict_SetDefaultRef
+
     // skipped PyDict_GET_SIZE
-    // skipped _PyDict_ContainsId
-    pub fn _PyDict_NewPresized(minused: Py_ssize_t) -> *mut PyObject;
-    // skipped _PyDict_MaybeUntrack
-    // skipped _PyDict_HasOnlyStringKeys
-    // skipped _PyDict_KeysSize
-    // skipped _PyDict_SizeOf
+
+    // skipped PyDict_ContainsString
+
+    // skipped private _PyDict_NewPresized
+
+    // skipped PyDict_Pop
+    // skipped PyDict_PopString
     // skipped _PyDict_Pop
-    // skipped _PyDict_Pop_KnownHash
-    // skipped _PyDict_FromKeys
-    // skipped _PyDict_HasSplitTable
-    // skipped _PyDict_MergeEx
-    // skipped _PyDict_SetItemId
-    // skipped _PyDict_DelItemId
-    // skipped _PyDict_DebugMallocStats
-    // skipped _PyObjectDict_SetItem
-    // skipped _PyDict_LoadGlobal
-    // skipped _PyDict_GetItemHint
-    // skipped _PyDictViewObject
-    // skipped _PyDictView_New
-    // skipped _PyDictView_Intersect
 
-    #[cfg(Py_3_10)]
-    pub fn _PyDict_Contains_KnownHash(
-        op: *mut PyObject,
-        key: *mut PyObject,
-        hash: crate::Py_hash_t,
-    ) -> c_int;
+    // skipped PyDict_WatchEvent
+    // skipped PyDict_WatchCallback
 
-    #[cfg(not(Py_3_10))]
-    pub fn _PyDict_Contains(mp: *mut PyObject, key: *mut PyObject, hash: Py_ssize_t) -> c_int;
+    // skipped PyDict_AddWatcher
+    // skipped PyDict_ClearWatcher
+
+    // skipped PyDict_Watch
+    // skipped PyDict_Unwatch
 }

--- a/pyo3-ffi/src/cpython/floatobject.rs
+++ b/pyo3-ffi/src/cpython/floatobject.rs
@@ -11,7 +11,7 @@ pub struct PyFloatObject {
 }
 
 #[inline]
-pub unsafe fn _PyFloat_CAST(op: *mut PyObject) -> *mut PyFloatObject {
+unsafe fn _PyFloat_CAST(op: *mut PyObject) -> *mut PyFloatObject {
     debug_assert_eq!(PyFloat_Check(op), 1);
     op.cast()
 }

--- a/pyo3-ffi/src/cpython/listobject.rs
+++ b/pyo3-ffi/src/cpython/listobject.rs
@@ -39,3 +39,18 @@ pub unsafe fn PyList_SET_ITEM(op: *mut PyObject, i: Py_ssize_t, v: *mut PyObject
 pub unsafe fn PyList_GET_SIZE(op: *mut PyObject) -> Py_ssize_t {
     Py_SIZE(op)
 }
+
+extern "C" {
+    // CPython macros exported as functions on PyPy or GraalPy
+    #[cfg(any(PyPy, GraalPy))]
+    #[cfg_attr(PyPy, link_name = "PyPyList_GET_ITEM")]
+    #[cfg_attr(GraalPy, link_name = "PyList_GetItem")]
+    pub fn PyList_GET_ITEM(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject;
+    #[cfg(PyPy)]
+    #[cfg_attr(PyPy, link_name = "PyPyList_GET_SIZE")]
+    pub fn PyList_GET_SIZE(arg1: *mut PyObject) -> Py_ssize_t;
+    #[cfg(any(PyPy, GraalPy))]
+    #[cfg_attr(PyPy, link_name = "PyPyList_SET_ITEM")]
+    #[cfg_attr(GraalPy, link_name = "_PyList_SET_ITEM")]
+    pub fn PyList_SET_ITEM(arg1: *mut PyObject, arg2: Py_ssize_t, arg3: *mut PyObject);
+}

--- a/pyo3-ffi/src/cpython/longobject.rs
+++ b/pyo3-ffi/src/cpython/longobject.rs
@@ -53,6 +53,9 @@ extern "C" {
     // skipped PyUnstable_Long_IsCompact
     // skipped PyUnstable_Long_CompactValue
 
+    #[cfg_attr(PyPy, link_name = "_PyPyLong_NumBits")]
+    pub fn _PyLong_NumBits(obj: *mut PyObject) -> size_t;
+
     #[cfg_attr(PyPy, link_name = "_PyPyLong_FromByteArray")]
     pub fn _PyLong_FromByteArray(
         bytes: *const c_uchar,

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod bytesobject;
 pub(crate) mod ceval;
 pub(crate) mod code;
 pub(crate) mod compile;
+pub(crate) mod complexobject;
 pub(crate) mod descrobject;
 #[cfg(not(PyPy))]
 pub(crate) mod dictobject;
@@ -25,6 +26,7 @@ pub(crate) mod object;
 pub(crate) mod objimpl;
 pub(crate) mod pydebug;
 pub(crate) mod pyerrors;
+pub(crate) mod pyhash;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub(crate) mod pylifecycle;
 pub(crate) mod pymem;
@@ -43,6 +45,7 @@ pub use self::bytesobject::*;
 pub use self::ceval::*;
 pub use self::code::*;
 pub use self::compile::*;
+pub use self::complexobject::*;
 pub use self::descrobject::*;
 #[cfg(not(PyPy))]
 pub use self::dictobject::*;
@@ -63,6 +66,7 @@ pub use self::pydebug::*;
 pub use self::pyerrors::*;
 #[cfg(Py_3_11)]
 pub use self::pyframe::*;
+pub use self::pyhash::*;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub use self::pylifecycle::*;
 pub use self::pymem::*;

--- a/pyo3-ffi/src/cpython/objimpl.rs
+++ b/pyo3-ffi/src/cpython/objimpl.rs
@@ -9,11 +9,6 @@ use crate::object::*;
 // skipped _PyObject_SIZE
 // skipped _PyObject_VAR_SIZE
 
-#[cfg(not(Py_3_11))]
-extern "C" {
-    pub fn _Py_GetAllocatedBlocks() -> crate::Py_ssize_t;
-}
-
 #[cfg(not(any(PyPy, GraalPy)))]
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -49,12 +44,6 @@ pub unsafe fn PyObject_IS_GC(o: *mut PyObject) -> c_int {
             Some(tp_is_gc) => tp_is_gc(o) != 0,
             None => true,
         }) as c_int
-}
-
-#[cfg(not(Py_3_11))]
-extern "C" {
-    pub fn _PyObject_GC_Malloc(size: size_t) -> *mut PyObject;
-    pub fn _PyObject_GC_Calloc(size: size_t) -> *mut PyObject;
 }
 
 #[inline]

--- a/pyo3-ffi/src/cpython/pyhash.rs
+++ b/pyo3-ffi/src/cpython/pyhash.rs
@@ -1,0 +1,27 @@
+#[cfg(not(any(PyPy, GraalPy)))]
+use crate::pyport::{Py_hash_t, Py_ssize_t};
+#[cfg(not(any(PyPy, GraalPy)))]
+use std::os::raw::{c_char, c_int, c_void};
+
+#[cfg(not(any(PyPy, GraalPy)))]
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyHash_FuncDef {
+    pub hash: Option<extern "C" fn(arg1: *const c_void, arg2: Py_ssize_t) -> Py_hash_t>,
+    pub name: *const c_char,
+    pub hash_bits: c_int,
+    pub seed_bits: c_int,
+}
+
+#[cfg(not(any(PyPy, GraalPy)))]
+impl Default for PyHash_FuncDef {
+    #[inline]
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+extern "C" {
+    #[cfg(not(any(PyPy, GraalPy)))]
+    pub fn PyHash_GetFuncDef() -> *mut PyHash_FuncDef;
+}

--- a/pyo3-ffi/src/cpython/pythonrun.rs
+++ b/pyo3-ffi/src/cpython/pythonrun.rs
@@ -9,21 +9,9 @@ use std::os::raw::{c_char, c_int};
 
 extern "C" {
     pub fn PyRun_SimpleStringFlags(arg1: *const c_char, arg2: *mut PyCompilerFlags) -> c_int;
-    pub fn _PyRun_SimpleFileObject(
-        fp: *mut FILE,
-        filename: *mut PyObject,
-        closeit: c_int,
-        flags: *mut PyCompilerFlags,
-    ) -> c_int;
     pub fn PyRun_AnyFileExFlags(
         fp: *mut FILE,
         filename: *const c_char,
-        closeit: c_int,
-        flags: *mut PyCompilerFlags,
-    ) -> c_int;
-    pub fn _PyRun_AnyFileObject(
-        fp: *mut FILE,
-        filename: *mut PyObject,
         closeit: c_int,
         flags: *mut PyCompilerFlags,
     ) -> c_int;
@@ -46,11 +34,6 @@ extern "C" {
     pub fn PyRun_InteractiveLoopFlags(
         fp: *mut FILE,
         filename: *const c_char,
-        flags: *mut PyCompilerFlags,
-    ) -> c_int;
-    pub fn _PyRun_InteractiveLoopObject(
-        fp: *mut FILE,
-        filename: *mut PyObject,
         flags: *mut PyCompilerFlags,
     ) -> c_int;
 

--- a/pyo3-ffi/src/cpython/unicodeobject.rs
+++ b/pyo3-ffi/src/cpython/unicodeobject.rs
@@ -403,11 +403,6 @@ pub struct PyUnicodeObject {
     pub data: PyUnicodeObjectData,
 }
 
-extern "C" {
-    #[cfg(not(any(PyPy, GraalPy)))]
-    pub fn _PyUnicode_CheckConsistency(op: *mut PyObject, check_content: c_int) -> c_int;
-}
-
 // skipped PyUnicode_GET_SIZE
 // skipped PyUnicode_GET_DATA_SIZE
 // skipped PyUnicode_AS_UNICODE
@@ -479,7 +474,7 @@ pub unsafe fn PyUnicode_KIND(op: *mut PyObject) -> c_uint {
 
 #[cfg(not(GraalPy))]
 #[inline]
-pub unsafe fn _PyUnicode_COMPACT_DATA(op: *mut PyObject) -> *mut c_void {
+unsafe fn _PyUnicode_COMPACT_DATA(op: *mut PyObject) -> *mut c_void {
     if PyUnicode_IS_ASCII(op) != 0 {
         (op as *mut PyASCIIObject).offset(1) as *mut c_void
     } else {
@@ -489,7 +484,7 @@ pub unsafe fn _PyUnicode_COMPACT_DATA(op: *mut PyObject) -> *mut c_void {
 
 #[cfg(not(any(GraalPy, PyPy)))]
 #[inline]
-pub unsafe fn _PyUnicode_NONCOMPACT_DATA(op: *mut PyObject) -> *mut c_void {
+unsafe fn _PyUnicode_NONCOMPACT_DATA(op: *mut PyObject) -> *mut c_void {
     debug_assert!(!(*(op as *mut PyUnicodeObject)).data.any.is_null());
 
     (*(op as *mut PyUnicodeObject)).data.any
@@ -560,7 +555,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_New")]
     pub fn PyUnicode_New(size: Py_ssize_t, maxchar: Py_UCS4) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "_PyPyUnicode_Ready")]
-    pub fn _PyUnicode_Ready(unicode: *mut PyObject) -> c_int;
+    fn _PyUnicode_Ready(unicode: *mut PyObject) -> c_int;
 
     // skipped _PyUnicode_Copy
 

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -48,7 +48,7 @@ pub struct PyDateTime_Delta {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 /// Structure representing a `datetime.time` without a `tzinfo` member.
-pub struct _PyDateTime_BaseTime {
+struct _PyDateTime_BaseTime {
     pub ob_base: PyObject,
     pub hashcode: Py_hash_t,
     pub hastzinfo: c_char,
@@ -93,7 +93,7 @@ pub struct PyDateTime_Date {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 /// Structure representing a `datetime.datetime` without a `tzinfo` member.
-pub struct _PyDateTime_BaseDateTime {
+struct _PyDateTime_BaseDateTime {
     pub ob_base: PyObject,
     pub hashcode: Py_hash_t,
     pub hastzinfo: c_char,

--- a/pyo3-ffi/src/fileobject.rs
+++ b/pyo3-ffi/src/fileobject.rs
@@ -34,5 +34,3 @@ extern "C" {
     pub static mut Py_HasFileSystemDefaultEncoding: c_int;
     // skipped 3.12-deprecated Py_UTF8Mode
 }
-
-// skipped _PyIsSelectable_fd

--- a/pyo3-ffi/src/floatobject.rs
+++ b/pyo3-ffi/src/floatobject.rs
@@ -36,12 +36,3 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyFloat_AsDouble")]
     pub fn PyFloat_AsDouble(arg1: *mut PyObject) -> c_double;
 }
-
-// skipped non-limited _PyFloat_Pack2
-// skipped non-limited _PyFloat_Pack4
-// skipped non-limited _PyFloat_Pack8
-// skipped non-limited _PyFloat_Unpack2
-// skipped non-limited _PyFloat_Unpack4
-// skipped non-limited _PyFloat_Unpack8
-// skipped non-limited _PyFloat_DebugMallocStats
-// skipped non-limited _PyFloat_FormatAdvancedWriter

--- a/pyo3-ffi/src/intrcheck.rs
+++ b/pyo3-ffi/src/intrcheck.rs
@@ -3,9 +3,6 @@ use std::os::raw::c_int;
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyOS_InterruptOccurred")]
     pub fn PyOS_InterruptOccurred() -> c_int;
-    #[cfg(not(Py_3_10))]
-    #[deprecated(note = "Not documented in Python API; see Python 3.10 release notes")]
-    pub fn PyOS_InitInterrupts();
 
     pub fn PyOS_BeforeFork();
     pub fn PyOS_AfterFork_Parent();
@@ -13,7 +10,4 @@ extern "C" {
     #[deprecated(note = "use PyOS_AfterFork_Child instead")]
     #[cfg_attr(PyPy, link_name = "PyPyOS_AfterFork")]
     pub fn PyOS_AfterFork();
-
-    // skipped non-limited _PyOS_IsMainThread
-    // skipped non-limited Windows _PyOS_SigintEvent
 }

--- a/pyo3-ffi/src/listobject.rs
+++ b/pyo3-ffi/src/listobject.rs
@@ -53,17 +53,4 @@ extern "C" {
     pub fn PyList_Reverse(arg1: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyList_AsTuple")]
     pub fn PyList_AsTuple(arg1: *mut PyObject) -> *mut PyObject;
-
-    // CPython macros exported as functions on PyPy or GraalPy
-    #[cfg(any(PyPy, GraalPy))]
-    #[cfg_attr(PyPy, link_name = "PyPyList_GET_ITEM")]
-    #[cfg_attr(GraalPy, link_name = "PyList_GetItem")]
-    pub fn PyList_GET_ITEM(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject;
-    #[cfg(PyPy)]
-    #[cfg_attr(PyPy, link_name = "PyPyList_GET_SIZE")]
-    pub fn PyList_GET_SIZE(arg1: *mut PyObject) -> Py_ssize_t;
-    #[cfg(any(PyPy, GraalPy))]
-    #[cfg_attr(PyPy, link_name = "PyPyList_SET_ITEM")]
-    #[cfg_attr(GraalPy, link_name = "_PyList_SET_ITEM")]
-    pub fn PyList_SET_ITEM(arg1: *mut PyObject, arg2: Py_ssize_t, arg3: *mut PyObject);
 }

--- a/pyo3-ffi/src/longobject.rs
+++ b/pyo3-ffi/src/longobject.rs
@@ -33,6 +33,7 @@ extern "C" {
     pub fn PyLong_FromSsize_t(arg1: Py_ssize_t) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyLong_FromDouble")]
     pub fn PyLong_FromDouble(arg1: c_double) -> *mut PyObject;
+
     #[cfg_attr(PyPy, link_name = "PyPyLong_AsLong")]
     pub fn PyLong_AsLong(arg1: *mut PyObject) -> c_long;
     #[cfg_attr(PyPy, link_name = "PyPyLong_AsLongAndOverflow")]
@@ -45,30 +46,32 @@ extern "C" {
     pub fn PyLong_AsUnsignedLong(arg1: *mut PyObject) -> c_ulong;
     #[cfg_attr(PyPy, link_name = "PyPyLong_AsUnsignedLongMask")]
     pub fn PyLong_AsUnsignedLongMask(arg1: *mut PyObject) -> c_ulong;
-    // skipped non-limited _PyLong_AsInt
+
+    #[cfg(Py_3_13)]
+    pub fn PyLong_AsInt(obj: *mut PyObject) -> c_int;
+
     pub fn PyLong_GetInfo() -> *mut PyObject;
-    // skipped PyLong_AS_LONG
+}
 
-    // skipped PyLong_FromPid
-    // skipped PyLong_AsPid
-    // skipped _Py_PARSE_INTPTR
-    // skipped _Py_PARSE_UINTPTR
+#[inline(always)]
+pub unsafe fn PyLong_AS_LONG(obj: *mut PyObject) -> c_long {
+    PyLong_AsLong(obj)
+}
 
-    // skipped non-limited _PyLong_UnsignedShort_Converter
-    // skipped non-limited _PyLong_UnsignedInt_Converter
-    // skipped non-limited _PyLong_UnsignedLong_Converter
-    // skipped non-limited _PyLong_UnsignedLongLong_Converter
-    // skipped non-limited _PyLong_Size_t_Converter
+// skipped PyLong_FromPid
+// skipped PyLong_AsPid
 
-    // skipped non-limited _PyLong_DigitValue
-    // skipped non-limited _PyLong_Frexp
+// skipped private _Py_PARSE_INTPTR
+// skipped private _Py_PARSE_UINTPTR
 
+extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyLong_AsDouble")]
     pub fn PyLong_AsDouble(arg1: *mut PyObject) -> c_double;
     #[cfg_attr(PyPy, link_name = "PyPyLong_FromVoidPtr")]
     pub fn PyLong_FromVoidPtr(arg1: *mut c_void) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyLong_AsVoidPtr")]
     pub fn PyLong_AsVoidPtr(arg1: *mut PyObject) -> *mut c_void;
+
     #[cfg_attr(PyPy, link_name = "PyPyLong_FromLongLong")]
     pub fn PyLong_FromLongLong(arg1: c_longlong) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyLong_FromUnsignedLongLong")]
@@ -81,30 +84,14 @@ extern "C" {
     pub fn PyLong_AsUnsignedLongLongMask(arg1: *mut PyObject) -> c_ulonglong;
     #[cfg_attr(PyPy, link_name = "PyPyLong_AsLongLongAndOverflow")]
     pub fn PyLong_AsLongLongAndOverflow(arg1: *mut PyObject, arg2: *mut c_int) -> c_longlong;
+
     #[cfg_attr(PyPy, link_name = "PyPyLong_FromString")]
     pub fn PyLong_FromString(
         arg1: *const c_char,
         arg2: *mut *mut c_char,
         arg3: c_int,
     ) -> *mut PyObject;
-}
 
-#[cfg(not(Py_LIMITED_API))]
-extern "C" {
-    #[cfg_attr(PyPy, link_name = "_PyPyLong_NumBits")]
-    #[cfg(not(Py_3_13))]
-    pub fn _PyLong_NumBits(obj: *mut PyObject) -> size_t;
-}
-
-// skipped non-limited _PyLong_Format
-// skipped non-limited _PyLong_FormatWriter
-// skipped non-limited _PyLong_FormatBytesWriter
-// skipped non-limited _PyLong_FormatAdvancedWriter
-
-extern "C" {
     pub fn PyOS_strtoul(arg1: *const c_char, arg2: *mut *mut c_char, arg3: c_int) -> c_ulong;
     pub fn PyOS_strtol(arg1: *const c_char, arg2: *mut *mut c_char, arg3: c_int) -> c_long;
 }
-
-// skipped non-limited _PyLong_Rshift
-// skipped non-limited _PyLong_Lshift

--- a/pyo3-ffi/src/memoryobject.rs
+++ b/pyo3-ffi/src/memoryobject.rs
@@ -5,9 +5,6 @@ use std::ptr::addr_of_mut;
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
-    #[cfg(not(Py_LIMITED_API))]
-    pub static mut _PyManagedBuffer_Type: PyTypeObject;
-
     #[cfg_attr(PyPy, link_name = "PyPyMemoryView_Type")]
     pub static mut PyMemoryView_Type: PyTypeObject;
 }

--- a/pyo3-ffi/src/methodobject.rs
+++ b/pyo3-ffi/src/methodobject.rs
@@ -43,11 +43,15 @@ pub type PyCFunction =
     unsafe extern "C" fn(slf: *mut PyObject, args: *mut PyObject) -> *mut PyObject;
 
 #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
-pub type _PyCFunctionFast = unsafe extern "C" fn(
+pub type PyCFunctionFast = unsafe extern "C" fn(
     slf: *mut PyObject,
     args: *mut *mut PyObject,
     nargs: crate::pyport::Py_ssize_t,
 ) -> *mut PyObject;
+
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+#[deprecated(note = "renamed to PyCFunctionFast")]
+pub type _PyCFunctionFast = PyCFunctionFast;
 
 pub type PyCFunctionWithKeywords = unsafe extern "C" fn(
     slf: *mut PyObject,
@@ -55,13 +59,17 @@ pub type PyCFunctionWithKeywords = unsafe extern "C" fn(
     kwds: *mut PyObject,
 ) -> *mut PyObject;
 
-#[cfg(not(Py_LIMITED_API))]
-pub type _PyCFunctionFastWithKeywords = unsafe extern "C" fn(
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+pub type PyCFunctionFastWithKeywords = unsafe extern "C" fn(
     slf: *mut PyObject,
     args: *const *mut PyObject,
     nargs: crate::pyport::Py_ssize_t,
     kwnames: *mut PyObject,
 ) -> *mut PyObject;
+
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+#[deprecated(note = "renamed to PyCFunctionFastWithKeywords")]
+pub type _PyCFunctionFastWithKeywords = PyCFunctionFastWithKeywords;
 
 #[cfg(all(Py_3_9, not(Py_LIMITED_API)))]
 pub type PyCMethod = unsafe extern "C" fn(
@@ -144,11 +152,21 @@ pub union PyMethodDefPointer {
 
     /// This variant corresponds with [`METH_FASTCALL`].
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
-    pub _PyCFunctionFast: _PyCFunctionFast,
+    #[deprecated(note = "renamed to PyCFunctionFast")]
+    pub _PyCFunctionFast: PyCFunctionFast,
+
+    /// This variant corresponds with [`METH_FASTCALL`].
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    pub PyCFunctionFast: PyCFunctionFast,
 
     /// This variant corresponds with [`METH_FASTCALL`] | [`METH_KEYWORDS`].
-    #[cfg(not(Py_LIMITED_API))]
-    pub _PyCFunctionFastWithKeywords: _PyCFunctionFastWithKeywords,
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    #[deprecated(note = "renamed to PyCFunctionFastWithKeywords")]
+    pub _PyCFunctionFastWithKeywords: PyCFunctionFastWithKeywords,
+
+    /// This variant corresponds with [`METH_FASTCALL`] | [`METH_KEYWORDS`].
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    pub PyCFunctionFastWithKeywords: PyCFunctionFastWithKeywords,
 
     /// This variant corresponds with [`METH_METHOD`] | [`METH_FASTCALL`] | [`METH_KEYWORDS`].
     #[cfg(all(Py_3_9, not(Py_LIMITED_API)))]

--- a/pyo3-ffi/src/modsupport.rs
+++ b/pyo3-ffi/src/modsupport.rs
@@ -28,30 +28,6 @@ extern "C" {
     ) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPy_BuildValue")]
     pub fn Py_BuildValue(arg1: *const c_char, ...) -> *mut PyObject;
-    // #[cfg_attr(PyPy, link_name = "_PyPy_BuildValue_SizeT")]
-    //pub fn _Py_BuildValue_SizeT(arg1: *const c_char, ...)
-    // -> *mut PyObject;
-    // #[cfg_attr(PyPy, link_name = "PyPy_VaBuildValue")]
-
-    // skipped non-limited _PyArg_UnpackStack
-    // skipped non-limited _PyArg_NoKeywords
-    // skipped non-limited _PyArg_NoKwnames
-    // skipped non-limited _PyArg_NoPositional
-    // skipped non-limited _PyArg_BadArgument
-    // skipped non-limited _PyArg_CheckPositional
-
-    //pub fn Py_VaBuildValue(arg1: *const c_char, arg2: va_list)
-    // -> *mut PyObject;
-
-    // skipped non-limited _Py_VaBuildStack
-    // skipped non-limited _PyArg_Parser
-
-    // skipped non-limited _PyArg_ParseTupleAndKeywordsFast
-    // skipped non-limited _PyArg_ParseStack
-    // skipped non-limited _PyArg_ParseStackAndKeywords
-    // skipped non-limited _PyArg_VaParseTupleAndKeywordsFast
-    // skipped non-limited _PyArg_UnpackKeywords
-    // skipped non-limited _PyArg_Fini
 
     #[cfg(Py_3_10)]
     #[cfg_attr(PyPy, link_name = "PyPyModule_AddObjectRef")]
@@ -158,10 +134,4 @@ pub unsafe fn PyModule_FromDefAndSpec(def: *mut PyModuleDef, spec: *mut PyObject
             PYTHON_API_VERSION
         },
     )
-}
-
-#[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
-extern "C" {
-    pub static mut _Py_PackageContext: *const c_char;
 }

--- a/pyo3-ffi/src/moduleobject.rs
+++ b/pyo3-ffi/src/moduleobject.rs
@@ -35,13 +35,11 @@ extern "C" {
     pub fn PyModule_GetFilename(arg1: *mut PyObject) -> *const c_char;
     #[cfg(not(PyPy))]
     pub fn PyModule_GetFilenameObject(arg1: *mut PyObject) -> *mut PyObject;
-    // skipped non-limited _PyModule_Clear
-    // skipped non-limited _PyModule_ClearDict
-    // skipped non-limited _PyModuleSpec_IsInitializing
     #[cfg_attr(PyPy, link_name = "PyPyModule_GetDef")]
     pub fn PyModule_GetDef(arg1: *mut PyObject) -> *mut PyModuleDef;
     #[cfg_attr(PyPy, link_name = "PyPyModule_GetState")]
     pub fn PyModule_GetState(arg1: *mut PyObject) -> *mut c_void;
+
     #[cfg_attr(PyPy, link_name = "PyPyModuleDef_Init")]
     pub fn PyModuleDef_Init(arg1: *mut PyModuleDef) -> *mut PyObject;
 }
@@ -94,8 +92,6 @@ pub const Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED: *mut c_void = 0 as *mut c_
 pub const Py_MOD_MULTIPLE_INTERPRETERS_SUPPORTED: *mut c_void = 1 as *mut c_void;
 #[cfg(Py_3_12)]
 pub const Py_MOD_PER_INTERPRETER_GIL_SUPPORTED: *mut c_void = 2 as *mut c_void;
-
-// skipped non-limited _Py_mod_LAST_SLOT
 
 #[repr(C)]
 #[derive(Copy, Clone)]

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -9,11 +9,8 @@ opaque_struct!(PyTypeObject);
 #[cfg(not(Py_LIMITED_API))]
 pub use crate::cpython::object::PyTypeObject;
 
-// _PyObject_HEAD_EXTRA: conditionally defined in PyObject_HEAD_INIT
-// _PyObject_EXTRA_INIT: conditionally defined in PyObject_HEAD_INIT
-
 #[cfg(Py_3_12)]
-pub const _Py_IMMORTAL_REFCNT: Py_ssize_t = {
+const _Py_IMMORTAL_REFCNT: Py_ssize_t = {
     if cfg!(target_pointer_width = "64") {
         c_uint::MAX as Py_ssize_t
     } else {
@@ -73,7 +70,7 @@ pub struct PyObject {
     pub ob_type: *mut PyTypeObject,
 }
 
-// skipped _PyObject_CAST
+// skipped private _PyObject_CAST
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -83,7 +80,7 @@ pub struct PyVarObject {
     pub ob_size: Py_ssize_t,
 }
 
-// skipped _PyVarObject_CAST
+// skipped private _PyVarObject_CAST
 
 #[inline]
 pub unsafe fn Py_Is(x: *mut PyObject, y: *mut PyObject) -> c_int {
@@ -135,13 +132,13 @@ pub unsafe fn Py_IS_TYPE(ob: *mut PyObject, tp: *mut PyTypeObject) -> c_int {
 
 #[inline(always)]
 #[cfg(all(Py_3_12, target_pointer_width = "64"))]
-pub unsafe fn _Py_IsImmortal(op: *mut PyObject) -> c_int {
+unsafe fn _Py_IsImmortal(op: *mut PyObject) -> c_int {
     (((*op).ob_refcnt.ob_refcnt as crate::PY_INT32_T) < 0) as c_int
 }
 
 #[inline(always)]
 #[cfg(all(Py_3_12, target_pointer_width = "32"))]
-pub unsafe fn _Py_IsImmortal(op: *mut PyObject) -> c_int {
+unsafe fn _Py_IsImmortal(op: *mut PyObject) -> c_int {
     ((*op).ob_refcnt.ob_refcnt == _Py_IMMORTAL_REFCNT) as c_int
 }
 
@@ -399,7 +396,7 @@ extern "C" {
 pub const Py_PRINT_RAW: c_int = 1; // No string quotes etc.
 
 #[cfg(all(Py_3_12, not(Py_LIMITED_API)))]
-pub const _Py_TPFLAGS_STATIC_BUILTIN: c_ulong = 1 << 1;
+const _Py_TPFLAGS_STATIC_BUILTIN: c_ulong = 1 << 1;
 
 #[cfg(all(Py_3_12, not(Py_LIMITED_API)))]
 pub const Py_TPFLAGS_MANAGED_WEAKREF: c_ulong = 1 << 3;
@@ -474,14 +471,14 @@ pub const Py_TPFLAGS_HAVE_VERSION_TAG: c_ulong = 1 << 18;
 
 extern "C" {
     #[cfg(all(py_sys_config = "Py_REF_DEBUG", not(Py_LIMITED_API)))]
-    pub fn _Py_NegativeRefcount(filename: *const c_char, lineno: c_int, op: *mut PyObject);
+    fn _Py_NegativeRefcount(filename: *const c_char, lineno: c_int, op: *mut PyObject);
     #[cfg(all(Py_3_12, py_sys_config = "Py_REF_DEBUG", not(Py_LIMITED_API)))]
     fn _Py_INCREF_IncRefTotal();
     #[cfg(all(Py_3_12, py_sys_config = "Py_REF_DEBUG", not(Py_LIMITED_API)))]
     fn _Py_DECREF_DecRefTotal();
 
     #[cfg_attr(PyPy, link_name = "_PyPy_Dealloc")]
-    pub fn _Py_Dealloc(arg1: *mut PyObject);
+    fn _Py_Dealloc(arg1: *mut PyObject);
 
     #[cfg_attr(PyPy, link_name = "PyPy_IncRef")]
     #[cfg_attr(GraalPy, link_name = "_Py_IncRef")]
@@ -491,18 +488,18 @@ extern "C" {
     pub fn Py_DecRef(o: *mut PyObject);
 
     #[cfg(all(Py_3_10, not(PyPy)))]
-    pub fn _Py_IncRef(o: *mut PyObject);
+    fn _Py_IncRef(o: *mut PyObject);
     #[cfg(all(Py_3_10, not(PyPy)))]
-    pub fn _Py_DecRef(o: *mut PyObject);
+    fn _Py_DecRef(o: *mut PyObject);
 
     #[cfg(GraalPy)]
-    pub fn _Py_REFCNT(arg1: *const PyObject) -> Py_ssize_t;
+    fn _Py_REFCNT(arg1: *const PyObject) -> Py_ssize_t;
 
     #[cfg(GraalPy)]
-    pub fn _Py_TYPE(arg1: *const PyObject) -> *mut PyTypeObject;
+    fn _Py_TYPE(arg1: *const PyObject) -> *mut PyTypeObject;
 
     #[cfg(GraalPy)]
-    pub fn _Py_SIZE(arg1: *const PyObject) -> Py_ssize_t;
+    fn _Py_SIZE(arg1: *const PyObject) -> Py_ssize_t;
 }
 
 #[inline(always)]
@@ -657,14 +654,16 @@ extern "C" {
 // implementation works on all supported Python versions so we define these macros on all
 // versions for simplicity.
 
-#[inline]
-pub unsafe fn _Py_NewRef(obj: *mut PyObject) -> *mut PyObject {
+#[inline(always)]
+#[cfg(all(Py_3_10, not(Py_LIMITED_API)))]
+unsafe fn _Py_NewRef(obj: *mut PyObject) -> *mut PyObject {
     Py_INCREF(obj);
     obj
 }
 
-#[inline]
-pub unsafe fn _Py_XNewRef(obj: *mut PyObject) -> *mut PyObject {
+#[inline(always)]
+#[cfg(all(Py_3_10, not(Py_LIMITED_API)))]
+unsafe fn _Py_XNewRef(obj: *mut PyObject) -> *mut PyObject {
     Py_XINCREF(obj);
     obj
 }

--- a/pyo3-ffi/src/objimpl.rs
+++ b/pyo3-ffi/src/objimpl.rs
@@ -33,15 +33,32 @@ extern "C" {
     // skipped PyObject_INIT_VAR
 
     #[cfg_attr(PyPy, link_name = "_PyPyObject_New")]
-    pub fn _PyObject_New(arg1: *mut PyTypeObject) -> *mut PyObject;
+    fn _PyObject_New(arg1: *mut PyTypeObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "_PyPyObject_NewVar")]
-    pub fn _PyObject_NewVar(arg1: *mut PyTypeObject, arg2: Py_ssize_t) -> *mut PyVarObject;
+    fn _PyObject_NewVar(arg1: *mut PyTypeObject, arg2: Py_ssize_t) -> *mut PyVarObject;
+}
 
-    // skipped PyObject_New
-    // skipped PyObject_NEW
-    // skipped PyObject_NewVar
-    // skipped PyObject_NEW_VAR
+#[inline(always)]
+pub unsafe fn PyObject_New(t: *mut PyTypeObject) -> *mut PyObject {
+    _PyObject_New(t)
+}
 
+#[inline(always)]
+pub unsafe fn PyObject_NEW(t: *mut PyTypeObject) -> *mut PyObject {
+    PyObject_New(t)
+}
+
+#[inline(always)]
+pub unsafe fn PyObject_NewVar(t: *mut PyTypeObject, size: Py_ssize_t) -> *mut PyVarObject {
+    _PyObject_NewVar(t, size)
+}
+
+#[inline(always)]
+pub unsafe fn PyObject_NEW_VAR(t: *mut PyTypeObject, size: Py_ssize_t) -> *mut PyVarObject {
+    PyObject_NewVar(t, size)
+}
+
+extern "C" {
     pub fn PyGC_Collect() -> Py_ssize_t;
 
     #[cfg(Py_3_10)]
@@ -55,8 +72,6 @@ extern "C" {
     #[cfg(Py_3_10)]
     #[cfg_attr(PyPy, link_name = "PyPyGC_IsEnabled")]
     pub fn PyGC_IsEnabled() -> c_int;
-
-    // skipped PyUnstable_GC_VisitObjects
 }
 
 #[inline]
@@ -65,14 +80,19 @@ pub unsafe fn PyType_IS_GC(t: *mut PyTypeObject) -> c_int {
 }
 
 extern "C" {
-    pub fn _PyObject_GC_Resize(arg1: *mut PyVarObject, arg2: Py_ssize_t) -> *mut PyVarObject;
+    fn _PyObject_GC_Resize(arg1: *mut PyVarObject, arg2: Py_ssize_t) -> *mut PyVarObject;
+}
 
-    // skipped PyObject_GC_Resize
-
+#[inline(always)]
+pub unsafe fn PyObject_GC_Resize<T>(op: *mut PyVarObject, n: Py_ssize_t) -> *mut T {
+    _PyObject_GC_Resize(op, n).cast::<T>()
+}
+// skipped PyObject_GC_Resize
+extern "C" {
     #[cfg_attr(PyPy, link_name = "_PyPyObject_GC_New")]
-    pub fn _PyObject_GC_New(arg1: *mut PyTypeObject) -> *mut PyObject;
+    fn _PyObject_GC_New(arg1: *mut PyTypeObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "_PyPyObject_GC_NewVar")]
-    pub fn _PyObject_GC_NewVar(arg1: *mut PyTypeObject, arg2: Py_ssize_t) -> *mut PyVarObject;
+    fn _PyObject_GC_NewVar(arg1: *mut PyTypeObject, arg2: Py_ssize_t) -> *mut PyVarObject;
     #[cfg(not(PyPy))]
     pub fn PyObject_GC_Track(arg1: *mut c_void);
     #[cfg(not(PyPy))]
@@ -80,9 +100,19 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyObject_GC_Del")]
     pub fn PyObject_GC_Del(arg1: *mut c_void);
 
-    // skipped PyObject_GC_New
-    // skipped PyObject_GC_NewVar
+}
 
+#[inline(always)]
+pub unsafe fn PyObject_GC_New<T>(typeobj: *mut PyTypeObject) -> *mut T {
+    _PyObject_GC_New(typeobj).cast::<T>()
+}
+
+#[inline(always)]
+pub unsafe fn PyObject_GC_NewVar<T>(typeobj: *mut PyTypeObject, n: Py_ssize_t) -> *mut T {
+    _PyObject_GC_NewVar(typeobj, n).cast::<T>()
+}
+
+extern "C" {
     #[cfg(any(all(Py_3_9, not(PyPy)), Py_3_10))] // added in 3.9, or 3.10 on PyPy
     #[cfg_attr(PyPy, link_name = "PyPyObject_GC_IsTracked")]
     pub fn PyObject_GC_IsTracked(arg1: *mut PyObject) -> c_int;

--- a/pyo3-ffi/src/pyhash.rs
+++ b/pyo3-ffi/src/pyhash.rs
@@ -1,47 +1,4 @@
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-use crate::pyport::{Py_hash_t, Py_ssize_t};
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-use std::os::raw::{c_char, c_void};
-
-use std::os::raw::{c_int, c_ulong};
-
-extern "C" {
-    // skipped non-limited _Py_HashDouble
-    // skipped non-limited _Py_HashPointer
-    // skipped non-limited _Py_HashPointerRaw
-
-    #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-    pub fn _Py_HashBytes(src: *const c_void, len: Py_ssize_t) -> Py_hash_t;
-}
-
-pub const _PyHASH_MULTIPLIER: c_ulong = 1000003;
-
-// skipped _PyHASH_BITS
-
-// skipped non-limited _Py_HashSecret_t
-
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct PyHash_FuncDef {
-    pub hash: Option<extern "C" fn(arg1: *const c_void, arg2: Py_ssize_t) -> Py_hash_t>,
-    pub name: *const c_char,
-    pub hash_bits: c_int,
-    pub seed_bits: c_int,
-}
-
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-impl Default for PyHash_FuncDef {
-    #[inline]
-    fn default() -> Self {
-        unsafe { std::mem::zeroed() }
-    }
-}
-
-extern "C" {
-    #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-    pub fn PyHash_GetFuncDef() -> *mut PyHash_FuncDef;
-}
+use std::os::raw::c_int;
 
 // skipped Py_HASH_CUTOFF
 

--- a/pyo3-ffi/src/pylifecycle.rs
+++ b/pyo3-ffi/src/pylifecycle.rs
@@ -37,8 +37,6 @@ extern "C" {
     pub fn Py_GetPath() -> *mut wchar_t;
     pub fn Py_SetPath(arg1: *const wchar_t);
 
-    // skipped _Py_CheckPython3
-
     #[cfg_attr(PyPy, link_name = "PyPy_GetVersion")]
     pub fn Py_GetVersion() -> *const c_char;
     pub fn Py_GetPlatform() -> *const c_char;
@@ -47,7 +45,7 @@ extern "C" {
     pub fn Py_GetBuildInfo() -> *const c_char;
 }
 
-type PyOS_sighandler_t = unsafe extern "C" fn(arg1: c_int);
+pub type PyOS_sighandler_t = unsafe extern "C" fn(arg1: c_int);
 
 extern "C" {
     pub fn PyOS_getsig(arg1: c_int) -> PyOS_sighandler_t;

--- a/pyo3-ffi/src/pystrtod.rs
+++ b/pyo3-ffi/src/pystrtod.rs
@@ -18,13 +18,11 @@ extern "C" {
     ) -> *mut c_char;
 }
 
-// skipped non-limited _Py_string_to_number_with_underscores
-// skipped non-limited _Py_parse_inf_or_nan
-
 /* PyOS_double_to_string's "flags" parameter can be set to 0 or more of: */
 pub const Py_DTSF_SIGN: c_int = 0x01; /* always add the sign */
 pub const Py_DTSF_ADD_DOT_0: c_int = 0x02; /* if the result is an integer add ".0" */
 pub const Py_DTSF_ALT: c_int = 0x04; /* "alternate" formatting. it's format_code specific */
+pub const Py_DTSF_NO_NEG: c_int = 0x08; /* negative zero result is coerced to 0 */
 
 /* PyOS_double_to_string's "type", if non-NULL, will be set to one of: */
 pub const Py_DTST_FINITE: c_int = 0;

--- a/pyo3-ffi/src/setobject.rs
+++ b/pyo3-ffi/src/setobject.rs
@@ -39,25 +39,6 @@ pub unsafe fn PySet_GET_SIZE(so: *mut PyObject) -> Py_ssize_t {
     (*so).used
 }
 
-#[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
-extern "C" {
-    pub static mut _PySet_Dummy: *mut PyObject;
-}
-
-extern "C" {
-    #[cfg(not(Py_LIMITED_API))]
-    #[cfg_attr(PyPy, link_name = "_PyPySet_NextEntry")]
-    pub fn _PySet_NextEntry(
-        set: *mut PyObject,
-        pos: *mut Py_ssize_t,
-        key: *mut *mut PyObject,
-        hash: *mut super::Py_hash_t,
-    ) -> c_int;
-
-    // skipped non-limited _PySet_Update
-}
-
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPySet_Type")]

--- a/pyo3-ffi/src/weakrefobject.rs
+++ b/pyo3-ffi/src/weakrefobject.rs
@@ -11,8 +11,11 @@ pub use crate::_PyWeakReference as PyWeakReference;
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
+    #[cfg(not(PyPy))]
     pub static mut _PyWeakref_RefType: PyTypeObject;
+    #[cfg(not(PyPy))]
     pub static mut _PyWeakref_ProxyType: PyTypeObject;
+    #[cfg(not(PyPy))]
     pub static mut _PyWeakref_CallableProxyType: PyTypeObject;
 
     #[cfg(PyPy)]

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -186,8 +186,6 @@ fn ascii() {
             // 2 and 4 byte macros return nonsense for this string instance.
             assert_eq!(PyUnicode_KIND(ptr), PyUnicode_1BYTE_KIND);
 
-            assert!(!_PyUnicode_COMPACT_DATA(ptr).is_null());
-            // _PyUnicode_NONCOMPACT_DATA isn't valid for compact strings.
             assert!(!PyUnicode_DATA(ptr).is_null());
 
             assert_eq!(PyUnicode_GET_LENGTH(ptr), s.len().unwrap() as Py_ssize_t);
@@ -226,8 +224,6 @@ fn ucs4() {
             assert!(!PyUnicode_4BYTE_DATA(ptr).is_null());
             assert_eq!(PyUnicode_KIND(ptr), PyUnicode_4BYTE_KIND);
 
-            assert!(!_PyUnicode_COMPACT_DATA(ptr).is_null());
-            // _PyUnicode_NONCOMPACT_DATA isn't valid for compact strings.
             assert!(!PyUnicode_DATA(ptr).is_null());
 
             assert_eq!(

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -74,8 +74,8 @@ pub enum PyMethodDefType {
 pub enum PyMethodType {
     PyCFunction(ffi::PyCFunction),
     PyCFunctionWithKeywords(ffi::PyCFunctionWithKeywords),
-    #[cfg(not(Py_LIMITED_API))]
-    PyCFunctionFastWithKeywords(ffi::_PyCFunctionFastWithKeywords),
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    PyCFunctionFastWithKeywords(ffi::PyCFunctionFastWithKeywords),
 }
 
 pub type PyClassAttributeFactory = for<'p> fn(Python<'p>) -> PyResult<PyObject>;
@@ -147,10 +147,10 @@ impl PyMethodDef {
     }
 
     /// Define a function that can take `*args` and `**kwargs`.
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     pub const fn fastcall_cfunction_with_keywords(
         ml_name: &'static CStr,
-        cfunction: ffi::_PyCFunctionFastWithKeywords,
+        cfunction: ffi::PyCFunctionFastWithKeywords,
         ml_doc: &'static CStr,
     ) -> Self {
         Self {
@@ -173,9 +173,9 @@ impl PyMethodDef {
             PyMethodType::PyCFunctionWithKeywords(meth) => ffi::PyMethodDefPointer {
                 PyCFunctionWithKeywords: meth,
             },
-            #[cfg(not(Py_LIMITED_API))]
+            #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
             PyMethodType::PyCFunctionFastWithKeywords(meth) => ffi::PyMethodDefPointer {
-                _PyCFunctionFastWithKeywords: meth,
+                PyCFunctionFastWithKeywords: meth,
             },
         };
 


### PR DESCRIPTION
Closes #3762 

This PR removes (as much as possible) all FFI functions and constants which start with `_Py`. Given that the guidance in #3762 from the CPython team is that we shouldn't be using these symbols (except in some cases where they are ABI implementation details) I have proceeded to remove them rather than deprecate. In the cases where we need to use them for implementations I removed the `pub` from the symbol definition so that `pyo3-ffi` retains use of the symbol without re-exporting.

Marked as draft for now as I need to finish off later; if we agree that this is a good idea then I will:
- Split this out into smaller PRs which are individually reviewable
- Add a migration guide entry and update `Architecture.md` to note that we don't expose these symbols.