### PR TITLE
eagerly complete once in normalized error state

### DIFF
--- a/newsfragments/4766.fixed.md
+++ b/newsfragments/4766.fixed.md
@@ -1,0 +1,1 @@
+Fix unnecessary internal `py.allow_threads` GIL-switch when attempting to access contents of a `PyErr` which originated from Python (could lead to unintended deadlocks).


### PR DESCRIPTION
This should hopefully fix the `polars` case in #4764