### PR TITLE
fix error with named lifetimes in `#[new]` return types

### DIFF
--- a/newsfragments/5998.fixed.md
+++ b/newsfragments/5998.fixed.md
@@ -1,0 +1,1 @@
+fixed compilation error for `#[new]` return types that contain named lifetimes

--- a/pyo3-macros-backend/src/py_expr.rs
+++ b/pyo3-macros-backend/src/py_expr.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use std::borrow::Cow;
 use syn::visit_mut::{visit_type_mut, VisitMut};
-use syn::{Expr, ExprLit, ExprPath, Lifetime, Lit, Type};
+use syn::{Expr, ExprLit, ExprPath, Lit, Type};
 
 /// A Python expression
 ///
@@ -268,24 +268,8 @@ fn clean_type(mut t: Type, self_type: Option<&Type>) -> Type {
     if let Some(self_type) = self_type {
         replace_self(&mut t, self_type);
     }
-    elide_lifetimes(&mut t);
+    crate::utils::elide_lifetimes(&mut t);
     t
-}
-
-/// Replaces all explicit lifetimes in `self` with elided (`'_`) lifetimes
-///
-/// This is useful if `Self` is used in `const` context, where explicit
-/// lifetimes are not allowed (yet).
-fn elide_lifetimes(ty: &mut Type) {
-    struct ElideLifetimesVisitor;
-
-    impl VisitMut for ElideLifetimesVisitor {
-        fn visit_lifetime_mut(&mut self, l: &mut Lifetime) {
-            *l = Lifetime::new("'_", l.span());
-        }
-    }
-
-    ElideLifetimesVisitor.visit_type_mut(ty);
 }
 
 // Replace Self in types with the given type

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1474,9 +1474,11 @@ fn generate_method_body(
             });
 
             let output = if let syn::ReturnType::Type(_, ty) = &spec.output {
+                let mut ty = ty.clone();
+                utils::elide_lifetimes(&mut ty);
                 ty
             } else {
-                &parse_quote!(())
+                parse_quote!(())
             };
             let body = quote! {
                 #text_signature_impl

--- a/pyo3-macros-backend/src/utils.rs
+++ b/pyo3-macros-backend/src/utils.rs
@@ -375,3 +375,19 @@ pub(crate) fn locate_tokens_at(tokens: TokenStream, span: Span) -> TokenStream {
     let output_span = tokens.span().located_at(span);
     set_span_recursively(tokens, output_span)
 }
+
+/// Replaces all explicit lifetimes in `self` with elided (`'_`) lifetimes
+///
+/// This is useful if `Self` is used in `const` context, where explicit
+/// lifetimes are not allowed (yet).
+pub(crate) fn elide_lifetimes(ty: &mut syn::Type) {
+    struct ElideLifetimesVisitor;
+
+    impl syn::visit_mut::VisitMut for ElideLifetimesVisitor {
+        fn visit_lifetime_mut(&mut self, l: &mut syn::Lifetime) {
+            *l = syn::Lifetime::new("'_", l.span());
+        }
+    }
+
+    syn::visit_mut::VisitMut::visit_type_mut(&mut ElideLifetimesVisitor, ty);
+}

--- a/src/tests/hygiene/pymethods.rs
+++ b/src/tests/hygiene/pymethods.rs
@@ -566,3 +566,14 @@ impl WarningDummy2 {
     #[pyo3(warn(message = "this class-method raises user-defined warning", category = UserDefinedWarning))]
     fn multiple_warnings_fn_with_custom_category(&self) {}
 }
+
+#[crate::pyclass(crate = "crate")]
+struct NewReturnsNamedLifetime;
+
+#[crate::pymethods(crate = "crate")]
+impl NewReturnsNamedLifetime {
+    #[new]
+    fn new<'py>(py: crate::Python<'py>) -> crate::PyResult<crate::Bound<'py, Self>> {
+        crate::Bound::new(py, Self)
+    }
+}


### PR DESCRIPTION
While exploring I noticed that `#[new]` functions with named lifetimes in their output type give a compile error. This is because the type is used in our const specialization. There is no particular reason to block such types, most notable `Bound` is one of them, so this fixes that.
