### PR TITLE
Allow converting `PyMemoryError` into/from `io::ErrorKind::OutOfMemory`

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -13,6 +13,16 @@ For this reason we chose to rename these to more modern terminology introduced i
 - `Python::allow_threads` is now called `Python::detach`, it detaches a previously attached thread-state.
 </details>
 
+### `PyMemoryError` now maps to `io::ErrorKind::OutOfMemory` when converted to `io::Error`
+<details>
+<summary><small>Click to expand</small></summary>
+
+Previously, converting a `PyMemoryError` into a Rust `io::Error` would result in an error with kind `Other`. Now, it produces an error with kind `OutOfMemory`.
+Similarly, converting an `io::Error` with kind `OutOfMemory` back into a Python error would previously yield a generic `PyOSError`. Now, it yields a `PyMemoryError`.
+
+This change makes error conversions more precise and matches the semantics of out-of-memory errors between Python and Rust.
+</details>
+
 ## from 0.24.* to 0.25
 ### `AsPyPointer` removal
 <details>

--- a/newsfragments/5256.added.md
+++ b/newsfragments/5256.added.md
@@ -1,0 +1,1 @@
+Allow converting `PyMemoryError` into/from `io::ErrorKind::OutOfMemory`

--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -26,6 +26,8 @@ impl From<PyErr> for io::Error {
                 io::ErrorKind::WouldBlock
             } else if err.is_instance_of::<exceptions::PyTimeoutError>(py) {
                 io::ErrorKind::TimedOut
+            } else if err.is_instance_of::<exceptions::PyMemoryError>(py) {
+                io::ErrorKind::OutOfMemory
             } else {
                 #[cfg(io_error_more)]
                 if err.is_instance_of::<exceptions::PyIsADirectoryError>(py) {
@@ -63,6 +65,7 @@ impl From<io::Error> for PyErr {
             io::ErrorKind::AlreadyExists => exceptions::PyFileExistsError::new_err(err),
             io::ErrorKind::WouldBlock => exceptions::PyBlockingIOError::new_err(err),
             io::ErrorKind::TimedOut => exceptions::PyTimeoutError::new_err(err),
+            io::ErrorKind::OutOfMemory => exceptions::PyMemoryError::new_err(err),
             #[cfg(io_error_more)]
             io::ErrorKind::IsADirectory => exceptions::PyIsADirectoryError::new_err(err),
             #[cfg(io_error_more)]


### PR DESCRIPTION
Allow converting `PyMemoryError` into/from `io::ErrorKind::OutOfMemory`.