### PR TITLE
add second lifetime to `FromPyObject`

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1410,6 +1410,7 @@ impl pyo3::PyClass for MyClass {
 impl<'a, 'holder, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false> for &'holder MyClass
 {
     type Holder = ::std::option::Option<pyo3::PyClassGuard<'a, MyClass>>;
+    type Error = pyo3::PyErr;
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "MyClass";
 
@@ -1422,6 +1423,7 @@ impl<'a, 'holder, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'ho
 impl<'a, 'holder, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false> for &'holder mut MyClass
 {
     type Holder = ::std::option::Option<pyo3::PyClassGuardMut<'a, MyClass>>;
+    type Error = pyo3::PyErr;
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "MyClass";
 

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -13,14 +13,14 @@ With the removal of the `gil-ref` API it is now possible to fully split the Pyth
 GIL lifetime.
 
 `FromPyObject` now takes an additional lifetime `'a` describing the input lifetime. The argument
-type of the `extract` method changed from `&Bound<'_, PyAny>` to `Borrowed<'_, '_, PyAny>`. This was
-done to lift the implicit restriction `'py: 'a` due to the reference type. `extract_bound` with it's
+type of the `extract` method changed from `&Bound<'py, PyAny>` to `Borrowed<'a, 'py, PyAny>`. This was
+done because `&'a Bound<'py, PyAny>` would have an implicit restriction `'py: 'a` due to the reference type. `extract_bound` with its
 old signature is deprecated, but still available during migration.
 
 This new form was partly implemented already in 0.22 using the internal `FromPyObjectBound` trait and
 is now extended to all types.
 
-Most implementation can just add an elided lifetime to migrate,
+Most implementations can just add an elided lifetime to migrate.
 
 Before:
 ```rust,ignore
@@ -42,7 +42,7 @@ impl<'py> FromPyObject<'_, 'py> for IpAddr {
 }
 ```
 
-but occasually more steps are neccessary. For generic types, the bounds need to be adjusted. The
+Occasionally, more steps are necessary. For generic types, the bounds need to be adjusted. The
 correct bound depends on how the type is used.
 
 For simple wrapper types usually it's possible to just forward the bound.

--- a/newsfragments/4390.added.md
+++ b/newsfragments/4390.added.md
@@ -1,0 +1,2 @@
+added `FromPyObjectOwned` as more convenient trait bound
+added `Borrowed::extract`, same as `PyAnyMethods::extract`, but does not restrict the lifetime by deref

--- a/newsfragments/4390.changed.md
+++ b/newsfragments/4390.changed.md
@@ -1,3 +1,2 @@
 added second lifetime to `FromPyObject`
 reintroduced `extract` method
-deprecated `extract_bound` method

--- a/newsfragments/4390.changed.md
+++ b/newsfragments/4390.changed.md
@@ -1,0 +1,3 @@
+added second lifetime to `FromPyObject`
+reintroduced `extract` method
+deprecated `extract_bound` method

--- a/newsfragments/4390.removed.md
+++ b/newsfragments/4390.removed.md
@@ -1,0 +1,1 @@
+removed `FromPyObjectBound`

--- a/pyo3-benches/benches/bench_dict.rs
+++ b/pyo3-benches/benches/bench_dict.rs
@@ -62,8 +62,9 @@ fn extract_hashmap(b: &mut Bencher<'_>) {
         let dict = (0..LEN as u64)
             .map(|i| (i, i * 2))
             .into_py_dict(py)
-            .unwrap();
-        b.iter(|| HashMap::<u64, u64>::extract_bound(&dict));
+            .unwrap()
+            .into_any();
+        b.iter(|| HashMap::<u64, u64>::extract(dict.as_borrowed()));
     });
 }
 
@@ -73,8 +74,9 @@ fn extract_btreemap(b: &mut Bencher<'_>) {
         let dict = (0..LEN as u64)
             .map(|i| (i, i * 2))
             .into_py_dict(py)
-            .unwrap();
-        b.iter(|| BTreeMap::<u64, u64>::extract_bound(&dict));
+            .unwrap()
+            .into_any();
+        b.iter(|| BTreeMap::<u64, u64>::extract(dict.as_borrowed()));
     });
 }
 
@@ -84,8 +86,9 @@ fn extract_hashbrown_map(b: &mut Bencher<'_>) {
         let dict = (0..LEN as u64)
             .map(|i| (i, i * 2))
             .into_py_dict(py)
-            .unwrap();
-        b.iter(|| hashbrown::HashMap::<u64, u64>::extract_bound(&dict));
+            .unwrap()
+            .into_any();
+        b.iter(|| hashbrown::HashMap::<u64, u64>::extract(dict.as_borrowed()));
     });
 }
 

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -543,7 +543,7 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
         let gen_ident = &param.ident;
         where_clause
             .predicates
