### PR TITLE
add support for defining a metaclass in Rust

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -617,6 +617,166 @@ impl MyDict {
 
 Here, the `args` and `kwargs` allow creating instances of the subclass passing initial items, such as `MyDict(item_sequence)` or `MyDict(a=1, b=2)`.
 
+## Defining a metaclass in Rust
+
+A **metaclass** is a class whose instances are themselves classes. Python's built-in `type` is the default metaclass; every class you write is an instance of `type`. By defining a custom metaclass you can intercept and customise class creation, `isinstance` / `issubclass` checks, subscript (`C[T]`) dispatch, and more.
+
+PyO3 lets you define a metaclass in Rust by extending `PyType` with `#[pyclass(extends = PyType)]`:
+
+```rust
+# use pyo3::prelude::*;
+# use pyo3::types::{PyAny, PyDict, PyTuple, PyType};
+#[pyclass(extends = PyType)]
+struct MyMeta;
+
+#[pymethods]
+impl MyMeta {
+    /// Called on `isinstance(x, C)` where `C` has metaclass `MyMeta`.
+    fn __instancecheck__(&self, _instance: &Bound<'_, PyAny>) -> bool {
+        true
+    }
+
+    /// Called on `issubclass(X, C)` where `C` has metaclass `MyMeta`.
+    fn __subclasscheck__(&self, _subclass: &Bound<'_, PyAny>) -> bool {
+        true
+    }
+
+    /// Called on `C[item]` – enables Generic-style subscript syntax.
+    fn __getitem__(&self, item: Py<PyAny>) -> Py<PyAny> {
+        item
+    }
+
+    /// Called when the class itself is called, e.g. `C()`.
+    #[pyo3(signature = (*args, **_kwargs))]
+    fn __call__(
+        slf: &Bound<'_, Self>,
+        args: &Bound<'_, PyTuple>,
+        _kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<PyAny>> {
+        let py = slf.py();
+        let result = PyTuple::new(py, [slf.as_any().clone(), args.as_any().clone()])?;
+        Ok(result.into())
+    }
+}
+# Python::attach(|py| {
+#     let meta = py.get_type::<MyMeta>();
+#     pyo3::py_run!(py, meta, "
+# class C(metaclass=meta): pass
+# assert isinstance(C, meta)
+# assert issubclass(meta, type)
+# assert isinstance(42, C)
+# assert issubclass(int, C)
+# assert C[int] is int
+# result = C()
+# assert isinstance(result, tuple)
+# ")
+# });
+```
+
+Under the hood `#[pyclass(extends = PyType)]` makes the Rust struct a **subtype of Python's `type`** (i.e. `issubclass(MyMeta, type)` is always `True`). The metaclass status is inferred automatically: any struct that extends `PyType` (or another metaclass) has `IS_METACLASS = true` propagated through the type chain at compile time.
+
+### `__prepare__`
+
+`__prepare__` is a class method called by Python before the class body is executed; it returns a mapping used as the class namespace. Define it with `#[classmethod]`:
+
+```rust
+# use pyo3::prelude::*;
+# use pyo3::types::{PyDict, PyTuple, PyType};
+# #[pyclass(extends = PyType)]
+# struct PrepMeta;
+#[pymethods]
+impl PrepMeta {
+    #[classmethod]
+    #[pyo3(signature = (_name, _bases, **_kwargs))]
+    fn __prepare__(
+        _mcs: &Bound<'_, PyType>,
+        _name: &str,
+        _bases: &Bound<'_, PyTuple>,
+        _kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<PyDict>> {
+        let py = _mcs.py();
+        let d = PyDict::new(py);
+        d.set_item("injected", true)?;
+        Ok(d.into())
+    }
+}
+# Python::attach(|py| {
+#     let meta = py.get_type::<PrepMeta>();
+#     pyo3::py_run!(py, meta, "
+# class C(metaclass=meta): pass
+# assert C.injected is True
+# ")
+# });
+```
+
+### Custom `__new__` and the safe helper
+
+When you define a custom `__new__`, use the combination `#[new] #[classmethod]` and return `Py<Self>`. The Python-level `type.__new__` performs a safety check (`metatype->tp_new != type_new`) that rejects PyO3 metaclasses that have a custom `tp_new` slot. Use the provided safe helper [`PyType::metaclass_type_new`] instead:
+
+```rust
+# use pyo3::prelude::*;
+# use pyo3::types::{PyDict, PyString, PyTuple, PyType};
+# #[pyclass(extends = PyType)]
+# struct CustomMeta;
+#[pymethods]
+impl CustomMeta {
+    #[new]
+    #[classmethod]
+    fn new(
+        cls: &Bound<'_, PyType>,
+        name: &Bound<'_, PyString>,
+        bases: &Bound<'_, PyTuple>,
+        namespace: &Bound<'_, PyDict>,
+    ) -> PyResult<Py<Self>> {
+        PyType::metaclass_type_new(cls, name, bases, namespace)?
+            .cast_into::<Self>()
+            .map(|b| b.unbind())
+            .map_err(Into::into)
+    }
+}
+# Python::attach(|py| {
+#     let meta = py.get_type::<CustomMeta>();
+#     pyo3::py_run!(py, meta, "
+# class E(metaclass=meta): pass
+# assert isinstance(E, meta)
+# ")
+# });
+```
+
+### Extending a Rust metaclass
+
+A Rust metaclass can be used as a base for further specialisation. Add `subclass` to the base metaclass to make it eligible, then extend it normally:
+
+```rust
+# use pyo3::prelude::*;
+# #[pyclass(extends = pyo3::types::PyType, subclass)]
+# struct BaseMeta;
+# #[pymethods]
+# impl BaseMeta {}
+#[pyclass(extends = BaseMeta)]
+struct DerivedMeta;
+
+#[pymethods]
+impl DerivedMeta {
+    // Add or override methods here
+}
+# Python::attach(|py| {
+#     let base_meta = py.get_type::<BaseMeta>();
+#     let derived_meta = py.get_type::<DerivedMeta>();
+#     pyo3::py_run!(py, base_meta derived_meta, "
+# assert issubclass(derived_meta, base_meta)
+# class C(metaclass=derived_meta): pass
+# assert isinstance(C, derived_meta)
+# assert isinstance(C, base_meta)
+# ")
+# });
+```
+
+### Limitations
+
+- Applying a Rust-defined metaclass to another `#[pyclass]` via `#[pyclass(metaclass = MyMeta)]` is not yet supported; metaclasses can only be applied in Python code (`class C(metaclass=MyMeta): ...`).
+- Inheriting from a Python-defined metaclass using `extends` is not currently supported.
+
 ## Object properties
 
 PyO3 supports two ways to add properties to your `#[pyclass]`:
@@ -1587,3 +1747,5 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
 
 [lifetime-elision]: https://doc.rust-lang.org/reference/lifetime-elision.html
 [compiler-error-e0106]: https://doc.rust-lang.org/error_codes/E0106.html
+
+[`PyType::metaclass_type_new`]: {{#PYO3_DOCS_URL}}/pyo3/types/struct.PyType.html#method.metaclass_type_new

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2923,6 +2923,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     type Initializer = #pyo3_path::pyclass_init::PyClassInitializer<Self>;
                     type PyClassMutability = <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::PyClassMutability;
                     type Layout<T: #pyo3_path::impl_::pyclass::PyClassImpl> = <Self::BaseNativeType as #pyo3_path::impl_::pyclass::PyClassBaseType>::Layout<T>;
+                    const IS_METACLASS: bool = <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::IS_METACLASS;
                 }
             }
         });
