### PR TITLE
ci: run coverage as part of "build" job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,15 @@ jobs:
     if: ${{ !(startsWith(inputs.python-version, 'graalpy') && startsWith(inputs.os, 'windows')) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # For PRs, we need to run on the real PR head, not the resultant merge of the PR into the target branch.
+          #
+          # This is necessary for coverage reporting to make sense; we then get exactly the coverage change
+          # between the base branch and the real PR head.
+          #
+          # If it were run on the merge commit the problem is that the coverage potentially does not align
+          # with the commit diff, because the merge may affect line numbers.
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5
@@ -47,8 +56,17 @@ jobs:
         with:
           toolchain: ${{ inputs.rust }}
           targets: ${{ inputs.rust-target }}
-          # needed to correctly format errors, see #1865
-          components: rust-src
+          # rust-src needed to correctly format errors, see #1865
+          components: rust-src,llvm-tools-preview
+
+      # On windows 32 bit, we are running on an x64 host, so we need to specifically set the target
+      # NB we don't do this for *all* jobs because it breaks coverage of proc macros to have an
+      # explicit target set.
+      - name: Set Rust target for Windows 32-bit
+        if: inputs.os == 'windows-latest' && inputs.python-architecture == 'x86'
+        shell: bash
+        run: |
+          echo "CARGO_BUILD_TARGET=i686-pc-windows-msvc" >> $GITHUB_ENV
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -69,6 +87,16 @@ jobs:
       - if: inputs.rust == 'nightly'
         name: Prepare to test on nightly rust
         run: echo "MAYBE_NIGHTLY=nightly" >> "$GITHUB_ENV"
+
+      - if: inputs.python-version == '3.12'
+        name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - if: inputs.python-version == '3.12'
+        name: Prepare coverage environment
+        run: |
+          cargo llvm-cov clean --workspace --profraw-only
+          nox -s set-coverage-env
 
       - name: Build docs
         run: nox -s docs
@@ -152,9 +180,26 @@ jobs:
         if: ${{ endsWith(inputs.python-version, '-dev') || (steps.ffi-changes.outputs.changed == 'true' && inputs.rust == 'stable' && !startsWith(inputs.python-version, 'graalpy') && !(inputs.python-version == 'pypy3.9' && contains(inputs.os, 'windows'))) }}
         run: nox -s ffi-check
 
+      - name: Generate coverage report
+        if: inputs.python-version == '3.12'
+        run: cargo llvm-cov
+          --package=pyo3
+          --package=pyo3-build-config
+          --package=pyo3-macros-backend
+          --package=pyo3-macros
+          --package=pyo3-ffi
+          report --codecov --output-path coverage.json
+
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4
+        if: inputs.python-version == '3.12'
+        with:
+          file: coverage.json
+          name: ${{ inputs.os }}/${{ inputs.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+
     env:
       CARGO_TERM_VERBOSE: true
-      CARGO_BUILD_TARGET: ${{ inputs.rust-target }}
       RUST_BACKTRACE: 1
       RUSTFLAGS: "-D warnings"
       RUSTDOCFLAGS: "-D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,35 +462,6 @@ jobs:
           components: rust-src
       - run: cargo rustdoc --lib --no-default-features --features full,jiff-02 -Zunstable-options --config "build.rustdocflags=[\"--cfg\", \"docsrs\"]"
 
-  coverage:
-    if: ${{ github.event_name != 'merge_group' }}
-    needs: [fmt]
-    name: coverage ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ["windows-latest", "macos-latest", "ubuntu-latest"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview,rust-src
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - run: python -m pip install --upgrade pip && pip install nox
-      - run: nox -s coverage
-      - uses: codecov/codecov-action@v5
-        with:
-          files: coverage.json
-          name: ${{ matrix.os }}
-          token: ${{ secrets.CODECOV_TOKEN }}
-
   emscripten:
     name: emscripten
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
@@ -813,7 +784,6 @@ jobs:
       - valgrind
       - careful
       - docsrs
-      - coverage
       - emscripten
       - test-debug
       - test-free-threaded


### PR DESCRIPTION
As a followup to #4633, this attempts to move the coverage measurement into the main CI jobs. Let's see how much this impacts perf and complexity...