### PR TITLE
fix `unused_imports` warning for `IsOption` probe (#5002)

### DIFF
--- a/newsfragments/5030.fixed.md
+++ b/newsfragments/5030.fixed.md
@@ -1,0 +1,1 @@
+Fixes accidentally emitting `unused_imports` lint in `macro_rules` context.

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -238,7 +238,10 @@ pub(crate) fn impl_regular_arg_param(
 
     // Use this macro inside this function, to ensure that all code generated here is associated
     // with the function argument
-    let use_probe = quote!(use #pyo3_path::impl_::pyclass::Probe as _;);
+    let use_probe = quote! {
+        #[allow(unused_imports)]
+        use #pyo3_path::impl_::pyclass::Probe as _;
+    };
     macro_rules! quote_arg_span {
         ($($tokens:tt)*) => { quote_spanned!(arg.ty.span() => { #use_probe $($tokens)* }) }
     }

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -701,6 +701,7 @@ pub fn impl_py_setter_def(
             let holder = holders.push_holder(span);
             let ty = field.ty.clone().elide_lifetimes();
             quote! {
+                #[allow(unused_imports)]
                 use #pyo3_path::impl_::pyclass::Probe as _;
                 let _val = #pyo3_path::impl_::extract_argument::extract_argument::<
                     _,
@@ -1203,6 +1204,7 @@ fn extract_object(
         let holder = holders.push_holder(Span::call_site());
         let ty = arg.ty().clone().elide_lifetimes();
         quote! {{
+            #[allow(unused_imports)]
             use #pyo3_path::impl_::pyclass::Probe as _;
             #pyo3_path::impl_::extract_argument::extract_argument::<
                 _,

--- a/tests/ui/pyclass_probe.rs
+++ b/tests/ui/pyclass_probe.rs
@@ -1,3 +1,4 @@
+#![deny(unused_imports)]
 use pyo3::prelude::*;
 
 #[pyclass]
@@ -16,5 +17,21 @@ fn probe(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Probe>()?;
     Ok(())
 }
+
+#[pyclass]
+struct Check5029();
+
+macro_rules! impl_methods {
+    ($name:ident) => {
+        #[pymethods]
+        impl Check5029 {
+            fn $name(&self, _value: Option<&str>) -> PyResult<()> {
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_methods!(some_method);
 
 fn main() {}


### PR DESCRIPTION
This `#[allow(unused_imports)]` for the probe introduced in #5002. 

Closes #5029 