### PR TITLE
ci: fix rust nightly unused macro warning

### DIFF
--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -223,6 +223,7 @@ mod inner {
         }};
     }
 
+    #[allow(unused_imports)] // not all tests use this macro
     pub(crate) use assert_warnings;
 
     pub fn generate_unique_module_name(base: &str) -> std::ffi::CString {


### PR DESCRIPTION
Not all tests use the offending macro, so the `pub(crate) use` statement is triggering warnings on nightly.