### PR TITLE
Use thread::park() in HangThread.

### DIFF
--- a/newsfragments/5115.changed.md
+++ b/newsfragments/5115.changed.md
@@ -1,0 +1,1 @@
+Use `std::thread::park()` instead of `libc::pause()` or `sleep(9999999)`.

--- a/pyo3-ffi/src/pystate.rs
+++ b/pyo3-ffi/src/pystate.rs
@@ -87,12 +87,7 @@ struct HangThread;
 impl Drop for HangThread {
     fn drop(&mut self) {
         loop {
-            #[cfg(target_family = "unix")]
-            unsafe {
-                libc::pause();
-            }
-            #[cfg(not(target_family = "unix"))]
-            std::thread::sleep(std::time::Duration::from_secs(9_999_999));
+            std::thread::park(); // Block forever.
         }
     }
 }


### PR DESCRIPTION
std::thread::park() is basically Rust's version of libc::pause(), it waits for a 'signal' from std::thread::unpark().
On its own it can be used as a way to block forever without needing to resort to sleep(9999999) or platform-specific apis.