### PR TITLE
Update example to use into_py_dict_bound (into_py_dict deprecated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ fn main() -> PyResult<()> {
         let sys = py.import_bound("sys")?;
         let version: String = sys.getattr("version")?.extract()?;
 
-        let locals = [("os", py.import_bound("os")?)].into_py_dict(py);
+        let locals = [("os", py.import_bound("os")?)].into_py_dict_bound(py);
         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
         let user: String = py.eval_bound(code, None, Some(&locals))?.extract()?;
 


### PR DESCRIPTION
The example in the `README.md` is using a deprecated method.

`into_py_dict` is deprecated; one should use `into_py_dict_bound` instead (https://github.com/PyO3/pyo3/blob/0a185cd77f852bfeb19dc294df12385bb382e75b/src/types/dict.rs#L540).

Although it's a small fix, it's one of the first examples (copy paste) I tried since it was in the README page on Github and it failed surprisingly.

```
error[E0599]: no method named `into_py_dict` found for array `[(&str, pyo3::Bound<'_, PyModule>); 1]` in the current scope
 --> src/main.rs:9:55
  |
9 |         let locals = [("os", py.import_bound("os")?)].into_py_dict(py);
  |                                                       ^^^^^^^^^^^^
  |
help: there is a method `into_py` with a similar name
  |
9 |         let locals = [("os", py.import_bound("os")?)].into_py(py);
  |                                                       ~~~~~~~

```