### PR TITLE
ci: don't need metadata for netlify deploy

### DIFF
--- a/.github/workflows/netlify-deploy.yml
+++ b/.github/workflows/netlify-deploy.yml
@@ -28,14 +28,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Download PR Metadata
-        uses: actions/download-artifact@v4
-        with:
-          name: metadata
-          path: .metadata
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id }}
-
       - name: Install netlify-cli
         run: |
           npm install -g netlify-cli


### PR DESCRIPTION
I removed this in #5275 because we should be able to work everything out from github actions metadata.