### PR TITLE
introduce `PyClassGuard(Mut)` as future replacement for `PyRef(Mut)`

### DIFF
--- a/newsfragments/5233.added.md
+++ b/newsfragments/5233.added.md
@@ -1,0 +1,1 @@
+added new `PyClassGuard(Mut)` pyclass holders. In the future they will replace `PyRef(Mut)`

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -1125,7 +1125,7 @@ fn parse_method_attributes(attrs: &mut Vec<syn::Attribute>) -> Result<Vec<Method
 const IMPL_TRAIT_ERR: &str = "Python functions cannot have `impl Trait` arguments";
 const RECEIVER_BY_VALUE_ERR: &str =
     "Python objects are shared, so 'self' cannot be moved out of the Python interpreter.
-Try `&self`, `&mut self, `slf: PyRef<'_, Self>` or `slf: PyRefMut<'_, Self>`.";
+Try `&self`, `&mut self, `slf: PyClassGuard<'_, Self>` or `slf: PyClassGuardMut<'_, Self>`.";
 
 fn ensure_signatures_on_valid_method(
     fn_type: &FnType,

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -315,6 +315,8 @@ pub trait FromPyObject<'py>: Sized {
 }
 
 mod from_py_object_bound_sealed {
+    use crate::{pyclass::boolean_struct::False, PyClass, PyClassGuard, PyClassGuardMut};
+
     /// Private seal for the `FromPyObjectBound` trait.
     ///
     /// This prevents downstream types from implementing the trait before
@@ -324,6 +326,8 @@ mod from_py_object_bound_sealed {
     // This generic implementation is why the seal is separate from
     // `crate::sealed::Sealed`.
     impl<'py, T> Sealed for T where T: super::FromPyObject<'py> {}
+    impl<T> Sealed for PyClassGuard<'_, T> where T: PyClass {}
+    impl<T> Sealed for PyClassGuardMut<'_, T> where T: PyClass<Frozen = False> {}
     impl Sealed for &'_ str {}
     impl Sealed for std::borrow::Cow<'_, str> {}
     impl Sealed for &'_ [u8] {}

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -80,39 +80,6 @@ where
     }
 }
 
