### PR TITLE
ci: add a abi3 feature to pyo3-benches

### DIFF
--- a/pyo3-benches/Cargo.toml
+++ b/pyo3-benches/Cargo.toml
@@ -19,6 +19,9 @@ num-bigint = "0.4.3"
 rust_decimal = { version = "1.0.0", default-features = false }
 hashbrown = "0.16"
 
+[features]
+abi3 = ["pyo3-build-config/abi3"]
+
 [[bench]]
 name = "bench_any"
 harness = false


### PR DESCRIPTION
I needed this to run benchmarks for a scenario that can only happen under abi3: https://github.com/PyO3/pyo3/pull/5807#issuecomment-3909788593

I didn't think it was worth adding fine-grained abi3 features for each Python version and hooking this up with the feature powerset tests. Happy to add that if anyone thinks it's worth it.