### PR TITLE
fix(pymodule): improve safety of PyModule::from_code

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -60,7 +60,7 @@ struct RustyStruct {
 #             c_str!("class Foo:
 #             def __init__(self):
 #                 self.my_string = 'test'"),
-#             c_str!(""),
+#             c_str!("<string>"),
 #             c_str!(""),
 #         )?;
 #
@@ -119,7 +119,7 @@ struct RustyStruct {
 #             def __init__(self):
 #                 self.name = 'test'
 #                 self['key'] = 'test2'"),
-#             c_str!(""),
+#             c_str!("<string>"),
 #             c_str!(""),
 #         )?;
 #
@@ -349,7 +349,7 @@ enum RustyEnum<'py> {
 #                 self.x = 0
 #                 self.y = 1
 #                 self.z = 2"),
-#                 c_str!(""),
+#                 c_str!("<string>"),
 #                 c_str!(""),
 #             )?;
 #
@@ -373,7 +373,7 @@ enum RustyEnum<'py> {
 #             def __init__(self):
 #                 self.x = 3
 #                 self.y = 4"),
-#                 c_str!(""),
+#                 c_str!("<string>"),
 #                 c_str!(""),
 #             )?;
 #

--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -265,8 +265,8 @@ fn main() -> PyResult<()> {
     )));
     let py_app = c_str!(include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/python_app/app.py")));
     let from_python = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
-        PyModule::from_code(py, py_foo, c_str!("utils.foo"), c_str!("utils.foo"))?;
-        let app: Py<PyAny> = PyModule::from_code(py, py_app, c_str!(""), c_str!(""))?
+        PyModule::from_code(py, py_foo, c_str!("foo.py"), c_str!("utils.foo"))?;
+        let app: Py<PyAny> = PyModule::from_code(py, py_app, c_str!("app.py"), c_str!(""))?
             .getattr("run")?
             .into();
         app.call0(py)
@@ -305,7 +305,7 @@ fn main() -> PyResult<()> {
             .getattr("path")?
             .downcast_into::<PyList>()?;
         syspath.insert(0, path)?;
-        let app: Py<PyAny> = PyModule::from_code(py, py_app.as_c_str(), c_str!(""), c_str!(""))?
+        let app: Py<PyAny> = PyModule::from_code(py, py_app.as_c_str(), c_str!("app.py"), c_str!(""))?
             .getattr("run")?
             .into();
         app.call0(py)

--- a/guide/src/python-from-rust/function-calls.md
+++ b/guide/src/python-from-rust/function-calls.md
@@ -36,7 +36,7 @@ fn main() -> PyResult<()> {
                     print('called with kwargs', kwargs)
                 if args == () and kwargs == {}:
                     print('called with no arguments')"),
-            c_str!(""),
+            c_str!("example.py"),
             c_str!(""),
         )?
         .getattr("example")?
@@ -83,7 +83,7 @@ fn main() -> PyResult<()> {
                     print('called with kwargs', kwargs)
                 if args == () and kwargs == {}:
                     print('called with no arguments')"),
-            c_str!(""),
+            c_str!("example.py"),
             c_str!(""),
         )?
         .getattr("example")?

--- a/newsfragments/4777.changed.md
+++ b/newsfragments/4777.changed.md
@@ -1,0 +1,1 @@
+`PyModule::from_code` now defaults `file_name` to `<string>` if empty. Ref #4769

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -457,7 +457,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
-    ///     let module = PyModule::from_code(py, CODE, c_str!(""), c_str!(""))?;
+    ///     let module = PyModule::from_code(py, CODE, c_str!("func.py"), c_str!(""))?;
     ///     let fun = module.getattr("function")?;
     ///     let args = ("hello",);
     ///     let kwargs = PyDict::new(py);
@@ -514,7 +514,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
-    ///     let module = PyModule::from_code(py, CODE, c_str!(""), c_str!(""))?;
+    ///     let module = PyModule::from_code(py, CODE, c_str!("func.py"), c_str!(""))?;
     ///     let fun = module.getattr("function")?;
     ///     let args = ("hello",);
     ///     let result = fun.call1(args)?;
@@ -553,7 +553,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
-    ///     let module = PyModule::from_code(py, CODE, c_str!(""), c_str!(""))?;
+    ///     let module = PyModule::from_code(py, CODE, c_str!("a.py"), c_str!(""))?;
     ///     let instance = module.getattr("a")?;
     ///     let args = ("hello",);
     ///     let kwargs = PyDict::new(py);
@@ -599,7 +599,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
-    ///     let module = PyModule::from_code(py, CODE, c_str!(""), c_str!(""))?;
+    ///     let module = PyModule::from_code(py, CODE, c_str!("a.py"), c_str!(""))?;
     ///     let instance = module.getattr("a")?;
     ///     let result = instance.call_method0("method")?;
     ///     assert_eq!(result.extract::<String>()?, "called with no arguments");
@@ -636,7 +636,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///
     /// # fn main() -> PyResult<()> {
     /// Python::with_gil(|py| {
-    ///     let module = PyModule::from_code(py, CODE, c_str!(""), c_str!(""))?;
+    ///     let module = PyModule::from_code(py, CODE, c_str!("a.py"), c_str!(""))?;
     ///     let instance = module.getattr("a")?;
     ///     let args = ("hello",);
     ///     let result = instance.call_method1("method", args)?;

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -548,6 +548,8 @@ fn __name__(py: Python<'_>) -> &Bound<'_, PyString> {
 
 #[cfg(test)]
 mod tests {
+    use pyo3_ffi::c_str;
+
     use crate::{
         types::{module::PyModuleMethods, PyModule},
         Python,
@@ -572,6 +574,14 @@ mod tests {
                 .to_cow()
                 .unwrap()
                 .ends_with("site.py"));
+        })
+    }
+
+    #[test]
+    fn module_from_code_empty_file() {
+        Python::with_gil(|py| {
+            let builtins = PyModule::from_code(py, c_str!(""), c_str!(""), c_str!("")).unwrap();
+            assert_eq!(builtins.filename().unwrap(), "<string>");
         })
     }
 }

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -1,3 +1,5 @@
+use pyo3_ffi::c_str;
+
 use crate::err::{PyErr, PyResult};
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::impl_::callback::IntoPyCallbackOutput;
@@ -95,6 +97,8 @@ impl PyModule {
     /// containing the Python code passed to `code`
     /// and pretending to live at `file_name`.
     ///
+    /// If `file_name` is empty, it will be set to `<string>`.
+    ///
     /// <div class="information">
     ///     <div class="tooltip compile_fail" style="">&#x26a0; &#xfe0f;</div>
     /// </div><div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
@@ -154,6 +158,11 @@ impl PyModule {
         file_name: &CStr,
         module_name: &CStr,
     ) -> PyResult<Bound<'py, PyModule>> {
+        let file_name = if file_name.is_empty() {
+            c_str!("<string>")
+        } else {
+            file_name
+        };
         unsafe {
             let code = ffi::Py_CompileString(code.as_ptr(), file_name.as_ptr(), ffi::Py_file_input)
                 .assume_owned_or_err(py)?;


### PR DESCRIPTION
If `PyImport_ExecCodeModuleEx` is called with an empty filename or module name, references to any Python variables defined in this context may break assumptions in standard library code.

Notably, if `inspect.stack()` is called while any stack frame holds a reference to a variable declared in this Python snippet, and `file_name` is empty, then `inspect.stack()` will throw while trying to resolve the file in which said variable was defined.

The `exec` builtin handles this by defaulting `file_name` to `<string>` and `module_name` to `<module>` - these are not the most obvious defaults, but in the spirit of consistency and providing pyo3 users with a safe API, it makes sense for `PyModule::from_code` to do the same.

Fixes #4769 

---

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
