### PR TITLE
Introspection: macro: introduce a PythonTypeHint struct

### DIFF
--- a/pyo3-introspection/src/introspection.rs
+++ b/pyo3-introspection/src/introspection.rs
@@ -224,7 +224,7 @@ fn convert_decorator(decorator: &ChunkTypeHint) -> Result<PythonIdentifier> {
             if let TypeHintExpr::Identifier(i) = expr {
                 Ok(i)
             } else {
-                bail!("PyO3 introspection currently only support decorators that are identifiers of a Python function")
+                bail!("PyO3 introspection currently only support decorators that are identifiers of a Python function, got {expr:?}")
             }
         }
     }

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -1,7 +1,7 @@
 use crate::attributes::{DefaultAttribute, FromPyWithAttribute, RenamingRule};
 use crate::derive_attributes::{ContainerAttributes, FieldAttributes, FieldGetter};
 #[cfg(feature = "experimental-inspect")]
-use crate::introspection::elide_lifetimes;
+use crate::type_hint::PythonTypeHint;
 use crate::utils::{self, Ctx};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
@@ -100,12 +100,8 @@ impl<'a> Enum<'a> {
     }
 
     #[cfg(feature = "experimental-inspect")]
-    fn input_type(&self, ctx: &Ctx) -> TokenStream {
-        let pyo3_crate_path = &ctx.pyo3_path;
-        let variants = self.variants.iter().map(|var| var.input_type(ctx));
-        quote! {
-            #pyo3_crate_path::inspect::TypeHint::union(&[#(#variants),*])
-        }
+    fn input_type(&self) -> PythonTypeHint {
+        PythonTypeHint::union(self.variants.iter().map(|var| var.input_type()))
     }
 }
 
@@ -457,24 +453,23 @@ impl<'a> Container<'a> {
     }
 
     #[cfg(feature = "experimental-inspect")]
