### PR TITLE
fix(pyo3-macros): allow pyclass named Probe

### DIFF
--- a/newsfragments/5837.fixed.md
+++ b/newsfragments/5837.fixed.md
@@ -1,0 +1,1 @@
+Allow pyclass named `Probe` with `get_all` fields.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2829,7 +2829,11 @@ impl<'a> PyClassImplsBuilder<'a> {
         };
 
         let (pymethods_items, inventory, inventory_class) = match self.methods_type {
-            PyClassMethodsType::Specialization => (quote! { collector.py_methods() }, None, None),
+            PyClassMethodsType::Specialization => (
+                quote! {{ use #pyo3_path::impl_::pyclass::PyMethods as _; collector.py_methods() }},
+                None,
+                None,
+            ),
             PyClassMethodsType::Inventory => {
                 // To allow multiple #[pymethods] block, we define inventory types.
                 let inventory_class_name = syn::Ident::new(
@@ -3010,13 +3014,12 @@ impl<'a> PyClassImplsBuilder<'a> {
                 type BaseNativeType = #base_nativetype;
 
                 fn items_iter() -> #pyo3_path::impl_::pyclass::PyClassItemsIter {
-                    use #pyo3_path::impl_::pyclass::*;
-                    let collector = PyClassImplCollector::<Self>::new();
-                    static INTRINSIC_ITEMS: PyClassItems = PyClassItems {
+                    let collector = #pyo3_path::impl_::pyclass::PyClassImplCollector::<Self>::new();
+                    static INTRINSIC_ITEMS: #pyo3_path::impl_::pyclass::PyClassItems = #pyo3_path::impl_::pyclass::PyClassItems {
                         methods: &[#(#default_method_defs),*],
                         slots: &[#(#default_slot_defs),* #(#freelist_slots),*],
                     };
-                    PyClassItemsIter::new(&INTRINSIC_ITEMS, #pymethods_items)
+                    #pyo3_path::impl_::pyclass::PyClassItemsIter::new(&INTRINSIC_ITEMS, #pymethods_items)
                 }
 
                 const RAW_DOC: &'static ::std::ffi::CStr = #doc;

--- a/tests/ui/pyclass_probe.rs
+++ b/tests/ui/pyclass_probe.rs
@@ -1,21 +1,36 @@
 #![deny(unused_imports)]
 use pyo3::prelude::*;
 
-#[pyclass]
-pub struct Probe {}
-
-#[pymethods]
-impl Probe {
-    #[new]
-    fn new() -> Self {
-        Self {}
+#[pymodule]
+mod probe_no_fields {
+    use pyo3::prelude::*;
+    #[pyclass]
+    pub struct Probe {}
+    
+    #[pymethods]
+    impl Probe {
+        #[new]
+        fn new() -> Self {
+            Self {}
+        }
     }
 }
 
 #[pymodule]
-fn probe(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_class::<Probe>()?;
-    Ok(())
+mod probe_with_fields {
+    use pyo3::prelude::*;
+    #[pyclass(get_all)]
+    pub struct Probe {
+        field: u8,
+    }
+    
+    #[pymethods]
+    impl Probe {
+        #[new]
+        fn new() -> Self {
+            Self { field: 0 }
+        }
+    }
 }
 
 #[pyclass]


### PR DESCRIPTION
The `*` import was shadowing the name of the pyclass.

Fixes #4792.

I tested on a codebase that had one struct/pyclass named Probe, and many other structs/pyclasses.
But I'm not sure if some of the imports that I removed are necessary in other situations that I have not tested.