### PR TITLE
migrate `IntoPyCallbackOutput` to use `IntoPyObject`

### DIFF
--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -334,9 +334,9 @@ pub struct IterBaseTag;
 
 impl IterBaseTag {
     #[inline]
-    pub fn convert<Value, Target>(self, py: Python<'_>, value: Value) -> PyResult<Target>
+    pub fn convert<'py, Value, Target>(self, py: Python<'py>, value: Value) -> PyResult<Target>
     where
-        Value: IntoPyCallbackOutput<Target>,
+        Value: IntoPyCallbackOutput<'py, Target>,
     {
         value.convert(py)
     }
@@ -355,13 +355,13 @@ pub struct IterOptionTag;
 
 impl IterOptionTag {
     #[inline]
-    pub fn convert<Value>(
+    pub fn convert<'py, Value>(
         self,
-        py: Python<'_>,
+        py: Python<'py>,
         value: Option<Value>,
     ) -> PyResult<*mut ffi::PyObject>
     where
-        Value: IntoPyCallbackOutput<*mut ffi::PyObject>,
+        Value: IntoPyCallbackOutput<'py, *mut ffi::PyObject>,
     {
         match value {
             Some(value) => value.convert(py),
@@ -383,13 +383,13 @@ pub struct IterResultOptionTag;
 
 impl IterResultOptionTag {
     #[inline]
-    pub fn convert<Value, Error>(
+    pub fn convert<'py, Value, Error>(
         self,
-        py: Python<'_>,
+        py: Python<'py>,
         value: Result<Option<Value>, Error>,
     ) -> PyResult<*mut ffi::PyObject>
     where
-        Value: IntoPyCallbackOutput<*mut ffi::PyObject>,
+        Value: IntoPyCallbackOutput<'py, *mut ffi::PyObject>,
         Error: Into<PyErr>,
     {
         match value {
@@ -415,9 +415,9 @@ pub struct AsyncIterBaseTag;
 
 impl AsyncIterBaseTag {
     #[inline]
-    pub fn convert<Value, Target>(self, py: Python<'_>, value: Value) -> PyResult<Target>
+    pub fn convert<'py, Value, Target>(self, py: Python<'py>, value: Value) -> PyResult<Target>
     where
-        Value: IntoPyCallbackOutput<Target>,
+        Value: IntoPyCallbackOutput<'py, Target>,
     {
         value.convert(py)
     }
@@ -436,13 +436,13 @@ pub struct AsyncIterOptionTag;
 
 impl AsyncIterOptionTag {
     #[inline]
-    pub fn convert<Value>(
+    pub fn convert<'py, Value>(
         self,
-        py: Python<'_>,
+        py: Python<'py>,
         value: Option<Value>,
     ) -> PyResult<*mut ffi::PyObject>
     where
-        Value: IntoPyCallbackOutput<*mut ffi::PyObject>,
+        Value: IntoPyCallbackOutput<'py, *mut ffi::PyObject>,
     {
         match value {
             Some(value) => value.convert(py),
@@ -464,13 +464,13 @@ pub struct AsyncIterResultOptionTag;
 
 impl AsyncIterResultOptionTag {
     #[inline]
-    pub fn convert<Value, Error>(
+    pub fn convert<'py, Value, Error>(
         self,
-        py: Python<'_>,
+        py: Python<'py>,
         value: Result<Option<Value>, Error>,
     ) -> PyResult<*mut ffi::PyObject>
     where
-        Value: IntoPyCallbackOutput<*mut ffi::PyObject>,
+        Value: IntoPyCallbackOutput<'py, *mut ffi::PyObject>,
         Error: Into<PyErr>,
     {
         match value {

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -344,7 +344,7 @@ impl<'py, T: PyClass> From<Bound<'py, T>> for PyClassInitializer<T> {
 
 // Implementation used by proc macros to allow anything convertible to PyClassInitializer<T> to be
 // the return value of pyclass #[new] method (optionally wrapped in `Result<U, E>`).
-impl<T, U> IntoPyCallbackOutput<PyClassInitializer<T>> for U
+impl<T, U> IntoPyCallbackOutput<'_, PyClassInitializer<T>> for U
 where
     T: PyClass,
     U: Into<PyClassInitializer<T>>,

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -104,7 +104,7 @@ impl PyCFunction {
     ) -> PyResult<Bound<'py, Self>>
     where
         F: Fn(&Bound<'_, PyTuple>, Option<&Bound<'_, PyDict>>) -> R + Send + 'static,
-        R: crate::callback::IntoPyCallbackOutput<*mut ffi::PyObject>,
+        for<'p> R: crate::callback::IntoPyCallbackOutput<'p, *mut ffi::PyObject>,
     {
         let name = name.unwrap_or(ffi::c_str!("pyo3-closure"));
         let doc = doc.unwrap_or(ffi::c_str!(""));
@@ -142,7 +142,7 @@ impl PyCFunction {
     ) -> PyResult<Bound<'py, Self>>
     where
         F: Fn(&Bound<'_, PyTuple>, Option<&Bound<'_, PyDict>>) -> R + Send + 'static,
-        R: crate::callback::IntoPyCallbackOutput<*mut ffi::PyObject>,
+        for<'p> R: crate::callback::IntoPyCallbackOutput<'p, *mut ffi::PyObject>,
     {
         Self::new_closure(py, name, doc, closure)
     }
@@ -185,7 +185,7 @@ unsafe extern "C" fn run_closure<F, R>(
 ) -> *mut ffi::PyObject
 where
     F: Fn(&Bound<'_, PyTuple>, Option<&Bound<'_, PyDict>>) -> R + Send + 'static,
-    R: crate::callback::IntoPyCallbackOutput<*mut ffi::PyObject>,
+    for<'py> R: crate::callback::IntoPyCallbackOutput<'py, *mut ffi::PyObject>,
 {
     use crate::types::any::PyAnyMethods;
 

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -305,7 +305,7 @@ pub trait PyModuleMethods<'py>: crate::sealed::Sealed {
     /// instead.
     fn add_wrapped<T>(&self, wrapper: &impl Fn(Python<'py>) -> T) -> PyResult<()>
     where
-        T: IntoPyCallbackOutput<PyObject>;
+        T: IntoPyCallbackOutput<'py, PyObject>;
 
     /// Adds a submodule to a module.
     ///
@@ -490,7 +490,7 @@ impl<'py> PyModuleMethods<'py> for Bound<'py, PyModule> {
 
     fn add_wrapped<T>(&self, wrapper: &impl Fn(Python<'py>) -> T) -> PyResult<()>
     where
-        T: IntoPyCallbackOutput<PyObject>,
+        T: IntoPyCallbackOutput<'py, PyObject>,
     {
         fn inner(module: &Bound<'_, PyModule>, object: Bound<'_, PyAny>) -> PyResult<()> {
             let name = object.getattr(__name__(module.py()))?;


### PR DESCRIPTION
This migrates `IntoPyCallbackOutput` blanket to use `IntoPyObject`.
