### PR TITLE
Add public methods `compile_string` and `run_code` to the Python struct

### DIFF
--- a/newsfragments/5149.added.md
+++ b/newsfragments/5149.added.md
@@ -1,1 +1,2 @@
-Add public methods `compile_string` and `run_code` to the Python struct.
+Add public methods `compile` and `run` to the PyCode struct.
+Add public method `run_code_object` to the Python struct.

--- a/newsfragments/5149.added.md
+++ b/newsfragments/5149.added.md
@@ -1,0 +1,1 @@
+Add public methods `compile_string` and `run_code` to the Python struct.

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -124,6 +124,7 @@ use crate::gil::{GILGuard, SuspendGIL};
 use crate::impl_::not_send::NotSend;
 use crate::py_result_ext::PyResultExt;
 use crate::types::any::PyAnyMethods;
+#[cfg(all(not(Py_LIMITED_API), not(PyPy), not(GraalPy)))]
 use crate::types::PyCode;
 use crate::types::{
     PyAny, PyDict, PyEllipsis, PyModule, PyNone, PyNotImplemented, PyString, PyType,
@@ -613,10 +614,54 @@ impl<'py> Python<'py> {
         let code_obj = unsafe {
             ffi::Py_CompileString(code.as_ptr(), ffi::c_str!("<string>").as_ptr(), start)
                 .assume_owned_or_err(self)?
-        }
-        .downcast_into()?;
+        };
 
-        self.run_code_object(&code_obj, globals, locals)
+        let mptr = unsafe {
+            ffi::compat::PyImport_AddModuleRef(ffi::c_str!("__main__").as_ptr())
+                .assume_owned_or_err(self)?
+        };
+        let attr = mptr.getattr(crate::intern!(self, "__dict__"))?;
+        let globals = match globals {
+            Some(globals) => globals,
+            None => attr.downcast::<PyDict>()?,
+        };
+        let locals = locals.unwrap_or(globals);
+
+        // If `globals` don't provide `__builtins__`, most of the code will fail if Python
+        // version is <3.10. That's probably not what user intended, so insert `__builtins__`
+        // for them.
+        //
+        // See also:
+        // - https://github.com/python/cpython/pull/24564 (the same fix in CPython 3.10)
+        // - https://github.com/PyO3/pyo3/issues/3370
+        let builtins_s = crate::intern!(self, "__builtins__");
+        let has_builtins = globals.contains(builtins_s)?;
+        if !has_builtins {
+            crate::sync::with_critical_section(globals, || {
+                // check if another thread set __builtins__ while this thread was blocked on the critical section
+                let has_builtins = globals.contains(builtins_s)?;
+                if !has_builtins {
+                    // Inherit current builtins.
+                    let builtins = unsafe { ffi::PyEval_GetBuiltins() };
+
+                    // `PyDict_SetItem` doesn't take ownership of `builtins`, but `PyEval_GetBuiltins`
+                    // seems to return a borrowed reference, so no leak here.
+                    if unsafe {
+                        ffi::PyDict_SetItem(globals.as_ptr(), builtins_s.as_ptr(), builtins)
+                    } == -1
+                    {
+                        return Err(PyErr::fetch(self));
+                    }
+                }
+                Ok(())
+            })?;
+        }
+
+        unsafe {
+            ffi::PyEval_EvalCode(code_obj.as_ptr(), globals.as_ptr(), locals.as_ptr())
+                .assume_owned_or_err(self)
+                .downcast_into_unchecked()
+        }
     }
 
     /// Runs code object in the given context.
@@ -626,6 +671,7 @@ impl<'py> Python<'py> {
     ///
     /// If `globals` is `None`, it defaults to Python module `__main__`.
     /// If `locals` is `None`, it defaults to the value of `globals`.
+    #[cfg(all(not(Py_LIMITED_API), not(PyPy), not(GraalPy)))]
     pub fn run_code_object(
         self,
         code_obj: &Bound<'py, PyCode>,
@@ -874,6 +920,7 @@ mod tests {
         });
     }
 
