### PR TITLE
docs: duplicated words in pyo3-introspection, guide, and ffi compat comment

### DIFF
--- a/guide/src/advanced/sharing-types.md
+++ b/guide/src/advanced/sharing-types.md
@@ -392,7 +392,7 @@ Using vtables introduces overhead (e.g. prevents inlining), however this is a ne
 
 ### Error handling across the boundary { #error-handling }
 
-Similar to many other types, PyO3's `PyErr` type is is not currently `#[repr(C)]`, so cannot be shared across the package boundary.
+Similar to many other types, PyO3's `PyErr` type is not currently `#[repr(C)]`, so cannot be shared across the package boundary.
 
 The simplest approach to handling errors across the boundary is to use `Option` return types in the API struct, and to return `None` on error.
 This is the approach taken in the [example project].

--- a/pyo3-ffi/src/compat/mod.rs
+++ b/pyo3-ffi/src/compat/mod.rs
@@ -33,7 +33,7 @@ macro_rules! compat_function {
         #[cfg(test)]
         paste::paste! {
             // Test that the compat function does not overlap with the original function. If the
-            // cfgs line up, then the the two glob imports will resolve to the same item via the
+            // cfgs line up, then the two glob imports will resolve to the same item via the
             // re-export. If the cfgs mismatch, then the use of $name will be ambiguous in cases
             // where the function is defined twice, and the test will fail to compile.
             #[allow(unused_imports, reason = "imports exist to try to trigger name conflicts")]

--- a/pyo3-introspection/src/main.rs
+++ b/pyo3-introspection/src/main.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::{env, fs};
 
 fn main() -> Result<()> {
-    let [_, binary_path, module_name, output_path] = env::args().collect::<Vec<_>>().try_into().map_err(|_| anyhow!("pyo3-introspection takes three arguments, the path of the binary to introspect, the name of the python module to introspect and and the path of the directory to write the stub to"))?;
+    let [_, binary_path, module_name, output_path] = env::args().collect::<Vec<_>>().try_into().map_err(|_| anyhow!("pyo3-introspection takes three arguments, the path of the binary to introspect, the name of the python module to introspect and the path of the directory to write the stub to"))?;
     let module = introspect_cdylib(&binary_path, &module_name)
         .with_context(|| format!("Failed to introspect module {binary_path}"))?;
     let actual_stubs = module_stub_files(&module);


### PR DESCRIPTION
Three one-line typo fixes for duplicated words:
- `pyo3-introspection/src/main.rs` — in the `anyhow!` error message: "the name of the python module to introspect and and the path of the directory" → "...introspect and the path of the directory"
- `guide/src/advanced/sharing-types.md` — "PyO3's `PyErr` type is is not currently `#[repr(C)]`" → "...PyErr type is not currently..."
- `pyo3-ffi/src/compat/mod.rs` — "// cfgs line up, then the the two glob imports will resolve" → "...then the two glob imports..."

No code/behavior change.