### PR TITLE
Add example Cargo.toml and build.rs for exposing pyo3 cfgs

### DIFF
--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -39,6 +39,7 @@ generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 
 [dev-dependencies]
 paste = "1"
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }
 
 [build-dependencies]
 pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -39,7 +39,6 @@ generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 
 [dev-dependencies]
 paste = "1"
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }
 
 [build-dependencies]
 pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.0-dev", features = ["resolve-config"] }

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -55,7 +55,7 @@
 //! corresponding C build-time defines. For example, to conditionally define
 //! debug code using `Py_DEBUG`, you could do:
 //!
-//! ```rust
+//! ```rust,ignore
 //! #[cfg(py_sys_config = "Py_DEBUG")]
 //! println!("only runs if python was compiled with Py_DEBUG")
 //! ```
@@ -71,7 +71,7 @@
 //! And then either create a new `build.rs` file in the project root or modify
 //! the existing `build.rs` file to call `use_pyo3_cfgs()`:
 //!
-//! ```rust
+//! ```rust,ignore
 //! fn main() {
 //!     pyo3_build_config::use_pyo3_cfgs();
 //! }

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -57,7 +57,7 @@
 //!
 //! ```rust
 //! #[cfg(py_sys_config = "Py_DEBUG")]
-//! // code that only runs if python was compiled with Py_DEBUG
+//! println!("only runs if python was compiled with Py_DEBUG")
 //! ```
 //!
 //! To use these attributes, add [`pyo3-build-config`] as a build dependency in

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -43,12 +43,25 @@
 //! PyO3 uses `rustc`'s `--cfg` flags to enable or disable code used for different Python versions.
 //! If you want to do this for your own crate, you can do so with the [`pyo3-build-config`] crate.
 //!
-//! - `Py_3_7`, `Py_3_8`, `Py_3_9`, `Py_3_10`: Marks code that is only enabled when
-//!  compiling for a given minimum Python version.
+//! - `Py_3_7`, `Py_3_8`, `Py_3_9`, `Py_3_10`, `Py_3_11`, `Py_3_12`, `Py_3_13`: Marks code that is
+//!    only enabled when compiling for a given minimum Python version.
 //! - `Py_LIMITED_API`: Marks code enabled when the `abi3` feature flag is enabled.
+//! - `Py_GIL_DISABLED`: Marks code that runs only in the free-threaded build of CPython.
 //! - `PyPy` - Marks code enabled when compiling for PyPy.
+//! - `GraalPy` - Marks code enabled when compiling for GraalPy.
 //!
-//! Add [`pyo3-build-config`] as a build dependency in your `Cargo.toml`:
+//! Additionally, you can query for the values `Py_DEBUG`, `Py_REF_DEBUG`,
+//! `Py_TRACE_REFS`, and `COUNT_ALLOCS` from `py_sys_config` to query for the
+//! corresponding C build-time defines. For example, to conditionally define
+//! debug code using `Py_DEBUG`, you could do:
+//!
+//! ```rust
+//! #[cfg(py_sys_config = "Py_DEBUG")]
+//! // code that only runs if python was compiled with Py_DEBUG
+//! ```
+//!
+//! To use these attributes, add [`pyo3-build-config`] as a build dependency in
+//! your `Cargo.toml`:
 //!
 //! ```toml
 //! [build-dependency]

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -48,6 +48,22 @@
 //! - `Py_LIMITED_API`: Marks code enabled when the `abi3` feature flag is enabled.
 //! - `PyPy` - Marks code enabled when compiling for PyPy.
 //!
+//! Add [`pyo3-build-config`] as a build dependency in your `Cargo.toml`:
+//!
+//! ```toml
+//! [build-dependency]
+//! pyo3-build-config = "VER"
+//! ```
+//!
+//! And then either create a new `build.rs` file in the project root or modify
+//! the existing `build.rs` file to call `use_pyo3_cfgs()`:
+//!
+//! ```rust
+//! fn main() {
+//!     pyo3_build_config::use_pyo3_cfgs();
+//! }
+//! ```
+//!
 //! # Minimum supported Rust and Python versions
 //!
 //! `pyo3-ffi` supports the following Python distributions:


### PR DESCRIPTION
While working on #4588 I ran into this documentation snippet and it would have saved me some time if the docs explicitly spelled out what you need to do.