### PR TITLE
ci: re-enable `list_get_item_unchecked` benchmark on free-threaded build

### DIFF
--- a/pyo3-benches/benches/bench_list.rs
+++ b/pyo3-benches/benches/bench_list.rs
@@ -65,7 +65,7 @@ fn list_nth_back(b: &mut Bencher<'_>) {
     });
 }
 
-#[cfg(not(any(Py_LIMITED_API, Py_GIL_DISABLED)))]
+#[cfg(not(Py_LIMITED_API))]
 fn list_get_item_unchecked(b: &mut Bencher<'_>) {
     Python::attach(|py| {
         const LEN: usize = 50_000;
@@ -95,7 +95,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("list_nth", list_nth);
     c.bench_function("list_nth_back", list_nth_back);
     c.bench_function("list_get_item", list_get_item);
-    #[cfg(not(any(Py_LIMITED_API, Py_GIL_DISABLED)))]
+    #[cfg(not(Py_LIMITED_API))]
     c.bench_function("list_get_item_unchecked", list_get_item_unchecked);
     c.bench_function("sequence_from_list", sequence_from_list);
 }


### PR DESCRIPTION
This was disabled a long time ago because (IIRC) we didn't have `get_item_unchecked` enabled on the free-threaded build initially, once we had critical sections (I think) we re-enabled that function, but forgot the benchmark.