### PR TITLE
initial migration of the trait bounds to `IntoPyObject` (`PyAnyMethods`)

### DIFF
--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -47,6 +47,7 @@ use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 #[cfg(not(Py_LIMITED_API))]
 use crate::types::datetime::timezone_from_offset;
+use crate::types::PyNone;
 #[cfg(not(Py_LIMITED_API))]
 use crate::types::{
     timezone_utc, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess,
@@ -551,12 +552,12 @@ impl FromPyObject<'_> for FixedOffset {
         #[cfg(Py_LIMITED_API)]
         check_type(ob, &DatetimeTypes::get(ob.py()).tzinfo, "PyTzInfo")?;
 
-        // Passing `()` (so Python's None) to the `utcoffset` function will only
+        // Passing Python's None to the `utcoffset` function will only
         // work for timezones defined as fixed offsets in Python.
         // Any other timezone would require a datetime as the parameter, and return
         // None if the datetime is not provided.
         // Trying to convert None to a PyDelta in the next line will then fail.
-        let py_timedelta = ob.call_method1("utcoffset", ((),))?;
+        let py_timedelta = ob.call_method1("utcoffset", (PyNone::get(ob.py()),))?;
         if py_timedelta.is_none() {
             return Err(PyTypeError::new_err(format!(
                 "{:?} is not a fixed offset timezone",
@@ -810,7 +811,7 @@ fn timezone_utc(py: Python<'_>) -> Bound<'_, PyAny> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{types::PyTuple, Py};
+    use crate::types::PyTuple;
     use std::{cmp::Ordering, panic};
 
     #[test]
@@ -1318,11 +1319,11 @@ mod tests {
         })
     }
 
-    fn new_py_datetime_ob<'py>(
-        py: Python<'py>,
-        name: &str,
-        args: impl IntoPy<Py<PyTuple>>,
-    ) -> Bound<'py, PyAny> {
+    fn new_py_datetime_ob<'py, A>(py: Python<'py>, name: &str, args: A) -> Bound<'py, PyAny>
+    where
+        A: IntoPyObject<'py, Target = PyTuple>,
+        A::Error: Into<PyErr>,
+    {
         py.import("datetime")
             .unwrap()
             .getattr(name)

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -46,6 +46,16 @@ macro_rules! int_fits_larger_int {
             }
         }
 
+        impl<'py> IntoPyObject<'py> for &$rust_type {
+            type Target = PyInt;
+            type Output = Bound<'py, Self::Target>;
+            type Error = Infallible;
+
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                (*self).into_pyobject(py)
+            }
+        }
+
         impl FromPyObject<'_> for $rust_type {
             fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
                 let val: $larger_type = obj.extract()?;

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,3 +1,4 @@
+use crate::conversion::IntoPyObject;
 use crate::err::{self, PyErr, PyResult};
 use crate::impl_::pycell::PyClassObject;
 use crate::internal_tricks::ptr_from_ref;
@@ -1426,9 +1427,10 @@ impl<T> Py<T> {
     /// #    version(sys, py).unwrap();
     /// # });
     /// ```
-    pub fn getattr<N>(&self, py: Python<'_>, attr_name: N) -> PyResult<PyObject>
+    pub fn getattr<'py, N>(&self, py: Python<'py>, attr_name: N) -> PyResult<PyObject>
     where
-        N: IntoPy<Py<PyString>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>,
     {
         self.bind(py).as_any().getattr(attr_name).map(Bound::unbind)
     }
@@ -1455,32 +1457,40 @@ impl<T> Py<T> {
     /// #    set_answer(ob, py).unwrap();
     /// # });
     /// ```
-    pub fn setattr<N, V>(&self, py: Python<'_>, attr_name: N, value: V) -> PyResult<()>
+    pub fn setattr<'py, N, V>(&self, py: Python<'py>, attr_name: N, value: V) -> PyResult<()>
     where
-        N: IntoPy<Py<PyString>>,
-        V: IntoPy<Py<PyAny>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        V: IntoPyObject<'py>,
+        N::Error: Into<PyErr>,
+        V::Error: Into<PyErr>,
     {
-        self.bind(py)
-            .as_any()
-            .setattr(attr_name, value.into_py(py).into_bound(py))
+        self.bind(py).as_any().setattr(attr_name, value)
     }
 
     /// Calls the object.
     ///
     /// This is equivalent to the Python expression `self(*args, **kwargs)`.
-    pub fn call_bound(
+    pub fn call_bound<'py, N>(
         &self,
-        py: Python<'_>,
-        args: impl IntoPy<Py<PyTuple>>,
-        kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<PyObject> {
+        py: Python<'py>,
+        args: N,
+        kwargs: Option<&Bound<'py, PyDict>>,
+    ) -> PyResult<PyObject>
+    where
+        N: IntoPyObject<'py, Target = PyTuple>,
+        N::Error: Into<PyErr>,
+    {
         self.bind(py).as_any().call(args, kwargs).map(Bound::unbind)
     }
 
     /// Calls the object with only positional arguments.
     ///
     /// This is equivalent to the Python expression `self(*args)`.
-    pub fn call1(&self, py: Python<'_>, args: impl IntoPy<Py<PyTuple>>) -> PyResult<PyObject> {
+    pub fn call1<'py, N>(&self, py: Python<'py>, args: N) -> PyResult<PyObject>
+    where
+        N: IntoPyObject<'py, Target = PyTuple>,
+        N::Error: Into<PyErr>,
+    {
         self.bind(py).as_any().call1(args).map(Bound::unbind)
     }
 
@@ -1497,16 +1507,18 @@ impl<T> Py<T> {
     ///
     /// To avoid repeated temporary allocations of Python strings, the [`intern!`](crate::intern)
     /// macro can be used to intern `name`.
-    pub fn call_method_bound<N, A>(
+    pub fn call_method_bound<'py, N, A>(
         &self,
-        py: Python<'_>,
+        py: Python<'py>,
         name: N,
         args: A,
         kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<PyObject>
     where
-        N: IntoPy<Py<PyString>>,
-        A: IntoPy<Py<PyTuple>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        A: IntoPyObject<'py, Target = PyTuple>,
+        N::Error: Into<PyErr>,
+        A::Error: Into<PyErr>,
     {
         self.bind(py)
             .as_any()
@@ -1520,10 +1532,12 @@ impl<T> Py<T> {
     ///
     /// To avoid repeated temporary allocations of Python strings, the [`intern!`](crate::intern)
     /// macro can be used to intern `name`.
-    pub fn call_method1<N, A>(&self, py: Python<'_>, name: N, args: A) -> PyResult<PyObject>
+    pub fn call_method1<'py, N, A>(&self, py: Python<'py>, name: N, args: A) -> PyResult<PyObject>
     where
-        N: IntoPy<Py<PyString>>,
-        A: IntoPy<Py<PyTuple>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        A: IntoPyObject<'py, Target = PyTuple>,
+        N::Error: Into<PyErr>,
+        A::Error: Into<PyErr>,
     {
         self.bind(py)
             .as_any()
@@ -1537,9 +1551,10 @@ impl<T> Py<T> {
     ///
     /// To avoid repeated temporary allocations of Python strings, the [`intern!`](crate::intern)
     /// macro can be used to intern `name`.
-    pub fn call_method0<N>(&self, py: Python<'_>, name: N) -> PyResult<PyObject>
+    pub fn call_method0<'py, N>(&self, py: Python<'py>, name: N) -> PyResult<PyObject>
     where
-        N: IntoPy<Py<PyString>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>,
     {
         self.bind(py).as_any().call_method0(name).map(Bound::unbind)
     }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,7 +8,7 @@
 //! use pyo3::prelude::*;
 //! ```
 
-pub use crate::conversion::{FromPyObject, IntoPy, ToPyObject};
+pub use crate::conversion::{FromPyObject, IntoPy, IntoPyObject, ToPyObject};
 pub use crate::err::{PyErr, PyResult};
 pub use crate::instance::{Borrowed, Bound, Py, PyObject};
 pub use crate::marker::Python;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1,5 +1,5 @@
 use crate::class::basic::CompareOp;
-use crate::conversion::{AsPyPointer, FromPyObjectBound, IntoPy, ToPyObject};
+use crate::conversion::{AsPyPointer, FromPyObjectBound, IntoPyObject};
 use crate::err::{DowncastError, DowncastIntoError, PyErr, PyResult};
 use crate::exceptions::{PyAttributeError, PyTypeError};
 use crate::ffi_ptr_ext::FfiPtrExt;
@@ -10,7 +10,7 @@ use crate::type_object::{PyTypeCheck, PyTypeInfo};
 #[cfg(not(any(PyPy, GraalPy)))]
 use crate::types::PySuper;
 use crate::types::{PyDict, PyIterator, PyList, PyString, PyTuple, PyType};
-use crate::{err, ffi, Py, Python};
+use crate::{err, ffi, BoundObject, Python};
 use std::cell::UnsafeCell;
 use std::cmp::Ordering;
 use std::os::raw::c_int;
@@ -81,7 +81,8 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn hasattr<N>(&self, attr_name: N) -> PyResult<bool>
     where
-        N: IntoPy<Py<PyString>>;
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>;
 
     /// Retrieves an attribute value.
     ///
@@ -107,7 +108,8 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn getattr<N>(&self, attr_name: N) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPy<Py<PyString>>;
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>;
 
     /// Sets an attribute value.
     ///
@@ -133,8 +135,10 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn setattr<N, V>(&self, attr_name: N, value: V) -> PyResult<()>
     where
-        N: IntoPy<Py<PyString>>,
-        V: ToPyObject;
+        N: IntoPyObject<'py, Target = PyString>,
+        V: IntoPyObject<'py>,
+        N::Error: Into<PyErr>,
+        V::Error: Into<PyErr>;
 
     /// Deletes an attribute.
     ///
@@ -144,7 +148,8 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// to intern `attr_name`.
     fn delattr<N>(&self, attr_name: N) -> PyResult<()>
     where
-        N: IntoPy<Py<PyString>>;
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>;
 
     /// Returns an [`Ordering`] between `self` and `other`.
     ///
@@ -194,7 +199,8 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn compare<O>(&self, other: O) -> PyResult<Ordering>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Tests whether two Python objects obey a given [`CompareOp`].
     ///
@@ -232,7 +238,8 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn rich_compare<O>(&self, other: O, compare_op: CompareOp) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes the negative of self.
     ///
@@ -257,114 +264,135 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// This is equivalent to the Python expression `self < other`.
     fn lt<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Tests whether this object is less than or equal to another.
     ///
     /// This is equivalent to the Python expression `self <= other`.
     fn le<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Tests whether this object is equal to another.
     ///
     /// This is equivalent to the Python expression `self == other`.
     fn eq<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Tests whether this object is not equal to another.
     ///
     /// This is equivalent to the Python expression `self != other`.
     fn ne<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Tests whether this object is greater than another.
     ///
     /// This is equivalent to the Python expression `self > other`.
     fn gt<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Tests whether this object is greater than or equal to another.
     ///
     /// This is equivalent to the Python expression `self >= other`.
     fn ge<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self + other`.
     fn add<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self - other`.
     fn sub<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self * other`.
     fn mul<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self @ other`.
     fn matmul<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self / other`.
     fn div<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self // other`.
     fn floor_div<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self % other`.
     fn rem<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `divmod(self, other)`.
     fn divmod<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self << other`.
     fn lshift<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self >> other`.
     fn rshift<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self ** other % modulus` (`pow(self, other, modulus)`).
     /// `py.None()` may be passed for the `modulus`.
     fn pow<O1, O2>(&self, other: O1, modulus: O2) -> PyResult<Bound<'py, PyAny>>
     where
-        O1: ToPyObject,
-        O2: ToPyObject;
+        O1: IntoPyObject<'py>,
+        O2: IntoPyObject<'py>,
+        O1::Error: Into<PyErr>,
+        O2::Error: Into<PyErr>;
 
     /// Computes `self & other`.
     fn bitand<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self | other`.
     fn bitor<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Computes `self ^ other`.
     fn bitxor<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject;
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>;
 
     /// Determines whether this object appears callable.
     ///
@@ -427,11 +455,10 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// })
     /// # }
     /// ```
-    fn call(
-        &self,
-        args: impl IntoPy<Py<PyTuple>>,
-        kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<Bound<'py, PyAny>>;
+    fn call<A>(&self, args: A, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Bound<'py, PyAny>>
+    where
+        A: IntoPyObject<'py, Target = PyTuple>,
+        A::Error: Into<PyErr>;
 
     /// Calls the object without arguments.
     ///
@@ -484,7 +511,10 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// })
     /// # }
     /// ```
-    fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<Bound<'py, PyAny>>;
+    fn call1<A>(&self, args: A) -> PyResult<Bound<'py, PyAny>>
+    where
+        A: IntoPyObject<'py, Target = PyTuple>,
+        A::Error: Into<PyErr>;
 
     /// Calls a method on the object.
     ///
@@ -530,8 +560,10 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
         kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPy<Py<PyString>>,
-        A: IntoPy<Py<PyTuple>>;
+        N: IntoPyObject<'py, Target = PyString>,
+        A: IntoPyObject<'py, Target = PyTuple>,
+        N::Error: Into<PyErr>,
+        A::Error: Into<PyErr>;
 
     /// Calls a method on the object without arguments.
     ///
@@ -568,7 +600,8 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn call_method0<N>(&self, name: N) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPy<Py<PyString>>;
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>;
 
     /// Calls a method on the object with only positional arguments.
     ///
@@ -606,8 +639,10 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn call_method1<N, A>(&self, name: N, args: A) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPy<Py<PyString>>,
-        A: IntoPy<Py<PyTuple>>;
+        N: IntoPyObject<'py, Target = PyString>,
+        A: IntoPyObject<'py, Target = PyTuple>,
+        N::Error: Into<PyErr>,
+        A::Error: Into<PyErr>;
 
     /// Returns whether the object is considered to be true.
     ///
@@ -635,22 +670,26 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// This is equivalent to the Python expression `self[key]`.
     fn get_item<K>(&self, key: K) -> PyResult<Bound<'py, PyAny>>
     where
-        K: ToPyObject;
+        K: IntoPyObject<'py>,
+        K::Error: Into<PyErr>;
 
     /// Sets a collection item value.
     ///
     /// This is equivalent to the Python expression `self[key] = value`.
     fn set_item<K, V>(&self, key: K, value: V) -> PyResult<()>
     where
-        K: ToPyObject,
-        V: ToPyObject;
+        K: IntoPyObject<'py>,
+        V: IntoPyObject<'py>,
+        K::Error: Into<PyErr>,
+        V::Error: Into<PyErr>;
 
     /// Deletes an item from the collection.
     ///
     /// This is equivalent to the Python expression `del self[key]`.
     fn del_item<K>(&self, key: K) -> PyResult<()>
     where
-        K: ToPyObject;
+        K: IntoPyObject<'py>,
+        K::Error: Into<PyErr>;
 
     /// Takes an object and returns an iterator for it.
     ///
@@ -862,7 +901,8 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// This is equivalent to the Python expression `value in self`.
     fn contains<V>(&self, value: V) -> PyResult<bool>
     where
-        V: ToPyObject;
+        V: IntoPyObject<'py>,
+        V::Error: Into<PyErr>;
 
     /// Return a proxy object that delegates method calls to a parent or sibling class of type.
     ///
@@ -876,17 +916,25 @@ macro_rules! implement_binop {
         #[doc = concat!("Computes `self ", $op, " other`.")]
         fn $name<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
         where
-            O: ToPyObject,
+            O: IntoPyObject<'py>,
+            O::Error: Into<PyErr>,
         {
             fn inner<'py>(
                 any: &Bound<'py, PyAny>,
-                other: Bound<'_, PyAny>,
+                other: &Bound<'_, PyAny>,
             ) -> PyResult<Bound<'py, PyAny>> {
                 unsafe { ffi::$c_api(any.as_ptr(), other.as_ptr()).assume_owned_or_err(any.py()) }
             }
 
             let py = self.py();
-            inner(self, other.to_object(py).into_bound(py))
+            inner(
+                self,
+                &other
+                    .into_pyobject(py)
+                    .map_err(Into::into)?
+                    .into_any()
+                    .as_borrowed(),
+            )
         }
     };
 }
@@ -899,7 +947,8 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn hasattr<N>(&self, attr_name: N) -> PyResult<bool>
     where
-        N: IntoPy<Py<PyString>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>,
     {
         // PyObject_HasAttr suppresses all exceptions, which was the behaviour of `hasattr` in Python 2.
         // Use an implementation which suppresses only AttributeError, which is consistent with `hasattr` in Python 3.
@@ -911,16 +960,17 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
             }
         }
 
-        inner(self.py(), self.getattr(attr_name))
+        inner(self.py(), self.getattr(attr_name).map_err(Into::into))
     }
 
     fn getattr<N>(&self, attr_name: N) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPy<Py<PyString>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
-            attr_name: Bound<'_, PyString>,
+            attr_name: &Bound<'_, PyString>,
         ) -> PyResult<Bound<'py, PyAny>> {
             unsafe {
                 ffi::PyObject_GetAttr(any.as_ptr(), attr_name.as_ptr())
@@ -928,19 +978,26 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
             }
         }
 
-        let py = self.py();
-        inner(self, attr_name.into_py(self.py()).into_bound(py))
+        inner(
+            self,
+            &attr_name
+                .into_pyobject(self.py())
+                .map_err(Into::into)?
+                .as_borrowed(),
+        )
     }
 
     fn setattr<N, V>(&self, attr_name: N, value: V) -> PyResult<()>
     where
-        N: IntoPy<Py<PyString>>,
-        V: ToPyObject,
+        N: IntoPyObject<'py, Target = PyString>,
+        V: IntoPyObject<'py>,
+        N::Error: Into<PyErr>,
+        V::Error: Into<PyErr>,
     {
         fn inner(
             any: &Bound<'_, PyAny>,
-            attr_name: Bound<'_, PyString>,
-            value: Bound<'_, PyAny>,
+            attr_name: &Bound<'_, PyString>,
+            value: &Bound<'_, PyAny>,
         ) -> PyResult<()> {
             err::error_on_minusone(any.py(), unsafe {
                 ffi::PyObject_SetAttr(any.as_ptr(), attr_name.as_ptr(), value.as_ptr())
@@ -950,30 +1007,45 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         let py = self.py();
         inner(
             self,
-            attr_name.into_py(py).into_bound(py),
-            value.to_object(py).into_bound(py),
+            &attr_name
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .as_borrowed(),
+            &value
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
         )
     }
 
     fn delattr<N>(&self, attr_name: N) -> PyResult<()>
     where
-        N: IntoPy<Py<PyString>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>,
     {
-        fn inner(any: &Bound<'_, PyAny>, attr_name: Bound<'_, PyString>) -> PyResult<()> {
+        fn inner(any: &Bound<'_, PyAny>, attr_name: &Bound<'_, PyString>) -> PyResult<()> {
             err::error_on_minusone(any.py(), unsafe {
                 ffi::PyObject_DelAttr(any.as_ptr(), attr_name.as_ptr())
             })
         }
 
         let py = self.py();
-        inner(self, attr_name.into_py(py).into_bound(py))
+        inner(
+            self,
+            &attr_name
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .as_borrowed(),
+        )
     }
 
     fn compare<O>(&self, other: O) -> PyResult<Ordering>
     where
-        O: ToPyObject,
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>,
     {
-        fn inner(any: &Bound<'_, PyAny>, other: Bound<'_, PyAny>) -> PyResult<Ordering> {
+        fn inner(any: &Bound<'_, PyAny>, other: &Bound<'_, PyAny>) -> PyResult<Ordering> {
             let other = other.as_ptr();
             // Almost the same as ffi::PyObject_RichCompareBool, but this one doesn't try self == other.
             // See https://github.com/PyO3/pyo3/issues/985 for more.
@@ -996,16 +1068,24 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         }
 
         let py = self.py();
-        inner(self, other.to_object(py).into_bound(py))
+        inner(
+            self,
+            &other
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
+        )
     }
 
     fn rich_compare<O>(&self, other: O, compare_op: CompareOp) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject,
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
-            other: Bound<'_, PyAny>,
+            other: &Bound<'_, PyAny>,
             compare_op: CompareOp,
         ) -> PyResult<Bound<'py, PyAny>> {
             unsafe {
@@ -1015,7 +1095,15 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         }
 
         let py = self.py();
-        inner(self, other.to_object(py).into_bound(py), compare_op)
+        inner(
+            self,
+            &other
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
+            compare_op,
+        )
     }
 
     fn neg(&self) -> PyResult<Bound<'py, PyAny>> {
@@ -1048,7 +1136,8 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn lt<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject,
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Lt)
             .and_then(|any| any.is_truthy())
@@ -1056,7 +1145,8 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn le<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject,
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Le)
             .and_then(|any| any.is_truthy())
@@ -1064,7 +1154,8 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn eq<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject,
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Eq)
             .and_then(|any| any.is_truthy())
@@ -1072,7 +1163,8 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn ne<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject,
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Ne)
             .and_then(|any| any.is_truthy())
@@ -1080,7 +1172,8 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn gt<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject,
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Gt)
             .and_then(|any| any.is_truthy())
@@ -1088,7 +1181,8 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn ge<O>(&self, other: O) -> PyResult<bool>
     where
-        O: ToPyObject,
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Ge)
             .and_then(|any| any.is_truthy())
@@ -1110,11 +1204,12 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     /// Computes `divmod(self, other)`.
     fn divmod<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: ToPyObject,
+        O: IntoPyObject<'py>,
+        O::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
-            other: Bound<'_, PyAny>,
+            other: &Bound<'_, PyAny>,
         ) -> PyResult<Bound<'py, PyAny>> {
             unsafe {
                 ffi::PyNumber_Divmod(any.as_ptr(), other.as_ptr()).assume_owned_or_err(any.py())
@@ -1122,20 +1217,29 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         }
 
         let py = self.py();
