### PR TITLE
Small fixes

### DIFF
--- a/newsfragments/4567.fixed.md
+++ b/newsfragments/4567.fixed.md
@@ -1,0 +1,1 @@
+Fix compiler warning about non snake case method names inside `#[pymethods]` generated code.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -48,7 +48,7 @@ impl PyClassArgs {
         })
     }
 
-    pub fn parse_stuct_args(input: ParseStream<'_>) -> syn::Result<Self> {
+    pub fn parse_struct_args(input: ParseStream<'_>) -> syn::Result<Self> {
         Self::parse(input, PyClassKind::Struct)
     }
 

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1295,6 +1295,7 @@ impl SlotDef {
         let name = spec.name;
         let holders = holders.init_holders(ctx);
         let associated_method = quote! {
+            #[allow(non_snake_case)]
             unsafe fn #wrapper_ident(
                 py: #pyo3_path::Python<'_>,
                 _raw_slf: *mut #pyo3_path::ffi::PyObject,
@@ -1418,6 +1419,7 @@ impl SlotFragmentDef {
         let holders = holders.init_holders(ctx);
         Ok(quote! {
             impl #cls {
+                #[allow(non_snake_case)]
                 unsafe fn #wrapper_ident(
                     py: #pyo3_path::Python,
                     _raw_slf: *mut #pyo3_path::ffi::PyObject,

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -168,7 +168,7 @@ fn pyclass_impl(
     mut ast: syn::ItemStruct,
     methods_type: PyClassMethodsType,
 ) -> TokenStream {
-    let args = parse_macro_input!(attrs with PyClassArgs::parse_stuct_args);
+    let args = parse_macro_input!(attrs with PyClassArgs::parse_struct_args);
     let expanded = build_py_class(&mut ast, args, methods_type).unwrap_or_compile_error();
 
     quote!(


### PR DESCRIPTION
This PR fixes a misprint in `parse_stuct_args` fn name and also fixes Rust compiler warning about non snake case method names on macro generated methods like `__pymethod___setitem__`.