### PR TITLE
fix: cross-compilation compatibility checks for Windows

### DIFF
--- a/newsfragments/4800.fixed.md
+++ b/newsfragments/4800.fixed.md
@@ -1,0 +1,1 @@
+fix: cross-compilation compatibility checks for Windows

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -2897,6 +2897,16 @@ mod tests {
     }
 
     #[test]
+    fn test_is_cross_compiling_from_to() {
+        assert!(cross_compiling_from_to(
+            &triple!("x86_64-pc-windows-msvc"),
+            &triple!("aarch64-pc-windows-msvc")
+        )
+        .unwrap()
+        .is_some());
+    }
+
+    #[test]
     fn test_run_python_script() {
         // as above, this should be okay in CI where Python is presumed installed
         let interpreter = make_interpreter_config()

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -22,7 +22,7 @@ use std::{
 
 pub use target_lexicon::Triple;
 
-use target_lexicon::{Environment, OperatingSystem};
+use target_lexicon::{Architecture, Environment, OperatingSystem};
 
 use crate::{
     bail, ensure,
@@ -931,7 +931,9 @@ impl CrossCompileConfig {
 
         // Not cross-compiling to compile for 32-bit Python from windows 64-bit
         compatible |= target.operating_system == OperatingSystem::Windows
-            && host.operating_system == OperatingSystem::Windows;
+            && host.operating_system == OperatingSystem::Windows
+            && matches!(target.architecture, Architecture::X86_32(_))
+            && host.architecture == Architecture::X86_64;
 
         // Not cross-compiling to compile for x86-64 Python from macOS arm64 and vice versa
         compatible |= target.operating_system == OperatingSystem::Darwin


### PR DESCRIPTION
`pyo3-build-config` has an `is_cross_compiling_from_to` check which returns `false` when compiling for 32-bit on 64-bit Windows, but the check doesn't take Windows on Arm into consideration and simply returns `false` when both `host` and `target` are Windows, resulting in compilation failure when cross-compiling for aarch64 on x86-64 Windows.

This PR fixes the check according to the original comment, and `marutin build --target aarch64-pc-windows-msvc` works as expected on x86-64 Windows with MSVC toolchain.

Related Issue: https://github.com/PyO3/maturin/issues/2368

I wonder if this PR should be merged with #4773.