### PR TITLE
Use a critical section to serialize adding builtins to globals

### DIFF
--- a/newsfragments/4921.fixed.md
+++ b/newsfragments/4921.fixed.md
@@ -1,0 +1,1 @@
+* Reenabled a workaround for situations where CPython incorrectly does not add `__builtins__` to `__globals__` in code executed by `Python::py_run`.

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -117,7 +117,6 @@
 //! [`Rc`]: std::rc::Rc
 //! [`Py`]: crate::Py
 use crate::conversion::IntoPyObject;
-#[cfg(any(doc, not(Py_3_10)))]
 use crate::err::PyErr;
 use crate::err::{self, PyResult};
 use crate::ffi_ptr_ext::FfiPtrExt;
@@ -649,30 +648,40 @@ impl<'py> Python<'py> {
         };
         let locals = locals.unwrap_or(globals);
 
-        #[cfg(not(Py_3_10))]
-        {
-            // If `globals` don't provide `__builtins__`, most of the code will fail if Python
-            // version is <3.10. That's probably not what user intended, so insert `__builtins__`
-            // for them.
-            //
-            // See also:
-            // - https://github.com/python/cpython/pull/24564 (the same fix in CPython 3.10)
-            // - https://github.com/PyO3/pyo3/issues/3370
-            let builtins_s = crate::intern!(self, "__builtins__").as_ptr();
-            let has_builtins = unsafe { ffi::PyDict_Contains(globals.as_ptr(), builtins_s) };
-            if has_builtins == -1 {
-                return Err(PyErr::fetch(self));
-            }
-            if has_builtins == 0 {
-                // Inherit current builtins.
-                let builtins = unsafe { ffi::PyEval_GetBuiltins() };
-
-                // `PyDict_SetItem` doesn't take ownership of `builtins`, but `PyEval_GetBuiltins`
-                // seems to return a borrowed reference, so no leak here.
-                if unsafe { ffi::PyDict_SetItem(globals.as_ptr(), builtins_s, builtins) } == -1 {
+        // If `globals` don't provide `__builtins__`, most of the code will fail if Python
+        // version is <3.10. That's probably not what user intended, so insert `__builtins__`
+        // for them.
+        //
+        // See also:
+        // - https://github.com/python/cpython/pull/24564 (the same fix in CPython 3.10)
+        // - https://github.com/PyO3/pyo3/issues/3370
+        let builtins_s = crate::intern!(self, "__builtins__").as_ptr();
+        let has_builtins = unsafe { ffi::PyDict_Contains(globals.as_ptr(), builtins_s) };
+        if has_builtins == -1 {
+            return Err(PyErr::fetch(self));
+        }
+        if has_builtins == 0 {
+            crate::sync::with_critical_section(globals, || {
+                // check if another thread set __builtins__ while this thread was blocked on the critical section
+                let has_builtins: i32 =
+                    unsafe { ffi::PyDict_Contains(globals.as_ptr(), builtins_s) };
+                if has_builtins == -1 {
                     return Err(PyErr::fetch(self));
                 }
-            }
+                if has_builtins == 0 {
+                    // Inherit current builtins.
+                    let builtins = unsafe { ffi::PyEval_GetBuiltins() };
+
+                    // `PyDict_SetItem` doesn't take ownership of `builtins`, but `PyEval_GetBuiltins`
+                    // seems to return a borrowed reference, so no leak here.
+                    if unsafe { ffi::PyDict_SetItem(globals.as_ptr(), builtins_s, builtins) } == -1
+                    {
+                        return Err(PyErr::fetch(self));
+                    }
+                    return Ok(());
+                }
+                Ok(())
+            })?;
         }
 
         let code_obj = unsafe {


### PR DESCRIPTION
Fixes #4913

Because `PyDict` is a concurrent hash table, it's safe to first check if the dict has a key without holding a critical section then acquire the critical section and fill the dict.

Also adds a test based on the reproducer that I verified fails on `main`.