### PR TITLE
switch issue templates to use task types instead of bug / enhancement label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: 🐛 Bug Report
 description: Create a bug report
-labels: [bug]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,10 @@
 ---
 name: 💡 Feature request
 about: Suggest an idea for this project
-labels: [enhancement]
+type: Feature
 ---
 
-<!-- 
+<!--
 Thank you for sharing your idea!
 
 Please describe your idea in depth. If you're not sure what to write, imagine the following:


### PR DESCRIPTION
Looks like github has "issue type" which includes bug / feature, I propose let's use these instead of labels.

If we merge this, I'll clean up the issue tracker past & present to match.