### PR TITLE
fix clippy beta

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "pyo3-examples"
 version = "0.0.0"
 publish = false
 edition = "2021"
+rust-version = "1.63"
 
 [dev-dependencies]
 pyo3 = { path = "..", features = ["auto-initialize", "extension-module"] }

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/pyo3/pyo3"
 categories = ["api-bindings", "development-tools::ffi"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.63"
 
 [dependencies]
 once_cell = "1"

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1122,11 +1122,7 @@ impl BuildFlags {
         Self(
             BuildFlags::ALL
                 .iter()
-                .filter(|flag| {
-                    config_map
-                        .get_value(flag.to_string())
-                        .map_or(false, |value| value == "1")
-                })
+                .filter(|flag| config_map.get_value(flag.to_string()) == Some("1"))
                 .cloned()
                 .collect(),
         )

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["api-bindings", "development-tools::ffi"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 links = "python"
+rust-version = "1.63"
 
 [dependencies]
 libc = "0.2.62"

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/pyo3/pyo3"
 categories = ["api-bindings", "development-tools::ffi"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.63"
 
 # Note: we use default-features = false for proc-macro related crates
 # not to depend on proc-macro itself.

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/pyo3/pyo3"
 categories = ["api-bindings", "development-tools::ffi"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+rust-version = "1.63"
 
 [lib]
 proc-macro = true

--- a/pytests/Cargo.toml
+++ b/pytests/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 description = "Python-based tests for PyO3"
 edition = "2021"
 publish = false
+rust-version = "1.63"
 
 [dependencies]
 pyo3 = { path = "../", features = ["extension-module"] }


### PR DESCRIPTION
This fixes the clippy beta error. ~I moved `rust-version` into the workspace~ (I guess we can only do this after the next bump), so all our crates can inherit it and we don't get lints which we can't apply due to MSRV.