### PR TITLE
Change author field to authors list in book.toml

### DIFF
--- a/guide/book.toml
+++ b/guide/book.toml
@@ -1,7 +1,7 @@
 [book]
 title = "PyO3 user guide"
 description = "PyO3 user guide"
-author = "PyO3 Project and Contributors"
+authors = ["PyO3 Project and Contributors"]
 
 [preprocessor.pyo3_version]
 command = "python3 guide/pyo3_version.py"


### PR DESCRIPTION
i don't know anything about mdbook beyond the error in ci and the example at https://rust-lang.github.io/mdBook/format/configuration/general.html#general-metadata

i now see https://github.com/PyO3/pyo3/pull/5632 pinning back mdbook.  i guess i'll see if this is enough or not.