### PR TITLE
ci: tidy up some testing on 3.14t

### DIFF
--- a/pytests/pyproject.toml
+++ b/pytests/pyproject.toml
@@ -21,9 +21,8 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "hypothesis>=3.55",
-    "pytest-asyncio>=0.21",
+    "pytest-asyncio>=1.0.0",
     "pytest-benchmark>=3.4",
-    # pinned < 8.1 because https://github.com/CodSpeedHQ/pytest-codspeed/issues/27
-    "pytest>=7,<8.1",
+    "pytest>=7",
     "typing_extensions>=4.0.0"
 ]

--- a/pytests/tests/test_pyclasses.py
+++ b/pytests/tests/test_pyclasses.py
@@ -64,16 +64,15 @@ def test_parallel_iter():
 
     i = pyclasses.PyClassThreadIter()
 
-    def func():
-        next(i)
-
     # the second thread attempts to borrow a reference to the instance's
     # state while the first thread is still sleeping, so we trigger a
     # runtime borrow-check error
     with pytest.raises(RuntimeError, match="Already borrowed"):
         with concurrent.futures.ThreadPoolExecutor(max_workers=2) as tpe:
-            futures = [tpe.submit(func), tpe.submit(func)]
-            [f.result() for f in futures]
+            # should never reach 100 iterations, should error out as soon
+            # as the borrow error occurs
+            for _ in tpe.map(lambda _: next(i), range(100)):
+                pass
 
 
 class AssertingSubClass(pyclasses.AssertingBaseClass):


### PR DESCRIPTION
Closes #5372

I increased the number of iterations on the test, which doesn't add to the total time thanks to the error causing the process to bail out, but it should.

I also unpinned pytest because the linked issue is resolved, and it allows us to pull a newer version of `pytest-asyncio` which no longer emits warnings for deprecations on 3.14.