### PR TITLE
Conversions: make use of public APIs to construct set and list

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -7,7 +7,6 @@ use crate::inspect::types::TypeInfo;
 use crate::inspect::{type_hint_identifier, type_hint_subscript, PyStaticExpr};
 use crate::pyclass::boolean_struct::False;
 use crate::pyclass::{PyClassGuardError, PyClassGuardMutError};
-#[cfg(feature = "experimental-inspect")]
 use crate::types::PyList;
 use crate::types::PyTuple;
 use crate::{
@@ -90,9 +89,7 @@ pub trait IntoPyObject<'py>: Sized {
         I: IntoIterator<Item = Self> + AsRef<[Self]>,
         I::IntoIter: ExactSizeIterator<Item = Self>,
     {
-        let mut iter = iter.into_iter().map(|e| e.into_bound_py_any(py));
-        let list = crate::types::list::try_new_from_iter(py, &mut iter);
-        list.map(Bound::into_any)
+        Ok(PyList::new(py, iter)?.into_any())
     }
 
     /// Converts sequence of Self into a Python object. Used to specialize `&[u8]` and `Cow<[u8]>`
@@ -108,9 +105,7 @@ pub trait IntoPyObject<'py>: Sized {
         I: IntoIterator<Item = Self> + AsRef<[<Self as private::Reference>::BaseType]>,
         I::IntoIter: ExactSizeIterator<Item = Self>,
     {
-        let mut iter = iter.into_iter().map(|e| e.into_bound_py_any(py));
-        let list = crate::types::list::try_new_from_iter(py, &mut iter);
-        list.map(Bound::into_any)
+        Ok(PyList::new(py, iter)?.into_any())
     }
 
     /// The output type of [`IntoPyObject::owned_sequence_into_pyobject`] and [`IntoPyObject::borrowed_sequence_into_pyobject`]

--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -21,10 +21,7 @@ use crate::inspect::PyStaticExpr;
 use crate::{
     conversion::{FromPyObjectOwned, IntoPyObject},
     types::{
-        any::PyAnyMethods,
-        dict::PyDictMethods,
-        frozenset::PyFrozenSetMethods,
-        set::{try_new_from_iter, PySetMethods},
+        any::PyAnyMethods, dict::PyDictMethods, frozenset::PyFrozenSetMethods, set::PySetMethods,
         PyDict, PyFrozenSet, PySet,
     },
     Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python,
@@ -117,7 +114,7 @@ where
     const OUTPUT_TYPE: PyStaticExpr = type_hint_subscript!(PySet::TYPE_HINT, K::OUTPUT_TYPE);
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(py, self)
+        PySet::new(py, self)
     }
 }
 
@@ -134,7 +131,7 @@ where
     const OUTPUT_TYPE: PyStaticExpr = type_hint_subscript!(PySet::TYPE_HINT, <&K>::OUTPUT_TYPE);
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(py, self)
+        PySet::new(py, self)
     }
 }
 

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -9,10 +9,7 @@ use crate::type_object::PyTypeInfo;
 use crate::{
     conversion::{FromPyObjectOwned, IntoPyObject},
     types::{
-        any::PyAnyMethods,
-        frozenset::PyFrozenSetMethods,
-        set::{try_new_from_iter, PySetMethods},
-        PyFrozenSet, PySet,
+        any::PyAnyMethods, frozenset::PyFrozenSetMethods, set::PySetMethods, PyFrozenSet, PySet,
     },
     Borrowed, Bound, FromPyObject, PyAny, PyErr, Python,
 };
@@ -30,7 +27,7 @@ where
     const OUTPUT_TYPE: PyStaticExpr = type_hint_subscript!(PySet::TYPE_HINT, K::OUTPUT_TYPE);
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(py, self)
+        PySet::new(py, self)
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -51,7 +48,7 @@ where
     const OUTPUT_TYPE: PyStaticExpr = type_hint_subscript!(PySet::TYPE_HINT, <&K>::OUTPUT_TYPE);
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(py, self.iter())
+        PySet::new(py, self)
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -107,7 +104,7 @@ where
     const OUTPUT_TYPE: PyStaticExpr = type_hint_subscript!(PySet::TYPE_HINT, K::OUTPUT_TYPE);
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(py, self)
+        PySet::new(py, self)
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -129,7 +126,7 @@ where
     const OUTPUT_TYPE: PyStaticExpr = type_hint_subscript!(PySet::TYPE_HINT, <&K>::OUTPUT_TYPE);
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
-        try_new_from_iter(py, self.iter())
+        PySet::new(py, self)
     }
 
     #[cfg(feature = "experimental-inspect")]

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -38,7 +38,7 @@ impl crate::impl_::pyclass::PyClassBaseType for PyList {
 
 #[inline]
 #[track_caller]
-pub(crate) fn try_new_from_iter<'py>(
+fn try_new_from_iter<'py>(
     py: Python<'py>,
     mut elements: impl ExactSizeIterator<Item = PyResult<Bound<'py, PyAny>>>,
 ) -> PyResult<Bound<'py, PyList>> {


### PR DESCRIPTION
- Remove try_new_from_iter utility functions duplicating new() constructors
- Remove some duplicated code
