### PR TITLE
fix `#[pyclass]` could not be named `Probe`

### DIFF
--- a/newsfragments/4794.fixed.md
+++ b/newsfragments/4794.fixed.md
@@ -1,0 +1,1 @@
+fix `#[pyclass]` could not be named `Probe`

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2294,10 +2294,9 @@ impl<'a> PyClassImplsBuilder<'a> {
         let assertions = if attr.options.unsendable.is_some() {
             TokenStream::new()
         } else {
-            let assert = quote_spanned! { cls.span() => assert_pyclass_sync::<#cls>(); };
+            let assert = quote_spanned! { cls.span() => #pyo3_path::impl_::pyclass::assert_pyclass_sync::<#cls>(); };
             quote! {
                 const _: () = {
-                    use #pyo3_path::impl_::pyclass::*;
                     #assert
                 };
             }
@@ -2337,7 +2336,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     static DOC: #pyo3_path::sync::GILOnceCell<::std::borrow::Cow<'static, ::std::ffi::CStr>> = #pyo3_path::sync::GILOnceCell::new();
                     DOC.get_or_try_init(py, || {
                         let collector = PyClassImplCollector::<Self>::new();
-                        build_pyclass_doc(<#cls as #pyo3_path::PyTypeInfo>::NAME, #doc, collector.new_text_signature())
+                        build_pyclass_doc(<Self as #pyo3_path::PyTypeInfo>::NAME, #doc, collector.new_text_signature())
                     }).map(::std::ops::Deref::deref)
                 }
 

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -67,4 +67,5 @@ fn test_compile_errors() {
     #[cfg(all(not(Py_LIMITED_API), Py_3_11))]
     t.compile_fail("tests/ui/invalid_base_class.rs");
     t.pass("tests/ui/ambiguous_associated_items.rs");
+    t.pass("tests/ui/pyclass_probe.rs");
 }

--- a/tests/ui/pyclass_probe.rs
+++ b/tests/ui/pyclass_probe.rs
@@ -1,0 +1,6 @@
+use pyo3::prelude::*;
+
+#[pyclass]
+pub struct Probe {}
+
+fn main() {}

--- a/tests/ui/pyclass_send.stderr
+++ b/tests/ui/pyclass_send.stderr
@@ -10,7 +10,7 @@ note: required because it appears within the type `NotSyncNotSend`
   |
 5 | struct NotSyncNotSend(*mut c_void);
   |        ^^^^^^^^^^^^^^
-note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
+note: required by a bound in `assert_pyclass_sync`
  --> src/impl_/pyclass/assertions.rs
   |
   | pub const fn assert_pyclass_sync<T>()
@@ -52,7 +52,7 @@ note: required because it appears within the type `SendNotSync`
   |
 8 | struct SendNotSync(*mut c_void);
   |        ^^^^^^^^^^^
-note: required by a bound in `pyo3::impl_::pyclass::assertions::assert_pyclass_sync`
+note: required by a bound in `assert_pyclass_sync`
  --> src/impl_/pyclass/assertions.rs
   |
   | pub const fn assert_pyclass_sync<T>()


### PR DESCRIPTION
Fixes  `#[pyclass]` could not be named `Probe`.

Closes #4792 