### PR TITLE
gate `try_trait_v2` feature when enabling the `nightly` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 #![warn(missing_docs)]
 #![cfg_attr(
     feature = "nightly",
-    feature(auto_traits, negative_impls, try_trait_v2, iter_advance_by)
+    feature(auto_traits, negative_impls, iter_advance_by)
 )]
+#![cfg_attr(all(feature = "nightly", Py_GIL_DISABLED), feature(try_trait_v2))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(unsafe_op_in_unsafe_fn)]
 // Deny some lints in doctests.


### PR DESCRIPTION
Resolves the nightly CI failure by gating the `try_trait_v2` feature to the free threaded build. Looks like the compiler got smarter and tells us that we are not actually making use of the feature in GIL enabled builds.
