### PR TITLE
ci: fix nightly warning about unreachable pattern

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -126,6 +126,7 @@ impl<T> GILOnceCell<T> {
             return value;
         }
 
+        // .unwrap() will never panic because the result is always Ok
         self.init(py, || Ok::<T, std::convert::Infallible>(f()))
             .unwrap()
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -126,10 +126,8 @@ impl<T> GILOnceCell<T> {
             return value;
         }
 
-        match self.init(py, || Ok::<T, std::convert::Infallible>(f())) {
-            Ok(value) => value,
-            Err(void) => match void {},
-        }
+        self.init(py, || Ok::<T, std::convert::Infallible>(f()))
+            .unwrap()
     }
 
     /// Like `get_or_init`, but accepts a fallible initialization function. If it fails, the cell


### PR DESCRIPTION
Unwrapping here seems fine, especially as `GILOnceCell` needs to be re-thought for free threading soon anyway.