### PR TITLE
update `complexobject.rs` for 3.13

### DIFF
--- a/newsfragments/4521.removed.md
+++ b/newsfragments/4521.removed.md
@@ -1,0 +1,1 @@
+Remove private FFI definitions `_Py_c_sum`, `_Py_c_diff`, `_Py_c_neg`, `_Py_c_prod`, `_Py_c_quot`, `_Py_c_pow`, `_Py_c_abs`.

--- a/pyo3-ffi/src/complexobject.rs
+++ b/pyo3-ffi/src/complexobject.rs
@@ -2,37 +2,6 @@ use crate::object::*;
 use std::os::raw::{c_double, c_int};
 use std::ptr::addr_of_mut;
 
-#[repr(C)]
-#[derive(Copy, Clone)]
-// non-limited
-pub struct Py_complex {
-    pub real: c_double,
-    pub imag: c_double,
-}
-
-#[cfg(not(Py_LIMITED_API))]
-extern "C" {
-    pub fn _Py_c_sum(left: Py_complex, right: Py_complex) -> Py_complex;
-    pub fn _Py_c_diff(left: Py_complex, right: Py_complex) -> Py_complex;
-    pub fn _Py_c_neg(complex: Py_complex) -> Py_complex;
-    pub fn _Py_c_prod(left: Py_complex, right: Py_complex) -> Py_complex;
-    pub fn _Py_c_quot(dividend: Py_complex, divisor: Py_complex) -> Py_complex;
-    pub fn _Py_c_pow(num: Py_complex, exp: Py_complex) -> Py_complex;
-    pub fn _Py_c_abs(arg: Py_complex) -> c_double;
-    #[cfg_attr(PyPy, link_name = "PyPyComplex_FromCComplex")]
-    pub fn PyComplex_FromCComplex(v: Py_complex) -> *mut PyObject;
-    #[cfg_attr(PyPy, link_name = "PyPyComplex_AsCComplex")]
-    pub fn PyComplex_AsCComplex(op: *mut PyObject) -> Py_complex;
-}
-
-#[repr(C)]
-// non-limited
-pub struct PyComplexObject {
-    pub ob_base: PyObject,
-    #[cfg(not(GraalPy))]
-    pub cval: Py_complex,
-}
-
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyComplex_Type")]
@@ -46,17 +15,16 @@ pub unsafe fn PyComplex_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyComplex_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == addr_of_mut!(PyComplex_Type)) as c_int
+    Py_IS_TYPE(op, addr_of_mut!(PyComplex_Type))
 }
 
 extern "C" {
     // skipped non-limited PyComplex_FromCComplex
     #[cfg_attr(PyPy, link_name = "PyPyComplex_FromDoubles")]
     pub fn PyComplex_FromDoubles(real: c_double, imag: c_double) -> *mut PyObject;
+
     #[cfg_attr(PyPy, link_name = "PyPyComplex_RealAsDouble")]
     pub fn PyComplex_RealAsDouble(op: *mut PyObject) -> c_double;
     #[cfg_attr(PyPy, link_name = "PyPyComplex_ImagAsDouble")]
     pub fn PyComplex_ImagAsDouble(op: *mut PyObject) -> c_double;
-    // skipped non-limited PyComplex_AsCComplex
-    // skipped non-limited _PyComplex_FormatAdvancedWriter
 }

--- a/pyo3-ffi/src/cpython/complexobject.rs
+++ b/pyo3-ffi/src/cpython/complexobject.rs
@@ -1,0 +1,31 @@
+use crate::PyObject;
+use std::os::raw::c_double;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct Py_complex {
+    pub real: c_double,
+    pub imag: c_double,
+}
+
+// skipped private function _Py_c_sum
+// skipped private function _Py_c_diff
+// skipped private function _Py_c_neg
+// skipped private function _Py_c_prod
+// skipped private function _Py_c_quot
+// skipped private function _Py_c_pow
+// skipped private function _Py_c_abs
+
+#[repr(C)]
+pub struct PyComplexObject {
+    pub ob_base: PyObject,
+    #[cfg(not(GraalPy))]
+    pub cval: Py_complex,
+}
+
+extern "C" {
+    #[cfg_attr(PyPy, link_name = "PyPyComplex_FromCComplex")]
+    pub fn PyComplex_FromCComplex(v: Py_complex) -> *mut PyObject;
+    #[cfg_attr(PyPy, link_name = "PyPyComplex_AsCComplex")]
+    pub fn PyComplex_AsCComplex(op: *mut PyObject) -> Py_complex;
+}

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod bytesobject;
 pub(crate) mod ceval;
 pub(crate) mod code;
 pub(crate) mod compile;
+pub(crate) mod complexobject;
 #[cfg(Py_3_13)]
 pub(crate) mod critical_section;
 pub(crate) mod descrobject;
@@ -47,6 +48,7 @@ pub use self::bytesobject::*;
 pub use self::ceval::*;
 pub use self::code::*;
 pub use self::compile::*;
+pub use self::complexobject::*;
 #[cfg(Py_3_13)]
 pub use self::critical_section::*;
 pub use self::descrobject::*;


### PR DESCRIPTION
Split from #4379 

This updates `complexobject.rs` for 3.13 structure, and removes the definitions of the private symbols at the same time.