### PR TITLE
avoid mutable references in `critical_section_mutex` implementations

### DIFF
--- a/src/sync/critical_section.rs
+++ b/src/sync/critical_section.rs
@@ -198,7 +198,7 @@ where
     #[cfg(Py_GIL_DISABLED)]
     {
         let mut guard = CSGuard(unsafe { core::mem::zeroed() });
-        unsafe { crate::ffi::PyCriticalSection_BeginMutex(&mut guard.0, &mut *mutex.mutex.get()) };
+        unsafe { crate::ffi::PyCriticalSection_BeginMutex(&raw mut guard.0, mutex.mutex.get()) };
         f(EnteredCriticalSection(&mutex.data))
     }
     #[cfg(not(Py_GIL_DISABLED))]
@@ -243,9 +243,9 @@ where
         let mut guard = CS2Guard(unsafe { core::mem::zeroed() });
         unsafe {
             crate::ffi::PyCriticalSection2_BeginMutex(
-                &mut guard.0,
-                &mut *m1.mutex.get(),
-                &mut *m2.mutex.get(),
+                &raw mut guard.0,
+                m1.mutex.get(),
+                m2.mutex.get(),
             )
         };
         f(


### PR DESCRIPTION
There is a slight technicality in `with_critical_section_mutex2` that if the same `PyMutex` is passed as both arguments, the `&mut` references to the raw ffi mutex internally are UB due to mutable aliasing.

Fortunately we can just work with raw pointers here as this is an FFI call. I'm not sure wether the compiler actually will produce exploitable UB in this particular position due to the references being immediately coerced to pointers for the FFI call, but it seems wise to tidy this up.

cc @ngoldbaum

(Credit to Codex security scanning for this discovery.)