### PR TITLE
Fix a soundness bug with `PyClassInitializer`

### DIFF
--- a/newsfragments/4454.fixed.md
+++ b/newsfragments/4454.fixed.md
@@ -1,0 +1,1 @@
+Fix a soundness bug with `PyClassInitializer`: from now you cannot initialize a `PyClassInitializer<SubClass>` with `PyClassInitializer::from(Py<BaseClass>).add_subclass(SubClass)`.


### PR DESCRIPTION
From now you cannot initialize a `PyClassInitializer<SubClass>` with `PyClassInitializer::from(Py<BaseClass>).add_subclass(SubClass)`.

This was out of bounds write. Now it panics. See details at https://github.com/PyO3/pyo3/issues/4452.

This is a short-term fix for #4452.

Long-term, we probably want to forbid that at compile time, but that will be a breaking change.