### PR TITLE
add a MutexExt trait to avoid deadlocks using Mutex::lock()

### DIFF
--- a/guide/src/class/thread-safety.md
+++ b/guide/src/class/thread-safety.md
@@ -101,6 +101,8 @@ impl MyClass {
 }
 ```
 
+If you need to lock around state stored in the Python interpreter or otherwise call into the Python C API while a lock is held, you might find the `MutexExt` trait useful. It provides a `lock_py_attached` method for `std::sync::Mutex` that avoids deadlocks with the GIL or other global synchronization events in the interpreter.
+
 ### Wrapping unsynchronized data
 
 In some cases, the data structures stored within a `#[pyclass]` may themselves not be thread-safe. Rust will therefore not implement `Send` and `Sync` on the `#[pyclass]` type.

--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -387,18 +387,15 @@ Python::with_gil(|py| {
 # }
 ```
 
-If you are executing arbitrary Python code while holding the lock, then you will
-need to use conditional compilation to use [`GILProtected`] on GIL-enabled Python
-builds and mutexes otherwise. If your use of [`GILProtected`] does not guard the
-execution of arbitrary Python code or use of the CPython C API, then conditional
-compilation is likely unnecessary since [`GILProtected`] was not needed in the
-first place and instead Rust mutexes or atomics should be preferred. Python 3.13
-introduces [`PyMutex`](https://docs.python.org/3/c-api/init.html#c.PyMutex),
-which releases the GIL while the waiting for the lock, so that is another option
-if you only need to support newer Python versions.
+If you are executing arbitrary Python code while holding the lock, then you
+should import the [`MutexExt`] trait and use the `lock_py_attached` method
+instead of `lock`. This ensures that global synchronization events started by
+the Python runtime can proceed, avoiding possible deadlocks with the
+interpreter.
 
 [`GILOnceCell`]: {{#PYO3_DOCS_URL}}/pyo3/sync/struct.GILOnceCell.html
 [`GILProtected`]: https://docs.rs/pyo3/0.22/pyo3/sync/struct.GILProtected.html
+[`MutexExt`]: {{#PYO3_DOCS_URL}}/pyo3/sync/trait.MutexExt.html
 [`Once`]: https://doc.rust-lang.org/stable/std/sync/struct.Once.html
 [`Once::call_once`]: https://doc.rust-lang.org/stable/std/sync/struct.Once.html#tymethod.call_once
 [`Once::call_once_force`]: https://doc.rust-lang.org/stable/std/sync/struct.Once.html#tymethod.call_once_force

--- a/newsfragments/4934.added.md
+++ b/newsfragments/4934.added.md
@@ -1,0 +1,1 @@
+* Added `MutextExt`, an extension trait to avoid deadlocks with the GIL while locking a `std::sync::Mutex`.

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -55,3 +55,4 @@ impl<T: crate::type_object::PyTypeInfo> Sealed for PyNativeTypeInitializer<T> {}
 impl<T: crate::pyclass::PyClass> Sealed for PyClassInitializer<T> {}
 
 impl Sealed for std::sync::Once {}
+impl<T> Sealed for std::sync::Mutex<T> {}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -576,12 +576,10 @@ impl<T> MutexExt<T> for std::sync::Mutex<T> {
         // possible deadlocks.
         match self.try_lock() {
             Ok(inner) => return Ok(inner),
-            Err(err_val) => match err_val {
-                std::sync::TryLockError::Poisoned(inner) => {
-                    return std::sync::LockResult::Err(inner)
-                }
-                std::sync::TryLockError::WouldBlock => {}
-            },
+            Err(std::sync::TryLockError::Poisoned(inner)) => {
+                return std::sync::LockResult::Err(inner)
+            }
+            Err(std::sync::TryLockError::WouldBlock) => {}
         }
         // SAFETY: detach from the runtime right before a possibly blocking call
         // then reattach when the blocking call completes and before calling


### PR DESCRIPTION
Fixes #4771.

I couldn't find any good uses for this inside PyO3 itself, but we know of at least two spots in rust-numpy this would be useful.