### PR TITLE
docs: Improves `IntoPyObject` documentation in the guides

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -675,6 +675,7 @@ struct RustyStruct {
 #   fn new() -> Self {
 #     Self {
 #       string_in_mapping: String::from("test"),
+#       string_attr: String::from(""),
 #     }
 #   }
 # }


### PR DESCRIPTION
closes #5709
