### PR TITLE
require `#[pyclass]` to be `Sync`

### DIFF
--- a/examples/decorator/src/lib.rs
+++ b/examples/decorator/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub struct PyCounter {
     // Keeps track of how many calls have gone through.
     //
-    // See the discussion at the end for why `Cell` is used.
+    // See the discussion at the end for why `AtomicU64` is used.
     count: AtomicU64,
 
     // This is the actual function being wrapped.

--- a/examples/decorator/src/lib.rs
+++ b/examples/decorator/src/lib.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
-use std::cell::Cell;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A function decorator that keeps track how often it is called.
 ///
@@ -10,7 +10,7 @@ pub struct PyCounter {
     // Keeps track of how many calls have gone through.
     //
     // See the discussion at the end for why `Cell` is used.
-    count: Cell<u64>,
+    count: AtomicU64,
 
     // This is the actual function being wrapped.
     wraps: Py<PyAny>,
@@ -26,14 +26,14 @@ impl PyCounter {
     #[new]
     fn __new__(wraps: Py<PyAny>) -> Self {
         PyCounter {
-            count: Cell::new(0),
+            count: AtomicU64::new(0),
             wraps,
         }
     }
 
     #[getter]
     fn count(&self) -> u64 {
-        self.count.get()
+        self.count.load(Ordering::Relaxed)
     }
 
     #[pyo3(signature = (*args, **kwargs))]
@@ -43,9 +43,7 @@ impl PyCounter {
         args: &Bound<'_, PyTuple>,
         kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<Py<PyAny>> {
-        let old_count = self.count.get();
-        let new_count = old_count + 1;
-        self.count.set(new_count);
+        let new_count = self.count.fetch_add(1, Ordering::Relaxed);
         let name = self.wraps.getattr(py, "__name__")?;
 
         println!("{} has been called {} time(s).", name, new_count);

--- a/guide/src/class/call.md
+++ b/guide/src/class/call.md
@@ -66,7 +66,7 @@ def Counter(wraps):
     return call
 ```
 
-### What is the `Cell` for?
+### What is the `AtomicU64` for?
 
 A [previous implementation] used a normal `u64`, which meant it required a `&mut self` receiver to update the count:
 
@@ -108,14 +108,15 @@ say_hello()
 # RuntimeError: Already borrowed
 ```
 
-The implementation in this chapter fixes that by never borrowing exclusively; all the methods take `&self` as receivers, of which multiple may exist simultaneously. This requires a shared counter and the easiest way to do that is to use [`Cell`], so that's what is used here.
+The implementation in this chapter fixes that by never borrowing exclusively; all the methods take `&self` as receivers, of which multiple may exist simultaneously. This requires a shared counter and the most straightforward way to implement thread-safe interior mutability (e.g. the type does not need to accept `&mut self` to modify the "interior" state) for a `u64` is to use [`AtomicU64`], so that's what is used here.
 
 This shows the dangers of running arbitrary Python code - note that "running arbitrary Python code" can be far more subtle than the example above:
 - Python's asynchronous executor may park the current thread in the middle of Python code, even in Python code that *you* control, and let other Python code run.
 - Dropping arbitrary Python objects may invoke destructors defined in Python (`__del__` methods).
 - Calling Python's C-api (most PyO3 apis call C-api functions internally) may raise exceptions, which may allow Python code in signal handlers to run.
+- On the free-threaded build, users might use Python's `threading` module to work with your types simultaneously from multiple OS threads.
 
 This is especially important if you are writing unsafe code; Python code must never be able to cause undefined behavior. You must ensure that your Rust code is in a consistent state before doing any of the above things.
 
 [previous implementation]: https://github.com/PyO3/pyo3/discussions/2598 "Thread Safe Decorator <Help Wanted> · Discussion #2598 · PyO3/pyo3"
-[`Cell`]: https://doc.rust-lang.org/std/cell/struct.Cell.html "Cell in std::cell - Rust"
+[`AtomicU64`]: https://doc.rust-lang.org/std/sync/atomic/struct.AtomicU64.html "AtomicU64 in std::sync::atomic - Rust"

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -158,9 +158,11 @@ Example:
 ```rust
 use pyo3::prelude::*;
 
+use std::sync::Mutex;
+
 #[pyclass]
 struct MyIterator {
-    iter: Box<dyn Iterator<Item = PyObject> + Send>,
+    iter: Mutex<Box<dyn Iterator<Item = PyObject> + Send>>,
 }
 
 #[pymethods]
@@ -168,8 +170,8 @@ impl MyIterator {
     fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
         slf
     }
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<PyObject> {
-        slf.iter.next()
+    fn __next__(slf: PyRefMut<'_, Self>) -> Option<PyObject> {
+        slf.iter.lock().unwrap().next()
     }
 }
 ```

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -1800,7 +1800,7 @@ There can be two fixes:
    ```
 
    After:
-   ```rust
+   ```rust,ignore
    # #![allow(dead_code)]
    use pyo3::prelude::*;
    use std::sync::{Arc, Mutex};

--- a/newsfragments/4566.changed.md
+++ b/newsfragments/4566.changed.md
@@ -1,0 +1,5 @@
+* The `pyclass` macro now creates a rust type that is `Sync` by default.  If you
+  would like to opt out of this, annotate your class with
+  `pyclass(unsendable)`. See the migraiton guide entry (INSERT GUIDE LINK HERE)
+  for more information on updating to accommadate this change.
+  

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2310,7 +2310,21 @@ impl<'a> PyClassImplsBuilder<'a> {
             }
         });
 
+        let assertions = if attr.options.unsendable.is_some() {
+            TokenStream::new()
+        } else {
+            quote_spanned! {
+                cls.span() =>
+                const _: () = {
+                    use #pyo3_path::impl_::pyclass::*;
+                    assert_pyclass_sync::<#cls, { IsSync::<#cls>::VALUE }>();
+                };
+            }
+        };
+
         Ok(quote! {
+            #assertions
+
             #pyclass_base_type_impl
 
             impl #pyo3_path::impl_::pyclass::PyClassImpl for #cls {

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2317,7 +2317,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                 cls.span() =>
                 const _: () = {
                     use #pyo3_path::impl_::pyclass::*;
-                    assert_pyclass_sync::<#cls, { IsSync::<#cls>::VALUE }>();
+                    assert_pyclass_sync::<#cls>();
                 };
             }
         };

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -35,6 +35,10 @@ pub struct Coroutine {
     waker: Option<Arc<AsyncioWaker>>,
 }
 
+// Safety: `Coroutine` is allowed to be `Sync` even though the future is not,
+// because the future is polled with `&mut self` receiver
+unsafe impl Sync for Coroutine {}
+
 impl Coroutine {
     ///  Wrap a future into a Python coroutine.
     ///

--- a/src/impl_/pyclass/assertions.rs
+++ b/src/impl_/pyclass/assertions.rs
@@ -40,10 +40,10 @@ impl<T> PyClassSync<true> for T {}
 impl<T> PyClassSync<false> for T {}
 
 mod tests {
-    use super::assert_pyclass_sync;
-
     #[test]
     fn test_assert_pyclass_sync() {
+        use super::assert_pyclass_sync;
+
         #[crate::pyclass(crate = "crate")]
         struct MyClass {}
         assert_pyclass_sync::<MyClass, true>();

--- a/src/impl_/pyclass/assertions.rs
+++ b/src/impl_/pyclass/assertions.rs
@@ -38,3 +38,14 @@ impl<T> PyClassSync<true> for T {}
 // an implementation for `false`` to avoid a useless diagnostic.
 #[cfg(not(diagnostic_namespace))]
 impl<T> PyClassSync<false> for T {}
+
+mod tests {
+    use super::assert_pyclass_sync;
+
+    #[test]
+    fn test_assert_pyclass_sync() {
+        #[crate::pyclass(crate = "crate")]
+        struct IntWrapper {}
+        assert_pyclass_sync::<IntWrapper, true>();
+    }
+}

--- a/src/impl_/pyclass/assertions.rs
+++ b/src/impl_/pyclass/assertions.rs
@@ -45,7 +45,7 @@ mod tests {
     #[test]
     fn test_assert_pyclass_sync() {
         #[crate::pyclass(crate = "crate")]
-        struct IntWrapper {}
-        assert_pyclass_sync::<IntWrapper, true>();
+        struct MyClass {}
+        assert_pyclass_sync::<MyClass, true>();
     }
 }

--- a/src/impl_/pyclass/assertions.rs
+++ b/src/impl_/pyclass/assertions.rs
@@ -40,6 +40,7 @@ impl<T> PyClassSync<true> for T {}
 impl<T> PyClassSync<false> for T {}
 
 mod tests {
+    #[cfg(feature = "macros")]
     #[test]
     fn test_assert_pyclass_sync() {
         use super::assert_pyclass_sync;

--- a/src/impl_/pyclass/assertions.rs
+++ b/src/impl_/pyclass/assertions.rs
@@ -6,9 +6,10 @@
 ///
 /// The additional `const IS_SYNC: bool` parameter is used to allow the custom
 /// diagnostic to be emitted; if `PyClassSync`
-pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
+#[allow(unused)]
+pub const fn assert_pyclass_sync<T>()
 where
-    T: PyClassSync<IS_SYNC> + Sync,
+    T: PyClassSync + Sync,
 {
 }
 
@@ -21,23 +22,9 @@ where
         note = "see <TODO INSERT PYO3 GUIDE> for more information",
     )
 )]
-pub trait PyClassSync<const IS_SYNC: bool>: private::Sealed<IS_SYNC> {}
+pub trait PyClassSync<T: Sync = Self> {}
 
-mod private {
-    pub trait Sealed<const IS_SYNC: bool> {}
-    impl<T> Sealed<true> for T {}
-    #[cfg(not(diagnostic_namespace))]
-    impl<T> Sealed<false> for T {}
-}
-
-// If `true` is passed for the const parameter, then the diagnostic will
-// not be emitted.
-impl<T> PyClassSync<true> for T {}
-
-// Without `diagnostic_namespace`, the trait bound is not useful, so we add
-// an implementation for `false`` to avoid a useless diagnostic.
-#[cfg(not(diagnostic_namespace))]
-impl<T> PyClassSync<false> for T {}
+impl<T> PyClassSync for T where T: Sync {}
 
 mod tests {
     #[cfg(feature = "macros")]
@@ -47,6 +34,7 @@ mod tests {
 
         #[crate::pyclass(crate = "crate")]
         struct MyClass {}
-        assert_pyclass_sync::<MyClass, true>();
+
+        assert_pyclass_sync::<MyClass>();
     }
 }

--- a/src/impl_/pyclass/assertions.rs
+++ b/src/impl_/pyclass/assertions.rs
@@ -16,8 +16,8 @@ where
     diagnostic_namespace,
     diagnostic::on_unimplemented(
         message = "the trait `Sync` is not implemented for `{Self}`",
-        label = "needs to implement `Sync` to be `#[pyclass]`",
-        note = "to opt-out of threading support, use `#[pyclass(unsendable)]`",
+        label = "required by `#[pyclass]`",
+        note = "replace thread-unsafe fields with thread-safe alternatives",
         note = "see <TODO INSERT PYO3 GUIDE> for more information",
     )
 )]

--- a/src/impl_/pyclass/assertions.rs
+++ b/src/impl_/pyclass/assertions.rs
@@ -1,0 +1,40 @@
+/// Helper function that can be used at compile time to emit a diagnostic if
+/// the type does not implement `Sync` when it should.
+///
+/// The mere act of invoking this function will cause the diagnostic to be
+/// emitted if `T` does not implement `Sync` when it should.
+///
+/// The additional `const IS_SYNC: bool` parameter is used to allow the custom
+/// diagnostic to be emitted; if `PyClassSync`
+pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
+where
+    T: PyClassSync<IS_SYNC> + Sync,
+{
+}
+
+#[cfg_attr(
+    diagnostic_namespace,
+    diagnostic::on_unimplemented(
+        message = "the trait `Sync` is not implemented for `{Self}`",
+        label = "needs to implement `Sync` to be `#[pyclass]`",
+        note = "to opt-out of threading support, use `#[pyclass(unsendable)]`",
+        note = "see <TODO INSERT PYO3 GUIDE> for more information",
+    )
+)]
+pub trait PyClassSync<const IS_SYNC: bool>: private::Sealed<IS_SYNC> {}
+
+mod private {
+    pub trait Sealed<const IS_SYNC: bool> {}
+    impl<T> Sealed<true> for T {}
+    #[cfg(not(diagnostic_namespace))]
+    impl<T> Sealed<false> for T {}
+}
+
+// If `true` is passed for the const parameter, then the diagnostic will
+// not be emitted.
+impl<T> PyClassSync<true> for T {}
+
+// Without `diagnostic_namespace`, the trait bound is not useful, so we add
+// an implementation for `false`` to avoid a useless diagnostic.
+#[cfg(not(diagnostic_namespace))]
+impl<T> PyClassSync<false> for T {}

