### PR TITLE
Add `pyo3::sync::with_critical_section2` binding

### DIFF
--- a/newsfragments/4992.added.md
+++ b/newsfragments/4992.added.md
@@ -1,0 +1,1 @@
+Add `pyo3::sync::with_critical_section2` binding


### PR DESCRIPTION
> Thank you for contributing to PyO3!
> 
> By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).
> 
> Please consider adding the following to your pull request:
>  - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
>    - or start the PR title with `docs:` if this is a docs-only change to skip the check
>  - docs to all new functions and / or detail in the guide
>  - tests for all new or changed functions
> 
> PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
> locally, you can run ```nox```. See ```nox --list-sessions```
> for a list of supported actions.

------

Add `pyo3::sync::with_critical_section2` binding for `Py_{BEGIN,END}_CRITICAL_SECTION2` macros.

For free-threading builds, some functions need to be run with two objects locked. E.g. `PyDict_Update(dict, other)`, `dequeiter_next(it, it->deque)`.