### PR TITLE
refactor: break `gil.rs` into parts

### DIFF
--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -17,7 +17,6 @@ pub mod freelist;
 pub mod frompyobject;
 #[cfg(feature = "experimental-inspect")]
 pub mod introspection;
-pub(crate) mod not_send;
 pub mod panic;
 pub mod pycell;
 pub mod pyclass;

--- a/src/impl_/not_send.rs
+++ b/src/impl_/not_send.rs
@@ -1,7 +1,0 @@
-use std::marker::PhantomData;
-
-use crate::Python;
-
-/// A marker type that makes the type !Send.
-/// Workaround for lack of !Send on stable (<https://github.com/rust-lang/rust/issues/68318>).
-pub(crate) struct NotSend(PhantomData<*mut Python<'static>>);

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -1,9 +1,9 @@
 use crate::exceptions::PyStopAsyncIteration;
-use crate::gil::LockGIL;
 use crate::impl_::callback::IntoPyCallbackOutput;
 use crate::impl_::panic::PanicTrap;
 use crate::impl_::pycell::{PyClassObject, PyClassObjectLayout};
 use crate::internal::get_slot::{get_slot, TP_BASE, TP_CLEAR, TP_TRAVERSE};
+use crate::internal::state::ForbidAttaching;
 use crate::pycell::impl_::PyClassBorrowChecker as _;
 use crate::pycell::{PyBorrowError, PyBorrowMutError};
 use crate::pyclass::boolean_struct::False;
@@ -293,7 +293,7 @@ where
     // Since we do not create a `GILPool` at all, it is important that our usage of the GIL
     // token does not produce any owned objects thereby calling into `register_owned`.
     let trap = PanicTrap::new("uncaught panic inside __traverse__ handler");
-    let lock = LockGIL::during_traverse();
+    let lock = ForbidAttaching::during_traverse();
 
     let super_retval = unsafe { call_super_traverse(slf, visit, arg, current_traverse) };
     if super_retval != 0 {

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -222,7 +222,7 @@ where
 /// # Safety
 ///
 /// - ctx must be either a valid ffi::PyObject or NULL
-/// - The GIL must already be held when this is called.
+/// - The thread must be attached to the interpreter when this is called.
 #[inline]
 unsafe fn trampoline_unraisable<F>(body: F, ctx: *mut ffi::PyObject)
 where
@@ -230,7 +230,7 @@ where
 {
     let trap = PanicTrap::new("uncaught panic at ffi boundary");
 
-    // SAFETY: The GIL is already held.
+    // SAFETY: Thread is known to be attached.
     let guard = unsafe { AttachGuard::assume() };
     let py = guard.python();
 

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -9,7 +9,7 @@ use std::{
     panic::{self, UnwindSafe},
 };
 
-use crate::gil::GILGuard;
+use crate::internal::state::AttachGuard;
 use crate::{
     ffi, ffi_ptr_ext::FfiPtrExt, impl_::callback::PyCallbackOutput, impl_::panic::PanicTrap,
     impl_::pymethods::IPowModulo, panic::PanicException, types::PyModule, Py, PyResult, Python,
@@ -168,12 +168,12 @@ trampoline!(
     ) -> *mut ffi::PyObject;
 );
 
-/// Implementation of trampoline functions, which sets up a GILPool and calls F.
+/// Implementation of trampoline functions, which sets up an AttachGuard and calls F.
 ///
 /// Panics during execution are trapped so that they don't propagate through any
 /// outer FFI boundary.
 ///
-/// The GIL must already be held when this is called.
+/// The thread must already be attached to the interpreter when this is called.
 #[inline]
 pub(crate) unsafe fn trampoline<F, R>(body: F) -> R
 where
@@ -182,8 +182,8 @@ where
 {
     let trap = PanicTrap::new("uncaught panic at ffi boundary");
 
-    // SAFETY: This function requires the GIL to already be held.
-    let guard = unsafe { GILGuard::assume() };
+    // SAFETY: This function requires the thread to already be attached.
+    let guard = unsafe { AttachGuard::assume() };
     let py = guard.python();
     let out = panic_result_into_callback_output(
         py,
@@ -231,7 +231,7 @@ where
     let trap = PanicTrap::new("uncaught panic at ffi boundary");
 
     // SAFETY: The GIL is already held.
-    let guard = unsafe { GILGuard::assume() };
+    let guard = unsafe { AttachGuard::assume() };
     let py = guard.python();
 
     if let Err(py_err) = panic::catch_unwind(move || body(py))

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -11,7 +11,7 @@ use crate::{
     ffi, DowncastError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyRef, PyRefMut,
     PyTypeInfo, Python,
 };
-use crate::{gil, PyTypeCheck};
+use crate::{internal::state, PyTypeCheck};
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
@@ -1747,7 +1747,7 @@ impl<T> Clone for Py<T> {
     #[track_caller]
     fn clone(&self) -> Self {
         unsafe {
-            gil::register_incref(self.0);
+            state::register_incref(self.0);
         }
         Self(self.0, PhantomData)
     }
@@ -1765,7 +1765,7 @@ impl<T> Drop for Py<T> {
     #[track_caller]
     fn drop(&mut self) {
         unsafe {
-            gil::register_decref(self.0);
+            state::register_decref(self.0);
         }
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,3 +1,4 @@
 //! Holding place for code which is not intended to be reachable from outside of PyO3.
 
 pub(crate) mod get_slot;
+pub(crate) mod state;

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -37,7 +37,7 @@ fn thread_is_attached() -> bool {
 
 /// RAII type that represents thread attachment to the interpreter.
 pub(crate) enum AttachGuard {
-    /// Indicates the thread was already attached with this AttachGuard was acquired.
+    /// Indicates the thread was already attached when this AttachGuard was acquired.
     Assumed,
     /// Indicates that we attached when this AttachGuard was acquired
     Ensured { gstate: ffi::PyGILState_STATE },

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -191,7 +191,7 @@ impl Drop for SuspendAttach {
         unsafe {
             ffi::PyEval_RestoreThread(self.tstate);
 
-            // Update counts of PyObjects / Py that were cloned or dropped while not attached.
+            // Update counts of `Py<T>` that were dropped while not attached.
             #[cfg(not(pyo3_disable_reference_pool))]
             if let Some(pool) = POOL.get() {
                 pool.update_counts(Python::assume_gil_acquired());
@@ -221,7 +221,7 @@ impl ForbidAttaching {
     fn bail(current: isize) {
         match current {
             ATTACH_FORBIDDEN_DURING_TRAVERSE => panic!(
-                "Attaching a thread to the interpreter is prohibited while a __traverse__ implmentation is running."
+                "Attaching a thread to the interpreter is prohibited while a __traverse__ implementation is running."
             ),
             _ => panic!("Attaching a thread to the interpreter is currently prohibited."),
         }

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -163,7 +163,7 @@ fn get_pool() -> &'static ReferencePool {
     POOL.get_or_init(ReferencePool::new)
 }
 
-/// A guard which can be used to temporarily release the interpreter and restore on `Drop`.
+/// A guard which can be used to temporarily detach from the interpreter and restore on `Drop`.
 pub(crate) struct SuspendAttach {
     count: isize,
     tstate: *mut ffi::PyThreadState,
@@ -193,7 +193,7 @@ impl Drop for SuspendAttach {
     }
 }
 
-/// Used to lock safe access to the GIL
+/// Used to lock safe access to the interpreter
 pub(crate) struct ForbidAttaching {
     count: isize,
 }

--- a/src/interpreter_lifecycle.rs
+++ b/src/interpreter_lifecycle.rs
@@ -1,0 +1,140 @@
+use std::sync;
+
+use crate::{ffi, internal::state::AttachGuard, Python};
+
+static START: sync::Once = sync::Once::new();
+
+/// Prepares the use of Python in a free-threaded context.
+///
+/// If the Python interpreter is not already initialized, this function will initialize it with
+/// signal handling disabled (Python will not raise the `KeyboardInterrupt` exception). Python
+/// signal handling depends on the notion of a 'main thread', which must be the thread that
+/// initializes the Python interpreter.
+///
+/// If the Python interpreter is already initialized, this function has no effect.
+///
+/// This function is unavailable under PyPy because PyPy cannot be embedded in Rust (or any other
+/// software). Support for this is tracked on the
+/// [PyPy issue tracker](https://github.com/pypy/pypy/issues/3836).
+///
+/// # Examples
+/// ```rust
+/// use pyo3::prelude::*;
+///
+/// # fn main() -> PyResult<()> {
+/// pyo3::prepare_freethreaded_python();
+/// Python::attach(|py| py.run(pyo3::ffi::c_str!("print('Hello World')"), None, None))
+/// # }
+/// ```
+pub fn prepare_freethreaded_python() {
+    // Protect against race conditions when Python is not yet initialized and multiple threads
+    // concurrently call 'prepare_freethreaded_python()'. Note that we do not protect against
+    // concurrent initialization of the Python runtime by other users of the Python C API.
+    START.call_once_force(|_| unsafe {
+        // Use call_once_force because if initialization panics, it's okay to try again.
+        if ffi::Py_IsInitialized() == 0 {
+            ffi::Py_InitializeEx(0);
+
+            // Release the GIL.
+            ffi::PyEval_SaveThread();
+        }
+    });
+}
+
+/// Executes the provided closure with an embedded Python interpreter.
+///
+/// This function initializes the Python interpreter, executes the provided closure, and then
+/// finalizes the Python interpreter.
+///
+/// After execution all Python resources are cleaned up, and no further Python APIs can be called.
+/// Because many Python modules implemented in C do not support multiple Python interpreters in a
+/// single process, it is not safe to call this function more than once. (Many such modules will not
+/// initialize correctly on the second run.)
+///
+/// # Panics
+/// - If the Python interpreter is already initialized before calling this function.
+///
+/// # Safety
+/// - This function should only ever be called once per process (usually as part of the `main`
+///   function). It is also not thread-safe.
+/// - No Python APIs can be used after this function has finished executing.
+/// - The return value of the closure must not contain any Python value, _including_ `PyResult`.
+///
+/// # Examples
+///
+/// ```rust
+/// unsafe {
+///     pyo3::with_embedded_python_interpreter(|py| {
+///         if let Err(e) = py.run(pyo3::ffi::c_str!("print('Hello World')"), None, None) {
+///             // We must make sure to not return a `PyErr`!
+///             e.print(py);
+///         }
+///     });
+/// }
+/// ```
+pub unsafe fn with_embedded_python_interpreter<F, R>(f: F) -> R
+where
+    F: for<'p> FnOnce(Python<'p>) -> R,
+{
+    assert_eq!(
+        unsafe { ffi::Py_IsInitialized() },
+        0,
+        "called `with_embedded_python_interpreter` but a Python interpreter is already running."
+    );
+
+    unsafe { ffi::Py_InitializeEx(0) };
+
+    let result = {
+        let guard = unsafe { AttachGuard::assume() };
+        let py = guard.python();
+        // Import the threading module - this ensures that it will associate this thread as the "main"
+        // thread, which is important to avoid an `AssertionError` at finalization.
+        py.import("threading").unwrap();
+
+        // Execute the closure.
+        f(py)
+    };
+
+    // Finalize the Python interpreter.
+    unsafe { ffi::Py_Finalize() };
+
+    result
+}
+
+pub(crate) fn ensure_initialized() {
+    // Maybe auto-initialize the GIL:
+    //  - If auto-initialize feature set and supported, try to initialize the interpreter.
+    //  - If the auto-initialize feature is set but unsupported, emit hard errors only when the
+    //    extension-module feature is not activated - extension modules don't care about
+    //    auto-initialize so this avoids breaking existing builds.
+    //  - Otherwise, just check the GIL is initialized.
+    #[cfg(all(feature = "auto-initialize", not(any(PyPy, GraalPy))))]
+    {
+        prepare_freethreaded_python();
+    }
+    #[cfg(not(all(feature = "auto-initialize", not(any(PyPy, GraalPy)))))]
+    {
+        // This is a "hack" to make running `cargo test` for PyO3 convenient (i.e. no need
+        // to specify `--features auto-initialize` manually. Tests within the crate itself
+        // all depend on the auto-initialize feature for conciseness but Cargo does not
+        // provide a mechanism to specify required features for tests.
+        #[cfg(not(any(PyPy, GraalPy)))]
+        if option_env!("CARGO_PRIMARY_PACKAGE").is_some() {
+            prepare_freethreaded_python();
+        }
+
+        START.call_once_force(|_| unsafe {
+            // Use call_once_force because if there is a panic because the interpreter is
+            // not initialized, it's fine for the user to initialize the interpreter and
+            // retry.
+            assert_ne!(
+                ffi::Py_IsInitialized(),
+                0,
+                "The Python interpreter is not initialized and the `auto-initialize` \
+                        feature is not enabled.\n\n\
+                        Consider calling `pyo3::prepare_freethreaded_python()` before attempting \
+                        to use Python APIs."
+            );
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,7 +426,6 @@ pub mod ffi;
 #[doc(hidden)]
 pub mod impl_;
 mod instance;
-#[cfg(not(any(PyPy, GraalPy)))]
 mod interpreter_lifecycle;
 pub mod marker;
 pub mod marshal;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,9 +343,11 @@
 pub use crate::class::*;
 pub use crate::conversion::{FromPyObject, IntoPyObject, IntoPyObjectExt};
 pub use crate::err::{DowncastError, DowncastIntoError, PyErr, PyErrArguments, PyResult, ToPyErr};
-#[cfg(not(any(PyPy, GraalPy)))]
-pub use crate::gil::{prepare_freethreaded_python, with_embedded_python_interpreter};
 pub use crate::instance::{Borrowed, Bound, BoundObject, Py, PyObject};
+#[cfg(not(any(PyPy, GraalPy)))]
+pub use crate::interpreter_lifecycle::{
+    prepare_freethreaded_python, with_embedded_python_interpreter,
+};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyRef, PyRefMut};
 pub use crate::pyclass::PyClass;
@@ -421,10 +423,11 @@ pub mod coroutine;
 mod err;
 pub mod exceptions;
 pub mod ffi;
-mod gil;
 #[doc(hidden)]
 pub mod impl_;
 mod instance;
+#[cfg(not(any(PyPy, GraalPy)))]
+mod interpreter_lifecycle;
 pub mod marker;
 pub mod marshal;
 #[macro_use]

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -416,8 +416,6 @@ impl Python<'_> {
         F: for<'py> FnOnce(Python<'py>) -> R,
     {
         let guard = AttachGuard::acquire();
-
-        // SAFETY: Either the GIL was already acquired or we just created a new `GILGuard`.
         f(guard.python())
     }
 

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -118,8 +118,7 @@
 //! [`Py`]: crate::Py
 use crate::conversion::IntoPyObject;
 use crate::err::{self, PyResult};
-use crate::gil::{GILGuard, SuspendGIL};
-use crate::impl_::not_send::NotSend;
+use crate::internal::state::{AttachGuard, SuspendAttach};
 use crate::types::any::PyAnyMethods;
 use crate::types::{
     PyAny, PyCode, PyCodeMethods, PyDict, PyEllipsis, PyModule, PyNone, PyNotImplemented, PyString,
@@ -351,7 +350,11 @@ pub use nightly::Ungil;
 /// The [`Python<'py>`] type can be used to create references to variables owned by the Python
 /// interpreter, using functions such as [`Python::eval`] and [`PyModule::import`].
 #[derive(Copy, Clone)]
-pub struct Python<'py>(PhantomData<(&'py GILGuard, NotSend)>);
+pub struct Python<'py>(PhantomData<&'py AttachGuard>, PhantomData<NotSend>);
+
+/// A marker type that makes the type !Send.
+/// Workaround for lack of !Send on stable (<https://github.com/rust-lang/rust/issues/68318>).
+struct NotSend(PhantomData<*mut Python<'static>>);
 
 impl Python<'_> {
     /// See [Python::attach]
@@ -412,7 +415,7 @@ impl Python<'_> {
     where
         F: for<'py> FnOnce(Python<'py>) -> R,
     {
-        let guard = GILGuard::acquire();
+        let guard = AttachGuard::acquire();
 
         // SAFETY: Either the GIL was already acquired or we just created a new `GILGuard`.
         f(guard.python())
@@ -447,7 +450,7 @@ impl Python<'_> {
     where
         F: for<'py> FnOnce(Python<'py>) -> R,
     {
-        let guard = unsafe { GILGuard::acquire_unchecked() };
+        let guard = unsafe { AttachGuard::acquire_unchecked() };
 
         f(guard.python())
     }
@@ -535,7 +538,7 @@ impl<'py> Python<'py> {
         // so that the GIL will be reacquired even if `f` panics.
         // The `Send` bound on the closure prevents the user from
         // transferring the `Python` token into the closure.
-        let _guard = unsafe { SuspendGIL::new() };
+        let _guard = unsafe { SuspendAttach::new() };
         f()
     }
 
@@ -770,7 +773,7 @@ impl<'unbound> Python<'unbound> {
     /// [nomicon]: https://doc.rust-lang.org/nomicon/unbounded-lifetimes.html
     #[inline]
     pub unsafe fn assume_gil_acquired() -> Python<'unbound> {
-        Python(PhantomData)
+        Python(PhantomData, PhantomData)
     }
 }
 
@@ -978,5 +981,10 @@ cls.func()
         Python::attach(|py| {
             runner.reproducer(py).unwrap();
         });
+    }
+
+    #[test]
+    fn python_is_zst() {
+        assert_eq!(std::mem::size_of::<Python<'_>>(), 0);
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -5,7 +5,7 @@
 //!
 //! [PEP 703]: https://peps.python.org/pep-703/
 use crate::{
-    gil::SuspendGIL,
+    internal::state::SuspendAttach,
     sealed::Sealed,
     types::{any::PyAnyMethods, PyAny, PyString},
     Bound, Py, PyResult, PyTypeCheck, Python,
@@ -611,7 +611,7 @@ impl OnceExt for parking_lot::Once {
             return;
         }
 
-        let ts_guard = unsafe { SuspendGIL::new() };
+        let ts_guard = unsafe { SuspendAttach::new() };
 
         self.call_once(move || {
             drop(ts_guard);
@@ -628,7 +628,7 @@ impl OnceExt for parking_lot::Once {
             return;
         }
 
-        let ts_guard = unsafe { SuspendGIL::new() };
+        let ts_guard = unsafe { SuspendAttach::new() };
 
         self.call_once_force(move |state| {
             drop(ts_guard);
@@ -672,7 +672,7 @@ impl<T> MutexExt<T> for std::sync::Mutex<T> {
         // SAFETY: detach from the runtime right before a possibly blocking call
         // then reattach when the blocking call completes and before calling
         // into the C API.
-        let ts_guard = unsafe { SuspendGIL::new() };
+        let ts_guard = unsafe { SuspendAttach::new() };
         let res = self.lock();
         drop(ts_guard);
         res
@@ -691,7 +691,7 @@ impl<R: lock_api::RawMutex, T> MutexExt<T> for lock_api::Mutex<R, T> {
             return guard;
         }
 
-        let ts_guard = unsafe { SuspendGIL::new() };
+        let ts_guard = unsafe { SuspendAttach::new() };
         let res = self.lock();
         drop(ts_guard);
         res
@@ -713,7 +713,7 @@ where
             return guard;
         }
 
-        let ts_guard = unsafe { SuspendGIL::new() };
+        let ts_guard = unsafe { SuspendAttach::new() };
         let res = self.lock_arc();
         drop(ts_guard);
         res
@@ -728,7 +728,7 @@ where
     // SAFETY: detach from the runtime right before a possibly blocking call
     // then reattach when the blocking call completes and before calling
     // into the C API.
-    let ts_guard = unsafe { SuspendGIL::new() };
+    let ts_guard = unsafe { SuspendAttach::new() };
 
     once.call_once(move || {
         drop(ts_guard);
@@ -744,7 +744,7 @@ where
     // SAFETY: detach from the runtime right before a possibly blocking call
     // then reattach when the blocking call completes and before calling
     // into the C API.
-    let ts_guard = unsafe { SuspendGIL::new() };
+    let ts_guard = unsafe { SuspendAttach::new() };
 
     once.call_once_force(move |state| {
         drop(ts_guard);
@@ -764,7 +764,7 @@ where
     // SAFETY: detach from the runtime right before a possibly blocking call
     // then reattach when the blocking call completes and before calling
     // into the C API.
-    let ts_guard = unsafe { SuspendGIL::new() };
+    let ts_guard = unsafe { SuspendAttach::new() };
 
     // this trait is guarded by a rustc version config
     // so clippy's MSRV check is wrong

--- a/tests/ui/not_send.stderr
+++ b/tests/ui/not_send.stderr
@@ -12,13 +12,12 @@ note: required because it appears within the type `PhantomData<*mut pyo3::Python
   |
   | pub struct PhantomData<T: ?Sized>;
   |            ^^^^^^^^^^^
-note: required because it appears within the type `impl_::not_send::NotSend`
- --> src/impl_/not_send.rs
+note: required because it appears within the type `pyo3::marker::NotSend`
+ --> src/marker.rs
   |
-  | pub(crate) struct NotSend(PhantomData<*mut Python<'static>>);
-  |                   ^^^^^^^
-  = note: required because it appears within the type `(&pyo3::gil::GILGuard, impl_::not_send::NotSend)`
-note: required because it appears within the type `PhantomData<(&pyo3::gil::GILGuard, impl_::not_send::NotSend)>`
+  | struct NotSend(PhantomData<*mut Python<'static>>);
+  |        ^^^^^^^
+note: required because it appears within the type `PhantomData<pyo3::marker::NotSend>`
  --> $RUST/core/src/marker.rs
   |
   | pub struct PhantomData<T: ?Sized>;
@@ -26,7 +25,7 @@ note: required because it appears within the type `PhantomData<(&pyo3::gil::GILG
 note: required because it appears within the type `pyo3::Python<'_>`
  --> src/marker.rs
   |
-  | pub struct Python<'py>(PhantomData<(&'py GILGuard, NotSend)>);
+  | pub struct Python<'py>(PhantomData<&'py AttachGuard>, PhantomData<NotSend>);
   |            ^^^^^^
   = note: required for `&pyo3::Python<'_>` to implement `Send`
 note: required because it's used within this closure

--- a/tests/ui/not_send2.stderr
+++ b/tests/ui/not_send2.stderr
@@ -15,13 +15,12 @@ note: required because it appears within the type `PhantomData<*mut pyo3::Python
    |
    | pub struct PhantomData<T: ?Sized>;
    |            ^^^^^^^^^^^
-note: required because it appears within the type `impl_::not_send::NotSend`
-  --> src/impl_/not_send.rs
+note: required because it appears within the type `pyo3::marker::NotSend`
+  --> src/marker.rs
    |
-   | pub(crate) struct NotSend(PhantomData<*mut Python<'static>>);
-   |                   ^^^^^^^
-   = note: required because it appears within the type `(&pyo3::gil::GILGuard, impl_::not_send::NotSend)`
-note: required because it appears within the type `PhantomData<(&pyo3::gil::GILGuard, impl_::not_send::NotSend)>`
+   | struct NotSend(PhantomData<*mut Python<'static>>);
+   |        ^^^^^^^
+note: required because it appears within the type `PhantomData<pyo3::marker::NotSend>`
   --> $RUST/core/src/marker.rs
    |
    | pub struct PhantomData<T: ?Sized>;
@@ -29,7 +28,7 @@ note: required because it appears within the type `PhantomData<(&pyo3::gil::GILG
 note: required because it appears within the type `pyo3::Python<'_>`
   --> src/marker.rs
    |
-   | pub struct Python<'py>(PhantomData<(&'py GILGuard, NotSend)>);
+   | pub struct Python<'py>(PhantomData<&'py AttachGuard>, PhantomData<NotSend>);
    |            ^^^^^^
 note: required because it appears within the type `pyo3::Bound<'_, PyString>`
   --> src/instance.rs


### PR DESCRIPTION
Following our general cleanup to remove references to "GIL" from the codebase, this takes the chance to rename `gil.rs` and `GilGuard` into more up-to-date terms:
- `GIL_COUNT` and similar friends have become `ATTACH_COUNT` and moved to `internal/state.rs`
- `prepare_freethreaded_python` and similar have moved to `interpreter_lifecycle.rs`