### PR TITLE
remove all functionality deprecated in PyO3 0.23 (except `IntoPy` and `ToPyObject`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.24.0"
+version = "0.25.0-dev"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -21,10 +21,10 @@ memoffset = "0.9"
 once_cell = "1.13"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.24.0" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.25.0-dev" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.24.0", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.25.0-dev", optional = true }
 indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
@@ -68,7 +68,7 @@ static_assertions = "1.1.0"
 uuid = { version = "1.10.0", features = ["v4"] }
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "=0.24.0", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "=0.25.0-dev", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -179,7 +179,7 @@ With the removal of the old API, many "Bound" API functions which had been intro
 
 Before:
 
-```rust
+```rust,ignore
 # #![allow(deprecated)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyTuple;

--- a/guide/src/python-from-rust.md
+++ b/guide/src/python-from-rust.md
@@ -17,7 +17,7 @@ are met. Its lifetime `'py` is a central part of PyO3's API.
 
 The `Python<'py>` token serves three purposes:
 
-* It provides global APIs for the Python interpreter, such as [`py.eval_bound()`][eval] and [`py.import_bound()`][import].
+* It provides global APIs for the Python interpreter, such as [`py.eval()`][eval] and [`py.import()`][import].
 * It can be passed to functions that require a proof of holding the GIL, such as [`Py::clone_ref`][clone_ref].
 * Its lifetime `'py` is used to bind many of PyO3's types to the Python interpreter, such as [`Bound<'py, T>`][Bound].
 
@@ -45,6 +45,6 @@ Because of the lack of exclusive `&mut` references, PyO3's APIs for Python objec
 [obtaining-py]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#obtaining-a-python-token
 [`pyo3::sync`]: {{#PYO3_DOCS_URL}}/pyo3/sync/index.html
 [eval]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.eval
-[import]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.import_bound
+[import]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.import
 [clone_ref]: {{#PYO3_DOCS_URL}}/pyo3/prelude/struct.Py.html#method.clone_ref
 [Bound]: {{#PYO3_DOCS_URL}}/pyo3/struct.Bound.html

--- a/newsfragments/4982.removed.md
+++ b/newsfragments/4982.removed.md
@@ -1,0 +1,1 @@
+Remove all functionality deprecated in PyO3 0.23.

--- a/pyo3-benches/benches/bench_list.rs
+++ b/pyo3-benches/benches/bench_list.rs
@@ -42,7 +42,7 @@ fn list_get_item(b: &mut Bencher<'_>) {
 fn list_nth(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50;
-        let list = PyList::new(py, 0..LEN);
+        let list = PyList::new(py, 0..LEN).unwrap();
         let mut sum = 0;
         b.iter(|| {
             for i in 0..LEN {
@@ -55,7 +55,7 @@ fn list_nth(b: &mut Bencher<'_>) {
 fn list_nth_back(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50;
-        let list = PyList::new(py, 0..LEN);
+        let list = PyList::new(py, 0..LEN).unwrap();
         let mut sum = 0;
         b.iter(|| {
             for i in 0..LEN {

--- a/pyo3-benches/benches/bench_list.rs
+++ b/pyo3-benches/benches/bench_list.rs
@@ -42,7 +42,7 @@ fn list_get_item(b: &mut Bencher<'_>) {
 fn list_nth(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50;
-        let list = PyList::new_bound(py, 0..LEN);
+        let list = PyList::new(py, 0..LEN);
         let mut sum = 0;
         b.iter(|| {
             for i in 0..LEN {
@@ -55,7 +55,7 @@ fn list_nth(b: &mut Bencher<'_>) {
 fn list_nth_back(b: &mut Bencher<'_>) {
     Python::with_gil(|py| {
         const LEN: usize = 50;
-        let list = PyList::new_bound(py, 0..LEN);
+        let list = PyList::new(py, 0..LEN);
         let mut sum = 0;
         b.iter(|| {
             for i in 0..LEN {

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.24.0"
+version = "0.25.0-dev"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.24.0"
+version = "0.25.0-dev"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -43,7 +43,7 @@ generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 paste = "1"
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.0", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.25.0-dev", features = ["resolve-config"] }
 
 [lints]
 workspace = true

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.24.0"
+version = "0.25.0-dev"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -17,7 +17,7 @@ rust-version = "1.63"
 [dependencies]
 heck = "0.5"
 proc-macro2 = { version = "1.0.60", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.0", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.25.0-dev", features = ["resolve-config"] }
 quote = { version = "1", default-features = false }
 
 [dependencies.syn]
@@ -26,7 +26,7 @@ default-features = false
 features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits"]
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.0" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.25.0-dev" }
 
 [lints]
 workspace = true

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.24.0"
+version = "0.25.0-dev"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -22,7 +22,7 @@ experimental-async = ["pyo3-macros-backend/experimental-async"]
 proc-macro2 = { version = "1.0.60", default-features = false }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.24.0" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.25.0-dev" }
 
 [lints]
 workspace = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "0.24.0"
+version = "0.25.0-dev"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -224,13 +224,6 @@ impl<T: Element> PyBuffer<T> {
         }
     }
 
-    /// Deprecated name for [`PyBuffer::get`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyBuffer::get`")]
-    #[inline]
-    pub fn get_bound(obj: &Bound<'_, PyAny>) -> PyResult<PyBuffer<T>> {
-        Self::get(obj)
-    }
-
     /// Gets the pointer to the start of the buffer memory.
     ///
     /// Warning: the buffer memory might be mutated by other Python functions,

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -14,7 +14,7 @@ use crate::{Borrowed, BoundObject, Py, PyAny, PyObject, Python};
 #[allow(deprecated)]
 use crate::{IntoPy, ToPyObject};
 use std::borrow::Cow;
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 
 mod err_state;
 mod impls;
@@ -29,8 +29,8 @@ use std::convert::Infallible;
 /// compatibility with `?` and other Rust errors) this type supports creating exceptions instances
 /// in a lazy fashion, where the full Python object for the exception is created only when needed.
 ///
-/// Accessing the contained exception in any way, such as with [`value_bound`](PyErr::value_bound),
-/// [`get_type_bound`](PyErr::get_type_bound), or [`is_instance_bound`](PyErr::is_instance_bound)
+/// Accessing the contained exception in any way, such as with [`value`](PyErr::value),
+/// [`get_type`](PyErr::get_type), or [`is_instance`](PyErr::is_instance)
 /// will create the full exception object if it was not already created.
 pub struct PyErr {
     state: PyErrState,
@@ -126,7 +126,7 @@ impl PyErr {
     ///
     /// This exception instance will be initialized lazily. This avoids the need for the Python GIL
     /// to be held, but requires `args` to be `Send` and `Sync`. If `args` is not `Send` or `Sync`,
-    /// consider using [`PyErr::from_value_bound`] instead.
+    /// consider using [`PyErr::from_value`] instead.
     ///
     /// If `T` does not inherit from `BaseException`, then a `TypeError` will be returned.
     ///
@@ -198,16 +198,6 @@ impl PyErr {
         PyErr::from_state(PyErrState::lazy_arguments(ty.unbind().into_any(), args))
     }
 
-    /// Deprecated name for [`PyErr::from_type`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::from_type`")]
-    #[inline]
-    pub fn from_type_bound<A>(ty: Bound<'_, PyType>, args: A) -> PyErr
-    where
-        A: PyErrArguments + Send + Sync + 'static,
-    {
-        Self::from_type(ty, args)
-    }
-
     /// Creates a new PyErr.
     ///
     /// If `obj` is a Python exception object, the PyErr will contain that object.
@@ -256,13 +246,6 @@ impl PyErr {
         PyErr::from_state(state)
     }
 
-    /// Deprecated name for [`PyErr::from_value`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::from_value`")]
-    #[inline]
-    pub fn from_value_bound(obj: Bound<'_, PyAny>) -> PyErr {
-        Self::from_value(obj)
-    }
-
     /// Returns the type of this exception.
     ///
     /// # Examples
@@ -276,13 +259,6 @@ impl PyErr {
     /// ```
     pub fn get_type<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
         self.normalized(py).ptype(py)
-    }
-
-    /// Deprecated name for [`PyErr::get_type`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::get_type`")]
-    #[inline]
-    pub fn get_type_bound<'py>(&self, py: Python<'py>) -> Bound<'py, PyType> {
-        self.get_type(py)
     }
 
     /// Returns the value of this exception.
@@ -300,13 +276,6 @@ impl PyErr {
     /// ```
     pub fn value<'py>(&self, py: Python<'py>) -> &Bound<'py, PyBaseException> {
         self.normalized(py).pvalue.bind(py)
-    }
-
-    /// Deprecated name for [`PyErr::value`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::value`")]
-    #[inline]
-    pub fn value_bound<'py>(&self, py: Python<'py>) -> &Bound<'py, PyBaseException> {
-        self.value(py)
     }
 
     /// Consumes self to take ownership of the exception value contained in this error.
