### PR TITLE
migrate `PySet` to `IntoPyObject`

### DIFF
--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -147,15 +147,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(
-            py,
-            self.into_iter().map(|item| {
-                item.into_pyobject(py)
-                    .map(BoundObject::into_any)
-                    .map(BoundObject::unbind)
-                    .map_err(Into::into)
-            }),
-        )
+        try_new_from_iter(py, self)
     }
 }
 
@@ -169,15 +161,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(
-            py,
-            self.into_iter().map(|item| {
-                item.into_pyobject(py)
-                    .map(BoundObject::into_any)
-                    .map(BoundObject::unbind)
-                    .map_err(Into::into)
-            }),
-        )
+        try_new_from_iter(py, self)
     }
 }
 
@@ -272,11 +256,11 @@ mod tests {
     #[test]
     fn test_extract_hashbrown_hashset() {
         Python::with_gil(|py| {
-            let set = PySet::new(py, &[1, 2, 3, 4, 5]).unwrap();
+            let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: hashbrown::HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
 
-            let set = PyFrozenSet::new(py, &[1, 2, 3, 4, 5]).unwrap();
+            let set = PyFrozenSet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: hashbrown::HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
         });

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -11,7 +11,7 @@ use crate::{
         set::{new_from_iter, try_new_from_iter, PySetMethods},
         PyFrozenSet, PySet,
     },
-    BoundObject, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
 };
 
 impl<T, S> ToPyObject for collections::HashSet<T, S>
@@ -64,15 +64,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(
-            py,
-            self.into_iter().map(|item| {
-                item.into_pyobject(py)
-                    .map(BoundObject::into_any)
-                    .map(BoundObject::unbind)
-                    .map_err(Into::into)
-            }),
-        )
+        try_new_from_iter(py, self)
     }
 }
 
@@ -86,15 +78,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(
-            py,
-            self.iter().map(|item| {
-                item.into_pyobject(py)
-                    .map(BoundObject::into_any)
-                    .map(BoundObject::unbind)
-                    .map_err(Into::into)
-            }),
-        )
+        try_new_from_iter(py, self.iter())
     }
 }
 
@@ -147,15 +131,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(
-            py,
-            self.into_iter().map(|item| {
-                item.into_pyobject(py)
-                    .map(BoundObject::into_any)
-                    .map(BoundObject::unbind)
-                    .map_err(Into::into)
-            }),
-        )
+        try_new_from_iter(py, self)
     }
 }
 
@@ -168,15 +144,7 @@ where
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(
-            py,
-            self.iter().map(|item| {
-                item.into_pyobject(py)
-                    .map(BoundObject::into_any)
-                    .map(BoundObject::unbind)
-                    .map_err(Into::into)
-            }),
-        )
+        try_new_from_iter(py, self.iter())
     }
 }
 
