### PR TITLE
Introducing PyO3 Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![minimum rustc 1.63](https://img.shields.io/badge/rustc-1.63+-blue?logo=rust)](https://rust-lang.github.io/rfcs/2495-min-rust-version.html)
 [![discord server](https://img.shields.io/discord/1209263839632424990?logo=discord)](https://discord.gg/33kcChzH7f)
 [![contributing notes](https://img.shields.io/badge/contribute-on%20github-Green?logo=github)](https://github.com/PyO3/pyo3/blob/main/Contributing.md)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20PyO3%20Guru-006BFF)](https://gurubase.io/g/pyo3)
 
 [Rust](https://www.rust-lang.org/) bindings for [Python](https://www.python.org/), including tools for creating native Python extension modules. Running and interacting with Python code from a Rust binary is also supported.
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [PyO3 Guru](https://gurubase.io/g/pyo3) to Gurubase. PyO3 Guru uses the data from this repo and data from the [docs](https://pyo3.rs) to answer questions by leveraging the LLM.

In this PR, I showcased the "PyO3 Guru", which highlights that PyO3 now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable PyO3 Guru in Gurubase, just let me know that's totally fine.
