### PR TITLE
Add support for type hinting objects

### DIFF
--- a/newsfragments/4917.added.md
+++ b/newsfragments/4917.added.md
@@ -1,0 +1,2 @@
+Added support for creating [types.GenericAlias](https://docs.python.org/3/library/types.html#types.GenericAlias)
+objects in PyO3 with `pyo3::types::PyGenericAlias`.

--- a/pyo3-ffi/src/genericaliasobject.rs
+++ b/pyo3-ffi/src/genericaliasobject.rs
@@ -1,17 +1,4 @@
-use crate::object::{PyObject, PyTypeObject, Py_TYPE};
-use crate::PyObject_TypeCheck;
-use std::os::raw::c_int;
-use std::ptr;
-
-#[inline]
-pub unsafe fn PyGenericAlias_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == ptr::addr_of_mut!(Py_GenericAliasType)) as c_int
-}
-
-#[inline]
-pub unsafe fn PyGenericAlias_Check(op: *mut PyObject) -> c_int {
-    PyObject_TypeCheck(op, ptr::addr_of_mut!(Py_GenericAliasType))
-}
+use crate::object::{PyObject, PyTypeObject};
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {

--- a/pyo3-ffi/src/genericaliasobject.rs
+++ b/pyo3-ffi/src/genericaliasobject.rs
@@ -2,7 +2,9 @@ use crate::object::{PyObject, PyTypeObject};
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
+    #[cfg(Py_3_9)]
     pub fn Py_GenericAlias(origin: *mut PyObject, args: *mut PyObject) -> *mut PyObject;
 
+    #[cfg(Py_3_9)]
     pub static mut Py_GenericAliasType: PyTypeObject;
 }

--- a/pyo3-ffi/src/genericaliasobject.rs
+++ b/pyo3-ffi/src/genericaliasobject.rs
@@ -1,3 +1,4 @@
+#[cfg(Py_3_9)]
 use crate::object::{PyObject, PyTypeObject};
 
 #[cfg_attr(windows, link(name = "pythonXY"))]

--- a/pyo3-ffi/src/genericaliasobject.rs
+++ b/pyo3-ffi/src/genericaliasobject.rs
@@ -1,0 +1,21 @@
+use crate::object::{PyObject, PyTypeObject, Py_TYPE};
+use crate::PyObject_TypeCheck;
+use std::os::raw::c_int;
+use std::ptr;
+
+#[inline]
+pub unsafe fn PyGenericAlias_CheckExact(op: *mut PyObject) -> c_int {
+    (Py_TYPE(op) == ptr::addr_of_mut!(Py_GenericAliasType)) as c_int
+}
+
+#[inline]
+pub unsafe fn PyGenericAlias_Check(op: *mut PyObject) -> c_int {
+    PyObject_TypeCheck(op, ptr::addr_of_mut!(Py_GenericAliasType))
+}
+
+#[cfg_attr(windows, link(name = "pythonXY"))]
+extern "C" {
+    pub fn Py_GenericAlias(origin: *mut PyObject, args: *mut PyObject) -> *mut PyObject;
+
+    pub static mut Py_GenericAliasType: PyTypeObject;
+}

--- a/pyo3-ffi/src/genericaliasobject.rs
+++ b/pyo3-ffi/src/genericaliasobject.rs
@@ -4,6 +4,7 @@ use crate::object::{PyObject, PyTypeObject};
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     #[cfg(Py_3_9)]
+    #[cfg_attr(PyPy, link_name = "PyPy_GenericAlias")]
     pub fn Py_GenericAlias(origin: *mut PyObject, args: *mut PyObject) -> *mut PyObject;
 
     #[cfg(Py_3_9)]

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -410,6 +410,8 @@ pub use self::enumobject::*;
 pub use self::fileobject::*;
 pub use self::fileutils::*;
 pub use self::floatobject::*;
+#[cfg(Py_3_9)]
+pub use self::genericaliasobject::*;
 pub use self::import::*;
 pub use self::intrcheck::*;
 pub use self::iterobject::*;
@@ -479,7 +481,8 @@ mod fileobject;
 mod fileutils;
 mod floatobject;
 // skipped empty frameobject.h
