### PR TITLE
docs: ignore 404 errors from https://pyo3.rs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build the guide
         run: |
           python -m pip install --upgrade pip && pip install nox
-          nox -s check-guide
+          nox -s check-guide -- --exclude https://pyo3.rs
         env:
           PYO3_VERSION_TAG: ${{ steps.prepare_tag.outputs.tag_name }}
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build the guide
         run: |
           python -m pip install --upgrade pip && pip install nox
-          nox -s check-guide -- --exclude https://pyo3.rs
+          nox -s ${{ github.event_name == 'release' && 'build-guide' || 'check-guide' }}
         env:
           PYO3_VERSION_TAG: ${{ steps.prepare_tag.outputs.tag_name }}
 


### PR DESCRIPTION
Fixes #4964 

I don't know whether this makes sense to keep here permanently, but this should allow `nox -s check-guide` to pass in the failing docs build for 0.24.0: https://github.com/PyO3/pyo3/actions/runs/13753506986/job/38457433823#step:7:228