### PR TITLE
Add PyList_GetItemRef and use it in list.get_item

### DIFF
--- a/newsfragments/4410.added.md
+++ b/newsfragments/4410.added.md
@@ -1,5 +1,1 @@
-* Added bindings for `PyList_GetItemRef` on Python 3.13 and newer. Also added
-  `ffi::compat::PyList_GetItemRef` which re-exports the FFI binding on Python
-  3.13 and newer and defines a compatibility shim on older versions. This
-  function returns an owned reference to the item in the list and should be
-  preferred if the list is not known *a priori* to be shared between threads.
+Add ffi binding `PyList_GetItemRef` and `pyo3_ffi::compat::PyList_GetItemRef`

--- a/newsfragments/4410.added.md
+++ b/newsfragments/4410.added.md
@@ -1,0 +1,5 @@
+* Added bindings for `PyList_GetItemRef` on Python 3.13 and newer. Also added
+  `ffi::compat::PyList_GetItemRef` which re-exports the FFI binding on Python
+  3.13 and newer and defines a compatibility shim on older versions. This
+  function returns an owned reference to the item in the list and should be
+  preferred if the list is not known *a priori* to be shared between threads.

--- a/newsfragments/4410.fixed.md
+++ b/newsfragments/4410.fixed.md
@@ -1,0 +1,3 @@
+* Avoid creating temporary borrowed reference in list.get_item
+  bindings. Temporary borrowed references are unsafe in the free-threaded python
+  build if the list is shared between threads.

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -16,11 +16,11 @@ use crate::pyport::Py_ssize_t;
 #[cfg(not(Py_3_13))]
 use std::os::raw::c_int;
 
-#[cfg_attr(docsrs, doc(cfg(all)))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 #[cfg(Py_3_13)]
 pub use crate::dictobject::PyDict_GetItemRef;
 
-#[cfg_attr(docsrs, doc(cfg(all)))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 #[cfg(not(Py_3_13))]
 pub unsafe fn PyDict_GetItemRef(
     dp: *mut PyObject,

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -12,6 +12,8 @@
 #[cfg(not(Py_3_13))]
 use crate::object::PyObject;
 #[cfg(not(Py_3_13))]
+use crate::pyport::Py_ssize_t;
+#[cfg(not(Py_3_13))]
 use std::os::raw::c_int;
 
 #[cfg_attr(docsrs, doc(cfg(all)))]
@@ -41,4 +43,17 @@ pub unsafe fn PyDict_GetItemRef(
         }
         -1
     }
+}
+
+#[cfg_attr(docsrs, doc(cfg(all)))]
+#[cfg(Py_3_13)]
+pub use crate::PyList_GetItemRef;
+
+#[cfg(not(Py_3_13))]
+pub unsafe fn PyList_GetItemRef(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject {
+    use crate::{PyList_GetItem, Py_XINCREF};
+
+    let item: *mut PyObject = PyList_GetItem(arg1, arg2);
+    Py_XINCREF(item);
+    item
 }

--- a/pyo3-ffi/src/compat.rs
+++ b/pyo3-ffi/src/compat.rs
@@ -45,11 +45,12 @@ pub unsafe fn PyDict_GetItemRef(
     }
 }
 
-#[cfg_attr(docsrs, doc(cfg(all)))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 #[cfg(Py_3_13)]
 pub use crate::PyList_GetItemRef;
 
 #[cfg(not(Py_3_13))]
+#[cfg_attr(docsrs, doc(cfg(all())))]
 pub unsafe fn PyList_GetItemRef(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject {
     use crate::{PyList_GetItem, Py_XINCREF};
 

--- a/pyo3-ffi/src/listobject.rs
+++ b/pyo3-ffi/src/listobject.rs
@@ -28,6 +28,8 @@ extern "C" {
     pub fn PyList_Size(arg1: *mut PyObject) -> Py_ssize_t;
     #[cfg_attr(PyPy, link_name = "PyPyList_GetItem")]
     pub fn PyList_GetItem(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject;
+    #[cfg(Py_3_13)]
+    pub fn PyList_GetItemRef(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyList_SetItem")]
     pub fn PyList_SetItem(arg1: *mut PyObject, arg2: Py_ssize_t, arg3: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyList_Insert")]

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -1,6 +1,6 @@
 use std::iter::FusedIterator;
 
-use crate::err::{self, PyErr, PyResult};
+use crate::err::{self, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::get_ssize_index;
@@ -287,12 +287,10 @@ impl<'py> PyListMethods<'py> for Bound<'py, PyList> {
     /// });
     /// ```
     fn get_item(&self, index: usize) -> PyResult<Bound<'py, PyAny>> {
-        let py = self.py();
-        let result = unsafe { ffi::compat::PyList_GetItemRef(self.as_ptr(), index as Py_ssize_t) };
-        if !result.is_null() {
-            return Ok(unsafe { result.assume_owned(py) });
+        unsafe {
+            ffi::compat::PyList_GetItemRef(self.as_ptr(), index as Py_ssize_t)
+                .assume_owned_or_err(self.py())
         }
-        Err(PyErr::fetch(py))
     }
 
     /// Gets the list item at the specified index. Undefined behavior on bad index. Use with caution.


### PR DESCRIPTION
Refs https://github.com/PyO3/pyo3/issues/4265 https://github.com/PyO3/pyo3/pull/4355

See [the C API docs](https://docs.python.org/3.13/c-api/list.html#c.PyList_GetItemRef).

Both the new shim and the bindings to the CPython C API on 3.13 should be covered by existing tests in PyO3.