### PR TITLE
ci: run benchmarks on free-threaded build

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - "main"
   pull_request:
-  # `workflow_dispatch` allows CodSpeed to trigger backtest
-  # performance analysis in order to generate initial data.
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}-benches

--- a/pyo3-benches/build.rs
+++ b/pyo3-benches/build.rs
@@ -1,3 +1,4 @@
 fn main() {
     pyo3_build_config::use_pyo3_cfgs();
+    pyo3_build_config::add_libpython_rpath_link_args();
 }


### PR DESCRIPTION
Given that:
- users looking for maximum performance from Python are _probably_ going to be shooting for the free-threaded build to make use of parallelism
- the direction Python seems to be heading is that the free-threaded build is eventually going to be the default build of Python

Maybe it makes sense to run the benchmarks on the free-threaded build?