### PR TITLE
ci: fix release job token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   release:
+    permissions:
+      id-token: write
+
     runs-on: ubuntu-latest
     environment: release
     steps:


### PR DESCRIPTION
To fix https://github.com/PyO3/pyo3/actions/runs/17323500129/job/49181928639

```
Error: Please ensure the 'id-token' permission is set to 'write' in your workflow.
For more information, see: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings
```
