### PR TITLE
ci: install `cargo-careful` from binary again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,9 +349,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
-      # FIXME: workaround https://github.com/RalfJung/cargo-careful/issues/36
-      # - uses: taiki-e/install-action@cargo-careful
-      - run: cargo install cargo-careful
+      - uses: taiki-e/install-action@cargo-careful
       - run: python -m pip install --upgrade pip && pip install nox
       - run: nox -s test-rust -- careful skip-full
     env:


### PR DESCRIPTION
`cargo-careful` build from source in #4429 no longer needed following its latest binary release.