### PR TITLE
update guide to the current state

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## Usage
 
-Requires Rust 1.63 or greater.
+Requires Rust 1.74 or greater.
 
 PyO3 supports the following Python distributions:
   - CPython 3.7 or greater

--- a/guide/src/async-await.md
+++ b/guide/src/async-await.md
@@ -35,15 +35,15 @@ As a consequence, `async fn` parameters and return types must also be `Send + 's
 
 However, there is an exception for method receivers, so async methods can accept `&self`/`&mut self`. Note that this means that the class instance is borrowed for as long as the returned future is not completed, even across yield points and while waiting for I/O operations to complete. Hence, other methods cannot obtain exclusive borrows while the future is still being polled. This is the same as how async methods in Rust generally work but it is more problematic for Rust code interfacing with Python code due to pervasive shared mutability. This strongly suggests to prefer shared borrows `&self` over exclusive ones `&mut self` to avoid racy borrow check failures at runtime.
 
-## Implicit GIL holding
+## Implicitly attached to the interpreter
 
-Even if it is not possible to pass a `py: Python<'py>` parameter to `async fn`, the GIL is still held during the execution of the future – it's also the case for regular `fn` without `Python<'py>`/`Bound<'py, PyAny>` parameter, yet the GIL is held.
+Even if it is not possible to pass a `py: Python<'py>` token to an `async fn`, we're still attached to the interpreter during the execution of the future – the same as for a regular `fn` without `Python<'py>`/`Bound<'py, PyAny>` parameter
 
 It is still possible to get a `Python` marker using [`Python::attach`]({{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.attach); because `attach` is reentrant and optimized, the cost will be negligible.
 
-## Release the GIL across `.await`
+## Detaching from the interpreter across `.await`
 
-There is currently no simple way to release the GIL when awaiting a future, *but solutions are currently in development*.
+There is currently no simple way to detach from the interpreter when awaiting a future, *but solutions are currently in development*.
 
 Here is the advised workaround for now:
 

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -4,6 +4,7 @@ Recall the `Number` class from the previous chapter:
 
 ```rust,no_run
 # #![allow(dead_code)]
+# fn main() {}
 use pyo3::prelude::*;
 
 #[pyclass]
@@ -18,9 +19,9 @@ impl Number {
 }
 
 #[pymodule]
-fn my_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<Number>()?;
-    Ok(())
+mod my_module {
+    #[pymodule_export]
+    use super::Number;
 }
 ```
 
@@ -331,6 +332,7 @@ impl Number {
 ### Final code
 
 ```rust,no_run
+# fn main() {}
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
@@ -380,9 +382,9 @@ impl Number {
 }
 
 #[pymodule]
-fn my_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<Number>()?;
-    Ok(())
+mod my_module {
+    #[pymodule_export]
+    use super::Number;
 }
 ```
 

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -457,7 +457,7 @@ impl ClassWithGCSupport {
 ```
 
 Usually, an implementation of `__traverse__` should do nothing but calls to `visit.call`.
-Most importantly, safe access to the GIL is prohibited inside implementations of `__traverse__`,
+Most importantly, safe access to the interpreter is prohibited inside implementations of `__traverse__`,
 i.e. `Python::attach` will panic.
 
 > Note: these methods are part of the C API, PyPy does not necessarily honor them. If you are building for PyPy you should measure memory consumption to make sure you do not have runaway memory growth. See [this issue on the PyPy bug tracker](https://github.com/pypy/pypy/issues/3848).

--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -67,7 +67,7 @@ Using Rust library types as function arguments will incur a conversion cost comp
 However, once that conversion cost has been paid, the Rust standard library types offer a number of benefits:
 - You can write functionality in native-speed Rust code (free of Python's runtime costs).
 - You get better interoperability with the rest of the Rust ecosystem.
-- You can use `Python::detach` to release the Python GIL and let other Python threads make progress while your Rust code is executing.
+- You can use `Python::detach` to detach from the interpreter and let other Python threads make progress while your Rust code is executing.
 - You also benefit from stricter type checking. For example you can specify `Vec<i32>`, which will only accept a Python `list` containing integers. The Python-native equivalent, `&PyList`, would accept a Python `list` containing Python objects of any type.
 
 For most PyO3 usage the conversion cost is worth paying to get these benefits. As always, if you're not sure it's worth it in your case, benchmark it!

--- a/guide/src/ecosystem/logging.md
+++ b/guide/src/ecosystem/logging.md
@@ -19,23 +19,23 @@ Use [`pyo3_log::init`][init] to install the logger in its default configuration.
 It's also possible to tweak its configuration (mostly to tune its performance).
 
 ```rust,no_run
-use log::info;
-use pyo3::prelude::*;
+#[pyo3::pymodule]
+mod my_module {
+    use log::info;
+    use pyo3::prelude::*;
 
-#[pyfunction]
-fn log_something() {
-    // This will use the logger installed in `my_module` to send the `info`
-    // message to the Python logging facilities.
-    info!("Something!");
-}
+    #[pyfunction]
+    fn log_something() {
+        // This will use the logger installed in `my_module` to send the `info`
+        // message to the Python logging facilities.
+        info!("Something!");
+    }
 
-#[pymodule]
-fn my_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // A good place to install the Rust -> Python logger.
-    pyo3_log::init();
-
-    m.add_function(wrap_pyfunction!(log_something, m)?)?;
-    Ok(())
+    #[pymodule_init]
+    fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
+        // A good place to install the Rust -> Python logger.
+        pyo3_log::init();
+    }
 }
 ```
 

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -41,17 +41,18 @@ When using PyO3 to create an extension module, you can add the new exception to
 the module like this, so that it is importable from Python:
 
 ```rust,no_run
+# fn main() {}
 use pyo3::prelude::*;
 use pyo3::exceptions::PyException;
 
 pyo3::create_exception!(mymodule, CustomError, PyException);
 
 #[pymodule]
-fn mymodule(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // ... other elements added to module ...
-    m.add("CustomError", py.get_type::<CustomError>())?;
+mod mymodule {
+    #[pymodule_export]
+    use super::CustomError;
 
-    Ok(())
+    // ... other elements added to module ...
 }
 ```
 

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -65,12 +65,6 @@ Also, this feature adds the `pyo3::inspect` module, as well as `IntoPy::type_out
 
 This is a first step towards adding first-class support for generating type annotations automatically in PyO3, however work is needed to finish this off. All feedback and offers of help welcome on [issue #2454](https://github.com/PyO3/pyo3/issues/2454).
 
-### `gil-refs`
-
-This feature is a backwards-compatibility feature to allow continued use of the "GIL Refs" APIs deprecated in PyO3 0.21. These APIs have performance drawbacks and soundness edge cases which the newer `Bound<T>` smart pointer and accompanying APIs resolve.
-
-This feature and the APIs it enables is expected to be removed in a future PyO3 version.
-
 ### `py-clone`
 
 This feature was introduced to ease migration. It was found that delayed reference counts cannot be made sound and hence `Clon`ing an instance of `Py<T>` must panic without the GIL being held. To avoid migrations introducing new panics without warning, the `Clone` implementation itself is now gated behind this feature.

--- a/guide/src/function.md
+++ b/guide/src/function.md
@@ -1,20 +1,18 @@
 # Python functions
 
-The `#[pyfunction]` attribute is used to define a Python function from a Rust function. Once defined, the function needs to be added to a [module](./module.md) using the `wrap_pyfunction!` macro.
+The `#[pyfunction]` attribute is used to define a Python function from a Rust function. Once defined, the function needs to be added to a [module](./module.md).
 
 The following example defines a function called `double` in a Python module called `my_extension`:
 
 ```rust,no_run
-use pyo3::prelude::*;
+#[pyo3::pymodule]
+mod my_extension {
+    use pyo3::prelude::*;
 
-#[pyfunction]
-fn double(x: usize) -> usize {
-    x * 2
-}
-
-#[pymodule]
-fn my_extension(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(double, m)?)
+    #[pyfunction]
+    fn double(x: usize) -> usize {
+        x * 2
+    }
 }
 ```
 
@@ -46,17 +44,16 @@ The `#[pyo3]` attribute can be used to modify properties of the generated Python
     `module_with_functions` as the Python function `no_args`:
 
     ```rust
-    use pyo3::prelude::*;
+    # use pyo3::prelude::*;
+    #[pyo3::pymodule]
+    mod module_with_functions {
+        use pyo3::prelude::*;
 
-    #[pyfunction]
-    #[pyo3(name = "no_args")]
-    fn no_args_py() -> usize {
-        42
-    }
-
-    #[pymodule]
-    fn module_with_functions(m: &Bound<'_, PyModule>) -> PyResult<()> {
-        m.add_function(wrap_pyfunction!(no_args_py, m)?)
+        #[pyfunction]
+        #[pyo3(name = "no_args")]
+        fn no_args_py() -> usize {
+            42
+        }
     }
 
     # Python::attach(|py| {
@@ -81,20 +78,18 @@ The `#[pyo3]` attribute can be used to modify properties of the generated Python
     The following example creates a function `pyfunction_with_module` which returns the containing module's name (i.e. `module_with_fn`):
 
     ```rust,no_run
-    use pyo3::prelude::*;
-    use pyo3::types::PyString;
+    #[pyo3::pymodule]
+    mod module_with_fn {
+        use pyo3::prelude::*;
+        use pyo3::types::PyString;
 
-    #[pyfunction]
-    #[pyo3(pass_module)]
-    fn pyfunction_with_module<'py>(
-        module: &Bound<'py, PyModule>,
-    ) -> PyResult<Bound<'py, PyString>> {
-        module.name()
-    }
-
-    #[pymodule]
-    fn module_with_fn(m: &Bound<'_, PyModule>) -> PyResult<()> {
-        m.add_function(wrap_pyfunction!(pyfunction_with_module, m)?)
+        #[pyfunction]
+        #[pyo3(pass_module)]
+        fn pyfunction_with_module<'py>(
+            module: &Bound<'py, PyModule>,
+        ) -> PyResult<Bound<'py, PyString>> {
+            module.name()
+        }
     }
     ```
   - <a id="warn"></a> `#[pyo3(warn(message = "...", category = ...))]`

--- a/guide/src/function/signature.md
+++ b/guide/src/function/signature.md
@@ -11,18 +11,16 @@ This section of the guide goes into detail about use of the `#[pyo3(signature = 
 For example, below is a function that accepts arbitrary keyword arguments (`**kwargs` in Python syntax) and returns the number that was passed:
 
 ```rust,no_run
-use pyo3::prelude::*;
-use pyo3::types::PyDict;
+#[pyo3::pymodule]
+mod module_with_functions {
+    use pyo3::prelude::*;
+    use pyo3::types::PyDict;
 
-#[pyfunction]
-#[pyo3(signature = (**kwds))]
-fn num_kwds(kwds: Option<&Bound<'_, PyDict>>) -> usize {
-    kwds.map_or(0, |dict| dict.len())
-}
-
-#[pymodule]
-fn module_with_functions(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(num_kwds, m)?)
+    #[pyfunction]
+    #[pyo3(signature = (**kwds))]
+    fn num_kwds(kwds: Option<&Bound<'_, PyDict>>) -> usize {
+        kwds.map_or(0, |dict| dict.len())
+    }
 }
 ```
 

--- a/guide/src/getting-started.md
+++ b/guide/src/getting-started.md
@@ -6,7 +6,7 @@ To get started using PyO3 you will need three things: a Rust toolchain, a Python
 
 ## Rust
 
-First, make sure you have Rust installed on your system. If you haven't already done so, try following the instructions [here](https://www.rust-lang.org/tools/install). PyO3 runs on both the `stable` and `nightly` versions so you can choose whichever one fits you best. The minimum required Rust version is 1.63.
+First, make sure you have Rust installed on your system. If you haven't already done so, try following the instructions [here](https://www.rust-lang.org/tools/install). PyO3 runs on both the `stable` and `nightly` versions so you can choose whichever one fits you best. The minimum required Rust version is 1.74.
 
 If you can run `rustc --version` and the version is new enough you're good to go!
 
@@ -146,20 +146,18 @@ classifiers = [
 After this you can setup Rust code to be available in Python as below; for example, you can place this code in `src/lib.rs`:
 
 ```rust,no_run
-use pyo3::prelude::*;
-
-/// Formats the sum of two numbers as string.
-#[pyfunction]
-fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
-    Ok((a + b).to_string())
-}
-
 /// A Python module implemented in Rust. The name of this function must match
 /// the `lib.name` setting in the `Cargo.toml`, else Python will not be able to
 /// import the module.
-#[pymodule]
-fn pyo3_example(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(sum_as_string, m)?)
+#[pyo3::pymodule]
+mod pyo3_example {
+    use pyo3::prelude::*;
+
+    /// Formats the sum of two numbers as string.
+    #[pyfunction]
+    fn sum_as_string(a: usize, b: usize) -> PyResult<String> {
+        Ok((a + b).to_string())
+    }
 }
 ```
 

--- a/guide/src/parallelism.md
+++ b/guide/src/parallelism.md
@@ -134,7 +134,7 @@ that deadlocks with the GIL in these cases.
 
 In the example below, we share a `Vec` of User ID objects defined using the
 `pyclass` macro and spawn threads to process the collection of data into a `Vec`
-of booleans based on a predicate using a rayon parallel iterator:
+of booleans based on a predicate using a `rayon` parallel iterator:
 
 ```rust,no_run
 use pyo3::prelude::*;
@@ -160,15 +160,15 @@ let allowed_ids: Vec<bool> = Python::attach(|outer_py| {
 assert!(allowed_ids.into_iter().filter(|b| *b).count() == 4);
 ```
 
-It's important to note that there is an `outer_py` GIL lifetime token as well as
-an `inner_py` token. Sharing GIL lifetime tokens between threads is not allowed
-and threads must individually acquire the GIL to access data wrapped by a python
+It's important to note that there is an `outer_py` Python token as well as
+an `inner_py` token. Sharing Python tokens between threads is not allowed
+and threads must individually attach to the interpreter to access data wrapped by a Python
 object.
 
 It's also important to see that this example uses [`Python::detach`] to
 wrap the code that spawns OS threads via `rayon`. If this example didn't use
-`detach`, a rayon worker thread would block on acquiring the GIL while a
-thread that owns the GIL spins forever waiting for the result of the rayon
+`detach`, a `rayon` worker thread would block on acquiring the GIL while a
+thread that owns the GIL spins forever waiting for the result of the `rayon`
 thread. Calling `detach` allows the GIL to be released in the thread
 collecting the results from the worker threads. You should always call
 `detach` in situations that spawn worker threads, but especially so in

--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -159,15 +159,14 @@ As an example, the below adds the module `foo` to the embedded interpreter:
 use pyo3::prelude::*;
 use pyo3::ffi::c_str;
 
-#[pyfunction]
-fn add_one(x: i64) -> i64 {
-    x + 1
-}
-
 #[pymodule]
-fn foo(foo_module: &Bound<'_, PyModule>) -> PyResult<()> {
-    foo_module.add_function(wrap_pyfunction!(add_one, foo_module)?)?;
-    Ok(())
+mod foo {
+    use pyo3::prelude::*;
+    
+    #[pyfunction]
+    fn add_one(x: i64) -> i64 {
+        x + 1
+    }
 }
 
 fn main() -> PyResult<()> {

--- a/guide/src/trait-bounds.md
+++ b/guide/src/trait-bounds.md
@@ -118,6 +118,7 @@ Let's add the PyO3 annotations and add a constructor:
 
 ```rust,no_run
 # #![allow(dead_code)]
+# fn main() {}
 # pub trait Model {
 #   fn set_variables(&mut self, inputs: &Vec<f64>);
 #   fn compute(&mut self);
@@ -130,18 +131,18 @@ struct UserModel {
     model: Py<PyAny>,
 }
 
-#[pymodule]
-fn trait_exposure(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<UserModel>()?;
-    Ok(())
-}
-
 #[pymethods]
 impl UserModel {
     #[new]
     pub fn new(model: Py<PyAny>) -> Self {
         UserModel { model }
     }
+}
+
+#[pymodule]
+mod trait_exposure {
+    #[pymodule_export]
+    use super::UserModel;
 }
 ```
 
@@ -458,6 +459,7 @@ It is also required to make the struct public.
 
 ```rust,no_run
 # #![allow(dead_code)]
+# fn main() {}
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 
@@ -482,13 +484,6 @@ pub struct UserModel {
     model: Py<PyAny>,
 }
 
-#[pymodule]
-fn trait_exposure(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<UserModel>()?;
-    m.add_function(wrap_pyfunction!(solve_wrapper, m)?)?;
-    Ok(())
-}
-
 #[pymethods]
 impl UserModel {
     #[new]
@@ -509,6 +504,12 @@ impl UserModel {
     pub fn compute(&mut self) {
         Model::compute(self)
     }
+}
+
+#[pymodule]
+mod trait_exposure {
+    #[pymodule_export]
+    use super::{UserModel, solve_wrapper};
 }
 
 impl Model for UserModel {

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -30,7 +30,7 @@ Because `Py<T>` is not bound to [the `'py` lifetime](./python-from-rust.md#the-p
 
 The lack of binding to the `'py` lifetime also carries drawbacks:
  - Almost all methods on `Py<T>` require a `Python<'py>` token as the first argument
- - Other functionality, such as [`Drop`][Drop], needs to check at runtime for attachment to the Python GIL, at a small performance cost
+ - Other functionality, such as [`Drop`][Drop], needs to check at runtime for attachment to the Python interpreter, at a small performance cost
 
 Because of the drawbacks `Bound<'py, T>` is preferred for many of PyO3's APIs. In particular, `Bound<'py, T>` is better for function arguments.
 


### PR DESCRIPTION
This is a general pass of the documentation in our guide. I tried to reduce our terminology around the GIL where possible in light of #5209 and #5221. Additionally I moved some of our examples to declarative modules and fixed some outdated information that slipped in over time.