### PR TITLE
fix incorrect spans on `ret` and `py` local varianbles in emitted code

### DIFF
--- a/newsfragments/4382.fixed.md
+++ b/newsfragments/4382.fixed.md
@@ -1,0 +1,1 @@
+Fixed hygiene/span issues of emitted code which affected expansion in `macro_rules` context.

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -720,9 +720,10 @@ impl<'a> FnSpec<'a> {
 
             // We must assign the output_span to the return value of the call,
             // but *not* of the call itself otherwise the spans get really weird
-            let ret_expr = quote! { let ret = #call; };
-            let ret_var = quote_spanned! {*output_span=> ret };
-            let return_conversion = quotes::map_result_into_ptr(quotes::ok_wrap(ret_var, ctx), ctx);
+            let ret_ident = Ident::new("ret", *output_span);
+            let ret_expr = quote! { let #ret_ident = #call; };
+            let return_conversion =
+                quotes::map_result_into_ptr(quotes::ok_wrap(ret_ident.to_token_stream(), ctx), ctx);
             quote! {
                 {
                     #ret_expr

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2081,7 +2081,7 @@ impl<'a> PyClassImplsBuilder<'a> {
         if attr.options.extends.is_none() {
             quote! {
                 impl #pyo3_path::IntoPy<#pyo3_path::PyObject> for #cls {
-                    fn into_py(self, py: #pyo3_path::Python) -> #pyo3_path::PyObject {
+                    fn into_py(self, py: #pyo3_path::Python<'_>) -> #pyo3_path::PyObject {
                         #pyo3_path::IntoPy::into_py(#pyo3_path::Py::new(py, self).unwrap(), py)
                     }
                 }

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -27,5 +27,6 @@ pub(crate) fn map_result_into_ptr(result: TokenStream, ctx: &Ctx) -> TokenStream
         output_span,
     } = ctx;
     let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
-    quote_spanned! {*output_span=> #pyo3_path::impl_::wrap::map_result_into_ptr(py, #result) }
+    let py = syn::Ident::new("py", proc_macro2::Span::call_site());
+    quote_spanned! {*output_span=> #pyo3_path::impl_::wrap::map_result_into_ptr(#py, #result) }
 }

--- a/src/tests/hygiene/misc.rs
+++ b/src/tests/hygiene/misc.rs
@@ -37,3 +37,22 @@ fn append_to_inittab() {
 
     crate::append_to_inittab!(module_for_inittab);
 }
+
+macro_rules! macro_rules_hygiene {
+    ($name_a:ident, $name_b:ident) => {
+        #[crate::pyclass(crate = "crate")]
+        struct $name_a {}
+
+        #[crate::pymethods(crate = "crate")]
+        impl $name_a {
+            fn finalize(&mut self) -> $name_b {
+                $name_b {}
+            }
+        }
+
+        #[crate::pyclass(crate = "crate")]
+        struct $name_b {}
+    };
+}
+
+macro_rules_hygiene!(MyClass1, MyClass2);


### PR DESCRIPTION
This fixes the new `output_span` (#4220) of the return type of functions and methods (`ret`) is not carried to every usage, and the span of `py` in `map_result_into_ptr` has incorrectly changed.

Closes #4381 
