### PR TITLE
Add more `IntoPyObject` impls

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -291,6 +291,16 @@ impl<'a, 'py, T> IntoPyObject<'py> for Borrowed<'a, 'py, T> {
     }
 }
 
+impl<'a, 'py, T> IntoPyObject<'py> for &Borrowed<'a, 'py, T> {
+    type Target = T;
+    type Output = Borrowed<'a, 'py, Self::Target>;
+    type Error = Infallible;
+
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(*self)
+    }
+}
+
 impl<'py, T> IntoPyObject<'py> for Py<T> {
     type Target = T;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -152,6 +152,20 @@ impl<'py> IntoPyObject<'py> for Duration {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &Duration {
+    #[cfg(Py_LIMITED_API)]
+    type Target = PyAny;
+    #[cfg(not(Py_LIMITED_API))]
+    type Target = PyDelta;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
+    }
+}
+
 impl FromPyObject<'_> for Duration {
     fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Duration> {
         // Python size are much lower than rust size so we do not need bound checks.
@@ -228,6 +242,20 @@ impl<'py> IntoPyObject<'py> for NaiveDate {
         {
             DatetimeTypes::try_get(py).and_then(|dt| dt.date.bind(py).call1((year, month, day)))
         }
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &NaiveDate {
+    #[cfg(Py_LIMITED_API)]
+    type Target = PyAny;
+    #[cfg(not(Py_LIMITED_API))]
+    type Target = PyDate;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 
@@ -309,6 +337,20 @@ impl<'py> IntoPyObject<'py> for NaiveTime {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &NaiveTime {
+    #[cfg(Py_LIMITED_API)]
+    type Target = PyAny;
+    #[cfg(not(Py_LIMITED_API))]
+    type Target = PyTime;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
+    }
+}
+
 impl FromPyObject<'_> for NaiveTime {
     fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<NaiveTime> {
         #[cfg(not(Py_LIMITED_API))]
@@ -372,6 +414,20 @@ impl<'py> IntoPyObject<'py> for NaiveDateTime {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &NaiveDateTime {
+    #[cfg(Py_LIMITED_API)]
+    type Target = PyAny;
+    #[cfg(not(Py_LIMITED_API))]
+    type Target = PyDateTime;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
+    }
+}
+
 impl FromPyObject<'_> for NaiveDateTime {
     fn extract_bound(dt: &Bound<'_, PyAny>) -> PyResult<NaiveDateTime> {
         #[cfg(not(Py_LIMITED_API))]
@@ -412,6 +468,20 @@ impl<Tz: TimeZone> IntoPy<PyObject> for DateTime<Tz> {
 }
 
 impl<'py, Tz: TimeZone> IntoPyObject<'py> for DateTime<Tz> {
+    #[cfg(Py_LIMITED_API)]
+    type Target = PyAny;
+    #[cfg(not(Py_LIMITED_API))]
+    type Target = PyDateTime;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (&self).into_pyobject(py)
+    }
+}
+
+impl<'py, Tz: TimeZone> IntoPyObject<'py> for &DateTime<Tz> {
     #[cfg(Py_LIMITED_API)]
     type Target = PyAny;
     #[cfg(not(Py_LIMITED_API))]
@@ -531,6 +601,20 @@ impl<'py> IntoPyObject<'py> for FixedOffset {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &FixedOffset {
+    #[cfg(Py_LIMITED_API)]
+    type Target = PyAny;
+    #[cfg(not(Py_LIMITED_API))]
+    type Target = PyTzInfo;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
+    }
+}
+
 impl FromPyObject<'_> for FixedOffset {
     /// Convert python tzinfo to rust [`FixedOffset`].
     ///
@@ -591,6 +675,20 @@ impl<'py> IntoPyObject<'py> for Utc {
         {
             Ok(timezone_utc_bound(py))
         }
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &Utc {
+    #[cfg(Py_LIMITED_API)]
+    type Target = PyAny;
+    #[cfg(not(Py_LIMITED_API))]
+    type Target = PyTzInfo;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -75,6 +75,17 @@ impl<'py> IntoPyObject<'py> for Tz {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &Tz {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
+    }
+}
+
 impl FromPyObject<'_> for Tz {
     fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Tz> {
         Tz::from_str(

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -45,20 +45,16 @@ use chrono_tz::Tz;
 use std::str::FromStr;
 
 impl ToPyObject for Tz {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        static ZONE_INFO: GILOnceCell<Py<PyType>> = GILOnceCell::new();
-        ZONE_INFO
-            .get_or_try_init_type_ref(py, "zoneinfo", "ZoneInfo")
-            .unwrap()
-            .call1((self.name(),))
-            .unwrap()
-            .unbind()
+        self.into_pyobject(py).unwrap().unbind()
     }
 }
 
 impl IntoPy<PyObject> for Tz {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().unbind()
     }
 }
 

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -67,12 +67,40 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "either")))]
-impl<'py, L, R, E1, E2> IntoPyObject<'py> for Either<L, R>
+impl<'py, L, R> IntoPyObject<'py> for Either<L, R>
 where
-    L: IntoPyObject<'py, Error = E1>,
-    R: IntoPyObject<'py, Error = E2>,
-    E1: Into<PyErr>,
-    E2: Into<PyErr>,
+    L: IntoPyObject<'py>,
+    R: IntoPyObject<'py>,
+    L::Error: Into<PyErr>,
+    R::Error: Into<PyErr>,
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self {
+            Either::Left(l) => l
+                .into_pyobject(py)
+                .map(BoundObject::into_any)
+                .map(BoundObject::into_bound)
+                .map_err(Into::into),
+            Either::Right(r) => r
+                .into_pyobject(py)
+                .map(BoundObject::into_any)
+                .map(BoundObject::into_bound)
+                .map_err(Into::into),
+        }
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "either")))]
+impl<'a, 'py, L, R> IntoPyObject<'py> for &'a Either<L, R>
+where
+    &'a L: IntoPyObject<'py>,
+    &'a R: IntoPyObject<'py>,
+    <&'a L as IntoPyObject<'py>>::Error: Into<PyErr>,
+    <&'a R as IntoPyObject<'py>>::Error: Into<PyErr>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -119,10 +119,33 @@ where
 
 impl<'py, K, V, H> IntoPyObject<'py> for indexmap::IndexMap<K, V, H>
 where
