### PR TITLE
ci: add save-cache instruction to all `setup-uv` uses

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           # codspeed action needs to be run from within the final Python environment
           activate-environment: true
+          save-cache: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           python-version: cpython-${{ inputs.python-version }}-macos-x86-64
+          save-cache: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
 
       - name: Install nox
         run: python -m pip install --upgrade pip && pip install nox[uv]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
           targets: ${{ matrix.target }}
           components: clippy,rust-src
       - uses: astral-sh/setup-uv@v7
+        with:
+          save-cache: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
       - run: uvx nox -s clippy-all
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
           persist-credentials: false
 
       - uses: astral-sh/setup-uv@v7
+        with:
+          save-cache: false
 
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth


### PR DESCRIPTION
This adjusts CI to only save uv cache when run on main, same as we do with the Rust build cache.

I made the release workflow never save cache, as it's run so infrequently.