### PR TITLE
Fix struct layouts on GraalPy

### DIFF
--- a/newsfragments/4802.fixed.md
+++ b/newsfragments/4802.fixed.md
@@ -1,0 +1,1 @@
+Fixed missing struct fields on GraalPy when subclassing builtin classes

--- a/pyo3-ffi/src/abstract_.rs
+++ b/pyo3-ffi/src/abstract_.rs
@@ -17,7 +17,6 @@ pub unsafe fn PyObject_DelAttr(o: *mut PyObject, attr_name: *mut PyObject) -> c_
 extern "C" {
     #[cfg(all(
         not(PyPy),
-        not(GraalPy),
         any(Py_3_10, all(not(Py_LIMITED_API), Py_3_9)) // Added to python in 3.9 but to limited API in 3.10
     ))]
     #[cfg_attr(PyPy, link_name = "PyPyObject_CallNoArgs")]

--- a/pyo3-ffi/src/cpython/abstract_.rs
+++ b/pyo3-ffi/src/cpython/abstract_.rs
@@ -1,5 +1,7 @@
 use crate::{PyObject, Py_ssize_t};
-use std::os::raw::{c_char, c_int};
+#[cfg(not(all(Py_3_11, GraalPy)))]
+use std::os::raw::c_char;
+use std::os::raw::c_int;
 
 #[cfg(not(Py_3_11))]
 use crate::Py_buffer;

