### PR TITLE
refactor pyclass initialization

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -59,6 +59,35 @@ let _: Bound<'_, PyNone> = unsafe { Bound::from_owned_ptr(py, raw_ptr).cast_into
 # })
 ```
 
+### Removal of `From<Bound<'_, T>` and `From<Py<T>> for PyClassInitializer<T>`
+
+As part of refactoring the initialization code these impls were removed and its functionality was moved into the generated code for `#[new]`.
+As a small side side effect the following pattern will not be accepted anymore:
+
+```rust,ignore
+# use pyo3::prelude::*;
+# Python::attach(|py| {
+# let existing_py: Py<PyAny> = py.None();
+let obj_1 = Py::new(py, existing_py);
+
+# let existing_bound: Bound<'_, PyAny> = py.None().into_bound(py);
+let obj_2 = Bound::new(py, existing_bound);
+# })
+```
+
+To migrate use `clone` or `clone_ref`:
+
+```rust
+# use pyo3::prelude::*;
+# Python::attach(|py| {
+# let existing_py: Py<PyAny> = py.None();
+let obj_1 = existing_py.clone_ref(py);
+
+# let existing_bound: Bound<'_, PyAny> = py.None().into_bound(py);
+let obj_2 = existing_bound.clone();
+# })
+```
+
 ### Internal change to use multi-phase initialization
 
 [PEP 489](https://peps.python.org/pep-0489/) introduced "multi-phase initialization" for extension modules which provides ways to allocate and clean up per-module state.

--- a/newsfragments/5739.changed.md
+++ b/newsfragments/5739.changed.md
@@ -1,0 +1,1 @@
+`#[new]` can now return arbitrary Python objects

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -427,7 +427,6 @@ pub struct FnSpec<'a> {
     pub asyncness: Option<syn::Token![async]>,
     pub unsafety: Option<syn::Token![unsafe]>,
     pub warnings: Vec<PyFunctionWarning>,
-    #[cfg(feature = "experimental-inspect")]
     pub output: syn::ReturnType,
 }
 
@@ -503,7 +502,6 @@ impl<'a> FnSpec<'a> {
             asyncness: sig.asyncness,
             unsafety: sig.unsafety,
             warnings,
-            #[cfg(feature = "experimental-inspect")]
             output: sig.output.clone(),
         })
     }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1817,7 +1817,6 @@ fn complex_enum_struct_variant_new<'a>(
         asyncness: None,
         unsafety: None,
         warnings: vec![],
-        #[cfg(feature = "experimental-inspect")]
         output: syn::ReturnType::Default,
     };
 
@@ -1875,7 +1874,6 @@ fn complex_enum_tuple_variant_new<'a>(
         asyncness: None,
         unsafety: None,
         warnings: vec![],
-        #[cfg(feature = "experimental-inspect")]
         output: syn::ReturnType::Default,
     };
 
@@ -1903,7 +1901,6 @@ fn complex_enum_variant_field_getter<'a>(
         asyncness: None,
         unsafety: None,
         warnings: vec![],
-        #[cfg(feature = "experimental-inspect")]
         output: parse_quote!(-> #variant_cls_type),
     };
 

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -415,7 +415,6 @@ pub fn impl_wrap_pyfunction(
         asyncness: func.sig.asyncness,
         unsafety: func.sig.unsafety,
         warnings,
-        #[cfg(feature = "experimental-inspect")]
         output: func.sig.output.clone(),
     };
 

--- a/src/impl_/pyclass/probes.rs
+++ b/src/impl_/pyclass/probes.rs
@@ -1,6 +1,9 @@
 use std::marker::PhantomData;
 
-use crate::{conversion::IntoPyObject, FromPyObject, Py};
+use crate::conversion::IntoPyObject;
+use crate::impl_::pyclass::PyClassBaseType;
+use crate::impl_::pyclass_init::PyNativeTypeInitializer;
+use crate::{FromPyObject, Py, PyClass, PyClassInitializer};
 
 /// Trait used to combine with zero-sized types to calculate at compile time
 /// some property of a type.
