### PR TITLE
ci: re-enable ffi check on 3.13 for PyConfig, ignore `_PyCoLineInstrumentationData`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           architecture: ${{ inputs.python-architecture }}
-          check-latest: ${{ startsWith(inputs.python-version, 'pypy') }} # PyPy can have FFI changes within Python versions, which creates pain in CI
+          # PyPy can have FFI changes within Python versions, which creates pain in CI
+          # 3.13.2 also had an ABI break so temporarily add this for 3.13 to ensure that we're using 3.13.3
+          check-latest: ${{ startsWith(inputs.python-version, 'pypy') || startsWith(inputs.python-version, '3.13') }}
 
       - name: Install nox
         run: python -m pip install --upgrade pip && pip install nox

--- a/pyo3-ffi-check/macro/src/lib.rs
+++ b/pyo3-ffi-check/macro/src/lib.rs
@@ -55,10 +55,13 @@ pub fn for_all_structs(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
             .strip_suffix(".html")
             .unwrap();
 
-        if struct_name == "PyConfig" && pyo3_build_config::get().version == PY_3_13 {
-            // https://github.com/python/cpython/issues/130940
-            // PyConfig has an ABI break on Python 3.13.1 -> 3.13.2, waiting for advice
-            // how to proceed in PyO3.
+        if struct_name == "_PyCoLineInstrumentationData"
+            && pyo3_build_config::get().version == PY_3_13
+        {
+            // private type, fields changed name in 3.13.2 -> 3.13.3
+            //
+            // PyO3 0.25 will remove this struct, ignoring temporarily just to unblock CI
+            // changed, the size stayed the same.
             continue;
         }
 


### PR DESCRIPTION
3.13.2 broke ffi-check for `PyConfig` due to ABI break upstream, should have been fixed in 3.13.3.

Let's also ignore `_PyCoLineInstrumentationData` temporarily to unblock CI, will be removed in #5064 