### PR TITLE
switch trait sealing in `impl_` module

### DIFF
--- a/src/internal_tricks.rs
+++ b/src/internal_tricks.rs
@@ -1,21 +1,4 @@
 use crate::ffi::{self, Py_ssize_t, PY_SSIZE_T_MAX};
-pub struct PrivateMarker;
-
-macro_rules! private_decl {
-    () => {
-        /// This trait is private to implement; this method exists to make it
-        /// impossible to implement outside the crate.
-        fn __private__(&self) -> crate::internal_tricks::PrivateMarker;
-    };
-}
-
-macro_rules! private_impl {
-    () => {
-        fn __private__(&self) -> crate::internal_tricks::PrivateMarker {
-            crate::internal_tricks::PrivateMarker
-        }
-    };
-}
 
 macro_rules! pyo3_exception {
     ($doc: expr, $name: ident, $base: ty) => {


### PR DESCRIPTION
Switches to modern trait sealing and removes the old helper macros.

Xref: #3908 