### PR TITLE
use `datetime.fold` to distinguish ambiguous datetimes when converting

### DIFF
--- a/newsfragments/4791.fixed.md
+++ b/newsfragments/4791.fixed.md
@@ -1,0 +1,1 @@
+use `datetime.fold` to distinguish ambiguous datetimes when converting to `chrono::DateTime<Tz>`

--- a/newsfragments/4791.fixed.md
+++ b/newsfragments/4791.fixed.md
@@ -1,1 +1,1 @@
-use `datetime.fold` to distinguish ambiguous datetimes when converting to `chrono::DateTime<Tz>`
+use `datetime.fold` to distinguish ambiguous datetimes when converting to and from `chrono::DateTime<Tz>`

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -48,6 +48,8 @@ use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 #[cfg(not(Py_LIMITED_API))]
 use crate::types::datetime::timezone_from_offset;
+#[cfg(Py_LIMITED_API)]
+use crate::types::IntoPyDict;
 use crate::types::PyNone;
 #[cfg(not(Py_LIMITED_API))]
 use crate::types::{
@@ -466,14 +468,21 @@ where
             truncated_leap_second,
         } = (&self.naive_local().time()).into();
 
+        let fold = matches!(
+            self.timezone().offset_from_local_datetime(&self.naive_local()),
+            LocalResult::Ambiguous(_, latest) if self.offset().fix() == latest.fix()
+        );
+
         #[cfg(not(Py_LIMITED_API))]
-        let datetime = PyDateTime::new(py, year, month, day, hour, min, sec, micro, Some(tz))?;
+        let datetime =
+            PyDateTime::new_with_fold(py, year, month, day, hour, min, sec, micro, Some(tz), fold)?;
 
         #[cfg(Py_LIMITED_API)]
         let datetime = DatetimeTypes::try_get(py).and_then(|dt| {
-            dt.datetime
-                .bind(py)
-                .call1((year, month, day, hour, min, sec, micro, tz))
+            dt.datetime.bind(py).call(
+                (year, month, day, hour, min, sec, micro, tz),
+                Some(&[("fold", fold as u8)].into_py_dict(py)?),
+            )
         })?;
 
         if truncated_leap_second {

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -98,6 +98,10 @@ impl FromPyObject<'_> for Tz {
 #[cfg(all(test, not(windows)))] // Troubles loading timezones on Windows
 mod tests {
     use super::*;
+    use crate::prelude::PyAnyMethods;
+    use crate::Python;
+    use chrono::{DateTime, Utc};
+    use chrono_tz::Tz;
 
     #[test]
     fn test_frompyobject() {
@@ -112,6 +116,54 @@ mod tests {
                 Tz::Etc__GMTMinus5
             );
         });
+    }
+
+    #[test]
+    fn test_ambiguous_datetime_to_pyobject() {
+        let dates = [
+            DateTime::<Utc>::from_str("2020-10-24 23:00:00 UTC").unwrap(),
+            DateTime::<Utc>::from_str("2020-10-25 00:00:00 UTC").unwrap(),
+            DateTime::<Utc>::from_str("2020-10-25 01:00:00 UTC").unwrap(),
+        ];
+
+        let dates = dates.map(|dt| dt.with_timezone(&Tz::Europe__London));
+
+        assert_eq!(
+            dates.map(|dt| dt.to_string()),
+            [
+                "2020-10-25 00:00:00 BST",
+                "2020-10-25 01:00:00 BST",
+                "2020-10-25 01:00:00 GMT"
+            ]
+        );
+
+        let dates = Python::with_gil(|py| {
+            let pydates = dates.map(|dt| dt.into_pyobject(py).unwrap());
+            assert_eq!(
+                pydates
+                    .clone()
+                    .map(|dt| dt.getattr("hour").unwrap().extract::<usize>().unwrap()),
+                [0, 1, 1]
+            );
+
+            assert_eq!(
+                pydates
+                    .clone()
+                    .map(|dt| dt.getattr("fold").unwrap().extract::<usize>().unwrap() > 0),
+                [false, false, true]
+            );
+
+            pydates.map(|dt| dt.extract::<DateTime<Tz>>().unwrap())
+        });
+
+        assert_eq!(
+            dates.map(|dt| dt.to_string()),
+            [
+                "2020-10-25 00:00:00 BST",
+                "2020-10-25 01:00:00 BST",
+                "2020-10-25 01:00:00 GMT"
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
fixes #4722 
