### PR TITLE
move away from the `FromPyObject` blanket for `PyClass + Clone`

### DIFF
--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -53,6 +53,7 @@ pub mod kw {
     syn::custom_keyword!(warn);
     syn::custom_keyword!(message);
     syn::custom_keyword!(category);
+    syn::custom_keyword!(skip_from_py_object);
 }
 
 fn take_int(read: &mut &str, tracker: &mut usize) -> String {

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -90,6 +90,7 @@ pub struct PyClassPyO3Options {
     pub unsendable: Option<kw::unsendable>,
     pub weakref: Option<kw::weakref>,
     pub generic: Option<kw::generic>,
+    pub skip_from_py_object: Option<kw::skip_from_py_object>,
 }
 
 pub enum PyClassPyO3Option {
@@ -115,6 +116,7 @@ pub enum PyClassPyO3Option {
     Unsendable(kw::unsendable),
     Weakref(kw::weakref),
     Generic(kw::generic),
+    SkipFromPyObject(kw::skip_from_py_object),
 }
 
 impl Parse for PyClassPyO3Option {
@@ -164,6 +166,8 @@ impl Parse for PyClassPyO3Option {
             input.parse().map(PyClassPyO3Option::Weakref)
         } else if lookahead.peek(attributes::kw::generic) {
             input.parse().map(PyClassPyO3Option::Generic)
+        } else if lookahead.peek(attributes::kw::skip_from_py_object) {
+            input.parse().map(PyClassPyO3Option::SkipFromPyObject)
         } else {
             Err(lookahead.error())
         }
@@ -243,6 +247,9 @@ impl PyClassPyO3Options {
                 set_option!(weakref);
             }
             PyClassPyO3Option::Generic(generic) => set_option!(generic),
+            PyClassPyO3Option::SkipFromPyObject(skip_from_py_object) => {
+                set_option!(skip_from_py_object)
+            }
         }
         Ok(())
     }
@@ -2497,8 +2504,14 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote! {}
         };
 
+        let extract_pyclass_with_clone = if self.attr.options.skip_from_py_object.is_none() {
+            quote!( impl #pyo3_path::impl_::pyclass::ExtractPyClassWithClone for #cls {} )
+        } else {
+            TokenStream::new()
+        };
+
         Ok(quote! {
-            impl #pyo3_path::impl_::pyclass::ExtractPyClassWithClone for #cls {}
+            #extract_pyclass_with_clone
 
             #assertions
 

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2498,6 +2498,8 @@ impl<'a> PyClassImplsBuilder<'a> {
         };
 
         Ok(quote! {
+            impl #pyo3_path::impl_::pyclass::ExtractPyClassWithClone for #cls {}
+
             #assertions
 
             #pyclass_base_type_impl

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,5 +1,6 @@
 //! Defines conversions between Rust and Python types.
 use crate::err::PyResult;
+use crate::impl_::pyclass::ExtractPyClassWithClone;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::types::TypeInfo;
 use crate::pyclass::boolean_struct::False;
@@ -529,7 +530,7 @@ impl<'py, T> FromPyObjectOwned<'py> for T where T: for<'a> FromPyObject<'a, 'py>
 
 impl<'a, 'py, T> FromPyObject<'a, 'py> for T
 where
-    T: PyClass + Clone,
+    T: PyClass + Clone + ExtractPyClassWithClone,
 {
     type Error = PyClassGuardError<'a, 'py>;
 

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1426,6 +1426,8 @@ impl<const IMPLEMENTS_INTOPYOBJECT: bool> ConvertField<false, IMPLEMENTS_INTOPYO
     }
 }
 
+pub trait ExtractPyClassWithClone {}
+
 #[cfg(test)]
 #[cfg(feature = "macros")]
 mod tests {


### PR DESCRIPTION
This proposes a first step in removing the `FromPyObject` blanket implementation for cloneable pyclasses.

This adds a marker trait `ExtractPyClassWithClone` which is automatically implemented by the `#[pyclass]` macro for every pyclass and modifies the blanket to require the marker. I think this should be functionally equivalent. It also adds a new `skip_from_py_object` option to opt out of emitting the marker trait and thus enable a custom `FromPyObject` implementation.

The following steps could then be:
- add an option to explicitly opt-in (this can then just emit the `FromPyObject` impl directly)
- emit a warning for pyclasses that do not declare out-out nor opt in 
- switch the default from opt-out to opt-in
- remove the blanket and the marker and deprecate the out-out option


Ref #5419
