### PR TITLE
Add PyWeakref_GetRef and use it in weakref wrappers.

### DIFF
--- a/newsfragments/4528.added.md
+++ b/newsfragments/4528.added.md
@@ -1,0 +1,2 @@
+* Added bindings for `pyo3_ffi::PyWeakref_GetRef` on Python 3.13 and newer and
+  `py03_ffi::compat::PyWeakref_GetRef` for older Python versions.

--- a/newsfragments/4528.removed.md
+++ b/newsfragments/4528.removed.md
@@ -1,0 +1,7 @@
+* Removed the `get_object_borrowed`, `upgrade_borrowed`, `upgrade_borrowed_as`,
+`upgrade_borrowed_as_unchecked`, `upgrade_borrowed_as_exact` methods of
+`PyWeakref` and `PyWeakrefProxy`. These returned borrowed references to weakly
+referenced data, and in principle if the GIL is released the last strong
+reference could be released, allowing a possible use-after-free error. If you
+are using these functions, you should change to the equivalent function that
+returns a `Bound<'py, T>` reference.

--- a/pyo3-ffi/src/compat/py_3_13.rs
+++ b/pyo3-ffi/src/compat/py_3_13.rs
@@ -56,7 +56,7 @@ compat_function!(
 
     #[inline]
     pub unsafe fn PyWeakref_GetRef(
-        _ref: *mut crate::PyObject,
+        reference: *mut crate::PyObject,
         pobj: *mut *mut crate::PyObject,
     ) -> std::os::raw::c_int {
         use crate::{
@@ -64,14 +64,14 @@ compat_function!(
             PyWeakref_GetObject, Py_None,
         };
 
-        if !_ref.is_null() && PyWeakref_Check(_ref) == 0 {
+        if !reference.is_null() && PyWeakref_Check(reference) == 0 {
             *pobj = std::ptr::null_mut();
             PyErr_SetString(PyExc_TypeError, c_str!("expected a weakref").as_ptr());
             return -1;
         }
-        let obj = PyWeakref_GetObject(_ref);
+        let obj = PyWeakref_GetObject(reference);
         if obj.is_null() {
-            // SystemError if _ref is NULL
+            // SystemError if reference is NULL
             *pobj = std::ptr::null_mut();
             return -1;
         }

--- a/pyo3-ffi/src/weakrefobject.rs
+++ b/pyo3-ffi/src/weakrefobject.rs
@@ -58,6 +58,10 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyWeakref_NewProxy")]
     pub fn PyWeakref_NewProxy(ob: *mut PyObject, callback: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyWeakref_GetObject")]
+    #[cfg_attr(
+        Py_3_13,
+        deprecated(note = "deprecated since Python 3.13. Use `PyWeakref_GetRef` instead.")
+    )]
     pub fn PyWeakref_GetObject(reference: *mut PyObject) -> *mut PyObject;
     #[cfg(Py_3_13)]
     #[cfg_attr(PyPy, link_name = "PyPyWeakref_GetRef")]

--- a/pyo3-ffi/src/weakrefobject.rs
+++ b/pyo3-ffi/src/weakrefobject.rs
@@ -58,8 +58,8 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyWeakref_NewProxy")]
     pub fn PyWeakref_NewProxy(ob: *mut PyObject, callback: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyWeakref_GetObject")]
-    pub fn PyWeakref_GetObject(_ref: *mut PyObject) -> *mut PyObject;
+    pub fn PyWeakref_GetObject(reference: *mut PyObject) -> *mut PyObject;
     #[cfg(Py_3_13)]
     #[cfg_attr(PyPy, link_name = "PyPyWeakref_GetRef")]
-    pub fn PyWeakref_GetRef(_ref: *mut PyObject, pobj: *mut *mut PyObject) -> c_int;
+    pub fn PyWeakref_GetRef(reference: *mut PyObject, pobj: *mut *mut PyObject) -> c_int;
 }

--- a/pyo3-ffi/src/weakrefobject.rs
+++ b/pyo3-ffi/src/weakrefobject.rs
@@ -59,4 +59,7 @@ extern "C" {
     pub fn PyWeakref_NewProxy(ob: *mut PyObject, callback: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyWeakref_GetObject")]
     pub fn PyWeakref_GetObject(_ref: *mut PyObject) -> *mut PyObject;
+    #[cfg(Py_3_13)]
+    #[cfg_attr(PyPy, link_name = "PyPyWeakref_GetRef")]
+    pub fn PyWeakref_GetRef(_ref: *mut PyObject, pobj: *mut *mut PyObject) -> c_int;
 }

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -1,11 +1,11 @@
-use crate::err::{DowncastError, PyResult};
+use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::type_object::{PyTypeCheck, PyTypeInfo};
 use crate::types::{
     any::{PyAny, PyAnyMethods},
     PyNone,
 };
-use crate::{ffi, Borrowed, Bound};
+use crate::{ffi, Bound};
 
 /// Represents any Python `weakref` reference.
 ///

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -37,7 +37,7 @@ pub trait PyWeakrefMethods<'py> {
     /// Upgrade the weakref to a direct Bound object reference.
     ///
     /// It is named `upgrade` to be inline with [rust's `Weak::upgrade`](std::rc::Weak::upgrade).
-    /// In Python it would be equivalent to [`PyWeakref_GetObject`].
+    /// In Python it would be equivalent to [`PyWeakref_GetRef`].
     ///
     /// # Example
     #[cfg_attr(
@@ -97,7 +97,7 @@ pub trait PyWeakrefMethods<'py> {
     /// This function panics is the current object is invalid.
     /// If used propperly this is never the case. (NonNull and actually a weakref type)
     ///
-    /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
+    /// [`PyWeakref_GetRef`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetRef
     /// [`weakref.ReferenceType`]: https://docs.python.org/3/library/weakref.html#weakref.ReferenceType
     /// [`weakref.ref`]: https://docs.python.org/3/library/weakref.html#weakref.ref
     fn upgrade_as<T>(&self) -> PyResult<Option<Bound<'py, T>>>
@@ -194,7 +194,7 @@ pub trait PyWeakrefMethods<'py> {
     /// Upgrade the weakref to a direct Bound object reference unchecked. The type of the recovered object is not checked before downcasting, this could lead to unexpected behavior. Use only when absolutely certain the type can be guaranteed. The `weakref` may still return `None`.
     ///
     /// It is named `upgrade` to be inline with [rust's `Weak::upgrade`](std::rc::Weak::upgrade).
-    /// In Python it would be equivalent to [`PyWeakref_GetObject`].
+    /// In Python it would be equivalent to [`PyWeakref_GetRef`].
     ///
     /// # Safety
     /// Callers must ensure that the type is valid or risk type confusion.
@@ -258,7 +258,7 @@ pub trait PyWeakrefMethods<'py> {
     /// This function panics is the current object is invalid.
     /// If used propperly this is never the case. (NonNull and actually a weakref type)
     ///
-    /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
+    /// [`PyWeakref_GetRef`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetRef
     /// [`weakref.ReferenceType`]: https://docs.python.org/3/library/weakref.html#weakref.ReferenceType
     /// [`weakref.ref`]: https://docs.python.org/3/library/weakref.html#weakref.ref
     unsafe fn upgrade_as_unchecked<T>(&self) -> Option<Bound<'py, T>> {
@@ -345,7 +345,7 @@ pub trait PyWeakrefMethods<'py> {
     /// Upgrade the weakref to a exact direct Bound object reference.
     ///
     /// It is named `upgrade` to be inline with [rust's `Weak::upgrade`](std::rc::Weak::upgrade).
-    /// In Python it would be equivalent to [`PyWeakref_GetObject`].
+    /// In Python it would be equivalent to [`PyWeakref_GetRef`].
     ///
     /// # Example
     #[cfg_attr(
@@ -405,7 +405,7 @@ pub trait PyWeakrefMethods<'py> {
     /// This function panics is the current object is invalid.
     /// If used propperly this is never the case. (NonNull and actually a weakref type)
     ///
-    /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
+    /// [`PyWeakref_GetRef`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetRef
     /// [`weakref.ReferenceType`]: https://docs.python.org/3/library/weakref.html#weakref.ReferenceType
     /// [`weakref.ref`]: https://docs.python.org/3/library/weakref.html#weakref.ref
     fn upgrade_as_exact<T>(&self) -> PyResult<Option<Bound<'py, T>>>
@@ -505,7 +505,7 @@ pub trait PyWeakrefMethods<'py> {
     /// This function returns `Some(Bound<'py, PyAny>)` if the reference still exists, otherwise `None` will be returned.
     ///
     /// This function gets the optional target of this [`weakref.ReferenceType`] (result of calling [`weakref.ref`]).
-    /// It produces similar results to using [`PyWeakref_GetObject`] in the C api.
+    /// It produces similar results to using [`PyWeakref_GetRef`] in the C api.
     ///
     /// # Example
     #[cfg_attr(
@@ -556,7 +556,7 @@ pub trait PyWeakrefMethods<'py> {
     /// This function panics is the current object is invalid.
     /// If used propperly this is never the case. (NonNull and actually a weakref type)
     ///
-    /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
+    /// [`PyWeakref_GetRef`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetRef
     /// [`weakref.ReferenceType`]: https://docs.python.org/3/library/weakref.html#weakref.ReferenceType
     /// [`weakref.ref`]: https://docs.python.org/3/library/weakref.html#weakref.ref
     fn upgrade(&self) -> Option<Bound<'py, PyAny>> {
@@ -647,7 +647,7 @@ pub trait PyWeakrefMethods<'py> {
     /// This function returns `Bound<'py, PyAny>`, which is either the object if it still exists, otherwise it will refer to [`PyNone`](crate::types::PyNone).
     ///
     /// This function gets the optional target of this [`weakref.ReferenceType`] (result of calling [`weakref.ref`]).
-    /// It produces similar results to using [`PyWeakref_GetObject`] in the C api.
+    /// It produces similar results to using [`PyWeakref_GetRef`] in the C api.
     ///
     /// # Example
     #[cfg_attr(
@@ -695,7 +695,7 @@ pub trait PyWeakrefMethods<'py> {
     /// This function panics is the current object is invalid.
     /// If used propperly this is never the case. (NonNull and actually a weakref type)
     ///
-    /// [`PyWeakref_GetObject`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject
+    /// [`PyWeakref_GetRef`]: https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetRef
     /// [`weakref.ReferenceType`]: https://docs.python.org/3/library/weakref.html#weakref.ReferenceType
     /// [`weakref.ref`]: https://docs.python.org/3/library/weakref.html#weakref.ref
     fn get_object(&self) -> Bound<'py, PyAny>;

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -758,12 +758,14 @@ pub trait PyWeakrefMethods<'py> {
     /// [`weakref.ref`]: https://docs.python.org/3/library/weakref.html#weakref.ref
     #[track_caller]
     // TODO: This function is the reason every function tracks caller, however it only panics when the weakref object is not actually a weakreference type. So is it this neccessary?
+    // TODO: we should deprecate this because it relies on the semantics of a deprecated C API item
     fn get_object_borrowed(&self) -> Borrowed<'_, 'py, PyAny>;
 }
 
 impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakref> {
     fn get_object_borrowed(&self) -> Borrowed<'_, 'py, PyAny> {
         // PyWeakref_GetObject does some error checking, however we ensure the passed object is Non-Null and a Weakref type.
+        #![allow(deprecated)]
         unsafe { ffi::PyWeakref_GetObject(self.as_ptr()).assume_borrowed_or_err(self.py()) }
              .expect("The 'weakref' weak reference instance should be valid (non-null and actually a weakref reference)")
     }

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -184,6 +184,7 @@ impl PyWeakrefProxy {
 impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakrefProxy> {
     fn get_object_borrowed(&self) -> Borrowed<'_, 'py, PyAny> {
         // PyWeakref_GetObject does some error checking, however we ensure the passed object is Non-Null and a Weakref type.
+        #![allow(deprecated)]
         unsafe { ffi::PyWeakref_GetObject(self.as_ptr()).assume_borrowed_or_err(self.py()) }
             .expect("The 'weakref.ProxyType' (or `weakref.CallableProxyType`) instance should be valid (non-null and actually a weakref reference)")
     }

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -3,7 +3,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::type_object::PyTypeCheck;
 use crate::types::{any::PyAny, PyNone};
-use crate::{ffi, Borrowed, Bound, ToPyObject};
+use crate::{ffi, Bound, ToPyObject};
 
 use super::PyWeakrefMethods;
 
@@ -182,13 +182,6 @@ impl PyWeakrefProxy {
 }
 
 impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakrefProxy> {
-    fn get_object_borrowed(&self) -> Borrowed<'_, 'py, PyAny> {
-        // PyWeakref_GetObject does some error checking, however we ensure the passed object is Non-Null and a Weakref type.
-        #![allow(deprecated)]
-        unsafe { ffi::PyWeakref_GetObject(self.as_ptr()).assume_borrowed_or_err(self.py()) }
-            .expect("The 'weakref.ProxyType' (or `weakref.CallableProxyType`) instance should be valid (non-null and actually a weakref reference)")
-    }
-
     fn get_object(&self) -> Bound<'py, PyAny> {
         let mut obj: *mut ffi::PyObject = std::ptr::null_mut();
         match unsafe { ffi::compat::PyWeakref_GetRef(self.as_ptr(), &mut obj) } {
@@ -370,41 +363,6 @@ mod tests {
             }
 
             #[test]
-            fn test_weakref_upgrade_borrowed_as() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let class = get_type(py)?;
-                    let object = class.call0()?;
-                    let reference = PyWeakrefProxy::new(&object)?;
-
-                    {
-                        // This test is a bit weird but ok.
-                        let obj = reference.upgrade_borrowed_as::<PyAny>();
-
-                        assert!(obj.is_ok());
-                        let obj = obj.unwrap();
-
-                        assert!(obj.is_some());
-                        assert!(obj.map_or(false, |obj| obj.as_ptr() == object.as_ptr()
-                            && obj.is_exact_instance(&class)));
-                    }
-
-                    drop(object);
-
-                    {
-                        // This test is a bit weird but ok.
-                        let obj = reference.upgrade_borrowed_as::<PyAny>();
-
-                        assert!(obj.is_ok());
-                        let obj = obj.unwrap();
-
-                        assert!(obj.is_none());
-                    }
-
-                    Ok(())
-                })
-            }
-
-            #[test]
             fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
                 Python::with_gil(|py| {
                     let class = get_type(py)?;
@@ -434,35 +392,6 @@ mod tests {
             }
 
             #[test]
-            fn test_weakref_upgrade_borrowed_as_unchecked() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let class = get_type(py)?;
-                    let object = class.call0()?;
-                    let reference = PyWeakrefProxy::new(&object)?;
-
-                    {
-                        // This test is a bit weird but ok.
-                        let obj = unsafe { reference.upgrade_borrowed_as_unchecked::<PyAny>() };
-
-                        assert!(obj.is_some());
-                        assert!(obj.map_or(false, |obj| obj.as_ptr() == object.as_ptr()
-                            && obj.is_exact_instance(&class)));
-                    }
-
-                    drop(object);
-
-                    {
-                        // This test is a bit weird but ok.
-                        let obj = unsafe { reference.upgrade_borrowed_as_unchecked::<PyAny>() };
-
-                        assert!(obj.is_none());
-                    }
-
-                    Ok(())
-                })
-            }
-
-            #[test]
             fn test_weakref_upgrade() -> PyResult<()> {
                 Python::with_gil(|py| {
                     let class = get_type(py)?;
@@ -481,26 +410,6 @@ mod tests {
             }
 
             #[test]
-            fn test_weakref_upgrade_borrowed() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let class = get_type(py)?;
-                    let object = class.call0()?;
-                    let reference = PyWeakrefProxy::new(&object)?;
-
-                    assert!(reference.upgrade_borrowed().is_some());
-                    assert!(reference
-                        .upgrade_borrowed()
-                        .map_or(false, |obj| obj.is(&object)));
-
-                    drop(object);
-
-                    assert!(reference.upgrade_borrowed().is_none());
-
-                    Ok(())
-                })
-            }
-
-            #[test]
             fn test_weakref_get_object() -> PyResult<()> {
                 Python::with_gil(|py| {
                     let class = get_type(py)?;
@@ -512,23 +421,6 @@ mod tests {
                     drop(object);
 
                     assert!(reference.get_object().is_none());
-
-                    Ok(())
-                })
-            }
-
-            #[test]
-            fn test_weakref_get_object_borrowed() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let class = get_type(py)?;
-                    let object = class.call0()?;
-                    let reference = PyWeakrefProxy::new(&object)?;
-
-                    assert!(reference.get_object_borrowed().is(&object));
-
-                    drop(object);
-
-                    assert!(reference.get_object_borrowed().is_none());
 
                     Ok(())
                 })
@@ -640,37 +532,6 @@ mod tests {
             }
 
             #[test]
-            fn test_weakref_upgrade_borrowed_as() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    {
-                        let obj = reference.upgrade_borrowed_as::<WeakrefablePyClass>();
-
-                        assert!(obj.is_ok());
-                        let obj = obj.unwrap();
-
-                        assert!(obj.is_some());
-                        assert!(obj.map_or(false, |obj| obj.as_ptr() == object.as_ptr()));
-                    }
-
-                    drop(object);
-
-                    {
-                        let obj = reference.upgrade_borrowed_as::<WeakrefablePyClass>();
-
-                        assert!(obj.is_ok());
-                        let obj = obj.unwrap();
-
-                        assert!(obj.is_none());
-                    }
-
-                    Ok(())
-                })
-            }
-
-            #[test]
             fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
                 Python::with_gil(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
@@ -687,35 +548,6 @@ mod tests {
 
                     {
                         let obj = unsafe { reference.upgrade_as_unchecked::<WeakrefablePyClass>() };
-
-                        assert!(obj.is_none());
-                    }
-
-                    Ok(())
-                })
-            }
-
-            #[test]
-            fn test_weakref_upgrade_borrowed_as_unchecked() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    {
-                        let obj = unsafe {
-                            reference.upgrade_borrowed_as_unchecked::<WeakrefablePyClass>()
-                        };
-
-                        assert!(obj.is_some());
-                        assert!(obj.map_or(false, |obj| obj.as_ptr() == object.as_ptr()));
-                    }
-
-                    drop(object);
-
-                    {
-                        let obj = unsafe {
-                            reference.upgrade_borrowed_as_unchecked::<WeakrefablePyClass>()
-                        };
 
                         assert!(obj.is_none());
                     }
