### PR TITLE
Fix `Probe` class naming issue with `#[pymethods]`

### DIFF
--- a/newsfragments/4988.fixed.md
+++ b/newsfragments/4988.fixed.md
@@ -1,0 +1,1 @@
+Fix `Probe` class naming issue with `#[pymethods]`

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -367,9 +367,8 @@ pub fn impl_py_method_def_new(
                     args: *mut #pyo3_path::ffi::PyObject,
                     kwargs: *mut #pyo3_path::ffi::PyObject,
                 ) -> *mut #pyo3_path::ffi::PyObject {
-                    use #pyo3_path::impl_::pyclass::*;
                     #[allow(unknown_lints, non_local_definitions)]
-                    impl PyClassNewTextSignature<#cls> for PyClassImplCollector<#cls> {
+                    impl #pyo3_path::impl_::pyclass::PyClassNewTextSignature<#cls> for #pyo3_path::impl_::pyclass::PyClassImplCollector<#cls> {
                         #[inline]
                         fn new_text_signature(self) -> ::std::option::Option<&'static str> {
                             #text_signature_body

--- a/tests/ui/pyclass_probe.rs
+++ b/tests/ui/pyclass_probe.rs
@@ -3,4 +3,18 @@ use pyo3::prelude::*;
 #[pyclass]
 pub struct Probe {}
 
+#[pymethods]
+impl Probe {
+    #[new]
+    fn new() -> Self {
+        Self {}
+    }
+}
+
+#[pymodule]
+fn probe(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<Probe>()?;
+    Ok(())
+}
+
 fn main() {}


### PR DESCRIPTION
Commit 603a55f204e3 ("fix `#[pyclass]` could not be named `Probe` (#4794)") fixed the issue where it was not possible to define a class named `Probe`. However, similar issue exists when trying to add `#[pymethods]` implementations to the `Probe` class. It generates similar confusing errors as the original issue (#4792), due to the internal `Probe` trait being in scope at the user code:
```
  error[E0782]: expected a type, found a trait
  help: you can add the `dyn` keyword if you want a trait object
  * | impl dyn Probe {
```

Fix the issue by avoiding pollution of the imports from the macro expansion and instead use qualified path to the internal types.