### PR TITLE
Allow parsing exotic python version

### DIFF
--- a/newsfragments/4949.fixed.md
+++ b/newsfragments/4949.fixed.md
@@ -1,0 +1,1 @@
+Allow parsing exotic python version

--- a/src/version.rs
+++ b/src/version.rs
@@ -44,9 +44,6 @@ impl<'a> PythonVersionInfo<'a> {
         let major_str = parts.next().ok_or("Python major version missing")?;
         let minor_str = parts.next().ok_or("Python minor version missing")?;
         let patch_str = parts.next();
-        if parts.next().is_some() {
-            return Err("Python version string has too many parts");
-        };
 
         let major = major_str
             .parse()
@@ -139,5 +136,6 @@ mod test {
         assert!(PythonVersionInfo::from_str("3.5+").unwrap() == (3, 5));
         assert!(PythonVersionInfo::from_str("3.5.2a1+").unwrap() < (3, 6));
         assert!(PythonVersionInfo::from_str("3.5.2a1+").unwrap() > (3, 4));
+        assert!(PythonVersionInfo::from_str("3.11.3+chromium.29").unwrap() >= (3, 11, 3));
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -40,7 +40,7 @@ impl<'a> PythonVersionInfo<'a> {
             }
         }
 
-        let mut parts = version_number_str.split('.');
+        let mut parts = version_number_str.splitn(3, '.');
         let major_str = parts.next().ok_or("Python major version missing")?;
         let minor_str = parts.next().ok_or("Python minor version missing")?;
         let patch_str = parts.next();
@@ -137,5 +137,11 @@ mod test {
         assert!(PythonVersionInfo::from_str("3.5.2a1+").unwrap() < (3, 6));
         assert!(PythonVersionInfo::from_str("3.5.2a1+").unwrap() > (3, 4));
         assert!(PythonVersionInfo::from_str("3.11.3+chromium.29").unwrap() >= (3, 11, 3));
+        assert_eq!(
+            PythonVersionInfo::from_str("3.11.3+chromium.29")
+                .unwrap()
+                .suffix,
+            Some("+chromium.29")
+        );
     }
 }


### PR DESCRIPTION
On specific linux disto, the python version output can be exotic.

For example, in my machine I got the following:
```
❯ python --version
Python 3.11.3+chromium.29
```

Which can lead to not desired end of program:

```
from cryptography.hazmat.bindings._rust import openssl as rust_openssl
pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: "Python version string has too many parts"
```