### PR TITLE
Emscripten: No extra rustc-cdylib-link-args on Rust >= 1.95

### DIFF
--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -444,7 +444,7 @@ mod tests {
         _add_extension_module_link_args(
             &Triple::from_str("wasm32-unknown-emscripten").unwrap(),
             &mut buf,
-            None,
+            Some(94),
         );
         assert_eq!(
             std::str::from_utf8(&buf).unwrap(),


### PR DESCRIPTION
We used to have to pass extra flags to build with Emscripten but
1. Emscripten 4.0.0 made WASM_BIGINT automatic
2. Rust version 1.95 learned how to build cdylibs https://github.com/rust-lang/rust/pull/151704

We use Emscripten 3.1.58 to build for Python 3.12 which would be broken by dropping WASM_BIGINT but for Python 3.12 we also use JS eh which doesn't work at all with Rust version >= 1.93 so there's no added breakage.

On the other hand, Python 3.13 uses Emscripten 4.0.9 and doesn't need `-sWASM_BIGINT`.
