### PR TITLE
fixup `towncrier` config

### DIFF
--- a/.towncrier.template.md
+++ b/.towncrier.template.md
@@ -1,6 +1,8 @@
 {% for section_text, section in sections.items() %}{%- if section %}{{section_text}}{% endif -%}
+
 {% if section %}
 {% for category in ['packaging', 'added', 'changed', 'removed', 'fixed' ] if category in section %}
+
 ### {{ definitions[category]['name'] }}
 
 {% if definitions[category]['showcontent'] %}
@@ -10,5 +12,10 @@
 {% else %}
 - {{ section[category]['']|join(', ') }}
 {% endif %}
+{% endfor %}
+{% else %}
 
-{% endfor %}{% else %}No significant changes.{% endif %}{% endfor %}
+No significant changes.
+{% endif %}
+
+{% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ template = ".towncrier.template.md"
 title_format = "## [{version}] - {project_date}"
 issue_format = "[#{issue}](https://github.com/PyO3/pyo3/pull/{issue})"  # Note PyO3 shows pulls, not issues, in the CHANGELOG
 underlines = ["", "", ""]
+directory = "newsfragments"
 
 [tool.towncrier.fragment.packaging]
 name = "Packaging"


### PR DESCRIPTION
Just noticed the formatting and content was broken on https://pyo3.rs/main/changelog.html

<img width="456" height="149" alt="image" src="https://github.com/user-attachments/assets/111b6fa7-0739-4e23-8241-818915321a76" />

Will just merge this as trivial.