### PR TITLE
Fetch type name dynamically on cast errors instead of using `PyTypeInfo::NAME`

### DIFF
--- a/newsfragments/5387.added.md
+++ b/newsfragments/5387.added.md
@@ -1,0 +1,1 @@
+Add `PyTypeCheck::classinfo_object` that returns an object that can be used as parameter in `isinstance` or `issubclass`

--- a/newsfragments/5387.changed.md
+++ b/newsfragments/5387.changed.md
@@ -1,1 +1,1 @@
-Fetch type name dynamically on cast errors instead of using `PyTypeInfo::NAME`
+Fetch type name dynamically on cast errors instead of using `PyTypeCheck::NAME`

--- a/newsfragments/5387.changed.md
+++ b/newsfragments/5387.changed.md
@@ -1,1 +1,2 @@
-Fetch type name dynamically on cast errors instead of using `PyTypeCheck::NAME`
+- Fetch type name dynamically on cast errors instead of using `PyTypeCheck::NAME`
+- Deprecate `PyTypeCheck::NAME`, please `TypeTypeCheck::classinfo_object` to get the expected type and format it at runtime.

--- a/newsfragments/5387.changed.md
+++ b/newsfragments/5387.changed.md
@@ -1,0 +1,1 @@
+Fetch type name dynamically on cast errors instead of using `PyTypeInfo::NAME`

--- a/newsfragments/5387.removed.md
+++ b/newsfragments/5387.removed.md
@@ -1,1 +1,0 @@
-removed `PyTypeCheck::NAME`

--- a/newsfragments/5387.removed.md
+++ b/newsfragments/5387.removed.md
@@ -1,0 +1,1 @@
+removed `PyTypeCheck::NAME`

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -692,11 +692,11 @@ mod tests {
             let none = py.None().into_bound(py);
             assert_eq!(
                 none.extract::<Duration>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyDelta'"
+                "TypeError: 'NoneType' object cannot be converted to 'timedelta'"
             );
             assert_eq!(
                 none.extract::<FixedOffset>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyTzInfo'"
+                "TypeError: 'NoneType' object cannot be converted to 'tzinfo'"
             );
             assert_eq!(
                 none.extract::<Utc>().unwrap_err().to_string(),
@@ -704,25 +704,25 @@ mod tests {
             );
             assert_eq!(
                 none.extract::<NaiveTime>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyTime'"
+                "TypeError: 'NoneType' object cannot be converted to 'time'"
             );
             assert_eq!(
                 none.extract::<NaiveDate>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyDate'"
+                "TypeError: 'NoneType' object cannot be converted to 'date'"
             );
             assert_eq!(
                 none.extract::<NaiveDateTime>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyDateTime'"
+                "TypeError: 'NoneType' object cannot be converted to 'datetime'"
             );
             assert_eq!(
                 none.extract::<DateTime<Utc>>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyDateTime'"
+                "TypeError: 'NoneType' object cannot be converted to 'datetime'"
             );
             assert_eq!(
                 none.extract::<DateTime<FixedOffset>>()
                     .unwrap_err()
                     .to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyDateTime'"
+                "TypeError: 'NoneType' object cannot be converted to 'datetime'"
             );
         });
     }