@@ -742,25 +574,6 @@ mod tests {
             }
 
             #[test]
-            fn test_weakref_upgrade_borrowed() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    assert!(reference.upgrade_borrowed().is_some());
-                    assert!(reference
-                        .upgrade_borrowed()
-                        .map_or(false, |obj| obj.is(&object)));
-
-                    drop(object);
-
-                    assert!(reference.upgrade_borrowed().is_none());
-
-                    Ok(())
-                })
-            }
-
-            #[test]
             fn test_weakref_get_object() -> PyResult<()> {
                 Python::with_gil(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
@@ -771,22 +584,6 @@ mod tests {
                     drop(object);
 
                     assert!(reference.get_object().is_none());
-
-                    Ok(())
-                })
-            }
-
-            #[test]
-            fn test_weakref_get_object_borrowed() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    assert!(reference.get_object_borrowed().is(&object));
-
-                    drop(object);
-
-                    assert!(reference.get_object_borrowed().is_none());
 
                     Ok(())
                 })
@@ -903,41 +700,6 @@ mod tests {
             }
 
             #[test]
-            fn test_weakref_upgrade_borrowed_as() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let class = get_type(py)?;
-                    let object = class.call0()?;
-                    let reference = PyWeakrefProxy::new(&object)?;
-
-                    {
-                        // This test is a bit weird but ok.
-                        let obj = reference.upgrade_borrowed_as::<PyAny>();
-
-                        assert!(obj.is_ok());
-                        let obj = obj.unwrap();
-
-                        assert!(obj.is_some());
-                        assert!(obj.map_or(false, |obj| obj.as_ptr() == object.as_ptr()
-                            && obj.is_exact_instance(&class)));
-                    }
-
-                    drop(object);
-
-                    {
-                        // This test is a bit weird but ok.
-                        let obj = reference.upgrade_borrowed_as::<PyAny>();
-
-                        assert!(obj.is_ok());
-                        let obj = obj.unwrap();
-
-                        assert!(obj.is_none());
-                    }
-
-                    Ok(())
-                })
-            }
-
-            #[test]
             fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
                 Python::with_gil(|py| {
                     let class = get_type(py)?;
@@ -967,35 +729,6 @@ mod tests {
             }
 
             #[test]
-            fn test_weakref_upgrade_borrowed_as_unchecked() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let class = get_type(py)?;
-                    let object = class.call0()?;
-                    let reference = PyWeakrefProxy::new(&object)?;
-
-                    {
-                        // This test is a bit weird but ok.
-                        let obj = unsafe { reference.upgrade_borrowed_as_unchecked::<PyAny>() };
-
-                        assert!(obj.is_some());
-                        assert!(obj.map_or(false, |obj| obj.as_ptr() == object.as_ptr()
-                            && obj.is_exact_instance(&class)));
-                    }
-
-                    drop(object);
-
-                    {
-                        // This test is a bit weird but ok.
-                        let obj = unsafe { reference.upgrade_borrowed_as_unchecked::<PyAny>() };
-
-                        assert!(obj.is_none());
-                    }
-
-                    Ok(())
-                })
-            }
-
-            #[test]
             fn test_weakref_upgrade() -> PyResult<()> {
                 Python::with_gil(|py| {
                     let class = get_type(py)?;
@@ -1014,26 +747,6 @@ mod tests {
             }
 
             #[test]
-            fn test_weakref_upgrade_borrowed() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let class = get_type(py)?;
-                    let object = class.call0()?;
-                    let reference = PyWeakrefProxy::new(&object)?;
-
-                    assert!(reference.upgrade_borrowed().is_some());
-                    assert!(reference
-                        .upgrade_borrowed()
-                        .map_or(false, |obj| obj.is(&object)));
-
-                    drop(object);
-
-                    assert!(reference.upgrade_borrowed().is_none());
-
-                    Ok(())
-                })
-            }
-
-            #[test]
             fn test_weakref_get_object() -> PyResult<()> {
                 Python::with_gil(|py| {
                     let class = get_type(py)?;
@@ -1045,23 +758,6 @@ mod tests {
                     drop(object);
 
                     assert!(reference.get_object().is_none());
-
-                    Ok(())
-                })
-            }
-
-            #[test]
-            fn test_weakref_get_object_borrowed() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let class = get_type(py)?;
-                    let object = class.call0()?;
-                    let reference = PyWeakrefProxy::new(&object)?;
-
-                    assert!(reference.get_object_borrowed().is(&object));
-
-                    drop(object);
-
-                    assert!(reference.get_object_borrowed().is_none());
 
                     Ok(())
                 })
