### PR TITLE
bump `benchmarks` ci base image

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -15,8 +15,7 @@ concurrency:
 
 jobs:
   benchmarks:
-    # No support for 24.04, see https://github.com/CodSpeedHQ/runner/issues/42
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Closes #4911 