### PR TITLE
Move env! to env::var_os for buck determinism

### DIFF
--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -123,7 +123,7 @@ const HOST_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-con
 #[cfg(feature = "resolve-config")]
 fn resolve_cross_compile_config_path() -> Option<PathBuf> {
     env::var_os("TARGET").map(|target| {
-        let mut path = PathBuf::from(env!("OUT_DIR"));
+        let mut path = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR not set"));
         path.push(Path::new(&target));
         path.push("pyo3-build-config.txt");
         path


### PR DESCRIPTION
When building pyo3 with buck2 and remote execution, we're especially sensitive to deterministic builds and being able to compile different rust libraries on different hosts in parallel.

The issue with `resolve_cross_compile_config_path` was that we were embedding the full path of `OUT_DIR` into the compiled rlib and we are unable to guarantee the path is identical across all invocations of `rustc`. The other instances of `env!("OUT_DIR")` are no issue as they are used as part of the larger expression `include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config-file.txt"));` and we *are* able to guarantee that the contents of those files are deterministic.

By switching to `env::var_os("OUT_DIR")`, we are able to avoid embedding absolute paths into the compiled rust library and maintain backwards compatibility with the rest of the cargo ecosystem.