-    K: hash::Hash + cmp::Eq + IntoPyObject<'py>,
+    K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     V: IntoPyObject<'py>,
     H: hash::BuildHasher,
     PyErr: From<K::Error> + From<V::Error>,
+{
+    type Target = PyDict;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let dict = PyDict::new(py);
+        for (k, v) in self {
+            dict.set_item(
+                k.into_pyobject(py)?.into_bound(),
+                v.into_pyobject(py)?.into_bound(),
+            )?;
+        }
+        Ok(dict)
+    }
+}
+
+impl<'a, 'py, K, V, H> IntoPyObject<'py> for &'a indexmap::IndexMap<K, V, H>
+where
+    &'a K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
+    &'a V: IntoPyObject<'py>,
+    H: hash::BuildHasher,
+    PyErr: From<<&'a K as IntoPyObject<'py>>::Error> + From<<&'a V as IntoPyObject<'py>>::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -141,6 +141,18 @@ macro_rules! bigint_conversion {
             type Output = Bound<'py, Self::Target>;
             type Error = PyErr;
 
+            #[inline]
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                (&self).into_pyobject(py)
+            }
+        }
+
+        #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
+        impl<'py> IntoPyObject<'py> for &$rust_ty {
+            type Target = PyInt;
+            type Output = Bound<'py, Self::Target>;
+            type Error = PyErr;
+
             #[cfg(not(Py_LIMITED_API))]
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 use crate::ffi_ptr_ext::FfiPtrExt;

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -47,8 +47,6 @@
 //! assert n + 1 == value
 //! ```
 
-#[cfg(not(Py_LIMITED_API))]
-use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(Py_LIMITED_API)]
 use crate::types::{bytes::PyBytesMethods, PyBytes};
 use crate::{
@@ -69,69 +67,17 @@ macro_rules! bigint_conversion {
     ($rust_ty: ty, $is_signed: literal, $to_bytes: path) => {
         #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
         impl ToPyObject for $rust_ty {
-            #[cfg(not(Py_LIMITED_API))]
+            #[inline]
             fn to_object(&self, py: Python<'_>) -> PyObject {
-                let bytes = $to_bytes(self);
-                #[cfg(not(Py_3_13))]
-                {
-                    unsafe {
-                        ffi::_PyLong_FromByteArray(
-                            bytes.as_ptr().cast(),
-                            bytes.len(),
-                            1,
-                            $is_signed.into(),
-                        )
-                        .assume_owned(py)
-                        .unbind()
-                    }
-                }
-                #[cfg(Py_3_13)]
-                {
-                    if $is_signed {
-                        unsafe {
-                            ffi::PyLong_FromNativeBytes(
-                                bytes.as_ptr().cast(),
-                                bytes.len(),
-                                ffi::Py_ASNATIVEBYTES_LITTLE_ENDIAN,
-                            )
-                            .assume_owned(py)
-                        }
-                    } else {
-                        unsafe {
-                            ffi::PyLong_FromUnsignedNativeBytes(
-                                bytes.as_ptr().cast(),
-                                bytes.len(),
-                                ffi::Py_ASNATIVEBYTES_LITTLE_ENDIAN,
-                            )
-                            .assume_owned(py)
-                        }
-                    }
-                    .unbind()
-                }
-            }
-
-            #[cfg(Py_LIMITED_API)]
-            fn to_object(&self, py: Python<'_>) -> PyObject {
-                let bytes = $to_bytes(self);
-                let bytes_obj = PyBytes::new(py, &bytes);
-                let kwargs = if $is_signed {
-                    let kwargs = crate::types::PyDict::new(py);
-                    kwargs.set_item(crate::intern!(py, "signed"), true).unwrap();
-                    Some(kwargs)
-                } else {
-                    None
-                };
-                py.get_type::<PyInt>()
-                    .call_method("from_bytes", (bytes_obj, "little"), kwargs.as_ref())
-                    .expect("int.from_bytes() failed during to_object()") // FIXME: #1813 or similar
-                    .into()
+                self.into_pyobject(py).unwrap().into_any().unbind()
             }
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
         impl IntoPy<PyObject> for $rust_ty {
+            #[inline]
             fn into_py(self, py: Python<'_>) -> PyObject {
-                self.to_object(py)
+                self.into_pyobject(py).unwrap().into_any().unbind()
             }
         }
 

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -155,6 +155,18 @@ macro_rules! complex_conversion {
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
+        impl<'py> crate::conversion::IntoPyObject<'py> for &Complex<$float> {
+            type Target = PyComplex;
+            type Output = Bound<'py, Self::Target>;
+            type Error = std::convert::Infallible;
+
+            #[inline]
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                (*self).into_pyobject(py)
+            }
+        }
+
+        #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
         impl FromPyObject<'_> for Complex<$float> {
             fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Complex<$float>> {
                 #[cfg(not(any(Py_LIMITED_API, PyPy)))]

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -43,11 +43,14 @@
 //! assert fraction + 5 == fraction_plus_five
 //! ```
 
+use crate::conversion::IntoPyObject;
 use crate::ffi;
 use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
-use crate::{Bound, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject};
+use crate::{
+    Bound, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+};
 
 #[cfg(feature = "num-bigint")]
 use num_bigint::BigInt;
@@ -93,6 +96,27 @@ macro_rules! rational_conversion {
         impl IntoPy<PyObject> for Ratio<$int> {
             fn into_py(self, py: Python<'_>) -> PyObject {
                 self.to_object(py)
+            }
+        }
+
+        impl<'py> IntoPyObject<'py> for Ratio<$int> {
+            type Target = PyAny;
+            type Output = Bound<'py, Self::Target>;
+            type Error = PyErr;
+
+            #[inline]
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                (&self).into_pyobject(py)
+            }
+        }
+
+        impl<'py> IntoPyObject<'py> for &Ratio<$int> {
+            type Target = PyAny;
+            type Output = Bound<'py, Self::Target>;
+            type Error = PyErr;
+
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                get_fraction_cls(py)?.call1((self.numer().clone(), self.denom().clone()))
             }
         }
     };

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -85,17 +85,15 @@ macro_rules! rational_conversion {
         }
 
         impl ToPyObject for Ratio<$int> {
+            #[inline]
             fn to_object(&self, py: Python<'_>) -> PyObject {
-                let fraction_cls = get_fraction_cls(py).expect("failed to load fractions.Fraction");
-                let ret = fraction_cls
-                    .call1((self.numer().clone(), self.denom().clone()))
-                    .expect("failed to call fractions.Fraction(value)");
-                ret.to_object(py)
+                self.into_pyobject(py).unwrap().into_any().unbind()
             }
         }
         impl IntoPy<PyObject> for Ratio<$int> {
+            #[inline]
             fn into_py(self, py: Python<'_>) -> PyObject {
-                self.to_object(py)
+                self.into_pyobject(py).unwrap().into_any().unbind()
             }
         }
 

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -115,6 +115,17 @@ impl<'py> IntoPyObject<'py> for Decimal {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &Decimal {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
+    }
+}
+
 #[cfg(test)]
 mod test_rust_decimal {
     use super::*;

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -83,22 +83,16 @@ fn get_decimal_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
 }
 
 impl ToPyObject for Decimal {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        // TODO: handle error gracefully when ToPyObject can error
-        // look up the decimal.Decimal
-        let dec_cls = get_decimal_cls(py).expect("failed to load decimal.Decimal");
-        // now call the constructor with the Rust Decimal string-ified
-        // to not be lossy
-        let ret = dec_cls
-            .call1((self.to_string(),))
-            .expect("failed to call decimal.Decimal(value)");
-        ret.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for Decimal {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -76,6 +76,22 @@ where
     }
 }
 
+impl<'a, 'py, A> IntoPyObject<'py> for &'a SmallVec<A>
+where
+    A: Array,
+    &'a A::Item: IntoPyObject<'py>,
+    PyErr: From<<&'a A::Item as IntoPyObject<'py>>::Error>,
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        self.as_slice().into_pyobject(py)
+    }
+}
+
 impl<'py, A> FromPyObject<'py> for SmallVec<A>
 where
     A: Array,

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -56,6 +56,21 @@ where
     }
 }
 
