### PR TITLE
ci: Add test for minimum supported debug build of Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,7 +617,7 @@ jobs:
           components: rust-src
       - uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.10+debug"
+          python-version: "3.11+debug"
       - run: uvx python -m sysconfig
       - run: uvx nox -s test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -603,6 +603,24 @@ jobs:
       - run: uvx python -m sysconfig
       - run: uvx nox -s test
 
+  test-debug-min-version:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-src
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.10+debug"
+      - run: uvx python -m sysconfig
+      - run: uvx nox -s test
+
   test-version-limits:
     needs: [fmt, resolve]
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}


### PR DESCRIPTION
<!--
Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run `nox`. See `nox --list-sessions` for a list of supported actions.
-->

As per comment in #5847.

> Makes sense. We should probably also add a `Py_REF_DEBUG` build to CI on the lowest supported Python version.

*Note* that the original debug build downloads prebuilt standalone binaries from `python-build-standalone`, but the prebuilt binaries are limited (for old versions). In the latest release there's only 3.10.19 available, and I could not find a 3.7 build in all releases.
This PR pins it to `3.10.19-3.14.3` from `20260211` release.
            