### PR TITLE
allow extending `PyList` on Python 3.12+

### DIFF
--- a/newsfragments/5734.added.md
+++ b/newsfragments/5734.added.md
@@ -1,0 +1,1 @@
+added support for subclassing `PyList` when building for Python 3.12+

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -19,7 +19,22 @@ use std::num::NonZero;
 #[repr(transparent)]
 pub struct PyList(PyAny);
 
-pyobject_native_type_core!(PyList, pyobject_native_static_type_object!(ffi::PyList_Type), "builtins", "list", #checkfunction=ffi::PyList_Check);
+pyobject_native_type_core!(
+    PyList,
+    pyobject_native_static_type_object!(ffi::PyList_Type),
+    "builtins", "list",
+    #checkfunction=ffi::PyList_Check
+);
+
+#[cfg(Py_3_12)]
+impl crate::impl_::pyclass::PyClassBaseType for PyList {
+    type LayoutAsBase = crate::impl_::pycell::PyVariableClassObjectBase;
+    type BaseNativeType = Self;
+    type Initializer = crate::impl_::pyclass_init::PyNativeTypeInitializer<Self>;
+    type PyClassMutability = crate::pycell::impl_::ImmutableClass;
+    type Layout<T: crate::impl_::pyclass::PyClassImpl> =
+        crate::impl_::pycell::PyVariableClassObject<T>;
+}
 
 #[inline]
 #[track_caller]

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -300,6 +300,33 @@ mod inheriting_native_type {
             )
         })
     }
+
+    #[test]
+    #[cfg(Py_3_12)]
+    fn inherit_list() {
+        #[pyclass(extends=pyo3::types::PyList)]
+        struct ListWithName {
+            #[pyo3(get)]
+            name: &'static str,
+        }
+
+        #[pymethods]
+        impl ListWithName {
+            #[new]
+            fn new() -> Self {
+                Self { name: "Hello :)" }
+            }
+        }
+
+        Python::attach(|py| {
+            let list_sub = pyo3::Bound::new(py, ListWithName::new()).unwrap();
+            py_run!(
+                py,
+                list_sub,
+                r#"list_sub.append(1); assert list_sub[0] == 1; assert list_sub.name == "Hello :)""#
+            );
+        });
+    }
 }
 
 #[pyclass(subclass)]


### PR DESCRIPTION
This uses the infrastructure from #5728 to enable inheriting from `PyList` on Python 3.12+.

Closes #5164 