+impl<'a, 'py, T, const N: usize> IntoPyObject<'py> for &'a [T; N]
+where
+    &'a T: IntoPyObject<'py>,
+    PyErr: From<<&'a T as IntoPyObject<'py>>::Error>,
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        self.as_slice().into_pyobject(py)
+    }
+}
+
 impl<T, const N: usize> ToPyObject for [T; N]
 where
     T: ToPyObject,

--- a/src/conversions/std/cell.rs
+++ b/src/conversions/std/cell.rs
@@ -22,6 +22,18 @@ impl<'py, T: Copy + IntoPyObject<'py>> IntoPyObject<'py> for Cell<T> {
     type Output = T::Output;
     type Error = T::Error;
 
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        self.get().into_pyobject(py)
+    }
+}
+
+impl<'a, 'py, T: Copy + IntoPyObject<'py>> IntoPyObject<'py> for &'a Cell<T> {
+    type Target = T::Target;
+    type Output = T::Output;
+    type Error = T::Error;
+
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.get().into_pyobject(py)
     }

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -32,14 +32,9 @@ impl FromPyObject<'_> for IpAddr {
 }
 
 impl ToPyObject for Ipv4Addr {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        static IPV4_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
-        IPV4_ADDRESS
-            .get_or_try_init_type_ref(py, "ipaddress", "IPv4Address")
-            .expect("failed to load ipaddress.IPv4Address")
-            .call1((u32::from_be_bytes(self.octets()),))
-            .expect("failed to construct ipaddress.IPv4Address")
-            .unbind()
+        self.into_pyobject(py).unwrap().unbind()
     }
 }
 
