### PR TITLE
fix `clippy::wildcard_import` firing on `#[pyclass]`

### DIFF
--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2322,11 +2322,11 @@ impl<'a> PyClassImplsBuilder<'a> {
         let assertions = if attr.options.unsendable.is_some() {
             TokenStream::new()
         } else {
-            quote_spanned! {
-                cls.span() =>
+            let assert = quote_spanned! { cls.span() => assert_pyclass_sync::<#cls>(); };
+            quote! {
                 const _: () = {
                     use #pyo3_path::impl_::pyclass::*;
-                    assert_pyclass_sync::<#cls>();
+                    #assert
                 };
             }
         };


### PR DESCRIPTION
Closes #4701 
