### PR TITLE
Free-threaded build config fixes

### DIFF
--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -108,6 +108,15 @@ using single-phase initialization and the
 [`sequential`](https://github.com/PyO3/pyo3/tree/main/pyo3-ffi/examples/sequential)
 example for modules using multi-phase initialization.
 
+If you would like to use conditional compilation to trigger different code paths
+under the free-threaded build, you can use the `Py_GIL_DISABLED` attribute once
+you have configured your crate to generate the necessary build configuration
+data. See [the guide
+section](./building-and-distribution/multiple-python-versions.md) for more
+details about supporting multiple different Python versions, including the
+free-threaded build.
+
+
 ## Special considerations for the free-threaded build
 
 The free-threaded interpreter does not have a GIL, and this can make interacting
@@ -234,7 +243,24 @@ needed. For now you should explicitly add locking, possibly using conditional
 compilation or using the critical section API to avoid creating deadlocks with
 the GIL.
 
-## Thread-safe single initialization
+### Cannot build extensions using the limited API
+
+The free-threaded build uses a completely new ABI and there is not yet an
+equivalent to the limited API for the free-threaded ABI. That means if your
+crate depends on PyO3 using the `abi3` feature or an an `abi-pyxx` feature, PyO3
+will print a warning and ignore that setting when building extensions using the
+free-threaded interpreter.
+
+This means that if your package makes use of the ABI forward compatibility
+provided by the limited API to uploads only one wheel for each release of your
+package, you will need to update and tooling or instructions to also upload a
+version-specific free-threaded wheel.
+
+See [the guide section](./building-and-distribution/multiple-python-versions.md)
+for more details about supporting multiple different Python versions, including
+the free-threaded build.
+
+### Thread-safe single initialization
 
 Until version 0.23, PyO3 provided only [`GILOnceCell`] to enable deadlock-free
 single initialization of data in contexts that might execute arbitrary Python

--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -247,9 +247,9 @@ the GIL.
 
 The free-threaded build uses a completely new ABI and there is not yet an
 equivalent to the limited API for the free-threaded ABI. That means if your
-crate depends on PyO3 using the `abi3` feature or an an `abi-pyxx` feature, PyO3
-will print a warning and ignore that setting when building extensions using the
-free-threaded interpreter.
+crate depends on PyO3 using the `abi3` feature or an an `abi3-pyxx` feature,
+PyO3 will print a warning and ignore that setting when building extensions using
+the free-threaded interpreter.
 
 This means that if your package makes use of the ABI forward compatibility
 provided by the limited API to uploads only one wheel for each release of your

--- a/newsfragments/4719.fixed.md
+++ b/newsfragments/4719.fixed.md
@@ -1,1 +1,2 @@
-* Building extensions for the free-threaded ABI using Pythons ABIs older than 3.13 will now panic.
+* Fixed an issue that prevented building free-threaded extensions for crates
+  that request a specific minimum limited API version.

--- a/newsfragments/4719.fixed.md
+++ b/newsfragments/4719.fixed.md
@@ -1,0 +1,1 @@
+* Building extensions for the free-threaded ABI using Pythons ABIs older than 3.13 will now panic.

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1650,9 +1650,6 @@ fn default_lib_name_windows(
         // https://github.com/python/cpython/issues/101614
         format!("python{}{}_d", version.major, version.minor)
     } else if abi3 && !(implementation.is_pypy() || implementation.is_graalpy()) {
-        if gil_disabled {
-            panic!("Free-threaded ABI does not support limited API extensions");
-        }
         if debug {
             WINDOWS_ABI3_DEBUG_LIB_NAME.to_owned()
         } else {
@@ -2511,35 +2508,6 @@ mod tests {
                 },
                 CPython,
                 false,
-                false,
-                false,
-                true,
-            )
-        })
-        .is_err());
-        // abi3 and free-threading are incompatible
-        assert!(std::panic::catch_unwind(|| {
-            super::default_lib_name_windows(
-                PythonVersion {
-                    major: 3,
-                    minor: 12,
-                },
-                CPython,
-                true,
-                false,
-                false,
-                true,
-            )
-        })
-        .is_err());
-        assert!(std::panic::catch_unwind(|| {
-            super::default_lib_name_windows(
-                PythonVersion {
-                    major: 3,
-                    minor: 13,
-                },
-                CPython,
-                true,
                 false,
                 false,
                 true,

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -660,10 +660,14 @@ print("gil_disabled", get_config_var("Py_GIL_DISABLED"))
         )
     }
 
-    /// Lowers the configured version to the abi3 version, if set.
+    /// Updates configured ABI to build for to the requested abi3 version
+    /// This is a no-op for platforms where abi3 is not supported
     fn fixup_for_abi3_version(&mut self, abi3_version: Option<PythonVersion>) -> Result<()> {
-        // PyPy doesn't support abi3; don't adjust the version
-        if self.implementation.is_pypy() || self.implementation.is_graalpy() {
+        // PyPy, GraalPy, and the free-threaded build don't support abi3; don't adjust the version
+        if self.implementation.is_pypy()
+            || self.implementation.is_graalpy()
+            || self.build_flags.0.contains(&BuildFlag::Py_GIL_DISABLED)
+        {
             return Ok(());
         }
 

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1662,7 +1662,7 @@ fn default_lib_name_windows(
         // https://packages.msys2.org/base/mingw-w64-python
         format!("python{}.{}", version.major, version.minor)
     } else if gil_disabled {
-        if version.major <= 3 && version.minor < 13 {
+        if version < PythonVersion::PY313 {
             panic!("Cannot compile C extensions for the free-threaded build on Python versions earlier than 3.13, found {}.{}", version.major, version.minor);
         }
         if debug {

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -2507,7 +2507,7 @@ mod tests {
             .unwrap(),
             "python3_d",
         );
-        // Python versions older than 3.13 panic if gil_disabled is true
+        // Python versions older than 3.13 don't support gil_disabled
         assert!(super::default_lib_name_windows(
             PythonVersion {
                 major: 3,

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -695,7 +695,10 @@ impl PythonVersion {
         major: 3,
         minor: 13,
     };
-    #[allow(dead_code)]
+    const PY310: Self = PythonVersion {
+        major: 3,
+        minor: 10,
+    };
     const PY37: Self = PythonVersion { major: 3, minor: 7 };
 }
 
@@ -1645,7 +1648,7 @@ fn default_lib_name_windows(
     debug: bool,
     gil_disabled: bool,
 ) -> String {
-    if debug && version.minor < 10 {
+    if debug && version < PythonVersion::PY310 {
         // CPython bug: linking against python3_d.dll raises error
         // https://github.com/python/cpython/issues/101614
         format!("python{}{}_d", version.major, version.minor)
@@ -1688,6 +1691,7 @@ fn default_lib_name_unix(
             Some(ld_version) => format!("python{}", ld_version),
             None => {
                 if version > PythonVersion::PY37 {
+                    // PEP 3149 ABI version tags are finally gone
                     if gil_disabled {
                         if version < PythonVersion::PY313 {
                             panic!("Cannot compile C extensions for the free-threaded build on Python versions earlier than 3.13, found {}.{}", version.major, version.minor);

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -113,11 +113,7 @@ fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
     if interpreter_config.abi3 {
         match interpreter_config.implementation {
             PythonImplementation::CPython => {
-                if interpreter_config
-                    .build_flags
-                    .0
-                    .contains(&BuildFlag::Py_GIL_DISABLED)
-                {
+                if interpreter_config.is_free_threaded() {
                     warn!(
                             "The free-threaded build of CPython does not yet support abi3 so the build artifacts will be version-specific."
                     )

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -118,16 +118,9 @@ fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
                     .0
                     .contains(&BuildFlag::Py_GIL_DISABLED)
                 {
-                    let version = interpreter_config.version;
-                    if version < PythonVersion::PY313 {
-                        panic!(
-                            "The free-threaded ABI is not defined for versions older than 3.13, tried to build using Python {}.{} ABI", version.major, version.minor
-                        );
-                    } else {
-                        warn!(
+                    warn!(
                             "The free-threaded build of CPython does not yet support abi3 so the build artifacts will be version-specific."
-                        )
-                    }
+                    )
                 }
             }
             PythonImplementation::PyPy => warn!(

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -1,11 +1,10 @@
 use pyo3_build_config::{
     bail, ensure, print_feature_cfgs,
     pyo3_build_script_impl::{
-        cargo_env_var, env_var,
-        errors::{Error, Result},
-        is_linking_libpython, resolve_interpreter_config, InterpreterConfig, PythonVersion,
+        cargo_env_var, env_var, errors::Result, is_linking_libpython, resolve_interpreter_config,
+        InterpreterConfig, PythonVersion,
     },
-    warn, BuildFlag, PythonImplementation,
+    warn, PythonImplementation,
 };
 
 /// Minimum Python version PyO3 supports.

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -112,9 +112,16 @@ fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
                     .0
                     .contains(&BuildFlag::Py_GIL_DISABLED)
                 {
-                    warn!(
+                    let version = interpreter_config.version;
+                    if version < PythonVersion::PY313 {
+                        panic!(
+                            "The free-threaded ABI is not defined for versions older than 3.13, tried to build using Python {}.{} ABI", version.major, version.minor
+                        );
+                    } else {
+                        warn!(
                             "The free-threaded build of CPython does not yet support abi3 so the build artifacts will be version-specific."
                         )
+                    }
                 }
             }
             PythonImplementation::PyPy => warn!(

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -56,15 +56,21 @@ fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
                 interpreter_config.version,
                 versions.min,
             );
-            ensure!(
-                interpreter_config.version <= versions.max || env_var("PYO3_USE_ABI3_FORWARD_COMPATIBILITY").map_or(false, |os_str| os_str == "1"),
-                "the configured Python interpreter version ({}) is newer than PyO3's maximum supported version ({})\n\
-                 = help: please check if an updated version of PyO3 is available. Current version: {}\n\
-                 = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI",
-                interpreter_config.version,
-                versions.max,
-                std::env::var("CARGO_PKG_VERSION").unwrap(),
-            );
+            if !interpreter_config
+                .build_flags
+                .0
+                .contains(&BuildFlag::Py_GIL_DISABLED)
+            {
+                ensure!(
+                        interpreter_config.version <= versions.max || env_var("PYO3_USE_ABI3_FORWARD_COMPATIBILITY").map_or(false, |os_str| os_str == "1"),
+                        "the configured Python interpreter version ({}) is newer than PyO3's maximum supported version ({})\n\
+                         = help: please check if an updated version of PyO3 is available. Current version: {}\n\
+                         = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI",
+                        interpreter_config.version,
+                        versions.max,
+                        std::env::var("CARGO_PKG_VERSION").unwrap(),
+                    );
+            }
         }
         PythonImplementation::PyPy => {
             let versions = SUPPORTED_VERSIONS_PYPY;


### PR DESCRIPTION
Fixes #4709.

Trying to get a library name or build pyo3-ffi against a free-threaded ABI for Python earlier than 3.13 now panics.

Also adds tests for the panics and for the free-threaded library names as followup for #4690 where I ran out of steam to add new tests.

While working on this I noticed that there was code to work around https://github.com/python/cpython/issues/101614 which was fixed in CPython for 3.10 and newer, so I modified the workaround code path to only apply for Python 3.9 and older.