### PR TITLE
WIP: Generalize the rpath API for relocatable Python installations

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use pyo3_build_config::pyo3_build_script_impl::{cargo_env_var, errors::Result};
 use pyo3_build_config::{
-    add_python_framework_link_args, bail, print_feature_cfgs, InterpreterConfig,
+    add_python_link_args, bail, print_feature_cfgs, InterpreterConfig,
 };
 
 fn ensure_auto_initialize_ok(interpreter_config: &InterpreterConfig) -> Result<()> {
@@ -44,8 +44,8 @@ fn configure_pyo3() -> Result<()> {
     // Emit cfgs like `invalid_from_utf8_lint`
     print_feature_cfgs();
 
-    // Make `cargo test` etc work on macOS with Xcode bundled Python
-    add_python_framework_link_args();
+    // Make `cargo test` etc work on non-global Python installations
+    add_python_link_args();
 
     Ok(())
 }

--- a/guide/src/getting-started.md
+++ b/guide/src/getting-started.md
@@ -120,6 +120,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { {{#PYO3_CRATE_VERSION}}, features = ["extension-module"] }
+
+[build-dependencies]
+pyo3-build-config = { {{#PYO3_CRATE_VERSION} }
 ```
 
 ## pyproject.toml
@@ -139,6 +142,17 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
+```
+
+## build.rs
+
+Finally, in order to make `cargo test` work correctly, you should create
+a `build.rs` file with the following contents:
+
+```
+fn main() {
+    pyo3_build_config::add_python_link_args();
+}
 ```
 
 ## Running code

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -74,18 +74,47 @@ fn _add_extension_module_link_args(triple: &Triple, mut writer: impl std::io::Wr
     }
 }
 
-/// Adds linker arguments suitable for linking against the Python framework on macOS.
+#[doc(hidden)]
+#[deprecated = "Use add_python_link_args instead"]
+pub fn add_python_framework_link_args() {
+    add_python_link_args();
+}
+
+/// Adds any linker arguments needed to locate libpython.
 ///
-/// This should be called from a build script.
+/// This should be called from a build script. While this is only needed
+/// on certain platforms, it is recommended to unconditionally call this
+/// from your build.rs to ensure that your crate correctly builds on
+/// those platforms.
+///
+/// This is necessary for any code that dynamically links libpython,
+/// including binary crates as well as Rust test cases that call into
+/// the Python interpreter. It is not necessary for an extension module,
+/// provided that your test cases do not call the Python interpreter.
 ///
 /// The following link flags are added:
-/// - macOS: `-Wl,-rpath,<framework_prefix>`
+/// - macOS framework builds: `-Wl,-rpath,<framework_prefix>`
+/// - UNIX relocatable Python builds: `-Wl,rpath,<lib_dir>`
 ///
 /// All other platforms currently are no-ops.
+///
+/// Note that this function works by including a reference to the location of
+/// the libpython dynamic library into your executable. If your only use of this
+/// library is in `cargo test`, or if the Python installation will be in the same
+/// place on your build system and production system (e.g., you are building on
+/// the same machine where you run, or you are generating a container or system
+/// image, or you are building against a Python installation packaged by your
+/// operating system), then this is probably the behavior you want. If you are
+/// distributing an application to run on other systems, you will likely want to
+/// figure out a plan to distribute libpython along with your application and
+/// manually set the correct rpath, either by having your build.rs emit the right
+/// flags instead of calling this function, or by using a tool like patchelf
+/// after the fact, or alternatively you will want to build against a
+/// static libpython.
 #[cfg(feature = "resolve-config")]
-pub fn add_python_framework_link_args() {
+pub fn add_python_link_args() {
     let interpreter_config = pyo3_build_script_impl::resolve_interpreter_config().unwrap();
-    _add_python_framework_link_args(
+    _add_python_link_args(
         &interpreter_config,
         &impl_::target_triple_from_env(),
         impl_::is_linking_libpython(),
@@ -94,7 +123,7 @@ pub fn add_python_framework_link_args() {
 }
 
 #[cfg(feature = "resolve-config")]
-fn _add_python_framework_link_args(
+fn _add_python_link_args(
     interpreter_config: &InterpreterConfig,
     triple: &Triple,
     link_libpython: bool,
@@ -106,6 +135,15 @@ fn _add_python_framework_link_args(
                 writer,
                 "cargo:rustc-link-arg=-Wl,-rpath,{}",
                 framework_prefix
+            )
+            .unwrap();
+        }
+    } else if interpreter_config.relocatable && link_libpython && triple.operating_system != OperatingSystem::Windows {
+        if let Some(lib_dir) = interpreter_config.lib_dir.as_ref() {
+            writeln!(
+                writer,
+                "cargo:rustc-link-arg=-Wl,-rpath,{}",
+                lib_dir
             )
             .unwrap();
         }
@@ -347,10 +385,10 @@ mod tests {
 
     #[cfg(feature = "resolve-config")]
     #[test]
-    fn python_framework_link_args() {
+    fn python_link_args() {
         let mut buf = Vec::new();
 
-        let interpreter_config = InterpreterConfig {
+        let base = InterpreterConfig {
             implementation: PythonImplementation::CPython,
             version: PythonVersion {
                 major: 3,
@@ -365,21 +403,34 @@ mod tests {
             build_flags: BuildFlags::default(),
             suppress_build_script_link_lines: false,
             extra_build_script_lines: vec![],
+            python_framework_prefix: None,
+            relocatable: false,
+        };
+
+        let mac_framework_config = InterpreterConfig {
             python_framework_prefix: Some(
                 "/Applications/Xcode.app/Contents/Developer/Library/Frameworks".to_string(),
             ),
+            ..base
+        };
+        let relocatable_config = InterpreterConfig {
+            lib_dir: "/home/xyz/Downloads/python/lib",
+            relocatable: true,
+            ..base
         };
         // Does nothing on non-mac
-        _add_python_framework_link_args(
-            &interpreter_config,
-            &Triple::from_str("x86_64-pc-windows-msvc").unwrap(),
-            true,
-            &mut buf,
-        );
-        assert_eq!(buf, Vec::new());
+        for interpreter_config in &[mac_framework_config, relocatable_config] {
+            _add_python_link_args(
+                &interpreter_config,
+                &Triple::from_str("x86_64-pc-windows-msvc").unwrap(),
+                true,
+                &mut buf,
+            );
+            assert_eq!(buf, Vec::new());
+        }
 
-        _add_python_framework_link_args(
-            &interpreter_config,
+        _add_python_link_args(
+            &mac_framework_config,
             &Triple::from_str("x86_64-apple-darwin").unwrap(),
             true,
             &mut buf,
@@ -387,6 +438,17 @@ mod tests {
         assert_eq!(
             std::str::from_utf8(&buf).unwrap(),
             "cargo:rustc-link-arg=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Library/Frameworks\n"
+        );
+
+        _add_python_link_args(
+            &relocatable_config,
+            &Triple::from_str("x86_64-apple-darwin").unwrap(),
+            true,
+            &mut buf,
+        );
+        assert_eq!(
+            std::str::from_utf8(&buf).unwrap(),
+            "cargo:rustc-link-arg=-Wl,-rpath,/home/xyz/Downloads/python/lib\n"
         );
     }
 }


### PR DESCRIPTION
Relocatable Python installations like python-build-standalone have a similar need for an rpath as the macOS framework builds in Xcode. Furthermore, the platform on which you build your code is not really a function of the code itself. This change generalizes the recent `add_python_framework_link_args()` from #4833 to
`add_python_link_args()`, which also does the right thing on python-build-standalone, and encourages everyone to set up a build.rs file that invokes it, whether or not they need it on their current machine.

---

The motivation here is #4813 and astral-sh/uv#11006: currently, `cargo test` doesn't work if your test cases call into libpython and your libpython isn't installed systemwide.

I'm opening this now to get feedback on the general approach of encouraging everyone to have a build.rs file regardless of whether they currently need it. This needs some more docs changes to convey that. If this sounds good, I also plan to contribute a change to `maturin new` to create this file.

At the moment the heuristic for whether your Python installation needs the rpath setting is whether there's a `sysconfig.get_var("PYTHON_BUILD_STANDALONE") == "1"`. We're planning on trying to get a mode in upstream CPython to build a relocatable installation (mostly to build `bin/python` itself with `$ORIGIN`-relative rpaths, but also to get libpython to detect some things about its own path better), at which point it would make sense to add an official sysconfig var to designate relocatability. Until then I think a heuristic is the best we can do. I suppose we can unconditionally emit an rpath line but having an rpath for system directories like /usr/lib is pretty weird.

Test case: download some recent python-build-standalone build, add its bin directory to the front of your `PATH`, and try to run `cargo test` on, say
```rust
 #[test]
fn test_something() {
    Python::with_gil(|_py| ());   
}
```
This currently fails, but works with this patch. (It does not work with a stock python-build-standalone build if you set `PYO3_PYTHON` instead of adding to your `PATH`, which is a bug; it does work with a Python installed by `uv`, which does some post-install tweaks.)