### PR TITLE
Introspection: split module and name in decorators

### DIFF
--- a/newsfragments/5618.changed.md
+++ b/newsfragments/5618.changed.md
@@ -1,0 +1,1 @@
+Introspection: properly represent decorators as module + name (allows to get imports working)

--- a/pyo3-introspection/src/model.rs
+++ b/pyo3-introspection/src/model.rs
@@ -19,7 +19,7 @@ pub struct Class {
 pub struct Function {
     pub name: String,
     /// decorator like 'property' or 'staticmethod'
-    pub decorators: Vec<String>,
+    pub decorators: Vec<PythonIdentifier>,
     pub arguments: Arguments,
     /// return type
     pub returns: Option<TypeHint>,
@@ -77,17 +77,27 @@ pub enum TypeHint {
 /// A type hint annotation as an AST fragment
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub enum TypeHintExpr {
-    /// A local identifier which module is unknown
-    Local { id: String },
-    /// A Python builtin like `int`
-    Builtin { id: String },
-    /// The attribute of a python object like `{value}.{attr}`
-    Attribute { module: String, attr: String },
+    /// An identifier
+    Identifier(PythonIdentifier),
     /// A union `{left} | {right}`
-    Union { elts: Vec<TypeHintExpr> },
+    Union(Vec<TypeHintExpr>),
     /// A subscript `{value}[*slice]`
     Subscript {
         value: Box<TypeHintExpr>,
         slice: Vec<TypeHintExpr>,
     },
+}
+
+impl From<PythonIdentifier> for TypeHintExpr {
+    #[inline]
+    fn from(value: PythonIdentifier) -> Self {
+        Self::Identifier(value)
+    }
+}
+
+/// An Python identifier, either local (with `module = None`) or global (with `module = Some(_)`)
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub struct PythonIdentifier {
+    pub module: Option<String>,
+    pub name: String,
 }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -16,7 +16,7 @@ use crate::attributes::{
 use crate::combine_errors::CombineErrors;
 #[cfg(feature = "experimental-inspect")]
 use crate::introspection::{
-    class_introspection_code, function_introspection_code, introspection_id_const,
+    class_introspection_code, function_introspection_code, introspection_id_const, PythonIdentifier,
 };
 use crate::konst::{ConstAttributes, ConstSpec};
 use crate::method::{FnArg, FnSpec, PyArg, RegularArg};
@@ -1900,7 +1900,7 @@ fn descriptors_to_items(
                     &FunctionSignature::from_arguments(vec![]),
                     Some("self"),
                     parse_quote!(-> #return_type),
-                    vec!["property".into()],
+                    vec![PythonIdentifier::builtins("property")],
                     Some(&parse_quote!(#cls)),
                 ));
             }
@@ -1939,7 +1939,7 @@ fn descriptors_to_items(
                     })]),
                     Some("self"),
                     syn::ReturnType::Default,
-                    vec![format!("{name}.setter")],
+                    vec![PythonIdentifier::local(format!("{name}.setter"))],
                     Some(&parse_quote!(#cls)),
                 ));
             }

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -15,6 +15,8 @@ use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, ToTokens};
 use std::cmp::PartialEq;
 use std::ffi::CString;
+#[cfg(feature = "experimental-inspect")]
+use std::iter::empty;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::LitCStr;
@@ -393,7 +395,7 @@ pub fn impl_wrap_pyfunction(
         &signature,
         None,
         func.sig.output.clone(),
-        [] as [String; 0],
+        empty(),
         None,
     );
     #[cfg(not(feature = "experimental-inspect"))]

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 
 use crate::combine_errors::CombineErrors;
 #[cfg(feature = "experimental-inspect")]
-use crate::introspection::{attribute_introspection_code, function_introspection_code};
+use crate::introspection::{
+    attribute_introspection_code, function_introspection_code, PythonIdentifier,
+};
 #[cfg(feature = "experimental-inspect")]
 use crate::method::{FnSpec, FnType};
 #[cfg(feature = "experimental-inspect")]
@@ -400,11 +402,11 @@ fn method_introspection_code(spec: &FnSpec<'_>, parent: &syn::Type, ctx: &Ctx) -
     match &spec.tp {
         FnType::Getter(_) => {
             first_argument = Some("self");
-            decorators.push("property".into());
+            decorators.push(PythonIdentifier::builtins("property"));
         }
         FnType::Setter(_) => {
             first_argument = Some("self");
-            decorators.push(format!("{name}.setter"));
+            decorators.push(PythonIdentifier::local(format!("{name}.setter")));
         }
         FnType::Fn(_) => {
             first_argument = Some("self");
@@ -415,17 +417,17 @@ fn method_introspection_code(spec: &FnSpec<'_>, parent: &syn::Type, ctx: &Ctx) -
         }
         FnType::FnClass(_) => {
             first_argument = Some("cls");
-            decorators.push("classmethod".into());
+            decorators.push(PythonIdentifier::builtins("classmethod"));
         }
         FnType::FnStatic => {
-            decorators.push("staticmethod".into());
+            decorators.push(PythonIdentifier::builtins("staticmethod"));
         }
         FnType::FnModule(_) => (), // TODO: not sure this can happen
         FnType::ClassAttribute => {
             first_argument = Some("cls");
             // TODO: this combination only works with Python 3.9-3.11 https://docs.python.org/3.11/library/functions.html#classmethod
-            decorators.push("classmethod".into());
-            decorators.push("property".into());
+            decorators.push(PythonIdentifier::builtins("classmethod"));
+            decorators.push(PythonIdentifier::builtins("property"));
         }
     }
     function_introspection_code(


### PR DESCRIPTION
Introspection API: Introduces the `PythonIdentifier` struct to store an optional module name + a name inside the module or local

First step to get `@typing.Final` on classes (#5552)