@@ -3019,6 +3020,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                 const IS_MAPPING: bool = #is_mapping;
                 const IS_SEQUENCE: bool = #is_sequence;
                 const IS_IMMUTABLE_TYPE: bool = #is_immutable_type;
+                const IS_METACLASS: bool = <#base as #pyo3_path::impl_::pyclass::PyClassBaseType>::IS_METACLASS;
 
                 type Layout = <Self::BaseNativeType as #pyo3_path::impl_::pyclass::PyClassBaseType>::Layout<Self>;
                 type BaseType = #base;

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -177,6 +177,10 @@ pub trait PyClassImpl: Sized + 'static {
     /// #[pyclass(immutable_type)]
     const IS_IMMUTABLE_TYPE: bool = false;
 
+    /// True when this type is a metaclass (subtype of `type`).
+    /// Inferred automatically from `extends = PyType` or `extends = <other metaclass>`.
+    const IS_METACLASS: bool = false;
+
     /// Description of how this class is laid out in memory
     type Layout: PyClassObjectLayout<Self>;
 
@@ -1084,6 +1088,10 @@ pub trait PyClassBaseType: Sized {
     type PyClassMutability: PyClassMutability;
     /// The type of object layout to use for ancestors or descendants of this type.
     type Layout<T: PyClassImpl>;
+    /// True when this type is itself a metaclass (a subtype of `type`).
+    /// Set to `true` for [`pyo3::types::PyType`] and propagated automatically to
+    /// any `#[pyclass]` that uses `extends = PyType` (or extends another metaclass).
+    const IS_METACLASS: bool = false;
 }
 
 /// Implementation of tp_dealloc for pyclasses without gc

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -49,6 +49,7 @@ where
         is_mapping: bool,
         is_sequence: bool,
         is_immutable_type: bool,
