### PR TITLE
Do not use static type references when compiling for  `RustPython`

### DIFF
--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1772,7 +1772,7 @@ fn default_lib_name_unix(
         },
 
         PythonImplementation::GraalPy => Ok("python-native".to_string()),
-        PythonImplementation::RustPython => Ok("rustpython-capi".to_string()),
+        PythonImplementation::RustPython => Ok("rustpython_capi".to_string()),
     }
 }
 

--- a/pyo3-ffi/src/boolobject.rs
+++ b/pyo3-ffi/src/boolobject.rs
@@ -4,11 +4,15 @@ use crate::object::*;
 use std::ffi::{c_int, c_long};
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyBool_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyBool_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyBool_Check(op: *mut PyObject) -> c_int;
+
     #[cfg(all(not(GraalPy), not(all(Py_3_13, Py_LIMITED_API))))]
     #[cfg_attr(PyPy, link_name = "_PyPy_FalseStruct")]
     static mut _Py_FalseStruct: PyLongObject;

--- a/pyo3-ffi/src/bytearrayobject.rs
+++ b/pyo3-ffi/src/bytearrayobject.rs
@@ -2,6 +2,7 @@ use crate::object::*;
 use crate::pyport::Py_ssize_t;
 use std::ffi::{c_char, c_int};
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyByteArray_Type")]
     pub static mut PyByteArray_Type: PyTypeObject;
