### PR TITLE
Fix `lib_dir` when cross compiling

### DIFF
--- a/newsfragments/4389.fixed.md
+++ b/newsfragments/4389.fixed.md
@@ -1,0 +1,1 @@
+Fix invalid library search path `lib_dir` when cross-compiling.

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1438,7 +1438,10 @@ fn cross_compile_from_sysconfigdata(
 ) -> Result<Option<InterpreterConfig>> {
     if let Some(path) = find_sysconfigdata(cross_compile_config)? {
         let data = parse_sysconfigdata(path)?;
-        let config = InterpreterConfig::from_sysconfigdata(&data)?;
+        let mut config = InterpreterConfig::from_sysconfigdata(&data)?;
+        if let Some(cross_lib_dir) = cross_compile_config.lib_dir_string() {
+            config.lib_dir = Some(cross_lib_dir)
+        }
 
         Ok(Some(config))
     } else {


### PR DESCRIPTION
This PR suggests a fix for #4350 , where a linker option was incorrect when cross-compiling. Change a bit the creation of the `InterpreterConfig` in case of cross compilation in `pyo3-build-config`, to take the value of `PYO3_CROSS_LIB_DIR` in priority if set, instead of the value provided by the sysconfigdata.

Ref: (#4350)
