### PR TITLE
Fix tests for cargo stress on free-threaded build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
 rayon = "1.6.1"
 futures = "0.3.28"
+tempfile = "3.12.0"
 
 [build-dependencies]
 pyo3-build-config = { path = "pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }

--- a/tests/test_datetime_import.rs
+++ b/tests/test_datetime_import.rs
@@ -1,31 +1,28 @@
 #![cfg(not(Py_LIMITED_API))]
 
 use pyo3::{prelude::*, types::PyDate};
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-static COUNTER: AtomicUsize = AtomicUsize::new(0);
+use tempfile::Builder;
 
 #[test]
 #[should_panic(expected = "module 'datetime' has no attribute 'datetime_CAPI'")]
 fn test_bad_datetime_module_panic() {
     // Create an empty temporary directory
     // with an empty "datetime" module which we'll put on the sys.path
-    let tmpdir = std::env::temp_dir();
-    let id = COUNTER.fetch_add(1, Ordering::SeqCst);
-    let tmpdir = tmpdir.join(format!("pyo3_test_date_check_{id}"));
-    let _ = std::fs::remove_dir_all(&tmpdir);
-    std::fs::create_dir(&tmpdir).unwrap();
-    std::fs::File::create(tmpdir.join("datetime.py")).unwrap();
+    let tmpdir = Builder::new()
+        .prefix("pyo3_test_data_check")
+        .tempdir()
+        .unwrap();
+    std::fs::File::create(tmpdir.path().join("datetime.py")).unwrap();
 
     Python::with_gil(|py: Python<'_>| {
         let sys = py.import("sys").unwrap();
         sys.getattr("path")
             .unwrap()
-            .call_method1("insert", (0, &tmpdir))
+            .call_method1("insert", (0, tmpdir.path()))
             .unwrap();
 
         // This should panic because the "datetime" module is empty
         PyDate::new(py, 2018, 1, 1).unwrap();
     });
-    std::fs::remove_dir_all(&tmpdir).unwrap();
+    tmpdir.close().unwrap();
 }


### PR DESCRIPTION
refs #4265

The free-threaded build has a lot of flaky tests at the moment and I'm trying various strategies to find them. Running `cargo test` in a bash while loop works well, but `cargo stress` also seems to find interesting bugs. This fixes issues that `cargo stress` hits quickly on my local setup.

The changes to `test_datetime_imports` can be hit in a regular gil-enabled python build, the test uses the filesystem assuming no other instances of the test function are running simultaneously. I updated it so it will create directories with unique names.

The changes for the decref pool tests are because in the free-threaded build other threads are free to process the decref pool at any time, it's no longer locked by the GIL. That's fine, it doesn't matter if the owning thread or another random thread processes the pool. It does mean that the assertions in the tests are no longer always true and depend on timing. I added comments where I had to think really hard about scenarios where the assertions don't hold.

There's also one assertion that is changed because the `Py_DECREF` calls on the pending decref pool can happen concurrently with calls to `Py_REFCNT` in other threads, making the result of `Py_REFCNT` racy. The mutex on the pending decrefs pool is implicitly released when `pending_decrefs` is dropped before calling the C API here:

https://github.com/PyO3/pyo3/blob/2f5b45efa10e52a44bb3185dfeb716c2e815a4f8/src/gil.rs#L276-L281