### PR TITLE
docs: fix typo in `Ipv4Addr` and `Ipv6Addr` type names

### DIFF
--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -37,8 +37,8 @@ The table below contains the Python type and the corresponding function argument
 | `datetime.timedelta` | `Duration`, `chrono::Duration`[^5] | `PyDelta`           |
 | `decimal.Decimal` | `rust_decimal::Decimal`[^7] | -                    |
 | `decimal.Decimal` | `bigdecimal::BigDecimal`[^9] | -                   |
-| `ipaddress.IPv4Address` | `std::net::IpAddr`, `std::net::IpV4Addr` | - |
-| `ipaddress.IPv6Address` | `std::net::IpAddr`, `std::net::IpV6Addr` | - |
+| `ipaddress.IPv4Address` | `std::net::IpAddr`, `std::net::Ipv4Addr` | - |
+| `ipaddress.IPv6Address` | `std::net::IpAddr`, `std::net::Ipv6Addr` | - |
 | `os.PathLike ` | `PathBuf`, `Path`              | `PyString` |
 | `pathlib.Path` | `PathBuf`, `Path`              | `PyString` |
 | `typing.Optional[T]` | `Option<T>`              | -                    |


### PR DESCRIPTION
This pull request makes corrections to type annotations in a documentation table to ensure accuracy and consistency. The most notable changes involve fixing the capitalization of certain Rust type names.

Documentation corrections:

* [`guide/src/conversions/tables.md`](diffhunk://#diff-df391f2cf513e1ac8ee8f7de3f3f80b0a5448c859e58308a8b8c865bcad1ededL40-R41): Corrected the capitalization of `std::net::Ipv4Addr` and `std::net::Ipv6Addr` in the table describing Python-to-Rust type conversions. Previously, these were incorrectly written as `IpV4Addr` and `IpV6Addr`.
