### PR TITLE
use `PyErr::write_unraisable` when panicking

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -878,14 +878,6 @@ impl std::fmt::Display for TypeNameOrValue<'_> {
     }
 }
 
-#[track_caller]
-pub fn panic_after_error(_py: Python<'_>) -> ! {
-    unsafe {
-        ffi::PyErr_Print();
-    }
-    panic!("Python API call failed");
-}
-
 /// Returns Ok if the error code is not -1.
 #[inline]
 pub(crate) fn error_on_minusone<T: SignedInteger>(py: Python<'_>, result: T) -> PyResult<()> {


### PR DESCRIPTION
Draft follow-up to #5484, pushing so I don't forget this for another day.