### PR TITLE
Avoid clippy::useless_conversion lint in macros

### DIFF
--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -265,26 +265,20 @@ impl FnType {
                 let slf: Ident = syn::Ident::new("_slf", Span::call_site());
                 let pyo3_path = pyo3_path.to_tokens_spanned(*span);
                 let ret = quote_spanned! { *span =>
-                    #[allow(clippy::useless_conversion)]
-                    ::std::convert::Into::into(
-                        #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(#py, &*(&#slf as *const _ as *const *mut _))
-                            .downcast_unchecked::<#pyo3_path::types::PyType>()
-                    )
+                    #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(#py, &*(&#slf as *const _ as *const *mut _))
+                        .downcast_unchecked::<#pyo3_path::types::PyType>()
                 };
-                Some(quote! { unsafe { #ret }, })
+                Some(quote! { unsafe { ::std::convert::Into::into(#ret) }, })
             }
             FnType::FnModule(span) => {
                 let py = syn::Ident::new("py", Span::call_site());
                 let slf: Ident = syn::Ident::new("_slf", Span::call_site());
                 let pyo3_path = pyo3_path.to_tokens_spanned(*span);
                 let ret = quote_spanned! { *span =>
-                    #[allow(clippy::useless_conversion)]
-                    ::std::convert::Into::into(
-                        #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(#py, &*(&#slf as *const _ as *const *mut _))
-                            .downcast_unchecked::<#pyo3_path::types::PyModule>()
-                    )
+                    #pyo3_path::impl_::pymethods::BoundRef::ref_from_ptr(#py, &*(&#slf as *const _ as *const *mut _))
+                        .downcast_unchecked::<#pyo3_path::types::PyModule>()
                 };
-                Some(quote! { unsafe { #ret }, })
+                Some(quote! { unsafe { ::std::convert::Into::into(#ret) }, })
             }
             FnType::FnNew | FnType::FnStatic | FnType::ClassAttribute => None,
         }

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -15,11 +15,13 @@ pub(crate) fn ok_wrap(obj: TokenStream, ctx: &Ctx) -> TokenStream {
         output_span,
     } = ctx;
     let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
-    quote_spanned! { *output_span => {
+    let converter = quote_spanned! { *output_span => {
         let obj = #obj;
-        #[allow(clippy::useless_conversion)]
-        #pyo3_path::impl_::wrap::converter(&obj).wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
-    }}
+        #pyo3_path::impl_::wrap::converter(&obj).wrap(obj)
+    }};
+    quote! {
+        #converter.map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
+    }
 }
 
 pub(crate) fn map_result_into_ptr(result: TokenStream, ctx: &Ctx) -> TokenStream {


### PR DESCRIPTION
Using `#[allow(clippy::useless_conversion)]` still causes failures if the PyO3 user uses `#[forbid(clippy::useless_conversion)]`. Instead we can ensure the `into` call is not within a `quote_spanned!` block, allowing clippy to know this is macro code.

https://github.com/rust-lang/rust-clippy/issues/14272#issuecomment-2686661392

I tried adding a UI test for this, but I couldn't get it to fail (before implementing the fix). I can confirm that this patch resolves the error in my project.