### PR TITLE
use `PyLong_FromNativeBytes` in `num-bigint` conversion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ jiff-02 = { package = "jiff", version = "0.2", optional = true }
 num-bigint = { version = "0.4.2", optional = true }
 num-complex = { version = ">= 0.4.6, < 0.5", optional = true }
 num-rational = { version = "0.4.1", optional = true }
+num-traits = { version = "0.2.15", optional = true }
 ordered-float = { version = "5.0.0", default-features = false, optional = true }
 rust_decimal = { version = "1.15", default-features = false, optional = true }
 time = { version = "0.3.38", default-features = false, optional = true }
@@ -135,9 +136,11 @@ py-clone = []
 parking_lot = ["dep:parking_lot", "lock_api"]
 arc_lock = ["lock_api", "lock_api/arc_lock", "parking_lot?/arc_lock"]
 
+num-bigint = ["dep:num-bigint", "num-traits"]
 bigdecimal = ["dep:bigdecimal", "num-bigint"]
 
 chrono-local = ["chrono/clock", "dep:iana-time-zone"]
+
 
 # Optimizes PyObject to Vec conversion and so on.
 nightly = []

--- a/src/conversions/mod.rs
+++ b/src/conversions/mod.rs
@@ -17,6 +17,6 @@ pub mod ordered_float;
 pub mod rust_decimal;
 pub mod serde;
 pub mod smallvec;
