### PR TITLE
ci: stop running on macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       # installs using setup-python do not work for arm macOS 3.9 and below
-      - if: ${{ !(inputs.os == 'macos-latest' && contains(fromJSON('["3.7", "3.8", "3.9"]'), inputs.python-version)) && inputs.python-architecture == 'x64' }}
+      - if: ${{ !(inputs.os == 'macos-latest' && contains(fromJSON('["3.7", "3.8", "3.9"]'), inputs.python-version) && inputs.python-architecture == 'x64') }}
         name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,14 +328,15 @@ jobs:
 
           # arm64 macOS Python not available on GitHub Actions until 3.10,
           # and 3.7 & 3.8 not available to install from uv, but can backfill 3.9 with x64 from uv
-          - rust: stable
-            python-version: "3.9"
-            platform:
-              {
-                os: "macos-latest",
-                python-architecture: "x64",
-                rust-target: "x86_64-apple-darwin",
-              }
+          # FIXME: setup-uv issue prevents this from working, https://github.com/astral-sh/setup-uv/issues/554
+          # - rust: stable
+          #   python-version: "3.9"
+          #   platform:
+          #     {
+          #       os: "macos-latest",
+          #       python-architecture: "x64",
+          #       rust-target: "x86_64-apple-darwin",
+          #     }
           # arm64 Linux runner is in public preview, so test 3.13 on it
           - rust: stable
             python-version: "3.13"


### PR DESCRIPTION
As per https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down

GitHub is retiring x86_64 macos hardware. I think due to rosetta emulation we can still run tests for x64 macos on aarch64 runners.

Both CPython and Rust are downgrading this platform to tier 2
- https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#demoting-x86-64-apple-darwin-to-tier-2-with-host-tools
- https://discuss.python.org/t/dropping-intel-mac-to-tier-2/102100

Accordingly:
- I changed all `macos-13` jobs to run on `macos-latest` with x64 Python
- I stopped running macos x64 tests on PR, to reduce number of builds
- I also stopped running cross-compilation tests as we now will be testing arm64 -> x86_64 as part of the main build, and macos x86_64 -> arm64 seems like an unusual case we won't need to support (everyone will probably be building from macos arm machines if they're running macos builds now)