### PR TITLE
ci: run coverage jobs in `pull_request_target` context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,46 +385,6 @@ jobs:
           components: rust-src
       - run: cargo rustdoc --lib --no-default-features --features full -Zunstable-options --config "build.rustdocflags=[\"--cfg\", \"docsrs\"]"
 
-  coverage:
-    needs: [fmt]
-    name: coverage ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ["windows-latest", "macos-14", "ubuntu-latest"]  # first available arm macos runner
-    runs-on: ${{ matrix.os }}
-    steps:
-      - if: ${{ github.event_name == 'pull_request' && matrix.os != 'ubuntu-latest' }}
-        id: should-skip
-        shell: bash
-        run: echo 'skip=true' >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v4
-        if: steps.should-skip.outputs.skip != 'true'
-      - uses: actions/setup-python@v5
-        if: steps.should-skip.outputs.skip != 'true'
-        with:
-          python-version: '3.12'
-      - uses: Swatinem/rust-cache@v2
-        if: steps.should-skip.outputs.skip != 'true'
-        with:
-          save-if: ${{ github.event_name != 'merge_group' }}
-      - uses: dtolnay/rust-toolchain@stable
-        if: steps.should-skip.outputs.skip != 'true'
-        with:
-          components: llvm-tools-preview,rust-src
-      - name: Install cargo-llvm-cov
-        if: steps.should-skip.outputs.skip != 'true'
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - run: python -m pip install --upgrade pip && pip install nox
-        if: steps.should-skip.outputs.skip != 'true'
-      - run: nox -s coverage
-        if: steps.should-skip.outputs.skip != 'true'
-      - uses: codecov/codecov-action@v4
-        if: steps.should-skip.outputs.skip != 'true'
-        with:
-          file: coverage.json
-          name: ${{ matrix.os }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-
   emscripten:
     name: emscripten
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
@@ -673,7 +633,6 @@ jobs:
       - valgrind
       - careful
       - docsrs
-      - coverage
       - emscripten
       - test-debug
       - test-free-threaded

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,54 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request_target:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}-coverage
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    name: coverage ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["windows-latest", "macos-14", "ubuntu-latest"]  # first available arm macos runner
+    runs-on: ${{ matrix.os }}
+    steps:
+      - if: ${{ github.event_name == 'pull_request' && matrix.os != 'ubuntu-latest' }}
+        id: should-skip
+        shell: bash
+        run: echo 'skip=true' >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
+        if: steps.should-skip.outputs.skip != 'true'
+      - uses: actions/setup-python@v5
+        if: steps.should-skip.outputs.skip != 'true'
+        with:
+          python-version: '3.12'
+      - uses: Swatinem/rust-cache@v2
+        if: steps.should-skip.outputs.skip != 'true'
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+      - uses: dtolnay/rust-toolchain@stable
+        if: steps.should-skip.outputs.skip != 'true'
+        with:
+          components: llvm-tools-preview,rust-src
+      - name: Install cargo-llvm-cov
+        if: steps.should-skip.outputs.skip != 'true'
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - run: python -m pip install --upgrade pip && pip install nox
+        if: steps.should-skip.outputs.skip != 'true'
+      - run: nox -s coverage
+        if: steps.should-skip.outputs.skip != 'true'
+      - uses: codecov/codecov-action@v4
+        if: steps.should-skip.outputs.skip != 'true'
+        with:
+          file: coverage.json
+          name: ${{ matrix.os }}
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Moves the `coverage` task to a separate ci task which runs on the `pull_request_target` trigger. This ensures that coverage runs against the original branch and compares to its base. The rest of our jobs run on the merge commit so pick up CI fixes from main, but codecov seems to get confused about how to calculate the merge base correctly so we get strange job failures.

Replaces #4472 