### PR TITLE
map `io::ErrorKind::IsADirectory`/`NotADirectory` to Python on 1.83+

### DIFF
--- a/newsfragments/4747.changed.md
+++ b/newsfragments/4747.changed.md
@@ -1,0 +1,1 @@
+Map `io::ErrorKind::IsADirectory`/`NotADirectory` to the corresponding Python exception on Rust 1.83+

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -156,6 +156,10 @@ pub fn print_feature_cfgs() {
     if rustc_minor_version >= 79 {
         println!("cargo:rustc-cfg=diagnostic_namespace");
     }
+
+    if rustc_minor_version >= 83 {
+        println!("cargo:rustc-cfg=io_error_more");
+    }
 }
 
 /// Registers `pyo3`s config names as reachable cfg expressions
@@ -180,6 +184,7 @@ pub fn print_expected_cfgs() {
     println!("cargo:rustc-check-cfg=cfg(diagnostic_namespace)");
     println!("cargo:rustc-check-cfg=cfg(c_str_lit)");
     println!("cargo:rustc-check-cfg=cfg(rustc_has_once_lock)");
+    println!("cargo:rustc-check-cfg=cfg(io_error_more)");
 
     // allow `Py_3_*` cfgs from the minimum supported version up to the
     // maximum minor version (+1 for development for the next)


### PR DESCRIPTION
This maps `io::ErrorKind::IsADirectory`/`NotADirectory`  to the corresponding Python exception when compiling on Rust 1.83+.

Closes #4740 