### PR TITLE
Use vectorcall (where possible) when calling Python functions

### DIFF
--- a/newsfragments/4456.changed.md
+++ b/newsfragments/4456.changed.md
@@ -1,0 +1,1 @@
+Improve performance of calls to Python by using the vectorcall calling convention where possible.

--- a/pyo3-benches/benches/bench_call.rs
+++ b/pyo3-benches/benches/bench_call.rs
@@ -2,8 +2,9 @@ use std::hint::black_box;
 
 use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
 
-use pyo3::prelude::*;
 use pyo3::ffi::c_str;
+use pyo3::prelude::*;
+use pyo3::types::IntoPyDict;
 
 macro_rules! test_module {
     ($py:ident, $code:literal) => {
@@ -21,6 +22,62 @@ fn bench_call_0(b: &mut Bencher<'_>) {
         b.iter(|| {
             for _ in 0..1000 {
                 black_box(foo_module).call0().unwrap();
+            }
+        });
+    })
+}
+
+fn bench_call_1(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let module = test_module!(py, "def foo(a, b, c): pass");
+
+        let foo_module = &module.getattr("foo").unwrap();
+        let args = (
+            <_ as IntoPy<PyObject>>::into_py(1, py).into_bound(py),
+            <_ as IntoPy<PyObject>>::into_py("s", py).into_bound(py),
+            <_ as IntoPy<PyObject>>::into_py(1.23, py).into_bound(py),
+        );
+
+        b.iter(|| {
+            for _ in 0..1000 {
+                black_box(foo_module).call1(args.clone()).unwrap();
+            }
+        });
+    })
+}
+
+fn bench_call(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let module = test_module!(py, "def foo(a, b, c, d, e): pass");
+
+        let foo_module = &module.getattr("foo").unwrap();
+        let args = (
+            <_ as IntoPy<PyObject>>::into_py(1, py).into_bound(py),
+            <_ as IntoPy<PyObject>>::into_py("s", py).into_bound(py),
+            <_ as IntoPy<PyObject>>::into_py(1.23, py).into_bound(py),
+        );
+        let kwargs = [("d", 1), ("e", 42)].into_py_dict(py);
+
+        b.iter(|| {
+            for _ in 0..1000 {
+                black_box(foo_module)
+                    .call(args.clone(), Some(&kwargs))
+                    .unwrap();
+            }
+        });
+    })
+}
+
+fn bench_call_one_arg(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let module = test_module!(py, "def foo(a): pass");
+
+        let foo_module = &module.getattr("foo").unwrap();
+        let arg = <_ as IntoPy<PyObject>>::into_py(1, py).into_bound(py);
+
+        b.iter(|| {
+            for _ in 0..1000 {
+                black_box(foo_module).call1((arg.clone(),)).unwrap();
             }
         });
     })
@@ -47,9 +104,96 @@ class Foo:
     })
 }
 
+fn bench_call_method_1(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let module = test_module!(
+            py,
+            "
+class Foo:
+    def foo(self, a, b, c):
+        pass
+"
+        );
+
+        let foo_module = &module.getattr("Foo").unwrap().call0().unwrap();
+        let args = (
+            <_ as IntoPy<PyObject>>::into_py(1, py).into_bound(py),
+            <_ as IntoPy<PyObject>>::into_py("s", py).into_bound(py),
+            <_ as IntoPy<PyObject>>::into_py(1.23, py).into_bound(py),
+        );
+
+        b.iter(|| {
+            for _ in 0..1000 {
+                black_box(foo_module)
+                    .call_method1("foo", args.clone())
+                    .unwrap();
+            }
+        });
+    })
+}
+
+fn bench_call_method(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let module = test_module!(
+            py,
+            "
+class Foo:
+    def foo(self, a, b, c, d, e):
+        pass
+"
+        );
+
+        let foo_module = &module.getattr("Foo").unwrap().call0().unwrap();
+        let args = (
+            <_ as IntoPy<PyObject>>::into_py(1, py).into_bound(py),
+            <_ as IntoPy<PyObject>>::into_py("s", py).into_bound(py),
+            <_ as IntoPy<PyObject>>::into_py(1.23, py).into_bound(py),
+        );
+        let kwargs = [("d", 1), ("e", 42)].into_py_dict(py);
+
+        b.iter(|| {
+            for _ in 0..1000 {
+                black_box(foo_module)
+                    .call_method("foo", args.clone(), Some(&kwargs))
+                    .unwrap();
+            }
+        });
+    })
+}
+
+fn bench_call_method_one_arg(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        let module = test_module!(
+            py,
+            "
+class Foo:
+    def foo(self, a):
+        pass
+"
+        );
+
+        let foo_module = &module.getattr("Foo").unwrap().call0().unwrap();
+        let arg = <_ as IntoPy<PyObject>>::into_py(1, py).into_bound(py);
+
+        b.iter(|| {
+            for _ in 0..1000 {
+                black_box(foo_module)
+                    .call_method1("foo", (arg.clone(),))
+                    .unwrap();
+            }
+        });
+    })
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("call_0", bench_call_0);
+    c.bench_function("call_1", bench_call_1);
+    c.bench_function("call", bench_call);
+    c.bench_function("call_one_arg", bench_call_one_arg);
     c.bench_function("call_method_0", bench_call_method_0);
