### PR TITLE
release: 0.23.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - run: python -m pip install --upgrade pip && pip install nox
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -41,11 +41,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: resolve MSRV
         id: resolve-msrv
-        run:
-          echo MSRV=`python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["package"]["rust-version"])'` >> $GITHUB_OUTPUT
+        run: echo MSRV=`python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["package"]["rust-version"])'` >> $GITHUB_OUTPUT
 
   semver-checks:
     if: github.ref != 'refs/heads/main'
@@ -55,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - uses: obi1kenobi/cargo-semver-checks-action@v2
 
   check-msrv:
@@ -69,7 +68,7 @@ jobs:
           components: rust-src
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
@@ -91,43 +90,44 @@ jobs:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
         rust: [stable]
-        platform: [
-          {
-            os: "macos-latest",
-            python-architecture: "arm64",
-            rust-target: "aarch64-apple-darwin",
-          },
-          {
-            os: "ubuntu-latest",
-            python-architecture: "x64",
-            rust-target: "x86_64-unknown-linux-gnu",
-          },
-          {
-            os: "ubuntu-latest",
-            python-architecture: "x64",
-            rust-target: "powerpc64le-unknown-linux-gnu",
-          },
-          {
-            os: "ubuntu-latest",
-            python-architecture: "x64",
-            rust-target: "s390x-unknown-linux-gnu",
-          },
-          {
-            os: "ubuntu-latest",
-            python-architecture: "x64",
-            rust-target: "wasm32-wasi",
-          },
-          {
-            os: "windows-latest",
-            python-architecture: "x64",
-            rust-target: "x86_64-pc-windows-msvc",
-          },
-          {
-            os: "windows-latest",
-            python-architecture: "x86",
-            rust-target: "i686-pc-windows-msvc",
-          },
-        ]
+        platform:
+          [
+            {
+              os: "macos-latest",
+              python-architecture: "arm64",
+              rust-target: "aarch64-apple-darwin",
+            },
+            {
+              os: "ubuntu-latest",
+              python-architecture: "x64",
+              rust-target: "x86_64-unknown-linux-gnu",
+            },
+            {
+              os: "ubuntu-latest",
+              python-architecture: "x64",
+              rust-target: "powerpc64le-unknown-linux-gnu",
+            },
+            {
+              os: "ubuntu-latest",
+              python-architecture: "x64",
+              rust-target: "s390x-unknown-linux-gnu",
+            },
+            {
+              os: "ubuntu-latest",
+              python-architecture: "x64",
+              rust-target: "wasm32-wasi",
+            },
+            {
+              os: "windows-latest",
+              python-architecture: "x64",
+              rust-target: "x86_64-pc-windows-msvc",
+            },
+            {
+              os: "windows-latest",
+              python-architecture: "x86",
+              rust-target: "i686-pc-windows-msvc",
+            },
+          ]
         include:
           # Run beta clippy as a way to detect any incoming lints which may affect downstream users
           - rust: beta
@@ -148,7 +148,7 @@ jobs:
           components: clippy,rust-src
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
           architecture: ${{ matrix.platform.python-architecture }}
       - uses: Swatinem/rust-cache@v2
         with:
@@ -177,15 +177,14 @@ jobs:
       matrix:
         rust: [stable]
         python-version: ["3.12"]
