### PR TITLE
docs: update guide to mention GIL less

### DIFF
--- a/Architecture.md
+++ b/Architecture.md
@@ -99,7 +99,7 @@ Thus, when copying a Rust struct to a Python object, we first allocate `PyClassO
 move `T` into it.
 
 The primary way to interact with Python objects implemented in Rust is through the `Bound<'py, T>` smart pointer.
-By having the `'py` lifetime of the `Python<'py>` token, this ties the lifetime of the `Bound<'py, T>` smart pointer to the lifetime of the GIL and allows PyO3 to call Python APIs at maximum efficiency.
+By having the `'py` lifetime of the `Python<'py>` token, this ties the lifetime of the `Bound<'py, T>` smart pointer to the lifetime which the program is attached to the Python interpreter and allows PyO3 to call Python APIs at maximum efficiency.
 
 `Bound<'py, T>` requires that `T` implements `PyClass`.
 This trait is somewhat complex and derives many traits, but the most important one is `PyTypeInfo`

--- a/Architecture.md
+++ b/Architecture.md
@@ -99,7 +99,7 @@ Thus, when copying a Rust struct to a Python object, we first allocate `PyClassO
 move `T` into it.
 
 The primary way to interact with Python objects implemented in Rust is through the `Bound<'py, T>` smart pointer.
-By having the `'py` lifetime of the `Python<'py>` token, this ties the lifetime of the `Bound<'py, T>` smart pointer to the lifetime which the program is attached to the Python interpreter and allows PyO3 to call Python APIs at maximum efficiency.
+By having the `'py` lifetime of the `Python<'py>` token, this ties the lifetime of the `Bound<'py, T>` smart pointer to the lifetime for which the thread is attached to the Python interpreter and allows PyO3 to call Python APIs at maximum efficiency.
 
 `Bound<'py, T>` requires that `T` implements `PyClass`.
 This trait is somewhat complex and derives many traits, but the most important one is `PyTypeInfo`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,8 @@ generate-import-lib = ["pyo3-ffi/generate-import-lib"]
 # Changes `Python::attach` to automatically initialize the Python interpreter if needed.
 auto-initialize = []
 
