### PR TITLE
Optimize `Iterator::last()` for `PyList` & `PyTuple` and `Iterator::count()` for `PyDict`, `PyList`, `PyTuple` & `PySet`

### DIFF
--- a/newsfragments/4878.added.md
+++ b/newsfragments/4878.added.md
@@ -1,0 +1,1 @@
+Optimizes `last` for `BoundListIterator`, `BoundTupleIterator` and `BorrowedTupleIterator`

--- a/newsfragments/4878.added.md
+++ b/newsfragments/4878.added.md
@@ -1,1 +1,2 @@
-Optimizes `last` for `BoundListIterator`, `BoundTupleIterator` and `BorrowedTupleIterator`
+- Optimizes `last` for `BoundListIterator`, `BoundTupleIterator` and `BorrowedTupleIterator`
+- Optimizes `Iterator::count()` for `PyDict`, `PyList`, `PyTuple` & `PySet`

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -535,6 +535,14 @@ impl<'py> Iterator for BoundDictIterator<'py> {
     }
 
     #[inline]
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.len()
+    }
+
+    #[inline]
     #[cfg(Py_GIL_DISABLED)]
     fn fold<B, F>(mut self, init: B, mut f: F) -> B
     where
@@ -735,6 +743,14 @@ mod borrowed_iter {
         fn size_hint(&self) -> (usize, Option<usize>) {
             let len = self.len();
             (len, Some(len))
+        }
+
+        #[inline]
+        fn count(self) -> usize
+        where
+            Self: Sized,
+        {
+            self.len()
         }
     }
 
@@ -1656,5 +1672,13 @@ mod tests {
                 .try_fold(0, |acc, (_, v)| PyResult::Ok(acc + v.extract::<i32>()?))
                 .is_err());
         });
+    }
+
+    #[test]
+    fn test_iter_count() {
+        Python::with_gil(|py| {
+            let dict = [(1, 1), (2, 2), (3, 3)].into_py_dict(py).unwrap();
+            assert_eq!(dict.iter().count(), 3);
+        })
     }
 }

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -237,6 +237,14 @@ impl<'py> Iterator for BoundFrozenSetIterator<'py> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }
+
+    #[inline]
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.len()
+    }
 }
 
 impl ExactSizeIterator for BoundFrozenSetIterator<'_> {
@@ -357,5 +365,13 @@ mod tests {
             assert!(set.contains(2).unwrap());
             assert!(!set.contains(3).unwrap());
         });
+    }
+
+    #[test]
+    fn test_iter_count() {
+        Python::with_gil(|py| {
+            let set = PyFrozenSet::new(py, vec![1, 2, 3]).unwrap();
+            assert_eq!(set.iter().count(), 3);
+        })
     }
 }

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -696,6 +696,14 @@ impl<'py> Iterator for BoundListIterator<'py> {
     }
 
     #[inline]
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.len()
+    }
+
+    #[inline]
     fn last(mut self) -> Option<Self::Item>
     where
         Self: Sized,
@@ -1793,6 +1801,14 @@ mod tests {
             let list = PyList::new(py, vec![1, 2, 3]).unwrap();
             let last = list.iter().last();
             assert_eq!(last.unwrap().extract::<i32>().unwrap(), 3);
+        })
+    }
+
+    #[test]
+    fn test_iter_count() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, vec![1, 2, 3]).unwrap();
+            assert_eq!(list.iter().count(), 3);
         })
     }
 }

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -696,6 +696,14 @@ impl<'py> Iterator for BoundListIterator<'py> {
     }
 
     #[inline]
+    fn last(mut self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.next_back()
+    }
+
+    #[inline]
     #[cfg(all(Py_GIL_DISABLED, not(feature = "nightly")))]
     fn fold<B, F>(mut self, init: B, mut f: F) -> B
     where
@@ -1776,6 +1784,15 @@ mod tests {
             let mut iter4 = list.iter();
             assert_eq!(iter4.advance_back_by(0), Ok(()));
             assert_eq!(iter4.next_back().unwrap().extract::<i32>().unwrap(), 5);
+        })
+    }
+
+    #[test]
+    fn test_iter_last() {
+        Python::with_gil(|py| {
+            let list = PyList::new(py, vec![1, 2, 3]).unwrap();
+            let last = list.iter().last();
+            assert_eq!(last.unwrap().extract::<i32>().unwrap(), 3);
         })
     }
 }

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -267,6 +267,14 @@ impl<'py> Iterator for BoundSetIterator<'py> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }
+
+    #[inline]
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.len()
+    }
 }
 
 impl ExactSizeIterator for BoundSetIterator<'_> {
@@ -478,5 +486,13 @@ mod tests {
             assert_eq!(iter.len(), 0);
             assert_eq!(iter.size_hint(), (0, Some(0)));
         });
+    }
+
+    #[test]
+    fn test_iter_count() {
+        Python::with_gil(|py| {
+            let set = PySet::new(py, vec![1, 2, 3]).unwrap();
+            assert_eq!(set.iter().count(), 3);
+        })
     }
 }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -378,6 +378,14 @@ impl<'py> Iterator for BoundTupleIterator<'py> {
     }
 
     #[inline]
+    fn last(mut self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.next_back()
+    }
+
+    #[inline]
     #[cfg(not(feature = "nightly"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let length = self.length.min(self.tuple.len());
@@ -547,6 +555,14 @@ impl<'a, 'py> Iterator for BorrowedTupleIterator<'a, 'py> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         (len, Some(len))
+    }
+
+    #[inline]
+    fn last(mut self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.next_back()
     }
 }
 
@@ -1726,6 +1742,15 @@ mod tests {
             let mut iter4 = tuple.iter();
             assert_eq!(iter4.advance_back_by(0), Ok(()));
             assert_eq!(iter4.next_back().unwrap().extract::<i32>().unwrap(), 5);
+        })
+    }
+
+    #[test]
+    fn test_iter_last() {
+        Python::with_gil(|py| {
+            let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
+            let last = tuple.iter().last();
+            assert_eq!(last.unwrap().extract::<i32>().unwrap(), 3);
         })
     }
 }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -378,6 +378,14 @@ impl<'py> Iterator for BoundTupleIterator<'py> {
     }
 
     #[inline]
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.len()
+    }
+
+    #[inline]
     fn last(mut self) -> Option<Self::Item>
     where
         Self: Sized,
@@ -555,6 +563,14 @@ impl<'a, 'py> Iterator for BorrowedTupleIterator<'a, 'py> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         (len, Some(len))
+    }
+
+    #[inline]
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.len()
     }
 
     #[inline]
@@ -1751,6 +1767,14 @@ mod tests {
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
             let last = tuple.iter().last();
             assert_eq!(last.unwrap().extract::<i32>().unwrap(), 3);
+        })
+    }
+
+    #[test]
+    fn test_iter_count() {
+        Python::with_gil(|py| {
+            let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
+            assert_eq!(tuple.iter().count(), 3);
         })
     }
 }


### PR DESCRIPTION
Complements #4810

Part of https://github.com/PyO3/pyo3/issues/4787