-        platform:
-          [
+        platform: [
             {
-              os: "macos-latest",  # first available arm macos runner
+              os: "macos-latest", # first available arm macos runner
               python-architecture: "arm64",
               rust-target: "aarch64-apple-darwin",
             },
             {
-              os: "macos-13",  # last available x86_64 macos runner
+              os: "macos-13", # last available x86_64 macos runner
               python-architecture: "x64",
               rust-target: "x86_64-apple-darwin",
             },
@@ -234,18 +233,19 @@ jobs:
       fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
       matrix:
         rust: [stable]
-        python-version: [
-          "3.7",
-          "3.8",
-          "3.9",
-          "3.10",
-          "3.11",
-          "3.12",
-          "3.13",
-          "pypy3.9",
-          "pypy3.10",
-          "graalpy24.0",
-        ]
+        python-version:
+          [
+            "3.7",
+            "3.8",
+            "3.9",
+            "3.10",
+            "3.11",
+            "3.12",
+            "3.13",
+            "pypy3.9",
+            "pypy3.10",
+            "graalpy24.0",
+          ]
         platform:
           [
             {
@@ -389,7 +389,7 @@ jobs:
         with:
           # FIXME valgrind detects an issue with Python 3.12.5, needs investigation
           # whether it's a PyO3 issue or upstream CPython.
-          python-version: '3.12.4'
+          python-version: "3.12.4"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
@@ -410,7 +410,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
@@ -432,7 +432,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
@@ -442,7 +442,7 @@ jobs:
       - run: cargo rustdoc --lib --no-default-features --features full -Zunstable-options --config "build.rustdocflags=[\"--cfg\", \"docsrs\"]"
 
   coverage:
-    if : ${{ github.event_name != 'merge_group' }}
+    if: ${{ github.event_name != 'merge_group' }}
     needs: [fmt]
     name: coverage ${{ matrix.os }}
     strategy:
@@ -453,7 +453,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
@@ -464,9 +464,9 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - run: python -m pip install --upgrade pip && pip install nox
       - run: nox -s coverage
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
-          file: coverage.json
+          files: coverage.json
           name: ${{ matrix.os }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -552,11 +552,11 @@ jobs:
 
   test-free-threaded:
     needs: [fmt]
-    name: Free threaded tests - ${{ matrix.runner }}
-    runs-on: ${{ matrix.runner }}
+    name: Free threaded tests - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        runner: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -568,7 +568,7 @@ jobs:
       # TODO: replace with actions/setup-python when there is support
       - uses: quansight-labs/setup-python@v5.3.1
         with:
-          python-version: '3.13t'
+          python-version: "3.13t"
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - run: python3 -m sysconfig
@@ -582,10 +582,10 @@ jobs:
       - name: Generate coverage report
         run: nox -s generate-coverage-report
       - name: Upload coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: coverage.json
-          name: test-free-threaded
+          files: coverage.json
+          name: ${{ matrix.os }}-test-free-threaded
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test-version-limits:
@@ -596,7 +596,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
@@ -620,7 +620,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
@@ -659,7 +659,7 @@ jobs:
             flags: "-i python3.12 --features abi3 --features generate-import-lib"
             manylinux: off
           # macos x86_64 -> aarch64
-          - os: "macos-13"  # last x86_64 macos runners
+          - os: "macos-13" # last x86_64 macos runners
             target: "aarch64-apple-darwin"
           # macos aarch64 -> x86_64
           - os: "macos-latest"
@@ -668,11 +668,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces:
-            examples/maturin-starter
+          workspaces: examples/maturin-starter
           save-if: ${{ github.event_name != 'merge_group' }}
           key: ${{ matrix.target }}
       - name: Setup cross-compiler
@@ -692,11 +691,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces:
-            examples/maturin-starter
+          workspaces: examples/maturin-starter
           save-if: ${{ github.event_name != 'merge_group' }}
       - uses: actions/cache/restore@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ To see unreleased changes, please see the [CHANGELOG on the main branch guide](h
 
 <!-- towncrier release notes start -->
 
+## [0.23.2] - 2024-11-25
+
+### Added
+
+- Add `IntoPyObjectExt` trait. [#4708](https://github.com/PyO3/pyo3/pull/4708)
+
+### Fixed
+
+- Fix compile failures when building for free-threaded Python when the `abi3` or `abi3-pyxx` features are enabled. [#4719](https://github.com/PyO3/pyo3/pull/4719)
+- Fix `ambiguous_associated_items` lint error in `#[pyclass]` and `#[derive(IntoPyObject)]` macros. [#4725](https://github.com/PyO3/pyo3/pull/4725)
+
+
 ## [0.23.1] - 2024-11-16
 
 Re-release of 0.23.0 with fixes to docs.rs build.
@@ -2000,7 +2012,8 @@ Yanked
 
 - Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.23.1...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.23.2...HEAD
+[0.23.2]: https://github.com/pyo3/pyo3/compare/v0.23.1...v0.23.2
 [0.23.1]: https://github.com/pyo3/pyo3/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/pyo3/pyo3/compare/v0.22.5...v0.23.0
 [0.22.5]: https://github.com/pyo3/pyo3/compare/v0.22.4...v0.22.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.23.1"
+version = "0.23.2"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -21,10 +21,10 @@ memoffset = "0.9"
 once_cell = "1.13"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.23.1" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.23.2" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.23.1", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.23.2", optional = true }
 indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
@@ -66,7 +66,7 @@ static_assertions = "1.1.0"
 uuid = {version = "1.10.0", features = ["v4"] }
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "=0.23.1", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "=0.23.2", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.23.1", features = ["extension-module"] }
+pyo3 = { version = "0.23.2", features = ["extension-module"] }
 ```
 
 **`src/lib.rs`**
@@ -140,7 +140,7 @@ Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like th
 
 ```toml
 [dependencies.pyo3]
-version = "0.23.1"
+version = "0.23.2"
 features = ["auto-initialize"]
 ```
 

--- a/examples/decorator/.template/pre-script.rhai
+++ b/examples/decorator/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.1");
+variable::set("PYO3_VERSION", "0.23.2");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/maturin-starter/.template/pre-script.rhai
+++ b/examples/maturin-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.1");
+variable::set("PYO3_VERSION", "0.23.2");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/plugin/.template/pre-script.rhai
+++ b/examples/plugin/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.1");
+variable::set("PYO3_VERSION", "0.23.2");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/plugin_api/Cargo.toml", "plugin_api/Cargo.toml");
 file::delete(".template");

--- a/examples/setuptools-rust-starter/.template/pre-script.rhai
+++ b/examples/setuptools-rust-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.1");
+variable::set("PYO3_VERSION", "0.23.2");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/setup.cfg", "setup.cfg");
 file::delete(".template");

--- a/examples/word-count/.template/pre-script.rhai
+++ b/examples/word-count/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.1");
+variable::set("PYO3_VERSION", "0.23.2");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/guide/pyclass-parameters.md
+++ b/guide/pyclass-parameters.md
@@ -21,7 +21,6 @@
 | `set_all` | Generates setters for all fields of the pyclass. |
 | `str` | Implements `__str__` using the `Display` implementation of the underlying Rust datatype or by passing an optional format string `str="<format string>"`. *Note: The optional format string is only allowed for structs.  `name` and `rename_all` are incompatible with the optional format string.  Additional details can be found in the discussion on this [PR](https://github.com/PyO3/pyo3/pull/4233).* |
 | `subclass` | Allows other Python classes and `#[pyclass]` to inherit from this class. Enums cannot be subclassed. |
-| <span style="white-space: pre">`text_signature = "(arg1, arg2, ...)"`</span> |  Sets the text signature for the Python class' `__new__` method. |
 | `unsendable` | Required if your struct is not [`Send`][params-3]. Rather than using `unsendable`, consider implementing your struct in a thread-safe way by e.g. substituting [`Rc`][params-4] with [`Arc`][params-5]. By using `unsendable`, your class will panic when accessed by another thread. Also note the Python's GC is multi-threaded and while unsendable classes will not be traversed on foreign threads to avoid UB, this can lead to memory leaks. |
 | `weakref` | Allows this class to be [weakly referenceable][params-6]. |
 

--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -108,6 +108,15 @@ using single-phase initialization and the
 [`sequential`](https://github.com/PyO3/pyo3/tree/main/pyo3-ffi/examples/sequential)
 example for modules using multi-phase initialization.
 
+If you would like to use conditional compilation to trigger different code paths
+under the free-threaded build, you can use the `Py_GIL_DISABLED` attribute once
+you have configured your crate to generate the necessary build configuration
+data. See [the guide
+section](./building-and-distribution/multiple-python-versions.md) for more
+details about supporting multiple different Python versions, including the
+free-threaded build.
+
+
 ## Special considerations for the free-threaded build
 
 The free-threaded interpreter does not have a GIL, and this can make interacting
@@ -234,7 +243,24 @@ needed. For now you should explicitly add locking, possibly using conditional
 compilation or using the critical section API to avoid creating deadlocks with
 the GIL.
 
-## Thread-safe single initialization
+### Cannot build extensions using the limited API
+
+The free-threaded build uses a completely new ABI and there is not yet an
+equivalent to the limited API for the free-threaded ABI. That means if your
+crate depends on PyO3 using the `abi3` feature or an an `abi3-pyxx` feature,
+PyO3 will print a warning and ignore that setting when building extensions using
+the free-threaded interpreter.
+
+This means that if your package makes use of the ABI forward compatibility
+provided by the limited API to uploads only one wheel for each release of your
+package, you will need to update and tooling or instructions to also upload a
+version-specific free-threaded wheel.
+
+See [the guide section](./building-and-distribution/multiple-python-versions.md)
+for more details about supporting multiple different Python versions, including
+the free-threaded build.
+
+### Thread-safe single initialization
 
 Until version 0.23, PyO3 provided only [`GILOnceCell`] to enable deadlock-free
 single initialization of data in contexts that might execute arbitrary Python

--- a/newsfragments/4708.added.md
+++ b/newsfragments/4708.added.md
@@ -1,1 +1,0 @@
-Add `IntoPyObjectExt` trait.

--- a/newsfragments/4708.added.md
+++ b/newsfragments/4708.added.md
@@ -1,0 +1,1 @@
+Add `IntoPyObjectExt` trait.

--- a/newsfragments/4719.fixed.md
+++ b/newsfragments/4719.fixed.md
@@ -1,0 +1,2 @@
+* Fixed an issue that prevented building free-threaded extensions for crates
+  that request a specific minimum limited API version.

--- a/newsfragments/4719.fixed.md
+++ b/newsfragments/4719.fixed.md
@@ -1,2 +1,0 @@
-* Fixed an issue that prevented building free-threaded extensions for crates
-  that request a specific minimum limited API version.

--- a/newsfragments/4725.fixed.md
+++ b/newsfragments/4725.fixed.md
@@ -1,1 +1,0 @@
-Fix `ambiguous_associated_items` lint error in `#[pyclass]` and `#[derive(IntoPyObject)]` macros.

--- a/newsfragments/4725.fixed.md
+++ b/newsfragments/4725.fixed.md
@@ -1,0 +1,1 @@
+Fix `ambiguous_associated_items` lint error in `#[pyclass]` and `#[derive(IntoPyObject)]` macros.

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.23.1"
+version = "0.23.2"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.23.1"
+version = "0.23.2"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -41,7 +41,7 @@ generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 paste = "1"
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.1", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.2", features = ["resolve-config"] }
 
 [lints]
 workspace = true

--- a/pyo3-ffi/README.md
+++ b/pyo3-ffi/README.md
@@ -41,13 +41,13 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3-ffi]
-version = "0.23.1"
+version = "0.23.2"
 features = ["extension-module"]
 
 [build-dependencies]
 # This is only necessary if you need to configure your build based on
 # the Python version or the compile-time configuration for the interpreter.
-pyo3_build_config = "0.23.1"
+pyo3_build_config = "0.23.2"
 ```
 
 If you need to use conditional compilation based on Python version or how

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -4,7 +4,7 @@ use pyo3_build_config::{
         cargo_env_var, env_var, errors::Result, is_linking_libpython, resolve_interpreter_config,
         InterpreterConfig, PythonVersion,
     },
-    warn, BuildFlag, PythonImplementation,
+    warn, PythonImplementation,
 };
 
 /// Minimum Python version PyO3 supports.
@@ -56,15 +56,22 @@ fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
                 interpreter_config.version,
                 versions.min,
             );
-            ensure!(
-                interpreter_config.version <= versions.max || env_var("PYO3_USE_ABI3_FORWARD_COMPATIBILITY").map_or(false, |os_str| os_str == "1"),
-                "the configured Python interpreter version ({}) is newer than PyO3's maximum supported version ({})\n\
-                 = help: please check if an updated version of PyO3 is available. Current version: {}\n\
-                 = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI",
-                interpreter_config.version,
-                versions.max,
-                std::env::var("CARGO_PKG_VERSION").unwrap(),
-            );
+            if interpreter_config.version > versions.max {
+                ensure!(!interpreter_config.is_free_threaded(),
+                        "The configured Python interpreter version ({}) is newer than PyO3's maximum supported version ({})\n\
+                         = help: please check if an updated version of PyO3 is available. Current version: {}\n\
+                         = help: The free-threaded build of CPython does not support the limited API so this check cannot be suppressed.",
+                        interpreter_config.version, versions.max, std::env::var("CARGO_PKG_VERSION").unwrap()
+                );
+                ensure!(env_var("PYO3_USE_ABI3_FORWARD_COMPATIBILITY").map_or(false, |os_str| os_str == "1"),
+                        "the configured Python interpreter version ({}) is newer than PyO3's maximum supported version ({})\n\
+                         = help: please check if an updated version of PyO3 is available. Current version: {}\n\
+                         = help: set PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 to suppress this check and build anyway using the stable ABI",
+                        interpreter_config.version,
+                        versions.max,
+                        std::env::var("CARGO_PKG_VERSION").unwrap(),
+                );
+            }
         }
         PythonImplementation::PyPy => {
             let versions = SUPPORTED_VERSIONS_PYPY;
@@ -107,14 +114,10 @@ fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {
     if interpreter_config.abi3 {
         match interpreter_config.implementation {
             PythonImplementation::CPython => {
-                if interpreter_config
-                    .build_flags
-                    .0
-                    .contains(&BuildFlag::Py_GIL_DISABLED)
-                {
+                if interpreter_config.is_free_threaded() {
                     warn!(
                             "The free-threaded build of CPython does not yet support abi3 so the build artifacts will be version-specific."
-                        )
+                    )
                 }
             }
             PythonImplementation::PyPy => warn!(

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.23.1"
+version = "0.23.2"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -16,7 +16,7 @@ edition = "2021"
 [dependencies]
 heck = "0.5"
 proc-macro2 = { version = "1.0.60", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.1", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.2", features = ["resolve-config"] }
 quote = { version = "1", default-features = false }
 
 [dependencies.syn]
@@ -25,7 +25,7 @@ default-features = false
 features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits"]
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.1" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.2" }
 
 [lints]
 workspace = true

--- a/pyo3-macros-backend/src/intopyobject.rs
+++ b/pyo3-macros-backend/src/intopyobject.rs
@@ -512,7 +512,7 @@ impl<'a> Enum<'a> {
         IntoPyObjectImpl {
             types: IntoPyObjectTypes::Opaque {
                 target: quote!(#pyo3_path::types::PyAny),
-                output: quote!(#pyo3_path::Bound<'py, Self::Target>),
+                output: quote!(#pyo3_path::Bound<'py, <Self as #pyo3_path::conversion::IntoPyObject<'py>>::Target>),
                 error: quote!(#pyo3_path::PyErr),
             },
             body: quote! {
@@ -617,7 +617,10 @@ pub fn build_derive_into_pyobject<const REF: bool>(tokens: &DeriveInput) -> Resu
             type Output = #output;
             type Error = #error;
 
-            fn into_pyobject(self, py: #pyo3_path::Python<#lt_param>) -> ::std::result::Result<Self::Output, Self::Error> {
+            fn into_pyobject(self, py: #pyo3_path::Python<#lt_param>) -> ::std::result::Result<
+                <Self as #pyo3_path::conversion::IntoPyObject>::Output,
+                <Self as #pyo3_path::conversion::IntoPyObject>::Error,
+            > {
                 #body
             }
         }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1367,10 +1367,7 @@ fn impl_complex_enum_tuple_variant_getitem(
         .map(|i| {
             let field_access = format_ident!("_{}", i);
             quote! { #i =>
-                #pyo3_path::IntoPyObject::into_pyobject(#variant_cls::#field_access(slf)?, py)
-                    .map(#pyo3_path::BoundObject::into_any)
-                    .map(#pyo3_path::BoundObject::unbind)
-                    .map_err(::std::convert::Into::into)
+                #pyo3_path::IntoPyObjectExt::into_py_any(#variant_cls::#field_access(slf)?, py)
             }
         })
         .collect();
@@ -1852,16 +1849,10 @@ fn pyclass_richcmp_arms(
         .map(|span| {
             quote_spanned! { span =>
                 #pyo3_path::pyclass::CompareOp::Eq => {
-                    #pyo3_path::IntoPyObject::into_pyobject(self_val == other, py)
-                        .map(#pyo3_path::BoundObject::into_any)
-                        .map(#pyo3_path::BoundObject::unbind)
-                        .map_err(::std::convert::Into::into)
+                    #pyo3_path::IntoPyObjectExt::into_py_any(self_val == other, py)
                 },
                 #pyo3_path::pyclass::CompareOp::Ne => {
-                    #pyo3_path::IntoPyObject::into_pyobject(self_val != other, py)
-                        .map(#pyo3_path::BoundObject::into_any)
-                        .map(#pyo3_path::BoundObject::unbind)
-                        .map_err(::std::convert::Into::into)
+                    #pyo3_path::IntoPyObjectExt::into_py_any(self_val != other, py)
                 },
             }
         })
@@ -1876,28 +1867,16 @@ fn pyclass_richcmp_arms(
         .map(|ord| {
             quote_spanned! { ord.span() =>
                 #pyo3_path::pyclass::CompareOp::Gt => {
-                    #pyo3_path::IntoPyObject::into_pyobject(self_val > other, py)
-                        .map(#pyo3_path::BoundObject::into_any)
-                        .map(#pyo3_path::BoundObject::unbind)
-                        .map_err(::std::convert::Into::into)
+                    #pyo3_path::IntoPyObjectExt::into_py_any(self_val > other, py)
                 },
                 #pyo3_path::pyclass::CompareOp::Lt => {
-                    #pyo3_path::IntoPyObject::into_pyobject(self_val < other, py)
-                        .map(#pyo3_path::BoundObject::into_any)
-                        .map(#pyo3_path::BoundObject::unbind)
-                        .map_err(::std::convert::Into::into)
+                    #pyo3_path::IntoPyObjectExt::into_py_any(self_val < other, py)
                  },
                 #pyo3_path::pyclass::CompareOp::Le => {
-                    #pyo3_path::IntoPyObject::into_pyobject(self_val <= other, py)
-                        .map(#pyo3_path::BoundObject::into_any)
-                        .map(#pyo3_path::BoundObject::unbind)
-                        .map_err(::std::convert::Into::into)
+                    #pyo3_path::IntoPyObjectExt::into_py_any(self_val <= other, py)
                  },
                 #pyo3_path::pyclass::CompareOp::Ge => {
-                    #pyo3_path::IntoPyObject::into_pyobject(self_val >= other, py)
-                        .map(#pyo3_path::BoundObject::into_any)
-                        .map(#pyo3_path::BoundObject::unbind)
-                        .map_err(::std::convert::Into::into)
+                    #pyo3_path::IntoPyObjectExt::into_py_any(self_val >= other, py)
                  },
             }
         })

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1072,10 +1072,13 @@ fn impl_complex_enum(
         quote! {
             impl<'py> #pyo3_path::conversion::IntoPyObject<'py> for #cls {
                 type Target = Self;
-                type Output = #pyo3_path::Bound<'py, Self::Target>;
+                type Output = #pyo3_path::Bound<'py, <Self as #pyo3_path::conversion::IntoPyObject<'py>>::Target>;
                 type Error = #pyo3_path::PyErr;
 
-                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<Self::Output, Self::Error> {
+                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<
+                    <Self as #pyo3_path::conversion::IntoPyObject>::Output,
+                    <Self as #pyo3_path::conversion::IntoPyObject>::Error,
+                > {
                     match self {
                         #(#match_arms)*
                     }
@@ -2161,10 +2164,13 @@ impl<'a> PyClassImplsBuilder<'a> {
 
                 impl<'py> #pyo3_path::conversion::IntoPyObject<'py> for #cls {
                     type Target = Self;
-                    type Output = #pyo3_path::Bound<'py, Self::Target>;
+                    type Output = #pyo3_path::Bound<'py, <Self as #pyo3_path::conversion::IntoPyObject<'py>>::Target>;
                     type Error = #pyo3_path::PyErr;
 
-                    fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<Self::Output, Self::Error> {
+                    fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<
+                        <Self as #pyo3_path::conversion::IntoPyObject>::Output,
+                        <Self as #pyo3_path::conversion::IntoPyObject>::Error,
+                    > {
                         #pyo3_path::Bound::new(py, self)
                     }
                 }

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -213,10 +213,7 @@ pub fn gen_py_const(cls: &syn::Type, spec: &ConstSpec, ctx: &Ctx) -> MethodAndMe
 
     let associated_method = quote! {
         fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
-            #pyo3_path::IntoPyObject::into_pyobject(#cls::#member, py)
-                .map(#pyo3_path::BoundObject::into_any)
-                .map(#pyo3_path::BoundObject::unbind)
-                .map_err(::std::convert::Into::into)
+            #pyo3_path::IntoPyObjectExt::into_py_any(#cls::#member, py)
         }
     };
 

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.23.1"
+version = "0.23.2"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -21,7 +21,7 @@ experimental-async = ["pyo3-macros-backend/experimental-async"]
 proc-macro2 = { version = "1.0.60", default-features = false }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.23.1" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.23.2" }
 
 [lints]
 workspace = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "0.23.1"
+version = "0.23.2"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -47,8 +47,8 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::IntoPyObject, exceptions::PyTypeError, types::any::PyAnyMethods, Bound,
-    BoundObject, FromPyObject, PyAny, PyErr, PyObject, PyResult, Python,
+    exceptions::PyTypeError, types::any::PyAnyMethods, Bound, FromPyObject, IntoPyObject,
+    IntoPyObjectExt, PyAny, PyErr, PyObject, PyResult, Python,
 };
 #[allow(deprecated)]
 use crate::{IntoPy, ToPyObject};
@@ -82,16 +82,8 @@ where
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-            Either::Left(l) => l
-                .into_pyobject(py)
-                .map(BoundObject::into_any)
-                .map(BoundObject::into_bound)
-                .map_err(Into::into),
-            Either::Right(r) => r
-                .into_pyobject(py)
-                .map(BoundObject::into_any)
-                .map(BoundObject::into_bound)
-                .map_err(Into::into),
+            Either::Left(l) => l.into_bound_py_any(py),
+            Either::Right(r) => r.into_bound_py_any(py),
         }
     }
 }
@@ -108,16 +100,8 @@ where
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-            Either::Left(l) => l
-                .into_pyobject(py)
-                .map(BoundObject::into_any)
-                .map(BoundObject::into_bound)
-                .map_err(Into::into),
-            Either::Right(r) => r
-                .into_pyobject(py)
-                .map(BoundObject::into_any)
-                .map(BoundObject::into_bound)
-                .map_err(Into::into),
+            Either::Left(l) => l.into_bound_py_any(py),
+            Either::Right(r) => r.into_bound_py_any(py),
         }
     }
 }

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -15,7 +15,7 @@ use crate::{
     exceptions::{PyAttributeError, PyRuntimeError, PyStopIteration},
     panic::PanicException,
     types::{string::PyStringMethods, PyIterator, PyString},
-    Bound, BoundObject, IntoPyObject, Py, PyAny, PyErr, PyObject, PyResult, Python,
+    Bound, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyErr, PyObject, PyResult, Python,
 };
 
 pub(crate) mod cancel;
@@ -60,10 +60,7 @@ impl Coroutine {
         let wrap = async move {
             let obj = future.await.map_err(Into::into)?;
             // SAFETY: GIL is acquired when future is polled (see `Coroutine::poll`)
-            obj.into_pyobject(unsafe { Python::assume_gil_acquired() })
-                .map(BoundObject::into_any)
-                .map(BoundObject::unbind)
-                .map_err(Into::into)
+            obj.into_py_any(unsafe { Python::assume_gil_acquired() })
         };
         Self {
             name: name.map(Bound::unbind),

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1,5 +1,4 @@
 use crate::{
-    conversion::IntoPyObject,
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError, PyValueError},
     ffi,
     impl_::{
@@ -10,7 +9,8 @@ use crate::{
     },
     pycell::PyBorrowError,
     types::{any::PyAnyMethods, PyBool},
-    Borrowed, BoundObject, Py, PyAny, PyClass, PyErr, PyRef, PyResult, PyTypeInfo, Python,
+    Borrowed, BoundObject, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyClass, PyErr, PyRef,
+    PyResult, PyTypeInfo, Python,
 };
 #[allow(deprecated)]
 use crate::{IntoPy, ToPyObject};
@@ -1532,10 +1532,7 @@ impl<const IMPLEMENTS_INTOPYOBJECT: bool> ConvertField<true, IMPLEMENTS_INTOPYOB
     where
         &'a T: IntoPyObject<'py>,
     {
-        obj.into_pyobject(py)
-            .map(BoundObject::into_any)
-            .map(BoundObject::unbind)
-            .map_err(Into::into)
+        obj.into_py_any(py)
     }
 }
 
@@ -1545,11 +1542,7 @@ impl<const IMPLEMENTS_INTOPYOBJECT: bool> ConvertField<false, IMPLEMENTS_INTOPYO
     where
         T: PyO3GetField<'py>,
     {
-        obj.clone()
-            .into_pyobject(py)
-            .map(BoundObject::into_any)
-            .map(BoundObject::unbind)
-            .map_err(Into::into)
+        obj.clone().into_py_any(py)
     }
 }
 

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -2,9 +2,7 @@ use std::{convert::Infallible, marker::PhantomData, ops::Deref};
 
 #[allow(deprecated)]
 use crate::IntoPy;
-use crate::{
-    conversion::IntoPyObject, ffi, types::PyNone, Bound, BoundObject, PyObject, PyResult, Python,
-};
+use crate::{ffi, types::PyNone, Bound, IntoPyObject, IntoPyObjectExt, PyObject, PyResult, Python};
 
 /// Used to wrap values in `Option<T>` for default arguments.
 pub trait SomeWrap<T> {
@@ -97,9 +95,7 @@ impl<'py, T: IntoPyObject<'py>, E> IntoPyObjectConverter<Result<T, E>> {
     where
         T: IntoPyObject<'py>,
     {
-        obj.and_then(|obj| obj.into_pyobject(py).map_err(Into::into))
-            .map(BoundObject::into_any)
-            .map(BoundObject::unbind)
+        obj.and_then(|obj| obj.into_py_any(py))
     }
 
     #[inline]
@@ -107,8 +103,7 @@ impl<'py, T: IntoPyObject<'py>, E> IntoPyObjectConverter<Result<T, E>> {
     where
         T: IntoPyObject<'py>,
     {
-        obj.and_then(|obj| obj.into_pyobject(py).map_err(Into::into))
-            .map(BoundObject::into_bound)
+        obj.and_then(|obj| obj.into_bound_py_any(py))
             .map(Bound::into_ptr)
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1466,7 +1466,7 @@ impl<T> Py<T> {
     /// # Example: `intern!`ing the attribute name
     ///
     /// ```
-    /// # use pyo3::{intern, pyfunction, types::PyModule, IntoPyObject, PyObject, Python, PyResult};
+    /// # use pyo3::{intern, pyfunction, types::PyModule, IntoPyObjectExt, PyObject, Python, PyResult};
     /// #
     /// #[pyfunction]
     /// fn set_answer(ob: PyObject, py: Python<'_>) -> PyResult<()> {
@@ -1474,7 +1474,7 @@ impl<T> Py<T> {
     /// }
     /// #
     /// # Python::with_gil(|py| {
-    /// #    let ob = PyModule::new(py, "empty").unwrap().into_pyobject(py).unwrap().into_any().unbind();
+    /// #    let ob = PyModule::new(py, "empty").unwrap().into_py_any(py).unwrap();
     /// #    set_answer(ob, py).unwrap();
     /// # });
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,7 +334,7 @@
 #![doc = concat!("[Features chapter of the guide]: https://pyo3.rs/v", env!("CARGO_PKG_VERSION"), "/features.html#features-reference \"Features Reference - PyO3 user guide\"")]
 //! [`Ungil`]: crate::marker::Ungil
 pub use crate::class::*;
-pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPyObject};
+pub use crate::conversion::{AsPyPointer, FromPyObject, IntoPyObject, IntoPyObjectExt};
 #[allow(deprecated)]
 pub use crate::conversion::{IntoPy, ToPyObject};
 pub use crate::err::{DowncastError, DowncastIntoError, PyErr, PyErrArguments, PyResult, ToPyErr};

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -4,7 +4,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::{Borrowed, Bound};
 use crate::py_result_ext::PyResultExt;
 use crate::types::{PyAny, PyAnyMethods, PyList, PyMapping};
-use crate::{ffi, BoundObject, IntoPyObject, Python};
+use crate::{ffi, BoundObject, IntoPyObject, IntoPyObjectExt, Python};
 
 /// Represents a Python `dict`.
 ///
@@ -239,7 +239,7 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
     where
         K: IntoPyObject<'py>,
     {
-        fn inner(dict: &Bound<'_, PyDict>, key: &Bound<'_, PyAny>) -> PyResult<bool> {
+        fn inner(dict: &Bound<'_, PyDict>, key: Borrowed<'_, '_, PyAny>) -> PyResult<bool> {
             match unsafe { ffi::PyDict_Contains(dict.as_ptr(), key.as_ptr()) } {
                 1 => Ok(true),
                 0 => Ok(false),
@@ -250,10 +250,7 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
         let py = self.py();
         inner(
             self,
-            &key.into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            key.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -263,7 +260,7 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
     {
         fn inner<'py>(
             dict: &Bound<'py, PyDict>,
-            key: &Bound<'_, PyAny>,
+            key: Borrowed<'_, '_, PyAny>,
         ) -> PyResult<Option<Bound<'py, PyAny>>> {
             let py = dict.py();
             let mut result: *mut ffi::PyObject = std::ptr::null_mut();
@@ -283,10 +280,7 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
         let py = self.py();
         inner(
             self,
-            &key.into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            key.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -297,8 +291,8 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
     {
         fn inner(
             dict: &Bound<'_, PyDict>,
-            key: &Bound<'_, PyAny>,
-            value: &Bound<'_, PyAny>,
+            key: Borrowed<'_, '_, PyAny>,
+            value: Borrowed<'_, '_, PyAny>,
         ) -> PyResult<()> {
             err::error_on_minusone(dict.py(), unsafe {
                 ffi::PyDict_SetItem(dict.as_ptr(), key.as_ptr(), value.as_ptr())
@@ -308,15 +302,8 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
         let py = self.py();
         inner(
             self,
-            &key.into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
-            &value
-                .into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            key.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
+            value.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -324,7 +311,7 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
     where
         K: IntoPyObject<'py>,
     {
-        fn inner(dict: &Bound<'_, PyDict>, key: &Bound<'_, PyAny>) -> PyResult<()> {
+        fn inner(dict: &Bound<'_, PyDict>, key: Borrowed<'_, '_, PyAny>) -> PyResult<()> {
             err::error_on_minusone(dict.py(), unsafe {
                 ffi::PyDict_DelItem(dict.as_ptr(), key.as_ptr())
             })
@@ -333,10 +320,7 @@ impl<'py> PyDictMethods<'py> for Bound<'py, PyDict> {
         let py = self.py();
         inner(
             self,
-            &key.into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            key.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -1,4 +1,3 @@
-use crate::conversion::IntoPyObject;
 use crate::types::PyIterator;
 use crate::{
     err::{self, PyErr, PyResult},
@@ -8,7 +7,7 @@ use crate::{
     types::any::PyAnyMethods,
     Bound, PyAny, Python,
 };
-use crate::{Borrowed, BoundObject};
+use crate::{Borrowed, BoundObject, IntoPyObject, IntoPyObjectExt};
 use std::ptr;
 
 /// Allows building a Python `frozenset` one item at a time
@@ -181,10 +180,7 @@ impl<'py> PyFrozenSetMethods<'py> for Bound<'py, PyFrozenSet> {
         let py = self.py();
         inner(
             self,
-            key.into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            key.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -266,7 +262,7 @@ where
     let ptr = set.as_ptr();
 
     for e in elements {
-        let obj = e.into_pyobject(py).map_err(Into::into)?;
+        let obj = e.into_pyobject_or_pyerr(py)?;
         err::error_on_minusone(py, unsafe { ffi::PySet_Add(ptr, obj.as_ptr()) })?;
     }
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -9,7 +9,10 @@ use crate::py_result_ext::PyResultExt;
 use crate::sync::GILOnceCell;
 use crate::type_object::PyTypeInfo;
 use crate::types::{any::PyAnyMethods, PyAny, PyList, PyString, PyTuple, PyType};
-use crate::{ffi, Borrowed, BoundObject, FromPyObject, IntoPyObject, Py, PyTypeCheck, Python};
+use crate::{
+    ffi, Borrowed, BoundObject, FromPyObject, IntoPyObject, IntoPyObjectExt, Py, PyTypeCheck,
+    Python,
+};
 
 /// Represents a reference to a Python object supporting the sequence protocol.
 ///
@@ -221,10 +224,7 @@ impl<'py> PySequenceMethods<'py> for Bound<'py, PySequence> {
         inner(
             self,
             i,
-            item.into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            item.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -269,11 +269,7 @@ impl<'py> PySequenceMethods<'py> for Bound<'py, PySequence> {
         let py = self.py();
         inner(
             self,
-            value
-                .into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            value.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -294,11 +290,7 @@ impl<'py> PySequenceMethods<'py> for Bound<'py, PySequence> {
         let py = self.py();
         inner(
             self,
-            value
-                .into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            value.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -316,11 +308,7 @@ impl<'py> PySequenceMethods<'py> for Bound<'py, PySequence> {
         let py = self.py();
         inner(
             self,
-            value
-                .into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            value.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -1,4 +1,3 @@
-use crate::conversion::IntoPyObject;
 use crate::types::PyIterator;
 #[allow(deprecated)]
 use crate::ToPyObject;
@@ -9,7 +8,7 @@ use crate::{
     py_result_ext::PyResultExt,
     types::any::PyAnyMethods,
 };
-use crate::{ffi, Borrowed, BoundObject, PyAny, Python};
+use crate::{ffi, Borrowed, BoundObject, IntoPyObject, IntoPyObjectExt, PyAny, Python};
 use std::ptr;
 
 /// Represents a Python `set`.
@@ -161,10 +160,7 @@ impl<'py> PySetMethods<'py> for Bound<'py, PySet> {
         let py = self.py();
         inner(
             self,
-            key.into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            key.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -183,10 +179,7 @@ impl<'py> PySetMethods<'py> for Bound<'py, PySet> {
         let py = self.py();
         inner(
             self,
-            key.into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            key.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -203,10 +196,7 @@ impl<'py> PySetMethods<'py> for Bound<'py, PySet> {
         let py = self.py();
         inner(
             self,
-            key.into_pyobject(py)
-                .map_err(Into::into)?
-                .into_any()
-                .as_borrowed(),
+            key.into_pyobject_or_pyerr(py)?.into_any().as_borrowed(),
         )
     }
 
@@ -316,7 +306,7 @@ where
     let ptr = set.as_ptr();
 
     elements.into_iter().try_for_each(|element| {
-        let obj = element.into_pyobject(py).map_err(Into::into)?;
+        let obj = element.into_pyobject_or_pyerr(py)?;
         err::error_on_minusone(py, unsafe { ffi::PySet_Add(ptr, obj.as_ptr()) })
     })?;
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1,6 +1,5 @@
 use std::iter::FusedIterator;
 
-use crate::conversion::IntoPyObject;
 use crate::ffi::{self, Py_ssize_t};
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
@@ -9,7 +8,8 @@ use crate::instance::Borrowed;
 use crate::internal_tricks::get_ssize_index;
 use crate::types::{any::PyAnyMethods, sequence::PySequenceMethods, PyList, PySequence};
 use crate::{
-    exceptions, Bound, BoundObject, FromPyObject, Py, PyAny, PyErr, PyObject, PyResult, Python,
+    exceptions, Bound, FromPyObject, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyErr, PyObject,
+    PyResult, Python,
 };
 #[allow(deprecated)]
 use crate::{IntoPy, ToPyObject};
@@ -99,12 +99,7 @@ impl PyTuple {
         T: IntoPyObject<'py>,
         U: ExactSizeIterator<Item = T>,
     {
-        let elements = elements.into_iter().map(|e| {
-            e.into_pyobject(py)
-                .map(BoundObject::into_any)
-                .map(BoundObject::into_bound)
-                .map_err(Into::into)
-        });
+        let elements = elements.into_iter().map(|e| e.into_bound_py_any(py));
         try_new_from_iter(py, elements)
     }
 
@@ -523,14 +518,14 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
     #[allow(deprecated)]
     impl <$($T: ToPyObject),+> ToPyObject for ($($T,)+) {
         fn to_object(&self, py: Python<'_>) -> PyObject {
-            array_into_tuple(py, [$(self.$n.to_object(py)),+]).into()
+            array_into_tuple(py, [$(self.$n.to_object(py).into_bound(py)),+]).into()
         }
     }
 
     #[allow(deprecated)]
     impl <$($T: IntoPy<PyObject>),+> IntoPy<PyObject> for ($($T,)+) {
         fn into_py(self, py: Python<'_>) -> PyObject {
-            array_into_tuple(py, [$(self.$n.into_py(py)),+]).into()
+            array_into_tuple(py, [$(self.$n.into_py(py).into_bound(py)),+]).into()
         }
     }
 
@@ -543,7 +538,7 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
         type Error = PyErr;
 
         fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-            Ok(array_into_tuple(py, [$(self.$n.into_pyobject(py).map_err(Into::into)?.into_any().unbind()),+]).into_bound(py))
+            Ok(array_into_tuple(py, [$(self.$n.into_bound_py_any(py)?),+]))
         }
 
         #[cfg(feature = "experimental-inspect")]
@@ -562,7 +557,7 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
         type Error = PyErr;
 
         fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-            Ok(array_into_tuple(py, [$(self.$n.into_pyobject(py).map_err(Into::into)?.into_any().unbind()),+]).into_bound(py))
+            Ok(array_into_tuple(py, [$(self.$n.into_bound_py_any(py)?),+]))
         }
 
         #[cfg(feature = "experimental-inspect")]
@@ -574,7 +569,7 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
     #[allow(deprecated)]
     impl <$($T: IntoPy<PyObject>),+> IntoPy<Py<PyTuple>> for ($($T,)+) {
         fn into_py(self, py: Python<'_>) -> Py<PyTuple> {
-            array_into_tuple(py, [$(self.$n.into_py(py)),+])
+            array_into_tuple(py, [$(self.$n.into_py(py).into_bound(py)),+]).unbind()
         }
     }
 
@@ -600,10 +595,13 @@ macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+
     }
 });
 
-fn array_into_tuple<const N: usize>(py: Python<'_>, array: [PyObject; N]) -> Py<PyTuple> {
+fn array_into_tuple<'py, const N: usize>(
+    py: Python<'py>,
+    array: [Bound<'py, PyAny>; N],
+) -> Bound<'py, PyTuple> {
     unsafe {
         let ptr = ffi::PyTuple_New(N.try_into().expect("0 < N <= 12"));
-        let tup = Py::from_owned_ptr(py, ptr);
+        let tup = ptr.assume_owned(py).downcast_into_unchecked();
         for (index, obj) in array.into_iter().enumerate() {
             #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
             ffi::PyTuple_SET_ITEM(ptr, index as ffi::Py_ssize_t, obj.into_ptr());

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -3,7 +3,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::type_object::PyTypeCheck;
 use crate::types::any::PyAny;
-use crate::{ffi, Bound, BoundObject, IntoPyObject};
+use crate::{ffi, Borrowed, Bound, BoundObject, IntoPyObject, IntoPyObjectExt};
 
 use super::PyWeakrefMethods;
 
@@ -152,7 +152,7 @@ impl PyWeakrefProxy {
     {
         fn inner<'py>(
             object: &Bound<'py, PyAny>,
-            callback: Bound<'py, PyAny>,
+            callback: Borrowed<'_, 'py, PyAny>,
         ) -> PyResult<Bound<'py, PyWeakrefProxy>> {
             unsafe {
                 Bound::from_owned_ptr_or_err(
@@ -167,10 +167,9 @@ impl PyWeakrefProxy {
         inner(
             object,
             callback
-                .into_pyobject(py)
-                .map(BoundObject::into_any)
-                .map(BoundObject::into_bound)
-                .map_err(Into::into)?,
+                .into_pyobject_or_pyerr(py)?
+                .into_any()
+                .as_borrowed(),
         )
     }
 

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -2,7 +2,7 @@ use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::types::any::PyAny;
-use crate::{ffi, Bound, BoundObject, IntoPyObject};
+use crate::{ffi, Borrowed, Bound, BoundObject, IntoPyObject, IntoPyObjectExt};
 
 #[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]
 use crate::type_object::PyTypeCheck;
@@ -161,7 +161,7 @@ impl PyWeakrefReference {
     {
         fn inner<'py>(
             object: &Bound<'py, PyAny>,
-            callback: Bound<'py, PyAny>,
+            callback: Borrowed<'_, 'py, PyAny>,
         ) -> PyResult<Bound<'py, PyWeakrefReference>> {
             unsafe {
                 Bound::from_owned_ptr_or_err(
@@ -176,10 +176,9 @@ impl PyWeakrefReference {
         inner(
             object,
             callback
-                .into_pyobject(py)
-                .map(BoundObject::into_any)
-                .map(BoundObject::into_bound)
-                .map_err(Into::into)?,
+                .into_pyobject_or_pyerr(py)?
+                .into_any()
+                .as_borrowed(),
         )
     }
 

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -67,4 +67,5 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/duplicate_pymodule_submodule.rs");
     #[cfg(all(not(Py_LIMITED_API), Py_3_11))]
     t.compile_fail("tests/ui/invalid_base_class.rs");
+    t.pass("tests/ui/ambiguous_associated_items.rs");
 }

--- a/tests/ui/ambiguous_associated_items.rs
+++ b/tests/ui/ambiguous_associated_items.rs
@@ -1,0 +1,25 @@
+use pyo3::prelude::*;
+
+#[pyclass(eq)]
+#[derive(PartialEq)]
+pub enum SimpleItems {
+    Error,
+    Output,
+    Target,
+}
+
+#[pyclass]
+pub enum ComplexItems {
+    Error(PyObject),
+    Output(PyObject),
+    Target(PyObject),
+}
+
+#[derive(IntoPyObject)]
+enum DeriveItems {
+    Error(PyObject),
+    Output(PyObject),
+    Target(PyObject),
+}
+
+fn main() {}

--- a/tests/ui/reject_generics.stderr
+++ b/tests/ui/reject_generics.stderr
@@ -1,10 +1,10 @@
-error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.23.1/class.html#no-generic-parameters
+error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.23.2/class.html#no-generic-parameters
  --> tests/ui/reject_generics.rs:4:25
   |
 4 | struct ClassWithGenerics<A> {
   |                         ^
 
-error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.23.1/class.html#no-lifetime-parameters
+error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.23.2/class.html#no-lifetime-parameters
  --> tests/ui/reject_generics.rs:9:27
   |
 9 | struct ClassWithLifetimes<'a> {


### PR DESCRIPTION
Staging branch for the 0.23 release series so that I can cherry-pick onto it without getting worried about the state of `main`.

We probably want to have merged:
- #4719 
- #4725 

... and I'd also potentially want `MutexExt` and `RwLockExt` traits as per https://github.com/PyO3/rust-numpy/pull/471#discussion_r1854253187, but those could also wait for a future release.