### PR TITLE
Apply the conda workaround for detecting shared builds to sysconfigdata

### DIFF
--- a/newsfragments/5037.fixed.md
+++ b/newsfragments/5037.fixed.md
@@ -1,0 +1,1 @@
+Ensure we correctly pick up the shared state for conda-based Python installation when reading information from sysconfigdata.

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1306,6 +1306,10 @@ pub fn parse_sysconfigdata(sysconfigdata_path: impl AsRef<Path>) -> Result<Sysco
     })?;
     script += r#"
 for key, val in build_time_vars.items():
+    # (ana)conda(-forge) built Pythons are statically linked but ship the shared library with them.
+    # We detect them based on the magic prefix directory they have encoded in their builds.
+    if key == "Py_ENABLE_SHARED" and "_h_env_placehold" in build_time_vars.get("prefix"):
+        val = 1
     print(key, val)
 "#;
 


### PR DESCRIPTION
This applies that same workaround that is already using in `from_interpreter` in `from_sysconfigdata`. See https://github.com/PyO3/pyo3/blob/561c699876fd7c114b8c8a776cfe3c362ea82ae8/pyo3-build-config/src/impl_.rs#L233 for the workaround in `from_interpreter`.

I have checked this in a conda-based installation manually, but I'm not sure whether we can add a unit test for it.
