### PR TITLE
Add `PyList_Extend` & `PyList_Clear` to pyo3-ffi

### DIFF
--- a/newsfragments/4667.added.md
+++ b/newsfragments/4667.added.md
@@ -1,0 +1,1 @@
+Add `PyList_Extend` & `PyList_Clear` to pyo3-ffi

--- a/pyo3-ffi/src/compat/py_3_13.rs
+++ b/pyo3-ffi/src/compat/py_3_13.rs
@@ -83,3 +83,24 @@ compat_function!(
         1
     }
 );
+
+compat_function!(
+    originally_defined_for(Py_3_13);
+
+    #[inline]
+    pub unsafe fn PyList_Extend(
+        list: *mut crate::PyObject,
+        iterable: *mut crate::PyObject,
+    ) -> std::os::raw::c_int {
+        crate::PyList_SetSlice(list, crate::PY_SSIZE_T_MAX, crate::PY_SSIZE_T_MAX, iterable)
+    }
+);
+
+compat_function!(
+    originally_defined_for(Py_3_13);
+
+    #[inline]
+    pub unsafe fn PyList_Clear(list: *mut crate::PyObject) -> std::os::raw::c_int {
+        crate::PyList_SetSlice(list, 0, crate::PY_SSIZE_T_MAX, std::ptr::null_mut())
+    }
+);

--- a/pyo3-ffi/src/listobject.rs
+++ b/pyo3-ffi/src/listobject.rs
@@ -50,6 +50,10 @@ extern "C" {
         arg3: Py_ssize_t,
         arg4: *mut PyObject,
     ) -> c_int;
+    #[cfg(Py_3_13)]
+    pub fn PyList_Extend(list: *mut PyObject, iterable: *mut PyObject) -> c_int;
+    #[cfg(Py_3_13)]
+    pub fn PyList_Clear(list: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyList_Sort")]
     pub fn PyList_Sort(arg1: *mut PyObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyList_Reverse")]


### PR DESCRIPTION
Pulled the binding of `PyList_Extend` out of #4664 and included `PyList_Clear` for completeness so we can ship this in the upcoming release.