### PR TITLE
fix unintentional `unsafe_op_in_unsafe_fn` trigger

### DIFF
--- a/newsfragments/4674.fixed.md
+++ b/newsfragments/4674.fixed.md
@@ -1,0 +1,1 @@
+Fixes unintentional `unsafe_op_in_unsafe_fn` trigger by adjusting macro hygiene.

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -449,7 +449,7 @@ fn module_initialization(
             #[doc(hidden)]
             #[export_name = #pyinit_symbol]
             pub unsafe extern "C" fn __pyo3_init() -> *mut #pyo3_path::ffi::PyObject {
-                #pyo3_path::impl_::trampoline::module_init(|py| _PYO3_DEF.make_module(py))
+                unsafe { #pyo3_path::impl_::trampoline::module_init(|py| _PYO3_DEF.make_module(py)) }
             }
         });
     }

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -79,7 +79,7 @@ pub fn impl_arg_params(
             .collect();
         return (
             quote! {
-                let _args = #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(py, &_args);
+                let _args = unsafe { #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(py, &_args) };
                 let _kwargs = #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr_or_opt(py, &_kwargs);
                 #from_py_with
             },
@@ -301,9 +301,10 @@ pub(crate) fn impl_regular_arg_param(
         }
     } else {
         let holder = holders.push_holder(arg.name.span());
+        let unwrap = quote! {unsafe { #pyo3_path::impl_::extract_argument::unwrap_required_argument(#arg_value) }};
         quote_arg_span! {
             #pyo3_path::impl_::extract_argument::extract_argument(
-                #pyo3_path::impl_::extract_argument::unwrap_required_argument(#arg_value),
+                #unwrap,
                 &mut #holder,
                 #name_str
             )?

--- a/tests/ui/forbid_unsafe.rs
+++ b/tests/ui/forbid_unsafe.rs
@@ -1,4 +1,5 @@
 #![forbid(unsafe_code)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use pyo3::*;
 


### PR DESCRIPTION
Closes #4663 

Adjusts our expansion to comply with `unsafe_op_in_unsafe_fn` and adjusts the spans to prevent `unsafe_code` to trigger.
