### PR TITLE
Add `PyTzInfo` constructors

### DIFF
--- a/newsfragments/5055.added.md
+++ b/newsfragments/5055.added.md
@@ -1,0 +1,1 @@
+Add `PyTzInfo` constructors

--- a/newsfragments/5055.changed.md
+++ b/newsfragments/5055.changed.md
@@ -1,0 +1,1 @@
+Deprecated `timezone_utc` in favor of `PyTzInfo::utc`

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -538,7 +538,7 @@ fn py_time_to_naive_time(py_time: &Bound<'_, PyAny>) -> PyResult<NaiveTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{types::timezone_utc, types::PyTuple, BoundObject};
+    use crate::{types::PyTuple, BoundObject};
     use std::{cmp::Ordering, panic};
 
     #[test]
@@ -923,7 +923,7 @@ mod tests {
             let minute = 8;
             let second = 9;
             let micro = 999_999;
-            let tz_utc = timezone_utc(py);
+            let tz_utc = PyTzInfo::utc(py).unwrap();
             let py_datetime = new_py_datetime_ob(
                 py,
                 "datetime",

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -47,13 +47,10 @@ use crate::exceptions::{PyTypeError, PyUserWarning, PyValueError};
 use crate::intern;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyNone;
-use crate::types::{
-    datetime::timezone_from_offset, timezone_utc, PyDate, PyDateTime, PyDelta, PyTime, PyTzInfo,
-    PyTzInfoAccess,
-};
+use crate::types::{PyDate, PyDateTime, PyDelta, PyTime, PyTzInfo, PyTzInfoAccess};
 #[cfg(not(Py_LIMITED_API))]
 use crate::types::{PyDateAccess, PyDeltaAccess, PyTimeAccess};
-use crate::{ffi, Bound, FromPyObject, IntoPyObjectExt, PyAny, PyErr, PyResult, Python};
+use crate::{ffi, Borrowed, Bound, FromPyObject, IntoPyObjectExt, PyAny, PyErr, PyResult, Python};
 use chrono::offset::{FixedOffset, Utc};
 use chrono::{
     DateTime, Datelike, Duration, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Offset,
@@ -363,7 +360,7 @@ impl<'py> IntoPyObject<'py> for FixedOffset {
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let seconds_offset = self.local_minus_utc();
         let td = PyDelta::new(py, 0, seconds_offset, 0, true)?;
-        timezone_from_offset(&td)
+        PyTzInfo::fixed_offset(py, td)
     }
 }
 
@@ -408,17 +405,17 @@ impl FromPyObject<'_> for FixedOffset {
 
 impl<'py> IntoPyObject<'py> for Utc {
     type Target = PyTzInfo;
-    type Output = Bound<'py, Self::Target>;
+    type Output = Borrowed<'static, 'py, Self::Target>;
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(timezone_utc(py))
+        Ok(PyTzInfo::utc(py))
     }
 }
 
 impl<'py> IntoPyObject<'py> for &Utc {
     type Target = PyTzInfo;
-    type Output = Bound<'py, Self::Target>;
+    type Output = Borrowed<'static, 'py, Self::Target>;
     type Error = PyErr;
 
     #[inline]
@@ -429,7 +426,7 @@ impl<'py> IntoPyObject<'py> for &Utc {
 
 impl FromPyObject<'_> for Utc {
     fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Utc> {
-        let py_utc = timezone_utc(ob.py());
+        let py_utc = PyTzInfo::utc(ob.py());
         if ob.eq(py_utc)? {
             Ok(Utc)
         } else {
@@ -541,7 +538,7 @@ fn py_time_to_naive_time(py_time: &Bound<'_, PyAny>) -> PyResult<NaiveTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{types::PyTuple, BoundObject};
+    use crate::{types::timezone_utc, types::PyTuple, BoundObject};
     use std::{cmp::Ordering, panic};
 
     #[test]

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -409,7 +409,7 @@ impl<'py> IntoPyObject<'py> for Utc {
     type Error = PyErr;
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(PyTzInfo::utc(py))
+        PyTzInfo::utc(py)
     }
 }
 
@@ -426,7 +426,7 @@ impl<'py> IntoPyObject<'py> for &Utc {
 
 impl FromPyObject<'_> for Utc {
     fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Utc> {
-        let py_utc = PyTzInfo::utc(ob.py());
+        let py_utc = PyTzInfo::utc(ob.py())?;
         if ob.eq(py_utc)? {
             Ok(Utc)
         } else {

--- a/src/conversions/jiff.rs
+++ b/src/conversions/jiff.rs
@@ -48,8 +48,8 @@
 //! ```
 use crate::exceptions::{PyTypeError, PyValueError};
 use crate::pybacked::PyBackedStr;
-use crate::types::{timezone_utc, PyDate, PyDateTime, PyDelta, PyTime, PyTzInfo, PyTzInfoAccess};
 use crate::types::{PyAnyMethods, PyNone};
+use crate::types::{PyDate, PyDateTime, PyDelta, PyTime, PyTzInfo, PyTzInfoAccess};
 #[cfg(not(Py_LIMITED_API))]
 use crate::types::{PyDateAccess, PyDeltaAccess, PyTimeAccess};
 use crate::{intern, Bound, FromPyObject, IntoPyObject, PyAny, PyErr, PyResult, Python};
@@ -329,7 +329,7 @@ impl<'py> IntoPyObject<'py> for &TimeZone {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         if self == &TimeZone::UTC {
-            return Ok(timezone_utc(py));
+            return Ok(PyTzInfo::utc(py)?.to_owned());
         }
 
         #[cfg(Py_3_9)]
@@ -361,7 +361,7 @@ impl<'py> IntoPyObject<'py> for &Offset {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         if self == &Offset::UTC {
-            return Ok(timezone_utc(py));
+            return Ok(PyTzInfo::utc(py)?.to_owned());
         }
 
         PyTzInfo::fixed_offset(py, self.duration_since(Offset::UTC))
@@ -468,8 +468,6 @@ impl From<jiff::Error> for PyErr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(not(Py_LIMITED_API))]
-    use crate::types::timezone_utc;
     use crate::{types::PyTuple, BoundObject};
     use jiff::tz::Offset;
     use std::cmp::Ordering;
@@ -719,7 +717,7 @@ mod tests {
             let minute = 8;
             let second = 9;
             let micro = 999_999;
-            let tz_utc = timezone_utc(py);
+            let tz_utc = PyTzInfo::utc(py).unwrap();
             let py_datetime = new_py_datetime_ob(
                 py,
                 "datetime",

--- a/src/conversions/time.rs
+++ b/src/conversions/time.rs
@@ -53,7 +53,6 @@
 use crate::exceptions::{PyTypeError, PyValueError};
 #[cfg(Py_LIMITED_API)]
 use crate::intern;
-use crate::types::datetime::timezone_from_offset;
 #[cfg(not(Py_LIMITED_API))]
 use crate::types::datetime::{PyDateAccess, PyDeltaAccess};
 use crate::types::{
@@ -359,7 +358,7 @@ impl<'py> IntoPyObject<'py> for UtcOffset {
         // Get offset in seconds
         let seconds_offset = self.whole_seconds();
         let td = PyDelta::new(py, 0, seconds_offset, 0, true)?;
-        timezone_from_offset(&td)
+        PyTzInfo::fixed_offset(py, td)
     }
 }
 

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -250,12 +250,12 @@ fn ucs4() {
 #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
 #[cfg(not(PyPy))]
 fn test_get_tzinfo() {
-    use crate::types::timezone_utc;
+    use crate::types::PyTzInfo;
 
     crate::Python::with_gil(|py| {
         use crate::types::{PyDateTime, PyTime};
 
-        let utc = &timezone_utc(py);
+        let utc: &Bound<'_, _> = &PyTzInfo::utc(py).unwrap();
 
         let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(utc)).unwrap();
 

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -853,6 +853,7 @@ impl PyTzInfo {
 }
 
 /// Equivalent to `datetime.timezone.utc`
+#[deprecated(since = "0.25.0", note = "use `PyTzInfo::utc` instead")]
 pub fn timezone_utc(py: Python<'_>) -> Bound<'_, PyTzInfo> {
     PyTzInfo::utc(py)
         .expect("failed to import datetime.timezone.utc")
@@ -972,7 +973,8 @@ mod tests {
                 "import datetime; assert dt == datetime.datetime.fromtimestamp(100)"
             );
 
-            let dt = PyDateTime::from_timestamp(py, 100.0, Some(&timezone_utc(py))).unwrap();
+            let utc = PyTzInfo::utc(py).unwrap();
+            let dt = PyDateTime::from_timestamp(py, 100.0, Some(&utc)).unwrap();
             py_run!(
                 py,
                 dt,
@@ -1012,11 +1014,11 @@ mod tests {
     #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_get_tzinfo() {
         crate::Python::with_gil(|py| {
-            let utc = timezone_utc(py);
+            let utc = PyTzInfo::utc(py).unwrap();
 
             let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(&utc)).unwrap();
 
-            assert!(dt.get_tzinfo().unwrap().eq(&utc).unwrap());
+            assert!(dt.get_tzinfo().unwrap().eq(utc).unwrap());
 
             let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, None).unwrap();
 

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -17,11 +17,15 @@ use crate::ffi::{
 #[cfg(all(GraalPy, not(Py_LIMITED_API)))]
 use crate::ffi::{PyDateTime_DATE_GET_TZINFO, PyDateTime_TIME_GET_TZINFO, Py_IsNone};
 use crate::types::any::PyAnyMethods;
+#[cfg(Py_3_9)]
+use crate::types::PyString;
 #[cfg(not(Py_LIMITED_API))]
-use crate::{ffi_ptr_ext::FfiPtrExt, py_result_ext::PyResultExt, types::PyTuple, IntoPyObject};
+use crate::{ffi_ptr_ext::FfiPtrExt, py_result_ext::PyResultExt, types::PyTuple, BoundObject};
+#[cfg(any(Py_3_9, Py_LIMITED_API))]
+use crate::{sync::GILOnceCell, types::PyType, Py};
 #[cfg(Py_LIMITED_API)]
-use crate::{sync::GILOnceCell, types::IntoPyDict, types::PyType, Py, PyTypeCheck};
-use crate::{Bound, PyAny, PyErr, Python};
+use crate::{types::IntoPyDict, PyTypeCheck};
+use crate::{Borrowed, Bound, IntoPyObject, PyAny, PyErr, Python};
 #[cfg(not(Py_LIMITED_API))]
 use std::os::raw::c_int;
 
@@ -781,65 +785,78 @@ impl PyTypeCheck for PyTzInfo {
     }
 }
 
-/// Equivalent to `datetime.timezone.utc`
-pub fn timezone_utc(py: Python<'_>) -> Bound<'_, PyTzInfo> {
-    // TODO: this _could_ have a borrowed form `timezone_utc_borrowed`, but that seems
-    // like an edge case optimization and we'd prefer in PyO3 0.21 to use `Bound` as
-    // much as possible
-    #[cfg(not(Py_LIMITED_API))]
-    unsafe {
-        expect_datetime_api(py)
-            .TimeZone_UTC
-            .assume_borrowed(py)
-            .to_owned()
-            .downcast_into_unchecked()
-    }
-
-    #[cfg(Py_LIMITED_API)]
-    {
-        static UTC: GILOnceCell<Py<PyTzInfo>> = GILOnceCell::new();
-        UTC.get_or_init(py, || {
-            DatetimeTypes::get(py)
-                .timezone
-                .bind(py)
-                .getattr("utc")
-                .expect("failed to import datetime.timezone.utc")
-                .downcast_into()
-                .unwrap()
-                .unbind()
-        })
-        .bind(py)
-        .to_owned()
-    }
-}
-
-/// Equivalent to `datetime.timezone` constructor
-///
-/// Only used internally
-#[cfg(any(feature = "chrono", feature = "jiff-02", feature = "time"))]
-pub(crate) fn timezone_from_offset<'py>(
-    offset: &Bound<'py, PyDelta>,
-) -> PyResult<Bound<'py, PyTzInfo>> {
-    let py = offset.py();
-
-    #[cfg(not(Py_LIMITED_API))]
-    {
-        let api = ensure_datetime_api(py)?;
+impl PyTzInfo {
+    /// Equivalent to `datetime.timezone.utc`
+    pub fn utc(py: Python<'_>) -> Borrowed<'static, '_, PyTzInfo> {
+        #[cfg(not(Py_LIMITED_API))]
         unsafe {
-            (api.TimeZone_FromTimeZone)(offset.as_ptr(), std::ptr::null_mut())
-                .assume_owned_or_err(py)
-                .downcast_into_unchecked()
+            expect_datetime_api(py)
+                .TimeZone_UTC
+                .assume_borrowed(py)
+                .downcast_unchecked()
+        }
+
+        #[cfg(Py_LIMITED_API)]
+        {
+            static UTC: GILOnceCell<Py<PyTzInfo>> = GILOnceCell::new();
+            UTC.get_or_init(py, || {
+                DatetimeTypes::get(py)
+                    .timezone
+                    .bind(py)
+                    .getattr("utc")
+                    .expect("failed to import datetime.timezone.utc")
+                    .downcast_into()
+                    .unwrap()
+                    .unbind()
+            })
+            .bind_borrowed(py)
         }
     }
 
-    #[cfg(Py_LIMITED_API)]
-    unsafe {
-        Ok(DatetimeTypes::try_get(py)?
-            .timezone
-            .bind(py)
-            .call1((offset,))?
-            .downcast_into_unchecked())
+    /// Equivalent to `zoneinfo.ZoneInfo` constructor
+    #[cfg(Py_3_9)]
+    pub fn timezone<'py, T>(py: Python<'py>, iana_name: T) -> PyResult<Bound<'py, PyTzInfo>>
+    where
+        T: IntoPyObject<'py, Target = PyString>,
+    {
+        static ZONE_INFO: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+        ZONE_INFO
+            .import(py, "zoneinfo", "ZoneInfo")?
+            .call1((iana_name,))?
+            .downcast_into()
+            .map_err(Into::into)
     }
+
+    /// Equivalent to `datetime.timezone` constructor
+    pub fn fixed_offset<'py, T>(py: Python<'py>, offset: T) -> PyResult<Bound<'py, PyTzInfo>>
+    where
+        T: IntoPyObject<'py, Target = PyDelta>,
+    {
+        #[cfg(not(Py_LIMITED_API))]
+        {
+            let api = ensure_datetime_api(py)?;
+            let delta = offset.into_pyobject(py).map_err(Into::into)?;
+            unsafe {
+                (api.TimeZone_FromTimeZone)(delta.as_ptr(), std::ptr::null_mut())
+                    .assume_owned_or_err(py)
+                    .downcast_into_unchecked()
+            }
+        }
+
+        #[cfg(Py_LIMITED_API)]
+        unsafe {
+            Ok(DatetimeTypes::try_get(py)?
+                .timezone
+                .bind(py)
+                .call1((offset,))?
+                .downcast_into_unchecked())
+        }
+    }
+}
+
+/// Equivalent to `datetime.timezone.utc`
+pub fn timezone_utc(py: Python<'_>) -> Bound<'_, PyTzInfo> {
+    PyTzInfo::utc(py).to_owned()
 }
 
 /// Bindings for `datetime.timedelta`.
@@ -1023,7 +1040,7 @@ mod tests {
 
         Python::with_gil(|py| {
             assert!(
-                timezone_from_offset(&PyDelta::new(py, 0, -3600, 0, true).unwrap())
+                PyTzInfo::fixed_offset(py, PyDelta::new(py, 0, -3600, 0, true).unwrap())
                     .unwrap()
                     .call_method1("utcoffset", (PyNone::get(py),))
                     .unwrap()
@@ -1034,7 +1051,7 @@ mod tests {
             );
 
             assert!(
-                timezone_from_offset(&PyDelta::new(py, 0, 3600, 0, true).unwrap())
+                PyTzInfo::fixed_offset(py, PyDelta::new(py, 0, 3600, 0, true).unwrap())
                     .unwrap()
                     .call_method1("utcoffset", (PyNone::get(py),))
                     .unwrap()
@@ -1044,7 +1061,7 @@ mod tests {
                     .unwrap()
             );
 
-            timezone_from_offset(&PyDelta::new(py, 1, 0, 0, true).unwrap()).unwrap_err();
+            PyTzInfo::fixed_offset(py, PyDelta::new(py, 1, 0, 0, true).unwrap()).unwrap_err();
         })
     }
 }

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -1,6 +1,6 @@
 #![cfg(not(Py_LIMITED_API))]
 
-use pyo3::types::{timezone_utc, IntoPyDict, PyDate, PyDateTime, PyTime};
+use pyo3::types::{IntoPyDict, PyDate, PyDateTime, PyTime, PyTzInfo};
 use pyo3::{ffi, prelude::*};
 use pyo3_ffi::PyDateTime_IMPORT;
 use std::ffi::CString;
@@ -133,7 +133,7 @@ fn test_datetime_utc() {
     use pyo3::types::PyDateTime;
 
     Python::with_gil(|py| {
-        let utc = timezone_utc(py);
+        let utc = PyTzInfo::utc(py).unwrap();
 
         let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(&utc)).unwrap();
 


### PR DESCRIPTION
This continuous the discussion if we want additional constructors for `PyTzInfo`, started in #4970. By doing so it enables users to easily create timezone aware datetimes without going trough chrono-tz or jiff integrations.