### PR TITLE
ci: silence `ffi-check` for private `_PyCoLineInstrumentationData` on 3.13

### DIFF
--- a/pyo3-ffi-check/macro/src/lib.rs
+++ b/pyo3-ffi-check/macro/src/lib.rs
@@ -62,6 +62,16 @@ pub fn for_all_structs(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
             continue;
         }
 
+        if struct_name == "_PyCoLineInstrumentationData"
+            && pyo3_build_config::get().version == PY_3_13
+        {
+            // private type, fields changed name in 3.13.2 -> 3.13.3
+            //
+            // PyO3 0.25 will remove this struct, for 0.24 we don't really care the names
+            // changed, the size stayed the same.
+            continue;
+        }
+
         let struct_ident = Ident::new(struct_name, Span::call_site());
         output.extend(quote!(#macro_name!(#struct_ident);));
     }


### PR DESCRIPTION
This is just for the 0.24 patch releases, target branch is `release-0.24.2`; I will send a better PR for the 0.25 series.

Related to #5062 

cc @ngoldbaum 