### PR TITLE
add PyInt constructor for all supported number types (i32, u32, i64, u64, isize, usize)

### DIFF
--- a/newsfragments/4984.added.md
+++ b/newsfragments/4984.added.md
@@ -1,1 +1,1 @@
-Added PyInt constructor for all supported number types (i32, u32, i64, u64, isize, usize, f64)
+Added PyInt constructor for all supported number types (i32, u32, i64, u64, isize, usize)

--- a/newsfragments/4984.added.md
+++ b/newsfragments/4984.added.md
@@ -1,0 +1,1 @@
+Added PyInt constructor for all supported number types (i32, u32, i64, u64, isize, usize, f64)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,7 +36,7 @@ pub use self::module::{PyModule, PyModuleMethods};
 pub use self::none::PyNone;
 pub use self::notimplemented::PyNotImplemented;
 #[allow(deprecated)]
-pub use self::num::{PyInt, PyLong};
+pub use self::num::{PyInt, PyLong, ToPyInt};
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use self::pysuper::PySuper;
 pub use self::sequence::{PySequence, PySequenceMethods};

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,7 +36,7 @@ pub use self::module::{PyModule, PyModuleMethods};
 pub use self::none::PyNone;
 pub use self::notimplemented::PyNotImplemented;
 #[allow(deprecated)]
-pub use self::num::{PyInt, PyLong, ToPyInt};
+pub use self::num::{PyInt, PyLong};
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use self::pysuper::PySuper;
 pub use self::sequence::{PySequence, PySequenceMethods};

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -149,7 +149,7 @@ mod tests {
         Python::with_gil(|py| {
             let s = PyInt::new(py, 42u8);
             assert_eq!(format!("{}", s), "42");
-            
+
             let s = PyInt::new(py, 43i32);
             assert_eq!(format!("{}", s), "43");
 

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -1,6 +1,6 @@
 use super::any::PyAnyMethods;
 
-use crate::{ffi, instance::Bound, PyAny};
+use crate::{ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, PyAny, Python};
 
 /// Represents a Python `int` object.
 ///
@@ -19,6 +19,47 @@ pyobject_native_type_core!(PyInt, pyobject_native_static_type_object!(ffi::PyLon
 /// Deprecated alias for [`PyInt`].
 #[deprecated(since = "0.23.0", note = "use `PyInt` instead")]
 pub type PyLong = PyInt;
+
+impl PyInt {}
+
+impl PyInt {
+    /// Creates a new Python int object.
+    ///
+    /// Panics if out of memory.
+    pub fn new<T: ToPyInt>(py: Python<'_>, i: T) -> Bound<'_, PyInt> {
+        T::to_pyint(py, i)
+    }
+}
+
+/// Trait for the conversion to [`PyInt`]`.
+pub trait ToPyInt {
+    /// Creates a new Python int object.
+    ///
+    /// Panics if out of memory.
+    fn to_pyint(py: Python<'_>, i: Self) -> Bound<'_, PyInt>;
+}
+
+macro_rules! int_from {
+    ($rust_type: ty, $from_function: ident) => {
+        impl ToPyInt for $rust_type {
+            fn to_pyint(py: Python<'_>, i: Self) -> Bound<'_, PyInt> {
+                unsafe {
+                    ffi::$from_function(i)
+                        .assume_owned(py)
+                        .downcast_into_unchecked()
+                }
+            }
+        }
+    };
+}
+
+int_from!(i32, PyLong_FromLong);
+int_from!(u32, PyLong_FromUnsignedLong);
+int_from!(i64, PyLong_FromLongLong);
+int_from!(u64, PyLong_FromUnsignedLongLong);
+int_from!(isize, PyLong_FromSsize_t);
+int_from!(usize, PyLong_FromSize_t);
+int_from!(f64, PyLong_FromDouble);
 
 macro_rules! int_compare {
     ($rust_type: ty) => {
@@ -60,6 +101,7 @@ int_compare!(usize);
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{IntoPyObject, Python};
 
     #[test]
@@ -122,5 +164,16 @@ mod tests {
                 assert_ne!(big_obj, x);
             }
         });
+    }
+
+    #[test]
+    fn test_display_int() {
+        Python::with_gil(|py| {
+            let s = PyInt::new(py, 42);
+            assert_eq!(format!("{}", s), "42");
+
+            let s = PyInt::new(py, 3.14);
+            assert_eq!(format!("{}", s), "3");
+        })
     }
 }

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -24,14 +24,14 @@ impl PyInt {
     /// Creates a new Python int object.
     ///
     /// Panics if out of memory.
-    pub fn new<
-        'a,
+    pub fn new<'a, T>(py: Python<'a>, i: T) -> Bound<'a, PyInt>
+    where
         T: IntoPyObject<'a, Target = PyInt, Output = Bound<'a, PyInt>, Error = Infallible>,
-    >(
-        py: Python<'a>,
-        i: T,
-    ) -> Bound<'a, PyInt> {
-        T::into_pyobject(i, py).unwrap()
+    {
+        match T::into_pyobject(i, py) {
+            Ok(v) => v,
+            Err(never) => match never {},
+        }
     }
 }
 

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -1,8 +1,6 @@
-use std::convert::Infallible;
-
 use super::any::PyAnyMethods;
-
 use crate::{ffi, instance::Bound, IntoPyObject, PyAny, Python};
+use std::convert::Infallible;
 
 /// Represents a Python `int` object.
 ///

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -202,8 +202,8 @@ mod tests {
             let s = PyInt::new(py, 42);
             assert_eq!(format!("{}", s), "42");
 
-            let s = PyInt::new(py, 3.14);
-            assert_eq!(format!("{}", s), "3");
+            let s = PyInt::new(py, 69.420);
+            assert_eq!(format!("{}", s), "69");
         })
     }
 }

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -55,6 +55,7 @@ macro_rules! int_from {
 }
 
 /// Macro to invoke the corresponding PyLong_From variant, upcasting the value if required.
+#[cfg(not(target_family = "windows"))]
 macro_rules! int_from_upcasting {
     ($rust_type: ty, $from_function: ident) => {
         impl crate::types::num::ToPyInt for $rust_type {

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -20,8 +20,6 @@ pyobject_native_type_core!(PyInt, pyobject_native_static_type_object!(ffi::PyLon
 #[deprecated(since = "0.23.0", note = "use `PyInt` instead")]
 pub type PyLong = PyInt;
 
-impl PyInt {}
-
 impl PyInt {
     /// Creates a new Python int object.
     ///


### PR DESCRIPTION
Solves a part of https://github.com/PyO3/pyo3/issues/2221.

I deliberately did not implement support for `PyLong_FromString` because I don't feel familiar enough with the codebase to do this in my first PR.

I am aware that my `ToPyInt` trait will not work with `PyLong_FromString`, because  `PyLong_FromString` takes more parameters than just a single value. I acknowledge that changing the trait to also accommodate  `PyLong_FromString` will be a breaking change, but one could also add a dedicated constructor for that instead of squeezing it into `new`.
