### PR TITLE
move `IntoPy::type_output` to `IntoPyObject::type_output`

### DIFF
--- a/newsfragments/4657.changed.md
+++ b/newsfragments/4657.changed.md
@@ -1,0 +1,1 @@
+`IntoPy::type_output` moved to `IntoPyObject::type_output`

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -164,18 +164,6 @@ pub trait ToPyObject {
 pub trait IntoPy<T>: Sized {
     /// Performs the conversion.
     fn into_py(self, py: Python<'_>) -> T;
-
-    /// Extracts the type hint information for this type when it appears as a return value.
-    ///
-    /// For example, `Vec<u32>` would return `List[int]`.
-    /// The default implementation returns `Any`, which is correct for any type.
-    ///
-    /// For most types, the return value for this method will be identical to that of [`FromPyObject::type_input`].
-    /// It may be different for some types, such as `Dict`, to allow duck-typing: functions return `Dict` but take `Mapping` as argument.
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::Any
-    }
 }
 
 /// Defines a conversion from a Rust type to a Python object, which may fail.
@@ -204,6 +192,18 @@ pub trait IntoPyObject<'py>: Sized {
 
     /// Performs the conversion.
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error>;
+
+    /// Extracts the type hint information for this type when it appears as a return value.
+    ///
+    /// For example, `Vec<u32>` would return `List[int]`.
+    /// The default implementation returns `Any`, which is correct for any type.
+    ///
+    /// For most types, the return value for this method will be identical to that of [`FromPyObject::type_input`].
+    /// It may be different for some types, such as `Dict`, to allow duck-typing: functions return `Dict` but take `Mapping` as argument.
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::Any
+    }
 
     /// Converts sequence of Self into a Python object. Used to specialize `Vec<u8>`, `[u8; N]`
     /// and `SmallVec<[u8; N]>` as a sequence of bytes into a `bytes` object.
@@ -379,8 +379,9 @@ pub trait FromPyObject<'py>: Sized {
     /// For example, `Vec<u32>` would return `Sequence[int]`.
     /// The default implementation returns `Any`, which is correct for any type.
     ///
-    /// For most types, the return value for this method will be identical to that of [`IntoPy::type_output`].
-    /// It may be different for some types, such as `Dict`, to allow duck-typing: functions return `Dict` but take `Mapping` as argument.
+    /// For most types, the return value for this method will be identical to that of
+    /// [`IntoPyObject::type_output`]. It may be different for some types, such as `Dict`,
+    /// to allow duck-typing: functions return `Dict` but take `Mapping` as argument.
     #[cfg(feature = "experimental-inspect")]
     fn type_input() -> TypeInfo {
         TypeInfo::Any
@@ -440,8 +441,9 @@ pub trait FromPyObjectBound<'a, 'py>: Sized + from_py_object_bound_sealed::Seale
     /// For example, `Vec<u32>` would return `Sequence[int]`.
     /// The default implementation returns `Any`, which is correct for any type.
     ///
-    /// For most types, the return value for this method will be identical to that of [`IntoPy::type_output`].
-    /// It may be different for some types, such as `Dict`, to allow duck-typing: functions return `Dict` but take `Mapping` as argument.
+    /// For most types, the return value for this method will be identical to that of
+    /// [`IntoPyObject::type_output`]. It may be different for some types, such as `Dict`,
+    /// to allow duck-typing: functions return `Dict` but take `Mapping` as argument.
     #[cfg(feature = "experimental-inspect")]
     fn type_input() -> TypeInfo {
         TypeInfo::Any

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -51,11 +51,6 @@ where
         let list = new_from_iter(py, &mut iter);
         list.into()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::list_of(A::Item::type_output())
-    }
 }
 
 impl<'py, A> IntoPyObject<'py> for SmallVec<A>
@@ -75,6 +70,11 @@ where
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         <A::Item>::owned_sequence_into_pyobject(self, py, crate::conversion::private::Token)
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::list_of(A::Item::type_output())
+    }
 }
 
 impl<'a, 'py, A> IntoPyObject<'py> for &'a SmallVec<A>
@@ -89,6 +89,11 @@ where
     #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.as_slice().into_pyobject(py)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::list_of(<&A::Item>::type_output())
     }
 }
 

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -81,6 +81,7 @@ impl<'a, 'py, A> IntoPyObject<'py> for &'a SmallVec<A>
 where
     A: Array,
     &'a A::Item: IntoPyObject<'py>,
