### PR TITLE
migrate `PySequenceMethods` trait bounds

### DIFF
--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -301,7 +301,7 @@ fn main() -> PyResult<()> {
             .import("sys")?
             .getattr("path")?
             .downcast_into::<PyList>()?;
-        syspath.insert(0, &path)?;
+        syspath.insert(0, path)?;
         let app: Py<PyAny> = PyModule::from_code(py, py_app.as_c_str(), c_str!(""), c_str!(""))?
             .getattr("run")?
             .into();


### PR DESCRIPTION
This migrates the trait bounds of  `PySequenceMethods`, `PyListMethods` and `PyTupleMethods` to `IntoPyObject`. Constructor migration for `PyList` and `PyTuple` will be in a followup to keep the diff a bit smaller.