### PR TITLE
Moving `PyObjectInit` into `impl_` and sealing the trait

### DIFF
--- a/newsfragments/4611.changed.md
+++ b/newsfragments/4611.changed.md
@@ -1,0 +1,1 @@
+`PyNativeTypeInitializer` and `PyObjectInit` are moved into `impl_`. `PyObjectInit` is now a Sealed trait

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -16,6 +16,7 @@ pub(crate) mod not_send;
 pub mod panic;
 pub mod pycell;
 pub mod pyclass;
+pub mod pyclass_init;
 pub mod pyfunction;
 pub mod pymethods;
 pub mod pymodule;

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -7,10 +7,10 @@ use crate::{
     impl_::{
         freelist::FreeList,
         pycell::{GetBorrowChecker, PyClassMutability, PyClassObjectLayout},
+        pyclass_init::PyObjectInit,
         pymethods::{PyGetterDef, PyMethodDefType},
     },
     pycell::PyBorrowError,
-    pyclass_init::PyObjectInit,
     types::{any::PyAnyMethods, PyBool},
     Borrowed, BoundObject, IntoPy, Py, PyAny, PyClass, PyErr, PyRef, PyResult, PyTypeInfo, Python,
 };

--- a/src/impl_/pyclass_init.rs
+++ b/src/impl_/pyclass_init.rs
@@ -21,8 +21,6 @@ pub trait PyObjectInit<T>: Sized + Sealed {
 
     #[doc(hidden)]
     fn can_be_subclassed(&self) -> bool;
-
-    private_decl! {}
 }
 
 /// Initializer for Python native types, like `PyDict`.
@@ -88,6 +86,4 @@ impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
     fn can_be_subclassed(&self) -> bool {
         true
     }
-
-    private_impl! {}
 }

--- a/src/impl_/pyclass_init.rs
+++ b/src/impl_/pyclass_init.rs
@@ -1,0 +1,93 @@
+//! Contains initialization utilities for `#[pyclass]`.
+use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::internal::get_slot::TP_ALLOC;
+use crate::types::PyType;
+use crate::{ffi, Borrowed, PyErr, PyResult, Python};
+use crate::{ffi::PyTypeObject, sealed::Sealed, type_object::PyTypeInfo};
+use std::marker::PhantomData;
+
+/// Initializer for Python types.
+///
+/// This trait is intended to use internally for distinguishing `#[pyclass]` and
+/// Python native types.
+pub trait PyObjectInit<T>: Sized + Sealed {
+    /// # Safety
+    /// - `subtype` must be a valid pointer to a type object of T or a subclass.
+    unsafe fn into_new_object(
+        self,
+        py: Python<'_>,
+        subtype: *mut PyTypeObject,
+    ) -> PyResult<*mut ffi::PyObject>;
+
+    #[doc(hidden)]
+    fn can_be_subclassed(&self) -> bool;
+
+    private_decl! {}
+}
+
+/// Initializer for Python native types, like `PyDict`.
+pub struct PyNativeTypeInitializer<T: PyTypeInfo>(pub PhantomData<T>);
+
+impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
+    unsafe fn into_new_object(
+        self,
+        py: Python<'_>,
+        subtype: *mut PyTypeObject,
+    ) -> PyResult<*mut ffi::PyObject> {
+        unsafe fn inner(
+            py: Python<'_>,
+            type_object: *mut PyTypeObject,
+            subtype: *mut PyTypeObject,
+        ) -> PyResult<*mut ffi::PyObject> {
+            // HACK (due to FIXME below): PyBaseObject_Type's tp_new isn't happy with NULL arguments
+            let is_base_object = type_object == std::ptr::addr_of_mut!(ffi::PyBaseObject_Type);
+            let subtype_borrowed: Borrowed<'_, '_, PyType> = subtype
+                .cast::<ffi::PyObject>()
+                .assume_borrowed_unchecked(py)
+                .downcast_unchecked();
+
+            if is_base_object {
+                let alloc = subtype_borrowed
+                    .get_slot(TP_ALLOC)
+                    .unwrap_or(ffi::PyType_GenericAlloc);
+
+                let obj = alloc(subtype, 0);
+                return if obj.is_null() {
+                    Err(PyErr::fetch(py))
+                } else {
+                    Ok(obj)
+                };
+            }
+
+            #[cfg(Py_LIMITED_API)]
+            unreachable!("subclassing native types is not possible with the `abi3` feature");
+
+            #[cfg(not(Py_LIMITED_API))]
+            {
+                match (*type_object).tp_new {
+                    // FIXME: Call __new__ with actual arguments
+                    Some(newfunc) => {
+                        let obj = newfunc(subtype, std::ptr::null_mut(), std::ptr::null_mut());
+                        if obj.is_null() {
+                            Err(PyErr::fetch(py))
+                        } else {
+                            Ok(obj)
+                        }
+                    }
+                    None => Err(crate::exceptions::PyTypeError::new_err(
+                        "base type without tp_new",
+                    )),
+                }
+            }
+        }
+        let type_object = T::type_object_raw(py);
+        inner(py, type_object, subtype)
+    }
+
+    #[inline]
+    fn can_be_subclassed(&self) -> bool {
+        true
+    }
+
+    private_impl! {}
+}

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -2,106 +2,18 @@
 use crate::callback::IntoPyCallbackOutput;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::impl_::pyclass::{PyClassBaseType, PyClassDict, PyClassThreadChecker, PyClassWeakRef};