-        inner(self, other.to_object(py).into_bound(py))
+        inner(
+            self,
+            &other
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
+        )
     }
 
     /// Computes `self ** other % modulus` (`pow(self, other, modulus)`).
     /// `py.None()` may be passed for the `modulus`.
     fn pow<O1, O2>(&self, other: O1, modulus: O2) -> PyResult<Bound<'py, PyAny>>
     where
-        O1: ToPyObject,
-        O2: ToPyObject,
+        O1: IntoPyObject<'py>,
+        O2: IntoPyObject<'py>,
+        O1::Error: Into<PyErr>,
+        O2::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
-            other: Bound<'_, PyAny>,
-            modulus: Bound<'_, PyAny>,
+            other: &Bound<'_, PyAny>,
+            modulus: &Bound<'_, PyAny>,
         ) -> PyResult<Bound<'py, PyAny>> {
             unsafe {
                 ffi::PyNumber_Power(any.as_ptr(), other.as_ptr(), modulus.as_ptr())
@@ -1146,8 +1250,16 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         let py = self.py();
         inner(
             self,
-            other.to_object(py).into_bound(py),
-            modulus.to_object(py).into_bound(py),
+            &other
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
+            &modulus
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
         )
     }
 
@@ -1155,14 +1267,14 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         unsafe { ffi::PyCallable_Check(self.as_ptr()) != 0 }
     }
 
