### PR TITLE
simplify `extract_argument` code for `&T: PyClass`

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1407,32 +1407,6 @@ impl pyo3::PyClass for MyClass {
     type Frozen = pyo3::pyclass::boolean_struct::False;
 }
 
-impl<'a, 'holder, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false> for &'holder MyClass
-{
-    type Holder = ::std::option::Option<pyo3::PyClassGuard<'a, MyClass>>;
-    type Error = pyo3::PyErr;
-    #[cfg(feature = "experimental-inspect")]
-    const INPUT_TYPE: &'static str = "MyClass";
-
-    #[inline]
-    fn extract(obj: &'a pyo3::Bound<'py, PyAny>, holder: &'holder mut Self::Holder) -> pyo3::PyResult<Self> {
-        pyo3::impl_::extract_argument::extract_pyclass_ref(obj, holder)
-    }
-}
-
-impl<'a, 'holder, 'py> pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false> for &'holder mut MyClass
-{
-    type Holder = ::std::option::Option<pyo3::PyClassGuardMut<'a, MyClass>>;
-    type Error = pyo3::PyErr;
-    #[cfg(feature = "experimental-inspect")]
-    const INPUT_TYPE: &'static str = "MyClass";
-
-    #[inline]
-    fn extract(obj: &'a pyo3::Bound<'py, PyAny>, holder: &'holder mut Self::Holder) -> pyo3::PyResult<Self> {
-        pyo3::impl_::extract_argument::extract_pyclass_ref_mut(obj, holder)
-    }
-}
-
 impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
     const IS_BASETYPE: bool = false;
     const IS_SUBCLASS: bool = false;

