### PR TITLE
ci: Use per-file-ignores for MD041 in guide/pyclass-parameters.md

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,13 @@ disable = [
 ]
 
 exclude = [
-    # cannot figure out how to ignore MD041 in this file
-    "guide/pyclass-parameters.md",
-
     # just has an include to the top-level files
     "guide/src/changelog.md",
     "guide/src/contributing.md"
 ]
+
+[tool.rumdl.per-file-ignores]
+"guide/pyclass-parameters.md" = ["MD041"]
 
 [tool.rumdl.MD004]
 style = "dash"


### PR DESCRIPTION
Hello! 👋 

Thanks for using rumdl! 

I saw the note "cannot figure out how to ignore MD041 in this file" in the pyproject.toml, so I thought I'd help out. 
The per-file-ignores option is available for this, as shown in the diff.