### PR TITLE
use "fastcall" convention on abi3, if >3.10

### DIFF
--- a/examples/string-sum/src/lib.rs
+++ b/examples/string-sum/src/lib.rs
@@ -19,7 +19,7 @@ static mut METHODS: &[PyMethodDef] = &[
     PyMethodDef {
         ml_name: c_str!("sum_as_string").as_ptr(),
         ml_meth: PyMethodDefPointer {
-            _PyCFunctionFast: sum_as_string,
+            PyCFunctionFast: sum_as_string,
         },
         ml_flags: METH_FASTCALL,
         ml_doc: c_str!("returns the sum of two integers as a string").as_ptr(),

--- a/newsfragments/4415.added.md
+++ b/newsfragments/4415.added.md
@@ -1,0 +1,1 @@
+Add FFI definitions `PyCFunctionFast` and `PyCFunctionFastWithKeywords`

--- a/newsfragments/4415.changed.md
+++ b/newsfragments/4415.changed.md
@@ -1,0 +1,1 @@
+Use "fastcall" Python calling convention for `#[pyfunction]`s when compiling on abi3 for Python 3.10 and up.

--- a/pyo3-ffi/README.md
+++ b/pyo3-ffi/README.md
@@ -65,7 +65,7 @@ static mut METHODS: [PyMethodDef; 2] = [
     PyMethodDef {
         ml_name: c_str!("sum_as_string").as_ptr(),
         ml_meth: PyMethodDefPointer {
-            _PyCFunctionFast: sum_as_string,
+            PyCFunctionFast: sum_as_string,
         },
         ml_flags: METH_FASTCALL,
         ml_doc: c_str!("returns the sum of two integers as a string").as_ptr(),

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -103,7 +103,7 @@
 //!     PyMethodDef {
 //!         ml_name: c_str!("sum_as_string").as_ptr(),
 //!         ml_meth: PyMethodDefPointer {
-//!             _PyCFunctionFast: sum_as_string,
+//!             PyCFunctionFast: sum_as_string,
 //!         },
 //!         ml_flags: METH_FASTCALL,
 //!         ml_doc: c_str!("returns the sum of two integers as a string").as_ptr(),

--- a/pyo3-ffi/src/methodobject.rs
+++ b/pyo3-ffi/src/methodobject.rs
@@ -43,11 +43,15 @@ pub type PyCFunction =
     unsafe extern "C" fn(slf: *mut PyObject, args: *mut PyObject) -> *mut PyObject;
 
 #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
-pub type _PyCFunctionFast = unsafe extern "C" fn(
+pub type PyCFunctionFast = unsafe extern "C" fn(
     slf: *mut PyObject,
     args: *mut *mut PyObject,
     nargs: crate::pyport::Py_ssize_t,
 ) -> *mut PyObject;
+
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+#[deprecated(note = "renamed to `PyCFunctionFast`")]
+pub type _PyCFunctionFast = PyCFunctionFast;
 
 pub type PyCFunctionWithKeywords = unsafe extern "C" fn(
     slf: *mut PyObject,
@@ -55,13 +59,17 @@ pub type PyCFunctionWithKeywords = unsafe extern "C" fn(
     kwds: *mut PyObject,
 ) -> *mut PyObject;
 
-#[cfg(not(Py_LIMITED_API))]
-pub type _PyCFunctionFastWithKeywords = unsafe extern "C" fn(
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+pub type PyCFunctionFastWithKeywords = unsafe extern "C" fn(
     slf: *mut PyObject,
     args: *const *mut PyObject,
     nargs: crate::pyport::Py_ssize_t,
     kwnames: *mut PyObject,
 ) -> *mut PyObject;
+
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+#[deprecated(note = "renamed to `PyCFunctionFastWithKeywords`")]
+pub type _PyCFunctionFastWithKeywords = PyCFunctionFastWithKeywords;
 
 #[cfg(all(Py_3_9, not(Py_LIMITED_API)))]
 pub type PyCMethod = unsafe extern "C" fn(
@@ -144,11 +152,21 @@ pub union PyMethodDefPointer {
 
     /// This variant corresponds with [`METH_FASTCALL`].
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
-    pub _PyCFunctionFast: _PyCFunctionFast,
+    #[deprecated(note = "renamed to `PyCFunctionFast`")]
+    pub _PyCFunctionFast: PyCFunctionFast,
+
+    /// This variant corresponds with [`METH_FASTCALL`].
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    pub PyCFunctionFast: PyCFunctionFast,
 
     /// This variant corresponds with [`METH_FASTCALL`] | [`METH_KEYWORDS`].
-    #[cfg(not(Py_LIMITED_API))]
-    pub _PyCFunctionFastWithKeywords: _PyCFunctionFastWithKeywords,
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    #[deprecated(note = "renamed to `PyCFunctionFastWithKeywords`")]
+    pub _PyCFunctionFastWithKeywords: PyCFunctionFastWithKeywords,
+
+    /// This variant corresponds with [`METH_FASTCALL`] | [`METH_KEYWORDS`].
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    pub PyCFunctionFastWithKeywords: PyCFunctionFastWithKeywords,
 
     /// This variant corresponds with [`METH_METHOD`] | [`METH_FASTCALL`] | [`METH_KEYWORDS`].
     #[cfg(all(Py_3_9, not(Py_LIMITED_API)))]

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -7,6 +7,7 @@ use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::{ext::IdentExt, spanned::Spanned, Ident, Result};
 
 use crate::deprecations::deprecate_trailing_option_default;
+use crate::pyversions::{is_abi3, py_version_ge};
 use crate::utils::{Ctx, LitCStr};
 use crate::{
     attributes::{FromPyWithAttribute, TextSignatureAttribute, TextSignatureAttributeValue},
@@ -15,7 +16,7 @@ use crate::{
         FunctionSignature, PyFunctionArgPyO3Attributes, PyFunctionOptions, SignatureAttribute,
     },
     quotes,
-    utils::{self, is_abi3, PythonDoc},
+    utils::{self, PythonDoc},
 };
 
 #[derive(Clone, Debug)]
@@ -389,8 +390,7 @@ impl CallingConvention {
         } else if signature.python_signature.kwargs.is_some() {
             // for functions that accept **kwargs, always prefer varargs
             Self::Varargs
-        } else if !is_abi3() {
-            // FIXME: available in the stable ABI since 3.10
+        } else if py_version_ge(3, 10) || !is_abi3() {
             Self::Fastcall
         } else {
             Self::Varargs

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -387,12 +387,11 @@ impl CallingConvention {
     pub fn from_signature(signature: &FunctionSignature<'_>) -> Self {
         if signature.python_signature.has_no_args() {
             Self::Noargs
-        } else if {
-            // for functions that accept **kwargs, always prefer varargs
-            signature.python_signature.kwargs.is_none()
+        } else if signature.python_signature.kwargs.is_none() && !is_abi3_before(3, 10) {
+            // For functions that accept **kwargs, always prefer varargs for now based on
+            // historical performance testing.
+            //
             // FASTCALL not compatible with `abi3` before 3.10
-            && !is_abi3_before(3, 10)
-        } {
             Self::Fastcall
         } else {
             Self::Varargs

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -22,7 +22,7 @@ use crate::pymethod::{
     impl_py_getter_def, impl_py_setter_def, MethodAndMethodDef, MethodAndSlotDef, PropertyType,
     SlotDef, __GETITEM__, __HASH__, __INT__, __LEN__, __REPR__, __RICHCMP__, __STR__,
 };
-use crate::pyversions::{is_abi3, py_version_ge};
+use crate::pyversions::is_abi3_before;
 use crate::utils::{self, apply_renaming_rule, Ctx, LitCStr, PythonDoc};
 use crate::PyFunctionOptions;
 
@@ -189,7 +189,7 @@ impl PyClassPyO3Options {
             PyClassPyO3Option::Crate(krate) => set_option!(krate),
             PyClassPyO3Option::Dict(dict) => {
                 ensure_spanned!(
-                    py_version_ge(3, 9) || !is_abi3(),
+                    !is_abi3_before(3, 9),
                     dict.span() => "`dict` requires Python >= 3.9 when using the `abi3` feature"
                 );
                 set_option!(dict);
@@ -213,7 +213,7 @@ impl PyClassPyO3Options {
             PyClassPyO3Option::Unsendable(unsendable) => set_option!(unsendable),
             PyClassPyO3Option::Weakref(weakref) => {
                 ensure_spanned!(
-                    py_version_ge(3, 9) || !is_abi3(),
+                    !is_abi3_before(3, 9),
                     weakref.span() => "`weakref` requires Python >= 3.9 when using the `abi3` feature"
                 );
                 set_option!(weakref);

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -22,9 +22,8 @@ use crate::pymethod::{
     impl_py_getter_def, impl_py_setter_def, MethodAndMethodDef, MethodAndSlotDef, PropertyType,
     SlotDef, __GETITEM__, __HASH__, __INT__, __LEN__, __REPR__, __RICHCMP__, __STR__,
 };
-use crate::pyversions;
-use crate::utils::{self, apply_renaming_rule, LitCStr, PythonDoc};
-use crate::utils::{is_abi3, Ctx};
+use crate::pyversions::{is_abi3, py_version_ge};
+use crate::utils::{self, apply_renaming_rule, Ctx, LitCStr, PythonDoc};
 use crate::PyFunctionOptions;
 
 /// If the class is derived from a Rust `struct` or `enum`.
@@ -186,13 +185,11 @@ impl PyClassPyO3Options {
             };
         }
 
-        let python_version = pyo3_build_config::get().version;
-
         match option {
             PyClassPyO3Option::Crate(krate) => set_option!(krate),
             PyClassPyO3Option::Dict(dict) => {
                 ensure_spanned!(
-                    python_version >= pyversions::PY_3_9 || !is_abi3(),
+                    py_version_ge(3, 9) || !is_abi3(),
                     dict.span() => "`dict` requires Python >= 3.9 when using the `abi3` feature"
                 );
                 set_option!(dict);
@@ -216,7 +213,7 @@ impl PyClassPyO3Options {
             PyClassPyO3Option::Unsendable(unsendable) => set_option!(unsendable),
             PyClassPyO3Option::Weakref(weakref) => {
                 ensure_spanned!(
-                    python_version >= pyversions::PY_3_9 || !is_abi3(),
+                    py_version_ge(3, 9) || !is_abi3(),
                     weakref.span() => "`weakref` requires Python >= 3.9 when using the `abi3` feature"
                 );
                 set_option!(weakref);

--- a/pyo3-macros-backend/src/pyversions.rs
+++ b/pyo3-macros-backend/src/pyversions.rs
@@ -1,9 +1,6 @@
 use pyo3_build_config::PythonVersion;
 
-pub fn py_version_ge(major: u8, minor: u8) -> bool {
-    pyo3_build_config::get().version >= PythonVersion { major, minor }
-}
-
-pub fn is_abi3() -> bool {
-    pyo3_build_config::get().abi3
+pub fn is_abi3_before(major: u8, minor: u8) -> bool {
+    let config = pyo3_build_config::get();
+    config.abi3 && config.version < PythonVersion { major, minor }
 }

--- a/pyo3-macros-backend/src/pyversions.rs
+++ b/pyo3-macros-backend/src/pyversions.rs
@@ -1,3 +1,9 @@
 use pyo3_build_config::PythonVersion;
 
-pub const PY_3_9: PythonVersion = PythonVersion { major: 3, minor: 9 };
+pub fn py_version_ge(major: u8, minor: u8) -> bool {
+    pyo3_build_config::get().version >= PythonVersion { major, minor }
+}
+
+pub fn is_abi3() -> bool {
+    pyo3_build_config::get().abi3
+}

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -288,10 +288,6 @@ pub fn apply_renaming_rule(rule: RenamingRule, name: &str) -> String {
     }
 }
 
-pub(crate) fn is_abi3() -> bool {
-    pyo3_build_config::get().abi3
-}
-
 pub(crate) enum IdentOrStr<'a> {
     Str(&'a str),
     Ident(syn::Ident),

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -265,7 +265,7 @@ impl FunctionDescription {
     /// - `args` must be a pointer to a C-style array of valid `ffi::PyObject` pointers, or NULL.
     /// - `kwnames` must be a pointer to a PyTuple, or NULL.
     /// - `nargs + kwnames.len()` is the total length of the `args` array.
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     pub unsafe fn extract_arguments_fastcall<'py, V, K>(
         &self,
         py: Python<'py>,

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -72,8 +72,8 @@ pub enum PyMethodDefType {
 pub enum PyMethodType {
     PyCFunction(ffi::PyCFunction),
     PyCFunctionWithKeywords(ffi::PyCFunctionWithKeywords),
-    #[cfg(not(Py_LIMITED_API))]
-    PyCFunctionFastWithKeywords(ffi::_PyCFunctionFastWithKeywords),
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    PyCFunctionFastWithKeywords(ffi::PyCFunctionFastWithKeywords),
 }
 
 pub type PyClassAttributeFactory = for<'p> fn(Python<'p>) -> PyResult<PyObject>;
@@ -145,10 +145,10 @@ impl PyMethodDef {
     }
 
     /// Define a function that can take `*args` and `**kwargs`.
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     pub const fn fastcall_cfunction_with_keywords(
         ml_name: &'static CStr,
-        cfunction: ffi::_PyCFunctionFastWithKeywords,
+        cfunction: ffi::PyCFunctionFastWithKeywords,
         ml_doc: &'static CStr,
     ) -> Self {
         Self {
@@ -171,9 +171,9 @@ impl PyMethodDef {
             PyMethodType::PyCFunctionWithKeywords(meth) => ffi::PyMethodDefPointer {
                 PyCFunctionWithKeywords: meth,
             },
-            #[cfg(not(Py_LIMITED_API))]
+            #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
             PyMethodType::PyCFunctionFastWithKeywords(meth) => ffi::PyMethodDefPointer {
-                _PyCFunctionFastWithKeywords: meth,
+                PyCFunctionFastWithKeywords: meth,
             },
         };
 

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -538,7 +538,7 @@ mod tests {
             ) -> *mut ffi::PyObject {
                 assert_eq!(nargs, 0);
                 assert!(kwargs.is_null());
-                unsafe { ffi::Py_NewRef(ffi::Py_None()) }
+                Python::assume_gil_acquired().None().into_ptr()
             }
 
             let f = PyCFunction::internal_new(


### PR DESCRIPTION
The `METH_FASTCALL` calling convention [is part of `abi3` since 3.10](https://docs.python.org/3/c-api/structures.html#c.METH_FASTCALL), so this PR is updating our function calling conventions accordingly.

At the same time I've pulled in the FFI definition `PyCFunctionFast` and `PyCFunctionFastWithKeywords`, which have had their `_Py` prefix adjusted to just `Py` in 3.13