### PR TITLE
add back `PyTuple::new`

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -181,7 +181,7 @@ struct RustyTuple(String, String);
 # use pyo3::types::PyTuple;
 # fn main() -> PyResult<()> {
 #     Python::with_gil(|py| -> PyResult<()> {
-#         let tuple = PyTuple::new_bound(py, vec!["test", "test2"]);
+#         let tuple = PyTuple::new(py, vec!["test", "test2"]);
 #
 #         let rustytuple: RustyTuple = tuple.extract()?;
 #         assert_eq!(rustytuple.0, "test");
@@ -204,7 +204,7 @@ struct RustyTuple((String,));
 # use pyo3::types::PyTuple;
 # fn main() -> PyResult<()> {
 #     Python::with_gil(|py| -> PyResult<()> {
-#         let tuple = PyTuple::new_bound(py, vec!["test"]);
+#         let tuple = PyTuple::new(py, vec!["test"]);
 #
 #         let rustytuple: RustyTuple = tuple.extract()?;
 #         assert_eq!((rustytuple.0).0, "test");

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -3,7 +3,7 @@
 This guide can help you upgrade code through breaking changes from one PyO3 version to the next.
 For a detailed list of all changes, see the [CHANGELOG](changelog.md).
 
-## from 0.21.* to 0.23
+## from 0.22.* to 0.23
 
 ### `gil-refs` feature removed
 <details open>

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -3,6 +3,44 @@
 This guide can help you upgrade code through breaking changes from one PyO3 version to the next.
 For a detailed list of all changes, see the [CHANGELOG](changelog.md).
 
+## from 0.21.* to 0.23
+
+### `gil-refs` feature removed
+<details open>
+<summary><small>Click to expand</small></summary>
+
+PyO3 0.23 completes the removal of the "GIL Refs" API in favour of the new "Bound" API introduced in PyO3 0.21.
+
+With the removal of the old API, many "Bound" API functions which had been introduced with `_bound` suffixes no longer need the suffixes as these names has been freed up. For example, `PyTuple::new_bound` is now just `PyTuple::new` (the existing name remains but is deprecated).
+
+Before:
+
+```rust
+# #![allow(deprecated)]
+# use pyo3::prelude::*;
+# use pyo3::types::PyTuple;
+# fn main() {
+# Python::with_gil(|py| {
+// For example, for PyTuple. Many such APIs have been changed.
+let tup = PyTuple::new_bound(py, [1, 2, 3]);
+# })
+# }
+```
+
+After:
+
+```rust
+# use pyo3::prelude::*;
+# use pyo3::types::PyTuple;
+# fn main() {
+# Python::with_gil(|py| {
+// For example, for PyTuple. Many such APIs have been changed.
+let tup = PyTuple::new(py, [1, 2, 3]);
+# })
+# }
+```
+</details>
+
 ## from 0.21.* to 0.22
 
 ### Deprecation of `gil-refs` feature continues

--- a/guide/src/python-from-rust/function-calls.md
+++ b/guide/src/python-from-rust/function-calls.md
@@ -49,7 +49,7 @@ fn main() -> PyResult<()> {
         fun.call1(py, args)?;
 
         // call object with Python tuple of positional arguments
-        let args = PyTuple::new_bound(py, &[arg1, arg2, arg3]);
+        let args = PyTuple::new(py, &[arg1, arg2, arg3]);
         fun.call1(py, args)?;
         Ok(())
     })

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -145,7 +145,7 @@ use pyo3::types::PyTuple;
 
 # fn example<'py>(py: Python<'py>) -> PyResult<()> {
 // Create a new tuple with the elements (0, 1, 2)
