### PR TITLE
run nox -s clippy-all against free-threaded build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,6 +577,7 @@ jobs:
           cargo llvm-cov clean --workspace --profraw-only
           nox -s set-coverage-env
       - run: nox -s ffi-check
+      - run: nox -s clippy-all
       - run: nox
       - name: Generate coverage report
         run: nox -s generate-coverage-report


### PR DESCRIPTION
While working on #4588 I realized the clippy CI job doesn't run against the free-threaded build. Rather than adjusting the clippy CI job to install a free-threaded Python, I thought it was easier to update the existing free-threaded test to do this.