### PR TITLE
Remove the `BoundObject` impl for `&Bound`, use `Borrowed` instead

### DIFF
--- a/newsfragments/4487.changed.md
+++ b/newsfragments/4487.changed.md
@@ -1,0 +1,1 @@
+Remove the `BoundObject` impl for `&Bound`, use `Borrowed` instead. For rationale see https://github.com/PyO3/pyo3/issues/4467.

--- a/newsfragments/4487.changed.md
+++ b/newsfragments/4487.changed.md
@@ -1,1 +1,0 @@
-Remove the `BoundObject` impl for `&Bound`, use `Borrowed` instead. For rationale see https://github.com/PyO3/pyo3/issues/4467.

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -192,8 +192,8 @@ pub trait IntoPyObject<'py>: Sized {
     type Target;
     /// The smart pointer type to use.
     ///
-    /// This will usually be [`Bound<'py, Target>`], but can special cases `&'a Bound<'py, Target>`
-    /// or [`Borrowed<'a, 'py, Target>`] can be used to minimize reference counting overhead.
+    /// This will usually be [`Bound<'py, Target>`], but in special cases [`Borrowed<'a, 'py, Target>`] can be
+    /// used to minimize reference counting overhead.
     type Output: BoundObject<'py, Self::Target>;
     /// The type returned in the event of a conversion error.
     type Error;
@@ -273,11 +273,11 @@ impl<'py, T> IntoPyObject<'py> for Bound<'py, T> {
 
 impl<'a, 'py, T> IntoPyObject<'py> for &'a Bound<'py, T> {
     type Target = T;
-    type Output = &'a Bound<'py, Self::Target>;
+    type Output = Borrowed<'a, 'py, Self::Target>;
     type Error = Infallible;
 
     fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(self)
+        Ok(self.as_borrowed())
     }
 }
 

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -199,7 +199,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::{ptr_from_mut, ptr_from_ref};
 use crate::pyclass::{boolean_struct::False, PyClass};
 use crate::types::any::PyAnyMethods;
-use crate::{ffi, Bound, IntoPy, PyErr, PyObject, Python};
+use crate::{ffi, Borrowed, Bound, IntoPy, PyErr, PyObject, Python};
 use std::convert::Infallible;
 use std::fmt;
 use std::mem::ManuallyDrop;
@@ -479,11 +479,11 @@ impl<'py, T: PyClass> IntoPyObject<'py> for PyRef<'py, T> {
 
 impl<'a, 'py, T: PyClass> IntoPyObject<'py> for &'a PyRef<'py, T> {
     type Target = T;
-    type Output = &'a Bound<'py, T>;
+    type Output = Borrowed<'a, 'py, T>;
     type Error = Infallible;
 
     fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(&self.inner)
+        Ok(self.inner.as_borrowed())
     }
 }
 
@@ -668,11 +668,11 @@ impl<'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for PyRefMut<'py, T> {
 
 impl<'a, 'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for &'a PyRefMut<'py, T> {
     type Target = T;
-    type Output = &'a Bound<'py, T>;
+    type Output = Borrowed<'a, 'py, T>;
     type Error = Infallible;
 
     fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(&self.inner)
+        Ok(self.inner.as_borrowed())
     }
 }
 


### PR DESCRIPTION
For rationale see https://github.com/PyO3/pyo3/issues/4467.

I chose to make `bound_object_sealed::Sealed` unsafe instead of `BoundObject` so that users won't see the `# Safety`
section, as it's not relevant for them.

Closes #4467.