### PR TITLE
docs: Fix small typo in modules guide

### DIFF
--- a/guide/src/module.md
+++ b/guide/src/module.md
@@ -104,7 +104,7 @@ fn func() -> String {
 #
 #      py.run(c"assert parent_module.child_module.func() == 'func'", None, Some(&ctx)).unwrap();
 #   })
-}
+# }
 ```
 
 Note that this does not define a package, so this won’t allow Python code to directly import submodules by using `from parent_module import child_module`.


### PR DESCRIPTION
A line from the hidden main function in an example was missing its escape character, so the example rendered as invalid code.

<img width="278" height="373" alt="image" src="https://github.com/user-attachments/assets/5ef42425-bd08-4646-8bf3-356149dcab2c" />