### PR TITLE
bytes specialization via unsafe slice cast

### DIFF
--- a/newsfragments/4417.changed.md
+++ b/newsfragments/4417.changed.md
@@ -1,0 +1,2 @@
+`IntoPyObject` impls for `Vec<u8>`, `&[u8]`, `[u8; N]`, `Cow<[u8]>` and `SmallVec<[u8; N]>` now
+convert into `PyBytes` rather than `PyList`.

--- a/pyo3-benches/Cargo.toml
+++ b/pyo3-benches/Cargo.toml
@@ -48,6 +48,10 @@ name = "bench_gil"
 harness = false
 
 [[bench]]
+name = "bench_intopyobject"
+harness = false
+
+[[bench]]
 name = "bench_list"
 harness = false
 

--- a/pyo3-benches/benches/bench_intopyobject.rs
+++ b/pyo3-benches/benches/bench_intopyobject.rs
@@ -1,0 +1,93 @@
+use std::hint::black_box;
+
+use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
+
+use pyo3::conversion::IntoPyObject;
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+fn bench_bytes_new(b: &mut Bencher<'_>, data: &[u8]) {
+    Python::with_gil(|py| {
+        b.iter_with_large_drop(|| PyBytes::new(py, black_box(data)));
+    });
+}
+
+fn bytes_new_small(b: &mut Bencher<'_>) {
+    bench_bytes_new(b, &[]);
+}
+
+fn bytes_new_medium(b: &mut Bencher<'_>) {
+    let data = (0..u8::MAX).into_iter().collect::<Vec<u8>>();
+    bench_bytes_new(b, &data);
+}
+
+fn bytes_new_large(b: &mut Bencher<'_>) {
+    let data = vec![10u8; 100_000];
+    bench_bytes_new(b, &data);
+}
+
+fn bench_bytes_into_pyobject(b: &mut Bencher<'_>, data: &[u8]) {
+    Python::with_gil(|py| {
+        b.iter_with_large_drop(|| black_box(data).into_pyobject(py));
+    });
+}
+
+fn byte_slice_into_pyobject_small(b: &mut Bencher<'_>) {
+    bench_bytes_into_pyobject(b, &[]);
+}
+
+fn byte_slice_into_pyobject_medium(b: &mut Bencher<'_>) {
+    let data = (0..u8::MAX).into_iter().collect::<Vec<u8>>();
+    bench_bytes_into_pyobject(b, &data);
+}
+
+fn byte_slice_into_pyobject_large(b: &mut Bencher<'_>) {
+    let data = vec![10u8; 100_000];
+    bench_bytes_into_pyobject(b, &data);
+}
+
+fn byte_slice_into_py(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let data = (0..u8::MAX).into_iter().collect::<Vec<u8>>();
+        let bytes = data.as_slice();
+        b.iter_with_large_drop(|| black_box(bytes).into_py(py));
+    });
+}
+
+fn vec_into_pyobject(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let bytes = (0..u8::MAX).into_iter().collect::<Vec<u8>>();
+        b.iter_with_large_drop(|| black_box(&bytes).clone().into_pyobject(py));
+    });
+}
+
+fn vec_into_py(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let bytes = (0..u8::MAX).into_iter().collect::<Vec<u8>>();
+        b.iter_with_large_drop(|| black_box(&bytes).clone().into_py(py));
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("bytes_new_small", bytes_new_small);
+    c.bench_function("bytes_new_medium", bytes_new_medium);
+    c.bench_function("bytes_new_large", bytes_new_large);
+    c.bench_function(
+        "byte_slice_into_pyobject_small",
+        byte_slice_into_pyobject_small,
+    );
+    c.bench_function(
+        "byte_slice_into_pyobject_medium",
+        byte_slice_into_pyobject_medium,
+    );
+    c.bench_function(
+        "byte_slice_into_pyobject_large",
+        byte_slice_into_pyobject_large,
+    );
+    c.bench_function("byte_slice_into_py", byte_slice_into_py);
+    c.bench_function("vec_into_pyobject", vec_into_pyobject);
+    c.bench_function("vec_into_py", vec_into_py);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -6,7 +6,7 @@ use crate::pyclass::boolean_struct::False;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
 use crate::{
-    ffi, Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyObject, PyRef, PyRefMut, Python,
+    ffi, Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyObject, PyRef, PyRefMut, Python,
 };
 use std::convert::Infallible;
 
@@ -200,6 +200,31 @@ pub trait IntoPyObject<'py>: Sized {
 
     /// Performs the conversion.
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error>;
+
+    /// Converts slice of self into a Python object
+    fn iter_into_pyobject<I, E>(
+        iter: I,
+        py: Python<'py>,
+        _: private::Token,
+    ) -> Result<Bound<'py, PyAny>, PyErr>
+    where
+        I: IntoIterator<Item = Self, IntoIter = E>,
+        E: ExactSizeIterator<Item = Self>,
+        PyErr: From<Self::Error>,
+    {
+        let mut iter = iter.into_iter().map(|e| {
+            e.into_pyobject(py)
+                .map(BoundObject::into_any)
+                .map(BoundObject::unbind)
+                .map_err(Into::into)
+        });
+        let list = crate::types::list::try_new_from_iter(py, &mut iter);
+        list.map(Bound::into_any)
+    }
+}
+
+pub(crate) mod private {
+    pub struct Token;
 }
 
 impl<'py, T> IntoPyObject<'py> for Bound<'py, T> {

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -70,8 +70,19 @@ where
     ///
     /// [`PyBytes`]: crate::types::PyBytes
     /// [`PyList`]: crate::types::PyList
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         <A::Item>::iter_into_pyobject(self, py, crate::conversion::private::Token)
+    }
+}
+
+impl<A> crate::conversion::SliceableIntoPyObjectIterator for SmallVec<A>
+where
+    A: Array,
+{
+    #[inline]
+    fn as_bytes_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.as_ptr().cast::<u8>(), self.len()) }
     }
 }
 

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -20,12 +20,12 @@ use crate::exceptions::PyTypeError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::any::PyAnyMethods;
-use crate::types::list::{new_from_iter, try_new_from_iter};
-use crate::types::{PyList, PySequence, PyString};
+use crate::types::list::new_from_iter;
+use crate::types::{PySequence, PyString};
 use crate::PyErr;
 use crate::{
-    err::DowncastError, ffi, Bound, BoundObject, FromPyObject, IntoPy, PyAny, PyObject, PyResult,
-    Python, ToPyObject,
+    err::DowncastError, ffi, Bound, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python,
+    ToPyObject,
 };
 use smallvec::{Array, SmallVec};
 
