### PR TITLE
chore: pin rustc version with rust-toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.95.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.95.0"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.95.0"
-components = ["rustfmt", "clippy"]
+components = ["rust-src", "rustfmt", "clippy"]


### PR DESCRIPTION
We can pin the Rust toolchain version with a `rust-toolchain.toml` to avoid situations like #5981
