### PR TITLE
Derive macro for `IntoPyObject`

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -489,7 +489,117 @@ If the input is neither a string nor an integer, the error message will be:
     - the argument must be the name of the function as a string.
     - the function signature must be `fn(&Bound<PyAny>) -> PyResult<T>` where `T` is the Rust type of the argument.
 
+### `IntoPyObject`
+This trait defines the to-python conversion for a Rust type. All types in PyO3 implement this trait,
+as does a `#[pyclass]` which doesn't use `extends`.
+
+Occasionally you may choose to implement this for custom types which are mapped to Python types
+_without_ having a unique python type.
+
+#### derive macro
+
+`IntoPyObject` can be implemented using our derive macro. Both `struct`s and `enum`s are supported.
+
+`struct`s will turn into a `PyDict` using the field names as keys, tuple `struct`s will turn convert
+into `PyTuple` with the fields in declaration order.
+```rust
+# #![allow(dead_code)]
+# use pyo3::prelude::*;
+# use std::collections::HashMap;
+# use std::hash::Hash;
+
+// structs convert into `PyDict` with field names as keys
+#[derive(IntoPyObject)]
+struct Struct { 
+    count: usize,
+    obj: Py<PyAny>,
+}
+
+// tuple structs convert into `PyTuple`
+// lifetimes and generics are supported, the impl will be bounded by
+// `K: IntoPyObject, V: IntoPyObject`
+#[derive(IntoPyObject)]
+struct Tuple<'a, K: Hash + Eq, V>(&'a str, HashMap<K, V>);
+```
+
+For structs with a single field (newtype patter) the `#[pyo3(transparent)]` option can be used to
+forward the implementation to the inner type.
+
+
+```rust
+# #![allow(dead_code)]
+# use pyo3::prelude::*;
+
+// newtype tuple structs are implicitly `transparent`
+#[derive(IntoPyObject)]
+struct TransparentTuple(PyObject); 
+
+#[derive(IntoPyObject)]
+#[pyo3(transparent)]
+struct TransparentStruct<'py> { 
+    inner: Bound<'py, PyAny>, // `'py` lifetime will be used as the Python lifetime
+}
+```
+
+For `enum`s each variant is converted according to the rules for `struct`s above.
+
+```rust
+# #![allow(dead_code)]
+# use pyo3::prelude::*;
+# use std::collections::HashMap;
+# use std::hash::Hash;
+
+#[derive(IntoPyObject)]
+enum Enum<'a, 'py, K: Hash + Eq, V> { // enums are supported and convert using the same
+    TransparentTuple(PyObject),       // rules on the variants as the structs above
+    #[pyo3(transparent)]
+    TransparentStruct { inner: Bound<'py, PyAny> },
+    Tuple(&'a str, HashMap<K, V>),
+    Struct { count: usize, obj: Py<PyAny> }
+}
+```
+
+#### manual implementation
+
+If the derive macro is not suitable for your use case, `IntoPyObject` can be implemented manually as
+demonstrated below.
+
+```rust
+# use pyo3::prelude::*;
+# #[allow(dead_code)]
+struct MyPyObjectWrapper(PyObject);
+
+impl<'py> IntoPyObject<'py> for MyPyObjectWrapper {
+    type Target = PyAny; // the Python type
+    type Output = Bound<'py, Self::Target>; // in most cases this will be `Bound`
+    type Error = std::convert::Infallible; // the conversion error type, has to be convertable to `PyErr`
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(self.0.into_bound(py))
+    }
+}
+
+// equivalent to former `ToPyObject` implementations 
+impl<'a, 'py> IntoPyObject<'py> for &'a MyPyObjectWrapper {
+    type Target = PyAny;
+    type Output = Borrowed<'a, 'py, Self::Target>; // `Borrowed` can be used to optimized reference counting
+    type Error = std::convert::Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(self.0.bind_borrowed(py))
+    }
+}
+```
+
 ### `IntoPy<T>`
+
+<div class="warning">
+
+⚠️ Warning: API update in progress 🛠️
+
+PyO3 0.23 has introduced `IntoPyObject` as the new trait for to-python conversions. While `#[pymethods]` and `#[pyfunction]` contain a compatibility layer to allow `IntoPy<PyObject>` as a return type, all Python API have been migrated to use `IntoPyObject`. To migrate implement `IntoPyObject` for your type.
+</div>
+
 
 This trait defines the to-python conversion for a Rust type. It is usually implemented as
 `IntoPy<PyObject>`, which is the trait needed for returning a value from `#[pyfunction]` and
