### PR TITLE
remove continue-on-error from free-threaded CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,13 +519,7 @@ jobs:
           nogil: true
       - run: python3 -m sysconfig
       - run: python3 -m pip install --upgrade pip && pip install nox
-      - run: nox -s ffi-check
-      - name: Run default nox sessions that should pass
-        run: nox -s clippy docs rustfmt ruff
-      - name: Run PyO3 tests with free-threaded Python (can fail)
-        # TODO fix the test crashes so we can unset this
-        continue-on-error: true
-        run: nox -s test
+      - run: nox
 
   test-version-limits:
     needs: [fmt]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,7 @@ jobs:
           nogil: true
       - run: python3 -m sysconfig
       - run: python3 -m pip install --upgrade pip && pip install nox
+      - run: nox -s ffi-check
       - run: nox
 
   test-version-limits:

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1115,7 +1115,7 @@ impl<T> PyClassThreadChecker<T> for ThreadCheckerImpl {
 /// Trait denoting that this class is suitable to be used as a base type for PyClass.
 
 #[cfg_attr(
-    all(diagnostic_namespace, feature = "abi3"),
+    all(diagnostic_namespace, Py_LIMITED_API),
     diagnostic::on_unimplemented(
         message = "pyclass `{Self}` cannot be subclassed",
         label = "required for `#[pyclass(extends={Self})]`",
@@ -1124,7 +1124,7 @@ impl<T> PyClassThreadChecker<T> for ThreadCheckerImpl {
     )
 )]
 #[cfg_attr(
-    all(diagnostic_namespace, not(feature = "abi3")),
+    all(diagnostic_namespace, not(Py_LIMITED_API)),
     diagnostic::on_unimplemented(
         message = "pyclass `{Self}` cannot be subclassed",
         label = "required for `#[pyclass(extends={Self})]`",

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -120,6 +120,10 @@ fn gc_integration() {
     Python::with_gil(|py| {
         py.run(ffi::c_str!("import gc; gc.collect()"), None, None)
             .unwrap();
+        // threads are resumed before tp_clear() calls finish, so drop might not
+        // necessarily be called when we get here see
+        // https://peps.python.org/pep-0703/#stop-the-world
+        #[cfg(not(Py_GIL_DISABLED))]
         assert!(drop_called.load(Ordering::Relaxed));
     });
 }


### PR DESCRIPTION
Now that 3.13.0rc2 is out, the tests shouldn't be crashing anymore.

In principle it's also possible internal uses of `GILOnceCell` could also cause crashes. In practice I don't ever see any crashes caused by `GILOnceCell` in my local testing.

I do need help with one thing, there is currently a failing test introduced by https://github.com/PyO3/pyo3/pull/4453, which added a new diagnostic warning to compiler errors if the abi3 feature is enabled. But since the free-threaded build (like pypy) simply warns that abi3 isn't supported and ignores it, this leads to a test failure due to this new line in the compiler error:

```
$ diff -u expected actual
--- expected	2024-09-11 14:26:36
+++ actual	2024-09-11 14:26:47
@@ -6,6 +6,7 @@
   |
   = help: the trait `PyClassBaseType` is not implemented for `PyBool`
   = note: `PyBool` must have `#[pyclass(subclass)]` to be eligible for subclassing
+  = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
   = help: the following other types implement trait `PyClassBaseType`:
             PyAny
             PyArithmeticError
@@ -30,6 +31,7 @@
   |
   = help: the trait `PyClassBaseType` is not implemented for `PyBool`
   = note: `PyBool` must have `#[pyclass(subclass)]` to be eligible for subclassing
+  = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
   = help: the following other types implement trait `PyClassBaseType`:
             PyAny
             PyArithmeticError
```

I'm not sure how to account for that in the compiler error tests.