### PR TITLE
make `GILOnceCell::get_or_try_init_type_ref` public

### DIFF
--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -2,9 +2,9 @@
 
 If you already have some existing Python code that you need to execute from Rust, the following FAQs can help you select the right PyO3 functionality for your situation:
 
-## Want to access Python APIs? Then use `import`.
+## Want to access Python APIs? Then use `PyModule::import`.
 
-[`Python::import`] can be used to get handle to a Python module from Rust. You can use this to import and use any Python
+[`PyModule::import`] can be used to get handle to a Python module from Rust. You can use this to import and use any Python
 module available in your environment.
 
 ```rust
@@ -12,7 +12,7 @@ use pyo3::prelude::*;
 
 fn main() -> PyResult<()> {
     Python::with_gil(|py| {
-        let builtins = py.import("builtins")?;
+        let builtins = PyModule::import(py, "builtins")?;
         let total: i32 = builtins
             .getattr("sum")?
             .call1((vec![1, 2, 3],))?
@@ -23,12 +23,12 @@ fn main() -> PyResult<()> {
 }
 ```
 
-[`Python::import`] introduces an overhead each time it's called. To avoid this in functions that are called multiple times,
+[`PyModule::import`] introduces an overhead each time it's called. To avoid this in functions that are called multiple times,
 using a [`GILOnceCell`]({{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html) is recommended. Specifically, for importing types,
-[`GILOnceCell::get_or_try_init_type_ref`]({{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html#method.get_or_try_init_type_ref) is provided
+[`GILOnceCell::import`]({{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html#method.import) is provided
 (check out the [example]({{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html#example-using-giloncecell-to-avoid-the-overhead-of-importing-a-class-multiple-times)).
 
-[`Python::import`]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.import
+[`PyModule::import`]: {{#PYO3_DOCS_URL}}/pyo3/types/struct.PyModule.html#method.import
 
 ## Want to run just an expression? Then use `eval`.
 

--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -23,11 +23,6 @@ fn main() -> PyResult<()> {
 }
 ```
 
-[`PyModule::import`] introduces an overhead each time it's called. To avoid this in functions that are called multiple times,
-using a [`GILOnceCell`]({{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html) is recommended. Specifically, for importing types,
-[`GILOnceCell::import`]({{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html#method.import) is provided
-(check out the [example]({{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html#example-using-giloncecell-to-avoid-the-overhead-of-importing-a-class-multiple-times)).
-
 [`PyModule::import`]: {{#PYO3_DOCS_URL}}/pyo3/types/struct.PyModule.html#method.import
 
 ## Want to run just an expression? Then use `eval`.

--- a/newsfragments/4542.changed.md
+++ b/newsfragments/4542.changed.md
@@ -1,1 +1,1 @@
-Change `GILOnceCell::get_or_try_init_type_ref` to public.
+Change `GILOnceCell::get_or_try_init_type_ref` to `GILOnceCell::import` and make it public API.

--- a/newsfragments/4542.changed.md
+++ b/newsfragments/4542.changed.md
@@ -1,0 +1,1 @@
+Change `GILOnceCell::get_or_try_init_type_ref` to public.

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -66,7 +66,7 @@ impl<'py> IntoPyObject<'py> for Tz {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         static ZONE_INFO: GILOnceCell<Py<PyType>> = GILOnceCell::new();
         ZONE_INFO
-            .get_or_try_init_type_ref(py, "zoneinfo", "ZoneInfo")
+            .import(py, "zoneinfo", "ZoneInfo")
             .and_then(|obj| obj.call1((self.name(),)))
     }
 }

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -59,7 +59,7 @@ use num_rational::Ratio;
 static FRACTION_CLS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 
 fn get_fraction_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
-    FRACTION_CLS.get_or_try_init_type_ref(py, "fractions", "Fraction")
+    FRACTION_CLS.import(py, "fractions", "Fraction")
 }
 
 macro_rules! rational_conversion {

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -79,7 +79,7 @@ impl FromPyObject<'_> for Decimal {
 static DECIMAL_CLS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 
 fn get_decimal_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
-    DECIMAL_CLS.get_or_try_init_type_ref(py, "decimal", "Decimal")
+    DECIMAL_CLS.import(py, "decimal", "Decimal")
 }
 
 impl ToPyObject for Decimal {

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -46,7 +46,7 @@ impl<'py> IntoPyObject<'py> for Ipv4Addr {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         static IPV4_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
         IPV4_ADDRESS
-            .get_or_try_init_type_ref(py, "ipaddress", "IPv4Address")?
+            .import(py, "ipaddress", "IPv4Address")?
             .call1((u32::from_be_bytes(self.octets()),))
     }
 }
@@ -77,7 +77,7 @@ impl<'py> IntoPyObject<'py> for Ipv6Addr {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         static IPV6_ADDRESS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
         IPV6_ADDRESS
-            .get_or_try_init_type_ref(py, "ipaddress", "IPv6Address")?
+            .import(py, "ipaddress", "IPv6Address")?
             .call1((u128::from_be_bytes(self.octets()),))
     }
 }

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -93,7 +93,7 @@ impl<'py> IntoPyObject<'py> for Duration {
         {
             static TIMEDELTA: GILOnceCell<Py<PyType>> = GILOnceCell::new();
             TIMEDELTA
-                .get_or_try_init_type_ref(py, "datetime", "timedelta")?
+                .import(py, "datetime", "timedelta")?
                 .call1((days, seconds, microseconds))
         }
     }

--- a/src/impl_/exceptions.rs
+++ b/src/impl_/exceptions.rs
@@ -17,7 +17,7 @@ impl ImportedExceptionTypeObject {
 
     pub fn get<'py>(&self, py: Python<'py>) -> &Bound<'py, PyType> {
         self.imported_value
-            .get_or_try_init_type_ref(py, self.module, self.name)
+            .import(py, self.module, self.name)
             .unwrap_or_else(|e| {
                 panic!(
                     "failed to import exception {}.{}: {}",

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -224,7 +224,7 @@ where
     ///
     /// # Example: Using `GILOnceCell` to store a class in a static variable.
     ///
-    /// `GILOnceCell` can be used to avoid importing a class multiple times
+    /// `GILOnceCell` can be used to avoid importing a class multiple times:
     /// ```
     /// # use pyo3::prelude::*;
     /// # use pyo3::sync::GILOnceCell;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -222,8 +222,9 @@ where
     ///
     /// This is a shorthand method for `get_or_init` which imports the type from Python on init.
     ///
-    /// # Example: Using `GILOnceCell` to avoid the overhead of importing a class multiple times
+    /// # Example: Using `GILOnceCell` to store a class in a static variable.
     ///
+    /// `GILOnceCell` can be used to avoid importing a class multiple times
     /// ```
     /// # use pyo3::prelude::*;
     /// # use pyo3::sync::GILOnceCell;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -218,7 +218,7 @@ impl<T> GILOnceCell<Py<T>>
 where
     T: PyTypeCheck,
 {
-    /// Get a reference to the contained Python type, initializing it if needed.
+    /// Get a reference to the contained Python type, initializing the cell if needed.
     ///
     /// This is a shorthand method for `get_or_init` which imports the type from Python on init.
     ///

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -163,7 +163,7 @@ impl<'py> PyMappingMethods<'py> for Bound<'py, PyMapping> {
 fn get_mapping_abc(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
     static MAPPING_ABC: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 
-    MAPPING_ABC.get_or_try_init_type_ref(py, "collections.abc", "Mapping")
+    MAPPING_ABC.import(py, "collections.abc", "Mapping")
 }
 
 impl PyTypeCheck for PyMapping {

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -79,6 +79,9 @@ impl PyModule {
     /// ```python
     /// import antigravity
     /// ```
+    ///
+    /// If you want to import a class, you can store a reference to it with
+    /// [`GILOnceCell::import`][crate::sync::GILOnceCell#method.import].
     pub fn import<N>(py: Python<'_>, name: N) -> PyResult<Bound<'_, PyModule>>
     where
         N: IntoPy<Py<PyString>>,

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -352,7 +352,7 @@ where
 fn get_sequence_abc(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
     static SEQUENCE_ABC: GILOnceCell<Py<PyType>> = GILOnceCell::new();
 
-    SEQUENCE_ABC.get_or_try_init_type_ref(py, "collections.abc", "Sequence")
+    SEQUENCE_ABC.import(py, "collections.abc", "Sequence")
 }
 
 impl PyTypeCheck for PySequence {


### PR DESCRIPTION
Resolves https://github.com/PyO3/pyo3/issues/4516.

- Change `GILOnceCell::get_or_try_init_type_ref` to `GILOnceCell::import` and make it public API, adding an example for it.
- Update "Executing existing Python code" section of the guide:
  - Add mention to `GILOnceCell::import`.
  - Change `Python::eval_bound` (which is deprecated) to `Python::eval`.
  - Change `Python::run_bound` (which is deprecated) to `Python::run`, also adding missing link.