### PR TITLE
docs: remove doc refs to PyCell

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -85,23 +85,23 @@ To realize object-oriented programming in C, all Python objects have `ob_base: P
 first field in their structure definition. Thanks to this guarantee, casting `*mut A` to `*mut PyObject`
 is valid if `A` is a Python object.
 
-To ensure this guarantee, we have a wrapper struct `PyCell<T>` in [`src/pycell.rs`] which is roughly:
+To ensure this guarantee, we have a wrapper struct `PyClassObject<T>` in [`src/pycell/impl_.rs`] which is roughly:
 
 ```rust
 #[repr(C)]
-pub struct PyCell<T: PyClass> {
+pub struct PyClassObject<T> {
     ob_base: crate::ffi::PyObject,
     inner: T,
 }
 ```
 
-Thus, when copying a Rust struct to a Python object, we first allocate `PyCell` on the Python heap and then
+Thus, when copying a Rust struct to a Python object, we first allocate `PyClassObject` on the Python heap and then
 move `T` into it.
-Also, `PyCell` provides [RefCell](https://doc.rust-lang.org/std/cell/struct.RefCell.html)-like methods
-to ensure Rust's borrow rules.
-See [the documentation](https://docs.rs/pyo3/latest/pyo3/pycell/struct.PyCell.html) for more.
 
-`PyCell<T>` requires that `T` implements `PyClass`.
+The primary way to interact with Python objects implemented in Rust is through the `Bound<'py, T>` smart pointer.
+By having the `'py` lifetime of the `Python<'py>` token, this ties the lifetime of the `Bound<'py, T>` smart pointer to the lifetime of the GIL and allows PyO3 to call Python APIs at maximum efficiency.
+
+`Bound<'py, T>` requires that `T` implements `PyClass`.
 This trait is somewhat complex and derives many traits, but the most important one is `PyTypeInfo`
 in [`src/type_object.rs`].
 `PyTypeInfo` is also implemented for built-in types.

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -133,7 +133,7 @@ impl Number {
     fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
         // This is the equivalent of `self.__class__.__name__` in Python.
         let class_name: Bound<'_, PyString> = slf.get_type().qualname()?;
-        // To access fields of the Rust struct, we need to borrow the `PyCell`.
+        // To access fields of the Rust struct, we need to borrow from the Bound object.
         Ok(format!("{}({})", class_name, slf.borrow().0))
     }
 }

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -145,7 +145,7 @@ impl<T: PyClass> PyClassInitializer<T> {
         PyClassInitializer::new(subclass_value, self)
     }
 
-    /// Creates a new PyCell and initializes it.
+    /// Creates a new class object and initializes it.
     pub(crate) fn create_class_object(self, py: Python<'_>) -> PyResult<Bound<'_, T>>
     where
         T: PyClass,


### PR DESCRIPTION
Closes #5187 

With these changes, the only repo files containing `PyCell` references (`git ls-files | xargs grep PyCell`) are now: `guide/src/migration.md`, `CHANGELOG.md` (both seem fine, as historical references), and `src/pycell.rs` (which I haven't changed at all).

For the doc changes, I can't say I fully understand all the implementation details, so if anything is off here, best to just tell me literally what to rewrite it to.
