### PR TITLE
ci: run benchmarks on ubuntu 22.04

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -15,7 +15,8 @@ concurrency:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-latest
+    # No support for 24.04, see https://github.com/CodSpeedHQ/runner/issues/42
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Just fixing the latest CI failure on the benchmark jobs. Will merge immediately as trivial.