### PR TITLE
add pyo3::sync::with_critical_section_ptr

### DIFF
--- a/newsfragments/4922.added.md
+++ b/newsfragments/4922.added.md
@@ -1,0 +1,1 @@
+* Added an unsafe wrapper for the critical section API that accepts an FFI PyObject pointer.


### PR DESCRIPTION
This adds a public wrapper for the critical section C API that accepts a raw FFI pointer and refactors `with_critical_section` to use this new function.

While working on #4921 I thought I needed this but later realized I don't. Still, I think it's worth providing both the safe wrapper and unsafe wrapper in the public API, since sometimes you only have a raw pointer and it would be annoying to have to reimplement this every time.