### PR TITLE
Vec<u8>: support u8-compatible buffer exporters

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -451,7 +451,7 @@ pub trait FromPyObject<'a, 'py>: Sized {
         impl<T> FromPyObjectSequence for NeverASequence<T> {
             type Target = T;
 
-            fn to_vec(&self) -> Vec<Self::Target> {
+            fn to_vec(&self) -> PyResult<Vec<Self::Target>> {
                 unreachable!()
             }
 
@@ -480,7 +480,7 @@ mod from_py_object_sequence {
     pub trait FromPyObjectSequence {
         type Target;
 
-        fn to_vec(&self) -> Vec<Self::Target>;
+        fn to_vec(&self) -> PyResult<Vec<Self::Target>>;
 
         fn to_array<const N: usize>(&self) -> PyResult<[Self::Target; N]>;
     }

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -73,7 +73,7 @@ where
 
     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
         if let Some(extractor) = T::sequence_extractor(obj, crate::conversion::private::Token) {
-            return Ok(extractor.to_vec());
+            return extractor.to_vec();
         }
 
         if obj.is_instance_of::<PyString>() {


### PR DESCRIPTION
## Summary

This PR extends `Vec<u8>` extraction to support **u8-compatible buffer-protocol exporters** (e.g. `memoryview`, `array('B')`, and custom types implementing `__getbuffer__`) by performing a contiguous copy via `PyBuffer<u8>`.

When the object exports a buffer that is *not* compatible with `u8` (e.g. `array('I')`), extraction **falls back to the existing sequence semantics**, preserving current behavior.

## Why

`Vec<u8>` is a common "byte payload" type. Today:

- `bytes` / `bytearray` already have a specialized path via `u8::sequence_extractor`.
- Other buffer exporters can still hit element-wise sequence extraction, and non-sequence buffer exporters cannot be extracted into `Vec<u8>` at all.

This change treats the buffer protocol as a first-class source for `Vec<u8>` when it is semantically valid (`u8`-compatible).

## Implementation notes

- Extends the `u8::sequence_extractor` specialization to recognize buffer exporters.
- Makes the internal `FromPyObjectSequence::to_vec` fallible (`PyResult<Vec<_>>`) so buffer copies can propagate errors cleanly.
- Uses the existing `PyBuffer<u8>` implementation to perform the copy.

## Compatibility

- No change to `str -> Vec<_>` rejection.
- `bytes` / `bytearray` behavior unchanged.
- For incompatible buffers (e.g. `array('I')`), behavior is preserved via fallback to sequence semantics.

## Tests

Added to `tests/test_buffer_protocol.rs`:

- `test_extract_vec_u8_from_buffer_exporter` (custom buffer exporter, not a sequence)
- `test_extract_vec_u8_falls_back_when_buffer_incompatible` (`array('I')` fallback)
