### PR TITLE
Extend `PyType` to create metaclasses

### DIFF
--- a/newsfragments/4621.added.md
+++ b/newsfragments/4621.added.md
@@ -1,0 +1,1 @@
+Added the ability to extend `PyType` to create metaclasses.

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1110,7 +1110,6 @@ impl<T> PyClassThreadChecker<T> for ThreadCheckerImpl {
 }
 
 /// Trait denoting that this class is suitable to be used as a base type for PyClass.
-
 #[cfg_attr(
     all(diagnostic_namespace, Py_LIMITED_API),
     diagnostic::on_unimplemented(

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -16,7 +16,7 @@ use crate::{ffi, Bound, Python};
 /// This trait must only be implemented for types which represent valid layouts of Python objects.
 pub unsafe trait PyLayout<T> {}
 
-/// `T: PySizedLayout<U>` represents that `T` is not a instance of
+/// `T: PySizedLayout<U>` represents that `T` is not an instance of
 /// [`PyVarObject`](https://docs.python.org/3/c-api/structures.html#c.PyVarObject).
 ///
 /// In addition, that `T` is a concrete representation of `U`.


### PR DESCRIPTION
I am investigating adding support for metaclasses in PyO3 (https://github.com/PyO3/pyo3/issues/906), mainly as a way to implement proper enums or a close equivalent (https://github.com/PyO3/pyo3/issues/2887).

As a first step I created a metaclass in c. That example can be found in [this comment](https://github.com/PyO3/pyo3/issues/906#issuecomment-2395112056). I then tried to recreate the example in PyO3. I found that the first issue is the missing ability to inherit from `type`.

This PR allows metaclasses (classes that extend `type`) to be created from Pyo3 using `#[pyclass(extends=PyType)]` and used in python (but not used with other Pyo3 classes yet).

I'm not sure if `PyType::new_type` is required or the correct way to go about calling `type(name, bases, namespace)` from the PyO3 metaclass. There are probably also lifetime issues with the current implementation. guidance here would be appreciated.

## Background: Creating a metaclass in c

Initially I wasn't sure how to correctly inherit from `type` using the c api since there are no examples I could find online. By pattern matching with similar examples I ended up with:

```c
typedef struct { PyTypeObject base_type; } MyMetaclass;

static PyTypeObject MyMetaclassType = {
    PyVarObject_HEAD_INIT(NULL, 0)
    .tp_name = "metaclass_test.MyMetaclass",
    .tp_basicsize = sizeof(MyMetaclass),
    .tp_base = &PyType_Type,
    // etc
};
```
But this has a problem. `PyTypeObject` is a `PyVarObject` and so cannot implement the `PySizedLayout` trait necessary for using it as a base in Pyo3. After some searching I found [PEP-0697](https://peps.python.org/pep-0697/) which was very useful because it explains that the actual base of `PyType_Type` is `PyHeapTypeObject` meaning that the example should have been:

```c
typedef struct { PyHeapTypeObject base_type; } MyMetaclass;
```

The PEP also explains a mechanism introduced in python 3.12 for supporting extending opaque or variable sized base classes in extension modules. The one example of an extension module metaclass that I could find (the ctypes metaclass `_ctypes.CType_Type` defined in `_ctypes.c` in the cpython source code) uses this mechanism
```c
PyType_Spec pyctype_type_spec = {
    .name = "_ctypes.CType_Type",
    .basicsize = -(Py_ssize_t)sizeof(StgInfo),
    // etc
};
```
For this approach `basicsize` is set to a negative number equal to the size of the storage space required just for the
derived class (`StfInfo` in the example above). A pointer to that memory is accessed using `PyObject_GetTypeData()`.

If Pyo3 supported this then it would be possible to extend builtins (including `type`) using the limited API (for python >=3.12).

### Background: Why is inheriting type required
In python the following does not crash, but also does not work correctly as a metaclass:
```python
import pytest

class MyMetaclass:
    def __new__(cls, name, bases, namespace):
        # adding cls to bases doesn't change much other than MyClass.__bases__
        return type(name, bases, namespace)

    def __getitem__(self, item):
        return item

class MyClass(metaclass=MyMetaclass):
    pass

assert MyMetaclass.__bases__ == (object,)  # not a metaclass
assert type(MyClass) is type  # want this to be `MyMetaclass`
with pytest.raises(TypeError):
    MyClass[123]  # want this to call MyMetaclass.__getitem__
```

And in the c example removing the `.tp_base = &PyType_Type,` line from the definition of `MyMetaclassType` results in
```
TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```
because without that line the base becomes `object`.
