### PR TITLE
sync FFI definitions in ceval.h as of Python 3.14

### DIFF
--- a/newsfragments/5590.added.md
+++ b/newsfragments/5590.added.md
@@ -1,0 +1,1 @@
+Add FFI definitions `PyEval_GetFrameBuiltins`, `PyEval_GetFrameGlobals` and `PyEval_GetFrameLocals` on Python 3.13 and up.

--- a/newsfragments/5590.changed.md
+++ b/newsfragments/5590.changed.md
@@ -1,0 +1,1 @@
+Deprecate FFI definitions `PyEval_AcquireLock` and `PyEval_ReleaseLock`.

--- a/newsfragments/5590.removed.md
+++ b/newsfragments/5590.removed.md
@@ -1,0 +1,2 @@
+Remove FFI definition `PyEval_GetCallStats` (removed from CPython in Python 3.7).
+Remove FFI definitions `PyEval_AcquireLock` and `PyEval_ReleaseLock` on Python 3.13 and up.

--- a/pyo3-ffi/src/ceval.rs
+++ b/pyo3-ffi/src/ceval.rs
@@ -65,10 +65,13 @@ extern "C" {
     #[cfg_attr(PyPy, link_name = "PyPyEval_GetFrame")]
     pub fn PyEval_GetFrame() -> *mut crate::PyFrameObject;
 
+    #[cfg(Py_3_13)]
     #[cfg_attr(PyPy, link_name = "PyPyEval_GetFrameBuiltins")]
     pub fn PyEval_GetFrameBuiltins() -> *mut PyObject;
+    #[cfg(Py_3_13)]
     #[cfg_attr(PyPy, link_name = "PyPyEval_GetFrameGlobals")]
     pub fn PyEval_GetFrameGlobals() -> *mut PyObject;
+    #[cfg(Py_3_13)]
     #[cfg_attr(PyPy, link_name = "PyPyEval_GetFrameLocals")]
     pub fn PyEval_GetFrameLocals() -> *mut PyObject;
 


### PR DESCRIPTION
Noticed this had a few missing / outdated pieces.