### PR TITLE
ci: avoid races in tests asserting warnings

### DIFF
--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -593,7 +593,7 @@ fn py_time_to_naive_time(py_time: &Bound<'_, PyAny>) -> PyResult<NaiveTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{types::PyTuple, BoundObject};
+    use crate::{test_utils::assert_warnings, types::PyTuple, BoundObject};
     use std::{cmp::Ordering, panic};
 
     #[test]
@@ -875,7 +875,6 @@ mod tests {
 
             check_utc("regular", 2014, 5, 6, 7, 8, 9, 999_999, 999_999);
 
-            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 check_utc("leap second", 2014, 5, 6, 7, 8, 59, 1_999_999, 999_999),
@@ -915,7 +914,6 @@ mod tests {
 
             check_fixed_offset("regular", 2014, 5, 6, 7, 8, 9, 999_999, 999_999);
 
-            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 check_fixed_offset("leap second", 2014, 5, 6, 7, 8, 59, 1_999_999, 999_999),
@@ -1101,7 +1099,6 @@ mod tests {
 
             check_time("regular", 3, 5, 7, 999_999, 999_999);
 
-            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 check_time("leap second", 3, 5, 59, 1_999_999, 999_999),
@@ -1163,10 +1160,10 @@ mod tests {
             .unwrap()
     }
 
-    #[cfg(not(any(target_arch = "wasm32", Py_GIL_DISABLED)))]
+    #[cfg(not(any(target_arch = "wasm32")))]
     mod proptests {
         use super::*;
-        use crate::tests::common::CatchWarnings;
+        use crate::test_utils::CatchWarnings;
         use crate::types::IntoPyDict;
         use proptest::prelude::*;
         use std::ffi::CString;

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -317,7 +317,7 @@ fn int_n_bits(long: &Bound<'_, PyInt>) -> PyResult<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::common::generate_unique_module_name;
+    use crate::test_utils::generate_unique_module_name;
     use crate::types::{PyAnyMethods as _, PyDict, PyModule};
     use indoc::indoc;
     use pyo3_ffi::c_str;

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -196,7 +196,7 @@ complex_conversion!(f64);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::common::generate_unique_module_name;
+    use crate::test_utils::generate_unique_module_name;
     use crate::types::PyAnyMethods as _;
     use crate::types::{complex::PyComplexMethods, PyModule};
     use crate::IntoPyObject;

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -853,6 +853,7 @@ mod tests {
     use super::PyErrState;
     use crate::exceptions::{self, PyTypeError, PyValueError};
     use crate::impl_::pyclass::{value_of, IsSend, IsSync};
+    use crate::test_utils::assert_warnings;
     use crate::{ffi, PyErr, PyTypeInfo, Python};
 
     #[test]
@@ -1052,7 +1053,6 @@ mod tests {
             warnings.call_method0("resetwarnings").unwrap();
 
             // First, test the warning is emitted
-            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 { PyErr::warn(py, &cls, ffi::c_str!("I am warning you"), 0).unwrap() },
@@ -1072,7 +1072,6 @@ mod tests {
                 .unwrap();
 
             // This has the wrong module and will not raise, just be emitted
-            #[cfg(not(Py_GIL_DISABLED))]
             assert_warnings!(
                 py,
                 { PyErr::warn(py, &cls, ffi::c_str!("I am warning you"), 0).unwrap() },

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -2171,7 +2171,7 @@ impl Py<PyAny> {
 #[cfg(test)]
 mod tests {
     use super::{Bound, IntoPyObject, Py};
-    use crate::tests::common::generate_unique_module_name;
+    use crate::test_utils::generate_unique_module_name;
     use crate::types::{dict::IntoPyDict, PyAnyMethods, PyCapsule, PyDict, PyString};
     use crate::{ffi, Borrowed, PyAny, PyResult, Python};
     use pyo3_ffi::c_str;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,7 +410,8 @@ pub use inventory; // Re-exported for `#[pyclass]` and `#[pymethods]` with `mult
 /// Tests and helpers which reside inside PyO3's main library. Declared first so that macros
 /// are available in unit tests.
 #[cfg(test)]
-#[macro_use]
+mod test_utils;
+#[cfg(test)]
 mod tests;
 
 // Macro dependencies, also contains macros exported for use across the codebase and

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,6 @@
+// Brings in `test_utils` from the `tests` directory
+//
+// to make that file function (lots of references to `pyo3` within it) need
+// re-bind `crate` as pyo3
+use crate as pyo3;
+include!("../tests/test_utils/mod.rs");

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,10 +1,3 @@
-#[macro_use]
-pub(crate) mod common {
-    #[cfg(not(Py_GIL_DISABLED))]
-    use crate as pyo3;
-    include!("./common.rs");
-}
-
 /// Test macro hygiene - this is in the crate since we won't have
 /// `pyo3` available in the crate root.
 #[cfg(all(test, feature = "macros"))]

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1624,7 +1624,7 @@ mod tests {
     use crate::{
         basic::CompareOp,
         ffi,
-        tests::common::generate_unique_module_name,
+        test_utils::generate_unique_module_name,
         types::{IntoPyDict, PyAny, PyAnyMethods, PyBool, PyInt, PyList, PyModule, PyTypeMethods},
         Bound, BoundObject, IntoPyObject, PyTypeInfo, Python,
     };

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -244,7 +244,7 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
 
 #[cfg(test)]
 mod tests {
-    use crate::tests::common::generate_unique_module_name;
+    use crate::test_utils::generate_unique_module_name;
     use crate::types::{PyAnyMethods, PyBool, PyInt, PyModule, PyTuple, PyType, PyTypeMethods};
     use crate::PyAny;
     use crate::Python;

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -4,8 +4,7 @@ use pyo3::class::basic::CompareOp;
 use pyo3::py_run;
 use pyo3::{prelude::*, BoundObject};
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct UnaryArithmetic {

--- a/tests/test_buffer.rs
+++ b/tests/test_buffer.rs
@@ -9,8 +9,7 @@ use std::{
 };
 
 #[macro_use]
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 enum TestGetBufferError {
     NullShape,

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -13,8 +13,7 @@ use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct TestBufferClass {
@@ -98,8 +97,8 @@ fn test_buffer_referenced() {
 #[test]
 #[cfg(all(Py_3_8, not(Py_GIL_DISABLED)))] // sys.unraisablehook not available until Python 3.8
 fn test_releasebuffer_unraisable_error() {
-    use common::UnraisableCapture;
     use pyo3::exceptions::PyValueError;
+    use test_utils::UnraisableCapture;
 
     #[pyclass]
     struct ReleaseBufferError {}

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -3,8 +3,7 @@
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyfunction]
 fn bytes_pybytes_conversion(bytes: &[u8]) -> &[u8] {

--- a/tests/test_class_attributes.rs
+++ b/tests/test_class_attributes.rs
@@ -3,8 +3,7 @@
 use pyo3::prelude::*;
 use pyo3::py_run;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct Foo {
@@ -154,8 +153,8 @@ fn recursive_class_attributes() {
 #[test]
 #[cfg(all(Py_3_8, not(Py_GIL_DISABLED)))] // sys.unraisablehook not available until Python 3.8
 fn test_fallible_class_attribute() {
-    use common::UnraisableCapture;
     use pyo3::exceptions::PyValueError;
+    use test_utils::UnraisableCapture;
 
     #[pyclass]
     struct BrokenClass;

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -4,8 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyType;
 use pyo3::{py_run, PyClass};
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct EmptyClass {}
@@ -619,12 +618,12 @@ fn access_frozen_class_without_gil() {
 #[cfg(all(Py_3_8, not(Py_GIL_DISABLED)))] // sys.unraisablehook not available until Python 3.8
 #[cfg_attr(target_arch = "wasm32", ignore)]
 fn drop_unsendable_elsewhere() {
-    use common::UnraisableCapture;
     use std::sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     };
     use std::thread::spawn;
+    use test_utils::UnraisableCapture;
 
     #[pyclass(unsendable)]
     struct Unsendable {

--- a/tests/test_class_comparisons.rs
+++ b/tests/test_class_comparisons.rs
@@ -2,8 +2,7 @@
 
 use pyo3::prelude::*;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass(eq)]
 #[derive(Debug, Clone, PartialEq)]

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -3,8 +3,7 @@
 use pyo3::prelude::*;
 
 #[macro_use]
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 #[derive(Clone, Debug, PartialEq)]

--- a/tests/test_class_formatting.rs
+++ b/tests/test_class_formatting.rs
@@ -4,8 +4,7 @@ use pyo3::prelude::*;
 use pyo3::py_run;
 use std::fmt::{Display, Formatter};
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass(eq, str)]
 #[derive(Debug, PartialEq)]

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -14,8 +14,7 @@ use pyo3::{
 #[cfg(target_has_atomic = "64")]
 use std::sync::atomic::{AtomicBool, Ordering};
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 fn handle_windows(test: &str) -> String {
     let set_event_loop_policy = r#"

--- a/tests/test_declarative_module.rs
+++ b/tests/test_declarative_module.rs
@@ -7,8 +7,7 @@ use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use pyo3::sync::OnceLockExt;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 mod some_module {
     use pyo3::create_exception;

--- a/tests/test_default_impls.rs
+++ b/tests/test_default_impls.rs
@@ -2,8 +2,7 @@
 
 use pyo3::prelude::*;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 // Test default generated __repr__.
 #[pyclass(eq, eq_int)]

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -4,8 +4,7 @@ use pyo3::prelude::*;
 use pyo3::py_run;
 use pyo3::types::PyString;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/tests/test_exceptions.rs
+++ b/tests/test_exceptions.rs
@@ -7,8 +7,7 @@ use std::fmt;
 #[cfg(not(target_os = "windows"))]
 use std::fs::File;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyfunction]
 #[cfg(not(target_os = "windows"))]
@@ -101,9 +100,9 @@ fn test_exception_nosegfault() {
 #[test]
 #[cfg(all(Py_3_8, not(Py_GIL_DISABLED)))]
 fn test_write_unraisable() {
-    use common::UnraisableCapture;
     use pyo3::{exceptions::PyRuntimeError, ffi, types::PyNotImplemented};
     use std::ptr;
+    use test_utils::UnraisableCapture;
 
     Python::attach(|py| {
         let capture = UnraisableCapture::install(py);

--- a/tests/test_frompy_intopy_roundtrip.rs
+++ b/tests/test_frompy_intopy_roundtrip.rs
@@ -6,8 +6,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 #[macro_use]
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[derive(Debug, Clone, IntoPyObject, IntoPyObjectRef, FromPyObject)]
 pub struct A<'py> {

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -5,8 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{IntoPyDict, PyDict, PyList, PyString, PyTuple};
 
 #[macro_use]
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 /// Helper function that concatenates the error message from
 /// each error in the traceback into a single string that can

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -13,8 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 use std::sync::{Arc, Mutex};
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass(freelist = 2)]
 struct ClassWithFreelist {}

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -7,8 +7,7 @@ use pyo3::py_run;
 use pyo3::types::PyString;
 use pyo3::types::{IntoPyDict, PyList};
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct ClassWithProperties {

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -6,8 +6,7 @@ use pyo3::py_run;
 use pyo3::ffi;
 use pyo3::types::IntoPyDict;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass(subclass)]
 struct BaseClass {

--- a/tests/test_intopyobject.rs
+++ b/tests/test_intopyobject.rs
@@ -6,8 +6,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 
 #[macro_use]
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[derive(Debug, IntoPyObject)]
 pub struct A<'py> {

--- a/tests/test_macro_docs.rs
+++ b/tests/test_macro_docs.rs
@@ -4,8 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::IntoPyDict;
 
 #[macro_use]
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 /// The MacroDocs class.

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -5,8 +5,7 @@
 use pyo3::prelude::*;
 
 #[macro_use]
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 macro_rules! make_struct_using_macro {
     // Ensure that one doesn't need to fall back on the escape type: tt

--- a/tests/test_mapping.rs
+++ b/tests/test_mapping.rs
@@ -10,8 +10,7 @@ use pyo3::types::PyList;
 use pyo3::types::PyMapping;
 use pyo3::types::PySequence;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass(mapping)]
 struct Mapping {

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -2,7 +2,6 @@
 
 #[cfg(not(Py_LIMITED_API))]
 use pyo3::exceptions::PyWarning;
-#[cfg(not(Py_GIL_DISABLED))]
 use pyo3::exceptions::{PyFutureWarning, PyUserWarning};
 use pyo3::prelude::*;
 use pyo3::py_run;
@@ -11,8 +10,7 @@ use pyo3::types::{IntoPyDict, PyDict, PyList, PySet, PyString, PyTuple, PyType};
 use pyo3::BoundObject;
 use pyo3_macros::pyclass;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct InstanceMethod {
@@ -1223,7 +1221,6 @@ impl UserDefinedWarning {
 }
 
 #[test]
-#[cfg(not(Py_GIL_DISABLED))] // FIXME: enable once `warnings` is thread-safe
 fn test_pymethods_warn() {
     // We do not test #[classattr] nor __traverse__
     // because it doesn't make sense to implement deprecated methods for them.
@@ -1424,7 +1421,6 @@ fn test_pymethods_warn() {
 }
 
 #[test]
-#[cfg(not(Py_GIL_DISABLED))] // FIXME: enable once `warnings` is thread-safe
 fn test_py_methods_multiple_warn() {
     #[pyclass]
     struct MultipleWarnContainer {}

--- a/tests/test_module.rs
+++ b/tests/test_module.rs
@@ -8,8 +8,7 @@ use pyo3::types::{IntoPyDict, PyDict, PyTuple};
 use pyo3::BoundObject;
 use pyo3_ffi::c_str;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct AnonClass {}
@@ -168,7 +167,7 @@ fn test_module_from_code_bound() {
             py,
             c_str!("def add(a,b):\n\treturn a+b"),
             c_str!("adder_mod.py"),
-            &common::generate_unique_module_name("adder_mod"),
+            &test_utils::generate_unique_module_name("adder_mod"),
         )
         .expect("Module code should be loaded");
 

--- a/tests/test_multiple_pymethods.rs
+++ b/tests/test_multiple_pymethods.rs
@@ -4,8 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyType;
 
 #[macro_use]
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct PyClassWithMultiplePyMethods {}

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -6,8 +6,7 @@ use pyo3::{prelude::*, py_run};
 use std::iter;
 use std::sync::Mutex;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct EmptyClass;

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use pyo3::buffer::PyBuffer;
 #[cfg(not(Py_LIMITED_API))]
 use pyo3::exceptions::PyWarning;
-#[cfg(not(Py_GIL_DISABLED))]
 use pyo3::exceptions::{PyFutureWarning, PyUserWarning};
 use pyo3::ffi::c_str;
 use pyo3::prelude::*;
@@ -18,8 +17,7 @@ use pyo3::types::PyFunction;
 use pyo3::types::{self, PyCFunction};
 use pyo3_macros::pyclass;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyfunction(name = "struct")]
 fn struct_function() {}
@@ -669,7 +667,6 @@ impl UserDefinedWarning {
 }
 
 #[test]
-#[cfg(not(Py_GIL_DISABLED))] // FIXME: enable once `warnings` is thread-safe
 fn test_pyfunction_warn() {
     #[pyfunction]
     #[pyo3(warn(message = "this function raises warning"))]
@@ -724,7 +721,6 @@ fn test_pyfunction_warn() {
 }
 
 #[test]
-#[cfg(not(Py_GIL_DISABLED))] // FIXME: enable once `warnings` is thread-safe
 fn test_pyfunction_multiple_warnings() {
     #[pyfunction]
     #[pyo3(warn(message = "this function raises warning"))]

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -5,8 +5,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
 use std::collections::HashMap;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 /// Assumes it's a file reader or so.
 /// Inspired by https://github.com/jothan/cordoba, thanks.

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -6,8 +6,7 @@ use pyo3::{ffi, prelude::*};
 
 use pyo3::py_run;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct ByteSequence {

--- a/tests/test_static_slots.rs
+++ b/tests/test_static_slots.rs
@@ -6,8 +6,7 @@ use pyo3::types::IntoPyDict;
 
 use pyo3::py_run;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct Count5();

--- a/tests/test_string.rs
+++ b/tests/test_string.rs
@@ -2,8 +2,7 @@
 
 use pyo3::prelude::*;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyfunction]
 fn take_str(_s: &str) {}

--- a/tests/test_text_signature.rs
+++ b/tests/test_text_signature.rs
@@ -4,8 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 use pyo3::{types::PyType, wrap_pymodule};
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[test]
 fn class_without_docs_or_signature() {

--- a/tests/test_variable_arguments.rs
+++ b/tests/test_variable_arguments.rs
@@ -3,8 +3,7 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct MyClass {}

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -6,8 +6,7 @@ use pyo3::types::PyTuple;
 
 use std::fmt;
 
-#[path = "../src/tests/common.rs"]
-mod common;
+mod test_utils;
 
 #[pyclass]
 struct MutRefArg {


### PR DESCRIPTION
This PR avoids races in tests which use `warnings.capture_warnings`.

While we had issues with `Py_GIL_DISABLED` with these tests previously, `warnings.capture_warnings`, not being thread-safe of course means that no two rust tests doing such work can be run concurrently, because even GIL switches can lead to tests interleaving and therefore getting bad results.

While we'd not observed these races on the GIL-enabled builds before, I think #5341 has actually gotten stuck due to this behavior because disallowing races to build types has introduced a new synchronization point between test threads.

I fix that problem in this PR by introducing a mutex into the `CatchWarnings` test helper; as long as all tests go through that helper they will be forced to run sequentially for the sensitive block. I had to rearrange the "test utils" file a bit so that it was available at `crate::test_utils` in all places it's used, so that the macros inside it work properly.

As a result, I think I can enable all these tests on the free-threaded build too :)

cc @ngoldbaum 

