### PR TITLE
fix `#[pyfunction]` option parsing

### DIFF
--- a/newsfragments/5015.fixed.md
+++ b/newsfragments/5015.fixed.md
@@ -1,0 +1,1 @@
+Fixes compile error if more options followed after `crate` for `#[pyfunction]`.

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -94,9 +94,8 @@ impl Parse for PyFunctionOptions {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let mut options = PyFunctionOptions::default();
 
-        for option in Punctuated::<PyFunctionOption, syn::Token![,]>::parse_terminated(input)? {
-            options.add_attributes([option])?;
-        }
+        let attrs = Punctuated::<PyFunctionOption, syn::Token![,]>::parse_terminated(input)?;
+        options.add_attributes(attrs)?;
 
         Ok(options)
     }

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -9,11 +9,9 @@ use crate::{
 };
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
 use syn::{ext::IdentExt, spanned::Spanned, Result};
-use syn::{
-    parse::{Parse, ParseStream},
-    token::Comma,
-};
 
 mod signature;
 
@@ -96,23 +94,8 @@ impl Parse for PyFunctionOptions {
     fn parse(input: ParseStream<'_>) -> Result<Self> {
         let mut options = PyFunctionOptions::default();
 
-        while !input.is_empty() {
-            let lookahead = input.lookahead1();
-            if lookahead.peek(attributes::kw::name)
-                || lookahead.peek(attributes::kw::pass_module)
-                || lookahead.peek(attributes::kw::signature)
-                || lookahead.peek(attributes::kw::text_signature)
-            {
-                options.add_attributes(std::iter::once(input.parse()?))?;
-                if !input.is_empty() {
-                    let _: Comma = input.parse()?;
-                }
-            } else if lookahead.peek(syn::Token![crate]) {
-                // TODO needs duplicate check?
-                options.krate = Some(input.parse()?);
-            } else {
-                return Err(lookahead.error());
-            }
+        for option in Punctuated::<PyFunctionOption, syn::Token![,]>::parse_terminated(input)? {
+            options.add_attributes([option])?;
         }
 
         Ok(options)

--- a/src/tests/hygiene/pyfunction.rs
+++ b/src/tests/hygiene/pyfunction.rs
@@ -4,6 +4,12 @@ fn do_something(x: i32) -> crate::PyResult<i32> {
     ::std::result::Result::Ok(x)
 }
 
+#[crate::pyfunction]
+#[pyo3(crate = "crate", name = "check5012")]
+fn check_5012(x: i32) -> crate::PyResult<i32> {
+    ::std::result::Result::Ok(x)
+}
+
 #[test]
 fn invoke_wrap_pyfunction() {
     crate::Python::with_gil(|py| {


### PR DESCRIPTION
We did not consume the "," after the `crate` option, so it could only be used as the last one.

Closes #5012
