### PR TITLE
only show free-threaded warning on free-threaded build

### DIFF
--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -135,7 +135,7 @@ fn ensure_gil_enabled(interpreter_config: &InterpreterConfig) -> Result<()> {
         = help: set UNSAFE_PYO3_BUILD_FREE_THREADED=1 to suppress this check and build anyway for free-threaded Python",
         std::env::var("CARGO_PKG_VERSION").unwrap()
     );
-    if interpreter_config.abi3 {
+    if !gil_enabled && interpreter_config.abi3 {
         warn!(
             "The free-threaded build of CPython does not yet support abi3 so the build artifacts will be version-specific."
         )


### PR DESCRIPTION
cc @ngoldbaum 

(No changelog because we added this warning as part of 0.23...)