### PR TITLE
add `IntoPyObjectRef` derive macro

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -559,6 +559,9 @@ enum Enum<'a, 'py, K: Hash + Eq, V> { // enums are supported and convert using t
 }
 ```
 
+Additionally `IntoPyObject` can be derived for a reference to a struct or enum using the
+`IntoPyObjectRef` derive macro. All the same rules from above apply as well.
+
 #### manual implementation
 
 If the derive macro is not suitable for your use case, `IntoPyObject` can be implemented manually as

--- a/pyo3-macros/src/lib.rs
+++ b/pyo3-macros/src/lib.rs
@@ -156,7 +156,18 @@ pub fn pyfunction(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_derive(IntoPyObject, attributes(pyo3))]
 pub fn derive_into_py_object(item: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(item as syn::DeriveInput);
-    let expanded = build_derive_into_pyobject(&ast).unwrap_or_compile_error();
+    let expanded = build_derive_into_pyobject::<false>(&ast).unwrap_or_compile_error();
+    quote!(
+        #expanded
+    )
+    .into()
+}
+
+#[proc_macro_derive(IntoPyObjectRef, attributes(pyo3))]
+pub fn derive_into_py_object_ref(item: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(item as syn::DeriveInput);
+    let expanded =
+        pyo3_macros_backend::build_derive_into_pyobject::<true>(&ast).unwrap_or_compile_error();
     quote!(
         #expanded
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,9 @@ mod version;
 pub use crate::conversions::*;
 
 #[cfg(feature = "macros")]
-pub use pyo3_macros::{pyfunction, pymethods, pymodule, FromPyObject, IntoPyObject};
+pub use pyo3_macros::{
+    pyfunction, pymethods, pymodule, FromPyObject, IntoPyObject, IntoPyObjectRef,
+};
 
 /// A proc macro used to expose Rust structs and fieldless enums as Python objects.
 ///

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -19,7 +19,9 @@ pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::types::{PyAny, PyModule};
 
 #[cfg(feature = "macros")]
-pub use pyo3_macros::{pyclass, pyfunction, pymethods, pymodule, FromPyObject, IntoPyObject};
+pub use pyo3_macros::{
+    pyclass, pyfunction, pymethods, pymodule, FromPyObject, IntoPyObject, IntoPyObjectRef,
+};
 
 #[cfg(feature = "macros")]
 pub use crate::wrap_pyfunction;

--- a/src/tests/hygiene/misc.rs
+++ b/src/tests/hygiene/misc.rs
@@ -57,17 +57,17 @@ macro_rules! macro_rules_hygiene {
 
 macro_rules_hygiene!(MyClass1, MyClass2);
 
-#[derive(crate::IntoPyObject)]
+#[derive(crate::IntoPyObject, crate::IntoPyObjectRef)]
 #[pyo3(crate = "crate")]
 struct IntoPyObject1(i32); // transparent newtype case
 
-#[derive(crate::IntoPyObject)]
+#[derive(crate::IntoPyObject, crate::IntoPyObjectRef)]
 #[pyo3(crate = "crate", transparent)]
 struct IntoPyObject2<'a> {
     inner: &'a str, // transparent newtype case
 }
 
-#[derive(crate::IntoPyObject)]
+#[derive(crate::IntoPyObject, crate::IntoPyObjectRef)]
 #[pyo3(crate = "crate")]
 struct IntoPyObject3<'py>(i32, crate::Bound<'py, crate::PyAny>); // tuple case
 
@@ -78,7 +78,7 @@ struct IntoPyObject4<'a, 'py> {
     num: usize,
 }
 
-#[derive(crate::IntoPyObject)]
+#[derive(crate::IntoPyObject, crate::IntoPyObjectRef)]
 #[pyo3(crate = "crate")]
 enum IntoPyObject5<'a, 'py> {
     TransparentTuple(i32),

--- a/tests/test_frompy_intopy_roundtrip.rs
+++ b/tests/test_frompy_intopy_roundtrip.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "macros")]
 
 use pyo3::types::{PyDict, PyString};
-use pyo3::{prelude::*, IntoPyObject};
+use pyo3::{prelude::*, IntoPyObject, IntoPyObjectRef};
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -9,7 +9,7 @@ use std::hash::Hash;
 #[path = "../src/tests/common.rs"]
 mod common;
 
-#[derive(Debug, Clone, IntoPyObject, FromPyObject)]
+#[derive(Debug, Clone, IntoPyObject, IntoPyObjectRef, FromPyObject)]
 pub struct A<'py> {
     #[pyo3(item)]
     s: String,
@@ -27,6 +27,16 @@ fn test_named_fields_struct() {
             t: PyString::new(py, "World"),
             p: 42i32.into_pyobject(py).unwrap().into_any(),
         };
+        let pya = (&a).into_pyobject(py).unwrap();
+        let new_a = pya.extract::<A<'_>>().unwrap();
+
+        assert_eq!(a.s, new_a.s);
+        assert_eq!(a.t.to_cow().unwrap(), new_a.t.to_cow().unwrap());
+        assert_eq!(
+            a.p.extract::<i32>().unwrap(),
+            new_a.p.extract::<i32>().unwrap()
+        );
+
         let pya = a.clone().into_pyobject(py).unwrap();
         let new_a = pya.extract::<A<'_>>().unwrap();
 
@@ -39,7 +49,7 @@ fn test_named_fields_struct() {
     });
 }
 
-#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+#[derive(Debug, Clone, PartialEq, IntoPyObject, IntoPyObjectRef, FromPyObject)]
 #[pyo3(transparent)]
 pub struct B {
     test: String,
@@ -51,13 +61,17 @@ fn test_transparent_named_field_struct() {
         let b = B {
             test: "test".into(),
         };
+        let pyb = (&b).into_pyobject(py).unwrap();
+        let new_b = pyb.extract::<B>().unwrap();
+        assert_eq!(b, new_b);
+
         let pyb = b.clone().into_pyobject(py).unwrap();
         let new_b = pyb.extract::<B>().unwrap();
         assert_eq!(b, new_b);
     });
 }
 
-#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+#[derive(Debug, Clone, PartialEq, IntoPyObject, IntoPyObjectRef, FromPyObject)]
 #[pyo3(transparent)]
 pub struct D<T> {
     test: T,
@@ -66,6 +80,18 @@ pub struct D<T> {
 #[test]
 fn test_generic_transparent_named_field_struct() {
     Python::with_gil(|py| {
+        let d = D {
+            test: String::from("test"),
+        };
+        let pyd = (&d).into_pyobject(py).unwrap();
+        let new_d = pyd.extract::<D<String>>().unwrap();
+        assert_eq!(d, new_d);
+
+        let d = D { test: 1usize };
+        let pyd = (&d).into_pyobject(py).unwrap();
+        let new_d = pyd.extract::<D<usize>>().unwrap();
+        assert_eq!(d, new_d);
+
         let d = D {
             test: String::from("test"),
         };
@@ -80,7 +106,7 @@ fn test_generic_transparent_named_field_struct() {
     });
 }
 
-#[derive(Debug, IntoPyObject, FromPyObject)]
+#[derive(Debug, IntoPyObject, IntoPyObjectRef, FromPyObject)]
 pub struct GenericWithBound<K: Hash + Eq, V>(HashMap<K, V>);
 
 #[test]
@@ -89,10 +115,12 @@ fn test_generic_with_bound() {
         let mut hash_map = HashMap::<String, i32>::new();
         hash_map.insert("1".into(), 1);
         hash_map.insert("2".into(), 2);
-        let map = GenericWithBound(hash_map).into_pyobject(py).unwrap();
-        assert_eq!(map.len(), 2);
+        let map = GenericWithBound(hash_map);
+        let py_map = (&map).into_pyobject(py).unwrap();
+        assert_eq!(py_map.len(), 2);
         assert_eq!(
-            map.get_item("1")
+            py_map
+                .get_item("1")
                 .unwrap()
                 .unwrap()
                 .extract::<i32>()
@@ -100,44 +128,75 @@ fn test_generic_with_bound() {
             1
         );
         assert_eq!(
-            map.get_item("2")
+            py_map
+                .get_item("2")
                 .unwrap()
                 .unwrap()
                 .extract::<i32>()
                 .unwrap(),
             2
         );
-        assert!(map.get_item("3").unwrap().is_none());
+        assert!(py_map.get_item("3").unwrap().is_none());
+
+        let py_map = map.into_pyobject(py).unwrap();
+        assert_eq!(py_map.len(), 2);
+        assert_eq!(
+            py_map
+                .get_item("1")
+                .unwrap()
+                .unwrap()
+                .extract::<i32>()
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            py_map
+                .get_item("2")
+                .unwrap()
+                .unwrap()
+                .extract::<i32>()
+                .unwrap(),
+            2
+        );
+        assert!(py_map.get_item("3").unwrap().is_none());
     });
 }
 
-#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+#[derive(Debug, Clone, PartialEq, IntoPyObject, IntoPyObjectRef, FromPyObject)]
 pub struct Tuple(String, usize);
 
 #[test]
 fn test_tuple_struct() {
     Python::with_gil(|py| {
         let tup = Tuple(String::from("test"), 1);
+        let tuple = (&tup).into_pyobject(py).unwrap();
+        let new_tup = tuple.extract::<Tuple>().unwrap();
+        assert_eq!(tup, new_tup);
+
         let tuple = tup.clone().into_pyobject(py).unwrap();
         let new_tup = tuple.extract::<Tuple>().unwrap();
         assert_eq!(tup, new_tup);
     });
 }
 
-#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+#[derive(Debug, Clone, PartialEq, IntoPyObject, IntoPyObjectRef, FromPyObject)]
 pub struct TransparentTuple(String);
 
 #[test]
 fn test_transparent_tuple_struct() {
     Python::with_gil(|py| {
         let tup = TransparentTuple(String::from("test"));
+        let tuple = (&tup).into_pyobject(py).unwrap();
+        let new_tup = tuple.extract::<TransparentTuple>().unwrap();
+        assert_eq!(tup, new_tup);
+
         let tuple = tup.clone().into_pyobject(py).unwrap();
         let new_tup = tuple.extract::<TransparentTuple>().unwrap();
         assert_eq!(tup, new_tup);
     });
 }
 
-#[derive(Debug, Clone, PartialEq, IntoPyObject, FromPyObject)]
+#[derive(Debug, Clone, PartialEq, IntoPyObject, IntoPyObjectRef, FromPyObject)]
 pub enum Foo {
     TupleVar(usize, String),
     StructVar {
@@ -156,10 +215,20 @@ pub enum Foo {
 fn test_enum() {
     Python::with_gil(|py| {
         let tuple_var = Foo::TupleVar(1, "test".into());
+        let foo = (&tuple_var).into_pyobject(py).unwrap();
+        assert_eq!(tuple_var, foo.extract::<Foo>().unwrap());
+
         let foo = tuple_var.clone().into_pyobject(py).unwrap();
         assert_eq!(tuple_var, foo.extract::<Foo>().unwrap());
 
         let struct_var = Foo::StructVar { test: 'b' };
+        let foo = (&struct_var)
+            .into_pyobject(py)
+            .unwrap()
+            .downcast_into::<PyDict>()
+            .unwrap();
+        assert_eq!(struct_var, foo.extract::<Foo>().unwrap());
+
         let foo = struct_var
             .clone()
             .into_pyobject(py)
@@ -170,10 +239,16 @@ fn test_enum() {
         assert_eq!(struct_var, foo.extract::<Foo>().unwrap());
 
         let transparent_tuple = Foo::TransparentTuple(1);
+        let foo = (&transparent_tuple).into_pyobject(py).unwrap();
+        assert_eq!(transparent_tuple, foo.extract::<Foo>().unwrap());
+
         let foo = transparent_tuple.clone().into_pyobject(py).unwrap();
         assert_eq!(transparent_tuple, foo.extract::<Foo>().unwrap());
 
         let transparent_struct_var = Foo::TransparentStructVar { a: None };
+        let foo = (&transparent_struct_var).into_pyobject(py).unwrap();
+        assert_eq!(transparent_struct_var, foo.extract::<Foo>().unwrap());
+
         let foo = transparent_struct_var.clone().into_pyobject(py).unwrap();
         assert_eq!(transparent_struct_var, foo.extract::<Foo>().unwrap());
     });

--- a/tests/ui/invalid_intopy_derive.rs
+++ b/tests/ui/invalid_intopy_derive.rs
@@ -1,67 +1,67 @@
-use pyo3::IntoPyObject;
+use pyo3::{IntoPyObject, IntoPyObjectRef};
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 struct Foo();
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 struct Foo2 {}
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 enum EmptyEnum {}
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 enum EnumWithEmptyTupleVar {
     EmptyTuple(),
     Valid(String),
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 enum EnumWithEmptyStructVar {
     EmptyStruct {},
     Valid(String),
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 #[pyo3(transparent)]
 struct EmptyTransparentTup();
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 #[pyo3(transparent)]
 struct EmptyTransparentStruct {}
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 enum EnumWithTransparentEmptyTupleVar {
     #[pyo3(transparent)]
     EmptyTuple(),
     Valid(String),
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 enum EnumWithTransparentEmptyStructVar {
     #[pyo3(transparent)]
     EmptyStruct {},
     Valid(String),
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 #[pyo3(transparent)]
 struct TransparentTupTooManyFields(String, String);
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 #[pyo3(transparent)]
 struct TransparentStructTooManyFields {
     foo: String,
     bar: String,
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 enum EnumWithTransparentTupleTooMany {
     #[pyo3(transparent)]
     EmptyTuple(String, String),
     Valid(String),
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 enum EnumWithTransparentStructTooMany {
     #[pyo3(transparent)]
     EmptyStruct {
@@ -71,35 +71,35 @@ enum EnumWithTransparentStructTooMany {
     Valid(String),
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 #[pyo3(unknown = "should not work")]
 struct UnknownContainerAttr {
     a: String,
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 union Union {
     a: usize,
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 enum UnitEnum {
     Unit,
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 struct TupleAttribute(#[pyo3(attribute)] String, usize);
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 struct TupleItem(#[pyo3(item)] String, usize);
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 struct StructAttribute {
     #[pyo3(attribute)]
     foo: String,
 }
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 #[pyo3(transparent)]
 struct StructTransparentItem {
     #[pyo3(item)]


### PR DESCRIPTION
From https://github.com/PyO3/pyo3/issues/4041#issuecomment-2439713614

Introduces the `IntoPyObjectRef` derive macro to implement `IntoPyObject` for a reference to the derived type. It pretty much uses the same code gen as the ordinary `IntoPyObject` derive macro. I have moved the relevant branches up to the root function, to avoid threading the reference condition through the whole machinery. We really only need to adjust the ident itself, generic bounds, `transparent` types and introduce the named lifetime, the body works by inference and does not need changes between the two.

I added this to the hygiene, roundtrip and ui tests. I skipped hygiene `IntoPyObject4` because it would need `IntoPyObject for &&Bound` which we currently don't have, not sure where we want to draw the line.

Closes #4041 🎉 