### PR TITLE
reintroduce `vectorcall` optimization with new `PyCallArgs` trait

### DIFF
--- a/newsfragments/4768.added.md
+++ b/newsfragments/4768.added.md
@@ -1,0 +1,1 @@
+Added `PyCallArgs` trait for arguments into the Python calling protocol. This enabled using a faster calling convention for certain types, improving performance.

--- a/newsfragments/4768.changed.md
+++ b/newsfragments/4768.changed.md
@@ -1,0 +1,1 @@
+`PyAnyMethods::call` an friends now require `PyCallArgs` for their positional arguments.

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,0 +1,150 @@
+//! Defines how Python calls are dispatched, see [`PyCallArgs`].for more information.
+
+use crate::ffi_ptr_ext::FfiPtrExt as _;
+use crate::types::{PyAnyMethods as _, PyDict, PyString, PyTuple};
+use crate::{ffi, Borrowed, Bound, IntoPyObjectExt as _, Py, PyAny, PyResult};
+
+pub(crate) mod private {
+    use super::*;
+
+    pub trait Sealed {}
+
+    impl Sealed for () {}
+    impl Sealed for Bound<'_, PyTuple> {}
+    impl Sealed for Py<PyTuple> {}
+
+    pub struct Token;
+}
+
+/// This trait marks types that can be used as arguments to Python function
+/// calls.
+///
+/// This trait is currently implemented for Rust tuple (up to a size of 12),
+/// [`Bound<'py, PyTuple>`] and [`Py<PyTuple>`]. Custom types that are
+/// convertable to `PyTuple` via `IntoPyObject` need to do so before passing it
+/// to `call`.
+///
+/// This trait is not intended to used by downstream crates directly. As such it
+/// has no publicly available methods and cannot be implemented ouside of
+/// `pyo3`. The corresponding public API is available through [`call`]
+/// ([`call0`], [`call1`] and friends) on [`PyAnyMethods`].
+///
+/// # What is `PyCallArgs` used for?
+/// `PyCallArgs` is used internally in `pyo3` to dispatch the Python calls in
+/// the most optimal way for the current build configuration. Certain types,
+/// such as Rust tuples, do allow the usage of a faster calling convention of
+/// the Python interpreter (if available). More types that may take advantage
+/// from this may be added in the future.
+///
+/// [`call0`]: crate::types::PyAnyMethods::call0
+/// [`call1`]: crate::types::PyAnyMethods::call1
+/// [`call`]: crate::types::PyAnyMethods::call
+/// [`PyAnyMethods`]: crate::types::PyAnyMethods
+#[cfg_attr(
+    diagnostic_namespace,
+    diagnostic::on_unimplemented(
+        message = "`{Self}` cannot used as a Python `call` argument",
+        note = "`PyCallArgs` is implemented for Rust tuples, `Bound<'py, PyTuple>` and `Py<PyTuple>`",
+        note = "if your type is convertable to `PyTuple` via `IntoPyObject`, call `<arg>.into_pyobject(py)` manually",
+        note = "if you meant to pass the type as a single argument, wrap it in a 1-tuple, `(<arg>,)`"
+    )
+)]
+pub trait PyCallArgs<'py>: Sized + private::Sealed {
+    #[doc(hidden)]
+    fn call(
+        self,
+        function: Borrowed<'_, 'py, PyAny>,
+        kwargs: Borrowed<'_, 'py, PyDict>,
+        token: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>>;
+
+    #[doc(hidden)]
+    fn call_positional(
+        self,
+        function: Borrowed<'_, 'py, PyAny>,
+        token: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>>;
+
+    #[doc(hidden)]
+    fn call_method_positional(
+        self,
+        object: Borrowed<'_, 'py, PyAny>,
+        method_name: Borrowed<'_, 'py, PyString>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        object
+            .getattr(method_name)
+            .and_then(|method| method.call1(self))
+    }
+}
+
+impl<'py> PyCallArgs<'py> for () {
+    fn call(
+        self,
+        function: Borrowed<'_, 'py, PyAny>,
+        kwargs: Borrowed<'_, 'py, PyDict>,
+        token: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let args = self.into_pyobject_or_pyerr(function.py())?;
+        args.call(function, kwargs, token)
+    }
+
+    fn call_positional(
+        self,
+        function: Borrowed<'_, 'py, PyAny>,
+        token: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let args = self.into_pyobject_or_pyerr(function.py())?;
+        args.call_positional(function, token)
+    }
+}
+
+impl<'py> PyCallArgs<'py> for Bound<'py, PyTuple> {
+    fn call(
+        self,
+        function: Borrowed<'_, 'py, PyAny>,
+        kwargs: Borrowed<'_, '_, PyDict>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        unsafe {
+            ffi::PyObject_Call(function.as_ptr(), self.as_ptr(), kwargs.as_ptr())
+                .assume_owned_or_err(function.py())
+        }
+    }
+
+    fn call_positional(
+        self,
+        function: Borrowed<'_, 'py, PyAny>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        unsafe {
+            ffi::PyObject_Call(function.as_ptr(), self.as_ptr(), std::ptr::null_mut())
+                .assume_owned_or_err(function.py())
+        }
+    }
+}
+
+impl<'py> PyCallArgs<'py> for Py<PyTuple> {
+    fn call(
+        self,
+        function: Borrowed<'_, 'py, PyAny>,
+        kwargs: Borrowed<'_, '_, PyDict>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        unsafe {
+            ffi::PyObject_Call(function.as_ptr(), self.as_ptr(), kwargs.as_ptr())
+                .assume_owned_or_err(function.py())
+        }
+    }
+
+    fn call_positional(
+        self,
+        function: Borrowed<'_, 'py, PyAny>,
+        _: private::Token,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        unsafe {
+            ffi::PyObject_Call(function.as_ptr(), self.as_ptr(), std::ptr::null_mut())
+                .assume_owned_or_err(function.py())
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,6 +428,7 @@ mod internal_tricks;
 mod internal;
 
 pub mod buffer;
+pub mod call;
 pub mod conversion;
 mod conversions;
 #[cfg(feature = "experimental-async")]

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -20,6 +20,7 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_pymethod_enum.rs");
     t.compile_fail("tests/ui/invalid_pymethod_names.rs");
     t.compile_fail("tests/ui/invalid_pymodule_args.rs");
+    t.compile_fail("tests/ui/invalid_pycallargs.rs");
     t.compile_fail("tests/ui/reject_generics.rs");
     t.compile_fail("tests/ui/invalid_closure.rs");
     t.compile_fail("tests/ui/pyclass_send.rs");

--- a/tests/ui/invalid_pycallargs.rs
+++ b/tests/ui/invalid_pycallargs.rs
@@ -1,0 +1,8 @@
+use pyo3::prelude::*;
+
+fn main() {
+    Python::with_gil(|py| {
+        let any = py.None().into_bound(py);
+        any.call1("foo");
+    })
+}

--- a/tests/ui/invalid_pycallargs.stderr
+++ b/tests/ui/invalid_pycallargs.stderr
@@ -1,0 +1,29 @@
+error[E0277]: `&str` cannot used as a Python `call` argument
+ --> tests/ui/invalid_pycallargs.rs:6:19
+  |
+6 |         any.call1("foo");
+  |             ----- ^^^^^ the trait `PyCallArgs<'_>` is not implemented for `&str`
+  |             |
+  |             required by a bound introduced by this call
+  |
+  = note: `PyCallArgs` is implemented for Rust tuples, `Bound<'py, PyTuple>` and `Py<PyTuple>`
+  = note: if your type is convertable to `PyTuple` via `IntoPyObject`, call `<arg>.into_pyobject(py)` manually
+  = note: if you meant to pass the type as a single argument, wrap it in a 1-tuple, `(<arg>,)`
+  = help: the following other types implement trait `PyCallArgs<'py>`:
+            &'a (T0, T1)
+            &'a (T0, T1, T2)
+            &'a (T0, T1, T2, T3)
+            &'a (T0, T1, T2, T3, T4)
+            &'a (T0, T1, T2, T3, T4, T5)
+            &'a (T0, T1, T2, T3, T4, T5, T6)
+            &'a (T0, T1, T2, T3, T4, T5, T6, T7)
+            &'a (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+          and $N others
+note: required by a bound in `call1`
+ --> src/types/any.rs
+  |
+  |     fn call1<A>(&self, args: A) -> PyResult<Bound<'py, PyAny>>
+  |        ----- required by a bound in this associated function
+  |     where
+  |         A: PyCallArgs<'py>;
+  |            ^^^^^^^^^^^^^^^ required by this bound in `PyAnyMethods::call1`


### PR DESCRIPTION
This reintroduces the `vectorcall` optimization we removed temporarily in #4653 using a new `PyCallArgs` trait as was discussed during the initial implementation in #4456.

This slightly reduces the number of types that can be passed to `PyAnyMethods::call` and friends. With this only Rust tuples (including unit), `Bound<PyTuple>` and `Py<PyTuple>` are allowed (instead of any type that can be converted into a `PyTuple` via `IntoPyObject` as before). Inside `pyo3` there is no such type, but there could be user types (for example `#[derive(IntoPyObject)]` tuple structs) that won't work anymore. The work around is to simply convert at the call site, so I don't think that's a huge blocker.

There are still possibilities left open with regards to `kwargs`. One idea could be a `PyCallArgs` _type_ with a builder like API to set both, positional and keyword args which can than be transformed as needed depending on the calling convention (maybe with something like `smallvec` or even `heapless::Vec` to avoid lots of small allocation). I might explore that as a followup.

Closes #4656 