### PR TITLE
ci: enable incremental compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Usually in CI this is disabled (by dtolnay/rust-toolchain) because the assumption is that
+  # workspace artifacts are not cached and never re-used.
+  #
+  # However, in PyO3's case we have lots of cases where we build with different feature sets
+  # and config versions, and incremental builds offer a significant speedup in this instance.
+  CARGO_INCREMENTAL: 1
 
 jobs:
   fmt:


### PR DESCRIPTION
This is an attempt to speed up CI by using incremental compilation.

Because we recompile stuff multiple times with different feature sets (or Python configs), I think there's a real possibility that incremental compilation's overheads will be mitigated by significant re-use of partial artifacts.