### PR TITLE
docs: added link to error handling article in function main article, just below function signature article link

### DIFF
--- a/guide/src/function.md
+++ b/guide/src/function.md
@@ -31,6 +31,7 @@ This chapter of the guide explains full usage of the `#[pyfunction]` attribute. 
 There are also additional sections on the following topics:
 
 - [Function Signatures](./function/signature.md)
+- [Error Handling](./function/error-handling.md)
 
 ## Function options
 


### PR DESCRIPTION
I was reading the docs, and at `2.2 Python functions` the "subarticle" `2.2.1 Function signature` is linked when mentioning additional topics, but not chapter `2.2.2 Error handling`.

This PR adds the link just below, I hope this can be of any utility 