+        is_metaclass: bool,
         doc: &'static CStr,
         dict_offset: Option<PyObjectOffset>,
         weaklist_offset: Option<PyObjectOffset>,
@@ -72,6 +73,7 @@ where
                 is_mapping,
                 is_sequence,
                 is_immutable_type,
+                is_metaclass,
                 has_new: false,
                 has_dealloc: false,
                 has_getitem: false,
@@ -100,6 +102,7 @@ where
             T::IS_MAPPING,
             T::IS_SEQUENCE,
             T::IS_IMMUTABLE_TYPE,
+            T::IS_METACLASS,
             T::DOC,
             T::dict_offset(),
             T::weaklist_offset(),
@@ -131,6 +134,7 @@ struct PyTypeBuilder {
     is_mapping: bool,
     is_sequence: bool,
     is_immutable_type: bool,
+    is_metaclass: bool,
     has_new: bool,
     has_dealloc: bool,
     has_getitem: bool,
@@ -449,14 +453,20 @@ impl PyTypeBuilder {
         unsafe { self.push_slot(ffi::Py_tp_base, self.tp_base) }
 
         if !self.has_new {
-            #[cfg(not(Py_3_10))]
-            {
-                // Safety: This is the correct slot type for Py_tp_new
-                unsafe { self.push_slot(ffi::Py_tp_new, no_constructor_defined as *mut c_void) }
-            }
-            #[cfg(Py_3_10)]
-            {
-                self.class_flags |= ffi::Py_TPFLAGS_DISALLOW_INSTANTIATION;
+            // For metaclasses (subclasses of `type`), we do not install a stub constructor;
+            // instead, we rely on the inherited `type.__new__` from the base `tp_base`.
+            if !self.is_metaclass {
+                #[cfg(not(Py_3_10))]
+                {
+                    // Safety: This is the correct slot type for Py_tp_new
+                    unsafe {
+                        self.push_slot(ffi::Py_tp_new, no_constructor_defined as *mut c_void)
+                    }
+                }
+                #[cfg(Py_3_10)]
+                {
+                    self.class_flags |= ffi::Py_TPFLAGS_DISALLOW_INSTANTIATION;
+                }
             }
         }
 

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -46,6 +46,60 @@ impl PyType {
                 .to_owned()
         }
     }
+
+    /// Calls CPython's `type.__new__` to create a new type object as part of a
+    /// custom metaclass `__new__` implementation.
+    ///
+    /// This is the safe alternative to calling `PyType_Type.tp_new` directly.
+    /// The Python-level `type.__new__` callable performs a safety check that
+    /// rejects PyO3 metaclasses (because their `tp_new` slot differs from the
+    /// built-in `type_new`), so this function invokes the C-level slot directly
+    /// to bypass that check while still creating a well-formed type object.
+    ///
+    /// # Usage
+    ///
+    /// ```rust,ignore
+    /// #[pyclass(extends = pyo3::types::PyType)]
+    /// struct MyMeta;
+    ///
+    /// #[pymethods]
+    /// impl MyMeta {
+    ///     #[new]
+    ///     #[classmethod]
+    ///     fn new(
+    ///         cls: &Bound<'_, PyType>,
+    ///         name: &Bound<'_, PyString>,
+    ///         bases: &Bound<'_, PyTuple>,
+    ///         namespace: &Bound<'_, PyDict>,
+    ///     ) -> PyResult<Py<Self>> {
+    ///         PyType::metaclass_type_new(cls, name, bases, namespace)?
+    ///             .extract()
+    ///             .map_err(Into::into)
+    ///     }
+    /// }
+    /// ```
+    pub fn metaclass_type_new<'py>(
+        cls: &Bound<'py, PyType>,
+        name: &Bound<'py, super::PyString>,
+        bases: &Bound<'py, PyTuple>,
+        namespace: &Bound<'py, super::PyDict>,
+    ) -> PyResult<Bound<'py, PyType>> {
+        let py = cls.py();
+        let args = PyTuple::new(py, [name.as_any(), bases.as_any(), namespace.as_any()])?;
+        let obj_ptr = unsafe {
+            let tp_new = ffi::PyType_Type
+                .tp_new
+                .expect("PyType_Type must have tp_new");
+            tp_new(cls.as_type_ptr(), args.as_ptr(), std::ptr::null_mut())
+        };
+        if obj_ptr.is_null() {
+            return Err(crate::PyErr::fetch(py));
+        }
+        // Safety: tp_new returned a non-null PyTypeObject pointer.
+        Ok(unsafe {
+            Bound::<PyAny>::from_owned_ptr(py, obj_ptr).cast_into_unchecked::<PyType>()
+        })
+    }
 }
 
 /// Implementation of functionality for [`PyType`].