-use crate::internal::get_slot::TP_ALLOC;
-use crate::types::{PyAnyMethods, PyType};
-use crate::{ffi, Borrowed, Bound, Py, PyClass, PyErr, PyResult, Python};
+use crate::impl_::pyclass_init::{PyNativeTypeInitializer, PyObjectInit};
+use crate::types::PyAnyMethods;
+use crate::{ffi, Bound, Py, PyClass, PyResult, Python};
 use crate::{
     ffi::PyTypeObject,
     pycell::impl_::{PyClassBorrowChecker, PyClassMutability, PyClassObjectContents},
-    sealed::Sealed,
-    type_object::PyTypeInfo,
 };
 use std::{
     cell::UnsafeCell,
     marker::PhantomData,
     mem::{ManuallyDrop, MaybeUninit},
 };
-
-/// Initializer for Python types.
-///
-/// This trait is intended to use internally for distinguishing `#[pyclass]` and
-/// Python native types.
-pub trait PyObjectInit<T>: Sized + Sealed {
-    /// # Safety
-    /// - `subtype` must be a valid pointer to a type object of T or a subclass.
-    unsafe fn into_new_object(
-        self,
-        py: Python<'_>,
-        subtype: *mut PyTypeObject,
-    ) -> PyResult<*mut ffi::PyObject>;
-
-    #[doc(hidden)]
-    fn can_be_subclassed(&self) -> bool;
-
-    private_decl! {}
-}
-
-/// Initializer for Python native types, like `PyDict`.
-pub struct PyNativeTypeInitializer<T: PyTypeInfo>(PhantomData<T>);
-
-impl<T: PyTypeInfo> PyObjectInit<T> for PyNativeTypeInitializer<T> {
-    unsafe fn into_new_object(
-        self,
-        py: Python<'_>,
-        subtype: *mut PyTypeObject,
-    ) -> PyResult<*mut ffi::PyObject> {
-        unsafe fn inner(
-            py: Python<'_>,
-            type_object: *mut PyTypeObject,
-            subtype: *mut PyTypeObject,
-        ) -> PyResult<*mut ffi::PyObject> {
-            // HACK (due to FIXME below): PyBaseObject_Type's tp_new isn't happy with NULL arguments
-            let is_base_object = type_object == std::ptr::addr_of_mut!(ffi::PyBaseObject_Type);
-            let subtype_borrowed: Borrowed<'_, '_, PyType> = subtype
-                .cast::<ffi::PyObject>()
-                .assume_borrowed_unchecked(py)
-                .downcast_unchecked();
-
-            if is_base_object {
-                let alloc = subtype_borrowed
-                    .get_slot(TP_ALLOC)
-                    .unwrap_or(ffi::PyType_GenericAlloc);
-
-                let obj = alloc(subtype, 0);
-                return if obj.is_null() {
-                    Err(PyErr::fetch(py))
-                } else {
-                    Ok(obj)
-                };
-            }
-
-            #[cfg(Py_LIMITED_API)]
-            unreachable!("subclassing native types is not possible with the `abi3` feature");
-
-            #[cfg(not(Py_LIMITED_API))]
-            {
-                match (*type_object).tp_new {
-                    // FIXME: Call __new__ with actual arguments
-                    Some(newfunc) => {
-                        let obj = newfunc(subtype, std::ptr::null_mut(), std::ptr::null_mut());
-                        if obj.is_null() {
-                            Err(PyErr::fetch(py))
-                        } else {
-                            Ok(obj)
-                        }
-                    }
-                    None => Err(crate::exceptions::PyTypeError::new_err(
-                        "base type without tp_new",
-                    )),
-                }
-            }
-        }
-        let type_object = T::type_object_raw(py);
-        inner(py, type_object, subtype)
-    }
-
-    #[inline]
-    fn can_be_subclassed(&self) -> bool {
-        true
-    }
-
-    private_impl! {}
-}
 
 /// Initializer for our `#[pyclass]` system.
 ///

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -212,8 +212,6 @@ impl<T: PyClass> PyObjectInit<T> for PyClassInitializer<T> {
     fn can_be_subclassed(&self) -> bool {
         !matches!(self.0, PyClassInitializerImpl::Existing(..))
     }
-
-    private_impl! {}
 }
 
 impl<T> From<T> for PyClassInitializer<T>

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -8,6 +8,7 @@ use crate::{ffi, Borrowed, Bound, Py, PyClass, PyErr, PyResult, Python};
 use crate::{
     ffi::PyTypeObject,
     pycell::impl_::{PyClassBorrowChecker, PyClassMutability, PyClassObjectContents},
+    sealed::Sealed,
     type_object::PyTypeInfo,
 };
 use std::{
@@ -20,7 +21,7 @@ use std::{
 ///
 /// This trait is intended to use internally for distinguishing `#[pyclass]` and
 /// Python native types.
-pub trait PyObjectInit<T>: Sized {
+pub trait PyObjectInit<T>: Sized + Sealed {
     /// # Safety
     /// - `subtype` must be a valid pointer to a type object of T or a subclass.
     unsafe fn into_new_object(

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -8,7 +8,7 @@ use crate::{ffi, Bound, PyAny, PyResult};
 use crate::pyclass_init::PyClassInitializer;
 
 use crate::impl_::{
-    pyclass_init::{PyNativeTypeInitializer, PyObjectInit},
+    pyclass_init::PyNativeTypeInitializer,
     pymethods::PyMethodDef,
     pymodule::{AddClassToModule, AddTypeToModule, ModuleDef},
 };
@@ -50,6 +50,5 @@ impl<T> Sealed for AddClassToModule<T> {}
 impl Sealed for PyMethodDef {}
 impl Sealed for ModuleDef {}
 
-impl<T: PyObjectInit<T>> Sealed for T {}
 impl<T: crate::type_object::PyTypeInfo> Sealed for PyNativeTypeInitializer<T> {}
 impl<T: crate::pyclass::PyClass> Sealed for PyClassInitializer<T> {}

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -10,6 +10,8 @@ use crate::impl_::{
     pymodule::{AddClassToModule, AddTypeToModule, ModuleDef},
 };
 
+use crate::pyclass_init::{PyClassInitializer, PyNativeTypeInitializer, PyObjectInit};
+
 pub trait Sealed {}
 
 // for FfiPtrExt
@@ -46,3 +48,7 @@ impl<T> Sealed for AddTypeToModule<T> {}
 impl<T> Sealed for AddClassToModule<T> {}
 impl Sealed for PyMethodDef {}
 impl Sealed for ModuleDef {}
+
+impl<T: PyObjectInit<T>> Sealed for T {}
+impl<T: crate::type_object::PyTypeInfo> Sealed for PyNativeTypeInitializer<T> {}
+impl<T: crate::pyclass::PyClass> Sealed for PyClassInitializer<T> {}

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -5,12 +5,13 @@ use crate::types::{
 };
 use crate::{ffi, Bound, PyAny, PyResult};
 
+use crate::pyclass_init::PyClassInitializer;
+
 use crate::impl_::{
+    pyclass_init::{PyNativeTypeInitializer, PyObjectInit},
     pymethods::PyMethodDef,
     pymodule::{AddClassToModule, AddTypeToModule, ModuleDef},
 };
-
-use crate::pyclass_init::{PyClassInitializer, PyNativeTypeInitializer, PyObjectInit};
 
 pub trait Sealed {}
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -49,7 +49,7 @@ pyobject_native_type_sized!(PyAny, ffi::PyObject);
 impl crate::impl_::pyclass::PyClassBaseType for PyAny {
     type LayoutAsBase = crate::impl_::pycell::PyClassObjectBase<ffi::PyObject>;
     type BaseNativeType = PyAny;
-    type Initializer = crate::pyclass_init::PyNativeTypeInitializer<Self>;
+    type Initializer = crate::impl_::pyclass_init::PyNativeTypeInitializer<Self>;
     type PyClassMutability = crate::pycell::impl_::ImmutableClass;
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -200,7 +200,7 @@ macro_rules! pyobject_subclassable_native_type {
         impl<$($generics,)*> $crate::impl_::pyclass::PyClassBaseType for $name {
             type LayoutAsBase = $crate::impl_::pycell::PyClassObjectBase<$layout>;
             type BaseNativeType = $name;
-            type Initializer = $crate::pyclass_init::PyNativeTypeInitializer<Self>;
+            type Initializer = $crate::impl_::pyclass_init::PyNativeTypeInitializer<Self>;
             type PyClassMutability = $crate::pycell::impl_::ImmutableClass;
         }
     }


### PR DESCRIPTION
Potentially closes #4552 

`PyNativeTypeInitializer` and `PyObjectInit` are moved into `impl_` but not `PyClassInitializer` as it is used in the prelude and used in the lib so I assume that is available to the public.

`PyObjectInit` is now a Sealed trait