### PR TITLE
ffi-check: ignore mingw types

### DIFF
--- a/pyo3-ffi-check/definitions/build.rs
+++ b/pyo3-ffi-check/definitions/build.rs
@@ -60,6 +60,8 @@ fn main() {
         .blocklist_item("FP_INT_TONEARESTFROMZERO")
         .blocklist_item("FP_INT_TONEAREST")
         .blocklist_item("FP_ZERO")
+        // blocklist mingw specific types
+        .blocklist_type("__mingw_ldbl_type_t")
         // ARM neon intrinsics cause issue on GitHub actions windows CI, also not relevant to
         // what we're trying to check anyway.
         .blocklist_file(r".*(\\|/)arm(64)?_neon\.h")


### PR DESCRIPTION
I commonly develop using a mingw toolchain and noticed that for me ffi-check started failing locally after #5918 with this error:
```txt
error[E0080]: index out of bounds: the length is 1 but the index is 8
    --> ...\pyo3\pyo3-ffi-check\target\x86_64-pc-windows-gnullvm\debug\build\pyo3-ffi-check-definitions-10e98362a5f4c68d\out/bindings.rs:6511:5
     |
6511 |     ["Alignment of __mingw_ldbl_type_t"][::std::mem::align_of::<__mingw_ldbl_type_t>() - 8usize];
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `bindgen::_` failed here

For more information about this error, try `rustc --explain E0080`.
error: could not compile `pyo3-ffi-check-definitions` (lib) due to 1 previous error
```

I think this is just caused because bindgen generates some checks for mingw internal types, which we can simply ignore. 

This will have no effect on CI (and I don't think we need to extend it as it is not commonly used), but it might be nice to fix it anyway.