### PR TITLE
ignore `PyConfig` struct in `ffi-check` on 3.13 for now

### DIFF
--- a/pyo3-ffi-check/macro/src/lib.rs
+++ b/pyo3-ffi-check/macro/src/lib.rs
@@ -49,6 +49,14 @@ pub fn for_all_structs(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
             .unwrap()
             .strip_suffix(".html")
             .unwrap();
+
+        if struct_name == "PyConfig" && pyo3_build_config::get().version == PY_3_13 {
+            // https://github.com/python/cpython/issues/130940
+            // PyConfig has an ABI break on Python 3.13.1 -> 3.13.2, waiting for advice
+            // how to proceed in PyO3.
+            continue;
+        }
+
         let struct_ident = Ident::new(struct_name, Span::call_site());
         output.extend(quote!(#macro_name!(#struct_ident);));
     }


### PR DESCRIPTION
This will unblock CI while waiting for a decision in https://github.com/python/cpython/issues/130940 about whether PyO3 should switch to use 3.13.2's ABI, or CPython will revert.