### PR TITLE
ffi: add FFI definition `PyDateTime_CAPSULE_NAME`

### DIFF
--- a/newsfragments/4634.added.md
+++ b/newsfragments/4634.added.md
@@ -1,0 +1,1 @@
+Add FFI definition `PyDateTime_CAPSULE_NAME`.


### PR DESCRIPTION
While reviewing #4623 I realised that `PyDateTime_CAPSULE_NAME` was a temporary allocation rather than a constant. It also wasn't exposed even though it is in the C header. So a tiny cleanup.