### PR TITLE
remove some unneeded `AsPyPointer` implementations

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -319,23 +319,6 @@ impl<T: ?Sized + ToPyObject> ToPyObject for &'_ T {
     }
 }
 
-impl IntoPy<PyObject> for &'_ PyAny {
-    #[inline]
-    fn into_py(self, py: Python<'_>) -> PyObject {
-        unsafe { PyObject::from_borrowed_ptr(py, self.as_ptr()) }
-    }
-}
-
-impl<T> IntoPy<PyObject> for &'_ T
-where
-    T: AsRef<PyAny>,
-{
-    #[inline]
-    fn into_py(self, py: Python<'_>) -> PyObject {
-        unsafe { PyObject::from_borrowed_ptr(py, self.as_ref().as_ptr()) }
-    }
-}
-
 impl<T> FromPyObject<'_> for T
 where
     T: PyClass + Clone,

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -29,13 +29,6 @@ use std::os::raw::c_int;
 #[repr(transparent)]
 pub struct PyAny(UnsafeCell<ffi::PyObject>);
 
-unsafe impl AsPyPointer for PyAny {
-    #[inline]
-    fn as_ptr(&self) -> *mut ffi::PyObject {
-        self.0.get()
-    }
-}
-
 #[allow(non_snake_case)]
 // Copied here as the macro does not accept deprecated functions.
 // Originally ffi::object::PyObject_Check, but this is not in the Python C API.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -116,7 +116,6 @@ pub trait DerefToPyAny {
 #[macro_export]
 macro_rules! pyobject_native_type_named (
     ($name:ty $(;$generics:ident)*) => {
-
         impl<$($generics,)*> ::std::convert::AsRef<$crate::PyAny> for $name {
             #[inline]
             fn as_ref(&self) -> &$crate::PyAny {
@@ -130,15 +129,6 @@ macro_rules! pyobject_native_type_named (
             #[inline]
             fn deref(&self) -> &$crate::PyAny {
                 &self.0
-            }
-        }
-
-        #[allow(unsafe_code)]
-        unsafe impl<$($generics,)*> $crate::AsPyPointer for $name {
-            /// Gets the underlying FFI pointer, returns a borrowed pointer.
-            #[inline]
-            fn as_ptr(&self) -> *mut $crate::ffi::PyObject {
-                self.0.as_ptr()
             }
         }
 


### PR DESCRIPTION
This PR removes some `AsPyPointer` implementations for types like `PyAny`, `PyDict` etc.

These implementations were part of the `gil-refs` functionality and are now both meaningless and have no functional use.