-// skipped genericaliasobject.h
+#[cfg(Py_3_9)]
+mod genericaliasobject;
 mod import;
 // skipped interpreteridobject.h
 mod intrcheck;

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -410,7 +410,6 @@ pub use self::enumobject::*;
 pub use self::fileobject::*;
 pub use self::fileutils::*;
 pub use self::floatobject::*;
-#[cfg(Py_3_9)]
 pub use self::genericaliasobject::*;
 pub use self::import::*;
 pub use self::intrcheck::*;

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -481,7 +481,6 @@ mod fileobject;
 mod fileutils;
 mod floatobject;
 // skipped empty frameobject.h
-#[cfg(Py_3_9)]
 mod genericaliasobject;
 mod import;
 // skipped interpreteridobject.h

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -410,6 +410,7 @@ pub use self::enumobject::*;
 pub use self::fileobject::*;
 pub use self::fileutils::*;
 pub use self::floatobject::*;
+#[cfg(Py_3_9)]
 pub use self::genericaliasobject::*;
 pub use self::import::*;
 pub use self::intrcheck::*;

--- a/src/types/genericalias.rs
+++ b/src/types/genericalias.rs
@@ -1,0 +1,68 @@
+#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
+use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::{ffi, types::any::PyAnyMethods, Bound, PyAny, Python};
+
+/// Represents a Python [`types.GenericAlias`](https://docs.python.org/3/library/types.html#types.GenericAlias) object.
+///
+/// Values of this type are accessed via PyO3's smart pointers, e.g. as
+/// [`Py<PyGenericAlias>`][crate::Py] or [`Bound<'py, PyGenericAlias>`][Bound].
+#[repr(transparent)]
+pub struct PyGenericAlias(PyAny);
+
+pyobject_native_type!(
+    PyGenericAlias,
+    ffi::PyDictObject,
+    pyobject_native_static_type_object!(ffi::Py_GenericAliasType),
+    #checkfunction=ffi::PyGenericAlias_Check
+);
+
+impl PyGenericAlias {
+    /// Creates a new Python GenericAlias object.
+    ///
+    /// origin should be a non-parameterized generic class.
+    /// args should be a tuple (possibly of length 1) of types which parameterize origin.
+    pub fn new<'py>(
+        py: Python<'py>,
+        origin: &Bound<'py, PyAny>,
+        args: &Bound<'py, PyAny>,
+    ) -> Bound<'py, PyGenericAlias> {
+        unsafe {
+            ffi::Py_GenericAlias(origin.as_ptr(), args.as_ptr())
+                .assume_owned(py)
+                .downcast_into_unchecked()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::instance::BoundObject;
+    use crate::types::any::PyAnyMethods;
+    use crate::{ffi, Python};
+
+    use super::PyGenericAlias;
+
+    // Tests that PyGenericAlias::new is identical to types.GenericAlias
+    // created from Python.
+    #[test]
+    fn equivalency_test() {
+        Python::with_gil(|py| {
+            let list_int = py
+                .eval(ffi::c_str!("list[int]"), None, None)
+                .unwrap()
+                .into_bound();
+
+            let cls = py
+                .eval(ffi::c_str!("list"), None, None)
+                .unwrap()
+                .into_bound();
+            let key = py
+                .eval(ffi::c_str!("(int,)"), None, None)
+                .unwrap()
+                .into_bound();
+            let generic_alias = PyGenericAlias::new(py, &cls, &key);
+
+            assert!(generic_alias.eq(list_int).unwrap());
+        })
+    }
+}

--- a/src/types/genericalias.rs
+++ b/src/types/genericalias.rs
@@ -5,14 +5,17 @@ use crate::{ffi, types::any::PyAnyMethods, Bound, PyAny, Python};
 ///
 /// Values of this type are accessed via PyO3's smart pointers, e.g. as
 /// [`Py<PyGenericAlias>`][crate::Py] or [`Bound<'py, PyGenericAlias>`][Bound].
