### PR TITLE
add missing CHANGELOG entry for 5973

### DIFF
--- a/newsfragments/5973.packaging.md
+++ b/newsfragments/5973.packaging.md
@@ -1,0 +1,1 @@
+Extend range of supported versions of `hashbrown` optional dependency to include version 0.17.


### PR DESCRIPTION
I should have added a CHANGELOG entry to #5973, I missed that it bumped the main `Cargo.toml`.