### PR TITLE
restrict `IntoPyObject::Error` to convert into `PyErr`

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -284,7 +284,7 @@ pub trait IntoPyObject<'py>: Sized {
     /// used to minimize reference counting overhead.
     type Output: BoundObject<'py, Self::Target>;
     /// The type returned in the event of a conversion error.
-    type Error;
+    type Error: Into<PyErr>;
 
     /// Performs the conversion.
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error>;
@@ -300,7 +300,6 @@ pub trait IntoPyObject<'py>: Sized {
     where
         I: IntoIterator<Item = Self> + AsRef<[Self]>,
         I::IntoIter: ExactSizeIterator<Item = Self>,
-        PyErr: From<Self::Error>,
     {
         let mut iter = iter.into_iter().map(|e| {
             e.into_pyobject(py)
@@ -324,7 +323,6 @@ pub trait IntoPyObject<'py>: Sized {
         Self: private::Reference,
         I: IntoIterator<Item = Self> + AsRef<[<Self as private::Reference>::BaseType]>,
         I::IntoIter: ExactSizeIterator<Item = Self>,
-        PyErr: From<Self::Error>,
     {
         let mut iter = iter.into_iter().map(|e| {
             e.into_pyobject(py)

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -1327,7 +1327,6 @@ mod tests {
     fn new_py_datetime_ob<'py, A>(py: Python<'py>, name: &str, args: A) -> Bound<'py, PyAny>
     where
         A: IntoPyObject<'py, Target = PyTuple>,
-        A::Error: Into<PyErr>,
     {
         py.import("datetime")
             .unwrap()

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -71,8 +71,6 @@ impl<'py, L, R> IntoPyObject<'py> for Either<L, R>
 where
     L: IntoPyObject<'py>,
     R: IntoPyObject<'py>,
-    L::Error: Into<PyErr>,
-    R::Error: Into<PyErr>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -99,8 +97,6 @@ impl<'a, 'py, L, R> IntoPyObject<'py> for &'a Either<L, R>
 where
     &'a L: IntoPyObject<'py>,
     &'a R: IntoPyObject<'py>,
-    <&'a L as IntoPyObject<'py>>::Error: Into<PyErr>,
-    <&'a R as IntoPyObject<'py>>::Error: Into<PyErr>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -59,7 +59,6 @@ where
     K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     V: IntoPyObject<'py>,
     H: hash::BuildHasher,
-    PyErr: From<K::Error> + From<V::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
@@ -69,8 +68,8 @@ where
         let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
-                k.into_pyobject(py)?.into_bound(),
-                v.into_pyobject(py)?.into_bound(),
+                k.into_pyobject(py).map_err(Into::into)?.into_bound(),
+                v.into_pyobject(py).map_err(Into::into)?.into_bound(),
             )?;
         }
         Ok(dict)
@@ -82,7 +81,6 @@ where
     &'a K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     &'a V: IntoPyObject<'py>,
     H: hash::BuildHasher,
-    PyErr: From<<&'a K as IntoPyObject<'py>>::Error> + From<<&'a V as IntoPyObject<'py>>::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
@@ -92,8 +90,8 @@ where
         let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
-                k.into_pyobject(py)?.into_bound(),
-                v.into_pyobject(py)?.into_bound(),
+                k.into_pyobject(py).map_err(Into::into)?.into_bound(),
+                v.into_pyobject(py).map_err(Into::into)?.into_bound(),
             )?;
         }
         Ok(dict)
@@ -143,7 +141,6 @@ impl<'py, K, H> IntoPyObject<'py> for hashbrown::HashSet<K, H>
 where
     K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     H: hash::BuildHasher,
-    PyErr: From<K::Error>,
 {
     type Target = PySet;
     type Output = Bound<'py, Self::Target>;
@@ -166,7 +163,6 @@ impl<'a, 'py, K, H> IntoPyObject<'py> for &'a hashbrown::HashSet<K, H>
 where
     &'a K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     H: hash::BuildHasher,
-    PyErr: From<<&'a K as IntoPyObject<'py>>::Error>,
 {
     type Target = PySet;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -122,7 +122,6 @@ where
     K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     V: IntoPyObject<'py>,
     H: hash::BuildHasher,
-    PyErr: From<K::Error> + From<V::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
@@ -132,8 +131,8 @@ where
         let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
-                k.into_pyobject(py)?.into_bound(),
-                v.into_pyobject(py)?.into_bound(),
+                k.into_pyobject(py).map_err(Into::into)?.into_bound(),
+                v.into_pyobject(py).map_err(Into::into)?.into_bound(),
             )?;
         }
         Ok(dict)
@@ -145,7 +144,6 @@ where
     &'a K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     &'a V: IntoPyObject<'py>,
     H: hash::BuildHasher,
-    PyErr: From<<&'a K as IntoPyObject<'py>>::Error> + From<<&'a V as IntoPyObject<'py>>::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
@@ -155,8 +153,8 @@ where
         let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
-                k.into_pyobject(py)?.into_bound(),
-                v.into_pyobject(py)?.into_bound(),
+                k.into_pyobject(py).map_err(Into::into)?.into_bound(),
+                v.into_pyobject(py).map_err(Into::into)?.into_bound(),
             )?;
         }
         Ok(dict)

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -60,7 +60,6 @@ impl<'py, A> IntoPyObject<'py> for SmallVec<A>
 where
     A: Array,
     A::Item: IntoPyObject<'py>,
-    PyErr: From<<A::Item as IntoPyObject<'py>>::Error>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -80,7 +79,6 @@ impl<'a, 'py, A> IntoPyObject<'py> for &'a SmallVec<A>
 where
     A: Array,
     &'a A::Item: IntoPyObject<'py>,
-    PyErr: From<<&'a A::Item as IntoPyObject<'py>>::Error>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -40,7 +40,6 @@ where
 impl<'py, T, const N: usize> IntoPyObject<'py> for [T; N]
 where
     T: IntoPyObject<'py>,
-    PyErr: From<T::Error>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -59,7 +58,6 @@ where
 impl<'a, 'py, T, const N: usize> IntoPyObject<'py> for &'a [T; N]
 where
     &'a T: IntoPyObject<'py>,
-    PyErr: From<<&'a T as IntoPyObject<'py>>::Error>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -54,7 +54,6 @@ where
     K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     V: IntoPyObject<'py>,
     H: hash::BuildHasher,
-    PyErr: From<K::Error> + From<V::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
@@ -64,8 +63,8 @@ where
         let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
-                k.into_pyobject(py)?.into_bound(),
-                v.into_pyobject(py)?.into_bound(),
+                k.into_pyobject(py).map_err(Into::into)?.into_bound(),
+                v.into_pyobject(py).map_err(Into::into)?.into_bound(),
             )?;
         }
         Ok(dict)