--- a/src/conversions/jiff.rs
+++ b/src/conversions/jiff.rs
@@ -553,31 +553,31 @@ mod tests {
             let none = py.None().into_bound(py);
             assert_eq!(
                 none.extract::<Span>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyDelta'"
+                "TypeError: 'NoneType' object cannot be converted to 'timedelta'"
             );
             assert_eq!(
                 none.extract::<Offset>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyTzInfo'"
+                "TypeError: 'NoneType' object cannot be converted to 'tzinfo'"
             );
             assert_eq!(
                 none.extract::<TimeZone>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyTzInfo'"
+                "TypeError: 'NoneType' object cannot be converted to 'tzinfo'"
             );
             assert_eq!(
                 none.extract::<Time>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyTime'"
+                "TypeError: 'NoneType' object cannot be converted to 'time'"
             );
             assert_eq!(
                 none.extract::<Date>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyDate'"
+                "TypeError: 'NoneType' object cannot be converted to 'date'"
             );
             assert_eq!(
                 none.extract::<DateTime>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyDateTime'"
+                "TypeError: 'NoneType' object cannot be converted to 'datetime'"
             );
             assert_eq!(
                 none.extract::<Zoned>().unwrap_err().to_string(),
-                "TypeError: 'NoneType' object cannot be converted to 'PyDateTime'"
+                "TypeError: 'NoneType' object cannot be converted to 'datetime'"
             );
         });
     }

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -22,7 +22,8 @@ use crate::inspect::types::TypeInfo;
 use crate::types::any::PyAnyMethods;
 use crate::types::{PySequence, PyString};
 use crate::{
-    err::DowncastError, ffi, Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python,
+    err::DowncastError, ffi, Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, PyTypeInfo,
+    Python,
 };
 use smallvec::{Array, SmallVec};
 
@@ -102,7 +103,11 @@ where
         if ffi::PySequence_Check(obj.as_ptr()) != 0 {
             obj.cast_unchecked::<PySequence>()
         } else {
-            return Err(DowncastError::new_from_borrowed(obj, "Sequence").into());
+            return Err(DowncastError::new_from_type(
+                obj,
+                PySequence::type_object(obj.py()).into_any(),
+            )
+            .into());
         }
     };
 

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -1,7 +1,7 @@
 use crate::conversion::{FromPyObjectOwned, IntoPyObject};
 use crate::types::any::PyAnyMethods;
 use crate::types::PySequence;
-use crate::{err::DowncastError, ffi, FromPyObject, PyAny, PyResult, Python};
+use crate::{err::DowncastError, ffi, FromPyObject, PyAny, PyResult, PyTypeInfo, Python};
 use crate::{exceptions, Borrowed, Bound, PyErr};
 
 impl<'py, T, const N: usize> IntoPyObject<'py> for [T; N]
@@ -57,7 +57,11 @@ where
         if ffi::PySequence_Check(obj.as_ptr()) != 0 {
             obj.cast_unchecked::<PySequence>()
         } else {
-            return Err(DowncastError::new_from_borrowed(obj, "Sequence").into());
+            return Err(DowncastError::new_from_type(
+                obj,
+                PySequence::type_object(obj.py()).into_any(),
+            )
+            .into());
         }
     };
     let seq_len = seq.len()?;

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -111,6 +111,7 @@ impl<'py> DowncastIntoError<'py> {
 }
 
 // Helper to store either a concrete type or a type name
+#[derive(Debug)]
 enum TypeNameOrValue<'py> {
     Name(Cow<'static, str>),
     Value(Bound<'py, PyType>),
@@ -843,12 +844,6 @@ fn display_downcast_error(
         from.get_type().qualname().map_err(|_| std::fmt::Error)?,
         to
     )
-}
-
-impl std::fmt::Debug for TypeNameOrValue<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self, f)
-    }
 }
 
 impl std::fmt::Display for TypeNameOrValue<'_> {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -167,7 +167,10 @@ impl<'py, T> Bound<'py, T> {
                 // Safety: type_check is responsible for ensuring that the type is correct
                 Ok(unsafe { any.cast_unchecked() })
             } else {
-                Err(DowncastError::new(any, U::NAME))
+                Err(DowncastError::new_from_type(
+                    any.as_borrowed(),
+                    U::classinfo_object(any.py()),
+                ))
             }
         }
 
@@ -211,7 +214,8 @@ impl<'py, T> Bound<'py, T> {
                 // Safety: type_check is responsible for ensuring that the type is correct
                 Ok(unsafe { any.cast_into_unchecked() })
             } else {
-                Err(DowncastIntoError::new(any, U::NAME))
+                let to = U::classinfo_object(any.py());
+                Err(DowncastIntoError::new_from_type(any, to))
             }
         }
 
