### PR TITLE
specialize collections holding bytes to turn into `PyBytes` rather than `PyList`

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -92,6 +92,46 @@ where
 ```
 </details>
 
+### Macro conversion changed for byte collections (`Vec<u8>`, `[u8; N]` and `SmallVec<[u8; N]>`).
+<details open>
+<summary><small>Click to expand</small></summary>
+
+PyO3 0.23 introduced the new fallible conversion trait `IntoPyObject`. The `#[pyfunction]` and
+`#[pymethods]` macros prefer `IntoPyObject` implementations over `IntoPy<PyObject>`.
+
+This change has an effect on functions and methods returning _byte_ collections like
+- `Vec<u8>`
+- `[u8; N]`
+- `SmallVec<[u8; N]>`
+
+In their new `IntoPyObject` implementation these will now turn into `PyBytes` rather than a
+`PyList`. All other `T`s are unaffected and still convert into a `PyList`.
+
+```rust
+# #![allow(dead_code)]
+# use pyo3::prelude::*;
+#[pyfunction]
+fn foo() -> Vec<u8> { // would previously turn into a `PyList`, now `PyBytes`
+    vec![0, 1, 2, 3]
+}
+
+#[pyfunction]
+fn bar() -> Vec<u16> { // unaffected, returns `PyList`
+    vec![0, 1, 2, 3]
+}
+```
+
+If this conversion is _not_ desired, consider building a list manually using `PyList::new`.
+
+The following types were previously _only_ implemented for `u8` and now allow other `T`s turn into
+`PyList`
+- `&[T]`
+- `Cow<[T]>`
+
+This is purely additional and should just extend the possible return types.
+
+</details>
+
 ## from 0.21.* to 0.22
 
 ### Deprecation of `gil-refs` feature continues

--- a/newsfragments/4417.changed.md
+++ b/newsfragments/4417.changed.md
@@ -1,0 +1,2 @@
+`IntoPyObject` impls for `Vec<u8>`, `&[u8]`, `[u8; N]`, `Cow<[u8]>` and `SmallVec<[u8; N]>` now
+convert into `PyBytes` rather than `PyList`.

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -202,6 +202,7 @@ pub trait IntoPyObject<'py>: Sized {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error>;
 
     /// Converts slice of self into a Python object
