### PR TITLE
cfg features for enum variants

### DIFF
--- a/newsfragments/4509.fixed.md
+++ b/newsfragments/4509.fixed.md
@@ -1,0 +1,1 @@
+Fix compile failure when using `#[cfg]` attributes for simple enum variants.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2444,6 +2444,8 @@ fn generate_cfg_check(variants: &[PyClassEnumUnitVariant<'_>], cls: &syn::Ident)
         let cfg_attrs = &variant.cfg_attrs;
 
         if cfg_attrs.is_empty() {
+            // There's at least one variant of the enum without cfg attributes,
+            // so the check is not necessary
             return quote! {};
         }
 
@@ -2455,9 +2457,10 @@ fn generate_cfg_check(variants: &[PyClassEnumUnitVariant<'_>], cls: &syn::Ident)
         }
     }
 
-    quote! {
+    quote_spanned! {
+        cls.span() =>
         #[cfg(all(#(#conditions),*))]
-        ::core::compile_error!(concat!("All variants of enum `", stringify!(#cls), "` have been disabled by cfg attributes"));
+        ::core::compile_error!(concat!("#[pyclass] can't be used on enums without any variants - all variants of enum `", stringify!(#cls), "` have been configured out by cfg attributes"));
     }
 }
 

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -330,7 +330,7 @@ fn submit_methods_inventory(
     }
 }
 
-fn get_cfg_attributes(attrs: &[syn::Attribute]) -> Vec<&syn::Attribute> {
+pub(crate) fn get_cfg_attributes(attrs: &[syn::Attribute]) -> Vec<&syn::Attribute> {
     attrs
         .iter()
         .filter(|attr| attr.path().is_ident("cfg"))

--- a/tests/test_field_cfg.rs
+++ b/tests/test_field_cfg.rs
@@ -17,6 +17,15 @@ struct CfgClass {
     pub b: u32,
 }
 
+#[pyclass(eq, eq_int)]
+#[derive(PartialEq)]
+enum CfgSimpleEnum {
+    #[cfg(any())]
+    DisabledVariant,
+    #[cfg(not(any()))]
+    EnabledVariant,
+}
+
 #[test]
 fn test_cfg() {
     Python::with_gil(|py| {
@@ -26,4 +35,19 @@ fn test_cfg() {
         let b: u32 = py_cfg.bind(py).getattr("b").unwrap().extract().unwrap();
         assert_eq!(b, 3);
     });
+}
+
+#[test]
+fn test_cfg_simple_enum() {
+    Python::with_gil(|py| {
+        let simple = py.get_type::<CfgSimpleEnum>();
+        pyo3::py_run!(
+            py,
+            simple,
+            r#"
+            assert hasattr(simple, "EnabledVariant")
+            assert not hasattr(simple, "DisabledVariant")
+        "#
+        );
+    })
 }

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -93,4 +93,13 @@ enum InvalidOrderedComplexEnum2 {
     VariantB { msg: String }
 }
 
+#[pyclass(eq)]
+#[derive(PartialEq)]
+enum AllEnumVariantsDisabled {
+    #[cfg(any())]
+    DisabledA,
+    #[cfg(not(all()))]
+    DisabledB,
+}
+
 fn main() {}

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -66,6 +66,14 @@ error: The `ord` option requires the `eq` option.
 83 | #[pyclass(ord)]
    |           ^^^
 
+error: All variants of enum `AllEnumVariantsDisabled` have been disabled by cfg attributes
+  --> tests/ui/invalid_pyclass_enum.rs:96:1
+   |
+96 | #[pyclass(eq)]
+   | ^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0369]: binary operation `==` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
   --> tests/ui/invalid_pyclass_enum.rs:31:11
    |

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -66,13 +66,11 @@ error: The `ord` option requires the `eq` option.
 83 | #[pyclass(ord)]
    |           ^^^
 
-error: All variants of enum `AllEnumVariantsDisabled` have been disabled by cfg attributes
-  --> tests/ui/invalid_pyclass_enum.rs:96:1
+error: #[pyclass] can't be used on enums without any variants - all variants of enum `AllEnumVariantsDisabled` have been configured out by cfg attributes
+  --> tests/ui/invalid_pyclass_enum.rs:98:6
    |
-96 | #[pyclass(eq)]
-   | ^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+98 | enum AllEnumVariantsDisabled {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0369]: binary operation `==` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
   --> tests/ui/invalid_pyclass_enum.rs:31:11


### PR DESCRIPTION
This is a fix for #4411. `#[cfg]` attributes are propagated to the generated python classes as described in this comment: https://github.com/PyO3/pyo3/issues/4411#issuecomment-2323342598

It only covers the case for simple enums but a similar solution could be extended for complex enums.