### PR TITLE
Stubs: use `_typeshed.Incomplete` in traits default values

### DIFF
--- a/newsfragments/5744.changed.md
+++ b/newsfragments/5744.changed.md
@@ -1,0 +1,1 @@
+Stubs: use `_typeshed.Incomplete` instead of `typing.Any` as default value in traits. Allows to distinguish between `PyAny` and not implementations when annotations are not overridden. 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -61,7 +61,7 @@ pub trait IntoPyObject<'py>: Sized {
     /// For most types, the return value for this method will be identical to that of [`FromPyObject::INPUT_TYPE`].
     /// It may be different for some types, such as `Dict`, to allow duck-typing: functions return `Dict` but take `Mapping` as argument.
     #[cfg(feature = "experimental-inspect")]
-    const OUTPUT_TYPE: PyStaticExpr = type_hint_identifier!("typing", "Any");
+    const OUTPUT_TYPE: PyStaticExpr = type_hint_identifier!("_typeshed", "Incomplete");
 
     /// Performs the conversion.
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error>;
@@ -416,7 +416,7 @@ pub trait FromPyObject<'a, 'py>: Sized {
     /// For example, `Vec<u32>` would be `collections.abc.Sequence[int]`.
     /// The default value is `typing.Any`, which is correct for any type.
     #[cfg(feature = "experimental-inspect")]
-    const INPUT_TYPE: PyStaticExpr = type_hint_identifier!("typing", "Any");
+    const INPUT_TYPE: PyStaticExpr = type_hint_identifier!("_typeshed", "Incomplete");
 
     /// Extracts `Self` from the bound smart pointer `obj`.
     ///

--- a/src/type_object.rs
+++ b/src/type_object.rs
@@ -58,7 +58,7 @@ pub unsafe trait PyTypeInfo: Sized {
 
     /// Provides the full python type as a type hint.
     #[cfg(feature = "experimental-inspect")]
-    const TYPE_HINT: PyStaticExpr = type_hint_identifier!("typing", "Any");
+    const TYPE_HINT: PyStaticExpr = type_hint_identifier!("_typeshed", "Incomplete");
 
     /// Returns the PyTypeObject instance for this type.
     fn type_object_raw(py: Python<'_>) -> *mut ffi::PyTypeObject;


### PR DESCRIPTION
Alias of `typing.Any` that highlight that the value should be replaced by a better annotation (in the implementation of the traits...). Makes clearer what is a trait implemented without annotation set and what is `PyAny`.