### PR TITLE
Lookup cross compile config paths with runtime OUT_DIR vs compile time

### DIFF
--- a/newsfragments/4555.changed.md
+++ b/newsfragments/4555.changed.md
@@ -1,0 +1,2 @@
+`pyo3-build-config` now refers to `OUT_DIR` at runtime vs compile-time when
+resolving cross-compilation config files.

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -122,11 +122,13 @@ const HOST_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-con
 #[doc(hidden)]
 #[cfg(feature = "resolve-config")]
 fn resolve_cross_compile_config_path() -> Option<PathBuf> {
-    env::var_os("TARGET").map(|target| {
-        let mut path = PathBuf::from(env!("OUT_DIR"));
-        path.push(Path::new(&target));
-        path.push("pyo3-build-config.txt");
-        path
+    env::var_os("TARGET").and_then(|target| {
+        std::env::var("OUT_DIR").ok().map(|out_dir| {
+            let mut path = PathBuf::from(out_dir);
+            path.push(Path::new(&target));
+            path.push("pyo3-build-config.txt");
+            path
+        })
     })
 }
 


### PR DESCRIPTION
This change addresses a build failure I found when building Bazel rules for PyO3 (https://github.com/abrisco/rules_pyo3/pull/14). Essentially, because Bazel compiles and runs build scripts in a sandbox at different locations, when environment variables that refer to a directory are compiled into build scripts, the directory embedded is to an old sandbox location that will not exist for any other action (running build scripts, compiling). This change resolves the build failure by using the `OUT_DIR` environment variable at runtime vs compile time to locate a cross compilation config.

This change would have the side effect of these config files not being written into `pyo3-build-config`'s `OUT_DIR` but the `OUT_DIR` of whatever the crate was linked into. This is because when the `pyo3-build-config`'s `rlib` is compiled, it's `OUT_DIR` will be embedded into it then, thus providing a locked absolute path for it's consumers.