### PR TITLE
Remove cfg-if dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2021"
 rust-version = "1.63"
 
 [dependencies]
-cfg-if = "1.0"
 libc = "0.2.62"
 memoffset = "0.9"
 once_cell = "1.13"

--- a/newsfragments/5110.changed.md
+++ b/newsfragments/5110.changed.md
@@ -1,0 +1,1 @@
+Remove `cfg-if` dependency.


### PR DESCRIPTION
This removes the `cfg-if` dependency.

It was only used in one place with a single if-else, which can easily be replaced.

Before:

```rust
cfg_if::cfg_if! {
    if #[cfg(..)] {
        ..
    } else {
        ..
    }
}
```

After:

```rust    
#[cfg(..)]
{
    ..
}
#[cfg(not(..))]
{
    ..
}
```