### PR TITLE
don't link to abi3 dll on windows for free-threaded build

### DIFF
--- a/newsfragments/4733.fixed.md
+++ b/newsfragments/4733.fixed.md
@@ -1,0 +1,1 @@
+Fix unresolved symbol link failures (due to linking to wrong DLL) when compiling for Python 3.13t with `abi3` features enabled.

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1653,7 +1653,7 @@ fn default_lib_name_windows(
         // CPython bug: linking against python3_d.dll raises error
         // https://github.com/python/cpython/issues/101614
         Ok(format!("python{}{}_d", version.major, version.minor))
-    } else if abi3 && !(implementation.is_pypy() || implementation.is_graalpy()) {
+    } else if abi3 && !(gil_disabled || implementation.is_pypy() || implementation.is_graalpy()) {
         if debug {
             Ok(WINDOWS_ABI3_DEBUG_LIB_NAME.to_owned())
         } else {
@@ -2541,6 +2541,21 @@ mod tests {
                 },
                 CPython,
                 false,
+                false,
+                false,
+                true,
+            )
+            .unwrap(),
+            "python313t",
+        );
+        assert_eq!(
+            super::default_lib_name_windows(
+                PythonVersion {
+                    major: 3,
+                    minor: 13
+                },
+                CPython,
+                true, // abi3 true should not affect the free-threaded lib name
                 false,
                 false,
                 true,


### PR DESCRIPTION
As free-threaded build doesn't support abi3, even if the abi3 features are set we should not use the abi3 dll.

Hopefully resolves the build error seen in https://github.com/pyca/bcrypt/pull/925#issuecomment-2501781415