### PR TITLE
bump `inventory` minimum version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
 # support crate for multiple-pymethods feature
-inventory = { version = "0.3.0", optional = true }
+inventory = { version = "0.3.5", optional = true }
 
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0.1", optional = true }

--- a/newsfragments/4954.packaging.md
+++ b/newsfragments/4954.packaging.md
@@ -1,0 +1,1 @@
+bump minimum supported `inventory` version to 0.3.5


### PR DESCRIPTION
Bump the minimum inventory version, see https://github.com/PyO3/pyo3/issues/4950#issuecomment-2692272807

Closes #4950 
