### PR TITLE
ci: do not require changelog for ci

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@ By submitting these contributions you agree for them to be dual-licensed under P
 Please consider adding the following to your pull request:
  - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
    - or start the PR title with `docs:` if this is a docs-only change to skip the check
+   - or start the PR title with `ci:` if this is a ci-only change to skip the check
  - docs to all new functions and / or detail in the guide
  - tests for all new or changed functions
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -573,6 +573,7 @@ def address_sanitizer(session: nox.Session):
 _IGNORE_CHANGELOG_PR_CATEGORIES = (
     "release",
     "docs",
+    "ci",
 )
 
 


### PR DESCRIPTION
Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
