### PR TITLE
add cellular_raza to examples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ about this topic.
 - [ballista-python](https://github.com/apache/arrow-ballista-python) _A Python library that binds to Apache Arrow distributed query engine Ballista._
 - [bed-reader](https://github.com/fastlmm/bed-reader) _Read and write the PLINK BED format, simply and efficiently._
     - Shows Rayon/ndarray::parallel (including capturing errors, controlling thread num), Python types to Rust generics, Github Actions
+- [cellular_raza](https://cellular-raza.com) A cellular agent-based simulation framework for building complex models from a clean slate._
 - [connector-x](https://github.com/sfu-db/connector-x) _Fastest library to load data from DB to DataFrames in Rust and Python._
 - [cryptography](https://github.com/pyca/cryptography/tree/main/src/rust) _Python cryptography library with some functionality in Rust._
 - [css-inline](https://github.com/Stranger6667/css-inline/tree/master/bindings/python) _CSS inlining for Python implemented in Rust._


### PR DESCRIPTION
Hi Everyone,

I have enjoyed using `pyo3` for the better part of my PhD and would love to include my simulation framework in the list of examples.
Please let me know if you would like to have any more details. I am currently also working on a guide on how to structure a project with `cellular_raza` which uses `pyo3` to generate bindings. You will find it in the coming weeks on my project's website: https://cellular-raza.com/guides/.

Thanks for all your hard work!