### PR TITLE
add more `IntoPyObject` impls

### DIFF
--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -1,13 +1,16 @@
 //! Contains types for working with Python objects that own the underlying data.
 
-use std::{ops::Deref, ptr::NonNull, sync::Arc};
+use std::{convert::Infallible, ops::Deref, ptr::NonNull, sync::Arc};
 
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
+    prelude::IntoPyObject,
     types::{
         any::PyAnyMethods, bytearray::PyByteArrayMethods, bytes::PyBytesMethods,
         string::PyStringMethods, PyByteArray, PyBytes, PyString,
     },
-    Bound, DowncastError, FromPyObject, IntoPy, Py, PyAny, PyErr, PyResult, Python, ToPyObject,
+    Bound, DowncastError, FromPyObject, IntoPy, Py, PyAny, PyErr, PyResult, Python,
 };
 
 /// A wrapper around `str` where the storage is owned by a Python `bytes` or `str` object.
@@ -61,7 +64,7 @@ impl TryFrom<Bound<'_, PyString>> for PyBackedStr {
             let s = py_string.to_str()?;
             let data = NonNull::from(s);
             Ok(Self {
-                storage: py_string.as_any().to_owned().unbind(),
+                storage: py_string.into_any().unbind(),
                 data,
             })
         }
@@ -85,10 +88,11 @@ impl FromPyObject<'_> for PyBackedStr {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for PyBackedStr {
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
-        self.storage.clone_ref(py)
+        self.storage.as_any().clone_ref(py)
     }
     #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
     fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
@@ -99,11 +103,43 @@ impl ToPyObject for PyBackedStr {
 impl IntoPy<Py<PyAny>> for PyBackedStr {
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
-        self.storage
+        self.storage.into_any()
     }
     #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
     fn into_py(self, py: Python<'_>) -> Py<PyAny> {
         PyString::new(py, &self).into_any().unbind()
+    }
+}
+
+impl<'py> IntoPyObject<'py> for PyBackedStr {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(self.storage.into_bound(py))
+    }
+
+    #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyString::new(py, &self).into_any())
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &PyBackedStr {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(self.storage.bind(py).to_owned())
+    }
+
+    #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PyString::new(py, self).into_any())
     }
 }
 
