### PR TITLE
fix `OsStr` conversion for non-utf8 strings on windows

### DIFF
--- a/newsfragments/5444.fixed.md
+++ b/newsfragments/5444.fixed.md
@@ -1,0 +1,1 @@
+fix `OsStr` conversion for non-utf8 strings on windows


### PR DESCRIPTION
While testing `OsStr` conversions with ill-formed UTF-16 strings on windows, I found out that the current implementation is wrong.
> When wstr is NULL, instead return the size that would be required to store all of unicode including a terminating null.

>Note that the resulting wchar_t* string may or may not be null-terminated. It is the responsibility of the caller to make sure that the wchar_t* string is null-terminated in case this is required by the application. Also, note that the wchar_t* string might contain null characters, which would cause the string to be truncated when used with most C functions.

[PyUnicode_AsWideChar](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsWideChar) returns the size including the null byte, but does not copy the null byte. This fails the assert in this function. Furthermore we want the byte slice without the null byte.

ref #5368
