### PR TITLE
Add an API to set rpath when using macOS system Python

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,9 @@
 use std::env;
 
 use pyo3_build_config::pyo3_build_script_impl::{cargo_env_var, errors::Result};
-use pyo3_build_config::{bail, print_feature_cfgs, InterpreterConfig};
+use pyo3_build_config::{
+    add_python_framework_link_args, bail, print_feature_cfgs, InterpreterConfig,
+};
 
 fn ensure_auto_initialize_ok(interpreter_config: &InterpreterConfig) -> Result<()> {
     if cargo_env_var("CARGO_FEATURE_AUTO_INITIALIZE").is_some() && !interpreter_config.shared {
@@ -41,6 +43,9 @@ fn configure_pyo3() -> Result<()> {
 
     // Emit cfgs like `invalid_from_utf8_lint`
     print_feature_cfgs();
+
+    // Make `cargo test` etc work on macOS with Xcode bundled Python
+    add_python_framework_link_args();
 
     Ok(())
 }

--- a/guide/src/building-and-distribution.md
+++ b/guide/src/building-and-distribution.md
@@ -144,23 +144,23 @@ rustflags = [
 ]
 ```
 
-Using the MacOS system python3 (`/usr/bin/python3`, as opposed to python installed via homebrew, pyenv, nix, etc.) may result in runtime errors such as `Library not loaded: @rpath/Python3.framework/Versions/3.8/Python3`. These can be resolved with another addition to `.cargo/config.toml`:
+Using the MacOS system python3 (`/usr/bin/python3`, as opposed to python installed via homebrew, pyenv, nix, etc.) may result in runtime errors such as `Library not loaded: @rpath/Python3.framework/Versions/3.8/Python3`.
+
+The easiest way to set the correct linker arguments is to add a `build.rs` with the following content:
+
+```rust,ignore
+fn main() {
+    pyo3_build_config::add_python_framework_link_args();
+}
+```
+
+Alternatively it can be resolved with another addition to `.cargo/config.toml`:
 
 ```toml
 [build]
 rustflags = [
   "-C", "link-args=-Wl,-rpath,/Library/Developer/CommandLineTools/Library/Frameworks",
 ]
-```
-
-Alternatively, one can include in `build.rs`:
-
-```rust
-fn main() {
-    println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,/Library/Developer/CommandLineTools/Library/Frameworks"
-    );
-}
 ```
 
 For more discussion on and workarounds for MacOS linking problems [see this issue](https://github.com/PyO3/pyo3/issues/1800#issuecomment-906786649).

--- a/newsfragments/4833.added.md
+++ b/newsfragments/4833.added.md
@@ -1,0 +1,1 @@
+Add `pyo3_build_config::add_python_framework_link_args` build script API to set rpath when using macOS system Python.


### PR DESCRIPTION
Because of https://github.com/rust-lang/cargo/issues/9554 we can not do it automatically, I think adding an API is better than ask users to hardcode it in `build.rs` or `.cargo/config.toml`.