### PR TITLE
fix case of gil-refs feature breaking `create_exception!` macro

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -201,14 +201,6 @@ macro_rules! pyobject_native_type_named (
             }
         }
 
-        unsafe impl<$($generics,)*> $crate::AsPyPointer for $name {
-            /// Gets the underlying FFI pointer, returns a borrowed pointer.
-            #[inline]
-            fn as_ptr(&self) -> *mut $crate::ffi::PyObject {
-                self.0.as_ptr()
-            }
-        }
-
         impl $crate::types::DerefToPyAny for $name {}
     };
 );


### PR DESCRIPTION
***Note: this is a patch fix for 0.22.4, the PR is targeting that branch, not `main`.***

Fixes #4562 

The bug is that the macros to set up all the traits for native types expand to use `#[cfg(feature = "gil-refs")]` inside the expanded code, which doesn't work properly in downstream crates.

The solution is to split the macro definitions so that they have gil-refs and non-gil-refs versions.

I verified this works manually; I couldn't think of a good testing strategy for the bug in question besides making yet another test crate. For a patch fix it didn't seem worth it.