### PR TITLE
PyGetSetDef: Remove Eq and PartialEq

### DIFF
--- a/newsfragments/5196.removed.md
+++ b/newsfragments/5196.removed.md
@@ -1,0 +1,1 @@
+Remove `Eq` and `PartialEq` implementations on `PyGetSetDef`

--- a/pyo3-ffi/src/descrobject.rs
+++ b/pyo3-ffi/src/descrobject.rs
@@ -14,7 +14,7 @@ pub type setter =
 /// Note that CPython may leave fields uninitialized. You must ensure that
 /// `name` != NULL before dereferencing or reading other fields.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug)]
 pub struct PyGetSetDef {
     pub name: *const c_char,
     pub get: Option<getter>,


### PR DESCRIPTION
Clippy notes that "function pointer comparisons do not produce meaningful results since their addresses are not guaranteed to be unique"