### PR TITLE
ci: run 3.14 on PR for the moment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,6 @@ jobs:
       - name: Test python examples and tests
         shell: bash
         run: nox -s test-py
-        continue-on-error: ${{ endsWith(inputs.python-version, '-dev') }}
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/target
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,24 @@ jobs:
                 python-architecture: "x64",
                 rust-target: "x86_64-unknown-linux-gnu",
               }
+          # As we approach 3.14 release date, let's also have testing for 3.14 and 3.14t
+          # on linux
+          - rust: stable
+            python-version: "3.14"
+            platform:
+              {
+                os: "ubuntu-latest",
+                python-architecture: "x64",
+                rust-target: "x86_64-unknown-linux-gnu",
+              }
+          - rust: stable
+            python-version: "3.14t"
+            platform:
+              {
+                os: "ubuntu-latest",
+                python-architecture: "x64",
+                rust-target: "x86_64-unknown-linux-gnu",
+              }
 
   build-full:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}


### PR DESCRIPTION
As we are now at release candidates for 3.14, let's maybe test 3.14 on PRs temporarily?