### PR TITLE
restore derive(Debug) for ffi types where it was removed

### DIFF
--- a/pyo3-ffi/src/cpython/object.rs
+++ b/pyo3-ffi/src/cpython/object.rs
@@ -205,6 +205,7 @@ pub type printfunc =
     unsafe extern "C" fn(arg1: *mut PyObject, arg2: *mut ::libc::FILE, arg3: c_int) -> c_int;
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct PyTypeObject {
     #[cfg(all(PyPy, not(Py_3_9)))]
     pub ob_refcnt: Py_ssize_t,

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -27,6 +27,7 @@ const _PyDateTime_TIME_DATASIZE: usize = 6;
 const _PyDateTime_DATETIME_DATASIZE: usize = 10;
 
 #[repr(C)]
+#[derive(Debug)]
 /// Structure representing a `datetime.timedelta`.
 pub struct PyDateTime_Delta {
     pub ob_base: PyObject,
@@ -45,6 +46,7 @@ pub struct PyDateTime_Delta {
 
 #[cfg(not(any(PyPy, GraalPy)))]
 #[repr(C)]
+#[derive(Debug)]
 /// Structure representing a `datetime.time` without a `tzinfo` member.
 pub struct _PyDateTime_BaseTime {
     pub ob_base: PyObject,
@@ -54,6 +56,7 @@ pub struct _PyDateTime_BaseTime {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 /// Structure representing a `datetime.time`.
 pub struct PyDateTime_Time {
     pub ob_base: PyObject,
@@ -74,6 +77,7 @@ pub struct PyDateTime_Time {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 /// Structure representing a `datetime.date`
 pub struct PyDateTime_Date {
     pub ob_base: PyObject,
@@ -87,6 +91,7 @@ pub struct PyDateTime_Date {
 
 #[cfg(not(any(PyPy, GraalPy)))]
 #[repr(C)]
+#[derive(Debug)]
 /// Structure representing a `datetime.datetime` without a `tzinfo` member.
 pub struct _PyDateTime_BaseDateTime {
     pub ob_base: PyObject,
@@ -96,6 +101,7 @@ pub struct _PyDateTime_BaseDateTime {
 }
 
 #[repr(C)]
+#[derive(Debug)]
 /// Structure representing a `datetime.datetime`.
 pub struct PyDateTime_DateTime {
     pub ob_base: PyObject,


### PR DESCRIPTION
I was looking over #4434 and realized I incorrectly removed `Debug` from a number of structs in the ffi in that PR. This restores it.