### PR TITLE
ci: don't run `clippy` on `main`, stop caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
       CARGO_BUILD_TARGET: x86_64-unknown-linux-gnu
 
   clippy:
+    # Don't run clippy on `main` because it's already run in the merge queue.
+    if: github.ref != 'refs/heads/main'
     needs: [fmt]
     runs-on: ${{ matrix.platform.os }}
     strategy:
@@ -159,13 +161,8 @@ jobs:
           components: clippy,rust-src
       - uses: actions/setup-python@v5
         with:
-          # FIXME: 3.13.4 has an issue on windows so pinned to 3.13.3
-          # once 3.13.5 is out, unpin the patch version
-          python-version: "3.13.3"
+          python-version: "3.13"
           architecture: ${{ matrix.platform.python-architecture }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
       # windows on arm image contains x86-64 libclang
       - name: Install LLVM and Clang
         if: matrix.platform.os == 'windows-11-arm'


### PR DESCRIPTION
Part of #5141

clippy jobs are currently run against each commit which lands on `main` twice:
 - once for the merge queue, and
 - once for the push to main

The merge queue is necessary to maintain a green CI on `main`.

The run on push to main has been to populate caches. But as per #5141 the repository contents are not cached anyway. I don't think the dependency download and check run on dependencies is going to save sufficient time compared to the ~20 mins per platform for each push to main.

If the clippy jobs do seem negatively impacted by the removal of the cache, we can perhaps reconsider this and add a `clippy-caches` job or similar which runs on main to populate the dependency caches.

However I suggest we start with the simpler change, which is just removing the duplicate run & caching for now.