### PR TITLE
fix `async` functions return `()`, not `None`

### DIFF
--- a/newsfragments/5685.fixed.md
+++ b/newsfragments/5685.fixed.md
@@ -1,0 +1,1 @@
+fix `async` functions return `()`, not `None`

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -704,7 +704,12 @@ impl<'a> FnSpec<'a> {
                         #throw_callback,
                         async move {
                             let fut = future.await;
-                            #pyo3_path::impl_::wrap::converter(&fut).wrap(fut)
+                            let res = #pyo3_path::impl_::wrap::converter(&fut).wrap(fut).map_err(::std::convert::Into::into);
+                            #pyo3_path::impl_::wrap::converter(&res).map_into_pyobject(
+                                // SAFETY: attached when future is polled (see `Coroutine::poll`)
+                                unsafe { #pyo3_path::Python::assume_attached() },
+                                res
+                            )
                         },
                     )
                 }};

--- a/src/impl_/coroutine.rs
+++ b/src/impl_/coroutine.rs
@@ -9,19 +9,17 @@ use crate::{
     pycell::impl_::PyClassBorrowChecker,
     pyclass::boolean_struct::False,
     types::PyString,
-    IntoPyObject, Py, PyAny, PyClass, PyErr, PyResult, Python,
+    Py, PyAny, PyClass, PyErr, PyResult, Python,
 };
 
-pub fn new_coroutine<'py, F, T, E>(
+pub fn new_coroutine<'py, F>(
     name: &Bound<'py, PyString>,
     qualname_prefix: Option<&'static str>,
     throw_callback: Option<ThrowCallback>,
     future: F,
 ) -> Coroutine
 where
-    F: Future<Output = Result<T, E>> + Send + 'static,
-    T: IntoPyObject<'py>,
-    E: Into<PyErr>,
+    F: Future<Output = Result<Py<PyAny>, PyErr>> + Send + 'static,
 {
     Coroutine::new(Some(name.clone()), qualname_prefix, throw_callback, future)
 }

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -67,6 +67,11 @@ impl EmptyTupleConverter<PyResult<()>> {
     pub fn map_into_ptr(&self, py: Python<'_>, obj: PyResult<()>) -> PyResult<*mut ffi::PyObject> {
         obj.map(|_| PyNone::get(py).to_owned().into_ptr())
     }
+
+    #[inline]
+    pub fn map_into_pyobject(&self, py: Python<'_>, obj: PyResult<()>) -> PyResult<Py<PyAny>> {
+        obj.map(|_| PyNone::get(py).to_owned().into_any().unbind())
+    }
 }
 
 impl<'py, T: IntoPyObject<'py>> IntoPyObjectConverter<T> {

--- a/tests/test_coroutine.rs
+++ b/tests/test_coroutine.rs
@@ -39,6 +39,18 @@ fn noop_coroutine() {
 }
 
 #[test]
+fn test_async_function_returns_unit_none() {
+    #[pyfunction]
+    async fn returns_unit() {}
+
+    Python::attach(|py| {
+        let returns_unit = wrap_pyfunction!(returns_unit, py).unwrap();
+        let test = "import asyncio; assert asyncio.run(returns_unit()) is None";
+        pyo3::py_run!(py, returns_unit, &handle_windows(test));
+    });
+}
+
+#[test]
 fn test_coroutine_qualname() {
     #[pyfunction]
     async fn my_fn() {}


### PR DESCRIPTION
Fixes #5683 by moving this wrapping into the macro code:
https://github.com/PyO3/pyo3/blob/e74edbf955730d51c8cad9d7f0bc55092ab419fe/src/coroutine.rs#L61-L65
This way we can use the same specialization that the regular functions also use.