-// FIXME(icxolu): It currently seems hard to implement `FromPyObjectBound` for
-// `PyClassGuard(Mut)` instead, because there is no simple way to get a &Py<T>
-// from a `Borrowed<T>` (double indirection vs single indirection)
-impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for PyClassGuard<'a, T>
-where
-    T: PyClass,
-{
-    type Holder = ();
-
-    #[cfg(feature = "experimental-inspect")]
-    const INPUT_TYPE: &'static str = "typing.Any";
-
-    #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> PyResult<Self> {
-        PyClassGuard::try_borrow(obj.downcast()?.as_unbound()).map_err(Into::into)
-    }
-}
-
-impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for PyClassGuardMut<'a, T>
-where
-    T: PyClass<Frozen = False>,
-{
-    type Holder = ();
-
-    #[cfg(feature = "experimental-inspect")]
-    const INPUT_TYPE: &'static str = "typing.Any";
-
-    #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> PyResult<Self> {
-        PyClassGuardMut::try_borrow_mut(obj.downcast()?.as_unbound()).map_err(Into::into)
-    }
-}
-
 #[cfg(all(Py_LIMITED_API, not(Py_3_10)))]
 impl<'a, 'holder> PyFunctionArgument<'a, 'holder, '_, false> for &'holder str {
     type Holder = Option<std::borrow::Cow<'a, str>>;

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -4,7 +4,8 @@ use crate::{
     ffi,
     pyclass::boolean_struct::False,
     types::{any::PyAnyMethods, dict::PyDictMethods, tuple::PyTupleMethods, PyDict, PyTuple},
-    Borrowed, Bound, PyAny, PyClass, PyErr, PyRef, PyRefMut, PyResult, PyTypeCheck, Python,
+    Borrowed, Bound, PyAny, PyClass, PyClassGuard, PyClassGuardMut, PyErr, PyResult, PyTypeCheck,
+    Python,
 };
 
 /// Helper type used to keep implementation more concise.
@@ -20,19 +21,19 @@ type PyArg<'py> = Borrowed<'py, 'py, PyAny>;
 /// will be dropped as soon as the pyfunction call ends.
 ///
 /// There exists a trivial blanket implementation for `T: FromPyObject` with `Holder = ()`.
-pub trait PyFunctionArgument<'a, 'py, const IS_OPTION: bool>: Sized + 'a {
+pub trait PyFunctionArgument<'a, 'holder, 'py, const IS_OPTION: bool>: Sized {
     type Holder: FunctionArgumentHolder;
 
     /// Provides the type hint information for which Python types are allowed.
     #[cfg(feature = "experimental-inspect")]
     const INPUT_TYPE: &'static str;
 
-    fn extract(obj: &'a Bound<'py, PyAny>, holder: &'a mut Self::Holder) -> PyResult<Self>;
+    fn extract(obj: &'a Bound<'py, PyAny>, holder: &'holder mut Self::Holder) -> PyResult<Self>;
 }
 
-impl<'a, 'py, T> PyFunctionArgument<'a, 'py, false> for T
+impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for T
 where
-    T: FromPyObjectBound<'a, 'py> + 'a,
+    T: FromPyObjectBound<'a, 'py>,
 {
     type Holder = ();
 
@@ -40,12 +41,12 @@ where
     const INPUT_TYPE: &'static str = T::INPUT_TYPE;
 
     #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, _: &'a mut ()) -> PyResult<Self> {
+    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> PyResult<Self> {
         obj.extract()
     }
 }
 
-impl<'a, 'py, T: 'py> PyFunctionArgument<'a, 'py, false> for &'a Bound<'py, T>
+impl<'a, 'holder, 'py, T: 'py> PyFunctionArgument<'a, 'holder, 'py, false> for &'a Bound<'py, T>
 where
     T: PyTypeCheck,
 {
@@ -55,14 +56,14 @@ where
     const INPUT_TYPE: &'static str = T::PYTHON_TYPE;
 
     #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, _: &'a mut ()) -> PyResult<Self> {
+    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> PyResult<Self> {
         obj.downcast().map_err(Into::into)
     }
 }
 
-impl<'a, 'py, T> PyFunctionArgument<'a, 'py, true> for Option<T>
+impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, true> for Option<T>
 where
-    T: PyFunctionArgument<'a, 'py, false>, // inner `Option`s will use `FromPyObject`
+    T: PyFunctionArgument<'a, 'holder, 'py, false>, // inner `Option`s will use `FromPyObject`
 {
     type Holder = T::Holder;
 
@@ -70,7 +71,7 @@ where
     const INPUT_TYPE: &'static str = "typing.Any | None";
 
     #[inline]
-    fn extract(obj: &'a Bound<'py, PyAny>, holder: &'a mut T::Holder) -> PyResult<Self> {
+    fn extract(obj: &'a Bound<'py, PyAny>, holder: &'holder mut T::Holder) -> PyResult<Self> {
         if obj.is_none() {
             Ok(None)
         } else {
@@ -79,8 +80,41 @@ where
     }
 }
 
+// FIXME(icxolu): It currently seems hard to implement `FromPyObjectBound` for
+// `PyClassGuard(Mut)` instead, because there is no simple way to get a &Py<T>
+// from a `Borrowed<T>` (double indirection vs single indirection)
+impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for PyClassGuard<'a, T>
+where
+    T: PyClass,
+{
+    type Holder = ();
+
+    #[cfg(feature = "experimental-inspect")]
+    const INPUT_TYPE: &'static str = "typing.Any";
+
+    #[inline]
+    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> PyResult<Self> {
+        PyClassGuard::try_borrow(obj.downcast()?.as_unbound()).map_err(Into::into)
+    }
+}
+
+impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for PyClassGuardMut<'a, T>
+where
+    T: PyClass<Frozen = False>,
+{
+    type Holder = ();
+
+    #[cfg(feature = "experimental-inspect")]
+    const INPUT_TYPE: &'static str = "typing.Any";
+
+    #[inline]
+    fn extract(obj: &'a Bound<'py, PyAny>, _: &'holder mut ()) -> PyResult<Self> {
+        PyClassGuardMut::try_borrow_mut(obj.downcast()?.as_unbound()).map_err(Into::into)
+    }
+}
+
 #[cfg(all(Py_LIMITED_API, not(Py_3_10)))]
-impl<'a> PyFunctionArgument<'a, '_, false> for &'a str {
+impl<'a, 'holder> PyFunctionArgument<'a, 'holder, '_, false> for &'holder str {
     type Holder = Option<std::borrow::Cow<'a, str>>;
 
     #[cfg(feature = "experimental-inspect")]
@@ -89,7 +123,7 @@ impl<'a> PyFunctionArgument<'a, '_, false> for &'a str {
     #[inline]
     fn extract(
         obj: &'a Bound<'_, PyAny>,
-        holder: &'a mut Option<std::borrow::Cow<'a, str>>,
+        holder: &'holder mut Option<std::borrow::Cow<'a, str>>,
     ) -> PyResult<Self> {
         Ok(holder.insert(obj.extract()?))
     }
@@ -110,30 +144,32 @@ impl<T> FunctionArgumentHolder for Option<T> {
 }
 
 #[inline]
-pub fn extract_pyclass_ref<'a, 'py: 'a, T: PyClass>(
+pub fn extract_pyclass_ref<'a, 'holder, 'py, T: PyClass>(
     obj: &'a Bound<'py, PyAny>,
-    holder: &'a mut Option<PyRef<'py, T>>,
-) -> PyResult<&'a T> {
-    Ok(&*holder.insert(obj.extract()?))
+    holder: &'holder mut Option<PyClassGuard<'a, T>>,
+) -> PyResult<&'holder T> {
+    Ok(&*holder.insert(PyClassGuard::try_borrow(obj.downcast()?.as_unbound())?))
 }
 
 #[inline]
-pub fn extract_pyclass_ref_mut<'a, 'py: 'a, T: PyClass<Frozen = False>>(
+pub fn extract_pyclass_ref_mut<'a, 'holder, 'py, T: PyClass<Frozen = False>>(
     obj: &'a Bound<'py, PyAny>,
-    holder: &'a mut Option<PyRefMut<'py, T>>,
-) -> PyResult<&'a mut T> {
-    Ok(&mut *holder.insert(obj.extract()?))
+    holder: &'holder mut Option<PyClassGuardMut<'a, T>>,
+) -> PyResult<&'holder mut T> {
+    Ok(&mut *holder.insert(PyClassGuardMut::try_borrow_mut(
+        obj.downcast()?.as_unbound(),
+    )?))
 }
 
 /// The standard implementation of how PyO3 extracts a `#[pyfunction]` or `#[pymethod]` function argument.
 #[doc(hidden)]
-pub fn extract_argument<'a, 'py, T, const IS_OPTION: bool>(
+pub fn extract_argument<'a, 'holder, 'py, T, const IS_OPTION: bool>(
     obj: &'a Bound<'py, PyAny>,
-    holder: &'a mut T::Holder,
+    holder: &'holder mut T::Holder,
     arg_name: &str,
 ) -> PyResult<T>
 where
-    T: PyFunctionArgument<'a, 'py, IS_OPTION>,
+    T: PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>,
 {
     match PyFunctionArgument::extract(obj, holder) {
         Ok(value) => Ok(value),
@@ -144,14 +180,14 @@ where
 /// Alternative to [`extract_argument`] used for `Option<T>` arguments. This is necessary because Option<&T>
 /// does not implement `PyFunctionArgument` for `T: PyClass`.
 #[doc(hidden)]
-pub fn extract_optional_argument<'a, 'py, T, const IS_OPTION: bool>(
+pub fn extract_optional_argument<'a, 'holder, 'py, T, const IS_OPTION: bool>(
     obj: Option<&'a Bound<'py, PyAny>>,
-    holder: &'a mut T::Holder,
+    holder: &'holder mut T::Holder,
     arg_name: &str,
     default: fn() -> Option<T>,
 ) -> PyResult<Option<T>>
 where
-    T: PyFunctionArgument<'a, 'py, IS_OPTION>,
+    T: PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>,
 {
     match obj {
         Some(obj) => {
@@ -168,14 +204,14 @@ where
 
 /// Alternative to [`extract_argument`] used when the argument has a default value provided by an annotation.
 #[doc(hidden)]
-pub fn extract_argument_with_default<'a, 'py, T, const IS_OPTION: bool>(
+pub fn extract_argument_with_default<'a, 'holder, 'py, T, const IS_OPTION: bool>(
     obj: Option<&'a Bound<'py, PyAny>>,
-    holder: &'a mut T::Holder,
+    holder: &'holder mut T::Holder,
     arg_name: &str,
     default: fn() -> T,
 ) -> PyResult<T>
 where
-    T: PyFunctionArgument<'a, 'py, IS_OPTION>,
+    T: PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>,
 {
     match obj {
         Some(obj) => extract_argument(obj, holder, arg_name),

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -10,8 +10,9 @@ use crate::pyclass::boolean_struct::False;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyType;
 use crate::{
-    ffi, Bound, DowncastError, Py, PyAny, PyClass, PyClassInitializer, PyErr, PyObject, PyRef,
-    PyRefMut, PyResult, PyTraverseError, PyTypeCheck, PyVisit, Python,
+    ffi, Bound, DowncastError, Py, PyAny, PyClass, PyClassGuard, PyClassGuardMut,
+    PyClassInitializer, PyErr, PyObject, PyRef, PyRefMut, PyResult, PyTraverseError, PyTypeCheck,
+    PyVisit, Python,
 };
 use std::ffi::CStr;
 use std::fmt;
@@ -654,11 +655,27 @@ impl<'a, 'py> BoundRef<'a, 'py, PyAny> {
     }
 }
 
+impl<'a, 'py, T: PyClass> TryFrom<BoundRef<'a, 'py, T>> for PyClassGuard<'a, T> {
+    type Error = PyBorrowError;
+    #[inline]
+    fn try_from(value: BoundRef<'a, 'py, T>) -> Result<Self, Self::Error> {
+        PyClassGuard::try_borrow(value.0.as_unbound())
+    }
+}
+
+impl<'a, 'py, T: PyClass<Frozen = False>> TryFrom<BoundRef<'a, 'py, T>> for PyClassGuardMut<'a, T> {
+    type Error = PyBorrowMutError;
+    #[inline]
+    fn try_from(value: BoundRef<'a, 'py, T>) -> Result<Self, Self::Error> {
+        PyClassGuardMut::try_borrow_mut(value.0.as_unbound())
+    }
+}
+
 impl<'a, 'py, T: PyClass> TryFrom<BoundRef<'a, 'py, T>> for PyRef<'py, T> {
     type Error = PyBorrowError;
     #[inline]
     fn try_from(value: BoundRef<'a, 'py, T>) -> Result<Self, Self::Error> {
-        value.0.try_borrow()
+        PyRef::try_borrow(value.0)
     }
 }
 
@@ -666,7 +683,7 @@ impl<'a, 'py, T: PyClass<Frozen = False>> TryFrom<BoundRef<'a, 'py, T>> for PyRe
     type Error = PyBorrowMutError;
     #[inline]
     fn try_from(value: BoundRef<'a, 'py, T>) -> Result<Self, Self::Error> {
-        value.0.try_borrow_mut()
+        PyRefMut::try_borrow(value.0)
     }
 }
 

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -19,7 +19,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::os::raw::{c_int, c_void};
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::ptr::null_mut;
+use std::ptr::{null_mut, NonNull};
 
 use super::trampoline;
 use crate::internal_tricks::{clear_eq, traverse_eq};
@@ -644,6 +644,10 @@ impl<'a, 'py> BoundRef<'a, 'py, PyAny> {
         ptr: &'a *mut ffi::PyObject,
     ) -> Option<Self> {
         unsafe { Bound::ref_from_ptr_or_opt(py, ptr).as_ref().map(BoundRef) }
+    }
+
+    pub unsafe fn ref_from_non_null(py: Python<'py>, ptr: &'a NonNull<ffi::PyObject>) -> Self {
+        unsafe { Self(Bound::ref_from_non_null(py, ptr)) }
     }
 
     pub fn downcast<T: PyTypeCheck>(self) -> Result<BoundRef<'a, 'py, T>, DowncastError<'a, 'py>> {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -721,6 +721,17 @@ impl<'a, 'py, T> Borrowed<'a, 'py, T> {
     }
 }
 
+impl<'a, T: PyClass> Borrowed<'a, '_, T> {
+    /// Get a view on the underlying `PyClass` contents.
+    #[inline]
+    pub(crate) fn get_class_object(self) -> &'a PyClassObject<T> {
+        // Safety: Borrowed<'a, '_, T: PyClass> is known to contain an object
+        // which is laid out in memory as a PyClassObject<T> and lives for at
+        // least 'a.
+        unsafe { &*self.as_ptr().cast::<PyClassObject<T>>() }
+    }
+}
+
 impl<'a, 'py> Borrowed<'a, 'py, PyAny> {
     /// Constructs a new `Borrowed<'a, 'py, PyAny>` from a pointer. Panics if `ptr` is null.
     ///

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -788,6 +788,15 @@ impl<'a, 'py> Borrowed<'a, 'py, PyAny> {
         Self(unsafe { NonNull::new_unchecked(ptr) }, PhantomData, py)
     }
 
+    /// # Safety
+    /// This similar to `std::slice::from_raw_parts`, the lifetime `'a` is
+    /// completely defined by the caller and it is the caller's responsibility
+    /// to ensure that the reference this is derived from is valid for the
+    /// lifetime `'a`.
+    pub(crate) unsafe fn from_non_null(py: Python<'py>, ptr: NonNull<ffi::PyObject>) -> Self {
+        Self(ptr, PhantomData, py)
+    }
+
     #[inline]
     pub(crate) fn downcast<T>(self) -> Result<Borrowed<'a, 'py, T>, DowncastError<'a, 'py>>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,7 +351,7 @@ pub use crate::interpreter_lifecycle::{
 };
 pub use crate::marker::Python;
 pub use crate::pycell::{PyRef, PyRefMut};
-pub use crate::pyclass::PyClass;
+pub use crate::pyclass::{PyClass, PyClassGuard, PyClassGuardMut};
 pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::type_object::{PyTypeCheck, PyTypeInfo};
 pub use crate::types::PyAny;

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -4,10 +4,12 @@ use std::{cmp::Ordering, os::raw::c_int};
 
 mod create_type_object;
 mod gc;
+mod guard;
 
 pub(crate) use self::create_type_object::{create_type_object, PyClassTypeObject};
 
 pub use self::gc::{PyTraverseError, PyVisit};
+pub use self::guard::{PyClassGuard, PyClassGuardMut};
 
 /// Types that can be used as Python classes.
 ///

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -1,0 +1,616 @@
+use crate::impl_::pycell::{PyClassObject, PyClassObjectLayout as _};
+use crate::pycell::PyBorrowMutError;
+use crate::pycell::{impl_::PyClassBorrowChecker, PyBorrowError};
+use crate::pyclass::boolean_struct::False;
+use crate::{ffi, Py, PyClass};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
+use std::ptr::NonNull;
+
+/// A wrapper type for an immutably borrowed value from a `PyClass`.
+///
+/// Rust has strict aliasing rules - you can either have any number of immutable
+/// (shared) references or one mutable reference. Python's ownership model is
+/// the complete opposite of that - any Python object can be referenced any
+/// number of times, and mutation is allowed from any reference.
+///
+/// PyO3 deals with these differences by employing the [Interior Mutability]
+/// pattern. This requires that PyO3 enforces the borrowing rules and it has two
+/// mechanisms for doing so:
+/// - Statically it can enforce thread-safe access with the
+///   [`Python<'py>`](crate::Python) token. All Rust code holding that token, or
+///   anything derived from it, can assume that they have safe access to the
+///   Python interpreter's state. For this reason all the native Python objects
+///   can be mutated through shared references.
+/// - However, methods and functions in Rust usually *do* need `&mut`
+///   references. While PyO3 can use the [`Python<'py>`](crate::Python) token to
+///   guarantee thread-safe access to them, it cannot statically guarantee
+///   uniqueness of `&mut` references. As such those references have to be
+///   tracked dynamically at runtime, using [`PyClassGuard`] and
+///   [`PyClassGuardMut`] defined in this module. This works similar to std's
+///   [`RefCell`](std::cell::RefCell) type. Especially when building for
+///   free-threaded Python it gets harder to track which thread borrows which
+///   object at any time. This can lead to method calls failing with
+///   [`PyBorrowError`]. In these cases consider using `frozen` classes together
+///   with Rust interior mutability primitives like [`Mutex`](std::sync::Mutex)
+///   instead of using [`PyClassGuardMut`] to get mutable access.
+///
+/// # Examples
+///
+/// You can use [`PyClassGuard`] as an alternative to a `&self` receiver when
+/// - you need to access the pointer of the `PyClass`, or
+/// - you want to get a super class.
+/// ```
+/// # use pyo3::prelude::*;
+/// # use pyo3::PyClassGuard;
+/// #[pyclass(subclass)]
+/// struct Parent {
+///     basename: &'static str,
+/// }
+///
+/// #[pyclass(extends=Parent)]
+/// struct Child {
+///     name: &'static str,
+///  }
+///
+/// #[pymethods]
+/// impl Child {
+///     #[new]
+///     fn new() -> (Self, Parent) {
+///         (Child { name: "Caterpillar" }, Parent { basename: "Butterfly" })
+///     }
+///
+///     fn format(slf: PyClassGuard<'_, Self>) -> String {
+///         // We can get &Self::BaseType by as_super
+///         let basename = slf.as_super().basename;
+///         format!("{}(base: {})", slf.name, basename)
+///     }
+/// }
+/// # Python::attach(|py| {
+/// #     let sub = Py::new(py, Child::new()).unwrap();
+/// #     pyo3::py_run!(py, sub, "assert sub.format() == 'Caterpillar(base: Butterfly)', sub.format()");
+/// # });
+/// ```
+///
+/// See also [`PyClassGuardMut`] and the [guide] for more information.
+///
+/// [Interior Mutability]:
+///     https://doc.rust-lang.org/book/ch15-05-interior-mutability.html
+///     "RefCell<T> and the Interior Mutability Pattern - The Rust Programming
+///     Language"
+/// [guide]: https://pyo3.rs/latest/class.html#bound-and-interior-mutability
+///     "Bound and interior mutability"
+#[repr(transparent)]
+pub struct PyClassGuard<'a, T: PyClass> {
+    ptr: NonNull<ffi::PyObject>,
+    marker: PhantomData<&'a Py<T>>,
+}
+
+impl<'a, T: PyClass> PyClassGuard<'a, T> {
+    pub(crate) fn try_borrow(obj: &'a Py<T>) -> Result<Self, PyBorrowError> {
+        Self::try_from_class_object(obj.get_class_object())
+    }
+
+    fn try_from_class_object(obj: &'a PyClassObject<T>) -> Result<Self, PyBorrowError> {
+        obj.ensure_threadsafe();
+        obj.borrow_checker().try_borrow().map(|_| Self {
+            ptr: NonNull::from(obj).cast(),
+            marker: PhantomData,
+        })
+    }
+
+    pub(crate) fn as_class_object(&self) -> &'a PyClassObject<T> {
+        // SAFETY: `ptr` by construction points to a `PyClassObject<T>` and is
+        // valid for at least 'a
+        unsafe { self.ptr.cast().as_ref() }
+    }
+}
+
+impl<'a, T, U> PyClassGuard<'a, T>
+where
+    T: PyClass<BaseType = U>,
+    U: PyClass,
+{
+    /// Borrows a shared reference to `PyClassGuard<T::BaseType>`.
+    ///
+    /// With the help of this method, you can access attributes and call methods
+    /// on the superclass without consuming the `PyClassGuard<T>`. This method
+    /// can also be chained to access the super-superclass (and so on).
+    ///
+    /// # Examples
+    /// ```
+    /// # use pyo3::prelude::*;
+    /// # use pyo3::PyClassGuard;
+    /// #[pyclass(subclass)]
+    /// struct Base {
+    ///     base_name: &'static str,
+    /// }
+    /// #[pymethods]
+    /// impl Base {
+    ///     fn base_name_len(&self) -> usize {
+    ///         self.base_name.len()
+    ///     }
+    /// }
+    ///
+    /// #[pyclass(extends=Base)]
+    /// struct Sub {
+    ///     sub_name: &'static str,
+    /// }
+    ///
+    /// #[pymethods]
+    /// impl Sub {
+    ///     #[new]
+    ///     fn new() -> (Self, Base) {
+    ///         (Self { sub_name: "sub_name" }, Base { base_name: "base_name" })
+    ///     }
+    ///     fn sub_name_len(&self) -> usize {
+    ///         self.sub_name.len()
+    ///     }
+    ///     fn format_name_lengths(slf: PyClassGuard<'_, Self>) -> String {
+    ///         format!("{} {}", slf.as_super().base_name_len(), slf.sub_name_len())
+    ///     }
+    /// }
+    /// # Python::attach(|py| {
+    /// #     let sub = Py::new(py, Sub::new()).unwrap();
+    /// #     pyo3::py_run!(py, sub, "assert sub.format_name_lengths() == '9 8'")
+    /// # });
+    /// ```
+    pub fn as_super(&self) -> &PyClassGuard<'a, U> {
+        // SAFETY: `PyClassGuard<T>` and `PyClassGuard<U>` have the same layout
+        unsafe { NonNull::from(self).cast().as_ref() }
+    }
+
+    /// Gets a `PyClassGuard<T::BaseType>`.
+    ///
+    /// With the help of this method, you can get hold of instances of the
+    /// super-superclass when needed.
+    ///
+    /// # Examples
+    /// ```
+    /// # use pyo3::prelude::*;
+    /// # use pyo3::PyClassGuard;
+    /// #[pyclass(subclass)]
+    /// struct Base1 {
+    ///     name1: &'static str,
+    /// }
+    ///
+    /// #[pyclass(extends=Base1, subclass)]
+    /// struct Base2 {
+    ///     name2: &'static str,
+    /// }
+    ///
+    /// #[pyclass(extends=Base2)]
+    /// struct Sub {
+    ///     name3: &'static str,
+    /// }
+    ///
+    /// #[pymethods]
+    /// impl Sub {
+    ///     #[new]
+    ///     fn new() -> PyClassInitializer<Self> {
+    ///         PyClassInitializer::from(Base1 { name1: "base1" })
+    ///             .add_subclass(Base2 { name2: "base2" })
+    ///             .add_subclass(Self { name3: "sub" })
+    ///     }
+    ///     fn name(slf: PyClassGuard<'_, Self>) -> String {
+    ///         let subname = slf.name3;
+    ///         let super_ = slf.into_super();
+    ///         format!("{} {} {}", super_.as_super().name1, super_.name2, subname)
+    ///     }
+    /// }
+    /// # Python::attach(|py| {
+    /// #     let sub = Py::new(py, Sub::new()).unwrap();
+    /// #     pyo3::py_run!(py, sub, "assert sub.name() == 'base1 base2 sub'")
+    /// # });
+    /// ```
+    pub fn into_super(self) -> PyClassGuard<'a, U> {
+        PyClassGuard {
+            ptr: std::mem::ManuallyDrop::new(self).ptr,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: PyClass> Deref for PyClassGuard<'_, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: `PyClassObject<T>` constains a valid `T`, by construction no
+        // mutable alias is enforced
+        unsafe { &*self.as_class_object().get_ptr().cast_const() }
+    }
+}
+
+impl<T: PyClass> Drop for PyClassGuard<'_, T> {
+    /// Releases the shared borrow
+    fn drop(&mut self) {
+        self.as_class_object().borrow_checker().release_borrow()
+    }
+}
+
+/// A wrapper type for a mutably borrowed value from a `PyClass`
+///
+/// # When *not* to use [`PyClassGuardMut`]
+///
+/// Usually you can use `&mut` references as method and function receivers and
+/// arguments, and you won't need to use [`PyClassGuardMut`] directly:
+///
+/// ```rust,no_run
+/// use pyo3::prelude::*;
+///
+/// #[pyclass]
+/// struct Number {
+///     inner: u32,
+/// }
+///
+/// #[pymethods]
+/// impl Number {
+///     fn increment(&mut self) {
+///         self.inner += 1;
+///     }
+/// }
+/// ```
+///
+/// The [`#[pymethods]`](crate::pymethods) proc macro will generate this wrapper
+/// function (and more), using [`PyClassGuardMut`] under the hood:
+///
+/// ```rust,no_run
+/// # use pyo3::prelude::*;
+/// # #[pyclass]
+/// # struct Number {
+/// #    inner: u32,
+/// # }
+/// #
+/// # #[pymethods]
+/// # impl Number {
+/// #    fn increment(&mut self) {
+/// #        self.inner += 1;
+/// #    }
+/// # }
+/// #
+/// // The function which is exported to Python looks roughly like the following
+/// unsafe extern "C" fn __pymethod_increment__(
+///     _slf: *mut ::pyo3::ffi::PyObject,
+///     _args: *mut ::pyo3::ffi::PyObject,
+/// ) -> *mut ::pyo3::ffi::PyObject {
+///     unsafe fn inner<'py>(
+///         py: ::pyo3::Python<'py>,
+///         _slf: *mut ::pyo3::ffi::PyObject,
+///     ) -> ::pyo3::PyResult<*mut ::pyo3::ffi::PyObject> {
+///         let function = Number::increment;
+/// #       #[allow(clippy::let_unit_value)]
+///         let mut holder_0 = ::pyo3::impl_::extract_argument::FunctionArgumentHolder::INIT;
+///         let result = {
+///             let ret = function(::pyo3::impl_::extract_argument::extract_pyclass_ref_mut::<Number>(
+///                 unsafe { ::pyo3::impl_::pymethods::BoundRef::ref_from_ptr(py, &_slf) }.0,
+///                 &mut holder_0,
+///             )?);
+///             {
+///                 let result = {
+///                     let obj = ret;
+/// #                   #[allow(clippy::useless_conversion)]
+///                     ::pyo3::impl_::wrap::converter(&obj)
+///                         .wrap(obj)
+///                         .map_err(::core::convert::Into::<::pyo3::PyErr>::into)
+///                 };
+///                 ::pyo3::impl_::wrap::converter(&result).map_into_ptr(py, result)
+///             }
+///         };
+///         result
+///     }
+///
+///     unsafe {
+///         ::pyo3::impl_::trampoline::noargs(
+///             _slf,
+///             _args,
+///             inner,
+///         )
+///     }
+/// }
+/// ```
+///
+/// # When to use [`PyClassGuardMut`]
+/// ## Using PyClasses from Rust
+///
+/// However, we *do* need [`PyClassGuardMut`] if we want to call its methods
+/// from Rust:
+/// ```rust
+/// # use pyo3::prelude::*;
+/// # use pyo3::{PyClassGuard, PyClassGuardMut};
+/// #
+/// # #[pyclass]
+/// # struct Number {
+/// #     inner: u32,
+/// # }
+/// #
+/// # #[pymethods]
+/// # impl Number {
+/// #     fn increment(&mut self) {
+/// #         self.inner += 1;
+/// #     }
+/// # }
+/// # fn main() -> PyResult<()> {
+/// Python::attach(|py| {
+///     let n = Py::new(py, Number { inner: 0 })?;
+///
+///     // We borrow the guard and then dereference
+///     // it to get a mutable reference to Number
+///     let mut guard: PyClassGuardMut<'_, Number> = n.extract(py)?;
+///     let n_mutable: &mut Number = &mut *guard;
+///
+///     n_mutable.increment();
+///
+///     // To avoid panics we must dispose of the
+///     // `PyClassGuardMut` before borrowing again.
+///     drop(guard);
+///
+///     let n_immutable: &Number = &*n.extract::<PyClassGuard<'_, Number>>(py)?;
+///     assert_eq!(n_immutable.inner, 1);
+///
+///     Ok(())
+/// })
+/// # }
+/// ```
+/// ## Dealing with possibly overlapping mutable references
+///
+/// It is also necessary to use [`PyClassGuardMut`] if you can receive mutable
+/// arguments that may overlap. Suppose the following function that swaps the
+/// values of two `Number`s:
+/// ```
+/// # use pyo3::prelude::*;
+/// # #[pyclass]
+/// # pub struct Number {
+/// #     inner: u32,
+/// # }
+/// #[pyfunction]
+/// fn swap_numbers(a: &mut Number, b: &mut Number) {
+///     std::mem::swap(&mut a.inner, &mut b.inner);
+/// }
+/// # fn main() {
+/// #     Python::attach(|py| {
+/// #         let n = Py::new(py, Number{inner: 35}).unwrap();
+/// #         let n2 = n.clone_ref(py);
+/// #         assert!(n.is(&n2));
+/// #         let fun = pyo3::wrap_pyfunction!(swap_numbers, py).unwrap();
+/// #         fun.call1((n, n2)).expect_err("Managed to create overlapping mutable references. Note: this is undefined behaviour.");
+/// #     });
+/// # }
+/// ```
+/// When users pass in the same `Number` as both arguments, one of the mutable
+/// borrows will fail and raise a `RuntimeError`:
+/// ```text
+/// >>> a = Number()
+/// >>> swap_numbers(a, a)
+/// Traceback (most recent call last):
+///   File "<stdin>", line 1, in <module>
+///   RuntimeError: Already borrowed
+/// ```
+///
+/// It is better to write that function like this:
+/// ```rust
+/// # use pyo3::prelude::*;
+/// # use pyo3::{PyClassGuard, PyClassGuardMut};
+/// # #[pyclass]
+/// # pub struct Number {
+/// #     inner: u32,
+/// # }
+/// #[pyfunction]
+/// fn swap_numbers(a: &Bound<'_, Number>, b: &Bound<'_, Number>) -> PyResult<()> {
+///     // Check that the pointers are unequal
+///     if !a.is(b) {
+///         let mut a: PyClassGuardMut<'_, Number> = a.extract()?;
+///         let mut b: PyClassGuardMut<'_, Number> = b.extract()?;
+///         std::mem::swap(&mut a.inner, &mut b.inner);
+///     } else {
+///         // Do nothing - they are the same object, so don't need swapping.
+///     }
+///     Ok(())
+/// }
+/// # fn main() {
+/// #     // With duplicate numbers
+/// #     Python::attach(|py| {
+/// #         let n = Py::new(py, Number{inner: 35}).unwrap();
+/// #         let n2 = n.clone_ref(py);
+/// #         assert!(n.is(&n2));
+/// #         let fun = pyo3::wrap_pyfunction!(swap_numbers, py).unwrap();
+/// #         fun.call1((n, n2)).unwrap();
+/// #     });
+/// #
+/// #     // With two different numbers
+/// #     Python::attach(|py| {
+/// #         let n = Py::new(py, Number{inner: 35}).unwrap();
+/// #         let n2 = Py::new(py, Number{inner: 42}).unwrap();
+/// #         assert!(!n.is(&n2));
+/// #         let fun = pyo3::wrap_pyfunction!(swap_numbers, py).unwrap();
+/// #         fun.call1((&n, &n2)).unwrap();
+/// #         let n: u32 = n.extract::<PyClassGuard<'_, Number>>(py).unwrap().inner;
+/// #         let n2: u32 = n2.extract::<PyClassGuard<'_, Number>>(py).unwrap().inner;
+/// #         assert_eq!(n, 42);
+/// #         assert_eq!(n2, 35);
+/// #     });
+/// # }
+/// ```
+/// See [`PyClassGuard`] and the [guide] for more information.
+///
+/// [guide]: https://pyo3.rs/latest/class.html#bound-and-interior-mutability
+///     "Bound and interior mutability"
+#[repr(transparent)]
+pub struct PyClassGuardMut<'a, T: PyClass<Frozen = False>> {
+    ptr: NonNull<ffi::PyObject>,
+    marker: PhantomData<&'a Py<T>>,
+}
+
+impl<'a, T: PyClass<Frozen = False>> PyClassGuardMut<'a, T> {
+    pub(crate) fn try_borrow_mut(obj: &'a Py<T>) -> Result<Self, PyBorrowMutError> {
+        Self::try_from_class_object(obj.get_class_object())
+    }
+
+    fn try_from_class_object(obj: &'a PyClassObject<T>) -> Result<Self, PyBorrowMutError> {
+        obj.ensure_threadsafe();
+        obj.borrow_checker().try_borrow_mut().map(|_| Self {
+            ptr: NonNull::from(obj).cast(),
+            marker: PhantomData,
+        })
+    }
+
+    pub(crate) fn as_class_object(&self) -> &'a PyClassObject<T> {
+        // SAFETY: `ptr` by construction points to a `PyClassObject<T>` and is
+        // valid for at least 'a
+        unsafe { self.ptr.cast().as_ref() }
+    }
+}
+
+impl<'a, T, U> PyClassGuardMut<'a, T>
+where
+    T: PyClass<BaseType = U, Frozen = False>,
+    U: PyClass<Frozen = False>,
+{
+    /// Borrows a mutable reference to `PyClassGuardMut<T::BaseType>`.
+    ///
+    /// With the help of this method, you can mutate attributes and call
+    /// mutating methods on the superclass without consuming the
+    /// `PyClassGuardMut<T>`. This method can also be chained to access the
+    /// super-superclass (and so on).
+    ///
+    /// See [`PyClassGuard::as_super`] for more.
+    pub fn as_super(&mut self) -> &mut PyClassGuardMut<'a, U> {
+        // SAFETY: `PyClassGuardMut<T>` and `PyClassGuardMut<U>` have the same layout
+        unsafe { NonNull::from(self).cast().as_mut() }
+    }
+
+    /// Gets a `PyClassGuardMut<T::BaseType>`.
+    ///
+    /// See [`PyClassGuard::into_super`] for more.
+    pub fn into_super(self) -> PyClassGuardMut<'a, U> {
+        PyClassGuardMut {
+            ptr: std::mem::ManuallyDrop::new(self).ptr,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<T: PyClass<Frozen = False>> Deref for PyClassGuardMut<'_, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &T {
+        // SAFETY: `PyClassObject<T>` constains a valid `T`, by construction no
+        // alias is enforced
+        unsafe { &*self.as_class_object().get_ptr().cast_const() }
+    }
+}
+impl<T: PyClass<Frozen = False>> DerefMut for PyClassGuardMut<'_, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut T {
+        // SAFETY: `PyClassObject<T>` constains a valid `T`, by construction no
+        // alias is enforced
+        unsafe { &mut *self.as_class_object().get_ptr() }
+    }
+}
+
+impl<T: PyClass<Frozen = False>> Drop for PyClassGuardMut<'_, T> {
+    /// Releases the mutable borrow
+    fn drop(&mut self) {
+        self.as_class_object().borrow_checker().release_borrow_mut()
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "macros")]
+mod tests {
+    use super::{PyClassGuard, PyClassGuardMut};
+    use crate::{Py, Python};
+
+    #[crate::pyclass]
+    #[pyo3(crate = "crate", subclass)]
+    struct BaseClass {
+        val1: usize,
+    }
+
+    #[crate::pyclass]
+    #[pyo3(crate = "crate", extends=BaseClass, subclass)]
+    struct SubClass {
+        val2: usize,
+    }
+
+    #[crate::pyclass]
+    #[pyo3(crate = "crate", extends=SubClass)]
+    struct SubSubClass {
+        #[pyo3(get)]
+        val3: usize,
+    }
+
+    #[crate::pymethods]
+    #[pyo3(crate = "crate")]
+    impl SubSubClass {
+        #[new]
+        fn new(py: Python<'_>) -> Py<SubSubClass> {
+            let init = crate::PyClassInitializer::from(BaseClass { val1: 10 })
+                .add_subclass(SubClass { val2: 15 })
+                .add_subclass(SubSubClass { val3: 20 });
+            Py::new(py, init).expect("allocation error")
+        }
+
+        fn get_values(self_: PyClassGuard<'_, Self>) -> (usize, usize, usize) {
+            let val1 = self_.as_super().as_super().val1;
+            let val2 = self_.as_super().val2;
+            (val1, val2, self_.val3)
+        }
+
+        fn double_values(mut self_: PyClassGuardMut<'_, Self>) {
+            self_.as_super().as_super().val1 *= 2;
+            self_.as_super().val2 *= 2;
+            self_.val3 *= 2;
+        }
+    }
+
+    #[test]
+    fn test_pyclassguard_as_super() {
+        Python::attach(|py| {
+            let obj = SubSubClass::new(py).into_bound(py);
+            let pyref = PyClassGuard::try_borrow(obj.as_unbound()).unwrap();
+            assert_eq!(pyref.as_super().as_super().val1, 10);
+            assert_eq!(pyref.as_super().val2, 15);
+            assert_eq!(pyref.val3, 20);
+            assert_eq!(SubSubClass::get_values(pyref), (10, 15, 20));
+        });
+    }
+
+    #[test]
+    fn test_pyclassguardmut_as_super() {
+        Python::attach(|py| {
+            let obj = SubSubClass::new(py).into_bound(py);
+            assert_eq!(
+                SubSubClass::get_values(PyClassGuard::try_borrow(obj.as_unbound()).unwrap()),
+                (10, 15, 20)
+            );
+            {
+                let mut pyrefmut = PyClassGuardMut::try_borrow_mut(obj.as_unbound()).unwrap();
+                assert_eq!(pyrefmut.as_super().as_super().val1, 10);
+                pyrefmut.as_super().as_super().val1 -= 5;
+                pyrefmut.as_super().val2 -= 5;
+                pyrefmut.val3 -= 5;
+            }
+            assert_eq!(
+                SubSubClass::get_values(PyClassGuard::try_borrow(obj.as_unbound()).unwrap()),
+                (5, 10, 15)
+            );
+            SubSubClass::double_values(PyClassGuardMut::try_borrow_mut(obj.as_unbound()).unwrap());
+            assert_eq!(
+                SubSubClass::get_values(PyClassGuard::try_borrow(obj.as_unbound()).unwrap()),
+                (10, 20, 30)
+            );
+        });
+    }
+
+    #[test]
+    fn test_pyclassguards_in_python() {
+        Python::attach(|py| {
+            let obj = SubSubClass::new(py);
+            crate::py_run!(py, obj, "assert obj.get_values() == (10, 15, 20)");
+            crate::py_run!(py, obj, "assert obj.double_values() is None");
+            crate::py_run!(py, obj, "assert obj.get_values() == (20, 30, 40)");
+        });
+    }
+}

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -44,8 +44,6 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, fals
              `&'holder mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
              `&'holder pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
              `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, true>`
