### PR TITLE
Unraw complex struct enum field python names

### DIFF
--- a/newsfragments/5050.fixed.md
+++ b/newsfragments/5050.fixed.md
@@ -1,0 +1,1 @@
+Fix struct-type complex enum variant fields exposing raw identifiers as `r#ident` in Python bindings.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1164,7 +1164,7 @@ fn impl_complex_enum_variant_match_args(
     field_names: &[Ident],
 ) -> syn::Result<(MethodAndMethodDef, syn::ImplItemFn)> {
     let ident = format_ident!("__match_args__");
-    let field_names_unraw: Vec<_> = field_names.iter().map(|name| name.unraw()).collect();
+    let field_names_unraw = field_names.iter().map(|name| name.unraw());
     let mut match_args_impl: syn::ImplItemFn = {
         parse_quote! {
             #[classattr]

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1161,7 +1161,7 @@ fn impl_complex_enum_variant_cls(
 fn impl_complex_enum_variant_match_args(
     ctx @ Ctx { pyo3_path, .. }: &Ctx,
     variant_cls_type: &syn::Type,
-    field_names: &mut Vec<Ident>,
+    field_names: &[Ident],
 ) -> syn::Result<(MethodAndMethodDef, syn::ImplItemFn)> {
     let ident = format_ident!("__match_args__");
     let field_names_unraw: Vec<_> = field_names.iter().map(|name| name.unraw()).collect();
@@ -1231,7 +1231,7 @@ fn impl_complex_enum_struct_variant_cls(
     }
 
     let (variant_match_args, match_args_const_impl) =
-        impl_complex_enum_variant_match_args(ctx, &variant_cls_type, &mut field_names)?;
+        impl_complex_enum_variant_match_args(ctx, &variant_cls_type, &field_names)?;
 
     field_getters.push(variant_match_args);
 
@@ -1406,7 +1406,7 @@ fn impl_complex_enum_tuple_variant_cls(
     slots.push(variant_getitem);
 
     let (variant_match_args, match_args_method_impl) =
-        impl_complex_enum_variant_match_args(ctx, &variant_cls_type, &mut field_names)?;
+        impl_complex_enum_variant_match_args(ctx, &variant_cls_type, &field_names)?;
 
     field_getters.push(variant_match_args);
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1164,12 +1164,13 @@ fn impl_complex_enum_variant_match_args(
     field_names: &mut Vec<Ident>,
 ) -> syn::Result<(MethodAndMethodDef, syn::ImplItemFn)> {
     let ident = format_ident!("__match_args__");
+    let field_names_unraw: Vec<_> = field_names.iter().map(|name| name.unraw()).collect();
     let mut match_args_impl: syn::ImplItemFn = {
         parse_quote! {
             #[classattr]
             fn #ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::Bound<'_, #pyo3_path::types::PyTuple>> {
                 #pyo3_path::types::PyTuple::new::<&str, _>(py, [
-                    #(stringify!(#field_names),)*
+                    #(stringify!(#field_names_unraw),)*
                 ])
             }
         }
@@ -1716,7 +1717,7 @@ fn complex_enum_variant_field_getter<'a>(
     let spec = FnSpec {
         tp: crate::method::FnType::Getter(self_type.clone()),
         name: field_name,
-        python_name: field_name.clone(),
+        python_name: field_name.unraw(),
         signature,
         convention: crate::method::CallingConvention::Noargs,
         text_signature: None,

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -370,19 +370,29 @@ fn custom_eq() {
     })
 }
 
+#[pyclass]
+#[derive(Clone, Copy)]
+pub enum ComplexEnumWithRaw {
+    Raw { r#type: i32 },
+}
+
+// Cover simple field lookups with raw identifiers
 #[test]
 fn complex_enum_with_raw() {
-    #[pyclass]
-    #[derive(Clone, Copy)]
-    pub enum ComplexEnumWithRaw {
-        Raw { r#type: i32 },
-    }
+    Python::with_gil(|py| {
+        let complex = ComplexEnumWithRaw::Raw { r#type: 314159 };
+
+        py_assert!(py, complex, "complex.type == 314159");
+    });
+}
+
+// Cover pattern matching with raw identifiers
+#[test]
+#[cfg(Py_3_10)]
+fn complex_enum_with_raw_pattern_match() {
     Python::with_gil(|py| {
         let complex = ComplexEnumWithRaw::Raw { r#type: 314159 };
         let cls = py.get_type::<ComplexEnumWithRaw>();
-
-        // Cover simple field lookups
-        py_assert!(py, complex, "complex.type == 314159");
 
         // Cover destructuring by pattern matching
         py_run!(py, cls complex, r#"

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -369,3 +369,28 @@ fn custom_eq() {
         assert!(b.as_any().ne("A").unwrap());
     })
 }
+
+#[test]
+fn complex_enum_with_raw() {
+    #[pyclass]
+    #[derive(Clone, Copy)]
+    pub enum ComplexEnumWithRaw {
+        Raw { r#type: i32 },
+    }
+    Python::with_gil(|py| {
+        let complex = ComplexEnumWithRaw::Raw { r#type: 314159 };
+        let cls = py.get_type::<ComplexEnumWithRaw>();
+
+        // Cover simple field lookups
+        py_assert!(py, complex, "complex.type == 314159");
+
+        // Cover destructuring by pattern matching
+        py_run!(py, cls complex, r#"
+        match complex:
+            case cls.Raw(type=ty):
+                assert ty == 314159
+            case _:
+                assert False, "no matching variant found"
+        "#);
+    });
+}


### PR DESCRIPTION
Stray case related to #2395 (probably unnoticed because the functionality is newer and a bit of an edge case).

The `python_name` of struct-type enum variant fields (and the `__match_args__` of the variant) do not unraw the names of these fields, which effectively makes them unusable as the resulting identifiers contain '#' which the Python lexer interprets as comments. The only reason you'd probably want to do this anyway is to use reserved identifiers (`type` in my case).