--- a/src/impl_/pyclass/probes.rs
+++ b/src/impl_/pyclass/probes.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 
+use crate::{conversion::IntoPyObject, Py};
 #[allow(deprecated)]
-use crate::ToPyObject;
-use crate::{conversion::IntoPyObject, IntoPy, Py};
+use crate::{IntoPy, ToPyObject};
 
 /// Trait used to combine with zero-sized types to calculate at compile time
 /// some property of a type.

--- a/src/impl_/pyclass/probes.rs
+++ b/src/impl_/pyclass/probes.rs
@@ -1,6 +1,8 @@
 use std::marker::PhantomData;
 
-use crate::{conversion::IntoPyObject, IntoPy, Py, ToPyObject};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{conversion::IntoPyObject, IntoPy, Py};
 
 /// Trait used to combine with zero-sized types to calculate at compile time
 /// some property of a type.

--- a/src/impl_/pyclass/probes.rs
+++ b/src/impl_/pyclass/probes.rs
@@ -1,0 +1,70 @@
+use std::marker::PhantomData;
+
+use crate::{conversion::IntoPyObject, IntoPy, Py, ToPyObject};
+
+/// Trait used to combine with zero-sized types to calculate at compile time
+/// some property of a type.
+///
+/// The trick uses the fact that an associated constant has higher priority
+/// than a trait constant, so we can use the trait to define the false case.
+///
+/// The true case is defined in the zero-sized type's impl block, which is
+/// gated on some property like trait bound or only being implemented
+/// for fixed concrete types.
+pub trait Probe {
+    const VALUE: bool = false;
+}
+
+macro_rules! probe {
+    ($name:ident) => {
+        pub struct $name<T>(PhantomData<T>);
+        impl<T> Probe for $name<T> {}
+    };
+}
+
+probe!(IsPyT);
+
+impl<T> IsPyT<Py<T>> {
+    pub const VALUE: bool = true;
+}
+
+probe!(IsToPyObject);
+
+#[allow(deprecated)]
+impl<T: ToPyObject> IsToPyObject<T> {
+    pub const VALUE: bool = true;
+}
+
+probe!(IsIntoPy);
+
+#[allow(deprecated)]
+impl<T: IntoPy<crate::PyObject>> IsIntoPy<T> {
+    pub const VALUE: bool = true;
+}
+
+probe!(IsIntoPyObjectRef);
+
+// Possible clippy beta regression,
+// see https://github.com/rust-lang/rust-clippy/issues/13578
+#[allow(clippy::extra_unused_lifetimes)]
+impl<'a, 'py, T: 'a> IsIntoPyObjectRef<T>
+where
+    &'a T: IntoPyObject<'py>,
+{
+    pub const VALUE: bool = true;
+}
+
+probe!(IsIntoPyObject);
+
+impl<'py, T> IsIntoPyObject<T>
+where
+    T: IntoPyObject<'py>,
+{
+    pub const VALUE: bool = true;
+}
+
+probe!(IsSync);
+
+impl<T: Sync> IsSync<T> {
+    pub const VALUE: bool = true;
+}

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -5,6 +5,7 @@ use pyo3::class::PyVisit;
 use pyo3::ffi;
 use pyo3::prelude::*;
 use pyo3::py_run;
