### PR TITLE
ci: tidy up testing for send / sync w. probes

### DIFF
--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1229,7 +1229,7 @@ fn impl_complex_enum_struct_variant_cls(
         let field_getter_impl = quote! {
             fn #field_name(slf: #pyo3_path::PyClassGuard<'_, Self>, py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
                 #[allow(unused_imports)]
-                use #pyo3_path::impl_::pyclass::Probe;
+                use #pyo3_path::impl_::pyclass::Probe as _;
                 match &*slf.into_super() {
                     #enum_name::#variant_ident { #field_name, .. } =>
                         #pyo3_path::impl_::pyclass::ConvertField::<
@@ -1305,7 +1305,7 @@ fn impl_complex_enum_tuple_variant_field_getters(
         let field_getter_impl: syn::ImplItemFn = parse_quote! {
             fn #field_name(slf: #pyo3_path::PyClassGuard<'_, Self>, py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
                 #[allow(unused_imports)]
-                use #pyo3_path::impl_::pyclass::Probe;
+                use #pyo3_path::impl_::pyclass::Probe as _;
                 match &*slf.into_super() {
                     #enum_name::#variant_ident ( #(#field_access_tokens), *) =>
                         #pyo3_path::impl_::pyclass::ConvertField::<

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -853,7 +853,7 @@ pub fn impl_py_getter_def(
                 #cfg_attrs
                 {
                     #[allow(unused_imports)]  // might not be used if all probes are positve
-                    use #pyo3_path::impl_::pyclass::Probe;
+                    use #pyo3_path::impl_::pyclass::Probe as _;
 
                     struct Offset;
                     unsafe impl #pyo3_path::impl_::pyclass::OffsetCalculator<#cls, #ty> for Offset {

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -852,6 +852,7 @@ impl_signed_integer!(isize);
 mod tests {
     use super::PyErrState;
     use crate::exceptions::{self, PyTypeError, PyValueError};
+    use crate::impl_::pyclass::{value_of, IsSend, IsSync};
     use crate::{ffi, PyErr, PyTypeInfo, Python};
 
     #[test]
@@ -977,14 +978,11 @@ mod tests {
 
     #[test]
     fn test_pyerr_send_sync() {
-        fn is_send<T: Send>() {}
-        fn is_sync<T: Sync>() {}
+        assert!(value_of!(IsSend, PyErr));
+        assert!(value_of!(IsSync, PyErr));
 
-        is_send::<PyErr>();
-        is_sync::<PyErr>();
-
-        is_send::<PyErrState>();
-        is_sync::<PyErrState>();
+        assert!(value_of!(IsSend, PyErrState));
+        assert!(value_of!(IsSync, PyErrState));
     }
 
     #[test]

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -26,6 +26,7 @@ use std::{
 
 mod assertions;
 mod lazy_type_object;
+#[macro_use]
 mod probes;
 
 pub use assertions::*;

--- a/src/impl_/pyclass/probes.rs
+++ b/src/impl_/pyclass/probes.rs
@@ -49,6 +49,12 @@ where
     pub const VALUE: bool = true;
 }
 
+probe!(IsSend);
+
+impl<T: Send> IsSend<T> {
+    pub const VALUE: bool = true;
+}
+
 probe!(IsSync);
 
 impl<T: Sync> IsSync<T> {
@@ -60,3 +66,19 @@ probe!(IsOption);
 impl<T> IsOption<Option<T>> {
     pub const VALUE: bool = true;
 }
+
+#[cfg(test)]
+mod value_of_impl {
+
+    #[macro_export]
+    macro_rules! value_of {
+        ($probe:ident, $ty:ty) => {{
+            #[allow(unused_imports)] // probe trait not used if VALUE is true
+            use crate::impl_::pyclass::Probe as _;
+            $probe::<$ty>::VALUE
+        }};
+    }
+}
+
+#[cfg(test)]
+pub use crate::value_of; // because `#[macro_export]` puts it in the crate root...

--- a/src/impl_/pyclass/probes.rs
+++ b/src/impl_/pyclass/probes.rs
@@ -68,17 +68,13 @@ impl<T> IsOption<Option<T>> {
 }
 
 #[cfg(test)]
-mod value_of_impl {
-
-    #[macro_export]
-    macro_rules! value_of {
-        ($probe:ident, $ty:ty) => {{
-            #[allow(unused_imports)] // probe trait not used if VALUE is true
-            use crate::impl_::pyclass::Probe as _;
-            $probe::<$ty>::VALUE
-        }};
-    }
+macro_rules! value_of {
+    ($probe:ident, $ty:ty) => {{
+        #[allow(unused_imports)] // probe trait not used if VALUE is true
+        use crate::impl_::pyclass::Probe as _;
+        $probe::<$ty>::VALUE
+    }};
 }
 
 #[cfg(test)]
-pub use crate::value_of; // because `#[macro_export]` puts it in the crate root...
+pub(crate) use value_of;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,6 +411,11 @@ pub use inventory; // Re-exported for `#[pyclass]` and `#[pymethods]` with `mult
 #[macro_use]
 mod tests;
 
+// Macro dependencies, also contains macros exported for use across the codebase and
+// in expanded macros.
+#[doc(hidden)]
+pub mod impl_;
+
 #[macro_use]
 mod internal_tricks;
 mod internal;
@@ -424,8 +429,6 @@ pub mod coroutine;
 mod err;
 pub mod exceptions;
 pub mod ffi;
-#[doc(hidden)]
-pub mod impl_;
 mod instance;
 mod interpreter_lifecycle;
 pub mod marker;

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -315,6 +315,7 @@ use impl_traits;
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::impl_::pyclass::{value_of, IsSend, IsSync};
     use crate::{IntoPyObject, Python};
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -423,14 +424,11 @@ mod test {
 
     #[test]
     fn test_backed_types_send_sync() {
-        fn is_send<T: Send>() {}
-        fn is_sync<T: Sync>() {}
+        assert!(value_of!(IsSend, PyBackedStr));
+        assert!(value_of!(IsSync, PyBackedStr));
 
-        is_send::<PyBackedStr>();
-        is_sync::<PyBackedStr>();
-
-        is_send::<PyBackedBytes>();
-        is_sync::<PyBackedBytes>();
+        assert!(value_of!(IsSend, PyBackedBytes));
+        assert!(value_of!(IsSync, PyBackedBytes));
     }
 
     #[cfg(feature = "py-clone")]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,2 +1,0 @@
-use crate as pyo3;
-include!("../tests/common.rs");


### PR DESCRIPTION
I think this can help with #4523.

Basically allows us to write tests to assert types are send / sync:

```rust
 assert!(value_of!(IsSend, PyBackedStr));
```