### PR TITLE
optimize conversion from bytes for Vec<u8> and [u8; N]

### DIFF
--- a/newsfragments/5244.changed.md
+++ b/newsfragments/5244.changed.md
@@ -1,0 +1,1 @@
+Optimize `FromPyObject` implementations for `Vec<u8>` and `[u8; N]` from `bytes` and `bytearray`

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -181,6 +181,7 @@ fn print_feature_cfg(minor_version_required: u32, cfg: &str) {
 /// so this function is unstable.
 #[doc(hidden)]
 pub fn print_feature_cfgs() {
+    print_feature_cfg(75, "return_position_impl_trait_in_traits");
     print_feature_cfg(79, "c_str_lit");
     // Actually this is available on 1.78, but we should avoid
     // https://github.com/rust-lang/rust/issues/124651 just in case

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -1,4 +1,4 @@
-use crate::conversion::{FromPyObjectOwned, IntoPyObject};
+use crate::conversion::{FromPyObjectOwned, FromPyObjectSequence, IntoPyObject};
 use crate::types::any::PyAnyMethods;
 use crate::types::PySequence;
 use crate::{err::DowncastError, ffi, FromPyObject, PyAny, PyResult, Python};
@@ -43,9 +43,8 @@ where
     type Error = PyErr;
 
     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
-        if let Some(slice) = T::object_as_slice(obj, crate::conversion::private::Token) {
-            // If the object is a slice, we can extract it directly.
-            return T::slice_into_array(slice, crate::conversion::private::Token);
+        if let Some(extractor) = T::sequence_extractor(obj, crate::conversion::private::Token) {
+            return extractor.to_array();
         }
 
         create_array_from_obj(obj)

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -303,7 +303,7 @@ impl<'py> FromPyObject<'_, 'py> for u8 {
     ) -> Option<impl FromPyObjectSequence<Target = u8>> {
         if let Ok(bytes) = obj.cast::<PyBytes>() {
             Some(BytesSequenceExtractor::Bytes(bytes))
-        } else if let Ok(byte_array) = obj.cast::<crate::types::PyByteArray>() {
+        } else if let Ok(byte_array) = obj.cast::<PyByteArray>() {
             Some(BytesSequenceExtractor::ByteArray(byte_array))
         } else {
             None
@@ -316,14 +316,10 @@ impl<'py> FromPyObject<'_, 'py> for u8 {
         obj: Borrowed<'_, 'py, PyAny>,
         _: crate::conversion::private::Token,
     ) -> Option<Box<dyn FromPyObjectSequence<Target = u8>>> {
-        if let Ok(_) = obj.cast::<PyBytes>() {
-            Some(Box::new(BytesSequenceExtractor::Bytes(
-                _obj.cast::<PyBytes>().ok()?,
-            )))
-        } else if let Ok(_) = _obj.cast::<crate::types::PyByteArray>() {
-            Some(Box::new(BytesSequenceExtractor::ByteArray(
-                _obj.cast::<crate::types::PyByteArray>().ok()?,
-            )))
+        if let Ok(bytes) = obj.cast::<PyBytes>() {
+            Some(Box::new(BytesSequenceExtractor::Bytes(bytes)))
+        } else if let Ok(byte_array) = obj.cast::<PyByteArray>() {
+            Some(Box::new(BytesSequenceExtractor::ByteArray(byte_array)))
         } else {
             None
         }

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -347,7 +347,7 @@ impl BytesSequenceExtractor<'_, '_> {
 
         match self {
             BytesSequenceExtractor::Bytes(b) => copy_slice(b.as_bytes()),
-            BytesSequenceExtractor::ByteArray(b) => crate::sync::with_critical_section(&b, || {
+            BytesSequenceExtractor::ByteArray(b) => crate::sync::with_critical_section(b, || {
                 // Safety: b is protected by a critical section
                 copy_slice(unsafe { b.as_bytes() })
             }),

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -7,6 +7,7 @@ use crate::types::{PyByteArray, PyByteArrayMethods, PyBytes, PyInt};
 use crate::{exceptions, ffi, Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python};
 use std::convert::Infallible;
 use std::ffi::c_long;
+use std::mem::MaybeUninit;
 use std::num::{
     NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
     NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
@@ -312,10 +313,10 @@ impl<'py> FromPyObject<'_, 'py> for u8 {
 
     #[cfg(not(return_position_impl_trait_in_traits))]
     #[inline]
-    fn sequence_extractor(
-        obj: Borrowed<'_, 'py, PyAny>,
+    fn sequence_extractor<'b>(
+        obj: Borrowed<'b, 'b, PyAny>,
         _: crate::conversion::private::Token,
-    ) -> Option<Box<dyn FromPyObjectSequence<Target = u8>>> {
+    ) -> Option<Box<dyn FromPyObjectSequence<Target = u8> + 'b>> {
         if let Ok(bytes) = obj.cast::<PyBytes>() {
             Some(Box::new(BytesSequenceExtractor::Bytes(bytes)))
         } else if let Ok(byte_array) = obj.cast::<PyByteArray>() {
@@ -331,6 +332,29 @@ pub(crate) enum BytesSequenceExtractor<'a, 'py> {
     ByteArray(Borrowed<'a, 'py, PyByteArray>),
 }
 
+impl BytesSequenceExtractor<'_, '_> {
+    fn fill_slice(&self, out: &mut [MaybeUninit<u8>]) -> PyResult<()> {
+        let mut copy_slice = |slice: &[u8]| {
+            if slice.len() != out.len() {
+                return Err(invalid_sequence_length(out.len(), slice.len()));
+            }
+            // Safety: `slice` and `out` are guaranteed not to overlap due to `&mut` reference on `out`.
+            unsafe {
+                std::ptr::copy_nonoverlapping(slice.as_ptr(), out.as_mut_ptr().cast(), out.len())
+            };
+            Ok(())
+        };
+
+        match self {
+            BytesSequenceExtractor::Bytes(b) => copy_slice(b.as_bytes()),
+            BytesSequenceExtractor::ByteArray(b) => crate::sync::with_critical_section(&b, || {
+                // Safety: b is protected by a critical section
+                copy_slice(unsafe { b.as_bytes() })
+            }),
+        }
+    }
+}
+
 impl FromPyObjectSequence for BytesSequenceExtractor<'_, '_> {
     type Target = u8;
 
@@ -341,20 +365,24 @@ impl FromPyObjectSequence for BytesSequenceExtractor<'_, '_> {
         }
     }
 
-    fn to_array<const N: usize>(&self) -> PyResult<[Self::Target; N]> {
-        match self {
-            BytesSequenceExtractor::Bytes(b) => b
-                .as_bytes()
-                .try_into()
-                .map_err(|_| invalid_sequence_length(N, b.as_bytes().len())),
-            BytesSequenceExtractor::ByteArray(b) => crate::sync::with_critical_section(&b, || {
-                // Safety: b is protected by a critical section
-                let slice = unsafe { b.as_bytes() };
-                slice
-                    .try_into()
-                    .map_err(|_| invalid_sequence_length(N, slice.len()))
-            }),
-        }
+    #[cfg(return_position_impl_trait_in_traits)]
+    fn to_array<const N: usize>(&self) -> PyResult<[u8; N]> {
+        let mut out: MaybeUninit<[u8; N]> = MaybeUninit::uninit();
+
+        // Safety: `[u8; N]` has the same layout as `[MaybeUninit<u8>; N]`
+        let slice = unsafe {
+            std::slice::from_raw_parts_mut(out.as_mut_ptr().cast::<MaybeUninit<u8>>(), N)
+        };
+
+        self.fill_slice(slice)?;
+
+        // Safety: `out` is fully initialized
+        Ok(unsafe { out.assume_init() })
+    }
+
+    #[cfg(not(return_position_impl_trait_in_traits))]
+    fn fill_slice(&self, out: &mut [MaybeUninit<Self::Target>]) -> PyResult<()> {
+        self.fill_slice(out)
     }
 }
 

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::{
-    conversion::{FromPyObject, FromPyObjectOwned, FromPyObjectSequence, IntoPyObject},
+    conversion::{FromPyObject, FromPyObjectOwned, IntoPyObject},
     exceptions::PyTypeError,
     ffi,
     types::{PyAnyMethods, PySequence, PyString},
@@ -63,6 +63,8 @@ where
 
     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         if let Some(extractor) = T::sequence_extractor(obj, crate::conversion::private::Token) {
+            #[cfg(return_position_impl_trait_in_traits)]
+            use crate::conversion::FromPyObjectSequence;
             return Ok(extractor.to_vec());
         }
 

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -1,6 +1,12 @@
-use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
+use crate::{
+    conversion::{FromPyObject, FromPyObjectOwned, IntoPyObject},
+    exceptions::PyTypeError,
+    ffi,
+    types::{PyAnyMethods, PySequence, PyString},
+    Borrowed, DowncastError, PyResult,
+};
 use crate::{Bound, PyAny, PyErr, Python};
 
 impl<'py, T> IntoPyObject<'py> for Vec<T>
@@ -49,11 +55,56 @@ where
     }
 }
 
+impl<'py, T> FromPyObject<'_, 'py> for Vec<T>
+where
+    T: FromPyObjectOwned<'py>,
+{
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
+        if obj.is_instance_of::<PyString>() {
+            return Err(PyTypeError::new_err("Can't extract `str` to `Vec`"));
+        }
+        if let Some(slice) =
+            T::object_as_slice(obj, crate::conversion::private::Token).transpose()?
+        {
+            return T::slice_into_vec(slice, crate::conversion::private::Token);
+        }
+        extract_sequence(obj)
+    }
+
+    #[cfg(feature = "experimental-inspect")]
+    fn type_input() -> TypeInfo {
+        TypeInfo::sequence_of(T::type_input())
+    }
+}
+
+fn extract_sequence<'py, T>(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Vec<T>>
+where
+    T: FromPyObjectOwned<'py>,
+{
+    // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
+    // to support this function and if not, we will only fail extraction safely.
+    let seq = unsafe {
+        if ffi::PySequence_Check(obj.as_ptr()) != 0 {
+            obj.downcast_unchecked::<PySequence>()
+        } else {
+            return Err(DowncastError::new_from_borrowed(obj, "Sequence").into());
+        }
+    };
+
+    let mut v = Vec::with_capacity(seq.len().unwrap_or(0));
+    for item in seq.try_iter()? {
+        v.push(item?.extract::<T>().map_err(Into::into)?);
+    }
+    Ok(v)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::conversion::IntoPyObject;
     use crate::types::{PyAnyMethods, PyBytes, PyBytesMethods, PyList};
-    use crate::Python;
+    use crate::{ffi, Python};
 
     #[test]
     fn test_vec_intopyobject_impl() {
@@ -82,6 +133,61 @@ mod tests {
             let nums: Vec<u16> = vec![0, 1, 2, 3];
             let obj = (&nums).into_pyobject(py).unwrap();
             assert!(obj.is_instance_of::<PyList>());
+        });
+    }
+
+    #[test]
+    fn test_strings_cannot_be_extracted_to_vec() {
+        Python::attach(|py| {
+            let v = "London Calling";
+            let ob = v.into_pyobject(py).unwrap();
+
+            assert!(ob.extract::<Vec<String>>().is_err());
+            assert!(ob.extract::<Vec<char>>().is_err());
+        });
+    }
+
+    #[test]
+    fn test_extract_bytes_to_vec() {
+        Python::attach(|py| {
+            let v: Vec<u8> = PyBytes::new(py, b"abc").extract().unwrap();
+            assert_eq!(v, b"abc");
+        });
+    }
+
+    #[test]
+    fn test_extract_tuple_to_vec() {
+        Python::attach(|py| {
+            let v: Vec<i32> = py
+                .eval(ffi::c_str!("(1, 2)"), None, None)
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert!(v == [1, 2]);
+        });
+    }
+
+    #[test]
+    fn test_extract_range_to_vec() {
+        Python::attach(|py| {
+            let v: Vec<i32> = py
+                .eval(ffi::c_str!("range(1, 5)"), None, None)
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert!(v == [1, 2, 3, 4]);
+        });
+    }
+
+    #[test]
+    fn test_extract_bytearray_to_vec() {
+        Python::attach(|py| {
+            let v: Vec<u8> = py
+                .eval(ffi::c_str!("bytearray(b'abc')"), None, None)
+                .unwrap()
+                .extract()
+                .unwrap();
+            assert!(v == b"abc");
         });
     }
 }

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -299,7 +299,7 @@ impl<'a> Borrowed<'a, '_, PyByteArray> {
     }
 
     #[allow(clippy::wrong_self_convention)]
-    unsafe fn as_bytes(self) -> &'a [u8] {
+    pub(crate) unsafe fn as_bytes(self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.data(), self.len()) }
     }
 

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -1,19 +1,12 @@
-use crate::conversion::FromPyObjectOwned;
-use crate::err::{self, DowncastError, PyErr, PyResult};
-use crate::exceptions::PyTypeError;
+use crate::err::{self, PyErr, PyResult};
 use crate::ffi_ptr_ext::FfiPtrExt;
-#[cfg(feature = "experimental-inspect")]
-use crate::inspect::types::TypeInfo;
 use crate::instance::Bound;
 use crate::internal_tricks::get_ssize_index;
 use crate::py_result_ext::PyResultExt;
 use crate::sync::PyOnceLock;
 use crate::type_object::PyTypeInfo;
-use crate::types::{any::PyAnyMethods, PyAny, PyList, PyString, PyTuple, PyType};
-use crate::{
-    ffi, Borrowed, BoundObject, FromPyObject, IntoPyObject, IntoPyObjectExt, Py, PyTypeCheck,
-    Python,
-};
+use crate::types::{any::PyAnyMethods, PyAny, PyList, PyTuple, PyType};
+use crate::{ffi, Borrowed, BoundObject, IntoPyObject, IntoPyObjectExt, Py, PyTypeCheck, Python};
 
 /// Represents a reference to a Python object supporting the sequence protocol.
 ///
@@ -332,46 +325,6 @@ impl<'py> PySequenceMethods<'py> for Bound<'py, PySequence> {
     }
 }
 
-impl<'py, T> FromPyObject<'_, 'py> for Vec<T>
-where
-    T: FromPyObjectOwned<'py>,
-{
-    type Error = PyErr;
-
-    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
-        if obj.is_instance_of::<PyString>() {
-            return Err(PyTypeError::new_err("Can't extract `str` to `Vec`"));
-        }
-        extract_sequence(obj)
-    }
-
-    #[cfg(feature = "experimental-inspect")]
-    fn type_input() -> TypeInfo {
-        TypeInfo::sequence_of(T::type_input())
-    }
-}
-
-fn extract_sequence<'py, T>(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Vec<T>>
-where
-    T: FromPyObjectOwned<'py>,
-{
-    // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
-    // to support this function and if not, we will only fail extraction safely.
-    let seq = unsafe {
-        if ffi::PySequence_Check(obj.as_ptr()) != 0 {
-            obj.cast_unchecked::<PySequence>()
-        } else {
-            return Err(DowncastError::new_from_borrowed(obj, "Sequence").into());
-        }
-    };
-
-    let mut v = Vec::with_capacity(seq.len().unwrap_or(0));
-    for item in seq.try_iter()? {
-        v.push(item?.extract::<T>().map_err(Into::into)?);
-    }
-    Ok(v)
-}
-
 fn get_sequence_abc(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
     static SEQUENCE_ABC: PyOnceLock<Py<PyType>> = PyOnceLock::new();
 
@@ -426,17 +379,6 @@ mod tests {
         Python::attach(|py| {
             let v = "London Calling";
             assert!(v.into_pyobject(py).unwrap().cast::<PySequence>().is_ok());
-        });
-    }
-
-    #[test]
-    fn test_strings_cannot_be_extracted_to_vec() {
-        Python::attach(|py| {
-            let v = "London Calling";
-            let ob = v.into_pyobject(py).unwrap();
-
-            assert!(ob.extract::<Vec<String>>().is_err());
-            assert!(ob.extract::<Vec<char>>().is_err());
         });
     }
 
@@ -777,42 +719,6 @@ mod tests {
                 .unwrap()
                 .eq(PyTuple::new(py, &v).unwrap())
                 .unwrap());
-        });
-    }
-
-    #[test]
-    fn test_extract_tuple_to_vec() {
-        Python::attach(|py| {
-            let v: Vec<i32> = py
-                .eval(ffi::c_str!("(1, 2)"), None, None)
-                .unwrap()
-                .extract()
-                .unwrap();
-            assert!(v == [1, 2]);
-        });
-    }
-
-    #[test]
-    fn test_extract_range_to_vec() {
-        Python::attach(|py| {
-            let v: Vec<i32> = py
-                .eval(ffi::c_str!("range(1, 5)"), None, None)
-                .unwrap()
-                .extract()
-                .unwrap();
-            assert!(v == [1, 2, 3, 4]);
-        });
-    }
-
-    #[test]
-    fn test_extract_bytearray_to_vec() {
-        Python::attach(|py| {
-            let v: Vec<u8> = py
-                .eval(ffi::c_str!("bytearray(b'abc')"), None, None)
-                .unwrap()
-                .extract()
-                .unwrap();
-            assert!(v == b"abc");
         });
     }
 


