### PR TITLE
docs: improve convention for handling `static mut` slots

### DIFF
--- a/pyo3-ffi/README.md
+++ b/pyo3-ffi/README.md
@@ -76,14 +76,14 @@ static mut MODULE_DEF: PyModuleDef = PyModuleDef {
     m_name: c_str!("string_sum").as_ptr(),
     m_doc: c_str!("A Python module written in Rust.").as_ptr(),
     m_size: 0,
-    m_methods: unsafe { METHODS as *const [PyMethodDef] as *mut PyMethodDef },
+    m_methods: std::ptr::addr_of_mut!(METHODS).cast(),
     m_slots: std::ptr::null_mut(),
     m_traverse: None,
     m_clear: None,
     m_free: None,
 };
 
-static mut METHODS: &[PyMethodDef] = &[
+static mut METHODS: [PyMethodDef; 2] = [
     PyMethodDef {
         ml_name: c_str!("sum_as_string").as_ptr(),
         ml_meth: PyMethodDefPointer {

--- a/pyo3-ffi/examples/sequential/src/id.rs
+++ b/pyo3-ffi/examples/sequential/src/id.rs
@@ -99,7 +99,7 @@ unsafe extern "C" fn id_richcompare(
     }
 }
 
-static mut SLOTS: &[PyType_Slot] = &[
+static mut SLOTS: [PyType_Slot; 6] = [
     PyType_Slot {
         slot: Py_tp_new,
         pfunc: id_new as *mut c_void,
@@ -132,5 +132,5 @@ pub static mut ID_SPEC: PyType_Spec = PyType_Spec {
     basicsize: mem::size_of::<PyId>() as c_int,
     itemsize: 0,
     flags: (Py_TPFLAGS_DEFAULT | Py_TPFLAGS_IMMUTABLETYPE) as c_uint,
-    slots: unsafe { SLOTS as *const [PyType_Slot] as *mut PyType_Slot },
+    slots: ptr::addr_of_mut!(SLOTS).cast(),
 };

--- a/pyo3-ffi/examples/sequential/src/module.rs
+++ b/pyo3-ffi/examples/sequential/src/module.rs
@@ -8,13 +8,14 @@ pub static mut MODULE_DEF: PyModuleDef = PyModuleDef {
     m_doc: c_str!("A library for generating sequential ids, written in Rust.").as_ptr(),
     m_size: mem::size_of::<sequential_state>() as Py_ssize_t,
     m_methods: std::ptr::null_mut(),
-    m_slots: unsafe { SEQUENTIAL_SLOTS as *const [PyModuleDef_Slot] as *mut PyModuleDef_Slot },
+    m_slots: std::ptr::addr_of_mut!(SEQUENTIAL_SLOTS).cast(),
     m_traverse: Some(sequential_traverse),
     m_clear: Some(sequential_clear),
     m_free: Some(sequential_free),
 };
 
-static mut SEQUENTIAL_SLOTS: &[PyModuleDef_Slot] = &[
+const SEQUENTIAL_SLOTS_LEN: usize = 3 + if cfg!(Py_GIL_DISABLED) { 1 } else { 0 };
+static mut SEQUENTIAL_SLOTS: [PyModuleDef_Slot; SEQUENTIAL_SLOTS_LEN] = [
     PyModuleDef_Slot {
         slot: Py_mod_exec,
         value: sequential_exec as *mut c_void,

--- a/pyo3-ffi/examples/string-sum/src/lib.rs
+++ b/pyo3-ffi/examples/string-sum/src/lib.rs
@@ -8,14 +8,14 @@ static mut MODULE_DEF: PyModuleDef = PyModuleDef {
     m_name: c_str!("string_sum").as_ptr(),
     m_doc: c_str!("A Python module written in Rust.").as_ptr(),
     m_size: 0,
-    m_methods: unsafe { METHODS as *const [PyMethodDef] as *mut PyMethodDef },
+    m_methods: std::ptr::addr_of_mut!(METHODS).cast(),
     m_slots: std::ptr::null_mut(),
     m_traverse: None,
     m_clear: None,
     m_free: None,
 };
 
-static mut METHODS: &[PyMethodDef] = &[
+static mut METHODS: [PyMethodDef; 2] = [
     PyMethodDef {
         ml_name: c_str!("sum_as_string").as_ptr(),
         ml_meth: PyMethodDefPointer {


### PR DESCRIPTION
While considering CI failures in #5481 I realised our way of defining static "slots" is potentially questionable.

- We use a `&` immutable reference in the static, which seems questionable given the intent is to express mutable data. We cast this away using pointer casting.
- The reference seems to also requires us to read the mutable static's value to cast to a pointer, hence the `unsafe` block. Reading the value of mutable statics is known to be full of footguns.

The cleanest way I could find to do this, as proposed in this PR, is to store the mutable static as a `static mut [T; N]` array. It requires specifying `N`, because the compiler does not allow inference of the array size.

The nice thing about storing slots as an array is that we can then get a pointer to its first element with `addr_of_mut!(SLOTS).cast()`, which avoids any `unsafe` block or reading the value of the static.
