### PR TITLE
add `Borrowed::as_ptr`

### DIFF
--- a/newsfragments/4520.added.md
+++ b/newsfragments/4520.added.md
@@ -1,0 +1,1 @@
+Add `Borrowed::as_ptr`.

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -710,7 +710,7 @@ fn warn_truncated_leap_second(obj: &Bound<'_, PyAny>) {
         ffi::c_str!("ignored leap-second, `datetime` does not support leap-seconds"),
         0,
     ) {
-        e.write_unraisable(py, Some(&obj.as_borrowed()))
+        e.write_unraisable(py, Some(obj))
     };
 }
 

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -107,10 +107,7 @@ impl Coroutine {
         if let Some(future) = self.waker.as_ref().unwrap().initialize_future(py)? {
             // `asyncio.Future` must be awaited; fortunately, it implements `__iter__ = __await__`
             // and will yield itself if its result has not been set in polling above
-            if let Some(future) = PyIterator::from_object(&future.as_borrowed())
-                .unwrap()
-                .next()
-            {
+            if let Some(future) = PyIterator::from_object(future).unwrap().next() {
                 // future has not been leaked into Python for now, and Rust code can only call
                 // `set_result(None)` in `Wake` implementation, so it's safe to unwrap
                 return Ok(future.unwrap().into());

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -659,6 +659,19 @@ impl<'a, 'py, T> Borrowed<'a, 'py, T> {
         (*self).clone()
     }
 
+    /// Returns the raw FFI pointer represented by self.
+    ///
+    /// # Safety
+    ///
+    /// Callers are responsible for ensuring that the pointer does not outlive self.
+    ///
+    /// The reference is borrowed; callers should not decrease the reference count
+    /// when they are finished with the pointer.
+    #[inline]
+    pub fn as_ptr(self) -> *mut ffi::PyObject {
+        self.0.as_ptr()
+    }
+
     pub(crate) fn to_any(self) -> Borrowed<'a, 'py, PyAny> {
         Borrowed(self.0, PhantomData, self.2)
     }
@@ -2062,11 +2075,7 @@ a = A()
     #[test]
     fn test_py2_into_py_object() {
         Python::with_gil(|py| {
-            let instance = py
-                .eval(ffi::c_str!("object()"), None, None)
-                .unwrap()
-                .as_borrowed()
-                .to_owned();
+            let instance = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             let ptr = instance.as_ptr();
             let instance: PyObject = instance.clone().unbind();
             assert_eq!(instance.as_ptr(), ptr);

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -1189,9 +1189,7 @@ mod tests {
         Python::with_gil(|py| {
             let dict = abc_dict(py);
             let keys = dict.call_method0("keys").unwrap();
-            assert!(keys
-                .is_instance(&py.get_type::<PyDictKeys>().as_borrowed())
-                .unwrap());
+            assert!(keys.is_instance(&py.get_type::<PyDictKeys>()).unwrap());
         })
     }
 
@@ -1201,9 +1199,7 @@ mod tests {
         Python::with_gil(|py| {
             let dict = abc_dict(py);
             let values = dict.call_method0("values").unwrap();
-            assert!(values
-                .is_instance(&py.get_type::<PyDictValues>().as_borrowed())
-                .unwrap());
+            assert!(values.is_instance(&py.get_type::<PyDictValues>()).unwrap());
         })
     }
 
@@ -1213,9 +1209,7 @@ mod tests {
         Python::with_gil(|py| {
             let dict = abc_dict(py);
             let items = dict.call_method0("items").unwrap();
-            assert!(items
-                .is_instance(&py.get_type::<PyDictItems>().as_borrowed())
-                .unwrap());
+            assert!(items.is_instance(&py.get_type::<PyDictItems>()).unwrap());
         })
     }
 

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -177,7 +177,7 @@ impl PyTypeCheck for PyMapping {
             || get_mapping_abc(object.py())
                 .and_then(|abc| object.is_instance(abc))
                 .unwrap_or_else(|err| {
-                    err.write_unraisable(object.py(), Some(&object.as_borrowed()));
+                    err.write_unraisable(object.py(), Some(object));
                     false
                 })
     }

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -367,7 +367,7 @@ impl PyTypeCheck for PySequence {
             || get_sequence_abc(object.py())
                 .and_then(|abc| object.is_instance(abc))
                 .unwrap_or_else(|err| {
-                    err.write_unraisable(object.py(), Some(&object.as_borrowed()));
+                    err.write_unraisable(object.py(), Some(object));
                     false
                 })
     }

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -69,10 +69,7 @@ fn test_coroutine_qualname() {
             assert coro.__name__ == name and coro.__qualname__ == qualname
         "#;
         let locals = [
-            (
-                "my_fn",
-                wrap_pyfunction!(my_fn, gil).unwrap().as_borrowed().as_any(),
-            ),
+            ("my_fn", wrap_pyfunction!(my_fn, gil).unwrap().as_any()),
             ("MyClass", gil.get_type::<MyClass>().as_any()),
         ]
         .into_py_dict(gil);


### PR DESCRIPTION
Following the addition of the `IntoPyObject` trait, I noticed there are a few places in `src/types/any.rs` where we were creating a `Borrowed<'_, '_, PyAny>`, then temporarily deref-ing it to `&Bound<'_, PyAny>`, then immediately calling `.as_ptr()`. 

This PR adds `Borrowed::as_ptr` to avoid the need to go through the deref. I doubt this will actually change performance, but it'll at least make less work for the optimizer to chew on.

While working through this I found a few cases of unnecessary calls to `.as_borrowed()` (probably left over from GIL Ref migration work), which I removed at the same time.