### PR TITLE
apply default lib name for `PYO3_CONFIG_FILE` after abi3 detection

### DIFF
--- a/newsfragments/5503.fixed.md
+++ b/newsfragments/5503.fixed.md
@@ -1,0 +1,1 @@
+Fix failure to build for `abi3` interpreters on Windows using maturin's built-in sysconfig in combination with the `generate-import-lib` feature.

--- a/pyo3-build-config/Cargo.toml
+++ b/pyo3-build-config/Cargo.toml
@@ -29,6 +29,9 @@ resolve-config = []
 # This feature is enabled by pyo3 when building an extension module.
 extension-module = []
 
+# Automatically generates `python3.dll` import libraries for Windows targets.
+generate-import-lib = ["dep:python3-dll-a"]
+
 # These features are enabled by pyo3 when building Stable ABI extension modules.
 abi3 = []
 abi3-py37 = ["abi3-py38"]

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -119,7 +119,7 @@ pub fn get() -> &'static InterpreterConfig {
             .map(|path| path.exists())
             .unwrap_or(false);
 
-        // CONFIG_FILE is generated in build.rs, so it's content can vary
+        // CONFIG_FILE is generated in build.rs, so its content can vary
         #[allow(unknown_lints, clippy::const_is_empty)]
         if let Some(interpreter_config) = InterpreterConfig::from_cargo_dep_env() {
             interpreter_config
@@ -140,7 +140,7 @@ pub fn get() -> &'static InterpreterConfig {
 const CONFIG_FILE: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config-file.txt"));
 
 /// Build configuration discovered by `pyo3-build-config` build script. Not aware of
-/// cross-compilation settings.
+/// cross-compilation settings. Not generated if `PYO3_CONFIG_FILE` is set.
 #[doc(hidden)]
 #[cfg(feature = "resolve-config")]
 const HOST_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-config.txt"));

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -38,7 +38,7 @@ abi3-py313 = ["abi3-py314", "pyo3-build-config/abi3-py313"]
 abi3-py314 = ["abi3", "pyo3-build-config/abi3-py314"]
 
 # Automatically generates `python3.dll` import libraries for Windows targets.
-generate-import-lib = ["pyo3-build-config/python3-dll-a"]
+generate-import-lib = ["pyo3-build-config/generate-import-lib"]
 
 [dev-dependencies]
 paste = "1"


### PR DESCRIPTION
This moves the code added in #2404 after `abi3` detection, so that the default lib name is correctly calculated on Windows.

cc @messense - I _think_ what happened here is that `maturin` 1.9.6 got more correct at the Windows arm64 build state interpreter properly, and this led to the config file now being used (it's a cross-compile). This all seems plausibly better to me.