### PR TITLE
Fix missing return types in PyModExport API wrappers

### DIFF
--- a/pyo3-ffi/src/modsupport.rs
+++ b/pyo3-ffi/src/modsupport.rs
@@ -172,7 +172,7 @@ pub const PyABIInfo_FREETHREADING_AGNOSTIC: u16 = PyABIInfo_GIL | PyABIInfo_FREE
 
 #[cfg(Py_3_15)]
 extern "C" {
-    pub fn PyABIInfo_Check(info: *mut PyABIInfo, module_name: *const c_char);
+    pub fn PyABIInfo_Check(info: *mut PyABIInfo, module_name: *const c_char) -> c_int;
 }
 
 #[cfg(all(Py_LIMITED_API, Py_3_15))]
@@ -209,6 +209,6 @@ pub const _PyABIInfo_DEFAULT: PyABIInfo = PyABIInfo {
 #[macro_export]
 macro_rules! PyABIInfo_VAR {
     ($name:ident) => {
-        static mut $name: PyABIInfo = _PyABIInfo_DEFAULT;
+        static mut $name: pyo3_ffi::PyABIInfo = pyo3_ffi::_PyABIInfo_DEFAULT;
     };
 }

--- a/pyo3-ffi/src/moduleobject.rs
+++ b/pyo3-ffi/src/moduleobject.rs
@@ -142,10 +142,13 @@ extern "C" {
 
 #[cfg(Py_3_15)]
 extern "C" {
-    pub fn PyModule_FromSlotsAndSpec(slots: *const PyModuleDef_Slot, spec: *mut PyObject);
-    pub fn PyModule_Exec(_mod: *mut PyObject);
-    pub fn PyModule_GetStateSize(_mod: *mut PyObject, result: *mut Py_ssize_t);
-    pub fn PyModule_GetToken(module: *mut PyObject, result: *mut *mut c_void);
+    pub fn PyModule_FromSlotsAndSpec(
+        slots: *const PyModuleDef_Slot,
+        spec: *mut PyObject,
+    ) -> *mut PyObject;
+    pub fn PyModule_Exec(_mod: *mut PyObject) -> c_int;
+    pub fn PyModule_GetStateSize(_mod: *mut PyObject, result: *mut Py_ssize_t) -> c_int;
+    pub fn PyModule_GetToken(module: *mut PyObject, result: *mut *mut c_void) -> c_int;
 }
 
 #[repr(C)]

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -742,5 +742,6 @@ extern "C" {
     pub fn PyType_Freeze(tp: *mut crate::PyTypeObject) -> c_int;
 
     #[cfg(Py_3_15)]
-    pub fn PyType_GetModuleByToken(_type: *mut PyTypeObject, token: *const c_void);
+    pub fn PyType_GetModuleByToken(_type: *mut PyTypeObject, token: *const c_void)
+        -> *mut PyObject;
 }


### PR DESCRIPTION
Extracted from #5753 to fix the bugs in the FFI definitions fixed there. There's no need to include #5753 in the 0.28 release.