### PR TITLE
ci: expand pyclass benchmarks

### DIFF
--- a/pyo3-benches/benches/bench_pyclass.rs
+++ b/pyo3-benches/benches/bench_pyclass.rs
@@ -69,11 +69,9 @@ pub fn bench_pyclass(c: &mut Criterion) {
     });
     c.bench_function("bench_str", |b| {
         Python::attach(|py| {
-            b.iter_batched(
-                || MyClass::new(vec![1, 2, 3]).into_py_any(py).unwrap(),
-                |inst| inst.bind(py).str(),
-                BatchSize::SmallInput,
-            );
+            let inst = MyClass::new(vec![1, 2, 3]).into_py_any(py).unwrap();
+            let bound = inst.bind(py);
+            b.iter(|| bound.str());
         });
     });
 }


### PR DESCRIPTION
c.f. https://github.com/PyO3/pyo3/pull/5807#issuecomment-3909055947.

This will allow me to test whether using an opaque PyObject in all limited API builds on 3.12 and newer has performance implications.