-             `PyClassGuard<'a, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-             `PyClassGuardMut<'a, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
@@ -96,8 +94,6 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, fals
              `&'holder mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
              `&'holder pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
              `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, true>`
-             `PyClassGuard<'a, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-             `PyClassGuardMut<'a, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
    = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -22,7 +22,7 @@ error: `from_py_with` and `cancel_handle` cannot be specified together
 24 |     #[pyo3(cancel_handle, from_py_with = cancel_handle)] _param: pyo3::coroutine::CancelHandle,
    |            ^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, false>` is not satisfied
+error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, false>` is not satisfied
   --> tests/ui/invalid_cancel_handle.rs:20:50
    |
 20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
@@ -31,22 +31,24 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, false>` 
    = help: the trait `PyClass` is implemented for `pyo3::coroutine::Coroutine`
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, false>`
+   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
 
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, false>` is not satisfied
+error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, false>` is not satisfied
   --> tests/ui/invalid_cancel_handle.rs:20:50
    |
 20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `CancelHandle`
    |
-   = help: the following other types implement trait `PyFunctionArgument<'a, 'py, IS_OPTION>`:
-             `&'a mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'py, false>`
-             `&'a pyo3::Bound<'py, T>` implements `PyFunctionArgument<'a, 'py, false>`
-             `&'a pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'py, false>`
-             `Option<T>` implements `PyFunctionArgument<'a, 'py, true>`
+   = help: the following other types implement trait `PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>`:
+             `&'a pyo3::Bound<'py, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+             `&'holder mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+             `&'holder pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+             `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, true>`
+             `PyClassGuard<'a, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+             `PyClassGuardMut<'a, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, false>`
+   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
 
 error[E0308]: mismatched types
   --> tests/ui/invalid_cancel_handle.rs:16:1
