### PR TITLE
PyMappingProxy and PyWeakrefReference: allow subclasses during type check

### DIFF
--- a/newsfragments/5883.changed.md
+++ b/newsfragments/5883.changed.md
@@ -1,0 +1,2 @@
+`PyMappingProxy`: allow subclasses during type checking
+`PyWeakrefReference`: always allow subclasses during type checking

--- a/src/types/mappingproxy.rs
+++ b/src/types/mappingproxy.rs
@@ -8,23 +8,15 @@ use crate::types::any::PyAnyMethods;
 use crate::types::{PyAny, PyIterator, PyList};
 use crate::{ffi, Python};
 
-use std::ffi::c_int;
-
 /// Represents a Python `mappingproxy`.
 #[repr(transparent)]
 pub struct PyMappingProxy(PyAny);
-
-#[inline]
-unsafe fn dict_proxy_check(op: *mut ffi::PyObject) -> c_int {
-    unsafe { ffi::Py_IS_TYPE(op, &raw mut ffi::PyDictProxy_Type) }
-}
 
 pyobject_native_type_core!(
     PyMappingProxy,
     pyobject_native_static_type_object!(ffi::PyDictProxy_Type),
     "types",
-    "MappingProxyType",
-    #checkfunction=dict_proxy_check
+    "MappingProxyType"
 );
 
 impl PyMappingProxy {

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -32,7 +32,7 @@ pyobject_native_type!(
     "weakref",
     "ReferenceType",
     #module=Some("weakref"),
-    #checkfunction=ffi::PyWeakref_CheckRefExact
+    #checkfunction=ffi::PyWeakref_CheckRef
 );
 
 // When targeting alternative or multiple interpreters, it is better to not use the internal API.


### PR DESCRIPTION
This is the behavior for the other type and already the behavior of PyWeakrefReference in abi3 or PyPy/GraalPy
