### PR TITLE
seal `PyWeakrefMethods`

### DIFF
--- a/newsfragments/4598.changed.md
+++ b/newsfragments/4598.changed.md
@@ -1,0 +1,1 @@
+Seal `PyWeakrefMethods` trait.

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -1,6 +1,7 @@
 use crate::types::{
     PyBool, PyByteArray, PyBytes, PyCapsule, PyComplex, PyDict, PyFloat, PyFrozenSet, PyList,
     PyMapping, PyModule, PySequence, PySet, PySlice, PyString, PyTraceback, PyTuple, PyType,
+    PyWeakref, PyWeakrefProxy, PyWeakrefReference,
 };
 use crate::{ffi, Bound, PyAny, PyResult};
 
@@ -32,3 +33,6 @@ impl Sealed for Bound<'_, PyString> {}
 impl Sealed for Bound<'_, PyTraceback> {}
 impl Sealed for Bound<'_, PyTuple> {}
 impl Sealed for Bound<'_, PyType> {}
+impl Sealed for Bound<'_, PyWeakref> {}
+impl Sealed for Bound<'_, PyWeakrefProxy> {}
+impl Sealed for Bound<'_, PyWeakrefReference> {}

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -33,7 +33,7 @@ impl PyTypeCheck for PyWeakref {
 /// syntax these methods are separated into a trait, because stable Rust does not yet support
 /// `arbitrary_self_types`.
 #[doc(alias = "PyWeakref")]
-pub trait PyWeakrefMethods<'py> {
+pub trait PyWeakrefMethods<'py>: crate::sealed::Sealed {
     /// Upgrade the weakref to a direct Bound object reference.
     ///
     /// It is named `upgrade` to be inline with [rust's `Weak::upgrade`](std::rc::Weak::upgrade).


### PR DESCRIPTION
This is a kind of fixup to bind `PyWeakrefMethods` in line with the rest of our `PyXMethods` traits, which are all sealed.