### PR TITLE
split `PyFunctionArgument` to specialize `Option`

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1390,7 +1390,7 @@ impl pyo3::PyClass for MyClass {
     type Frozen = pyo3::pyclass::boolean_struct::False;
 }
 
-impl<'a, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'py> for &'a MyClass
+impl<'a, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'py, false> for &'a MyClass
 {
     type Holder = ::std::option::Option<pyo3::PyRef<'py, MyClass>>;
 
@@ -1400,7 +1400,7 @@ impl<'a, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'py> for &'a
     }
 }
 
-impl<'a, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'py> for &'a mut MyClass
+impl<'a, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'py, false> for &'a mut MyClass
 {
     type Holder = ::std::option::Option<pyo3::PyRefMut<'py, MyClass>>;
 

--- a/newsfragments/5002.fixed.md
+++ b/newsfragments/5002.fixed.md
@@ -1,0 +1,1 @@
+Fix compile failure with required `#[pyfunction]` arguments taking `Option<&str>` and `Option<&T>` (for `#[pyclass]` types).

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2097,7 +2097,7 @@ impl<'a> PyClassImplsBuilder<'a> {
         let cls = self.cls;
         if self.attr.options.frozen.is_some() {
             quote! {
-                impl<'a, 'py> #pyo3_path::impl_::extract_argument::PyFunctionArgument<'a, 'py> for &'a #cls
+                impl<'a, 'py> #pyo3_path::impl_::extract_argument::PyFunctionArgument<'a, 'py, false> for &'a #cls
                 {
                     type Holder = ::std::option::Option<#pyo3_path::PyRef<'py, #cls>>;
 
@@ -2109,7 +2109,7 @@ impl<'a> PyClassImplsBuilder<'a> {
             }
         } else {
             quote! {
-                impl<'a, 'py> #pyo3_path::impl_::extract_argument::PyFunctionArgument<'a, 'py> for &'a #cls
+                impl<'a, 'py> #pyo3_path::impl_::extract_argument::PyFunctionArgument<'a, 'py, false> for &'a #cls
                 {
                     type Holder = ::std::option::Option<#pyo3_path::PyRef<'py, #cls>>;
 
@@ -2119,7 +2119,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     }
                 }
 
-                impl<'a, 'py> #pyo3_path::impl_::extract_argument::PyFunctionArgument<'a, 'py> for &'a mut #cls
+                impl<'a, 'py> #pyo3_path::impl_::extract_argument::PyFunctionArgument<'a, 'py, false> for &'a mut #cls
                 {
                     type Holder = ::std::option::Option<#pyo3_path::PyRefMut<'py, #cls>>;
 

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -337,3 +337,73 @@ pub(crate) fn deprecated_from_py_with(expr_path: &ExprPathWrap) -> Option<TokenS
         }
     })
 }
+
+pub(crate) trait TypeExt {
+    /// Replaces all explicit lifetimes in `self` with elided (`'_`) lifetimes
+    ///
+    /// This is useful if `Self` is used in `const` context, where explicit
+    /// lifetimes are not allowed (yet).
+    fn elide_lifetimes(self) -> Self;
+}
+
+impl TypeExt for syn::Type {
+    fn elide_lifetimes(mut self) -> Self {
+        fn elide_lifetimes(ty: &mut syn::Type) {
+            match ty {
+                syn::Type::Path(type_path) => {
+                    if let Some(qself) = &mut type_path.qself {
+                        elide_lifetimes(&mut qself.ty)
+                    }
+                    for seg in &mut type_path.path.segments {
+                        if let syn::PathArguments::AngleBracketed(args) = &mut seg.arguments {
+                            for generic_arg in &mut args.args {
+                                match generic_arg {
+                                    syn::GenericArgument::Lifetime(lt) => {
+                                        *lt = syn::Lifetime::new("'_", lt.span());
+                                    }
+                                    syn::GenericArgument::Type(ty) => elide_lifetimes(ty),
+                                    syn::GenericArgument::AssocType(assoc) => {
+                                        elide_lifetimes(&mut assoc.ty)
+                                    }
+
+                                    syn::GenericArgument::Const(_)
+                                    | syn::GenericArgument::AssocConst(_)
+                                    | syn::GenericArgument::Constraint(_)
+                                    | _ => {}
+                                }
+                            }
+                        }
+                    }
+                }
+                syn::Type::Reference(type_ref) => {
+                    if let Some(lt) = type_ref.lifetime.as_mut() {
+                        *lt = syn::Lifetime::new("'_", lt.span());
+                    }
+                    elide_lifetimes(&mut type_ref.elem);
+                }
+                syn::Type::Tuple(type_tuple) => {
+                    for ty in &mut type_tuple.elems {
+                        elide_lifetimes(ty);
+                    }
+                }
+                syn::Type::Array(type_array) => elide_lifetimes(&mut type_array.elem),
+                syn::Type::Slice(ty) => elide_lifetimes(&mut ty.elem),
+                syn::Type::Group(ty) => elide_lifetimes(&mut ty.elem),
+                syn::Type::Paren(ty) => elide_lifetimes(&mut ty.elem),
+                syn::Type::Ptr(ty) => elide_lifetimes(&mut ty.elem),
+
+                syn::Type::BareFn(_)
+                | syn::Type::ImplTrait(_)
+                | syn::Type::Infer(_)
+                | syn::Type::Macro(_)
+                | syn::Type::Never(_)
+                | syn::Type::TraitObject(_)
+                | syn::Type::Verbatim(_)
+                | _ => {}
+            }
+        }
+
+        elide_lifetimes(&mut self);
+        self
+    }
+}

--- a/src/impl_/pyclass/probes.rs
+++ b/src/impl_/pyclass/probes.rs
@@ -70,3 +70,9 @@ probe!(IsSync);
 impl<T: Sync> IsSync<T> {
     pub const VALUE: bool = true;
 }
+
+probe!(IsOption);
+
+impl<T> IsOption<Option<T>> {
+    pub const VALUE: bool = true;
+}

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -46,6 +46,45 @@ fn test_optional_bool() {
     });
 }
 
