### PR TITLE
Fix ambiguous associated item error

### DIFF
--- a/newsfragments/5784.fixed.md
+++ b/newsfragments/5784.fixed.md
@@ -1,0 +1,1 @@
+Fix `ambiguous_associated_items` compilation error when deriving `FromPyObject` or using `#[pyclass(from_py_object)]` macro on enums with `Error` variant.

--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -588,7 +588,7 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
         #[automatically_derived]
         impl #impl_generics #pyo3_path::FromPyObject<'_, #lt_param> for #ident #ty_generics #where_clause {
             type Error = #pyo3_path::PyErr;
-            fn extract(obj: #pyo3_path::Borrowed<'_, #lt_param, #pyo3_path::PyAny>) -> ::std::result::Result<Self, Self::Error> {
+            fn extract(obj: #pyo3_path::Borrowed<'_, #lt_param, #pyo3_path::PyAny>) -> ::std::result::Result<Self, #pyo3_path::PyErr> {
                 let obj: &#pyo3_path::Bound<'_, _> = &*obj;
                 #derives
             }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2833,7 +2833,7 @@ impl<'a> PyClassImplsBuilder<'a> {
 
                     #input_type
 
-                    fn extract(obj: #pyo3_path::Borrowed<'a, 'py, #pyo3_path::PyAny>) -> ::std::result::Result<Self, Self::Error> {
+                    fn extract(obj: #pyo3_path::Borrowed<'a, 'py, #pyo3_path::PyAny>) -> ::std::result::Result<Self,  <Self as #pyo3_path::FromPyObject<'a, 'py>>::Error> {
                         ::std::result::Result::Ok(::std::clone::Clone::clone(&*obj.extract::<#pyo3_path::PyClassGuard<'_, #cls>>()?))
                     }
                 }

--- a/tests/ui/ambiguous_associated_items.rs
+++ b/tests/ui/ambiguous_associated_items.rs
@@ -22,4 +22,27 @@ enum DeriveItems {
     Target(Py<PyAny>),
 }
 
+#[pyclass(from_py_object)]
+#[derive(Clone)]
+pub enum SimpleItemsFromPyObject {
+    Error,
+    Output,
+    Target,
+}
+
+#[pyclass(from_py_object)]
+#[derive(Clone)]
+pub enum ComplexItemsFromPyObject {
+    Error(i32),
+    Output(i32),
+    Target(i32),
+}
+
+#[derive(FromPyObject, Clone)]
+enum DeriveItemsFromPyObject {
+    Error(i32),
+    Output(i32),
+    Target(i32),
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes #5781

It's possible to use `<Self as #pyo3_path::FromPyObject<..., ...>>::Error` instead of `#pyo3_path::PyErr` in `frompyobject.rs`, but it requires changing a bit more code, and I don't think it's more readable