### PR TITLE
ci: release cargo crate from git tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: Release Rust Crate
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --upgrade pip && pip install nox
+
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Publish to crates.io
-        run: cargo publish
+        run: nox -s publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,6 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
 
       - name: Publish to crates.io
         run: cargo publish

--- a/newsfragments/5027.packaging.md
+++ b/newsfragments/5027.packaging.md
@@ -1,1 +1,1 @@
-Release cargo create from git tag with github actions.
+Release cargo crate from git tag with github actions.

--- a/newsfragments/5027.packaging.md
+++ b/newsfragments/5027.packaging.md
@@ -1,1 +1,0 @@
-Release cargo crate from git tag with github actions.

--- a/newsfragments/5027.packaging.md
+++ b/newsfragments/5027.packaging.md
@@ -1,0 +1,1 @@
+Release cargo create from git tag with github actions.


### PR DESCRIPTION
new workflow trigged by git tag to release carge crate.

context: https://github.com/PyO3/pyo3/issues/5026

Need to set a secret `CARGO_REGISTRY_TOKEN` from maintainer with write permission of carge crate resigtry.

@davidhewitt