+    A::Item: 'a, // MSRV
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -55,11 +55,6 @@ where
         }
         dict.into_any().unbind()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::dict_of(K::type_output(), V::type_output())
-    }
 }
 
 impl<'py, K, V, H> IntoPyObject<'py> for collections::HashMap<K, V, H>
@@ -78,6 +73,11 @@ where
             dict.set_item(k, v)?;
         }
         Ok(dict)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::dict_of(K::type_output(), V::type_output())
     }
 }
 
@@ -98,6 +98,11 @@ where
         }
         Ok(dict)
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::dict_of(<&K>::type_output(), <&V>::type_output())
+    }
 }
 
 impl<K, V> IntoPy<PyObject> for collections::BTreeMap<K, V>
@@ -111,11 +116,6 @@ where
             dict.set_item(k.into_py(py), v.into_py(py)).unwrap();
         }
         dict.into_any().unbind()
-    }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::dict_of(K::type_output(), V::type_output())
     }
 }
 
@@ -135,6 +135,11 @@ where
         }
         Ok(dict)
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::dict_of(K::type_output(), V::type_output())
+    }
 }
 
 impl<'a, 'py, K, V> IntoPyObject<'py> for &'a collections::BTreeMap<K, V>
@@ -152,6 +157,11 @@ where
             dict.set_item(k, v)?;
         }
         Ok(dict)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::dict_of(<&K>::type_output(), <&V>::type_output())
     }
 }
 

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -85,6 +85,8 @@ impl<'a, 'py, K, V, H> IntoPyObject<'py> for &'a collections::HashMap<K, V, H>
 where
     &'a K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     &'a V: IntoPyObject<'py>,
+    K: 'a, // MSRV
+    V: 'a, // MSRV
     H: hash::BuildHasher,
 {
     type Target = PyDict;
@@ -146,6 +148,8 @@ impl<'a, 'py, K, V> IntoPyObject<'py> for &'a collections::BTreeMap<K, V>
 where
     &'a K: IntoPyObject<'py> + cmp::Eq,
     &'a V: IntoPyObject<'py>,
+    K: 'a,
+    V: 'a,
 {
     type Target = PyDict;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -31,11 +31,6 @@ macro_rules! int_fits_larger_int {
             fn into_py(self, py: Python<'_>) -> PyObject {
                 self.into_pyobject(py).unwrap().into_any().unbind()
             }
-
-            #[cfg(feature = "experimental-inspect")]
-            fn type_output() -> TypeInfo {
-                <$larger_type>::type_output()
-            }
         }
 
         impl<'py> IntoPyObject<'py> for $rust_type {
@@ -46,6 +41,11 @@ macro_rules! int_fits_larger_int {
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 (self as $larger_type).into_pyobject(py)
             }
+
+            #[cfg(feature = "experimental-inspect")]
+            fn type_output() -> TypeInfo {
+                <$larger_type>::type_output()
+            }
         }
 
         impl<'py> IntoPyObject<'py> for &$rust_type {
@@ -55,6 +55,11 @@ macro_rules! int_fits_larger_int {
 
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 (*self).into_pyobject(py)
+            }
+
+            #[cfg(feature = "experimental-inspect")]
+            fn type_output() -> TypeInfo {
+                <$larger_type>::type_output()
             }
         }
 
@@ -112,11 +117,6 @@ macro_rules! int_convert_u64_or_i64 {
             fn into_py(self, py: Python<'_>) -> PyObject {
                 self.into_pyobject(py).unwrap().into_any().unbind()
             }
-
-            #[cfg(feature = "experimental-inspect")]
-            fn type_output() -> TypeInfo {
-                TypeInfo::builtin("int")
-            }
         }
         impl<'py> IntoPyObject<'py> for $rust_type {
             type Target = PyInt;
@@ -130,6 +130,11 @@ macro_rules! int_convert_u64_or_i64 {
                         .downcast_into_unchecked())
                 }
             }
+
+            #[cfg(feature = "experimental-inspect")]
+            fn type_output() -> TypeInfo {
+                TypeInfo::builtin("int")
+            }
         }
         impl<'py> IntoPyObject<'py> for &$rust_type {
             type Target = PyInt;
@@ -139,6 +144,11 @@ macro_rules! int_convert_u64_or_i64 {
             #[inline]
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 (*self).into_pyobject(py)
+            }
+
+            #[cfg(feature = "experimental-inspect")]
+            fn type_output() -> TypeInfo {
+                TypeInfo::builtin("int")
             }
         }
         impl FromPyObject<'_> for $rust_type {
