### PR TITLE
add `PyModule_Add` to `pyo3-ffi`

### DIFF
--- a/newsfragments/5085.added.md
+++ b/newsfragments/5085.added.md
@@ -1,0 +1,1 @@
+add `PyModule_Add` to `pyo3-ffi`

--- a/pyo3-ffi/src/compat/py_3_10.rs
+++ b/pyo3-ffi/src/compat/py_3_10.rs
@@ -17,3 +17,29 @@ compat_function!(
         obj
     }
 );
+
+compat_function!(
+    originally_defined_for(Py_3_10);
+
+    #[inline]
+    pub unsafe fn PyModule_AddObjectRef(
+        module: *mut crate::PyObject,
+        name: *const std::os::raw::c_char,
+        value: *mut crate::PyObject,
+    ) -> std::os::raw::c_int {
+        if value.is_null() && crate::PyErr_Occurred().is_null() {
+            crate::PyErr_SetString(
+                crate::PyExc_SystemError,
+                c_str!("PyModule_AddObjectRef() must be called with an exception raised if value is NULL").as_ptr(),
+            );
+            return -1;
+        }
+
+        crate::Py_XINCREF(value);
+        let result = crate::PyModule_AddObject(module, name, value);
+        if result < 0 {
+            crate::Py_XDECREF(value);
+        }
+        result
+    }
+);

--- a/pyo3-ffi/src/compat/py_3_13.rs
+++ b/pyo3-ffi/src/compat/py_3_13.rs
@@ -114,7 +114,7 @@ compat_function!(
         name: *const std::os::raw::c_char,
         value: *mut crate::PyObject,
     ) -> std::os::raw::c_int {
-        let result = crate::PyModule_AddObjectRef(module, name, value);
+        let result = crate::compat::PyModule_AddObjectRef(module, name, value);
         crate::Py_XDECREF(value);
         result
     }

--- a/pyo3-ffi/src/compat/py_3_13.rs
+++ b/pyo3-ffi/src/compat/py_3_13.rs
@@ -104,3 +104,18 @@ compat_function!(
         crate::PyList_SetSlice(list, 0, crate::PY_SSIZE_T_MAX, std::ptr::null_mut())
     }
 );
+
+compat_function!(
+    originally_defined_for(Py_3_13);
+
+    #[inline]
+    pub unsafe fn PyModule_Add(
+        module: *mut crate::PyObject,
+        name: *const std::os::raw::c_char,
+        value: *mut crate::PyObject,
+    ) -> std::os::raw::c_int {
+        let result = crate::PyModule_AddObjectRef(module, name, value);
+        crate::Py_XDECREF(value);
+        result
+    }
+);

--- a/pyo3-ffi/src/modsupport.rs
+++ b/pyo3-ffi/src/modsupport.rs
@@ -36,6 +36,8 @@ extern "C" {
     pub fn Py_BuildValue(arg1: *const c_char, ...) -> *mut PyObject;
     // skipped Py_VaBuildValue
 
+    #[cfg(Py_3_13)]
+    pub fn PyModule_Add(module: *mut PyObject, name: *const c_char, value: *mut PyObject) -> c_int;
     #[cfg(Py_3_10)]
     #[cfg_attr(PyPy, link_name = "PyPyModule_AddObjectRef")]
     pub fn PyModule_AddObjectRef(


### PR DESCRIPTION
Added `PyModule_Add` with a compatibility wrapper for pre-3.13 python versions. 
