### PR TITLE
ci: move more ci onto Python 3.14

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - run: python -m pip install --upgrade pip && pip install nox[uv]
       - run: nox -s check-changelog

--- a/.github/workflows/ci-cache-warmup.yml
+++ b/.github/workflows/ci-cache-warmup.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-gnu,x86_64-pc-windows-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: python -m pip install --upgrade pip && pip install nox[uv]
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: resolve MSRV
         id: resolve-msrv
         run: echo MSRV=`python -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["rust-version"])'` >> $GITHUB_OUTPUT
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Fetch merge base
         id: fetch_merge_base
         uses: ./.github/actions/fetch-merge-base
@@ -76,7 +76,7 @@ jobs:
           components: rust-src
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
@@ -393,7 +393,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
@@ -414,7 +414,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
@@ -436,7 +436,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
@@ -539,7 +539,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
@@ -563,7 +563,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
@@ -608,7 +608,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: examples/maturin-starter
@@ -638,7 +638,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-gnu,x86_64-pc-windows-msvc
@@ -692,7 +692,7 @@ jobs:
           components: rust-src
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           architecture: ${{ matrix.platform.python-architecture }}
       - uses: Swatinem/rust-cache@v2
         with:
@@ -713,7 +713,7 @@ jobs:
           components: rust-src
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - run: python -m pip install --upgrade pip && pip install nox[uv]
       - run: nox -s test-introspection
 

--- a/.github/workflows/coverage-pr-base.yml
+++ b/.github/workflows/coverage-pr-base.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Fetch merge base
         id: fetch_merge_base
         uses: ./.github/actions/fetch-merge-base

--- a/.github/workflows/netlify-build.yml
+++ b/.github/workflows/netlify-build.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v6.0.0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - uses: dtolnay/rust-toolchain@nightly
 


### PR DESCRIPTION
This updates a bunch of CI jobs to use Python 3.14 (including the benchmarks).