@@ -10,16 +11,23 @@ extern_libpython! {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyByteArray_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut PyByteArray_Type)
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyByteArray_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyByteArray_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyByteArray_Check(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyByteArray_CheckExact(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPyByteArray_FromObject")]
     pub fn PyByteArray_FromObject(o: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyByteArray_Concat")]

--- a/pyo3-ffi/src/bytesobject.rs
+++ b/pyo3-ffi/src/bytesobject.rs
@@ -2,6 +2,7 @@ use crate::object::*;
 use crate::pyport::Py_ssize_t;
 use std::ffi::{c_char, c_int};
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyBytes_Type")]
     pub static mut PyBytes_Type: PyTypeObject;
@@ -14,11 +15,15 @@ pub unsafe fn PyBytes_Check(op: *mut PyObject) -> c_int {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyBytes_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyBytes_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyBytes_CheckExact(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPyBytes_FromStringAndSize")]
     pub fn PyBytes_FromStringAndSize(arg1: *const c_char, arg2: Py_ssize_t) -> *mut PyObject;
     pub fn PyBytes_FromString(arg1: *const c_char) -> *mut PyObject;

--- a/pyo3-ffi/src/bytesobject.rs
+++ b/pyo3-ffi/src/bytesobject.rs
@@ -10,6 +10,7 @@ extern_libpython! {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyBytes_Check(op: *mut PyObject) -> c_int {
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_BYTES_SUBCLASS)
 }
@@ -21,6 +22,8 @@ pub unsafe fn PyBytes_CheckExact(op: *mut PyObject) -> c_int {
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyBytes_Check(op: *mut PyObject) -> c_int;
     #[cfg(RustPython)]
     pub fn PyBytes_CheckExact(op: *mut PyObject) -> c_int;
 

--- a/pyo3-ffi/src/complexobject.rs
+++ b/pyo3-ffi/src/complexobject.rs
@@ -1,22 +1,30 @@
 use crate::object::*;
 use std::ffi::{c_double, c_int};
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyComplex_Type")]
     pub static mut PyComplex_Type: PyTypeObject;
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyComplex_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut PyComplex_Type)
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyComplex_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyComplex_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyComplex_Check(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyComplex_CheckExact(op: *mut PyObject) -> c_int;
+
     // skipped non-limited PyComplex_FromCComplex
     #[cfg_attr(PyPy, link_name = "PyPyComplex_FromDoubles")]
     pub fn PyComplex_FromDoubles(real: c_double, imag: c_double) -> *mut PyObject;

--- a/pyo3-ffi/src/context.rs
+++ b/pyo3-ffi/src/context.rs
@@ -1,7 +1,11 @@
-use crate::object::{PyObject, PyTypeObject};
+use crate::object::PyObject;
+#[cfg(not(RustPython))]
+use crate::object::PyTypeObject;
+#[cfg(not(RustPython))]
 use crate::Py_IS_TYPE;
 use std::ffi::{c_char, c_int};
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     pub static mut PyContext_Type: PyTypeObject;
     // skipped non-limited opaque PyContext
@@ -12,21 +16,31 @@ extern_libpython! {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyContext_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyContext_Type)
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyContextVar_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyContextVar_Type)
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyContextToken_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyContextToken_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyContext_CheckExact(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyContextVar_CheckExact(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyContextToken_CheckExact(op: *mut PyObject) -> c_int;
+
     pub fn PyContext_New() -> *mut PyObject;
     pub fn PyContext_Copy(ctx: *mut PyObject) -> *mut PyObject;
     pub fn PyContext_CopyCurrent() -> *mut PyObject;

--- a/pyo3-ffi/src/descrobject.rs
+++ b/pyo3-ffi/src/descrobject.rs
@@ -35,6 +35,7 @@ impl Default for PyGetSetDef {
     }
 }
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyClassMethodDescr_Type")]
     pub static mut PyClassMethodDescr_Type: PyTypeObject;

--- a/pyo3-ffi/src/dictobject.rs
+++ b/pyo3-ffi/src/dictobject.rs
@@ -2,6 +2,7 @@ use crate::object::*;
 use crate::pyport::Py_ssize_t;
 use std::ffi::{c_char, c_int};
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyDict_Type")]
     pub static mut PyDict_Type: PyTypeObject;
@@ -13,11 +14,15 @@ pub unsafe fn PyDict_Check(op: *mut PyObject) -> c_int {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyDict_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyDict_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyDict_CheckExact(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPyDict_New")]
     pub fn PyDict_New() -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyDict_GetItem")]
@@ -88,6 +93,7 @@ extern_libpython! {
     // skipped 3.10 / ex-non-limited PyObject_GenericGetDict
 }
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     pub static mut PyDictKeys_Type: PyTypeObject;
     pub static mut PyDictValues_Type: PyTypeObject;
@@ -95,18 +101,30 @@ extern_libpython! {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyDictKeys_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut PyDictKeys_Type)
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyDictValues_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut PyDictValues_Type)
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyDictItems_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut PyDictItems_Type)
+}
+
+extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyDictKeys_Check(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyDictValues_Check(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyDictItems_Check(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
@@ -114,6 +132,7 @@ pub unsafe fn PyDictViewSet_Check(op: *mut PyObject) -> c_int {
     (PyDictKeys_Check(op) != 0 || PyDictItems_Check(op) != 0) as c_int
 }
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     pub static mut PyDictIterKey_Type: PyTypeObject;
     pub static mut PyDictIterValue_Type: PyTypeObject;

--- a/pyo3-ffi/src/dictobject.rs
+++ b/pyo3-ffi/src/dictobject.rs
@@ -9,6 +9,7 @@ extern_libpython! {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyDict_Check(op: *mut PyObject) -> c_int {
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_DICT_SUBCLASS)
 }
@@ -20,6 +21,8 @@ pub unsafe fn PyDict_CheckExact(op: *mut PyObject) -> c_int {
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyDict_Check(op: *mut PyObject) -> c_int;
     #[cfg(RustPython)]
     pub fn PyDict_CheckExact(op: *mut PyObject) -> c_int;
 

--- a/pyo3-ffi/src/floatobject.rs
+++ b/pyo3-ffi/src/floatobject.rs
@@ -5,19 +5,29 @@ use std::ffi::{c_double, c_int};
 // TODO: remove (see https://github.com/PyO3/pyo3/pull/1341#issuecomment-751515985)
 opaque_struct!(pub PyFloatObject);
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyFloat_Type")]
     pub static mut PyFloat_Type: PyTypeObject;
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyFloat_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut PyFloat_Type)
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyFloat_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyFloat_Type)
+}
+
+extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyFloat_Check(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyFloat_CheckExact(op: *mut PyObject) -> c_int;
 }
 
 // skipped Py_RETURN_NAN

--- a/pyo3-ffi/src/floatobject.rs
+++ b/pyo3-ffi/src/floatobject.rs
@@ -5,10 +5,15 @@ use std::ffi::{c_double, c_int};
 // TODO: remove (see https://github.com/PyO3/pyo3/pull/1341#issuecomment-751515985)
 opaque_struct!(pub PyFloatObject);
 
-#[cfg(not(RustPython))]
 extern_libpython! {
+    #[cfg(not(RustPython))]
     #[cfg_attr(PyPy, link_name = "PyPyFloat_Type")]
     pub static mut PyFloat_Type: PyTypeObject;
+
+    #[cfg(RustPython)]
+    pub fn PyFloat_Check(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyFloat_CheckExact(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
@@ -21,13 +26,6 @@ pub unsafe fn PyFloat_Check(op: *mut PyObject) -> c_int {
 #[cfg(not(RustPython))]
 pub unsafe fn PyFloat_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyFloat_Type)
-}
-
-extern_libpython! {
-    #[cfg(RustPython)]
-    pub fn PyFloat_Check(op: *mut PyObject) -> c_int;
-    #[cfg(RustPython)]
-    pub fn PyFloat_CheckExact(op: *mut PyObject) -> c_int;
 }
 
 // skipped Py_RETURN_NAN

--- a/pyo3-ffi/src/genericaliasobject.rs
+++ b/pyo3-ffi/src/genericaliasobject.rs
@@ -1,11 +1,13 @@
 #[cfg(Py_3_9)]
-use crate::object::{PyObject, PyTypeObject};
+use crate::PyObject;
+#[cfg(all(Py_3_9, not(RustPython)))]
+use crate::PyTypeObject;
 
 extern_libpython! {
     #[cfg(Py_3_9)]
     #[cfg_attr(PyPy, link_name = "PyPy_GenericAlias")]
     pub fn Py_GenericAlias(origin: *mut PyObject, args: *mut PyObject) -> *mut PyObject;
 
-    #[cfg(Py_3_9)]
+    #[cfg(all(Py_3_9, not(RustPython)))]
     pub static mut Py_GenericAliasType: PyTypeObject;
 }

--- a/pyo3-ffi/src/iterobject.rs
+++ b/pyo3-ffi/src/iterobject.rs
@@ -1,27 +1,36 @@
 use crate::object::*;
 use std::ffi::c_int;
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     pub static mut PySeqIter_Type: PyTypeObject;
     pub static mut PyCallIter_Type: PyTypeObject;
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PySeqIter_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PySeqIter_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PySeqIter_Check(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPySeqIter_New")]
     pub fn PySeqIter_New(arg1: *mut PyObject) -> *mut PyObject;
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyCallIter_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyCallIter_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyCallIter_Check(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPyCallIter_New")]
     pub fn PyCallIter_New(arg1: *mut PyObject, arg2: *mut PyObject) -> *mut PyObject;
 }

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -429,6 +429,7 @@ pub mod compat;
 mod impl_;
 
 pub use self::abstract_::*;
+#[cfg(not(RustPython))]
 pub use self::bltinmodule::*;
 pub use self::boolobject::*;
 pub use self::bytearrayobject::*;
@@ -443,6 +444,7 @@ pub use self::context::*;
 pub use self::datetime::*;
 pub use self::descrobject::*;
 pub use self::dictobject::*;
+#[cfg(not(RustPython))]
 pub use self::enumobject::*;
 pub use self::fileobject::*;
 pub use self::fileutils::*;
@@ -492,6 +494,7 @@ pub use self::weakrefobject::*;
 mod abstract_;
 // skipped asdl.h
 // skipped ast.h
+#[cfg(not(RustPython))]
 mod bltinmodule;
 mod boolobject;
 mod bytearrayobject;
@@ -509,6 +512,7 @@ pub(crate) mod datetime;
 mod descrobject;
 mod dictobject;
 // skipped dynamic_annotations.h
+#[cfg(not(RustPython))]
 mod enumobject;
 // skipped errcode.h
 // skipped exports.h

--- a/pyo3-ffi/src/listobject.rs
+++ b/pyo3-ffi/src/listobject.rs
@@ -2,6 +2,7 @@ use crate::object::*;
 use crate::pyport::Py_ssize_t;
 use std::ffi::c_int;
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyList_Type")]
     pub static mut PyList_Type: PyTypeObject;
@@ -15,11 +16,15 @@ pub unsafe fn PyList_Check(op: *mut PyObject) -> c_int {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyList_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyList_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyList_CheckExact(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPyList_New")]
     pub fn PyList_New(size: Py_ssize_t) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyList_Size")]

--- a/pyo3-ffi/src/listobject.rs
+++ b/pyo3-ffi/src/listobject.rs
@@ -10,6 +10,7 @@ extern_libpython! {
     pub static mut PyListRevIter_Type: PyTypeObject;
 }
 
+#[cfg(not(RustPython))]
 #[inline]
 pub unsafe fn PyList_Check(op: *mut PyObject) -> c_int {
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_LIST_SUBCLASS)
@@ -22,6 +23,8 @@ pub unsafe fn PyList_CheckExact(op: *mut PyObject) -> c_int {
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyList_Check(op: *mut PyObject) -> c_int;
     #[cfg(RustPython)]
     pub fn PyList_CheckExact(op: *mut PyObject) -> c_int;
 

--- a/pyo3-ffi/src/longobject.rs
+++ b/pyo3-ffi/src/longobject.rs
@@ -11,11 +11,15 @@ pub unsafe fn PyLong_Check(op: *mut PyObject) -> c_int {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyLong_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyLong_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyLong_CheckExact(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPyLong_FromLong")]
     pub fn PyLong_FromLong(arg1: c_long) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyLong_FromUnsignedLong")]

--- a/pyo3-ffi/src/longobject.rs
+++ b/pyo3-ffi/src/longobject.rs
@@ -6,6 +6,7 @@ use std::ffi::{c_char, c_double, c_int, c_long, c_longlong, c_ulong, c_ulonglong
 opaque_struct!(pub PyLongObject);
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyLong_Check(op: *mut PyObject) -> c_int {
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_LONG_SUBCLASS)
 }
@@ -17,6 +18,8 @@ pub unsafe fn PyLong_CheckExact(op: *mut PyObject) -> c_int {
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyLong_Check(op: *mut PyObject) -> c_int;
     #[cfg(RustPython)]
     pub fn PyLong_CheckExact(op: *mut PyObject) -> c_int;
 

--- a/pyo3-ffi/src/memoryobject.rs
+++ b/pyo3-ffi/src/memoryobject.rs
@@ -4,14 +4,21 @@ use std::ffi::{c_char, c_int};
 
 // skipped _PyManagedBuffer_Type
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyMemoryView_Type")]
     pub static mut PyMemoryView_Type: PyTypeObject;
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyMemoryView_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyMemoryView_Type)
+}
+
+extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyMemoryView_Check(op: *mut PyObject) -> c_int;
 }
 
 // skipped non-limited PyMemoryView_GET_BUFFER

--- a/pyo3-ffi/src/memoryobject.rs
+++ b/pyo3-ffi/src/memoryobject.rs
@@ -4,21 +4,19 @@ use std::ffi::{c_char, c_int};
 
 // skipped _PyManagedBuffer_Type
 
-#[cfg(not(RustPython))]
 extern_libpython! {
+    #[cfg(not(RustPython))]
     #[cfg_attr(PyPy, link_name = "PyPyMemoryView_Type")]
     pub static mut PyMemoryView_Type: PyTypeObject;
+
+    #[cfg(RustPython)]
+    pub fn PyMemoryView_Check(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
 #[cfg(not(RustPython))]
 pub unsafe fn PyMemoryView_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyMemoryView_Type)
-}
-
-extern_libpython! {
-    #[cfg(RustPython)]
-    pub fn PyMemoryView_Check(op: *mut PyObject) -> c_int;
 }
 
 // skipped non-limited PyMemoryView_GET_BUFFER

--- a/pyo3-ffi/src/methodobject.rs
+++ b/pyo3-ffi/src/methodobject.rs
@@ -1,6 +1,8 @@
 use crate::object::{PyObject, PyTypeObject};
 #[cfg(Py_3_9)]
+#[cfg(not(RustPython))]
 use crate::PyObject_TypeCheck;
+#[cfg(not(RustPython))]
 use crate::Py_IS_TYPE;
 use std::ffi::{c_char, c_int, c_void};
 use std::{mem, ptr};
@@ -16,6 +18,7 @@ pub struct PyCFunctionObject {
     pub vectorcall: Option<crate::vectorcallfunc>,
 }
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyCFunction_Type")]
     pub static mut PyCFunction_Type: PyTypeObject;
@@ -23,20 +26,30 @@ extern_libpython! {
 
 #[cfg(Py_3_9)]
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyCFunction_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyCFunction_Type)
 }
 
 #[cfg(Py_3_9)]
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut PyCFunction_Type)
 }
 
 #[cfg(not(Py_3_9))]
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyCFunction_Type)
+}
+
+extern_libpython! {
+    #[cfg(all(RustPython, Py_3_9))]
+    pub fn PyCFunction_CheckExact(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyCFunction_Check(op: *mut PyObject) -> c_int;
 }
 
 pub type PyCFunction =

--- a/pyo3-ffi/src/methodobject.rs
+++ b/pyo3-ffi/src/methodobject.rs
@@ -23,7 +23,7 @@ extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyCFunction_Type")]
     pub static mut PyCFunction_Type: PyTypeObject;
 
-    #[cfg(all(RustPython, Py_3_9))]
+    #[cfg(RustPython)]
     pub fn PyCFunction_CheckExact(op: *mut PyObject) -> c_int;
     #[cfg(RustPython)]
     pub fn PyCFunction_Check(op: *mut PyObject) -> c_int;
@@ -41,7 +41,7 @@ pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut PyCFunction_Type)
 }
 
-#[cfg(all(Py_3_9, not(RustPython)))]
+#[cfg(not(any(Py_3_9, RustPython)))]
 #[inline]
 pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyCFunction_Type)

--- a/pyo3-ffi/src/methodobject.rs
+++ b/pyo3-ffi/src/methodobject.rs
@@ -18,38 +18,33 @@ pub struct PyCFunctionObject {
     pub vectorcall: Option<crate::vectorcallfunc>,
 }
 
-#[cfg(not(RustPython))]
 extern_libpython! {
+    #[cfg(not(RustPython))]
     #[cfg_attr(PyPy, link_name = "PyPyCFunction_Type")]
     pub static mut PyCFunction_Type: PyTypeObject;
-}
 
-#[cfg(Py_3_9)]
-#[inline]
-#[cfg(not(RustPython))]
-pub unsafe fn PyCFunction_CheckExact(op: *mut PyObject) -> c_int {
-    Py_IS_TYPE(op, &raw mut PyCFunction_Type)
-}
-
-#[cfg(Py_3_9)]
-#[inline]
-#[cfg(not(RustPython))]
-pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
-    PyObject_TypeCheck(op, &raw mut PyCFunction_Type)
-}
-
-#[cfg(not(Py_3_9))]
-#[inline]
-#[cfg(not(RustPython))]
-pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
-    Py_IS_TYPE(op, &raw mut PyCFunction_Type)
-}
-
-extern_libpython! {
     #[cfg(all(RustPython, Py_3_9))]
     pub fn PyCFunction_CheckExact(op: *mut PyObject) -> c_int;
     #[cfg(RustPython)]
     pub fn PyCFunction_Check(op: *mut PyObject) -> c_int;
+}
+
+#[cfg(all(Py_3_9, not(RustPython)))]
+#[inline]
+pub unsafe fn PyCFunction_CheckExact(op: *mut PyObject) -> c_int {
+    Py_IS_TYPE(op, &raw mut PyCFunction_Type)
+}
+
+#[cfg(all(Py_3_9, not(RustPython)))]
+#[inline]
+pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
+    PyObject_TypeCheck(op, &raw mut PyCFunction_Type)
+}
+
+#[cfg(all(Py_3_9, not(RustPython)))]
+#[inline]
+pub unsafe fn PyCFunction_Check(op: *mut PyObject) -> c_int {
+    Py_IS_TYPE(op, &raw mut PyCFunction_Type)
 }
 
 pub type PyCFunction =

--- a/pyo3-ffi/src/moduleobject.rs
+++ b/pyo3-ffi/src/moduleobject.rs
@@ -3,22 +3,30 @@ use crate::object::*;
 use crate::pyport::Py_ssize_t;
 use std::ffi::{c_char, c_int, c_void};
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyModule_Type")]
     pub static mut PyModule_Type: PyTypeObject;
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyModule_Check(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut PyModule_Type)
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyModule_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyModule_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyModule_Check(op: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyModule_CheckExact(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPyModule_NewObject")]
     pub fn PyModule_NewObject(name: *mut PyObject) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyModule_New")]
@@ -45,6 +53,7 @@ extern_libpython! {
     pub fn PyModuleDef_Init(arg1: *mut PyModuleDef) -> *mut PyObject;
 }
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     pub static mut PyModuleDef_Type: PyTypeObject;
 }
@@ -132,19 +141,20 @@ pub const Py_MOD_GIL_USED: *mut c_void = 0 as *mut c_void;
 #[cfg(Py_3_13)]
 pub const Py_MOD_GIL_NOT_USED: *mut c_void = 1 as *mut c_void;
 
-#[cfg(all(not(Py_LIMITED_API), Py_GIL_DISABLED))]
 extern_libpython! {
+    #[cfg(all(not(Py_LIMITED_API), Py_GIL_DISABLED))]
     pub fn PyUnstable_Module_SetGIL(module: *mut PyObject, gil: *mut c_void) -> c_int;
-}
 
-#[cfg(Py_3_15)]
-extern_libpython! {
+    #[cfg(Py_3_15)]
     pub fn PyModule_FromSlotsAndSpec(
         slots: *const PyModuleDef_Slot,
         spec: *mut PyObject,
     ) -> *mut PyObject;
+    #[cfg(Py_3_15)]
     pub fn PyModule_Exec(_mod: *mut PyObject) -> c_int;
+    #[cfg(Py_3_15)]
     pub fn PyModule_GetStateSize(_mod: *mut PyObject, result: *mut Py_ssize_t) -> c_int;
+    #[cfg(Py_3_15)]
     pub fn PyModule_GetToken(module: *mut PyObject, result: *mut *mut c_void) -> c_int;
 }
 

--- a/pyo3-ffi/src/moduleobject.rs
+++ b/pyo3-ffi/src/moduleobject.rs
@@ -51,10 +51,8 @@ extern_libpython! {
     pub fn PyModule_GetState(arg1: *mut PyObject) -> *mut c_void;
     #[cfg_attr(PyPy, link_name = "PyPyModuleDef_Init")]
     pub fn PyModuleDef_Init(arg1: *mut PyModuleDef) -> *mut PyObject;
-}
 
-#[cfg(not(RustPython))]
-extern_libpython! {
+    #[cfg(not(RustPython))]
     pub static mut PyModuleDef_Type: PyTypeObject;
 }
 

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -166,13 +166,13 @@ pub struct PyVarObject {
 // skipped private _PyVarObject_CAST
 
 #[inline]
-#[cfg(not(any(GraalPy, PyPy)))]
+#[cfg(not(any(GraalPy, PyPy, RustPython)))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 pub unsafe fn Py_Is(x: *mut PyObject, y: *mut PyObject) -> c_int {
     (x == y).into()
 }
 
-#[cfg(any(GraalPy, PyPy))]
+#[cfg(any(GraalPy, PyPy, RustPython))]
 #[cfg_attr(docsrs, doc(cfg(all())))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPy_Is")]
@@ -211,6 +211,7 @@ extern_libpython! {
 
 // skip _Py_TYPE compat shim
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyLong_Type")]
     pub static mut PyLong_Type: PyTypeObject;
@@ -219,6 +220,7 @@ extern_libpython! {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn Py_SIZE(ob: *mut PyObject) -> Py_ssize_t {
     #[cfg(not(GraalPy))]
     {
@@ -230,13 +232,15 @@ pub unsafe fn Py_SIZE(ob: *mut PyObject) -> Py_ssize_t {
     _Py_SIZE(ob)
 }
 
-#[cfg(all(Py_LIMITED_API, Py_3_15))]
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn Py_SIZE(ob: *mut PyObject) -> Py_ssize_t;
+    #[cfg(any(all(Py_LIMITED_API, Py_3_15), RustPython))]
     pub fn Py_IS_TYPE(ob: *mut PyObject, tp: *mut PyTypeObject) -> c_int;
 }
 
 #[inline]
-#[cfg(not(all(Py_LIMITED_API, Py_3_15)))]
+#[cfg(not(any(all(Py_LIMITED_API, Py_3_15), RustPython)))]
 pub unsafe fn Py_IS_TYPE(ob: *mut PyObject, tp: *mut PyTypeObject) -> c_int {
     (Py_TYPE(ob) == tp) as c_int
 }
@@ -388,16 +392,17 @@ pub unsafe fn PyObject_TypeCheck(ob: *mut PyObject, tp: *mut PyTypeObject) -> c_
 
 extern_libpython! {
     /// built-in 'type'
+    #[cfg(not(RustPython))]
     #[cfg_attr(PyPy, link_name = "PyPyType_Type")]
     pub static mut PyType_Type: PyTypeObject;
     /// built-in 'object'
+    #[cfg(not(RustPython))]
     #[cfg_attr(PyPy, link_name = "PyPyBaseObject_Type")]
     pub static mut PyBaseObject_Type: PyTypeObject;
     /// built-in 'super'
+    #[cfg(not(RustPython))]
     pub static mut PySuper_Type: PyTypeObject;
-}
 
-extern_libpython! {
     pub fn PyType_GetFlags(arg1: *mut PyTypeObject) -> c_ulong;
 
     #[cfg_attr(PyPy, link_name = "PyPyType_Ready")]
@@ -615,9 +620,7 @@ extern_libpython! {
     #[cfg(Py_3_13)]
     #[cfg_attr(PyPy, link_name = "PyPy_GetConstantBorrowed")]
     pub fn Py_GetConstantBorrowed(constant_id: c_uint) -> *mut PyObject;
-}
 
-extern_libpython! {
     #[cfg(all(not(GraalPy), not(all(Py_3_13, Py_LIMITED_API))))]
     #[cfg_attr(PyPy, link_name = "_PyPy_NoneStruct")]
     static mut _Py_NoneStruct: PyObject;
@@ -714,11 +717,15 @@ pub unsafe fn PyType_Check(op: *mut PyObject) -> c_int {
 // skipped _PyType_CAST
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyType_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyType_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyType_CheckExact(op: *mut PyObject) -> c_int;
+
     #[cfg(any(Py_3_13, all(Py_3_11, not(Py_LIMITED_API))))]
     #[cfg_attr(PyPy, link_name = "PyPyType_GetModuleByDef")]
     pub fn PyType_GetModuleByDef(

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -705,11 +705,13 @@ pub unsafe fn PyType_HasFeature(ty: *mut PyTypeObject, feature: c_ulong) -> c_in
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyType_FastSubclass(t: *mut PyTypeObject, f: c_ulong) -> c_int {
     PyType_HasFeature(t, f)
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyType_Check(op: *mut PyObject) -> c_int {
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_TYPE_SUBCLASS)
 }
@@ -723,6 +725,8 @@ pub unsafe fn PyType_CheckExact(op: *mut PyObject) -> c_int {
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyType_Check(op: *mut PyObject) -> c_int;
     #[cfg(RustPython)]
     pub fn PyType_CheckExact(op: *mut PyObject) -> c_int;
 

--- a/pyo3-ffi/src/pycapsule.rs
+++ b/pyo3-ffi/src/pycapsule.rs
@@ -1,6 +1,7 @@
 use crate::object::*;
 use std::ffi::{c_char, c_int, c_void};
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyCapsule_Type")]
     pub static mut PyCapsule_Type: PyTypeObject;
@@ -9,11 +10,15 @@ extern_libpython! {
 pub type PyCapsule_Destructor = unsafe extern "C" fn(o: *mut PyObject);
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyCapsule_CheckExact(ob: *mut PyObject) -> c_int {
     (Py_TYPE(ob) == &raw mut PyCapsule_Type) as c_int
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyCapsule_CheckExact(ob: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPyCapsule_New")]
     pub fn PyCapsule_New(
         pointer: *mut c_void,

--- a/pyo3-ffi/src/pyerrors.rs
+++ b/pyo3-ffi/src/pyerrors.rs
@@ -72,12 +72,18 @@ extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyException_SetContext")]
     pub fn PyException_SetContext(arg1: *mut PyObject, arg2: *mut PyObject);
 
+    #[cfg(RustPython)]
+    pub fn PyExceptionClass_Check(x: *mut PyObject) -> c_int;
+    #[cfg(RustPython)]
+    pub fn PyExceptionInstance_Check(x: *mut PyObject) -> c_int;
+
     #[cfg(PyPy)]
     #[link_name = "PyPyExceptionInstance_Class"]
     pub fn PyExceptionInstance_Class(x: *mut PyObject) -> *mut PyObject;
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyExceptionClass_Check(x: *mut PyObject) -> c_int {
     (PyType_Check(x) != 0
         && PyType_FastSubclass(x as *mut PyTypeObject, Py_TPFLAGS_BASE_EXC_SUBCLASS) != 0)
@@ -85,6 +91,7 @@ pub unsafe fn PyExceptionClass_Check(x: *mut PyObject) -> c_int {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyExceptionInstance_Check(x: *mut PyObject) -> c_int {
     PyType_FastSubclass(Py_TYPE(x), Py_TPFLAGS_BASE_EXC_SUBCLASS)
 }

--- a/pyo3-ffi/src/rangeobject.rs
+++ b/pyo3-ffi/src/rangeobject.rs
@@ -1,6 +1,7 @@
 use crate::object::*;
 use std::ffi::c_int;
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyRange_Type")]
     pub static mut PyRange_Type: PyTypeObject;
@@ -9,6 +10,12 @@ extern_libpython! {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyRange_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyRange_Type)
+}
+
+extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyRange_Check(op: *mut PyObject) -> c_int;
 }

--- a/pyo3-ffi/src/rangeobject.rs
+++ b/pyo3-ffi/src/rangeobject.rs
@@ -1,21 +1,21 @@
 use crate::object::*;
 use std::ffi::c_int;
 
-#[cfg(not(RustPython))]
 extern_libpython! {
+    #[cfg(not(RustPython))]
     #[cfg_attr(PyPy, link_name = "PyPyRange_Type")]
     pub static mut PyRange_Type: PyTypeObject;
+    #[cfg(not(RustPython))]
     pub static mut PyRangeIter_Type: PyTypeObject;
+    #[cfg(not(RustPython))]
     pub static mut PyLongRangeIter_Type: PyTypeObject;
+
+    #[cfg(RustPython)]
+    pub fn PyRange_Check(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
 #[cfg(not(RustPython))]
 pub unsafe fn PyRange_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyRange_Type)
-}
-
-extern_libpython! {
-    #[cfg(RustPython)]
-    pub fn PyRange_Check(op: *mut PyObject) -> c_int;
 }

--- a/pyo3-ffi/src/setobject.rs
+++ b/pyo3-ffi/src/setobject.rs
@@ -73,41 +73,16 @@ extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPySet_Size")]
     pub fn PySet_Size(anyset: *mut PyObject) -> Py_ssize_t;
 
-    #[cfg(PyPy)]
-    #[link_name = "PyPyFrozenSet_CheckExact"]
-    pub fn PyFrozenSet_CheckExact(ob: *mut PyObject) -> c_int;
-}
-
-#[inline]
-#[cfg(not(any(PyPy, GraalPy)))]
-#[cfg(not(RustPython))]
-pub unsafe fn PyFrozenSet_CheckExact(ob: *mut PyObject) -> c_int {
-    (Py_TYPE(ob) == &raw mut PyFrozenSet_Type) as c_int
-}
-
-extern_libpython! {
-    #[cfg(all(RustPython, not(any(PyPy, GraalPy))))]
+    #[cfg(any(PyPy, RustPython))]
+    #[cfg_attr(PyPy, link_name = "PyPyFrozenSet_CheckExact")]
     pub fn PyFrozenSet_CheckExact(ob: *mut PyObject) -> c_int;
 
-    #[cfg(PyPy)]
-    #[link_name = "PyPyFrozenSet_Check"]
-    pub fn PyFrozenSet_Check(ob: *mut PyObject) -> c_int;
-}
-
-#[inline]
-#[cfg(not(PyPy))]
-#[cfg(not(RustPython))]
-pub unsafe fn PyFrozenSet_Check(ob: *mut PyObject) -> c_int {
-    (Py_TYPE(ob) == &raw mut PyFrozenSet_Type
-        || PyType_IsSubtype(Py_TYPE(ob), &raw mut PyFrozenSet_Type) != 0) as c_int
-}
-
-extern_libpython! {
-    #[cfg(all(RustPython, not(PyPy)))]
+    #[cfg(any(PyPy, RustPython))]
+    #[cfg_attr(PyPy, link_name = "PyPyFrozenSet_Check")]
     pub fn PyFrozenSet_Check(ob: *mut PyObject) -> c_int;
 
-    #[cfg(all(RustPython, not(PyPy)))]
-    #[link_name = "PyPyAnySet_CheckExact"]
+    #[cfg(any(PyPy, RustPython))]
+    #[cfg_attr(PyPy, link_name = "PyPyAnySet_CheckExact")]
     pub fn PyAnySet_CheckExact(ob: *mut PyObject) -> c_int;
 
     #[cfg(RustPython)]
@@ -117,13 +92,25 @@ extern_libpython! {
     pub fn PySet_CheckExact(op: *mut PyObject) -> c_int;
 
     #[cfg(any(PyPy, RustPython))]
-    #[link_name = "PyPySet_Check"]
+    #[cfg_attr(PyPy, link_name = "PyPySet_Check")]
     pub fn PySet_Check(ob: *mut PyObject) -> c_int;
 }
 
 #[inline]
-#[cfg(not(PyPy))]
-#[cfg(not(RustPython))]
+#[cfg(not(any(PyPy, GraalPy, RustPython)))]
+pub unsafe fn PyFrozenSet_CheckExact(ob: *mut PyObject) -> c_int {
+    (Py_TYPE(ob) == &raw mut PyFrozenSet_Type) as c_int
+}
+
+#[inline]
+#[cfg(not(any(PyPy, RustPython)))]
+pub unsafe fn PyFrozenSet_Check(ob: *mut PyObject) -> c_int {
+    (Py_TYPE(ob) == &raw mut PyFrozenSet_Type
+        || PyType_IsSubtype(Py_TYPE(ob), &raw mut PyFrozenSet_Type) != 0) as c_int
+}
+
+#[inline]
+#[cfg(not(any(PyPy, RustPython)))]
 pub unsafe fn PyAnySet_CheckExact(ob: *mut PyObject) -> c_int {
     (Py_TYPE(ob) == &raw mut PySet_Type || Py_TYPE(ob) == &raw mut PyFrozenSet_Type) as c_int
 }

--- a/pyo3-ffi/src/setobject.rs
+++ b/pyo3-ffi/src/setobject.rs
@@ -106,9 +106,19 @@ extern_libpython! {
     #[cfg(all(RustPython, not(PyPy)))]
     pub fn PyFrozenSet_Check(ob: *mut PyObject) -> c_int;
 
-    #[cfg(PyPy)]
+    #[cfg(all(RustPython, not(PyPy)))]
     #[link_name = "PyPyAnySet_CheckExact"]
     pub fn PyAnySet_CheckExact(ob: *mut PyObject) -> c_int;
+
+    #[cfg(RustPython)]
+    pub fn PyAnySet_Check(ob: *mut PyObject) -> c_int;
+
+    #[cfg(RustPython)]
+    pub fn PySet_CheckExact(op: *mut PyObject) -> c_int;
+
+    #[cfg(any(PyPy, RustPython))]
+    #[link_name = "PyPySet_Check"]
+    pub fn PySet_Check(ob: *mut PyObject) -> c_int;
 }
 
 #[inline]
@@ -116,11 +126,6 @@ extern_libpython! {
 #[cfg(not(RustPython))]
 pub unsafe fn PyAnySet_CheckExact(ob: *mut PyObject) -> c_int {
     (Py_TYPE(ob) == &raw mut PySet_Type || Py_TYPE(ob) == &raw mut PyFrozenSet_Type) as c_int
-}
-
-extern_libpython! {
-    #[cfg(all(RustPython, not(PyPy)))]
-    pub fn PyAnySet_CheckExact(ob: *mut PyObject) -> c_int;
 }
 
 #[inline]
@@ -131,24 +136,10 @@ pub unsafe fn PyAnySet_Check(ob: *mut PyObject) -> c_int {
         || PyType_IsSubtype(Py_TYPE(ob), &raw mut PyFrozenSet_Type) != 0) as c_int
 }
 
-extern_libpython! {
-    #[cfg(RustPython)]
-    pub fn PyAnySet_Check(ob: *mut PyObject) -> c_int;
-}
-
 #[inline]
 #[cfg(all(Py_3_10, not(RustPython)))]
 pub unsafe fn PySet_CheckExact(op: *mut PyObject) -> c_int {
     crate::Py_IS_TYPE(op, &raw mut PySet_Type)
-}
-
-extern_libpython! {
-    #[cfg(RustPython)]
-    pub fn PySet_CheckExact(op: *mut PyObject) -> c_int;
-
-    #[cfg(any(PyPy, RustPython))]
-    #[link_name = "PyPySet_Check"]
-    pub fn PySet_Check(ob: *mut PyObject) -> c_int;
 }
 
 #[inline]

--- a/pyo3-ffi/src/setobject.rs
+++ b/pyo3-ffi/src/setobject.rs
@@ -45,6 +45,7 @@ extern_libpython! {
     // skipped non-limited _PySet_Update
 }
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPySet_Type")]
     pub static mut PySet_Type: PyTypeObject;
@@ -79,11 +80,15 @@ extern_libpython! {
 
 #[inline]
 #[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(RustPython))]
 pub unsafe fn PyFrozenSet_CheckExact(ob: *mut PyObject) -> c_int {
     (Py_TYPE(ob) == &raw mut PyFrozenSet_Type) as c_int
 }
 
 extern_libpython! {
+    #[cfg(all(RustPython, not(any(PyPy, GraalPy))))]
+    pub fn PyFrozenSet_CheckExact(ob: *mut PyObject) -> c_int;
+
     #[cfg(PyPy)]
     #[link_name = "PyPyFrozenSet_Check"]
     pub fn PyFrozenSet_Check(ob: *mut PyObject) -> c_int;
@@ -91,12 +96,16 @@ extern_libpython! {
 
 #[inline]
 #[cfg(not(PyPy))]
+#[cfg(not(RustPython))]
 pub unsafe fn PyFrozenSet_Check(ob: *mut PyObject) -> c_int {
     (Py_TYPE(ob) == &raw mut PyFrozenSet_Type
         || PyType_IsSubtype(Py_TYPE(ob), &raw mut PyFrozenSet_Type) != 0) as c_int
 }
 
 extern_libpython! {
+    #[cfg(all(RustPython, not(PyPy)))]
+    pub fn PyFrozenSet_Check(ob: *mut PyObject) -> c_int;
+
     #[cfg(PyPy)]
     #[link_name = "PyPyAnySet_CheckExact"]
     pub fn PyAnySet_CheckExact(ob: *mut PyObject) -> c_int;
@@ -104,31 +113,46 @@ extern_libpython! {
 
 #[inline]
 #[cfg(not(PyPy))]
+#[cfg(not(RustPython))]
 pub unsafe fn PyAnySet_CheckExact(ob: *mut PyObject) -> c_int {
     (Py_TYPE(ob) == &raw mut PySet_Type || Py_TYPE(ob) == &raw mut PyFrozenSet_Type) as c_int
 }
 
+extern_libpython! {
+    #[cfg(all(RustPython, not(PyPy)))]
+    pub fn PyAnySet_CheckExact(ob: *mut PyObject) -> c_int;
+}
+
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyAnySet_Check(ob: *mut PyObject) -> c_int {
     (PyAnySet_CheckExact(ob) != 0
         || PyType_IsSubtype(Py_TYPE(ob), &raw mut PySet_Type) != 0
         || PyType_IsSubtype(Py_TYPE(ob), &raw mut PyFrozenSet_Type) != 0) as c_int
 }
 
+extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyAnySet_Check(ob: *mut PyObject) -> c_int;
+}
+
 #[inline]
-#[cfg(Py_3_10)]
+#[cfg(all(Py_3_10, not(RustPython)))]
 pub unsafe fn PySet_CheckExact(op: *mut PyObject) -> c_int {
     crate::Py_IS_TYPE(op, &raw mut PySet_Type)
 }
 
 extern_libpython! {
-    #[cfg(PyPy)]
+    #[cfg(RustPython)]
+    pub fn PySet_CheckExact(op: *mut PyObject) -> c_int;
+
+    #[cfg(any(PyPy, RustPython))]
     #[link_name = "PyPySet_Check"]
     pub fn PySet_Check(ob: *mut PyObject) -> c_int;
 }
 
 #[inline]
-#[cfg(not(PyPy))]
+#[cfg(not(any(PyPy, RustPython)))]
 pub unsafe fn PySet_Check(ob: *mut PyObject) -> c_int {
     (Py_TYPE(ob) == &raw mut PySet_Type || PyType_IsSubtype(Py_TYPE(ob), &raw mut PySet_Type) != 0)
         as c_int

--- a/pyo3-ffi/src/sliceobject.rs
+++ b/pyo3-ffi/src/sliceobject.rs
@@ -35,6 +35,7 @@ pub struct PySliceObject {
     pub step: *mut PyObject,
 }
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPySlice_Type")]
     pub static mut PySlice_Type: PyTypeObject;
@@ -42,11 +43,15 @@ extern_libpython! {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PySlice_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PySlice_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PySlice_Check(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPySlice_New")]
     pub fn PySlice_New(
         start: *mut PyObject,

--- a/pyo3-ffi/src/traceback.rs
+++ b/pyo3-ffi/src/traceback.rs
@@ -6,19 +6,19 @@ extern_libpython! {
     pub fn PyTraceBack_Here(arg1: *mut crate::PyFrameObject) -> c_int;
     #[cfg_attr(PyPy, link_name = "PyPyTraceBack_Print")]
     pub fn PyTraceBack_Print(arg1: *mut PyObject, arg2: *mut PyObject) -> c_int;
-}
 
-extern_libpython! {
+    #[cfg(not(RustPython))]
     #[cfg_attr(PyPy, link_name = "PyPyTraceBack_Type")]
     pub static mut PyTraceBack_Type: PyTypeObject;
 
-    #[cfg(PyPy)]
+    #[cfg(any(PyPy, RustPython))]
     #[link_name = "PyPyTraceBack_Check"]
     pub fn PyTraceBack_Check(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
 #[cfg(not(PyPy))]
+#[cfg(not(RustPython))]
 pub unsafe fn PyTraceBack_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyTraceBack_Type)
 }

--- a/pyo3-ffi/src/traceback.rs
+++ b/pyo3-ffi/src/traceback.rs
@@ -12,13 +12,12 @@ extern_libpython! {
     pub static mut PyTraceBack_Type: PyTypeObject;
 
     #[cfg(any(PyPy, RustPython))]
-    #[link_name = "PyPyTraceBack_Check"]
+    #[cfg_attr(PyPy, link_name = "PyPyTraceBack_Check")]
     pub fn PyTraceBack_Check(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
-#[cfg(not(PyPy))]
-#[cfg(not(RustPython))]
+#[cfg(not(any(PyPy, RustPython)))]
 pub unsafe fn PyTraceBack_Check(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyTraceBack_Type)
 }

--- a/pyo3-ffi/src/tupleobject.rs
+++ b/pyo3-ffi/src/tupleobject.rs
@@ -2,6 +2,7 @@ use crate::object::*;
 use crate::pyport::Py_ssize_t;
 use std::ffi::c_int;
 
+#[cfg(not(RustPython))]
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyTuple_Type")]
     pub static mut PyTuple_Type: PyTypeObject;
@@ -14,11 +15,15 @@ pub unsafe fn PyTuple_Check(op: *mut PyObject) -> c_int {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyTuple_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyTuple_Type)
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyTuple_CheckExact(op: *mut PyObject) -> c_int;
+
     #[cfg_attr(PyPy, link_name = "PyPyTuple_New")]
     pub fn PyTuple_New(size: Py_ssize_t) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyTuple_Size")]

--- a/pyo3-ffi/src/tupleobject.rs
+++ b/pyo3-ffi/src/tupleobject.rs
@@ -10,6 +10,7 @@ extern_libpython! {
 }
 
 #[inline]
+#[cfg(not(RustPython))]
 pub unsafe fn PyTuple_Check(op: *mut PyObject) -> c_int {
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_TUPLE_SUBCLASS)
 }
@@ -21,6 +22,8 @@ pub unsafe fn PyTuple_CheckExact(op: *mut PyObject) -> c_int {
 }
 
 extern_libpython! {
+    #[cfg(RustPython)]
+    pub fn PyTuple_Check(op: *mut PyObject) -> c_int;
     #[cfg(RustPython)]
     pub fn PyTuple_CheckExact(op: *mut PyObject) -> c_int;
 

--- a/pyo3-ffi/src/unicodeobject.rs
+++ b/pyo3-ffi/src/unicodeobject.rs
@@ -22,11 +22,11 @@ extern_libpython! {
     pub static mut PyUnicodeIter_Type: PyTypeObject;
 
     #[cfg(any(PyPy, RustPython))]
-    #[link_name = "PyPyUnicode_Check"]
+    #[cfg_attr(PyPy, link_name = "PyPyUnicode_Check")]
     pub fn PyUnicode_Check(op: *mut PyObject) -> c_int;
 
     #[cfg(any(PyPy, RustPython))]
-    #[link_name = "PyPyUnicode_CheckExact"]
+    #[cfg_attr(PyPy, link_name = "PyPyUnicode_CheckExact")]
     pub fn PyUnicode_CheckExact(op: *mut PyObject) -> c_int;
 }
 

--- a/pyo3-ffi/src/unicodeobject.rs
+++ b/pyo3-ffi/src/unicodeobject.rs
@@ -15,27 +15,29 @@ pub type Py_UCS2 = u16;
 pub type Py_UCS1 = u8;
 
 extern_libpython! {
+    #[cfg(not(RustPython))]
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_Type")]
     pub static mut PyUnicode_Type: PyTypeObject;
+    #[cfg(not(RustPython))]
     pub static mut PyUnicodeIter_Type: PyTypeObject;
 
-    #[cfg(PyPy)]
+    #[cfg(any(PyPy, RustPython))]
     #[link_name = "PyPyUnicode_Check"]
     pub fn PyUnicode_Check(op: *mut PyObject) -> c_int;
 
-    #[cfg(PyPy)]
+    #[cfg(any(PyPy, RustPython))]
     #[link_name = "PyPyUnicode_CheckExact"]
     pub fn PyUnicode_CheckExact(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
-#[cfg(not(PyPy))]
+#[cfg(not(any(PyPy, RustPython)))]
 pub unsafe fn PyUnicode_Check(op: *mut PyObject) -> c_int {
     PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_UNICODE_SUBCLASS)
 }
 
 #[inline]
-#[cfg(not(PyPy))]
+#[cfg(not(any(PyPy, RustPython)))]
 pub unsafe fn PyUnicode_CheckExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut PyUnicode_Type)
 }

--- a/pyo3-ffi/src/weakrefobject.rs
+++ b/pyo3-ffi/src/weakrefobject.rs
@@ -10,37 +10,41 @@ pub use crate::_PyWeakReference as PyWeakReference;
 extern_libpython! {
     // TODO: PyO3 is depending on this symbol in `reference.rs`, we should change this and
     // remove the export as this is a private symbol.
+    #[cfg(not(RustPython))]
     pub static mut _PyWeakref_RefType: PyTypeObject;
+    #[cfg(not(RustPython))]
     static mut _PyWeakref_ProxyType: PyTypeObject;
+    #[cfg(not(RustPython))]
     static mut _PyWeakref_CallableProxyType: PyTypeObject;
 
-    #[cfg(PyPy)]
+    #[cfg(any(PyPy, RustPython))]
     #[link_name = "PyPyWeakref_CheckRef"]
     pub fn PyWeakref_CheckRef(op: *mut PyObject) -> c_int;
 
-    #[cfg(PyPy)]
+    #[cfg(any(PyPy, RustPython))]
     #[link_name = "PyPyWeakref_CheckRefExact"]
     pub fn PyWeakref_CheckRefExact(op: *mut PyObject) -> c_int;
 
-    #[cfg(PyPy)]
+    #[cfg(any(PyPy, RustPython))]
     #[link_name = "PyPyWeakref_CheckProxy"]
     pub fn PyWeakref_CheckProxy(op: *mut PyObject) -> c_int;
 }
 
 #[inline]
-#[cfg(not(PyPy))]
+#[cfg(not(any(PyPy, RustPython)))]
+#[cfg(not(RustPython))]
 pub unsafe fn PyWeakref_CheckRef(op: *mut PyObject) -> c_int {
     PyObject_TypeCheck(op, &raw mut _PyWeakref_RefType)
 }
 
 #[inline]
-#[cfg(not(PyPy))]
+#[cfg(not(any(PyPy, RustPython)))]
 pub unsafe fn PyWeakref_CheckRefExact(op: *mut PyObject) -> c_int {
     Py_IS_TYPE(op, &raw mut _PyWeakref_RefType)
 }
 
 #[inline]
-#[cfg(not(PyPy))]
+#[cfg(not(any(PyPy, RustPython)))]
 pub unsafe fn PyWeakref_CheckProxy(op: *mut PyObject) -> c_int {
     (Py_IS_TYPE(op, &raw mut _PyWeakref_ProxyType) > 0
         || Py_IS_TYPE(op, &raw mut _PyWeakref_CallableProxyType) > 0) as c_int

--- a/pyo3-ffi/src/weakrefobject.rs
+++ b/pyo3-ffi/src/weakrefobject.rs
@@ -18,15 +18,15 @@ extern_libpython! {
     static mut _PyWeakref_CallableProxyType: PyTypeObject;
 
     #[cfg(any(PyPy, RustPython))]
-    #[link_name = "PyPyWeakref_CheckRef"]
+    #[cfg_attr(PyPy, link_name = "PyPyWeakref_CheckRef")]
     pub fn PyWeakref_CheckRef(op: *mut PyObject) -> c_int;
 
     #[cfg(any(PyPy, RustPython))]
-    #[link_name = "PyPyWeakref_CheckRefExact"]
+    #[cfg_attr(PyPy, link_name = "PyPyWeakref_CheckRefExact")]
     pub fn PyWeakref_CheckRefExact(op: *mut PyObject) -> c_int;
 
     #[cfg(any(PyPy, RustPython))]
-    #[link_name = "PyPyWeakref_CheckProxy"]
+    #[cfg_attr(PyPy, link_name = "PyPyWeakref_CheckProxy")]
     pub fn PyWeakref_CheckProxy(op: *mut PyObject) -> c_int;
 }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -10,6 +10,8 @@ use crate::impl_::pyclass::{
     PyClassBaseType, PyClassDict, PyClassImpl, PyClassThreadChecker, PyClassWeakRef, PyObjectOffset,
 };
 use crate::internal::get_slot::{TP_DEALLOC, TP_FREE};
+#[cfg(RustPython)]
+use crate::sync::PyOnceLock;
 use crate::type_object::{PyLayout, PySizedLayout, PyTypeInfo};
 use crate::types::PyType;
 use crate::{ffi, PyClass, Python};
@@ -264,7 +266,18 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
         let actual_type = PyType::from_borrowed_type_ptr(py, ffi::Py_TYPE(slf));
 
         // For `#[pyclass]` types which inherit from PyAny, we can just call tp_free
+        #[cfg(not(RustPython))]
         if std::ptr::eq(type_ptr, &raw const ffi::PyBaseObject_Type) {
+            let tp_free = actual_type
+                .get_slot(TP_FREE)
+                .expect("PyBaseObject_Type should have tp_free");
+            return tp_free(slf.cast());
+        }
+        #[cfg(RustPython)]
+        if std::ptr::eq(type_ptr, {
+            static TYPE: PyOnceLock<crate::Py<PyType>> = PyOnceLock::new();
+            TYPE.import(py, "builtins", "object").unwrap().as_type_ptr()
+        }) {
             let tp_free = actual_type
                 .get_slot(TP_FREE)
                 .expect("PyBaseObject_Type should have tp_free");

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -12,6 +12,8 @@ use crate::type_object::{PyTypeCheck, PyTypeInfo};
 use crate::types::PySuper;
 use crate::types::{PyDict, PyIterator, PyList, PyString, PyType};
 use crate::{err, ffi, Borrowed, BoundObject, IntoPyObjectExt, Py};
+#[cfg(RustPython)]
+use crate::{sync::PyOnceLock, types::typeobject::PyTypeMethods};
 #[allow(deprecated)]
 use crate::{DowncastError, DowncastIntoError};
 use std::cell::UnsafeCell;
@@ -41,9 +43,23 @@ fn PyObject_Check(_: *mut ffi::PyObject) -> c_int {
 }
 
 // We follow stub writing guidelines and use "object" instead of "typing.Any": https://typing.python.org/en/latest/guides/writing_stubs.html#using-any
+#[cfg(not(RustPython))]
 pyobject_native_type_info!(
     PyAny,
     pyobject_native_static_type_object!(ffi::PyBaseObject_Type),
+    "typing",
+    "Any",
+    Some("builtins"),
+    #checkfunction=PyObject_Check
+);
+
+#[cfg(RustPython)]
+pyobject_native_type_info!(
+    PyAny,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "object").unwrap().as_type_ptr()
+    },
     "typing",
     "Any",
     Some("builtins"),

--- a/src/types/boolobject.rs
+++ b/src/types/boolobject.rs
@@ -9,6 +9,8 @@ use crate::{
     exceptions::PyTypeError, ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound,
     types::typeobject::PyTypeMethods, Borrowed, FromPyObject, PyAny, Python,
 };
+#[cfg(RustPython)]
+use crate::{sync::PyOnceLock, types::PyType, Py};
 use std::convert::Infallible;
 use std::ptr;
 
@@ -22,7 +24,21 @@ use std::ptr;
 #[repr(transparent)]
 pub struct PyBool(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type!(PyBool, ffi::PyObject, pyobject_native_static_type_object!(ffi::PyBool_Type), "builtins", "bool", #checkfunction=ffi::PyBool_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type!(
+    PyBool,
+    ffi::PyObject,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "bool").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "bool",
+    #checkfunction=ffi::PyBool_Check
+);
 
 impl PyBool {
     /// Depending on `val`, returns `true` or `false`.

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -4,6 +4,12 @@ use crate::instance::{Borrowed, Bound};
 use crate::py_result_ext::PyResultExt;
 use crate::sync::critical_section::with_critical_section;
 use crate::{ffi, PyAny, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use std::slice;
 
 /// Represents a Python `bytearray`.
@@ -16,7 +22,20 @@ use std::slice;
 #[repr(transparent)]
 pub struct PyByteArray(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyByteArray, pyobject_native_static_type_object!(ffi::PyByteArray_Type), "builtins", "bytearray", #checkfunction=ffi::PyByteArray_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyByteArray,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "bytearray").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "bytearray",
+    #checkfunction=ffi::PyByteArray_Check
+);
 
 impl PyByteArray {
     /// Creates a new Python bytearray object.

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -2,6 +2,11 @@ use crate::byteswriter::PyBytesWriter;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::{Borrowed, Bound};
 use crate::{ffi, Py, PyAny, PyResult, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+};
 use std::io::Write;
 use std::ops::Index;
 use std::slice::SliceIndex;
@@ -49,7 +54,20 @@ use std::str;
 #[repr(transparent)]
 pub struct PyBytes(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyBytes, pyobject_native_static_type_object!(ffi::PyBytes_Type), "builtins", "bytes", #checkfunction=ffi::PyBytes_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyBytes,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "bytes").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "bytes",
+    #checkfunction=ffi::PyBytes_Check
+);
 
 impl PyBytes {
     /// Creates a new Python bytestring object.

--- a/src/types/capsule.rs
+++ b/src/types/capsule.rs
@@ -4,6 +4,12 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::box_into_non_null;
 use crate::py_result_ext::PyResultExt;
 use crate::{ffi, PyAny};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use crate::{Bound, Python};
 use crate::{PyErr, PyResult};
 use std::ffi::{c_char, c_int, c_void};
@@ -75,7 +81,20 @@ use std::ptr::{self, NonNull};
 #[repr(transparent)]
 pub struct PyCapsule(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyCapsule, pyobject_native_static_type_object!(ffi::PyCapsule_Type), "types", "CapsuleType", #checkfunction=ffi::PyCapsule_CheckExact);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyCapsule,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "types", "CapsuleType").unwrap().as_type_ptr()
+    },
+    "types",
+    "CapsuleType",
+    #checkfunction=ffi::PyCapsule_CheckExact
+);
 
 impl PyCapsule {
     /// Constructs a new capsule whose contents are `value`, associated with `name`.

--- a/src/types/complex.rs
+++ b/src/types/complex.rs
@@ -3,6 +3,12 @@ use crate::py_result_ext::PyResultExt;
 #[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
 use crate::types::any::PyAnyMethods;
 use crate::{ffi, Bound, PyAny, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use std::ffi::c_double;
 
 /// Represents a Python [`complex`](https://docs.python.org/3/library/functions.html#complex) object.
@@ -23,10 +29,24 @@ pub struct PyComplex(PyAny);
 
 pyobject_subclassable_native_type!(PyComplex, ffi::PyComplexObject);
 
+#[cfg(not(RustPython))]
 pyobject_native_type!(
     PyComplex,
     ffi::PyComplexObject,
     pyobject_native_static_type_object!(ffi::PyComplex_Type),
+    "builtins",
+    "complex",
+    #checkfunction=ffi::PyComplex_Check
+);
+
+#[cfg(RustPython)]
+pyobject_native_type!(
+    PyComplex,
+    ffi::PyComplexObject,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "complex").unwrap().as_type_ptr()
+    },
     "builtins",
     "complex",
     #checkfunction=ffi::PyComplex_Check

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -5,6 +5,12 @@ use crate::instance::{Borrowed, Bound};
 use crate::py_result_ext::PyResultExt;
 use crate::types::{PyAny, PyList, PyMapping};
 use crate::{ffi, BoundObject, IntoPyObject, IntoPyObjectExt, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 
 /// Represents a Python `dict`.
 ///
@@ -19,6 +25,7 @@ pub struct PyDict(PyAny);
 #[cfg(not(GraalPy))]
 pyobject_subclassable_native_type!(PyDict, crate::ffi::PyDictObject);
 
+#[cfg(not(RustPython))]
 pyobject_native_type!(
     PyDict,
     ffi::PyDictObject,
@@ -28,12 +35,25 @@ pyobject_native_type!(
     #checkfunction=ffi::PyDict_Check
 );
 
+#[cfg(RustPython)]
+pyobject_native_type!(
+    PyDict,
+    ffi::PyDictObject,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "dict").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "dict",
+    #checkfunction=ffi::PyDict_Check
+);
+
 /// Represents a Python `dict_keys`.
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(any(PyPy, GraalPy, RustPython)))]
 #[repr(transparent)]
 pub struct PyDictKeys(PyAny);
 
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(any(PyPy, GraalPy, RustPython)))]
 pyobject_native_type_core!(
     PyDictKeys,
     pyobject_native_static_type_object!(ffi::PyDictKeys_Type),
@@ -43,11 +63,11 @@ pyobject_native_type_core!(
 );
 
 /// Represents a Python `dict_values`.
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(any(PyPy, GraalPy, RustPython)))]
 #[repr(transparent)]
 pub struct PyDictValues(PyAny);
 
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(any(PyPy, GraalPy, RustPython)))]
 pyobject_native_type_core!(
     PyDictValues,
     pyobject_native_static_type_object!(ffi::PyDictValues_Type),
@@ -57,11 +77,11 @@ pyobject_native_type_core!(
 );
 
 /// Represents a Python `dict_items`.
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(any(PyPy, GraalPy, RustPython)))]
 #[repr(transparent)]
 pub struct PyDictItems(PyAny);
 
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(any(PyPy, GraalPy, RustPython)))]
 pyobject_native_type_core!(
     PyDictItems,
     pyobject_native_static_type_object!(ffi::PyDictItems_Type),
@@ -1487,7 +1507,7 @@ mod tests {
         });
     }
 
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(any(PyPy, GraalPy, RustPython)))]
     fn abc_dict(py: Python<'_>) -> Bound<'_, PyDict> {
         let mut map = HashMap::<&'static str, i32>::new();
         map.insert("a", 1);
@@ -1497,7 +1517,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(any(PyPy, GraalPy, RustPython)))]
     fn dict_keys_view() {
         Python::attach(|py| {
             let dict = abc_dict(py);
@@ -1507,7 +1527,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(any(PyPy, GraalPy, RustPython)))]
     fn dict_values_view() {
         Python::attach(|py| {
             let dict = abc_dict(py);
@@ -1517,7 +1537,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(any(PyPy, GraalPy, RustPython)))]
     fn dict_items_view() {
         Python::attach(|py| {
             let dict = abc_dict(py);

--- a/src/types/float.rs
+++ b/src/types/float.rs
@@ -6,6 +6,12 @@ use crate::type_object::PyTypeInfo;
 use crate::{
     ffi, ffi_ptr_ext::FfiPtrExt, instance::Bound, Borrowed, FromPyObject, PyAny, PyErr, Python,
 };
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use std::convert::Infallible;
 use std::ffi::c_double;
 
@@ -25,10 +31,24 @@ pub struct PyFloat(PyAny);
 
 pyobject_subclassable_native_type!(PyFloat, crate::ffi::PyFloatObject);
 
+#[cfg(not(RustPython))]
 pyobject_native_type!(
     PyFloat,
     ffi::PyFloatObject,
     pyobject_native_static_type_object!(ffi::PyFloat_Type),
+    "builtins",
+    "float",
+    #checkfunction=ffi::PyFloat_Check
+);
+
+#[cfg(RustPython)]
+pyobject_native_type!(
+    PyFloat,
+    ffi::PyFloatObject,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "float").unwrap().as_type_ptr()
+    },
     "builtins",
     "float",
     #checkfunction=ffi::PyFloat_Check

--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -6,6 +6,12 @@ use crate::{
     py_result_ext::PyResultExt,
     Bound, PyAny, Python,
 };
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use crate::{Borrowed, BoundObject, IntoPyObject, IntoPyObjectExt};
 use std::ptr;
 
@@ -61,11 +67,24 @@ pub struct PyFrozenSet(PyAny);
 
 #[cfg(not(any(PyPy, GraalPy)))]
 pyobject_subclassable_native_type!(PyFrozenSet, crate::ffi::PySetObject);
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(all(not(any(PyPy, GraalPy)), not(RustPython)))]
 pyobject_native_type!(
     PyFrozenSet,
     ffi::PySetObject,
     pyobject_native_static_type_object!(ffi::PyFrozenSet_Type),
+    "builtins",
+    "frozenset",
+    #checkfunction=ffi::PyFrozenSet_Check
+);
+
+#[cfg(all(not(any(PyPy, GraalPy)), RustPython))]
+pyobject_native_type!(
+    PyFrozenSet,
+    ffi::PySetObject,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "frozenset").unwrap().as_type_ptr()
+    },
     "builtins",
     "frozenset",
     #checkfunction=ffi::PyFrozenSet_Check

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -7,6 +7,12 @@ use crate::{
     impl_::pymethods::{self, PyMethodDef},
     types::{PyCapsule, PyDict, PyModule, PyTuple},
 };
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use crate::{Bound, PyAny, PyResult, Python};
 use std::cell::UnsafeCell;
 use std::ffi::CStr;
@@ -19,7 +25,22 @@ use std::ptr::NonNull;
 #[repr(transparent)]
 pub struct PyCFunction(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyCFunction, pyobject_native_static_type_object!(ffi::PyCFunction_Type), "builtins", "builtin_function_or_method", #checkfunction=ffi::PyCFunction_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyCFunction,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "builtin_function_or_method")
+            .unwrap()
+            .as_type_ptr()
+    },
+    "builtins",
+    "builtin_function_or_method",
+    #checkfunction=ffi::PyCFunction_Check
+);
 
 impl PyCFunction {
     /// Create a new built-in function with keywords (*args and/or **kwargs).

--- a/src/types/genericalias.rs
+++ b/src/types/genericalias.rs
@@ -2,6 +2,12 @@ use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::{ffi, Bound, PyAny, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 
 /// Represents a Python [`types.GenericAlias`](https://docs.python.org/3/library/types.html#types.GenericAlias) object.
 ///
@@ -14,10 +20,25 @@ use crate::{ffi, Bound, PyAny, Python};
 #[repr(transparent)]
 pub struct PyGenericAlias(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type!(
     PyGenericAlias,
     ffi::PyDictObject,
     pyobject_native_static_type_object!(ffi::Py_GenericAliasType),
+    "builtins",
+    "GenericAlias"
+);
+
+#[cfg(RustPython)]
+pyobject_native_type!(
+    PyGenericAlias,
+    ffi::PyDictObject,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "types", "GenericAlias")
+            .unwrap()
+            .as_type_ptr()
+    },
     "builtins",
     "GenericAlias"
 );

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -4,6 +4,12 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::get_ssize_index;
 use crate::types::sequence::PySequenceMethods;
 use crate::types::{PySequence, PyTuple};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use crate::{Borrowed, Bound, BoundObject, IntoPyObject, IntoPyObjectExt, PyAny, PyErr, Python};
 use std::iter::FusedIterator;
 #[cfg(feature = "nightly")]
@@ -19,10 +25,23 @@ use std::num::NonZero;
 #[repr(transparent)]
 pub struct PyList(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(
     PyList,
     pyobject_native_static_type_object!(ffi::PyList_Type),
     "builtins", "list",
+    #checkfunction=ffi::PyList_Check
+);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyList,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "list").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "list",
     #checkfunction=ffi::PyList_Check
 );
 

--- a/src/types/mappingproxy.rs
+++ b/src/types/mappingproxy.rs
@@ -7,14 +7,34 @@ use crate::instance::Bound;
 use crate::types::any::PyAnyMethods;
 use crate::types::{PyAny, PyIterator, PyList};
 use crate::{ffi, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 
 /// Represents a Python `mappingproxy`.
 #[repr(transparent)]
 pub struct PyMappingProxy(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(
     PyMappingProxy,
     pyobject_native_static_type_object!(ffi::PyDictProxy_Type),
+    "types",
+    "MappingProxyType"
+);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyMappingProxy,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "types", "MappingProxyType")
+            .unwrap()
+            .as_type_ptr()
+    },
     "types",
     "MappingProxyType"
 );
@@ -414,7 +434,7 @@ mod tests {
         });
     }
 
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(any(PyPy, GraalPy, RustPython)))]
     fn abc_mappingproxy(py: Python<'_>) -> Bound<'_, PyMappingProxy> {
         let mut map = HashMap::<&'static str, i32>::new();
         map.insert("a", 1);
@@ -425,7 +445,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(any(PyPy, GraalPy, RustPython)))]
     fn mappingproxy_keys_view() {
         Python::attach(|py| {
             let mappingproxy = abc_mappingproxy(py);
@@ -435,7 +455,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(any(PyPy, GraalPy, RustPython)))]
     fn mappingproxy_values_view() {
         Python::attach(|py| {
             let mappingproxy = abc_mappingproxy(py);
@@ -445,7 +465,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(any(PyPy, GraalPy, RustPython)))]
     fn mappingproxy_items_view() {
         Python::attach(|py| {
             let mappingproxy = abc_mappingproxy(py);

--- a/src/types/memoryview.rs
+++ b/src/types/memoryview.rs
@@ -2,6 +2,12 @@ use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
 use crate::{ffi, Bound, PyAny};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 
 /// Represents a Python `memoryview`.
 ///
@@ -10,7 +16,20 @@ use crate::{ffi, Bound, PyAny};
 #[repr(transparent)]
 pub struct PyMemoryView(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyMemoryView, pyobject_native_static_type_object!(ffi::PyMemoryView_Type), "builtins", "memoryview", #checkfunction=ffi::PyMemoryView_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyMemoryView,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "memoryview").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "memoryview",
+    #checkfunction=ffi::PyMemoryView_Check
+);
 
 impl PyMemoryView {
     /// Creates a new Python `memoryview` object from another Python object that

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -11,7 +11,7 @@ pub use self::datetime::{PyDate, PyDateTime, PyDelta, PyTime, PyTzInfo, PyTzInfo
 #[cfg(not(Py_LIMITED_API))]
 pub use self::datetime::{PyDateAccess, PyDeltaAccess, PyTimeAccess};
 pub use self::dict::{IntoPyDict, PyDict, PyDictMethods};
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(not(any(PyPy, GraalPy, RustPython)))]
 pub use self::dict::{PyDictItems, PyDictKeys, PyDictValues};
 pub use self::ellipsis::PyEllipsis;
 pub use self::float::{PyFloat, PyFloatMethods};

--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -10,6 +10,11 @@ use crate::types::{
 use crate::{
     exceptions, ffi, Borrowed, Bound, BoundObject, IntoPyObject, IntoPyObjectExt, Py, Python,
 };
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+};
 use std::borrow::Cow;
 #[cfg(all(not(Py_LIMITED_API), Py_GIL_DISABLED))]
 use std::ffi::c_int;
@@ -32,7 +37,20 @@ use std::str;
 #[repr(transparent)]
 pub struct PyModule(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyModule, pyobject_native_static_type_object!(ffi::PyModule_Type), "types", "ModuleType", #checkfunction=ffi::PyModule_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyModule,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "types", "ModuleType").unwrap().as_type_ptr()
+    },
+    "types",
+    "ModuleType",
+    #checkfunction=ffi::PyModule_Check
+);
 
 impl PyModule {
     /// Creates a new module object with the `__name__` attribute set to `name`.  When creating

--- a/src/types/num.rs
+++ b/src/types/num.rs
@@ -1,5 +1,11 @@
 use super::any::PyAnyMethods;
 use crate::{ffi, instance::Bound, IntoPyObject, PyAny, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use std::convert::Infallible;
 
 /// Represents a Python `int` object.
@@ -13,7 +19,20 @@ use std::convert::Infallible;
 #[repr(transparent)]
 pub struct PyInt(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyInt, pyobject_native_static_type_object!(ffi::PyLong_Type), "builtins", "int", #checkfunction=ffi::PyLong_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyInt,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "int").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "int",
+    #checkfunction=ffi::PyLong_Check
+);
 
 impl PyInt {
     /// Creates a new Python int object.

--- a/src/types/pysuper.rs
+++ b/src/types/pysuper.rs
@@ -11,7 +11,7 @@ use crate::{PyAny, PyResult};
 #[repr(transparent)]
 pub struct PySuper(PyAny);
 
-#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy)))]
+#[cfg(not(any(Py_LIMITED_API, PyPy, GraalPy, RustPython)))]
 pyobject_native_type_core!(
     PySuper,
     pyobject_native_static_type_object!(crate::ffi::PySuper_Type),
@@ -19,7 +19,7 @@ pyobject_native_type_core!(
     "super"
 );
 
-#[cfg(any(Py_LIMITED_API, PyPy, GraalPy))]
+#[cfg(any(Py_LIMITED_API, PyPy, GraalPy, RustPython))]
 pyobject_native_type_core!(
     PySuper,
     |py| {

--- a/src/types/range.rs
+++ b/src/types/range.rs
@@ -1,6 +1,12 @@
 use crate::sealed::Sealed;
 use crate::types::PyAnyMethods;
 use crate::{ffi, Bound, PyAny, PyResult, PyTypeInfo, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 
 /// Represents a Python `range`.
 ///
@@ -12,7 +18,20 @@ use crate::{ffi, Bound, PyAny, PyResult, PyTypeInfo, Python};
 #[repr(transparent)]
 pub struct PyRange(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyRange, pyobject_native_static_type_object!(ffi::PyRange_Type), "builtins", "range", #checkfunction=ffi::PyRange_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyRange,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "range").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "range",
+    #checkfunction=ffi::PyRange_Check
+);
 
 impl<'py> PyRange {
     /// Creates a new Python `range` object with a default step of 1.

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -6,6 +6,12 @@ use crate::{
     py_result_ext::PyResultExt,
 };
 use crate::{ffi, Borrowed, BoundObject, IntoPyObject, IntoPyObjectExt, PyAny, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use std::ptr;
 
 /// Represents a Python `set`.
@@ -21,11 +27,24 @@ pub struct PySet(PyAny);
 #[cfg(not(any(PyPy, GraalPy)))]
 pyobject_subclassable_native_type!(PySet, crate::ffi::PySetObject);
 
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(all(not(any(PyPy, GraalPy)), not(RustPython)))]
 pyobject_native_type!(
     PySet,
     ffi::PySetObject,
     pyobject_native_static_type_object!(ffi::PySet_Type),
+    "builtins",
+    "set",
+    #checkfunction=ffi::PySet_Check
+);
+
+#[cfg(all(not(any(PyPy, GraalPy)), RustPython))]
+pyobject_native_type!(
+    PySet,
+    ffi::PySetObject,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "set").unwrap().as_type_ptr()
+    },
     "builtins",
     "set",
     #checkfunction=ffi::PySet_Check

--- a/src/types/slice.rs
+++ b/src/types/slice.rs
@@ -6,6 +6,12 @@ use crate::inspect::PyStaticExpr;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;
 use crate::types::{PyRange, PyRangeMethods};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 use crate::{Bound, IntoPyObject, PyAny, Python};
 use std::convert::Infallible;
 
@@ -21,10 +27,24 @@ use std::convert::Infallible;
 #[repr(transparent)]
 pub struct PySlice(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type!(
     PySlice,
     ffi::PySliceObject,
     pyobject_native_static_type_object!(ffi::PySlice_Type),
+    "builtins",
+    "slice",
+    #checkfunction=ffi::PySlice_Check
+);
+
+#[cfg(RustPython)]
+pyobject_native_type!(
+    PySlice,
+    ffi::PySliceObject,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "slice").unwrap().as_type_ptr()
+    },
     "builtins",
     "slice",
     #checkfunction=ffi::PySlice_Check

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -6,6 +6,11 @@ use crate::py_result_ext::PyResultExt;
 use crate::types::bytes::PyBytesMethods;
 use crate::types::PyBytes;
 use crate::{ffi, Bound, Py, PyAny, PyResult, Python};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+};
 use std::borrow::Cow;
 use std::ffi::CStr;
 use std::{fmt, str};
@@ -152,7 +157,20 @@ impl<'a> PyStringData<'a> {
 #[repr(transparent)]
 pub struct PyString(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyString, pyobject_native_static_type_object!(ffi::PyUnicode_Type), "builtins", "str", #checkfunction=ffi::PyUnicode_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyString,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "str").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "str",
+    #checkfunction=ffi::PyUnicode_Check
+);
 
 impl PyString {
     /// Creates a new Python string object.

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -1,6 +1,12 @@
 use crate::err::{error_on_minusone, PyResult};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, PyString};
 use crate::{ffi, Bound, PyAny};
+#[cfg(RustPython)]
+use crate::{
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
+};
 #[cfg(all(not(Py_LIMITED_API), not(PyPy), not(GraalPy)))]
 use crate::{types::PyFrame, PyTypeCheck, Python};
 
@@ -14,9 +20,22 @@ use crate::{types::PyFrame, PyTypeCheck, Python};
 #[repr(transparent)]
 pub struct PyTraceback(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(
     PyTraceback,
     pyobject_native_static_type_object!(ffi::PyTraceBack_Type),
+    "builtins",
+    "traceback",
+    #checkfunction=ffi::PyTraceBack_Check
+);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyTraceback,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "traceback").unwrap().as_type_ptr()
+    },
     "builtins",
     "traceback",
     #checkfunction=ffi::PyTraceBack_Check

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -34,7 +34,7 @@ pyobject_native_type_core!(
     PyTraceback,
     |py| {
         static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
-        TYPE.import(py, "builtins", "traceback").unwrap().as_type_ptr()
+        TYPE.import(py, "types", "TracebackType").unwrap().as_type_ptr()
     },
     "builtins",
     "traceback",

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -4,8 +4,6 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::inspect::{type_hint_subscript, PyStaticExpr};
 use crate::instance::Borrowed;
 use crate::internal_tricks::get_ssize_index;
-#[cfg(RustPython)]
-use crate::py_result_ext::PyResultExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;
 use crate::types::{sequence::PySequenceMethods, PyList, PySequence};
@@ -16,6 +14,13 @@ use crate::types::{sequence::PySequenceMethods, PyList, PySequence};
 use crate::BoundObject;
 use crate::{
     exceptions, Bound, FromPyObject, IntoPyObject, IntoPyObjectExt, PyAny, PyErr, PyResult, Python,
+};
+#[cfg(RustPython)]
+use crate::{
+    py_result_ext::PyResultExt,
+    sync::PyOnceLock,
+    types::{PyType, PyTypeMethods},
+    Py,
 };
 use std::iter::FusedIterator;
 #[cfg(feature = "nightly")]
@@ -84,7 +89,20 @@ fn try_new_from_iter<'py>(
 #[repr(transparent)]
 pub struct PyTuple(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyTuple, pyobject_native_static_type_object!(ffi::PyTuple_Type), "builtins", "tuple", #checkfunction=ffi::PyTuple_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyTuple,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "tuple").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "tuple",
+    #checkfunction=ffi::PyTuple_Check
+);
 
 impl PyTuple {
     /// Constructs a new tuple with the given elements.

--- a/src/types/typeobject.rs
+++ b/src/types/typeobject.rs
@@ -6,6 +6,8 @@ use crate::pybacked::PyBackedStr;
 use crate::types::any::PyAnyMethods;
 use crate::types::PyTuple;
 use crate::{ffi, Bound, PyAny, PyTypeInfo, Python};
+#[cfg(RustPython)]
+use crate::{sync::PyOnceLock, Py};
 
 use super::PyString;
 
@@ -19,7 +21,20 @@ use super::PyString;
 #[repr(transparent)]
 pub struct PyType(PyAny);
 
+#[cfg(not(RustPython))]
 pyobject_native_type_core!(PyType, pyobject_native_static_type_object!(ffi::PyType_Type), "builtins", "type", #checkfunction=ffi::PyType_Check);
+
+#[cfg(RustPython)]
+pyobject_native_type_core!(
+    PyType,
+    |py| {
+        static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+        TYPE.import(py, "builtins", "type").unwrap().as_type_ptr()
+    },
+    "builtins",
+    "type",
+    #checkfunction=ffi::PyType_Check
+);
 
 impl PyType {
     /// Creates a new type object.

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -1,14 +1,14 @@
 use crate::err::PyResult;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::py_result_ext::PyResultExt;
-#[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]
+#[cfg(any(PyPy, GraalPy, Py_LIMITED_API, RustPython))]
 use crate::sync::PyOnceLock;
 use crate::types::any::PyAny;
-#[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]
+#[cfg(any(PyPy, GraalPy, Py_LIMITED_API, RustPython))]
 use crate::types::typeobject::PyTypeMethods;
-#[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]
+#[cfg(any(PyPy, GraalPy, Py_LIMITED_API, RustPython))]
 use crate::types::PyType;
-#[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]
+#[cfg(any(PyPy, GraalPy, Py_LIMITED_API, RustPython))]
 use crate::Py;
 use crate::{ffi, Borrowed, Bound, BoundObject, IntoPyObject, IntoPyObjectExt};
 
@@ -20,10 +20,10 @@ use super::PyWeakrefMethods;
 #[repr(transparent)]
 pub struct PyWeakrefReference(PyAny);
 
-#[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API)))]
+#[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API, RustPython)))]
 pyobject_subclassable_native_type!(PyWeakrefReference, ffi::PyWeakReference);
 
-#[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API)))]
+#[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API, RustPython)))]
 pyobject_native_type!(
     PyWeakrefReference,
     ffi::PyWeakReference,
@@ -36,7 +36,7 @@ pyobject_native_type!(
 );
 
 // When targeting alternative or multiple interpreters, it is better to not use the internal API.
-#[cfg(any(PyPy, GraalPy, Py_LIMITED_API))]
+#[cfg(any(PyPy, GraalPy, Py_LIMITED_API, RustPython))]
 pyobject_native_type_core!(
     PyWeakrefReference,
     |py| {


### PR DESCRIPTION
Removed all usage of static type pointers when compiling for RustPython. Diff is large but is very repetitive.

### Test plan
```console
~/repo/pyo3 ❱ RUSTFLAGS="--cfg RustPython" cargo check
    Blocking waiting for file lock on build directory
    Checking pyo3-ffi v0.28.3 (/Users/basschoenmaeckers/repo/pyo3/pyo3-ffi)
    Checking pyo3 v0.28.3 (/Users/basschoenmaeckers/repo/pyo3)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.38s
```

xref https://github.com/RustPython/RustPython/pull/7562

https://discuss.python.org/t/c-api-add-py-getbuildintype-and-py-getbuildintypeborrowed/107010
