### PR TITLE
add `#[cold]` paths for unlikely error-fetching branches

### DIFF
--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -628,13 +628,9 @@ impl PyErr {
 fn failed_to_fetch() -> PyErr {
     const FAILED_TO_FETCH: &str = "attempted to fetch exception but none was set";
 
-    #[cfg(debug_assertions)]
-    {
+    if cfg!(debug_assertions) {
         panic!("{}", FAILED_TO_FETCH)
-    }
-
-    #[cfg(not(debug_assertions))]
-    {
+    } else {
         crate::exceptions::PySystemError::new_err(FAILED_TO_FETCH)
     }
 }


### PR DESCRIPTION
This PR carries out a small cleanup I noted while reading the error implementation recently.

The error handling code had logic to handle panics and missing exceptions inline in the functions. I pull this all out into separate `#[cold]` functions so that the happy paths are as lean as possible.