### PR TITLE
Reintroduce `PyDict` constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ fn main() -> PyResult<()> {
         let sys = py.import_bound("sys")?;
         let version: String = sys.getattr("version")?.extract()?;
 
-        let locals = [("os", py.import_bound("os")?)].into_py_dict_bound(py);
+        let locals = [("os", py.import_bound("os")?)].into_py_dict(py);
         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
         let user: String = py.eval_bound(code, None, Some(&locals))?.extract()?;
 

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -86,7 +86,7 @@ struct RustyStruct {
 # use pyo3::types::PyDict;
 # fn main() -> PyResult<()> {
 #     Python::with_gil(|py| -> PyResult<()> {
-#         let dict = PyDict::new_bound(py);
+#         let dict = PyDict::new(py);
 #         dict.set_item("my_string", "test")?;
 #
 #         let rustystruct: RustyStruct = dict.extract()?;

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -24,7 +24,7 @@ use pyo3::exceptions::PyException;
 create_exception!(mymodule, CustomError, PyException);
 
 Python::with_gil(|py| {
-    let ctx = [("CustomError", py.get_type_bound::<CustomError>())].into_py_dict_bound(py);
+    let ctx = [("CustomError", py.get_type_bound::<CustomError>())].into_py_dict(py);
     pyo3::py_run!(
         py,
         *ctx,

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -41,6 +41,57 @@ let tup = PyTuple::new(py, [1, 2, 3]);
 ```
 </details>
 
+### Renamed `IntoPyDict::into_py_dict_bound` into `IntoPyDict::into_py_dict`.
+<details open>
+<summary><small>Click to expand</small></summary>
+
+The `IntoPyDict::into_py_dict_bound` method has been renamed to `IntoPyDict::into_py_dict`. If you implemented `IntoPyDict` for your type, you should implement `into_py_dict` instead of `into_py_dict_bound`. The old name is still available but deprecated.
+
+Before:
+
+```rust,ignore
+# use pyo3::prelude::*;
+# use pyo3::types::{PyDict, IntoPyDict};
+# use pyo3::types::dict::PyDictItem;
+impl<T, I> IntoPyDict for I
+where
+    T: PyDictItem,
+    I: IntoIterator<Item = T>,
+{
+    fn into_py_dict_bound(self, py: Python<'_>) -> Bound<'_, PyDict> {
+        let dict = PyDict::new(py);
+        for item in self {
+            dict.set_item(item.key(), item.value())
+                .expect("Failed to set_item on dict");
+        }
+        dict
+    }
+}
+```
+
+After:
+
+```rust,ignore
+# use pyo3::prelude::*;
+# use pyo3::types::{PyDict, IntoPyDict};
+# use pyo3::types::dict::PyDictItem;
+impl<T, I> IntoPyDict for I
+where
+    T: PyDictItem,
+    I: IntoIterator<Item = T>,
+{
+    fn into_py_dict(self, py: Python<'_>) -> Bound<'_, PyDict> {
+        let dict = PyDict::new(py);
+        for item in self {
+            dict.set_item(item.key(), item.value())
+                .expect("Failed to set_item on dict");
+        }
+        dict
+    }
+}
+```
+</details>
+
 ## from 0.21.* to 0.22
 
 ### Deprecation of `gil-refs` feature continues

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -89,7 +89,7 @@ fn func() -> String {
 #    use pyo3::wrap_pymodule;
 #    use pyo3::types::IntoPyDict;
 #    let parent_module = wrap_pymodule!(parent_module)(py);
-#    let ctx = [("parent_module", parent_module)].into_py_dict_bound(py);
+#    let ctx = [("parent_module", parent_module)].into_py_dict(py);
 #
 #    py.run_bound("assert parent_module.child_module.func() == 'func'", None, Some(&ctx)).unwrap();
 # })

--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -126,7 +126,7 @@ def leaky_relu(x, slope=0.01):
     let relu_result: f64 = activators.getattr("relu")?.call1((-1.0,))?.extract()?;
     assert_eq!(relu_result, 0.0);
 
-    let kwargs = [("slope", 0.2)].into_py_dict_bound(py);
+    let kwargs = [("slope", 0.2)].into_py_dict(py);
     let lrelu_result: f64 = activators
         .getattr("leaky_relu")?
         .call((-1.0,), Some(&kwargs))?

--- a/guide/src/python-from-rust/function-calls.md
+++ b/guide/src/python-from-rust/function-calls.md
@@ -88,17 +88,17 @@ fn main() -> PyResult<()> {
         .into();
 
         // call object with PyDict
-        let kwargs = [(key1, val1)].into_py_dict_bound(py);
+        let kwargs = [(key1, val1)].into_py_dict(py);
         fun.call_bound(py, (), Some(&kwargs))?;
 
         // pass arguments as Vec
         let kwargs = vec![(key1, val1), (key2, val2)];
-        fun.call_bound(py, (), Some(&kwargs.into_py_dict_bound(py)))?;
+        fun.call_bound(py, (), Some(&kwargs.into_py_dict(py)))?;
 
         // pass arguments as HashMap
         let mut kwargs = HashMap::<&str, i32>::new();
         kwargs.insert(key1, 1);
-        fun.call_bound(py, (), Some(&kwargs.into_py_dict_bound(py)))?;
+        fun.call_bound(py, (), Some(&kwargs.into_py_dict(py)))?;
 
         Ok(())
     })

--- a/newsfragments/4388.changed.md
+++ b/newsfragments/4388.changed.md
@@ -1,0 +1,1 @@
+Renamed `IntoPyDict::into_py_dict_bound` into `IntoPyDict::into_py_dict`.

--- a/pyo3-benches/benches/bench_bigint.rs
+++ b/pyo3-benches/benches/bench_bigint.rs
@@ -8,7 +8,7 @@ use pyo3::types::PyDict;
 
 fn extract_bigint_extract_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let d = PyDict::new_bound(py).into_any();
+        let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).extract::<BigInt>() {
             Ok(v) => panic!("should err {}", v),

--- a/pyo3-benches/benches/bench_decimal.rs
+++ b/pyo3-benches/benches/bench_decimal.rs
@@ -8,7 +8,7 @@ use pyo3::types::PyDict;
 
 fn decimal_via_extract(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let locals = PyDict::new_bound(py);
+        let locals = PyDict::new(py);
         py.run_bound(
             r#"
 import decimal

--- a/pyo3-benches/benches/bench_dict.rs
+++ b/pyo3-benches/benches/bench_dict.rs
@@ -9,7 +9,7 @@ use pyo3::{prelude::*, types::PyMapping};
 fn iter_dict(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
-        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py);
+        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
         let mut sum = 0;
         b.iter(|| {
             for (k, _v) in &dict {
@@ -23,14 +23,14 @@ fn iter_dict(b: &mut Bencher<'_>) {
 fn dict_new(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
-        b.iter_with_large_drop(|| (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py));
+        b.iter_with_large_drop(|| (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py));
     });
 }
 
 fn dict_get_item(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50_000;
-        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py);
+        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
         let mut sum = 0;
         b.iter(|| {
             for i in 0..LEN {
@@ -48,7 +48,7 @@ fn dict_get_item(b: &mut Bencher<'_>) {
 fn extract_hashmap(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
-        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py);
+        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
         b.iter(|| HashMap::<u64, u64>::extract_bound(&dict));
     });
 }
@@ -56,7 +56,7 @@ fn extract_hashmap(b: &mut Bencher<'_>) {
 fn extract_btreemap(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
-        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py);
+        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
         b.iter(|| BTreeMap::<u64, u64>::extract_bound(&dict));
     });
 }
@@ -65,7 +65,7 @@ fn extract_btreemap(b: &mut Bencher<'_>) {
 fn extract_hashbrown_map(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
-        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py);
+        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
         b.iter(|| hashbrown::HashMap::<u64, u64>::extract_bound(&dict));
     });
 }
@@ -73,7 +73,7 @@ fn extract_hashbrown_map(b: &mut Bencher<'_>) {
 fn mapping_from_dict(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 100_000;
-        let dict = &(0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py);
+        let dict = &(0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
         b.iter(|| black_box(dict).downcast::<PyMapping>().unwrap());
     });
 }

--- a/pyo3-benches/benches/bench_extract.rs
+++ b/pyo3-benches/benches/bench_extract.rs
@@ -17,7 +17,7 @@ fn extract_str_extract_success(bench: &mut Bencher<'_>) {
 
 fn extract_str_extract_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let d = PyDict::new_bound(py).into_any();
+        let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).extract::<&str>() {
             Ok(v) => panic!("should err {}", v),
@@ -40,7 +40,7 @@ fn extract_str_downcast_success(bench: &mut Bencher<'_>) {
 
 fn extract_str_downcast_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let d = PyDict::new_bound(py).into_any();
+        let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).downcast::<PyString>() {
             Ok(v) => panic!("should err {}", v),
@@ -59,7 +59,7 @@ fn extract_int_extract_success(bench: &mut Bencher<'_>) {
 
 fn extract_int_extract_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let d = PyDict::new_bound(py).into_any();
+        let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).extract::<i64>() {
             Ok(v) => panic!("should err {}", v),
@@ -81,7 +81,7 @@ fn extract_int_downcast_success(bench: &mut Bencher<'_>) {
 
 fn extract_int_downcast_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let d = PyDict::new_bound(py).into_any();
+        let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).downcast::<PyInt>() {
             Ok(v) => panic!("should err {}", v),
@@ -100,7 +100,7 @@ fn extract_float_extract_success(bench: &mut Bencher<'_>) {
 
 fn extract_float_extract_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let d = PyDict::new_bound(py).into_any();
+        let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).extract::<f64>() {
             Ok(v) => panic!("should err {}", v),
@@ -122,7 +122,7 @@ fn extract_float_downcast_success(bench: &mut Bencher<'_>) {
 
 fn extract_float_downcast_fail(bench: &mut Bencher<'_>) {
     Python::with_gil(|py| {
-        let d = PyDict::new_bound(py).into_any();
+        let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).downcast::<PyFloat>() {
             Ok(v) => panic!("should err {}", v),

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -146,7 +146,7 @@ mod test_anyhow {
         let pyerr = PyErr::from(err);
 
         Python::with_gil(|py| {
-            let locals = [("err", pyerr)].into_py_dict_bound(py);
+            let locals = [("err", pyerr)].into_py_dict(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
@@ -163,7 +163,7 @@ mod test_anyhow {
         let pyerr = PyErr::from(err);
 
         Python::with_gil(|py| {
-            let locals = [("err", pyerr)].into_py_dict_bound(py);
+            let locals = [("err", pyerr)].into_py_dict(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1108,7 +1108,7 @@ mod tests {
             fn test_pyo3_offset_fixed_frompyobject_created_in_python(timestamp in 0..(i32::MAX as i64), timedelta in -86399i32..=86399i32) {
                 Python::with_gil(|py| {
 
-                    let globals = [("datetime", py.import_bound("datetime").unwrap())].into_py_dict_bound(py);
+                    let globals = [("datetime", py.import_bound("datetime").unwrap())].into_py_dict(py);
                     let code = format!("datetime.datetime.fromtimestamp({}).replace(tzinfo=datetime.timezone(datetime.timedelta(seconds={})))", timestamp, timedelta);
                     let t = py.eval_bound(&code, Some(&globals), None).unwrap();
 

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -578,7 +578,7 @@ mod tests {
         use crate::types::dict::PyDictMethods;
 
         Python::with_gil(|py| {
-            let locals = crate::types::PyDict::new_bound(py);
+            let locals = crate::types::PyDict::new(py);
             py.run_bound(
                 "import zoneinfo; zi = zoneinfo.ZoneInfo('Europe/London')",
                 None,

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -151,7 +151,7 @@ mod tests {
         let pyerr = PyErr::from(err);
 
         Python::with_gil(|py| {
-            let locals = [("err", pyerr)].into_py_dict_bound(py);
+            let locals = [("err", pyerr)].into_py_dict(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
@@ -168,7 +168,7 @@ mod tests {
         let pyerr = PyErr::from(err);
 
         Python::with_gil(|py| {
-            let locals = [("err", pyerr)].into_py_dict_bound(py);
+            let locals = [("err", pyerr)].into_py_dict(py);
             let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -33,7 +33,7 @@ where
     H: hash::BuildHasher,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        IntoPyDict::into_py_dict_bound(self, py).into()
+        IntoPyDict::into_py_dict(self, py).into()
     }
 }
 
@@ -47,7 +47,7 @@ where
         let iter = self
             .into_iter()
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
-        IntoPyDict::into_py_dict_bound(iter, py).into()
+        IntoPyDict::into_py_dict(iter, py).into()
     }
 }
 
@@ -163,7 +163,7 @@ mod tests {
             let mut map = hashbrown::HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let py_map = map.into_py_dict_bound(py);
+            let py_map = map.into_py_dict(py);
 
             assert_eq!(py_map.len(), 1);
             assert_eq!(

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -98,7 +98,7 @@ where
     H: hash::BuildHasher,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        IntoPyDict::into_py_dict_bound(self, py).into()
+        IntoPyDict::into_py_dict(self, py).into()
     }
 }
 
@@ -112,7 +112,7 @@ where
         let iter = self
             .into_iter()
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
-        IntoPyDict::into_py_dict_bound(iter, py).into()
+        IntoPyDict::into_py_dict(iter, py).into()
     }
 }
 
@@ -192,7 +192,7 @@ mod test_indexmap {
             let mut map = indexmap::IndexMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let py_map = map.into_py_dict_bound(py);
+            let py_map = map.into_py_dict(py);
 
             assert_eq!(py_map.len(), 1);
             assert_eq!(
@@ -221,7 +221,7 @@ mod test_indexmap {
                 }
             }
 
-            let py_map = map.clone().into_py_dict_bound(py);
+            let py_map = map.clone().into_py_dict(py);
 
             let trip_map = py_map.extract::<indexmap::IndexMap<i32, i32>>().unwrap();
 

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -114,7 +114,7 @@ macro_rules! bigint_conversion {
                 let bytes = $to_bytes(self);
                 let bytes_obj = PyBytes::new(py, &bytes);
                 let kwargs = if $is_signed {
-                    let kwargs = crate::types::PyDict::new_bound(py);
+                    let kwargs = crate::types::PyDict::new(py);
                     kwargs.set_item(crate::intern!(py, "signed"), true).unwrap();
                     Some(kwargs)
                 } else {
@@ -297,7 +297,7 @@ fn int_to_py_bytes<'py>(
     use crate::intern;
     let py = long.py();
     let kwargs = if is_signed {
-        let kwargs = crate::types::PyDict::new_bound(py);
+        let kwargs = crate::types::PyDict::new(py);
         kwargs.set_item(intern!(py, "signed"), true)?;
         Some(kwargs)
     } else {
@@ -414,7 +414,7 @@ mod tests {
     fn convert_index_class() {
         Python::with_gil(|py| {
             let index = python_index_class(py);
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             locals.set_item("index", index).unwrap();
             let ob = py.eval_bound("index.C(10)", None, Some(&locals)).unwrap();
             let _: BigInt = ob.extract().unwrap();

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn test_negative_fraction() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             py.run_bound(
                 "import fractions\npy_frac = fractions.Fraction(-0.125)",
                 None,
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn test_obj_with_incorrect_atts() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             py.run_bound(
                 "not_fraction = \"contains_incorrect_atts\"",
                 None,
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn test_fraction_with_fraction_type() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             py.run_bound(
                 "import fractions\npy_frac = fractions.Fraction(fractions.Fraction(10))",
                 None,
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn test_fraction_with_decimal() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             py.run_bound(
                 "import fractions\n\nfrom decimal import Decimal\npy_frac = fractions.Fraction(Decimal(\"1.1\"))",
                 None,
@@ -180,7 +180,7 @@ mod tests {
     #[test]
     fn test_fraction_with_num_den() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             py.run_bound(
                 "import fractions\npy_frac = fractions.Fraction(10,5)",
                 None,
@@ -245,7 +245,7 @@ mod tests {
     #[test]
     fn test_infinity() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             let py_bound = py.run_bound(
                 "import fractions\npy_frac = fractions.Fraction(\"Infinity\")",
                 None,

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -116,7 +116,7 @@ mod test_rust_decimal {
                 Python::with_gil(|py| {
                     let rs_orig = $rs;
                     let rs_dec = rs_orig.into_py(py);
-                    let locals = PyDict::new_bound(py);
+                    let locals = PyDict::new(py);
                     locals.set_item("rs_dec", &rs_dec).unwrap();
                     // Checks if Rust Decimal -> Python Decimal conversion is correct
                     py.run_bound(
@@ -158,7 +158,7 @@ mod test_rust_decimal {
             let num = Decimal::from_parts(lo, mid, high, negative, scale);
             Python::with_gil(|py| {
                 let rs_dec = num.into_py(py);
-                let locals = PyDict::new_bound(py);
+                let locals = PyDict::new(py);
                 locals.set_item("rs_dec", &rs_dec).unwrap();
                 py.run_bound(
                     &format!(
@@ -184,7 +184,7 @@ mod test_rust_decimal {
     #[test]
     fn test_nan() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             py.run_bound(
                 "import decimal\npy_dec = decimal.Decimal(\"NaN\")",
                 None,
@@ -200,7 +200,7 @@ mod test_rust_decimal {
     #[test]
     fn test_scientific_notation() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             py.run_bound(
                 "import decimal\npy_dec = decimal.Decimal(\"1e3\")",
                 None,
@@ -217,7 +217,7 @@ mod test_rust_decimal {
     #[test]
     fn test_infinity() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             py.run_bound(
                 "import decimal\npy_dec = decimal.Decimal(\"Infinity\")",
                 None,

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn test_smallvec_from_py_object_fails() {
         Python::with_gil(|py| {
-            let dict = PyDict::new_bound(py);
+            let dict = PyDict::new(py);
             let sv: PyResult<SmallVec<[u64; 8]>> = dict.extract();
             assert_eq!(
                 sv.unwrap_err().to_string(),

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -16,7 +16,7 @@ where
     H: hash::BuildHasher,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        IntoPyDict::into_py_dict_bound(self, py).into()
+        IntoPyDict::into_py_dict(self, py).into()
     }
 }
 
@@ -26,7 +26,7 @@ where
     V: ToPyObject,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        IntoPyDict::into_py_dict_bound(self, py).into()
+        IntoPyDict::into_py_dict(self, py).into()
     }
 }
 
@@ -40,7 +40,7 @@ where
         let iter = self
             .into_iter()
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
-        IntoPyDict::into_py_dict_bound(iter, py).into()
+        IntoPyDict::into_py_dict(iter, py).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -58,7 +58,7 @@ where
         let iter = self
             .into_iter()
             .map(|(k, v)| (k.into_py(py), v.into_py(py)));
-        IntoPyDict::into_py_dict_bound(iter, py).into()
+        IntoPyDict::into_py_dict(iter, py).into()
     }
 
     #[cfg(feature = "experimental-inspect")]

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -436,7 +436,7 @@ mod test_128bit_integers {
         fn test_i128_roundtrip(x: i128) {
             Python::with_gil(|py| {
                 let x_py = x.into_py(py);
-                let locals = PyDict::new_bound(py);
+                let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
                 py.run_bound(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
                 let roundtripped: i128 = x_py.extract(py).unwrap();
@@ -452,7 +452,7 @@ mod test_128bit_integers {
         ) {
             Python::with_gil(|py| {
                 let x_py = x.into_py(py);
-                let locals = PyDict::new_bound(py);
+                let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
                 py.run_bound(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
                 let roundtripped: NonZeroI128 = x_py.extract(py).unwrap();
@@ -467,7 +467,7 @@ mod test_128bit_integers {
         fn test_u128_roundtrip(x: u128) {
             Python::with_gil(|py| {
                 let x_py = x.into_py(py);
-                let locals = PyDict::new_bound(py);
+                let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
                 py.run_bound(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
                 let roundtripped: u128 = x_py.extract(py).unwrap();
@@ -483,7 +483,7 @@ mod test_128bit_integers {
         ) {
             Python::with_gil(|py| {
                 let x_py = x.into_py(py);
-                let locals = PyDict::new_bound(py);
+                let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
                 py.run_bound(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
                 let roundtripped: NonZeroU128 = x_py.extract(py).unwrap();

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -348,7 +348,7 @@ mod tests {
 
     fn max_datetime(py: Python<'_>) -> Bound<'_, PyAny> {
         let naive_max = datetime_class(py).getattr("max").unwrap();
-        let kargs = PyDict::new_bound(py);
+        let kargs = PyDict::new(py);
         kargs.set_item("tzinfo", tz_utc(py)).unwrap();
         naive_max.call_method("replace", (), Some(&kargs)).unwrap()
     }

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -62,7 +62,7 @@ macro_rules! impl_exception_boilerplate_bound {
 /// import_exception!(socket, gaierror);
 ///
 /// Python::with_gil(|py| {
-///     let ctx = [("gaierror", py.get_type_bound::<gaierror>())].into_py_dict_bound(py);
+///     let ctx = [("gaierror", py.get_type_bound::<gaierror>())].into_py_dict(py);
 ///     pyo3::py_run!(py, *ctx, "import socket; assert gaierror is socket.gaierror");
 /// });
 ///
@@ -874,7 +874,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let error_type = py.get_type_bound::<CustomError>();
-            let ctx = [("CustomError", error_type)].into_py_dict_bound(py);
+            let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
                 .eval_bound("str(CustomError)", None, Some(&ctx))
                 .unwrap()
@@ -897,7 +897,7 @@ mod tests {
         create_exception!(mymodule.exceptions, CustomError, PyException);
         Python::with_gil(|py| {
             let error_type = py.get_type_bound::<CustomError>();
-            let ctx = [("CustomError", error_type)].into_py_dict_bound(py);
+            let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
                 .eval_bound("str(CustomError)", None, Some(&ctx))
                 .unwrap()
@@ -916,7 +916,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let error_type = py.get_type_bound::<CustomError>();
-            let ctx = [("CustomError", error_type)].into_py_dict_bound(py);
+            let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
                 .eval_bound("str(CustomError)", None, Some(&ctx))
                 .unwrap()
@@ -949,7 +949,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let error_type = py.get_type_bound::<CustomError>();
-            let ctx = [("CustomError", error_type)].into_py_dict_bound(py);
+            let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
                 .eval_bound("str(CustomError)", None, Some(&ctx))
                 .unwrap()

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -175,7 +175,7 @@ macro_rules! import_exception_bound {
 /// # fn main() -> PyResult<()> {
 /// #     Python::with_gil(|py| -> PyResult<()> {
 /// #         let fun = wrap_pyfunction!(raise_myerror, py)?;
-/// #         let locals = pyo3::types::PyDict::new_bound(py);
+/// #         let locals = pyo3::types::PyDict::new(py);
 /// #         locals.set_item("MyError", py.get_type_bound::<MyError>())?;
 /// #         locals.set_item("raise_myerror", fun)?;
 /// #
@@ -826,7 +826,7 @@ mod tests {
                 .map_err(|e| e.display(py))
                 .expect("could not import socket");
 
-            let d = PyDict::new_bound(py);
+            let d = PyDict::new(py);
             d.set_item("socket", socket)
                 .map_err(|e| e.display(py))
                 .expect("could not setitem");
@@ -850,7 +850,7 @@ mod tests {
                 .map_err(|e| e.display(py))
                 .expect("could not import email");
 
-            let d = PyDict::new_bound(py);
+            let d = PyDict::new(py);
             d.set_item("email", email)
                 .map_err(|e| e.display(py))
                 .expect("could not setitem");

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -20,7 +20,7 @@ fn test_datetime_fromtimestamp() {
             PyDateTime_IMPORT();
             Bound::from_owned_ptr(py, PyDateTime_FromTimestamp(args.as_ptr()))
         };
-        let locals = PyDict::new_bound(py);
+        let locals = PyDict::new(py);
         locals.set_item("dt", dt).unwrap();
         py.run_bound(
             "import datetime; assert dt == datetime.datetime.fromtimestamp(100)",
@@ -41,7 +41,7 @@ fn test_date_fromtimestamp() {
             PyDateTime_IMPORT();
             Bound::from_owned_ptr(py, PyDate_FromTimestamp(args.as_ptr()))
         };
-        let locals = PyDict::new_bound(py);
+        let locals = PyDict::new(py);
         locals.set_item("dt", dt).unwrap();
         py.run_bound(
             "import datetime; assert dt == datetime.date.fromtimestamp(100)",
@@ -61,7 +61,7 @@ fn test_utc_timezone() {
             PyDateTime_IMPORT();
             Bound::from_borrowed_ptr(py, PyDateTime_TimeZone_UTC())
         };
-        let locals = PyDict::new_bound(py);
+        let locals = PyDict::new(py);
         locals.set_item("utc_timezone", utc_timezone).unwrap();
         py.run_bound(
             "import datetime; assert utc_timezone is datetime.timezone.utc",

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -808,7 +808,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let args = PyTuple::empty(py);
-            let kwargs = [("foo", 0u8)].into_py_dict_bound(py);
+            let kwargs = [("foo", 0u8)].into_py_dict(py);
             let err = unsafe {
                 function_description
                     .extract_arguments_tuple_dict::<NoVarargs, NoVarkeywords>(
@@ -839,7 +839,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let args = PyTuple::empty(py);
-            let kwargs = [(1u8, 1u8)].into_py_dict_bound(py);
+            let kwargs = [(1u8, 1u8)].into_py_dict(py);
             let err = unsafe {
                 function_description
                     .extract_arguments_tuple_dict::<NoVarargs, NoVarkeywords>(

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -762,7 +762,7 @@ impl<'py> VarkeywordsHandler<'py> for DictVarkeywords {
         _function_description: &FunctionDescription,
     ) -> PyResult<()> {
         varkeywords
-            .get_or_insert_with(|| PyDict::new_bound(name.py()))
+            .get_or_insert_with(|| PyDict::new(name.py()))
             .set_item(name, value)
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -786,7 +786,7 @@ impl<T> IntoPy<PyObject> for Borrowed<'_, '_, T> {
 ///
 ///             // `Bound<'py, PyDict>` inherits the GIL lifetime from `py` and
 ///             // so won't be able to outlive this closure.
-///             let dict: Bound<'_, PyDict> = PyDict::new_bound(py);
+///             let dict: Bound<'_, PyDict> = PyDict::new(py);
 ///
 ///             // because `Foo` contains `dict` its lifetime
 ///             // is now also tied to `py`.
@@ -815,7 +815,7 @@ impl<T> IntoPy<PyObject> for Borrowed<'_, '_, T> {
 ///     #[new]
 ///     fn __new__() -> Foo {
 ///         Python::with_gil(|py| {
-///             let dict: Py<PyDict> = PyDict::new_bound(py).unbind();
+///             let dict: Py<PyDict> = PyDict::new(py).unbind();
 ///             Foo { inner: dict }
 ///         })
 ///     }
@@ -887,7 +887,7 @@ impl<T> IntoPy<PyObject> for Borrowed<'_, '_, T> {
 ///
 /// # fn main() {
 /// Python::with_gil(|py| {
-///     let first: Py<PyDict> = PyDict::new_bound(py).unbind();
+///     let first: Py<PyDict> = PyDict::new(py).unbind();
 ///
 ///     // All of these are valid syntax
 ///     let second = Py::clone_ref(&first, py);
@@ -1229,7 +1229,7 @@ impl<T> Py<T> {
     ///
     /// # fn main() {
     /// Python::with_gil(|py| {
-    ///     let first: Py<PyDict> = PyDict::new_bound(py).unbind();
+    ///     let first: Py<PyDict> = PyDict::new(py).unbind();
     ///     let second = Py::clone_ref(&first, py);
     ///
     ///     // Both point to the same object
@@ -1261,7 +1261,7 @@ impl<T> Py<T> {
     ///
     /// # fn main() {
     /// Python::with_gil(|py| {
-    ///     let object: Py<PyDict> = PyDict::new_bound(py).unbind();
+    ///     let object: Py<PyDict> = PyDict::new(py).unbind();
     ///
     ///     // some usage of object
     ///
@@ -1740,7 +1740,7 @@ impl PyObject {
     /// use pyo3::types::{PyDict, PyList};
     ///
     /// Python::with_gil(|py| {
-    ///     let any: PyObject = PyDict::new_bound(py).into();
+    ///     let any: PyObject = PyDict::new(py).into();
     ///
     ///     assert!(any.downcast_bound::<PyDict>(py).is_ok());
     ///     assert!(any.downcast_bound::<PyList>(py).is_err());
@@ -1829,7 +1829,7 @@ mod tests {
     #[test]
     fn test_call_for_non_existing_method() {
         Python::with_gil(|py| {
-            let obj: PyObject = PyDict::new_bound(py).into();
+            let obj: PyObject = PyDict::new(py).into();
             assert!(obj.call_method0(py, "asdf").is_err());
             assert!(obj
                 .call_method_bound(py, "nonexistent_method", (1,), None)
@@ -1842,7 +1842,7 @@ mod tests {
     #[test]
     fn py_from_dict() {
         let dict: Py<PyDict> = Python::with_gil(|py| {
-            let native = PyDict::new_bound(py);
+            let native = PyDict::new(py);
             Py::from(native)
         });
 
@@ -1854,7 +1854,7 @@ mod tests {
     #[test]
     fn pyobject_from_py() {
         Python::with_gil(|py| {
-            let dict: Py<PyDict> = PyDict::new_bound(py).unbind();
+            let dict: Py<PyDict> = PyDict::new(py).unbind();
             let cnt = dict.get_refcnt(py);
             let p: PyObject = dict.into();
             assert_eq!(p.get_refcnt(py), cnt);
@@ -2074,7 +2074,7 @@ a = A()
     #[test]
     fn explicit_drop_ref() {
         Python::with_gil(|py| {
-            let object: Py<PyDict> = PyDict::new_bound(py).unbind();
+            let object: Py<PyDict> = PyDict::new(py).unbind();
             let object2 = object.clone_ref(py);
 
             assert_eq!(object.as_ptr(), object2.as_ptr());

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1818,7 +1818,7 @@ mod tests {
 
             assert_repr(obj.call1(py, ((('x', 1),),)).unwrap().bind(py), "{'x': 1}");
             assert_repr(
-                obj.call_bound(py, (), Some(&[('x', 1)].into_py_dict_bound(py)))
+                obj.call_bound(py, (), Some(&[('x', 1)].into_py_dict(py)))
                     .unwrap()
                     .bind(py),
                 "{'x': 1}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@
 //!         let sys = py.import_bound("sys")?;
 //!         let version: String = sys.getattr("version")?.extract()?;
 //!
-//!         let locals = [("os", py.import_bound("os")?)].into_py_dict_bound(py);
+//!         let locals = [("os", py.import_bound("os")?)].into_py_dict(py);
 //!         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
 //!         let user: String = py.eval_bound(code, None, Some(&locals))?.extract()?;
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,7 +73,7 @@
 /// }
 ///
 /// Python::with_gil(|py| {
-///     let locals = [("C", py.get_type_bound::<MyClass>())].into_py_dict_bound(py);
+///     let locals = [("C", py.get_type_bound::<MyClass>())].into_py_dict(py);
 ///     pyo3::py_run!(py, *locals, "c = C()");
 /// });
 /// ```
@@ -99,7 +99,7 @@ macro_rules! py_run_impl {
     ($py:expr, $($val:ident)+, $code:expr) => {{
         use $crate::types::IntoPyDict;
         use $crate::ToPyObject;
-        let d = [$((stringify!($val), $val.to_object($py)),)+].into_py_dict_bound($py);
+        let d = [$((stringify!($val), $val.to_object($py)),)+].into_py_dict($py);
         $crate::py_run_impl!($py, *d, $code)
     }};
     ($py:expr, *$dict:expr, $code:expr) => {{

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -815,7 +815,7 @@ mod tests {
                 .unwrap();
             assert_eq!(v, 1);
 
-            let d = [("foo", 13)].into_py_dict_bound(py);
+            let d = [("foo", 13)].into_py_dict(py);
 
             // Inject our own global namespace
             let v: i32 = py

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -557,7 +557,7 @@ impl<'py> Python<'py> {
     ///     types::{PyBytes, PyDict},
     /// };
     /// Python::with_gil(|py| {
-    ///     let locals = PyDict::new_bound(py);
+    ///     let locals = PyDict::new(py);
     ///     py.run_bound(
     ///         r#"
     /// import base64
@@ -943,7 +943,7 @@ mod tests {
         use crate::types::dict::PyDictMethods;
 
         Python::with_gil(|py| {
-            let namespace = PyDict::new_bound(py);
+            let namespace = PyDict::new(py);
             py.run_bound("class Foo: pass", Some(&namespace), Some(&namespace))
                 .unwrap();
             assert!(matches!(namespace.get_item("Foo"), Ok(Some(..))));

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -24,7 +24,7 @@ pub const VERSION: i32 = 4;
 /// ```
 /// # use pyo3::{marshal, types::PyDict, prelude::PyDictMethods};
 /// # pyo3::Python::with_gil(|py| {
-/// let dict = PyDict::new_bound(py);
+/// let dict = PyDict::new(py);
 /// dict.set_item("aap", "noot").unwrap();
 /// dict.set_item("mies", "wim").unwrap();
 /// dict.set_item("zus", "jet").unwrap();
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn marshal_roundtrip() {
         Python::with_gil(|py| {
-            let dict = PyDict::new_bound(py);
+            let dict = PyDict::new(py);
             dict.set_item("aap", "noot").unwrap();
             dict.set_item("mies", "wim").unwrap();
             dict.set_item("zus", "jet").unwrap();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -231,7 +231,7 @@ impl GILOnceCell<Py<PyType>> {
 ///
 /// #[pyfunction]
 /// fn create_dict(py: Python<'_>) -> PyResult<Bound<'_, PyDict>> {
-///     let dict = PyDict::new_bound(py);
+///     let dict = PyDict::new(py);
 ///     //             👇 A new `PyString` is created
 ///     //                for every call of this function.
 ///     dict.set_item("foo", 42)?;
@@ -240,7 +240,7 @@ impl GILOnceCell<Py<PyType>> {
 ///
 /// #[pyfunction]
 /// fn create_dict_faster(py: Python<'_>) -> PyResult<Bound<'_, PyDict>> {
-///     let dict = PyDict::new_bound(py);
+///     let dict = PyDict::new(py);
 ///     //               👇 A `PyString` is created once and reused
 ///     //                  for the lifetime of the program.
 ///     dict.set_item(intern!(py, "foo"), 42)?;
@@ -296,7 +296,7 @@ mod tests {
             let foo2 = intern!(py, "foo");
             let foo3 = intern!(py, stringify!(foo));
 
-            let dict = PyDict::new_bound(py);
+            let dict = PyDict::new(py);
             dict.set_item(foo1, 42_usize).unwrap();
             assert!(dict.contains(foo2).unwrap());
             assert_eq!(

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -35,7 +35,7 @@ mod inner {
         // Case1: idents & no err_msg
         ($py:expr, $($val:ident)+, $code:expr, $err:ident) => {{
             use pyo3::types::IntoPyDict;
-            let d = [$((stringify!($val), $val.to_object($py)),)+].into_py_dict_bound($py);
+            let d = [$((stringify!($val), $val.to_object($py)),)+].into_py_dict($py);
             py_expect_exception!($py, *d, $code, $err)
         }};
         // Case2: dict & no err_msg
@@ -119,7 +119,7 @@ mod inner {
             f: impl FnOnce(&Bound<'py, PyList>) -> PyResult<R>,
         ) -> PyResult<R> {
             let warnings = py.import_bound("warnings")?;
-            let kwargs = [("record", true)].into_py_dict_bound(py);
+            let kwargs = [("record", true)].into_py_dict(py);
             let catch_warnings = warnings
                 .getattr("catch_warnings")?
                 .call((), Some(&kwargs))?;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -424,7 +424,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///     let module = PyModule::from_code_bound(py, CODE, "", "")?;
     ///     let fun = module.getattr("function")?;
     ///     let args = ("hello",);
-    ///     let kwargs = PyDict::new_bound(py);
+    ///     let kwargs = PyDict::new(py);
     ///     kwargs.set_item("cruel", "world")?;
     ///     let result = fun.call(args, Some(&kwargs))?;
     ///     assert_eq!(result.extract::<String>()?, "called with args and kwargs");
@@ -516,7 +516,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///     let module = PyModule::from_code_bound(py, CODE, "", "")?;
     ///     let instance = module.getattr("a")?;
     ///     let args = ("hello",);
-    ///     let kwargs = PyDict::new_bound(py);
+    ///     let kwargs = PyDict::new(py);
     ///     kwargs.set_item("cruel", "world")?;
     ///     let result = instance.call_method("method", args, Some(&kwargs))?;
     ///     assert_eq!(result.extract::<String>()?, "called with args and kwargs");
@@ -676,7 +676,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::types::{PyDict, PyList};
     ///
     /// Python::with_gil(|py| {
-    ///     let dict = PyDict::new_bound(py);
+    ///     let dict = PyDict::new(py);
     ///     assert!(dict.is_instance_of::<PyAny>());
     ///     let any = dict.as_any();
     ///
@@ -728,7 +728,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::types::{PyDict, PyList};
     ///
     /// Python::with_gil(|py| {
-    ///     let obj: Bound<'_, PyAny> = PyDict::new_bound(py).into_any();
+    ///     let obj: Bound<'_, PyAny> = PyDict::new(py).into_any();
     ///
     ///     let obj: Bound<'_, PyAny> = match obj.downcast_into::<PyList>() {
     ///         Ok(_) => panic!("obj should not be a list"),

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1623,7 +1623,7 @@ class NonHeapNonDescriptorInt:
     fn test_call_with_kwargs() {
         Python::with_gil(|py| {
             let list = vec![3, 6, 5, 4, 7].to_object(py);
-            let dict = vec![("reverse", true)].into_py_dict_bound(py);
+            let dict = vec![("reverse", true)].into_py_dict(py);
             list.call_method_bound(py, "sort", (), Some(&dict)).unwrap();
             assert_eq!(list.extract::<Vec<i32>>(py).unwrap(), vec![7, 6, 5, 4, 3]);
         });

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -161,7 +161,7 @@ pub trait PyByteArrayMethods<'py>: crate::sealed::Sealed {
     /// # fn main() -> PyResult<()> {
     /// #     Python::with_gil(|py| -> PyResult<()> {
     /// #         let fun = wrap_pyfunction!(a_valid_function, py)?;
-    /// #         let locals = pyo3::types::PyDict::new_bound(py);
+    /// #         let locals = pyo3::types::PyDict::new(py);
     /// #         locals.set_item("a_valid_function", fun)?;
     /// #
     /// #         py.run_bound(

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -534,7 +534,14 @@ pub(crate) use borrowed_iter::BorrowedDictIter;
 pub trait IntoPyDict: Sized {
     /// Converts self into a `PyDict` object pointer. Whether pointer owned or borrowed
     /// depends on implementation.
-    fn into_py_dict_bound(self, py: Python<'_>) -> Bound<'_, PyDict>;
+    fn into_py_dict(self, py: Python<'_>) -> Bound<'_, PyDict>;
+
+    /// Deprecated name for [`IntoPyDict::into_py_dict`].
+    #[deprecated(since = "0.23.0", note = "renamed to `IntoPyDict::into_py_dict`")]
+    #[inline]
+    fn into_py_dict_bound(self, py: Python<'_>) -> Bound<'_, PyDict> {
+        self.into_py_dict(py)
+    }
 }
 
 impl<T, I> IntoPyDict for I
@@ -542,7 +549,7 @@ where
     T: PyDictItem,
     I: IntoIterator<Item = T>,
 {
-    fn into_py_dict_bound(self, py: Python<'_>) -> Bound<'_, PyDict> {
+    fn into_py_dict(self, py: Python<'_>) -> Bound<'_, PyDict> {
         let dict = PyDict::new(py);
         for item in self {
             dict.set_item(item.key(), item.value())
@@ -599,7 +606,7 @@ mod tests {
     #[test]
     fn test_new() {
         Python::with_gil(|py| {
-            let dict = [(7, 32)].into_py_dict_bound(py);
+            let dict = [(7, 32)].into_py_dict(py);
             assert_eq!(
                 32,
                 dict.get_item(7i32)
@@ -659,7 +666,7 @@ mod tests {
     #[test]
     fn test_copy() {
         Python::with_gil(|py| {
-            let dict = [(7, 32)].into_py_dict_bound(py);
+            let dict = [(7, 32)].into_py_dict(py);
 
             let ndict = dict.copy().unwrap();
             assert_eq!(
@@ -755,7 +762,7 @@ mod tests {
             let obj = py.eval_bound("object()", None, None).unwrap();
             {
                 cnt = obj.get_refcnt();
-                let _dict = [(10, &obj)].into_py_dict_bound(py);
+                let _dict = [(10, &obj)].into_py_dict(py);
             }
             {
                 assert_eq!(cnt, obj.get_refcnt());
@@ -1020,7 +1027,7 @@ mod tests {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let py_map = map.into_py_dict_bound(py);
+            let py_map = map.into_py_dict(py);
 
             assert_eq!(py_map.len(), 1);
             assert_eq!(
@@ -1041,7 +1048,7 @@ mod tests {
             let mut map = BTreeMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let py_map = map.into_py_dict_bound(py);
+            let py_map = map.into_py_dict(py);
 
             assert_eq!(py_map.len(), 1);
             assert_eq!(
@@ -1060,7 +1067,7 @@ mod tests {
     fn test_vec_into_dict() {
         Python::with_gil(|py| {
             let vec = vec![("a", 1), ("b", 2), ("c", 3)];
-            let py_map = vec.into_py_dict_bound(py);
+            let py_map = vec.into_py_dict(py);
 
             assert_eq!(py_map.len(), 3);
             assert_eq!(
@@ -1079,7 +1086,7 @@ mod tests {
     fn test_slice_into_dict() {
         Python::with_gil(|py| {
             let arr = [("a", 1), ("b", 2), ("c", 3)];
-            let py_map = arr.into_py_dict_bound(py);
+            let py_map = arr.into_py_dict(py);
 
             assert_eq!(py_map.len(), 3);
             assert_eq!(
@@ -1100,7 +1107,7 @@ mod tests {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let py_map = map.into_py_dict_bound(py);
+            let py_map = map.into_py_dict(py);
 
             assert_eq!(py_map.as_mapping().len().unwrap(), 1);
             assert_eq!(
@@ -1121,7 +1128,7 @@ mod tests {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let py_map = map.into_py_dict_bound(py);
+            let py_map = map.into_py_dict(py);
 
             let py_mapping = py_map.into_mapping();
             assert_eq!(py_mapping.len().unwrap(), 1);
@@ -1135,7 +1142,7 @@ mod tests {
         map.insert("a", 1);
         map.insert("b", 2);
         map.insert("c", 3);
-        map.into_py_dict_bound(py)
+        map.into_py_dict(py)
     }
 
     #[test]
@@ -1177,8 +1184,8 @@ mod tests {
     #[test]
     fn dict_update() {
         Python::with_gil(|py| {
-            let dict = [("a", 1), ("b", 2), ("c", 3)].into_py_dict_bound(py);
-            let other = [("b", 4), ("c", 5), ("d", 6)].into_py_dict_bound(py);
+            let dict = [("a", 1), ("b", 2), ("c", 3)].into_py_dict(py);
+            let other = [("b", 4), ("c", 5), ("d", 6)].into_py_dict(py);
             dict.update(other.as_mapping()).unwrap();
             assert_eq!(dict.len(), 4);
             assert_eq!(
@@ -1248,8 +1255,8 @@ mod tests {
     #[test]
     fn dict_update_if_missing() {
         Python::with_gil(|py| {
-            let dict = [("a", 1), ("b", 2), ("c", 3)].into_py_dict_bound(py);
-            let other = [("b", 4), ("c", 5), ("d", 6)].into_py_dict_bound(py);
+            let dict = [("a", 1), ("b", 2), ("c", 3)].into_py_dict(py);
+            let other = [("b", 4), ("c", 5), ("d", 6)].into_py_dict(py);
             dict.update_if_missing(other.as_mapping()).unwrap();
             assert_eq!(dict.len(), 4);
             assert_eq!(

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn test_dict_is_not_ellipsis() {
         Python::with_gil(|py| {
-            assert!(PyDict::new_bound(py).downcast::<PyEllipsis>().is_err());
+            assert!(PyDict::new(py).downcast::<PyEllipsis>().is_err());
         })
     }
 }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -183,7 +183,7 @@ def fibonacci(target):
 "#;
 
         Python::with_gil(|py| {
-            let context = PyDict::new_bound(py);
+            let context = PyDict::new(py);
             py.run_bound(fibonacci_generator, None, Some(&context))
                 .unwrap();
 
@@ -210,7 +210,7 @@ def fibonacci(target):
 "#;
 
         Python::with_gil(|py| {
-            let context = PyDict::new_bound(py);
+            let context = PyDict::new(py);
             py.run_bound(fibonacci_generator, None, Some(&context))
                 .unwrap();
 

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn test_dict_is_not_none() {
         Python::with_gil(|py| {
-            assert!(PyDict::new_bound(py).downcast::<PyNone>().is_err());
+            assert!(PyDict::new(py).downcast::<PyNone>().is_err());
         })
     }
 }

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -70,9 +70,7 @@ mod tests {
     #[test]
     fn test_dict_is_not_notimplemented() {
         Python::with_gil(|py| {
-            assert!(PyDict::new_bound(py)
-                .downcast::<PyNotImplemented>()
-                .is_err());
+            assert!(PyDict::new(py).downcast::<PyNotImplemented>().is_err());
         })
     }
 }

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -102,7 +102,7 @@ mod tests {
     #[test]
     fn test_err_from_value() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             // Produce an error from python so that it has a traceback
             py.run_bound(
                 r"
@@ -124,7 +124,7 @@ except Exception as e:
     #[test]
     fn test_err_into_py() {
         Python::with_gil(|py| {
-            let locals = PyDict::new_bound(py);
+            let locals = PyDict::new(py);
             // Produce an error from python so that it has a traceback
             py.run_bound(
                 r"

--- a/tests/test_anyhow.rs
+++ b/tests/test_anyhow.rs
@@ -37,7 +37,7 @@ fn test_anyhow_py_function_err_result() {
 
     Python::with_gil(|py| {
         let func = wrap_pyfunction!(produce_err_result)(py).unwrap();
-        let locals = PyDict::new_bound(py);
+        let locals = PyDict::new(py);
         locals.set_item("func", func).unwrap();
 
         py.run_bound(

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -57,7 +57,7 @@ fn test_buffer() {
             },
         )
         .unwrap();
-        let env = [("ob", instance)].into_py_dict_bound(py);
+        let env = [("ob", instance)].into_py_dict(py);
         py_assert!(py, *env, "bytes(ob) == b' 23'");
     });
 
@@ -122,7 +122,7 @@ fn test_releasebuffer_unraisable_error() {
         let capture = UnraisableCapture::install(py);
 
         let instance = Py::new(py, ReleaseBufferError {}).unwrap();
-        let env = [("ob", instance.clone_ref(py))].into_py_dict_bound(py);
+        let env = [("ob", instance.clone_ref(py))].into_py_dict(py);
 
         assert!(capture.borrow(py).capture.is_none());
 

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -249,7 +249,7 @@ fn class_with_hash() {
             ("obj", Py::new(py, class).unwrap().into_any()),
             ("hsh", hash.into_py(py)),
         ]
-        .into_py_dict_bound(py);
+        .into_py_dict(py);
 
         py_assert!(py, *env, "hash(obj) == hsh");
     });

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -29,7 +29,7 @@ fn empty_class_with_new() {
         // Calling with arbitrary args or kwargs is not ok
         assert!(typeobj.call(("some", "args"), None).is_err());
         assert!(typeobj
-            .call((), Some(&[("some", "kwarg")].into_py_dict_bound(py)))
+            .call((), Some(&[("some", "kwarg")].into_py_dict(py)))
             .is_err());
     });
 }

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -75,7 +75,7 @@ fn test_coroutine_qualname() {
             ),
             ("MyClass", gil.get_type_bound::<MyClass>().as_any()),
         ]
-        .into_py_dict_bound(gil);
+        .into_py_dict(gil);
         py_run!(gil, *locals, &handle_windows(test));
     })
 }
@@ -302,7 +302,7 @@ fn test_async_method_receiver() {
             assert False
         assert asyncio.run(coro3) == 1
         "#;
-        let locals = [("Counter", gil.get_type_bound::<Counter>())].into_py_dict_bound(gil);
+        let locals = [("Counter", gil.get_type_bound::<Counter>())].into_py_dict(gil);
         py_run!(gil, *locals, test);
     });
 
@@ -337,7 +337,7 @@ fn test_async_method_receiver_with_other_args() {
         assert asyncio.run(v.set_value(10)) == 10
         assert asyncio.run(v.get_value_plus_with(1, 1)) == 12
         "#;
-        let locals = [("Value", gil.get_type_bound::<Value>())].into_py_dict_bound(gil);
+        let locals = [("Value", gil.get_type_bound::<Value>())].into_py_dict(gil);
         py_run!(gil, *locals, test);
     });
 }

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -12,7 +12,7 @@ fn _get_subclasses<'py>(
     // Import the class from Python and create some subclasses
     let datetime = py.import_bound("datetime")?;
 
-    let locals = [(py_type, datetime.getattr(py_type)?)].into_py_dict_bound(py);
+    let locals = [(py_type, datetime.getattr(py_type)?)].into_py_dict(py);
 
     let make_subclass_py = format!("class Subklass({}):\n    pass", py_type);
 
@@ -122,7 +122,7 @@ fn test_datetime_utc() {
 
         let dt = PyDateTime::new_bound(py, 2018, 1, 1, 0, 0, 0, 0, Some(&utc)).unwrap();
 
-        let locals = [("dt", dt)].into_py_dict_bound(py);
+        let locals = [("dt", dt)].into_py_dict(py);
 
         let offset: f32 = py
             .eval_bound("dt.utcoffset().total_seconds()", None, Some(&locals))

--- a/tests/test_dict_iter.rs
+++ b/tests/test_dict_iter.rs
@@ -6,7 +6,7 @@ use pyo3::types::IntoPyDict;
 fn iter_dict_nosegv() {
     Python::with_gil(|py| {
         const LEN: usize = 10_000_000;
-        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict_bound(py);
+        let dict = (0..LEN as u64).map(|i| (i, i * 2)).into_py_dict(py);
         let mut sum = 0;
         for (k, _v) in dict {
             let i: u64 = k.extract().unwrap();

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -259,7 +259,7 @@ fn test_simple_enum_with_hash() {
             ("obj", Py::new(py, class).unwrap().into_any()),
             ("hsh", hash.into_py(py)),
         ]
-        .into_py_dict_bound(py);
+        .into_py_dict(py);
 
         py_assert!(py, *env, "hash(obj) == hsh");
     });
@@ -290,7 +290,7 @@ fn test_complex_enum_with_hash() {
             ("obj", Py::new(py, class).unwrap().into_any()),
             ("hsh", hash.into_py(py)),
         ]
-        .into_py_dict_bound(py);
+        .into_py_dict(py);
 
         py_assert!(py, *env, "hash(obj) == hsh");
     });

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -384,7 +384,7 @@ fn test_enum() {
             _ => panic!("Expected extracting Foo::StructVarGetAttrArg, got {:?}", f),
         }
 
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         dict.set_item("a", "test").expect("Failed to set item");
         let f = dict
             .extract::<Foo<'_>>()
@@ -394,7 +394,7 @@ fn test_enum() {
             _ => panic!("Expected extracting Foo::StructWithGetItem, got {:?}", f),
         }
 
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         dict.set_item("foo", "test").expect("Failed to set item");
         let f = dict
             .extract::<Foo<'_>>()
@@ -409,7 +409,7 @@ fn test_enum() {
 #[test]
 fn test_enum_error() {
     Python::with_gil(|py| {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         let err = dict.extract::<Foo<'_>>().unwrap_err();
         assert_eq!(
             err.to_string(),
@@ -453,7 +453,7 @@ enum EnumWithCatchAll<'py> {
 #[test]
 fn test_enum_catch_all() {
     Python::with_gil(|py| {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         let f = dict
             .extract::<EnumWithCatchAll<'_>>()
             .expect("Failed to extract EnumWithCatchAll from dict");
@@ -483,7 +483,7 @@ pub enum Bar {
 #[test]
 fn test_err_rename() {
     Python::with_gil(|py| {
-        let dict = PyDict::new_bound(py);
+        let dict = PyDict::new(py);
         let f = dict.extract::<Bar>();
         assert!(f.is_err());
         assert_eq!(

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -85,7 +85,7 @@ fn class_with_properties() {
         py_run!(py, inst, "inst.from_any = 15");
         py_run!(py, inst, "assert inst.get_num() == 15");
 
-        let d = [("C", py.get_type_bound::<ClassWithProperties>())].into_py_dict_bound(py);
+        let d = [("C", py.get_type_bound::<ClassWithProperties>())].into_py_dict(py);
         py_assert!(py, *d, "C.DATA.__doc__ == 'a getter for data'");
     });
 }

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -20,7 +20,7 @@ struct SubclassAble {}
 #[test]
 fn subclass() {
     Python::with_gil(|py| {
-        let d = [("SubclassAble", py.get_type_bound::<SubclassAble>())].into_py_dict_bound(py);
+        let d = [("SubclassAble", py.get_type_bound::<SubclassAble>())].into_py_dict(py);
 
         py.run_bound(
             "class A(SubclassAble): pass\nassert issubclass(A, SubclassAble)",
@@ -97,7 +97,7 @@ fn call_base_and_sub_methods() {
 fn mutation_fails() {
     Python::with_gil(|py| {
         let obj = Py::new(py, SubClass::new()).unwrap();
-        let global = [("obj", obj)].into_py_dict_bound(py);
+        let global = [("obj", obj)].into_py_dict(py);
         let e = py
             .run_bound(
                 "obj.base_set(lambda: obj.sub_set_and_ret(1))",
@@ -275,7 +275,7 @@ mod inheriting_native_type {
     fn custom_exception() {
         Python::with_gil(|py| {
             let cls = py.get_type_bound::<CustomException>();
-            let dict = [("cls", &cls)].into_py_dict_bound(py);
+            let dict = [("cls", &cls)].into_py_dict(py);
             let res = py.run_bound(
             "e = cls('hello'); assert str(e) == 'hello'; assert e.context == 'Hello :)'; raise e",
             None,

--- a/tests/test_macro_docs.rs
+++ b/tests/test_macro_docs.rs
@@ -23,7 +23,7 @@ impl MacroDocs {
 #[test]
 fn meth_doc() {
     Python::with_gil(|py| {
-        let d = [("C", py.get_type_bound::<MacroDocs>())].into_py_dict_bound(py);
+        let d = [("C", py.get_type_bound::<MacroDocs>())].into_py_dict(py);
         py_assert!(
             py,
             *d,

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -71,7 +71,7 @@ impl Mapping {
 
 /// Return a dict with `m = Mapping(['1', '2', '3'])`.
 fn map_dict(py: Python<'_>) -> Bound<'_, pyo3::types::PyDict> {
-    let d = [("Mapping", py.get_type_bound::<Mapping>())].into_py_dict_bound(py);
+    let d = [("Mapping", py.get_type_bound::<Mapping>())].into_py_dict(py);
     py_run!(py, *d, "m = Mapping(['1', '2', '3'])");
     d
 }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -86,7 +86,7 @@ impl ClassMethod {
 #[test]
 fn class_method() {
     Python::with_gil(|py| {
-        let d = [("C", py.get_type_bound::<ClassMethod>())].into_py_dict_bound(py);
+        let d = [("C", py.get_type_bound::<ClassMethod>())].into_py_dict(py);
         py_assert!(py, *d, "C.method() == 'ClassMethod.method()!'");
         py_assert!(py, *d, "C().method() == 'ClassMethod.method()!'");
         py_assert!(
@@ -113,7 +113,7 @@ impl ClassMethodWithArgs {
 #[test]
 fn class_method_with_args() {
     Python::with_gil(|py| {
-        let d = [("C", py.get_type_bound::<ClassMethodWithArgs>())].into_py_dict_bound(py);
+        let d = [("C", py.get_type_bound::<ClassMethodWithArgs>())].into_py_dict(py);
         py_assert!(
             py,
             *d,
@@ -144,7 +144,7 @@ fn static_method() {
     Python::with_gil(|py| {
         assert_eq!(StaticMethod::method(py), "StaticMethod.method()!");
 
-        let d = [("C", py.get_type_bound::<StaticMethod>())].into_py_dict_bound(py);
+        let d = [("C", py.get_type_bound::<StaticMethod>())].into_py_dict(py);
         py_assert!(py, *d, "C.method() == 'StaticMethod.method()!'");
         py_assert!(py, *d, "C().method() == 'StaticMethod.method()!'");
         py_assert!(py, *d, "C.method.__doc__ == 'Test static method.'");
@@ -168,7 +168,7 @@ fn static_method_with_args() {
     Python::with_gil(|py| {
         assert_eq!(StaticMethodWithArgs::method(py, 1234), "0x4d2");
 
-        let d = [("C", py.get_type_bound::<StaticMethodWithArgs>())].into_py_dict_bound(py);
+        let d = [("C", py.get_type_bound::<StaticMethodWithArgs>())].into_py_dict(py);
         py_assert!(py, *d, "C.method(1337) == '0x539'");
     });
 }
@@ -677,7 +677,7 @@ impl MethDocs {
 #[test]
 fn meth_doc() {
     Python::with_gil(|py| {
-        let d = [("C", py.get_type_bound::<MethDocs>())].into_py_dict_bound(py);
+        let d = [("C", py.get_type_bound::<MethDocs>())].into_py_dict(py);
         py_assert!(py, *d, "C.__doc__ == 'A class with \"documentation\".'");
         py_assert!(
             py,
@@ -764,7 +764,7 @@ fn method_with_pyclassarg() {
     Python::with_gil(|py| {
         let obj1 = Py::new(py, MethodWithPyClassArg { value: 10 }).unwrap();
         let obj2 = Py::new(py, MethodWithPyClassArg { value: 10 }).unwrap();
-        let d = [("obj1", obj1), ("obj2", obj2)].into_py_dict_bound(py);
+        let d = [("obj1", obj1), ("obj2", obj2)].into_py_dict(py);
         py_run!(py, *d, "obj = obj1.add(obj2); assert obj.value == 20");
         py_run!(py, *d, "obj = obj1.add_pyref(obj2); assert obj.value == 20");
         py_run!(py, *d, "obj = obj1.optional_add(); assert obj.value == 20");

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -75,7 +75,7 @@ fn test_module_with_functions() {
             "module_with_functions",
             wrap_pymodule!(module_with_functions)(py),
         )]
-        .into_py_dict_bound(py);
+        .into_py_dict(py);
 
         py_assert!(
             py,
@@ -132,7 +132,7 @@ fn test_module_with_explicit_py_arg() {
             "module_with_explicit_py_arg",
             wrap_pymodule!(module_with_explicit_py_arg)(py),
         )]
-        .into_py_dict_bound(py);
+        .into_py_dict(py);
 
         py_assert!(py, *d, "module_with_explicit_py_arg.double(3) == 6");
     });
@@ -149,7 +149,7 @@ fn test_module_renaming() {
     use pyo3::wrap_pymodule;
 
     Python::with_gil(|py| {
-        let d = [("different_name", wrap_pymodule!(some_name)(py))].into_py_dict_bound(py);
+        let d = [("different_name", wrap_pymodule!(some_name)(py))].into_py_dict(py);
 
         py_run!(py, *d, "assert different_name.__name__ == 'other_name'");
     });

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -212,7 +212,7 @@ fn mapping() {
         let inst = Py::new(
             py,
             Mapping {
-                values: PyDict::new_bound(py).into(),
+                values: PyDict::new(py).into(),
             },
         )
         .unwrap();

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -107,7 +107,7 @@ impl ByteSequence {
 
 /// Return a dict with `s = ByteSequence([1, 2, 3])`.
 fn seq_dict(py: Python<'_>) -> Bound<'_, pyo3::types::PyDict> {
-    let d = [("ByteSequence", py.get_type_bound::<ByteSequence>())].into_py_dict_bound(py);
+    let d = [("ByteSequence", py.get_type_bound::<ByteSequence>())].into_py_dict(py);
     // Though we can construct `s` in Rust, let's test `__new__` works.
     py_run!(py, *d, "s = ByteSequence([1, 2, 3])");
     d
@@ -139,7 +139,7 @@ fn test_setitem() {
 #[test]
 fn test_delitem() {
     Python::with_gil(|py| {
-        let d = [("ByteSequence", py.get_type_bound::<ByteSequence>())].into_py_dict_bound(py);
+        let d = [("ByteSequence", py.get_type_bound::<ByteSequence>())].into_py_dict(py);
 
         py_run!(
             py,
@@ -235,7 +235,7 @@ fn test_repeat() {
 #[test]
 fn test_inplace_repeat() {
     Python::with_gil(|py| {
-        let d = [("ByteSequence", py.get_type_bound::<ByteSequence>())].into_py_dict_bound(py);
+        let d = [("ByteSequence", py.get_type_bound::<ByteSequence>())].into_py_dict(py);
 
         py_run!(
             py,

--- a/tests/test_static_slots.rs
+++ b/tests/test_static_slots.rs
@@ -38,7 +38,7 @@ impl Count5 {
 
 /// Return a dict with `s = Count5()`.
 fn test_dict(py: Python<'_>) -> Bound<'_, pyo3::types::PyDict> {
-    let d = [("Count5", py.get_type_bound::<Count5>())].into_py_dict_bound(py);
+    let d = [("Count5", py.get_type_bound::<Count5>())].into_py_dict(py);
     // Though we can construct `s` in Rust, let's test `__new__` works.
     py_run!(py, *d, "s = Count5()");
     d

--- a/tests/ui/wrong_aspyref_lifetimes.rs
+++ b/tests/ui/wrong_aspyref_lifetimes.rs
@@ -1,7 +1,7 @@
 use pyo3::{types::PyDict, Bound, Py, Python};
 
 fn main() {
-    let dict: Py<PyDict> = Python::with_gil(|py| PyDict::new_bound(py).unbind());
+    let dict: Py<PyDict> = Python::with_gil(|py| PyDict::new(py).unbind());
 
     // Should not be able to get access to Py contents outside of with_gil.
     let dict: &Bound<'_, PyDict> = Python::with_gil(|py| dict.bind(py));


### PR DESCRIPTION
Readded the non-bound contructors to `PyDict` & `IntoPyDict`, hopefully this time more thorough.