@@ -337,13 +306,6 @@ impl PyErr {
     /// ```
     pub fn traceback<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTraceback>> {
         self.normalized(py).ptraceback(py)
-    }
-
-    /// Deprecated name for [`PyErr::traceback`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::traceback`")]
-    #[inline]
-    pub fn traceback_bound<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTraceback>> {
-        self.traceback(py)
     }
 
     /// Gets whether an error is present in the Python interpreter's global state.
@@ -449,29 +411,6 @@ impl PyErr {
         unsafe { Py::from_owned_ptr_or_err(py, ptr) }
     }
 
-    /// Deprecated name for [`PyErr::new_type`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::new_type`")]
-    #[inline]
-    pub fn new_type_bound<'py>(
-        py: Python<'py>,
-        name: &str,
-        doc: Option<&str>,
-        base: Option<&Bound<'py, PyType>>,
-        dict: Option<PyObject>,
-    ) -> PyResult<Py<PyType>> {
-        let null_terminated_name =
-            CString::new(name).expect("Failed to initialize nul terminated exception name");
-        let null_terminated_doc =
-            doc.map(|d| CString::new(d).expect("Failed to initialize nul terminated docstring"));
-        Self::new_type(
-            py,
-            &null_terminated_name,
-            null_terminated_doc.as_deref(),
-            base,
-            dict,
-        )
-    }
-
     /// Prints a standard traceback to `sys.stderr`.
     pub fn display(&self, py: Python<'_>) {
         #[cfg(Py_3_12)]
@@ -529,13 +468,6 @@ impl PyErr {
         (unsafe { ffi::PyErr_GivenExceptionMatches(type_bound.as_ptr(), ty.as_ptr()) }) != 0
     }
 
-    /// Deprecated name for [`PyErr::is_instance`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::is_instance`")]
-    #[inline]
-    pub fn is_instance_bound(&self, py: Python<'_>, ty: &Bound<'_, PyAny>) -> bool {
-        self.is_instance(py, ty)
-    }
-
     /// Returns true if the current exception is instance of `T`.
     #[inline]
     pub fn is_instance_of<T>(&self, py: Python<'_>) -> bool
@@ -586,13 +518,6 @@ impl PyErr {
         unsafe { ffi::PyErr_WriteUnraisable(obj.map_or(std::ptr::null_mut(), Bound::as_ptr)) }
     }
 
-    /// Deprecated name for [`PyErr::write_unraisable`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::write_unraisable`")]
-    #[inline]
-    pub fn write_unraisable_bound(self, py: Python<'_>, obj: Option<&Bound<'_, PyAny>>) {
-        self.write_unraisable(py, obj)
-    }
-
     /// Issues a warning message.
     ///
     /// May return an `Err(PyErr)` if warnings-as-errors is enabled.
@@ -601,7 +526,7 @@ impl PyErr {
     ///
     /// The `category` should be one of the `Warning` classes available in
     /// [`pyo3::exceptions`](crate::exceptions), or a subclass.  The Python
-    /// object can be retrieved using [`Python::get_type_bound()`].
+    /// object can be retrieved using [`Python::get_type()`].
     ///
     /// Example:
     /// ```rust
@@ -628,19 +553,6 @@ impl PyErr {
                 stacklevel as ffi::Py_ssize_t,
             )
         })
-    }
-
-    /// Deprecated name for [`PyErr::warn`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::warn`")]
-    #[inline]
-    pub fn warn_bound<'py>(
-        py: Python<'py>,
-        category: &Bound<'py, PyAny>,
-        message: &str,
-        stacklevel: i32,
-    ) -> PyResult<()> {
-        let message = CString::new(message)?;
-        Self::warn(py, category, &message, stacklevel)
     }
 
     /// Issues a warning message, with more control over the warning attributes.
@@ -678,32 +590,6 @@ impl PyErr {
                 registry,
             )
         })
-    }
-
-    /// Deprecated name for [`PyErr::warn_explicit`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyErr::warn`")]
-    #[inline]
-    pub fn warn_explicit_bound<'py>(
-        py: Python<'py>,
-        category: &Bound<'py, PyAny>,
-        message: &str,
-        filename: &str,
-        lineno: i32,
-        module: Option<&str>,
-        registry: Option<&Bound<'py, PyAny>>,
-    ) -> PyResult<()> {
-        let message = CString::new(message)?;
-        let filename = CString::new(filename)?;
-        let module = module.map(CString::new).transpose()?;
-        Self::warn_explicit(
-            py,
-            category,
-            &message,
-            &filename,
-            lineno,
-            module.as_deref(),
-            registry,
-        )
     }
 
     /// Clone the PyErr. This requires the GIL, which is why PyErr does not implement Clone.

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -653,19 +653,6 @@ impl PyUnicodeDecodeError {
         .downcast_into()
     }
 
-    /// Deprecated name for [`PyUnicodeDecodeError::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyUnicodeDecodeError::new`")]
-    #[inline]
-    pub fn new_bound<'py>(
-        py: Python<'py>,
-        encoding: &CStr,
-        input: &[u8],
-        range: ops::Range<usize>,
-        reason: &CStr,
-    ) -> PyResult<Bound<'py, PyUnicodeDecodeError>> {
-        Self::new(py, encoding, input, range, reason)
-    }
-
     /// Creates a Python `UnicodeDecodeError` from a Rust UTF-8 decoding error.
     ///
     /// # Examples
@@ -700,17 +687,6 @@ impl PyUnicodeDecodeError {
             pos..(pos + 1),
             ffi::c_str!("invalid utf-8"),
         )
-    }
-
-    /// Deprecated name for [`PyUnicodeDecodeError::new_utf8`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyUnicodeDecodeError::new_utf8`")]
-    #[inline]
-    pub fn new_utf8_bound<'py>(
-        py: Python<'py>,
-        input: &[u8],
-        err: std::str::Utf8Error,
-    ) -> PyResult<Bound<'py, PyUnicodeDecodeError>> {
-        Self::new_utf8(py, input, err)
     }
 }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -884,7 +884,7 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// See the
 #[doc = concat!("[guide entry](https://pyo3.rs/v", env!("CARGO_PKG_VERSION"), "/class.html#bound-and-interior-mutability)")]
 /// for more information.
-///  - You can call methods directly on `Py` with [`Py::call_bound`], [`Py::call_method_bound`] and friends.
+///  - You can call methods directly on `Py` with [`Py::call`], [`Py::call_method`] and friends.
 ///
 /// These require passing in the [`Python<'py>`](crate::Python) token but are otherwise similar to the corresponding
 /// methods on [`PyAny`].
@@ -1514,19 +1514,6 @@ impl<T> Py<T> {
             .map(Bound::unbind)
     }
 
-    /// Deprecated name for [`Py::call`].
-    #[deprecated(since = "0.23.0", note = "renamed to `Py::call`")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn call_bound(
-        &self,
-        py: Python<'_>,
-        args: impl IntoPy<Py<PyTuple>>,
-        kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<PyObject> {
-        self.call(py, args.into_py(py), kwargs)
-    }
-
     /// Calls the object with only positional arguments.
     ///
     /// This is equivalent to the Python expression `self(*args)`.
@@ -1574,24 +1561,6 @@ impl<T> Py<T> {
                 kwargs,
             )
             .map(Bound::unbind)
