### PR TITLE
introduce `into_py_with` for `#[derive(IntoPyObject, IntoPyObjectRef)]`

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -607,30 +607,27 @@ Additionally `IntoPyObject` can be derived for a reference to a struct or enum u
 `IntoPyObjectRef` derive macro. All the same rules from above apply as well.
 
 ##### `#[derive(IntoPyObject)]`/`#[derive(IntoPyObjectRef)]` Field Attributes
-- `pyo3(into_py_with = ...)`/`pyo3(into_py_with_ref = ...)`
+- `pyo3(into_py_with = ...)`
     - apply a custom function to convert the field from Rust into Python.
     - the argument must be the function indentifier
-    - the function signature must be `fn(T, Python<'_>) -> PyResult<Bound<'_, PyAny>>`/`fn<'py>(&T, Python<'py>) -> PyResult<Bound<'py, PyAny>>` where `T` is the Rust type of the argument.
+    - the function signature must be `fn(Cow<'_, T>, Python<'py>) -> PyResult<Bound<'py, PyAny>>` where `T` is the Rust type of the argument.
 
     ```rust
     # use pyo3::prelude::*;
     # use pyo3::IntoPyObjectExt;
+    # use std::borrow::Cow;
+    #[derive(Clone)]
     struct NotIntoPy(usize);
 
     #[derive(IntoPyObject, IntoPyObjectRef)]
     struct MyStruct {
-        #[pyo3(into_py_with = convert, into_py_with_ref = convert_ref)]
+        #[pyo3(into_py_with = convert)]
         not_into_py: NotIntoPy,
     }
 
-    /// Convert `NotIntoPy` into Python by value
-    fn convert(NotIntoPy(i): NotIntoPy, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
-        i.into_bound_py_any(py)
-    }
-
-    /// Convert `NotIntoPy` into Python by reference
-    fn convert_ref<'py>(&NotIntoPy(i): &NotIntoPy, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        i.into_bound_py_any(py)
+    /// Convert `NotIntoPy` into Python
+    fn convert<'py>(not_into_py: Cow<'_, NotIntoPy>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        not_into_py.0.into_bound_py_any(py)
     }
     ```
 

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -606,6 +606,34 @@ enum Enum<'a, 'py, K: Hash + Eq, V> { // enums are supported and convert using t
 Additionally `IntoPyObject` can be derived for a reference to a struct or enum using the
 `IntoPyObjectRef` derive macro. All the same rules from above apply as well.
 
+##### `#[derive(IntoPyObject)]`/`#[derive(IntoPyObjectRef)]` Field Attributes
+- `pyo3(into_py_with = ...)`/`pyo3(into_py_with_ref = ...)`
+    - apply a custom function to convert the field from Rust into Python.
+    - the argument must be the function indentifier
+    - the function signature must be `fn(T, Python<'_>) -> PyResult<Bound<'_, PyAny>>`/`fn<'py>(&T, Python<'py>) -> PyResult<Bound<'py, PyAny>>` where `T` is the Rust type of the argument.
+
+    ```rust
+    # use pyo3::prelude::*;
+    # use pyo3::IntoPyObjectExt;
+    struct NotIntoPy(usize);
+
+    #[derive(IntoPyObject, IntoPyObjectRef)]
+    struct MyStruct {
+        #[pyo3(into_py_with = convert, into_py_with_ref = convert_ref)]
+        not_into_py: NotIntoPy,
+    }
+
+    /// Convert `NotIntoPy` into Python by value
+    fn convert(NotIntoPy(i): NotIntoPy, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+        i.into_bound_py_any(py)
+    }
+
+    /// Convert `NotIntoPy` into Python by reference
+    fn convert_ref<'py>(&NotIntoPy(i): &NotIntoPy, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        i.into_bound_py_any(py)
+    }
+    ```
+
 #### manual implementation
 
 If the derive macro is not suitable for your use case, `IntoPyObject` can be implemented manually as

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -611,6 +611,8 @@ Additionally `IntoPyObject` can be derived for a reference to a struct or enum u
     - apply a custom function to convert the field from Rust into Python.
     - the argument must be the function indentifier
     - the function signature must be `fn(Cow<'_, T>, Python<'py>) -> PyResult<Bound<'py, PyAny>>` where `T` is the Rust type of the argument.
+      - `#[derive(IntoPyObject)]` will invoke the function with `Cow::Owned`
+      - `#[derive(IntoPyObjectRef)]` will invoke the function with `Cow::Borrowed`
 
     ```rust
     # use pyo3::prelude::*;

--- a/newsfragments/4850.added.md
+++ b/newsfragments/4850.added.md
@@ -1,0 +1,1 @@
+introduce `into_py_with`/`into_py_with_ref` for `#[derive(IntoPyObject, IntoPyObjectRef)]`

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -25,6 +25,8 @@ pub mod kw {
     syn::custom_keyword!(get);
     syn::custom_keyword!(get_all);
     syn::custom_keyword!(hash);
+    syn::custom_keyword!(into_py_with);
+    syn::custom_keyword!(into_py_with_ref);
     syn::custom_keyword!(item);
     syn::custom_keyword!(from_item_all);
     syn::custom_keyword!(mapping);
@@ -350,6 +352,8 @@ impl<K: ToTokens, V: ToTokens> ToTokens for OptionalKeywordAttribute<K, V> {
 }
 
 pub type FromPyWithAttribute = KeywordAttribute<kw::from_py_with, LitStrValue<ExprPath>>;
+pub type IntoPyWithAttribute = KeywordAttribute<kw::into_py_with, ExprPath>;
+pub type IntoPyWithRefAttribute = KeywordAttribute<kw::into_py_with_ref, ExprPath>;
 
 pub type DefaultAttribute = OptionalKeywordAttribute<Token![default], Expr>;
 

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -26,7 +26,6 @@ pub mod kw {
     syn::custom_keyword!(get_all);
     syn::custom_keyword!(hash);
     syn::custom_keyword!(into_py_with);
-    syn::custom_keyword!(into_py_with_ref);
     syn::custom_keyword!(item);
     syn::custom_keyword!(from_item_all);
     syn::custom_keyword!(mapping);
@@ -353,7 +352,6 @@ impl<K: ToTokens, V: ToTokens> ToTokens for OptionalKeywordAttribute<K, V> {
 
 pub type FromPyWithAttribute = KeywordAttribute<kw::from_py_with, LitStrValue<ExprPath>>;
 pub type IntoPyWithAttribute = KeywordAttribute<kw::into_py_with, ExprPath>;
-pub type IntoPyWithRefAttribute = KeywordAttribute<kw::into_py_with_ref, ExprPath>;
 
 pub type DefaultAttribute = OptionalKeywordAttribute<Token![default], Expr>;
 

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -26,6 +26,8 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/pyclass_send.rs");
     t.compile_fail("tests/ui/invalid_argument_attributes.rs");
     t.compile_fail("tests/ui/invalid_intopy_derive.rs");
+    #[cfg(not(windows))]
+    t.compile_fail("tests/ui/invalid_intopy_with.rs");
     t.compile_fail("tests/ui/invalid_frompy_derive.rs");
     t.compile_fail("tests/ui/static_ref.rs");
     t.compile_fail("tests/ui/wrong_aspyref_lifetimes.rs");

--- a/tests/test_intopyobject.rs
+++ b/tests/test_intopyobject.rs
@@ -150,14 +150,14 @@ fn test_transparent_tuple_struct() {
     });
 }
 
-fn phantom_into_py<T>(
-    _: std::marker::PhantomData<T>,
-    py: Python<'_>,
-) -> PyResult<Bound<'_, PyAny>> {
+fn phantom_into_py<'py, T>(
+    _: std::borrow::Cow<'_, std::marker::PhantomData<T>>,
+    py: Python<'py>,
+) -> PyResult<Bound<'py, PyAny>> {
     std::any::type_name::<T>().into_bound_py_any(py)
 }
 
