### PR TITLE
Use dynamic dispatch when converting chrono timezones into python

### DIFF
--- a/newsfragments/4923.fixed.md
+++ b/newsfragments/4923.fixed.md
@@ -1,0 +1,1 @@
+Use dynamic dispatch when converting chrono timezones into python to allow for custom timezone implementations.


### PR DESCRIPTION
This fixes #4909 by removing the constraint for `Tz` to be `IntoPyObject` and instead using dynamic dispatch, albeit at the cost of some performance.

I'm not sure if we want to go this route in future pyo3 releases and instead require users to implement `IntoPyObject` for custom `TimeZone` implementations or let them convert it into a standard chrono one. If so then this PR should be merged into the 0.23 branch only.
