### PR TITLE
Fix remote builds by making build-config contents deterministic

### DIFF
--- a/newsfragments/5745.fixed.md
+++ b/newsfragments/5745.fixed.md
@@ -1,0 +1,1 @@
+Fix remote builds by not baking paths in the `pyo3-build-config` build scripts.

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -208,12 +208,10 @@ const HOST_CONFIG: &str = include_str!(concat!(env!("OUT_DIR"), "/pyo3-build-con
 #[doc(hidden)]
 #[cfg(feature = "resolve-config")]
 fn resolve_cross_compile_config_path() -> Option<PathBuf> {
-    env::var_os("TARGET").map(|target| {
-        let mut path = PathBuf::from(env!("OUT_DIR"));
-        path.push(Path::new(&target));
-        path.push("pyo3-build-config.txt");
-        path
-    })
+    let mut path = PathBuf::from(env::var_os("OUT_DIR")?);
+    path.push(Path::new(&env::var_os("TARGET")?));
+    path.push("pyo3-build-config.txt");
+    Some(path)
 }
 
 /// Helper to print a feature cfg with a minimum rust version required.


### PR DESCRIPTION
See the commit message for context.

Note that it I am not 100% confident about what impact this has on cross compilation, because there are no tests/examples for it.