### PR TITLE
[RFC] split PyErr::new() into multiple methods

### DIFF
--- a/examples/getitem/src/lib.rs
+++ b/examples/getitem/src/lib.rs
@@ -55,7 +55,7 @@ impl ExampleContainer {
 
             return Ok(delta);
         } else {
-            return Err(PyTypeError::new_err("Unsupported type"));
+            return Err(PyTypeError::new_err1("Unsupported type"));
         }
     }
     fn __setitem__(&self, idx: IntOrSlice, value: u32) -> PyResult<()> {

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -158,7 +158,7 @@ impl Nonzero {
     #[new]
     fn py_new(value: i32) -> PyResult<Self> {
         if value == 0 {
-            Err(PyValueError::new_err("cannot be zero"))
+            Err(PyValueError::new_err1("cannot be zero"))
         } else {
             Ok(Nonzero(value))
         }

--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -95,28 +95,28 @@ impl Number {
     fn __truediv__(&self, other: &Self) -> PyResult<Self> {
         match self.0.checked_div(other.0) {
             Some(i) => Ok(Self(i)),
-            None => Err(PyZeroDivisionError::new_err("division by zero")),
+            None => Err(PyZeroDivisionError::new_err1("division by zero")),
         }
     }
 
     fn __floordiv__(&self, other: &Self) -> PyResult<Self> {
         match self.0.checked_div(other.0) {
             Some(i) => Ok(Self(i)),
-            None => Err(PyZeroDivisionError::new_err("division by zero")),
+            None => Err(PyZeroDivisionError::new_err1("division by zero")),
         }
     }
 
     fn __rshift__(&self, other: &Self) -> PyResult<Self> {
         match other.0.try_into() {
             Ok(rhs) => Ok(Self(self.0.wrapping_shr(rhs))),
-            Err(_) => Err(PyValueError::new_err("negative shift count")),
+            Err(_) => Err(PyValueError::new_err1("negative shift count")),
         }
     }
 
     fn __lshift__(&self, other: &Self) -> PyResult<Self> {
         match other.0.try_into() {
             Ok(rhs) => Ok(Self(self.0.wrapping_shl(rhs))),
-            Err(_) => Err(PyValueError::new_err("negative shift count")),
+            Err(_) => Err(PyValueError::new_err1("negative shift count")),
         }
     }
 }
@@ -275,28 +275,28 @@ impl Number {
     fn __truediv__(&self, other: &Self) -> PyResult<Self> {
         match self.0.checked_div(other.0) {
             Some(i) => Ok(Self(i)),
-            None => Err(PyZeroDivisionError::new_err("division by zero")),
+            None => Err(PyZeroDivisionError::new_err1("division by zero")),
         }
     }
 
     fn __floordiv__(&self, other: &Self) -> PyResult<Self> {
         match self.0.checked_div(other.0) {
             Some(i) => Ok(Self(i)),
-            None => Err(PyZeroDivisionError::new_err("division by zero")),
+            None => Err(PyZeroDivisionError::new_err1("division by zero")),
         }
     }
 
     fn __rshift__(&self, other: &Self) -> PyResult<Self> {
         match other.0.try_into() {
             Ok(rhs) => Ok(Self(self.0.wrapping_shr(rhs))),
-            Err(_) => Err(PyValueError::new_err("negative shift count")),
+            Err(_) => Err(PyValueError::new_err1("negative shift count")),
         }
     }
 
     fn __lshift__(&self, other: &Self) -> PyResult<Self> {
         match other.0.try_into() {
             Ok(rhs) => Ok(Self(self.0.wrapping_shl(rhs))),
-            Err(_) => Err(PyValueError::new_err("negative shift count")),
+            Err(_) => Err(PyValueError::new_err1("negative shift count")),
         }
     }
 

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -63,7 +63,7 @@ use pyo3::{Python, PyErr};
 use pyo3::exceptions::PyTypeError;
 
 Python::with_gil(|py| {
-    PyTypeError::new_err("Error").restore(py);
+    PyTypeError::new_err1("Error").restore(py);
     assert!(PyErr::occurred(py));
     drop(PyErr::fetch(py));
 });
@@ -92,7 +92,7 @@ To check the type of an exception, you can similarly do:
 # use pyo3::exceptions::PyTypeError;
 # use pyo3::prelude::*;
 # Python::with_gil(|py| {
-# let err = PyTypeError::new_err(());
+# let err = PyTypeError::new_err0();
 err.is_instance_of::<PyTypeError>(py);
 # });
 ```
@@ -113,7 +113,7 @@ mod io {
 
 fn tell(file: &Bound<'_, PyAny>) -> PyResult<u64> {
     match file.call_method0("tell") {
-        Err(_) => Err(io::UnsupportedOperation::new_err("not supported: tell")),
+        Err(_) => Err(io::UnsupportedOperation::new_err1("not supported: tell")),
         Ok(x) => x.extract::<u64>(),
     }
 }

--- a/guide/src/function/error-handling.md
+++ b/guide/src/function/error-handling.md
@@ -36,7 +36,7 @@ use pyo3::prelude::*;
 #[pyfunction]
 fn check_positive(x: i32) -> PyResult<()> {
     if x < 0 {
-        Err(PyValueError::new_err("x is negative"))
+        Err(PyValueError::new_err1("x is negative"))
     } else {
         Ok(())
     }
@@ -109,7 +109,7 @@ impl fmt::Display for CustomIOError {
 
 impl std::convert::From<CustomIOError> for PyErr {
     fn from(err: CustomIOError) -> PyErr {
-        PyOSError::new_err(err.to_string())
+        PyOSError::new_err1(err.to_string())
     }
 }
 
@@ -205,7 +205,7 @@ struct MyOtherError(OtherError);
 
 impl From<MyOtherError> for PyErr {
     fn from(error: MyOtherError) -> Self {
-        PyValueError::new_err(error.0.message())
+        PyValueError::new_err1(error.0.message())
     }
 }
 

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -398,7 +398,7 @@ impl PyClassIter {
             self.count += 1;
             Ok(self.count)
         } else {
-            Err(PyStopIteration::new_err("done"))
+            Err(PyStopIteration::new_err1("done"))
         }
     }
 }
@@ -811,7 +811,7 @@ When converting from `anyhow::Error` or `eyre::Report` to `PyErr`, if the inner 
 # use pyo3::exceptions::PyValueError;
 #[pyfunction]
 fn raise_err() -> anyhow::Result<()> {
-    Err(PyValueError::new_err("original error message").into())
+    Err(PyValueError::new_err1("original error message").into())
 }
 
 fn main() {
@@ -1476,7 +1476,7 @@ let result: PyResult<()> = PyErr::new::<TypeError, _>("error message").into();
 After (also using the new reworked exception types; see the following section):
 ```rust
 # use pyo3::{PyResult, exceptions::PyTypeError};
-let result: PyResult<()> = Err(PyTypeError::new_err("error message"));
+let result: PyResult<()> = Err(PyTypeError::new_err1("error message"));
 ```
 </details>
 
@@ -1500,7 +1500,7 @@ After:
 # use pyo3::{PyErr, PyResult, Python, type_object::PyTypeObject};
 # use pyo3::exceptions::{PyBaseException, PyTypeError};
 # Python::with_gil(|py| -> PyResult<()> {
-let err: PyErr = PyTypeError::new_err("error message");
+let err: PyErr = PyTypeError::new_err1("error message");
 
 // Uses Display for PyErr, new for PyO3 0.12
 assert_eq!(err.to_string(), "TypeError: error message");

--- a/guide/src/performance.md
+++ b/guide/src/performance.md
@@ -26,7 +26,7 @@ fn frobnicate<'py>(value: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
     } else if let Ok(vec) = value.extract::<Vec<Bound<'_, PyAny>>>() {
         frobnicate_vec(vec)
     } else {
-        Err(PyTypeError::new_err("Cannot frobnicate that type."))
+        Err(PyTypeError::new_err1("Cannot frobnicate that type."))
     }
 }
 ```
@@ -48,7 +48,7 @@ fn frobnicate<'py>(value: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
     } else if let Ok(vec) = value.extract::<Vec<Bound<'_, PyAny>>>() {
         frobnicate_vec(vec)
     } else {
-        Err(PyTypeError::new_err("Cannot frobnicate that type."))
+        Err(PyTypeError::new_err1("Cannot frobnicate that type."))
     }
 }
 ```

--- a/pyo3-benches/benches/bench_err.rs
+++ b/pyo3-benches/benches/bench_err.rs
@@ -5,14 +5,14 @@ use pyo3::{exceptions::PyValueError, prelude::*};
 fn err_new_restore_and_fetch(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         b.iter(|| {
-            PyValueError::new_err("some exception message").restore(py);
+            PyValueError::new_err1("some exception message").restore(py);
             PyErr::fetch(py)
         })
     })
 }
 
 fn err_new_without_gil(b: &mut Bencher<'_>) {
-    b.iter(|| PyValueError::new_err("some exception message"))
+    b.iter(|| PyValueError::new_err1("some exception message"))
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1324,7 +1324,7 @@ fn impl_complex_enum_tuple_variant_getitem(
             let py = slf.py();
             match idx {
                 #( #match_arms, )*
-                _ => ::std::result::Result::Err(#pyo3_path::exceptions::PyIndexError::new_err("tuple index out of range")),
+                _ => ::std::result::Result::Err(#pyo3_path::exceptions::PyIndexError::new_err1("tuple index out of range")),
             }
         }
     };

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -678,7 +678,7 @@ pub fn impl_py_setter_def(
             use ::std::convert::Into;
             let _value = #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr_or_opt(py, &_value)
                 .ok_or_else(|| {
-                    #pyo3_path::exceptions::PyAttributeError::new_err("can't delete attribute")
+                    #pyo3_path::exceptions::PyAttributeError::new_err1("can't delete attribute")
                 })?;
             #init_holders
             #extract
@@ -1094,7 +1094,7 @@ impl Ty {
             Ty::CompareOp => extract_error_mode.handle_error(
                 quote! {
                     #pyo3_path::class::basic::CompareOp::from_raw(#ident)
-                        .ok_or_else(|| #pyo3_path::exceptions::PyValueError::new_err("invalid comparison operator"))
+                        .ok_or_else(|| #pyo3_path::exceptions::PyValueError::new_err1("invalid comparison operator"))
                 },
                 ctx
             ),
@@ -1102,7 +1102,7 @@ impl Ty {
                 let ty = arg.ty();
                 extract_error_mode.handle_error(
                     quote! {
-                            ::std::convert::TryInto::<#ty>::try_into(#ident).map_err(|e| #pyo3_path::exceptions::PyValueError::new_err(e.to_string()))
+                            ::std::convert::TryInto::<#ty>::try_into(#ident).map_err(|e| #pyo3_path::exceptions::PyValueError::new_err1(e.to_string()))
                     },
                     ctx
                 )

--- a/pytests/src/awaitable.rs
+++ b/pytests/src/awaitable.rs
@@ -34,7 +34,7 @@ impl IterAwaitable {
     fn __next__(&mut self, py: Python<'_>) -> PyResult<PyObject> {
         match self.result.take() {
             Some(res) => match res {
-                Ok(v) => Err(PyStopIteration::new_err(v)),
+                Ok(v) => Err(PyStopIteration::new_err1(v)),
                 Err(err) => Err(err),
             },
             _ => Ok(py.None()),
@@ -70,7 +70,7 @@ impl FutureAwaitable {
     fn __next__(mut pyself: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
         match pyself.result {
             Some(_) => match pyself.result.take().unwrap() {
-                Ok(v) => Err(PyStopIteration::new_err(v)),
+                Ok(v) => Err(PyStopIteration::new_err1(v)),
                 Err(err) => Err(err),
             },
             _ => Ok(pyself),

--- a/pytests/src/dict_iter.rs
+++ b/pytests/src/dict_iter.rs
@@ -33,7 +33,7 @@ impl DictSize {
         if seen == self.expected {
             Ok(seen)
         } else {
-            Err(PyErr::new::<PyRuntimeError, _>(format!(
+            Err(PyErr::new1::<PyRuntimeError, _>(format!(
                 "Expected {} iterations - performed {}",
                 self.expected, seen
             )))

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -38,7 +38,7 @@ impl PyClassIter {
             self.count += 1;
             Ok(self.count)
         } else {
-            Err(PyStopIteration::new_err("Ended"))
+            Err(PyStopIteration::new_err1("Ended"))
         }
     }
 }
@@ -54,7 +54,7 @@ impl AssertingBaseClass {
     #[classmethod]
     fn new(cls: &Bound<'_, PyType>, expected_type: Bound<'_, PyType>) -> PyResult<Self> {
         if !cls.is(&expected_type) {
-            return Err(PyValueError::new_err(format!(
+            return Err(PyValueError::new_err1(format!(
                 "{:?} != {:?}",
                 cls, expected_type
             )));

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -206,16 +206,16 @@ impl<T: Element> PyBuffer<T> {
         let buf = PyBuffer(Pin::from(buf), PhantomData);
 
         if buf.0.shape.is_null() {
-            Err(PyBufferError::new_err("shape is null"))
+            Err(PyBufferError::new_err1("shape is null"))
         } else if buf.0.strides.is_null() {
-            Err(PyBufferError::new_err("strides is null"))
+            Err(PyBufferError::new_err1("strides is null"))
         } else if mem::size_of::<T>() != buf.item_size() || !T::is_compatible_format(buf.format()) {
-            Err(PyBufferError::new_err(format!(
+            Err(PyBufferError::new_err1(format!(
                 "buffer contents are not compatible with {}",
                 std::any::type_name::<T>()
             )))
         } else if buf.0.buf.align_offset(mem::align_of::<T>()) != 0 {
-            Err(PyBufferError::new_err(format!(
+            Err(PyBufferError::new_err1(format!(
                 "buffer contents are insufficiently aligned for {}",
                 std::any::type_name::<T>()
             )))
@@ -476,7 +476,7 @@ impl<T: Element> PyBuffer<T> {
 
     fn _copy_to_slice(&self, py: Python<'_>, target: &mut [T], fort: u8) -> PyResult<()> {
         if mem::size_of_val(target) != self.len_bytes() {
-            return Err(PyBufferError::new_err(format!(
+            return Err(PyBufferError::new_err1(format!(
                 "slice to copy to (of length {}) does not match buffer length of {}",
                 target.len(),
                 self.item_count()
@@ -568,9 +568,9 @@ impl<T: Element> PyBuffer<T> {
 
     fn _copy_from_slice(&self, py: Python<'_>, source: &[T], fort: u8) -> PyResult<()> {
         if self.readonly() {
-            return Err(PyBufferError::new_err("cannot write to read-only buffer"));
+            return Err(PyBufferError::new_err1("cannot write to read-only buffer"));
         } else if mem::size_of_val(source) != self.len_bytes() {
-            return Err(PyBufferError::new_err(format!(
+            return Err(PyBufferError::new_err1(format!(
                 "slice to copy from (of length {}) does not match buffer length of {}",
                 source.len(),
                 self.item_count()

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -84,7 +84,7 @@ impl IntoPyCallbackOutput<()> for () {
 impl IntoPyCallbackOutput<ffi::Py_ssize_t> for usize {
     #[inline]
     fn convert(self, _py: Python<'_>) -> PyResult<ffi::Py_ssize_t> {
-        self.try_into().map_err(|_err| PyOverflowError::new_err(()))
+        self.try_into().map_err(|_err| PyOverflowError::new_err0())
     }
 }
 

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -114,7 +114,7 @@ impl From<anyhow::Error> for PyErr {
                 Err(error) => error,
             };
         }
-        PyRuntimeError::new_err(format!("{:?}", error))
+        PyRuntimeError::new_err1(format!("{:?}", error))
     }
 }
 
@@ -171,7 +171,7 @@ mod test_anyhow {
 
     #[test]
     fn test_pyo3_unwrap_simple_err() {
-        let origin_exc = PyValueError::new_err("Value Error");
+        let origin_exc = PyValueError::new_err0();
         let err: anyhow::Error = origin_exc.into();
         let converted: PyErr = err.into();
         assert!(Python::with_gil(
@@ -180,7 +180,7 @@ mod test_anyhow {
     }
     #[test]
     fn test_pyo3_unwrap_complex_err() {
-        let origin_exc = PyValueError::new_err("Value Error");
+        let origin_exc = PyValueError::new_err0();
         let mut err: anyhow::Error = origin_exc.into();
         err = err.context("Context");
         let converted: PyErr = err.into();

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -251,7 +251,7 @@ impl FromPyObject<'_> for NaiveDateTime {
         #[cfg(Py_LIMITED_API)]
         let has_tzinfo = !dt.getattr(intern!(dt.py(), "tzinfo"))?.is_none();
         if has_tzinfo {
-            return Err(PyTypeError::new_err("expected a datetime without tzinfo"));
+            return Err(PyTypeError::new_err1("expected a datetime without tzinfo"));
         }
 
         let dt = NaiveDateTime::new(py_date_to_naive_date(dt)?, py_time_to_naive_time(dt)?);
@@ -290,13 +290,13 @@ impl<Tz: TimeZone + for<'py> FromPyObject<'py>> FromPyObject<'_> for DateTime<Tz
         let tz = if let Some(tzinfo) = tzinfo {
             tzinfo.extract()?
         } else {
-            return Err(PyTypeError::new_err(
+            return Err(PyTypeError::new_err1(
                 "expected a datetime with non-None tzinfo",
             ));
         };
         let naive_dt = NaiveDateTime::new(py_date_to_naive_date(dt)?, py_time_to_naive_time(dt)?);
         naive_dt.and_local_timezone(tz).single().ok_or_else(|| {
-            PyValueError::new_err(format!(
+            PyValueError::new_err1(format!(
                 "The datetime {:?} contains an incompatible or ambiguous timezone",
                 dt
             ))
@@ -351,7 +351,7 @@ impl FromPyObject<'_> for FixedOffset {
         // Trying to convert None to a PyDelta in the next line will then fail.
         let py_timedelta = ob.call_method1("utcoffset", ((),))?;
         if py_timedelta.is_none() {
-            return Err(PyTypeError::new_err(format!(
+            return Err(PyTypeError::new_err1(format!(
                 "{:?} is not a fixed offset timezone",
                 ob
             )));
@@ -360,7 +360,7 @@ impl FromPyObject<'_> for FixedOffset {
         // This cast is safe since the timedelta is limited to -24 hours and 24 hours.
         let total_seconds = total_seconds.num_seconds() as i32;
         FixedOffset::east_opt(total_seconds)
-            .ok_or_else(|| PyValueError::new_err("fixed offset out of bounds"))
+            .ok_or_else(|| PyValueError::new_err1("fixed offset out of bounds"))
     }
 }
 
@@ -382,7 +382,7 @@ impl FromPyObject<'_> for Utc {
         if ob.eq(py_utc)? {
             Ok(Utc)
         } else {
-            Err(PyValueError::new_err("expected datetime.timezone.utc"))
+            Err(PyValueError::new_err1("expected datetime.timezone.utc"))
         }
     }
 }
@@ -475,7 +475,7 @@ fn py_date_to_naive_date(py_date: &impl PyDateAccess) -> PyResult<NaiveDate> {
         py_date.get_month().into(),
         py_date.get_day().into(),
     )
-    .ok_or_else(|| PyValueError::new_err("invalid or out-of-range date"))
+    .ok_or_else(|| PyValueError::new_err1("invalid or out-of-range date"))
 }
 
 #[cfg(Py_LIMITED_API)]
@@ -485,7 +485,7 @@ fn py_date_to_naive_date(py_date: &Bound<'_, PyAny>) -> PyResult<NaiveDate> {
         py_date.getattr(intern!(py_date.py(), "month"))?.extract()?,
         py_date.getattr(intern!(py_date.py(), "day"))?.extract()?,
     )
-    .ok_or_else(|| PyValueError::new_err("invalid or out-of-range date"))
+    .ok_or_else(|| PyValueError::new_err1("invalid or out-of-range date"))
 }
 
 #[cfg(not(Py_LIMITED_API))]
@@ -496,7 +496,7 @@ fn py_time_to_naive_time(py_time: &impl PyTimeAccess) -> PyResult<NaiveTime> {
         py_time.get_second().into(),
         py_time.get_microsecond(),
     )
-    .ok_or_else(|| PyValueError::new_err("invalid or out-of-range time"))
+    .ok_or_else(|| PyValueError::new_err1("invalid or out-of-range time"))
 }
 
 #[cfg(Py_LIMITED_API)]
@@ -513,7 +513,7 @@ fn py_time_to_naive_time(py_time: &Bound<'_, PyAny>) -> PyResult<NaiveTime> {
             .getattr(intern!(py_time.py(), "microsecond"))?
             .extract()?,
     )
-    .ok_or_else(|| PyValueError::new_err("invalid or out-of-range time"))
+    .ok_or_else(|| PyValueError::new_err1("invalid or out-of-range time"))
 }
 
 #[cfg(Py_LIMITED_API)]

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -67,7 +67,7 @@ impl FromPyObject<'_> for Tz {
             &ob.getattr(intern!(ob.py(), "key"))?
                 .extract::<PyBackedStr>()?,
         )
-        .map_err(|e| PyValueError::new_err(e.to_string()))
+        .map_err(|e| PyValueError::new_err1(e.to_string()))
     }
 }
 

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -101,7 +101,7 @@ where
                 std::any::type_name::<L>(),
                 std::any::type_name::<R>()
             );
-            Err(PyTypeError::new_err(err_msg))
+            Err(PyTypeError::new_err1(err_msg))
         }
     }
 

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -119,7 +119,7 @@ impl From<eyre::Report> for PyErr {
                 Err(error) => error,
             };
         }
-        PyRuntimeError::new_err(format!("{:?}", error))
+        PyRuntimeError::new_err1(format!("{:?}", error))
     }
 }
 
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_unwrap_simple_err() {
-        let origin_exc = PyValueError::new_err("Value Error");
+        let origin_exc = PyValueError::new_err0();
         let report: Report = origin_exc.into();
         let converted: PyErr = report.into();
         assert!(Python::with_gil(
@@ -185,7 +185,7 @@ mod tests {
     }
     #[test]
     fn test_pyo3_unwrap_complex_err() {
-        let origin_exc = PyValueError::new_err("Value Error");
+        let origin_exc = PyValueError::new_err0();
         let mut report: Report = origin_exc.into();
         report = report.wrap_err("Wrapped");
         let converted: PyErr = report.into();

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -67,7 +67,7 @@ impl FromPyObject<'_> for Decimal {
             let py_str = &obj.str()?;
             let rs_str = &py_str.to_cow()?;
             Decimal::from_str(rs_str).or_else(|_| {
-                Decimal::from_scientific(rs_str).map_err(|e| PyValueError::new_err(e.to_string()))
+                Decimal::from_scientific(rs_str).map_err(|e| PyValueError::new_err1(e.to_string()))
             })
         }
     }

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -61,7 +61,7 @@ where
 {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         if obj.is_instance_of::<PyString>() {
-            return Err(PyTypeError::new_err("Can't extract `str` to `SmallVec`"));
+            return Err(PyTypeError::new_err1("Can't extract `str` to `SmallVec`"));
         }
         extract_sequence(obj)
     }

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -117,7 +117,7 @@ where
 }
 
 fn invalid_sequence_length(expected: usize, actual: usize) -> PyErr {
-    exceptions::PyValueError::new_err(format!(
+    exceptions::PyValueError::new_err1(format!(
         "expected a sequence of length {} (got {})",
         expected, actual
     ))

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -17,12 +17,12 @@ impl FromPyObject<'_> for IpAddr {
                 } else if let Ok(packed) = packed.extract::<[u8; 16]>() {
                     Ok(IpAddr::V6(Ipv6Addr::from(packed)))
                 } else {
-                    Err(PyValueError::new_err("invalid packed length"))
+                    Err(PyValueError::new_err1("invalid packed length"))
                 }
             }
             Err(_) => {
                 // We don't have a .packed attribute, so we try to construct an IP from str().
-                obj.str()?.to_cow()?.parse().map_err(PyValueError::new_err)
+                obj.str()?.to_cow()?.parse().map_err(PyValueError::new_err_args)
             }
         }
     }

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -35,7 +35,7 @@ macro_rules! int_fits_larger_int {
             fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
                 let val: $larger_type = obj.extract()?;
                 <$rust_type>::try_from(val)
-                    .map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
+                    .map_err(|e| exceptions::PyOverflowError::new_err1(e.to_string()))
             }
 
             #[cfg(feature = "experimental-inspect")]
@@ -125,7 +125,7 @@ macro_rules! int_fits_c_long {
             fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
                 let val: c_long = extract_int!(obj, -1, ffi::PyLong_AsLong)?;
                 <$rust_type>::try_from(val)
-                    .map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
+                    .map_err(|e| exceptions::PyOverflowError::new_err1(e.to_string()))
             }
 
             #[cfg(feature = "experimental-inspect")]
@@ -271,7 +271,7 @@ mod fast_128bit_int_conversion {
                         .try_into()
                         .map_err(|_| PyErr::fetch(ob.py()))?;
                         if actual_size as usize > buffer.len() {
-                            return Err(crate::exceptions::PyOverflowError::new_err(
+                            return Err(crate::exceptions::PyOverflowError::new_err1(
                                 "Python int larger than 128 bits",
                             ));
                         }
@@ -393,7 +393,7 @@ macro_rules! nonzero_int_impl {
             fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
                 let val: $primitive_type = obj.extract()?;
                 <$nonzero_type>::try_from(val)
-                    .map_err(|_| exceptions::PyValueError::new_err("invalid zero value"))
+                    .map_err(|_| exceptions::PyValueError::new_err1("invalid zero value"))
             }
 
             #[cfg(feature = "experimental-inspect")]

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -155,7 +155,7 @@ impl FromPyObject<'_> for char {
         if let (Some(ch), None) = (iter.next(), iter.next()) {
             Ok(ch)
         } else {
-            Err(crate::exceptions::PyValueError::new_err(
+            Err(crate::exceptions::PyValueError::new_err1(
                 "expected a string of length 1",
             ))
         }

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -36,7 +36,7 @@ impl FromPyObject<'_> for Duration {
 
         // We cast
         let days = u64::try_from(days).map_err(|_| {
-            PyValueError::new_err(
+            PyValueError::new_err1(
                 "It is not possible to convert a negative timedelta to a Rust Duration",
             )
         })?;
@@ -103,7 +103,7 @@ impl FromPyObject<'_> for SystemTime {
         UNIX_EPOCH
             .checked_add(duration_since_unix_epoch)
             .ok_or_else(|| {
-                PyOverflowError::new_err("Overflow error when converting the time to Rust")
+                PyOverflowError::new_err1("Overflow error when converting the time to Rust")
             })
     }
 }

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -71,7 +71,7 @@ impl Coroutine {
         // raise if the coroutine has already been run to completion
         let future_rs = match self.future {
             Some(ref mut fut) => fut,
-            None => return Err(PyRuntimeError::new_err(COROUTINE_REUSED_ERROR)),
+            None => return Err(PyRuntimeError::new_err1(COROUTINE_REUSED_ERROR)),
         };
         // reraise thrown exception it
         match (throw, &self.throw_callback) {
@@ -95,7 +95,7 @@ impl Coroutine {
         match panic::catch_unwind(panic::AssertUnwindSafe(poll)) {
             Ok(Poll::Ready(res)) => {
                 self.close();
-                return Err(PyStopIteration::new_err((res?,)));
+                return Err(PyStopIteration::new_err1(res?));
             }
             Err(err) => {
                 self.close();
@@ -128,7 +128,7 @@ impl Coroutine {
     fn __name__(&self, py: Python<'_>) -> PyResult<Py<PyString>> {
         match &self.name {
             Some(name) => Ok(name.clone_ref(py)),
-            None => Err(PyAttributeError::new_err("__name__")),
+            None => Err(PyAttributeError::new_err1("__name__")),
         }
     }
 
@@ -139,7 +139,7 @@ impl Coroutine {
                 .as_str()
                 .into_py(py)),
             (Some(name), None) => Ok(name.clone_ref(py)),
-            (None, _) => Err(PyAttributeError::new_err("__qualname__")),
+            (None, _) => Err(PyAttributeError::new_err1("__qualname__")),
         }
     }
 

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -1,7 +1,7 @@
 use crate::{
     exceptions::{PyBaseException, PyTypeError},
     ffi,
-    types::{PyTraceback, PyType},
+    types::{PyTraceback, PyType, PyTuple},
     Bound, IntoPy, Py, PyAny, PyObject, PyTypeInfo, Python,
 };
 
@@ -98,24 +98,24 @@ pub(crate) enum PyErrState {
 
 /// Helper conversion trait that allows to use custom arguments for lazy exception construction.
 pub trait PyErrArguments: Send + Sync {
-    /// Arguments for exception
+    /// Arguments for exception (either a single object or a tuple)
     fn arguments(self, py: Python<'_>) -> PyObject;
 }
 
 impl<T> PyErrArguments for T
 where
-    T: IntoPy<PyObject> + Send + Sync,
+    T: IntoPy<Py<PyTuple>> + Send + Sync,
 {
     fn arguments(self, py: Python<'_>) -> PyObject {
-        self.into_py(py)
+        self.into_py(py).into_any()
     }
 }
 
 impl PyErrState {
-    pub(crate) fn lazy(ptype: Py<PyAny>, args: impl PyErrArguments + 'static) -> Self {
+    pub(crate) fn lazy(ptype: Py<PyAny>, arg: Option<impl PyErrArguments + 'static>) -> Self {
         PyErrState::Lazy(Box::new(move |py| PyErrStateLazyFnOutput {
             ptype,
-            pvalue: args.arguments(py),
+            pvalue: arg.map_or(py.None(), |arg| arg.arguments(py))
         }))
     }
 

--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -43,17 +43,17 @@ impl From<io::Error> for PyErr {
             return *err.into_inner().unwrap().downcast().unwrap();
         }
         match err.kind() {
-            io::ErrorKind::BrokenPipe => exceptions::PyBrokenPipeError::new_err(err),
-            io::ErrorKind::ConnectionRefused => exceptions::PyConnectionRefusedError::new_err(err),
-            io::ErrorKind::ConnectionAborted => exceptions::PyConnectionAbortedError::new_err(err),
-            io::ErrorKind::ConnectionReset => exceptions::PyConnectionResetError::new_err(err),
-            io::ErrorKind::Interrupted => exceptions::PyInterruptedError::new_err(err),
-            io::ErrorKind::NotFound => exceptions::PyFileNotFoundError::new_err(err),
-            io::ErrorKind::PermissionDenied => exceptions::PyPermissionError::new_err(err),
-            io::ErrorKind::AlreadyExists => exceptions::PyFileExistsError::new_err(err),
-            io::ErrorKind::WouldBlock => exceptions::PyBlockingIOError::new_err(err),
-            io::ErrorKind::TimedOut => exceptions::PyTimeoutError::new_err(err),
-            _ => exceptions::PyOSError::new_err(err),
+            io::ErrorKind::BrokenPipe => exceptions::PyBrokenPipeError::new_err_args(err),
+            io::ErrorKind::ConnectionRefused => exceptions::PyConnectionRefusedError::new_err_args(err),
+            io::ErrorKind::ConnectionAborted => exceptions::PyConnectionAbortedError::new_err_args(err),
+            io::ErrorKind::ConnectionReset => exceptions::PyConnectionResetError::new_err_args(err),
+            io::ErrorKind::Interrupted => exceptions::PyInterruptedError::new_err_args(err),
+            io::ErrorKind::NotFound => exceptions::PyFileNotFoundError::new_err_args(err),
+            io::ErrorKind::PermissionDenied => exceptions::PyPermissionError::new_err_args(err),
+            io::ErrorKind::AlreadyExists => exceptions::PyFileExistsError::new_err_args(err),
+            io::ErrorKind::WouldBlock => exceptions::PyBlockingIOError::new_err_args(err),
+            io::ErrorKind::TimedOut => exceptions::PyTimeoutError::new_err_args(err),
+            _ => exceptions::PyOSError::new_err_args(err),
         }
     }
 }
@@ -92,7 +92,7 @@ macro_rules! impl_to_pyerr {
 
         impl std::convert::From<$err> for PyErr {
             fn from(err: $err) -> PyErr {
-                <$pyexc>::new_err(err)
+                <$pyexc>::new_err_args(err)
             }
         }
     };

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -2,7 +2,7 @@ use crate::instance::Bound;
 use crate::panic::PanicException;
 use crate::type_object::PyTypeInfo;
 use crate::types::any::PyAnyMethods;
-use crate::types::{string::PyStringMethods, typeobject::PyTypeMethods, PyTraceback, PyType};
+use crate::types::{string::PyStringMethods, typeobject::PyTypeMethods, PyTraceback, PyType, tuple::PyTuple};
 use crate::{
     exceptions::{self, PyBaseException},
     ffi,
@@ -113,7 +113,32 @@ impl PyErr {
     ///
     /// If `T` does not inherit from `BaseException`, then a `TypeError` will be returned.
     ///
-    /// If calling T's constructor with `args` raises an exception, that exception will be returned.
+    /// For examples, see [`new1`].
+    /// ```
+    #[inline]
+    #[deprecated(since = "0.23.0", note = "Use `PyErr::new0`, `PyErr::new1` or `PyErr::new_args` instead")]
+    pub fn new<T, A>(args: A) -> PyErr
+    where
+        T: PyTypeInfo,
+        A: PyErrArguments + Send + Sync + 'static,
+    {
+        PyErr::from_state(PyErrState::Lazy(Box::new(move |py| {
+            PyErrStateLazyFnOutput {
+                ptype: T::type_object_bound(py).into(),
+                pvalue: args.arguments(py),
+            }
+        })))
+    }
+
+    /// Creates a new PyErr of type `T`, with a single argument.
+    ///
+    /// This exception instance will be initialized lazily. This avoids the need for the Python GIL
+    /// to be held, but requires `args` to be `Send` and `Sync`. If `args` is not `Send` or `Sync`,
+    /// consider using [`PyErr::from_value_bound`] instead.
+    ///
+    /// If `T` does not inherit from `BaseException`, then a `TypeError` will be returned.
+    ///
+    /// If calling T's constructor raises an exception, that exception will be returned.
     ///
     /// # Examples
     ///
@@ -123,7 +148,7 @@ impl PyErr {
     ///
     /// #[pyfunction]
     /// fn always_throws() -> PyResult<()> {
-    ///     Err(PyErr::new::<PyTypeError, _>("Error message"))
+    ///     Err(PyErr::new1::<PyTypeError, _>("Error message"))
     /// }
     /// #
     /// # Python::with_gil(|py| {
@@ -141,7 +166,7 @@ impl PyErr {
     ///
     /// #[pyfunction]
     /// fn always_throws() -> PyResult<()> {
-    ///     Err(PyTypeError::new_err("Error message"))
+    ///     Err(PyTypeError::new_err1("Error message"))
     /// }
     /// #
     /// # Python::with_gil(|py| {
@@ -151,7 +176,56 @@ impl PyErr {
     /// # });
     /// ```
     #[inline]
-    pub fn new<T, A>(args: A) -> PyErr
+    pub fn new1<T, A>(arg: A) -> PyErr
+    where
+        T: PyTypeInfo,
+        A: IntoPy<PyObject> + Send + Sync + 'static,
+    {
+        PyErr::from_state(PyErrState::Lazy(Box::new(move |py| {
+            PyErrStateLazyFnOutput {
+                ptype: T::type_object_bound(py).into(),
+                pvalue: PyTuple::new(py, &[arg.into_py(py)]).into(),
+            }
+        })))
+    }
+
+    /// Creates a new PyErr of type `T`, without any arguments.
+    ///
+    /// This exception instance will be initialized lazily. This avoids the need for the Python GIL
+    /// to be held, but requires `args` to be `Send` and `Sync`. If `args` is not `Send` or `Sync`,
+    /// consider using [`PyErr::from_value_bound`] instead.
+    ///
+    /// If `T` does not inherit from `BaseException`, then a `TypeError` will be returned.
+    ///
+    /// If calling T's constructor raises an exception, that exception will be returned.
+    ///
+    /// For examples, see [`new1`].
+    #[inline]
+    pub fn new0<T>() -> PyErr where T: PyTypeInfo {
+        PyErr::from_state(PyErrState::Lazy(Box::new(move |py| {
+            PyErrStateLazyFnOutput {
+                ptype: T::type_object_bound(py).into(),
+                pvalue: py.None(),
+            }
+        })))
+    }
+
+    /// Creates a new PyErr of type `T`, with multiple arguments.
+    ///
+    /// `args` can be either be a tuple or another object implementing
+    /// [`PyErrArguments`], which allows custom conversion into error arguments.
+    ///
+    /// This exception instance will be initialized lazily. This avoids the need for the Python GIL
+    /// to be held, but requires `args` to be `Send` and `Sync`. If `args` is not `Send` or `Sync`,
+    /// consider using [`PyErr::from_value_bound`] instead.
+    ///
+    /// If `T` does not inherit from `BaseException`, then a `TypeError` will be returned.
+    ///
+    /// If calling T's constructor raises an exception, that exception will be returned.
+    ///
+    /// For examples, see [`new1`].
+    #[inline]
+    pub fn new_args<T, A>(args: A) -> PyErr
     where
         T: PyTypeInfo,
         A: PyErrArguments + Send + Sync + 'static,
@@ -169,7 +243,8 @@ impl PyErr {
     /// `ty` is the exception type; usually one of the standard exceptions
     /// like `exceptions::PyRuntimeError`.
     ///
-    /// `args` is either a tuple or a single value, with the same meaning as in [`PyErr::new`].
+    /// `args` can be either be a tuple or another object implementing
+    /// [`PyErrArguments`], which allows custom conversion into error arguments.
     ///
     /// If `ty` does not inherit from `BaseException`, then a `TypeError` will be returned.
     ///
@@ -178,7 +253,7 @@ impl PyErr {
     where
         A: PyErrArguments + Send + Sync + 'static,
     {
-        PyErr::from_state(PyErrState::lazy(ty.unbind().into_any(), args))
+        PyErr::from_state(PyErrState::lazy(ty.unbind().into_any(), Some(args)))
     }
 
     /// Creates a new PyErr.
@@ -198,7 +273,7 @@ impl PyErr {
     ///
     /// Python::with_gil(|py| {
     ///     // Case #1: Exception object
-    ///     let err = PyErr::from_value_bound(PyTypeError::new_err("some type error")
+    ///     let err = PyErr::from_value_bound(PyTypeError::new_err1("some type error")
     ///         .value_bound(py).clone().into_any());
     ///     assert_eq!(err.to_string(), "TypeError: some type error");
     ///
@@ -222,7 +297,7 @@ impl PyErr {
                 // is not the case
                 let obj = err.into_inner();
                 let py = obj.py();
-                PyErrState::lazy(obj.into_py(py), py.None())
+                PyErrState::lazy(obj.into_py(py), None::<()>)
             }
         };
 
@@ -236,7 +311,7 @@ impl PyErr {
     /// use pyo3::{prelude::*, exceptions::PyTypeError, types::PyType};
     ///
     /// Python::with_gil(|py| {
-    ///     let err: PyErr = PyTypeError::new_err(("some type error",));
+    ///     let err: PyErr = PyTypeError::new_err1("some type error");
     ///     assert!(err.get_type_bound(py).is(&PyType::new_bound::<PyTypeError>(py)));
     /// });
     /// ```
@@ -252,7 +327,7 @@ impl PyErr {
     /// use pyo3::{exceptions::PyTypeError, PyErr, Python};
     ///
     /// Python::with_gil(|py| {
-    ///     let err: PyErr = PyTypeError::new_err(("some type error",));
+    ///     let err: PyErr = PyTypeError::new_err1("some type error");
     ///     assert!(err.is_instance_of::<PyTypeError>(py));
     ///     assert_eq!(err.value_bound(py).to_string(), "some type error");
     /// });
@@ -283,7 +358,7 @@ impl PyErr {
     /// use pyo3::{exceptions::PyTypeError, Python};
     ///
     /// Python::with_gil(|py| {
-    ///     let err = PyTypeError::new_err(("some type error",));
+    ///     let err = PyTypeError::new_err1("some type error");
     ///     assert!(err.traceback_bound(py).is_none());
     /// });
     /// ```
@@ -413,7 +488,7 @@ impl PyErr {
             #[cfg(debug_assertions)]
             None => panic!("{}", FAILED_TO_FETCH),
             #[cfg(not(debug_assertions))]
-            None => exceptions::PySystemError::new_err(FAILED_TO_FETCH),
+            None => exceptions::PySystemError::new_err1(FAILED_TO_FETCH),
         }
     }
 
@@ -565,7 +640,7 @@ impl PyErr {
     /// ```rust
     /// # use pyo3::prelude::*;
     /// # use pyo3::exceptions::PyRuntimeError;
-    /// # fn failing_function() -> PyResult<()> { Err(PyRuntimeError::new_err("foo")) }
+    /// # fn failing_function() -> PyResult<()> { Err(PyRuntimeError::new_err1("foo")) }
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
     ///     match failing_function() {
@@ -664,7 +739,7 @@ impl PyErr {
     /// ```rust
     /// use pyo3::{exceptions::PyTypeError, PyErr, Python, prelude::PyAnyMethods};
     /// Python::with_gil(|py| {
-    ///     let err: PyErr = PyTypeError::new_err(("some type error",));
+    ///     let err: PyErr = PyTypeError::new_err1("some type error");
     ///     let err_clone = err.clone_ref(py);
     ///     assert!(err.get_type_bound(py).is(&err_clone.get_type_bound(py)));
     ///     assert!(err.value_bound(py).is(err_clone.value_bound(py)));
@@ -843,7 +918,7 @@ impl std::convert::From<DowncastError<'_, '_>> for PyErr {
             to: err.to,
         };
 
-        exceptions::PyTypeError::new_err(args)
+        exceptions::PyTypeError::new_err_args(args)
     }
 }
 
@@ -863,7 +938,7 @@ impl std::convert::From<DowncastIntoError<'_>> for PyErr {
             to: err.to,
         };
 
-        exceptions::PyTypeError::new_err(args)
+        exceptions::PyTypeError::new_err_args(args)
     }
 }
 
@@ -939,7 +1014,7 @@ mod tests {
     #[test]
     fn set_valueerror() {
         Python::with_gil(|py| {
-            let err: PyErr = exceptions::PyValueError::new_err("some exception message");
+            let err: PyErr = exceptions::PyValueError::new_err1("some exception message");
             assert!(err.is_instance_of::<exceptions::PyValueError>(py));
             err.restore(py);
             assert!(PyErr::occurred(py));
@@ -952,7 +1027,7 @@ mod tests {
     #[test]
     fn invalid_error_type() {
         Python::with_gil(|py| {
-            let err: PyErr = PyErr::new::<crate::types::PyString, _>(());
+            let err: PyErr = PyErr::new0::<crate::types::PyString>();
             assert!(err.is_instance_of::<exceptions::PyTypeError>(py));
             err.restore(py);
             let err = PyErr::fetch(py);
@@ -968,7 +1043,7 @@ mod tests {
     #[test]
     fn set_typeerror() {
         Python::with_gil(|py| {
-            let err: PyErr = exceptions::PyTypeError::new_err(());
+            let err: PyErr = exceptions::PyTypeError::new_err0();
             err.restore(py);
             assert!(PyErr::occurred(py));
             drop(PyErr::fetch(py));
@@ -981,7 +1056,7 @@ mod tests {
         use crate::panic::PanicException;
 
         Python::with_gil(|py| {
-            let err: PyErr = PanicException::new_err("new panic");
+            let err: PyErr = PanicException::new_err1("new panic");
             err.restore(py);
             assert!(PyErr::occurred(py));
 
@@ -997,7 +1072,7 @@ mod tests {
         use crate::panic::PanicException;
 
         Python::with_gil(|py| {
-            let err: PyErr = PanicException::new_err("new panic");
+            let err: PyErr = PanicException::new_err1("new panic");
             // Restoring an error doesn't normalize it before Python 3.12,
             // so we have to explicitly test this case.
             let _ = err.normalized(py);
@@ -1066,7 +1141,7 @@ mod tests {
     #[test]
     fn test_pyerr_matches() {
         Python::with_gil(|py| {
-            let err = PyErr::new::<PyValueError, _>("foo");
+            let err = PyErr::new1::<PyValueError, _>("foo");
             assert!(err.matches(py, PyValueError::type_object_bound(py)));
 
             assert!(err.matches(
@@ -1081,7 +1156,7 @@ mod tests {
 
             // String is not a valid exception class, so we should get a TypeError
             let err: PyErr =
-                PyErr::from_type_bound(crate::types::PyString::type_object_bound(py), "foo");
+                PyErr::from_type_bound(crate::types::PyString::type_object_bound(py), ("foo",));
             assert!(err.matches(py, PyTypeError::type_object_bound(py)));
         })
     }
@@ -1109,7 +1184,7 @@ mod tests {
             err.set_cause(py, None);
             assert!(err.cause(py).is_none());
 
-            let new_cause = exceptions::PyValueError::new_err("orange");
+            let new_cause = exceptions::PyValueError::new_err1("orange");
             err.set_cause(py, Some(new_cause));
             let cause = err
                 .cause(py)

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -33,12 +33,43 @@ macro_rules! impl_exception_boilerplate_bound {
             ///
             /// [`PyErr`]: https://docs.rs/pyo3/latest/pyo3/struct.PyErr.html "PyErr in pyo3"
             #[inline]
-            #[allow(dead_code)]
+            #[allow(dead_code, deprecated)]
+            #[deprecated(since = "0.23.0", note = "Use `new_err0`, `new_err1` or `new_err_args` instead")]
             pub fn new_err<A>(args: A) -> $crate::PyErr
             where
                 A: $crate::PyErrArguments + ::std::marker::Send + ::std::marker::Sync + 'static,
             {
                 $crate::PyErr::new::<$name, A>(args)
+            }
+            /// Creates a new [`PyErr`] of this type with no arguments.
+            ///
+            /// [`PyErr`]: https://docs.rs/pyo3/latest/pyo3/struct.PyErr.html "PyErr in pyo3"
+            #[inline]
+            #[allow(dead_code)]
+            pub fn new_err0() -> $crate::PyErr {
+                $crate::PyErr::new0::<$name>()
+            }
+            /// Creates a new [`PyErr`] of this type with a single argument.
+            ///
+            /// [`PyErr`]: https://docs.rs/pyo3/latest/pyo3/struct.PyErr.html "PyErr in pyo3"
+            #[inline]
+            #[allow(dead_code)]
+            pub fn new_err1<A>(arg: A) -> $crate::PyErr
+            where
+                A: $crate::conversion::IntoPy<$crate::PyObject> + ::std::marker::Send + ::std::marker::Sync + 'static,
+            {
+                $crate::PyErr::new1::<$name, A>(arg)
+            }
+            /// Creates a new [`PyErr`] of this type with an argument tuple.
+            ///
+            /// [`PyErr`]: https://docs.rs/pyo3/latest/pyo3/struct.PyErr.html "PyErr in pyo3"
+            #[inline]
+            #[allow(dead_code)]
+            pub fn new_err_args<A>(args: A) -> $crate::PyErr
+            where
+                A: $crate::PyErrArguments + ::std::marker::Send + ::std::marker::Sync + 'static,
+            {
+                $crate::PyErr::new_args::<$name, A>(args)
             }
         }
     };
@@ -162,7 +193,7 @@ macro_rules! import_exception_bound {
 ///
 /// #[pyfunction]
 /// fn raise_myerror() -> PyResult<()> {
-///     let err = MyError::new_err("Some error happened.");
+///     let err = MyError::new_err1("Some error happened.");
 ///     Err(err)
 /// }
 ///
@@ -321,7 +352,7 @@ use pyo3::exceptions::Py", $name, ";
 #[pyfunction]
 fn always_throws() -> PyResult<()> {
     let message = \"I'm ", $name ,", and I was raised from Rust.\";
-    Err(Py", $name, "::new_err(message))
+    Err(Py", $name, "::new_err1(message))
 }
 #
 # Python::with_gil(|py| {
@@ -752,7 +783,7 @@ macro_rules! test_exception {
                     $(
                         .or(Some({ let $py = py; $constructor }))
                     )?
-                        .unwrap_or($exc_ty::new_err("a test exception"))
+                        .unwrap_or($exc_ty::new_err1("a test exception"))
                 };
 
                 assert!(err.is_instance_of::<$exc_ty>(py));
@@ -781,10 +812,10 @@ pub mod asyncio {
         test_exception!(CancelledError);
         test_exception!(InvalidStateError);
         test_exception!(TimeoutError);
-        test_exception!(IncompleteReadError, |_| IncompleteReadError::new_err((
+        test_exception!(IncompleteReadError, |_| IncompleteReadError::new_err_args((
             "partial", "expected"
         )));
-        test_exception!(LimitOverrunError, |_| LimitOverrunError::new_err((
+        test_exception!(LimitOverrunError, |_| LimitOverrunError::new_err_args((
             "message", "consumed"
         )));
         test_exception!(QueueEmpty);
@@ -820,7 +851,7 @@ mod tests {
     #[test]
     fn test_check_exception() {
         Python::with_gil(|py| {
-            let err: PyErr = gaierror::new_err(());
+            let err: PyErr = gaierror::new_err0();
             let socket = py
                 .import_bound("socket")
                 .map_err(|e| e.display(py))
@@ -844,7 +875,7 @@ mod tests {
     #[test]
     fn test_check_exception_nested() {
         Python::with_gil(|py| {
-            let err: PyErr = MessageError::new_err(());
+            let err: PyErr = MessageError::new_err0();
             let email = py
                 .import_bound("email")
                 .map_err(|e| e.display(py))
@@ -1024,9 +1055,9 @@ mod tests {
         });
     }
     #[cfg(Py_3_11)]
-    test_exception!(PyBaseExceptionGroup, |_| PyBaseExceptionGroup::new_err((
+    test_exception!(PyBaseExceptionGroup, |_| PyBaseExceptionGroup::new_err_args((
         "msg",
-        vec![PyValueError::new_err("err")]
+        vec![PyValueError::new_err1("err")]
     )));
     test_exception!(PyBaseException);
     test_exception!(PyException);
@@ -1073,7 +1104,7 @@ mod tests {
         .eval_bound("chr(40960).encode('ascii')", None, None)
         .unwrap_err());
     test_exception!(PyUnicodeTranslateError, |_| {
-        PyUnicodeTranslateError::new_err(("\u{3042}", 0, 1, "ouch"))
+        PyUnicodeTranslateError::new_err_args(("\u{3042}", 0, 1, "ouch"))
     });
     test_exception!(PyValueError);
     test_exception!(PyZeroDivisionError);

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -204,7 +204,7 @@ pub fn argument_extraction_error(py: Python<'_>, arg_name: &str, error: PyErr) -
         .get_type_bound(py)
         .is(&py.get_type_bound::<PyTypeError>())
     {
-        let remapped_error = PyTypeError::new_err(format!(
+        let remapped_error = PyTypeError::new_err1(format!(
             "argument '{}': {}",
             arg_name,
             error.value_bound(py)
@@ -559,12 +559,12 @@ impl FunctionDescription {
                 was
             )
         };
-        PyTypeError::new_err(msg)
+        PyTypeError::new_err1(msg)
     }
 
     #[cold]
     fn multiple_values_for_argument(&self, argument: &str) -> PyErr {
-        PyTypeError::new_err(format!(
+        PyTypeError::new_err1(format!(
             "{} got multiple values for argument '{}'",
             self.full_name(),
             argument
@@ -573,7 +573,7 @@ impl FunctionDescription {
 
     #[cold]
     fn unexpected_keyword_argument(&self, argument: PyArg<'_>) -> PyErr {
-        PyTypeError::new_err(format!(
+        PyTypeError::new_err1(format!(
             "{} got an unexpected keyword argument '{}'",
             self.full_name(),
             argument.as_any()
@@ -587,7 +587,7 @@ impl FunctionDescription {
             self.full_name()
         );
         push_parameter_list(&mut msg, parameter_names);
-        PyTypeError::new_err(msg)
+        PyTypeError::new_err1(msg)
     }
 
     #[cold]
@@ -605,7 +605,7 @@ impl FunctionDescription {
             arguments,
         );
         push_parameter_list(&mut msg, parameter_names);
-        PyTypeError::new_err(msg)
+        PyTypeError::new_err1(msg)
     }
 
     #[cold]

--- a/src/impl_/frompyobject.rs
+++ b/src/impl_/frompyobject.rs
@@ -27,7 +27,7 @@ pub fn failed_to_extract_enum(
         )
         .unwrap();
     }
-    PyTypeError::new_err(err_msg)
+    PyTypeError::new_err1(err_msg)
 }
 
 /// Flattens a chain of errors into a single string.
@@ -85,7 +85,7 @@ fn failed_to_extract_struct_field(
     struct_name: &str,
     field_name: &str,
 ) -> PyErr {
-    let new_err = PyTypeError::new_err(format!(
+    let new_err = PyTypeError::new_err1(format!(
         "failed to extract field {}.{}",
         struct_name, field_name
     ));
@@ -137,7 +137,7 @@ fn failed_to_extract_tuple_struct_field(
     index: usize,
 ) -> PyErr {
     let new_err =
-        PyTypeError::new_err(format!("failed to extract field {}.{}", struct_name, index));
+        PyTypeError::new_err1(format!("failed to extract field {}.{}", struct_name, index));
     new_err.set_cause(py, ::std::option::Option::Some(inner_err));
     new_err
 }

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -223,7 +223,7 @@ pub fn build_pyclass_doc(
             text_signature,
             doc.to_str().unwrap(),
         ))
-        .map_err(|_| PyValueError::new_err("class doc cannot contain nul bytes"))?;
+        .map_err(|_| PyValueError::new_err1("class doc cannot contain nul bytes"))?;
         Ok(Cow::Owned(doc))
     } else {
         Ok(Cow::Borrowed(doc))
@@ -336,8 +336,8 @@ slot_fragment_trait! {
         _slf: *mut ffi::PyObject,
         attr: *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject> {
-        Err(PyErr::new::<PyAttributeError, _>(
-            (Py::<PyAny>::from_borrowed_ptr(py, attr),)
+        Err(PyErr::new1::<PyAttributeError, _>(
+            Py::<PyAny>::from_borrowed_ptr(py, attr)
         ))
     }
 }
@@ -466,8 +466,8 @@ define_pyclass_setattr_slot! {
     PyClass__delattr__SlotFragment,
     __setattr__,
     __delattr__,
-    Err(PyAttributeError::new_err("can't set attribute")),
-    Err(PyAttributeError::new_err("can't delete attribute")),
+    Err(PyAttributeError::new_err1("can't set attribute")),
+    Err(PyAttributeError::new_err1("can't delete attribute")),
     generate_pyclass_setattr_slot,
     Py_tp_setattro,
     setattrofunc,
@@ -478,8 +478,8 @@ define_pyclass_setattr_slot! {
     PyClass__delete__SlotFragment,
     __set__,
     __delete__,
-    Err(PyNotImplementedError::new_err("can't set descriptor")),
-    Err(PyNotImplementedError::new_err("can't delete descriptor")),
+    Err(PyNotImplementedError::new_err1("can't set descriptor")),
+    Err(PyNotImplementedError::new_err1("can't delete descriptor")),
     generate_pyclass_setdescr_slot,
     Py_tp_descr_set,
     descrsetfunc,
@@ -490,8 +490,8 @@ define_pyclass_setattr_slot! {
     PyClass__delitem__SlotFragment,
     __setitem__,
     __delitem__,
-    Err(PyNotImplementedError::new_err("can't set item")),
-    Err(PyNotImplementedError::new_err("can't delete item")),
+    Err(PyNotImplementedError::new_err1("can't set item")),
+    Err(PyNotImplementedError::new_err1("can't delete item")),
     generate_pyclass_setitem_slot,
     Py_mp_ass_subscript,
     objobjargproc,
@@ -1074,7 +1074,7 @@ impl ThreadCheckerImpl {
 
     fn can_drop(&self, py: Python<'_>, type_name: &'static str) -> bool {
         if thread::current().id() != self.0 {
-            PyRuntimeError::new_err(format!(
+            PyRuntimeError::new_err1(format!(
                 "{} is unsendable, but is being dropped on another thread",
                 type_name
             ))

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -221,7 +221,7 @@ unsafe impl<T> Sync for LazyTypeObject<T> {}
 
 #[cold]
 fn wrap_in_runtime_error(py: Python<'_>, err: PyErr, message: String) -> PyErr {
-    let runtime_err = PyRuntimeError::new_err(message);
+    let runtime_err = PyRuntimeError::new_err1(message);
     runtime_err.set_cause(py, Some(err));
     runtime_err
 }

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -391,7 +391,7 @@ impl AsyncIterOptionTag {
     {
         match value {
             Some(value) => value.convert(py),
-            None => Err(PyStopAsyncIteration::new_err(())),
+            None => Err(PyStopAsyncIteration::new_err0()),
         }
     }
 }
@@ -420,7 +420,7 @@ impl AsyncIterResultOptionTag {
     {
         match value {
             Ok(Some(value)) => value.convert(py),
-            Ok(None) => Err(PyStopAsyncIteration::new_err(())),
+            Ok(None) => Err(PyStopAsyncIteration::new_err0()),
             Err(err) => Err(err.into()),
         }
     }

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -123,7 +123,7 @@ impl ModuleDef {
                     Ordering::SeqCst,
                 ) {
                     if initialized_interpreter != current_interpreter {
-                        return Err(PyImportError::new_err(
+                        return Err(PyImportError::new_err1(
                             "PyO3 modules do not yet support subinterpreters, see https://github.com/PyO3/pyo3/issues/576",
                         ));
                     }
@@ -134,7 +134,7 @@ impl ModuleDef {
                 // CPython before 3.9 does not have APIs to check the interpreter ID, so best that can be
                 // done to guard against subinterpreters is fail if the module is initialized twice
                 if self.module.get(py).is_some() {
-                    return Err(PyImportError::new_err(
+                    return Err(PyImportError::new_err1(
                         "PyO3 modules compiled for CPython 3.8 or older may only be initialized once per interpreter process"
                     ));
                 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -22,11 +22,11 @@ impl PanicException {
     #[cold]
     pub(crate) fn from_panic_payload(payload: Box<dyn Any + Send + 'static>) -> PyErr {
         if let Some(string) = payload.downcast_ref::<String>() {
-            Self::new_err((string.clone(),))
+            Self::new_err1(string.clone())
         } else if let Some(s) = payload.downcast_ref::<&str>() {
-            Self::new_err((s.to_string(),))
+            Self::new_err1(s.to_string())
         } else {
-            Self::new_err(("panic from Rust code",))
+            Self::new_err1("panic from Rust code")
         }
     }
 }

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -668,7 +668,7 @@ impl fmt::Display for PyBorrowError {
 
 impl From<PyBorrowError> for PyErr {
     fn from(other: PyBorrowError) -> Self {
-        PyRuntimeError::new_err(other.to_string())
+        PyRuntimeError::new_err1(other.to_string())
     }
 }
 
@@ -693,7 +693,7 @@ impl fmt::Display for PyBorrowMutError {
 
 impl From<PyBorrowMutError> for PyErr {
     fn from(other: PyBorrowMutError) -> Self {
-        PyRuntimeError::new_err(other.to_string())
+        PyRuntimeError::new_err1(other.to_string())
     }
 }
 

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -440,7 +440,7 @@ impl PyTypeBuilder {
         unsafe { self.push_slot(ffi::Py_tp_dealloc, tp_dealloc as *mut c_void) }
 
         if self.has_clear && !self.has_traverse {
-            return Err(PyTypeError::new_err(format!(
+            return Err(PyTypeError::new_err1(format!(
                 "`#[pyclass]` {} implements __clear__ without __traverse__",
                 name
             )));
@@ -529,7 +529,7 @@ unsafe extern "C" fn no_constructor_defined(
     _kwds: *mut ffi::PyObject,
 ) -> *mut ffi::PyObject {
     trampoline(|_| {
-        Err(crate::exceptions::PyTypeError::new_err(
+        Err(crate::exceptions::PyTypeError::new_err1(
             "No constructor defined",
         ))
     })

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -71,7 +71,7 @@ impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
                             Ok(obj)
                         }
                     }
-                    None => Err(crate::exceptions::PyTypeError::new_err(
+                    None => Err(crate::exceptions::PyTypeError::new_err1(
                         "base type without tp_new",
                     )),
                 }

--- a/src/tests/hygiene/pymethods.rs
+++ b/src/tests/hygiene/pymethods.rs
@@ -113,7 +113,7 @@ impl Dummy {
     }
 
     fn __getitem__(&self, key: u32) -> crate::PyResult<u32> {
-        ::std::result::Result::Err(crate::exceptions::PyKeyError::new_err("boo"))
+        ::std::result::Result::Err(crate::exceptions::PyKeyError::new_err0())
     }
 
     fn __setitem__(&self, key: u32, value: u32) {}
@@ -156,11 +156,11 @@ impl Dummy {
     }
 
     fn __truediv__(&self, _other: &Self) -> crate::PyResult<()> {
-        ::std::result::Result::Err(crate::exceptions::PyZeroDivisionError::new_err("boo"))
+        ::std::result::Result::Err(crate::exceptions::PyZeroDivisionError::new_err0())
     }
 
     fn __floordiv__(&self, _other: &Self) -> crate::PyResult<()> {
-        ::std::result::Result::Err(crate::exceptions::PyZeroDivisionError::new_err("boo"))
+        ::std::result::Result::Err(crate::exceptions::PyZeroDivisionError::new_err0())
     }
 
     fn __mod__(&self, _other: &Self) -> u32 {
@@ -208,11 +208,11 @@ impl Dummy {
     }
 
     fn __rtruediv__(&self, _other: &Self) -> crate::PyResult<()> {
-        ::std::result::Result::Err(crate::exceptions::PyZeroDivisionError::new_err("boo"))
+        ::std::result::Result::Err(crate::exceptions::PyZeroDivisionError::new_err0())
     }
 
     fn __rfloordiv__(&self, _other: &Self) -> crate::PyResult<()> {
-        ::std::result::Result::Err(crate::exceptions::PyZeroDivisionError::new_err("boo"))
+        ::std::result::Result::Err(crate::exceptions::PyZeroDivisionError::new_err0())
     }
 
     fn __rmod__(&self, _other: &Self) -> u32 {

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -986,7 +986,7 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
             } else if do_compare(other, ffi::Py_GT)? {
                 Ok(Ordering::Greater)
             } else {
-                Err(PyTypeError::new_err(
+                Err(PyTypeError::new_err1(
                     "PyAny::compare(): All comparisons returned false",
                 ))
             }
@@ -1707,7 +1707,7 @@ class SimpleClass:
         #[pymethods(crate = "crate")]
         impl GetattrFail {
             fn __getattr__(&self, attr: PyObject) -> PyResult<PyObject> {
-                Err(PyValueError::new_err(attr))
+                Err(PyValueError::new_err1(attr))
             }
         }
 
@@ -1962,7 +1962,7 @@ class SimpleClass:
         #[pymethods(crate = "crate")]
         impl DirFail {
             fn __dir__(&self) -> PyResult<PyObject> {
-                Err(PyValueError::new_err("uh-oh!"))
+                Err(PyValueError::new_err0())
             }
         }
 

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -190,7 +190,7 @@ impl FromPyObject<'_> for bool {
 
         if is_numpy_bool {
             let missing_conversion = |obj: &Bound<'_, PyAny>| {
-                PyTypeError::new_err(format!(
+                PyTypeError::new_err1(format!(
                     "object of type '{}' does not define a '__bool__' conversion",
                     obj.get_type()
                 ))

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -172,7 +172,7 @@ pub trait PyByteArrayMethods<'py>: crate::sealed::Sealed {
     ///         // `to_vec` which copies the entire thing.
     ///         let section = slice
     ///             .get(6..11)
-    ///             .ok_or_else(|| PyRuntimeError::new_err("input is not long enough"))?;
+    ///             .ok_or_else(|| PyRuntimeError::new_err1("input is not long enough"))?;
     ///         Vec::from(section)
     ///     };
     ///
@@ -463,7 +463,7 @@ mod tests {
         use crate::exceptions::PyValueError;
         Python::with_gil(|py| {
             let py_bytearray_result = PyByteArray::new_with(py, 10, |_b: &mut [u8]| {
-                Err(PyValueError::new_err("Hello Crustaceans!"))
+                Err(PyValueError::new_err1("Hello Crustaceans!"))
             });
             assert!(py_bytearray_result.is_err());
             assert!(py_bytearray_result

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -354,7 +354,7 @@ mod tests {
         use crate::exceptions::PyValueError;
         Python::with_gil(|py| {
             let py_bytes_result = PyBytes::new_with(py, 10, |_b: &mut [u8]| {
-                Err(PyValueError::new_err("Hello Crustaceans!"))
+                Err(PyValueError::new_err1("Hello Crustaceans!"))
             });
             assert!(py_bytes_result.is_err());
             assert!(py_bytes_result

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -743,7 +743,7 @@ mod tests {
             }
 
             fn __hash__(&self) -> PyResult<isize> {
-                Err(PyTypeError::new_err("Error from __hash__"))
+                Err(PyTypeError::new_err1("Error from __hash__"))
             }
         }
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -392,7 +392,7 @@ impl<'py> PyModuleMethods<'py> for Bound<'py, PyModule> {
         {
             self.dict()
                 .get_item("__name__")
-                .map_err(|_| exceptions::PyAttributeError::new_err("__name__"))?
+                .map_err(|_| exceptions::PyAttributeError::new_err1("__name__"))?
                 .downcast_into()
                 .map_err(PyErr::from)
         }
@@ -410,7 +410,7 @@ impl<'py> PyModuleMethods<'py> for Bound<'py, PyModule> {
         {
             self.dict()
                 .get_item("__file__")
-                .map_err(|_| exceptions::PyAttributeError::new_err("__file__"))?
+                .map_err(|_| exceptions::PyAttributeError::new_err1("__file__"))?
                 .downcast_into()
                 .map_err(PyErr::from)
         }

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -317,7 +317,7 @@ where
 {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         if obj.is_instance_of::<PyString>() {
-            return Err(PyTypeError::new_err("Can't extract `str` to `Vec`"));
+            return Err(PyTypeError::new_err1("Can't extract `str` to `Vec`"));
         }
         extract_sequence(obj)
     }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -506,7 +506,7 @@ fn wrong_tuple_length(t: &Bound<'_, PyTuple>, expected_length: usize) -> PyErr {
         expected_length,
         t.len()
     );
-    exceptions::PyValueError::new_err(msg)
+    exceptions::PyValueError::new_err1(msg)
 }
 
 macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+} => {

--- a/tests/test_buffer.rs
+++ b/tests/test_buffer.rs
@@ -33,11 +33,11 @@ impl TestBufferErrors {
         flags: c_int,
     ) -> PyResult<()> {
         if view.is_null() {
-            return Err(PyBufferError::new_err("View is null"));
+            return Err(PyBufferError::new_err1("View is null"));
         }
 
         if (flags & ffi::PyBUF_WRITABLE) == ffi::PyBUF_WRITABLE {
-            return Err(PyBufferError::new_err("Object is not writable"));
+            return Err(PyBufferError::new_err1("Object is not writable"));
         }
 
         let bytes = &slf.buf;

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -114,7 +114,7 @@ fn test_releasebuffer_unraisable_error() {
         }
 
         unsafe fn __releasebuffer__(&self, _view: *mut ffi::Py_buffer) -> PyResult<()> {
-            Err(PyValueError::new_err("oh dear"))
+            Err(PyValueError::new_err1("oh dear"))
         }
     }
 
@@ -148,11 +148,11 @@ unsafe fn fill_view_from_readonly_data(
     owner: Bound<'_, PyAny>,
 ) -> PyResult<()> {
     if view.is_null() {
-        return Err(PyBufferError::new_err("View is null"));
+        return Err(PyBufferError::new_err1("View is null"));
     }
 
     if (flags & ffi::PyBUF_WRITABLE) == ffi::PyBUF_WRITABLE {
-        return Err(PyBufferError::new_err("Object is not writable"));
+        return Err(PyBufferError::new_err1("Object is not writable"));
     }
 
     (*view).obj = owner.into_ptr();

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -139,7 +139,7 @@ fn test_fallible_class_attribute() {
     impl BrokenClass {
         #[classattr]
         fn fails_to_init() -> PyResult<i32> {
-            Err(PyValueError::new_err("failed to create class attribute"))
+            Err(PyValueError::new_err1("failed to create class attribute"))
         }
     }
 

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -185,7 +185,7 @@ struct CustomError;
 
 impl From<CustomError> for PyErr {
     fn from(_error: CustomError) -> PyErr {
-        PyValueError::new_err("custom error")
+        PyValueError::new_err1("custom error")
     }
 }
 

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -50,7 +50,7 @@ impl fmt::Display for CustomError {
 
 impl std::convert::From<CustomError> for PyErr {
     fn from(err: CustomError) -> PyErr {
-        exceptions::PyOSError::new_err(err.to_string())
+        exceptions::PyOSError::new_err1(err.to_string())
     }
 }
 
@@ -109,14 +109,14 @@ fn test_write_unraisable() {
 
         assert!(capture.borrow(py).capture.is_none());
 
-        let err = PyRuntimeError::new_err("foo");
+        let err = PyRuntimeError::new_err1("foo");
         err.write_unraisable_bound(py, None);
 
         let (err, object) = capture.borrow_mut(py).capture.take().unwrap();
         assert_eq!(err.to_string(), "RuntimeError: foo");
         assert!(object.is_none(py));
 
-        let err = PyRuntimeError::new_err("bar");
+        let err = PyRuntimeError::new_err1("bar");
         err.write_unraisable_bound(py, Some(&PyNotImplemented::get_bound(py)));
 
         let (err, object) = capture.borrow_mut(py).capture.take().unwrap();

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -45,7 +45,7 @@ impl PyA {
         if key == "t" {
             Ok("bar".into())
         } else {
-            Err(PyValueError::new_err("Failed"))
+            Err(PyValueError::new_err1("Failed"))
         }
     }
 }

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -45,7 +45,7 @@ impl Mapping {
         self.index
             .get(&query)
             .copied()
-            .ok_or_else(|| PyKeyError::new_err("unknown key"))
+            .ok_or_else(|| PyKeyError::new_err1("unknown key"))
     }
 
     fn __setitem__(&mut self, key: String, value: usize) {
@@ -54,7 +54,7 @@ impl Mapping {
 
     fn __delitem__(&mut self, key: String) -> PyResult<()> {
         if self.index.remove(&key).is_none() {
-            Err(PyKeyError::new_err("unknown key"))
+            Err(PyKeyError::new_err1("unknown key"))
         } else {
             Ok(())
         }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -24,7 +24,7 @@ impl ExampleClass {
         if attr == "special_custom_attr" {
             Ok(self.custom_attr.into_py(py))
         } else {
-            Err(PyAttributeError::new_err(attr.to_string()))
+            Err(PyAttributeError::new_err1(attr.to_string()))
         }
     }
 
@@ -33,7 +33,7 @@ impl ExampleClass {
             self.custom_attr = Some(value.extract()?);
             Ok(())
         } else {
-            Err(PyAttributeError::new_err(attr.to_string()))
+            Err(PyAttributeError::new_err1(attr.to_string()))
         }
     }
 
@@ -42,7 +42,7 @@ impl ExampleClass {
             self.custom_attr = None;
             Ok(())
         } else {
-            Err(PyAttributeError::new_err(attr.to_string()))
+            Err(PyAttributeError::new_err1(attr.to_string()))
         }
     }
 
@@ -267,7 +267,7 @@ impl Sequence {
                 self.values
                     .get(uindex)
                     .map(|o| o.clone_ref(py))
-                    .ok_or_else(|| PyIndexError::new_err(index))
+                    .ok_or_else(|| PyIndexError::new_err1(index))
             }
             // Just to prove that slicing can be implemented
             SequenceIndex::Slice(s) => Ok(s.into()),
@@ -279,13 +279,13 @@ impl Sequence {
         self.values
             .get_mut(uindex)
             .map(|place| *place = value)
-            .ok_or_else(|| PyIndexError::new_err(index))
+            .ok_or_else(|| PyIndexError::new_err1(index))
     }
 
     fn __delitem__(&mut self, index: isize) -> PyResult<()> {
         let uindex = self.usize_index(index)?;
         if uindex >= self.values.len() {
-            Err(PyIndexError::new_err(index))
+            Err(PyIndexError::new_err1(index))
         } else {
             self.values.remove(uindex);
             Ok(())
@@ -302,7 +302,7 @@ impl Sequence {
         if index < 0 {
             let corrected_index = index + self.values.len() as isize;
             if corrected_index < 0 {
-                Err(PyIndexError::new_err(index))
+                Err(PyIndexError::new_err1(index))
             } else {
                 Ok(corrected_index as usize)
             }
@@ -536,7 +536,7 @@ impl GetItem {
                 return Ok("int");
             }
         }
-        Err(PyValueError::new_err("error"))
+        Err(PyValueError::new_err1("error"))
     }
 }
 
@@ -603,9 +603,9 @@ impl ClassWithGetAttrAndGetAttribute {
         if name == "exists" {
             Ok(42)
         } else if name == "error" {
-            Err(PyValueError::new_err("bad"))
+            Err(PyValueError::new_err1("bad"))
         } else {
-            Err(PyAttributeError::new_err("fallback"))
+            Err(PyAttributeError::new_err1("fallback"))
         }
     }
 
@@ -613,7 +613,7 @@ impl ClassWithGetAttrAndGetAttribute {
         if name == "lucky" {
             Ok(57)
         } else {
-            Err(PyAttributeError::new_err("no chance"))
+            Err(PyAttributeError::new_err1("no chance"))
         }
     }
 }

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -41,7 +41,7 @@ impl ByteSequence {
         self.elements
             .get(idx as usize)
             .copied()
-            .ok_or_else(|| PyIndexError::new_err("list index out of range"))
+            .ok_or_else(|| PyIndexError::new_err1("list index out of range"))
     }
 
     fn __setitem__(&mut self, idx: isize, value: u8) {
@@ -57,7 +57,7 @@ impl ByteSequence {
             self.elements.remove(idx as usize);
             Ok(())
         } else {
-            Err(PyIndexError::new_err("list index out of range"))
+            Err(PyIndexError::new_err1("list index out of range"))
         }
     }
 
@@ -87,7 +87,7 @@ impl ByteSequence {
             }
             Ok(Self { elements })
         } else {
-            Err(PyValueError::new_err("invalid repeat count"))
+            Err(PyValueError::new_err1("invalid repeat count"))
         }
     }
 
@@ -100,7 +100,7 @@ impl ByteSequence {
             slf.elements = elements;
             Ok(slf.into())
         } else {
-            Err(PyValueError::new_err("invalid repeat count"))
+            Err(PyValueError::new_err1("invalid repeat count"))
         }
     }
 }
@@ -296,7 +296,7 @@ impl OptionList {
     fn __getitem__(&self, idx: isize) -> PyResult<Option<i64>> {
         match self.items.get(idx as usize) {
             Some(x) => Ok(*x),
-            None => Err(PyIndexError::new_err("Index out of bounds")),
+            None => Err(PyIndexError::new_err1("Index out of bounds")),
         }
     }
 }

--- a/tests/test_static_slots.rs
+++ b/tests/test_static_slots.rs
@@ -27,9 +27,9 @@ impl Count5 {
     #[staticmethod]
     fn __getitem__(idx: isize) -> PyResult<f64> {
         if idx < 0 {
-            Err(PyIndexError::new_err("Count5 cannot count backwards"))
+            Err(PyIndexError::new_err1("Count5 cannot count backwards"))
         } else if idx > 4 {
-            Err(PyIndexError::new_err("Count5 cannot count higher than 5"))
+            Err(PyIndexError::new_err1("Count5 cannot count higher than 5"))
         } else {
             Ok(idx as f64 + 1.0)
         }

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -189,7 +189,7 @@ impl fmt::Display for MyError {
 /// Important for the automatic conversion to `PyErr`.
 impl From<MyError> for PyErr {
     fn from(err: MyError) -> pyo3::PyErr {
-        pyo3::exceptions::PyOSError::new_err(err.to_string())
+        pyo3::exceptions::PyOSError::new_err1(err.to_string())
     }
 }
 


### PR DESCRIPTION
Intended to start a discussion, about APIs, but also names :)

Similar to call(), introduces new0(), new1() and new_args(), and the same on Exception types as new_err0(), new_err1() and new_err_args().

After the deprecation cycle, new1() could be renamed back to new(), since it is the one used in the vast majority of cases.

I kept `PyErrArguments`, but it's now only implemented for tuples, not for all Python-convertible types.
