### PR TITLE
ci: properly invoke nox via uv for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: The version to build
 
 jobs:
   release:
@@ -13,7 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          # The tag to build or the tag received by the tag event
+          ref: ${{ github.event.inputs.version || github.ref }}
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@v6
 
@@ -21,6 +29,6 @@ jobs:
         id: auth
 
       - name: Publish to crates.io
-        run: nox -s publish
+        run: uvx nox -s publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Should fix the release build.

Added a `workflow_dispatch` trigger as suggested by @alex in #5373