### PR TITLE
ci: move netlify site build to nox

### DIFF
--- a/.github/workflows/netlify-build.yml
+++ b/.github/workflows/netlify-build.yml
@@ -57,29 +57,11 @@ jobs:
           TAG_NAME="${GITHUB_REF##*/}"
           echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
 
-      # Start with the current guides.
-      - name: Get the guide
+      # Build the site
+      - name: Prepare the versioned guide entries
         run: |
-          wget -qc https://github.com/PyO3/pyo3/archive/gh-pages.tar.gz -O - | tar -xz
-          mv pyo3-gh-pages netlify_build
-
-      # Set redirects.
-      - name: Set redirects
-        run: sh .netlify/redirect.sh
-
-      # This builds the book and docs in netlify_build/main
-      - name: Build the guide and public docs
-        run: |
-          python -m pip install --upgrade pip && pip install nox towncrier
-          towncrier build --yes --version Unreleased --date TBC
-          nox -s check-guide
-          mv target/guide/ netlify_build/main/
-          nox -s docs
-          mv target/doc netlify_build/main/doc/
-          echo "<meta http-equiv=refresh content=0;url=pyo3/>" > netlify_build/main/doc/index.html
-          nox -s docs -- nightly internal
-          mkdir -p netlify_build/internal
-          mv target/doc netlify_build/internal/
+          python -m pip install --upgrade pip && pip install nox towncrier requests
+          nox -s build-netlify-site -- ${{ github.ref == 'refs/heads/main' && '' || '--preview' }}
 
       # Upload the built site as an artifact for deploy workflow to consume
       - name: Upload Build Artifact

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import re
@@ -5,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import sysconfig
+import tarfile
 import tempfile
 from contextlib import contextmanager
 from functools import lru_cache
@@ -30,6 +32,11 @@ except ImportError:
         import toml
     except ImportError:
         toml = None
+
+try:
+    import requests
+except ImportError:
+    requests = None
 
 nox.options.sessions = ["test", "clippy", "rustfmt", "ruff", "docs"]
 
@@ -433,20 +440,23 @@ def test_emscripten(session: nox.Session):
 
 
 @nox.session(venv_backend="none")
-def docs(session: nox.Session) -> None:
+def docs(session: nox.Session, nightly: bool = False, internal: bool = False) -> None:
     rustdoc_flags = ["-Dwarnings"]
     toolchain_flags = []
     cargo_flags = []
 
+    nightly = nightly or ("nightly" in session.posargs)
+    internal = internal or ("internal" in session.posargs)
+
     if "open" in session.posargs:
         cargo_flags.append("--open")
 
-    if "nightly" in session.posargs:
+    if nightly:
         rustdoc_flags.append("--cfg docsrs")
         toolchain_flags.append("+nightly")
         cargo_flags.extend(["-Z", "unstable-options", "-Z", "rustdoc-scrape-examples"])
 
-    if "nightly" in session.posargs and "internal" in session.posargs:
+    if internal:
         rustdoc_flags.append("--Z unstable-options")
         rustdoc_flags.append("--document-hidden-items")
         rustdoc_flags.extend(("--html-after-content", ".netlify/internal_banner.html"))
@@ -481,6 +491,125 @@ def build_guide(session: nox.Session):
         target_file = PYO3_GUIDE_TARGET / license
         target_file.unlink(missing_ok=True)
         shutil.copy(PYO3_DIR / license, target_file)