+    c.bench_function("call_method_1", bench_call_method_1);
+    c.bench_function("call_method", bench_call_method);
+    c.bench_function("call_method_one_arg", bench_call_method_one_arg);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/pyo3-ffi/src/cpython/abstract_.rs
+++ b/pyo3-ffi/src/cpython/abstract_.rs
@@ -40,7 +40,7 @@ extern "C" {
 }
 
 #[cfg(Py_3_8)]
-const PY_VECTORCALL_ARGUMENTS_OFFSET: size_t =
+pub const PY_VECTORCALL_ARGUMENTS_OFFSET: size_t =
     1 << (8 * std::mem::size_of::<size_t>() as size_t - 1);
 
 #[cfg(Py_3_8)]

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,10 +1,11 @@
 //! Defines conversions between Rust and Python types.
 use crate::err::PyResult;
+use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::pyclass::boolean_struct::False;
 use crate::types::any::PyAnyMethods;
-use crate::types::PyTuple;
+use crate::types::{PyDict, PyString, PyTuple};
 use crate::{
     ffi, Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyObject, PyRef, PyRefMut, Python,
 };
@@ -171,6 +172,93 @@ pub trait IntoPy<T>: Sized {
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         TypeInfo::Any
+    }
+
+    // The following methods are helpers to use the vectorcall API where possible.
+    // They are overridden on tuples to perform a vectorcall.
+    // Be careful when you're implementing these: they can never refer to `Bound` call methods,
+    // as those refer to these methods, so this will create an infinite recursion.
+    #[doc(hidden)]
+    #[inline]
+    fn __py_call_vectorcall1<'py>(
+        self,
+        py: Python<'py>,
+        function: Borrowed<'_, 'py, PyAny>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>>
+    where
+        Self: IntoPy<Py<PyTuple>>,
+    {
+        #[inline]
+        fn inner<'py>(
+            py: Python<'py>,
+            function: Borrowed<'_, 'py, PyAny>,
+            args: Bound<'py, PyTuple>,
+        ) -> PyResult<Bound<'py, PyAny>> {
+            unsafe {
+                ffi::PyObject_Call(function.as_ptr(), args.as_ptr(), std::ptr::null_mut())
+                    .assume_owned_or_err(py)
+            }
+        }
+        inner(
+            py,
+            function,
+            <Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py),
+        )
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    fn __py_call_vectorcall<'py>(
+        self,
+        py: Python<'py>,
+        function: Borrowed<'_, 'py, PyAny>,
+        kwargs: Option<Borrowed<'_, '_, PyDict>>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>>
+    where
+        Self: IntoPy<Py<PyTuple>>,
+    {
+        #[inline]
+        fn inner<'py>(
+            py: Python<'py>,
+            function: Borrowed<'_, 'py, PyAny>,
+            args: Bound<'py, PyTuple>,
+            kwargs: Option<Borrowed<'_, '_, PyDict>>,
+        ) -> PyResult<Bound<'py, PyAny>> {
+            unsafe {
+                ffi::PyObject_Call(
+                    function.as_ptr(),
+                    args.as_ptr(),
+                    kwargs.map_or_else(std::ptr::null_mut, |kwargs| kwargs.as_ptr()),
+                )
+                .assume_owned_or_err(py)
+            }
+        }
+        inner(
+            py,
+            function,
+            <Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py),
+            kwargs,
+        )
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    fn __py_call_method_vectorcall1<'py>(
+        self,
+        _py: Python<'py>,
+        object: Borrowed<'_, 'py, PyAny>,
+        method_name: Bound<'py, PyString>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>>
+    where
+        Self: IntoPy<Py<PyTuple>>,
+    {
+        // Don't `self.into_py()`! This will lose the optimization of vectorcall.
+        object
+            .getattr(method_name)
+            .and_then(|method| method.call1(self))
     }
 }
 