+    #[doc(hidden)]
     fn iter_into_pyobject<I, E>(
         iter: I,
         py: Python<'py>,

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -203,14 +203,14 @@ pub trait IntoPyObject<'py>: Sized {
 
     /// Converts slice of self into a Python object
     #[doc(hidden)]
-    fn iter_into_pyobject<I, E>(
+    fn iter_into_pyobject<I>(
         iter: I,
         py: Python<'py>,
         _: private::Token,
     ) -> Result<Bound<'py, PyAny>, PyErr>
     where
-        I: IntoIterator<Item = Self, IntoIter = E>,
-        E: ExactSizeIterator<Item = Self>,
+        I: IntoIterator<Item = Self>,
+        I::IntoIter: ExactSizeIterator<Item = Self>,
         PyErr: From<Self::Error>,
     {
         let mut iter = iter.into_iter().map(|e| {

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -6,7 +6,7 @@ use crate::pyclass::boolean_struct::False;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
 use crate::{
-    ffi, Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyObject, PyRef, PyRefMut, Python,
+    ffi, Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyObject, PyRef, PyRefMut, Python,
 };
 use std::convert::Infallible;
 
@@ -200,6 +200,31 @@ pub trait IntoPyObject<'py>: Sized {
 
     /// Performs the conversion.
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error>;
+
+    /// Converts slice of self into a Python object
+    fn iter_into_pyobject<I, E>(
+        iter: I,
+        py: Python<'py>,
+        _: private::Token,
+    ) -> Result<Bound<'py, PyAny>, PyErr>
+    where
+        I: IntoIterator<Item = Self, IntoIter = E>,
+        E: ExactSizeIterator<Item = Self>,
+        PyErr: From<Self::Error>,
+    {
+        let mut iter = iter.into_iter().map(|e| {
+            e.into_pyobject(py)
+                .map(BoundObject::into_any)
+                .map(BoundObject::unbind)
+                .map_err(Into::into)
+        });
+        let list = crate::types::list::try_new_from_iter(py, &mut iter);
+        list.map(Bound::into_any)
+    }
+}
+
+pub(crate) mod private {
+    pub struct Token;
 }
 
 impl<'py, T> IntoPyObject<'py> for Bound<'py, T> {

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -20,12 +20,12 @@ use crate::exceptions::PyTypeError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::any::PyAnyMethods;
-use crate::types::list::{new_from_iter, try_new_from_iter};
-use crate::types::{PyList, PySequence, PyString};
+use crate::types::list::new_from_iter;
+use crate::types::{PySequence, PyString};
 use crate::PyErr;
 use crate::{
-    err::DowncastError, ffi, Bound, BoundObject, FromPyObject, IntoPy, PyAny, PyObject, PyResult,
-    Python, ToPyObject,
+    err::DowncastError, ffi, Bound, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python,
+    ToPyObject,
 };
 use smallvec::{Array, SmallVec};
 
@@ -62,18 +62,16 @@ where
     A::Item: IntoPyObject<'py>,
     PyErr: From<<A::Item as IntoPyObject<'py>>::Error>,
 {
-    type Target = PyList;
+    type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
+    /// Turns [`SmallVec<u8>`] into [`PyBytes`], all other `T`s will be turned into a [`PyList`]
+    ///
+    /// [`PyBytes`]: crate::types::PyBytes
+    /// [`PyList`]: crate::types::PyList
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let mut iter = self.into_iter().map(|e| {
-            e.into_pyobject(py)
-                .map(BoundObject::into_any)
-                .map(BoundObject::unbind)
-                .map_err(Into::into)
-        });
-        try_new_from_iter(py, &mut iter)
+        <A::Item>::iter_into_pyobject(self, py, crate::conversion::private::Token)
     }
 }
 
@@ -120,7 +118,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::PyDict;
+    use crate::types::{PyDict, PyList};
 
     #[test]
     fn test_smallvec_into_py() {

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -118,7 +118,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{PyDict, PyList};
+    use crate::types::{PyBytes, PyBytesMethods, PyDict, PyList};
 
     #[test]
     fn test_smallvec_into_py() {
@@ -158,6 +158,21 @@ mod tests {
             let hso: PyObject = sv.to_object(py);
             let l = PyList::new(py, [1, 2, 3, 4, 5]);
             assert!(l.eq(hso).unwrap());
+        });
+    }
+
+    #[test]
+    fn test_smallvec_intopyobject_impl() {
+        Python::with_gil(|py| {
+            let bytes: SmallVec<[u8; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();
+            let obj = bytes.clone().into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyBytes>());
+            let obj = obj.downcast_into::<PyBytes>().unwrap();
+            assert_eq!(obj.as_bytes(), &*bytes);
+
+            let nums: SmallVec<[u16; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();
+            let obj = nums.into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyList>());
         });
     }
 }

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -149,7 +149,10 @@ mod tests {
         sync::atomic::{AtomicUsize, Ordering},
     };
 
-    use crate::types::any::PyAnyMethods;
+    use crate::{
+        conversion::IntoPyObject,
+        types::{any::PyAnyMethods, PyBytes, PyBytesMethods},
+    };
     use crate::{types::PyList, IntoPy, PyResult, Python, ToPyObject};
 
     #[test]
@@ -237,6 +240,21 @@ mod tests {
             assert_eq!(pylist.get_item(1).unwrap().extract::<f32>().unwrap(), -16.0);
             assert_eq!(pylist.get_item(2).unwrap().extract::<f32>().unwrap(), 16.0);
             assert_eq!(pylist.get_item(3).unwrap().extract::<f32>().unwrap(), 42.0);
+        });
+    }
+
+    #[test]
+    fn test_array_intopyobject_impl() {
+        Python::with_gil(|py| {
+            let bytes: [u8; 6] = *b"foobar";
+            let obj = bytes.into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyBytes>());
+            let obj = obj.downcast_into::<PyBytes>().unwrap();
+            assert_eq!(obj.as_bytes(), &bytes);
+
+            let nums: [u16; 4] = [0, 1, 2, 3];
+            let obj = nums.into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyList>());
         });
     }
 

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -213,14 +213,14 @@ impl<'py> IntoPyObject<'py> for u8 {
         }
     }
 
