### PR TITLE
docs: Update multiple-python-versions.md

### DIFF
--- a/guide/src/building-and-distribution/multiple-python-versions.md
+++ b/guide/src/building-and-distribution/multiple-python-versions.md
@@ -1,6 +1,6 @@
 # Supporting multiple Python versions
 
-PyO3 supports all actively-supported Python 3 and PyPy versions. As much as possible, this is done internally to PyO3 so that your crate's code does not need to adapt to the differences between each version. However, as Python features grow and change between versions, PyO3 cannot a completely identical API for every Python version. This may require you to add conditional compilation to your crate or runtime checks for the Python version.
+PyO3 supports all actively-supported Python 3 and PyPy versions. As much as possible, this is done internally to PyO3 so that your crate's code does not need to adapt to the differences between each version. However, as Python features grow and change between versions, PyO3 cannot offer a completely identical API for every Python version. This may require you to add conditional compilation to your crate or runtime checks for the Python version.
 
 This section of the guide first introduces the `pyo3-build-config` crate, which you can use as a `build-dependency` to add additional `#[cfg]` flags which allow you to support multiple Python versions at compile-time.
 


### PR DESCRIPTION
docs: Missing word in documentation. "PyO3 cannot a completely identical API" to "PyO3 cannot offer a completely identical API"

