### PR TITLE
Ignore spurious clippy warning (bug caused by rust-lang/rust-clippy#13885

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ todo = "warn"
 unnecessary_wraps = "warn"
 useless_transmute = "warn"
 used_underscore_binding = "warn"
+literal_string_with_formatting_args = "allow"
 
 [workspace.lints.rust]
 elided_lifetimes_in_paths = "warn"

--- a/newsfragments/4862.fixed.md
+++ b/newsfragments/4862.fixed.md
@@ -1,0 +1,1 @@
+Ignore spurious clippy warning due to https://github.com/rust-lang/rust-clippy/issues/13885

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(missing_docs)]
-#[allow(clippy::literal_string_with_formatting_args)]
 #![cfg_attr(
     feature = "nightly",
     feature(auto_traits, negative_impls, try_trait_v2)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#[allow(clippy::literal_string_with_formatting_args)]
 #![cfg_attr(
     feature = "nightly",
     feature(auto_traits, negative_impls, try_trait_v2)


### PR DESCRIPTION
rust-lang/rust-clippy#13885