-    fn call(
-        &self,
-        args: impl IntoPy<Py<PyTuple>>,
-        kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn call<A>(&self, args: A, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Bound<'py, PyAny>>
+    where
+        A: IntoPyObject<'py, Target = PyTuple>,
+        A::Error: Into<PyErr>,
+    {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
-            args: Bound<'_, PyTuple>,
+            args: &Bound<'_, PyTuple>,
             kwargs: Option<&Bound<'_, PyDict>>,
         ) -> PyResult<Bound<'py, PyAny>> {
             unsafe {
@@ -1176,14 +1288,22 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         }
 
         let py = self.py();
-        inner(self, args.into_py(py).into_bound(py), kwargs)
+        inner(
+            self,
+            &args.into_pyobject(py).map_err(Into::into)?.as_borrowed(),
+            kwargs,
+        )
     }
 
     fn call0(&self) -> PyResult<Bound<'py, PyAny>> {
         unsafe { ffi::compat::PyObject_CallNoArgs(self.as_ptr()).assume_owned_or_err(self.py()) }
     }
 
-    fn call1(&self, args: impl IntoPy<Py<PyTuple>>) -> PyResult<Bound<'py, PyAny>> {
+    fn call1<A>(&self, args: A) -> PyResult<Bound<'py, PyAny>>
+    where
+        A: IntoPyObject<'py, Target = PyTuple>,
+        A::Error: Into<PyErr>,
+    {
         self.call(args, None)
     }
 
