### PR TITLE
fix: prevent GIL re-enabled RuntimeWarning in tests

### DIFF
--- a/tests/test_append_to_inittab.rs
+++ b/tests/test_append_to_inittab.rs
@@ -7,13 +7,13 @@ fn foo() -> usize {
     123
 }
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 fn module_fn_with_functions(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(foo, m)?)?;
     Ok(())
 }
 
-#[pymodule]
+#[pymodule(gil_used = false)]
 mod module_mod_with_functions {
     #[pymodule_export]
     use super::foo;


### PR DESCRIPTION
On current `main`, with a free-threaded interpreter:

```
± cargo test --test test_append_to_inittab
   Compiling pyo3 v0.26.0-dev (/Users/goldbaum/Documents/pyo3)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.93s
     Running tests/test_append_to_inittab.rs (target/debug/deps/test_append_to_inittab-c5f07e5c993bbcfd)
test_append_to_inittab-c5f07e5c993bbcfd(95325,0x20c141f00) malloc: nano zone abandoned due to inability to reserve vm space.

running 1 test
<frozen importlib._bootstrap>:491: RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'module_fn_with_functions', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.
test test_module_append_to_inittab ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.23s
```

Seems better to avoid the warning if we can.