### PR TITLE
fix returning tuples from async fns

### DIFF
--- a/newsfragments/4407.fixed.md
+++ b/newsfragments/4407.fixed.md
@@ -1,0 +1,1 @@
+Fix async functions returning a tuple only returning the first element to Python.

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -95,7 +95,7 @@ impl Coroutine {
         match panic::catch_unwind(panic::AssertUnwindSafe(poll)) {
             Ok(Poll::Ready(res)) => {
                 self.close();
-                return Err(PyStopIteration::new_err(res?));
+                return Err(PyStopIteration::new_err((res?,)));
             }
             Err(err) => {
                 self.close();

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -121,6 +121,20 @@ fn sleep_coroutine() {
     })
 }
 
+#[pyfunction]
+async fn return_tuple() -> (usize, usize) {
+    (42, 43)
+}
+
+#[test]
+fn tuple_coroutine() {
+    Python::with_gil(|gil| {
+        let func = wrap_pyfunction!(return_tuple, gil).unwrap();
+        let test = r#"import asyncio; assert asyncio.run(func()) == (42, 43)"#;
+        py_run!(gil, func, &handle_windows(test));
+    })
+}
+
 #[test]
 fn cancelled_coroutine() {
     Python::with_gil(|gil| {


### PR DESCRIPTION
Fixes #4400

As the return value is ultimately communicated back via a StopIteration exception instance, a peculiar behavior of `PyErr::new` is encountered here: when the argument is a tuple `arg`, it is used to construct the exception as if calling from Python `Exception(*arg)` and not `Exception(arg)` like for every other type of argument.

This comes from from CPython's `PyErr_SetObject` which ultimately calls `_PyErr_CreateException` where the "culprit" is found here: https://github.com/python/cpython/blob/main/Python/errors.c#L33

We can fix this particular bug in the invocation of `PyErr::new` but it is a more general question if we want to keep reflecting this somewhat surprising CPython behavior, or create a better API, introducing a breaking change.
