### PR TITLE
ci: allow slightly bigger drop in project coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,12 @@ coverage:
     project:
       default:
         target: auto
-        # Allow a tiny drop of overall project coverage in PR to reduce spurious failures.
-        threshold: 0.25%
+        # Allow a tiny drop of overall project coverage in PR due to
+        # not all configurations being tested in PR runs.
+        #
+        # (Note that patch coverage will still be required to be at least
+        # the project coverage.)
+        threshold: 1%
 
 ignore:
   - tests/


### PR DESCRIPTION
I noticed a lot of PRs currently report ~0.7% drop in project coverage despite suitable patch testing.

This is because on main we measure all Python versions, on PR we just measure a primary selection.