### PR TITLE
ci: cache more in `benches.yml`

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -31,6 +31,7 @@ jobs:
             .
             pyo3-benches
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
+          cache-all-crates: 'true'
 
       - uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
We run the benchmarks on every PR and push to `main`. The job takes ~15 mins due to building release artifacts.

There's quite a few crates which experience cache misses, and with #5399 I think we have space to add a bit more cache usage here. Building release artifacts is also more costly.

Will merge immediately as a trivial CI edit, hopefully an improvement else will revert later.