### PR TITLE
replace quansight-labs/setup-python with actions/setup-python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,8 +592,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src
-      # TODO: replace with actions/setup-python when there is support
-      - uses: quansight-labs/setup-python@v5.4.0
+      - uses: actions/setup-python@v5.5.0
         with:
           python-version: "3.13t"
       - name: Install cargo-llvm-cov


### PR DESCRIPTION
The changes in the fork were upstreamed and released in 5.5.0. See https://github.com/actions/setup-python/releases/tag/v5.5.0.