### PR TITLE
rename `Python::with_gil` to `Python::attach`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ abi3-py314 = ["abi3", "pyo3-build-config/abi3-py314", "pyo3-ffi/abi3-py314"]
 # Automatically generates `python3.dll` import libraries for Windows targets.
 generate-import-lib = ["pyo3-ffi/generate-import-lib"]
 
-# Changes `Python::with_gil` to automatically initialize the Python interpreter if needed.
+# Changes `Python::attach` to automatically initialize the Python interpreter if needed.
 auto-initialize = []
 
 # Enables `Clone`ing references to Python objects `Py<T>` which panics if the GIL is not held.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ use pyo3::types::IntoPyDict;
 use pyo3::ffi::c_str;
 
 fn main() -> PyResult<()> {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let sys = py.import("sys")?;
         let version: String = sys.getattr("version")?.extract()?;
 

--- a/examples/plugin/src/main.rs
+++ b/examples/plugin/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //import path for python
     let path = Path::new("./python_plugin/");
     //do useful work
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         //add the current directory to import path of Python (do not use this in production!)
         let syspath: Bound<PyList> = py.import("sys")?.getattr("path")?.extract()?;
         syspath.insert(0, &path)?;

--- a/guide/src/async-await.md
+++ b/guide/src/async-await.md
@@ -39,7 +39,7 @@ However, there is an exception for method receivers, so async methods can accept
 
 Even if it is not possible to pass a `py: Python<'py>` parameter to `async fn`, the GIL is still held during the execution of the future – it's also the case for regular `fn` without `Python<'py>`/`Bound<'py, PyAny>` parameter, yet the GIL is held.
 
-It is still possible to get a `Python` marker using [`Python::with_gil`]({{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.with_gil); because `with_gil` is reentrant and optimized, the cost will be negligible.
+It is still possible to get a `Python` marker using [`Python::attach`]({{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.attach); because `attach` is reentrant and optimized, the cost will be negligible.
 
 ## Release the GIL across `.await`
 
@@ -66,7 +66,7 @@ where
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let waker = cx.waker();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             py.allow_threads(|| pin!(&mut self.0).poll(&mut Context::from_waker(waker)))
         })
     }

--- a/guide/src/building-and-distribution.md
+++ b/guide/src/building-and-distribution.md
@@ -278,7 +278,7 @@ If you encounter these or other complications when linking the interpreter stati
 
 ### Import your module when embedding the Python interpreter
 
-When you run your Rust binary with an embedded interpreter, any `#[pymodule]` created modules won't be accessible to import unless added to a table called `PyImport_Inittab` before the embedded interpreter is initialized. This will cause Python statements in your embedded interpreter such as `import your_new_module` to fail. You can call the macro [`append_to_inittab`]({{#PYO3_DOCS_URL}}/pyo3/macro.append_to_inittab.html) with your module before initializing the Python interpreter to add the module function into that table. (The Python interpreter will be initialized by calling `prepare_freethreaded_python`, `with_embedded_python_interpreter`, or `Python::with_gil` with the [`auto-initialize`](features.md#auto-initialize) feature enabled.)
+When you run your Rust binary with an embedded interpreter, any `#[pymodule]` created modules won't be accessible to import unless added to a table called `PyImport_Inittab` before the embedded interpreter is initialized. This will cause Python statements in your embedded interpreter such as `import your_new_module` to fail. You can call the macro [`append_to_inittab`]({{#PYO3_DOCS_URL}}/pyo3/macro.append_to_inittab.html) with your module before initializing the Python interpreter to add the module function into that table. (The Python interpreter will be initialized by calling `prepare_freethreaded_python`, `with_embedded_python_interpreter`, or `Python::attach` with the [`auto-initialize`](features.md#auto-initialize) feature enabled.)
 
 ## Cross Compiling
 

--- a/guide/src/building-and-distribution/multiple-python-versions.md
+++ b/guide/src/building-and-distribution/multiple-python-versions.md
@@ -97,7 +97,7 @@ PyO3 provides the APIs [`Python::version()`] and [`Python::version_info()`] to q
 ```rust
 use pyo3::Python;
 
-Python::with_gil(|py| {
+Python::attach(|py| {
     // PyO3 supports Python 3.7 and up.
     assert!(py.version_info() >= (3, 7));
     assert!(py.version_info() >= (3, 7, 0));

--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -385,7 +385,7 @@ fn my_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 # use pyo3::PyTypeInfo;
 #
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         let globals = PyModule::import(py, "__main__")?.dict();
 #         globals.set_item("Number", Number::type_object(py))?;
 #

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -277,7 +277,7 @@ impl Number {
 }
 
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| {
+#     Python::attach(|py| {
 #         let x = &Bound::new(py, Number(4))?;
 #         let y = &Bound::new(py, Number(4))?;
 #         assert!(x.eq(y)?);

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -215,7 +215,7 @@ impl Container {
     }
 }
 
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 #     let container = Container { iter: vec![1, 2, 3, 4] };
 #     let inst = pyo3::Py::new(py, container).unwrap();
 #     pyo3::py_run!(py, inst, "assert list(inst) == [1, 2, 3, 4]");
@@ -458,7 +458,7 @@ impl ClassWithGCSupport {
 
 Usually, an implementation of `__traverse__` should do nothing but calls to `visit.call`.
 Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`,
-i.e. `Python::with_gil` will panic.
+i.e. `Python::attach` will panic.
 
 > Note: these methods are part of the C API, PyPy does not necessarily honor them. If you are building for PyPy you should measure memory consumption to make sure you do not have runaway memory growth. See [this issue on the PyPy bug tracker](https://github.com/pypy/pypy/issues/3848).
 

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -12,7 +12,7 @@ fails, so usually you will use something like
 # use pyo3::prelude::*;
 # use pyo3::types::PyList;
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| {
+#     Python::attach(|py| {
 #         let list = PyList::new(py, b"foo")?;
 let v: Vec<i32> = list.extract()?;
 #         assert_eq!(&v, &[102, 111, 111]);
@@ -54,7 +54,7 @@ struct RustyStruct {
 }
 #
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         let module = PyModule::from_code(
 #             py,
 #             c_str!("class Foo:
@@ -86,7 +86,7 @@ struct RustyStruct {
 #
 # use pyo3::types::PyDict;
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         let dict = PyDict::new(py);
 #         dict.set_item("my_string", "test")?;
 #
@@ -112,7 +112,7 @@ struct RustyStruct {
 }
 #
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         let module = PyModule::from_code(
 #             py,
 #             c_str!("class Foo(dict):
@@ -156,7 +156,7 @@ struct RustyStruct {
 }
 #
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         let py_dict = py.eval(pyo3::ffi::c_str!("{'foo': 'foo', 'bar': 'bar', 'foobar': 'foobar'}"), None, None)?;
 #         let rustystruct: RustyStruct = py_dict.extract()?;
 # 		  assert_eq!(rustystruct.foo, "foo");
@@ -182,7 +182,7 @@ struct RustyTuple(String, String);
 
 # use pyo3::types::PyTuple;
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         let tuple = PyTuple::new(py, vec!["test", "test2"])?;
 #
 #         let rustytuple: RustyTuple = tuple.extract()?;
@@ -205,7 +205,7 @@ struct RustyTuple((String,));
 
 # use pyo3::types::PyTuple;
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         let tuple = PyTuple::new(py, vec!["test"])?;
 #
 #         let rustytuple: RustyTuple = tuple.extract()?;
@@ -237,7 +237,7 @@ struct RustyTransparentStruct {
 
 # use pyo3::types::PyString;
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         let s = PyString::new(py, "test");
 #
 #         let tup: RustyTransparentTupleStruct = s.extract()?;
@@ -292,7 +292,7 @@ enum RustyEnum<'py> {
 #
 # use pyo3::types::{PyBytes, PyString};
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         {
 #             let thing = 42_u8.into_pyobject(py)?;
 #             let rust_thing: RustyEnum<'_> = thing.extract()?;
@@ -425,7 +425,7 @@ enum RustyEnum {
 }
 #
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         {
 #             let thing = 42_u8.into_pyobject(py)?;
 #             let rust_thing: RustyEnum = thing.extract()?;
@@ -515,7 +515,7 @@ struct RustyStruct {
 #
 # use pyo3::types::PyDict;
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| -> PyResult<()> {
+#     Python::attach(|py| -> PyResult<()> {
 #         // Filled case
 #         let dict = PyDict::new(py);
 #         dict.set_item("value", (1,)).unwrap();
@@ -681,7 +681,7 @@ use pyo3::types::{PyBool, PyInt};
 let ints: Vec<u32> = vec![1, 2, 3, 4];
 let bools = vec![true, false, false, true];
 
-Python::with_gil(|py| {
+Python::attach(|py| {
     let ints_as_pyint: Vec<Bound<'_, PyInt>> = ints
         .iter()
         .map(|x| Ok(x.into_pyobject(py)?))
@@ -696,7 +696,7 @@ Python::with_gil(|py| {
 });
 ```
 
-In this example if we wanted to combine `ints_as_pyints` and `bools_as_pybool` into a single `Vec<Py<PyAny>>` to return from the `with_gil` closure, we would have to manually convert the concrete types for the smart pointers and the python types.
+In this example if we wanted to combine `ints_as_pyints` and `bools_as_pybool` into a single `Vec<Py<PyAny>>` to return from the `Python::attach` closure, we would have to manually convert the concrete types for the smart pointers and the python types.
 
 Instead, we can write a function that generically converts vectors of either integers or bools into a vector of `Py<PyAny>` using the [`BoundObject`] trait:
 
@@ -726,7 +726,7 @@ where
         .collect()
 }
 
-let vec_of_pyobjs: Vec<Py<PyAny>> = Python::with_gil(|py| {
+let vec_of_pyobjs: Vec<Py<PyAny>> = Python::attach(|py| {
     let mut bools_as_pyany = convert_to_vec_of_pyobj(py, bools).unwrap();
     let mut ints_as_pyany = convert_to_vec_of_pyobj(py, ints).unwrap();
     let mut result: Vec<Py<PyAny>> = vec![];

--- a/guide/src/ecosystem/logging.md
+++ b/guide/src/ecosystem/logging.md
@@ -78,7 +78,7 @@ fn main() -> PyResult<()> {
     warn!("Something spooky happened!");
 
     // Log some messages from Python
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         py.run(
             "
 import logging

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -24,7 +24,7 @@ use pyo3::exceptions::PyException;
 create_exception!(mymodule, CustomError, PyException);
 
 # fn main() -> PyResult<()> {
-Python::with_gil(|py| {
+Python::attach(|py| {
     let ctx = [("CustomError", py.get_type::<CustomError>())].into_py_dict(py)?;
     pyo3::py_run!(
         py,
@@ -65,7 +65,7 @@ You can also manually write and fetch errors in the Python interpreter's global 
 use pyo3::{Python, PyErr};
 use pyo3::exceptions::PyTypeError;
 
-Python::with_gil(|py| {
+Python::attach(|py| {
     PyTypeError::new_err("Error").restore(py);
     assert!(PyErr::occurred(py));
     drop(PyErr::fetch(py));
@@ -82,7 +82,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyList};
 
 # fn main() -> PyResult<()> {
-Python::with_gil(|py| {
+Python::attach(|py| {
     assert!(PyBool::new(py, true).is_instance_of::<PyBool>());
     let list = PyList::new(py, &[1, 2, 3, 4])?;
     assert!(!list.is_instance_of::<PyBool>());
@@ -97,7 +97,7 @@ To check the type of an exception, you can similarly do:
 ```rust,no_run
 # use pyo3::exceptions::PyTypeError;
 # use pyo3::prelude::*;
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 # let err = PyTypeError::new_err(());
 err.is_instance_of::<PyTypeError>(py);
 # });
@@ -166,7 +166,7 @@ impl CustomError {
 }
 
 # fn main() -> PyResult<()> {
-Python::with_gil(|py| {
+Python::attach(|py| {
     let ctx = [("CustomError", py.get_type::<CustomError>())].into_py_dict(py)?;
     pyo3::py_run!(
         py,

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -45,7 +45,7 @@ section for further detail.
 
 ### `auto-initialize`
 
-This feature changes [`Python::with_gil`]({{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.with_gil) to automatically initialize a Python interpreter (by calling [`prepare_freethreaded_python`]({{#PYO3_DOCS_URL}}/pyo3/fn.prepare_freethreaded_python.html)) if needed.
+This feature changes [`Python::attach`]({{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.attach) to automatically initialize a Python interpreter (by calling [`prepare_freethreaded_python`]({{#PYO3_DOCS_URL}}/pyo3/fn.prepare_freethreaded_python.html)) if needed.
 
 If you do not enable this feature, you should call `pyo3::prepare_freethreaded_python()` before attempting to call any other Python APIs.
 

--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -136,7 +136,7 @@ We are aware that there are some naming issues in the PyO3 API that make it
 awkward to think about a runtime environment where there is no GIL. We plan to
 change the names of these types to de-emphasize the role of the GIL in future
 versions of PyO3, but for now you should remember that the use of the term `GIL`
-in functions and types like [`Python::with_gil`] and [`GILOnceCell`] is
+in functions and types like [`Python::attach`] and [`GILOnceCell`] is
 historical.
 
 Instead, you should think about whether or not a Rust thread is attached to a
@@ -158,7 +158,7 @@ simultaneously interacting with the interpreter.
 
 You still need to obtain a `'py` lifetime is to interact with Python
 objects or call into the CPython C API. If you are not yet attached to the
-Python runtime, you can register a thread using the [`Python::with_gil`]
+Python runtime, you can register a thread using the [`Python::attach`]
 function. Threads created via the Python [`threading`] module do not not need to
 do this, and pyo3 will handle setting up the [`Python<'py>`] token when CPython
 calls into your extension.
@@ -322,7 +322,7 @@ let mut cache = RuntimeCache {
     cache: None
 };
 
-Python::with_gil(|py| {
+Python::attach(|py| {
     // guaranteed to be called once and only once
     cache.once.call_once_py_attached(py, || {
         cache.cache = Some(PyDict::new(py).unbind());
@@ -353,7 +353,7 @@ use std::cell::RefCell;
 static OBJECTS: GILProtected<RefCell<Vec<Py<PyDict>>>> =
     GILProtected::new(RefCell::new(Vec::new()));
 
-Python::with_gil(|py| {
+Python::attach(|py| {
     // stand-in for something that executes arbitrary Python code
     let d = PyDict::new(py);
     d.set_item(PyNone::get(py), PyNone::get(py)).unwrap();
@@ -372,7 +372,7 @@ use std::sync::Mutex;
 
 static OBJECTS: Mutex<Vec<Py<PyDict>>> = Mutex::new(Vec::new());
 
-Python::with_gil(|py| {
+Python::attach(|py| {
     // stand-in for something that executes arbitrary Python code
     let d = PyDict::new(py);
     d.set_item(PyNone::get(py), PyNone::get(py)).unwrap();
@@ -403,6 +403,6 @@ interpreter.
 [`OnceLock`]: https://doc.rust-lang.org/stable/std/sync/struct.OnceLock.html
 [`OnceLock::get_or_init`]: https://doc.rust-lang.org/stable/std/sync/struct.OnceLock.html#method.get_or_init
 [`Python::allow_threads`]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.allow_threads
-[`Python::with_gil`]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.with_gil
+[`Python::attach`]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.attach
 [`Python<'py>`]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html
 [`threading`]: https://docs.python.org/3/library/threading.html

--- a/guide/src/function.md
+++ b/guide/src/function.md
@@ -59,7 +59,7 @@ The `#[pyo3]` attribute can be used to modify properties of the generated Python
         m.add_function(wrap_pyfunction!(no_args_py, m)?)
     }
 
-    # Python::with_gil(|py| {
+    # Python::attach(|py| {
     #     let m = pyo3::wrap_pymodule!(module_with_functions)(py);
     #     assert!(m.getattr(py, "no_args").is_ok());
     #     assert!(m.getattr(py, "no_args_py").is_err());
@@ -164,7 +164,7 @@ The `#[pyo3]` attribute can be used to modify properties of the generated Python
     #     };
     # }
     # 
-    # Python::with_gil(|py| {
+    # Python::attach(|py| {
     #     assert_warnings!(
     #         py,
     #         {
@@ -224,7 +224,7 @@ The `#[pyo3]` attribute can be used on individual arguments to modify properties
         argument
     }
 
-    # Python::with_gil(|py| {
+    # Python::attach(|py| {
     #     let f = pyo3::wrap_pyfunction!(object_length)(py).unwrap();
     #     assert_eq!(f.call1((vec![1, 2, 3],)).unwrap().extract::<usize>().unwrap(), 3);
     # });

--- a/guide/src/function/error-handling.md
+++ b/guide/src/function/error-handling.md
@@ -43,7 +43,7 @@ fn check_positive(x: i32) -> PyResult<()> {
 }
 #
 # fn main(){
-# 	Python::with_gil(|py|{
+# 	Python::attach(|py|{
 # 		let fun = pyo3::wrap_pyfunction!(check_positive, py).unwrap();
 # 		fun.call1((-1,)).unwrap_err();
 # 		fun.call1((1,)).unwrap();
@@ -71,7 +71,7 @@ fn parse_int(x: &str) -> Result<usize, ParseIntError> {
 }
 
 # fn main() {
-#     Python::with_gil(|py| {
+#     Python::attach(|py| {
 #         let fun = pyo3::wrap_pyfunction!(parse_int, py).unwrap();
 #         let value: usize = fun.call1(("5",)).unwrap().extract().unwrap();
 #         assert_eq!(value, 5);
@@ -131,7 +131,7 @@ fn connect(s: String) -> Result<(), CustomIOError> {
 }
 
 fn main() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let fun = pyo3::wrap_pyfunction!(connect, py).unwrap();
         let err = fun.call1(("0.0.0.0",)).unwrap_err();
         assert!(err.is_instance_of::<PyOSError>(py));
@@ -158,7 +158,7 @@ fn parse_int(s: String) -> PyResult<usize> {
 # use pyo3::exceptions::PyValueError;
 #
 # fn main() {
-#     Python::with_gil(|py| {
+#     Python::attach(|py| {
 #         assert_eq!(parse_int(String::from("1")).unwrap(), 1);
 #         assert_eq!(parse_int(String::from("1337")).unwrap(), 1337);
 #
@@ -223,7 +223,7 @@ fn wrapped_get_x() -> Result<i32, MyOtherError> {
 }
 
 # fn main() {
-#     Python::with_gil(|py| {
+#     Python::attach(|py| {
 #         let fun = pyo3::wrap_pyfunction!(wrapped_get_x, py).unwrap();
 #         let value: usize = fun.call0().unwrap().extract().unwrap();
 #         assert_eq!(value, 5);

--- a/guide/src/function/signature.md
+++ b/guide/src/function/signature.md
@@ -139,7 +139,7 @@ fn add(a: u64, b: u64) -> u64 {
 }
 #
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| {
+#     Python::attach(|py| {
 #         let fun = pyo3::wrap_pyfunction!(add, py)?;
 #
 #         let doc: String = fun.getattr("__doc__")?.extract()?;
@@ -187,7 +187,7 @@ fn add(a: u64, b: u64) -> u64 {
 }
 #
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| {
+#     Python::attach(|py| {
 #         let fun = pyo3::wrap_pyfunction!(add, py)?;
 #
 #         let doc: String = fun.getattr("__doc__")?.extract()?;
@@ -229,7 +229,7 @@ fn add(a: u64, b: u64) -> u64 {
 }
 #
 # fn main() -> PyResult<()> {
-#     Python::with_gil(|py| {
+#     Python::attach(|py| {
 #         let fun = pyo3::wrap_pyfunction!(add, py)?;
 #
 #         let doc: String = fun.getattr("__doc__")?.extract()?;

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -201,7 +201,7 @@ Before:
 # use pyo3::prelude::*;
 # use pyo3::types::PyTuple;
 # fn main() {
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 // For example, for PyTuple. Many such APIs have been changed.
 let tup = PyTuple::new_bound(py, [1, 2, 3]);
 # })
@@ -214,7 +214,7 @@ After:
 # use pyo3::prelude::*;
 # use pyo3::types::PyTuple;
 # fn main() {
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 // For example, for PyTuple. Many such APIs have been changed.
 let tup = PyTuple::new(py, [1, 2, 3]);
 # })
@@ -1160,7 +1160,7 @@ fn simple_function(a: i32, b: i32, c: i32) {}
 fn function_with_defaults(a: i32, b: i32, c: i32) {}
 
 # fn main() {
-#     Python::with_gil(|py| {
+#     Python::attach(|py| {
 #         let simple = wrap_pyfunction!(simple_function, py).unwrap();
 #         assert_eq!(simple.getattr("__text_signature__").unwrap().to_string(), "(a, b, c)");
 #         let defaulted = wrap_pyfunction!(function_with_defaults, py).unwrap();
@@ -1891,14 +1891,14 @@ To migrate, just pass a `py` argument to any calls to these methods.
 
 Before:
 ```rust,compile_fail
-# pyo3::Python::with_gil(|py| {
+# pyo3::Python::attach(|py| {
 py.None().get_refcnt();
 # })
 ```
 
 After:
 ```rust
-# pyo3::Python::with_gil(|py| {
+# pyo3::Python::attach(|py| {
 py.None().get_refcnt(py);
 # })
 ```
@@ -2018,7 +2018,7 @@ impl Names {
         self.names.append(&mut other.names)
     }
 }
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 #     let names = Py::new(py, Names::new()).unwrap();
 #     pyo3::py_run!(py, names, r"
 #     try:

--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -85,7 +85,7 @@ fn func() -> String {
     "func".to_string()
 }
 
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 #    use pyo3::wrap_pymodule;
 #    use pyo3::types::IntoPyDict;
 #    use pyo3::ffi::c_str;

--- a/guide/src/parallelism.md
+++ b/guide/src/parallelism.md
@@ -147,11 +147,11 @@ struct UserID {
     id: i64,
 }
 
-let allowed_ids: Vec<bool> = Python::with_gil(|outer_py| {
+let allowed_ids: Vec<bool> = Python::attach(|outer_py| {
     let instances: Vec<Py<UserID>> = (0..10).map(|x| Py::new(outer_py, UserID { id: x }).unwrap()).collect();
     outer_py.allow_threads(|| {
         instances.par_iter().map(|instance| {
-            Python::with_gil(|inner_py| {
+            Python::attach(|inner_py| {
                 instance.borrow(inner_py).id > 5
             })
         }).collect()

--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -11,7 +11,7 @@ module available in your environment.
 use pyo3::prelude::*;
 
 fn main() -> PyResult<()> {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let builtins = PyModule::import(py, "builtins")?;
         let total: i32 = builtins
             .getattr("sum")?
@@ -36,7 +36,7 @@ use pyo3::prelude::*;
 use pyo3::ffi::c_str;
 
 # fn main() -> Result<(), ()> {
-Python::with_gil(|py| {
+Python::attach(|py| {
     let result = py
         .eval(c_str!("[i * 10 for i in range(5)]"), None, None)
         .map_err(|e| {
@@ -84,7 +84,7 @@ impl UserData {
     }
 }
 
-Python::with_gil(|py| {
+Python::attach(|py| {
     let userdata = UserData {
         id: 34,
         name: "Yu".to_string(),
@@ -113,7 +113,7 @@ use pyo3::{prelude::*, types::IntoPyDict};
 use pyo3_ffi::c_str;
 
 # fn main() -> PyResult<()> {
-Python::with_gil(|py| {
+Python::attach(|py| {
     let activators = PyModule::from_code(
         py,
         c_str!(r#"
@@ -172,7 +172,7 @@ fn foo(foo_module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 fn main() -> PyResult<()> {
     pyo3::append_to_inittab!(foo);
-    Python::with_gil(|py| Python::run(py, c_str!("import foo; foo.add_one(6)"), None, None))
+    Python::attach(|py| Python::run(py, c_str!("import foo; foo.add_one(6)"), None, None))
 }
 ```
 
@@ -191,7 +191,7 @@ pub fn add_one(x: i64) -> i64 {
 }
 
 fn main() -> PyResult<()> {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // Create new module
         let foo_module = PyModule::new(py, "foo")?;
         foo_module.add_function(wrap_pyfunction!(add_one, &foo_module)?)?;
@@ -264,7 +264,7 @@ fn main() -> PyResult<()> {
         "/python_app/utils/foo.py"
     )));
     let py_app = c_str!(include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/python_app/app.py")));
-    let from_python = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+    let from_python = Python::attach(|py| -> PyResult<Py<PyAny>> {
         PyModule::from_code(py, py_foo, c_str!("foo.py"), c_str!("utils.foo"))?;
         let app: Py<PyAny> = PyModule::from_code(py, py_app, c_str!("app.py"), c_str!(""))?
             .getattr("run")?
@@ -299,7 +299,7 @@ use std::ffi::CString;
 fn main() -> PyResult<()> {
     let path = Path::new("/usr/share/python_app");
     let py_app = CString::new(fs::read_to_string(path.join("app.py"))?)?;
-    let from_python = Python::with_gil(|py| -> PyResult<Py<PyAny>> {
+    let from_python = Python::attach(|py| -> PyResult<Py<PyAny>> {
         let syspath = py
             .import("sys")?
             .getattr("path")?
@@ -329,7 +329,7 @@ use pyo3::prelude::*;
 use pyo3::ffi::c_str;
 
 fn main() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let custom_manager = PyModule::from_code(
             py,
             c_str!(r#"
@@ -393,7 +393,7 @@ Alternatively, set Python's `signal` module to take the default action for a sig
 use pyo3::prelude::*;
 
 # fn main() -> PyResult<()> {
-Python::with_gil(|py| -> PyResult<()> {
+Python::attach(|py| -> PyResult<()> {
     let signal = py.import("signal")?;
     // Set SIGINT to have the default action
     signal

--- a/guide/src/python-from-rust/function-calls.md
+++ b/guide/src/python-from-rust/function-calls.md
@@ -26,7 +26,7 @@ fn main() -> PyResult<()> {
     let arg2 = "arg2";
     let arg3 = "arg3";
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let fun: Py<PyAny> = PyModule::from_code(
             py,
             c_str!("def example(*args, **kwargs):
@@ -73,7 +73,7 @@ fn main() -> PyResult<()> {
     let key2 = "key2";
     let val2 = 2;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let fun: Py<PyAny> = PyModule::from_code(
             py,
             c_str!("def example(*args, **kwargs):

--- a/guide/src/trait-bounds.md
+++ b/guide/src/trait-bounds.md
@@ -81,7 +81,7 @@ struct UserModel {
 impl Model for UserModel {
     fn set_variables(&mut self, var: &Vec<f64>) {
         println!("Rust calling Python to set the variables");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.model
                 .bind(py)
                 .call_method("set_variables", (PyList::new(py, var).unwrap(),), None)
@@ -91,7 +91,7 @@ impl Model for UserModel {
 
     fn get_results(&self) -> Vec<f64> {
         println!("Rust calling Python to get the results");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.model
                 .bind(py)
                 .call_method("get_results", (), None)
@@ -103,7 +103,7 @@ impl Model for UserModel {
 
     fn compute(&mut self) {
         println!("Rust calling Python to perform the computation");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.model
                 .bind(py)
                 .call_method("compute", (), None)
@@ -180,7 +180,7 @@ This wrapper will also perform the type conversions between Python and Rust.
 # impl Model for UserModel {
 #  fn set_variables(&mut self, var: &Vec<f64>) {
 #      println!("Rust calling Python to set the variables");
-#      Python::with_gil(|py| {
+#      Python::attach(|py| {
 #          self.model.bind(py)
 #              .call_method("set_variables", (PyList::new(py, var).unwrap(),), None)
 #              .unwrap();
@@ -189,7 +189,7 @@ This wrapper will also perform the type conversions between Python and Rust.
 #
 #  fn get_results(&self) -> Vec<f64> {
 #      println!("Rust calling Python to get the results");
-#      Python::with_gil(|py| {
+#      Python::attach(|py| {
 #          self.model
 #              .bind(py)
 #              .call_method("get_results", (), None)
@@ -201,7 +201,7 @@ This wrapper will also perform the type conversions between Python and Rust.
 #
 #  fn compute(&mut self) {
 #      println!("Rust calling Python to perform the computation");
-#      Python::with_gil(|py| {
+#      Python::attach(|py| {
 #          self.model
 #              .bind(py)
 #              .call_method("compute", (), None)
@@ -347,7 +347,7 @@ We used in our `get_results` method the following call that performs the type co
 impl Model for UserModel {
     fn get_results(&self) -> Vec<f64> {
         println!("Rust calling Python to get the results");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.model
                 .bind(py)
                 .call_method("get_results", (), None)
@@ -358,7 +358,7 @@ impl Model for UserModel {
     }
 #     fn set_variables(&mut self, var: &Vec<f64>) {
 #         println!("Rust calling Python to set the variables");
-#         Python::with_gil(|py| {
+#         Python::attach(|py| {
 #             self.model.bind(py)
 #                 .call_method("set_variables", (PyList::new(py, var).unwrap(),), None)
 #                 .unwrap();
@@ -367,7 +367,7 @@ impl Model for UserModel {
 #
 #     fn compute(&mut self) {
 #         println!("Rust calling Python to perform the computation");
-#         Python::with_gil(|py| {
+#         Python::attach(|py| {
 #             self.model
 #                 .bind(py)
 #                 .call_method("compute", (), None)
@@ -398,7 +398,7 @@ Let's break it down in order to perform better error handling:
 impl Model for UserModel {
     fn get_results(&self) -> Vec<f64> {
         println!("Get results from Rust calling Python");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_result: Bound<'_, PyAny> = self
                 .model
                 .bind(py)
@@ -417,7 +417,7 @@ impl Model for UserModel {
     }
 #     fn set_variables(&mut self, var: &Vec<f64>) {
 #         println!("Rust calling Python to set the variables");
-#         Python::with_gil(|py| {
+#         Python::attach(|py| {
 #             let py_model = self.model.bind(py)
 #                 .call_method("set_variables", (PyList::new(py, var).unwrap(),), None)
 #                 .unwrap();
@@ -426,7 +426,7 @@ impl Model for UserModel {
 #
 #     fn compute(&mut self) {
 #         println!("Rust calling Python to perform the computation");
-#         Python::with_gil(|py| {
+#         Python::attach(|py| {
 #             self.model
 #                 .bind(py)
 #                 .call_method("compute", (), None)
@@ -514,7 +514,7 @@ impl UserModel {
 impl Model for UserModel {
     fn set_variables(&mut self, var: &Vec<f64>) {
         println!("Rust calling Python to set the variables");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.model
                 .bind(py)
                 .call_method("set_variables", (PyList::new(py, var).unwrap(),), None)
@@ -524,7 +524,7 @@ impl Model for UserModel {
 
     fn get_results(&self) -> Vec<f64> {
         println!("Get results from Rust calling Python");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_result: Bound<'_, PyAny> = self
                 .model
                 .bind(py)
@@ -544,7 +544,7 @@ impl Model for UserModel {
 
     fn compute(&mut self) {
         println!("Rust calling Python to perform the computation");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.model
                 .bind(py)
                 .call_method("compute", (), None)

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -67,7 +67,7 @@ fn example<'py>(py: Python<'py>) -> PyResult<()> {
     drop(x); // release the original reference x
     Ok(())
 }
-# Python::with_gil(example).unwrap();
+# Python::attach(example).unwrap();
 ```
 
 Or, without the type annotations:
@@ -83,7 +83,7 @@ fn example(py: Python<'_>) -> PyResult<()> {
     drop(x);
     Ok(())
 }
-# Python::with_gil(example).unwrap();
+# Python::attach(example).unwrap();
 ```
 
 #### Function argument lifetimes
@@ -111,7 +111,7 @@ fn add<'py>(
 ) -> PyResult<Bound<'py, PyAny>> {
     left.add(right)
 }
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 #     let s = pyo3::types::PyString::new(py, "s");
 #     assert!(add(&s, &s).unwrap().eq("ss").unwrap());
 # })
@@ -125,7 +125,7 @@ fn add(left: &Bound<'_, PyAny>, right: &Bound<'_, PyAny>) -> PyResult<PyObject> 
     let output: Bound<'_, PyAny> = left.add(right)?;
     Ok(output.unbind())
 }
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 #     let s = pyo3::types::PyString::new(py, "s");
 #     assert!(add(&s, &s).unwrap().bind(py).eq("ss").unwrap());
 # })
@@ -155,7 +155,7 @@ for i in 0..=2 {
 }
 # Ok(())
 # }
-# Python::with_gil(example).unwrap();
+# Python::attach(example).unwrap();
 ```
 
 ### Casting between smart pointer types
@@ -231,7 +231,7 @@ use pyo3::types::PyList;
 fn get_first_item<'py>(list: &Bound<'py, PyList>) -> PyResult<Bound<'py, PyAny>> {
     list.get_item(0)
 }
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 #     let l = PyList::new(py, ["hello world"]).unwrap();
 #     assert!(get_first_item(&l).unwrap().eq("hello world").unwrap());
 # })
@@ -259,7 +259,7 @@ let _: &Bound<'py, PyTuple> = obj.downcast()?;
 let _: Bound<'py, PyTuple> = obj.downcast_into()?;
 # Ok(())
 # }
-# Python::with_gil(example).unwrap()
+# Python::attach(example).unwrap()
 ```
 
 Custom [`#[pyclass]`][pyclass] types implement [`PyTypeCheck`], so `.downcast()` also works for these types. The snippet below is the same as the snippet above casting instead to a custom type `MyClass`:
@@ -281,7 +281,7 @@ let _: &Bound<'py, MyClass> = obj.downcast()?;
 let _: Bound<'py, MyClass> = obj.downcast_into()?;
 # Ok(())
 # }
-# Python::with_gil(example).unwrap()
+# Python::attach(example).unwrap()
 ```
 
 ### Extracting Rust data from Python objects
@@ -302,7 +302,7 @@ let (x, y, z) = obj.extract::<(i32, i32, i32)>()?;
 assert_eq!((x, y, z), (1, 2, 3));
 # Ok(())
 # }
-# Python::with_gil(example).unwrap()
+# Python::attach(example).unwrap()
 ```
 
 To avoid copying data, [`#[pyclass]`][pyclass] types can directly reference Rust data stored within the Python objects without needing to `.extract()`. See the [corresponding documentation in the class section of the guide](./class.md#bound-and-interior-mutability)

--- a/newsfragments/5209.changed.md
+++ b/newsfragments/5209.changed.md
@@ -1,0 +1,1 @@
+rename `Python::with_gil` to `Python::attach`

--- a/pyo3-benches/benches/bench_any.rs
+++ b/pyo3-benches/benches/bench_any.rs
@@ -62,7 +62,7 @@ fn find_object_type(obj: &Bound<'_, PyAny>) -> ObjectType {
 }
 
 fn bench_identify_object_type(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = py.eval(c"object()", None, None).unwrap();
 
         b.iter(|| find_object_type(&obj));
@@ -72,7 +72,7 @@ fn bench_identify_object_type(b: &mut Bencher<'_>) {
 }
 
 fn bench_collect_generic_iterator(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let collection = py.eval(c"list(range(1 << 20))", None, None).unwrap();
 
         b.iter(|| {

--- a/pyo3-benches/benches/bench_bigint.rs
+++ b/pyo3-benches/benches/bench_bigint.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 fn extract_bigint_extract_fail(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).extract::<BigInt>() {
@@ -18,7 +18,7 @@ fn extract_bigint_extract_fail(bench: &mut Bencher<'_>) {
 }
 
 fn extract_bigint_small(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let int = py.eval(c"-42", None, None).unwrap();
 
         bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());
@@ -26,7 +26,7 @@ fn extract_bigint_small(bench: &mut Bencher<'_>) {
 }
 
 fn extract_bigint_big_negative(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let int = py.eval(c"-10**300", None, None).unwrap();
 
         bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());
@@ -34,7 +34,7 @@ fn extract_bigint_big_negative(bench: &mut Bencher<'_>) {
 }
 
 fn extract_bigint_big_positive(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let int = py.eval(c"10**300", None, None).unwrap();
 
         bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());
@@ -42,7 +42,7 @@ fn extract_bigint_big_positive(bench: &mut Bencher<'_>) {
 }
 
 fn extract_bigint_huge_negative(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let int = py.eval(c"-10**3000", None, None).unwrap();
 
         bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());
@@ -50,7 +50,7 @@ fn extract_bigint_huge_negative(bench: &mut Bencher<'_>) {
 }
 
 fn extract_bigint_huge_positive(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let int = py.eval(c"10**3000", None, None).unwrap();
 
         bench.iter_with_large_drop(|| black_box(&int).extract::<BigInt>().unwrap());

--- a/pyo3-benches/benches/bench_call.rs
+++ b/pyo3-benches/benches/bench_call.rs
@@ -14,7 +14,7 @@ macro_rules! test_module {
 }
 
 fn bench_call_0(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = test_module!(py, "def foo(): pass");
 
         let foo_module = &module.getattr("foo").unwrap();
@@ -28,7 +28,7 @@ fn bench_call_0(b: &mut Bencher<'_>) {
 }
 
 fn bench_call_1(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = test_module!(py, "def foo(a, b, c): pass");
 
         let foo_module = &module.getattr("foo").unwrap();
@@ -47,7 +47,7 @@ fn bench_call_1(b: &mut Bencher<'_>) {
 }
 
 fn bench_call(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = test_module!(py, "def foo(a, b, c, d, e): pass");
 
         let foo_module = &module.getattr("foo").unwrap();
@@ -69,7 +69,7 @@ fn bench_call(b: &mut Bencher<'_>) {
 }
 
 fn bench_call_one_arg(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = test_module!(py, "def foo(a): pass");
 
         let foo_module = &module.getattr("foo").unwrap();
@@ -84,7 +84,7 @@ fn bench_call_one_arg(b: &mut Bencher<'_>) {
 }
 
 fn bench_call_method_0(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = test_module!(
             py,
             "
@@ -105,7 +105,7 @@ class Foo:
 }
 
 fn bench_call_method_1(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = test_module!(
             py,
             "
@@ -133,7 +133,7 @@ class Foo:
 }
 
 fn bench_call_method(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = test_module!(
             py,
             "
@@ -162,7 +162,7 @@ class Foo:
 }
 
 fn bench_call_method_one_arg(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = test_module!(
             py,
             "

--- a/pyo3-benches/benches/bench_comparisons.rs
+++ b/pyo3-benches/benches/bench_comparisons.rs
@@ -44,7 +44,7 @@ impl OrderedRichcmp {
 }
 
 fn bench_ordered_dunder_methods(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj1 = &Bound::new(py, OrderedDunderMethods(0)).unwrap().into_any();
         let obj2 = &Bound::new(py, OrderedDunderMethods(1)).unwrap().into_any();
 
@@ -53,7 +53,7 @@ fn bench_ordered_dunder_methods(b: &mut Bencher<'_>) {
 }
 
 fn bench_ordered_richcmp(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj1 = &Bound::new(py, OrderedRichcmp(0)).unwrap().into_any();
         let obj2 = &Bound::new(py, OrderedRichcmp(1)).unwrap().into_any();
 

--- a/pyo3-benches/benches/bench_decimal.rs
+++ b/pyo3-benches/benches/bench_decimal.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 fn decimal_via_extract(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let locals = PyDict::new(py);
         py.run(
             cr#"

--- a/pyo3-benches/benches/bench_dict.rs
+++ b/pyo3-benches/benches/bench_dict.rs
@@ -7,7 +7,7 @@ use pyo3::types::IntoPyDict;
 use pyo3::{prelude::*, types::PyMapping};
 
 fn iter_dict(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let dict = (0..LEN as u64)
             .map(|i| (i, i * 2))
@@ -24,7 +24,7 @@ fn iter_dict(b: &mut Bencher<'_>) {
 }
 
 fn dict_new(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         b.iter_with_large_drop(|| {
             (0..LEN as u64)
@@ -36,7 +36,7 @@ fn dict_new(b: &mut Bencher<'_>) {
 }
 
 fn dict_get_item(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let dict = (0..LEN as u64)
             .map(|i| (i, i * 2))
@@ -57,7 +57,7 @@ fn dict_get_item(b: &mut Bencher<'_>) {
 }
 
 fn extract_hashmap(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let dict = (0..LEN as u64)
             .map(|i| (i, i * 2))
@@ -68,7 +68,7 @@ fn extract_hashmap(b: &mut Bencher<'_>) {
 }
 
 fn extract_btreemap(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let dict = (0..LEN as u64)
             .map(|i| (i, i * 2))
@@ -79,7 +79,7 @@ fn extract_btreemap(b: &mut Bencher<'_>) {
 }
 
 fn extract_hashbrown_map(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let dict = (0..LEN as u64)
             .map(|i| (i, i * 2))
@@ -90,7 +90,7 @@ fn extract_hashbrown_map(b: &mut Bencher<'_>) {
 }
 
 fn mapping_from_dict(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let dict = &(0..LEN as u64)
             .map(|i| (i, i * 2))

--- a/pyo3-benches/benches/bench_err.rs
+++ b/pyo3-benches/benches/bench_err.rs
@@ -3,7 +3,7 @@ use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criter
 use pyo3::{exceptions::PyValueError, prelude::*};
 
 fn err_new_restore_and_fetch(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         b.iter(|| {
             PyValueError::new_err("some exception message").restore(py);
             PyErr::fetch(py)

--- a/pyo3-benches/benches/bench_extract.rs
+++ b/pyo3-benches/benches/bench_extract.rs
@@ -8,7 +8,7 @@ use pyo3::{
 };
 
 fn extract_str_extract_success(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let s = PyString::new(py, "Hello, World!").into_any();
 
         bench.iter(|| black_box(&s).extract::<&str>().unwrap());
@@ -16,7 +16,7 @@ fn extract_str_extract_success(bench: &mut Bencher<'_>) {
 }
 
 fn extract_str_extract_fail(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).extract::<&str>() {
@@ -28,7 +28,7 @@ fn extract_str_extract_fail(bench: &mut Bencher<'_>) {
 
 #[cfg(Py_3_10)]
 fn extract_str_downcast_success(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let s = PyString::new(py, "Hello, World!").into_any();
 
         bench.iter(|| {
@@ -39,7 +39,7 @@ fn extract_str_downcast_success(bench: &mut Bencher<'_>) {
 }
 
 fn extract_str_downcast_fail(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).downcast::<PyString>() {
@@ -50,7 +50,7 @@ fn extract_str_downcast_fail(bench: &mut Bencher<'_>) {
 }
 
 fn extract_int_extract_success(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let int = 123i32.into_pyobject(py).unwrap();
 
         bench.iter(|| black_box(&int).extract::<i64>().unwrap());
@@ -58,7 +58,7 @@ fn extract_int_extract_success(bench: &mut Bencher<'_>) {
 }
 
 fn extract_int_extract_fail(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).extract::<i64>() {
@@ -69,7 +69,7 @@ fn extract_int_extract_fail(bench: &mut Bencher<'_>) {
 }
 
 fn extract_int_downcast_success(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let int = 123i32.into_pyobject(py).unwrap();
 
         bench.iter(|| {
@@ -80,7 +80,7 @@ fn extract_int_downcast_success(bench: &mut Bencher<'_>) {
 }
 
 fn extract_int_downcast_fail(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).downcast::<PyInt>() {
@@ -91,7 +91,7 @@ fn extract_int_downcast_fail(bench: &mut Bencher<'_>) {
 }
 
 fn extract_float_extract_success(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let float = 23.42f64.into_pyobject(py).unwrap();
 
         bench.iter(|| black_box(&float).extract::<f64>().unwrap());
@@ -99,7 +99,7 @@ fn extract_float_extract_success(bench: &mut Bencher<'_>) {
 }
 
 fn extract_float_extract_fail(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).extract::<f64>() {
@@ -110,7 +110,7 @@ fn extract_float_extract_fail(bench: &mut Bencher<'_>) {
 }
 
 fn extract_float_downcast_success(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let float = 23.42f64.into_pyobject(py).unwrap();
 
         bench.iter(|| {
@@ -121,7 +121,7 @@ fn extract_float_downcast_success(bench: &mut Bencher<'_>) {
 }
 
 fn extract_float_downcast_fail(bench: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = PyDict::new(py).into_any();
 
         bench.iter(|| match black_box(&d).downcast::<PyFloat>() {

--- a/pyo3-benches/benches/bench_frompyobject.rs
+++ b/pyo3-benches/benches/bench_frompyobject.rs
@@ -16,7 +16,7 @@ enum ManyTypes {
 }
 
 fn enum_from_pyobject(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let any = PyString::new(py, "hello world").into_any();
 
         b.iter(|| black_box(&any).extract::<ManyTypes>().unwrap());
@@ -24,7 +24,7 @@ fn enum_from_pyobject(b: &mut Bencher<'_>) {
 }
 
 fn list_via_downcast(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let any = PyList::empty(py).into_any();
 
         b.iter(|| black_box(&any).downcast::<PyList>().unwrap());
@@ -32,7 +32,7 @@ fn list_via_downcast(b: &mut Bencher<'_>) {
 }
 
 fn list_via_extract(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let any = PyList::empty(py).into_any();
 
         b.iter(|| black_box(&any).extract::<Bound<'_, PyList>>().unwrap());
@@ -40,7 +40,7 @@ fn list_via_extract(b: &mut Bencher<'_>) {
 }
 
 fn not_a_list_via_downcast(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let any = PyString::new(py, "foobar").into_any();
 
         b.iter(|| black_box(&any).downcast::<PyList>().unwrap_err());
@@ -48,7 +48,7 @@ fn not_a_list_via_downcast(b: &mut Bencher<'_>) {
 }
 
 fn not_a_list_via_extract(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let any = PyString::new(py, "foobar").into_any();
 
         b.iter(|| black_box(&any).extract::<Bound<'_, PyList>>().unwrap_err());
@@ -62,7 +62,7 @@ enum ListOrNotList<'a> {
 }
 
 fn not_a_list_via_extract_enum(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let any = PyString::new(py, "foobar").into_any();
 
         b.iter(|| match black_box(&any).extract::<ListOrNotList<'_>>() {

--- a/pyo3-benches/benches/bench_gil.rs
+++ b/pyo3-benches/benches/bench_gil.rs
@@ -4,13 +4,13 @@ use pyo3::prelude::*;
 
 fn bench_clean_acquire_gil(b: &mut Bencher<'_>) {
     // Acquiring first GIL will also create a "clean" GILPool, so this measures the Python overhead.
-    b.iter(|| Python::with_gil(|_| {}));
+    b.iter(|| Python::attach(|_| {}));
 }
 
 fn bench_dirty_acquire_gil(b: &mut Bencher<'_>) {
-    let obj = Python::with_gil(|py| py.None());
+    let obj = Python::attach(|py| py.None());
     // Drop the returned clone of the object so that the reference pool has work to do.
-    b.iter(|| Python::with_gil(|py| obj.clone_ref(py)));
+    b.iter(|| Python::attach(|py| obj.clone_ref(py)));
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/pyo3-benches/benches/bench_intern.rs
+++ b/pyo3-benches/benches/bench_intern.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use pyo3::intern;
 
 fn getattr_direct(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let sys = &py.import("sys").unwrap();
 
         b.iter(|| black_box(sys).getattr("version").unwrap());
@@ -15,7 +15,7 @@ fn getattr_direct(b: &mut Bencher<'_>) {
 }
 
 fn getattr_intern(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let sys = &py.import("sys").unwrap();
 
         b.iter(|| black_box(sys).getattr(intern!(py, "version")).unwrap());

--- a/pyo3-benches/benches/bench_intopyobject.rs
+++ b/pyo3-benches/benches/bench_intopyobject.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
 fn bench_bytes_new(b: &mut Bencher<'_>, data: &[u8]) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         b.iter_with_large_drop(|| PyBytes::new(py, black_box(data)));
     });
 }
@@ -27,7 +27,7 @@ fn bytes_new_large(b: &mut Bencher<'_>) {
 }
 
 fn bench_bytes_into_pyobject(b: &mut Bencher<'_>, data: &[u8]) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         b.iter_with_large_drop(|| black_box(data).into_pyobject(py));
     });
 }
@@ -47,7 +47,7 @@ fn byte_slice_into_pyobject_large(b: &mut Bencher<'_>) {
 }
 
 fn vec_into_pyobject(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let bytes = (0..u8::MAX).collect::<Vec<u8>>();
         b.iter_with_large_drop(|| black_box(&bytes).clone().into_pyobject(py));
     });

--- a/pyo3-benches/benches/bench_list.rs
+++ b/pyo3-benches/benches/bench_list.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyList, PySequence};
 
 fn iter_list(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let list = PyList::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -20,14 +20,14 @@ fn iter_list(b: &mut Bencher<'_>) {
 }
 
 fn list_new(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         b.iter_with_large_drop(|| PyList::new(py, 0..LEN));
     });
 }
 
 fn list_get_item(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let list = PyList::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -40,7 +40,7 @@ fn list_get_item(b: &mut Bencher<'_>) {
 }
 
 fn list_nth(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50;
         let list = PyList::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -53,7 +53,7 @@ fn list_nth(b: &mut Bencher<'_>) {
 }
 
 fn list_nth_back(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50;
         let list = PyList::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -67,7 +67,7 @@ fn list_nth_back(b: &mut Bencher<'_>) {
 
 #[cfg(not(Py_LIMITED_API))]
 fn list_get_item_unchecked(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let list = PyList::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -82,7 +82,7 @@ fn list_get_item_unchecked(b: &mut Bencher<'_>) {
 }
 
 fn sequence_from_list(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let list = &PyList::new(py, 0..LEN).unwrap();
         b.iter(|| black_box(list).downcast::<PySequence>().unwrap());

--- a/pyo3-benches/benches/bench_pyclass.rs
+++ b/pyo3-benches/benches/bench_pyclass.rs
@@ -27,7 +27,7 @@ impl MyClass {
 }
 
 pub fn first_time_init(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         b.iter(|| {
             // This is using an undocumented internal PyO3 API to measure pyclass performance; please
             // don't use this in your own code!

--- a/pyo3-benches/benches/bench_set.rs
+++ b/pyo3-benches/benches/bench_set.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 fn set_new(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         // Create Python objects up-front, so that the benchmark doesn't need to include
         // the cost of allocating LEN Python integers
@@ -18,7 +18,7 @@ fn set_new(b: &mut Bencher<'_>) {
 }
 
 fn iter_set(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let set = PySet::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -32,7 +32,7 @@ fn iter_set(b: &mut Bencher<'_>) {
 }
 
 fn extract_hashset(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let any = PySet::new(py, 0..LEN).unwrap().into_any();
         b.iter_with_large_drop(|| black_box(&any).extract::<HashSet<u64>>());
@@ -40,7 +40,7 @@ fn extract_hashset(b: &mut Bencher<'_>) {
 }
 
 fn extract_btreeset(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let any = PySet::new(py, 0..LEN).unwrap().into_any();
         b.iter_with_large_drop(|| black_box(&any).extract::<BTreeSet<u64>>());
@@ -48,7 +48,7 @@ fn extract_btreeset(b: &mut Bencher<'_>) {
 }
 
 fn extract_hashbrown_set(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let any = PySet::new(py, 0..LEN).unwrap().into_any();
         b.iter_with_large_drop(|| black_box(&any).extract::<hashbrown::HashSet<u64>>());

--- a/pyo3-benches/benches/bench_tuple.rs
+++ b/pyo3-benches/benches/bench_tuple.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyList, PySequence, PyTuple};
 
 fn iter_tuple(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 100_000;
         let tuple = PyTuple::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -20,14 +20,14 @@ fn iter_tuple(b: &mut Bencher<'_>) {
 }
 
 fn tuple_new(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         b.iter_with_large_drop(|| PyTuple::new(py, 0..LEN).unwrap());
     });
 }
 
 fn tuple_get_item(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let tuple = PyTuple::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -41,7 +41,7 @@ fn tuple_get_item(b: &mut Bencher<'_>) {
 
 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
 fn tuple_get_item_unchecked(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let tuple = PyTuple::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -56,7 +56,7 @@ fn tuple_get_item_unchecked(b: &mut Bencher<'_>) {
 }
 
 fn tuple_get_borrowed_item(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let tuple = PyTuple::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -74,7 +74,7 @@ fn tuple_get_borrowed_item(b: &mut Bencher<'_>) {
 
 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
 fn tuple_get_borrowed_item_unchecked(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let tuple = PyTuple::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -92,7 +92,7 @@ fn tuple_get_borrowed_item_unchecked(b: &mut Bencher<'_>) {
 }
 
 fn sequence_from_tuple(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let tuple = PyTuple::new(py, 0..LEN).unwrap().into_any();
         b.iter(|| black_box(&tuple).downcast::<PySequence>().unwrap());
@@ -100,7 +100,7 @@ fn sequence_from_tuple(b: &mut Bencher<'_>) {
 }
 
 fn tuple_new_list(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let tuple = PyTuple::new(py, 0..LEN).unwrap();
         b.iter_with_large_drop(|| PyList::new(py, tuple.iter_borrowed()));
@@ -108,7 +108,7 @@ fn tuple_new_list(b: &mut Bencher<'_>) {
 }
 
 fn tuple_to_list(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50_000;
         let tuple = PyTuple::new(py, 0..LEN).unwrap();
         b.iter_with_large_drop(|| tuple.to_list());
@@ -116,7 +116,7 @@ fn tuple_to_list(b: &mut Bencher<'_>) {
 }
 
 fn tuple_into_pyobject(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         b.iter(|| {
             (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
                 .into_pyobject(py)
@@ -126,7 +126,7 @@ fn tuple_into_pyobject(b: &mut Bencher<'_>) {
 }
 
 fn tuple_nth(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50;
         let list = PyTuple::new(py, 0..LEN).unwrap();
         let mut sum = 0;
@@ -139,7 +139,7 @@ fn tuple_nth(b: &mut Bencher<'_>) {
 }
 
 fn tuple_nth_back(b: &mut Bencher<'_>) {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         const LEN: usize = 50;
         let list = PyTuple::new(py, 0..LEN).unwrap();
         let mut sum = 0;

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -444,7 +444,7 @@ fn impl_traverse_slot(
         return Err(syn::Error::new_spanned(py_arg.ty, "__traverse__ may not take `Python`. \
             Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` \
             should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited \
-            inside implementations of `__traverse__`, i.e. `Python::with_gil` will panic."));
+            inside implementations of `__traverse__`, i.e. `Python::attach` will panic."));
     }
 
     // check that the receiver does not try to smuggle an (implicit) `Python` token into here
@@ -458,7 +458,7 @@ fn impl_traverse_slot(
             "__traverse__ may not take a receiver other than `&self`. Usually, an implementation of \
             `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` \
             should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited \
-            inside implementations of `__traverse__`, i.e. `Python::with_gil` will panic."
+            inside implementations of `__traverse__`, i.e. `Python::attach` will panic."
         }
     }
 

--- a/pytests/src/misc.rs
+++ b/pytests/src/misc.rs
@@ -6,7 +6,7 @@ use pyo3::{
 #[pyfunction]
 fn issue_219() {
     // issue 219: acquiring GIL inside #[pyfunction] deadlocks.
-    Python::with_gil(|_| {});
+    Python::attach(|_| {});
 }
 
 #[pyclass]
@@ -24,7 +24,7 @@ fn hammer_gil_in_thread() -> LockHolder {
         // now the interpreter has shut down, so hammer the GIL. In buggy
         // versions of PyO3 this will cause a crash.
         loop {
-            Python::with_gil(|_py| ());
+            Python::attach(|_py| ());
         }
     });
     LockHolder { sender }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -622,7 +622,7 @@ impl<T: Element> PyBuffer<T> {
 
 impl<T> Drop for PyBuffer<T> {
     fn drop(&mut self) {
-        Python::with_gil(|_| unsafe { ffi::PyBuffer_Release(&mut *self.0) });
+        Python::attach(|_| unsafe { ffi::PyBuffer_Release(&mut *self.0) });
     }
 }
 
@@ -684,7 +684,7 @@ mod tests {
 
     #[test]
     fn test_debug() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes = py.eval(ffi::c_str!("b'abcde'"), None, None).unwrap();
             let buffer: PyBuffer<u8> = PyBuffer::get(&bytes).unwrap();
             let expected = format!(
@@ -845,7 +845,7 @@ mod tests {
 
     #[test]
     fn test_bytes_buffer() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes = py.eval(ffi::c_str!("b'abcde'"), None, None).unwrap();
             let buffer = PyBuffer::get(&bytes).unwrap();
             assert_eq!(buffer.dimensions(), 1);
@@ -877,7 +877,7 @@ mod tests {
 
     #[test]
     fn test_array_buffer() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let array = py
                 .import("array")
                 .unwrap()

--- a/src/call.rs
+++ b/src/call.rs
@@ -240,7 +240,7 @@ mod tests {
             wrap_pyfunction, Py, Python,
         };
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let f = wrap_pyfunction!(args_kwargs, py).unwrap();
 
             let args = PyTuple::new(py, [1, 2, 3]).unwrap();
@@ -282,7 +282,7 @@ mod tests {
             wrap_pyfunction, Py, Python,
         };
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let f = wrap_pyfunction!(args_kwargs, py).unwrap();
 
             let args = PyTuple::new(py, [1, 2, 3]).unwrap();

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -244,7 +244,7 @@ impl<'py, T> IntoPyObjectExt<'py> for T where T: IntoPyObject<'py> {}
 /// use pyo3::types::PyString;
 ///
 /// # fn main() -> PyResult<()> {
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     // Calling `.extract()` on a `Bound` smart pointer
 ///     let obj: Bound<'_, PyString> = PyString::new(py, "blah");
 ///     let s: String = obj.extract()?;
@@ -438,7 +438,7 @@ impl<'py> IntoPyObject<'py> for () {
 ///
 /// let t = TestClass { num: 10 };
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let pyvalue = Py::new(py, t).unwrap().to_object(py);
 ///     let t: TestClass = pyvalue.extract(py).unwrap();
 /// })

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -43,7 +43,7 @@
 //! }
 //!
 //! fn main() {
-//!     let error = Python::with_gil(|py| -> PyResult<Vec<u8>> {
+//!     let error = Python::attach(|py| -> PyResult<Vec<u8>> {
 //!         let fun = wrap_pyfunction!(py_open, py)?;
 //!         let text = fun.call1(("foo.txt",))?.extract::<Vec<u8>>()?;
 //!         Ok(text)
@@ -70,7 +70,7 @@
 //!     // An arbitrary example of a Python api you
 //!     // could call inside an application...
 //!     // This might return a `PyErr`.
-//!     let res = Python::with_gil(|py| {
+//!     let res = Python::attach(|py| {
 //!         let zlib = PyModule::import(py, "zlib")?;
 //!         let decompress = zlib.getattr("decompress")?;
 //!         let bytes = PyBytes::new(py, bytes);
@@ -144,7 +144,7 @@ mod test_anyhow {
         let expected_contents = format!("{err:?}");
         let pyerr = PyErr::from(err);
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = [("err", pyerr)].into_py_dict(py).unwrap();
             let pyerr = py
                 .run(ffi::c_str!("raise err"), None, Some(&locals))
@@ -163,7 +163,7 @@ mod test_anyhow {
         let expected_contents = format!("{err:?}");
         let pyerr = PyErr::from(err);
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = [("err", pyerr)].into_py_dict(py).unwrap();
             let pyerr = py
                 .run(ffi::c_str!("raise err"), None, Some(&locals))
@@ -177,7 +177,7 @@ mod test_anyhow {
         let origin_exc = PyValueError::new_err("Value Error");
         let err: anyhow::Error = origin_exc.into();
         let converted: PyErr = err.into();
-        assert!(Python::with_gil(
+        assert!(Python::attach(
             |py| converted.is_instance_of::<PyValueError>(py)
         ))
     }
@@ -187,7 +187,7 @@ mod test_anyhow {
         let mut err: anyhow::Error = origin_exc.into();
         err = err.context("Context");
         let converted: PyErr = err.into();
-        assert!(Python::with_gil(
+        assert!(Python::attach(
             |py| converted.is_instance_of::<PyRuntimeError>(py)
         ))
     }

--- a/src/conversions/bigdecimal.rs
+++ b/src/conversions/bigdecimal.rs
@@ -120,7 +120,7 @@ mod test_bigdecimal {
         ($name:ident, $rs:expr, $py:literal) => {
             #[test]
             fn $name() {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let rs_orig = $rs;
                     let rs_dec = rs_orig.clone().into_pyobject(py).unwrap();
                     let locals = PyDict::new(py);
@@ -173,7 +173,7 @@ mod test_bigdecimal {
             number in 0..28u32
         ) {
             let num = BigDecimal::from(number);
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let rs_dec = num.clone().into_pyobject(py).unwrap();
                 let locals = PyDict::new(py);
                 locals.set_item("rs_dec", &rs_dec).unwrap();
@@ -188,7 +188,7 @@ mod test_bigdecimal {
 
         #[test]
         fn test_integers(num in any::<i64>()) {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let py_num = num.into_pyobject(py).unwrap();
                 let roundtripped: BigDecimal = py_num.extract().unwrap();
                 let rs_dec = BigDecimal::from(num);
@@ -199,7 +199,7 @@ mod test_bigdecimal {
 
     #[test]
     fn test_nan() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!("import decimal\npy_dec = decimal.Decimal(\"NaN\")"),
@@ -215,7 +215,7 @@ mod test_bigdecimal {
 
     #[test]
     fn test_infinity() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!("import decimal\npy_dec = decimal.Decimal(\"Infinity\")"),
@@ -231,7 +231,7 @@ mod test_bigdecimal {
 
     #[test]
     fn test_no_precision_loss() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let src = "1e4";
             let expected = get_decimal_cls(py)
                 .unwrap()

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -25,7 +25,7 @@
 //!
 //! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();
-//!     Python::with_gil(|py| {
+//!     Python::attach(|py| {
 //!         // Convert to Python
 //!         let py_tzinfo = Tz::Europe__Paris.into_pyobject(py)?;
 //!         // Convert back to Rust
@@ -84,7 +84,7 @@ mod tests {
 
     #[test]
     fn test_frompyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert_eq!(
                 new_zoneinfo(py, "Europe/Paris").extract::<Tz>().unwrap(),
                 Tz::Europe__Paris
@@ -116,7 +116,7 @@ mod tests {
             ]
         );
 
-        let dates = Python::with_gil(|py| {
+        let dates = Python::attach(|py| {
             let pydates = dates.map(|dt| dt.into_pyobject(py).unwrap());
             assert_eq!(
                 pydates
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     #[cfg(not(Py_GIL_DISABLED))] // https://github.com/python/cpython/issues/116738#issuecomment-2404360445
     fn test_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let assert_eq = |l: Bound<'_, PyTzInfo>, r: Bound<'_, PyTzInfo>| {
                 assert!(l.eq(&r).unwrap(), "{l:?} != {r:?}");
             };

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -30,7 +30,7 @@
 //!
 //! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();
-//!     Python::with_gil(|py| {
+//!     Python::attach(|py| {
 //!         // Create a string and an int in Python.
 //!         let py_str = "crab".into_pyobject(py)?;
 //!         let py_int = 42i32.into_pyobject(py)?;
@@ -134,7 +134,7 @@ mod tests {
         type E1 = Either<i32, f32>;
         type E2 = Either<f32, i32>;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let l = E::Left(42);
             let obj_l = (&l).into_pyobject(py).unwrap();
             assert_eq!(obj_l.extract::<i32>().unwrap(), 42);

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -45,7 +45,7 @@
 //! }
 //!
 //! fn main() {
-//!     let error = Python::with_gil(|py| -> PyResult<Vec<u8>> {
+//!     let error = Python::attach(|py| -> PyResult<Vec<u8>> {
 //!         let fun = wrap_pyfunction!(py_open, py)?;
 //!         let text = fun.call1(("foo.txt",))?.extract::<Vec<u8>>()?;
 //!         Ok(text)
@@ -72,7 +72,7 @@
 //!     // An arbitrary example of a Python api you
 //!     // could call inside an application...
 //!     // This might return a `PyErr`.
-//!     let res = Python::with_gil(|py| {
+//!     let res = Python::attach(|py| {
 //!         let zlib = PyModule::import(py, "zlib")?;
 //!         let decompress = zlib.getattr("decompress")?;
 //!         let bytes = PyBytes::new(py, bytes);
@@ -150,7 +150,7 @@ mod tests {
         let expected_contents = format!("{err:?}");
         let pyerr = PyErr::from(err);
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = [("err", pyerr)].into_py_dict(py).unwrap();
             let pyerr = py
                 .run(ffi::c_str!("raise err"), None, Some(&locals))
@@ -169,7 +169,7 @@ mod tests {
         let expected_contents = format!("{err:?}");
         let pyerr = PyErr::from(err);
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = [("err", pyerr)].into_py_dict(py).unwrap();
             let pyerr = py
                 .run(ffi::c_str!("raise err"), None, Some(&locals))
@@ -183,7 +183,7 @@ mod tests {
         let origin_exc = PyValueError::new_err("Value Error");
         let report: Report = origin_exc.into();
         let converted: PyErr = report.into();
-        assert!(Python::with_gil(
+        assert!(Python::attach(
             |py| converted.is_instance_of::<PyValueError>(py)
         ))
     }
@@ -193,7 +193,7 @@ mod tests {
         let mut report: Report = origin_exc.into();
         report = report.wrap_err("Wrapped");
         let converted: PyErr = report.into();
-        assert!(Python::with_gil(
+        assert!(Python::attach(
             |py| converted.is_instance_of::<PyRuntimeError>(py)
         ))
     }

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn test_hashbrown_hashmap_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map =
                 hashbrown::HashMap::<i32, i32, RandomState>::with_hasher(RandomState::new());
             map.insert(1, 1);
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn test_hashbrown_hashmap_into_dict() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map =
                 hashbrown::HashMap::<i32, i32, RandomState>::with_hasher(RandomState::new());
             map.insert(1, 1);
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_extract_hashbrown_hashset() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: hashbrown::HashSet<usize, RandomState> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_hashbrown_hashset_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let hs: hashbrown::HashSet<u64, RandomState> =
                 [1, 2, 3, 4, 5].iter().cloned().collect();
 

--- a/src/conversions/indexmap.rs
+++ b/src/conversions/indexmap.rs
@@ -154,7 +154,7 @@ mod test_indexmap {
 
     #[test]
     fn test_indexmap_indexmap_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = indexmap::IndexMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -179,7 +179,7 @@ mod test_indexmap {
 
     #[test]
     fn test_indexmap_indexmap_into_dict() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = indexmap::IndexMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -200,7 +200,7 @@ mod test_indexmap {
 
     #[test]
     fn test_indexmap_indexmap_insertion_order_round_trip() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let n = 20;
             let mut map = indexmap::IndexMap::<i32, i32>::new();
 

--- a/src/conversions/jiff.rs
+++ b/src/conversions/jiff.rs
@@ -29,7 +29,7 @@
 //! # #[cfg(not(windows))]
 //! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();
-//!     Python::with_gil(|py| {
+//!     Python::attach(|py| {
 //!         // Build some jiff values
 //!         let jiff_zoned = Zoned::now();
 //!         let jiff_span = 1.second();
@@ -480,7 +480,7 @@ mod tests {
         use crate::types::any::PyAnyMethods;
         use crate::types::dict::PyDictMethods;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = crate::types::PyDict::new(py);
             py.run(
                 ffi::c_str!("import zoneinfo; zi = zoneinfo.ZoneInfo('Europe/London')"),
@@ -501,7 +501,7 @@ mod tests {
     fn test_timezone_aware_to_naive_fails() {
         // Test that if a user tries to convert a python's timezone aware datetime into a naive
         // one, the conversion fails.
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_datetime =
                 new_py_datetime_ob(py, "datetime", (2022, 1, 1, 1, 0, 0, 0, python_utc(py)));
             // Now test that converting a PyDateTime with tzinfo to a NaiveDateTime fails
@@ -517,7 +517,7 @@ mod tests {
     fn test_naive_to_timezone_aware_fails() {
         // Test that if a user tries to convert a python's naive datetime into a timezone aware
         // one, the conversion fails.
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_datetime = new_py_datetime_ob(py, "datetime", (2022, 1, 1, 1, 0, 0, 0));
             let res: PyResult<Zoned> = py_datetime.extract();
             assert_eq!(
@@ -529,7 +529,7 @@ mod tests {
 
     #[test]
     fn test_invalid_types_fail() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let none = py.None().into_bound(py);
             assert_eq!(
                 none.extract::<Span>().unwrap_err().to_string(),
@@ -565,7 +565,7 @@ mod tests {
     #[test]
     fn test_pyo3_date_into_pyobject() {
         let eq_ymd = |name: &'static str, year, month, day| {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let date = Date::new(year, month, day)
                     .unwrap()
                     .into_pyobject(py)
@@ -588,7 +588,7 @@ mod tests {
     #[test]
     fn test_pyo3_date_frompyobject() {
         let eq_ymd = |name: &'static str, year, month, day| {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let py_date = new_py_datetime_ob(py, "date", (year, month, day));
                 let py_date: Date = py_date.extract().unwrap();
                 let date = Date::new(year, month, day).unwrap();
@@ -604,7 +604,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_datetime_into_pyobject_utc() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let check_utc =
                 |name: &'static str, year, month, day, hour, minute, second, ms, py_ms| {
                     let datetime = DateTime::new(year, month, day, hour, minute, second, ms * 1000)
@@ -639,7 +639,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_datetime_into_pyobject_fixed_offset() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let check_fixed_offset =
                 |name: &'static str, year, month, day, hour, minute, second, ms, py_ms| {
                     let offset = Offset::from_seconds(3600).unwrap();
@@ -672,7 +672,7 @@ mod tests {
     #[test]
     #[cfg(all(Py_3_9, not(windows)))]
     fn test_pyo3_datetime_into_pyobject_tz() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let datetime = DateTime::new(2024, 12, 11, 23, 3, 13, 0)
                 .unwrap()
                 .to_zoned(TimeZone::get("Europe/London").unwrap())
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_datetime_frompyobject_utc() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let year = 2014;
             let month = 5;
             let day = 6;
@@ -745,7 +745,7 @@ mod tests {
             ]
         );
 
-        let dates = Python::with_gil(|py| {
+        let dates = Python::attach(|py| {
             let pydates = dates.map(|dt| dt.into_pyobject(py).unwrap());
             assert_eq!(
                 pydates
@@ -777,7 +777,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_datetime_frompyobject_fixed_offset() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let year = 2014;
             let month = 5;
             let day = 6;
@@ -803,7 +803,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_offset_fixed_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // jiff offset
             let offset = Offset::from_seconds(3600)
                 .unwrap()
@@ -828,7 +828,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_offset_fixed_frompyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_timedelta = new_py_datetime_ob(py, "timedelta", (0, 3600, 0));
             let py_tzinfo = new_py_datetime_ob(py, "timezone", (py_timedelta,));
             let offset: Offset = py_tzinfo.extract().unwrap();
@@ -838,7 +838,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_offset_utc_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let utc = Offset::UTC.into_pyobject(py).unwrap();
             let py_utc = python_utc(py);
             assert!(utc.is(&py_utc));
@@ -847,7 +847,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_offset_utc_frompyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_utc = python_utc(py);
             let py_utc: Offset = py_utc.extract().unwrap();
             assert_eq!(Offset::UTC, py_utc);
@@ -865,7 +865,7 @@ mod tests {
 
     #[test]
     fn test_pyo3_time_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let check_time = |name: &'static str, hour, minute, second, ms, py_ms| {
                 let time = Time::new(hour, minute, second, ms * 1000)
                     .unwrap()
@@ -885,7 +885,7 @@ mod tests {
         let minute = 5;
         let second = 7;
         let micro = 999_999;
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_time = new_py_datetime_ob(py, "time", (hour, minute, second, micro));
             let py_time: Time = py_time.extract().unwrap();
             let time = Time::new(hour, minute, second, micro * 1000).unwrap();
@@ -971,7 +971,7 @@ mod tests {
             // Range is limited to 1970 to 2038 due to windows limitations
             #[test]
             fn test_pyo3_offset_fixed_frompyobject_created_in_python(timestamp in 0..(i32::MAX as i64), timedelta in -86399i32..=86399i32) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
 
                     let globals = [("datetime", py.import("datetime").unwrap())].into_py_dict(py).unwrap();
                     let code = format!("datetime.datetime.fromtimestamp({timestamp}).replace(tzinfo=datetime.timezone(datetime.timedelta(seconds={timedelta})))");
@@ -992,7 +992,7 @@ mod tests {
             fn test_duration_roundtrip(days in -999999999i64..=999999999i64) {
                 // Test roundtrip conversion rust->python->rust for all allowed
                 // python values of durations (from -999999999 to 999999999 days),
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let dur = SignedDuration::new(days * 24 * 60 * 60, 0);
                     let py_delta = dur.into_pyobject(py).unwrap();
                     let roundtripped: SignedDuration = py_delta.extract().expect("Round trip");
@@ -1004,7 +1004,7 @@ mod tests {
             fn test_span_roundtrip(days in -999999999i64..=999999999i64) {
                 // Test roundtrip conversion rust->python->rust for all allowed
                 // python values of durations (from -999999999 to 999999999 days),
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     if let Ok(span) = Span::new().try_days(days) {
                         let relative_to = SpanRelativeTo::days_are_24_hours();
                         let jiff_duration = span.to_duration(relative_to).unwrap();
@@ -1017,7 +1017,7 @@ mod tests {
 
             #[test]
             fn test_fixed_offset_roundtrip(secs in -86399i32..=86399i32) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let offset = Offset::from_seconds(secs).unwrap();
                     let py_offset = offset.into_pyobject(py).unwrap();
                     let roundtripped: Offset = py_offset.extract().expect("Round trip");
@@ -1033,7 +1033,7 @@ mod tests {
             ) {
                 // Test roundtrip conversion rust->python->rust for all allowed
                 // python dates (from year 1 to year 9999)
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     if let Ok(date) = try_date(year, month, day) {
                         let py_date = date.into_pyobject(py).unwrap();
                         let roundtripped: Date = py_date.extract().expect("Round trip");
@@ -1049,7 +1049,7 @@ mod tests {
                 sec in 0u32..=59u32,
                 micro in 0u32..=1_999_999u32
             ) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     if let Ok(time) = try_time(hour, min, sec, micro) {
                         let py_time = time.into_pyobject(py).unwrap();
                         let roundtripped: Time = py_time.extract().expect("Round trip");
@@ -1068,7 +1068,7 @@ mod tests {
                 sec in 0u32..=60u32,
                 micro in 0u32..=999_999u32
             ) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let date_opt = try_date(year, month, day);
                     let time_opt = try_time(hour, min, sec, micro);
                     if let (Ok(date), Ok(time)) = (date_opt, time_opt) {
@@ -1090,7 +1090,7 @@ mod tests {
                 sec in 0u32..=59u32,
                 micro in 0u32..=1_999_999u32
             ) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let date_opt = try_date(year, month, day);
                     let time_opt = try_time(hour, min, sec, micro);
                     if let (Ok(date), Ok(time)) = (date_opt, time_opt) {
@@ -1113,7 +1113,7 @@ mod tests {
                 micro in 0u32..=1_999_999u32,
                 offset_secs in -86399i32..=86399i32
             ) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let date_opt = try_date(year, month, day);
                     let time_opt = try_time(hour, min, sec, micro);
                     let offset = Offset::from_seconds(offset_secs).unwrap();
@@ -1138,7 +1138,7 @@ mod tests {
                 min in 0u32..=59u32,
             ) {
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let transition_moment = transition.timestamp();
                     let zoned = (transition_moment - Span::new().hours(hour).minutes(min))
                         .to_zoned(timezone.clone());

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn convert_biguint() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // check the first 2000 numbers in the fibonacci sequence
             for (py_result, rs_result) in python_fib(py).zip(rust_fib::<BigUint>()).take(2000) {
                 // Python -> Rust
@@ -359,7 +359,7 @@ mod tests {
 
     #[test]
     fn convert_bigint() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // check the first 2000 numbers in the fibonacci sequence
             for (py_result, rs_result) in python_fib(py).zip(rust_fib::<BigInt>()).take(2000) {
                 // Python -> Rust
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn convert_index_class() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let index = python_index_class(py);
             let locals = PyDict::new(py);
             locals.set_item("index", index).unwrap();
@@ -414,7 +414,7 @@ mod tests {
 
     #[test]
     fn handle_zero() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let zero: BigInt = 0i32.into_pyobject(py).unwrap().extract().unwrap();
             assert_eq!(zero, BigInt::from(0));
         })
@@ -423,7 +423,7 @@ mod tests {
     /// `OverflowError` on converting Python int to BigInt, see issue #629
     #[test]
     fn check_overflow() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             macro_rules! test {
                 ($T:ty, $value:expr, $py:expr) => {
                     let value = $value;

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -54,7 +54,7 @@
 //! # use pyo3::types::PyComplex;
 //! #
 //! # fn main() -> PyResult<()> {
-//! #     Python::with_gil(|py| -> PyResult<()> {
+//! #     Python::attach(|py| -> PyResult<()> {
 //! #         let module = PyModule::new(py, "my_module")?;
 //! #
 //! #         module.add_function(&wrap_pyfunction!(get_eigenvalues, module)?)?;
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn from_complex() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let complex = Complex::new(3.0, 1.2);
             let py_c = PyComplex::from_complex_bound(py, complex);
             assert_eq!(py_c.real(), 3.0);
@@ -213,7 +213,7 @@ mod tests {
     }
     #[test]
     fn to_from_complex() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let val = Complex::new(3.0f64, 1.2);
             let obj = val.into_pyobject(py).unwrap();
             assert_eq!(obj.extract::<Complex<f64>>().unwrap(), val);
@@ -221,14 +221,14 @@ mod tests {
     }
     #[test]
     fn from_complex_err() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = vec![1i32].into_pyobject(py).unwrap();
             assert!(obj.extract::<Complex<f64>>().is_err());
         });
     }
     #[test]
     fn from_python_magic() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module = PyModule::from_code(
                 py,
                 c_str!(
@@ -268,7 +268,7 @@ class C:
     }
     #[test]
     fn from_python_inherited_magic() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module = PyModule::from_code(
                 py,
                 c_str!(
@@ -314,7 +314,7 @@ class C(First, IndexMixin): pass
         // Functions and lambdas implement the descriptor protocol in a way that makes
         // `type(inst).attr(inst)` equivalent to `inst.attr()` for methods, but this isn't the only
         // way the descriptor protocol might be implemented.
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module = PyModule::from_code(
                 py,
                 c_str!(
@@ -339,7 +339,7 @@ class A:
     #[test]
     fn from_python_nondescriptor_magic() {
         // Magic methods don't need to implement the descriptor protocol, if they're callable.
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module = PyModule::from_code(
                 py,
                 c_str!(

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -121,7 +121,7 @@ mod tests {
     use proptest::prelude::*;
     #[test]
     fn test_negative_fraction() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!("import fractions\npy_frac = fractions.Fraction(-0.125)"),
@@ -137,7 +137,7 @@ mod tests {
     }
     #[test]
     fn test_obj_with_incorrect_atts() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!("not_fraction = \"contains_incorrect_atts\""),
@@ -152,7 +152,7 @@ mod tests {
 
     #[test]
     fn test_fraction_with_fraction_type() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!(
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_fraction_with_decimal() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!("import fractions\n\nfrom decimal import Decimal\npy_frac = fractions.Fraction(Decimal(\"1.1\"))"),
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_fraction_with_num_den() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!("import fractions\npy_frac = fractions.Fraction(10,5)"),
@@ -206,7 +206,7 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     #[test]
     fn test_int_roundtrip() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let rs_frac = Ratio::new(1i32, 2);
             let py_frac = rs_frac.into_pyobject(py).unwrap();
             let roundtripped: Ratio<i32> = py_frac.extract().unwrap();
@@ -218,7 +218,7 @@ mod tests {
     #[cfg(target_arch = "wasm32")]
     #[test]
     fn test_big_int_roundtrip() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let rs_frac = Ratio::from_float(5.5).unwrap();
             let py_frac = rs_frac.clone().into_pyobject(py).unwrap();
             let roundtripped: Ratio<BigInt> = py_frac.extract().unwrap();
@@ -230,7 +230,7 @@ mod tests {
     proptest! {
         #[test]
         fn test_int_roundtrip(num in any::<i32>(), den in any::<i32>()) {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let rs_frac = Ratio::new(num, den);
                 let py_frac = rs_frac.into_pyobject(py).unwrap();
                 let roundtripped: Ratio<i32> = py_frac.extract().unwrap();
@@ -241,7 +241,7 @@ mod tests {
         #[test]
         #[cfg(feature = "num-bigint")]
         fn test_big_int_roundtrip(num in any::<f32>()) {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let rs_frac = Ratio::from_float(num).unwrap();
                 let py_frac = rs_frac.clone().into_pyobject(py).unwrap();
                 let roundtripped: Ratio<BigInt> = py_frac.extract().unwrap();
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn test_infinity() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             let py_bound = py.run(
                 ffi::c_str!("import fractions\npy_frac = fractions.Fraction(\"Infinity\")"),

--- a/src/conversions/ordered_float.rs
+++ b/src/conversions/ordered_float.rs
@@ -113,7 +113,7 @@ mod test_ordered_float {
             fn $standard_test(inner_f: $float_type) {
                 let f = $constructor(inner_f);
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let f_py: Bound<'_, PyFloat>  = f.into_pyobject(py).unwrap();
 
                     py_run!(
@@ -139,7 +139,7 @@ mod test_ordered_float {
                 let inner_f = 10.0;
                 let f = $constructor(inner_f);
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let f_py: Bound<'_, PyFloat>  = f.into_pyobject(py).unwrap();
 
                     py_run!(
@@ -166,7 +166,7 @@ mod test_ordered_float {
                 let inner_ninf = <$float_type>::NEG_INFINITY;
                 let ninf = $constructor(inner_ninf);
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let pinf_py: Bound<'_, PyFloat>  = pinf.into_pyobject(py).unwrap();
                     let ninf_py: Bound<'_, PyFloat>  = ninf.into_pyobject(py).unwrap();
 
@@ -194,7 +194,7 @@ mod test_ordered_float {
                 let inner_nzero: $float_type = -0.0;
                 let nzero = $constructor(inner_nzero);
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let pzero_py: Bound<'_, PyFloat>  = pzero.into_pyobject(py).unwrap();
                     let nzero_py: Bound<'_, PyFloat>  = nzero.into_pyobject(py).unwrap();
 
@@ -266,7 +266,7 @@ mod test_ordered_float {
                 let inner_nan: $float_type = <$float_type>::NAN;
                 let nan = OrderedFloat(inner_nan);
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let nan_py: Bound<'_, PyFloat> = nan.into_pyobject(py).unwrap();
 
                     py_run!(
@@ -291,7 +291,7 @@ mod test_ordered_float {
         ($test_name:ident, $float_type:ty) => {
             #[test]
             fn $test_name() {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let nan_py = py.eval(c_str!("float('nan')"), None, None).unwrap();
 
                     let nan_rs: PyResult<NotNan<$float_type>> = nan_py.extract();
@@ -308,7 +308,7 @@ mod test_ordered_float {
         ($test_name:ident, $wrapper:ident, $float_type:ty) => {
             #[test]
             fn $test_name() {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let py_64 = py
                         .import("sys")
                         .unwrap()

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -119,7 +119,7 @@ mod test_rust_decimal {
         ($name:ident, $rs:expr, $py:literal) => {
             #[test]
             fn $name() {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let rs_orig = $rs;
                     let rs_dec = rs_orig.into_pyobject(py).unwrap();
                     let locals = PyDict::new(py);
@@ -163,7 +163,7 @@ mod test_rust_decimal {
             scale in 0..28u32
         ) {
             let num = Decimal::from_parts(lo, mid, high, negative, scale);
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let rs_dec = num.into_pyobject(py).unwrap();
                 let locals = PyDict::new(py);
                 locals.set_item("rs_dec", &rs_dec).unwrap();
@@ -178,7 +178,7 @@ mod test_rust_decimal {
 
         #[test]
         fn test_integers(num in any::<i64>()) {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let py_num = num.into_pyobject(py).unwrap();
                 let roundtripped: Decimal = py_num.extract().unwrap();
                 let rs_dec = Decimal::new(num, 0);
@@ -189,7 +189,7 @@ mod test_rust_decimal {
 
     #[test]
     fn test_nan() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!("import decimal\npy_dec = decimal.Decimal(\"NaN\")"),
@@ -205,7 +205,7 @@ mod test_rust_decimal {
 
     #[test]
     fn test_scientific_notation() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!("import decimal\npy_dec = decimal.Decimal(\"1e3\")"),
@@ -222,7 +222,7 @@ mod test_rust_decimal {
 
     #[test]
     fn test_infinity() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             py.run(
                 ffi::c_str!("import decimal\npy_dec = decimal.Decimal(\"Infinity\")"),

--- a/src/conversions/serde.rs
+++ b/src/conversions/serde.rs
@@ -23,7 +23,7 @@ where
     where
         S: Serializer,
     {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.try_borrow(py)
                 .map_err(|e| ser::Error::custom(e.to_string()))?
                 .serialize(serializer)
@@ -41,8 +41,6 @@ where
     {
         let deserialized = T::deserialize(deserializer)?;
 
-        Python::with_gil(|py| {
-            Py::new(py, deserialized).map_err(|e| de::Error::custom(e.to_string()))
-        })
+        Python::attach(|py| Py::new(py, deserialized).map_err(|e| de::Error::custom(e.to_string())))
     }
 }

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn test_smallvec_from_py_object() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let l = PyList::new(py, [1, 2, 3, 4, 5]).unwrap();
             let sv: SmallVec<[u64; 8]> = l.extract().unwrap();
             assert_eq!(sv.as_slice(), [1, 2, 3, 4, 5]);
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_smallvec_from_py_object_fails() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = PyDict::new(py);
             let sv: PyResult<SmallVec<[u64; 8]>> = dict.extract();
             assert_eq!(
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn test_smallvec_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let sv: SmallVec<[u64; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();
             let hso = sv.into_pyobject(py).unwrap();
             let l = PyList::new(py, [1, 2, 3, 4, 5]).unwrap();
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn test_smallvec_intopyobject_impl() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes: SmallVec<[u8; 8]> = [1, 2, 3, 4, 5].iter().cloned().collect();
             let obj = bytes.clone().into_pyobject(py).unwrap();
             assert!(obj.is_instance_of::<PyBytes>());

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_extract_bytearray_to_array() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: [u8; 33] = py
                 .eval(
                     ffi::c_str!("bytearray(b'abcabcabcabcabcabcabcabcabcabcabc')"),
@@ -167,7 +167,7 @@ mod tests {
 
     #[test]
     fn test_extract_small_bytearray_to_array() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: [u8; 3] = py
                 .eval(ffi::c_str!("bytearray(b'abc')"), None, None)
                 .unwrap()
@@ -178,7 +178,7 @@ mod tests {
     }
     #[test]
     fn test_into_pyobject_array_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let array: [f32; 4] = [0.0, -16.0, 16.0, 42.0];
             let pyobject = array.into_pyobject(py).unwrap();
             let pylist = pyobject.downcast::<PyList>().unwrap();
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_extract_invalid_sequence_length() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: PyResult<[u8; 3]> = py
                 .eval(ffi::c_str!("bytearray(b'abcdefg')"), None, None)
                 .unwrap()
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_intopyobject_array_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let array: [f32; 4] = [0.0, -16.0, 16.0, 42.0];
             let pylist = array
                 .into_pyobject(py)
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_array_intopyobject_impl() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes: [u8; 6] = *b"foobar";
             let obj = bytes.into_pyobject(py).unwrap();
             assert!(obj.is_instance_of::<PyBytes>());
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn test_extract_non_iterable_to_array() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = py.eval(ffi::c_str!("42"), None, None).unwrap();
             v.extract::<i32>().unwrap();
             v.extract::<[i32; 1]>().unwrap_err();
@@ -250,7 +250,7 @@ mod tests {
         #[crate::pyclass(crate = "crate")]
         struct Foo;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let array: [Foo; 8] = [Foo, Foo, Foo, Foo, Foo, Foo, Foo, Foo];
             let list = array
                 .into_pyobject(py)

--- a/src/conversions/std/ipaddr.rs
+++ b/src/conversions/std/ipaddr.rs
@@ -111,7 +111,7 @@ mod test_ipaddr {
 
     #[test]
     fn test_roundtrip() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             fn roundtrip(py: Python<'_>, ip: &str) {
                 let ip = IpAddr::from_str(ip).unwrap();
                 let py_cls = if ip.is_ipv4() {
@@ -136,7 +136,7 @@ mod test_ipaddr {
 
     #[test]
     fn test_from_pystring() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_str = PyString::new(py, "0:0:0:0:0:0:0:1");
             let ip: IpAddr = py_str.extract().unwrap();
             assert_eq!(ip, IpAddr::from_str("::1").unwrap());

--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_hashmap_to_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_btreemap_to_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = BTreeMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -199,7 +199,7 @@ mod tests {
 
     #[test]
     fn test_hashmap_into_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -220,7 +220,7 @@ mod tests {
 
     #[test]
     fn test_btreemap_into_py() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = BTreeMap::<i32, i32>::new();
             map.insert(1, 1);
 

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -623,7 +623,7 @@ mod test_128bit_integers {
     proptest! {
         #[test]
         fn test_i128_roundtrip(x: i128) {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let x_py = x.into_pyobject(py).unwrap();
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", &x_py).unwrap();
@@ -639,7 +639,7 @@ mod test_128bit_integers {
                 .prop_filter("Values must not be 0", |x| x != &0)
                 .prop_map(|x| NonZeroI128::new(x).unwrap())
         ) {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let x_py = x.into_pyobject(py).unwrap();
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", &x_py).unwrap();
@@ -654,7 +654,7 @@ mod test_128bit_integers {
     proptest! {
         #[test]
         fn test_u128_roundtrip(x: u128) {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let x_py = x.into_pyobject(py).unwrap();
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", &x_py).unwrap();
@@ -670,7 +670,7 @@ mod test_128bit_integers {
                 .prop_filter("Values must not be 0", |x| x != &0)
                 .prop_map(|x| NonZeroU128::new(x).unwrap())
         ) {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let x_py = x.into_pyobject(py).unwrap();
                 let locals = PyDict::new(py);
                 locals.set_item("x_py", &x_py).unwrap();
@@ -683,7 +683,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_i128_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = i128::MAX;
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<i128>().unwrap());
@@ -694,7 +694,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_i128_min() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = i128::MIN;
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<i128>().unwrap());
@@ -705,7 +705,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_u128_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = u128::MAX;
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<u128>().unwrap());
@@ -715,7 +715,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_i128_overflow() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("(1 << 130) * -1"), None, None).unwrap();
             let err = obj.extract::<i128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
@@ -724,7 +724,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_u128_overflow() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("1 << 130"), None, None).unwrap();
             let err = obj.extract::<u128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
@@ -733,7 +733,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_nonzero_i128_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = NonZeroI128::new(i128::MAX).unwrap();
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<NonZeroI128>().unwrap());
@@ -747,7 +747,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_nonzero_i128_min() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = NonZeroI128::new(i128::MIN).unwrap();
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<NonZeroI128>().unwrap());
@@ -758,7 +758,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_nonzero_u128_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = NonZeroU128::new(u128::MAX).unwrap();
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<NonZeroU128>().unwrap());
@@ -768,7 +768,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_nonzero_i128_overflow() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("(1 << 130) * -1"), None, None).unwrap();
             let err = obj.extract::<NonZeroI128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
@@ -777,7 +777,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_nonzero_u128_overflow() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("1 << 130"), None, None).unwrap();
             let err = obj.extract::<NonZeroU128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyOverflowError>(py));
@@ -786,7 +786,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_nonzero_i128_zero_value() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("0"), None, None).unwrap();
             let err = obj.extract::<NonZeroI128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyValueError>(py));
@@ -795,7 +795,7 @@ mod test_128bit_integers {
 
     #[test]
     fn test_nonzero_u128_zero_value() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("0"), None, None).unwrap();
             let err = obj.extract::<NonZeroU128>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyValueError>(py));
@@ -811,7 +811,7 @@ mod tests {
 
     #[test]
     fn test_u32_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = u32::MAX;
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<u32>().unwrap());
@@ -822,7 +822,7 @@ mod tests {
 
     #[test]
     fn test_i64_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = i64::MAX;
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<i64>().unwrap());
@@ -833,7 +833,7 @@ mod tests {
 
     #[test]
     fn test_i64_min() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = i64::MIN;
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<i64>().unwrap());
@@ -844,7 +844,7 @@ mod tests {
 
     #[test]
     fn test_u64_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = u64::MAX;
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<u64>().unwrap());
@@ -862,7 +862,7 @@ mod tests {
 
                 #[test]
                 fn from_py_string_type_error() {
-                    Python::with_gil(|py| {
+                    Python::attach(|py| {
                     let obj = ("123").into_pyobject(py).unwrap();
                     let err = obj.extract::<$t>().unwrap_err();
                     assert!(err.is_instance_of::<exceptions::PyTypeError>(py));
@@ -871,7 +871,7 @@ mod tests {
 
                 #[test]
                 fn from_py_float_type_error() {
-                    Python::with_gil(|py| {
+                    Python::attach(|py| {
                     let obj = (12.3f64).into_pyobject(py).unwrap();
                     let err = obj.extract::<$t>().unwrap_err();
                     assert!(err.is_instance_of::<exceptions::PyTypeError>(py));});
@@ -879,7 +879,7 @@ mod tests {
 
                 #[test]
                 fn to_py_object_and_back() {
-                    Python::with_gil(|py| {
+                    Python::attach(|py| {
                     let val = 123 as $t;
                     let obj = val.into_pyobject(py).unwrap();
                     assert_eq!(obj.extract::<$t>().unwrap(), val as $t);});
@@ -903,7 +903,7 @@ mod tests {
 
     #[test]
     fn test_nonzero_u32_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = NonZeroU32::new(u32::MAX).unwrap();
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<NonZeroU32>().unwrap());
@@ -914,7 +914,7 @@ mod tests {
 
     #[test]
     fn test_nonzero_i64_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = NonZeroI64::new(i64::MAX).unwrap();
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<NonZeroI64>().unwrap());
@@ -928,7 +928,7 @@ mod tests {
 
     #[test]
     fn test_nonzero_i64_min() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = NonZeroI64::new(i64::MIN).unwrap();
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<NonZeroI64>().unwrap());
@@ -939,7 +939,7 @@ mod tests {
 
     #[test]
     fn test_nonzero_u64_max() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = NonZeroU64::new(u64::MAX).unwrap();
             let obj = v.into_pyobject(py).unwrap();
             assert_eq!(v, obj.extract::<NonZeroU64>().unwrap());
@@ -958,7 +958,7 @@ mod tests {
 
                 #[test]
                 fn from_py_string_type_error() {
-                    Python::with_gil(|py| {
+                    Python::attach(|py| {
                     let obj = ("123").into_pyobject(py).unwrap();
                     let err = obj.extract::<$t>().unwrap_err();
                     assert!(err.is_instance_of::<exceptions::PyTypeError>(py));
@@ -967,7 +967,7 @@ mod tests {
 
                 #[test]
                 fn from_py_float_type_error() {
-                    Python::with_gil(|py| {
+                    Python::attach(|py| {
                     let obj = (12.3f64).into_pyobject(py).unwrap();
                     let err = obj.extract::<$t>().unwrap_err();
                     assert!(err.is_instance_of::<exceptions::PyTypeError>(py));});
@@ -975,7 +975,7 @@ mod tests {
 
                 #[test]
                 fn to_py_object_and_back() {
-                    Python::with_gil(|py| {
+                    Python::attach(|py| {
                     let val = <$t>::new(123).unwrap();
                     let obj = val.into_pyobject(py).unwrap();
                     assert_eq!(obj.extract::<$t>().unwrap(), val);});
@@ -999,7 +999,7 @@ mod tests {
 
     #[test]
     fn test_i64_bool() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = true.into_pyobject(py).unwrap();
             assert_eq!(1, obj.extract::<i64>().unwrap());
             let obj = false.into_pyobject(py).unwrap();
@@ -1009,7 +1009,7 @@ mod tests {
 
     #[test]
     fn test_i64_f64() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = 12.34f64.into_pyobject(py).unwrap();
             let err = obj.extract::<i64>().unwrap_err();
             assert!(err.is_instance_of::<crate::exceptions::PyTypeError>(py));

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -181,7 +181,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn test_non_utf8_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             #[cfg(not(target_os = "wasi"))]
             use std::os::unix::ffi::OsStrExt;
             #[cfg(target_os = "wasi")]
@@ -200,7 +200,7 @@ mod tests {
 
     #[test]
     fn test_intopyobject_roundtrip() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             fn test_roundtrip<'py, T>(py: Python<'py>, obj: T)
             where
                 T: IntoPyObject<'py> + AsRef<OsStr> + Debug + Clone,

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn test_non_utf8_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             use std::ffi::OsStr;
             #[cfg(not(target_os = "wasi"))]
             use std::os::unix::ffi::OsStrExt;
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_intopyobject_roundtrip() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             fn test_roundtrip<'py, T>(py: Python<'py>, obj: T)
             where
                 T: IntoPyObject<'py> + AsRef<Path> + Debug + Clone,
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn test_from_pystring() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let path = "Hello\0\n🐍";
             let pystring = PyString::new(py, path);
             let roundtrip: PathBuf = pystring.extract().unwrap();

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn test_extract_hashset() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_extract_btreeset() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: BTreeSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn test_set_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bt: BTreeSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();
             let hs: HashSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();
 

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -99,7 +99,7 @@ mod tests {
 
     #[test]
     fn test_extract_bytes() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_bytes = py.eval(ffi::c_str!("b'Hello Python'"), None, None).unwrap();
             let bytes: &[u8] = py_bytes.extract().unwrap();
             assert_eq!(bytes, b"Hello Python");
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     fn test_cow_impl() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes = py.eval(ffi::c_str!(r#"b"foobar""#), None, None).unwrap();
             let cow = bytes.extract::<Cow<'_, [u8]>>().unwrap();
             assert_eq!(cow, Cow::<[u8]>::Borrowed(b"foobar"));
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn test_slice_intopyobject_impl() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes: &[u8] = b"foobar";
             let obj = bytes.into_pyobject(py).unwrap();
             assert!(obj.is_instance_of::<PyBytes>());
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_cow_intopyobject_impl() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let borrowed_bytes = Cow::<[u8]>::Borrowed(b"foobar");
             let obj = borrowed_bytes.clone().into_pyobject(py).unwrap();
             assert!(obj.is_instance_of::<PyBytes>());

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -211,7 +211,7 @@ mod tests {
 
     #[test]
     fn test_cow_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "Hello Python";
             let py_string = Cow::Borrowed(s).into_pyobject(py).unwrap();
             assert_eq!(s, py_string.extract::<Cow<'_, str>>().unwrap());
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_non_bmp() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "\u{1F30F}";
             let py_string = s.into_pyobject(py).unwrap();
             assert_eq!(s, py_string.extract::<String>().unwrap());
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_extract_str() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "Hello Python";
             let py_string = s.into_pyobject(py).unwrap();
 
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn test_extract_char() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ch = '😃';
             let py_string = ch.into_pyobject(py).unwrap();
             let ch2: char = py_string.extract().unwrap();
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_extract_char_err() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "Hello Python";
             let py_string = s.into_pyobject(py).unwrap();
             let err: crate::PyResult<char> = py_string.extract();
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn test_string_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "Hello Python";
             let s2 = s.to_owned();
             let s3 = &s2;

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -141,7 +141,7 @@ mod tests {
 
     #[test]
     fn test_duration_frompyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert_eq!(
                 new_timedelta(py, 0, 0, 0).extract::<Duration>().unwrap(),
                 Duration::new(0, 0)
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn test_duration_frompyobject_negative() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert_eq!(
                 new_timedelta(py, 0, -1, 0)
                     .extract::<Duration>()
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_duration_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let assert_eq = |l: Bound<'_, PyAny>, r: Bound<'_, PyAny>| {
                 assert!(l.eq(r).unwrap());
             };
@@ -238,14 +238,14 @@ mod tests {
 
     #[test]
     fn test_duration_into_pyobject_overflow() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(Duration::MAX.into_pyobject(py).is_err());
         })
     }
 
     #[test]
     fn test_time_frompyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert_eq!(
                 new_datetime(py, 1970, 1, 1, 0, 0, 0, 0)
                     .extract::<SystemTime>()
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn test_time_frompyobject_before_epoch() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert_eq!(
                 new_datetime(py, 1950, 1, 1, 0, 0, 0, 0)
                     .extract::<SystemTime>()
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn test_time_intopyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let assert_eq = |l: Bound<'_, PyDateTime>, r: Bound<'_, PyDateTime>| {
                 assert!(l.eq(r).unwrap());
             };
@@ -352,7 +352,7 @@ mod tests {
         let big_system_time = UNIX_EPOCH
             .checked_add(Duration::new(300000000000, 0))
             .unwrap();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(big_system_time.into_pyobject(py).is_err());
         })
     }

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn test_vec_intopyobject_impl() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes: Vec<u8> = b"foobar".to_vec();
             let obj = bytes.clone().into_pyobject(py).unwrap();
             assert!(obj.is_instance_of::<PyBytes>());
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_vec_reference_intopyobject_impl() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes: Vec<u8> = b"foobar".to_vec();
             let obj = (&bytes).into_pyobject(py).unwrap();
             assert!(obj.is_instance_of::<PyBytes>());

--- a/src/conversions/time.rs
+++ b/src/conversions/time.rs
@@ -22,7 +22,7 @@
 //!
 //! fn main() -> PyResult<()> {
 //!     pyo3::prepare_freethreaded_python();
-//!     Python::with_gil(|py| {
+//!     Python::attach(|py| {
 //!         // Create a fixed date and time (2022-01-01 12:00:00 UTC)
 //!         let date = Date::from_calendar_date(2022, Month::January, 1).unwrap();
 //!         let time = Time::from_hms(12, 0, 0).unwrap();
@@ -761,7 +761,7 @@ mod tests {
     }
     #[test]
     fn test_time_duration_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Regular duration
             let duration = Duration::new(1, 500_000_000); // 1.5 seconds
             let (_, seconds, microseconds) = utils::extract_py_delta_from_duration(duration, py);
@@ -786,7 +786,7 @@ mod tests {
 
     #[test]
     fn test_time_duration_conversion_large_values() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Large duration (close to max)
             let large_duration = Duration::seconds(86_399_999_000_000); // Almost max
             let (days, _, _) = utils::extract_py_delta_from_duration(large_duration, py);
@@ -803,7 +803,7 @@ mod tests {
 
     #[test]
     fn test_time_duration_nanosecond_resolution() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Test nanosecond conversion to microseconds
             let duration = Duration::new(0, 1_234_567);
             let (_, _, microseconds) = utils::extract_py_delta_from_duration(duration, py);
@@ -814,7 +814,7 @@ mod tests {
 
     #[test]
     fn test_time_duration_from_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Create Python timedeltas with various values
             let datetime = py.import("datetime").unwrap();
             let timedelta = datetime.getattr(intern!(py, "timedelta")).unwrap();
@@ -836,7 +836,7 @@ mod tests {
 
     #[test]
     fn test_time_date_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Regular date
             let date = Date::from_calendar_date(2023, Month::April, 15).unwrap();
             let (year, month, day) = utils::extract_py_date_from_date(date, py);
@@ -861,7 +861,7 @@ mod tests {
 
     #[test]
     fn test_time_date_from_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let date1 = utils::create_date_from_py_date(py, 2023, 4, 15).unwrap();
             assert_eq!(date1.year(), 2023);
             assert_eq!(date1.month(), Month::April);
@@ -889,7 +889,7 @@ mod tests {
 
     #[test]
     fn test_time_date_invalid_values() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let invalid_date = utils::create_date_from_py_date(py, 2023, 2, 30);
             assert!(invalid_date.is_err());
 
@@ -901,7 +901,7 @@ mod tests {
 
     #[test]
     fn test_time_time_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Regular time
             let time = Time::from_hms_micro(14, 30, 45, 123456).unwrap();
             let (hour, minute, second, microsecond) = utils::extract_py_time_from_time(time, py);
@@ -931,7 +931,7 @@ mod tests {
 
     #[test]
     fn test_time_time_from_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let time1 = utils::create_time_from_py_time(py, 14, 30, 45, 123456).unwrap();
             assert_eq!(time1.hour(), 14);
             assert_eq!(time1.minute(), 30);
@@ -956,7 +956,7 @@ mod tests {
 
     #[test]
     fn test_time_time_invalid_values() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let result = utils::create_time_from_py_time(py, 24, 0, 0, 0);
             assert!(result.is_err());
             let result = utils::create_time_from_py_time(py, 12, 60, 0, 0);
@@ -970,7 +970,7 @@ mod tests {
 
     #[test]
     fn test_time_time_with_timezone() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Create Python time with timezone (just to ensure we can handle it properly)
             let datetime = py.import("datetime").unwrap();
             let time_type = datetime.getattr(intern!(py, "time")).unwrap();
@@ -988,7 +988,7 @@ mod tests {
 
     #[test]
     fn test_time_primitive_datetime_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Regular datetime
             let date = Date::from_calendar_date(2023, Month::April, 15).unwrap();
             let time = Time::from_hms_micro(14, 30, 45, 123456).unwrap();
@@ -1022,7 +1022,7 @@ mod tests {
 
     #[test]
     fn test_time_primitive_datetime_from_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dt1 =
                 utils::create_primitive_date_time_from_py(py, 2023, 4, 15, 14, 30, 45, 123456)
                     .unwrap();
@@ -1045,7 +1045,7 @@ mod tests {
 
     #[test]
     fn test_time_utc_offset_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Test positive offset
             let offset = UtcOffset::from_hms(5, 30, 0).unwrap();
             let total_seconds = utils::extract_total_seconds_from_utcoffset(offset, py);
@@ -1060,7 +1060,7 @@ mod tests {
 
     #[test]
     fn test_time_utc_offset_from_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Create timezone objects
             let datetime = py.import("datetime").unwrap();
             let timezone = datetime.getattr(intern!(py, "timezone")).unwrap();
@@ -1091,7 +1091,7 @@ mod tests {
 
     #[test]
     fn test_time_offset_datetime_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Create an OffsetDateTime with +5:30 offset
             let date = Date::from_calendar_date(2023, Month::April, 15).unwrap();
             let time = Time::from_hms_micro(14, 30, 45, 123456).unwrap();
@@ -1160,7 +1160,7 @@ mod tests {
 
     #[test]
     fn test_time_offset_datetime_from_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Create Python datetime with timezone
             let datetime = py.import("datetime").unwrap();
             let datetime_type = datetime.getattr(intern!(py, "datetime")).unwrap();
@@ -1194,7 +1194,7 @@ mod tests {
 
     #[test]
     fn test_time_utc_datetime_conversion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let date = Date::from_calendar_date(2023, Month::April, 15).unwrap();
             let time = Time::from_hms_micro(14, 30, 45, 123456).unwrap();
             let primitive_dt = PrimitiveDateTime::new(date, time);
@@ -1214,7 +1214,7 @@ mod tests {
 
     #[test]
     fn test_time_utc_datetime_from_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Create Python UTC datetime
             let datetime = py.import("datetime").unwrap();
             let datetime_type = datetime.getattr(intern!(py, "datetime")).unwrap();
@@ -1241,7 +1241,7 @@ mod tests {
 
     #[test]
     fn test_time_utc_datetime_non_utc_timezone() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Create Python datetime with non-UTC timezone
             let datetime = py.import("datetime").unwrap();
             let datetime_type = datetime.getattr(intern!(py, "datetime")).unwrap();
@@ -1272,7 +1272,7 @@ mod tests {
             #[test]
             fn test_time_duration_roundtrip(days in -9999i64..=9999i64, seconds in -86399i64..=86399i64, microseconds in -999999i64..=999999i64) {
                 // Generate a valid duration that should roundtrip successfully
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let duration = Duration::days(days) + Duration::seconds(seconds) + Duration::microseconds(microseconds);
 
                     // Skip if outside Python's timedelta bounds
@@ -1296,7 +1296,7 @@ mod tests {
                 year in 1i32..=9999,
                 month_num in 1u8..=12,
             ) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let month = match month_num {
                         1 => (Month::January, 31),
                         2 => {
@@ -1337,7 +1337,7 @@ mod tests {
                 second in 0u8..=59u8,
                 microsecond in 0u32..=999999u32
             ) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let time = Time::from_hms_micro(hour, minute, second, microsecond).unwrap();
                     let py_time = time.into_pyobject(py).unwrap();
                     let roundtripped: Time = py_time.extract().unwrap();
@@ -1355,7 +1355,7 @@ mod tests {
                 second in 0u8..=59u8,
                 microsecond in 0u32..=999999u32
             ) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let month = match month {
                         1 => Month::January,
                         2 => Month::February,
@@ -1392,7 +1392,7 @@ mod tests {
                     return Ok(());
                 }
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     if let Ok(offset) = UtcOffset::from_hms(hours, minutes, 0) {
                         let py_tz = offset.into_pyobject(py).unwrap();
                         let roundtripped: UtcOffset = py_tz.extract().unwrap();
@@ -1414,7 +1414,7 @@ mod tests {
                 tz_hour in -23i8..=23i8,
                 tz_minute in 0i8..=59i8
             ) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let month = match month {
                         1 => Month::January,
                         2 => Month::February,
@@ -1465,7 +1465,7 @@ mod tests {
                 second in 0u8..=59u8,
                 microsecond in 0u32..=999999u32
             ) {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let month = match month {
                         1 => Month::January,
                         2 => Month::February,

--- a/src/conversions/uuid.rs
+++ b/src/conversions/uuid.rs
@@ -126,7 +126,7 @@ mod tests {
         ($name:ident, $rs:expr, $py:literal) => {
             #[test]
             fn $name() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let rs_orig = $rs;
                     let rs_uuid = rs_orig.into_pyobject(py).unwrap();
                     let locals = PyDict::new(py);

--- a/src/coroutine/waker.rs
+++ b/src/coroutine/waker.rs
@@ -41,7 +41,7 @@ impl Wake for AsyncioWaker {
     }
 
     fn wake_by_ref(self: &Arc<Self>) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             if let Some(loop_and_future) = self.0.get_or_init(py, || None) {
                 loop_and_future
                     .set_result(py)

--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -5,7 +5,7 @@ use std::io;
 /// Convert `PyErr` to `io::Error`
 impl From<PyErr> for io::Error {
     fn from(err: PyErr) -> Self {
-        let kind = Python::with_gil(|py| {
+        let kind = Python::attach(|py| {
             if err.is_instance_of::<exceptions::PyBrokenPipeError>(py) {
                 io::ErrorKind::BrokenPipe
             } else if err.is_instance_of::<exceptions::PyConnectionRefusedError>(py) {
@@ -151,7 +151,7 @@ mod tests {
         use crate::types::any::PyAnyMethods;
 
         let check_err = |kind, expected_ty| {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let rust_err = io::Error::new(kind, "some error msg");
 
                 let py_err: PyErr = rust_err.into();

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -62,7 +62,7 @@ macro_rules! impl_exception_boilerplate_bound {
 /// import_exception!(socket, gaierror);
 ///
 /// # fn main() -> pyo3::PyResult<()> {
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let ctx = [("gaierror", py.get_type::<gaierror>())].into_py_dict(py)?;
 ///     pyo3::py_run!(py, *ctx, "import socket; assert gaierror is socket.gaierror");
 /// #   Ok(())
@@ -176,7 +176,7 @@ macro_rules! import_exception_bound {
 ///     Ok(())
 /// }
 /// # fn main() -> PyResult<()> {
-/// #     Python::with_gil(|py| -> PyResult<()> {
+/// #     Python::attach(|py| -> PyResult<()> {
 /// #         let fun = wrap_pyfunction!(raise_myerror, py)?;
 /// #         let locals = pyo3::types::PyDict::new(py);
 /// #         locals.set_item("MyError", py.get_type::<MyError>())?;
@@ -331,7 +331,7 @@ fn always_throws() -> PyResult<()> {
     Err(Py", $name, "::new_err(message))
 }
 #
-# Python::with_gil(|py| {
+# Python::attach(|py| {
 #     let fun = pyo3::wrap_pyfunction!(always_throws, py).unwrap();
 #     let err = fun.call0().expect_err(\"called a function that should always return an error but the return value was Ok\");
 #     assert!(err.is_instance_of::<Py", $name, ">(py))
@@ -355,7 +355,7 @@ use pyo3::prelude::*;
 use pyo3::exceptions::Py", $name, ";
 use pyo3::ffi::c_str;
 
-Python::with_gil(|py| {
+Python::attach(|py| {
     let result: PyResult<()> = py.run(c_str!(\"raise ", $name, "\"), None, None);
 
     let error_type = match result {
@@ -662,7 +662,7 @@ impl PyUnicodeDecodeError {
     /// use pyo3::exceptions::PyUnicodeDecodeError;
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let invalid_utf8 = b"fo\xd8o";
     /// #   #[allow(invalid_from_utf8)]
     ///     let err = std::str::from_utf8(invalid_utf8).expect_err("should be invalid utf8");
@@ -753,7 +753,7 @@ macro_rules! test_exception {
         fn $exc_ty () {
             use super::$exc_ty;
 
-            $crate::Python::with_gil(|py| {
+            $crate::Python::attach(|py| {
                 use $crate::types::PyAnyMethods;
                 let err: $crate::PyErr = {
                     None
@@ -827,7 +827,7 @@ mod tests {
 
     #[test]
     fn test_check_exception() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let err: PyErr = gaierror::new_err(());
             let socket = py
                 .import("socket")
@@ -855,7 +855,7 @@ mod tests {
 
     #[test]
     fn test_check_exception_nested() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let err: PyErr = MessageError::new_err(());
             let email = py
                 .import("email")
@@ -884,7 +884,7 @@ mod tests {
     fn custom_exception() {
         create_exception!(mymodule, CustomError, PyException);
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py).unwrap();
             let type_description: String = py
@@ -911,7 +911,7 @@ mod tests {
     #[test]
     fn custom_exception_dotted_module() {
         create_exception!(mymodule.exceptions, CustomError, PyException);
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py).unwrap();
             let type_description: String = py
@@ -930,7 +930,7 @@ mod tests {
     fn custom_exception_doc() {
         create_exception!(mymodule, CustomError, PyException, "Some docs");
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py).unwrap();
             let type_description: String = py
@@ -963,7 +963,7 @@ mod tests {
             concat!("Some", " more ", stringify!(docs))
         );
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let error_type = py.get_type::<CustomError>();
             let ctx = [("CustomError", error_type)].into_py_dict(py).unwrap();
             let type_description: String = py
@@ -989,7 +989,7 @@ mod tests {
 
     #[test]
     fn native_exception_debug() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let exc = py
                 .run(ffi::c_str!("raise Exception('banana')"), None, None)
                 .expect_err("raising should have given us an error")
@@ -1004,7 +1004,7 @@ mod tests {
 
     #[test]
     fn native_exception_display() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let exc = py
                 .run(ffi::c_str!("raise Exception('banana')"), None, None)
                 .expect_err("raising should have given us an error")
@@ -1022,7 +1022,7 @@ mod tests {
         let invalid_utf8 = b"fo\xd8o";
         #[allow(invalid_from_utf8)]
         let err = std::str::from_utf8(invalid_utf8).expect_err("should be invalid utf8");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let decode_err = PyUnicodeDecodeError::new_utf8(py, invalid_utf8, err).unwrap();
             assert_eq!(
                 format!("{decode_err:?}"),

--- a/src/ffi/tests.rs
+++ b/src/ffi/tests.rs
@@ -15,7 +15,7 @@ use libc::wchar_t;
 #[test]
 fn test_datetime_fromtimestamp() {
     use crate::IntoPyObject;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let args = (100,).into_pyobject(py).unwrap();
         let dt = unsafe {
             PyDateTime_IMPORT();
@@ -37,7 +37,7 @@ fn test_datetime_fromtimestamp() {
 #[test]
 fn test_date_fromtimestamp() {
     use crate::IntoPyObject;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let args = (100,).into_pyobject(py).unwrap();
         let dt = unsafe {
             PyDateTime_IMPORT();
@@ -58,7 +58,7 @@ fn test_date_fromtimestamp() {
 #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
 #[test]
 fn test_utc_timezone() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let utc_timezone: Bound<'_, PyAny> = unsafe {
             PyDateTime_IMPORT();
             Bound::from_borrowed_ptr(py, PyDateTime_TimeZone_UTC())
@@ -81,7 +81,7 @@ fn test_utc_timezone() {
 fn test_timezone_from_offset() {
     use crate::{ffi_ptr_ext::FfiPtrExt, types::PyDelta};
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let delta = PyDelta::new(py, 0, 100, 0, false).unwrap();
         let tz = unsafe { PyTimeZone_FromOffset(delta.as_ptr()).assume_owned(py) };
         crate::py_run!(
@@ -99,7 +99,7 @@ fn test_timezone_from_offset() {
 fn test_timezone_from_offset_and_name() {
     use crate::{ffi_ptr_ext::FfiPtrExt, types::PyDelta};
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let delta = PyDelta::new(py, 0, 100, 0, false).unwrap();
         let tzname = PyString::new(py, "testtz");
         let tz = unsafe {
@@ -171,7 +171,7 @@ fn ascii_object_bitfield() {
 #[test]
 #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
 fn ascii() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // This test relies on implementation details of PyString.
         let s = PyString::new(py, "hello, world");
         let ptr = s.as_ptr();
@@ -216,7 +216,7 @@ fn ascii() {
 #[test]
 #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
 fn ucs4() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let s = "哈哈🐈";
         let py_string = PyString::new(py, s);
         let ptr = py_string.as_ptr();
@@ -266,7 +266,7 @@ fn ucs4() {
 fn test_get_tzinfo() {
     use crate::types::PyTzInfo;
 
-    crate::Python::with_gil(|py| {
+    crate::Python::attach(|py| {
         use crate::types::{PyDateTime, PyTime};
 
         let utc: &Bound<'_, _> = &PyTzInfo::utc(py).unwrap();
@@ -302,7 +302,7 @@ fn test_get_tzinfo() {
 
 #[test]
 fn test_inc_dec_ref() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
 
         let ref_count = obj.get_refcnt();
@@ -321,7 +321,7 @@ fn test_inc_dec_ref() {
 #[test]
 #[cfg(Py_3_12)]
 fn test_inc_dec_ref_immortal() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = py.None();
 
         let ref_count = obj.get_refcnt(py);

--- a/src/impl_/coroutine.rs
+++ b/src/impl_/coroutine.rs
@@ -50,7 +50,7 @@ impl<T: PyClass> Deref for RefGuard<T> {
 
 impl<T: PyClass> Drop for RefGuard<T> {
     fn drop(&mut self) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.0
                 .bind(py)
                 .get_class_object()
@@ -87,7 +87,7 @@ impl<T: PyClass<Frozen = False>> DerefMut for RefMutGuard<T> {
 
 impl<T: PyClass<Frozen = False>> Drop for RefMutGuard<T> {
     fn drop(&mut self) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             self.0
                 .bind(py)
                 .get_class_object()

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -822,7 +822,7 @@ mod tests {
             keyword_only_parameters: &[],
         };
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let args = PyTuple::empty(py);
             let kwargs = [("foo", 0u8)].into_py_dict(py).unwrap();
             let err = unsafe {
@@ -853,7 +853,7 @@ mod tests {
             keyword_only_parameters: &[],
         };
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let args = PyTuple::empty(py);
             let kwargs = [(1u8, 1u8)].into_py_dict(py).unwrap();
             let err = unsafe {
@@ -884,7 +884,7 @@ mod tests {
             keyword_only_parameters: &[],
         };
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let args = PyTuple::empty(py);
             let mut output = [None, None];
             let err = unsafe {

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -720,7 +720,7 @@ mod tests {
         use crate::types::{PyAnyMethods, PyCFunction};
         use crate::{ffi, Python};
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             unsafe extern "C" fn accepts_no_arguments(
                 _slf: *mut ffi::PyObject,
                 _args: *const *mut ffi::PyObject,

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -245,7 +245,7 @@ mod tests {
                 }),
             )
         };
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module = MODULE_DEF.make_module(py, false).unwrap().into_bound(py);
             assert_eq!(
                 module
@@ -294,7 +294,7 @@ mod tests {
             assert_eq!((*module_def.ffi_def.get()).m_name, NAME.as_ptr() as _);
             assert_eq!((*module_def.ffi_def.get()).m_doc, DOC.as_ptr() as _);
 
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 module_def.initializer.0(&py.import("builtins").unwrap()).unwrap();
                 assert!(INIT_CALLED.load(Ordering::SeqCst));
             })

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -81,11 +81,11 @@ where
     /// struct Foo {/* fields omitted */}
     ///
     /// # fn main() -> PyResult<()> {
-    /// let foo: Py<Foo> = Python::with_gil(|py| -> PyResult<_> {
+    /// let foo: Py<Foo> = Python::attach(|py| -> PyResult<_> {
     ///     let foo: Bound<'_, Foo> = Bound::new(py, Foo {})?;
     ///     Ok(foo.into())
     /// })?;
-    /// # Python::with_gil(move |_py| drop(foo));
+    /// # Python::attach(move |_py| drop(foo));
     /// # Ok(())
     /// # }
     /// ```
@@ -248,7 +248,7 @@ where
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Bound<'_, Foo> = Bound::new(py, Foo { inner: 73 })?;
     ///     let inner: &u8 = &foo.borrow().inner;
     ///
@@ -284,7 +284,7 @@ where
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Bound<'_, Foo> = Bound::new(py, Foo { inner: 73 })?;
     ///     foo.borrow_mut().inner = 35;
     ///
@@ -347,7 +347,7 @@ where
     ///     value: AtomicUsize,
     /// }
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let counter = FrozenCounter { value: AtomicUsize::new(0) };
     ///
     ///     let py_counter = Bound::new(py, counter).unwrap();
@@ -399,7 +399,7 @@ where
     /// #[pyclass(extends = BaseClass)]
     /// struct SubClass;
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let obj = Bound::new(py, (SubClass, BaseClass)).unwrap();
     ///     assert!(obj.as_super().pyrepr().is_ok());
     /// })
@@ -451,7 +451,7 @@ where
     /// #[pyclass(extends = BaseClass)]
     /// struct SubClass;
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let obj = Bound::new(py, (SubClass, BaseClass)).unwrap();
     ///     assert!(obj.into_super().pyrepr().is_ok());
     /// })
@@ -666,7 +666,7 @@ impl<'a, 'py, T> Borrowed<'a, 'py, T> {
     /// use pyo3::{prelude::*, types::PyTuple};
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let tuple = PyTuple::new(py, [1, 2, 3])?;
     ///
     ///     // borrows from `tuple`, so can only be
@@ -899,7 +899,7 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 ///
 /// impl Foo {
 ///     fn new() -> Foo {
-///         let foo = Python::with_gil(|py| {
+///         let foo = Python::attach(|py| {
 ///             // `py` will only last for this scope.
 ///
 ///             // `Bound<'py, PyDict>` inherits the GIL lifetime from `py` and
@@ -932,7 +932,7 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// impl Foo {
 ///     #[new]
 ///     fn __new__() -> Foo {
-///         Python::with_gil(|py| {
+///         Python::attach(|py| {
 ///             let dict: Py<PyDict> = PyDict::new(py).unbind();
 ///             Foo { inner: dict }
 ///         })
@@ -940,7 +940,7 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// }
 /// #
 /// # fn main() -> PyResult<()> {
-/// #     Python::with_gil(|py| {
+/// #     Python::attach(|py| {
 /// #         let m = pyo3::types::PyModule::new(py, "test")?;
 /// #         m.add_class::<Foo>()?;
 /// #
@@ -969,7 +969,7 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// impl Foo {
 ///     #[new]
 ///     fn __new__() -> PyResult<Foo> {
-///         Python::with_gil(|py| {
+///         Python::attach(|py| {
 ///             let bar: Py<Bar> = Py::new(py, Bar {})?;
 ///             Ok(Foo { inner: bar })
 ///         })
@@ -977,7 +977,7 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// }
 /// #
 /// # fn main() -> PyResult<()> {
-/// #     Python::with_gil(|py| {
+/// #     Python::attach(|py| {
 /// #         let m = pyo3::types::PyModule::new(py, "test")?;
 /// #         m.add_class::<Foo>()?;
 /// #
@@ -1004,7 +1004,7 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// use pyo3::types::PyDict;
 ///
 /// # fn main() {
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let first: Py<PyDict> = PyDict::new(py).unbind();
 ///
 ///     // All of these are valid syntax
@@ -1084,11 +1084,11 @@ where
     /// struct Foo {/* fields omitted */}
     ///
     /// # fn main() -> PyResult<()> {
-    /// let foo = Python::with_gil(|py| -> PyResult<_> {
+    /// let foo = Python::attach(|py| -> PyResult<_> {
     ///     let foo: Py<Foo> = Py::new(py, Foo {})?;
     ///     Ok(foo)
     /// })?;
-    /// # Python::with_gil(move |_py| drop(foo));
+    /// # Python::attach(move |_py| drop(foo));
     /// # Ok(())
     /// # }
     /// ```
@@ -1162,7 +1162,7 @@ where
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Py<Foo> = Py::new(py, Foo { inner: 73 })?;
     ///     let inner: &u8 = &foo.borrow(py).inner;
     ///
@@ -1200,7 +1200,7 @@ where
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Py<Foo> = Py::new(py, Foo { inner: 73 })?;
     ///     foo.borrow_mut(py).inner = 35;
     ///
@@ -1270,14 +1270,14 @@ where
     ///     value: AtomicUsize,
     /// }
     ///
-    /// let cell  = Python::with_gil(|py| {
+    /// let cell  = Python::attach(|py| {
     ///     let counter = FrozenCounter { value: AtomicUsize::new(0) };
     ///
     ///     Py::new(py, counter).unwrap()
     /// });
     ///
     /// cell.get().value.fetch_add(1, Ordering::Relaxed);
-    /// # Python::with_gil(move |_py| drop(cell));
+    /// # Python::attach(move |_py| drop(cell));
     /// ```
     #[inline]
     pub fn get(&self) -> &T
@@ -1346,7 +1346,7 @@ impl<T> Py<T> {
     /// use pyo3::types::PyDict;
     ///
     /// # fn main() {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let first: Py<PyDict> = PyDict::new(py).unbind();
     ///     let second = Py::clone_ref(&first, py);
     ///
@@ -1378,7 +1378,7 @@ impl<T> Py<T> {
     /// use pyo3::types::PyDict;
     ///
     /// # fn main() {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let object: Py<PyDict> = PyDict::new(py).unbind();
     ///
     ///     // some usage of object
@@ -1439,7 +1439,7 @@ impl<T> Py<T> {
     ///     sys.getattr(py, intern!(py, "version"))
     /// }
     /// #
-    /// # Python::with_gil(|py| {
+    /// # Python::attach(|py| {
     /// #    let sys = py.import("sys").unwrap().unbind();
     /// #    version(sys, py).unwrap();
     /// # });
@@ -1468,7 +1468,7 @@ impl<T> Py<T> {
     ///     ob.setattr(py, intern!(py, "answer"), 42)
     /// }
     /// #
-    /// # Python::with_gil(|py| {
+    /// # Python::attach(|py| {
     /// #    let ob = PyModule::new(py, "empty").unwrap().into_py_any(py).unwrap();
     /// #    set_answer(ob, py).unwrap();
     /// # });
@@ -1795,7 +1795,7 @@ where
     T: PyTypeInfo,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        Python::with_gil(|py| std::fmt::Display::fmt(self.bind(py), f))
+        Python::attach(|py| std::fmt::Display::fmt(self.bind(py), f))
     }
 }
 
@@ -1828,7 +1828,7 @@ impl PyObject {
     /// use pyo3::prelude::*;
     /// use pyo3::types::{PyDict, PyList};
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let any: PyObject = PyDict::new(py).into();
     ///
     ///     assert!(any.downcast_bound::<PyDict>(py).is_ok());
@@ -1850,7 +1850,7 @@ impl PyObject {
     ///     i: i32,
     /// }
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let class: PyObject = Py::new(py, Class { i: 0 })?.into_any();
     ///
     ///     let class_bound = class.downcast_bound::<Class>(py)?;
@@ -1897,7 +1897,7 @@ mod tests {
 
     #[test]
     fn test_call() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.get_type::<PyDict>().into_pyobject(py).unwrap();
 
             let assert_repr = |obj: Bound<'_, PyAny>, expected: &str| {
@@ -1946,7 +1946,7 @@ mod tests {
             };
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             tuple!(py, "a" => 1);
             tuple!(py, "a" => 1, "b" => 2);
             tuple!(py, "a" => 1, "b" => 2, "c" => 3);
@@ -1963,7 +1963,7 @@ mod tests {
 
     #[test]
     fn test_call_for_non_existing_method() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj: PyObject = PyDict::new(py).into();
             assert!(obj.call_method0(py, "asdf").is_err());
             assert!(obj
@@ -1976,19 +1976,19 @@ mod tests {
 
     #[test]
     fn py_from_dict() {
-        let dict: Py<PyDict> = Python::with_gil(|py| {
+        let dict: Py<PyDict> = Python::attach(|py| {
             let native = PyDict::new(py);
             Py::from(native)
         });
 
-        Python::with_gil(move |py| {
+        Python::attach(move |py| {
             assert_eq!(dict.get_refcnt(py), 1);
         });
     }
 
     #[test]
     fn pyobject_from_py() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict: Py<PyDict> = PyDict::new(py).unbind();
             let cnt = dict.get_refcnt(py);
             let p: PyObject = dict.into();
@@ -2000,7 +2000,7 @@ mod tests {
     fn attr() -> PyResult<()> {
         use crate::types::PyModule;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             const CODE: &CStr = c_str!(
                 r#"
 class A:
@@ -2030,7 +2030,7 @@ a = A()
     fn pystring_attr() -> PyResult<()> {
         use crate::types::PyModule;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             const CODE: &CStr = c_str!(
                 r#"
 class A:
@@ -2054,7 +2054,7 @@ a = A()
 
     #[test]
     fn invalid_attr() -> PyResult<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let instance: Py<PyAny> = py.eval(ffi::c_str!("object()"), None, None)?.into();
 
             instance.getattr(py, "foo").unwrap_err();
@@ -2067,7 +2067,7 @@ a = A()
 
     #[test]
     fn test_py2_from_py_object() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let instance = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             let ptr = instance.as_ptr();
             let instance: Bound<'_, PyAny> = instance.extract().unwrap();
@@ -2077,7 +2077,7 @@ a = A()
 
     #[test]
     fn test_py2_into_py_object() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let instance = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             let ptr = instance.as_ptr();
             let instance: PyObject = instance.clone().unbind();
@@ -2087,7 +2087,7 @@ a = A()
 
     #[test]
     fn test_debug_fmt() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = "hello world".into_pyobject(py).unwrap();
             assert_eq!(format!("{obj:?}"), "'hello world'");
         });
@@ -2095,7 +2095,7 @@ a = A()
 
     #[test]
     fn test_display_fmt() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = "hello world".into_pyobject(py).unwrap();
             assert_eq!(format!("{obj}"), "hello world");
         });
@@ -2103,7 +2103,7 @@ a = A()
 
     #[test]
     fn test_bound_as_any() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = PyString::new(py, "hello world");
             let any = obj.as_any();
             assert_eq!(any.as_ptr(), obj.as_ptr());
@@ -2112,7 +2112,7 @@ a = A()
 
     #[test]
     fn test_bound_into_any() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = PyString::new(py, "hello world");
             let any = obj.clone().into_any();
             assert_eq!(any.as_ptr(), obj.as_ptr());
@@ -2121,7 +2121,7 @@ a = A()
 
     #[test]
     fn test_bound_py_conversions() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj: Bound<'_, PyString> = PyString::new(py, "hello world");
             let obj_unbound: &Py<PyString> = obj.as_unbound();
             let _: &Bound<'_, PyString> = obj_unbound.bind(py);
@@ -2135,7 +2135,7 @@ a = A()
 
     #[test]
     fn test_borrowed_identity() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let yes = true.into_pyobject(py).unwrap();
             let no = false.into_pyobject(py).unwrap();
 
@@ -2147,7 +2147,7 @@ a = A()
     #[test]
     fn bound_from_borrowed_ptr_constructors() {
         // More detailed tests of the underlying semantics in pycell.rs
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             fn check_drop<'py>(
                 py: Python<'py>,
                 method: impl FnOnce(*mut ffi::PyObject) -> Bound<'py, PyAny>,
@@ -2186,7 +2186,7 @@ a = A()
     #[test]
     fn borrowed_ptr_constructors() {
         // More detailed tests of the underlying semantics in pycell.rs
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             fn check_drop<'py>(
                 py: Python<'py>,
                 method: impl FnOnce(&*mut ffi::PyObject) -> Borrowed<'_, 'py, PyAny>,
@@ -2221,7 +2221,7 @@ a = A()
 
     #[test]
     fn explicit_drop_ref() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let object: Py<PyDict> = PyDict::new(py).unbind();
             let object2 = object.clone_ref(py);
 
@@ -2246,7 +2246,7 @@ a = A()
         #[test]
         fn py_borrow_methods() {
             // More detailed tests of the underlying semantics in pycell.rs
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let instance = Py::new(py, SomeClass(0)).unwrap();
                 assert_eq!(instance.borrow(py).0, 0);
                 assert_eq!(instance.try_borrow(py).unwrap().0, 0);
@@ -2265,7 +2265,7 @@ a = A()
         #[test]
         fn bound_borrow_methods() {
             // More detailed tests of the underlying semantics in pycell.rs
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let instance = Bound::new(py, SomeClass(0)).unwrap();
                 assert_eq!(instance.borrow().0, 0);
                 assert_eq!(instance.try_borrow().unwrap().0, 0);
@@ -2286,7 +2286,7 @@ a = A()
 
         #[test]
         fn test_frozen_get() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 for i in 0..10 {
                     let instance = Py::new(py, FrozenClass(i)).unwrap();
                     assert_eq!(instance.get().0, i);
@@ -2316,7 +2316,7 @@ a = A()
 
         #[test]
         fn test_as_super() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let obj = Bound::new(py, (SubClass, BaseClass)).unwrap();
                 let _: &Bound<'_, BaseClass> = obj.as_super();
                 let _: &Bound<'_, PyAny> = obj.as_super().as_super();
@@ -2326,7 +2326,7 @@ a = A()
 
         #[test]
         fn test_into_super() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let obj = Bound::new(py, (SubClass, BaseClass)).unwrap();
                 let _: Bound<'_, BaseClass> = obj.clone().into_super();
                 let _: Bound<'_, PyAny> = obj.clone().into_super().into_super();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 //!
 //! - `abi3`: Restricts PyO3's API to a subset of the full Python API which is guaranteed by
 //! [PEP 384] to be forward-compatible with future Python versions.
-//! - `auto-initialize`: Changes [`Python::with_gil`] to automatically initialize the Python
+//! - `auto-initialize`: Changes [`Python::attach`] to automatically initialize the Python
 //! interpreter if needed.
 //! - `extension-module`: This will tell the linker to keep the Python symbols unresolved, so that
 //! your module can also be used with statically linked Python interpreters. Use this feature when
@@ -255,7 +255,7 @@
 //! use pyo3::ffi::c_str;
 //!
 //! fn main() -> PyResult<()> {
-//!     Python::with_gil(|py| {
+//!     Python::attach(|py| {
 //!         let sys = py.import("sys")?;
 //!         let version: String = sys.getattr("version")?.extract()?;
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -12,7 +12,7 @@
 /// use pyo3::{prelude::*, py_run, types::PyList};
 ///
 /// # fn main() -> PyResult<()> {
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let list = PyList::new(py, &[1, 2, 3])?;
 ///     py_run!(py, list, "assert list == [1, 2, 3]");
 /// # Ok(())
@@ -47,7 +47,7 @@
 ///     }
 /// }
 ///
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let time = Py::new(py, Time {hour: 8, minute: 43, second: 16}).unwrap();
 ///     let time_as_tuple = (8, 43, 16);
 ///     py_run!(py, time time_as_tuple, r#"
@@ -76,7 +76,7 @@
 /// }
 ///
 /// # fn main() -> PyResult<()> {
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let locals = [("C", py.get_type::<MyClass>())].into_py_dict(py)?;
 ///     pyo3::py_run!(py, *locals, "c = C()");
 /// #   Ok(())

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -23,7 +23,7 @@ pub const VERSION: i32 = 4;
 /// # Examples
 /// ```
 /// # use pyo3::{marshal, types::PyDict, prelude::PyDictMethods};
-/// # pyo3::Python::with_gil(|py| {
+/// # pyo3::Python::attach(|py| {
 /// let dict = PyDict::new(py);
 /// dict.set_item("aap", "noot").unwrap();
 /// dict.set_item("mies", "wim").unwrap();
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn marshal_roundtrip() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = PyDict::new(py);
             dict.set_item("aap", "noot").unwrap();
             dict.set_item("mies", "wim").unwrap();

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -321,7 +321,7 @@ mod test {
 
     #[test]
     fn py_backed_str_empty() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = PyString::new(py, "");
             let py_backed_str = s.extract::<PyBackedStr>().unwrap();
             assert_eq!(&*py_backed_str, "");
@@ -330,7 +330,7 @@ mod test {
 
     #[test]
     fn py_backed_str() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = PyString::new(py, "hello");
             let py_backed_str = s.extract::<PyBackedStr>().unwrap();
             assert_eq!(&*py_backed_str, "hello");
@@ -339,7 +339,7 @@ mod test {
 
     #[test]
     fn py_backed_str_try_from() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = PyString::new(py, "hello");
             let py_backed_str = PyBackedStr::try_from(s).unwrap();
             assert_eq!(&*py_backed_str, "hello");
@@ -348,7 +348,7 @@ mod test {
 
     #[test]
     fn py_backed_str_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let orig_str = PyString::new(py, "hello");
             let py_backed_str = orig_str.extract::<PyBackedStr>().unwrap();
             let new_str = py_backed_str.into_pyobject(py).unwrap();
@@ -360,7 +360,7 @@ mod test {
 
     #[test]
     fn py_backed_bytes_empty() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let b = PyBytes::new(py, b"");
             let py_backed_bytes = b.extract::<PyBackedBytes>().unwrap();
             assert_eq!(&*py_backed_bytes, b"");
@@ -369,7 +369,7 @@ mod test {
 
     #[test]
     fn py_backed_bytes() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let b = PyBytes::new(py, b"abcde");
             let py_backed_bytes = b.extract::<PyBackedBytes>().unwrap();
             assert_eq!(&*py_backed_bytes, b"abcde");
@@ -378,7 +378,7 @@ mod test {
 
     #[test]
     fn py_backed_bytes_from_bytes() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let b = PyBytes::new(py, b"abcde");
             let py_backed_bytes = PyBackedBytes::from(b);
             assert_eq!(&*py_backed_bytes, b"abcde");
@@ -387,7 +387,7 @@ mod test {
 
     #[test]
     fn py_backed_bytes_from_bytearray() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let b = PyByteArray::new(py, b"abcde");
             let py_backed_bytes = PyBackedBytes::from(b);
             assert_eq!(&*py_backed_bytes, b"abcde");
@@ -396,7 +396,7 @@ mod test {
 
     #[test]
     fn py_backed_bytes_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let orig_bytes = PyBytes::new(py, b"abcde");
             let py_backed_bytes = PyBackedBytes::from(orig_bytes.clone());
             assert!((&py_backed_bytes)
@@ -408,7 +408,7 @@ mod test {
 
     #[test]
     fn rust_backed_bytes_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let orig_bytes = PyByteArray::new(py, b"abcde");
             let rust_backed_bytes = PyBackedBytes::from(orig_bytes);
             assert!(matches!(
@@ -436,7 +436,7 @@ mod test {
     #[cfg(feature = "py-clone")]
     #[test]
     fn test_backed_str_clone() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s1: PyBackedStr = PyString::new(py, "hello").try_into().unwrap();
             let s2 = s1.clone();
             assert_eq!(s1, s2);
@@ -448,7 +448,7 @@ mod test {
 
     #[test]
     fn test_backed_str_eq() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s1: PyBackedStr = PyString::new(py, "hello").try_into().unwrap();
             let s2: PyBackedStr = PyString::new(py, "hello").try_into().unwrap();
             assert_eq!(s1, "hello");
@@ -462,7 +462,7 @@ mod test {
 
     #[test]
     fn test_backed_str_hash() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let h = {
                 let mut hasher = DefaultHasher::new();
                 "abcde".hash(&mut hasher);
@@ -482,7 +482,7 @@ mod test {
 
     #[test]
     fn test_backed_str_ord() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut a = vec!["a", "c", "d", "b", "f", "g", "e"];
             let mut b = a
                 .iter()
@@ -499,7 +499,7 @@ mod test {
     #[cfg(feature = "py-clone")]
     #[test]
     fn test_backed_bytes_from_bytes_clone() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let b1: PyBackedBytes = PyBytes::new(py, b"abcde").into();
             let b2 = b1.clone();
             assert_eq!(b1, b2);
@@ -512,7 +512,7 @@ mod test {
     #[cfg(feature = "py-clone")]
     #[test]
     fn test_backed_bytes_from_bytearray_clone() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let b1: PyBackedBytes = PyByteArray::new(py, b"abcde").into();
             let b2 = b1.clone();
             assert_eq!(b1, b2);
@@ -524,7 +524,7 @@ mod test {
 
     #[test]
     fn test_backed_bytes_eq() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let b1: PyBackedBytes = PyBytes::new(py, b"abcde").into();
             let b2: PyBackedBytes = PyByteArray::new(py, b"abcde").into();
 
@@ -539,7 +539,7 @@ mod test {
 
     #[test]
     fn test_backed_bytes_hash() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let h = {
                 let mut hasher = DefaultHasher::new();
                 b"abcde".hash(&mut hasher);
@@ -567,7 +567,7 @@ mod test {
 
     #[test]
     fn test_backed_bytes_ord() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut a = vec![b"a", b"c", b"d", b"b", b"f", b"g", b"e"];
             let mut b = a
                 .iter()

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -92,7 +92,7 @@
 //! #     }
 //! # }
 //! # fn main() -> PyResult<()> {
-//! Python::with_gil(|py| {
+//! Python::attach(|py| {
 //!     let n = Py::new(py, Number { inner: 0 })?;
 //!
 //!     // We borrow the guard and then dereference
@@ -128,7 +128,7 @@
 //!     std::mem::swap(&mut a.inner, &mut b.inner);
 //! }
 //! # fn main() {
-//! #     Python::with_gil(|py| {
+//! #     Python::attach(|py| {
 //! #         let n = Py::new(py, Number{inner: 35}).unwrap();
 //! #         let n2 = n.clone_ref(py);
 //! #         assert!(n.is(&n2));
@@ -166,7 +166,7 @@
 //! }
 //! # fn main() {
 //! #     // With duplicate numbers
-//! #     Python::with_gil(|py| {
+//! #     Python::attach(|py| {
 //! #         let n = Py::new(py, Number{inner: 35}).unwrap();
 //! #         let n2 = n.clone_ref(py);
 //! #         assert!(n.is(&n2));
@@ -175,7 +175,7 @@
 //! #     });
 //! #
 //! #     // With two different numbers
-//! #     Python::with_gil(|py| {
+//! #     Python::attach(|py| {
 //! #         let n = Py::new(py, Number{inner: 35}).unwrap();
 //! #         let n2 = Py::new(py, Number{inner: 42}).unwrap();
 //! #         assert!(!n.is(&n2));
@@ -244,7 +244,7 @@ use impl_::{PyClassBorrowChecker, PyClassObjectLayout};
 ///         format!("{}(base: {}, cnt: {})", slf.name, basename, refcnt)
 ///     }
 /// }
-/// # Python::with_gil(|py| {
+/// # Python::attach(|py| {
 /// #     let sub = Py::new(py, Child::new()).unwrap();
 /// #     pyo3::py_run!(py, sub, "assert sub.format() == 'Caterpillar(base: Butterfly, cnt: 4)', sub.format()");
 /// # });
@@ -359,7 +359,7 @@ where
     ///         format!("{} {} {}", super_.as_ref().name1, super_.name2, subname)
     ///     }
     /// }
-    /// # Python::with_gil(|py| {
+    /// # Python::attach(|py| {
     /// #     let sub = Py::new(py, Sub::new()).unwrap();
     /// #     pyo3::py_run!(py, sub, "assert sub.name() == 'base1 base2 sub'")
     /// # });
@@ -414,7 +414,7 @@ where
     ///         format!("{} {}", slf.as_super().base_name_len(), slf.sub_name_len())
     ///     }
     /// }
-    /// # Python::with_gil(|py| {
+    /// # Python::attach(|py| {
     /// #     let sub = Py::new(py, Sub::new()).unwrap();
     /// #     pyo3::py_run!(py, sub, "assert sub.format_name_lengths() == '9 8'")
     /// # });
@@ -707,7 +707,7 @@ mod tests {
 
     #[test]
     fn test_as_ptr() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let cell = Bound::new(py, SomeClass(0)).unwrap();
             let ptr = cell.as_ptr();
 
@@ -718,7 +718,7 @@ mod tests {
 
     #[test]
     fn test_into_ptr() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let cell = Bound::new(py, SomeClass(0)).unwrap();
             let ptr = cell.as_ptr();
 
@@ -774,7 +774,7 @@ mod tests {
 
     #[test]
     fn test_pyref_as_super() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = SubSubClass::new(py).into_bound(py);
             let pyref = obj.borrow();
             assert_eq!(pyref.as_super().as_super().val1, 10);
@@ -787,7 +787,7 @@ mod tests {
 
     #[test]
     fn test_pyrefmut_as_super() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = SubSubClass::new(py).into_bound(py);
             assert_eq!(SubSubClass::get_values(obj.borrow()), (10, 15, 20));
             {
@@ -806,7 +806,7 @@ mod tests {
 
     #[test]
     fn test_pyrefs_in_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = SubSubClass::new(py);
             crate::py_run!(py, obj, "assert obj.get_values() == (10, 15, 20)");
             crate::py_run!(py, obj, "assert obj.double_values() is None");

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -449,7 +449,7 @@ mod tests {
 
     #[test]
     fn test_mutable_borrow_prevents_further_borrows() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mmm = Py::new(
                 py,
                 PyClassInitializer::from(MutableBase)
@@ -500,7 +500,7 @@ mod tests {
 
     #[test]
     fn test_immutable_borrows_prevent_mutable_borrows() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mmm = Py::new(
                 py,
                 PyClassInitializer::from(MutableBase)
@@ -552,7 +552,7 @@ mod tests {
             x: u64,
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let inst = Py::new(py, MyClass { x: 0 }).unwrap();
 
             let total_modifications = py.allow_threads(|| {
@@ -562,7 +562,7 @@ mod tests {
                     let threads = (0..10)
                         .map(|_| {
                             s.spawn(|| {
-                                Python::with_gil(|py| {
+                                Python::attach(|py| {
                                     // Each thread records its own view of how many writes it made
                                     let mut local_modifications = 0;
                                     for _ in 0..100 {

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -51,7 +51,7 @@ use std::{
 ///             })
 ///     }
 /// }
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let typeobj = py.get_type::<SubSubClass>();
 ///     let sub_sub_class = typeobj.call((), None).unwrap();
 ///     py_run!(
@@ -120,7 +120,7 @@ impl<T: PyClass> PyClassInitializer<T> {
     /// }
     ///
     /// fn main() -> PyResult<()> {
-    ///     Python::with_gil(|py| {
+    ///     Python::attach(|py| {
     ///         let m = PyModule::new(py, "example")?;
     ///         m.add_class::<SubClass>()?;
     ///         m.add_class::<BaseClass>()?;
@@ -287,7 +287,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn add_subclass_to_py_is_unsound() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let base = Py::new(py, BaseClass {}).unwrap();
             let _subclass = PyClassInitializer::from(base).add_subclass(SubClass { _data: 42 });
         });

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -107,7 +107,7 @@ with warnings.catch_warnings(record=True) as warning_record:
     #[macro_export]
     macro_rules! py_expect_warning_for_fn {
         ($fn:ident, $($val:ident)+, [$(($warning_msg:literal, $warning_category:path)),+] $(,)?) => {
-            pyo3::Python::with_gil(|py| {
+            pyo3::Python::attach(|py| {
                 let f = wrap_pyfunction!($fn)(py).unwrap();
                 py_expect_warning!(
                     py,

--- a/src/tests/hygiene/pyfunction.rs
+++ b/src/tests/hygiene/pyfunction.rs
@@ -26,7 +26,7 @@ fn multiple_warning_function() {}
 
 #[test]
 fn invoke_wrap_pyfunction() {
-    crate::Python::with_gil(|py| {
+    crate::Python::attach(|py| {
         let func = crate::wrap_pyfunction!(do_something, py).unwrap();
         crate::py_run!(py, func, r#"func(5)"#);
     });

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -84,7 +84,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///     sys.hasattr(intern!(sys.py(), "version"))
     /// }
     /// #
-    /// # Python::with_gil(|py| {
+    /// # Python::attach(|py| {
     /// #    let sys = py.import("sys").unwrap();
     /// #    has_version(&sys).unwrap();
     /// # });
@@ -110,7 +110,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///     sys.getattr(intern!(sys.py(), "version"))
     /// }
     /// #
-    /// # Python::with_gil(|py| {
+    /// # Python::attach(|py| {
     /// #    let sys = py.import("sys").unwrap();
     /// #    version(&sys).unwrap();
     /// # });
@@ -141,7 +141,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///     sys.getattr_opt(intern!(sys.py(), "version"))
     /// }
     /// #
-    /// # Python::with_gil(|py| {
+    /// # Python::attach(|py| {
     /// #    let sys = py.import("sys").unwrap();
     /// #    let version = get_version_if_exists(&sys).unwrap();
     /// #    assert!(version.is_some());
@@ -168,7 +168,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///     ob.setattr(intern!(ob.py(), "answer"), 42)
     /// }
     /// #
-    /// # Python::with_gil(|py| {
+    /// # Python::attach(|py| {
     /// #    let ob = PyModule::new(py, "empty").unwrap();
     /// #    set_answer(&ob).unwrap();
     /// # });
@@ -210,7 +210,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use std::cmp::Ordering;
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let a = PyFloat::new(py, 0_f64);
     ///     let b = PyFloat::new(py, 42_f64);
     ///     assert_eq!(a.compare(b)?, Ordering::Less);
@@ -226,7 +226,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::types::{PyFloat, PyString};
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let a = PyFloat::new(py, 0_f64);
     ///     let b = PyString::new(py, "zero");
     ///     assert!(a.compare(b).is_err());
@@ -263,7 +263,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::prelude::*;
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let a = 0_u8.into_pyobject(py)?;
     ///     let b = 42_u8.into_pyobject(py)?;
     ///     assert!(a.rich_compare(b, CompareOp::Le)?.is_truthy()?);
@@ -417,7 +417,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::prelude::*;
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let builtins = PyModule::import(py, "builtins")?;
     ///     let print = builtins.getattr("print")?;
     ///     assert!(print.is_callable());
@@ -456,7 +456,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// "#);
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let module = PyModule::from_code(py, CODE, c_str!("func.py"), c_str!(""))?;
     ///     let fun = module.getattr("function")?;
     ///     let args = ("hello",);
@@ -482,7 +482,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::prelude::*;
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let module = PyModule::import(py, "builtins")?;
     ///     let help = module.getattr("help")?;
     ///     help.call0()?;
@@ -513,7 +513,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// "#);
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let module = PyModule::from_code(py, CODE, c_str!("func.py"), c_str!(""))?;
     ///     let fun = module.getattr("function")?;
     ///     let args = ("hello",);
@@ -552,7 +552,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// "#);
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let module = PyModule::from_code(py, CODE, c_str!("a.py"), c_str!(""))?;
     ///     let instance = module.getattr("a")?;
     ///     let args = ("hello",);
@@ -598,7 +598,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// "#);
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let module = PyModule::from_code(py, CODE, c_str!("a.py"), c_str!(""))?;
     ///     let instance = module.getattr("a")?;
     ///     let result = instance.call_method0("method")?;
@@ -635,7 +635,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// "#);
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let module = PyModule::from_code(py, CODE, c_str!("a.py"), c_str!(""))?;
     ///     let instance = module.getattr("a")?;
     ///     let args = ("hello",);
@@ -706,7 +706,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///     }
     /// }
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     assert!(is_iterable(&vec![1, 2, 3].into_pyobject(py).unwrap()));
     ///     assert!(!is_iterable(&PyNone::get(py)));
     /// });
@@ -733,7 +733,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::prelude::*;
     /// use pyo3::types::{PyDict, PyList};
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let dict = PyDict::new(py);
     ///     assert!(dict.is_instance_of::<PyAny>());
     ///     let any = dict.as_any();
@@ -757,7 +757,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     ///     i: i32,
     /// }
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let class = Py::new(py, Class { i: 0 }).unwrap().into_bound(py).into_any();
     ///
     ///     let class_bound: &Bound<'_, Class> = class.downcast()?;
@@ -785,7 +785,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::prelude::*;
     /// use pyo3::types::{PyDict, PyList};
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let obj: Bound<'_, PyAny> = PyDict::new(py).into_any();
     ///
     ///     let obj: Bound<'_, PyAny> = match obj.downcast_into::<PyList>() {
@@ -818,7 +818,7 @@ pub trait PyAnyMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::prelude::*;
     /// use pyo3::types::{PyBool, PyInt};
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let b = PyBool::new(py, true);
     ///     assert!(b.is_instance_of::<PyBool>());
     ///     let any: &Bound<'_, PyAny> = b.as_any();
@@ -1644,7 +1644,7 @@ mod tests {
 
     #[test]
     fn test_lookup_special() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module = PyModule::from_code(
                 py,
                 c_str!(
@@ -1718,7 +1718,7 @@ class NonHeapNonDescriptorInt:
 
     #[test]
     fn test_getattr_opt() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module = PyModule::from_code(
                 py,
                 c_str!(
@@ -1763,7 +1763,7 @@ class Test:
 
     #[test]
     fn test_call_for_non_existing_method() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let a = py.eval(ffi::c_str!("42"), None, None).unwrap();
             a.call_method0("__str__").unwrap(); // ok
             assert!(a.call_method("nonexistent_method", (1,), None).is_err());
@@ -1774,7 +1774,7 @@ class Test:
 
     #[test]
     fn test_call_with_kwargs() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = vec![3, 6, 5, 4, 7].into_pyobject(py).unwrap();
             let dict = vec![("reverse", true)].into_py_dict(py).unwrap();
             list.call_method("sort", (), Some(&dict)).unwrap();
@@ -1784,7 +1784,7 @@ class Test:
 
     #[test]
     fn test_call_method0() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module = PyModule::from_code(
                 py,
                 c_str!(
@@ -1813,7 +1813,7 @@ class SimpleClass:
 
     #[test]
     fn test_type() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("42"), None, None).unwrap();
             assert_eq!(obj.get_type().as_type_ptr(), obj.get_type_ptr());
         });
@@ -1821,7 +1821,7 @@ class SimpleClass:
 
     #[test]
     fn test_dir() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("42"), None, None).unwrap();
             let dir = py
                 .eval(ffi::c_str!("dir(42)"), None, None)
@@ -1840,7 +1840,7 @@ class SimpleClass:
 
     #[test]
     fn test_hasattr() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let x = 5i32.into_pyobject(py).unwrap();
             assert!(x.is_instance_of::<PyInt>());
 
@@ -1866,7 +1866,7 @@ class SimpleClass:
             }
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = Py::new(py, GetattrFail).unwrap();
             let obj = obj.bind(py).as_any();
 
@@ -1879,7 +1879,7 @@ class SimpleClass:
 
     #[test]
     fn test_nan_eq() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let nan = py.eval(ffi::c_str!("float('nan')"), None, None).unwrap();
             assert!(nan.compare(&nan).is_err());
         });
@@ -1887,7 +1887,7 @@ class SimpleClass:
 
     #[test]
     fn test_any_is_instance_of() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let x = 5i32.into_pyobject(py).unwrap();
             assert!(x.is_instance_of::<PyInt>());
 
@@ -1898,7 +1898,7 @@ class SimpleClass:
 
     #[test]
     fn test_any_is_instance() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let l = vec![1i8, 2].into_pyobject(py).unwrap();
             assert!(l.is_instance(&py.get_type::<PyList>()).unwrap());
         });
@@ -1906,7 +1906,7 @@ class SimpleClass:
 
     #[test]
     fn test_any_is_exact_instance_of() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let x = 5i32.into_pyobject(py).unwrap();
             assert!(x.is_exact_instance_of::<PyInt>());
 
@@ -1922,7 +1922,7 @@ class SimpleClass:
 
     #[test]
     fn test_any_is_exact_instance() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let t = PyBool::new(py, true);
             assert!(t.is_instance(&py.get_type::<PyInt>()).unwrap());
             assert!(!t.is_exact_instance(&py.get_type::<PyInt>()));
@@ -1932,7 +1932,7 @@ class SimpleClass:
 
     #[test]
     fn test_any_contains() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.into_pyobject(py).unwrap();
 
@@ -1959,7 +1959,7 @@ class SimpleClass:
         for<'py> &'a T: IntoPyObject<'py>,
         for<'py> <&'a T as IntoPyObject<'py>>::Error: Debug,
     {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             for a in list {
                 for b in list {
                     let a_py = a.into_pyobject(py).unwrap().into_any().into_bound();
@@ -2053,7 +2053,7 @@ class SimpleClass:
 
     #[test]
     fn test_rich_compare_type_error() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_int = 1i32.into_pyobject(py).unwrap();
             let py_str = "1".into_pyobject(py).unwrap();
 
@@ -2068,7 +2068,7 @@ class SimpleClass:
 
     #[test]
     fn test_is_callable() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyList::type_object(py).is_callable());
 
             let not_callable = 5i32.into_pyobject(py).unwrap();
@@ -2078,7 +2078,7 @@ class SimpleClass:
 
     #[test]
     fn test_is_empty() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let empty_list = PyList::empty(py).into_any();
             assert!(empty_list.is_empty().unwrap());
 
@@ -2107,7 +2107,7 @@ class SimpleClass:
             }
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = Bound::new(py, DirFail).unwrap();
             assert!(obj.dir().unwrap_err().is_instance_of::<PyValueError>(py));
         })

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn test_true() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyBool::new(py, true).is_true());
             let t = PyBool::new(py, true);
             assert!(t.extract::<bool>().unwrap());
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_false() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(!PyBool::new(py, false).is_true());
             let t = PyBool::new(py, false);
             assert!(!t.extract::<bool>().unwrap());
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn test_pybool_comparisons() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_bool = PyBool::new(py, true);
             let py_bool_false = PyBool::new(py, false);
             let rust_bool = true;

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -45,7 +45,7 @@ impl PyByteArray {
     /// use pyo3::{prelude::*, types::PyByteArray};
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let py_bytearray = PyByteArray::new_with(py, 10, |bytes: &mut [u8]| {
     ///         bytes.copy_from_slice(b"Hello Rust");
     ///         Ok(())
@@ -155,7 +155,7 @@ pub trait PyByteArrayMethods<'py>: crate::sealed::Sealed {
     ///     Ok(())
     /// }
     /// # fn main() -> PyResult<()> {
-    /// #     Python::with_gil(|py| -> PyResult<()> {
+    /// #     Python::attach(|py| -> PyResult<()> {
     /// #         let fun = wrap_pyfunction!(a_valid_function, py)?;
     /// #         let locals = pyo3::types::PyDict::new(py);
     /// #         locals.set_item("a_valid_function", fun)?;
@@ -222,7 +222,7 @@ pub trait PyByteArrayMethods<'py>: crate::sealed::Sealed {
     /// ```
     /// # use pyo3::prelude::*;
     /// # use pyo3::types::PyByteArray;
-    /// # Python::with_gil(|py| {
+    /// # Python::attach(|py| {
     /// let bytearray = PyByteArray::new(py, b"Hello World.");
     /// let mut copied_message = bytearray.to_vec();
     /// assert_eq!(b"Hello World.", copied_message.as_slice());
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn test_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let src = b"Hello Python";
             let bytearray = PyByteArray::new(py, src);
             assert_eq!(src.len(), bytearray.len());
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn test_as_bytes() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let src = b"Hello Python";
             let bytearray = PyByteArray::new(py, src);
 
@@ -336,7 +336,7 @@ mod tests {
 
     #[test]
     fn test_as_bytes_mut() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let src = b"Hello Python";
             let bytearray = PyByteArray::new(py, src);
 
@@ -352,7 +352,7 @@ mod tests {
 
     #[test]
     fn test_to_vec() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let src = b"Hello Python";
             let bytearray = PyByteArray::new(py, src);
 
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_from() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let src = b"Hello Python";
             let bytearray = PyByteArray::new(py, src);
 
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn test_from_err() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             if let Err(err) = PyByteArray::from(py.None().bind(py)) {
                 assert!(err.is_instance_of::<exceptions::PyTypeError>(py));
             } else {
@@ -387,7 +387,7 @@ mod tests {
 
     #[test]
     fn test_try_from() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let src = b"Hello Python";
             let bytearray: &Bound<'_, PyAny> = &PyByteArray::new(py, src);
             let bytearray: Bound<'_, PyByteArray> = TryInto::try_into(bytearray).unwrap();
@@ -398,7 +398,7 @@ mod tests {
 
     #[test]
     fn test_resize() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let src = b"Hello Python";
             let bytearray = PyByteArray::new(py, src);
 
@@ -409,7 +409,7 @@ mod tests {
 
     #[test]
     fn test_byte_array_new_with() -> super::PyResult<()> {
-        Python::with_gil(|py| -> super::PyResult<()> {
+        Python::attach(|py| -> super::PyResult<()> {
             let py_bytearray = PyByteArray::new_with(py, 10, |b: &mut [u8]| {
                 b.copy_from_slice(b"Hello Rust");
                 Ok(())
@@ -422,7 +422,7 @@ mod tests {
 
     #[test]
     fn test_byte_array_new_with_zero_initialised() -> super::PyResult<()> {
-        Python::with_gil(|py| -> super::PyResult<()> {
+        Python::attach(|py| -> super::PyResult<()> {
             let py_bytearray = PyByteArray::new_with(py, 10, |_b: &mut [u8]| Ok(()))?;
             let bytearray: &[u8] = unsafe { py_bytearray.as_bytes() };
             assert_eq!(bytearray, &[0; 10]);
@@ -433,7 +433,7 @@ mod tests {
     #[test]
     fn test_byte_array_new_with_error() {
         use crate::exceptions::PyValueError;
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_bytearray_result = PyByteArray::new_with(py, 10, |_b: &mut [u8]| {
                 Err(PyValueError::new_err("Hello Crustaceans!"))
             });

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -29,7 +29,7 @@ use std::str;
 /// # use pyo3::prelude::*;
 /// use pyo3::types::PyBytes;
 ///
-/// # Python::with_gil(|py| {
+/// # Python::attach(|py| {
 /// let py_bytes = PyBytes::new(py, b"foo".as_slice());
 /// // via PartialEq<[u8]>
 /// assert_eq!(py_bytes, b"foo".as_slice());
@@ -77,7 +77,7 @@ impl PyBytes {
     /// use pyo3::{prelude::*, types::PyBytes};
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let py_bytes = PyBytes::new_with(py, 10, |bytes: &mut [u8]| {
     ///         bytes.copy_from_slice(b"Hello Rust");
     ///         Ok(())
@@ -281,7 +281,7 @@ mod tests {
 
     #[test]
     fn test_bytes_index() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes = PyBytes::new(py, b"Hello World");
             assert_eq!(bytes[1], b'e');
         });
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_bound_bytes_index() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bytes = PyBytes::new(py, b"Hello World");
             assert_eq!(bytes[1], b'e');
 
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn test_bytes_new_with() -> super::PyResult<()> {
-        Python::with_gil(|py| -> super::PyResult<()> {
+        Python::attach(|py| -> super::PyResult<()> {
             let py_bytes = PyBytes::new_with(py, 10, |b: &mut [u8]| {
                 b.copy_from_slice(b"Hello Rust");
                 Ok(())
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_bytes_new_with_zero_initialised() -> super::PyResult<()> {
-        Python::with_gil(|py| -> super::PyResult<()> {
+        Python::attach(|py| -> super::PyResult<()> {
             let py_bytes = PyBytes::new_with(py, 10, |_b: &mut [u8]| Ok(()))?;
             let bytes: &[u8] = py_bytes.extract()?;
             assert_eq!(bytes, &[0; 10]);
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     fn test_bytes_new_with_error() {
         use crate::exceptions::PyValueError;
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_bytes_result = PyBytes::new_with(py, 10, |_b: &mut [u8]| {
                 Err(PyValueError::new_err("Hello Crustaceans!"))
             });
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_comparisons() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let b = b"hello, world".as_slice();
             let py_bytes = PyBytes::new(py, b);
 
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     #[cfg(not(Py_LIMITED_API))]
     fn test_as_string() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let b = b"hello, world".as_slice();
             let py_bytes = PyBytes::new(py, b);
             unsafe {

--- a/src/types/code.rs
+++ b/src/types/code.rs
@@ -22,7 +22,7 @@ mod tests {
 
     #[test]
     fn test_type_object() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert_eq!(PyCode::type_object(py).name().unwrap(), "code");
         })
     }

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -127,7 +127,7 @@ mod not_limited_impls {
 
         #[test]
         fn test_add() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let l = PyComplex::from_doubles(py, 3.0, 1.2);
                 let r = PyComplex::from_doubles(py, 1.0, 2.6);
                 let res = l + r;
@@ -138,7 +138,7 @@ mod not_limited_impls {
 
         #[test]
         fn test_sub() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let l = PyComplex::from_doubles(py, 3.0, 1.2);
                 let r = PyComplex::from_doubles(py, 1.0, 2.6);
                 let res = l - r;
@@ -149,7 +149,7 @@ mod not_limited_impls {
 
         #[test]
         fn test_mul() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let l = PyComplex::from_doubles(py, 3.0, 1.2);
                 let r = PyComplex::from_doubles(py, 1.0, 2.6);
                 let res = l * r;
@@ -160,7 +160,7 @@ mod not_limited_impls {
 
         #[test]
         fn test_div() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let l = PyComplex::from_doubles(py, 3.0, 1.2);
                 let r = PyComplex::from_doubles(py, 1.0, 2.6);
                 let res = l / r;
@@ -171,7 +171,7 @@ mod not_limited_impls {
 
         #[test]
         fn test_neg() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let val = PyComplex::from_doubles(py, 3.0, 1.2);
                 let res = -val;
                 assert_approx_eq!(res.real(), -3.0);
@@ -181,7 +181,7 @@ mod not_limited_impls {
 
         #[test]
         fn test_abs() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let val = PyComplex::from_doubles(py, 3.0, 1.2);
                 assert_approx_eq!(val.abs(), 3.231_098_884_280_702_2);
             });
@@ -189,7 +189,7 @@ mod not_limited_impls {
 
         #[test]
         fn test_pow() {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let l = PyComplex::from_doubles(py, 3.0, 1.2);
                 let r = PyComplex::from_doubles(py, 1.2, 2.6);
                 let val = l.pow(&r);
@@ -239,7 +239,7 @@ impl<'py> PyComplexMethods<'py> for Bound<'py, PyComplex> {
 
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn pow(&self, other: &Bound<'py, PyComplex>) -> Bound<'py, PyComplex> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             PyAnyMethods::pow(self.as_any(), other, py.None())
                 .downcast_into()
                 .expect("Complex method __pow__ failed.")
@@ -257,7 +257,7 @@ mod tests {
     fn test_from_double() {
         use assert_approx_eq::assert_approx_eq;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let complex = PyComplex::from_doubles(py, 3.0, 1.2);
             assert_approx_eq!(complex.real(), 3.0);
             assert_approx_eq!(complex.imag(), 1.2);

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -976,7 +976,7 @@ mod tests {
     #[cfg(feature = "macros")]
     #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_datetime_fromtimestamp() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dt = PyDateTime::from_timestamp(py, 100.0, None).unwrap();
             py_run!(
                 py,
@@ -998,7 +998,7 @@ mod tests {
     #[cfg(feature = "macros")]
     #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_date_fromtimestamp() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dt = PyDate::from_timestamp(py, 100).unwrap();
             py_run!(
                 py,
@@ -1012,7 +1012,7 @@ mod tests {
     #[cfg(not(Py_LIMITED_API))]
     #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_new_with_fold() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let a = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, false);
             let b = PyDateTime::new_with_fold(py, 2021, 1, 23, 20, 32, 40, 341516, None, true);
 
@@ -1024,7 +1024,7 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", ignore)] // DateTime import fails on wasm for mysterious reasons
     fn test_get_tzinfo() {
-        crate::Python::with_gil(|py| {
+        crate::Python::attach(|py| {
             let utc = PyTzInfo::utc(py).unwrap();
 
             let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(&utc)).unwrap();
@@ -1051,7 +1051,7 @@ mod tests {
     fn test_timezone_from_offset() {
         use crate::types::PyNone;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(
                 PyTzInfo::fixed_offset(py, PyDelta::new(py, 0, -3600, 0, true).unwrap())
                     .unwrap()

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -819,7 +819,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [(7, 32)].into_py_dict(py).unwrap();
             assert_eq!(
                 32,
@@ -840,7 +840,7 @@ mod tests {
     #[test]
     #[cfg(not(any(PyPy, GraalPy)))]
     fn test_from_sequence() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let items = PyList::new(py, vec![("a", 1), ("b", 2)]).unwrap();
             let dict = PyDict::from_sequence(&items).unwrap();
             assert_eq!(
@@ -871,7 +871,7 @@ mod tests {
     #[test]
     #[cfg(not(any(PyPy, GraalPy)))]
     fn test_from_sequence_err() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let items = PyList::new(py, vec!["a", "b"]).unwrap();
             assert!(PyDict::from_sequence(&items).is_err());
         });
@@ -879,7 +879,7 @@ mod tests {
 
     #[test]
     fn test_copy() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [(7, 32)].into_py_dict(py).unwrap();
 
             let ndict = dict.copy().unwrap();
@@ -898,7 +898,7 @@ mod tests {
 
     #[test]
     fn test_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::<i32, i32>::new();
             let dict = (&v).into_pyobject(py).unwrap();
             assert_eq!(0, dict.len());
@@ -910,7 +910,7 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let dict = v.into_pyobject(py).unwrap();
@@ -921,7 +921,7 @@ mod tests {
 
     #[test]
     fn test_get_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let dict = v.into_pyobject(py).unwrap();
@@ -957,7 +957,7 @@ mod tests {
             }
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let class = py.get_type::<HashErrors>();
             let instance = class.call0().unwrap();
             let d = PyDict::new(py);
@@ -975,7 +975,7 @@ mod tests {
 
     #[test]
     fn test_set_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let dict = v.into_pyobject(py).unwrap();
@@ -1002,7 +1002,7 @@ mod tests {
 
     #[test]
     fn test_set_item_refcnt() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let cnt;
             let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             {
@@ -1017,7 +1017,7 @@ mod tests {
 
     #[test]
     fn test_set_item_does_not_update_original_object() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let dict = (&v).into_pyobject(py).unwrap();
@@ -1030,7 +1030,7 @@ mod tests {
 
     #[test]
     fn test_del_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let dict = v.into_pyobject(py).unwrap();
@@ -1042,7 +1042,7 @@ mod tests {
 
     #[test]
     fn test_del_item_does_not_update_original_object() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let dict = (&v).into_pyobject(py).unwrap();
@@ -1053,7 +1053,7 @@ mod tests {
 
     #[test]
     fn test_items() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -1074,7 +1074,7 @@ mod tests {
 
     #[test]
     fn test_keys() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -1091,7 +1091,7 @@ mod tests {
 
     #[test]
     fn test_values() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -1108,7 +1108,7 @@ mod tests {
 
     #[test]
     fn test_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -1127,7 +1127,7 @@ mod tests {
 
     #[test]
     fn test_iter_bound() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -1146,7 +1146,7 @@ mod tests {
 
     #[test]
     fn test_iter_value_mutated() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -1164,7 +1164,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_iter_key_mutated() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             for i in 0..10 {
                 v.insert(i * 2, i * 2);
@@ -1188,7 +1188,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_iter_key_mutated_constant_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             for i in 0..10 {
                 v.insert(i * 2, i * 2);
@@ -1211,7 +1211,7 @@ mod tests {
 
     #[test]
     fn test_iter_size_hint() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -1236,7 +1236,7 @@ mod tests {
 
     #[test]
     fn test_into_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -1255,7 +1255,7 @@ mod tests {
 
     #[test]
     fn test_hashmap_into_dict() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -1276,7 +1276,7 @@ mod tests {
 
     #[test]
     fn test_btreemap_into_dict() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = BTreeMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -1297,7 +1297,7 @@ mod tests {
 
     #[test]
     fn test_vec_into_dict() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let vec = vec![("a", 1), ("b", 2), ("c", 3)];
             let py_map = vec.into_py_dict(py).unwrap();
 
@@ -1316,7 +1316,7 @@ mod tests {
 
     #[test]
     fn test_slice_into_dict() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let arr = [("a", 1), ("b", 2), ("c", 3)];
             let py_map = arr.into_py_dict(py).unwrap();
 
@@ -1335,7 +1335,7 @@ mod tests {
 
     #[test]
     fn dict_as_mapping() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -1356,7 +1356,7 @@ mod tests {
 
     #[test]
     fn dict_into_mapping() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -1380,7 +1380,7 @@ mod tests {
     #[test]
     #[cfg(not(any(PyPy, GraalPy)))]
     fn dict_keys_view() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = abc_dict(py);
             let keys = dict.call_method0("keys").unwrap();
             assert!(keys.is_instance(&py.get_type::<PyDictKeys>()).unwrap());
@@ -1390,7 +1390,7 @@ mod tests {
     #[test]
     #[cfg(not(any(PyPy, GraalPy)))]
     fn dict_values_view() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = abc_dict(py);
             let values = dict.call_method0("values").unwrap();
             assert!(values.is_instance(&py.get_type::<PyDictValues>()).unwrap());
@@ -1400,7 +1400,7 @@ mod tests {
     #[test]
     #[cfg(not(any(PyPy, GraalPy)))]
     fn dict_items_view() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = abc_dict(py);
             let items = dict.call_method0("items").unwrap();
             assert!(items.is_instance(&py.get_type::<PyDictItems>()).unwrap());
@@ -1409,7 +1409,7 @@ mod tests {
 
     #[test]
     fn dict_update() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [("a", 1), ("b", 2), ("c", 3)].into_py_dict(py).unwrap();
             let other = [("b", 4), ("c", 5), ("d", 6)].into_py_dict(py).unwrap();
             dict.update(other.as_mapping()).unwrap();
@@ -1480,7 +1480,7 @@ mod tests {
 
     #[test]
     fn dict_update_if_missing() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [("a", 1), ("b", 2), ("c", 3)].into_py_dict(py).unwrap();
             let other = [("b", 4), ("c", 5), ("d", 6)].into_py_dict(py).unwrap();
             dict.update_if_missing(other.as_mapping()).unwrap();
@@ -1551,7 +1551,7 @@ mod tests {
 
     #[test]
     fn test_iter_all() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [(1, true), (2, true), (3, true)].into_py_dict(py).unwrap();
             assert!(dict.iter().all(|(_, v)| v.extract::<bool>().unwrap()));
 
@@ -1562,7 +1562,7 @@ mod tests {
 
     #[test]
     fn test_iter_any() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [(1, true), (2, false), (3, false)]
                 .into_py_dict(py)
                 .unwrap();
@@ -1578,7 +1578,7 @@ mod tests {
     #[test]
     #[allow(clippy::search_is_some)]
     fn test_iter_find() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [(1, false), (2, true), (3, false)]
                 .into_py_dict(py)
                 .unwrap();
@@ -1604,7 +1604,7 @@ mod tests {
     #[test]
     #[allow(clippy::search_is_some)]
     fn test_iter_position() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [(1, false), (2, false), (3, true)]
                 .into_py_dict(py)
                 .unwrap();
@@ -1625,7 +1625,7 @@ mod tests {
 
     #[test]
     fn test_iter_fold() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [(1, 1), (2, 2), (3, 3)].into_py_dict(py).unwrap();
             let sum = dict
                 .iter()
@@ -1636,7 +1636,7 @@ mod tests {
 
     #[test]
     fn test_iter_try_fold() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [(1, 1), (2, 2), (3, 3)].into_py_dict(py).unwrap();
             let sum = dict
                 .iter()
@@ -1654,7 +1654,7 @@ mod tests {
 
     #[test]
     fn test_iter_count() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict = [(1, 1), (2, 2), (3, 3)].into_py_dict(py).unwrap();
             assert_eq!(dict.iter().count(), 3);
         })

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -49,7 +49,7 @@ mod tests {
 
     #[test]
     fn test_ellipsis_is_itself() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyEllipsis::get(py).is_instance_of::<PyEllipsis>());
             assert!(PyEllipsis::get(py).is_exact_instance_of::<PyEllipsis>());
         })
@@ -57,7 +57,7 @@ mod tests {
 
     #[test]
     fn test_ellipsis_type_object_consistent() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyEllipsis::get(py)
                 .get_type()
                 .is(PyEllipsis::type_object(py)));
@@ -66,7 +66,7 @@ mod tests {
 
     #[test]
     fn test_dict_is_not_ellipsis() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyDict::new(py).downcast::<PyEllipsis>().is_err());
         })
     }

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -271,7 +271,7 @@ mod tests {
             fn $func_name() {
                 use assert_approx_eq::assert_approx_eq;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
 
                 let val = 123 as $t1;
                 let obj = val.into_pyobject(py).unwrap();
@@ -289,7 +289,7 @@ mod tests {
     fn test_float_value() {
         use assert_approx_eq::assert_approx_eq;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = 1.23f64;
             let obj = PyFloat::new(py, 1.23);
             assert_approx_eq!(v, obj.value());
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_pyfloat_comparisons() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let f_64 = 1.01f64;
             let py_f64 = PyFloat::new(py, 1.01);
             let py_f64_ref = &py_f64;

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_frozenset_new_and_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PyFrozenSet::new(py, [1]).unwrap();
             assert_eq!(1, set.len());
 
@@ -269,7 +269,7 @@ mod tests {
 
     #[test]
     fn test_frozenset_empty() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PyFrozenSet::empty(py).unwrap();
             assert_eq!(0, set.len());
             assert!(set.is_empty());
@@ -278,7 +278,7 @@ mod tests {
 
     #[test]
     fn test_frozenset_contains() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PyFrozenSet::new(py, [1]).unwrap();
             assert!(set.contains(1).unwrap());
         });
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn test_frozenset_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PyFrozenSet::new(py, [1]).unwrap();
 
             for el in set {
@@ -297,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_frozenset_iter_bound() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PyFrozenSet::new(py, [1]).unwrap();
 
             for el in &set {
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_frozenset_iter_size_hint() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PyFrozenSet::new(py, [1]).unwrap();
             let mut iter = set.iter();
 
@@ -325,7 +325,7 @@ mod tests {
     fn test_frozenset_builder() {
         use super::PyFrozenSetBuilder;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut builder = PyFrozenSetBuilder::new(py).unwrap();
 
             // add an item
@@ -344,7 +344,7 @@ mod tests {
 
     #[test]
     fn test_iter_count() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PyFrozenSet::new(py, vec![1, 2, 3]).unwrap();
             assert_eq!(set.iter().count(), 3);
         })

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -61,7 +61,7 @@ impl PyCFunction {
     /// # use pyo3::prelude::*;
     /// # use pyo3::{py_run, types::{PyCFunction, PyDict, PyTuple}};
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let add_one = |args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>| -> PyResult<_> {
     ///         let i = args.extract::<(i64,)>()?.0;
     ///         Ok(i+1)

--- a/src/types/genericalias.rs
+++ b/src/types/genericalias.rs
@@ -50,7 +50,7 @@ mod tests {
     // created from Python.
     #[test]
     fn equivalency_test() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list_int = py
                 .eval(ffi::c_str!("list[int]"), None, None)
                 .unwrap()

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -15,7 +15,7 @@ use crate::{ffi, Bound, PyAny, PyErr, PyResult, PyTypeCheck};
 /// use pyo3::ffi::c_str;
 ///
 /// # fn main() -> PyResult<()> {
-/// Python::with_gil(|py| -> PyResult<()> {
+/// Python::attach(|py| -> PyResult<()> {
 ///     let list = py.eval(c_str!("iter([1, 2, 3, 4])"), None, None)?;
 ///     let numbers: PyResult<Vec<usize>> = list
 ///         .try_iter()?
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn vec_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let inst = vec![10, 20].into_pyobject(py).unwrap();
             let mut it = inst.try_iter().unwrap();
             assert_eq!(
@@ -157,13 +157,13 @@ mod tests {
 
     #[test]
     fn iter_refcnt() {
-        let (obj, count) = Python::with_gil(|py| {
+        let (obj, count) = Python::attach(|py| {
             let obj = vec![10, 20].into_pyobject(py).unwrap();
             let count = obj.get_refcnt();
             (obj.unbind(), count)
         });
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let inst = obj.bind(py);
             let mut it = inst.try_iter().unwrap();
 
@@ -173,14 +173,14 @@ mod tests {
             );
         });
 
-        Python::with_gil(move |py| {
+        Python::attach(move |py| {
             assert_eq!(count, obj.get_refcnt(py));
         });
     }
 
     #[test]
     fn iter_item_refcnt() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let count;
             let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             let list = {
@@ -215,7 +215,7 @@ def fibonacci(target):
 "#
         );
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let context = PyDict::new(py);
             py.run(fibonacci_generator, None, Some(&context)).unwrap();
 
@@ -243,7 +243,7 @@ def gen():
 "#
         );
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let context = PyDict::new(py);
             py.run(generator, None, Some(&context)).unwrap();
 
@@ -281,7 +281,7 @@ def fibonacci(target):
 "#
         );
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let context = PyDict::new(py);
             py.run(fibonacci_generator, None, Some(&context)).unwrap();
 
@@ -301,7 +301,7 @@ def fibonacci(target):
 
     #[test]
     fn int_not_iterable() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let x = 5i32.into_pyobject(py).unwrap();
             let err = PyIterator::from_object(&x).unwrap_err();
 
@@ -327,7 +327,7 @@ def fibonacci(target):
         }
 
         // Regression test for 2913
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let downcaster = crate::Py::new(py, Downcaster { failed: None }).unwrap();
             crate::py_run!(
                 py,
@@ -365,7 +365,7 @@ def fibonacci(target):
         }
 
         // Regression test for 2913
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let assert_iterator = crate::wrap_pyfunction!(assert_iterator, py).unwrap();
             crate::py_run!(
                 py,
@@ -384,7 +384,7 @@ def fibonacci(target):
     #[test]
     #[cfg(not(Py_LIMITED_API))]
     fn length_hint_becomes_size_hint_lower_bound() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = py.eval(ffi::c_str!("[1, 2, 3]"), None, None).unwrap();
             let iter = list.try_iter().unwrap();
             let hint = iter.size_hint();

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -72,7 +72,7 @@ impl PyList {
     /// use pyo3::types::PyList;
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let elements: Vec<i32> = vec![0, 1, 2, 3, 4, 5];
     ///     let list = PyList::new(py, elements)?;
     ///     assert_eq!(format!("{:?}", list), "[0, 1, 2, 3, 4, 5]");
@@ -132,7 +132,7 @@ pub trait PyListMethods<'py>: crate::sealed::Sealed {
     /// # Example
     /// ```
     /// use pyo3::{prelude::*, types::PyList};
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
     ///     let obj = list.get_item(0);
     ///     assert_eq!(obj.unwrap().extract::<i32>().unwrap(), 2);
@@ -263,7 +263,7 @@ impl<'py> PyListMethods<'py> for Bound<'py, PyList> {
     /// # Example
     /// ```
     /// use pyo3::{prelude::*, types::PyList};
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
     ///     let obj = list.get_item(0);
     ///     assert_eq!(obj.unwrap().extract::<i32>().unwrap(), 2);
@@ -950,7 +950,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
             assert_eq!(2, list.get_item(0).unwrap().extract::<i32>().unwrap());
             assert_eq!(3, list.get_item(1).unwrap().extract::<i32>().unwrap());
@@ -961,7 +961,7 @@ mod tests {
 
     #[test]
     fn test_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 2, 3, 4]).unwrap();
             assert_eq!(4, list.len());
         });
@@ -969,7 +969,7 @@ mod tests {
 
     #[test]
     fn test_get_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
             assert_eq!(2, list.get_item(0).unwrap().extract::<i32>().unwrap());
             assert_eq!(3, list.get_item(1).unwrap().extract::<i32>().unwrap());
@@ -980,7 +980,7 @@ mod tests {
 
     #[test]
     fn test_get_slice() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
             let slice = list.get_slice(1, 3);
             assert_eq!(2, slice.len());
@@ -991,7 +991,7 @@ mod tests {
 
     #[test]
     fn test_set_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
             let val = 42i32.into_pyobject(py).unwrap();
             let val2 = 42i32.into_pyobject(py).unwrap();
@@ -1004,7 +1004,7 @@ mod tests {
 
     #[test]
     fn test_set_item_refcnt() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             let cnt;
             {
@@ -1021,7 +1021,7 @@ mod tests {
 
     #[test]
     fn test_insert() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
             let val = 42i32.into_pyobject(py).unwrap();
             let val2 = 43i32.into_pyobject(py).unwrap();
@@ -1038,7 +1038,7 @@ mod tests {
 
     #[test]
     fn test_insert_refcnt() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let cnt;
             let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             {
@@ -1053,7 +1053,7 @@ mod tests {
 
     #[test]
     fn test_append() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [2]).unwrap();
             list.append(3).unwrap();
             assert_eq!(2, list.get_item(0).unwrap().extract::<i32>().unwrap());
@@ -1063,7 +1063,7 @@ mod tests {
 
     #[test]
     fn test_append_refcnt() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let cnt;
             let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
             {
@@ -1077,7 +1077,7 @@ mod tests {
 
     #[test]
     fn test_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![2, 3, 5, 7];
             let list = PyList::new(py, &v).unwrap();
             let mut idx = 0;
@@ -1091,7 +1091,7 @@ mod tests {
 
     #[test]
     fn test_iter_size_hint() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![2, 3, 5, 7];
             let ob = (&v).into_pyobject(py).unwrap();
             let list = ob.downcast::<PyList>().unwrap();
@@ -1110,7 +1110,7 @@ mod tests {
 
     #[test]
     fn test_iter_rev() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![2, 3, 5, 7];
             let ob = v.into_pyobject(py).unwrap();
             let list = ob.downcast::<PyList>().unwrap();
@@ -1138,7 +1138,7 @@ mod tests {
 
     #[test]
     fn test_iter_all() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [true, true, true]).unwrap();
             assert!(list.iter().all(|x| x.extract::<bool>().unwrap()));
 
@@ -1149,7 +1149,7 @@ mod tests {
 
     #[test]
     fn test_iter_any() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [true, true, true]).unwrap();
             assert!(list.iter().any(|x| x.extract::<bool>().unwrap()));
 
@@ -1163,7 +1163,7 @@ mod tests {
 
     #[test]
     fn test_iter_find() {
-        Python::with_gil(|py: Python<'_>| {
+        Python::attach(|py: Python<'_>| {
             let list = PyList::new(py, ["hello", "world"]).unwrap();
             assert_eq!(
                 Some("world".to_string()),
@@ -1182,7 +1182,7 @@ mod tests {
 
     #[test]
     fn test_iter_position() {
-        Python::with_gil(|py: Python<'_>| {
+        Python::attach(|py: Python<'_>| {
             let list = PyList::new(py, ["hello", "world"]).unwrap();
             assert_eq!(
                 Some(1),
@@ -1199,7 +1199,7 @@ mod tests {
 
     #[test]
     fn test_iter_fold() {
-        Python::with_gil(|py: Python<'_>| {
+        Python::attach(|py: Python<'_>| {
             let list = PyList::new(py, [1, 2, 3]).unwrap();
             let sum = list
                 .iter()
@@ -1210,7 +1210,7 @@ mod tests {
 
     #[test]
     fn test_iter_fold_out_of_bounds() {
-        Python::with_gil(|py: Python<'_>| {
+        Python::attach(|py: Python<'_>| {
             let list = PyList::new(py, [1, 2, 3]).unwrap();
             let sum = list.iter().fold(0, |_, _| {
                 // clear the list to create a pathological fold operation
@@ -1227,7 +1227,7 @@ mod tests {
 
     #[test]
     fn test_iter_rfold() {
-        Python::with_gil(|py: Python<'_>| {
+        Python::attach(|py: Python<'_>| {
             let list = PyList::new(py, [1, 2, 3]).unwrap();
             let sum = list
                 .iter()
@@ -1238,7 +1238,7 @@ mod tests {
 
     #[test]
     fn test_iter_try_fold() {
-        Python::with_gil(|py: Python<'_>| {
+        Python::attach(|py: Python<'_>| {
             let list = PyList::new(py, [1, 2, 3]).unwrap();
             let sum = list
                 .iter()
@@ -1256,7 +1256,7 @@ mod tests {
 
     #[test]
     fn test_iter_try_rfold() {
-        Python::with_gil(|py: Python<'_>| {
+        Python::attach(|py: Python<'_>| {
             let list = PyList::new(py, [1, 2, 3]).unwrap();
             let sum = list
                 .iter()
@@ -1274,7 +1274,7 @@ mod tests {
 
     #[test]
     fn test_into_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 2, 3, 4]).unwrap();
             for (i, item) in list.iter().enumerate() {
                 assert_eq!((i + 1) as i32, item.extract::<i32>().unwrap());
@@ -1286,7 +1286,7 @@ mod tests {
     fn test_into_iter_bound() {
         use crate::types::any::PyAnyMethods;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 2, 3, 4]).unwrap();
             let mut items = vec![];
             for item in &list {
@@ -1298,7 +1298,7 @@ mod tests {
 
     #[test]
     fn test_as_sequence() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 2, 3, 4]).unwrap();
 
             assert_eq!(list.as_sequence().len().unwrap(), 4);
@@ -1315,7 +1315,7 @@ mod tests {
 
     #[test]
     fn test_into_sequence() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 2, 3, 4]).unwrap();
 
             let sequence = list.into_sequence();
@@ -1327,7 +1327,7 @@ mod tests {
 
     #[test]
     fn test_extract() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![2, 3, 5, 7];
             let list = PyList::new(py, &v).unwrap();
             let v2 = list.as_any().extract::<Vec<i32>>().unwrap();
@@ -1337,7 +1337,7 @@ mod tests {
 
     #[test]
     fn test_sort() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![7, 3, 2, 5];
             let list = PyList::new(py, &v).unwrap();
             assert_eq!(7, list.get_item(0).unwrap().extract::<i32>().unwrap());
@@ -1354,7 +1354,7 @@ mod tests {
 
     #[test]
     fn test_reverse() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![2, 3, 5, 7];
             let list = PyList::new(py, &v).unwrap();
             assert_eq!(2, list.get_item(0).unwrap().extract::<i32>().unwrap());
@@ -1371,7 +1371,7 @@ mod tests {
 
     #[test]
     fn test_array_into_pyobject() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let array = [1, 2].into_pyobject(py).unwrap();
             let list = array.downcast::<PyList>().unwrap();
             assert_eq!(1, list.get_item(0).unwrap().extract::<i32>().unwrap());
@@ -1381,7 +1381,7 @@ mod tests {
 
     #[test]
     fn test_list_get_item_invalid_index() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
             let obj = list.get_item(5);
             assert!(obj.is_err());
@@ -1394,7 +1394,7 @@ mod tests {
 
     #[test]
     fn test_list_get_item_sanity() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
             let obj = list.get_item(0);
             assert_eq!(obj.unwrap().extract::<i32>().unwrap(), 2);
@@ -1404,7 +1404,7 @@ mod tests {
     #[cfg(not(Py_LIMITED_API))]
     #[test]
     fn test_list_get_item_unchecked_sanity() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [2, 3, 5, 7]).unwrap();
             let obj = unsafe { list.get_item_unchecked(0) };
             assert_eq!(obj.extract::<i32>().unwrap(), 2);
@@ -1413,7 +1413,7 @@ mod tests {
 
     #[test]
     fn test_list_del_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 1, 2, 3, 5, 8]).unwrap();
             assert!(list.del_item(10).is_err());
             assert_eq!(1, list.get_item(0).unwrap().extract::<i32>().unwrap());
@@ -1435,7 +1435,7 @@ mod tests {
 
     #[test]
     fn test_list_set_slice() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 1, 2, 3, 5, 8]).unwrap();
             let ins = PyList::new(py, [7, 4]).unwrap();
             list.set_slice(1, 4, &ins).unwrap();
@@ -1447,7 +1447,7 @@ mod tests {
 
     #[test]
     fn test_list_del_slice() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 1, 2, 3, 5, 8]).unwrap();
             list.del_slice(1, 4).unwrap();
             assert_eq!([1, 5, 8], list.extract::<[i32; 3]>().unwrap());
@@ -1458,7 +1458,7 @@ mod tests {
 
     #[test]
     fn test_list_contains() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 1, 2, 3, 5, 8]).unwrap();
             assert_eq!(6, list.len());
 
@@ -1475,7 +1475,7 @@ mod tests {
 
     #[test]
     fn test_list_index() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, [1, 1, 2, 3, 5, 8]).unwrap();
             assert_eq!(0, list.index(1i32).unwrap());
             assert_eq!(2, list.index(2i32).unwrap());
@@ -1511,7 +1511,7 @@ mod tests {
         expected = "Attempted to create PyList but `elements` was larger than reported by its `ExactSizeIterator` implementation."
     )]
     fn too_long_iterator() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let iter = FaultyIter(0..usize::MAX, 73);
             let _list = PyList::new(py, iter).unwrap();
         })
@@ -1522,7 +1522,7 @@ mod tests {
         expected = "Attempted to create PyList but `elements` was smaller than reported by its `ExactSizeIterator` implementation."
     )]
     fn too_short_iterator() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let iter = FaultyIter(0..35, 73);
             let _list = PyList::new(py, iter).unwrap();
         })
@@ -1533,7 +1533,7 @@ mod tests {
         expected = "out of range integral type conversion attempted on `elements.len()`"
     )]
     fn overflowing_size() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let iter = FaultyIter(0..0, usize::MAX);
 
             let _list = PyList::new(py, iter).unwrap();
@@ -1586,7 +1586,7 @@ mod tests {
             }
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             std::panic::catch_unwind(|| {
                 let iter = FaultyIter(0..50, 50);
                 let _list = PyList::new(py, iter).unwrap();
@@ -1603,7 +1603,7 @@ mod tests {
 
     #[test]
     fn test_list_to_tuple() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, vec![1, 2, 3]).unwrap();
             let tuple = list.to_tuple();
             let tuple_expected = PyTuple::new(py, vec![1, 2, 3]).unwrap();
@@ -1613,7 +1613,7 @@ mod tests {
 
     #[test]
     fn test_iter_nth() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![6, 7, 8, 9, 10];
             let ob = (&v).into_pyobject(py).unwrap();
             let list = ob.downcast::<PyList>().unwrap();
@@ -1656,7 +1656,7 @@ mod tests {
 
     #[test]
     fn test_iter_nth_back() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![1, 2, 3, 4, 5];
             let ob = (&v).into_pyobject(py).unwrap();
             let list = ob.downcast::<PyList>().unwrap();
@@ -1714,7 +1714,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[test]
     fn test_iter_advance_by() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![1, 2, 3, 4, 5];
             let ob = (&v).into_pyobject(py).unwrap();
             let list = ob.downcast::<PyList>().unwrap();
@@ -1740,7 +1740,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[test]
     fn test_iter_advance_back_by() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec![1, 2, 3, 4, 5];
             let ob = (&v).into_pyobject(py).unwrap();
             let list = ob.downcast::<PyList>().unwrap();
@@ -1765,7 +1765,7 @@ mod tests {
 
     #[test]
     fn test_iter_last() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, vec![1, 2, 3]).unwrap();
             let last = list.iter().last();
             assert_eq!(last.unwrap().extract::<i32>().unwrap(), 3);
@@ -1774,7 +1774,7 @@ mod tests {
 
     #[test]
     fn test_iter_count() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = PyList::new(py, vec![1, 2, 3]).unwrap();
             assert_eq!(list.iter().count(), 3);
         })

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::<i32, i32>::new();
             let ob = (&v).into_pyobject(py).unwrap();
             let mapping = ob.downcast::<PyMapping>().unwrap();
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert("key0", 1234);
             let ob = v.into_pyobject(py).unwrap();
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_get_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.into_pyobject(py).unwrap();
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn test_set_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.into_pyobject(py).unwrap();
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_del_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let ob = v.into_pyobject(py).unwrap();
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn test_items() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_keys() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_values() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);

--- a/src/types/mappingproxy.rs
+++ b/src/types/mappingproxy.rs
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let pydict = [(7, 32)].into_py_dict(py).unwrap();
             let mappingproxy = PyMappingProxy::new(py, pydict.as_mapping());
             mappingproxy.get_item(7i32).unwrap();
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             let dict = v.clone().into_py_dict(py).unwrap();
             let mappingproxy = PyMappingProxy::new(py, dict.as_mapping());
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let dict = v.clone().into_py_dict(py).unwrap();
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_get_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             let dict = v.clone().into_py_dict(py).unwrap();
@@ -213,7 +213,7 @@ mod tests {
 
     #[test]
     fn test_set_item_refcnt() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let cnt;
             {
                 let none = py.None();
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_isempty() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let map: HashMap<usize, usize> = HashMap::new();
             let dict = map.into_py_dict(py).unwrap();
             let mappingproxy = PyMappingProxy::new(py, dict.as_mapping());
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn test_keys() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn test_values() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v: HashMap<i32, i32> = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_items() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn test_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashMap::new();
             v.insert(7, 32);
             v.insert(8, 42);
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn test_hashmap_into_python() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_hashmap_into_mappingproxy() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_btreemap_into_py() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = BTreeMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_btreemap_into_mappingproxy() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = BTreeMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -375,7 +375,7 @@ mod tests {
 
     #[test]
     fn test_vec_into_mappingproxy() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let vec = vec![("a", 1), ("b", 2), ("c", 3)];
             let dict = vec.clone().into_py_dict(py).unwrap();
             let py_map = PyMappingProxy::new(py, dict.as_mapping());
@@ -387,7 +387,7 @@ mod tests {
 
     #[test]
     fn test_slice_into_mappingproxy() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let arr = [("a", 1), ("b", 2), ("c", 3)];
 
             let dict = arr.into_py_dict(py).unwrap();
@@ -400,7 +400,7 @@ mod tests {
 
     #[test]
     fn mappingproxy_as_mapping() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
 
@@ -433,7 +433,7 @@ mod tests {
     #[test]
     #[cfg(not(any(PyPy, GraalPy)))]
     fn mappingproxy_keys_view() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mappingproxy = abc_mappingproxy(py);
             let keys = mappingproxy.call_method0("keys").unwrap();
             assert!(keys.is_instance(&py.get_type::<PyDictKeys>()).unwrap());
@@ -443,7 +443,7 @@ mod tests {
     #[test]
     #[cfg(not(any(PyPy, GraalPy)))]
     fn mappingproxy_values_view() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mappingproxy = abc_mappingproxy(py);
             let values = mappingproxy.call_method0("values").unwrap();
             assert!(values.is_instance(&py.get_type::<PyDictValues>()).unwrap());
@@ -453,7 +453,7 @@ mod tests {
     #[test]
     #[cfg(not(any(PyPy, GraalPy)))]
     fn mappingproxy_items_view() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mappingproxy = abc_mappingproxy(py);
             let items = mappingproxy.call_method0("items").unwrap();
             assert!(items.is_instance(&py.get_type::<PyDictItems>()).unwrap());
@@ -462,7 +462,7 @@ mod tests {
 
     #[test]
     fn get_value_from_mappingproxy_of_strings() {
-        Python::with_gil(|py: Python<'_>| {
+        Python::attach(|py: Python<'_>| {
             let mut map = HashMap::new();
             map.insert("first key".to_string(), "first value".to_string());
             map.insert("second key".to_string(), "second value".to_string());
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn get_value_from_mappingproxy_of_integers() {
-        Python::with_gil(|py: Python<'_>| {
+        Python::attach(|py: Python<'_>| {
             const LEN: usize = 10_000;
             let items: Vec<(usize, usize)> = (1..LEN).map(|i| (i, i - 1)).collect();
 
@@ -538,7 +538,7 @@ mod tests {
 
     #[test]
     fn iter_mappingproxy_nosegv() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             const LEN: usize = 1_000;
             let items = (0..LEN as u64).map(|i| (i, i * 2));
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -64,7 +64,7 @@ pub use self::weakref::{PyWeakref, PyWeakrefMethods, PyWeakrefProxy, PyWeakrefRe
 /// use pyo3::ffi::c_str;
 ///
 /// # pub fn main() -> PyResult<()> {
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     let dict = py.eval(c_str!("{'a':'b', 'c':'d'}"), None, None)?.downcast_into::<PyDict>()?;
 ///
 ///     for (key, value) in &dict {

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -43,7 +43,7 @@ impl PyModule {
     /// use pyo3::prelude::*;
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let module = PyModule::new(py, "my_module")?;
     ///
     ///     assert_eq!(module.name()?, "my_module");
@@ -68,7 +68,7 @@ impl PyModule {
     /// # fn main() {
     /// use pyo3::prelude::*;
     ///
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let module = PyModule::import(py, "antigravity").expect("No flying for you.");
     /// });
     /// # }
@@ -124,7 +124,7 @@ impl PyModule {
     /// // This path is resolved relative to this file.
     /// let code = c_str!(include_str!("../../assets/script.py"));
     ///
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     PyModule::from_code(py, code, c_str!("example.py"), c_str!("example"))?;
     ///     Ok(())
     /// })?;
@@ -145,7 +145,7 @@ impl PyModule {
     /// // if you just want to bundle a script with your module.
     /// let code = std::fs::read_to_string("assets/script.py")?;
     ///
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     PyModule::from_code(py, CString::new(code)?.as_c_str(), c_str!("example.py"), c_str!("example"))?;
     ///     Ok(())
     /// })?;
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn module_import_and_name() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let builtins = PyModule::import(py, "builtins").unwrap();
             assert_eq!(builtins.name().unwrap(), "builtins");
         })
@@ -566,7 +566,7 @@ mod tests {
     #[test]
     fn module_filename() {
         use crate::types::string::PyStringMethods;
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let site = PyModule::import(py, "site").unwrap();
             assert!(site
                 .filename()
@@ -579,7 +579,7 @@ mod tests {
 
     #[test]
     fn module_from_code_empty_file() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let builtins = PyModule::from_code(py, c_str!(""), c_str!(""), c_str!("")).unwrap();
             assert_eq!(builtins.filename().unwrap(), "<string>");
         })

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -47,7 +47,7 @@ mod tests {
 
     #[test]
     fn test_none_is_itself() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyNone::get(py).is_instance_of::<PyNone>());
             assert!(PyNone::get(py).is_exact_instance_of::<PyNone>());
         })
@@ -55,21 +55,21 @@ mod tests {
 
     #[test]
     fn test_none_type_object_consistent() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyNone::get(py).get_type().is(PyNone::type_object(py)));
         })
     }
 
     #[test]
     fn test_none_is_none() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyNone::get(py).downcast::<PyNone>().unwrap().is_none());
         })
     }
 
     #[test]
     fn test_dict_is_not_none() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyDict::new(py).downcast::<PyNone>().is_err());
         })
     }

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -52,7 +52,7 @@ mod tests {
 
     #[test]
     fn test_notimplemented_is_itself() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyNotImplemented::get(py).is_instance_of::<PyNotImplemented>());
             assert!(PyNotImplemented::get(py).is_exact_instance_of::<PyNotImplemented>());
         })
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn test_notimplemented_type_object_consistent() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyNotImplemented::get(py)
                 .get_type()
                 .is(PyNotImplemented::type_object(py)));
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn test_dict_is_not_notimplemented() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(PyDict::new(py).downcast::<PyNotImplemented>().is_err());
         })
     }

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     fn test_partial_eq() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v_i8 = 123i8;
             let v_u8 = 123i8;
             let v_i16 = 123i16;
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_display_int() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = PyInt::new(py, 42u8);
             assert_eq!(format!("{s}"), "42");
 

--- a/src/types/range.rs
+++ b/src/types/range.rs
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_py_range_new() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let range = PyRange::new(py, isize::MIN, isize::MAX).unwrap();
             assert_eq!(range.start().unwrap(), isize::MIN);
             assert_eq!(range.stop().unwrap(), isize::MAX);
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn test_py_range_new_with_step() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let range = PyRange::new_with_step(py, 1, 10, 2).unwrap();
             assert_eq!(range.start().unwrap(), 1);
             assert_eq!(range.stop().unwrap(), 10);

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -403,7 +403,7 @@ mod tests {
 
     fn get_object() -> PyObject {
         // Convenience function for getting a single unique object
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();
 
             obj.into_pyobject(py).unwrap().unbind()
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_numbers_are_not_sequences() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = 42i32;
             assert!(v
                 .into_pyobject(py)
@@ -424,7 +424,7 @@ mod tests {
 
     #[test]
     fn test_strings_are_sequences() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = "London Calling";
             assert!(v
                 .into_pyobject(py)
@@ -436,7 +436,7 @@ mod tests {
 
     #[test]
     fn test_strings_cannot_be_extracted_to_vec() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = "London Calling";
             let ob = v.into_pyobject(py).unwrap();
 
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_seq_empty() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn test_seq_is_empty() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let list = vec![1].into_pyobject(py).unwrap();
             let seq = list.downcast::<PySequence>().unwrap();
             assert!(!seq.is_empty().unwrap());
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn test_seq_contains() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -492,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_seq_get_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -508,7 +508,7 @@ mod tests {
 
     #[test]
     fn test_seq_del_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -532,7 +532,7 @@ mod tests {
 
     #[test]
     fn test_seq_set_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 2];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -546,7 +546,7 @@ mod tests {
     fn test_seq_set_item_refcnt() {
         let obj = get_object();
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 2];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -554,14 +554,14 @@ mod tests {
             assert!(ptr::eq(seq.get_item(1).unwrap().as_ptr(), obj.as_ptr()));
         });
 
-        Python::with_gil(move |py| {
+        Python::attach(move |py| {
             assert_eq!(1, obj.get_refcnt(py));
         });
     }
 
     #[test]
     fn test_seq_get_slice() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -581,7 +581,7 @@ mod tests {
 
     #[test]
     fn test_set_slice() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let w: Vec<i32> = vec![7, 4];
             let ob = v.into_pyobject(py).unwrap();
@@ -596,7 +596,7 @@ mod tests {
 
     #[test]
     fn test_del_slice() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -609,7 +609,7 @@ mod tests {
 
     #[test]
     fn test_seq_index() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -625,7 +625,7 @@ mod tests {
     #[test]
     #[cfg(not(any(PyPy, GraalPy)))]
     fn test_seq_count() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -640,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_seq_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 1, 2, 3, 5, 8];
             let ob = (&v).into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn test_seq_strings() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec!["It", "was", "the", "worst", "of", "times"];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -670,7 +670,7 @@ mod tests {
 
     #[test]
     fn test_seq_concat() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = vec![1, 2, 3];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -685,7 +685,7 @@ mod tests {
 
     #[test]
     fn test_seq_concat_string() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = "string";
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -700,7 +700,7 @@ mod tests {
 
     #[test]
     fn test_seq_repeat() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec!["foo", "bar"];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -715,7 +715,7 @@ mod tests {
 
     #[test]
     fn test_seq_inplace() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec!["foo", "bar"];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -731,7 +731,7 @@ mod tests {
 
     #[test]
     fn test_list_coercion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec!["foo", "bar"];
             let ob = (&v).into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -745,7 +745,7 @@ mod tests {
 
     #[test]
     fn test_strings_coerce_to_lists() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = "foo";
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -759,7 +759,7 @@ mod tests {
 
     #[test]
     fn test_tuple_coercion() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = ("foo", "bar");
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -773,7 +773,7 @@ mod tests {
 
     #[test]
     fn test_lists_coerce_to_tuples() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec!["foo", "bar"];
             let ob = (&v).into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();
@@ -787,7 +787,7 @@ mod tests {
 
     #[test]
     fn test_extract_tuple_to_vec() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = py
                 .eval(ffi::c_str!("(1, 2)"), None, None)
                 .unwrap()
@@ -799,7 +799,7 @@ mod tests {
 
     #[test]
     fn test_extract_range_to_vec() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<i32> = py
                 .eval(ffi::c_str!("range(1, 5)"), None, None)
                 .unwrap()
@@ -811,7 +811,7 @@ mod tests {
 
     #[test]
     fn test_extract_bytearray_to_vec() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v: Vec<u8> = py
                 .eval(ffi::c_str!("bytearray(b'abc')"), None, None)
                 .unwrap()
@@ -823,7 +823,7 @@ mod tests {
 
     #[test]
     fn test_seq_downcast_unchecked() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let v = vec!["foo", "bar"];
             let ob = v.into_pyobject(py).unwrap();
             let seq = ob.downcast::<PySequence>().unwrap();

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_set_new() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1]).unwrap();
             assert_eq!(1, set.len());
 
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn test_set_empty() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::empty(py).unwrap();
             assert_eq!(0, set.len());
             assert!(set.is_empty());
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_set_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let mut v = HashSet::<i32>::new();
             let ob = (&v).into_pyobject(py).unwrap();
             let set = ob.downcast::<PySet>().unwrap();
@@ -335,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_set_clear() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1]).unwrap();
             assert_eq!(1, set.len());
             set.clear();
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn test_set_contains() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1]).unwrap();
             assert!(set.contains(1).unwrap());
         });
@@ -353,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_set_discard() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1]).unwrap();
             assert!(!set.discard(2).unwrap());
             assert_eq!(1, set.len());
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn test_set_add() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1, 2]).unwrap();
             set.add(1).unwrap(); // Add a dupliated element
             assert!(set.contains(1).unwrap());
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_set_pop() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1]).unwrap();
             let val = set.pop();
             assert!(val.is_some());
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn test_set_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1]).unwrap();
 
             for el in set {
@@ -408,7 +408,7 @@ mod tests {
     fn test_set_iter_bound() {
         use crate::types::any::PyAnyMethods;
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1]).unwrap();
 
             for el in &set {
@@ -420,7 +420,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_set_iter_mutation() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
 
             for _ in &set {
@@ -432,7 +432,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_set_iter_mutation_same_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
 
             for item in &set {
@@ -445,7 +445,7 @@ mod tests {
 
     #[test]
     fn test_set_iter_size_hint() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, [1]).unwrap();
             let mut iter = set.iter();
 
@@ -460,7 +460,7 @@ mod tests {
 
     #[test]
     fn test_iter_count() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set = PySet::new(py, vec![1, 2, 3]).unwrap();
             assert_eq!(set.iter().count(), 3);
         })

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -160,7 +160,7 @@ mod tests {
 
     #[test]
     fn test_py_slice_new() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let slice = PySlice::new(py, isize::MIN, isize::MAX, 1);
             assert_eq!(
                 slice.getattr("start").unwrap().extract::<isize>().unwrap(),
@@ -179,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_py_slice_full() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let slice = PySlice::full(py);
             assert!(slice.getattr("start").unwrap().is_none(),);
             assert!(slice.getattr("stop").unwrap().is_none(),);

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -141,7 +141,7 @@ impl<'a> PyStringData<'a> {
 /// # use pyo3::prelude::*;
 /// use pyo3::types::PyString;
 ///
-/// # Python::with_gil(|py| {
+/// # Python::attach(|py| {
 /// let py_string = PyString::new(py, "foo");
 /// // via PartialEq<str>
 /// assert_eq!(py_string, "foo");
@@ -539,7 +539,7 @@ mod tests {
 
     #[test]
     fn test_to_cow_utf8() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "ascii 🐈";
             let py_string = PyString::new(py, s);
             assert_eq!(s, py_string.to_cow().unwrap());
@@ -548,7 +548,7 @@ mod tests {
 
     #[test]
     fn test_to_cow_surrogate() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_string = py
                 .eval(ffi::c_str!(r"'\ud800'"), None, None)
                 .unwrap()
@@ -560,7 +560,7 @@ mod tests {
 
     #[test]
     fn test_to_cow_unicode() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "哈哈🐈";
             let py_string = PyString::new(py, s);
             assert_eq!(s, py_string.to_cow().unwrap());
@@ -569,7 +569,7 @@ mod tests {
 
     #[test]
     fn test_encode_utf8_unicode() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "哈哈🐈";
             let obj = PyString::new(py, s);
             assert_eq!(s.as_bytes(), obj.encode_utf8().unwrap().as_bytes());
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn test_encode_utf8_surrogate() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let obj: PyObject = py
                 .eval(ffi::c_str!(r"'\ud800'"), None, None)
                 .unwrap()
@@ -594,7 +594,7 @@ mod tests {
 
     #[test]
     fn test_to_string_lossy() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_string = py
                 .eval(ffi::c_str!(r"'🐈 Hello \ud800World'"), None, None)
                 .unwrap()
@@ -607,7 +607,7 @@ mod tests {
 
     #[test]
     fn test_debug_string() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "Hello\n".into_pyobject(py).unwrap();
             assert_eq!(format!("{s:?}"), "'Hello\\n'");
         })
@@ -615,7 +615,7 @@ mod tests {
 
     #[test]
     fn test_display_string() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "Hello\n".into_pyobject(py).unwrap();
             assert_eq!(format!("{s}"), "Hello\n");
         })
@@ -623,7 +623,7 @@ mod tests {
 
     #[test]
     fn test_string_from_object() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_bytes = PyBytes::new(py, b"ab\xFFcd");
 
             let py_string = PyString::from_object(&py_bytes, "utf-8", "ignore").unwrap();
@@ -635,7 +635,7 @@ mod tests {
 
     #[test]
     fn test_string_from_obect_with_invalid_encoding_errors() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_bytes = PyBytes::new(py, b"abcd");
 
             let result = PyString::from_object(&py_bytes, "utf\0-8", "ignore");
@@ -649,7 +649,7 @@ mod tests {
     #[test]
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn test_string_data_ucs1() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = PyString::new(py, "hello, world");
             let data = unsafe { s.data().unwrap() };
 
@@ -662,7 +662,7 @@ mod tests {
     #[test]
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn test_string_data_ucs1_invalid() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // 0xfe is not allowed in UTF-8.
             let buffer = b"f\xfe\0";
             let ptr = unsafe {
@@ -688,7 +688,7 @@ mod tests {
     #[test]
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn test_string_data_ucs2() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = py.eval(ffi::c_str!("'foo\\ud800'"), None, None).unwrap();
             let py_string = s.downcast::<PyString>().unwrap();
             let data = unsafe { py_string.data().unwrap() };
@@ -704,7 +704,7 @@ mod tests {
     #[test]
     #[cfg(all(not(any(Py_LIMITED_API, PyPy, GraalPy)), target_endian = "little"))]
     fn test_string_data_ucs2_invalid() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // U+FF22 (valid) & U+d800 (never valid)
             let buffer = b"\x22\xff\x00\xd8\x00\x00";
             let ptr = unsafe {
@@ -730,7 +730,7 @@ mod tests {
     #[test]
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     fn test_string_data_ucs4() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "哈哈🐈";
             let py_string = PyString::new(py, s);
             let data = unsafe { py_string.data().unwrap() };
@@ -743,7 +743,7 @@ mod tests {
     #[test]
     #[cfg(all(not(any(Py_LIMITED_API, PyPy, GraalPy)), target_endian = "little"))]
     fn test_string_data_ucs4_invalid() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // U+20000 (valid) & U+d800 (never valid)
             let buffer = b"\x00\x00\x02\x00\x00\xd8\x00\x00\x00\x00\x00\x00";
             let ptr = unsafe {
@@ -768,7 +768,7 @@ mod tests {
 
     #[test]
     fn test_intern_string() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_string1 = PyString::intern(py, "foo");
             assert_eq!(py_string1, "foo");
 
@@ -786,7 +786,7 @@ mod tests {
 
     #[test]
     fn test_py_to_str_utf8() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "ascii 🐈";
             let py_string = PyString::new(py, s).unbind();
 
@@ -799,7 +799,7 @@ mod tests {
 
     #[test]
     fn test_py_to_str_surrogate() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_string: Py<PyString> = py
                 .eval(ffi::c_str!(r"'\ud800'"), None, None)
                 .unwrap()
@@ -815,7 +815,7 @@ mod tests {
 
     #[test]
     fn test_py_to_string_lossy() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_string: Py<PyString> = py
                 .eval(ffi::c_str!(r"'🐈 Hello \ud800World'"), None, None)
                 .unwrap()
@@ -827,7 +827,7 @@ mod tests {
 
     #[test]
     fn test_comparisons() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s = "hello, world";
             let py_string = PyString::new(py, s);
 

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -37,7 +37,7 @@ pub trait PyTracebackMethods<'py>: crate::sealed::Sealed {
     /// ```rust
     /// # use pyo3::{Python, PyResult, prelude::PyTracebackMethods, ffi::c_str};
     /// # let result: PyResult<()> =
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let err = py
     ///         .run(c_str!("raise Exception('banana')"), None, None)
     ///         .expect_err("raise will create a Python error");
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn format_traceback() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let err = py
                 .run(ffi::c_str!("raise Exception('banana')"), None, None)
                 .expect_err("raising should have given us an error");
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_err_from_value() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             // Produce an error from python so that it has a traceback
             py.run(
@@ -127,7 +127,7 @@ except Exception as e:
 
     #[test]
     fn test_err_into_py() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let locals = PyDict::new(py);
             // Produce an error from python so that it has a traceback
             py.run(

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -74,7 +74,7 @@ impl PyTuple {
     /// use pyo3::types::PyTuple;
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let elements: Vec<i32> = vec![0, 1, 2, 3, 4, 5];
     ///     let tuple = PyTuple::new(py, elements)?;
     ///     assert_eq!(format!("{:?}", tuple), "(0, 1, 2, 3, 4, 5)");
@@ -142,7 +142,7 @@ pub trait PyTupleMethods<'py>: crate::sealed::Sealed {
     /// use pyo3::prelude::*;
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| -> PyResult<()> {
+    /// Python::attach(|py| -> PyResult<()> {
     ///     let tuple = (1, 2, 3).into_pyobject(py)?;
     ///     let obj = tuple.get_item(0);
     ///     assert_eq!(obj?.extract::<i32>()?, 1);
@@ -1038,7 +1038,7 @@ mod tests {
     use std::ops::Range;
     #[test]
     fn test_new() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = PyTuple::new(py, [1, 2, 3]).unwrap();
             assert_eq!(3, ob.len());
             let ob = ob.as_any();
@@ -1053,7 +1053,7 @@ mod tests {
 
     #[test]
     fn test_len() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 2, 3).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
             assert_eq!(3, tuple.len());
@@ -1065,7 +1065,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::empty(py);
             assert!(tuple.is_empty());
             assert_eq!(0, tuple.len());
@@ -1074,7 +1074,7 @@ mod tests {
 
     #[test]
     fn test_slice() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tup = PyTuple::new(py, [2, 3, 5, 7]).unwrap();
             let slice = tup.get_slice(1, 3);
             assert_eq!(2, slice.len());
@@ -1085,7 +1085,7 @@ mod tests {
 
     #[test]
     fn test_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 2, 3).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
             assert_eq!(3, tuple.len());
@@ -1109,7 +1109,7 @@ mod tests {
 
     #[test]
     fn test_iter_rev() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 2, 3).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
             assert_eq!(3, tuple.len());
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[test]
     fn test_bound_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, [1, 2, 3]).unwrap();
             assert_eq!(3, tuple.len());
             let mut iter = tuple.iter();
@@ -1156,7 +1156,7 @@ mod tests {
 
     #[test]
     fn test_bound_iter_rev() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, [1, 2, 3]).unwrap();
             assert_eq!(3, tuple.len());
             let mut iter = tuple.iter().rev();
@@ -1179,7 +1179,7 @@ mod tests {
 
     #[test]
     fn test_into_iter() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 2, 3).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
             assert_eq!(3, tuple.len());
@@ -1192,7 +1192,7 @@ mod tests {
 
     #[test]
     fn test_into_iter_bound() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = (1, 2, 3).into_pyobject(py).unwrap();
             assert_eq!(3, tuple.len());
 
@@ -1207,7 +1207,7 @@ mod tests {
     #[test]
     #[cfg(not(any(Py_LIMITED_API, GraalPy)))]
     fn test_as_slice() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 2, 3).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
 
@@ -1221,7 +1221,7 @@ mod tests {
 
     #[test]
     fn test_tuple_lengths_up_to_12() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let t0 = (0,).into_pyobject(py).unwrap();
             let t1 = (0, 1).into_pyobject(py).unwrap();
             let t2 = (0, 1, 2).into_pyobject(py).unwrap();
@@ -1289,7 +1289,7 @@ mod tests {
 
     #[test]
     fn test_tuple_get_item_invalid_index() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 2, 3).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
             let obj = tuple.get_item(5);
@@ -1303,7 +1303,7 @@ mod tests {
 
     #[test]
     fn test_tuple_get_item_sanity() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 2, 3).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
             let obj = tuple.get_item(0);
@@ -1314,7 +1314,7 @@ mod tests {
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     #[test]
     fn test_tuple_get_item_unchecked_sanity() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 2, 3).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
             let obj = unsafe { tuple.get_item_unchecked(0) };
@@ -1324,7 +1324,7 @@ mod tests {
 
     #[test]
     fn test_tuple_contains() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 1, 2, 3, 5, 8).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
             assert_eq!(6, tuple.len());
@@ -1342,7 +1342,7 @@ mod tests {
 
     #[test]
     fn test_tuple_index() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ob = (1, 1, 2, 3, 5, 8).into_pyobject(py).unwrap();
             let tuple = ob.downcast::<PyTuple>().unwrap();
             assert_eq!(0, tuple.index(1i32).unwrap());
@@ -1377,7 +1377,7 @@ mod tests {
         expected = "Attempted to create PyTuple but `elements` was larger than reported by its `ExactSizeIterator` implementation."
     )]
     fn too_long_iterator() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let iter = FaultyIter(0..usize::MAX, 73);
             let _tuple = PyTuple::new(py, iter);
         })
@@ -1388,7 +1388,7 @@ mod tests {
         expected = "Attempted to create PyTuple but `elements` was smaller than reported by its `ExactSizeIterator` implementation."
     )]
     fn too_short_iterator() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let iter = FaultyIter(0..35, 73);
             let _tuple = PyTuple::new(py, iter);
         })
@@ -1399,7 +1399,7 @@ mod tests {
         expected = "out of range integral type conversion attempted on `elements.len()`"
     )]
     fn overflowing_size() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let iter = FaultyIter(0..0, usize::MAX);
 
             let _tuple = PyTuple::new(py, iter);
@@ -1453,7 +1453,7 @@ mod tests {
             }
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             std::panic::catch_unwind(|| {
                 let iter = FaultyIter(0..50, 50);
                 let _tuple = PyTuple::new(py, iter);
@@ -1498,7 +1498,7 @@ mod tests {
 
         let s = (Bad(1), Bad(2), Bad(3), Bad(4));
         NEEDS_DESTRUCTING_COUNT.store(4, SeqCst);
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             std::panic::catch_unwind(|| {
                 let _tuple = (&s).into_pyobject(py).unwrap();
             })
@@ -1515,7 +1515,7 @@ mod tests {
 
     #[test]
     fn test_tuple_to_list() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
             let list = tuple.to_list();
             let list_expected = PyList::new(py, vec![1, 2, 3]).unwrap();
@@ -1525,7 +1525,7 @@ mod tests {
 
     #[test]
     fn test_tuple_as_sequence() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
             let sequence = tuple.as_sequence();
             assert!(tuple.get_item(0).unwrap().eq(1).unwrap());
@@ -1538,7 +1538,7 @@ mod tests {
 
     #[test]
     fn test_tuple_into_sequence() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
             let sequence = tuple.into_sequence();
             assert!(sequence.get_item(0).unwrap().eq(1).unwrap());
@@ -1548,7 +1548,7 @@ mod tests {
 
     #[test]
     fn test_bound_tuple_get_item() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4]).unwrap();
 
             assert_eq!(tuple.len(), 4);
@@ -1581,7 +1581,7 @@ mod tests {
 
     #[test]
     fn test_bound_tuple_nth() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4]).unwrap();
             let mut iter = tuple.iter();
             assert_eq!(iter.nth(1).unwrap().extract::<i32>().unwrap(), 2);
@@ -1612,7 +1612,7 @@ mod tests {
 
     #[test]
     fn test_bound_tuple_nth_back() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
             let mut iter = tuple.iter();
             assert_eq!(iter.nth_back(0).unwrap().extract::<i32>().unwrap(), 5);
@@ -1655,7 +1655,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[test]
     fn test_bound_tuple_advance_by() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
             let mut iter = tuple.iter();
 
@@ -1680,7 +1680,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[test]
     fn test_bound_tuple_advance_back_by() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
             let mut iter = tuple.iter();
 
@@ -1704,7 +1704,7 @@ mod tests {
 
     #[test]
     fn test_iter_last() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
             let last = tuple.iter().last();
             assert_eq!(last.unwrap().extract::<i32>().unwrap(), 3);
@@ -1713,7 +1713,7 @@ mod tests {
 
     #[test]
     fn test_iter_count() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
             assert_eq!(tuple.iter().count(), 3);
         })

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn test_type_is_subclass() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bool_type = py.get_type::<PyBool>();
             let long_type = py.get_type::<PyInt>();
             assert!(bool_type.is_subclass(&long_type).unwrap());
@@ -262,14 +262,14 @@ mod tests {
 
     #[test]
     fn test_type_is_subclass_of() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(py.get_type::<PyBool>().is_subclass_of::<PyInt>().unwrap());
         });
     }
 
     #[test]
     fn test_mro() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(py
                 .get_type::<PyBool>()
                 .mro()
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn test_bases_bool() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(py
                 .get_type::<PyBool>()
                 .bases()
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn test_bases_object() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(py
                 .get_type::<PyAny>()
                 .bases()
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_type_names_standard() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module_name = generate_unique_module_name("test_module");
             let module = PyModule::from_code(
                 py,
@@ -341,7 +341,7 @@ class MyClass:
 
     #[test]
     fn test_type_names_builtin() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bool_type = py.get_type::<PyBool>();
             assert_eq!(bool_type.name().unwrap(), "bool");
             assert_eq!(bool_type.qualname().unwrap(), "bool");
@@ -352,7 +352,7 @@ class MyClass:
 
     #[test]
     fn test_type_names_nested() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let module_name = generate_unique_module_name("test_module");
             let module = PyModule::from_code(
                 py,

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -71,7 +71,7 @@ pub trait PyWeakrefMethods<'py>: crate::sealed::Sealed {
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let data = Bound::new(py, Foo{})?;
     ///     let reference = PyWeakrefReference::new(&data)?;
     ///
@@ -151,7 +151,7 @@ pub trait PyWeakrefMethods<'py>: crate::sealed::Sealed {
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let data = Bound::new(py, Foo{})?;
     ///     let reference = PyWeakrefReference::new(&data)?;
     ///
@@ -221,7 +221,7 @@ pub trait PyWeakrefMethods<'py>: crate::sealed::Sealed {
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let data = Bound::new(py, Foo{})?;
     ///     let reference = PyWeakrefReference::new(&data)?;
     ///
@@ -291,7 +291,7 @@ pub trait PyWeakrefMethods<'py>: crate::sealed::Sealed {
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let data = Bound::new(py, Foo{})?;
     ///     let reference = PyWeakrefReference::new(&data)?;
     ///
@@ -369,7 +369,7 @@ mod tests {
                 )
                     -> PyResult<Bound<'py, PyWeakref>>,
             ) -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = create_reference(&object)?;
@@ -414,7 +414,7 @@ mod tests {
                 )
                     -> PyResult<Bound<'py, PyWeakref>>,
             ) -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = create_reference(&object)?;
@@ -456,7 +456,7 @@ mod tests {
             ) -> PyResult<()> {
                 let not_call_retrievable = !call_retrievable;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = create_reference(&object)?;
@@ -497,7 +497,7 @@ mod tests {
                 )
                     -> PyResult<Bound<'py, PyWeakref>>,
             ) -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
                     let reference = create_reference(object.bind(py))?;
 
@@ -538,7 +538,7 @@ mod tests {
                 )
                     -> PyResult<Bound<'py, PyWeakref>>,
             ) -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
                     let reference = create_reference(object.bind(py))?;
 
@@ -576,7 +576,7 @@ mod tests {
             ) -> PyResult<()> {
                 let not_call_retrievable = !call_retrievable;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
                     let reference = create_reference(object.bind(py))?;
 

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -52,7 +52,7 @@ impl PyWeakrefProxy {
     /// struct Foo { /* fields omitted */ }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let foo = Bound::new(py, Foo {})?;
     ///     let weakref = PyWeakrefProxy::new(&foo)?;
     ///     assert!(
@@ -109,7 +109,7 @@ impl PyWeakrefProxy {
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     py.run(c_str!("counter = 0"), None, None)?;
     ///     assert_eq!(py.eval(c_str!("counter"), None, None)?.extract::<u32>()?, 0);
     ///     let foo = Bound::new(py, Foo{})?;
@@ -254,7 +254,7 @@ mod tests {
 
             #[test]
             fn test_weakref_proxy_behavior() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -316,7 +316,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade_as() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -351,7 +351,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -380,7 +380,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -398,7 +398,7 @@ mod tests {
 
             #[test]
             fn test_weakref_get_object() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -426,7 +426,7 @@ mod tests {
 
             #[test]
             fn test_weakref_proxy_behavior() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object: Bound<'_, WeakrefablePyClass> =
                         Bound::new(py, WeakrefablePyClass {})?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -490,7 +490,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade_as() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
                     let reference = PyWeakrefProxy::new(object.bind(py))?;
 
@@ -521,7 +521,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
                     let reference = PyWeakrefProxy::new(object.bind(py))?;
 
@@ -546,7 +546,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
                     let reference = PyWeakrefProxy::new(object.bind(py))?;
 
@@ -590,7 +590,7 @@ mod tests {
 
             #[test]
             fn test_weakref_proxy_behavior() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -639,7 +639,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade_as() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -674,7 +674,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -703,7 +703,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let class = get_type(py)?;
                     let object = class.call0()?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -739,7 +739,7 @@ mod tests {
 
             #[test]
             fn test_weakref_proxy_behavior() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object: Bound<'_, WeakrefablePyClass> =
                         Bound::new(py, WeakrefablePyClass {})?;
                     let reference = PyWeakrefProxy::new(&object)?;
@@ -791,7 +791,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade_as() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
                     let reference = PyWeakrefProxy::new(object.bind(py))?;
 
@@ -822,7 +822,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
                     let reference = PyWeakrefProxy::new(object.bind(py))?;
 
@@ -847,7 +847,7 @@ mod tests {
 
             #[test]
             fn test_weakref_upgrade() -> PyResult<()> {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let object = Py::new(py, WeakrefablePyClass {})?;
                     let reference = PyWeakrefProxy::new(object.bind(py))?;
 

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -64,7 +64,7 @@ impl PyWeakrefReference {
     /// struct Foo { /* fields omitted */ }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     let foo = Bound::new(py, Foo {})?;
     ///     let weakref = PyWeakrefReference::new(&foo)?;
     ///     assert!(
@@ -120,7 +120,7 @@ impl PyWeakrefReference {
     /// }
     ///
     /// # fn main() -> PyResult<()> {
-    /// Python::with_gil(|py| {
+    /// Python::attach(|py| {
     ///     py.run(c_str!("counter = 0"), None, None)?;
     ///     assert_eq!(py.eval(c_str!("counter"), None, None)?.extract::<u32>()?, 0);
     ///     let foo = Bound::new(py, Foo{})?;
@@ -250,7 +250,7 @@ mod tests {
 
         #[test]
         fn test_weakref_reference_behavior() -> PyResult<()> {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let class = get_type(py)?;
                 let object = class.call0()?;
                 let reference = PyWeakrefReference::new(&object)?;
@@ -292,7 +292,7 @@ mod tests {
 
         #[test]
         fn test_weakref_upgrade_as() -> PyResult<()> {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let class = get_type(py)?;
                 let object = class.call0()?;
                 let reference = PyWeakrefReference::new(&object)?;
@@ -327,7 +327,7 @@ mod tests {
 
         #[test]
         fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let class = get_type(py)?;
                 let object = class.call0()?;
                 let reference = PyWeakrefReference::new(&object)?;
@@ -356,7 +356,7 @@ mod tests {
 
         #[test]
         fn test_weakref_upgrade() -> PyResult<()> {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let class = get_type(py)?;
                 let object = class.call0()?;
                 let reference = PyWeakrefReference::new(&object)?;
@@ -387,7 +387,7 @@ mod tests {
 
         #[test]
         fn test_weakref_reference_behavior() -> PyResult<()> {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let object: Bound<'_, WeakrefablePyClass> = Bound::new(py, WeakrefablePyClass {})?;
                 let reference = PyWeakrefReference::new(&object)?;
 
@@ -426,7 +426,7 @@ mod tests {
 
         #[test]
         fn test_weakref_upgrade_as() -> PyResult<()> {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let object = Py::new(py, WeakrefablePyClass {})?;
                 let reference = PyWeakrefReference::new(object.bind(py))?;
 
@@ -457,7 +457,7 @@ mod tests {
 
         #[test]
         fn test_weakref_upgrade_as_unchecked() -> PyResult<()> {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let object = Py::new(py, WeakrefablePyClass {})?;
                 let reference = PyWeakrefReference::new(object.bind(py))?;
 
@@ -482,7 +482,7 @@ mod tests {
 
         #[test]
         fn test_weakref_upgrade() -> PyResult<()> {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let object = Py::new(py, WeakrefablePyClass {})?;
                 let reference = PyWeakrefReference::new(object.bind(py))?;
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -6,7 +6,7 @@
 ///
 /// ```rust
 /// # use pyo3::Python;
-/// Python::with_gil(|py| {
+/// Python::attach(|py| {
 ///     // PyO3 supports Python 3.7 and up.
 ///     assert!(py.version_info() >= (3, 7));
 ///     assert!(py.version_info() >= (3, 7, 0));
@@ -99,7 +99,7 @@ mod test {
     use crate::Python;
     #[test]
     fn test_python_version_info() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let version = py.version_info();
             #[cfg(Py_3_7)]
             assert!(version >= (3, 7));

--- a/tests/test_anyhow.rs
+++ b/tests/test_anyhow.rs
@@ -12,7 +12,7 @@ fn test_anyhow_py_function_ok_result() {
         Ok(String::from("OK buddy"))
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let func = wrap_pyfunction!(produce_ok_result)(py).unwrap();
 
         py_run!(
@@ -35,7 +35,7 @@ fn test_anyhow_py_function_err_result() {
         anyhow::bail!("error time")
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let func = wrap_pyfunction!(produce_err_result)(py).unwrap();
         let locals = PyDict::new(py);
         locals.set_item("func", func).unwrap();

--- a/tests/test_append_to_inittab.rs
+++ b/tests/test_append_to_inittab.rs
@@ -28,7 +28,7 @@ fn test_module_append_to_inittab() {
 
     append_to_inittab!(module_mod_with_functions);
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         py.run(
             ffi::c_str!(
                 r#"
@@ -43,7 +43,7 @@ assert module_fn_with_functions.foo() == 123
         .unwrap();
     });
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         py.run(
             ffi::c_str!(
                 r#"

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -47,7 +47,7 @@ impl UnaryArithmetic {
 
 #[test]
 fn unary_arithmetic() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Py::new(py, UnaryArithmetic::new(2.7)).unwrap();
         py_run!(py, c, "assert repr(-c) == 'UA(-2.7)'");
         py_run!(py, c, "assert repr(+c) == 'UA(2.7)'");
@@ -91,7 +91,7 @@ impl Indexable {
 
 #[test]
 fn indexable() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let i = Py::new(py, Indexable(5)).unwrap();
         py_run!(py, i, "assert int(i) == 5");
         py_run!(py, i, "assert [0, 1, 2, 3, 4, 5][i] == 5");
@@ -150,7 +150,7 @@ impl InPlaceOperations {
 
 #[test]
 fn inplace_operations() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let init = |value, code| {
             let c = Py::new(py, InPlaceOperations { value }).unwrap();
             py_run!(py, c, code);
@@ -240,7 +240,7 @@ impl BinaryArithmetic {
 
 #[test]
 fn binary_arithmetic() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Py::new(py, BinaryArithmetic {}).unwrap();
         py_run!(py, c, "assert c + c == 'BA + BA'");
         py_run!(py, c, "assert c.__add__(c) == 'BA + BA'");
@@ -341,7 +341,7 @@ impl RhsArithmetic {
 
 #[test]
 fn rhs_arithmetic() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Py::new(py, RhsArithmetic {}).unwrap();
         py_run!(py, c, "assert c.__radd__(1) == '1 + RA'");
         py_run!(py, c, "assert 1 + c == '1 + RA'");
@@ -470,7 +470,7 @@ impl LhsAndRhs {
 
 #[test]
 fn lhs_fellback_to_rhs() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Py::new(py, LhsAndRhs {}).unwrap();
         // If the light hand value is `LhsAndRhs`, LHS is used.
         py_run!(py, c, "assert c + 1 == 'LR + 1'");
@@ -546,7 +546,7 @@ impl RichComparisons2 {
 
 #[test]
 fn rich_comparisons() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Py::new(py, RichComparisons {}).unwrap();
         py_run!(py, c, "assert (c < c) == 'RC < RC'");
         py_run!(py, c, "assert (c < 1) == 'RC < 1'");
@@ -571,7 +571,7 @@ fn rich_comparisons() {
 
 #[test]
 fn rich_comparisons_python_3_type_error() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c2 = Py::new(py, RichComparisons2 {}).unwrap();
         py_expect_exception!(py, c2, "c2 < c2", PyTypeError);
         py_expect_exception!(py, c2, "c2 < 1", PyTypeError);
@@ -672,7 +672,7 @@ mod return_not_implemented {
     }
 
     fn _test_binary_dunder(dunder: &str) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let c2 = Py::new(py, RichComparisonToSelf {}).unwrap();
             py_run!(
                 py,
@@ -685,7 +685,7 @@ mod return_not_implemented {
     fn _test_binary_operator(operator: &str, dunder: &str) {
         _test_binary_dunder(dunder);
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let c2 = Py::new(py, RichComparisonToSelf {}).unwrap();
             py_expect_exception!(
                 py,

--- a/tests/test_buffer.rs
+++ b/tests/test_buffer.rs
@@ -88,7 +88,7 @@ impl TestBufferErrors {
 
 #[test]
 fn test_get_buffer_errors() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let instance = Py::new(
             py,
             TestBufferErrors {

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -49,7 +49,7 @@ impl Drop for TestBufferClass {
 fn test_buffer() {
     let drop_called = Arc::new(AtomicBool::new(false));
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let instance = Py::new(
             py,
             TestBufferClass {
@@ -71,7 +71,7 @@ fn test_buffer_referenced() {
 
     let buf = {
         let input = vec![b' ', b'2', b'3'];
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let instance = TestBufferClass {
                 vec: input.clone(),
                 drop_called: drop_called.clone(),
@@ -88,7 +88,7 @@ fn test_buffer_referenced() {
 
     assert!(!drop_called.load(Ordering::Relaxed));
 
-    Python::with_gil(|_| {
+    Python::attach(|_| {
         drop(buf);
     });
 
@@ -120,7 +120,7 @@ fn test_releasebuffer_unraisable_error() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let capture = UnraisableCapture::install(py);
 
         let instance = Py::new(py, ReleaseBufferError {}).unwrap();

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -13,7 +13,7 @@ fn bytes_pybytes_conversion(bytes: &[u8]) -> &[u8] {
 
 #[test]
 fn test_pybytes_bytes_conversion() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(bytes_pybytes_conversion)(py).unwrap();
         py_assert!(py, f, "f(b'Hello World') == b'Hello World'");
     });
@@ -26,7 +26,7 @@ fn bytes_vec_conversion(py: Python<'_>, bytes: Vec<u8>) -> Bound<'_, PyBytes> {
 
 #[test]
 fn test_pybytes_vec_conversion() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(bytes_vec_conversion)(py).unwrap();
         py_assert!(py, f, "f(b'Hello World') == b'Hello World'");
     });
@@ -34,7 +34,7 @@ fn test_pybytes_vec_conversion() {
 
 #[test]
 fn test_bytearray_vec_conversion() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(bytes_vec_conversion)(py).unwrap();
         py_assert!(py, f, "f(bytearray(b'Hello World')) == b'Hello World'");
     });
@@ -43,11 +43,11 @@ fn test_bytearray_vec_conversion() {
 #[test]
 fn test_py_as_bytes() {
     let pyobj: pyo3::Py<pyo3::types::PyBytes> =
-        Python::with_gil(|py| pyo3::types::PyBytes::new(py, b"abc").unbind());
+        Python::attach(|py| pyo3::types::PyBytes::new(py, b"abc").unbind());
 
-    let data = Python::with_gil(|py| pyobj.as_bytes(py));
+    let data = Python::attach(|py| pyobj.as_bytes(py));
 
     assert_eq!(data, b"abc");
 
-    Python::with_gil(move |_py| drop(pyobj));
+    Python::attach(move |_py| drop(pyobj));
 }

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -56,7 +56,7 @@ impl Foo {
 
 #[test]
 fn class_attributes() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let foo_obj = py.get_type::<Foo>();
         py_assert!(py, foo_obj, "foo_obj.MY_CONST == 'foobar'");
         py_assert!(py, foo_obj, "foo_obj.RENAMED_CONST == 'foobar_2'");
@@ -83,7 +83,7 @@ fn class_attributes_mutable() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = py.get_type::<Foo>();
         py_run!(py, obj, "obj.MY_CONST = 'BAZ'");
         py_run!(py, obj, "obj.a = 42");
@@ -119,7 +119,7 @@ fn immutable_type_object() {
         Variant(u32),
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = py.get_type::<ImmutableType>();
         py_expect_exception!(py, obj, "obj.MY_CONST = 'FOOBAR'", PyTypeError);
         py_expect_exception!(py, obj, "obj.a = 6", PyTypeError);
@@ -142,7 +142,7 @@ impl Bar {
 
 #[test]
 fn recursive_class_attributes() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let foo_obj = py.get_type::<Foo>();
         let bar_obj = py.get_type::<Bar>();
         py_assert!(py, foo_obj, "foo_obj.a_foo.x == 1");
@@ -198,7 +198,7 @@ fn test_fallible_class_attribute() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let stderr = CaptureStdErr::new(py).unwrap();
         assert!(std::panic::catch_unwind(|| py.get_type::<BrokenClass>()).is_err());
         assert_eq!(
@@ -241,7 +241,7 @@ impl StructWithRenamedFields {
 fn test_renaming_all_struct_fields() {
     use pyo3::types::PyBool;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let struct_class = py.get_type::<StructWithRenamedFields>();
         let struct_obj = struct_class.call0().unwrap();
         assert!(struct_obj
@@ -274,7 +274,7 @@ macro_rules! test_case {
         fn $test_name() {
             //use pyo3::types::PyInt;
 
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let struct_class = py.get_type::<$struct_name>();
                 let struct_obj = struct_class.call0().unwrap();
                 assert!(struct_obj.setattr($renamed_field_name, 2).is_ok());

--- a/tests/test_class_comparisons.rs
+++ b/tests/test_class_comparisons.rs
@@ -21,7 +21,7 @@ pub enum MyEnumOrd {
 
 #[test]
 fn test_enum_eq_enum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, MyEnum::Variant).unwrap();
         let var2 = Py::new(py, MyEnum::Variant).unwrap();
         let other_var = Py::new(py, MyEnum::OtherVariant).unwrap();
@@ -33,7 +33,7 @@ fn test_enum_eq_enum() {
 
 #[test]
 fn test_enum_eq_incomparable() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, MyEnum::Variant).unwrap();
         py_assert!(py, var1, "(var1 == 'foo') == False");
         py_assert!(py, var1, "(var1 != 'foo') == True");
@@ -42,7 +42,7 @@ fn test_enum_eq_incomparable() {
 
 #[test]
 fn test_enum_ord_comparable_opt_in_only() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, MyEnum::Variant).unwrap();
         let var2 = Py::new(py, MyEnum::OtherVariant).unwrap();
         // ordering on simple enums if opt in only, thus raising an error below
@@ -52,7 +52,7 @@ fn test_enum_ord_comparable_opt_in_only() {
 
 #[test]
 fn test_simple_enum_ord_comparable() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, MyEnumOrd::Variant).unwrap();
         let var2 = Py::new(py, MyEnumOrd::OtherVariant).unwrap();
         let var3 = Py::new(py, MyEnumOrd::OtherVariant).unwrap();
@@ -80,7 +80,7 @@ pub enum MyComplexEnumOrd2 {
 
 #[test]
 fn test_complex_enum_ord_comparable() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, MyComplexEnumOrd::Variant(-2)).unwrap();
         let var2 = Py::new(py, MyComplexEnumOrd::Variant(5)).unwrap();
         let var3 = Py::new(py, MyComplexEnumOrd::OtherVariant("a".to_string())).unwrap();
@@ -156,7 +156,7 @@ pub struct Point {
 
 #[test]
 fn test_struct_numeric_ord_comparable() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, Point { x: 10, y: 2, z: 3 }).unwrap();
         let var2 = Py::new(py, Point { x: 2, y: 2, z: 3 }).unwrap();
         let var3 = Py::new(py, Point { x: 1, y: 22, z: 4 }).unwrap();
@@ -180,7 +180,7 @@ pub struct Person {
 
 #[test]
 fn test_struct_string_ord_comparable() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(
             py,
             Person {
@@ -239,7 +239,7 @@ impl PartialOrd for Record {
 
 #[test]
 fn test_struct_custom_ord_comparable() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(
             py,
             Record {

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -16,7 +16,7 @@ struct Cloneable {
 fn test_cloneable_pyclass() {
     let c = Cloneable { x: 10 };
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_c = Py::new(py, c.clone()).unwrap();
 
         let c2: Cloneable = py_c.extract(py).unwrap();
@@ -62,7 +62,7 @@ struct PolymorphicContainer {
 
 #[test]
 fn test_polymorphic_container_stores_base_class() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let p = Py::new(
             py,
             PolymorphicContainer {
@@ -77,7 +77,7 @@ fn test_polymorphic_container_stores_base_class() {
 
 #[test]
 fn test_polymorphic_container_stores_sub_class() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let p = Py::new(
             py,
             PolymorphicContainer {
@@ -103,7 +103,7 @@ fn test_polymorphic_container_stores_sub_class() {
 
 #[test]
 fn test_polymorphic_container_does_not_accept_other_types() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let p = Py::new(
             py,
             PolymorphicContainer {
@@ -122,7 +122,7 @@ fn test_polymorphic_container_does_not_accept_other_types() {
 
 #[test]
 fn test_pyref_as_base() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let cell = Bound::new(py, (SubClass {}, BaseClass { value: 120 })).unwrap();
 
         // First try PyRefMut
@@ -142,7 +142,7 @@ fn test_pyref_as_base() {
 
 #[test]
 fn test_pycell_deref() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = Bound::new(py, (SubClass {}, BaseClass { value: 120 })).unwrap();
 
         // Should be able to deref as PyAny

--- a/tests/test_class_formatting.rs
+++ b/tests/test_class_formatting.rs
@@ -40,7 +40,7 @@ impl Display for MyEnum3 {
 
 #[test]
 fn test_enum_class_fmt() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var2 = Py::new(py, MyEnum2::Variant).unwrap();
         let var3 = Py::new(py, MyEnum3::Variant).unwrap();
         let var4 = Py::new(py, MyEnum3::OtherVariant).unwrap();
@@ -60,7 +60,7 @@ pub struct Point {
 
 #[test]
 fn test_custom_struct_custom_str() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, Point { x: 1, y: 2, z: 3 }).unwrap();
         py_assert!(py, var1, "str(var1) == 'X: 1, Y: 2, Z: 3'");
     })
@@ -82,7 +82,7 @@ impl Display for Point2 {
 
 #[test]
 fn test_struct_str() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, Point2 { x: 1, y: 2, z: 3 }).unwrap();
         py_assert!(py, var1, "str(var1) == '(1, 2, 3)'");
     })
@@ -103,7 +103,7 @@ impl Display for ComplexEnumWithStr {
 
 #[test]
 fn test_custom_complex_enum_str() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, ComplexEnumWithStr::A(45)).unwrap();
         let var2 = Py::new(
             py,
@@ -127,7 +127,7 @@ struct Coord2(u32, u32, u32);
 
 #[test]
 fn test_str_representation_by_position() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, Coord(1, 2, 3)).unwrap();
         let var2 = Py::new(py, Coord2(1, 2, 3)).unwrap();
         py_assert!(py, var1, "str(var1) == '1, 2, 3'");
@@ -145,7 +145,7 @@ struct Point4 {
 
 #[test]
 fn test_mixed_and_repeated_str_formats() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(
             py,
             Point4 {
@@ -172,7 +172,7 @@ struct Foo {
 
 #[test]
 fn test_raw_identifier_struct_custom_str() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, Foo { r#type: 3 }).unwrap();
         py_assert!(py, var1, "str(var1) == 'type: 3'");
     })

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -18,7 +18,7 @@ impl EmptyClassWithNew {
 
 #[test]
 fn empty_class_with_new() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<EmptyClassWithNew>();
         assert!(typeobj
             .call((), None)
@@ -47,7 +47,7 @@ impl UnitClassWithNew {
 
 #[test]
 fn unit_class_with_new() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<UnitClassWithNew>();
         assert!(typeobj
             .call((), None)
@@ -70,7 +70,7 @@ impl TupleClassWithNew {
 
 #[test]
 fn tuple_class_with_new() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<TupleClassWithNew>();
         let wrp = typeobj.call((42,), None).unwrap();
         let obj = wrp.downcast::<TupleClassWithNew>().unwrap();
@@ -95,7 +95,7 @@ impl NewWithOneArg {
 
 #[test]
 fn new_with_one_arg() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<NewWithOneArg>();
         let wrp = typeobj.call((42,), None).unwrap();
         let obj = wrp.downcast::<NewWithOneArg>().unwrap();
@@ -123,7 +123,7 @@ impl NewWithTwoArgs {
 
 #[test]
 fn new_with_two_args() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<NewWithTwoArgs>();
         let wrp = typeobj
             .call((10, 20), None)
@@ -154,7 +154,7 @@ impl SuperClass {
 /// See https://github.com/PyO3/pyo3/issues/947 for the corresponding bug.
 #[test]
 fn subclass_new() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let super_cls = py.get_type::<SuperClass>();
         let source = pyo3_ffi::c_str!(pyo3::indoc::indoc!(
             r#"
@@ -199,7 +199,7 @@ impl NewWithCustomError {
 
 #[test]
 fn new_with_custom_error() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<NewWithCustomError>();
         let err = typeobj.call0().unwrap_err();
         assert_eq!(err.to_string(), "ValueError: custom error");
@@ -234,7 +234,7 @@ impl NewExisting {
 
 #[test]
 fn test_new_existing() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<NewExisting>();
 
         let obj1 = typeobj.call1((0,)).unwrap();
@@ -272,7 +272,7 @@ impl NewReturnsPy {
 
 #[test]
 fn test_new_returns_py() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let type_ = py.get_type::<NewReturnsPy>();
         let obj = type_.call0().unwrap();
         assert!(obj.is_exact_instance_of::<NewReturnsPy>());
@@ -292,7 +292,7 @@ impl NewReturnsBound {
 
 #[test]
 fn test_new_returns_bound() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let type_ = py.get_type::<NewReturnsBound>();
         let obj = type_.call0().unwrap();
         assert!(obj.is_exact_instance_of::<NewReturnsBound>());
@@ -318,7 +318,7 @@ impl NewClassMethod {
 
 #[test]
 fn test_new_class_method() {
-    pyo3::Python::with_gil(|py| {
+    pyo3::Python::attach(|py| {
         let cls = py.get_type::<NewClassMethod>();
         pyo3::py_run!(py, cls, "assert cls().cls is cls");
     });

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -32,7 +32,7 @@ fn noop_coroutine() {
     async fn noop() -> usize {
         42
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let noop = wrap_pyfunction!(noop, py).unwrap();
         let test = "import asyncio; assert asyncio.run(noop()) == 42";
         py_run!(py, noop, &handle_windows(test));
@@ -58,7 +58,7 @@ fn test_coroutine_qualname() {
         #[staticmethod]
         async fn my_staticmethod() {}
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let test = r#"
         for coro, name, qualname in [
             (my_fn(), "my_fn", "my_fn"),
@@ -93,7 +93,7 @@ fn sleep_0_like_coroutine() {
         })
         .await
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let sleep_0 = wrap_pyfunction!(sleep_0, py).unwrap();
         let test = "import asyncio; assert asyncio.run(sleep_0()) == 42";
         py_run!(py, sleep_0, &handle_windows(test));
@@ -112,7 +112,7 @@ async fn sleep(seconds: f64) -> usize {
 
 #[test]
 fn sleep_coroutine() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let sleep = wrap_pyfunction!(sleep, py).unwrap();
         let test = r#"import asyncio; assert asyncio.run(sleep(0.1)) == 42"#;
         py_run!(py, sleep, &handle_windows(test));
@@ -126,7 +126,7 @@ async fn return_tuple() -> (usize, usize) {
 
 #[test]
 fn tuple_coroutine() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let func = wrap_pyfunction!(return_tuple, py).unwrap();
         let test = r#"import asyncio; assert asyncio.run(func()) == (42, 43)"#;
         py_run!(py, func, &handle_windows(test));
@@ -135,7 +135,7 @@ fn tuple_coroutine() {
 
 #[test]
 fn cancelled_coroutine() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let sleep = wrap_pyfunction!(sleep, py).unwrap();
         let test = r#"
         import asyncio
@@ -174,7 +174,7 @@ fn coroutine_cancel_handle() {
             _ = cancel.cancelled().fuse() => 0,
         }
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let cancellable_sleep = wrap_pyfunction!(cancellable_sleep, py).unwrap();
         let test = r#"
         import asyncio;
@@ -206,7 +206,7 @@ fn coroutine_is_cancelled() {
             sleep(0.001).await;
         }
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let sleep_loop = wrap_pyfunction!(sleep_loop, py).unwrap();
         let test = r#"
         import asyncio;
@@ -234,7 +234,7 @@ fn coroutine_panic() {
     async fn panic() {
         panic!("test panic");
     }
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let panic = wrap_pyfunction!(panic, py).unwrap();
         let test = r#"
         import asyncio
@@ -284,7 +284,7 @@ fn test_async_method_receiver() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let test = r#"
         import asyncio
 
@@ -342,7 +342,7 @@ fn test_async_method_receiver_with_other_args() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let test = r#"
         import asyncio
 

--- a/tests/test_datetime.rs
+++ b/tests/test_datetime.rs
@@ -70,7 +70,7 @@ macro_rules! assert_check_only {
 
 #[test]
 fn test_date_check() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let (obj, sub_obj, sub_sub_obj) = _get_subclasses(py, "date", "2018, 1, 1").unwrap();
         unsafe { PyDateTime_IMPORT() }
         assert_check_exact!(PyDate_Check, PyDate_CheckExact, obj);
@@ -84,7 +84,7 @@ fn test_date_check() {
 
 #[test]
 fn test_time_check() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let (obj, sub_obj, sub_sub_obj) = _get_subclasses(py, "time", "12, 30, 15").unwrap();
         unsafe { PyDateTime_IMPORT() }
 
@@ -99,7 +99,7 @@ fn test_time_check() {
 
 #[test]
 fn test_datetime_check() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let (obj, sub_obj, sub_sub_obj) = _get_subclasses(py, "datetime", "2018, 1, 1, 13, 30, 15")
             .map_err(|e| e.display(py))
             .unwrap();
@@ -117,7 +117,7 @@ fn test_datetime_check() {
 
 #[test]
 fn test_delta_check() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let (obj, sub_obj, sub_sub_obj) = _get_subclasses(py, "timedelta", "1, -3").unwrap();
         unsafe { PyDateTime_IMPORT() }
 
@@ -132,7 +132,7 @@ fn test_datetime_utc() {
     use assert_approx_eq::assert_approx_eq;
     use pyo3::types::PyDateTime;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let utc = PyTzInfo::utc(py).unwrap();
 
         let dt = PyDateTime::new(py, 2018, 1, 1, 0, 0, 0, 0, Some(&utc)).unwrap();
@@ -171,7 +171,7 @@ static INVALID_TIMES: &[(u8, u8, u8, u32)] =
 fn test_pydate_out_of_bounds() {
     use pyo3::types::PyDate;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         for val in INVALID_DATES {
             let (year, month, day) = val;
             let dt = PyDate::new(py, *year, *month, *day);
@@ -184,7 +184,7 @@ fn test_pydate_out_of_bounds() {
 fn test_pytime_out_of_bounds() {
     use pyo3::types::PyTime;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         for val in INVALID_TIMES {
             let (hour, minute, second, microsecond) = val;
             let dt = PyTime::new(py, *hour, *minute, *second, *microsecond, None);
@@ -198,7 +198,7 @@ fn test_pydatetime_out_of_bounds() {
     use pyo3::types::PyDateTime;
     use std::iter;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let valid_time = (0, 0, 0, 0);
         let valid_date = (2018, 1, 1);
 

--- a/tests/test_datetime_import.rs
+++ b/tests/test_datetime_import.rs
@@ -14,7 +14,7 @@ fn test_bad_datetime_module_panic() {
         .unwrap();
     std::fs::File::create(tmpdir.path().join("datetime.py")).unwrap();
 
-    Python::with_gil(|py: Python<'_>| {
+    Python::attach(|py: Python<'_>| {
         let sys = py.import("sys").unwrap();
         sys.getattr("path")
             .unwrap()

--- a/tests/test_declarative_module.rs
+++ b/tests/test_declarative_module.rs
@@ -173,7 +173,7 @@ fn declarative_module(py: Python<'_>) -> &Bound<'_, PyModule> {
 
 #[test]
 fn test_declarative_module() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = declarative_module(py);
         py_assert!(
             py,
@@ -216,7 +216,7 @@ mod r#type {
 
 #[test]
 fn test_raw_ident_module() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = pyo3::wrap_pymodule!(r#type)(py).into_bound(py);
         py_assert!(py, m, "m.double(2) == 4");
     })
@@ -224,7 +224,7 @@ fn test_raw_ident_module() {
 
 #[test]
 fn test_module_names() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = declarative_module(py);
         py_assert!(
             py,
@@ -248,7 +248,7 @@ fn test_module_names() {
 
 #[test]
 fn test_inner_module_full_path() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = declarative_module(py);
         py_assert!(py, m, "m.full_path_inner");
     })

--- a/tests/test_default_impls.rs
+++ b/tests/test_default_impls.rs
@@ -14,7 +14,7 @@ enum TestDefaultRepr {
 
 #[test]
 fn test_default_slot_exists() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let test_object = Py::new(py, TestDefaultRepr::Var).unwrap();
         py_assert!(
             py,
@@ -39,7 +39,7 @@ impl OverrideSlot {
 
 #[test]
 fn test_override_slot() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let test_object = Py::new(py, OverrideSlot::Var).unwrap();
         py_assert!(py, test_object, "repr(test_object) == 'overridden'");
     })

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -16,7 +16,7 @@ pub enum MyEnum {
 
 #[test]
 fn test_enum_class_attr() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let my_enum = py.get_type::<MyEnum>();
         let var = Py::new(py, MyEnum::Variant).unwrap();
         py_assert!(py, my_enum var, "my_enum.Variant == var");
@@ -25,7 +25,7 @@ fn test_enum_class_attr() {
 
 #[test]
 fn test_enum_eq_enum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, MyEnum::Variant).unwrap();
         let var2 = Py::new(py, MyEnum::Variant).unwrap();
         let other_var = Py::new(py, MyEnum::OtherVariant).unwrap();
@@ -37,7 +37,7 @@ fn test_enum_eq_enum() {
 
 #[test]
 fn test_enum_eq_incomparable() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, MyEnum::Variant).unwrap();
         py_assert!(py, var1, "(var1 == 'foo') == False");
         py_assert!(py, var1, "(var1 != 'foo') == True");
@@ -51,7 +51,7 @@ fn return_enum() -> MyEnum {
 
 #[test]
 fn test_return_enum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(return_enum)(py).unwrap();
         let mynum = py.get_type::<MyEnum>();
 
@@ -66,7 +66,7 @@ fn enum_arg(e: MyEnum) {
 
 #[test]
 fn test_enum_arg() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(enum_arg)(py).unwrap();
         let mynum = py.get_type::<MyEnum>();
 
@@ -83,7 +83,7 @@ enum CustomDiscriminant {
 
 #[test]
 fn test_custom_discriminant() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         #[allow(non_snake_case)]
         let CustomDiscriminant = py.get_type::<CustomDiscriminant>();
         let one = Py::new(py, CustomDiscriminant::One).unwrap();
@@ -102,7 +102,7 @@ fn test_custom_discriminant() {
 
 #[test]
 fn test_enum_to_int() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let one = Py::new(py, CustomDiscriminant::One).unwrap();
         py_assert!(py, one, "int(one) == 1");
         let v = Py::new(py, MyEnum::Variant).unwrap();
@@ -113,7 +113,7 @@ fn test_enum_to_int() {
 
 #[test]
 fn test_enum_compare_int() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let one = Py::new(py, CustomDiscriminant::One).unwrap();
         py_run!(
             py,
@@ -136,7 +136,7 @@ enum SmallEnum {
 
 #[test]
 fn test_enum_compare_int_no_throw_when_overflow() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let v = Py::new(py, SmallEnum::V).unwrap();
         py_assert!(py, v, "v != 1<<30")
     })
@@ -152,7 +152,7 @@ enum BigEnum {
 
 #[test]
 fn test_big_enum_no_overflow() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let usize_max = usize::MAX;
         let v = Py::new(py, BigEnum::V).unwrap();
 
@@ -181,7 +181,7 @@ pub enum RenameEnum {
 
 #[test]
 fn test_rename_enum_repr_correct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, RenameEnum::Variant).unwrap();
         py_assert!(py, var1, "repr(var1) == 'MyEnum.Variant'");
     })
@@ -196,7 +196,7 @@ pub enum RenameVariantEnum {
 
 #[test]
 fn test_rename_variant_repr_correct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, RenameVariantEnum::Variant).unwrap();
         py_assert!(py, var1, "repr(var1) == 'RenameVariantEnum.VARIANT'");
     })
@@ -214,7 +214,7 @@ enum RenameAllVariantsEnum {
 
 #[test]
 fn test_renaming_all_enum_variants() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let enum_obj = py.get_type::<RenameAllVariantsEnum>();
         py_assert!(py, enum_obj, "enum_obj.VARIANT_ONE == enum_obj.VARIANT_ONE");
         py_assert!(py, enum_obj, "enum_obj.VARIANT_TWO == enum_obj.VARIANT_TWO");
@@ -235,7 +235,7 @@ enum CustomModuleComplexEnum {
 
 #[test]
 fn test_custom_module() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let enum_obj = py.get_type::<CustomModuleComplexEnum>();
         py_assert!(
             py,
@@ -254,7 +254,7 @@ pub enum EqOnly {
 
 #[test]
 fn test_simple_enum_eq_only() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let var1 = Py::new(py, EqOnly::VariantA).unwrap();
         let var2 = Py::new(py, EqOnly::VariantA).unwrap();
         let var3 = Py::new(py, EqOnly::VariantB).unwrap();
@@ -272,7 +272,7 @@ enum SimpleEnumWithHash {
 
 #[test]
 fn test_simple_enum_with_hash() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         use pyo3::types::IntoPyDict;
         let class = SimpleEnumWithHash::A;
         let hash = {
@@ -302,7 +302,7 @@ enum ComplexEnumWithHash {
 
 #[test]
 fn test_complex_enum_with_hash() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         use pyo3::types::IntoPyDict;
         let class = ComplexEnumWithHash::B {
             msg: String::from("Hello"),
@@ -354,7 +354,7 @@ fn custom_eq() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let a = Bound::new(py, CustomPyEq::A).unwrap();
         let b = Bound::new(py, CustomPyEq::B).unwrap();
 
@@ -379,7 +379,7 @@ pub enum ComplexEnumWithRaw {
 // Cover simple field lookups with raw identifiers
 #[test]
 fn complex_enum_with_raw() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let complex = ComplexEnumWithRaw::Raw { r#type: 314159 };
 
         py_assert!(py, complex, "complex.type == 314159");
@@ -390,7 +390,7 @@ fn complex_enum_with_raw() {
 #[test]
 #[cfg(Py_3_10)]
 fn complex_enum_with_raw_pattern_match() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let complex = ComplexEnumWithRaw::Raw { r#type: 314159 };
         let cls = py.get_type::<ComplexEnumWithRaw>();
 

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -21,7 +21,7 @@ fn fail_to_open_file() -> PyResult<()> {
 #[cfg_attr(target_arch = "wasm32", ignore)] // Not sure why this fails.
 #[cfg(not(target_os = "windows"))]
 fn test_filenotfounderror() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let fail_to_open_file = wrap_pyfunction!(fail_to_open_file)(py).unwrap();
 
         py_run!(
@@ -66,7 +66,7 @@ fn call_fail_with_custom_error() -> PyResult<()> {
 
 #[test]
 fn test_custom_error() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let call_fail_with_custom_error =
             wrap_pyfunction!(call_fail_with_custom_error)(py).unwrap();
 
@@ -105,7 +105,7 @@ fn test_write_unraisable() {
     use pyo3::{exceptions::PyRuntimeError, ffi, types::PyNotImplemented};
     use std::ptr;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let capture = UnraisableCapture::install(py);
 
         assert!(capture.borrow(py).capture.is_none());

--- a/tests/test_field_cfg.rs
+++ b/tests/test_field_cfg.rs
@@ -28,7 +28,7 @@ enum CfgSimpleEnum {
 
 #[test]
 fn test_cfg() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let cfg = CfgClass { b: 3 };
         let py_cfg = Py::new(py, cfg).unwrap();
         assert!(py_cfg.bind(py).getattr("a").is_err());
@@ -39,7 +39,7 @@ fn test_cfg() {
 
 #[test]
 fn test_cfg_simple_enum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let simple = py.get_type::<CfgSimpleEnum>();
         pyo3::py_run!(
             py,

--- a/tests/test_frompy_intopy_roundtrip.rs
+++ b/tests/test_frompy_intopy_roundtrip.rs
@@ -21,7 +21,7 @@ pub struct A<'py> {
 
 #[test]
 fn test_named_fields_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let a = A {
             s: "Hello".into(),
             t: PyString::new(py, "World"),
@@ -57,7 +57,7 @@ pub struct B {
 
 #[test]
 fn test_transparent_named_field_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let b = B {
             test: "test".into(),
         };
@@ -79,7 +79,7 @@ pub struct D<T> {
 
 #[test]
 fn test_generic_transparent_named_field_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = D {
             test: String::from("test"),
         };
@@ -111,7 +111,7 @@ pub struct GenericWithBound<K: Hash + Eq, V>(HashMap<K, V>);
 
 #[test]
 fn test_generic_with_bound() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let mut hash_map = HashMap::<String, i32>::new();
         hash_map.insert("1".into(), 1);
         hash_map.insert("2".into(), 2);
@@ -167,7 +167,7 @@ pub struct Tuple(String, usize);
 
 #[test]
 fn test_tuple_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = Tuple(String::from("test"), 1);
         let tuple = (&tup).into_pyobject(py).unwrap();
         let new_tup = tuple.extract::<Tuple>().unwrap();
@@ -184,7 +184,7 @@ pub struct TransparentTuple(String);
 
 #[test]
 fn test_transparent_tuple_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = TransparentTuple(String::from("test"));
         let tuple = (&tup).into_pyobject(py).unwrap();
         let new_tup = tuple.extract::<TransparentTuple>().unwrap();
@@ -234,7 +234,7 @@ pub enum Foo {
 
 #[test]
 fn test_enum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tuple_var = Foo::TupleVar(1, "test".into());
         let foo = (&tuple_var).into_pyobject(py).unwrap();
         assert_eq!(tuple_var, foo.extract::<Foo>().unwrap());

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -52,7 +52,7 @@ impl PyA {
 
 #[test]
 fn test_named_fields_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pya = PyA {
             s: "foo".into(),
             foo: None,
@@ -75,7 +75,7 @@ pub struct B {
 
 #[test]
 fn test_transparent_named_field_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let test = "test".into_pyobject(py).unwrap();
         let b = test
             .extract::<B>()
@@ -95,7 +95,7 @@ pub struct D<T> {
 
 #[test]
 fn test_generic_transparent_named_field_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let test = "test".into_pyobject(py).unwrap();
         let d = test
             .extract::<D<String>>()
@@ -114,7 +114,7 @@ pub struct GenericWithBound<K: std::hash::Hash + Eq, V>(std::collections::HashMa
 
 #[test]
 fn test_generic_with_bound() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dict = [("1", 1), ("2", 2)].into_py_dict(py).unwrap();
         let map = dict.extract::<GenericWithBound<String, i32>>().unwrap().0;
         assert_eq!(map.len(), 2);
@@ -141,7 +141,7 @@ pub struct PyE {
 
 #[test]
 fn test_generic_named_fields_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pye = PyE {
             test: "test".into(),
             test2: 2,
@@ -167,7 +167,7 @@ pub struct C {
 
 #[test]
 fn test_named_field_with_ext_fn() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyc = PyE {
             test: "foo".into(),
             test2: 0,
@@ -184,7 +184,7 @@ pub struct Tuple(String, usize);
 
 #[test]
 fn test_tuple_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = PyTuple::new(
             py,
             &[
@@ -216,7 +216,7 @@ pub struct TransparentTuple(String);
 
 #[test]
 fn test_transparent_tuple_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = 1i32.into_pyobject(py).unwrap();
         let tup = tup.extract::<TransparentTuple>();
         assert!(tup.is_err());
@@ -245,7 +245,7 @@ struct Baz<U, T> {
 
 #[test]
 fn test_struct_nested_type_errors() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pybaz = PyBaz {
             tup: ("test".into(), "test".into()),
             e: PyE {
@@ -268,7 +268,7 @@ fn test_struct_nested_type_errors() {
 
 #[test]
 fn test_struct_nested_type_errors_with_generics() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pybaz = PyBaz {
             tup: ("test".into(), "test".into()),
             e: PyE {
@@ -291,7 +291,7 @@ fn test_struct_nested_type_errors_with_generics() {
 
 #[test]
 fn test_transparent_struct_error_message() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = 1i32.into_pyobject(py).unwrap();
         let tup = tup.extract::<B>();
         assert!(tup.is_err());
@@ -305,7 +305,7 @@ fn test_transparent_struct_error_message() {
 
 #[test]
 fn test_tuple_struct_error_message() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = (1, "test").into_pyobject(py).unwrap();
         let tup = tup.extract::<Tuple>();
         assert!(tup.is_err());
@@ -319,7 +319,7 @@ fn test_tuple_struct_error_message() {
 
 #[test]
 fn test_transparent_tuple_error_message() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = 1i32.into_pyobject(py).unwrap();
         let tup = tup.extract::<TransparentTuple>();
         assert!(tup.is_err());
@@ -368,7 +368,7 @@ fn test_struct_rename_all() {
         custom_name: i32,
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let RenameAll {
             some_field,
             other_field,
@@ -399,7 +399,7 @@ fn test_enum_rename_all() {
         },
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let RenameAll::Foo {
             some_field,
             other_field,
@@ -450,7 +450,7 @@ pub struct PyBool {
 
 #[test]
 fn test_enum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = PyTuple::new(
             py,
             &[
@@ -534,7 +534,7 @@ fn test_enum() {
 
 #[test]
 fn test_enum_error() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dict = PyDict::new(py);
         let err = dict.extract::<Foo<'_>>().unwrap_err();
         assert_eq!(
@@ -578,7 +578,7 @@ enum EnumWithCatchAll<'py> {
 
 #[test]
 fn test_enum_catch_all() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dict = PyDict::new(py);
         let f = dict
             .extract::<EnumWithCatchAll<'_>>()
@@ -605,7 +605,7 @@ pub enum Bar {
 
 #[test]
 fn test_err_rename() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dict = PyDict::new(py);
         let f = dict.extract::<Bar>();
         assert!(f.is_err());
@@ -631,7 +631,7 @@ pub struct Zap {
 
 #[test]
 fn test_from_py_with() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_zap = py
             .eval(
                 pyo3_ffi::c_str!(r#"{"name": "whatever", "my_object": [1, 2, 3]}"#),
@@ -655,7 +655,7 @@ pub struct ZapTuple(
 
 #[test]
 fn test_from_py_with_tuple_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_zap = py
             .eval(pyo3_ffi::c_str!(r#"("whatever", [1, 2, 3])"#), None, None)
             .expect("failed to create tuple");
@@ -669,7 +669,7 @@ fn test_from_py_with_tuple_struct() {
 
 #[test]
 fn test_from_py_with_tuple_struct_error() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_zap = py
             .eval(
                 pyo3_ffi::c_str!(r#"("whatever", [1, 2, 3], "third")"#),
@@ -699,7 +699,7 @@ pub enum ZapEnum {
 
 #[test]
 fn test_from_py_with_enum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_zap = py
             .eval(pyo3_ffi::c_str!(r#"("whatever", [1, 2, 3])"#), None, None)
             .expect("failed to create tuple");
@@ -720,7 +720,7 @@ pub struct TransparentFromPyWith {
 
 #[test]
 fn test_transparent_from_py_with() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let result = PyList::new(py, [1, 2, 3])
             .unwrap()
             .extract::<TransparentFromPyWith>()
@@ -744,7 +744,7 @@ pub struct WithKeywordAttrC {
 
 #[test]
 fn test_with_keyword_attr() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let cls = WithKeywordAttrC { r#box: 3 }.into_pyobject(py).unwrap();
         let result = cls.extract::<WithKeywordAttr>().unwrap();
         let expected = WithKeywordAttr { r#box: 3 };
@@ -760,7 +760,7 @@ pub struct WithKeywordItem {
 
 #[test]
 fn test_with_keyword_item() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dict = PyDict::new(py);
         dict.set_item("box", 3).unwrap();
         let result = dict.extract::<WithKeywordItem>().unwrap();
@@ -779,7 +779,7 @@ pub struct WithDefaultItem {
 
 #[test]
 fn test_with_default_item() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dict = PyDict::new(py);
         dict.set_item("value", 3).unwrap();
         let result = dict.extract::<WithDefaultItem>().unwrap();
@@ -801,7 +801,7 @@ pub struct WithExplicitDefaultItem {
 
 #[test]
 fn test_with_explicit_default_item() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let dict = PyDict::new(py);
         dict.set_item("value", 3).unwrap();
         let result = dict.extract::<WithExplicitDefaultItem>().unwrap();
@@ -820,7 +820,7 @@ pub struct WithDefaultItemAndConversionFunction {
 
 #[test]
 fn test_with_default_item_and_conversion_function() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // Filled case
         let dict = PyDict::new(py);
         dict.set_item("opt", (1,)).unwrap();
@@ -865,7 +865,7 @@ pub enum WithDefaultItemEnum {
 
 #[test]
 fn test_with_default_item_enum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // A and B filled
         let dict = PyDict::new(py);
         dict.set_item("a", 1).unwrap();

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -65,7 +65,7 @@ fn extract_len(any: &Bound<'_, PyAny>) -> PyResult<i32> {
 
 #[test]
 fn class_with_properties() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, ClassWithProperties { num: 10 }).unwrap();
 
         py_run!(py, inst, "assert inst.get_num() == 10");
@@ -110,7 +110,7 @@ impl GetterSetter {
 
 #[test]
 fn getter_setter_autogen() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(
             py,
             GetterSetter {
@@ -151,7 +151,7 @@ impl RefGetterSetter {
 #[test]
 fn ref_getter_setter() {
     // Regression test for #837
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, RefGetterSetter { num: 10 }).unwrap();
 
         py_run!(py, inst, "assert inst.num == 10");
@@ -177,7 +177,7 @@ impl TupleClassGetterSetter {
 
 #[test]
 fn tuple_struct_getter_setter() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, TupleClassGetterSetter(10)).unwrap();
 
         py_assert!(py, inst, "inst.num == 10");
@@ -193,7 +193,7 @@ struct All {
 
 #[test]
 fn get_set_all() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, All { num: 10 }).unwrap();
 
         py_run!(py, inst, "assert inst.num == 10");
@@ -209,7 +209,7 @@ struct All2 {
 
 #[test]
 fn get_all_and_set() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, All2 { num: 10 }).unwrap();
 
         py_run!(py, inst, "assert inst.num == 10");
@@ -228,7 +228,7 @@ fn cell_getter_setter() {
     let c = CellGetterSetter {
         cell_inner: Cell::new(10),
     };
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, c).unwrap();
         let cell = Cell::new(20i32).into_pyobject(py).unwrap();
 
@@ -255,7 +255,7 @@ fn borrowed_value_with_lifetime_of_self() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, BorrowedValue {}).unwrap();
 
         py_run!(py, inst, "assert inst.value == 'value'");
@@ -270,7 +270,7 @@ fn frozen_py_field_get() {
         value: Py<PyString>,
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(
             py,
             FrozenPyField {
@@ -303,7 +303,7 @@ fn test_optional_setter() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let instance = Py::new(py, SimpleClass { field: None }).unwrap();
         py_run!(py, instance, "assert instance.field is None");
         py_run!(

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -20,7 +20,7 @@ struct SubclassAble {}
 
 #[test]
 fn subclass() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [("SubclassAble", py.get_type::<SubclassAble>())]
             .into_py_dict(py)
             .unwrap();
@@ -74,7 +74,7 @@ impl SubClass {
 
 #[test]
 fn inheritance_with_new_methods() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<SubClass>();
         let inst = typeobj.call((), None).unwrap();
         py_run!(py, inst, "assert inst.val1 == 10; assert inst.val2 == 5");
@@ -83,7 +83,7 @@ fn inheritance_with_new_methods() {
 
 #[test]
 fn call_base_and_sub_methods() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = Py::new(py, SubClass::new()).unwrap();
         py_run!(
             py,
@@ -98,7 +98,7 @@ fn call_base_and_sub_methods() {
 
 #[test]
 fn mutation_fails() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = Py::new(py, SubClass::new()).unwrap();
         let global = [("obj", obj)].into_py_dict(py).unwrap();
         let e = py
@@ -114,7 +114,7 @@ fn mutation_fails() {
 
 #[test]
 fn is_subclass_and_is_instance() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let sub_ty = py.get_type::<SubClass>();
         let base_ty = py.get_type::<BaseClass>();
         assert!(sub_ty.is_subclass_of::<BaseClass>().unwrap());
@@ -157,7 +157,7 @@ impl SubClass2 {
 
 #[test]
 fn handle_result_in_new() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let subclass = py.get_type::<SubClass2>();
         py_run!(
             py,
@@ -202,7 +202,7 @@ mod inheriting_native_type {
             }
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let set_sub = pyo3::Py::new(py, SetWithName::new()).unwrap();
             py_run!(
                 py,
@@ -229,7 +229,7 @@ mod inheriting_native_type {
 
     #[test]
     fn inherit_dict() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict_sub = pyo3::Py::new(py, DictWithName::new()).unwrap();
             py_run!(
                 py,
@@ -241,7 +241,7 @@ mod inheriting_native_type {
 
     #[test]
     fn inherit_dict_drop() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let dict_sub = pyo3::Py::new(py, DictWithName::new()).unwrap();
             assert_eq!(dict_sub.get_refcnt(py), 1);
 
@@ -274,7 +274,7 @@ mod inheriting_native_type {
 
     #[test]
     fn custom_exception() {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let cls = py.get_type::<CustomException>();
             let dict = [("cls", &cls)].into_py_dict(py).unwrap();
             let res = py.run(
@@ -314,7 +314,7 @@ impl SimpleClass {
 #[test]
 fn test_subclass_ref_counts() {
     // regression test for issue #1363
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         #[allow(non_snake_case)]
         let SimpleClass = py.get_type::<SimpleClass>();
         py_run!(

--- a/tests/test_intopyobject.rs
+++ b/tests/test_intopyobject.rs
@@ -18,7 +18,7 @@ pub struct A<'py> {
 
 #[test]
 fn test_named_fields_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let a = A {
             s: "Hello".into(),
             t: PyString::new(py, "World"),
@@ -60,7 +60,7 @@ pub struct B<'a> {
 
 #[test]
 fn test_transparent_named_field_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyb = B { test: "test" }.into_pyobject(py).unwrap();
         let b = pyb.extract::<String>().unwrap();
         assert_eq!(b, "test");
@@ -75,7 +75,7 @@ pub struct D<T> {
 
 #[test]
 fn test_generic_transparent_named_field_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyd = D {
             test: String::from("test"),
         }
@@ -95,7 +95,7 @@ pub struct GenericWithBound<K: Hash + Eq, V>(HashMap<K, V>);
 
 #[test]
 fn test_generic_with_bound() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let mut hash_map = HashMap::<String, i32>::new();
         hash_map.insert("1".into(), 1);
         hash_map.insert("2".into(), 2);
@@ -126,7 +126,7 @@ pub struct Tuple(String, usize);
 
 #[test]
 fn test_tuple_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = Tuple(String::from("test"), 1).into_pyobject(py).unwrap();
         assert!(tup.extract::<(usize, String)>().is_err());
         let tup = tup.extract::<(String, usize)>().unwrap();
@@ -140,7 +140,7 @@ pub struct TransparentTuple(String);
 
 #[test]
 fn test_transparent_tuple_struct() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = TransparentTuple(String::from("test"))
             .into_pyobject(py)
             .unwrap();
@@ -177,7 +177,7 @@ pub enum Foo<'py> {
 
 #[test]
 fn test_enum() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let foo = Foo::TupleVar(1, "test".into(), std::marker::PhantomData)
             .into_pyobject(py)
             .unwrap();
@@ -231,7 +231,7 @@ fn zap_into_py<'py>(
 
 #[test]
 fn test_into_py_with() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let zap = Zap {
             name: "whatever".into(),
             some_object_length: 3,
@@ -271,7 +271,7 @@ fn test_struct_into_py_rename_all() {
         long_field_name: 0.0,
     };
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_foo_ref = (&foo).into_pyobject(py).unwrap();
         let py_foo = foo.into_pyobject(py).unwrap();
 

--- a/tests/test_macro_docs.rs
+++ b/tests/test_macro_docs.rs
@@ -22,7 +22,7 @@ impl MacroDocs {
 
 #[test]
 fn meth_doc() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [("C", py.get_type::<MacroDocs>())]
             .into_py_dict(py)
             .unwrap();

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -73,7 +73,7 @@ property_rename_via_macro!(my_new_property_name);
 
 #[test]
 fn test_macro_rules_interactions() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let my_base = py.get_type::<MyBaseClass>();
         py_assert!(py, my_base, "my_base.__name__ == 'MyClass'");
 

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -85,7 +85,7 @@ fn map_dict(py: Python<'_>) -> Bound<'_, pyo3::types::PyDict> {
 
 #[test]
 fn test_getitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = map_dict(py);
 
         py_assert!(py, *d, "m['1'] == 0");
@@ -97,7 +97,7 @@ fn test_getitem() {
 
 #[test]
 fn test_setitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = map_dict(py);
 
         py_run!(py, *d, "m['1'] = 4; assert m['1'] == 4");
@@ -110,7 +110,7 @@ fn test_setitem() {
 
 #[test]
 fn test_delitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = map_dict(py);
         py_run!(
             py,
@@ -124,7 +124,7 @@ fn test_delitem() {
 
 #[test]
 fn mapping_is_not_sequence() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let mut index = HashMap::new();
         index.insert("Foo".into(), 1);
         index.insert("Bar".into(), 2);

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -34,7 +34,7 @@ impl InstanceMethod {
 
 #[test]
 fn instance_method() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = Bound::new(py, InstanceMethod { member: 42 }).unwrap();
         let obj_ref = obj.borrow();
         assert_eq!(obj_ref.method(), 42);
@@ -58,7 +58,7 @@ impl InstanceMethodWithArgs {
 
 #[test]
 fn instance_method_with_args() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = Bound::new(py, InstanceMethodWithArgs { member: 7 }).unwrap();
         let obj_ref = obj.borrow();
         assert_eq!(obj_ref.method(6), 42);
@@ -91,7 +91,7 @@ impl ClassMethod {
 
 #[test]
 fn class_method() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [("C", py.get_type::<ClassMethod>())]
             .into_py_dict(py)
             .unwrap();
@@ -120,7 +120,7 @@ impl ClassMethodWithArgs {
 
 #[test]
 fn class_method_with_args() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [("C", py.get_type::<ClassMethodWithArgs>())]
             .into_py_dict(py)
             .unwrap();
@@ -151,7 +151,7 @@ impl StaticMethod {
 
 #[test]
 fn static_method() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         assert_eq!(StaticMethod::method(py), "StaticMethod.method()!");
 
         let d = [("C", py.get_type::<StaticMethod>())]
@@ -177,7 +177,7 @@ impl StaticMethodWithArgs {
 
 #[test]
 fn static_method_with_args() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         assert_eq!(StaticMethodWithArgs::method(py, 1234), "0x4d2");
 
         let d = [("C", py.get_type::<StaticMethodWithArgs>())]
@@ -375,7 +375,7 @@ impl MethSignature {
 
 #[test]
 fn meth_signature() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, MethSignature {}).unwrap();
 
         py_run!(py, inst, "assert inst.get_optional() == 10");
@@ -722,7 +722,7 @@ impl MethDocs {
 
 #[test]
 fn meth_doc() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [("C", py.get_type::<MethDocs>())].into_py_dict(py).unwrap();
         py_assert!(py, *d, "C.__doc__ == 'A class with \"documentation\".'");
         py_assert!(
@@ -757,7 +757,7 @@ impl MethodWithLifeTime {
 
 #[test]
 fn method_with_lifetime() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj = Py::new(py, MethodWithLifeTime {}).unwrap();
         py_run!(
             py,
@@ -807,7 +807,7 @@ impl MethodWithPyClassArg {
 
 #[test]
 fn method_with_pyclassarg() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let obj1 = Py::new(py, MethodWithPyClassArg { value: 10 }).unwrap();
         let obj2 = Py::new(py, MethodWithPyClassArg { value: 10 }).unwrap();
         let d = [("obj1", obj1), ("obj2", obj2)].into_py_dict(py).unwrap();
@@ -870,7 +870,7 @@ impl CfgStruct {
 
 #[test]
 fn test_cfg_attrs() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, CfgStruct {}).unwrap();
 
         #[cfg(unix)]
@@ -913,7 +913,7 @@ impl FromSequence {
 
 #[test]
 fn test_from_sequence() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<FromSequence>();
         py_assert!(py, typeobj, "typeobj(range(0, 4)).numbers == [0, 1, 2, 3]");
     });
@@ -993,7 +993,7 @@ impl r#RawIdents {
 
 #[test]
 fn test_raw_idents() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let raw_idents_type = py.get_type::<r#RawIdents>();
         assert_eq!(raw_idents_type.qualname().unwrap(), "RawIdents");
         py_run!(
@@ -1180,7 +1180,7 @@ fn test_option_pyclass_arg() {
         arg.map(|_| SomePyClass {})
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(option_class_arg, py).unwrap();
         assert!(f.call0().unwrap().is_none());
         let obj = Py::new(py, SomePyClass {}).unwrap();
@@ -1289,7 +1289,7 @@ fn test_pymethods_warn() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<WarningMethodContainer>();
         let obj = typeobj.call0().unwrap();
 
@@ -1407,7 +1407,7 @@ fn test_pymethods_warn() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<WarningMethodContainer2>();
 
         // #[new], #[classmethod], FnType::FnNewClass
@@ -1446,7 +1446,7 @@ fn test_py_methods_multiple_warn() {
         fn multiple_warn_custom_category_method(&self) {}
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<MultipleWarnContainer>();
         let obj = typeobj.call0().unwrap();
 

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -72,7 +72,7 @@ fn module_with_functions(m: &Bound<'_, PyModule>) -> PyResult<()> {
 fn test_module_with_functions() {
     use pyo3::wrap_pymodule;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [(
             "module_with_functions",
             wrap_pymodule!(module_with_functions)(py),
@@ -130,7 +130,7 @@ fn module_with_explicit_py_arg(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyRe
 fn test_module_with_explicit_py_arg() {
     use pyo3::wrap_pymodule;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [(
             "module_with_explicit_py_arg",
             wrap_pymodule!(module_with_explicit_py_arg)(py),
@@ -152,7 +152,7 @@ fn some_name(m: &Bound<'_, PyModule>) -> PyResult<()> {
 fn test_module_renaming() {
     use pyo3::wrap_pymodule;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [("different_name", wrap_pymodule!(some_name)(py))]
             .into_py_dict(py)
             .unwrap();
@@ -163,7 +163,7 @@ fn test_module_renaming() {
 
 #[test]
 fn test_module_from_code_bound() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let adder_mod = PyModule::from_code(
             py,
             c_str!("def add(a,b):\n\treturn a+b"),
@@ -202,7 +202,7 @@ fn raw_ident_module(module: &Bound<'_, PyModule>) -> PyResult<()> {
 fn test_raw_idents() {
     use pyo3::wrap_pymodule;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = wrap_pymodule!(raw_ident_module)(py);
 
         py_assert!(py, module, "module.move() == 42");
@@ -223,7 +223,7 @@ fn test_custom_names() {
         Ok(())
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = pyo3::wrap_pymodule!(custom_names)(py);
 
         py_assert!(py, module, "not hasattr(module, 'custom_named_fn')");
@@ -239,7 +239,7 @@ fn test_module_dict() {
         Ok(())
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = pyo3::wrap_pymodule!(module_dict)(py);
 
         py_assert!(py, module, "module.yay == 'me'");
@@ -248,7 +248,7 @@ fn test_module_dict() {
 
 #[test]
 fn test_module_dunder_all() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         #[pymodule]
         fn dunder_all(m: &Bound<'_, PyModule>) -> PyResult<()> {
             m.dict().set_item("yay", "me")?;
@@ -299,7 +299,7 @@ fn supermodule(module: &Bound<'_, PyModule>) -> PyResult<()> {
 fn test_module_nesting() {
     use pyo3::wrap_pymodule;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let supermodule = wrap_pymodule!(supermodule)(py);
 
         py_assert!(
@@ -345,7 +345,7 @@ fn vararg_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[test]
 fn test_vararg_module() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = pyo3::wrap_pymodule!(vararg_module)(py);
 
         py_assert!(py, m, "m.ext_vararg_fn() == [5, ()]");
@@ -370,7 +370,7 @@ fn test_module_with_constant() {
         Ok(())
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = pyo3::wrap_pymodule!(module_with_constant)(py);
         py_assert!(py, m, "isinstance(m.ANON, m.AnonClass)");
     });
@@ -444,7 +444,7 @@ fn module_with_functions_with_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[test]
 fn test_module_functions_with_module() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = pyo3::wrap_pymodule!(module_with_functions_with_module)(py);
         py_assert!(
             py,
@@ -485,7 +485,7 @@ fn test_module_doc_hidden() {
         Ok(())
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = pyo3::wrap_pymodule!(my_module)(py);
         py_assert!(py, m, "m.__doc__ == ''");
     })

--- a/tests/test_multiple_pymethods.rs
+++ b/tests/test_multiple_pymethods.rs
@@ -64,7 +64,7 @@ impl PyClassWithMultiplePyMethods {
 
 #[test]
 fn test_class_with_multiple_pymethods() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let cls = py.get_type::<PyClassWithMultiplePyMethods>();
         py_assert!(py, cls, "cls()() == 'call'");
         py_assert!(py, cls, "cls().method() == 'method'");

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -78,7 +78,7 @@ fn make_example(py: Python<'_>) -> Bound<'_, ExampleClass> {
 
 #[test]
 fn test_getattr() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let example_py = make_example(py);
         assert_eq!(
             example_py
@@ -105,7 +105,7 @@ fn test_getattr() {
 
 #[test]
 fn test_setattr() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let example_py = make_example(py);
         example_py.setattr("special_custom_attr", 15).unwrap();
         assert_eq!(
@@ -121,7 +121,7 @@ fn test_setattr() {
 
 #[test]
 fn test_delattr() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let example_py = make_example(py);
         example_py.delattr("special_custom_attr").unwrap();
         assert!(example_py.getattr("special_custom_attr").unwrap().is_none());
@@ -130,7 +130,7 @@ fn test_delattr() {
 
 #[test]
 fn test_str() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let example_py = make_example(py);
         assert_eq!(example_py.str().unwrap(), "5");
     })
@@ -138,7 +138,7 @@ fn test_str() {
 
 #[test]
 fn test_repr() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let example_py = make_example(py);
         assert_eq!(example_py.repr().unwrap(), "ExampleClass(value=5)");
     })
@@ -146,7 +146,7 @@ fn test_repr() {
 
 #[test]
 fn test_hash() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let example_py = make_example(py);
         assert_eq!(example_py.hash().unwrap(), 5);
     })
@@ -154,7 +154,7 @@ fn test_hash() {
 
 #[test]
 fn test_bool() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let example_py = make_example(py);
         assert!(example_py.is_truthy().unwrap());
         example_py.borrow_mut().value = 0;
@@ -174,7 +174,7 @@ impl LenOverflow {
 
 #[test]
 fn len_overflow() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, LenOverflow).unwrap();
         py_expect_exception!(py, inst, "len(inst)", PyOverflowError);
     });
@@ -207,7 +207,7 @@ impl Mapping {
 
 #[test]
 fn mapping() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         PyMapping::register::<Mapping>(py).unwrap();
 
         let inst = Py::new(
@@ -315,7 +315,7 @@ impl Sequence {
 
 #[test]
 fn sequence() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         PySequence::register::<Sequence>(py).unwrap();
 
         let inst = Py::new(py, Sequence { values: vec![] }).unwrap();
@@ -378,7 +378,7 @@ impl Iterator {
 
 #[test]
 fn iterator() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(
             py,
             Iterator {
@@ -406,7 +406,7 @@ struct NotCallable;
 
 #[test]
 fn callable() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Py::new(py, Callable).unwrap();
         py_assert!(py, c, "callable(c)");
         py_assert!(py, c, "c(7) == 42");
@@ -433,7 +433,7 @@ impl SetItem {
 
 #[test]
 fn setitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Bound::new(py, SetItem { key: 0, val: 0 }).unwrap();
         py_run!(py, c, "c[1] = 2");
         {
@@ -459,7 +459,7 @@ impl DelItem {
 
 #[test]
 fn delitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Bound::new(py, DelItem { key: 0 }).unwrap();
         py_run!(py, c, "del c[1]");
         {
@@ -488,7 +488,7 @@ impl SetDelItem {
 
 #[test]
 fn setdelitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Bound::new(py, SetDelItem { val: None }).unwrap();
         py_run!(py, c, "c[1] = 2");
         {
@@ -513,7 +513,7 @@ impl Contains {
 
 #[test]
 fn contains() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let c = Py::new(py, Contains {}).unwrap();
         py_run!(py, c, "assert 1 in c");
         py_run!(py, c, "assert -1 not in c");
@@ -543,7 +543,7 @@ impl GetItem {
 
 #[test]
 fn test_getitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let ob = Py::new(py, GetItem {}).unwrap();
 
         py_assert!(py, ob, "ob[1] == 'int'");
@@ -566,7 +566,7 @@ impl ClassWithGetAttr {
 
 #[test]
 fn getattr_doesnt_override_member() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, ClassWithGetAttr { data: 4 }).unwrap();
         py_assert!(py, inst, "inst.data == 4");
         py_assert!(py, inst, "inst.a == 8");
@@ -588,7 +588,7 @@ impl ClassWithGetAttribute {
 
 #[test]
 fn getattribute_overrides_member() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, ClassWithGetAttribute { data: 4 }).unwrap();
         py_assert!(py, inst, "inst.data == 8");
         py_assert!(py, inst, "inst.y == 8");
@@ -621,7 +621,7 @@ impl ClassWithGetAttrAndGetAttribute {
 
 #[test]
 fn getattr_and_getattribute() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst = Py::new(py, ClassWithGetAttrAndGetAttribute).unwrap();
         py_assert!(py, inst, "inst.exists == 42");
         py_assert!(py, inst, "inst.lucky == 57");
@@ -668,7 +668,7 @@ impl OnceFuture {
 #[test]
 #[cfg(not(target_arch = "wasm32"))] // Won't work without wasm32 event loop (e.g., Pyodide has WebLoop)
 fn test_await() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let once = py.get_type::<OnceFuture>();
         let source = pyo3_ffi::c_str!(
             r#"
@@ -720,7 +720,7 @@ impl AsyncIterator {
 #[test]
 #[cfg(not(target_arch = "wasm32"))] // Won't work without wasm32 event loop (e.g., Pyodide has WebLoop)
 fn test_anext_aiter() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let once = py.get_type::<OnceFuture>();
         let source = pyo3_ffi::c_str!(
             r#"
@@ -787,7 +787,7 @@ impl DescrCounter {
 
 #[test]
 fn descr_getset() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let counter = py.get_type::<DescrCounter>();
         let source = pyo3_ffi::c_str!(pyo3::indoc::indoc!(
             r#"
@@ -835,7 +835,7 @@ impl NotHashable {
 fn test_hash_opt_out() {
     // By default Python provides a hash implementation, which can be disabled by setting __hash__
     // to None.
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let empty = Py::new(py, EmptyClass).unwrap();
         py_assert!(py, empty, "hash(empty) is not None");
 
@@ -884,7 +884,7 @@ impl NoContains {
 
 #[test]
 fn test_contains_opt_out() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let defaulted_contains = Py::new(py, DefaultedContains).unwrap();
         py_assert!(py, defaulted_contains, "'a' in defaulted_contains");
 

--- a/tests/test_pyerr_debug_unformattable.rs
+++ b/tests/test_pyerr_debug_unformattable.rs
@@ -14,7 +14,7 @@ fn err_debug_unformattable() {
     //     traceback: Some(\"<unformattable <traceback object at 0x...>>\")
     // }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // PyTracebackMethods::format uses io.StringIO. Mock it out to trigger a
         // formatting failure:
         // TypeError: 'Mock' object cannot be converted to 'PyString'

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -26,7 +26,7 @@ fn struct_function() {}
 
 #[test]
 fn test_rust_keyword_name() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(struct_function)(py).unwrap();
 
         py_assert!(py, f, "f.__name__ == 'struct'");
@@ -41,7 +41,7 @@ fn optional_bool(arg: Option<bool>) -> String {
 #[test]
 fn test_optional_bool() {
     // Regression test for issue #932
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(optional_bool)(py).unwrap();
 
         py_assert!(py, f, "f() == 'Some(true)'");
@@ -60,7 +60,7 @@ fn required_optional_str(arg: Option<&str>) -> &str {
 #[test]
 fn test_optional_str() {
     // Regression test for issue #4965
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(required_optional_str)(py).unwrap();
 
         py_assert!(py, f, "f('') == ''");
@@ -81,7 +81,7 @@ fn required_optional_class(arg: Option<&MyClass>) {
 #[test]
 fn test_required_optional_class() {
     // Regression test for issue #4965
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(required_optional_class)(py).unwrap();
         let val = Bound::new(py, MyClass()).unwrap();
 
@@ -104,7 +104,7 @@ fn buffer_inplace_add(py: Python<'_>, x: PyBuffer<i32>, y: PyBuffer<i32>) {
 #[cfg(not(Py_LIMITED_API))]
 #[test]
 fn test_buffer_add() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(buffer_inplace_add)(py).unwrap();
 
         py_expect_exception!(
@@ -148,7 +148,7 @@ fn function_with_pycfunction_arg<'py>(
 
 #[test]
 fn test_functions_with_function_args() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let py_cfunc_arg = wrap_pyfunction!(function_with_pycfunction_arg)(py).unwrap();
         let bool_to_string = wrap_pyfunction!(optional_bool)(py).unwrap();
 
@@ -196,7 +196,7 @@ fn function_with_custom_conversion(
 #[cfg(not(Py_LIMITED_API))]
 #[test]
 fn test_function_with_custom_conversion() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let custom_conv_func = wrap_pyfunction!(function_with_custom_conversion)(py).unwrap();
 
         pyo3::py_run!(
@@ -215,7 +215,7 @@ fn test_function_with_custom_conversion() {
 #[cfg(not(Py_LIMITED_API))]
 #[test]
 fn test_function_with_custom_conversion_error() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let custom_conv_func = wrap_pyfunction!(function_with_custom_conversion)(py).unwrap();
 
         py_expect_exception!(
@@ -252,7 +252,7 @@ fn test_from_py_with_defaults() {
         len
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(from_py_with_option)(py).unwrap();
 
         assert_eq!(f.call0().unwrap().extract::<i32>().unwrap(), 0);
@@ -288,7 +288,7 @@ fn conversion_error(
 
 #[test]
 fn test_conversion_error() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let conversion_error = wrap_pyfunction!(conversion_error)(py).unwrap();
         py_expect_exception!(
             py,
@@ -376,7 +376,7 @@ fn extract_traceback(py: Python<'_>, mut error: PyErr) -> String {
 fn test_pycfunction_new() {
     use pyo3::ffi;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         unsafe extern "C" fn c_fn(
             _self: *mut ffi::PyObject,
             _args: *mut ffi::PyObject,
@@ -408,7 +408,7 @@ fn test_pycfunction_new_with_keywords() {
     use std::os::raw::c_long;
     use std::ptr;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         unsafe extern "C" fn c_fn(
             _self: *mut ffi::PyObject,
             args: *mut ffi::PyObject,
@@ -474,11 +474,11 @@ fn test_pycfunction_new_with_keywords() {
 
 #[test]
 fn test_closure() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = |args: &Bound<'_, types::PyTuple>,
                  _kwargs: Option<&Bound<'_, types::PyDict>>|
          -> PyResult<_> {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 let res: PyResult<Vec<_>> = args
                     .iter()
                     .map(|elem| {
@@ -514,7 +514,7 @@ fn test_closure() {
 
 #[test]
 fn test_closure_counter() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let counter = std::cell::RefCell::new(0);
         let counter_fn = move |_args: &Bound<'_, types::PyTuple>,
                                _kwargs: Option<&Bound<'_, types::PyDict>>|
@@ -542,7 +542,7 @@ fn use_pyfunction() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         use function_in_module::foo;
 
         // check imported name can be wrapped
@@ -578,7 +578,7 @@ fn return_value_borrows_from_arguments<'py>(
 
 #[test]
 fn test_return_value_borrows_from_arguments() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let function = wrap_pyfunction!(return_value_borrows_from_arguments, py).unwrap();
 
         let key = Py::new(py, Key("key".to_owned())).unwrap();
@@ -602,7 +602,7 @@ fn test_some_wrap_arguments() {
         [a, b, c, d]
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let function = wrap_pyfunction!(some_wrap_arguments, py).unwrap();
         py_assert!(py, function, "function() == [1, 2, None, None]");
     })
@@ -619,7 +619,7 @@ fn test_reference_to_bound_arguments() {
         y.map_or_else(|| Ok(x.clone()), |y| y.add(x))
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let function = wrap_pyfunction!(reference_args, py).unwrap();
         py_assert!(py, function, "function(1) == 1");
         py_assert!(py, function, "function(1, 2) == 3");
@@ -646,7 +646,7 @@ fn test_pyfunction_raw_ident() {
         Ok(())
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = pyo3::wrap_pymodule!(m)(py);
         py_assert!(py, m, "m.struct()");
         py_assert!(py, m, "m.enum()");

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -92,7 +92,7 @@ fn reader() -> Reader {
 
 #[test]
 fn test_nested_iter() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let reader = reader().into_pyobject(py).unwrap();
         py_assert!(
             py,
@@ -104,7 +104,7 @@ fn test_nested_iter() {
 
 #[test]
 fn test_clone_ref() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let reader = reader().into_pyobject(py).unwrap();
         py_assert!(py, reader, "reader == reader.clone_ref()");
         py_assert!(py, reader, "reader == reader.clone_ref_with_py()");
@@ -113,7 +113,7 @@ fn test_clone_ref() {
 
 #[test]
 fn test_nested_iter_reset() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let reader = Bound::new(py, reader()).unwrap();
         py_assert!(
             py,

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -117,7 +117,7 @@ fn seq_dict(py: Python<'_>) -> Bound<'_, pyo3::types::PyDict> {
 
 #[test]
 fn test_getitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = seq_dict(py);
 
         py_assert!(py, *d, "s[0] == 1");
@@ -130,7 +130,7 @@ fn test_getitem() {
 
 #[test]
 fn test_setitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = seq_dict(py);
 
         py_run!(py, *d, "s[0] = 4; assert list(s) == [4, 2, 3]");
@@ -140,7 +140,7 @@ fn test_setitem() {
 
 #[test]
 fn test_delitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [("ByteSequence", py.get_type::<ByteSequence>())]
             .into_py_dict(py)
             .unwrap();
@@ -182,7 +182,7 @@ fn test_delitem() {
 
 #[test]
 fn test_contains() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = seq_dict(py);
 
         py_assert!(py, *d, "1 in s");
@@ -195,7 +195,7 @@ fn test_contains() {
 
 #[test]
 fn test_concat() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = seq_dict(py);
 
         py_run!(
@@ -214,7 +214,7 @@ fn test_concat() {
 
 #[test]
 fn test_inplace_concat() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = seq_dict(py);
 
         py_run!(
@@ -228,7 +228,7 @@ fn test_inplace_concat() {
 
 #[test]
 fn test_repeat() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = seq_dict(py);
 
         py_run!(py, *d, "s2 = s * 2; assert list(s2) == [1, 2, 3, 1, 2, 3]");
@@ -238,7 +238,7 @@ fn test_repeat() {
 
 #[test]
 fn test_inplace_repeat() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = [("ByteSequence", py.get_type::<ByteSequence>())]
             .into_py_dict(py)
             .unwrap();
@@ -262,7 +262,7 @@ struct AnyObjectList {
 
 #[test]
 fn test_any_object_list_get() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let list = AnyObjectList {
             items: [1i32, 2, 3]
                 .iter()
@@ -278,7 +278,7 @@ fn test_any_object_list_get() {
 
 #[test]
 fn test_any_object_list_set() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let list = Bound::new(py, AnyObjectList { items: vec![] }).unwrap();
 
         py_run!(py, list, "list.items = [1, 2, 3]");
@@ -314,7 +314,7 @@ impl OptionList {
 #[test]
 fn test_option_list_get() {
     // Regression test for #798
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let list = Py::new(
             py,
             OptionList {
@@ -331,7 +331,7 @@ fn test_option_list_get() {
 
 #[test]
 fn sequence_is_not_mapping() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let list = Bound::new(
             py,
             OptionList {
@@ -350,7 +350,7 @@ fn sequence_is_not_mapping() {
 
 #[test]
 fn sequence_length() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let list = Bound::new(
             py,
             OptionList {
@@ -384,7 +384,7 @@ impl GenericList {
 
     fn __getitem__(&self, idx: isize) -> PyResult<PyObject> {
         match self.items.get(idx as usize) {
-            Some(x) => pyo3::Python::with_gil(|py| Ok(x.clone_ref(py))),
+            Some(x) => pyo3::Python::attach(|py| Ok(x.clone_ref(py))),
             None => Err(PyIndexError::new_err("Index out of bounds")),
         }
     }
@@ -396,7 +396,7 @@ fn test_generic_both_subscriptions_types() {
     use pyo3::types::PyInt;
     use std::convert::Infallible;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let l = Bound::new(
             py,
             GenericList {

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -31,7 +31,7 @@ mod test_serde {
             friends: vec![],
         };
 
-        let user = Python::with_gil(|py| {
+        let user = Python::attach(|py| {
             let py_friend1 = Py::new(py, friend1).expect("failed to create friend 1");
             let py_friend2 = Py::new(py, friend2).expect("failed to create friend 2");
 
@@ -69,7 +69,7 @@ mod test_serde {
         assert_eq!(user.friends.len(), 1usize);
         let friend = user.friends.first().unwrap();
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert_eq!(friend.borrow(py).username, "friend");
             assert_eq!(
                 friend.borrow(py).group.as_ref().unwrap().borrow(py).name,

--- a/tests/test_static_slots.rs
+++ b/tests/test_static_slots.rs
@@ -48,7 +48,7 @@ fn test_dict(py: Python<'_>) -> Bound<'_, pyo3::types::PyDict> {
 
 #[test]
 fn test_len() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = test_dict(py);
 
         py_assert!(py, *d, "len(s) == 5");
@@ -57,7 +57,7 @@ fn test_len() {
 
 #[test]
 fn test_getitem() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = test_dict(py);
 
         py_assert!(py, *d, "s[4] == 5.0");
@@ -66,7 +66,7 @@ fn test_getitem() {
 
 #[test]
 fn test_list() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let d = test_dict(py);
 
         py_assert!(py, *d, "list(s) == [1.0, 2.0, 3.0, 4.0, 5.0]");

--- a/tests/test_string.rs
+++ b/tests/test_string.rs
@@ -10,7 +10,7 @@ fn take_str(_s: &str) {}
 
 #[test]
 fn test_unicode_encode_error() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let take_str = wrap_pyfunction!(take_str)(py).unwrap();
         py_expect_exception!(
             py,

--- a/tests/test_super.rs
+++ b/tests/test_super.rs
@@ -42,7 +42,7 @@ impl SubClass {
 
 #[test]
 fn test_call_super_method() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let cls = py.get_type::<SubClass>();
         pyo3::py_run!(
             py,

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -12,7 +12,7 @@ fn class_without_docs_or_signature() {
     #[pyclass]
     struct MyClass {}
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<MyClass>();
 
         py_assert!(py, typeobj, "typeobj.__doc__ is None");
@@ -27,7 +27,7 @@ fn class_with_docs() {
     /// docs line2
     struct MyClass {}
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<MyClass>();
 
         py_assert!(py, typeobj, "typeobj.__doc__ == 'docs line1\\ndocs line2'");
@@ -51,7 +51,7 @@ fn class_with_signature_no_doc() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<MyClass>();
         py_assert!(py, typeobj, "typeobj.__doc__ == ''");
         py_assert!(
@@ -80,7 +80,7 @@ fn class_with_docs_and_signature() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<MyClass>();
 
         py_assert!(py, typeobj, "typeobj.__doc__ == 'docs line1\\ndocs line2'");
@@ -100,7 +100,7 @@ fn test_function() {
         let _ = (a, b, c);
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(my_function)(py).unwrap();
 
         py_assert!(py, f, "f.__text_signature__ == '(a, b=None, *, c=42)'");
@@ -147,7 +147,7 @@ fn test_auto_test_signature_function() {
         let _ = (a, b, c);
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(my_function)(py).unwrap();
         py_assert!(
             py,
@@ -238,7 +238,7 @@ fn test_auto_test_signature_method() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let cls = py.get_type::<MyClass>();
         #[cfg(any(not(Py_LIMITED_API), Py_3_10))]
         py_assert!(py, cls, "cls.__text_signature__ == '(a, b, c)'");
@@ -317,7 +317,7 @@ fn test_auto_test_signature_opt_out() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let f = wrap_pyfunction!(my_function)(py).unwrap();
         py_assert!(py, f, "f.__text_signature__ == None");
 
@@ -345,7 +345,7 @@ fn test_pyfn() {
         Ok(())
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let m = wrap_pymodule!(my_module)(py);
 
         py_assert!(
@@ -383,7 +383,7 @@ fn test_methods() {
         }
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<MyClass>();
 
         py_assert!(
@@ -424,7 +424,7 @@ fn test_raw_identifiers() {
         fn r#method(&self) {}
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let typeobj = py.get_type::<MyClass>();
 
         py_assert!(py, typeobj, "typeobj.__text_signature__ == '()'");

--- a/tests/test_variable_arguments.rs
+++ b/tests/test_variable_arguments.rs
@@ -26,7 +26,7 @@ impl MyClass {
 
 #[test]
 fn variable_args() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let my_obj = py.get_type::<MyClass>();
         py_assert!(py, my_obj, "my_obj.test_args() == ()");
         py_assert!(py, my_obj, "my_obj.test_args(1) == (1,)");
@@ -36,7 +36,7 @@ fn variable_args() {
 
 #[test]
 fn variable_kwargs() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let my_obj = py.get_type::<MyClass>();
         py_assert!(py, my_obj, "my_obj.test_kwargs() == None");
         py_assert!(py, my_obj, "my_obj.test_kwargs(test=1) == {'test': 1}");

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -26,7 +26,7 @@ impl MutRefArg {
 
 #[test]
 fn mut_ref_arg() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let inst1 = Py::new(py, MutRefArg { n: 0 }).unwrap();
         let inst2 = Py::new(py, MutRefArg { n: 0 }).unwrap();
 
@@ -51,7 +51,7 @@ fn get_zero() -> PyUsize {
 /// Checks that we can use return a custom class in arbitrary function and use those functions
 /// both in rust and python
 fn return_custom_class() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // Using from rust
         assert_eq!(get_zero().value, 0);
 
@@ -63,7 +63,7 @@ fn return_custom_class() {
 
 #[test]
 fn intopytuple_primitive() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = (1, 2, "foo");
         py_assert!(py, tup, "tup == (1, 2, 'foo')");
         py_assert!(py, tup, "tup[0] == 1");
@@ -77,7 +77,7 @@ struct SimplePyClass {}
 
 #[test]
 fn intopytuple_pyclass() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = (
             Py::new(py, SimplePyClass {}).unwrap(),
             Py::new(py, SimplePyClass {}).unwrap(),
@@ -90,7 +90,7 @@ fn intopytuple_pyclass() {
 
 #[test]
 fn pytuple_primitive_iter() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = PyTuple::new(py, [1u32, 2, 3].iter()).unwrap();
         py_assert!(py, tup, "tup == (1, 2, 3)");
     });
@@ -98,7 +98,7 @@ fn pytuple_primitive_iter() {
 
 #[test]
 fn pytuple_pyclass_iter() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let tup = PyTuple::new(
             py,
             [
@@ -149,7 +149,7 @@ fn test_pickle() {
             .set_item(module.name()?, module)
     }
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let module = PyModule::new(py, "test_module").unwrap();
         module.add_class::<PickleSupport>().unwrap();
         add_module(module).unwrap();
@@ -203,7 +203,7 @@ fn result_conversion_function() -> Result<(), MyError> {
 
 #[test]
 fn test_result_conversion() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         wrap_pyfunction!(result_conversion_function)(py).unwrap();
     });
 }

--- a/tests/ui/invalid_closure.rs
+++ b/tests/ui/invalid_closure.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyCFunction, PyDict, PyTuple};
 
 fn main() {
-    let fun: Py<PyCFunction> = Python::with_gil(|py| {
+    let fun: Py<PyCFunction> = Python::attach(|py| {
         let local_data = vec![0, 1, 2, 3, 4];
         let ref_: &[u8] = &local_data;
 
@@ -16,7 +16,7 @@ fn main() {
             .into()
     });
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         fun.call0(py).unwrap();
     });
 }

--- a/tests/ui/invalid_intern_arg.rs
+++ b/tests/ui/invalid_intern_arg.rs
@@ -2,5 +2,5 @@ use pyo3::Python;
 
 fn main() {
     let _foo = if true { "foo" } else { "bar" };
-    Python::with_gil(|py| py.import(pyo3::intern!(py, _foo)).unwrap());
+    Python::attach(|py| py.import(pyo3::intern!(py, _foo)).unwrap());
 }

--- a/tests/ui/invalid_intern_arg.stderr
+++ b/tests/ui/invalid_intern_arg.stderr
@@ -1,8 +1,8 @@
 error[E0435]: attempt to use a non-constant value in a constant
- --> tests/ui/invalid_intern_arg.rs:5:55
+ --> tests/ui/invalid_intern_arg.rs:5:53
   |
-5 |     Python::with_gil(|py| py.import(pyo3::intern!(py, _foo)).unwrap());
-  |                                                       ^^^^ non-constant value
+5 |     Python::attach(|py| py.import(pyo3::intern!(py, _foo)).unwrap());
+  |                                                     ^^^^ non-constant value
   |
 help: consider using `let` instead of `static`
  --> src/sync.rs
@@ -12,10 +12,10 @@ help: consider using `let` instead of `static`
   |
 
 error: lifetime may not live long enough
- --> tests/ui/invalid_intern_arg.rs:5:27
+ --> tests/ui/invalid_intern_arg.rs:5:25
   |
-5 |     Python::with_gil(|py| py.import(pyo3::intern!(py, _foo)).unwrap());
-  |                       --- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
-  |                       | |
-  |                       | return type of closure is pyo3::Bound<'2, PyModule>
-  |                       has type `Python<'1>`
+5 |     Python::attach(|py| py.import(pyo3::intern!(py, _foo)).unwrap());
+  |                     --- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+  |                     | |
+  |                     | return type of closure is pyo3::Bound<'2, PyModule>
+  |                     has type `Python<'1>`

--- a/tests/ui/invalid_pycallargs.rs
+++ b/tests/ui/invalid_pycallargs.rs
@@ -1,7 +1,7 @@
 use pyo3::prelude::*;
 
 fn main() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let any = py.None().into_bound(py);
         any.call1("foo");
     })

--- a/tests/ui/invalid_result_conversion.rs
+++ b/tests/ui/invalid_result_conversion.rs
@@ -26,7 +26,7 @@ fn should_not_work() -> Result<(), MyError> {
 }
 
 fn main() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         wrap_pyfunction!(should_not_work)(py);
     });
 }

--- a/tests/ui/not_send.rs
+++ b/tests/ui/not_send.rs
@@ -5,7 +5,7 @@ fn test_not_send_allow_threads(py: Python<'_>) {
 }
 
 fn main() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         test_not_send_allow_threads(py);
     })
 }

--- a/tests/ui/not_send2.rs
+++ b/tests/ui/not_send2.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyString;
 
 fn main() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let string = PyString::new(py, "foo");
 
         py.allow_threads(|| {

--- a/tests/ui/traverse.stderr
+++ b/tests/ui/traverse.stderr
@@ -1,28 +1,28 @@
-error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::with_gil` will panic.
+error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
   --> tests/ui/traverse.rs:10:27
    |
 10 |     fn __traverse__(_slf: PyRef<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                           ^^^^^
 
-error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::with_gil` will panic.
+error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
   --> tests/ui/traverse.rs:20:27
    |
 20 |     fn __traverse__(_slf: PyRefMut<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                           ^^^^^^^^
 
-error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::with_gil` will panic.
+error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
   --> tests/ui/traverse.rs:30:27
    |
 30 |     fn __traverse__(_slf: Bound<'_, Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                           ^^^^^
 
-error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::with_gil` will panic.
+error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
   --> tests/ui/traverse.rs:40:21
    |
 40 |     fn __traverse__(&mut self, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                     ^
 
-error: __traverse__ may not take `Python`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::with_gil` will panic.
+error: __traverse__ may not take `Python`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
   --> tests/ui/traverse.rs:60:33
    |
 60 |     fn __traverse__(&self, _py: Python<'_>, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {

--- a/tests/ui/wrong_aspyref_lifetimes.rs
+++ b/tests/ui/wrong_aspyref_lifetimes.rs
@@ -1,10 +1,10 @@
 use pyo3::{types::PyDict, Bound, Py, Python};
 
 fn main() {
-    let dict: Py<PyDict> = Python::with_gil(|py| PyDict::new(py).unbind());
+    let dict: Py<PyDict> = Python::attach(|py| PyDict::new(py).unbind());
 
-    // Should not be able to get access to Py contents outside of with_gil.
-    let dict: &Bound<'_, PyDict> = Python::with_gil(|py| dict.bind(py));
+    // Should not be able to get access to Py contents outside of `attach`.
+    let dict: &Bound<'_, PyDict> = Python::attach(|py| dict.bind(py));
 
     let _py: Python = dict.py(); // Obtain a Python<'p> without GIL.
 }

--- a/tests/ui/wrong_aspyref_lifetimes.stderr
+++ b/tests/ui/wrong_aspyref_lifetimes.stderr
@@ -1,8 +1,8 @@
 error: lifetime may not live long enough
- --> tests/ui/wrong_aspyref_lifetimes.rs:7:58
+ --> tests/ui/wrong_aspyref_lifetimes.rs:7:56
   |
-7 |     let dict: &Bound<'_, PyDict> = Python::with_gil(|py| dict.bind(py));
-  |                                                      --- ^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
-  |                                                      | |
-  |                                                      | return type of closure is &'2 pyo3::Bound<'_, PyDict>
-  |                                                      has type `Python<'1>`
+7 |     let dict: &Bound<'_, PyDict> = Python::attach(|py| dict.bind(py));
+  |                                                    --- ^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+  |                                                    | |
+  |                                                    | return type of closure is &'2 pyo3::Bound<'_, PyDict>
+  |                                                    has type `Python<'1>`


### PR DESCRIPTION
Part of #3987

This renames `Python::with_gil` to `Python::attach` to detangle our naming from the GIL which is not always relevant anymore. The old name is deprecated. (Big diff, but pretty much just a mechanical change)