### PR TITLE
Simplify PyFunctionArgument impl on &Bound<T>

### DIFF
--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -41,10 +41,10 @@ impl<'a, 'py, T: 'py> PyFunctionArgument<'a, 'py> for &'a Bound<'py, T>
 where
     T: PyTypeCheck,
 {
-    type Holder = Option<()>;
+    type Holder = ();
 
     #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, _: &'a mut Option<()>) -> PyResult<Self> {
+    fn extract(obj: &'a Bound<'py, PyAny>, _: &'a mut ()) -> PyResult<Self> {
         obj.downcast().map_err(Into::into)
     }
 }


### PR DESCRIPTION
The default `Holder`works well