### PR TITLE
Exclude emscripten/pybuilddir.txt from the crate package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
     "/.github",
     "/tests/test_compile_error.rs",
     "/tests/ui",
+    "/emscripten/pybuilddir.txt",
 ]
 edition = "2021"
 rust-version.workspace = true


### PR DESCRIPTION
fixes #5431

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run `nox`. See `nox --list-sessions` for a list of supported actions.
