### PR TITLE
Align the PyCapsule API with the original C API, making it safer

### DIFF
--- a/newsfragments/5229.added.md
+++ b/newsfragments/5229.added.md
@@ -1,0 +1,1 @@
+added checked methods into `PyCapsuleMethods`: `pointer_checked()`, `reference_checked()`, `is_valid_checked()`

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -96,7 +96,9 @@ impl PyCFunction {
         )?;
 
         // Safety: just created the capsule with type ClosureDestructor<F> above
-        let data = unsafe { capsule.reference::<ClosureDestructor<F>>() };
+        let data = unsafe {
+            capsule.reference_checked::<ClosureDestructor<F>>(Some(CLOSURE_CAPSULE_NAME))
+        }?;
 
         unsafe {
             ffi::PyCFunction_NewEx(data.def.get(), capsule.as_ptr(), std::ptr::null_mut())


### PR DESCRIPTION
In the [PyCapsule C API](https://docs.python.org/3/c-api/capsule.html), the caller has to specify the correct name of the PyCapsule to get the pointer stored in the capsule. This is intended as a safety check: casting `void*` to an arbitrary pointer is inherently quite dangerous and the capsule name provides the only (albeit imperfect) way to check that the pointer has the expected type.

However, the Rust API exposed by pyo3 didn't require the capsule name to get the pointer or reference stored in the capsule:

```rust
trait PyCapsuleMethods {
    fn pointer(&self) -> *mut c_void;
    unsafe fn reference<T>(&self) -> &'py T;
    fn is_valid(&self) -> bool;
}
```

This PR changes these methods to be more in line with the C API and thus harder to misuse:

```rust
trait PyCapsuleMethods {
    fn pointer(&self, name: Option<&CStr>) -> PyResult<NonNull<c_void>>;
    unsafe fn reference<T>(&self, name: Option<&CStr>) -> PyResult<&'py T>;
    fn is_valid(&self, name: Option<&CStr>) -> bool;
}
```

This is a breaking change, but I believe that the benefit of increased safety is worth the cost of API breakage.