-mod std;
+pub(crate) mod std;
 pub mod time;
 pub mod uuid;

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -61,7 +61,7 @@ use num_bigint::Sign;
 
 // for identical functionality between BigInt and BigUint
 macro_rules! bigint_conversion {
-    ($rust_ty: ty, $is_signed: literal, $to_bytes: path) => {
+    ($rust_ty: ty, $is_signed: literal) => {
         #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
         impl<'py> IntoPyObject<'py> for $rust_ty {
             type Target = PyInt;
@@ -82,45 +82,48 @@ macro_rules! bigint_conversion {
 
             #[cfg(not(Py_LIMITED_API))]
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-                use crate::ffi_ptr_ext::FfiPtrExt;
-                let bytes = $to_bytes(&self);
-                unsafe {
-                    Ok(ffi::_PyLong_FromByteArray(
-                        bytes.as_ptr().cast(),
-                        bytes.len(),
-                        1,
-                        $is_signed.into(),
-                    )
-                    .assume_owned(py)
-                    .cast_into_unchecked())
-                }
-            }
+                use num_traits::ToBytes;
 
-            #[cfg(Py_LIMITED_API)]
-            fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-                use $crate::py_result_ext::PyResultExt;
-                use $crate::types::any::PyAnyMethods;
-                let bytes = $to_bytes(&self);
-                let bytes_obj = PyBytes::new(py, &bytes);
-                let kwargs = if $is_signed {
-                    let kwargs = crate::types::PyDict::new(py);
-                    kwargs.set_item(crate::intern!(py, "signed"), true)?;
-                    Some(kwargs)
-                } else {
-                    None
-                };
-                unsafe {
-                    py.get_type::<PyInt>()
-                        .call_method("from_bytes", (bytes_obj, "little"), kwargs.as_ref())
-                        .cast_into_unchecked()
+                #[cfg(Py_3_13)]
+                {
+                    use crate::conversions::std::num::py_int_from_ne_bytes;
+                    let bytes = self.to_ne_bytes();
+                    Ok(py_int_from_ne_bytes::<{ $is_signed }>(py, &bytes))
+                }
+
+                #[cfg(all(not(Py_LIMITED_API), not(Py_3_13)))]
+                {
+                    use crate::conversions::std::num::py_int_from_le_bytes;
+                    let bytes = self.to_le_bytes();
+                    Ok(py_int_from_le_bytes::<{ $is_signed }>(py, &bytes))
+                }
+
+                #[cfg(all(Py_LIMITED_API, not(Py_3_13)))]
+                {
+                    use $crate::py_result_ext::PyResultExt;
+                    use $crate::types::any::PyAnyMethods;
+                    let bytes = self.to_le_bytes();
+                    let bytes_obj = PyBytes::new(py, &bytes);
+                    let kwargs = if $is_signed {
+                        let kwargs = crate::types::PyDict::new(py);
+                        kwargs.set_item(crate::intern!(py, "signed"), true)?;
+                        Some(kwargs)
+                    } else {
+                        None
+                    };
+                    unsafe {
+                        py.get_type::<PyInt>()
+                            .call_method("from_bytes", (bytes_obj, "little"), kwargs.as_ref())
+                            .cast_into_unchecked()
+                    }
                 }
             }
         }
     };
 }
 
-bigint_conversion!(BigUint, false, BigUint::to_bytes_le);
-bigint_conversion!(BigInt, true, BigInt::to_signed_bytes_le);
+bigint_conversion!(BigUint, false);
+bigint_conversion!(BigInt, true);
 
 #[cfg_attr(docsrs, doc(cfg(feature = "num-bigint")))]
 impl<'py> FromPyObject<'_, 'py> for BigInt {

--- a/src/conversions/std/mod.rs
+++ b/src/conversions/std/mod.rs
@@ -2,7 +2,7 @@ mod array;
 mod cell;
 mod ipaddr;
 mod map;
-mod num;
+pub(crate) mod num;
 mod option;
 mod osstr;
 mod path;

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -435,45 +435,15 @@ mod fast_128bit_int_conversion {
                 const OUTPUT_TYPE: &'static str = "int";
 
                 fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-                    #[cfg(not(Py_3_13))]
-                    {
-                        let bytes = self.to_le_bytes();
-                        unsafe {
-                            Ok(ffi::_PyLong_FromByteArray(
-                                bytes.as_ptr().cast(),
-                                bytes.len(),
-                                1,
-                                $is_signed.into(),
-                            )
-                            .assume_owned(py)
-                            .cast_into_unchecked())
-                        }
-                    }
                     #[cfg(Py_3_13)]
                     {
                         let bytes = self.to_ne_bytes();
-
-                        if $is_signed {
-                            unsafe {
-                                Ok(ffi::PyLong_FromNativeBytes(
-                                    bytes.as_ptr().cast(),
-                                    bytes.len(),
-                                    ffi::Py_ASNATIVEBYTES_NATIVE_ENDIAN,
-                                )
-                                .assume_owned(py)
-                                .cast_into_unchecked())
-                            }
-                        } else {
-                            unsafe {
-                                Ok(ffi::PyLong_FromUnsignedNativeBytes(
-                                    bytes.as_ptr().cast(),
-                                    bytes.len(),
-                                    ffi::Py_ASNATIVEBYTES_NATIVE_ENDIAN,
-                                )
-                                .assume_owned(py)
-                                .cast_into_unchecked())
-                            }
-                        }
+                        Ok(py_int_from_ne_bytes::<{ $is_signed }>(py, &bytes))
+                    }
+                    #[cfg(not(Py_3_13))]
+                    {
+                        let bytes = self.to_le_bytes();
+                        Ok(py_int_from_le_bytes::<{ $is_signed }>(py, &bytes))
                     }
                 }
 
@@ -564,6 +534,37 @@ mod fast_128bit_int_conversion {
 
     int_convert_128!(i128, true);
     int_convert_128!(u128, false);
+}
+
+#[cfg(all(not(Py_LIMITED_API), not(Py_3_13)))]
+pub(crate) fn py_int_from_le_bytes<'py, const IS_SIGNED: bool>(
+    py: Python<'py>,
+    bytes: &[u8],
+) -> Bound<'py, PyInt> {
+    unsafe {
+        Ok(
+            ffi::_PyLong_FromByteArray(bytes.as_ptr().cast(), bytes.len(), 1, IS_SIGNED.into())
+                .assume_owned(py)
+                .cast_into_unchecked(),
+        )
+    }
+}
+
+#[cfg(Py_3_13)]
+pub(crate) fn py_int_from_ne_bytes<'py, const IS_SIGNED: bool>(
+    py: Python<'py>,
+    bytes: &[u8],
+) -> Bound<'py, PyInt> {
+    let flags = if IS_SIGNED {
+        ffi::Py_ASNATIVEBYTES_NATIVE_ENDIAN
+    } else {
+        ffi::Py_ASNATIVEBYTES_NATIVE_ENDIAN | ffi::Py_ASNATIVEBYTES_UNSIGNED_BUFFER
+    };
+    unsafe {
+        ffi::PyLong_FromNativeBytes(bytes.as_ptr().cast(), bytes.len(), flags)
+            .assume_owned(py)
+            .cast_into_unchecked()
+    }
 }
 
 // For ABI3 we implement the conversion manually.


### PR DESCRIPTION
Looks like we missed using the new 3.13 API in the `num-bigint` code. 

Adds a dependency on `num-traits` when the feature is enabled, which is immaterial as the dependency is already transitive when the feature is enabled.