### PR TITLE
add `RwLockExt` trait

### DIFF
--- a/newsfragments/5435.added.md
+++ b/newsfragments/5435.added.md
@@ -1,1 +1,1 @@
-Added the `pyo3::sync::RwLockExt` trait for `std::sync::RwLock` to detach from the Python interpreter while blocking to acquire a read or write lock on a `std::sync::RwLock`.
+Added the `pyo3::sync::RwLockExt` trait to allow detaching from the Python interpreter while blocking to acquire a rwlock. The trait is implemented for `std::sync::RwLock` as well as `parking_lot`'s / `lock_api`'s `RwLock`.


### PR DESCRIPTION
Add a new `pyo3::sync::RwLockExt` trait for `std::sync::RwLock` to detach from the Python interpreter while blocking to acquire a read or write lock on a `std::sync::RwLock`. This mirrors what `pyo3::sync::MutexExt` and `pyo3::sync::OnceLockExt` do for `std::sync::Mutex` and `std::sync::OnceLock` respectively. The trait is also implemented for `parking_lot`'s / `lock_api`'s `RwLock`.