### PR TITLE
ci: fixes 2025-06-06

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,7 @@ jobs:
           python-version: ${{ inputs.python-version }}
           architecture: ${{ inputs.python-architecture }}
           # PyPy can have FFI changes within Python versions, which creates pain in CI
-          # 3.13.2 also had an ABI break so temporarily add this for 3.13 to ensure that we're using 3.13.3
-          check-latest: ${{ startsWith(inputs.python-version, 'pypy') || startsWith(inputs.python-version, '3.13') }}
+          check-latest: ${{ startsWith(inputs.python-version, 'pypy') }}
 
       - name: Install nox
         run: python -m pip install --upgrade pip && pip install nox
@@ -111,6 +110,9 @@ jobs:
               - '.github/workflows/build.yml'
 
       - name: Run pyo3-ffi-check
+        # Python 3.13.4 has an issue on Windows where the headers are configured to always be free-threaded
+        # https://discuss.python.org/t/heads-up-3-13-5-release-coming-soon/94535
+        continue-on-error: ${{ inputs.python-version == '3.13' && (inputs.os == 'windows-latest' || inputs.os == 'windows-11-arm') }}
         # pypy 3.9 on windows is not PEP 3123 compliant, nor is graalpy
         if: ${{ endsWith(inputs.python-version, '-dev') || (steps.ffi-changes.outputs.changed == 'true' && inputs.rust == 'stable' && !startsWith(inputs.python-version, 'graalpy') && !(inputs.python-version == 'pypy3.9' && contains(inputs.os, 'windows'))) }}
         run: nox -s ffi-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,9 @@ jobs:
           components: clippy,rust-src
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          # FIXME: 3.13.4 has an issue on windows so pinned to 3.13.3
+          # once 3.13.5 is out, unpin the patch version
+          python-version: "3.13.3"
           architecture: ${{ matrix.platform.python-architecture }}
       - uses: Swatinem/rust-cache@v2
         with:

--- a/pyo3-macros-backend/src/intopyobject.rs
+++ b/pyo3-macros-backend/src/intopyobject.rs
@@ -530,8 +530,8 @@ pub fn build_derive_into_pyobject<const REF: bool>(tokens: &DeriveInput) -> Resu
             type Error = #error;
 
             fn into_pyobject(self, py: #pyo3_path::Python<#lt_param>) -> ::std::result::Result<
-                <Self as #pyo3_path::conversion::IntoPyObject>::Output,
-                <Self as #pyo3_path::conversion::IntoPyObject>::Error,
+                <Self as #pyo3_path::conversion::IntoPyObject<#lt_param>>::Output,
+                <Self as #pyo3_path::conversion::IntoPyObject<#lt_param>>::Error,
             > {
                 #body
             }


### PR DESCRIPTION
- Nightly Rust is emitting a new warning on the `IntoPyObject` generated code
- Python 3.13.4 has an upstream issue on Windows causing `ffi-check` to fail