### PR TITLE
Introspection: allows to override annotations in signature

### DIFF
--- a/newsfragments/5241.added.md
+++ b/newsfragments/5241.added.md
@@ -1,0 +1,1 @@
+Introspection: Allow to set annotations in PyO3 signature attribute

--- a/pyo3-introspection/src/introspection.rs
+++ b/pyo3-introspection/src/introspection.rs
@@ -208,6 +208,7 @@ fn convert_argument(arg: &ChunkArgument) -> Argument {
 fn convert_variable_length_argument(arg: &ChunkArgument) -> VariableLengthArgument {
     VariableLengthArgument {
         name: arg.name.clone(),
+        annotation: arg.annotation.clone(),
     }
 }
 

--- a/pyo3-introspection/src/model.rs
+++ b/pyo3-introspection/src/model.rs
@@ -56,4 +56,6 @@ pub struct Argument {
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct VariableLengthArgument {
     pub name: String,
+    /// Type annotation as a Python expression
+    pub annotation: Option<String>,
 }

--- a/pyo3-introspection/src/stubs.rs
+++ b/pyo3-introspection/src/stubs.rs
@@ -98,7 +98,10 @@ fn function_stubs(function: &Function, modules_to_import: &mut BTreeSet<String>)
         parameters.push(argument_stub(argument, modules_to_import));
     }
     if let Some(argument) = &function.arguments.vararg {
-        parameters.push(format!("*{}", variable_length_argument_stub(argument)));
+        parameters.push(format!(
+            "*{}",
+            variable_length_argument_stub(argument, modules_to_import)
+        ));
     } else if !function.arguments.keyword_only_arguments.is_empty() {
         parameters.push("*".into());
     }
@@ -106,7 +109,10 @@ fn function_stubs(function: &Function, modules_to_import: &mut BTreeSet<String>)
         parameters.push(argument_stub(argument, modules_to_import));
     }
     if let Some(argument) = &function.arguments.kwarg {
-        parameters.push(format!("**{}", variable_length_argument_stub(argument)));
+        parameters.push(format!(
+            "**{}",
+            variable_length_argument_stub(argument, modules_to_import)
+        ));
     }
     let mut buffer = String::new();
     for decorator in &function.decorators {
@@ -150,8 +156,16 @@ fn argument_stub(argument: &Argument, modules_to_import: &mut BTreeSet<String>) 
     output
 }
 
-fn variable_length_argument_stub(argument: &VariableLengthArgument) -> String {
-    argument.name.clone()
+fn variable_length_argument_stub(
+    argument: &VariableLengthArgument,
+    modules_to_import: &mut BTreeSet<String>,
+) -> String {
+    let mut output = argument.name.clone();
+    if let Some(annotation) = &argument.annotation {
+        output.push_str(": ");
+        output.push_str(annotation_stub(annotation, modules_to_import));
+    }
+    output
 }
 
 fn annotation_stub<'a>(annotation: &'a str, modules_to_import: &mut BTreeSet<String>) -> &'a str {
@@ -185,6 +199,7 @@ mod tests {
                 }],
                 vararg: Some(VariableLengthArgument {
                     name: "varargs".into(),
+                    annotation: None,
                 }),
                 keyword_only_arguments: vec![Argument {
                     name: "karg".into(),
@@ -193,12 +208,13 @@ mod tests {
                 }],
                 kwarg: Some(VariableLengthArgument {
                     name: "kwarg".into(),
+                    annotation: Some("str".into()),
                 }),
             },
             returns: Some("list[str]".into()),
         };
         assert_eq!(
-            "def func(posonly, /, arg, *varargs, karg: str, **kwarg) -> list[str]: ...",
+            "def func(posonly, /, arg, *varargs, karg: str, **kwarg: str) -> list[str]: ...",
             function_stubs(&function, &mut BTreeSet::new())
         )
     }

