### PR TITLE
Run tests with macros and without experimental inspect

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1494,7 +1494,7 @@ def _get_feature_sets() -> Tuple[Optional[str], ...]:
     if is_rust_nightly():
         features += ",nightly"
 
-    return (None, "abi3", features, f"abi3,{features}")
+    return (None, "abi3", "macros", "abi3,macros", features, f"abi3,{features}")
 
 
 _RELEASE_LINE_START = "release: "

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -9,6 +9,7 @@ fn test_compile_errors() {
     #[cfg(not(feature = "experimental-inspect"))]
     t.compile_fail("tests/ui/invalid_property_args.rs");
     t.compile_fail("tests/ui/invalid_proto_pymethods.rs");
+    #[cfg(not(feature = "experimental-inspect"))]
     #[cfg(not(all(Py_LIMITED_API, not(Py_3_10))))] // to avoid PyFunctionArgument for &str
     t.compile_fail("tests/ui/invalid_pyclass_args.rs");
     t.compile_fail("tests/ui/invalid_pyclass_doc.rs");
@@ -78,7 +79,7 @@ fn test_compile_errors() {
     t.pass("tests/ui/pymodule_missing_docs.rs");
     #[cfg(not(any(Py_LIMITED_API, feature = "experimental-inspect")))]
     t.pass("tests/ui/forbid_unsafe.rs");
-    #[cfg(all(Py_LIMITED_API, not(feature = "experimental-async")))]
+    #[cfg(all(Py_LIMITED_API, not(Py_3_12), not(feature = "experimental-async")))]
     // output changes with async feature
     t.compile_fail("tests/ui/abi3_inheritance.rs");
     #[cfg(all(Py_LIMITED_API, not(Py_3_9)))]

--- a/tests/ui/invalid_pyclass_args.stderr
+++ b/tests/ui/invalid_pyclass_args.stderr
@@ -192,35 +192,6 @@ error[E0119]: conflicting implementations of trait `PyClassNewTextSignature` for
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:205:12
-    |
-205 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyFunctionArgument<'_, '_, '_, false>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
-    |
-    = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
-   --> src/impl_/extract_argument.rs
-    |
-    | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-    | |     for &'holder Bound<'py, T>
-    | | where
-    | |     T: PyTypeCheck,
-    | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-    | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-    | | where
-    | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-    | |___________________________________________________^ `Option<T>` implements `PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-    |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-    |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `PyFunctionArgument<'a, 'holder, '_, false>`
-...
-    | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-    | |     for &'holder mut T
-    | |______________________^ `&'holder mut T` implements `PyFunctionArgument<'a, 'holder, '_, false>`
-
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
   --> tests/ui/invalid_pyclass_args.rs:37:1
    |
@@ -456,11 +427,11 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
    --> tests/ui/invalid_pyclass_args.rs:205:12
     |
 205 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::PyClass` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+    |            ^^^ the trait `PyClass` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::PyClass`:
+    = help: the following other types implement trait `PyClass`:
               Coord
               Coord2
               Coord3


### PR DESCRIPTION
We are currently not testing pyo3 with the `macros` feature enabled but without `full` enabled, i.e. with the default set of pyo3 features

Fixes Issue #5910