-    }
-
-    /// Deprecated name for [`Py::call_method`].
-    #[deprecated(since = "0.23.0", note = "renamed to `Py::call_method`")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn call_method_bound<N, A>(
-        &self,
-        py: Python<'_>,
-        name: N,
-        args: A,
-        kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<PyObject>
-    where
-        N: IntoPy<Py<PyString>>,
-        A: IntoPy<Py<PyTuple>>,
-    {
-        self.call_method(py, name.into_py(py), args.into_py(py), kwargs)
     }
 
     /// Calls a method on the object with only positional arguments.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -367,26 +367,6 @@ pub(crate) mod sealed;
 pub mod class {
     pub use self::gc::{PyTraverseError, PyVisit};
 
-    pub use self::methods::*;
-
-    #[doc(hidden)]
-    pub mod methods {
-        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
-        pub type IPowModulo = crate::impl_::pymethods::IPowModulo;
-        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
-        pub type PyClassAttributeDef = crate::impl_::pymethods::PyClassAttributeDef;
-        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
-        pub type PyGetterDef = crate::impl_::pymethods::PyGetterDef;
-        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
-        pub type PyMethodDef = crate::impl_::pymethods::PyMethodDef;
-        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
-        pub type PyMethodDefType = crate::impl_::pymethods::PyMethodDefType;
-        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
-        pub type PyMethodType = crate::impl_::pymethods::PyMethodType;
-        #[deprecated(since = "0.23.0", note = "PyO3 implementation detail")]
-        pub type PySetterDef = crate::impl_::pymethods::PySetterDef;
-    }
-
     /// Old module which contained some implementation details of the `#[pyproto]` module.
     ///
     /// Prefer using the same content from `pyo3::pyclass`, e.g. `use pyo3::pyclass::CompareOp` instead

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,10 +2,10 @@
 ///
 /// # Panics
 ///
-/// This macro internally calls [`Python::run_bound`](crate::Python::run_bound) and panics
+/// This macro internally calls [`Python::run`](crate::Python::run) and panics
 /// if it returns `Err`, after printing the error to stdout.
 ///
-/// If you need to handle failures, please use [`Python::run_bound`](crate::marker::Python::run_bound) instead.
+/// If you need to handle failures, please use [`Python::run`](crate::marker::Python::run) instead.
 ///
 /// # Examples
 /// ```
@@ -147,22 +147,6 @@ macro_rules! wrap_pyfunction {
             &wrapped_pyfunction::_PYO3_DEF,
         )
     }};
-}
-
-/// Wraps a Rust function annotated with [`#[pyfunction]`](macro@crate::pyfunction).
-///
-/// This can be used with [`PyModule::add_function`](crate::types::PyModuleMethods::add_function) to
-/// add free functions to a [`PyModule`](crate::types::PyModule) - see its documentation for more
-/// information.
-#[deprecated(since = "0.23.0", note = "renamed to `wrap_pyfunction!`")]
-#[macro_export]
-macro_rules! wrap_pyfunction_bound {
-    ($function:path) => {
-        $crate::wrap_pyfunction!($function)
-    };
-    ($function:path, $py_or_module:expr) => {
-        $crate::wrap_pyfunction!($function, $py_or_module)
-    };
 }
 
 /// Returns a function that takes a [`Python`](crate::Python) instance and returns a

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -40,19 +40,6 @@ pub fn dumps<'py>(object: &Bound<'py, PyAny>, version: i32) -> PyResult<Bound<'p
     }
 }
 
-/// Deprecated form of [`dumps`].
-#[deprecated(since = "0.23.0", note = "use `dumps` instead")]
-pub fn dumps_bound<'py>(
-    py: Python<'py>,
-    object: &impl crate::AsPyPointer,
-    version: i32,
-) -> PyResult<Bound<'py, PyBytes>> {
-    dumps(
-        unsafe { object.as_ptr().assume_borrowed(py) }.as_any(),
-        version,
-    )
-}
-
 /// Deserialize an object from bytes using the Python built-in marshal module.
 pub fn loads<'py, B>(py: Python<'py>, data: &B) -> PyResult<Bound<'py, PyAny>>
 where
@@ -63,12 +50,6 @@ where
         ffi::PyMarshal_ReadObjectFromString(data.as_ptr().cast(), data.len() as isize)
             .assume_owned_or_err(py)
     }
-}
-
-/// Deprecated form of [`loads`].
-#[deprecated(since = "0.23.0", note = "renamed to `loads`")]
-pub fn loads_bound<'py>(py: Python<'py>, data: &[u8]) -> PyResult<Bound<'py, PyAny>> {
-    loads(py, data)
 }
 
 #[cfg(test)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,9 +25,6 @@ pub use pyo3_macros::{
 
 #[cfg(feature = "macros")]
 pub use crate::wrap_pyfunction;
-#[cfg(feature = "macros")]
-#[allow(deprecated)]
-pub use crate::wrap_pyfunction_bound;
 
 pub use crate::types::any::PyAnyMethods;
 pub use crate::types::boolobject::PyBoolMethods;

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -62,37 +62,16 @@ pub unsafe trait PyTypeInfo: Sized {
         }
     }
 
-    /// Deprecated name for [`PyTypeInfo::type_object`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyTypeInfo::type_object`")]
-    #[inline]
-    fn type_object_bound(py: Python<'_>) -> Bound<'_, PyType> {
-        Self::type_object(py)
-    }
-
     /// Checks if `object` is an instance of this type or a subclass of this type.
     #[inline]
     fn is_type_of(object: &Bound<'_, PyAny>) -> bool {
         unsafe { ffi::PyObject_TypeCheck(object.as_ptr(), Self::type_object_raw(object.py())) != 0 }
     }
 
-    /// Deprecated name for [`PyTypeInfo::is_type_of`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyTypeInfo::is_type_of`")]
-    #[inline]
-    fn is_type_of_bound(object: &Bound<'_, PyAny>) -> bool {
-        Self::is_type_of(object)
-    }
-
     /// Checks if `object` is an instance of this type.
     #[inline]
     fn is_exact_type_of(object: &Bound<'_, PyAny>) -> bool {
         unsafe { ffi::Py_TYPE(object.as_ptr()) == Self::type_object_raw(object.py()) }
-    }
-
-    /// Deprecated name for [`PyTypeInfo::is_exact_type_of`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyTypeInfo::is_exact_type_of`")]
-    #[inline]
-    fn is_exact_type_of_bound(object: &Bound<'_, PyAny>) -> bool {
-        Self::is_exact_type_of(object)
     }
 }
 

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -659,12 +659,6 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// This is equivalent to the Python expression `self is None`.
     fn is_none(&self) -> bool;
 
-    /// Returns whether the object is Ellipsis, e.g. `...`.
-    ///
-    /// This is equivalent to the Python expression `self is ...`.
-    #[deprecated(since = "0.23.0", note = "use `.is(py.Ellipsis())` instead")]
-    fn is_ellipsis(&self) -> bool;
-
     /// Returns true if the sequence or mapping has a length of 0.
     ///
     /// This is equivalent to the Python expression `len(self) == 0`.
@@ -717,13 +711,6 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// });
     /// ```
     fn try_iter(&self) -> PyResult<Bound<'py, PyIterator>>;
-
-    /// Takes an object and returns an iterator for it.
-    ///
-    /// This is typically a new iterator but if the argument is an iterator,
-    /// this returns itself.
-    #[deprecated(since = "0.23.0", note = "use `try_iter` instead")]
-    fn iter(&self) -> PyResult<Bound<'py, PyIterator>>;
 
     /// Returns the Python type object for this object's type.
     fn get_type(&self) -> Bound<'py, PyType>;
@@ -1371,10 +1358,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
         unsafe { ffi::Py_None() == self.as_ptr() }
     }
 
-    fn is_ellipsis(&self) -> bool {
-        unsafe { ffi::Py_Ellipsis() == self.as_ptr() }
-    }
-
     fn is_empty(&self) -> PyResult<bool> {
         self.len().map(|l| l == 0)
     }
@@ -1441,10 +1424,6 @@ impl<'py> PyAnyMethods<'py> for Bound<'py, PyAny> {
 
     fn try_iter(&self) -> PyResult<Bound<'py, PyIterator>> {
         PyIterator::from_object(self)
-    }
-
-    fn iter(&self) -> PyResult<Bound<'py, PyIterator>> {
-        self.try_iter()
     }
 
     fn get_type(&self) -> Bound<'py, PyType> {