@@ -168,11 +178,6 @@ macro_rules! int_fits_c_long {
             fn into_py(self, py: Python<'_>) -> PyObject {
                 self.into_pyobject(py).unwrap().into_any().unbind()
             }
-
-            #[cfg(feature = "experimental-inspect")]
-            fn type_output() -> TypeInfo {
-                TypeInfo::builtin("int")
-            }
         }
 
         impl<'py> IntoPyObject<'py> for $rust_type {
@@ -187,6 +192,11 @@ macro_rules! int_fits_c_long {
                         .downcast_into_unchecked())
                 }
             }
+
+            #[cfg(feature = "experimental-inspect")]
+            fn type_output() -> TypeInfo {
+                TypeInfo::builtin("int")
+            }
         }
 
         impl<'py> IntoPyObject<'py> for &$rust_type {
@@ -197,6 +207,11 @@ macro_rules! int_fits_c_long {
             #[inline]
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 (*self).into_pyobject(py)
+            }
+
+            #[cfg(feature = "experimental-inspect")]
+            fn type_output() -> TypeInfo {
+                TypeInfo::builtin("int")
             }
         }
 
@@ -227,10 +242,6 @@ impl IntoPy<PyObject> for u8 {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
     }
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::builtin("int")
-    }
 }
 impl<'py> IntoPyObject<'py> for u8 {
     type Target = PyInt;
@@ -243,6 +254,11 @@ impl<'py> IntoPyObject<'py> for u8 {
                 .assume_owned(py)
                 .downcast_into_unchecked())
         }
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("int")
     }
 
     #[inline]
@@ -265,6 +281,11 @@ impl<'py> IntoPyObject<'py> for &'_ u8 {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         u8::into_pyobject(*self, py)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("int")
     }
 
     #[inline]
@@ -345,11 +366,6 @@ mod fast_128bit_int_conversion {
                 fn into_py(self, py: Python<'_>) -> PyObject {
                     self.into_pyobject(py).unwrap().into_any().unbind()
                 }
-
-                #[cfg(feature = "experimental-inspect")]
-                fn type_output() -> TypeInfo {
-                    TypeInfo::builtin("int")
-                }
             }
 
             impl<'py> IntoPyObject<'py> for $rust_type {
@@ -399,6 +415,11 @@ mod fast_128bit_int_conversion {
                         }
                     }
                 }
+
+                #[cfg(feature = "experimental-inspect")]
+                fn type_output() -> TypeInfo {
+                    TypeInfo::builtin("int")
+                }
             }
 
             impl<'py> IntoPyObject<'py> for &$rust_type {
@@ -409,6 +430,11 @@ mod fast_128bit_int_conversion {
                 #[inline]
                 fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                     (*self).into_pyobject(py)
+                }
+
+                #[cfg(feature = "experimental-inspect")]
+                fn type_output() -> TypeInfo {
+                    TypeInfo::builtin("int")
                 }
             }
 
@@ -493,11 +519,6 @@ mod slow_128bit_int_conversion {
                 fn into_py(self, py: Python<'_>) -> PyObject {
                     self.into_pyobject(py).unwrap().into_any().unbind()
                 }
-
-                #[cfg(feature = "experimental-inspect")]
-                fn type_output() -> TypeInfo {
-                    TypeInfo::builtin("int")
-                }
             }
 
             impl<'py> IntoPyObject<'py> for $rust_type {
@@ -518,6 +539,11 @@ mod slow_128bit_int_conversion {
                             .downcast_into_unchecked())
                     }
                 }
+
+                #[cfg(feature = "experimental-inspect")]
+                fn type_output() -> TypeInfo {
+                    TypeInfo::builtin("int")
+                }
             }
 
             impl<'py> IntoPyObject<'py> for &$rust_type {
@@ -528,6 +554,11 @@ mod slow_128bit_int_conversion {
                 #[inline]
                 fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                     (*self).into_pyobject(py)
+                }
+
+                #[cfg(feature = "experimental-inspect")]
+                fn type_output() -> TypeInfo {
+                    TypeInfo::builtin("int")
                 }
             }
 
