### PR TITLE
Make `PyDict` iterator compatible with free-threaded build

### DIFF
--- a/newsfragments/4439.changed.md
+++ b/newsfragments/4439.changed.md
@@ -1,0 +1,3 @@
+* Make `PyDict` iterator compatible with free-threaded build
+* Added `PyDict::locked_for_each` method to iterate on free-threaded builds to prevent the dict being mutated during iteration
+* Iterate over `dict.items()` when dict is subclassed from `PyDict`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![warn(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(auto_traits, negative_impls))]
+#![cfg_attr(
+    feature = "nightly",
+    feature(auto_traits, negative_impls, try_trait_v2)
+)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 // Deny some lints in doctests.
 // Use `#[allow(...)]` locally to override.

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -436,7 +436,8 @@ impl ExactSizeIterator for BoundDictIterator<'_> {
 impl<'py> BoundDictIterator<'py> {
     fn new(dict: Bound<'py, PyDict>) -> Self {
         let remaining = dict_len(&dict) as usize;
-        let iter = PyIterator::from_object(&dict.items()).unwrap();
+        let items = dict.call_method0(intern!(dict.py(), "items")).unwrap();
+        let iter = PyIterator::from_object(&items).unwrap();
 
         BoundDictIterator { iter, remaining }
     }

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -184,6 +184,11 @@ pub trait PyDictMethods<'py>: crate::sealed::Sealed {
     /// This is useful when the GIL is disabled and the dictionary is shared between threads.
     /// It is not guaranteed that the dictionary will not be modified during iteration when the
     /// closure calls arbitrary Python code that releases the current critical section.
+    ///
+    /// This method is a small performance optimization over `.iter().try_for_each()` when the
+    /// nightly feature is not enabled because we cannot implement an optimised version of
+    /// `iter().try_fold()` on stable yet. If your iteration is infallible then this method has the
+    /// same performance as `.iter().for_each()`.
     fn locked_for_each<F>(&self, closure: F) -> PyResult<()>
     where
         F: Fn(Bound<'py, PyAny>, Bound<'py, PyAny>) -> PyResult<()>;


### PR DESCRIPTION
This pulls in the `PyCriticalSection_Begin` & `PyCriticalSection_End` functions new in 3.13 and use it to lock the PyDict iterators as d 
described [here](https://docs.python.org/3.13/howto/free-threading-extensions.html#pydict-next). I'm not sure about the `PyCriticalSection` struct definition. We cannot use the `opaque_struct!` macro to define this struct because we have to allocate enough space on the stack so we can pass the uninitialized  pointer to `PyCriticalSection_Begin`. So some help would be appreciated!

depends on #4421 
related to #4265