### PR TITLE
Add Python-ref cloning `GILOnceCell::<Py<T>>::clone_ref`

### DIFF
--- a/newsfragments/4511.added.md
+++ b/newsfragments/4511.added.md
@@ -1,0 +1,1 @@
+Add Python-ref cloning `clone_ref` for `GILOnceCell<Py<T>>`


### PR DESCRIPTION
This adds a helper method to `GILOnceCell` containing `Py` pointers, allowing a cheap clone by Python-space incref.  This might want to be supplanted/supplemented by a derive macro as part of #4133.

Close #4428 

As an aside: I'm on an Intel Mac and wasn't able to run `nox -s clippy-all` due to pre-existing failures in some sort of macro expansion such as:
```
nox > cargo clippy '--features=full multiple-pymethods' --all-targets --workspace -- --deny=warnings
```
```text
error: custom attribute panicked
   --> src/coroutine.rs:125:1
    |
125 | #[pymethods(crate = "crate")]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: message: Unrecognized literal: `c"__name__"`
    = note: this error originates in the macro `crate::inventory::submit` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
```

I assume this is what you were seeing in CI prior to #3985.