@@ -64,7 +66,7 @@ note: function defined here
    |          ^^^^^^^^^^^^^^^^^^^^^^^^                        --------------
    = note: this error originates in the attribute macro `pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, false>` is not satisfied
+error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, false>` is not satisfied
   --> tests/ui/invalid_cancel_handle.rs:20:50
    |
 20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
@@ -73,35 +75,37 @@ error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, false>` 
    = help: the trait `PyClass` is implemented for `pyo3::coroutine::Coroutine`
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, false>`
+   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
 note: required by a bound in `extract_argument`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_argument<'a, 'py, T, const IS_OPTION: bool>(
+   | pub fn extract_argument<'a, 'holder, 'py, T, const IS_OPTION: bool>(
    |        ---------------- required by a bound in this function
 ...
-   |     T: PyFunctionArgument<'a, 'py, IS_OPTION>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+   |     T: PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
 
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, false>` is not satisfied
+error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, false>` is not satisfied
   --> tests/ui/invalid_cancel_handle.rs:20:50
    |
 20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
    |                                                  ^^^^ the trait `Clone` is not implemented for `CancelHandle`
    |
-   = help: the following other types implement trait `PyFunctionArgument<'a, 'py, IS_OPTION>`:
-             `&'a mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'py, false>`
-             `&'a pyo3::Bound<'py, T>` implements `PyFunctionArgument<'a, 'py, false>`
-             `&'a pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'py, false>`
-             `Option<T>` implements `PyFunctionArgument<'a, 'py, true>`
+   = help: the following other types implement trait `PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>`:
+             `&'a pyo3::Bound<'py, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+             `&'holder mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+             `&'holder pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+             `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, true>`
+             `PyClassGuard<'a, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+             `PyClassGuardMut<'a, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
    = note: required for `CancelHandle` to implement `FromPyObject<'_>`
    = note: required for `CancelHandle` to implement `FromPyObjectBound<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, false>`
