### PR TITLE
docs: Add a note detailing the parent class __traverse__/__clear__ is always called

### DIFF
--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -473,14 +473,12 @@ impl ClassWithGCSupport {
 }
 ```
 
+> [!NOTE]
+> When a class inherits from either a Python builtins type or another type declared in Rust and implement either or both `__traverse__` and `__clear__`, the parent class `__traverse__` and `__clear__` is called automatically.
+> There is no need to explicitly call it from inside the class implementation.
+
 Usually, an implementation of `__traverse__` should do nothing but calls to `visit.call`.
 Most importantly, safe access to the interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-
-> [!NOTE]
-> When a class inherits from either a Python builtins type or another type
-> declared in Rust and implement either or both `__traverse__` and `__clear__`,
-> the parent class `__traverse__` and `__clear__` is called automatically.
-> There is no need to explicitly call it from inside the class implementation.
 
 > [!NOTE]
 > These methods are part of the C API, PyPy does not necessarily honor them. If you are building for PyPy you should measure memory consumption to make sure you do not have runaway memory growth. See [this issue on the PyPy bug tracker](https://github.com/pypy/pypy/issues/3848).


### PR DESCRIPTION
As a follow up to https://github.com/PyO3/pyo3/discussions/5697, spell out explicitly that when inheriting from a builtin Python type (or a PyO3) implemented one, the methods __clear__ and __traverse__ of the parent are implicitly and automatically called.

I agree for my contributions to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).