@@ -68,14 +63,9 @@ impl<'py> IntoPyObject<'py> for &Ipv4Addr {
 }
 
 impl ToPyObject for Ipv6Addr {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        static IPV6_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
-        IPV6_ADDRESS
-            .get_or_try_init_type_ref(py, "ipaddress", "IPv6Address")
-            .expect("failed to load ipaddress.IPv6Address")
-            .call1((u128::from_be_bytes(self.octets()),))
-            .expect("failed to construct ipaddress.IPv6Address")
-            .unbind()
+        self.into_pyobject(py).unwrap().unbind()
     }
 }
 
@@ -104,17 +94,16 @@ impl<'py> IntoPyObject<'py> for &Ipv6Addr {
 }
 
 impl ToPyObject for IpAddr {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        match self {
-            IpAddr::V4(ip) => ip.to_object(py),
-            IpAddr::V6(ip) => ip.to_object(py),
-        }
+        self.into_pyobject(py).unwrap().unbind()
     }
 }
 
 impl IntoPy<PyObject> for IpAddr {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().unbind()
     }
 }
 

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -56,6 +56,17 @@ impl<'py> IntoPyObject<'py> for Ipv4Addr {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &Ipv4Addr {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
+    }
+}
+
 impl ToPyObject for Ipv6Addr {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         static IPV6_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
@@ -78,6 +89,17 @@ impl<'py> IntoPyObject<'py> for Ipv6Addr {
         IPV6_ADDRESS
             .get_or_try_init_type_ref(py, "ipaddress", "IPv6Address")?
             .call1((u128::from_be_bytes(self.octets()),))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &Ipv6Addr {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 
@@ -106,6 +128,17 @@ impl<'py> IntoPyObject<'py> for IpAddr {
             IpAddr::V4(ip) => ip.into_pyobject(py),
             IpAddr::V6(ip) => ip.into_pyobject(py),
         }
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &IpAddr {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -51,10 +51,33 @@ where
 
 impl<'py, K, V, H> IntoPyObject<'py> for collections::HashMap<K, V, H>
 where
-    K: hash::Hash + cmp::Eq + IntoPyObject<'py>,
+    K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     V: IntoPyObject<'py>,
     H: hash::BuildHasher,
     PyErr: From<K::Error> + From<V::Error>,
+{
+    type Target = PyDict;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let dict = PyDict::new(py);
+        for (k, v) in self {
+            dict.set_item(
+                k.into_pyobject(py)?.into_bound(),
+                v.into_pyobject(py)?.into_bound(),
+            )?;
+        }
+        Ok(dict)
+    }
+}
+
+impl<'a, 'py, K, V, H> IntoPyObject<'py> for &'a collections::HashMap<K, V, H>
+where
+    &'a K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
+    &'a V: IntoPyObject<'py>,
+    &'a H: hash::BuildHasher,
+    PyErr: From<<&'a K as IntoPyObject<'py>>::Error> + From<<&'a V as IntoPyObject<'py>>::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
@@ -92,9 +115,31 @@ where
 
 impl<'py, K, V> IntoPyObject<'py> for collections::BTreeMap<K, V>
 where
-    K: cmp::Eq + IntoPyObject<'py>,
+    K: IntoPyObject<'py> + cmp::Eq,
     V: IntoPyObject<'py>,
     PyErr: From<K::Error> + From<V::Error>,
+{
+    type Target = PyDict;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let dict = PyDict::new(py);
+        for (k, v) in self {
+            dict.set_item(
+                k.into_pyobject(py)?.into_bound(),
+                v.into_pyobject(py)?.into_bound(),
+            )?;
+        }
+        Ok(dict)
+    }
+}
+
+impl<'a, 'py, K, V> IntoPyObject<'py> for &'a collections::BTreeMap<K, V>
+where
+    &'a K: IntoPyObject<'py> + cmp::Eq,
+    &'a V: IntoPyObject<'py>,
+    PyErr: From<<&'a K as IntoPyObject<'py>>::Error> + From<<&'a V as IntoPyObject<'py>>::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/option.rs
+++ b/src/conversions/std/option.rs
@@ -44,6 +44,20 @@ where
     }
 }
 