@@ -602,6 +633,11 @@ macro_rules! nonzero_int_impl {
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 self.get().into_pyobject(py)
             }
+
+            #[cfg(feature = "experimental-inspect")]
+            fn type_output() -> TypeInfo {
+                TypeInfo::builtin("int")
+            }
         }
 
         impl<'py> IntoPyObject<'py> for &$nonzero_type {
@@ -612,6 +648,11 @@ macro_rules! nonzero_int_impl {
             #[inline]
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                 (*self).into_pyobject(py)
+            }
+
+            #[cfg(feature = "experimental-inspect")]
+            fn type_output() -> TypeInfo {
+                TypeInfo::builtin("int")
             }
         }
 

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -75,6 +75,7 @@ where
 impl<'a, 'py, K, H> IntoPyObject<'py> for &'a collections::HashSet<K, H>
 where
     &'a K: IntoPyObject<'py> + Eq + hash::Hash,
+    K: 'a, // MSRV
     H: hash::BuildHasher,
 {
     type Target = PySet;
@@ -147,6 +148,7 @@ where
 impl<'a, 'py, K> IntoPyObject<'py> for &'a collections::BTreeSet<K>
 where
     &'a K: IntoPyObject<'py> + cmp::Ord,
+    K: 'a,
 {
     type Target = PySet;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -51,11 +51,6 @@ where
             .expect("Failed to create Python set from HashSet")
             .into()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::set_of(K::type_output())
-    }
 }
 
 impl<'py, K, S> IntoPyObject<'py> for collections::HashSet<K, S>
@@ -70,6 +65,11 @@ where
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         try_new_from_iter(py, self)
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::set_of(K::type_output())
+    }
 }
 
 impl<'a, 'py, K, H> IntoPyObject<'py> for &'a collections::HashSet<K, H>
@@ -83,6 +83,11 @@ where
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         try_new_from_iter(py, self.iter())
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::set_of(<&K>::type_output())
     }
 }
 
@@ -119,11 +124,6 @@ where
             .expect("Failed to create Python set from BTreeSet")
             .into()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::set_of(K::type_output())
-    }
 }
 
 impl<'py, K> IntoPyObject<'py> for collections::BTreeSet<K>
@@ -137,6 +137,11 @@ where
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         try_new_from_iter(py, self)
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::set_of(K::type_output())
+    }
 }
 
 impl<'a, 'py, K> IntoPyObject<'py> for &'a collections::BTreeSet<K>
@@ -149,6 +154,11 @@ where
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         try_new_from_iter(py, self.iter())
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::set_of(<&K>::type_output())
     }
 }
 

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -19,6 +19,7 @@ impl IntoPy<PyObject> for &[u8] {
 impl<'a, 'py, T> IntoPyObject<'py> for &'a [T]
 where
     &'a T: IntoPyObject<'py>,
+    T: 'a, // MSRV
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -14,11 +14,6 @@ impl IntoPy<PyObject> for &[u8] {
     fn into_py(self, py: Python<'_>) -> PyObject {
         PyBytes::new(py, self).unbind().into()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::builtin("bytes")
-    }
 }
 
 impl<'a, 'py, T> IntoPyObject<'py> for &'a [T]
@@ -37,6 +32,14 @@ where
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         <&T>::borrowed_sequence_into_pyobject(self, py, crate::conversion::private::Token)
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::union_of(&[
+            TypeInfo::builtin("bytes"),
+            TypeInfo::list_of(<&T>::type_output()),
+        ])
+    }
 }
 
 impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a [u8] {
@@ -46,7 +49,7 @@ impl<'a> crate::conversion::FromPyObjectBound<'a, '_> for &'a [u8] {
 
     #[cfg(feature = "experimental-inspect")]
     fn type_input() -> TypeInfo {
-        Self::type_output()
+        TypeInfo::builtin("bytes")
     }
 }
 

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -26,22 +26,12 @@ impl IntoPy<PyObject> for &str {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        <String>::type_output()
-    }
 }
 
 impl IntoPy<Py<PyString>> for &str {
     #[inline]
     fn into_py(self, py: Python<'_>) -> Py<PyString> {
         self.into_pyobject(py).unwrap().unbind()
-    }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        <String>::type_output()
     }
 }
 
