### PR TITLE
make `abi3` feature apply to config imported from `PYO3_BUILD_CONFIG`

### DIFF
--- a/newsfragments/4497.changed.md
+++ b/newsfragments/4497.changed.md
@@ -1,0 +1,1 @@
+The `abi3` feature will now override config files provided via `PYO3_BUILD_CONFIG`.

--- a/pyo3-build-config/build.rs
+++ b/pyo3-build-config/build.rs
@@ -12,7 +12,7 @@ mod errors;
 use std::{env, path::Path};
 
 use errors::{Context, Result};
-use impl_::{env_var, make_interpreter_config, InterpreterConfig};
+use impl_::{make_interpreter_config, InterpreterConfig};
 
 fn configure(interpreter_config: Option<InterpreterConfig>, name: &str) -> Result<bool> {
     let target = Path::new(&env::var_os("OUT_DIR").unwrap()).join(name);
@@ -29,28 +29,12 @@ fn configure(interpreter_config: Option<InterpreterConfig>, name: &str) -> Resul
     }
 }
 
-/// If PYO3_CONFIG_FILE is set, copy it into the crate.
-fn config_file() -> Result<Option<InterpreterConfig>> {
-    if let Some(path) = env_var("PYO3_CONFIG_FILE") {
-        let path = Path::new(&path);
-        println!("cargo:rerun-if-changed={}", path.display());
-        // Absolute path is necessary because this build script is run with a cwd different to the
-        // original `cargo build` instruction.
-        ensure!(
-            path.is_absolute(),
-            "PYO3_CONFIG_FILE must be an absolute path"
-        );
-
-        let interpreter_config = InterpreterConfig::from_path(path)
-            .context("failed to parse contents of PYO3_CONFIG_FILE")?;
-        Ok(Some(interpreter_config))
-    } else {
-        Ok(None)
-    }
-}
-
 fn generate_build_configs() -> Result<()> {
-    let configured = configure(config_file()?, "pyo3-build-config-file.txt")?;
+    // If PYO3_CONFIG_FILE is set, copy it into the crate.
+    let configured = configure(
+        InterpreterConfig::from_pyo3_config_file_env().transpose()?,
+        "pyo3-build-config-file.txt",
+    )?;
 
     if configured {
         // Don't bother trying to find an interpreter on the host system

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -66,9 +66,11 @@ impl AssertingBaseClass {
 #[pyclass]
 struct ClassWithoutConstructor;
 
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 #[pyclass(dict)]
 struct ClassWithDict;
 
+#[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 #[pymethods]
 impl ClassWithDict {
     #[new]
@@ -83,6 +85,7 @@ pub fn pyclasses(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyClassIter>()?;
     m.add_class::<AssertingBaseClass>()?;
     m.add_class::<ClassWithoutConstructor>()?;
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     m.add_class::<ClassWithDict>()?;
 
     Ok(())

--- a/pytests/tests/test_pyclasses.py
+++ b/pytests/tests/test_pyclasses.py
@@ -89,7 +89,12 @@ def test_no_constructor_defined_propagates_cause(cls: Type):
 
 
 def test_dict():
-    d = pyclasses.ClassWithDict()
+    try:
+        ClassWithDict = pyclasses.ClassWithDict
+    except AttributeError:
+        pytest.skip("not defined using abi3 < 3.9")
+
+    d = ClassWithDict()
     assert d.__dict__ == {}
 
     d.foo = 42


### PR DESCRIPTION
This adjusts the `PYO3_CONFIG_FILE` system so that if the `abi3` feature is set but the config file didn't set it, the `abi3` feature wins.

While a breaking change, people using `PYO3_CONFIG_FILE` directly are relatively rare. I also think that it's better for the `abi3` feature to apply consistently rather than silently ignoring it.

There's a case to be made that the `InterpreterConfig` doesn't need to have the `abi3` field as that's a property of the binding mode and not the interpreter, but that's a possible refactor for another time.