-#[derive(Debug, IntoPyObject)]
+#[derive(Debug, IntoPyObject, IntoPyObjectRef)]
 pub enum Foo<'py> {
     TupleVar(
         usize,
@@ -218,16 +218,15 @@ pub struct Zap {
     #[pyo3(item)]
     name: String,
 
-    #[pyo3(into_py_with = zap_into_py, into_py_with_ref = zap_into_py_ref, item("my_object"))]
+    #[pyo3(into_py_with = zap_into_py, item("my_object"))]
     some_object_length: usize,
 }
 
-fn zap_into_py(len: usize, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
-    Ok(PyList::new(py, 1..len + 1)?.into_any())
-}
-
-fn zap_into_py_ref<'py>(&len: &usize, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-    Ok(PyList::new(py, 1..len + 1)?.into_any())
+fn zap_into_py<'py>(
+    len: std::borrow::Cow<'_, usize>,
+    py: Python<'py>,
+) -> PyResult<Bound<'py, PyAny>> {
+    Ok(PyList::new(py, 1..*len + 1)?.into_any())
 }
 
 #[test]

--- a/tests/test_intopyobject.rs
+++ b/tests/test_intopyobject.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "macros")]
 
-use pyo3::types::{PyDict, PyString};
-use pyo3::{prelude::*, IntoPyObject};
+use pyo3::types::{PyDict, PyList, PyString};
+use pyo3::{prelude::*, py_run, IntoPyObject, IntoPyObjectExt};
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -150,9 +150,20 @@ fn test_transparent_tuple_struct() {
     });
 }
 
