### PR TITLE
bump supported GraalPy version to 24.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,10 +49,6 @@ jobs:
       - name: Install nox
         run: python -m pip install --upgrade pip && pip install nox
 
-      - if: ${{ startsWith(inputs.python-version, 'graalpy24.1') }}
-        name: Install GraalPy virtualenv (only GraalPy 24.1)
-        run: python -m pip install 'git+https://github.com/oracle/graalpython#egg=graalpy_virtualenv_seeder&subdirectory=graalpy_virtualenv_seeder'
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,8 +269,7 @@ jobs:
             "pypy3.9",
             "pypy3.10",
             "pypy3.11",
-            "graalpy24.0",
-            "graalpy24.1",
+            "graalpy24.2",
           ]
         platform:
           [

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requires Rust 1.63 or greater.
 PyO3 supports the following Python distributions:
   - CPython 3.7 or greater
   - PyPy 7.3 (Python 3.9+)
-  - GraalPy 24.0 or greater (Python 3.10+)
+  - GraalPy 24.2 or greater (Python 3.11+)
 
 You can use PyO3 to write a native Python module in Rust, or to embed Python in a Rust binary. The following sections explain each of these in turn.
 

--- a/newsfragments/5116.packaging.md
+++ b/newsfragments/5116.packaging.md
@@ -1,0 +1,1 @@
+Bump supported GraalPy version to 24.2.

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -2,12 +2,12 @@ use crate::ffi::{self, *};
 use crate::types::any::PyAnyMethods;
 use crate::Python;
 
-#[cfg(all(not(Py_LIMITED_API), any(not(PyPy), feature = "macros")))]
+#[cfg(all(not(Py_LIMITED_API), any(not(any(PyPy, GraalPy)), feature = "macros")))]
 use crate::types::PyString;
 
 #[cfg(not(Py_LIMITED_API))]
 use crate::{types::PyDict, Bound, PyAny};
-#[cfg(not(any(Py_3_12, Py_LIMITED_API)))]
+#[cfg(not(any(Py_3_12, Py_LIMITED_API, GraalPy)))]
 use libc::wchar_t;
 
 #[cfg(not(Py_LIMITED_API))]
@@ -114,7 +114,7 @@ fn test_timezone_from_offset_and_name() {
 }
 
 #[test]
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(not(any(Py_LIMITED_API, GraalPy)))]
 fn ascii_object_bitfield() {
     let ob_base: PyObject = unsafe { std::mem::zeroed() };
 
@@ -167,7 +167,7 @@ fn ascii_object_bitfield() {
 }
 
 #[test]
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
 fn ascii() {
     Python::with_gil(|py| {
         // This test relies on implementation details of PyString.
@@ -208,7 +208,7 @@ fn ascii() {
 }
 
 #[test]
-#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
 fn ucs4() {
     Python::with_gil(|py| {
         let s = "哈哈🐈";
@@ -253,7 +253,7 @@ fn ucs4() {
 #[test]
 #[cfg(not(Py_LIMITED_API))]
 #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
-#[cfg(not(PyPy))]
+#[cfg(not(all(PyPy, not(Py_3_10))))]
 fn test_get_tzinfo() {
     use crate::types::PyTzInfo;
 

--- a/src/tests/hygiene/misc.rs
+++ b/src/tests/hygiene/misc.rs
@@ -31,7 +31,7 @@ fn intern(py: crate::Python<'_>) {
     let _bar = crate::intern!(py, stringify!(bar));
 }
 
-#[cfg(not(PyPy))]
+#[cfg(not(any(PyPy, GraalPy)))]
 fn append_to_inittab() {
     #[crate::pymodule]
     #[pyo3(crate = "crate")]

--- a/src/types/mappingproxy.rs
+++ b/src/types/mappingproxy.rs
@@ -420,7 +420,7 @@ mod tests {
         });
     }
 
-    #[cfg(not(PyPy))]
+    #[cfg(not(any(PyPy, GraalPy)))]
     fn abc_mappingproxy(py: Python<'_>) -> Bound<'_, PyMappingProxy> {
         let mut map = HashMap::<&'static str, i32>::new();
         map.insert("a", 1);
@@ -431,7 +431,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(PyPy))]
+    #[cfg(not(any(PyPy, GraalPy)))]
     fn mappingproxy_keys_view() {
         Python::with_gil(|py| {
             let mappingproxy = abc_mappingproxy(py);
@@ -441,7 +441,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(PyPy))]
+    #[cfg(not(any(PyPy, GraalPy)))]
     fn mappingproxy_values_view() {
         Python::with_gil(|py| {
             let mappingproxy = abc_mappingproxy(py);
@@ -451,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(PyPy))]
+    #[cfg(not(any(PyPy, GraalPy)))]
     fn mappingproxy_items_view() {
         Python::with_gil(|py| {
             let mappingproxy = abc_mappingproxy(py);

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -647,7 +647,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+    #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn test_string_data_ucs1() {
         Python::with_gil(|py| {
             let s = PyString::new(py, "hello, world");
@@ -660,7 +660,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+    #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn test_string_data_ucs1_invalid() {
         Python::with_gil(|py| {
             // 0xfe is not allowed in UTF-8.
@@ -686,7 +686,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+    #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn test_string_data_ucs2() {
         Python::with_gil(|py| {
             let s = py.eval(ffi::c_str!("'foo\\ud800'"), None, None).unwrap();
@@ -702,7 +702,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(not(any(Py_LIMITED_API, PyPy)), target_endian = "little"))]
+    #[cfg(all(not(any(Py_LIMITED_API, PyPy, GraalPy)), target_endian = "little"))]
     fn test_string_data_ucs2_invalid() {
         Python::with_gil(|py| {
             // U+FF22 (valid) & U+d800 (never valid)
@@ -728,7 +728,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+    #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn test_string_data_ucs4() {
         Python::with_gil(|py| {
             let s = "哈哈🐈";
@@ -741,7 +741,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(not(any(Py_LIMITED_API, PyPy)), target_endian = "little"))]
+    #[cfg(all(not(any(Py_LIMITED_API, PyPy, GraalPy)), target_endian = "little"))]
     fn test_string_data_ucs4_invalid() {
         Python::with_gil(|py| {
             // U+20000 (valid) & U+d800 (never valid)

--- a/tests/test_append_to_inittab.rs
+++ b/tests/test_append_to_inittab.rs
@@ -19,7 +19,7 @@ mod module_mod_with_functions {
     use super::foo;
 }
 
-#[cfg(not(PyPy))]
+#[cfg(not(any(PyPy, GraalPy)))]
 #[test]
 fn test_module_append_to_inittab() {
     use pyo3::{append_to_inittab, ffi};

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -182,12 +182,11 @@ mod inheriting_native_type {
     use pyo3::exceptions::PyException;
     use pyo3::types::PyDict;
 
-    #[cfg(not(PyPy))]
+    #[cfg(not(any(PyPy, GraalPy)))]
     #[test]
     fn inherit_set() {
         use pyo3::types::PySet;
 
-        #[cfg(not(PyPy))]
         #[pyclass(extends=PySet)]
         #[derive(Debug)]
         struct SetWithName {
@@ -195,7 +194,6 @@ mod inheriting_native_type {
             _name: &'static str,
         }
 
-        #[cfg(not(PyPy))]
         #[pymethods]
         impl SetWithName {
             #[new]

--- a/tests/test_super.rs
+++ b/tests/test_super.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "macros", not(PyPy)))]
+#![cfg(all(feature = "macros", not(any(PyPy, GraalPy))))]
 
 use pyo3::{prelude::*, types::PySuper};
 


### PR DESCRIPTION
Split from #5091, as the GraalPy changes got more and more numerous.

This PR bumps the GraalPy version we test to 24.2. From what I can tell, the GraalPy team only releases patch fixes for the current GraalPy version, so the older ones are presumably unsupported and we probably don't need to test those either. It would also reduce our CI pressure to cut the number of GraalPy jobs running.