### PR TITLE
deprecate `PyObject` type alias

### DIFF
--- a/guide/src/async-await.md
+++ b/guide/src/async-await.md
@@ -13,7 +13,7 @@ use pyo3::prelude::*;
 
 #[pyfunction]
 #[pyo3(signature=(seconds, result=None))]
-async fn sleep(seconds: f64, result: Option<PyObject>) -> Option<PyObject> {
+async fn sleep(seconds: f64, result: Option<Py<PyAny>>) -> Option<Py<PyAny>> {
     let (tx, rx) = oneshot::channel();
     thread::spawn(move || {
         thread::sleep(Duration::from_secs_f64(seconds));

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -413,7 +413,7 @@ impl SubSubClass {
     }
 
     #[staticmethod]
-    fn factory_method(py: Python<'_>, val: usize) -> PyResult<PyObject> {
+    fn factory_method(py: Python<'_>, val: usize) -> PyResult<Py<PyAny>> {
         let base = PyClassInitializer::from(BaseClass::new());
         let sub = base.add_subclass(SubClass { val2: val });
         if val % 2 == 0 {
@@ -748,7 +748,7 @@ To create a constructor which takes a positional class argument, you can combine
 # use pyo3::prelude::*;
 # use pyo3::types::PyType;
 # #[pyclass]
-# struct BaseClass(PyObject);
+# struct BaseClass(Py<PyAny>);
 #
 #[pymethods]
 impl BaseClass {

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -59,7 +59,7 @@ given signatures should be interpreted as follows:
     #[pymethods]
     impl NotHashable {
         #[classattr]
-        const __hash__: Option<PyObject> = None;
+        const __hash__: Option<Py<PyAny>> = None;
     }
     ```
     </details>
@@ -162,7 +162,7 @@ use std::sync::Mutex;
 
 #[pyclass]
 struct MyIterator {
-    iter: Mutex<Box<dyn Iterator<Item = PyObject> + Send>>,
+    iter: Mutex<Box<dyn Iterator<Item = Py<PyAny>> + Send>>,
 }
 
 #[pymethods]
@@ -170,7 +170,7 @@ impl MyIterator {
     fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
         slf
     }
-    fn __next__(slf: PyRefMut<'_, Self>) -> Option<PyObject> {
+    fn __next__(slf: PyRefMut<'_, Self>) -> Option<Py<PyAny>> {
         slf.iter.lock().unwrap().next()
     }
 }
@@ -283,7 +283,7 @@ Use the `#[pyclass(sequence)]` annotation to instruct PyO3 to fill the `sq_lengt
     #[pymethods]
     impl NoContains {
         #[classattr]
-        const __contains__: Option<PyObject> = None;
+        const __contains__: Option<Py<PyAny>> = None;
     }
     ```
     </details>
@@ -439,7 +439,7 @@ use pyo3::gc::PyVisit;
 
 #[pyclass]
 struct ClassWithGCSupport {
-    obj: Option<PyObject>,
+    obj: Option<Py<PyAny>>,
 }
 
 #[pymethods]

--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -1,6 +1,6 @@
 ## Mapping of Rust types to Python types
 
-When writing functions callable from Python (such as a `#[pyfunction]` or in a `#[pymethods]` block), the trait `FromPyObject` is required for function arguments, and `IntoPy<PyObject>` is required for function return values.
+When writing functions callable from Python (such as a `#[pyfunction]` or in a `#[pymethods]` block), the trait `FromPyObject` is required for function arguments, and `IntoPyObject` is required for function return values.
 
 Consult the tables in the following section to find the Rust types provided by PyO3 which implement these traits.
 
@@ -54,7 +54,6 @@ It is also worth remembering the following special types:
 | `Python<'py>`    | A GIL token, used to pass to PyO3 constructors to prove ownership of the GIL. |
 | `Bound<'py, T>`  | A Python object connected to the GIL lifetime. This provides access to most of PyO3's APIs. |
 | `Py<T>`          | A Python object isolated from the GIL lifetime. This can be sent to other threads. |
-| `PyObject`       | An alias for `Py<PyAny>`              |
 | `PyRef<T>`       | A `#[pyclass]` borrowed immutably.    |
 | `PyRefMut<T>`    | A `#[pyclass]` borrowed mutably.      |
 

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -580,7 +580,7 @@ forward the implementation to the inner type.
 
 // newtype tuple structs are implicitly `transparent`
 #[derive(IntoPyObject)]
-struct TransparentTuple(PyObject);
+struct TransparentTuple(Py<PyAny>);
 
 #[derive(IntoPyObject)]
 #[pyo3(transparent)]
@@ -599,7 +599,7 @@ For `enum`s each variant is converted according to the rules for `struct`s above
 
 #[derive(IntoPyObject)]
 enum Enum<'a, 'py, K: Hash + Eq, V> { // enums are supported and convert using the same
-    TransparentTuple(PyObject),       // rules on the variants as the structs above
+    TransparentTuple(Py<PyAny>),       // rules on the variants as the structs above
     #[pyo3(transparent)]
     TransparentStruct { inner: Bound<'py, PyAny> },
     Tuple(&'a str, HashMap<K, V>),
@@ -645,7 +645,7 @@ demonstrated below.
 ```rust,no_run
 # use pyo3::prelude::*;
 # #[allow(dead_code)]
-struct MyPyObjectWrapper(PyObject);
+struct MyPyObjectWrapper(Py<PyAny>);
 
 impl<'py> IntoPyObject<'py> for MyPyObjectWrapper {
     type Target = PyAny; // the Python type
@@ -741,7 +741,6 @@ In the example above we used `BoundObject::into_any` and `BoundObject::unbind` t
 [`FromPyObject`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.FromPyObject.html
 [`IntoPyObject`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObject.html
 [`IntoPyObjectExt`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObjectExt.html
-[`PyObject`]: {{#PYO3_DOCS_URL}}/pyo3/type.PyObject.html
 
 [`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
 [`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRefMut.html

--- a/guide/src/function/signature.md
+++ b/guide/src/function/signature.md
@@ -82,7 +82,7 @@ Arguments of type `Python` must not be part of the signature:
 # use pyo3::prelude::*;
 #[pyfunction]
 #[pyo3(signature = (lambda))]
-pub fn simple_python_bound_function(py: Python<'_>, lambda: PyObject) -> PyResult<()> {
+pub fn simple_python_bound_function(py: Python<'_>, lambda: Py<PyAny>) -> PyResult<()> {
     Ok(())
 }
 ```

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -16,6 +16,14 @@ For this reason we chose to rename these to more modern terminology introduced i
 - `pyo3::prepare_freethreaded_python` is now called `Python::initialize`.
 </details>
 
+### Deprecation of `PyObject` type alias
+<details open>
+<summary><small>Click to expand</small></summary>
+
+The type alias `PyObject` (aka `Py<PyAny>`) is often confused with the identically named FFI definition `pyo3::ffi::PyObject`. For this reason we are deprecating is usage. To migrate simply replace it's usage by the target type `Py<PyAny>`.
+
+</details>
+
 ### Deprecation of `GILProtected`
 <details open>
 <summary><small>Click to expand</small></summary>
@@ -186,6 +194,7 @@ impl ToPyObject for MyPyObjectWrapper {
 
 After:
 ```rust,no_run
+# #![allow(deprecated)]
 # use pyo3::prelude::*;
 # #[allow(dead_code)]
 # struct MyPyObjectWrapper(PyObject);

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -20,7 +20,7 @@ For this reason we chose to rename these to more modern terminology introduced i
 <details open>
 <summary><small>Click to expand</small></summary>
 
-The type alias `PyObject` (aka `Py<PyAny>`) is often confused with the identically named FFI definition `pyo3::ffi::PyObject`. For this reason we are deprecating is usage. To migrate simply replace it's usage by the target type `Py<PyAny>`.
+The type alias `PyObject` (aka `Py<PyAny>`) is often confused with the identically named FFI definition `pyo3::ffi::PyObject`. For this reason we are deprecating its usage. To migrate simply replace its usage by the target type `Py<PyAny>`.
 
 </details>
 

--- a/guide/src/python-from-rust/function-calls.md
+++ b/guide/src/python-from-rust/function-calls.md
@@ -12,9 +12,9 @@ Both of these APIs take `args` and `kwargs` arguments (for positional and keywor
 * [`call1`]({{#PYO3_DOCS_URL}}/pyo3/types/trait.PyAnyMethods.html#tymethod.call1) and [`call_method1`]({{#PYO3_DOCS_URL}}/pyo3/types/trait.PyAnyMethods.html#tymethod.call_method1) to call only with positional `args`.
 * [`call0`]({{#PYO3_DOCS_URL}}/pyo3/types/trait.PyAnyMethods.html#tymethod.call0) and [`call_method0`]({{#PYO3_DOCS_URL}}/pyo3/types/trait.PyAnyMethods.html#tymethod.call_method0) to call with no arguments.
 
-For convenience the [`Py<T>`](../types.md#pyt-and-pyobject) smart pointer also exposes these same six API methods, but needs a `Python` token as an additional first argument to prove the GIL is held.
+For convenience the [`Py<T>`](../types.md#pyt) smart pointer also exposes these same six API methods, but needs a `Python` token as an additional first argument to prove the GIL is held.
 
-The example below calls a Python function behind a `PyObject` (aka `Py<PyAny>`) reference:
+The example below calls a Python function behind a `Py<PyAny>` reference:
 
 ```rust
 use pyo3::prelude::*;

--- a/guide/src/python-typing-hints.md
+++ b/guide/src/python-typing-hints.md
@@ -230,7 +230,7 @@ impl MyClass {
     pub fn __class_getitem__(
         cls: &Bound<'_, PyType>,
         key: &Bound<'_, PyAny>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         /* implementation details */
     }
 }

--- a/guide/src/trait-bounds.md
+++ b/guide/src/trait-bounds.md
@@ -44,7 +44,7 @@ How could we expose this solver to Python thanks to PyO3 ?
 ## Implementation of the trait bounds for the Python class
 
 If a Python class implements the same three methods as the `Model` trait, it seems logical it could be adapted to use the solver.
-However, it is not possible to pass a `PyObject` to it as it does not implement the Rust trait (even if the Python model has the required methods).
+However, it is not possible to pass a `Py<PyAny>` to it as it does not implement the Rust trait (even if the Python model has the required methods).
 
 In order to implement the trait, we must write a wrapper around the calls in Rust to the Python model.
 The method signatures must be the same as the trait, keeping in mind that the Rust trait cannot be changed for the purpose of making the code available in Python.

--- a/guide/src/types.md
+++ b/guide/src/types.md
@@ -22,9 +22,9 @@ The recommendation of when to use each of these smart pointers is as follows:
 
 The sections below also explain these smart pointers in a little more detail.
 
-### `Py<T>` (and `PyObject`)
+### `Py<T>`
 
-[`Py<T>`][Py] is the foundational smart pointer in PyO3's API. The type parameter `T` denotes the type of the Python object. Very frequently this is `PyAny`, meaning any Python object. This is so common that `Py<PyAny>` has a type alias `PyObject`.
+[`Py<T>`][Py] is the foundational smart pointer in PyO3's API. The type parameter `T` denotes the type of the Python object. Very frequently this is `PyAny`, meaning any Python object.
 
 Because `Py<T>` is not bound to [the `'py` lifetime](./python-from-rust.md#the-py-lifetime), it is the type to use when storing a Python object inside a Rust `struct` or `enum` which do not want to have a lifetime parameter. In particular, [`#[pyclass]`][pyclass] types are not permitted to have a lifetime, so `Py<T>` is the correct type to store Python objects inside them.
 
@@ -117,11 +117,11 @@ fn add<'py>(
 # })
 ```
 
-If naming the `'py` lifetime adds unwanted complexity to the function signature, it is also acceptable to return `PyObject` (aka `Py<PyAny>`), which has no lifetime. The cost is instead paid by a slight increase in implementation complexity, as seen by the introduction of a call to [`Bound::unbind`]:
+If naming the `'py` lifetime adds unwanted complexity to the function signature, it is also acceptable to return `Py<PyAny>`, which has no lifetime. The cost is instead paid by a slight increase in implementation complexity, as seen by the introduction of a call to [`Bound::unbind`]:
 
 ```rust
 # use pyo3::prelude::*;
-fn add(left: &Bound<'_, PyAny>, right: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+fn add(left: &Bound<'_, PyAny>, right: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
     let output: Bound<'_, PyAny> = left.add(right)?;
     Ok(output.unbind())
 }

--- a/newsfragments/5325.changed.md
+++ b/newsfragments/5325.changed.md
@@ -1,0 +1,1 @@
+deprecated `PyObject` type alias for `Py<PyAny>`

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1237,7 +1237,7 @@ fn impl_complex_enum_struct_variant_cls(
             complex_enum_variant_field_getter(&variant_cls_type, field_name, field.span, ctx)?;
 
         let field_getter_impl = quote! {
-            fn #field_name(slf: #pyo3_path::PyClassGuard<'_, Self>, py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
+            fn #field_name(slf: #pyo3_path::PyClassGuard<'_, Self>, py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
                 #[allow(unused_imports)]
                 use #pyo3_path::impl_::pyclass::Probe as _;
                 match &*slf.into_super() {
@@ -1313,7 +1313,7 @@ fn impl_complex_enum_tuple_variant_field_getters(
             })
             .collect();
         let field_getter_impl: syn::ImplItemFn = parse_quote! {
-            fn #field_name(slf: #pyo3_path::PyClassGuard<'_, Self>, py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
+            fn #field_name(slf: #pyo3_path::PyClassGuard<'_, Self>, py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
                 #[allow(unused_imports)]
                 use #pyo3_path::impl_::pyclass::Probe as _;
                 match &*slf.into_super() {
@@ -1374,7 +1374,7 @@ fn impl_complex_enum_tuple_variant_getitem(
         .collect();
 
     let mut get_item_method_impl: syn::ImplItemFn = parse_quote! {
-        fn __getitem__(slf: #pyo3_path::PyClassGuard<'_, Self>, py: #pyo3_path::Python<'_>, idx: usize) -> #pyo3_path::PyResult< #pyo3_path::PyObject> {
+        fn __getitem__(slf: #pyo3_path::PyClassGuard<'_, Self>, py: #pyo3_path::Python<'_>, idx: usize) -> #pyo3_path::PyResult< #pyo3_path::Py<#pyo3_path::PyAny>> {
             match idx {
                 #( #match_arms, )*
                 _ => ::std::result::Result::Err(#pyo3_path::exceptions::PyIndexError::new_err("tuple index out of range")),
@@ -1582,7 +1582,7 @@ pub fn gen_complex_enum_variant_attr(
 
     let variant_cls = format_ident!("{}_{}", cls, member);
     let associated_method = quote! {
-        fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
+        fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
             ::std::result::Result::Ok(py.get_type::<#variant_cls>().into_any().unbind())
         }
     };
@@ -1953,7 +1953,7 @@ fn pyclass_richcmp_simple_enum(
             py: #pyo3_path::Python,
             other: &#pyo3_path::Bound<'_, #pyo3_path::PyAny>,
             op: #pyo3_path::pyclass::CompareOp
-        ) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
+        ) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
             #eq
 
             #eq_int
@@ -1987,7 +1987,7 @@ fn pyclass_richcmp(
                 py: #pyo3_path::Python,
                 other: &#pyo3_path::Bound<'_, #pyo3_path::PyAny>,
                 op: #pyo3_path::pyclass::CompareOp
-            ) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
+            ) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
                 let self_val = self;
                 if let ::std::result::Result::Ok(other) = other.cast::<Self>() {
                     let other = &*other.borrow();

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -236,7 +236,7 @@ pub fn gen_py_const(cls: &syn::Type, spec: &ConstSpec, ctx: &Ctx) -> MethodAndMe
     let Ctx { pyo3_path, .. } = ctx;
 
     let associated_method = quote! {
-        fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
+        fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
             #pyo3_path::IntoPyObjectExt::into_py_any(#cls::#member, py)
         }
     };

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -565,7 +565,7 @@ pub(crate) fn impl_py_class_attribute(
     let body = quotes::ok_wrap(fncall, ctx);
 
     let associated_method = quote! {
-        fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::PyObject> {
+        fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
             let function = #cls::#name; // Shadow the method name to avoid #3017
             let result = #body;
             #pyo3_path::impl_::wrap::converter(&result).map_into_pyobject(py, result)

--- a/pytests/src/awaitable.rs
+++ b/pytests/src/awaitable.rs
@@ -11,13 +11,13 @@ use pyo3::prelude::*;
 #[pyclass]
 #[derive(Debug)]
 pub(crate) struct IterAwaitable {
-    result: Option<PyResult<PyObject>>,
+    result: Option<PyResult<Py<PyAny>>>,
 }
 
 #[pymethods]
 impl IterAwaitable {
     #[new]
-    fn new(result: PyObject) -> Self {
+    fn new(result: Py<PyAny>) -> Self {
         IterAwaitable {
             result: Some(Ok(result)),
         }
@@ -31,7 +31,7 @@ impl IterAwaitable {
         pyself
     }
 
-    fn __next__(&mut self, py: Python<'_>) -> PyResult<PyObject> {
+    fn __next__(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         match self.result.take() {
             Some(res) => match res {
                 Ok(v) => Err(PyStopIteration::new_err(v)),
@@ -46,13 +46,13 @@ impl IterAwaitable {
 pub(crate) struct FutureAwaitable {
     #[pyo3(get, set, name = "_asyncio_future_blocking")]
     py_block: bool,
-    result: Option<PyResult<PyObject>>,
+    result: Option<PyResult<Py<PyAny>>>,
 }
 
 #[pymethods]
 impl FutureAwaitable {
     #[new]
-    fn new(result: PyObject) -> Self {
+    fn new(result: Py<PyAny>) -> Self {
         FutureAwaitable {
             py_block: false,
             result: Some(Ok(result)),

--- a/pytests/src/objstore.rs
+++ b/pytests/src/objstore.rs
@@ -3,7 +3,7 @@ use pyo3::prelude::*;
 #[pyclass]
 #[derive(Default)]
 pub struct ObjStore {
-    obj: Vec<PyObject>,
+    obj: Vec<Py<PyAny>>,
 }
 
 #[pymethods]

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -3,7 +3,7 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Bound;
 use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
-use crate::{ffi, FromPyObject, PyAny, PyErr, PyObject, PyResult, Python};
+use crate::{ffi, FromPyObject, Py, PyAny, PyErr, PyResult, Python};
 use std::borrow::Cow;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
@@ -25,7 +25,7 @@ impl<'py> IntoPyObject<'py> for &Path {
 
     #[inline]
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        static PY_PATH: GILOnceCell<PyObject> = GILOnceCell::new();
+        static PY_PATH: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
         PY_PATH
             .import(py, "pathlib", "Path")?
             .call((self.as_os_str(),), None)

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -15,7 +15,7 @@ use crate::{
     exceptions::{PyAttributeError, PyRuntimeError, PyStopIteration},
     panic::PanicException,
     types::{string::PyStringMethods, PyIterator, PyString},
-    Bound, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyErr, PyObject, PyResult, Python,
+    Bound, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyErr, PyResult, Python,
 };
 
 pub(crate) mod cancel;
@@ -31,7 +31,8 @@ pub struct Coroutine {
     name: Option<Py<PyString>>,
     qualname_prefix: Option<&'static str>,
     throw_callback: Option<ThrowCallback>,
-    future: Option<Pin<Box<dyn Future<Output = PyResult<PyObject>> + Send>>>,
+    #[allow(clippy::type_complexity)]
+    future: Option<Pin<Box<dyn Future<Output = PyResult<Py<PyAny>>> + Send>>>,
     waker: Option<Arc<AsyncioWaker>>,
 }
 
@@ -71,7 +72,7 @@ impl Coroutine {
         }
     }
 
-    fn poll(&mut self, py: Python<'_>, throw: Option<PyObject>) -> PyResult<PyObject> {
+    fn poll(&mut self, py: Python<'_>, throw: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
         // raise if the coroutine has already been run to completion
         let future_rs = match self.future {
             Some(ref mut fut) => fut,
@@ -145,11 +146,11 @@ impl Coroutine {
         }
     }
 
-    fn send(&mut self, py: Python<'_>, _value: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+    fn send(&mut self, py: Python<'_>, _value: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
         self.poll(py, None)
     }
 
-    fn throw(&mut self, py: Python<'_>, exc: PyObject) -> PyResult<PyObject> {
+    fn throw(&mut self, py: Python<'_>, exc: Py<PyAny>) -> PyResult<Py<PyAny>> {
         self.poll(py, Some(exc))
     }
 
@@ -163,7 +164,7 @@ impl Coroutine {
         self_
     }
 
-    fn __next__(&mut self, py: Python<'_>) -> PyResult<PyObject> {
+    fn __next__(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         self.poll(py, None)
     }
 }

--- a/src/coroutine/cancel.rs
+++ b/src/coroutine/cancel.rs
@@ -1,4 +1,4 @@
-use crate::{Py, PyAny, PyObject};
+use crate::{Py, PyAny};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -6,7 +6,7 @@ use std::task::{Context, Poll, Waker};
 
 #[derive(Debug, Default)]
 struct Inner {
-    exception: Option<PyObject>,
+    exception: Option<Py<PyAny>>,
     waker: Option<Waker>,
 }
 
@@ -28,7 +28,7 @@ impl CancelHandle {
     }
 
     /// Poll to retrieve the exception thrown in the associated coroutine.
-    pub fn poll_cancelled(&mut self, cx: &mut Context<'_>) -> Poll<PyObject> {
+    pub fn poll_cancelled(&mut self, cx: &mut Context<'_>) -> Poll<Py<PyAny>> {
         let mut inner = self.0.lock().unwrap();
         if let Some(exc) = inner.exception.take() {
             return Poll::Ready(exc);
@@ -43,7 +43,7 @@ impl CancelHandle {
     }
 
     /// Retrieve the exception thrown in the associated coroutine.
-    pub async fn cancelled(&mut self) -> PyObject {
+    pub async fn cancelled(&mut self) -> Py<PyAny> {
         Cancelled(self).await
     }
 
@@ -57,7 +57,7 @@ impl CancelHandle {
 struct Cancelled<'a>(&'a mut CancelHandle);
 
 impl Future for Cancelled<'_> {
-    type Output = PyObject;
+    type Output = Py<PyAny>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         self.0.poll_cancelled(cx)
     }

--- a/src/coroutine/waker.rs
+++ b/src/coroutine/waker.rs
@@ -1,7 +1,7 @@
 use crate::sync::GILOnceCell;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyCFunction;
-use crate::{intern, wrap_pyfunction, Bound, Py, PyAny, PyObject, PyResult, Python};
+use crate::{intern, wrap_pyfunction, Bound, Py, PyAny, PyResult, Python};
 use pyo3_macros::pyfunction;
 use std::sync::Arc;
 use std::task::Wake;
@@ -52,13 +52,13 @@ impl Wake for AsyncioWaker {
 }
 
 struct LoopAndFuture {
-    event_loop: PyObject,
-    future: PyObject,
+    event_loop: Py<PyAny>,
+    future: Py<PyAny>,
 }
 
 impl LoopAndFuture {
     fn new(py: Python<'_>) -> PyResult<Self> {
-        static GET_RUNNING_LOOP: GILOnceCell<PyObject> = GILOnceCell::new();
+        static GET_RUNNING_LOOP: GILOnceCell<Py<PyAny>> = GILOnceCell::new();
         let import = || -> PyResult<_> {
             let module = py.import("asyncio")?;
             Ok(module.getattr("get_running_loop")?.into())

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -9,7 +9,7 @@ use crate::{
     ffi,
     ffi_ptr_ext::FfiPtrExt,
     types::{PyAnyMethods, PyTraceback, PyType},
-    Bound, Py, PyAny, PyErrArguments, PyObject, PyTypeInfo, Python,
+    Bound, Py, PyAny, PyErrArguments, PyTypeInfo, Python,
 };
 
 pub(crate) struct PyErrState {
@@ -263,8 +263,8 @@ impl PyErrStateNormalized {
 }
 
 pub(crate) struct PyErrStateLazyFnOutput {
-    pub(crate) ptype: PyObject,
-    pub(crate) pvalue: PyObject,
+    pub(crate) ptype: Py<PyAny>,
+    pub(crate) pvalue: Py<PyAny>,
 }
 
 pub(crate) type PyErrStateLazyFn =
@@ -368,7 +368,7 @@ fn raise_lazy(py: Python<'_>, lazy: Box<PyErrStateLazyFn>) {
 mod tests {
 
     use crate::{
-        exceptions::PyValueError, sync::GILOnceCell, PyErr, PyErrArguments, PyObject, Python,
+        exceptions::PyValueError, sync::GILOnceCell, Py, PyAny, PyErr, PyErrArguments, Python,
     };
 
     #[test]
@@ -379,7 +379,7 @@ mod tests {
         struct RecursiveArgs;
 
         impl PyErrArguments for RecursiveArgs {
-            fn arguments(self, py: Python<'_>) -> PyObject {
+            fn arguments(self, py: Python<'_>) -> Py<PyAny> {
                 // .value(py) triggers normalization
                 ERR.get(py)
                     .expect("is set just below")
@@ -403,7 +403,7 @@ mod tests {
         struct GILSwitchArgs;
 
         impl PyErrArguments for GILSwitchArgs {
-            fn arguments(self, py: Python<'_>) -> PyObject {
+            fn arguments(self, py: Python<'_>) -> Py<PyAny> {
                 // releasing the GIL potentially allows for other threads to deadlock
                 // with the normalization going on here
                 py.detach(|| {

--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -1,5 +1,5 @@
-use crate::IntoPyObject;
-use crate::{err::PyErrArguments, exceptions, PyErr, PyObject, Python};
+use crate::{err::PyErrArguments, exceptions, PyErr, Python};
+use crate::{IntoPyObject, Py, PyAny};
 use std::io;
 
 /// Convert `PyErr` to `io::Error`
@@ -77,7 +77,7 @@ impl From<io::Error> for PyErr {
 }
 
 impl PyErrArguments for io::Error {
-    fn arguments(self, py: Python<'_>) -> PyObject {
+    fn arguments(self, py: Python<'_>) -> Py<PyAny> {
         //FIXME(icxolu) remove unwrap
         self.to_string()
             .into_pyobject(py)
@@ -94,7 +94,7 @@ impl<W> From<io::IntoInnerError<W>> for PyErr {
 }
 
 impl<W: Send + Sync> PyErrArguments for io::IntoInnerError<W> {
-    fn arguments(self, py: Python<'_>) -> PyObject {
+    fn arguments(self, py: Python<'_>) -> Py<PyAny> {
         self.into_error().arguments(py)
     }
 }
@@ -108,7 +108,7 @@ impl From<std::convert::Infallible> for PyErr {
 macro_rules! impl_to_pyerr {
     ($err: ty, $pyexc: ty) => {
         impl PyErrArguments for $err {
-            fn arguments(self, py: Python<'_>) -> PyObject {
+            fn arguments(self, py: Python<'_>) -> $crate::Py<$crate::PyAny> {
                 // FIXME(icxolu) remove unwrap
                 self.to_string()
                     .into_pyobject(py)

--- a/src/impl_/callback.rs
+++ b/src/impl_/callback.rs
@@ -3,7 +3,7 @@
 use crate::err::{PyErr, PyResult};
 use crate::exceptions::PyOverflowError;
 use crate::ffi::{self, Py_hash_t};
-use crate::{BoundObject, IntoPyObject, PyObject, Python};
+use crate::{BoundObject, IntoPyObject, Py, PyAny, Python};
 use std::ffi::c_int;
 
 /// A type which can be the return type of a python C-API callback
@@ -106,12 +106,12 @@ impl IntoPyCallbackOutput<'_, usize> for usize {
     }
 }
 
-impl<'py, T> IntoPyCallbackOutput<'py, PyObject> for T
+impl<'py, T> IntoPyCallbackOutput<'py, Py<PyAny>> for T
 where
     T: IntoPyObject<'py>,
 {
     #[inline]
-    fn convert(self, py: Python<'py>) -> PyResult<PyObject> {
+    fn convert(self, py: Python<'py>) -> PyResult<Py<PyAny>> {
         self.into_pyobject(py)
             .map(BoundObject::into_any)
             .map(BoundObject::unbind)

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -11,12 +11,11 @@ use crate::types::PyTypeMethods;
 use crate::{
     exceptions::PyRuntimeError,
     ffi,
-    impl_::pyclass::MaybeRuntimePyMethodDef,
-    impl_::pymethods::PyMethodDefType,
+    impl_::{pyclass::MaybeRuntimePyMethodDef, pymethods::PyMethodDefType},
     pyclass::{create_type_object, PyClassTypeObject},
     sync::GILOnceCell,
     types::PyType,
-    Bound, PyClass, PyErr, PyObject, PyResult, Python,
+    Bound, Py, PyAny, PyClass, PyErr, PyResult, Python,
 };
 
 use std::sync::Mutex;
@@ -235,7 +234,7 @@ impl LazyTypeObjectInner {
 fn initialize_tp_dict(
     py: Python<'_>,
     type_object: *mut ffi::PyObject,
-    items: Vec<(&'static CStr, PyObject)>,
+    items: Vec<(&'static CStr, Py<PyAny>)>,
 ) -> PyResult<()> {
     // We hold the GIL: the dictionary update can be considered atomic from
     // the POV of other threads.

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -10,8 +10,8 @@ use crate::pyclass::boolean_struct::False;
 use crate::types::PyType;
 use crate::{
     ffi, Bound, DowncastError, Py, PyAny, PyClass, PyClassGuard, PyClassGuardMut,
-    PyClassInitializer, PyErr, PyObject, PyRef, PyRefMut, PyResult, PyTraverseError, PyTypeCheck,
-    PyVisit, Python,
+    PyClassInitializer, PyErr, PyRef, PyRefMut, PyResult, PyTraverseError, PyTypeCheck, PyVisit,
+    Python,
 };
 use std::ffi::CStr;
 use std::ffi::{c_int, c_void};
@@ -84,7 +84,7 @@ pub enum PyMethodType {
     PyCFunctionFastWithKeywords(ffi::PyCFunctionFastWithKeywords),
 }
 
-pub type PyClassAttributeFactory = for<'p> fn(Python<'p>) -> PyResult<PyObject>;
+pub type PyClassAttributeFactory = for<'p> fn(Python<'p>) -> PyResult<Py<PyAny>>;
 
 // TODO: it would be nice to use CStr in these types, but then the constructors can't be const fn
 // until `CStr::from_bytes_with_nul_unchecked` is const fn.

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -1,6 +1,8 @@
 use std::{convert::Infallible, marker::PhantomData, ops::Deref};
 
-use crate::{ffi, types::PyNone, Bound, IntoPyObject, IntoPyObjectExt, PyObject, PyResult, Python};
+use crate::{
+    ffi, types::PyNone, Bound, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyResult, Python,
+};
 
 /// Used to wrap values in `Option<T>` for default arguments.
 pub trait SomeWrap<T> {
@@ -89,7 +91,7 @@ impl<'py, T: IntoPyObject<'py>, E> IntoPyObjectConverter<Result<T, E>> {
     }
 
     #[inline]
-    pub fn map_into_pyobject(&self, py: Python<'py>, obj: PyResult<T>) -> PyResult<PyObject>
+    pub fn map_into_pyobject(&self, py: Python<'py>, obj: PyResult<T>) -> PyResult<Py<PyAny>>
     where
         T: IntoPyObject<'py>,
     {
@@ -126,7 +128,7 @@ impl<T> UnknownReturnType<T> {
     }
 
     #[inline]
-    pub fn map_into_pyobject<'py>(&self, _: Python<'py>, _: PyResult<T>) -> PyResult<PyObject>
+    pub fn map_into_pyobject<'py>(&self, _: Python<'py>, _: PyResult<T>) -> PyResult<Py<PyAny>>
     where
         T: IntoPyObject<'py>,
     {

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -338,17 +338,17 @@ fn decrement_attach_count() {
 mod tests {
     use super::*;
 
-    use crate::{ffi, types::PyAnyMethods, PyObject, Python};
+    use crate::{ffi, types::PyAnyMethods, Py, PyAny, Python};
     use std::ptr::NonNull;
 
-    fn get_object(py: Python<'_>) -> PyObject {
+    fn get_object(py: Python<'_>) -> Py<PyAny> {
         py.eval(ffi::c_str!("object()"), None, None)
             .unwrap()
             .unbind()
     }
 
     #[cfg(not(pyo3_disable_reference_pool))]
-    fn pool_dec_refs_does_not_contain(obj: &PyObject) -> bool {
+    fn pool_dec_refs_does_not_contain(obj: &Py<PyAny>) -> bool {
         !get_pool()
             .pending_decrefs
             .lock()
@@ -359,7 +359,7 @@ mod tests {
     // With free-threading, threads can empty the POOL at any time, so this
     // function does not test anything meaningful
     #[cfg(not(any(pyo3_disable_reference_pool, Py_GIL_DISABLED)))]
-    fn pool_dec_refs_contains(obj: &PyObject) -> bool {
+    fn pool_dec_refs_contains(obj: &Py<PyAny>) -> bool {
         get_pool()
             .pending_decrefs
             .lock()
@@ -527,7 +527,7 @@ mod tests {
 
                 // Rebuild obj so that it can be dropped
                 unsafe {
-                    PyObject::from_owned_ptr(
+                    Py::<PyAny>::from_owned_ptr(
                         pool.python(),
                         ffi::PyCapsule_GetPointer(capsule, std::ptr::null()) as _,
                     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,9 @@
 pub use crate::class::*;
 pub use crate::conversion::{FromPyObject, IntoPyObject, IntoPyObjectExt};
 pub use crate::err::{DowncastError, DowncastIntoError, PyErr, PyErrArguments, PyResult, ToPyErr};
-pub use crate::instance::{Borrowed, Bound, BoundObject, Py, PyObject};
+#[allow(deprecated)]
+pub use crate::instance::PyObject;
+pub use crate::instance::{Borrowed, Bound, BoundObject, Py};
 #[cfg(not(any(PyPy, GraalPy)))]
 #[allow(deprecated)]
 pub use crate::interpreter_lifecycle::{

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -125,7 +125,7 @@ use crate::types::{
     PyType,
 };
 use crate::version::PythonVersionInfo;
-use crate::{ffi, Bound, PyObject, PyTypeInfo};
+use crate::{ffi, Bound, Py, PyTypeInfo};
 use std::ffi::CStr;
 use std::marker::PhantomData;
 
@@ -689,21 +689,21 @@ impl<'py> Python<'py> {
     /// Gets the Python builtin value `None`.
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]
-    pub fn None(self) -> PyObject {
+    pub fn None(self) -> Py<PyAny> {
         PyNone::get(self).to_owned().into_any().unbind()
     }
 
     /// Gets the Python builtin value `Ellipsis`, or `...`.
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]
-    pub fn Ellipsis(self) -> PyObject {
+    pub fn Ellipsis(self) -> Py<PyAny> {
         PyEllipsis::get(self).to_owned().into_any().unbind()
     }
 
     /// Gets the Python builtin value `NotImplemented`.
     #[allow(non_snake_case)] // the Python keyword starts with uppercase
     #[inline]
-    pub fn NotImplemented(self) -> PyObject {
+    pub fn NotImplemented(self) -> Py<PyAny> {
         PyNotImplemented::get(self).to_owned().into_any().unbind()
     }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -10,7 +10,9 @@
 
 pub use crate::conversion::{FromPyObject, IntoPyObject};
 pub use crate::err::{PyErr, PyResult};
-pub use crate::instance::{Borrowed, Bound, Py, PyObject};
+#[allow(deprecated)]
+pub use crate::instance::PyObject;
+pub use crate::instance::{Borrowed, Bound, Py};
 pub use crate::marker::Python;
 pub use crate::pycell::{PyRef, PyRefMut};
 pub use crate::pyclass_init::PyClassInitializer;

--- a/src/tests/common.rs
+++ b/src/tests/common.rs
@@ -123,8 +123,8 @@ with warnings.catch_warnings(record=True) as warning_record:
     #[cfg(all(feature = "macros", Py_3_8, not(Py_GIL_DISABLED)))]
     #[pyclass(crate = "pyo3")]
     pub struct UnraisableCapture {
-        pub capture: Option<(PyErr, PyObject)>,
-        old_hook: Option<PyObject>,
+        pub capture: Option<(PyErr, Py<PyAny>)>,
+        old_hook: Option<Py<PyAny>>,
     }
 
     #[cfg(all(feature = "macros", Py_3_8, not(Py_GIL_DISABLED)))]

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1850,7 +1850,7 @@ class SimpleClass:
 
         #[pymethods(crate = "crate")]
         impl GetattrFail {
-            fn __getattr__(&self, attr: PyObject) -> PyResult<PyObject> {
+            fn __getattr__(&self, attr: Py<PyAny>) -> PyResult<Py<PyAny>> {
                 Err(PyValueError::new_err(attr))
             }
         }
@@ -2091,7 +2091,7 @@ class SimpleClass:
 
         #[pymethods(crate = "crate")]
         impl DirFail {
-            fn __dir__(&self) -> PyResult<PyObject> {
+            fn __dir__(&self) -> PyResult<Py<PyAny>> {
                 Err(PyValueError::new_err("uh-oh!"))
             }
         }

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -322,7 +322,7 @@ impl<'py> TryFrom<&Bound<'py, PyAny>> for Bound<'py, PyByteArray> {
 #[cfg(test)]
 mod tests {
     use crate::types::{PyAnyMethods, PyByteArray, PyByteArrayMethods};
-    use crate::{exceptions, Bound, PyAny, PyObject, Python};
+    use crate::{exceptions, Bound, Py, PyAny, Python};
 
     #[test]
     fn test_len() {
@@ -378,7 +378,7 @@ mod tests {
             let src = b"Hello Python";
             let bytearray = PyByteArray::new(py, src);
 
-            let ba: PyObject = bytearray.into();
+            let ba: Py<PyAny> = bytearray.into();
             let bytearray = PyByteArray::from(ba.bind(py)).unwrap();
 
             assert_eq!(src, unsafe { bytearray.as_bytes() });

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -9,7 +9,7 @@ use crate::types::{
     any::PyAnyMethods, list::PyListMethods, PyAny, PyCFunction, PyDict, PyList, PyString,
 };
 use crate::{
-    exceptions, ffi, Borrowed, Bound, BoundObject, IntoPyObject, IntoPyObjectExt, PyObject, Python,
+    exceptions, ffi, Borrowed, Bound, BoundObject, IntoPyObject, IntoPyObjectExt, Py, Python,
 };
 #[cfg(all(not(Py_LIMITED_API), Py_GIL_DISABLED))]
 use std::ffi::c_int;
@@ -287,7 +287,7 @@ pub trait PyModuleMethods<'py>: crate::sealed::Sealed {
     /// instead.
     fn add_wrapped<T>(&self, wrapper: &impl Fn(Python<'py>) -> T) -> PyResult<()>
     where
-        T: IntoPyCallbackOutput<'py, PyObject>;
+        T: IntoPyCallbackOutput<'py, Py<PyAny>>;
 
     /// Adds a submodule to a module.
     ///
@@ -502,7 +502,7 @@ impl<'py> PyModuleMethods<'py> for Bound<'py, PyModule> {
 
     fn add_wrapped<T>(&self, wrapper: &impl Fn(Python<'py>) -> T) -> PyResult<()>
     where
-        T: IntoPyCallbackOutput<'py, PyObject>,
+        T: IntoPyCallbackOutput<'py, Py<PyAny>>,
     {
         fn inner(module: &Bound<'_, PyModule>, object: Bound<'_, PyAny>) -> PyResult<()> {
             let name = object.getattr(__name__(module.py()))?;

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -398,10 +398,10 @@ impl PyTypeCheck for PySequence {
 #[cfg(test)]
 mod tests {
     use crate::types::{PyAnyMethods, PyList, PySequence, PySequenceMethods, PyTuple};
-    use crate::{ffi, IntoPyObject, PyObject, Python};
+    use crate::{ffi, IntoPyObject, Py, PyAny, Python};
     use std::ptr;
 
-    fn get_object() -> PyObject {
+    fn get_object() -> Py<PyAny> {
         // Convenience function for getting a single unique object
         Python::attach(|py| {
             let obj = py.eval(ffi::c_str!("object()"), None, None).unwrap();

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -562,7 +562,7 @@ mod tests {
     use pyo3_ffi::c_str;
 
     use super::*;
-    use crate::{exceptions::PyLookupError, types::PyAnyMethods as _, IntoPyObject, PyObject};
+    use crate::{exceptions::PyLookupError, types::PyAnyMethods as _, IntoPyObject};
 
     #[test]
     fn test_to_cow_utf8() {
@@ -606,7 +606,7 @@ mod tests {
     #[test]
     fn test_encode_utf8_surrogate() {
         Python::attach(|py| {
-            let obj: PyObject = py
+            let obj: Py<PyAny> = py
                 .eval(ffi::c_str!(r"'\ud800'"), None, None)
                 .unwrap()
                 .into();

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -527,7 +527,7 @@ impl RichComparisons2 {
         "RC2"
     }
 
-    fn __richcmp__(&self, other: &Bound<'_, PyAny>, op: CompareOp) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Bound<'_, PyAny>, op: CompareOp) -> PyResult<Py<PyAny>> {
         match op {
             CompareOp::Eq => true
                 .into_pyobject(other.py())
@@ -608,7 +608,7 @@ mod return_not_implemented {
             "RC_Self"
         }
 
-        fn __richcmp__(&self, other: PyRef<'_, Self>, _op: CompareOp) -> PyObject {
+        fn __richcmp__(&self, other: PyRef<'_, Self>, _op: CompareOp) -> Py<PyAny> {
             other.py().None()
         }
 

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -207,13 +207,13 @@ struct ClassWithObjectField {
     // It used to be that PyObject was not supported with (get, set)
     // - this test is just ensuring it compiles.
     #[pyo3(get, set)]
-    value: PyObject,
+    value: Py<PyAny>,
 }
 
 #[pymethods]
 impl ClassWithObjectField {
     #[new]
-    fn new(value: PyObject) -> ClassWithObjectField {
+    fn new(value: Py<PyAny>) -> ClassWithObjectField {
         Self { value }
     }
 }
@@ -719,14 +719,14 @@ fn test_unsendable_dict_with_weakref() {
 #[pyclass(generic)]
 struct ClassWithRuntimeParametrization {
     #[pyo3(get, set)]
-    value: PyObject,
+    value: Py<PyAny>,
 }
 
 #[cfg(Py_3_9)]
 #[pymethods]
 impl ClassWithRuntimeParametrization {
     #[new]
-    fn new(value: PyObject) -> ClassWithRuntimeParametrization {
+    fn new(value: Py<PyAny>) -> ClassWithRuntimeParametrization {
         Self { value }
     }
 }

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -302,7 +302,7 @@ fn test_new_returns_bound() {
 #[pyo3::pyclass]
 struct NewClassMethod {
     #[pyo3(get)]
-    cls: pyo3::PyObject,
+    cls: pyo3::Py<PyAny>,
 }
 
 #[pyo3::pymethods]

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -151,7 +151,7 @@ fn data_is_dropped() {
 
 #[pyclass(subclass)]
 struct CycleWithClear {
-    cycle: Option<PyObject>,
+    cycle: Option<Py<PyAny>>,
     _guard: DropGuard,
 }
 
@@ -342,7 +342,7 @@ fn gc_during_borrow() {
 fn traverse_partial() {
     #[pyclass]
     struct PartialTraverse {
-        member: PyObject,
+        member: Py<PyAny>,
     }
 
     impl PartialTraverse {
@@ -378,7 +378,7 @@ fn traverse_partial() {
 fn traverse_panic() {
     #[pyclass]
     struct PanickyTraverse {
-        member: PyObject,
+        member: Py<PyAny>,
     }
 
     impl PanickyTraverse {
@@ -753,7 +753,7 @@ fn test_drop_buffer_during_traversal_without_gil() {
     #[pyclass]
     struct BufferDropDuringTraversal {
         inner: Mutex<Option<(DropGuard, PyBuffer<u8>)>>,
-        cycle: Option<PyObject>,
+        cycle: Option<Py<PyAny>>,
     }
 
     #[pymethods]

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -65,8 +65,8 @@ impl Mapping {
         &self,
         py: Python<'_>,
         key: &str,
-        default: Option<PyObject>,
-    ) -> PyResult<Option<PyObject>> {
+        default: Option<Py<PyAny>>,
+    ) -> PyResult<Option<Py<PyAny>>> {
         match self.index.get(key) {
             Some(value) => Ok(Some(value.into_pyobject(py)?.into_any().unbind())),
             None => Ok(default),

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -289,7 +289,7 @@ impl MethSignature {
         py: Python<'_>,
         a: i32,
         kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         [
             a.into_pyobject(py)?.into_any().into_bound(),
             kwargs.into_pyobject(py)?.into_any().into_bound(),
@@ -304,7 +304,7 @@ impl MethSignature {
         py: Python<'_>,
         a: i32,
         kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         [
             a.into_pyobject(py)?.into_any().into_bound(),
             kwargs.into_pyobject(py)?.into_any().into_bound(),
@@ -334,7 +334,7 @@ impl MethSignature {
         py: Python<'_>,
         args: &Bound<'_, PyTuple>,
         a: i32,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         (args, a)
             .into_pyobject(py)
             .map(BoundObject::into_any)
@@ -357,7 +357,7 @@ impl MethSignature {
         py: Python<'_>,
         a: i32,
         kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         [
             a.into_pyobject(py)?.into_any().into_bound(),
             kwargs.into_pyobject(py)?.into_any().into_bound(),
@@ -922,9 +922,9 @@ fn test_from_sequence() {
 #[pyclass]
 struct r#RawIdents {
     #[pyo3(get, set)]
-    r#type: PyObject,
-    r#subtype: PyObject,
-    r#subsubtype: PyObject,
+    r#type: Py<PyAny>,
+    r#subtype: Py<PyAny>,
+    r#subsubtype: Py<PyAny>,
 }
 
 #[pymethods]
@@ -932,9 +932,9 @@ impl r#RawIdents {
     #[new]
     pub fn r#new(
         r#_py: Python<'_>,
-        r#type: PyObject,
-        r#subtype: PyObject,
-        r#subsubtype: PyObject,
+        r#type: Py<PyAny>,
+        r#subtype: Py<PyAny>,
+        r#subsubtype: Py<PyAny>,
     ) -> Self {
         Self {
             r#type,
@@ -944,36 +944,36 @@ impl r#RawIdents {
     }
 
     #[getter(r#subtype)]
-    pub fn r#get_subtype(&self, py: Python<'_>) -> PyObject {
+    pub fn r#get_subtype(&self, py: Python<'_>) -> Py<PyAny> {
         self.r#subtype.clone_ref(py)
     }
 
     #[setter(r#subtype)]
-    pub fn r#set_subtype(&mut self, r#subtype: PyObject) {
+    pub fn r#set_subtype(&mut self, r#subtype: Py<PyAny>) {
         self.r#subtype = r#subtype;
     }
 
     #[getter]
-    pub fn r#get_subsubtype(&self, py: Python<'_>) -> PyObject {
+    pub fn r#get_subsubtype(&self, py: Python<'_>) -> Py<PyAny> {
         self.r#subsubtype.clone_ref(py)
     }
 
     #[setter]
-    pub fn r#set_subsubtype(&mut self, r#subsubtype: PyObject) {
+    pub fn r#set_subsubtype(&mut self, r#subsubtype: Py<PyAny>) {
         self.r#subsubtype = r#subsubtype;
     }
 
-    pub fn r#__call__(&mut self, r#type: PyObject) {
+    pub fn r#__call__(&mut self, r#type: Py<PyAny>) {
         self.r#type = r#type;
     }
 
     #[staticmethod]
-    pub fn r#static_method(r#type: PyObject) -> PyObject {
+    pub fn r#static_method(r#type: Py<PyAny>) -> Py<PyAny> {
         r#type
     }
 
     #[classmethod]
-    pub fn r#class_method(_: &Bound<'_, PyType>, r#type: PyObject) -> PyObject {
+    pub fn r#class_method(_: &Bound<'_, PyType>, r#type: Py<PyAny>) -> Py<PyAny> {
         r#type
     }
 

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -323,7 +323,7 @@ fn test_module_nesting() {
 // Test that argument parsing specification works for pyfunctions
 
 #[pyfunction(signature = (a=5, *args))]
-fn ext_vararg_fn(py: Python<'_>, a: i32, args: &Bound<'_, PyTuple>) -> PyResult<PyObject> {
+fn ext_vararg_fn(py: Python<'_>, a: i32, args: &Bound<'_, PyTuple>) -> PyResult<Py<PyAny>> {
     [
         a.into_pyobject(py)?.into_any().into_bound(),
         args.as_any().clone(),
@@ -335,7 +335,7 @@ fn ext_vararg_fn(py: Python<'_>, a: i32, args: &Bound<'_, PyTuple>) -> PyResult<
 #[pymodule]
 fn vararg_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     #[pyfn(m, signature = (a=5, *args))]
-    fn int_vararg_fn(py: Python<'_>, a: i32, args: &Bound<'_, PyTuple>) -> PyResult<PyObject> {
+    fn int_vararg_fn(py: Python<'_>, a: i32, args: &Bound<'_, PyTuple>) -> PyResult<Py<PyAny>> {
         ext_vararg_fn(py, a, args)
     }
 

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -21,7 +21,7 @@ struct ExampleClass {
 
 #[pymethods]
 impl ExampleClass {
-    fn __getattr__(&self, py: Python<'_>, attr: &str) -> PyResult<PyObject> {
+    fn __getattr__(&self, py: Python<'_>, attr: &str) -> PyResult<Py<PyAny>> {
         if attr == "special_custom_attr" {
             Ok(self.custom_attr.into_pyobject(py)?.into_any().unbind())
         } else {
@@ -252,7 +252,7 @@ enum SequenceIndex<'py> {
 
 #[pyclass]
 pub struct Sequence {
-    values: Vec<PyObject>,
+    values: Vec<Py<PyAny>>,
 }
 
 #[pymethods]
@@ -261,7 +261,7 @@ impl Sequence {
         self.values.len()
     }
 
-    fn __getitem__(&self, index: SequenceIndex<'_>, py: Python<'_>) -> PyResult<PyObject> {
+    fn __getitem__(&self, index: SequenceIndex<'_>, py: Python<'_>) -> PyResult<Py<PyAny>> {
         match index {
             SequenceIndex::Integer(index) => {
                 let uindex = self.usize_index(index)?;
@@ -275,7 +275,7 @@ impl Sequence {
         }
     }
 
-    fn __setitem__(&mut self, index: isize, value: PyObject) -> PyResult<()> {
+    fn __setitem__(&mut self, index: isize, value: Py<PyAny>) -> PyResult<()> {
         let uindex = self.usize_index(index)?;
         self.values
             .get_mut(uindex)
@@ -293,7 +293,7 @@ impl Sequence {
         }
     }
 
-    fn append(&mut self, value: PyObject) {
+    fn append(&mut self, value: Py<PyAny>) {
         self.values.push(value);
     }
 }
@@ -634,14 +634,14 @@ fn getattr_and_getattribute() {
 #[pyclass]
 #[derive(Debug)]
 struct OnceFuture {
-    future: PyObject,
+    future: Py<PyAny>,
     polled: bool,
 }
 
 #[pymethods]
 impl OnceFuture {
     #[new]
-    fn new(future: PyObject) -> Self {
+    fn new(future: Py<PyAny>) -> Self {
         OnceFuture {
             future,
             polled: false,
@@ -828,7 +828,7 @@ struct NotHashable;
 #[pymethods]
 impl NotHashable {
     #[classattr]
-    const __hash__: Option<PyObject> = None;
+    const __hash__: Option<Py<PyAny>> = None;
 }
 
 #[test]
@@ -850,7 +850,7 @@ struct DefaultedContains;
 
 #[pymethods]
 impl DefaultedContains {
-    fn __iter__(&self, py: Python<'_>) -> PyObject {
+    fn __iter__(&self, py: Python<'_>) -> Py<PyAny> {
         PyList::new(py, ["a", "b", "c"])
             .unwrap()
             .as_any()
@@ -865,7 +865,7 @@ struct NoContains;
 
 #[pymethods]
 impl NoContains {
-    fn __iter__(&self, py: Python<'_>) -> PyObject {
+    fn __iter__(&self, py: Python<'_>) -> Py<PyAny> {
         PyList::new(py, ["a", "b", "c"])
             .unwrap()
             .as_any()
@@ -877,7 +877,7 @@ impl NoContains {
     // Equivalent to the opt-out const form in NotHashable above, just more verbose, to confirm this
     // also works.
     #[classattr]
-    fn __contains__() -> Option<PyObject> {
+    fn __contains__() -> Option<Py<PyAny>> {
         None
     }
 }

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -64,7 +64,7 @@ impl Iter {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<PyObject>> {
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<Py<PyAny>>> {
         let bytes = slf.keys.bind(slf.py()).as_bytes();
         match bytes.get(slf.idx) {
             Some(&b) => {

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -257,7 +257,7 @@ fn test_inplace_repeat() {
 #[pyclass]
 struct AnyObjectList {
     #[pyo3(get, set)]
-    items: Vec<PyObject>,
+    items: Vec<Py<PyAny>>,
 }
 
 #[test]
@@ -372,7 +372,7 @@ fn sequence_length() {
 #[pyclass(generic, sequence)]
 struct GenericList {
     #[pyo3(get, set)]
-    items: Vec<PyObject>,
+    items: Vec<Py<PyAny>>,
 }
 
 #[cfg(Py_3_10)]
@@ -382,7 +382,7 @@ impl GenericList {
         self.items.len()
     }
 
-    fn __getitem__(&self, idx: isize) -> PyResult<PyObject> {
+    fn __getitem__(&self, idx: isize) -> PyResult<Py<PyAny>> {
         match self.items.get(idx as usize) {
             Some(x) => pyo3::Python::attach(|py| Ok(x.clone_ref(py))),
             None => Err(PyIndexError::new_err("Index out of bounds")),
@@ -402,7 +402,7 @@ fn test_generic_both_subscriptions_types() {
             GenericList {
                 items: [1, 2, 3]
                     .iter()
-                    .map(|x| -> PyObject {
+                    .map(|x| -> Py<PyAny> {
                         let x: Result<Bound<'_, PyInt>, Infallible> = x.into_pyobject(py);
                         x.unwrap().into_any().unbind()
                     })

--- a/tests/ui/ambiguous_associated_items.rs
+++ b/tests/ui/ambiguous_associated_items.rs
@@ -10,16 +10,16 @@ pub enum SimpleItems {
 
 #[pyclass]
 pub enum ComplexItems {
-    Error(PyObject),
-    Output(PyObject),
-    Target(PyObject),
+    Error(Py<PyAny>),
+    Output(Py<PyAny>),
+    Target(Py<PyAny>),
 }
 
 #[derive(IntoPyObject)]
 enum DeriveItems {
-    Error(PyObject),
-    Output(PyObject),
-    Target(PyObject),
+    Error(Py<PyAny>),
+    Output(Py<PyAny>),
+    Target(Py<PyAny>),
 }
 
 fn main() {}

--- a/tests/ui/invalid_pyclass_args.rs
+++ b/tests/ui/invalid_pyclass_args.rs
@@ -45,7 +45,7 @@ impl EqOptAndManualRichCmp {
         _py: Python,
         _other: Bound<'_, PyAny>,
         _op: pyo3::pyclass::CompareOp,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         todo!()
     }
 }

--- a/tests/ui/invalid_pyclass_generic.rs
+++ b/tests/ui/invalid_pyclass_generic.rs
@@ -2,8 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyType;
 
 #[pyclass(generic)]
-struct ClassRedefinesClassGetItem {
-}
+struct ClassRedefinesClassGetItem {}
 
 #[pymethods]
 impl ClassRedefinesClassGetItem {
@@ -16,7 +15,7 @@ impl ClassRedefinesClassGetItem {
     pub fn __class_getitem__(
         cls: &Bound<'_, PyType>,
         key: &Bound<'_, PyAny>,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         pyo3::types::PyGenericAlias::new(cls.py(), cls.as_any(), key)
     }
 }

--- a/tests/ui/invalid_pyclass_generic.stderr
+++ b/tests/ui/invalid_pyclass_generic.stderr
@@ -4,7 +4,7 @@ error[E0592]: duplicate definitions with name `__pymethod___class_getitem____`
 4 | #[pyclass(generic)]
   | ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___class_getitem____`
 ...
-8 | #[pymethods]
+7 | #[pymethods]
   | ------------ other definition for `__pymethod___class_getitem____`
   |
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -15,11 +15,11 @@ error[E0592]: duplicate definitions with name `__class_getitem__`
 4  |   #[pyclass(generic)]
    |   ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__class_getitem__`
 ...
-16 | /     pub fn __class_getitem__(
-17 | |         cls: &Bound<'_, PyType>,
-18 | |         key: &Bound<'_, PyAny>,
-19 | |     ) -> PyResult<PyObject> {
-   | |___________________________- other definition for `__class_getitem__`
+15 | /     pub fn __class_getitem__(
+16 | |         cls: &Bound<'_, PyType>,
+17 | |         key: &Bound<'_, PyAny>,
+18 | |     ) -> PyResult<Py<PyAny>> {
+   | |____________________________- other definition for `__class_getitem__`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -35,9 +35,9 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
 4 | #[pyclass(generic)]
   | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
- --> tests/ui/invalid_pyclass_generic.rs:8:1
+ --> tests/ui/invalid_pyclass_generic.rs:7:1
   |
-8 | #[pymethods]
+7 | #[pymethods]
   | ^^^^^^^^^^^^
   = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -53,13 +53,13 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
 4  | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:16:5
+  --> tests/ui/invalid_pyclass_generic.rs:15:5
    |
-16 | /     pub fn __class_getitem__(
-17 | |         cls: &Bound<'_, PyType>,
-18 | |         key: &Bound<'_, PyAny>,
-19 | |     ) -> PyResult<PyObject> {
-   | |___________________________^
+15 | /     pub fn __class_getitem__(
+16 | |         cls: &Bound<'_, PyType>,
+17 | |         key: &Bound<'_, PyAny>,
+18 | |     ) -> PyResult<Py<PyAny>> {
+   | |____________________________^
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
@@ -75,20 +75,20 @@ error[E0034]: multiple applicable items in scope
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/ui/invalid_pyclass_generic.rs:20:9
+  --> tests/ui/invalid_pyclass_generic.rs:19:9
    |
-19 |     ) -> PyResult<PyObject> {
-   |          ------------------ expected `Result<Py<pyo3::PyAny>, PyErr>` because of return type
-20 |         pyo3::types::PyGenericAlias::new(cls.py(), cls.as_any(), key)
+18 |     ) -> PyResult<Py<PyAny>> {
+   |          ------------------- expected `Result<pyo3::Py<pyo3::PyAny>, PyErr>` because of return type
+19 |         pyo3::types::PyGenericAlias::new(cls.py(), cls.as_any(), key)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Py<PyAny>, PyErr>`, found `Result<Bound<'_, PyGenericAlias>, PyErr>`
    |
-   = note: expected enum `Result<Py<pyo3::PyAny>, PyErr>`
+   = note: expected enum `Result<pyo3::Py<pyo3::PyAny>, PyErr>`
               found enum `Result<pyo3::Bound<'_, PyGenericAlias>, PyErr>`
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_generic.rs:16:12
+  --> tests/ui/invalid_pyclass_generic.rs:15:12
    |
-16 |     pub fn __class_getitem__(
+15 |     pub fn __class_getitem__(
    |            ^^^^^^^^^^^^^^^^^ multiple `__pymethod___class_getitem____` found
    |
 note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetItem`
@@ -97,16 +97,16 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
 4  | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:8:1
+  --> tests/ui/invalid_pyclass_generic.rs:7:1
    |
-8  | #[pymethods]
+7  | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_generic.rs:16:12
+  --> tests/ui/invalid_pyclass_generic.rs:15:12
    |
-16 |     pub fn __class_getitem__(
+15 |     pub fn __class_getitem__(
    |            ^^^^^^^^^^^^^^^^^ multiple `__class_getitem__` found
    |
 note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetItem`
@@ -115,19 +115,19 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
 4  | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:16:5
+  --> tests/ui/invalid_pyclass_generic.rs:15:5
    |
-16 | /     pub fn __class_getitem__(
-17 | |         cls: &Bound<'_, PyType>,
-18 | |         key: &Bound<'_, PyAny>,
-19 | |     ) -> PyResult<PyObject> {
-   | |___________________________^
+15 | /     pub fn __class_getitem__(
+16 | |         cls: &Bound<'_, PyType>,
+17 | |         key: &Bound<'_, PyAny>,
+18 | |     ) -> PyResult<Py<PyAny>> {
+   | |____________________________^
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_generic.rs:19:10
+  --> tests/ui/invalid_pyclass_generic.rs:18:10
    |
-19 |     ) -> PyResult<PyObject> {
+18 |     ) -> PyResult<Py<PyAny>> {
    |          ^^^^^^^^ multiple `wrap` found
    |
    = note: candidate #1 is defined in an impl for the type `IntoPyObjectConverter<Result<T, E>>`


### PR DESCRIPTION
This deprecates the `PyObject` type alias for `Py<PyAny>`. This alias is confused easily with `pyo3_ffi::PyObject`, last time https://github.com/PyO3/pyo3/pull/4434#issuecomment-3079193245. 

This may fit nicely with all the other renaming cleanups in 0.26, but I'm also fine postponing until 0.27 if we think it's to much.
