### PR TITLE
Link against limited API DLL under Cygwin when abi3 is used

### DIFF
--- a/newsfragments/5574.fixed.md
+++ b/newsfragments/5574.fixed.md
@@ -1,0 +1,1 @@
+Fix linking against the limited API DLL under Cygwin when abi3 is used


### PR DESCRIPTION
Like with Windows Python, we need to link to a different DLL which exports the limited API when using abi3.

This makes pyo3 link against libpython3.dll instead of libpython3.X.dll when abi3 is enabled.

Note: The limited API DLL is currently not provided in cygwin upstream, but only in MSYS2 (downstream):
https://github.com/msys2/MSYS2-packages/pull/5751
I've contacted upstream about this change
https://cygwin.com/pipermail/cygwin-apps/2025-October/044659.html

---

With #5571 and this python-cryptography builds without changes to pyo3.
