### PR TITLE
`test:` Add edge case test for num_bigint conversion

### DIFF
--- a/tests/test_intopyobject.rs
+++ b/tests/test_intopyobject.rs
@@ -287,3 +287,26 @@ fn test_struct_into_py_rename_all() {
         );
     });
 }
+
+#[cfg(feature = "num-bigint")]
+#[test]
+fn test_bigint_to_python_i64_max_plus_one() {
+    use num_bigint::BigInt;
+    use pyo3::ToPyObject;
+    use std::str::FromStr;
+
+    Python::with_gil(|py| {
+        let big_int_str = "9223372036854775808"; // i64::MAX + 1
+        let big_int = BigInt::from_str(big_int_str).unwrap();
+
+        let py_int = big_int.to_object(py);
+
+        let result: String = py
+            .eval(&format!("str({})", py_int), None, None)
+            .unwrap()
+            .extract()
+            .unwrap();
+
+        assert_eq!(result, big_int_str);
+    });
+}

--- a/tests/test_intopyobject.rs
+++ b/tests/test_intopyobject.rs
@@ -296,7 +296,7 @@ fn test_bigint_to_python_i64_max_plus_one() {
     use std::str::FromStr;
 
     Python::with_gil(|py| {
-        let big_int_str = "9223372036854775808"; // i64::MAX + 1
+        let big_int_str = "9223372036854775808"; 
         let big_int = BigInt::from_str(big_int_str).unwrap();
 
         let py_int = big_int.to_object(py);


### PR DESCRIPTION
The new test, test_bigint_to_python_i64_max_plus_one, specifically covers the edge case of converting a BigInt with a value of i64::MAX + 1. This ensures that values just outside the range of a 64-bit signed integer are handled correctly without overflow or loss of precision.

This is a valuable addition to our test suite as it strengthens the reliability of one of our core type conversion features.

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
locally, you can run ```nox```. See ```nox --list-sessions```
for a list of supported actions.
