### PR TITLE
feat: raw pointer capsule instantiation method

### DIFF
--- a/newsfragments/5689.added.md
+++ b/newsfragments/5689.added.md
@@ -1,0 +1,1 @@
+Add `PyCapsule::new_with_pointer` and `PyCapsule::new_with_pointer_and_destructor` for creating capsules with raw pointers.


### PR DESCRIPTION
> - via #5688 

Implements `PyCapsule::new_with_pointer` and `PyCapsule::new_with_pointer_and_destructor` as described in the issue above

## Purpose

Allows users to write much simpler code, without getting under the hood of `pyo3-ffi` to make a `pyo3::PyCapsule`

**Edit**: original version using `*mut c_void` was deprecated

<details><summary>Click to show original version</summary>
<p>

```rust
#[pyfunction(name = "rms_norm")]
fn rms_norm_jax(py: Python<'_>) -> PyResult<Bound<'_, PyCapsule>> {
    unsafe {
        PyCapsule::new_with_pointer(py, ffi::RmsNorm as *mut c_void, None)
    }
}
```

</p>
</details> 

**Update** We now use the `std::ptr::NonNull<T>`  type (in which the T is a `*mut T`) so we can write it as `NonNull<c_void>` instead of `*mut c_void` and then checking `ptr.is_null()`.

Usage would therefore be

```rust
#[pyfunction(name = "rms_norm")]
fn rms_norm_jax(py: Python<'_>) -> PyResult<Bound<'_, PyCapsule>> {
    let fn_ptr = NonNull::new(ffi::RmsNorm as *mut c_void)
        .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err(
            "Function pointer must not be null",
        ))?;

    unsafe {
        PyCapsule::new_with_pointer(py, fn_ptr, None)
    }
}
```

instead of

```rust
#[pyfunction(name = "rms_norm")]
fn rms_norm_jax(py: Python<'_>) -> PyResult<Bound<'_, PyCapsule>> {
    let fn_ptr: *mut c_void = ffi::RmsNorm as *mut c_void;
    let name = std::ptr::null();

    unsafe {
        let capsule = pyo3::ffi::PyCapsule_New(fn_ptr, name, None);
        if capsule.is_null() {
            return Err(pyo3::exceptions::PyRuntimeError::new_err(
                "Failed to create PyCapsule",
            ));
        }
        let any: Bound<'_, PyAny> = Bound::from_owned_ptr(py, capsule);
        Ok(any.cast_into_unchecked::<PyCapsule>())
    }
}
```

- Specifically this was the refactor enabled by switching to use this PR branch in https://github.com/jeertmans/extending-jax/commit/8fbb5bbe92776ef158b4b4dfda8bbf0f756ec556