@@ -240,6 +294,41 @@ impl<'py> PyTypeMethods<'py> for Bound<'py, PyType> {
 
         bases
     }
+}
+
+// PyType can be used as a base class for metaclass structs (i.e. #[pyclass(extends = PyType)]).
+//
+// For non-limited API builds the exact C layout (PyHeapTypeObject) is known at
+// compile-time, so we use the static-size object approach.
+// For limited-API builds (Python ≥ 3.12) CPython will allocate the correct
+// amount of memory for us when we pass a negative basicsize; we use the
+// variable-size approach for those.
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+unsafe impl crate::type_object::PyLayout<PyType> for crate::ffi::PyHeapTypeObject {}
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+impl crate::type_object::PySizedLayout<PyType> for crate::ffi::PyHeapTypeObject {}
+
+#[cfg(not(any(Py_LIMITED_API, PyPy)))]
+impl crate::impl_::pyclass::PyClassBaseType for PyType {
+    type LayoutAsBase =
+        crate::impl_::pycell::PyClassObjectBase<crate::ffi::PyHeapTypeObject>;
+    type BaseNativeType = PyType;
+    type Initializer = crate::impl_::pyclass_init::PyNativeTypeInitializer<Self>;
+    type PyClassMutability = crate::pycell::impl_::ImmutableClass;
+    type Layout<T: crate::impl_::pyclass::PyClassImpl> =
+        crate::impl_::pycell::PyStaticClassObject<T>;
+    const IS_METACLASS: bool = true;
+}
+
+#[cfg(all(Py_3_12, Py_LIMITED_API))]
+impl crate::impl_::pyclass::PyClassBaseType for PyType {
+    type LayoutAsBase = crate::impl_::pycell::PyVariableClassObjectBase;
+    type BaseNativeType = PyType;
+    type Initializer = crate::impl_::pyclass_init::PyNativeTypeInitializer<Self>;
+    type PyClassMutability = crate::pycell::impl_::ImmutableClass;
+    type Layout<T: crate::impl_::pyclass::PyClassImpl> =
+        crate::impl_::pycell::PyVariableClassObject<T>;
+    const IS_METACLASS: bool = true;
 }
 
 #[cfg(test)]

