### PR TITLE
add `clone_ref` methods to `PyBacked` types

### DIFF
--- a/newsfragments/5654.added.md
+++ b/newsfragments/5654.added.md
@@ -1,0 +1,1 @@
+Add `PyBackedStr::clone_ref` and `PyBackedBytes::clone_ref` methods.


### PR DESCRIPTION
This PR adds `PyBackedStr::clone_ref` and `PyBackedBytes::clone_ref`. This essentially does a reference-counted clone by delegating to `Py::clone_ref` (except if the bytes are in Rust storage).

This may also help with the closed #5462 in cases where the Python token is available (cc @bschoenmaeckers).