### PR TITLE
ci: move main build to use `test-rust` nox job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,24 @@ jobs:
         name: Prepare to test on nightly rust
         run: echo "MAYBE_NIGHTLY=nightly" >> "$GITHUB_ENV"
 
+      - uses: dorny/paths-filter@v3
+        if: ${{ inputs.rust == 'stable' && !startsWith(inputs.python-version, 'graalpy') }}
+        id: ffi-changes
+        with:
+          base: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
+          filters: |
+            changed:
+              - 'pyo3-ffi/**'
+              - 'pyo3-ffi-check/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/build.yml'
+
+      - name: Run pyo3-ffi-check
+        # pypy 3.9 on windows is not PEP 3123 compliant, nor is graalpy
+        if: ${{ endsWith(inputs.python-version, '-dev') || (steps.ffi-changes.outputs.changed == 'true' && inputs.rust == 'stable' && !startsWith(inputs.python-version, 'graalpy') && !(inputs.python-version == 'pypy3.9' && contains(inputs.os, 'windows'))) }}
+        run: nox -s ffi-check
+
       - if: ${{ github.event_name != 'merge_group' }}
         name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
@@ -99,65 +117,8 @@ jobs:
       - name: Build docs
         run: nox -s docs
 
-      - name: Build (no features)
-        if: ${{ !startsWith(inputs.python-version, 'graalpy') }}
-        run: cargo build --lib --tests --no-default-features
-
-      # --no-default-features when used with `cargo build/test -p` doesn't seem to work!
-      - name: Build pyo3-build-config (no features)
-        run: |
-          cd pyo3-build-config
-          cargo build --no-default-features
-
-      # Run tests (except on PyPy, because no embedding API).
-      - if: ${{ !startsWith(inputs.python-version, 'pypy') && !startsWith(inputs.python-version, 'graalpy') }}
-        name: Test (no features)
-        run: cargo test --no-default-features --lib --tests
-
-      # --no-default-features when used with `cargo build/test -p` doesn't seem to work!
-      - name: Test pyo3-build-config (no features)
-        run: |
-          cd pyo3-build-config
-          cargo test --no-default-features
-
-      - name: Build (all additive features)
-        if: ${{ !startsWith(inputs.python-version, 'graalpy') }}
-        run: cargo build --lib --tests --no-default-features --features "multiple-pymethods full $MAYBE_NIGHTLY"
-
-      - if: ${{ startsWith(inputs.python-version, 'pypy') }}
-        name: Build PyPy (abi3-py39)
-        run: cargo build --lib --tests --no-default-features --features "multiple-pymethods abi3-py39 full $MAYBE_NIGHTLY"
-
-      - name: Run pyo3-ffi-check
-        # pypy 3.9 on windows is not PEP 3123 compliant, nor is graalpy
-        if: ${{ endsWith(inputs.python-version, '-dev') || (steps.ffi-changes.outputs.changed == 'true' && inputs.rust == 'stable' && !startsWith(inputs.python-version, 'graalpy') && !(inputs.python-version == 'pypy3.9' && contains(inputs.os, 'windows'))) }}
-        run: nox -s ffi-check
-
-      # Run tests (except on PyPy, because no embedding API).
-      - if: ${{ !startsWith(inputs.python-version, 'pypy') && !startsWith(inputs.python-version, 'graalpy') }}
-        name: Test
-        run: cargo test --no-default-features --features "full $MAYBE_NIGHTLY"
-
-      # Repeat, with multiple-pymethods feature enabled (it's not entirely additive)
-      - if: ${{ !startsWith(inputs.python-version, 'pypy') && !startsWith(inputs.python-version, 'graalpy') }}
-        name: Test
-        run: cargo test --no-default-features --features "multiple-pymethods full $MAYBE_NIGHTLY"
-
-      # Run tests again, but in abi3 mode
-      - if: ${{ !startsWith(inputs.python-version, 'pypy') && !startsWith(inputs.python-version, 'graalpy') }}
-        name: Test (abi3)
-        run: cargo test --no-default-features --features "multiple-pymethods abi3 full $MAYBE_NIGHTLY"
-
-      # Run tests again, for abi3-py37 (the minimal Python version)
-      - if: ${{ (!startsWith(inputs.python-version, 'pypy') && !startsWith(inputs.python-version, 'graalpy')) && (inputs.python-version != '3.7') }}
-        name: Test (abi3-py37)
-        run: cargo test --no-default-features --features "multiple-pymethods abi3-py37 full $MAYBE_NIGHTLY"
-
-      - name: Test proc-macro code
-        run: cargo test --manifest-path=pyo3-macros-backend/Cargo.toml
-
-      - name: Test build config
-        run: cargo test --manifest-path=pyo3-build-config/Cargo.toml
+      - name: Run Rust tests
+        run: nox -s test-rust
 
       - name: Test python examples and tests
         shell: bash
