### PR TITLE
ci: skip fragment checking in links for now

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -509,22 +509,15 @@ def check_guide(session: nox.Session):
     for key, value in remaps.items():
         remap_args.extend(("--remap", f"{key} {value}"))
 
-    # some http URL fragments fail to be loaded (needs javascript?)
-    lychee_exclusions = [
-        "https://github.com/PyO3/pyo3/issues/1800#issuecomment-906786649",
-        "https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html#method.lock_arc",
-        "https://github.com/PyO3/pyo3/issues/1517#issuecomment-808664021",
-        "https://github.com/PyO3/maturin/blob/0dee40510083c03607834c821eea76964140a126/Readme.md#mixed-rustpython-projects",
-    ]
-
     # check all links in the guide
     _run(
         session,
         "lychee",
-        "--include-fragments",
+        # FIXME: would be nice to use `--include-fragments` here, but we've had
+        # a lot of flaky failures from it - see https://github.com/lycheeverse/lychee/issues/1746
+        # "--include-fragments",
         str(PYO3_GUIDE_SRC),
         *remap_args,
-        "--exclude=" + "|".join(lychee_exclusions),
         "--accept=200,429",
         *session.posargs,
     )


### PR DESCRIPTION
The `guide-build` job keeps failing due to flaky fragment check failures.

The fragment checking is nice but not worth red PRs confusing everyone, so turning off for now until https://github.com/lycheeverse/lychee/issues/1746 can give us a better idea.