### PR TITLE
ci: fix free-threading issue in `test_coroutine`

### DIFF
--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -9,7 +9,7 @@ use pyo3::{
     coroutine::CancelHandle,
     prelude::*,
     py_run,
-    types::{IntoPyDict, PyType},
+    types::{IntoPyDict, PyDict, PyType},
 };
 #[cfg(target_has_atomic = "64")]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -146,7 +146,7 @@ fn cancelled_coroutine() {
             await task
         asyncio.run(main())
         "#;
-        let globals = gil.import("__main__").unwrap().dict();
+        let globals = PyDict::new(gil);
         globals.set_item("sleep", sleep).unwrap();
         let err = gil
             .run(
@@ -185,7 +185,7 @@ fn coroutine_cancel_handle() {
             return await task
         assert asyncio.run(main()) == 0
         "#;
-        let globals = gil.import("__main__").unwrap().dict();
+        let globals = PyDict::new(gil);
         globals
             .set_item("cancellable_sleep", cancellable_sleep)
             .unwrap();
@@ -217,7 +217,7 @@ fn coroutine_is_cancelled() {
             await task
         asyncio.run(main())
         "#;
-        let globals = gil.import("__main__").unwrap().dict();
+        let globals = PyDict::new(gil);
         globals.set_item("sleep_loop", sleep_loop).unwrap();
         gil.run(
             &CString::new(pyo3::unindent::unindent(&handle_windows(test))).unwrap(),


### PR DESCRIPTION
Three tests in `test_coroutine` all import the `__main__` module and then execute some code which defines a symbol `main()`.

This is problematic on the free-threaded build because the definition of `def main()` and then the following call to `asyncio.run()` can race with the other tests overwriting the `main` symbol with their own implementation of it.

This can lead to the wrong code getting called in the tests & unexpected failures!

cc @ngoldbaum - no issues in CPython or PyO3 to worry about, just a flaky test suite 😂 