+#[pyfunction]
+#[pyo3(signature=(arg))]
+fn required_optional_str(arg: Option<&str>) -> PyResult<&str> {
+    Ok(arg.unwrap_or(""))
+}
+
+#[test]
+fn test_optional_str() {
+    // Regression test for issue #4965
+    Python::with_gil(|py| {
+        let f = wrap_pyfunction!(required_optional_str)(py).unwrap();
+
+        py_assert!(py, f, "f('') == ''");
+        py_assert!(py, f, "f('foo') == 'foo'");
+        py_assert!(py, f, "f(None) == ''");
+    });
+}
+
+#[pyclass]
+struct MyClass();
+
+#[pyfunction]
+#[pyo3(signature=(arg))]
+fn required_optional_class(arg: Option<&MyClass>) {
+    let _ = arg;
+}
+
+#[test]
+fn test_required_optional_class() {
+    // Regression test for issue #4965
+    Python::with_gil(|py| {
+        let f = wrap_pyfunction!(required_optional_class)(py).unwrap();
+        let val = Bound::new(py, MyClass()).unwrap();
+
+        py_assert!(py, f val, "f(val) is None");
+        py_assert!(py, f, "f(None) is None");
+    });
+}
+
 #[cfg(not(Py_LIMITED_API))]
 #[pyfunction]
 fn buffer_inplace_add(py: Python<'_>, x: PyBuffer<i32>, y: PyBuffer<i32>) {

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -48,8 +48,8 @@ fn test_optional_bool() {
 
 #[pyfunction]
 #[pyo3(signature=(arg))]
-fn required_optional_str(arg: Option<&str>) -> PyResult<&str> {
-    Ok(arg.unwrap_or(""))
+fn required_optional_str(arg: Option<&str>) -> &str {
+    arg.unwrap_or("")
 }
 
 #[test]

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -38,7 +38,7 @@ note: function defined here
    |          ^^^^^^^^^^^^^^^^^^^^^^^^                        --------------
    = note: this error originates in the attribute macro `pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_>` is not satisfied
+error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, false>` is not satisfied
   --> tests/ui/invalid_cancel_handle.rs:20:50
    |
 20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
@@ -47,35 +47,35 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_>` is not 
    = help: the trait `PyClass` is implemented for `pyo3::coroutine::Coroutine`
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_>`
+   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, false>`
 note: required by a bound in `extract_argument`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_argument<'a, 'py, T>(
+   | pub fn extract_argument<'a, 'py, T, const IS_OPTION: bool>(
    |        ---------------- required by a bound in this function
 ...
-   |     T: PyFunctionArgument<'a, 'py>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+   |     T: PyFunctionArgument<'a, 'py, IS_OPTION>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
 
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_>` is not satisfied
+error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, false>` is not satisfied
   --> tests/ui/invalid_cancel_handle.rs:20:50
    |
 20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
    |                                                  ^^^^ the trait `Clone` is not implemented for `CancelHandle`
    |
-   = help: the following other types implement trait `PyFunctionArgument<'a, 'py>`:
-             &'a mut pyo3::coroutine::Coroutine
-             &'a pyo3::Bound<'py, T>
-             &'a pyo3::coroutine::Coroutine
-             Option<&'a pyo3::Bound<'py, T>>
+   = help: the following other types implement trait `PyFunctionArgument<'a, 'py, IS_OPTION>`:
+             `&'a mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'py, false>`
+             `&'a pyo3::Bound<'py, T>` implements `PyFunctionArgument<'a, 'py, false>`
+             `&'a pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'py, false>`
+             `Option<T>` implements `PyFunctionArgument<'a, 'py, true>`
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_>`
+   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, false>`
 note: required by a bound in `extract_argument`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_argument<'a, 'py, T>(
+   | pub fn extract_argument<'a, 'py, T, const IS_OPTION: bool>(
    |        ---------------- required by a bound in this function
 ...
-   |     T: PyFunctionArgument<'a, 'py>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+   |     T: PyFunctionArgument<'a, 'py, IS_OPTION>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`


### PR DESCRIPTION
Adds const generic parameter to `PyFunctionArgument` to allow specialization. This allows `Option` wrapped extraction of some types that can't implement `FromPyObject(Bound)` because they require a `holder` to borrow from, most notably `&T` for `T: PyClass`.

- requires modifying the argument types, to elide lifetimes
- only works for "outest" `Option`, inner `Option`s will use the `FromPyObject` impl

ToDo:
- [x] add some tests

Closes #4965