@@ -77,7 +76,6 @@ where
     &'a K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     &'a V: IntoPyObject<'py>,
     H: hash::BuildHasher,
-    PyErr: From<<&'a K as IntoPyObject<'py>>::Error> + From<<&'a V as IntoPyObject<'py>>::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
@@ -87,8 +85,8 @@ where
         let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
-                k.into_pyobject(py)?.into_bound(),
-                v.into_pyobject(py)?.into_bound(),
+                k.into_pyobject(py).map_err(Into::into)?.into_bound(),
+                v.into_pyobject(py).map_err(Into::into)?.into_bound(),
             )?;
         }
         Ok(dict)
@@ -117,7 +115,6 @@ impl<'py, K, V> IntoPyObject<'py> for collections::BTreeMap<K, V>
 where
     K: IntoPyObject<'py> + cmp::Eq,
     V: IntoPyObject<'py>,
-    PyErr: From<K::Error> + From<V::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
@@ -127,8 +124,8 @@ where
         let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
-                k.into_pyobject(py)?.into_bound(),
-                v.into_pyobject(py)?.into_bound(),
+                k.into_pyobject(py).map_err(Into::into)?.into_bound(),
+                v.into_pyobject(py).map_err(Into::into)?.into_bound(),
             )?;
         }
         Ok(dict)
@@ -139,7 +136,6 @@ impl<'a, 'py, K, V> IntoPyObject<'py> for &'a collections::BTreeMap<K, V>
 where
     &'a K: IntoPyObject<'py> + cmp::Eq,
     &'a V: IntoPyObject<'py>,