+   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
 note: required by a bound in `extract_argument`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_argument<'a, 'py, T, const IS_OPTION: bool>(
+   | pub fn extract_argument<'a, 'holder, 'py, T, const IS_OPTION: bool>(
    |        ---------------- required by a bound in this function
 ...
-   |     T: PyFunctionArgument<'a, 'py, IS_OPTION>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+   |     T: PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`

--- a/tests/ui/invalid_frozen_pyclass_borrow.stderr
+++ b/tests/ui/invalid_frozen_pyclass_borrow.stderr
@@ -18,8 +18,8 @@ note: expected this to be `False`
 note: required by a bound in `extract_pyclass_ref_mut`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_pyclass_ref_mut<'a, 'py: 'a, T: PyClass<Frozen = False>>(
-   |                                                        ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
+   | pub fn extract_pyclass_ref_mut<'a, 'holder, 'py, T: PyClass<Frozen = False>>(
+   |                                                             ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`
@@ -33,11 +33,11 @@ note: expected this to be `False`
   |
 3 | #[pyclass(frozen)]
   | ^^^^^^^^^^^^^^^^^^
-note: required by a bound in `PyRefMut`
- --> src/pycell.rs
+note: required by a bound in `PyClassGuardMut`
+ --> src/pyclass/guard.rs
   |
-  | pub struct PyRefMut<'p, T: PyClass<Frozen = False>> {
-  |                                    ^^^^^^^^^^^^^^ required by this bound in `PyRefMut`
+  | pub struct PyClassGuardMut<'a, T: PyClass<Frozen = False>> {
+  |                                           ^^^^^^^^^^^^^^ required by this bound in `PyClassGuardMut`
   = note: this error originates in the attribute macro `pymethods` which comes from the expansion of the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`

--- a/tests/ui/invalid_pymethod_enum.stderr
+++ b/tests/ui/invalid_pymethod_enum.stderr
@@ -12,8 +12,8 @@ note: expected this to be `False`
 note: required by a bound in `extract_pyclass_ref_mut`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_pyclass_ref_mut<'a, 'py: 'a, T: PyClass<Frozen = False>>(
-   |                                                        ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
+   | pub fn extract_pyclass_ref_mut<'a, 'holder, 'py, T: PyClass<Frozen = False>>(
+   |                                                             ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<ComplexEnum as PyClass>::Frozen == False`
@@ -27,11 +27,11 @@ note: expected this to be `False`
   |
 3 | #[pyclass]
   | ^^^^^^^^^^
-note: required by a bound in `PyRefMut`
- --> src/pycell.rs
+note: required by a bound in `PyClassGuardMut`
+ --> src/pyclass/guard.rs
   |
-  | pub struct PyRefMut<'p, T: PyClass<Frozen = False>> {
-  |                                    ^^^^^^^^^^^^^^ required by this bound in `PyRefMut`
+  | pub struct PyClassGuardMut<'a, T: PyClass<Frozen = False>> {
+  |                                           ^^^^^^^^^^^^^^ required by this bound in `PyClassGuardMut`
   = note: this error originates in the attribute macro `pymethods` which comes from the expansion of the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<TupleEnum as PyClass>::Frozen == False`
@@ -48,8 +48,8 @@ note: expected this to be `False`
 note: required by a bound in `extract_pyclass_ref_mut`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_pyclass_ref_mut<'a, 'py: 'a, T: PyClass<Frozen = False>>(
-   |                                                        ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
+   | pub fn extract_pyclass_ref_mut<'a, 'holder, 'py, T: PyClass<Frozen = False>>(
+   |                                                             ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<TupleEnum as PyClass>::Frozen == False`
@@ -63,9 +63,9 @@ note: expected this to be `False`
    |
 19 | #[pyclass]
    | ^^^^^^^^^^
-note: required by a bound in `PyRefMut`
-  --> src/pycell.rs
+note: required by a bound in `PyClassGuardMut`
+  --> src/pyclass/guard.rs
    |
-   | pub struct PyRefMut<'p, T: PyClass<Frozen = False>> {
-   |                                    ^^^^^^^^^^^^^^ required by this bound in `PyRefMut`
+   | pub struct PyClassGuardMut<'a, T: PyClass<Frozen = False>> {
+   |                                           ^^^^^^^^^^^^^^ required by this bound in `PyClassGuardMut`
    = note: this error originates in the attribute macro `pymethods` which comes from the expansion of the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/invalid_pymethods.stderr
+++ b/tests/ui/invalid_pymethods.stderr
@@ -166,7 +166,7 @@ error: `pass_module` cannot be used on Python methods
     |            ^^^^^^^^^^^
 
 error: Python objects are shared, so 'self' cannot be moved out of the Python interpreter.
-       Try `&self`, `&mut self, `slf: PyRef<'_, Self>` or `slf: PyRefMut<'_, Self>`.
+       Try `&self`, `&mut self, `slf: PyClassGuard<'_, Self>` or `slf: PyClassGuardMut<'_, Self>`.
    --> tests/ui/invalid_pymethods.rs:151:29
     |
 151 |     fn method_self_by_value(self) {}


### PR DESCRIPTION
Ref #4720 

Introduces `PyClassGuard(Mut)` as future replacement for `PyRef(Mut)`. It switches the lifetime from `'py` to `'a`, borrowing from the input pointer directly regardless of whether we're attached or not. In this experiment I build it around `&'a Py<T>` which seems to work (at least locally), let's see what CI says.