### PR TITLE
add back new `marshal` APIs

### DIFF
--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -6,7 +6,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::types::{PyAny, PyBytes};
 use crate::{ffi, Bound};
-use crate::{AsPyPointer, PyResult, Python};
+use crate::{PyResult, Python};
 use std::os::raw::c_int;
 
 /// The current version of the marshal binary format.
@@ -29,23 +29,32 @@ pub const VERSION: i32 = 4;
 /// dict.set_item("mies", "wim").unwrap();
 /// dict.set_item("zus", "jet").unwrap();
 ///
-/// let bytes = marshal::dumps_bound(py, &dict, marshal::VERSION);
+/// let bytes = marshal::dumps(py, &dict, marshal::VERSION);
 /// # });
 /// ```
-pub fn dumps_bound<'py>(
-    py: Python<'py>,
-    object: &impl AsPyPointer,
-    version: i32,
-) -> PyResult<Bound<'py, PyBytes>> {
+pub fn dumps<'py>(object: &Bound<'py, PyAny>, version: i32) -> PyResult<Bound<'py, PyBytes>> {
     unsafe {
         ffi::PyMarshal_WriteObjectToString(object.as_ptr(), version as c_int)
-            .assume_owned_or_err(py)
+            .assume_owned_or_err(object.py())
             .downcast_into_unchecked()
     }
 }
 
+/// Deprecated form of [`dumps`].
+#[deprecated(since = "0.23.0", note = "use `dumps` instead")]
+pub fn dumps_bound<'py>(
+    py: Python<'py>,
+    object: &impl crate::AsPyPointer,
+    version: i32,
+) -> PyResult<Bound<'py, PyBytes>> {
+    dumps(
+        unsafe { object.as_ptr().assume_borrowed(py) }.as_any(),
+        version,
+    )
+}
+
 /// Deserialize an object from bytes using the Python built-in marshal module.
-pub fn loads_bound<'py, B>(py: Python<'py>, data: &B) -> PyResult<Bound<'py, PyAny>>
+pub fn loads<'py, B>(py: Python<'py>, data: &B) -> PyResult<Bound<'py, PyAny>>
 where
     B: AsRef<[u8]> + ?Sized,
 {
@@ -56,10 +65,16 @@ where
     }
 }
 
+/// Deprecated form of [`loads`].
+#[deprecated(since = "0.23.0", note = "renamed to `loads`")]
+pub fn loads_bound<'py>(py: Python<'py>, data: &[u8]) -> PyResult<Bound<'py, PyAny>> {
+    loads(py, data)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{bytes::PyBytesMethods, dict::PyDictMethods, PyDict};
+    use crate::types::{bytes::PyBytesMethods, dict::PyDictMethods, PyAnyMethods, PyDict};
 
     #[test]
     fn marshal_roundtrip() {
@@ -69,14 +84,10 @@ mod tests {
             dict.set_item("mies", "wim").unwrap();
             dict.set_item("zus", "jet").unwrap();
 
-            let pybytes = dumps_bound(py, &dict, VERSION).expect("marshalling failed");
-            let deserialized = loads_bound(py, pybytes.as_bytes()).expect("unmarshalling failed");
+            let pybytes = dumps(&dict, VERSION).expect("marshalling failed");
+            let deserialized = loads(py, pybytes.as_bytes()).expect("unmarshalling failed");
 
-            assert!(equal(py, &dict, &deserialized));
+            assert!(dict.eq(&deserialized).unwrap());
         });
-    }
-
-    fn equal(_py: Python<'_>, a: &impl AsPyPointer, b: &impl AsPyPointer) -> bool {
-        unsafe { ffi::PyObject_RichCompareBool(a.as_ptr(), b.as_ptr(), ffi::Py_EQ) != 0 }
     }
 }

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -29,7 +29,7 @@ pub const VERSION: i32 = 4;
 /// dict.set_item("mies", "wim").unwrap();
 /// dict.set_item("zus", "jet").unwrap();
 ///
-/// let bytes = marshal::dumps(py, &dict, marshal::VERSION);
+/// let bytes = marshal::dumps(&dict, marshal::VERSION);
 /// # });
 /// ```
 pub fn dumps<'py>(object: &Bound<'py, PyAny>, version: i32) -> PyResult<Bound<'py, PyBytes>> {


### PR DESCRIPTION
Part of restoration of names after removal of `gil-refs`, this time for the `marshal` module.

While adding the new `dumps` API I took the moment to remove a use of the `AsPyPointer` trait which we'd like to remove (as per #3429), and instead just take a `&Bound<'_, PyAny>`.