### PR TITLE
Remove warning that's a bit outdated

### DIFF
--- a/guide/src/index.md
+++ b/guide/src/index.md
@@ -10,15 +10,6 @@ The rough order of material in this user guide is as follows:
 
 Please choose from the chapters on the left to jump to individual topics, or continue below to start with PyO3's README.
 
-<div class="warning">
-
-⚠️ Warning: API update in progress 🛠️
-
-PyO3 0.21 has introduced a significant new API, termed the "Bound" API after the new smart pointer `Bound<T>`.
-
-While most of this guide has been updated to the new API, it is possible some stray references to the older "GIL Refs" API such as `&PyAny` remain.
-</div>
-
 <hr style="opacity:0.2">
 
 {{#include ../../README.md}}


### PR DESCRIPTION
I'm reasonably that at this point we've updated all the examples
