### PR TITLE
change `Py` constructors from pointer to produce `Py<PyAny>`

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -1,5 +1,7 @@
+use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Bound;
 use crate::panic::PanicException;
+use crate::py_result_ext::PyResultExt;
 use crate::type_object::PyTypeInfo;
 use crate::types::any::PyAnyMethods;
 use crate::types::{
@@ -421,7 +423,11 @@ impl PyErr {
 
         let ptr = unsafe { ffi::PyErr_NewExceptionWithDoc(name.as_ptr(), doc_ptr, base, dict) };
 
-        unsafe { Py::from_owned_ptr_or_err(py, ptr) }
+        unsafe {
+            ptr.assume_owned_or_err(py)
+                .cast_into_unchecked()
+                .map(Bound::unbind)
+        }
     }
 
     /// Prints a standard traceback to `sys.stderr`.

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -1,6 +1,7 @@
 use crate::{
     exceptions::PyTypeError,
     ffi,
+    ffi_ptr_ext::FfiPtrExt,
     impl_::{
         pycell::PyClassObject,
         pyclass::{
@@ -505,18 +506,21 @@ impl PyTypeBuilder {
         };
 
         // Safety: We've correctly setup the PyType_Spec at this point
-        let type_object: Py<PyType> =
-            unsafe { Py::from_owned_ptr_or_err(py, ffi::PyType_FromSpec(&mut spec))? };
+        let type_object = unsafe {
+            ffi::PyType_FromSpec(&mut spec)
+                .assume_owned_or_err(py)?
+                .cast_into_unchecked()
+        };
 
         #[cfg(not(Py_3_11))]
         bpo_45315_workaround(py, class_name);
 
         for cleanup in std::mem::take(&mut self.cleanup) {
-            cleanup(&self, type_object.bind(py).as_type_ptr());
+            cleanup(&self, type_object.as_type_ptr());
         }
 
         Ok(PyClassTypeObject {
-            type_object,
+            type_object: type_object.unbind(),
             is_immutable_type: self.is_immutable_type,
             getset_destructors,
         })


### PR DESCRIPTION
The constructors such as `Py::from_owned_ptr` are implemented on `Py<T>`. This is different to `Bound` and `Borrowed` where the implementation is only on `Bound<'py, PyAny>` and `Borrowed<'a, 'py, PyAny>`.

I would argue that implementing only on the `PyAny` type is better because it forces the caller to decide what casting logic to do - e.g. `.cast()`, `.cast_exact()`, or `.cast_unchecked()`. The `Py<T>` constructors basically all do `.cast_unchecked()`.

Implementing this diff I found places in the codebase where the unchecked cast was probably not good (return value of `PyNumber_Index`), and I'd bet user code more likely makes the same mistake.

If we like moving forward with this, I think a better path than actually changing the constructors immediately would be to introduce new temporary names (`Py::any_from_owned_ptr` etc. maybe?) and deprecate the existing, and rename the new forms once the deprecated ones are removed.

We might want to also introduce proper `.cast()` methods to `Py<T>` similar to `Bound::cast` etc, to make the handling of the `Py<PyAny>` return values easier.