@@ -501,6 +589,52 @@ where
 impl IntoPy<Py<PyTuple>> for () {
     fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
         PyTuple::empty(py).unbind()
+    }
+
+    #[inline]
+    fn __py_call_vectorcall1<'py>(
+        self,
+        py: Python<'py>,
+        function: Borrowed<'_, 'py, PyAny>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        unsafe { ffi::compat::PyObject_CallNoArgs(function.as_ptr()).assume_owned_or_err(py) }
+    }
+
+    #[inline]
+    fn __py_call_vectorcall<'py>(
+        self,
+        py: Python<'py>,
+        function: Borrowed<'_, 'py, PyAny>,
+        kwargs: Option<Borrowed<'_, '_, PyDict>>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        unsafe {
+            match kwargs {
+                Some(kwargs) => ffi::PyObject_Call(
+                    function.as_ptr(),
+                    PyTuple::empty(py).as_ptr(),
+                    kwargs.as_ptr(),
+                )
+                .assume_owned_or_err(py),
+                None => ffi::compat::PyObject_CallNoArgs(function.as_ptr()).assume_owned_or_err(py),
+            }
+        }
+    }
+
+    #[inline]
+    #[allow(clippy::used_underscore_binding)]
+    fn __py_call_method_vectorcall1<'py>(
+        self,
+        py: Python<'py>,
+        object: Borrowed<'_, 'py, PyAny>,
+        method_name: Bound<'py, PyString>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        unsafe {
+            ffi::compat::PyObject_CallMethodNoArgs(object.as_ptr(), method_name.as_ptr())
+                .assume_owned_or_err(py)
+        }
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1485,7 +1485,7 @@ impl<T> Py<T> {
     /// Calls the object with only positional arguments.
     ///
     /// This is equivalent to the Python expression `self(*args)`.
-    pub fn call1<'py, N>(&self, py: Python<'py>, args: N) -> PyResult<PyObject>
+    pub fn call1<N>(&self, py: Python<'_>, args: N) -> PyResult<PyObject>
     where
         N: IntoPy<Py<PyTuple>>,
     {

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1,13 +1,15 @@
 use std::iter::FusedIterator;
 
-use crate::conversion::IntoPyObject;
+use crate::conversion::{private, IntoPyObject};
 use crate::ffi::{self, Py_ssize_t};
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::instance::Borrowed;
 use crate::internal_tricks::get_ssize_index;
-use crate::types::{any::PyAnyMethods, sequence::PySequenceMethods, PyList, PySequence};
+use crate::types::{
+    any::PyAnyMethods, sequence::PySequenceMethods, PyDict, PyList, PySequence, PyString,
+};
 use crate::{
     exceptions, Bound, BoundObject, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult,
     Python, ToPyObject,
@@ -522,7 +524,7 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
         }
 
         #[cfg(feature = "experimental-inspect")]
-fn type_output() -> TypeInfo {
+        fn type_output() -> TypeInfo {
             TypeInfo::Tuple(Some(vec![$( $T::type_output() ),+]))
         }
     }
@@ -550,6 +552,109 @@ fn type_output() -> TypeInfo {
         fn type_output() -> TypeInfo {
             TypeInfo::Tuple(Some(vec![$( $T::type_output() ),+]))
         }
+
+        #[inline]
+        fn __py_call_vectorcall1<'py>(
+            self,
+            py: Python<'py>,
+            function: Borrowed<'_, 'py, PyAny>,
+            _: private::Token,
+        ) -> PyResult<Bound<'py, PyAny>> {
+            cfg_if::cfg_if! {
+                if #[cfg(all(Py_3_9, not(any(PyPy, GraalPy, Py_LIMITED_API))))] {
+                    // We need this to drop the arguments correctly.
+                    let args_bound = [$(self.$n.into_py(py).into_bound(py),)*];
+                    if $length == 1 {
+                        unsafe {
+                            ffi::PyObject_CallOneArg(function.as_ptr(), args_bound[0].as_ptr()).assume_owned_or_err(py)
+                        }
+                    } else {
+                        // Prepend one null argument for `PY_VECTORCALL_ARGUMENTS_OFFSET`.
+                        let mut args = [std::ptr::null_mut(), $(args_bound[$n].as_ptr()),*];
+                        unsafe {
+                            ffi::PyObject_Vectorcall(
+                                function.as_ptr(),
+                                args.as_mut_ptr().add(1),
+                                $length + ffi::PY_VECTORCALL_ARGUMENTS_OFFSET,
+                                std::ptr::null_mut(),
+                            )
+                            .assume_owned_or_err(py)
+                        }
+                    }
+                } else {
+                    function.call1(<Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py))
+                }
+            }
+        }
+
+        #[inline]
+        fn __py_call_vectorcall<'py>(
+            self,
+            py: Python<'py>,
+            function: Borrowed<'_, 'py, PyAny>,
+            kwargs: Option<Borrowed<'_, '_, PyDict>>,
+            _: private::Token,
+        ) -> PyResult<Bound<'py, PyAny>> {
+            cfg_if::cfg_if! {
+                if #[cfg(all(Py_3_9, not(any(PyPy, GraalPy, Py_LIMITED_API))))] {
+                    // We need this to drop the arguments correctly.
+                    let args_bound = [$(self.$n.into_py(py).into_bound(py),)*];
+                    // Prepend one null argument for `PY_VECTORCALL_ARGUMENTS_OFFSET`.
+                    let mut args = [std::ptr::null_mut(), $(args_bound[$n].as_ptr()),*];
+                    unsafe {
+                        ffi::PyObject_VectorcallDict(
+                            function.as_ptr(),
+                            args.as_mut_ptr().add(1),
+                            $length + ffi::PY_VECTORCALL_ARGUMENTS_OFFSET,
+                            kwargs.map_or_else(std::ptr::null_mut, |kwargs| kwargs.as_ptr()),
+                        )
+                        .assume_owned_or_err(py)
+                    }
+                } else {
+                    function.call(<Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py), kwargs.as_deref())
+                }
+            }
+        }
+
+        #[inline]
+        fn __py_call_method_vectorcall1<'py>(
+            self,
+            py: Python<'py>,
+            object: Borrowed<'_, 'py, PyAny>,
+            method_name: Bound<'py, PyString>,
+            _: private::Token,
+        ) -> PyResult<Bound<'py, PyAny>> {
+            cfg_if::cfg_if! {
+                if #[cfg(all(Py_3_9, not(any(PyPy, GraalPy, Py_LIMITED_API))))] {
+                    // We need this to drop the arguments correctly.
+                    let args_bound = [$(self.$n.into_py(py).into_bound(py),)*];
+                    if $length == 1 {
+                        unsafe {
+                            ffi::PyObject_CallMethodOneArg(
+                                    object.as_ptr(),
+                                    method_name.as_ptr(),
+                                    args_bound[0].as_ptr(),
+                            )
+                            .assume_owned_or_err(py)
+                        }
+                    } else {
+                        let mut args = [object.as_ptr(), $(args_bound[$n].as_ptr()),*];
+                        unsafe {
+                            ffi::PyObject_VectorcallMethod(
+                                method_name.as_ptr(),
+                                args.as_mut_ptr(),
+                                // +1 for the receiver.
+                                1 + $length + ffi::PY_VECTORCALL_ARGUMENTS_OFFSET,
+                                std::ptr::null_mut(),
+                            )
+                            .assume_owned_or_err(py)
+                        }
+                    }
+                } else {
+                    object.call_method1(method_name, <Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py))
+                }
+            }
+        }
     }
 
     impl<'py, $($T: FromPyObject<'py>),+> FromPyObject<'py> for ($($T,)+) {
@@ -568,7 +673,7 @@ fn type_output() -> TypeInfo {
         }
 
         #[cfg(feature = "experimental-inspect")]
-fn type_input() -> TypeInfo {
+        fn type_input() -> TypeInfo {
             TypeInfo::Tuple(Some(vec![$( $T::type_input() ),+]))
         }
     }


### PR DESCRIPTION
This works without any changes to user code.

The way it works is by creating a methods on `IntoPy` to call functions, and specializing them for tuples.

This currently supports only non-kwargs for methods, and kwargs with somewhat slow approach (converting from PyDict) for functions. This can be improved, but that will require additional API.

We may consider adding more impls `IntoPy<Py<PyTuple>>` that specialize (for example, for arrays and `Vec`), but this is a good start.

What should I put in the news? There is no `perf`.