### PR TITLE
Use `Py_IS_TYPE` on abi3 & python 3.15+

### DIFF
--- a/newsfragments/5977.changed.md
+++ b/newsfragments/5977.changed.md
@@ -1,1 +1,0 @@
-Use `Py_IS_TYPE` on abi3 & python 3.15+

--- a/newsfragments/5977.changed.md
+++ b/newsfragments/5977.changed.md
@@ -1,0 +1,1 @@
+Use `Py_IS_TYPE` on abi3 & python 3.15+

--- a/pyo3-ffi/src/boolobject.rs
+++ b/pyo3-ffi/src/boolobject.rs
@@ -5,7 +5,7 @@ use std::ffi::{c_int, c_long};
 
 #[inline]
 pub unsafe fn PyBool_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyBool_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyBool_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/bytearrayobject.rs
+++ b/pyo3-ffi/src/bytearrayobject.rs
@@ -16,7 +16,7 @@ pub unsafe fn PyByteArray_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyByteArray_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyByteArray_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyByteArray_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/bytesobject.rs
+++ b/pyo3-ffi/src/bytesobject.rs
@@ -15,7 +15,7 @@ pub unsafe fn PyBytes_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyBytes_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyBytes_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyBytes_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/context.rs
+++ b/pyo3-ffi/src/context.rs
@@ -1,4 +1,5 @@
-use crate::object::{PyObject, PyTypeObject, Py_TYPE};
+use crate::object::{PyObject, PyTypeObject};
+use crate::Py_IS_TYPE;
 use std::ffi::{c_char, c_int};
 
 extern_libpython! {
@@ -12,17 +13,17 @@ extern_libpython! {
 
 #[inline]
 pub unsafe fn PyContext_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyContext_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyContext_Type)
 }
 
 #[inline]
 pub unsafe fn PyContextVar_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyContextVar_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyContextVar_Type)
 }
 
 #[inline]
 pub unsafe fn PyContextToken_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyContextToken_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyContextToken_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/cpython/code.rs
+++ b/pyo3-ffi/src/cpython/code.rs
@@ -72,7 +72,7 @@ extern_libpython! {
 #[inline]
 #[cfg(not(PyPy))]
 pub unsafe fn PyCode_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyCode_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyCode_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/cpython/funcobject.rs
+++ b/pyo3-ffi/src/cpython/funcobject.rs
@@ -1,4 +1,4 @@
-use crate::PyObject;
+use crate::{PyObject, Py_IS_TYPE};
 use std::ffi::c_int;
 
 #[cfg(all(not(any(PyPy, GraalPy)), not(Py_3_10)))]
@@ -65,7 +65,7 @@ extern_libpython! {
 
 #[inline]
 pub unsafe fn PyFunction_Check(op: *mut PyObject) -> c_int {
-    (crate::Py_TYPE(op) == &raw mut PyFunction_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyFunction_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/cpython/genobject.rs
+++ b/pyo3-ffi/src/cpython/genobject.rs
@@ -50,7 +50,7 @@ pub unsafe fn PyGen_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyGen_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyGen_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyGen_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/cpython/methodobject.rs
+++ b/pyo3-ffi/src/cpython/methodobject.rs
@@ -15,7 +15,7 @@ extern_libpython! {
 
 #[inline]
 pub unsafe fn PyCMethod_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyCMethod_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyCMethod_Type)
 }
 
 #[inline]

--- a/pyo3-ffi/src/cpython/pyframe.rs
+++ b/pyo3-ffi/src/cpython/pyframe.rs
@@ -1,6 +1,6 @@
 #[cfg(any(Py_3_11, all(Py_3_9, not(PyPy))))]
 use crate::PyFrameObject;
-use crate::{PyObject, PyTypeObject, Py_TYPE};
+use crate::{PyObject, PyTypeObject, Py_IS_TYPE};
 #[cfg(Py_3_12)]
 use std::ffi::c_char;
 use std::ffi::c_int;
@@ -32,13 +32,13 @@ extern_libpython! {
 
 #[inline]
 pub unsafe fn PyFrame_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyFrame_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyFrame_Type)
 }
 
 #[cfg(Py_3_13)]
 #[inline]
 pub unsafe fn PyFrameLocalsProxy_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyFrameLocalsProxy_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyFrameLocalsProxy_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/datetime.rs
+++ b/pyo3-ffi/src/datetime.rs
@@ -8,7 +8,7 @@
 use crate::PyCapsule_Import;
 #[cfg(GraalPy)]
 use crate::{PyLong_AsLong, PyLong_Check, PyObject_GetAttrString, Py_DecRef};
-use crate::{PyObject, PyObject_TypeCheck, PyTypeObject, Py_None, Py_TYPE};
+use crate::{PyObject, PyObject_TypeCheck, PyTypeObject, Py_IS_TYPE, Py_None};
 use std::ffi::c_char;
 use std::ffi::c_int;
 use std::ptr;
@@ -651,7 +651,7 @@ pub unsafe fn PyDate_Check(op: *mut PyObject) -> c_int {
 #[inline]
 /// Check if `op`'s type is exactly `PyDateTimeAPI.DateType`.
 pub unsafe fn PyDate_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == (*PyDateTimeAPI()).DateType) as c_int
+    Py_IS_TYPE(op, (*PyDateTimeAPI()).DateType)
 }
 
 #[inline]
@@ -663,7 +663,7 @@ pub unsafe fn PyDateTime_Check(op: *mut PyObject) -> c_int {
 #[inline]
 /// Check if `op`'s type is exactly `PyDateTimeAPI.DateTimeType`.
 pub unsafe fn PyDateTime_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == (*PyDateTimeAPI()).DateTimeType) as c_int
+    Py_IS_TYPE(op, (*PyDateTimeAPI()).DateTimeType)
 }
 
 #[inline]
