### PR TITLE
ci: test windows-aarch64 on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
               rust-target: "x86_64-unknown-linux-gnu",
             },
             {
-              os: "ubuntu-22.04-arm",
+              os: "ubuntu-24.04-arm",
               python-architecture: "arm64",
               rust-target: "aarch64-unknown-linux-gnu",
             },
@@ -172,6 +172,11 @@ jobs:
               os: "windows-latest",
               python-architecture: "x86",
               rust-target: "i686-pc-windows-msvc",
+            },
+            {
+              os: "windows-11-arm",
+              python-architecture: "arm64",
+              rust-target: "aarch64-pc-windows-msvc",
             },
           ]
         include:
@@ -337,12 +342,12 @@ jobs:
           #       python-architecture: "x64",
           #       rust-target: "x86_64-apple-darwin",
           #     }
-          # arm64 Linux runner is in public preview, so test 3.13 on it
+          # test latest Python on arm64 linux & windows runners
           - rust: stable
             python-version: "3.13"
             platform:
               {
-                os: "ubuntu-22.04-arm",
+                os: "ubuntu-24.04-arm",
                 python-architecture: "arm64",
                 rust-target: "aarch64-unknown-linux-gnu",
               }


### PR DESCRIPTION
Adds a job for Windows arm64 to the PR checks, similar to how we have linux arm64 (and Windows x86).