### PR TITLE
type_object: fix new clippy complaint about length of doc comment

### DIFF
--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -27,7 +27,7 @@ fn main() -> PyResult<()> {
 ## Want to run just an expression? Then use `eval_bound`.
 
 [`Python::eval_bound`]({{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.eval_bound) is
-a method to execute a [Python expression](https://docs.python.org/3.7/reference/expressions.html)
+a method to execute a [Python expression](https://docs.python.org/3/reference/expressions.html)
 and return the evaluated value as a `Bound<'py, PyAny>` object.
 
 ```rust
@@ -51,7 +51,7 @@ Python::with_gil(|py| {
 ## Want to run statements? Then use `run_bound`.
 
 [`Python::run_bound`] is a method to execute one or more
-[Python statements](https://docs.python.org/3.7/reference/simple_stmts.html).
+[Python statements](https://docs.python.org/3/reference/simple_stmts.html).
 This method returns nothing (like any Python statement), but you can get
 access to manipulated objects via the `locals` dict.
 

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -17,7 +17,7 @@ use crate::{ffi, Bound, Python};
 pub unsafe trait PyLayout<T> {}
 
 /// `T: PySizedLayout<U>` represents that `T` is not a instance of
-/// [`PyVarObject`](https://docs.python.org/3.8/c-api/structures.html?highlight=pyvarobject#c.PyVarObject).
+/// [`PyVarObject`](https://docs.python.org/3/c-api/structures.html#c.PyVarObject).
 ///
 /// In addition, that `T` is a concrete representation of `U`.
 pub trait PySizedLayout<T>: PyLayout<T> + Sized {}

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -18,6 +18,7 @@ pub unsafe trait PyLayout<T> {}
 
 /// `T: PySizedLayout<U>` represents that `T` is not a instance of
 /// [`PyVarObject`](https://docs.python.org/3.8/c-api/structures.html?highlight=pyvarobject#c.PyVarObject).
+///
 /// In addition, that `T` is a concrete representation of `U`.
 pub trait PySizedLayout<T>: PyLayout<T> + Sized {}
 


### PR DESCRIPTION
On beta/nightly:
```
warning: first doc comment paragraph is too long
  --> src/type_object.rs:19:1
   |
19 | / /// `T: PySizedLayout<U>` represents that `T` is not a instance of
20 | | /// [`PyVarObject`](https://docs.python.org/3.8/c-api/structures.html?highlight=pyvarobject#c.PyVarObject).
21 | | /// In addition, that `T` is a concrete representation of `U`.
   | |_
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_long_first_doc_paragraph
   = note: `#[warn(clippy::too_long_first_doc_paragraph)]` on by default
```