@@ -54,6 +44,11 @@ impl<'py> IntoPyObject<'py> for &str {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyString::new(py, self))
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        <String>::type_output()
+    }
 }
 
 impl<'py> IntoPyObject<'py> for &&str {
@@ -64,6 +59,11 @@ impl<'py> IntoPyObject<'py> for &&str {
     #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        <String>::type_output()
     }
 }
 
@@ -82,11 +82,6 @@ impl IntoPy<PyObject> for Cow<'_, str> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        <String>::type_output()
-    }
 }
 
 impl<'py> IntoPyObject<'py> for Cow<'_, str> {
@@ -98,6 +93,11 @@ impl<'py> IntoPyObject<'py> for Cow<'_, str> {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        <String>::type_output()
+    }
 }
 
 impl<'py> IntoPyObject<'py> for &Cow<'_, str> {
@@ -108,6 +108,11 @@ impl<'py> IntoPyObject<'py> for &Cow<'_, str> {
     #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (&**self).into_pyobject(py)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        <String>::type_output()
     }
 }
 
@@ -134,11 +139,6 @@ impl IntoPy<PyObject> for char {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        <String>::type_output()
-    }
 }
 
 impl<'py> IntoPyObject<'py> for char {
@@ -149,6 +149,11 @@ impl<'py> IntoPyObject<'py> for char {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let mut bytes = [0u8; 4];
         Ok(PyString::new(py, self.encode_utf8(&mut bytes)))
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        <String>::type_output()
     }
 }
 
@@ -161,17 +166,17 @@ impl<'py> IntoPyObject<'py> for &char {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        <String>::type_output()
+    }
 }
 
 impl IntoPy<PyObject> for String {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
-    }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::builtin("str")
     }
 }
 
@@ -183,17 +188,17 @@ impl<'py> IntoPyObject<'py> for String {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyString::new(py, &self))
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("str")
+    }
 }
 
 impl IntoPy<PyObject> for &String {
     #[inline]
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
-    }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        <String>::type_output()
     }
 }
 
@@ -205,6 +210,11 @@ impl<'py> IntoPyObject<'py> for &String {
     #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyString::new(py, self))
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        <String>::type_output()
     }
 }
 

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -65,6 +65,7 @@ where
 impl<'a, 'py, T> IntoPyObject<'py> for &'a Vec<T>
 where
     &'a T: IntoPyObject<'py>,
+    T: 'a, // MSRV
 {
     type Target = PyAny;
     type Output = Bound<'py, Self::Target>;

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -37,11 +37,6 @@ where
         let list = new_from_iter(py, &mut iter);
         list.into()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::list_of(T::type_output())
-    }
 }
 
 impl<'py, T> IntoPyObject<'py> for Vec<T>
@@ -60,6 +55,11 @@ where
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         T::owned_sequence_into_pyobject(self, py, crate::conversion::private::Token)
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::list_of(T::type_output())
+    }
 }
 
 impl<'a, 'py, T> IntoPyObject<'py> for &'a Vec<T>