@@ -513,6 +623,14 @@ impl IntoPy<PyObject> for MyPyObjectWrapper {
 ```
 
 ### The `ToPyObject` trait
+
+<div class="warning">
+
+⚠️ Warning: API update in progress 🛠️
+
+PyO3 0.23 has introduced `IntoPyObject` as the new trait for to-python conversions. To migrate
+implement `IntoPyObject` on a referece of your type (`impl<'py> IntoPyObject<'py> for &Type { ... }`).
+</div>
 
 [`ToPyObject`] is a conversion trait that allows various objects to be
 converted into [`PyObject`]. `IntoPy<PyObject>` serves the

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -522,7 +522,7 @@ struct Struct {
 struct Tuple<'a, K: Hash + Eq, V>(&'a str, HashMap<K, V>);
 ```
 
-For structs with a single field (newtype patter) the `#[pyo3(transparent)]` option can be used to
+For structs with a single field (newtype pattern) the `#[pyo3(transparent)]` option can be used to
 forward the implementation to the inner type.
 
 

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -173,29 +173,6 @@ struct Struct {
 }
 ```
 
-will expand into the following:
-
-```rust
-# use pyo3::prelude::*;
-# use pyo3::types::PyDict;
-# struct Struct { 
-#     count: usize,
-#     obj: Py<PyAny>,
-# }
-
-impl<'py> IntoPyObject<'py> for Struct {
-    type Target = PyDict;
-    type Output = Bound<'py, Self::Target>;
-    type Error = PyErr;
-
-    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        let dict = PyDict::new(py);
-        dict.set_item("count", self.count)?;
-        dict.set_item("obj", self.obj)?;
-        Ok(dict)
-    }
-}
-```
 
 #### `IntoPyObject` manual implementation
 

--- a/newsfragments/4495.added.md
+++ b/newsfragments/4495.added.md
@@ -1,0 +1,1 @@
+Added `IntoPyObject` derive macro

--- a/pyo3-macros-backend/src/intopyobject.rs
+++ b/pyo3-macros-backend/src/intopyobject.rs
@@ -320,7 +320,7 @@ impl<'a> Container<'a> {
             error: quote!(#pyo3_path::PyErr),
             body: quote! {
                 #unpack
-                ::std::result::Result::Ok::<_, Self::Error>(#pyo3_path::types::PyTuple::new(py, [#setter]))
+                #pyo3_path::types::PyTuple::new(py, [#setter])
             },
         }
     }

--- a/pyo3-macros-backend/src/intopyobject.rs
+++ b/pyo3-macros-backend/src/intopyobject.rs
@@ -1,0 +1,285 @@
+use crate::attributes::{self, get_pyo3_options, CrateAttribute};
+use crate::utils::Ctx;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned as _;
+use syn::{parse_quote, Attribute, DeriveInput, Fields, Result, Token};
+
+/// Attributes for deriving FromPyObject scoped on containers.
+enum ContainerPyO3Attribute {
+    /// Treat the Container as a Wrapper, directly convert its field into the output object.
+    Transparent(attributes::kw::transparent),
+    /// Change the path for the pyo3 crate
+    Crate(CrateAttribute),
+}
+
+impl Parse for ContainerPyO3Attribute {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(attributes::kw::transparent) {
+            let kw: attributes::kw::transparent = input.parse()?;
+            Ok(ContainerPyO3Attribute::Transparent(kw))
+        } else if lookahead.peek(Token![crate]) {
+            input.parse().map(ContainerPyO3Attribute::Crate)
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+#[derive(Default)]
+struct ContainerOptions {
+    /// Treat the Container as a Wrapper, directly convert its field into the output object.
+    transparent: Option<attributes::kw::transparent>,
+    /// Change the path for the pyo3 crate
+    krate: Option<CrateAttribute>,
+}
+
+impl ContainerOptions {
+    fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
+        let mut options = ContainerOptions::default();
+
+        for attr in attrs {
+            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
+                pyo3_attrs
+                    .into_iter()
+                    .try_for_each(|opt| options.set_option(opt))?;
+            }
+        }
+        Ok(options)
+    }
+
+    fn set_option(&mut self, option: ContainerPyO3Attribute) -> syn::Result<()> {
+        macro_rules! set_option {
+            ($key:ident) => {
+                {
+                    ensure_spanned!(
+                        self.$key.is_none(),
+                        $key.span() => concat!("`", stringify!($key), "` may only be specified once")
+                    );
+                    self.$key = Some($key);
+                }
+            };
+        }
+
+        match option {
+            ContainerPyO3Attribute::Transparent(transparent) => set_option!(transparent),
+            ContainerPyO3Attribute::Crate(krate) => set_option!(krate),
+        }
+        Ok(())
+    }
+}
+
+struct IntoPyObjectImpl {
+    target: TokenStream,
+    output: TokenStream,
+    error: TokenStream,
+    body: TokenStream,
+}
+
+struct NamedStructField<'a> {
+    ident: &'a syn::Ident,
+    ty: &'a syn::Type,
+}
+
+struct TupleStructField {}
+
+/// Container Style
+///
+/// Covers Structs, Tuplestructs and corresponding Newtypes.
+enum ContainerType<'a> {
+    /// Struct Container, e.g. `struct Foo { a: String }`
+    ///
+    /// Variant contains the list of field identifiers and the corresponding extraction call.
+    Struct(Vec<NamedStructField<'a>>),
+    /// Newtype struct container, e.g. `#[transparent] struct Foo { a: String }`
+    ///
+    /// The field specified by the identifier is extracted directly from the object.
+    StructNewtype(&'a syn::Field),
+    /// Tuple struct, e.g. `struct Foo(String)`.
+    ///
+    /// Variant contains a list of conversion methods for each of the fields that are directly
+    ///  extracted from the tuple.
+    Tuple(Vec<TupleStructField>),
+    /// Tuple newtype, e.g. `#[transparent] struct Foo(String)`
+    ///
+    /// The wrapped field is directly extracted from the object.
+    TupleNewtype(&'a syn::Field),
+}
+
+/// Data container
+///
+/// Either describes a struct or an enum variant.
+struct Container<'a> {
+    path: syn::Path,
+    ty: ContainerType<'a>,
+    err_name: String,
+}
+
+impl<'a> Container<'a> {
+    /// Construct a container based on fields, identifier and attributes.
+    ///
+    /// Fails if the variant has no fields or incompatible attributes.
+    fn new(fields: &'a Fields, path: syn::Path, options: ContainerOptions) -> Result<Self> {
+        let style = match fields {
+            Fields::Unnamed(unnamed) if !unnamed.unnamed.is_empty() => {
+                if unnamed.unnamed.iter().count() == 1 {
+                    // Always treat a 1-length tuple struct as "transparent", even without the
+                    // explicit annotation.
+                    let field = unnamed.unnamed.iter().next().unwrap();
+                    ContainerType::TupleNewtype(field)
+                } else if options.transparent.is_some() {
+                    bail_spanned!(
+                        fields.span() => "transparent structs and variants can only have 1 field"
+                    );
+                } else {
+                    let tuple_fields = unnamed
+                        .unnamed
+                        .iter()
+                        .map(|_field| Ok(TupleStructField {}))
+                        .collect::<Result<Vec<_>>>()?;
+
+                    ContainerType::Tuple(tuple_fields)
+                }
+            }
+            Fields::Named(named) if !named.named.is_empty() => {
+                if options.transparent.is_some() {
+                    ensure_spanned!(
+                        named.named.iter().count() == 1,
+                        fields.span() => "transparent structs and variants can only have 1 field"
+                    );
+
+                    let field = named.named.iter().next().unwrap();
+                    ContainerType::StructNewtype(field)
+                } else {
+                    let struct_fields = named
+                        .named
+                        .iter()
+                        .map(|field| {
+                            let ident = field
+                                .ident
+                                .as_ref()
+                                .expect("Named fields should have identifiers");
+                            let ty = &field.ty;
+
+                            Ok(NamedStructField { ident, ty })
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    ContainerType::Struct(struct_fields)
+                }
+            }
+            _ => bail_spanned!(
+                fields.span() => "cannot derive `IntoPyObject` for empty structs and variants"
+            ),
+        };
+        let err_name = path.segments.last().unwrap().ident.to_string();
+
+        let v = Container {
+            path,
+            ty: style,
+            err_name,
+        };
+        Ok(v)
+    }
+
+    fn name(&self) -> String {
+        let mut value = String::new();
+        for segment in &self.path.segments {
+            if !value.is_empty() {
+                value.push_str("::");
+            }
+            value.push_str(&segment.ident.to_string());
+        }
+        value
+    }
+
+    /// Build derivation body for a struct.
+    fn build(&self, ctx: &Ctx) -> IntoPyObjectImpl {
+        match &self.ty {
+            ContainerType::StructNewtype(field) | ContainerType::TupleNewtype(field) => {
+                self.build_newtype_struct(field, ctx)
+            }
+            ContainerType::Tuple(tups) => todo!(), // self.build_tuple_struct(tups, ctx),
+            ContainerType::Struct(tups) => todo!(), // self.build_struct(tups, ctx),
+        }
+    }
+
+    fn build_newtype_struct(&self, field: &syn::Field, ctx: &Ctx) -> IntoPyObjectImpl {
+        let Ctx { pyo3_path, .. } = ctx;
+        let ty = &field.ty;
+        let ident = if let Some(ident) = &field.ident {
+            quote! {self.#ident}
+        } else {
+            quote! {self.0}
+        };
+
+        IntoPyObjectImpl {
+            target: quote! {<#ty as #pyo3_path::conversion::IntoPyObject<'py>>::Target},
+            output: quote! {<#ty as #pyo3_path::conversion::IntoPyObject<'py>>::Output},
+            error: quote! {<#ty as #pyo3_path::conversion::IntoPyObject<'py>>::Error},
+            body: quote! { <#ty as #pyo3_path::conversion::IntoPyObject<'py>>::into_pyobject(#ident, py) },
+        }
+    }
+}
+
+pub fn build_derive_into_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
+    let options = ContainerOptions::from_attrs(&tokens.attrs)?;
+    let ctx = &Ctx::new(&options.krate, None);
+    let Ctx { pyo3_path, .. } = &ctx;
+
+    let mut trait_generics = tokens.generics.clone();
+    let generics = &tokens.generics;
+    // let lt_param = if let Some(lt) = verify_and_get_lifetime(generics)? {
+    //     lt.clone()
+    // } else {
+    trait_generics.params.push(parse_quote!('py));
+    // parse_quote!('py)
+    // };
+    let mut where_clause: syn::WhereClause = parse_quote!(where);
+    for param in generics.type_params() {
+        let gen_ident = &param.ident;
+        where_clause
+            .predicates
+            .push(parse_quote!(#gen_ident: #pyo3_path::conversion::IntoPyObject<'py>))
+    }
+
+    let IntoPyObjectImpl {
+        target,
+        output,
+        error,
+        body,
+    } = match &tokens.data {
+        syn::Data::Enum(en) => {
+            // if options.transparent || options.annotation.is_some() {
+            //     bail_spanned!(tokens.span() => "`transparent` or `annotation` is not supported \
+            //                                     at top level for enums");
+            // }
+            // let en = Enum::new(en, &tokens.ident)?;
+            // en.build(ctx)
+            todo!()
+        }
+        syn::Data::Struct(st) => {
+            let ident = &tokens.ident;
+            let st = Container::new(&st.fields, parse_quote!(#ident), options)?;
+            st.build(ctx)
+        }
+        syn::Data::Union(_) => bail_spanned!(
+            tokens.span() => "#[derive(FromPyObject)] is not supported for unions"
+        ),
+    };
+
+    let ident = &tokens.ident;
+    Ok(quote!(
+        #[automatically_derived]
+        impl #trait_generics #pyo3_path::conversion::IntoPyObject<'py> for #ident #generics #where_clause {
+            type Target = #target;
+            type Output = #output;
+            type Error = #error;
+
+            fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<Self::Output, Self::Error> {
+                #body
+            }
+        }
+    ))
+}

--- a/pyo3-macros-backend/src/intopyobject.rs
+++ b/pyo3-macros-backend/src/intopyobject.rs
@@ -393,7 +393,7 @@ impl<'a> Enum<'a> {
     }
 }
 
-// if there is a `'py` lifetime, we treat is as the `Python<'py>` lifetime
+// if there is a `'py` lifetime, we treat it as the `Python<'py>` lifetime
 fn verify_and_get_lifetime(generics: &syn::Generics) -> Option<&syn::LifetimeParam> {
     let mut lifetimes = generics.lifetimes();
     lifetimes.find(|l| l.lifetime.ident == "py")

--- a/pyo3-macros-backend/src/intopyobject.rs
+++ b/pyo3-macros-backend/src/intopyobject.rs
@@ -177,7 +177,7 @@ impl<'a> Container<'a> {
                 }
             }
             _ => bail_spanned!(
-                fields.span() => "cannot derive `IntoPyObject` for empty structs and variants"
+                fields.span() => "cannot derive `IntoPyObject` for empty structs"
             ),
         };
 
@@ -347,6 +347,12 @@ impl<'a> Enum<'a> {
             .map(|variant| {
                 let attrs = ContainerOptions::from_attrs(&variant.attrs)?;
                 let var_ident = &variant.ident;
+
+                ensure_spanned!(
+                    !variant.fields.is_empty(),
+                    variant.ident.span() => "cannot derive `IntoPyObject` for empty variants"
+                );
+
                 Container::new(
                     None,
                     &variant.fields,

--- a/pyo3-macros-backend/src/intopyobject.rs
+++ b/pyo3-macros-backend/src/intopyobject.rs
@@ -7,7 +7,7 @@ use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned as _;
 use syn::{parse_quote, Attribute, DataEnum, DeriveInput, Fields, Ident, Index, Result, Token};
 
-/// Attributes for deriving FromPyObject scoped on containers.
+/// Attributes for deriving `IntoPyObject` scoped on containers.
 enum ContainerPyO3Attribute {
     /// Treat the Container as a Wrapper, directly convert its field into the output object.
     Transparent(attributes::kw::transparent),
@@ -374,7 +374,7 @@ impl<'a> Enum<'a> {
                         {#body}
                             .map(#pyo3_path::BoundObject::into_any)
                             .map(#pyo3_path::BoundObject::into_bound)
-                            .map_err(::std::convert::Into::<PyErr>::into)
+                            .map_err(::std::convert::Into::<#pyo3_path::PyErr>::into)
                     }
                 }
             })

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -11,6 +11,7 @@ mod utils;
 mod attributes;
 mod deprecations;
 mod frompyobject;
+mod intopyobject;
 mod konst;
 mod method;
 mod module;
@@ -23,6 +24,7 @@ mod pyversions;
 mod quotes;
 
 pub use frompyobject::build_derive_from_pyobject;
+pub use intopyobject::build_derive_into_pyobject;
 pub use module::{pymodule_function_impl, pymodule_module_impl, PyModuleOptions};
 pub use pyclass::{build_py_class, build_py_enum, PyClassArgs};
 pub use pyfunction::{build_py_function, PyFunctionOptions};

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -5,9 +5,9 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use pyo3_macros_backend::{
-    build_derive_from_pyobject, build_py_class, build_py_enum, build_py_function, build_py_methods,
-    pymodule_function_impl, pymodule_module_impl, PyClassArgs, PyClassMethodsType,
-    PyFunctionOptions, PyModuleOptions,
+    build_derive_from_pyobject, build_derive_into_pyobject, build_py_class, build_py_enum,
+    build_py_function, build_py_methods, pymodule_function_impl, pymodule_module_impl, PyClassArgs,
+    PyClassMethodsType, PyFunctionOptions, PyModuleOptions,
 };
 use quote::quote;
 use syn::{parse_macro_input, Item};
@@ -148,6 +148,16 @@ pub fn pyfunction(attr: TokenStream, input: TokenStream) -> TokenStream {
 
     quote!(
         #ast
+        #expanded
+    )
+    .into()
+}
+
+#[proc_macro_derive(IntoPyObject, attributes(pyo3))]
+pub fn derive_into_py_object(item: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(item as syn::DeriveInput);
+    let expanded = build_derive_into_pyobject(&ast).unwrap_or_compile_error();
+    quote!(
         #expanded
     )
     .into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@ mod version;
 pub use crate::conversions::*;
 
 #[cfg(feature = "macros")]
-pub use pyo3_macros::{pyfunction, pymethods, pymodule, FromPyObject};
+pub use pyo3_macros::{pyfunction, pymethods, pymodule, FromPyObject, IntoPyObject};
 
 /// A proc macro used to expose Rust structs and fieldless enums as Python objects.
 ///

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,7 +19,7 @@ pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::types::{PyAny, PyModule};
 
 #[cfg(feature = "macros")]
-pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, FromPyObject};
+pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, FromPyObject, IntoPyObject};
 
 #[cfg(feature = "macros")]
 pub use crate::wrap_pyfunction;

--- a/src/tests/hygiene/misc.rs
+++ b/src/tests/hygiene/misc.rs
@@ -56,3 +56,39 @@ macro_rules! macro_rules_hygiene {
 }
 
 macro_rules_hygiene!(MyClass1, MyClass2);
+
+#[derive(crate::IntoPyObject)]
+#[pyo3(crate = "crate")]
+struct IntoPyObject1(i32); // transparent newtype case
+
+#[derive(crate::IntoPyObject)]
+#[pyo3(crate = "crate", transparent)]
+struct IntoPyObject2<'a> {
+    inner: &'a str, // transparent newtype case
+}
+
+#[derive(crate::IntoPyObject)]
+#[pyo3(crate = "crate")]
+struct IntoPyObject3<'py>(i32, crate::Bound<'py, crate::PyAny>); // tuple case
+
+#[derive(crate::IntoPyObject)]
+#[pyo3(crate = "crate")]
+struct IntoPyObject4<'a, 'py> {
+    callable: &'a crate::Bound<'py, crate::PyAny>, // struct case
+    num: usize,
+}
+
+#[derive(crate::IntoPyObject)]
+#[pyo3(crate = "crate")]
+enum IntoPyObject5<'a, 'py> {
+    TransparentTuple(i32),
+    #[pyo3(transparent)]
+    TransparentStruct {
+        f: crate::Py<crate::PyAny>,
+    },
+    Tuple(crate::Bound<'py, crate::types::PyString>, usize),
+    Struct {
+        f: i32,
+        g: &'a str,
+    },
+} // enum case

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -25,6 +25,7 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_closure.rs");
     t.compile_fail("tests/ui/pyclass_send.rs");
     t.compile_fail("tests/ui/invalid_argument_attributes.rs");
+    t.compile_fail("tests/ui/invalid_intopy_derive.rs");
     t.compile_fail("tests/ui/invalid_frompy_derive.rs");
     t.compile_fail("tests/ui/static_ref.rs");
     t.compile_fail("tests/ui/wrong_aspyref_lifetimes.rs");

--- a/tests/test_frompy_intopy_roundtrip.rs
+++ b/tests/test_frompy_intopy_roundtrip.rs
@@ -1,0 +1,180 @@
+#![cfg(feature = "macros")]
+
+use pyo3::types::{PyDict, PyString};
+use pyo3::{prelude::*, IntoPyObject};
+use std::collections::HashMap;
+use std::hash::Hash;
+
+#[macro_use]
+#[path = "../src/tests/common.rs"]
+mod common;
+
+#[derive(Debug, Clone, IntoPyObject, FromPyObject)]
+pub struct A<'py> {
+    #[pyo3(item)]
+    s: String,
+    #[pyo3(item)]
+    t: Bound<'py, PyString>,
+    #[pyo3(item("foo"))]
+    p: Bound<'py, PyAny>,
+}
+
+#[test]
+fn test_named_fields_struct() {
+    Python::with_gil(|py| {
+        let a = A {
+            s: "Hello".into(),
+            t: PyString::new(py, "World"),
+            p: 42i32.into_pyobject(py).unwrap().into_any(),
+        };
+        let pya = a.clone().into_pyobject(py).unwrap();
+        let new_a = pya.extract::<A<'_>>().unwrap();
+
+        assert_eq!(a.s, new_a.s);
+        assert_eq!(a.t.to_cow().unwrap(), new_a.t.to_cow().unwrap());
+        assert_eq!(
+            a.p.extract::<i32>().unwrap(),
+            new_a.p.extract::<i32>().unwrap()
+        );
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+#[pyo3(transparent)]
+pub struct B {
+    test: String,
+}
+
+#[test]
+fn test_transparent_named_field_struct() {
+    Python::with_gil(|py| {
+        let b = B {
+            test: "test".into(),
+        };
+        let pyb = b.clone().into_pyobject(py).unwrap();
+        let new_b = pyb.extract::<B>().unwrap();
+        assert_eq!(b, new_b);
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+#[pyo3(transparent)]
+pub struct D<T> {
+    test: T,
+}
+
+#[test]
+fn test_generic_transparent_named_field_struct() {
+    Python::with_gil(|py| {
+        let d = D {
+            test: String::from("test"),
+        };
+        let pyd = d.clone().into_pyobject(py).unwrap();
+        let new_d = pyd.extract::<D<String>>().unwrap();
+        assert_eq!(d, new_d);
+
+        let d = D { test: 1usize };
+        let pyd = d.clone().into_pyobject(py).unwrap();
+        let new_d = pyd.extract::<D<usize>>().unwrap();
+        assert_eq!(d, new_d);
+    });
+}
+
+#[derive(Debug, IntoPyObject, FromPyObject)]
+pub struct GenericWithBound<K: Hash + Eq, V>(HashMap<K, V>);
+
+#[test]
+fn test_generic_with_bound() {
+    Python::with_gil(|py| {
+        let mut hash_map = HashMap::<String, i32>::new();
+        hash_map.insert("1".into(), 1);
+        hash_map.insert("2".into(), 2);
+        let map = GenericWithBound(hash_map).into_pyobject(py).unwrap();
+        assert_eq!(map.len(), 2);
+        assert_eq!(
+            map.get_item("1")
+                .unwrap()
+                .unwrap()
+                .extract::<i32>()
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            map.get_item("2")
+                .unwrap()
+                .unwrap()
+                .extract::<i32>()
+                .unwrap(),
+            2
+        );
+        assert!(map.get_item("3").unwrap().is_none());
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+pub struct Tuple(String, usize);
+
+#[test]
+fn test_tuple_struct() {
+    Python::with_gil(|py| {
+        let tup = Tuple(String::from("test"), 1);
+        let tuple = tup.clone().into_pyobject(py).unwrap();
+        let new_tup = tuple.extract::<Tuple>().unwrap();
+        assert_eq!(tup, new_tup);
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+pub struct TransparentTuple(String);
+
+#[test]
+fn test_transparent_tuple_struct() {
+    Python::with_gil(|py| {
+        let tup = TransparentTuple(String::from("test"));
+        let tuple = tup.clone().into_pyobject(py).unwrap();
+        let new_tup = tuple.extract::<TransparentTuple>().unwrap();
+        assert_eq!(tup, new_tup);
+    });
+}
+
+#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+pub enum Foo {
+    TupleVar(usize, String),
+    StructVar {
+        #[pyo3(item)]
+        test: char,
+    },
+    #[pyo3(transparent)]
+    TransparentTuple(usize),
+    #[pyo3(transparent)]
+    TransparentStructVar {
+        a: Option<String>,
+    },
+}
+
+#[test]
+fn test_enum() {
+    Python::with_gil(|py| {
+        let tuple_var = Foo::TupleVar(1, "test".into());
+        let foo = tuple_var.clone().into_pyobject(py).unwrap();
+        assert_eq!(tuple_var, foo.extract::<Foo>().unwrap());
+
+        let struct_var = Foo::StructVar { test: 'b' };
+        let foo = struct_var
+            .clone()
+            .into_pyobject(py)
+            .unwrap()
+            .downcast_into::<PyDict>()
+            .unwrap();
+
+        assert_eq!(struct_var, foo.extract::<Foo>().unwrap());
+
+        let transparent_tuple = Foo::TransparentTuple(1);
+        let foo = transparent_tuple.clone().into_pyobject(py).unwrap();
+        assert_eq!(transparent_tuple, foo.extract::<Foo>().unwrap());
+
+        let transparent_struct_var = Foo::TransparentStructVar { a: None };
+        let foo = transparent_struct_var.clone().into_pyobject(py).unwrap();
+        assert_eq!(transparent_struct_var, foo.extract::<Foo>().unwrap());
+    });
+}

--- a/tests/test_intopyobject.rs
+++ b/tests/test_intopyobject.rs
@@ -1,0 +1,168 @@
+#![cfg(feature = "macros")]
+
+use pyo3::types::{PyDict, PyString};
+use pyo3::{prelude::*, IntoPyObject};
+
+#[macro_use]
+#[path = "../src/tests/common.rs"]
+mod common;
+
+#[derive(Debug, IntoPyObject)]
+pub struct A<'py> {
+    s: String,
+    t: Bound<'py, PyString>,
+    p: Bound<'py, PyAny>,
+}
+
+#[test]
+fn test_named_fields_struct() {
+    Python::with_gil(|py| {
+        let a = A {
+            s: "Hello".into(),
+            t: PyString::new(py, "World"),
+            p: 42i32.into_pyobject(py).unwrap().into_any(),
+        };
+        let pya = a.into_pyobject(py).unwrap();
+        assert_eq!(
+            pya.get_item("s")
+                .unwrap()
+                .unwrap()
+                .downcast::<PyString>()
+                .unwrap(),
+            "Hello"
+        );
+        assert_eq!(
+            pya.get_item("t")
+                .unwrap()
+                .unwrap()
+                .downcast::<PyString>()
+                .unwrap(),
+            "World"
+        );
+        assert_eq!(
+            pya.get_item("p")
+                .unwrap()
+                .unwrap()
+                .extract::<i32>()
+                .unwrap(),
+            42
+        );
+    });
+}
+
+#[derive(Debug, IntoPyObject)]
+#[pyo3(transparent)]
+pub struct B<'a> {
+    test: &'a str,
+}
+
+#[test]
+fn test_transparent_named_field_struct() {
+    Python::with_gil(|py| {
+        let pyb = B { test: "test" }.into_pyobject(py).unwrap();
+        let b = pyb.extract::<String>().unwrap();
+        assert_eq!(b, "test");
+    });
+}
+
+#[derive(Debug, IntoPyObject)]
+#[pyo3(transparent)]
+pub struct D<T> {
+    test: T,
+}
+
+#[test]
+fn test_generic_transparent_named_field_struct() {
+    Python::with_gil(|py| {
+        let pyd = D {
+            test: String::from("test"),
+        }
+        .into_pyobject(py)
+        .unwrap();
+        let d = pyd.extract::<String>().unwrap();
+        assert_eq!(d, "test");
+
+        let pyd = D { test: 1usize }.into_pyobject(py).unwrap();
+        let d = pyd.extract::<usize>().unwrap();
+        assert_eq!(d, 1);
+    });
+}
+
+#[derive(Debug, IntoPyObject)]
+pub struct Tuple(String, usize);
+
+#[test]
+fn test_tuple_struct() {
+    Python::with_gil(|py| {
+        let tup = Tuple(String::from("test"), 1).into_pyobject(py).unwrap();
+        assert!(tup.extract::<(usize, String)>().is_err());
+        let tup = tup.extract::<(String, usize)>().unwrap();
+        assert_eq!(tup.0, "test");
+        assert_eq!(tup.1, 1);
+    });
+}
+
+#[derive(Debug, IntoPyObject)]
+pub struct TransparentTuple(String);
+
+#[test]
+fn test_transparent_tuple_struct() {
+    Python::with_gil(|py| {
+        let tup = TransparentTuple(String::from("test"))
+            .into_pyobject(py)
+            .unwrap();
+        assert!(tup.extract::<(String,)>().is_err());
+        let tup = tup.extract::<String>().unwrap();
+        assert_eq!(tup, "test");
+    });
+}
+
+#[derive(Debug, IntoPyObject)]
+pub enum Foo<'py> {
+    TupleVar(usize, String),
+    StructVar {
+        test: Bound<'py, PyString>,
+    },
+    #[pyo3(transparent)]
+    TransparentTuple(usize),
+    #[pyo3(transparent)]
+    TransparentStructVar {
+        a: Option<String>,
+    },
+}
+
+#[test]
+fn test_enum() {
+    Python::with_gil(|py| {
+        let foo = Foo::TupleVar(1, "test".into()).into_pyobject(py).unwrap();
+        assert_eq!(
+            foo.extract::<(usize, String)>().unwrap(),
+            (1, String::from("test"))
+        );
+
+        let foo = Foo::StructVar {
+            test: PyString::new(py, "test"),
+        }
+        .into_pyobject(py)
+        .unwrap()
+        .downcast_into::<PyDict>()
+        .unwrap();
+
+        assert_eq!(
+            foo.get_item("test")
+                .unwrap()
+                .unwrap()
+                .downcast_into::<PyString>()
+                .unwrap(),
+            "test"
+        );
+
+        let foo = Foo::TransparentTuple(1).into_pyobject(py).unwrap();
+        assert_eq!(foo.extract::<usize>().unwrap(), 1);
+
+        let foo = Foo::TransparentStructVar { a: None }
+            .into_pyobject(py)
+            .unwrap();
+        assert!(foo.is_none());
+    });
+}

--- a/tests/ui/invalid_intopy_derive.rs
+++ b/tests/ui/invalid_intopy_derive.rs
@@ -87,4 +87,23 @@ enum UnitEnum {
     Unit,
 }
 
+#[derive(IntoPyObject)]
+struct TupleAttribute(#[pyo3(attribute)] String, usize);
+
+#[derive(IntoPyObject)]
+struct TupleItem(#[pyo3(item)] String, usize);
+
+#[derive(IntoPyObject)]
+struct StructAttribute {
+    #[pyo3(attribute)]
+    foo: String,
+}
+
+#[derive(IntoPyObject)]
+#[pyo3(transparent)]
+struct StructTransparentItem {
+    #[pyo3(item)]
+    foo: String,
+}
+
 fn main() {}

--- a/tests/ui/invalid_intopy_derive.rs
+++ b/tests/ui/invalid_intopy_derive.rs
@@ -1,0 +1,90 @@
+use pyo3::IntoPyObject;
+
+#[derive(IntoPyObject)]
+struct Foo();
+
+#[derive(IntoPyObject)]
+struct Foo2 {}
+
+#[derive(IntoPyObject)]
+enum EmptyEnum {}
+
+#[derive(IntoPyObject)]
+enum EnumWithEmptyTupleVar {
+    EmptyTuple(),
+    Valid(String),
+}
+
+#[derive(IntoPyObject)]
+enum EnumWithEmptyStructVar {
+    EmptyStruct {},
+    Valid(String),
+}
+
+#[derive(IntoPyObject)]
+#[pyo3(transparent)]
+struct EmptyTransparentTup();
+
+#[derive(IntoPyObject)]
+#[pyo3(transparent)]
+struct EmptyTransparentStruct {}
+
+#[derive(IntoPyObject)]
+enum EnumWithTransparentEmptyTupleVar {
+    #[pyo3(transparent)]
+    EmptyTuple(),
+    Valid(String),
+}
+
+#[derive(IntoPyObject)]
+enum EnumWithTransparentEmptyStructVar {
+    #[pyo3(transparent)]
+    EmptyStruct {},
+    Valid(String),
+}
+
+#[derive(IntoPyObject)]
+#[pyo3(transparent)]
+struct TransparentTupTooManyFields(String, String);
+
+#[derive(IntoPyObject)]
+#[pyo3(transparent)]
+struct TransparentStructTooManyFields {
+    foo: String,
+    bar: String,
+}
+
+#[derive(IntoPyObject)]
+enum EnumWithTransparentTupleTooMany {
+    #[pyo3(transparent)]
+    EmptyTuple(String, String),
+    Valid(String),
+}
+
+#[derive(IntoPyObject)]
+enum EnumWithTransparentStructTooMany {
+    #[pyo3(transparent)]
+    EmptyStruct {
+        foo: String,
+        bar: String,
+    },
+    Valid(String),
+}
+
+#[derive(IntoPyObject)]
+#[pyo3(unknown = "should not work")]
+struct UnknownContainerAttr {
+    a: String,
+}
+
+#[derive(IntoPyObject)]
+union Union {
+    a: usize,
+}
+
+#[derive(IntoPyObject)]
+enum UnitEnum {
+    Unit,
+}
+
+fn main() {}

--- a/tests/ui/invalid_intopy_derive.stderr
+++ b/tests/ui/invalid_intopy_derive.stderr
@@ -101,3 +101,27 @@ error: cannot derive `IntoPyObject` for empty variants
    |
 87 |     Unit,
    |     ^^^^
+
+error: `attribute` is not supported by `IntoPyObject`
+  --> tests/ui/invalid_intopy_derive.rs:91:30
+   |
+91 | struct TupleAttribute(#[pyo3(attribute)] String, usize);
+   |                              ^^^^^^^^^
+
+error: `item` is not permitted on tuple struct elements.
+  --> tests/ui/invalid_intopy_derive.rs:94:25
+   |
+94 | struct TupleItem(#[pyo3(item)] String, usize);
+   |                         ^^^^
+
+error: `attribute` is not supported by `IntoPyObject`
+  --> tests/ui/invalid_intopy_derive.rs:98:12
+   |
+98 |     #[pyo3(attribute)]
+   |            ^^^^^^^^^
+
+error: `transparent` structs may not have `item` for the inner field
+   --> tests/ui/invalid_intopy_derive.rs:105:12
+    |
+105 |     #[pyo3(item)]
+    |            ^^^^

--- a/tests/ui/invalid_intopy_derive.stderr
+++ b/tests/ui/invalid_intopy_derive.stderr
@@ -1,10 +1,10 @@
-error: cannot derive `IntoPyObject` for empty structs and variants
+error: cannot derive `IntoPyObject` for empty structs
  --> tests/ui/invalid_intopy_derive.rs:4:11
   |
 4 | struct Foo();
   |           ^^
 
-error: cannot derive `IntoPyObject` for empty structs and variants
+error: cannot derive `IntoPyObject` for empty structs
  --> tests/ui/invalid_intopy_derive.rs:7:13
   |
 7 | struct Foo2 {}
@@ -16,41 +16,41 @@ error: cannot derive `IntoPyObject` for empty enum
 10 | enum EmptyEnum {}
    |      ^^^^^^^^^
 
-error: cannot derive `IntoPyObject` for empty structs and variants
-  --> tests/ui/invalid_intopy_derive.rs:14:15
+error: cannot derive `IntoPyObject` for empty variants
+  --> tests/ui/invalid_intopy_derive.rs:14:5
    |
 14 |     EmptyTuple(),
-   |               ^^
+   |     ^^^^^^^^^^
 
-error: cannot derive `IntoPyObject` for empty structs and variants
-  --> tests/ui/invalid_intopy_derive.rs:20:17
+error: cannot derive `IntoPyObject` for empty variants
+  --> tests/ui/invalid_intopy_derive.rs:20:5
    |
 20 |     EmptyStruct {},
-   |                 ^^
+   |     ^^^^^^^^^^^
 
-error: cannot derive `IntoPyObject` for empty structs and variants
+error: cannot derive `IntoPyObject` for empty structs
   --> tests/ui/invalid_intopy_derive.rs:26:27
    |
 26 | struct EmptyTransparentTup();
    |                           ^^
 
-error: cannot derive `IntoPyObject` for empty structs and variants
+error: cannot derive `IntoPyObject` for empty structs
   --> tests/ui/invalid_intopy_derive.rs:30:31
    |
 30 | struct EmptyTransparentStruct {}
    |                               ^^
 
-error: cannot derive `IntoPyObject` for empty structs and variants
-  --> tests/ui/invalid_intopy_derive.rs:35:15
+error: cannot derive `IntoPyObject` for empty variants
+  --> tests/ui/invalid_intopy_derive.rs:35:5
    |
 35 |     EmptyTuple(),
-   |               ^^
+   |     ^^^^^^^^^^
 
-error: cannot derive `IntoPyObject` for empty structs and variants
-  --> tests/ui/invalid_intopy_derive.rs:42:17
+error: cannot derive `IntoPyObject` for empty variants
+  --> tests/ui/invalid_intopy_derive.rs:42:5
    |
 42 |     EmptyStruct {},
-   |                 ^^
+   |     ^^^^^^^^^^^
 
 error: transparent structs and variants can only have 1 field
   --> tests/ui/invalid_intopy_derive.rs:48:35
@@ -96,10 +96,8 @@ error: #[derive(`IntoPyObject`)] is not supported for unions
 81 | union Union {
    | ^^^^^
 
-error: cannot derive `IntoPyObject` for empty structs and variants
-  --> tests/ui/invalid_intopy_derive.rs:85:10
+error: cannot derive `IntoPyObject` for empty variants
+  --> tests/ui/invalid_intopy_derive.rs:87:5
    |
-85 | #[derive(IntoPyObject)]
-   |          ^^^^^^^^^^^^
-   |
-   = note: this error originates in the derive macro `IntoPyObject` (in Nightly builds, run with -Z macro-backtrace for more info)
+87 |     Unit,
+   |     ^^^^

--- a/tests/ui/invalid_intopy_derive.stderr
+++ b/tests/ui/invalid_intopy_derive.stderr
@@ -1,0 +1,105 @@
+error: cannot derive `IntoPyObject` for empty structs and variants
+ --> tests/ui/invalid_intopy_derive.rs:4:11
+  |
+4 | struct Foo();
+  |           ^^
+
+error: cannot derive `IntoPyObject` for empty structs and variants
+ --> tests/ui/invalid_intopy_derive.rs:7:13
+  |
+7 | struct Foo2 {}
+  |             ^^
+
+error: cannot derive `IntoPyObject` for empty enum
+  --> tests/ui/invalid_intopy_derive.rs:10:6
+   |
+10 | enum EmptyEnum {}
+   |      ^^^^^^^^^
+
+error: cannot derive `IntoPyObject` for empty structs and variants
+  --> tests/ui/invalid_intopy_derive.rs:14:15
+   |
+14 |     EmptyTuple(),
+   |               ^^
+
+error: cannot derive `IntoPyObject` for empty structs and variants
+  --> tests/ui/invalid_intopy_derive.rs:20:17
+   |
+20 |     EmptyStruct {},
+   |                 ^^
+
+error: cannot derive `IntoPyObject` for empty structs and variants
+  --> tests/ui/invalid_intopy_derive.rs:26:27
+   |
+26 | struct EmptyTransparentTup();
+   |                           ^^
+
+error: cannot derive `IntoPyObject` for empty structs and variants
+  --> tests/ui/invalid_intopy_derive.rs:30:31
+   |
+30 | struct EmptyTransparentStruct {}
+   |                               ^^
+
+error: cannot derive `IntoPyObject` for empty structs and variants
+  --> tests/ui/invalid_intopy_derive.rs:35:15
+   |
+35 |     EmptyTuple(),
+   |               ^^
+
+error: cannot derive `IntoPyObject` for empty structs and variants
+  --> tests/ui/invalid_intopy_derive.rs:42:17
+   |
+42 |     EmptyStruct {},
+   |                 ^^
+
+error: transparent structs and variants can only have 1 field
+  --> tests/ui/invalid_intopy_derive.rs:48:35
+   |
+48 | struct TransparentTupTooManyFields(String, String);
+   |                                   ^^^^^^^^^^^^^^^^
+
+error: transparent structs and variants can only have 1 field
+  --> tests/ui/invalid_intopy_derive.rs:52:39
+   |
+52 |   struct TransparentStructTooManyFields {
+   |  _______________________________________^
+53 | |     foo: String,
+54 | |     bar: String,
+55 | | }
+   | |_^
+
+error: transparent structs and variants can only have 1 field
+  --> tests/ui/invalid_intopy_derive.rs:60:15
+   |
+60 |     EmptyTuple(String, String),
+   |               ^^^^^^^^^^^^^^^^
+
+error: transparent structs and variants can only have 1 field
+  --> tests/ui/invalid_intopy_derive.rs:67:17
+   |
+67 |       EmptyStruct {
+   |  _________________^
+68 | |         foo: String,
+69 | |         bar: String,
+70 | |     },
+   | |_____^
+
+error: expected `transparent` or `crate`
+  --> tests/ui/invalid_intopy_derive.rs:75:8
+   |
+75 | #[pyo3(unknown = "should not work")]
+   |        ^^^^^^^
+
+error: #[derive(`IntoPyObject`)] is not supported for unions
+  --> tests/ui/invalid_intopy_derive.rs:81:1
+   |
+81 | union Union {
+   | ^^^^^
+
+error: cannot derive `IntoPyObject` for empty structs and variants
+  --> tests/ui/invalid_intopy_derive.rs:85:10
+   |
+85 | #[derive(IntoPyObject)]
+   |          ^^^^^^^^^^^^
+   |
+   = note: this error originates in the derive macro `IntoPyObject` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
Initial implementation of `#[derive(IntoPyObject)]`. `#[derive(FromPyObject)]` was used as a base/reference for this implementation. 

This currently supports `#[pyo3(transparent)]` as the only real option, which just forwards to the inner `IntoPyObject` impl.

- Newtype structs (`#[pyo3(transparent)]` named and single tuple): forward impl.
- Named structs: `PyDict` with the field names as keys
- Tuple structs: `PyTuple` in declaration order
- Enums: matches on the variant and treats it as an anonymous struct with the rules above.
- Lifetimes and Generics are supported, `'py` is treated special and is used a the `Python<'py>` lifetime if given.

We still need lots of tests here, but I thought I'll put this up as a POC already. Hopefully this can smoothen the migration to `IntoPyObject` a bit. 

One thing not needed initially, but may be a nice to have at some point is some like `#[pyo3(into_py_with = "...")]` analogous to `#[pyo3(from_py_with = "...")]`



Closes #4458 