@@ -62,18 +62,16 @@ where
     A::Item: IntoPyObject<'py>,
     PyErr: From<<A::Item as IntoPyObject<'py>>::Error>,
 {
-    type Target = PyList;
+    type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
+    /// Turns [`SmallVec<u8>`] into [`PyBytes`], all other `T`s will be turned into a [`PyList`]
+    ///
+    /// [`PyBytes`]: crate::types::PyBytes
+    /// [`PyList`]: crate::types::PyList
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let mut iter = self.into_iter().map(|e| {
-            e.into_pyobject(py)
-                .map(BoundObject::into_any)
-                .map(BoundObject::unbind)
-                .map_err(Into::into)
-        });
-        try_new_from_iter(py, &mut iter)
+        <A::Item>::iter_into_pyobject(self, py, crate::conversion::private::Token)
     }
 }
 
@@ -120,7 +118,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::PyDict;
+    use crate::types::{PyDict, PyList};
 
     #[test]
     fn test_smallvec_into_py() {

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -118,7 +118,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{PyDict, PyList};
+    use crate::types::{PyBytes, PyBytesMethods, PyDict, PyList};
 
     #[test]
     fn test_smallvec_into_py() {
@@ -158,6 +158,21 @@ mod tests {
             let hso: PyObject = sv.to_object(py);
             let l = PyList::new(py, [1, 2, 3, 4, 5]);
             assert!(l.eq(hso).unwrap());
+        });
+    }
+
+    #[test]
+    fn test_smallvec_intopyobject_impl() {
+        Python::with_gil(|py| {
+            let bytes: SmallVec<[u8; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();
+            let obj = bytes.clone().into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyBytes>());
+            let obj = obj.downcast_into::<PyBytes>().unwrap();
+            assert_eq!(obj.as_bytes(), &*bytes);
+
+            let nums: SmallVec<[u16; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();
+            let obj = nums.into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyList>());
         });
     }
 }

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -149,7 +149,10 @@ mod tests {
         sync::atomic::{AtomicUsize, Ordering},
     };
 
-    use crate::types::any::PyAnyMethods;
+    use crate::{
+        conversion::IntoPyObject,
+        types::{any::PyAnyMethods, PyBytes, PyBytesMethods},
+    };
     use crate::{types::PyList, IntoPy, PyResult, Python, ToPyObject};
 
     #[test]
