### PR TITLE
ci: pin `zope.interface<7`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
-      - uses: taiki-e/install-action@cargo-careful
+      # FIXME: workaround https://github.com/RalfJung/cargo-careful/issues/36
+      # - uses: taiki-e/install-action@cargo-careful
+      - run: cargo install cargo-careful
       - run: python -m pip install --upgrade pip && pip install nox
       - run: nox -s test-rust -- careful skip-full
     env:

--- a/noxfile.py
+++ b/noxfile.py
@@ -869,6 +869,8 @@ def _run_cargo_test(
 ) -> None:
     command = ["cargo"]
     if "careful" in session.posargs:
+        # do explicit setup so failures in setup can be seen
+        _run_cargo(session, "careful", "setup")
         command.append("careful")
     command.extend(("test", "--no-fail-fast"))
     if "release" in session.posargs:

--- a/pytests/noxfile.py
+++ b/pytests/noxfile.py
@@ -12,12 +12,15 @@ def test(session: nox.Session):
 
     def try_install_binary(package: str, constraint: str):
         try:
-            session.install(f"--only-binary={package}", f"{package}{constraint}")
+            session.install("--only-binary=:all:", f"{package}{constraint}")
         except CommandFailed:
             # No binary wheel available on this platform
             pass
 
     try_install_binary("numpy", ">=1.16")
+    # https://github.com/zopefoundation/zope.interface/issues/316
+    # - is a dependency of gevent
+    try_install_binary("zope.interface", "<7")
     try_install_binary("gevent", ">=22.10.2")
     ignored_paths = []
     if sys.version_info < (3, 10):


### PR DESCRIPTION
This should fix the failing `test-debug` CI job, by pinning `zope.interface` back to a version before the broken one released at the start of August.