### PR TITLE
ci: use semver checks only to compare current PR changes

### DIFF
--- a/.github/actions/fetch-merge-base/action.yml
+++ b/.github/actions/fetch-merge-base/action.yml
@@ -1,0 +1,31 @@
+name: 'Fetch Merge Base'
+description: 'Fetches the merge base between two branches, deepening the git checkout until complete'
+inputs:
+  base_ref:
+    description: 'The base branch reference'
+    required: true
+  head_ref:
+    description: 'The head branch reference'
+    required: true
+outputs:
+  merge_base:
+    description: 'The merge base commit SHA'
+    value: ${{ steps.fetch_merge_base.outputs.merge_base }}
+runs:
+  using: "composite"
+  steps:
+  - name: Fetch Merge Base
+    id: fetch_merge_base
+    shell: bash
+    run: |
+      # fetch the merge commit between the PR base and head
+      git fetch -u --progress --depth=1 origin "+$BASE_REF:$BASE_REF" "+$HEAD_REF:$HEAD_REF"
+      while [ -z "$(git merge-base "$BASE_REF" "$HEAD_REF")" ]; do
+        git fetch -u -q --deepen="10" origin "$BASE_REF" "$HEAD_REF";
+      done
+
+      MERGE_BASE=$(git merge-base "$BASE_REF" "$HEAD_REF")
+      echo "merge_base=$MERGE_BASE" >> $GITHUB_OUTPUT
+    env:
+      BASE_REF: "${{ inputs.base_ref }}"
+      HEAD_REF: "${{ inputs.head_ref }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo MSRV=`python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["rust-version"])'` >> $GITHUB_OUTPUT
 
   semver-checks:
-    if: github.ref != 'refs/heads/main'
+    if: github.event == 'pull_request'
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +56,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - name: Fetch merge base
+        id: fetch_merge_base
+        uses: ./.github/actions/fetch-merge-base
+        with:
+          base_ref: "refs/heads/${{ github.event.pull_request.base.ref }}"
+          head_ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
       - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          baseline-rev: ${{ steps.fetch_merge_base.outputs.merge_base }}
 
   check-msrv:
     needs: [fmt, resolve]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo MSRV=`python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["rust-version"])'` >> $GITHUB_OUTPUT
 
   semver-checks:
-    if: github.event == 'pull_request'
+    if: github.event_name == 'pull_request'
     needs: [fmt]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coverage-pr-base.yml
+++ b/.github/workflows/coverage-pr-base.yml
@@ -16,27 +16,18 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
+      - name: Fetch merge base
+        id: fetch_merge_base
+        uses: ./.github/actions/fetch-merge-base
+        with:
+          base_ref: "refs/heads/${{ github.event.pull_request.base.ref }}"
+          head_ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
       - name: Set PR base on codecov
         run: |
-          # fetch the merge commit between the PR base and head
-          git fetch -u --progress --depth=1 origin "+$BASE_REF:$BASE_REF" "+$MERGE_REF:$MERGE_REF"
-          while [ -z "$(git merge-base "$BASE_REF" "$MERGE_REF")" ]; do
-            git fetch -u -q --deepen="10" origin "$BASE_REF" "$MERGE_REF";
-          done
-
-          MERGE_BASE=$(git merge-base "$BASE_REF" "$MERGE_REF")
-          echo "Merge base: $MERGE_BASE"
-
-          # inform codecov about the merge base
           pip install codecov-cli
           codecovcli pr-base-picking \
-            --base-sha $MERGE_BASE \
+            --base-sha ${{ steps.fetch_merge_base.outputs.merge_base }} \
             --pr ${{ github.event.number }} \
             --slug PyO3/pyo3 \
             --token ${{ secrets.CODECOV_TOKEN }} \
             --service github
-        env:
-          # Don't put these in bash, because we don't want the expansion to
-          # risk code execution
-          BASE_REF: "refs/heads/${{ github.event.pull_request.base.ref }}"
-          MERGE_REF: "refs/pull/${{ github.event.pull_request.number }}/merge"


### PR DESCRIPTION
After merging #4390 the `semver-checks` job is unsuprisingly failing. I think rather than bumping the version in the `Cargo.toml` to silence it, let's try running only on the current PR changes so that if we make other breaking changes we can identify & judge them.