+#[cfg(not(target_arch = "wasm32"))]
 use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -7,8 +7,8 @@ use pyo3::prelude::*;
 use pyo3::py_run;
 use std::cell::Cell;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
 use std::sync::Once;
+use std::sync::{Arc, Mutex};
 
 #[path = "../src/tests/common.rs"]
 mod common;
@@ -403,20 +403,23 @@ fn tries_gil_in_traverse() {
 fn traverse_cannot_be_hijacked() {
     #[pyclass]
     struct HijackedTraverse {
-        traversed: Cell<bool>,
-        hijacked: Cell<bool>,
+        traversed: AtomicBool,
+        hijacked: AtomicBool,
     }
 
     impl HijackedTraverse {
         fn new() -> Self {
             Self {
-                traversed: Cell::new(false),
-                hijacked: Cell::new(false),
+                traversed: AtomicBool::new(false),
+                hijacked: AtomicBool::new(false),
             }
         }
 
         fn traversed_and_hijacked(&self) -> (bool, bool) {
-            (self.traversed.get(), self.hijacked.get())
+            (
+                self.traversed.load(Ordering::Acquire),
+                self.hijacked.load(Ordering::Acquire),
+            )
         }
     }
 
@@ -424,7 +427,7 @@ fn traverse_cannot_be_hijacked() {
     impl HijackedTraverse {
         #[allow(clippy::unnecessary_wraps)]
         fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-            self.traversed.set(true);
+            self.traversed.store(true, Ordering::Release);
             Ok(())
         }
     }
@@ -436,7 +439,7 @@ fn traverse_cannot_be_hijacked() {
 
     impl Traversable for PyRef<'_, HijackedTraverse> {
         fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-            self.hijacked.set(true);
+            self.hijacked.store(true, Ordering::Release);
             Ok(())
         }
     }
@@ -455,7 +458,7 @@ fn traverse_cannot_be_hijacked() {
 
 #[pyclass]
 struct DropDuringTraversal {
-    cycle: Cell<Option<Py<Self>>>,
+    cycle: Mutex<Option<Py<Self>>>,
     _guard: DropGuard,
 }
 
@@ -463,7 +466,8 @@ struct DropDuringTraversal {
 impl DropDuringTraversal {
     #[allow(clippy::unnecessary_wraps)]
     fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-        self.cycle.take();
+        let mut cycle_ref = self.cycle.lock().unwrap();
+        *cycle_ref = None;
         Ok(())
     }
 }
@@ -474,7 +478,7 @@ fn drop_during_traversal_with_gil() {
     let (guard, check) = drop_check();
 
     let ptr = Python::with_gil(|py| {
-        let cycle = Cell::new(None);
+        let cycle = Mutex::new(None);
         let inst = Py::new(
             py,
             DropDuringTraversal {
@@ -484,7 +488,7 @@ fn drop_during_traversal_with_gil() {
         )
         .unwrap();
 
-        inst.borrow_mut(py).cycle.set(Some(inst.clone_ref(py)));
+        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         let ptr = inst.as_ptr();
@@ -508,7 +512,7 @@ fn drop_during_traversal_without_gil() {
     let (guard, check) = drop_check();
 
     let inst = Python::with_gil(|py| {
-        let cycle = Cell::new(None);
+        let cycle = Mutex::new(None);
         let inst = Py::new(
             py,
             DropDuringTraversal {
@@ -518,7 +522,7 @@ fn drop_during_traversal_without_gil() {
         )
         .unwrap();
 
-        inst.borrow_mut(py).cycle.set(Some(inst.clone_ref(py)));
+        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         inst

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -217,7 +217,7 @@ fn get_all_and_set() {
     });
 }
 
-#[pyclass]
+#[pyclass(unsendable)]
 struct CellGetterSetter {
     #[pyo3(get, set)]
     cell_inner: Cell<i32>,

--- a/tests/ui/pyclass_send.rs
+++ b/tests/ui/pyclass_send.rs
@@ -1,26 +1,28 @@
 use pyo3::prelude::*;
-use std::rc::Rc;
+use std::os::raw::c_void;
 
 #[pyclass]
-struct NotThreadSafe {
-    data: Rc<i32>,
-}
+struct NotSyncNotSend(*mut c_void);
 
-fn main() {
-    let obj = Python::with_gil(|py| {
-        Bound::new(py, NotThreadSafe { data: Rc::new(5) })
-            .unwrap()
-            .unbind()
-    });
+#[pyclass]
+struct SendNotSync(*mut c_void);
+unsafe impl Send for SendNotSync {}
 
-    std::thread::spawn(move || {
-        Python::with_gil(|py| {
-            // Uh oh, moved Rc to a new thread!
-            let c = obj.bind(py).downcast::<NotThreadSafe>().unwrap();
+#[pyclass]
+struct SyncNotSend(*mut c_void);
+unsafe impl Sync for SyncNotSend {}
 
-            assert_eq!(*c.borrow().data, 5);
-        })
-    })
-    .join()
-    .unwrap();
-}
+// None of the `unsendable` forms below should fail to compile
+
+#[pyclass(unsendable)]
+struct NotSyncNotSendUnsendable(*mut c_void);
+
+#[pyclass(unsendable)]
+struct SendNotSyncUnsendable(*mut c_void);
+unsafe impl Send for SendNotSyncUnsendable {}
+
+#[pyclass(unsendable)]
+struct SyncNotSendUnsendable(*mut c_void);
+unsafe impl Sync for SyncNotSendUnsendable {}
+
+fn main() {}

--- a/tests/ui/pyclass_send.stderr
+++ b/tests/ui/pyclass_send.stderr
@@ -2,10 +2,10 @@ error[E0277]: the trait `Sync` is not implemented for `NotSyncNotSend`
  --> tests/ui/pyclass_send.rs:5:8
   |
 5 | struct NotSyncNotSend(*mut c_void);
-  |        ^^^^^^^^^^^^^^ needs to implement `Sync` to be `#[pyclass]`
+  |        ^^^^^^^^^^^^^^ required by `#[pyclass]`
   |
   = help: the trait `PyClassSync<false>` is not implemented for `NotSyncNotSend`
-  = note: to opt-out of threading support, use `#[pyclass(unsendable)]`
+  = note: replace thread-unsafe fields with thread-safe alternatives
   = note: see <TODO INSERT PYO3 GUIDE> for more information
 note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
  --> src/impl_/pyclass/assertions.rs
@@ -62,10 +62,10 @@ error[E0277]: the trait `Sync` is not implemented for `SendNotSync`
  --> tests/ui/pyclass_send.rs:8:8
   |
 8 | struct SendNotSync(*mut c_void);
-  |        ^^^^^^^^^^^ needs to implement `Sync` to be `#[pyclass]`
+  |        ^^^^^^^^^^^ required by `#[pyclass]`
   |
   = help: the trait `PyClassSync<false>` is not implemented for `SendNotSync`
-  = note: to opt-out of threading support, use `#[pyclass(unsendable)]`
+  = note: replace thread-unsafe fields with thread-safe alternatives
   = note: see <TODO INSERT PYO3 GUIDE> for more information
 note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
  --> src/impl_/pyclass/assertions.rs

--- a/tests/ui/pyclass_send.stderr
+++ b/tests/ui/pyclass_send.stderr
@@ -1,17 +1,56 @@
-error[E0277]: `Rc<i32>` cannot be sent between threads safely
+error[E0277]: the trait `Sync` is not implemented for `NotSyncNotSend`
+ --> tests/ui/pyclass_send.rs:5:8
+  |
+5 | struct NotSyncNotSend(*mut c_void);
+  |        ^^^^^^^^^^^^^^ needs to implement `Sync` to be `#[pyclass]`
+  |
+  = help: the trait `PyClassSync<false>` is not implemented for `NotSyncNotSend`
+  = note: to opt-out of threading support, use `#[pyclass(unsendable)]`
+  = note: see <TODO INSERT PYO3 GUIDE> for more information
+note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
+ --> src/impl_/pyclass/assertions.rs
+  |
+  | pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
+  |              ------------------- required by a bound in this function
+  | where
+  |     T: PyClassSync<IS_SYNC> + Sync,
+  |        ^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_pyclass_sync`
+
+error[E0277]: `*mut c_void` cannot be shared between threads safely
+ --> tests/ui/pyclass_send.rs:5:8
+  |
+5 | struct NotSyncNotSend(*mut c_void);
+  |        ^^^^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
+  |
+  = help: within `NotSyncNotSend`, the trait `Sync` is not implemented for `*mut c_void`, which is required by `NotSyncNotSend: Sync`
+note: required because it appears within the type `NotSyncNotSend`
+ --> tests/ui/pyclass_send.rs:5:8
+  |
+5 | struct NotSyncNotSend(*mut c_void);
+  |        ^^^^^^^^^^^^^^
+note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
+ --> src/impl_/pyclass/assertions.rs
+  |
+  | pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
+  |              ------------------- required by a bound in this function
+  | where
+  |     T: PyClassSync<IS_SYNC> + Sync,
+  |                               ^^^^ required by this bound in `assert_pyclass_sync`
+
+error[E0277]: `*mut c_void` cannot be sent between threads safely
  --> tests/ui/pyclass_send.rs:4:1
   |
 4 | #[pyclass]
-  | ^^^^^^^^^^ `Rc<i32>` cannot be sent between threads safely
+  | ^^^^^^^^^^ `*mut c_void` cannot be sent between threads safely
   |
-  = help: within `NotThreadSafe`, the trait `Send` is not implemented for `Rc<i32>`, which is required by `SendablePyClass<NotThreadSafe>: pyo3::impl_::pyclass::PyClassThreadChecker<NotThreadSafe>`
+  = help: within `NotSyncNotSend`, the trait `Send` is not implemented for `*mut c_void`, which is required by `SendablePyClass<NotSyncNotSend>: pyo3::impl_::pyclass::PyClassThreadChecker<NotSyncNotSend>`
   = help: the trait `pyo3::impl_::pyclass::PyClassThreadChecker<T>` is implemented for `SendablePyClass<T>`
-note: required because it appears within the type `NotThreadSafe`
+note: required because it appears within the type `NotSyncNotSend`
  --> tests/ui/pyclass_send.rs:5:8
   |
-5 | struct NotThreadSafe {
-  |        ^^^^^^^^^^^^^
-  = note: required for `SendablePyClass<NotThreadSafe>` to implement `pyo3::impl_::pyclass::PyClassThreadChecker<NotThreadSafe>`
+5 | struct NotSyncNotSend(*mut c_void);
+  |        ^^^^^^^^^^^^^^
+  = note: required for `SendablePyClass<NotSyncNotSend>` to implement `pyo3::impl_::pyclass::PyClassThreadChecker<NotSyncNotSend>`
 note: required by a bound in `PyClassImpl::ThreadChecker`
  --> src/impl_/pyclass.rs
   |
@@ -19,21 +58,100 @@ note: required by a bound in `PyClassImpl::ThreadChecker`
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::ThreadChecker`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `Rc<i32>` cannot be sent between threads safely
+error[E0277]: the trait `Sync` is not implemented for `SendNotSync`
+ --> tests/ui/pyclass_send.rs:8:8
+  |
+8 | struct SendNotSync(*mut c_void);
+  |        ^^^^^^^^^^^ needs to implement `Sync` to be `#[pyclass]`
+  |
+  = help: the trait `PyClassSync<false>` is not implemented for `SendNotSync`
+  = note: to opt-out of threading support, use `#[pyclass(unsendable)]`
+  = note: see <TODO INSERT PYO3 GUIDE> for more information
+note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
+ --> src/impl_/pyclass/assertions.rs
+  |
+  | pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
+  |              ------------------- required by a bound in this function
+  | where
+  |     T: PyClassSync<IS_SYNC> + Sync,
+  |        ^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_pyclass_sync`
+
+error[E0277]: `*mut c_void` cannot be shared between threads safely
+ --> tests/ui/pyclass_send.rs:8:8
+  |
+8 | struct SendNotSync(*mut c_void);
+  |        ^^^^^^^^^^^ `*mut c_void` cannot be shared between threads safely
+  |
+  = help: within `SendNotSync`, the trait `Sync` is not implemented for `*mut c_void`, which is required by `SendNotSync: Sync`
+note: required because it appears within the type `SendNotSync`
+ --> tests/ui/pyclass_send.rs:8:8
+  |
+8 | struct SendNotSync(*mut c_void);
+  |        ^^^^^^^^^^^
+note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
+ --> src/impl_/pyclass/assertions.rs
+  |
+  | pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
+  |              ------------------- required by a bound in this function
+  | where
+  |     T: PyClassSync<IS_SYNC> + Sync,
+  |                               ^^^^ required by this bound in `assert_pyclass_sync`
+
+error[E0277]: `*mut c_void` cannot be sent between threads safely
+  --> tests/ui/pyclass_send.rs:11:1
+   |
+11 | #[pyclass]
+   | ^^^^^^^^^^ `*mut c_void` cannot be sent between threads safely
+   |
+   = help: within `SyncNotSend`, the trait `Send` is not implemented for `*mut c_void`, which is required by `SendablePyClass<SyncNotSend>: pyo3::impl_::pyclass::PyClassThreadChecker<SyncNotSend>`
+   = help: the trait `pyo3::impl_::pyclass::PyClassThreadChecker<T>` is implemented for `SendablePyClass<T>`
+note: required because it appears within the type `SyncNotSend`
+  --> tests/ui/pyclass_send.rs:12:8
+   |
+12 | struct SyncNotSend(*mut c_void);
+   |        ^^^^^^^^^^^
+   = note: required for `SendablePyClass<SyncNotSend>` to implement `pyo3::impl_::pyclass::PyClassThreadChecker<SyncNotSend>`
+note: required by a bound in `PyClassImpl::ThreadChecker`
+  --> src/impl_/pyclass.rs
+   |
+   |     type ThreadChecker: PyClassThreadChecker<Self>;
+   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::ThreadChecker`
+   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `*mut c_void` cannot be sent between threads safely
  --> tests/ui/pyclass_send.rs:4:1
   |
 4 | #[pyclass]
-  | ^^^^^^^^^^ `Rc<i32>` cannot be sent between threads safely
+  | ^^^^^^^^^^ `*mut c_void` cannot be sent between threads safely
   |
-  = help: within `NotThreadSafe`, the trait `Send` is not implemented for `Rc<i32>`, which is required by `NotThreadSafe: Send`
-note: required because it appears within the type `NotThreadSafe`
+  = help: within `NotSyncNotSend`, the trait `Send` is not implemented for `*mut c_void`, which is required by `NotSyncNotSend: Send`
+note: required because it appears within the type `NotSyncNotSend`
  --> tests/ui/pyclass_send.rs:5:8
   |
-5 | struct NotThreadSafe {
-  |        ^^^^^^^^^^^^^
+5 | struct NotSyncNotSend(*mut c_void);
+  |        ^^^^^^^^^^^^^^
 note: required by a bound in `SendablePyClass`
  --> src/impl_/pyclass.rs
   |
   | pub struct SendablePyClass<T: Send>(PhantomData<T>);
   |                               ^^^^ required by this bound in `SendablePyClass`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `*mut c_void` cannot be sent between threads safely
+  --> tests/ui/pyclass_send.rs:11:1
+   |
+11 | #[pyclass]
+   | ^^^^^^^^^^ `*mut c_void` cannot be sent between threads safely
+   |
+   = help: within `SyncNotSend`, the trait `Send` is not implemented for `*mut c_void`, which is required by `SyncNotSend: Send`
+note: required because it appears within the type `SyncNotSend`
+  --> tests/ui/pyclass_send.rs:12:8
+   |
+12 | struct SyncNotSend(*mut c_void);
+   |        ^^^^^^^^^^^
+note: required by a bound in `SendablePyClass`
+  --> src/impl_/pyclass.rs
+   |
+   | pub struct SendablePyClass<T: Send>(PhantomData<T>);
+   |                               ^^^^ required by this bound in `SendablePyClass`
+   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/pyclass_send.stderr
+++ b/tests/ui/pyclass_send.stderr
@@ -1,21 +1,3 @@
-error[E0277]: the trait `Sync` is not implemented for `NotSyncNotSend`
- --> tests/ui/pyclass_send.rs:5:8
-  |
-5 | struct NotSyncNotSend(*mut c_void);
-  |        ^^^^^^^^^^^^^^ required by `#[pyclass]`
-  |
-  = help: the trait `PyClassSync<false>` is not implemented for `NotSyncNotSend`
-  = note: replace thread-unsafe fields with thread-safe alternatives
-  = note: see <TODO INSERT PYO3 GUIDE> for more information
-note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
- --> src/impl_/pyclass/assertions.rs
-  |
-  | pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
-  |              ------------------- required by a bound in this function
-  | where
-  |     T: PyClassSync<IS_SYNC> + Sync,
-  |        ^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_pyclass_sync`
-
 error[E0277]: `*mut c_void` cannot be shared between threads safely
  --> tests/ui/pyclass_send.rs:5:8
   |
@@ -31,11 +13,11 @@ note: required because it appears within the type `NotSyncNotSend`
 note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
  --> src/impl_/pyclass/assertions.rs
   |
-  | pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
+  | pub const fn assert_pyclass_sync<T>()
   |              ------------------- required by a bound in this function
   | where
-  |     T: PyClassSync<IS_SYNC> + Sync,
-  |                               ^^^^ required by this bound in `assert_pyclass_sync`
+  |     T: PyClassSync + Sync,
+  |                      ^^^^ required by this bound in `assert_pyclass_sync`
 
 error[E0277]: `*mut c_void` cannot be sent between threads safely
  --> tests/ui/pyclass_send.rs:4:1
@@ -58,24 +40,6 @@ note: required by a bound in `PyClassImpl::ThreadChecker`
   |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::ThreadChecker`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait `Sync` is not implemented for `SendNotSync`
- --> tests/ui/pyclass_send.rs:8:8
-  |
-8 | struct SendNotSync(*mut c_void);
-  |        ^^^^^^^^^^^ required by `#[pyclass]`
-  |
-  = help: the trait `PyClassSync<false>` is not implemented for `SendNotSync`
-  = note: replace thread-unsafe fields with thread-safe alternatives
-  = note: see <TODO INSERT PYO3 GUIDE> for more information
-note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
- --> src/impl_/pyclass/assertions.rs
-  |
-  | pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
-  |              ------------------- required by a bound in this function
-  | where
-  |     T: PyClassSync<IS_SYNC> + Sync,
-  |        ^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_pyclass_sync`
-
 error[E0277]: `*mut c_void` cannot be shared between threads safely
  --> tests/ui/pyclass_send.rs:8:8
   |
@@ -91,11 +55,11 @@ note: required because it appears within the type `SendNotSync`
 note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
  --> src/impl_/pyclass/assertions.rs
   |
-  | pub const fn assert_pyclass_sync<T, const IS_SYNC: bool>()
+  | pub const fn assert_pyclass_sync<T>()
   |              ------------------- required by a bound in this function
   | where
-  |     T: PyClassSync<IS_SYNC> + Sync,
-  |                               ^^^^ required by this bound in `assert_pyclass_sync`
+  |     T: PyClassSync + Sync,
+  |                      ^^^^ required by this bound in `assert_pyclass_sync`
 
 error[E0277]: `*mut c_void` cannot be sent between threads safely
   --> tests/ui/pyclass_send.rs:11:1


### PR DESCRIPTION
For #4265 

A brief attempt to add a compile error to require `#[pyclass]` values to be `Sync`. I allow this constraint to be opted-out with the existing `#[pyclass(unsendable)]` option.

Mostly here I've focused on implementing the compile error with a reasonable diagnostic, I think there's a lot of documentation to add too.