### PR TITLE
derive(FromPyObject): adds default option

### DIFF
--- a/newsfragments/4829.added.md
+++ b/newsfragments/4829.added.md
@@ -1,1 +1,1 @@
-`derive(FromPyObject)` allow a `default` attribute to set a default value for extracted fields. The default value is either provided explicitly or fetched via `Default::default()`.
+`derive(FromPyObject)` allow a `default` attribute to set a default value for extracted fields of named structs. The default value is either provided explicitly or fetched via `Default::default()`.

--- a/newsfragments/4829.added.md
+++ b/newsfragments/4829.added.md
@@ -1,0 +1,1 @@
+`derive(FromPyObject)` allow a `default` attribute to set a default value for extracted fields. The default value is either provided explicitly or fetched via `Default::default()`.

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -45,6 +45,7 @@ pub mod kw {
     syn::custom_keyword!(unsendable);
     syn::custom_keyword!(weakref);
     syn::custom_keyword!(gil_used);
+    syn::custom_keyword!(default);
 }
 
 fn take_int(read: &mut &str, tracker: &mut usize) -> String {
@@ -350,6 +351,8 @@ impl<K: ToTokens, V: ToTokens> ToTokens for OptionalKeywordAttribute<K, V> {
 }
 
 pub type FromPyWithAttribute = KeywordAttribute<kw::from_py_with, LitStrValue<ExprPath>>;
+
+pub type DefaultAttribute = OptionalKeywordAttribute<kw::default, Expr>;
 
 /// For specifying the path to the pyo3 crate.
 pub type CrateAttribute = KeywordAttribute<Token![crate], LitStrValue<Path>>;

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -45,7 +45,6 @@ pub mod kw {
     syn::custom_keyword!(unsendable);
     syn::custom_keyword!(weakref);
     syn::custom_keyword!(gil_used);
-    syn::custom_keyword!(default);
 }
 
 fn take_int(read: &mut &str, tracker: &mut usize) -> String {
@@ -352,7 +351,7 @@ impl<K: ToTokens, V: ToTokens> ToTokens for OptionalKeywordAttribute<K, V> {
 
 pub type FromPyWithAttribute = KeywordAttribute<kw::from_py_with, LitStrValue<ExprPath>>;
 
-pub type DefaultAttribute = OptionalKeywordAttribute<kw::default, Expr>;
+pub type DefaultAttribute = OptionalKeywordAttribute<Token![default], Expr>;
 
 /// For specifying the path to the pyo3 crate.
 pub type CrateAttribute = KeywordAttribute<Token![crate], LitStrValue<Path>>;

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -1,7 +1,9 @@
-use crate::attributes::{self, get_pyo3_options, CrateAttribute, FromPyWithAttribute};
+use crate::attributes::{
+    self, get_pyo3_options, CrateAttribute, DefaultAttribute, FromPyWithAttribute,
+};
 use crate::utils::Ctx;
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, ToTokens};
 use syn::{
     ext::IdentExt,
     parenthesized,
@@ -90,6 +92,7 @@ struct NamedStructField<'a> {
     ident: &'a syn::Ident,
     getter: Option<FieldGetter>,
     from_py_with: Option<FromPyWithAttribute>,
+    default: Option<DefaultAttribute>,
 }
 
 struct TupleStructField {
@@ -193,6 +196,7 @@ impl<'a> Container<'a> {
                             ident,
                             getter: attrs.getter,
                             from_py_with: attrs.from_py_with,
+                            default: attrs.default,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?;
@@ -346,18 +350,33 @@ impl<'a> Container<'a> {
                     quote!(#pyo3_path::types::PyAnyMethods::get_item(obj, #pyo3_path::intern!(obj.py(), #field_name)))
                 }
             };
-            let extractor = match &field.from_py_with {
-                None => {
-                    quote!(#pyo3_path::impl_::frompyobject::extract_struct_field(&#getter?, #struct_name, #field_name)?)
-                }
-                Some(FromPyWithAttribute {
-                    value: expr_path, ..
-                }) => {
-                    quote! (#pyo3_path::impl_::frompyobject::extract_struct_field_with(#expr_path as fn(_) -> _, &#getter?, #struct_name, #field_name)?)
-                }
+            let extractor = if let Some(FromPyWithAttribute {
+                value: expr_path, ..
+            }) = &field.from_py_with
+            {
+                quote!(#pyo3_path::impl_::frompyobject::extract_struct_field_with(#expr_path as fn(_) -> _, &value, #struct_name, #field_name)?)
+            } else {
+                quote!(#pyo3_path::impl_::frompyobject::extract_struct_field(&value, #struct_name, #field_name)?)
+            };
+            let extracted = if let Some(default) = &field.default {
+                let default_expr = if let Some(default_expr) = &default.value {
+                    default_expr.to_token_stream()
+                } else {
+                    quote!(Default::default())
+                };
+                quote!(if let Ok(value) = #getter {
+                    #extractor
+                } else {
+                    #default_expr
+                })
+            } else {
+                quote!({
+                    let value = #getter?;
+                    #extractor
+                })
             };
 
-            fields.push(quote!(#ident: #extractor));
+            fields.push(quote!(#ident: #extracted));
         }
 
         quote!(::std::result::Result::Ok(#self_ty{#fields}))
@@ -458,6 +477,7 @@ impl ContainerOptions {
 struct FieldPyO3Attributes {
     getter: Option<FieldGetter>,
     from_py_with: Option<FromPyWithAttribute>,
+    default: Option<DefaultAttribute>,
 }
 
 #[derive(Clone, Debug)]
@@ -469,6 +489,7 @@ enum FieldGetter {
 enum FieldPyO3Attribute {
     Getter(FieldGetter),
     FromPyWith(FromPyWithAttribute),
+    Default(DefaultAttribute),
 }
 
 impl Parse for FieldPyO3Attribute {
@@ -512,6 +533,8 @@ impl Parse for FieldPyO3Attribute {
             }
         } else if lookahead.peek(attributes::kw::from_py_with) {
             input.parse().map(FieldPyO3Attribute::FromPyWith)
+        } else if lookahead.peek(attributes::kw::default) {
+            input.parse().map(FieldPyO3Attribute::Default)
         } else {
             Err(lookahead.error())
         }
@@ -523,6 +546,7 @@ impl FieldPyO3Attributes {
     fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
         let mut getter = None;
         let mut from_py_with = None;
+        let mut default = None;
 
         for attr in attrs {
             if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
@@ -542,6 +566,13 @@ impl FieldPyO3Attributes {
                             );
                             from_py_with = Some(from_py_with_attr);
                         }
+                        FieldPyO3Attribute::Default(default_attr) => {
+                            ensure_spanned!(
+                                default.is_none(),
+                                attr.span() => "`default` may only be provided once"
+                            );
+                            default = Some(default_attr);
+                        }
                     }
                 }
             }
@@ -550,6 +581,7 @@ impl FieldPyO3Attributes {
         Ok(FieldPyO3Attributes {
             getter,
             from_py_with,
+            default,
         })
     }
 }

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -362,9 +362,9 @@ impl<'a> Container<'a> {
                 let default_expr = if let Some(default_expr) = &default.value {
                     default_expr.to_token_stream()
                 } else {
-                    quote!(Default::default())
+                    quote!(::std::default::Default::default())
                 };
-                quote!(if let Ok(value) = #getter {
+                quote!(if let ::std::result::Result::Ok(value) = #getter {
                     #extractor
                 } else {
                     #default_expr
@@ -533,7 +533,7 @@ impl Parse for FieldPyO3Attribute {
             }
         } else if lookahead.peek(attributes::kw::from_py_with) {
             input.parse().map(FieldPyO3Attribute::FromPyWith)
-        } else if lookahead.peek(attributes::kw::default) {
+        } else if lookahead.peek(Token![default]) {
             input.parse().map(FieldPyO3Attribute::Default)
         } else {
             Err(lookahead.error())

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -147,6 +147,10 @@ impl<'a> Container<'a> {
                             attrs.getter.is_none(),
                             field.span() => "`getter` is not permitted on tuple struct elements."
                         );
+                        ensure_spanned!(
+                            attrs.default.is_none(),
+                            field.span() => "`default` is not permitted on tuple struct elements."
+                        );
                         Ok(TupleStructField {
                             from_py_with: attrs.from_py_with,
                         })
@@ -200,7 +204,11 @@ impl<'a> Container<'a> {
                         })
                     })
                     .collect::<Result<Vec<_>>>()?;
-                if options.transparent {
+                if struct_fields.iter().all(|field| field.default.is_some()) {
+                    bail_spanned!(
+                        fields.span() => "cannot derive FromPyObject for structs and variants with only default values"
+                    )
+                } else if options.transparent {
                     ensure_spanned!(
                         struct_fields.len() == 1,
                         fields.span() => "transparent structs and variants can only have 1 field"

--- a/src/tests/hygiene/misc.rs
+++ b/src/tests/hygiene/misc.rs
@@ -12,6 +12,8 @@ struct Derive3 {
     f: i32,
     #[pyo3(item(42))]
     g: i32,
+    #[pyo3(default)]
+    h: i32,
 } // struct case
 
 #[derive(crate::FromPyObject)]

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -718,3 +718,38 @@ fn test_with_explicit_default_item() {
         assert_eq!(result, expected);
     });
 }
+
+#[derive(Debug, FromPyObject, PartialEq, Eq)]
+pub struct WithDefaultItemAndConversionFunction {
+    #[pyo3(item, default, from_py_with = "Bound::<'_, PyAny>::len")]
+    value: usize,
+}
+
+#[test]
+fn test_with_default_item_and_conversion_function() {
+    Python::with_gil(|py| {
+        // Filled case
+        let dict = PyDict::new(py);
+        dict.set_item("value", (1,)).unwrap();
+        let result = dict
+            .extract::<WithDefaultItemAndConversionFunction>()
+            .unwrap();
+        let expected = WithDefaultItemAndConversionFunction { value: 1 };
+        assert_eq!(result, expected);
+
+        // Empty case
+        let dict = PyDict::new(py);
+        let result = dict
+            .extract::<WithDefaultItemAndConversionFunction>()
+            .unwrap();
+        let expected = WithDefaultItemAndConversionFunction { value: 0 };
+        assert_eq!(result, expected);
+
+        // Error case
+        let dict = PyDict::new(py);
+        dict.set_item("value", 1).unwrap();
+        assert!(dict
+            .extract::<WithDefaultItemAndConversionFunction>()
+            .is_err());
+    });
+}

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -686,3 +686,35 @@ fn test_with_keyword_item() {
         assert_eq!(result, expected);
     });
 }
+
+#[derive(Debug, FromPyObject, PartialEq, Eq)]
+pub struct WithDefaultItem {
+    #[pyo3(item, default)]
+    value: Option<usize>,
+}
+
+#[test]
+fn test_with_default_item() {
+    Python::with_gil(|py| {
+        let dict = PyDict::new(py);
+        let result = dict.extract::<WithDefaultItem>().unwrap();
+        let expected = WithDefaultItem { value: None };
+        assert_eq!(result, expected);
+    });
+}
+
+#[derive(Debug, FromPyObject, PartialEq, Eq)]
+pub struct WithExplicitDefaultItem {
+    #[pyo3(item, default = 1)]
+    value: usize,
+}
+
+#[test]
+fn test_with_explicit_default_item() {
+    Python::with_gil(|py| {
+        let dict = PyDict::new(py);
+        let result = dict.extract::<WithExplicitDefaultItem>().unwrap();
+        let expected = WithExplicitDefaultItem { value: 1 };
+        assert_eq!(result, expected);
+    });
+}

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -690,15 +690,21 @@ fn test_with_keyword_item() {
 #[derive(Debug, FromPyObject, PartialEq, Eq)]
 pub struct WithDefaultItem {
     #[pyo3(item, default)]
-    value: Option<usize>,
+    opt: Option<usize>,
+    #[pyo3(item)]
+    value: usize,
 }
 
 #[test]
 fn test_with_default_item() {
     Python::with_gil(|py| {
         let dict = PyDict::new(py);
+        dict.set_item("value", 3).unwrap();
         let result = dict.extract::<WithDefaultItem>().unwrap();
-        let expected = WithDefaultItem { value: None };
+        let expected = WithDefaultItem {
+            value: 3,
+            opt: None,
+        };
         assert_eq!(result, expected);
     });
 }
@@ -706,6 +712,8 @@ fn test_with_default_item() {
 #[derive(Debug, FromPyObject, PartialEq, Eq)]
 pub struct WithExplicitDefaultItem {
     #[pyo3(item, default = 1)]
+    opt: usize,
+    #[pyo3(item)]
     value: usize,
 }
 
@@ -713,8 +721,9 @@ pub struct WithExplicitDefaultItem {
 fn test_with_explicit_default_item() {
     Python::with_gil(|py| {
         let dict = PyDict::new(py);
+        dict.set_item("value", 3).unwrap();
         let result = dict.extract::<WithExplicitDefaultItem>().unwrap();
-        let expected = WithExplicitDefaultItem { value: 1 };
+        let expected = WithExplicitDefaultItem { value: 3, opt: 1 };
         assert_eq!(result, expected);
     });
 }
@@ -722,6 +731,8 @@ fn test_with_explicit_default_item() {
 #[derive(Debug, FromPyObject, PartialEq, Eq)]
 pub struct WithDefaultItemAndConversionFunction {
     #[pyo3(item, default, from_py_with = "Bound::<'_, PyAny>::len")]
+    opt: usize,
+    #[pyo3(item)]
     value: usize,
 }
 
@@ -730,26 +741,62 @@ fn test_with_default_item_and_conversion_function() {
     Python::with_gil(|py| {
         // Filled case
         let dict = PyDict::new(py);
-        dict.set_item("value", (1,)).unwrap();
+        dict.set_item("opt", (1,)).unwrap();
+        dict.set_item("value", 3).unwrap();
         let result = dict
             .extract::<WithDefaultItemAndConversionFunction>()
             .unwrap();
-        let expected = WithDefaultItemAndConversionFunction { value: 1 };
+        let expected = WithDefaultItemAndConversionFunction { opt: 1, value: 3 };
         assert_eq!(result, expected);
 
         // Empty case
         let dict = PyDict::new(py);
+        dict.set_item("value", 3).unwrap();
         let result = dict
             .extract::<WithDefaultItemAndConversionFunction>()
             .unwrap();
-        let expected = WithDefaultItemAndConversionFunction { value: 0 };
+        let expected = WithDefaultItemAndConversionFunction { opt: 0, value: 3 };
         assert_eq!(result, expected);
 
         // Error case
         let dict = PyDict::new(py);
-        dict.set_item("value", 1).unwrap();
+        dict.set_item("value", 3).unwrap();
+        dict.set_item("opt", 1).unwrap();
         assert!(dict
             .extract::<WithDefaultItemAndConversionFunction>()
             .is_err());
+    });
+}
+
+#[derive(Debug, FromPyObject, PartialEq, Eq)]
+pub enum WithDefaultItemEnum {
+    #[pyo3(from_item_all)]
+    Foo {
+        a: usize,
+        #[pyo3(default)]
+        b: usize,
+    },
+    NeverUsedA {
+        a: usize,
+    },
+}
+
+#[test]
+fn test_with_default_item_enum() {
+    Python::with_gil(|py| {
+        // A and B filled
+        let dict = PyDict::new(py);
+        dict.set_item("a", 1).unwrap();
+        dict.set_item("b", 2).unwrap();
+        let result = dict.extract::<WithDefaultItemEnum>().unwrap();
+        let expected = WithDefaultItemEnum::Foo { a: 1, b: 2 };
+        assert_eq!(result, expected);
+
+        // A filled
+        let dict = PyDict::new(py);
+        dict.set_item("a", 1).unwrap();
+        let result = dict.extract::<WithDefaultItemEnum>().unwrap();
+        let expected = WithDefaultItemEnum::Foo { a: 1, b: 0 };
+        assert_eq!(result, expected);
     });
 }

--- a/tests/ui/invalid_frompy_derive.rs
+++ b/tests/ui/invalid_frompy_derive.rs
@@ -213,4 +213,21 @@ struct FromItemAllConflictAttrWithArgs {
     field: String,
 }
 
+#[derive(FromPyObject)]
+struct StructWithOnlyDefaultValues {
+    #[pyo3(default)]
+    field: String,
+}
+
+#[derive(FromPyObject)]
+enum EnumVariantWithOnlyDefaultValues {
+    Foo {
+        #[pyo3(default)]
+        field: String,
+    },
+}
+
+#[derive(FromPyObject)]
+struct NamedTuplesWithDefaultValues(#[pyo3(default)] String);
+
 fn main() {}

--- a/tests/ui/invalid_frompy_derive.stderr
+++ b/tests/ui/invalid_frompy_derive.stderr
@@ -223,3 +223,29 @@ error: The struct is already annotated with `from_item_all`, `attribute` is not 
     |
 210 | #[pyo3(from_item_all)]
     |        ^^^^^^^^^^^^^
+
+error: cannot derive FromPyObject for structs and variants with only default values
+   --> tests/ui/invalid_frompy_derive.rs:217:36
+    |
+217 |   struct StructWithOnlyDefaultValues {
+    |  ____________________________________^
+218 | |     #[pyo3(default)]
+219 | |     field: String,
+220 | | }
+    | |_^
+
+error: cannot derive FromPyObject for structs and variants with only default values
+   --> tests/ui/invalid_frompy_derive.rs:224:9
+    |
+224 |       Foo {
+    |  _________^
+225 | |         #[pyo3(default)]
+226 | |         field: String,
+227 | |     },
+    | |_____^
+
+error: `default` is not permitted on tuple struct elements.
+   --> tests/ui/invalid_frompy_derive.rs:231:37
+    |
+231 | struct NamedTuplesWithDefaultValues(#[pyo3(default)] String);
+    |                                     ^

--- a/tests/ui/invalid_frompy_derive.stderr
+++ b/tests/ui/invalid_frompy_derive.stderr
@@ -84,7 +84,7 @@ error: transparent structs and variants can only have 1 field
 70 | |     },
    | |_____^
 
-error: expected one of: `attribute`, `item`, `from_py_with`
+error: expected one of: `attribute`, `item`, `from_py_with`, `default`
   --> tests/ui/invalid_frompy_derive.rs:76:12
    |
 76 |     #[pyo3(attr)]


### PR DESCRIPTION
Takes an optional expression to set a custom value that is not the one from the `Default` trait

Note that the default value is only used if the key fetching fails (item/attr not present...) but errors are still raised if the value extraction fails

Issue #4643