--- a/pyo3-macros-backend/src/introspection.rs
+++ b/pyo3-macros-backend/src/introspection.rs
@@ -124,7 +124,7 @@ pub fn function_introspection_code(
                 .as_ref()
                 .and_then(|attribute| attribute.value.returns.as_ref())
             {
-                IntrospectionNode::String(returns.value().into())
+                IntrospectionNode::String(returns.to_python().into())
             } else {
                 match returns {
                     ReturnType::Default => IntrospectionNode::String("None".into()),
@@ -225,7 +225,7 @@ fn arguments_introspection_data<'a>(
     }
 
     if let Some(param) = &signature.python_signature.varargs {
-        let Some(FnArg::VarArgs(arg_desc)) = argument_desc.next() {
+        let Some(FnArg::VarArgs(arg_desc)) = argument_desc.next() else {
             panic!("Fewer arguments than in python signature");
         };
         let mut params = HashMap::from([("name", IntrospectionNode::String(param.into()))]);
@@ -236,18 +236,14 @@ fn arguments_introspection_data<'a>(
     }
 
     for (param, _) in &signature.python_signature.keyword_only_parameters {
-        let arg_desc = if let Some(FnArg::Regular(arg_desc)) = argument_desc.next() {
-            arg_desc
-        } else {
+        let Some(FnArg::Regular(arg_desc)) = argument_desc.next() else {
             panic!("Less arguments than in python signature");
         };
         kwonlyargs.push(argument_introspection_data(param, arg_desc, class_type));
     }
 
     if let Some(param) = &signature.python_signature.kwargs {
-        let arg_desc = if let Some(FnArg::KwArgs(arg_desc)) = argument_desc.next() {
-            arg_desc
-        } else {
+        let Some(FnArg::KwArgs(arg_desc)) = argument_desc.next() else {
             panic!("Less arguments than in python signature");
         };
         let mut params = HashMap::from([("name", IntrospectionNode::String(param.into()))]);

--- a/pyo3-macros-backend/src/introspection.rs
+++ b/pyo3-macros-backend/src/introspection.rs
@@ -119,21 +119,29 @@ pub fn function_introspection_code(
         ),
         (
             "returns",
-            match returns {
-                ReturnType::Default => IntrospectionNode::String("None".into()),
-                ReturnType::Type(_, ty) => match *ty {
-                    Type::Tuple(t) if t.elems.is_empty() => {
-                        // () is converted to None in return types
-                        IntrospectionNode::String("None".into())
-                    }
-                    mut ty => {
-                        if let Some(class_type) = parent {
-                            replace_self(&mut ty, class_type);
+            if let Some((_, returns)) = signature
+                .attribute
+                .as_ref()
+                .and_then(|attribute| attribute.value.returns.as_ref())
+            {
+                IntrospectionNode::String(returns.value().into())
+            } else {
+                match returns {
+                    ReturnType::Default => IntrospectionNode::String("None".into()),
+                    ReturnType::Type(_, ty) => match *ty {
+                        Type::Tuple(t) if t.elems.is_empty() => {
+                            // () is converted to None in return types
+                            IntrospectionNode::String("None".into())
                         }
-                        ty = ty.elide_lifetimes();
-                        IntrospectionNode::OutputType { rust_type: ty }
-                    }
-                },
+                        mut ty => {
+                            if let Some(class_type) = parent {
+                                replace_self(&mut ty, class_type);
+                            }
+                            ty = ty.elide_lifetimes();
+                            IntrospectionNode::OutputType { rust_type: ty }
+                        }
+                    },
+                }
             },
         ),
     ]);
@@ -178,12 +186,11 @@ fn arguments_introspection_data<'a>(
     first_argument: Option<&'a str>,
     class_type: Option<&Type>,
 ) -> IntrospectionNode<'a> {
-    let mut argument_desc = signature.arguments.iter().filter_map(|arg| {
-        if let FnArg::Regular(arg) = arg {
-            Some(arg)
-        } else {
-            None
-        }
+    let mut argument_desc = signature.arguments.iter().filter(|arg| {
+        matches!(
+            arg,
+            FnArg::Regular(_) | FnArg::VarArgs(_) | FnArg::KwArgs(_)
+        )
     });
 
     let mut posonlyargs = Vec::new();
@@ -204,7 +211,7 @@ fn arguments_introspection_data<'a>(
         .iter()
         .enumerate()
     {
-        let arg_desc = if let Some(arg_desc) = argument_desc.next() {
+        let arg_desc = if let Some(FnArg::Regular(arg_desc)) = argument_desc.next() {
             arg_desc
         } else {
             panic!("Less arguments than in python signature");
@@ -218,13 +225,20 @@ fn arguments_introspection_data<'a>(
     }
 
     if let Some(param) = &signature.python_signature.varargs {
-        vararg = Some(IntrospectionNode::Map(
-            [("name", IntrospectionNode::String(param.into()))].into(),
-        ));
+        let arg_desc = if let Some(FnArg::VarArgs(arg_desc)) = argument_desc.next() {
+            arg_desc
+        } else {
+            panic!("Less arguments than in python signature");
+        };
+        let mut params = HashMap::from([("name", IntrospectionNode::String(param.into()))]);
+        if let Some(annotation) = &arg_desc.annotation {
+            params.insert("annotation", IntrospectionNode::String(annotation.into()));
+        }
+        vararg = Some(IntrospectionNode::Map(params));
     }
 
     for (param, _) in &signature.python_signature.keyword_only_parameters {
-        let arg_desc = if let Some(arg_desc) = argument_desc.next() {
+        let arg_desc = if let Some(FnArg::Regular(arg_desc)) = argument_desc.next() {
             arg_desc
         } else {
             panic!("Less arguments than in python signature");
@@ -233,13 +247,16 @@ fn arguments_introspection_data<'a>(
     }
 
     if let Some(param) = &signature.python_signature.kwargs {
-        kwarg = Some(IntrospectionNode::Map(
-            [
-                ("name", IntrospectionNode::String(param.into())),
-                ("kind", IntrospectionNode::String("VAR_KEYWORD".into())),
-            ]
-            .into(),
-        ));
+        let arg_desc = if let Some(FnArg::KwArgs(arg_desc)) = argument_desc.next() {
+            arg_desc
+        } else {
+            panic!("Less arguments than in python signature");
+        };
+        let mut params = HashMap::from([("name", IntrospectionNode::String(param.into()))]);
+        if let Some(annotation) = &arg_desc.annotation {
+            params.insert("annotation", IntrospectionNode::String(annotation.into()));
+        }
+        kwarg = Some(IntrospectionNode::Map(params));
     }
 
     let mut map = HashMap::new();
@@ -273,7 +290,10 @@ fn argument_introspection_data<'a>(
             IntrospectionNode::String(desc.default_value().into()),
         );
     }
-    if desc.from_py_with.is_none() {
+
+    if let Some(annotation) = &desc.annotation {
+        params.insert("annotation", IntrospectionNode::String(annotation.into()));
+    } else if desc.from_py_with.is_none() {
         // If from_py_with is set we don't know anything on the input type
         if let Some(ty) = desc.option_wrapped_type {
             // Special case to properly generate a `T | None` annotation

--- a/pyo3-macros-backend/src/introspection.rs
+++ b/pyo3-macros-backend/src/introspection.rs
@@ -225,10 +225,8 @@ fn arguments_introspection_data<'a>(
     }
 
     if let Some(param) = &signature.python_signature.varargs {
-        let arg_desc = if let Some(FnArg::VarArgs(arg_desc)) = argument_desc.next() {
-            arg_desc
-        } else {
-            panic!("Less arguments than in python signature");
+        let Some(FnArg::VarArgs(arg_desc)) = argument_desc.next() {
+            panic!("Fewer arguments than in python signature");
         };
         let mut params = HashMap::from([("name", IntrospectionNode::String(param.into()))]);
         if let Some(annotation) = &arg_desc.annotation {

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -26,6 +26,8 @@ pub struct RegularArg<'a> {
     pub from_py_with: Option<FromPyWithAttribute>,
     pub default_value: Option<syn::Expr>,
     pub option_wrapped_type: Option<&'a syn::Type>,
+    #[cfg(feature = "experimental-inspect")]
+    pub annotation: Option<String>,
 }
 
 impl RegularArg<'_> {
@@ -55,6 +57,8 @@ impl RegularArg<'_> {
 pub struct VarargsArg<'a> {
     pub name: Cow<'a, syn::Ident>,
     pub ty: &'a syn::Type,
+    #[cfg(feature = "experimental-inspect")]
+    pub annotation: Option<String>,
 }
 
 /// Pythons **kwarg argument
@@ -62,6 +66,8 @@ pub struct VarargsArg<'a> {
 pub struct KwargsArg<'a> {
     pub name: Cow<'a, syn::Ident>,
     pub ty: &'a syn::Type,
+    #[cfg(feature = "experimental-inspect")]
+    pub annotation: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -121,12 +127,16 @@ impl<'a> FnArg<'a> {
             name,
             ty,
             option_wrapped_type: None,
+            #[cfg(feature = "experimental-inspect")]
+            annotation,
             ..
         }) = self
         {
             *self = Self::VarArgs(VarargsArg {
                 name: name.clone(),
                 ty,
+                #[cfg(feature = "experimental-inspect")]
+                annotation: annotation.clone(),
             });
             Ok(self)
         } else {
@@ -139,12 +149,16 @@ impl<'a> FnArg<'a> {
             name,
             ty,
             option_wrapped_type: Some(..),
+            #[cfg(feature = "experimental-inspect")]
+            annotation,
             ..
         }) = self
         {
             *self = Self::KwArgs(KwargsArg {
                 name: name.clone(),
                 ty,
+                #[cfg(feature = "experimental-inspect")]
+                annotation: annotation.clone(),
             });
             Ok(self)
         } else {
@@ -196,6 +210,8 @@ impl<'a> FnArg<'a> {
                     from_py_with,
                     default_value: None,
                     option_wrapped_type: utils::option_type_argument(&cap.ty),
+                    #[cfg(feature = "experimental-inspect")]
+                    annotation: None,
                 }))
             }
         }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1646,6 +1646,8 @@ fn complex_enum_struct_variant_new<'a>(
                 from_py_with: None,
                 default_value: None,
                 option_wrapped_type: None,
+                #[cfg(feature = "experimental-inspect")]
+                annotation: None,
             }));
         }
         args
@@ -1703,6 +1705,8 @@ fn complex_enum_tuple_variant_new<'a>(
                 from_py_with: None,
                 default_value: None,
                 option_wrapped_type: None,
+                #[cfg(feature = "experimental-inspect")]
+                annotation: None,
             }));
         }
         args

