### PR TITLE
Fix typo in PyType_GetTypeDataSize bindings

### DIFF
--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -381,8 +381,8 @@ extern "C" {
     pub fn PyObject_GetTypeData(obj: *mut PyObject, cls: *mut PyTypeObject) -> *mut c_void;
 
     #[cfg(Py_3_12)]
-    #[cfg_attr(PyPy, link_name = "PyPyObject_GetTypeDataSize")]
-    pub fn PyObject_GetTypeDataSize(cls: *mut PyTypeObject) -> Py_ssize_t;
+    #[cfg_attr(PyPy, link_name = "PyPyType_GetTypeDataSize")]
+    pub fn PyType_GetTypeDataSize(cls: *mut PyTypeObject) -> Py_ssize_t;
 
     #[cfg_attr(PyPy, link_name = "PyPyType_IsSubtype")]
     pub fn PyType_IsSubtype(a: *mut PyTypeObject, b: *mut PyTypeObject) -> c_int;


### PR DESCRIPTION
Looks like this was a typo that's been missed since the function is currently unused in PyO3. I noticed this while working on opaque PyObject support (https://github.com/PyO3/pyo3/pull/5807#issuecomment-3910542350).

See the C API docs: https://docs.python.org/3/c-api/object.html#c.PyType_GetTypeDataSize.