### PR TITLE
ci: fix clippy beta warning

### DIFF
--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1458,6 +1458,9 @@ impl<T: IntoPy<crate::PyObject>> IsIntoPy<T> {
 
 probe!(IsIntoPyObjectRef);
 
+// Possible clippy beta regression,
+// see https://github.com/rust-lang/rust-clippy/issues/13578
+#[allow(clippy::extra_unused_lifetimes)]
 impl<'a, 'py, T: 'a> IsIntoPyObjectRef<T>
 where
     &'a T: IntoPyObject<'py>,


### PR DESCRIPTION
I believe the current beta clippy warning is a regression; I've opened a report at https://github.com/rust-lang/rust-clippy/issues/13578

Until that gets resolved I suggest we just mute the warning here to avoid getting the red cross on every PR.