### PR TITLE
remove dangling newsfragment

### DIFF
--- a/newsfragments/5518-packaging.md
+++ b/newsfragments/5518-packaging.md
@@ -1,1 +1,0 @@
-Add 3.15 to CI for preliminary testing


### PR DESCRIPTION
This had the wrong name so never got recognised by CI / towncrier; we didn't need it anyway.