### PR TITLE
ci: pin `mdbook` to 0.4 for now, properly install `mdbook-tabs`

### DIFF
--- a/.github/workflows/netlify-build.yml
+++ b/.github/workflows/netlify-build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup mdBook
         uses: taiki-e/install-action@v2
         with:
-          tool: mdbook, mdbook-linkcheck, lychee
+          tool: mdbook@0.4, mdbook-tabs@0.2, lychee
 
       - name: Prepare tag
         id: prepare_tag


### PR DESCRIPTION
Should fix the guide build failures.

`mdbook-linkcheck` is not needed (we use `lychee` for this purpose).