### PR TITLE
docs: update Using Python from Rust code to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,11 @@ sudo apt install python3-dev
 
 To install the Python shared library on RPM based distributions (e.g. Fedora, Red Hat, SuSE), install the `python3-devel` package.
 
-
 Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like this:
 
 ```toml
-[dependencies.pyo3]
-version = "0.22.2"
-features = ["auto-initialize"]
+[dependencies]
+pyo3 = { version = "0.22.2", features = ["auto-initialize"] }
 ```
 
 Example program displaying the value of `sys.version` and the current user name:
@@ -146,16 +144,15 @@ Example program displaying the value of `sys.version` and the current user name:
 ```rust
 use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
-use pyo3::ffi::c_str;
 
 fn main() -> PyResult<()> {
     Python::with_gil(|py| {
-        let sys = py.import("sys")?;
+        let sys = py.import_bound("sys")?;
         let version: String = sys.getattr("version")?.extract()?;
 
-        let locals = [("os", py.import("os")?)].into_py_dict(py);
-        let code = c_str!("os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'");
-        let user: String = py.eval(code, None, Some(&locals))?.extract()?;
+        let locals = [("os", py.import_bound("os")?)].into_py_dict_bound(py);
+        let code = "os.getenv('USER') or os.getenv('USERNAME') or 'Unknown'";
+        let user: String = py.eval_bound(code, None, Some(&locals))?.extract()?;
 
         println!("Hello {}, I'm Python {}", user, version);
         Ok(())


### PR DESCRIPTION
updates the "Using Python from Rust" example in the readme to compile with the current library version

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
