### PR TITLE
deprecate `ToPyObject` in favor or `IntoPyObject`

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -412,10 +412,10 @@ impl SubSubClass {
         let base = PyClassInitializer::from(BaseClass::new());
         let sub = base.add_subclass(SubClass { val2: val });
         if val % 2 == 0 {
-            Ok(Py::new(py, sub)?.to_object(py))
+            Ok(Py::new(py, sub)?.into_any())
         } else {
             let sub_sub = sub.add_subclass(SubSubClass { val3: val });
-            Ok(Py::new(py, sub_sub)?.to_object(py))
+            Ok(Py::new(py, sub_sub)?.into_any())
         }
     }
 }

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -294,8 +294,8 @@ enum RustyEnum<'py> {
 # fn main() -> PyResult<()> {
 #     Python::with_gil(|py| -> PyResult<()> {
 #         {
-#             let thing = 42_u8.to_object(py);
-#             let rust_thing: RustyEnum<'_> = thing.extract(py)?;
+#             let thing = 42_u8.into_pyobject(py)?;
+#             let rust_thing: RustyEnum<'_> = thing.extract()?;
 #
 #             assert_eq!(
 #                 42,
@@ -318,8 +318,8 @@ enum RustyEnum<'py> {
 #             );
 #         }
 #         {
-#             let thing = (32_u8, 73_u8).to_object(py);
-#             let rust_thing: RustyEnum<'_> = thing.extract(py)?;
+#             let thing = (32_u8, 73_u8).into_pyobject(py)?;
+#             let rust_thing: RustyEnum<'_> = thing.extract()?;
 #
 #             assert_eq!(
 #                 (32, 73),
@@ -330,8 +330,8 @@ enum RustyEnum<'py> {
 #             );
 #         }
 #         {
-#             let thing = ("foo", 73_u8).to_object(py);
-#             let rust_thing: RustyEnum<'_> = thing.extract(py)?;
+#             let thing = ("foo", 73_u8).into_pyobject(py)?;
+#             let rust_thing: RustyEnum<'_> = thing.extract()?;
 #
 #             assert_eq!(
 #                 (String::from("foo"), 73),