@@ -1166,36 +862,6 @@ mod tests {
                     Ok(())
                 })
             }
-            #[test]
-            fn test_weakref_upgrade_borrowed_as() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    {
-                        let obj = reference.upgrade_borrowed_as::<WeakrefablePyClass>();
-
-                        assert!(obj.is_ok());
-                        let obj = obj.unwrap();
-
-                        assert!(obj.is_some());
-                        assert!(obj.map_or(false, |obj| obj.as_ptr() == object.as_ptr()));
-                    }
-
-                    drop(object);
-
-                    {
-                        let obj = reference.upgrade_borrowed_as::<WeakrefablePyClass>();
-
-                        assert!(obj.is_ok());
-                        let obj = obj.unwrap();
-
-                        assert!(obj.is_none());
-                    }
-
-                    Ok(())
-                })
-            }
 
             #[test]
             fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
@@ -1214,34 +880,6 @@ mod tests {
 
                     {
                         let obj = unsafe { reference.upgrade_as_unchecked::<WeakrefablePyClass>() };
-
-                        assert!(obj.is_none());
-                    }
-
-                    Ok(())
-                })
-            }
-            #[test]
-            fn test_weakref_upgrade_borrowed_as_unchecked() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    {
-                        let obj = unsafe {
-                            reference.upgrade_borrowed_as_unchecked::<WeakrefablePyClass>()
-                        };
-
-                        assert!(obj.is_some());
-                        assert!(obj.map_or(false, |obj| obj.as_ptr() == object.as_ptr()));
-                    }
-
-                    drop(object);
-
-                    {
-                        let obj = unsafe {
-                            reference.upgrade_borrowed_as_unchecked::<WeakrefablePyClass>()
-                        };
 
                         assert!(obj.is_none());
                     }
