### PR TITLE
Test free-threaded build on all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,7 @@ jobs:
       - run: python3 -m nox -s test
 
   test-free-threaded:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
+    if: github.ref != 'refs/heads/main'
     needs: [fmt]
     runs-on: ubuntu-latest
     env:
@@ -568,11 +568,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src
-      # TODO: replace with setup-python when there is support
-      - uses: deadsnakes/action@v3.2.0
-        with:
-          python-version: '3.13-dev'
-          nogil: true
+      - uses: astral-sh/setup-uv@f3bcaebff5eace81a1c062af9f9011aae482ca9d
+      - run: |
+          uv python install 3.13t
+          uv venv --python 3.13t
+          uv pip install pip
+          . .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
       - run: python3 -m sysconfig
       - run: python3 -m pip install --upgrade pip && pip install nox
       - run: nox -s ffi-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,7 +555,6 @@ jobs:
       - run: python3 -m nox -s test
 
   test-free-threaded:
-    if: github.ref != 'refs/heads/main'
     needs: [fmt]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,13 +568,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src
-      - uses: astral-sh/setup-uv@f3bcaebff5eace81a1c062af9f9011aae482ca9d
-      - run: |
-          uv python install 3.13t
-          uv venv --python 3.13t
-          uv pip install pip
-          . .venv/bin/activate
-          echo PATH=$PATH >> $GITHUB_ENV
+      # TODO: replace with setup-python when there is support
+      - uses: deadsnakes/action@v3.2.0
+        with:
+          python-version: '3.13-dev'
+          nogil: true
       - run: python3 -m sysconfig
       - run: python3 -m pip install --upgrade pip && pip install nox
       - run: nox -s ffi-check


### PR DESCRIPTION
This makes the free-threaded CI fire on all PRs, which should hopefully allow us to spot flakey tests sooner. Also 3.13.0 is out, so this is now a build that's officially supported by upstream.

Unfortunately setup-python still doesn't support the free-threaded build. As an experiment, I'm using setup-uv to install a free-threaded build. I've been experimenting with setup-uv in the NumPy CI so I'm interested if the PyO3 tests find anything weird. I'll switch back to the deadsnakes build if the uv build proves problematic.