### PR TITLE
docs: fix typo in migration guide

### DIFF
--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -55,7 +55,7 @@ let _: Py<PyNone> = unsafe { Py::from_owned_ptr(py, raw_ptr) };
 # })
 ```
 
-Before:
+After:
 
 ```rust
 # use pyo3::prelude::*;


### PR DESCRIPTION
Fix two "befores" to be a "before" and "after."