### PR TITLE
conversions: fix FromPyObject impl for uuid::Uuid for big-endian

### DIFF
--- a/src/conversions/uuid.rs
+++ b/src/conversions/uuid.rs
@@ -85,7 +85,7 @@ impl FromPyObject<'_> for Uuid {
 
         if obj.is_instance(uuid_cls)? {
             let uuid_int: u128 = obj.getattr(intern!(py, "int"))?.extract()?;
-            Ok(Uuid::from_u128(uuid_int.to_le()))
+            Ok(Uuid::from_u128(uuid_int))
         } else {
             Err(PyTypeError::new_err("Expected a `uuid.UUID` instance."))
         }


### PR DESCRIPTION
The "to_le()" conversion on the u128 seems to be just wrong. See https://github.com/PyO3/pyo3/issues/5160 for a more thorough investigation that led me to this simple "delete 8 characters to fix the problem" fix :)

Note that it looks like this implementation has *always* been wrong since it was originally added ... I'll likely end up backporting this change to older PyO3 versions that we still need to support in Fedora Linux and EPEL.

Fixes #5160 