### PR TITLE
use unique module names in unit and integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ rayon = "1.6.1"
 futures = "0.3.28"
 tempfile = "3.12.0"
 static_assertions = "1.1.0"
+uuid = {version = "1.10.0", features = ["v4"] }
 
 [build-dependencies]
 pyo3-build-config = { path = "pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -337,6 +337,7 @@ fn int_n_bits(long: &Bound<'_, PyInt>) -> PyResult<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::common::generate_unique_module_name;
     use crate::types::{PyDict, PyModule};
     use indoc::indoc;
     use pyo3_ffi::c_str;
@@ -409,7 +410,13 @@ mod tests {
                         return self.x
                 "#
         ));
-        PyModule::from_code(py, index_code, c_str!("index.py"), c_str!("index")).unwrap()
+        PyModule::from_code(
+            py,
+            index_code,
+            c_str!("index.py"),
+            &generate_unique_module_name("index"),
+        )
+        .unwrap()
     }
 
     #[test]

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -216,6 +216,7 @@ complex_conversion!(f64);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::common::generate_unique_module_name;
     use crate::types::{complex::PyComplexMethods, PyModule};
     use pyo3_ffi::c_str;
 
@@ -259,7 +260,7 @@ class C:
                 "#
                 ),
                 c_str!("test.py"),
-                c_str!("test"),
+                &generate_unique_module_name("test"),
             )
             .unwrap();
             let from_complex = module.getattr("A").unwrap().call0().unwrap();
@@ -303,7 +304,7 @@ class C(First, IndexMixin): pass
                 "#
                 ),
                 c_str!("test.py"),
-                c_str!("test"),
+                &generate_unique_module_name("test"),
             )
             .unwrap();
             let from_complex = module.getattr("A").unwrap().call0().unwrap();
@@ -343,7 +344,7 @@ class A:
                 "#
                 ),
                 c_str!("test.py"),
-                c_str!("test"),
+                &generate_unique_module_name("test"),
             )
             .unwrap();
             let obj = module.getattr("A").unwrap().call0().unwrap();
@@ -368,7 +369,7 @@ class A:
                 "#
                 ),
                 c_str!("test.py"),
-                c_str!("test"),
+                &generate_unique_module_name("test"),
             )
             .unwrap();
             let obj = module.getattr("A").unwrap().call0().unwrap();

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1887,6 +1887,7 @@ impl PyObject {
 #[cfg(test)]
 mod tests {
     use super::{Bound, Py, PyObject};
+    use crate::tests::common::generate_unique_module_name;
     use crate::types::{dict::IntoPyDict, PyAnyMethods, PyCapsule, PyDict, PyString};
     use crate::{ffi, Borrowed, PyAny, PyResult, Python, ToPyObject};
     use pyo3_ffi::c_str;
@@ -1962,7 +1963,8 @@ class A:
 a = A()
    "#
             );
-            let module = PyModule::from_code(py, CODE, c_str!(""), c_str!(""))?;
+            let module =
+                PyModule::from_code(py, CODE, c_str!(""), &generate_unique_module_name(""))?;
             let instance: Py<PyAny> = module.getattr("a")?.into();
 
             instance.getattr(py, "foo").unwrap_err();
@@ -1991,7 +1993,8 @@ class A:
 a = A()
    "#
             );
-            let module = PyModule::from_code(py, CODE, c_str!(""), c_str!(""))?;
+            let module =
+                PyModule::from_code(py, CODE, c_str!(""), &generate_unique_module_name(""))?;
             let instance: Py<PyAny> = module.getattr("a")?.into();
 
             let foo = crate::intern!(py, "foo");

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -15,6 +15,8 @@ mod inner {
     #[cfg(not(Py_GIL_DISABLED))]
     use pyo3::types::{IntoPyDict, PyList};
 
+    use uuid::Uuid;
+
     #[macro_export]
     macro_rules! py_assert {
         ($py:expr, $($val:ident)+, $assertion:literal) => {
@@ -165,6 +167,11 @@ mod inner {
             })
             .unwrap();
         }};
