### PR TITLE
ci: install lychee stable using `install-action`

### DIFF
--- a/.github/workflows/netlify-build.yml
+++ b/.github/workflows/netlify-build.yml
@@ -31,15 +31,7 @@ jobs:
       - name: Setup mdBook
         uses: taiki-e/install-action@v2
         with:
-          tool: mdbook, mdbook-linkcheck
-
-      - name: Link Checker
-        id: lychee
-        uses: lycheeverse/lychee-action@v2
-        with:
-          # setup lychee but don't run it yet
-          args: --version
-          lycheeVersion: nightly
+          tool: mdbook, mdbook-linkcheck, lychee
 
       - name: Prepare tag
         id: prepare_tag


### PR DESCRIPTION
We don't need `nightly` lychee any more; the bugs which were affecting us with fragment checking (#5214) have been fixed. It also failed to install just now on #5520 