### PR TITLE
remove `ptr_from_ref` helpers

### DIFF
--- a/src/internal_tricks.rs
+++ b/src/internal_tricks.rs
@@ -19,18 +19,6 @@ pub(crate) fn get_ssize_index(index: usize) -> Py_ssize_t {
     index.min(PY_SSIZE_T_MAX as usize) as Py_ssize_t
 }
 
-// TODO: use ptr::from_ref on MSRV 1.76
-#[inline]
-pub(crate) const fn ptr_from_ref<T>(t: &T) -> *const T {
-    t as *const T
-}
-
-// TODO: use ptr::from_mut on MSRV 1.76
-#[inline]
-pub(crate) fn ptr_from_mut<T>(t: &mut T) -> *mut T {
-    t as *mut T
-}
-
 // TODO: use ptr::fn_addr_eq on MSRV 1.85
 pub(crate) fn clear_eq(f: Option<ffi::inquiry>, g: ffi::inquiry) -> bool {
     #[cfg(fn_ptr_eq)]

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -10,7 +10,6 @@ use crate::{
         pymethods::{Getter, PyGetterDef, PyMethodDefType, PySetterDef, Setter, _call_clear},
         trampoline::trampoline,
     },
-    internal_tricks::ptr_from_ref,
     types::{typeobject::PyTypeMethods, PyType},
     Py, PyClass, PyResult, PyTypeInfo, Python,
 };
@@ -18,7 +17,7 @@ use std::{
     collections::HashMap,
     ffi::{CStr, CString},
     os::raw::{c_char, c_int, c_ulong, c_void},
-    ptr,
+    ptr::{self, NonNull},
 };
 
 pub(crate) struct PyClassTypeObject {
@@ -700,7 +699,9 @@ impl GetSetDefType {
                     (
                         Some(getset_getter),
                         Some(getset_setter),
-                        ptr_from_ref::<GetterAndSetter>(closure) as *mut _,
+                        NonNull::<GetterAndSetter>::from(closure.as_ref())
+                            .cast()
+                            .as_ptr(),
                     )
                 }
             };


### PR DESCRIPTION
In preparation for bumping MSRV to 1.83, I noticed that we don't need the `ptr_from_ref` or `ptr_from_mut` functions at all (we tend to prefer using `NonNull` for these use cases).