@@ -427,8 +427,8 @@ enum RustyEnum {
 # fn main() -> PyResult<()> {
 #     Python::with_gil(|py| -> PyResult<()> {
 #         {
-#             let thing = 42_u8.to_object(py);
-#             let rust_thing: RustyEnum = thing.extract(py)?;
+#             let thing = 42_u8.into_pyobject(py)?;
+#             let rust_thing: RustyEnum = thing.extract()?;
 #
 #             assert_eq!(
 #                 42,
@@ -440,8 +440,8 @@ enum RustyEnum {
 #         }
 #
 #         {
-#             let thing = "foo".to_object(py);
-#             let rust_thing: RustyEnum = thing.extract(py)?;
+#             let thing = "foo".into_pyobject(py)?;
+#             let rust_thing: RustyEnum = thing.extract()?;
 #
 #             assert_eq!(
 #                 "foo",
@@ -453,8 +453,8 @@ enum RustyEnum {
 #         }
 #
 #         {
-#             let thing = b"foo".to_object(py);
-#             let error = thing.extract::<RustyEnum>(py).unwrap_err();
+#             let thing = b"foo".into_pyobject(py)?;
+#             let error = thing.extract::<RustyEnum>().unwrap_err();
 #             assert!(error.is_instance_of::<pyo3::exceptions::PyTypeError>(py));
 #         }
 #

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -157,7 +157,7 @@ need to adapt an implementation of `IntoPyObject` to stay compatible with the Py
 
 
 Before:
-```rust
+```rust,ignore
 # use pyo3::prelude::*;
 # #[allow(dead_code)]
 struct MyPyObjectWrapper(PyObject);

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -155,6 +155,9 @@ Notable features of this new trait:
 All PyO3 provided types as well as `#[pyclass]`es already implement `IntoPyObject`. Other types will
 need to adapt an implementation of `IntoPyObject` to stay compatible with the Python APIs.
 
+Together with the introduction of `IntoPyObject` the old conversion traits `ToPyObject` and `IntoPy`
+are deprecated and will be removed in a future PyO3 version.
+
 
 Before:
 ```rust,ignore

--- a/newsfragments/4595.changed.md
+++ b/newsfragments/4595.changed.md
@@ -1,0 +1,2 @@
+- `PyErr::matches` is now fallible due to `IntoPyObject` migration.
+- deprecate `ToPyObject` in favor of `IntoPyObject`

--- a/pytests/src/objstore.rs
+++ b/pytests/src/objstore.rs
@@ -13,8 +13,8 @@ impl ObjStore {
         ObjStore::default()
     }
 
-    fn push(&mut self, py: Python<'_>, obj: &Bound<'_, PyAny>) {
-        self.obj.push(obj.to_object(py));
+    fn push(&mut self, obj: &Bound<'_, PyAny>) {
+        self.obj.push(obj.clone().unbind());
     }
 }
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -66,7 +66,7 @@ pub unsafe trait AsPyPointer {
 /// Conversion trait that allows various objects to be converted into `PyObject`.
 #[deprecated(
     since = "0.23.0",
-    note = "`ToPyObject` is going to be replaced by `IntoPyObject`. See the migration guide for more information."
+    note = "`ToPyObject` is going to be replaced by `IntoPyObject`. See the migration guide (https://pyo3.rs/v0.23/migration) for more information."
 )]
 pub trait ToPyObject {
     /// Converts self into a Python object.

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -64,6 +64,10 @@ pub unsafe trait AsPyPointer {
 }
 
 /// Conversion trait that allows various objects to be converted into `PyObject`.
+#[deprecated(
+    since = "0.23.0",
+    note = "`ToPyObject` is going to be replaced by `IntoPyObject`. See the migration guide for more information."
+)]
 pub trait ToPyObject {
     /// Converts self into a Python object.
     fn to_object(&self, py: Python<'_>) -> PyObject;
@@ -548,6 +552,7 @@ where
 
 /// Identity conversion: allows using existing `PyObject` instances where
 /// `T: ToPyObject` is expected.
+#[allow(deprecated)]
 impl<T: ?Sized + ToPyObject> ToPyObject for &'_ T {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -20,23 +20,24 @@
 //!
 //! ```rust
 //! use chrono::{DateTime, Duration, TimeZone, Utc};
-//! use pyo3::{Python, ToPyObject};
+//! use pyo3::{Python, PyResult, conversion::IntoPyObject, types::PyAnyMethods};
 //!
-//! fn main() {
+//! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();
 //!     Python::with_gil(|py| {
 //!         // Build some chrono values
 //!         let chrono_datetime = Utc.with_ymd_and_hms(2022, 1, 1, 12, 0, 0).unwrap();
 //!         let chrono_duration = Duration::seconds(1);
 //!         // Convert them to Python
-//!         let py_datetime = chrono_datetime.to_object(py);
-//!         let py_timedelta = chrono_duration.to_object(py);
+//!         let py_datetime = chrono_datetime.into_pyobject(py)?;
+//!         let py_timedelta = chrono_duration.into_pyobject(py)?;
 //!         // Do an operation in Python
-//!         let py_sum = py_datetime.call_method1(py, "__add__", (py_timedelta,)).unwrap();
+//!         let py_sum = py_datetime.call_method1("__add__", (py_timedelta,))?;
 //!         // Convert back to Rust
-//!         let chrono_sum: DateTime<Utc> = py_sum.extract(py).unwrap();
+//!         let chrono_sum: DateTime<Utc> = py_sum.extract()?;
 //!         println!("DateTime<Utc>: {}", chrono_datetime);
-//!     });
+//!         Ok(())
+//!     })
 //! }
 //! ```
 
@@ -53,9 +54,9 @@ use crate::types::{
     timezone_utc, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess,
     PyTzInfo, PyTzInfoAccess,
 };
-use crate::{
-    ffi, Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
-};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{ffi, Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python};
 #[cfg(Py_LIMITED_API)]
 use crate::{intern, DowncastError};
 use chrono::offset::{FixedOffset, Utc};
@@ -63,6 +64,7 @@ use chrono::{
     DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike,
 };
 
+#[allow(deprecated)]
 impl ToPyObject for Duration {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -168,6 +170,7 @@ impl FromPyObject<'_> for Duration {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for NaiveDate {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -233,6 +236,7 @@ impl FromPyObject<'_> for NaiveDate {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for NaiveTime {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -308,6 +312,7 @@ impl FromPyObject<'_> for NaiveTime {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for NaiveDateTime {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -395,6 +400,7 @@ impl FromPyObject<'_> for NaiveDateTime {
     }
 }
 
+#[allow(deprecated)]
 impl<Tz: TimeZone> ToPyObject for DateTime<Tz> {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         // FIXME: convert to better timezone representation here than just convert to fixed offset
@@ -407,7 +413,7 @@ impl<Tz: TimeZone> ToPyObject for DateTime<Tz> {
 
 impl<Tz: TimeZone> IntoPy<PyObject> for DateTime<Tz> {
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -491,6 +497,7 @@ impl<Tz: TimeZone + for<'py> FromPyObject<'py>> FromPyObject<'_> for DateTime<Tz
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for FixedOffset {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -574,6 +581,7 @@ impl FromPyObject<'_> for FixedOffset {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for Utc {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -925,15 +933,15 @@ mod tests {
     }
 
     #[test]
-    fn test_pyo3_timedelta_topyobject() {
+    fn test_pyo3_timedelta_into_pyobject() {
         // Utility function used to check different durations.
         // The `name` parameter is used to identify the check in case of a failure.
         let check = |name: &'static str, delta: Duration, py_days, py_seconds, py_ms| {
             Python::with_gil(|py| {
-                let delta = delta.to_object(py);
+                let delta = delta.into_pyobject(py).unwrap();
                 let py_delta = new_py_datetime_ob(py, "timedelta", (py_days, py_seconds, py_ms));
                 assert!(
-                    delta.bind(py).eq(&py_delta).unwrap(),
+                    delta.eq(&py_delta).unwrap(),
                     "{}: {} != {}",
                     name,
                     delta,
@@ -954,10 +962,10 @@ mod tests {
         let delta = Duration::seconds(86399999999999) + Duration::nanoseconds(999999000); // max
         check("delta max value", delta, 999999999, 86399, 999999);
 
-        // Also check that trying to convert an out of bound value panics.
+        // Also check that trying to convert an out of bound value errors.
         Python::with_gil(|py| {
-            assert!(panic::catch_unwind(|| Duration::min_value().to_object(py)).is_err());
-            assert!(panic::catch_unwind(|| Duration::max_value().to_object(py)).is_err());
+            assert!(Duration::min_value().into_pyobject(py).is_err());
+            assert!(Duration::max_value().into_pyobject(py).is_err());
         });
     }
 
@@ -1021,15 +1029,16 @@ mod tests {
     }
 
     #[test]
-    fn test_pyo3_date_topyobject() {
+    fn test_pyo3_date_into_pyobject() {
         let eq_ymd = |name: &'static str, year, month, day| {
             Python::with_gil(|py| {
                 let date = NaiveDate::from_ymd_opt(year, month, day)
                     .unwrap()
-                    .to_object(py);
+                    .into_pyobject(py)
+                    .unwrap();
                 let py_date = new_py_datetime_ob(py, "date", (year, month, day));
                 assert_eq!(
-                    date.bind(py).compare(&py_date).unwrap(),
+                    date.compare(&py_date).unwrap(),
                     Ordering::Equal,
                     "{}: {} != {}",
                     name,
@@ -1063,7 +1072,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pyo3_datetime_topyobject_utc() {
+    fn test_pyo3_datetime_into_pyobject_utc() {
         Python::with_gil(|py| {
             let check_utc =
                 |name: &'static str, year, month, day, hour, minute, second, ms, py_ms| {
@@ -1072,7 +1081,7 @@ mod tests {
                         .and_hms_micro_opt(hour, minute, second, ms)
                         .unwrap()
                         .and_utc();
-                    let datetime = datetime.to_object(py);
+                    let datetime = datetime.into_pyobject(py).unwrap();
                     let py_datetime = new_py_datetime_ob(
                         py,
                         "datetime",
@@ -1088,7 +1097,7 @@ mod tests {
                         ),
                     );
                     assert_eq!(
-                        datetime.bind(py).compare(&py_datetime).unwrap(),
+                        datetime.compare(&py_datetime).unwrap(),
                         Ordering::Equal,
                         "{}: {} != {}",
                         name,
@@ -1112,7 +1121,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pyo3_datetime_topyobject_fixed_offset() {
+    fn test_pyo3_datetime_into_pyobject_fixed_offset() {
         Python::with_gil(|py| {
             let check_fixed_offset =
                 |name: &'static str, year, month, day, hour, minute, second, ms, py_ms| {
@@ -1123,15 +1132,15 @@ mod tests {
                         .unwrap()
                         .and_local_timezone(offset)
                         .unwrap();
-                    let datetime = datetime.to_object(py);
-                    let py_tz = offset.to_object(py);
+                    let datetime = datetime.into_pyobject(py).unwrap();
+                    let py_tz = offset.into_pyobject(py).unwrap();
                     let py_datetime = new_py_datetime_ob(
                         py,
                         "datetime",
                         (year, month, day, hour, minute, second, py_ms, py_tz),
                     );
                     assert_eq!(
-                        datetime.bind(py).compare(&py_datetime).unwrap(),
+                        datetime.compare(&py_datetime).unwrap(),
                         Ordering::Equal,
                         "{}: {} != {}",
                         name,
@@ -1191,7 +1200,7 @@ mod tests {
             let second = 9;
             let micro = 999_999;
             let offset = FixedOffset::east_opt(3600).unwrap();
-            let py_tz = offset.to_object(py);
+            let py_tz = offset.into_pyobject(py).unwrap();
             let py_datetime = new_py_datetime_ob(
                 py,
                 "datetime",
@@ -1224,21 +1233,27 @@ mod tests {
     }
 
     #[test]
-    fn test_pyo3_offset_fixed_topyobject() {
+    fn test_pyo3_offset_fixed_into_pyobject() {
         Python::with_gil(|py| {
             // Chrono offset
-            let offset = FixedOffset::east_opt(3600).unwrap().to_object(py);
+            let offset = FixedOffset::east_opt(3600)
+                .unwrap()
+                .into_pyobject(py)
+                .unwrap();
             // Python timezone from timedelta
             let td = new_py_datetime_ob(py, "timedelta", (0, 3600, 0));
             let py_timedelta = new_py_datetime_ob(py, "timezone", (td,));
             // Should be equal
-            assert!(offset.bind(py).eq(py_timedelta).unwrap());
+            assert!(offset.eq(py_timedelta).unwrap());
 
             // Same but with negative values
-            let offset = FixedOffset::east_opt(-3600).unwrap().to_object(py);
+            let offset = FixedOffset::east_opt(-3600)
+                .unwrap()
+                .into_pyobject(py)
+                .unwrap();
             let td = new_py_datetime_ob(py, "timedelta", (0, -3600, 0));
             let py_timedelta = new_py_datetime_ob(py, "timezone", (td,));
-            assert!(offset.bind(py).eq(py_timedelta).unwrap());
+            assert!(offset.eq(py_timedelta).unwrap());
         })
     }
 
@@ -1253,11 +1268,11 @@ mod tests {
     }
 
     #[test]
-    fn test_pyo3_offset_utc_topyobject() {
+    fn test_pyo3_offset_utc_into_pyobject() {
         Python::with_gil(|py| {
-            let utc = Utc.to_object(py);
+            let utc = Utc.into_pyobject(py).unwrap();
             let py_utc = python_utc(py);
-            assert!(utc.bind(py).is(&py_utc));
+            assert!(utc.is(&py_utc));
         })
     }
 
@@ -1280,15 +1295,16 @@ mod tests {
     }
 
     #[test]
-    fn test_pyo3_time_topyobject() {
+    fn test_pyo3_time_into_pyobject() {
         Python::with_gil(|py| {
             let check_time = |name: &'static str, hour, minute, second, ms, py_ms| {
                 let time = NaiveTime::from_hms_micro_opt(hour, minute, second, ms)
                     .unwrap()
-                    .to_object(py);
+                    .into_pyobject(py)
+                    .unwrap();
                 let py_time = new_py_datetime_ob(py, "time", (hour, minute, second, py_ms));
                 assert!(
-                    time.bind(py).eq(&py_time).unwrap(),
+                    time.eq(&py_time).unwrap(),
                     "{}: {} != {}",
                     name,
                     time,
@@ -1420,8 +1436,8 @@ mod tests {
                     // We use to `from_ymd_opt` constructor so that we only test valid `NaiveDate`s.
                     // This is to skip the test if we are creating an invalid date, like February 31.
                     if let Some(date) = NaiveDate::from_ymd_opt(year, month, day) {
-                        let py_date = date.to_object(py);
-                        let roundtripped: NaiveDate = py_date.extract(py).expect("Round trip");
+                        let py_date = date.into_pyobject(py).unwrap();
+                        let roundtripped: NaiveDate = py_date.extract().expect("Round trip");
                         assert_eq!(date, roundtripped);
                     }
                 })
@@ -1441,8 +1457,8 @@ mod tests {
                 Python::with_gil(|py| {
                     if let Some(time) = NaiveTime::from_hms_micro_opt(hour, min, sec, micro) {
                         // Wrap in CatchWarnings to avoid to_object firing warning for truncated leap second
-                        let py_time = CatchWarnings::enter(py, |_| Ok(time.to_object(py))).unwrap();
-                        let roundtripped: NaiveTime = py_time.extract(py).expect("Round trip");
+                        let py_time = CatchWarnings::enter(py, |_| time.into_pyobject(py)).unwrap();
+                        let roundtripped: NaiveTime = py_time.extract().expect("Round trip");
                         // Leap seconds are not roundtripped
                         let expected_roundtrip_time = micro.checked_sub(1_000_000).map(|micro| NaiveTime::from_hms_micro_opt(hour, min, sec, micro).unwrap()).unwrap_or(time);
                         assert_eq!(expected_roundtrip_time, roundtripped);
@@ -1465,8 +1481,8 @@ mod tests {
                     let time_opt = NaiveTime::from_hms_micro_opt(hour, min, sec, micro);
                     if let (Some(date), Some(time)) = (date_opt, time_opt) {
                         let dt = NaiveDateTime::new(date, time);
-                        let pydt = dt.to_object(py);
-                        let roundtripped: NaiveDateTime = pydt.extract(py).expect("Round trip");
+                        let pydt = dt.into_pyobject(py).unwrap();
+                        let roundtripped: NaiveDateTime = pydt.extract().expect("Round trip");
                         assert_eq!(dt, roundtripped);
                     }
                 })

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -20,7 +20,7 @@
 //!
 //! ```rust
 //! use chrono::{DateTime, Duration, TimeZone, Utc};
-//! use pyo3::{Python, PyResult, conversion::IntoPyObject, types::PyAnyMethods};
+//! use pyo3::{Python, PyResult, IntoPyObject, types::PyAnyMethods};
 //!
 //! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -21,7 +21,7 @@
 //!
 //! ```rust,no_run
 //! use chrono_tz::Tz;
-//! use pyo3::{Python, PyResult, conversion::IntoPyObject, types::PyAnyMethods};
+//! use pyo3::{Python, PyResult, IntoPyObject, types::PyAnyMethods};
 //!
 //! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -21,16 +21,17 @@
 //!
 //! ```rust,no_run
 //! use chrono_tz::Tz;
-//! use pyo3::{Python, ToPyObject};
+//! use pyo3::{Python, PyResult, conversion::IntoPyObject, types::PyAnyMethods};
 //!
-//! fn main() {
+//! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();
 //!     Python::with_gil(|py| {
 //!         // Convert to Python
-//!         let py_tzinfo = Tz::Europe__Paris.to_object(py);
+//!         let py_tzinfo = Tz::Europe__Paris.into_pyobject(py)?;
 //!         // Convert back to Rust
-//!         assert_eq!(py_tzinfo.extract::<Tz>(py).unwrap(), Tz::Europe__Paris);
-//!     });
+//!         assert_eq!(py_tzinfo.extract::<Tz>()?, Tz::Europe__Paris);
+//!         Ok(())
+//!     })
 //! }
 //! ```
 use crate::conversion::IntoPyObject;
@@ -38,12 +39,13 @@ use crate::exceptions::PyValueError;
 use crate::pybacked::PyBackedStr;
 use crate::sync::GILOnceCell;
 use crate::types::{any::PyAnyMethods, PyType};
-use crate::{
-    intern, Bound, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
-};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{intern, Bound, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python};
 use chrono_tz::Tz;
 use std::str::FromStr;
 
+#[allow(deprecated)]
 impl ToPyObject for Tz {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -112,19 +114,19 @@ mod tests {
     }
 
     #[test]
-    fn test_topyobject() {
+    fn test_into_pyobject() {
         Python::with_gil(|py| {
-            let assert_eq = |l: PyObject, r: Bound<'_, PyAny>| {
-                assert!(l.bind(py).eq(r).unwrap());
+            let assert_eq = |l: Bound<'_, PyAny>, r: Bound<'_, PyAny>| {
+                assert!(l.eq(r).unwrap());
             };
 
             assert_eq(
-                Tz::Europe__Paris.to_object(py),
+                Tz::Europe__Paris.into_pyobject(py).unwrap(),
                 new_zoneinfo(py, "Europe/Paris"),
             );
-            assert_eq(Tz::UTC.to_object(py), new_zoneinfo(py, "UTC"));
+            assert_eq(Tz::UTC.into_pyobject(py).unwrap(), new_zoneinfo(py, "UTC"));
             assert_eq(
-                Tz::Etc__GMTMinus5.to_object(py),
+                Tz::Etc__GMTMinus5.into_pyobject(py).unwrap(),
                 new_zoneinfo(py, "Etc/GMT-5"),
             );
         });

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -26,7 +26,7 @@
 //!
 //! ```rust
 //! use either::Either;
-//! use pyo3::{Python, PyResult, conversion::IntoPyObject, types::PyAnyMethods};
+//! use pyo3::{Python, PyResult, IntoPyObject, types::PyAnyMethods};
 //!
 //! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();
@@ -172,9 +172,8 @@ mod tests {
     use std::borrow::Cow;
 
     use crate::exceptions::PyTypeError;
-    use crate::Python;
+    use crate::{IntoPyObject, Python};
 
-    use crate::prelude::IntoPyObject;
     use crate::types::PyAnyMethods;
     use either::Either;
 

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -26,18 +26,19 @@
 //!
 //! ```rust
 //! use either::Either;
-//! use pyo3::{Python, ToPyObject};
+//! use pyo3::{Python, PyResult, conversion::IntoPyObject, types::PyAnyMethods};
 //!
-//! fn main() {
+//! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();
 //!     Python::with_gil(|py| {
 //!         // Create a string and an int in Python.
-//!         let py_str = "crab".to_object(py);
-//!         let py_int = 42.to_object(py);
+//!         let py_str = "crab".into_pyobject(py)?;
+//!         let py_int = 42i32.into_pyobject(py)?;
 //!         // Now convert it to an Either<i32, String>.
-//!         let either_str: Either<i32, String> = py_str.extract(py).unwrap();
-//!         let either_int: Either<i32, String> = py_int.extract(py).unwrap();
-//!     });
+//!         let either_str: Either<i32, String> = py_str.extract()?;
+//!         let either_int: Either<i32, String> = py_int.extract()?;
+//!         Ok(())
+//!     })
 //! }
 //! ```
 //!
@@ -45,9 +46,11 @@
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject, exceptions::PyTypeError, types::any::PyAnyMethods, Bound,
-    BoundObject, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    BoundObject, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
 };
 use either::Either;
 
@@ -119,6 +122,7 @@ where
 }
 
 #[cfg_attr(docsrs, doc(cfg(feature = "either")))]
+#[allow(deprecated)]
 impl<L, R> ToPyObject for Either<L, R>
 where
     L: ToPyObject,
@@ -168,8 +172,10 @@ mod tests {
     use std::borrow::Cow;
 
     use crate::exceptions::PyTypeError;
-    use crate::{Python, ToPyObject};
+    use crate::Python;
 
+    use crate::prelude::IntoPyObject;
+    use crate::types::PyAnyMethods;
     use either::Either;
 
     #[test]
@@ -180,30 +186,30 @@ mod tests {
 
         Python::with_gil(|py| {
             let l = E::Left(42);
-            let obj_l = l.to_object(py);
-            assert_eq!(obj_l.extract::<i32>(py).unwrap(), 42);
-            assert_eq!(obj_l.extract::<E>(py).unwrap(), l);
+            let obj_l = (&l).into_pyobject(py).unwrap();
+            assert_eq!(obj_l.extract::<i32>().unwrap(), 42);
+            assert_eq!(obj_l.extract::<E>().unwrap(), l);
 
             let r = E::Right("foo".to_owned());
-            let obj_r = r.to_object(py);
-            assert_eq!(obj_r.extract::<Cow<'_, str>>(py).unwrap(), "foo");
-            assert_eq!(obj_r.extract::<E>(py).unwrap(), r);
+            let obj_r = (&r).into_pyobject(py).unwrap();
+            assert_eq!(obj_r.extract::<Cow<'_, str>>().unwrap(), "foo");
+            assert_eq!(obj_r.extract::<E>().unwrap(), r);
 
-            let obj_s = "foo".to_object(py);
-            let err = obj_s.extract::<E1>(py).unwrap_err();
+            let obj_s = "foo".into_pyobject(py).unwrap();
+            let err = obj_s.extract::<E1>().unwrap_err();
             assert!(err.is_instance_of::<PyTypeError>(py));
             assert_eq!(
                 err.to_string(),
                 "TypeError: failed to convert the value to 'Union[i32, f32]'"
             );
 
-            let obj_i = 42.to_object(py);
-            assert_eq!(obj_i.extract::<E1>(py).unwrap(), E1::Left(42));
-            assert_eq!(obj_i.extract::<E2>(py).unwrap(), E2::Left(42.0));
+            let obj_i = 42i32.into_pyobject(py).unwrap();
+            assert_eq!(obj_i.extract::<E1>().unwrap(), E1::Left(42));
+            assert_eq!(obj_i.extract::<E2>().unwrap(), E2::Left(42.0));
 
-            let obj_f = 42.0.to_object(py);
-            assert_eq!(obj_f.extract::<E1>(py).unwrap(), E1::Right(42.0));
-            assert_eq!(obj_f.extract::<E2>(py).unwrap(), E2::Left(42.0));
+            let obj_f = 42.0f64.into_pyobject(py).unwrap();
+            assert_eq!(obj_f.extract::<E1>().unwrap(), E1::Right(42.0));
+            assert_eq!(obj_f.extract::<E2>().unwrap(), E2::Left(42.0));
         });
     }
 }

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -16,6 +16,8 @@
 //!
 //! Note that you must use compatible versions of hashbrown and PyO3.
 //! The required hashbrown version may vary based on the version of PyO3.
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     types::{
@@ -25,10 +27,11 @@ use crate::{
         set::{new_from_iter, try_new_from_iter, PySetMethods},
         PyDict, PyFrozenSet, PySet,
     },
-    Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
 };
 use std::{cmp, hash};
 
+#[allow(deprecated)]
 impl<K, V, H> ToPyObject for hashbrown::HashMap<K, V, H>
 where
     K: hash::Hash + cmp::Eq + ToPyObject,
@@ -113,6 +116,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> ToPyObject for hashbrown::HashSet<T>
 where
     T: hash::Hash + Eq + ToPyObject,
@@ -194,8 +198,7 @@ mod tests {
             let mut map = hashbrown::HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let m = map.to_object(py);
-            let py_map = m.downcast_bound::<PyDict>(py).unwrap();
+            let py_map = (&map).into_pyobject(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -89,9 +89,12 @@
 
 use crate::conversion::IntoPyObject;
 use crate::types::*;
-use crate::{Bound, FromPyObject, IntoPy, PyErr, PyObject, Python, ToPyObject};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{Bound, FromPyObject, IntoPy, PyErr, PyObject, Python};
 use std::{cmp, hash};
 
+#[allow(deprecated)]
 impl<K, V, H> ToPyObject for indexmap::IndexMap<K, V, H>
 where
     K: hash::Hash + cmp::Eq + ToPyObject,
@@ -179,8 +182,9 @@ where
 #[cfg(test)]
 mod test_indexmap {
 
+    use crate::prelude::IntoPyObject;
     use crate::types::*;
-    use crate::{IntoPy, PyObject, Python, ToPyObject};
+    use crate::{IntoPy, PyObject, Python};
 
     #[test]
     fn test_indexmap_indexmap_to_python() {
@@ -188,8 +192,7 @@ mod test_indexmap {
             let mut map = indexmap::IndexMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let m = map.to_object(py);
-            let py_map = m.downcast_bound::<PyDict>(py).unwrap();
+            let py_map = (&map).into_pyobject(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -182,9 +182,8 @@ where
 #[cfg(test)]
 mod test_indexmap {
 
-    use crate::prelude::IntoPyObject;
     use crate::types::*;
-    use crate::{IntoPy, PyObject, Python};
+    use crate::{IntoPy, IntoPyObject, PyObject, Python};
 
     #[test]
     fn test_indexmap_indexmap_to_python() {

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -219,9 +219,9 @@ complex_conversion!(f64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::IntoPyObject;
     use crate::tests::common::generate_unique_module_name;
     use crate::types::{complex::PyComplexMethods, PyModule};
+    use crate::IntoPyObject;
     use pyo3_ffi::c_str;
 
     #[test]

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -93,11 +93,13 @@
 //! result = get_eigenvalues(m11,m12,m21,m22)
 //! assert result == [complex(1,-1), complex(-2,0)]
 //! ```
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     ffi,
     ffi_ptr_ext::FfiPtrExt,
     types::{any::PyAnyMethods, PyComplex},
-    Bound, FromPyObject, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    Bound, FromPyObject, PyAny, PyErr, PyObject, PyResult, Python,
 };
 use num_complex::Complex;
 use std::os::raw::c_double;
@@ -119,6 +121,7 @@ impl PyComplex {
 macro_rules! complex_conversion {
     ($float: ty) => {
         #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
+        #[allow(deprecated)]
         impl ToPyObject for Complex<$float> {
             #[inline]
             fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -216,6 +219,7 @@ complex_conversion!(f64);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::prelude::IntoPyObject;
     use crate::tests::common::generate_unique_module_name;
     use crate::types::{complex::PyComplexMethods, PyModule};
     use pyo3_ffi::c_str;
@@ -232,16 +236,16 @@ mod tests {
     #[test]
     fn to_from_complex() {
         Python::with_gil(|py| {
-            let val = Complex::new(3.0, 1.2);
-            let obj = val.to_object(py);
-            assert_eq!(obj.extract::<Complex<f64>>(py).unwrap(), val);
+            let val = Complex::new(3.0f64, 1.2);
+            let obj = val.into_pyobject(py).unwrap();
+            assert_eq!(obj.extract::<Complex<f64>>().unwrap(), val);
         });
     }
     #[test]
     fn from_complex_err() {
         Python::with_gil(|py| {
-            let obj = vec![1].to_object(py);
-            assert!(obj.extract::<Complex<f64>>(py).is_err());
+            let obj = vec![1i32].into_pyobject(py).unwrap();
+            assert!(obj.extract::<Complex<f64>>().is_err());
         });
     }
     #[test]

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -48,9 +48,9 @@ use crate::ffi;
 use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
-use crate::{
-    Bound, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
-};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{Bound, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python};
 
 #[cfg(feature = "num-bigint")]
 use num_bigint::BigInt;
@@ -84,6 +84,7 @@ macro_rules! rational_conversion {
             }
         }
 
+        #[allow(deprecated)]
         impl ToPyObject for Ratio<$int> {
             #[inline]
             fn to_object(&self, py: Python<'_>) -> PyObject {

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -55,9 +55,9 @@ use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::string::PyStringMethods;
 use crate::types::PyType;
-use crate::{
-    Bound, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
-};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{Bound, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python};
 use rust_decimal::Decimal;
 use std::str::FromStr;
 
@@ -82,6 +82,7 @@ fn get_decimal_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
     DECIMAL_CLS.import(py, "decimal", "Decimal")
 }
 
+#[allow(deprecated)]
 impl ToPyObject for Decimal {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -23,12 +23,14 @@ use crate::types::any::PyAnyMethods;
 use crate::types::list::new_from_iter;
 use crate::types::{PySequence, PyString};
 use crate::PyErr;
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     err::DowncastError, ffi, Bound, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python,
-    ToPyObject,
 };
 use smallvec::{Array, SmallVec};
 
+#[allow(deprecated)]
 impl<A> ToPyObject for SmallVec<A>
 where
     A: Array,
@@ -167,10 +169,10 @@ mod tests {
     }
 
     #[test]
-    fn test_smallvec_to_object() {
+    fn test_smallvec_into_pyobject() {
         Python::with_gil(|py| {
             let sv: SmallVec<[u64; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();
-            let hso: PyObject = sv.to_object(py);
+            let hso = sv.into_pyobject(py).unwrap();
             let l = PyList::new(py, [1, 2, 3, 4, 5]).unwrap();
             assert!(l.eq(hso).unwrap());
         });

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -2,10 +2,9 @@ use crate::conversion::IntoPyObject;
 use crate::instance::Bound;
 use crate::types::any::PyAnyMethods;
 use crate::types::PySequence;
-use crate::{
-    err::DowncastError, ffi, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python,
-    ToPyObject,
-};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{err::DowncastError, ffi, FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python};
 use crate::{exceptions, PyErr};
 
 impl<T, const N: usize> IntoPy<PyObject> for [T; N]
@@ -69,6 +68,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T, const N: usize> ToPyObject for [T; N]
 where
     T: ToPyObject,
@@ -168,7 +168,7 @@ mod tests {
         ffi,
         types::{any::PyAnyMethods, PyBytes, PyBytesMethods},
     };
-    use crate::{types::PyList, IntoPy, PyResult, Python, ToPyObject};
+    use crate::{types::PyList, IntoPy, PyResult, Python};
 
     #[test]
     fn array_try_from_fn() {
@@ -219,11 +219,11 @@ mod tests {
         });
     }
     #[test]
-    fn test_topyobject_array_conversion() {
+    fn test_into_pyobject_array_conversion() {
         Python::with_gil(|py| {
             let array: [f32; 4] = [0.0, -16.0, 16.0, 42.0];
-            let pyobject = array.to_object(py);
-            let pylist = pyobject.downcast_bound::<PyList>(py).unwrap();
+            let pyobject = array.into_pyobject(py).unwrap();
+            let pylist = pyobject.downcast::<PyList>().unwrap();
             assert_eq!(pylist.get_item(0).unwrap().extract::<f32>().unwrap(), 0.0);
             assert_eq!(pylist.get_item(1).unwrap().extract::<f32>().unwrap(), -16.0);
             assert_eq!(pylist.get_item(2).unwrap().extract::<f32>().unwrap(), 16.0);

--- a/src/conversions/std/cell.rs
+++ b/src/conversions/std/cell.rs
@@ -2,10 +2,11 @@ use std::cell::Cell;
 
 use crate::{
     conversion::IntoPyObject, types::any::PyAnyMethods, Bound, FromPyObject, IntoPy, PyAny,
-    PyObject, PyResult, Python, ToPyObject,
+    PyObject, PyResult, Python,
 };
 
-impl<T: Copy + ToPyObject> ToPyObject for Cell<T> {
+#[allow(deprecated)]
+impl<T: Copy + crate::ToPyObject> crate::ToPyObject for Cell<T> {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         self.get().to_object(py)
     }

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -7,9 +7,9 @@ use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::string::PyStringMethods;
 use crate::types::PyType;
-use crate::{
-    intern, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
-};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{intern, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python};
 
 impl FromPyObject<'_> for IpAddr {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
@@ -31,6 +31,7 @@ impl FromPyObject<'_> for IpAddr {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for Ipv4Addr {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -62,6 +63,7 @@ impl<'py> IntoPyObject<'py> for &Ipv4Addr {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for Ipv6Addr {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -93,6 +95,7 @@ impl<'py> IntoPyObject<'py> for &Ipv6Addr {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for IpAddr {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -168,11 +171,11 @@ mod test_ipaddr {
     fn test_from_pystring() {
         Python::with_gil(|py| {
             let py_str = PyString::new(py, "0:0:0:0:0:0:0:1");
-            let ip: IpAddr = py_str.to_object(py).extract(py).unwrap();
+            let ip: IpAddr = py_str.extract().unwrap();
             assert_eq!(ip, IpAddr::from_str("::1").unwrap());
 
             let py_str = PyString::new(py, "invalid");
-            assert!(py_str.to_object(py).extract::<IpAddr>(py).is_err());
+            assert!(py_str.extract::<IpAddr>().is_err());
         });
     }
 }

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -2,13 +2,16 @@ use std::{cmp, collections, hash};
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     instance::Bound,
     types::{any::PyAnyMethods, dict::PyDictMethods, PyDict},
-    FromPyObject, IntoPy, PyAny, PyErr, PyObject, Python, ToPyObject,
+    FromPyObject, IntoPy, PyAny, PyErr, PyObject, Python,
 };
 
+#[allow(deprecated)]
 impl<K, V, H> ToPyObject for collections::HashMap<K, V, H>
 where
     K: hash::Hash + cmp::Eq + ToPyObject,
@@ -24,6 +27,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<K, V> ToPyObject for collections::BTreeMap<K, V>
 where
     K: cmp::Eq + ToPyObject,
@@ -203,8 +207,7 @@ mod tests {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let m = map.to_object(py);
-            let py_map = m.downcast_bound::<PyDict>(py).unwrap();
+            let py_map = (&map).into_pyobject(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(
@@ -226,8 +229,7 @@ mod tests {
             let mut map = BTreeMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let m = map.to_object(py);
-            let py_map = m.downcast_bound::<PyDict>(py).unwrap();
+            let py_map = (&map).into_pyobject(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -5,9 +5,10 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::inspect::types::TypeInfo;
 use crate::types::any::PyAnyMethods;
 use crate::types::{PyBytes, PyInt};
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     exceptions, ffi, Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
-    ToPyObject,
 };
 use std::convert::Infallible;
 use std::num::{
@@ -18,6 +19,7 @@ use std::os::raw::c_long;
 
 macro_rules! int_fits_larger_int {
     ($rust_type:ty, $larger_type:ty) => {
+        #[allow(deprecated)]
         impl ToPyObject for $rust_type {
             #[inline]
             fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -98,6 +100,7 @@ macro_rules! extract_int {
 
 macro_rules! int_convert_u64_or_i64 {
     ($rust_type:ty, $pylong_from_ll_or_ull:expr, $pylong_as_ll_or_ull:expr, $force_index_call:literal) => {
+        #[allow(deprecated)]
         impl ToPyObject for $rust_type {
             #[inline]
             fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -153,6 +156,7 @@ macro_rules! int_convert_u64_or_i64 {
 
 macro_rules! int_fits_c_long {
     ($rust_type:ty) => {
+        #[allow(deprecated)]
         impl ToPyObject for $rust_type {
             #[inline]
             fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -211,6 +215,7 @@ macro_rules! int_fits_c_long {
     };
 }
 
+#[allow(deprecated)]
 impl ToPyObject for u8 {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -328,6 +333,7 @@ mod fast_128bit_int_conversion {
     // for 128bit Integers
     macro_rules! int_convert_128 {
         ($rust_type: ty, $is_signed: literal) => {
+            #[allow(deprecated)]
             impl ToPyObject for $rust_type {
                 #[inline]
                 fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -474,6 +480,7 @@ mod slow_128bit_int_conversion {
     // for 128bit Integers
     macro_rules! int_convert_128 {
         ($rust_type: ty, $half_type: ty) => {
+            #[allow(deprecated)]
             impl ToPyObject for $rust_type {
                 #[inline]
                 fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -571,6 +578,7 @@ fn err_if_invalid_value<T: PartialEq>(
 
 macro_rules! nonzero_int_impl {
     ($nonzero_type:ty, $primitive_type:ty) => {
+        #[allow(deprecated)]
         impl ToPyObject for $nonzero_type {
             #[inline]
             fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -717,10 +725,10 @@ mod test_128bit_integers {
     fn test_i128_max() {
         Python::with_gil(|py| {
             let v = i128::MAX;
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<i128>(py).unwrap());
-            assert_eq!(v as u128, obj.extract::<u128>(py).unwrap());
-            assert!(obj.extract::<u64>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<i128>().unwrap());
+            assert_eq!(v as u128, obj.extract::<u128>().unwrap());
+            assert!(obj.extract::<u64>().is_err());
         })
     }
 
@@ -728,10 +736,10 @@ mod test_128bit_integers {
     fn test_i128_min() {
         Python::with_gil(|py| {
             let v = i128::MIN;
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<i128>(py).unwrap());
-            assert!(obj.extract::<i64>(py).is_err());
-            assert!(obj.extract::<u128>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<i128>().unwrap());
+            assert!(obj.extract::<i64>().is_err());
+            assert!(obj.extract::<u128>().is_err());
         })
     }
 
@@ -739,9 +747,9 @@ mod test_128bit_integers {
     fn test_u128_max() {
         Python::with_gil(|py| {
             let v = u128::MAX;
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<u128>(py).unwrap());
-            assert!(obj.extract::<i128>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<u128>().unwrap());
+            assert!(obj.extract::<i128>().is_err());
         })
     }
 
@@ -767,13 +775,13 @@ mod test_128bit_integers {
     fn test_nonzero_i128_max() {
         Python::with_gil(|py| {
             let v = NonZeroI128::new(i128::MAX).unwrap();
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<NonZeroI128>(py).unwrap());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<NonZeroI128>().unwrap());
             assert_eq!(
                 NonZeroU128::new(v.get() as u128).unwrap(),
-                obj.extract::<NonZeroU128>(py).unwrap()
+                obj.extract::<NonZeroU128>().unwrap()
             );
-            assert!(obj.extract::<NonZeroU64>(py).is_err());
+            assert!(obj.extract::<NonZeroU64>().is_err());
         })
     }
 
@@ -781,10 +789,10 @@ mod test_128bit_integers {
     fn test_nonzero_i128_min() {
         Python::with_gil(|py| {
             let v = NonZeroI128::new(i128::MIN).unwrap();
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<NonZeroI128>(py).unwrap());
-            assert!(obj.extract::<NonZeroI64>(py).is_err());
-            assert!(obj.extract::<NonZeroU128>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<NonZeroI128>().unwrap());
+            assert!(obj.extract::<NonZeroI64>().is_err());
+            assert!(obj.extract::<NonZeroU128>().is_err());
         })
     }
 
@@ -792,9 +800,9 @@ mod test_128bit_integers {
     fn test_nonzero_u128_max() {
         Python::with_gil(|py| {
             let v = NonZeroU128::new(u128::MAX).unwrap();
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<NonZeroU128>(py).unwrap());
-            assert!(obj.extract::<NonZeroI128>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<NonZeroU128>().unwrap());
+            assert!(obj.extract::<NonZeroI128>().is_err());
         })
     }
 
@@ -837,18 +845,19 @@ mod test_128bit_integers {
 
 #[cfg(test)]
 mod tests {
+    use crate::prelude::IntoPyObject;
+    use crate::types::PyAnyMethods;
     use crate::Python;
-    use crate::ToPyObject;
     use std::num::*;
 
     #[test]
     fn test_u32_max() {
         Python::with_gil(|py| {
             let v = u32::MAX;
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<u32>(py).unwrap());
-            assert_eq!(u64::from(v), obj.extract::<u64>(py).unwrap());
-            assert!(obj.extract::<i32>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<u32>().unwrap());
+            assert_eq!(u64::from(v), obj.extract::<u64>().unwrap());
+            assert!(obj.extract::<i32>().is_err());
         });
     }
 
@@ -856,10 +865,10 @@ mod tests {
     fn test_i64_max() {
         Python::with_gil(|py| {
             let v = i64::MAX;
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<i64>(py).unwrap());
-            assert_eq!(v as u64, obj.extract::<u64>(py).unwrap());
-            assert!(obj.extract::<u32>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<i64>().unwrap());
+            assert_eq!(v as u64, obj.extract::<u64>().unwrap());
+            assert!(obj.extract::<u32>().is_err());
         });
     }
 
@@ -867,10 +876,10 @@ mod tests {
     fn test_i64_min() {
         Python::with_gil(|py| {
             let v = i64::MIN;
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<i64>(py).unwrap());
-            assert!(obj.extract::<i32>(py).is_err());
-            assert!(obj.extract::<u64>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<i64>().unwrap());
+            assert!(obj.extract::<i32>().is_err());
+            assert!(obj.extract::<u64>().is_err());
         });
     }
 
@@ -878,9 +887,9 @@ mod tests {
     fn test_u64_max() {
         Python::with_gil(|py| {
             let v = u64::MAX;
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<u64>(py).unwrap());
-            assert!(obj.extract::<i64>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<u64>().unwrap());
+            assert!(obj.extract::<i64>().is_err());
         });
     }
 
@@ -888,14 +897,15 @@ mod tests {
         ($test_mod_name:ident, $t:ty) => (
             mod $test_mod_name {
                 use crate::exceptions;
-                use crate::ToPyObject;
+                use crate::conversion::IntoPyObject;
+                use crate::types::PyAnyMethods;
                 use crate::Python;
 
                 #[test]
                 fn from_py_string_type_error() {
                     Python::with_gil(|py| {
-                    let obj = ("123").to_object(py);
-                    let err = obj.extract::<$t>(py).unwrap_err();
+                    let obj = ("123").into_pyobject(py).unwrap();
+                    let err = obj.extract::<$t>().unwrap_err();
                     assert!(err.is_instance_of::<exceptions::PyTypeError>(py));
                     });
                 }
@@ -903,8 +913,8 @@ mod tests {
                 #[test]
                 fn from_py_float_type_error() {
                     Python::with_gil(|py| {
-                    let obj = (12.3).to_object(py);
-                    let err = obj.extract::<$t>(py).unwrap_err();
+                    let obj = (12.3f64).into_pyobject(py).unwrap();
+                    let err = obj.extract::<$t>().unwrap_err();
                     assert!(err.is_instance_of::<exceptions::PyTypeError>(py));});
                 }
 
@@ -912,8 +922,8 @@ mod tests {
                 fn to_py_object_and_back() {
                     Python::with_gil(|py| {
                     let val = 123 as $t;
-                    let obj = val.to_object(py);
-                    assert_eq!(obj.extract::<$t>(py).unwrap(), val as $t);});
+                    let obj = val.into_pyobject(py).unwrap();
+                    assert_eq!(obj.extract::<$t>().unwrap(), val as $t);});
                 }
             }
         )
@@ -936,10 +946,10 @@ mod tests {
     fn test_nonzero_u32_max() {
         Python::with_gil(|py| {
             let v = NonZeroU32::new(u32::MAX).unwrap();
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<NonZeroU32>(py).unwrap());
-            assert_eq!(NonZeroU64::from(v), obj.extract::<NonZeroU64>(py).unwrap());
-            assert!(obj.extract::<NonZeroI32>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<NonZeroU32>().unwrap());
+            assert_eq!(NonZeroU64::from(v), obj.extract::<NonZeroU64>().unwrap());
+            assert!(obj.extract::<NonZeroI32>().is_err());
         });
     }
 
@@ -947,13 +957,13 @@ mod tests {
     fn test_nonzero_i64_max() {
         Python::with_gil(|py| {
             let v = NonZeroI64::new(i64::MAX).unwrap();
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<NonZeroI64>(py).unwrap());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<NonZeroI64>().unwrap());
             assert_eq!(
                 NonZeroU64::new(v.get() as u64).unwrap(),
-                obj.extract::<NonZeroU64>(py).unwrap()
+                obj.extract::<NonZeroU64>().unwrap()
             );
-            assert!(obj.extract::<NonZeroU32>(py).is_err());
+            assert!(obj.extract::<NonZeroU32>().is_err());
         });
     }
 
@@ -961,10 +971,10 @@ mod tests {
     fn test_nonzero_i64_min() {
         Python::with_gil(|py| {
             let v = NonZeroI64::new(i64::MIN).unwrap();
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<NonZeroI64>(py).unwrap());
-            assert!(obj.extract::<NonZeroI32>(py).is_err());
-            assert!(obj.extract::<NonZeroU64>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<NonZeroI64>().unwrap());
+            assert!(obj.extract::<NonZeroI32>().is_err());
+            assert!(obj.extract::<NonZeroU64>().is_err());
         });
     }
 
@@ -972,9 +982,9 @@ mod tests {
     fn test_nonzero_u64_max() {
         Python::with_gil(|py| {
             let v = NonZeroU64::new(u64::MAX).unwrap();
-            let obj = v.to_object(py);
-            assert_eq!(v, obj.extract::<NonZeroU64>(py).unwrap());
-            assert!(obj.extract::<NonZeroI64>(py).is_err());
+            let obj = v.into_pyobject(py).unwrap();
+            assert_eq!(v, obj.extract::<NonZeroU64>().unwrap());
+            assert!(obj.extract::<NonZeroI64>().is_err());
         });
     }
 
@@ -982,15 +992,16 @@ mod tests {
         ($test_mod_name:ident, $t:ty) => (
             mod $test_mod_name {
                 use crate::exceptions;
-                use crate::ToPyObject;
+                use crate::conversion::IntoPyObject;
+                use crate::types::PyAnyMethods;
                 use crate::Python;
                 use std::num::*;
 
                 #[test]
                 fn from_py_string_type_error() {
                     Python::with_gil(|py| {
-                    let obj = ("123").to_object(py);
-                    let err = obj.extract::<$t>(py).unwrap_err();
+                    let obj = ("123").into_pyobject(py).unwrap();
+                    let err = obj.extract::<$t>().unwrap_err();
                     assert!(err.is_instance_of::<exceptions::PyTypeError>(py));
                     });
                 }
@@ -998,8 +1009,8 @@ mod tests {
                 #[test]
                 fn from_py_float_type_error() {
                     Python::with_gil(|py| {
-                    let obj = (12.3).to_object(py);
-                    let err = obj.extract::<$t>(py).unwrap_err();
+                    let obj = (12.3f64).into_pyobject(py).unwrap();
+                    let err = obj.extract::<$t>().unwrap_err();
                     assert!(err.is_instance_of::<exceptions::PyTypeError>(py));});
                 }
 
@@ -1007,8 +1018,8 @@ mod tests {
                 fn to_py_object_and_back() {
                     Python::with_gil(|py| {
                     let val = <$t>::new(123).unwrap();
-                    let obj = val.to_object(py);
-                    assert_eq!(obj.extract::<$t>(py).unwrap(), val);});
+                    let obj = val.into_pyobject(py).unwrap();
+                    assert_eq!(obj.extract::<$t>().unwrap(), val);});
                 }
             }
         )
@@ -1030,22 +1041,22 @@ mod tests {
     #[test]
     fn test_i64_bool() {
         Python::with_gil(|py| {
-            let obj = true.to_object(py);
-            assert_eq!(1, obj.extract::<i64>(py).unwrap());
-            let obj = false.to_object(py);
-            assert_eq!(0, obj.extract::<i64>(py).unwrap());
+            let obj = true.into_pyobject(py).unwrap();
+            assert_eq!(1, obj.extract::<i64>().unwrap());
+            let obj = false.into_pyobject(py).unwrap();
+            assert_eq!(0, obj.extract::<i64>().unwrap());
         })
     }
 
     #[test]
     fn test_i64_f64() {
         Python::with_gil(|py| {
-            let obj = 12.34f64.to_object(py);
-            let err = obj.extract::<i64>(py).unwrap_err();
+            let obj = 12.34f64.into_pyobject(py).unwrap();
+            let err = obj.extract::<i64>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyTypeError>(py));
             // with no remainder
-            let obj = 12f64.to_object(py);
-            let err = obj.extract::<i64>(py).unwrap_err();
+            let obj = 12f64.into_pyobject(py).unwrap();
+            let err = obj.extract::<i64>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyTypeError>(py));
         })
     }

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -845,9 +845,8 @@ mod test_128bit_integers {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::IntoPyObject;
     use crate::types::PyAnyMethods;
-    use crate::Python;
+    use crate::{IntoPyObject, Python};
     use std::num::*;
 
     #[test]

--- a/src/conversions/std/option.rs
+++ b/src/conversions/std/option.rs
@@ -1,13 +1,14 @@
 use crate::{
     conversion::IntoPyObject, ffi, types::any::PyAnyMethods, AsPyPointer, Bound, BoundObject,
-    FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject,
+    FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python,
 };
 
 /// `Option::Some<T>` is converted like `T`.
 /// `Option::None` is converted to Python `None`.
-impl<T> ToPyObject for Option<T>
+#[allow(deprecated)]
+impl<T> crate::ToPyObject for Option<T>
 where
-    T: ToPyObject,
+    T: crate::ToPyObject,
 {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         self.as_ref()

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -224,10 +224,8 @@ impl<'py> IntoPyObject<'py> for &OsString {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::IntoPyObject;
-    use crate::types::{PyAnyMethods, PyStringMethods};
-    use crate::BoundObject;
-    use crate::{types::PyString, IntoPy, PyObject, Python};
+    use crate::types::{PyAnyMethods, PyString, PyStringMethods};
+    use crate::{BoundObject, IntoPy, IntoPyObject, PyObject, Python};
     use std::fmt::Debug;
     use std::{
         borrow::Cow,

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -3,11 +3,14 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Bound;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyString;
-use crate::{ffi, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{ffi, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python};
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::ffi::{OsStr, OsString};
 
+#[allow(deprecated)]
 impl ToPyObject for OsStr {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -138,6 +141,7 @@ impl IntoPy<PyObject> for &'_ OsStr {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for Cow<'_, OsStr> {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -174,6 +178,7 @@ impl<'py> IntoPyObject<'py> for &Cow<'_, OsStr> {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for OsString {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -141,10 +141,8 @@ impl<'py> IntoPyObject<'py> for &PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::IntoPyObject;
-    use crate::types::{PyAnyMethods, PyStringMethods};
-    use crate::BoundObject;
-    use crate::{types::PyString, IntoPy, PyObject, Python};
+    use crate::types::{PyAnyMethods, PyString, PyStringMethods};
+    use crate::{BoundObject, IntoPy, IntoPyObject, PyObject, Python};
     use std::borrow::Cow;
     use std::fmt::Debug;
     use std::path::{Path, PathBuf};

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -3,12 +3,15 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Bound;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyString;
-use crate::{ffi, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python, ToPyObject};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{ffi, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python};
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
+#[allow(deprecated)]
 impl ToPyObject for Path {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -55,6 +58,7 @@ impl<'py> IntoPyObject<'py> for &&Path {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for Cow<'_, Path> {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -91,6 +95,7 @@ impl<'py> IntoPyObject<'py> for &Cow<'_, Path> {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for PathBuf {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -2,6 +2,8 @@ use std::{cmp, collections, hash};
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     instance::Bound,
@@ -11,9 +13,10 @@ use crate::{
         set::{new_from_iter, try_new_from_iter, PySetMethods},
         PyFrozenSet, PySet,
     },
-    FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python, ToPyObject,
+    FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
 };
 
+#[allow(deprecated)]
 impl<T, S> ToPyObject for collections::HashSet<T, S>
 where
     T: hash::Hash + Eq + ToPyObject,
@@ -26,6 +29,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> ToPyObject for collections::BTreeSet<T>
 where
     T: hash::Hash + Eq + ToPyObject,
@@ -173,8 +177,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::prelude::IntoPyObject;
     use crate::types::{any::PyAnyMethods, PyFrozenSet, PySet};
-    use crate::{IntoPy, PyObject, Python, ToPyObject};
+    use crate::{IntoPy, PyObject, Python};
     use std::collections::{BTreeSet, HashSet};
 
     #[test]
@@ -218,16 +223,16 @@ mod tests {
     }
 
     #[test]
-    fn test_set_to_object() {
+    fn test_set_into_pyobject() {
         Python::with_gil(|py| {
             let bt: BTreeSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();
             let hs: HashSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();
 
-            let bto: PyObject = bt.to_object(py);
-            let hso: PyObject = hs.to_object(py);
+            let bto = (&bt).into_pyobject(py).unwrap();
+            let hso = (&hs).into_pyobject(py).unwrap();
 
-            assert_eq!(bt, bto.extract(py).unwrap());
-            assert_eq!(hs, hso.extract(py).unwrap());
+            assert_eq!(bt, bto.extract().unwrap());
+            assert_eq!(hs, hso.extract().unwrap());
         });
     }
 }

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -177,9 +177,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::IntoPyObject;
     use crate::types::{any::PyAnyMethods, PyFrozenSet, PySet};
-    use crate::{IntoPy, PyObject, Python};
+    use crate::{IntoPy, IntoPyObject, PyObject, Python};
     use std::collections::{BTreeSet, HashSet};
 
     #[test]

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -2,15 +2,18 @@ use std::{borrow::Cow, convert::Infallible};
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     instance::Bound,
     types::{any::PyAnyMethods, string::PyStringMethods, PyString},
-    FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python, ToPyObject,
+    FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python,
 };
 
 /// Converts a Rust `str` to a Python object.
 /// See `PyString::new` for details on the conversion.
+#[allow(deprecated)]
 impl ToPyObject for str {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -66,6 +69,7 @@ impl<'py> IntoPyObject<'py> for &&str {
 
 /// Converts a Rust `Cow<'_, str>` to a Python object.
 /// See `PyString::new` for details on the conversion.
+#[allow(deprecated)]
 impl ToPyObject for Cow<'_, str> {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -109,6 +113,7 @@ impl<'py> IntoPyObject<'py> for &Cow<'_, str> {
 
 /// Converts a Rust `String` to a Python object.
 /// See `PyString::new` for details on the conversion.
+#[allow(deprecated)]
 impl ToPyObject for String {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -116,6 +121,7 @@ impl ToPyObject for String {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for char {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -259,9 +265,10 @@ impl FromPyObject<'_> for char {
 
 #[cfg(test)]
 mod tests {
+    use crate::prelude::IntoPyObject;
     use crate::types::any::PyAnyMethods;
     use crate::Python;
-    use crate::{IntoPy, PyObject, ToPyObject};
+    use crate::{IntoPy, PyObject};
     use std::borrow::Cow;
 
     #[test]
@@ -276,13 +283,13 @@ mod tests {
     }
 
     #[test]
-    fn test_cow_to_object() {
+    fn test_cow_into_pyobject() {
         Python::with_gil(|py| {
             let s = "Hello Python";
-            let py_string = Cow::Borrowed(s).to_object(py);
-            assert_eq!(s, py_string.extract::<Cow<'_, str>>(py).unwrap());
-            let py_string = Cow::<str>::Owned(s.into()).to_object(py);
-            assert_eq!(s, py_string.extract::<Cow<'_, str>>(py).unwrap());
+            let py_string = Cow::Borrowed(s).into_pyobject(py).unwrap();
+            assert_eq!(s, py_string.extract::<Cow<'_, str>>().unwrap());
+            let py_string = Cow::<str>::Owned(s.into()).into_pyobject(py).unwrap();
+            assert_eq!(s, py_string.extract::<Cow<'_, str>>().unwrap());
         })
     }
 
@@ -290,8 +297,8 @@ mod tests {
     fn test_non_bmp() {
         Python::with_gil(|py| {
             let s = "\u{1F30F}";
-            let py_string = s.to_object(py);
-            assert_eq!(s, py_string.extract::<String>(py).unwrap());
+            let py_string = s.into_pyobject(py).unwrap();
+            assert_eq!(s, py_string.extract::<String>().unwrap());
         })
     }
 
@@ -299,9 +306,9 @@ mod tests {
     fn test_extract_str() {
         Python::with_gil(|py| {
             let s = "Hello Python";
-            let py_string = s.to_object(py);
+            let py_string = s.into_pyobject(py).unwrap();
 
-            let s2: Cow<'_, str> = py_string.bind(py).extract().unwrap();
+            let s2: Cow<'_, str> = py_string.extract().unwrap();
             assert_eq!(s, s2);
         })
     }
@@ -310,8 +317,8 @@ mod tests {
     fn test_extract_char() {
         Python::with_gil(|py| {
             let ch = '😃';
-            let py_string = ch.to_object(py);
-            let ch2: char = py_string.bind(py).extract().unwrap();
+            let py_string = ch.into_pyobject(py).unwrap();
+            let ch2: char = py_string.extract().unwrap();
             assert_eq!(ch, ch2);
         })
     }
@@ -320,8 +327,8 @@ mod tests {
     fn test_extract_char_err() {
         Python::with_gil(|py| {
             let s = "Hello Python";
-            let py_string = s.to_object(py);
-            let err: crate::PyResult<char> = py_string.bind(py).extract();
+            let py_string = s.into_pyobject(py).unwrap();
+            let err: crate::PyResult<char> = py_string.extract();
             assert!(err
                 .unwrap_err()
                 .to_string()

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -265,10 +265,8 @@ impl FromPyObject<'_> for char {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::IntoPyObject;
     use crate::types::any::PyAnyMethods;
-    use crate::Python;
-    use crate::{IntoPy, PyObject};
+    use crate::{IntoPy, IntoPyObject, PyObject, Python};
     use std::borrow::Cow;
 
     #[test]

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -2,8 +2,11 @@ use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::list::new_from_iter;
-use crate::{Bound, IntoPy, PyAny, PyErr, PyObject, Python, ToPyObject};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{Bound, IntoPy, PyAny, PyErr, PyObject, Python};
 
+#[allow(deprecated)]
 impl<T> ToPyObject for [T]
 where
     T: ToPyObject,
@@ -15,6 +18,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> ToPyObject for Vec<T>
 where
     T: ToPyObject,

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1,3 +1,5 @@
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError, PyValueError},
@@ -11,7 +13,6 @@ use crate::{
     pyclass_init::PyObjectInit,
     types::{any::PyAnyMethods, PyBool},
     Borrowed, BoundObject, IntoPy, Py, PyAny, PyClass, PyErr, PyRef, PyResult, PyTypeInfo, Python,
-    ToPyObject,
 };
 use std::{
     borrow::Cow,
@@ -1292,6 +1293,7 @@ impl<
 
 /// Fallback case; Field is not `Py<T>`; try to use `ToPyObject` to avoid potentially expensive
 /// clones of containers like `Vec`
+#[allow(deprecated)]
 impl<
         ClassT: PyClass,
         FieldT: ToPyObject,
@@ -1443,6 +1445,7 @@ impl<T> IsPyT<Py<T>> {
 
 probe!(IsToPyObject);
 
+#[allow(deprecated)]
 impl<T: ToPyObject> IsToPyObject<T> {
     pub const VALUE: bool = true;
 }
@@ -1492,6 +1495,7 @@ where
     unsafe { obj.cast::<u8>().add(Offset::offset()).cast::<FieldT>() }
 }
 
+#[allow(deprecated)]
 fn pyo3_get_value_topyobject<
     ClassT: PyClass,
     FieldT: ToPyObject,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1965,8 +1965,7 @@ impl PyObject {
 
 #[cfg(test)]
 mod tests {
-    use super::{Bound, Py, PyObject};
-    use crate::prelude::IntoPyObject;
+    use super::{Bound, IntoPyObject, Py, PyObject};
     use crate::tests::common::generate_unique_module_name;
     use crate::types::{dict::IntoPyDict, PyAnyMethods, PyCapsule, PyDict, PyString};
     use crate::{ffi, Borrowed, PyAny, PyResult, Python};

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -6,9 +6,11 @@ use crate::pycell::{PyBorrowError, PyBorrowMutError};
 use crate::pyclass::boolean_struct::{False, True};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
 use crate::types::{DerefToPyAny, PyDict, PyString, PyTuple};
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     ffi, AsPyPointer, DowncastError, FromPyObject, IntoPy, PyAny, PyClass, PyClassInitializer,
-    PyRef, PyRefMut, PyTypeInfo, Python, ToPyObject,
+    PyRef, PyRefMut, PyTypeInfo, Python,
 };
 use crate::{gil, PyTypeCheck};
 use std::marker::PhantomData;
@@ -819,6 +821,7 @@ impl<T> Clone for Borrowed<'_, '_, T> {
 
 impl<T> Copy for Borrowed<'_, '_, T> {}
 
+#[allow(deprecated)]
 impl<T> ToPyObject for Borrowed<'_, '_, T> {
     /// Converts `Py` instance -> PyObject.
     #[inline]
@@ -1708,6 +1711,7 @@ impl<T> Py<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T> ToPyObject for Py<T> {
     /// Converts `Py` instance -> PyObject.
     #[inline]
@@ -1728,10 +1732,11 @@ impl<T> IntoPy<PyObject> for Py<T> {
 impl<T> IntoPy<PyObject> for &'_ Py<T> {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
+#[allow(deprecated)]
 impl<T> ToPyObject for Bound<'_, T> {
     /// Converts `&Bound` instance -> PyObject, increasing the reference count.
     #[inline]
@@ -1752,7 +1757,7 @@ impl<T> IntoPy<PyObject> for &Bound<'_, T> {
     /// Converts `&Bound` instance -> PyObject, increasing the reference count.
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
-        self.to_object(py)
+        self.into_pyobject(py).unwrap().into_any().unbind()
     }
 }
 
@@ -1961,30 +1966,30 @@ impl PyObject {
 #[cfg(test)]
 mod tests {
     use super::{Bound, Py, PyObject};
+    use crate::prelude::IntoPyObject;
     use crate::tests::common::generate_unique_module_name;
     use crate::types::{dict::IntoPyDict, PyAnyMethods, PyCapsule, PyDict, PyString};
-    use crate::{ffi, Borrowed, PyAny, PyResult, Python, ToPyObject};
+    use crate::{ffi, Borrowed, PyAny, PyResult, Python};
     use pyo3_ffi::c_str;
     use std::ffi::CStr;
 
     #[test]
     fn test_call() {
         Python::with_gil(|py| {
-            let obj = py.get_type::<PyDict>().to_object(py);
+            let obj = py.get_type::<PyDict>().into_pyobject(py).unwrap();
 
-            let assert_repr = |obj: &Bound<'_, PyAny>, expected: &str| {
+            let assert_repr = |obj: Bound<'_, PyAny>, expected: &str| {
                 assert_eq!(obj.repr().unwrap(), expected);
             };
 
-            assert_repr(obj.call0(py).unwrap().bind(py), "{}");
-            assert_repr(obj.call1(py, ()).unwrap().bind(py), "{}");
-            assert_repr(obj.call(py, (), None).unwrap().bind(py), "{}");
+            assert_repr(obj.call0().unwrap(), "{}");
+            assert_repr(obj.call1(()).unwrap(), "{}");
+            assert_repr(obj.call((), None).unwrap(), "{}");
 
-            assert_repr(obj.call1(py, ((('x', 1),),)).unwrap().bind(py), "{'x': 1}");
+            assert_repr(obj.call1(((('x', 1),),)).unwrap(), "{'x': 1}");
             assert_repr(
-                obj.call(py, (), Some(&[('x', 1)].into_py_dict(py).unwrap()))
-                    .unwrap()
-                    .bind(py),
+                obj.call((), Some(&[('x', 1)].into_py_dict(py).unwrap()))
+                    .unwrap(),
                 "{'x': 1}",
             );
         })
@@ -2117,7 +2122,7 @@ a = A()
     #[test]
     fn test_debug_fmt() {
         Python::with_gil(|py| {
-            let obj = "hello world".to_object(py).into_bound(py);
+            let obj = "hello world".into_pyobject(py).unwrap();
             assert_eq!(format!("{:?}", obj), "'hello world'");
         });
     }
@@ -2125,7 +2130,7 @@ a = A()
     #[test]
     fn test_display_fmt() {
         Python::with_gil(|py| {
-            let obj = "hello world".to_object(py).into_bound(py);
+            let obj = "hello world".into_pyobject(py).unwrap();
             assert_eq!(format!("{}", obj), "hello world");
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,7 @@
 pub use crate::class::*;
 #[allow(deprecated)]
 pub use crate::conversion::ToPyObject;
-pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPy};
+pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPy, IntoPyObject};
 pub use crate::err::{DowncastError, DowncastIntoError, PyErr, PyErrArguments, PyResult, ToPyErr};
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,9 @@
 #![doc = concat!("[Features chapter of the guide]: https://pyo3.rs/v", env!("CARGO_PKG_VERSION"), "/features.html#features-reference \"Features Reference - PyO3 user guide\"")]
 //! [`Ungil`]: crate::marker::Ungil
 pub use crate::class::*;
-pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPy, ToPyObject};
+#[allow(deprecated)]
+pub use crate::conversion::ToPyObject;
+pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPy};
 pub use crate::err::{DowncastError, DowncastIntoError, PyErr, PyErrArguments, PyResult, ToPyErr};
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -104,8 +104,9 @@ macro_rules! py_run {
 macro_rules! py_run_impl {
     ($py:expr, $($val:ident)+, $code:expr) => {{
         use $crate::types::IntoPyDict;
-        use $crate::ToPyObject;
-        let d = [$((stringify!($val), $val.to_object($py)),)+].into_py_dict($py).unwrap();
+        use $crate::conversion::IntoPyObject;
+        use $crate::BoundObject;
+        let d = [$((stringify!($val), (&$val).into_pyobject($py).unwrap().into_any().into_bound()),)+].into_py_dict($py).unwrap();
         $crate::py_run_impl!($py, *d, $code)
     }};
     ($py:expr, *$dict:expr, $code:expr) => {{

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,7 +8,9 @@
 //! use pyo3::prelude::*;
 //! ```
 
-pub use crate::conversion::{FromPyObject, IntoPy, IntoPyObject, ToPyObject};
+#[allow(deprecated)]
+pub use crate::conversion::ToPyObject;
+pub use crate::conversion::{FromPyObject, IntoPy, IntoPyObject};
 pub use crate::err::{PyErr, PyResult};
 pub use crate::instance::{Borrowed, Bound, Py, PyObject};
 pub use crate::marker::Python;

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -5,12 +5,11 @@ use std::{convert::Infallible, ops::Deref, ptr::NonNull, sync::Arc};
 #[allow(deprecated)]
 use crate::ToPyObject;
 use crate::{
-    prelude::IntoPyObject,
     types::{
         any::PyAnyMethods, bytearray::PyByteArrayMethods, bytes::PyBytesMethods,
         string::PyStringMethods, PyByteArray, PyBytes, PyString,
     },
-    Bound, DowncastError, FromPyObject, IntoPy, Py, PyAny, PyErr, PyResult, Python,
+    Bound, DowncastError, FromPyObject, IntoPy, IntoPyObject, Py, PyAny, PyErr, PyResult, Python,
 };
 
 /// A wrapper around `str` where the storage is owned by a Python `bytes` or `str` object.
@@ -360,8 +359,7 @@ use impl_traits;
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::prelude::IntoPyObject;
-    use crate::Python;
+    use crate::{IntoPyObject, Python};
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1637,10 +1637,9 @@ mod tests {
     use crate::{
         basic::CompareOp,
         ffi,
-        prelude::IntoPyObject,
         tests::common::generate_unique_module_name,
         types::{IntoPyDict, PyAny, PyAnyMethods, PyBool, PyInt, PyList, PyModule, PyTypeMethods},
-        Bound, BoundObject, PyTypeInfo, Python,
+        Bound, BoundObject, IntoPyObject, PyTypeInfo, Python,
     };
     use pyo3_ffi::c_str;
     use std::fmt::Debug;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1637,11 +1637,13 @@ mod tests {
     use crate::{
         basic::CompareOp,
         ffi,
+        prelude::IntoPyObject,
         tests::common::generate_unique_module_name,
         types::{IntoPyDict, PyAny, PyAnyMethods, PyBool, PyInt, PyList, PyModule, PyTypeMethods},
-        Bound, PyTypeInfo, Python, ToPyObject,
+        Bound, BoundObject, PyTypeInfo, Python,
     };
     use pyo3_ffi::c_str;
+    use std::fmt::Debug;
 
     #[test]
     fn test_lookup_special() {
@@ -1731,10 +1733,10 @@ class NonHeapNonDescriptorInt:
     #[test]
     fn test_call_with_kwargs() {
         Python::with_gil(|py| {
-            let list = vec![3, 6, 5, 4, 7].to_object(py);
+            let list = vec![3, 6, 5, 4, 7].into_pyobject(py).unwrap();
             let dict = vec![("reverse", true)].into_py_dict(py).unwrap();
-            list.call_method(py, "sort", (), Some(&dict)).unwrap();
-            assert_eq!(list.extract::<Vec<i32>>(py).unwrap(), vec![7, 6, 5, 4, 3]);
+            list.call_method("sort", (), Some(&dict)).unwrap();
+            assert_eq!(list.extract::<Vec<i32>>().unwrap(), vec![7, 6, 5, 4, 3]);
         });
     }
 
@@ -1797,7 +1799,7 @@ class SimpleClass:
     #[test]
     fn test_hasattr() {
         Python::with_gil(|py| {
-            let x = 5.to_object(py).into_bound(py);
+            let x = 5i32.into_pyobject(py).unwrap();
             assert!(x.is_instance_of::<PyInt>());
 
             assert!(x.hasattr("to_bytes").unwrap());
@@ -1844,10 +1846,10 @@ class SimpleClass:
     #[test]
     fn test_any_is_instance_of() {
         Python::with_gil(|py| {
-            let x = 5.to_object(py).into_bound(py);
+            let x = 5i32.into_pyobject(py).unwrap();
             assert!(x.is_instance_of::<PyInt>());
 
-            let l = vec![&x, &x].to_object(py).into_bound(py);
+            let l = vec![&x, &x].into_pyobject(py).unwrap();
             assert!(l.is_instance_of::<PyList>());
         });
     }
@@ -1855,7 +1857,7 @@ class SimpleClass:
     #[test]
     fn test_any_is_instance() {
         Python::with_gil(|py| {
-            let l = vec![1u8, 2].to_object(py).into_bound(py);
+            let l = vec![1i8, 2].into_pyobject(py).unwrap();
             assert!(l.is_instance(&py.get_type::<PyList>()).unwrap());
         });
     }
@@ -1863,7 +1865,7 @@ class SimpleClass:
     #[test]
     fn test_any_is_exact_instance_of() {
         Python::with_gil(|py| {
-            let x = 5.to_object(py).into_bound(py);
+            let x = 5i32.into_pyobject(py).unwrap();
             assert!(x.is_exact_instance_of::<PyInt>());
 
             let t = PyBool::new(py, true);
@@ -1871,7 +1873,7 @@ class SimpleClass:
             assert!(!t.is_exact_instance_of::<PyInt>());
             assert!(t.is_exact_instance_of::<PyBool>());
 
-            let l = vec![&x, &x].to_object(py).into_bound(py);
+            let l = vec![&x, &x].into_pyobject(py).unwrap();
             assert!(l.is_exact_instance_of::<PyList>());
         });
     }
@@ -1890,34 +1892,36 @@ class SimpleClass:
     fn test_any_contains() {
         Python::with_gil(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
-            let ob = v.to_object(py).into_bound(py);
+            let ob = v.into_pyobject(py).unwrap();
 
-            let bad_needle = 7i32.to_object(py);
+            let bad_needle = 7i32.into_pyobject(py).unwrap();
             assert!(!ob.contains(&bad_needle).unwrap());
 
-            let good_needle = 8i32.to_object(py);
+            let good_needle = 8i32.into_pyobject(py).unwrap();
             assert!(ob.contains(&good_needle).unwrap());
 
-            let type_coerced_needle = 8f32.to_object(py);
+            let type_coerced_needle = 8f32.into_pyobject(py).unwrap();
             assert!(ob.contains(&type_coerced_needle).unwrap());
 
             let n: u32 = 42;
-            let bad_haystack = n.to_object(py).into_bound(py);
-            let irrelevant_needle = 0i32.to_object(py);
+            let bad_haystack = n.into_pyobject(py).unwrap();
+            let irrelevant_needle = 0i32.into_pyobject(py).unwrap();
             assert!(bad_haystack.contains(&irrelevant_needle).is_err());
         });
     }
 
     // This is intentionally not a test, it's a generic function used by the tests below.
-    fn test_eq_methods_generic<T>(list: &[T])
+    fn test_eq_methods_generic<'a, T>(list: &'a [T])
     where
-        T: PartialEq + PartialOrd + ToPyObject,
+        T: PartialEq + PartialOrd,
+        for<'py> &'a T: IntoPyObject<'py>,
+        for<'py> <&'a T as IntoPyObject<'py>>::Error: Debug,
     {
         Python::with_gil(|py| {
             for a in list {
                 for b in list {
-                    let a_py = a.to_object(py).into_bound(py);
-                    let b_py = b.to_object(py).into_bound(py);
+                    let a_py = a.into_pyobject(py).unwrap().into_any().into_bound();
+                    let b_py = b.into_pyobject(py).unwrap().into_any().into_bound();
 
                     assert_eq!(
                         a.lt(b),
@@ -1975,13 +1979,13 @@ class SimpleClass:
     #[test]
     fn test_eq_methods_integers() {
         let ints = [-4, -4, 1, 2, 0, -100, 1_000_000];
-        test_eq_methods_generic(&ints);
+        test_eq_methods_generic::<i32>(&ints);
     }
 
     #[test]
     fn test_eq_methods_strings() {
         let strings = ["Let's", "test", "some", "eq", "methods"];
-        test_eq_methods_generic(&strings);
+        test_eq_methods_generic::<&str>(&strings);
     }
 
     #[test]
@@ -1996,20 +2000,20 @@ class SimpleClass:
             10.0 / 3.0,
             -1_000_000.0,
         ];
-        test_eq_methods_generic(&floats);
+        test_eq_methods_generic::<f64>(&floats);
     }
 
     #[test]
     fn test_eq_methods_bools() {
         let bools = [true, false];
-        test_eq_methods_generic(&bools);
+        test_eq_methods_generic::<bool>(&bools);
     }
 
     #[test]
     fn test_rich_compare_type_error() {
         Python::with_gil(|py| {
-            let py_int = 1.to_object(py).into_bound(py);
-            let py_str = "1".to_object(py).into_bound(py);
+            let py_int = 1i32.into_pyobject(py).unwrap();
+            let py_str = "1".into_pyobject(py).unwrap();
 
             assert!(py_int.rich_compare(&py_str, CompareOp::Lt).is_err());
             assert!(!py_int
@@ -2031,7 +2035,7 @@ class SimpleClass:
 
             assert!(v.is_ellipsis());
 
-            let not_ellipsis = 5.to_object(py).into_bound(py);
+            let not_ellipsis = 5i32.into_pyobject(py).unwrap();
             assert!(!not_ellipsis.is_ellipsis());
         });
     }
@@ -2041,7 +2045,7 @@ class SimpleClass:
         Python::with_gil(|py| {
             assert!(PyList::type_object(py).is_callable());
 
-            let not_callable = 5.to_object(py).into_bound(py);
+            let not_callable = 5i32.into_pyobject(py).unwrap();
             assert!(!not_callable.is_callable());
         });
     }
@@ -2055,7 +2059,7 @@ class SimpleClass:
             let list = PyList::new(py, vec![1, 2, 3]).unwrap().into_any();
             assert!(!list.is_empty().unwrap());
 
-            let not_container = 5.to_object(py).into_bound(py);
+            let not_container = 5i32.into_pyobject(py).unwrap();
             assert!(not_container.is_empty().is_err());
         });
     }

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -254,10 +254,10 @@ impl FromPyObject<'_> for bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::IntoPyObject;
     use crate::types::any::PyAnyMethods;
     use crate::types::boolobject::PyBoolMethods;
     use crate::types::PyBool;
+    use crate::IntoPyObject;
     use crate::Python;
 
     #[test]

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,9 +1,11 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     exceptions::PyTypeError, ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound,
     types::typeobject::PyTypeMethods, Borrowed, FromPyObject, IntoPy, PyAny, PyObject, PyResult,
-    Python, ToPyObject,
+    Python,
 };
 
 use super::any::PyAnyMethods;
@@ -145,6 +147,7 @@ impl PartialEq<Borrowed<'_, '_, PyBool>> for &'_ bool {
 }
 
 /// Converts a Rust `bool` to a Python `bool`.
+#[allow(deprecated)]
 impl ToPyObject for bool {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -251,11 +254,11 @@ impl FromPyObject<'_> for bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::prelude::IntoPyObject;
     use crate::types::any::PyAnyMethods;
     use crate::types::boolobject::PyBoolMethods;
     use crate::types::PyBool;
     use crate::Python;
-    use crate::ToPyObject;
 
     #[test]
     fn test_true() {
@@ -263,7 +266,7 @@ mod tests {
             assert!(PyBool::new(py, true).is_true());
             let t = PyBool::new(py, true);
             assert!(t.extract::<bool>().unwrap());
-            assert!(true.to_object(py).is(&*PyBool::new(py, true)));
+            assert!(true.into_pyobject(py).unwrap().is(&*PyBool::new(py, true)));
         });
     }
 
@@ -273,7 +276,10 @@ mod tests {
             assert!(!PyBool::new(py, false).is_true());
             let t = PyBool::new(py, false);
             assert!(!t.extract::<bool>().unwrap());
-            assert!(false.to_object(py).is(&*PyBool::new(py, false)));
+            assert!(false
+                .into_pyobject(py)
+                .unwrap()
+                .is(&*PyBool::new(py, false)));
         });
     }
 

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -628,7 +628,6 @@ where
 mod tests {
     use super::*;
     use crate::types::PyTuple;
-    use crate::ToPyObject;
     use std::collections::{BTreeMap, HashMap};
 
     #[test]
@@ -713,13 +712,11 @@ mod tests {
     #[test]
     fn test_len() {
         Python::with_gil(|py| {
-            let mut v = HashMap::new();
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let mut v = HashMap::<i32, i32>::new();
+            let dict = (&v).into_pyobject(py).unwrap();
             assert_eq!(0, dict.len());
             v.insert(7, 32);
-            let ob = v.to_object(py);
-            let dict2 = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict2 = v.into_pyobject(py).unwrap();
             assert_eq!(1, dict2.len());
         });
     }
@@ -729,8 +726,7 @@ mod tests {
         Python::with_gil(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             assert!(dict.contains(7i32).unwrap());
             assert!(!dict.contains(8i32).unwrap());
         });
@@ -741,8 +737,7 @@ mod tests {
         Python::with_gil(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             assert_eq!(
                 32,
                 dict.get_item(7i32)
@@ -796,8 +791,7 @@ mod tests {
         Python::with_gil(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             assert!(dict.set_item(7i32, 42i32).is_ok()); // change
             assert!(dict.set_item(8i32, 123i32).is_ok()); // insert
             assert_eq!(
@@ -839,8 +833,7 @@ mod tests {
         Python::with_gil(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = (&v).into_pyobject(py).unwrap();
             assert!(dict.set_item(7i32, 42i32).is_ok()); // change
             assert!(dict.set_item(8i32, 123i32).is_ok()); // insert
             assert_eq!(32i32, v[&7i32]); // not updated!
@@ -853,8 +846,7 @@ mod tests {
         Python::with_gil(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             assert!(dict.del_item(7i32).is_ok());
             assert_eq!(0, dict.len());
             assert!(dict.get_item(7i32).unwrap().is_none());
@@ -866,8 +858,7 @@ mod tests {
         Python::with_gil(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = (&v).into_pyobject(py).unwrap();
             assert!(dict.del_item(7i32).is_ok()); // change
             assert_eq!(32i32, *v.get(&7i32).unwrap()); // not updated!
         });
@@ -880,8 +871,7 @@ mod tests {
             v.insert(7, 32);
             v.insert(8, 42);
             v.insert(9, 123);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
             let mut key_sum = 0;
             let mut value_sum = 0;
@@ -902,8 +892,7 @@ mod tests {
             v.insert(7, 32);
             v.insert(8, 42);
             v.insert(9, 123);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
             let mut key_sum = 0;
             for el in dict.keys() {
@@ -920,8 +909,7 @@ mod tests {
             v.insert(7, 32);
             v.insert(8, 42);
             v.insert(9, 123);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             // Can't just compare against a vector of tuples since we don't have a guaranteed ordering.
             let mut values_sum = 0;
             for el in dict.values() {
@@ -938,8 +926,7 @@ mod tests {
             v.insert(7, 32);
             v.insert(8, 42);
             v.insert(9, 123);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             let mut key_sum = 0;
             let mut value_sum = 0;
             for (key, value) in dict {
@@ -958,8 +945,7 @@ mod tests {
             v.insert(7, 32);
             v.insert(8, 42);
             v.insert(9, 123);
-            let ob = v.to_object(py);
-            let dict: &Bound<'_, PyDict> = ob.downcast_bound(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             let mut key_sum = 0;
             let mut value_sum = 0;
             for (key, value) in dict {
@@ -979,10 +965,9 @@ mod tests {
             v.insert(8, 42);
             v.insert(9, 123);
 
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = (&v).into_pyobject(py).unwrap();
 
-            for (key, value) in dict {
+            for (key, value) in &dict {
                 dict.set_item(key, value.extract::<i32>().unwrap() + 7)
                     .unwrap();
             }
@@ -997,8 +982,7 @@ mod tests {
             for i in 0..10 {
                 v.insert(i * 2, i * 2);
             }
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
 
             for (i, (key, value)) in dict.iter().enumerate() {
                 let key = key.extract::<i32>().unwrap();
@@ -1022,8 +1006,7 @@ mod tests {
             for i in 0..10 {
                 v.insert(i * 2, i * 2);
             }
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
 
             for (i, (key, value)) in dict.iter().enumerate() {
                 let key = key.extract::<i32>().unwrap();
@@ -1046,8 +1029,7 @@ mod tests {
             v.insert(7, 32);
             v.insert(8, 42);
             v.insert(9, 123);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = (&v).into_pyobject(py).unwrap();
 
             let mut iter = dict.iter();
             assert_eq!(iter.size_hint(), (v.len(), Some(v.len())));
@@ -1072,8 +1054,7 @@ mod tests {
             v.insert(7, 32);
             v.insert(8, 42);
             v.insert(9, 123);
-            let ob = v.to_object(py);
-            let dict = ob.downcast_bound::<PyDict>(py).unwrap();
+            let dict = v.into_pyobject(py).unwrap();
             let mut key_sum = 0;
             let mut value_sum = 0;
             for (key, value) in dict {

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -6,7 +6,7 @@ use crate::instance::{Borrowed, Bound};
 use crate::py_result_ext::PyResultExt;
 use crate::types::any::PyAnyMethods;
 use crate::types::{PyAny, PyList};
-use crate::{ffi, BoundObject, Python};
+use crate::{ffi, BoundObject, IntoPyObject, Python};
 
 /// Represents a Python `dict`.
 ///
@@ -558,7 +558,6 @@ mod borrowed_iter {
     }
 }
 
-use crate::prelude::IntoPyObject;
 pub(crate) use borrowed_iter::BorrowedDictIter;
 
 /// Conversion trait that allows a sequence of tuples to be converted into `PyDict`

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -2,9 +2,11 @@ use super::any::PyAnyMethods;
 use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, Borrowed, FromPyObject, IntoPy, PyAny, PyErr,
-    PyObject, PyResult, Python, ToPyObject,
+    PyObject, PyResult, Python,
 };
 use std::convert::Infallible;
 use std::os::raw::c_double;
@@ -76,6 +78,7 @@ impl<'py> PyFloatMethods<'py> for Bound<'py, PyFloat> {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for f64 {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -147,6 +150,7 @@ impl<'py> FromPyObject<'py> for f64 {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for f32 {
     #[inline]
     fn to_object(&self, py: Python<'_>) -> PyObject {
@@ -279,8 +283,9 @@ impl_partial_eq_for_float!(f32);
 #[cfg(test)]
 mod tests {
     use crate::{
-        types::{PyFloat, PyFloatMethods},
-        Python, ToPyObject,
+        conversion::IntoPyObject,
+        types::{PyAnyMethods, PyFloat, PyFloatMethods},
+        Python,
     };
 
     macro_rules! num_to_py_object_and_back (
@@ -292,8 +297,8 @@ mod tests {
                 Python::with_gil(|py| {
 
                 let val = 123 as $t1;
-                let obj = val.to_object(py);
-                assert_approx_eq!(obj.extract::<$t2>(py).unwrap(), val as $t2);
+                let obj = val.into_pyobject(py).unwrap();
+                assert_approx_eq!(obj.extract::<$t2>().unwrap(), val as $t2);
                 });
             }
         )

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -6,7 +6,7 @@ use crate::{
     ffi_ptr_ext::FfiPtrExt,
     py_result_ext::PyResultExt,
     types::any::PyAnyMethods,
-    Bound, PyAny, Python, ToPyObject,
+    Bound, PyAny, Python,
 };
 use crate::{Borrowed, BoundObject};
 use std::ptr;
@@ -103,8 +103,9 @@ impl PyFrozenSet {
 
     /// Deprecated name for [`PyFrozenSet::new`].
     #[deprecated(since = "0.23.0", note = "renamed to `PyFrozenSet::new`")]
+    #[allow(deprecated)]
     #[inline]
-    pub fn new_bound<'a, 'p, T: ToPyObject + 'a>(
+    pub fn new_bound<'a, 'p, T: crate::ToPyObject + 'a>(
         py: Python<'p>,
         elements: impl IntoIterator<Item = &'a T>,
     ) -> PyResult<Bound<'p, PyFrozenSet>> {

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -107,14 +107,14 @@ impl PyTypeCheck for PyIterator {
 mod tests {
     use super::PyIterator;
     use crate::exceptions::PyTypeError;
+    use crate::prelude::IntoPyObject;
     use crate::types::{PyAnyMethods, PyDict, PyList, PyListMethods};
-    use crate::{ffi, Python, ToPyObject};
+    use crate::{ffi, Python};
 
     #[test]
     fn vec_iter() {
         Python::with_gil(|py| {
-            let obj = vec![10, 20].to_object(py);
-            let inst = obj.bind(py);
+            let inst = vec![10, 20].into_pyobject(py).unwrap();
             let mut it = inst.try_iter().unwrap();
             assert_eq!(
                 10_i32,
@@ -131,9 +131,9 @@ mod tests {
     #[test]
     fn iter_refcnt() {
         let (obj, count) = Python::with_gil(|py| {
-            let obj = vec![10, 20].to_object(py);
-            let count = obj.get_refcnt(py);
-            (obj, count)
+            let obj = vec![10, 20].into_pyobject(py).unwrap();
+            let count = obj.get_refcnt();
+            (obj.unbind(), count)
         });
 
         Python::with_gil(|py| {
@@ -161,18 +161,14 @@ mod tests {
                 list.append(10).unwrap();
                 list.append(&obj).unwrap();
                 count = obj.get_refcnt();
-                list.to_object(py)
+                list
             };
 
             {
-                let inst = list.bind(py);
-                let mut it = inst.try_iter().unwrap();
+                let mut it = list.iter();
 
-                assert_eq!(
-                    10_i32,
-                    it.next().unwrap().unwrap().extract::<'_, i32>().unwrap()
-                );
-                assert!(it.next().unwrap().unwrap().is(&obj));
+                assert_eq!(10_i32, it.next().unwrap().extract::<'_, i32>().unwrap());
+                assert!(it.next().unwrap().is(&obj));
                 assert!(it.next().is_none());
             }
             assert_eq!(count, obj.get_refcnt());
@@ -243,8 +239,8 @@ def fibonacci(target):
     #[test]
     fn int_not_iterable() {
         Python::with_gil(|py| {
-            let x = 5.to_object(py);
-            let err = PyIterator::from_object(x.bind(py)).unwrap_err();
+            let x = 5i32.into_pyobject(py).unwrap();
+            let err = PyIterator::from_object(&x).unwrap_err();
 
             assert!(err.is_instance_of::<PyTypeError>(py));
         });

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -107,9 +107,8 @@ impl PyTypeCheck for PyIterator {
 mod tests {
     use super::PyIterator;
     use crate::exceptions::PyTypeError;
-    use crate::prelude::IntoPyObject;
     use crate::types::{PyAnyMethods, PyDict, PyList, PyListMethods};
-    use crate::{ffi, Python};
+    use crate::{ffi, IntoPyObject, Python};
 
     #[test]
     fn vec_iter() {

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -5,9 +5,8 @@ use crate::ffi::{self, Py_ssize_t};
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::get_ssize_index;
 use crate::types::{PySequence, PyTuple};
-use crate::{Borrowed, Bound, BoundObject, PyAny, PyObject, Python};
+use crate::{Borrowed, Bound, BoundObject, IntoPyObject, PyAny, PyObject, Python};
 
-use crate::prelude::IntoPyObject;
 use crate::types::any::PyAnyMethods;
 use crate::types::sequence::PySequenceMethods;
 
@@ -575,7 +574,7 @@ mod tests {
     use crate::types::list::PyListMethods;
     use crate::types::sequence::PySequenceMethods;
     use crate::types::{PyList, PyTuple};
-    use crate::{ffi, Python};
+    use crate::{ffi, IntoPyObject, Python};
 
     #[test]
     fn test_new() {
@@ -979,7 +978,6 @@ mod tests {
         });
     }
 
-    use crate::prelude::IntoPyObject;
     use std::ops::Range;
 
     // An iterator that lies about its `ExactSizeIterator` implementation.

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -5,7 +5,7 @@ use crate::ffi::{self, Py_ssize_t};
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::get_ssize_index;
 use crate::types::{PySequence, PyTuple};
-use crate::{Borrowed, Bound, BoundObject, PyAny, PyObject, Python, ToPyObject};
+use crate::{Borrowed, Bound, BoundObject, PyAny, PyObject, Python};
 
 use crate::prelude::IntoPyObject;
 use crate::types::any::PyAnyMethods;
@@ -116,6 +116,7 @@ impl PyList {
 
     /// Deprecated name for [`PyList::new`].
     #[deprecated(since = "0.23.0", note = "renamed to `PyList::new`")]
+    #[allow(deprecated)]
     #[inline]
     #[track_caller]
     pub fn new_bound<T, U>(
@@ -123,7 +124,7 @@ impl PyList {
         elements: impl IntoIterator<Item = T, IntoIter = U>,
     ) -> Bound<'_, PyList>
     where
-        T: ToPyObject,
+        T: crate::ToPyObject,
         U: ExactSizeIterator<Item = T>,
     {
         Self::new(py, elements.into_iter().map(|e| e.to_object(py))).unwrap()

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -1,7 +1,8 @@
 use crate::ffi_ptr_ext::FfiPtrExt;
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     ffi, types::any::PyAnyMethods, Borrowed, Bound, IntoPy, PyAny, PyObject, PyTypeInfo, Python,
-    ToPyObject,
 };
 
 /// Represents the Python `None` object.
@@ -50,6 +51,7 @@ unsafe impl PyTypeInfo for PyNone {
 }
 
 /// `()` is converted to Python `None`.
+#[allow(deprecated)]
 impl ToPyObject for () {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         PyNone::get(py).into_py(py)
@@ -67,7 +69,7 @@ impl IntoPy<PyObject> for () {
 mod tests {
     use crate::types::any::PyAnyMethods;
     use crate::types::{PyDict, PyNone};
-    use crate::{IntoPy, PyObject, PyTypeInfo, Python, ToPyObject};
+    use crate::{IntoPy, PyObject, PyTypeInfo, Python};
     #[test]
     fn test_none_is_itself() {
         Python::with_gil(|py| {
@@ -91,7 +93,9 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_unit_to_object_is_none() {
+        use crate::ToPyObject;
         Python::with_gil(|py| {
             assert!(().to_object(py).downcast_bound::<PyNone>(py).is_ok());
         })

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -5,12 +5,11 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::inspect::types::TypeInfo;
 use crate::instance::Bound;
 use crate::internal_tricks::get_ssize_index;
-use crate::prelude::IntoPyObject;
 use crate::py_result_ext::PyResultExt;
 use crate::sync::GILOnceCell;
 use crate::type_object::PyTypeInfo;
 use crate::types::{any::PyAnyMethods, PyAny, PyList, PyString, PyTuple, PyType};
-use crate::{ffi, Borrowed, BoundObject, FromPyObject, Py, PyTypeCheck, Python};
+use crate::{ffi, Borrowed, BoundObject, FromPyObject, IntoPyObject, Py, PyTypeCheck, Python};
 
 /// Represents a reference to a Python object supporting the sequence protocol.
 ///
@@ -408,9 +407,8 @@ impl PyTypeCheck for PySequence {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::IntoPyObject;
     use crate::types::{PyAnyMethods, PyList, PySequence, PySequenceMethods, PyTuple};
-    use crate::{ffi, PyObject, Python};
+    use crate::{ffi, IntoPyObject, PyObject, Python};
 
     fn get_object() -> PyObject {
         // Convenience function for getting a single unique object

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -1,5 +1,7 @@
 use crate::conversion::IntoPyObject;
 use crate::types::PyIterator;
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     err::{self, PyErr, PyResult},
     ffi_ptr_ext::FfiPtrExt,
@@ -7,7 +9,7 @@ use crate::{
     py_result_ext::PyResultExt,
     types::any::PyAnyMethods,
 };
-use crate::{ffi, Borrowed, BoundObject, PyAny, Python, ToPyObject};
+use crate::{ffi, Borrowed, BoundObject, PyAny, Python};
 use std::ptr;
 
 /// Represents a Python `set`.
@@ -55,6 +57,7 @@ impl PySet {
 
     /// Deprecated name for [`PySet::new`].
     #[deprecated(since = "0.23.0", note = "renamed to `PySet::new`")]
+    #[allow(deprecated)]
     #[inline]
     pub fn new_bound<'a, 'p, T: ToPyObject + 'a>(
         py: Python<'p>,
@@ -285,6 +288,7 @@ impl ExactSizeIterator for BoundSetIterator<'_> {
     }
 }
 
+#[allow(deprecated)]
 #[inline]
 pub(crate) fn new_from_iter<T: ToPyObject>(
     py: Python<'_>,

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -1,11 +1,10 @@
 use crate::err::{PyErr, PyResult};
 use crate::ffi;
 use crate::ffi_ptr_ext::FfiPtrExt;
-use crate::prelude::IntoPyObject;
 use crate::types::any::PyAnyMethods;
 #[allow(deprecated)]
 use crate::ToPyObject;
-use crate::{Bound, PyAny, PyObject, Python};
+use crate::{Bound, IntoPyObject, PyAny, PyObject, Python};
 use std::convert::Infallible;
 
 /// Represents a Python `slice`.

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -3,7 +3,9 @@ use crate::ffi;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::prelude::IntoPyObject;
 use crate::types::any::PyAnyMethods;
-use crate::{Bound, PyAny, PyObject, Python, ToPyObject};
+#[allow(deprecated)]
+use crate::ToPyObject;
+use crate::{Bound, PyAny, PyObject, Python};
 use std::convert::Infallible;
 
 /// Represents a Python `slice`.
@@ -135,6 +137,7 @@ impl<'py> PySliceMethods<'py> for Bound<'py, PySlice> {
     }
 }
 
+#[allow(deprecated)]
 impl ToPyObject for PySliceIndices {
     fn to_object(&self, py: Python<'_>) -> PyObject {
         PySlice::new(py, self.start, self.stop, self.step).into()

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -577,8 +577,7 @@ impl PartialEq<Borrowed<'_, '_, PyString>> for &'_ str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::IntoPyObject;
-    use crate::PyObject;
+    use crate::{IntoPyObject, PyObject};
 
     #[test]
     fn test_to_cow_utf8() {

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -577,7 +577,8 @@ impl PartialEq<Borrowed<'_, '_, PyString>> for &'_ str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{PyObject, ToPyObject};
+    use crate::prelude::IntoPyObject;
+    use crate::PyObject;
 
     #[test]
     fn test_to_cow_utf8() {
@@ -650,8 +651,7 @@ mod tests {
     #[test]
     fn test_debug_string() {
         Python::with_gil(|py| {
-            let v = "Hello\n".to_object(py);
-            let s = v.downcast_bound::<PyString>(py).unwrap();
+            let s = "Hello\n".into_pyobject(py).unwrap();
             assert_eq!(format!("{:?}", s), "'Hello\\n'");
         })
     }
@@ -659,8 +659,7 @@ mod tests {
     #[test]
     fn test_display_string() {
         Python::with_gil(|py| {
-            let v = "Hello\n".to_object(py);
-            let s = v.downcast_bound::<PyString>(py).unwrap();
+            let s = "Hello\n".into_pyobject(py).unwrap();
             assert_eq!(format!("{}", s), "Hello\n");
         })
     }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -821,8 +821,9 @@ tuple_conversion!(
 #[cfg(test)]
 mod tests {
     use crate::types::{any::PyAnyMethods, tuple::PyTupleMethods, PyList, PyTuple};
-    use crate::Python;
+    use crate::{IntoPyObject, Python};
     use std::collections::HashSet;
+    use std::ops::Range;
 
     #[test]
     fn test_new() {
@@ -1141,9 +1142,6 @@ mod tests {
             assert!(tuple.index(42i32).is_err());
         });
     }
-
-    use crate::prelude::IntoPyObject;
-    use std::ops::Range;
 
     // An iterator that lies about its `ExactSizeIterator` implementation.
     // See https://github.com/PyO3/pyo3/issues/2118

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -10,9 +10,11 @@ use crate::internal_tricks::get_ssize_index;
 use crate::types::{
     any::PyAnyMethods, sequence::PySequenceMethods, PyDict, PyList, PySequence, PyString,
 };
+#[allow(deprecated)]
+use crate::ToPyObject;
 use crate::{
     exceptions, Bound, BoundObject, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult,
-    Python, ToPyObject,
+    Python,
 };
 
 #[inline]
@@ -111,6 +113,7 @@ impl PyTuple {
 
     /// Deprecated name for [`PyTuple::new`].
     #[deprecated(since = "0.23.0", note = "renamed to `PyTuple::new`")]
+    #[allow(deprecated)]
     #[track_caller]
     #[inline]
     pub fn new_bound<T, U>(
@@ -169,14 +172,13 @@ pub trait PyTupleMethods<'py>: crate::sealed::Sealed {
     /// Gets the tuple item at the specified index.
     /// # Example
     /// ```
-    /// use pyo3::{prelude::*, types::PyTuple};
+    /// use pyo3::prelude::*;
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let ob = (1, 2, 3).to_object(py);
-    ///     let tuple = ob.downcast_bound::<PyTuple>(py).unwrap();
+    ///     let tuple = (1, 2, 3).into_pyobject(py)?;
     ///     let obj = tuple.get_item(0);
-    ///     assert_eq!(obj.unwrap().extract::<i32>().unwrap(), 1);
+    ///     assert_eq!(obj?.extract::<i32>()?, 1);
     ///     Ok(())
     /// })
     /// # }
@@ -519,6 +521,7 @@ fn wrong_tuple_length(t: &Bound<'_, PyTuple>, expected_length: usize) -> PyErr {
 }
 
 macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+} => {
+    #[allow(deprecated)]
     impl <$($T: ToPyObject),+> ToPyObject for ($($T,)+) {
         fn to_object(&self, py: Python<'_>) -> PyObject {
             array_into_tuple(py, [$(self.$n.to_object(py)),+]).into()

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -1,9 +1,10 @@
 use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::prelude::IntoPyObject;
 use crate::py_result_ext::PyResultExt;
 use crate::type_object::PyTypeCheck;
 use crate::types::{any::PyAny, PyNone};
-use crate::{ffi, Bound, ToPyObject};
+use crate::{ffi, Bound, BoundObject};
 
 use super::PyWeakrefMethods;
 
@@ -148,7 +149,7 @@ impl PyWeakrefProxy {
         callback: C,
     ) -> PyResult<Bound<'py, PyWeakrefProxy>>
     where
-        C: ToPyObject,
+        C: IntoPyObject<'py>,
     {
         fn inner<'py>(
             object: &Bound<'py, PyAny>,
@@ -164,20 +165,28 @@ impl PyWeakrefProxy {
         }
 
         let py = object.py();
-        inner(object, callback.to_object(py).into_bound(py))
+        inner(
+            object,
+            callback
+                .into_pyobject(py)
+                .map(BoundObject::into_any)
+                .map(BoundObject::into_bound)
+                .map_err(Into::into)?,
+        )
     }
 
     /// Deprecated name for [`PyWeakrefProxy::new_with`].
     #[deprecated(since = "0.23.0", note = "renamed to `PyWeakrefProxy::new_with`")]
+    #[allow(deprecated)]
     #[inline]
     pub fn new_bound_with<'py, C>(
         object: &Bound<'py, PyAny>,
         callback: C,
     ) -> PyResult<Bound<'py, PyWeakrefProxy>>
     where
-        C: ToPyObject,
+        C: crate::ToPyObject,
     {
-        Self::new_with(object, callback)
+        Self::new_with(object, callback.to_object(object.py()))
     }
 }
 

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -1,10 +1,9 @@
 use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
-use crate::prelude::IntoPyObject;
 use crate::py_result_ext::PyResultExt;
 use crate::type_object::PyTypeCheck;
 use crate::types::{any::PyAny, PyNone};
-use crate::{ffi, Bound, BoundObject};
+use crate::{ffi, Bound, BoundObject, IntoPyObject};
 
 use super::PyWeakrefMethods;
 

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -1,8 +1,9 @@
 use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::prelude::IntoPyObject;
 use crate::py_result_ext::PyResultExt;
 use crate::types::{any::PyAny, PyNone};
-use crate::{ffi, Bound, ToPyObject};
+use crate::{ffi, Bound, BoundObject};
 
 #[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]
 use crate::type_object::PyTypeCheck;
@@ -157,7 +158,7 @@ impl PyWeakrefReference {
         callback: C,
     ) -> PyResult<Bound<'py, PyWeakrefReference>>
     where
-        C: ToPyObject,
+        C: IntoPyObject<'py>,
     {
         fn inner<'py>(
             object: &Bound<'py, PyAny>,
@@ -173,20 +174,28 @@ impl PyWeakrefReference {
         }
 
         let py = object.py();
-        inner(object, callback.to_object(py).into_bound(py))
+        inner(
+            object,
+            callback
+                .into_pyobject(py)
+                .map(BoundObject::into_any)
+                .map(BoundObject::into_bound)
+                .map_err(Into::into)?,
+        )
     }
 
     /// Deprecated name for [`PyWeakrefReference::new_with`].
     #[deprecated(since = "0.23.0", note = "renamed to `PyWeakrefReference::new_with`")]
+    #[allow(deprecated)]
     #[inline]
     pub fn new_bound_with<'py, C>(
         object: &Bound<'py, PyAny>,
         callback: C,
     ) -> PyResult<Bound<'py, PyWeakrefReference>>
     where
-        C: ToPyObject,
+        C: crate::ToPyObject,
     {
-        Self::new_with(object, callback)
+        Self::new_with(object, callback.to_object(object.py()))
     }
 }
 

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -1,9 +1,8 @@
 use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
-use crate::prelude::IntoPyObject;
 use crate::py_result_ext::PyResultExt;
 use crate::types::{any::PyAny, PyNone};
-use crate::{ffi, Bound, BoundObject};
+use crate::{ffi, Bound, BoundObject, IntoPyObject};
 
 #[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]
 use crate::type_object::PyTypeCheck;

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -17,7 +17,7 @@ fn test_cloneable_pyclass() {
     let c = Cloneable { x: 10 };
 
     Python::with_gil(|py| {
-        let py_c = Py::new(py, c.clone()).unwrap().to_object(py);
+        let py_c = Py::new(py, c.clone()).unwrap();
 
         let c2: Cloneable = py_c.extract(py).unwrap();
         assert_eq!(c, c2);
@@ -69,8 +69,7 @@ fn test_polymorphic_container_stores_base_class() {
                 inner: Py::new(py, BaseClass::default()).unwrap(),
             },
         )
-        .unwrap()
-        .to_object(py);
+        .unwrap();
 
         py_assert!(py, p, "p.inner.foo() == 'BaseClass'");
     });
@@ -85,8 +84,7 @@ fn test_polymorphic_container_stores_sub_class() {
                 inner: Py::new(py, BaseClass::default()).unwrap(),
             },
         )
-        .unwrap()
-        .to_object(py);
+        .unwrap();
 
         p.bind(py)
             .setattr(
@@ -112,8 +110,7 @@ fn test_polymorphic_container_does_not_accept_other_types() {
                 inner: Py::new(py, BaseClass::default()).unwrap(),
             },
         )
-        .unwrap()
-        .to_object(py);
+        .unwrap();
 
         let setattr = |value: PyObject| p.bind(py).setattr("inner", value);
 

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -228,8 +228,8 @@ fn cell_getter_setter() {
         cell_inner: Cell::new(10),
     };
     Python::with_gil(|py| {
-        let inst = Py::new(py, c).unwrap().to_object(py);
-        let cell = Cell::new(20).to_object(py);
+        let inst = Py::new(py, c).unwrap();
+        let cell = Cell::new(20i32).into_pyobject(py).unwrap();
 
         py_run!(py, cell, "assert cell == 20");
         py_run!(py, inst, "assert inst.cell_inner == 10");
@@ -255,7 +255,7 @@ fn borrowed_value_with_lifetime_of_self() {
     }
 
     Python::with_gil(|py| {
-        let inst = Py::new(py, BorrowedValue {}).unwrap().to_object(py);
+        let inst = Py::new(py, BorrowedValue {}).unwrap();
 
         py_run!(py, inst, "assert inst.value == 'value'");
     });
@@ -276,8 +276,7 @@ fn frozen_py_field_get() {
                 value: "value".into_py(py),
             },
         )
-        .unwrap()
-        .to_object(py);
+        .unwrap();
 
         py_run!(py, inst, "assert inst.value == 'value'");
     });

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -285,7 +285,7 @@ mod inheriting_native_type {
             Some(&dict)
             );
             let err = res.unwrap_err();
-            assert!(err.matches(py, &cls), "{}", err);
+            assert!(err.matches(py, &cls).unwrap(), "{}", err);
 
             // catching the exception in Python also works:
             py_run!(

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -264,7 +264,10 @@ struct GenericList {
 fn test_generic_list_get() {
     Python::with_gil(|py| {
         let list: PyObject = GenericList {
-            items: [1, 2, 3].iter().map(|i| i.to_object(py)).collect(),
+            items: [1i32, 2, 3]
+                .iter()
+                .map(|i| i.into_pyobject(py).unwrap().into_any().unbind())
+                .collect(),
         }
         .into_py(py);
 

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -132,9 +132,9 @@ fn test_pickle() {
         pub fn __reduce__<'py>(
             slf: &Bound<'py, Self>,
             py: Python<'py>,
-        ) -> PyResult<(PyObject, Bound<'py, PyTuple>, PyObject)> {
-            let cls = slf.to_object(py).getattr(py, "__class__")?;
-            let dict = slf.to_object(py).getattr(py, "__dict__")?;
+        ) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyTuple>, Bound<'py, PyAny>)> {
+            let cls = slf.getattr("__class__")?;
+            let dict = slf.getattr("__dict__")?;
             Ok((cls, PyTuple::empty(py), dict))
         }
     }


### PR DESCRIPTION
This deprecates `ToPyObject` in favor or `IntoPyObject`. All the `impl`s are `[allow(deprecated)]`, tests were adapted to use `IntoPyObject`. This will probably cause some hit in coverage, but it should hopefully recover once we can remove a lot of this after 0.23.

Since the diff went quite big, let me know if I should try to split this.