### PR TITLE
use singleton in simple enum `IntoPyObject`

### DIFF
--- a/newsfragments/5665.changed.md
+++ b/newsfragments/5665.changed.md
@@ -1,0 +1,1 @@
+`IntoPyObject` for simple enums now uses a sigleton value, allowing identity (python `is`) comparisons

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -54,7 +54,8 @@ fn test_return_enum() {
         let f = wrap_pyfunction!(return_enum)(py).unwrap();
         let mynum = py.get_type::<MyEnum>();
 
-        py_run!(py, f mynum, "assert f() == mynum.Variant")
+        py_run!(py, f mynum, "assert f() == mynum.Variant");
+        py_run!(py, f mynum, "assert f() is mynum.Variant");
     });
 }
 


### PR DESCRIPTION
This attempts solving #3059 by changing the generated `IntoPyObject` implementation for simple enums.
This lazily stores the instances in a static array and creates them on first access.

This solves the issue for the cases where `IntoPyObject` is used, so for example the class attribute and function return types can now be compared by identity. This does not solve the issue that `Py|Bound::new` behave differently here. This is similar to #3747 as well. The solution for that is probably to remove the `impl<T> From<T> for PyClassInitializer<T>` blanket and instead emit customized code via `#[pyclass]`. That could be done as a follow up.