--- a/tests/test_metaclass.rs
+++ b/tests/test_metaclass.rs
@@ -1,0 +1,288 @@
+#![cfg(feature = "macros")]
+
+use pyo3::prelude::*;
+use pyo3::py_run;
+use pyo3::types::{PyAny, PyDict, PyString, PyTuple, PyType};
+
+mod test_utils;
+
+// A simple metaclass with no extra data fields or custom __new__.
+// It relies on the inherited `type.__new__` for class creation.
+// `subclass` is set so this metaclass can itself be used as a base (e.g. for DerivedMeta).
+#[pyclass(extends = PyType, subclass)]
+struct SimpleMeta;
+
+#[pymethods]
+impl SimpleMeta {
+    // Overrides isinstance(x, C) where C has metaclass SimpleMeta.
+    // Always returns True for testing purposes.
+    fn __instancecheck__(&self, _instance: &Bound<'_, PyAny>) -> bool {
+        true
+    }
+
+    // Overrides issubclass(X, C) where C has metaclass SimpleMeta.
+    // Always returns True for testing purposes.
+    fn __subclasscheck__(&self, _subclass: &Bound<'_, PyAny>) -> bool {
+        true
+    }
+
+    // Overrides C[item] where C has metaclass SimpleMeta.
+    fn __getitem__(&self, item: Py<PyAny>) -> Py<PyAny> {
+        item
+    }
+}
+
+// A metaclass that demonstrates __prepare__ (returns a custom namespace dict).
+#[pyclass(extends = PyType)]
+struct PrepMeta;
+
+#[pymethods]
+impl PrepMeta {
+    // __prepare__ is a classmethod called before the class body is executed.
+    // It should return a mapping (typically a dict) used as the class namespace.
+    #[classmethod]
+    #[pyo3(signature = (_name, _bases, **_kwargs))]
+    fn __prepare__(
+        _mcs: &Bound<'_, PyType>,
+        _name: &str,
+        _bases: &Bound<'_, PyTuple>,
+        _kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<PyDict>> {
+        let py = _mcs.py();
+        let d = PyDict::new(py);
+        d.set_item("__prepared__", true)?;
+        Ok(d.into())
+    }
+}
+
+// A metaclass that overrides __call__ so that calling C() returns a tuple
+// (cls, args, kwargs) for testing.
+#[pyclass(extends = PyType)]
+struct CallMeta;
+
+#[pymethods]
+impl CallMeta {
+    #[pyo3(signature = (*args, **_kwargs))]
+    fn __call__(
+        slf: &Bound<'_, Self>,
+        args: &Bound<'_, PyTuple>,
+        _kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Py<PyAny>> {
+        let py = slf.py();
+        // Return (type, args) to show we intercept the call
+        let result = PyTuple::new(py, [slf.as_any().clone(), args.as_any().clone()])?;
+        Ok(result.into())
+    }
+}
+
+// A metaclass with a custom __new__ that uses the safe PyType::metaclass_type_new helper.
+#[pyclass(extends = PyType)]
+struct CustomNewMeta;
+
+#[pymethods]
+impl CustomNewMeta {
+    #[new]
+    #[classmethod]
+    fn new(
+        cls: &Bound<'_, PyType>,
+        name: &Bound<'_, PyString>,
+        bases: &Bound<'_, PyTuple>,
+        namespace: &Bound<'_, PyDict>,
+    ) -> PyResult<Py<Self>> {
+        // Use the safe helper instead of raw FFI.
+        PyType::metaclass_type_new(cls, name, bases, namespace)?
+            .cast_into::<Self>()
+            .map(|b| b.unbind())
+            .map_err(Into::into)
+    }
+}
+
+// A Rust metaclass that extends another Rust metaclass.
+// Uses #[pyclass(extends = SimpleMeta)] to inherit from SimpleMeta
+// (which must have `subclass` to be usable as a base).
+#[pyclass(extends = SimpleMeta)]
+struct DerivedMeta;
+
+#[pymethods]
+impl DerivedMeta {
+    #[new]
+    #[classmethod]
+    fn new(
+        cls: &Bound<'_, PyType>,
+        name: &Bound<'_, PyString>,
+        bases: &Bound<'_, PyTuple>,
+        namespace: &Bound<'_, PyDict>,
+    ) -> PyResult<Py<Self>> {
+        SimpleMeta::new(cls, &(name.to_string() + "-derived"), bases, namespace)?
+            .cast_into::<Self>()
+            .map(|b| b.unbind())
+            .map_err(Into::into)
+    }
+}
+
+#[test]
+fn test_simple_metaclass_type_hierarchy() {
+    Python::attach(|py| {
+        let meta = py.get_type::<SimpleMeta>();
+        py_run!(
+            py,
+            meta,
+            r#"
+# SimpleMeta must be a subclass of type
+assert issubclass(meta, type), f"Expected issubclass(meta, type) but got False"
+# A class created with metaclass=meta must be an instance of meta
+class C(metaclass=meta): pass
+assert isinstance(C, meta), f"Expected isinstance(C, meta) but got False"
+assert type(C) is meta, f"Expected type(C) is meta but got {type(C)}"
+"#
+        );
+    });
+}
+
+#[test]
+fn test_metaclass_instancecheck() {
+    Python::attach(|py| {
+        let meta = py.get_type::<SimpleMeta>();
+        py_run!(
+            py,
+            meta,
+            r#"
+class C(metaclass=meta): pass
+# __instancecheck__ on SimpleMeta always returns True
+assert isinstance(42, C)
+assert isinstance("hello", C)
+assert isinstance(None, C)
+"#
+        );
+    });
+}
+
+#[test]
+fn test_metaclass_subclasscheck() {
+    Python::attach(|py| {
+        let meta = py.get_type::<SimpleMeta>();
+        py_run!(
+            py,
+            meta,
+            r#"
+class C(metaclass=meta): pass
+# __subclasscheck__ on SimpleMeta always returns True
+assert issubclass(int, C)
+assert issubclass(str, C)
+assert issubclass(list, C)
+"#
+        );
+    });
+}
+
+#[test]
+fn test_metaclass_getitem() {
+    Python::attach(|py| {
+        let meta = py.get_type::<SimpleMeta>();
+        py_run!(
+            py,
+            meta,
+            r#"
+class C(metaclass=meta): pass
+# __getitem__ on SimpleMeta returns the item unchanged
+assert C[int] is int
+assert C[str] is str
+# Tuple subscript creates a tuple
+tup = C[int, str]
+assert tup == (int, str)
+"#
+        );
+    });
+}
+
+#[test]
+fn test_metaclass_prepare() {
+    Python::attach(|py| {
+        let meta = py.get_type::<PrepMeta>();
+        py_run!(
+            py,
+            meta,
+            r#"
+# __prepare__ injects '__prepared__' into the class namespace before body runs
+class C(metaclass=meta): pass
+assert C.__prepared__ is True, f"Expected C.__prepared__ == True, got {C.__dict__.get('__prepared__')}"
+"#
+        );
+    });
+}
+
+#[test]
+fn test_metaclass_call() {
+    Python::attach(|py| {
+        let meta = py.get_type::<CallMeta>();
+        py_run!(
+            py,
+            meta,
+            r#"
+class D(metaclass=meta): pass
+# Calling D() invokes CallMeta.__call__(D, (), {})
+result = D()
+assert isinstance(result, tuple)
+assert result[0] is D
+"#
+        );
+    });
+}
+
+#[test]
+fn test_metaclass_custom_new() {
+    Python::attach(|py| {
+        let meta = py.get_type::<CustomNewMeta>();
+        py_run!(
+            py,
+            meta,
+            r#"
+class E(metaclass=meta): pass
+assert isinstance(E, meta), f"Expected isinstance(E, meta) but got False"
+assert issubclass(meta, type), f"Expected issubclass(meta, type) but got False"
+"#
+        );
+    });
+}
+
+#[test]
+fn test_metaclass_is_subclassable() {
+    Python::attach(|py| {
+        let meta = py.get_type::<SimpleMeta>();
+        // SimpleMeta should be subclassable (i.e., can be used as a metaclass)
+        py_run!(
+            py,
+            meta,
+            r#"
+# Metaclasses can be subclassed in Python
+class SubMeta(meta): pass
+class F(metaclass=SubMeta): pass
+assert isinstance(F, SubMeta)
+assert isinstance(F, meta)
+"#
+        );
+    });
+}
+
+#[test]
+fn test_rust_metaclass_extends_rust_metaclass() {
+    Python::attach(|py| {
+        let base_meta = py.get_type::<SimpleMeta>();
+        let derived_meta = py.get_type::<DerivedMeta>();
+        py_run!(
+            py,
+            base_meta derived_meta,
+            r#"
+# DerivedMeta must be a subclass of SimpleMeta (and hence of type)
+assert issubclass(derived_meta, base_meta), f"Expected issubclass(derived_meta, base_meta)"
+assert issubclass(derived_meta, type), f"Expected issubclass(derived_meta, type)"
+# Classes using DerivedMeta must be instances of both
+class G(metaclass=derived_meta): pass
+assert isinstance(G, derived_meta)
+assert isinstance(G, base_meta)
+assert issubclass(type(G), derived_meta)
+assert G.__name__ == "G-derived", f"Expected G.__name__ == 'G-derived', got {G.__name__}"
+"#
+        );
+    });
+}

--- a/tests/ui/invalid_base_class.stderr
+++ b/tests/ui/invalid_base_class.stderr
@@ -41,3 +41,22 @@ note: required by a bound in `PyClassImpl::BaseType`
   |
   |     type BaseType: PyTypeInfo + PyClassBaseType;
   |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`
+
+error[E0277]: pyclass `PyBool` cannot be subclassed
+ --> tests/ui/invalid_base_class.rs:4:19
+  |
+4 | #[pyclass(extends=PyBool)]
+  |                   ^^^^^^ required for `#[pyclass(extends=PyBool)]`
+  |
+  = help: the trait `PyClassBaseType` is not implemented for `PyBool`
+  = note: `PyBool` must have `#[pyclass(subclass)]` to be eligible for subclassing
+  = help: the following other types implement trait `PyClassBaseType`:
+            PyAny
+            PyArithmeticError
+            PyAssertionError
+            PyAttributeError
+            PyBaseException
+            PyBaseExceptionGroup
+            PyBlockingIOError
+            PyBrokenPipeError
+          and $N others

--- a/tests/ui/not_send.stderr
+++ b/tests/ui/not_send.stderr
@@ -9,9 +9,6 @@ error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safe
   = help: within `pyo3::Python<'_>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
 note: required because it appears within the type `PhantomData<*mut pyo3::Python<'static>>`
  --> $RUST/core/src/marker.rs
-  |
-  | pub struct PhantomData<T: PointeeSized>;
-  |            ^^^^^^^^^^^
 note: required because it appears within the type `pyo3::marker::NotSend`
  --> src/marker.rs
   |
@@ -19,9 +16,6 @@ note: required because it appears within the type `pyo3::marker::NotSend`
   |        ^^^^^^^
 note: required because it appears within the type `PhantomData<pyo3::marker::NotSend>`
  --> $RUST/core/src/marker.rs
-  |
-  | pub struct PhantomData<T: PointeeSized>;
-  |            ^^^^^^^^^^^
 note: required because it appears within the type `pyo3::Python<'_>`
  --> src/marker.rs
   |

--- a/tests/ui/not_send2.stderr
+++ b/tests/ui/not_send2.stderr
@@ -12,9 +12,6 @@ error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safe
    = help: within `pyo3::Bound<'_, PyString>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
 note: required because it appears within the type `PhantomData<*mut pyo3::Python<'static>>`
   --> $RUST/core/src/marker.rs
-   |
-   | pub struct PhantomData<T: PointeeSized>;
-   |            ^^^^^^^^^^^
 note: required because it appears within the type `pyo3::marker::NotSend`
   --> src/marker.rs
    |
@@ -22,9 +19,6 @@ note: required because it appears within the type `pyo3::marker::NotSend`
    |        ^^^^^^^
 note: required because it appears within the type `PhantomData<pyo3::marker::NotSend>`
   --> $RUST/core/src/marker.rs
-   |
-   | pub struct PhantomData<T: PointeeSized>;
-   |            ^^^^^^^^^^^
 note: required because it appears within the type `pyo3::Python<'_>`
   --> src/marker.rs
    |


### PR DESCRIPTION
A new method is added to PyType to allow to use a metaclass with a custom new method

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [https://pyo3.rs/main/contributing.html#documenting-changes]
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run `nox`. See `nox --list-sessions` for a list of supported actions.
