### PR TITLE
release: 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ To see unreleased changes, please see the [CHANGELOG on the main branch guide](h
 
 <!-- towncrier release notes start -->
 
+## [0.24.1] - 2025-03-31
+
+### Added
+
+- Add `abi3-py313` feature. [#4969](https://github.com/PyO3/pyo3/pull/4969)
+- Add `PyAnyMethods::getattr_opt`. [#4978](https://github.com/PyO3/pyo3/pull/4978)
+- Add `PyInt::new` constructor for all supported number types (i32, u32, i64, u64, isize, usize). [#4984](https://github.com/PyO3/pyo3/pull/4984)
+- Add `pyo3::sync::with_critical_section2`. [#4992](https://github.com/PyO3/pyo3/pull/4992)
+- Implement `PyCallArgs` for `Borrowed<'_, 'py, PyTuple>`, `&Bound<'py, PyTuple>`, and `&Py<PyTuple>`. [#5013](https://github.com/PyO3/pyo3/pull/5013)
+
+### Fixed
+
+- Fix `is_type_of` for native types not using same specialized check as `is_type_of_bound`. [#4981](https://github.com/PyO3/pyo3/pull/4981)
+- Fix `Probe` class naming issue with `#[pymethods]`. [#4988](https://github.com/PyO3/pyo3/pull/4988)
+- Fix compile failure with required `#[pyfunction]` arguments taking `Option<&str>` and `Option<&T>` (for `#[pyclass]` types). [#5002](https://github.com/PyO3/pyo3/pull/5002)
+- Fix `PyString::from_object` causing of bounds reads whith `encoding` and `errors` parameters which are not nul-terminated. [#5008](https://github.com/PyO3/pyo3/pull/5008)
+- Fix compile error when additional options follow after `crate` for `#[pyfunction]`. [#5015](https://github.com/PyO3/pyo3/pull/5015)
+
 ## [0.24.0] - 2025-03-09
 
 ### Packaging
@@ -17,6 +35,7 @@ To see unreleased changes, please see the [CHANGELOG on the main branch guide](h
 - Add supported CPython/PyPy versions to cargo package metadata. [#4756](https://github.com/PyO3/pyo3/pull/4756)
 - Bump `target-lexicon` dependency to 0.13. [#4822](https://github.com/PyO3/pyo3/pull/4822)
 - Add optional `jiff` dependency to add conversions for `jiff` datetime types. [#4823](https://github.com/PyO3/pyo3/pull/4823)
+- Add optional `uuid` dependency to add conversions for `uuid::Uuid`. [#4864](https://github.com/PyO3/pyo3/pull/4864)
 - Bump minimum supported `inventory` version to 0.3.5. [#4954](https://github.com/PyO3/pyo3/pull/4954)
 
 ### Added
@@ -25,7 +44,6 @@ To see unreleased changes, please see the [CHANGELOG on the main branch guide](h
 - Add `PyCallArgs` trait for passing arguments into the Python calling protocol. This enabled using a faster calling convention for certain types, improving performance. [#4768](https://github.com/PyO3/pyo3/pull/4768)
 - Add `#[pyo3(default = ...']` option for `#[derive(FromPyObject)]` to set a default value for extracted fields of named structs. [#4829](https://github.com/PyO3/pyo3/pull/4829)
 - Add `#[pyo3(into_py_with = ...)]` option for `#[derive(IntoPyObject, IntoPyObjectRef)]`. [#4850](https://github.com/PyO3/pyo3/pull/4850)
-- Add uuid to/from python conversions. [#4864](https://github.com/PyO3/pyo3/pull/4864)
 - Add FFI definitions `PyThreadState_GetFrame` and `PyFrame_GetBack`. [#4866](https://github.com/PyO3/pyo3/pull/4866)
 - Optimize `last` for `BoundListIterator`, `BoundTupleIterator` and `BorrowedTupleIterator`. [#4878](https://github.com/PyO3/pyo3/pull/4878)
 - Optimize `Iterator::count()` for `PyDict`, `PyList`, `PyTuple` & `PySet`. [#4878](https://github.com/PyO3/pyo3/pull/4878)
@@ -60,6 +78,7 @@ To see unreleased changes, please see the [CHANGELOG on the main branch guide](h
 
 
 ## [0.23.5] - 2025-02-22
+
 ### Packaging
 
 - Add support for PyPy3.11 [#4760](https://github.com/PyO3/pyo3/pull/4760)
@@ -108,7 +127,6 @@ To see unreleased changes, please see the [CHANGELOG on the main branch guide](h
 - Fix unresolved symbol link failures on Windows when compiling for Python 3.13t with `abi3` features enabled. [#4733](https://github.com/PyO3/pyo3/pull/4733)
 - Fix unresolved symbol link failures on Windows when compiling for Python 3.13t using the `generate-import-lib` feature. [#4749](https://github.com/PyO3/pyo3/pull/4749)
 - Fix compile-time regression in PyO3 0.23.0 where changing `PYO3_CONFIG_FILE` would not reconfigure PyO3 for the new interpreter. [#4758](https://github.com/PyO3/pyo3/pull/4758)
-
 
 ## [0.23.2] - 2024-11-25
 
@@ -2113,7 +2131,8 @@ Yanked
 
 - Initial release
 
-[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/pyo3/pyo3/compare/v0.24.1...HEAD
+[0.24.1]: https://github.com/pyo3/pyo3/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/pyo3/pyo3/compare/v0.23.5...v0.24.0
 [0.23.5]: https://github.com/pyo3/pyo3/compare/v0.23.4...v0.23.5
 [0.23.4]: https://github.com/pyo3/pyo3/compare/v0.23.3...v0.23.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3"
-version = "0.24.0"
+version = "0.24.1"
 description = "Bindings to Python interpreter"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 readme = "README.md"
@@ -21,10 +21,10 @@ memoffset = "0.9"
 once_cell = "1.13"
 
 # ffi bindings to the python interpreter, split into a separate crate so they can be used independently
-pyo3-ffi = { path = "pyo3-ffi", version = "=0.24.0" }
+pyo3-ffi = { path = "pyo3-ffi", version = "=0.24.1" }
 
 # support crates for macros feature
-pyo3-macros = { path = "pyo3-macros", version = "=0.24.0", optional = true }
+pyo3-macros = { path = "pyo3-macros", version = "=0.24.1", optional = true }
 indoc = { version = "2.0.1", optional = true }
 unindent = { version = "0.2.1", optional = true }
 
@@ -68,7 +68,7 @@ static_assertions = "1.1.0"
 uuid = { version = "1.10.0", features = ["v4"] }
 
 [build-dependencies]
-pyo3-build-config = { path = "pyo3-build-config", version = "=0.24.0", features = ["resolve-config"] }
+pyo3-build-config = { path = "pyo3-build-config", version = "=0.24.1", features = ["resolve-config"] }
 
 [features]
 default = ["macros"]

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.24.0", features = ["extension-module"] }
+pyo3 = { version = "0.24.1", features = ["extension-module"] }
 ```
 
 **`src/lib.rs`**
@@ -140,7 +140,7 @@ Start a new project with `cargo new` and add  `pyo3` to the `Cargo.toml` like th
 
 ```toml
 [dependencies.pyo3]
-version = "0.24.0"
+version = "0.24.1"
 features = ["auto-initialize"]
 ```
 

--- a/examples/decorator/.template/pre-script.rhai
+++ b/examples/decorator/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.24.0");
+variable::set("PYO3_VERSION", "0.24.1");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/maturin-starter/.template/pre-script.rhai
+++ b/examples/maturin-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.24.0");
+variable::set("PYO3_VERSION", "0.24.1");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/examples/plugin/.template/pre-script.rhai
+++ b/examples/plugin/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.24.0");
+variable::set("PYO3_VERSION", "0.24.1");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/plugin_api/Cargo.toml", "plugin_api/Cargo.toml");
 file::delete(".template");

--- a/examples/setuptools-rust-starter/.template/pre-script.rhai
+++ b/examples/setuptools-rust-starter/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.24.0");
+variable::set("PYO3_VERSION", "0.24.1");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/setup.cfg", "setup.cfg");
 file::delete(".template");

--- a/examples/word-count/.template/pre-script.rhai
+++ b/examples/word-count/.template/pre-script.rhai
@@ -1,4 +1,4 @@
-variable::set("PYO3_VERSION", "0.24.0");
+variable::set("PYO3_VERSION", "0.24.1");
 file::rename(".template/Cargo.toml", "Cargo.toml");
 file::rename(".template/pyproject.toml", "pyproject.toml");
 file::delete(".template");

--- a/newsfragments/4969.added.md
+++ b/newsfragments/4969.added.md
@@ -1,1 +1,0 @@
-Added `abi3-py313` feature

--- a/newsfragments/4978.added.md
+++ b/newsfragments/4978.added.md
@@ -1,1 +1,0 @@
-Implement getattr_opt in `PyAnyMethods`

--- a/newsfragments/4981.fixed.md
+++ b/newsfragments/4981.fixed.md
@@ -1,1 +1,0 @@
-Fix `is_type_of` for native types not using same specialized check as `is_type_of_bound`.

--- a/newsfragments/4984.added.md
+++ b/newsfragments/4984.added.md
@@ -1,1 +1,0 @@
-Added PyInt constructor for all supported number types (i32, u32, i64, u64, isize, usize)

--- a/newsfragments/4988.fixed.md
+++ b/newsfragments/4988.fixed.md
@@ -1,1 +1,0 @@
-Fix `Probe` class naming issue with `#[pymethods]`

--- a/newsfragments/4992.added.md
+++ b/newsfragments/4992.added.md
@@ -1,1 +1,0 @@
-Add `pyo3::sync::with_critical_section2` binding

--- a/newsfragments/5002.fixed.md
+++ b/newsfragments/5002.fixed.md
@@ -1,1 +1,0 @@
-Fix compile failure with required `#[pyfunction]` arguments taking `Option<&str>` and `Option<&T>` (for `#[pyclass]` types).

--- a/newsfragments/5008.fixed.md
+++ b/newsfragments/5008.fixed.md
@@ -1,1 +1,0 @@
-Fix `PyString::from_object`, avoid out of bounds reads by null terminating the `encoding` and `errors` parameters

--- a/newsfragments/5013.added.md
+++ b/newsfragments/5013.added.md
@@ -1,1 +1,0 @@
-Implement `PyCallArgs` for `Borrowed<'_, 'py, PyTuple>`, `&Bound<'py, PyTuple>`, and `&Py<PyTuple>`.

--- a/newsfragments/5015.fixed.md
+++ b/newsfragments/5015.fixed.md
@@ -1,1 +1,0 @@
-Fixes compile error if more options followed after `crate` for `#[pyfunction]`.

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-build-config"
-version = "0.24.0"
+version = "0.24.1"
 description = "Build configuration for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-ffi"
-version = "0.24.0"
+version = "0.24.1"
 description = "Python-API bindings for the PyO3 ecosystem"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -43,7 +43,7 @@ generate-import-lib = ["pyo3-build-config/python3-dll-a"]
 paste = "1"
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.0", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.1", features = ["resolve-config"] }
 
 [lints]
 workspace = true

--- a/pyo3-ffi/README.md
+++ b/pyo3-ffi/README.md
@@ -41,13 +41,13 @@ name = "string_sum"
 crate-type = ["cdylib"]
 
 [dependencies.pyo3-ffi]
-version = "0.24.0"
+version = "0.24.1"
 features = ["extension-module"]
 
 [build-dependencies]
 # This is only necessary if you need to configure your build based on
 # the Python version or the compile-time configuration for the interpreter.
-pyo3_build_config = "0.24.0"
+pyo3_build_config = "0.24.1"
 ```
 
 If you need to use conditional compilation based on Python version or how

--- a/pyo3-macros-backend/Cargo.toml
+++ b/pyo3-macros-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros-backend"
-version = "0.24.0"
+version = "0.24.1"
 description = "Code generation for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -17,7 +17,7 @@ rust-version = "1.63"
 [dependencies]
 heck = "0.5"
 proc-macro2 = { version = "1.0.60", default-features = false }
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.0", features = ["resolve-config"] }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.1", features = ["resolve-config"] }
 quote = { version = "1", default-features = false }
 
 [dependencies.syn]
@@ -26,7 +26,7 @@ default-features = false
 features = ["derive", "parsing", "printing", "clone-impls", "full", "extra-traits"]
 
 [build-dependencies]
-pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.0" }
+pyo3-build-config = { path = "../pyo3-build-config", version = "=0.24.1" }
 
 [lints]
 workspace = true

--- a/pyo3-macros/Cargo.toml
+++ b/pyo3-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-macros"
-version = "0.24.0"
+version = "0.24.1"
 description = "Proc macros for PyO3 package"
 authors = ["PyO3 Project and Contributors <https://github.com/PyO3>"]
 keywords = ["pyo3", "python", "cpython", "ffi"]
@@ -22,7 +22,7 @@ experimental-async = ["pyo3-macros-backend/experimental-async"]
 proc-macro2 = { version = "1.0.60", default-features = false }
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }
-pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.24.0" }
+pyo3-macros-backend = { path = "../pyo3-macros-backend", version = "=0.24.1" }
 
 [lints]
 workspace = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.towncrier]
 filename = "CHANGELOG.md"
-version = "0.24.0"
+version = "0.24.1"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"

--- a/tests/ui/reject_generics.stderr
+++ b/tests/ui/reject_generics.stderr
@@ -1,10 +1,10 @@
-error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.24.0/class.html#no-generic-parameters
+error: #[pyclass] cannot have generic parameters. For an explanation, see https://pyo3.rs/v0.24.1/class.html#no-generic-parameters
  --> tests/ui/reject_generics.rs:4:25
   |
 4 | struct ClassWithGenerics<A> {
   |                         ^
 
-error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.24.0/class.html#no-lifetime-parameters
+error: #[pyclass] cannot have lifetime parameters. For an explanation, see https://pyo3.rs/v0.24.1/class.html#no-lifetime-parameters
  --> tests/ui/reject_generics.rs:9:27
   |
 9 | struct ClassWithLifetimes<'a> {


### PR DESCRIPTION
I think we're ready to ship a first patch release for 0.24.

Given #5005 is a memory safety issue, I will issue an advisory once this patch is released.

I plan to put live on Sunday evening unless I hear a reason to delay.

(I fixed a couple of other minor things in the CHANGELOG as part of this commit.)