### PR TITLE
trigger rebuilds when virtualenv changes

### DIFF
--- a/newsfragments/6008.changed.md
+++ b/newsfragments/6008.changed.md
@@ -1,0 +1,1 @@
+`pyo3-ffi` will now rebuild when the Python virtual environment changes in-place.

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1818,10 +1818,16 @@ where
 }
 
 fn venv_interpreter(virtual_env: &OsStr, windows: bool) -> PathBuf {
+    let venv = Path::new(virtual_env);
+    // Rebuild if the virtual environment configuration changes
+    println!(
+        "cargo:rerun-if-changed={}",
+        venv.join("pyvenv.cfg").display()
+    );
     if windows {
-        Path::new(virtual_env).join("Scripts").join("python.exe")
+        venv.join("Scripts").join("python.exe")
     } else {
-        Path::new(virtual_env).join("bin").join("python")
+        venv.join("bin").join("python")
     }
 }
 


### PR DESCRIPTION
I realised that frequently I am attempting to test specific Python versions with commands like

```bash
UV_PYTHON=3.12 uv run cargo test --test test_compile_error
```

Unfortunately at the moment, even though `uv` recreates the venv, we don't reconfigure the build. (Full details of why are basically the same as #4882.)

I realised today that when the venv is recreated there will be a new `pyvenv.cfg` file created, and that will have a new mtime, so we should be able to reliably trigger a rebuild based on that.