### PR TITLE
Restore _PyLong_NumBits on Python 3.13 and later

### DIFF
--- a/newsfragments/4450.changed.md
+++ b/newsfragments/4450.changed.md
@@ -1,0 +1,1 @@
+Restore `_PyLong_NumBits` on Python 3.13 and later

--- a/pyo3-ffi/src/longobject.rs
+++ b/pyo3-ffi/src/longobject.rs
@@ -92,7 +92,6 @@ extern "C" {
 #[cfg(not(Py_LIMITED_API))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "_PyPyLong_NumBits")]
-    #[cfg(not(Py_3_13))]
     pub fn _PyLong_NumBits(obj: *mut PyObject) -> size_t;
 }
 


### PR DESCRIPTION
See https://github.com/python/cpython/commit/cc663b7e25539d938bf71bc1b4d69efd8824c2d3

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
