### PR TITLE
fix precision loss when converting `bigdecimal` into python

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ inventory = { version = "0.3.5", optional = true }
 
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0.1", optional = true }
-bigdecimal = { version = "0.4", optional = true }
+bigdecimal = { version = "0.4.3", optional = true }
 chrono = { version = "0.4.25", default-features = false, optional = true }
 chrono-tz = { version = ">= 0.10, < 0.11", default-features = false, optional = true }
 either = { version = "1.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ inventory = { version = "0.3.5", optional = true }
 
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0.1", optional = true }
-bigdecimal = { version = "0.4.4", optional = true }
+bigdecimal = { version = "0.4.7", optional = true }
 chrono = { version = "0.4.25", default-features = false, optional = true }
 chrono-tz = { version = ">= 0.10, < 0.11", default-features = false, optional = true }
 either = { version = "1.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ inventory = { version = "0.3.5", optional = true }
 
 # crate integrations that can be added using the eponymous features
 anyhow = { version = "1.0.1", optional = true }
-bigdecimal = { version = "0.4.3", optional = true }
+bigdecimal = { version = "0.4.4", optional = true }
 chrono = { version = "0.4.25", default-features = false, optional = true }
 chrono-tz = { version = ">= 0.10, < 0.11", default-features = false, optional = true }
 either = { version = "1.9", optional = true }
@@ -121,6 +121,8 @@ py-clone = []
 
 parking_lot = ["dep:parking_lot", "lock_api"]
 arc_lock = ["lock_api", "lock_api/arc_lock", "parking_lot?/arc_lock"]
+
+bigdecimal = ["dep:bigdecimal", "num-bigint"]
 
 chrono-local = ["chrono/clock", "dep:iana-time-zone"]
 

--- a/newsfragments/5198.fixed.md
+++ b/newsfragments/5198.fixed.md
@@ -1,0 +1,1 @@
+fix precision loss when converting `bigdecimal` into python

--- a/src/conversions/bigdecimal.rs
+++ b/src/conversions/bigdecimal.rs
@@ -51,6 +51,7 @@
 
 use std::str::FromStr;
 
+use crate::types::PyTuple;
 use crate::{
     exceptions::PyValueError,
     sync::GILOnceCell,
@@ -58,11 +59,16 @@ use crate::{
     Bound, FromPyObject, IntoPyObject, Py, PyAny, PyErr, PyResult, Python,
 };
 use bigdecimal::BigDecimal;
-
-static DECIMAL_CLS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+use num_bigint::Sign;
 
 fn get_decimal_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static DECIMAL_CLS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
     DECIMAL_CLS.import(py, "decimal", "Decimal")
+}
+
+fn get_invalid_operation_error_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static INVALID_OPERATION_CLS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+    INVALID_OPERATION_CLS.import(py, "decimal", "InvalidOperation")
 }
 
 impl FromPyObject<'_> for BigDecimal {
@@ -82,7 +88,19 @@ impl<'py> IntoPyObject<'py> for BigDecimal {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         let cls = get_decimal_cls(py)?;
-        cls.call1((self.to_scientific_notation(),))
+        let (bigint, scale) = self.into_bigint_and_scale();
+        if scale == 0 {
+            return cls.call1((bigint,));
+        }
+        let exponent = scale.checked_neg().ok_or_else(|| {
+            get_invalid_operation_error_cls(py)
+                .map_or_else(|err| err, |cls| PyErr::from_type(cls.clone(), ()))
+        })?;
+        let (sign, digits) = bigint.to_radix_be(10);
+        let signed = matches!(sign, Sign::Minus).into_pyobject(py)?;
+        let digits = PyTuple::new(py, digits)?;
+
+        cls.call1(((signed, digits, exponent),))
     }
 }
 


### PR DESCRIPTION
This uses the scientific notation when converting a `bigdecimal` into python. This encodes the desired precision of the decimal.

I have not tested if this is faster or slower than going through the tuple constructor as this seemed to be the easiest option.

closes #5151
