### PR TITLE
ci: Add critical section benchmarks

### DIFF
--- a/pyo3-benches/Cargo.toml
+++ b/pyo3-benches/Cargo.toml
@@ -39,6 +39,10 @@ name = "bench_comparisons"
 harness = false
 
 [[bench]]
+name = "bench_critical_sections"
+harness = false
+
+[[bench]]
 name = "bench_err"
 harness = false
 

--- a/pyo3-benches/benches/bench_critical_sections.rs
+++ b/pyo3-benches/benches/bench_critical_sections.rs
@@ -1,0 +1,32 @@
+use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
+
+use pyo3::prelude::*;
+use pyo3::sync::critical_section::{with_critical_section, with_critical_section2};
+use pyo3::types::PyList;
+
+fn create_cs(b: &mut Bencher<'_>) {
+    Python::attach(|py| {
+        let lis = PyList::new(py, 0..3).unwrap();
+        b.iter(|| {
+            with_critical_section(&lis, || {});
+        })
+    });
+}
+
+fn create_cs2(b: &mut Bencher<'_>) {
+    Python::attach(|py| {
+        let lis1 = PyList::new(py, 0..3).unwrap();
+        let lis2 = PyList::new(py, 4..6).unwrap();
+        b.iter(|| {
+            with_critical_section2(&lis1, &lis2, || {});
+        })
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("critical_section_creation", create_cs);
+    c.bench_function("critical_section_creation2", create_cs2);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This was useful for me to benchmark critical sections in the stable ABI. Not sure if it necessarily makes sense to live in the PyO3 benchmarks but I thought I'd send it in. It'd be useful to know if any of our wrappers change performance as we experiment with different ABIs.

ping @encukou.