@@ -266,7 +270,7 @@ impl<'py, T> Bound<'py, T> {
             } else {
                 Err(DowncastError::new_from_type(
                     any.as_borrowed(),
-                    U::type_object(any.py()),
+                    U::type_object(any.py()).into_any(),
                 ))
             }
         }
@@ -289,7 +293,7 @@ impl<'py, T> Bound<'py, T> {
                 // Safety: is_exact_instance_of is responsible for ensuring that the type is correct
                 Ok(unsafe { any.cast_into_unchecked() })
             } else {
-                let to = U::type_object(any.py());
+                let to = U::type_object(any.py()).into_any();
                 Err(DowncastIntoError::new_from_type(any, to))
             }
         }
@@ -1048,7 +1052,10 @@ impl<'a, 'py> Borrowed<'a, 'py, PyAny> {
             // Safety: type_check is responsible for ensuring that the type is correct
             Ok(unsafe { self.cast_unchecked() })
         } else {
-            Err(DowncastError::new_from_borrowed(self, T::NAME))
+            Err(DowncastError::new_from_type(
+                self,
+                T::classinfo_object(self.py()),
+            ))
         }
     }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -12,6 +12,7 @@ use crate::{
     PyRefMut, PyTypeInfo, Python,
 };
 use crate::{internal::state, PyTypeCheck};
+use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
@@ -264,7 +265,7 @@ impl<'py, T> Bound<'py, T> {
                 // Safety: is_exact_instance_of is responsible for ensuring that the type is correct
                 Ok(unsafe { any.cast_unchecked() })
             } else {
-                Err(DowncastError::new(any, U::NAME))
+                Err(DowncastError::new(any, type_name::<U>(any.py())))
             }
         }
 
@@ -286,7 +287,8 @@ impl<'py, T> Bound<'py, T> {
                 // Safety: is_exact_instance_of is responsible for ensuring that the type is correct
                 Ok(unsafe { any.cast_into_unchecked() })
             } else {
-                Err(DowncastIntoError::new(any, U::NAME))
+                let to = type_name::<U>(any.py());
+                Err(DowncastIntoError::new(any, to))
             }
         }
 
@@ -2229,6 +2231,13 @@ impl<T> Py<T> {
     pub unsafe fn cast_bound_unchecked<'py, U>(&self, py: Python<'py>) -> &Bound<'py, U> {
         unsafe { self.bind(py).cast_unchecked() }
     }
