### PR TITLE
docs: guide - add link to tables and traits

### DIFF
--- a/guide/src/conversions.md
+++ b/guide/src/conversions.md
@@ -1,3 +1,5 @@
 # Type conversions
 
 In this portion of the guide we'll talk about the mapping of Python types to Rust types offered by PyO3, as well as the traits available to perform conversions between them.
+
+See also the conversion [tables](conversions/tables.html) and [traits](conversions/traits.html).

--- a/guide/src/conversions.md
+++ b/guide/src/conversions.md
@@ -2,4 +2,4 @@
 
 In this portion of the guide we'll talk about the mapping of Python types to Rust types offered by PyO3, as well as the traits available to perform conversions between them.
 
-See also the conversion [tables](conversions/tables.html) and [traits](conversions/traits.html).
+See also the conversion [tables](conversions/tables.md) and [traits](conversions/traits.md).


### PR DESCRIPTION
I recently made an oopsie and missed the new implicit conversion of `[u8; N]` to `PyBytes` https://github.com/PyO3/pyo3/issues/4996. This was mainly due to Google showing the old page for https://pyo3.rs/v0.11.0/conversions (see https://github.com/PyO3/pyo3/issues/4855) as first search result. I simply changed the `0.11.0` part to `0.24.0` and got shown an almost empty page.

These two links are here to guide towards the additional pages relating to tables and traits such that they do not get missed as easily.