-let t = PyTuple::new_bound(py, [0, 1, 2]);
+let t = PyTuple::new(py, [0, 1, 2]);
 for i in 0..=2 {
     let entry: Borrowed<'_, 'py, PyAny> = t.get_borrowed_item(i)?;
     // `PyAnyMethods::extract` is available on `Borrowed`
@@ -250,7 +250,7 @@ For example, the following snippet shows how to cast `Bound<'py, PyAny>` to `Bou
 # use pyo3::types::PyTuple;
 # fn example<'py>(py: Python<'py>) -> PyResult<()> {
 // create a new Python `tuple`, and use `.into_any()` to erase the type
-let obj: Bound<'py, PyAny> = PyTuple::empty_bound(py).into_any();
+let obj: Bound<'py, PyAny> = PyTuple::empty(py).into_any();
 
 // use `.downcast()` to cast to `PyTuple` without transferring ownership
 let _: &Bound<'py, PyTuple> = obj.downcast()?;
@@ -295,7 +295,7 @@ For example, the following snippet extracts a Rust tuple of integers from a Pyth
 # use pyo3::types::PyTuple;
 # fn example<'py>(py: Python<'py>) -> PyResult<()> {
 // create a new Python `tuple`, and use `.into_any()` to erase the type
-let obj: Bound<'py, PyAny> = PyTuple::new_bound(py, [1, 2, 3]).into_any();
+let obj: Bound<'py, PyAny> = PyTuple::new(py, [1, 2, 3]).into_any();
 
 // extracting the Python `tuple` to a rust `(i32, i32, i32)` tuple
 let (x, y, z) = obj.extract::<(i32, i32, i32)>()?;

--- a/pytests/src/datetime.rs
+++ b/pytests/src/datetime.rs
@@ -13,7 +13,7 @@ fn make_date(py: Python<'_>, year: i32, month: u8, day: u8) -> PyResult<Bound<'_
 
 #[pyfunction]
 fn get_date_tuple<'py>(d: &Bound<'py, PyDate>) -> Bound<'py, PyTuple> {
-    PyTuple::new_bound(
+    PyTuple::new(
         d.py(),
         [d.get_year(), d.get_month() as i32, d.get_day() as i32],
     )
@@ -53,7 +53,7 @@ fn time_with_fold<'py>(
 
 #[pyfunction]
 fn get_time_tuple<'py>(dt: &Bound<'py, PyTime>) -> Bound<'py, PyTuple> {
-    PyTuple::new_bound(
+    PyTuple::new(
         dt.py(),
         [
             dt.get_hour() as u32,
@@ -66,7 +66,7 @@ fn get_time_tuple<'py>(dt: &Bound<'py, PyTime>) -> Bound<'py, PyTuple> {
 
 #[pyfunction]
 fn get_time_tuple_fold<'py>(dt: &Bound<'py, PyTime>) -> Bound<'py, PyTuple> {
-    PyTuple::new_bound(
+    PyTuple::new(
         dt.py(),
         [
             dt.get_hour() as u32,
@@ -90,7 +90,7 @@ fn make_delta(
 
 #[pyfunction]
 fn get_delta_tuple<'py>(delta: &Bound<'py, PyDelta>) -> Bound<'py, PyTuple> {
-    PyTuple::new_bound(
+    PyTuple::new(
         delta.py(),
         [
             delta.get_days(),
@@ -129,7 +129,7 @@ fn make_datetime<'py>(
 
 #[pyfunction]
 fn get_datetime_tuple<'py>(dt: &Bound<'py, PyDateTime>) -> Bound<'py, PyTuple> {
-    PyTuple::new_bound(
+    PyTuple::new(
         dt.py(),
         [
             dt.get_year(),
@@ -145,7 +145,7 @@ fn get_datetime_tuple<'py>(dt: &Bound<'py, PyDateTime>) -> Bound<'py, PyTuple> {
 
 #[pyfunction]
 fn get_datetime_tuple_fold<'py>(dt: &Bound<'py, PyDateTime>) -> Bound<'py, PyTuple> {
-    PyTuple::new_bound(
+    PyTuple::new(
         dt.py(),
         [
             dt.get_year(),

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -366,7 +366,7 @@ where
 /// Converts `()` to an empty Python tuple.
 impl IntoPy<Py<PyTuple>> for () {
     fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
-        PyTuple::empty_bound(py).unbind()
+        PyTuple::empty(py).unbind()
     }
 }
 

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -709,7 +709,7 @@ impl<'py> VarargsHandler<'py> for TupleVarargs {
         varargs: &[Option<PyArg<'py>>],
         _function_description: &FunctionDescription,
     ) -> PyResult<Self::Varargs> {
-        Ok(PyTuple::new_bound(py, varargs))
+        Ok(PyTuple::new(py, varargs))
     }
 
     #[inline]
@@ -807,7 +807,7 @@ mod tests {
         };
 
         Python::with_gil(|py| {
-            let args = PyTuple::empty_bound(py);
+            let args = PyTuple::empty(py);
             let kwargs = [("foo", 0u8)].into_py_dict_bound(py);
             let err = unsafe {
                 function_description
@@ -838,7 +838,7 @@ mod tests {
         };
 
         Python::with_gil(|py| {
-            let args = PyTuple::empty_bound(py);
+            let args = PyTuple::empty(py);
             let kwargs = [(1u8, 1u8)].into_py_dict_bound(py);
             let err = unsafe {
                 function_description
@@ -869,7 +869,7 @@ mod tests {
         };
 
         Python::with_gil(|py| {
-            let args = PyTuple::empty_bound(py);
+            let args = PyTuple::empty(py);
             let mut output = [None, None];
             let err = unsafe {
                 function_description.extract_arguments_tuple_dict::<NoVarargs, NoVarkeywords>(

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -95,7 +95,7 @@ impl ModuleDef {
                 .import_bound("sys")?
                 .getattr("implementation")?
                 .getattr("version")?;
-            if version.lt(crate::types::PyTuple::new_bound(py, PYPY_GOOD_VERSION))? {
+            if version.lt(crate::types::PyTuple::new(py, PYPY_GOOD_VERSION))? {
                 let warn = py.import_bound("warnings")?.getattr("warn")?;
                 warn.call1((
                     "PyPy 3.7 versions older than 7.3.8 are known to have binary \

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -585,7 +585,7 @@ impl<'py, T> Borrowed<'_, 'py, T> {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let tuple = PyTuple::new_bound(py, [1, 2, 3]);
+    ///     let tuple = PyTuple::new(py, [1, 2, 3]);
     ///
     ///     // borrows from `tuple`, so can only be
     ///     // used while `tuple` stays alive

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -208,7 +208,7 @@ impl PyDate {
     ///
     /// This is equivalent to `datetime.date.fromtimestamp`
     pub fn from_timestamp_bound(py: Python<'_>, timestamp: i64) -> PyResult<Bound<'_, PyDate>> {
-        let time_tuple = PyTuple::new_bound(py, [timestamp]);
+        let time_tuple = PyTuple::new(py, [timestamp]);
 
         // safety ensure that the API is loaded
         let _api = ensure_datetime_api(py)?;

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -1046,7 +1046,7 @@ mod tests {
         Python::with_gil(|py| {
             let list = PyList::new_bound(py, vec![1, 2, 3]);
             let tuple = list.to_tuple();
-            let tuple_expected = PyTuple::new_bound(py, vec![1, 2, 3]);
+            let tuple_expected = PyTuple::new(py, vec![1, 2, 3]);
             assert!(tuple.eq(tuple_expected).unwrap());
         })
     }

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -735,7 +735,7 @@ mod tests {
             assert!(seq
                 .to_tuple()
                 .unwrap()
-                .eq(PyTuple::new_bound(py, ["foo", "bar"]))
+                .eq(PyTuple::new(py, ["foo", "bar"]))
                 .unwrap());
         });
     }
@@ -746,11 +746,7 @@ mod tests {
             let v = vec!["foo", "bar"];
             let ob = v.to_object(py);
             let seq = ob.downcast_bound::<PySequence>(py).unwrap();
-            assert!(seq
-                .to_tuple()
-                .unwrap()
-                .eq(PyTuple::new_bound(py, &v))
-                .unwrap());
+            assert!(seq.to_tuple().unwrap().eq(PyTuple::new(py, &v)).unwrap());
         });
     }
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -272,7 +272,7 @@ mod tests {
             assert!(py
                 .get_type_bound::<PyBool>()
                 .mro()
-                .eq(PyTuple::new_bound(
+                .eq(PyTuple::new(
                     py,
                     [
                         py.get_type_bound::<PyBool>(),
@@ -290,7 +290,7 @@ mod tests {
             assert!(py
                 .get_type_bound::<PyBool>()
                 .bases()
-                .eq(PyTuple::new_bound(py, [py.get_type_bound::<PyInt>()]))
+                .eq(PyTuple::new(py, [py.get_type_bound::<PyInt>()]))
                 .unwrap());
         });
     }
@@ -301,7 +301,7 @@ mod tests {
             assert!(py
                 .get_type_bound::<PyAny>()
                 .bases()
-                .eq(PyTuple::empty_bound(py))
+                .eq(PyTuple::empty(py))
                 .unwrap());
         });
     }

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -168,10 +168,10 @@ pub struct Tuple(String, usize);
 #[test]
 fn test_tuple_struct() {
     Python::with_gil(|py| {
-        let tup = PyTuple::new_bound(py, &[1.into_py(py), "test".into_py(py)]);
+        let tup = PyTuple::new(py, &[1.into_py(py), "test".into_py(py)]);
         let tup = tup.extract::<Tuple>();
         assert!(tup.is_err());
-        let tup = PyTuple::new_bound(py, &["test".into_py(py), 1.into_py(py)]);
+        let tup = PyTuple::new(py, &["test".into_py(py), 1.into_py(py)]);
         let tup = tup
             .extract::<Tuple>()
             .expect("Failed to extract Tuple from PyTuple");
@@ -333,7 +333,7 @@ pub struct PyBool {
 #[test]
 fn test_enum() {
     Python::with_gil(|py| {
-        let tup = PyTuple::new_bound(py, &[1.into_py(py), "test".into_py(py)]);
+        let tup = PyTuple::new(py, &[1.into_py(py), "test".into_py(py)]);
         let f = tup
             .extract::<Foo<'_>>()
             .expect("Failed to extract Foo from tuple");
@@ -424,7 +424,7 @@ TypeError: failed to extract enum Foo ('TupleVar | StructVar | TransparentTuple 
 - variant StructWithGetItemArg (StructWithGetItemArg): KeyError: 'foo'"
         );
 
-        let tup = PyTuple::empty_bound(py);
+        let tup = PyTuple::empty(py);
         let err = tup.extract::<Foo<'_>>().unwrap_err();
         assert_eq!(
             err.to_string(),

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -91,7 +91,7 @@ fn intopytuple_pyclass() {
 #[test]
 fn pytuple_primitive_iter() {
     Python::with_gil(|py| {
-        let tup = PyTuple::new_bound(py, [1u32, 2, 3].iter());
+        let tup = PyTuple::new(py, [1u32, 2, 3].iter());
         py_assert!(py, tup, "tup == (1, 2, 3)");
     });
 }
@@ -99,7 +99,7 @@ fn pytuple_primitive_iter() {
 #[test]
 fn pytuple_pyclass_iter() {
     Python::with_gil(|py| {
-        let tup = PyTuple::new_bound(
+        let tup = PyTuple::new(
             py,
             [
                 Py::new(py, SimplePyClass {}).unwrap(),
@@ -134,7 +134,7 @@ fn test_pickle() {
         ) -> PyResult<(PyObject, Bound<'py, PyTuple>, PyObject)> {
             let cls = slf.to_object(py).getattr(py, "__class__")?;
             let dict = slf.to_object(py).getattr(py, "__dict__")?;
-            Ok((cls, PyTuple::empty_bound(py), dict))
+            Ok((cls, PyTuple::empty(py), dict))
         }
     }
 


### PR DESCRIPTION
After reviewing #4378 I found myself itching to write a migration guide entry, so here's a first attempt at that. To support the guide with an example I added back new forms of `PyTuple::new` and `PyTuple::empty` and deprecated the `_bound` names for those.