### PR TITLE
Don't use PyList.get_item_unchecked() on free-threaded build

### DIFF
--- a/newsfragments/4539.removed.md
+++ b/newsfragments/4539.removed.md
@@ -1,0 +1,3 @@
+* `PyListMethods::get_item_unchecked` is disabled on the free-threaded build.
+  It relies on accessing list internals without any locking and is not
+  thread-safe without the GIL to synchronize access.

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -175,7 +175,7 @@ pub trait PyListMethods<'py>: crate::sealed::Sealed {
     /// # Safety
     ///
     /// Caller must verify that the index is within the bounds of the list.
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(not(any(Py_LIMITED_API, Py_GIL_DISABLED)))]
     unsafe fn get_item_unchecked(&self, index: usize) -> Bound<'py, PyAny>;
 
     /// Takes the slice `self[low:high]` and returns it as a new list.
@@ -298,7 +298,7 @@ impl<'py> PyListMethods<'py> for Bound<'py, PyList> {
     /// # Safety
     ///
     /// Caller must verify that the index is within the bounds of the list.
-    #[cfg(not(Py_LIMITED_API))]
+    #[cfg(not(any(Py_LIMITED_API, Py_GIL_DISABLED)))]
     unsafe fn get_item_unchecked(&self, index: usize) -> Bound<'py, PyAny> {
         // PyList_GET_ITEM return borrowed ptr; must make owned for safety (see #890).
         ffi::PyList_GET_ITEM(self.as_ptr(), index as Py_ssize_t)
@@ -465,9 +465,9 @@ impl<'py> BoundListIterator<'py> {
     }
 
     unsafe fn get_item(&self, index: usize) -> Bound<'py, PyAny> {
-        #[cfg(any(Py_LIMITED_API, PyPy))]
+        #[cfg(any(Py_LIMITED_API, PyPy, Py_GIL_DISABLED))]
         let item = self.list.get_item(index).expect("list.get failed");
-        #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+        #[cfg(not(any(Py_LIMITED_API, PyPy, Py_GIL_DISABLED)))]
         let item = self.list.get_item_unchecked(index);
         item
     }
@@ -863,7 +863,7 @@ mod tests {
         });
     }
 
-    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+    #[cfg(not(any(Py_LIMITED_API, PyPy, Py_GIL_DISABLED)))]
     #[test]
     fn test_list_get_item_unchecked_sanity() {
         Python::with_gil(|py| {


### PR DESCRIPTION
Followup for #4410.

`get_item_unchecked` allows possible access of dangling pointers and other data races because `PyList_GET_ITEM` returns a borrowed reference. I added bindings for `PyList_GetItemRef` in #4410 but missed that the liter iterator uses `get_item_unchecked`.

I could leave the APIs visible since they're already marked as unsafe, but since this API is already cfg-ed out for the limited API I thought it might make sense to disable it for free-threaded build as well.

Will add a release note if we decide disabling it is the correct thing to do.