+impl<'a, 'py, T> IntoPyObject<'py> for &'a Option<T>
+where
+    &'a T: IntoPyObject<'py>,
+{
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = <&'a T as IntoPyObject<'py>>::Error;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        self.as_ref().into_pyobject(py)
+    }
+}
+
 impl<'py, T> FromPyObject<'py> for Option<T>
 where
     T: FromPyObject<'py>,

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -9,6 +9,7 @@ use std::convert::Infallible;
 use std::ffi::{OsStr, OsString};
 
 impl ToPyObject for OsStr {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
     }
@@ -122,21 +123,21 @@ impl FromPyObject<'_> for OsString {
 impl IntoPy<PyObject> for &'_ OsStr {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl ToPyObject for Cow<'_, OsStr> {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        (self as &OsStr).to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for Cow<'_, OsStr> {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -165,13 +166,14 @@ impl<'py> IntoPyObject<'py> for &Cow<'_, OsStr> {
 impl ToPyObject for OsString {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        (self as &OsStr).to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for OsString {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -187,8 +189,9 @@ impl<'py> IntoPyObject<'py> for OsString {
 }
 
 impl<'a> IntoPy<PyObject> for &'a OsString {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -145,8 +145,20 @@ impl<'py> IntoPyObject<'py> for Cow<'_, OsStr> {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &Cow<'_, OsStr> {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (&**self).into_pyobject(py)
     }
 }
 
@@ -168,6 +180,7 @@ impl<'py> IntoPyObject<'py> for OsString {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
@@ -184,6 +197,7 @@ impl<'py> IntoPyObject<'py> for &OsString {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -10,8 +10,9 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 impl ToPyObject for Path {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.as_os_str().to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -28,7 +29,7 @@ impl FromPyObject<'_> for PathBuf {
 impl<'a> IntoPy<PyObject> for &'a Path {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.as_os_str().to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -46,14 +47,14 @@ impl<'py> IntoPyObject<'py> for &Path {
 impl<'a> ToPyObject for Cow<'a, Path> {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.as_os_str().to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl<'a> IntoPy<PyObject> for Cow<'a, Path> {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -82,13 +83,14 @@ impl<'py> IntoPyObject<'py> for &Cow<'_, Path> {
 impl ToPyObject for PathBuf {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.as_os_str().to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for PathBuf {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.into_os_string().to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -104,8 +106,9 @@ impl<'py> IntoPyObject<'py> for PathBuf {
 }
 
 impl<'a> IntoPy<PyObject> for &'a PathBuf {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.as_os_str().to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -37,6 +37,7 @@ impl<'py> IntoPyObject<'py> for &Path {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
@@ -61,6 +62,18 @@ impl<'py> IntoPyObject<'py> for Cow<'_, Path> {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        self.as_os_str().into_pyobject(py)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &Cow<'_, Path> {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
@@ -84,6 +97,7 @@ impl<'py> IntoPyObject<'py> for PathBuf {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }
@@ -100,6 +114,7 @@ impl<'py> IntoPyObject<'py> for &PathBuf {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_os_str().into_pyobject(py)
     }

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -14,14 +14,14 @@ use crate::{
 impl ToPyObject for str {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl<'a> IntoPy<PyObject> for &'a str {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -33,7 +33,7 @@ impl<'a> IntoPy<PyObject> for &'a str {
 impl<'a> IntoPy<Py<PyString>> for &'a str {
     #[inline]
     fn into_py(self, py: Python<'_>) -> Py<PyString> {
-        PyString::new(py, self).into()
+        self.into_pyobject(py).unwrap().unbind()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -69,14 +69,14 @@ impl<'py> IntoPyObject<'py> for &&str {
 impl ToPyObject for Cow<'_, str> {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for Cow<'_, str> {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -112,20 +112,21 @@ impl<'py> IntoPyObject<'py> for &Cow<'_, str> {
 impl ToPyObject for String {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl ToPyObject for char {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.into_py(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for char {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        let mut bytes = [0u8; 4];
-        PyString::new(py, self.encode_utf8(&mut bytes)).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -157,8 +158,9 @@ impl<'py> IntoPyObject<'py> for &char {
 }
 
 impl IntoPy<PyObject> for String {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyString::new(py, &self).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -180,7 +182,7 @@ impl<'py> IntoPyObject<'py> for String {
 impl<'a> IntoPy<PyObject> for &'a String {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyString::new(py, self).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 
     #[cfg(feature = "experimental-inspect")]

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -47,8 +47,20 @@ impl<'py> IntoPyObject<'py> for &str {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyString::new(py, self))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &&str {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 
@@ -78,8 +90,20 @@ impl<'py> IntoPyObject<'py> for Cow<'_, str> {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &Cow<'_, str> {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (&**self).into_pyobject(py)
     }
 }
 
@@ -121,6 +145,17 @@ impl<'py> IntoPyObject<'py> for char {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &char {
+    type Target = PyString;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
+    }
+}
+
 impl IntoPy<PyObject> for String {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyString::new(py, &self).into()
@@ -159,6 +194,7 @@ impl<'py> IntoPyObject<'py> for &String {
     type Output = Bound<'py, Self::Target>;
     type Error = Infallible;
 
+    #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyString::new(py, self))
     }

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -53,40 +53,16 @@ impl FromPyObject<'_> for Duration {
 }
 
 impl ToPyObject for Duration {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        let days = self.as_secs() / SECONDS_PER_DAY;
-        let seconds = self.as_secs() % SECONDS_PER_DAY;
-        let microseconds = self.subsec_micros();
-
-        #[cfg(not(Py_LIMITED_API))]
-        {
-            PyDelta::new_bound(
-                py,
-                days.try_into()
-                    .expect("Too large Rust duration for timedelta"),
-                seconds.try_into().unwrap(),
-                microseconds.try_into().unwrap(),
-                false,
-            )
-            .expect("failed to construct timedelta (overflow?)")
-            .into()
-        }
-        #[cfg(Py_LIMITED_API)]
-        {
-            static TIMEDELTA: GILOnceCell<Py<PyType>> = GILOnceCell::new();
-            TIMEDELTA
-                .get_or_try_init_type_ref(py, "datetime", "timedelta")
-                .unwrap()
-                .call1((days, seconds, microseconds))
-                .unwrap()
-                .into()
-        }
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for Duration {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -146,7 +122,7 @@ impl<'py> IntoPyObject<'py> for &Duration {
 impl FromPyObject<'_> for SystemTime {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         let duration_since_unix_epoch: Duration = obj
-            .call_method1(intern!(obj.py(), "__sub__"), (unix_epoch_py(obj.py()),))?
+            .call_method1(intern!(obj.py(), "__sub__"), (unix_epoch_py(obj.py())?,))?
             .extract()?;
         UNIX_EPOCH
             .checked_add(duration_since_unix_epoch)
@@ -157,17 +133,16 @@ impl FromPyObject<'_> for SystemTime {
 }
 
 impl ToPyObject for SystemTime {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        let duration_since_unix_epoch = self.duration_since(UNIX_EPOCH).unwrap().into_py(py);
-        unix_epoch_py(py)
-            .call_method1(py, intern!(py, "__add__"), (duration_since_unix_epoch,))
-            .unwrap()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for SystemTime {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -179,7 +154,7 @@ impl<'py> IntoPyObject<'py> for SystemTime {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let duration_since_unix_epoch =
             self.duration_since(UNIX_EPOCH).unwrap().into_pyobject(py)?;
-        unix_epoch_py(py)
+        unix_epoch_py(py)?
             .bind(py)
             .call_method1(intern!(py, "__add__"), (duration_since_unix_epoch,))
     }
@@ -196,41 +171,29 @@ impl<'py> IntoPyObject<'py> for &SystemTime {
     }
 }
 
-fn unix_epoch_py(py: Python<'_>) -> &PyObject {
+fn unix_epoch_py(py: Python<'_>) -> PyResult<&PyObject> {
     static UNIX_EPOCH: GILOnceCell<PyObject> = GILOnceCell::new();
-    UNIX_EPOCH
-        .get_or_try_init(py, || {
-            #[cfg(not(Py_LIMITED_API))]
-            {
-                Ok::<_, PyErr>(
-                    PyDateTime::new_bound(
-                        py,
-                        1970,
-                        1,
-                        1,
-                        0,
-                        0,
-                        0,
-                        0,
-                        Some(&timezone_utc_bound(py)),
-                    )?
+    UNIX_EPOCH.get_or_try_init(py, || {
+        #[cfg(not(Py_LIMITED_API))]
+        {
+            Ok::<_, PyErr>(
+                PyDateTime::new_bound(py, 1970, 1, 1, 0, 0, 0, 0, Some(&timezone_utc_bound(py)))?
                     .into(),
-                )
-            }
-            #[cfg(Py_LIMITED_API)]
-            {
-                let datetime = py.import("datetime")?;
-                let utc = datetime.getattr("timezone")?.getattr("utc")?;
-                Ok::<_, PyErr>(
-                    datetime
-                        .getattr("datetime")?
-                        .call1((1970, 1, 1, 0, 0, 0, 0, utc))
-                        .unwrap()
-                        .into(),
-                )
-            }
-        })
-        .unwrap()
+            )
+        }
+        #[cfg(Py_LIMITED_API)]
+        {
+            let datetime = py.import("datetime")?;
+            let utc = datetime.getattr("timezone")?.getattr("utc")?;
+            Ok::<_, PyErr>(
+                datetime
+                    .getattr("datetime")?
+                    .call1((1970, 1, 1, 0, 0, 0, 0, utc))
+                    .unwrap()
+                    .into(),
+            )
+        }
+    })
 }
 
 #[cfg(test)]

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -123,6 +123,20 @@ impl<'py> IntoPyObject<'py> for Duration {
     }
 }
 
+impl<'py> IntoPyObject<'py> for &Duration {
+    #[cfg(not(Py_LIMITED_API))]
+    type Target = PyDelta;
+    #[cfg(Py_LIMITED_API)]
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
+    }
+}
+
 // Conversions between SystemTime and datetime do not rely on the floating point timestamp of the
 // timestamp/fromtimestamp APIs to avoid possible precision loss but goes through the
 // timedelta/std::time::Duration types by taking for reference point the UNIX epoch.
@@ -168,6 +182,17 @@ impl<'py> IntoPyObject<'py> for SystemTime {
         unix_epoch_py(py)
             .bind(py)
             .call_method1(intern!(py, "__add__"), (duration_since_unix_epoch,))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &SystemTime {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -15,8 +15,10 @@ use std::ffi::CString;
 mod err_state;
 mod impls;
 
+use crate::conversion::IntoPyObject;
 pub use err_state::PyErrArguments;
 use err_state::{PyErrState, PyErrStateLazyFnOutput, PyErrStateNormalized};
+use std::convert::Infallible;
 
 /// Represents a Python exception.
 ///
@@ -797,6 +799,28 @@ impl ToPyObject for PyErr {
 impl<'a> IntoPy<PyObject> for &'a PyErr {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.clone_ref(py).into_py(py)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for PyErr {
+    type Target = PyBaseException;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(self.into_value(py).into_bound(py))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &PyErr {
+    type Target = PyBaseException;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        self.clone_ref(py).into_pyobject(py)
     }
 }
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -785,20 +785,23 @@ impl std::fmt::Display for PyErr {
 impl std::error::Error for PyErr {}
 
 impl IntoPy<PyObject> for PyErr {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.into_value(py).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl ToPyObject for PyErr {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        self.clone_ref(py).into_py(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl<'a> IntoPy<PyObject> for &'a PyErr {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.clone_ref(py).into_py(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -8,6 +8,7 @@ use crate::{
 
 use super::any::PyAnyMethods;
 use crate::conversion::IntoPyObject;
+use crate::BoundObject;
 use std::convert::Infallible;
 
 /// Represents a Python `bool`.
@@ -147,23 +148,14 @@ impl PartialEq<Borrowed<'_, '_, PyBool>> for &'_ bool {
 impl ToPyObject for bool {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        unsafe {
-            PyObject::from_borrowed_ptr(
-                py,
-                if *self {
-                    ffi::Py_True()
-                } else {
-                    ffi::Py_False()
-                },
-            )
-        }
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for bool {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyBool::new(py, self).into_py(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 
     #[cfg(feature = "experimental-inspect")]

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 
 use super::any::PyAnyMethods;
+use crate::conversion::IntoPyObject;
+use std::convert::Infallible;
 
 /// Represents a Python `bool`.
 ///
@@ -167,6 +169,28 @@ impl IntoPy<PyObject> for bool {
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         TypeInfo::builtin("bool")
+    }
+}
+
+impl<'py> IntoPyObject<'py> for bool {
+    type Target = PyBool;
+    type Output = Borrowed<'py, 'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyBool::new(py, self))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &bool {
+    type Target = PyBool;
+    type Output = Borrowed<'py, 'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -1,10 +1,12 @@
 use super::any::PyAnyMethods;
+use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
     ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, Borrowed, FromPyObject, IntoPy, PyAny, PyErr,
     PyObject, PyResult, Python, ToPyObject,
 };
+use std::convert::Infallible;
 use std::os::raw::c_double;
 
 /// Represents a Python `float` object.
@@ -73,19 +75,43 @@ impl<'py> PyFloatMethods<'py> for Bound<'py, PyFloat> {
 }
 
 impl ToPyObject for f64 {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyFloat::new(py, *self).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for f64 {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyFloat::new(py, self).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         TypeInfo::builtin("float")
+    }
+}
+
+impl<'py> IntoPyObject<'py> for f64 {
+    type Target = PyFloat;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyFloat::new(py, self))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &f64 {
+    type Target = PyFloat;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 
@@ -120,19 +146,43 @@ impl<'py> FromPyObject<'py> for f64 {
 }
 
 impl ToPyObject for f32 {
+    #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
-        PyFloat::new(py, f64::from(*self)).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
 impl IntoPy<PyObject> for f32 {
+    #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        PyFloat::new(py, f64::from(self)).into()
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         TypeInfo::builtin("float")
+    }
+}
+
+impl<'py> IntoPyObject<'py> for f32 {
+    type Target = PyFloat;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyFloat::new(py, self.into()))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &f32 {
+    type Target = PyFloat;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[inline]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        (*self).into_pyobject(py)
     }
 }
 

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -8,14 +8,14 @@ error[E0277]: `Blah` cannot be converted to a Python object
   = note: if you do not wish to have a corresponding Python type, implement it manually
   = note: if you do not own `Blah` you can perform a manual conversion to one of the types in `pyo3::types::*`
   = help: the following other types implement trait `IntoPyObject<'py>`:
+            &&str
+            &'a BTreeMap<K, V>
+            &'a BTreeSet<K>
+            &'a Cell<T>
+            &'a HashMap<K, V, H>
+            &'a HashSet<K, H>
+            &'a Option<T>
             &'a Py<T>
-            &'a PyRef<'py, T>
-            &'a PyRefMut<'py, T>
-            &'a Vec<T>
-            &'a [T]
-            &'a pyo3::Bound<'py, T>
-            &OsStr
-            &OsString
           and $N others
 note: required by a bound in `UnknownReturnType::<T>::wrap`
  --> src/impl_/wrap.rs


### PR DESCRIPTION
This adds more `IntoPyObject` impls, mostly for reference types, plus a few that I missed in the first round. I generally tried to provide one where ever we also have a `ToPyObject` impl, but there could be still some that I missed somewhere. They will hopefully show up once I start migrating trait bounds.
