### PR TITLE
avoid FailedHealthCheck in test_double

### DIFF
--- a/newsfragments/4879.fixed.md
+++ b/newsfragments/4879.fixed.md
@@ -1,0 +1,1 @@
+ * fixed spurious `test_double` failures.

--- a/pytests/tests/test_othermod.py
+++ b/pytests/tests/test_othermod.py
@@ -3,11 +3,16 @@ from hypothesis import strategies as st
 
 from pyo3_pytests import othermod
 
-INTEGER32_ST = st.integers(min_value=(-(2**31)), max_value=(2**31 - 1))
+INTEGER31_ST = st.integers(min_value=(-(2**30)), max_value=(2**30 - 1))
 USIZE_ST = st.integers(min_value=othermod.USIZE_MIN, max_value=othermod.USIZE_MAX)
 
 
-@given(x=INTEGER32_ST)
+# If the full 32 bits are used here, then you can get failures that look like this:
+# hypothesis.errors.FailedHealthCheck: It looks like your strategy is filtering out a lot of data.
+# Health check found 50 filtered examples but only 7 good ones.
+#
+# Limit the range to 31 bits to avoid this problem.
+@given(x=INTEGER31_ST)
 def test_double(x):
     expected = x * 2
     assume(-(2**31) <= expected <= (2**31 - 1))


### PR DESCRIPTION
avoid FailedHealthCheck in test_double, e.g. on the CI runners.

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).