### PR TITLE
fix multithreaded access to freelist pyclasses

### DIFF
--- a/newsfragments/4902.fixed.md
+++ b/newsfragments/4902.fixed.md
@@ -1,0 +1,1 @@
+* Fixed thread-unsafe implementation of freelist pyclasses on the free-threaded build.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2380,12 +2380,12 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote! {
                 impl #pyo3_path::impl_::pyclass::PyClassWithFreeList for #cls {
                     #[inline]
-                    fn get_free_list(py: #pyo3_path::Python<'_>) -> &mut #pyo3_path::impl_::freelist::FreeList<*mut #pyo3_path::ffi::PyObject> {
-                        static mut FREELIST: *mut #pyo3_path::impl_::freelist::FreeList<*mut #pyo3_path::ffi::PyObject> = 0 as *mut _;
+                    fn get_free_list(py: #pyo3_path::Python<'_>) -> &mut #pyo3_path::impl_::freelist::PyObjectFreeList {
+                        static mut FREELIST: *mut #pyo3_path::impl_::freelist::PyObjectFreeList = 0 as *mut _;
                         unsafe {
                             if FREELIST.is_null() {
                                 FREELIST = ::std::boxed::Box::into_raw(::std::boxed::Box::new(
-                                    #pyo3_path::impl_::freelist::FreeList::with_capacity(#freelist)));
+                                    #pyo3_path::impl_::freelist::PyObjectFreeList::with_capacity(#freelist)));
                             }
                             &mut *FREELIST
                         }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2381,14 +2381,12 @@ impl<'a> PyClassImplsBuilder<'a> {
                 impl #pyo3_path::impl_::pyclass::PyClassWithFreeList for #cls {
                     #[inline]
                     fn get_free_list(py: #pyo3_path::Python<'_>) -> &'static ::std::sync::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList> {
-                        static mut FREELIST: #pyo3_path::sync::GILOnceCell<::std::sync::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList>> = #pyo3_path::sync::GILOnceCell::new();
-                        unsafe {
-                            // If there's a race to fill the cell, the object created
-                            // by the losing thread will be deallocated via RAII
-                            &FREELIST.get_or_init(py, || {
-                                ::std::sync::Mutex::new(#pyo3_path::impl_::freelist::PyObjectFreeList::with_capacity(#freelist))
-                            })
-                        }
+                        static FREELIST: #pyo3_path::sync::GILOnceCell<::std::sync::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList>> = #pyo3_path::sync::GILOnceCell::new();
+                        // If there's a race to fill the cell, the object created
+                        // by the losing thread will be deallocated via RAII
+                        &FREELIST.get_or_init(py, || {
+                            ::std::sync::Mutex::new(#pyo3_path::impl_::freelist::PyObjectFreeList::with_capacity(#freelist))
+                        })
                     }
                 }
             }

--- a/src/impl_/freelist.rs
+++ b/src/impl_/freelist.rs
@@ -12,7 +12,7 @@ use crate::ffi;
 use std::mem;
 
 /// Represents a slot of a [`PyObjectFreeList`].
-pub enum PyObjectSlot {
+enum PyObjectSlot {
     /// A free slot.
     Empty,
     /// An allocated slot.
@@ -26,7 +26,7 @@ unsafe impl Send for PyObjectSlot {}
 ///
 /// See [the parent module](crate::impl_::freelist) for more details.
 pub struct PyObjectFreeList {
-    entries: Vec<PyObjectSlot>,
+    entries: Box<[PyObjectSlot]>,
     split: usize,
     capacity: usize,
 }
@@ -36,7 +36,7 @@ impl PyObjectFreeList {
     pub fn with_capacity(capacity: usize) -> PyObjectFreeList {
         let entries = (0..capacity)
             .map(|_| PyObjectSlot::Empty)
-            .collect::<Vec<_>>();
+            .collect::<Box<[_]>>();
 
         PyObjectFreeList {
             entries,

--- a/src/impl_/freelist.rs
+++ b/src/impl_/freelist.rs
@@ -8,31 +8,37 @@
 //!
 //! [1]: https://en.wikipedia.org/wiki/Free_list
 
+use crate::ffi;
 use std::mem;
 
-/// Represents a slot of a [`FreeList`].
-pub enum Slot<T> {
+/// Represents a slot of a [`PyObjectFreeList`].
+pub enum PyObjectSlot {
     /// A free slot.
     Empty,
     /// An allocated slot.
-    Filled(T),
+    Filled(*mut ffi::PyObject),
 }
 
-/// A free allocation list.
+// safety: access is guarded by a per-pyclass mutex
+unsafe impl Send for PyObjectSlot {}
+
+/// A free allocation list for PyObject ffi pointers.
 ///
 /// See [the parent module](crate::impl_::freelist) for more details.
-pub struct FreeList<T> {
-    entries: Vec<Slot<T>>,
+pub struct PyObjectFreeList {
+    entries: Vec<PyObjectSlot>,
     split: usize,
     capacity: usize,
 }
 
-impl<T> FreeList<T> {
-    /// Creates a new `FreeList` instance with specified capacity.
-    pub fn with_capacity(capacity: usize) -> FreeList<T> {
-        let entries = (0..capacity).map(|_| Slot::Empty).collect::<Vec<_>>();
+impl PyObjectFreeList {
+    /// Creates a new `PyObjectFreeList` instance with specified capacity.
+    pub fn with_capacity(capacity: usize) -> PyObjectFreeList {
+        let entries = (0..capacity)
+            .map(|_| PyObjectSlot::Empty)
+            .collect::<Vec<_>>();
 
-        FreeList {
+        PyObjectFreeList {
             entries,
             split: 0,
             capacity,
@@ -40,26 +46,26 @@ impl<T> FreeList<T> {
     }
 
     /// Pops the first non empty item.
-    pub fn pop(&mut self) -> Option<T> {
+    pub fn pop(&mut self) -> Option<*mut ffi::PyObject> {
         let idx = self.split;
         if idx == 0 {
             None
         } else {
-            match mem::replace(&mut self.entries[idx - 1], Slot::Empty) {
-                Slot::Filled(v) => {
+            match mem::replace(&mut self.entries[idx - 1], PyObjectSlot::Empty) {
+                PyObjectSlot::Filled(v) => {
                     self.split = idx - 1;
                     Some(v)
                 }
-                _ => panic!("FreeList is corrupt"),
+                _ => panic!("PyObjectFreeList is corrupt"),
             }
         }
     }
 
-    /// Inserts a value into the list. Returns `Some(val)` if the `FreeList` is full.
-    pub fn insert(&mut self, val: T) -> Option<T> {
+    /// Inserts a value into the list. Returns `Some(val)` if the `PyObjectFreeList` is full.
+    pub fn insert(&mut self, val: *mut ffi::PyObject) -> Option<*mut ffi::PyObject> {
         let next = self.split + 1;
         if next < self.capacity {
-            self.entries[self.split] = Slot::Filled(val);
+            self.entries[self.split] = PyObjectSlot::Filled(val);
             self.split = next;
             None
         } else {

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -936,6 +936,7 @@ pub unsafe extern "C" fn alloc_with_freelist<T: PyClassWithFreeList>(
     if nitems == 0 && subtype == self_type {
         let mut free_list = T::get_free_list(py).lock().unwrap();
         if let Some(obj) = free_list.pop() {
+            drop(free_list);
             ffi::PyObject_Init(obj, subtype);
             return obj as _;
         }
@@ -959,6 +960,7 @@ pub unsafe extern "C" fn free_with_freelist<T: PyClassWithFreeList>(obj: *mut c_
         .lock()
         .unwrap();
     if let Some(obj) = free_list.insert(obj) {
+        drop(free_list);
         let ty = ffi::Py_TYPE(obj);
 
         // Deduce appropriate inverse of PyType_GenericAlloc

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -2,7 +2,7 @@ use crate::{
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError, PyValueError},
     ffi,
     impl_::{
-        freelist::FreeList,
+        freelist::PyObjectFreeList,
         pycell::{GetBorrowChecker, PyClassMutability, PyClassObjectLayout},
         pyclass_init::PyObjectInit,
         pymethods::{PyGetterDef, PyMethodDefType},
@@ -912,7 +912,7 @@ use super::{pycell::PyClassObject, pymethods::BoundRef};
 /// Do not implement this trait manually. Instead, use `#[pyclass(freelist = N)]`
 /// on a Rust struct to implement it.
 pub trait PyClassWithFreeList: PyClass {
-    fn get_free_list(py: Python<'_>) -> &mut FreeList<*mut ffi::PyObject>;
+    fn get_free_list(py: Python<'_>) -> &mut PyObjectFreeList;
 }
 
 /// Implementation of tp_alloc for `freelist` classes.

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -37,10 +37,12 @@ fn class_with_freelist() {
 }
 
 #[pyclass(freelist = 2)]
+#[cfg(not(target_arch = "wasm32"))]
 struct ClassWithFreelistAndData {
     data: Option<usize>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn spin_freelist(py: Python<'_>, data: usize) {
     for _ in 0..500 {
         let inst1 = Py::new(py, ClassWithFreelistAndData { data: Some(data) }).unwrap();
@@ -51,6 +53,7 @@ fn spin_freelist(py: Python<'_>, data: usize) {
 }
 
 #[test]
+#[cfg(not(target_arch = "wasm32"))]
 fn multithreaded_class_with_freelist() {
     std::thread::scope(|s| {
         s.spawn(|| {


### PR DESCRIPTION
Fixes #4894

Wraps the freelist in a mutex.

I removed the generic from the `FreeList` struct and renamed it `PyObjectFreeList`. That makes it much easier to add an `unsafe impl for Send`. The generic parameter in `FreeList` is not used for anything but `*mut PyObject`.

Note: I haven't benchmarked whether this causes multithreaded scaling issues, but also scaling badly is better than segfaulting 🤷‍♂️