### PR TITLE
Reintroduce `Python::run` and `Python::eval`

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Example program displaying the value of `sys.version` and the current user name:
 ```rust
 use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
+use pyo3::ffi::c_str;
 
 fn main() -> PyResult<()> {
     Python::with_gil(|py| {
@@ -153,7 +154,7 @@ fn main() -> PyResult<()> {
         let version: String = sys.getattr("version")?.extract()?;
 
         let locals = [("os", py.import("os")?)].into_py_dict(py);
-        let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
+        let code = c_str!("os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'");
         let user: String = py.eval(code, None, Some(&locals))?.extract()?;
 
         println!("Hello {}, I'm Python {}", user, version);

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ fn main() -> PyResult<()> {
 
         let locals = [("os", py.import("os")?)].into_py_dict(py);
         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
-        let user: String = py.eval_bound(code, None, Some(&locals))?.extract()?;
+        let user: String = py.eval(code, None, Some(&locals))?.extract()?;
 
         println!("Hello {}, I'm Python {}", user, version);
         Ok(())

--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -330,7 +330,7 @@ fn my_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Number>()?;
     Ok(())
 }
-# const SCRIPT: &'static str = r#"
+# const SCRIPT: &'static std::ffi::CStr = pyo3::ffi::c_str!(r#"
 # def hash_djb2(s: str):
 #     n = Number(0)
 #     five = Number(5)
@@ -379,7 +379,7 @@ fn my_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #     pass
 # assert Number(1337).__str__() == '1337'
 # assert Number(1337).__repr__() == 'Number(1337)'
-"#;
+"#);
 
 #
 # use pyo3::PyTypeInfo;

--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -389,7 +389,7 @@ fn my_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #         let globals = PyModule::import(py, "__main__")?.dict();
 #         globals.set_item("Number", Number::type_object_bound(py))?;
 #
-#         py.run_bound(SCRIPT, Some(&globals), None)?;
+#         py.run(SCRIPT, Some(&globals), None)?;
 #         Ok(())
 #     })
 # }

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -157,7 +157,7 @@ struct RustyStruct {
 #
 # fn main() -> PyResult<()> {
 #     Python::with_gil(|py| -> PyResult<()> {
-#         let py_dict = py.eval_bound("{'foo': 'foo', 'bar': 'bar', 'foobar': 'foobar'}", None, None)?;
+#         let py_dict = py.eval("{'foo': 'foo', 'bar': 'bar', 'foobar': 'foobar'}", None, None)?;
 #         let rustystruct: RustyStruct = py_dict.extract()?;
 # 		  assert_eq!(rustystruct.foo, "foo");
 #         assert_eq!(rustystruct.bar, "bar");

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -157,7 +157,7 @@ struct RustyStruct {
 #
 # fn main() -> PyResult<()> {
 #     Python::with_gil(|py| -> PyResult<()> {
-#         let py_dict = py.eval("{'foo': 'foo', 'bar': 'bar', 'foobar': 'foobar'}", None, None)?;
+#         let py_dict = py.eval(pyo3::ffi::c_str!("{'foo': 'foo', 'bar': 'bar', 'foobar': 'foobar'}"), None, None)?;
 #         let rustystruct: RustyStruct = py_dict.extract()?;
 # 		  assert_eq!(rustystruct.foo, "foo");
 #         assert_eq!(rustystruct.bar, "bar");

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -91,7 +91,7 @@ fn func() -> String {
 #    let parent_module = wrap_pymodule!(parent_module)(py);
 #    let ctx = [("parent_module", parent_module)].into_py_dict(py);
 #
-#    py.run_bound("assert parent_module.child_module.func() == 'func'", None, Some(&ctx)).unwrap();
+#    py.run("assert parent_module.child_module.func() == 'func'", None, Some(&ctx)).unwrap();
 # })
 ```
 

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -88,10 +88,11 @@ fn func() -> String {
 # Python::with_gil(|py| {
 #    use pyo3::wrap_pymodule;
 #    use pyo3::types::IntoPyDict;
+#    use pyo3::ffi::c_str;
 #    let parent_module = wrap_pymodule!(parent_module)(py);
 #    let ctx = [("parent_module", parent_module)].into_py_dict(py);
 #
-#    py.run("assert parent_module.child_module.func() == 'func'", None, Some(&ctx)).unwrap();
+#    py.run(c_str!("assert parent_module.child_module.func() == 'func'"), None, Some(&ctx)).unwrap();
 # })
 ```
 

--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -36,7 +36,7 @@ use pyo3::prelude::*;
 # fn main() -> Result<(), ()> {
 Python::with_gil(|py| {
     let result = py
-        .eval_bound("[i * 10 for i in range(5)]", None, None)
+        .eval("[i * 10 for i in range(5)]", None, None)
         .map_err(|e| {
             e.print_and_set_sys_last_vars(py);
         })?;
@@ -349,7 +349,7 @@ class House(object):
 
         house.call_method0("__enter__").unwrap();
 
-        let result = py.eval_bound("undefined_variable + 1", None, None);
+        let result = py.eval("undefined_variable + 1", None, None);
 
         // If the eval threw an exception we'll pass it through to the context manager.
         // Otherwise, __exit__  is called with empty arguments (Python "None").

--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -32,11 +32,12 @@ and return the evaluated value as a `Bound<'py, PyAny>` object.
 
 ```rust
 use pyo3::prelude::*;
+use pyo3::ffi::c_str;
 
 # fn main() -> Result<(), ()> {
 Python::with_gil(|py| {
     let result = py
-        .eval("[i * 10 for i in range(5)]", None, None)
+        .eval(c_str!("[i * 10 for i in range(5)]"), None, None)
         .map_err(|e| {
             e.print_and_set_sys_last_vars(py);
         })?;
@@ -153,6 +154,7 @@ As an example, the below adds the module `foo` to the embedded interpreter:
 
 ```rust
 use pyo3::prelude::*;
+use pyo3::ffi::c_str;
 
 #[pyfunction]
 fn add_one(x: i64) -> i64 {
@@ -167,7 +169,7 @@ fn foo(foo_module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 fn main() -> PyResult<()> {
     pyo3::append_to_inittab!(foo);
-    Python::with_gil(|py| Python::run(py, "import foo; foo.add_one(6)", None, None))
+    Python::with_gil(|py| Python::run(py, c_str!("import foo; foo.add_one(6)"), None, None))
 }
 ```
 
@@ -178,6 +180,7 @@ and insert it manually into `sys.modules`:
 ```rust
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use pyo3::ffi::c_str;
 
 #[pyfunction]
 pub fn add_one(x: i64) -> i64 {
@@ -198,7 +201,7 @@ fn main() -> PyResult<()> {
         py_modules.set_item("foo", foo_module)?;
 
         // Now we can import + run our python code
-        Python::run(py, "import foo; foo.add_one(6)", None, None)
+        Python::run(py, c_str!("import foo; foo.add_one(6)"), None, None)
     })
 }
 ```
@@ -320,7 +323,7 @@ Use context managers by directly invoking `__enter__` and `__exit__`.
 
 ```rust
 use pyo3::prelude::*;
-use pyo3_ffi::c_str;
+use pyo3::ffi::c_str;
 
 fn main() {
     Python::with_gil(|py| {
@@ -349,7 +352,7 @@ class House(object):
 
         house.call_method0("__enter__").unwrap();
 
-        let result = py.eval("undefined_variable + 1", None, None);
+        let result = py.eval(c_str!("undefined_variable + 1"), None, None);
 
         // If the eval threw an exception we'll pass it through to the context manager.
         // Otherwise, __exit__  is called with empty arguments (Python "None").

--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -167,7 +167,7 @@ fn foo(foo_module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 fn main() -> PyResult<()> {
     pyo3::append_to_inittab!(foo);
-    Python::with_gil(|py| Python::run_bound(py, "import foo; foo.add_one(6)", None, None))
+    Python::with_gil(|py| Python::run(py, "import foo; foo.add_one(6)", None, None))
 }
 ```
 
@@ -198,7 +198,7 @@ fn main() -> PyResult<()> {
         py_modules.set_item("foo", foo_module)?;
 
         // Now we can import + run our python code
-        Python::run_bound(py, "import foo; foo.add_one(6)", None, None)
+        Python::run(py, "import foo; foo.add_one(6)", None, None)
     })
 }
 ```

--- a/newsfragments/4435.changed.md
+++ b/newsfragments/4435.changed.md
@@ -1,0 +1,1 @@
+Reintroduced `Python::eval` and `Python::run` now take a `&CStr` instead of `&str`.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -685,7 +685,7 @@ mod tests {
     #[test]
     fn test_debug() {
         Python::with_gil(|py| {
-            let bytes = py.eval("b'abcde'", None, None).unwrap();
+            let bytes = py.eval(ffi::c_str!("b'abcde'"), None, None).unwrap();
             let buffer: PyBuffer<u8> = PyBuffer::get_bound(&bytes).unwrap();
             let expected = format!(
                 concat!(
@@ -847,7 +847,7 @@ mod tests {
     #[test]
     fn test_bytes_buffer() {
         Python::with_gil(|py| {
-            let bytes = py.eval("b'abcde'", None, None).unwrap();
+            let bytes = py.eval(ffi::c_str!("b'abcde'"), None, None).unwrap();
             let buffer = PyBuffer::get_bound(&bytes).unwrap();
             assert_eq!(buffer.dimensions(), 1);
             assert_eq!(buffer.item_count(), 5);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -685,7 +685,7 @@ mod tests {
     #[test]
     fn test_debug() {
         Python::with_gil(|py| {
-            let bytes = py.eval_bound("b'abcde'", None, None).unwrap();
+            let bytes = py.eval("b'abcde'", None, None).unwrap();
             let buffer: PyBuffer<u8> = PyBuffer::get_bound(&bytes).unwrap();
             let expected = format!(
                 concat!(
@@ -847,7 +847,7 @@ mod tests {
     #[test]
     fn test_bytes_buffer() {
         Python::with_gil(|py| {
-            let bytes = py.eval_bound("b'abcde'", None, None).unwrap();
+            let bytes = py.eval("b'abcde'", None, None).unwrap();
             let buffer = PyBuffer::get_bound(&bytes).unwrap();
             assert_eq!(buffer.dimensions(), 1);
             assert_eq!(buffer.item_count(), 5);

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -121,8 +121,8 @@ impl From<anyhow::Error> for PyErr {
 #[cfg(test)]
 mod test_anyhow {
     use crate::exceptions::{PyRuntimeError, PyValueError};
-    use crate::prelude::*;
     use crate::types::IntoPyDict;
+    use crate::{ffi, prelude::*};
 
     use anyhow::{anyhow, bail, Context, Result};
 
@@ -147,7 +147,9 @@ mod test_anyhow {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run("raise err", None, Some(&locals)).unwrap_err();
+            let pyerr = py
+                .run(ffi::c_str!("raise err"), None, Some(&locals))
+                .unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }
@@ -164,7 +166,9 @@ mod test_anyhow {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run("raise err", None, Some(&locals)).unwrap_err();
+            let pyerr = py
+                .run(ffi::c_str!("raise err"), None, Some(&locals))
+                .unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -147,7 +147,7 @@ mod test_anyhow {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
+            let pyerr = py.run("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }
@@ -164,7 +164,7 @@ mod test_anyhow {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
+            let pyerr = py.run("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1330,7 +1330,7 @@ mod tests {
 
                     let globals = [("datetime", py.import("datetime").unwrap())].into_py_dict(py);
                     let code = format!("datetime.datetime.fromtimestamp({}).replace(tzinfo=datetime.timezone(datetime.timedelta(seconds={})))", timestamp, timedelta);
-                    let t = py.eval_bound(&code, Some(&globals), None).unwrap();
+                    let t = py.eval(&code, Some(&globals), None).unwrap();
 
                     // Get ISO 8601 string from python
                     let py_iso_str = t.call_method0("isoformat").unwrap();

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -794,13 +794,14 @@ mod tests {
     // tzdata there to make this work.
     #[cfg(all(Py_3_9, not(target_os = "windows")))]
     fn test_zoneinfo_is_not_fixed_offset() {
+        use crate::ffi;
         use crate::types::any::PyAnyMethods;
         use crate::types::dict::PyDictMethods;
 
         Python::with_gil(|py| {
             let locals = crate::types::PyDict::new(py);
             py.run(
-                "import zoneinfo; zi = zoneinfo.ZoneInfo('Europe/London')",
+                ffi::c_str!("import zoneinfo; zi = zoneinfo.ZoneInfo('Europe/London')"),
                 None,
                 Some(&locals),
             )
@@ -1320,6 +1321,7 @@ mod tests {
         use crate::tests::common::CatchWarnings;
         use crate::types::IntoPyDict;
         use proptest::prelude::*;
+        use std::ffi::CString;
 
         proptest! {
 
@@ -1330,7 +1332,7 @@ mod tests {
 
                     let globals = [("datetime", py.import("datetime").unwrap())].into_py_dict(py);
                     let code = format!("datetime.datetime.fromtimestamp({}).replace(tzinfo=datetime.timezone(datetime.timedelta(seconds={})))", timestamp, timedelta);
-                    let t = py.eval(&code, Some(&globals), None).unwrap();
+                    let t = py.eval(&CString::new(code).unwrap(), Some(&globals), None).unwrap();
 
                     // Get ISO 8601 string from python
                     let py_iso_str = t.call_method0("isoformat").unwrap();

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -799,7 +799,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let locals = crate::types::PyDict::new(py);
-            py.run_bound(
+            py.run(
                 "import zoneinfo; zi = zoneinfo.ZoneInfo('Europe/London')",
                 None,
                 Some(&locals),

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -126,8 +126,8 @@ impl From<eyre::Report> for PyErr {
 #[cfg(test)]
 mod tests {
     use crate::exceptions::{PyRuntimeError, PyValueError};
-    use crate::prelude::*;
     use crate::types::IntoPyDict;
+    use crate::{ffi, prelude::*};
 
     use eyre::{bail, eyre, Report, Result, WrapErr};
 
@@ -152,7 +152,9 @@ mod tests {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run("raise err", None, Some(&locals)).unwrap_err();
+            let pyerr = py
+                .run(ffi::c_str!("raise err"), None, Some(&locals))
+                .unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }
@@ -169,7 +171,9 @@ mod tests {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run("raise err", None, Some(&locals)).unwrap_err();
+            let pyerr = py
+                .run(ffi::c_str!("raise err"), None, Some(&locals))
+                .unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -152,7 +152,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
+            let pyerr = py.run("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }
@@ -169,7 +169,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let locals = [("err", pyerr)].into_py_dict(py);
-            let pyerr = py.run_bound("raise err", None, Some(&locals)).unwrap_err();
+            let pyerr = py.run("raise err", None, Some(&locals)).unwrap_err();
             assert_eq!(pyerr.value_bound(py).to_string(), expected_contents);
         })
     }

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -460,7 +460,9 @@ mod tests {
             let index = python_index_class(py);
             let locals = PyDict::new(py);
             locals.set_item("index", index).unwrap();
-            let ob = py.eval("index.C(10)", None, Some(&locals)).unwrap();
+            let ob = py
+                .eval(ffi::c_str!("index.C(10)"), None, Some(&locals))
+                .unwrap();
             let _: BigInt = ob.extract().unwrap();
         });
     }

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -460,7 +460,7 @@ mod tests {
             let index = python_index_class(py);
             let locals = PyDict::new(py);
             locals.set_item("index", index).unwrap();
-            let ob = py.eval_bound("index.C(10)", None, Some(&locals)).unwrap();
+            let ob = py.eval("index.C(10)", None, Some(&locals)).unwrap();
             let _: BigInt = ob.extract().unwrap();
         });
     }

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -117,7 +117,7 @@ mod tests {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             py.run(
-                "import fractions\npy_frac = fractions.Fraction(-0.125)",
+                ffi::c_str!("import fractions\npy_frac = fractions.Fraction(-0.125)"),
                 None,
                 Some(&locals),
             )
@@ -133,7 +133,7 @@ mod tests {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             py.run(
-                "not_fraction = \"contains_incorrect_atts\"",
+                ffi::c_str!("not_fraction = \"contains_incorrect_atts\""),
                 None,
                 Some(&locals),
             )
@@ -148,7 +148,9 @@ mod tests {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             py.run(
-                "import fractions\npy_frac = fractions.Fraction(fractions.Fraction(10))",
+                ffi::c_str!(
+                    "import fractions\npy_frac = fractions.Fraction(fractions.Fraction(10))"
+                ),
                 None,
                 Some(&locals),
             )
@@ -165,7 +167,7 @@ mod tests {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             py.run(
-                "import fractions\n\nfrom decimal import Decimal\npy_frac = fractions.Fraction(Decimal(\"1.1\"))",
+                ffi::c_str!("import fractions\n\nfrom decimal import Decimal\npy_frac = fractions.Fraction(Decimal(\"1.1\"))"),
                 None,
                 Some(&locals),
             )
@@ -182,7 +184,7 @@ mod tests {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             py.run(
-                "import fractions\npy_frac = fractions.Fraction(10,5)",
+                ffi::c_str!("import fractions\npy_frac = fractions.Fraction(10,5)"),
                 None,
                 Some(&locals),
             )
@@ -247,7 +249,7 @@ mod tests {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             let py_bound = py.run(
-                "import fractions\npy_frac = fractions.Fraction(\"Infinity\")",
+                ffi::c_str!("import fractions\npy_frac = fractions.Fraction(\"Infinity\")"),
                 None,
                 Some(&locals),
             );

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -116,7 +116,7 @@ mod tests {
     fn test_negative_fraction() {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
-            py.run_bound(
+            py.run(
                 "import fractions\npy_frac = fractions.Fraction(-0.125)",
                 None,
                 Some(&locals),
@@ -132,7 +132,7 @@ mod tests {
     fn test_obj_with_incorrect_atts() {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
-            py.run_bound(
+            py.run(
                 "not_fraction = \"contains_incorrect_atts\"",
                 None,
                 Some(&locals),
@@ -147,7 +147,7 @@ mod tests {
     fn test_fraction_with_fraction_type() {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
-            py.run_bound(
+            py.run(
                 "import fractions\npy_frac = fractions.Fraction(fractions.Fraction(10))",
                 None,
                 Some(&locals),
@@ -164,7 +164,7 @@ mod tests {
     fn test_fraction_with_decimal() {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
-            py.run_bound(
+            py.run(
                 "import fractions\n\nfrom decimal import Decimal\npy_frac = fractions.Fraction(Decimal(\"1.1\"))",
                 None,
                 Some(&locals),
@@ -181,7 +181,7 @@ mod tests {
     fn test_fraction_with_num_den() {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
-            py.run_bound(
+            py.run(
                 "import fractions\npy_frac = fractions.Fraction(10,5)",
                 None,
                 Some(&locals),
@@ -246,7 +246,7 @@ mod tests {
     fn test_infinity() {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
-            let py_bound = py.run_bound(
+            let py_bound = py.run(
                 "import fractions\npy_frac = fractions.Fraction(\"Infinity\")",
                 None,
                 Some(&locals),

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -134,7 +134,7 @@ mod test_rust_decimal {
                     let locals = PyDict::new(py);
                     locals.set_item("rs_dec", &rs_dec).unwrap();
                     // Checks if Rust Decimal -> Python Decimal conversion is correct
-                    py.run_bound(
+                    py.run(
                         &format!(
                             "import decimal\npy_dec = decimal.Decimal({})\nassert py_dec == rs_dec",
                             $py
@@ -175,7 +175,7 @@ mod test_rust_decimal {
                 let rs_dec = num.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("rs_dec", &rs_dec).unwrap();
-                py.run_bound(
+                py.run(
                     &format!(
                        "import decimal\npy_dec = decimal.Decimal(\"{}\")\nassert py_dec == rs_dec",
                      num),
@@ -200,7 +200,7 @@ mod test_rust_decimal {
     fn test_nan() {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
-            py.run_bound(
+            py.run(
                 "import decimal\npy_dec = decimal.Decimal(\"NaN\")",
                 None,
                 Some(&locals),
@@ -216,7 +216,7 @@ mod test_rust_decimal {
     fn test_scientific_notation() {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
-            py.run_bound(
+            py.run(
                 "import decimal\npy_dec = decimal.Decimal(\"1e3\")",
                 None,
                 Some(&locals),
@@ -233,7 +233,7 @@ mod test_rust_decimal {
     fn test_infinity() {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
-            py.run_bound(
+            py.run(
                 "import decimal\npy_dec = decimal.Decimal(\"Infinity\")",
                 None,
                 Some(&locals),

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -120,7 +120,9 @@ mod test_rust_decimal {
     use super::*;
     use crate::types::dict::PyDictMethods;
     use crate::types::PyDict;
+    use std::ffi::CString;
 
+    use crate::ffi;
     #[cfg(not(target_arch = "wasm32"))]
     use proptest::prelude::*;
 
@@ -135,10 +137,11 @@ mod test_rust_decimal {
                     locals.set_item("rs_dec", &rs_dec).unwrap();
                     // Checks if Rust Decimal -> Python Decimal conversion is correct
                     py.run(
-                        &format!(
+                        &CString::new(format!(
                             "import decimal\npy_dec = decimal.Decimal({})\nassert py_dec == rs_dec",
                             $py
-                        ),
+                        ))
+                        .unwrap(),
                         None,
                         Some(&locals),
                     )
@@ -176,9 +179,9 @@ mod test_rust_decimal {
                 let locals = PyDict::new(py);
                 locals.set_item("rs_dec", &rs_dec).unwrap();
                 py.run(
-                    &format!(
+                    &CString::new(format!(
                        "import decimal\npy_dec = decimal.Decimal(\"{}\")\nassert py_dec == rs_dec",
-                     num),
+                     num)).unwrap(),
                 None, Some(&locals)).unwrap();
                 let roundtripped: Decimal = rs_dec.extract(py).unwrap();
                 assert_eq!(num, roundtripped);
@@ -201,7 +204,7 @@ mod test_rust_decimal {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             py.run(
-                "import decimal\npy_dec = decimal.Decimal(\"NaN\")",
+                ffi::c_str!("import decimal\npy_dec = decimal.Decimal(\"NaN\")"),
                 None,
                 Some(&locals),
             )
@@ -217,7 +220,7 @@ mod test_rust_decimal {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             py.run(
-                "import decimal\npy_dec = decimal.Decimal(\"1e3\")",
+                ffi::c_str!("import decimal\npy_dec = decimal.Decimal(\"1e3\")"),
                 None,
                 Some(&locals),
             )
@@ -234,7 +237,7 @@ mod test_rust_decimal {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             py.run(
-                "import decimal\npy_dec = decimal.Decimal(\"Infinity\")",
+                ffi::c_str!("import decimal\npy_dec = decimal.Decimal(\"Infinity\")"),
                 None,
                 Some(&locals),
             )

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -166,7 +166,7 @@ mod tests {
         sync::atomic::{AtomicUsize, Ordering},
     };
 
-    use crate::types::any::PyAnyMethods;
+    use crate::{ffi, types::any::PyAnyMethods};
     use crate::{types::PyList, IntoPy, PyResult, Python, ToPyObject};
 
     #[test]
@@ -195,7 +195,7 @@ mod tests {
         Python::with_gil(|py| {
             let v: [u8; 33] = py
                 .eval(
-                    "bytearray(b'abcabcabcabcabcabcabcabcabcabcabc')",
+                    ffi::c_str!("bytearray(b'abcabcabcabcabcabcabcabcabcabcabc')"),
                     None,
                     None,
                 )
@@ -210,7 +210,7 @@ mod tests {
     fn test_extract_small_bytearray_to_array() {
         Python::with_gil(|py| {
             let v: [u8; 3] = py
-                .eval("bytearray(b'abc')", None, None)
+                .eval(ffi::c_str!("bytearray(b'abc')"), None, None)
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -234,7 +234,7 @@ mod tests {
     fn test_extract_invalid_sequence_length() {
         Python::with_gil(|py| {
             let v: PyResult<[u8; 3]> = py
-                .eval("bytearray(b'abcdefg')", None, None)
+                .eval(ffi::c_str!("bytearray(b'abcdefg')"), None, None)
                 .unwrap()
                 .extract();
             assert_eq!(
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn test_extract_non_iterable_to_array() {
         Python::with_gil(|py| {
-            let v = py.eval("42", None, None).unwrap();
+            let v = py.eval(ffi::c_str!("42"), None, None).unwrap();
             v.extract::<i32>().unwrap();
             v.extract::<[i32; 1]>().unwrap_err();
         });

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -194,7 +194,7 @@ mod tests {
     fn test_extract_bytearray_to_array() {
         Python::with_gil(|py| {
             let v: [u8; 33] = py
-                .eval_bound(
+                .eval(
                     "bytearray(b'abcabcabcabcabcabcabcabcabcabcabc')",
                     None,
                     None,
@@ -210,7 +210,7 @@ mod tests {
     fn test_extract_small_bytearray_to_array() {
         Python::with_gil(|py| {
             let v: [u8; 3] = py
-                .eval_bound("bytearray(b'abc')", None, None)
+                .eval("bytearray(b'abc')", None, None)
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -234,7 +234,7 @@ mod tests {
     fn test_extract_invalid_sequence_length() {
         Python::with_gil(|py| {
             let v: PyResult<[u8; 3]> = py
-                .eval_bound("bytearray(b'abcdefg')", None, None)
+                .eval("bytearray(b'abcdefg')", None, None)
                 .unwrap()
                 .extract();
             assert_eq!(
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn test_extract_non_iterable_to_array() {
         Python::with_gil(|py| {
-            let v = py.eval_bound("42", None, None).unwrap();
+            let v = py.eval("42", None, None).unwrap();
             v.extract::<i32>().unwrap();
             v.extract::<[i32; 1]>().unwrap_err();
         });

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -567,7 +567,7 @@ mod test_128bit_integers {
     #[test]
     fn test_i128_overflow() {
         Python::with_gil(|py| {
-            let obj = py.eval_bound("(1 << 130) * -1", None, None).unwrap();
+            let obj = py.eval("(1 << 130) * -1", None, None).unwrap();
             let err = obj.extract::<i128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
@@ -576,7 +576,7 @@ mod test_128bit_integers {
     #[test]
     fn test_u128_overflow() {
         Python::with_gil(|py| {
-            let obj = py.eval_bound("1 << 130", None, None).unwrap();
+            let obj = py.eval("1 << 130", None, None).unwrap();
             let err = obj.extract::<u128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
@@ -620,7 +620,7 @@ mod test_128bit_integers {
     #[test]
     fn test_nonzero_i128_overflow() {
         Python::with_gil(|py| {
-            let obj = py.eval_bound("(1 << 130) * -1", None, None).unwrap();
+            let obj = py.eval("(1 << 130) * -1", None, None).unwrap();
             let err = obj.extract::<NonZeroI128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
@@ -629,7 +629,7 @@ mod test_128bit_integers {
     #[test]
     fn test_nonzero_u128_overflow() {
         Python::with_gil(|py| {
-            let obj = py.eval_bound("1 << 130", None, None).unwrap();
+            let obj = py.eval("1 << 130", None, None).unwrap();
             let err = obj.extract::<NonZeroU128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
@@ -638,7 +638,7 @@ mod test_128bit_integers {
     #[test]
     fn test_nonzero_i128_zero_value() {
         Python::with_gil(|py| {
-            let obj = py.eval_bound("0", None, None).unwrap();
+            let obj = py.eval("0", None, None).unwrap();
             let err = obj.extract::<NonZeroI128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyValueError>(py));
         })
@@ -647,7 +647,7 @@ mod test_128bit_integers {
     #[test]
     fn test_nonzero_u128_zero_value() {
         Python::with_gil(|py| {
-            let obj = py.eval_bound("0", None, None).unwrap();
+            let obj = py.eval("0", None, None).unwrap();
             let err = obj.extract::<NonZeroU128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyValueError>(py));
         })

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -471,6 +471,9 @@ mod test_128bit_integers {
     use proptest::prelude::*;
 
     #[cfg(not(target_arch = "wasm32"))]
+    use std::ffi::CString;
+
+    #[cfg(not(target_arch = "wasm32"))]
     proptest! {
         #[test]
         fn test_i128_roundtrip(x: i128) {
@@ -478,7 +481,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
+                py.run(&CString::new(format!("assert x_py == {}", x)).unwrap(), None, Some(&locals)).unwrap();
                 let roundtripped: i128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -494,7 +497,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
+                py.run(&CString::new(format!("assert x_py == {}", x)).unwrap(), None, Some(&locals)).unwrap();
                 let roundtripped: NonZeroI128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -509,7 +512,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
+                py.run(&CString::new(format!("assert x_py == {}", x)).unwrap(), None, Some(&locals)).unwrap();
                 let roundtripped: u128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -525,7 +528,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
+                py.run(&CString::new(format!("assert x_py == {}", x)).unwrap(), None, Some(&locals)).unwrap();
                 let roundtripped: NonZeroU128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -567,7 +570,7 @@ mod test_128bit_integers {
     #[test]
     fn test_i128_overflow() {
         Python::with_gil(|py| {
-            let obj = py.eval("(1 << 130) * -1", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("(1 << 130) * -1"), None, None).unwrap();
             let err = obj.extract::<i128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
@@ -576,7 +579,7 @@ mod test_128bit_integers {
     #[test]
     fn test_u128_overflow() {
         Python::with_gil(|py| {
-            let obj = py.eval("1 << 130", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("1 << 130"), None, None).unwrap();
             let err = obj.extract::<u128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
@@ -620,7 +623,7 @@ mod test_128bit_integers {
     #[test]
     fn test_nonzero_i128_overflow() {
         Python::with_gil(|py| {
-            let obj = py.eval("(1 << 130) * -1", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("(1 << 130) * -1"), None, None).unwrap();
             let err = obj.extract::<NonZeroI128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
@@ -629,7 +632,7 @@ mod test_128bit_integers {
     #[test]
     fn test_nonzero_u128_overflow() {
         Python::with_gil(|py| {
-            let obj = py.eval("1 << 130", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("1 << 130"), None, None).unwrap();
             let err = obj.extract::<NonZeroU128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
         })
@@ -638,7 +641,7 @@ mod test_128bit_integers {
     #[test]
     fn test_nonzero_i128_zero_value() {
         Python::with_gil(|py| {
-            let obj = py.eval("0", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("0"), None, None).unwrap();
             let err = obj.extract::<NonZeroI128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyValueError>(py));
         })
@@ -647,7 +650,7 @@ mod test_128bit_integers {
     #[test]
     fn test_nonzero_u128_zero_value() {
         Python::with_gil(|py| {
-            let obj = py.eval("0", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("0"), None, None).unwrap();
             let err = obj.extract::<NonZeroU128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyValueError>(py));
         })

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -478,7 +478,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run_bound(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
                 let roundtripped: i128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -494,7 +494,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run_bound(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
                 let roundtripped: NonZeroI128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -509,7 +509,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run_bound(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
                 let roundtripped: u128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })
@@ -525,7 +525,7 @@ mod test_128bit_integers {
                 let x_py = x.into_py(py);
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", x_py.clone_ref(py)).unwrap();
-                py.run_bound(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
+                py.run(&format!("assert x_py == {}", x), None, Some(&locals)).unwrap();
                 let roundtripped: NonZeroU128 = x_py.extract(py).unwrap();
                 assert_eq!(x, roundtripped);
             })

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -95,7 +95,7 @@ mod tests {
     #[test]
     fn test_extract_bytes() {
         Python::with_gil(|py| {
-            let py_bytes = py.eval_bound("b'Hello Python'", None, None).unwrap();
+            let py_bytes = py.eval("b'Hello Python'", None, None).unwrap();
             let bytes: &[u8] = py_bytes.extract().unwrap();
             assert_eq!(bytes, b"Hello Python");
         });
@@ -104,17 +104,15 @@ mod tests {
     #[test]
     fn test_cow_impl() {
         Python::with_gil(|py| {
-            let bytes = py.eval_bound(r#"b"foobar""#, None, None).unwrap();
+            let bytes = py.eval(r#"b"foobar""#, None, None).unwrap();
             let cow = bytes.extract::<Cow<'_, [u8]>>().unwrap();
             assert_eq!(cow, Cow::<[u8]>::Borrowed(b"foobar"));
 
-            let byte_array = py
-                .eval_bound(r#"bytearray(b"foobar")"#, None, None)
-                .unwrap();
+            let byte_array = py.eval(r#"bytearray(b"foobar")"#, None, None).unwrap();
             let cow = byte_array.extract::<Cow<'_, [u8]>>().unwrap();
             assert_eq!(cow, Cow::<[u8]>::Owned(b"foobar".to_vec()));
 
-            let something_else_entirely = py.eval_bound("42", None, None).unwrap();
+            let something_else_entirely = py.eval("42", None, None).unwrap();
             something_else_entirely
                 .extract::<Cow<'_, [u8]>>()
                 .unwrap_err();

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -88,6 +88,7 @@ mod tests {
     use std::borrow::Cow;
 
     use crate::{
+        ffi,
         types::{any::PyAnyMethods, PyBytes},
         Python, ToPyObject,
     };
@@ -95,7 +96,7 @@ mod tests {
     #[test]
     fn test_extract_bytes() {
         Python::with_gil(|py| {
-            let py_bytes = py.eval("b'Hello Python'", None, None).unwrap();
+            let py_bytes = py.eval(ffi::c_str!("b'Hello Python'"), None, None).unwrap();
             let bytes: &[u8] = py_bytes.extract().unwrap();
             assert_eq!(bytes, b"Hello Python");
         });
@@ -104,15 +105,17 @@ mod tests {
     #[test]
     fn test_cow_impl() {
         Python::with_gil(|py| {
-            let bytes = py.eval(r#"b"foobar""#, None, None).unwrap();
+            let bytes = py.eval(ffi::c_str!(r#"b"foobar""#), None, None).unwrap();
             let cow = bytes.extract::<Cow<'_, [u8]>>().unwrap();
             assert_eq!(cow, Cow::<[u8]>::Borrowed(b"foobar"));
 
-            let byte_array = py.eval(r#"bytearray(b"foobar")"#, None, None).unwrap();
+            let byte_array = py
+                .eval(ffi::c_str!(r#"bytearray(b"foobar")"#), None, None)
+                .unwrap();
             let cow = byte_array.extract::<Cow<'_, [u8]>>().unwrap();
             assert_eq!(cow, Cow::<[u8]>::Owned(b"foobar".to_vec()));
 
-            let something_else_entirely = py.eval("42", None, None).unwrap();
+            let something_else_entirely = py.eval(ffi::c_str!("42"), None, None).unwrap();
             something_else_entirely
                 .extract::<Cow<'_, [u8]>>()
                 .unwrap_err();

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -929,7 +929,7 @@ impl_signed_integer!(isize);
 mod tests {
     use super::PyErrState;
     use crate::exceptions::{self, PyTypeError, PyValueError};
-    use crate::{PyErr, PyTypeInfo, Python};
+    use crate::{ffi, PyErr, PyTypeInfo, Python};
 
     #[test]
     fn no_error() {
@@ -1020,7 +1020,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let err = py
-                .run("raise Exception('banana')", None, None)
+                .run(ffi::c_str!("raise Exception('banana')"), None, None)
                 .expect_err("raising should have given us an error");
 
             let debug_str = format!("{:?}", err);
@@ -1045,7 +1045,7 @@ mod tests {
     fn err_display() {
         Python::with_gil(|py| {
             let err = py
-                .run("raise Exception('banana')", None, None)
+                .run(ffi::c_str!("raise Exception('banana')"), None, None)
                 .expect_err("raising should have given us an error");
             assert_eq!(err.to_string(), "Exception: banana");
         });
@@ -1090,13 +1090,13 @@ mod tests {
     fn test_pyerr_cause() {
         Python::with_gil(|py| {
             let err = py
-                .run("raise Exception('banana')", None, None)
+                .run(ffi::c_str!("raise Exception('banana')"), None, None)
                 .expect_err("raising should have given us an error");
             assert!(err.cause(py).is_none());
 
             let err = py
                 .run(
-                    "raise Exception('banana') from Exception('apple')",
+                    ffi::c_str!("raise Exception('banana') from Exception('apple')"),
                     None,
                     None,
                 )

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1020,7 +1020,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let err = py
-                .run_bound("raise Exception('banana')", None, None)
+                .run("raise Exception('banana')", None, None)
                 .expect_err("raising should have given us an error");
 
             let debug_str = format!("{:?}", err);
@@ -1045,7 +1045,7 @@ mod tests {
     fn err_display() {
         Python::with_gil(|py| {
             let err = py
-                .run_bound("raise Exception('banana')", None, None)
+                .run("raise Exception('banana')", None, None)
                 .expect_err("raising should have given us an error");
             assert_eq!(err.to_string(), "Exception: banana");
         });
@@ -1090,12 +1090,12 @@ mod tests {
     fn test_pyerr_cause() {
         Python::with_gil(|py| {
             let err = py
-                .run_bound("raise Exception('banana')", None, None)
+                .run("raise Exception('banana')", None, None)
                 .expect_err("raising should have given us an error");
             assert!(err.cause(py).is_none());
 
             let err = py
-                .run_bound(
+                .run(
                     "raise Exception('banana') from Exception('apple')",
                     None,
                     None,

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -179,7 +179,7 @@ macro_rules! import_exception_bound {
 /// #         locals.set_item("MyError", py.get_type::<MyError>())?;
 /// #         locals.set_item("raise_myerror", fun)?;
 /// #
-/// #         py.run_bound(
+/// #         py.run(
 /// # "try:
 /// #     raise_myerror()
 /// # except MyError as e:
@@ -348,7 +348,7 @@ use pyo3::prelude::*;
 use pyo3::exceptions::Py", $name, ";
 
 Python::with_gil(|py| {
-    let result: PyResult<()> = py.run_bound(\"raise ", $name, "\", None, None);
+    let result: PyResult<()> = py.run(\"raise ", $name, "\", None, None);
 
     let error_type = match result {
         Ok(_) => \"Not an error\",
@@ -835,7 +835,7 @@ mod tests {
                 .map_err(|e| e.display(py))
                 .expect("could not setitem");
 
-            py.run_bound("assert isinstance(exc, socket.gaierror)", None, Some(&d))
+            py.run("assert isinstance(exc, socket.gaierror)", None, Some(&d))
                 .map_err(|e| e.display(py))
                 .expect("assertion failed");
         });
@@ -858,7 +858,7 @@ mod tests {
                 .map_err(|e| e.display(py))
                 .expect("could not setitem");
 
-            py.run_bound(
+            py.run(
                 "assert isinstance(exc, email.errors.MessageError)",
                 None,
                 Some(&d),
@@ -881,13 +881,13 @@ mod tests {
                 .extract()
                 .unwrap();
             assert_eq!(type_description, "<class 'mymodule.CustomError'>");
-            py.run_bound(
+            py.run(
                 "assert CustomError('oops').args == ('oops',)",
                 None,
                 Some(&ctx),
             )
             .unwrap();
-            py.run_bound("assert CustomError.__doc__ is None", None, Some(&ctx))
+            py.run("assert CustomError.__doc__ is None", None, Some(&ctx))
                 .unwrap();
         });
     }
@@ -923,13 +923,13 @@ mod tests {
                 .extract()
                 .unwrap();
             assert_eq!(type_description, "<class 'mymodule.CustomError'>");
-            py.run_bound(
+            py.run(
                 "assert CustomError('oops').args == ('oops',)",
                 None,
                 Some(&ctx),
             )
             .unwrap();
-            py.run_bound(
+            py.run(
                 "assert CustomError.__doc__ == 'Some docs'",
                 None,
                 Some(&ctx),
@@ -956,13 +956,13 @@ mod tests {
                 .extract()
                 .unwrap();
             assert_eq!(type_description, "<class 'mymodule.CustomError'>");
-            py.run_bound(
+            py.run(
                 "assert CustomError('oops').args == ('oops',)",
                 None,
                 Some(&ctx),
             )
             .unwrap();
-            py.run_bound(
+            py.run(
                 "assert CustomError.__doc__ == 'Some more docs'",
                 None,
                 Some(&ctx),
@@ -975,7 +975,7 @@ mod tests {
     fn native_exception_debug() {
         Python::with_gil(|py| {
             let exc = py
-                .run_bound("raise Exception('banana')", None, None)
+                .run("raise Exception('banana')", None, None)
                 .expect_err("raising should have given us an error")
                 .into_value(py)
                 .into_bound(py);
@@ -990,7 +990,7 @@ mod tests {
     fn native_exception_display() {
         Python::with_gil(|py| {
             let exc = py
-                .run_bound("raise Exception('banana')", None, None)
+                .run("raise Exception('banana')", None, None)
                 .expect_err("raising should have given us an error")
                 .into_value(py)
                 .into_bound(py);

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -876,7 +876,7 @@ mod tests {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
-                .eval_bound("str(CustomError)", None, Some(&ctx))
+                .eval("str(CustomError)", None, Some(&ctx))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -899,7 +899,7 @@ mod tests {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
-                .eval_bound("str(CustomError)", None, Some(&ctx))
+                .eval("str(CustomError)", None, Some(&ctx))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -918,7 +918,7 @@ mod tests {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
-                .eval_bound("str(CustomError)", None, Some(&ctx))
+                .eval("str(CustomError)", None, Some(&ctx))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -951,7 +951,7 @@ mod tests {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py);
             let type_description: String = py
-                .eval_bound("str(CustomError)", None, Some(&ctx))
+                .eval("str(CustomError)", None, Some(&ctx))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -1070,7 +1070,7 @@ mod tests {
         )
     });
     test_exception!(PyUnicodeEncodeError, |py| py
-        .eval_bound("chr(40960).encode('ascii')", None, None)
+        .eval("chr(40960).encode('ascii')", None, None)
         .unwrap_err());
     test_exception!(PyUnicodeTranslateError, |_| {
         PyUnicodeTranslateError::new_err(("\u{3042}", 0, 1, "ouch"))

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -1,4 +1,4 @@
-use crate::ffi::*;
+use crate::ffi::{self, *};
 use crate::types::any::PyAnyMethods;
 use crate::Python;
 
@@ -23,7 +23,7 @@ fn test_datetime_fromtimestamp() {
         let locals = PyDict::new(py);
         locals.set_item("dt", dt).unwrap();
         py.run(
-            "import datetime; assert dt == datetime.datetime.fromtimestamp(100)",
+            ffi::c_str!("import datetime; assert dt == datetime.datetime.fromtimestamp(100)"),
             None,
             Some(&locals),
         )
@@ -44,7 +44,7 @@ fn test_date_fromtimestamp() {
         let locals = PyDict::new(py);
         locals.set_item("dt", dt).unwrap();
         py.run(
-            "import datetime; assert dt == datetime.date.fromtimestamp(100)",
+            ffi::c_str!("import datetime; assert dt == datetime.date.fromtimestamp(100)"),
             None,
             Some(&locals),
         )
@@ -64,7 +64,7 @@ fn test_utc_timezone() {
         let locals = PyDict::new(py);
         locals.set_item("utc_timezone", utc_timezone).unwrap();
         py.run(
-            "import datetime; assert utc_timezone is datetime.timezone.utc",
+            ffi::c_str!("import datetime; assert utc_timezone is datetime.timezone.utc"),
             None,
             Some(&locals),
         )
@@ -287,7 +287,7 @@ fn test_get_tzinfo() {
 #[test]
 fn test_inc_dec_ref() {
     Python::with_gil(|py| {
-        let obj = py.eval("object()", None, None).unwrap();
+        let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
 
         let ref_count = obj.get_refcnt();
         let ptr = obj.as_ptr();

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -22,7 +22,7 @@ fn test_datetime_fromtimestamp() {
         };
         let locals = PyDict::new(py);
         locals.set_item("dt", dt).unwrap();
-        py.run_bound(
+        py.run(
             "import datetime; assert dt == datetime.datetime.fromtimestamp(100)",
             None,
             Some(&locals),
@@ -43,7 +43,7 @@ fn test_date_fromtimestamp() {
         };
         let locals = PyDict::new(py);
         locals.set_item("dt", dt).unwrap();
-        py.run_bound(
+        py.run(
             "import datetime; assert dt == datetime.date.fromtimestamp(100)",
             None,
             Some(&locals),
@@ -63,7 +63,7 @@ fn test_utc_timezone() {
         };
         let locals = PyDict::new(py);
         locals.set_item("utc_timezone", utc_timezone).unwrap();
-        py.run_bound(
+        py.run(
             "import datetime; assert utc_timezone is datetime.timezone.utc",
             None,
             Some(&locals),

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -287,7 +287,7 @@ fn test_get_tzinfo() {
 #[test]
 fn test_inc_dec_ref() {
     Python::with_gil(|py| {
-        let obj = py.eval_bound("object()", None, None).unwrap();
+        let obj = py.eval("object()", None, None).unwrap();
 
         let ref_count = obj.get_refcnt();
         let ptr = obj.as_ptr();

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -55,7 +55,7 @@ fn gil_is_acquired() -> bool {
 ///
 /// # fn main() -> PyResult<()> {
 /// pyo3::prepare_freethreaded_python();
-/// Python::with_gil(|py| py.run_bound("print('Hello World')", None, None))
+/// Python::with_gil(|py| py.run("print('Hello World')", None, None))
 /// # }
 /// ```
 #[cfg(not(any(PyPy, GraalPy)))]
@@ -98,7 +98,7 @@ pub fn prepare_freethreaded_python() {
 /// ```rust
 /// unsafe {
 ///     pyo3::with_embedded_python_interpreter(|py| {
-///         if let Err(e) = py.run_bound("print('Hello World')", None, None) {
+///         if let Err(e) = py.run("print('Hello World')", None, None) {
 ///             // We must make sure to not return a `PyErr`!
 ///             e.print(py);
 ///         }

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -433,7 +433,7 @@ mod tests {
     use std::ptr::NonNull;
 
     fn get_object(py: Python<'_>) -> PyObject {
-        py.eval_bound("object()", None, None).unwrap().unbind()
+        py.eval("object()", None, None).unwrap().unbind()
     }
 
     #[cfg(not(pyo3_disable_reference_pool))]
@@ -571,7 +571,7 @@ mod tests {
     fn dropping_gil_does_not_invalidate_references() {
         // Acquiring GIL for the second time should be safe - see #864
         Python::with_gil(|py| {
-            let obj = Python::with_gil(|_| py.eval_bound("object()", None, None).unwrap());
+            let obj = Python::with_gil(|_| py.eval("object()", None, None).unwrap());
 
             // After gil2 drops, obj should still have a reference count of one
             assert_eq!(obj.get_refcnt(), 1);

--- a/src/gil.rs
+++ b/src/gil.rs
@@ -55,7 +55,7 @@ fn gil_is_acquired() -> bool {
 ///
 /// # fn main() -> PyResult<()> {
 /// pyo3::prepare_freethreaded_python();
-/// Python::with_gil(|py| py.run("print('Hello World')", None, None))
+/// Python::with_gil(|py| py.run(pyo3::ffi::c_str!("print('Hello World')"), None, None))
 /// # }
 /// ```
 #[cfg(not(any(PyPy, GraalPy)))]
@@ -98,7 +98,7 @@ pub fn prepare_freethreaded_python() {
 /// ```rust
 /// unsafe {
 ///     pyo3::with_embedded_python_interpreter(|py| {
-///         if let Err(e) = py.run("print('Hello World')", None, None) {
+///         if let Err(e) = py.run(pyo3::ffi::c_str!("print('Hello World')"), None, None) {
 ///             // We must make sure to not return a `PyErr`!
 ///             e.print(py);
 ///         }
@@ -428,12 +428,14 @@ mod tests {
     use super::GIL_COUNT;
     #[cfg(not(pyo3_disable_reference_pool))]
     use super::{gil_is_acquired, POOL};
+    use crate::{ffi, PyObject, Python};
     use crate::{gil::GILGuard, types::any::PyAnyMethods};
-    use crate::{PyObject, Python};
     use std::ptr::NonNull;
 
     fn get_object(py: Python<'_>) -> PyObject {
-        py.eval("object()", None, None).unwrap().unbind()
+        py.eval(ffi::c_str!("object()"), None, None)
+            .unwrap()
+            .unbind()
     }
 
     #[cfg(not(pyo3_disable_reference_pool))]
@@ -571,7 +573,7 @@ mod tests {
     fn dropping_gil_does_not_invalidate_references() {
         // Acquiring GIL for the second time should be safe - see #864
         Python::with_gil(|py| {
-            let obj = Python::with_gil(|_| py.eval("object()", None, None).unwrap());
+            let obj = Python::with_gil(|_| py.eval(ffi::c_str!("object()"), None, None).unwrap());
 
             // After gil2 drops, obj should still have a reference count of one
             assert_eq!(obj.get_refcnt(), 1);

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2020,7 +2020,7 @@ a = A()
     #[test]
     fn invalid_attr() -> PyResult<()> {
         Python::with_gil(|py| {
-            let instance: Py<PyAny> = py.eval_bound("object()", None, None)?.into();
+            let instance: Py<PyAny> = py.eval("object()", None, None)?.into();
 
             instance.getattr(py, "foo").unwrap_err();
 
@@ -2033,7 +2033,7 @@ a = A()
     #[test]
     fn test_py2_from_py_object() {
         Python::with_gil(|py| {
-            let instance = py.eval_bound("object()", None, None).unwrap();
+            let instance = py.eval("object()", None, None).unwrap();
             let ptr = instance.as_ptr();
             let instance: Bound<'_, PyAny> = instance.extract().unwrap();
             assert_eq!(instance.as_ptr(), ptr);
@@ -2044,7 +2044,7 @@ a = A()
     fn test_py2_into_py_object() {
         Python::with_gil(|py| {
             let instance = py
-                .eval_bound("object()", None, None)
+                .eval("object()", None, None)
                 .unwrap()
                 .as_borrowed()
                 .to_owned();

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2020,7 +2020,7 @@ a = A()
     #[test]
     fn invalid_attr() -> PyResult<()> {
         Python::with_gil(|py| {
-            let instance: Py<PyAny> = py.eval("object()", None, None)?.into();
+            let instance: Py<PyAny> = py.eval(ffi::c_str!("object()"), None, None)?.into();
 
             instance.getattr(py, "foo").unwrap_err();
 
@@ -2033,7 +2033,7 @@ a = A()
     #[test]
     fn test_py2_from_py_object() {
         Python::with_gil(|py| {
-            let instance = py.eval("object()", None, None).unwrap();
+            let instance = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             let ptr = instance.as_ptr();
             let instance: Bound<'_, PyAny> = instance.extract().unwrap();
             assert_eq!(instance.as_ptr(), ptr);
@@ -2044,7 +2044,7 @@ a = A()
     fn test_py2_into_py_object() {
         Python::with_gil(|py| {
             let instance = py
-                .eval("object()", None, None)
+                .eval(ffi::c_str!("object()"), None, None)
                 .unwrap()
                 .as_borrowed()
                 .to_owned();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,7 @@
 //! ```rust
 //! use pyo3::prelude::*;
 //! use pyo3::types::IntoPyDict;
+//! use pyo3::ffi::c_str;
 //!
 //! fn main() -> PyResult<()> {
 //!     Python::with_gil(|py| {
@@ -239,7 +240,7 @@
 //!         let version: String = sys.getattr("version")?.extract()?;
 //!
 //!         let locals = [("os", py.import("os")?)].into_py_dict(py);
-//!         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
+//!         let code = c_str!("os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'");
 //!         let user: String = py.eval(code, None, Some(&locals))?.extract()?;
 //!
 //!         println!("Hello {}, I'm Python {}", user, version);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,7 @@
 //!
 //!         let locals = [("os", py.import("os")?)].into_py_dict(py);
 //!         let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
-//!         let user: String = py.eval_bound(code, None, Some(&locals))?.extract()?;
+//!         let user: String = py.eval(code, None, Some(&locals))?.extract()?;
 //!
 //!         println!("Hello {}, I'm Python {}", user, version);
 //!         Ok(())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -83,13 +83,13 @@ macro_rules! py_run {
         $crate::py_run_impl!($py, $($val)+, $crate::indoc::indoc!($code))
     }};
     ($py:expr, $($val:ident)+, $code:expr) => {{
-        $crate::py_run_impl!($py, $($val)+, &$crate::unindent::unindent($code))
+        $crate::py_run_impl!($py, $($val)+, $crate::unindent::unindent($code))
     }};
     ($py:expr, *$dict:expr, $code:literal) => {{
         $crate::py_run_impl!($py, *$dict, $crate::indoc::indoc!($code))
     }};
     ($py:expr, *$dict:expr, $code:expr) => {{
-        $crate::py_run_impl!($py, *$dict, &$crate::unindent::unindent($code))
+        $crate::py_run_impl!($py, *$dict, $crate::unindent::unindent($code))
     }};
 }
 
@@ -105,12 +105,12 @@ macro_rules! py_run_impl {
     ($py:expr, *$dict:expr, $code:expr) => {{
         use ::std::option::Option::*;
         #[allow(unused_imports)]
-        if let ::std::result::Result::Err(e) = $py.run($code, None, Some(&$dict)) {
+        if let ::std::result::Result::Err(e) = $py.run(&::std::ffi::CString::new($code).unwrap(), None, Some(&$dict)) {
             e.print($py);
             // So when this c api function the last line called printed the error to stderr,
             // the output is only written into a buffer which is never flushed because we
             // panic before flushing. This is where this hack comes into place
-            $py.run("import sys; sys.stderr.flush()", None, None)
+            $py.run($crate::ffi::c_str!("import sys; sys.stderr.flush()"), None, None)
                 .unwrap();
             ::std::panic!("{}", $code)
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -105,12 +105,12 @@ macro_rules! py_run_impl {
     ($py:expr, *$dict:expr, $code:expr) => {{
         use ::std::option::Option::*;
         #[allow(unused_imports)]
-        if let ::std::result::Result::Err(e) = $py.run_bound($code, None, Some(&$dict)) {
+        if let ::std::result::Result::Err(e) = $py.run($code, None, Some(&$dict)) {
             e.print($py);
             // So when this c api function the last line called printed the error to stderr,
             // the output is only written into a buffer which is never flushed because we
             // panic before flushing. This is where this hack comes into place
-            $py.run_bound("import sys; sys.stderr.flush()", None, None)
+            $py.run("import sys; sys.stderr.flush()", None, None)
                 .unwrap();
             ::std::panic!("{}", $code)
         }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -387,7 +387,7 @@ impl Python<'_> {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let x: i32 = py.eval_bound("5", None, None)?.extract()?;
+    ///     let x: i32 = py.eval("5", None, None)?.extract()?;
     ///     assert_eq!(x, 5);
     ///     Ok(())
     /// })
@@ -528,18 +528,31 @@ impl<'py> Python<'py> {
     /// ```
     /// # use pyo3::prelude::*;
     /// # Python::with_gil(|py| {
-    /// let result = py.eval_bound("[i * 10 for i in range(5)]", None, None).unwrap();
+    /// let result = py.eval("[i * 10 for i in range(5)]", None, None).unwrap();
     /// let res: Vec<i64> = result.extract().unwrap();
     /// assert_eq!(res, vec![0, 10, 20, 30, 40])
     /// # });
     /// ```
-    pub fn eval_bound(
+    pub fn eval(
         self,
         code: &str,
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         self.run_code(code, ffi::Py_eval_input, globals, locals)
+    }
+
+    /// Deprecated name for [`Python::eval`].
+    #[deprecated(since = "0.23.0", note = "renamed to `Python::eval`")]
+    #[track_caller]
+    #[inline]
+    pub fn eval_bound(
+        self,
+        code: &str,
+        globals: Option<&Bound<'py, PyDict>>,
+        locals: Option<&Bound<'py, PyDict>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.eval(code, globals, locals)
     }
 
     /// Executes one or more Python statements in the given context.
@@ -830,7 +843,7 @@ mod tests {
         Python::with_gil(|py| {
             // Make sure builtin names are accessible
             let v: i32 = py
-                .eval_bound("min(1, 2)", None, None)
+                .eval("min(1, 2)", None, None)
                 .map_err(|e| e.display(py))
                 .unwrap()
                 .extract()
@@ -841,7 +854,7 @@ mod tests {
 
             // Inject our own global namespace
             let v: i32 = py
-                .eval_bound("foo + 29", Some(&d), None)
+                .eval("foo + 29", Some(&d), None)
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -849,7 +862,7 @@ mod tests {
 
             // Inject our own local namespace
             let v: i32 = py
-                .eval_bound("foo + 29", None, Some(&d))
+                .eval("foo + 29", None, Some(&d))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -857,7 +870,7 @@ mod tests {
 
             // Make sure builtin names are still accessible when using a local namespace
             let v: i32 = py
-                .eval_bound("min(foo, 2)", None, Some(&d))
+                .eval("min(foo, 2)", None, Some(&d))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -952,7 +965,7 @@ mod tests {
             assert_eq!(py.Ellipsis().to_string(), "Ellipsis");
 
             let v = py
-                .eval_bound("...", None, None)
+                .eval("...", None, None)
                 .map_err(|e| e.display(py))
                 .unwrap();
 

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -384,10 +384,11 @@ impl Python<'_> {
     ///
     /// ```
     /// use pyo3::prelude::*;
+    /// use pyo3::ffi::c_str;
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let x: i32 = py.eval("5", None, None)?.extract()?;
+    ///     let x: i32 = py.eval(c_str!("5"), None, None)?.extract()?;
     ///     assert_eq!(x, 5);
     ///     Ok(())
     /// })
@@ -527,15 +528,16 @@ impl<'py> Python<'py> {
     ///
     /// ```
     /// # use pyo3::prelude::*;
+    /// # use pyo3::ffi::c_str;
     /// # Python::with_gil(|py| {
-    /// let result = py.eval("[i * 10 for i in range(5)]", None, None).unwrap();
+    /// let result = py.eval(c_str!("[i * 10 for i in range(5)]"), None, None).unwrap();
     /// let res: Vec<i64> = result.extract().unwrap();
     /// assert_eq!(res, vec![0, 10, 20, 30, 40])
     /// # });
     /// ```
     pub fn eval(
         self,
-        code: &str,
+        code: &CStr,
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
@@ -552,7 +554,8 @@ impl<'py> Python<'py> {
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.eval(code, globals, locals)
+        let code = CString::new(code)?;
+        self.eval(&code, globals, locals)
     }
 
     /// Executes one or more Python statements in the given context.
@@ -568,15 +571,16 @@ impl<'py> Python<'py> {
     /// use pyo3::{
     ///     prelude::*,
     ///     types::{PyBytes, PyDict},
+    ///     ffi::c_str,
     /// };
     /// Python::with_gil(|py| {
     ///     let locals = PyDict::new(py);
-    ///     py.run(
+    ///     py.run(c_str!(
     ///         r#"
     /// import base64
     /// s = 'Hello Rust!'
     /// ret = base64.b64encode(s.encode('utf-8'))
-    /// "#,
+    /// "#),
     ///         None,
     ///         Some(&locals),
     ///     )
@@ -591,7 +595,7 @@ impl<'py> Python<'py> {
     /// if you don't need `globals` and unwrapping is OK.
     pub fn run(
         self,
-        code: &str,
+        code: &CStr,
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<()> {
@@ -611,7 +615,8 @@ impl<'py> Python<'py> {
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<()> {
-        self.run(code, globals, locals)
+        let code = CString::new(code)?;
+        self.run(&code, globals, locals)
     }
 
     /// Runs code in the given context.
@@ -623,12 +628,11 @@ impl<'py> Python<'py> {
     /// If `locals` is `None`, it defaults to the value of `globals`.
     fn run_code(
         self,
-        code: &str,
+        code: &CStr,
         start: c_int,
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let code = CString::new(code)?;
         unsafe {
             let mptr = ffi::PyImport_AddModule(ffi::c_str!("__main__").as_ptr());
             if mptr.is_null() {
@@ -856,7 +860,7 @@ mod tests {
         Python::with_gil(|py| {
             // Make sure builtin names are accessible
             let v: i32 = py
-                .eval("min(1, 2)", None, None)
+                .eval(ffi::c_str!("min(1, 2)"), None, None)
                 .map_err(|e| e.display(py))
                 .unwrap()
                 .extract()
@@ -867,7 +871,7 @@ mod tests {
 
             // Inject our own global namespace
             let v: i32 = py
-                .eval("foo + 29", Some(&d), None)
+                .eval(ffi::c_str!("foo + 29"), Some(&d), None)
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -875,7 +879,7 @@ mod tests {
 
             // Inject our own local namespace
             let v: i32 = py
-                .eval("foo + 29", None, Some(&d))
+                .eval(ffi::c_str!("foo + 29"), None, Some(&d))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -883,7 +887,7 @@ mod tests {
 
             // Make sure builtin names are still accessible when using a local namespace
             let v: i32 = py
-                .eval("min(foo, 2)", None, Some(&d))
+                .eval(ffi::c_str!("min(foo, 2)"), None, Some(&d))
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -978,7 +982,7 @@ mod tests {
             assert_eq!(py.Ellipsis().to_string(), "Ellipsis");
 
             let v = py
-                .eval("...", None, None)
+                .eval(ffi::c_str!("..."), None, None)
                 .map_err(|e| e.display(py))
                 .unwrap();
 
@@ -992,8 +996,12 @@ mod tests {
 
         Python::with_gil(|py| {
             let namespace = PyDict::new(py);
-            py.run("class Foo: pass", Some(&namespace), Some(&namespace))
-                .unwrap();
+            py.run(
+                ffi::c_str!("class Foo: pass"),
+                Some(&namespace),
+                Some(&namespace),
+            )
+            .unwrap();
             assert!(matches!(namespace.get_item("Foo"), Ok(Some(..))));
             assert!(matches!(namespace.get_item("__builtins__"), Ok(Some(..))));
         })

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -571,7 +571,7 @@ impl<'py> Python<'py> {
     /// };
     /// Python::with_gil(|py| {
     ///     let locals = PyDict::new(py);
-    ///     py.run_bound(
+    ///     py.run(
     ///         r#"
     /// import base64
     /// s = 'Hello Rust!'
@@ -589,7 +589,7 @@ impl<'py> Python<'py> {
     ///
     /// You can use [`py_run!`](macro.py_run.html) for a handy alternative of `run`
     /// if you don't need `globals` and unwrapping is OK.
-    pub fn run_bound(
+    pub fn run(
         self,
         code: &str,
         globals: Option<&Bound<'py, PyDict>>,
@@ -599,6 +599,19 @@ impl<'py> Python<'py> {
         res.map(|obj| {
             debug_assert!(obj.is_none());
         })
+    }
+
+    /// Deprecated name for [`Python::run`].
+    #[deprecated(since = "0.23.0", note = "renamed to `Python::run`")]
+    #[track_caller]
+    #[inline]
+    pub fn run_bound(
+        self,
+        code: &str,
+        globals: Option<&Bound<'py, PyDict>>,
+        locals: Option<&Bound<'py, PyDict>>,
+    ) -> PyResult<()> {
+        self.run(code, globals, locals)
     }
 
     /// Runs code in the given context.
@@ -979,7 +992,7 @@ mod tests {
 
         Python::with_gil(|py| {
             let namespace = PyDict::new(py);
-            py.run_bound("class Foo: pass", Some(&namespace), Some(&namespace))
+            py.run("class Foo: pass", Some(&namespace), Some(&namespace))
                 .unwrap();
             assert!(matches!(namespace.get_item("Foo"), Ok(Some(..))));
             assert!(matches!(namespace.get_item("__builtins__"), Ok(Some(..))));

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -40,7 +40,7 @@ mod inner {
         }};
         // Case2: dict & no err_msg
         ($py:expr, *$dict:expr, $code:expr, $err:ident) => {{
-            let res = $py.run($code, None, Some(&$dict.as_borrowed()));
+            let res = $py.run(&std::ffi::CString::new($code).unwrap(), None, Some(&$dict.as_borrowed()));
             let err = res.expect_err(&format!("Did not raise {}", stringify!($err)));
             if !err.matches($py, $py.get_type::<pyo3::exceptions::$err>()) {
                 panic!("Expected {} but got {:?}", stringify!($err), err)

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -40,7 +40,7 @@ mod inner {
         }};
         // Case2: dict & no err_msg
         ($py:expr, *$dict:expr, $code:expr, $err:ident) => {{
-            let res = $py.run_bound($code, None, Some(&$dict.as_borrowed()));
+            let res = $py.run($code, None, Some(&$dict.as_borrowed()));
             let err = res.expect_err(&format!("Did not raise {}", stringify!($err)));
             if !err.matches($py, $py.get_type::<pyo3::exceptions::$err>()) {
                 panic!("Expected {} but got {:?}", stringify!($err), err)

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1617,7 +1617,7 @@ class NonHeapNonDescriptorInt:
     #[test]
     fn test_call_for_non_existing_method() {
         Python::with_gil(|py| {
-            let a = py.eval_bound("42", None, None).unwrap();
+            let a = py.eval("42", None, None).unwrap();
             a.call_method0("__str__").unwrap(); // ok
             assert!(a.call_method("nonexistent_method", (1,), None).is_err());
             assert!(a.call_method0("nonexistent_method").is_err());
@@ -1667,7 +1667,7 @@ class SimpleClass:
     #[test]
     fn test_type() {
         Python::with_gil(|py| {
-            let obj = py.eval_bound("42", None, None).unwrap();
+            let obj = py.eval("42", None, None).unwrap();
             assert_eq!(obj.get_type().as_type_ptr(), obj.get_type_ptr());
         });
     }
@@ -1675,9 +1675,9 @@ class SimpleClass:
     #[test]
     fn test_dir() {
         Python::with_gil(|py| {
-            let obj = py.eval_bound("42", None, None).unwrap();
+            let obj = py.eval("42", None, None).unwrap();
             let dir = py
-                .eval_bound("dir(42)", None, None)
+                .eval("dir(42)", None, None)
                 .unwrap()
                 .downcast_into::<PyList>()
                 .unwrap();
@@ -1733,7 +1733,7 @@ class SimpleClass:
     #[test]
     fn test_nan_eq() {
         Python::with_gil(|py| {
-            let nan = py.eval_bound("float('nan')", None, None).unwrap();
+            let nan = py.eval("float('nan')", None, None).unwrap();
             assert!(nan.compare(&nan).is_err());
         });
     }
@@ -1922,7 +1922,7 @@ class SimpleClass:
     fn test_is_ellipsis() {
         Python::with_gil(|py| {
             let v = py
-                .eval_bound("...", None, None)
+                .eval("...", None, None)
                 .map_err(|e| e.display(py))
                 .unwrap();
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1535,6 +1535,7 @@ impl<'py> Bound<'py, PyAny> {
 mod tests {
     use crate::{
         basic::CompareOp,
+        ffi,
         types::{IntoPyDict, PyAny, PyAnyMethods, PyBool, PyInt, PyList, PyModule, PyTypeMethods},
         Bound, PyTypeInfo, Python, ToPyObject,
     };
@@ -1617,7 +1618,7 @@ class NonHeapNonDescriptorInt:
     #[test]
     fn test_call_for_non_existing_method() {
         Python::with_gil(|py| {
-            let a = py.eval("42", None, None).unwrap();
+            let a = py.eval(ffi::c_str!("42"), None, None).unwrap();
             a.call_method0("__str__").unwrap(); // ok
             assert!(a.call_method("nonexistent_method", (1,), None).is_err());
             assert!(a.call_method0("nonexistent_method").is_err());
@@ -1667,7 +1668,7 @@ class SimpleClass:
     #[test]
     fn test_type() {
         Python::with_gil(|py| {
-            let obj = py.eval("42", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("42"), None, None).unwrap();
             assert_eq!(obj.get_type().as_type_ptr(), obj.get_type_ptr());
         });
     }
@@ -1675,9 +1676,9 @@ class SimpleClass:
     #[test]
     fn test_dir() {
         Python::with_gil(|py| {
-            let obj = py.eval("42", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("42"), None, None).unwrap();
             let dir = py
-                .eval("dir(42)", None, None)
+                .eval(ffi::c_str!("dir(42)"), None, None)
                 .unwrap()
                 .downcast_into::<PyList>()
                 .unwrap();
@@ -1733,7 +1734,7 @@ class SimpleClass:
     #[test]
     fn test_nan_eq() {
         Python::with_gil(|py| {
-            let nan = py.eval("float('nan')", None, None).unwrap();
+            let nan = py.eval(ffi::c_str!("float('nan')"), None, None).unwrap();
             assert!(nan.compare(&nan).is_err());
         });
     }
@@ -1922,7 +1923,7 @@ class SimpleClass:
     fn test_is_ellipsis() {
         Python::with_gil(|py| {
             let v = py
-                .eval("...", None, None)
+                .eval(ffi::c_str!("..."), None, None)
                 .map_err(|e| e.display(py))
                 .unwrap();
 

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -188,7 +188,7 @@ pub trait PyByteArrayMethods<'py>: crate::sealed::Sealed {
     /// #         let locals = pyo3::types::PyDict::new(py);
     /// #         locals.set_item("a_valid_function", fun)?;
     /// #
-    /// #         py.run_bound(
+    /// #         py.run(
     /// # r#"b = bytearray(b"hello world")
     /// # a_valid_function(b)
     /// #

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -188,14 +188,14 @@ pub trait PyByteArrayMethods<'py>: crate::sealed::Sealed {
     /// #         let locals = pyo3::types::PyDict::new(py);
     /// #         locals.set_item("a_valid_function", fun)?;
     /// #
-    /// #         py.run(
+    /// #         py.run(pyo3::ffi::c_str!(
     /// # r#"b = bytearray(b"hello world")
     /// # a_valid_function(b)
     /// #
     /// # try:
     /// #     a_valid_function(bytearray())
     /// # except RuntimeError as e:
-    /// #     assert str(e) == 'input is not long enough'"#,
+    /// #     assert str(e) == 'input is not long enough'"#),
     /// #             None,
     /// #             Some(&locals),
     /// #         )?;

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -795,7 +795,7 @@ mod tests {
     fn test_set_item_refcnt() {
         Python::with_gil(|py| {
             let cnt;
-            let obj = py.eval("object()", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             {
                 cnt = obj.get_refcnt();
                 let _dict = [(10, &obj)].into_py_dict(py);

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -795,7 +795,7 @@ mod tests {
     fn test_set_item_refcnt() {
         Python::with_gil(|py| {
             let cnt;
-            let obj = py.eval_bound("object()", None, None).unwrap();
+            let obj = py.eval("object()", None, None).unwrap();
             {
                 cnt = obj.get_refcnt();
                 let _dict = [(10, &obj)].into_py_dict(py);

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -15,7 +15,7 @@ use crate::{ffi, Bound, PyAny, PyErr, PyResult, PyTypeCheck};
 ///
 /// # fn main() -> PyResult<()> {
 /// Python::with_gil(|py| -> PyResult<()> {
-///     let list = py.eval_bound("iter([1, 2, 3, 4])", None, None)?;
+///     let list = py.eval("iter([1, 2, 3, 4])", None, None)?;
 ///     let numbers: PyResult<Vec<usize>> = list
 ///         .iter()?
 ///         .map(|i| i.and_then(|i|i.extract::<usize>()))
@@ -154,7 +154,7 @@ mod tests {
     fn iter_item_refcnt() {
         Python::with_gil(|py| {
             let count;
-            let obj = py.eval_bound("object()", None, None).unwrap();
+            let obj = py.eval("object()", None, None).unwrap();
             let list = {
                 let list = PyList::empty(py);
                 list.append(10).unwrap();
@@ -194,7 +194,7 @@ def fibonacci(target):
             py.run_bound(fibonacci_generator, None, Some(&context))
                 .unwrap();
 
-            let generator = py.eval_bound("fibonacci(5)", None, Some(&context)).unwrap();
+            let generator = py.eval("fibonacci(5)", None, Some(&context)).unwrap();
             for (actual, expected) in generator.iter().unwrap().zip(&[1, 1, 2, 3, 5]) {
                 let actual = actual.unwrap().extract::<usize>().unwrap();
                 assert_eq!(actual, *expected)
@@ -222,7 +222,7 @@ def fibonacci(target):
                 .unwrap();
 
             let generator: Bound<'_, PyIterator> = py
-                .eval_bound("fibonacci(5)", None, Some(&context))
+                .eval("fibonacci(5)", None, Some(&context))
                 .unwrap()
                 .downcast_into()
                 .unwrap();
@@ -321,7 +321,7 @@ def fibonacci(target):
     #[cfg(not(Py_LIMITED_API))]
     fn length_hint_becomes_size_hint_lower_bound() {
         Python::with_gil(|py| {
-            let list = py.eval_bound("[1, 2, 3]", None, None).unwrap();
+            let list = py.eval("[1, 2, 3]", None, None).unwrap();
             let iter = list.iter().unwrap();
             let hint = iter.size_hint();
             assert_eq!(hint, (3, None));

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -191,8 +191,7 @@ def fibonacci(target):
 
         Python::with_gil(|py| {
             let context = PyDict::new(py);
-            py.run_bound(fibonacci_generator, None, Some(&context))
-                .unwrap();
+            py.run(fibonacci_generator, None, Some(&context)).unwrap();
 
             let generator = py.eval("fibonacci(5)", None, Some(&context)).unwrap();
             for (actual, expected) in generator.iter().unwrap().zip(&[1, 1, 2, 3, 5]) {
@@ -218,8 +217,7 @@ def fibonacci(target):
 
         Python::with_gil(|py| {
             let context = PyDict::new(py);
-            py.run_bound(fibonacci_generator, None, Some(&context))
-                .unwrap();
+            py.run(fibonacci_generator, None, Some(&context)).unwrap();
 
             let generator: Bound<'_, PyIterator> = py
                 .eval("fibonacci(5)", None, Some(&context))

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -12,10 +12,11 @@ use crate::{ffi, Bound, PyAny, PyErr, PyResult, PyTypeCheck};
 ///
 /// ```rust
 /// use pyo3::prelude::*;
+/// use pyo3::ffi::c_str;
 ///
 /// # fn main() -> PyResult<()> {
 /// Python::with_gil(|py| -> PyResult<()> {
-///     let list = py.eval("iter([1, 2, 3, 4])", None, None)?;
+///     let list = py.eval(c_str!("iter([1, 2, 3, 4])"), None, None)?;
 ///     let numbers: PyResult<Vec<usize>> = list
 ///         .iter()?
 ///         .map(|i| i.and_then(|i|i.extract::<usize>()))
@@ -107,7 +108,7 @@ mod tests {
     use super::PyIterator;
     use crate::exceptions::PyTypeError;
     use crate::types::{PyAnyMethods, PyDict, PyList, PyListMethods};
-    use crate::{Python, ToPyObject};
+    use crate::{ffi, Python, ToPyObject};
 
     #[test]
     fn vec_iter() {
@@ -154,7 +155,7 @@ mod tests {
     fn iter_item_refcnt() {
         Python::with_gil(|py| {
             let count;
-            let obj = py.eval("object()", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             let list = {
                 let list = PyList::empty(py);
                 list.append(10).unwrap();
@@ -180,20 +181,24 @@ mod tests {
 
     #[test]
     fn fibonacci_generator() {
-        let fibonacci_generator = r#"
+        let fibonacci_generator = ffi::c_str!(
+            r#"
 def fibonacci(target):
     a = 1
     b = 1
     for _ in range(target):
         yield a
         a, b = b, a + b
-"#;
+"#
+        );
 
         Python::with_gil(|py| {
             let context = PyDict::new(py);
             py.run(fibonacci_generator, None, Some(&context)).unwrap();
 
-            let generator = py.eval("fibonacci(5)", None, Some(&context)).unwrap();
+            let generator = py
+                .eval(ffi::c_str!("fibonacci(5)"), None, Some(&context))
+                .unwrap();
             for (actual, expected) in generator.iter().unwrap().zip(&[1, 1, 2, 3, 5]) {
                 let actual = actual.unwrap().extract::<usize>().unwrap();
                 assert_eq!(actual, *expected)
@@ -206,21 +211,23 @@ def fibonacci(target):
         use crate::types::any::PyAnyMethods;
         use crate::Bound;
 
-        let fibonacci_generator = r#"
+        let fibonacci_generator = ffi::c_str!(
+            r#"
 def fibonacci(target):
     a = 1
     b = 1
     for _ in range(target):
         yield a
         a, b = b, a + b
-"#;
+"#
+        );
 
         Python::with_gil(|py| {
             let context = PyDict::new(py);
             py.run(fibonacci_generator, None, Some(&context)).unwrap();
 
             let generator: Bound<'_, PyIterator> = py
-                .eval("fibonacci(5)", None, Some(&context))
+                .eval(ffi::c_str!("fibonacci(5)"), None, Some(&context))
                 .unwrap()
                 .downcast_into()
                 .unwrap();
@@ -319,7 +326,7 @@ def fibonacci(target):
     #[cfg(not(Py_LIMITED_API))]
     fn length_hint_becomes_size_hint_lower_bound() {
         Python::with_gil(|py| {
-            let list = py.eval("[1, 2, 3]", None, None).unwrap();
+            let list = py.eval(ffi::c_str!("[1, 2, 3]"), None, None).unwrap();
             let iter = list.iter().unwrap();
             let hint = iter.size_hint();
             assert_eq!(hint, (3, None));

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -603,7 +603,7 @@ mod tests {
     #[test]
     fn test_set_item_refcnt() {
         Python::with_gil(|py| {
-            let obj = py.eval_bound("object()", None, None).unwrap();
+            let obj = py.eval("object()", None, None).unwrap();
             let cnt;
             {
                 let v = vec![2];
@@ -638,7 +638,7 @@ mod tests {
     fn test_insert_refcnt() {
         Python::with_gil(|py| {
             let cnt;
-            let obj = py.eval_bound("object()", None, None).unwrap();
+            let obj = py.eval("object()", None, None).unwrap();
             {
                 let list = PyList::empty(py);
                 cnt = obj.get_refcnt();
@@ -663,7 +663,7 @@ mod tests {
     fn test_append_refcnt() {
         Python::with_gil(|py| {
             let cnt;
-            let obj = py.eval_bound("object()", None, None).unwrap();
+            let obj = py.eval("object()", None, None).unwrap();
             {
                 let list = PyList::empty(py);
                 cnt = obj.get_refcnt();

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -543,7 +543,7 @@ mod tests {
     use crate::types::list::PyListMethods;
     use crate::types::sequence::PySequenceMethods;
     use crate::types::{PyList, PyTuple};
-    use crate::Python;
+    use crate::{ffi, Python};
     use crate::{IntoPy, PyObject, ToPyObject};
 
     #[test]
@@ -603,7 +603,7 @@ mod tests {
     #[test]
     fn test_set_item_refcnt() {
         Python::with_gil(|py| {
-            let obj = py.eval("object()", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             let cnt;
             {
                 let v = vec![2];
@@ -638,7 +638,7 @@ mod tests {
     fn test_insert_refcnt() {
         Python::with_gil(|py| {
             let cnt;
-            let obj = py.eval("object()", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             {
                 let list = PyList::empty(py);
                 cnt = obj.get_refcnt();
@@ -663,7 +663,7 @@ mod tests {
     fn test_append_refcnt() {
         Python::with_gil(|py| {
             let cnt;
-            let obj = py.eval("object()", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             {
                 let list = PyList::empty(py);
                 cnt = obj.get_refcnt();

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -61,7 +61,7 @@ pub use self::weakref::{PyWeakref, PyWeakrefMethods, PyWeakrefProxy, PyWeakrefRe
 ///
 /// # pub fn main() -> PyResult<()> {
 /// Python::with_gil(|py| {
-///     let dict = py.eval_bound("{'a':'b', 'c':'d'}", None, None)?.downcast_into::<PyDict>()?;
+///     let dict = py.eval("{'a':'b', 'c':'d'}", None, None)?.downcast_into::<PyDict>()?;
 ///
 ///     for (key, value) in &dict {
 ///         println!("key: {}, value: {}", key, value);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -58,10 +58,11 @@ pub use self::weakref::{PyWeakref, PyWeakrefMethods, PyWeakrefProxy, PyWeakrefRe
 /// ```rust
 /// use pyo3::prelude::*;
 /// use pyo3::types::PyDict;
+/// use pyo3::ffi::c_str;
 ///
 /// # pub fn main() -> PyResult<()> {
 /// Python::with_gil(|py| {
-///     let dict = py.eval("{'a':'b', 'c':'d'}", None, None)?.downcast_into::<PyDict>()?;
+///     let dict = py.eval(c_str!("{'a':'b', 'c':'d'}"), None, None)?.downcast_into::<PyDict>()?;
 ///
 ///     for (key, value) in &dict {
 ///         println!("key: {}, value: {}", key, value);

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -381,7 +381,7 @@ mod tests {
     fn get_object() -> PyObject {
         // Convenience function for getting a single unique object
         Python::with_gil(|py| {
-            let obj = py.eval_bound("object()", None, None).unwrap();
+            let obj = py.eval("object()", None, None).unwrap();
 
             obj.to_object(py)
         })
@@ -749,11 +749,7 @@ mod tests {
     #[test]
     fn test_extract_tuple_to_vec() {
         Python::with_gil(|py| {
-            let v: Vec<i32> = py
-                .eval_bound("(1, 2)", None, None)
-                .unwrap()
-                .extract()
-                .unwrap();
+            let v: Vec<i32> = py.eval("(1, 2)", None, None).unwrap().extract().unwrap();
             assert!(v == [1, 2]);
         });
     }
@@ -762,7 +758,7 @@ mod tests {
     fn test_extract_range_to_vec() {
         Python::with_gil(|py| {
             let v: Vec<i32> = py
-                .eval_bound("range(1, 5)", None, None)
+                .eval("range(1, 5)", None, None)
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -774,7 +770,7 @@ mod tests {
     fn test_extract_bytearray_to_vec() {
         Python::with_gil(|py| {
             let v: Vec<u8> = py
-                .eval_bound("bytearray(b'abc')", None, None)
+                .eval("bytearray(b'abc')", None, None)
                 .unwrap()
                 .extract()
                 .unwrap();

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -376,12 +376,12 @@ impl PyTypeCheck for PySequence {
 #[cfg(test)]
 mod tests {
     use crate::types::{PyAnyMethods, PyList, PySequence, PySequenceMethods, PyTuple};
-    use crate::{PyObject, Python, ToPyObject};
+    use crate::{ffi, PyObject, Python, ToPyObject};
 
     fn get_object() -> PyObject {
         // Convenience function for getting a single unique object
         Python::with_gil(|py| {
-            let obj = py.eval("object()", None, None).unwrap();
+            let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
 
             obj.to_object(py)
         })
@@ -749,7 +749,11 @@ mod tests {
     #[test]
     fn test_extract_tuple_to_vec() {
         Python::with_gil(|py| {
-            let v: Vec<i32> = py.eval("(1, 2)", None, None).unwrap().extract().unwrap();
+            let v: Vec<i32> = py
+                .eval(ffi::c_str!("(1, 2)"), None, None)
+                .unwrap()
+                .extract()
+                .unwrap();
             assert!(v == [1, 2]);
         });
     }
@@ -758,7 +762,7 @@ mod tests {
     fn test_extract_range_to_vec() {
         Python::with_gil(|py| {
             let v: Vec<i32> = py
-                .eval("range(1, 5)", None, None)
+                .eval(ffi::c_str!("range(1, 5)"), None, None)
                 .unwrap()
                 .extract()
                 .unwrap();
@@ -770,7 +774,7 @@ mod tests {
     fn test_extract_bytearray_to_vec() {
         Python::with_gil(|py| {
             let v: Vec<u8> = py
-                .eval("bytearray(b'abc')", None, None)
+                .eval(ffi::c_str!("bytearray(b'abc')"), None, None)
                 .unwrap()
                 .extract()
                 .unwrap();

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -367,7 +367,7 @@ mod tests {
             let val2 = set.pop();
             assert!(val2.is_none());
             assert!(py
-                .eval_bound("print('Exception state should not be set.')", None, None)
+                .eval("print('Exception state should not be set.')", None, None)
                 .is_ok());
         });
     }

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -277,6 +277,7 @@ pub(crate) fn try_new_from_iter(
 mod tests {
     use super::PySet;
     use crate::{
+        ffi,
         types::{PyAnyMethods, PySetMethods},
         Python, ToPyObject,
     };
@@ -367,7 +368,11 @@ mod tests {
             let val2 = set.pop();
             assert!(val2.is_none());
             assert!(py
-                .eval("print('Exception state should not be set.')", None, None)
+                .eval(
+                    ffi::c_str!("print('Exception state should not be set.')"),
+                    None,
+                    None
+                )
                 .is_ok());
         });
     }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -592,7 +592,7 @@ mod tests {
     fn test_to_cow_surrogate() {
         Python::with_gil(|py| {
             let py_string = py
-                .eval_bound(r"'\ud800'", None, None)
+                .eval(r"'\ud800'", None, None)
                 .unwrap()
                 .downcast_into::<PyString>()
                 .unwrap();
@@ -621,7 +621,7 @@ mod tests {
     #[test]
     fn test_encode_utf8_surrogate() {
         Python::with_gil(|py| {
-            let obj: PyObject = py.eval_bound(r"'\ud800'", None, None).unwrap().into();
+            let obj: PyObject = py.eval(r"'\ud800'", None, None).unwrap().into();
             assert!(obj
                 .bind(py)
                 .downcast::<PyString>()
@@ -635,7 +635,7 @@ mod tests {
     fn test_to_string_lossy() {
         Python::with_gil(|py| {
             let py_string = py
-                .eval_bound(r"'🐈 Hello \ud800World'", None, None)
+                .eval(r"'🐈 Hello \ud800World'", None, None)
                 .unwrap()
                 .downcast_into::<PyString>()
                 .unwrap();
@@ -707,7 +707,7 @@ mod tests {
     #[cfg(not(any(Py_LIMITED_API, PyPy)))]
     fn test_string_data_ucs2() {
         Python::with_gil(|py| {
-            let s = py.eval_bound("'foo\\ud800'", None, None).unwrap();
+            let s = py.eval("'foo\\ud800'", None, None).unwrap();
             let py_string = s.downcast::<PyString>().unwrap();
             let data = unsafe { py_string.data().unwrap() };
 
@@ -822,11 +822,8 @@ mod tests {
     #[test]
     fn test_py_to_str_surrogate() {
         Python::with_gil(|py| {
-            let py_string: Py<PyString> = py
-                .eval_bound(r"'\ud800'", None, None)
-                .unwrap()
-                .extract()
-                .unwrap();
+            let py_string: Py<PyString> =
+                py.eval(r"'\ud800'", None, None).unwrap().extract().unwrap();
 
             #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
             assert!(py_string.to_str(py).is_err());
@@ -839,7 +836,7 @@ mod tests {
     fn test_py_to_string_lossy() {
         Python::with_gil(|py| {
             let py_string: Py<PyString> = py
-                .eval_bound(r"'🐈 Hello \ud800World'", None, None)
+                .eval(r"'🐈 Hello \ud800World'", None, None)
                 .unwrap()
                 .extract()
                 .unwrap();

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -592,7 +592,7 @@ mod tests {
     fn test_to_cow_surrogate() {
         Python::with_gil(|py| {
             let py_string = py
-                .eval(r"'\ud800'", None, None)
+                .eval(ffi::c_str!(r"'\ud800'"), None, None)
                 .unwrap()
                 .downcast_into::<PyString>()
                 .unwrap();
@@ -621,7 +621,10 @@ mod tests {
     #[test]
     fn test_encode_utf8_surrogate() {
         Python::with_gil(|py| {
-            let obj: PyObject = py.eval(r"'\ud800'", None, None).unwrap().into();
+            let obj: PyObject = py
+                .eval(ffi::c_str!(r"'\ud800'"), None, None)
+                .unwrap()
+                .into();
             assert!(obj
                 .bind(py)
                 .downcast::<PyString>()
@@ -635,7 +638,7 @@ mod tests {
     fn test_to_string_lossy() {
         Python::with_gil(|py| {
             let py_string = py
-                .eval(r"'🐈 Hello \ud800World'", None, None)
+                .eval(ffi::c_str!(r"'🐈 Hello \ud800World'"), None, None)
                 .unwrap()
                 .downcast_into::<PyString>()
                 .unwrap();
@@ -707,7 +710,7 @@ mod tests {
     #[cfg(not(any(Py_LIMITED_API, PyPy)))]
     fn test_string_data_ucs2() {
         Python::with_gil(|py| {
-            let s = py.eval("'foo\\ud800'", None, None).unwrap();
+            let s = py.eval(ffi::c_str!("'foo\\ud800'"), None, None).unwrap();
             let py_string = s.downcast::<PyString>().unwrap();
             let data = unsafe { py_string.data().unwrap() };
 
@@ -822,8 +825,11 @@ mod tests {
     #[test]
     fn test_py_to_str_surrogate() {
         Python::with_gil(|py| {
-            let py_string: Py<PyString> =
-                py.eval(r"'\ud800'", None, None).unwrap().extract().unwrap();
+            let py_string: Py<PyString> = py
+                .eval(ffi::c_str!(r"'\ud800'"), None, None)
+                .unwrap()
+                .extract()
+                .unwrap();
 
             #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
             assert!(py_string.to_str(py).is_err());
@@ -836,7 +842,7 @@ mod tests {
     fn test_py_to_string_lossy() {
         Python::with_gil(|py| {
             let py_string: Py<PyString> = py
-                .eval(r"'🐈 Hello \ud800World'", None, None)
+                .eval(ffi::c_str!(r"'🐈 Hello \ud800World'"), None, None)
                 .unwrap()
                 .extract()
                 .unwrap();

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -39,7 +39,7 @@ pub trait PyTracebackMethods<'py>: crate::sealed::Sealed {
     /// # let result: PyResult<()> =
     /// Python::with_gil(|py| {
     ///     let err = py
-    ///         .run_bound("raise Exception('banana')", None, None)
+    ///         .run("raise Exception('banana')", None, None)
     ///         .expect_err("raise will create a Python error");
     ///
     ///     let traceback = err.traceback_bound(py).expect("raised exception will have a traceback");
@@ -89,7 +89,7 @@ mod tests {
     fn format_traceback() {
         Python::with_gil(|py| {
             let err = py
-                .run_bound("raise Exception('banana')", None, None)
+                .run("raise Exception('banana')", None, None)
                 .expect_err("raising should have given us an error");
 
             assert_eq!(
@@ -104,7 +104,7 @@ mod tests {
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             // Produce an error from python so that it has a traceback
-            py.run_bound(
+            py.run(
                 r"
 try:
     raise ValueError('raised exception')
@@ -126,7 +126,7 @@ except Exception as e:
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
             // Produce an error from python so that it has a traceback
-            py.run_bound(
+            py.run(
                 r"
 def f():
     raise ValueError('raised exception')

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -35,11 +35,11 @@ pub trait PyTracebackMethods<'py>: crate::sealed::Sealed {
     /// The following code formats a Python traceback and exception pair from Rust:
     ///
     /// ```rust
-    /// # use pyo3::{Python, PyResult, prelude::PyTracebackMethods};
+    /// # use pyo3::{Python, PyResult, prelude::PyTracebackMethods, ffi::c_str};
     /// # let result: PyResult<()> =
     /// Python::with_gil(|py| {
     ///     let err = py
-    ///         .run("raise Exception('banana')", None, None)
+    ///         .run(c_str!("raise Exception('banana')"), None, None)
     ///         .expect_err("raise will create a Python error");
     ///
     ///     let traceback = err.traceback_bound(py).expect("raised exception will have a traceback");
@@ -81,6 +81,7 @@ impl<'py> PyTracebackMethods<'py> for Bound<'py, PyTraceback> {
 #[cfg(test)]
 mod tests {
     use crate::{
+        ffi,
         types::{any::PyAnyMethods, dict::PyDictMethods, traceback::PyTracebackMethods, PyDict},
         IntoPy, PyErr, Python,
     };
@@ -89,7 +90,7 @@ mod tests {
     fn format_traceback() {
         Python::with_gil(|py| {
             let err = py
-                .run("raise Exception('banana')", None, None)
+                .run(ffi::c_str!("raise Exception('banana')"), None, None)
                 .expect_err("raising should have given us an error");
 
             assert_eq!(
@@ -105,12 +106,14 @@ mod tests {
             let locals = PyDict::new(py);
             // Produce an error from python so that it has a traceback
             py.run(
-                r"
+                ffi::c_str!(
+                    r"
 try:
     raise ValueError('raised exception')
 except Exception as e:
     err = e
-",
+"
+                ),
                 None,
                 Some(&locals),
             )
@@ -127,10 +130,12 @@ except Exception as e:
             let locals = PyDict::new(py);
             // Produce an error from python so that it has a traceback
             py.run(
-                r"
+                ffi::c_str!(
+                    r"
 def f():
     raise ValueError('raised exception')
-",
+"
+                ),
                 None,
                 Some(&locals),
             )

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -790,7 +790,7 @@ mod tests {
         use crate::{py_result_ext::PyResultExt, types::PyType};
 
         fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
-            py.run_bound("class A:\n    pass\n", None, None)?;
+            py.run("class A:\n    pass\n", None, None)?;
             py.eval("A", None, None).downcast_into::<PyType>()
         }
 

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -787,11 +787,13 @@ mod tests {
 
     mod python_class {
         use super::*;
+        use crate::ffi;
         use crate::{py_result_ext::PyResultExt, types::PyType};
 
         fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
-            py.run("class A:\n    pass\n", None, None)?;
-            py.eval("A", None, None).downcast_into::<PyType>()
+            py.run(ffi::c_str!("class A:\n    pass\n"), None, None)?;
+            py.eval(ffi::c_str!("A"), None, None)
+                .downcast_into::<PyType>()
         }
 
         #[test]

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -791,7 +791,7 @@ mod tests {
 
         fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
             py.run_bound("class A:\n    pass\n", None, None)?;
-            py.eval_bound("A", None, None).downcast_into::<PyType>()
+            py.eval("A", None, None).downcast_into::<PyType>()
         }
 
         #[test]

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -100,6 +100,7 @@ impl PyWeakrefProxy {
     )]
     /// use pyo3::prelude::*;
     /// use pyo3::types::PyWeakrefProxy;
+    /// use pyo3::ffi::c_str;
     ///
     /// #[pyclass(weakref)]
     /// struct Foo { /* fields omitted */ }
@@ -108,13 +109,13 @@ impl PyWeakrefProxy {
     /// fn callback(wref: Bound<'_, PyWeakrefProxy>) -> PyResult<()> {
     ///         let py = wref.py();
     ///         assert!(wref.upgrade_as::<Foo>()?.is_none());
-    ///         py.run("counter = 1", None, None)
+    ///         py.run(c_str!("counter = 1"), None, None)
     /// }
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
-    ///     py.run("counter = 0", None, None)?;
-    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
+    ///     py.run(c_str!("counter = 0"), None, None)?;
+    ///     assert_eq!(py.eval(c_str!("counter"), None, None)?.extract::<u32>()?, 0);
     ///     let foo = Bound::new(py, Foo{})?;
     ///
     ///     // This is fine.
@@ -125,7 +126,7 @@ impl PyWeakrefProxy {
     ///         weakref.upgrade()
     ///             .map_or(false, |obj| obj.is(&foo))
     ///     );
-    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
+    ///     assert_eq!(py.eval(c_str!("counter"), None, None)?.extract::<u32>()?, 0);
     ///
     ///     let weakref2 = PyWeakrefProxy::new_bound_with(&foo, wrap_pyfunction!(callback, py)?)?;
     ///     assert!(!weakref.is(&weakref2)); // Not the same weakref
@@ -134,7 +135,7 @@ impl PyWeakrefProxy {
     ///     drop(foo);
     ///
     ///     assert!(weakref.upgrade_as::<Foo>()?.is_none());
-    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 1);
+    ///     assert_eq!(py.eval(c_str!("counter"), None, None)?.extract::<u32>()?, 1);
     ///     Ok(())
     /// })
     /// # }
@@ -236,11 +237,13 @@ mod tests {
 
         mod python_class {
             use super::*;
+            use crate::ffi;
             use crate::{py_result_ext::PyResultExt, types::PyType};
 
             fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
-                py.run("class A:\n    pass\n", None, None)?;
-                py.eval("A", None, None).downcast_into::<PyType>()
+                py.run(ffi::c_str!("class A:\n    pass\n"), None, None)?;
+                py.eval(ffi::c_str!("A"), None, None)
+                    .downcast_into::<PyType>()
             }
 
             #[test]
@@ -778,15 +781,17 @@ mod tests {
 
         mod python_class {
             use super::*;
+            use crate::ffi;
             use crate::{py_result_ext::PyResultExt, types::PyType};
 
             fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
                 py.run(
-                    "class A:\n    def __call__(self):\n        return 'This class is callable!'\n",
+                    ffi::c_str!("class A:\n    def __call__(self):\n        return 'This class is callable!'\n"),
                     None,
                     None,
                 )?;
-                py.eval("A", None, None).downcast_into::<PyType>()
+                py.eval(ffi::c_str!("A"), None, None)
+                    .downcast_into::<PyType>()
             }
 
             #[test]

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -108,12 +108,12 @@ impl PyWeakrefProxy {
     /// fn callback(wref: Bound<'_, PyWeakrefProxy>) -> PyResult<()> {
     ///         let py = wref.py();
     ///         assert!(wref.upgrade_as::<Foo>()?.is_none());
-    ///         py.run_bound("counter = 1", None, None)
+    ///         py.run("counter = 1", None, None)
     /// }
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
-    ///     py.run_bound("counter = 0", None, None)?;
+    ///     py.run("counter = 0", None, None)?;
     ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
     ///     let foo = Bound::new(py, Foo{})?;
     ///
@@ -239,7 +239,7 @@ mod tests {
             use crate::{py_result_ext::PyResultExt, types::PyType};
 
             fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
-                py.run_bound("class A:\n    pass\n", None, None)?;
+                py.run("class A:\n    pass\n", None, None)?;
                 py.eval("A", None, None).downcast_into::<PyType>()
             }
 
@@ -781,7 +781,7 @@ mod tests {
             use crate::{py_result_ext::PyResultExt, types::PyType};
 
             fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
-                py.run_bound(
+                py.run(
                     "class A:\n    def __call__(self):\n        return 'This class is callable!'\n",
                     None,
                     None,

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -114,7 +114,7 @@ impl PyWeakrefProxy {
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
     ///     py.run_bound("counter = 0", None, None)?;
-    ///     assert_eq!(py.eval_bound("counter", None, None)?.extract::<u32>()?, 0);
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
     ///     let foo = Bound::new(py, Foo{})?;
     ///
     ///     // This is fine.
@@ -125,7 +125,7 @@ impl PyWeakrefProxy {
     ///         weakref.upgrade()
     ///             .map_or(false, |obj| obj.is(&foo))
     ///     );
-    ///     assert_eq!(py.eval_bound("counter", None, None)?.extract::<u32>()?, 0);
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
     ///
     ///     let weakref2 = PyWeakrefProxy::new_bound_with(&foo, wrap_pyfunction!(callback, py)?)?;
     ///     assert!(!weakref.is(&weakref2)); // Not the same weakref
@@ -134,7 +134,7 @@ impl PyWeakrefProxy {
     ///     drop(foo);
     ///
     ///     assert!(weakref.upgrade_as::<Foo>()?.is_none());
-    ///     assert_eq!(py.eval_bound("counter", None, None)?.extract::<u32>()?, 1);
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 1);
     ///     Ok(())
     /// })
     /// # }
@@ -240,7 +240,7 @@ mod tests {
 
             fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
                 py.run_bound("class A:\n    pass\n", None, None)?;
-                py.eval_bound("A", None, None).downcast_into::<PyType>()
+                py.eval("A", None, None).downcast_into::<PyType>()
             }
 
             #[test]
@@ -786,7 +786,7 @@ mod tests {
                     None,
                     None,
                 )?;
-                py.eval_bound("A", None, None).downcast_into::<PyType>()
+                py.eval("A", None, None).downcast_into::<PyType>()
             }
 
             #[test]

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -107,6 +107,7 @@ impl PyWeakrefReference {
     )]
     /// use pyo3::prelude::*;
     /// use pyo3::types::PyWeakrefReference;
+    /// use pyo3::ffi::c_str;
     ///
     /// #[pyclass(weakref)]
     /// struct Foo { /* fields omitted */ }
@@ -115,13 +116,13 @@ impl PyWeakrefReference {
     /// fn callback(wref: Bound<'_, PyWeakrefReference>) -> PyResult<()> {
     ///         let py = wref.py();
     ///         assert!(wref.upgrade_as::<Foo>()?.is_none());
-    ///         py.run("counter = 1", None, None)
+    ///         py.run(c_str!("counter = 1"), None, None)
     /// }
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
-    ///     py.run("counter = 0", None, None)?;
-    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
+    ///     py.run(c_str!("counter = 0"), None, None)?;
+    ///     assert_eq!(py.eval(c_str!("counter"), None, None)?.extract::<u32>()?, 0);
     ///     let foo = Bound::new(py, Foo{})?;
     ///
     ///     // This is fine.
@@ -132,7 +133,7 @@ impl PyWeakrefReference {
     ///         weakref.upgrade()
     ///             .map_or(false, |obj| obj.is(&foo))
     ///     );
-    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
+    ///     assert_eq!(py.eval(c_str!("counter"), None, None)?.extract::<u32>()?, 0);
     ///
     ///     let weakref2 = PyWeakrefReference::new_bound_with(&foo, wrap_pyfunction!(callback, py)?)?;
     ///     assert!(!weakref.is(&weakref2)); // Not the same weakref
@@ -141,7 +142,7 @@ impl PyWeakrefReference {
     ///     drop(foo);
     ///
     ///     assert!(weakref.upgrade_as::<Foo>()?.is_none());
-    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 1);
+    ///     assert_eq!(py.eval(c_str!("counter"), None, None)?.extract::<u32>()?, 1);
     ///     Ok(())
     /// })
     /// # }
@@ -229,11 +230,13 @@ mod tests {
 
     mod python_class {
         use super::*;
+        use crate::ffi;
         use crate::{py_result_ext::PyResultExt, types::PyType};
 
         fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
-            py.run("class A:\n    pass\n", None, None)?;
-            py.eval("A", None, None).downcast_into::<PyType>()
+            py.run(ffi::c_str!("class A:\n    pass\n"), None, None)?;
+            py.eval(ffi::c_str!("A"), None, None)
+                .downcast_into::<PyType>()
         }
 
         #[test]

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -121,7 +121,7 @@ impl PyWeakrefReference {
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
     ///     py.run_bound("counter = 0", None, None)?;
-    ///     assert_eq!(py.eval_bound("counter", None, None)?.extract::<u32>()?, 0);
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
     ///     let foo = Bound::new(py, Foo{})?;
     ///
     ///     // This is fine.
@@ -132,7 +132,7 @@ impl PyWeakrefReference {
     ///         weakref.upgrade()
     ///             .map_or(false, |obj| obj.is(&foo))
     ///     );
-    ///     assert_eq!(py.eval_bound("counter", None, None)?.extract::<u32>()?, 0);
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
     ///
     ///     let weakref2 = PyWeakrefReference::new_bound_with(&foo, wrap_pyfunction!(callback, py)?)?;
     ///     assert!(!weakref.is(&weakref2)); // Not the same weakref
@@ -141,7 +141,7 @@ impl PyWeakrefReference {
     ///     drop(foo);
     ///
     ///     assert!(weakref.upgrade_as::<Foo>()?.is_none());
-    ///     assert_eq!(py.eval_bound("counter", None, None)?.extract::<u32>()?, 1);
+    ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 1);
     ///     Ok(())
     /// })
     /// # }
@@ -233,7 +233,7 @@ mod tests {
 
         fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
             py.run_bound("class A:\n    pass\n", None, None)?;
-            py.eval_bound("A", None, None).downcast_into::<PyType>()
+            py.eval("A", None, None).downcast_into::<PyType>()
         }
 
         #[test]

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -115,12 +115,12 @@ impl PyWeakrefReference {
     /// fn callback(wref: Bound<'_, PyWeakrefReference>) -> PyResult<()> {
     ///         let py = wref.py();
     ///         assert!(wref.upgrade_as::<Foo>()?.is_none());
-    ///         py.run_bound("counter = 1", None, None)
+    ///         py.run("counter = 1", None, None)
     /// }
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
-    ///     py.run_bound("counter = 0", None, None)?;
+    ///     py.run("counter = 0", None, None)?;
     ///     assert_eq!(py.eval("counter", None, None)?.extract::<u32>()?, 0);
     ///     let foo = Bound::new(py, Foo{})?;
     ///
@@ -232,7 +232,7 @@ mod tests {
         use crate::{py_result_ext::PyResultExt, types::PyType};
 
         fn get_type(py: Python<'_>) -> PyResult<Bound<'_, PyType>> {
-            py.run_bound("class A:\n    pass\n", None, None)?;
+            py.run("class A:\n    pass\n", None, None)?;
             py.eval("A", None, None).downcast_into::<PyType>()
         }
 

--- a/tests/test_anyhow.rs
+++ b/tests/test_anyhow.rs
@@ -40,7 +40,7 @@ fn test_anyhow_py_function_err_result() {
         let locals = PyDict::new(py);
         locals.set_item("func", func).unwrap();
 
-        py.run_bound(
+        py.run(
             r#"
             func()
             "#,

--- a/tests/test_anyhow.rs
+++ b/tests/test_anyhow.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "anyhow")]
 
-use pyo3::wrap_pyfunction;
+use pyo3::{ffi, wrap_pyfunction};
 
 #[test]
 fn test_anyhow_py_function_ok_result() {
@@ -41,9 +41,11 @@ fn test_anyhow_py_function_err_result() {
         locals.set_item("func", func).unwrap();
 
         py.run(
-            r#"
+            ffi::c_str!(
+                r#"
             func()
-            "#,
+            "#
+            ),
             None,
             Some(&locals),
         )

--- a/tests/test_append_to_inittab.rs
+++ b/tests/test_append_to_inittab.rs
@@ -22,7 +22,7 @@ mod module_mod_with_functions {
 #[cfg(not(PyPy))]
 #[test]
 fn test_module_append_to_inittab() {
-    use pyo3::append_to_inittab;
+    use pyo3::{append_to_inittab, ffi};
 
     append_to_inittab!(module_fn_with_functions);
 
@@ -30,10 +30,12 @@ fn test_module_append_to_inittab() {
 
     Python::with_gil(|py| {
         py.run(
-            r#"
+            ffi::c_str!(
+                r#"
 import module_fn_with_functions
 assert module_fn_with_functions.foo() == 123
-"#,
+"#
+            ),
             None,
             None,
         )
@@ -43,10 +45,12 @@ assert module_fn_with_functions.foo() == 123
 
     Python::with_gil(|py| {
         py.run(
-            r#"
+            ffi::c_str!(
+                r#"
 import module_mod_with_functions
 assert module_mod_with_functions.foo() == 123
-"#,
+"#
+            ),
             None,
             None,
         )

--- a/tests/test_append_to_inittab.rs
+++ b/tests/test_append_to_inittab.rs
@@ -29,7 +29,7 @@ fn test_module_append_to_inittab() {
     append_to_inittab!(module_mod_with_functions);
 
     Python::with_gil(|py| {
-        py.run_bound(
+        py.run(
             r#"
 import module_fn_with_functions
 assert module_fn_with_functions.foo() == 123
@@ -42,7 +42,7 @@ assert module_fn_with_functions.foo() == 123
     });
 
     Python::with_gil(|py| {
-        py.run_bound(
+        py.run(
             r#"
 import module_mod_with_functions
 assert module_mod_with_functions.foo() == 123

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -685,7 +685,7 @@ mod return_not_implemented {
             py_expect_exception!(
                 py,
                 c2,
-                &format!("class Other: pass\nc2 {} Other()", operator),
+                format!("class Other: pass\nc2 {} Other()", operator),
                 PyTypeError
             );
         });

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -171,7 +171,7 @@ assert c.from_rust is False
         );
         let globals = PyModule::import(py, "__main__").unwrap().dict();
         globals.set_item("SuperClass", super_cls).unwrap();
-        py.run_bound(source, Some(&globals), None)
+        py.run(source, Some(&globals), None)
             .map_err(|e| e.display(py))
             .unwrap();
     });

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -156,7 +156,7 @@ impl SuperClass {
 fn subclass_new() {
     Python::with_gil(|py| {
         let super_cls = py.get_type::<SuperClass>();
-        let source = pyo3::indoc::indoc!(
+        let source = pyo3_ffi::c_str!(pyo3::indoc::indoc!(
             r#"
 class Class(SuperClass):
     def __new__(cls):
@@ -168,7 +168,7 @@ class Class(SuperClass):
 c = Class()
 assert c.from_rust is False
 "#
-        );
+        ));
         let globals = PyModule::import(py, "__main__").unwrap().dict();
         globals.set_item("SuperClass", super_cls).unwrap();
         py.run(source, Some(&globals), None)

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -151,7 +151,7 @@ fn cancelled_coroutine() {
         let globals = gil.import("__main__").unwrap().dict();
         globals.set_item("sleep", sleep).unwrap();
         let err = gil
-            .run_bound(
+            .run(
                 &pyo3::unindent::unindent(&handle_windows(test)),
                 Some(&globals),
                 None,
@@ -191,7 +191,7 @@ fn coroutine_cancel_handle() {
         globals
             .set_item("cancellable_sleep", cancellable_sleep)
             .unwrap();
-        gil.run_bound(
+        gil.run(
             &pyo3::unindent::unindent(&handle_windows(test)),
             Some(&globals),
             None,
@@ -221,7 +221,7 @@ fn coroutine_is_cancelled() {
         "#;
         let globals = gil.import("__main__").unwrap().dict();
         globals.set_item("sleep_loop", sleep_loop).unwrap();
-        gil.run_bound(
+        gil.run(
             &pyo3::unindent::unindent(&handle_windows(test)),
             Some(&globals),
             None,

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "experimental-async")]
 #![cfg(not(target_arch = "wasm32"))]
-use std::{task::Poll, thread, time::Duration};
+use std::{ffi::CString, task::Poll, thread, time::Duration};
 
 use futures::{channel::oneshot, future::poll_fn, FutureExt};
 #[cfg(not(target_has_atomic = "64"))]
@@ -152,7 +152,7 @@ fn cancelled_coroutine() {
         globals.set_item("sleep", sleep).unwrap();
         let err = gil
             .run(
-                &pyo3::unindent::unindent(&handle_windows(test)),
+                &CString::new(pyo3::unindent::unindent(&handle_windows(test))).unwrap(),
                 Some(&globals),
                 None,
             )
@@ -192,7 +192,7 @@ fn coroutine_cancel_handle() {
             .set_item("cancellable_sleep", cancellable_sleep)
             .unwrap();
         gil.run(
-            &pyo3::unindent::unindent(&handle_windows(test)),
+            &CString::new(pyo3::unindent::unindent(&handle_windows(test))).unwrap(),
             Some(&globals),
             None,
         )
@@ -222,7 +222,7 @@ fn coroutine_is_cancelled() {
         let globals = gil.import("__main__").unwrap().dict();
         globals.set_item("sleep_loop", sleep_loop).unwrap();
         gil.run(
-            &pyo3::unindent::unindent(&handle_windows(test)),
+            &CString::new(pyo3::unindent::unindent(&handle_windows(test))).unwrap(),
             Some(&globals),
             None,
         )

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -18,8 +18,8 @@ fn _get_subclasses<'py>(
 
     let make_sub_subclass_py = "class SubSubklass(Subklass):\n    pass";
 
-    py.run_bound(&make_subclass_py, None, Some(&locals))?;
-    py.run_bound(make_sub_subclass_py, None, Some(&locals))?;
+    py.run(&make_subclass_py, None, Some(&locals))?;
+    py.run(make_sub_subclass_py, None, Some(&locals))?;
 
     // Construct an instance of the base class
     let obj = py.eval(&format!("{}({})", py_type, args), None, Some(&locals))?;

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -1,8 +1,9 @@
 #![cfg(not(Py_LIMITED_API))]
 
-use pyo3::prelude::*;
 use pyo3::types::{timezone_utc_bound, IntoPyDict, PyDate, PyDateTime, PyTime};
+use pyo3::{ffi, prelude::*};
 use pyo3_ffi::PyDateTime_IMPORT;
+use std::ffi::CString;
 
 fn _get_subclasses<'py>(
     py: Python<'py>,
@@ -14,21 +15,33 @@ fn _get_subclasses<'py>(
 
     let locals = [(py_type, datetime.getattr(py_type)?)].into_py_dict(py);
 
-    let make_subclass_py = format!("class Subklass({}):\n    pass", py_type);
+    let make_subclass_py = CString::new(format!("class Subklass({}):\n    pass", py_type))?;
 
-    let make_sub_subclass_py = "class SubSubklass(Subklass):\n    pass";
+    let make_sub_subclass_py = ffi::c_str!("class SubSubklass(Subklass):\n    pass");
 
     py.run(&make_subclass_py, None, Some(&locals))?;
     py.run(make_sub_subclass_py, None, Some(&locals))?;
 
     // Construct an instance of the base class
-    let obj = py.eval(&format!("{}({})", py_type, args), None, Some(&locals))?;
+    let obj = py.eval(
+        &CString::new(format!("{}({})", py_type, args))?,
+        None,
+        Some(&locals),
+    )?;
 
     // Construct an instance of the subclass
-    let sub_obj = py.eval(&format!("Subklass({})", args), None, Some(&locals))?;
+    let sub_obj = py.eval(
+        &CString::new(format!("Subklass({})", args))?,
+        None,
+        Some(&locals),
+    )?;
 
     // Construct an instance of the sub-subclass
-    let sub_sub_obj = py.eval(&format!("SubSubklass({})", args), None, Some(&locals))?;
+    let sub_sub_obj = py.eval(
+        &CString::new(format!("SubSubklass({})", args))?,
+        None,
+        Some(&locals),
+    )?;
 
     Ok((obj, sub_obj, sub_sub_obj))
 }
@@ -125,7 +138,11 @@ fn test_datetime_utc() {
         let locals = [("dt", dt)].into_py_dict(py);
 
         let offset: f32 = py
-            .eval("dt.utcoffset().total_seconds()", None, Some(&locals))
+            .eval(
+                ffi::c_str!("dt.utcoffset().total_seconds()"),
+                None,
+                Some(&locals),
+            )
             .unwrap()
             .extract()
             .unwrap();

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -22,13 +22,13 @@ fn _get_subclasses<'py>(
     py.run_bound(make_sub_subclass_py, None, Some(&locals))?;
 
     // Construct an instance of the base class
-    let obj = py.eval_bound(&format!("{}({})", py_type, args), None, Some(&locals))?;
+    let obj = py.eval(&format!("{}({})", py_type, args), None, Some(&locals))?;
 
     // Construct an instance of the subclass
-    let sub_obj = py.eval_bound(&format!("Subklass({})", args), None, Some(&locals))?;
+    let sub_obj = py.eval(&format!("Subklass({})", args), None, Some(&locals))?;
 
     // Construct an instance of the sub-subclass
-    let sub_sub_obj = py.eval_bound(&format!("SubSubklass({})", args), None, Some(&locals))?;
+    let sub_sub_obj = py.eval(&format!("SubSubklass({})", args), None, Some(&locals))?;
 
     Ok((obj, sub_obj, sub_sub_obj))
 }
@@ -125,7 +125,7 @@ fn test_datetime_utc() {
         let locals = [("dt", dt)].into_py_dict(py);
 
         let offset: f32 = py
-            .eval_bound("dt.utcoffset().total_seconds()", None, Some(&locals))
+            .eval("dt.utcoffset().total_seconds()", None, Some(&locals))
             .unwrap()
             .extract()
             .unwrap();

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -511,7 +511,7 @@ fn test_from_py_with() {
     Python::with_gil(|py| {
         let py_zap = py
             .eval(
-                r#"{"name": "whatever", "my_object": [1, 2, 3]}"#,
+                pyo3_ffi::c_str!(r#"{"name": "whatever", "my_object": [1, 2, 3]}"#),
                 None,
                 None,
             )
@@ -534,7 +534,7 @@ pub struct ZapTuple(
 fn test_from_py_with_tuple_struct() {
     Python::with_gil(|py| {
         let py_zap = py
-            .eval(r#"("whatever", [1, 2, 3])"#, None, None)
+            .eval(pyo3_ffi::c_str!(r#"("whatever", [1, 2, 3])"#), None, None)
             .expect("failed to create tuple");
 
         let zap = py_zap.extract::<ZapTuple>().unwrap();
@@ -548,7 +548,11 @@ fn test_from_py_with_tuple_struct() {
 fn test_from_py_with_tuple_struct_error() {
     Python::with_gil(|py| {
         let py_zap = py
-            .eval(r#"("whatever", [1, 2, 3], "third")"#, None, None)
+            .eval(
+                pyo3_ffi::c_str!(r#"("whatever", [1, 2, 3], "third")"#),
+                None,
+                None,
+            )
             .expect("failed to create tuple");
 
         let f = py_zap.extract::<ZapTuple>();
@@ -574,7 +578,7 @@ pub enum ZapEnum {
 fn test_from_py_with_enum() {
     Python::with_gil(|py| {
         let py_zap = py
-            .eval(r#"("whatever", [1, 2, 3])"#, None, None)
+            .eval(pyo3_ffi::c_str!(r#"("whatever", [1, 2, 3])"#), None, None)
             .expect("failed to create tuple");
 
         let zap = py_zap.extract::<ZapEnum>().unwrap();

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -510,7 +510,7 @@ pub struct Zap {
 fn test_from_py_with() {
     Python::with_gil(|py| {
         let py_zap = py
-            .eval_bound(
+            .eval(
                 r#"{"name": "whatever", "my_object": [1, 2, 3]}"#,
                 None,
                 None,
@@ -534,7 +534,7 @@ pub struct ZapTuple(
 fn test_from_py_with_tuple_struct() {
     Python::with_gil(|py| {
         let py_zap = py
-            .eval_bound(r#"("whatever", [1, 2, 3])"#, None, None)
+            .eval(r#"("whatever", [1, 2, 3])"#, None, None)
             .expect("failed to create tuple");
 
         let zap = py_zap.extract::<ZapTuple>().unwrap();
@@ -548,7 +548,7 @@ fn test_from_py_with_tuple_struct() {
 fn test_from_py_with_tuple_struct_error() {
     Python::with_gil(|py| {
         let py_zap = py
-            .eval_bound(r#"("whatever", [1, 2, 3], "third")"#, None, None)
+            .eval(r#"("whatever", [1, 2, 3], "third")"#, None, None)
             .expect("failed to create tuple");
 
         let f = py_zap.extract::<ZapTuple>();
@@ -574,7 +574,7 @@ pub enum ZapEnum {
 fn test_from_py_with_enum() {
     Python::with_gil(|py| {
         let py_zap = py
-            .eval_bound(r#"("whatever", [1, 2, 3])"#, None, None)
+            .eval(r#"("whatever", [1, 2, 3])"#, None, None)
             .expect("failed to create tuple");
 
         let zap = py_zap.extract::<ZapEnum>().unwrap();

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -117,7 +117,7 @@ fn gc_integration() {
     });
 
     Python::with_gil(|py| {
-        py.run_bound("import gc; gc.collect()", None, None).unwrap();
+        py.run("import gc; gc.collect()", None, None).unwrap();
         assert!(drop_called.load(Ordering::Relaxed));
     });
 }
@@ -156,7 +156,7 @@ fn gc_null_traversal() {
         obj.borrow_mut(py).cycle = Some(obj.clone_ref(py));
 
         // the object doesn't have to be cleaned up, it just needs to be traversed.
-        py.run_bound("import gc; gc.collect()", None, None).unwrap();
+        py.run("import gc; gc.collect()", None, None).unwrap();
     });
 }
 
@@ -471,7 +471,7 @@ fn drop_during_traversal_with_gil() {
     // (but not too many) collections to get `inst` actually dropped.
     for _ in 0..10 {
         Python::with_gil(|py| {
-            py.run_bound("import gc; gc.collect()", None, None).unwrap();
+            py.run("import gc; gc.collect()", None, None).unwrap();
         });
     }
     assert!(drop_called.load(Ordering::Relaxed));
@@ -505,7 +505,7 @@ fn drop_during_traversal_without_gil() {
     // (but not too many) collections to get `inst` actually dropped.
     for _ in 0..10 {
         Python::with_gil(|py| {
-            py.run_bound("import gc; gc.collect()", None, None).unwrap();
+            py.run("import gc; gc.collect()", None, None).unwrap();
         });
     }
     assert!(drop_called.load(Ordering::Relaxed));

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -2,6 +2,7 @@
 
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
+use pyo3::ffi;
 use pyo3::prelude::*;
 use pyo3::py_run;
 use std::cell::Cell;
@@ -117,7 +118,8 @@ fn gc_integration() {
     });
 
     Python::with_gil(|py| {
-        py.run("import gc; gc.collect()", None, None).unwrap();
+        py.run(ffi::c_str!("import gc; gc.collect()"), None, None)
+            .unwrap();
         assert!(drop_called.load(Ordering::Relaxed));
     });
 }
@@ -156,7 +158,8 @@ fn gc_null_traversal() {
         obj.borrow_mut(py).cycle = Some(obj.clone_ref(py));
 
         // the object doesn't have to be cleaned up, it just needs to be traversed.
-        py.run("import gc; gc.collect()", None, None).unwrap();
+        py.run(ffi::c_str!("import gc; gc.collect()"), None, None)
+            .unwrap();
     });
 }
 
@@ -471,7 +474,8 @@ fn drop_during_traversal_with_gil() {
     // (but not too many) collections to get `inst` actually dropped.
     for _ in 0..10 {
         Python::with_gil(|py| {
-            py.run("import gc; gc.collect()", None, None).unwrap();
+            py.run(ffi::c_str!("import gc; gc.collect()"), None, None)
+                .unwrap();
         });
     }
     assert!(drop_called.load(Ordering::Relaxed));
@@ -505,7 +509,8 @@ fn drop_during_traversal_without_gil() {
     // (but not too many) collections to get `inst` actually dropped.
     for _ in 0..10 {
         Python::with_gil(|py| {
-            py.run("import gc; gc.collect()", None, None).unwrap();
+            py.run(ffi::c_str!("import gc; gc.collect()"), None, None)
+                .unwrap();
         });
     }
     assert!(drop_called.load(Ordering::Relaxed));

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -244,7 +244,7 @@ mod inheriting_native_type {
             let dict_sub = pyo3::Py::new(py, DictWithName::new()).unwrap();
             assert_eq!(dict_sub.get_refcnt(py), 1);
 
-            let item = &py.eval_bound("object()", None, None).unwrap();
+            let item = &py.eval("object()", None, None).unwrap();
             assert_eq!(item.get_refcnt(), 1);
 
             dict_sub.bind(py).set_item("foo", item).unwrap();

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -3,6 +3,7 @@
 use pyo3::prelude::*;
 use pyo3::py_run;
 
+use pyo3::ffi;
 use pyo3::types::IntoPyDict;
 
 #[path = "../src/tests/common.rs"]
@@ -23,7 +24,7 @@ fn subclass() {
         let d = [("SubclassAble", py.get_type::<SubclassAble>())].into_py_dict(py);
 
         py.run(
-            "class A(SubclassAble): pass\nassert issubclass(A, SubclassAble)",
+            ffi::c_str!("class A(SubclassAble): pass\nassert issubclass(A, SubclassAble)"),
             None,
             Some(&d),
         )
@@ -100,7 +101,7 @@ fn mutation_fails() {
         let global = [("obj", obj)].into_py_dict(py);
         let e = py
             .run(
-                "obj.base_set(lambda: obj.sub_set_and_ret(1))",
+                ffi::c_str!("obj.base_set(lambda: obj.sub_set_and_ret(1))"),
                 Some(&global),
                 None,
             )
@@ -244,7 +245,7 @@ mod inheriting_native_type {
             let dict_sub = pyo3::Py::new(py, DictWithName::new()).unwrap();
             assert_eq!(dict_sub.get_refcnt(py), 1);
 
-            let item = &py.eval("object()", None, None).unwrap();
+            let item = &py.eval(ffi::c_str!("object()"), None, None).unwrap();
             assert_eq!(item.get_refcnt(), 1);
 
             dict_sub.bind(py).set_item("foo", item).unwrap();
@@ -277,7 +278,7 @@ mod inheriting_native_type {
             let cls = py.get_type::<CustomException>();
             let dict = [("cls", &cls)].into_py_dict(py);
             let res = py.run(
-            "e = cls('hello'); assert str(e) == 'hello'; assert e.context == 'Hello :)'; raise e",
+            ffi::c_str!("e = cls('hello'); assert str(e) == 'hello'; assert e.context == 'Hello :)'; raise e"),
             None,
             Some(&dict)
             );

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -22,7 +22,7 @@ fn subclass() {
     Python::with_gil(|py| {
         let d = [("SubclassAble", py.get_type::<SubclassAble>())].into_py_dict(py);
 
-        py.run_bound(
+        py.run(
             "class A(SubclassAble): pass\nassert issubclass(A, SubclassAble)",
             None,
             Some(&d),
@@ -99,7 +99,7 @@ fn mutation_fails() {
         let obj = Py::new(py, SubClass::new()).unwrap();
         let global = [("obj", obj)].into_py_dict(py);
         let e = py
-            .run_bound(
+            .run(
                 "obj.base_set(lambda: obj.sub_set_and_ret(1))",
                 Some(&global),
                 None,
@@ -276,7 +276,7 @@ mod inheriting_native_type {
         Python::with_gil(|py| {
             let cls = py.get_type::<CustomException>();
             let dict = [("cls", &cls)].into_py_dict(py);
-            let res = py.run_bound(
+            let res = py.run(
             "e = cls('hello'); assert str(e) == 'hello'; assert e.context == 'Hello :)'; raise e",
             None,
             Some(&dict)

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -685,7 +685,7 @@ asyncio.run(main())
 "#;
         let globals = PyModule::import(py, "__main__").unwrap().dict();
         globals.set_item("Once", once).unwrap();
-        py.run_bound(source, Some(&globals), None)
+        py.run(source, Some(&globals), None)
             .map_err(|e| e.display(py))
             .unwrap();
     });
@@ -742,7 +742,7 @@ asyncio.run(main())
         globals
             .set_item("AsyncIterator", py.get_type::<AsyncIterator>())
             .unwrap();
-        py.run_bound(source, Some(&globals), None)
+        py.run(source, Some(&globals), None)
             .map_err(|e| e.display(py))
             .unwrap();
     });
@@ -811,7 +811,7 @@ assert c.counter.count == 1
         );
         let globals = PyModule::import(py, "__main__").unwrap().dict();
         globals.set_item("Counter", counter).unwrap();
-        py.run_bound(source, Some(&globals), None)
+        py.run(source, Some(&globals), None)
             .map_err(|e| e.display(py))
             .unwrap();
     });

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -669,7 +669,8 @@ impl OnceFuture {
 fn test_await() {
     Python::with_gil(|py| {
         let once = py.get_type::<OnceFuture>();
-        let source = r#"
+        let source = pyo3_ffi::c_str!(
+            r#"
 import asyncio
 import sys
 
@@ -682,7 +683,8 @@ if sys.platform == "win32" and sys.version_info >= (3, 8, 0):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 asyncio.run(main())
-"#;
+"#
+        );
         let globals = PyModule::import(py, "__main__").unwrap().dict();
         globals.set_item("Once", once).unwrap();
         py.run(source, Some(&globals), None)
@@ -719,7 +721,8 @@ impl AsyncIterator {
 fn test_anext_aiter() {
     Python::with_gil(|py| {
         let once = py.get_type::<OnceFuture>();
-        let source = r#"
+        let source = pyo3_ffi::c_str!(
+            r#"
 import asyncio
 import sys
 
@@ -736,7 +739,8 @@ if sys.platform == "win32" and sys.version_info >= (3, 8, 0):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 asyncio.run(main())
-"#;
+"#
+        );
         let globals = PyModule::import(py, "__main__").unwrap().dict();
         globals.set_item("Once", once).unwrap();
         globals
@@ -784,7 +788,7 @@ impl DescrCounter {
 fn descr_getset() {
     Python::with_gil(|py| {
         let counter = py.get_type::<DescrCounter>();
-        let source = pyo3::indoc::indoc!(
+        let source = pyo3_ffi::c_str!(pyo3::indoc::indoc!(
             r#"
 class Class:
     counter = Counter()
@@ -808,7 +812,7 @@ assert c.counter.count == 4
 del c.counter
 assert c.counter.count == 1
 "#
-        );
+        ));
         let globals = PyModule::import(py, "__main__").unwrap().dict();
         globals.set_item("Counter", counter).unwrap();
         py.run(source, Some(&globals), None)


### PR DESCRIPTION
Should we also change `code` to a `&CStr` for both of these?