### PR TITLE
Implement optional feature `ordered-float` for NotNan/OrderedFloat <-> Python float conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ jiff-02 = { package = "jiff", version = "0.2", optional = true }
 num-bigint = { version = "0.4.2", optional = true }
 num-complex = { version = ">= 0.4.6, < 0.5", optional = true }
 num-rational = { version = "0.4.1", optional = true }
+ordered-float = { version = ">= 5.0.0", default-features = false, optional = true }
 rust_decimal = { version = "1.15", default-features = false, optional = true }
 time = { version = "0.3.38", default-features = false, optional = true }
 serde = { version = "1.0", optional = true }
@@ -136,6 +137,7 @@ full = [
     "num-bigint",
     "num-complex",
     "num-rational",
+    "ordered-float",
     "py-clone",
     "rust_decimal",
     "serde",

--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -17,7 +17,7 @@ The table below contains the Python type and the corresponding function argument
 | `bytes`       | `Vec<u8>`, `&[u8]`, `Cow<[u8]>` | `PyBytes`           |
 | `bool`        | `bool`                          | `PyBool`            |
 | `int`         | `i8`, `u8`, `i16`, `u16`, `i32`, `u32`, `i64`, `u64`, `i128`, `u128`, `isize`, `usize`, `num_bigint::BigInt`[^1], `num_bigint::BigUint`[^1] | `PyInt` |
-| `float`       | `f32`, `f64`                    | `PyFloat`           |
+| `float`       | `f32`, `f64`, `ordered_float::NotNan`[^10], `ordered_float::OrderedFloat`[^10]                    | `PyFloat`           |
 | `complex`     | `num_complex::Complex`[^2]      | `PyComplex`         |
 | `fractions.Fraction`| `num_rational::Ratio`[^8] | -         |
 | `list[T]`     | `Vec<T>`                        | `PyList`            |
@@ -119,3 +119,5 @@ Finally, the following Rust types are also able to convert to Python as return v
 [^8]: Requires the `num-rational` optional feature.
 
 [^9]: Requires the `bigdecimal` optional feature.
+
+[^10]: Requires the `ordered-float` optional feature.

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -180,6 +180,12 @@ Adds a dependency on [num-complex](https://docs.rs/num-complex) and enables conv
 
 Adds a dependency on [num-rational](https://docs.rs/num-rational) and enables conversions into its [`Ratio`](https://docs.rs/num-rational/latest/num_rational/struct.Ratio.html) type.
 
+### `ordered-float`
+
+Adds a dependency on [ordered-float](https://docs.rs/ordered-float) and enables conversions between [ordered-float](https://docs.rs/ordered-float)'s types and Python:
+- [NotNan](https://docs.rs/ordered-float/latest/ordered_float/struct.NotNan.html) -> [`PyFloat`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyFloat.html)
+- [OrderedFloat](https://docs.rs/ordered-float/latest/ordered_float/struct.OrderedFloat.html) -> [`PyFloat`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyFloat.html)
+
 ### `rust_decimal`
 
 Adds a dependency on [rust_decimal](https://docs.rs/rust_decimal) and enables conversions into its [`Decimal`](https://docs.rs/rust_decimal/latest/rust_decimal/struct.Decimal.html) type.

--- a/newsfragments/5103.added.md
+++ b/newsfragments/5103.added.md
@@ -1,0 +1,1 @@
+Added conversion support for `ordered_float::NotNan` & `ordered_float::OrderedFloat` to and from python native float type

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -12,6 +12,7 @@ pub mod jiff;
 pub mod num_bigint;
 pub mod num_complex;
 pub mod num_rational;
+pub mod ordered_float;
 pub mod rust_decimal;
 pub mod serde;
 pub mod smallvec;

--- a/src/conversions/ordered_float.rs
+++ b/src/conversions/ordered_float.rs
@@ -256,7 +256,7 @@ mod test_ordered_float {
     float_roundtrip_tests!(
         OrderedFloat,
         f32,
-        |val| OrderedFloat(val),
+        OrderedFloat,
         ordered_float_f32_standard,
         ordered_float_f32_wasm,
         ordered_float_f32_infinity,
@@ -265,7 +265,7 @@ mod test_ordered_float {
     float_roundtrip_tests!(
         OrderedFloat,
         f64,
-        |val| OrderedFloat(val),
+        OrderedFloat,
         ordered_float_f64_standard,
         ordered_float_f64_wasm,
         ordered_float_f64_infinity,

--- a/src/conversions/ordered_float.rs
+++ b/src/conversions/ordered_float.rs
@@ -367,9 +367,9 @@ mod test_ordered_float {
                     )
                     .unwrap();
                     let py_64 = locals.get_item("max_float").unwrap().unwrap();
-                    let rs_64 = py_64.extract::<$wrapper<f32>>().unwrap();
+                    let rs_32 = py_64.extract::<$wrapper<f32>>().unwrap();
                     // The python f64 is not representable in a rust f32
-                    assert!(rs_64.is_infinite());
+                    assert!(rs_32.is_infinite());
                 })
             }
         };

--- a/src/conversions/ordered_float.rs
+++ b/src/conversions/ordered_float.rs
@@ -1,0 +1,482 @@
+#![cfg(feature = "ordered-float")]
+
+use crate::conversion::IntoPyObject;
+use crate::exceptions::PyValueError;
+use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::types::any::PyAnyMethods;
+use crate::{ffi, Bound, FromPyObject, PyAny, PyErr, PyResult, Python};
+use ordered_float::{NotNan, OrderedFloat};
+
+macro_rules! ordered_float_conversions {
+    ($float_type:ty) => {
+        impl FromPyObject<'_> for OrderedFloat<$float_type> {
+            fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+                let val: $float_type = obj.extract()?;
+                Ok(OrderedFloat(val))
+            }
+        }
+
+        impl<'py> IntoPyObject<'py> for OrderedFloat<$float_type> {
+            type Target = PyAny;
+            type Output = Bound<'py, Self::Target>;
+            type Error = PyErr;
+
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                let float = unsafe {
+                    ffi::PyFloat_FromDouble(self.into_inner() as f64)
+                        .assume_owned(py)
+                        .downcast_into_unchecked()
+                };
+                Ok(float)
+            }
+        }
+
+        impl<'py> IntoPyObject<'py> for &OrderedFloat<$float_type> {
+            type Target = PyAny;
+            type Output = Bound<'py, Self::Target>;
+            type Error = PyErr;
+
+            #[inline]
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                (*self).into_pyobject(py)
+            }
+        }
+    };
+}
+ordered_float_conversions!(f32);
+ordered_float_conversions!(f64);
+
+macro_rules! not_nan_conversions {
+    ($float_type:ty) => {
+        impl FromPyObject<'_> for NotNan<$float_type> {
+            fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+                let val: $float_type = obj.extract()?;
+                NotNan::new(val).map_err(|e| PyValueError::new_err(e.to_string()))
+            }
+        }
+
+        impl<'py> IntoPyObject<'py> for NotNan<$float_type> {
+            type Target = PyAny;
+            type Output = Bound<'py, Self::Target>;
+            type Error = PyErr;
+
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                let float = unsafe {
+                    ffi::PyFloat_FromDouble(self.into_inner() as f64)
+                        .assume_owned(py)
+                        .downcast_into_unchecked()
+                };
+                Ok(float)
+            }
+        }
+
+        impl<'py> IntoPyObject<'py> for &NotNan<$float_type> {
+            type Target = PyAny;
+            type Output = Bound<'py, Self::Target>;
+            type Error = PyErr;
+
+            #[inline]
+            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                (*self).into_pyobject(py)
+            }
+        }
+    };
+}
+not_nan_conversions!(f32);
+not_nan_conversions!(f64);
+
+#[cfg(test)]
+mod test_ordered_float {
+    use super::*;
+    use crate::types::dict::PyDictMethods;
+    use crate::types::PyDict;
+    use std::ffi::CString;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    use proptest::prelude::*;
+
+    macro_rules! ordered_float_roundtrip_tests {
+        ($standard_test:ident, $wasm_test:ident, $infinity_test:ident, $zero_test:ident, $nan_test:ident, $float_type:ty) => {
+            #[cfg(not(target_arch = "wasm32"))]
+            proptest! {
+            #[test]
+            fn $standard_test(inner_f: $float_type) {
+                let f = OrderedFloat(inner_f);
+
+                Python::with_gil(|py| {
+                    let f_py = f.into_pyobject(py).unwrap();
+
+                    let locals = PyDict::new(py);
+                    locals.set_item("f_py", &f_py).unwrap();
+
+                    py.run(
+                        &CString::new(format!(
+                            "import math\nassert math.isclose(f_py, {})",
+                             inner_f as f64 // Always interpret the literal rs float value as f64
+                                            // so that it's comparable with the python float
+                        ))
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let roundtripped_f: OrderedFloat<$float_type> = f_py.extract().unwrap();
+
+                    assert_eq!(f, roundtripped_f);
+                })
+            }
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            fn $wasm_test() {
+                let inner_f = 10.0;
+                let f = OrderedFloat(inner_f);
+
+                Python::with_gil(|py| {
+                    let f_py = f.into_pyobject(py).unwrap();
+
+                    let locals = PyDict::new(py);
+                    locals.set_item("f_py", &f_py).unwrap();
+
+                    py.run(
+                        &CString::new(format!(
+                            "import math\nassert math.isclose(f_py, {})",
+                            inner_f as f64 // Always interpret the literal rs float value as f64
+                                           // so that it's comparable with the python float
+                        ))
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let roundtripped_f: OrderedFloat<$float_type> = f_py.extract().unwrap();
+
+                    assert_eq!(f, roundtripped_f);
+                })
+            }
+
+            #[test]
+            fn $infinity_test() {
+                let inner_pinf = <$float_type>::INFINITY;
+                let pinf = OrderedFloat(inner_pinf);
+
+                let inner_ninf = <$float_type>::NEG_INFINITY;
+                let ninf = OrderedFloat(inner_ninf);
+
+                Python::with_gil(|py| {
+                    let pinf_py = pinf.into_pyobject(py).unwrap();
+                    let ninf_py = ninf.into_pyobject(py).unwrap();
+
+                    let locals = PyDict::new(py);
+                    locals.set_item("pinf_py", &pinf_py).unwrap();
+                    locals.set_item("ninf_py", &ninf_py).unwrap();
+
+                    py.run(
+                        &CString::new(
+                            "\
+                            assert pinf_py == float('inf')\n\
+                            assert ninf_py == float('-inf')",
+                        )
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let roundtripped_pinf: OrderedFloat<$float_type> = pinf_py.extract().unwrap();
+                    let roundtripped_ninf: OrderedFloat<$float_type> = ninf_py.extract().unwrap();
+
+                    assert_eq!(pinf, roundtripped_pinf);
+                    assert_eq!(ninf, roundtripped_ninf);
+                })
+            }
+
+            #[test]
+            fn $zero_test() {
+                let inner_pzero: $float_type = 0.0;
+                let pzero = OrderedFloat(inner_pzero);
+
+                let inner_nzero: $float_type = -0.0;
+                let nzero = OrderedFloat(inner_nzero);
+
+                Python::with_gil(|py| {
+                    let pzero_py = pzero.into_pyobject(py).unwrap();
+                    let nzero_py = nzero.into_pyobject(py).unwrap();
+
+                    let locals = PyDict::new(py);
+                    locals.set_item("pzero_py", &pzero_py).unwrap();
+                    locals.set_item("nzero_py", &nzero_py).unwrap();
+
+                    py.run(
+                        &CString::new(
+                            "\
+                            assert pzero_py == 0.0\n\
+                            assert nzero_py == -0.0",
+                        )
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let roundtripped_pzero: OrderedFloat<$float_type> = pzero_py.extract().unwrap();
+                    let roundtripped_nzero: OrderedFloat<$float_type> = nzero_py.extract().unwrap();
+
+                    assert_eq!(pzero, roundtripped_pzero);
+                    assert_eq!(nzero, roundtripped_nzero);
+                })
+            }
+
+            #[test]
+            fn $nan_test() {
+                let inner_nan: $float_type = <$float_type>::NAN;
+                let nan = OrderedFloat(inner_nan);
+
+                Python::with_gil(|py| {
+                    let nan_py = nan.into_pyobject(py).unwrap();
+
+                    let locals = PyDict::new(py);
+                    locals.set_item("nan_py", &nan_py).unwrap();
+
+                    py.run(
+                        &CString::new(
+                            "\
+                            import math\n\
+                            assert math.isnan(nan_py)",
+                        )
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let roundtripped_nan: OrderedFloat<$float_type> = nan_py.extract().unwrap();
+
+                    assert_eq!(nan, roundtripped_nan);
+                })
+            }
+        };
+    }
+    ordered_float_roundtrip_tests!(
+        ordered_float_f32_standard,
+        ordered_float_f32_wasm,
+        ordered_float_f32_infinity,
+        ordered_float_f32_zero,
+        ordered_float_f32_nan,
+        f32
+    );
+    ordered_float_roundtrip_tests!(
+        ordered_float_f64_standard,
+        ordered_float_f64_wasm,
+        ordered_float_f64_infinity,
+        ordered_float_f64_zero,
+        ordered_float_f64_nan,
+        f64
+    );
+
+    macro_rules! not_nan_roundtrip_tests {
+        ($standard_test:ident, $wasm_test:ident, $infinity_test:ident, $zero_test:ident, $float_type:ty) => {
+            #[cfg(not(target_arch = "wasm32"))]
+            proptest! {
+            #[test]
+            fn $standard_test(inner_f: $float_type) {
+                let f = NotNan::new(inner_f).unwrap();
+
+                Python::with_gil(|py| {
+                    let f_py = f.into_pyobject(py).unwrap();
+
+                    let locals = PyDict::new(py);
+                    locals.set_item("f_py", &f_py).unwrap();
+
+                    py.run(
+                        &CString::new(format!(
+                            "import math\nassert math.isclose(f_py, {})",
+                             inner_f as f64 // Always interpret the literal rs float value as f64
+                                            // so that it's comparable with the python float
+                        ))
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let roundtripped_f: NotNan<$float_type> = f_py.extract().unwrap();
+
+                    assert_eq!(f, roundtripped_f);
+                })
+            }
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            fn $wasm_test() {
+                let inner_f = 10.0;
+                let f = NotNan::new(inner_f).unwrap();
+
+                Python::with_gil(|py| {
+                    let f_py = f.into_pyobject(py).unwrap();
+
+                    let locals = PyDict::new(py);
+                    locals.set_item("f_py", &f_py).unwrap();
+
+                    py.run(
+                        &CString::new(format!(
+                            "import math\nassert math.isclose(f_py, {})",
+                            inner_f as f64 // Always interpret the literal rs float value as f64
+                                           // so that it's comparable with the python float
+                        ))
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let roundtripped_f: NotNan<$float_type> = f_py.extract().unwrap();
+
+                    assert_eq!(f, roundtripped_f);
+                })
+            }
+
+            #[test]
+            fn $infinity_test() {
+                let inner_pinf = <$float_type>::INFINITY;
+                let pinf = NotNan::new(inner_pinf).unwrap();
+
+                let inner_ninf = <$float_type>::NEG_INFINITY;
+                let ninf = NotNan::new(inner_ninf).unwrap();
+
+                Python::with_gil(|py| {
+                    let pinf_py = pinf.into_pyobject(py).unwrap();
+                    let ninf_py = ninf.into_pyobject(py).unwrap();
+
+                    let locals = PyDict::new(py);
+                    locals.set_item("pinf_py", &pinf_py).unwrap();
+                    locals.set_item("ninf_py", &ninf_py).unwrap();
+
+                    py.run(
+                        &CString::new(
+                            "\
+                            assert pinf_py == float('inf')\n\
+                            assert ninf_py == float('-inf')",
+                        )
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let roundtripped_pinf: NotNan<$float_type> = pinf_py.extract().unwrap();
+                    let roundtripped_ninf: NotNan<$float_type> = ninf_py.extract().unwrap();
+
+                    assert_eq!(pinf, roundtripped_pinf);
+                    assert_eq!(ninf, roundtripped_ninf);
+                })
+            }
+
+            #[test]
+            fn $zero_test() {
+                let inner_pzero: $float_type = 0.0;
+                let pzero = NotNan::new(inner_pzero).unwrap();
+
+                let inner_nzero: $float_type = -0.0;
+                let nzero = NotNan::new(inner_nzero).unwrap();
+
+                Python::with_gil(|py| {
+                    let pzero_py = pzero.into_pyobject(py).unwrap();
+                    let nzero_py = nzero.into_pyobject(py).unwrap();
+
+                    let locals = PyDict::new(py);
+                    locals.set_item("pzero_py", &pzero_py).unwrap();
+                    locals.set_item("nzero_py", &nzero_py).unwrap();
+
+                    py.run(
+                        &CString::new(
+                            "\
+                            assert pzero_py == 0.0\n\
+                            assert nzero_py == -0.0",
+                        )
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let roundtripped_pzero: NotNan<$float_type> = pzero_py.extract().unwrap();
+                    let roundtripped_nzero: NotNan<$float_type> = nzero_py.extract().unwrap();
+
+                    assert_eq!(pzero, roundtripped_pzero);
+                    assert_eq!(nzero, roundtripped_nzero);
+                })
+            }
+        };
+    }
+    not_nan_roundtrip_tests!(
+        not_nan_f32_standard,
+        not_nan_f32_wasm,
+        not_nan_f32_infinity,
+        not_nan_f32_zero,
+        f32
+    );
+    not_nan_roundtrip_tests!(
+        not_nan_f64_standard,
+        not_nan_f64_wasm,
+        not_nan_f64_infinity,
+        not_nan_f64_zero,
+        f64
+    );
+
+    macro_rules! not_nan_pynan_tests {
+        ($test_name:ident, $float_type:ty) => {
+            #[test]
+            fn $test_name() {
+                Python::with_gil(|py| {
+                    let locals = PyDict::new(py);
+
+                    py.run(
+                        &CString::new("nan_py = float('nan')").unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+
+                    let nan_rs: PyResult<NotNan<$float_type>> =
+                        locals.get_item("nan_py").unwrap().unwrap().extract();
+
+                    assert!(nan_rs.is_err());
+                })
+            }
+        };
+    }
+    not_nan_pynan_tests!(test_not_nan_pynan_f32, f32);
+    not_nan_pynan_tests!(test_not_nan_pynan_f64, f64);
+
+    macro_rules! py64_rs32 {
+        ($test_name:ident, $wrapper:ident, $float_type:ty) => {
+            #[test]
+            fn $test_name() {
+                Python::with_gil(|py| {
+                    let locals = PyDict::new(py);
+                    py.run(
+                        &CString::new(
+                            "import sys\n\
+                            max_float = sys.float_info.max",
+                        )
+                        .unwrap(),
+                        None,
+                        Some(&locals),
+                    )
+                    .unwrap();
+                    let py_64 = locals.get_item("max_float").unwrap().unwrap();
+                    let rs_64 = py_64.extract::<$wrapper<f32>>().unwrap();
+                    // The python f64 is not representable in a rust f32
+                    assert!(rs_64.is_infinite());
+                })
+            }
+        };
+    }
+    py64_rs32!(ordered_float_f32, OrderedFloat, f32);
+    py64_rs32!(ordered_float_f64, OrderedFloat, f64);
+    py64_rs32!(not_nan_f32, NotNan, f32);
+    py64_rs32!(not_nan_f64, NotNan, f64);
+}

--- a/src/conversions/ordered_float.rs
+++ b/src/conversions/ordered_float.rs
@@ -209,11 +209,16 @@ mod test_ordered_float {
                     locals.set_item("pzero_py", &pzero_py).unwrap();
                     locals.set_item("nzero_py", &nzero_py).unwrap();
 
+                    // This python script verifies that the values are 0.0 in magnitude
+                    // and that the signs are correct(+0.0 vs -0.0)
                     py.run(
                         &CString::new(
                             "\
+                            import math\n\
                             assert pzero_py == 0.0\n\
-                            assert nzero_py == -0.0",
+                            assert math.copysign(1.0, pzero_py) > 0.0\n\
+                            assert nzero_py == 0.0\n\
+                            assert math.copysign(1.0, nzero_py) < 0.0",
                         )
                         .unwrap(),
                         None,
@@ -225,7 +230,9 @@ mod test_ordered_float {
                     let roundtripped_nzero: $wrapper<$float_type> = nzero_py.extract().unwrap();
 
                     assert_eq!(pzero, roundtripped_pzero);
+                    assert_eq!(roundtripped_pzero.signum(), 1.0);
                     assert_eq!(nzero, roundtripped_nzero);
+                    assert_eq!(roundtripped_nzero.signum(), -1.0);
                 })
             }
         };

--- a/src/conversions/ordered_float.rs
+++ b/src/conversions/ordered_float.rs
@@ -1,4 +1,55 @@
 #![cfg(feature = "ordered-float")]
+//! Conversions to and from [ordered-float](https://docs.rs/ordered-float) types.
+//! [`NotNan`]`<`[`f32`]`>` and [`NotNan`]`<`[`f64`]`>`.
+//! [`OrderedFloat`]`<`[`f32`]`>` and [`OrderedFloat`]`<`[`f64`]`>`.
+//!
+//! This is useful for converting between Python's float into and from a native Rust type.
+//!
+//! Take care when comparing sorted collections of float types between Python and Rust.
+//! They will likely differ due to the ambiguous sort order of NaNs in Python.
+//
+//!
+//! To use this feature, add to your **`Cargo.toml`**:
+//!
+//! ```toml
+//! [dependencies]
+#![doc = concat!("pyo3 = { version = \"", env!("CARGO_PKG_VERSION"),  "\", features = [\"ordered-float\"] }")]
+//! ordered-float = "5.0.0"
+//! ```
+//!
+//! # Example
+//!
+//! Rust code to create functions that add ordered floats:
+//!
+//! ```rust,no_run
+//! use ordered_float::{NotNan, OrderedFloat};
+//! use pyo3::prelude::*;
+//!
+//! #[pyfunction]
+//! fn add_not_nans(a: NotNan<f64>, b: NotNan<f64>) -> NotNan<f64> {
+//!     a + b
+//! }
+//!
+//! #[pyfunction]
+//! fn add_ordered_floats(a: OrderedFloat<f64>, b: OrderedFloat<f64>) -> OrderedFloat<f64> {
+//!     a + b
+//! }
+//!
+//! #[pymodule]
+//! fn my_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+//!     m.add_function(wrap_pyfunction!(add_not_nans, m)?)?;
+//!     m.add_function(wrap_pyfunction!(add_ordered_floats, m)?)?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Python code that validates the functionality:
+//! ```python
+//! from my_module import add_not_nans, add_ordered_floats
+//!
+//! assert add_not_nans(1.0,2.0) == 3.0
+//! assert add_ordered_floats(1.0,2.0) == 3.0
+//! ```
 
 use crate::conversion::IntoPyObject;
 use crate::exceptions::PyValueError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@
 //! - [`num-complex`]: Enables conversions between Python objects and [num-complex]'s [`Complex`]
 //!  type.
 //! - [`num-rational`]: Enables conversions between Python's fractions.Fraction and [num-rational]'s types
+//! - [`ordered-float`]: Enables conversions between Python's float and [ordered-float]'s types
 //! - [`rust_decimal`]: Enables conversions between Python's decimal.Decimal and [rust_decimal]'s
 //! [`Decimal`] type.
 //! - [`serde`]: Allows implementing [serde]'s [`Serialize`] and [`Deserialize`] traits for
@@ -311,6 +312,7 @@
 //! [`num-bigint`]: ./num_bigint/index.html "Documentation about the `num-bigint` feature."
 //! [`num-complex`]: ./num_complex/index.html "Documentation about the `num-complex` feature."
 //! [`num-rational`]: ./num_rational/index.html "Documentation about the `num-rational` feature."
+//! [`ordered-float`]: ./ordered_float/index.html "Documentation about the `ordered-float` feature."
 //! [`pyo3-build-config`]: https://docs.rs/pyo3-build-config
 //! [rust_decimal]: https://docs.rs/rust_decimal
 //! [`rust_decimal`]: ./rust_decimal/index.html "Documenation about the `rust_decimal` feature."
@@ -328,6 +330,7 @@
 //! [num-bigint]: https://docs.rs/num-bigint
 //! [num-complex]: https://docs.rs/num-complex
 //! [num-rational]: https://docs.rs/num-rational
+//! [ordered-float]: https://docs.rs/ordered-float
 //! [serde]: https://docs.rs/serde
 //! [setuptools-rust]: https://github.com/PyO3/setuptools-rust "Setuptools plugin for Rust extensions"
 //! [the guide]: https://pyo3.rs "PyO3 user guide"


### PR DESCRIPTION
This adds support for optional feature `ordered-float`, which enables converting Rust `NotNan` and `OrderedFloat` structs to/from Python floats. There are quite a few type combinations / edge cases to cover, so I used declarative macros heavily to reduce boilerplate while hopefully still preserving readability.