@@ -212,11 +180,11 @@ mod tests {
     #[test]
     fn test_extract_hashset() {
         Python::with_gil(|py| {
-            let set = PySet::new(py, &[1, 2, 3, 4, 5]).unwrap();
+            let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
 
-            let set = PyFrozenSet::new(py, &[1, 2, 3, 4, 5]).unwrap();
+            let set = PyFrozenSet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
         });
@@ -225,11 +193,11 @@ mod tests {
     #[test]
     fn test_extract_btreeset() {
         Python::with_gil(|py| {
-            let set = PySet::new(py, &[1, 2, 3, 4, 5]).unwrap();
+            let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: BTreeSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
 
-            let set = PyFrozenSet::new(py, &[1, 2, 3, 4, 5]).unwrap();
+            let set = PyFrozenSet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: BTreeSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
         });

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -30,6 +30,8 @@ pub trait BoundObject<'py, T>: bound_object_sealed::Sealed {
     fn into_any(self) -> Self::Any;
     /// Turn this smart pointer into a strong reference pointer
     fn into_ptr(self) -> *mut ffi::PyObject;
+    /// Turn this smart pointer into a borrowed reference pointer
+    fn as_ptr(&self) -> *mut ffi::PyObject;
     /// Turn this smart pointer into an owned [`Py<T>`]
     fn unbind(self) -> Py<T>;
 }
@@ -616,6 +618,10 @@ impl<'py, T> BoundObject<'py, T> for Bound<'py, T> {
         self.into_ptr()
     }
 
+    fn as_ptr(&self) -> *mut ffi::PyObject {
+        self.as_ptr()
+    }
+
     fn unbind(self) -> Py<T> {
         self.unbind()
     }
@@ -833,6 +839,10 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 
     fn into_ptr(self) -> *mut ffi::PyObject {
         (*self).to_owned().into_ptr()
+    }
+
+    fn as_ptr(&self) -> *mut ffi::PyObject {
+        (*self).as_ptr()
     }
 
     fn unbind(self) -> Py<T> {

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -6,7 +6,7 @@ use crate::{
     ffi_ptr_ext::FfiPtrExt,
     py_result_ext::PyResultExt,
     types::any::PyAnyMethods,
-    Bound, PyAny, PyObject, Python, ToPyObject,
+    Bound, PyAny, Python, ToPyObject,
 };
 use crate::{Borrowed, BoundObject};
 use std::ptr;
@@ -29,15 +29,21 @@ impl<'py> PyFrozenSetBuilder<'py> {
     /// Adds an element to the set.
     pub fn add<K>(&mut self, key: K) -> PyResult<()>
     where
-        K: ToPyObject,
+        K: IntoPyObject<'py>,
     {
-        fn inner(frozenset: &Bound<'_, PyFrozenSet>, key: PyObject) -> PyResult<()> {
+        fn inner(frozenset: &Bound<'_, PyFrozenSet>, key: Borrowed<'_, '_, PyAny>) -> PyResult<()> {
             err::error_on_minusone(frozenset.py(), unsafe {
                 ffi::PySet_Add(frozenset.as_ptr(), key.as_ptr())
             })
         }
 
-        inner(&self.py_frozen_set, key.to_object(self.py_frozen_set.py()))
+        inner(
+            &self.py_frozen_set,
+            key.into_pyobject(self.py_frozen_set.py())
+                .map_err(Into::into)?
+                .into_any()
+                .as_borrowed(),
+        )
     }
 
     /// Finish building the set and take ownership of its current value
@@ -85,11 +91,14 @@ impl PyFrozenSet {
     ///
     /// May panic when running out of memory.
     #[inline]
-    pub fn new<'a, 'p, T: ToPyObject + 'a>(
-        py: Python<'p>,
-        elements: impl IntoIterator<Item = &'a T>,
-    ) -> PyResult<Bound<'p, PyFrozenSet>> {
-        new_from_iter(py, elements)
+    pub fn new<'py, T>(
+        py: Python<'py>,
+        elements: impl IntoIterator<Item = T>,
+    ) -> PyResult<Bound<'py, PyFrozenSet>>
+    where
+        T: IntoPyObject<'py>,
+    {
+        try_new_from_iter(py, elements)
     }
 
     /// Deprecated name for [`PyFrozenSet::new`].
@@ -99,7 +108,7 @@ impl PyFrozenSet {
         py: Python<'p>,
         elements: impl IntoIterator<Item = &'a T>,
     ) -> PyResult<Bound<'p, PyFrozenSet>> {
-        Self::new(py, elements)
+        Self::new(py, elements.into_iter().map(|e| e.to_object(py)))
     }
 
     /// Creates a new empty frozen set
@@ -240,31 +249,27 @@ impl<'py> ExactSizeIterator for BoundFrozenSetIterator<'py> {
 }
 
 #[inline]
-pub(crate) fn new_from_iter<T: ToPyObject>(
-    py: Python<'_>,
+pub(crate) fn try_new_from_iter<'py, T>(
+    py: Python<'py>,
     elements: impl IntoIterator<Item = T>,
-) -> PyResult<Bound<'_, PyFrozenSet>> {
-    fn inner<'py>(
-        py: Python<'py>,
-        elements: &mut dyn Iterator<Item = PyObject>,
-    ) -> PyResult<Bound<'py, PyFrozenSet>> {
-        let set = unsafe {
-            // We create the  `Py` pointer because its Drop cleans up the set if user code panics.
-            ffi::PyFrozenSet_New(std::ptr::null_mut())
-                .assume_owned_or_err(py)?
-                .downcast_into_unchecked()
-        };
-        let ptr = set.as_ptr();
+) -> PyResult<Bound<'py, PyFrozenSet>>
+where
+    T: IntoPyObject<'py>,
+{
+    let set = unsafe {
+        // We create the  `Py` pointer because its Drop cleans up the set if user code panics.
+        ffi::PyFrozenSet_New(std::ptr::null_mut())
+            .assume_owned_or_err(py)?
+            .downcast_into_unchecked()
+    };
+    let ptr = set.as_ptr();
 
-        for obj in elements {
-            err::error_on_minusone(py, unsafe { ffi::PySet_Add(ptr, obj.as_ptr()) })?;
-        }
-
-        Ok(set)
+    for e in elements {
+        let obj = e.into_pyobject(py).map_err(Into::into)?;
+        err::error_on_minusone(py, unsafe { ffi::PySet_Add(ptr, obj.as_ptr()) })?;
     }
 
-    let mut iter = elements.into_iter().map(|e| e.to_object(py));
-    inner(py, &mut iter)
+    Ok(set)
 }
 
 #[cfg(test)]
@@ -274,7 +279,7 @@ mod tests {
     #[test]
     fn test_frozenset_new_and_len() {
         Python::with_gil(|py| {
-            let set = PyFrozenSet::new(py, &[1]).unwrap();
+            let set = PyFrozenSet::new(py, [1]).unwrap();
             assert_eq!(1, set.len());
 
             let v = vec![1];
@@ -294,7 +299,7 @@ mod tests {
     #[test]
     fn test_frozenset_contains() {
         Python::with_gil(|py| {
-            let set = PyFrozenSet::new(py, &[1]).unwrap();
+            let set = PyFrozenSet::new(py, [1]).unwrap();
             assert!(set.contains(1).unwrap());
         });
     }
@@ -302,7 +307,7 @@ mod tests {
     #[test]
     fn test_frozenset_iter() {
         Python::with_gil(|py| {
-            let set = PyFrozenSet::new(py, &[1]).unwrap();
+            let set = PyFrozenSet::new(py, [1]).unwrap();
 
             for el in set {
                 assert_eq!(1i32, el.extract::<i32>().unwrap());
@@ -313,7 +318,7 @@ mod tests {
     #[test]
     fn test_frozenset_iter_bound() {
         Python::with_gil(|py| {
-            let set = PyFrozenSet::new(py, &[1]).unwrap();
+            let set = PyFrozenSet::new(py, [1]).unwrap();
 
             for el in &set {
                 assert_eq!(1i32, el.extract::<i32>().unwrap());
@@ -324,7 +329,7 @@ mod tests {
     #[test]
     fn test_frozenset_iter_size_hint() {
         Python::with_gil(|py| {
-            let set = PyFrozenSet::new(py, &[1]).unwrap();
+            let set = PyFrozenSet::new(py, [1]).unwrap();
             let mut iter = set.iter();
 
             // Exact size


### PR DESCRIPTION
- adds `BoundObject::as_ptr` as a convenience function for a borrowed reference pointer
- removed the "inner" function from `try_new_from_iter`, this is more codegen, but allows us to otherwise needed reference bumps
