### PR TITLE
ci: try using uv as default nox venv backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Install nox
         run: python -m pip install --upgrade pip && pip install nox
 
-      - if: inputs.python-version == 'graalpy24.1'
-        name: Install GraalPy virtualenv (only GraalPy 24.1)
-        run: python -m pip install 'git+https://github.com/oracle/graalpython#egg=graalpy_virtualenv_seeder&subdirectory=graalpy_virtualenv_seeder'
+      # - if: inputs.python-version == 'graalpy24.1'
+      #   name: Install GraalPy virtualenv (only GraalPy 24.1)
+      #   run: python -m pip install 'git+https://github.com/oracle/graalpython#egg=graalpy_virtualenv_seeder&subdirectory=graalpy_virtualenv_seeder'
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  NOX_DEFAULT_VENV_BACKEND: uv
 
 jobs:
   fmt:


### PR DESCRIPTION
I noticed that virtualenv creation is a slow part of the CI jobs (e.g. for `graalpy`), I was curious if running with uv is any better...