### PR TITLE
ci: avoid even more caches being saved when not main

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -30,7 +30,7 @@ jobs:
           workspaces: |
             .
             pyo3-benches
-        continue-on-error: true
+          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
 
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -797,7 +797,7 @@ jobs:
           architecture: ${{ matrix.platform.python-architecture }}
       - uses: Swatinem/rust-cache@v2
         with:
-          save-if: ${{ github.event_name != 'merge_group' }}
+          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
       - run: python -m pip install --upgrade pip && pip install nox
       - run: nox -s test-introspection
     env:


### PR DESCRIPTION
The `benchmarks` job and the new `test-introspection` jobs are still saving caches on all PRs, let's remove those and hopefully get even fewer cache misses caused by eviction.