@@ -2084,22 +2063,6 @@ class SimpleClass:
                 .is_truthy()
                 .unwrap());
         })
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn test_is_ellipsis() {
-        Python::with_gil(|py| {
-            let v = py
-                .eval(ffi::c_str!("..."), None, None)
-                .map_err(|e| e.display(py))
-                .unwrap();
-
-            assert!(v.is_ellipsis());
-
-            let not_ellipsis = 5i32.into_pyobject(py).unwrap();
-            assert!(!not_ellipsis.is_ellipsis());
-        });
     }
 
     #[test]

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -38,13 +38,6 @@ impl PyBool {
                 .downcast_unchecked()
         }
     }
-
-    /// Deprecated name for [`PyBool::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyBool::new`")]
-    #[inline]
-    pub fn new_bound(py: Python<'_>, val: bool) -> Borrowed<'_, '_, Self> {
-        Self::new(py, val)
-    }
 }
 
 /// Implementation of functionality for [`PyBool`].

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -32,13 +32,6 @@ impl PyByteArray {
         }
     }
 
-    /// Deprecated name for [`PyByteArray::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyByteArray::new`")]
-    #[inline]
-    pub fn new_bound<'py>(py: Python<'py>, src: &[u8]) -> Bound<'py, PyByteArray> {
-        Self::new(py, src)
-    }
-
     /// Creates a new Python `bytearray` object with an `init` closure to write its contents.
     /// Before calling `init` the bytearray is zero-initialised.
     /// * If Python raises a MemoryError on the allocation, `new_with` will return
@@ -84,20 +77,6 @@ impl PyByteArray {
         }
     }
 
-    /// Deprecated name for [`PyByteArray::new_with`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyByteArray::new_with`")]
-    #[inline]
-    pub fn new_bound_with<F>(
-        py: Python<'_>,
-        len: usize,
-        init: F,
-    ) -> PyResult<Bound<'_, PyByteArray>>
-    where
-        F: FnOnce(&mut [u8]) -> PyResult<()>,
-    {
-        Self::new_with(py, len, init)
-    }
-
     /// Creates a new Python `bytearray` object from another Python object that
     /// implements the buffer protocol.
     pub fn from<'py>(src: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyByteArray>> {
@@ -106,13 +85,6 @@ impl PyByteArray {
                 .assume_owned_or_err(src.py())
                 .downcast_into_unchecked()
         }
-    }
-
-    ///Deprecated name for [`PyByteArray::from`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyByteArray::from`")]
-    #[inline]
-    pub fn from_bound<'py>(src: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyByteArray>> {
-        Self::from(src)
     }
 }
 

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -64,13 +64,6 @@ impl PyBytes {
         }
     }
 
-    /// Deprecated name for [`PyBytes::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyBytes::new`")]
-    #[inline]
-    pub fn new_bound<'p>(py: Python<'p>, s: &[u8]) -> Bound<'p, PyBytes> {
-        Self::new(py, s)
-    }
-
     /// Creates a new Python `bytes` object with an `init` closure to write its contents.
     /// Before calling `init` the bytes' contents are zero-initialised.
     /// * If Python raises a MemoryError on the allocation, `new_with` will return
@@ -114,16 +107,6 @@ impl PyBytes {
         }
     }
 
-    /// Deprecated name for [`PyBytes::new_with`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyBytes::new_with`")]
-    #[inline]
-    pub fn new_bound_with<F>(py: Python<'_>, len: usize, init: F) -> PyResult<Bound<'_, PyBytes>>
-    where
-        F: FnOnce(&mut [u8]) -> PyResult<()>,
-    {
-        Self::new_with(py, len, init)
-    }
-
     /// Creates a new Python byte string object from a raw pointer and length.
     ///
     /// Panics if out of memory.
@@ -140,20 +123,6 @@ impl PyBytes {
                 .assume_owned(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyBytes::from_ptr`].
-    ///
-    /// # Safety
-    ///
-    /// This function dereferences the raw pointer `ptr` as the
-    /// leading pointer of a slice of length `len`. [As with
-    /// `std::slice::from_raw_parts`, this is
-    /// unsafe](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety).
-    #[deprecated(since = "0.23.0", note = "renamed to `PyBytes::from_ptr`")]
-    #[inline]
-    pub unsafe fn bound_from_ptr(py: Python<'_>, ptr: *const u8, len: usize) -> Bound<'_, PyBytes> {
-        unsafe { Self::from_ptr(py, ptr, len) }
     }
 }
 

--- a/src/types/capsule.rs
+++ b/src/types/capsule.rs
@@ -89,17 +89,6 @@ impl PyCapsule {
         Self::new_with_destructor(py, value, name, |_, _| {})
     }
 
-    /// Deprecated name for [`PyCapsule::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyCapsule::new`")]
-    #[inline]
-    pub fn new_bound<T: 'static + Send + AssertNotZeroSized>(
-        py: Python<'_>,
-        value: T,
-        name: Option<CString>,
-    ) -> PyResult<Bound<'_, Self>> {
-        Self::new(py, value, name)
-    }
-
     /// Constructs a new capsule whose contents are `value`, associated with `name`.
     ///
     /// Also provides a destructor: when the `PyCapsule` is destroyed, it will be passed the original object,
@@ -137,21 +126,6 @@ impl PyCapsule {
             .assume_owned_or_err(py)
             .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyCapsule::new_with_destructor`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyCapsule::new_with_destructor`")]
-    #[inline]
-    pub fn new_bound_with_destructor<
-        T: 'static + Send + AssertNotZeroSized,
-        F: FnOnce(T, *mut c_void) + Send,
-    >(
-        py: Python<'_>,
-        value: T,
-        name: Option<CString>,
-        destructor: F,
-    ) -> PyResult<Bound<'_, Self>> {
-        Self::new_with_destructor(py, value, name, destructor)
     }
 
     /// Imports an existing capsule.

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -38,17 +38,6 @@ impl PyComplex {
                 .downcast_into_unchecked()
         }
     }
-
-    /// Deprecated name for [`PyComplex::from_doubles`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyComplex::from_doubles`")]
-    #[inline]
-    pub fn from_doubles_bound(
-        py: Python<'_>,
-        real: c_double,
-        imag: c_double,
-    ) -> Bound<'_, PyComplex> {
-        Self::from_doubles(py, real, imag)
-    }
 }
 
 #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -177,13 +177,6 @@ pub trait PyTzInfoAccess<'py> {
     /// <https://docs.python.org/3/c-api/datetime.html#c.PyDateTime_DATE_GET_TZINFO>
     /// <https://docs.python.org/3/c-api/datetime.html#c.PyDateTime_TIME_GET_TZINFO>
     fn get_tzinfo(&self) -> Option<Bound<'py, PyTzInfo>>;
-
-    /// Deprecated name for [`PyTzInfoAccess::get_tzinfo`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyTzInfoAccess::get_tzinfo`")]
-    #[inline]
-    fn get_tzinfo_bound(&self) -> Option<Bound<'py, PyTzInfo>> {
-        self.get_tzinfo()
-    }
 }
 
 /// Bindings around `datetime.date`.
@@ -212,13 +205,6 @@ impl PyDate {
         }
     }
 
-    /// Deprecated name for [`PyDate::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyDate::new`")]
-    #[inline]
-    pub fn new_bound(py: Python<'_>, year: i32, month: u8, day: u8) -> PyResult<Bound<'_, PyDate>> {
-        Self::new(py, year, month, day)
-    }
-
     /// Construct a `datetime.date` from a POSIX timestamp
     ///
     /// This is equivalent to `datetime.date.fromtimestamp`
@@ -233,13 +219,6 @@ impl PyDate {
                 .assume_owned_or_err(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyDate::from_timestamp`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyDate::from_timestamp`")]
-    #[inline]
-    pub fn from_timestamp_bound(py: Python<'_>, timestamp: i64) -> PyResult<Bound<'_, PyDate>> {
-        Self::from_timestamp(py, timestamp)
     }
 }
 
@@ -304,34 +283,6 @@ impl PyDateTime {
         }
     }
 
-    /// Deprecated name for [`PyDateTime::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyDateTime::new`")]
-    #[inline]
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_bound<'py>(
-        py: Python<'py>,
-        year: i32,
-        month: u8,
-        day: u8,
-        hour: u8,
-        minute: u8,
-        second: u8,
-        microsecond: u32,
-        tzinfo: Option<&Bound<'py, PyTzInfo>>,
-    ) -> PyResult<Bound<'py, PyDateTime>> {
-        Self::new(
-            py,
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            second,
-            microsecond,
-            tzinfo,
-        )
-    }
-
     /// Alternate constructor that takes a `fold` parameter. A `true` value for this parameter
     /// signifies this this datetime is the later of two moments with the same representation,
     /// during a repeated interval.
