### PR TITLE
Fix duplicate PyObject_Init call in alloc_with_freelist

### DIFF
--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -924,7 +924,6 @@ pub unsafe extern "C" fn alloc_with_freelist<T: PyClassWithFreeList>(
         if let Some(obj) = free_list.pop() {
             drop(free_list);
             unsafe { ffi::PyObject_Init(obj, subtype) };
-            unsafe { ffi::PyObject_Init(obj, subtype) };
             return obj as _;
         }
     }


### PR DESCRIPTION
Looks like a bad merge to me.