+///
+/// This type is particularly convenient for users implementing
+/// [`__class_getitem__`](https://docs.python.org/3/reference/datamodel.html#object.__class_getitem__)
+/// for PyO3 classes to allow runtime parameterization.
 #[repr(transparent)]
 pub struct PyGenericAlias(PyAny);
 
 pyobject_native_type!(
     PyGenericAlias,
     ffi::PyDictObject,
-    pyobject_native_static_type_object!(ffi::Py_GenericAliasType),
-    #checkfunction=ffi::PyGenericAlias_Check
+    pyobject_native_static_type_object!(ffi::Py_GenericAliasType)
 );
 
 impl PyGenericAlias {

--- a/src/types/genericalias.rs
+++ b/src/types/genericalias.rs
@@ -1,4 +1,3 @@
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::{ffi, types::any::PyAnyMethods, Bound, PyAny, Python};
 

--- a/src/types/genericalias.rs
+++ b/src/types/genericalias.rs
@@ -1,3 +1,4 @@
+use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::{ffi, types::any::PyAnyMethods, Bound, PyAny, Python};
 
@@ -27,11 +28,11 @@ impl PyGenericAlias {
         py: Python<'py>,
         origin: &Bound<'py, PyAny>,
         args: &Bound<'py, PyAny>,
-    ) -> Bound<'py, PyGenericAlias> {
+    ) -> PyResult<Bound<'py, PyGenericAlias>> {
         unsafe {
-            ffi::Py_GenericAlias(origin.as_ptr(), args.as_ptr())
-                .assume_owned(py)
-                .downcast_into_unchecked()
+            Ok(ffi::Py_GenericAlias(origin.as_ptr(), args.as_ptr())
+                .assume_owned_or_err(py)?
+                .downcast_into_unchecked())
         }
     }
 }
@@ -62,7 +63,7 @@ mod tests {
                 .eval(ffi::c_str!("(int,)"), None, None)
                 .unwrap()
                 .into_bound();
-            let generic_alias = PyGenericAlias::new(py, &cls, &key);
+            let generic_alias = PyGenericAlias::new(py, &cls, &key).unwrap();
 
             assert!(generic_alias.eq(list_int).unwrap());
         })

--- a/src/types/genericalias.rs
+++ b/src/types/genericalias.rs
@@ -1,6 +1,7 @@
 use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
-use crate::{ffi, types::any::PyAnyMethods, Bound, PyAny, Python};
+use crate::py_result_ext::PyResultExt;
+use crate::{ffi, Bound, PyAny, Python};
 
 /// Represents a Python [`types.GenericAlias`](https://docs.python.org/3/library/types.html#types.GenericAlias) object.
 ///
@@ -30,9 +31,9 @@ impl PyGenericAlias {
         args: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyGenericAlias>> {
         unsafe {
-            Ok(ffi::Py_GenericAlias(origin.as_ptr(), args.as_ptr())
-                .assume_owned_or_err(py)?
-                .downcast_into_unchecked())
+            ffi::Py_GenericAlias(origin.as_ptr(), args.as_ptr())
+                .assume_owned_or_err(py)
+                .downcast_into_unchecked()
         }
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -25,6 +25,8 @@ pub use self::frozenset::{PyFrozenSet, PyFrozenSetBuilder, PyFrozenSetMethods};
 pub use self::function::PyCFunction;
 #[cfg(all(not(Py_LIMITED_API), not(all(PyPy, not(Py_3_8)))))]
 pub use self::function::PyFunction;
+#[cfg(Py_3_9)]
+pub use self::genericalias::PyGenericAlias;
 pub use self::iterator::PyIterator;
 pub use self::list::{PyList, PyListMethods};
 pub use self::mapping::{PyMapping, PyMappingMethods};
@@ -248,6 +250,8 @@ pub(crate) mod float;
 mod frame;
 pub(crate) mod frozenset;
 mod function;
+#[cfg(Py_3_9)]
+pub(crate) mod genericalias;
 pub(crate) mod iterator;
 pub(crate) mod list;
 pub(crate) mod mapping;


### PR DESCRIPTION
Related to #4849 

This PR adds the `pyo3-ffi`  bindings to [type hinting objects](https://docs.python.org/3/c-api/typehints.html)
and then exposes them in `pyo3`.

I gated this for Python 3.9+ but I am not confident this is the appropriate way to doing so in PyO3. Is this the idiomatic way? I prefered to gate the whole module instead of individual methods.

