### PR TITLE
Set the same maximum version for all interpreters

### DIFF
--- a/newsfragments/5192.packaging.md
+++ b/newsfragments/5192.packaging.md
@@ -1,0 +1,1 @@
+Set the same maximum supported version for alternative interpreters as for CPython

--- a/noxfile.py
+++ b/noxfile.py
@@ -754,10 +754,6 @@ def test_version_limits(session: nox.Session):
         config_file.set("PyPy", "3.8")
         _run_cargo(session, "check", env=env, expect_error=True)
 
-        assert "3.12" not in PYPY_VERSIONS
-        config_file.set("PyPy", "3.12")
-        _run_cargo(session, "check", env=env, expect_error=True)
-
 
 @nox.session(name="check-feature-powerset", venv_backend="none")
 def check_feature_powerset(session: nox.Session):

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -23,10 +23,7 @@ const SUPPORTED_VERSIONS_CPYTHON: SupportedVersions = SupportedVersions {
 
 const SUPPORTED_VERSIONS_PYPY: SupportedVersions = SupportedVersions {
     min: PythonVersion { major: 3, minor: 9 },
-    max: PythonVersion {
-        major: 3,
-        minor: 11,
-    },
+    max: SUPPORTED_VERSIONS_CPYTHON.max,
 };
 
 const SUPPORTED_VERSIONS_GRAALPY: SupportedVersions = SupportedVersions {
@@ -34,10 +31,7 @@ const SUPPORTED_VERSIONS_GRAALPY: SupportedVersions = SupportedVersions {
         major: 3,
         minor: 10,
     },
-    max: PythonVersion {
-        major: 3,
-        minor: 11,
-    },
+    max: SUPPORTED_VERSIONS_CPYTHON.max,
 };
 
 fn ensure_python_version(interpreter_config: &InterpreterConfig) -> Result<()> {


### PR DESCRIPTION
Hi PyO3 maintainers. We're in progress of updating GraalPy to support Python 3.12 and we've run into the version check that hardcodes the maximum supported Python version on GraalPy to 3.11, which prevents any pyo3-based extension from building against our 3.12 snapshots. I'd like to propose setting the maximum supported version of alternative interpreters to the same as CPython. Here's why:
Having to bump the maximum supported version in PyO3 for GraalPy independently of CPython means that even if we do it while our version update is still in development, by the time we release, many packages will not have updated yet and thus won't work. In case of CPython, package maintainers typically work to update their PyO3 version to support the new CPython version soon after it's released or even before that. But GraalPy is not yet widespread enough, so we cannot realistically expect the same would happen for a new GraalPy release. When we merged GraalPy support in PyO3, it took many months for packages to update to the compatible PyO3 version and we still sometimes encounter packages that haven't updated to that version even though it's been more than a year.
The API exposed by GraalPy (and PyPy) should be mostly the same as CPython, so once PyO3 has been updated to support CPython 3.XY, there isn't much reason why it wouldn't work with the same Python version on GraalPy. In the case of 3.12, everything I've tried works fine with no PyO3 changes, except the version check.

CC @timfel 