--- a/pytests/src/pyfunctions.rs
+++ b/pytests/src/pyfunctions.rs
@@ -77,11 +77,21 @@ fn with_typed_args(a: bool, b: u64, c: f64, d: &str) -> (bool, u64, f64, &str) {
     (a, b, c, d)
 }
 
+#[pyfunction(signature = (a: "int", *_args: "str", _b: "int" = None, **_kwargs: "bool") -> "int")]
+fn with_custom_type_annotations<'py>(
+    a: Any<'py>,
+    _args: Tuple<'py>,
+    _b: Option<Any<'py>>,
+    _kwargs: Option<Dict<'py>>,
+) -> Any<'py> {
+    a
+}
+
 #[pymodule]
 pub mod pyfunctions {
     #[pymodule_export]
     use super::{
         args_kwargs, none, positional_only, simple, simple_args, simple_args_kwargs, simple_kwargs,
-        with_typed_args,
+        with_custom_type_annotations, with_typed_args,
     };
 }

--- a/pytests/src/pyfunctions.rs
+++ b/pytests/src/pyfunctions.rs
@@ -77,7 +77,7 @@ fn with_typed_args(a: bool, b: u64, c: f64, d: &str) -> (bool, u64, f64, &str) {
     (a, b, c, d)
 }
 
