### PR TITLE
migrate `call` API to `IntoPyObject`

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,11 +1,10 @@
 //! Defines conversions between Rust and Python types.
 use crate::err::PyResult;
-use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::pyclass::boolean_struct::False;
 use crate::types::any::PyAnyMethods;
-use crate::types::{PyDict, PyString, PyTuple};
+use crate::types::PyTuple;
 use crate::{
     ffi, Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyObject, PyRef, PyRefMut, Python,
 };
@@ -176,93 +175,6 @@ pub trait IntoPy<T>: Sized {
     #[cfg(feature = "experimental-inspect")]
     fn type_output() -> TypeInfo {
         TypeInfo::Any
-    }
-
-    // The following methods are helpers to use the vectorcall API where possible.
-    // They are overridden on tuples to perform a vectorcall.
-    // Be careful when you're implementing these: they can never refer to `Bound` call methods,
-    // as those refer to these methods, so this will create an infinite recursion.
-    #[doc(hidden)]
-    #[inline]
-    fn __py_call_vectorcall1<'py>(
-        self,
-        py: Python<'py>,
-        function: Borrowed<'_, 'py, PyAny>,
-        _: private::Token,
-    ) -> PyResult<Bound<'py, PyAny>>
-    where
-        Self: IntoPy<Py<PyTuple>>,
-    {
-        #[inline]
-        fn inner<'py>(
-            py: Python<'py>,
-            function: Borrowed<'_, 'py, PyAny>,
-            args: Bound<'py, PyTuple>,
-        ) -> PyResult<Bound<'py, PyAny>> {
-            unsafe {
-                ffi::PyObject_Call(function.as_ptr(), args.as_ptr(), std::ptr::null_mut())
-                    .assume_owned_or_err(py)
-            }
-        }
-        inner(
-            py,
-            function,
-            <Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py),
-        )
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    fn __py_call_vectorcall<'py>(
-        self,
-        py: Python<'py>,
-        function: Borrowed<'_, 'py, PyAny>,
-        kwargs: Option<Borrowed<'_, '_, PyDict>>,
-        _: private::Token,
-    ) -> PyResult<Bound<'py, PyAny>>
-    where
-        Self: IntoPy<Py<PyTuple>>,
-    {
-        #[inline]
-        fn inner<'py>(
-            py: Python<'py>,
-            function: Borrowed<'_, 'py, PyAny>,
-            args: Bound<'py, PyTuple>,
-            kwargs: Option<Borrowed<'_, '_, PyDict>>,
-        ) -> PyResult<Bound<'py, PyAny>> {
-            unsafe {
-                ffi::PyObject_Call(
-                    function.as_ptr(),
-                    args.as_ptr(),
-                    kwargs.map_or_else(std::ptr::null_mut, |kwargs| kwargs.as_ptr()),
-                )
-                .assume_owned_or_err(py)
-            }
-        }
-        inner(
-            py,
-            function,
-            <Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py),
-            kwargs,
-        )
-    }
-
-    #[doc(hidden)]
-    #[inline]
-    fn __py_call_method_vectorcall1<'py>(
-        self,
-        _py: Python<'py>,
-        object: Borrowed<'_, 'py, PyAny>,
-        method_name: Borrowed<'_, 'py, PyString>,
-        _: private::Token,
-    ) -> PyResult<Bound<'py, PyAny>>
-    where
-        Self: IntoPy<Py<PyTuple>>,
-    {
-        // Don't `self.into_py()`! This will lose the optimization of vectorcall.
-        object
-            .getattr(method_name)
-            .and_then(|method| method.call1(self))
     }
 }
 
