### PR TITLE
Update jiff to v0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,7 +460,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
-      - run: cargo rustdoc --lib --no-default-features --features full,jiff-01 -Zunstable-options --config "build.rustdocflags=[\"--cfg\", \"docsrs\"]"
+      - run: cargo rustdoc --lib --no-default-features --features full,jiff-02 -Zunstable-options --config "build.rustdocflags=[\"--cfg\", \"docsrs\"]"
 
   coverage:
     if: ${{ github.event_name != 'merge_group' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ either = { version = "1.9", optional = true }
 eyre = { version = ">= 0.6.8, < 0.7", optional = true }
 hashbrown = { version = ">= 0.14.5, < 0.16", optional = true }
 indexmap = { version = ">= 2.5.0, < 3", optional = true }
-jiff-01 = { package = "jiff", version = "0.1.18", optional = true }
+jiff-02 = { package = "jiff", version = "0.2", optional = true }
 num-bigint = { version = "0.4.2", optional = true }
 num-complex = { version = ">= 0.4.6, < 0.5", optional = true }
 num-rational = {version = "0.4.1", optional = true }

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -151,9 +151,9 @@ Adds a dependency on [hashbrown](https://docs.rs/hashbrown) and enables conversi
 
 Adds a dependency on [indexmap](https://docs.rs/indexmap) and enables conversions into its [`IndexMap`](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html) type.
 
-### `jiff-01`
+### `jiff-02`
 
-Adds a dependency on [jiff@0.1](https://docs.rs/jiff/0.1) and requires MSRV 1.70. Enables a conversion from [jiff](https://docs.rs/jiff)'s types to python:
+Adds a dependency on [jiff@0.2](https://docs.rs/jiff/0.2) and requires MSRV 1.70. Enables a conversion from [jiff](https://docs.rs/jiff)'s types to python:
 - [SignedDuration](https://docs.rs/jiff/0.1/jiff/struct.SignedDuration.html) -> [`PyDelta`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDelta.html)
 - [TimeZone](https://docs.rs/jiff/0.1/jiff/tz/struct.TimeZone.html) -> [`PyTzInfo`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTzInfo.html)
 - [Offset](https://docs.rs/jiff/0.1/jiff/tz/struct.Offset.html) -> [`PyTzInfo`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTzInfo.html)

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -154,14 +154,14 @@ Adds a dependency on [indexmap](https://docs.rs/indexmap) and enables conversion
 ### `jiff-02`
 
 Adds a dependency on [jiff@0.2](https://docs.rs/jiff/0.2) and requires MSRV 1.70. Enables a conversion from [jiff](https://docs.rs/jiff)'s types to python:
-- [SignedDuration](https://docs.rs/jiff/0.1/jiff/struct.SignedDuration.html) -> [`PyDelta`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDelta.html)
-- [TimeZone](https://docs.rs/jiff/0.1/jiff/tz/struct.TimeZone.html) -> [`PyTzInfo`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTzInfo.html)
-- [Offset](https://docs.rs/jiff/0.1/jiff/tz/struct.Offset.html) -> [`PyTzInfo`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTzInfo.html)
-- [Date](https://docs.rs/jiff/0.1/jiff/civil/struct.Date.html) -> [`PyDate`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDate.html)
-- [Time](https://docs.rs/jiff/0.1/jiff/civil/struct.Time.html) -> [`PyTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTime.html)
-- [DateTime](https://docs.rs/jiff/0.1/jiff/civil/struct.DateTime.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
-- [Zoned](https://docs.rs/jiff/0.1/jiff/struct.Zoned.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
-- [Timestamp](https://docs.rs/jiff/0.1/jiff/struct.Timestamp.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
+- [SignedDuration](https://docs.rs/jiff/0.2/jiff/struct.SignedDuration.html) -> [`PyDelta`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDelta.html)
+- [TimeZone](https://docs.rs/jiff/0.2/jiff/tz/struct.TimeZone.html) -> [`PyTzInfo`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTzInfo.html)
+- [Offset](https://docs.rs/jiff/0.2/jiff/tz/struct.Offset.html) -> [`PyTzInfo`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTzInfo.html)
+- [Date](https://docs.rs/jiff/0.2/jiff/civil/struct.Date.html) -> [`PyDate`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDate.html)
+- [Time](https://docs.rs/jiff/0.2/jiff/civil/struct.Time.html) -> [`PyTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTime.html)
+- [DateTime](https://docs.rs/jiff/0.2/jiff/civil/struct.DateTime.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
+- [Zoned](https://docs.rs/jiff/0.2/jiff/struct.Zoned.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
+- [Timestamp](https://docs.rs/jiff/0.2/jiff/struct.Timestamp.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
 
 ### `num-bigint`
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,9 +65,9 @@ def test_rust(session: nox.Session):
     if not FREE_THREADED_BUILD:
         _run_cargo_test(session, features="abi3")
     if "skip-full" not in session.posargs:
-        _run_cargo_test(session, features="full jiff-01")
+        _run_cargo_test(session, features="full jiff-02")
         if not FREE_THREADED_BUILD:
-            _run_cargo_test(session, features="abi3 full jiff-01")
+            _run_cargo_test(session, features="abi3 full jiff-02")
 
 
 @nox.session(name="test-py", venv_backend="none")
@@ -395,7 +395,7 @@ def docs(session: nox.Session) -> None:
 
     if get_rust_version()[:2] >= (1, 70):
         # jiff needs MSRC 1.70+
-        features += ",jiff-01"
+        features += ",jiff-02"
 
     shutil.rmtree(PYO3_DOCS_TARGET, ignore_errors=True)
     _run_cargo(
@@ -777,8 +777,8 @@ def update_ui_tests(session: nox.Session):
     env["TRYBUILD"] = "overwrite"
     command = ["test", "--test", "test_compile_error"]
     _run_cargo(session, *command, env=env)
-    _run_cargo(session, *command, "--features=full,jiff-01", env=env)
-    _run_cargo(session, *command, "--features=abi3,full,jiff-01", env=env)
+    _run_cargo(session, *command, "--features=full,jiff-02", env=env)
+    _run_cargo(session, *command, "--features=abi3,full,jiff-02", env=env)
 
 
 def _build_docs_for_ffi_check(session: nox.Session) -> None:
@@ -831,7 +831,7 @@ def _get_feature_sets() -> Generator[Tuple[str, ...], None, None]:
 
     if get_rust_version()[:2] >= (1, 70):
         # jiff needs MSRC 1.70+
-        features += ",jiff-01"
+        features += ",jiff-02"
 
     yield (f"--features={features}",)
     yield (f"--features=abi3,{features}",)

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -27,7 +27,7 @@ use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
 use crate::{Bound, IntoPyObject, PyAny, PyErr, Python};
 use std::os::raw::c_int;
-#[cfg(any(feature = "chrono", feature = "jiff-01"))]
+#[cfg(any(feature = "chrono", feature = "jiff-02"))]
 use std::ptr;
 
 fn ensure_datetime_api(py: Python<'_>) -> PyResult<&'static PyDateTime_CAPI> {
@@ -698,7 +698,7 @@ pub fn timezone_utc_bound(py: Python<'_>) -> Bound<'_, PyTzInfo> {
 /// Equivalent to `datetime.timezone` constructor
 ///
 /// Only used internally
-#[cfg(any(feature = "chrono", feature = "jiff-01"))]
+#[cfg(any(feature = "chrono", feature = "jiff-02"))]
 pub(crate) fn timezone_from_offset<'py>(
     offset: &Bound<'py, PyDelta>,
 ) -> PyResult<Bound<'py, PyTzInfo>> {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -239,7 +239,7 @@ mod code;
 pub(crate) mod complex;
 #[cfg(not(Py_LIMITED_API))]
 pub(crate) mod datetime;
-#[cfg(all(Py_LIMITED_API, any(feature = "chrono", feature = "jiff-01")))]
+#[cfg(all(Py_LIMITED_API, any(feature = "chrono", feature = "jiff-02")))]
 pub(crate) mod datetime_abi3;
 pub(crate) mod dict;
 mod ellipsis;


### PR DESCRIPTION
I removed the support for jiff v0.1 because we didn't released it yet, this felt cleaner to me.