+
+
+@nox.session(name="build-netlify-site")
+def build_netlify_site(session: nox.Session):
+    # Remove netlify_build directory if it exists
+    netlify_build = Path("netlify_build")
+    if netlify_build.exists():
+        shutil.rmtree(netlify_build)
+
+    url = "https://github.com/PyO3/pyo3/archive/gh-pages.tar.gz"
+    response = requests.get(url, stream=True)
+    response.raise_for_status()
+    with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:gz") as tar:
+        tar.extractall()
+    shutil.move("pyo3-gh-pages", "netlify_build")
+    build_netlify_redirects(session)
+
+    session.install("towncrier")
+    # Save a copy of the changelog to restore later
+    changelog = (PYO3_DIR / "CHANGELOG.md").read_text()
+
+    # Build the changelog
+    session.run(
+        "towncrier", "build", "--keep", "--version", "Unreleased", "--date", "TBC"
+    )
+
+    # Build the guide
+    build_guide(session)
+    PYO3_GUIDE_TARGET.rename("netlify_build/main")
+
+    # Restore the original changelog
+    (PYO3_DIR / "CHANGELOG.md").write_text(changelog)
+    session.run("git", "restore", "--staged", "CHANGELOG.md", external=True)
+
+    # Build the main branch docs
+    docs(session)
+    PYO3_DOCS_TARGET.rename("netlify_build/main/doc")
+
+    Path("netlify_build/main/doc/index.html").write_text(
+        "<meta http-equiv=refresh content=0;url=pyo3/>"
+    )
+
+    # Build the internal docs
+    docs(session, nightly=True, internal=True)
+    PYO3_DOCS_TARGET.rename("netlify_build/internal")
+
+
+@nox.session(name="build-netlify-redirects", venv_backend="none")
+def build_netlify_redirects(session: nox.Session):
+
+    current_version = os.environ.get("PYO3_VERSION")
+    preview = "--preview" in session.posargs
+
+    with open("netlify_build/_redirects", "w") as redirects_file, open(
+        "netlify_build/_headers", "w"
+    ) as headers_file:
+
+        for d in glob("netlify_build/v*"):
+            version = d.removeprefix("netlify_build/v")
+            full_directory = d + "/"
+            redirects_file.write(
+                f"/v{version}/doc/* https://docs.rs/pyo3/{version}/:splat\n"
+            )
+            if version != current_version:
+                # for old versions, mark the files in the latest version as the canonical URL
+                for file in glob(f"{d}/**", recursive=True):
+                    file_path = file.removeprefix(full_directory)
+                    # remove index.html and/or .html suffix to match the page URL on the
+                    # final netlfiy site
+                    url_path = file_path
+                    if file_path == "index.html":
+                        url_path = ""
+
+                    url_path = url_path.removesuffix(".html")
+
+                    # if the file exists in the latest version, add a canonical
+                    # URL as a header
+                    for url in (
+                        f"/v{version}/{url_path}",
+                        *(
+                            (f"/v{version}/{file_path}",)
+                            if file_path != url_path
+                            else ()
+                        ),
+                    ):
+                        headers_file.write(url + "\n")
+                        if os.path.exists(
+                            f"netlify_build/v{current_version}/{file_path}"
+                        ):
+                            headers_file.write(
+                                f'  Link: <https://pyo3.rs/v{current_version}/{url_path}>; rel="canonical"\n'
+                            )
+                        else:
+                            # this file doesn't exist in the latest guide, don't
+                            # index it
+                            headers_file.write("  X-Robots-Tag: noindex\n")
+
+        # Add latest redirect
+        if current_version is not None:
+            redirects_file.write(f"/latest/* /v{current_version}/:splat 302\n")
+
+        # some backwards compatbiility redirects
+        redirects_file.write(
+            """\
+/latest/building_and_distribution/* /latest/building-and-distribution/:splat 302
+/latest/building_and_distribution/multiple_python_versions/* /latest/building-and-distribution/multiple-python-versions:splat 302
+/latest/function/error_handling/* /latest/function/error-handling/:splat 302
+/latest/getting_started/* /latest/getting-started/:splat 302
+/latest/python_from_rust/* /latest/python-from-rust/:splat 302
+/latest/python_typing_hints/* /latest/python-typing-hints/:splat 302
+/latest/trait_bounds/* /latest/trait-bounds/:splat 302
+"""
+        )
+
+        # Add landing page redirect
+        if preview:
+            redirects_file.write("/ /main/ 302\n")
+        else:
+            redirects_file.write(f"/ /v{current_version}/ 302\n")
 
 
 @nox.session(name="check-guide", venv_backend="none")


### PR DESCRIPTION
This moves the netlify site build into `noxfile.py` so that it's easier to reproduce locally, and at the same time fixes the failure currently recurrent in CI.