@@ -1268,25 +906,6 @@ mod tests {
             }
 
             #[test]
-            fn test_weakref_upgrade_borrowed() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    assert!(reference.upgrade_borrowed().is_some());
-                    assert!(reference
-                        .upgrade_borrowed()
-                        .map_or(false, |obj| obj.is(&object)));
-
-                    drop(object);
-
-                    assert!(reference.upgrade_borrowed().is_none());
-
-                    Ok(())
-                })
-            }
-
-            #[test]
             fn test_weakref_get_object() -> PyResult<()> {
                 Python::with_gil(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
@@ -1297,22 +916,6 @@ mod tests {
                     drop(object);
 
                     assert!(reference.get_object().is_none());
-
-                    Ok(())
-                })
-            }
-
-            #[test]
-            fn test_weakref_get_object_borrowed() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    assert!(reference.get_object_borrowed().is(&object));
-
-                    drop(object);
-
-                    assert!(reference.get_object_borrowed().is_none());
 
                     Ok(())
                 })

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -2,7 +2,7 @@ use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::type_object::PyTypeCheck;
-use crate::types::any::PyAny;
+use crate::types::{any::PyAny, PyNone};
 use crate::{ffi, Borrowed, Bound, ToPyObject};
 
 use super::PyWeakrefMethods;