@@ -76,6 +76,11 @@ where
         // `&Vec<u8>`, but that'd be inconsistent with the `IntoPyObject` impl
         // above which always returns a `PyAny` for `Vec<T>`.
         self.as_slice().into_pyobject(py).map(Bound::into_any)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::list_of(<&T>::type_output())
     }
 }
 

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -277,6 +277,7 @@ mod test {
 
     use crate::inspect::types::{ModuleName, TypeInfo};
 
+    #[track_caller]
     pub fn assert_display(t: &TypeInfo, expected: &str) {
         assert_eq!(format!("{}", t), expected)
     }
@@ -405,7 +406,7 @@ mod conversion {
     use std::collections::{HashMap, HashSet};
 
     use crate::inspect::types::test::assert_display;
-    use crate::{FromPyObject, IntoPy};
+    use crate::{FromPyObject, IntoPyObject};
 
     #[test]
     fn unsigned_int() {
@@ -463,7 +464,8 @@ mod conversion {
         assert_display(&String::type_output(), "str");
         assert_display(&String::type_input(), "str");
 
-        assert_display(&<&[u8]>::type_output(), "bytes");
+        assert_display(&<&[u8]>::type_output(), "Union[bytes, List[int]]");
+        assert_display(&<&[String]>::type_output(), "Union[bytes, List[str]]");
         assert_display(
             &<&[u8] as crate::conversion::FromPyObjectBound>::type_input(),
             "bytes",

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -160,11 +160,6 @@ impl IntoPy<PyObject> for bool {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::builtin("bool")
-    }
 }
 
 impl<'py> IntoPyObject<'py> for bool {
@@ -176,6 +171,11 @@ impl<'py> IntoPyObject<'py> for bool {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyBool::new(py, self))
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("bool")
+    }
 }
 
 impl<'py> IntoPyObject<'py> for &bool {
@@ -186,6 +186,11 @@ impl<'py> IntoPyObject<'py> for &bool {
     #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("bool")
     }
 }
 

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -91,11 +91,6 @@ impl IntoPy<PyObject> for f64 {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::builtin("float")
-    }
 }
 
 impl<'py> IntoPyObject<'py> for f64 {
@@ -107,6 +102,11 @@ impl<'py> IntoPyObject<'py> for f64 {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyFloat::new(py, self))
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("float")
+    }
 }
 
 impl<'py> IntoPyObject<'py> for &f64 {
@@ -117,6 +117,11 @@ impl<'py> IntoPyObject<'py> for &f64 {
     #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("float")
     }
 }
 
@@ -163,11 +168,6 @@ impl IntoPy<PyObject> for f32 {
     fn into_py(self, py: Python<'_>) -> PyObject {
         self.into_pyobject(py).unwrap().into_any().unbind()
     }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_output() -> TypeInfo {
-        TypeInfo::builtin("float")
-    }
 }
 
 impl<'py> IntoPyObject<'py> for f32 {
@@ -179,6 +179,11 @@ impl<'py> IntoPyObject<'py> for f32 {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         Ok(PyFloat::new(py, self.into()))
     }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("float")
+    }
 }
 
 impl<'py> IntoPyObject<'py> for &f32 {
@@ -189,6 +194,11 @@ impl<'py> IntoPyObject<'py> for &f32 {
     #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         (*self).into_pyobject(py)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_output() -> TypeInfo {
+        TypeInfo::builtin("float")
     }
 }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -552,6 +552,7 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
     impl <'a, 'py, $($T),+> IntoPyObject<'py> for &'a ($($T,)+)
     where
         $(&'a $T: IntoPyObject<'py>,)+
+        $($T: 'a,)+ // MSRV
     {
         type Target = PyTuple;
         type Output = Bound<'py, Self::Target>;

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -529,11 +529,6 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
         fn into_py(self, py: Python<'_>) -> PyObject {
             array_into_tuple(py, [$(self.$n.into_py(py)),+]).into()
         }
-
-        #[cfg(feature = "experimental-inspect")]
-        fn type_output() -> TypeInfo {
-            TypeInfo::Tuple(Some(vec![$( $T::type_output() ),+]))
-        }
     }
 
     impl <'py, $($T),+> IntoPyObject<'py> for ($($T,)+)
@@ -546,6 +541,11 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
 
         fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
             Ok(array_into_tuple(py, [$(self.$n.into_pyobject(py).map_err(Into::into)?.into_any().unbind()),+]).into_bound(py))
+        }
+
+        #[cfg(feature = "experimental-inspect")]
+        fn type_output() -> TypeInfo {
+            TypeInfo::Tuple(Some(vec![$( $T::type_output() ),+]))
         }
     }
 
@@ -560,16 +560,16 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
         fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
             Ok(array_into_tuple(py, [$(self.$n.into_pyobject(py).map_err(Into::into)?.into_any().unbind()),+]).into_bound(py))
         }
+
+        #[cfg(feature = "experimental-inspect")]
+        fn type_output() -> TypeInfo {
+            TypeInfo::Tuple(Some(vec![$( <&$T>::type_output() ),+]))
+        }
     }
 
     impl <$($T: IntoPy<PyObject>),+> IntoPy<Py<PyTuple>> for ($($T,)+) {
         fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
             array_into_tuple(py, [$(self.$n.into_py(py)),+])
-        }
-
-        #[cfg(feature = "experimental-inspect")]
-        fn type_output() -> TypeInfo {
-            TypeInfo::Tuple(Some(vec![$( $T::type_output() ),+]))
         }
     }
 


### PR DESCRIPTION
Part of #4618

This moves `IntoPy::type_output` to `IntoPyObject::type_output`. This is a breaking change, but this is an experimantel feature and the ergonomics of duplicating the API is pretty bad, because it would need fully qualified syntax on the callsite to determine the trait to use.