### PR TITLE
fix: convert to cstrings in PyString::from_object

### DIFF
--- a/newsfragments/5008.fixed.md
+++ b/newsfragments/5008.fixed.md
@@ -1,0 +1,1 @@
+Fix `PyString::from_object`, avoid out of bounds reads by null terminating the `encoding` and `errors` parameters


### PR DESCRIPTION
fixes #5005

This only fixes the API, and adds a test of the API, it does not deprecate the API or introduce a version which takes `&CStr` directly, this can be done later.