### PR TITLE
add `sync::OnceExt` and `sync::OnceLockExt` traits

### DIFF
--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -13,9 +13,11 @@ Sorry that you're having trouble using PyO3. If you can't find the answer to you
 5. Thread A is blocked, because it waits to re-acquire the GIL which thread B still holds.
 6. Deadlock.
 
-PyO3 provides a struct [`GILOnceCell`] which works similarly to these types but avoids risk of deadlocking with the Python GIL. This means it can be used in place of other choices when you are experiencing the deadlock described above. See the documentation for [`GILOnceCell`] for further details and an example how to use it.
+PyO3 provides a struct [`GILOnceCell`] and an extension trait [`OnceExt`] that
+enable functionality similar to these types but avoid the risk of deadlocking with the Python GIL. This means they can be used in place of other choices when you are experiencing the deadlock described above. See the documentation for [`GILOnceCell`] and [`OnceExt`] for further details and an example how to use them.
 
 [`GILOnceCell`]: {{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html
+[`OnceExt`]: {{#PYO3_DOCS_URL}}/pyo3/sync/trait.OnceExt.html
 
 ## I can't run `cargo test`; or I can't build in a Cargo workspace: I'm having linker issues like "Symbol not found" or "Undefined reference to _PyExc_SystemError"!
 

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -13,10 +13,11 @@ Sorry that you're having trouble using PyO3. If you can't find the answer to you
 5. Thread A is blocked, because it waits to re-acquire the GIL which thread B still holds.
 6. Deadlock.
 
-PyO3 provides a struct [`GILOnceCell`] which implements a single-initialization API based on these types that relies on the GIL for locking. If the GIL is released or there is no GIL, then this type allows the initialization function to race but ensures that the data is only ever initialized once. If you need ot ensure that the initialization function is called once and only once, you can make use of the [`OnceExt`] and [`OnceLockExt`] extension traits that enable using the standard library types for this purpose but provide new methods for these types that avoid the risk of deadlocking with the Python GIL. This means they can be used in place of other choices when you are experiencing the deadlock described above. See the documentation for [`GILOnceCell`] and [`OnceExt`] for further details and an example how to use them.
+PyO3 provides a struct [`GILOnceCell`] which implements a single-initialization API based on these types that relies on the GIL for locking. If the GIL is released or there is no GIL, then this type allows the initialization function to race but ensures that the data is only ever initialized once. If you need to ensure that the initialization function is called once and only once, you can make use of the [`OnceExt`] and [`OnceLockExt`] extension traits that enable using the standard library types for this purpose but provide new methods for these types that avoid the risk of deadlocking with the Python GIL. This means they can be used in place of other choices when you are experiencing the deadlock described above. See the documentation for [`GILOnceCell`] and [`OnceExt`] for further details and an example how to use them.
 
 [`GILOnceCell`]: {{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html
 [`OnceExt`]: {{#PYO3_DOCS_URL}}/pyo3/sync/trait.OnceExt.html
+[`OnceLockExt`]: {{#PYO3_DOCS_URL}}/pyo3/sync/trait.OnceLockExt.html
 
 ## I can't run `cargo test`; or I can't build in a Cargo workspace: I'm having linker issues like "Symbol not found" or "Undefined reference to _PyExc_SystemError"!
 

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -13,8 +13,7 @@ Sorry that you're having trouble using PyO3. If you can't find the answer to you
 5. Thread A is blocked, because it waits to re-acquire the GIL which thread B still holds.
 6. Deadlock.
 
-PyO3 provides a struct [`GILOnceCell`] and an extension trait [`OnceExt`] that
-enable functionality similar to these types but avoid the risk of deadlocking with the Python GIL. This means they can be used in place of other choices when you are experiencing the deadlock described above. See the documentation for [`GILOnceCell`] and [`OnceExt`] for further details and an example how to use them.
+PyO3 provides a struct [`GILOnceCell`] which implements a single-initialization API based on these types that relies on the GIL for locking. If the GIL is released or there is no GIL, then this type allows the initialization function to race but ensures that the data is only ever initialized once. If you need ot ensure that the initialization function is called once and only once, you can make use of the [`OnceExt`] and [`OnceLockExt`] extension traits that enable using the standard library types for this purpose but provide new methods for these types that avoid the risk of deadlocking with the Python GIL. This means they can be used in place of other choices when you are experiencing the deadlock described above. See the documentation for [`GILOnceCell`] and [`OnceExt`] for further details and an example how to use them.
 
 [`GILOnceCell`]: {{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html
 [`OnceExt`]: {{#PYO3_DOCS_URL}}/pyo3/sync/trait.OnceExt.html

--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -152,6 +152,58 @@ We plan to allow user-selectable semantics for mutable pyclass definitions in
 PyO3 0.24, allowing some form of opt-in locking to emulate the GIL if that is
 needed.
 
+## Thread-safe single initialization
+
+Until version 0.23, PyO3 provided only `GILOnceCell` to enable deadlock-free
+single initialization of data in contexts that might execute arbitrary Python
+code. While we have updated `GILOnceCell` to avoid thread safety issues
+triggered only under the free-threaded build, the design of `GILOnceCell` is
+inherently thread-unsafe, in a manner that can be problematic even in the
+GIL-enabled build.
+
+If, for example, the function executed by `GILOnceCell` releases the GIL or
+calls code that releases the GIL, then it is possible for multiple threads to
+try to race to initialize the cell. While the cell will only ever be intialized
+once, it can be problematic in some contexts that `GILOnceCell` does not block
+like the standard library `OnceLock`.
+
+In cases where the initialization function must run exactly once, you can bring
+the `OnceExt` trait into scope. This trait adds `OnceExt::call_once_py_attached`
+and `OnceExt::call_once_force_py_attached` functions to the api of
+`std::sync::Once`, enabling use of `Once` in contexts where the GIL is
+held. These functions are analogous to `Once::call_once` and
+`Once::call_once_force` except they both accept a `Python<'py>` token in
+addition to an `FnOnce`. Both functions release the GIL and re-acquire it before
+executing the function, avoiding deadlocks with the GIL that are possible
+without using these functions. Here is an example of how to use this function to
+enable single-initialization of a runtime cache:
+
+```rust
+# fn main() {
+# use pyo3::prelude::*;
+use std::sync::Once;
+use pyo3::sync::OnceExt;
+use pyo3::types::PyDict;
+
+struct RuntimeCache {
+    once: Once,
+    cache: Option<Py<PyDict>>
+}
+
+let mut cache = RuntimeCache {
+    once: Once::new(),
+    cache: None
+};
+
+Python::with_gil(|py| {
+    // guaranteed to be called once and only once
+    cache.once.call_once_py_attached(py, || {
+        cache.cache = Some(PyDict::new(py).unbind());
+    });
+});
+# }
+```
+
 ## `GILProtected` is not exposed
 
 `GILProtected` is a PyO3 type that allows mutable access to static data by

--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -168,15 +168,17 @@ once, it can be problematic in some contexts that `GILOnceCell` does not block
 like the standard library `OnceLock`.
 
 In cases where the initialization function must run exactly once, you can bring
-the `OnceExt` trait into scope. This trait adds `OnceExt::call_once_py_attached`
-and `OnceExt::call_once_force_py_attached` functions to the api of
-`std::sync::Once`, enabling use of `Once` in contexts where the GIL is
-held. These functions are analogous to `Once::call_once` and
-`Once::call_once_force` except they both accept a `Python<'py>` token in
-addition to an `FnOnce`. Both functions release the GIL and re-acquire it before
-executing the function, avoiding deadlocks with the GIL that are possible
-without using these functions. Here is an example of how to use this function to
-enable single-initialization of a runtime cache:
+the `OnceExt` or `OnceLockExt` traits into scope. The `OnceExt` trait adds
+`OnceExt::call_once_py_attached` and `OnceExt::call_once_force_py_attached`
+functions to the api of `std::sync::Once`, enabling use of `Once` in contexts
+where the GIL is held. Similarly, `OnceLockExt` adds
+`OnceLockExt::get_or_init_py_attached`. These functions are analogous to
+`Once::call_once`, `Once::call_once_force`, and `OnceLock::get_or_init` except
+they accept a `Python<'py>` token in addition to an `FnOnce`. All of these
+functions release the GIL and re-acquire it before executing the function,
+avoiding deadlocks with the GIL that are possible without using the PyO3
+extension traits. Here is an example of how to use `OnceExt` to
+enable single-initialization of a runtime cache holding a `Py<PyDict>`.
 
 ```rust
 # fn main() {

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -230,7 +230,12 @@ PyO3 0.23 introduces preliminary support for the new free-threaded build of
 CPython 3.13. PyO3 features that implicitly assumed the existence of the GIL are
 not exposed in the free-threaded build, since they are no longer safe.  Other
 features, such as `GILOnceCell`, have been internally rewritten to be threadsafe
-without the GIL.
+without the GIL, although note that `GILOnceCell` is inherently racey. You can
+also use `OnceExt::call_once_py_attached` or
+`OnceExt::call_once_force_py_attached` to enable use of `std::sync::Once` in
+code that has the GIL acquired without risking a dealock with the GIL. We plan
+We plan to expose more extension traits in the future that make it easier to
+write code for the GIL-enabled and free-threaded builds of Python.
 
 If you make use of these features then you will need to account for the
 unavailability of this API in the free-threaded build. One way to handle it is

--- a/newsfragments/4676.added.md
+++ b/newsfragments/4676.added.md
@@ -1,0 +1,1 @@
+Add `pyo3::sync::OnceExt` trait.

--- a/newsfragments/4676.added.md
+++ b/newsfragments/4676.added.md
@@ -1,1 +1,1 @@
-Add `pyo3::sync::OnceExt` trait.
+Add `pyo3::sync::OnceExt` and `pyo3::sync::OnceLockExt` traits.

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -138,6 +138,10 @@ fn resolve_cross_compile_config_path() -> Option<PathBuf> {
 pub fn print_feature_cfgs() {
     let rustc_minor_version = rustc_minor_version().unwrap_or(0);
 
+    if rustc_minor_version >= 70 {
+        println!("cargo:rustc-cfg=rustc_has_once_lock");
+    }
+
     // invalid_from_utf8 lint was added in Rust 1.74
     if rustc_minor_version >= 74 {
         println!("cargo:rustc-cfg=invalid_from_utf8_lint");
@@ -175,6 +179,7 @@ pub fn print_expected_cfgs() {
     println!("cargo:rustc-check-cfg=cfg(pyo3_leak_on_drop_without_reference_pool)");
     println!("cargo:rustc-check-cfg=cfg(diagnostic_namespace)");
     println!("cargo:rustc-check-cfg=cfg(c_str_lit)");
+    println!("cargo:rustc-check-cfg=cfg(rustc_has_once_lock)");
 
     // allow `Py_3_*` cfgs from the minimum supported version up to the
     // maximum minor version (+1 for development for the next)

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -53,3 +53,5 @@ impl Sealed for ModuleDef {}
 
 impl<T: crate::type_object::PyTypeInfo> Sealed for PyNativeTypeInitializer<T> {}
 impl<T: crate::pyclass::PyClass> Sealed for PyClassInitializer<T> {}
+
+impl Sealed for std::sync::Once {}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -550,6 +550,9 @@ impl<T> OnceLockExt<T> for std::sync::OnceLock<T> {
     where
         F: FnOnce() -> T,
     {
+        // this trait is guarded by a rustc version config
+        // so clippy's MSRV check is wrong
+        #[allow(clippy::incompatible_msrv)]
         // Use self.get() first to create a fast path when initialized
         self.get()
             .unwrap_or_else(|| init_once_lock_py_attached(self, py, f))
@@ -599,6 +602,9 @@ where
     // SAFETY: we are currently attached to a Python thread
     let ts_guard = Guard(Some(unsafe { ffi::PyEval_SaveThread() }));
 
+    // this trait is guarded by a rustc version config
+    // so clippy's MSRV check is wrong
+    #[allow(clippy::incompatible_msrv)]
     // By having detached here, we guarantee that `.get_or_init` cannot deadlock with
     // the Python interpreter
     let value = lock.get_or_init(move || {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -731,6 +731,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
     fn test_once_ext() {
         // adapted from the example in the docs for Once::try_once_force
         let init = Once::new();
@@ -765,6 +766,7 @@ mod tests {
     }
 
     #[cfg(rustc_has_once_lock)]
+    #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
     #[test]
     fn test_once_lock_ext() {
         let cell = std::sync::OnceLock::new();


### PR DESCRIPTION
Related to #4513, #4671 

It turns out that within our test suite the racy behaviour of `GILOnceCell` is already problematic on GIL-enabled builds, and is just waiting for additional GIL switches to bait out problems 😬. In particular in `test_declarative_module` we have a race which might attempt to create a module twice; we explicitly forbid this because we don't support subinterpreters.

This PR introduces `pyo3::sync::OnceExt`, which adds helper methods to `std::sync::Once` which avoid deadlocking with the GIL by releasing if necessary before blocking.

This solves the issue with `test_declarative_module` by using the `Once` to guarantee we only ever create the module once.

I think we should document this in the FAQ and freethreading guides, and probably this is good justification for getting #4513 and maybe also some `OnceCellExt` traits into 0.23. cc @ngoldbaum, I guess this would delay the release by a few days.