-# Enables `Clone`ing references to Python objects `Py<T>` which panics if the GIL is not held.
+# Enables `Clone`ing references to Python objects `Py<T>` which panics if the
+# thread is not attached to the Python interpreter.
 py-clone = []
 
 # Adds `OnceExt` and `MutexExt` implementations to the `parking_lot` types

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -206,7 +206,7 @@ It is often useful to turn a `#[pyclass]` type `T` into a Python object and acce
 Most Python objects do not offer exclusive (`&mut`) access (see the [section on Python's memory model](./python-from-rust.md#pythons-memory-model)). However, Rust structs wrapped as Python objects (called `pyclass` types) often *do* need `&mut` access.
 However, the Rust borrow checker cannot reason about `&mut` references once an object's ownership has been passed to the Python interpreter.
 
-To solve this, PyO3 does borrow checking at runtime using with a scheme very similar to `std::cell::RefCell<T>`. This is known as [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html).
+To solve this, PyO3 does borrow checking at runtime using a scheme very similar to `std::cell::RefCell<T>`. This is known as [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html).
 
 Users who are familiar with `RefCell<T>` can use `Py<T>` and `Bound<'py, T>` just like `RefCell<T>`.
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -203,9 +203,10 @@ mod my_module {
 
 It is often useful to turn a `#[pyclass]` type `T` into a Python object and access it from Rust code. The [`Py<T>`] and [`Bound<'py, T>`] smart pointers are the ways to represent a Python object in PyO3's API. More detail can be found about them [in the Python objects](./types.md#pyo3s-smart-pointers) section of the guide.
 
-Most Python objects do not offer exclusive (`&mut`) access (see the [section on Python's memory model](./python-from-rust.md#pythons-memory-model)). However, Rust structs wrapped as Python objects (called `pyclass` types) often *do* need `&mut` access. Due to the GIL, PyO3 *can* guarantee exclusive access to them.
+Most Python objects do not offer exclusive (`&mut`) access (see the [section on Python's memory model](./python-from-rust.md#pythons-memory-model)). However, Rust structs wrapped as Python objects (called `pyclass` types) often *do* need `&mut` access.
+However, the Rust borrow checker cannot reason about `&mut` references once an object's ownership has been passed to the Python interpreter.
 
-The Rust borrow checker cannot reason about `&mut` references once an object's ownership has been passed to the Python interpreter. This means that borrow checking is done at runtime using with a scheme very similar to `std::cell::RefCell<T>`. This is known as [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html).
+To solve this, PyO3 does borrow checking at runtime using with a scheme very similar to `std::cell::RefCell<T>`. This is known as [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html).
 
 Users who are familiar with `RefCell<T>` can use `Py<T>` and `Bound<'py, T>` just like `RefCell<T>`.
 
@@ -685,7 +686,8 @@ impl MyClass {
 }
 ```
 
-Calls to these methods are protected by the GIL, so both `&self` and `&mut self` can be used.
+Both `&self` and `&mut self` can be used, due to the use of [runtime borrow checking](#bound-and-interior-mutability).
+
 The return type must be `PyResult<T>` or `T` for some `T` that implements `IntoPyObject`;
 the latter is allowed if the method cannot raise Python exceptions.
 
@@ -828,7 +830,12 @@ impl MyClass {
 
 ## Classes as function arguments
 
-Free functions defined using `#[pyfunction]` interact with classes through the same mechanisms as the self parameters of instance methods, i.e. they can take Python-bound references, Python-bound reference wrappers or Python-independent references:
+Class objects can be used as arguments to `#[pyfunction]`s and `#[pymethods]` in the same way as the self parameters of instance methods, i.e. they can be passed as:
+- `Py<T>` or `Bound<'py, T>` smart pointers to the class Python object,
+- `&T` or `&mut T` references to the Rust data contained in the Python object, or
+- `PyRef<T>` and `PyRefMut<T>` reference wrappers.
+
+Examples of each of these below:
 
 ```rust,no_run
 # #![allow(dead_code)]
@@ -838,21 +845,21 @@ struct MyClass {
     my_field: i32,
 }
 
-// Take a reference when the underlying `Bound` is irrelevant.
+// Take a reference to Rust data when the Python object is irrelevant.
 #[pyfunction]
 fn increment_field(my_class: &mut MyClass) {
     my_class.my_field += 1;
 }
 
 // Take a reference wrapper when borrowing should be automatic,
-// but interaction with the underlying `Bound` is desired.
+// but access to the Python object is still needed
 #[pyfunction]
-fn print_field(my_class: PyRef<'_, MyClass>) {
+fn print_field_and_return_me(my_class: PyRef<'_, MyClass>) -> PyRef<'_, MyClass> {
     println!("{}", my_class.my_field);
+    my_class
 }
 
-// Take a reference to the underlying Bound
-// when borrowing needs to be managed manually.
+// Take (a reference to) a Python object smart pointer when borrowing needs to be managed manually.
 #[pyfunction]
 fn increment_then_print_field(my_class: &Bound<'_, MyClass>) {
     my_class.borrow_mut().my_field += 1;
@@ -860,7 +867,8 @@ fn increment_then_print_field(my_class: &Bound<'_, MyClass>) {
     println!("{}", my_class.borrow().my_field);
 }
 
-// Take a GIL-independent reference when you want to store the reference elsewhere.
+// When the Python object smart pointer needs to be stored elsewhere prefer `Py<T>` over `Bound<'py, T>`
+// to avoid the lifetime restrictions.
 #[pyfunction]
 fn print_refcnt(my_class: Py<MyClass>, py: Python<'_>) {
     println!("{}", my_class.get_refcnt(py));

--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -51,9 +51,9 @@ It is also worth remembering the following special types:
 
 | What             | Description                           |
 | ---------------- | ------------------------------------- |
-| `Python<'py>`    | A GIL token, used to pass to PyO3 constructors to prove ownership of the GIL. |
-| `Bound<'py, T>`  | A Python object connected to the GIL lifetime. This provides access to most of PyO3's APIs. |
-| `Py<T>`          | A Python object isolated from the GIL lifetime. This can be sent to other threads. |
+| `Python<'py>`    | A token used to prove attachment to the Python interpreter. |
+| `Bound<'py, T>`  | A Python object with a lifetime which binds it to the attachment to the Python interpreter. This provides access to most of PyO3's APIs. |
+| `Py<T>`          | A Python object not connected to any lifetime of attachment to the Python interpreter. This can be sent to other threads. |
 | `PyRef<T>`       | A `#[pyclass]` borrowed immutably.    |
 | `PyRefMut<T>`    | A `#[pyclass]` borrowed mutably.      |
 

--- a/guide/src/faq.md
+++ b/guide/src/faq.md
@@ -166,7 +166,8 @@ print(f"a: {a}\nb: {b}")
 a: <builtins.Inner object at 0x0000020044FCC670>
 b: <builtins.Inner object at 0x0000020044FCC670>
 ```
-The downside to this approach is that any Rust code working on the `Outer` struct now has to acquire the GIL to do anything with its field.
+The downside to this approach is that any Rust code working on the `Outer` struct potentially has to attach to the Python interpreter to do anything with the `inner` field. (If `Inner` is `#[pyclass(frozen)]` and implements `Sync`, then `Py::get`
+may be used to access the `Inner` contents from `Py<Inner>` without needing to attach to the interpreter.)
 
 ## I want to use the `pyo3` crate re-exported from dependency but the proc-macros fail!
 

--- a/guide/src/features.md
+++ b/guide/src/features.md
@@ -67,11 +67,11 @@ This is a first step towards adding first-class support for generating type anno
 
 ### `py-clone`
 
-This feature was introduced to ease migration. It was found that delayed reference counts cannot be made sound and hence `Clon`ing an instance of `Py<T>` must panic without the GIL being held. To avoid migrations introducing new panics without warning, the `Clone` implementation itself is now gated behind this feature.
+This feature was introduced to ease migration. It was found that delayed reference counting (which PyO3 used historically) could not be made sound and hence `Clone`-ing an instance of `Py<T>` is impossible when not attached to Python interpreter (it will panic). To avoid migrations introducing new panics without warning, the `Clone` implementation itself is now gated behind this feature.
 
 ### `pyo3_disable_reference_pool`
 
-This is a performance-oriented conditional compilation flag, e.g. [set via `$RUSTFLAGS`][set-configuration-options], which disabled the global reference pool and the associated overhead for the crossing the Python-Rust boundary. However, if enabled, `Drop`ping an instance of `Py<T>` without the GIL being held will abort the process.
+This is a performance-oriented conditional compilation flag, e.g. [set via `$RUSTFLAGS`][set-configuration-options], which disabled the global reference pool and the associated overhead for the crossing the Python-Rust boundary. However, if enabled, `Drop`ping an instance of `Py<T>` when not attached to the Python interpreter will abort the process.
 
 ### `macros`
 

--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -1,26 +1,26 @@
 # Supporting Free-Threaded CPython
 
-CPython 3.13 introduces an experimental "free-threaded" build of CPython that
-does not rely on the [global interpreter
-lock](https://docs.python.org/3/glossary.html#term-global-interpreter-lock)
-(often referred to as the GIL) for thread safety. As of version 0.23, PyO3 also
-has preliminary support for building Rust extensions for the free-threaded
-Python build and support for calling into free-threaded Python from Rust.
+CPython 3.14 declared support for the "free-threaded" build of CPython that
+does not rely on the [global interpreter lock](https://docs.python.org/3/glossary.html#term-global-interpreter-lock)
+(often referred to as the GIL) for thread safety. Since version 0.23, PyO3
+supports building Rust extensions for the free-threaded Python build and
+calling into free-threaded Python from Rust.
 
-If you want more background on free-threaded Python in general, see the [what's
-new](https://docs.python.org/3/whatsnew/3.13.html#whatsnew313-free-threaded-cpython)
-entry in the 3.13 release notes, the [free-threading HOWTO
-guide](https://docs.python.org/3/howto/free-threading-extensions.html#freethreading-extensions-howto)
-in the CPython docs, the [extension porting
-guide](https://py-free-threading.github.io/porting-extensions/) in the
-community-maintained Python free-threading guide, and [PEP
-703](https://peps.python.org/pep-0703/), which provides the technical background
+If you want more background on free-threaded Python in general, see the
+[what's new](https://docs.python.org/3/whatsnew/3.13.html#whatsnew313-free-threaded-cpython)
+entry in the 3.13 release notes (when the "free-threaded" build was first added as an experimental
+mode), the
+[free-threading HOWTO guide](https://docs.python.org/3/howto/free-threading-extensions.html#freethreading-extensions-howto)
+in the CPython docs, the
+[extension porting guide](https://py-free-threading.github.io/porting-extensions/)
+in the community-maintained Python free-threading guide, and
+[PEP 703](https://peps.python.org/pep-0703/), which provides the technical background
 for the free-threading implementation in CPython.
 
-In the GIL-enabled build, the global interpreter lock serializes access to the
-Python runtime. The GIL is therefore a fundamental limitation to parallel
-scaling of multithreaded Python workflows, due to [Amdahl's
-law](https://en.wikipedia.org/wiki/Amdahl%27s_law), because any time spent
+In the GIL-enabled build (the only choice before the "free-threaded" build was introduced),
+the global interpreter lock serializes access to the Python runtime. The GIL is therefore
+a fundamental limitation to parallel scaling of multithreaded Python workflows, due to
+[Amdahl's law](https://en.wikipedia.org/wiki/Amdahl%27s_law), because any time spent
 executing a parallel processing task on only one execution context fundamentally
 cannot be sped up using parallelism.
 
@@ -123,9 +123,7 @@ free-threaded build.
 
 The free-threaded interpreter does not have a GIL. Many existing extensions
 providing mutable data structures relied on the GIL to lock Python objects and
-make interior mutability thread-safe.  Historically, PyO3's API was designed
-around the same strong assumptions, but is transitioning towards more general
-APIs applicable for both builds.
+make interior mutability thread-safe.
 
 Calling into the CPython C API is only legal when an OS thread is explicitly
 attached to the interpreter runtime. In the GIL-enabled build, this happens when

--- a/guide/src/python-from-rust.md
+++ b/guide/src/python-from-rust.md
@@ -12,13 +12,14 @@ The subchapters also cover the following topics:
 
 ## The `'py` lifetime
 
-To safely interact with the Python interpreter a Rust thread must have a corresponding Python thread state and hold the [Global Interpreter Lock (GIL)](#the-global-interpreter-lock). PyO3 has a `Python<'py>` token that is used to prove that these conditions
-are met. Its lifetime `'py` is a central part of PyO3's API.
+To safely interact with the Python interpreter a Rust thread must be [attached] to the Python interpreter.
+PyO3 has a `Python<'py>` token that is used to prove that these conditions are met.
+Its lifetime `'py` is a central part of PyO3's API.
 
 The `Python<'py>` token serves three purposes:
 
 * It provides global APIs for the Python interpreter, such as [`py.eval()`][eval] and [`py.import()`][import].
-* It can be passed to functions that require a proof of holding the GIL, such as [`Py::clone_ref`][clone_ref].
+* It can be passed to functions that require a proof of attachment, such as [`Py::clone_ref`][clone_ref].
 * Its lifetime `'py` is used to bind many of PyO3's types to the Python interpreter, such as [`Bound<'py, T>`][Bound].
 
 PyO3's types that are bound to the `'py` lifetime, for example `Bound<'py, T>`, all contain a `Python<'py>` token. This means they have full access to the Python interpreter and offer a complete API for interacting with Python objects.
@@ -27,9 +28,13 @@ Consult [PyO3's API documentation][obtaining-py] to learn how to acquire one of 
 
 ### The Global Interpreter Lock
 
-Concurrent programming in Python is aided by the Global Interpreter Lock (GIL), which ensures that only one Python thread can use the Python interpreter and its API at the same time. This allows it to be used to synchronize code. See the [`pyo3::sync`] module for synchronization tools PyO3 offers that are based on the GIL's guarantees.
+Prior to the introduction of free-threaded Python (first available in 3.13, fully supported in 3.14), the Python interpreter was made thread-safe by the [global interpreter lock].
+This ensured that only one Python thread can use the Python interpreter and its API at the same time.
+Historically, Rust code was able to use the GIL as a synchronization guarantee, but the introduction of free-threaded Python removed this possibility.
 
-Non-Python operations (system calls and native Rust code) can unlock the GIL. See [the section on parallelism](parallelism.md) for how to do that using PyO3's API.
+The [`pyo3::sync`] module offers synchronization tools which abstract over both Python builds.
+
+To enable any parallelism on the GIL-enabled build, and best throughput on the free-threaded build, non-Python operations (system calls and native Rust code) should consider detaching from the Python interpreter to allow other work to proceed. See [the section on parallelism](parallelism.md) for how to do that using PyO3's API.
 
 ## Python's memory model
 
@@ -41,6 +46,8 @@ PyO3's API reflects this by providing [smart pointer][smart-pointers] types, `Py
 
 Because of the lack of exclusive `&mut` references, PyO3's APIs for Python objects, for example [`PyListMethods::append`], use shared references. This is safe because Python objects have internal mechanisms to prevent data races (as of time of writing, the Python GIL).
 
+[attached]: https://docs.python.org/3.14/glossary.html#term-attached-thread-state
+[global interpreter lock]: https://docs.python.org/3/c-api/init.html#thread-state-and-the-global-interpreter-lock
 [smart-pointers]: https://doc.rust-lang.org/book/ch15-00-smart-pointers.html
 [obtaining-py]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#obtaining-a-python-token
 [`pyo3::sync`]: {{#PYO3_DOCS_URL}}/pyo3/sync/index.html

--- a/pyo3-benches/Cargo.toml
+++ b/pyo3-benches/Cargo.toml
@@ -24,6 +24,10 @@ name = "bench_any"
 harness = false
 
 [[bench]]
+name = "bench_attach"
+harness = false
+
+[[bench]]
 name = "bench_call"
 harness = false
 
@@ -45,10 +49,6 @@ harness = false
 
 [[bench]]
 name = "bench_frompyobject"
-harness = false
-
-[[bench]]
-name = "bench_gil"
 harness = false
 
 [[bench]]

--- a/pyo3-benches/benches/bench_attach.rs
+++ b/pyo3-benches/benches/bench_attach.rs
@@ -2,20 +2,20 @@ use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criter
 
 use pyo3::prelude::*;
 
-fn bench_clean_acquire_gil(b: &mut Bencher<'_>) {
+fn bench_clean_attach(b: &mut Bencher<'_>) {
     // Acquiring first GIL will also create a "clean" GILPool, so this measures the Python overhead.
     b.iter(|| Python::attach(|_| {}));
 }
 
-fn bench_dirty_acquire_gil(b: &mut Bencher<'_>) {
+fn bench_dirty_attach(b: &mut Bencher<'_>) {
     let obj = Python::attach(|py| py.None());
     // Drop the returned clone of the object so that the reference pool has work to do.
     b.iter(|| Python::attach(|py| obj.clone_ref(py)));
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    c.bench_function("clean_acquire_gil", bench_clean_acquire_gil);
-    c.bench_function("dirty_acquire_gil", bench_dirty_acquire_gil);
+    c.bench_function("clean_attach", bench_clean_attach);
+    c.bench_function("dirty_attach", bench_dirty_attach);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,9 +1,14 @@
-//! Synchronization mechanisms based on the Python GIL.
+//! Synchronization mechanisms which are aware of the existence of the Python interpreter.
 //!
-//! With the acceptance of [PEP 703] (aka a "freethreaded Python") for Python 3.13, these
-//! are likely to undergo significant developments in the future.
+//! The Python interpreter has multiple "stop the world" situations which may block threads, such as
+//! - The Python global interpreter lock (GIL), on GIL-enabled builds of Python, or
+//! - The Python garbage collector (GC), which pauses attached threads during collection.
 //!
-//! [PEP 703]: https://peps.python.org/pep-703/
+//! To avoid deadlocks in these cases, threads should take care to be detached from the Python interpreter
+//! before performing operations which might block waiting for other threads attached to the Python
+//! interpreter.
+//!
+//! This module provides synchronization primitives which are able to synchronize under these conditions.
 use crate::{
     internal::state::SuspendAttach,
     sealed::Sealed,


### PR DESCRIPTION
Following on from all the work we did in PyO3 0.26 to move API names to be less dependent on the GIL, this takes a first pass at documentation (particularly in the guide) to do similar.

There's probably more to do, however this is all I had time for today, and I figure it's probably easier for reviewers to have not too much of this in one go.