+    }
+
+    pub fn generate_unique_module_name(base: &str) -> std::ffi::CString {
+        let uuid = Uuid::new_v4().simple().to_string();
+        std::ffi::CString::new(format!("{base}_{uuid}")).unwrap()
     }
 }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1603,6 +1603,7 @@ mod tests {
     use crate::{
         basic::CompareOp,
         ffi,
+        tests::common::generate_unique_module_name,
         types::{IntoPyDict, PyAny, PyAnyMethods, PyBool, PyInt, PyList, PyModule, PyTypeMethods},
         Bound, PyTypeInfo, Python, ToPyObject,
     };
@@ -1647,7 +1648,7 @@ class NonHeapNonDescriptorInt:
                 "#
                 ),
                 c_str!("test.py"),
-                c_str!("test"),
+                &generate_unique_module_name("test"),
             )
             .unwrap();
 
@@ -1716,7 +1717,7 @@ class SimpleClass:
 "#
                 ),
                 c_str!(file!()),
-                c_str!("test_module"),
+                &generate_unique_module_name("test_module"),
             )
             .expect("module creation failed");
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -250,6 +250,7 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
 
 #[cfg(test)]
 mod tests {
+    use crate::tests::common::generate_unique_module_name;
     use crate::types::{PyAnyMethods, PyBool, PyInt, PyModule, PyTuple, PyType, PyTypeMethods};
     use crate::PyAny;
     use crate::Python;
@@ -314,6 +315,7 @@ mod tests {
     #[test]
     fn test_type_names_standard() {
         Python::with_gil(|py| {
+            let module_name = generate_unique_module_name("test_module");
             let module = PyModule::from_code(
                 py,
                 c_str!(
@@ -323,7 +325,7 @@ class MyClass:
 "#
                 ),
                 c_str!(file!()),
-                c_str!("test_module"),
+                &module_name,
             )
             .expect("module create failed");
 
@@ -331,10 +333,12 @@ class MyClass:
             let my_class_type = my_class.downcast_into::<PyType>().unwrap();
             assert_eq!(my_class_type.name().unwrap(), "MyClass");
             assert_eq!(my_class_type.qualname().unwrap(), "MyClass");
-            assert_eq!(my_class_type.module().unwrap(), "test_module");
+            let module_name = module_name.to_str().unwrap();
+            let qualname = format!("{module_name}.MyClass");
+            assert_eq!(my_class_type.module().unwrap(), module_name);
             assert_eq!(
                 my_class_type.fully_qualified_name().unwrap(),
-                "test_module.MyClass"
+                qualname.as_str()
             );
         });
     }
@@ -353,6 +357,7 @@ class MyClass:
     #[test]
     fn test_type_names_nested() {
         Python::with_gil(|py| {
+            let module_name = generate_unique_module_name("test_module");
             let module = PyModule::from_code(
                 py,
                 c_str!(
@@ -363,7 +368,7 @@ class OuterClass:
 "#
                 ),
                 c_str!(file!()),
-                c_str!("test_module"),
+                &module_name,
             )
             .expect("module create failed");
 
@@ -375,10 +380,12 @@ class OuterClass:
                 inner_class_type.qualname().unwrap(),
                 "OuterClass.InnerClass"
             );
-            assert_eq!(inner_class_type.module().unwrap(), "test_module");
+            let module_name = module_name.to_str().unwrap();
+            let qualname = format!("{module_name}.OuterClass.InnerClass");
+            assert_eq!(inner_class_type.module().unwrap(), module_name);
             assert_eq!(
                 inner_class_type.fully_qualified_name().unwrap(),
-                "test_module.OuterClass.InnerClass"
+                qualname.as_str()
             );
         });
     }

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -163,7 +163,7 @@ fn test_module_from_code_bound() {
             py,
             c_str!("def add(a,b):\n\treturn a+b"),
             c_str!("adder_mod.py"),
-            c_str!("adder_mod"),
+            &common::generate_unique_module_name("adder_mod"),
         )
         .expect("Module code should be loaded");
 


### PR DESCRIPTION
Refs https://github.com/PyO3/pyo3/issues/4265#issuecomment-2316931289 and https://github.com/PyO3/pyo3/issues/4265#issuecomment-2315814173.

Adds a dev dependency on `uuid` and uses it to define a helper to generate unique module names based on a base string. I then use the helper in usages of `PyModule::from_code` in unit and integration tests. Doctests don't need it because rustdoc spawns one process per code block.