### PR TITLE
Make PyClassBorrowChecker thread safe

### DIFF
--- a/newsfragments/4544.changed.md
+++ b/newsfragments/4544.changed.md
@@ -1,0 +1,2 @@
+* Refactored runtime borrow checking for mutable pyclass instances
+  to be thread-safe when the GIL is disabled.

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -1,3 +1,5 @@
+use std::{thread, time};
+
 use pyo3::exceptions::{PyStopIteration, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyType;
@@ -43,6 +45,29 @@ impl PyClassIter {
     }
 }
 
+#[pyclass]
+#[derive(Default)]
+struct PyClassThreadIter {
+    count: usize,
+}
+
+#[pymethods]
+impl PyClassThreadIter {
+    #[new]
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    fn __next__(&mut self) -> PyResult<usize> {
+        let should_wait = self.count == 0;
+        self.count += 1;
+        if should_wait {
+            thread::sleep(time::Duration::from_millis(100));
+        }
+        Ok(self.count)
+    }
+}
+
 /// Demonstrates a base class which can operate on the relevant subclass in its constructor.
 #[pyclass(subclass)]
 #[derive(Clone, Debug)]
@@ -83,6 +108,7 @@ impl ClassWithDict {
 pub fn pyclasses(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<EmptyClass>()?;
     m.add_class::<PyClassIter>()?;
+    m.add_class::<PyClassThreadIter>()?;
     m.add_class::<AssertingBaseClass>()?;
     m.add_class::<ClassWithoutConstructor>()?;
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -58,13 +58,13 @@ impl PyClassThreadIter {
         Default::default()
     }
 
-    fn __next__(&mut self) -> PyResult<usize> {
+    fn __next__(&mut self) -> usize {
         let should_wait = self.count == 0;
         self.count += 1;
         if should_wait {
             thread::sleep(time::Duration::from_millis(100));
         }
-        Ok(self.count)
+        self.count
     }
 }
 

--- a/pytests/tests/test_pyclasses.py
+++ b/pytests/tests/test_pyclasses.py
@@ -57,7 +57,9 @@ def test_iter():
     assert excinfo.value.value == "Ended"
 
 
-@pytest.mark.skipif(not FREETHREADED_BUILD, "The GIL enforces runtime borrow checking")
+@pytest.mark.skipif(
+    not FREETHREADED_BUILD, reason="The GIL enforces runtime borrow checking"
+)
 def test_parallel_iter():
     i = pyclasses.PyClassThreadIter()
 

--- a/pytests/tests/test_pyclasses.py
+++ b/pytests/tests/test_pyclasses.py
@@ -1,4 +1,4 @@
-import concurrent.futures
+import platform
 from typing import Type
 
 import pytest
@@ -53,8 +53,10 @@ def test_iter():
         next(i)
     assert excinfo.value.value == "Ended"
 
-
+@pytest.mark.skipif(platform.machine() in ["wasm32", "wasm64"])
 def test_parallel_iter():
+    import concurrent.futures
+
     i = pyclasses.PyClassThreadIter()
 
     def func():

--- a/pytests/tests/test_pyclasses.py
+++ b/pytests/tests/test_pyclasses.py
@@ -53,6 +53,7 @@ def test_iter():
         next(i)
     assert excinfo.value.value == "Ended"
 
+
 @pytest.mark.skipif(platform.machine() in ["wasm32", "wasm64"])
 def test_parallel_iter():
     import concurrent.futures

--- a/pytests/tests/test_pyclasses.py
+++ b/pytests/tests/test_pyclasses.py
@@ -1,5 +1,4 @@
 import concurrent.futures
-import sysconfig
 from typing import Type
 
 import pytest

--- a/pytests/tests/test_pyclasses.py
+++ b/pytests/tests/test_pyclasses.py
@@ -5,8 +5,6 @@ from typing import Type
 import pytest
 from pyo3_pytests import pyclasses
 
-FREETHREADED_BUILD = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
-
 
 def test_empty_class_init(benchmark):
     benchmark(pyclasses.EmptyClass)
@@ -57,9 +55,6 @@ def test_iter():
     assert excinfo.value.value == "Ended"
 
 
-@pytest.mark.skipif(
-    not FREETHREADED_BUILD, reason="The GIL enforces runtime borrow checking"
-)
 def test_parallel_iter():
     i = pyclasses.PyClassThreadIter()
 

--- a/pytests/tests/test_pyclasses.py
+++ b/pytests/tests/test_pyclasses.py
@@ -54,7 +54,10 @@ def test_iter():
     assert excinfo.value.value == "Ended"
 
 
-@pytest.mark.skipif(platform.machine() in ["wasm32", "wasm64"])
+@pytest.mark.skipif(
+    platform.machine() in ["wasm32", "wasm64"],
+    reason="not supporting threads in CI for WASM yet",
+)
 def test_parallel_iter():
     import concurrent.futures
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -156,10 +156,9 @@ impl PyClassBorrowChecker for BorrowChecker {
             // currently unused
             BorrowFlag::UNUSED,
             BorrowFlag::HAS_MUTABLE_BORROW,
-            // On success the read is synchronized to ensure other
-            // threads don't get a reference before this thread checks
-            // that it can get one
-            Ordering::Acquire,
+            // On success, reading the flag and updating its state are an atomic
+            // operation
+            Ordering::AcqRel,
             // It doesn't matter precisely when the failure gets turned
             // into an error
             Ordering::Relaxed,

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -529,6 +529,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_arch = "wasm32"))]
     fn test_thread_safety() {
         #[crate::pyclass(crate = "crate")]
         struct MyClass {
@@ -572,6 +573,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_arch = "wasm32"))]
     fn test_thread_safety_2() {
         struct SyncUnsafeCell<T>(UnsafeCell<T>);
         unsafe impl<T> Sync for SyncUnsafeCell<T> {}

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -74,7 +74,7 @@ impl BorrowFlag {
                 Ok(..) => {
                     // value has been successfully incremented, we need an acquire fence
                     // so that data this borrow flag protects can be read safely in this thread
-                    std::atomic::fence(Ordering::Acquire);
+                    std::sync::atomic::fence(Ordering::Acquire);
                     break Ok(());
                 }
                 Err(changed_value) => {


### PR DESCRIPTION
Ref https://github.com/PyO3/pyo3/issues/4265#issuecomment-2341515202 and replies from @alex.

I tried doing this with an `AtomicUsize` but because `try_borrow` accepts an immutable reference, I couldn't figure out a way to get that to work without keeping the `Cell`. A mutex seemed like a more natural choice for the existing code structure.

I think in principle we could use a mutex on the GIL-enabled build as well, since the lock is only held very briefly in rust to update the borrow checker state.

Is the new test that only triggers on the free-threaded build OK? I could also write it to test that there *isn't* an exception on the GIL-enabled build.