### PR TITLE
ci: add jobs for 3.14t on aarch64 windows and ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,23 @@ jobs:
                 rust-target: "aarch64-unknown-linux-gnu",
               }
           - rust: stable
+            python-version: "3.14t"
+            platform:
+              {
+                os: "ubuntu-24.04-arm",
+                python-architecture: "arm64",
+                rust-target: "aarch64-unknown-linux-gnu",
+              }
+          - rust: stable
             python-version: "3.14"
+            platform:
+              {
+                os: "windows-11-arm",
+                python-architecture: "arm64",
+                rust-target: "aarch64-pc-windows-msvc",
+              }
+          - rust: stable
+            python-version: "3.14t"
             platform:
               {
                 os: "windows-11-arm",


### PR DESCRIPTION
Adds additional testing for 3.14t on latest OS / platforms.

As an additive change to CI coverage will send this straight to merge and hope it's green.