### PR TITLE
docs: replace "GIL token" with "Python token"

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -1280,7 +1280,7 @@ However, if the `anyhow::Error` or `eyre::Report` has a source, then the origina
 <details>
 <summary><small>Click to expand</small></summary>
 
-While the API provided by [`Python::acquire_gil`](https://docs.rs/pyo3/0.18.3/pyo3/marker/struct.Python.html#method.acquire_gil) seems convenient, it is somewhat brittle as the design of the GIL token [`Python`](https://docs.rs/pyo3/0.18.3/pyo3/marker/struct.Python.html) relies on proper nesting and panics if not used correctly, e.g.
+While the API provided by [`Python::acquire_gil`](https://docs.rs/pyo3/0.18.3/pyo3/marker/struct.Python.html#method.acquire_gil) seems convenient, it is somewhat brittle as the design of the [`Python`](https://docs.rs/pyo3/0.18.3/pyo3/marker/struct.Python.html) token relies on proper nesting and panics if not used correctly, e.g.
 
 ```rust,ignore
 # #![allow(dead_code, deprecated)]
@@ -1346,7 +1346,7 @@ Python::with_gil(|py| {
 });
 ```
 
-Furthermore, `Python::acquire_gil` provides ownership of a `GILGuard` which can be freely stored and passed around. This is usually not helpful as it may keep the lock held for a long time thereby blocking progress in other parts of the program. Due to the generative lifetime attached to the GIL token supplied by `Python::with_gil`, the problem is avoided as the GIL token can only be passed down the call chain. Often, this issue can also be avoided entirely as any GIL-bound reference `&'py PyAny` implies access to a GIL token `Python<'py>` via the [`PyAny::py`](https://docs.rs/pyo3/0.22.5/pyo3/types/struct.PyAny.html#method.py) method.
+Furthermore, `Python::acquire_gil` provides ownership of a `GILGuard` which can be freely stored and passed around. This is usually not helpful as it may keep the lock held for a long time thereby blocking progress in other parts of the program. Due to the generative lifetime attached to the Python token supplied by `Python::with_gil`, the problem is avoided as the Python token can only be passed down the call chain. Often, this issue can also be avoided entirely as any GIL-bound reference `&'py PyAny` implies access to a Python token `Python<'py>` via the [`PyAny::py`](https://docs.rs/pyo3/0.22.5/pyo3/types/struct.PyAny.html#method.py) method.
 </details>
 
 ## from 0.17.* to 0.18

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -17,7 +17,7 @@ use std::marker::PhantomData;
 /// This trait has `#[derive(IntoPyObject)]` to automatically implement it for simple types and
 /// `#[derive(IntoPyObjectRef)]` to implement the same for references.
 ///
-/// It functions similarly to std's [`TryInto`] trait, but requires a [GIL token](Python)
+/// It functions similarly to std's [`TryInto`] trait, but requires a [`Python<'py>`] token
 /// as an argument.
 ///
 /// The [`into_pyobject`][IntoPyObject::into_pyobject] method is designed for maximum flexibility and efficiency; it

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -85,8 +85,8 @@ impl PyErrState {
     #[cold]
     fn make_normalized(&self, py: Python<'_>) -> &PyErrStateNormalized {
         // This process is safe because:
-        // - Access is guaranteed not to be concurrent thanks to `Python` GIL token
         // - Write happens only once, and then never will change again.
+        // - The `Once` ensure that only one thread will do the write.
 
         // Guard against re-entrant normalization, because `Once` does not provide
         // re-entrancy guarantees.

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -275,13 +275,11 @@ pub unsafe fn _call_traverse<T>(
 where
     T: PyClass,
 {
-    // It is important the implementation of `__traverse__` cannot safely access the GIL,
-    // c.f. https://github.com/PyO3/pyo3/issues/3165, and hence we do not expose our GIL
-    // token to the user code and lock safe methods for acquiring the GIL.
+    // It is important the implementation of `__traverse__` cannot safely access the interpreter,
+    // c.f. https://github.com/PyO3/pyo3/issues/3165, and hence we do not expose our Python
+    // token to the user code and forbid safe methods for attaching.
     // (This includes enforcing the `&self` method receiver as e.g. `PyRef<Self>` could
-    // reconstruct a GIL token via `PyRef::py`.)
-    // Since we do not create a `GILPool` at all, it is important that our usage of the GIL
-    // token does not produce any owned objects thereby calling into `register_owned`.
+    // reconstruct a Python token via `PyRef::py`.)
     let trap = PanicTrap::new("uncaught panic inside __traverse__ handler");
     let lock = ForbidAttaching::during_traverse();
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -789,7 +789,7 @@ impl<T> Drop for Bound<'_, T> {
 }
 
 impl<'py, T> Bound<'py, T> {
-    /// Returns the GIL token associated with this object.
+    /// Returns the [`Python``] token associated with this object.
     #[inline]
     pub fn py(&self) -> Python<'py> {
         self.0

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -219,7 +219,7 @@ mod nightly {
         /// });
         /// ```
         ///
-        /// This applies to the GIL token `Python` itself as well, e.g.
+        /// This applies to the [`Python`] token itself as well, e.g.
         ///
         /// ```compile_fail
         /// # use pyo3::prelude::*;


### PR DESCRIPTION
Fixes #5449 

Usually I would be careful not to alter the CHANGELOG or `migration.md`, however in this case I think the meaning is not lost by the replacement.