### PR TITLE
Error at compile-time when a non-subclassable class is being subclassed

### DIFF
--- a/newsfragments/4453.changed.md
+++ b/newsfragments/4453.changed.md
@@ -1,0 +1,1 @@
+Make subclassing a class that doesn't allow that a compile-time error instead of runtime

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2244,7 +2244,20 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote! { #pyo3_path::PyAny }
         };
 
+        let pyclass_base_type_impl = attr.options.subclass.map(|subclass| {
+            quote_spanned! { subclass.span() =>
+                impl #pyo3_path::impl_::pyclass::PyClassBaseType for #cls {
+                    type LayoutAsBase = #pyo3_path::impl_::pycell::PyClassObject<Self>;
+                    type BaseNativeType = <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::BaseNativeType;
+                    type Initializer = #pyo3_path::pyclass_init::PyClassInitializer<Self>;
+                    type PyClassMutability = <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::PyClassMutability;
+                }
+            }
+        });
+
         Ok(quote! {
+            #pyclass_base_type_impl
+
             impl #pyo3_path::impl_::pyclass::PyClassImpl for #cls {
                 const IS_BASETYPE: bool = #is_basetype;
                 const IS_SUBCLASS: bool = #is_subclass;

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -276,6 +276,7 @@ macro_rules! impl_native_exception (
 
         $crate::impl_exception_boilerplate!($name);
         $crate::pyobject_native_type!($name, $layout, |_py| unsafe { $crate::ffi::$exc_name as *mut $crate::ffi::PyTypeObject } $(, #checkfunction=$checkfunction)?);
+        $crate::pyobject_subclassable_native_type!($name, $layout);
     );
     ($name:ident, $exc_name:ident, $doc:expr) => (
         impl_native_exception!($name, $exc_name, $doc, $crate::ffi::PyBaseExceptionObject);

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1118,7 +1118,7 @@ impl<T> PyClassThreadChecker<T> for ThreadCheckerImpl {
     diagnostic::on_unimplemented(
         message = "pyclass `{Self}` cannot be subclassed",
         label = "required for `#[pyclass(extends={Self})]`",
-        note = "if you own `{Self}`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`",
+        note = "`{Self}` must have `#[pyclass(subclass)]` to be eligible for subclassing",
         note = "with the `abi3` feature enabled, PyO3 does not support subclassing native types",
     )
 )]
@@ -1127,7 +1127,7 @@ impl<T> PyClassThreadChecker<T> for ThreadCheckerImpl {
     diagnostic::on_unimplemented(
         message = "pyclass `{Self}` cannot be subclassed",
         label = "required for `#[pyclass(extends={Self})]`",
-        note = "if you own `{Self}`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`",
+        note = "`{Self}` must have `#[pyclass(subclass)]` to be eligible for subclassing",
     )
 )]
 pub trait PyClassBaseType: Sized {

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1116,7 +1116,18 @@ impl<T> PyClassThreadChecker<T> for ThreadCheckerImpl {
 #[cfg_attr(
     all(diagnostic_namespace, feature = "abi3"),
     diagnostic::on_unimplemented(
-        note = "with the `abi3` feature enabled, PyO3 does not support subclassing native types"
+        message = "pyclass `{Self}` cannot be subclassed",
+        label = "required for `#[pyclass(extends={Self})]`",
+        note = "if you own `{Self}`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`",
+        note = "with the `abi3` feature enabled, PyO3 does not support subclassing native types",
+    )
+)]
+#[cfg_attr(
+    all(diagnostic_namespace, not(feature = "abi3")),
+    diagnostic::on_unimplemented(
+        message = "pyclass `{Self}` cannot be subclassed",
+        label = "required for `#[pyclass(extends={Self})]`",
+        note = "if you own `{Self}`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`",
     )
 )]
 pub trait PyClassBaseType: Sized {
@@ -1124,16 +1135,6 @@ pub trait PyClassBaseType: Sized {
     type BaseNativeType;
     type Initializer: PyObjectInit<Self>;
     type PyClassMutability: PyClassMutability;
-}
-
-/// All mutable PyClasses can be used as a base type.
-///
-/// In the future this will be extended to immutable PyClasses too.
-impl<T: PyClass> PyClassBaseType for T {
-    type LayoutAsBase = crate::impl_::pycell::PyClassObject<T>;
-    type BaseNativeType = T::BaseNativeType;
-    type Initializer = crate::pyclass_init::PyClassInitializer<Self>;
-    type PyClassMutability = T::PyClassMutability;
 }
 
 /// Implementation of tp_dealloc for pyclasses without gc

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -308,7 +308,7 @@ where
 impl<S, B> From<(S, B)> for PyClassInitializer<S>
 where
     S: PyClass<BaseType = B>,
-    B: PyClass,
+    B: PyClass + PyClassBaseType<Initializer = PyClassInitializer<B>>,
     B::BaseType: PyClassBaseType<Initializer = PyNativeTypeInitializer<B::BaseType>>,
 {
     #[track_caller]

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -44,6 +44,13 @@ pyobject_native_type_info!(
 );
 
 pyobject_native_type_sized!(PyAny, ffi::PyObject);
+// We cannot use `pyobject_subclassable_native_type!()` because it cfgs out on `Py_LIMITED_API`.
+impl crate::impl_::pyclass::PyClassBaseType for PyAny {
+    type LayoutAsBase = crate::impl_::pycell::PyClassObjectBase<ffi::PyObject>;
+    type BaseNativeType = PyAny;
+    type Initializer = crate::pyclass_init::PyNativeTypeInitializer<Self>;
+    type PyClassMutability = crate::pycell::impl_::ImmutableClass;
+}
 
 /// This trait represents the Python APIs which are usable on all Python objects.
 ///

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -19,6 +19,8 @@ use std::os::raw::c_double;
 #[repr(transparent)]
 pub struct PyComplex(PyAny);
 
+pyobject_subclassable_native_type!(PyComplex, ffi::PyComplexObject);
+
 pyobject_native_type!(
     PyComplex,
     ffi::PyComplexObject,

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -199,6 +199,7 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyDate_Check
 );
+pyobject_subclassable_native_type!(PyDate, crate::ffi::PyDateTime_Date);
 
 impl PyDate {
     /// Creates a new `datetime.date`.
@@ -269,6 +270,7 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyDateTime_Check
 );
+pyobject_subclassable_native_type!(PyDateTime, crate::ffi::PyDateTime_DateTime);
 
 impl PyDateTime {
     /// Creates a new `datetime.datetime` object.
@@ -514,6 +516,7 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyTime_Check
 );
+pyobject_subclassable_native_type!(PyTime, crate::ffi::PyDateTime_Time);
 
 impl PyTime {
     /// Creates a new `datetime.time` object.
@@ -669,6 +672,7 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyTZInfo_Check
 );
+pyobject_subclassable_native_type!(PyTzInfo, crate::ffi::PyObject);
 
 /// Equivalent to `datetime.timezone.utc`
 pub fn timezone_utc(py: Python<'_>) -> Bound<'_, PyTzInfo> {
@@ -720,6 +724,7 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyDelta_Check
 );
+pyobject_subclassable_native_type!(PyDelta, crate::ffi::PyDateTime_Delta);
 
 impl PyDelta {
     /// Creates a new `timedelta`.

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -18,6 +18,8 @@ use crate::{ffi, Python, ToPyObject};
 #[repr(transparent)]
 pub struct PyDict(PyAny);
 
+pyobject_subclassable_native_type!(PyDict, crate::ffi::PyDictObject);
+
 pyobject_native_type!(
     PyDict,
     ffi::PyDictObject,

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -23,6 +23,8 @@ use std::os::raw::c_double;
 #[repr(transparent)]
 pub struct PyFloat(PyAny);
 
+pyobject_subclassable_native_type!(PyFloat, crate::ffi::PyFloatObject);
+
 pyobject_native_type!(
     PyFloat,
     ffi::PyFloatObject,

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -62,6 +62,8 @@ impl<'py> PyFrozenSetBuilder<'py> {
 pub struct PyFrozenSet(PyAny);
 
 #[cfg(not(any(PyPy, GraalPy)))]
+pyobject_subclassable_native_type!(PyFrozenSet, crate::ffi::PySetObject);
+#[cfg(not(any(PyPy, GraalPy)))]
 pyobject_native_type!(
     PyFrozenSet,
     ffi::PySetObject,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -195,10 +195,9 @@ macro_rules! pyobject_native_type_core {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! pyobject_native_type_sized {
+macro_rules! pyobject_subclassable_native_type {
     ($name:ty, $layout:path $(;$generics:ident)*) => {
-        unsafe impl $crate::type_object::PyLayout<$name> for $layout {}
-        impl $crate::type_object::PySizedLayout<$name> for $layout {}
+        #[cfg(not(Py_LIMITED_API))]
         impl<$($generics,)*> $crate::impl_::pyclass::PyClassBaseType for $name {
             type LayoutAsBase = $crate::impl_::pycell::PyClassObjectBase<$layout>;
             type BaseNativeType = $name;
@@ -206,6 +205,15 @@ macro_rules! pyobject_native_type_sized {
             type PyClassMutability = $crate::pycell::impl_::ImmutableClass;
         }
     }
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! pyobject_native_type_sized {
+    ($name:ty, $layout:path $(;$generics:ident)*) => {
+        unsafe impl $crate::type_object::PyLayout<$name> for $layout {}
+        impl $crate::type_object::PySizedLayout<$name> for $layout {}
+    };
 }
 
 /// Declares all of the boilerplate for Python types which can be inherited from (because the exact

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -20,6 +20,9 @@ use std::ptr;
 pub struct PySet(PyAny);
 
 #[cfg(not(any(PyPy, GraalPy)))]
+pyobject_subclassable_native_type!(PySet, crate::ffi::PySetObject);
+
+#[cfg(not(any(PyPy, GraalPy)))]
 pyobject_native_type!(
     PySet,
     ffi::PySetObject,

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -16,6 +16,9 @@ use super::PyWeakrefMethods;
 pub struct PyWeakrefReference(PyAny);
 
 #[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API)))]
+pyobject_subclassable_native_type!(PyWeakrefReference, crate::ffi::PyWeakReference);
+
+#[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API)))]
 pyobject_native_type!(
     PyWeakrefReference,
     ffi::PyWeakReference,

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -62,4 +62,5 @@ fn test_compile_errors() {
     #[cfg(all(Py_LIMITED_API, not(Py_3_9)))]
     t.compile_fail("tests/ui/abi3_dict.rs");
     t.compile_fail("tests/ui/duplicate_pymodule_submodule.rs");
+    t.compile_fail("tests/ui/invalid_base_class.rs");
 }

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -62,6 +62,6 @@ fn test_compile_errors() {
     #[cfg(all(Py_LIMITED_API, not(Py_3_9)))]
     t.compile_fail("tests/ui/abi3_dict.rs");
     t.compile_fail("tests/ui/duplicate_pymodule_submodule.rs");
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(all(not(Py_LIMITED_API), Py_3_11))]
     t.compile_fail("tests/ui/invalid_base_class.rs");
 }

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -62,5 +62,6 @@ fn test_compile_errors() {
     #[cfg(all(Py_LIMITED_API, not(Py_3_9)))]
     t.compile_fail("tests/ui/abi3_dict.rs");
     t.compile_fail("tests/ui/duplicate_pymodule_submodule.rs");
+    #[cfg(not(Py_LIMITED_API))]
     t.compile_fail("tests/ui/invalid_base_class.rs");
 }

--- a/tests/test_declarative_module.rs
+++ b/tests/test_declarative_module.rs
@@ -4,8 +4,6 @@ use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use pyo3::sync::GILOnceCell;
-#[cfg(not(Py_LIMITED_API))]
-use pyo3::types::PyBool;
 
 #[path = "../src/tests/common.rs"]
 mod common;
@@ -183,31 +181,6 @@ fn test_declarative_module() {
         py_assert!(py, m, "isinstance(m.inner.Struct(), m.inner.Struct)");
         py_assert!(py, m, "isinstance(m.inner.Enum.A, m.inner.Enum)");
         py_assert!(py, m, "hasattr(m, 'external_submodule')")
-    })
-}
-
-#[cfg(not(Py_LIMITED_API))]
-#[pyclass(extends = PyBool)]
-struct ExtendsBool;
-
-#[cfg(not(Py_LIMITED_API))]
-#[pymodule]
-mod class_initialization_module {
-    #[pymodule_export]
-    use super::ExtendsBool;
-}
-
-#[test]
-#[cfg(not(Py_LIMITED_API))]
-fn test_class_initialization_fails() {
-    Python::with_gil(|py| {
-        let err = class_initialization_module::_PYO3_DEF
-            .make_module(py)
-            .unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "RuntimeError: An error occurred while initializing class ExtendsBool"
-        );
     })
 }
 

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -345,26 +345,3 @@ fn test_subclass_ref_counts() {
         );
     })
 }
-
-#[test]
-#[cfg(not(Py_LIMITED_API))]
-fn module_add_class_inherit_bool_fails() {
-    use pyo3::types::PyBool;
-
-    #[pyclass(extends = PyBool)]
-    struct ExtendsBool;
-
-    Python::with_gil(|py| {
-        let m = PyModule::new(py, "test_module").unwrap();
-
-        let err = m.add_class::<ExtendsBool>().unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "RuntimeError: An error occurred while initializing class ExtendsBool"
-        );
-        assert_eq!(
-            err.cause(py).unwrap().to_string(),
-            "TypeError: type 'bool' is not an acceptable base type"
-        );
-    })
-}

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -12,7 +12,7 @@ macro_rules! make_struct_using_macro {
     // Ensure that one doesn't need to fall back on the escape type: tt
     // in order to macro create pyclass.
     ($class_name:ident, $py_name:literal) => {
-        #[pyclass(name=$py_name)]
+        #[pyclass(name=$py_name, subclass)]
         struct $class_name {}
     };
 }

--- a/tests/ui/abi3_inheritance.stderr
+++ b/tests/ui/abi3_inheritance.stderr
@@ -5,7 +5,7 @@ error[E0277]: pyclass `PyException` cannot be subclassed
   |                   ^^^^^^^^^^^ required for `#[pyclass(extends=PyException)]`
   |
   = help: the trait `PyClassBaseType` is not implemented for `PyException`
-  = note: if you own `PyException`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = note: `PyException` must have `#[pyclass(subclass)]` to be eligible for subclassing
   = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
   = help: the trait `PyClassBaseType` is implemented for `PyAny`
 note: required by a bound in `PyClassImpl::BaseType`
@@ -21,7 +21,7 @@ error[E0277]: pyclass `PyException` cannot be subclassed
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required for `#[pyclass(extends=PyException)]`
   |
   = help: the trait `PyClassBaseType` is not implemented for `PyException`
-  = note: if you own `PyException`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = note: `PyException` must have `#[pyclass(subclass)]` to be eligible for subclassing
   = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
   = help: the trait `PyClassBaseType` is implemented for `PyAny`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/abi3_inheritance.stderr
+++ b/tests/ui/abi3_inheritance.stderr
@@ -1,24 +1,27 @@
-error[E0277]: the trait bound `PyException: PyClassBaseType` is not satisfied
+error[E0277]: pyclass `PyException` cannot be subclassed
  --> tests/ui/abi3_inheritance.rs:4:19
   |
 4 | #[pyclass(extends=PyException)]
-  |                   ^^^^^^^^^^^ the trait `PyClass` is not implemented for `PyException`, which is required by `PyException: PyClassBaseType`
+  |                   ^^^^^^^^^^^ required for `#[pyclass(extends=PyException)]`
   |
+  = help: the trait `PyClassBaseType` is not implemented for `PyException`
+  = note: if you own `PyException`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
   = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
   = help: the trait `PyClassBaseType` is implemented for `PyAny`
-  = note: required for `PyException` to implement `PyClassBaseType`
 note: required by a bound in `PyClassImpl::BaseType`
  --> src/impl_/pyclass.rs
   |
   |     type BaseType: PyTypeInfo + PyClassBaseType;
   |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`
 
-error[E0277]: the trait bound `PyException: PyClass` is not satisfied
+error[E0277]: pyclass `PyException` cannot be subclassed
  --> tests/ui/abi3_inheritance.rs:4:1
   |
 4 | #[pyclass(extends=PyException)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyClass` is not implemented for `PyException`, which is required by `PyException: PyClassBaseType`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required for `#[pyclass(extends=PyException)]`
   |
-  = help: the trait `PyClass` is implemented for `MyException`
-  = note: required for `PyException` to implement `PyClassBaseType`
+  = help: the trait `PyClassBaseType` is not implemented for `PyException`
+  = note: if you own `PyException`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
+  = help: the trait `PyClassBaseType` is implemented for `PyAny`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/abi3_nativetype_inheritance.stderr
+++ b/tests/ui/abi3_nativetype_inheritance.stderr
@@ -5,7 +5,7 @@ error[E0277]: pyclass `PyDict` cannot be subclassed
   |                   ^^^^^^ required for `#[pyclass(extends=PyDict)]`
   |
   = help: the trait `PyClassBaseType` is not implemented for `PyDict`
-  = note: if you own `PyDict`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = note: `PyDict` must have `#[pyclass(subclass)]` to be eligible for subclassing
   = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
   = help: the trait `PyClassBaseType` is implemented for `PyAny`
 note: required by a bound in `PyClassImpl::BaseType`
@@ -21,7 +21,7 @@ error[E0277]: pyclass `PyDict` cannot be subclassed
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required for `#[pyclass(extends=PyDict)]`
   |
   = help: the trait `PyClassBaseType` is not implemented for `PyDict`
-  = note: if you own `PyDict`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = note: `PyDict` must have `#[pyclass(subclass)]` to be eligible for subclassing
   = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
   = help: the trait `PyClassBaseType` is implemented for `PyAny`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/abi3_nativetype_inheritance.stderr
+++ b/tests/ui/abi3_nativetype_inheritance.stderr
@@ -1,26 +1,27 @@
-error[E0277]: the trait bound `PyDict: PyClassBaseType` is not satisfied
+error[E0277]: pyclass `PyDict` cannot be subclassed
  --> tests/ui/abi3_nativetype_inheritance.rs:5:19
   |
 5 | #[pyclass(extends=PyDict)]
-  |                   ^^^^^^ the trait `PyClass` is not implemented for `PyDict`, which is required by `PyDict: PyClassBaseType`
+  |                   ^^^^^^ required for `#[pyclass(extends=PyDict)]`
   |
+  = help: the trait `PyClassBaseType` is not implemented for `PyDict`
+  = note: if you own `PyDict`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
   = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
   = help: the trait `PyClassBaseType` is implemented for `PyAny`
-  = note: required for `PyDict` to implement `PyClassBaseType`
 note: required by a bound in `PyClassImpl::BaseType`
  --> src/impl_/pyclass.rs
   |
   |     type BaseType: PyTypeInfo + PyClassBaseType;
   |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`
 
-error[E0277]: the trait bound `PyDict: PyClass` is not satisfied
+error[E0277]: pyclass `PyDict` cannot be subclassed
  --> tests/ui/abi3_nativetype_inheritance.rs:5:1
   |
 5 | #[pyclass(extends=PyDict)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyClass` is not implemented for `PyDict`, which is required by `PyDict: PyClassBaseType`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required for `#[pyclass(extends=PyDict)]`
   |
-  = help: the following other types implement trait `PyClass`:
-            TestClass
-            pyo3::coroutine::Coroutine
-  = note: required for `PyDict` to implement `PyClassBaseType`
+  = help: the trait `PyClassBaseType` is not implemented for `PyDict`
+  = note: if you own `PyDict`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
+  = help: the trait `PyClassBaseType` is implemented for `PyAny`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/invalid_base_class.rs
+++ b/tests/ui/invalid_base_class.rs
@@ -1,0 +1,7 @@
+use pyo3::prelude::*;
+use pyo3::types::PyBool;
+
+#[pyclass(extends=PyBool)]
+struct ExtendsBool;
+
+fn main() {}

--- a/tests/ui/invalid_base_class.stderr
+++ b/tests/ui/invalid_base_class.stderr
@@ -1,0 +1,43 @@
+error[E0277]: pyclass `PyBool` cannot be subclassed
+ --> tests/ui/invalid_base_class.rs:4:19
+  |
+4 | #[pyclass(extends=PyBool)]
+  |                   ^^^^^^ required for `#[pyclass(extends=PyBool)]`
+  |
+  = help: the trait `PyClassBaseType` is not implemented for `PyBool`
+  = note: if you own `PyBool`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = help: the following other types implement trait `PyClassBaseType`:
+            PyAny
+            PyArithmeticError
+            PyAssertionError
+            PyAttributeError
+            PyBaseException
+            PyBaseExceptionGroup
+            PyBlockingIOError
+            PyBrokenPipeError
+          and $N others
+note: required by a bound in `PyClassImpl::BaseType`
+ --> src/impl_/pyclass.rs
+  |
+  |     type BaseType: PyTypeInfo + PyClassBaseType;
+  |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`
+
+error[E0277]: pyclass `PyBool` cannot be subclassed
+ --> tests/ui/invalid_base_class.rs:4:1
+  |
+4 | #[pyclass(extends=PyBool)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required for `#[pyclass(extends=PyBool)]`
+  |
+  = help: the trait `PyClassBaseType` is not implemented for `PyBool`
+  = note: if you own `PyBool`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = help: the following other types implement trait `PyClassBaseType`:
+            PyAny
+            PyArithmeticError
+            PyAssertionError
+            PyAttributeError
+            PyBaseException
+            PyBaseExceptionGroup
+            PyBlockingIOError
+            PyBrokenPipeError
+          and $N others
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/invalid_base_class.stderr
+++ b/tests/ui/invalid_base_class.stderr
@@ -5,7 +5,7 @@ error[E0277]: pyclass `PyBool` cannot be subclassed
   |                   ^^^^^^ required for `#[pyclass(extends=PyBool)]`
   |
   = help: the trait `PyClassBaseType` is not implemented for `PyBool`
-  = note: if you own `PyBool`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = note: `PyBool` must have `#[pyclass(subclass)]` to be eligible for subclassing
   = help: the following other types implement trait `PyClassBaseType`:
             PyAny
             PyArithmeticError
@@ -29,7 +29,7 @@ error[E0277]: pyclass `PyBool` cannot be subclassed
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required for `#[pyclass(extends=PyBool)]`
   |
   = help: the trait `PyClassBaseType` is not implemented for `PyBool`
-  = note: if you own `PyBool`, add `subclass` to the `#[pyclass]` macro: `#[pyclass(subclass)]`
+  = note: `PyBool` must have `#[pyclass(subclass)]` to be eligible for subclassing
   = help: the following other types implement trait `PyClassBaseType`:
             PyAny
             PyArithmeticError


### PR DESCRIPTION
Previously this crashed at runtime.

We even get to remove few tests. Nothing more fun than removing a no-longer-needed test!

Fixes #4451.