### PR TITLE
support `doc_mode` attribute to limit docs to a single language

### DIFF
--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -18,8 +18,10 @@ pub mod kw {
     syn::custom_keyword!(cancel_handle);
     syn::custom_keyword!(constructor);
     syn::custom_keyword!(dict);
+    syn::custom_keyword!(doc_mode);
     syn::custom_keyword!(eq);
     syn::custom_keyword!(eq_int);
+    syn::custom_keyword!(end_doc_mode);
     syn::custom_keyword!(extends);
     syn::custom_keyword!(freelist);
     syn::custom_keyword!(from_py_with);
@@ -318,6 +320,7 @@ pub type StrFormatterAttribute = OptionalKeywordAttribute<kw::str, StringFormatt
 pub type TextSignatureAttribute = KeywordAttribute<kw::text_signature, TextSignatureAttributeValue>;
 pub type SubmoduleAttribute = kw::submodule;
 pub type GILUsedAttribute = KeywordAttribute<kw::gil_used, LitBool>;
+pub type DocModeAttribute = KeywordAttribute<kw::doc_mode, LitStr>;
 
 impl<K: Parse + std::fmt::Debug, V: Parse> Parse for KeywordAttribute<K, V> {
     fn parse(input: ParseStream<'_>) -> Result<Self> {

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -975,7 +975,7 @@ impl<'a> FnSpec<'a> {
     }
 
     /// Forwards to [utils::get_doc] with the text signature of this spec.
-    pub fn get_doc(&self, attrs: &[syn::Attribute], ctx: &Ctx) -> PythonDoc {
+    pub fn get_doc(&self, attrs: &mut Vec<syn::Attribute>, ctx: &Ctx) -> syn::Result<PythonDoc> {
         let text_signature = self
             .text_signature_call_signature()
             .map(|sig| format!("{}{}", self.python_name, sig));

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -112,7 +112,7 @@ pub fn pymodule_module_impl(
     options.take_pyo3_options(attrs)?;
     let ctx = &Ctx::new(&options.krate, None);
     let Ctx { pyo3_path, .. } = ctx;
-    let doc = get_doc(attrs, None, ctx);
+    let doc = get_doc(attrs, None, ctx)?;
     let name = options
         .name
         .map_or_else(|| ident.unraw(), |name| name.value.0);
@@ -434,7 +434,7 @@ pub fn pymodule_function_impl(
         .name
         .map_or_else(|| ident.unraw(), |name| name.value.0);
     let vis = &function.vis;
-    let doc = get_doc(&function.attrs, None, ctx);
+    let doc = get_doc(&mut function.attrs, None, ctx)?;
 
     let initialization = module_initialization(
         &name,

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -250,7 +250,7 @@ pub fn build_py_class(
     args.options.take_pyo3_options(&mut class.attrs)?;
 
     let ctx = &Ctx::new(&args.options.krate, None);
-    let doc = utils::get_doc(&class.attrs, None, ctx);
+    let doc = utils::get_doc(&mut class.attrs, None, ctx)?;
 
     if let Some(lt) = class.generics.lifetimes().next() {
         bail_spanned!(
@@ -436,11 +436,11 @@ fn impl_class(
         ctx,
     )?;
 
-    let (default_class_geitem, default_class_geitem_method) =
-        pyclass_class_geitem(&args.options, &syn::parse_quote!(#cls), ctx)?;
+    let (default_class_getitem, default_class_getitem_method) =
+        pyclass_class_getitem(&args.options, &syn::parse_quote!(#cls), ctx)?;
 
-    if let Some(default_class_geitem_method) = default_class_geitem_method {
-        default_methods.push(default_class_geitem_method);
+    if let Some(default_class_getitem_method) = default_class_getitem_method {
+        default_methods.push(default_class_getitem_method);
     }
 
     let (default_str, default_str_slot) =
@@ -474,7 +474,7 @@ fn impl_class(
             #default_richcmp
             #default_hash
             #default_str
-            #default_class_geitem
+            #default_class_getitem
         }
     })
 }
@@ -521,7 +521,7 @@ pub fn build_py_enum(
         bail_spanned!(generic.span() => "enums do not support #[pyclass(generic)]");
     }
 
-    let doc = utils::get_doc(&enum_.attrs, None, ctx);
+    let doc = utils::get_doc(&mut enum_.attrs, None, ctx)?;
     let enum_ = PyClassEnum::new(enum_)?;
     impl_enum(enum_, &args, doc, method_type, ctx)
 }
@@ -1759,7 +1759,7 @@ fn complex_enum_variant_field_getter<'a>(
     let property_type = crate::pymethod::PropertyType::Function {
         self_type: &self_type,
         spec: &spec,
-        doc: crate::get_doc(&[], None, ctx),
+        doc: PythonDoc::empty(ctx),
     };
 
     let getter = crate::pymethod::impl_py_getter_def(variant_cls_type, property_type, ctx)?;
@@ -2027,7 +2027,7 @@ fn pyclass_hash(
     }
 }
 
-fn pyclass_class_geitem(
+fn pyclass_class_getitem(
     options: &PyClassPyO3Options,
     cls: &syn::Type,
     ctx: &Ctx,
@@ -2036,7 +2036,7 @@ fn pyclass_class_geitem(
     match options.generic {
         Some(_) => {
             let ident = format_ident!("__class_getitem__");
-            let mut class_geitem_impl: syn::ImplItemFn = {
+            let mut class_getitem_impl: syn::ImplItemFn = {
                 parse_quote! {
                     #[classmethod]
                     fn #ident<'py>(
@@ -2049,19 +2049,19 @@ fn pyclass_class_geitem(
             };
 
             let spec = FnSpec::parse(
-                &mut class_geitem_impl.sig,
-                &mut class_geitem_impl.attrs,
+                &mut class_getitem_impl.sig,
+                &mut class_getitem_impl.attrs,
                 Default::default(),
             )?;
 
-            let class_geitem_method = crate::pymethod::impl_py_method_def(
+            let class_getitem_method = crate::pymethod::impl_py_method_def(
                 cls,
                 &spec,
-                &spec.get_doc(&class_geitem_impl.attrs, ctx),
+                &spec.get_doc(&mut class_getitem_impl.attrs, ctx)?,
                 Some(quote!(#pyo3_path::ffi::METH_CLASS)),
                 ctx,
             )?;
-            Ok((Some(class_geitem_impl), Some(class_geitem_method)))
+            Ok((Some(class_getitem_impl), Some(class_getitem_method)))
         }
         None => Ok((None, None)),
     }

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -424,7 +424,7 @@ pub fn impl_wrap_pyfunction(
         );
     }
     let wrapper = spec.get_wrapper_function(&wrapper_ident, None, ctx)?;
-    let methoddef = spec.get_methoddef(wrapper_ident, &spec.get_doc(&func.attrs, ctx), ctx);
+    let methoddef = spec.get_methoddef(wrapper_ident, &spec.get_doc(&mut func.attrs, ctx)?, ctx);
 
     let wrapped_pyfunction = quote! {
         // Create a module with the same name as the `#[pyfunction]` - this way `use <the function>`

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -136,7 +136,7 @@ pub fn impl_methods(
                     let method = PyMethod::parse(&mut meth.sig, &mut meth.attrs, fun_options)?;
                     #[cfg(feature = "experimental-inspect")]
                     extra_fragments.push(method_introspection_code(&method.spec, ty, ctx));
-                    match pymethod::gen_py_method(ty, method, &meth.attrs, ctx)? {
+                    match pymethod::gen_py_method(ty, method, &mut meth.attrs, ctx)? {
                         GeneratedPyMethod::Method(MethodAndMethodDef {
                             associated_method,
                             method_def,


### PR DESCRIPTION
This is a prototype attempt at #5269 

It actually works, which is pretty promising!

```rust
#[pyo3::pymodule]
/// A simple example of a native module with varying docs.
///
#[pyo3_doc_mode(doc_mode = "rust")]
/// This is a Rust-only comment.
#[pyo3_doc_mode(doc_mode = "python")]
/// This is a Python-only comment.
#[pyo3_doc_mode(end_doc_mode)]
pub mod pyo3_scratch {}
```

----

<img width="508" height="213" alt="image" src="https://github.com/user-attachments/assets/11b61ef4-9564-4d07-be0e-a5711f8afc71" />

```python
>>>> import pyo3_scratch
>>>> print(pyo3_scratch.__doc__)
A simple example of a native module with varying docs.

This is a Python-only comment.
```

----

One big drawback of this is that if the docs are placed above the attribute, which I'd consider normal Rust style, then the `#[pyo3_doc_mode]` attributes are evaluated before the `#[pymodule]` attribute, and this then causes compiler errors:

```rust
/// A simple example of a native module with varying docs.
///
#[pyo3_doc_mode(doc_mode = "rust")]
/// This is a Rust-only comment.
#[pyo3_doc_mode(doc_mode = "python")]
/// This is a Python-only comment.
#[pyo3_doc_mode(end_doc_mode)]
#[pyo3::pymodule]
pub mod pyo3_scratch {}
```

```
error: cannot find attribute `pyo3_doc_mode` in this scope
 --> src/lib.rs:3:3
  |
3 | #[pyo3_doc_mode(doc_mode = "rust")]
  |   ^^^^^^^^^^^^^

error: cannot find attribute `pyo3_doc_mode` in this scope
 --> src/lib.rs:5:3
  |
5 | #[pyo3_doc_mode(doc_mode = "python")]
  |   ^^^^^^^^^^^^^

error: cannot find attribute `pyo3_doc_mode` in this scope
 --> src/lib.rs:7:3
  |
7 | #[pyo3_doc_mode(end_doc_mode)]
  |   ^^^^^^^^^^^^^

error: could not document `pyo3-scratch`
```

We can probably improve the UX there so that an incorrect placement works better.

Or maybe there are other ideas entirely which are not placement sensitive?