-    fn input_type(&self, ctx: &Ctx) -> TokenStream {
-        let pyo3_crate_path = &ctx.pyo3_path;
+    fn input_type(&self) -> PythonTypeHint {
         match &self.ty {
             ContainerType::StructNewtype(_, from_py_with, ty) => {
-                Self::field_input_type(from_py_with, ty, ctx)
+                Self::field_input_type(from_py_with, ty)
             }
             ContainerType::TupleNewtype(from_py_with, ty) => {
-                Self::field_input_type(from_py_with, ty, ctx)
+                Self::field_input_type(from_py_with, ty)
             }
-            ContainerType::Tuple(tups) => {
-                let elements = tups.iter().map(|TupleStructField { from_py_with, ty }| {
-                    Self::field_input_type(from_py_with, ty, ctx)
-                });
-                quote! { #pyo3_crate_path::inspect::TypeHint::subscript(&#pyo3_crate_path::inspect::TypeHint::builtin("tuple"), &[#(#elements),*]) }
-            }
+            ContainerType::Tuple(tups) => PythonTypeHint::subscript(
+                PythonTypeHint::builtin("tuple"),
+                tups.iter().map(|TupleStructField { from_py_with, ty }| {
+                    Self::field_input_type(from_py_with, ty)
+                }),
+            ),
             ContainerType::Struct(_) => {
                 // TODO: implement using a Protocol?
-                quote! { #pyo3_crate_path::inspect::TypeHint::module_attr("_typeshed", "Incomplete") }
+                PythonTypeHint::module_attr("_typeshed", "Incomplete")
             }
         }
     }
@@ -483,16 +478,12 @@ impl<'a> Container<'a> {
     fn field_input_type(
         from_py_with: &Option<FromPyWithAttribute>,
         ty: &syn::Type,
-        ctx: &Ctx,
-    ) -> TokenStream {
-        let pyo3_crate_path = &ctx.pyo3_path;
+    ) -> PythonTypeHint {
         if from_py_with.is_some() {
             // We don't know what from_py_with is doing
-            quote! { #pyo3_crate_path::inspect::TypeHint::module_attr("_typeshed", "Incomplete") }
+            PythonTypeHint::module_attr("_typeshed", "Incomplete")
         } else {
-            let mut ty = ty.clone();
-            elide_lifetimes(&mut ty);
-            quote! { <#ty as #pyo3_crate_path::FromPyObject<'_, '_>>::INPUT_TYPE }
+            PythonTypeHint::from_from_py_object(ty.clone(), None)
         }
     }
 }
@@ -570,22 +561,22 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
             .all(|p| matches!(p, syn::GenericParam::Lifetime(_)))
         {
             match &tokens.data {
-                syn::Data::Enum(en) => Enum::new(en, &tokens.ident, options)?.input_type(ctx),
+                syn::Data::Enum(en) => Enum::new(en, &tokens.ident, options)?.input_type(),
                 syn::Data::Struct(st) => {
                     let ident = &tokens.ident;
-                    Container::new(&st.fields, parse_quote!(#ident), options.clone())?
-                        .input_type(ctx)
+                    Container::new(&st.fields, parse_quote!(#ident), options.clone())?.input_type()
                 }
                 syn::Data::Union(_) => {
                     // Not supported at this point
-                    quote! { #pyo3_crate_path::inspect::TypeHint::module_attr("_typeshed", "Incomplete") }
+                    PythonTypeHint::module_attr("_typeshed", "Incomplete")
                 }
             }
         } else {
             // We don't know how to deal with generic parameters
             // Blocked by https://github.com/rust-lang/rust/issues/76560
-            quote! { #pyo3_crate_path::inspect::TypeHint::module_attr("_typeshed", "Incomplete") }
-        };
+            PythonTypeHint::module_attr("_typeshed", "Incomplete")
+        }
+        .to_introspection_token_stream(pyo3_crate_path);
         quote! { const INPUT_TYPE: #pyo3_crate_path::inspect::TypeHint = #input_type; }
     };
     #[cfg(not(feature = "experimental-inspect"))]

--- a/pyo3-macros-backend/src/lib.rs
+++ b/pyo3-macros-backend/src/lib.rs
@@ -25,6 +25,8 @@ mod pyimpl;
 mod pymethod;
 mod pyversions;
 mod quotes;
+#[cfg(feature = "experimental-inspect")]
+mod type_hint;
 
 pub use frompyobject::build_derive_from_pyobject;
 pub use intopyobject::build_derive_into_pyobject;

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -16,7 +16,7 @@ use crate::attributes::{
 use crate::combine_errors::CombineErrors;
 #[cfg(feature = "experimental-inspect")]
 use crate::introspection::{
-    class_introspection_code, function_introspection_code, introspection_id_const, PythonIdentifier,
+    class_introspection_code, function_introspection_code, introspection_id_const,
 };
 use crate::konst::{ConstAttributes, ConstSpec};
 use crate::method::{FnArg, FnSpec, PyArg, RegularArg};
@@ -32,6 +32,8 @@ use crate::pymethod::{
     __REPR__, __RICHCMP__, __STR__,
 };
 use crate::pyversions::{is_abi3_before, is_py_before};
+#[cfg(feature = "experimental-inspect")]
+use crate::type_hint::PythonTypeHint;
 use crate::utils::{self, apply_renaming_rule, Ctx, PythonDoc};
 use crate::PyFunctionOptions;
 
@@ -1897,7 +1899,7 @@ fn descriptors_to_items(
                     &FunctionSignature::from_arguments(vec![]),
                     Some("self"),
                     parse_quote!(-> #return_type),
-                    vec![PythonIdentifier::builtins("property")],
+                    vec![PythonTypeHint::builtin("property")],
                     Some(&parse_quote!(#cls)),
                 ));
             }
@@ -1936,7 +1938,7 @@ fn descriptors_to_items(
                     })]),
                     Some("self"),
                     syn::ReturnType::Default,
-                    vec![PythonIdentifier::local(format!("{name}.setter"))],
+                    vec![PythonTypeHint::local(format!("{name}.setter"))],
                     Some(&parse_quote!(#cls)),
                 ));
             }

--- a/pyo3-macros-backend/src/type_hint.rs
+++ b/pyo3-macros-backend/src/type_hint.rs
@@ -1,0 +1,209 @@
+//! Define a data structure for Python type hints, mixing static data from macros and call to Pyo3 constants.
+
+use crate::utils::PyO3CratePath;
+use proc_macro2::TokenStream;
+use quote::quote;
+use std::borrow::Cow;
+use syn::visit_mut::{visit_type_mut, VisitMut};
+use syn::{Lifetime, Type};
+
+#[derive(Clone)]
+pub struct PythonTypeHint(PythonTypeHintVariant);
+
+#[derive(Clone)]
+enum PythonTypeHintVariant {
+    /// The Python type hint of a FromPyObject implementation
+    FromPyObject(Type),
+    /// The Python type hint of a IntoPyObject implementation
+    IntoPyObject(Type),
+    /// The Python type matching the given Rust type given as a function argument
+    ArgumentType(Type),
+    /// The Python type matching the given Rust type given as a function returned value
+    ReturnType(Type),
+    /// A local type
+    Local(Cow<'static, str>),
+    /// A type in a module
+    ModuleAttribute {
+        module: Cow<'static, str>,
+        attr: Cow<'static, str>,
+    },
+    /// A union
+    Union(Vec<PythonTypeHint>),
+    /// A subscript
+    Subscript {
+        value: Box<PythonTypeHint>,
+        slice: Vec<PythonTypeHint>,
+    },
+}
+
+impl PythonTypeHint {
+    /// Build from a local name
+    pub fn local(name: impl Into<Cow<'static, str>>) -> Self {
+        Self(PythonTypeHintVariant::Local(name.into()))
+    }
+
+    /// Build from a builtins name like `None`
+    pub fn builtin(name: impl Into<Cow<'static, str>>) -> Self {
+        Self::module_attr("builtins", name)
+    }
+
+    /// Build from a module and a name like `collections.abc` and `Sequence`
+    pub fn module_attr(
+        module: impl Into<Cow<'static, str>>,
+        name: impl Into<Cow<'static, str>>,
+    ) -> Self {
+        Self(PythonTypeHintVariant::ModuleAttribute {
+            module: module.into(),
+            attr: name.into(),
+        })
+    }
+
+    /// The type hint of a FromPyObject implementation as a function argument
+    ///
+    /// If self_type is set, Self in the given type will be replaced by self_type
+    pub fn from_from_py_object(t: Type, self_type: Option<&Type>) -> Self {
+        Self(PythonTypeHintVariant::FromPyObject(clean_type(
+            t, self_type,
+        )))
+    }
+
+    /// The type hint of a IntoPyObject implementation as a function argument
+    ///
+    /// If self_type is set, Self in the given type will be replaced by self_type
+    pub fn from_into_py_object(t: Type, self_type: Option<&Type>) -> Self {
+        Self(PythonTypeHintVariant::IntoPyObject(clean_type(
+            t, self_type,
+        )))
+    }
+
+    /// The type hint of the Rust type used as a function argument
+    ///
+    /// If self_type is set, Self in the given type will be replaced by self_type
+    pub fn from_argument_type(t: Type, self_type: Option<&Type>) -> Self {
+        Self(PythonTypeHintVariant::ArgumentType(clean_type(
+            t, self_type,
+        )))
+    }
+
+    /// The type hint of the Rust type used as a function output type
+    ///
+    /// If self_type is set, Self in the given type will be replaced by self_type
+    pub fn from_return_type(t: Type, self_type: Option<&Type>) -> Self {
+        Self(PythonTypeHintVariant::ReturnType(clean_type(t, self_type)))
+    }
+
+    /// Build the union of the different element
+    pub fn union(elements: impl IntoIterator<Item = Self>) -> Self {
+        let elements = elements.into_iter().collect::<Vec<_>>();
+        if elements.len() == 1 {
+            return elements.into_iter().next().unwrap();
+        }
+        Self(PythonTypeHintVariant::Union(elements))
+    }
+
+    /// Build the subscripted type value[slice[0], ..., slice[n]]
+    pub fn subscript(value: Self, slice: impl IntoIterator<Item = Self>) -> Self {
+        Self(crate::type_hint::PythonTypeHintVariant::Subscript {
+            value: Box::new(value),
+            slice: slice.into_iter().collect(),
+        })
+    }
+
+    pub fn to_introspection_token_stream(&self, pyo3_crate_path: &PyO3CratePath) -> TokenStream {
+        match &self.0 {
+            PythonTypeHintVariant::Local(name) => {
+                quote! { #pyo3_crate_path::inspect::TypeHint::local(#name) }
+            }
+            PythonTypeHintVariant::ModuleAttribute { module, attr } => {
+                if module == "builtins" {
+                    quote! { #pyo3_crate_path::inspect::TypeHint::builtin(#attr) }
+                } else {
+                    quote! { #pyo3_crate_path::inspect::TypeHint::module_attr(#module, #attr) }
+                }
+            }
+            PythonTypeHintVariant::FromPyObject(t) => {
+                quote! { <#t as #pyo3_crate_path::FromPyObject<'_, '_>>::INPUT_TYPE }
+            }
+            PythonTypeHintVariant::IntoPyObject(t) => {
+                quote! { <#t as #pyo3_crate_path::IntoPyObject<'_>>::OUTPUT_TYPE }
+            }
+            PythonTypeHintVariant::ArgumentType(t) => {
+                quote! {
+                    <#t as #pyo3_crate_path::impl_::extract_argument::PyFunctionArgument<
+                        {
+                            #[allow(unused_imports, reason = "`Probe` trait used on negative case only")]
+                            use #pyo3_crate_path::impl_::pyclass::Probe as _;
+                            #pyo3_crate_path::impl_::pyclass::IsFromPyObject::<#t>::VALUE
+                        }
+                    >>::INPUT_TYPE
+                }
+            }
+            PythonTypeHintVariant::ReturnType(t) => {
+                quote! { <#t as #pyo3_crate_path::impl_::introspection::PyReturnType>::OUTPUT_TYPE }
+            }
+            PythonTypeHintVariant::Union(elements) => {
+                let elements = elements
+                    .iter()
+                    .map(|elt| elt.to_introspection_token_stream(pyo3_crate_path));
+                quote! { #pyo3_crate_path::inspect::TypeHint::union(&[#(#elements),*]) }
+            }
+            PythonTypeHintVariant::Subscript { value, slice } => {
+                let value = value.to_introspection_token_stream(pyo3_crate_path);
+                let slice = slice
+                    .iter()
+                    .map(|elt| elt.to_introspection_token_stream(pyo3_crate_path));
+                quote! { #pyo3_crate_path::inspect::TypeHint::subscript(&#value, &[#(#slice),*]) }
+            }
+        }
+    }
+}
+
+fn clean_type(mut t: Type, self_type: Option<&Type>) -> Type {
+    if let Some(self_type) = self_type {
+        replace_self(&mut t, self_type);
+    }
+    elide_lifetimes(&mut t);
+    t
+}
+
+/// Replaces all explicit lifetimes in `self` with elided (`'_`) lifetimes
+///
+/// This is useful if `Self` is used in `const` context, where explicit
+/// lifetimes are not allowed (yet).
+fn elide_lifetimes(ty: &mut Type) {
+    struct ElideLifetimesVisitor;
+
+    impl VisitMut for ElideLifetimesVisitor {
+        fn visit_lifetime_mut(&mut self, l: &mut syn::Lifetime) {
+            *l = Lifetime::new("'_", l.span());
+        }
+    }
+
+    ElideLifetimesVisitor.visit_type_mut(ty);
+}
+
+// Replace Self in types with the given type
+fn replace_self(ty: &mut Type, self_target: &Type) {
+    struct SelfReplacementVisitor<'a> {
+        self_target: &'a Type,
+    }
+
+    impl VisitMut for SelfReplacementVisitor<'_> {
+        fn visit_type_mut(&mut self, ty: &mut Type) {
+            if let Type::Path(type_path) = ty {
+                if type_path.qself.is_none()
+                    && type_path.path.segments.len() == 1
+                    && type_path.path.segments[0].ident == "Self"
+                    && type_path.path.segments[0].arguments.is_empty()
+                {
+                    // It is Self
+                    *ty = self.self_target.clone();
+                    return;
+                }
+            }
+            visit_type_mut(self, ty);
+        }
+    }
+
+    SelfReplacementVisitor { self_target }.visit_type_mut(ty);
+}


### PR DESCRIPTION
Allows to build static type hint or manipulate the ones from PyO3 traits

Makes type hint manipulation code much nicer