@@ -186,6 +186,15 @@ impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakrefProxy> {
         // PyWeakref_GetObject does some error checking, however we ensure the passed object is Non-Null and a Weakref type.
         unsafe { ffi::PyWeakref_GetObject(self.as_ptr()).assume_borrowed_or_err(self.py()) }
             .expect("The 'weakref.ProxyType' (or `weakref.CallableProxyType`) instance should be valid (non-null and actually a weakref reference)")
+    }
+
+    fn get_object(&self) -> Bound<'py, PyAny> {
+        let mut obj: *mut ffi::PyObject = std::ptr::null_mut();
+        match unsafe { ffi::compat::PyWeakref_GetRef(self.as_ptr(), &mut obj) } {
+            std::os::raw::c_int::MIN..=-1 => panic!("The 'weakref.ProxyType' (or `weakref.CallableProxyType`) instance should be valid (non-null and actually a weakref reference)"),
+            0 => PyNone::get(self.py()).to_owned().into_any(),
+            1..=std::os::raw::c_int::MAX => unsafe { obj.assume_owned(self.py()) },
+        }
     }
 }
 

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -193,6 +193,7 @@ impl PyWeakrefReference {
 impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakrefReference> {
     fn get_object_borrowed(&self) -> Borrowed<'_, 'py, PyAny> {
         // PyWeakref_GetObject does some error checking, however we ensure the passed object is Non-Null and a Weakref type.
+        #![allow(deprecated)]
         unsafe { ffi::PyWeakref_GetObject(self.as_ptr()).assume_borrowed_or_err(self.py()) }
             .expect("The 'weakref.ReferenceType' instance should be valid (non-null and actually a weakref reference)")
     }

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -2,7 +2,7 @@ use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::types::{any::PyAny, PyNone};
-use crate::{ffi, Borrowed, Bound, ToPyObject};
+use crate::{ffi, Bound, ToPyObject};
 
 #[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]
 use crate::type_object::PyTypeCheck;


### PR DESCRIPTION
Refs #4265. Also ping @SuperJappie08.

The compat definition is adapted from the C implementation in pythoncapi-compat.

See also [my comment in the weakref issue](https://github.com/PyO3/pyo3/issues/3134#issuecomment-2330239407) about whether we should add a new API based on `PyWeakref_GetRef` that doesn't panic or return borrowed references.