### PR TITLE
pyo3-ffi: expose PyThreadState_GetFrame and PyFrame_GetBack

### DIFF
--- a/newsfragments/4866.added.md
+++ b/newsfragments/4866.added.md
@@ -1,0 +1,1 @@
+Exposing PyThreadState_GetFrame and PyFrame_GetBack.

--- a/pyo3-ffi/src/cpython/frameobject.rs
+++ b/pyo3-ffi/src/cpython/frameobject.rs
@@ -89,7 +89,8 @@ extern "C" {
     pub fn PyFrame_FastToLocals(f: *mut PyFrameObject);
 
     // skipped _PyFrame_DebugMallocStats
-    // skipped PyFrame_GetBack
+    #[cfg(all(Py_3_9, not(PyPy)))]
+    pub fn PyFrame_GetBack(f: *mut PyFrameObject) -> *mut PyFrameObject;
 
     #[cfg(not(Py_3_9))]
     pub fn PyFrame_ClearFreeList() -> c_int;

--- a/pyo3-ffi/src/pystate.rs
+++ b/pyo3-ffi/src/pystate.rs
@@ -1,3 +1,5 @@
+#[cfg(all(Py_3_10, not(PyPy), not(Py_LIMITED_API)))]
+use crate::frameobject::PyFrameObject;
 use crate::moduleobject::PyModuleDef;
 use crate::object::PyObject;
 use std::os::raw::c_int;
@@ -63,8 +65,13 @@ extern "C" {
 }
 
 // skipped non-limited / 3.9 PyThreadState_GetInterpreter
-// skipped non-limited / 3.9 PyThreadState_GetFrame
 // skipped non-limited / 3.9 PyThreadState_GetID
+
+extern "C" {
+    // PyThreadState_GetFrame
+    #[cfg(all(Py_3_10, not(PyPy), not(Py_LIMITED_API)))]
+    pub fn PyThreadState_GetFrame(arg1: *mut PyThreadState) -> *mut PyFrameObject;
+}
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
I'm working on writing (another) profiler in rust for python.
This PR exposes the functions required for unwinding the stack.