--- a/pyo3-macros-backend/src/introspection.rs
+++ b/pyo3-macros-backend/src/introspection.rs
@@ -390,7 +390,7 @@ impl IntrospectionNode<'_> {
                 nullable,
             } => {
                 content.push_str("\"");
-                content.push_tokens(quote! { <#rust_type as #pyo3_crate_path::impl_::extract_argument::PyFunctionArgument<false>>::INPUT_TYPE.as_bytes() });
+                content.push_tokens(quote! { <#rust_type as #pyo3_crate_path::impl_::extract_argument::PyFunctionArgument<_>>::INPUT_TYPE.as_bytes() });
                 if nullable {
                     content.push_str(" | None");
                 }

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -196,9 +196,17 @@ fn impl_arg_param(
         }
         FnArg::VarArgs(arg) => {
             let holder = holders.push_holder(arg.name.span());
+            let ty = arg.ty.clone().elide_lifetimes();
             let name_str = arg.name.to_string();
             quote_spanned! { arg.name.span() =>
-                #pyo3_path::impl_::extract_argument::extract_argument::<_, false>(
+                #pyo3_path::impl_::extract_argument::extract_argument::<
+                    _,
+                    {
+                        #[allow(unused_imports)]
+                        use #pyo3_path::impl_::pyclass::Probe as _;
+                        #pyo3_path::impl_::pyclass::IsFromPyObject::<#ty>::VALUE
+                    }
+                >(
                     &_args,
                     &mut #holder,
                     #name_str
@@ -207,9 +215,17 @@ fn impl_arg_param(
         }
         FnArg::KwArgs(arg) => {
             let holder = holders.push_holder(arg.name.span());
+            let ty = arg.ty.clone().elide_lifetimes();
             let name_str = arg.name.to_string();
             quote_spanned! { arg.name.span() =>
-                #pyo3_path::impl_::extract_argument::extract_optional_argument::<_, false>(
+                #pyo3_path::impl_::extract_argument::extract_optional_argument::<
+                    _,
+                    {
+                        #[allow(unused_imports)]
+                        use #pyo3_path::impl_::pyclass::Probe as _;
+                        #pyo3_path::impl_::pyclass::IsFromPyObject::<#ty>::VALUE
+                    }
+                >(
                     _kwargs.as_deref(),
                     &mut #holder,
                     #name_str,
@@ -287,7 +303,7 @@ pub(crate) fn impl_regular_arg_param(
             quote_arg_span! {
                 #pyo3_path::impl_::extract_argument::extract_optional_argument::<
                     _,
-                    { #pyo3_path::impl_::pyclass::IsOption::<#arg_ty>::VALUE }
+                    { #pyo3_path::impl_::pyclass::IsFromPyObject::<#arg_ty>::VALUE }
                 >(
                     #arg_value,
                     &mut #holder,
@@ -302,7 +318,7 @@ pub(crate) fn impl_regular_arg_param(
             quote_arg_span! {
                 #pyo3_path::impl_::extract_argument::extract_argument_with_default::<
                     _,
-                    { #pyo3_path::impl_::pyclass::IsOption::<#arg_ty>::VALUE }
+                    { #pyo3_path::impl_::pyclass::IsFromPyObject::<#arg_ty>::VALUE }
                 >(
                     #arg_value,
                     &mut #holder,
@@ -320,7 +336,7 @@ pub(crate) fn impl_regular_arg_param(
         quote_arg_span! {
             #pyo3_path::impl_::extract_argument::extract_argument::<
                 _,
-                { #pyo3_path::impl_::pyclass::IsOption::<#arg_ty>::VALUE }
+                { #pyo3_path::impl_::pyclass::IsFromPyObject::<#arg_ty>::VALUE }
             >(
                 #unwrap,
                 &mut #holder,

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -745,7 +745,7 @@ pub fn impl_py_setter_def(
                 use #pyo3_path::impl_::pyclass::Probe as _;
                 let _val = #pyo3_path::impl_::extract_argument::extract_argument::<
                     _,
-                    { #pyo3_path::impl_::pyclass::IsOption::<#ty>::VALUE }
+                    { #pyo3_path::impl_::pyclass::IsFromPyObject::<#ty>::VALUE }
                 >(_value.into(), &mut #holder, #name)?;
             }
         }
@@ -1251,7 +1251,7 @@ fn extract_object(
             use #pyo3_path::impl_::pyclass::Probe as _;
             #pyo3_path::impl_::extract_argument::extract_argument::<
                 _,
-                { #pyo3_path::impl_::pyclass::IsOption::<#ty>::VALUE }
+                { #pyo3_path::impl_::pyclass::IsFromPyObject::<#ty>::VALUE }
             >(
                 unsafe { #pyo3_path::impl_::pymethods::BoundRef::#ref_from_method(py, &#source_ptr).0 },
                 &mut #holder,

--- a/src/impl_/pyclass/probes.rs
+++ b/src/impl_/pyclass/probes.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{conversion::IntoPyObject, Py};
+use crate::{conversion::IntoPyObject, FromPyObject, Py};
 
 /// Trait used to combine with zero-sized types to calculate at compile time
 /// some property of a type.
@@ -58,9 +58,12 @@ impl<T: Sync> IsSync<T> {
     pub const VALUE: bool = true;
 }
 
-probe!(IsOption);
+probe!(IsFromPyObject);
 
-impl<T> IsOption<Option<T>> {
+impl<'a, 'py, T> IsFromPyObject<T>
+where
+    T: FromPyObject<'a, 'py>,
+{
     pub const VALUE: bool = true;
 }
 

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -38,66 +38,66 @@ note: function defined here
    |          ^^^^^^^^^^^^^^^^^^^^^^^^                        --------------
    = note: this error originates in the attribute macro `pyfunction` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, false>` is not satisfied
+error[E0277]: `CancelHandle` cannot be used as a Python function argument
   --> tests/ui/invalid_cancel_handle.rs:20:50
    |
 20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
-   |                                                  ^^^^ the trait `PyClass` is not implemented for `CancelHandle`
+   |                                                  ^^^^ the trait `PyFunctionArgument<'_, '_, '_, false>` is not implemented for `CancelHandle`
    |
-   = help: the trait `PyClass` is implemented for `pyo3::coroutine::Coroutine`
-   = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
-note: required by a bound in `extract_argument`
-  --> src/impl_/extract_argument.rs
-   |
-   | pub fn extract_argument<'a, 'holder, 'py, T, const IS_OPTION: bool>(
-   |        ---------------- required by a bound in this function
-...
-   |     T: PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, false>` is not satisfied
-  --> tests/ui/invalid_cancel_handle.rs:20:50
-   |
-20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
-   |                                                  ^^^^ the trait `Clone` is not implemented for `CancelHandle`
-   |
-   = help: the following other types implement trait `PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>`:
+   = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
+   = note: `Python<'py>` is also a valid argument type to pass the Python token into a PyO3 function
+   = help: the following other types implement trait `PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`:
              `&'a pyo3::Bound<'py, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-             `&'holder mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-             `&'holder pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-             `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, true>`
-   = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
+             `&'holder T` implements `PyFunctionArgument<'a, 'holder, '_, false>`
+             `&'holder mut T` implements `PyFunctionArgument<'a, 'holder, '_, false>`
+             `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
 note: required by a bound in `extract_argument`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_argument<'a, 'holder, 'py, T, const IS_OPTION: bool>(
+   | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
    |        ---------------- required by a bound in this function
 ...
-   |     T: PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>,
-   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
 
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, false>` is not satisfied
+error[E0277]: `CancelHandle` cannot be used as a Python function argument
+  --> tests/ui/invalid_cancel_handle.rs:20:42
+   |
+20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
+   |                                          ^^^^^^^^^^^^ the trait `PyFunctionArgument<'_, '_, '_, false>` is not implemented for `CancelHandle`
+   |
+   = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
+   = note: `Python<'py>` is also a valid argument type to pass the Python token into a PyO3 function
+   = help: the following other types implement trait `PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`:
+             `&'a pyo3::Bound<'py, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+             `&'holder T` implements `PyFunctionArgument<'a, 'holder, '_, false>`
+             `&'holder mut T` implements `PyFunctionArgument<'a, 'holder, '_, false>`
+             `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
+
+error[E0277]: `CancelHandle` cannot be used as a Python function argument
   --> tests/ui/invalid_cancel_handle.rs:20:50
    |
 20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyClass` is not implemented for `CancelHandle`
    |
+   = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
+   = note: `Python<'py>` is also a valid argument type to pass the Python token into a PyO3 function
    = help: the trait `PyClass` is implemented for `pyo3::coroutine::Coroutine`
    = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
+   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, true>`
 
-error[E0277]: the trait bound `CancelHandle: PyFunctionArgument<'_, '_, '_, false>` is not satisfied
+error[E0277]: `CancelHandle` cannot be used as a Python function argument
   --> tests/ui/invalid_cancel_handle.rs:20:50
    |
 20 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `CancelHandle`
    |
-   = help: the following other types implement trait `PyFunctionArgument<'a, 'holder, 'py, IS_OPTION>`:
+   = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
+   = note: `Python<'py>` is also a valid argument type to pass the Python token into a PyO3 function
+   = help: the following other types implement trait `PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`:
              `&'a pyo3::Bound<'py, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-             `&'holder mut pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-             `&'holder pyo3::coroutine::Coroutine` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-             `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, true>`
+             `&'holder T` implements `PyFunctionArgument<'a, 'holder, '_, false>`
+             `&'holder mut T` implements `PyFunctionArgument<'a, 'holder, '_, false>`
+             `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
    = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, false>`
+   = note: required for `CancelHandle` to implement `PyFunctionArgument<'_, '_, '_, true>`

--- a/tests/ui/invalid_frozen_pyclass_borrow.stderr
+++ b/tests/ui/invalid_frozen_pyclass_borrow.stderr
@@ -18,8 +18,8 @@ note: expected this to be `False`
 note: required by a bound in `extract_pyclass_ref_mut`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_pyclass_ref_mut<'a, 'holder, 'py, T: PyClass<Frozen = False>>(
-   |                                                             ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
+   | pub fn extract_pyclass_ref_mut<'a, 'holder, T: PyClass<Frozen = False>>(
+   |                                                        ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`

--- a/tests/ui/invalid_pymethod_enum.stderr
+++ b/tests/ui/invalid_pymethod_enum.stderr
@@ -12,8 +12,8 @@ note: expected this to be `False`
 note: required by a bound in `extract_pyclass_ref_mut`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_pyclass_ref_mut<'a, 'holder, 'py, T: PyClass<Frozen = False>>(
-   |                                                             ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
+   | pub fn extract_pyclass_ref_mut<'a, 'holder, T: PyClass<Frozen = False>>(
+   |                                                        ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<ComplexEnum as PyClass>::Frozen == False`
@@ -48,8 +48,8 @@ note: expected this to be `False`
 note: required by a bound in `extract_pyclass_ref_mut`
   --> src/impl_/extract_argument.rs
    |
-   | pub fn extract_pyclass_ref_mut<'a, 'holder, 'py, T: PyClass<Frozen = False>>(
-   |                                                             ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
+   | pub fn extract_pyclass_ref_mut<'a, 'holder, T: PyClass<Frozen = False>>(
+   |                                                        ^^^^^^^^^^^^^^ required by this bound in `extract_pyclass_ref_mut`
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<TupleEnum as PyClass>::Frozen == False`


### PR DESCRIPTION
Following on from #4390 I was exploring `extract_argument.rs` to understand if anything could be simplified, and I've found a way to move the definition of `PyFunctionArgument` for the `#[pyclass]` type references out of the macros and into generic code.

The main trick is to adjust the const generic specialization from `IsOption` to `IsFromPyObject` and then all the custom implementations in `extract_argument.rs` set that parameter to `false`, while all "normal" types will have that be discovered to be true.

While at it, I added a `diagnostic::on_unimplemented` to make the error messages a touch nicer.