### PR TITLE
Change `OSError`type aliases to also be type aliases in Rust

### DIFF
--- a/guide/src/building-and-distribution.md
+++ b/guide/src/building-and-distribution.md
@@ -275,6 +275,7 @@ These are:
 - `#[pyo3(text_signature = "...")]` does not work on classes until Python 3.10 or greater.
 - The `dict` and `weakref` options on classes are not supported until Python 3.9 or greater.
 - The buffer API is not supported until Python 3.11 or greater.
+- Subclassing native types (e.g. `PyException`) is not supported until Python 3.12 or greater.
 - Optimizations which rely on knowledge of the exact Python version compiled against.
 
 ## Embedding Python in Rust

--- a/guide/src/exception.md
+++ b/guide/src/exception.md
@@ -172,7 +172,7 @@ Python::attach(|py| {
 
 ```
 
-Note that this is not possible when the ``abi3`` feature is enabled, as that prevents subclassing ``PyException``.
+Note that when the `abi3` feature is enabled, subclassing `PyException` is only possible on Python 3.12 or greater.
 
 [`create_exception!`]: {{#PYO3_DOCS_URL}}/pyo3/macro.create_exception.html
 [`import_exception!`]: {{#PYO3_DOCS_URL}}/pyo3/macro.import_exception.html

--- a/newsfragments/5803.changed.md
+++ b/newsfragments/5803.changed.md
@@ -1,0 +1,1 @@
+`PyEnvironmentError`, `PyIOError`, and `PyWindowsError` are now type aliases of `PyOSError` (as is the case in Python since 3.3).

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -294,23 +294,6 @@ macro_rules! impl_native_exception (
     )
 );
 
-#[cfg(windows)]
-macro_rules! impl_windows_native_exception (
-    ($name:ident, $exc_name:ident, $python_name:expr, $doc:expr, $layout:path) => (
-        #[cfg(windows)]
-        #[doc = $doc]
-        #[repr(transparent)]
-        #[allow(clippy::upper_case_acronyms, reason = "Python exception names")]
-        pub struct $name($crate::PyAny);
-
-        $crate::impl_exception_boilerplate!($name);
-        $crate::pyobject_native_type!($name, $layout, |_py| unsafe { $crate::ffi::$exc_name as *mut $crate::ffi::PyTypeObject }, "builtins", $python_name);
-    );
-    ($name:ident, $exc_name:ident, $python_name:expr, $doc:expr) => (
-        impl_windows_native_exception!($name, $exc_name, $python_name, $doc, $crate::ffi::PyBaseExceptionObject);
-    )
-);
-
 macro_rules! native_doc(
     ($name: literal, $alt: literal) => (
         concat!(
@@ -732,21 +715,15 @@ impl_native_exception!(
     native_doc!("TimeoutError")
 );
 
-impl_native_exception!(
-    PyEnvironmentError,
-    PyExc_EnvironmentError,
-    "EnvironmentError",
-    native_doc!("EnvironmentError")
-);
-impl_native_exception!(PyIOError, PyExc_IOError, "IOError", native_doc!("IOError"));
+/// Alias of `PyOSError`, corresponding to `EnvironmentError` alias in Python.
+pub type PyEnvironmentError = PyOSError;
+
+/// Alias of `PyOSError`, corresponding to `IOError` alias in Python.
+pub type PyIOError = PyOSError;
 
 #[cfg(windows)]
-impl_windows_native_exception!(
-    PyWindowsError,
-    PyExc_WindowsError,
-    "WindowsError",
-    native_doc!("WindowsError")
-);
+/// Alias of `PyOSError`, corresponding to `WindowsError` alias in Python.
+pub type PyWindowsError = PyOSError;
 
 impl PyUnicodeDecodeError {
     /// Creates a Python `UnicodeDecodeError`.


### PR DESCRIPTION
Just noticed a few places where the docs were out of date following #5733

At the same time, I saw `WindowsError` was using a windows-specific macro which had no difference to the other macro except that it was (accidentally?) missing subclass support. And even better, that, `EnvironmentError`, and `IOError` are all just aliases of `OSError` since Python 3.3, so I propose we match that in PyO3.