### PR TITLE
Add back `PyBytes::new`

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -388,7 +388,7 @@ enum RustyEnum<'py> {
 #         }
 #
 #         {
-#             let thing = PyBytes::new_bound(py, b"text");
+#             let thing = PyBytes::new(py, b"text");
 #             let rust_thing: RustyEnum<'_> = thing.extract()?;
 #
 #             assert_eq!(

--- a/pytests/src/buf_and_str.rs
+++ b/pytests/src/buf_and_str.rs
@@ -43,7 +43,7 @@ impl BytesExtractor {
 
 #[pyfunction]
 fn return_memoryview(py: Python<'_>) -> PyResult<Bound<'_, PyMemoryView>> {
-    let bytes = PyBytes::new_bound(py, b"hello world");
+    let bytes = PyBytes::new(py, b"hello world");
     PyMemoryView::from_bound(&bytes)
 }
 

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -76,7 +76,7 @@
 //!     let res = Python::with_gil(|py| {
 //!         let zlib = PyModule::import_bound(py, "zlib")?;
 //!         let decompress = zlib.getattr("decompress")?;
-//!         let bytes = PyBytes::new_bound(py, bytes);
+//!         let bytes = PyBytes::new(py, bytes);
 //!         let value = decompress.call1((bytes,))?;
 //!         value.extract::<Vec<u8>>()
 //!     })?;

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -75,7 +75,7 @@
 //!     let res = Python::with_gil(|py| {
 //!         let zlib = PyModule::import_bound(py, "zlib")?;
 //!         let decompress = zlib.getattr("decompress")?;
-//!         let bytes = PyBytes::new_bound(py, bytes);
+//!         let bytes = PyBytes::new(py, bytes);
 //!         let value = decompress.call1((bytes,))?;
 //!         value.extract::<Vec<u8>>()
 //!     })?;

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -112,7 +112,7 @@ macro_rules! bigint_conversion {
             #[cfg(Py_LIMITED_API)]
             fn to_object(&self, py: Python<'_>) -> PyObject {
                 let bytes = $to_bytes(self);
-                let bytes_obj = PyBytes::new_bound(py, &bytes);
+                let bytes_obj = PyBytes::new(py, &bytes);
                 let kwargs = if $is_signed {
                     let kwargs = crate::types::PyDict::new_bound(py);
                     kwargs.set_item(crate::intern!(py, "signed"), true).unwrap();

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -9,7 +9,7 @@ use crate::{
 
 impl<'a> IntoPy<PyObject> for &'a [u8] {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyBytes::new_bound(py, self).unbind().into()
+        PyBytes::new(py, self).unbind().into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -52,7 +52,7 @@ impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for Cow<'a, [u8]> {
 
 impl ToPyObject for Cow<'_, [u8]> {
     fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
-        PyBytes::new_bound(py, self.as_ref()).into()
+        PyBytes::new(py, self.as_ref()).into()
     }
 }
 

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -207,7 +207,7 @@ impl ToPyObject for PyBackedBytes {
     fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
         match &self.storage {
             PyBackedBytesStorage::Python(bytes) => bytes.to_object(py),
-            PyBackedBytesStorage::Rust(bytes) => PyBytes::new_bound(py, bytes).into_any().unbind(),
+            PyBackedBytesStorage::Rust(bytes) => PyBytes::new(py, bytes).into_any().unbind(),
         }
     }
 }
@@ -216,7 +216,7 @@ impl IntoPy<Py<PyAny>> for PyBackedBytes {
     fn into_py(self, py: Python<'_>) -> Py<PyAny> {
         match self.storage {
             PyBackedBytesStorage::Python(bytes) => bytes.into_any(),
-            PyBackedBytesStorage::Rust(bytes) => PyBytes::new_bound(py, &bytes).into_any().unbind(),
+            PyBackedBytesStorage::Rust(bytes) => PyBytes::new(py, &bytes).into_any().unbind(),
         }
     }
 }
@@ -355,7 +355,7 @@ mod test {
     #[test]
     fn py_backed_bytes_empty() {
         Python::with_gil(|py| {
-            let b = PyBytes::new_bound(py, b"");
+            let b = PyBytes::new(py, b"");
             let py_backed_bytes = b.extract::<PyBackedBytes>().unwrap();
             assert_eq!(&*py_backed_bytes, b"");
         });
@@ -364,7 +364,7 @@ mod test {
     #[test]
     fn py_backed_bytes() {
         Python::with_gil(|py| {
-            let b = PyBytes::new_bound(py, b"abcde");
+            let b = PyBytes::new(py, b"abcde");
             let py_backed_bytes = b.extract::<PyBackedBytes>().unwrap();
             assert_eq!(&*py_backed_bytes, b"abcde");
         });
@@ -373,7 +373,7 @@ mod test {
     #[test]
     fn py_backed_bytes_from_bytes() {
         Python::with_gil(|py| {
-            let b = PyBytes::new_bound(py, b"abcde");
+            let b = PyBytes::new(py, b"abcde");
             let py_backed_bytes = PyBackedBytes::from(b);
             assert_eq!(&*py_backed_bytes, b"abcde");
         });
@@ -391,7 +391,7 @@ mod test {
     #[test]
     fn py_backed_bytes_into_py() {
         Python::with_gil(|py| {
-            let orig_bytes = PyBytes::new_bound(py, b"abcde");
+            let orig_bytes = PyBytes::new(py, b"abcde");
             let py_backed_bytes = PyBackedBytes::from(orig_bytes.clone());
             assert!(py_backed_bytes.to_object(py).is(&orig_bytes));
             assert!(py_backed_bytes.into_py(py).is(&orig_bytes));
@@ -495,7 +495,7 @@ mod test {
     #[test]
     fn test_backed_bytes_from_bytes_clone() {
         Python::with_gil(|py| {
-            let b1: PyBackedBytes = PyBytes::new_bound(py, b"abcde").into();
+            let b1: PyBackedBytes = PyBytes::new(py, b"abcde").into();
             let b2 = b1.clone();
             assert_eq!(b1, b2);
 
@@ -520,13 +520,13 @@ mod test {
     #[test]
     fn test_backed_bytes_eq() {
         Python::with_gil(|py| {
-            let b1: PyBackedBytes = PyBytes::new_bound(py, b"abcde").into();
+            let b1: PyBackedBytes = PyBytes::new(py, b"abcde").into();
             let b2: PyBackedBytes = PyByteArray::new_bound(py, b"abcde").into();
 
             assert_eq!(b1, b"abcde");
             assert_eq!(b1, b2);
 
-            let b3: PyBackedBytes = PyBytes::new_bound(py, b"hello").into();
+            let b3: PyBackedBytes = PyBytes::new(py, b"hello").into();
             assert_eq!(b"hello", b3);
             assert_ne!(b1, b3);
         });
@@ -541,7 +541,7 @@ mod test {
                 hasher.finish()
             };
 
-            let b1: PyBackedBytes = PyBytes::new_bound(py, b"abcde").into();
+            let b1: PyBackedBytes = PyBytes::new(py, b"abcde").into();
             let h1 = {
                 let mut hasher = DefaultHasher::new();
                 b1.hash(&mut hasher);
@@ -566,7 +566,7 @@ mod test {
             let mut a = vec![b"a", b"c", b"d", b"b", b"f", b"g", b"e"];
             let mut b = a
                 .iter()
-                .map(|&b| PyBytes::new_bound(py, b).into())
+                .map(|&b| PyBytes::new(py, b).into())
                 .collect::<Vec<PyBackedBytes>>();
 
             a.sort();

--- a/src/tests/hygiene/pymethods.rs
+++ b/src/tests/hygiene/pymethods.rs
@@ -21,7 +21,7 @@ impl Dummy {
     }
 
     fn __bytes__<'py>(&self, py: crate::Python<'py>) -> crate::Bound<'py, crate::types::PyBytes> {
-        crate::types::PyBytes::new_bound(py, &[0])
+        crate::types::PyBytes::new(py, &[0])
     }
 
     fn __format__(&self, format_spec: ::std::string::String) -> ::std::string::String {

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -21,7 +21,7 @@ fn test_pybytes_bytes_conversion() {
 
 #[pyfunction]
 fn bytes_vec_conversion(py: Python<'_>, bytes: Vec<u8>) -> Bound<'_, PyBytes> {
-    PyBytes::new_bound(py, bytes.as_slice())
+    PyBytes::new(py, bytes.as_slice())
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn test_bytearray_vec_conversion() {
 #[test]
 fn test_py_as_bytes() {
     let pyobj: pyo3::Py<pyo3::types::PyBytes> =
-        Python::with_gil(|py| pyo3::types::PyBytes::new_bound(py, b"abc").unbind());
+        Python::with_gil(|py| pyo3::types::PyBytes::new(py, b"abc").unbind());
 
     let data = Python::with_gil(|py| pyobj.as_bytes(py));
 


### PR DESCRIPTION
Add back the `PyBytes` constructors without `_bound`.