### PR TITLE
Fix manual_ok_err clippy lint on nightly

### DIFF
--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -202,10 +202,7 @@ impl<'py> PySetMethods<'py> for Bound<'py, PySet> {
 
     fn pop(&self) -> Option<Bound<'py, PyAny>> {
         let element = unsafe { ffi::PySet_Pop(self.as_ptr()).assume_owned_or_err(self.py()) };
-        match element {
-            Ok(e) => Some(e),
-            Err(_) => None,
-        }
+        element.ok()
     }
 
     fn iter(&self) -> BoundSetIterator<'py> {


### PR DESCRIPTION
When working on #4885 I kept seeing this lint.

https://rust-lang.github.io/rust-clippy/master/index.html#manual_ok_err