### PR TITLE
Don't cross compile for win7 target

### DIFF
--- a/newsfragments/5210.changed.md
+++ b/newsfragments/5210.changed.md
@@ -1,0 +1,1 @@
+Don't necessarily treat win7 target as a cross-compilation


### PR DESCRIPTION
Don't treat `-pc-windows-msvc` to `-win7-windows-msvc` as a cross compilation. Not sure if there's a more preferred way to do this, but this more easily allows using win7 target with pyo3.
