### PR TITLE
Reduce runtime of slow test

### DIFF
--- a/src/types/mappingproxy.rs
+++ b/src/types/mappingproxy.rs
@@ -539,7 +539,7 @@ mod tests {
     #[test]
     fn iter_mappingproxy_nosegv() {
         Python::with_gil(|py| {
-            const LEN: usize = 10_000_000;
+            const LEN: usize = 1_000;
             let items = (0..LEN as u64).map(|i| (i, i * 2));
 
             let dict = items.clone().into_py_dict(py).unwrap();
@@ -551,7 +551,7 @@ mod tests {
                 let i: u64 = k.extract().unwrap();
                 sum += i;
             }
-            assert_eq!(sum, 49_999_995_000_000);
+            assert_eq!(sum, 499_500);
         })
     }
 }


### PR DESCRIPTION
On my main development machine - an M3 Macbook Pro - this test currently takes ~2 seconds, introducing a noticeable pause running `cargo test --lib`:

```
cargo test --lib "types::mappingproxy::tests::iter_mappingproxy_nosegv" -- -Zunstable-options --report-time
   Compiling pyo3 v0.23.5 (/Users/goldbaum/Documents/pyo3)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.39s
     Running unittests src/lib.rs (target/debug/deps/pyo3-246e609de32070b5)

running 1 test
test types::mappingproxy::tests::iter_mappingproxy_nosegv ... ok <2.079s>

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 717 filtered out; finished in 2.08s
```

After this PR, it drops down to 35 milliseconds:

```
running 1 test
test types::mappingproxy::tests::iter_mappingproxy_nosegv ... ok <0.035s>

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 717 filtered out; finished in 0.04s
```

The slowdown is much worse when I'm testing some thread safety-related changes under TSAN.

I don't *think* there's any particular reason this loop needs so many iterations but please let me know if you chose the parameters for this test for a reason I'm missing @KLMatlock!