### PR TITLE
ci: install cargo-codspeed binary

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -30,8 +30,9 @@ jobs:
             pyo3-benches
         continue-on-error: true
 
-      - name: Install cargo-codspeed
-        run: cargo install cargo-codspeed
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed
 
       - name: Install nox
         run: pip install nox


### PR DESCRIPTION
Install of `cargo codspeed` has been failing to build; let's try downloading binary instead...