@@ -675,7 +675,7 @@ pub unsafe fn PyTime_Check(op: *mut PyObject) -> c_int {
 #[inline]
 /// Check if `op`'s type is exactly `PyDateTimeAPI.TimeType`.
 pub unsafe fn PyTime_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == (*PyDateTimeAPI()).TimeType) as c_int
+    Py_IS_TYPE(op, (*PyDateTimeAPI()).TimeType)
 }
 
 #[inline]
@@ -687,7 +687,7 @@ pub unsafe fn PyDelta_Check(op: *mut PyObject) -> c_int {
 #[inline]
 /// Check if `op`'s type is exactly `PyDateTimeAPI.DeltaType`.
 pub unsafe fn PyDelta_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == (*PyDateTimeAPI()).DeltaType) as c_int
+    Py_IS_TYPE(op, (*PyDateTimeAPI()).DeltaType)
 }
 
 #[inline]
@@ -699,7 +699,7 @@ pub unsafe fn PyTZInfo_Check(op: *mut PyObject) -> c_int {
 #[inline]
 /// Check if `op`'s type is exactly `PyDateTimeAPI.TZInfoType`.
 pub unsafe fn PyTZInfo_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == (*PyDateTimeAPI()).TZInfoType) as c_int
+    Py_IS_TYPE(op, (*PyDateTimeAPI()).TZInfoType)
 }
 
 pub unsafe fn PyDate_FromDate(year: c_int, month: c_int, day: c_int) -> *mut PyObject {

--- a/pyo3-ffi/src/dictobject.rs
+++ b/pyo3-ffi/src/dictobject.rs
@@ -14,7 +14,7 @@ pub unsafe fn PyDict_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyDict_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyDict_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyDict_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/floatobject.rs
+++ b/pyo3-ffi/src/floatobject.rs
@@ -17,7 +17,7 @@ pub unsafe fn PyFloat_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyFloat_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyFloat_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyFloat_Type)
 }
 
 // skipped Py_RETURN_NAN

--- a/pyo3-ffi/src/iterobject.rs
+++ b/pyo3-ffi/src/iterobject.rs
@@ -8,7 +8,7 @@ extern_libpython! {
 
 #[inline]
 pub unsafe fn PySeqIter_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PySeqIter_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PySeqIter_Type)
 }
 
 extern_libpython! {
@@ -18,7 +18,7 @@ extern_libpython! {
 
 #[inline]
 pub unsafe fn PyCallIter_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyCallIter_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyCallIter_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/listobject.rs
+++ b/pyo3-ffi/src/listobject.rs
@@ -16,7 +16,7 @@ pub unsafe fn PyList_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyList_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyList_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyList_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/longobject.rs
+++ b/pyo3-ffi/src/longobject.rs
@@ -12,7 +12,7 @@ pub unsafe fn PyLong_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyLong_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyLong_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyLong_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/memoryobject.rs
+++ b/pyo3-ffi/src/memoryobject.rs
@@ -11,7 +11,7 @@ extern_libpython! {
 
 #[inline]
 pub unsafe fn PyMemoryView_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyMemoryView_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyMemoryView_Type)
 }
 
 // skipped non-limited PyMemoryView_GET_BUFFER

--- a/pyo3-ffi/src/methodobject.rs
+++ b/pyo3-ffi/src/methodobject.rs
@@ -1,6 +1,7 @@
-use crate::object::{PyObject, PyTypeObject, Py_TYPE};
+use crate::object::{PyObject, PyTypeObject};
 #[cfg(Py_3_9)]
 use crate::PyObject_TypeCheck;
+use crate::Py_IS_TYPE;
 use std::ffi::{c_char, c_int, c_void};
 use std::{mem, ptr};
 
@@ -23,7 +24,7 @@ extern_libpython! {
 #[cfg(Py_3_9)]
 #[inline]
 pub unsafe fn PyCFunction_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyCFunction_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyCFunction_Type)
 }
 
 #[cfg(Py_3_9)]
