### PR TITLE
Avoid using unwind handling in WASM

### DIFF
--- a/pyo3-ffi/src/pystate.rs
+++ b/pyo3-ffi/src/pystate.rs
@@ -81,10 +81,10 @@ pub enum PyGILState_STATE {
     PyGILState_UNLOCKED,
 }
 
-#[cfg(not(Py_3_14))]
+#[cfg(not(any(Py_3_14, target_arch = "wasm32")))]
 struct HangThread;
 
-#[cfg(not(Py_3_14))]
+#[cfg(not(any(Py_3_14, target_arch = "wasm32")))]
 impl Drop for HangThread {
     fn drop(&mut self) {
         loop {
@@ -102,20 +102,20 @@ impl Drop for HangThread {
 // C-unwind only supported (and necessary) since 1.71. Python 3.14+ does not do
 // pthread_exit from PyGILState_Ensure (https://github.com/python/cpython/issues/87135).
 mod raw {
-    #[cfg(not(Py_3_14))]
+    #[cfg(not(any(Py_3_14, target_arch = "wasm32")))]
     extern "C-unwind" {
         #[cfg_attr(PyPy, link_name = "PyPyGILState_Ensure")]
         pub fn PyGILState_Ensure() -> super::PyGILState_STATE;
     }
 
-    #[cfg(Py_3_14)]
+    #[cfg(any(Py_3_14, target_arch = "wasm32"))]
     extern "C" {
         #[cfg_attr(PyPy, link_name = "PyPyGILState_Ensure")]
         pub fn PyGILState_Ensure() -> super::PyGILState_STATE;
     }
 }
 
-#[cfg(not(Py_3_14))]
+#[cfg(not(any(Py_3_14, target_arch = "wasm32")))]
 pub unsafe extern "C" fn PyGILState_Ensure() -> PyGILState_STATE {
     let guard = HangThread;
     // If `PyGILState_Ensure` calls `pthread_exit`, which it does on Python < 3.14
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn PyGILState_Ensure() -> PyGILState_STATE {
     ret
 }
 
-#[cfg(Py_3_14)]
+#[cfg(any(Py_3_14, target_arch = "wasm32"))]
 pub use self::raw::PyGILState_Ensure;
 
 extern "C" {


### PR DESCRIPTION
In WASM builds, CPython [does not call](https://github.com/python/cpython/blob/ef053a92d5552bb082bbe1fe7fcaab020cbe6f99/Python/thread_pthread.h#L363-L368) `pthread_exit` so there is no risk of undefined behavior due to unwinding out of `PyGILState_Ensure`. Including the C-unwind function here also causes exception-handling-related WASM to be emitted, which is not broadly supported (eg [wasmtime does not support it](https://docs.wasmtime.dev/stability-wasm-proposals.html)). So, this PR disables the `pthread_exit` workaround under WASM to improve compatibility.