### PR DESCRIPTION
This is a (successful!) experiment to try and close off some of the remaining questions in #4390 

In particular, this addresses the challenge of optimized bytes extraction and whether we can make it work while changing the trait.
Only the last commit 449bd26635577c70a538d0b08f0d85783101d9e8 is actually relevant here, the rest is just current snapshot of #4390.

This solves the problem encountered in https://github.com/PyO3/pyo3/pull/4390#issuecomment-2480501756, namely by avoiding any additional trait bounds and instead requiring the type adding a slice conversion to handle fully the pathways both to array and to vec.

```rust
// step 1 of slice extraction for specialized types like `Vec<u8>` and `[u8; N]`
// note that 's lifetime is deliberately different from 'a because the type may
// in general not have a meaningful relation to the lifetime 'a
#[doc(hidden)]
fn object_as_slice<'s>(
    _obj: Borrowed<'s, 'py, PyAny>,
    _: private::Token,
) -> Option<PyResult<&'s [Self]>> {
    None
}

// step 2 of the slice extraction into an array
#[doc(hidden)]
fn slice_into_array<const N: usize>(_slice: &[Self], _: private::Token) -> PyResult<[Self; N]> {
    unreachable!("types implementing as_slice must also implement slice_into_array");
}

// step 2 of the slice extraction into a vector
#[doc(hidden)]
fn slice_into_vec(_slice: &[Self], _: private::Token) -> PyResult<Vec<Self>>
where
    Self: Sized,
{
    unreachable!("types implementing as_slice must also implement slice_into_vec");
}
```

----

The nice thing about this design is that:
- I think this can generalize to also supporting `bytearray` extraction, and maybe even via `PyBuffer<T>`
- I _think_ we could also apply this to `main` if we wanted without changing `FromPyObject`, but that's more churn so I'd rather move forward with #4390. Hopefully we can unblock that in the near future.