### PR TITLE
avoid creating `PyRef` inside `__traverse__` handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ serde_json = "1.0.61"
 rayon = "1.6.1"
 futures = "0.3.28"
 tempfile = "3.12.0"
+static_assertions = "1.1.0"
 
 [build-dependencies]
 pyo3-build-config = { path = "pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }

--- a/newsfragments/4479.fixed.md
+++ b/newsfragments/4479.fixed.md
@@ -1,0 +1,1 @@
+Remove illegal reference counting op inside implementation of `__traverse__` handlers.

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -312,14 +312,6 @@ impl<'py, T: PyClass> PyRef<'py, T> {
             .try_borrow()
             .map(|_| Self { inner: obj.clone() })
     }
-
-    pub(crate) fn try_borrow_threadsafe(obj: &Bound<'py, T>) -> Result<Self, PyBorrowError> {
-        let cell = obj.get_class_object();
-        cell.check_threadsafe()?;
-        cell.borrow_checker()
-            .try_borrow()
-            .map(|_| Self { inner: obj.clone() })
-    }
 }
 
 impl<'p, T, U> PyRef<'p, T>

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -6,6 +6,7 @@ mod create_type_object;
 mod gc;
 
 pub(crate) use self::create_type_object::{create_type_object, PyClassTypeObject};
+
 pub use self::gc::{PyTraverseError, PyVisit};
 
 /// Types that can be used as Python classes.


### PR DESCRIPTION
See https://github.com/PyO3/pyo3/issues/4265#issuecomment-2305890021

We cannot use `PyRef<T>` to guard access to the value inside a `__traverse__` handler. Instead I use the `PyClassObject<T>` and manually perform the borrow checking.