### PR TITLE
Implement `AsPyPointer` for `Borrowed`

### DIFF
--- a/newsfragments/4868.added.md
+++ b/newsfragments/4868.added.md
@@ -1,0 +1,1 @@
+Implement [AsPyPointer] for [Borrowed]

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -839,6 +839,13 @@ impl<T> IntoPy<PyObject> for Borrowed<'_, '_, T> {
     }
 }
 
+unsafe impl<T> AsPyPointer for Borrowed<'_, '_, T> {
+    #[inline]
+    fn as_ptr(&self) -> *mut ffi::PyObject {
+        Self::as_ptr(*self)
+    }
+}
+
 impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
     type Any = Borrowed<'a, 'py, PyAny>;
 


### PR DESCRIPTION
This is already available in theory as the `as_ptr` method, but implementing the trait allows it to be used in a generic way.

I briefly rubbed against this trying to do a `obj.is(other)` where `other` was borrowed.