### PR TITLE
Add supported CPython/PyPy versions to cargo package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ max-version = "3.13"  # inclusive
 
 [package.metadata.pypy]
 min-version = "3.9"
-max-version = "3.10"  # inclusive
+max-version = "3.11"  # inclusive
 
 [workspace.lints.clippy]
 checked_conversions = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ indexmap = { version = ">= 2.5.0, < 3", optional = true }
 jiff-02 = { package = "jiff", version = "0.2", optional = true }
 num-bigint = { version = "0.4.2", optional = true }
 num-complex = { version = ">= 0.4.6, < 0.5", optional = true }
-num-rational = {version = "0.4.1", optional = true }
+num-rational = { version = "0.4.1", optional = true }
 rust_decimal = { version = "1.15", default-features = false, optional = true }
 serde = { version = "1.0", optional = true }
 smallvec = { version = "1.0", optional = true }
@@ -65,7 +65,7 @@ rayon = "1.6.1"
 futures = "0.3.28"
 tempfile = "3.12.0"
 static_assertions = "1.1.0"
-uuid = {version = "1.10.0", features = ["v4"] }
+uuid = { version = "1.10.0", features = ["v4"] }
 
 [build-dependencies]
 pyo3-build-config = { path = "pyo3-build-config", version = "=0.23.5", features = ["resolve-config"] }
@@ -152,6 +152,14 @@ members = [
 no-default-features = true
 features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cpython]
+min-version = "3.7"
+max-version = "3.13"  # inclusive
+
+[package.metadata.pypy]
+min-version = "3.9"
+max-version = "3.10"  # inclusive
 
 [workspace.lints.clippy]
 checked_conversions = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,14 +153,6 @@ no-default-features = true
 features = ["full"]
 rustdoc-args = ["--cfg", "docsrs"]
 
-[package.metadata.cpython]
-min-version = "3.7"
-max-version = "3.13"  # inclusive
-
-[package.metadata.pypy]
-min-version = "3.9"
-max-version = "3.11"  # inclusive
-
 [workspace.lints.clippy]
 checked_conversions = "warn"
 dbg_macro = "warn"

--- a/newsfragments/4756.packaging.md
+++ b/newsfragments/4756.packaging.md
@@ -1,0 +1,1 @@
+Add supported CPython/PyPy versions to cargo package metadata.

--- a/noxfile.py
+++ b/noxfile.py
@@ -54,6 +54,8 @@ def test(session: nox.Session) -> None:
 
 @nox.session(name="test-rust", venv_backend="none")
 def test_rust(session: nox.Session):
+    _run_cargo_package_metadata_test(session, packages=["pyo3", "pyo3-ffi"])
+
     _run_cargo_test(session, package="pyo3-build-config")
     _run_cargo_test(session, package="pyo3-macros-backend")
     _run_cargo_test(session, package="pyo3-macros")
@@ -929,6 +931,22 @@ def _run_cargo_set_package_version(
     if project:
         command.append(f"--manifest-path={project}/Cargo.toml")
     _run(session, *command, external=True)
+
+
+def _run_cargo_package_metadata_test(
+    session: nox.Session, *, packages: List[str]
+) -> None:
+    output = _get_output("cargo", "metadata", "--format-version=1", "--no-deps")
+    cargo_packages = json.loads(output)["packages"]
+    for package in packages:
+        # Check Python interpreter version support in package metadata
+        metadata = next(
+            pkg["metadata"] for pkg in cargo_packages if pkg["name"] == package
+        )
+        for python_impl in ["cpython", "pypy"]:
+            version_info = metadata[python_impl]
+            assert "min-version" in version_info
+            assert "max-version" in version_info
 
 
 def _get_output(*args: str) -> str:

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -46,3 +46,11 @@ pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.5", featur
 
 [lints]
 workspace = true
+
+[package.metadata.cpython]
+min-version = "3.7"
+max-version = "3.13"  # inclusive
+
+[package.metadata.pypy]
+min-version = "3.9"
+max-version = "3.10"  # inclusive

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -53,4 +53,4 @@ max-version = "3.13"  # inclusive
 
 [package.metadata.pypy]
 min-version = "3.9"
-max-version = "3.10"  # inclusive
+max-version = "3.11"  # inclusive


### PR DESCRIPTION
I tried to use workspace inheritance to reduce duplication, but when inspecting the `cargo package` artifact It does not seem to work.

Closes #4751