### PR TITLE
deprecate `IntoPy` in favor or `IntoPyObject`

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1290,7 +1290,7 @@ Python::with_gil(|py| {
 # .unwrap();
 ```
 
-WARNING: `Py::new` and `.into_py` are currently inconsistent. Note how the constructed value is _not_ an instance of the specific variant. For this reason, constructing values is only recommended using `.into_py`.
+WARNING: `Py::new` and `.into_pyobject` are currently inconsistent. Note how the constructed value is _not_ an instance of the specific variant. For this reason, constructing values is only recommended using `.into_pyobject`.
 
 ```rust
 # use pyo3::prelude::*;

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1258,8 +1258,8 @@ enum Shape {
 
 # #[cfg(Py_3_10)]
 Python::with_gil(|py| {
-    let circle = Shape::Circle { radius: 10.0 }.into_py(py);
-    let square = Shape::RegularPolygon(4, 10.0).into_py(py);
+    let circle = Shape::Circle { radius: 10.0 }.into_pyobject(py)?;
+    let square = Shape::RegularPolygon(4, 10.0).into_pyobject(py)?;
     let cls = py.get_type::<Shape>();
     pyo3::py_run!(py, circle square cls, r#"
         assert isinstance(circle, cls)
@@ -1284,8 +1284,10 @@ Python::with_gil(|py| {
 
         assert count_vertices(cls, circle) == 0
         assert count_vertices(cls, square) == 4
-    "#)
+    "#);
+#   Ok::<_, PyErr>(())
 })
+# .unwrap();
 ```
 
 WARNING: `Py::new` and `.into_py` are currently inconsistent. Note how the constructed value is _not_ an instance of the specific variant. For this reason, constructing values is only recommended using `.into_py`.
@@ -1404,6 +1406,7 @@ impl<'a, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'py> for &'a
     }
 }
 
+#[allow(deprecated)]
 impl pyo3::IntoPy<PyObject> for MyClass {
     fn into_py(self, py: pyo3::Python<'_>) -> pyo3::PyObject {
         pyo3::IntoPy::into_py(pyo3::Py::new(py, self).unwrap(), py)

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -97,19 +97,21 @@ given signatures should be interpreted as follows:
 
     ```rust
     use pyo3::class::basic::CompareOp;
+    use pyo3::types::PyNotImplemented;
 
     # use pyo3::prelude::*;
+    # use pyo3::BoundObject;
     #
     # #[pyclass]
     # struct Number(i32);
     #
     #[pymethods]
     impl Number {
-        fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyObject {
+        fn __richcmp__<'py>(&self, other: &Self, op: CompareOp, py: Python<'py>) -> PyResult<Borrowed<'py, 'py, PyAny>> {
             match op {
-                CompareOp::Eq => (self.0 == other.0).into_py(py),
-                CompareOp::Ne => (self.0 != other.0).into_py(py),
-                _ => py.NotImplemented(),
+                CompareOp::Eq => Ok((self.0 == other.0).into_pyobject(py)?.into_any()),
+                CompareOp::Ne => Ok((self.0 != other.0).into_pyobject(py)?.into_any()),
+                _ => Ok(PyNotImplemented::get(py).into_any()),
             }
         }
     }

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -615,6 +615,7 @@ use pyo3::prelude::*;
 # #[allow(dead_code)]
 struct MyPyObjectWrapper(PyObject);
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for MyPyObjectWrapper {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.0

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -1217,6 +1217,7 @@ Python::with_gil(|py| {
 After, some type annotations may be necessary:
 
 ```rust
+# #![allow(deprecated)]
 # use pyo3::prelude::*;
 #
 # fn main() {
@@ -1695,6 +1696,7 @@ After
 # #[allow(dead_code)]
 struct MyPyObjectWrapper(PyObject);
 
+# #[allow(deprecated)]
 impl IntoPy<PyObject> for MyPyObjectWrapper {
     fn into_py(self, _py: Python<'_>) -> PyObject {
         self.0
@@ -1714,6 +1716,7 @@ let obj = PyObject::from_py(1.234, py);
 
 After:
 ```rust
+# #![allow(deprecated)]
 # use pyo3::prelude::*;
 # Python::with_gil(|py| {
 let obj: PyObject = 1.234.into_py(py);

--- a/newsfragments/4618.changed.md
+++ b/newsfragments/4618.changed.md
@@ -1,0 +1,1 @@
+deprecate `IntoPy` in favor of `IntoPyObject`

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -213,7 +213,10 @@ pub fn gen_py_const(cls: &syn::Type, spec: &ConstSpec, ctx: &Ctx) -> MethodAndMe
 
     let associated_method = quote! {
         fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
-            ::std::result::Result::Ok(#pyo3_path::IntoPy::into_py(#cls::#member, py))
+            #pyo3_path::IntoPyObject::into_pyobject(#cls::#member, py)
+                .map(#pyo3_path::BoundObject::into_any)
+                .map(#pyo3_path::BoundObject::unbind)
+                .map_err(::std::convert::Into::into)
         }
     };
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -19,16 +19,17 @@ use std::convert::Infallible;
 ///
 /// ```rust
 /// use pyo3::prelude::*;
-/// use pyo3::types::PyString;
 /// use pyo3::ffi;
 ///
 /// Python::with_gil(|py| {
-///     let s: Py<PyString> = "foo".into_py(py);
+///     let s = "foo".into_pyobject(py)?;
 ///     let ptr = s.as_ptr();
 ///
 ///     let is_really_a_pystring = unsafe { ffi::PyUnicode_CheckExact(ptr) };
 ///     assert_eq!(is_really_a_pystring, 1);
-/// });
+/// #   Ok::<_, PyErr>(())
+/// })
+/// # .unwrap();
 /// ```
 ///
 /// # Safety
@@ -41,18 +42,20 @@ use std::convert::Infallible;
 /// # use pyo3::ffi;
 /// #
 /// Python::with_gil(|py| {
-///     let ptr: *mut ffi::PyObject = 0xabad1dea_u32.into_py(py).as_ptr();
+///     let ptr: *mut ffi::PyObject = 0xabad1dea_u32.into_pyobject(py)?.as_ptr();
 ///
 ///     let isnt_a_pystring = unsafe {
 ///         // `ptr` is dangling, this is UB
 ///         ffi::PyUnicode_CheckExact(ptr)
 ///     };
-/// #    assert_eq!(isnt_a_pystring, 0);
-/// });
+/// #   assert_eq!(isnt_a_pystring, 0);
+/// #   Ok::<_, PyErr>(())
+/// })
+/// # .unwrap();
 /// ```
 ///
 /// This happens because the pointer returned by `as_ptr` does not carry any lifetime information
-/// and the Python object is dropped immediately after the `0xabad1dea_u32.into_py(py).as_ptr()`
+/// and the Python object is dropped immediately after the `0xabad1dea_u32.into_pyobject(py).as_ptr()`
 /// expression is evaluated. To fix the problem, bind Python object to a local variable like earlier
 /// to keep the Python object alive until the end of its scope.
 ///
@@ -100,6 +103,7 @@ pub trait ToPyObject {
 /// However, it may not be desirable to expose the existence of `Number` to Python code.
 /// `IntoPy` allows us to define a conversion to an appropriate Python object.
 /// ```rust
+/// #![allow(deprecated)]
 /// use pyo3::prelude::*;
 ///
 /// # #[allow(dead_code)]
@@ -121,6 +125,7 @@ pub trait ToPyObject {
 /// This is useful for types like enums that can carry different types.
 ///
 /// ```rust
+/// #![allow(deprecated)]
 /// use pyo3::prelude::*;
 ///
 /// enum Value {
@@ -160,6 +165,10 @@ pub trait ToPyObject {
         note = "if you do not wish to have a corresponding Python type, implement it manually",
         note = "if you do not own `{Self}` you can perform a manual conversion to one of the types in `pyo3::types::*`"
     )
+)]
+#[deprecated(
+    since = "0.23.0",
+    note = "`IntoPy` is going to be replaced by `IntoPyObject`. See the migration guide (https://pyo3.rs/v0.23/migration) for more information."
 )]
 pub trait IntoPy<T>: Sized {
     /// Performs the conversion.
@@ -503,6 +512,7 @@ where
 }
 
 /// Converts `()` to an empty Python tuple.
+#[allow(deprecated)]
 impl IntoPy<Py<PyTuple>> for () {
     fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
         PyTuple::empty(py).unbind()

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -42,6 +42,7 @@ use std::convert::Infallible;
 /// # use pyo3::ffi;
 /// #
 /// Python::with_gil(|py| {
+///     // ERROR: calling `.as_ptr()` will throw away the temporary object and leave `ptr` dangling.
 ///     let ptr: *mut ffi::PyObject = 0xabad1dea_u32.into_pyobject(py)?.as_ptr();
 ///
 ///     let isnt_a_pystring = unsafe {

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -39,9 +39,9 @@ use crate::exceptions::PyValueError;
 use crate::pybacked::PyBackedStr;
 use crate::sync::GILOnceCell;
 use crate::types::{any::PyAnyMethods, PyType};
+use crate::{intern, Bound, FromPyObject, Py, PyAny, PyErr, PyObject, PyResult, Python};
 #[allow(deprecated)]
-use crate::ToPyObject;
-use crate::{intern, Bound, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python};
+use crate::{IntoPy, ToPyObject};
 use chrono_tz::Tz;
 use std::str::FromStr;
 
@@ -53,6 +53,7 @@ impl ToPyObject for Tz {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for Tz {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -46,15 +46,16 @@
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject, exceptions::PyTypeError, types::any::PyAnyMethods, Bound,
-    BoundObject, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
+    BoundObject, FromPyObject, PyAny, PyErr, PyObject, PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 use either::Either;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "either")))]
+#[allow(deprecated)]
 impl<L, R> IntoPy<PyObject> for Either<L, R>
 where
     L: IntoPy<PyObject>,

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -16,8 +16,6 @@
 //!
 //! Note that you must use compatible versions of hashbrown and PyO3.
 //! The required hashbrown version may vary based on the version of PyO3.
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     types::{
@@ -27,8 +25,10 @@ use crate::{
         set::{new_from_iter, try_new_from_iter, PySetMethods},
         PyDict, PyFrozenSet, PySet,
     },
-    Bound, FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
+    Bound, FromPyObject, PyAny, PyErr, PyObject, PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 use std::{cmp, hash};
 
 #[allow(deprecated)]
@@ -47,6 +47,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<K, V, H> IntoPy<PyObject> for hashbrown::HashMap<K, V, H>
 where
     K: hash::Hash + cmp::Eq + IntoPy<PyObject>,
@@ -128,6 +129,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<K, S> IntoPy<PyObject> for hashbrown::HashSet<K, S>
 where
     K: IntoPy<PyObject> + Eq + hash::Hash,
@@ -193,7 +195,7 @@ mod tests {
     use crate::types::IntoPyDict;
 
     #[test]
-    fn test_hashbrown_hashmap_to_python() {
+    fn test_hashbrown_hashmap_into_pyobject() {
         Python::with_gil(|py| {
             let mut map = hashbrown::HashMap::<i32, i32>::new();
             map.insert(1, 1);
@@ -211,27 +213,6 @@ mod tests {
                     == 1
             );
             assert_eq!(map, py_map.extract().unwrap());
-        });
-    }
-    #[test]
-    fn test_hashbrown_hashmap_into_python() {
-        Python::with_gil(|py| {
-            let mut map = hashbrown::HashMap::<i32, i32>::new();
-            map.insert(1, 1);
-
-            let m: PyObject = map.into_py(py);
-            let py_map = m.downcast_bound::<PyDict>(py).unwrap();
-
-            assert!(py_map.len() == 1);
-            assert!(
-                py_map
-                    .get_item(1)
-                    .unwrap()
-                    .unwrap()
-                    .extract::<i32>()
-                    .unwrap()
-                    == 1
-            );
         });
     }
 
@@ -270,13 +251,13 @@ mod tests {
     }
 
     #[test]
-    fn test_hashbrown_hashset_into_py() {
+    fn test_hashbrown_hashset_into_pyobject() {
         Python::with_gil(|py| {
             let hs: hashbrown::HashSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();
 
-            let hso: PyObject = hs.clone().into_py(py);
+            let hso = hs.clone().into_pyobject(py).unwrap();
 
-            assert_eq!(hs, hso.extract(py).unwrap());
+            assert_eq!(hs, hso.extract().unwrap());
         });
     }
 }

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -89,9 +89,9 @@
 
 use crate::conversion::IntoPyObject;
 use crate::types::*;
+use crate::{Bound, FromPyObject, PyErr, PyObject, Python};
 #[allow(deprecated)]
-use crate::ToPyObject;
-use crate::{Bound, FromPyObject, IntoPy, PyErr, PyObject, Python};
+use crate::{IntoPy, ToPyObject};
 use std::{cmp, hash};
 
 #[allow(deprecated)]
@@ -110,6 +110,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<K, V, H> IntoPy<PyObject> for indexmap::IndexMap<K, V, H>
 where
     K: hash::Hash + cmp::Eq + IntoPy<PyObject>,
@@ -183,10 +184,10 @@ where
 mod test_indexmap {
 
     use crate::types::*;
-    use crate::{IntoPy, IntoPyObject, PyObject, Python};
+    use crate::{IntoPyObject, Python};
 
     #[test]
-    fn test_indexmap_indexmap_to_python() {
+    fn test_indexmap_indexmap_into_pyobject() {
         Python::with_gil(|py| {
             let mut map = indexmap::IndexMap::<i32, i32>::new();
             map.insert(1, 1);
@@ -206,28 +207,6 @@ mod test_indexmap {
             assert_eq!(
                 map,
                 py_map.extract::<indexmap::IndexMap::<i32, i32>>().unwrap()
-            );
-        });
-    }
-
-    #[test]
-    fn test_indexmap_indexmap_into_python() {
-        Python::with_gil(|py| {
-            let mut map = indexmap::IndexMap::<i32, i32>::new();
-            map.insert(1, 1);
-
-            let m: PyObject = map.into_py(py);
-            let py_map = m.downcast_bound::<PyDict>(py).unwrap();
-
-            assert!(py_map.len() == 1);
-            assert!(
-                py_map
-                    .get_item(1)
-                    .unwrap()
-                    .unwrap()
-                    .extract::<i32>()
-                    .unwrap()
-                    == 1
             );
         });
     }

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -49,15 +49,15 @@
 
 #[cfg(Py_LIMITED_API)]
 use crate::types::{bytes::PyBytesMethods, PyBytes};
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     ffi,
     instance::Bound,
     types::{any::PyAnyMethods, PyInt},
-    FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python,
+    FromPyObject, Py, PyAny, PyErr, PyObject, PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 
 use num_bigint::{BigInt, BigUint};
 
@@ -77,6 +77,7 @@ macro_rules! bigint_conversion {
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
+        #[allow(deprecated)]
         impl IntoPy<PyObject> for $rust_ty {
             #[inline]
             fn into_py(self, py: Python<'_>) -> PyObject {
@@ -451,8 +452,8 @@ mod tests {
                 ($T:ty, $value:expr, $py:expr) => {
                     let value = $value;
                     println!("{}: {}", stringify!($T), value);
-                    let python_value = value.clone().into_py(py);
-                    let roundtrip_value = python_value.extract::<$T>(py).unwrap();
+                    let python_value = value.clone().into_pyobject(py).unwrap();
+                    let roundtrip_value = python_value.extract::<$T>().unwrap();
                     assert_eq!(value, roundtrip_value);
                 };
             }

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -130,6 +130,7 @@ macro_rules! complex_conversion {
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "num-complex")))]
+        #[allow(deprecated)]
         impl crate::IntoPy<PyObject> for Complex<$float> {
             fn into_py(self, py: Python<'_>) -> PyObject {
                 unsafe {

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -48,9 +48,9 @@ use crate::ffi;
 use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
+use crate::{Bound, FromPyObject, Py, PyAny, PyErr, PyObject, PyResult, Python};
 #[allow(deprecated)]
-use crate::ToPyObject;
-use crate::{Bound, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python};
+use crate::{IntoPy, ToPyObject};
 
 #[cfg(feature = "num-bigint")]
 use num_bigint::BigInt;
@@ -91,6 +91,7 @@ macro_rules! rational_conversion {
                 self.into_pyobject(py).unwrap().into_any().unbind()
             }
         }
+        #[allow(deprecated)]
         impl IntoPy<PyObject> for Ratio<$int> {
             #[inline]
             fn into_py(self, py: Python<'_>) -> PyObject {
@@ -223,9 +224,9 @@ mod tests {
     #[test]
     fn test_int_roundtrip() {
         Python::with_gil(|py| {
-            let rs_frac = Ratio::new(1, 2);
-            let py_frac: PyObject = rs_frac.into_py(py);
-            let roundtripped: Ratio<i32> = py_frac.extract(py).unwrap();
+            let rs_frac = Ratio::new(1i32, 2);
+            let py_frac = rs_frac.into_pyobject(py).unwrap();
+            let roundtripped: Ratio<i32> = py_frac.extract().unwrap();
             assert_eq!(rs_frac, roundtripped);
             // float conversion
         })
@@ -236,8 +237,8 @@ mod tests {
     fn test_big_int_roundtrip() {
         Python::with_gil(|py| {
             let rs_frac = Ratio::from_float(5.5).unwrap();
-            let py_frac: PyObject = rs_frac.clone().into_py(py);
-            let roundtripped: Ratio<BigInt> = py_frac.extract(py).unwrap();
+            let py_frac = rs_frac.clone().into_pyobject(py).unwrap();
+            let roundtripped: Ratio<BigInt> = py_frac.extract().unwrap();
             assert_eq!(rs_frac, roundtripped);
         })
     }
@@ -248,8 +249,8 @@ mod tests {
         fn test_int_roundtrip(num in any::<i32>(), den in any::<i32>()) {
             Python::with_gil(|py| {
                 let rs_frac = Ratio::new(num, den);
-                let py_frac = rs_frac.into_py(py);
-                let roundtripped: Ratio<i32> = py_frac.extract(py).unwrap();
+                let py_frac = rs_frac.into_pyobject(py).unwrap();
+                let roundtripped: Ratio<i32> = py_frac.extract().unwrap();
                 assert_eq!(rs_frac, roundtripped);
             })
         }
@@ -259,8 +260,8 @@ mod tests {
         fn test_big_int_roundtrip(num in any::<f32>()) {
             Python::with_gil(|py| {
                 let rs_frac = Ratio::from_float(num).unwrap();
-                let py_frac = rs_frac.clone().into_py(py);
-                let roundtripped: Ratio<BigInt> = py_frac.extract(py).unwrap();
+                let py_frac = rs_frac.clone().into_pyobject(py).unwrap();
+                let roundtripped: Ratio<BigInt> = py_frac.extract().unwrap();
                 assert_eq!(roundtripped, rs_frac);
             })
         }

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -23,11 +23,9 @@ use crate::types::any::PyAnyMethods;
 use crate::types::list::new_from_iter;
 use crate::types::{PySequence, PyString};
 use crate::PyErr;
+use crate::{err::DowncastError, ffi, Bound, FromPyObject, PyAny, PyObject, PyResult, Python};
 #[allow(deprecated)]
-use crate::ToPyObject;
-use crate::{
-    err::DowncastError, ffi, Bound, FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python,
-};
+use crate::{IntoPy, ToPyObject};
 use smallvec::{Array, SmallVec};
 
 #[allow(deprecated)]
@@ -41,6 +39,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<A> IntoPy<PyObject> for SmallVec<A>
 where
     A: Array,
@@ -144,6 +143,7 @@ mod tests {
     use crate::types::{PyBytes, PyBytesMethods, PyDict, PyList};
 
     #[test]
+    #[allow(deprecated)]
     fn test_smallvec_into_py() {
         Python::with_gil(|py| {
             let sv: SmallVec<[u64; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();

--- a/src/conversions/std/cell.rs
+++ b/src/conversions/std/cell.rs
@@ -1,8 +1,8 @@
 use std::cell::Cell;
 
 use crate::{
-    conversion::IntoPyObject, types::any::PyAnyMethods, Bound, FromPyObject, IntoPy, PyAny,
-    PyObject, PyResult, Python,
+    conversion::IntoPyObject, types::any::PyAnyMethods, Bound, FromPyObject, PyAny, PyObject,
+    PyResult, Python,
 };
 
 #[allow(deprecated)]
@@ -12,7 +12,8 @@ impl<T: Copy + crate::ToPyObject> crate::ToPyObject for Cell<T> {
     }
 }
 
-impl<T: Copy + IntoPy<PyObject>> IntoPy<PyObject> for Cell<T> {
+#[allow(deprecated)]
+impl<T: Copy + crate::IntoPy<PyObject>> crate::IntoPy<PyObject> for Cell<T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.get().into_py(py)
     }

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -7,9 +7,9 @@ use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::string::PyStringMethods;
 use crate::types::PyType;
+use crate::{intern, FromPyObject, Py, PyAny, PyErr, PyObject, PyResult, Python};
 #[allow(deprecated)]
-use crate::ToPyObject;
-use crate::{intern, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python};
+use crate::{IntoPy, ToPyObject};
 
 impl FromPyObject<'_> for IpAddr {
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
@@ -103,6 +103,7 @@ impl ToPyObject for IpAddr {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for IpAddr {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -153,12 +154,12 @@ mod test_ipaddr {
                     "IPv6Address"
                 };
 
-                let pyobj = ip.into_py(py);
-                let repr = pyobj.bind(py).repr().unwrap();
+                let pyobj = ip.into_pyobject(py).unwrap();
+                let repr = pyobj.repr().unwrap();
                 let repr = repr.to_string_lossy();
                 assert_eq!(repr, format!("{}('{}')", py_cls, ip));
 
-                let ip2: IpAddr = pyobj.extract(py).unwrap();
+                let ip2: IpAddr = pyobj.extract().unwrap();
                 assert_eq!(ip, ip2);
             }
             roundtrip(py, "127.0.0.1");

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -2,14 +2,14 @@ use std::{cmp, collections, hash};
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     instance::Bound,
     types::{any::PyAnyMethods, dict::PyDictMethods, PyDict},
-    FromPyObject, IntoPy, PyAny, PyErr, PyObject, Python,
+    FromPyObject, PyAny, PyErr, PyObject, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 
 #[allow(deprecated)]
 impl<K, V, H> ToPyObject for collections::HashMap<K, V, H>
@@ -42,6 +42,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<K, V, H> IntoPy<PyObject> for collections::HashMap<K, V, H>
 where
     K: hash::Hash + cmp::Eq + IntoPy<PyObject>,
@@ -107,6 +108,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<K, V> IntoPy<PyObject> for collections::BTreeMap<K, V>
 where
     K: cmp::Eq + IntoPy<PyObject>,
@@ -265,8 +267,7 @@ mod tests {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let m: PyObject = map.into_py(py);
-            let py_map = m.downcast_bound::<PyDict>(py).unwrap();
+            let py_map = map.into_pyobject(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(
@@ -287,8 +288,7 @@ mod tests {
             let mut map = BTreeMap::<i32, i32>::new();
             map.insert(1, 1);
 
-            let m: PyObject = map.into_py(py);
-            let py_map = m.downcast_bound::<PyDict>(py).unwrap();
+            let py_map = map.into_pyobject(py).unwrap();
 
             assert!(py_map.len() == 1);
             assert!(

--- a/src/conversions/std/option.rs
+++ b/src/conversions/std/option.rs
@@ -1,6 +1,6 @@
 use crate::{
     conversion::IntoPyObject, ffi, types::any::PyAnyMethods, AsPyPointer, Bound, BoundObject,
-    FromPyObject, IntoPy, PyAny, PyObject, PyResult, Python,
+    FromPyObject, PyAny, PyObject, PyResult, Python,
 };
 
 /// `Option::Some<T>` is converted like `T`.
@@ -16,9 +16,10 @@ where
     }
 }
 
-impl<T> IntoPy<PyObject> for Option<T>
+#[allow(deprecated)]
+impl<T> crate::IntoPy<PyObject> for Option<T>
 where
-    T: IntoPy<PyObject>,
+    T: crate::IntoPy<PyObject>,
 {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.map_or_else(|| py.None(), |val| val.into_py(py))

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -2,8 +2,6 @@ use std::{cmp, collections, hash};
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     instance::Bound,
@@ -13,8 +11,10 @@ use crate::{
         set::{new_from_iter, try_new_from_iter, PySetMethods},
         PyFrozenSet, PySet,
     },
-    FromPyObject, IntoPy, PyAny, PyErr, PyObject, PyResult, Python,
+    FromPyObject, PyAny, PyErr, PyObject, PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 
 #[allow(deprecated)]
 impl<T, S> ToPyObject for collections::HashSet<T, S>
@@ -41,6 +41,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<K, S> IntoPy<PyObject> for collections::HashSet<K, S>
 where
     K: IntoPy<PyObject> + Eq + hash::Hash,
@@ -116,6 +117,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<K> IntoPy<PyObject> for collections::BTreeSet<K>
 where
     K: IntoPy<PyObject> + cmp::Ord,
@@ -190,7 +192,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::types::{any::PyAnyMethods, PyFrozenSet, PySet};
-    use crate::{IntoPy, IntoPyObject, PyObject, Python};
+    use crate::{IntoPyObject, PyObject, Python};
     use std::collections::{BTreeSet, HashSet};
 
     #[test]
@@ -220,7 +222,9 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_set_into_py() {
+        use crate::IntoPy;
         Python::with_gil(|py| {
             let bt: BTreeSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();
             let hs: HashSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -2,14 +2,15 @@ use std::borrow::Cow;
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     types::{PyByteArray, PyByteArrayMethods, PyBytes},
-    Bound, IntoPy, Py, PyAny, PyErr, PyObject, PyResult, Python,
+    Bound, Py, PyAny, PyErr, PyObject, PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for &[u8] {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyBytes::new(py, self).unbind().into()
@@ -82,6 +83,7 @@ impl ToPyObject for Cow<'_, [u8]> {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<Py<PyAny>> for Cow<'_, [u8]> {
     fn into_py(self, py: Python<'_>) -> Py<PyAny> {
         self.into_pyobject(py).unwrap().into_any().unbind()

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -2,14 +2,14 @@ use std::{borrow::Cow, convert::Infallible};
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     instance::Bound,
     types::{any::PyAnyMethods, string::PyStringMethods, PyString},
-    FromPyObject, IntoPy, Py, PyAny, PyObject, PyResult, Python,
+    FromPyObject, Py, PyAny, PyObject, PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 
 /// Converts a Rust `str` to a Python object.
 /// See `PyString::new` for details on the conversion.
@@ -21,6 +21,7 @@ impl ToPyObject for str {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for &str {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -28,6 +29,7 @@ impl IntoPy<PyObject> for &str {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<Py<PyString>> for &str {
     #[inline]
     fn into_py(self, py: Python<'_>) -> Py<PyString> {
@@ -77,6 +79,7 @@ impl ToPyObject for Cow<'_, str> {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for Cow<'_, str> {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -134,6 +137,7 @@ impl ToPyObject for char {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for char {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -173,6 +177,7 @@ impl<'py> IntoPyObject<'py> for &char {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for String {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -195,6 +200,7 @@ impl<'py> IntoPyObject<'py> for String {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for &String {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -276,11 +282,13 @@ impl FromPyObject<'_> for char {
 #[cfg(test)]
 mod tests {
     use crate::types::any::PyAnyMethods;
-    use crate::{IntoPy, IntoPyObject, PyObject, Python};
+    use crate::{IntoPyObject, PyObject, Python};
     use std::borrow::Cow;
 
     #[test]
+    #[allow(deprecated)]
     fn test_cow_into_py() {
+        use crate::IntoPy;
         Python::with_gil(|py| {
             let s = "Hello Python";
             let py_string: PyObject = Cow::Borrowed(s).into_py(py);
@@ -345,27 +353,30 @@ mod tests {
     }
 
     #[test]
-    fn test_string_into_py() {
+    fn test_string_into_pyobject() {
         Python::with_gil(|py| {
             let s = "Hello Python";
             let s2 = s.to_owned();
             let s3 = &s2;
             assert_eq!(
                 s,
-                IntoPy::<PyObject>::into_py(s3, py)
-                    .extract::<Cow<'_, str>>(py)
+                s3.into_pyobject(py)
+                    .unwrap()
+                    .extract::<Cow<'_, str>>()
                     .unwrap()
             );
             assert_eq!(
                 s,
-                IntoPy::<PyObject>::into_py(s2, py)
-                    .extract::<Cow<'_, str>>(py)
+                s2.into_pyobject(py)
+                    .unwrap()
+                    .extract::<Cow<'_, str>>()
                     .unwrap()
             );
             assert_eq!(
                 s,
-                IntoPy::<PyObject>::into_py(s, py)
-                    .extract::<Cow<'_, str>>(py)
+                s.into_pyobject(py)
+                    .unwrap()
+                    .extract::<Cow<'_, str>>()
                     .unwrap()
             );
         })

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -2,9 +2,9 @@ use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::types::list::new_from_iter;
+use crate::{Bound, PyAny, PyErr, PyObject, Python};
 #[allow(deprecated)]
-use crate::ToPyObject;
-use crate::{Bound, IntoPy, PyAny, PyErr, PyObject, Python};
+use crate::{IntoPy, ToPyObject};
 
 #[allow(deprecated)]
 impl<T> ToPyObject for [T]
@@ -28,6 +28,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<T> IntoPy<PyObject> for Vec<T>
 where
     T: IntoPy<PyObject>,

--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -1,4 +1,5 @@
-use crate::{err::PyErrArguments, exceptions, IntoPy, PyErr, PyObject, Python};
+use crate::IntoPyObject;
+use crate::{err::PyErrArguments, exceptions, PyErr, PyObject, Python};
 use std::io;
 
 /// Convert `PyErr` to `io::Error`
@@ -60,7 +61,12 @@ impl From<io::Error> for PyErr {
 
 impl PyErrArguments for io::Error {
     fn arguments(self, py: Python<'_>) -> PyObject {
-        self.to_string().into_py(py)
+        //FIXME(icxolu) remove unwrap
+        self.to_string()
+            .into_pyobject(py)
+            .unwrap()
+            .into_any()
+            .unbind()
     }
 }
 
@@ -86,7 +92,12 @@ macro_rules! impl_to_pyerr {
     ($err: ty, $pyexc: ty) => {
         impl PyErrArguments for $err {
             fn arguments(self, py: Python<'_>) -> PyObject {
-                self.to_string().into_py(py)
+                // FIXME(icxolu) remove unwrap
+                self.to_string()
+                    .into_pyobject(py)
+                    .unwrap()
+                    .into_any()
+                    .unbind()
             }
         }
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -3,13 +3,13 @@ use crate::panic::PanicException;
 use crate::type_object::PyTypeInfo;
 use crate::types::any::PyAnyMethods;
 use crate::types::{string::PyStringMethods, typeobject::PyTypeMethods, PyTraceback, PyType};
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     exceptions::{self, PyBaseException},
     ffi,
 };
-use crate::{Borrowed, BoundObject, IntoPy, Py, PyAny, PyObject, Python};
+use crate::{Borrowed, BoundObject, Py, PyAny, PyObject, Python};
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 
@@ -246,7 +246,7 @@ impl PyErr {
                 // is not the case
                 let obj = err.into_inner();
                 let py = obj.py();
-                PyErrState::lazy_arguments(obj.into_py(py), py.None())
+                PyErrState::lazy_arguments(obj.unbind(), py.None())
             }
         };
 
@@ -847,6 +847,7 @@ impl std::fmt::Display for PyErr {
 
 impl std::error::Error for PyErr {}
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for PyErr {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -862,6 +863,7 @@ impl ToPyObject for PyErr {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for &PyErr {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -6,7 +6,7 @@ use crate::Python;
 use crate::types::PyString;
 
 #[cfg(not(Py_LIMITED_API))]
-use crate::{types::PyDict, Bound, IntoPy, Py, PyAny};
+use crate::{types::PyDict, Bound, PyAny};
 #[cfg(not(any(Py_3_12, Py_LIMITED_API)))]
 use libc::wchar_t;
 
@@ -14,8 +14,9 @@ use libc::wchar_t;
 #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
 #[test]
 fn test_datetime_fromtimestamp() {
+    use crate::IntoPyObject;
     Python::with_gil(|py| {
-        let args: Py<PyAny> = (100,).into_py(py);
+        let args = (100,).into_pyobject(py).unwrap();
         let dt = unsafe {
             PyDateTime_IMPORT();
             Bound::from_owned_ptr(py, PyDateTime_FromTimestamp(args.as_ptr()))
@@ -35,8 +36,9 @@ fn test_datetime_fromtimestamp() {
 #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
 #[test]
 fn test_date_fromtimestamp() {
+    use crate::IntoPyObject;
     Python::with_gil(|py| {
-        let args: Py<PyAny> = (100,).into_py(py);
+        let args = (100,).into_pyobject(py).unwrap();
         let dt = unsafe {
             PyDateTime_IMPORT();
             Bound::from_owned_ptr(py, PyDate_FromTimestamp(args.as_ptr()))

--- a/src/impl_/coroutine.rs
+++ b/src/impl_/coroutine.rs
@@ -9,26 +9,21 @@ use crate::{
     pycell::impl_::PyClassBorrowChecker,
     pyclass::boolean_struct::False,
     types::{PyAnyMethods, PyString},
-    IntoPy, Py, PyAny, PyClass, PyErr, PyObject, PyResult, Python,
+    IntoPyObject, Py, PyAny, PyClass, PyErr, PyResult, Python,
 };
 
-pub fn new_coroutine<F, T, E>(
-    name: &Bound<'_, PyString>,
+pub fn new_coroutine<'py, F, T, E>(
+    name: &Bound<'py, PyString>,
     qualname_prefix: Option<&'static str>,
     throw_callback: Option<ThrowCallback>,
     future: F,
 ) -> Coroutine
 where
     F: Future<Output = Result<T, E>> + Send + 'static,
-    T: IntoPy<PyObject>,
+    T: IntoPyObject<'py>,
     E: Into<PyErr>,
 {
-    Coroutine::new(
-        Some(name.clone().into()),
-        qualname_prefix,
-        throw_callback,
-        future,
-    )
+    Coroutine::new(Some(name.clone()), qualname_prefix, throw_callback, future)
 }
 
 fn get_ptr<T: PyClass>(obj: &Py<T>) -> *mut T {

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1,5 +1,3 @@
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     conversion::IntoPyObject,
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError, PyValueError},
@@ -12,8 +10,10 @@ use crate::{
     },
     pycell::PyBorrowError,
     types::{any::PyAnyMethods, PyBool},
-    Borrowed, BoundObject, IntoPy, Py, PyAny, PyClass, PyErr, PyRef, PyResult, PyTypeInfo, Python,
+    Borrowed, BoundObject, Py, PyAny, PyClass, PyErr, PyRef, PyResult, PyTypeInfo, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 use std::{
     borrow::Cow,
     ffi::{CStr, CString},
@@ -1372,6 +1372,7 @@ where
 }
 
 /// IntoPy + Clone fallback case, which was the only behaviour before PyO3 0.22.
+#[allow(deprecated)]
 impl<ClassT, FieldT, Offset>
     PyClassGetterGenerator<ClassT, FieldT, Offset, false, false, true, false, false>
 where
@@ -1452,6 +1453,7 @@ impl<T: ToPyObject> IsToPyObject<T> {
 
 probe!(IsIntoPy);
 
+#[allow(deprecated)]
 impl<T: IntoPy<crate::PyObject>> IsIntoPy<T> {
     pub const VALUE: bool = true;
 }
@@ -1556,6 +1558,7 @@ where
         .into_ptr())
 }
 
+#[allow(deprecated)]
 fn pyo3_get_value<
     ClassT: PyClass,
     FieldT: IntoPy<Py<PyAny>> + Clone,

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -1,8 +1,9 @@
 use std::{convert::Infallible, marker::PhantomData, ops::Deref};
 
+#[allow(deprecated)]
+use crate::IntoPy;
 use crate::{
-    conversion::IntoPyObject, ffi, types::PyNone, Bound, BoundObject, IntoPy, PyObject, PyResult,
-    Python,
+    conversion::IntoPyObject, ffi, types::PyNone, Bound, BoundObject, PyObject, PyResult, Python,
 };
 
 /// Used to wrap values in `Option<T>` for default arguments.
@@ -112,6 +113,7 @@ impl<'py, T: IntoPyObject<'py>, E> IntoPyObjectConverter<Result<T, E>> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: IntoPy<PyObject>> IntoPyConverter<T> {
     #[inline]
     pub fn wrap(&self, obj: T) -> Result<T, Infallible> {
@@ -119,6 +121,7 @@ impl<T: IntoPy<PyObject>> IntoPyConverter<T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: IntoPy<PyObject>, E> IntoPyConverter<Result<T, E>> {
     #[inline]
     pub fn wrap(&self, obj: Result<T, E>) -> Result<T, E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,9 +323,9 @@
 #![doc = concat!("[Features chapter of the guide]: https://pyo3.rs/v", env!("CARGO_PKG_VERSION"), "/features.html#features-reference \"Features Reference - PyO3 user guide\"")]
 //! [`Ungil`]: crate::marker::Ungil
 pub use crate::class::*;
+pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPyObject};
 #[allow(deprecated)]
-pub use crate::conversion::ToPyObject;
-pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPy, IntoPyObject};
+pub use crate::conversion::{IntoPy, ToPyObject};
 pub use crate::err::{DowncastError, DowncastIntoError, PyErr, PyErrArguments, PyResult, ToPyErr};
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -129,7 +129,9 @@ use crate::types::{
     PyAny, PyDict, PyEllipsis, PyModule, PyNone, PyNotImplemented, PyString, PyType,
 };
 use crate::version::PythonVersionInfo;
-use crate::{ffi, Bound, IntoPy, Py, PyObject, PyTypeInfo};
+#[allow(deprecated)]
+use crate::IntoPy;
+use crate::{ffi, Bound, Py, PyObject, PyTypeInfo};
 use std::ffi::{CStr, CString};
 use std::marker::PhantomData;
 use std::os::raw::c_int;
@@ -715,6 +717,7 @@ impl<'py> Python<'py> {
 
     /// Deprecated name for [`Python::import`].
     #[deprecated(since = "0.23.0", note = "renamed to `Python::import`")]
+    #[allow(deprecated)]
     #[track_caller]
     #[inline]
     pub fn import_bound<N>(self, name: N) -> PyResult<Bound<'py, PyModule>>
@@ -728,21 +731,21 @@ impl<'py> Python<'py> {
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]
     pub fn None(self) -> PyObject {
-        PyNone::get(self).into_py(self)
+        PyNone::get(self).to_owned().into_any().unbind()
     }
 
     /// Gets the Python builtin value `Ellipsis`, or `...`.
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]
     pub fn Ellipsis(self) -> PyObject {
-        PyEllipsis::get(self).into_py(self)
+        PyEllipsis::get(self).to_owned().into_any().unbind()
     }
 
     /// Gets the Python builtin value `NotImplemented`.
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]
     pub fn NotImplemented(self) -> PyObject {
-        PyNotImplemented::get(self).into_py(self)
+        PyNotImplemented::get(self).to_owned().into_any().unbind()
     }
 
     /// Gets the running Python interpreter version as a string.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,9 +8,9 @@
 //! use pyo3::prelude::*;
 //! ```
 
+pub use crate::conversion::{FromPyObject, IntoPyObject};
 #[allow(deprecated)]
-pub use crate::conversion::ToPyObject;
-pub use crate::conversion::{FromPyObject, IntoPy, IntoPyObject};
+pub use crate::conversion::{IntoPy, ToPyObject};
 pub use crate::err::{PyErr, PyResult};
 pub use crate::instance::{Borrowed, Bound, Py, PyObject};
 pub use crate::marker::Python;

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -2,15 +2,15 @@
 
 use std::{convert::Infallible, ops::Deref, ptr::NonNull, sync::Arc};
 
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     types::{
         any::PyAnyMethods, bytearray::PyByteArrayMethods, bytes::PyBytesMethods,
         string::PyStringMethods, PyByteArray, PyBytes, PyString,
     },
-    Bound, DowncastError, FromPyObject, IntoPy, IntoPyObject, Py, PyAny, PyErr, PyResult, Python,
+    Bound, DowncastError, FromPyObject, IntoPyObject, Py, PyAny, PyErr, PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 
 /// A wrapper around `str` where the storage is owned by a Python `bytes` or `str` object.
 ///
@@ -99,6 +99,7 @@ impl ToPyObject for PyBackedStr {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<Py<PyAny>> for PyBackedStr {
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     fn into_py(self, _py: Python<'_>) -> Py<PyAny> {
@@ -248,6 +249,7 @@ impl ToPyObject for PyBackedBytes {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<Py<PyAny>> for PyBackedBytes {
     fn into_py(self, py: Python<'_>) -> Py<PyAny> {
         match self.storage {
@@ -403,6 +405,7 @@ mod test {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn py_backed_str_into_py() {
         Python::with_gil(|py| {
             let orig_str = PyString::new(py, "hello");
@@ -451,6 +454,7 @@ mod test {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn py_backed_bytes_into_pyobject() {
         Python::with_gil(|py| {
             let orig_bytes = PyBytes::new(py, b"abcde");
@@ -464,6 +468,7 @@ mod test {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn rust_backed_bytes_into_pyobject() {
         Python::with_gil(|py| {
             let orig_bytes = PyByteArray::new(py, b"abcde");

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -199,7 +199,9 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::{ptr_from_mut, ptr_from_ref};
 use crate::pyclass::{boolean_struct::False, PyClass};
 use crate::types::any::PyAnyMethods;
-use crate::{ffi, Borrowed, Bound, IntoPy, PyErr, PyObject, Python};
+#[allow(deprecated)]
+use crate::IntoPy;
+use crate::{ffi, Borrowed, Bound, PyErr, PyObject, Python};
 use std::convert::Infallible;
 use std::fmt;
 use std::mem::ManuallyDrop;
@@ -447,12 +449,14 @@ impl<T: PyClass> Drop for PyRef<'_, T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: PyClass> IntoPy<PyObject> for PyRef<'_, T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
     }
 }
 
+#[allow(deprecated)]
 impl<T: PyClass> IntoPy<PyObject> for &'_ PyRef<'_, T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
@@ -636,12 +640,14 @@ impl<T: PyClass<Frozen = False>> Drop for PyRefMut<'_, T> {
     }
 }
 
+#[allow(deprecated)]
 impl<T: PyClass<Frozen = False>> IntoPy<PyObject> for PyRefMut<'_, T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         unsafe { PyObject::from_borrowed_ptr(py, self.inner.as_ptr()) }
     }
 }
 
+#[allow(deprecated)]
 impl<T: PyClass<Frozen = False>> IntoPy<PyObject> for &'_ PyRefMut<'_, T> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.inner.clone().into_py(py)

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -227,12 +227,11 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// ```rust
     /// use pyo3::class::basic::CompareOp;
     /// use pyo3::prelude::*;
-    /// use pyo3::types::PyInt;
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| -> PyResult<()> {
-    ///     let a: Bound<'_, PyInt> = 0_u8.into_py(py).into_bound(py).downcast_into()?;
-    ///     let b: Bound<'_, PyInt> = 42_u8.into_py(py).into_bound(py).downcast_into()?;
+    ///     let a = 0_u8.into_pyobject(py)?;
+    ///     let b = 42_u8.into_pyobject(py)?;
     ///     assert!(a.rich_compare(b, CompareOp::Le)?.is_truthy()?);
     ///     Ok(())
     /// })?;

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -1,12 +1,11 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
     exceptions::PyTypeError, ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound,
-    types::typeobject::PyTypeMethods, Borrowed, FromPyObject, IntoPy, PyAny, PyObject, PyResult,
-    Python,
+    types::typeobject::PyTypeMethods, Borrowed, FromPyObject, PyAny, PyObject, PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 
 use super::any::PyAnyMethods;
 use crate::conversion::IntoPyObject;
@@ -155,6 +154,7 @@ impl ToPyObject for bool {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for bool {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -25,7 +25,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
-use crate::{Bound, IntoPy, Py, PyAny, PyErr, Python};
+use crate::{Bound, IntoPyObject, PyAny, PyErr, Python};
 use std::os::raw::c_int;
 #[cfg(feature = "chrono")]
 use std::ptr;
@@ -409,7 +409,7 @@ impl PyDateTime {
         timestamp: f64,
         tzinfo: Option<&Bound<'py, PyTzInfo>>,
     ) -> PyResult<Bound<'py, PyDateTime>> {
-        let args = IntoPy::<Py<PyTuple>>::into_py((timestamp, tzinfo), py).into_bound(py);
+        let args = (timestamp, tzinfo).into_pyobject(py)?;
 
         // safety ensure API is loaded
         let _api = ensure_datetime_api(py)?;

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -2,12 +2,12 @@ use super::any::PyAnyMethods;
 use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
-    ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, Borrowed, FromPyObject, IntoPy, PyAny, PyErr,
-    PyObject, PyResult, Python,
+    ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, Borrowed, FromPyObject, PyAny, PyErr, PyObject,
+    PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 use std::convert::Infallible;
 use std::os::raw::c_double;
 
@@ -86,6 +86,7 @@ impl ToPyObject for f64 {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for f64 {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -163,6 +164,7 @@ impl ToPyObject for f32 {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for f32 {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -7,7 +7,7 @@ use crate::{
     impl_::pymethods::{self, PyMethodDef},
     types::{PyCapsule, PyDict, PyModule, PyString, PyTuple},
 };
-use crate::{Bound, IntoPy, Py, PyAny, PyResult, Python};
+use crate::{Bound, Py, PyAny, PyResult, Python};
 use std::cell::UnsafeCell;
 use std::ffi::CStr;
 
@@ -155,7 +155,7 @@ impl PyCFunction {
     ) -> PyResult<Bound<'py, Self>> {
         let (mod_ptr, module_name): (_, Option<Py<PyString>>) = if let Some(m) = module {
             let mod_ptr = m.as_ptr();
-            (mod_ptr, Some(m.name()?.into_py(py)))
+            (mod_ptr, Some(m.name()?.unbind()))
         } else {
             (std::ptr::null_mut(), None)
         };

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -97,6 +97,7 @@ impl PyModule {
 
     /// Deprecated name for [`PyModule::import`].
     #[deprecated(since = "0.23.0", note = "renamed to `PyModule::import`")]
+    #[allow(deprecated)]
     #[inline]
     pub fn import_bound<N>(py: Python<'_>, name: N) -> PyResult<Bound<'_, PyModule>>
     where

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -1,9 +1,7 @@
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::{ffi, types::any::PyAnyMethods, Borrowed, Bound, PyAny, PyObject, PyTypeInfo, Python};
 #[allow(deprecated)]
-use crate::ToPyObject;
-use crate::{
-    ffi, types::any::PyAnyMethods, Borrowed, Bound, IntoPy, PyAny, PyObject, PyTypeInfo, Python,
-};
+use crate::{IntoPy, ToPyObject};
 
 /// Represents the Python `None` object.
 ///
@@ -58,6 +56,7 @@ impl ToPyObject for () {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<PyObject> for () {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
@@ -69,7 +68,8 @@ impl IntoPy<PyObject> for () {
 mod tests {
     use crate::types::any::PyAnyMethods;
     use crate::types::{PyDict, PyNone};
-    use crate::{IntoPy, PyObject, PyTypeInfo, Python};
+    use crate::{PyObject, PyTypeInfo, Python};
+
     #[test]
     fn test_none_is_itself() {
         Python::with_gil(|py| {
@@ -102,7 +102,9 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_unit_into_py_is_none() {
+        use crate::IntoPy;
         Python::with_gil(|py| {
             let obj: PyObject = ().into_py(py);
             assert!(obj.downcast_bound::<PyNone>(py).is_ok());

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -60,8 +60,7 @@ int_compare!(usize);
 
 #[cfg(test)]
 mod tests {
-    use super::PyInt;
-    use crate::{types::PyAnyMethods, IntoPy, Python};
+    use crate::{IntoPyObject, Python};
 
     #[test]
     fn test_partial_eq() {
@@ -78,7 +77,7 @@ mod tests {
             let v_u128 = 123u128;
             let v_isize = 123isize;
             let v_usize = 123usize;
-            let obj = 123_i64.into_py(py).downcast_bound(py).unwrap().clone();
+            let obj = 123_i64.into_pyobject(py).unwrap();
             assert_eq!(v_i8, obj);
             assert_eq!(obj, v_i8);
 
@@ -116,11 +115,7 @@ mod tests {
             assert_eq!(obj, v_usize);
 
             let big_num = (u8::MAX as u16) + 1;
-            let big_obj = big_num
-                .into_py(py)
-                .into_bound(py)
-                .downcast_into::<PyInt>()
-                .unwrap();
+            let big_obj = big_num.into_pyobject(py).unwrap();
 
             for x in 0u8..=u8::MAX {
                 assert_ne!(x, big_obj);

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -6,7 +6,9 @@ use crate::py_result_ext::PyResultExt;
 use crate::types::any::PyAnyMethods;
 use crate::types::bytes::PyBytesMethods;
 use crate::types::PyBytes;
-use crate::{ffi, Bound, IntoPy, Py, PyAny, PyResult, Python};
+#[allow(deprecated)]
+use crate::IntoPy;
+use crate::{ffi, Bound, Py, PyAny, PyResult, Python};
 use std::borrow::Cow;
 use std::str;
 
@@ -444,18 +446,21 @@ impl Py<PyString> {
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<Py<PyString>> for Bound<'_, PyString> {
     fn into_py(self, _py: Python<'_>) -> Py<PyString> {
         self.unbind()
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<Py<PyString>> for &Bound<'_, PyString> {
     fn into_py(self, _py: Python<'_>) -> Py<PyString> {
         self.clone().unbind()
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<Py<PyString>> for &'_ Py<PyString> {
     fn into_py(self, py: Python<'_>) -> Py<PyString> {
         self.clone_ref(py)
@@ -805,7 +810,7 @@ mod tests {
     fn test_py_to_str_utf8() {
         Python::with_gil(|py| {
             let s = "ascii 🐈";
-            let py_string: Py<PyString> = PyString::new(py, s).into_py(py);
+            let py_string = PyString::new(py, s).unbind();
 
             #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
             assert_eq!(s, py_string.to_str(py).unwrap());

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -80,10 +80,11 @@ impl<'py> PyTracebackMethods<'py> for Bound<'py, PyTraceback> {
 
 #[cfg(test)]
 mod tests {
+    use crate::IntoPyObject;
     use crate::{
         ffi,
         types::{any::PyAnyMethods, dict::PyDictMethods, traceback::PyTracebackMethods, PyDict},
-        IntoPy, PyErr, Python,
+        PyErr, Python,
     };
 
     #[test]
@@ -143,7 +144,7 @@ def f():
             let f = locals.get_item("f").unwrap().unwrap();
             let err = f.call0().unwrap_err();
             let traceback = err.traceback(py).unwrap();
-            let err_object = err.clone_ref(py).into_py(py).into_bound(py);
+            let err_object = err.clone_ref(py).into_pyobject(py).unwrap();
 
             assert!(err_object.getattr("__traceback__").unwrap().is(&traceback));
         })

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -8,12 +8,11 @@ use crate::inspect::types::TypeInfo;
 use crate::instance::Borrowed;
 use crate::internal_tricks::get_ssize_index;
 use crate::types::{any::PyAnyMethods, sequence::PySequenceMethods, PyList, PySequence};
-#[allow(deprecated)]
-use crate::ToPyObject;
 use crate::{
-    exceptions, Bound, BoundObject, FromPyObject, IntoPy, Py, PyAny, PyErr, PyObject, PyResult,
-    Python,
+    exceptions, Bound, BoundObject, FromPyObject, Py, PyAny, PyErr, PyObject, PyResult, Python,
 };
+#[allow(deprecated)]
+use crate::{IntoPy, ToPyObject};
 
 #[inline]
 #[track_caller]
@@ -496,12 +495,14 @@ impl ExactSizeIterator for BorrowedTupleIterator<'_, '_> {
 
 impl FusedIterator for BorrowedTupleIterator<'_, '_> {}
 
+#[allow(deprecated)]
 impl IntoPy<Py<PyTuple>> for Bound<'_, PyTuple> {
     fn into_py(self, _: Python<'_>) -> Py<PyTuple> {
         self.unbind()
     }
 }
 
+#[allow(deprecated)]
 impl IntoPy<Py<PyTuple>> for &'_ Bound<'_, PyTuple> {
     fn into_py(self, _: Python<'_>) -> Py<PyTuple> {
         self.clone().unbind()
@@ -525,6 +526,8 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
             array_into_tuple(py, [$(self.$n.to_object(py)),+]).into()
         }
     }
+
+    #[allow(deprecated)]
     impl <$($T: IntoPy<PyObject>),+> IntoPy<PyObject> for ($($T,)+) {
         fn into_py(self, py: Python<'_>) -> PyObject {
             array_into_tuple(py, [$(self.$n.into_py(py)),+]).into()
@@ -568,6 +571,7 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
         }
     }
 
+    #[allow(deprecated)]
     impl <$($T: IntoPy<PyObject>),+> IntoPy<Py<PyTuple>> for ($($T,)+) {
         fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
             array_into_tuple(py, [$(self.$n.into_py(py)),+])

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -1,8 +1,8 @@
 #![cfg(feature = "macros")]
 
 use pyo3::class::basic::CompareOp;
-use pyo3::prelude::*;
 use pyo3::py_run;
+use pyo3::{prelude::*, BoundObject};
 
 #[path = "../src/tests/common.rs"]
 mod common;
@@ -527,11 +527,19 @@ impl RichComparisons2 {
         "RC2"
     }
 
-    fn __richcmp__(&self, other: &Bound<'_, PyAny>, op: CompareOp) -> PyObject {
+    fn __richcmp__(&self, other: &Bound<'_, PyAny>, op: CompareOp) -> PyResult<PyObject> {
         match op {
-            CompareOp::Eq => true.into_py(other.py()),
-            CompareOp::Ne => false.into_py(other.py()),
-            _ => other.py().NotImplemented(),
+            CompareOp::Eq => true
+                .into_pyobject(other.py())
+                .map_err(Into::into)
+                .map(BoundObject::into_any)
+                .map(BoundObject::unbind),
+            CompareOp::Ne => false
+                .into_pyobject(other.py())
+                .map_err(Into::into)
+                .map(BoundObject::into_any)
+                .map(BoundObject::unbind),
+            _ => Ok(other.py().NotImplemented()),
         }
     }
 }

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -78,7 +78,7 @@ fn test_buffer_referenced() {
             .into_pyobject(py)
             .unwrap();
 
-            let buf = PyBuffer::<u8>::get(instance.as_any()).unwrap();
+            let buf = PyBuffer::<u8>::get(&instance).unwrap();
             assert_eq!(buf.to_vec(py).unwrap(), input);
             drop(instance);
             buf

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -71,13 +71,14 @@ fn test_buffer_referenced() {
     let buf = {
         let input = vec![b' ', b'2', b'3'];
         Python::with_gil(|py| {
-            let instance: PyObject = TestBufferClass {
+            let instance = TestBufferClass {
                 vec: input.clone(),
                 drop_called: drop_called.clone(),
             }
-            .into_py(py);
+            .into_pyobject(py)
+            .unwrap();
 
-            let buf = PyBuffer::<u8>::get(instance.bind(py)).unwrap();
+            let buf = PyBuffer::<u8>::get(instance.as_any()).unwrap();
             assert_eq!(buf.to_vec(py).unwrap(), input);
             drop(instance);
             buf

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -247,7 +247,7 @@ fn class_with_hash() {
 
         let env = [
             ("obj", Py::new(py, class).unwrap().into_any()),
-            ("hsh", hash.into_py(py)),
+            ("hsh", hash.into_pyobject(py).unwrap().into_any().unbind()),
         ]
         .into_py_dict(py)
         .unwrap();

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -112,11 +112,11 @@ fn test_polymorphic_container_does_not_accept_other_types() {
         )
         .unwrap();
 
-        let setattr = |value: PyObject| p.bind(py).setattr("inner", value);
+        let setattr = |value: Bound<'_, PyAny>| p.bind(py).setattr("inner", value);
 
-        assert!(setattr(1i32.into_py(py)).is_err());
-        assert!(setattr(py.None()).is_err());
-        assert!(setattr((1i32, 2i32).into_py(py)).is_err());
+        assert!(setattr(1i32.into_pyobject(py).unwrap().into_any()).is_err());
+        assert!(setattr(py.None().into_bound(py)).is_err());
+        assert!(setattr((1i32, 2i32).into_pyobject(py).unwrap().into_any()).is_err());
     });
 }
 

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -257,7 +257,7 @@ fn test_simple_enum_with_hash() {
 
         let env = [
             ("obj", Py::new(py, class).unwrap().into_any()),
-            ("hsh", hash.into_py(py)),
+            ("hsh", hash.into_pyobject(py).unwrap().into_any().unbind()),
         ]
         .into_py_dict(py)
         .unwrap();
@@ -289,7 +289,7 @@ fn test_complex_enum_with_hash() {
 
         let env = [
             ("obj", Py::new(py, class).unwrap().into_any()),
-            ("hsh", hash.into_py(py)),
+            ("hsh", hash.into_pyobject(py).unwrap().into_any().unbind()),
         ]
         .into_py_dict(py)
         .unwrap();

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -4,6 +4,7 @@ use std::cell::Cell;
 
 use pyo3::prelude::*;
 use pyo3::py_run;
+use pyo3::types::PyString;
 use pyo3::types::{IntoPyDict, PyList};
 
 #[path = "../src/tests/common.rs"]
@@ -266,14 +267,14 @@ fn frozen_py_field_get() {
     #[pyclass(frozen)]
     struct FrozenPyField {
         #[pyo3(get)]
-        value: Py<PyAny>,
+        value: Py<PyString>,
     }
 
     Python::with_gil(|py| {
         let inst = Py::new(
             py,
             FrozenPyField {
-                value: "value".into_py(py),
+                value: "value".into_pyobject(py).unwrap().unbind(),
             },
         )
         .unwrap();

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -61,11 +61,16 @@ impl Mapping {
     }
 
     #[pyo3(signature=(key, default=None))]
-    fn get(&self, py: Python<'_>, key: &str, default: Option<PyObject>) -> Option<PyObject> {
-        self.index
-            .get(key)
-            .map(|value| value.into_py(py))
-            .or(default)
+    fn get(
+        &self,
+        py: Python<'_>,
+        key: &str,
+        default: Option<PyObject>,
+    ) -> PyResult<Option<PyObject>> {
+        match self.index.get(key) {
+            Some(value) => Ok(Some(value.into_pyobject(py)?.into_any().unbind())),
+            None => Ok(default),
+        }
     }
 }
 

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -22,7 +22,7 @@ struct ExampleClass {
 impl ExampleClass {
     fn __getattr__(&self, py: Python<'_>, attr: &str) -> PyResult<PyObject> {
         if attr == "special_custom_attr" {
-            Ok(self.custom_attr.into_py(py))
+            Ok(self.custom_attr.into_pyobject(py)?.into_any().unbind())
         } else {
             Err(PyAttributeError::new_err(attr.to_string()))
         }

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -435,22 +435,22 @@ fn test_closure() {
                  _kwargs: Option<&Bound<'_, types::PyDict>>|
          -> PyResult<_> {
             Python::with_gil(|py| {
-                let res: Vec<_> = args
+                let res: PyResult<Vec<_>> = args
                     .iter()
                     .map(|elem| {
                         if let Ok(i) = elem.extract::<i64>() {
-                            (i + 1).into_py(py)
+                            Ok((i + 1).into_pyobject(py)?.into_any().unbind())
                         } else if let Ok(f) = elem.extract::<f64>() {
-                            (2. * f).into_py(py)
+                            Ok((2. * f).into_pyobject(py)?.into_any().unbind())
                         } else if let Ok(mut s) = elem.extract::<String>() {
                             s.push_str("-py");
-                            s.into_py(py)
+                            Ok(s.into_pyobject(py)?.into_any().unbind())
                         } else {
                             panic!("unexpected argument type for {:?}", elem)
                         }
                     })
                     .collect();
-                Ok(res)
+                res
             })
         };
         let closure_py =

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -93,7 +93,7 @@ fn reader() -> Reader {
 #[test]
 fn test_nested_iter() {
     Python::with_gil(|py| {
-        let reader: PyObject = reader().into_py(py);
+        let reader = reader().into_pyobject(py).unwrap();
         py_assert!(
             py,
             reader,
@@ -105,7 +105,7 @@ fn test_nested_iter() {
 #[test]
 fn test_clone_ref() {
     Python::with_gil(|py| {
-        let reader: PyObject = reader().into_py(py);
+        let reader = reader().into_pyobject(py).unwrap();
         py_assert!(py, reader, "reader == reader.clone_ref()");
         py_assert!(py, reader, "reader == reader.clone_ref_with_py()");
     });

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -263,13 +263,14 @@ struct GenericList {
 #[test]
 fn test_generic_list_get() {
     Python::with_gil(|py| {
-        let list: PyObject = GenericList {
+        let list = GenericList {
             items: [1i32, 2, 3]
                 .iter()
                 .map(|i| i.into_pyobject(py).unwrap().into_any().unbind())
                 .collect(),
         }
-        .into_py(py);
+        .into_pyobject(py)
+        .unwrap();
 
         py_assert!(py, list, "list.items == [1, 2, 3]");
     });
@@ -286,7 +287,7 @@ fn test_generic_list_set() {
             .items
             .iter()
             .zip(&[1u32, 2, 3])
-            .all(|(a, b)| a.bind(py).eq(b.into_py(py)).unwrap()));
+            .all(|(a, b)| a.bind(py).eq(b.into_pyobject(py).unwrap()).unwrap()));
     });
 }
 


### PR DESCRIPTION
This deprecates `IntoPy` in favor of `IntoPyObject`. There are 3 blockers left:
- [x] What do we do with `IntoPy::type_output` from `feature = "experimental-inspect"`? Do we just transfer it onto `IntoPyObject`? #4657
- [x] The call family of methods still use `IntoPy` for the vectorcall enhancement of #4456. The plan was to split this out into some `PyCallArgs` trait. Maybe we want to target 0.24 for that and revert to the simple approach for now? #4653
- [x] `PyErrArguments` has a blanket for `IntoPy<PyAny>` which we probably should migrate to `IntoPyObject`. Its method should probably become fallible, but maybe we can just `unwrap` there for now and tackle this in a later release (maybe along side with #4584) #4660