+}
+
+fn type_name<T: PyTypeInfo>(py: Python<'_>) -> Cow<'static, str> {
+    T::type_object(py)
+        .name()
+        .map(|name| Cow::Owned(name.to_string_lossy().into_owned()))
+        .unwrap_or(Cow::Borrowed("unknown type"))
 }
 
 #[cfg(test)]

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -86,6 +86,13 @@ pub unsafe trait PyTypeInfo: Sized {
 
 /// Implemented by types which can be used as a concrete Python type inside `Py<T>` smart pointers.
 pub trait PyTypeCheck {
+    /// Name of self. This is used in error messages, for example.
+    #[deprecated(
+        since = "0.27.0",
+        note = "Use ::classinfo_object() instead and format the type name at runtime. Note that using built-in cast features is often better than manual PyTypeCheck usage."
+    )]
+    const NAME: &'static str;
+
     /// Provides the full python type of the allowed values.
     #[cfg(feature = "experimental-inspect")]
     const PYTHON_TYPE: &'static str;
@@ -105,6 +112,8 @@ impl<T> PyTypeCheck for T
 where
     T: PyTypeInfo,
 {
+    const NAME: &'static str = T::NAME;
+
     #[cfg(feature = "experimental-inspect")]
     const PYTHON_TYPE: &'static str = <T as PyTypeInfo>::PYTHON_TYPE;
 

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -354,7 +354,7 @@ def fibonacci(target):
 
             assert_eq!(
                 downcaster.borrow_mut(py).failed.take().unwrap().to_string(),
-                "TypeError: 'MySequence' object cannot be converted to 'PyIterator'"
+                "TypeError: 'MySequence' object cannot be converted to 'Iterator'"
             );
         });
     }

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -387,7 +387,11 @@ where
         if ffi::PySequence_Check(obj.as_ptr()) != 0 {
             obj.cast_unchecked::<PySequence>()
         } else {
-            return Err(DowncastError::new_from_borrowed(obj, "Sequence").into());
+            return Err(DowncastError::new_from_type(
+                obj,
+                PySequence::type_object(obj.py()).into_any(),
+            )
+            .into());
         }
     };
 

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -19,6 +19,8 @@ pyobject_native_type_named!(PyWeakref);
 // pyobject_native_type_sized!(PyWeakref, ffi::PyWeakReference);
 
 impl PyTypeCheck for PyWeakref {
+    const NAME: &'static str = "weakref";
+
     #[cfg(feature = "experimental-inspect")]
     const PYTHON_TYPE: &'static str =
         "weakref.ProxyType | weakref.CallableProxyType | weakref.ReferenceType";

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -1,8 +1,10 @@
 use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::sync::PyOnceLock;
 use crate::type_object::{PyTypeCheck, PyTypeInfo};
 use crate::types::any::PyAny;
-use crate::{ffi, Bound};
+use crate::types::{PyTuple, PyWeakrefProxy, PyWeakrefReference};
+use crate::{ffi, Bound, Py, Python};
 
 /// Represents any Python `weakref` reference.
 ///
@@ -17,12 +19,33 @@ pyobject_native_type_named!(PyWeakref);
 // pyobject_native_type_sized!(PyWeakref, ffi::PyWeakReference);
 
 impl PyTypeCheck for PyWeakref {
-    const NAME: &'static str = "weakref";
     #[cfg(feature = "experimental-inspect")]
-    const PYTHON_TYPE: &'static str = "weakref.ProxyTypes";
+    const PYTHON_TYPE: &'static str =
+        "weakref.ProxyType | weakref.CallableProxyType | weakref.ReferenceType";
 
+    #[inline]
     fn type_check(object: &Bound<'_, PyAny>) -> bool {
         unsafe { ffi::PyWeakref_Check(object.as_ptr()) > 0 }
+    }
+
+    fn classinfo_object(py: Python<'_>) -> Bound<'_, PyAny> {
+        static TYPE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+        TYPE.get_or_try_init(py, || {
+            PyResult::Ok(
+                PyTuple::new(
+                    py,
+                    [
+                        PyWeakrefProxy::classinfo_object(py),
+                        PyWeakrefReference::classinfo_object(py),
+                    ],
+                )?
+                .into_any()
+                .unbind(),
+            )
+        })
+        .unwrap()
+        .bind(py)
+        .clone()
     }
 }
 
@@ -351,7 +374,8 @@ mod tests {
 
     mod python_class {
         use super::*;
-        use crate::ffi;
+        use crate::types::PyInt;
+        use crate::{ffi, PyTypeCheck};
         use crate::{py_result_ext::PyResultExt, types::PyType};
         use std::ptr;
 
@@ -475,6 +499,42 @@ mod tests {
 
             inner(new_reference, true)?;
             inner(new_proxy, false)
+        }
+
+        #[test]
+        fn test_classinfo_object() -> PyResult<()> {
+            fn inner(
+                create_reference: impl for<'py> FnOnce(
+                    &Bound<'py, PyAny>,
+                )
+                    -> PyResult<Bound<'py, PyWeakref>>,
+            ) -> PyResult<()> {
+                Python::attach(|py| {
+                    let class = get_type(py)?;
+                    let object = class.call0()?;
+                    let reference = create_reference(&object)?;
+                    let t = PyWeakref::classinfo_object(py);
+                    assert!(reference.is_instance(&t)?);
+                    Ok(())
+                })
+            }
+
+            inner(new_reference)?;
+            inner(new_proxy)
+        }
+
+        #[test]
+        fn test_classinfo_downcast_error() -> PyResult<()> {
+            Python::attach(|py| {
+                assert_eq!(
+                    PyInt::new(py, 1)
+                        .cast_into::<PyWeakref>()
+                        .unwrap_err()
+                        .to_string(),
+                    "'int' object cannot be converted to 'ProxyType | CallableProxyType | ReferenceType'"
+                );
+                Ok(())
+            })
         }
     }
 

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -525,6 +525,7 @@ mod tests {
             inner(new_proxy)
         }
 
+        #[cfg(Py_3_10)] // Name is different in 3.9
         #[test]
         fn test_classinfo_downcast_error() -> PyResult<()> {
             Python::attach(|py| {

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -21,6 +21,8 @@ pyobject_native_type_named!(PyWeakrefProxy);
 // pyobject_native_type_sized!(PyWeakrefProxy, ffi::PyWeakReference);
 
 impl PyTypeCheck for PyWeakrefProxy {
+    const NAME: &'static str = "weakref.ProxyTypes";
+
     #[cfg(feature = "experimental-inspect")]
     const PYTHON_TYPE: &'static str = "weakref.ProxyType | weakref.CallableProxyType";
 

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -433,6 +433,7 @@ mod tests {
                 })
             }
 
+            #[cfg(Py_3_10)] // Name is different in 3.9
             #[test]
             fn test_classinfo_downcast_error() -> PyResult<()> {
                 Python::attach(|py| {

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -297,7 +297,7 @@ fn test_transparent_struct_error_message() {
         assert_eq!(
             extract_traceback(py,tup.unwrap_err()),
             "TypeError: failed to extract field B.test: TypeError: \'int\' object cannot be converted \
-         to \'PyString\'"
+         to \'str\'"
         );
     });
 }
@@ -311,7 +311,7 @@ fn test_tuple_struct_error_message() {
         assert_eq!(
             extract_traceback(py, tup.unwrap_err()),
             "TypeError: failed to extract field Tuple.0: TypeError: \'int\' object cannot be \
-         converted to \'PyString\'"
+         converted to \'str\'"
         );
     });
 }
@@ -325,7 +325,7 @@ fn test_transparent_tuple_error_message() {
         assert_eq!(
             extract_traceback(py, tup.unwrap_err()),
             "TypeError: failed to extract field TransparentTuple.0: TypeError: 'int' object \
-         cannot be converted to 'PyString'",
+         cannot be converted to 'str'",
         );
     });
 }
@@ -540,10 +540,10 @@ fn test_enum_error() {
             err.to_string(),
             "\
 TypeError: failed to extract enum Foo ('TupleVar | StructVar | TransparentTuple | TransparentStructVar | StructVarGetAttrArg | StructWithGetItem | StructWithGetItemArg')
-- variant TupleVar (TupleVar): TypeError: 'dict' object cannot be converted to 'PyTuple'
+- variant TupleVar (TupleVar): TypeError: 'dict' object cannot be converted to 'tuple'
 - variant StructVar (StructVar): AttributeError: 'dict' object has no attribute 'test'
 - variant TransparentTuple (TransparentTuple): TypeError: failed to extract field Foo::TransparentTuple.0, caused by TypeError: 'dict' object cannot be interpreted as an integer
-- variant TransparentStructVar (TransparentStructVar): TypeError: failed to extract field Foo::TransparentStructVar.a, caused by TypeError: 'dict' object cannot be converted to 'PyString'
+- variant TransparentStructVar (TransparentStructVar): TypeError: failed to extract field Foo::TransparentStructVar.a, caused by TypeError: 'dict' object cannot be converted to 'str'
 - variant StructVarGetAttrArg (StructVarGetAttrArg): AttributeError: 'dict' object has no attribute 'bla'
 - variant StructWithGetItem (StructWithGetItem): KeyError: 'a'
 - variant StructWithGetItemArg (StructWithGetItemArg): KeyError: 'foo'"
@@ -558,7 +558,7 @@ TypeError: failed to extract enum Foo ('TupleVar | StructVar | TransparentTuple 
 - variant TupleVar (TupleVar): ValueError: expected tuple of length 2, but got tuple of length 0
 - variant StructVar (StructVar): AttributeError: 'tuple' object has no attribute 'test'
 - variant TransparentTuple (TransparentTuple): TypeError: failed to extract field Foo::TransparentTuple.0, caused by TypeError: 'tuple' object cannot be interpreted as an integer
-- variant TransparentStructVar (TransparentStructVar): TypeError: failed to extract field Foo::TransparentStructVar.a, caused by TypeError: 'tuple' object cannot be converted to 'PyString'
+- variant TransparentStructVar (TransparentStructVar): TypeError: failed to extract field Foo::TransparentStructVar.a, caused by TypeError: 'tuple' object cannot be converted to 'str'
 - variant StructVarGetAttrArg (StructVarGetAttrArg): AttributeError: 'tuple' object has no attribute 'bla'
 - variant StructWithGetItem (StructWithGetItem): TypeError: tuple indices must be integers or slices, not str
 - variant StructWithGetItemArg (StructWithGetItemArg): TypeError: tuple indices must be integers or slices, not str"
@@ -612,7 +612,7 @@ fn test_err_rename() {
             f.unwrap_err().to_string(),
             "\
 TypeError: failed to extract enum Bar ('str | uint | int')
-- variant A (str): TypeError: failed to extract field Bar::A.0, caused by TypeError: 'dict' object cannot be converted to 'PyString'
+- variant A (str): TypeError: failed to extract field Bar::A.0, caused by TypeError: 'dict' object cannot be converted to 'str'
 - variant B (uint): TypeError: failed to extract field Bar::B.0, caused by TypeError: 'dict' object cannot be interpreted as an integer
 - variant C (int): TypeError: failed to extract field Bar::C.0, caused by TypeError: 'dict' object cannot be interpreted as an integer"
         );

--- a/tests/test_pyerr_debug_unformattable.rs
+++ b/tests/test_pyerr_debug_unformattable.rs
@@ -17,7 +17,7 @@ fn err_debug_unformattable() {
     Python::attach(|py| {
         // PyTracebackMethods::format uses io.StringIO. Mock it out to trigger a
         // formatting failure:
-        // TypeError: 'Mock' object cannot be converted to 'PyString'
+        // TypeError: 'Mock' object cannot be converted to 'str'
         let err = py
             .run(
                 ffi::c_str!(

--- a/tests/test_pyfunction.rs
+++ b/tests/test_pyfunction.rs
@@ -221,7 +221,7 @@ fn test_function_with_custom_conversion_error() {
             custom_conv_func,
             "custom_conv_func(['a'])",
             PyTypeError,
-            "argument 'timestamp': 'list' object cannot be converted to 'PyDateTime'"
+            "argument 'timestamp': 'list' object cannot be converted to 'datetime'"
         );
     });
 }
@@ -293,14 +293,14 @@ fn test_conversion_error() {
             conversion_error,
             "conversion_error(None, None, None, None, None)",
             PyTypeError,
-            "argument 'str_arg': 'NoneType' object cannot be converted to 'PyString'"
+            "argument 'str_arg': 'NoneType' object cannot be converted to 'str'"
         );
         py_expect_exception!(
             py,
             conversion_error,
             "conversion_error(100, None, None, None, None)",
             PyTypeError,
-            "argument 'str_arg': 'int' object cannot be converted to 'PyString'"
+            "argument 'str_arg': 'int' object cannot be converted to 'str'"
         );
         py_expect_exception!(
             py,
@@ -314,7 +314,7 @@ fn test_conversion_error() {
             conversion_error,
             "conversion_error('string1', -100, 'string2', None, None)",
             PyTypeError,
-            "argument 'tuple_arg': 'str' object cannot be converted to 'PyTuple'"
+            "argument 'tuple_arg': 'str' object cannot be converted to 'tuple'"
         );
         py_expect_exception!(
             py,


### PR DESCRIPTION
Introduce `PyTypeCheck::classinfo_object` that returns an object compatible with `instance` and make use of it.
Remove `PyTypeCheck::NAME`