### PR TITLE
Variable sized base types

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1374,6 +1374,7 @@ impl pyo3::types::DerefToPyAny for MyClass {}
 unsafe impl pyo3::type_object::PyTypeInfo for MyClass {
     const NAME: &'static str = "MyClass";
     const MODULE: ::std::option::Option<&'static str> = ::std::option::Option::None;
+    type Layout<T: pyo3::impl_::pyclass::PyClassImpl> = pyo3::impl_::pycell::PyStaticClassObject<T>;
     #[inline]
     fn type_object_raw(py: pyo3::Python<'_>) -> *mut pyo3::ffi::PyTypeObject {
         <Self as pyo3::impl_::pyclass::PyClassImpl>::lazy_type_object()
@@ -1418,6 +1419,7 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
     const IS_SUBCLASS: bool = false;
     const IS_MAPPING: bool = false;
     const IS_SEQUENCE: bool = false;
+    type Layout = <MyClass as pyo3::type_object::PyTypeInfo>::Layout<MyClass>;
     type BaseType = PyAny;
     type ThreadChecker = pyo3::impl_::pyclass::SendablePyClass<MyClass>;
     type PyClassMutability = <<pyo3::PyAny as pyo3::impl_::pyclass::PyClassBaseType>::PyClassMutability as pyo3::impl_::pycell::PyClassMutability>::MutableChild;

--- a/guide/src/class/metaclass.md
+++ b/guide/src/class/metaclass.md
@@ -8,7 +8,7 @@ Some examples of where metaclasses can be used:
 - [`EnumType`](https://docs.python.org/3/library/enum.html) for defining enums
 - [`NamedTuple`](https://docs.python.org/3/library/typing.html#typing.NamedTuple) for defining tuples with elements
   that can be accessed by name in addition to index.
-- to implement patterns such as singleton classes
+- singleton classes
 - automatic registration of classes
 - ORM
 - serialization / deserialization / validation (e.g. [pydantic](https://docs.pydantic.dev/latest/api/base_model/))
@@ -65,7 +65,7 @@ In the example above `MyMetaclass` extends `PyType` (making it a metaclass). It 
 [this is not supported](https://docs.python.org/3/c-api/type.html#c.PyType_FromMetaclass). Instead `__init__` is
 defined which is called whenever a class is created that uses `MyMetaclass` as its metaclass.
 The arguments to `__init__` are the same as the arguments to `type(name, bases, kwds)`. A `Default` impl is required
-in order to define `__init__`.
+in order to define `__init__`. The data in the struct is initialised to `Default` before `__init__` is called.
 
 When special methods like `__getitem__` are defined for a metaclass they apply to the classes they construct, so
 `Foo[123]` calls `MyMetaclass.__getitem__(Foo, 123)`.

--- a/guide/src/class/metaclass.md
+++ b/guide/src/class/metaclass.md
@@ -1,0 +1,69 @@
+# Creating a Metaclass
+A [metaclass](https://docs.python.org/3/reference/datamodel.html#metaclasses) is a class that derives `type` and can
+be used to influence the construction of other classes.
+
+Some examples of where metaclasses can be used:
+
+- [`ABCMeta`](https://docs.python.org/3/library/abc.html) for defining abstract classes
+- [`EnumType`](https://docs.python.org/3/library/enum.html) for defining enums
+- [`NamedTuple`](https://docs.python.org/3/library/typing.html#typing.NamedTuple) for defining tuples with elements
+  that can be accessed by name in addition to index.
+- to implement patterns such as singleton classes
+- automatic registration of classes
+- ORM
+- serialization / deserialization / validation (e.g. [pydantic](https://docs.pydantic.dev/latest/api/base_model/))
+
+### Example: A Simple Metaclass
+
+```rust
+#[pyclass(subclass, extends=PyType)]
+struct MyMetaclass {
+    counter: u64,
+};
+
+#[pymethods]
+impl MyMetaclass {
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn __init__(
+        slf: Bound<'_, Metaclass>,
+        _args: Bound<'_, PyTuple>,
+        _kwargs: Option<Bound<'_, PyDict>>,
+    ) -> PyResult<()> {
+        slf.as_any().setattr("some_var", 123)?;
+        Ok(())
+    }
+
+    fn __getitem__(&self, item: u64) -> u64 {
+        item + 1
+    }
+
+    fn increment_counter(&mut self) {
+        self.counter += 1;
+    }
+
+    fn get_counter(&self) -> u64 {
+        self.counter
+    }
+}
+```
+
+Used like so:
+```python
+class Foo(metaclass=MyMetaclass):
+    def __init__() -> None:
+        ...
+
+assert type(Foo) is MyMetaclass
+assert Foo.some_var == 123
+assert Foo[100] == 101
+Foo.increment_counter()
+assert Foo.get_counter() == 1
+```
+
+In the example above `MyMetaclass` extends `PyType` (making it a metaclass). It does not define `#[new]` as
+[this is not supported](https://docs.python.org/3/c-api/type.html#c.PyType_FromMetaclass). Instead `__init__` is
+defined which is called whenever a class is created that uses `MyMetaclass` as its metaclass.
+The arguments to `__init__` are the same as the arguments to `type(name, bases, kwds)`.
+
+When special methods like `__getitem__` are defined for a metaclass they apply to the classes they construct, so
+`Foo[123]` calls `MyMetaclass.__getitem__(Foo, 123)`.

--- a/guide/src/class/metaclass.md
+++ b/guide/src/class/metaclass.md
@@ -17,6 +17,7 @@ Some examples of where metaclasses can be used:
 
 ```rust
 #[pyclass(subclass, extends=PyType)]
+#[derive(Default)]
 struct MyMetaclass {
     counter: u64,
 };
@@ -63,7 +64,8 @@ assert Foo.get_counter() == 1
 In the example above `MyMetaclass` extends `PyType` (making it a metaclass). It does not define `#[new]` as
 [this is not supported](https://docs.python.org/3/c-api/type.html#c.PyType_FromMetaclass). Instead `__init__` is
 defined which is called whenever a class is created that uses `MyMetaclass` as its metaclass.
-The arguments to `__init__` are the same as the arguments to `type(name, bases, kwds)`.
+The arguments to `__init__` are the same as the arguments to `type(name, bases, kwds)`. A `Default` impl is required
+in order to define `__init__`.
 
 When special methods like `__getitem__` are defined for a metaclass they apply to the classes they construct, so
 `Foo[123]` calls `MyMetaclass.__getitem__(Foo, 123)`.

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -141,6 +141,9 @@ given signatures should be interpreted as follows:
 
     Determines the "truthyness" of an object.
 
+  - `__init__(<self>, ...) -> object` - here, any argument list can be defined
+    as for normal `pymethods`
+
   - `__call__(<self>, ...) -> object` - here, any argument list can be defined
     as for normal `pymethods`
 

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -141,8 +141,10 @@ given signatures should be interpreted as follows:
 
     Determines the "truthyness" of an object.
 
-  - `__init__(<self>, ...) -> object` - here, any argument list can be defined
-    as for normal `pymethods`
+  - `__init__(<self>, ...) -> ()` - the arguments can be defined as for
+    normal `pymethods`. The pyclass struct must implement `Default`.
+    If the class defines `__new__` and `__init__` the values set in
+    `__new__` are overridden by `Default` before `__init__` is called.
 
   - `__call__(<self>, ...) -> object` - here, any argument list can be defined
     as for normal `pymethods`

--- a/newsfragments/4678.added.md
+++ b/newsfragments/4678.added.md
@@ -1,0 +1,1 @@
+Add support for extending variable/unknown sized base classes (eg `type` to create metaclasses)

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1812,6 +1812,8 @@ fn impl_pytypeinfo(cls: &syn::Ident, attr: &PyClassArgs, ctx: &Ctx) -> TokenStre
             const NAME: &'static str = #cls_name;
             const MODULE: ::std::option::Option<&'static str> = #module;
 
+            type Layout<T: #pyo3_path::impl_::pyclass::PyClassImpl> = <<#cls as #pyo3_path::impl_::pyclass::PyClassImpl>::BaseNativeType as #pyo3_path::type_object::PyTypeInfo>::Layout<T>;
+
             #[inline]
             fn type_object_raw(py: #pyo3_path::Python<'_>) -> *mut #pyo3_path::ffi::PyTypeObject {
                 use #pyo3_path::prelude::PyTypeMethods;
@@ -2301,7 +2303,7 @@ impl<'a> PyClassImplsBuilder<'a> {
         let pyclass_base_type_impl = attr.options.subclass.map(|subclass| {
             quote_spanned! { subclass.span() =>
                 impl #pyo3_path::impl_::pyclass::PyClassBaseType for #cls {
-                    type LayoutAsBase = #pyo3_path::impl_::pycell::PyClassObject<Self>;
+                    type LayoutAsBase = <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::Layout;
                     type BaseNativeType = <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::BaseNativeType;
                     type Initializer = #pyo3_path::pyclass_init::PyClassInitializer<Self>;
                     type PyClassMutability = <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::PyClassMutability;
@@ -2318,6 +2320,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                 const IS_MAPPING: bool = #is_mapping;
                 const IS_SEQUENCE: bool = #is_sequence;
 
+                type Layout = <#cls as #pyo3_path::PyTypeInfo>::Layout<Self>;
                 type BaseType = #base;
                 type ThreadChecker = #thread_checker;
                 #inventory

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2206,7 +2206,7 @@ impl<'a> PyClassImplsBuilder<'a> {
 
         let dict_offset = if self.attr.options.dict.is_some() {
             quote! {
-                fn dict_offset() -> ::std::option::Option<#pyo3_path::ffi::Py_ssize_t> {
+                fn dict_offset() -> ::std::option::Option<#pyo3_path::impl_::pyclass::PyObjectOffset> {
                     ::std::option::Option::Some(#pyo3_path::impl_::pyclass::dict_offset::<Self>())
                 }
             }
@@ -2214,10 +2214,9 @@ impl<'a> PyClassImplsBuilder<'a> {
             TokenStream::new()
         };
 
-        // insert space for weak ref
         let weaklist_offset = if self.attr.options.weakref.is_some() {
             quote! {
-                fn weaklist_offset() -> ::std::option::Option<#pyo3_path::ffi::Py_ssize_t> {
+                fn weaklist_offset() -> ::std::option::Option<#pyo3_path::impl_::pyclass::PyObjectOffset> {
                     ::std::option::Option::Some(#pyo3_path::impl_::pyclass::weaklist_offset::<Self>())
                 }
             }

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -831,8 +831,8 @@ pub fn impl_py_getter_def(
 
                     struct Offset;
                     unsafe impl #pyo3_path::impl_::pyclass::OffsetCalculator<#cls, #ty> for Offset {
-                        fn offset() -> usize {
-                            #pyo3_path::impl_::pyclass::class_offset::<#cls>() +
+                        fn offset() -> #pyo3_path::impl_::pyclass::PyObjectOffset {
+                            #pyo3_path::impl_::pyclass::subclass_offset::<#cls>() +
                             #pyo3_path::impl_::pyclass::offset_of!(#cls, #field)
                         }
                     }

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -421,6 +421,7 @@ fn impl_init_slot(cls: &syn::Type, mut spec: FnSpec<'_>, ctx: &Ctx) -> Result<Me
                     kwargs: *mut #pyo3_path::ffi::PyObject,
                 ) -> ::std::os::raw::c_int
                 {
+                    #pyo3_path::impl_::pyclass_init::initialize_with_default::<#cls>(slf);
                     #pyo3_path::impl_::trampoline::initproc(
                         slf,
                         args,

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -124,7 +124,8 @@ macro_rules! import_exception_bound {
         $crate::pyobject_native_type_info!(
             $name,
             $name::type_object_raw,
-            ::std::option::Option::Some(stringify!($module))
+            ::std::option::Option::Some(stringify!($module)),
+            $crate::impl_::pycell::PyStaticClassObject<T>
         );
 
         impl $crate::types::DerefToPyAny for $name {}

--- a/src/impl_/coroutine.rs
+++ b/src/impl_/coroutine.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
     coroutine::{cancel::ThrowCallback, Coroutine},
     instance::Bound,
-    pycell::impl_::PyClassBorrowChecker,
+    pycell::impl_::{InternalPyClassObjectLayout, PyClassBorrowChecker},
     pyclass::boolean_struct::False,
     types::{PyAnyMethods, PyString},
     IntoPyObject, Py, PyAny, PyClass, PyErr, PyResult, Python,

--- a/src/impl_/pycell.rs
+++ b/src/impl_/pycell.rs
@@ -1,5 +1,5 @@
 //! Externally-accessible implementation of pycell
 pub use crate::pycell::impl_::{
     GetBorrowChecker, PyClassMutability, PyClassObjectBase, PyClassObjectLayout,
-    PyStaticClassObject,
+    PyStaticClassObject, PyVariableClassObject, PyVariableClassObjectBase,
 };

--- a/src/impl_/pycell.rs
+++ b/src/impl_/pycell.rs
@@ -1,4 +1,5 @@
 //! Externally-accessible implementation of pycell
 pub use crate::pycell::impl_::{
-    GetBorrowChecker, PyClassMutability, PyClassObject, PyClassObjectBase, PyClassObjectLayout,
+    GetBorrowChecker, PyClassMutability, PyClassObjectBase, PyClassObjectLayout,
+    PyStaticClassObject,
 };

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -167,6 +167,7 @@ pub trait PyClassImpl: Sized + 'static {
     /// #[pyclass(sequence)]
     const IS_SEQUENCE: bool = false;
 
+    /// Description of how this class is laid out in memory
     type Layout: InternalPyClassObjectLayout<Self>;
 
     /// Base class

--- a/src/impl_/pyclass_init.rs
+++ b/src/impl_/pyclass_init.rs
@@ -1,10 +1,17 @@
 //! Contains initialization utilities for `#[pyclass]`.
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::impl_::pyclass::PyClassImpl;
 use crate::internal::get_slot::TP_ALLOC;
+use crate::pycell::impl_::{InternalPyClassObjectLayout, PyClassObjectContents};
 use crate::types::PyType;
 use crate::{ffi, Borrowed, PyErr, PyResult, Python};
 use crate::{ffi::PyTypeObject, sealed::Sealed, type_object::PyTypeInfo};
 use std::marker::PhantomData;
+
+pub unsafe fn initialize_with_default<T: PyClassImpl + Default>(obj: *mut ffi::PyObject) {
+    let contents = T::Layout::contents_uninitialised(obj);
+    (*contents).write(PyClassObjectContents::new(T::default()));
+}
 
 /// Initializer for Python types.
 ///

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -4,7 +4,7 @@ use crate::impl_::callback::IntoPyCallbackOutput;
 use crate::impl_::panic::PanicTrap;
 use crate::impl_::pycell::{PyClassObject, PyClassObjectLayout};
 use crate::internal::get_slot::{get_slot, TP_BASE, TP_CLEAR, TP_TRAVERSE};
-use crate::pycell::impl_::PyClassBorrowChecker as _;
+use crate::pycell::impl_::{InternalPyClassObjectLayout, PyClassBorrowChecker as _};
 use crate::pycell::{PyBorrowError, PyBorrowMutError};
 use crate::pyclass::boolean_struct::False;
 use crate::types::any::PyAnyMethods;

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -319,7 +319,7 @@ where
         // `.try_borrow()` above created a borrow, we need to release it when we're done
         // traversing the object. This allows us to read `instance` safely.
         let _guard = TraverseGuard(class_object);
-        let instance = &*class_object.contents.value.get();
+        let instance = &*class_object.contents().value.get();
 
         let visit = PyVisit { visit, arg, _guard: PhantomData };
 

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -122,6 +122,23 @@ trampolines!(
     pub fn unaryfunc(slf: *mut ffi::PyObject) -> *mut ffi::PyObject;
 );
 
+// tp_init should return 0 on success and -1 on error
+// https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_init
+#[inline]
+pub unsafe fn initproc(
+    slf: *mut ffi::PyObject,
+    args: *mut ffi::PyObject,
+    kwargs: *mut ffi::PyObject,
+    f: for<'py> unsafe fn(
+        Python<'py>,
+        *mut ffi::PyObject,
+        *mut ffi::PyObject,
+        *mut ffi::PyObject,
+    ) -> PyResult<*mut ffi::PyObject>,
+) -> c_int {
+    trampoline(|py| f(py, slf, args, kwargs).map(|_| 0))
+}
+
 #[cfg(any(not(Py_LIMITED_API), Py_3_11))]
 trampoline! {
     pub fn getbufferproc(slf: *mut ffi::PyObject, buf: *mut ffi::Py_buffer, flags: c_int) -> c_int;

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -136,6 +136,7 @@ pub unsafe fn initproc(
         *mut ffi::PyObject,
     ) -> PyResult<*mut ffi::PyObject>,
 ) -> c_int {
+    // the map() discards the success value of `f` and converts to the success return value for tp_init (0)
     trampoline(|py| f(py, slf, args, kwargs).map(|_| 0))
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2,6 +2,7 @@ use crate::conversion::IntoPyObject;
 use crate::err::{self, PyErr, PyResult};
 use crate::impl_::pycell::PyClassObject;
 use crate::internal_tricks::ptr_from_ref;
+use crate::pycell::impl_::InternalPyClassObjectLayout;
 use crate::pycell::{PyBorrowError, PyBorrowMutError};
 use crate::pyclass::boolean_struct::{False, True};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,6 +1,6 @@
 use crate::conversion::IntoPyObject;
 use crate::err::{self, PyErr, PyResult};
-use crate::impl_::pycell::PyClassObject;
+use crate::impl_::pyclass::PyClassImpl;
 use crate::internal_tricks::ptr_from_ref;
 use crate::pycell::impl_::InternalPyClassObjectLayout;
 use crate::pycell::{PyBorrowError, PyBorrowMutError};
@@ -463,7 +463,7 @@ where
     }
 
     #[inline]
-    pub(crate) fn get_class_object(&self) -> &PyClassObject<T> {
+    pub(crate) fn get_class_object(&self) -> &<T as PyClassImpl>::Layout {
         self.1.get_class_object()
     }
 }
@@ -1296,10 +1296,10 @@ where
 
     /// Get a view on the underlying `PyClass` contents.
     #[inline]
-    pub(crate) fn get_class_object(&self) -> &PyClassObject<T> {
-        let class_object = self.as_ptr().cast::<PyClassObject<T>>();
+    pub(crate) fn get_class_object(&self) -> &<T as PyClassImpl>::Layout {
+        let class_object = self.as_ptr().cast::<<T as PyClassImpl>::Layout>();
         // Safety: Bound<T: PyClass> is known to contain an object which is laid out in memory as a
-        // PyClassObject<T>.
+        // <T as PyClassImpl>::Layout object
         unsafe { &*class_object }
     }
 }

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -208,7 +208,7 @@ use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 
 pub(crate) mod impl_;
-use impl_::{PyClassBorrowChecker, PyClassObjectLayout};
+use impl_::{InternalPyClassObjectLayout, PyClassBorrowChecker, PyClassObjectLayout};
 
 /// A wrapper type for an immutably borrowed value from a [`Bound<'py, T>`].
 ///

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -277,7 +277,7 @@ where
 #[repr(C)]
 pub struct PyClassObject<T: PyClassImpl> {
     pub(crate) ob_base: <T::BaseType as PyClassBaseType>::LayoutAsBase,
-    pub(crate) contents: PyClassObjectContents<T>,
+    contents: PyClassObjectContents<T>,
 }
 
 #[repr(C)]
@@ -294,6 +294,10 @@ impl<T: PyClassImpl> PyClassObject<T> {
         self.contents.value.get()
     }
 
+    pub(crate) fn contents(&self) -> &PyClassObjectContents<T> {
+        &self.contents
+    }
+
     /// used to set PyType_Spec::basicsize
     /// https://docs.python.org/3/c-api/type.html#c.PyType_Spec.basicsize
     pub(crate) fn basicsize() -> ffi::Py_ssize_t {
@@ -303,6 +307,10 @@ impl<T: PyClassImpl> PyClassObject<T> {
         #[allow(clippy::useless_conversion)]
         size.try_into().expect("size should fit in Py_ssize_t")
     }
+
+    /// Gets the offset of the contents from the start of the struct in bytes.
+    pub(crate) fn contents_offset() -> usize {
+        memoffset::offset_of!(PyClassObject<T>, contents)
     }
 
     /// Gets the offset of the dictionary from the start of the struct in bytes.
@@ -328,9 +336,7 @@ impl<T: PyClassImpl> PyClassObject<T> {
         #[allow(clippy::useless_conversion)]
         offset.try_into().expect("offset should fit in Py_ssize_t")
     }
-}
 
-impl<T: PyClassImpl> PyClassObject<T> {
     pub(crate) fn borrow_checker(&self) -> &<T::PyClassMutability as PyClassMutability>::Checker {
         T::PyClassMutability::borrow_checker(self)
     }

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -294,6 +294,17 @@ impl<T: PyClassImpl> PyClassObject<T> {
         self.contents.value.get()
     }
 
+    /// used to set PyType_Spec::basicsize
+    /// https://docs.python.org/3/c-api/type.html#c.PyType_Spec.basicsize
+    pub(crate) fn basicsize() -> ffi::Py_ssize_t {
+        let size = std::mem::size_of::<Self>();
+
+        // Py_ssize_t may not be equal to isize on all platforms
+        #[allow(clippy::useless_conversion)]
+        size.try_into().expect("size should fit in Py_ssize_t")
+    }
+    }
+
     /// Gets the offset of the dictionary from the start of the struct in bytes.
     pub(crate) fn dict_offset() -> ffi::Py_ssize_t {
         use memoffset::offset_of;

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -248,7 +248,9 @@ pub trait PyClassObjectLayout<T>: PyLayout<T> {
 pub trait InternalPyClassObjectLayout<T: PyClassImpl>: PyClassObjectLayout<T> {
     /// Obtain a pointer to the contents of an uninitialized PyObject of this type
     /// Safety: the provided object must have the layout that the implementation is expecting
-    unsafe fn contents_uninitialised(obj: *mut ffi::PyObject) -> *mut MaybeUninit<PyClassObjectContents<T>>;
+    unsafe fn contents_uninitialised(
+        obj: *mut ffi::PyObject,
+    ) -> *mut MaybeUninit<PyClassObjectContents<T>>;
 
     fn get_ptr(&self) -> *mut T;
 
@@ -362,7 +364,9 @@ pub struct PyStaticClassObject<T: PyClassImpl> {
 }
 
 impl<T: PyClassImpl> InternalPyClassObjectLayout<T> for PyStaticClassObject<T> {
-    unsafe fn contents_uninitialised(obj: *mut ffi::PyObject) -> *mut MaybeUninit<PyClassObjectContents<T>> {
+    unsafe fn contents_uninitialised(
+        obj: *mut ffi::PyObject,
+    ) -> *mut MaybeUninit<PyClassObjectContents<T>> {
         #[repr(C)]
         struct PartiallyInitializedClassObject<T: PyClassImpl> {
             _ob_base: <T::BaseType as PyClassBaseType>::LayoutAsBase,
@@ -480,7 +484,9 @@ impl<T: PyClassImpl> PyVariableClassObject<T> {
 
 #[cfg(Py_3_12)]
 impl<T: PyClassImpl> InternalPyClassObjectLayout<T> for PyVariableClassObject<T> {
-    unsafe fn contents_uninitialised(obj: *mut ffi::PyObject) -> * mut MaybeUninit<PyClassObjectContents<T>> {
+    unsafe fn contents_uninitialised(
+        obj: *mut ffi::PyObject,
+    ) -> *mut MaybeUninit<PyClassObjectContents<T>> {
         Self::get_contents_of_obj(obj) as *mut MaybeUninit<PyClassObjectContents<T>>
     }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -224,6 +224,28 @@ pub trait PyClassObjectLayout<T>: PyLayout<T> {
     unsafe fn tp_dealloc(py: Python<'_>, slf: *mut ffi::PyObject);
 }
 
+#[doc(hidden)]
+pub(crate) trait InternalPyClassObjectLayout<T: PyClassImpl>: PyLayout<T> {
+    fn get_ptr(&self) -> *mut T;
+
+    fn contents(&self) -> &PyClassObjectContents<T>;
+
+    /// used to set PyType_Spec::basicsize
+    /// https://docs.python.org/3/c-api/type.html#c.PyType_Spec.basicsize
+    fn basicsize() -> ffi::Py_ssize_t;
+
+    /// Gets the offset of the contents from the start of the struct in bytes.
+    fn contents_offset() -> PyObjectOffset;
+
+    /// Gets the offset of the dictionary from the start of the struct in bytes.
+    fn dict_offset() -> PyObjectOffset;
+
+    /// Gets the offset of the weakref list from the start of the struct in bytes.
+    fn weaklist_offset() -> PyObjectOffset;
+
+    fn borrow_checker(&self) -> &<T::PyClassMutability as PyClassMutability>::Checker;
+}
+
 impl<T, U> PyClassObjectLayout<T> for PyClassObjectBase<U>
 where
     U: PySizedLayout<T>,
@@ -289,18 +311,18 @@ pub(crate) struct PyClassObjectContents<T: PyClassImpl> {
     pub(crate) weakref: T::WeakRef,
 }
 
-impl<T: PyClassImpl> PyClassObject<T> {
-    pub(crate) fn get_ptr(&self) -> *mut T {
+impl<T: PyClassImpl> InternalPyClassObjectLayout<T> for PyClassObject<T> {
+    fn get_ptr(&self) -> *mut T {
         self.contents.value.get()
     }
 
-    pub(crate) fn contents(&self) -> &PyClassObjectContents<T> {
+    fn contents(&self) -> &PyClassObjectContents<T> {
         &self.contents
     }
 
     /// used to set PyType_Spec::basicsize
     /// https://docs.python.org/3/c-api/type.html#c.PyType_Spec.basicsize
-    pub(crate) fn basicsize() -> ffi::Py_ssize_t {
+    fn basicsize() -> ffi::Py_ssize_t {
         let size = std::mem::size_of::<Self>();
 
         // Py_ssize_t may not be equal to isize on all platforms
@@ -309,7 +331,7 @@ impl<T: PyClassImpl> PyClassObject<T> {
     }
 
     /// Gets the offset of the contents from the start of the struct in bytes.
-    pub(crate) fn contents_offset() -> PyObjectOffset {
+    fn contents_offset() -> PyObjectOffset {
         let offset = memoffset::offset_of!(PyClassObject<T>, contents);
 
         // Py_ssize_t may not be equal to isize on all platforms
@@ -318,7 +340,7 @@ impl<T: PyClassImpl> PyClassObject<T> {
     }
 
     /// Gets the offset of the dictionary from the start of the struct in bytes.
-    pub(crate) fn dict_offset() -> PyObjectOffset {
+    fn dict_offset() -> PyObjectOffset {
         use memoffset::offset_of;
 
         let offset =
@@ -330,7 +352,7 @@ impl<T: PyClassImpl> PyClassObject<T> {
     }
 
     /// Gets the offset of the weakref list from the start of the struct in bytes.
-    pub(crate) fn weaklist_offset() -> PyObjectOffset {
+    fn weaklist_offset() -> PyObjectOffset {
         use memoffset::offset_of;
 
         let offset =
@@ -341,7 +363,7 @@ impl<T: PyClassImpl> PyClassObject<T> {
         PyObjectOffset::Absolute(offset.try_into().expect("offset should fit in Py_ssize_t"))
     }
 
-    pub(crate) fn borrow_checker(&self) -> &<T::PyClassMutability as PyClassMutability>::Checker {
+    fn borrow_checker(&self) -> &<T::PyClassMutability as PyClassMutability>::Checker {
         T::PyClassMutability::borrow_checker(self)
     }
 }
@@ -424,6 +446,23 @@ mod tests {
 
     #[pyclass(crate = "crate", extends = ImmutableChildOfImmutableBase, frozen)]
     struct ImmutableChildOfImmutableChildOfImmutableBase;
+
+    #[pyclass(crate = "crate", subclass)]
+    struct BaseWithData(#[allow(unused)] u64);
+
+    #[pyclass(crate = "crate", extends = BaseWithData)]
+    struct ChildWithData(#[allow(unused)] u64);
+
+    #[pyclass(crate = "crate", extends = BaseWithData)]
+    struct ChildWithoutData;
+
+    #[test]
+    fn test_inherited_size() {
+        let base_size = PyClassObject::<BaseWithData>::basicsize();
+        assert!(base_size > 0); // negative indicates variable sized
+        assert_eq!(base_size, PyClassObject::<ChildWithoutData>::basicsize());
+        assert!(base_size < PyClassObject::<ChildWithData>::basicsize());
+    }
 
     fn assert_mutable<T: PyClass<Frozen = False, PyClassMutability = MutableClass>>() {}
     fn assert_immutable<T: PyClass<Frozen = True, PyClassMutability = ImmutableClass>>() {}

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -228,8 +228,8 @@ impl<T: PyTypeInfo> PyClassObjectLayout<T> for PyVariableClassObjectBase {
     fn check_threadsafe(&self) -> Result<(), PyBorrowError> {
         Ok(())
     }
-    unsafe fn tp_dealloc(_py: Python<'_>, _slf: *mut ffi::PyObject) {
-        // TODO(matt):
+    unsafe fn tp_dealloc(py: Python<'_>, slf: *mut ffi::PyObject) {
+        tp_dealloc(py, slf, T::type_object_raw(py));
     }
 }
 
@@ -284,43 +284,45 @@ where
         Ok(())
     }
     unsafe fn tp_dealloc(py: Python<'_>, slf: *mut ffi::PyObject) {
-        // FIXME: there is potentially subtle issues here if the base is overwritten
-        // at runtime? To be investigated.
-        let type_obj = T::type_object(py);
-        let type_ptr = type_obj.as_type_ptr();
-        let actual_type = PyType::from_borrowed_type_ptr(py, ffi::Py_TYPE(slf));
-
-        // For `#[pyclass]` types which inherit from PyAny, we can just call tp_free
-        if type_ptr == std::ptr::addr_of_mut!(ffi::PyBaseObject_Type) {
-            let tp_free = actual_type
-                .get_slot(TP_FREE)
-                .expect("PyBaseObject_Type should have tp_free");
-            return tp_free(slf.cast());
-        }
-
-        // More complex native types (e.g. `extends=PyDict`) require calling the base's dealloc.
-        #[cfg(not(Py_LIMITED_API))]
-        {
-            // FIXME: should this be using actual_type.tp_dealloc?
-            if let Some(dealloc) = (*type_ptr).tp_dealloc {
-                // Before CPython 3.11 BaseException_dealloc would use Py_GC_UNTRACK which
-                // assumes the exception is currently GC tracked, so we have to re-track
-                // before calling the dealloc so that it can safely call Py_GC_UNTRACK.
-                #[cfg(not(any(Py_3_11, PyPy)))]
-                if ffi::PyType_FastSubclass(type_ptr, ffi::Py_TPFLAGS_BASE_EXC_SUBCLASS) == 1 {
-                    ffi::PyObject_GC_Track(slf.cast());
-                }
-                dealloc(slf);
-            } else {
-                (*actual_type.as_type_ptr())
-                    .tp_free
-                    .expect("type missing tp_free")(slf.cast());
-            }
-        }
-
-        #[cfg(Py_LIMITED_API)]
-        unreachable!("subclassing native types is not possible with the `abi3` feature");
+        tp_dealloc(py, slf, T::type_object_raw(py));
     }
+}
+
+unsafe fn tp_dealloc(py: Python<'_>, obj: *mut ffi::PyObject, type_ptr: *mut ffi::PyTypeObject) {
+    // FIXME: there is potentially subtle issues here if the base is overwritten
+    // at runtime? To be investigated.
+    let actual_type = PyType::from_borrowed_type_ptr(py, ffi::Py_TYPE(obj));
+
+    // For `#[pyclass]` types which inherit from PyAny, we can just call tp_free
+    if type_ptr == std::ptr::addr_of_mut!(ffi::PyBaseObject_Type) {
+        let tp_free = actual_type
+            .get_slot(TP_FREE)
+            .expect("PyBaseObject_Type should have tp_free");
+        return tp_free(obj.cast());
+    }
+
+    // More complex native types (e.g. `extends=PyDict`) require calling the base's dealloc.
+    #[cfg(not(Py_LIMITED_API))]
+    {
+        // FIXME: should this be using actual_type.tp_dealloc?
+        if let Some(dealloc) = (*type_ptr).tp_dealloc {
+            // Before CPython 3.11 BaseException_dealloc would use Py_GC_UNTRACK which
+            // assumes the exception is currently GC tracked, so we have to re-track
+            // before calling the dealloc so that it can safely call Py_GC_UNTRACK.
+            #[cfg(not(any(Py_3_11, PyPy)))]
+            if ffi::PyType_FastSubclass(type_ptr, ffi::Py_TPFLAGS_BASE_EXC_SUBCLASS) == 1 {
+                ffi::PyObject_GC_Track(obj.cast());
+            }
+            dealloc(obj);
+        } else {
+            (*actual_type.as_type_ptr())
+                .tp_free
+                .expect("type missing tp_free")(obj.cast());
+        }
+    }
+
+    #[cfg(Py_LIMITED_API)]
+    unreachable!("subclassing native types is not possible with the `abi3` feature");
 }
 
 #[repr(C)]
@@ -333,6 +335,16 @@ pub(crate) struct PyClassObjectContents<T: PyClassImpl> {
 }
 
 impl<T: PyClassImpl> PyClassObjectContents<T> {
+    pub(crate) fn new(init: T) -> Self {
+        PyClassObjectContents {
+            value: ManuallyDrop::new(UnsafeCell::new(init)),
+            borrow_checker: <T::PyClassMutability as PyClassMutability>::Storage::new(),
+            thread_checker: T::ThreadChecker::new(),
+            dict: T::Dict::INIT,
+            weakref: T::WeakRef::INIT,
+        }
+    }
+
     unsafe fn dealloc(&mut self, py: Python<'_>, py_object: *mut ffi::PyObject) {
         if self.thread_checker.can_drop(py) {
             ManuallyDrop::drop(&mut self.value);

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -298,13 +298,6 @@ where
     }
 }
 
-/// The layout of a PyClass as a Python object
-#[repr(C)]
-pub struct PyStaticClassObject<T: PyClassImpl> {
-    ob_base: <T::BaseType as PyClassBaseType>::LayoutAsBase,
-    contents: PyClassObjectContents<T>,
-}
-
 #[repr(C)]
 pub(crate) struct PyClassObjectContents<T: PyClassImpl> {
     pub(crate) value: ManuallyDrop<UnsafeCell<T>>,
@@ -312,6 +305,13 @@ pub(crate) struct PyClassObjectContents<T: PyClassImpl> {
     pub(crate) thread_checker: T::ThreadChecker,
     pub(crate) dict: T::Dict,
     pub(crate) weakref: T::WeakRef,
+}
+
+/// The layout of a PyClass with a known sized base class as a Python object
+#[repr(C)]
+pub struct PyStaticClassObject<T: PyClassImpl> {
+    ob_base: <T::BaseType as PyClassBaseType>::LayoutAsBase,
+    contents: PyClassObjectContents<T>,
 }
 
 impl<T: PyClassImpl> InternalPyClassObjectLayout<T> for PyStaticClassObject<T> {

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -2,10 +2,10 @@ use crate::{
     exceptions::PyTypeError,
     ffi,
     impl_::{
-        pycell::PyClassObject,
         pyclass::{
             assign_sequence_item_from_mapping, get_sequence_item_from_mapping, tp_dealloc,
-            tp_dealloc_with_gc, MaybeRuntimePyMethodDef, PyClassItemsIter, PyObjectOffset,
+            tp_dealloc_with_gc, MaybeRuntimePyMethodDef, PyClassImpl, PyClassItemsIter,
+            PyObjectOffset,
         },
         pymethods::{Getter, PyGetterDef, PyMethodDefType, PySetterDef, Setter, _call_clear},
         trampoline::trampoline,
@@ -94,7 +94,7 @@ where
             T::items_iter(),
             T::NAME,
             T::MODULE,
-            PyClassObject::<T>::basicsize(),
+            <T as PyClassImpl>::Layout::basicsize(),
         )
     }
 }

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -414,9 +414,7 @@ impl PyTypeBuilder {
                         Some(PyObjectOffset::Absolute(offset)) => {
                             (*type_object).tp_dictoffset = offset;
                         }
-                        Some(PyObjectOffset::Relative(_)) => {
-                            panic!("relative offsets not supported until python 3.12")
-                        }
+                        // PyObjectOffset::Relative requires >=3.12
                         _ => {}
                     }
 
@@ -424,9 +422,7 @@ impl PyTypeBuilder {
                         Some(PyObjectOffset::Absolute(offset)) => {
                             (*type_object).tp_weaklistoffset = offset;
                         }
-                        Some(PyObjectOffset::Relative(_)) => {
-                            panic!("relative offsets not supported until python 3.12")
-                        }
+                        // PyObjectOffset::Relative requires >=3.12
                         _ => {}
                     }
                 }));

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -11,6 +11,7 @@ use crate::{
         trampoline::trampoline,
     },
     internal_tricks::ptr_from_ref,
+    pycell::impl_::InternalPyClassObjectLayout,
     types::{typeobject::PyTypeMethods, PyType},
     Py, PyClass, PyResult, PyTypeInfo, Python,
 };

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -47,7 +47,7 @@ where
         items_iter: PyClassItemsIter,
         name: &'static str,
         module: Option<&'static str>,
-        size_of: usize,
+        basicsize: ffi::Py_ssize_t,
     ) -> PyResult<PyClassTypeObject> {
         PyTypeBuilder {
             slots: Vec::new(),
@@ -75,7 +75,7 @@ where
         .offsets(dict_offset, weaklist_offset)
         .set_is_basetype(is_basetype)
         .class_items(items_iter)
-        .build(py, name, module, size_of)
+        .build(py, name, module, basicsize)
     }
 
     unsafe {
@@ -93,7 +93,7 @@ where
             T::items_iter(),
             T::NAME,
             T::MODULE,
-            std::mem::size_of::<PyClassObject<T>>(),
+            PyClassObject::<T>::basicsize(),
         )
     }
 }
@@ -417,7 +417,7 @@ impl PyTypeBuilder {
         py: Python<'_>,
         name: &'static str,
         module_name: Option<&'static str>,
-        basicsize: usize,
+        basicsize: ffi::Py_ssize_t,
     ) -> PyResult<PyClassTypeObject> {
         // `c_ulong` and `c_uint` have the same size
         // on some platforms (like windows)

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -1,19 +1,18 @@
 //! Contains initialization utilities for `#[pyclass]`.
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::impl_::callback::IntoPyCallbackOutput;
-use crate::impl_::pyclass::{PyClassBaseType, PyClassDict, PyClassThreadChecker, PyClassWeakRef};
+use crate::impl_::pyclass::{
+    PyClassBaseType, PyClassDict, PyClassImpl, PyClassThreadChecker, PyClassWeakRef,
+};
 use crate::impl_::pyclass_init::{PyNativeTypeInitializer, PyObjectInit};
+use crate::pycell::impl_::InternalPyClassObjectLayout;
 use crate::types::PyAnyMethods;
 use crate::{ffi, Bound, Py, PyClass, PyResult, Python};
 use crate::{
     ffi::PyTypeObject,
     pycell::impl_::{PyClassBorrowChecker, PyClassMutability, PyClassObjectContents},
 };
-use std::{
-    cell::UnsafeCell,
-    marker::PhantomData,
-    mem::{ManuallyDrop, MaybeUninit},
-};
+use std::{cell::UnsafeCell, marker::PhantomData, mem::ManuallyDrop};
 
 /// Initializer for our `#[pyclass]` system.
 ///
@@ -165,14 +164,6 @@ impl<T: PyClass> PyClassInitializer<T> {
     where
         T: PyClass,
     {
-        /// Layout of a PyClassObject after base new has been called, but the contents have not yet been
-        /// written.
-        #[repr(C)]
-        struct PartiallyInitializedClassObject<T: PyClass> {
-            _ob_base: <T::BaseType as PyClassBaseType>::LayoutAsBase,
-            contents: MaybeUninit<PyClassObjectContents<T>>,
-        }
-
         let (init, super_init) = match self.0 {
             PyClassInitializerImpl::Existing(value) => return Ok(value.into_bound(py)),
             PyClassInitializerImpl::New { init, super_init } => (init, super_init),
@@ -180,9 +171,9 @@ impl<T: PyClass> PyClassInitializer<T> {
 
         let obj = super_init.into_new_object(py, target_type)?;
 
-        let part_init: *mut PartiallyInitializedClassObject<T> = obj.cast();
+        let contents = <T as PyClassImpl>::Layout::contents_uninitialised(obj);
         std::ptr::write(
-            (*part_init).contents.as_mut_ptr(),
+            (*contents).as_mut_ptr(),
             PyClassObjectContents {
                 value: ManuallyDrop::new(UnsafeCell::new(init)),
                 borrow_checker: <T::PyClassMutability as PyClassMutability>::Storage::new(),

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -1,18 +1,13 @@
 //! Contains initialization utilities for `#[pyclass]`.
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::impl_::callback::IntoPyCallbackOutput;
-use crate::impl_::pyclass::{
-    PyClassBaseType, PyClassDict, PyClassImpl, PyClassThreadChecker, PyClassWeakRef,
-};
+use crate::impl_::pyclass::{PyClassBaseType, PyClassImpl};
 use crate::impl_::pyclass_init::{PyNativeTypeInitializer, PyObjectInit};
 use crate::pycell::impl_::InternalPyClassObjectLayout;
 use crate::types::PyAnyMethods;
 use crate::{ffi, Bound, Py, PyClass, PyResult, Python};
-use crate::{
-    ffi::PyTypeObject,
-    pycell::impl_::{PyClassBorrowChecker, PyClassMutability, PyClassObjectContents},
-};
-use std::{cell::UnsafeCell, marker::PhantomData, mem::ManuallyDrop};
+use crate::{ffi::PyTypeObject, pycell::impl_::PyClassObjectContents};
+use std::marker::PhantomData;
 
 /// Initializer for our `#[pyclass]` system.
 ///
@@ -172,16 +167,7 @@ impl<T: PyClass> PyClassInitializer<T> {
         let obj = super_init.into_new_object(py, target_type)?;
 
         let contents = <T as PyClassImpl>::Layout::contents_uninitialised(obj);
-        std::ptr::write(
-            (*contents).as_mut_ptr(),
-            PyClassObjectContents {
-                value: ManuallyDrop::new(UnsafeCell::new(init)),
-                borrow_checker: <T::PyClassMutability as PyClassMutability>::Storage::new(),
-                thread_checker: T::ThreadChecker::new(),
-                dict: T::Dict::INIT,
-                weakref: T::WeakRef::INIT,
-            },
-        );
+        (*contents).write(PyClassObjectContents::new(init));
 
         // Safety: obj is a valid pointer to an object of type `target_type`, which` is a known
         // subclass of `T`

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -1,6 +1,8 @@
 //! Python type object information
 
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::impl_::pyclass::PyClassImpl;
+use crate::pycell::impl_::InternalPyClassObjectLayout;
 use crate::types::any::PyAnyMethods;
 use crate::types::{PyAny, PyType};
 use crate::{ffi, Bound, Python};
@@ -41,6 +43,9 @@ pub unsafe trait PyTypeInfo: Sized {
 
     /// Module name, if any.
     const MODULE: Option<&'static str>;
+
+    /// The type of object layout to use for ancestors or descendents of this type
+    type Layout<T: PyClassImpl>: InternalPyClassObjectLayout<T>;
 
     /// Returns the PyTypeObject instance for this type.
     fn type_object_raw(py: Python<'_>) -> *mut ffi::PyTypeObject;

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -3,6 +3,7 @@ use crate::conversion::{AsPyPointer, FromPyObjectBound, IntoPyObject};
 use crate::err::{DowncastError, DowncastIntoError, PyErr, PyResult};
 use crate::exceptions::{PyAttributeError, PyTypeError};
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::impl_::pycell::PyStaticClassObject;
 use crate::instance::Bound;
 use crate::internal::get_slot::TP_DESCR_GET;
 use crate::internal_tricks::ptr_from_ref;
@@ -41,6 +42,7 @@ pyobject_native_type_info!(
     PyAny,
     pyobject_native_static_type_object!(ffi::PyBaseObject_Type),
     Some("builtins"),
+    PyStaticClassObject<T>,
     #checkfunction=PyObject_Check
 );
 

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -1,6 +1,9 @@
 use crate::{
-    ffi, ffi_ptr_ext::FfiPtrExt, types::any::PyAnyMethods, Borrowed, Bound, PyAny, PyTypeInfo,
-    Python,
+    ffi,
+    ffi_ptr_ext::FfiPtrExt,
+    impl_::{pycell::PyStaticClassObject, pyclass::PyClassImpl},
+    types::any::PyAnyMethods,
+    Borrowed, Bound, PyAny, PyTypeInfo, Python,
 };
 
 /// Represents the Python `Ellipsis` object.
@@ -31,6 +34,8 @@ unsafe impl PyTypeInfo for PyEllipsis {
     const NAME: &'static str = "ellipsis";
 
     const MODULE: Option<&'static str> = None;
+
+    type Layout<T: PyClassImpl> = PyStaticClassObject<T>;
 
     fn type_object_raw(_py: Python<'_>) -> *mut ffi::PyTypeObject {
         unsafe { ffi::Py_TYPE(ffi::Py_Ellipsis()) }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -158,6 +158,8 @@ macro_rules! pyobject_native_type_info(
             const NAME: &'static str = stringify!($name);
             const MODULE: ::std::option::Option<&'static str> = $module;
 
+            type Layout<T: $crate::impl_::pyclass::PyClassImpl> = $crate::impl_::pycell::PyStaticClassObject<T>;
+
             #[inline]
             #[allow(clippy::redundant_closure_call)]
             fn type_object_raw(py: $crate::Python<'_>) -> *mut $crate::ffi::PyTypeObject {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -153,12 +153,12 @@ macro_rules! pyobject_native_static_type_object(
 #[doc(hidden)]
 #[macro_export]
 macro_rules! pyobject_native_type_info(
-    ($name:ty, $typeobject:expr, $module:expr $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
+    ($name:ty, $typeobject:expr, $module:expr, $layout:path $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
         unsafe impl<$($generics,)*> $crate::type_object::PyTypeInfo for $name {
             const NAME: &'static str = stringify!($name);
             const MODULE: ::std::option::Option<&'static str> = $module;
 
-            type Layout<T: $crate::impl_::pyclass::PyClassImpl> = $crate::impl_::pycell::PyStaticClassObject<T>;
+            type Layout<T: $crate::impl_::pyclass::PyClassImpl> = $layout;
 
             #[inline]
             #[allow(clippy::redundant_closure_call)]
@@ -186,12 +186,15 @@ macro_rules! pyobject_native_type_info(
 #[doc(hidden)]
 #[macro_export]
 macro_rules! pyobject_native_type_core {
-    ($name:ty, $typeobject:expr, #module=$module:expr $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
+    ($name:ty, $typeobject:expr, #module=$module:expr, #layout=$layout:path $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
         $crate::pyobject_native_type_named!($name $(;$generics)*);
-        $crate::pyobject_native_type_info!($name, $typeobject, $module $(, #checkfunction=$checkfunction)? $(;$generics)*);
+        $crate::pyobject_native_type_info!($name, $typeobject, $module, $layout $(, #checkfunction=$checkfunction)? $(;$generics)*);
+    };
+    ($name:ty, $typeobject:expr, #module=$module:expr $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
+        $crate::pyobject_native_type_core!($name, $typeobject, #module=$module, #layout=$crate::impl_::pycell::PyStaticClassObject<T> $(, #checkfunction=$checkfunction)? $(;$generics)*);
     };
     ($name:ty, $typeobject:expr $(, #checkfunction=$checkfunction:path)? $(;$generics:ident)*) => {
-        $crate::pyobject_native_type_core!($name, $typeobject, #module=::std::option::Option::Some("builtins") $(, #checkfunction=$checkfunction)? $(;$generics)*);
+        $crate::pyobject_native_type_core!($name, $typeobject, #module=::std::option::Option::Some("builtins"), #layout=$crate::impl_::pycell::PyStaticClassObject<T> $(, #checkfunction=$checkfunction)? $(;$generics)*);
     };
 }
 

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -1,4 +1,6 @@
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::impl_::pycell::PyStaticClassObject;
+use crate::impl_::pyclass::PyClassImpl;
 use crate::{ffi, types::any::PyAnyMethods, Borrowed, Bound, PyAny, PyObject, PyTypeInfo, Python};
 #[allow(deprecated)]
 use crate::{IntoPy, ToPyObject};
@@ -31,6 +33,8 @@ unsafe impl PyTypeInfo for PyNone {
     const NAME: &'static str = "NoneType";
 
     const MODULE: Option<&'static str> = None;
+
+    type Layout<T: PyClassImpl> = PyStaticClassObject<T>;
 
     fn type_object_raw(_py: Python<'_>) -> *mut ffi::PyTypeObject {
         unsafe { ffi::Py_TYPE(ffi::Py_None()) }

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -1,6 +1,9 @@
 use crate::{
-    ffi, ffi_ptr_ext::FfiPtrExt, types::any::PyAnyMethods, Borrowed, Bound, PyAny, PyTypeInfo,
-    Python,
+    ffi,
+    ffi_ptr_ext::FfiPtrExt,
+    impl_::{pycell::PyStaticClassObject, pyclass::PyClassImpl},
+    types::any::PyAnyMethods,
+    Borrowed, Bound, PyAny, PyTypeInfo, Python,
 };
 
 /// Represents the Python `NotImplemented` object.
@@ -34,6 +37,8 @@ impl PyNotImplemented {
 unsafe impl PyTypeInfo for PyNotImplemented {
     const NAME: &'static str = "NotImplementedType";
     const MODULE: Option<&'static str> = None;
+
+    type Layout<T: PyClassImpl> = PyStaticClassObject<T>;
 
     fn type_object_raw(_py: Python<'_>) -> *mut ffi::PyTypeObject {
         unsafe { ffi::Py_TYPE(ffi::Py_NotImplemented()) }

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -18,7 +18,13 @@ use super::PyString;
 #[repr(transparent)]
 pub struct PyType(PyAny);
 
-pyobject_native_type_core!(PyType, pyobject_native_static_type_object!(ffi::PyType_Type), #checkfunction=ffi::PyType_Check);
+pyobject_native_type_core!(
+    PyType,
+    pyobject_native_static_type_object!(ffi::PyType_Type),
+    #module=::std::option::Option::Some("builtins"),
+    #layout=crate::impl_::pycell::PyStaticClassObject<T>,
+    #checkfunction = ffi::PyType_Check
+);
 
 impl PyType {
     /// Creates a new type object.

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -1,3 +1,4 @@
+use super::{PyDict, PyString};
 use crate::err::{self, PyResult};
 use crate::instance::Borrowed;
 #[cfg(not(Py_3_13))]
@@ -5,8 +6,6 @@ use crate::pybacked::PyBackedStr;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
 use crate::{ffi, Bound, PyAny, PyTypeInfo, Python};
-
-use super::PyString;
 
 /// Represents a reference to a Python `type` object.
 ///
@@ -22,9 +21,16 @@ pyobject_native_type_core!(
     PyType,
     pyobject_native_static_type_object!(ffi::PyType_Type),
     #module=::std::option::Option::Some("builtins"),
-    #layout=crate::impl_::pycell::PyStaticClassObject<T>,
+    #layout=crate::impl_::pycell::PyVariableClassObject<T>,
     #checkfunction = ffi::PyType_Check
 );
+
+impl crate::impl_::pyclass::PyClassBaseType for PyType {
+    type LayoutAsBase = crate::impl_::pycell::PyVariableClassObjectBase;
+    type BaseNativeType = PyType;
+    type Initializer = crate::impl_::pyclass_init::PyNativeTypeInitializer<Self>;
+    type PyClassMutability = crate::pycell::impl_::ImmutableClass;
+}
 
 impl PyType {
     /// Creates a new type object.
@@ -38,6 +44,29 @@ impl PyType {
     #[inline]
     pub fn new_bound<T: PyTypeInfo>(py: Python<'_>) -> Bound<'_, PyType> {
         Self::new::<T>(py)
+    }
+
+    /// Creates a new type object (class). The resulting type/class will inherit the given metaclass `T`
+    ///
+    /// Equivalent to calling `type(name, bases, dict, **kwds)`
+    /// <https://docs.python.org/3/library/functions.html#type>
+    #[cfg(not(Py_LIMITED_API))]
+    pub fn new_type<'py, T: PyTypeInfo>(
+        py: Python<'py>,
+        args: &Bound<'py, PyTuple>,
+        kwargs: Option<&Bound<'py, PyDict>>,
+    ) -> PyResult<Bound<'py, T>> {
+        let new_fn = unsafe {
+            ffi::PyType_Type
+                .tp_new
+                .expect("PyType_Type.tp_new should be present")
+        };
+        let raw_type = T::type_object_raw(py);
+        let raw_args = args.as_ptr();
+        let raw_kwargs = kwargs.map(|v| v.as_ptr()).unwrap_or(std::ptr::null_mut());
+        let obj_ptr = unsafe { new_fn(raw_type, raw_args, raw_kwargs) };
+        let borrowed_obj = unsafe { Borrowed::from_ptr_or_err(py, obj_ptr) }?;
+        Ok(borrowed_obj.downcast()?.to_owned())
     }
 
     /// Converts the given FFI pointer into `Bound<PyType>`, to use in safe code.
@@ -393,6 +422,42 @@ class OuterClass:
             assert_eq!(
                 inner_class_type.fully_qualified_name().unwrap(),
                 qualname.as_str()
+            );
+        });
+    }
+
+    #[test]
+    #[cfg(all(not(Py_LIMITED_API), feature = "macros"))]
+    fn test_new_type() {
+        use crate::{
+            types::{PyDict, PyList, PyString},
+            IntoPy,
+        };
+
+        Python::with_gil(|py| {
+            #[allow(non_snake_case)]
+            let ListType = py.get_type::<PyList>();
+            let name = PyString::new(py, "MyClass");
+            let bases = PyTuple::new(py, [ListType]).unwrap();
+            let dict = PyDict::new(py);
+            dict.set_item("foo", 123_i32.into_py(py)).unwrap();
+            let args = PyTuple::new(py, [name.as_any(), bases.as_any(), dict.as_any()]).unwrap();
+            #[allow(non_snake_case)]
+            let MyClass = PyType::new_type::<PyType>(py, &args, None).unwrap();
+
+            assert_eq!(MyClass.name().unwrap(), "MyClass");
+            assert_eq!(MyClass.qualname().unwrap(), "MyClass");
+
+            crate::py_run!(
+                py,
+                MyClass,
+                r#"
+                assert type(MyClass) is type
+                assert MyClass.__bases__ == (list,)
+                assert issubclass(MyClass, list)
+                assert MyClass.foo == 123
+                assert not hasattr(MyClass, "__module__")
+                "#
             );
         });
     }

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -427,6 +427,53 @@ fn test_tuple_struct_class() {
 }
 
 #[cfg(any(Py_3_9, not(Py_LIMITED_API)))]
+#[pyclass]
+struct NoDunderDictSupport {
+    _pad: [u8; 32],
+}
+
+#[test]
+#[cfg(any(Py_3_9, not(Py_LIMITED_API)))]
+#[should_panic(expected = "inst.a = 1")]
+fn no_dunder_dict_support_assignment() {
+    Python::with_gil(|py| {
+        let inst = Py::new(
+            py,
+            NoDunderDictSupport {
+                _pad: *b"DEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+            },
+        )
+        .unwrap();
+        // should panic as this class has no __dict__
+        py_run!(py, inst, r#"inst.a = 1"#);
+    });
+}
+
+#[test]
+#[cfg(any(Py_3_9, not(Py_LIMITED_API)))]
+fn no_dunder_dict_support_setattr() {
+    Python::with_gil(|py| {
+        let inst = Py::new(
+            py,
+            NoDunderDictSupport {
+                _pad: *b"DEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+            },
+        )
+        .unwrap();
+        let err = inst
+            .into_bound(py)
+            .as_any()
+            .setattr("a", 1)
+            .unwrap_err()
+            .to_string();
+        assert_eq!(
+            &err,
+            "AttributeError: 'builtins.NoDunderDictSupport' object has no attribute 'a'"
+        );
+    });
+}
+
+#[cfg(any(Py_3_9, not(Py_LIMITED_API)))]
 #[pyclass(dict, subclass)]
 struct DunderDictSupport {
     // Make sure that dict_offset runs with non-zero sized Self

--- a/tests/test_class_init.rs
+++ b/tests/test_class_init.rs
@@ -1,0 +1,353 @@
+#![cfg(feature = "macros")]
+
+use pyo3::{
+    exceptions::PyValueError,
+    prelude::*,
+    types::{IntoPyDict, PyDict, PyTuple},
+};
+
+#[pyclass]
+#[derive(Default)]
+struct EmptyClassWithInit {}
+
+#[pymethods]
+impl EmptyClassWithInit {
+    #[new]
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn new(_args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>) -> Self {
+        EmptyClassWithInit {}
+    }
+
+    fn __init__(&self) {}
+}
+
+#[test]
+fn empty_class_with_init() {
+    Python::with_gil(|py| {
+        let typeobj = py.get_type::<EmptyClassWithInit>();
+        assert!(typeobj
+            .call((), None)
+            .unwrap()
+            .downcast::<EmptyClassWithInit>()
+            .is_ok());
+
+        // Calling with arbitrary args or kwargs is not ok
+        assert!(typeobj.call(("some", "args"), None).is_err());
+        assert!(typeobj
+            .call((), Some(&[("some", "kwarg")].into_py_dict(py).unwrap()))
+            .is_err());
+    });
+}
+
+#[pyclass]
+struct SimpleInit {
+    pub number: u64,
+}
+
+impl Default for SimpleInit {
+    fn default() -> Self {
+        Self { number: 2 }
+    }
+}
+
+#[pymethods]
+impl SimpleInit {
+    #[new]
+    fn new() -> SimpleInit {
+        SimpleInit { number: 1 }
+    }
+
+    fn __init__(&mut self) {
+        assert_eq!(self.number, 2);
+        self.number = 3;
+    }
+}
+
+#[test]
+fn simple_init() {
+    Python::with_gil(|py| {
+        let typeobj = py.get_type::<SimpleInit>();
+        let obj = typeobj.call((), None).unwrap();
+        let obj = obj.downcast::<SimpleInit>().unwrap();
+        assert_eq!(obj.borrow().number, 3);
+
+        // Calling with arbitrary args or kwargs is not ok
+        assert!(typeobj.call(("some", "args"), None).is_err());
+        assert!(typeobj
+            .call((), Some(&[("some", "kwarg")].into_py_dict(py).unwrap()))
+            .is_err());
+    });
+}
+
+#[pyclass]
+struct InitWithTwoArgs {
+    data1: i32,
+    data2: i32,
+}
+
+impl Default for InitWithTwoArgs {
+    fn default() -> Self {
+        Self {
+            data1: 123,
+            data2: 234,
+        }
+    }
+}
+
+#[pymethods]
+impl InitWithTwoArgs {
+    #[new]
+    fn new(arg1: i32, _arg2: i32) -> Self {
+        InitWithTwoArgs {
+            data1: arg1,
+            data2: 0,
+        }
+    }
+
+    fn __init__(&mut self, _arg1: i32, arg2: i32) {
+        assert_eq!(self.data1, 123);
+        assert_eq!(self.data2, 234);
+        self.data2 = arg2;
+    }
+}
+
+#[test]
+fn init_with_two_args() {
+    Python::with_gil(|py| {
+        let typeobj = py.get_type::<InitWithTwoArgs>();
+        let wrp = typeobj
+            .call((10, 20), None)
+            .map_err(|e| e.display(py))
+            .unwrap();
+        let obj = wrp.downcast::<InitWithTwoArgs>().unwrap();
+        let obj_ref = obj.borrow();
+        assert_eq!(obj_ref.data1, 123);
+        assert_eq!(obj_ref.data2, 20);
+
+        assert!(typeobj.call(("a", "b", "c"), None).is_err());
+    });
+}
+
+#[pyclass]
+#[derive(Default)]
+struct InitWithVarArgs {
+    args: Option<String>,
+    kwargs: Option<String>,
+}
+
+#[pymethods]
+impl InitWithVarArgs {
+    #[new]
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn new(_args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>) -> Self {
+        InitWithVarArgs {
+            args: None,
+            kwargs: None,
+        }
+    }
+
+    #[pyo3(signature = (*args, **kwargs))]
+    fn __init__(&mut self, args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, PyDict>>) {
+        self.args = Some(args.to_string());
+        self.kwargs = Some(kwargs.map(|kwargs| kwargs.to_string()).unwrap_or_default());
+    }
+}
+
+#[test]
+fn init_with_var_args() {
+    Python::with_gil(|py| {
+        let typeobj = py.get_type::<InitWithVarArgs>();
+        let kwargs = [("a", 1), ("b", 42)].into_py_dict(py).unwrap();
+        let wrp = typeobj
+            .call((10, 20), Some(&kwargs))
+            .map_err(|e| e.display(py))
+            .unwrap();
+        let obj = wrp.downcast::<InitWithVarArgs>().unwrap();
+        let obj_ref = obj.borrow();
+        assert_eq!(obj_ref.args, Some("(10, 20)".to_owned()));
+        assert_eq!(obj_ref.kwargs, Some("{'a': 1, 'b': 42}".to_owned()));
+    });
+}
+
+#[pyclass(subclass)]
+struct SuperClass {
+    #[pyo3(get)]
+    rust_new: bool,
+    #[pyo3(get)]
+    rust_default: bool,
+    #[pyo3(get)]
+    rust_init: bool,
+}
+
+impl Default for SuperClass {
+    fn default() -> Self {
+        Self {
+            rust_new: false,
+            rust_default: true,
+            rust_init: false,
+        }
+    }
+}
+
+#[pymethods]
+impl SuperClass {
+    #[new]
+    fn new() -> Self {
+        SuperClass {
+            rust_new: true,
+            rust_default: false,
+            rust_init: false,
+        }
+    }
+
+    fn __init__(&mut self) {
+        assert!(!self.rust_new);
+        assert!(self.rust_default);
+        assert!(!self.rust_init);
+        self.rust_init = true;
+    }
+}
+
+#[test]
+fn subclass_init() {
+    Python::with_gil(|py| {
+        let super_cls = py.get_type::<SuperClass>();
+        let source = pyo3_ffi::c_str!(pyo3::indoc::indoc!(
+            r#"
+            class Class(SuperClass):
+                pass
+            c = Class()
+            assert c.rust_new is False  # overridden because __init__ called
+            assert c.rust_default is True
+            assert c.rust_init is True
+
+            class Class(SuperClass):
+                def __init__(self):
+                    self.py_init = True
+            c = Class()
+            assert c.rust_new is True  # not overridden because __init__ not called
+            assert c.rust_default is False
+            assert c.rust_init is False
+            assert c.py_init is True
+
+            class Class(SuperClass):
+                def __init__(self):
+                    super().__init__()
+                    self.py_init = True
+            c = Class()
+            assert c.rust_new is False  # overridden because __init__ called
+            assert c.rust_default is True
+            assert c.rust_init is True
+            assert c.py_init is True
+            "#
+        ));
+        let globals = PyModule::import(py, "__main__").unwrap().dict();
+        globals.set_item("SuperClass", super_cls).unwrap();
+        py.run(source, Some(&globals), None)
+            .map_err(|e| e.display(py))
+            .unwrap();
+    });
+}
+
+#[pyclass(extends=SuperClass)]
+struct SubClass {
+    #[pyo3(get)]
+    rust_subclass_new: bool,
+    #[pyo3(get)]
+    rust_subclass_default: bool,
+    #[pyo3(get)]
+    rust_subclass_init: bool,
+}
+
+impl Default for SubClass {
+    fn default() -> Self {
+        Self {
+            rust_subclass_new: false,
+            rust_subclass_default: true,
+            rust_subclass_init: false,
+        }
+    }
+}
+
+#[pymethods]
+impl SubClass {
+    #[new]
+    fn new() -> (Self, SuperClass) {
+        (
+            SubClass {
+                rust_subclass_new: true,
+                rust_subclass_default: false,
+                rust_subclass_init: false,
+            },
+            SuperClass::new(),
+        )
+    }
+
+    fn __init__(&mut self) {
+        assert!(!self.rust_subclass_new);
+        assert!(self.rust_subclass_default);
+        assert!(!self.rust_subclass_init);
+        self.rust_subclass_init = true;
+    }
+}
+
+#[test]
+fn subclass_pyclass_init() {
+    Python::with_gil(|py| {
+        let sub_cls = py.get_type::<SubClass>();
+        let source = pyo3_ffi::c_str!(pyo3::indoc::indoc!(
+            r#"
+            c = SubClass()
+            assert c.rust_new is True
+            assert c.rust_default is False
+            assert c.rust_init is False
+            assert c.rust_subclass_new is False  # overridden by calling __init__
+            assert c.rust_subclass_default is True
+            assert c.rust_subclass_init is True
+            "#
+        ));
+        let globals = PyModule::import(py, "__main__").unwrap().dict();
+        globals.set_item("SubClass", sub_cls).unwrap();
+        py.run(source, Some(&globals), None)
+            .map_err(|e| e.display(py))
+            .unwrap();
+    });
+}
+
+#[pyclass]
+#[derive(Debug, Default)]
+struct InitWithCustomError {}
+
+struct CustomError;
+
+impl From<CustomError> for PyErr {
+    fn from(_error: CustomError) -> PyErr {
+        PyValueError::new_err("custom error")
+    }
+}
+
+#[pymethods]
+impl InitWithCustomError {
+    #[new]
+    fn new(_should_raise: bool) -> InitWithCustomError {
+        InitWithCustomError {}
+    }
+
+    fn __init__(&self, should_raise: bool) -> Result<(), CustomError> {
+        if should_raise {
+            Err(CustomError)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[test]
+fn init_with_custom_error() {
+    Python::with_gil(|py| {
+        let typeobj = py.get_type::<InitWithCustomError>();
+        typeobj.call((false,), None).unwrap();
+        let err = typeobj.call((true,), None).unwrap_err();
+        assert_eq!(err.to_string(), "ValueError: custom error");
+    });
+}

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -46,6 +46,7 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/not_send.rs");
     t.compile_fail("tests/ui/not_send2.rs");
     t.compile_fail("tests/ui/get_set_all.rs");
+    t.compile_fail("tests/ui/init_without_default.rs");
     t.compile_fail("tests/ui/traverse.rs");
     t.compile_fail("tests/ui/invalid_pymodule_in_root.rs");
     t.compile_fail("tests/ui/invalid_pymodule_glob.rs");

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -192,16 +192,14 @@ mod inheriting_type {
 
         #[pymethods]
         impl Metaclass {
-            #[new]
-            #[pyo3(signature = (*args, **kwds))]
-            fn new<'py>(
-                py: Python<'py>,
-                args: &Bound<'py, PyTuple>,
-                kwds: Option<&Bound<'py, PyDict>>,
-            ) -> PyResult<Bound<'py, Self>> {
-                let type_object = PyType::new_type::<Metaclass>(py, args, kwds)?;
-                type_object.setattr("some_var", 123)?;
-                Ok(type_object)
+            #[pyo3(signature = (*_args, **_kwargs))]
+            fn __init__(
+                slf: Bound<'_, Metaclass>,
+                _args: Bound<'_, PyTuple>,
+                _kwargs: Option<Bound<'_, PyDict>>,
+            ) -> PyResult<()> {
+                slf.as_any().setattr("some_var", 123)?;
+                Ok(())
             }
 
             fn __getitem__(&self, item: u64) -> u64 {

--- a/tests/test_variable_sized_class_basics.rs
+++ b/tests/test_variable_sized_class_basics.rs
@@ -1,0 +1,60 @@
+#![cfg(all(Py_3_12, feature = "macros"))]
+
+use std::any::TypeId;
+
+use pyo3::impl_::pycell::PyVariableClassObject;
+use pyo3::impl_::pyclass::PyClassImpl;
+use pyo3::py_run;
+use pyo3::types::{PyDict, PyInt, PyTuple};
+use pyo3::{prelude::*, types::PyType};
+
+#[path = "../src/tests/common.rs"]
+mod common;
+
+fn uses_variable_layout<T: PyClassImpl>() -> bool {
+    TypeId::of::<T::Layout>() == TypeId::of::<PyVariableClassObject<T>>()
+}
+
+#[pyclass(extends=PyType)]
+#[derive(Default)]
+struct ClassWithObjectField {
+    #[pyo3(get, set)]
+    value: Option<PyObject>,
+}
+
+#[pymethods]
+impl ClassWithObjectField {
+    #[pyo3(signature = (*_args, **_kwargs))]
+    fn __init__(
+        _slf: Bound<'_, ClassWithObjectField>,
+        _args: Bound<'_, PyTuple>,
+        _kwargs: Option<Bound<'_, PyDict>>,
+    ) {
+    }
+}
+
+#[test]
+fn class_with_object_field() {
+    Python::with_gil(|py| {
+        let ty = py.get_type::<ClassWithObjectField>();
+        assert!(uses_variable_layout::<ClassWithObjectField>());
+        py_run!(
+            py,
+            ty,
+            "x = ty('X', (), {}); x.value = 5; assert x.value == 5"
+        );
+        py_run!(
+            py,
+            ty,
+            "x = ty('X', (), {}); x.value = None; assert x.value == None"
+        );
+
+        let obj = Bound::new(py, ClassWithObjectField { value: None }).unwrap();
+        py_run!(py, obj, "obj.value = 5");
+        let obj_ref = obj.borrow();
+        let Some(value) = &obj_ref.value else {
+            panic!("obj_ref.value is None");
+        };
+        assert_eq!(*value.downcast_bound::<PyInt>(py).unwrap(), 5);
+    });
+}

--- a/tests/ui/abi3_inheritance.stderr
+++ b/tests/ui/abi3_inheritance.stderr
@@ -1,20 +1,4 @@
 error[E0277]: pyclass `PyException` cannot be subclassed
- --> tests/ui/abi3_inheritance.rs:4:19
-  |
-4 | #[pyclass(extends=PyException)]
-  |                   ^^^^^^^^^^^ required for `#[pyclass(extends=PyException)]`
-  |
-  = help: the trait `PyClassBaseType` is not implemented for `PyException`
-  = note: `PyException` must have `#[pyclass(subclass)]` to be eligible for subclassing
-  = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
-  = help: the trait `PyClassBaseType` is implemented for `PyAny`
-note: required by a bound in `PyClassImpl::BaseType`
- --> src/impl_/pyclass.rs
-  |
-  |     type BaseType: PyTypeInfo + PyClassBaseType;
-  |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`
-
-error[E0277]: pyclass `PyException` cannot be subclassed
  --> tests/ui/abi3_inheritance.rs:4:1
   |
 4 | #[pyclass(extends=PyException)]
@@ -23,5 +7,25 @@ error[E0277]: pyclass `PyException` cannot be subclassed
   = help: the trait `PyClassBaseType` is not implemented for `PyException`
   = note: `PyException` must have `#[pyclass(subclass)]` to be eligible for subclassing
   = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
-  = help: the trait `PyClassBaseType` is implemented for `PyAny`
+  = help: the following other types implement trait `PyClassBaseType`:
+            PyAny
+            PyType
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: pyclass `PyException` cannot be subclassed
+ --> tests/ui/abi3_inheritance.rs:4:19
+  |
+4 | #[pyclass(extends=PyException)]
+  |                   ^^^^^^^^^^^ required for `#[pyclass(extends=PyException)]`
+  |
+  = help: the trait `PyClassBaseType` is not implemented for `PyException`
+  = note: `PyException` must have `#[pyclass(subclass)]` to be eligible for subclassing
+  = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
+  = help: the following other types implement trait `PyClassBaseType`:
+            PyAny
+            PyType
+note: required by a bound in `PyClassImpl::BaseType`
+ --> src/impl_/pyclass.rs
+  |
+  |     type BaseType: PyTypeInfo + PyClassBaseType;
+  |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`

--- a/tests/ui/abi3_nativetype_inheritance.stderr
+++ b/tests/ui/abi3_nativetype_inheritance.stderr
@@ -1,20 +1,4 @@
 error[E0277]: pyclass `PyDict` cannot be subclassed
- --> tests/ui/abi3_nativetype_inheritance.rs:5:19
-  |
-5 | #[pyclass(extends=PyDict)]
-  |                   ^^^^^^ required for `#[pyclass(extends=PyDict)]`
-  |
-  = help: the trait `PyClassBaseType` is not implemented for `PyDict`
-  = note: `PyDict` must have `#[pyclass(subclass)]` to be eligible for subclassing
-  = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
-  = help: the trait `PyClassBaseType` is implemented for `PyAny`
-note: required by a bound in `PyClassImpl::BaseType`
- --> src/impl_/pyclass.rs
-  |
-  |     type BaseType: PyTypeInfo + PyClassBaseType;
-  |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`
-
-error[E0277]: pyclass `PyDict` cannot be subclassed
  --> tests/ui/abi3_nativetype_inheritance.rs:5:1
   |
 5 | #[pyclass(extends=PyDict)]
@@ -23,5 +7,25 @@ error[E0277]: pyclass `PyDict` cannot be subclassed
   = help: the trait `PyClassBaseType` is not implemented for `PyDict`
   = note: `PyDict` must have `#[pyclass(subclass)]` to be eligible for subclassing
   = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
-  = help: the trait `PyClassBaseType` is implemented for `PyAny`
+  = help: the following other types implement trait `PyClassBaseType`:
+            PyAny
+            PyType
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: pyclass `PyDict` cannot be subclassed
+ --> tests/ui/abi3_nativetype_inheritance.rs:5:19
+  |
+5 | #[pyclass(extends=PyDict)]
+  |                   ^^^^^^ required for `#[pyclass(extends=PyDict)]`
+  |
+  = help: the trait `PyClassBaseType` is not implemented for `PyDict`
+  = note: `PyDict` must have `#[pyclass(subclass)]` to be eligible for subclassing
+  = note: with the `abi3` feature enabled, PyO3 does not support subclassing native types
+  = help: the following other types implement trait `PyClassBaseType`:
+            PyAny
+            PyType
+note: required by a bound in `PyClassImpl::BaseType`
+ --> src/impl_/pyclass.rs
+  |
+  |     type BaseType: PyTypeInfo + PyClassBaseType;
+  |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`

--- a/tests/ui/init_without_default.rs
+++ b/tests/ui/init_without_default.rs
@@ -1,0 +1,11 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+struct MyClass {}
+
+#[pymethods]
+impl MyClass {
+    fn __init__(&self) {}
+}
+
+fn main() {}

--- a/tests/ui/init_without_default.stderr
+++ b/tests/ui/init_without_default.stderr
@@ -1,0 +1,16 @@
+error[E0277]: the trait bound `MyClass: Default` is not satisfied
+ --> tests/ui/init_without_default.rs:7:6
+  |
+7 | impl MyClass {
+  |      ^^^^^^^ the trait `Default` is not implemented for `MyClass`
+  |
+note: required by a bound in `initialize_with_default`
+ --> src/impl_/pyclass_init.rs
+  |
+  | pub unsafe fn initialize_with_default<T: PyClassImpl + Default>(obj: *mut ffi::PyObject) {
+  |                                                        ^^^^^^^ required by this bound in `initialize_with_default`
+help: consider annotating `MyClass` with `#[derive(Default)]`
+  |
+4  + #[derive(Default)]
+5  | struct MyClass {}
+   |

--- a/tests/ui/invalid_base_class.stderr
+++ b/tests/ui/invalid_base_class.stderr
@@ -1,4 +1,24 @@
 error[E0277]: pyclass `PyBool` cannot be subclassed
+ --> tests/ui/invalid_base_class.rs:4:1
+  |
+4 | #[pyclass(extends=PyBool)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required for `#[pyclass(extends=PyBool)]`
+  |
+  = help: the trait `PyClassBaseType` is not implemented for `PyBool`
+  = note: `PyBool` must have `#[pyclass(subclass)]` to be eligible for subclassing
+  = help: the following other types implement trait `PyClassBaseType`:
+            PyAny
+            PyArithmeticError
+            PyAssertionError
+            PyAttributeError
+            PyBaseException
+            PyBaseExceptionGroup
+            PyBlockingIOError
+            PyBrokenPipeError
+          and $N others
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: pyclass `PyBool` cannot be subclassed
  --> tests/ui/invalid_base_class.rs:4:19
   |
 4 | #[pyclass(extends=PyBool)]
@@ -21,23 +41,3 @@ note: required by a bound in `PyClassImpl::BaseType`
   |
   |     type BaseType: PyTypeInfo + PyClassBaseType;
   |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`
-
-error[E0277]: pyclass `PyBool` cannot be subclassed
- --> tests/ui/invalid_base_class.rs:4:1
-  |
-4 | #[pyclass(extends=PyBool)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ required for `#[pyclass(extends=PyBool)]`
-  |
-  = help: the trait `PyClassBaseType` is not implemented for `PyBool`
-  = note: `PyBool` must have `#[pyclass(subclass)]` to be eligible for subclassing
-  = help: the following other types implement trait `PyClassBaseType`:
-            PyAny
-            PyArithmeticError
-            PyAssertionError
-            PyAttributeError
-            PyBaseException
-            PyBaseExceptionGroup
-            PyBlockingIOError
-            PyBrokenPipeError
-          and $N others
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR introduces the capability to inherit from classes where the exact layout/size is not known using the mechanism described in [PEP 697](https://peps.python.org/pep-0697/). This allows inheriting from `type` in order to create metaclasses. These metaclasses cannot yet be used with pyo3 classes (i.e. `#[pyclass(metaclass=Foo)]`) but this should be a possibility in future. It may also be possible in future for pyo3 classes to extend builtin classes using the limited API and to potentially extend imported classes (eg `enum.EnumType`).

This PR supersedes my first attempt at creating metaclasses: <https://github.com/PyO3/pyo3/pull/4621>. Previously I was using the normal class layout which relies on the exact layout of every base class to be known. For `type` the base structure is `ffi::PyHeapTypeObject`. The contents of this structure are intended to be private (even for the 'unlimited' API) and so an alternative mechanism is required (PEP 697).

Instead of nesting each base class at the beginning of the derived class in memory, objects created with PEP 697 only require knowledge of how much additional memory the derived class requires and the address of this section of memory is accessed via [PyObject_GetTypeData](https://docs.python.org/3.12/c-api/object.html#c.PyObject_GetTypeData). The PEP 697 mechanism could potentially be used to inherit from other builtins when only the 'limited' API is available however many of these builtins also store items (eg `list`, `set`) which introduces more complications, so this PR focuses on inheriting from `PyType` only.

This PR is a proof of concept but I am sure that some of the decisions I made aren't the best so feedback is welcome. The current design is as follows:

Before this PR the only possible layout was the 'static' layout where the size of the base class is known. This layout was described by `PyClassObject<T>` (now renamed to `PyStaticClassObject`). This PR introduces hides the details of the static layout behind a trait `InternalPyClassObjectLayout` so that other layouts are possible.

Before this PR: `PyClassObject<T>` was used to obtain the exact layout of `T: PyClassImpl` assuming that layout is the 'static' layout. This PR introduces `PyClassImpl::Layout` so that a pyclass declares its layout. The pyclass uses `PyTypeInfo::Layout` to set `T::Layout`. Each base type declares either `PyTypeInfo::Layout = PyStaticClassObject` or `PyTypeInfo::Layout = PyVariableClassObject`.

## Potential Improvements
Some questions still remain:

- how best to handle initialisation (see below)
    - using the `__init__` approach, how to initialise super classes?
    - using the `__init__` approach, how to restrict return value to `()` or `PyResult<()>`?
- how to handle subclassing variable sized pyclasses
    - I tried writing some unit tests that inherited from `type -> MyMetaclass -> MySubMetaclass` but I think there are some outstanding problems. I also am not sure how to prevent users from doing this so I have left it for now.
        - problems encountered: `setattr` works without using `#[pyclass(dict)]` but the set values aren't accessible in the subclass
        - values are not as expected after initialisation, perhaps only the subclass data is getting initialised?
- for some reason using `setattr` on a class extending `type` does not fail, unlike on a class extending `object`. I'm not sure if this means `type` has `__dict__` already?

### Initialisation
I'm not sure what the best way is to handle initialisation. `tp_new` cannot be used with metaclasses ([source](https://docs.python.org/3/c-api/type.html#c.PyType_FromMetaclass)) however the best semantics of `__init__` aren't clear. For now I am requiring that metaclasses implement `Default` which allows the struct to be initialised before `__init__` is called (but this is a hack and may have issues properly initialising superclasses). There are runtime checks when a class is constructed that metaclasses do not define `#[new]` and do define `__init__`. This should be sufficient to ensure that users cannot create a struct with uninitialized memory.

An alternative to using `__init__` could be to repurpose `#[new]` to wrap it and assign it to `tp_init` instead in the case of a metaclass but that would be more complex to implement.

