### PR TITLE
Fix typo and missed configs in FFI bindings

### DIFF
--- a/pyo3-ffi/src/cpython/lock.rs
+++ b/pyo3-ffi/src/cpython/lock.rs
@@ -10,5 +10,5 @@ pub struct PyMutex {
 
 extern "C" {
     pub fn PyMutex_Lock(m: *mut PyMutex);
-    pub fn PyMutex_UnLock(m: *mut PyMutex);
+    pub fn PyMutex_Unlock(m: *mut PyMutex);
 }

--- a/pyo3-ffi/src/dictobject.rs
+++ b/pyo3-ffi/src/dictobject.rs
@@ -67,6 +67,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyDict_DelItemString")]
     pub fn PyDict_DelItemString(dp: *mut PyObject, key: *const c_char) -> c_int;
     #[cfg(Py_3_13)]
+    #[cfg_attr(PyPy, link_name = "PyPyDict_GetItemRef")]
     pub fn PyDict_GetItemRef(
         dp: *mut PyObject,
         key: *mut PyObject,

--- a/pyo3-ffi/src/listobject.rs
+++ b/pyo3-ffi/src/listobject.rs
@@ -29,6 +29,7 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyList_GetItem")]
     pub fn PyList_GetItem(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject;
     #[cfg(Py_3_13)]
+    #[cfg_attr(PyPy, link_name = "PyPyList_GetItemRef")]
     pub fn PyList_GetItemRef(arg1: *mut PyObject, arg2: Py_ssize_t) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyList_SetItem")]
     pub fn PyList_SetItem(arg1: *mut PyObject, arg2: Py_ssize_t, arg3: *mut PyObject) -> c_int;


### PR DESCRIPTION
Extracted the FFI typo fix from #4523. Also added pypy support following the rest of the bindings for the new functions I added in #4355 and #4410