@@ -165,19 +126,6 @@ jobs:
         continue-on-error: ${{ endsWith(inputs.python-version, '-dev') }}
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/target
-
-      - uses: dorny/paths-filter@v3
-        if: ${{ inputs.rust == 'stable' && !startsWith(inputs.python-version, 'graalpy') }}
-        id: ffi-changes
-        with:
-          base: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
-          ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
-          filters: |
-            changed:
-              - 'pyo3-ffi/**'
-              - 'pyo3-ffi-check/**'
-              - '.github/workflows/ci.yml'
-              - '.github/workflows/build.yml'
 
       - if: ${{ github.event_name != 'merge_group' }}
         name: Generate coverage report
@@ -193,7 +141,7 @@ jobs:
         name: Upload coverage report
         uses: codecov/codecov-action@v5
         with:
-          file: coverage.json
+          files: coverage.json
           name: ${{ inputs.os }}/${{ inputs.python-version }}/${{ inputs.rust }}
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,6 @@ jobs:
         name: Ignore changed error messages when using trybuild
         run: echo "TRYBUILD=overwrite" >> "$GITHUB_ENV"
 
-      - if: inputs.rust == 'nightly'
-        name: Prepare to test on nightly rust
-        run: echo "MAYBE_NIGHTLY=nightly" >> "$GITHUB_ENV"
-
       - uses: dorny/paths-filter@v3
         if: ${{ inputs.rust == 'stable' && !startsWith(inputs.python-version, 'graalpy') }}
         id: ffi-changes

--- a/newsfragments/5091.fixed.md
+++ b/newsfragments/5091.fixed.md
@@ -1,0 +1,1 @@
+Fix various compile errors from missing FFI definitions using certain feature combinations on PyPy and GraalPy.

--- a/pyo3-ffi/src/cpython/mod.rs
+++ b/pyo3-ffi/src/cpython/mod.rs
@@ -74,6 +74,7 @@ pub use self::pydebug::*;
 pub use self::pyerrors::*;
 #[cfg(all(Py_3_11, not(PyPy)))]
 pub use self::pyframe::*;
+#[cfg(any(not(PyPy), Py_3_13))]
 pub use self::pyhash::*;
 #[cfg(all(Py_3_8, not(PyPy)))]
 pub use self::pylifecycle::*;

--- a/pyo3-ffi/src/cpython/pyhash.rs
+++ b/pyo3-ffi/src/cpython/pyhash.rs
@@ -1,17 +1,24 @@
+#[cfg(Py_3_14)]
+use crate::Py_ssize_t;
 #[cfg(Py_3_13)]
-use crate::PyObject;
-use crate::{Py_hash_t, Py_ssize_t};
-use std::os::raw::{c_char, c_int, c_void};
+use crate::{PyObject, Py_hash_t};
+#[cfg(any(Py_3_13, not(PyPy)))]
+use std::os::raw::c_void;
+#[cfg(not(PyPy))]
+use std::os::raw::{c_char, c_int};
 
+#[cfg(not(PyPy))]
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct PyHash_FuncDef {
-    pub hash: Option<extern "C" fn(arg1: *const c_void, arg2: Py_ssize_t) -> Py_hash_t>,
+    pub hash:
+        Option<extern "C" fn(arg1: *const c_void, arg2: crate::Py_ssize_t) -> crate::Py_hash_t>,
     pub name: *const c_char,
     pub hash_bits: c_int,
     pub seed_bits: c_int,
 }
 
+#[cfg(not(PyPy))]
 impl Default for PyHash_FuncDef {
     #[inline]
     fn default() -> Self {
@@ -20,6 +27,7 @@ impl Default for PyHash_FuncDef {
 }
 
 extern "C" {
+    #[cfg(not(PyPy))]
     pub fn PyHash_GetFuncDef() -> *mut PyHash_FuncDef;
     #[cfg(Py_3_13)]
     pub fn Py_HashPointer(ptr: *const c_void) -> Py_hash_t;

--- a/src/conversions/jiff.rs
+++ b/src/conversions/jiff.rs
@@ -32,7 +32,7 @@
 //!     pyo3::prepare_freethreaded_python();
 //!     Python::with_gil(|py| {
 //!         // Build some jiff values
-//!         let jiff_zoned = Zoned::now();
+//!         let jiff_zoned = Zoned::now().in_tz("UTC")?;
 //!         let jiff_span = 1.second();
 //!         // Convert them to Python
 //!         let py_datetime = jiff_zoned.into_pyobject(py)?;


### PR DESCRIPTION
As a precursor to investigating #5080, I wanted to make the test workflow in CI more similar to what I can run locally.

This modifies the noxfile's `test-rust` job to be much closer to `build.yml` semantics, and then changes `build.yml` to call it.