### PR TITLE
Add conversions for chrono's `Local` timezone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ smallvec = { version = "1.0", optional = true }
 uuid = { version = "1.11.0", optional = true }
 lock_api = { version = "0.4", optional = true }
 parking_lot = { version = "0.12", optional = true }
+iana-time-zone = { version = "0.1", optional = true, features = ["fallback"]}
 
 [target.'cfg(not(target_has_atomic = "64"))'.dependencies]
 portable-atomic = "1.0"
@@ -121,6 +122,8 @@ py-clone = []
 parking_lot = ["dep:parking_lot", "lock_api"]
 arc_lock = ["lock_api", "lock_api/arc_lock", "parking_lot?/arc_lock"]
 
+chrono-local = ["chrono/clock", "dep:iana-time-zone"]
+
 # Optimizes PyObject to Vec conversion and so on.
 nightly = []
 
@@ -133,6 +136,7 @@ full = [
     "arc_lock",
     "bigdecimal",
     "chrono",
+    "chrono-local",
     "chrono-tz",
     "either",
     "experimental-async",

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -138,6 +138,10 @@ Adds a dependency on [chrono](https://docs.rs/chrono). Enables a conversion from
 - [NaiveTime](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveTime.html) -> [`PyTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyTime.html)
 - [DateTime](https://docs.rs/chrono/latest/chrono/struct.DateTime.html) -> [`PyDateTime`]({{#PYO3_DOCS_URL}}/pyo3/types/struct.PyDateTime.html)
 
+### `chrono-local`
+
+Enables conversion from and to [Local](https://docs.rs/chrono/latest/chrono/struct.Local.html) timezones.
+
 ### `chrono-tz`
 
 Adds a dependency on [chrono-tz](https://docs.rs/chrono-tz).

--- a/newsfragments/5174.added.md
+++ b/newsfragments/5174.added.md
@@ -1,0 +1,1 @@
+Add conversions for chrono's `Local` timezone & `DateTime<Local>` instances.


### PR DESCRIPTION
This add `IntoPyObject` & `FromPyObject` implementations for `DateTime<Local>`. It will create datetime instances with a `ZoneInfo` bound to the local iana name. Furthermore when converting into rust it will validate it has the same timezone. This currently does not handle naive python datetimes and will throw a exception when it does not match (or contains) the local timezone.

closes #5169
