### PR TITLE
add `PyErr::set_traceback`

### DIFF
--- a/newsfragments/5349.added.md
+++ b/newsfragments/5349.added.md
@@ -1,0 +1,1 @@
+Added `PyErr::set_traceback` to set the traceback of an exception object

--- a/newsfragments/5349.changed.md
+++ b/newsfragments/5349.changed.md
@@ -1,0 +1,1 @@
+Changed exception remapping on argument extraction error to use `add_note` for enhancing the error message instead.

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -262,6 +262,11 @@ impl PyErr {
         self.normalized(py).ptraceback(py)
     }
 
+    /// Set the traceback associated with the exception, pass `None` to clear it.
+    pub fn set_traceback<'py>(&self, py: Python<'_>, tb: Option<Bound<'py, PyTraceback>>) {
+        self.normalized(py).set_ptraceback(py, tb)
+    }
+
     /// Gets whether an error is present in the Python interpreter's global state.
     #[inline]
     pub fn occurred(_: Python<'_>) -> bool {

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -278,14 +278,12 @@ pub fn from_py_with_with_default<'a, 'py, T>(
 /// single string.)
 #[cold]
 pub fn argument_extraction_error(py: Python<'_>, arg_name: &str, error: PyErr) -> PyErr {
-    if error.get_type(py).is(py.get_type::<PyTypeError>()) {
-        let remapped_error =
-            PyTypeError::new_err(format!("argument '{}': {}", arg_name, error.value(py)));
-        remapped_error.set_cause(py, error.cause(py));
-        remapped_error
-    } else {
-        error
-    }
+    if let Ok(msg) = crate::py_format!(py, "while processing '{arg_name}'") {
+        let _ = error
+            .value(py)
+            .call_method1(crate::intern!(py, "add_note"), (msg,));
+    };
+    error
 }
 
 /// Unwraps the Option<&PyAny> produced by the FunctionDescription `extract_arguments_` methods.

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -246,7 +246,8 @@ fn test_function_with_custom_conversion_error() {
             custom_conv_func,
             "custom_conv_func(['a'])",
             PyTypeError,
-            "argument 'timestamp': 'list' object is not an instance of 'datetime'"
+            "'list' object is not an instance of 'datetime'",
+            "while processing 'timestamp'"
         );
     });
 }
@@ -318,35 +319,40 @@ fn test_conversion_error() {
             conversion_error,
             "conversion_error(None, None, None, None, None)",
             PyTypeError,
-            "argument 'str_arg': 'None' is not an instance of 'str'"
+            "'None' is not an instance of 'str'",
+            "while processing 'str_arg'"
         );
         py_expect_exception!(
             py,
             conversion_error,
             "conversion_error(100, None, None, None, None)",
             PyTypeError,
-            "argument 'str_arg': 'int' object is not an instance of 'str'"
+            "'int' object is not an instance of 'str'",
+            "while processing 'str_arg'"
         );
         py_expect_exception!(
             py,
             conversion_error,
             "conversion_error('string1', 'string2', None, None, None)",
             PyTypeError,
-            "argument 'int_arg': 'str' object cannot be interpreted as an integer"
+            "'str' object cannot be interpreted as an integer",
+            "while processing 'int_arg'"
         );
         py_expect_exception!(
             py,
             conversion_error,
             "conversion_error('string1', -100, 'string2', None, None)",
             PyTypeError,
-            "argument 'tuple_arg': 'str' object is not an instance of 'tuple'"
+            "'str' object is not an instance of 'tuple'",
+            "while processing 'tuple_arg'"
         );
         py_expect_exception!(
             py,
             conversion_error,
             "conversion_error('string1', -100, ('string2', 10.), 'string3', None)",
             PyTypeError,
-            "argument 'option_arg': 'str' object cannot be interpreted as an integer"
+            "'str' object cannot be interpreted as an integer",
+            "while processing 'option_arg'"
         );
         let exception = py_expect_exception!(
             py,
@@ -358,9 +364,22 @@ class ValueClass:
 conversion_error('string1', -100, ('string2', 10.), None, ValueClass(\"no_expected_type\"))",
             PyTypeError
         );
+        if exception.value(py).hasattr("add_note").unwrap() {
+            assert_eq!(
+                exception
+                    .value(py)
+                    .getattr("__notes__")
+                    .unwrap()
+                    .get_item(0)
+                    .unwrap()
+                    .extract::<std::borrow::Cow<'_, str>>()
+                    .unwrap(),
+                "while processing 'struct_arg'"
+            );
+        }
         assert_eq!(
             extract_traceback(py, exception),
-            "TypeError: argument 'struct_arg': failed to \
+            "TypeError: failed to \
     extract field ValueClass.value: TypeError: 'str' object cannot be interpreted as an integer"
         );
 
@@ -374,9 +393,22 @@ class ValueClass:
 conversion_error('string1', -100, ('string2', 10.), None, ValueClass(-5))",
             PyTypeError
         );
+        if exception.value(py).hasattr("add_note").unwrap() {
+            assert_eq!(
+                exception
+                    .value(py)
+                    .getattr("__notes__")
+                    .unwrap()
+                    .get_item(0)
+                    .unwrap()
+                    .extract::<std::borrow::Cow<'_, str>>()
+                    .unwrap(),
+                "while processing 'struct_arg'"
+            );
+        }
         assert_eq!(
             extract_traceback(py, exception),
-            "TypeError: argument 'struct_arg': failed to \
+            "TypeError: failed to \
     extract field ValueClass.value: OverflowError: can't convert negative int to unsigned"
         );
     });

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -69,10 +69,17 @@ mod inner {
             err
         }};
         // Case3: idents & err_msg
-        ($py:expr, $($val:ident)+, $code:expr, $err:ident, $err_msg:literal) => {{
+        ($py:expr, $($val:ident)+, $code:expr, $err:ident, $err_msg:literal $(,$notes:literal)*) => {{
             let err = py_expect_exception!($py, $($val)+, $code, $err);
             // Suppose that the error message looks like 'TypeError: ~'
             assert_eq!(format!("Py{}", err), concat!(stringify!($err), ": ", $err_msg));
+            if err.value($py).hasattr("add_note").unwrap() {
+                let notes = err.value($py).getattr("__notes__").map(|n| n.cast_into::<pyo3::types::PyList>().unwrap()).unwrap_or_else(|_| pyo3::types::PyList::empty($py));
+                let mut _notes_iter = notes.iter();
+                $(
+                    assert_eq!(_notes_iter.next().as_ref().map(|v| v.extract::<std::borrow::Cow<'_, str>>().unwrap()).as_deref(), Some($notes));
+                )*
+            }
             err
         }};
         // Case4: dict & err_msg


### PR DESCRIPTION
This adds `PyErr::set_traceback` in an attempt to fix #5348. For Python 3.12+ this is pretty straight forward. For <3.12 it's a bit more tricky because we track it ourselves. For now used a `Mutex` to get the interior mutability, but since we always have a `Python` token available (and there is no free-threading in this scenario) it should also be possible to use an `UnsafeCell` and synchronize on the GIL. 

Closes #5348 
