### PR TITLE
remove some `methods` impl details from public API

### DIFF
--- a/newsfragments/4441.changed.md
+++ b/newsfragments/4441.changed.md
@@ -1,0 +1,1 @@
+Deprecate `IPowModulo`, `PyClassAttributeDef`, `PyGetterDef`, `PyMethodDef`, `PyMethodDefType`, and `PySetterDef` from PyO3's public API.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1541,8 +1541,8 @@ pub fn gen_complex_enum_variant_attr(
 
     let method_def = quote! {
         #pyo3_path::impl_::pyclass::MaybeRuntimePyMethodDef::Static(
-            #pyo3_path::class::PyMethodDefType::ClassAttribute({
-                #pyo3_path::class::PyClassAttributeDef::new(
+            #pyo3_path::impl_::pymethods::PyMethodDefType::ClassAttribute({
+                #pyo3_path::impl_::pymethods::PyClassAttributeDef::new(
                     #python_name,
                     #cls_type::#wrapper_ident
                 )

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -219,8 +219,8 @@ pub fn gen_py_const(cls: &syn::Type, spec: &ConstSpec, ctx: &Ctx) -> MethodAndMe
 
     let method_def = quote! {
         #pyo3_path::impl_::pyclass::MaybeRuntimePyMethodDef::Static(
-            #pyo3_path::class::PyMethodDefType::ClassAttribute({
-                #pyo3_path::class::PyClassAttributeDef::new(
+            #pyo3_path::impl_::pymethods::PyMethodDefType::ClassAttribute({
+                #pyo3_path::impl_::pymethods::PyClassAttributeDef::new(
                     #python_name,
                     #cls::#wrapper_ident
                 )

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -330,7 +330,7 @@ pub fn impl_py_method_def(
     let methoddef = spec.get_methoddef(quote! { #cls::#wrapper_ident }, doc, ctx);
     let method_def = quote! {
         #pyo3_path::impl_::pyclass::MaybeRuntimePyMethodDef::Static(
-            #pyo3_path::class::PyMethodDefType::#methoddef_type(#methoddef #add_flags)
+            #pyo3_path::impl_::pymethods::PyMethodDefType::#methoddef_type(#methoddef #add_flags)
         )
     };
     Ok(MethodAndMethodDef {
@@ -510,8 +510,8 @@ fn impl_py_class_attribute(
 
     let method_def = quote! {
         #pyo3_path::impl_::pyclass::MaybeRuntimePyMethodDef::Static(
-            #pyo3_path::class::PyMethodDefType::ClassAttribute({
-                #pyo3_path::class::PyClassAttributeDef::new(
+            #pyo3_path::impl_::pymethods::PyMethodDefType::ClassAttribute({
+                #pyo3_path::impl_::pymethods::PyClassAttributeDef::new(
                     #python_name,
                     #cls::#wrapper_ident
                 )
@@ -691,8 +691,8 @@ pub fn impl_py_setter_def(
     let method_def = quote! {
         #cfg_attrs
         #pyo3_path::impl_::pyclass::MaybeRuntimePyMethodDef::Static(
-            #pyo3_path::class::PyMethodDefType::Setter(
-                #pyo3_path::class::PySetterDef::new(
+            #pyo3_path::impl_::pymethods::PyMethodDefType::Setter(
+                #pyo3_path::impl_::pymethods::PySetterDef::new(
                     #python_name,
                     #cls::#wrapper_ident,
                     #doc
@@ -826,8 +826,8 @@ pub fn impl_py_getter_def(
             let method_def = quote! {
                 #cfg_attrs
                 #pyo3_path::impl_::pyclass::MaybeRuntimePyMethodDef::Static(
-                    #pyo3_path::class::PyMethodDefType::Getter(
-                        #pyo3_path::class::PyGetterDef::new(
+                    #pyo3_path::impl_::pymethods::PyMethodDefType::Getter(
+                        #pyo3_path::impl_::pymethods::PyGetterDef::new(
                             #python_name,
                             #cls::#wrapper_ident,
                             #doc

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1,12 +1,14 @@
 use crate::{
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError, PyValueError},
     ffi,
-    impl_::freelist::FreeList,
-    impl_::pycell::{GetBorrowChecker, PyClassMutability, PyClassObjectLayout},
+    impl_::{
+        freelist::FreeList,
+        pycell::{GetBorrowChecker, PyClassMutability, PyClassObjectLayout},
+        pymethods::{PyGetterDef, PyMethodDefType},
+    },
     pyclass_init::PyObjectInit,
     types::{any::PyAnyMethods, PyBool},
-    Borrowed, IntoPy, Py, PyAny, PyClass, PyErr, PyMethodDefType, PyResult, PyTypeInfo, Python,
-    ToPyObject,
+    Borrowed, IntoPy, Py, PyAny, PyClass, PyErr, PyResult, PyTypeInfo, Python, ToPyObject,
 };
 use std::{
     borrow::Cow,
@@ -1249,7 +1251,7 @@ impl<
                 doc: doc.as_ptr(),
             })
         } else {
-            PyMethodDefType::Getter(crate::PyGetterDef {
+            PyMethodDefType::Getter(PyGetterDef {
                 name,
                 meth: pyo3_get_value_topyobject::<ClassT, Py<U>, Offset>,
                 doc,
@@ -1263,7 +1265,7 @@ impl<ClassT: PyClass, FieldT: ToPyObject, Offset: OffsetCalculator<ClassT, Field
     PyClassGetterGenerator<ClassT, FieldT, Offset, false, true>
 {
     pub const fn generate(&self, name: &'static CStr, doc: &'static CStr) -> PyMethodDefType {
-        PyMethodDefType::Getter(crate::PyGetterDef {
+        PyMethodDefType::Getter(PyGetterDef {
             name,
             meth: pyo3_get_value_topyobject::<ClassT, FieldT, Offset>,
             doc,
@@ -1292,7 +1294,7 @@ impl<ClassT: PyClass, FieldT, Offset: OffsetCalculator<ClassT, FieldT>>
     where
         FieldT: PyO3GetField,
     {
-        PyMethodDefType::Getter(crate::PyGetterDef {
+        PyMethodDefType::Getter(PyGetterDef {
             name,
             meth: pyo3_get_value::<ClassT, FieldT, Offset>,
             doc,

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -9,10 +9,11 @@ use crate::{
     exceptions::PyRuntimeError,
     ffi,
     impl_::pyclass::MaybeRuntimePyMethodDef,
+    impl_::pymethods::PyMethodDefType,
     pyclass::{create_type_object, PyClassTypeObject},
     sync::{GILOnceCell, GILProtected},
     types::PyType,
-    Bound, PyClass, PyErr, PyMethodDefType, PyObject, PyResult, Python,
+    Bound, PyClass, PyErr, PyObject, PyResult, Python,
 };
 
 use super::PyClassItemsIter;

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -21,9 +21,10 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use crate::exceptions::PyImportError;
 use crate::{
     ffi,
+    impl_::pymethods::PyMethodDef,
     sync::GILOnceCell,
     types::{PyCFunction, PyModule, PyModuleMethods},
-    Bound, Py, PyClass, PyMethodDef, PyResult, PyTypeInfo, Python,
+    Bound, Py, PyClass, PyResult, PyTypeInfo, Python,
 };
 
 /// `Sync` wrapper of `ffi::PyModuleDef`.

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -12,7 +12,7 @@ use std::{
 use crate::gil::GILGuard;
 use crate::{
     callback::PyCallbackOutput, ffi, ffi_ptr_ext::FfiPtrExt, impl_::panic::PanicTrap,
-    methods::IPowModulo, panic::PanicException, types::PyModule, Py, PyResult, Python,
+    impl_::pymethods::IPowModulo, panic::PanicException, types::PyModule, Py, PyResult, Python,
 };
 
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,19 +343,24 @@ pub(crate) mod sealed;
 pub mod class {
     pub use self::gc::{PyTraverseError, PyVisit};
 
-    #[doc(hidden)]
-    pub use self::methods::{
-        PyClassAttributeDef, PyGetterDef, PyMethodDef, PyMethodDefType, PyMethodType, PySetterDef,
-    };
+    pub use self::methods::*;
 
     #[doc(hidden)]
     pub mod methods {
-        // frozen with the contents of the `impl_::pymethods` module in 0.20,
-        // this should probably all be replaced with deprecated type aliases and removed.
-        pub use crate::impl_::pymethods::{
-            IPowModulo, PyClassAttributeDef, PyGetterDef, PyMethodDef, PyMethodDefType,
-            PyMethodType, PySetterDef,
-        };
+        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
+        pub type IPowModulo = crate::impl_::pymethods::IPowModulo;
+        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
+        pub type PyClassAttributeDef = crate::impl_::pymethods::PyClassAttributeDef;
+        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
+        pub type PyGetterDef = crate::impl_::pymethods::PyGetterDef;
+        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
+        pub type PyMethodDef = crate::impl_::pymethods::PyMethodDef;
+        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
+        pub type PyMethodDefType = crate::impl_::pymethods::PyMethodDefType;
+        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
+        pub type PyMethodType = crate::impl_::pymethods::PyMethodType;
+        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
+        pub type PySetterDef = crate::impl_::pymethods::PySetterDef;
     }
 
     /// Old module which contained some implementation details of the `#[pyproto]` module.

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -7,12 +7,12 @@ use crate::{
             assign_sequence_item_from_mapping, get_sequence_item_from_mapping, tp_dealloc,
             tp_dealloc_with_gc, MaybeRuntimePyMethodDef, PyClassItemsIter,
         },
-        pymethods::{Getter, Setter},
+        pymethods::{Getter, PyGetterDef, PyMethodDefType, PySetterDef, Setter},
         trampoline::trampoline,
     },
     internal_tricks::ptr_from_ref,
     types::{typeobject::PyTypeMethods, PyType},
-    Py, PyClass, PyGetterDef, PyMethodDefType, PyResult, PySetterDef, PyTypeInfo, Python,
+    Py, PyClass, PyResult, PyTypeInfo, Python,
 };
 use std::{
     collections::HashMap,


### PR DESCRIPTION
A cleanup I've wanted to do for a while, which makes it easier to remove / rework these pieces in the future.