### PR TITLE
release: 0.22.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ To see unreleased changes, please see the [CHANGELOG on the main branch guide](h
 
 <!-- towncrier release notes start -->
 
+## [0.22.6] - 2024-11-05
+
+### Fixed
+
+- Fix detection of freethreaded Python 3.13t added in PyO3 0.22.2; freethreaded is not yet supported (support coming soon in 0.23). [#4684](https://github.com/PyO3/pyo3/pull/4684)
+
 ## [0.22.5] - 2024-10-15
 
 ### Fixed
@@ -1901,7 +1907,8 @@ Yanked
 
 - Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.22.5...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.22.6...HEAD
+[0.22.6]: https://github.com/pyo3/pyo3/compare/v0.22.5...v0.22.6
 [0.22.5]: https://github.com/pyo3/pyo3/compare/v0.22.4...v0.22.5
 [0.22.4]: https://github.com/pyo3/pyo3/compare/v0.22.3...v0.22.4
 [0.22.3]: https://github.com/pyo3/pyo3/compare/v0.22.2...v0.22.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.22.5"
+version = "0.22.6"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -21,10 +21,10 @@ memoffset = "0.9"
 once_cell = "1.13"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.22.5" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.22.6" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.22.5", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.22.6", optional = true }
 indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
@@ -64,7 +64,7 @@ futures = "0.3.28"
 static_assertions = "1.1.0"
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "=0.22.5", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "=0.22.6", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.22.5", features = ["extension-module"] }
+pyo3 = { version = "0.22.6", features = ["extension-module"] }
 ```
 
 **`src/lib.rs`**
@@ -137,7 +137,7 @@ Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like th
 
 ```toml
 [dependencies.pyo3]
-version = "0.22.5"
+version = "0.22.6"
 features = ["auto-initialize"]
 ```
 

--- a/examples/decorator/.template/pre-script.rhai
+++ b/examples/decorator/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.5");
+variable::set("PYO3_VERSION", "0.22.6");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/maturin-starter/.template/pre-script.rhai
+++ b/examples/maturin-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.5");
+variable::set("PYO3_VERSION", "0.22.6");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/plugin/.template/pre-script.rhai
+++ b/examples/plugin/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.5");
+variable::set("PYO3_VERSION", "0.22.6");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/plugin_api/Cargo.toml", "plugin_api/Cargo.toml");
 file::delete(".template");

--- a/examples/setuptools-rust-starter/.template/pre-script.rhai
+++ b/examples/setuptools-rust-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.5");
+variable::set("PYO3_VERSION", "0.22.6");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/setup.cfg", "setup.cfg");
 file::delete(".template");

--- a/examples/string-sum/src/lib.rs
+++ b/examples/string-sum/src/lib.rs
@@ -52,6 +52,7 @@ unsafe fn parse_arg_as_i32(obj: *mut PyObject, n_arg: usize) -> Option<i32> {
     let mut overflow = 0;
     let i_long: c_long = PyLong_AsLongAndOverflow(obj, &mut overflow);
 
+    #[allow(irrefutable_let_patterns)] // some platforms have c_long equal to i32
     if overflow != 0 {
         raise_overflowerror(obj);
         None

--- a/examples/word-count/.template/pre-script.rhai
+++ b/examples/word-count/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.22.5");
+variable::set("PYO3_VERSION", "0.22.6");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.22.5"
+version = "0.22.6"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.22.5"
+version = "0.22.6"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -41,7 +41,7 @@ generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 paste = "1"
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.5", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.6", features = ["resolve-config"] }
 
 [lints]
 workspace = true

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.22.5"
+version = "0.22.6"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,7 +16,7 @@ edition = "2021"
 [dependencies]
 heck = "0.5"
 proc-macro2 = { version = "1.0.60", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.5", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.6", features = ["resolve-config"] }
 quote = { version = "1", default-features = false }
 
 [dependencies.syn]
@@ -25,7 +25,7 @@ default-features = false
 features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits"]
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.5" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.22.6" }
 
 [lints]
 workspace = true

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.22.5"
+version = "0.22.6"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -22,7 +22,7 @@ gil-refs = ["pyo3-macros-backend/gil-refs"]
 proc-macro2 = { version = "1.0.60", default-features = false }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.22.5" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.22.6" }
 
 [lints]
 workspace = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "0.22.5"
+version = "0.22.6"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"

--- a/tests/ui/reject_generics.stderr
+++ b/tests/ui/reject_generics.stderr
@@ -1,10 +1,10 @@
-error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.22.5/class.html#no-generic-parameters
+error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.22.6/class.html#no-generic-parameters
  --> tests/ui/reject_generics.rs:4:25
   |
 4 | struct ClassWithGenerics<A> {
   |                         ^
 
-error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.22.5/class.html#no-lifetime-parameters
+error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.22.6/class.html#no-lifetime-parameters
  --> tests/ui/reject_generics.rs:9:27
   |
 9 | struct ClassWithLifetimes<'a> {


### PR DESCRIPTION
This fixes the detection of freethreaded Python on the 0.22 release branch, and bumps the version to 0.22.6 for shipping immediately.

Given 0.23 is days away, hopefully this is the last 0.22 patch fix (though I said that last time, and maybe the time before).

@ngoldbaum I tested this locally, would you mind pulling and also checking locally? I think if we are both happy this works, that's good enough given the branch is likely to remain frozen hereafter.

Closes #4682 