### PR TITLE
Fix PyDict issues on free-threaded build

### DIFF
--- a/newsfragments/4788.fixed.md
+++ b/newsfragments/4788.fixed.md
@@ -1,0 +1,4 @@
+* Fixed thread-unsafe access of dict internals in BoundDictIterator on the
+  free-threaded build.
+* Avoided creating unnecessary critical sections in BoundDictIterator
+  implementation on the free-threaded build.

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -437,9 +437,10 @@ enum DictIterImpl {
 }
 
 impl DictIterImpl {
+    #[deny(unsafe_op_in_unsafe_fn)]
+    #[inline]
     /// Safety: the dict should be locked with a critical section on the free-threaded build
     /// and otherwise not shared between threads in code that releases the GIL.
-    #[inline]
     unsafe fn next_unchecked<'py>(
         &mut self,
         dict: &Bound<'py, PyDict>,

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -512,10 +512,17 @@ impl<'py> Iterator for BoundDictIterator<'py> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner
-            .with_critical_section(&self.dict, |inner| unsafe {
-                inner.next_unchecked(&self.dict)
-            })
+        #[cfg(Py_GIL_DISABLED)]
+        {
+            self.inner
+                .with_critical_section(&self.dict, |inner| unsafe {
+                    inner.next_unchecked(&self.dict)
+                })
+        }
+        #[cfg(not(Py_GIL_DISABLED))]
+        {
+            unsafe { self.inner.next_unchecked(&self.dict) }
+        }
     }
 
     #[inline]

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -437,9 +437,9 @@ enum DictIterImpl {
 }
 
 impl DictIterImpl {
-    #[inline]
     /// Safety: the dict should be locked with a critical section on the free-threaded build
     /// and otherwise not shared between threads in code that releases the GIL.
+    #[inline]
     unsafe fn next_unchecked<'py>(
         &mut self,
         dict: &Bound<'py, PyDict>,

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -181,7 +181,8 @@ pub trait PyDictMethods<'py>: crate::sealed::Sealed {
     /// Iterates over the contents of this dictionary while holding a critical section on the dict.
     /// This is useful when the GIL is disabled and the dictionary is shared between threads.
     /// It is not guaranteed that the dictionary will not be modified during iteration when the
-    /// closure calls arbitrary Python code that releases the current critical section.
+    /// closure calls arbitrary Python code that releases the critical section held by the
+    /// iterator. Otherwise, the dictionary will not be modified during iteration.
     ///
     /// This method is a small performance optimization over `.iter().try_for_each()` when the
     /// nightly feature is not enabled because we cannot implement an optimised version of
@@ -396,7 +397,8 @@ impl<'a, 'py> Borrowed<'a, 'py, PyDict> {
     /// Iterates over the contents of this dictionary without incrementing reference counts.
     ///
     /// # Safety
-    /// It must be known that this dictionary will not be modified during iteration.
+    /// It must be known that this dictionary will not be modified during iteration,
+    /// for example, when parsing arguments in a keyword arguments dictionary.
     pub(crate) unsafe fn iter_borrowed(self) -> BorrowedDictIter<'a, 'py> {
         BorrowedDictIter::new(self)
     }

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -405,12 +405,18 @@ impl<'a, 'py> Borrowed<'a, 'py, PyDict> {
 }
 
 fn dict_len(dict: &Bound<'_, PyDict>) -> Py_ssize_t {
-    #[cfg(any(not(Py_3_8), PyPy, GraalPy, Py_LIMITED_API))]
+    #[cfg(any(not(Py_3_8), PyPy, GraalPy, Py_LIMITED_API, Py_GIL_DISABLED))]
     unsafe {
         ffi::PyDict_Size(dict.as_ptr())
     }
 
-    #[cfg(all(Py_3_8, not(PyPy), not(GraalPy), not(Py_LIMITED_API)))]
+    #[cfg(all(
+        Py_3_8,
+        not(PyPy),
+        not(GraalPy),
+        not(Py_LIMITED_API),
+        not(Py_GIL_DISABLED)
+    ))]
     unsafe {
         (*dict.as_ptr().cast::<ffi::PyDictObject>()).ma_used
     }


### PR DESCRIPTION
This fixes two issues with PyDict on the free-threaded build.

* We were acquiring an inner critical section in `next()` in functions where we had already acquired an outer critical section. That is unnecessary. I've renamed `DictIterImpl::DictIter::next` to `next_unchecked`, marked it `unsafe`, and systematically used it in spots where we already had a critical section acquired. In the only spot we didn't, I manually added a critical section. I think having an unsafe `next_unchecked` is easier to reason about - you need to do the locking yourself.

* We were accessing dict internals in a thread-unsafe manner, we should go through the C API on the free-threaded build. CPython uses a relaxed atomic load internally.

Also includes some minor doc improvements.

This should probably be backported to the 0.23 branch.

ping @bschoenmaeckers