@@ -371,36 +322,6 @@ impl PyDateTime {
         }
     }
 
-    /// Deprecated name for [`PyDateTime::new_with_fold`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyDateTime::new_with_fold`")]
-    #[inline]
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_bound_with_fold<'py>(
-        py: Python<'py>,
-        year: i32,
-        month: u8,
-        day: u8,
-        hour: u8,
-        minute: u8,
-        second: u8,
-        microsecond: u32,
-        tzinfo: Option<&Bound<'py, PyTzInfo>>,
-        fold: bool,
-    ) -> PyResult<Bound<'py, PyDateTime>> {
-        Self::new_with_fold(
-            py,
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            second,
-            microsecond,
-            tzinfo,
-            fold,
-        )
-    }
-
     /// Construct a `datetime` object from a POSIX timestamp
     ///
     /// This is equivalent to `datetime.datetime.fromtimestamp`
@@ -419,17 +340,6 @@ impl PyDateTime {
                 .assume_owned_or_err(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyDateTime::from_timestamp`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyDateTime::from_timestamp`")]
-    #[inline]
-    pub fn from_timestamp_bound<'py>(
-        py: Python<'py>,
-        timestamp: f64,
-        tzinfo: Option<&Bound<'py, PyTzInfo>>,
-    ) -> PyResult<Bound<'py, PyDateTime>> {
-        Self::from_timestamp(py, timestamp, tzinfo)
     }
 }
 
@@ -543,21 +453,7 @@ impl PyTime {
         }
     }
 
-    /// Deprecated name for [`PyTime::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyTime::new`")]
-    #[inline]
-    pub fn new_bound<'py>(
-        py: Python<'py>,
-        hour: u8,
-        minute: u8,
-        second: u8,
-        microsecond: u32,
-        tzinfo: Option<&Bound<'py, PyTzInfo>>,
-    ) -> PyResult<Bound<'py, PyTime>> {
-        Self::new(py, hour, minute, second, microsecond, tzinfo)
-    }
-
-    /// Alternate constructor that takes a `fold` argument. See [`PyDateTime::new_bound_with_fold`].
+    /// Alternate constructor that takes a `fold` argument. See [`PyDateTime::new_with_fold`].
     pub fn new_with_fold<'py>(
         py: Python<'py>,
         hour: u8,
@@ -581,21 +477,6 @@ impl PyTime {
             .assume_owned_or_err(py)
             .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyTime::new_with_fold`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyTime::new_with_fold`")]
-    #[inline]
-    pub fn new_bound_with_fold<'py>(
-        py: Python<'py>,
-        hour: u8,
-        minute: u8,
-        second: u8,
-        microsecond: u32,
-        tzinfo: Option<&Bound<'py, PyTzInfo>>,
-        fold: bool,
-    ) -> PyResult<Bound<'py, PyTime>> {
-        Self::new_with_fold(py, hour, minute, second, microsecond, tzinfo, fold)
     }
 }
 
@@ -661,7 +542,7 @@ impl<'py> PyTzInfoAccess<'py> for Bound<'py, PyTime> {
 /// [`Py<PyTzInfo>`][crate::Py] or [`Bound<'py, PyTzInfo>`][Bound].
 ///
 /// This is an abstract base class and cannot be constructed directly.
-/// For concrete time zone implementations, see [`timezone_utc_bound`] and
+/// For concrete time zone implementations, see [`timezone_utc`] and
 /// the [`zoneinfo` module](https://docs.python.org/3/library/zoneinfo.html).
 #[repr(transparent)]
 pub struct PyTzInfo(PyAny);
@@ -686,13 +567,6 @@ pub fn timezone_utc(py: Python<'_>) -> Bound<'_, PyTzInfo> {
             .to_owned()
             .downcast_into_unchecked()
     }
-}
-
-/// Deprecated name for [`timezone_utc`].
-#[deprecated(since = "0.23.0", note = "renamed to `timezone_utc`")]
-#[inline]
-pub fn timezone_utc_bound(py: Python<'_>) -> Bound<'_, PyTzInfo> {
-    timezone_utc(py)
 }
 
 /// Equivalent to `datetime.timezone` constructor
@@ -747,19 +621,6 @@ impl PyDelta {
             .assume_owned_or_err(py)
             .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyDelta::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyDelta::new`")]
-    #[inline]
-    pub fn new_bound(
-        py: Python<'_>,
-        days: i32,
-        seconds: i32,
-        microseconds: i32,
-        normalize: bool,
-    ) -> PyResult<Bound<'_, PyDelta>> {
-        Self::new(py, days, seconds, microseconds, normalize)
     }
 }
 

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -67,13 +67,6 @@ impl PyDict {
         unsafe { ffi::PyDict_New().assume_owned(py).downcast_into_unchecked() }
     }
 
-    /// Deprecated name for [`PyDict::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyDict::new`")]
-    #[inline]
-    pub fn new_bound(py: Python<'_>) -> Bound<'_, PyDict> {
-        Self::new(py)
-    }
-
     /// Creates a new dictionary from the sequence given.
     ///
     /// The sequence must consist of `(PyObject, PyObject)`. This is
@@ -89,14 +82,6 @@ impl PyDict {
             ffi::PyDict_MergeFromSeq2(dict.as_ptr(), seq.as_ptr(), 1)
         })?;
         Ok(dict)
-    }
-
-    /// Deprecated name for [`PyDict::from_sequence`].
-    #[cfg(not(any(PyPy, GraalPy)))]
-    #[deprecated(since = "0.23.0", note = "renamed to `PyDict::from_sequence`")]
-    #[inline]
-    pub fn from_sequence_bound<'py>(seq: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyDict>> {
-        Self::from_sequence(seq)
     }
 }
 
@@ -776,13 +761,6 @@ pub trait IntoPyDict<'py>: Sized {
     /// Converts self into a `PyDict` object pointer. Whether pointer owned or borrowed
     /// depends on implementation.
     fn into_py_dict(self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>>;
-
-    /// Deprecated name for [`IntoPyDict::into_py_dict`].
-    #[deprecated(since = "0.23.0", note = "renamed to `IntoPyDict::into_py_dict`")]
-    #[inline]
-    fn into_py_dict_bound(self, py: Python<'py>) -> Bound<'py, PyDict> {
-        self.into_py_dict(py).unwrap()
-    }
 }
 
 impl<'py, T, I> IntoPyDict<'py> for I

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -18,13 +18,6 @@ impl PyEllipsis {
     pub fn get(py: Python<'_>) -> Borrowed<'_, '_, PyEllipsis> {
         unsafe { ffi::Py_Ellipsis().assume_borrowed(py).downcast_unchecked() }
     }
-
-    /// Deprecated name for [`PyEllipsis::get`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyEllipsis::get`")]
-    #[inline]
-    pub fn get_bound(py: Python<'_>) -> Borrowed<'_, '_, PyEllipsis> {
-        Self::get(py)
-    }
 }
 
 unsafe impl PyTypeInfo for PyEllipsis {

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -43,13 +43,6 @@ impl PyFloat {
                 .downcast_into_unchecked()
         }
     }
-
-    /// Deprecated name for [`PyFloat::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyFloat::new`")]
-    #[inline]
-    pub fn new_bound(py: Python<'_>, val: c_double) -> Bound<'_, PyFloat> {
-        Self::new(py, val)
-    }
 }
 
 /// Implementation of functionality for [`PyFloat`].

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -49,13 +49,6 @@ impl<'py> PyFrozenSetBuilder<'py> {
     pub fn finalize(self) -> Bound<'py, PyFrozenSet> {
         self.py_frozen_set
     }
-
-    /// Deprecated name for [`PyFrozenSetBuilder::finalize`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyFrozenSetBuilder::finalize`")]
-    #[inline]
-    pub fn finalize_bound(self) -> Bound<'py, PyFrozenSet> {
-        self.finalize()
-    }
 }
 
 /// Represents a  Python `frozenset`.
