### PR TITLE
Avoid data races in BorrowFlag

### DIFF
--- a/newsfragments/4948.fixed.md
+++ b/newsfragments/4948.fixed.md
@@ -1,0 +1,1 @@
+* Fixed a thread safety issue in the runtime borrow checker used by mutable pyclass instances on the free-threaded build.


### PR DESCRIPTION
Fixes #4904 (specifically the race I found [here](https://github.com/PyO3/pyo3/issues/4904#issuecomment-2675087546), the others have been reported upstream).

I haven't been able to see any observable impact of the data races that TSAN finds. That said, with these changes I no longer see race reports from ThreadSanitizer. Note that you need to use Python 3.14 to be able to use thread sanitizer usefully without creating a ton of suppressions, free-threaded CPython 3.13 has a number of races with fixes in 3.14 that probably won't be backported.

As soon as we can add 3.14 in CI I'll look at setting up free-threaded TSAN CI using the [cpython_sanity](https://github.com/nascheme/cpython_sanity) docker image @nascheme has been working on.

I added some comments to explain the choices I made. I'm no expert in C++ atomics though so I'd appreciate some more careful eyes on this code.

I tested this by running this command in the 3.14t docker container after cloning pyo3, checking out the PR branch from #4811  and installing rustup to install a nightly toolchain and the `rust-src` component:

```
TSAN_OPTIONS="suppressions=$PWD/suppressions.txt:halt_on_error=1" LD_LIBRARY_PATH="$(pyenv prefix)/lib" LDFLAGS="-L$(pyenv prefix)/lib" RUSTFLAGS="-Zsanitizer=thread" cargo test --lib --test test_gc -Zbuild-std --target x86_64-unknown-linux-gnuTSAN_OPTIONS="suppressions=$PWD/suppressions.txt:halt_on_error=1" LD_LIBRARY_PATH="$(pyenv prefix)/lib" LDFLAGS="-L$(pyenv prefix)/lib" RUSTFLAGS="-Zsanitizer=thread" cargo test --lib --test test_gc -Zbuild-std --target x86_64-unknown-linux-gnu
```

I created a suppressions file for a race in CPython that's been reported upstream:

```
root@6221150df46c:/work/pyo3# cat suppressions.txt 
race:long_from_non_binary_base
```

Ping @davidhewitt.