### PR TITLE
Add failing example from graalpy CI

### DIFF
--- a/pytests/tests/test_datetime.py
+++ b/pytests/tests/test_datetime.py
@@ -238,6 +238,7 @@ def test_datetime_typeerror():
 
 @given(dt=st.datetimes(MIN_DATETIME, MAX_DATETIME))
 @example(dt=pdt.datetime(1971, 1, 2, 0, 0))
+@example(dt=pdt.datetime(4011, 7, 28, 23, 53, 28, 538099, fold=1))
 def test_datetime_from_timestamp(dt):
     try:
         ts = pdt.datetime.timestamp(dt)


### PR DESCRIPTION
I saw this failure on #4648 for the `pythongraalpy24.0-x64 ubuntu-latest rust-stable` build.

```python
  FAILED tests/test_datetime.py::test_datetime_from_timestamp - hypothesis.errors.FlakyFailure: Hypothesis test_datetime_from_timestamp(dt=datetime.datetime(4011, 7, 28, 23, 53, 28, 538099, fold=1)) produces unreliable results: Falsified on the first call but did not on a subsequent one (1 sub-exception)
  Falsifying example: test_datetime_from_timestamp(
      dt=datetime.datetime(4011, 7, 28, 23, 53, 28, 538099, fold=1),
  )
```