### PR TITLE
Add `PyTuple_FromArray`

### DIFF
--- a/newsfragments/5990.added.md
+++ b/newsfragments/5990.added.md
@@ -1,0 +1,1 @@
+Add `ffi::PyTuple_FromArray` on 3.15+ & `RustPython`

--- a/pyo3-ffi/src/tupleobject.rs
+++ b/pyo3-ffi/src/tupleobject.rs
@@ -35,6 +35,8 @@ extern_libpython! {
     ) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyTuple_Pack")]
     pub fn PyTuple_Pack(arg1: Py_ssize_t, ...) -> *mut PyObject;
+    #[cfg(any(all(Py_3_15, not(Py_LIMITED_API)), RustPython))]
+    pub fn PyTuple_FromArray(array: *const *mut PyObject, size: Py_ssize_t) -> *mut PyObject;
     #[cfg(not(Py_3_9))]
     pub fn PyTuple_ClearFreeList() -> c_int;
 }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -4,6 +4,8 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::inspect::{type_hint_subscript, PyStaticExpr};
 use crate::instance::Borrowed;
 use crate::internal_tricks::get_ssize_index;
+#[cfg(RustPython)]
+use crate::py_result_ext::PyResultExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;
 use crate::types::{sequence::PySequenceMethods, PyList, PySequence};
@@ -27,10 +29,12 @@ use libc::size_t;
 
 #[inline]
 #[track_caller]
+#[cfg_attr(RustPython, allow(unused_mut))]
 fn try_new_from_iter<'py>(
     py: Python<'py>,
     mut elements: impl ExactSizeIterator<Item = PyResult<Bound<'py, PyAny>>>,
 ) -> PyResult<Bound<'py, PyTuple>> {
+    #[cfg(not(RustPython))]
     unsafe {
         // PyTuple_New checks for overflow but has a bad error message, so we check ourselves
         let len: Py_ssize_t = elements
@@ -58,6 +62,15 @@ fn try_new_from_iter<'py>(
         assert_eq!(len, counter, "Attempted to create PyTuple but `elements` was smaller than reported by its `ExactSizeIterator` implementation.");
 
         Ok(tup)
+    }
+
+    #[cfg(RustPython)]
+    unsafe {
+        let elements = elements.collect::<PyResult<Vec<_>>>()?;
+        // SAFETY: list is layout compatible with *const *mut crate::PyObject
+        ffi::PyTuple_FromArray(elements.as_ptr().cast(), elements.len() as _)
+            .assume_owned_or_err(py)
+            .cast_into_unchecked()
     }
 }
 
@@ -935,6 +948,7 @@ fn array_into_tuple<'py, const N: usize>(
     py: Python<'py>,
     array: [Bound<'py, PyAny>; N],
 ) -> Bound<'py, PyTuple> {
+    #[cfg(not(RustPython))]
     unsafe {
         let ptr = ffi::PyTuple_New(N.try_into().expect("0 < N <= 12"));
         let tup = ptr.assume_owned(py).cast_into_unchecked();
@@ -945,6 +959,15 @@ fn array_into_tuple<'py, const N: usize>(
             ffi::PyTuple_SetItem(ptr, index as ffi::Py_ssize_t, obj.into_ptr());
         }
         tup
+    }
+
+    // SAFETY: array is layout compatible with *const *mut crate::PyObject
+    // and does not steal the bound reference.
+    #[cfg(RustPython)]
+    unsafe {
+        ffi::PyTuple_FromArray(array.as_ptr().cast(), N.try_into().expect("0 < N <= 12"))
+            .assume_owned(py)
+            .cast_into_unchecked()
     }
 }
 


### PR DESCRIPTION
Avoids creating tuples using mutation api's.

This will add a additional `Py_INCREF` + `Py_DECREF` on the tuple items, so this may be slower. 