### PR TITLE
add `Py_HashBuffer` to `pyo3-ffi`

### DIFF
--- a/newsfragments/5086.added.md
+++ b/newsfragments/5086.added.md
@@ -1,1 +1,3 @@
-add `Py_HashBuffer` to `pyo3-ffi`
+- add `Py_HashBuffer` to `pyo3-ffi`
+- add `Py_HashPointer` to `pyo3-ffi`
+- add `PyObject_GenericHash` to `pyo3-ffi`

--- a/newsfragments/5086.added.md
+++ b/newsfragments/5086.added.md
@@ -1,0 +1,1 @@
+add `Py_HashBuffer` to `pyo3-ffi`

--- a/pyo3-ffi/src/compat/mod.rs
+++ b/pyo3-ffi/src/compat/mod.rs
@@ -52,8 +52,10 @@ macro_rules! compat_function {
 
 mod py_3_10;
 mod py_3_13;
+mod py_3_14;
 mod py_3_9;
 
 pub use self::py_3_10::*;
 pub use self::py_3_13::*;
+pub use self::py_3_14::*;
 pub use self::py_3_9::*;

--- a/pyo3-ffi/src/compat/py_3_14.rs
+++ b/pyo3-ffi/src/compat/py_3_14.rs
@@ -1,5 +1,5 @@
 compat_function!(
-    originally_defined_for(Py_3_14);
+    originally_defined_for(all(Py_3_14, not(Py_LIMITED_API)));
 
     #[inline]
     pub unsafe fn Py_HashBuffer(

--- a/pyo3-ffi/src/compat/py_3_14.rs
+++ b/pyo3-ffi/src/compat/py_3_14.rs
@@ -1,0 +1,26 @@
+compat_function!(
+    originally_defined_for(Py_3_14);
+
+    #[inline]
+    pub unsafe fn Py_HashBuffer(
+        ptr: *const std::ffi::c_void,
+        len: crate::Py_ssize_t,
+    ) -> crate::Py_hash_t {
+        #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+        {
+            crate::_Py_HashBytes(ptr, len)
+        }
+
+        #[cfg(any(Py_LIMITED_API, PyPy))]
+        {
+            let bytes = crate::PyBytes_FromStringAndSize(ptr as *const std::os::raw::c_char, len);
+            if bytes.is_null() {
+                -1
+            } else {
+                let result = crate::PyObject_Hash(bytes);
+                crate::Py_DECREF(bytes);
+                result
+            }
+        }
+    }
+);

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -38,6 +38,7 @@ pub(crate) mod pythonrun;
 // skipped sysmodule.h
 pub(crate) mod floatobject;
 pub(crate) mod pyframe;
+pub(crate) mod pyhash;
 pub(crate) mod tupleobject;
 pub(crate) mod unicodeobject;
 pub(crate) mod weakrefobject;
@@ -73,6 +74,7 @@ pub use self::pydebug::*;
 pub use self::pyerrors::*;
 #[cfg(all(Py_3_11, not(PyPy)))]
 pub use self::pyframe::*;
+pub use self::pyhash::*;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub use self::pylifecycle::*;
 pub use self::pymem::*;

--- a/pyo3-ffi/src/cpython/pyhash.rs
+++ b/pyo3-ffi/src/cpython/pyhash.rs
@@ -1,0 +1,30 @@
+#[cfg(Py_3_13)]
+use crate::PyObject;
+use crate::{Py_hash_t, Py_ssize_t};
+use std::os::raw::{c_char, c_int, c_void};
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct PyHash_FuncDef {
+    pub hash: Option<extern "C" fn(arg1: *const c_void, arg2: Py_ssize_t) -> Py_hash_t>,
+    pub name: *const c_char,
+    pub hash_bits: c_int,
+    pub seed_bits: c_int,
+}
+
+impl Default for PyHash_FuncDef {
+    #[inline]
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+extern "C" {
+    pub fn PyHash_GetFuncDef() -> *mut PyHash_FuncDef;
+    #[cfg(Py_3_13)]
+    pub fn Py_HashPointer(ptr: *const c_void) -> Py_hash_t;
+    #[cfg(Py_3_13)]
+    pub fn PyObject_GenericHash(obj: *mut PyObject) -> Py_hash_t;
+    #[cfg(Py_3_14)]
+    pub fn Py_HashBuffer(ptr: *const c_void, len: Py_ssize_t) -> Py_hash_t;
+}

--- a/pyo3-ffi/src/pyhash.rs
+++ b/pyo3-ffi/src/pyhash.rs
@@ -14,6 +14,9 @@ extern "C" {
 
     #[cfg(not(any(Py_LIMITED_API, PyPy)))]
     pub fn _Py_HashBytes(src: *const c_void, len: Py_ssize_t) -> Py_hash_t;
+
+    #[cfg(Py_3_14)]
+    pub fn Py_HashBuffer(ptr: *const c_void, len: Py_ssize_t) -> Py_hash_t;
 }
 
 pub const _PyHASH_MULTIPLIER: c_ulong = 1000003;

--- a/pyo3-ffi/src/pyhash.rs
+++ b/pyo3-ffi/src/pyhash.rs
@@ -1,7 +1,5 @@
 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
 use crate::pyport::{Py_hash_t, Py_ssize_t};
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-use std::os::raw::c_char;
 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
 use std::os::raw::c_void;
 
@@ -14,9 +12,6 @@ extern "C" {
 
     #[cfg(not(any(Py_LIMITED_API, PyPy)))]
     pub fn _Py_HashBytes(src: *const c_void, len: Py_ssize_t) -> Py_hash_t;
-
-    #[cfg(Py_3_14)]
-    pub fn Py_HashBuffer(ptr: *const c_void, len: Py_ssize_t) -> Py_hash_t;
 }
 
 pub const _PyHASH_MULTIPLIER: c_ulong = 1000003;
@@ -24,29 +19,6 @@ pub const _PyHASH_MULTIPLIER: c_ulong = 1000003;
 // skipped _PyHASH_BITS
 
 // skipped non-limited _Py_HashSecret_t
-
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-#[repr(C)]
-#[derive(Copy, Clone)]
-pub struct PyHash_FuncDef {
-    pub hash: Option<extern "C" fn(arg1: *const c_void, arg2: Py_ssize_t) -> Py_hash_t>,
-    pub name: *const c_char,
-    pub hash_bits: c_int,
-    pub seed_bits: c_int,
-}
-
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-impl Default for PyHash_FuncDef {
-    #[inline]
-    fn default() -> Self {
-        unsafe { std::mem::zeroed() }
-    }
-}
-
-extern "C" {
-    #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
-    pub fn PyHash_GetFuncDef() -> *mut PyHash_FuncDef;
-}
 
 // skipped Py_HASH_CUTOFF
 


### PR DESCRIPTION
It is maybe too early to add support for python 3.14 function, but this paves the way to remove the private `_Py_HashBytes`.

ref [pythoncapi-compat](https://github.com/python/pythoncapi-compat/blob/0a8b2c56331a31d7f7096faaa1c1c26467b51c15/pythoncapi_compat.h#L1599-L1617)