### PR TITLE
ci: reduce verbosity & install zoneinfo backport on <3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ on:
       MSRV:
         required: true
         type: string
+      verbose:
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -66,6 +69,10 @@ jobs:
         run: |
           echo "CARGO_BUILD_TARGET=i686-pc-windows-msvc" >> $GITHUB_ENV
 
+      - name: Install zoneinfo backport for Python 3.7 / 3.8
+        if: contains(fromJSON('["3.7", "3.8"]'), inputs.python-version)
+        run: python -m pip install backports.zoneinfo
+
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
@@ -86,8 +93,8 @@ jobs:
         if: ${{ inputs.rust == 'stable' && !startsWith(inputs.python-version, 'graalpy') }}
         id: ffi-changes
         with:
-          base: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
-          ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
+          base: ${{ github.event.merge_group.base_ref }}
+          ref: ${{ github.event.merge_group.head_ref }}
           filters: |
             changed:
               - 'pyo3-ffi/**'
@@ -142,7 +149,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
     env:
-      CARGO_TERM_VERBOSE: true
+      CARGO_TERM_VERBOSE: ${{ inputs.verbose }}
       RUST_BACKTRACE: 1
       RUSTFLAGS: "-D warnings"
       RUSTDOCFLAGS: "-D warnings"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
       MSRV: ${{ needs.resolve.outputs.MSRV }}
-      verbose: ${{ needs.resole.outputs.verbose }}
+      verbose: ${{ needs.resolve.outputs.verbose }}
     secrets: inherit
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
@@ -250,7 +250,7 @@ jobs:
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
       MSRV: ${{ needs.resolve.outputs.MSRV }}
-      verbose: ${{ needs.resole.outputs.verbose }}
+      verbose: ${{ needs.resolve.outputs.verbose }}
     secrets: inherit
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       MSRV: ${{ steps.resolve-msrv.outputs.MSRV }}
+      verbose: ${{ runner.debug == '1' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -175,6 +176,7 @@ jobs:
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
       MSRV: ${{ needs.resolve.outputs.MSRV }}
+      verbose: ${{ needs.resole.outputs.verbose }}
     secrets: inherit
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
@@ -248,6 +250,7 @@ jobs:
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
       MSRV: ${{ needs.resolve.outputs.MSRV }}
+      verbose: ${{ needs.resole.outputs.verbose }}
     secrets: inherit
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
       MSRV: ${{ needs.resolve.outputs.MSRV }}
-      verbose: ${{ needs.resolve.outputs.verbose }}
+      verbose: ${{ needs.resolve.outputs.verbose == 'true' }}
     secrets: inherit
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
@@ -250,7 +250,7 @@ jobs:
       rust: ${{ matrix.rust }}
       rust-target: ${{ matrix.platform.rust-target }}
       MSRV: ${{ needs.resolve.outputs.MSRV }}
-      verbose: ${{ needs.resolve.outputs.verbose }}
+      verbose: ${{ needs.resolve.outputs.verbose == 'true' }}
     secrets: inherit
     strategy:
       # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present


### PR DESCRIPTION
Some cleanups to CI to reduce noise:
- Install `backports.zoneinfo` on 3.7 & 3.8, to fix failing test.
- Don't pass `base` / `ref` to `dorny/paths-filter` on PR (it picks these up automatically anyway and warns that it's ignoring what we set)
- Only set `CARGO_TERM_VERBOSE` if actions debug logging is enabled