### PR TITLE
Optimize nth and nth_back for BoundTupleIterator

### DIFF
--- a/newsfragments/4897.added.md
+++ b/newsfragments/4897.added.md
@@ -1,0 +1,1 @@
+Optimizes `nth`, `nth_back`, `advance_by` and `advance_back_by` for `BoundTupleIterator`

--- a/pyo3-benches/benches/bench_tuple.rs
+++ b/pyo3-benches/benches/bench_tuple.rs
@@ -132,10 +132,38 @@ fn tuple_into_pyobject(b: &mut Bencher<'_>) {
     });
 }
 
+fn tuple_nth(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        const LEN: usize = 50;
+        let list = PyTuple::new(py, 0..LEN).unwrap();
+        let mut sum = 0;
+        b.iter(|| {
+            for i in 0..LEN {
+                sum += list.iter().nth(i).unwrap().extract::<usize>().unwrap();
+            }
+        });
+    });
+}
+
+fn tuple_nth_back(b: &mut Bencher<'_>) {
+    Python::with_gil(|py| {
+        const LEN: usize = 50;
+        let list = PyTuple::new(py, 0..LEN).unwrap();
+        let mut sum = 0;
+        b.iter(|| {
+            for i in 0..LEN {
+                sum += list.iter().nth_back(i).unwrap().extract::<usize>().unwrap();
+            }
+        });
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("iter_tuple", iter_tuple);
     c.bench_function("tuple_new", tuple_new);
     c.bench_function("tuple_get_item", tuple_get_item);
+    c.bench_function("tuple_nth", tuple_nth);
+    c.bench_function("tuple_nth_back", tuple_nth_back);
     #[cfg(not(any(Py_LIMITED_API, PyPy)))]
     c.bench_function("tuple_get_item_unchecked", tuple_get_item_unchecked);
     c.bench_function("tuple_get_borrowed_item", tuple_get_borrowed_item);

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -920,7 +920,7 @@ impl DoubleEndedIterator for BoundListIterator<'_> {
                 length.0 = max_len - n;
                 Ok(())
             } else {
-                length.0 = max_len;
+                length.0 = currently_at;
                 let remainder = n - items_left;
                 Err(unsafe { NonZero::new_unchecked(remainder) })
             }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1,5 +1,3 @@
-use std::iter::FusedIterator;
-
 use crate::ffi::{self, Py_ssize_t};
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
@@ -13,6 +11,9 @@ use crate::{
 };
 #[allow(deprecated)]
 use crate::{IntoPy, ToPyObject};
+use std::iter::FusedIterator;
+#[cfg(feature = "nightly")]
+use std::num::NonZero;
 
 #[inline]
 #[track_caller]
@@ -375,6 +376,48 @@ impl<'py> Iterator for BoundTupleIterator<'py> {
         let len = self.len();
         (len, Some(len))
     }
+
+    #[inline]
+    #[cfg(not(feature = "nightly"))]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let length = self.length.min(self.tuple.len());
+        let target_index = self.index + n;
+        if target_index < length {
+            let item = {
+                {
+                    unsafe { self.tuple.get_item_unchecked(target_index) }
+                }
+            };
+            self.index = target_index + 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "nightly")]
+    fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        let max_len = self.length.min(self.tuple.len());
+        let currently_at = self.index;
+        if currently_at >= max_len {
+            if n == 0 {
+                return Ok(());
+            } else {
+                return Err(unsafe { NonZero::new_unchecked(n) });
+            }
+        }
+
+        let items_left = max_len - currently_at;
+        if n <= items_left {
+            self.index += n;
+            Ok(())
+        } else {
+            self.index = max_len;
+            let remainder = n - items_left;
+            Err(unsafe { NonZero::new_unchecked(remainder) })
+        }
+    }
 }
 
 impl DoubleEndedIterator for BoundTupleIterator<'_> {
@@ -389,6 +432,48 @@ impl DoubleEndedIterator for BoundTupleIterator<'_> {
             Some(item)
         } else {
             None
+        }
+    }
+
+    #[inline]
+    #[cfg(not(feature = "nightly"))]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        let length_size = self.length.min(self.tuple.len());
+        if self.index + n < length_size {
+            let target_index = length_size - n - 1;
+            let item = {
+                {
+                    unsafe { self.tuple.get_item_unchecked(target_index) }
+                }
+            };
+            self.length = target_index;
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "nightly")]
+    fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
+        let max_len = self.length.min(self.tuple.len());
+        let currently_at = self.index;
+        if currently_at >= max_len {
+            if n == 0 {
+                return Ok(());
+            } else {
+                return Err(unsafe { NonZero::new_unchecked(n) });
+            }
+        }
+
+        let items_left = max_len - currently_at;
+        if n <= items_left {
+            self.length = max_len - n;
+            Ok(())
+        } else {
+            self.length = max_len;
+            let remainder = n - items_left;
+            Err(unsafe { NonZero::new_unchecked(remainder) })
         }
     }
 }
