### PR TITLE
ci: relax pytests `pytest-asyncio` requirement

### DIFF
--- a/pytests/pyproject.toml
+++ b/pytests/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "hypothesis>=3.55",
-    "pytest-asyncio>=1.0.0",
+    "pytest-asyncio>=0.21,<2",
     "pytest-benchmark>=3.4",
     "pytest>=7",
     "typing_extensions>=4.0.0"


### PR DESCRIPTION
I noticed that merge-queue builds on Python 3.7 and 3.8 are failing due to dependency resolution problems from #5378. This relaxes the bounds to keep CI happy on these versions.

https://github.com/PyO3/pyo3/actions/runs/17414304652/job/49438896635#step:19:497

Is it intended that these are silently failing without the queue also failing?

cc @davidhewitt 