### PR TITLE
`IntoPyObject` for `#[pyo3(get)]`

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -97,7 +97,8 @@ where
 <summary><small>Click to expand</small></summary>
 
 PyO3 0.23 introduced the new fallible conversion trait `IntoPyObject`. The `#[pyfunction]` and
-`#[pymethods]` macros prefer `IntoPyObject` implementations over `IntoPy<PyObject>`.
+`#[pymethods]` macros prefer `IntoPyObject` implementations over `IntoPy<PyObject>`. This also
+applies to `#[pyo3(get)]`.
 
 This change has an effect on functions and methods returning _byte_ collections like
 - `Vec<u8>`

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -788,6 +788,7 @@ pub fn impl_py_getter_def(
                         Offset,
                         { #pyo3_path::impl_::pyclass::IsPyT::<#ty>::VALUE },
                         { #pyo3_path::impl_::pyclass::IsToPyObject::<#ty>::VALUE },
+                        { #pyo3_path::impl_::pyclass::IsIntoPy::<#ty>::VALUE },
                         { #pyo3_path::impl_::pyclass::IsIntoPyObjectRef::<#ty>::VALUE },
                         { #pyo3_path::impl_::pyclass::IsIntoPyObject::<#ty>::VALUE },
                     > = unsafe { #pyo3_path::impl_::pyclass::PyClassGetterGenerator::new() };

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -788,6 +788,8 @@ pub fn impl_py_getter_def(
                         Offset,
                         { #pyo3_path::impl_::pyclass::IsPyT::<#ty>::VALUE },
                         { #pyo3_path::impl_::pyclass::IsToPyObject::<#ty>::VALUE },
+                        { #pyo3_path::impl_::pyclass::IsIntoPyObjectRef::<#ty>::VALUE },
+                        { #pyo3_path::impl_::pyclass::IsIntoPyObject::<#ty>::VALUE },
                     > = unsafe { #pyo3_path::impl_::pyclass::PyClassGetterGenerator::new() };
                     #pyo3_path::impl_::pyclass::MaybeRuntimePyMethodDef::Runtime(
                         || GENERATOR.generate(#python_name, #doc)

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1501,6 +1501,16 @@ unsafe fn ensure_no_mutable_alias<'py, ClassT: PyClass>(
         .try_borrow()
 }
 
+/// calculates the field pointer from an PyObject pointer
+#[inline]
+fn field_from_object<ClassT, FieldT, Offset>(obj: *mut ffi::PyObject) -> *mut FieldT
+where
+    ClassT: PyClass,
+    Offset: OffsetCalculator<ClassT, FieldT>,
+{
+    unsafe { obj.cast::<u8>().add(Offset::offset()).cast::<FieldT>() }
+}
+
 fn pyo3_get_value_topyobject<
     ClassT: PyClass,
     FieldT: ToPyObject,
@@ -1510,8 +1520,7 @@ fn pyo3_get_value_topyobject<
     obj: *mut ffi::PyObject,
 ) -> PyResult<*mut ffi::PyObject> {
     let _holder = unsafe { ensure_no_mutable_alias::<ClassT>(py, &obj)? };
-
-    let value = unsafe { obj.cast::<u8>().add(Offset::offset()).cast::<FieldT>() };
+    let value = field_from_object::<ClassT, FieldT, Offset>(obj);
 
     // SAFETY: Offset is known to describe the location of the value, and
     // _holder is preventing mutable aliasing
@@ -1529,8 +1538,7 @@ where
     for<'a, 'py> PyErr: From<<&'a FieldT as IntoPyObject<'py>>::Error>,
 {
     let _holder = unsafe { ensure_no_mutable_alias::<ClassT>(py, &obj)? };
-
-    let value = unsafe { obj.cast::<u8>().add(Offset::offset()).cast::<FieldT>() };
+    let value = field_from_object::<ClassT, FieldT, Offset>(obj);
 
     // SAFETY: Offset is known to describe the location of the value, and
     // _holder is preventing mutable aliasing
@@ -1548,8 +1556,7 @@ where
     for<'py> <FieldT as IntoPyObject<'py>>::Error: Into<PyErr>,
 {
     let _holder = unsafe { ensure_no_mutable_alias::<ClassT>(py, &obj)? };
-
-    let value = unsafe { obj.cast::<u8>().add(Offset::offset()).cast::<FieldT>() };
+    let value = field_from_object::<ClassT, FieldT, Offset>(obj);
 
     // SAFETY: Offset is known to describe the location of the value, and
     // _holder is preventing mutable aliasing
@@ -1569,8 +1576,7 @@ fn pyo3_get_value<
     obj: *mut ffi::PyObject,
 ) -> PyResult<*mut ffi::PyObject> {
     let _holder = unsafe { ensure_no_mutable_alias::<ClassT>(py, &obj)? };
-
-    let value = unsafe { obj.cast::<u8>().add(Offset::offset()).cast::<FieldT>() };
+    let value = field_from_object::<ClassT, FieldT, Offset>(obj);
 
     // SAFETY: Offset is known to describe the location of the value, and
     // _holder is preventing mutable aliasing

--- a/tests/ui/invalid_property_args.stderr
+++ b/tests/ui/invalid_property_args.stderr
@@ -55,11 +55,11 @@ error[E0277]: `PhantomData<i32>` cannot be converted to a Python object
    = help: the trait `IntoPy<Py<PyAny>>` is not implemented for `PhantomData<i32>`, which is required by `PhantomData<i32>: PyO3GetField`
    = note: implement `ToPyObject` or `IntoPy<PyObject> + Clone` for `PhantomData<i32>` to define the conversion
    = note: required for `PhantomData<i32>` to implement `PyO3GetField`
-note: required by a bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false>::generate`
+note: required by a bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false>::generate`
   --> src/impl_/pyclass.rs
    |
    |     pub const fn generate(&self, name: &'static CStr, doc: &'static CStr) -> PyMethodDefType
    |                  -------- required by a bound in this associated function
 ...
    |         FieldT: PyO3GetField,
-   |                 ^^^^^^^^^^^^ required by this bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false>::generate`
+   |                 ^^^^^^^^^^^^ required by this bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false>::generate`

--- a/tests/ui/invalid_property_args.stderr
+++ b/tests/ui/invalid_property_args.stderr
@@ -52,14 +52,14 @@ error[E0277]: `PhantomData<i32>` cannot be converted to a Python object
 45 |     value: ::std::marker::PhantomData<i32>,
    |            ^ required by `#[pyo3(get)]` to create a readable property from a field of type `PhantomData<i32>`
    |
-   = help: the trait `IntoPy<Py<PyAny>>` is not implemented for `PhantomData<i32>`, which is required by `PhantomData<i32>: PyO3GetField`
-   = note: implement `ToPyObject` or `IntoPy<PyObject> + Clone` for `PhantomData<i32>` to define the conversion
-   = note: required for `PhantomData<i32>` to implement `PyO3GetField`
-note: required by a bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false>::generate`
+   = help: the trait `for<'py> IntoPyObject<'py>` is not implemented for `PhantomData<i32>`, which is required by `PhantomData<i32>: PyO3GetFieldIntoPyObject`
+   = note: implement `IntoPyObject` for `&PhantomData<i32>` or `IntoPyObject + Clone` for `PhantomData<i32>` to define the conversion
+   = note: required for `PhantomData<i32>` to implement `PyO3GetFieldIntoPyObject`
+note: required by a bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false, false>::generate`
   --> src/impl_/pyclass.rs
    |
    |     pub const fn generate(&self, name: &'static CStr, doc: &'static CStr) -> PyMethodDefType
    |                  -------- required by a bound in this associated function
 ...
-   |         FieldT: PyO3GetField,
-   |                 ^^^^^^^^^^^^ required by this bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false>::generate`
+   |         FieldT: PyO3GetFieldIntoPyObject,
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false, false>::generate`

--- a/tests/ui/invalid_property_args.stderr
+++ b/tests/ui/invalid_property_args.stderr
@@ -52,14 +52,14 @@ error[E0277]: `PhantomData<i32>` cannot be converted to a Python object
 45 |     value: ::std::marker::PhantomData<i32>,
    |            ^ required by `#[pyo3(get)]` to create a readable property from a field of type `PhantomData<i32>`
    |
-   = help: the trait `for<'py> IntoPyObject<'py>` is not implemented for `PhantomData<i32>`, which is required by `PhantomData<i32>: PyO3GetFieldIntoPyObject`
+   = help: the trait `IntoPyObject<'_>` is not implemented for `PhantomData<i32>`, which is required by `for<'py> PhantomData<i32>: PyO3GetField<'py>`
    = note: implement `IntoPyObject` for `&PhantomData<i32>` or `IntoPyObject + Clone` for `PhantomData<i32>` to define the conversion
-   = note: required for `PhantomData<i32>` to implement `PyO3GetFieldIntoPyObject`
+   = note: required for `PhantomData<i32>` to implement `for<'py> PyO3GetField<'py>`
 note: required by a bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false, false>::generate`
   --> src/impl_/pyclass.rs
    |
-   |     pub const fn generate(&self, name: &'static CStr, doc: &'static CStr) -> PyMethodDefType
+   |     pub const fn generate(&self, _name: &'static CStr, _doc: &'static CStr) -> PyMethodDefType
    |                  -------- required by a bound in this associated function
 ...
-   |         FieldT: PyO3GetFieldIntoPyObject,
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false, false>::generate`
+   |         for<'py> FieldT: PyO3GetField<'py>,
+   |                          ^^^^^^^^^^^^^^^^^ required by this bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false, false>::generate`


### PR DESCRIPTION
This extends the `#[pyo3(get)]` conversion specialization to include `IntoPyObject`. I implemented the following priority list (or at least tried to 🙃 )

1. `Py<T>`
2. `IntoPyObject` for `&T`
3. Temp case: `IntoPyObject + Clone` for `T` (to prefer over `IntoPy`)
4. Compat Fallback: `ToPyObject` for `T`
5. Compat Fallback: `IntoPy + Clone` for `T`
6. Base case: `IntoPyObject + Clone` for `T` (currently only used to emit the correct diagnostic if no conversion trait is implemented)