@@ -35,7 +36,7 @@ pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
 #[cfg(not(Py_3_9))]
 #[inline]
 pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyCFunction_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyCFunction_Type)
 }
 
 pub type PyCFunction =

--- a/pyo3-ffi/src/moduleobject.rs
+++ b/pyo3-ffi/src/moduleobject.rs
@@ -15,7 +15,7 @@ pub unsafe fn PyModule_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyModule_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyModule_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyModule_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -230,7 +230,13 @@ pub unsafe fn Py_SIZE(ob: *mut PyObject) -> Py_ssize_t {
     _Py_SIZE(ob)
 }
 
+#[cfg(all(Py_LIMITED_API, Py_3_15))]
+extern_libpython! {
+    pub fn Py_IS_TYPE(ob: *mut PyObject, tp: *mut PyTypeObject) -> c_int;
+}
+
 #[inline]
+#[cfg(not(all(Py_LIMITED_API, Py_3_15)))]
 pub unsafe fn Py_IS_TYPE(ob: *mut PyObject, tp: *mut PyTypeObject) -> c_int {
     (Py_TYPE(ob) == tp) as c_int
 }

--- a/pyo3-ffi/src/rangeobject.rs
+++ b/pyo3-ffi/src/rangeobject.rs
@@ -10,5 +10,5 @@ extern_libpython! {
 
 #[inline]
 pub unsafe fn PyRange_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyRange_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyRange_Type)
 }

--- a/pyo3-ffi/src/sliceobject.rs
+++ b/pyo3-ffi/src/sliceobject.rs
@@ -43,7 +43,7 @@ extern_libpython! {
 
 #[inline]
 pub unsafe fn PySlice_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PySlice_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PySlice_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/traceback.rs
+++ b/pyo3-ffi/src/traceback.rs
@@ -20,5 +20,5 @@ extern_libpython! {
 #[inline]
 #[cfg(not(PyPy))]
 pub unsafe fn PyTraceBack_Check(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyTraceBack_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyTraceBack_Type)
 }

--- a/pyo3-ffi/src/tupleobject.rs
+++ b/pyo3-ffi/src/tupleobject.rs
@@ -15,7 +15,7 @@ pub unsafe fn PyTuple_Check(op: *mut PyObject) -> c_int {
 
 #[inline]
 pub unsafe fn PyTuple_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyTuple_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyTuple_Type)
 }
 
 extern_libpython! {

--- a/pyo3-ffi/src/unicodeobject.rs
+++ b/pyo3-ffi/src/unicodeobject.rs
@@ -37,7 +37,7 @@ pub unsafe fn PyUnicode_Check(op: *mut PyObject) -> c_int {
 #[inline]
 #[cfg(not(PyPy))]
 pub unsafe fn PyUnicode_CheckExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut PyUnicode_Type) as c_int
+    Py_IS_TYPE(op, &raw mut PyUnicode_Type)
 }
 
 pub const Py_UNICODE_REPLACEMENT_CHARACTER: Py_UCS4 = 0xFFFD;

--- a/pyo3-ffi/src/weakrefobject.rs
+++ b/pyo3-ffi/src/weakrefobject.rs
@@ -36,14 +36,14 @@ pub unsafe fn PyWeakref_CheckRef(op: *mut PyObject) -> c_int {
 #[inline]
 #[cfg(not(PyPy))]
 pub unsafe fn PyWeakref_CheckRefExact(op: *mut PyObject) -> c_int {
-    (Py_TYPE(op) == &raw mut _PyWeakref_RefType) as c_int
+    Py_IS_TYPE(op, &raw mut _PyWeakref_RefType)
 }
 
 #[inline]
 #[cfg(not(PyPy))]
 pub unsafe fn PyWeakref_CheckProxy(op: *mut PyObject) -> c_int {
-    ((Py_TYPE(op) == &raw mut _PyWeakref_ProxyType)
-        || (Py_TYPE(op) == &raw mut _PyWeakref_CallableProxyType)) as c_int
+    (Py_IS_TYPE(op, &raw mut _PyWeakref_ProxyType) > 0
+        || Py_IS_TYPE(op, &raw mut _PyWeakref_CallableProxyType) > 0) as c_int
 }
 
 #[inline]


### PR DESCRIPTION
Avoid raw pointer comparison on ABI3 when `Py_IS_TYPE` is available.

xref https://github.com/RustPython/RustPython/pull/7562