### PR TITLE
simplify a few uses of `BoundObject`

### DIFF
--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -137,14 +137,13 @@ impl Coroutine {
     }
 
     #[getter]
-    fn __qualname__(&self, py: Python<'_>) -> PyResult<Py<PyString>> {
+    fn __qualname__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
         match (&self.name, &self.qualname_prefix) {
-            (Some(name), Some(prefix)) => format!("{}.{}", prefix, name.bind(py).to_cow()?)
-                .as_str()
-                .into_pyobject(py)
-                .map(BoundObject::unbind)
-                .map_err(Into::into),
-            (Some(name), None) => Ok(name.clone_ref(py)),
+            (Some(name), Some(prefix)) => Ok(PyString::new(
+                py,
+                &format!("{}.{}", prefix, name.bind(py).to_cow()?),
+            )),
+            (Some(name), None) => Ok(name.bind(py).clone()),
             (None, _) => Err(PyAttributeError::new_err("__qualname__")),
         }
     }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -290,7 +290,7 @@ impl MethSignature {
             kwargs.into_pyobject(py)?.into_any().into_bound(),
         ]
         .into_pyobject(py)
-        .map(BoundObject::unbind)
+        .map(Bound::unbind)
     }
 
     #[pyo3(signature = (a=0, /, **kwargs))]
@@ -305,7 +305,7 @@ impl MethSignature {
             kwargs.into_pyobject(py)?.into_any().into_bound(),
         ]
         .into_pyobject(py)
-        .map(BoundObject::unbind)
+        .map(Bound::unbind)
     }
 
     #[pyo3(signature = (*, a = 2, b = 3))]
@@ -333,7 +333,7 @@ impl MethSignature {
         (args, a)
             .into_pyobject(py)
             .map(BoundObject::into_any)
-            .map(BoundObject::unbind)
+            .map(Bound::unbind)
     }
 
     #[pyo3(signature = (a, b = 2, *, c = 3))]
@@ -358,7 +358,7 @@ impl MethSignature {
             kwargs.into_pyobject(py)?.into_any().into_bound(),
         ]
         .into_pyobject(py)
-        .map(BoundObject::unbind)
+        .map(Bound::unbind)
     }
 
     // "args" can be anything that can be extracted from PyTuple

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -329,7 +329,7 @@ fn ext_vararg_fn(py: Python<'_>, a: i32, args: &Bound<'_, PyTuple>) -> PyResult<
         args.as_any().clone(),
     ]
     .into_pyobject(py)
-    .map(BoundObject::unbind)
+    .map(Bound::unbind)
 }
 
 #[pymodule]


### PR DESCRIPTION
Just spotted a few places where we were using  `BoundObject` internally where we didn't need to.