### PR TITLE
add bindings for critical section API

### DIFF
--- a/newsfragments/4477.added.md
+++ b/newsfragments/4477.added.md
@@ -1,0 +1,1 @@
+* Added bindings for the Python critical section API available on Python 3.13 and newer.

--- a/pyo3-ffi/src/cpython/critical_section.rs
+++ b/pyo3-ffi/src/cpython/critical_section.rs
@@ -1,0 +1,28 @@
+use crate::{PyMutex, PyObject};
+
+#[repr(C)]
+#[cfg(Py_GIL_DISABLED)]
+pub struct PyCriticalSection {
+    _cs_prev: usize,
+    _cs_mutex: *mut PyMutex,
+}
+
+#[repr(C)]
+#[cfg(Py_GIL_DISABLED)]
+pub struct PyCriticalSection2 {
+    _cs_base: PyCriticalSection,
+    _cs_mutex2: *mut PyMutex,
+}
+
+#[cfg(not(Py_GIL_DISABLED))]
+opaque_struct!(PyCriticalSection);
+
+#[cfg(not(Py_GIL_DISABLED))]
+opaque_struct!(PyCriticalSection2);
+
+extern "C" {
+    pub fn PyCriticalSection_Begin(c: *mut PyCriticalSection, op: *mut PyObject);
+    pub fn PyCriticalSection_End(c: *mut PyCriticalSection);
+    pub fn PyCriticalSection2_Begin(c: *mut PyCriticalSection2, a: *mut PyObject, b: *mut PyObject);
+    pub fn PyCriticalSection2_End(c: *mut PyCriticalSection2);
+}

--- a/pyo3-ffi/src/cpython/critical_section.rs
+++ b/pyo3-ffi/src/cpython/critical_section.rs
@@ -1,4 +1,6 @@
-use crate::{PyMutex, PyObject};
+#[cfg(Py_GIL_DISABLED)]
+use crate::PyMutex;
+use crate::PyObject;
 
 #[repr(C)]
 #[cfg(Py_GIL_DISABLED)]

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod bytesobject;
 pub(crate) mod ceval;
 pub(crate) mod code;
 pub(crate) mod compile;
+pub(crate) mod critical_section;
 pub(crate) mod descrobject;
 #[cfg(not(PyPy))]
 pub(crate) mod dictobject;
@@ -45,6 +46,7 @@ pub use self::bytesobject::*;
 pub use self::ceval::*;
 pub use self::code::*;
 pub use self::compile::*;
+pub use self::critical_section::*;
 pub use self::descrobject::*;
 #[cfg(not(PyPy))]
 pub use self::dictobject::*;

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod bytesobject;
 pub(crate) mod ceval;
 pub(crate) mod code;
 pub(crate) mod compile;
+#[cfg(Py_3_13)]
 pub(crate) mod critical_section;
 pub(crate) mod descrobject;
 #[cfg(not(PyPy))]
@@ -46,6 +47,7 @@ pub use self::bytesobject::*;
 pub use self::ceval::*;
 pub use self::code::*;
 pub use self::compile::*;
+#[cfg(Py_3_13)]
 pub use self::critical_section::*;
 pub use self::descrobject::*;
 #[cfg(not(PyPy))]


### PR DESCRIPTION
refs #4265, specifically https://github.com/PyO3/pyo3/issues/4265#issuecomment-2293897660, ultimately we want to use this in `GILProtected` and `GILOnceCell`.

#4439 is an alternate approach that also uses this API for dict iteration (following the suggestion in the [docs for `PyDict_Next`](https://docs.python.org/3.13/c-api/dict.html#c.PyDict_Next)). I'm holding off on using this API in that spot because of the discussion in that PR.

That PR doesn't use `opaque_struct` on the GIL-enabled build, but I think that's actually the correct thing to do, since it's an opaque struct in the regular ABI:

https://github.com/python/cpython/blob/556e8556849cb9df0666629b0f564b5dd203344c/Include/cpython/critical_section.h#L70-L71

I'm not exposing the begin/end critical section macros because they include braces and are not expressible in rust.