### PR TITLE
ci: accept 429 as valid response for external url

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -493,7 +493,7 @@ def check_guide(session: nox.Session):
         "--include-fragments",
         str(PYO3_GUIDE_SRC),
         *remap_args,
-        "--accept 200,429",
+        "--accept=200,429",
         *session.posargs,
     )
     # check external links in the docs
@@ -505,7 +505,7 @@ def check_guide(session: nox.Session):
         *remap_args,
         f"--exclude=file://{PYO3_DOCS_TARGET}",
         "--exclude=http://www.adobe.com/",
-        "--accept 200,429",
+        "--accept=200,429",
         *session.posargs,
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -493,6 +493,7 @@ def check_guide(session: nox.Session):
         "--include-fragments",
         str(PYO3_GUIDE_SRC),
         *remap_args,
+        "--accept 200,429",
         *session.posargs,
     )
     # check external links in the docs
@@ -504,6 +505,7 @@ def check_guide(session: nox.Session):
         *remap_args,
         f"--exclude=file://{PYO3_DOCS_TARGET}",
         "--exclude=http://www.adobe.com/",
+        "--accept 200,429",
         *session.posargs,
     )
 


### PR DESCRIPTION
The `check-guide` job has been quite flaky recently.

As per https://lychee.cli.rs/troubleshooting/rate-limits/ one suggestion is to just allow 429 as valid. I think that's fine, the check is best effort and guide pages will bitrot with time anyway. As long as we eventually notice 404 responses and fix, it's doing its job IMO.