-#[pyfunction(signature = (a: "int", *_args: "str", _b: "int" = None, **_kwargs: "bool") -> "int")]
+#[pyfunction(signature = (a: "int", *_args: "str", _b: "int | None" = None, **_kwargs: "bool") -> "int")]
 fn with_custom_type_annotations<'py>(
     a: Any<'py>,
     _args: Tuple<'py>,

--- a/pytests/stubs/pyfunctions.pyi
+++ b/pytests/stubs/pyfunctions.pyi
@@ -19,6 +19,9 @@ def simple_args_kwargs(
 def simple_kwargs(
     a: typing.Any, b: typing.Any | None = None, c: typing.Any | None = None, **kwargs
 ) -> typing.Any: ...
+def with_custom_type_annotations(
+    a: int, *_args: str, _b: int = None, **_kwargs: bool
+) -> int: ...
 def with_typed_args(
     a: bool = False, b: int = 0, c: float = 0.0, d: str = ""
 ) -> typing.Any: ...

--- a/pytests/stubs/pyfunctions.pyi
+++ b/pytests/stubs/pyfunctions.pyi
@@ -20,7 +20,7 @@ def simple_kwargs(
     a: typing.Any, b: typing.Any | None = None, c: typing.Any | None = None, **kwargs
 ) -> typing.Any: ...
 def with_custom_type_annotations(
-    a: int, *_args: str, _b: int = None, **_kwargs: bool
+    a: int, *_args: str, _b: int | None = None, **_kwargs: bool
 ) -> int: ...
 def with_typed_args(
     a: bool = False, b: int = 0, c: float = 0.0, d: str = ""

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -28,6 +28,10 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/reject_generics.rs");
     t.compile_fail("tests/ui/invalid_closure.rs");
     t.compile_fail("tests/ui/pyclass_send.rs");
+    #[cfg(not(feature = "experimental-inspect"))]
+    t.compile_fail("tests/ui/invalid_annotation.rs");
+    #[cfg(not(feature = "experimental-inspect"))]
+    t.compile_fail("tests/ui/invalid_annotation_return.rs");
     t.compile_fail("tests/ui/invalid_argument_attributes.rs");
     t.compile_fail("tests/ui/invalid_intopy_derive.rs");
     #[cfg(not(windows))]
@@ -35,13 +39,13 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/invalid_frompy_derive.rs");
     t.compile_fail("tests/ui/static_ref.rs");
     t.compile_fail("tests/ui/wrong_aspyref_lifetimes.rs");
-    #[cfg(not(any(feature = "uuid")))]
+    #[cfg(not(feature = "uuid"))]
     t.compile_fail("tests/ui/invalid_pyfunctions.rs");
     t.compile_fail("tests/ui/invalid_pymethods.rs");
     // output changes with async feature
     #[cfg(all(Py_LIMITED_API, feature = "experimental-async"))]
     t.compile_fail("tests/ui/abi3_nativetype_inheritance.rs");
-    #[cfg(not(any(feature = "experimental-async")))]
+    #[cfg(not(feature = "experimental-async"))]
     t.compile_fail("tests/ui/invalid_async.rs");
     t.compile_fail("tests/ui/invalid_intern_arg.rs");
     t.compile_fail("tests/ui/invalid_frozen_pyclass_borrow.rs");

--- a/tests/ui/invalid_annotation.rs
+++ b/tests/ui/invalid_annotation.rs
@@ -1,0 +1,9 @@
+use pyo3::prelude::*;
+
+#[pyfunction]
+#[pyo3(signature = (a: "int"))]
+fn check(a: usize) -> usize {
+    a
+}
+
+fn main() {}

--- a/tests/ui/invalid_annotation.stderr
+++ b/tests/ui/invalid_annotation.stderr
@@ -1,0 +1,5 @@
+error: Type annotations in the signature is only supported with the `experimental-inspect` feature
+ --> tests/ui/invalid_annotation.rs:4:24
+  |
+4 | #[pyo3(signature = (a: "int"))]
+  |                        ^^^^^

--- a/tests/ui/invalid_annotation_return.rs
+++ b/tests/ui/invalid_annotation_return.rs
@@ -1,0 +1,9 @@
+use pyo3::prelude::*;
+
+#[pyfunction]
+#[pyo3(signature = (a) -> "int")]
+fn check(a: usize) -> usize {
+    a
+}
+
+fn main() {}

--- a/tests/ui/invalid_annotation_return.stderr
+++ b/tests/ui/invalid_annotation_return.stderr
@@ -1,0 +1,5 @@
+error: Return type annotation in the signature is only supported with the `experimental-inspect` feature
+ --> tests/ui/invalid_annotation_return.rs:4:27
+  |
+4 | #[pyo3(signature = (a) -> "int")]
+  |                           ^^^^^


### PR DESCRIPTION
Allow type annotations on vargs and kwargs

Example: `#[pyfunction(signature = (a: "int", *_args: "str", _b: "int" = None, **_kwargs: "bool") -> "int")]`

The signature annotations are string for now, because using `syn::Expr` is not enough, some valid Python types like `typing.Callable[[int], int]` are not valid Rust `Expr`. A possible option is to do like Python annotation, allow writing them as a string and then provide some nicer syntax is some cases with a small parser.

A possible first grammar for a follow-up MR:
type := single_type ('|' single_type)*
single_type := ident ('.' ident)* (bracketed)?
ident := Rust ident
bracketed := '[' bracketed_item (',' bracketed_item)* ']'
bracketed_item := bracketed | type