### PR TITLE
use lifetime elision in VisitMut

### DIFF
--- a/pyo3-macros-backend/src/introspection.rs
+++ b/pyo3-macros-backend/src/introspection.rs
@@ -516,7 +516,7 @@ fn replace_self(ty: &mut Type, self_target: &Type) {
         self_target: &'a Type,
     }
 
-    impl<'a> VisitMut for SelfReplacementVisitor<'a> {
+    impl VisitMut for SelfReplacementVisitor<'_> {
         fn visit_type_mut(&mut self, ty: &mut Type) {
             if let syn::Type::Path(type_path) = ty {
                 if type_path.qself.is_none()


### PR DESCRIPTION
Addresses the following `needless_lifetimes` clippy error that is preventing running `nox -s clippy-all`.

```
error: the following explicit lifetimes could be elided: 'a
   --> pyo3-macros-backend/src/introspection.rs:519:10
    |
519 |     impl<'a> VisitMut for SelfReplacementVisitor<'a> {
    |          ^^                                      ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
```