@@ -100,17 +93,6 @@ impl PyFrozenSet {
         try_new_from_iter(py, elements)
     }
 
-    /// Deprecated name for [`PyFrozenSet::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyFrozenSet::new`")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn new_bound<'a, 'p, T: crate::ToPyObject + 'a>(
-        py: Python<'p>,
-        elements: impl IntoIterator<Item = &'a T>,
-    ) -> PyResult<Bound<'p, PyFrozenSet>> {
-        Self::new(py, elements.into_iter().map(|e| e.to_object(py)))
-    }
-
     /// Creates a new empty frozen set
     pub fn empty(py: Python<'_>) -> PyResult<Bound<'_, PyFrozenSet>> {
         unsafe {
@@ -118,13 +100,6 @@ impl PyFrozenSet {
                 .assume_owned_or_err(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyFrozenSet::empty`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyFrozenSet::empty`")]
-    #[inline]
-    pub fn empty_bound(py: Python<'_>) -> PyResult<Bound<'_, PyFrozenSet>> {
-        Self::empty(py)
     }
 }
 

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -39,19 +39,6 @@ impl PyCFunction {
         )
     }
 
-    /// Deprecated name for [`PyCFunction::new_with_keywords`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyCFunction::new_with_keywords`")]
-    #[inline]
-    pub fn new_with_keywords_bound<'py>(
-        py: Python<'py>,
-        fun: ffi::PyCFunctionWithKeywords,
-        name: &'static CStr,
-        doc: &'static CStr,
-        module: Option<&Bound<'py, PyModule>>,
-    ) -> PyResult<Bound<'py, Self>> {
-        Self::new_with_keywords(py, fun, name, doc, module)
-    }
-
     /// Create a new built-in function which takes no arguments.
     ///
     /// To create `name` and `doc` static strings on Rust versions older than 1.77 (which added c"" literals),
@@ -64,19 +51,6 @@ impl PyCFunction {
         module: Option<&Bound<'py, PyModule>>,
     ) -> PyResult<Bound<'py, Self>> {
         Self::internal_new(py, &PyMethodDef::noargs(name, fun, doc), module)
-    }
-
-    /// Deprecated name for [`PyCFunction::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyCFunction::new`")]
-    #[inline]
-    pub fn new_bound<'py>(
-        py: Python<'py>,
-        fun: ffi::PyCFunction,
-        name: &'static CStr,
-        doc: &'static CStr,
-        module: Option<&Bound<'py, PyModule>>,
-    ) -> PyResult<Bound<'py, Self>> {
-        Self::new(py, fun, name, doc, module)
     }
 
     /// Create a new function from a closure.
@@ -129,22 +103,6 @@ impl PyCFunction {
                 .assume_owned_or_err(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyCFunction::new_closure`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyCFunction::new_closure`")]
-    #[inline]
-    pub fn new_closure_bound<'py, F, R>(
-        py: Python<'py>,
-        name: Option<&'static CStr>,
-        doc: Option<&'static CStr>,
-        closure: F,
-    ) -> PyResult<Bound<'py, Self>>
-    where
-        F: Fn(&Bound<'_, PyTuple>, Option<&Bound<'_, PyDict>>) -> R + Send + 'static,
-        for<'p> R: crate::impl_::callback::IntoPyCallbackOutput<'p, *mut ffi::PyObject>,
-    {
-        Self::new_closure(py, name, doc, closure)
     }
 
     #[doc(hidden)]

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -34,7 +34,7 @@ pyobject_native_type_named!(PyIterator);
 impl PyIterator {
     /// Builds an iterator for an iterable Python object; the equivalent of calling `iter(obj)` in Python.
     ///
-    /// Usually it is more convenient to write [`obj.iter()`][crate::types::any::PyAnyMethods::iter],
+    /// Usually it is more convenient to write [`obj.try_iter()`][crate::types::any::PyAnyMethods::try_iter],
     /// which is a more concise way of calling this function.
     pub fn from_object<'py>(obj: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyIterator>> {
         unsafe {
@@ -42,13 +42,6 @@ impl PyIterator {
                 .assume_owned_or_err(obj.py())
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyIterator::from_object`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyIterator::from_object`")]
-    #[inline]
-    pub fn from_bound_object<'py>(obj: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyIterator>> {
-        Self::from_object(obj)
     }
 }
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -110,22 +110,6 @@ impl PyList {
         try_new_from_iter(py, iter)
     }
 
-    /// Deprecated name for [`PyList::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyList::new`")]
-    #[allow(deprecated)]
-    #[inline]
-    #[track_caller]
-    pub fn new_bound<T, U>(
-        py: Python<'_>,
-        elements: impl IntoIterator<Item = T, IntoIter = U>,
-    ) -> Bound<'_, PyList>
-    where
-        T: crate::ToPyObject,
-        U: ExactSizeIterator<Item = T>,
-    {
-        Self::new(py, elements.into_iter().map(|e| e.to_object(py))).unwrap()
-    }
-
     /// Constructs a new empty list.
     pub fn empty(py: Python<'_>) -> Bound<'_, PyList> {
         unsafe {
@@ -133,13 +117,6 @@ impl PyList {
                 .assume_owned(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyList::empty`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyList::empty`")]
-    #[inline]
-    pub fn empty_bound(py: Python<'_>) -> Bound<'_, PyList> {
-        Self::empty(py)
     }
 }
 

--- a/src/types/memoryview.rs
+++ b/src/types/memoryview.rs
@@ -22,13 +22,6 @@ impl PyMemoryView {
                 .downcast_into_unchecked()
         }
     }
-
-    /// Deprecated name for [`PyMemoryView::from`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyMemoryView::from`")]
-    #[inline]
-    pub fn from_bound<'py>(src: &Bound<'py, PyAny>) -> PyResult<Bound<'py, Self>> {
-        Self::from(src)
-    }
 }
 
 impl<'py> TryFrom<&Bound<'py, PyAny>> for Bound<'py, PyMemoryView> {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,8 +11,8 @@ pub use self::complex::{PyComplex, PyComplexMethods};
 #[cfg(not(Py_LIMITED_API))]
 #[allow(deprecated)]
 pub use self::datetime::{
-    timezone_utc, timezone_utc_bound, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess,
-    PyTime, PyTimeAccess, PyTzInfo, PyTzInfoAccess,
+    timezone_utc, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyTime, PyTimeAccess,
+    PyTzInfo, PyTzInfoAccess,
 };
 pub use self::dict::{IntoPyDict, PyDict, PyDictMethods};
 #[cfg(not(any(PyPy, GraalPy)))]
@@ -35,8 +35,7 @@ pub use self::memoryview::PyMemoryView;
 pub use self::module::{PyModule, PyModuleMethods};
 pub use self::none::PyNone;
 pub use self::notimplemented::PyNotImplemented;
-#[allow(deprecated)]
-pub use self::num::{PyInt, PyLong};
+pub use self::num::PyInt;
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use self::pysuper::PySuper;
 pub use self::sequence::{PySequence, PySequenceMethods};
@@ -44,8 +43,7 @@ pub use self::set::{PySet, PySetMethods};
 pub use self::slice::{PySlice, PySliceIndices, PySliceMethods};
 #[cfg(not(Py_LIMITED_API))]
 pub use self::string::PyStringData;
-#[allow(deprecated)]
-pub use self::string::{PyString, PyStringMethods, PyUnicode};
+pub use self::string::{PyString, PyStringMethods};
 pub use self::traceback::{PyTraceback, PyTracebackMethods};
 pub use self::tuple::{PyTuple, PyTupleMethods};
 pub use self::typeobject::{PyType, PyTypeMethods};

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -7,10 +7,9 @@ use crate::types::{
     any::PyAnyMethods, list::PyListMethods, PyAny, PyCFunction, PyDict, PyList, PyString,
 };
 use crate::{
-    exceptions, ffi, Borrowed, Bound, BoundObject, IntoPyObject, IntoPyObjectExt, Py, PyObject,
-    Python,
+    exceptions, ffi, Borrowed, Bound, BoundObject, IntoPyObject, IntoPyObjectExt, PyObject, Python,
 };
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 #[cfg(all(not(Py_LIMITED_API), Py_GIL_DISABLED))]
 use std::os::raw::c_int;
 use std::str;
@@ -59,13 +58,6 @@ impl PyModule {
         }
     }
 
-    /// Deprecated name for [`PyModule::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyModule::new`")]
-    #[inline]
-    pub fn new_bound<'py>(py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyModule>> {
-        Self::new(py, name)
-    }
-
     /// Imports the Python module with the specified name.
     ///
     /// # Examples
@@ -99,17 +91,6 @@ impl PyModule {
         }
     }
 
