### PR TITLE
ci: mark many rust code blocks as no_run

### DIFF
--- a/guide/src/async-await.md
+++ b/guide/src/async-await.md
@@ -4,7 +4,7 @@
 
 `#[pyfunction]` and `#[pymethods]` attributes also support `async fn`.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # #[cfg(feature = "experimental-async")] {
 use std::{thread, time::Duration};
@@ -77,7 +77,7 @@ where
 
 Cancellation on the Python side can be caught using [`CancelHandle`]({{#PYO3_DOCS_URL}}/pyo3/coroutine/struct.CancelHandle.html) type, by annotating a function parameter with `#[pyo3(cancel_handle)]`.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # #[cfg(feature = "experimental-async")] {
 use futures::FutureExt;

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -788,7 +788,7 @@ impl MyClass {
 To create a class attribute (also called [class variable][classattr]), a method without
 any arguments can be annotated with the `#[classattr]` attribute.
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 # #[pyclass]
 # struct MyClass {}
@@ -812,7 +812,7 @@ class creation.
 If the class attribute is defined with `const` code only, one can also annotate associated
 constants:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 # #[pyclass]
 # struct MyClass {}
@@ -827,7 +827,7 @@ impl MyClass {
 
 Free functions defined using `#[pyfunction]` interact with classes through the same mechanisms as the self parameters of instance methods, i.e. they can take GIL-bound references, GIL-bound reference wrappers or GIL-indepedent references:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 #[pyclass]
@@ -866,7 +866,7 @@ fn print_refcnt(my_class: Py<MyClass>, py: Python<'_>) {
 
 Classes can also be passed by value if they can be cloned, i.e. they automatically implement `FromPyObject` if they implement `Clone`, e.g. via `#[derive(Clone)]`:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 #[pyclass]
@@ -890,7 +890,7 @@ Similar to `#[pyfunction]`, the `#[pyo3(signature = (...))]` attribute can be us
 
 The following example defines a class `MyClass` with a method `method`. This method has a signature that sets default values for `num` and `name`, and indicates that `py_args` should collect all extra positional arguments and `py_kwargs` all extra keyword arguments:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 #

--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -31,7 +31,7 @@ own extraction function, using the `#[pyo3(from_py_with = ...)]` attribute. Unfo
 doesn't provide a way to wrap Python integers out of the box, but we can do a Python call to mask it
 and cast it to an `i32`.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 use pyo3::prelude::*;
 
@@ -44,7 +44,7 @@ fn wrap(obj: &Bound<'_, PyAny>) -> PyResult<i32> {
 ```
 We also add documentation, via `///` comments, which are visible to Python users.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 use pyo3::prelude::*;
 
@@ -70,7 +70,7 @@ impl Number {
 
 
 With that out of the way, let's implement some operators:
-```rust
+```rust,no_run
 use pyo3::exceptions::{PyZeroDivisionError, PyValueError};
 
 # use pyo3::prelude::*;
@@ -124,7 +124,7 @@ impl Number {
 
 ### Unary arithmetic operations
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #
 # #[pyclass]
@@ -152,7 +152,7 @@ impl Number {
 
 ### Support for the `complex()`, `int()` and `float()` built-in functions.
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #
 # #[pyclass]
@@ -415,7 +415,7 @@ Let's create that helper function. The signature has to be `fn(&Bound<'_, PyAny>
 - `&Bound<'_, PyAny>` represents a checked borrowed reference, so the pointer derived from it is valid (and not null).
 - Whenever we have borrowed references to Python objects in scope, it is guaranteed that the GIL is held. This reference is also where we can get a [`Python`] token to use in our call to [`PyErr::take`].
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 use std::os::raw::c_ulong;
 use pyo3::prelude::*;

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -2,7 +2,7 @@
 
 Recall the `Number` class from the previous chapter:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 use pyo3::prelude::*;
 
@@ -44,7 +44,7 @@ It can't even print an user-readable representation of itself! We can fix that b
 `__repr__` and `__str__` methods inside a `#[pymethods]` block. We do this by accessing the value
 contained inside `Number`.
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #
 # #[pyclass]
@@ -72,7 +72,7 @@ impl Number {
 
 To automatically generate the `__str__` implementation using a `Display` trait implementation, pass the `str` argument to `pyclass`.
 
-```rust
+```rust,no_run
 # use std::fmt::{Display, Formatter};
 # use pyo3::prelude::*;
 #
@@ -91,16 +91,16 @@ impl Display for Coordinate {
 }
 ```
 
-For convenience, a shorthand format string can be passed to `str` as `str="<format string>"` for **structs only**.  It expands and is passed into the `format!` macro in the following ways:  
+For convenience, a shorthand format string can be passed to `str` as `str="<format string>"` for **structs only**.  It expands and is passed into the `format!` macro in the following ways:
 
 * `"{x}"` -> `"{}", self.x`
 * `"{0}"` -> `"{}", self.0`
 * `"{x:?}"` -> `"{:?}", self.x`
 
-*Note: Depending upon the format string you use, this may require implementation of the `Display` or `Debug` traits for the given Rust types.*  
+*Note: Depending upon the format string you use, this may require implementation of the `Display` or `Debug` traits for the given Rust types.*
 *Note: the pyclass args `name` and `rename_all` are incompatible with the shorthand format string and will raise a compile time error.*
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #
 # #[allow(dead_code)]
@@ -120,7 +120,7 @@ the subclass name. This is typically done in Python code by accessing
 `self.__class__.__name__`. In order to be able to access the Python type information
 *and* the Rust struct, we need to use a `Bound` as the `self` argument.
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 # use pyo3::types::PyString;
 #
@@ -145,7 +145,7 @@ impl Number {
 Let's also implement hashing. We'll just hash the `i32`. For that we need a [`Hasher`]. The one
 provided by `std` is [`DefaultHasher`], which uses the [SipHash] algorithm.
 
-```rust
+```rust,no_run
 use std::collections::hash_map::DefaultHasher;
 
 // Required to call the `.hash` and `.finish` methods, which are defined on traits.
@@ -171,7 +171,7 @@ This option is only available for `frozen` classes to prevent accidental hash ch
 an `__hash__` implementation for a mutable class, use the manual method from above. This option also requires `eq`: According to the
 [Python docs](https://docs.python.org/3/reference/datamodel.html#object.__hash__) "If a class does not define an `__eq__()`
 method it should not define a `__hash__()` operation either"
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #
 # #[allow(dead_code)]
@@ -195,7 +195,7 @@ struct Number(i32);
 > Types which should not be hashable can override this by setting `__hash__` to None.
 > This is the same mechanism as for a pure-Python class. This is done like so:
 >
-> ```rust
+> ```rust,no_run
 > # use pyo3::prelude::*;
 > #[pyclass]
 > struct NotHashable {}
@@ -213,7 +213,7 @@ PyO3 supports the usual magic comparison methods available in Python such as `__
 and so on. It is also possible to support all six operations at once with `__richcmp__`.
 This method will be called with a value of `CompareOp` depending on the operation.
 
-```rust
+```rust,no_run
 use pyo3::class::basic::CompareOp;
 
 # use pyo3::prelude::*;
@@ -240,7 +240,7 @@ impl Number {
 If you obtain the result by comparing two Rust values, as in this example, you
 can take a shortcut using `CompareOp::matches`:
 
-```rust
+```rust,no_run
 use pyo3::class::basic::CompareOp;
 
 # use pyo3::prelude::*;
@@ -289,7 +289,7 @@ impl Number {
 
 To implement `__eq__` using the Rust [`PartialEq`] trait implementation, the `eq` option can be used.
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #
 # #[allow(dead_code)]
@@ -300,7 +300,7 @@ struct Number(i32);
 
 To implement `__lt__`, `__le__`, `__gt__`, & `__ge__` using the Rust `PartialOrd` trait implementation, the `ord` option can be used. *Note: Requires `eq`.*
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #
 # #[allow(dead_code)]
@@ -313,7 +313,7 @@ struct Number(i32);
 
 We'll consider `Number` to be `True` if it is nonzero:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #
 # #[allow(dead_code)]
@@ -330,7 +330,7 @@ impl Number {
 
 ### Final code
 
-```rust
+```rust,no_run
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -50,7 +50,7 @@ given signatures should be interpreted as follows:
     <summary>Disabling Python's default hash</summary>
     By default, all `#[pyclass]` types have a default hash implementation from Python. Types which should not be hashable can override this by setting `__hash__` to `None`. This is the same mechanism as for a pure-Python class. This is done like so:
 
-    ```rust
+    ```rust,no_run
     # use pyo3::prelude::*;
     #
     #[pyclass]
@@ -95,7 +95,7 @@ given signatures should be interpreted as follows:
     If you want to leave some operations unimplemented, you can return `py.NotImplemented()`
     for some of the operations:
 
-    ```rust
+    ```rust,no_run
     use pyo3::class::basic::CompareOp;
     use pyo3::types::PyNotImplemented;
 
@@ -155,7 +155,7 @@ Returning `None` from `__next__` indicates that that there are no further items.
 
 Example:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 use std::sync::Mutex;
@@ -181,7 +181,7 @@ In many cases you'll have a distinction between the type being iterated over
 only needs to implement `__iter__()` while the iterator must implement both
 `__iter__()` and `__next__()`. For example:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 
 #[pyclass]
@@ -274,7 +274,7 @@ Use the `#[pyclass(sequence)]` annotation to instruct PyO3 to fill the `sq_lengt
     can override this by setting `__contains__` to `None`. This is the same
     mechanism as for a pure-Python class. This is done like so:
 
-    ```rust
+    ```rust,no_run
     # use pyo3::prelude::*;
     #
     #[pyclass]
@@ -430,7 +430,7 @@ cleared, as every cycle must contain at least one mutable reference.
 
 Example:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 use pyo3::PyTraverseError;
 use pyo3::gc::PyVisit;

--- a/guide/src/class/thread-safety.md
+++ b/guide/src/class/thread-safety.md
@@ -16,7 +16,7 @@ By default, `#[pyclass]` employs an ["interior mutability" pattern](../class.md#
 
 For example, the below simple class is thread-safe:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 
 #[pyclass]
@@ -47,7 +47,7 @@ To remove the possibility of having overlapping `&self` and `&mut self` referenc
 
 For example, a thread-safe version of the above `MyClass` using atomic integers would be as follows:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 use std::sync::atomic::{AtomicI32, Ordering};
 
@@ -75,7 +75,7 @@ An alternative to atomic data structures is to use [locks](https://doc.rust-lang
 
 For example, a thread-safe version of the above `MyClass` using locks would be as follows:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 use std::sync::Mutex;
 

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -550,7 +550,7 @@ _without_ having a unique python type.
 
 `struct`s will turn into a `PyDict` using the field names as keys, tuple `struct`s will turn convert
 into `PyTuple` with the fields in declaration order.
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use std::collections::HashMap;
@@ -574,7 +574,7 @@ For structs with a single field (newtype pattern) the `#[pyo3(transparent)]` opt
 forward the implementation to the inner type.
 
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 
@@ -591,7 +591,7 @@ struct TransparentStruct<'py> {
 
 For `enum`s each variant is converted according to the rules for `struct`s above.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use std::collections::HashMap;
@@ -618,7 +618,7 @@ Additionally `IntoPyObject` can be derived for a reference to a struct or enum u
       - `#[derive(IntoPyObject)]` will invoke the function with `Cow::Owned`
       - `#[derive(IntoPyObjectRef)]` will invoke the function with `Cow::Borrowed`
 
-    ```rust
+    ```rust,no_run
     # use pyo3::prelude::*;
     # use pyo3::IntoPyObjectExt;
     # use std::borrow::Cow;
@@ -642,7 +642,7 @@ Additionally `IntoPyObject` can be derived for a reference to a struct or enum u
 If the derive macro is not suitable for your use case, `IntoPyObject` can be implemented manually as
 demonstrated below.
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 # #[allow(dead_code)]
 struct MyPyObjectWrapper(PyObject);
@@ -673,7 +673,7 @@ impl<'a, 'py> IntoPyObject<'py> for &'a MyPyObjectWrapper {
 
 `IntoPyObject::into_py_object` returns either `Bound` or `Borrowed` depending on the implementation for a concrete type. For example, the `IntoPyObject` implementation for `u32` produces a `Bound<'py, PyInt>` and the `bool` implementation produces a `Borrowed<'py, 'py, PyBool>`:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 use pyo3::IntoPyObject;
 use pyo3::types::{PyBool, PyInt};
@@ -700,7 +700,7 @@ In this example if we wanted to combine `ints_as_pyints` and `bools_as_pybool` i
 
 Instead, we can write a function that generically converts vectors of either integers or bools into a vector of `Py<PyAny>` using the [`BoundObject`] trait:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 # use pyo3::BoundObject;
 # use pyo3::IntoPyObject;
@@ -757,7 +757,7 @@ All types in PyO3 implement this trait, as does a `#[pyclass]` which doesn't use
 Occasionally you may choose to implement this for custom types which are mapped to Python types
 _without_ having a unique python type.
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 # #[allow(dead_code)]
 struct MyPyObjectWrapper(PyObject);

--- a/guide/src/ecosystem/logging.md
+++ b/guide/src/ecosystem/logging.md
@@ -18,7 +18,7 @@ Python programs.
 Use [`pyo3_log::init`][init] to install the logger in its default configuration.
 It's also possible to tweak its configuration (mostly to tune its performance).
 
-```rust
+```rust,no_run
 use log::info;
 use pyo3::prelude::*;
 
@@ -61,7 +61,7 @@ To have python logs be handled by Rust, one need only register a rust function t
 
 This has been implemented within the [pyo3-pylogger] crate.
 
-```rust
+```rust,no_run
 use log::{info, warn};
 use pyo3::prelude::*;
 

--- a/guide/src/ecosystem/tracing.md
+++ b/guide/src/ecosystem/tracing.md
@@ -37,7 +37,7 @@ implementation defined in and passed in from Python.
 
 There are many ways an extension module could integrate `pyo3-python-tracing-subscriber`
 but a simple one may look something like this:
-```rust
+```rust,no_run
 #[tracing::instrument]
 #[pyfunction]
 fn fibonacci(index: usize, use_memoized: bool) -> PyResult<usize> {

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -40,7 +40,7 @@ Python::with_gil(|py| {
 When using PyO3 to create an extension module, you can add the new exception to
 the module like this, so that it is importable from Python:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 use pyo3::exceptions::PyException;
 
@@ -77,7 +77,7 @@ Python::with_gil(|py| {
 Python has an [`isinstance`](https://docs.python.org/3/library/functions.html#isinstance) method to check an object's type.
 In PyO3 every object has the [`PyAny::is_instance`] and [`PyAny::is_instance_of`] methods which do the same thing.
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyList};
 
@@ -94,7 +94,7 @@ Python::with_gil(|py| {
 
 To check the type of an exception, you can similarly do:
 
-```rust
+```rust,no_run
 # use pyo3::exceptions::PyTypeError;
 # use pyo3::prelude::*;
 # Python::with_gil(|py| {
@@ -109,7 +109,7 @@ It is possible to use an exception defined in Python code as a native Rust type.
 The `import_exception!` macro allows importing a specific exception class and defines a Rust type
 for that exception.
 
-```rust
+```rust,no_run
 #![allow(dead_code)]
 use pyo3::prelude::*;
 

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -86,7 +86,7 @@ You can give the Python interpreter a chance to process the signal properly by c
 
 You may have a nested struct similar to this:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #[pyclass]
 #[derive(Clone)]
@@ -126,7 +126,7 @@ b: <builtins.Inner object at 0x00000238FFB9C830>
 This can be especially confusing if the field is mutable, as getting the field and then mutating it won't persist - you'll just get a fresh clone of the original on the next access. Unfortunately Python and Rust don't agree about ownership - if PyO3 gave out references to (possibly) temporary Rust objects to Python code, Python code could then keep that reference alive indefinitely. Therefore returning Rust objects requires cloning.
 
 If you don't want that cloning to happen, a workaround is to allocate the field on the Python heap and store a reference to that, by using [`Py<...>`]({{#PYO3_DOCS_URL}}/pyo3/struct.Py.html):
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #[pyclass]
 struct Inner {/* fields omitted */}
@@ -179,7 +179,7 @@ However, when the dependency is renamed, or your crate only indirectly depends
 on `pyo3`, you need to let the macro code know where to find the crate.  This is
 done with the `crate` attribute:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 # pub extern crate pyo3;
 # mod reexported { pub use ::pyo3; }

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -184,7 +184,7 @@ Adds a dependency on [rust_decimal](https://docs.rs/rust_decimal) and enables co
 Enables (de)serialization of `Py<T>` objects via [serde](https://serde.rs/).
 This allows to use [`#[derive(Serialize, Deserialize)`](https://serde.rs/derive.html) on structs that hold references to `#[pyclass]` instances
 
-```rust
+```rust,no_run
 # #[cfg(feature = "serde")]
 # #[allow(dead_code)]
 # mod serde_only {

--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -72,7 +72,7 @@ thread-safe, then pass `gil_used = false` as a parameter to the
 `pymodule` procedural macro declaring the module or call
 `PyModule::gil_used` on a `PyModule` instance.  For example:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 /// This module supports free-threaded Python
@@ -85,7 +85,7 @@ fn my_extension(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 Or for a module that is set up without using the `pymodule` macro:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 # #[allow(dead_code)]
@@ -208,9 +208,8 @@ The most straightforward way to trigger this problem is to use the Python
 [`pyclass`]({{#PYO3_DOCS_URL}}/pyo3/attr.pyclass.html) in multiple threads. For
 example, consider the following implementation:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
-# fn main() {
 #[pyclass]
 #[derive(Default)]
 struct ThreadIter {
@@ -229,7 +228,6 @@ impl ThreadIter {
         self.count
     }
 }
-# }
 ```
 
 And then if we do something like this in Python:
@@ -309,7 +307,6 @@ extension traits. Here is an example of how to use [`OnceExt`] to
 enable single-initialization of a runtime cache holding a `Py<PyDict>`.
 
 ```rust
-# fn main() {
 # use pyo3::prelude::*;
 use std::sync::Once;
 use pyo3::sync::OnceExt;
@@ -331,7 +328,6 @@ Python::with_gil(|py| {
         cache.cache = Some(PyDict::new(py).unbind());
     });
 });
-# }
 ```
 
 ### `GILProtected` is not exposed

--- a/guide/src/function.md
+++ b/guide/src/function.md
@@ -4,7 +4,7 @@ The `#[pyfunction]` attribute is used to define a Python function from a Rust fu
 
 The following example defines a function called `double` in a Python module called `my_extension`:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -79,7 +79,7 @@ The `#[pyo3]` attribute can be used to modify properties of the generated Python
 
     The following example creates a function `pyfunction_with_module` which returns the containing module's name (i.e. `module_with_fn`):
 
-    ```rust
+    ```rust,no_run
     use pyo3::prelude::*;
     use pyo3::types::PyString;
 
@@ -174,7 +174,7 @@ annotated with `#[pyfn]`. To simplify PyO3, it is expected that `#[pyfn]` may be
 
 An example of `#[pyfn]` is below:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 #[pymodule]
@@ -191,7 +191,7 @@ fn my_extension(m: &Bound<'_, PyModule>) -> PyResult<()> {
 `#[pyfn(m)]` is just syntactic sugar for `#[pyfunction]`, and takes all the same options
 documented in the rest of this chapter. The code above is expanded to the following:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 #[pymodule]

--- a/guide/src/function/signature.md
+++ b/guide/src/function/signature.md
@@ -10,7 +10,7 @@ This section of the guide goes into detail about use of the `#[pyo3(signature = 
 
 For example, below is a function that accepts arbitrary keyword arguments (`**kwargs` in Python syntax) and returns the number that was passed:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -38,7 +38,7 @@ Just like in Python, the following constructs can be part of the signature::
    code unmodified.
 
 Example:
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 #
@@ -79,7 +79,7 @@ impl MyClass {
 
 Arguments of type `Python` must not be part of the signature:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 #[pyfunction]
@@ -108,7 +108,7 @@ num=-1
 
 > Note: to use keywords like `struct` as a function argument, use "raw identifier" syntax `r#struct` in both the signature and the function definition:
 >
-> ```rust
+> ```rust,no_run
 > # #![allow(dead_code)]
 > # use pyo3::prelude::*;
 > #[pyfunction(signature = (r#struct = "foo"))]

--- a/guide/src/getting-started.md
+++ b/guide/src/getting-started.md
@@ -145,7 +145,7 @@ classifiers = [
 
 After this you can setup Rust code to be available in Python as below; for example, you can place this code in `src/lib.rs`:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 /// Formats the sum of two numbers as string.

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -70,7 +70,7 @@ are deprecated and will be removed in a future PyO3 version.
 
 To implement the new trait you may use the new `IntoPyObject` and `IntoPyObjectRef` derive macros as below.
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #[derive(IntoPyObject, IntoPyObjectRef)]
 struct Struct {
@@ -103,7 +103,7 @@ impl ToPyObject for MyPyObjectWrapper {
 ```
 
 After:
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 # #[allow(dead_code)]
 # struct MyPyObjectWrapper(PyObject);
@@ -145,7 +145,7 @@ This change has an effect on functions and methods returning _byte_ collections 
 In their new `IntoPyObject` implementation these will now turn into `PyBytes` rather than a
 `PyList`. All other `T`s are unaffected and still convert into a `PyList`.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 #[pyfunction]
@@ -237,7 +237,7 @@ where
 
 After:
 
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 # use pyo3::types::{PyDict, IntoPyDict};
 # use std::collections::HashMap;
@@ -282,7 +282,7 @@ and unnoticed changes in behavior. With 0.24 this restriction will be lifted aga
 
 Before:
 
-```rust
+```rust,no_run
 # #![allow(deprecated, dead_code)]
 # use pyo3::prelude::*;
 #[pyfunction]
@@ -293,7 +293,7 @@ fn increment(x: u64, amount: Option<u64>) -> u64 {
 
 After:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 #[pyfunction]
@@ -326,7 +326,7 @@ To migrate, place a `#[pyo3(eq, eq_int)]` attribute on simple enum classes.
 
 Before:
 
-```rust
+```rust,no_run
 # #![allow(deprecated, dead_code)]
 # use pyo3::prelude::*;
 #[pyclass]
@@ -338,7 +338,7 @@ enum SimpleEnum {
 
 After:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 #[pyclass(eq, eq_int)]
@@ -528,7 +528,7 @@ impl PyClassIter {
 
 If returning `"done"` via `StopIteration` is not really required, this should be written as
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 #[pyclass]
@@ -553,7 +553,7 @@ This form also has additional benefits: It has already worked in previous PyO3 v
 
 Alternatively, the implementation can also be done as it would in Python itself, i.e. by "raising" a `StopIteration` exception
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 use pyo3::exceptions::PyStopIteration;
 
@@ -577,7 +577,7 @@ impl PyClassIter {
 
 Finally, an asynchronous iterator can directly return an awaitable without confusing wrapping
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 #[pyclass]
@@ -885,7 +885,7 @@ fn x_or_y(x: Option<u64>, y: u64) -> u64 {
 
 After:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 
@@ -915,7 +915,7 @@ fn add(a: u64, b: u64) -> u64 {
 
 After:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 
@@ -1105,7 +1105,7 @@ fn required_argument_after_option(x: Option<i32>, y: i32) {}
 
 After, specify the intended Python signature explicitly:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 
@@ -1553,7 +1553,7 @@ impl PyObjectProtocol for MyClass {
 
 After:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 #[pyclass]
@@ -1646,7 +1646,7 @@ let result: PyResult<()> = PyErr::new::<TypeError, _>("error message").into();
 ```
 
 After (also using the new reworked exception types; see the following section):
-```rust
+```rust,no_run
 # use pyo3::{PyResult, exceptions::PyTypeError};
 let result: PyResult<()> = Err(PyTypeError::new_err("error message"));
 ```
@@ -1712,7 +1712,7 @@ impl FromPy<MyPyObjectWrapper> for PyObject {
 ```
 
 After
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 # #[allow(dead_code)]
 struct MyPyObjectWrapper(PyObject);
@@ -1736,7 +1736,7 @@ let obj = PyObject::from_py(1.234, py);
 ```
 
 After:
-```rust
+```rust,no_run
 # #![allow(deprecated)]
 # use pyo3::prelude::*;
 # Python::with_gil(|py| {
@@ -1853,7 +1853,7 @@ There can be two fixes:
    ```
 
    After:
-   ```rust
+   ```rust,no_run
    # #![allow(dead_code)]
    use pyo3::prelude::*;
 
@@ -1951,7 +1951,7 @@ impl MyClass {
 ```
 
 After:
-```rust
+```rust,no_run
 # use pyo3::prelude::*;
 #[pyclass]
 struct MyClass {}

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -2,7 +2,7 @@
 
 You can create a module using `#[pymodule]`:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -23,7 +23,7 @@ module to Python.
 The module's name defaults to the name of the Rust function. You can override the module name by
 using `#[pyo3(name = "custom_name")]`:
 
-```rust
+```rust,no_run
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -108,7 +108,7 @@ It is not necessary to add `#[pymodule]` on nested modules, which is only requir
 Another syntax based on Rust inline modules is also available to declare modules.
 
 For example:
-```rust
+```rust,no_run
 # mod declarative_module_test {
 use pyo3::prelude::*;
 
@@ -151,7 +151,7 @@ For nested modules, the name of the parent module is automatically added.
 In the following example, the `Unit` class will have for `module` `my_extension.submodule` because it is properly nested
 but the `Ext` class will have for `module` the default `builtins` because it not nested.
 
-```rust
+```rust,no_run
 # mod declarative_module_module_attr_test {
 use pyo3::prelude::*;
 

--- a/guide/src/performance.md
+++ b/guide/src/performance.md
@@ -6,7 +6,7 @@ To achieve the best possible performance, it is useful to be aware of several tr
 
 Pythonic API implemented using PyO3 are often polymorphic, i.e. they will accept `&Bound<'_, PyAny>` and try to turn this into multiple more concrete types to which the requested operation is applied. This often leads to chains of calls to `extract`, e.g.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::{exceptions::PyTypeError, types::PyList};
@@ -33,7 +33,7 @@ fn frobnicate<'py>(value: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
 
 This suboptimal as the `FromPyObject<T>` trait requires `extract` to have a `Result<T, PyErr>` return type. For native types like `PyList`, it faster to use `downcast` (which `extract` calls internally) when the error value is ignored. This avoids the costly conversion of a `PyDowncastError` to a `PyErr` required to fulfil the `FromPyObject` contract, i.e.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::{exceptions::PyTypeError, types::PyList};
@@ -59,7 +59,7 @@ Calling `Python::with_gil` is effectively a no-op when the GIL is already held, 
 
 For example, instead of writing
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
@@ -80,7 +80,7 @@ impl PartialEq<Foo> for FooBound<'_> {
 
 use the more efficient
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;

--- a/guide/src/trait-bounds.md
+++ b/guide/src/trait-bounds.md
@@ -22,7 +22,7 @@ Let's work with the following basic example of an implementation of a optimizati
 Let's say we have a function `solve` that operates on a model and mutates its state.
 The argument of the function can be any model that implements the `Model` trait :
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 pub trait Model {
     fn set_variables(&mut self, inputs: &Vec<f64>);
@@ -63,7 +63,7 @@ class Model:
 
 The following wrapper will call the Python model from Rust, using a struct to hold the model as a `PyAny` object:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 use pyo3::prelude::*;
 use pyo3::types::PyList;
@@ -116,7 +116,7 @@ impl Model for UserModel {
 Now that this bit is implemented, let's expose the model wrapper to Python.
 Let's add the PyO3 annotations and add a constructor:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # pub trait Model {
 #   fn set_variables(&mut self, inputs: &Vec<f64>);
@@ -161,7 +161,7 @@ That's a bummer!
 However, we can write a second wrapper around these functions to call them directly.
 This wrapper will also perform the type conversions between Python and Rust.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
@@ -328,7 +328,7 @@ Let's modify the code performing the type conversion to give a helpful error mes
 
 We used in our `get_results` method the following call that performs the type conversion:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
@@ -379,7 +379,7 @@ impl Model for UserModel {
 
 Let's break it down in order to perform better error handling:
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
@@ -456,7 +456,7 @@ Because of this, we can write a function wrapper that takes the `UserModel`--whi
 
 It is also required to make the struct public.
 
-```rust
+```rust,no_run
 # #![allow(dead_code)]
 use pyo3::prelude::*;
 use pyo3::types::PyList;

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1146,7 +1146,7 @@ impl FromStr for BuildFlag {
 /// PyO3 will pick these up and pass to rustc via `--cfg=py_sys_config={varname}`;
 /// this allows using them conditional cfg attributes in the .rs files, so
 ///
-/// ```rust
+/// ```rust,no_run
 /// #[cfg(py_sys_config="{varname}")]
 /// # struct Foo;
 /// ```

--- a/pyo3-ffi/README.md
+++ b/pyo3-ffi/README.md
@@ -65,7 +65,7 @@ fn main() {
 ```
 
 **`src/lib.rs`**
-```rust
+```rust,no_run
 use std::os::raw::{c_char, c_long};
 use std::ptr;
 

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -129,7 +129,7 @@
 //! ```
 //!
 //! **`src/lib.rs`**
-//! ```rust
+//! ```rust,no_run
 //! use std::os::raw::{c_char, c_long};
 //! use std::ptr;
 //!
@@ -356,7 +356,7 @@ macro_rules! opaque_struct {
 ///
 /// Examples:
 ///
-/// ```rust
+/// ```rust,no_run
 /// use std::ffi::CStr;
 ///
 /// const HELLO: &CStr = pyo3_ffi::c_str!("hello");

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -87,7 +87,7 @@ pub trait ToPyObject {
 /// The easiest way to implement `IntoPy` is by exposing a struct as a native Python object
 /// by annotating it with [`#[pyclass]`](crate::prelude::pyclass).
 ///
-/// ```rust
+/// ```rust,no_run
 /// use pyo3::prelude::*;
 ///
 /// # #[allow(dead_code)]
@@ -103,7 +103,7 @@ pub trait ToPyObject {
 ///
 /// However, it may not be desirable to expose the existence of `Number` to Python code.
 /// `IntoPy` allows us to define a conversion to an appropriate Python object.
-/// ```rust
+/// ```rust,no_run
 /// #![allow(deprecated)]
 /// use pyo3::prelude::*;
 ///

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -21,7 +21,7 @@
 //! Using [`BigInt`] to correctly increment an arbitrary precision integer.
 //! This is not possible with Rust's native integers if the Python integer is too large,
 //! in which case it will fail its conversion and raise `OverflowError`.
-//! ```rust
+//! ```rust,no_run
 //! use num_bigint::BigInt;
 //! use pyo3::prelude::*;
 //!

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -17,7 +17,7 @@
 //!
 //! Rust code to create a function that adds five to a fraction:
 //!
-//! ```rust
+//! ```rust,no_run
 //! use num_rational::Ratio;
 //! use pyo3::prelude::*;
 //!

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -20,7 +20,7 @@
 //!
 //! Rust code to create a function that adds one to a Decimal
 //!
-//! ```rust
+//! ```rust,no_run
 //! use rust_decimal::Decimal;
 //! use pyo3::prelude::*;
 //!

--- a/src/conversions/uuid.rs
+++ b/src/conversions/uuid.rs
@@ -21,7 +21,7 @@
 //!
 //! Rust code to create a function that parses a UUID string and returns it as a `Uuid`:
 //!
-//! ```rust
+//! ```rust,no_run
 //! use pyo3::prelude::*;
 //! use pyo3::exceptions::PyValueError;
 //! use uuid::Uuid;

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -260,7 +260,7 @@ impl PySetterDef {
 ///
 /// Elided lifetime should compile ok:
 ///
-/// ```rust
+/// ```rust,no_run
 /// use pyo3::prelude::*;
 /// use pyo3::pyclass::{PyTraverseError, PyVisit};
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,7 @@
 //! ```
 //!
 //! **`src/lib.rs`**
-//! ```rust
+//! ```rust,no_run
 //! use pyo3::prelude::*;
 //!
 //! /// Formats the sum of two numbers as string.

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -18,7 +18,7 @@
 //! closure and the return type. This is done by relying on the [`Send`] auto trait. `Ungil` is
 //! defined as the following:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # #![allow(dead_code)]
 //! pub unsafe trait Ungil {}
 //!
@@ -95,7 +95,7 @@
 //! However on nightly Rust and when PyO3's `nightly` feature is
 //! enabled, `Ungil` is defined as the following:
 //!
-//! ```rust
+//! ```rust,no_run
 //! # #[cfg(any())]
 //! # {
 //! #![feature(auto_traits, negative_impls)]
@@ -803,7 +803,7 @@ impl<'py> Python<'py> {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # #![allow(dead_code)] // this example is quite impractical to test
     /// use pyo3::prelude::*;
     ///

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -22,7 +22,7 @@
 //! Usually you can use `&mut` references as method and function receivers and arguments, and you
 //! won't need to use `PyCell` directly:
 //!
-//! ```rust
+//! ```rust,no_run
 //! use pyo3::prelude::*;
 //!
 //! #[pyclass]

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -55,7 +55,7 @@ impl CompareOp {
     ///
     /// Usage example:
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # use pyo3::prelude::*;
     /// # use pyo3::class::basic::CompareOp;
     ///

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -234,7 +234,7 @@ pub trait PyModuleMethods<'py>: crate::sealed::Sealed {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use pyo3::prelude::*;
     ///
     /// #[pymodule]
@@ -270,7 +270,7 @@ pub trait PyModuleMethods<'py>: crate::sealed::Sealed {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use pyo3::prelude::*;
     ///
     /// #[pyclass]
@@ -323,7 +323,7 @@ pub trait PyModuleMethods<'py>: crate::sealed::Sealed {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use pyo3::prelude::*;
     ///
     /// #[pymodule]
@@ -359,7 +359,7 @@ pub trait PyModuleMethods<'py>: crate::sealed::Sealed {
     /// Note that this also requires the [`wrap_pyfunction!`][2] macro
     /// to wrap a function annotated with [`#[pyfunction]`][1].
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use pyo3::prelude::*;
     ///
     /// #[pyfunction]
@@ -404,7 +404,7 @@ pub trait PyModuleMethods<'py>: crate::sealed::Sealed {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use pyo3::prelude::*;
     ///
     /// #[pymodule(gil_used = false)]

--- a/src/types/pysuper.rs
+++ b/src/types/pysuper.rs
@@ -21,7 +21,7 @@ impl PySuper {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use pyo3::prelude::*;
     ///
     /// #[pyclass(subclass)]


### PR DESCRIPTION
A large chunk of our CI time is spent on doctests; a lot of the rust code blocks are just prose with no runnable content. Let's see if marking them as `no_run` can improve this.