### PR TITLE
fix ffi-check in 3.15.0a7

### DIFF
--- a/pyo3-ffi/src/cpython/initconfig.rs
+++ b/pyo3-ffi/src/cpython/initconfig.rs
@@ -155,6 +155,8 @@ pub struct PyConfig {
     pub enable_gil: c_int,
     #[cfg(all(Py_3_14, Py_GIL_DISABLED))]
     pub tlbc_enabled: c_int,
+    #[cfg(Py_3_15)]
+    pub lazy_imports: c_int,
     pub pathconfig_warnings: c_int,
     #[cfg(Py_3_10)]
     pub program_name: *mut wchar_t,


### PR DESCRIPTION
3.15.0a7 includes the lazy import feature, so there's a new PyConfig member to track that setting.

I noticed this working on https://github.com/PyO3/pyo3/pull/5753 and this is cherry-picked from there.