### PR TITLE
reintroduce `PyList` constructors

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -13,7 +13,7 @@ fails, so usually you will use something like
 # use pyo3::types::PyList;
 # fn main() -> PyResult<()> {
 #     Python::with_gil(|py| {
-#         let list = PyList::new_bound(py, b"foo");
+#         let list = PyList::new(py, b"foo");
 let v: Vec<i32> = list.extract()?;
 #         assert_eq!(&v, &[102, 111, 111]);
 #         Ok(())

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -80,7 +80,7 @@ use pyo3::types::{PyBool, PyList};
 
 Python::with_gil(|py| {
     assert!(PyBool::new_bound(py, true).is_instance_of::<PyBool>());
-    let list = PyList::new_bound(py, &[1, 2, 3, 4]);
+    let list = PyList::new(py, &[1, 2, 3, 4]);
     assert!(!list.is_instance_of::<PyBool>());
     assert!(list.is_instance_of::<PyList>());
 });

--- a/guide/src/performance.md
+++ b/guide/src/performance.md
@@ -108,7 +108,7 @@ This limitation is important to keep in mind when this setting is used, especial
 ```rust,ignore
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
-let numbers: Py<PyList> = Python::with_gil(|py| PyList::empty_bound(py).unbind());
+let numbers: Py<PyList> = Python::with_gil(|py| PyList::empty(py).unbind());
 
 Python::with_gil(|py| {
     numbers.bind(py).append(23).unwrap();
@@ -124,7 +124,7 @@ will abort if the list not explicitly disposed via
 ```rust
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
-let numbers: Py<PyList> = Python::with_gil(|py| PyList::empty_bound(py).unbind());
+let numbers: Py<PyList> = Python::with_gil(|py| PyList::empty(py).unbind());
 
 Python::with_gil(|py| {
     numbers.bind(py).append(23).unwrap();

--- a/guide/src/trait-bounds.md
+++ b/guide/src/trait-bounds.md
@@ -84,7 +84,7 @@ impl Model for UserModel {
         Python::with_gil(|py| {
             self.model
                 .bind(py)
-                .call_method("set_variables", (PyList::new_bound(py, var),), None)
+                .call_method("set_variables", (PyList::new(py, var),), None)
                 .unwrap();
         })
     }
@@ -182,7 +182,7 @@ This wrapper will also perform the type conversions between Python and Rust.
 #      println!("Rust calling Python to set the variables");
 #      Python::with_gil(|py| {
 #          self.model.bind(py)
-#              .call_method("set_variables", (PyList::new_bound(py, var),), None)
+#              .call_method("set_variables", (PyList::new(py, var),), None)
 #              .unwrap();
 #      })
 #  }
@@ -360,7 +360,7 @@ impl Model for UserModel {
 #         println!("Rust calling Python to set the variables");
 #         Python::with_gil(|py| {
 #             self.model.bind(py)
-#                 .call_method("set_variables", (PyList::new_bound(py, var),), None)
+#                 .call_method("set_variables", (PyList::new(py, var),), None)
 #                 .unwrap();
 #         })
 #     }
@@ -419,7 +419,7 @@ impl Model for UserModel {
 #         println!("Rust calling Python to set the variables");
 #         Python::with_gil(|py| {
 #             let py_model = self.model.bind(py)
-#                 .call_method("set_variables", (PyList::new_bound(py, var),), None)
+#                 .call_method("set_variables", (PyList::new(py, var),), None)
 #                 .unwrap();
 #         })
 #     }
@@ -517,7 +517,7 @@ impl Model for UserModel {
         Python::with_gil(|py| {
             self.model
                 .bind(py)
-                .call_method("set_variables", (PyList::new_bound(py, var),), None)
+                .call_method("set_variables", (PyList::new(py, var),), None)
                 .unwrap();
         })
     }

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -61,7 +61,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyList;
 
 fn example<'py>(py: Python<'py>) -> PyResult<()> {
-    let x: Bound<'py, PyList> = PyList::empty_bound(py);
+    let x: Bound<'py, PyList> = PyList::empty(py);
     x.append(1)?;
     let y: Bound<'py, PyList> = x.clone(); // y is a new reference to the same list
     drop(x); // release the original reference x
@@ -77,7 +77,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyList;
 
 fn example(py: Python<'_>) -> PyResult<()> {
-    let x = PyList::empty_bound(py);
+    let x = PyList::empty(py);
     x.append(1)?;
     let y = x.clone();
     drop(x);
@@ -232,7 +232,7 @@ fn get_first_item<'py>(list: &Bound<'py, PyList>) -> PyResult<Bound<'py, PyAny>>
     list.get_item(0)
 }
 # Python::with_gil(|py| {
-#     let l = PyList::new_bound(py, ["hello world"]);
+#     let l = PyList::new(py, ["hello world"]);
 #     assert!(get_first_item(&l).unwrap().eq("hello world").unwrap());
 # })
 ```

--- a/pyo3-benches/benches/bench_frompyobject.rs
+++ b/pyo3-benches/benches/bench_frompyobject.rs
@@ -25,7 +25,7 @@ fn enum_from_pyobject(b: &mut Bencher<'_>) {
 
 fn list_via_downcast(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let any = PyList::empty_bound(py).into_any();
+        let any = PyList::empty(py).into_any();
 
         b.iter(|| black_box(&any).downcast::<PyList>().unwrap());
     })
@@ -33,7 +33,7 @@ fn list_via_downcast(b: &mut Bencher<'_>) {
 
 fn list_via_extract(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let any = PyList::empty_bound(py).into_any();
+        let any = PyList::empty(py).into_any();
 
         b.iter(|| black_box(&any).extract::<Bound<'_, PyList>>().unwrap());
     })

--- a/pyo3-benches/benches/bench_list.rs
+++ b/pyo3-benches/benches/bench_list.rs
@@ -8,7 +8,7 @@ use pyo3::types::{PyList, PySequence};
 fn iter_list(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
-        let list = PyList::new_bound(py, 0..LEN);
+        let list = PyList::new(py, 0..LEN);
         let mut sum = 0;
         b.iter(|| {
             for x in &list {
@@ -22,14 +22,14 @@ fn iter_list(b: &mut Bencher<'_>) {
 fn list_new(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
-        b.iter_with_large_drop(|| PyList::new_bound(py, 0..LEN));
+        b.iter_with_large_drop(|| PyList::new(py, 0..LEN));
     });
 }
 
 fn list_get_item(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
-        let list = PyList::new_bound(py, 0..LEN);
+        let list = PyList::new(py, 0..LEN);
         let mut sum = 0;
         b.iter(|| {
             for i in 0..LEN {
@@ -43,7 +43,7 @@ fn list_get_item(b: &mut Bencher<'_>) {
 fn list_get_item_unchecked(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
-        let list = PyList::new_bound(py, 0..LEN);
+        let list = PyList::new(py, 0..LEN);
         let mut sum = 0;
         b.iter(|| {
             for i in 0..LEN {
@@ -58,7 +58,7 @@ fn list_get_item_unchecked(b: &mut Bencher<'_>) {
 fn sequence_from_list(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
-        let list = &PyList::new_bound(py, 0..LEN);
+        let list = &PyList::new(py, 0..LEN);
         b.iter(|| black_box(list).downcast::<PySequence>().unwrap());
     });
 }

--- a/pyo3-benches/benches/bench_tuple.rs
+++ b/pyo3-benches/benches/bench_tuple.rs
@@ -103,7 +103,7 @@ fn tuple_new_list(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
         let tuple = PyTuple::new_bound(py, 0..LEN);
-        b.iter_with_large_drop(|| PyList::new_bound(py, tuple.iter_borrowed()));
+        b.iter_with_large_drop(|| PyList::new(py, tuple.iter_borrowed()));
     });
 }
 

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -104,7 +104,7 @@ mod tests {
         Python::with_gil(|py| {
             let sv: SmallVec<[u64; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();
             let hso: PyObject = sv.clone().into_py(py);
-            let l = PyList::new_bound(py, [1, 2, 3, 4, 5]);
+            let l = PyList::new(py, [1, 2, 3, 4, 5]);
             assert!(l.eq(hso).unwrap());
         });
     }
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn test_smallvec_from_py_object() {
         Python::with_gil(|py| {
-            let l = PyList::new_bound(py, [1, 2, 3, 4, 5]);
+            let l = PyList::new(py, [1, 2, 3, 4, 5]);
             let sv: SmallVec<[u64; 8]> = l.extract().unwrap();
             assert_eq!(sv.as_slice(), [1, 2, 3, 4, 5]);
         });
@@ -135,7 +135,7 @@ mod tests {
         Python::with_gil(|py| {
             let sv: SmallVec<[u64; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();
             let hso: PyObject = sv.to_object(py);
-            let l = PyList::new_bound(py, [1, 2, 3, 4, 5]);
+            let l = PyList::new(py, [1, 2, 3, 4, 5]);
             assert!(l.eq(hso).unwrap());
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! - Types that also have the `'py` lifetime, such as the [`Bound<'py, T>`](Bound) smart pointer, are
 //!   bound to the Python GIL and rely on this to offer their functionality. These types often
 //!   have a [`.py()`](Bound::py) method to get the associated [`Python<'py>`](Python) token.
-//! - Functions which depend on the `'py` lifetime, such as [`PyList::new_bound`](types::PyList::new_bound),
+//! - Functions which depend on the `'py` lifetime, such as [`PyList::new`](types::PyList::new),
 //!   require a [`Python<'py>`](Python) token as an input. Sometimes the token is passed implicitly by
 //!   taking a [`Bound<'py, T>`](Bound) or other type which is bound to the `'py` lifetime.
 //! - Traits which depend on the `'py` lifetime, such as [`FromPyObject<'py>`](FromPyObject), usually have

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,7 +12,7 @@
 /// use pyo3::{prelude::*, py_run, types::PyList};
 ///
 /// Python::with_gil(|py| {
-///     let list = PyList::new_bound(py, &[1, 2, 3]);
+///     let list = PyList::new(py, &[1, 2, 3]);
 ///     py_run!(py, list, "assert list == [1, 2, 3]");
 /// });
 /// ```

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -882,7 +882,7 @@ mod tests {
 
             // If allow_threads is implemented correctly, this thread still owns the GIL here
             // so the following Python calls should not cause crashes.
-            let list = PyList::new_bound(py, [1, 2, 3, 4]);
+            let list = PyList::new(py, [1, 2, 3, 4]);
             assert_eq!(list.extract::<Vec<i32>>().unwrap(), vec![1, 2, 3, 4]);
         });
     }
@@ -890,7 +890,7 @@ mod tests {
     #[cfg(not(pyo3_disable_reference_pool))]
     #[test]
     fn test_allow_threads_pass_stuff_in() {
-        let list = Python::with_gil(|py| PyList::new_bound(py, vec!["foo", "bar"]).unbind());
+        let list = Python::with_gil(|py| PyList::new(py, vec!["foo", "bar"]).unbind());
         let mut v = vec![1, 2, 3];
         let a = std::sync::Arc::new(String::from("foo"));
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -87,7 +87,7 @@ unsafe impl<T> Sync for GILProtected<T> where T: Send {}
 ///
 /// pub fn get_shared_list(py: Python<'_>) -> &Bound<'_, PyList> {
 ///     LIST_CELL
-///         .get_or_init(py, || PyList::empty_bound(py).unbind())
+///         .get_or_init(py, || PyList::empty(py).unbind())
 ///         .bind(py)
 /// }
 /// # Python::with_gil(|py| assert_eq!(get_shared_list(py).len(), 0));

--- a/src/tests/hygiene/pymethods.rs
+++ b/src/tests/hygiene/pymethods.rs
@@ -73,7 +73,7 @@ impl Dummy {
     fn __delattr__(&mut self, name: ::std::string::String) {}
 
     fn __dir__<'py>(&self, py: crate::Python<'py>) -> crate::Bound<'py, crate::types::PyList> {
-        crate::types::PyList::new_bound(py, ::std::vec![0_u8])
+        crate::types::PyList::new(py, ::std::vec![0_u8])
     }
 
     //////////////////////

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1938,10 +1938,10 @@ class SimpleClass:
     #[test]
     fn test_is_empty() {
         Python::with_gil(|py| {
-            let empty_list = PyList::empty_bound(py).into_any();
+            let empty_list = PyList::empty(py).into_any();
             assert!(empty_list.is_empty().unwrap());
 
-            let list = PyList::new_bound(py, vec![1, 2, 3]).into_any();
+            let list = PyList::new(py, vec![1, 2, 3]).into_any();
             assert!(!list.is_empty().unwrap());
 
             let not_container = 5.to_object(py).into_bound(py);

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -605,7 +605,7 @@ mod tests {
     #[cfg(not(any(PyPy, GraalPy)))]
     fn test_from_sequence() {
         Python::with_gil(|py| {
-            let items = PyList::new_bound(py, vec![("a", 1), ("b", 2)]);
+            let items = PyList::new(py, vec![("a", 1), ("b", 2)]);
             let dict = PyDict::from_sequence_bound(&items).unwrap();
             assert_eq!(
                 1,
@@ -636,7 +636,7 @@ mod tests {
     #[cfg(not(any(PyPy, GraalPy)))]
     fn test_from_sequence_err() {
         Python::with_gil(|py| {
-            let items = PyList::new_bound(py, vec!["a", "b"]);
+            let items = PyList::new(py, vec!["a", "b"]);
             assert!(PyDict::from_sequence_bound(&items).is_err());
         });
     }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -149,7 +149,7 @@ mod tests {
             let count;
             let obj = py.eval_bound("object()", None, None).unwrap();
             let list = {
-                let list = PyList::empty_bound(py);
+                let list = PyList::empty(py);
                 list.append(10).unwrap();
                 list.append(&obj).unwrap();
                 count = obj.get_refcnt();

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -368,7 +368,7 @@ impl<'py> PyModuleMethods<'py> for Bound<'py, PyModule> {
             Ok(idx) => idx.downcast_into().map_err(PyErr::from),
             Err(err) => {
                 if err.is_instance_of::<exceptions::PyAttributeError>(self.py()) {
-                    let l = PyList::empty_bound(self.py());
+                    let l = PyList::empty(self.py());
                     self.setattr(__all__, &l).map_err(PyErr::from)?;
                     Ok(l)
                 } else {

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -558,7 +558,7 @@ mod tests {
             let ins = w.to_object(py);
             seq.set_slice(1, 4, ins.bind(py)).unwrap();
             assert_eq!([1, 7, 4, 5, 8], seq.extract::<[i32; 5]>().unwrap());
-            seq.set_slice(3, 100, &PyList::empty_bound(py)).unwrap();
+            seq.set_slice(3, 100, &PyList::empty(py)).unwrap();
             assert_eq!([1, 7, 4], seq.extract::<[i32; 3]>().unwrap());
         });
     }
@@ -704,11 +704,7 @@ mod tests {
             let v = vec!["foo", "bar"];
             let ob = v.to_object(py);
             let seq = ob.downcast_bound::<PySequence>(py).unwrap();
-            assert!(seq
-                .to_list()
-                .unwrap()
-                .eq(PyList::new_bound(py, &v))
-                .unwrap());
+            assert!(seq.to_list().unwrap().eq(PyList::new(py, &v)).unwrap());
         });
     }
 
@@ -721,7 +717,7 @@ mod tests {
             assert!(seq
                 .to_list()
                 .unwrap()
-                .eq(PyList::new_bound(py, ["f", "o", "o"]))
+                .eq(PyList::new(py, ["f", "o", "o"]))
                 .unwrap());
         });
     }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1178,7 +1178,7 @@ mod tests {
         Python::with_gil(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3]);
             let list = tuple.to_list();
-            let list_expected = PyList::new_bound(py, vec![1, 2, 3]);
+            let list_expected = PyList::new(py, vec![1, 2, 3]);
             assert!(list.eq(list_expected).unwrap());
         })
     }

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -594,7 +594,7 @@ pub struct TransparentFromPyWith {
 #[test]
 fn test_transparent_from_py_with() {
     Python::with_gil(|py| {
-        let result = PyList::new_bound(py, [1, 2, 3])
+        let result = PyList::new(py, [1, 2, 3])
             .extract::<TransparentFromPyWith>()
             .unwrap();
         let expected = TransparentFromPyWith { len: 3 };

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -54,7 +54,7 @@ impl ClassWithProperties {
 
     #[getter]
     fn get_data_list<'py>(&self, py: Python<'py>) -> Bound<'py, PyList> {
-        PyList::new_bound(py, [self.num])
+        PyList::new(py, [self.num])
     }
 }
 

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -703,7 +703,7 @@ impl MethodWithLifeTime {
         for _ in 0..set.len() {
             items.push(set.pop().unwrap());
         }
-        let list = PyList::new_bound(py, items);
+        let list = PyList::new(py, items);
         list.sort()?;
         Ok(list)
     }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -846,7 +846,7 @@ struct DefaultedContains;
 #[pymethods]
 impl DefaultedContains {
     fn __iter__(&self, py: Python<'_>) -> PyObject {
-        PyList::new_bound(py, ["a", "b", "c"])
+        PyList::new(py, ["a", "b", "c"])
             .as_ref()
             .iter()
             .unwrap()
@@ -860,7 +860,7 @@ struct NoContains;
 #[pymethods]
 impl NoContains {
     fn __iter__(&self, py: Python<'_>) -> PyObject {
-        PyList::new_bound(py, ["a", "b", "c"])
+        PyList::new(py, ["a", "b", "c"])
             .as_ref()
             .iter()
             .unwrap()


### PR DESCRIPTION
Reintroduces `PyList` constructors without `_bound` suffix and deprecates the old names.