-    /// Deprecated name for [`PyModule::import`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyModule::import`")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn import_bound<N>(py: Python<'_>, name: N) -> PyResult<Bound<'_, PyModule>>
-    where
-        N: crate::IntoPy<Py<PyString>>,
-    {
-        Self::import(py, name.into_py(py))
-    }
-
     /// Creates and loads a module named `module_name`,
     /// containing the Python code passed to `code`
     /// and pretending to live at `file_name`.
@@ -127,7 +108,7 @@ impl PyModule {
     /// Returns `PyErr` if:
     /// - `code` is not syntactically correct Python.
     /// - Any Python exceptions are raised while initializing the module.
-    /// - Any of the arguments cannot be converted to [`CString`]s.
+    /// - Any of the arguments cannot be converted to [`CString`][std::ffi::CString]s.
     ///
     /// # Example: bundle in a file at compile time with [`include_str!`][std::include_str]:
     ///
@@ -181,22 +162,6 @@ impl PyModule {
                 .assume_owned_or_err(py)
                 .downcast_into()
         }
-    }
-
-    /// Deprecated name for [`PyModule::from_code`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyModule::from_code`")]
-    #[inline]
-    pub fn from_code_bound<'py>(
-        py: Python<'py>,
-        code: &str,
-        file_name: &str,
-        module_name: &str,
-    ) -> PyResult<Bound<'py, PyModule>> {
-        let data = CString::new(code)?;
-        let filename = CString::new(file_name)?;
-        let module = CString::new(module_name)?;
-
-        Self::from_code(py, data.as_c_str(), filename.as_c_str(), module.as_c_str())
     }
 }
 

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -18,13 +18,6 @@ impl PyNone {
     pub fn get(py: Python<'_>) -> Borrowed<'_, '_, PyNone> {
         unsafe { ffi::Py_None().assume_borrowed(py).downcast_unchecked() }
     }
-
-    /// Deprecated name for [`PyNone::get`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyNone::get`")]
-    #[inline]
-    pub fn get_bound(py: Python<'_>) -> Borrowed<'_, '_, PyNone> {
-        Self::get(py)
-    }
 }
 
 unsafe impl PyTypeInfo for PyNone {

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -22,13 +22,6 @@ impl PyNotImplemented {
                 .downcast_unchecked()
         }
     }
-
-    /// Deprecated name for [`PyNotImplemented::get`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyNotImplemented::get`")]
-    #[inline]
-    pub fn get_bound(py: Python<'_>) -> Borrowed<'_, '_, PyNotImplemented> {
-        Self::get(py)
-    }
 }
 
 unsafe impl PyTypeInfo for PyNotImplemented {

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -16,10 +16,6 @@ pub struct PyInt(PyAny);
 
 pyobject_native_type_core!(PyInt, pyobject_native_static_type_object!(ffi::PyLong_Type), #checkfunction=ffi::PyLong_Check);
 
-/// Deprecated alias for [`PyInt`].
-#[deprecated(since = "0.23.0", note = "use `PyInt` instead")]
-pub type PyLong = PyInt;
-
 impl PyInt {
     /// Creates a new Python int object.
     ///

--- a/src/types/pysuper.rs
+++ b/src/types/pysuper.rs
@@ -66,14 +66,4 @@ impl PySuper {
             unsafe { any.downcast_into_unchecked() }
         })
     }
-
-    /// Deprecated name for [`PySuper::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PySuper::new`")]
-    #[inline]
-    pub fn new_bound<'py>(
-        ty: &Bound<'py, PyType>,
-        obj: &Bound<'py, PyAny>,
-    ) -> PyResult<Bound<'py, PySuper>> {
-        Self::new(ty, obj)
-    }
 }

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -54,17 +54,6 @@ impl PySet {
         try_new_from_iter(py, elements)
     }
 
-    /// Deprecated name for [`PySet::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PySet::new`")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn new_bound<'a, 'p, T: ToPyObject + 'a>(
-        py: Python<'p>,
-        elements: impl IntoIterator<Item = &'a T>,
-    ) -> PyResult<Bound<'p, PySet>> {
-        Self::new(py, elements.into_iter().map(|e| e.to_object(py)))
-    }
-
     /// Creates a new empty set.
     pub fn empty(py: Python<'_>) -> PyResult<Bound<'_, PySet>> {
         unsafe {
@@ -72,13 +61,6 @@ impl PySet {
                 .assume_owned_or_err(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PySet::empty`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PySet::empty`")]
-    #[inline]
-    pub fn empty_bound(py: Python<'_>) -> PyResult<Bound<'_, PySet>> {
-        Self::empty(py)
     }
 }
 

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -69,13 +69,6 @@ impl PySlice {
         }
     }
 
-    /// Deprecated name for [`PySlice::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PySlice::new`")]
-    #[inline]
-    pub fn new_bound(py: Python<'_>, start: isize, stop: isize, step: isize) -> Bound<'_, PySlice> {
-        Self::new(py, start, stop, step)
-    }
-
     /// Constructs a new full slice that is equivalent to `::`.
     pub fn full(py: Python<'_>) -> Bound<'_, PySlice> {
         unsafe {
@@ -83,13 +76,6 @@ impl PySlice {
                 .assume_owned(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PySlice::full`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PySlice::full`")]
-    #[inline]
-    pub fn full_bound(py: Python<'_>) -> Bound<'_, PySlice> {
-        Self::full(py)
     }
 }
 

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -13,10 +13,6 @@ use std::borrow::Cow;
 use std::ffi::CString;
 use std::str;
 
-/// Deprecated alias for [`PyString`].
-#[deprecated(since = "0.23.0", note = "use `PyString` instead")]
-pub type PyUnicode = PyString;
-
 /// Represents raw data backing a Python `str`.
 ///
 /// Python internally stores strings in various representations. This enumeration
@@ -175,19 +171,12 @@ impl PyString {
         }
     }
 
-    /// Deprecated name for [`PyString::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyString::new`")]
-    #[inline]
-    pub fn new_bound<'py>(py: Python<'py>, s: &str) -> Bound<'py, PyString> {
-        Self::new(py, s)
-    }
-
     /// Intern the given string
     ///
     /// This will return a reference to the same Python string object if called repeatedly with the same string.
     ///
-    /// Note that while this is more memory efficient than [`PyString::new_bound`], it unconditionally allocates a
-    /// temporary Python string object and is thereby slower than [`PyString::new_bound`].
+    /// Note that while this is more memory efficient than [`PyString::new`], it unconditionally allocates a
+    /// temporary Python string object and is thereby slower than [`PyString::new`].
     ///
     /// Panics if out of memory.
     pub fn intern<'py>(py: Python<'py>, s: &str) -> Bound<'py, PyString> {
@@ -200,13 +189,6 @@ impl PyString {
             }
             ob.assume_owned(py).downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyString::intern`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyString::intern`")]
-    #[inline]
-    pub fn intern_bound<'py>(py: Python<'py>, s: &str) -> Bound<'py, PyString> {
-        Self::intern(py, s)
     }
 
     /// Attempts to create a Python string from a Python [bytes-like object].
@@ -228,17 +210,6 @@ impl PyString {
             .assume_owned_or_err(src.py())
             .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyString::from_object`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyString::from_object`")]
-    #[inline]
-    pub fn from_object_bound<'py>(
-        src: &Bound<'py, PyAny>,
-        encoding: &str,
-        errors: &str,
-    ) -> PyResult<Bound<'py, PyString>> {
-        Self::from_object(src, encoding, errors)
     }
 }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -104,22 +104,6 @@ impl PyTuple {
         try_new_from_iter(py, elements)
     }
 
-    /// Deprecated name for [`PyTuple::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyTuple::new`")]
-    #[allow(deprecated)]
-    #[track_caller]
-    #[inline]
-    pub fn new_bound<T, U>(
-        py: Python<'_>,
-        elements: impl IntoIterator<Item = T, IntoIter = U>,
-    ) -> Bound<'_, PyTuple>
-    where
-        T: ToPyObject,
-        U: ExactSizeIterator<Item = T>,
-    {
-        PyTuple::new(py, elements.into_iter().map(|e| e.to_object(py))).unwrap()
-    }
-
     /// Constructs an empty tuple (on the Python side, a singleton object).
     pub fn empty(py: Python<'_>) -> Bound<'_, PyTuple> {
         unsafe {
@@ -127,13 +111,6 @@ impl PyTuple {
                 .assume_owned(py)
                 .downcast_into_unchecked()
         }
-    }
-
-    /// Deprecated name for [`PyTuple::empty`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyTuple::empty`")]
-    #[inline]
-    pub fn empty_bound(py: Python<'_>) -> Bound<'_, PyTuple> {
-        PyTuple::empty(py)
     }
 }
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -27,13 +27,6 @@ impl PyType {
         T::type_object(py)
     }
 
-    /// Deprecated name for [`PyType::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyType::new`")]
-    #[inline]
-    pub fn new_bound<T: PyTypeInfo>(py: Python<'_>) -> Bound<'_, PyType> {
-        Self::new::<T>(py)
-    }
-
     /// Converts the given FFI pointer into `Bound<PyType>`, to use in safe code.
     ///
     /// The function creates a new reference from the given pointer, and returns

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -80,13 +80,6 @@ impl PyWeakrefProxy {
         }
     }
 
-    /// Deprecated name for [`PyWeakrefProxy::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyWeakrefProxy::new`")]
-    #[inline]
-    pub fn new_bound<'py>(object: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyWeakrefProxy>> {
-        Self::new(object)
-    }
-
     /// Constructs a new Weak Reference (`weakref.proxy`/`weakref.ProxyType`/`weakref.CallableProxyType`) for the given object with a callback.
     ///
     /// Returns a `TypeError` if `object` is not weak referenceable (Most native types and PyClasses without `weakref` flag) or if the `callback` is not callable or None.
@@ -171,20 +164,6 @@ impl PyWeakrefProxy {
                 .into_any()
                 .as_borrowed(),
         )
-    }
-
-    /// Deprecated name for [`PyWeakrefProxy::new_with`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyWeakrefProxy::new_with`")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn new_bound_with<'py, C>(
-        object: &Bound<'py, PyAny>,
-        callback: C,
-    ) -> PyResult<Bound<'py, PyWeakrefProxy>>
-    where
-        C: crate::ToPyObject,
-    {
-        Self::new_with(object, callback.to_object(object.py()))
     }
 }
 
