### PR TITLE
ci: fix clippy beta incompatible msrv warning

### DIFF
--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -28,6 +28,7 @@ impl From<PyErr> for io::Error {
                 io::ErrorKind::TimedOut
             } else {
                 #[cfg(io_error_more)]
+                #[allow(clippy::incompatible_msrv)] // gated by `io_error_more`
                 if err.is_instance_of::<exceptions::PyIsADirectoryError>(py) {
                     io::ErrorKind::IsADirectory
                 } else if err.is_instance_of::<exceptions::PyNotADirectoryError>(py) {


### PR DESCRIPTION
To get the green tick back ✅