@@ -1194,8 +1314,10 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPy<Py<PyString>>,
-        A: IntoPy<Py<PyTuple>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        A: IntoPyObject<'py, Target = PyTuple>,
+        N::Error: Into<PyErr>,
+        A::Error: Into<PyErr>,
     {
         self.getattr(name)
             .and_then(|method| method.call(args, kwargs))
@@ -1203,10 +1325,11 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn call_method0<N>(&self, name: N) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPy<Py<PyString>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>,
     {
         let py = self.py();
-        let name = name.into_py(py).into_bound(py);
+        let name = name.into_pyobject(py).map_err(Into::into)?.into_bound();
         unsafe {
             ffi::compat::PyObject_CallMethodNoArgs(self.as_ptr(), name.as_ptr())
                 .assume_owned_or_err(py)
@@ -1215,8 +1338,10 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn call_method1<N, A>(&self, name: N, args: A) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPy<Py<PyString>>,
-        A: IntoPy<Py<PyTuple>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        A: IntoPyObject<'py, Target = PyTuple>,
+        N::Error: Into<PyErr>,
+        A::Error: Into<PyErr>,
     {
         self.call_method(name, args, None)
     }
@@ -1242,11 +1367,12 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn get_item<K>(&self, key: K) -> PyResult<Bound<'py, PyAny>>
     where
-        K: ToPyObject,
+        K: IntoPyObject<'py>,
+        K::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
-            key: Bound<'_, PyAny>,
+            key: &Bound<'_, PyAny>,
         ) -> PyResult<Bound<'py, PyAny>> {
             unsafe {
                 ffi::PyObject_GetItem(any.as_ptr(), key.as_ptr()).assume_owned_or_err(any.py())
@@ -1254,18 +1380,26 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         }
 
         let py = self.py();
-        inner(self, key.to_object(py).into_bound(py))
+        inner(
+            self,
+            &key.into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
+        )
     }
 
     fn set_item<K, V>(&self, key: K, value: V) -> PyResult<()>
     where
-        K: ToPyObject,
-        V: ToPyObject,
+        K: IntoPyObject<'py>,
+        V: IntoPyObject<'py>,
+        K::Error: Into<PyErr>,
+        V::Error: Into<PyErr>,
     {
         fn inner(
             any: &Bound<'_, PyAny>,
-            key: Bound<'_, PyAny>,
-            value: Bound<'_, PyAny>,
+            key: &Bound<'_, PyAny>,
+            value: &Bound<'_, PyAny>,
         ) -> PyResult<()> {
             err::error_on_minusone(any.py(), unsafe {
                 ffi::PyObject_SetItem(any.as_ptr(), key.as_ptr(), value.as_ptr())
@@ -1275,23 +1409,37 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         let py = self.py();
         inner(
             self,
-            key.to_object(py).into_bound(py),
-            value.to_object(py).into_bound(py),
+            &key.into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
+            &value
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
         )
     }
 
     fn del_item<K>(&self, key: K) -> PyResult<()>
     where
-        K: ToPyObject,
+        K: IntoPyObject<'py>,
+        K::Error: Into<PyErr>,
     {
-        fn inner(any: &Bound<'_, PyAny>, key: Bound<'_, PyAny>) -> PyResult<()> {
+        fn inner(any: &Bound<'_, PyAny>, key: &Bound<'_, PyAny>) -> PyResult<()> {
             err::error_on_minusone(any.py(), unsafe {
                 ffi::PyObject_DelItem(any.as_ptr(), key.as_ptr())
             })
         }
 
         let py = self.py();
-        inner(self, key.to_object(py).into_bound(py))
+        inner(
+            self,
+            &key.into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
+        )
     }
 
     fn iter(&self) -> PyResult<Bound<'py, PyIterator>> {
@@ -1440,9 +1588,10 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn contains<V>(&self, value: V) -> PyResult<bool>
     where
-        V: ToPyObject,
+        V: IntoPyObject<'py>,
+        V::Error: Into<PyErr>,
     {
-        fn inner(any: &Bound<'_, PyAny>, value: Bound<'_, PyAny>) -> PyResult<bool> {
+        fn inner(any: &Bound<'_, PyAny>, value: &Bound<'_, PyAny>) -> PyResult<bool> {
             match unsafe { ffi::PySequence_Contains(any.as_ptr(), value.as_ptr()) } {
                 0 => Ok(false),
                 1 => Ok(true),
@@ -1451,7 +1600,14 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         }
 
         let py = self.py();
-        inner(self, value.to_object(py).into_bound(py))
+        inner(
+            self,
+            &value
+                .into_pyobject(py)
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
+        )
     }
 
     #[cfg(not(any(PyPy, GraalPy)))]
@@ -1474,7 +1630,8 @@ impl<'py> Bound<'py, PyAny> {
     #[allow(dead_code)] // Currently only used with num-complex+abi3, so dead without that.
     pub(crate) fn lookup_special<N>(&self, attr_name: N) -> PyResult<Option<Bound<'py, PyAny>>>
     where
-        N: IntoPy<Py<PyString>>,
+        N: IntoPyObject<'py, Target = PyString>,
+        N::Error: Into<PyErr>,
     {
         let py = self.py();
         let self_type = self.get_type();

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -38,10 +38,10 @@ use std::str;
 /// let other = PyBytes::new(py, b"foo".as_slice());
 /// assert!(py_bytes.as_any().eq(other).unwrap());
 ///
-/// // Note that `eq` will convert it's argument to Python using `ToPyObject`,
-/// // so the following does not compare equal since the slice will convert into a
-/// // `list`, not a `bytes` object.
-/// assert!(!py_bytes.as_any().eq(b"foo".as_slice()).unwrap());
+/// // Note that `eq` will convert it's argument to Python using `IntoPyObject`,
+/// // byte collections are specialized, so that the following slice will indeed
+/// // convert into a `bytes` object and not a `list`
+/// assert!(py_bytes.as_any().eq(b"foo".as_slice()).unwrap());
 /// # });
 /// ```
 #[repr(transparent)]

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -38,9 +38,9 @@ use std::str;
 /// let other = PyBytes::new(py, b"foo".as_slice());
 /// assert!(py_bytes.as_any().eq(other).unwrap());
 ///
-/// // Note that `eq` will convert it's argument to Python using `IntoPyObject`,
-/// // byte collections are specialized, so that the following slice will indeed
-/// // convert into a `bytes` object and not a `list`
+/// // Note that `eq` will convert its argument to Python using `IntoPyObject`.
+/// // Byte collections are specialized, so that the following slice will indeed
+/// // convert into a `bytes` object and not a `list`:
 /// assert!(py_bytes.as_any().eq(b"foo".as_slice()).unwrap());
 /// # });
 /// ```

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -862,11 +862,13 @@ mod tests {
     #[cfg(all(feature = "macros", feature = "chrono"))]
     #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_timezone_from_offset() {
+        use crate::types::PyNone;
+
         Python::with_gil(|py| {
             assert!(
                 timezone_from_offset(&PyDelta::new(py, 0, -3600, 0, true).unwrap())
                     .unwrap()
-                    .call_method1("utcoffset", ((),))
+                    .call_method1("utcoffset", (PyNone::get(py),))
                     .unwrap()
                     .downcast_into::<PyDelta>()
                     .unwrap()
@@ -877,7 +879,7 @@ mod tests {
             assert!(
                 timezone_from_offset(&PyDelta::new(py, 0, 3600, 0, true).unwrap())
                     .unwrap()
-                    .call_method1("utcoffset", ((),))
+                    .call_method1("utcoffset", (PyNone::get(py),))
                     .unwrap()
                     .downcast_into::<PyDelta>()
                     .unwrap()


### PR DESCRIPTION
This starts the migration of the trait bounds to use `IntoPyObject` instead of `IntoPy`/`ToPyObject`

Test changes:
- datetime changes caused by `()` now turning into a `PyTuple`
- bytes changes caused by the specialization
both are expected by the new API.

I already added a small migration entry here, we can extend that when we migrate more APIs and implemented #4458. Same with the guide section.

Notable observation: Initially I tried to use `PyErr: From<T::Error>` as a bound on the APIs, but that caused inference issues of the associated type on the call site, so we should probably stick with `Into` even tho it's a bit more verbose on the implementation site.