### PR TITLE
Add support for #[pyclass(get(attr1, attr2, ...))] and #[pyclass(set(attr1, attr2, ...))]

### DIFF
--- a/guide/pyclass-parameters.md
+++ b/guide/pyclass-parameters.md
@@ -31,7 +31,6 @@
 | `get(foo, bar, ...)` | Applies `pyo3(get)` on given methods (i.e., on `foo` and `bar`). |
 | `set(foo, bar, ...)` | Applies `pyo3(set)` on given methods. |
 
-
 All of these parameters can either be passed directly on the `#[pyclass(...)]` annotation, or as one or more accompanying `#[pyo3(...)]` annotations, e.g.:
 
 ```rust,ignore

--- a/guide/pyclass-parameters.md
+++ b/guide/pyclass-parameters.md
@@ -28,6 +28,9 @@
 | `subclass` | Allows other Python classes and `#[pyclass]` to inherit from this class. Enums cannot be subclassed. |
 | `unsendable` | Required if your struct is not [`Send`][params-3]. Rather than using `unsendable`, consider implementing your struct in a thread-safe way by e.g. substituting [`Rc`][params-4] with [`Arc`][params-5]. By using `unsendable`, your class will panic when accessed by another thread. Also note the Python's GC is multi-threaded and while unsendable classes will not be traversed on foreign threads to avoid UB, this can lead to memory leaks. |
 | `weakref` | Allows this class to be [weakly referenceable][params-6]. |
