### PR TITLE
unify `IntoPyObject`/`FromPyObject` derive attributes

### DIFF
--- a/newsfragments/5070.fixed.md
+++ b/newsfragments/5070.fixed.md
@@ -1,0 +1,1 @@
+Fix compile failure with `#[derive(IntoPyObject, FromPyObject)]` when using `#[pyo3()]` options recognised by only one of the two derives.

--- a/pyo3-macros-backend/src/derive_attributes.rs
+++ b/pyo3-macros-backend/src/derive_attributes.rs
@@ -1,0 +1,217 @@
+use crate::attributes::{
+    self, get_pyo3_options, CrateAttribute, DefaultAttribute, FromPyWithAttribute,
+    IntoPyWithAttribute, RenameAllAttribute,
+};
+use proc_macro2::Span;
+use syn::parse::{Parse, ParseStream};
+use syn::spanned::Spanned;
+use syn::{parenthesized, Attribute, LitStr, Result, Token};
+
+/// Attributes for deriving `FromPyObject`/`IntoPyObject` scoped on containers.
+pub enum ContainerAttribute {
+    /// Treat the Container as a Wrapper, operate directly on its field
+    Transparent(attributes::kw::transparent),
+    /// Force every field to be extracted from item of source Python object.
+    ItemAll(attributes::kw::from_item_all),
+    /// Change the name of an enum variant in the generated error message.
+    ErrorAnnotation(LitStr),
+    /// Change the path for the pyo3 crate
+    Crate(CrateAttribute),
+    /// Converts the field idents according to the [RenamingRule](attributes::RenamingRule) before extraction
+    RenameAll(RenameAllAttribute),
+}
+
+impl Parse for ContainerAttribute {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(attributes::kw::transparent) {
+            let kw: attributes::kw::transparent = input.parse()?;
+            Ok(ContainerAttribute::Transparent(kw))
+        } else if lookahead.peek(attributes::kw::from_item_all) {
+            let kw: attributes::kw::from_item_all = input.parse()?;
+            Ok(ContainerAttribute::ItemAll(kw))
+        } else if lookahead.peek(attributes::kw::annotation) {
+            let _: attributes::kw::annotation = input.parse()?;
+            let _: Token![=] = input.parse()?;
+            input.parse().map(ContainerAttribute::ErrorAnnotation)
+        } else if lookahead.peek(Token![crate]) {
+            input.parse().map(ContainerAttribute::Crate)
+        } else if lookahead.peek(attributes::kw::rename_all) {
+            input.parse().map(ContainerAttribute::RenameAll)
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct ContainerAttributes {
+    /// Treat the Container as a Wrapper, operate directly on its field
+    pub transparent: Option<attributes::kw::transparent>,
+    /// Force every field to be extracted from item of source Python object.
+    pub from_item_all: Option<attributes::kw::from_item_all>,
+    /// Change the name of an enum variant in the generated error message.
+    pub annotation: Option<syn::LitStr>,
+    /// Change the path for the pyo3 crate
+    pub krate: Option<CrateAttribute>,
+    /// Converts the field idents according to the [RenamingRule](attributes::RenamingRule) before extraction
+    pub rename_all: Option<RenameAllAttribute>,
+}
+
+impl ContainerAttributes {
+    pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
+        let mut options = ContainerAttributes::default();
+
+        for attr in attrs {
+            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
+                pyo3_attrs
+                    .into_iter()
+                    .try_for_each(|opt| options.set_option(opt))?;
+            }
+        }
+        Ok(options)
+    }
+
+    fn set_option(&mut self, option: ContainerAttribute) -> syn::Result<()> {
+        macro_rules! set_option {
+            ($key:ident) => {
+                {
+                    ensure_spanned!(
+                        self.$key.is_none(),
+                        $key.span() => concat!("`", stringify!($key), "` may only be specified once")
+                    );
+                    self.$key = Some($key);
+                }
+            };
+        }
+
+        match option {
+            ContainerAttribute::Transparent(transparent) => set_option!(transparent),
+            ContainerAttribute::ItemAll(from_item_all) => set_option!(from_item_all),
+            ContainerAttribute::ErrorAnnotation(annotation) => set_option!(annotation),
+            ContainerAttribute::Crate(krate) => set_option!(krate),
+            ContainerAttribute::RenameAll(rename_all) => set_option!(rename_all),
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum FieldGetter {
+    GetItem(attributes::kw::item, Option<syn::Lit>),
+    GetAttr(attributes::kw::attribute, Option<syn::LitStr>),
+}
+
+impl FieldGetter {
+    pub fn span(&self) -> Span {
+        match self {
+            FieldGetter::GetItem(item, _) => item.span,
+            FieldGetter::GetAttr(attribute, _) => attribute.span,
+        }
+    }
+}
+
+pub enum FieldAttribute {
+    Getter(FieldGetter),
+    FromPyWith(FromPyWithAttribute),
+    IntoPyWith(IntoPyWithAttribute),
+    Default(DefaultAttribute),
+}
+
+impl Parse for FieldAttribute {
+    fn parse(input: ParseStream<'_>) -> Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(attributes::kw::attribute) {
+            let attr_kw: attributes::kw::attribute = input.parse()?;
+            if input.peek(syn::token::Paren) {
+                let content;
+                let _ = parenthesized!(content in input);
+                let attr_name: LitStr = content.parse()?;
+                if !content.is_empty() {
+                    return Err(content.error(
+                        "expected at most one argument: `attribute` or `attribute(\"name\")`",
+                    ));
+                }
+                ensure_spanned!(
+                    !attr_name.value().is_empty(),
+                    attr_name.span() => "attribute name cannot be empty"
+                );
+                Ok(Self::Getter(FieldGetter::GetAttr(attr_kw, Some(attr_name))))
+            } else {
+                Ok(Self::Getter(FieldGetter::GetAttr(attr_kw, None)))
+            }
+        } else if lookahead.peek(attributes::kw::item) {
+            let item_kw: attributes::kw::item = input.parse()?;
+            if input.peek(syn::token::Paren) {
+                let content;
+                let _ = parenthesized!(content in input);
+                let key = content.parse()?;
+                if !content.is_empty() {
+                    return Err(
+                        content.error("expected at most one argument: `item` or `item(key)`")
+                    );
+                }
+                Ok(Self::Getter(FieldGetter::GetItem(item_kw, Some(key))))
+            } else {
+                Ok(Self::Getter(FieldGetter::GetItem(item_kw, None)))
+            }
+        } else if lookahead.peek(attributes::kw::from_py_with) {
+            input.parse().map(Self::FromPyWith)
+        } else if lookahead.peek(attributes::kw::into_py_with) {
+            input.parse().map(FieldAttribute::IntoPyWith)
+        } else if lookahead.peek(Token![default]) {
+            input.parse().map(Self::Default)
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FieldAttributes {
+    pub getter: Option<FieldGetter>,
+    pub from_py_with: Option<FromPyWithAttribute>,
+    pub into_py_with: Option<IntoPyWithAttribute>,
+    pub default: Option<DefaultAttribute>,
+}
+
+impl FieldAttributes {
+    /// Extract the field attributes.
+    pub fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
+        let mut options = FieldAttributes::default();
+
+        for attr in attrs {
+            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
+                pyo3_attrs
+                    .into_iter()
+                    .try_for_each(|opt| options.set_option(opt))?;
+            }
+        }
+        Ok(options)
+    }
+
+    fn set_option(&mut self, option: FieldAttribute) -> syn::Result<()> {
+        macro_rules! set_option {
+            ($key:ident) => {
+                set_option!($key, concat!("`", stringify!($key), "` may only be specified once"))
+            };
+            ($key:ident, $msg: expr) => {{
+                ensure_spanned!(
+                    self.$key.is_none(),
+                    $key.span() => $msg
+                );
+                self.$key = Some($key);
+            }}
+        }
+
+        match option {
+            FieldAttribute::Getter(getter) => {
+                set_option!(getter, "only one of `attribute` or `item` can be provided")
+            }
+            FieldAttribute::FromPyWith(from_py_with) => set_option!(from_py_with),
+            FieldAttribute::IntoPyWith(into_py_with) => set_option!(into_py_with),
+            FieldAttribute::Default(default) => set_option!(default),
+        }
+        Ok(())
+    }
+}

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -1,18 +1,11 @@
-use crate::attributes::{
-    self, get_pyo3_options, CrateAttribute, DefaultAttribute, FromPyWithAttribute,
-    RenameAllAttribute, RenamingRule,
-};
+use crate::attributes::{DefaultAttribute, FromPyWithAttribute, RenamingRule};
+use crate::derive_attributes::{ContainerAttributes, FieldAttributes, FieldGetter};
 use crate::utils::{self, Ctx};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::{
-    ext::IdentExt,
-    parenthesized,
-    parse::{Parse, ParseStream},
-    parse_quote,
-    punctuated::Punctuated,
-    spanned::Spanned,
-    Attribute, DataEnum, DeriveInput, Fields, Ident, LitStr, Result, Token,
+    ext::IdentExt, parse_quote, punctuated::Punctuated, spanned::Spanned, DataEnum, DeriveInput,
+    Fields, Ident, Result, Token,
 };
 
 /// Describes derivation input of an enum.
@@ -26,7 +19,11 @@ impl<'a> Enum<'a> {
     ///
     /// `data_enum` is the `syn` representation of the input enum, `ident` is the
     /// `Identifier` of the enum.
-    fn new(data_enum: &'a DataEnum, ident: &'a Ident, options: ContainerOptions) -> Result<Self> {
+    fn new(
+        data_enum: &'a DataEnum,
+        ident: &'a Ident,
+        options: ContainerAttributes,
+    ) -> Result<Self> {
         ensure_spanned!(
             !data_enum.variants.is_empty(),
             ident.span() => "cannot derive FromPyObject for empty enum"
@@ -35,7 +32,7 @@ impl<'a> Enum<'a> {
             .variants
             .iter()
             .map(|variant| {
-                let mut variant_options = ContainerOptions::from_attrs(&variant.attrs)?;
+                let mut variant_options = ContainerAttributes::from_attrs(&variant.attrs)?;
                 if let Some(rename_all) = &options.rename_all {
                     ensure_spanned!(
                         variant_options.rename_all.is_none(),
@@ -149,7 +146,7 @@ impl<'a> Container<'a> {
     /// Construct a container based on fields, identifier and attributes.
     ///
     /// Fails if the variant has no fields or incompatible attributes.
-    fn new(fields: &'a Fields, path: syn::Path, options: ContainerOptions) -> Result<Self> {
+    fn new(fields: &'a Fields, path: syn::Path, options: ContainerAttributes) -> Result<Self> {
         let style = match fields {
             Fields::Unnamed(unnamed) if !unnamed.unnamed.is_empty() => {
                 ensure_spanned!(
@@ -160,7 +157,7 @@ impl<'a> Container<'a> {
                     .unnamed
                     .iter()
                     .map(|field| {
-                        let attrs = FieldPyO3Attributes::from_attrs(&field.attrs)?;
+                        let attrs = FieldAttributes::from_attrs(&field.attrs)?;
                         ensure_spanned!(
                             attrs.getter.is_none(),
                             field.span() => "`getter` is not permitted on tuple struct elements."
@@ -180,7 +177,7 @@ impl<'a> Container<'a> {
                     // explicit annotation.
                     let field = tuple_fields.pop().unwrap();
                     ContainerType::TupleNewtype(field.from_py_with)
-                } else if options.transparent {
+                } else if options.transparent.is_some() {
                     bail_spanned!(
                         fields.span() => "transparent structs and variants can only have 1 field"
                     );
@@ -197,17 +194,17 @@ impl<'a> Container<'a> {
                             .ident
                             .as_ref()
                             .expect("Named fields should have identifiers");
-                        let mut attrs = FieldPyO3Attributes::from_attrs(&field.attrs)?;
+                        let mut attrs = FieldAttributes::from_attrs(&field.attrs)?;
 
                         if let Some(ref from_item_all) = options.from_item_all {
-                            if let Some(replaced) = attrs.getter.replace(FieldGetter::GetItem(None))
+                            if let Some(replaced) = attrs.getter.replace(FieldGetter::GetItem(parse_quote!(item), None))
                             {
                                 match replaced {
-                                    FieldGetter::GetItem(Some(item_name)) => {
-                                        attrs.getter = Some(FieldGetter::GetItem(Some(item_name)));
+                                    FieldGetter::GetItem(item, Some(item_name)) => {
+                                        attrs.getter = Some(FieldGetter::GetItem(item, Some(item_name)));
                                     }
-                                    FieldGetter::GetItem(None) => bail_spanned!(from_item_all.span() => "Useless `item` - the struct is already annotated with `from_item_all`"),
-                                    FieldGetter::GetAttr(_) => bail_spanned!(
+                                    FieldGetter::GetItem(_, None) => bail_spanned!(from_item_all.span() => "Useless `item` - the struct is already annotated with `from_item_all`"),
+                                    FieldGetter::GetAttr(_, _) => bail_spanned!(
                                         from_item_all.span() => "The struct is already annotated with `from_item_all`, `attribute` is not allowed"
                                     ),
                                 }
@@ -226,7 +223,7 @@ impl<'a> Container<'a> {
                     bail_spanned!(
                         fields.span() => "cannot derive FromPyObject for structs and variants with only default values"
                     )
-                } else if options.transparent {
+                } else if options.transparent.is_some() {
                     ensure_spanned!(
                         struct_fields.len() == 1,
                         fields.span() => "transparent structs and variants can only have 1 field"
@@ -377,24 +374,28 @@ impl<'a> Container<'a> {
         for field in struct_fields {
             let ident = field.ident;
             let field_name = ident.unraw().to_string();
-            let getter = match field.getter.as_ref().unwrap_or(&FieldGetter::GetAttr(None)) {
-                FieldGetter::GetAttr(Some(name)) => {
+            let getter = match field
+                .getter
+                .as_ref()
+                .unwrap_or(&FieldGetter::GetAttr(parse_quote!(attribute), None))
+            {
+                FieldGetter::GetAttr(_, Some(name)) => {
                     quote!(#pyo3_path::types::PyAnyMethods::getattr(obj, #pyo3_path::intern!(obj.py(), #name)))
                 }
-                FieldGetter::GetAttr(None) => {
+                FieldGetter::GetAttr(_, None) => {
                     let name = self
                         .rename_rule
                         .map(|rule| utils::apply_renaming_rule(rule, &field_name));
                     let name = name.as_deref().unwrap_or(&field_name);
                     quote!(#pyo3_path::types::PyAnyMethods::getattr(obj, #pyo3_path::intern!(obj.py(), #name)))
                 }
-                FieldGetter::GetItem(Some(syn::Lit::Str(key))) => {
+                FieldGetter::GetItem(_, Some(syn::Lit::Str(key))) => {
                     quote!(#pyo3_path::types::PyAnyMethods::get_item(obj, #pyo3_path::intern!(obj.py(), #key)))
                 }
-                FieldGetter::GetItem(Some(key)) => {
+                FieldGetter::GetItem(_, Some(key)) => {
                     quote!(#pyo3_path::types::PyAnyMethods::get_item(obj, #key))
                 }
-                FieldGetter::GetItem(None) => {
+                FieldGetter::GetItem(_, None) => {
                     let name = self
                         .rename_rule
                         .map(|rule| utils::apply_renaming_rule(rule, &field_name));
@@ -439,222 +440,6 @@ impl<'a> Container<'a> {
     }
 }
 
-#[derive(Default)]
-struct ContainerOptions {
-    /// Treat the Container as a Wrapper, directly extract its fields from the input object.
-    transparent: bool,
-    /// Force every field to be extracted from item of source Python object.
-    from_item_all: Option<attributes::kw::from_item_all>,
-    /// Change the name of an enum variant in the generated error message.
-    annotation: Option<syn::LitStr>,
-    /// Change the path for the pyo3 crate
-    krate: Option<CrateAttribute>,
-    /// Converts the field idents according to the [RenamingRule] before extraction
-    rename_all: Option<RenameAllAttribute>,
-}
-
-/// Attributes for deriving FromPyObject scoped on containers.
-enum ContainerPyO3Attribute {
-    /// Treat the Container as a Wrapper, directly extract its fields from the input object.
-    Transparent(attributes::kw::transparent),
-    /// Force every field to be extracted from item of source Python object.
-    ItemAll(attributes::kw::from_item_all),
-    /// Change the name of an enum variant in the generated error message.
-    ErrorAnnotation(LitStr),
-    /// Change the path for the pyo3 crate
-    Crate(CrateAttribute),
-    /// Converts the field idents according to the [RenamingRule] before extraction
-    RenameAll(RenameAllAttribute),
-}
-
-impl Parse for ContainerPyO3Attribute {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(attributes::kw::transparent) {
-            let kw: attributes::kw::transparent = input.parse()?;
-            Ok(ContainerPyO3Attribute::Transparent(kw))
-        } else if lookahead.peek(attributes::kw::from_item_all) {
-            let kw: attributes::kw::from_item_all = input.parse()?;
-            Ok(ContainerPyO3Attribute::ItemAll(kw))
-        } else if lookahead.peek(attributes::kw::annotation) {
-            let _: attributes::kw::annotation = input.parse()?;
-            let _: Token![=] = input.parse()?;
-            input.parse().map(ContainerPyO3Attribute::ErrorAnnotation)
-        } else if lookahead.peek(Token![crate]) {
-            input.parse().map(ContainerPyO3Attribute::Crate)
-        } else if lookahead.peek(attributes::kw::rename_all) {
-            input.parse().map(ContainerPyO3Attribute::RenameAll)
-        } else {
-            Err(lookahead.error())
-        }
-    }
-}
-
-impl ContainerOptions {
-    fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
-        let mut options = ContainerOptions::default();
-
-        for attr in attrs {
-            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
-                for pyo3_attr in pyo3_attrs {
-                    match pyo3_attr {
-                        ContainerPyO3Attribute::Transparent(kw) => {
-                            ensure_spanned!(
-                                !options.transparent,
-                                kw.span() => "`transparent` may only be provided once"
-                            );
-                            options.transparent = true;
-                        }
-                        ContainerPyO3Attribute::ItemAll(kw) => {
-                            ensure_spanned!(
-                                options.from_item_all.is_none(),
-                                kw.span() => "`from_item_all` may only be provided once"
-                            );
-                            options.from_item_all = Some(kw);
-                        }
-                        ContainerPyO3Attribute::ErrorAnnotation(lit_str) => {
-                            ensure_spanned!(
-                                options.annotation.is_none(),
-                                lit_str.span() => "`annotation` may only be provided once"
-                            );
-                            options.annotation = Some(lit_str);
-                        }
-                        ContainerPyO3Attribute::Crate(path) => {
-                            ensure_spanned!(
-                                options.krate.is_none(),
-                                path.span() => "`crate` may only be provided once"
-                            );
-                            options.krate = Some(path);
-                        }
-                        ContainerPyO3Attribute::RenameAll(rename_all) => {
-                            ensure_spanned!(
-                                options.rename_all.is_none(),
-                                rename_all.span() => "`rename_all` may only be provided once"
-                            );
-                            options.rename_all = Some(rename_all);
-                        }
-                    }
-                }
-            }
-        }
-        Ok(options)
-    }
-}
-
-/// Attributes for deriving FromPyObject scoped on fields.
-#[derive(Clone, Debug)]
-struct FieldPyO3Attributes {
-    getter: Option<FieldGetter>,
-    from_py_with: Option<FromPyWithAttribute>,
-    default: Option<DefaultAttribute>,
-}
-
-#[derive(Clone, Debug)]
-enum FieldGetter {
-    GetItem(Option<syn::Lit>),
-    GetAttr(Option<LitStr>),
-}
-
-enum FieldPyO3Attribute {
-    Getter(FieldGetter),
-    FromPyWith(FromPyWithAttribute),
-    Default(DefaultAttribute),
-}
-
-impl Parse for FieldPyO3Attribute {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(attributes::kw::attribute) {
-            let _: attributes::kw::attribute = input.parse()?;
-            if input.peek(syn::token::Paren) {
-                let content;
-                let _ = parenthesized!(content in input);
-                let attr_name: LitStr = content.parse()?;
-                if !content.is_empty() {
-                    return Err(content.error(
-                        "expected at most one argument: `attribute` or `attribute(\"name\")`",
-                    ));
-                }
-                ensure_spanned!(
-                    !attr_name.value().is_empty(),
-                    attr_name.span() => "attribute name cannot be empty"
-                );
-                Ok(FieldPyO3Attribute::Getter(FieldGetter::GetAttr(Some(
-                    attr_name,
-                ))))
-            } else {
-                Ok(FieldPyO3Attribute::Getter(FieldGetter::GetAttr(None)))
-            }
-        } else if lookahead.peek(attributes::kw::item) {
-            let _: attributes::kw::item = input.parse()?;
-            if input.peek(syn::token::Paren) {
-                let content;
-                let _ = parenthesized!(content in input);
-                let key = content.parse()?;
-                if !content.is_empty() {
-                    return Err(
-                        content.error("expected at most one argument: `item` or `item(key)`")
-                    );
-                }
-                Ok(FieldPyO3Attribute::Getter(FieldGetter::GetItem(Some(key))))
-            } else {
-                Ok(FieldPyO3Attribute::Getter(FieldGetter::GetItem(None)))
-            }
-        } else if lookahead.peek(attributes::kw::from_py_with) {
-            input.parse().map(FieldPyO3Attribute::FromPyWith)
-        } else if lookahead.peek(Token![default]) {
-            input.parse().map(FieldPyO3Attribute::Default)
-        } else {
-            Err(lookahead.error())
-        }
-    }
-}
-
-impl FieldPyO3Attributes {
-    /// Extract the field attributes.
-    fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
-        let mut getter = None;
-        let mut from_py_with = None;
-        let mut default = None;
-
-        for attr in attrs {
-            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
-                for pyo3_attr in pyo3_attrs {
-                    match pyo3_attr {
-                        FieldPyO3Attribute::Getter(field_getter) => {
-                            ensure_spanned!(
-                                getter.is_none(),
-                                attr.span() => "only one of `attribute` or `item` can be provided"
-                            );
-                            getter = Some(field_getter);
-                        }
-                        FieldPyO3Attribute::FromPyWith(from_py_with_attr) => {
-                            ensure_spanned!(
-                                from_py_with.is_none(),
-                                attr.span() => "`from_py_with` may only be provided once"
-                            );
-                            from_py_with = Some(from_py_with_attr);
-                        }
-                        FieldPyO3Attribute::Default(default_attr) => {
-                            ensure_spanned!(
-                                default.is_none(),
-                                attr.span() => "`default` may only be provided once"
-                            );
-                            default = Some(default_attr);
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(FieldPyO3Attributes {
-            getter,
-            from_py_with,
-            default,
-        })
-    }
-}
-
 fn verify_and_get_lifetime(generics: &syn::Generics) -> Result<Option<&syn::LifetimeParam>> {
     let mut lifetimes = generics.lifetimes();
     let lifetime = lifetimes.next();
@@ -674,7 +459,7 @@ fn verify_and_get_lifetime(generics: &syn::Generics) -> Result<Option<&syn::Life
 ///   * Derivation for structs with generic fields like `struct<T> Foo(T)`
 ///     adds `T: FromPyObject` on the derived implementation.
 pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
-    let options = ContainerOptions::from_attrs(&tokens.attrs)?;
+    let options = ContainerAttributes::from_attrs(&tokens.attrs)?;
     let ctx = &Ctx::new(&options.krate, None);
     let Ctx { pyo3_path, .. } = &ctx;
 
@@ -698,7 +483,7 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
 
     let derives = match &tokens.data {
         syn::Data::Enum(en) => {
-            if options.transparent || options.annotation.is_some() {
+            if options.transparent.is_some() || options.annotation.is_some() {
                 bail_spanned!(tokens.span() => "`transparent` or `annotation` is not supported \
                                                 at top level for enums");
             }

--- a/pyo3-macros-backend/src/intopyobject.rs
+++ b/pyo3-macros-backend/src/intopyobject.rs
@@ -1,173 +1,13 @@
-use crate::attributes::{self, get_pyo3_options, CrateAttribute, IntoPyWithAttribute};
+use crate::attributes::IntoPyWithAttribute;
+use crate::derive_attributes::{ContainerAttributes, FieldAttributes};
 use crate::utils::Ctx;
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote, quote_spanned};
+use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::ext::IdentExt;
-use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned as _;
-use syn::{
-    parenthesized, parse_quote, Attribute, DataEnum, DeriveInput, Fields, Ident, Index, Result,
-    Token,
-};
+use syn::{parse_quote, DataEnum, DeriveInput, Fields, Ident, Index, Result};
 
-/// Attributes for deriving `IntoPyObject` scoped on containers.
-enum ContainerPyO3Attribute {
-    /// Treat the Container as a Wrapper, directly convert its field into the output object.
-    Transparent(attributes::kw::transparent),
-    /// Change the path for the pyo3 crate
-    Crate(CrateAttribute),
-}
-
-impl Parse for ContainerPyO3Attribute {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(attributes::kw::transparent) {
-            let kw: attributes::kw::transparent = input.parse()?;
-            Ok(ContainerPyO3Attribute::Transparent(kw))
-        } else if lookahead.peek(Token![crate]) {
-            input.parse().map(ContainerPyO3Attribute::Crate)
-        } else {
-            Err(lookahead.error())
-        }
-    }
-}
-
-#[derive(Default)]
-struct ContainerOptions {
-    /// Treat the Container as a Wrapper, directly convert its field into the output object.
-    transparent: Option<attributes::kw::transparent>,
-    /// Change the path for the pyo3 crate
-    krate: Option<CrateAttribute>,
-}
-
-impl ContainerOptions {
-    fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
-        let mut options = ContainerOptions::default();
-
-        for attr in attrs {
-            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
-                pyo3_attrs
-                    .into_iter()
-                    .try_for_each(|opt| options.set_option(opt))?;
-            }
-        }
-        Ok(options)
-    }
-
-    fn set_option(&mut self, option: ContainerPyO3Attribute) -> syn::Result<()> {
-        macro_rules! set_option {
-            ($key:ident) => {
-                {
-                    ensure_spanned!(
-                        self.$key.is_none(),
-                        $key.span() => concat!("`", stringify!($key), "` may only be specified once")
-                    );
-                    self.$key = Some($key);
-                }
-            };
-        }
-
-        match option {
-            ContainerPyO3Attribute::Transparent(transparent) => set_option!(transparent),
-            ContainerPyO3Attribute::Crate(krate) => set_option!(krate),
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Clone)]
-struct ItemOption {
-    field: Option<syn::LitStr>,
-    span: Span,
-}
-
-impl ItemOption {
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-enum FieldAttribute {
-    Item(ItemOption),
-    IntoPyWith(IntoPyWithAttribute),
-}
-
-impl Parse for FieldAttribute {
-    fn parse(input: ParseStream<'_>) -> Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(attributes::kw::attribute) {
-            let attr: attributes::kw::attribute = input.parse()?;
-            bail_spanned!(attr.span => "`attribute` is not supported by `IntoPyObject`");
-        } else if lookahead.peek(attributes::kw::item) {
-            let attr: attributes::kw::item = input.parse()?;
-            if input.peek(syn::token::Paren) {
-                let content;
-                let _ = parenthesized!(content in input);
-                let key = content.parse()?;
-                if !content.is_empty() {
-                    return Err(
-                        content.error("expected at most one argument: `item` or `item(key)`")
-                    );
-                }
-                Ok(FieldAttribute::Item(ItemOption {
-                    field: Some(key),
-                    span: attr.span,
-                }))
-            } else {
-                Ok(FieldAttribute::Item(ItemOption {
-                    field: None,
-                    span: attr.span,
-                }))
-            }
-        } else if lookahead.peek(attributes::kw::into_py_with) {
-            input.parse().map(FieldAttribute::IntoPyWith)
-        } else {
-            Err(lookahead.error())
-        }
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-struct FieldAttributes {
-    item: Option<ItemOption>,
-    into_py_with: Option<IntoPyWithAttribute>,
-}
-
-impl FieldAttributes {
-    /// Extract the field attributes.
-    fn from_attrs(attrs: &[Attribute]) -> Result<Self> {
-        let mut options = FieldAttributes::default();
-
-        for attr in attrs {
-            if let Some(pyo3_attrs) = get_pyo3_options(attr)? {
-                pyo3_attrs
-                    .into_iter()
-                    .try_for_each(|opt| options.set_option(opt))?;
-            }
-        }
-        Ok(options)
-    }
-
-    fn set_option(&mut self, option: FieldAttribute) -> syn::Result<()> {
-        macro_rules! set_option {
-            ($key:ident) => {
-                {
-                    ensure_spanned!(
-                        self.$key.is_none(),
-                        $key.span() => concat!("`", stringify!($key), "` may only be specified once")
-                    );
-                    self.$key = Some($key);
-                }
-            };
-        }
-
-        match option {
-            FieldAttribute::Item(item) => set_option!(item),
-            FieldAttribute::IntoPyWith(into_py_with) => set_option!(into_py_with),
-        }
-        Ok(())
-    }
-}
+struct ItemOption(Option<syn::Lit>);
 
 enum IntoPyObjectTypes {
     Transparent(syn::Type),
@@ -235,7 +75,7 @@ impl<'a, const REF: bool> Container<'a, REF> {
         receiver: Option<Ident>,
         fields: &'a Fields,
         path: syn::Path,
-        options: ContainerOptions,
+        options: ContainerAttributes,
     ) -> Result<Self> {
         let style = match fields {
             Fields::Unnamed(unnamed) if !unnamed.unnamed.is_empty() => {
@@ -245,8 +85,8 @@ impl<'a, const REF: bool> Container<'a, REF> {
                     .map(|field| {
                         let attrs = FieldAttributes::from_attrs(&field.attrs)?;
                         ensure_spanned!(
-                            attrs.item.is_none(),
-                            attrs.item.unwrap().span() => "`item` is not permitted on tuple struct elements."
+                            attrs.getter.is_none(),
+                            attrs.getter.unwrap().span() => "`item` and `attribute` are not permitted on tuple struct elements."
                         );
                         Ok(TupleStructField {
                             field,
@@ -284,8 +124,8 @@ impl<'a, const REF: bool> Container<'a, REF> {
                     let field = named.named.iter().next().unwrap();
                     let attrs = FieldAttributes::from_attrs(&field.attrs)?;
                     ensure_spanned!(
-                        attrs.item.is_none(),
-                        attrs.item.unwrap().span() => "`transparent` structs may not have `item` for the inner field"
+                        attrs.getter.is_none(),
+                        attrs.getter.unwrap().span() => "`transparent` structs may not have `item` nor `attribute` for the inner field"
                     );
                     ensure_spanned!(
                         attrs.into_py_with.is_none(),
@@ -307,7 +147,12 @@ impl<'a, const REF: bool> Container<'a, REF> {
                             Ok(NamedStructField {
                                 ident,
                                 field,
-                                item: attrs.item,
+                                item: attrs.getter.and_then(|getter| match getter {
+                                    crate::derive_attributes::FieldGetter::GetItem(_, lit) => {
+                                        Some(ItemOption(lit))
+                                    }
+                                    crate::derive_attributes::FieldGetter::GetAttr(_, _) => None,
+                                }),
                                 into_py_with: attrs.into_py_with,
                             })
                         })
@@ -407,9 +252,9 @@ impl<'a, const REF: bool> Container<'a, REF> {
                 let key = f
                     .item
                     .as_ref()
-                    .and_then(|item| item.field.as_ref())
-                    .map(|item| item.value())
-                    .unwrap_or_else(|| f.ident.unraw().to_string());
+                    .and_then(|item| item.0.as_ref())
+                    .map(|item| item.into_token_stream())
+                    .unwrap_or_else(|| f.ident.unraw().to_string().into_token_stream());
                 let value = Ident::new(&format!("arg{i}"), f.field.ty.span());
 
                 if let Some(expr_path) = f.into_py_with.as_ref().map(|i|&i.value) {
@@ -519,7 +364,7 @@ impl<'a, const REF: bool> Enum<'a, REF> {
             .variants
             .iter()
             .map(|variant| {
-                let attrs = ContainerOptions::from_attrs(&variant.attrs)?;
+                let attrs = ContainerAttributes::from_attrs(&variant.attrs)?;
                 let var_ident = &variant.ident;
 
                 ensure_spanned!(
@@ -582,7 +427,7 @@ fn verify_and_get_lifetime(generics: &syn::Generics) -> Option<&syn::LifetimePar
 }
 
 pub fn build_derive_into_pyobject<const REF: bool>(tokens: &DeriveInput) -> Result<TokenStream> {
-    let options = ContainerOptions::from_attrs(&tokens.attrs)?;
+    let options = ContainerAttributes::from_attrs(&tokens.attrs)?;
     let ctx = &Ctx::new(&options.krate, None);
     let Ctx { pyo3_path, .. } = &ctx;
 

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -9,6 +9,7 @@
 mod utils;
 
 mod attributes;
+mod derive_attributes;
 mod frompyobject;
 mod intopyobject;
 #[cfg(feature = "experimental-inspect")]

--- a/tests/ui/invalid_frompy_derive.stderr
+++ b/tests/ui/invalid_frompy_derive.stderr
@@ -84,7 +84,7 @@ error: transparent structs and variants can only have 1 field
 70 | |     },
    | |_____^
 
-error: expected one of: `attribute`, `item`, `from_py_with`, `default`
+error: expected one of: `attribute`, `item`, `from_py_with`, `into_py_with`, `default`
   --> tests/ui/invalid_frompy_derive.rs:76:12
    |
 76 |     #[pyo3(attr)]
@@ -127,10 +127,10 @@ error: unexpected end of input, expected literal
     |                 ^
 
 error: only one of `attribute` or `item` can be provided
-   --> tests/ui/invalid_frompy_derive.rs:118:5
+   --> tests/ui/invalid_frompy_derive.rs:118:18
     |
 118 |     #[pyo3(item, attribute)]
-    |     ^
+    |                  ^^^^^^^^^
 
 error: expected one of: `transparent`, `from_item_all`, `annotation`, `crate`, `rename_all`
    --> tests/ui/invalid_frompy_derive.rs:123:8
@@ -194,7 +194,7 @@ error: `transparent` structs may not have a `getter` for the inner field
 186 |     field: String,
     |     ^^^^^
 
-error: `from_item_all` may only be provided once
+error: `from_item_all` may only be specified once
    --> tests/ui/invalid_frompy_derive.rs:190:23
     |
 190 | #[pyo3(from_item_all, from_item_all)]
@@ -244,7 +244,7 @@ error: `default` is not permitted on tuple struct elements.
 231 | struct NamedTuplesWithDefaultValues(#[pyo3(default)] String);
     |                                     ^
 
-error: `rename_all` may only be provided once
+error: `rename_all` may only be specified once
    --> tests/ui/invalid_frompy_derive.rs:234:34
     |
 234 | #[pyo3(rename_all = "camelCase", rename_all = "kebab-case")]

--- a/tests/ui/invalid_intopy_derive.stderr
+++ b/tests/ui/invalid_intopy_derive.stderr
@@ -84,7 +84,7 @@ error: transparent structs and variants can only have 1 field
 70 | |     },
    | |_____^
 
-error: expected `transparent` or `crate`
+error: expected one of: `transparent`, `from_item_all`, `annotation`, `crate`, `rename_all`
   --> tests/ui/invalid_intopy_derive.rs:75:8
    |
 75 | #[pyo3(unknown = "should not work")]
@@ -102,25 +102,19 @@ error: cannot derive `IntoPyObject` for empty variants
 87 |     Unit,
    |     ^^^^
 
-error: `attribute` is not supported by `IntoPyObject`
+error: `item` and `attribute` are not permitted on tuple struct elements.
   --> tests/ui/invalid_intopy_derive.rs:91:30
    |
 91 | struct TupleAttribute(#[pyo3(attribute)] String, usize);
    |                              ^^^^^^^^^
 
-error: `item` is not permitted on tuple struct elements.
+error: `item` and `attribute` are not permitted on tuple struct elements.
   --> tests/ui/invalid_intopy_derive.rs:94:25
    |
 94 | struct TupleItem(#[pyo3(item)] String, usize);
    |                         ^^^^
 
-error: `attribute` is not supported by `IntoPyObject`
-  --> tests/ui/invalid_intopy_derive.rs:98:12
-   |
-98 |     #[pyo3(attribute)]
-   |            ^^^^^^^^^
-
-error: `transparent` structs may not have `item` for the inner field
+error: `transparent` structs may not have `item` nor `attribute` for the inner field
    --> tests/ui/invalid_intopy_derive.rs:105:12
     |
 105 |     #[pyo3(item)]


### PR DESCRIPTION
This combines the attributes of the `IntoPyObject` and `FromPyObject` derive macros, such that individual options can still be used when deriving both.

Closes #4884 