### PR TITLE
Fix generating import lib for python3.13t when abi3 feature is enabled

### DIFF
--- a/newsfragments/4808.fixed.md
+++ b/newsfragments/4808.fixed.md
@@ -1,0 +1,1 @@
+Fix generating import lib for python3.13t when `abi3` feature is enabled.

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -13,11 +13,11 @@ rust-version = "1.63"
 
 [dependencies]
 once_cell = "1"
-python3-dll-a = { version = "0.2.11", optional = true }
+python3-dll-a = { version = "0.2.12", optional = true }
 target-lexicon = "0.13"
 
 [build-dependencies]
-python3-dll-a = { version = "0.2.11", optional = true }
+python3-dll-a = { version = "0.2.12", optional = true }
 target-lexicon = "0.13"
 
 [features]


### PR DESCRIPTION
Together with #4800 and https://github.com/PyO3/python3-dll-a/pull/84, resolves https://github.com/PyO3/maturin/issues/2385 for both native and cross compilation.