+fn phantom_into_py<T>(
+    _: std::marker::PhantomData<T>,
+    py: Python<'_>,
+) -> PyResult<Bound<'_, PyAny>> {
+    std::any::type_name::<T>().into_bound_py_any(py)
+}
+
 #[derive(Debug, IntoPyObject)]
 pub enum Foo<'py> {
-    TupleVar(usize, String),
+    TupleVar(
+        usize,
+        String,
+        #[pyo3(into_py_with = phantom_into_py::<()>)] std::marker::PhantomData<()>,
+    ),
     StructVar {
         test: Bound<'py, PyString>,
     },
@@ -167,10 +178,12 @@ pub enum Foo<'py> {
 #[test]
 fn test_enum() {
     Python::with_gil(|py| {
-        let foo = Foo::TupleVar(1, "test".into()).into_pyobject(py).unwrap();
+        let foo = Foo::TupleVar(1, "test".into(), std::marker::PhantomData)
+            .into_pyobject(py)
+            .unwrap();
         assert_eq!(
-            foo.extract::<(usize, String)>().unwrap(),
-            (1, String::from("test"))
+            foo.extract::<(usize, String, String)>().unwrap(),
+            (1, String::from("test"), String::from("()"))
         );
 
         let foo = Foo::StructVar {
@@ -197,5 +210,46 @@ fn test_enum() {
             .into_pyobject(py)
             .unwrap();
         assert!(foo.is_none());
+    });
+}
+
+#[derive(Debug, IntoPyObject, IntoPyObjectRef)]
+pub struct Zap {
+    #[pyo3(item)]
+    name: String,
+
+    #[pyo3(into_py_with = zap_into_py, into_py_with_ref = zap_into_py_ref, item("my_object"))]
+    some_object_length: usize,
+}
+
+fn zap_into_py(len: usize, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+    Ok(PyList::new(py, 1..len + 1)?.into_any())
+}
+
+fn zap_into_py_ref<'py>(&len: &usize, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+    Ok(PyList::new(py, 1..len + 1)?.into_any())
+}
+
+#[test]
+fn test_into_py_with() {
+    Python::with_gil(|py| {
+        let zap = Zap {
+            name: "whatever".into(),
+            some_object_length: 3,
+        };
+
+        let py_zap_ref = (&zap).into_pyobject(py).unwrap();
+        let py_zap = zap.into_pyobject(py).unwrap();
+
+        py_run!(
+            py,
+            py_zap_ref,
+            "assert py_zap_ref == {'name': 'whatever', 'my_object': [1, 2, 3]},f'{py_zap_ref}'"
+        );
+        py_run!(
+            py,
+            py_zap,
+            "assert py_zap == {'name': 'whatever', 'my_object': [1, 2, 3]},f'{py_zap}'"
+        );
     });
 }

--- a/tests/ui/invalid_intopy_derive.rs
+++ b/tests/ui/invalid_intopy_derive.rs
@@ -124,10 +124,6 @@ struct StructTransparentIntoPyWithRef {
 #[pyo3(transparent)]
 struct TupleTransparentIntoPyWith(#[pyo3(into_py_with = into)] String);
 
-#[derive(IntoPyObjectRef)]
-#[pyo3(transparent)]
-struct TupleTransparentIntoPyWithRef(#[pyo3(into_py_with_ref = into_ref)] String);
-
 #[derive(IntoPyObject)]
 enum EnumTupleIntoPyWith {
     TransparentTuple(#[pyo3(into_py_with = into)] usize),
@@ -138,20 +134,6 @@ enum EnumStructIntoPyWith {
     #[pyo3(transparent)]
     TransparentStruct {
         #[pyo3(into_py_with = into)]
-        a: usize,
-    },
-}
-
-#[derive(IntoPyObjectRef)]
-enum EnumTupleIntoPyWithRef {
-    TransparentTuple(#[pyo3(into_py_with_ref = into_ref)] usize),
-}
-
-#[derive(IntoPyObjectRef)]
-enum EnumStructIntoPyWithRef {
-    #[pyo3(transparent)]
-    TransparentStruct {
-        #[pyo3(into_py_with_ref = into_ref)]
         a: usize,
     },
 }

--- a/tests/ui/invalid_intopy_derive.rs
+++ b/tests/ui/invalid_intopy_derive.rs
@@ -106,4 +106,54 @@ struct StructTransparentItem {
     foo: String,
 }
 
+#[derive(IntoPyObject)]
+#[pyo3(transparent)]
+struct StructTransparentIntoPyWith {
+    #[pyo3(into_py_with = into)]
+    foo: String,
+}
+
+#[derive(IntoPyObjectRef)]
+#[pyo3(transparent)]
+struct StructTransparentIntoPyWithRef {
+    #[pyo3(into_py_with = into_ref)]
+    foo: String,
+}
+
+#[derive(IntoPyObject)]
+#[pyo3(transparent)]
+struct TupleTransparentIntoPyWith(#[pyo3(into_py_with = into)] String);
+
+#[derive(IntoPyObjectRef)]
+#[pyo3(transparent)]
+struct TupleTransparentIntoPyWithRef(#[pyo3(into_py_with_ref = into_ref)] String);
+
+#[derive(IntoPyObject)]
+enum EnumTupleIntoPyWith {
+    TransparentTuple(#[pyo3(into_py_with = into)] usize),
+}
+
+#[derive(IntoPyObject)]
+enum EnumStructIntoPyWith {
+    #[pyo3(transparent)]
+    TransparentStruct {
+        #[pyo3(into_py_with = into)]
+        a: usize,
+    },
+}
+
+#[derive(IntoPyObjectRef)]
+enum EnumTupleIntoPyWithRef {
+    TransparentTuple(#[pyo3(into_py_with_ref = into_ref)] usize),
+}
+
+#[derive(IntoPyObjectRef)]
+enum EnumStructIntoPyWithRef {
+    #[pyo3(transparent)]
+    TransparentStruct {
+        #[pyo3(into_py_with_ref = into_ref)]
+        a: usize,
+    },
+}
+
 fn main() {}

--- a/tests/ui/invalid_intopy_derive.stderr
+++ b/tests/ui/invalid_intopy_derive.stderr
@@ -144,32 +144,14 @@ error: `into_py_with` is not permitted on `transparent` structs
 125 | struct TupleTransparentIntoPyWith(#[pyo3(into_py_with = into)] String);
     |                                          ^^^^^^^^^^^^
 
-error: `into_py_with_ref` is not permitted on `transparent` structs
-   --> tests/ui/invalid_intopy_derive.rs:129:45
-    |
-129 | struct TupleTransparentIntoPyWithRef(#[pyo3(into_py_with_ref = into_ref)] String);
-    |                                             ^^^^^^^^^^^^^^^^
-
 error: `into_py_with` is not permitted on `transparent` structs
-   --> tests/ui/invalid_intopy_derive.rs:133:29
+   --> tests/ui/invalid_intopy_derive.rs:129:29
     |
-133 |     TransparentTuple(#[pyo3(into_py_with = into)] usize),
+129 |     TransparentTuple(#[pyo3(into_py_with = into)] usize),
     |                             ^^^^^^^^^^^^
 
 error: `into_py_with` is not permitted on `transparent` structs or variants
-   --> tests/ui/invalid_intopy_derive.rs:140:16
+   --> tests/ui/invalid_intopy_derive.rs:136:16
     |
-140 |         #[pyo3(into_py_with = into)]
+136 |         #[pyo3(into_py_with = into)]
     |                ^^^^^^^^^^^^
-
-error: `into_py_with_ref` is not permitted on `transparent` structs
-   --> tests/ui/invalid_intopy_derive.rs:147:29
-    |
-147 |     TransparentTuple(#[pyo3(into_py_with_ref = into_ref)] usize),
-    |                             ^^^^^^^^^^^^^^^^
-
-error: `into_py_with_ref` is not permitted on `transparent` structs or variants
-   --> tests/ui/invalid_intopy_derive.rs:154:16
-    |
-154 |         #[pyo3(into_py_with_ref = into_ref)]
-    |                ^^^^^^^^^^^^^^^^

--- a/tests/ui/invalid_intopy_derive.stderr
+++ b/tests/ui/invalid_intopy_derive.stderr
@@ -125,3 +125,51 @@ error: `transparent` structs may not have `item` for the inner field
     |
 105 |     #[pyo3(item)]
     |            ^^^^
+
+error: `into_py_with` is not permitted on `transparent` structs or variants
+   --> tests/ui/invalid_intopy_derive.rs:112:12
+    |
+112 |     #[pyo3(into_py_with = into)]
+    |            ^^^^^^^^^^^^
+
+error: `into_py_with` is not permitted on `transparent` structs or variants
+   --> tests/ui/invalid_intopy_derive.rs:119:12
+    |
+119 |     #[pyo3(into_py_with = into_ref)]
+    |            ^^^^^^^^^^^^
+
+error: `into_py_with` is not permitted on `transparent` structs
+   --> tests/ui/invalid_intopy_derive.rs:125:42
+    |
+125 | struct TupleTransparentIntoPyWith(#[pyo3(into_py_with = into)] String);
+    |                                          ^^^^^^^^^^^^
+
+error: `into_py_with_ref` is not permitted on `transparent` structs
+   --> tests/ui/invalid_intopy_derive.rs:129:45
+    |
+129 | struct TupleTransparentIntoPyWithRef(#[pyo3(into_py_with_ref = into_ref)] String);
+    |                                             ^^^^^^^^^^^^^^^^
+
+error: `into_py_with` is not permitted on `transparent` structs
+   --> tests/ui/invalid_intopy_derive.rs:133:29
+    |
+133 |     TransparentTuple(#[pyo3(into_py_with = into)] usize),
+    |                             ^^^^^^^^^^^^
+
+error: `into_py_with` is not permitted on `transparent` structs or variants
+   --> tests/ui/invalid_intopy_derive.rs:140:16
+    |
+140 |         #[pyo3(into_py_with = into)]
+    |                ^^^^^^^^^^^^
+
+error: `into_py_with_ref` is not permitted on `transparent` structs
+   --> tests/ui/invalid_intopy_derive.rs:147:29
+    |
+147 |     TransparentTuple(#[pyo3(into_py_with_ref = into_ref)] usize),
+    |                             ^^^^^^^^^^^^^^^^
+
+error: `into_py_with_ref` is not permitted on `transparent` structs or variants
+   --> tests/ui/invalid_intopy_derive.rs:154:16
+    |
+154 |         #[pyo3(into_py_with_ref = into_ref)]
+    |                ^^^^^^^^^^^^^^^^

--- a/tests/ui/invalid_intopy_with.rs
+++ b/tests/ui/invalid_intopy_with.rs
@@ -1,22 +1,12 @@
 use pyo3::{IntoPyObject, IntoPyObjectRef};
 
-#[derive(IntoPyObject)]
+#[derive(IntoPyObject, IntoPyObjectRef)]
 struct InvalidIntoPyWithFn {
     #[pyo3(into_py_with = into)]
     inner: String,
 }
 
-#[derive(IntoPyObjectRef)]
-struct InvalidIntoPyWithRefFn {
-    #[pyo3(into_py_with_ref = into_ref)]
-    inner: String,
-}
-
-fn into(_a: String) -> pyo3::Py<pyo3::PyAny> {
-    todo!()
-}
-
-fn into_ref(_a: String, _py: pyo3::Python<'_>) -> pyo3::Bound<'_, pyo3::PyAny> {
+fn into(_a: String, _py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Bound<'_, pyo3::PyAny>> {
     todo!()
 }
 

--- a/tests/ui/invalid_intopy_with.rs
+++ b/tests/ui/invalid_intopy_with.rs
@@ -1,0 +1,23 @@
+use pyo3::{IntoPyObject, IntoPyObjectRef};
+
+#[derive(IntoPyObject)]
+struct InvalidIntoPyWithFn {
+    #[pyo3(into_py_with = into)]
+    inner: String,
+}
+
+#[derive(IntoPyObjectRef)]
+struct InvalidIntoPyWithRefFn {
+    #[pyo3(into_py_with_ref = into_ref)]
+    inner: String,
+}
+
+fn into(_a: String) -> pyo3::Py<pyo3::PyAny> {
+    todo!()
+}
+
+fn into_ref(_a: String, _py: pyo3::Python<'_>) -> pyo3::Bound<'_, pyo3::PyAny> {
+    todo!()
+}
+
+fn main() {}

--- a/tests/ui/invalid_intopy_with.stderr
+++ b/tests/ui/invalid_intopy_with.stderr
@@ -1,0 +1,23 @@
+error[E0308]: mismatched types
+ --> tests/ui/invalid_intopy_with.rs:5:27
+  |
+3 | #[derive(IntoPyObject)]
+  |          ------------ expected due to this
+4 | struct InvalidIntoPyWithFn {
+5 |     #[pyo3(into_py_with = into)]
+  |                           ^^^^ incorrect number of function parameters
+  |
+  = note: expected fn pointer `for<'a> fn(_, Python<'a>) -> Result<pyo3::Bound<'a, PyAny>, PyErr>`
+                found fn item `fn(String) -> Py<PyAny> {into}`
+
+error[E0308]: mismatched types
+  --> tests/ui/invalid_intopy_with.rs:11:31
+   |
+9  | #[derive(IntoPyObjectRef)]
+   |          --------------- expected due to this
+10 | struct InvalidIntoPyWithRefFn {
+11 |     #[pyo3(into_py_with_ref = into_ref)]
+   |                               ^^^^^^^^ expected fn pointer, found fn item
+   |
+   = note: expected fn pointer `for<'a> fn(_, Python<'a>) -> Result<pyo3::Bound<'a, PyAny>, PyErr>`
+                 found fn item `for<'a> fn(String, Python<'a>) -> pyo3::Bound<'a, PyAny> {into_ref}`

--- a/tests/ui/invalid_intopy_with.stderr
+++ b/tests/ui/invalid_intopy_with.stderr
@@ -1,23 +1,23 @@
 error[E0308]: mismatched types
  --> tests/ui/invalid_intopy_with.rs:5:27
   |
-3 | #[derive(IntoPyObject)]
+3 | #[derive(IntoPyObject, IntoPyObjectRef)]
   |          ------------ expected due to this
 4 | struct InvalidIntoPyWithFn {
 5 |     #[pyo3(into_py_with = into)]
-  |                           ^^^^ incorrect number of function parameters
+  |                           ^^^^ expected fn pointer, found fn item
   |
-  = note: expected fn pointer `for<'a> fn(_, Python<'a>) -> Result<pyo3::Bound<'a, PyAny>, PyErr>`
-                found fn item `fn(String) -> Py<PyAny> {into}`
+  = note: expected fn pointer `for<'a> fn(Cow<'a, _>, Python<'py>) -> Result<pyo3::Bound<'py, PyAny>, PyErr>`
+                found fn item `for<'a> fn(String, Python<'a>) -> Result<pyo3::Bound<'a, PyAny>, PyErr> {into}`
 
 error[E0308]: mismatched types
-  --> tests/ui/invalid_intopy_with.rs:11:31
-   |
-9  | #[derive(IntoPyObjectRef)]
-   |          --------------- expected due to this
-10 | struct InvalidIntoPyWithRefFn {
-11 |     #[pyo3(into_py_with_ref = into_ref)]
-   |                               ^^^^^^^^ expected fn pointer, found fn item
-   |
-   = note: expected fn pointer `for<'a> fn(_, Python<'a>) -> Result<pyo3::Bound<'a, PyAny>, PyErr>`
-                 found fn item `for<'a> fn(String, Python<'a>) -> pyo3::Bound<'a, PyAny> {into_ref}`
+ --> tests/ui/invalid_intopy_with.rs:5:27
+  |
+3 | #[derive(IntoPyObject, IntoPyObjectRef)]
+  |                        --------------- expected due to this
+4 | struct InvalidIntoPyWithFn {
+5 |     #[pyo3(into_py_with = into)]
+  |                           ^^^^ expected fn pointer, found fn item
+  |
+  = note: expected fn pointer `for<'a> fn(Cow<'a, _>, Python<'py>) -> Result<pyo3::Bound<'py, PyAny>, PyErr>`
+                found fn item `for<'a> fn(String, Python<'a>) -> Result<pyo3::Bound<'a, PyAny>, PyErr> {into}`


### PR DESCRIPTION
This adds `#[pyo3(into_py_with = ...)]` field options to the `#[derive(IntoPyObject, IntoPyObjectRef)]` derive macros as a complement to `#[pyo3(from_py_with= ...)]` of `#[derive(FromPyObject)]`.

This allows simple customization of the generated implementation, which allows (for example) the usage of the derive macro in cases where one or more fields do not implement `IntoPyObject` themselves.

One notable difference in the current implementation compared to `from_py_with` is the type of the argument. `from_py_with` takes it's argument via a string (mostly for historical reasons I believe), `into_py_with` takes it directly as a path, which has the advantage that we get better IDE support (proper syntax highlighting and autocomplete). For consistency I would propose to switch over `from_py_with` to the path syntax in a follow-up (#4860).
