### PR TITLE
docs: Add Radiate to README examples section

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ about this topic.
 - [pycrdt](https://github.com/jupyter-server/pycrdt) _Python bindings for the Rust CRDT implementation [Yrs](https://github.com/y-crdt/y-crdt)._
 - [pydantic-core](https://github.com/pydantic/pydantic-core) _Core validation logic for pydantic written in Rust._
 - [primp](https://github.com/deedy5/primp) _The fastest python HTTP client that can impersonate web browsers by mimicking their headers and TLS/JA3/JA4/HTTP2 fingerprints._
+- [radiate](https://github.com/pkalivas/radiate): _A high-performance evolution engine for genetic programming and evolutionary algorithms._
 - [rateslib](https://github.com/attack68/rateslib) _A fixed income library for Python using Rust extensions._
 - [river](https://github.com/online-ml/river) _Online machine learning in python, the computationally heavy statistics algorithms are implemented in Rust._
 - [robyn](https://github.com/sparckles/Robyn) A Super Fast Async Python Web Framework with a Rust runtime.


### PR DESCRIPTION
This PR adds [Radiate](https://github.com/pkalivas/radiate) to the “Examples” section of the README.

This is a documentation-only change.

For some **context**: radiate serves as a great example of a large-scale, multi-crate rust project fully integrated with Python through PyO3. Its Python package executes _almost_ all core logic (in some cases, all) in Rust, therefore achieving near-native Rust performance, while providing a clean, idiomatic Python API. Below are a few project highlights and relevant links.

**Highlights**
- Comprehensive support for genetic algorithms, genetic programming, and neuroevolution
- Multi-objective optimization, novelty search, and speciation
- First-class, built-in metric tracking and parallel evolution (supports GIL & no GIL)
- Distributed as both a Rust crate and a Python package

**Links**
- Crate: [crates.io/crates/radiate](https://crates.io/crates/radiate)
- PyPI: [pypi.org/project/radiate](https://pypi.org/project/radiate)
- User Guide: [pkalivas.github.io/radiate](https://pkalivas.github.io/radiate)
- GitHub: [github.com/pkalivas/radiate](https://github.com/pkalivas/radiate)

PR or not, big thanks to the PyO3 team for creating/maintaining such a great ecosystem - radiate's python integration relies entirely on PyO3/maturin and wouldn't be possible without it. Please let me know if I can add any extra color here or provide any more information! 

