### PR TITLE
ci: test debug builds using 3.13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,8 +520,8 @@ jobs:
           components: rust-src
       - name: Install python3 standalone debug build with nox
         run: |
-          PBS_RELEASE="20231002"
-          PBS_PYTHON_VERSION="3.12.0"
+          PBS_RELEASE="20241016"
+          PBS_PYTHON_VERSION="3.13.0"
           PBS_ARCHIVE="cpython-${PBS_PYTHON_VERSION}+${PBS_RELEASE}-x86_64-unknown-linux-gnu-debug-full.tar.zst"
           wget "https://github.com/indygreg/python-build-standalone/releases/download/${PBS_RELEASE}/${PBS_ARCHIVE}"
           tar -I zstd -xf "${PBS_ARCHIVE}"
@@ -537,10 +537,10 @@ jobs:
           PYO3_CONFIG_FILE=$(mktemp)
           cat > $PYO3_CONFIG_FILE << EOF
           implementation=CPython
-          version=3.12
+          version=3.13
           shared=true
           abi3=false
-          lib_name=python3.12d
+          lib_name=python3.13d
           lib_dir=${{ github.workspace }}/python/install/lib
           executable=${{ github.workspace }}/python/install/bin/python3
           pointer_width=64


### PR DESCRIPTION
Possible first step to see if can reproduce the crash from https://github.com/samuelcolvin/watchfiles/issues/313 within the PyO3 test suite.