@@ -979,8 +1064,9 @@ mod tests {
     use crate::types::{any::PyAnyMethods, tuple::PyTupleMethods, PyList, PyTuple};
     use crate::{IntoPyObject, Python};
     use std::collections::HashSet;
+    #[cfg(feature = "nightly")]
+    use std::num::NonZero;
     use std::ops::Range;
-
     #[test]
     fn test_new() {
         Python::with_gil(|py| {
@@ -1521,6 +1607,127 @@ mod tests {
                     4
                 );
             }
+        })
+    }
+
+    #[test]
+    fn test_bound_tuple_nth() {
+        Python::with_gil(|py| {
+            let tuple = PyTuple::new(py, vec![1, 2, 3, 4]).unwrap();
+            let mut iter = tuple.iter();
+            assert_eq!(iter.nth(1).unwrap().extract::<i32>().unwrap(), 2);
+            assert_eq!(iter.nth(1).unwrap().extract::<i32>().unwrap(), 4);
+            assert!(iter.nth(1).is_none());
+
+            let tuple = PyTuple::new(py, Vec::<i32>::new()).unwrap();
+            let mut iter = tuple.iter();
+            iter.next();
+            assert!(iter.nth(1).is_none());
+
+            let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
+            let mut iter = tuple.iter();
+            assert!(iter.nth(10).is_none());
+
+            let tuple = PyTuple::new(py, vec![6, 7, 8, 9, 10]).unwrap();
+            let mut iter = tuple.iter();
+            assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 6);
+            assert_eq!(iter.nth(2).unwrap().extract::<i32>().unwrap(), 9);
+            assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 10);
+
+            let mut iter = tuple.iter();
+            assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 9);
+            assert_eq!(iter.nth(2).unwrap().extract::<i32>().unwrap(), 8);
+            assert!(iter.next().is_none());
+        });
+    }
+
+    #[test]
+    fn test_bound_tuple_nth_back() {
+        Python::with_gil(|py| {
+            let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
+            let mut iter = tuple.iter();
+            assert_eq!(iter.nth_back(0).unwrap().extract::<i32>().unwrap(), 5);
+            assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 3);
+            assert!(iter.nth_back(2).is_none());
+
+            let tuple = PyTuple::new(py, Vec::<i32>::new()).unwrap();
+            let mut iter = tuple.iter();
+            assert!(iter.nth_back(0).is_none());
+            assert!(iter.nth_back(1).is_none());
+
+            let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
+            let mut iter = tuple.iter();
+            assert!(iter.nth_back(5).is_none());
+
+            let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
+            let mut iter = tuple.iter();
+            iter.next_back(); // Consume the last element
+            assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 3);
+            assert_eq!(iter.next_back().unwrap().extract::<i32>().unwrap(), 2);
+            assert_eq!(iter.nth_back(0).unwrap().extract::<i32>().unwrap(), 1);
+
+            let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
+            let mut iter = tuple.iter();
+            assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 4);
+            assert_eq!(iter.nth_back(2).unwrap().extract::<i32>().unwrap(), 1);
+
+            let mut iter2 = tuple.iter();
+            iter2.next_back();
+            assert_eq!(iter2.nth_back(1).unwrap().extract::<i32>().unwrap(), 3);
+            assert_eq!(iter2.next_back().unwrap().extract::<i32>().unwrap(), 2);
+
+            let mut iter3 = tuple.iter();
+            iter3.nth(1);
+            assert_eq!(iter3.nth_back(2).unwrap().extract::<i32>().unwrap(), 3);
+            assert!(iter3.nth_back(0).is_none());
+        });
+    }
+
+    #[cfg(feature = "nightly")]
+    #[test]
+    fn test_bound_tuple_advance_by() {
+        Python::with_gil(|py| {
+            let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
+            let mut iter = tuple.iter();
+
+            assert_eq!(iter.advance_by(2), Ok(()));
+            assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 3);
+            assert_eq!(iter.advance_by(0), Ok(()));
+            assert_eq!(iter.advance_by(100), Err(NonZero::new(98).unwrap()));
+
+            let mut iter2 = tuple.iter();
+            assert_eq!(iter2.advance_by(6), Err(NonZero::new(1).unwrap()));
+
+            let mut iter3 = tuple.iter();
+            assert_eq!(iter3.advance_by(5), Ok(()));
+
+            let mut iter4 = tuple.iter();
+            assert_eq!(iter4.advance_by(0), Ok(()));
+            assert_eq!(iter4.next().unwrap().extract::<i32>().unwrap(), 1);
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[test]
+    fn test_bound_tuple_advance_back_by() {
+        Python::with_gil(|py| {
+            let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
+            let mut iter = tuple.iter();
+
+            assert_eq!(iter.advance_back_by(2), Ok(()));
+            assert_eq!(iter.next_back().unwrap().extract::<i32>().unwrap(), 3);
+            assert_eq!(iter.advance_back_by(0), Ok(()));
+            assert_eq!(iter.advance_back_by(100), Err(NonZero::new(98).unwrap()));
+
+            let mut iter2 = tuple.iter();
+            assert_eq!(iter2.advance_back_by(6), Err(NonZero::new(1).unwrap()));
+
+            let mut iter3 = tuple.iter();
+            assert_eq!(iter3.advance_back_by(5), Ok(()));
+
+            let mut iter4 = tuple.iter();
+            assert_eq!(iter4.advance_back_by(0), Ok(()));
+            assert_eq!(iter4.next_back().unwrap().extract::<i32>().unwrap(), 5);
         })
     }
 }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -383,13 +383,8 @@ impl<'py> Iterator for BoundTupleIterator<'py> {
         let length = self.length.min(self.tuple.len());
         let target_index = self.index + n;
         if target_index < length {
-            let item = {
-                {
-                    unsafe {
-                        BorrowedTupleIterator::get_item(self.tuple.as_borrowed(), target_index)
-                            .to_owned()
-                    }
-                }
+            let item = unsafe {
+                BorrowedTupleIterator::get_item(self.tuple.as_borrowed(), target_index).to_owned()
             };
             self.index = target_index + 1;
             Some(item)
@@ -444,13 +439,8 @@ impl DoubleEndedIterator for BoundTupleIterator<'_> {
         let length_size = self.length.min(self.tuple.len());
         if self.index + n < length_size {
             let target_index = length_size - n - 1;
-            let item = {
-                {
-                    unsafe {
-                        BorrowedTupleIterator::get_item(self.tuple.as_borrowed(), target_index)
-                            .to_owned()
-                    }
-                }
+            let item = unsafe {
+                BorrowedTupleIterator::get_item(self.tuple.as_borrowed(), target_index).to_owned()
             };
             self.length = target_index;
             Some(item)
@@ -477,7 +467,7 @@ impl DoubleEndedIterator for BoundTupleIterator<'_> {
             self.length = max_len - n;
             Ok(())
         } else {
-            self.length = max_len;
+            self.length = currently_at;
             let remainder = n - items_left;
             Err(unsafe { NonZero::new_unchecked(remainder) })
         }
@@ -1700,6 +1690,7 @@ mod tests {
             assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 3);
             assert_eq!(iter.advance_by(0), Ok(()));
             assert_eq!(iter.advance_by(100), Err(NonZero::new(98).unwrap()));
+            assert!(iter.next().is_none());
 
             let mut iter2 = tuple.iter();
             assert_eq!(iter2.advance_by(6), Err(NonZero::new(1).unwrap()));
@@ -1724,6 +1715,7 @@ mod tests {
             assert_eq!(iter.next_back().unwrap().extract::<i32>().unwrap(), 3);
             assert_eq!(iter.advance_back_by(0), Ok(()));
             assert_eq!(iter.advance_back_by(100), Err(NonZero::new(98).unwrap()));
+            assert!(iter.next_back().is_none());
 
             let mut iter2 = tuple.iter();
             assert_eq!(iter2.advance_back_by(6), Err(NonZero::new(1).unwrap()));

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -385,7 +385,10 @@ impl<'py> Iterator for BoundTupleIterator<'py> {
         if target_index < length {
             let item = {
                 {
-                    unsafe { self.tuple.get_item_unchecked(target_index) }
+                    unsafe {
+                        BorrowedTupleIterator::get_item(self.tuple.as_borrowed(), target_index)
+                            .to_owned()
+                    }
                 }
             };
             self.index = target_index + 1;
@@ -443,7 +446,10 @@ impl DoubleEndedIterator for BoundTupleIterator<'_> {
             let target_index = length_size - n - 1;
             let item = {
                 {
-                    unsafe { self.tuple.get_item_unchecked(target_index) }
+                    unsafe {
+                        BorrowedTupleIterator::get_item(self.tuple.as_borrowed(), target_index)
+                            .to_owned()
+                    }
                 }
             };
             self.length = target_index;


### PR DESCRIPTION
See #4787 

This PR optimizes `nth` and `nth_back` for `BoundTupleIterator`, and added unittest & benchmarks for these 2 APIs. Here are the benchmark of the optimized `nth` and `nth_back`:

## On Stable toolchain
**With Optimization**
```
tuple_nth               time:   [283.96 ns 286.42 ns 291.01 ns]
tuple_nth_back          time:   [288.92 ns 289.83 ns 291.15 ns]
```

**The default `nth` and `nth_back` implementation**
```
tuple_nth               time:   [2.0933 µs 2.0961 µs 2.0992 µs]
tuple_nth_back          time:   [2.0425 µs 2.0445 µs 2.0468 µs]
```

## On nightly toolchain
**With Optimization**
```
tuple_nth               time:   [275.54 ns 275.97 ns 276.49 ns]
tuple_nth_back          time:   [315.25 ns 343.92 ns 375.81 ns]
```

**The default `nth` and `nth_back` implementation**
```
tuple_nth               time:   [1.9814 µs 1.9846 µs 1.9883 µs]
tuple_nth_back          time:   [2.0314 µs 2.0705 µs 2.1266 µs]
```
