### PR TITLE
Fixes pytests tests when using Python 3.7

### DIFF
--- a/pytests/tests/test_pyfunctions.py
+++ b/pytests/tests/test_pyfunctions.py
@@ -87,7 +87,7 @@ def test_args_kwargs_rs(benchmark):
     assert rust == py
 
 
-def positional_only_py(a, /, b):
+def positional_only_py(a, b):
     return a, b
 
 

--- a/pytests/tests/test_pyfunctions.py
+++ b/pytests/tests/test_pyfunctions.py
@@ -87,7 +87,7 @@ def test_args_kwargs_rs(benchmark):
     assert rust == py
 
 
-# TODO: the second argument should be positional-only 
+# TODO: the second argument should be positional-only
 # but can't be without breaking tests on Python 3.7.
 # See gh-5095.
 def positional_only_py(a, b):

--- a/pytests/tests/test_pyfunctions.py
+++ b/pytests/tests/test_pyfunctions.py
@@ -87,6 +87,9 @@ def test_args_kwargs_rs(benchmark):
     assert rust == py
 
 
+# TODO: the second argument should be positional-only 
+# but can't be without breaking tests on Python 3.7.
+# See gh-5095.
 def positional_only_py(a, b):
     return a, b
 


### PR DESCRIPTION
Positional-only arguments are not allowed in Python 3.7