@@ -237,6 +240,21 @@ mod tests {
             assert_eq!(pylist.get_item(1).unwrap().extract::<f32>().unwrap(), -16.0);
             assert_eq!(pylist.get_item(2).unwrap().extract::<f32>().unwrap(), 16.0);
             assert_eq!(pylist.get_item(3).unwrap().extract::<f32>().unwrap(), 42.0);
+        });
+    }
+
+    #[test]
+    fn test_array_intopyobject_impl() {
+        Python::with_gil(|py| {
+            let bytes: [u8; 6] = *b"foobar";
+            let obj = bytes.into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyBytes>());
+            let obj = obj.downcast_into::<PyBytes>().unwrap();
+            assert_eq!(obj.as_bytes(), &bytes);
+
+            let nums: [u16; 4] = [0, 1, 2, 3];
+            let obj = nums.into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyList>());
         });
     }
 

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -55,6 +55,12 @@ where
     }
 }
 
+impl<T, const N: usize> crate::conversion::SliceableIntoPyObjectIterator for [T; N] {
+    fn as_bytes_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.as_ptr().cast::<u8>(), self.len()) }
+    }
+}
+
 impl<T, const N: usize> ToPyObject for [T; N]
 where
     T: ToPyObject,

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -32,8 +32,16 @@ where
     ///
     /// [`PyBytes`]: crate::types::PyBytes
     /// [`PyList`]: crate::types::PyList
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         <&T>::iter_into_pyobject(self, py, crate::conversion::private::Token)
+    }
+}
+
+impl<'a, T> crate::conversion::SliceableIntoPyObjectIterator for &'a [T] {
+    #[inline]
+    fn as_bytes_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.as_ptr().cast::<u8>(), self.len()) }
     }
 }
 
@@ -91,8 +99,9 @@ where
     type Output = Bound<'py, Self::Target>;
     type Error = PyErr;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        <&T>::iter_into_pyobject(self.iter(), py, crate::conversion::private::Token)
+        <&T>::iter_into_pyobject(&*self, py, crate::conversion::private::Token)
     }
 }
 

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -53,8 +53,16 @@ where
     ///
     /// [`PyBytes`]: crate::types::PyBytes
     /// [`PyList`]: crate::types::PyList
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         T::iter_into_pyobject(self, py, crate::conversion::private::Token)
+    }
+}
+
+impl<T> crate::conversion::SliceableIntoPyObjectIterator for Vec<T> {
+    #[inline]
+    fn as_bytes_slice(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.as_ptr().cast::<u8>(), self.len()) }
     }
 }
 

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -57,3 +57,25 @@ where
         T::iter_into_pyobject(self, py, crate::conversion::private::Token)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::conversion::IntoPyObject;
+    use crate::types::{PyAnyMethods, PyBytes, PyBytesMethods, PyList};
+    use crate::Python;
+
+    #[test]
+    fn test_vec_intopyobject_impl() {
+        Python::with_gil(|py| {
+            let bytes: Vec<u8> = b"foobar".to_vec();
+            let obj = bytes.clone().into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyBytes>());
+            let obj = obj.downcast_into::<PyBytes>().unwrap();
+            assert_eq!(obj.as_bytes(), &bytes);
+
+            let nums: Vec<u16> = vec![0, 1, 2, 3];
+            let obj = nums.into_pyobject(py).unwrap();
+            assert!(obj.is_instance_of::<PyList>());
+        });
+    }
+}

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -11,11 +11,11 @@ error[E0277]: `Blah` cannot be converted to a Python object
             &'a Py<T>
             &'a PyRef<'py, T>
             &'a PyRefMut<'py, T>
+            &'a [T]
             &'a pyo3::Bound<'py, T>
             &OsStr
             &OsString
             &Path
-            &PathBuf
           and $N others
 note: required by a bound in `UnknownReturnType::<T>::wrap`
  --> src/impl_/wrap.rs


### PR DESCRIPTION
This is an extension of #4417 to attempt to maximise performance by utilising unsafe slice casting to convert

Code is a bit of a mess but hopefully illustrates the idea.

Benchmarks against `PyBytes::new`:

```
bytes_new_small         time:   [3.0873 ns 3.1257 ns 3.1597 ns]
bytes_new_medium        time:   [33.446 ns 33.675 ns 33.884 ns]
bytes_new_large         time:   [7.3872 µs 7.4767 µs 7.5715 µs]

byte_slice_into_pyobject_small
                        time:   [4.0567 ns 4.1082 ns 4.1558 ns]
byte_slice_into_pyobject_medium
                        time:   [36.650 ns 37.367 ns 38.093 ns]
byte_slice_into_pyobject_large
                        time:   [7.7810 µs 7.8967 µs 8.0074 µs]
```