### PR TITLE
ci: long-lines format, maybe avoid odd rendering in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@ Please consider adding the following to your pull request:
  - docs to all new functions and / or detail in the guide
  - tests for all new or changed functions
 
-PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run ``nox```. See ```nox --list-sessions``` for a list of supported actions.
+PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run `nox`. See `nox --list-sessions` for a list of supported actions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,6 @@ Please consider adding the following to your pull request:
  - docs to all new functions and / or detail in the guide
  - tests for all new or changed functions
 
-PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests
-locally, you can run ```nox```. See ```nox --list-sessions```
-for a list of supported actions.
+PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines.
+To run most of its tests locally, you can run ```nox```.
+See ```nox --list-sessions``` for a list of supported actions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,4 @@ Please consider adding the following to your pull request:
  - docs to all new functions and / or detail in the guide
  - tests for all new or changed functions
 
-PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines.
-To run most of its tests locally, you can run ```nox```.
-See ```nox --list-sessions``` for a list of supported actions.
+PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run ``nox```. See ```nox --list-sessions``` for a list of supported actions.


### PR DESCRIPTION
over at https://github.com/PyO3/pyo3/pull/5375 i'm getting some unexpected rendering from the template.  when editing the file, the preview, both with and without the changes, did not show the anomaly. specifically, the rendered newline between `tests` and `locally`.  but, i saw long-lines style over in `Contributing.md` so i figured i would offer this up as a formatting-tidy-and-maybe-avoid-trivially-irrelevant-unexpected-rendering-issue pr.  i looked and did not see carriage returns or other such anomalies at that point in the source.

<img width="1489" height="520" alt="image" src="https://github.com/user-attachments/assets/5f16ad00-fbf3-4dc6-b1b0-e8e91617257d" />

obviously not a big deal.  handle as you wish of course, including closing to avoid dealing with this triviality.