### PR TITLE
docs: remove note in crate docs about deprecated `PyObject` type alias

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //!
 //! The type parameter `T` in these smart pointers can be filled by:
 //!   - [`PyAny`], e.g. `Py<PyAny>` or `Bound<'py, PyAny>`, where the Python object type is not
-//!     known. `Py<PyAny>` is so common it has a type alias [`PyObject`].
+//!     known.
 //!   - Concrete Python types like [`PyList`](types::PyList) or [`PyTuple`](types::PyTuple).
 //!   - Rust types which are exposed to Python using the [`#[pyclass]`](macro@pyclass) macro.
 //!


### PR DESCRIPTION
I noticed this was still linking to the deprecated type alias (https://github.com/PyO3/pyo3/pull/5325).