@@ -579,23 +558,6 @@ mod tests {
                     Ok(())
                 })
             }
-
-            #[test]
-            #[allow(deprecated)]
-            fn test_weakref_get_object() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    assert!(reference.get_object().is(&object));
-
-                    drop(object);
-
-                    assert!(reference.get_object().is_none());
-
-                    Ok(())
-                })
-            }
         }
     }
 
@@ -753,24 +715,6 @@ mod tests {
                     Ok(())
                 })
             }
-
-            #[test]
-            #[allow(deprecated)]
-            fn test_weakref_get_object() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let class = get_type(py)?;
-                    let object = class.call0()?;
-                    let reference = PyWeakrefProxy::new(&object)?;
-
-                    assert!(reference.get_object().is(&object));
-
-                    drop(object);
-
-                    assert!(reference.get_object().is_none());
-
-                    Ok(())
-                })
-            }
         }
 
         // under 'abi3-py37' and 'abi3-py38' PyClass cannot be weakreferencable.
@@ -909,23 +853,6 @@ mod tests {
                     drop(object);
 
                     assert!(reference.upgrade().is_none());
-
-                    Ok(())
-                })
-            }
-
-            #[test]
-            #[allow(deprecated)]
-            fn test_weakref_get_object() -> PyResult<()> {
-                Python::with_gil(|py| {
-                    let object = Py::new(py, WeakrefablePyClass {})?;
-                    let reference = PyWeakrefProxy::new(object.bind(py))?;
-
-                    assert!(reference.get_object().is(&object));
-
-                    drop(object);
-
-                    assert!(reference.get_object().is_none());
 
                     Ok(())
                 })

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -90,13 +90,6 @@ impl PyWeakrefReference {
         }
     }
 
-    /// Deprecated name for [`PyWeakrefReference::new`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyWeakrefReference::new`")]
-    #[inline]
-    pub fn new_bound<'py>(object: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyWeakrefReference>> {
-        Self::new(object)
-    }
-
     /// Constructs a new Weak Reference (`weakref.ref`/`weakref.ReferenceType`) for the given object with a callback.
     ///
     /// Returns a `TypeError` if `object` is not weak referenceable (Most native types and PyClasses without `weakref` flag) or if the `callback` is not callable or None.
@@ -180,20 +173,6 @@ impl PyWeakrefReference {
                 .into_any()
                 .as_borrowed(),
         )
-    }
-
-    /// Deprecated name for [`PyWeakrefReference::new_with`].
-    #[deprecated(since = "0.23.0", note = "renamed to `PyWeakrefReference::new_with`")]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn new_bound_with<'py, C>(
-        object: &Bound<'py, PyAny>,
-        callback: C,
-    ) -> PyResult<Bound<'py, PyWeakrefReference>>
-    where
-        C: crate::ToPyObject,
-    {
-        Self::new_with(object, callback.to_object(object.py()))
     }
 }
 
@@ -392,27 +371,6 @@ mod tests {
                 Ok(())
             })
         }
-
-        #[test]
-        #[allow(deprecated)]
-        fn test_weakref_get_object() -> PyResult<()> {
-            Python::with_gil(|py| {
-                let class = get_type(py)?;
-                let object = class.call0()?;
-                let reference = PyWeakrefReference::new(&object)?;
-
-                assert!(reference.call0()?.is(&object));
-                assert!(reference.get_object().is(&object));
-
-                drop(object);
-
-                assert!(reference.call0()?.is(&reference.get_object()));
-                assert!(reference.call0()?.is_none());
-                assert!(reference.get_object().is_none());
-
-                Ok(())
-            })
-        }
     }
 
     // under 'abi3-py37' and 'abi3-py38' PyClass cannot be weakreferencable.
@@ -533,26 +491,6 @@ mod tests {
 
                 assert!(reference.call0()?.is_none());
                 assert!(reference.upgrade().is_none());
-
-                Ok(())
-            })
-        }
-
-        #[test]
-        #[allow(deprecated)]
-        fn test_weakref_get_object() -> PyResult<()> {
-            Python::with_gil(|py| {
-                let object = Py::new(py, WeakrefablePyClass {})?;
-                let reference = PyWeakrefReference::new(object.bind(py))?;
-
-                assert!(reference.call0()?.is(&object));
-                assert!(reference.get_object().is(&object));
-
-                drop(object);
-
-                assert!(reference.call0()?.is(&reference.get_object()));
-                assert!(reference.call0()?.is_none());
-                assert!(reference.get_object().is_none());
 
                 Ok(())
             })

--- a/tests/ui/reject_generics.stderr
+++ b/tests/ui/reject_generics.stderr
@@ -1,10 +1,10 @@
-error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.24.0/class.html#no-generic-parameters
+error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.25.0-dev/class.html#no-generic-parameters
  --> tests/ui/reject_generics.rs:4:25
   |
 4 | struct ClassWithGenerics<A> {
   |                         ^
 
-error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.24.0/class.html#no-lifetime-parameters
+error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.25.0-dev/class.html#no-lifetime-parameters
  --> tests/ui/reject_generics.rs:9:27
   |
 9 | struct ClassWithLifetimes<'a> {


### PR DESCRIPTION
As per title, removes a ton of stuff deprecated in PyO3 0.23.

I kept the traits for follow-up PRs because they have some more complex logic which falls back to them inside the macros, and I think it'll be easier to study those as part of a smaller diff.

Probably worth merging #4981 first as this PR necessarily contains the same change.