+    #[cfg(all(not(Py_LIMITED_API), not(PyPy), not(GraalPy)))]
     #[test]
     fn test_reuse_compiled_code() {
         Python::with_gil(|py| {

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -541,12 +541,11 @@ impl<'py> Python<'py> {
     /// ```
     pub fn eval(
         self,
-        code_str: &CStr,
+        code: &CStr,
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let code_obj = self.compile_string_as(code_str, ffi::Py_eval_input)?;
-        self.run_code(&code_obj, globals, locals)
+        self.run_code(code, ffi::Py_eval_input, globals, locals)
     }
 
     /// Executes one or more Python statements in the given context.
@@ -586,24 +585,27 @@ impl<'py> Python<'py> {
     /// if you don't need `globals` and unwrapping is OK.
     pub fn run(
         self,
-        code_str: &CStr,
+        code: &CStr,
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<()> {
-        let code_obj = self.compile_string(code_str)?;
-        let res = self.run_code(&code_obj, globals, locals);
+        let res = self.run_code(code, ffi::Py_file_input, globals, locals);
         res.map(|obj| {
             debug_assert!(obj.is_none());
         })
     }
 
-    /// Runs a code object in the given context.
+    /// Runs code in the given context.
+    ///
+    /// `start` indicates the type of input expected: one of `Py_single_input`,
+    /// `Py_file_input`, or `Py_eval_input`.
     ///
     /// If `globals` is `None`, it defaults to Python module `__main__`.
     /// If `locals` is `None`, it defaults to the value of `globals`.
-    pub fn run_code(
+    fn run_code(
         self,
-        code_obj: &Bound<'py, PyAny>,
+        code: &CStr,
+        start: c_int,
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
@@ -648,26 +650,15 @@ impl<'py> Python<'py> {
             })?;
         }
 
+        let code_obj = unsafe {
+            ffi::Py_CompileString(code.as_ptr(), ffi::c_str!("<string>").as_ptr(), start)
+                .assume_owned_or_err(self)?
+        };
+
         unsafe {
             ffi::PyEval_EvalCode(code_obj.as_ptr(), globals.as_ptr(), locals.as_ptr())
                 .assume_owned_or_err(self)
                 .downcast_into_unchecked()
-        }
-    }
-
-    /// Compiles an arbitrarily large string of code into a runnable code object.
-    pub fn compile_string(self, code_str: &CStr) -> PyResult<Bound<'py, PyAny>> {
-        self.compile_string_as(code_str, ffi::Py_file_input)
-    }
-
-    /// Compiles a string of code into a runnable code object.
-    ///
-    /// `start` indicates the type of input expected: one of `Py_single_input`,
-    /// `Py_file_input`, or `Py_eval_input`.
-    fn compile_string_as(self, code_str: &CStr, start: c_int) -> PyResult<Bound<'py, PyAny>> {
-        unsafe {
-            ffi::Py_CompileString(code_str.as_ptr(), ffi::c_str!("<string>").as_ptr(), start)
-                .assume_owned_or_err(self)
         }
     }
 
@@ -862,32 +853,6 @@ mod tests {
                 .extract()
                 .unwrap();
             assert_eq!(v, 2);
-        });
-    }
-
-    #[test]
-    fn test_reuse_compiled_code() {
-        Python::with_gil(|py| {
-            // Perform one-off compilation of a code string
-            let code = py
-                .compile_string(ffi::c_str!("total = local_int + global_int"))
-                .unwrap();
-
-            // Run compiled code with globals & locals
-            let globals = [("global_int", 50)].into_py_dict(py).unwrap();
-            let locals = [("local_int", 100)].into_py_dict(py).unwrap();
-            py.run_code(&code, Some(&globals), Some(&locals)).unwrap();
-
-            let py_total = locals.get_item("total").unwrap();
-            assert_eq!(py_total.extract::<i32>().unwrap(), 150);
-
-            // Run compiled code with different globals & locals
-            let globals = [("global_int", 150)].into_py_dict(py).unwrap();
-            let locals = [("local_int", 350)].into_py_dict(py).unwrap();
-            py.run_code(&code, Some(&globals), Some(&locals)).unwrap();
-
-            let py_total = locals.get_item("total").unwrap();
-            assert_eq!(py_total.extract::<i32>().unwrap(), 500);
         });
     }
 

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -611,11 +611,6 @@ impl<'py> Python<'py> {
         globals: Option<&Bound<'py, PyDict>>,
         locals: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let code_obj = unsafe {
-            ffi::Py_CompileString(code.as_ptr(), ffi::c_str!("<string>").as_ptr(), start)
-                .assume_owned_or_err(self)?
-        };
-
         let mptr = unsafe {
             ffi::compat::PyImport_AddModuleRef(ffi::c_str!("__main__").as_ptr())
                 .assume_owned_or_err(self)?
@@ -656,6 +651,11 @@ impl<'py> Python<'py> {
                 Ok(())
             })?;
         }
+
+        let code_obj = unsafe {
+            ffi::Py_CompileString(code.as_ptr(), ffi::c_str!("<string>").as_ptr(), start)
+                .assume_owned_or_err(self)?
+        };
 
         unsafe {
             ffi::PyEval_EvalCode(code_obj.as_ptr(), globals.as_ptr(), locals.as_ptr())

--- a/src/types/code.rs
+++ b/src/types/code.rs
@@ -1,5 +1,10 @@
-use crate::ffi;
-use crate::PyAny;
+use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::py_result_ext::PyResultExt;
+use crate::types::PyDict;
+use crate::{ffi, PyResult, Python};
+use crate::{Bound, PyAny};
+use std::ffi::CStr;
+use std::os::raw::c_int;
 
 /// Represents a Python code object.
 ///
@@ -14,10 +19,35 @@ pyobject_native_type_core!(
     #checkfunction=ffi::PyCode_Check
 );
 
+impl PyCode {
+    /// Compiles an arbitrarily large string of code into a runnable code object.
+    pub fn compile<'py>(
+        py: Python<'py>,
+        code_str: &CStr,
+        start: c_int,
+    ) -> PyResult<Bound<'py, Self>> {
+        let code_obj = unsafe {
+            ffi::Py_CompileString(code_str.as_ptr(), ffi::c_str!("<string>").as_ptr(), start)
+                .assume_owned_or_err(py)
+        };
+        code_obj.downcast_into()
+    }
+
+    /// Runs compiled code object in the given context.
+    pub fn run<'py>(
+        py: Python<'py>,
+        code_obj: &Bound<'py, PyCode>,
+        globals: Option<&Bound<'py, PyDict>>,
+        locals: Option<&Bound<'py, PyDict>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        py.run_code_object(code_obj, globals, locals)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::PyTypeMethods;
+    use crate::types::{IntoPyDict, PyAnyMethods, PyTypeMethods};
     use crate::{PyTypeInfo, Python};
 
     #[test]
@@ -25,5 +55,34 @@ mod tests {
         Python::with_gil(|py| {
             assert_eq!(PyCode::type_object(py).name().unwrap(), "code");
         })
+    }
+
+    #[test]
+    fn test_reuse_compiled_code() {
+        Python::with_gil(|py| {
+            // Perform one-off compilation of a code string
+            let code_obj = PyCode::compile(
+                py,
+                ffi::c_str!("total = local_int + global_int"),
+                ffi::Py_file_input,
+            )
+            .unwrap();
+
+            // Run compiled code with globals & locals
+            let globals = [("global_int", 50)].into_py_dict(py).unwrap();
+            let locals = [("local_int", 100)].into_py_dict(py).unwrap();
+            PyCode::run(py, &code_obj, Some(&globals), Some(&locals)).unwrap();
+
+            let py_total = locals.get_item("total").unwrap();
+            assert_eq!(py_total.extract::<i32>().unwrap(), 150);
+
+            // Run compiled code with different globals & locals
+            let globals = [("global_int", 150)].into_py_dict(py).unwrap();
+            let locals = [("local_int", 350)].into_py_dict(py).unwrap();
+            PyCode::run(py, &code_obj, Some(&globals), Some(&locals)).unwrap();
+
+            let py_total = locals.get_item("total").unwrap();
+            assert_eq!(py_total.extract::<i32>().unwrap(), 500);
+        });
     }
 }


### PR DESCRIPTION
Add public methods `compile_string` and `run_code` to the Python struct and refactor `run` & `eval` to use these methods internally.

For code that needs to be evaluated multiple times, compiling the input string and re-running the compiled object is more efficient than recompiling the input string for each run.

Closes #5124.