-    fn iter_into_pyobject<I, E>(
+    fn iter_into_pyobject<I>(
         iter: I,
         py: Python<'py>,
         _: crate::conversion::private::Token,
     ) -> Result<Bound<'py, PyAny>, PyErr>
     where
-        I: IntoIterator<Item = Self, IntoIter = E>,
-        E: ExactSizeIterator<Item = Self>,
+        I: IntoIterator<Item = Self>,
+        I::IntoIter: ExactSizeIterator<Item = Self>,
     {
         let mut iter = iter.into_iter();
         let len = iter.len();
@@ -250,14 +250,14 @@ impl<'py> IntoPyObject<'py> for &u8 {
         (*self).into_pyobject(py)
     }
 
-    fn iter_into_pyobject<I, E>(
+    fn iter_into_pyobject<I>(
         iter: I,
         py: Python<'py>,
         _: crate::conversion::private::Token,
     ) -> Result<Bound<'py, PyAny>, PyErr>
     where
-        I: IntoIterator<Item = Self, IntoIter = E>,
-        E: ExactSizeIterator<Item = Self>,
+        I: IntoIterator<Item = Self>,
+        I::IntoIter: ExactSizeIterator<Item = Self>,
         PyErr: From<Self::Error>,
     {
         u8::iter_into_pyobject(

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -57,3 +57,25 @@ where
         T::iter_into_pyobject(self, py, crate::conversion::private::Token)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::conversion::IntoPyObject;
+    use crate::types::{PyAnyMethods, PyBytes, PyBytesMethods, PyList};
+    use crate::Python;
+
+    #[test]
+    fn test_vec_intopyobject_impl() {
+        Python::with_gil(|py| {
+            let bytes: Vec<u8> = b"foobar".to_vec();
+            let obj = bytes.clone().into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyBytes>());
+            let obj = obj.downcast_into::<PyBytes>().unwrap();
+            assert_eq!(obj.as_bytes(), &bytes);
+
+            let nums: Vec<u16> = vec![0, 1, 2, 3];
+            let obj = nums.into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyList>());
+        });
+    }
+}

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -11,11 +11,11 @@ error[E0277]: `Blah` cannot be converted to a Python object
             &'a Py<T>
             &'a PyRef<'py, T>
             &'a PyRefMut<'py, T>
+            &'a [T]
             &'a pyo3::Bound<'py, T>
             &OsStr
             &OsString
             &Path
-            &PathBuf
           and $N others
 note: required by a bound in `UnknownReturnType::<T>::wrap`
  --> src/impl_/wrap.rs


### PR DESCRIPTION
Followup to #4060 
XRef #4182 

This implements specialization for collections holding bytes (in the new `IntoPyObject` trait) by a provided, sealed `iter_into_pyobject` method. The method is intended to be overwritten by the element type (for now `u8` only) and turns an iterator of elements into an appropriate Python type in type erased form. The default implementation creates a `PyList` while the `u8` override returns `PyBytes`.  

This method is then used by the generic `IntoPyObject::into_pyobject` implementation of collection types. I updated the implementations of `Vec<T>`, `&[T]`, `[T; N]` and `SmallVec<A>` accordingly. (I hope did not forget something)

From a quick test everything seems to work out. If this seems sensible to work with, I will add a few tests and the newsfragment.


Big thanks to @diliop for the previous work in #4182!