### PR TITLE
use `PyThreadState_GetUnchecked` to test if attached to the interpreter

### DIFF
--- a/pyo3-ffi/src/cpython/pystate.rs
+++ b/pyo3-ffi/src/cpython/pystate.rs
@@ -6,8 +6,6 @@ use std::ffi::c_int;
 // skipped _PyInterpreterState_RequiresIDRef
 // skipped _PyInterpreterState_RequireIDRef
 
-// skipped _PyInterpreterState_GetMainModule
-
 pub type Py_tracefunc = unsafe extern "C" fn(
     obj: *mut PyObject,
     frame: *mut PyFrameObject,
@@ -24,8 +22,8 @@ pub const PyTrace_C_EXCEPTION: c_int = 5;
 pub const PyTrace_C_RETURN: c_int = 6;
 pub const PyTrace_OPCODE: c_int = 7;
 
-// skipped PyTraceInfo
-// skipped CFrame
+// skipped Py_MAX_SCRIPT_PATH_SIZE
+// skipped _PyRemoteDebuggerSupport
 
 /// Private structure used inline in `PyGenObject`
 #[cfg(not(PyPy))]
@@ -44,14 +42,16 @@ pub(crate) struct _PyErr_StackItem {
 // skipped _ts (aka PyThreadState)
 
 extern "C" {
-    // skipped _PyThreadState_Prealloc
-    // skipped _PyThreadState_UncheckedGet
-    // skipped _PyThreadState_GetDict
+
+    #[cfg(Py_3_13)]
+    pub fn PyThreadState_GetUnchecked() -> *mut PyThreadState;
+
+    // skipped PyThreadState_EnterTracing
+    // skipped PyThreadState_LeaveTracing
 
     #[cfg_attr(PyPy, link_name = "PyPyGILState_Check")]
     pub fn PyGILState_Check() -> c_int;
 
-    // skipped _PyGILState_GetInterpreterStateUnsafe
     // skipped _PyThread_CurrentFrames
     // skipped _PyThread_CurrentExceptions
 
@@ -97,17 +97,3 @@ extern "C" {
         eval_frame: _PyFrameEvalFunction,
     );
 }
-
-// skipped _PyInterpreterState_GetConfig
-// skipped _PyInterpreterState_GetConfigCopy
-// skipped _PyInterpreterState_SetConfig
-// skipped _Py_GetConfig
-
-// skipped _PyCrossInterpreterData
-// skipped _PyObject_GetCrossInterpreterData
-// skipped _PyCrossInterpreterData_NewObject
-// skipped _PyCrossInterpreterData_Release
-// skipped _PyObject_CheckCrossInterpreterData
-// skipped crossinterpdatafunc
-// skipped _PyCrossInterpreterData_RegisterClass
-// skipped _PyCrossInterpreterData_Lookup


### PR DESCRIPTION
This is a bit of an experiment based upon the recommendation in PEP 788 to use `PyThreadState_GetUnchecked` as a correct way to check if the thread is currently attached to the interpreter.

- It's avaiable on 3.13 and up, but not yet for the stable ABI
- Annoyingly, during testing I found that it would return a non-null pointer while inside GC traversal, so I had to guard against this.

The really nice thing about this is that it would solve the long-standing problem #1683, at least on versions where this API is available, because we'd be using the interpreter's actual state instead of our guard in PyO3.