@@ -86,6 +89,39 @@ impl IsReturningEmptyTuple<()> {
 }
 
 impl<E> IsReturningEmptyTuple<Result<(), E>> {
+    pub const VALUE: bool = true;
+}
+
+probe!(IsPyClass);
+impl<T> IsPyClass<T>
+where
+    T: PyClass,
+{
+    pub const VALUE: bool = true;
+}
+
+impl<T, E> IsPyClass<Result<T, E>>
+where
+    T: PyClass,
+{
+    pub const VALUE: bool = true;
+}
+
+probe!(IsInitializerTuple);
+impl<S, B> IsInitializerTuple<(S, B)>
+where
+    S: PyClass<BaseType = B>,
+    B: PyClass + PyClassBaseType<Initializer = PyClassInitializer<B>>,
+    B::BaseType: PyClassBaseType<Initializer = PyNativeTypeInitializer<B::BaseType>>,
+{
+    pub const VALUE: bool = true;
+}
+impl<S, B, E> IsInitializerTuple<Result<(S, B), E>>
+where
+    S: PyClass<BaseType = B>,
+    B: PyClass + PyClassBaseType<Initializer = PyClassInitializer<B>>,
+    B::BaseType: PyClassBaseType<Initializer = PyNativeTypeInitializer<B::BaseType>>,
+{
     pub const VALUE: bool = true;
 }
 

--- a/src/pyclass_init.rs
+++ b/src/pyclass_init.rs
@@ -1,10 +1,9 @@
 //! Contains initialization utilities for `#[pyclass]`.
 use crate::ffi_ptr_ext::FfiPtrExt;
-use crate::impl_::callback::IntoPyCallbackOutput;
 use crate::impl_::pyclass::{PyClassBaseType, PyClassImpl};
 use crate::impl_::pyclass_init::{PyNativeTypeInitializer, PyObjectInit};
 use crate::pycell::impl_::PyClassObjectLayout;
-use crate::{ffi, Bound, Py, PyClass, PyResult, Python};
+use crate::{ffi, Bound, PyClass, PyResult, Python};
 use crate::{ffi::PyTypeObject, pycell::impl_::PyClassObjectContents};
 use std::marker::PhantomData;
 
@@ -57,14 +56,9 @@ use std::marker::PhantomData;
 ///     );
 /// });
 /// ```
