### PR TITLE
Reintroduce constructors for `PyByteArray`, `PyComplex`, `PyFloat`, `PyEllipsis`, `PyFrozenSet`

### DIFF
--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -171,7 +171,7 @@ impl Number {
     }
 
     fn __complex__<'py>(&self, py: Python<'py>) -> Bound<'py, PyComplex> {
-        PyComplex::from_doubles_bound(py, self.0 as f64, 0.0)
+        PyComplex::from_doubles(py, self.0 as f64, 0.0)
     }
 }
 ```
@@ -321,7 +321,7 @@ impl Number {
     }
 
     fn __complex__<'py>(&self, py: Python<'py>) -> Bound<'py, PyComplex> {
-        PyComplex::from_doubles_bound(py, self.0 as f64, 0.0)
+        PyComplex::from_doubles(py, self.0 as f64, 0.0)
     }
 }
 

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -185,7 +185,7 @@ mod tests {
             let hash_set: hashbrown::HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
 
-            let set = PyFrozenSet::new_bound(py, &[1, 2, 3, 4, 5]).unwrap();
+            let set = PyFrozenSet::new(py, &[1, 2, 3, 4, 5]).unwrap();
             let hash_set: hashbrown::HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
         });

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -59,10 +59,10 @@
 //! #
 //! #         module.add_function(&wrap_pyfunction!(get_eigenvalues, module)?)?;
 //! #
-//! #         let m11 = PyComplex::from_doubles_bound(py, 0_f64, -1_f64);
-//! #         let m12 = PyComplex::from_doubles_bound(py, 1_f64, 0_f64);
-//! #         let m21 = PyComplex::from_doubles_bound(py, 2_f64, -1_f64);
-//! #         let m22 = PyComplex::from_doubles_bound(py, -1_f64, 0_f64);
+//! #         let m11 = PyComplex::from_doubles(py, 0_f64, -1_f64);
+//! #         let m12 = PyComplex::from_doubles(py, 1_f64, 0_f64);
+//! #         let m21 = PyComplex::from_doubles(py, 2_f64, -1_f64);
+//! #         let m22 = PyComplex::from_doubles(py, -1_f64, 0_f64);
 //! #
 //! #         let result = module
 //! #             .getattr("get_eigenvalues")?

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -127,7 +127,7 @@ mod tests {
             let hash_set: HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
 
-            let set = PyFrozenSet::new_bound(py, &[1, 2, 3, 4, 5]).unwrap();
+            let set = PyFrozenSet::new(py, &[1, 2, 3, 4, 5]).unwrap();
             let hash_set: HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
         });
@@ -140,7 +140,7 @@ mod tests {
             let hash_set: BTreeSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
 
-            let set = PyFrozenSet::new_bound(py, &[1, 2, 3, 4, 5]).unwrap();
+            let set = PyFrozenSet::new(py, &[1, 2, 3, 4, 5]).unwrap();
             let hash_set: BTreeSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
         });

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -677,7 +677,7 @@ impl<'py> Python<'py> {
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]
     pub fn Ellipsis(self) -> PyObject {
-        PyEllipsis::get_bound(self).into_py(self)
+        PyEllipsis::get(self).into_py(self)
     }
 
     /// Gets the Python builtin value `NotImplemented`.

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -382,7 +382,7 @@ mod test {
     #[test]
     fn py_backed_bytes_from_bytearray() {
         Python::with_gil(|py| {
-            let b = PyByteArray::new_bound(py, b"abcde");
+            let b = PyByteArray::new(py, b"abcde");
             let py_backed_bytes = PyBackedBytes::from(b);
             assert_eq!(&*py_backed_bytes, b"abcde");
         });
@@ -401,7 +401,7 @@ mod test {
     #[test]
     fn rust_backed_bytes_into_py() {
         Python::with_gil(|py| {
-            let orig_bytes = PyByteArray::new_bound(py, b"abcde");
+            let orig_bytes = PyByteArray::new(py, b"abcde");
             let rust_backed_bytes = PyBackedBytes::from(orig_bytes);
             assert!(matches!(
                 rust_backed_bytes.storage,
@@ -508,7 +508,7 @@ mod test {
     #[test]
     fn test_backed_bytes_from_bytearray_clone() {
         Python::with_gil(|py| {
-            let b1: PyBackedBytes = PyByteArray::new_bound(py, b"abcde").into();
+            let b1: PyBackedBytes = PyByteArray::new(py, b"abcde").into();
             let b2 = b1.clone();
             assert_eq!(b1, b2);
 
@@ -521,7 +521,7 @@ mod test {
     fn test_backed_bytes_eq() {
         Python::with_gil(|py| {
             let b1: PyBackedBytes = PyBytes::new(py, b"abcde").into();
-            let b2: PyBackedBytes = PyByteArray::new_bound(py, b"abcde").into();
+            let b2: PyBackedBytes = PyByteArray::new(py, b"abcde").into();
 
             assert_eq!(b1, b"abcde");
             assert_eq!(b1, b2);
@@ -548,7 +548,7 @@ mod test {
                 hasher.finish()
             };
 
-            let b2: PyBackedBytes = PyByteArray::new_bound(py, b"abcde").into();
+            let b2: PyBackedBytes = PyByteArray::new(py, b"abcde").into();
             let h2 = {
                 let mut hasher = DefaultHasher::new();
                 b2.hash(&mut hasher);

--- a/src/tests/hygiene/pymethods.rs
+++ b/src/tests/hygiene/pymethods.rs
@@ -291,7 +291,7 @@ impl Dummy {
         &self,
         py: crate::Python<'py>,
     ) -> crate::Bound<'py, crate::types::PyComplex> {
-        crate::types::PyComplex::from_doubles_bound(py, 0.0, 0.0)
+        crate::types::PyComplex::from_doubles(py, 0.0, 0.0)
     }
 
     fn __int__(&self) -> u32 {

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -176,8 +176,8 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let a = PyFloat::new_bound(py, 0_f64);
-    ///     let b = PyFloat::new_bound(py, 42_f64);
+    ///     let a = PyFloat::new(py, 0_f64);
+    ///     let b = PyFloat::new(py, 42_f64);
     ///     assert_eq!(a.compare(b)?, Ordering::Less);
     ///     Ok(())
     /// })?;
@@ -192,7 +192,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let a = PyFloat::new_bound(py, 0_f64);
+    ///     let a = PyFloat::new(py, 0_f64);
     ///     let b = PyString::new_bound(py, "zero");
     ///     assert!(a.compare(b).is_err());
     ///     Ok(())

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -28,17 +28,24 @@ pyobject_native_type!(
 
 impl PyComplex {
     /// Creates a new `PyComplex` from the given real and imaginary values.
-    pub fn from_doubles_bound(
-        py: Python<'_>,
-        real: c_double,
-        imag: c_double,
-    ) -> Bound<'_, PyComplex> {
+    pub fn from_doubles(py: Python<'_>, real: c_double, imag: c_double) -> Bound<'_, PyComplex> {
         use crate::ffi_ptr_ext::FfiPtrExt;
         unsafe {
             ffi::PyComplex_FromDoubles(real, imag)
                 .assume_owned(py)
                 .downcast_into_unchecked()
         }
+    }
+
+    /// Deprecated name for [`PyComplex::from_doubles`].
+    #[deprecated(since = "0.23.0", note = "renamed to `PyComplex::from_doubles`")]
+    #[inline]
+    pub fn from_doubles_bound(
+        py: Python<'_>,
+        real: c_double,
+        imag: c_double,
+    ) -> Bound<'_, PyComplex> {
+        Self::from_doubles(py, real, imag)
     }
 }
 
@@ -130,8 +137,8 @@ mod not_limited_impls {
         #[test]
         fn test_add() {
             Python::with_gil(|py| {
-                let l = PyComplex::from_doubles_bound(py, 3.0, 1.2);
-                let r = PyComplex::from_doubles_bound(py, 1.0, 2.6);
+                let l = PyComplex::from_doubles(py, 3.0, 1.2);
+                let r = PyComplex::from_doubles(py, 1.0, 2.6);
                 let res = l + r;
                 assert_approx_eq!(res.real(), 4.0);
                 assert_approx_eq!(res.imag(), 3.8);
@@ -141,8 +148,8 @@ mod not_limited_impls {
         #[test]
         fn test_sub() {
             Python::with_gil(|py| {
-                let l = PyComplex::from_doubles_bound(py, 3.0, 1.2);
-                let r = PyComplex::from_doubles_bound(py, 1.0, 2.6);
+                let l = PyComplex::from_doubles(py, 3.0, 1.2);
+                let r = PyComplex::from_doubles(py, 1.0, 2.6);
                 let res = l - r;
                 assert_approx_eq!(res.real(), 2.0);
                 assert_approx_eq!(res.imag(), -1.4);
@@ -152,8 +159,8 @@ mod not_limited_impls {
         #[test]
         fn test_mul() {
             Python::with_gil(|py| {
-                let l = PyComplex::from_doubles_bound(py, 3.0, 1.2);
-                let r = PyComplex::from_doubles_bound(py, 1.0, 2.6);
+                let l = PyComplex::from_doubles(py, 3.0, 1.2);
+                let r = PyComplex::from_doubles(py, 1.0, 2.6);
                 let res = l * r;
                 assert_approx_eq!(res.real(), -0.12);
                 assert_approx_eq!(res.imag(), 9.0);
@@ -163,8 +170,8 @@ mod not_limited_impls {
         #[test]
         fn test_div() {
             Python::with_gil(|py| {
-                let l = PyComplex::from_doubles_bound(py, 3.0, 1.2);
-                let r = PyComplex::from_doubles_bound(py, 1.0, 2.6);
+                let l = PyComplex::from_doubles(py, 3.0, 1.2);
+                let r = PyComplex::from_doubles(py, 1.0, 2.6);
                 let res = l / r;
                 assert_approx_eq!(res.real(), 0.788_659_793_814_432_9);
                 assert_approx_eq!(res.imag(), -0.850_515_463_917_525_7);
@@ -174,7 +181,7 @@ mod not_limited_impls {
         #[test]
         fn test_neg() {
             Python::with_gil(|py| {
-                let val = PyComplex::from_doubles_bound(py, 3.0, 1.2);
+                let val = PyComplex::from_doubles(py, 3.0, 1.2);
                 let res = -val;
                 assert_approx_eq!(res.real(), -3.0);
                 assert_approx_eq!(res.imag(), -1.2);
@@ -184,7 +191,7 @@ mod not_limited_impls {
         #[test]
         fn test_abs() {
             Python::with_gil(|py| {
-                let val = PyComplex::from_doubles_bound(py, 3.0, 1.2);
+                let val = PyComplex::from_doubles(py, 3.0, 1.2);
                 assert_approx_eq!(val.abs(), 3.231_098_884_280_702_2);
             });
         }
@@ -192,8 +199,8 @@ mod not_limited_impls {
         #[test]
         fn test_pow() {
             Python::with_gil(|py| {
-                let l = PyComplex::from_doubles_bound(py, 3.0, 1.2);
-                let r = PyComplex::from_doubles_bound(py, 1.2, 2.6);
+                let l = PyComplex::from_doubles(py, 3.0, 1.2);
+                let r = PyComplex::from_doubles(py, 1.2, 2.6);
                 let val = l.pow(&r);
                 assert_approx_eq!(val.real(), -1.419_309_997_016_603_7);
                 assert_approx_eq!(val.imag(), -0.541_297_466_033_544_6);
@@ -260,7 +267,7 @@ mod tests {
         use assert_approx_eq::assert_approx_eq;
 
         Python::with_gil(|py| {
-            let complex = PyComplex::from_doubles_bound(py, 3.0, 1.2);
+            let complex = PyComplex::from_doubles(py, 3.0, 1.2);
             assert_approx_eq!(complex.real(), 3.0);
             assert_approx_eq!(complex.imag(), 1.2);
         });

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -15,8 +15,15 @@ pyobject_native_type_named!(PyEllipsis);
 impl PyEllipsis {
     /// Returns the `Ellipsis` object.
     #[inline]
-    pub fn get_bound(py: Python<'_>) -> Borrowed<'_, '_, PyEllipsis> {
+    pub fn get(py: Python<'_>) -> Borrowed<'_, '_, PyEllipsis> {
         unsafe { ffi::Py_Ellipsis().assume_borrowed(py).downcast_unchecked() }
+    }
+
+    /// Deprecated name for [`PyEllipsis::get`].
+    #[deprecated(since = "0.23.0", note = "renamed to `PyEllipsis::get`")]
+    #[inline]
+    pub fn get_bound(py: Python<'_>) -> Borrowed<'_, '_, PyEllipsis> {
+        Self::get(py)
     }
 }
 
@@ -37,7 +44,7 @@ unsafe impl PyTypeInfo for PyEllipsis {
 
     #[inline]
     fn is_exact_type_of_bound(object: &Bound<'_, PyAny>) -> bool {
-        object.is(&**Self::get_bound(object.py()))
+        object.is(&**Self::get(object.py()))
     }
 }
 
@@ -50,15 +57,15 @@ mod tests {
     #[test]
     fn test_ellipsis_is_itself() {
         Python::with_gil(|py| {
-            assert!(PyEllipsis::get_bound(py).is_instance_of::<PyEllipsis>());
-            assert!(PyEllipsis::get_bound(py).is_exact_instance_of::<PyEllipsis>());
+            assert!(PyEllipsis::get(py).is_instance_of::<PyEllipsis>());
+            assert!(PyEllipsis::get(py).is_exact_instance_of::<PyEllipsis>());
         })
     }
 
     #[test]
     fn test_ellipsis_type_object_consistent() {
         Python::with_gil(|py| {
-            assert!(PyEllipsis::get_bound(py)
+            assert!(PyEllipsis::get(py)
                 .get_type()
                 .is(&PyEllipsis::type_object_bound(py)));
         })

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -30,12 +30,19 @@ pyobject_native_type!(
 
 impl PyFloat {
     /// Creates a new Python `float` object.
-    pub fn new_bound(py: Python<'_>, val: c_double) -> Bound<'_, PyFloat> {
+    pub fn new(py: Python<'_>, val: c_double) -> Bound<'_, PyFloat> {
         unsafe {
             ffi::PyFloat_FromDouble(val)
                 .assume_owned(py)
                 .downcast_into_unchecked()
         }
+    }
+
+    /// Deprecated name for [`PyFloat::new`].
+    #[deprecated(since = "0.23.0", note = "renamed to `PyFloat::new`")]
+    #[inline]
+    pub fn new_bound(py: Python<'_>, val: c_double) -> Bound<'_, PyFloat> {
+        Self::new(py, val)
     }
 }
 
@@ -67,13 +74,13 @@ impl<'py> PyFloatMethods<'py> for Bound<'py, PyFloat> {
 
 impl ToPyObject for f64 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyFloat::new_bound(py, *self).into()
+        PyFloat::new(py, *self).into()
     }
 }
 
 impl IntoPy<PyObject> for f64 {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyFloat::new_bound(py, self).into()
+        PyFloat::new(py, self).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -114,13 +121,13 @@ impl<'py> FromPyObject<'py> for f64 {
 
 impl ToPyObject for f32 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyFloat::new_bound(py, f64::from(*self)).into()
+        PyFloat::new(py, f64::from(*self)).into()
     }
 }
 
 impl IntoPy<PyObject> for f32 {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyFloat::new_bound(py, f64::from(self)).into()
+        PyFloat::new(py, f64::from(self)).into()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -250,7 +257,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let v = 1.23f64;
-            let obj = PyFloat::new_bound(py, 1.23);
+            let obj = PyFloat::new(py, 1.23);
             assert_approx_eq!(v, obj.value());
         });
     }
@@ -259,7 +266,7 @@ mod tests {
     fn test_pyfloat_comparisons() {
         Python::with_gil(|py| {
             let f_64 = 1.01f64;
-            let py_f64 = PyFloat::new_bound(py, 1.01);
+            let py_f64 = PyFloat::new(py, 1.01);
             let py_f64_ref = &py_f64;
             let py_f64_borrowed = py_f64.as_borrowed();
 
@@ -288,7 +295,7 @@ mod tests {
             assert_eq!(&f_64, py_f64_borrowed);
 
             let f_32 = 2.02f32;
-            let py_f32 = PyFloat::new_bound(py, 2.02);
+            let py_f32 = PyFloat::new(py, 2.02);
             let py_f32_ref = &py_f32;
             let py_f32_borrowed = py_f32.as_borrowed();
 


### PR DESCRIPTION
I updated the constructors for  `PyByteArray`, `PyComplex`, `PyFloat`, `PyEllipsis`, `PyFrozenSet`. To make it issuer to review I combined the commits into this one PR to let it merge in one go. If you still want to split it into different PR's please let me know!.