### PR TITLE
skip tests using thread-unsafe constructs on free-threaded build

### DIFF
--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1340,7 +1340,7 @@ mod tests {
             .unwrap()
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(any(target_arch = "wasm32", Py_GIL_DISABLED)))]
     mod proptests {
         use super::*;
         use crate::tests::common::CatchWarnings;

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1096,6 +1096,7 @@ mod tests {
 
             check_utc("regular", 2014, 5, 6, 7, 8, 9, 999_999, 999_999);
 
+            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 check_utc("leap second", 2014, 5, 6, 7, 8, 59, 1_999_999, 999_999),
@@ -1138,6 +1139,7 @@ mod tests {
 
             check_fixed_offset("regular", 2014, 5, 6, 7, 8, 9, 999_999, 999_999);
 
+            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 check_fixed_offset("leap second", 2014, 5, 6, 7, 8, 59, 1_999_999, 999_999),
@@ -1293,6 +1295,7 @@ mod tests {
 
             check_time("regular", 3, 5, 7, 999_999, 999_999);
 
+            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 check_time("leap second", 3, 5, 59, 1_999_999, 999_999),

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1159,6 +1159,7 @@ mod tests {
             warnings.call_method0("resetwarnings").unwrap();
 
             // First, test the warning is emitted
+            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 { PyErr::warn_bound(py, &cls, "I am warning you", 0).unwrap() },
@@ -1178,6 +1179,7 @@ mod tests {
                 .unwrap();
 
             // This has the wrong module and will not raise, just be emitted
+            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 { PyErr::warn_bound(py, &cls, "I am warning you", 0).unwrap() },

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -9,8 +9,10 @@ mod inner {
     #[allow(unused_imports)] // pulls in `use crate as pyo3` in `test_utils.rs`
     use super::*;
 
+    #[cfg(not(Py_GIL_DISABLED))]
     use pyo3::prelude::*;
 
+    #[cfg(not(Py_GIL_DISABLED))]
     use pyo3::types::{IntoPyDict, PyList};
 
     #[macro_export]
@@ -63,14 +65,14 @@ mod inner {
     }
 
     // sys.unraisablehook not available until Python 3.8
-    #[cfg(all(feature = "macros", Py_3_8))]
+    #[cfg(all(feature = "macros", Py_3_8, not(Py_GIL_DISABLED)))]
     #[pyclass(crate = "pyo3")]
     pub struct UnraisableCapture {
         pub capture: Option<(PyErr, PyObject)>,
         old_hook: Option<PyObject>,
     }
 
-    #[cfg(all(feature = "macros", Py_3_8))]
+    #[cfg(all(feature = "macros", Py_3_8, not(Py_GIL_DISABLED)))]
     #[pymethods(crate = "pyo3")]
     impl UnraisableCapture {
         pub fn hook(&mut self, unraisable: Bound<'_, PyAny>) {
@@ -80,7 +82,7 @@ mod inner {
         }
     }
 
-    #[cfg(all(feature = "macros", Py_3_8))]
+    #[cfg(all(feature = "macros", Py_3_8, not(Py_GIL_DISABLED)))]
     impl UnraisableCapture {
         pub fn install(py: Python<'_>) -> Py<Self> {
             let sys = py.import("sys").unwrap();
@@ -109,10 +111,12 @@ mod inner {
         }
     }
 
+    #[cfg(not(Py_GIL_DISABLED))]
     pub struct CatchWarnings<'py> {
         catch_warnings: Bound<'py, PyAny>,
     }
 
+    #[cfg(not(Py_GIL_DISABLED))]
     impl<'py> CatchWarnings<'py> {
         pub fn enter<R>(
             py: Python<'py>,
@@ -129,6 +133,7 @@ mod inner {
         }
     }
 
+    #[cfg(not(Py_GIL_DISABLED))]
     impl Drop for CatchWarnings<'_> {
         fn drop(&mut self) {
             let py = self.catch_warnings.py();
@@ -138,6 +143,7 @@ mod inner {
         }
     }
 
+    #[cfg(not(Py_GIL_DISABLED))]
     #[macro_export]
     macro_rules! assert_warnings {
         ($py:expr, $body:expr, [$(($category:ty, $message:literal)),+] $(,)? ) => {{

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 pub(crate) mod common {
+    #[cfg(not(Py_GIL_DISABLED))]
     use crate as pyo3;
     include!("./common.rs");
 }

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -94,7 +94,7 @@ fn test_buffer_referenced() {
 }
 
 #[test]
-#[cfg(Py_3_8)] // sys.unraisablehook not available until Python 3.8
+#[cfg(all(Py_3_8, not(Py_GIL_DISABLED)))] // sys.unraisablehook not available until Python 3.8
 fn test_releasebuffer_unraisable_error() {
     use common::UnraisableCapture;
     use pyo3::exceptions::PyValueError;

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -615,7 +615,7 @@ fn access_frozen_class_without_gil() {
 }
 
 #[test]
-#[cfg(Py_3_8)] // sys.unraisablehook not available until Python 3.8
+#[cfg(all(Py_3_8, not(Py_GIL_DISABLED)))] // sys.unraisablehook not available until Python 3.8
 #[cfg_attr(target_arch = "wasm32", ignore)]
 fn drop_unsendable_elsewhere() {
     use common::UnraisableCapture;

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -99,7 +99,7 @@ fn test_exception_nosegfault() {
 }
 
 #[test]
-#[cfg(Py_3_8)]
+#[cfg(all(Py_3_8, not(Py_GIL_DISABLED)))]
 fn test_write_unraisable() {
     use common::UnraisableCapture;
     use pyo3::{exceptions::PyRuntimeError, ffi, types::PyNotImplemented};


### PR DESCRIPTION
This skips tests that rely on setting `sys.unraisablehook` and tests that use `warnings.catch_warnings`.

Setting anything on the `sys` module is overriding global state, so it fundamentally isn't thread safe. An alternative would be to make it so any test that uses `UnraisableCapture` needs to acquire a mutex first. Happy to do that if anyone is uncomfortable with skipping tests.

Unfortunately there isn't a similar workaround for tests relying on `catch_warnings`, it's fundamentally [not thread safe](https://github.com/python/cpython/issues/91505), as [mentioned in the docs for it](https://docs.python.org/3/library/warnings.html#warnings.catch_warnings).