### PR TITLE
add `#[pyclass(from_py_object)]` to opt-in to a `FromPyObject` impl

### DIFF
--- a/guide/pyclass-parameters.md
+++ b/guide/pyclass-parameters.md
@@ -9,6 +9,7 @@
 | `eq_int` | Implements `__eq__` using `__int__` for simple enums. |
 | <span style="white-space: pre">`extends = BaseType`</span>  | Use a custom baseclass. Defaults to [`PyAny`][params-1] |
 | <span style="white-space: pre">`freelist = N`</span> |  Implements a [free list][params-2] of size N. This can improve performance for types that are often created and deleted in quick succession. Profile your code to see whether `freelist` is right for you.  |
+| `from_py_object` | Implement `FromPyObject` for this pyclass. Requires the pyclass to be `Clone`. |
 | <span style="white-space: pre">`frozen`</span> | Declares that your pyclass is immutable. It removes the borrow checker overhead when retrieving a shared reference to the Rust struct, but disables the ability to get a mutable reference. |
 | `generic` | Implements runtime parametrization for the class following [PEP 560](https://peps.python.org/pep-0560/). |
 | `get_all` | Generates getters for all fields of the pyclass. |

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -558,6 +558,8 @@ impl<'py> FromPyObject<'_, 'py> for Number {
 }
 ```
 
+As a second step the `from_py_object` option was introduced. This option also opts-out of the blanket implementation and instead generates a custom `FromPyObject` implementation for the pyclass which is functionally equivalent to the blanket.
+
 ### `IntoPyObject`
 The [`IntoPyObject`] trait defines the to-python conversion for a Rust type. All types in PyO3 implement this trait,
 as does a `#[pyclass]` which doesn't use `extends`.

--- a/newsfragments/5506.added.md
+++ b/newsfragments/5506.added.md
@@ -1,0 +1,1 @@
+add `from_py_object` pyclass option, to opt-in to the extraction of pyclasses by value (requires `Clone`)

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -53,6 +53,7 @@ pub mod kw {
     syn::custom_keyword!(warn);
     syn::custom_keyword!(message);
     syn::custom_keyword!(category);
+    syn::custom_keyword!(from_py_object);
     syn::custom_keyword!(skip_from_py_object);
 }
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -636,4 +636,25 @@ mod tests {
         })
         .unwrap();
     }
+
+    #[test]
+    #[cfg(feature = "macros")]
+    fn test_pyclass_from_py_object() {
+        use crate::{types::PyAnyMethods, IntoPyObject, PyErr, Python};
+
+        #[crate::pyclass(crate = "crate", from_py_object)]
+        #[derive(Clone)]
+        struct Foo(i32);
+
+        Python::attach(|py| {
+            let foo1 = 42i32.into_pyobject(py)?;
+            assert!(foo1.extract::<Foo>().is_err());
+
+            let foo2 = Foo(0).into_pyobject(py)?;
+            assert_eq!(foo2.extract::<Foo>()?.0, 0);
+
+            Ok::<_, PyErr>(())
+        })
+        .unwrap();
+    }
 }

--- a/src/tests/hygiene/pyclass.rs
+++ b/src/tests/hygiene/pyclass.rs
@@ -151,3 +151,9 @@ impl ::std::fmt::Display for Point {
         ::std::write!(f, "({}, {}, {})", self.x, self.y, self.z)
     }
 }
+
+#[crate::pyclass(crate = "crate", from_py_object)]
+#[derive(Clone)]
+pub struct Foo5 {
+    a: i32,
+}

--- a/tests/ui/invalid_pyclass_args.rs
+++ b/tests/ui/invalid_pyclass_args.rs
@@ -181,4 +181,16 @@ impl Display for MyEnumInvalidStrFmt {
     }
 }
 
+#[pyclass(from_py_object, skip_from_py_object)]
+struct StructTooManyFromPyObject {
+    a: String,
+    b: String,
+}
+
+#[pyclass(from_py_object)]
+struct StructFromPyObjectNoClone {
+    a: String,
+    b: String,
+}
+
 fn main() {}

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -1,4 +1,4 @@
-error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `skip_from_py_object`
+error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
  --> tests/ui/invalid_pyclass_args.rs:4:11
   |
 4 | #[pyclass(extend=pyo3::types::PyDict)]
@@ -46,7 +46,7 @@ error: expected string literal
 25 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
-error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `skip_from_py_object`
+error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
   --> tests/ui/invalid_pyclass_args.rs:28:11
    |
 28 | #[pyclass(weakrev)]
@@ -161,6 +161,25 @@ error: The format string syntax cannot be used with enums
     |
 171 | #[pyclass(eq, str = "Stuff...")]
     |                     ^^^^^^^^^^
+
+error: `skip_from_py_object` and `from_py_object` are mutually exclusive
+   --> tests/ui/invalid_pyclass_args.rs:184:27
+    |
+184 | #[pyclass(from_py_object, skip_from_py_object)]
+    |                           ^^^^^^^^^^^^^^^^^^^
+
+error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
+   --> tests/ui/invalid_pyclass_args.rs:190:11
+    |
+190 | #[pyclass(from_py_object)]
+    |           ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `StructFromPyObjectNoClone`
+    |
+    = help: see issue #48214
+help: consider annotating `StructFromPyObjectNoClone` with `#[derive(Clone)]`
+    |
+191 + #[derive(Clone)]
+192 | struct StructFromPyObjectNoClone {
+    |
 
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
   --> tests/ui/invalid_pyclass_args.rs:37:1


### PR DESCRIPTION
Follow up to #5488

This introduces the `#[pyclass(from_py_object)]` option for pyclass, to opt-in to extraction of pyclasses by value. This uses the same approach as the blanket impl that we are phasing out and thus requires the pyclass to be `Clone`.

Ref #5419 
