### PR TITLE
docs: Don't try to build `gil-refs` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ members = [
 
 [package.metadata.docs.rs]
 no-default-features = true
-features = ["full", "gil-refs"]
+features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace.lints.clippy]


### PR DESCRIPTION
Build for v0.23.0 docs is currently failing (https://docs.rs/crate/pyo3/0.23.0/builds/1542136)
