### PR TITLE
ffi: expose PyDateTime_*_GET_TZINFO on PyPy

### DIFF
--- a/newsfragments/5079.changed.md
+++ b/newsfragments/5079.changed.md
@@ -1,0 +1,1 @@
+Expose `PyDateTime_DATE_GET_TZINFO` and `PyDateTime_TIME_GET_TZINFO` on PyPy 3.10 and later

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -487,7 +487,9 @@ extern "C" {
     pub fn PyDateTime_DATE_GET_MICROSECOND(o: *mut PyObject) -> c_int;
     #[link_name = "PyPyDateTime_GET_FOLD"]
     pub fn PyDateTime_DATE_GET_FOLD(o: *mut PyObject) -> c_int;
-    // skipped PyDateTime_DATE_GET_TZINFO (not in PyPy)
+    #[link_name = "PyPyDateTime_DATE_GET_TZINFO"]
+    #[cfg(Py_3_10)]
+    pub fn PyDateTime_DATE_GET_TZINFO(o: *mut PyObject) -> *mut PyObject;
 
     #[link_name = "PyPyDateTime_TIME_GET_HOUR"]
     pub fn PyDateTime_TIME_GET_HOUR(o: *mut PyObject) -> c_int;
@@ -499,7 +501,9 @@ extern "C" {
     pub fn PyDateTime_TIME_GET_MICROSECOND(o: *mut PyObject) -> c_int;
     #[link_name = "PyPyDateTime_TIME_GET_FOLD"]
     pub fn PyDateTime_TIME_GET_FOLD(o: *mut PyObject) -> c_int;
-    // skipped PyDateTime_TIME_GET_TZINFO (not in PyPy)
+    #[link_name = "PyPyDateTime_TIME_GET_TZINFO"]
+    #[cfg(Py_3_10)]
+    pub fn PyDateTime_TIME_GET_TZINFO(o: *mut PyObject) -> *mut PyObject;
 
     #[link_name = "PyPyDateTime_DELTA_GET_DAYS"]
     pub fn PyDateTime_DELTA_GET_DAYS(o: *mut PyObject) -> c_int;

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -14,7 +14,7 @@ use crate::ffi::{
     PyDateTime_TIME_GET_MICROSECOND, PyDateTime_TIME_GET_MINUTE, PyDateTime_TIME_GET_SECOND,
     PyDate_FromTimestamp,
 };
-#[cfg(all(GraalPy, not(Py_LIMITED_API)))]
+#[cfg(all(Py_3_10, not(Py_LIMITED_API)))]
 use crate::ffi::{PyDateTime_DATE_GET_TZINFO, PyDateTime_TIME_GET_TZINFO, Py_IsNone};
 use crate::types::any::PyAnyMethods;
 #[cfg(not(Py_LIMITED_API))]
@@ -518,11 +518,9 @@ impl PyTimeAccess for Bound<'_, PyDateTime> {
 
 impl<'py> PyTzInfoAccess<'py> for Bound<'py, PyDateTime> {
     fn get_tzinfo(&self) -> Option<Bound<'py, PyTzInfo>> {
-        #[cfg(not(Py_LIMITED_API))]
-        let ptr = self.as_ptr() as *mut ffi::PyDateTime_DateTime;
-
-        #[cfg(not(any(GraalPy, Py_LIMITED_API)))]
+        #[cfg(all(not(Py_3_10), not(Py_LIMITED_API)))]
         unsafe {
+            let ptr = self.as_ptr() as *mut ffi::PyDateTime_DateTime;
             if (*ptr).hastzinfo != 0 {
                 Some(
                     (*ptr)
@@ -536,9 +534,9 @@ impl<'py> PyTzInfoAccess<'py> for Bound<'py, PyDateTime> {
             }
         }
 
-        #[cfg(all(GraalPy, not(Py_LIMITED_API)))]
+        #[cfg(all(Py_3_10, not(Py_LIMITED_API)))]
         unsafe {
-            let res = PyDateTime_DATE_GET_TZINFO(ptr as *mut ffi::PyObject);
+            let res = PyDateTime_DATE_GET_TZINFO(self.as_ptr());
             if Py_IsNone(res) == 1 {
                 None
             } else {
@@ -700,11 +698,9 @@ impl PyTimeAccess for Bound<'_, PyTime> {
 
 impl<'py> PyTzInfoAccess<'py> for Bound<'py, PyTime> {
     fn get_tzinfo(&self) -> Option<Bound<'py, PyTzInfo>> {
-        #[cfg(not(Py_LIMITED_API))]
-        let ptr = self.as_ptr() as *mut ffi::PyDateTime_Time;
-
-        #[cfg(not(any(GraalPy, Py_LIMITED_API)))]
+        #[cfg(all(not(Py_3_10), not(Py_LIMITED_API)))]
         unsafe {
+            let ptr = self.as_ptr() as *mut ffi::PyDateTime_Time;
             if (*ptr).hastzinfo != 0 {
                 Some(
                     (*ptr)
@@ -718,9 +714,9 @@ impl<'py> PyTzInfoAccess<'py> for Bound<'py, PyTime> {
             }
         }
 
-        #[cfg(all(GraalPy, not(Py_LIMITED_API)))]
+        #[cfg(all(Py_3_10, not(Py_LIMITED_API)))]
         unsafe {
-            let res = PyDateTime_TIME_GET_TZINFO(ptr as *mut ffi::PyObject);
+            let res = PyDateTime_TIME_GET_TZINFO(self.as_ptr());
             if Py_IsNone(res) == 1 {
                 None
             } else {


### PR DESCRIPTION
They are available in PyPy3.10 and PyPy3.11.

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