-pub struct PyClassInitializer<T: PyClass>(PyClassInitializerImpl<T>);
-
-enum PyClassInitializerImpl<T: PyClass> {
-    Existing(Py<T>),
-    New {
-        init: T,
-        super_init: <T::BaseType as PyClassBaseType>::Initializer,
-    },
+pub struct PyClassInitializer<T: PyClass> {
+    init: T,
+    super_init: <T::BaseType as PyClassBaseType>::Initializer,
 }
 
 impl<T: PyClass> PyClassInitializer<T> {
@@ -74,12 +68,7 @@ impl<T: PyClass> PyClassInitializer<T> {
     #[track_caller]
     #[inline]
     pub fn new(init: T, super_init: <T::BaseType as PyClassBaseType>::Initializer) -> Self {
-        // This is unsound; see https://github.com/PyO3/pyo3/issues/4452.
-        assert!(
-            super_init.can_be_subclassed(),
-            "you cannot add a subclass to an existing value",
-        );
-        Self(PyClassInitializerImpl::New { init, super_init })
+        Self { init, super_init }
     }
 
     /// Constructs a new initializer from an initializer for the base class.
@@ -158,18 +147,13 @@ impl<T: PyClass> PyClassInitializer<T> {
     where
         T: PyClass,
     {
-        let (init, super_init) = match self.0 {
-            PyClassInitializerImpl::Existing(value) => return Ok(value.into_bound(py)),
-            PyClassInitializerImpl::New { init, super_init } => (init, super_init),
-        };
-
-        let obj = unsafe { super_init.into_new_object(py, target_type)? };
+        let obj = unsafe { self.super_init.into_new_object(py, target_type)? };
 
         // SAFETY: `obj` is constructed using `T::Layout` but has not been initialized yet
         let contents = unsafe { <T as PyClassImpl>::Layout::contents_uninit(obj) };
         // SAFETY: `contents` is a non-null pointer to the space allocated for our
         // `PyClassObjectContents` (either statically in Rust or dynamically by Python)
-        unsafe { (*contents).write(PyClassObjectContents::new(init)) };
+        unsafe { (*contents).write(PyClassObjectContents::new(self.init)) };
 
         // Safety: obj is a valid pointer to an object of type `target_type`, which` is a known
         // subclass of `T`
@@ -187,11 +171,6 @@ impl<T: PyClass> PyObjectInit<T> for PyClassInitializer<T> {
             self.create_class_object_of_type(py, subtype)
                 .map(Bound::into_ptr)
         }
-    }
-
-    #[inline]
-    fn can_be_subclassed(&self) -> bool {
-        !matches!(self.0, PyClassInitializerImpl::Existing(..))
     }
 }
 
@@ -217,56 +196,5 @@ where
     fn from(sub_and_base: (S, B)) -> PyClassInitializer<S> {
         let (sub, base) = sub_and_base;
         PyClassInitializer::from(base).add_subclass(sub)
-    }
-}
-
-impl<T: PyClass> From<Py<T>> for PyClassInitializer<T> {
-    #[inline]
-    fn from(value: Py<T>) -> PyClassInitializer<T> {
-        PyClassInitializer(PyClassInitializerImpl::Existing(value))
-    }
-}
-
-impl<'py, T: PyClass> From<Bound<'py, T>> for PyClassInitializer<T> {
-    #[inline]
-    fn from(value: Bound<'py, T>) -> PyClassInitializer<T> {
-        PyClassInitializer::from(value.unbind())
-    }
-}
-
-// Implementation used by proc macros to allow anything convertible to PyClassInitializer<T> to be
-// the return value of pyclass #[new] method (optionally wrapped in `Result<U, E>`).
-impl<T, U> IntoPyCallbackOutput<'_, PyClassInitializer<T>> for U
-where
-    T: PyClass,
-    U: Into<PyClassInitializer<T>>,
-{
-    #[inline]
-    fn convert(self, _py: Python<'_>) -> PyResult<PyClassInitializer<T>> {
-        Ok(self.into())
-    }
-}
-
-#[cfg(all(test, feature = "macros"))]
-mod tests {
-    //! See https://github.com/PyO3/pyo3/issues/4452.
-
-    use crate::prelude::*;
-
-    #[pyclass(crate = "crate", subclass)]
-    struct BaseClass {}
-
-    #[pyclass(crate = "crate", extends=BaseClass)]
-    struct SubClass {
-        _data: i32,
-    }
-
-    #[test]
-    #[should_panic]
-    fn add_subclass_to_py_is_unsound() {
-        Python::attach(|py| {
-            let base = Py::new(py, BaseClass {}).unwrap();
-            let _subclass = PyClassInitializer::from(base).add_subclass(SubClass { _data: 42 });
-        });
     }
 }


### PR DESCRIPTION
This refactors the code generation for `#[new]` / pyclass initialization. It uses the same const probe trick we already use elsewhere in the macro machinery to dispatch the initialization based on the return type of the `#[new]` function. This removes the `Existing` case from the `PyClassInitializer`, making it easier to solve passing arguments to the base `__new__ ` in a followup. Additionally it allows to return arbitrary object implementing `IntoPyObject` from `__new__` which also takes over the `Existing` case.

Closes #3291
Closes #4452
Closes #5560
