### PR TITLE
Remove `unsafe` that isn't needed

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -149,7 +149,7 @@ macro_rules! pyobject_native_type_named (
 #[macro_export]
 macro_rules! pyobject_native_static_type_object(
     ($typeobject:expr) => {
-        |_py| unsafe { ::std::ptr::addr_of_mut!($typeobject) }
+        |_py| ::std::ptr::addr_of_mut!($typeobject)
     };
 );
 


### PR DESCRIPTION
Merely taking the address of a static is safe, it's only dereferencing the pointer that's unsafe

