### PR TITLE
Basic introspection of #[derive(FromPyObject)]

### DIFF
--- a/newsfragments/5339.added.md
+++ b/newsfragments/5339.added.md
@@ -1,0 +1,1 @@
+Basic introspection of `#[derive(FromPyObject)]` (no struct fields support yet)

--- a/pyo3-macros-backend/src/derive_attributes.rs
+++ b/pyo3-macros-backend/src/derive_attributes.rs
@@ -44,7 +44,7 @@ impl Parse for ContainerAttribute {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ContainerAttributes {
     /// Treat the Container as a Wrapper, operate directly on its field
     pub transparent: Option<attributes::kw::transparent>,

--- a/pyo3-macros-backend/src/introspection.rs
+++ b/pyo3-macros-backend/src/introspection.rs
@@ -464,13 +464,13 @@ impl<'a> From<IntrospectionNode<'a>> for AttributedIntrospectionNode<'a> {
 }
 
 #[derive(Default)]
-struct ConcatenationBuilder {
+pub struct ConcatenationBuilder {
     elements: Vec<ConcatenationBuilderElement>,
     current_string: String,
 }
 
 impl ConcatenationBuilder {
-    fn push_tokens(&mut self, token_stream: TokenStream) {
+    pub fn push_tokens(&mut self, token_stream: TokenStream) {
         if !self.current_string.is_empty() {
             self.elements.push(ConcatenationBuilderElement::String(take(
                 &mut self.current_string,
@@ -480,7 +480,7 @@ impl ConcatenationBuilder {
             .push(ConcatenationBuilderElement::TokenStream(token_stream));
     }
 
-    fn push_str(&mut self, value: &str) {
+    pub fn push_str(&mut self, value: &str) {
         self.current_string.push_str(value);
     }
 
@@ -502,7 +502,7 @@ impl ConcatenationBuilder {
         self.current_string.push('"');
     }
 
-    fn into_token_stream(self, pyo3_crate_path: &PyO3CratePath) -> TokenStream {
+    pub fn into_token_stream(self, pyo3_crate_path: &PyO3CratePath) -> TokenStream {
         let mut elements = self.elements;
         if !self.current_string.is_empty() {
             elements.push(ConcatenationBuilderElement::String(self.current_string));

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2373,6 +2373,13 @@ impl<'a> PyClassImplsBuilder<'a> {
             }
         };
 
+        let type_name = if cfg!(feature = "experimental-inspect") {
+            let full_name = get_class_python_module_and_name(cls, self.attr);
+            quote! { const TYPE_NAME: &'static str = #full_name; }
+        } else {
+            quote! {}
+        };
+
         Ok(quote! {
             #assertions
 
@@ -2392,6 +2399,8 @@ impl<'a> PyClassImplsBuilder<'a> {
                 type Dict = #dict;
                 type WeakRef = #weakref;
                 type BaseNativeType = #base_nativetype;
+
+                #type_name
 
                 fn items_iter() -> #pyo3_path::impl_::pyclass::PyClassItemsIter {
                     use #pyo3_path::impl_::pyclass::*;

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -5,6 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyType;
 
 #[pyclass]
+#[derive(Clone, Default)]
 struct EmptyClass {}
 
 #[pymethods]
@@ -104,6 +105,7 @@ impl ClassWithDict {
 }
 
 #[pyclass]
+#[derive(Clone)]
 struct ClassWithDecorators {
     attr: usize,
 }
@@ -142,6 +144,24 @@ impl ClassWithDecorators {
     }
 }
 
+#[derive(FromPyObject, IntoPyObject)]
+enum AClass {
+    NewType(EmptyClass),
+    Tuple(EmptyClass, EmptyClass),
+    Struct {
+        f: EmptyClass,
+        #[pyo3(item(42))]
+        g: EmptyClass,
+        #[pyo3(default)]
+        h: EmptyClass,
+    },
+}
+
+#[pyfunction]
+fn map_a_class(cls: AClass) -> AClass {
+    cls
+}
+
 #[pymodule(gil_used = false)]
 pub mod pyclasses {
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
@@ -149,7 +169,7 @@ pub mod pyclasses {
     use super::ClassWithDict;
     #[pymodule_export]
     use super::{
-        AssertingBaseClass, ClassWithDecorators, ClassWithoutConstructor, EmptyClass, PyClassIter,
-        PyClassThreadIter,
+        map_a_class, AssertingBaseClass, ClassWithDecorators, ClassWithoutConstructor, EmptyClass,
+        PyClassIter, PyClassThreadIter,
     };
 }

--- a/pytests/stubs/pyclasses.pyi
+++ b/pytests/stubs/pyclasses.pyi
@@ -1,3 +1,4 @@
+import _typeshed
 import typing
 
 class AssertingBaseClass:
@@ -34,3 +35,7 @@ class PyClassIter:
 class PyClassThreadIter:
     def __new__(cls, /) -> None: ...
     def __next__(self, /) -> int: ...
+
+def map_a_class(
+    cls: EmptyClass | tuple[EmptyClass, EmptyClass] | _typeshed.Incomplete,
+) -> typing.Any: ...

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -407,6 +407,9 @@ impl<T> FromPyObject<'_> for T
 where
     T: PyClass + Clone,
 {
+    #[cfg(feature = "experimental-inspect")]
+    const INPUT_TYPE: &'static str = <T as crate::impl_::pyclass::PyClassImpl>::TYPE_NAME;
+
     fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         let bound = obj.cast::<Self>()?;
         Ok(bound.try_borrow()?.clone())
@@ -417,6 +420,9 @@ impl<'py, T> FromPyObject<'py> for PyRef<'py, T>
 where
     T: PyClass,
 {
+    #[cfg(feature = "experimental-inspect")]
+    const INPUT_TYPE: &'static str = <T as crate::impl_::pyclass::PyClassImpl>::TYPE_NAME;
+
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         obj.cast::<T>()?.try_borrow().map_err(Into::into)
     }
@@ -426,6 +432,9 @@ impl<'py, T> FromPyObject<'py> for PyRefMut<'py, T>
 where
     T: PyClass<Frozen = False>,
 {
+    #[cfg(feature = "experimental-inspect")]
+    const INPUT_TYPE: &'static str = <T as crate::impl_::pyclass::PyClassImpl>::TYPE_NAME;
+
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         obj.cast::<T>()?.try_borrow_mut().map_err(Into::into)
     }

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -219,6 +219,9 @@ pub trait PyClassImpl: Sized + 'static {
     /// from the PyClassDocGenerator` type.
     const DOC: &'static CStr;
 
+    #[cfg(feature = "experimental-inspect")]
+    const TYPE_NAME: &'static str;
+
     fn items_iter() -> PyClassItemsIter;
 
     #[inline]


### PR DESCRIPTION
Struct fields are not supported yet. Doing it cleanly might require a mix of `typing.Protocol` and `typing.TypedDict`