### PR TITLE
fix error with complex enums with many fields

### DIFF
--- a/newsfragments/4832.fixed.md
+++ b/newsfragments/4832.fixed.md
@@ -1,0 +1,1 @@
+`#[pyclass]` complex enums support more than 12 variant fields.

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -526,7 +526,7 @@ fn impl_clear_slot(cls: &syn::Type, spec: &FnSpec<'_>, ctx: &Ctx) -> syn::Result
     })
 }
 
-fn impl_py_class_attribute(
+pub(crate) fn impl_py_class_attribute(
     cls: &syn::Type,
     spec: &FnSpec<'_>,
     ctx: &Ctx,

--- a/src/tests/hygiene/pyclass.rs
+++ b/src/tests/hygiene/pyclass.rs
@@ -92,6 +92,44 @@ pub enum TupleEnumEqOrd {
     Variant2(u32),
 }
 
+#[crate::pyclass(crate = "crate")]
+pub enum ComplexEnumManyVariantFields {
+    ManyStructFields {
+        field_1: u16,
+        field_2: u32,
+        field_3: u32,
+        field_4: i32,
+        field_5: u32,
+        field_6: u32,
+        field_7: u8,
+        field_8: u32,
+        field_9: i32,
+        field_10: u32,
+        field_11: u32,
+        field_12: u32,
+        field_13: u32,
+        field_14: i16,
+        field_15: u32,
+    },
+    ManyTupleFields(
+        u16,
+        u32,
+        u32,
+        i32,
+        u32,
+        u32,
+        u8,
+        u32,
+        i32,
+        u32,
+        u32,
+        u32,
+        u32,
+        i16,
+        u32,
+    ),
+}
+
 #[crate::pyclass(str = "{x}, {y}, {z}")]
 #[pyo3(crate = "crate")]
 pub struct PointFmt {


### PR DESCRIPTION
Changes the expansion of `__match_args__` for complex enums to not use Rust tuples to lift the limit of 12 fields. 

Closes #4827 
