### PR TITLE
deps: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,13 @@ inventory = { version = "0.3.0", optional = true }
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0.1", optional = true }
 chrono = { version = "0.4.25", default-features = false, optional = true }
-chrono-tz = { version = ">= 0.6, < 0.11", default-features = false, optional = true }
+chrono-tz = { version = ">= 0.10, < 0.11", default-features = false, optional = true }
 either = { version = "1.9", optional = true }
-eyre = { version = ">= 0.4, < 0.7", optional = true }
-hashbrown = { version = ">= 0.9, < 0.16", optional = true }
-indexmap = { version = ">= 1.6, < 3", optional = true }
+eyre = { version = ">= 0.6.8, < 0.7", optional = true }
+hashbrown = { version = ">= 0.14.5, < 0.16", optional = true }
+indexmap = { version = ">= 2.5.0, < 3", optional = true }
 num-bigint = { version = "0.4.2", optional = true }
-num-complex = { version = ">= 0.2, < 0.5", optional = true }
+num-complex = { version = ">= 0.4.6, < 0.5", optional = true }
 num-rational = {version = "0.4.1", optional = true }
 rust_decimal = { version = "1.15", default-features = false, optional = true }
 serde = { version = "1.0", optional = true }
@@ -52,7 +52,7 @@ portable-atomic = "1.0"
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 chrono = "0.4.25"
-chrono-tz = ">= 0.6, < 0.11"
+chrono-tz = ">= 0.10, < 0.11"
 # Required for "and $N others" normalization
 trybuild = ">=1.0.70"
 proptest = { version = "1.0", default-features = false, features = ["std"] }

--- a/newsfragments/4617.packaging.md
+++ b/newsfragments/4617.packaging.md
@@ -1,0 +1,13 @@
+deps: update dependencies
+
+- eyre: 0.4 => 0.6.8
+- hashbrown: 0.9 => 0.14.5
+- indexmap: 1.6 => 2.5.0
+- num-complex: 0.2 => 0.4.6
+- chrono-tz: 0.6 => 0.10
+
+Eyre min-version is limited to 0.6.8 to be compatible with MSRV 1.63
+Hashbrown min-version is limited to 0.14.5:
+  https://github.com/rust-lang/hashbrown/issues/574
+Indexmap min-version is limited to 2.5.0 to be compatible with hashbrown 0.14.5
+


### PR DESCRIPTION
deps: update dependencies

- eyre: 0.4 => 0.6.8
- hashbrown: 0.9 => 0.14.5
- indexmap: 1.6 => 2.5.0
- num-complex: 0.2 => 0.4.6
- chrono-tz: 0.6 => 0.10

Eyre min-version is limited to 0.6.8 to be compatible with MSRV 1.63
Hashbrown min-version is limited to 0.14.5: https://github.com/rust-lang/hashbrown/issues/574
Indexmap min-version is limited to 2.5.0 to be compatible with hashbrown 0.14.5