--- a/pyo3-ffi/src/cpython/complexobject.rs
+++ b/pyo3-ffi/src/cpython/complexobject.rs
@@ -19,7 +19,6 @@ pub struct Py_complex {
 #[repr(C)]
 pub struct PyComplexObject {
     pub ob_base: PyObject,
-    #[cfg(not(GraalPy))]
     pub cval: Py_complex,
 }
 

--- a/pyo3-ffi/src/cpython/floatobject.rs
+++ b/pyo3-ffi/src/cpython/floatobject.rs
@@ -6,7 +6,6 @@ use std::os::raw::c_double;
 #[repr(C)]
 pub struct PyFloatObject {
     pub ob_base: PyObject,
-    #[cfg(not(GraalPy))]
     pub ob_fval: c_double,
 }
 

--- a/pyo3-ffi/src/cpython/genobject.rs
+++ b/pyo3-ffi/src/cpython/genobject.rs
@@ -2,7 +2,7 @@ use crate::object::*;
 use crate::PyFrameObject;
 #[cfg(not(any(PyPy, GraalPy)))]
 use crate::_PyErr_StackItem;
-#[cfg(Py_3_11)]
+#[cfg(all(Py_3_11, not(GraalPy)))]
 use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::ptr::addr_of_mut;

--- a/pyo3-ffi/src/cpython/listobject.rs
+++ b/pyo3-ffi/src/cpython/listobject.rs
@@ -2,7 +2,7 @@ use crate::object::*;
 #[cfg(not(PyPy))]
 use crate::pyport::Py_ssize_t;
 
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(PyPy))]
 #[repr(C)]
 pub struct PyListObject {
     pub ob_base: PyVarObject,
@@ -10,7 +10,7 @@ pub struct PyListObject {
     pub allocated: Py_ssize_t,
 }
 
-#[cfg(any(PyPy, GraalPy))]
+#[cfg(PyPy)]
 pub struct PyListObject {
     pub ob_base: PyObject,
 }

--- a/pyo3-ffi/src/cpython/object.rs
+++ b/pyo3-ffi/src/cpython/object.rs
@@ -211,8 +211,6 @@ pub type printfunc =
 #[derive(Debug)]
 pub struct PyTypeObject {
     pub ob_base: object::PyVarObject,
-    #[cfg(GraalPy)]
-    pub ob_size: Py_ssize_t,
     pub tp_name: *const c_char,
     pub tp_basicsize: Py_ssize_t,
     pub tp_itemsize: Py_ssize_t,

--- a/pyo3-ffi/src/cpython/objimpl.rs
+++ b/pyo3-ffi/src/cpython/objimpl.rs
@@ -1,3 +1,4 @@
+#[cfg(not(all(Py_3_11, GraalPy)))]
 use libc::size_t;
 use std::os::raw::c_int;
 

--- a/pyo3-ffi/src/cpython/pyerrors.rs
+++ b/pyo3-ffi/src/cpython/pyerrors.rs
@@ -6,19 +6,19 @@ use crate::Py_ssize_t;
 #[derive(Debug)]
 pub struct PyBaseExceptionObject {
     pub ob_base: PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub dict: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub args: *mut PyObject,
-    #[cfg(all(Py_3_11, not(any(PyPy, GraalPy))))]
+    #[cfg(all(Py_3_11, not(PyPy)))]
     pub notes: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub traceback: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub context: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub cause: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub suppress_context: char,
 }
 
@@ -134,19 +134,19 @@ pub struct PyOSErrorObject {
 #[derive(Debug)]
 pub struct PyStopIterationObject {
     pub ob_base: PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub dict: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub args: *mut PyObject,
-    #[cfg(all(Py_3_11, not(any(PyPy, GraalPy))))]
+    #[cfg(all(Py_3_11, not(PyPy)))]
     pub notes: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub traceback: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub context: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub cause: *mut PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub suppress_context: char,
 
     pub value: *mut PyObject,

--- a/pyo3-ffi/src/cpython/tupleobject.rs
+++ b/pyo3-ffi/src/cpython/tupleobject.rs
@@ -5,7 +5,6 @@ use crate::pyport::Py_ssize_t;
 #[repr(C)]
 pub struct PyTupleObject {
     pub ob_base: PyVarObject,
-    #[cfg(not(GraalPy))]
     pub ob_item: [*mut PyObject; 1],
 }
 

--- a/pyo3-ffi/src/cpython/unicodeobject.rs
+++ b/pyo3-ffi/src/cpython/unicodeobject.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(PyPy))]
 use crate::Py_hash_t;
 use crate::{PyObject, Py_UCS1, Py_UCS2, Py_UCS4, Py_ssize_t};
 use libc::wchar_t;
@@ -250,9 +250,8 @@ impl From<PyASCIIObjectState> for u32 {
 #[repr(C)]
 pub struct PyASCIIObject {
     pub ob_base: PyObject,
-    #[cfg(not(GraalPy))]
     pub length: Py_ssize_t,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub hash: Py_hash_t,
     /// A bit field with various properties.
     ///
@@ -265,9 +264,8 @@ pub struct PyASCIIObject {
     /// unsigned int ascii:1;
     /// unsigned int ready:1;
     /// unsigned int :24;
-    #[cfg(not(GraalPy))]
     pub state: u32,
-    #[cfg(not(any(Py_3_12, GraalPy)))]
+    #[cfg(not(Py_3_12))]
     pub wstr: *mut wchar_t,
 }
 
@@ -379,11 +377,9 @@ impl PyASCIIObject {
 #[repr(C)]
 pub struct PyCompactUnicodeObject {
     pub _base: PyASCIIObject,
-    #[cfg(not(GraalPy))]
     pub utf8_length: Py_ssize_t,
-    #[cfg(not(GraalPy))]
     pub utf8: *mut c_char,
-    #[cfg(not(any(Py_3_12, GraalPy)))]
+    #[cfg(not(Py_3_12))]
     pub wstr_length: Py_ssize_t,
 }
 
@@ -398,7 +394,6 @@ pub union PyUnicodeObjectData {
 #[repr(C)]
 pub struct PyUnicodeObject {
     pub _base: PyCompactUnicodeObject,
-    #[cfg(not(GraalPy))]
     pub data: PyUnicodeObjectData,
 }
 

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -9,13 +9,12 @@ use crate::PyCapsule_Import;
 #[cfg(GraalPy)]
 use crate::{PyLong_AsLong, PyLong_Check, PyObject_GetAttrString, Py_DecRef};
 use crate::{PyObject, PyObject_TypeCheck, PyTypeObject, Py_TYPE};
-#[cfg(not(GraalPy))]
 use std::os::raw::c_char;
 use std::os::raw::c_int;
 use std::ptr;
 use std::sync::Once;
 use std::{cell::UnsafeCell, ffi::CStr};
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(PyPy))]
 use {crate::Py_hash_t, std::os::raw::c_uchar};
 // Type struct wrappers
 const _PyDateTime_DATE_DATASIZE: usize = 4;
@@ -27,13 +26,10 @@ const _PyDateTime_DATETIME_DATASIZE: usize = 10;
 /// Structure representing a `datetime.timedelta`.
 pub struct PyDateTime_Delta {
     pub ob_base: PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub hashcode: Py_hash_t,
-    #[cfg(not(GraalPy))]
     pub days: c_int,
-    #[cfg(not(GraalPy))]
     pub seconds: c_int,
-    #[cfg(not(GraalPy))]
     pub microseconds: c_int,
 }
 
@@ -56,19 +52,17 @@ pub struct _PyDateTime_BaseTime {
 /// Structure representing a `datetime.time`.
 pub struct PyDateTime_Time {
     pub ob_base: PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub hashcode: Py_hash_t,
-    #[cfg(not(GraalPy))]
     pub hastzinfo: c_char,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub data: [c_uchar; _PyDateTime_TIME_DATASIZE],
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub fold: c_uchar,
     /// # Safety
     ///
     /// Care should be taken when reading this field. If the time does not have a
     /// tzinfo then CPython may allocate as a `_PyDateTime_BaseTime` without this field.
-    #[cfg(not(GraalPy))]
     pub tzinfo: *mut PyObject,
 }
 
@@ -77,11 +71,11 @@ pub struct PyDateTime_Time {
 /// Structure representing a `datetime.date`
 pub struct PyDateTime_Date {
     pub ob_base: PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub hashcode: Py_hash_t,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub hastzinfo: c_char,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub data: [c_uchar; _PyDateTime_DATE_DATASIZE],
 }
 
@@ -101,19 +95,17 @@ pub struct _PyDateTime_BaseDateTime {
 /// Structure representing a `datetime.datetime`.
 pub struct PyDateTime_DateTime {
     pub ob_base: PyObject,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub hashcode: Py_hash_t,
-    #[cfg(not(GraalPy))]
     pub hastzinfo: c_char,
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub data: [c_uchar; _PyDateTime_DATETIME_DATASIZE],
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(PyPy))]
     pub fold: c_uchar,
     /// # Safety
     ///
     /// Care should be taken when reading this field. If the time does not have a
     /// tzinfo then CPython may allocate as a `_PyDateTime_BaseDateTime` without this field.
-    #[cfg(not(GraalPy))]
     pub tzinfo: *mut PyObject,
 }
 

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -129,6 +129,9 @@ pub struct PyVarObject {
     pub ob_base: PyObject,
     #[cfg(not(GraalPy))]
     pub ob_size: Py_ssize_t,
+    // On GraalPy the field is physically there, but not always populated. We hide it to prevent accidental misuse
+    #[cfg(GraalPy)]
+    pub _ob_size_graalpy: Py_ssize_t,
 }
 
 // skipped private _PyVarObject_CAST

--- a/pyo3-ffi/src/pyhash.rs
+++ b/pyo3-ffi/src/pyhash.rs
@@ -1,7 +1,9 @@
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
 use crate::pyport::{Py_hash_t, Py_ssize_t};
 #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-use std::os::raw::{c_char, c_void};
+use std::os::raw::c_char;
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+use std::os::raw::c_void;
 
 use std::os::raw::{c_int, c_ulong};
 
@@ -10,7 +12,7 @@ extern "C" {
     // skipped non-limited _Py_HashPointer
     // skipped non-limited _Py_HashPointerRaw
 
-    #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
+    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
     pub fn _Py_HashBytes(src: *const c_void, len: Py_ssize_t) -> Py_hash_t;
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -23,7 +23,7 @@ pub use self::float::{PyFloat, PyFloatMethods};
 pub use self::frame::PyFrame;
 pub use self::frozenset::{PyFrozenSet, PyFrozenSetBuilder, PyFrozenSetMethods};
 pub use self::function::PyCFunction;
-#[cfg(all(not(Py_LIMITED_API), not(all(PyPy, not(Py_3_8))), not(GraalPy)))]
+#[cfg(all(not(Py_LIMITED_API), not(all(PyPy, not(Py_3_8)))))]
 pub use self::function::PyFunction;
 pub use self::iterator::PyIterator;
 pub use self::list::{PyList, PyListMethods};


### PR DESCRIPTION
- The initial GraalPy support PR removed some struct fields with the intention of hiding them. But the fields are physically present, which caused layout mismatch when users tried to subclass them via PyO3. I add them back.
- I also exposed a few functions, which were previsously omitted on GraalPy, but are actually available.

CC @timfel 