### PR TITLE
ci: run coverage for the free-threaded build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,10 +451,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Use the PR head, not the merge commit, because the head commit (and the base)
-          # is what codecov uses to calculate diffs.
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -572,10 +568,24 @@ jobs:
         with:
           python-version: '3.13-dev'
           nogil: true
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
       - run: python3 -m sysconfig
       - run: python3 -m pip install --upgrade pip && pip install nox
+      - name: Prepare coverage environment
+        run: |
+          cargo llvm-cov clean --workspace --profraw-only
+          nox -s set-coverage-env
       - run: nox -s ffi-check
       - run: nox
+      - name: Generate coverage report
+        run: nox -s generate-coverage-report
+      - name: Upload coverage report
+        uses: codecov/codecov-action@v4
+        with:
+          file: coverage.json
+          name: test-free-threaded
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-version-limits:
     needs: [fmt]

--- a/.github/workflows/coverage-pr-base.yml
+++ b/.github/workflows/coverage-pr-base.yml
@@ -1,0 +1,40 @@
+# This runs as a separate job because it needs to run on the `pull_request_target` event
+# in order to access the CODECOV_TOKEN secret.
+#
+# This is safe because this doesn't run arbitrary code from PRs.
+
+name: Set Codecov PR base
+on:
+  # See safety note / doc at the top of this file.
+  pull_request_target:
+
+jobs:
+  coverage-pr-base:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Set PR base on codecov
+        run: |
+          # fetch the merge commit between the PR base and head
+          BASE_REF=refs/heads/${{ github.event.pull_request.base.ref }}
+          MERGE_REF=refs/pull/${{ github.event.pull_request.number }}/merge
+
+          git fetch --progress --depth=1 origin "+$BASE_REF:$BASE_REF" "+$MERGE_REF:$MERGE_REF"
+          while [ -z "$(git merge-base "$BASE_REF" "$MERGE_REF")" ]; do
+            git fetch -q --deepen="10" origin "$BASE_REF" "$MERGE_REF";
+          done
+
+          MERGE_BASE=$(git merge-base "$BASE_REF" "$MERGE_REF")
+          echo "Merge base: $MERGE_BASE"
+
+          # inform codecov about the merge base
+          pip install codecov-cli
+          codecovcli pr-base-picking \
+            --base-sha $MERGE_BASE \
+            --pr ${{ github.event.number }} \
+            --slug PyO3/pyo3 \
+            --token ${{ secrets.CODECOV_TOKEN }} \
+            --service github

--- a/noxfile.py
+++ b/noxfile.py
@@ -72,7 +72,19 @@ def coverage(session: nox.Session) -> None:
     session.env.update(_get_coverage_env())
     _run_cargo(session, "llvm-cov", "clean", "--workspace")
     test(session)
+    generate_coverage_report(session)
 
+
+@nox.session(name="set-coverage-env", venv_backend="none")
+def set_coverage_env(session: nox.Session) -> None:
+    """For use in GitHub Actions to set coverage environment variables."""
+    with open(os.environ["GITHUB_ENV"], "a") as env_file:
+        for k, v in _get_coverage_env().items():
+            print(f"{k}={v}", file=env_file)
+
+
+@nox.session(name="generate-coverage-report", venv_backend="none")
+def generate_coverage_report(session: nox.Session) -> None:
     cov_format = "codecov"
     output_file = "coverage.json"
 


### PR DESCRIPTION
This is loosely related to #4635.

From what I've worked out experimenting with those PRs, I realise that we can run coverage on the merge commit in CI. The nice thing about this is that we can add all jobs (not just `build`) to coverage.

Most importantly for current work, this enables code coverage for the freethreaded job. cc @ngoldbaum 