### PR TITLE
ffi: update `modsupport.rs` for Python 3.13

### DIFF
--- a/newsfragments/4420.fixed.md
+++ b/newsfragments/4420.fixed.md
@@ -1,0 +1,1 @@
+Correct FFI definition `PyArg_ParseTupleAndKeywords` to take `*const *const c_char` instead of `*mut *mut c_char` on Python 3.13 and up.

--- a/newsfragments/4420.removed.md
+++ b/newsfragments/4420.removed.md
@@ -1,0 +1,1 @@
+Remove FFI definition of private variable `_Py_PackageContext`.

--- a/pyo3-ffi/src/modsupport.rs
+++ b/pyo3-ffi/src/modsupport.rs
@@ -14,9 +14,14 @@ extern "C" {
         arg1: *mut PyObject,
         arg2: *mut PyObject,
         arg3: *const c_char,
-        arg4: *mut *mut c_char,
+        #[cfg(not(Py_3_13))] arg4: *mut *mut c_char,
+        #[cfg(Py_3_13)] arg4: *const *const c_char,
         ...
     ) -> c_int;
+
+    // skipped PyArg_VaParse
+    // skipped PyArg_VaParseTupleAndKeywords
+
     pub fn PyArg_ValidateKeywordArguments(arg1: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyArg_UnpackTuple")]
     pub fn PyArg_UnpackTuple(
@@ -26,32 +31,10 @@ extern "C" {
         arg4: Py_ssize_t,
         ...
     ) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPy_BuildValue")]
     pub fn Py_BuildValue(arg1: *const c_char, ...) -> *mut PyObject;
-    // #[cfg_attr(PyPy, link_name = "_PyPy_BuildValue_SizeT")]
-    //pub fn _Py_BuildValue_SizeT(arg1: *const c_char, ...)
-    // -> *mut PyObject;
-    // #[cfg_attr(PyPy, link_name = "PyPy_VaBuildValue")]
-
-    // skipped non-limited _PyArg_UnpackStack
-    // skipped non-limited _PyArg_NoKeywords
-    // skipped non-limited _PyArg_NoKwnames
-    // skipped non-limited _PyArg_NoPositional
-    // skipped non-limited _PyArg_BadArgument
-    // skipped non-limited _PyArg_CheckPositional
-
-    //pub fn Py_VaBuildValue(arg1: *const c_char, arg2: va_list)
-    // -> *mut PyObject;
-
-    // skipped non-limited _Py_VaBuildStack
-    // skipped non-limited _PyArg_Parser
-
-    // skipped non-limited _PyArg_ParseTupleAndKeywordsFast
-    // skipped non-limited _PyArg_ParseStack
-    // skipped non-limited _PyArg_ParseStackAndKeywords
-    // skipped non-limited _PyArg_VaParseTupleAndKeywordsFast
-    // skipped non-limited _PyArg_UnpackKeywords
-    // skipped non-limited _PyArg_Fini
+    // skipped Py_VaBuildValue
 
     #[cfg(Py_3_10)]
     #[cfg_attr(PyPy, link_name = "PyPyModule_AddObjectRef")]
@@ -158,10 +141,4 @@ pub unsafe fn PyModule_FromDefAndSpec(def: *mut PyModuleDef, spec: *mut PyObject
             PYTHON_API_VERSION
         },
     )
-}
-
-#[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
-extern "C" {
-    pub static mut _Py_PackageContext: *const c_char;
 }


### PR DESCRIPTION
Partially split from #4379 

This updates `modsupport.rs` by removing private symbols and at the same time synchronising to Python 3.13. The only actual API change is the use of `*const *const char` instead of `*mut *mut char` in `PyArg_ParseTupleAndKeywords`, came from https://github.com/python/cpython/pull/105958