-            .push(parse_quote!(#gen_ident: for<'_a> #pyo3_path::FromPyObject<'_a, 'py>))
+            .push(parse_quote!(#gen_ident: #pyo3_path::conversion::FromPyObjectOwned<#lt_param>))
     }
 
     let derives = match &tokens.data {

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -606,7 +606,8 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
     Ok(quote!(
         #[automatically_derived]
         impl #impl_generics #pyo3_path::FromPyObject<'_, #lt_param> for #ident #ty_generics #where_clause {
-            fn extract(obj: #pyo3_path::Borrowed<'_, #lt_param, #pyo3_path::PyAny>) -> #pyo3_path::PyResult<Self> {
+            type Error = #pyo3_path::PyErr;
+            fn extract(obj: #pyo3_path::Borrowed<'_, #lt_param, #pyo3_path::PyAny>) -> ::std::result::Result<Self, Self::Error> {
                 let obj: &#pyo3_path::Bound<'_, _> = &*obj;
                 #derives
             }

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -499,7 +499,7 @@ impl<'a> Container<'a> {
             let ty = ty.clone().elide_lifetimes();
             let pyo3_crate_path = &ctx.pyo3_path;
             builder.push_tokens(
-                quote! { <#ty as #pyo3_crate_path::FromPyObject<'_>>::INPUT_TYPE.as_bytes() },
+                quote! { <#ty as #pyo3_crate_path::FromPyObject<'_, '_>>::INPUT_TYPE.as_bytes() },
             )
         }
     }
@@ -543,7 +543,7 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
         let gen_ident = &param.ident;
         where_clause
             .predicates
-            .push(parse_quote!(#gen_ident: #pyo3_path::FromPyObject<'py>))
+            .push(parse_quote!(#gen_ident: for<'_a> #pyo3_path::FromPyObject<'_a, 'py>))
     }
 
     let derives = match &tokens.data {
@@ -605,8 +605,9 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
     let ident = &tokens.ident;
     Ok(quote!(
         #[automatically_derived]
-        impl #impl_generics #pyo3_path::FromPyObject<#lt_param> for #ident #ty_generics #where_clause {
-            fn extract_bound(obj: &#pyo3_path::Bound<#lt_param, #pyo3_path::PyAny>) -> #pyo3_path::PyResult<Self>  {
+        impl #impl_generics #pyo3_path::FromPyObject<'_, #lt_param> for #ident #ty_generics #where_clause {
+            fn extract(obj: #pyo3_path::Borrowed<'_, #lt_param, #pyo3_path::PyAny>) -> #pyo3_path::PyResult<Self> {
+                let obj: &#pyo3_path::Bound<'_, _> = &*obj;
                 #derives
             }
             #input_type

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2327,6 +2327,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                 impl<'a, 'holder, 'py> #pyo3_path::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false> for &'holder #cls
                 {
                     type Holder = ::std::option::Option<#pyo3_path::PyClassGuard<'a, #cls>>;
+                    type Error = #pyo3_path::PyErr;
 
                     #input_type
 
@@ -2341,6 +2342,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                 impl<'a, 'holder, 'py> #pyo3_path::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false> for &'holder #cls
                 {
                     type Holder = ::std::option::Option<#pyo3_path::PyClassGuard<'a, #cls>>;
+                    type Error = #pyo3_path::PyErr;
 
                     #input_type
 
@@ -2353,6 +2355,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                 impl<'a, 'holder, 'py> #pyo3_path::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false> for &'holder mut #cls
                 {
                     type Holder = ::std::option::Option<#pyo3_path::PyClassGuardMut<'a, #cls>>;
+                    type Error =#pyo3_path::PyErr;
 
                     #input_type
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -18,8 +18,8 @@
 // DEALINGS IN THE SOFTWARE.
 
 //! `PyBuffer` implementation
-use crate::Bound;
 use crate::{err, exceptions::PyBufferError, ffi, FromPyObject, PyAny, PyResult, Python};
+use crate::{Borrowed, Bound};
 use std::ffi::{
     c_char, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint, c_ulong, c_ulonglong,
     c_ushort, c_void,
@@ -185,9 +185,9 @@ pub unsafe trait Element: Copy {
     fn is_compatible_format(format: &CStr) -> bool;
 }
 
-impl<T: Element> FromPyObject<'_> for PyBuffer<T> {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<PyBuffer<T>> {
-        Self::get(obj)
+impl<T: Element> FromPyObject<'_, '_> for PyBuffer<T> {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<PyBuffer<T>> {
+        Self::get(&obj)
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -19,7 +19,7 @@
 
 //! `PyBuffer` implementation
 use crate::{err, exceptions::PyBufferError, ffi, FromPyObject, PyAny, PyResult, Python};
-use crate::{Borrowed, Bound};
+use crate::{Borrowed, Bound, PyErr};
 use std::ffi::{
     c_char, c_int, c_long, c_longlong, c_schar, c_short, c_uchar, c_uint, c_ulong, c_ulonglong,
     c_ushort, c_void,
@@ -186,7 +186,9 @@ pub unsafe trait Element: Copy {
 }
 
 impl<T: Element> FromPyObject<'_, '_> for PyBuffer<T> {
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<PyBuffer<T>> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<PyBuffer<T>, Self::Error> {
         Self::get(&obj)
     }
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -293,6 +293,9 @@ impl<'py, T> IntoPyObjectExt<'py> for T where T: IntoPyObject<'py> {}
 /// [`Cow::Borrowed`]: std::borrow::Cow::Borrowed
 /// [`Cow::Owned`]: std::borrow::Cow::Owned
 pub trait FromPyObject<'a, 'py>: Sized {
+    /// The type returned in the event of a conversion error.
+    type Error: Into<PyErr>;
+
     /// Provides the type hint information for this type when it appears as an argument.
     ///
     /// For example, `Vec<u32>` would be `collections.abc.Sequence[int]`.
@@ -304,7 +307,7 @@ pub trait FromPyObject<'a, 'py>: Sized {
     ///
     /// Users are advised against calling this method directly: instead, use this via
     /// [`Bound<'_, PyAny>::extract`](crate::types::any::PyAnyMethods::extract) or [`Py::extract`].
-    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self>;
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error>;
 
     /// Extracts the type hint information for this type when it appears as an argument.
     ///
@@ -341,7 +344,9 @@ pub trait FromPyObject<'a, 'py>: Sized {
 /// where
 ///     T: FromPyObject<'a, 'py>
 /// {
-///     fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+///     type Error = T::Error;
+///
+///     fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
 ///         obj.extract().map(MyWrapper)
 ///     }
 /// }
@@ -354,10 +359,12 @@ pub trait FromPyObject<'a, 'py>: Sized {
 ///     T: FromPyObjectOwned<'py> // 👈 can only extract owned values, because each `item` below
 ///                               //    is a temporary short lived owned reference
 /// {
-///     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+///     type Error = PyErr;
+///
+///     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
 ///         let mut v = MyVec(Vec::new());
 ///         for item in obj.try_iter()? {
-///             v.0.push(item?.extract::<T>()?);
+///             v.0.push(item?.extract::<T>().map_err(Into::into)?);
 ///         }
 ///         Ok(v)
 ///     }
@@ -373,10 +380,12 @@ impl<T> FromPyObject<'_, '_> for T
 where
     T: PyClass + Clone,
 {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = <T as crate::impl_::pyclass::PyClassImpl>::TYPE_NAME;
 
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let bound = obj.cast::<Self>()?;
         Ok(bound.try_borrow()?.clone())
     }
@@ -386,10 +395,12 @@ impl<'py, T> FromPyObject<'_, 'py> for PyRef<'py, T>
 where
     T: PyClass,
 {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = <T as crate::impl_::pyclass::PyClassImpl>::TYPE_NAME;
 
-    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         obj.cast::<T>()?.try_borrow().map_err(Into::into)
     }
 }
@@ -398,10 +409,12 @@ impl<'py, T> FromPyObject<'_, 'py> for PyRefMut<'py, T>
 where
     T: PyClass<Frozen = False>,
 {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = <T as crate::impl_::pyclass::PyClassImpl>::TYPE_NAME;
 
-    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         obj.cast::<T>()?.try_borrow_mut().map_err(Into::into)
     }
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -247,7 +247,8 @@ impl<'py, T> IntoPyObjectExt<'py> for T where T: IntoPyObject<'py> {}
 /// Extract a type from a Python object.
 ///
 ///
-/// Normal usage is through the `extract` methods on [`Bound`] and [`Py`], which forward to this trait.
+/// Normal usage is through the `extract` methods on [`Bound`], [`Borrowed`] and
+/// [`Py`], which forward to this trait.
 ///
 /// # Examples
 ///
@@ -271,15 +272,38 @@ impl<'py, T> IntoPyObjectExt<'py> for T where T: IntoPyObject<'py> {}
 /// # }
 /// ```
 ///
-/// Note: depending on the implementation, the lifetime of the extracted result may
-/// depend on the lifetime of the `obj` or the `prepared` variable.
+/// Note: depending on the implementation, the extracted result may depend on
+/// the Python lifetime `'py` or the input lifetime `'a` of `obj`.
 ///
-/// For example, when extracting `&str` from a Python byte string, the resulting string slice will
-/// point to the existing string data (lifetime: `'py`).
-/// On the other hand, when extracting `&str` from a Python Unicode string, the preparation step
-/// will convert the string to UTF-8, and the resulting string slice will have lifetime `'prepared`.
-/// Since which case applies depends on the runtime type of the Python object,
-/// both the `obj` and `prepared` variables must outlive the resulting string slice.
+/// For example, when extracting a [`Cow<'a, str>`] the result may or may not
+/// borrow from the input lifetime `'a`. The behavior depends on the runtime
+/// type of the Python object. For a Python byte string, the existing string
+/// data can be borrowed (lifetime: `'a`) into a [`Cow::Borrowed`]. For a Python
+/// Unicode string, the data may have to be reencoded to UTF-8, and copied into
+/// a [`Cow::Owned`]. It does _not_ depend on the Python lifetime `'py`
+///
+/// An example of a type depending on the Python lifetime `'py` would be
+/// [`Bound<'py, PyString>`]. This type holds the invariant of beeing allowed to
+/// interact with the Python interpreter, so it inherits the Python lifetime
+/// from the input. It is however _not_ tied to the input lifetime `'a` and can
+/// be passed around independently of `obj`.
+///
+/// Special care needs to be taken for collection types, for example [`PyList`].
+/// In contrast to a Rust's [`Vec`] a Python list will not hand out references
+/// tied to its own lifetime, but "owned" references independent of it. (Similar
+/// to [`Vec<Arc<T>>`] where you clone the [`Arc<T>`] out). This makes it
+/// impossible to collect borrowed types in a collection, since they would not
+/// borrow from the original input list, but the much shorter lived element
+/// reference. This restriction is represented in PyO3 using
+/// [`FromPyObjectOwned`]. It is used by [`FromPyObject`] implementations on
+/// collection types to specify it can only collect types which do _not_ borrow
+/// from the input.
+///
+/// [`Cow<'a, str>`]: std::borrow::Cow
+/// [`Cow::Borrowed`]: std::borrow::Cow::Borrowed
+/// [`Cow::Owned`]: std::borrow::Cow::Owned
+/// [`PyList`]: crate::types::PyList
+/// [`Arc<T>`]: std::sync::Arc
 pub trait FromPyObject<'a, 'py>: Sized {
     /// Provides the type hint information for this type when it appears as an argument.
     ///
@@ -292,7 +316,7 @@ pub trait FromPyObject<'a, 'py>: Sized {
     ///
     /// Users are advised against calling this method directly: instead, use this via
     /// [`Bound<'_, PyAny>::extract`](crate::types::any::PyAnyMethods::extract) or [`Py::extract`].
-    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self>;
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self>;
 
     /// Extracts the type hint information for this type when it appears as an argument.
     ///

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -271,97 +271,16 @@ impl<'py, T> IntoPyObjectExt<'py> for T where T: IntoPyObject<'py> {}
 /// # }
 /// ```
 ///
-// /// FIXME: until `FromPyObject` can pick up a second lifetime, the below commentary is no longer
-// /// true. Update and restore this documentation at that time.
-// ///
-// /// Note: depending on the implementation, the lifetime of the extracted result may
-// /// depend on the lifetime of the `obj` or the `prepared` variable.
-// ///
-// /// For example, when extracting `&str` from a Python byte string, the resulting string slice will
-// /// point to the existing string data (lifetime: `'py`).
-// /// On the other hand, when extracting `&str` from a Python Unicode string, the preparation step
-// /// will convert the string to UTF-8, and the resulting string slice will have lifetime `'prepared`.
-// /// Since which case applies depends on the runtime type of the Python object,
-// /// both the `obj` and `prepared` variables must outlive the resulting string slice.
+/// Note: depending on the implementation, the lifetime of the extracted result may
+/// depend on the lifetime of the `obj` or the `prepared` variable.
 ///
-/// During the migration of PyO3 from the "GIL Refs" API to the `Bound<T>` smart pointer, this trait
-/// has two methods `extract` and `extract_bound` which are defaulted to call each other. To avoid
-/// infinite recursion, implementors must implement at least one of these methods. The recommendation
-/// is to implement `extract_bound` and leave `extract` as the default implementation.
-pub trait FromPyObject<'py>: Sized {
-    /// Provides the type hint information for this type when it appears as an argument.
-    ///
-    /// For example, `Vec<u32>` would be `collections.abc.Sequence[int]`.
-    /// The default value is `typing.Any`, which is correct for any type.
-    #[cfg(feature = "experimental-inspect")]
-    const INPUT_TYPE: &'static str = "typing.Any";
-
-    /// Extracts `Self` from the bound smart pointer `obj`.
-    ///
-    /// Implementors are encouraged to implement this method and leave `extract` defaulted, as
-    /// this will be most compatible with PyO3's future API.
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self>;
-
-    /// Extracts the type hint information for this type when it appears as an argument.
-    ///
-    /// For example, `Vec<u32>` would return `Sequence[int]`.
-    /// The default implementation returns `Any`, which is correct for any type.
-    ///
-    /// For most types, the return value for this method will be identical to that of
-    /// [`IntoPyObject::type_output`]. It may be different for some types, such as `Dict`,
-    /// to allow duck-typing: functions return `Dict` but take `Mapping` as argument.
-    #[cfg(feature = "experimental-inspect")]
-    fn type_input() -> TypeInfo {
-        TypeInfo::Any
-    }
-}
-
-mod from_py_object_bound_sealed {
-    use crate::{pyclass::boolean_struct::False, PyClass, PyClassGuard, PyClassGuardMut};
-
-    /// Private seal for the `FromPyObjectBound` trait.
-    ///
-    /// This prevents downstream types from implementing the trait before
-    /// PyO3 is ready to declare the trait as public API.
-    pub trait Sealed {}
-
-    // This generic implementation is why the seal is separate from
-    // `crate::sealed::Sealed`.
-    impl<'py, T> Sealed for T where T: super::FromPyObject<'py> {}
-    impl<T> Sealed for PyClassGuard<'_, T> where T: PyClass {}
-    impl<T> Sealed for PyClassGuardMut<'_, T> where T: PyClass<Frozen = False> {}
-    impl Sealed for &'_ str {}
-    impl Sealed for std::borrow::Cow<'_, str> {}
-    impl Sealed for &'_ [u8] {}
-    impl Sealed for std::borrow::Cow<'_, [u8]> {}
-}
-
-/// Expected form of [`FromPyObject`] to be used in a future PyO3 release.
-///
-/// The difference between this and `FromPyObject` is that this trait takes an
-/// additional lifetime `'a`, which is the lifetime of the input `Bound`.
-///
-/// This allows implementations for `&'a str` and `&'a [u8]`, which could not
-/// be expressed by the existing `FromPyObject` trait once the GIL Refs API was
-/// removed.
-///
-/// # Usage
-///
-/// Users are prevented from implementing this trait, instead they should implement
-/// the normal `FromPyObject` trait. This trait has a blanket implementation
-/// for `T: FromPyObject`.
-///
-/// The only case where this trait may have a use case to be implemented is when the
-/// lifetime of the extracted value is tied to the lifetime `'a` of the input `Bound`
-/// instead of the GIL lifetime `py`, as is the case for the `&'a str` implementation.
-///
-/// Please contact the PyO3 maintainers if you believe you have a use case for implementing
-/// this trait before PyO3 is ready to change the main `FromPyObject` trait to take an
-/// additional lifetime.
-///
-/// Similarly, users should typically not call these trait methods and should instead
-/// use this via the `extract` method on `Bound` and `Py`.
-pub trait FromPyObjectBound<'a, 'py>: Sized + from_py_object_bound_sealed::Sealed {
+/// For example, when extracting `&str` from a Python byte string, the resulting string slice will
+/// point to the existing string data (lifetime: `'py`).
+/// On the other hand, when extracting `&str` from a Python Unicode string, the preparation step
+/// will convert the string to UTF-8, and the resulting string slice will have lifetime `'prepared`.
+/// Since which case applies depends on the runtime type of the Python object,
+/// both the `obj` and `prepared` variables must outlive the resulting string slice.
+pub trait FromPyObject<'a, 'py>: Sized {
     /// Provides the type hint information for this type when it appears as an argument.
     ///
     /// For example, `Vec<u32>` would be `collections.abc.Sequence[int]`.
@@ -373,7 +292,7 @@ pub trait FromPyObjectBound<'a, 'py>: Sized + from_py_object_bound_sealed::Seale
     ///
     /// Users are advised against calling this method directly: instead, use this via
     /// [`Bound<'_, PyAny>::extract`](crate::types::any::PyAnyMethods::extract) or [`Py::extract`].
-    fn from_py_object_bound(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self>;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self>;
 
     /// Extracts the type hint information for this type when it appears as an argument.
     ///
@@ -389,56 +308,39 @@ pub trait FromPyObjectBound<'a, 'py>: Sized + from_py_object_bound_sealed::Seale
     }
 }
 
-impl<'py, T> FromPyObjectBound<'_, 'py> for T
-where
-    T: FromPyObject<'py>,
-{
-    #[cfg(feature = "experimental-inspect")]
-    const INPUT_TYPE: &'static str = T::INPUT_TYPE;
-
-    fn from_py_object_bound(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
-        Self::extract_bound(&ob)
-    }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_input() -> TypeInfo {
-        <T as FromPyObject>::type_input()
-    }
-}
-
-impl<T> FromPyObject<'_> for T
+impl<T> FromPyObject<'_, '_> for T
 where
     T: PyClass + Clone,
 {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = <T as crate::impl_::pyclass::PyClassImpl>::TYPE_NAME;
 
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let bound = obj.cast::<Self>()?;
         Ok(bound.try_borrow()?.clone())
     }
 }
 
-impl<'py, T> FromPyObject<'py> for PyRef<'py, T>
+impl<'py, T> FromPyObject<'_, 'py> for PyRef<'py, T>
 where
     T: PyClass,
 {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = <T as crate::impl_::pyclass::PyClassImpl>::TYPE_NAME;
 
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         obj.cast::<T>()?.try_borrow().map_err(Into::into)
     }
 }
 
-impl<'py, T> FromPyObject<'py> for PyRefMut<'py, T>
+impl<'py, T> FromPyObject<'_, 'py> for PyRefMut<'py, T>
 where
     T: PyClass<Frozen = False>,
 {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = <T as crate::impl_::pyclass::PyClassImpl>::TYPE_NAME;
 
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         obj.cast::<T>()?.try_borrow_mut().map_err(Into::into)
     }
 }

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -247,8 +247,8 @@ impl<'py, T> IntoPyObjectExt<'py> for T where T: IntoPyObject<'py> {}
 /// Extract a type from a Python object.
 ///
 ///
-/// Normal usage is through the `extract` methods on [`Bound`], [`Borrowed`] and
-/// [`Py`], which forward to this trait.
+/// Normal usage is through the `extract` methods on [`Bound`], [`Borrowed`] and [`Py`], which
+/// forward to this trait.
 ///
 /// # Examples
 ///
@@ -272,38 +272,27 @@ impl<'py, T> IntoPyObjectExt<'py> for T where T: IntoPyObject<'py> {}
 /// # }
 /// ```
 ///
-/// Note: depending on the implementation, the extracted result may depend on
-/// the Python lifetime `'py` or the input lifetime `'a` of `obj`.
+/// Note: Depending on the Python version and implementation, some [`FromPyObject`] implementations
+/// may produce a result that borrows into the Python type. This is described by the input lifetime
+/// `'a` of `obj`.
 ///
-/// For example, when extracting a [`Cow<'a, str>`] the result may or may not
-/// borrow from the input lifetime `'a`. The behavior depends on the runtime
-/// type of the Python object. For a Python byte string, the existing string
-/// data can be borrowed (lifetime: `'a`) into a [`Cow::Borrowed`]. For a Python
-/// Unicode string, the data may have to be reencoded to UTF-8, and copied into
-/// a [`Cow::Owned`]. It does _not_ depend on the Python lifetime `'py`
+/// Types that must not borrow from the input can use [`FromPyObjectOwned`] as a restriction. This
+/// is most often the case for collection types. See its documentation for more details.
 ///
-/// An example of a type depending on the Python lifetime `'py` would be
-/// [`Bound<'py, PyString>`]. This type holds the invariant of beeing allowed to
-/// interact with the Python interpreter, so it inherits the Python lifetime
-/// from the input. It is however _not_ tied to the input lifetime `'a` and can
-/// be passed around independently of `obj`.
+/// # Details
+/// [`Cow<'a, str>`] is an example of an output type that may or may not borrow from the input
+/// lifetime `'a`. Which variant will be produced depends on the runtime type of the Python object.
+/// For a Python byte string, the existing string data can be borrowed for `'a` into a
+/// [`Cow::Borrowed`]. For a Python Unicode string, the data may have to be reencoded to UTF-8, and
+/// copied into a [`Cow::Owned`]. It does _not_ depend on the Python lifetime `'py`.
 ///
-/// Special care needs to be taken for collection types, for example [`PyList`].
-/// In contrast to a Rust's [`Vec`] a Python list will not hand out references
-/// tied to its own lifetime, but "owned" references independent of it. (Similar
-/// to [`Vec<Arc<T>>`] where you clone the [`Arc<T>`] out). This makes it
-/// impossible to collect borrowed types in a collection, since they would not
-/// borrow from the original input list, but the much shorter lived element
-/// reference. This restriction is represented in PyO3 using
-/// [`FromPyObjectOwned`]. It is used by [`FromPyObject`] implementations on
-/// collection types to specify it can only collect types which do _not_ borrow
-/// from the input.
+/// The output type may also depend on the Python lifetime `'py`. This allows the output type to
+/// keep interacting with the Python interpreter. See also [`Bound<'py, T>`].
 ///
 /// [`Cow<'a, str>`]: std::borrow::Cow
 /// [`Cow::Borrowed`]: std::borrow::Cow::Borrowed
 /// [`Cow::Owned`]: std::borrow::Cow::Owned
-/// [`PyList`]: crate::types::PyList
-/// [`Arc<T>`]: std::sync::Arc
+
 pub trait FromPyObject<'a, 'py>: Sized {
     /// Provides the type hint information for this type when it appears as an argument.
     ///
@@ -332,11 +321,17 @@ pub trait FromPyObject<'a, 'py>: Sized {
     }
 }
 
-/// A data structure that can be extracted without borrowing any data from the input
+/// A data structure that can be extracted without borrowing any data from the input.
 ///
-/// This is primarily useful for trait bounds. For example a `FromPyObject` implementation of a
-/// wrapper type may be able to borrow data from the input, but a `FromPyObject` implementation of a
-/// collection type may only extract owned data.
+/// This is primarily useful for trait bounds. For example a [`FromPyObject`] implementation of a
+/// wrapper type may be able to borrow data from the input, but a [`FromPyObject`] implementation of
+/// a collection type may only extract owned data.
+///
+/// For example [`PyList`] will not hand out references tied to its own lifetime, but "owned"
+/// references independent of it. (Similar to [`Vec<Arc<T>>`] where you clone the [`Arc<T>`] out).
+/// This makes it impossible to collect borrowed types in a collection, since they would not borrow
+/// from the original [`PyList`], but the much shorter lived element reference. See the example
+/// below.
 ///
 /// ```,no_run
 /// # use pyo3::prelude::*;
@@ -369,6 +364,9 @@ pub trait FromPyObject<'a, 'py>: Sized {
 ///     }
 /// }
 /// ```
+///
+/// [`PyList`]: crate::types::PyList
+/// [`Arc<T>`]: std::sync::Arc
 pub trait FromPyObjectOwned<'py>: for<'a> FromPyObject<'a, 'py> {}
 impl<'py, T> FromPyObjectOwned<'py> for T where T: for<'a> FromPyObject<'a, 'py> {}
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -292,7 +292,6 @@ impl<'py, T> IntoPyObjectExt<'py> for T where T: IntoPyObject<'py> {}
 /// [`Cow<'a, str>`]: std::borrow::Cow
 /// [`Cow::Borrowed`]: std::borrow::Cow::Borrowed
 /// [`Cow::Owned`]: std::borrow::Cow::Owned
-
 pub trait FromPyObject<'a, 'py>: Sized {
     /// Provides the type hint information for this type when it appears as an argument.
     ///

--- a/src/conversions/bigdecimal.rs
+++ b/src/conversions/bigdecimal.rs
@@ -72,6 +72,8 @@ fn get_invalid_operation_error_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType
 }
 
 impl FromPyObject<'_, '_> for BigDecimal {
+    type Error = PyErr;
+
     fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let py_str = &obj.str()?;
         let rs_str = &py_str.to_cow()?;

--- a/src/conversions/bigdecimal.rs
+++ b/src/conversions/bigdecimal.rs
@@ -56,7 +56,7 @@ use crate::{
     exceptions::PyValueError,
     sync::PyOnceLock,
     types::{PyAnyMethods, PyStringMethods, PyType},
-    Bound, FromPyObject, IntoPyObject, Py, PyAny, PyErr, PyResult, Python,
+    Borrowed, Bound, FromPyObject, IntoPyObject, Py, PyAny, PyErr, PyResult, Python,
 };
 use bigdecimal::BigDecimal;
 use num_bigint::Sign;
@@ -71,8 +71,8 @@ fn get_invalid_operation_error_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType
     INVALID_OPERATION_CLS.import(py, "decimal", "InvalidOperation")
 }
 
-impl FromPyObject<'_> for BigDecimal {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for BigDecimal {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let py_str = &obj.str()?;
         let rs_str = &py_str.to_cow()?;
         BigDecimal::from_str(rs_str).map_err(|e| PyValueError::new_err(e.to_string()))

--- a/src/conversions/bytes.rs
+++ b/src/conversions/bytes.rs
@@ -68,10 +68,12 @@ use crate::conversion::IntoPyObject;
 use crate::instance::Bound;
 use crate::pybacked::PyBackedBytes;
 use crate::types::PyBytes;
-use crate::{Borrowed, FromPyObject, PyAny, PyErr, PyResult, Python};
+use crate::{Borrowed, DowncastError, FromPyObject, PyAny, PyErr, Python};
 
-impl FromPyObject<'_, '_> for Bytes {
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Bytes {
+    type Error = DowncastError<'a, 'py>;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         Ok(Bytes::from_owner(obj.extract::<PyBackedBytes>()?))
     }
 }

--- a/src/conversions/bytes.rs
+++ b/src/conversions/bytes.rs
@@ -67,13 +67,12 @@ use bytes::Bytes;
 use crate::conversion::IntoPyObject;
 use crate::instance::Bound;
 use crate::pybacked::PyBackedBytes;
-use crate::types::any::PyAnyMethods;
 use crate::types::PyBytes;
-use crate::{FromPyObject, PyAny, PyErr, PyResult, Python};
+use crate::{Borrowed, FromPyObject, PyAny, PyErr, PyResult, Python};
 
-impl FromPyObject<'_> for Bytes {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
-        Ok(Bytes::from_owner(ob.extract::<PyBackedBytes>()?))
+impl FromPyObject<'_, '_> for Bytes {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+        Ok(Bytes::from_owner(obj.extract::<PyBackedBytes>()?))
     }
 }
 
@@ -100,7 +99,7 @@ impl<'py> IntoPyObject<'py> for &Bytes {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{PyByteArray, PyByteArrayMethods, PyBytes};
+    use crate::types::{PyAnyMethods, PyByteArray, PyByteArrayMethods, PyBytes};
     use crate::Python;
 
     #[test]

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -41,7 +41,7 @@
 //! }
 //! ```
 
-use crate::conversion::IntoPyObject;
+use crate::conversion::{FromPyObjectOwned, IntoPyObject};
 use crate::exceptions::{PyTypeError, PyUserWarning, PyValueError};
 use crate::intern;
 use crate::types::any::PyAnyMethods;
@@ -326,7 +326,7 @@ where
 
 impl<'py, Tz> FromPyObject<'_, 'py> for DateTime<Tz>
 where
-    Tz: TimeZone + for<'a> FromPyObject<'a, 'py>,
+    Tz: TimeZone + FromPyObjectOwned<'py>,
 {
     fn extract(dt: Borrowed<'_, 'py, PyAny>) -> PyResult<DateTime<Tz>> {
         let dt = &*dt.cast::<PyDateTime>()?;

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -38,7 +38,7 @@ use crate::conversion::IntoPyObject;
 use crate::exceptions::PyValueError;
 use crate::pybacked::PyBackedStr;
 use crate::types::{any::PyAnyMethods, PyTzInfo};
-use crate::{intern, Bound, FromPyObject, PyAny, PyErr, PyResult, Python};
+use crate::{intern, Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python};
 use chrono_tz::Tz;
 use std::str::FromStr;
 
@@ -63,8 +63,8 @@ impl<'py> IntoPyObject<'py> for &Tz {
     }
 }
 
-impl FromPyObject<'_> for Tz {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Tz> {
+impl FromPyObject<'_, '_> for Tz {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Tz> {
         Tz::from_str(
             &ob.getattr(intern!(ob.py(), "key"))?
                 .extract::<PyBackedStr>()?,
@@ -78,6 +78,7 @@ mod tests {
     use super::*;
     use crate::prelude::PyAnyMethods;
     use crate::types::PyTzInfo;
+    use crate::Bound;
     use crate::Python;
     use chrono::{DateTime, Utc};
     use chrono_tz::Tz;

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -38,7 +38,7 @@ use crate::conversion::IntoPyObject;
 use crate::exceptions::PyValueError;
 use crate::pybacked::PyBackedStr;
 use crate::types::{any::PyAnyMethods, PyTzInfo};
-use crate::{intern, Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python};
+use crate::{intern, Borrowed, Bound, FromPyObject, PyAny, PyErr, Python};
 use chrono_tz::Tz;
 use std::str::FromStr;
 
@@ -64,7 +64,9 @@ impl<'py> IntoPyObject<'py> for &Tz {
 }
 
 impl FromPyObject<'_, '_> for Tz {
-    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Tz> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         Tz::from_str(
             &ob.getattr(intern!(ob.py(), "key"))?
                 .extract::<PyBackedStr>()?,

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -47,8 +47,8 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    exceptions::PyTypeError, types::any::PyAnyMethods, Bound, FromPyObject, IntoPyObject,
-    IntoPyObjectExt, PyAny, PyErr, PyResult, Python,
+    exceptions::PyTypeError, Borrowed, Bound, FromPyObject, IntoPyObject, IntoPyObjectExt, PyAny,
+    PyErr, PyResult, Python,
 };
 use either::Either;
 
@@ -89,13 +89,13 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "either")))]
-impl<'py, L, R> FromPyObject<'py> for Either<L, R>
+impl<'a, 'py, L, R> FromPyObject<'a, 'py> for Either<L, R>
 where
-    L: FromPyObject<'py>,
-    R: FromPyObject<'py>,
+    L: FromPyObject<'a, 'py>,
+    R: FromPyObject<'a, 'py>,
 {
     #[inline]
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         if let Ok(l) = obj.extract::<L>() {
             Ok(Either::Left(l))
         } else if let Ok(r) = obj.extract::<R>() {

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -48,7 +48,7 @@
 use crate::inspect::types::TypeInfo;
 use crate::{
     exceptions::PyTypeError, Borrowed, Bound, FromPyObject, IntoPyObject, IntoPyObjectExt, PyAny,
-    PyErr, PyResult, Python,
+    PyErr, Python,
 };
 use either::Either;
 
@@ -94,8 +94,10 @@ where
     L: FromPyObject<'a, 'py>,
     R: FromPyObject<'a, 'py>,
 {
+    type Error = PyErr;
+
     #[inline]
-    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(l) = obj.extract::<L>() {
             Ok(Either::Left(l))
         } else if let Ok(r) = obj.extract::<R>() {

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -17,7 +17,7 @@
 //! Note that you must use compatible versions of hashbrown and PyO3.
 //! The required hashbrown version may vary based on the version of PyO3.
 use crate::{
-    conversion::IntoPyObject,
+    conversion::{FromPyObjectOwned, IntoPyObject},
     types::{
         any::PyAnyMethods,
         dict::PyDictMethods,
@@ -69,8 +69,8 @@ where
 
 impl<'py, K, V, S> FromPyObject<'_, 'py> for hashbrown::HashMap<K, V, S>
 where
-    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
-    V: for<'a> FromPyObject<'a, 'py>,
+    K: FromPyObjectOwned<'py> + cmp::Eq + hash::Hash,
+    V: FromPyObjectOwned<'py>,
     S: hash::BuildHasher + Default,
 {
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
@@ -113,7 +113,7 @@ where
 
 impl<'py, K, S> FromPyObject<'_, 'py> for hashbrown::HashSet<K, S>
 where
-    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
+    K: FromPyObjectOwned<'py> + cmp::Eq + hash::Hash,
     S: hash::BuildHasher + Default,
 {
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -25,7 +25,7 @@ use crate::{
         set::{try_new_from_iter, PySetMethods},
         PyDict, PyFrozenSet, PySet,
     },
-    Bound, FromPyObject, PyAny, PyErr, PyResult, Python,
+    Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python,
 };
 use std::{cmp, hash};
 
@@ -67,16 +67,16 @@ where
     }
 }
 
-impl<'py, K, V, S> FromPyObject<'py> for hashbrown::HashMap<K, V, S>
+impl<'py, K, V, S> FromPyObject<'_, 'py> for hashbrown::HashMap<K, V, S>
 where
-    K: FromPyObject<'py> + cmp::Eq + hash::Hash,
-    V: FromPyObject<'py>,
+    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
+    V: for<'a> FromPyObject<'a, 'py>,
     S: hash::BuildHasher + Default,
 {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> Result<Self, PyErr> {
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.cast::<PyDict>()?;
         let mut ret = hashbrown::HashMap::with_capacity_and_hasher(dict.len(), S::default());
-        for (k, v) in dict {
+        for (k, v) in dict.iter() {
             ret.insert(k.extract()?, v.extract()?);
         }
         Ok(ret)
@@ -111,12 +111,12 @@ where
     }
 }
 
-impl<'py, K, S> FromPyObject<'py> for hashbrown::HashSet<K, S>
+impl<'py, K, S> FromPyObject<'_, 'py> for hashbrown::HashSet<K, S>
 where
-    K: FromPyObject<'py> + cmp::Eq + hash::Hash,
+    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
     S: hash::BuildHasher + Default,
 {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         match ob.cast::<PySet>() {
             Ok(set) => set.iter().map(|any| any.extract()).collect(),
             Err(err) => {

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -136,11 +136,16 @@ where
     V: FromPyObjectOwned<'py>,
     S: hash::BuildHasher + Default,
 {
-    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         let dict = ob.cast::<PyDict>()?;
         let mut ret = indexmap::IndexMap::with_capacity_and_hasher(dict.len(), S::default());
         for (k, v) in dict.iter() {
-            ret.insert(k.extract()?, v.extract()?);
+            ret.insert(
+                k.extract().map_err(Into::into)?,
+                v.extract().map_err(Into::into)?,
+            );
         }
         Ok(ret)
     }

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -87,7 +87,7 @@
 //! # if another hash table was used, the order could be random
 //! ```
 
-use crate::conversion::IntoPyObject;
+use crate::conversion::{FromPyObjectOwned, IntoPyObject};
 use crate::types::*;
 use crate::{Borrowed, Bound, FromPyObject, PyErr, Python};
 use std::{cmp, hash};
@@ -132,8 +132,8 @@ where
 
 impl<'py, K, V, S> FromPyObject<'_, 'py> for indexmap::IndexMap<K, V, S>
 where
-    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
-    V: for<'a> FromPyObject<'a, 'py>,
+    K: FromPyObjectOwned<'py> + cmp::Eq + hash::Hash,
+    V: FromPyObjectOwned<'py>,
     S: hash::BuildHasher + Default,
 {
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -89,7 +89,7 @@
 
 use crate::conversion::IntoPyObject;
 use crate::types::*;
-use crate::{Bound, FromPyObject, PyErr, Python};
+use crate::{Borrowed, Bound, FromPyObject, PyErr, Python};
 use std::{cmp, hash};
 
 impl<'py, K, V, H> IntoPyObject<'py> for indexmap::IndexMap<K, V, H>
@@ -130,16 +130,16 @@ where
     }
 }
 
-impl<'py, K, V, S> FromPyObject<'py> for indexmap::IndexMap<K, V, S>
+impl<'py, K, V, S> FromPyObject<'_, 'py> for indexmap::IndexMap<K, V, S>
 where
-    K: FromPyObject<'py> + cmp::Eq + hash::Hash,
-    V: FromPyObject<'py>,
+    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
+    V: for<'a> FromPyObject<'a, 'py>,
     S: hash::BuildHasher + Default,
 {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> Result<Self, PyErr> {
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.cast::<PyDict>()?;
         let mut ret = indexmap::IndexMap::with_capacity_and_hasher(dict.len(), S::default());
-        for (k, v) in dict {
+        for (k, v) in dict.iter() {
             ret.insert(k.extract()?, v.extract()?);
         }
         Ok(ret)

--- a/src/conversions/jiff.rs
+++ b/src/conversions/jiff.rs
@@ -122,8 +122,10 @@ impl<'py> IntoPyObject<'py> for &Timestamp {
     }
 }
 
-impl<'py> FromPyObject<'_, 'py> for Timestamp {
-    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Timestamp {
+    type Error = <Zoned as FromPyObject<'a, 'py>>::Error;
+
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         let zoned = ob.extract::<Zoned>()?;
         Ok(zoned.timestamp())
     }
@@ -155,6 +157,8 @@ impl<'py> IntoPyObject<'py> for &Date {
 }
 
 impl<'py> FromPyObject<'_, 'py> for Date {
+    type Error = PyErr;
+
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let date = ob.cast::<PyDate>()?;
 
@@ -207,6 +211,8 @@ impl<'py> IntoPyObject<'py> for &Time {
 }
 
 impl<'py> FromPyObject<'_, 'py> for Time {
+    type Error = PyErr;
+
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let ob = ob.cast::<PyTime>()?;
         #[allow(clippy::explicit_auto_deref)]
@@ -235,6 +241,8 @@ impl<'py> IntoPyObject<'py> for &DateTime {
 }
 
 impl<'py> FromPyObject<'_, 'py> for DateTime {
+    type Error = PyErr;
+
     fn extract(dt: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let dt = dt.cast::<PyDateTime>()?;
         let has_tzinfo = dt.get_tzinfo().is_some();
@@ -285,6 +293,8 @@ impl<'py> IntoPyObject<'py> for &Zoned {
 }
 
 impl<'py> FromPyObject<'_, 'py> for Zoned {
+    type Error = PyErr;
+
     fn extract(dt: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let dt = dt.cast::<PyDateTime>()?;
 
@@ -343,6 +353,8 @@ impl<'py> IntoPyObject<'py> for &TimeZone {
 }
 
 impl<'py> FromPyObject<'_, 'py> for TimeZone {
+    type Error = PyErr;
+
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let ob = ob.cast::<PyTzInfo>()?;
 
@@ -380,6 +392,8 @@ impl<'py> IntoPyObject<'py> for Offset {
 }
 
 impl<'py> FromPyObject<'_, 'py> for Offset {
+    type Error = PyErr;
+
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let py = ob.py();
         let ob = ob.cast::<PyTzInfo>()?;
@@ -428,6 +442,8 @@ impl<'py> IntoPyObject<'py> for SignedDuration {
 }
 
 impl<'py> FromPyObject<'_, 'py> for SignedDuration {
+    type Error = PyErr;
+
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let delta = ob.cast::<PyDelta>()?;
 
@@ -453,6 +469,8 @@ impl<'py> FromPyObject<'_, 'py> for SignedDuration {
 }
 
 impl<'py> FromPyObject<'_, 'py> for Span {
+    type Error = PyErr;
+
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let duration = ob.extract::<SignedDuration>()?;
         Ok(duration.try_into()?)

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -124,7 +124,9 @@ bigint_conversion!(BigInt, true, BigInt::to_signed_bytes_le);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
 impl<'py> FromPyObject<'_, 'py> for BigInt {
-    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<BigInt> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<BigInt, Self::Error> {
         let py = ob.py();
         // fast path - checking for subclass of `int` just checks a bit in the type object
         let num_owned: Py<PyInt>;
@@ -172,7 +174,9 @@ impl<'py> FromPyObject<'_, 'py> for BigInt {
 
 #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
 impl<'py> FromPyObject<'_, 'py> for BigUint {
-    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<BigUint> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<BigUint, Self::Error> {
         let py = ob.py();
         // fast path - checking for subclass of `int` just checks a bit in the type object
         let num_owned: Py<PyInt>;

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -50,7 +50,7 @@
 #[cfg(Py_LIMITED_API)]
 use crate::types::{bytes::PyBytesMethods, PyBytes};
 use crate::{
-    conversion::IntoPyObject, ffi, instance::Bound, types::PyInt, FromPyObject, Py, PyAny, PyErr,
+    conversion::IntoPyObject, ffi, types::PyInt, Borrowed, Bound, FromPyObject, Py, PyAny, PyErr,
     PyResult, Python,
 };
 
@@ -123,8 +123,8 @@ bigint_conversion!(BigUint, false, BigUint::to_bytes_le);
 bigint_conversion!(BigInt, true, BigInt::to_signed_bytes_le);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
-impl<'py> FromPyObject<'py> for BigInt {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<BigInt> {
+impl<'py> FromPyObject<'_, 'py> for BigInt {
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<BigInt> {
         let py = ob.py();
         // fast path - checking for subclass of `int` just checks a bit in the type object
         let num_owned: Py<PyInt>;
@@ -132,11 +132,11 @@ impl<'py> FromPyObject<'py> for BigInt {
             long
         } else {
             num_owned = unsafe { Py::from_owned_ptr_or_err(py, ffi::PyNumber_Index(ob.as_ptr()))? };
-            num_owned.bind(py)
+            num_owned.bind_borrowed(py)
         };
         #[cfg(not(Py_LIMITED_API))]
         {
-            let mut buffer = int_to_u32_vec::<true>(num)?;
+            let mut buffer = int_to_u32_vec::<true>(&num)?;
             let sign = if buffer.last().copied().is_some_and(|last| last >> 31 != 0) {
                 // BigInt::new takes an unsigned array, so need to convert from two's complement
                 // flip all bits, 'subtract' 1 (by adding one to the unsigned array)
@@ -160,19 +160,19 @@ impl<'py> FromPyObject<'py> for BigInt {
         }
         #[cfg(Py_LIMITED_API)]
         {
-            let n_bits = int_n_bits(num)?;
+            let n_bits = int_n_bits(&num)?;
             if n_bits == 0 {
                 return Ok(BigInt::from(0isize));
             }
-            let bytes = int_to_py_bytes(num, (n_bits + 8) / 8, true)?;
+            let bytes = int_to_py_bytes(&num, (n_bits + 8) / 8, true)?;
             Ok(BigInt::from_signed_bytes_le(bytes.as_bytes()))
         }
     }
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
-impl<'py> FromPyObject<'py> for BigUint {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<BigUint> {
+impl<'py> FromPyObject<'_, 'py> for BigUint {
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<BigUint> {
         let py = ob.py();
         // fast path - checking for subclass of `int` just checks a bit in the type object
         let num_owned: Py<PyInt>;
@@ -180,20 +180,20 @@ impl<'py> FromPyObject<'py> for BigUint {
             long
         } else {
             num_owned = unsafe { Py::from_owned_ptr_or_err(py, ffi::PyNumber_Index(ob.as_ptr()))? };
-            num_owned.bind(py)
+            num_owned.bind_borrowed(py)
         };
         #[cfg(not(Py_LIMITED_API))]
         {
-            let buffer = int_to_u32_vec::<false>(num)?;
+            let buffer = int_to_u32_vec::<false>(&num)?;
             Ok(BigUint::new(buffer))
         }
         #[cfg(Py_LIMITED_API)]
         {
-            let n_bits = int_n_bits(num)?;
+            let n_bits = int_n_bits(&num)?;
             if n_bits == 0 {
                 return Ok(BigUint::from(0usize));
             }
-            let bytes = int_to_py_bytes(num, n_bits.div_ceil(8), false)?;
+            let bytes = int_to_py_bytes(&num, n_bits.div_ceil(8), false)?;
             Ok(BigUint::from_bytes_le(bytes.as_bytes()))
         }
     }
@@ -307,8 +307,8 @@ fn int_n_bits(long: &Bound<'_, PyInt>) -> PyResult<usize> {
 
     #[cfg(Py_LIMITED_API)]
     {
-        use crate::types::any::PyAnyMethods;
         // slow path
+        use crate::types::PyAnyMethods;
         long.call_method0(crate::intern!(py, "bit_length"))
             .and_then(|any| any.extract())
     }

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -94,8 +94,8 @@
 //! assert result == [complex(1,-1), complex(-2,0)]
 //! ```
 use crate::{
-    ffi, ffi_ptr_ext::FfiPtrExt, types::PyComplex, Bound, FromPyObject, PyAny, PyErr, PyResult,
-    Python,
+    ffi, ffi_ptr_ext::FfiPtrExt, types::PyComplex, Borrowed, Bound, FromPyObject, PyAny, PyErr,
+    PyResult, Python,
 };
 use num_complex::Complex;
 use std::ffi::c_double;
@@ -146,8 +146,8 @@ macro_rules! complex_conversion {
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
-        impl FromPyObject<'_> for Complex<$float> {
-            fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Complex<$float>> {
+        impl FromPyObject<'_, '_> for Complex<$float> {
+            fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Complex<$float>> {
                 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
                 unsafe {
                     let val = ffi::PyComplex_AsCComplex(obj.as_ptr());
@@ -169,7 +169,7 @@ macro_rules! complex_conversion {
                         obj.lookup_special(crate::intern!(obj.py(), "__complex__"))?
                     {
                         complex = method.call0()?;
-                        &complex
+                        complex.as_borrowed()
                     } else {
                         // `obj` might still implement `__float__` or `__index__`, which will be
                         // handled by `PyComplex_{Real,Imag}AsDouble`, including propagating any

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -95,7 +95,7 @@
 //! ```
 use crate::{
     ffi, ffi_ptr_ext::FfiPtrExt, types::PyComplex, Borrowed, Bound, FromPyObject, PyAny, PyErr,
-    PyResult, Python,
+    Python,
 };
 use num_complex::Complex;
 use std::ffi::c_double;
@@ -147,7 +147,9 @@ macro_rules! complex_conversion {
 
         #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
         impl FromPyObject<'_, '_> for Complex<$float> {
-            fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Complex<$float>> {
+            type Error = PyErr;
+
+            fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Complex<$float>, Self::Error> {
                 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
                 unsafe {
                     let val = ffi::PyComplex_AsCComplex(obj.as_ptr());

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -48,7 +48,7 @@ use crate::ffi;
 use crate::sync::PyOnceLock;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
-use crate::{Bound, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
+use crate::{Borrowed, Bound, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
 
 #[cfg(feature = "num-bigint")]
 use num_bigint::BigInt;
@@ -62,8 +62,8 @@ fn get_fraction_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
 
 macro_rules! rational_conversion {
     ($int: ty) => {
-        impl<'py> FromPyObject<'py> for Ratio<$int> {
-            fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        impl<'py> FromPyObject<'_, 'py> for Ratio<$int> {
+            fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
                 let py = obj.py();
                 let py_numerator_obj = obj.getattr(crate::intern!(py, "numerator"))?;
                 let py_denominator_obj = obj.getattr(crate::intern!(py, "denominator"))?;

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -63,7 +63,9 @@ fn get_fraction_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
 macro_rules! rational_conversion {
     ($int: ty) => {
         impl<'py> FromPyObject<'_, 'py> for Ratio<$int> {
-            fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+            type Error = PyErr;
+
+            fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
                 let py = obj.py();
                 let py_numerator_obj = obj.getattr(crate::intern!(py, "numerator"))?;
                 let py_denominator_obj = obj.getattr(crate::intern!(py, "denominator"))?;

--- a/src/conversions/ordered_float.rs
+++ b/src/conversions/ordered_float.rs
@@ -53,15 +53,15 @@
 
 use crate::conversion::IntoPyObject;
 use crate::exceptions::PyValueError;
-use crate::types::{any::PyAnyMethods, PyFloat};
-use crate::{Bound, FromPyObject, PyAny, PyResult, Python};
+use crate::types::PyFloat;
+use crate::{Borrowed, Bound, FromPyObject, PyAny, PyResult, Python};
 use ordered_float::{NotNan, OrderedFloat};
 use std::convert::Infallible;
 
 macro_rules! float_conversions {
     ($wrapper:ident, $float_type:ty, $constructor:expr) => {
-        impl FromPyObject<'_> for $wrapper<$float_type> {
-            fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+        impl FromPyObject<'_, '_> for $wrapper<$float_type> {
+            fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
                 let val: $float_type = obj.extract()?;
                 $constructor(val)
             }
@@ -101,6 +101,7 @@ mod test_ordered_float {
     use super::*;
     use crate::ffi::c_str;
     use crate::py_run;
+    use crate::types::PyAnyMethods;
 
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -55,12 +55,12 @@ use crate::sync::PyOnceLock;
 use crate::types::any::PyAnyMethods;
 use crate::types::string::PyStringMethods;
 use crate::types::PyType;
-use crate::{Bound, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
+use crate::{Borrowed, Bound, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
 use rust_decimal::Decimal;
 use std::str::FromStr;
 
-impl FromPyObject<'_> for Decimal {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for Decimal {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         // use the string representation to not be lossy
         if let Ok(val) = obj.extract() {
             Ok(Decimal::new(val, 0))

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -60,7 +60,9 @@ use rust_decimal::Decimal;
 use std::str::FromStr;
 
 impl FromPyObject<'_, '_> for Decimal {
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         // use the string representation to not be lossy
         if let Ok(val) = obj.extract() {
             Ok(Decimal::new(val, 0))

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -15,7 +15,7 @@
 //!
 //! Note that you must use compatible versions of smallvec and PyO3.
 //! The required smallvec version may vary based on the version of PyO3.
-use crate::conversion::IntoPyObject;
+use crate::conversion::{FromPyObjectOwned, IntoPyObject};
 use crate::exceptions::PyTypeError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
@@ -74,7 +74,7 @@ where
 impl<'py, A> FromPyObject<'_, 'py> for SmallVec<A>
 where
     A: Array,
-    A::Item: for<'a> FromPyObject<'a, 'py>,
+    A::Item: FromPyObjectOwned<'py>,
 {
     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         if obj.is_instance_of::<PyString>() {
@@ -92,7 +92,7 @@ where
 fn extract_sequence<'py, A>(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<SmallVec<A>>
 where
     A: Array,
-    A::Item: for<'a> FromPyObject<'a, 'py>,
+    A::Item: FromPyObjectOwned<'py>,
 {
     // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
     // to support this function and if not, we will only fail extraction safely.

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -76,7 +76,9 @@ where
     A: Array,
     A::Item: FromPyObjectOwned<'py>,
 {
-    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         if obj.is_instance_of::<PyString>() {
             return Err(PyTypeError::new_err("Can't extract `str` to `SmallVec`"));
         }
@@ -106,7 +108,7 @@ where
 
     let mut sv = SmallVec::with_capacity(seq.len().unwrap_or(0));
     for item in seq.try_iter()? {
-        sv.push(item?.extract::<A::Item>()?);
+        sv.push(item?.extract::<A::Item>().map_err(Into::into)?);
     }
     Ok(sv)
 }

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -21,8 +21,9 @@ use crate::exceptions::PyTypeError;
 use crate::inspect::types::TypeInfo;
 use crate::types::any::PyAnyMethods;
 use crate::types::{PySequence, PyString};
-use crate::PyErr;
-use crate::{err::DowncastError, ffi, Bound, FromPyObject, PyAny, PyResult, Python};
+use crate::{
+    err::DowncastError, ffi, Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python,
+};
 use smallvec::{Array, SmallVec};
 
 impl<'py, A> IntoPyObject<'py> for SmallVec<A>
@@ -70,12 +71,12 @@ where
     }
 }
 
-impl<'py, A> FromPyObject<'py> for SmallVec<A>
+impl<'py, A> FromPyObject<'_, 'py> for SmallVec<A>
 where
     A: Array,
-    A::Item: FromPyObject<'py>,
+    A::Item: for<'a> FromPyObject<'a, 'py>,
 {
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         if obj.is_instance_of::<PyString>() {
             return Err(PyTypeError::new_err("Can't extract `str` to `SmallVec`"));
         }
@@ -88,10 +89,10 @@ where
     }
 }
 
-fn extract_sequence<'py, A>(obj: &Bound<'py, PyAny>) -> PyResult<SmallVec<A>>
+fn extract_sequence<'py, A>(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<SmallVec<A>>
 where
     A: Array,
-    A::Item: FromPyObject<'py>,
+    A::Item: for<'a> FromPyObject<'a, 'py>,
 {
     // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
     // to support this function and if not, we will only fail extraction safely.
@@ -99,7 +100,7 @@ where
         if ffi::PySequence_Check(obj.as_ptr()) != 0 {
             obj.cast_unchecked::<PySequence>()
         } else {
-            return Err(DowncastError::new(obj, "Sequence").into());
+            return Err(DowncastError::new_from_borrowed(obj, "Sequence").into());
         }
     };
 

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -1,4 +1,4 @@
-use crate::conversion::IntoPyObject;
+use crate::conversion::{FromPyObjectOwned, IntoPyObject};
 use crate::types::any::PyAnyMethods;
 use crate::types::PySequence;
 use crate::{err::DowncastError, ffi, FromPyObject, PyAny, PyResult, Python};
@@ -38,7 +38,7 @@ where
 
 impl<'py, T, const N: usize> FromPyObject<'_, 'py> for [T; N]
 where
-    T: for<'a> FromPyObject<'a, 'py>,
+    T: FromPyObjectOwned<'py>,
 {
     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         create_array_from_obj(obj)
@@ -47,7 +47,7 @@ where
 
 fn create_array_from_obj<'py, T, const N: usize>(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<[T; N]>
 where
-    T: for<'a> FromPyObject<'a, 'py>,
+    T: FromPyObjectOwned<'py>,
 {
     // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
     // to support this function and if not, we will only fail extraction safely.

--- a/src/conversions/std/cell.rs
+++ b/src/conversions/std/cell.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use crate::{conversion::IntoPyObject, Borrowed, FromPyObject, PyAny, PyResult, Python};
+use crate::{conversion::IntoPyObject, Borrowed, FromPyObject, PyAny, Python};
 
 impl<'py, T: Copy + IntoPyObject<'py>> IntoPyObject<'py> for Cell<T> {
     type Target = T::Target;
@@ -31,10 +31,12 @@ impl<'py, T: Copy + IntoPyObject<'py>> IntoPyObject<'py> for &Cell<T> {
 }
 
 impl<'a, 'py, T: FromPyObject<'a, 'py>> FromPyObject<'a, 'py> for Cell<T> {
+    type Error = T::Error;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = T::INPUT_TYPE;
 
-    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         ob.extract().map(Cell::new)
     }
 }

--- a/src/conversions/std/cell.rs
+++ b/src/conversions/std/cell.rs
@@ -1,9 +1,6 @@
 use std::cell::Cell;
 
-use crate::{
-    conversion::IntoPyObject, types::any::PyAnyMethods, Bound, FromPyObject, PyAny, PyResult,
-    Python,
-};
+use crate::{conversion::IntoPyObject, Borrowed, FromPyObject, PyAny, PyResult, Python};
 
 impl<'py, T: Copy + IntoPyObject<'py>> IntoPyObject<'py> for Cell<T> {
     type Target = T::Target;
@@ -33,11 +30,11 @@ impl<'py, T: Copy + IntoPyObject<'py>> IntoPyObject<'py> for &Cell<T> {
     }
 }
 
-impl<'py, T: FromPyObject<'py>> FromPyObject<'py> for Cell<T> {
+impl<'a, 'py, T: FromPyObject<'a, 'py>> FromPyObject<'a, 'py> for Cell<T> {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = T::INPUT_TYPE;
 
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         ob.extract().map(Cell::new)
     }
 }

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -6,10 +6,12 @@ use crate::sync::PyOnceLock;
 use crate::types::any::PyAnyMethods;
 use crate::types::string::PyStringMethods;
 use crate::types::PyType;
-use crate::{intern, Borrowed, Bound, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
+use crate::{intern, Borrowed, Bound, FromPyObject, Py, PyAny, PyErr, Python};
 
 impl FromPyObject<'_, '_> for IpAddr {
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         match obj.getattr(intern!(obj.py(), "packed")) {
             Ok(packed) => {
                 if let Ok(packed) = packed.extract::<[u8; 4]>() {

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -2,15 +2,14 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::conversion::IntoPyObject;
 use crate::exceptions::PyValueError;
-use crate::instance::Bound;
 use crate::sync::PyOnceLock;
 use crate::types::any::PyAnyMethods;
 use crate::types::string::PyStringMethods;
 use crate::types::PyType;
-use crate::{intern, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
+use crate::{intern, Borrowed, Bound, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
 
-impl FromPyObject<'_> for IpAddr {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for IpAddr {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         match obj.getattr(intern!(obj.py(), "packed")) {
             Ok(packed) => {
                 if let Ok(packed) = packed.extract::<[u8; 4]>() {

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -3,7 +3,7 @@ use std::{cmp, collections, hash};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::IntoPyObject,
+    conversion::{FromPyObjectOwned, IntoPyObject},
     instance::Bound,
     types::{any::PyAnyMethods, dict::PyDictMethods, PyDict},
     Borrowed, FromPyObject, PyAny, PyErr, Python,
@@ -109,8 +109,8 @@ where
 
 impl<'py, K, V, S> FromPyObject<'_, 'py> for collections::HashMap<K, V, S>
 where
-    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
-    V: for<'a> FromPyObject<'a, 'py>,
+    K: FromPyObjectOwned<'py> + cmp::Eq + hash::Hash,
+    V: FromPyObjectOwned<'py>,
     S: hash::BuildHasher + Default,
 {
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
@@ -130,8 +130,8 @@ where
 
 impl<'py, K, V> FromPyObject<'_, 'py> for collections::BTreeMap<K, V>
 where
-    K: for<'a> FromPyObject<'a, 'py> + cmp::Ord,
-    V: for<'a> FromPyObject<'a, 'py>,
+    K: FromPyObjectOwned<'py> + cmp::Ord,
+    V: FromPyObjectOwned<'py>,
 {
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.cast::<PyDict>()?;

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -6,7 +6,7 @@ use crate::{
     conversion::IntoPyObject,
     instance::Bound,
     types::{any::PyAnyMethods, dict::PyDictMethods, PyDict},
-    FromPyObject, PyAny, PyErr, Python,
+    Borrowed, FromPyObject, PyAny, PyErr, Python,
 };
 
 impl<'py, K, V, H> IntoPyObject<'py> for collections::HashMap<K, V, H>
@@ -107,16 +107,16 @@ where
     }
 }
 
-impl<'py, K, V, S> FromPyObject<'py> for collections::HashMap<K, V, S>
+impl<'py, K, V, S> FromPyObject<'_, 'py> for collections::HashMap<K, V, S>
 where
-    K: FromPyObject<'py> + cmp::Eq + hash::Hash,
-    V: FromPyObject<'py>,
+    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
+    V: for<'a> FromPyObject<'a, 'py>,
     S: hash::BuildHasher + Default,
 {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> Result<Self, PyErr> {
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.cast::<PyDict>()?;
         let mut ret = collections::HashMap::with_capacity_and_hasher(dict.len(), S::default());
-        for (k, v) in dict {
+        for (k, v) in dict.iter() {
             ret.insert(k.extract()?, v.extract()?);
         }
         Ok(ret)
@@ -128,15 +128,15 @@ where
     }
 }
 
-impl<'py, K, V> FromPyObject<'py> for collections::BTreeMap<K, V>
+impl<'py, K, V> FromPyObject<'_, 'py> for collections::BTreeMap<K, V>
 where
-    K: FromPyObject<'py> + cmp::Ord,
-    V: FromPyObject<'py>,
+    K: for<'a> FromPyObject<'a, 'py> + cmp::Ord,
+    V: for<'a> FromPyObject<'a, 'py>,
 {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> Result<Self, PyErr> {
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.cast::<PyDict>()?;
         let mut ret = collections::BTreeMap::new();
-        for (k, v) in dict {
+        for (k, v) in dict.iter() {
             ret.insert(k.extract()?, v.extract()?);
         }
         Ok(ret)

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -113,11 +113,16 @@ where
     V: FromPyObjectOwned<'py>,
     S: hash::BuildHasher + Default,
 {
-    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         let dict = ob.cast::<PyDict>()?;
         let mut ret = collections::HashMap::with_capacity_and_hasher(dict.len(), S::default());
         for (k, v) in dict.iter() {
-            ret.insert(k.extract()?, v.extract()?);
+            ret.insert(
+                k.extract().map_err(Into::into)?,
+                v.extract().map_err(Into::into)?,
+            );
         }
         Ok(ret)
     }
@@ -133,11 +138,16 @@ where
     K: FromPyObjectOwned<'py> + cmp::Ord,
     V: FromPyObjectOwned<'py>,
 {
+    type Error = PyErr;
+
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, PyErr> {
         let dict = ob.cast::<PyDict>()?;
         let mut ret = collections::BTreeMap::new();
         for (k, v) in dict.iter() {
-            ret.insert(k.extract()?, v.extract()?);
+            ret.insert(
+                k.extract().map_err(Into::into)?,
+                v.extract().map_err(Into::into)?,
+            );
         }
         Ok(ret)
     }

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -3,9 +3,8 @@ use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-use crate::types::any::PyAnyMethods;
 use crate::types::{PyBytes, PyInt};
-use crate::{exceptions, ffi, Bound, FromPyObject, PyAny, PyErr, PyResult, Python};
+use crate::{exceptions, ffi, Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python};
 use std::convert::Infallible;
 use std::ffi::c_long;
 use std::num::{
@@ -51,11 +50,11 @@ macro_rules! int_fits_larger_int {
             }
         }
 
-        impl FromPyObject<'_> for $rust_type {
+        impl FromPyObject<'_, '_> for $rust_type {
             #[cfg(feature = "experimental-inspect")]
             const INPUT_TYPE: &'static str = <$larger_type>::INPUT_TYPE;
 
-            fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+            fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
                 let val: $larger_type = obj.extract()?;
                 <$rust_type>::try_from(val)
                     .map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
@@ -129,17 +128,12 @@ macro_rules! int_convert_u64_or_i64 {
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 (*self).into_pyobject(py)
             }
-
-            #[cfg(feature = "experimental-inspect")]
-            fn type_output() -> TypeInfo {
-                TypeInfo::builtin("int")
-            }
         }
-        impl FromPyObject<'_> for $rust_type {
+        impl FromPyObject<'_, '_> for $rust_type {
             #[cfg(feature = "experimental-inspect")]
             const INPUT_TYPE: &'static str = "int";
 
-            fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<$rust_type> {
+            fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<$rust_type> {
                 extract_int!(obj, !0, $pylong_as_ll_or_ull, $force_index_call)
             }
 
@@ -194,11 +188,11 @@ macro_rules! int_fits_c_long {
             }
         }
 
-        impl<'py> FromPyObject<'py> for $rust_type {
+        impl<'py> FromPyObject<'_, 'py> for $rust_type {
             #[cfg(feature = "experimental-inspect")]
             const INPUT_TYPE: &'static str = "int";
 
-            fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+            fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
                 let val: c_long = extract_int!(obj, -1, ffi::PyLong_AsLong)?;
                 <$rust_type>::try_from(val)
                     .map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
@@ -277,11 +271,11 @@ impl<'py> IntoPyObject<'py> for &'_ u8 {
     }
 }
 
-impl FromPyObject<'_> for u8 {
+impl<'py> FromPyObject<'_, 'py> for u8 {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "int";
 
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         let val: c_long = extract_int!(obj, -1, ffi::PyLong_AsLong)?;
         u8::try_from(val).map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
     }
@@ -408,11 +402,11 @@ mod fast_128bit_int_conversion {
                 }
             }
 
-            impl FromPyObject<'_> for $rust_type {
+            impl FromPyObject<'_, '_> for $rust_type {
                 #[cfg(feature = "experimental-inspect")]
                 const INPUT_TYPE: &'static str = "int";
 
-                fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<$rust_type> {
+                fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<$rust_type> {
                     let num =
                         unsafe { ffi::PyNumber_Index(ob.as_ptr()).assume_owned_or_err(ob.py())? };
                     let mut buffer = [0u8; std::mem::size_of::<$rust_type>()];
@@ -474,6 +468,7 @@ mod fast_128bit_int_conversion {
 #[cfg(any(Py_LIMITED_API, GraalPy))]
 mod slow_128bit_int_conversion {
     use super::*;
+    use crate::types::any::PyAnyMethods as _;
     const SHIFT: usize = 64;
 
     // for 128bit Integers
@@ -526,11 +521,11 @@ mod slow_128bit_int_conversion {
                 }
             }
 
-            impl FromPyObject<'_> for $rust_type {
+            impl FromPyObject<'_, '_> for $rust_type {
                 #[cfg(feature = "experimental-inspect")]
                 const INPUT_TYPE: &'static str = "int";
 
-                fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<$rust_type> {
+                fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<$rust_type> {
                     let py = ob.py();
                     unsafe {
                         let lower = err_if_invalid_value(
@@ -614,11 +609,11 @@ macro_rules! nonzero_int_impl {
             }
         }
 
-        impl FromPyObject<'_> for $nonzero_type {
+        impl FromPyObject<'_, '_> for $nonzero_type {
             #[cfg(feature = "experimental-inspect")]
             const INPUT_TYPE: &'static str = <$primitive_type>::INPUT_TYPE;
 
-            fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+            fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
                 let val: $primitive_type = obj.extract()?;
                 <$nonzero_type>::try_from(val)
                     .map_err(|_| exceptions::PyValueError::new_err("invalid zero value"))
@@ -648,6 +643,7 @@ nonzero_int_impl!(NonZeroUsize, usize);
 #[cfg(test)]
 mod test_128bit_integers {
     use super::*;
+    use crate::types::PyAnyMethods;
 
     #[cfg(not(target_arch = "wasm32"))]
     use crate::types::PyDict;

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -51,10 +51,12 @@ macro_rules! int_fits_larger_int {
         }
 
         impl FromPyObject<'_, '_> for $rust_type {
+            type Error = PyErr;
+
             #[cfg(feature = "experimental-inspect")]
             const INPUT_TYPE: &'static str = <$larger_type>::INPUT_TYPE;
 
-            fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+            fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
                 let val: $larger_type = obj.extract()?;
                 <$rust_type>::try_from(val)
                     .map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
@@ -130,10 +132,12 @@ macro_rules! int_convert_u64_or_i64 {
             }
         }
         impl FromPyObject<'_, '_> for $rust_type {
+            type Error = PyErr;
+
             #[cfg(feature = "experimental-inspect")]
             const INPUT_TYPE: &'static str = "int";
 
-            fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<$rust_type> {
+            fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<$rust_type, Self::Error> {
                 extract_int!(obj, !0, $pylong_as_ll_or_ull, $force_index_call)
             }
 
@@ -189,10 +193,12 @@ macro_rules! int_fits_c_long {
         }
 
         impl<'py> FromPyObject<'_, 'py> for $rust_type {
+            type Error = PyErr;
+
             #[cfg(feature = "experimental-inspect")]
             const INPUT_TYPE: &'static str = "int";
 
-            fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+            fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
                 let val: c_long = extract_int!(obj, -1, ffi::PyLong_AsLong)?;
                 <$rust_type>::try_from(val)
                     .map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
@@ -272,10 +278,12 @@ impl<'py> IntoPyObject<'py> for &'_ u8 {
 }
 
 impl<'py> FromPyObject<'_, 'py> for u8 {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "int";
 
-    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         let val: c_long = extract_int!(obj, -1, ffi::PyLong_AsLong)?;
         u8::try_from(val).map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
     }
@@ -403,10 +411,12 @@ mod fast_128bit_int_conversion {
             }
 
             impl FromPyObject<'_, '_> for $rust_type {
+                type Error = PyErr;
+
                 #[cfg(feature = "experimental-inspect")]
                 const INPUT_TYPE: &'static str = "int";
 
-                fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<$rust_type> {
+                fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<$rust_type, Self::Error> {
                     let num =
                         unsafe { ffi::PyNumber_Index(ob.as_ptr()).assume_owned_or_err(ob.py())? };
                     let mut buffer = [0u8; std::mem::size_of::<$rust_type>()];
@@ -522,10 +532,12 @@ mod slow_128bit_int_conversion {
             }
 
             impl FromPyObject<'_, '_> for $rust_type {
+                type Error = PyErr;
+
                 #[cfg(feature = "experimental-inspect")]
                 const INPUT_TYPE: &'static str = "int";
 
-                fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<$rust_type> {
+                fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<$rust_type, Self::Error> {
                     let py = ob.py();
                     unsafe {
                         let lower = err_if_invalid_value(
@@ -610,10 +622,12 @@ macro_rules! nonzero_int_impl {
         }
 
         impl FromPyObject<'_, '_> for $nonzero_type {
+            type Error = PyErr;
+
             #[cfg(feature = "experimental-inspect")]
             const INPUT_TYPE: &'static str = <$primitive_type>::INPUT_TYPE;
 
-            fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+            fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
                 let val: $primitive_type = obj.extract()?;
                 <$nonzero_type>::try_from(val)
                     .map_err(|_| exceptions::PyValueError::new_err("invalid zero value"))

--- a/src/conversions/std/option.rs
+++ b/src/conversions/std/option.rs
@@ -1,7 +1,8 @@
 use crate::{
-    conversion::IntoPyObject, types::any::PyAnyMethods, Bound, BoundObject, FromPyObject, PyAny,
-    PyResult, Python,
+    conversion::IntoPyObject, types::any::PyAnyMethods, BoundObject, FromPyObject, PyAny, PyResult,
+    Python,
 };
+use crate::{Borrowed, Bound};
 
 impl<'py, T> IntoPyObject<'py> for Option<T>
 where
@@ -37,11 +38,11 @@ where
     }
 }
 
-impl<'py, T> FromPyObject<'py> for Option<T>
+impl<'a, 'py, T> FromPyObject<'a, 'py> for Option<T>
 where
-    T: FromPyObject<'py>,
+    T: FromPyObject<'a, 'py>,
 {
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         if obj.is_none() {
             Ok(None)
         } else {

--- a/src/conversions/std/option.rs
+++ b/src/conversions/std/option.rs
@@ -1,6 +1,5 @@
 use crate::{
-    conversion::IntoPyObject, types::any::PyAnyMethods, BoundObject, FromPyObject, PyAny, PyResult,
-    Python,
+    conversion::IntoPyObject, types::any::PyAnyMethods, BoundObject, FromPyObject, PyAny, Python,
 };
 use crate::{Borrowed, Bound};
 
@@ -42,7 +41,9 @@ impl<'a, 'py, T> FromPyObject<'a, 'py> for Option<T>
 where
     T: FromPyObject<'a, 'py>,
 {
-    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+    type Error = T::Error;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if obj.is_none() {
             Ok(None)
         } else {

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -2,7 +2,7 @@ use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Bound;
 use crate::types::PyString;
-use crate::{ffi, Borrowed, FromPyObject, PyAny, PyResult, Python};
+use crate::{ffi, Borrowed, FromPyObject, PyAny, PyErr, Python};
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::ffi::{OsStr, OsString};
@@ -71,7 +71,9 @@ impl<'py> IntoPyObject<'py> for &&OsStr {
 // be impossible to implement on Windows. Hence it's omitted entirely
 
 impl FromPyObject<'_, '_> for OsString {
-    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let pystring = ob.cast::<PyString>()?;
 
         #[cfg(not(windows))]

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -2,7 +2,7 @@ use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Bound;
 use crate::types::PyString;
-use crate::{ffi, FromPyObject, PyAny, PyResult, Python};
+use crate::{ffi, Borrowed, FromPyObject, PyAny, PyResult, Python};
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::ffi::{OsStr, OsString};
@@ -70,8 +70,8 @@ impl<'py> IntoPyObject<'py> for &&OsStr {
 // There's no FromPyObject implementation for &OsStr because albeit possible on Unix, this would
 // be impossible to implement on Windows. Hence it's omitted entirely
 
-impl FromPyObject<'_> for OsString {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for OsString {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let pystring = ob.cast::<PyString>()?;
 
         #[cfg(not(windows))]
@@ -97,8 +97,6 @@ impl FromPyObject<'_> for OsString {
 
         #[cfg(windows)]
         {
-            use crate::types::string::PyStringMethods;
-
             // Take the quick and easy shortcut if UTF-8
             if let Ok(utf8_string) = pystring.to_cow() {
                 return Ok(utf8_string.into_owned().into());
@@ -169,7 +167,7 @@ impl<'py> IntoPyObject<'py> for &OsString {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{PyAnyMethods, PyString, PyStringMethods};
+    use crate::types::{PyString, PyStringMethods};
     use crate::{BoundObject, IntoPyObject, Python};
     use std::fmt::Debug;
     use std::{

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -179,6 +179,7 @@ mod tests {
     #[cfg(not(windows))]
     fn test_non_utf8_conversion() {
         Python::attach(|py| {
+            use crate::types::PyAnyMethods;
             #[cfg(not(target_os = "wasi"))]
             use std::os::unix::ffi::OsStrExt;
             #[cfg(target_os = "wasi")]

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -1,17 +1,16 @@
 use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
-use crate::instance::Bound;
 use crate::sync::PyOnceLock;
 use crate::types::any::PyAnyMethods;
-use crate::{ffi, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
+use crate::{ffi, Borrowed, Bound, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 // See osstr.rs for why there's no FromPyObject impl for &Path
 
-impl FromPyObject<'_> for PathBuf {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for PathBuf {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         // We use os.fspath to get the underlying path as bytes or str
         let path = unsafe { ffi::PyOS_FSPath(ob.as_ptr()).assume_owned_or_err(ob.py())? };
         Ok(path.extract::<OsString>()?.into())

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -2,7 +2,7 @@ use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::sync::PyOnceLock;
 use crate::types::any::PyAnyMethods;
-use crate::{ffi, Borrowed, Bound, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
+use crate::{ffi, Borrowed, Bound, FromPyObject, Py, PyAny, PyErr, Python};
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -10,7 +10,9 @@ use std::path::{Path, PathBuf};
 // See osstr.rs for why there's no FromPyObject impl for &Path
 
 impl FromPyObject<'_, '_> for PathBuf {
-    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         // We use os.fspath to get the underlying path as bytes or str
         let path = unsafe { ffi::PyOS_FSPath(ob.as_ptr()).assume_owned_or_err(ob.py())? };
         Ok(path.extract::<OsString>()?.into())

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -98,6 +98,7 @@ mod tests {
     #[cfg(not(windows))]
     fn test_non_utf8_conversion() {
         Python::attach(|py| {
+            use crate::types::PyAnyMethods;
             use std::ffi::OsStr;
             #[cfg(not(target_os = "wasi"))]
             use std::os::unix::ffi::OsStrExt;

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -3,7 +3,7 @@ use std::{cmp, collections, hash};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::IntoPyObject,
+    conversion::{FromPyObjectOwned, IntoPyObject},
     types::{
         any::PyAnyMethods,
         frozenset::PyFrozenSetMethods,
@@ -54,7 +54,7 @@ where
 
 impl<'py, K, S> FromPyObject<'_, 'py> for collections::HashSet<K, S>
 where
-    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
+    K: FromPyObjectOwned<'py> + cmp::Eq + hash::Hash,
     S: hash::BuildHasher + Default,
 {
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
@@ -115,7 +115,7 @@ where
 
 impl<'py, K> FromPyObject<'_, 'py> for collections::BTreeSet<K>
 where
-    K: for<'a> FromPyObject<'a, 'py> + cmp::Ord,
+    K: FromPyObjectOwned<'py> + cmp::Ord,
 {
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         match ob.cast::<PySet>() {

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -4,14 +4,13 @@ use std::{cmp, collections, hash};
 use crate::inspect::types::TypeInfo;
 use crate::{
     conversion::IntoPyObject,
-    instance::Bound,
     types::{
         any::PyAnyMethods,
         frozenset::PyFrozenSetMethods,
         set::{try_new_from_iter, PySetMethods},
         PyFrozenSet, PySet,
     },
-    FromPyObject, PyAny, PyErr, PyResult, Python,
+    Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python,
 };
 
 impl<'py, K, S> IntoPyObject<'py> for collections::HashSet<K, S>
@@ -53,12 +52,12 @@ where
     }
 }
 
-impl<'py, K, S> FromPyObject<'py> for collections::HashSet<K, S>
+impl<'py, K, S> FromPyObject<'_, 'py> for collections::HashSet<K, S>
 where
-    K: FromPyObject<'py> + cmp::Eq + hash::Hash,
+    K: for<'a> FromPyObject<'a, 'py> + cmp::Eq + hash::Hash,
     S: hash::BuildHasher + Default,
 {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         match ob.cast::<PySet>() {
             Ok(set) => set.iter().map(|any| any.extract()).collect(),
             Err(err) => {
@@ -114,11 +113,11 @@ where
     }
 }
 
-impl<'py, K> FromPyObject<'py> for collections::BTreeSet<K>
+impl<'py, K> FromPyObject<'_, 'py> for collections::BTreeSet<K>
 where
-    K: FromPyObject<'py> + cmp::Ord,
+    K: for<'a> FromPyObject<'a, 'py> + cmp::Ord,
 {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         match ob.cast::<PySet>() {
             Ok(set) => set.iter().map(|any| any.extract()).collect(),
             Err(err) => {

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -35,8 +35,8 @@ where
     }
 }
 
-impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a [u8] {
-    fn from_py_object_bound(obj: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
+impl<'a> crate::conversion::FromPyObject<'a, '_> for &'a [u8] {
+    fn extract(obj: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         Ok(obj.cast::<PyBytes>()?.as_bytes())
     }
 
@@ -51,8 +51,8 @@ impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a [u8] {
 /// If the source object is a `bytes` object, the `Cow` will be borrowed and
 /// pointing into the source object, and no copying or heap allocations will happen.
 /// If it is a `bytearray`, its contents will be copied to an owned `Cow`.
-impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for Cow<'a, [u8]> {
-    fn from_py_object_bound(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
+impl<'a> crate::conversion::FromPyObject<'a, '_> for Cow<'a, [u8]> {
+    fn extract(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         if let Ok(bytes) = ob.cast::<PyBytes>() {
             return Ok(Cow::Borrowed(bytes.as_bytes()));
         }

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -5,7 +5,7 @@ use crate::inspect::types::TypeInfo;
 use crate::{
     conversion::IntoPyObject,
     types::{PyByteArray, PyByteArrayMethods, PyBytes},
-    Bound, PyAny, PyErr, PyResult, Python,
+    Bound, DowncastError, PyAny, PyErr, Python,
 };
 
 impl<'a, 'py, T> IntoPyObject<'py> for &'a [T]
@@ -35,8 +35,10 @@ where
     }
 }
 
-impl<'a> crate::conversion::FromPyObject<'a, '_> for &'a [u8] {
-    fn extract(obj: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> crate::conversion::FromPyObject<'a, 'py> for &'a [u8] {
+    type Error = DowncastError<'a, 'py>;
+
+    fn extract(obj: crate::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         Ok(obj.cast::<PyBytes>()?.as_bytes())
     }
 
@@ -51,8 +53,10 @@ impl<'a> crate::conversion::FromPyObject<'a, '_> for &'a [u8] {
 /// If the source object is a `bytes` object, the `Cow` will be borrowed and
 /// pointing into the source object, and no copying or heap allocations will happen.
 /// If it is a `bytearray`, its contents will be copied to an owned `Cow`.
-impl<'a> crate::conversion::FromPyObject<'a, '_> for Cow<'a, [u8]> {
-    fn extract(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> crate::conversion::FromPyObject<'a, 'py> for Cow<'a, [u8]> {
+    type Error = DowncastError<'a, 'py>;
+
+    fn extract(ob: crate::Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(bytes) = ob.cast::<PyBytes>() {
             return Ok(Cow::Borrowed(bytes.as_bytes()));
         }

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -3,10 +3,8 @@ use std::{borrow::Cow, convert::Infallible};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::IntoPyObject,
-    instance::Bound,
-    types::{string::PyStringMethods, PyString},
-    FromPyObject, PyAny, PyResult, Python,
+    conversion::IntoPyObject, instance::Bound, types::PyString, Borrowed, FromPyObject, PyAny,
+    PyResult, Python,
 };
 
 impl<'py> IntoPyObject<'py> for &str {
@@ -161,11 +159,11 @@ impl<'py> IntoPyObject<'py> for &String {
 }
 
 #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
-impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a str {
+impl<'a> crate::conversion::FromPyObject<'a, '_> for &'a str {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "str";
 
-    fn from_py_object_bound(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
+    fn extract(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         ob.cast::<PyString>()?.to_str()
     }
 
@@ -175,11 +173,11 @@ impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a str {
     }
 }
 
-impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for Cow<'a, str> {
+impl<'a> crate::conversion::FromPyObject<'a, '_> for Cow<'a, str> {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "str";
 
-    fn from_py_object_bound(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
+    fn extract(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
         ob.cast::<PyString>()?.to_cow()
     }
 
@@ -191,11 +189,11 @@ impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for Cow<'a, str> {
 
 /// Allows extracting strings from Python objects.
 /// Accepts Python `str` and `unicode` objects.
-impl FromPyObject<'_> for String {
+impl FromPyObject<'_, '_> for String {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "str";
 
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         obj.cast::<PyString>()?.to_cow().map(Cow::into_owned)
     }
 
@@ -205,11 +203,11 @@ impl FromPyObject<'_> for String {
     }
 }
 
-impl FromPyObject<'_> for char {
+impl FromPyObject<'_, '_> for char {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "str";
 
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let s = obj.cast::<PyString>()?.to_cow()?;
         let mut iter = s.chars();
         if let (Some(ch), None) = (iter.next(), iter.next()) {

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, convert::Infallible};
 use crate::inspect::types::TypeInfo;
 use crate::{
     conversion::IntoPyObject, instance::Bound, types::PyString, Borrowed, FromPyObject, PyAny,
-    PyResult, Python,
+    PyErr, Python,
 };
 
 impl<'py> IntoPyObject<'py> for &str {
@@ -160,10 +160,12 @@ impl<'py> IntoPyObject<'py> for &String {
 
 #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 impl<'a> crate::conversion::FromPyObject<'a, '_> for &'a str {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "str";
 
-    fn extract(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
+    fn extract(ob: crate::Borrowed<'a, '_, PyAny>) -> Result<Self, Self::Error> {
         ob.cast::<PyString>()?.to_str()
     }
 
@@ -174,10 +176,12 @@ impl<'a> crate::conversion::FromPyObject<'a, '_> for &'a str {
 }
 
 impl<'a> crate::conversion::FromPyObject<'a, '_> for Cow<'a, str> {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "str";
 
-    fn extract(ob: crate::Borrowed<'a, '_, PyAny>) -> PyResult<Self> {
+    fn extract(ob: crate::Borrowed<'a, '_, PyAny>) -> Result<Self, Self::Error> {
         ob.cast::<PyString>()?.to_cow()
     }
 
@@ -190,10 +194,12 @@ impl<'a> crate::conversion::FromPyObject<'a, '_> for Cow<'a, str> {
 /// Allows extracting strings from Python objects.
 /// Accepts Python `str` and `unicode` objects.
 impl FromPyObject<'_, '_> for String {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "str";
 
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         obj.cast::<PyString>()?.to_cow().map(Cow::into_owned)
     }
 
@@ -204,10 +210,12 @@ impl FromPyObject<'_, '_> for String {
 }
 
 impl FromPyObject<'_, '_> for char {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "str";
 
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let s = obj.cast::<PyString>()?.to_cow()?;
         let mut iter = s.chars();
         if let (Some(ch), None) = (iter.next(), iter.next()) {

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -13,7 +13,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
 
 impl FromPyObject<'_, '_> for Duration {
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let delta = obj.cast::<PyDelta>()?;
         #[cfg(not(Py_LIMITED_API))]
         let (days, seconds, microseconds) = {
@@ -88,7 +90,9 @@ impl<'py> IntoPyObject<'py> for &Duration {
 // TODO: it might be nice to investigate using timestamps anyway, at least when the datetime is a safe range.
 
 impl FromPyObject<'_, '_> for SystemTime {
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let duration_since_unix_epoch: Duration = obj.sub(unix_epoch_py(obj.py())?)?.extract()?;
         UNIX_EPOCH
             .checked_add(duration_since_unix_epoch)

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -12,8 +12,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
 
-impl FromPyObject<'_> for Duration {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for Duration {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let delta = obj.cast::<PyDelta>()?;
         #[cfg(not(Py_LIMITED_API))]
         let (days, seconds, microseconds) = {
@@ -87,8 +87,8 @@ impl<'py> IntoPyObject<'py> for &Duration {
 //
 // TODO: it might be nice to investigate using timestamps anyway, at least when the datetime is a safe range.
 
-impl FromPyObject<'_> for SystemTime {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for SystemTime {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let duration_since_unix_epoch: Duration = obj.sub(unix_epoch_py(obj.py())?)?.extract()?;
         UNIX_EPOCH
             .checked_add(duration_since_unix_epoch)

--- a/src/conversions/time.rs
+++ b/src/conversions/time.rs
@@ -181,7 +181,9 @@ impl<'py> IntoPyObject<'py> for Duration {
 }
 
 impl FromPyObject<'_, '_> for Duration {
-    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Duration> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         #[cfg(not(Py_LIMITED_API))]
         let (days, seconds, microseconds) = {
             let delta = ob.cast::<PyDelta>()?;
@@ -224,7 +226,9 @@ impl<'py> IntoPyObject<'py> for Date {
 }
 
 impl FromPyObject<'_, '_> for Date {
-    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Date> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let (year, month, day) = {
             #[cfg(not(Py_LIMITED_API))]
             {
@@ -265,7 +269,9 @@ impl<'py> IntoPyObject<'py> for Time {
 }
 
 impl FromPyObject<'_, '_> for Time {
-    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Time> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let (hour, minute, second, microsecond) = {
             #[cfg(not(Py_LIMITED_API))]
             {
@@ -324,7 +330,9 @@ impl<'py> IntoPyObject<'py> for PrimitiveDateTime {
 }
 
 impl FromPyObject<'_, '_> for PrimitiveDateTime {
-    fn extract(dt: Borrowed<'_, '_, PyAny>) -> PyResult<PrimitiveDateTime> {
+    type Error = PyErr;
+
+    fn extract(dt: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let has_tzinfo = {
             #[cfg(not(Py_LIMITED_API))]
             {
@@ -361,7 +369,9 @@ impl<'py> IntoPyObject<'py> for UtcOffset {
 }
 
 impl FromPyObject<'_, '_> for UtcOffset {
-    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<UtcOffset> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         #[cfg(not(Py_LIMITED_API))]
         let ob = ob.cast::<PyTzInfo>()?;
 
@@ -418,7 +428,9 @@ impl<'py> IntoPyObject<'py> for OffsetDateTime {
 }
 
 impl FromPyObject<'_, '_> for OffsetDateTime {
-    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<OffsetDateTime> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let offset: UtcOffset = {
             #[cfg(not(Py_LIMITED_API))]
             {
@@ -481,7 +493,9 @@ impl<'py> IntoPyObject<'py> for UtcDateTime {
 }
 
 impl FromPyObject<'_, '_> for UtcDateTime {
-    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<UtcDateTime> {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let tzinfo = {
             #[cfg(not(Py_LIMITED_API))]
             {

--- a/src/conversions/time.rs
+++ b/src/conversions/time.rs
@@ -58,7 +58,7 @@ use crate::types::datetime::{PyDateAccess, PyDeltaAccess};
 use crate::types::{PyAnyMethods, PyDate, PyDateTime, PyDelta, PyNone, PyTime, PyTzInfo};
 #[cfg(not(Py_LIMITED_API))]
 use crate::types::{PyTimeAccess, PyTzInfoAccess};
-use crate::{Bound, FromPyObject, IntoPyObject, PyAny, PyErr, PyResult, Python};
+use crate::{Borrowed, Bound, FromPyObject, IntoPyObject, PyAny, PyErr, PyResult, Python};
 use time::{
     Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcDateTime, UtcOffset,
 };
@@ -180,8 +180,8 @@ impl<'py> IntoPyObject<'py> for Duration {
     }
 }
 
-impl FromPyObject<'_> for Duration {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Duration> {
+impl FromPyObject<'_, '_> for Duration {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Duration> {
         #[cfg(not(Py_LIMITED_API))]
         let (days, seconds, microseconds) = {
             let delta = ob.cast::<PyDelta>()?;
@@ -223,8 +223,8 @@ impl<'py> IntoPyObject<'py> for Date {
     }
 }
 
-impl FromPyObject<'_> for Date {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Date> {
+impl FromPyObject<'_, '_> for Date {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Date> {
         let (year, month, day) = {
             #[cfg(not(Py_LIMITED_API))]
             {
@@ -264,8 +264,8 @@ impl<'py> IntoPyObject<'py> for Time {
     }
 }
 
-impl FromPyObject<'_> for Time {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Time> {
+impl FromPyObject<'_, '_> for Time {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Time> {
         let (hour, minute, second, microsecond) = {
             #[cfg(not(Py_LIMITED_API))]
             {
@@ -323,8 +323,8 @@ impl<'py> IntoPyObject<'py> for PrimitiveDateTime {
     }
 }
 
-impl FromPyObject<'_> for PrimitiveDateTime {
-    fn extract_bound(dt: &Bound<'_, PyAny>) -> PyResult<PrimitiveDateTime> {
+impl FromPyObject<'_, '_> for PrimitiveDateTime {
+    fn extract(dt: Borrowed<'_, '_, PyAny>) -> PyResult<PrimitiveDateTime> {
         let has_tzinfo = {
             #[cfg(not(Py_LIMITED_API))]
             {
@@ -341,7 +341,7 @@ impl FromPyObject<'_> for PrimitiveDateTime {
             return Err(PyTypeError::new_err("expected a datetime without tzinfo"));
         }
 
-        let (date, time) = extract_date_time(dt)?;
+        let (date, time) = extract_date_time(&dt)?;
 
         Ok(PrimitiveDateTime::new(date, time))
     }
@@ -360,8 +360,8 @@ impl<'py> IntoPyObject<'py> for UtcOffset {
     }
 }
 
-impl FromPyObject<'_> for UtcOffset {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<UtcOffset> {
+impl FromPyObject<'_, '_> for UtcOffset {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<UtcOffset> {
         #[cfg(not(Py_LIMITED_API))]
         let ob = ob.cast::<PyTzInfo>()?;
 
@@ -417,8 +417,8 @@ impl<'py> IntoPyObject<'py> for OffsetDateTime {
     }
 }
 
-impl FromPyObject<'_> for OffsetDateTime {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<OffsetDateTime> {
+impl FromPyObject<'_, '_> for OffsetDateTime {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<OffsetDateTime> {
         let offset: UtcOffset = {
             #[cfg(not(Py_LIMITED_API))]
             {
@@ -440,7 +440,7 @@ impl FromPyObject<'_> for OffsetDateTime {
             }
         };
 
-        let (date, time) = extract_date_time(ob)?;
+        let (date, time) = extract_date_time(&ob)?;
 
         let primitive_dt = PrimitiveDateTime::new(date, time);
         Ok(primitive_dt.assume_offset(offset))
@@ -480,8 +480,8 @@ impl<'py> IntoPyObject<'py> for UtcDateTime {
     }
 }
 
-impl FromPyObject<'_> for UtcDateTime {
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<UtcDateTime> {
+impl FromPyObject<'_, '_> for UtcDateTime {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<UtcDateTime> {
         let tzinfo = {
             #[cfg(not(Py_LIMITED_API))]
             {
@@ -512,7 +512,7 @@ impl FromPyObject<'_> for UtcDateTime {
             ));
         }
 
-        let (date, time) = extract_date_time(ob)?;
+        let (date, time) = extract_date_time(&ob)?;
         let primitive_dt = PrimitiveDateTime::new(date, time);
         Ok(primitive_dt.assume_utc().into())
     }

--- a/src/conversions/uuid.rs
+++ b/src/conversions/uuid.rs
@@ -71,15 +71,15 @@ use crate::instance::Bound;
 use crate::sync::PyOnceLock;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
-use crate::{intern, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
+use crate::{intern, Borrowed, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
 
 fn get_uuid_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
     static UUID_CLS: PyOnceLock<Py<PyType>> = PyOnceLock::new();
     UUID_CLS.import(py, "uuid", "UUID")
 }
 
-impl FromPyObject<'_> for Uuid {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for Uuid {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let py = obj.py();
         let uuid_cls = get_uuid_cls(py)?;
 

--- a/src/conversions/uuid.rs
+++ b/src/conversions/uuid.rs
@@ -79,6 +79,8 @@ fn get_uuid_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
 }
 
 impl FromPyObject<'_, '_> for Uuid {
+    type Error = PyErr;
+
     fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let py = obj.py();
         let uuid_cls = get_uuid_cls(py)?;

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -3,8 +3,8 @@ use crate::{
     ffi,
     pyclass::boolean_struct::False,
     types::{any::PyAnyMethods, dict::PyDictMethods, tuple::PyTupleMethods, PyDict, PyTuple},
-    Borrowed, Bound, FromPyObject, PyAny, PyClass, PyClassGuard, PyClassGuardMut, PyErr, PyResult,
-    PyTypeCheck, Python,
+    Borrowed, Bound, DowncastError, FromPyObject, PyAny, PyClass, PyClassGuard, PyClassGuardMut,
+    PyErr, PyResult, PyTypeCheck, Python,
 };
 
 /// Helper type used to keep implementation more concise.
@@ -22,12 +22,16 @@ type PyArg<'py> = Borrowed<'py, 'py, PyAny>;
 /// There exists a trivial blanket implementation for `T: FromPyObject` with `Holder = ()`.
 pub trait PyFunctionArgument<'a, 'holder, 'py, const IS_OPTION: bool>: Sized {
     type Holder: FunctionArgumentHolder;
+    type Error: Into<PyErr>;
 
     /// Provides the type hint information for which Python types are allowed.
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str;
 
-    fn extract(obj: &'a Bound<'py, PyAny>, holder: &'holder mut Self::Holder) -> PyResult<Self>;
+    fn extract(
+        obj: &'a Bound<'py, PyAny>,
+        holder: &'holder mut Self::Holder,
+    ) -> Result<Self, Self::Error>;
 }
 
 impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for T
@@ -35,12 +39,13 @@ where
     T: FromPyObject<'a, 'py>,
 {
     type Holder = ();
+    type Error = T::Error;
 
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = T::INPUT_TYPE;
 
     #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> PyResult<Self> {
+    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> Result<Self, Self::Error> {
         obj.extract()
     }
 }
@@ -50,13 +55,14 @@ where
     T: PyTypeCheck,
 {
     type Holder = ();
+    type Error = DowncastError<'a, 'py>;
 
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = T::PYTHON_TYPE;
 
     #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> PyResult<Self> {
-        obj.cast().map_err(Into::into)
+    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> Result<Self, Self::Error> {
+        obj.cast()
     }
 }
 
@@ -65,12 +71,16 @@ where
     T: PyFunctionArgument<'a, 'holder, 'py, false>, // inner `Option`s will use `FromPyObject`
 {
     type Holder = T::Holder;
+    type Error = T::Error;
 
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "typing.Any | None";
 
     #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, holder: &'holder mut T::Holder) -> PyResult<Self> {
+    fn extract(
+        obj: &'a Bound<'py, PyAny>,
+        holder: &'holder mut T::Holder,
+    ) -> Result<Self, Self::Error> {
         if obj.is_none() {
             Ok(None)
         } else {
@@ -80,15 +90,16 @@ where
 }
 
 #[cfg(all(Py_LIMITED_API, not(Py_3_10)))]
-impl<'a, 'holder> PyFunctionArgument<'a, 'holder, '_, false> for &'holder str {
+impl<'a, 'holder, 'py> PyFunctionArgument<'a, 'holder, 'py, false> for &'holder str {
     type Holder = Option<std::borrow::Cow<'a, str>>;
+    type Error = <std::borrow::Cow<'a, str> as FromPyObject<'a, 'py>>::Error;
 
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "str";
 
     #[inline]
     fn extract(
-        obj: &'a Bound<'_, PyAny>,
+        obj: &'a Bound<'py, PyAny>,
         holder: &'holder mut Option<std::borrow::Cow<'a, str>>,
     ) -> PyResult<Self> {
         Ok(holder.insert(obj.extract()?))
@@ -139,7 +150,7 @@ where
 {
     match PyFunctionArgument::extract(obj, holder) {
         Ok(value) => Ok(value),
-        Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e)),
+        Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e.into())),
     }
 }
 

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -1,11 +1,10 @@
 use crate::{
-    conversion::FromPyObjectBound,
     exceptions::PyTypeError,
     ffi,
     pyclass::boolean_struct::False,
     types::{any::PyAnyMethods, dict::PyDictMethods, tuple::PyTupleMethods, PyDict, PyTuple},
-    Borrowed, Bound, PyAny, PyClass, PyClassGuard, PyClassGuardMut, PyErr, PyResult, PyTypeCheck,
-    Python,
+    Borrowed, Bound, FromPyObject, PyAny, PyClass, PyClassGuard, PyClassGuardMut, PyErr, PyResult,
+    PyTypeCheck, Python,
 };
 
 /// Helper type used to keep implementation more concise.
@@ -33,7 +32,7 @@ pub trait PyFunctionArgument<'a, 'holder, 'py, const IS_OPTION: bool>: Sized {
 
 impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for T
 where
-    T: FromPyObjectBound<'a, 'py>,
+    T: FromPyObject<'a, 'py>,
 {
     type Holder = ();
 

--- a/src/impl_/frompyobject.rs
+++ b/src/impl_/frompyobject.rs
@@ -42,13 +42,13 @@ fn extract_traceback(py: Python<'_>, mut error: PyErr) -> String {
     error_msg
 }
 
-pub fn extract_struct_field<'py, T>(
-    obj: &Bound<'py, PyAny>,
+pub fn extract_struct_field<'a, 'py, T>(
+    obj: &'a Bound<'py, PyAny>,
     struct_name: &str,
     field_name: &str,
 ) -> PyResult<T>
 where
-    T: FromPyObject<'py>,
+    T: FromPyObject<'a, 'py>,
 {
     match obj.extract() {
         Ok(value) => Ok(value),
@@ -92,13 +92,13 @@ fn failed_to_extract_struct_field(
     new_err
 }
 
-pub fn extract_tuple_struct_field<'py, T>(
-    obj: &Bound<'py, PyAny>,
+pub fn extract_tuple_struct_field<'a, 'py, T>(
+    obj: &'a Bound<'py, PyAny>,
     struct_name: &str,
     index: usize,
 ) -> PyResult<T>
 where
-    T: FromPyObject<'py>,
+    T: FromPyObject<'a, 'py>,
 {
     match obj.extract() {
         Ok(value) => Ok(value),

--- a/src/impl_/frompyobject.rs
+++ b/src/impl_/frompyobject.rs
@@ -54,7 +54,7 @@ where
         Ok(value) => Ok(value),
         Err(err) => Err(failed_to_extract_struct_field(
             obj.py(),
-            err,
+            err.into(),
             struct_name,
             field_name,
         )),
@@ -104,7 +104,7 @@ where
         Ok(value) => Ok(value),
         Err(err) => Err(failed_to_extract_tuple_struct_field(
             obj.py(),
-            err,
+            err.into(),
             struct_name,
             index,
         )),

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -467,7 +467,7 @@ mod conversion {
         assert_display(&<&[u8]>::type_output(), "Union[bytes, List[int]]");
         assert_display(&<&[String]>::type_output(), "Union[bytes, List[str]]");
         assert_display(
-            &<&[u8] as crate::conversion::FromPyObjectBound>::type_input(),
+            &<&[u8] as crate::conversion::FromPyObject>::type_input(),
             "bytes",
         );
     }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -936,6 +936,16 @@ impl<'a, 'py, T> Borrowed<'a, 'py, T> {
     pub(crate) fn to_any(self) -> Borrowed<'a, 'py, PyAny> {
         Borrowed(self.0, PhantomData, self.2)
     }
+
+    /// Extracts some type from the Python object.
+    ///
+    /// This is a wrapper function around [`FromPyObject::extract()`](crate::FromPyObject::extract).
+    pub fn extract<O>(self) -> PyResult<O>
+    where
+        O: FromPyObject<'a, 'py>,
+    {
+        FromPyObject::extract(self.to_any())
+    }
 }
 
 impl<'a, T: PyClass> Borrowed<'a, '_, T> {
@@ -1667,7 +1677,7 @@ impl<T> Py<T> {
     /// This is a wrapper function around `FromPyObject::extract()`.
     pub fn extract<'a, 'py, D>(&'a self, py: Python<'py>) -> PyResult<D>
     where
-        D: crate::conversion::FromPyObjectBound<'a, 'py>,
+        D: crate::conversion::FromPyObject<'a, 'py>,
         // TODO it might be possible to relax this bound in future, to allow
         // e.g. `.extract::<&str>(py)` where `py` is short-lived.
         'py: 'a,
@@ -2024,7 +2034,7 @@ impl<T> Drop for Py<T> {
     }
 }
 
-impl<T> FromPyObject<'_> for Py<T>
+impl<T> FromPyObject<'_, '_> for Py<T>
 where
     T: PyTypeCheck,
 {
@@ -2032,12 +2042,12 @@ where
     const INPUT_TYPE: &'static str = T::PYTHON_TYPE;
 
     /// Extracts `Self` from the source `PyObject`.
-    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+    fn extract(ob: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         ob.extract::<Bound<'_, T>>().map(Bound::unbind)
     }
 }
 
-impl<'py, T> FromPyObject<'py> for Bound<'py, T>
+impl<'py, T> FromPyObject<'_, 'py> for Bound<'py, T>
 where
     T: PyTypeCheck,
 {
@@ -2045,8 +2055,8 @@ where
     const INPUT_TYPE: &'static str = T::PYTHON_TYPE;
 
     /// Extracts `Self` from the source `PyObject`.
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        ob.cast().cloned().map_err(Into::into)
+    fn extract(ob: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        ob.cast().map(Borrowed::to_owned).map_err(Into::into)
     }
 }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,7 +8,7 @@
 //! use pyo3::prelude::*;
 //! ```
 
-pub use crate::conversion::{FromPyObject, IntoPyObject};
+pub use crate::conversion::{FromPyObject, FromPyObjectOwned, IntoPyObject};
 pub use crate::err::{PyErr, PyResult};
 #[allow(deprecated)]
 pub use crate::instance::PyObject;

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -7,7 +7,7 @@ use crate::{
         bytearray::PyByteArrayMethods, bytes::PyBytesMethods, string::PyStringMethods, PyByteArray,
         PyBytes, PyString,
     },
-    Borrowed, Bound, DowncastError, FromPyObject, IntoPyObject, Py, PyAny, PyErr, PyResult, Python,
+    Borrowed, Bound, DowncastError, FromPyObject, IntoPyObject, Py, PyAny, PyErr, Python,
 };
 
 /// A wrapper around `str` where the storage is owned by a Python `bytes` or `str` object.
@@ -79,7 +79,9 @@ impl TryFrom<Bound<'_, PyString>> for PyBackedStr {
 }
 
 impl FromPyObject<'_, '_> for PyBackedStr {
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let py_string = obj.cast::<PyString>()?.to_owned();
         Self::try_from(py_string)
     }
@@ -201,14 +203,19 @@ impl From<Bound<'_, PyByteArray>> for PyBackedBytes {
     }
 }
 
-impl FromPyObject<'_, '_> for PyBackedBytes {
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for PyBackedBytes {
+    type Error = DowncastError<'a, 'py>;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(bytes) = obj.cast::<PyBytes>() {
             Ok(Self::from(bytes.to_owned()))
         } else if let Ok(bytearray) = obj.cast::<PyByteArray>() {
             Ok(Self::from(bytearray.to_owned()))
         } else {
-            Err(DowncastError::new_from_borrowed(obj, "`bytes` or `bytearray`").into())
+            Err(DowncastError::new_from_borrowed(
+                obj,
+                "`bytes` or `bytearray`",
+            ))
         }
     }
 }

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -2,7 +2,7 @@ use crate::impl_::pycell::{PyClassObject, PyClassObjectLayout as _};
 use crate::pycell::PyBorrowMutError;
 use crate::pycell::{impl_::PyClassBorrowChecker, PyBorrowError};
 use crate::pyclass::boolean_struct::False;
-use crate::{ffi, Borrowed, FromPyObject, IntoPyObject, Py, PyClass};
+use crate::{ffi, Borrowed, FromPyObject, IntoPyObject, Py, PyClass, PyErr};
 use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
@@ -277,7 +277,9 @@ impl<T: PyClass> Deref for PyClassGuard<'_, T> {
 }
 
 impl<'a, 'py, T: PyClass> FromPyObject<'a, 'py> for PyClassGuard<'a, T> {
-    fn extract(obj: Borrowed<'a, 'py, crate::PyAny>) -> crate::PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'a, 'py, crate::PyAny>) -> Result<Self, Self::Error> {
         Self::try_from_class_object(obj.cast()?.get_class_object()).map_err(Into::into)
     }
 }
@@ -640,7 +642,9 @@ impl<T: PyClass<Frozen = False>> DerefMut for PyClassGuardMut<'_, T> {
 }
 
 impl<'a, 'py, T: PyClass<Frozen = False>> FromPyObject<'a, 'py> for PyClassGuardMut<'a, T> {
-    fn extract(obj: Borrowed<'a, 'py, crate::PyAny>) -> crate::PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'a, 'py, crate::PyAny>) -> Result<Self, Self::Error> {
         Self::try_from_class_object(obj.cast()?.get_class_object()).map_err(Into::into)
     }
 }

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -1,9 +1,8 @@
-use crate::conversion::FromPyObjectBound;
 use crate::impl_::pycell::{PyClassObject, PyClassObjectLayout as _};
 use crate::pycell::PyBorrowMutError;
 use crate::pycell::{impl_::PyClassBorrowChecker, PyBorrowError};
 use crate::pyclass::boolean_struct::False;
-use crate::{ffi, Borrowed, IntoPyObject, Py, PyClass};
+use crate::{ffi, Borrowed, FromPyObject, IntoPyObject, Py, PyClass};
 use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
@@ -277,8 +276,8 @@ impl<T: PyClass> Deref for PyClassGuard<'_, T> {
     }
 }
 
-impl<'a, 'py, T: PyClass> FromPyObjectBound<'a, 'py> for PyClassGuard<'a, T> {
-    fn from_py_object_bound(obj: Borrowed<'a, 'py, crate::PyAny>) -> crate::PyResult<Self> {
+impl<'a, 'py, T: PyClass> FromPyObject<'a, 'py> for PyClassGuard<'a, T> {
+    fn extract(obj: Borrowed<'a, 'py, crate::PyAny>) -> crate::PyResult<Self> {
         Self::try_from_class_object(obj.cast()?.get_class_object()).map_err(Into::into)
     }
 }
@@ -640,8 +639,8 @@ impl<T: PyClass<Frozen = False>> DerefMut for PyClassGuardMut<'_, T> {
     }
 }
 
-impl<'a, 'py, T: PyClass<Frozen = False>> FromPyObjectBound<'a, 'py> for PyClassGuardMut<'a, T> {
-    fn from_py_object_bound(obj: Borrowed<'a, 'py, crate::PyAny>) -> crate::PyResult<Self> {
+impl<'a, 'py, T: PyClass<Frozen = False>> FromPyObject<'a, 'py> for PyClassGuardMut<'a, T> {
+    fn extract(obj: Borrowed<'a, 'py, crate::PyAny>) -> crate::PyResult<Self> {
         Self::try_from_class_object(obj.cast()?.get_class_object()).map_err(Into::into)
     }
 }

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1,6 +1,6 @@
 use crate::call::PyCallArgs;
 use crate::class::basic::CompareOp;
-use crate::conversion::{FromPyObjectBound, IntoPyObject};
+use crate::conversion::{FromPyObject, IntoPyObject};
 use crate::err::{DowncastError, DowncastIntoError, PyErr, PyResult};
 use crate::exceptions::{PyAttributeError, PyTypeError};
 use crate::ffi_ptr_ext::FfiPtrExt;
@@ -865,11 +865,10 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
 
     /// Extracts some type from the Python object.
     ///
-    /// This is a wrapper function around
-    /// [`FromPyObject::extract_bound()`](crate::FromPyObject::extract_bound).
+    /// This is a wrapper function around [`FromPyObject::extract()`](crate::FromPyObject::extract).
     fn extract<'a, T>(&'a self) -> PyResult<T>
     where
-        T: FromPyObjectBound<'a, 'py>;
+        T: FromPyObject<'a, 'py>;
 
     /// Returns the reference count for the Python object.
     fn get_refcnt(&self) -> isize;
@@ -1489,9 +1488,9 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn extract<'a, T>(&'a self) -> PyResult<T>
     where
-        T: FromPyObjectBound<'a, 'py>,
+        T: FromPyObject<'a, 'py>,
     {
-        FromPyObjectBound::from_py_object_bound(self.as_borrowed())
+        FromPyObject::extract(self.as_borrowed())
     }
 
     fn get_refcnt(&self) -> isize {

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -866,7 +866,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// Extracts some type from the Python object.
     ///
     /// This is a wrapper function around [`FromPyObject::extract()`](crate::FromPyObject::extract).
-    fn extract<'a, T>(&'a self) -> PyResult<T>
+    fn extract<'a, T>(&'a self) -> Result<T, T::Error>
     where
         T: FromPyObject<'a, 'py>;
 
@@ -1486,7 +1486,7 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         unsafe { self.cast_into_unchecked() }
     }
 
-    fn extract<'a, T>(&'a self) -> PyResult<T>
+    fn extract<'a, T>(&'a self) -> Result<T, T::Error>
     where
         T: FromPyObject<'a, 'py>,
     {

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -177,11 +177,11 @@ impl<'py> IntoPyObject<'py> for &bool {
 /// Converts a Python `bool` to a Rust `bool`.
 ///
 /// Fails with `TypeError` if the input is not a Python `bool`.
-impl FromPyObject<'_> for bool {
+impl FromPyObject<'_, '_> for bool {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "bool";
 
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         let err = match obj.cast::<PyBool>() {
             Ok(obj) => return Ok(obj.is_true()),
             Err(err) => err,
@@ -196,7 +196,7 @@ impl FromPyObject<'_> for bool {
         };
 
         if is_numpy_bool {
-            let missing_conversion = |obj: &Bound<'_, PyAny>| {
+            let missing_conversion = |obj: Borrowed<'_, '_, PyAny>| {
                 PyTypeError::new_err(format!(
                     "object of type '{}' does not define a '__bool__' conversion",
                     obj.get_type()
@@ -242,9 +242,7 @@ impl FromPyObject<'_> for bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::any::PyAnyMethods;
-    use crate::types::boolobject::PyBoolMethods;
-    use crate::types::PyBool;
+    use crate::types::{PyAnyMethods, PyBool, PyBoolMethods};
     use crate::IntoPyObject;
     use crate::Python;
 

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -2,11 +2,12 @@
 use crate::inspect::types::TypeInfo;
 use crate::{
     exceptions::PyTypeError, ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound,
-    types::typeobject::PyTypeMethods, Borrowed, FromPyObject, PyAny, PyResult, Python,
+    types::typeobject::PyTypeMethods, Borrowed, FromPyObject, PyAny, Python,
 };
 
 use super::any::PyAnyMethods;
 use crate::conversion::IntoPyObject;
+use crate::PyErr;
 use std::convert::Infallible;
 use std::ptr;
 
@@ -178,10 +179,12 @@ impl<'py> IntoPyObject<'py> for &bool {
 ///
 /// Fails with `TypeError` if the input is not a Python `bool`.
 impl FromPyObject<'_, '_> for bool {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "bool";
 
-    fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         let err = match obj.cast::<PyBool>() {
             Ok(obj) => return Ok(obj.is_true()),
             Err(err) => err,

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -1,4 +1,3 @@
-use super::any::PyAnyMethods;
 use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
@@ -18,7 +17,7 @@ use std::ffi::c_double;
 /// [`Bound<'py, PyFloat>`][Bound].
 ///
 /// You can usually avoid directly working with this type
-/// by using [`IntoPyObject`] and [`extract`][PyAnyMethods::extract]
+/// by using [`IntoPyObject`] and [`extract`][crate::types::PyAnyMethods::extract]
 /// with [`f32`]/[`f64`].
 #[repr(transparent)]
 pub struct PyFloat(PyAny);
@@ -107,13 +106,13 @@ impl<'py> IntoPyObject<'py> for &f64 {
     }
 }
 
-impl<'py> FromPyObject<'py> for f64 {
+impl<'py> FromPyObject<'_, 'py> for f64 {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "float";
 
     // PyFloat_AsDouble returns -1.0 upon failure
     #[allow(clippy::float_cmp)]
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         // On non-limited API, .value() uses PyFloat_AS_DOUBLE which
         // allows us to have an optimized fast path for the case when
         // we have exactly a `float` object (it's not worth going through
@@ -178,11 +177,11 @@ impl<'py> IntoPyObject<'py> for &f32 {
     }
 }
 
-impl<'py> FromPyObject<'py> for f32 {
+impl<'py> FromPyObject<'_, 'py> for f32 {
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "float";
 
-    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         Ok(obj.extract::<f64>()? as f32)
     }
 

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -2,8 +2,7 @@ use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, Borrowed, FromPyObject, PyAny, PyErr, PyResult,
-    Python,
+    ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, Borrowed, FromPyObject, PyAny, PyErr, Python,
 };
 use std::convert::Infallible;
 use std::ffi::c_double;
@@ -107,12 +106,14 @@ impl<'py> IntoPyObject<'py> for &f64 {
 }
 
 impl<'py> FromPyObject<'_, 'py> for f64 {
+    type Error = PyErr;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "float";
 
     // PyFloat_AsDouble returns -1.0 upon failure
     #[allow(clippy::float_cmp)]
-    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         // On non-limited API, .value() uses PyFloat_AS_DOUBLE which
         // allows us to have an optimized fast path for the case when
         // we have exactly a `float` object (it's not worth going through
@@ -177,11 +178,13 @@ impl<'py> IntoPyObject<'py> for &f32 {
     }
 }
 
-impl<'py> FromPyObject<'_, 'py> for f32 {
+impl<'a, 'py> FromPyObject<'a, 'py> for f32 {
+    type Error = <f64 as FromPyObject<'a, 'py>>::Error;
+
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str = "float";
 
-    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         Ok(obj.extract::<f64>()? as f32)
     }
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -336,7 +336,9 @@ impl<'py, T> FromPyObject<'_, 'py> for Vec<T>
 where
     T: FromPyObjectOwned<'py>,
 {
-    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         if obj.is_instance_of::<PyString>() {
             return Err(PyTypeError::new_err("Can't extract `str` to `Vec`"));
         }
@@ -365,7 +367,7 @@ where
 
     let mut v = Vec::with_capacity(seq.len().unwrap_or(0));
     for item in seq.try_iter()? {
-        v.push(item?.extract::<T>()?);
+        v.push(item?.extract::<T>().map_err(Into::into)?);
     }
     Ok(v)
 }

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -1,3 +1,4 @@
+use crate::conversion::FromPyObjectOwned;
 use crate::err::{self, DowncastError, PyErr, PyResult};
 use crate::exceptions::PyTypeError;
 use crate::ffi_ptr_ext::FfiPtrExt;
@@ -333,7 +334,7 @@ impl<'py> PySequenceMethods<'py> for Bound<'py, PySequence> {
 
 impl<'py, T> FromPyObject<'_, 'py> for Vec<T>
 where
-    T: for<'a> FromPyObject<'a, 'py>,
+    T: FromPyObjectOwned<'py>,
 {
     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         if obj.is_instance_of::<PyString>() {
@@ -350,7 +351,7 @@ where
 
 fn extract_sequence<'py, T>(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Vec<T>>
 where
-    T: for<'a> FromPyObject<'a, 'py>,
+    T: FromPyObjectOwned<'py>,
 {
     // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
     // to support this function and if not, we will only fail extraction safely.

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -4,7 +4,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::inspect::types::TypeInfo;
 use crate::instance::Borrowed;
 use crate::internal_tricks::get_ssize_index;
-use crate::types::{any::PyAnyMethods, sequence::PySequenceMethods, PyList, PySequence};
+use crate::types::{sequence::PySequenceMethods, PyList, PySequence};
 use crate::{
     exceptions, Bound, FromPyObject, IntoPyObject, IntoPyObjectExt, PyAny, PyErr, PyResult, Python,
 };
@@ -583,7 +583,7 @@ impl ExactSizeIterator for BorrowedTupleIterator<'_, '_> {
 impl FusedIterator for BorrowedTupleIterator<'_, '_> {}
 
 #[cold]
-fn wrong_tuple_length(t: &Bound<'_, PyTuple>, expected_length: usize) -> PyErr {
+fn wrong_tuple_length(t: Borrowed<'_, '_, PyTuple>, expected_length: usize) -> PyErr {
     let msg = format!(
         "expected tuple of length {}, but got tuple of length {}",
         expected_length,
@@ -888,8 +888,8 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
         }
     }
 
-    impl<'py, $($T: FromPyObject<'py>),+> FromPyObject<'py> for ($($T,)+) {
-        fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self>
+    impl<'a, 'py, $($T: FromPyObject<'a, 'py>),+> FromPyObject<'a, 'py> for ($($T,)+) {
+        fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self>
         {
             let t = obj.cast::<PyTuple>()?;
             if t.len() == $length {

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -45,8 +45,7 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, fals
    |                                                  ^^^^ the trait `PyClass` is not implemented for `CancelHandle`
    |
    = help: the trait `PyClass` is implemented for `pyo3::coroutine::Coroutine`
-   = note: required for `CancelHandle` to implement `FromPyObject<'_>`
-   = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
+   = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
 note: required by a bound in `extract_argument`
   --> src/impl_/extract_argument.rs
@@ -68,8 +67,7 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, fals
              `&'holder mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
              `&'holder pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
              `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, true>`
-   = note: required for `CancelHandle` to implement `FromPyObject<'_>`
-   = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
+   = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
 note: required by a bound in `extract_argument`
   --> src/impl_/extract_argument.rs
@@ -87,8 +85,7 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, fals
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyClass` is not implemented for `CancelHandle`
    |
    = help: the trait `PyClass` is implemented for `pyo3::coroutine::Coroutine`
-   = note: required for `CancelHandle` to implement `FromPyObject<'_>`
-   = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
+   = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
 
 error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, false>` is not satisfied
@@ -102,6 +99,5 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, fals
              `&'holder mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
              `&'holder pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
              `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, true>`
-   = note: required for `CancelHandle` to implement `FromPyObject<'_>`
-   = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
+   = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`


### PR DESCRIPTION
This adds the second lifetime to `FromPyObject` and removes `FromPyObjectBound`. I hope I adjusted all the bounds correctly. I believe the equivalent to our current implementation is use HRTB for the input lifetime on any generic bound. But this should only be necessary for containers that create temporary Python references during extraction. For wrapper types it should be possible to just forward the relaxed bound.

For easier trait bounds `FromPyObjectOwned` is introduced. This is blanket implemented for any `FromPyObject` type that does not depend on the input lifetime. It is intended to be used as a trait bound, the idea is inspired by `serde` (`Deserialize` <=> `DeserializeOwned`)

I tried to document different cases in the migration guide, but it can probably still be extended. ~Changelog entry is still missing, will write that tomorrow.~

Breaking changes:
- the second lifetime
- the `extract` method without default
- the addition lifetime bound on `extract_bound` to make the default work