### PR TITLE
release: 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,55 @@ To see unreleased changes, please see the [CHANGELOG on the main branch guide](h
 
 <!-- towncrier release notes start -->
 
+## [0.24.0] - 2025-03-09
+
+### Packaging
+
+- Add supported CPython/PyPy versions to cargo package metadata. [#4756](https://github.com/PyO3/pyo3/pull/4756)
+- Bump `target-lexicon` dependency to 0.13. [#4822](https://github.com/PyO3/pyo3/pull/4822)
+- Add optional `jiff` dependency to add conversions for `jiff` datetime types. [#4823](https://github.com/PyO3/pyo3/pull/4823)
+- Bump minimum supported `inventory` version to 0.3.5. [#4954](https://github.com/PyO3/pyo3/pull/4954)
+
+### Added
+
+- Add `PyIterator::send` method to allow sending values into a python generator. [#4746](https://github.com/PyO3/pyo3/pull/4746)
+- Add `PyCallArgs` trait for passing arguments into the Python calling protocol. This enabled using a faster calling convention for certain types, improving performance. [#4768](https://github.com/PyO3/pyo3/pull/4768)
+- Add `#[pyo3(default = ...']` option for `#[derive(FromPyObject)]` to set a default value for extracted fields of named structs. [#4829](https://github.com/PyO3/pyo3/pull/4829)
+- Add `#[pyo3(into_py_with = ...)]` option for `#[derive(IntoPyObject, IntoPyObjectRef)]`. [#4850](https://github.com/PyO3/pyo3/pull/4850)
+- Add uuid to/from python conversions. [#4864](https://github.com/PyO3/pyo3/pull/4864)
+- Add FFI definitions `PyThreadState_GetFrame` and `PyFrame_GetBack`. [#4866](https://github.com/PyO3/pyo3/pull/4866)
+- Optimize `last` for `BoundListIterator`, `BoundTupleIterator` and `BorrowedTupleIterator`. [#4878](https://github.com/PyO3/pyo3/pull/4878)
+- Optimize `Iterator::count()` for `PyDict`, `PyList`, `PyTuple` & `PySet`. [#4878](https://github.com/PyO3/pyo3/pull/4878)
+- Optimize `nth`, `nth_back`, `advance_by` and `advance_back_by` for `BoundTupleIterator` [#4897](https://github.com/PyO3/pyo3/pull/4897)
+- Add support for `types.GenericAlias` as `pyo3::types::PyGenericAlias`. [#4917](https://github.com/PyO3/pyo3/pull/4917)
+- Add `MutextExt` trait to help avoid deadlocks with the GIL while locking a `std::sync::Mutex`. [#4934](https://github.com/PyO3/pyo3/pull/4934)
+- Add `#[pyo3(rename_all = "...")]` option for `#[derive(FromPyObject)]`. [#4941](https://github.com/PyO3/pyo3/pull/4941)
+
+### Changed
+
+- Optimize `nth`, `nth_back`, `advance_by` and `advance_back_by` for `BoundListIterator`. [#4810](https://github.com/PyO3/pyo3/pull/4810)
+- Use `DerefToPyAny` in blanket implementations of `From<Py<T>>` and `From<Bound<'py, T>>` for `PyObject`. [#4593](https://github.com/PyO3/pyo3/pull/4593)
+- Map `io::ErrorKind::IsADirectory`/`NotADirectory` to the corresponding Python exception on Rust 1.83+. [#4747](https://github.com/PyO3/pyo3/pull/4747)
+- `PyAnyMethods::call` and friends now require `PyCallArgs` for their positional arguments. [#4768](https://github.com/PyO3/pyo3/pull/4768)
+- Expose FFI definitions for `PyObject_Vectorcall(Method)` on the stable abi on 3.12+. [#4853](https://github.com/PyO3/pyo3/pull/4853)
+- `#[pyo3(from_py_with = ...)]` now take a path rather than a string literal [#4860](https://github.com/PyO3/pyo3/pull/4860)
+- Format Python traceback in impl Debug for PyErr. [#4900](https://github.com/PyO3/pyo3/pull/4900)
+- Convert `PathBuf` & `Path` into Python `pathlib.Path` instead of `PyString`. [#4925](https://github.com/PyO3/pyo3/pull/4925)
+- Relax parsing of exotic Python versions. [#4949](https://github.com/PyO3/pyo3/pull/4949)
+- PyO3 threads now hang instead of `pthread_exit` trying to acquire the GIL when the interpreter is shutting down. This mimics the [Python 3.14](https://github.com/python/cpython/issues/87135) behavior and avoids undefined behavior and crashes. [#4874](https://github.com/PyO3/pyo3/pull/4874)
+
+### Removed
+
+- Remove implementations of `Deref` for `PyAny` and other "native" types. [#4593](https://github.com/PyO3/pyo3/pull/4593)
+- Remove implicit default of trailing optional arguments (see #2935) [#4729](https://github.com/PyO3/pyo3/pull/4729)
+- Remove the deprecated implicit eq fallback for simple enums. [#4730](https://github.com/PyO3/pyo3/pull/4730)
+
+### Fixed
+
+- Correct FFI definition of `PyIter_Send` to return a `PySendResult`. [#4746](https://github.com/PyO3/pyo3/pull/4746)
+- Fix a thread safety issue in the runtime borrow checker used by mutable pyclass instances on the free-threaded build. [#4948](https://github.com/PyO3/pyo3/pull/4948)
+
+
 ## [0.23.5] - 2025-02-22
 ### Packaging
 
@@ -2064,7 +2113,8 @@ Yanked
 
 - Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.23.5...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/pyo3/pyo3/compare/v0.23.5...v0.24.0
 [0.23.5]: https://github.com/pyo3/pyo3/compare/v0.23.4...v0.23.5
 [0.23.4]: https://github.com/pyo3/pyo3/compare/v0.23.3...v0.23.4
 [0.23.3]: https://github.com/pyo3/pyo3/compare/v0.23.2...v0.23.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.0"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -21,10 +21,10 @@ memoffset = "0.9"
 once_cell = "1.13"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.23.5" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.24.0" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.23.5", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.24.0", optional = true }
 indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
@@ -68,7 +68,7 @@ static_assertions = "1.1.0"
 uuid = { version = "1.10.0", features = ["v4"] }
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "=0.23.5", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "=0.24.0", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.23.5", features = ["extension-module"] }
+pyo3 = { version = "0.24.0", features = ["extension-module"] }
 ```
 
 **`src/lib.rs`**
@@ -140,7 +140,7 @@ Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like th
 
 ```toml
 [dependencies.pyo3]
-version = "0.23.5"
+version = "0.24.0"
 features = ["auto-initialize"]
 ```
 

--- a/examples/decorator/.template/pre-script.rhai
+++ b/examples/decorator/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.5");
+variable::set("PYO3_VERSION", "0.24.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/maturin-starter/.template/pre-script.rhai
+++ b/examples/maturin-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.5");
+variable::set("PYO3_VERSION", "0.24.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/plugin/.template/pre-script.rhai
+++ b/examples/plugin/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.5");
+variable::set("PYO3_VERSION", "0.24.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/plugin_api/Cargo.toml", "plugin_api/Cargo.toml");
 file::delete(".template");

--- a/examples/setuptools-rust-starter/.template/pre-script.rhai
+++ b/examples/setuptools-rust-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.5");
+variable::set("PYO3_VERSION", "0.24.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/setup.cfg", "setup.cfg");
 file::delete(".template");

--- a/examples/word-count/.template/pre-script.rhai
+++ b/examples/word-count/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.23.5");
+variable::set("PYO3_VERSION", "0.24.0");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/newsfragments/4593.changed.md
+++ b/newsfragments/4593.changed.md
@@ -1,1 +1,0 @@
-Use `DerefToPyAny` in blanket implementations of `From<Py<T>>` and `From<Bound<'py, T>>` for `PyObject`.

--- a/newsfragments/4593.removed.md
+++ b/newsfragments/4593.removed.md
@@ -1,1 +1,0 @@
-Remove implementations of `Deref` for `PyAny` and other "native" types.

--- a/newsfragments/4729.removed.md
+++ b/newsfragments/4729.removed.md
@@ -1,1 +1,0 @@
-removes implicit default of trailing optional arguments (see #2935)

--- a/newsfragments/4730.removed.md
+++ b/newsfragments/4730.removed.md
@@ -1,1 +1,0 @@
-Removed the deprecated implicit eq fallback for simple enums.

--- a/newsfragments/4746.added.md
+++ b/newsfragments/4746.added.md
@@ -1,1 +1,0 @@
-Added `PyIterator::send` method to allow sending values into a python generator.

--- a/newsfragments/4746.fixed.md
+++ b/newsfragments/4746.fixed.md
@@ -1,1 +1,0 @@
-Fixed the return value of pyo3-ffi's PyIter_Send() function to return PySendResult.

--- a/newsfragments/4747.changed.md
+++ b/newsfragments/4747.changed.md
@@ -1,1 +1,0 @@
-Map `io::ErrorKind::IsADirectory`/`NotADirectory` to the corresponding Python exception on Rust 1.83+

--- a/newsfragments/4756.packaging.md
+++ b/newsfragments/4756.packaging.md
@@ -1,1 +1,0 @@
-Add supported CPython/PyPy versions to cargo package metadata.

--- a/newsfragments/4768.added.md
+++ b/newsfragments/4768.added.md
@@ -1,1 +1,0 @@
-Added `PyCallArgs` trait for arguments into the Python calling protocol. This enabled using a faster calling convention for certain types, improving performance.

--- a/newsfragments/4768.changed.md
+++ b/newsfragments/4768.changed.md
@@ -1,1 +1,0 @@
-`PyAnyMethods::call` an friends now require `PyCallArgs` for their positional arguments.

--- a/newsfragments/4810.added.md
+++ b/newsfragments/4810.added.md
@@ -1,1 +1,0 @@
-Optimizes `nth`, `nth_back`, `advance_by` and `advance_back_by` for `BoundListIterator`

--- a/newsfragments/4822.changed.md
+++ b/newsfragments/4822.changed.md
@@ -1,1 +1,0 @@
-Bumped `target-lexicon` dependency to 0.13

--- a/newsfragments/4823.added.md
+++ b/newsfragments/4823.added.md
@@ -1,1 +1,0 @@
-Add jiff to/from python conversions.

--- a/newsfragments/4829.added.md
+++ b/newsfragments/4829.added.md
@@ -1,1 +1,0 @@
-`derive(FromPyObject)` allow a `default` attribute to set a default value for extracted fields of named structs. The default value is either provided explicitly or fetched via `Default::default()`.

--- a/newsfragments/4850.added.md
+++ b/newsfragments/4850.added.md
@@ -1,1 +1,0 @@
-introduce `into_py_with`/`into_py_with_ref` for `#[derive(IntoPyObject, IntoPyObjectRef)]`

--- a/newsfragments/4853.added.md
+++ b/newsfragments/4853.added.md
@@ -1,1 +1,0 @@
-pyo3-ffi: expose `PyObject_Vectorcall(Method)` on the stable abi on 3.12+

--- a/newsfragments/4860.changed.md
+++ b/newsfragments/4860.changed.md
@@ -1,1 +1,0 @@
-`#[pyo3(from_py_with = ...)]` now take a path rather than a string literal

--- a/newsfragments/4864.added.md
+++ b/newsfragments/4864.added.md
@@ -1,1 +1,0 @@
-Add uuid to/from python conversions.

--- a/newsfragments/4866.added.md
+++ b/newsfragments/4866.added.md
@@ -1,1 +1,0 @@
-Exposing PyThreadState_GetFrame and PyFrame_GetBack.

--- a/newsfragments/4874.changed.md
+++ b/newsfragments/4874.changed.md
@@ -1,1 +1,0 @@
- * PyO3 threads now hang instead of `pthread_exit` trying to acquire the GIL when the interpreter is shutting down. This mimics the [Python 3.14](https://github.com/python/cpython/issues/87135) behavior and avoids undefined behavior and crashes.

--- a/newsfragments/4878.added.md
+++ b/newsfragments/4878.added.md
@@ -1,2 +1,0 @@
-- Optimizes `last` for `BoundListIterator`, `BoundTupleIterator` and `BorrowedTupleIterator`
-- Optimizes `Iterator::count()` for `PyDict`, `PyList`, `PyTuple` & `PySet`

--- a/newsfragments/4897.added.md
+++ b/newsfragments/4897.added.md
@@ -1,1 +1,0 @@
-Optimizes `nth`, `nth_back`, `advance_by` and `advance_back_by` for `BoundTupleIterator`

--- a/newsfragments/4900.changed.md
+++ b/newsfragments/4900.changed.md
@@ -1,1 +1,0 @@
-Format python traceback in impl Debug for PyErr.

--- a/newsfragments/4917.added.md
+++ b/newsfragments/4917.added.md
@@ -1,2 +1,0 @@
-Added support for creating [types.GenericAlias](https://docs.python.org/3/library/types.html#types.GenericAlias)
-objects in PyO3 with `pyo3::types::PyGenericAlias`.

--- a/newsfragments/4925.changed.md
+++ b/newsfragments/4925.changed.md
@@ -1,1 +1,0 @@
-Convert `PathBuf` & `Path` into python `pathlib.Path` instead of `PyString`

--- a/newsfragments/4934.added.md
+++ b/newsfragments/4934.added.md
@@ -1,1 +1,0 @@
-* Added `MutextExt`, an extension trait to avoid deadlocks with the GIL while locking a `std::sync::Mutex`.

--- a/newsfragments/4941.added.md
+++ b/newsfragments/4941.added.md
@@ -1,1 +1,0 @@
-add `#[pyo3(rename_all = "...")]` for `#[derive(FromPyObject)]`

--- a/newsfragments/4948.fixed.md
+++ b/newsfragments/4948.fixed.md
@@ -1,1 +1,0 @@
-* Fixed a thread safety issue in the runtime borrow checker used by mutable pyclass instances on the free-threaded build.

--- a/newsfragments/4949.fixed.md
+++ b/newsfragments/4949.fixed.md
@@ -1,1 +1,0 @@
-Allow parsing exotic python version

--- a/newsfragments/4954.packaging.md
+++ b/newsfragments/4954.packaging.md
@@ -1,1 +1,0 @@
-bump minimum supported `inventory` version to 0.3.5

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.0"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.24.0"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -42,7 +42,7 @@ generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 paste = "1"
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.5", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.0", features = ["resolve-config"] }
 
 [lints]
 workspace = true

--- a/pyo3-ffi/README.md
+++ b/pyo3-ffi/README.md
@@ -41,13 +41,13 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3-ffi]
-version = "0.23.5"
+version = "0.24.0"
 features = ["extension-module"]
 
 [build-dependencies]
 # This is only necessary if you need to configure your build based on
 # the Python version or the compile-time configuration for the interpreter.
-pyo3_build_config = "0.23.5"
+pyo3_build_config = "0.24.0"
 ```
 
 If you need to use conditional compilation based on Python version or how

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.0"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -17,7 +17,7 @@ rust-version = "1.63"
 [dependencies]
 heck = "0.5"
 proc-macro2 = { version = "1.0.60", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.5", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.0", features = ["resolve-config"] }
 quote = { version = "1", default-features = false }
 
 [dependencies.syn]
@@ -26,7 +26,7 @@ default-features = false
 features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits"]
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.23.5" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.0" }
 
 [lints]
 workspace = true

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.0"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -22,7 +22,7 @@ experimental-async = ["pyo3-macros-backend/experimental-async"]
 proc-macro2 = { version = "1.0.60", default-features = false }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.23.5" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.24.0" }
 
 [lints]
 workspace = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "0.23.5"
+version = "0.24.0"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"

--- a/tests/ui/reject_generics.stderr
+++ b/tests/ui/reject_generics.stderr
@@ -1,10 +1,10 @@
-error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.23.5/class.html#no-generic-parameters
+error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.24.0/class.html#no-generic-parameters
  --> tests/ui/reject_generics.rs:4:25
   |
 4 | struct ClassWithGenerics<A> {
   |                         ^
 
-error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.23.5/class.html#no-lifetime-parameters
+error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.24.0/class.html#no-lifetime-parameters
  --> tests/ui/reject_generics.rs:9:27
   |
 9 | struct ClassWithLifetimes<'a> {


### PR DESCRIPTION
I think it's time we shipped a release.

Thank you to @Icxolu, @ngoldbaum and @bschoenmaeckers in particular, who have done a huge amount of the work and support in heading towards this release while I've been busy. I'm hopeful that I can be much more active in the coming months so we can make further progress on some of the things we know we want to improve in the releases to follow 0.24.

I'd like to ship ASAP; I think there's just a couple of PRs I would like to get merged before this is finalised and I prepare the CHANGELOG:
- #4593 was marked for 0.24 and I think is a small, straightforward clean up.
- #4746 is ready to merge but failed in the FFI checks; I want to investigate and ideally fix & merge before releasing.

Please ping if there's anything else you think must be included in the release. Once those PRs are in, I will do a final rebase & prep here and leave just a couple days for cooling off.