@@ -592,52 +504,6 @@ where
 impl IntoPy<Py<PyTuple>> for () {
     fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
         PyTuple::empty(py).unbind()
-    }
-
-    #[inline]
-    fn __py_call_vectorcall1<'py>(
-        self,
-        py: Python<'py>,
-        function: Borrowed<'_, 'py, PyAny>,
-        _: private::Token,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        unsafe { ffi::compat::PyObject_CallNoArgs(function.as_ptr()).assume_owned_or_err(py) }
-    }
-
-    #[inline]
-    fn __py_call_vectorcall<'py>(
-        self,
-        py: Python<'py>,
-        function: Borrowed<'_, 'py, PyAny>,
-        kwargs: Option<Borrowed<'_, '_, PyDict>>,
-        _: private::Token,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        unsafe {
-            match kwargs {
-                Some(kwargs) => ffi::PyObject_Call(
-                    function.as_ptr(),
-                    PyTuple::empty(py).as_ptr(),
-                    kwargs.as_ptr(),
-                )
-                .assume_owned_or_err(py),
-                None => ffi::compat::PyObject_CallNoArgs(function.as_ptr()).assume_owned_or_err(py),
-            }
-        }
-    }
-
-    #[inline]
-    #[allow(clippy::used_underscore_binding)]
-    fn __py_call_method_vectorcall1<'py>(
-        self,
-        py: Python<'py>,
-        object: Borrowed<'_, 'py, PyAny>,
-        method_name: Borrowed<'_, 'py, PyString>,
-        _: private::Token,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        unsafe {
-            ffi::compat::PyObject_CallMethodNoArgs(object.as_ptr(), method_name.as_ptr())
-                .assume_owned_or_err(py)
-        }
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1495,7 +1495,7 @@ impl<T> Py<T> {
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<PyObject>
     where
-        A: IntoPy<Py<PyTuple>>,
+        A: IntoPyObject<'py, Target = PyTuple>,
     {
         self.bind(py).as_any().call(args, kwargs).map(Bound::unbind)
     }
@@ -1509,15 +1509,15 @@ impl<T> Py<T> {
         args: impl IntoPy<Py<PyTuple>>,
         kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<PyObject> {
-        self.call(py, args, kwargs)
+        self.call(py, args.into_py(py), kwargs)
     }
 
     /// Calls the object with only positional arguments.
     ///
     /// This is equivalent to the Python expression `self(*args)`.
-    pub fn call1<N>(&self, py: Python<'_>, args: N) -> PyResult<PyObject>
+    pub fn call1<'py, N>(&self, py: Python<'py>, args: N) -> PyResult<PyObject>
     where
-        N: IntoPy<Py<PyTuple>>,
+        N: IntoPyObject<'py, Target = PyTuple>,
     {
         self.bind(py).as_any().call1(args).map(Bound::unbind)
     }
@@ -1540,11 +1540,11 @@ impl<T> Py<T> {
         py: Python<'py>,
         name: N,
         args: A,
-        kwargs: Option<&Bound<'_, PyDict>>,
+        kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<PyObject>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        A: IntoPy<Py<PyTuple>>,
+        A: IntoPyObject<'py, Target = PyTuple>,
     {
         self.bind(py)
             .as_any()
@@ -1566,7 +1566,7 @@ impl<T> Py<T> {
         N: IntoPy<Py<PyString>>,
         A: IntoPy<Py<PyTuple>>,
     {
-        self.call_method(py, name.into_py(py), args, kwargs)
+        self.call_method(py, name.into_py(py), args.into_py(py), kwargs)
     }
 
     /// Calls a method on the object with only positional arguments.
@@ -1578,7 +1578,7 @@ impl<T> Py<T> {
     pub fn call_method1<'py, N, A>(&self, py: Python<'py>, name: N, args: A) -> PyResult<PyObject>
     where
         N: IntoPyObject<'py, Target = PyString>,
-        A: IntoPy<Py<PyTuple>>,
+        A: IntoPyObject<'py, Target = PyTuple>,
     {
         self.bind(py)
             .as_any()

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1,15 +1,13 @@
 use std::iter::FusedIterator;
 
-use crate::conversion::{private, IntoPyObject};
+use crate::conversion::IntoPyObject;
 use crate::ffi::{self, Py_ssize_t};
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::instance::Borrowed;
 use crate::internal_tricks::get_ssize_index;
-use crate::types::{
-    any::PyAnyMethods, sequence::PySequenceMethods, PyDict, PyList, PySequence, PyString,
-};
+use crate::types::{any::PyAnyMethods, sequence::PySequenceMethods, PyList, PySequence};
 #[allow(deprecated)]
 use crate::ToPyObject;
 use crate::{
@@ -572,109 +570,6 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
         #[cfg(feature = "experimental-inspect")]
         fn type_output() -> TypeInfo {
             TypeInfo::Tuple(Some(vec![$( $T::type_output() ),+]))
-        }
-
-        #[inline]
-        fn __py_call_vectorcall1<'py>(
-            self,
-            py: Python<'py>,
-            function: Borrowed<'_, 'py, PyAny>,
-            _: private::Token,
-        ) -> PyResult<Bound<'py, PyAny>> {
-            cfg_if::cfg_if! {
-                if #[cfg(all(Py_3_9, not(any(PyPy, GraalPy, Py_LIMITED_API))))] {
-                    // We need this to drop the arguments correctly.
-                    let args_bound = [$(self.$n.into_py(py).into_bound(py),)*];
-                    if $length == 1 {
-                        unsafe {
-                            ffi::PyObject_CallOneArg(function.as_ptr(), args_bound[0].as_ptr()).assume_owned_or_err(py)
-                        }
-                    } else {
-                        // Prepend one null argument for `PY_VECTORCALL_ARGUMENTS_OFFSET`.
-                        let mut args = [std::ptr::null_mut(), $(args_bound[$n].as_ptr()),*];
-                        unsafe {
-                            ffi::PyObject_Vectorcall(
-                                function.as_ptr(),
-                                args.as_mut_ptr().add(1),
-                                $length + ffi::PY_VECTORCALL_ARGUMENTS_OFFSET,
-                                std::ptr::null_mut(),
-                            )
-                            .assume_owned_or_err(py)
-                        }
-                    }
-                } else {
-                    function.call1(<Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py))
-                }
-            }
-        }
-
-        #[inline]
-        fn __py_call_vectorcall<'py>(
-            self,
-            py: Python<'py>,
-            function: Borrowed<'_, 'py, PyAny>,
-            kwargs: Option<Borrowed<'_, '_, PyDict>>,
-            _: private::Token,
-        ) -> PyResult<Bound<'py, PyAny>> {
-            cfg_if::cfg_if! {
-                if #[cfg(all(Py_3_9, not(any(PyPy, GraalPy, Py_LIMITED_API))))] {
-                    // We need this to drop the arguments correctly.
-                    let args_bound = [$(self.$n.into_py(py).into_bound(py),)*];
-                    // Prepend one null argument for `PY_VECTORCALL_ARGUMENTS_OFFSET`.
-                    let mut args = [std::ptr::null_mut(), $(args_bound[$n].as_ptr()),*];
-                    unsafe {
-                        ffi::PyObject_VectorcallDict(
-                            function.as_ptr(),
-                            args.as_mut_ptr().add(1),
-                            $length + ffi::PY_VECTORCALL_ARGUMENTS_OFFSET,
-                            kwargs.map_or_else(std::ptr::null_mut, |kwargs| kwargs.as_ptr()),
-                        )
-                        .assume_owned_or_err(py)
-                    }
-                } else {
-                    function.call(<Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py), kwargs.as_deref())
-                }
-            }
-        }
-
-        #[inline]
-        fn __py_call_method_vectorcall1<'py>(
-            self,
-            py: Python<'py>,
-            object: Borrowed<'_, 'py, PyAny>,
-            method_name: Borrowed<'_, 'py, PyString>,
-            _: private::Token,
-        ) -> PyResult<Bound<'py, PyAny>> {
-            cfg_if::cfg_if! {
-                if #[cfg(all(Py_3_9, not(any(PyPy, GraalPy, Py_LIMITED_API))))] {
-                    // We need this to drop the arguments correctly.
-                    let args_bound = [$(self.$n.into_py(py).into_bound(py),)*];
-                    if $length == 1 {
-                        unsafe {
-                            ffi::PyObject_CallMethodOneArg(
-                                    object.as_ptr(),
-                                    method_name.as_ptr(),
-                                    args_bound[0].as_ptr(),
-                            )
-                            .assume_owned_or_err(py)
-                        }
-                    } else {
-                        let mut args = [object.as_ptr(), $(args_bound[$n].as_ptr()),*];
-                        unsafe {
-                            ffi::PyObject_VectorcallMethod(
-                                method_name.as_ptr(),
-                                args.as_mut_ptr(),
-                                // +1 for the receiver.
-                                1 + $length + ffi::PY_VECTORCALL_ARGUMENTS_OFFSET,
-                                std::ptr::null_mut(),
-                            )
-                            .assume_owned_or_err(py)
-                        }
-                    }
-                } else {
-                    object.call_method1(method_name, <Self as IntoPy<Py<PyTuple>>>::into_py(self, py).into_bound(py))
-                }
-            }
         }
     }
 


### PR DESCRIPTION
This migrates the Python `call` APIs to use `IntoPyObject` for their arguments. For simplicity this removes removes the vectorcall specialization for now. Hopefully we can bring it back with a `PyCallArgs` trait as discussed in https://github.com/PyO3/pyo3/pull/4456#discussion_r1723956269 in 0.24