### PR TITLE
ci: use `setup-python` install so codspeed builds flamegraphs correctly

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -20,9 +20,14 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v7
         with:
-          # codspeed action needs to be run from within the final Python environment
-          activate-environment: true
           save-cache: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
+
+      # Using this action is still necessary for CodSpeed to build flamegraphs correctly,
+      # see note about setup-python in https://codspeed.io/docs/benchmarks/python#recipes
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.UV_PYTHON }}
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rust-src


### PR DESCRIPTION
I noticed some of our benchmarks have weirdly recursive traces like this:

<img width="1038" height="735" alt="image" src="https://github.com/user-attachments/assets/be081783-dabc-4481-b22c-3e2042637845" />

I asked to codspeed team, apparently this is a limitation when using the `uv`-provided Python installs, so instead let's use `setup-python` to install Python for the benchmarks.