+| `get(foo, bar, ...)` | Applies `pyo3(get)` on given methods (i.e., on `foo` and `bar`). |
+| `set(foo, bar, ...)` | Applies `pyo3(set)` on given methods. |
+
 
 All of these parameters can either be passed directly on the `#[pyclass(...)]` annotation, or as one or more accompanying `#[pyo3(...)]` annotations, e.g.:
 

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -770,6 +770,23 @@ struct MyClass {
 }
 ```
 
+In the above example, `get(foo)` will insert `#[pyo3(get)]` on top of the `foo` attribute,
+and `set(foo)` will insert `#[pyo3(set)]` on top of the `foo` attribute.
+
+Use in above example is equivalent to:
+```rust
+# use pyo3::prelude::*;
+#[pyclass]
+struct MyClass {
+    #[pyo3(get, set)]
+    foo: i32,
+    #[pyo3(get, set)]
+    bar: i32,
+}
+```
+when the argument inside `cfg_attr` evaluates as true.
+
+
 ## Instance methods
 
 To define a Python compatible method, an `impl` block for your struct has to be annotated with the `#[pymethods]` attribute.

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -760,7 +760,9 @@ impl MyClass {
 In this case, the property `number` is defined and available from Python code as `self.number`.
 
 ### Object properties using `#[pyclass(get(...))]` and `#[pyclass(set(...))]`
+
 For cases where `cfg_attr` is used, getters and setters can be defined directly inside `#[pyclass]`:
+
 ```rust
 # use pyo3::prelude::*;
 #[cfg_attr(feature = "python-bindings", pyclass(get(foo, bar), set(foo, bar)))]
@@ -773,6 +775,7 @@ struct MyClass {
 In the above example, `get(foo)` will insert `#[pyo3(get)]` on top of the `foo` attribute, and `set(foo)` will insert `#[pyo3(set)]` on top of the `foo` attribute.
 
 Use in above example is equivalent to:
+
 ```rust
 # use pyo3::prelude::*;
 #[pyclass]
@@ -783,8 +786,8 @@ struct MyClass {
     bar: i32,
 }
 ```
-when the argument inside `cfg_attr` evaluates as true.
 
+when the argument inside `cfg_attr` evaluates as true.
 
 ## Instance methods
 
@@ -1508,8 +1511,7 @@ This implementation pattern enables the Rust compiler to use `#[pymethods]` impl
 
 This simple technique works for the case when there is zero or one implementations.
 To support multiple `#[pymethods]` for a `#[pyclass]` (in the [`multiple-pymethods`] feature), a registry mechanism provided by the [`inventory`](https://github.com/dtolnay/inventory) crate is used instead.
-This collects `impl`s at library load time, but isn't supported on all platforms.
-See [inventory: how it works](https://github.com/dtolnay/inventory#how-it-works) for more details.
+This collects `impl`s at library load time, but isn't supported on all platforms. See [inventory: how it works](https://github.com/dtolnay/inventory#how-it-works) for more details.
 
 The `#[pyclass]` macro expands to roughly the code seen below.
 The `PyClassImplCollector` is the type used internally by PyO3 for dtolnay specialization:

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -763,7 +763,7 @@ In this case, the property `number` is defined and available from Python code as
 
 For cases where `cfg_attr` is used, getters and setters can be defined directly inside `#[pyclass]`:
 
-```rust
+```rust,ignore
 # use pyo3::prelude::*;
 #[cfg_attr(feature = "python-bindings", pyclass(get(foo, bar), set(foo, bar)))]
 struct MyClass {

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -759,6 +759,17 @@ impl MyClass {
 
 In this case, the property `number` is defined and available from Python code as `self.number`.
 
+### Object properties using `#[pyclass(get(...))]` and `#[pyclass(set(...))]`
+For cases where `cfg_attr` is used, getters and setters can be defined directly inside `#[pyclass]`:
+```rust
+# use pyo3::prelude::*;
+#[cfg_attr(feature = "python-bindings", pyclass(get(foo, bar), set(foo, bar)))]
+struct MyClass {
+    foo: i32,
+    bar: i32,
+}
+```
+
 ## Instance methods
 
 To define a Python compatible method, an `impl` block for your struct has to be annotated with the `#[pymethods]` attribute.

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -770,8 +770,7 @@ struct MyClass {
 }
 ```
 
-In the above example, `get(foo)` will insert `#[pyo3(get)]` on top of the `foo` attribute,
-and `set(foo)` will insert `#[pyo3(set)]` on top of the `foo` attribute.
+In the above example, `get(foo)` will insert `#[pyo3(get)]` on top of the `foo` attribute, and `set(foo)` will insert `#[pyo3(set)]` on top of the `foo` attribute.
 
 Use in above example is equivalent to:
 ```rust
@@ -1509,7 +1508,8 @@ This implementation pattern enables the Rust compiler to use `#[pymethods]` impl
 
 This simple technique works for the case when there is zero or one implementations.
 To support multiple `#[pymethods]` for a `#[pyclass]` (in the [`multiple-pymethods`] feature), a registry mechanism provided by the [`inventory`](https://github.com/dtolnay/inventory) crate is used instead.
-This collects `impl`s at library load time, but isn't supported on all platforms. See [inventory: how it works](https://github.com/dtolnay/inventory#how-it-works) for more details.
+This collects `impl`s at library load time, but isn't supported on all platforms.
+See [inventory: how it works](https://github.com/dtolnay/inventory#how-it-works) for more details.
 
 The `#[pyclass]` macro expands to roughly the code seen below.
 The `PyClassImplCollector` is the type used internally by PyO3 for dtolnay specialization:

--- a/newsfragments/5766.added.md
+++ b/newsfragments/5766.added.md
@@ -1,0 +1,2 @@
+Added `get(...) and set(...)` support in `#[pyclass]`: `#[pyclass(get(foo, bar, rab), set(foo, bar, oof))]`,
+for allowing automatic definitions of getters/setters when using `#[cfg_attr]`.

--- a/pyo3-macros-backend/src/attributes.rs
+++ b/pyo3-macros-backend/src/attributes.rs
@@ -357,8 +357,7 @@ impl syn::parse::Parse for GetListAttribute {
         let paren_token = parenthesized!(content in input);
 
         // Parse identifiers inside: a, b, c
-        let fields =
-            content.parse_terminated(Ident::parse, Token![,])?;
+        let fields = content.parse_terminated(Ident::parse, Token![,])?;
 
         // Reject empty list: get()
         if fields.is_empty() {
@@ -408,8 +407,7 @@ impl syn::parse::Parse for SetListAttribute {
         let paren_token = parenthesized!(content in input);
 
         // Parse identifiers inside: a, b, c
-        let fields =
-            content.parse_terminated(Ident::parse, Token![,])?;
+        let fields = content.parse_terminated(Ident::parse, Token![,])?;
 
         // Reject empty list: set()
         if fields.is_empty() {

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -371,7 +371,7 @@ pub fn build_py_class(
 
     if let Some(get_list_attr) = &args.options.get {
         // get_list_attr contains the list of desired field names (NameAttribute or Ident)
-        for name in get_list_attr.fields.iter() {
+        for name in &get_list_attr.fields {
             // find matching field in `field_options`:
             if let Some((_, field_opts)) = field_options.iter_mut().find(|(f, _)| match &f.ident {
                 Some(ident) => ident == name,
@@ -394,7 +394,7 @@ pub fn build_py_class(
 
     if let Some(set_list_attr) = &args.options.set {
         // get_list_attr contains the list of desired field names (NameAttribute or Ident)
-        for name in set_list_attr.fields.iter() {
+        for name in &set_list_attr.fields {
             // find matching field in `field_options`:
             if let Some((_, field_opts)) = field_options.iter_mut().find(|(f, _)| match &f.ident {
                 Some(ident) => ident == name,

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -11,8 +11,8 @@ use syn::{parse_quote, parse_quote_spanned, spanned::Spanned, ImplItemFn, Result
 use crate::attributes::kw::frozen;
 use crate::attributes::{
     self, kw, take_pyo3_options, CrateAttribute, ExtendsAttribute, FreelistAttribute,
-    ModuleAttribute, NameAttribute, NameLitStr, NewImplTypeAttribute, NewImplTypeAttributeValue,
-    RenameAllAttribute, StrFormatterAttribute, GetListAttribute, SetListAttribute
+    GetListAttribute, ModuleAttribute, NameAttribute, NameLitStr, NewImplTypeAttribute,
+    NewImplTypeAttributeValue, RenameAllAttribute, SetListAttribute, StrFormatterAttribute,
 };
 use crate::combine_errors::CombineErrors;
 #[cfg(feature = "experimental-inspect")]
@@ -98,7 +98,7 @@ pub struct PyClassPyO3Options {
     pub from_py_object: Option<kw::from_py_object>,
     pub skip_from_py_object: Option<kw::skip_from_py_object>,
     pub get: Option<GetListAttribute>,
-    pub set: Option<SetListAttribute>
+    pub set: Option<SetListAttribute>,
 }
 
 pub enum PyClassPyO3Option {
@@ -373,16 +373,21 @@ pub fn build_py_class(
         // get_list_attr contains the list of desired field names (NameAttribute or Ident)
         for name in get_list_attr.fields.iter() {
             // find matching field in `field_options`:
-            if let Some((_, field_opts)) =
-                field_options.iter_mut().find(|(f, _)| match &f.ident {
-                    Some(ident) => ident == name,
-                    None => false,
-                }) {
-                if let Some(old_get) = field_opts.get.replace(Annotated::Struct(kw::get_all::default())) {
+            if let Some((_, field_opts)) = field_options.iter_mut().find(|(f, _)| match &f.ident {
+                Some(ident) => ident == name,
+                None => false,
+            }) {
+                if let Some(old_get) = field_opts
+                    .get
+                    .replace(Annotated::Struct(kw::get_all::default()))
+                {
                     return Err(syn::Error::new(old_get.span(), "duplicate get specified"));
                 }
             } else {
-                return Err(syn::Error::new_spanned(get_list_attr.clone(), format!("no field named `{}`", name)));
+                return Err(syn::Error::new_spanned(
+                    get_list_attr.clone(),
+                    format!("no field named `{}`", name),
+                ));
             }
         }
     }
@@ -391,16 +396,21 @@ pub fn build_py_class(
         // get_list_attr contains the list of desired field names (NameAttribute or Ident)
         for name in set_list_attr.fields.iter() {
             // find matching field in `field_options`:
-            if let Some((_, field_opts)) =
-                field_options.iter_mut().find(|(f, _)| match &f.ident {
-                    Some(ident) => ident == name,
-                    None => false,
-                }) {
-                if let Some(old_set) = field_opts.set.replace(Annotated::Struct(kw::set_all::default())) {
+            if let Some((_, field_opts)) = field_options.iter_mut().find(|(f, _)| match &f.ident {
+                Some(ident) => ident == name,
+                None => false,
+            }) {
+                if let Some(old_set) = field_opts
+                    .set
+                    .replace(Annotated::Struct(kw::set_all::default()))
+                {
                     return Err(syn::Error::new(old_set.span(), "duplicate set specified"));
                 }
             } else {
-                return Err(syn::Error::new_spanned(set_list_attr.clone(), format!("no field named `{}`", name)));
+                return Err(syn::Error::new_spanned(
+                    set_list_attr.clone(),
+                    format!("no field named `{}`", name),
+                ));
             }
         }
     }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -382,9 +382,12 @@ pub fn build_py_class(
                 Some(ident) => ident == name,
                 None => false,
             }) {
-                if let Some(old_get) = field_opts
-                    .get
-                    .replace(Annotated::Struct(FieldPyO3OptionsGetSource::GetList(get_list_attr.clone())))
+                if let Some(old_get) =
+                    field_opts
+                        .get
+                        .replace(Annotated::Struct(FieldPyO3OptionsGetSource::GetList(
+                            get_list_attr.clone(),
+                        )))
                 {
                     results.push(Err(syn::Error::new(old_get.span(), DUPE_GET)));
                 }
@@ -405,9 +408,12 @@ pub fn build_py_class(
                 Some(ident) => ident == name,
                 None => false,
             }) {
-                if let Some(old_set) = field_opts
-                    .set
-                    .replace(Annotated::Struct(FieldPyO3OptionsSetSource::SetList(set_list_attr.clone())))
+                if let Some(old_set) =
+                    field_opts
+                        .set
+                        .replace(Annotated::Struct(FieldPyO3OptionsSetSource::SetList(
+                            set_list_attr.clone(),
+                        )))
                 {
                     results.push(Err(syn::Error::new(old_set.span(), DUPE_SET)));
                 }
@@ -454,7 +460,7 @@ impl ToTokens for FieldPyO3OptionsGetSource {
 
 pub enum FieldPyO3OptionsSetSource {
     SetAll(attributes::kw::set_all),
-    SetList(SetListAttribute)
+    SetList(SetListAttribute),
 }
 
 impl ToTokens for FieldPyO3OptionsSetSource {


### PR DESCRIPTION
Solves the problem in #5125, which mentions the problem of having helper attributes, such as ``#[pyo3(get)]``, while conditionally enabling ``pyclass`` using ``cfg_attr``.

The problem is solved by allowing ``#[pyclass]`` to have options ``get`` and ``set``, which accept a comma separated sequence of attribute names.

Progress:
- [x] Implement ``#[pyclass(get(attr1, attr2, ...))]``;
- [x] Implement ``#[pyclass(set(attr1, attr2, ...))]``;
- [x] Document changes;
- [x] Update documentation.

## Example
```rust
#[cfg_attr(feature = "python-bindings", pyclass(module = "game", get(score, running), set(running)))]
pub struct GameManager {
    score: [u16; 2],
    running: bool
}
```
