### PR TITLE
Embedded doc mode using HTML comments to fix attribute order issues (fixes #5269)

### DIFF
--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -320,7 +320,6 @@ pub type StrFormatterAttribute = OptionalKeywordAttribute<kw::str, StringFormatt
 pub type TextSignatureAttribute = KeywordAttribute<kw::text_signature, TextSignatureAttributeValue>;
 pub type SubmoduleAttribute = kw::submodule;
 pub type GILUsedAttribute = KeywordAttribute<kw::gil_used, LitBool>;
-pub type DocModeAttribute = KeywordAttribute<kw::doc_mode, LitStr>;
 
 impl<K: Parse + std::fmt::Debug, V: Parse> Parse for KeywordAttribute<K, V> {
     fn parse(input: ParseStream<'_>) -> Result<Self> {

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -18,8 +18,10 @@ pub mod kw {
     syn::custom_keyword!(cancel_handle);
     syn::custom_keyword!(constructor);
     syn::custom_keyword!(dict);
+    syn::custom_keyword!(doc_mode);
     syn::custom_keyword!(eq);
     syn::custom_keyword!(eq_int);
+    syn::custom_keyword!(end_doc_mode);
     syn::custom_keyword!(extends);
     syn::custom_keyword!(freelist);
     syn::custom_keyword!(from_py_with);
@@ -318,6 +320,7 @@ pub type StrFormatterAttribute = OptionalKeywordAttribute<kw::str, StringFormatt
 pub type TextSignatureAttribute = KeywordAttribute<kw::text_signature, TextSignatureAttributeValue>;
 pub type SubmoduleAttribute = kw::submodule;
 pub type GILUsedAttribute = KeywordAttribute<kw::gil_used, LitBool>;
+pub type DocModeAttribute = KeywordAttribute<kw::doc_mode, LitStr>;
 
 impl<K: Parse + std::fmt::Debug, V: Parse> Parse for KeywordAttribute<K, V> {
     fn parse(input: ParseStream<'_>) -> Result<Self> {

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -975,7 +975,7 @@ impl<'a> FnSpec<'a> {
     }
 
     /// Forwards to [utils::get_doc] with the text signature of this spec.
-    pub fn get_doc(&self, attrs: &[syn::Attribute], ctx: &Ctx) -> PythonDoc {
+    pub fn get_doc(&self, attrs: &mut Vec<syn::Attribute>, ctx: &Ctx) -> syn::Result<PythonDoc> {
         let text_signature = self
             .text_signature_call_signature()
             .map(|sig| format!("{}{}", self.python_name, sig));

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -112,7 +112,7 @@ pub fn pymodule_module_impl(
     options.take_pyo3_options(attrs)?;
     let ctx = &Ctx::new(&options.krate, None);
     let Ctx { pyo3_path, .. } = ctx;
-    let doc = get_doc(attrs, None, ctx);
+    let doc = get_doc(attrs, None, ctx)?;
     let name = options
         .name
         .map_or_else(|| ident.unraw(), |name| name.value.0);
@@ -434,7 +434,7 @@ pub fn pymodule_function_impl(
         .name
         .map_or_else(|| ident.unraw(), |name| name.value.0);
     let vis = &function.vis;
-    let doc = get_doc(&function.attrs, None, ctx);
+    let doc = get_doc(&mut function.attrs, None, ctx)?;
 
     let initialization = module_initialization(
         &name,

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -250,7 +250,7 @@ pub fn build_py_class(
     args.options.take_pyo3_options(&mut class.attrs)?;
 
     let ctx = &Ctx::new(&args.options.krate, None);
-    let doc = utils::get_doc(&class.attrs, None, ctx);
+    let doc = utils::get_doc(&mut class.attrs, None, ctx)?;
 
     if let Some(lt) = class.generics.lifetimes().next() {
         bail_spanned!(
@@ -436,11 +436,11 @@ fn impl_class(
         ctx,
     )?;
 
-    let (default_class_geitem, default_class_geitem_method) =
-        pyclass_class_geitem(&args.options, &syn::parse_quote!(#cls), ctx)?;
+    let (default_class_getitem, default_class_getitem_method) =
+        pyclass_class_getitem(&args.options, &syn::parse_quote!(#cls), ctx)?;
 
-    if let Some(default_class_geitem_method) = default_class_geitem_method {
-        default_methods.push(default_class_geitem_method);
+    if let Some(default_class_getitem_method) = default_class_getitem_method {
+        default_methods.push(default_class_getitem_method);
     }
 
     let (default_str, default_str_slot) =
@@ -474,7 +474,7 @@ fn impl_class(
             #default_richcmp
             #default_hash
             #default_str
-            #default_class_geitem
+            #default_class_getitem
         }
     })
 }
@@ -521,7 +521,7 @@ pub fn build_py_enum(
         bail_spanned!(generic.span() => "enums do not support #[pyclass(generic)]");
     }
 
-    let doc = utils::get_doc(&enum_.attrs, None, ctx);
+    let doc = utils::get_doc(&mut enum_.attrs, None, ctx)?;
     let enum_ = PyClassEnum::new(enum_)?;
     impl_enum(enum_, &args, doc, method_type, ctx)
 }
@@ -1759,7 +1759,7 @@ fn complex_enum_variant_field_getter<'a>(
     let property_type = crate::pymethod::PropertyType::Function {
         self_type: &self_type,
         spec: &spec,
-        doc: crate::get_doc(&[], None, ctx),
+        doc: PythonDoc::empty(ctx),
     };
 
     let getter = crate::pymethod::impl_py_getter_def(variant_cls_type, property_type, ctx)?;
@@ -2027,7 +2027,7 @@ fn pyclass_hash(
     }
 }
 
-fn pyclass_class_geitem(
+fn pyclass_class_getitem(
     options: &PyClassPyO3Options,
     cls: &syn::Type,
     ctx: &Ctx,
@@ -2036,7 +2036,7 @@ fn pyclass_class_geitem(
     match options.generic {
         Some(_) => {
             let ident = format_ident!("__class_getitem__");
-            let mut class_geitem_impl: syn::ImplItemFn = {
+            let mut class_getitem_impl: syn::ImplItemFn = {
                 parse_quote! {
                     #[classmethod]
                     fn #ident<'py>(
@@ -2049,19 +2049,19 @@ fn pyclass_class_geitem(
             };
 
             let spec = FnSpec::parse(
-                &mut class_geitem_impl.sig,
-                &mut class_geitem_impl.attrs,
+                &mut class_getitem_impl.sig,
+                &mut class_getitem_impl.attrs,
                 Default::default(),
             )?;
 
-            let class_geitem_method = crate::pymethod::impl_py_method_def(
+            let class_getitem_method = crate::pymethod::impl_py_method_def(
                 cls,
                 &spec,
-                &spec.get_doc(&class_geitem_impl.attrs, ctx),
+                &spec.get_doc(&mut class_getitem_impl.attrs, ctx)?,
                 Some(quote!(#pyo3_path::ffi::METH_CLASS)),
                 ctx,
             )?;
-            Ok((Some(class_geitem_impl), Some(class_geitem_method)))
+            Ok((Some(class_getitem_impl), Some(class_getitem_method)))
         }
         None => Ok((None, None)),
     }

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -424,7 +424,7 @@ pub fn impl_wrap_pyfunction(
         );
     }
     let wrapper = spec.get_wrapper_function(&wrapper_ident, None, ctx)?;
-    let methoddef = spec.get_methoddef(wrapper_ident, &spec.get_doc(&func.attrs, ctx), ctx);
+    let methoddef = spec.get_methoddef(wrapper_ident, &spec.get_doc(&mut func.attrs, ctx)?, ctx);
 
     let wrapped_pyfunction = quote! {
         // Create a module with the same name as the `#[pyfunction]` - this way `use <the function>`

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -136,7 +136,7 @@ pub fn impl_methods(
                     let method = PyMethod::parse(&mut meth.sig, &mut meth.attrs, fun_options)?;
                     #[cfg(feature = "experimental-inspect")]
                     extra_fragments.push(method_introspection_code(&method.spec, ty, ctx));
-                    match pymethod::gen_py_method(ty, method, &meth.attrs, ctx)? {
+                    match pymethod::gen_py_method(ty, method, &mut meth.attrs, ctx)? {
                         GeneratedPyMethod::Method(MethodAndMethodDef {
                             associated_method,
                             method_def,

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -1,8 +1,7 @@
-use crate::attributes::{self, CrateAttribute, RenamingRule};
+use crate::attributes::{CrateAttribute, RenamingRule};
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::ffi::CString;
-use syn::parse::Parse;
 use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
 use syn::{punctuated::Punctuated, Token};
@@ -134,35 +133,10 @@ enum PythonDocKind {
 enum DocParseMode {
     /// Currently generating docs for both Python and Rust.
     Both,
-    /// Currently generating docs for Python only, starting from the given Span.
-    PythonOnly(Span),
-    /// Currently generating docs for Rust only, starting from the given Span.
-    RustOnly(Span),
-}
-
-impl Parse for DocParseMode {
-    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
-        let lookahead = input.lookahead1();
-        if lookahead.peek(attributes::kw::doc_mode) {
-            let attribute: attributes::DocModeAttribute = input.parse()?;
-            let lit = attribute.value;
-            if lit.value() == "python" {
-                Ok(DocParseMode::PythonOnly(lit.span()))
-            } else if lit.value() == "rust" {
-                Ok(DocParseMode::RustOnly(lit.span()))
-            } else {
-                Err(syn::Error::new(
-                    lit.span(),
-                    "expected `doc_mode = \"python\"` or `doc_mode = \"rust\"",
-                ))
-            }
-        } else if lookahead.peek(attributes::kw::end_doc_mode) {
-            let _: attributes::kw::end_doc_mode = input.parse()?;
-            Ok(DocParseMode::Both)
-        } else {
-            Err(lookahead.error())
-        }
-    }
+    /// Currently generating docs for Python only.
+    PythonOnly,
+    /// Currently generating docs for Rust only.
+    RustOnly,
 }
 
 /// Collects all #[doc = "..."] attributes into a TokenStream evaluating to a null-terminated string.
@@ -188,91 +162,85 @@ pub fn get_doc(
 
     let mut mode = DocParseMode::Both;
 
-    let mut error: Option<syn::Error> = None;
+    let mut to_retain = vec![]; // Collect indices of attributes to retain
 
-    attrs.retain(|attr| {
+    for (i, attr) in attrs.iter().enumerate() {
         if attr.path().is_ident("doc") {
-            // if not in Rust-only mode, we process the doc attribute to add to the Python docstring
-            if !matches!(mode, DocParseMode::RustOnly(_)) {
-                if let Ok(nv) = attr.meta.require_name_value() {
-                    if !first {
-                        current_part.push('\n');
-                    } else {
-                        first = false;
+            if let Ok(nv) = attr.meta.require_name_value() {
+                let include_in_python;
+                let retain_in_rust;
+
+                if let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(lit_str),
+                    ..
+                }) = &nv.value
+                {
+                    // Strip single left space from literal strings, if needed.
+                    let doc_line = lit_str.value();
+                    let stripped_line = doc_line.strip_prefix(' ').unwrap_or(&doc_line);
+                    let trimmed = stripped_line.trim();
+
+                    // Check if this is a mode switch instruction
+                    if let Some(content) = trimmed.strip_prefix("<!--").and_then(|s| s.strip_suffix("-->")) {
+                        let content_trimmed = content.trim();
+                        if content_trimmed.starts_with("pyo3_doc_mode:") {
+                            let value = content_trimmed.strip_prefix("pyo3_doc_mode:").unwrap_or("").trim();
+                            mode = match value {
+                                "python" => DocParseMode::PythonOnly,
+                                "rust" => DocParseMode::RustOnly,
+                                "both" => DocParseMode::Both,
+                                _ => return Err(syn::Error::new(lit_str.span(), format!("Invalid doc_mode: '{}'. Expected 'python', 'rust', or 'both'.", value))),
+                            };
+                            // Do not retain mode switch lines in Rust, and skip in Python
+                            continue;
+                        }
                     }
-                    if let syn::Expr::Lit(syn::ExprLit {
-                        lit: syn::Lit::Str(lit_str),
-                        ..
-                    }) = &nv.value
-                    {
-                        // Strip single left space from literal strings, if needed.
-                        // e.g. `/// Hello world` expands to #[doc = " Hello world"]
-                        let doc_line = lit_str.value();
-                        current_part.push_str(doc_line.strip_prefix(' ').unwrap_or(&doc_line));
-                    } else {
-                        // This is probably a macro doc from Rust 1.54, e.g. #[doc = include_str!(...)]
+
+                    // Not a mode switch, decide based on current mode
+                    include_in_python = matches!(mode, DocParseMode::Both | DocParseMode::PythonOnly);
+                    retain_in_rust = matches!(mode, DocParseMode::Both | DocParseMode::RustOnly);
+
+                    // Include in Python doc if needed
+                    if include_in_python {
+                        if !first {
+                            current_part.push('\n');
+                        } else {
+                            first = false;
+                        }
+                        current_part.push_str(stripped_line);
+                    }
+                } else {
+                    // This is probably a macro doc, e.g. #[doc = include_str!(...)]
+                    // Decide based on current mode
+                    include_in_python = matches!(mode, DocParseMode::Both | DocParseMode::PythonOnly);
+                    retain_in_rust = matches!(mode, DocParseMode::Both | DocParseMode::RustOnly);
+
+                    // Include in Python doc if needed
+                    if include_in_python {
                         // Reset the string buffer, write that part, and then push this macro part too.
                         parts.push(current_part.to_token_stream());
                         current_part.clear();
                         parts.push(nv.value.to_token_stream());
                     }
                 }
-            }
-            // discard doc attributes if we're in PythonOnly mode
-            !matches!(mode, DocParseMode::PythonOnly(_))
-        } else if attr.path().is_ident("pyo3_doc_mode") {
-            match attr.parse_args() {
-                Ok(new_mode) => {
-                    mode = new_mode;
+
+                // Collect to retain if needed
+                if retain_in_rust {
+                    to_retain.push(i);
                 }
-                Err(err) => match &mut error {
-                    Some(existing_error) => existing_error.combine(err),
-                    None => {
-                        error = Some(err);
-                    }
-                },
             }
-            // we processed these attributes, remove them
-            false
         } else {
-            true
+            // Non-doc attributes are always retained
+            to_retain.push(i);
         }
-    });
+    }
 
-    // for attr in attrs {
-    //     if attr.path().is_ident("doc") {
-    //         if let Ok(nv) = attr.meta.require_name_value() {
-    //             if !first {
-    //                 current_part.push('\n');
-    //             } else {
-    //                 first = false;
-    //             }
-    //             if let syn::Expr::Lit(syn::ExprLit {
-    //                 lit: syn::Lit::Str(lit_str),
-    //                 ..
-    //             }) = &nv.value
-    //             {
-    //                 // Strip single left space from literal strings, if needed.
-    //                 // e.g. `/// Hello world` expands to #[doc = " Hello world"]
-    //                 let doc_line = lit_str.value();
-    //                 current_part.push_str(doc_line.strip_prefix(' ').unwrap_or(&doc_line));
-    //             } else {
-    //                 // This is probably a macro doc from Rust 1.54, e.g. #[doc = include_str!(...)]
-    //                 // Reset the string buffer, write that part, and then push this macro part too.
-    //                 parts.push(current_part.to_token_stream());
-    //                 current_part.clear();
-    //                 parts.push(nv.value.to_token_stream());
-    //             }
-    //         }
-    //     }
-    // }
+    // Retain only the selected attributes
+    *attrs = to_retain.into_iter().map(|i| attrs[i].clone()).collect();
 
-    // if the mode has not been ended, we return an error
-    match mode {
-        DocParseMode::Both => {}
-        DocParseMode::PythonOnly(span) | DocParseMode::RustOnly(span) => {
-            return Err(err_spanned!(span => "doc_mode must be ended with `end_doc_mode`"));
-        }
+    // Check if mode ended in Both; if not, error to enforce "pairing"
+    if !matches!(mode, DocParseMode::Both) {
+        return Err(err_spanned!(Span::call_site() => "doc_mode did not end in 'both' mode; consider adding <!-- pyo3_doc_mode: both --> at the end"));
     }
 
     if !parts.is_empty() {


### PR DESCRIPTION
This PR proposes an alternative implementation for the doc mode feature discussed in #5269 and prototyped in #5283.

**Core Ideas:**
- Instead of using separate #[pyo3_doc_mode] attributes (which can cause compiler errors if docs are placed above attributes in Rust style), embed mode switches directly in doc comments using HTML comments like `<!-- pyo3_doc_mode: python -->`.
  - HTML comments are ignored in Rustdoc (not rendered) and skipped during Python docstring extraction.
  - This eliminates evaluation order problems entirely.
- Supported modes: `python`, `rust`, `both` (default).
- Added a compile-time check: if the doc doesn't end in 'both' mode, raise an error to prevent unbalanced docs.
- Handles macro-based docs (e.g., #[doc = include_str!(...)]) according to the current mode.

**Advantages over the prototype in #5283:**
- No dependency on attribute order.
- All configuration stays within doc comments, making it more intuitive.
- Tested locally with a sample project (pyo3-doc-mode-test), verifying Rustdoc, Python docstrings, and error cases.

Changes are primarily in `pyo3-macros-backend/src/utils.rs` (updated `get_doc` function) and `attributes.rs` .

Full code diffs below. Feedback welcome—happy to iterate!

Fixes #5269
References #5283
![1](https://github.com/user-attachments/assets/3073da49-fa8f-4e1d-a817-0d217aa11dc3)
![2](https://github.com/user-attachments/assets/f618d32a-a99d-44fc-a667-0fa451dbef3e)
![3](https://github.com/user-attachments/assets/caf42560-4274-4e6a-8bed-23206a239f97)
![4](https://github.com/user-attachments/assets/e6ed43b2-b897-460e-9402-1d07fd622d5d)
![5](https://github.com/user-attachments/assets/585e819d-f5bc-4425-a0ec-7a05b1a6607e)

