### PR TITLE
fix native types not implementing `is_type_of` correctly

### DIFF
--- a/newsfragments/4981.fixed.md
+++ b/newsfragments/4981.fixed.md
@@ -1,0 +1,1 @@
+Fix `is_type_of` for native types not using same specialized check as `is_type_of_bound`.

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -152,7 +152,7 @@ macro_rules! pyobject_native_type_info(
 
             $(
                 #[inline]
-                fn is_type_of_bound(obj: &$crate::Bound<'_, $crate::PyAny>) -> bool {
+                fn is_type_of(obj: &$crate::Bound<'_, $crate::PyAny>) -> bool {
                     #[allow(unused_unsafe)]
                     unsafe { $checkfunction(obj.as_ptr()) > 0 }
                 }


### PR DESCRIPTION
I noticed this while having a look at removing all the `_bound` methods from the code (as a first step towards 0.25).

This seems like a bugfix worth landing on the 0.24 series, so I split it out.