### PR TITLE
remove duplicate blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,4 +1,0 @@
----
-name: 📝 Blank Issue
-about: Create a blank issue.
----


### PR DESCRIPTION
Just noticed we have two "blank issue" items in the new issue menu, let's deduplicate and just use GitHub's built-in one.

<img width="794" height="469" alt="image" src="https://github.com/user-attachments/assets/309c666b-2917-4a9b-bd12-9c6b5518b574" />