### PR TITLE
remove FFI definitions of private static variables

### DIFF
--- a/newsfragments/5105.removed.md
+++ b/newsfragments/5105.removed.md
@@ -1,0 +1,1 @@
+Remove FFI definitions of private static variables: `_PyMethodWrapper_Type`, `_PyCoroWrapper_Type`, `_PyImport_FrozenBootstrap`, `_PyImport_FrozenStdlib`, `_PyImport_FrozenTest`, `_PyManagedBuffer_Type`, `_PySet_Dummy`, `_PyWeakref_RefType`, `_PyWeakref_ProxyType`, and `_PyWeakref_CallableProxyType`.

--- a/newsfragments/5105.removed.md
+++ b/newsfragments/5105.removed.md
@@ -1,1 +1,1 @@
-Remove FFI definitions of private static variables: `_PyMethodWrapper_Type`, `_PyCoroWrapper_Type`, `_PyImport_FrozenBootstrap`, `_PyImport_FrozenStdlib`, `_PyImport_FrozenTest`, `_PyManagedBuffer_Type`, `_PySet_Dummy`, `_PyWeakref_RefType`, `_PyWeakref_ProxyType`, and `_PyWeakref_CallableProxyType`.
+Remove FFI definitions of private static variables: `_PyMethodWrapper_Type`, `_PyCoroWrapper_Type`, `_PyImport_FrozenBootstrap`, `_PyImport_FrozenStdlib`, `_PyImport_FrozenTest`, `_PyManagedBuffer_Type`, `_PySet_Dummy`, `_PyWeakref_ProxyType`, and `_PyWeakref_CallableProxyType`.

--- a/pyo3-ffi/src/cpython/descrobject.rs
+++ b/pyo3-ffi/src/cpython/descrobject.rs
@@ -69,10 +69,7 @@ pub struct PyWrapperDescrObject {
     pub d_wrapped: *mut c_void,
 }
 
-#[cfg_attr(windows, link(name = "pythonXY"))]
-extern "C" {
-    pub static mut _PyMethodWrapper_Type: PyTypeObject;
-}
+// skipped _PyMethodWrapper_Type
 
 // skipped non-limited PyDescr_NewWrapper
 // skipped non-limited PyDescr_IsData

--- a/pyo3-ffi/src/cpython/genobject.rs
+++ b/pyo3-ffi/src/cpython/genobject.rs
@@ -68,8 +68,9 @@ extern "C" {
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
     pub static mut PyCoro_Type: PyTypeObject;
-    pub static mut _PyCoroWrapper_Type: PyTypeObject;
 }
+
+// skipped _PyCoroWrapper_Type
 
 #[inline]
 pub unsafe fn PyCoro_CheckExact(op: *mut PyObject) -> c_int {

--- a/pyo3-ffi/src/cpython/import.rs
+++ b/pyo3-ffi/src/cpython/import.rs
@@ -65,10 +65,8 @@ pub struct _frozen {
 extern "C" {
     #[cfg(not(PyPy))]
     pub static mut PyImport_FrozenModules: *const _frozen;
-    #[cfg(all(not(PyPy), Py_3_11))]
-    pub static mut _PyImport_FrozenBootstrap: *const _frozen;
-    #[cfg(all(not(PyPy), Py_3_11))]
-    pub static mut _PyImport_FrozenStdlib: *const _frozen;
-    #[cfg(all(not(PyPy), Py_3_11))]
-    pub static mut _PyImport_FrozenTest: *const _frozen;
 }
+
+// skipped _PyImport_FrozenBootstrap
+// skipped _PyImport_FrozenStdlib
+// skipped _PyImport_FrozenTest

--- a/pyo3-ffi/src/memoryobject.rs
+++ b/pyo3-ffi/src/memoryobject.rs
@@ -3,11 +3,10 @@ use crate::pyport::Py_ssize_t;
 use std::os::raw::{c_char, c_int};
 use std::ptr::addr_of_mut;
 
+// skipped _PyManagedBuffer_Type
+
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
-    #[cfg(not(Py_LIMITED_API))]
-    pub static mut _PyManagedBuffer_Type: PyTypeObject;
-
     #[cfg_attr(PyPy, link_name = "PyPyMemoryView_Type")]
     pub static mut PyMemoryView_Type: PyTypeObject;
 }

--- a/pyo3-ffi/src/setobject.rs
+++ b/pyo3-ffi/src/setobject.rs
@@ -39,11 +39,7 @@ pub unsafe fn PySet_GET_SIZE(so: *mut PyObject) -> Py_ssize_t {
     (*so).used
 }
 
-#[cfg(not(Py_LIMITED_API))]
-#[cfg_attr(windows, link(name = "pythonXY"))]
-extern "C" {
-    pub static mut _PySet_Dummy: *mut PyObject;
-}
+// skipped _PySet_Dummy
 
 extern "C" {
     #[cfg(not(Py_LIMITED_API))]

--- a/pyo3-ffi/src/weakrefobject.rs
+++ b/pyo3-ffi/src/weakrefobject.rs
@@ -11,7 +11,9 @@ pub use crate::_PyWeakReference as PyWeakReference;
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
-    static mut _PyWeakref_RefType: PyTypeObject;
+    // TODO: PyO3 is depending on this symbol in `reference.rs`, we should change this and
+    // remove the export as this is a private symbol.
+    pub static mut _PyWeakref_RefType: PyTypeObject;
     static mut _PyWeakref_ProxyType: PyTypeObject;
     static mut _PyWeakref_CallableProxyType: PyTypeObject;
 

--- a/pyo3-ffi/src/weakrefobject.rs
+++ b/pyo3-ffi/src/weakrefobject.rs
@@ -11,9 +11,9 @@ pub use crate::_PyWeakReference as PyWeakReference;
 
 #[cfg_attr(windows, link(name = "pythonXY"))]
 extern "C" {
-    pub static mut _PyWeakref_RefType: PyTypeObject;
-    pub static mut _PyWeakref_ProxyType: PyTypeObject;
-    pub static mut _PyWeakref_CallableProxyType: PyTypeObject;
+    static mut _PyWeakref_RefType: PyTypeObject;
+    static mut _PyWeakref_ProxyType: PyTypeObject;
+    static mut _PyWeakref_CallableProxyType: PyTypeObject;
 
     #[cfg(PyPy)]
     #[link_name = "PyPyWeakref_CheckRef"]

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -22,6 +22,7 @@ pyobject_subclassable_native_type!(PyWeakrefReference, crate::ffi::PyWeakReferen
 pyobject_native_type!(
     PyWeakrefReference,
     ffi::PyWeakReference,
+    // TODO: should not be depending on a private symbol here!
     pyobject_native_static_type_object!(ffi::_PyWeakref_RefType),
     #module=Some("weakref"),
     #checkfunction=ffi::PyWeakref_CheckRefExact


### PR DESCRIPTION
Related to #4379 

This removes all private (underscore-prefixed) of static variables from pyo3-ffi's API.

The ones in `weakrefobject.rs` remain around without `pub` because other functions in that file refer to them at the ABI level.