@@ -203,6 +239,7 @@ impl FromPyObject<'_> for PyBackedBytes {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for PyBackedBytes {
     fn to_object(&self, py: Python<'_>) -> Py<PyAny> {
         match &self.storage {
@@ -217,6 +254,32 @@ impl IntoPy<Py<PyAny>> for PyBackedBytes {
         match self.storage {
             PyBackedBytesStorage::Python(bytes) => bytes.into_any(),
             PyBackedBytesStorage::Rust(bytes) => PyBytes::new(py, &bytes).into_any().unbind(),
+        }
+    }
+}
+
+impl<'py> IntoPyObject<'py> for PyBackedBytes {
+    type Target = PyBytes;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self.storage {
+            PyBackedBytesStorage::Python(bytes) => Ok(bytes.into_bound(py)),
+            PyBackedBytesStorage::Rust(bytes) => Ok(PyBytes::new(py, &bytes)),
+        }
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &PyBackedBytes {
+    type Target = PyBytes;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match &self.storage {
+            PyBackedBytesStorage::Python(bytes) => Ok(bytes.bind(py).clone()),
+            PyBackedBytesStorage::Rust(bytes) => Ok(PyBytes::new(py, bytes)),
         }
     }
 }
@@ -297,6 +360,7 @@ use impl_traits;
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::prelude::IntoPyObject;
     use crate::Python;
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -329,12 +393,12 @@ mod test {
     }
 
     #[test]
-    fn py_backed_str_to_object() {
+    fn py_backed_str_into_pyobject() {
         Python::with_gil(|py| {
             let orig_str = PyString::new(py, "hello");
             let py_backed_str = orig_str.extract::<PyBackedStr>().unwrap();
-            let new_str = py_backed_str.to_object(py);
-            assert_eq!(new_str.extract::<PyBackedStr>(py).unwrap(), "hello");
+            let new_str = py_backed_str.into_pyobject(py).unwrap();
+            assert_eq!(new_str.extract::<PyBackedStr>().unwrap(), "hello");
             #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
             assert!(new_str.is(&orig_str));
         });
@@ -389,17 +453,20 @@ mod test {
     }
 
     #[test]
-    fn py_backed_bytes_into_py() {
+    fn py_backed_bytes_into_pyobject() {
         Python::with_gil(|py| {
             let orig_bytes = PyBytes::new(py, b"abcde");
             let py_backed_bytes = PyBackedBytes::from(orig_bytes.clone());
-            assert!(py_backed_bytes.to_object(py).is(&orig_bytes));
+            assert!((&py_backed_bytes)
+                .into_pyobject(py)
+                .unwrap()
+                .is(&orig_bytes));
             assert!(py_backed_bytes.into_py(py).is(&orig_bytes));
         });
     }
 
     #[test]
-    fn rust_backed_bytes_into_py() {
+    fn rust_backed_bytes_into_pyobject() {
         Python::with_gil(|py| {
             let orig_bytes = PyByteArray::new(py, b"abcde");
             let rust_backed_bytes = PyBackedBytes::from(orig_bytes);
@@ -407,7 +474,7 @@ mod test {
                 rust_backed_bytes.storage,
                 PyBackedBytesStorage::Rust(_)
             ));
-            let to_object = rust_backed_bytes.to_object(py).into_bound(py);
+            let to_object = (&rust_backed_bytes).into_pyobject(py).unwrap();
             assert!(&to_object.is_exact_instance_of::<PyBytes>());
             assert_eq!(&to_object.extract::<PyBackedBytes>().unwrap(), b"abcde");
             let into_py = rust_backed_bytes.into_py(py).into_bound(py);

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -1,8 +1,10 @@
 use crate::err::{PyErr, PyResult};
 use crate::ffi;
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::prelude::IntoPyObject;
 use crate::types::any::PyAnyMethods;
 use crate::{Bound, PyAny, PyObject, Python, ToPyObject};
+use std::convert::Infallible;
 
 /// Represents a Python `slice`.
 ///
@@ -136,6 +138,26 @@ impl<'py> PySliceMethods<'py> for Bound<'py, PySlice> {
 impl ToPyObject for PySliceIndices {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         PySlice::new(py, self.start, self.stop, self.step).into()
+    }
+}
+
+impl<'py> IntoPyObject<'py> for PySliceIndices {
+    type Target = PySlice;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PySlice::new(py, self.start, self.stop, self.step))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for &PySliceIndices {
+    type Target = PySlice;
+    type Output = Bound<'py, Self::Target>;
+    type Error = Infallible;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(PySlice::new(py, self.start, self.stop, self.step))
     }
 }
 

--- a/tests/ui/invalid_property_args.stderr
+++ b/tests/ui/invalid_property_args.stderr
@@ -55,14 +55,14 @@ error[E0277]: `PhantomData<i32>` cannot be converted to a Python object
    = help: the trait `IntoPyObject<'_>` is not implemented for `PhantomData<i32>`, which is required by `for<'py> PhantomData<i32>: PyO3GetField<'py>`
    = note: implement `IntoPyObject` for `&PhantomData<i32>` or `IntoPyObject + Clone` for `PhantomData<i32>` to define the conversion
    = help: the following other types implement trait `IntoPyObject<'py>`:
+             &&OsStr
+             &&Path
              &&str
              &'a (T0, T1)
              &'a (T0, T1, T2)
              &'a (T0, T1, T2, T3)
              &'a (T0, T1, T2, T3, T4)
              &'a (T0, T1, T2, T3, T4, T5)
-             &'a (T0, T1, T2, T3, T4, T5, T6)
-             &'a (T0, T1, T2, T3, T4, T5, T6, T7)
            and $N others
    = note: required for `PhantomData<i32>` to implement `for<'py> PyO3GetField<'py>`
 note: required by a bound in `PyClassGetterGenerator::<ClassT, FieldT, Offset, false, false, false, false, false>::generate`

--- a/tests/ui/missing_intopy.stderr
+++ b/tests/ui/missing_intopy.stderr
@@ -8,14 +8,14 @@ error[E0277]: `Blah` cannot be converted to a Python object
   = note: if you do not wish to have a corresponding Python type, implement it manually
   = note: if you do not own `Blah` you can perform a manual conversion to one of the types in `pyo3::types::*`
   = help: the following other types implement trait `IntoPyObject<'py>`:
+            &&OsStr
+            &&Path
             &&str
             &'a (T0, T1)
             &'a (T0, T1, T2)
             &'a (T0, T1, T2, T3)
             &'a (T0, T1, T2, T3, T4)
             &'a (T0, T1, T2, T3, T4, T5)
-            &'a (T0, T1, T2, T3, T4, T5, T6)
-            &'a (T0, T1, T2, T3, T4, T5, T6, T7)
           and $N others
 note: required by a bound in `UnknownReturnType::<T>::wrap`
  --> src/impl_/wrap.rs


### PR DESCRIPTION
While working through the deprecation of `ToPyObject` I noticed a few missing `IntoPyObject` impls.