-    PyErr: From<<&'a K as IntoPyObject<'py>>::Error> + From<<&'a V as IntoPyObject<'py>>::Error>,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;
@@ -149,8 +145,8 @@ where
         let dict = PyDict::new(py);
         for (k, v) in self {
             dict.set_item(
-                k.into_pyobject(py)?.into_bound(),
-                v.into_pyobject(py)?.into_bound(),
+                k.into_pyobject(py).map_err(Into::into)?.into_bound(),
+                v.into_pyobject(py).map_err(Into::into)?.into_bound(),
             )?;
         }
         Ok(dict)

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -58,7 +58,6 @@ impl<'py, K, S> IntoPyObject<'py> for collections::HashSet<K, S>
 where
     K: IntoPyObject<'py> + Eq + hash::Hash,
     S: hash::BuildHasher + Default,
-    PyErr: From<K::Error>,
 {
     type Target = PySet;
     type Output = Bound<'py, Self::Target>;
@@ -81,7 +80,6 @@ impl<'a, 'py, K, H> IntoPyObject<'py> for &'a collections::HashSet<K, H>
 where
     &'a K: IntoPyObject<'py> + Eq + hash::Hash,
     H: hash::BuildHasher,
-    PyErr: From<<&'a K as IntoPyObject<'py>>::Error>,
 {
     type Target = PySet;
     type Output = Bound<'py, Self::Target>;
@@ -143,7 +141,6 @@ where
 impl<'py, K> IntoPyObject<'py> for collections::BTreeSet<K>
 where
     K: IntoPyObject<'py> + cmp::Ord,
-    PyErr: From<K::Error>,
 {
     type Target = PySet;
     type Output = Bound<'py, Self::Target>;
@@ -165,7 +162,6 @@ where
 impl<'a, 'py, K> IntoPyObject<'py> for &'a collections::BTreeSet<K>
 where
     &'a K: IntoPyObject<'py> + cmp::Ord,
-    PyErr: From<<&'a K as IntoPyObject<'py>>::Error>,
 {
     type Target = PySet;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -22,7 +22,6 @@ impl<'a> IntoPy<PyObject> for &'a [u8] {
 impl<'a, 'py, T> IntoPyObject<'py> for &'a [T]
 where
     &'a T: IntoPyObject<'py>,
-    PyErr: From<<&'a T as IntoPyObject<'py>>::Error>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -86,7 +85,6 @@ impl<'py, T> IntoPyObject<'py> for Cow<'_, [T]>
 where
     T: Clone,
     for<'a> &'a T: IntoPyObject<'py>,
-    for<'a> PyErr: From<<&'a T as IntoPyObject<'py>>::Error>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -43,7 +43,6 @@ where
 impl<'py, T> IntoPyObject<'py> for Vec<T>
 where
     T: IntoPyObject<'py>,
-    PyErr: From<T::Error>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;
@@ -62,7 +61,6 @@ where
 impl<'a, 'py, T> IntoPyObject<'py> for &'a Vec<T>
 where
     &'a T: IntoPyObject<'py>,
-    PyErr: From<<&'a T as IntoPyObject<'py>>::Error>,
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -1,8 +1,8 @@
 use std::{convert::Infallible, marker::PhantomData, ops::Deref};
 
 use crate::{
-    conversion::IntoPyObject, ffi, types::PyNone, Bound, BoundObject, IntoPy, PyErr, PyObject,
-    PyResult, Python,
+    conversion::IntoPyObject, ffi, types::PyNone, Bound, BoundObject, IntoPy, PyObject, PyResult,
+    Python,
 };
 
 /// Used to wrap values in `Option<T>` for default arguments.
@@ -95,7 +95,6 @@ impl<'py, T: IntoPyObject<'py>, E> IntoPyObjectConverter<Result<T, E>> {
     pub fn map_into_pyobject(&self, py: Python<'py>, obj: PyResult<T>) -> PyResult<PyObject>
     where
         T: IntoPyObject<'py>,
-        PyErr: From<T::Error>,
     {
         obj.and_then(|obj| obj.into_pyobject(py).map_err(Into::into))
             .map(BoundObject::into_any)
@@ -106,7 +105,6 @@ impl<'py, T: IntoPyObject<'py>, E> IntoPyObjectConverter<Result<T, E>> {
     pub fn map_into_ptr(&self, py: Python<'py>, obj: PyResult<T>) -> PyResult<*mut ffi::PyObject>
     where
         T: IntoPyObject<'py>,
-        PyErr: From<T::Error>,
     {
         obj.and_then(|obj| obj.into_pyobject(py).map_err(Into::into))
             .map(BoundObject::into_bound)

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1412,7 +1412,6 @@ impl<T> Py<T> {
     pub fn getattr<'py, N>(&self, py: Python<'py>, attr_name: N) -> PyResult<PyObject>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>,
     {
         self.bind(py).as_any().getattr(attr_name).map(Bound::unbind)
     }
@@ -1443,8 +1442,6 @@ impl<T> Py<T> {
     where
         N: IntoPyObject<'py, Target = PyString>,
         V: IntoPyObject<'py>,
-        N::Error: Into<PyErr>,
-        V::Error: Into<PyErr>,
     {
         self.bind(py).as_any().setattr(attr_name, value)
     }
@@ -1497,7 +1494,6 @@ impl<T> Py<T> {
     where
         N: IntoPyObject<'py, Target = PyString>,
         A: IntoPy<Py<PyTuple>>,
-        N::Error: Into<PyErr>,
     {
         self.bind(py)
             .as_any()
@@ -1515,7 +1511,6 @@ impl<T> Py<T> {
     where
         N: IntoPyObject<'py, Target = PyString>,
         A: IntoPy<Py<PyTuple>>,
-        N::Error: Into<PyErr>,
     {
         self.bind(py)
             .as_any()
@@ -1532,7 +1527,6 @@ impl<T> Py<T> {
     pub fn call_method0<'py, N>(&self, py: Python<'py>, name: N) -> PyResult<PyObject>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>,
     {
         self.bind(py).as_any().call_method0(name).map(Bound::unbind)
     }

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -81,8 +81,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn hasattr<N>(&self, attr_name: N) -> PyResult<bool>
     where
-        N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>;
+        N: IntoPyObject<'py, Target = PyString>;
 
     /// Retrieves an attribute value.
     ///
@@ -108,8 +107,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn getattr<N>(&self, attr_name: N) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>;
+        N: IntoPyObject<'py, Target = PyString>;
 
     /// Sets an attribute value.
     ///
@@ -136,9 +134,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     fn setattr<N, V>(&self, attr_name: N, value: V) -> PyResult<()>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        V: IntoPyObject<'py>,
-        N::Error: Into<PyErr>,
-        V::Error: Into<PyErr>;
+        V: IntoPyObject<'py>;
 
     /// Deletes an attribute.
     ///
@@ -148,8 +144,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// to intern `attr_name`.
     fn delattr<N>(&self, attr_name: N) -> PyResult<()>
     where
-        N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>;
+        N: IntoPyObject<'py, Target = PyString>;
 
     /// Returns an [`Ordering`] between `self` and `other`.
     ///
@@ -199,8 +194,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn compare<O>(&self, other: O) -> PyResult<Ordering>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Tests whether two Python objects obey a given [`CompareOp`].
     ///
@@ -238,8 +232,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn rich_compare<O>(&self, other: O, compare_op: CompareOp) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes the negative of self.
     ///
@@ -264,135 +257,114 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// This is equivalent to the Python expression `self < other`.
     fn lt<O>(&self, other: O) -> PyResult<bool>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Tests whether this object is less than or equal to another.
     ///
     /// This is equivalent to the Python expression `self <= other`.
     fn le<O>(&self, other: O) -> PyResult<bool>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Tests whether this object is equal to another.
     ///
     /// This is equivalent to the Python expression `self == other`.
     fn eq<O>(&self, other: O) -> PyResult<bool>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Tests whether this object is not equal to another.
     ///
     /// This is equivalent to the Python expression `self != other`.
     fn ne<O>(&self, other: O) -> PyResult<bool>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Tests whether this object is greater than another.
     ///
     /// This is equivalent to the Python expression `self > other`.
     fn gt<O>(&self, other: O) -> PyResult<bool>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Tests whether this object is greater than or equal to another.
     ///
     /// This is equivalent to the Python expression `self >= other`.
     fn ge<O>(&self, other: O) -> PyResult<bool>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self + other`.
     fn add<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self - other`.
     fn sub<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self * other`.
     fn mul<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self @ other`.
     fn matmul<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self / other`.
     fn div<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self // other`.
     fn floor_div<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self % other`.
     fn rem<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `divmod(self, other)`.
     fn divmod<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self << other`.
     fn lshift<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self >> other`.
     fn rshift<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self ** other % modulus` (`pow(self, other, modulus)`).
     /// `py.None()` may be passed for the `modulus`.
     fn pow<O1, O2>(&self, other: O1, modulus: O2) -> PyResult<Bound<'py, PyAny>>
     where
         O1: IntoPyObject<'py>,
-        O2: IntoPyObject<'py>,
-        O1::Error: Into<PyErr>,
-        O2::Error: Into<PyErr>;
+        O2: IntoPyObject<'py>;
 
     /// Computes `self & other`.
     fn bitand<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self | other`.
     fn bitor<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Computes `self ^ other`.
     fn bitxor<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
-        O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>;
+        O: IntoPyObject<'py>;
 
     /// Determines whether this object appears callable.
     ///
@@ -559,8 +531,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ) -> PyResult<Bound<'py, PyAny>>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        A: IntoPy<Py<PyTuple>>,
-        N::Error: Into<PyErr>;
+        A: IntoPy<Py<PyTuple>>;
 
     /// Calls a method on the object without arguments.
     ///
@@ -597,8 +568,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn call_method0<N>(&self, name: N) -> PyResult<Bound<'py, PyAny>>
     where
-        N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>;
+        N: IntoPyObject<'py, Target = PyString>;
 
     /// Calls a method on the object with only positional arguments.
     ///
@@ -637,8 +607,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     fn call_method1<N, A>(&self, name: N, args: A) -> PyResult<Bound<'py, PyAny>>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        A: IntoPy<Py<PyTuple>>,
-        N::Error: Into<PyErr>;
+        A: IntoPy<Py<PyTuple>>;
 
     /// Returns whether the object is considered to be true.
     ///
@@ -666,8 +635,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// This is equivalent to the Python expression `self[key]`.
     fn get_item<K>(&self, key: K) -> PyResult<Bound<'py, PyAny>>
     where
-        K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>;
+        K: IntoPyObject<'py>;
 
     /// Sets a collection item value.
     ///
@@ -675,17 +643,14 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     fn set_item<K, V>(&self, key: K, value: V) -> PyResult<()>
     where
         K: IntoPyObject<'py>,
-        V: IntoPyObject<'py>,
-        K::Error: Into<PyErr>,
-        V::Error: Into<PyErr>;
+        V: IntoPyObject<'py>;
 
     /// Deletes an item from the collection.
     ///
     /// This is equivalent to the Python expression `del self[key]`.
     fn del_item<K>(&self, key: K) -> PyResult<()>
     where
-        K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>;
+        K: IntoPyObject<'py>;
 
     /// Takes an object and returns an iterator for it.
     ///
@@ -897,8 +862,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// This is equivalent to the Python expression `value in self`.
     fn contains<V>(&self, value: V) -> PyResult<bool>
     where
-        V: IntoPyObject<'py>,
-        V::Error: Into<PyErr>;
+        V: IntoPyObject<'py>;
 
     /// Return a proxy object that delegates method calls to a parent or sibling class of type.
     ///
@@ -913,7 +877,6 @@ macro_rules! implement_binop {
         fn $name<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
         where
             O: IntoPyObject<'py>,
-            O::Error: Into<PyErr>,
         {
             fn inner<'py>(
                 any: &Bound<'py, PyAny>,
@@ -944,7 +907,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn hasattr<N>(&self, attr_name: N) -> PyResult<bool>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>,
     {
         // PyObject_HasAttr suppresses all exceptions, which was the behaviour of `hasattr` in Python 2.
         // Use an implementation which suppresses only AttributeError, which is consistent with `hasattr` in Python 3.
@@ -962,7 +924,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn getattr<N>(&self, attr_name: N) -> PyResult<Bound<'py, PyAny>>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
@@ -987,8 +948,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     where
         N: IntoPyObject<'py, Target = PyString>,
         V: IntoPyObject<'py>,
-        N::Error: Into<PyErr>,
-        V::Error: Into<PyErr>,
     {
         fn inner(
             any: &Bound<'_, PyAny>,
@@ -1018,7 +977,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn delattr<N>(&self, attr_name: N) -> PyResult<()>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>,
     {
         fn inner(any: &Bound<'_, PyAny>, attr_name: &Bound<'_, PyString>) -> PyResult<()> {
             err::error_on_minusone(any.py(), unsafe {
@@ -1039,7 +997,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn compare<O>(&self, other: O) -> PyResult<Ordering>
     where
         O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>,
     {
         fn inner(any: &Bound<'_, PyAny>, other: &Bound<'_, PyAny>) -> PyResult<Ordering> {
             let other = other.as_ptr();
@@ -1077,7 +1034,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn rich_compare<O>(&self, other: O, compare_op: CompareOp) -> PyResult<Bound<'py, PyAny>>
     where
         O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
@@ -1133,7 +1089,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn lt<O>(&self, other: O) -> PyResult<bool>
     where
         O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Lt)
             .and_then(|any| any.is_truthy())
@@ -1142,7 +1097,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn le<O>(&self, other: O) -> PyResult<bool>
     where
         O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Le)
             .and_then(|any| any.is_truthy())
@@ -1151,7 +1105,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn eq<O>(&self, other: O) -> PyResult<bool>
     where
         O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Eq)
             .and_then(|any| any.is_truthy())
@@ -1160,7 +1113,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn ne<O>(&self, other: O) -> PyResult<bool>
     where
         O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Ne)
             .and_then(|any| any.is_truthy())
@@ -1169,7 +1121,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn gt<O>(&self, other: O) -> PyResult<bool>
     where
         O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Gt)
             .and_then(|any| any.is_truthy())
@@ -1178,7 +1129,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn ge<O>(&self, other: O) -> PyResult<bool>
     where
         O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>,
     {
         self.rich_compare(other, CompareOp::Ge)
             .and_then(|any| any.is_truthy())
@@ -1201,7 +1151,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn divmod<O>(&self, other: O) -> PyResult<Bound<'py, PyAny>>
     where
         O: IntoPyObject<'py>,
-        O::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
@@ -1229,8 +1178,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     where
         O1: IntoPyObject<'py>,
         O2: IntoPyObject<'py>,
-        O1::Error: Into<PyErr>,
-        O2::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
@@ -1297,7 +1244,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     where
         N: IntoPyObject<'py, Target = PyString>,
         A: IntoPy<Py<PyTuple>>,
-        N::Error: Into<PyErr>,
     {
         // Don't `args.into_py()`! This will lose the optimization of vectorcall.
         match kwargs {
@@ -1312,7 +1258,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn call_method0<N>(&self, name: N) -> PyResult<Bound<'py, PyAny>>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>,
     {
         let py = self.py();
         let name = name.into_pyobject(py).map_err(Into::into)?.into_bound();
@@ -1326,7 +1271,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     where
         N: IntoPyObject<'py, Target = PyString>,
         A: IntoPy<Py<PyTuple>>,
-        N::Error: Into<PyErr>,
     {
         args.__py_call_method_vectorcall1(
             self.py(),
@@ -1360,7 +1304,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn get_item<K>(&self, key: K) -> PyResult<Bound<'py, PyAny>>
     where
         K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>,
     {
         fn inner<'py>(
             any: &Bound<'py, PyAny>,
@@ -1385,8 +1328,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     where
         K: IntoPyObject<'py>,
         V: IntoPyObject<'py>,
-        K::Error: Into<PyErr>,
-        V::Error: Into<PyErr>,
     {
         fn inner(
             any: &Bound<'_, PyAny>,
@@ -1416,7 +1357,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn del_item<K>(&self, key: K) -> PyResult<()>
     where
         K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>,
     {
         fn inner(any: &Bound<'_, PyAny>, key: &Bound<'_, PyAny>) -> PyResult<()> {
             err::error_on_minusone(any.py(), unsafe {
@@ -1581,7 +1521,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
     fn contains<V>(&self, value: V) -> PyResult<bool>
     where
         V: IntoPyObject<'py>,
-        V::Error: Into<PyErr>,
     {
         fn inner(any: &Bound<'_, PyAny>, value: &Bound<'_, PyAny>) -> PyResult<bool> {
             match unsafe { ffi::PySequence_Contains(any.as_ptr(), value.as_ptr()) } {
@@ -1623,7 +1562,6 @@ impl<'py> Bound<'py, PyAny> {
     pub(crate) fn lookup_special<N>(&self, attr_name: N) -> PyResult<Option<Bound<'py, PyAny>>>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        N::Error: Into<PyErr>,
     {
         let py = self.py();
         let self_type = self.get_type();

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -7,7 +7,7 @@ use crate::sync::GILOnceCell;
 use crate::type_object::PyTypeInfo;
 use crate::types::any::PyAnyMethods;
 use crate::types::{PyAny, PyDict, PySequence, PyType};
-use crate::{ffi, Py, PyErr, PyTypeCheck, Python};
+use crate::{ffi, Py, PyTypeCheck, Python};
 
 /// Represents a reference to a Python object supporting the mapping protocol.
 ///
@@ -51,8 +51,7 @@ pub trait PyMappingMethods<'py>: crate::sealed::Sealed {
     /// This is equivalent to the Python expression `key in self`.
     fn contains<K>(&self, key: K) -> PyResult<bool>
     where
-        K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>;
+        K: IntoPyObject<'py>;
 
     /// Gets the item in self with key `key`.
     ///
@@ -61,8 +60,7 @@ pub trait PyMappingMethods<'py>: crate::sealed::Sealed {
     /// This is equivalent to the Python expression `self[key]`.
     fn get_item<K>(&self, key: K) -> PyResult<Bound<'py, PyAny>>
     where
-        K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>;
+        K: IntoPyObject<'py>;
 
     /// Sets the item in self with key `key`.
     ///
@@ -70,17 +68,14 @@ pub trait PyMappingMethods<'py>: crate::sealed::Sealed {
     fn set_item<K, V>(&self, key: K, value: V) -> PyResult<()>
     where
         K: IntoPyObject<'py>,
-        V: IntoPyObject<'py>,
-        K::Error: Into<PyErr>,
-        V::Error: Into<PyErr>;
+        V: IntoPyObject<'py>;
 
     /// Deletes the item with key `key`.
     ///
     /// This is equivalent to the Python statement `del self[key]`.
     fn del_item<K>(&self, key: K) -> PyResult<()>
     where
-        K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>;
+        K: IntoPyObject<'py>;
 
     /// Returns a sequence containing all keys in the mapping.
     fn keys(&self) -> PyResult<Bound<'py, PySequence>>;
@@ -108,7 +103,6 @@ impl<'py> PyMappingMethods<'py> for Bound<'py, PyMapping> {
     fn contains<K>(&self, key: K) -> PyResult<bool>
     where
         K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>,
     {
         PyAnyMethods::contains(&**self, key)
     }
@@ -117,7 +111,6 @@ impl<'py> PyMappingMethods<'py> for Bound<'py, PyMapping> {
     fn get_item<K>(&self, key: K) -> PyResult<Bound<'py, PyAny>>
     where
         K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>,
     {
         PyAnyMethods::get_item(&**self, key)
     }
@@ -127,8 +120,6 @@ impl<'py> PyMappingMethods<'py> for Bound<'py, PyMapping> {
     where
         K: IntoPyObject<'py>,
         V: IntoPyObject<'py>,
-        K::Error: Into<PyErr>,
-        V::Error: Into<PyErr>,
     {
         PyAnyMethods::set_item(&**self, key, value)
     }
@@ -137,7 +128,6 @@ impl<'py> PyMappingMethods<'py> for Bound<'py, PyMapping> {
     fn del_item<K>(&self, key: K) -> PyResult<()>
     where
         K: IntoPyObject<'py>,
-        K::Error: Into<PyErr>,
     {
         PyAnyMethods::del_item(&**self, key)
     }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -532,14 +532,13 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
     impl <'py, $($T),+> IntoPyObject<'py> for ($($T,)+)
     where
         $($T: IntoPyObject<'py>,)+
-        PyErr: $(From<$T::Error> + )+
     {
         type Target = PyTuple;
         type Output = Bound<'py, Self::Target>;
         type Error = PyErr;
 
         fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-            Ok(array_into_tuple(py, [$(self.$n.into_pyobject(py)?.into_any().unbind()),+]).into_bound(py))
+            Ok(array_into_tuple(py, [$(self.$n.into_pyobject(py).map_err(Into::into)?.into_any().unbind()),+]).into_bound(py))
         }
     }
 


### PR DESCRIPTION
This restricts the error type of `IntoPyObject` to be convertible into `PyErr`. While not _strictly_ necessary this makes writing generic code much nicer, because we don't need to repeat a bound on the associated type all the time. It's also potentially less surprising to users because the error with an incompatible error will occur at implementation site instead of usage site. The usage without this bound are extremely limited, since the macros and nearly all the PyO3 API and containers require it, so it could only be called manually anyway.

XRef: https://github.com/PyO3/pyo3/pull/4480#pullrequestreview-2258978813