### PR TITLE
Update plugin example to work with recent changes

### DIFF
--- a/examples/plugin/src/main.rs
+++ b/examples/plugin/src/main.rs
@@ -1,7 +1,6 @@
 use plugin_api::plugin_api as pylib_module;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
-use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     //"export" our API module to the python runtime
@@ -9,11 +8,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //spawn runtime
     Python::initialize();
     //import path for python
-    let path = Path::new("./python_plugin/");
+    let path = "./python_plugin/";
     //do useful work
     Python::attach(|py| {
         //add the current directory to import path of Python (do not use this in production!)
-        let syspath: Bound<PyList> = py.import("sys")?.getattr("path")?.extract()?;
+        let syspath: Bound<PyList> = py.import("sys")?.getattr("path")?.extract().map_err(PyErr::from)?;
         syspath.insert(0, &path)?;
         println!("Import path is: {:?}", syspath);
 
@@ -28,7 +27,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         {
             //this scope will have mutable access to the gadget instance, which will be dropped on
             //scope exit so Python can access it again.
-            let mut gadget_rs: PyRefMut<'_, plugin_api::Gadget> = gadget.extract()?;
+            let mut gadget_rs: PyRefMut<'_, plugin_api::Gadget> = gadget.extract().map_err( PyErr::from)?;
             // we can now modify it as if it was a native rust struct
             gadget_rs.prop = 42;
             //which includes access to rust-only fields that are not visible to python

--- a/newsfragments/5601.fixed.md
+++ b/newsfragments/5601.fixed.md
@@ -1,0 +1,1 @@
+Updated plugin example to work with recent changes to library


### PR DESCRIPTION
`Path::into_pyobject` now returns a `pathlib.Path` object which doesn't work
as expected when added to `sys.path` so revert to string (see #4925).

`impl FromPyObject for PyRefMut` now returns a custom error type (that
doesn't impl `std::error::Error`) so map the error back to `PyErr` to
return it (see #5413).