### PR TITLE
apply some more uses of `assume_borrowed_unchecked`

### DIFF
--- a/newsfragments/5494.changed.md
+++ b/newsfragments/5494.changed.md
@@ -1,0 +1,1 @@
+`PyList::get_item_unchecked`, `PyTuple::get_item_unchecked`, and `PyTuple::get_borrowed_item_unchecked` no longer check for null values at the provided index.

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -31,6 +31,7 @@ impl PyBool {
     /// `False` singletons
     #[inline]
     pub fn new(py: Python<'_>, val: bool) -> Borrowed<'_, '_, Self> {
+        // SAFETY: `Py_True` and `Py_False` are global singletons which are known to be boolean objects
         unsafe {
             if val { ffi::Py_True() } else { ffi::Py_False() }
                 .assume_borrowed_unchecked(py)

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -33,7 +33,7 @@ impl PyBool {
     pub fn new(py: Python<'_>, val: bool) -> Borrowed<'_, '_, Self> {
         unsafe {
             if val { ffi::Py_True() } else { ffi::Py_False() }
-                .assume_borrowed(py)
+                .assume_borrowed_unchecked(py)
                 .cast_unchecked()
         }
     }

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -718,7 +718,12 @@ mod borrowed_iter {
                 // Safety:
                 // - PyDict_Next returns borrowed values
                 // - we have already checked that `PyDict_Next` succeeded, so we can assume these to be non-null
-                Some(unsafe { (key.assume_borrowed(py), value.assume_borrowed(py)) })
+                Some(unsafe {
+                    (
+                        key.assume_borrowed_unchecked(py),
+                        value.assume_borrowed_unchecked(py),
+                    )
+                })
             } else {
                 None
             }

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -16,6 +16,7 @@ impl PyEllipsis {
     /// Returns the `Ellipsis` object.
     #[inline]
     pub fn get(py: Python<'_>) -> Borrowed<'_, '_, PyEllipsis> {
+        // SAFETY: `Py_Ellipsis` is a global singleton which is known to be the ellipsis object
         unsafe {
             ffi::Py_Ellipsis()
                 .assume_borrowed_unchecked(py)

--- a/src/types/ellipsis.rs
+++ b/src/types/ellipsis.rs
@@ -16,7 +16,11 @@ impl PyEllipsis {
     /// Returns the `Ellipsis` object.
     #[inline]
     pub fn get(py: Python<'_>) -> Borrowed<'_, '_, PyEllipsis> {
-        unsafe { ffi::Py_Ellipsis().assume_borrowed(py).cast_unchecked() }
+        unsafe {
+            ffi::Py_Ellipsis()
+                .assume_borrowed_unchecked(py)
+                .cast_unchecked()
+        }
     }
 }
 

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -281,7 +281,7 @@ impl<'py> PyListMethods<'py> for Bound<'py, PyList> {
         // PyList_GET_ITEM return borrowed ptr; must make owned for safety (see #890).
         unsafe {
             ffi::PyList_GET_ITEM(self.as_ptr(), index as Py_ssize_t)
-                .assume_borrowed(self.py())
+                .assume_borrowed_unchecked(self.py())
                 .to_owned()
         }
     }

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -135,13 +135,18 @@ pub trait PyListMethods<'py>: crate::sealed::Sealed {
     /// ```
     fn get_item(&self, index: usize) -> PyResult<Bound<'py, PyAny>>;
 
-    /// Gets the list item at the specified index. Undefined behavior on bad index. Use with caution.
+    /// Gets the list item at the specified index. Undefined behavior on bad index, or if the list
+    /// contains a null pointer at the specified index. Use with caution.
     ///
     /// # Safety
     ///
-    /// Caller must verify that the index is within the bounds of the list.
-    /// On the free-threaded build, caller must verify they have exclusive access to the list
-    /// via a lock or by holding the innermost critical section on the list.
+    /// - Caller must verify that the index is within the bounds of the list.
+    /// - A null pointer is only legal in a list which is in the process of being initialized, callers
+    ///   can typically assume the list item is non-null unless they are knowingly filling an
+    ///   uninitialized list. (If a list were to contain a null pointer element, accessing it from Python
+    ///   typically causes a segfault.)
+    /// - On the free-threaded build, caller must verify they have exclusive access to the list
+    ///   via a lock or by holding the innermost critical section on the list.
     #[cfg(not(Py_LIMITED_API))]
     unsafe fn get_item_unchecked(&self, index: usize) -> Bound<'py, PyAny>;
 
@@ -278,12 +283,13 @@ impl<'py> PyListMethods<'py> for Bound<'py, PyList> {
     /// Caller must verify that the index is within the bounds of the list.
     #[cfg(not(Py_LIMITED_API))]
     unsafe fn get_item_unchecked(&self, index: usize) -> Bound<'py, PyAny> {
-        // PyList_GET_ITEM return borrowed ptr; must make owned for safety (see #890).
+        // SAFETY: caller has upheld the safety contract
         unsafe {
             ffi::PyList_GET_ITEM(self.as_ptr(), index as Py_ssize_t)
                 .assume_borrowed_unchecked(self.py())
-                .to_owned()
         }
+        // PyList_GET_ITEM return borrowed ptr; must make owned for safety (see #890).
+        .to_owned()
     }
 
     /// Takes the slice `self[low:high]` and returns it as a new list.

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -14,6 +14,7 @@ impl PyNone {
     /// Returns the `None` object.
     #[inline]
     pub fn get(py: Python<'_>) -> Borrowed<'_, '_, PyNone> {
+        // SAFETY: `Py_None` is a global singleton which is known to be the None object
         unsafe {
             ffi::Py_None()
                 .assume_borrowed_unchecked(py)

--- a/src/types/none.rs
+++ b/src/types/none.rs
@@ -14,7 +14,11 @@ impl PyNone {
     /// Returns the `None` object.
     #[inline]
     pub fn get(py: Python<'_>) -> Borrowed<'_, '_, PyNone> {
-        unsafe { ffi::Py_None().assume_borrowed(py).cast_unchecked() }
+        unsafe {
+            ffi::Py_None()
+                .assume_borrowed_unchecked(py)
+                .cast_unchecked()
+        }
     }
 }
 

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -16,6 +16,7 @@ impl PyNotImplemented {
     /// Returns the `NotImplemented` object.
     #[inline]
     pub fn get(py: Python<'_>) -> Borrowed<'_, '_, PyNotImplemented> {
+        // SAFETY: `Py_NotImplemented` is a global singleton which is known to be the NotImplemented object
         unsafe {
             ffi::Py_NotImplemented()
                 .assume_borrowed_unchecked(py)

--- a/src/types/notimplemented.rs
+++ b/src/types/notimplemented.rs
@@ -18,7 +18,7 @@ impl PyNotImplemented {
     pub fn get(py: Python<'_>) -> Borrowed<'_, '_, PyNotImplemented> {
         unsafe {
             ffi::Py_NotImplemented()
-                .assume_borrowed(py)
+                .assume_borrowed_unchecked(py)
                 .cast_unchecked()
         }
     }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -159,11 +159,16 @@ pub trait PyTupleMethods<'py>: crate::sealed::Sealed {
     /// by avoiding a reference count change.
     fn get_borrowed_item<'a>(&'a self, index: usize) -> PyResult<Borrowed<'a, 'py, PyAny>>;
 
-    /// Gets the tuple item at the specified index. Undefined behavior on bad index. Use with caution.
+    /// Gets the tuple item at the specified index. Undefined behavior on bad index, or if the tuple
+    /// contains a null pointer at the specified index. Use with caution.
     ///
     /// # Safety
     ///
-    /// Caller must verify that the index is within the bounds of the tuple.
+    /// - Caller must verify that the index is within the bounds of the tuple.
+    /// - A null pointer is only legal in a tuple which is in the process of being initialized, callers
+    ///   can typically assume the tuple item is non-null unless they are knowingly filling an
+    ///   uninitialized tuple. (If a tuple were to contain a null pointer element, accessing it from Python
+    ///   typically causes a segfault.)
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     unsafe fn get_item_unchecked(&self, index: usize) -> Bound<'py, PyAny>;
 
@@ -172,7 +177,7 @@ pub trait PyTupleMethods<'py>: crate::sealed::Sealed {
     ///
     /// # Safety
     ///
-    /// Caller must verify that the index is within the bounds of the tuple.
+    /// See [`get_item_unchecked`][PyTupleMethods::get_item_unchecked].
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     unsafe fn get_borrowed_item_unchecked<'a>(&'a self, index: usize) -> Borrowed<'a, 'py, PyAny>;
 
@@ -304,8 +309,12 @@ impl<'a, 'py> Borrowed<'a, 'py, PyTuple> {
         }
     }
 
+    /// # Safety
+    ///
+    /// See `get_item_unchecked` in `PyTupleMethods`.
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     unsafe fn get_borrowed_item_unchecked(self, index: usize) -> Borrowed<'a, 'py, PyAny> {
+        // SAFETY: caller has upheld the safety contract
         unsafe {
             ffi::PyTuple_GET_ITEM(self.as_ptr(), index as Py_ssize_t)
                 .assume_borrowed_unchecked(self.py())

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -307,7 +307,8 @@ impl<'a, 'py> Borrowed<'a, 'py, PyTuple> {
     #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
     unsafe fn get_borrowed_item_unchecked(self, index: usize) -> Borrowed<'a, 'py, PyAny> {
         unsafe {
-            ffi::PyTuple_GET_ITEM(self.as_ptr(), index as Py_ssize_t).assume_borrowed(self.py())
+            ffi::PyTuple_GET_ITEM(self.as_ptr(), index as Py_ssize_t)
+                .assume_borrowed_unchecked(self.py())
         }
     }
 


### PR DESCRIPTION
This changes a few uses of `.assume_borrowed()` to `.assume_borrowed_unchecked()`:
- inside access off global singletons like `True`, `False`, and `None`
- inside iteration of dicts where the return value already signalled success (one of the other dict iterators already uses this optimization)
- inside `PyList::get_item_unchecked` and `PyTuple::get_item_unchecked`

Doing this removes the branch to check for null (and panic if so), so it's a micro-optimization that's only relevant in these cases where it seems extremely justified.