### PR TITLE
expose `Borrowed::cast` and `Borrowed::cast_unchecked` as public api

### DIFF
--- a/newsfragments/5475.added.md
+++ b/newsfragments/5475.added.md
@@ -1,0 +1,1 @@
+added `Borrowed::cast`, `Borrowed::cast_exact` and `Borrowed::cast_unchecked`

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -257,8 +257,6 @@ mod tests {
 
     #[test]
     fn test_from_double() {
-        use assert_approx_eq::assert_approx_eq;
-
         Python::attach(|py| {
             let complex = PyComplex::from_doubles(py, 3.0, 1.2);
             assert_approx_eq!(complex.real(), 3.0);


### PR DESCRIPTION
Exposes `Borrowed::cast(_unchecked)`. I moved them into the generic impl block, so they can be used on any `Borrowed`, not just `PyAny`, like we did for `Bound`. I also extended the general type level docs of `Borrowed` a bit.

Ref: #5390
