### PR TITLE
If the bare abi3 feature is requested on a too-new Python, fall back to the maximum supported abi3

### DIFF
--- a/newsfragments/5144.changed.md
+++ b/newsfragments/5144.changed.md
@@ -1,0 +1,1 @@
+When building with `abi3` for a Python version newer than pyo3 supports, we now automatically fall back to an abi3 build for the latest version.

--- a/noxfile.py
+++ b/noxfile.py
@@ -743,6 +743,9 @@ def test_version_limits(session: nox.Session):
         config_file.set("CPython", "3.15")
         _run_cargo(session, "check", env=env, expect_error=True)
 
+        # 3.15 CPython should build if abi3 is explicitly requested
+        _run_cargo(session, "check", "--features=pyo3/abi3", env=env)
+
         # 3.15 CPython should build with forward compatibility
         env["PYO3_USE_ABI3_FORWARD_COMPATIBILITY"] = "1"
         _run_cargo(session, "check", env=env)

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -730,6 +730,9 @@ print("gil_disabled", get_config_var("Py_GIL_DISABLED"))
             );
 
             self.version = version;
+        } else if is_abi3() && self.version.minor > ABI3_MAX_MINOR {
+            warn!("Automatically falling back to abi3-py3{ABI3_MAX_MINOR} because current Python is higher than the maximum supported");
+            self.version.minor = ABI3_MAX_MINOR;
         }
 
         Ok(())


### PR DESCRIPTION
Fixes #5093