### PR TITLE
ci: fix clippy boolean condition

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -214,7 +214,7 @@ def rumdl(session: nox.Session):
 
 @nox.session(name="clippy", venv_backend="none")
 def clippy(session: nox.Session) -> bool:
-    if not _clippy(session) and _clippy_additional_workspaces(session):
+    if not (_clippy(session) and _clippy_additional_workspaces(session)):
         session.error("one or more jobs failed")
 
 


### PR DESCRIPTION
Noticed that the additional workspaces were only getting linted if the main `clippy` jobs failed. 🤦 