### PR TITLE
internal: use `std` as extern crate

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -22,6 +22,7 @@
 //! `PyBuffer` implementation
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_identifier, PyStaticExpr};
+use crate::platform::prelude::*;
 use crate::{err, exceptions::PyBufferError, ffi, FromPyObject, PyAny, PyResult, Python};
 use crate::{Borrowed, Bound, PyErr};
 use core::ffi::{

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -20,6 +20,7 @@
 //! `PyBuffer` implementation
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_identifier, PyStaticExpr};
+use crate::platform::prelude::*;
 use crate::{err, exceptions::PyBufferError, ffi, FromPyObject, PyAny, PyResult, Python};
 use crate::{Borrowed, Bound, PyErr};
 use core::ffi::{

--- a/src/byteswriter.rs
+++ b/src/byteswriter.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::PyTypeInfo;
 #[cfg(not(Py_LIMITED_API))]

--- a/src/byteswriter.rs
+++ b/src/byteswriter.rs
@@ -3,6 +3,8 @@
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::PyTypeInfo;
 #[cfg(not(Py_LIMITED_API))]

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -3,6 +3,7 @@ use crate::err::PyResult;
 use crate::impl_::pyclass::ExtractPyClassWithClone;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_identifier, type_hint_subscript, PyStaticExpr};
+use crate::platform::prelude::*;
 use crate::pyclass::boolean_struct::False;
 use crate::pyclass::{PyClassGuardError, PyClassGuardMutError};
 use crate::types::PyList;
@@ -441,6 +442,7 @@ pub trait FromPyObject<'a, 'py>: Sized {
 }
 
 mod from_py_object_sequence {
+    use crate::platform::prelude::*;
     use crate::PyResult;
 
     /// Private trait for implementing specialized sequence extraction for `Vec<u8>` and `[u8; N]`

--- a/src/conversions/anyhow.rs
+++ b/src/conversions/anyhow.rs
@@ -120,6 +120,7 @@ impl From<anyhow::Error> for PyErr {
 #[cfg(test)]
 mod test_anyhow {
     use crate::exceptions::{PyRuntimeError, PyValueError};
+    use crate::platform::prelude::*;
     use crate::prelude::*;
     use crate::types::IntoPyDict;
 

--- a/src/conversions/bigdecimal.rs
+++ b/src/conversions/bigdecimal.rs
@@ -53,6 +53,7 @@ use core::str::FromStr;
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_hint_identifier;
 use crate::types::PyTuple;

--- a/src/conversions/bytes.rs
+++ b/src/conversions/bytes.rs
@@ -70,6 +70,8 @@ use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
 use crate::instance::Bound;
+#[allow(unused_imports, reason = "used to build docs")]
+use crate::platform::prelude::*;
 use crate::pybacked::PyBackedBytes;
 use crate::types::PyBytes;
 #[cfg(feature = "experimental-inspect")]

--- a/src/conversions/bytes.rs
+++ b/src/conversions/bytes.rs
@@ -68,6 +68,8 @@ use crate::conversion::IntoPyObject;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
 use crate::instance::Bound;
+#[allow(unused_imports, reason = "used to build docs")]
+use crate::platform::prelude::*;
 use crate::pybacked::PyBackedBytes;
 use crate::types::PyBytes;
 #[cfg(feature = "experimental-inspect")]

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -714,9 +714,9 @@ fn py_datetime_to_datetime_with_timezone<Tz: TimeZone>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::{test_utils::assert_warnings, types::PyTuple, BoundObject};
     use core::cmp::Ordering;
-    use std::panic;
 
     #[test]
     // Only Python>=3.9 has the zoneinfo package
@@ -898,9 +898,9 @@ mod tests {
         Python::attach(|py| {
             let low_days: i32 = -1000000000;
             // This is possible
-            assert!(panic::catch_unwind(|| Duration::days(low_days as i64)).is_ok());
+            assert!(std::panic::catch_unwind(|| Duration::days(low_days as i64)).is_ok());
             // This panics on PyDelta::new
-            assert!(panic::catch_unwind(|| {
+            assert!(std::panic::catch_unwind(|| {
                 let py_delta = new_py_datetime_ob(py, "timedelta", (low_days, 0, 0));
                 if let Ok(_duration) = py_delta.extract::<Duration>() {
                     // So we should never get here
@@ -910,9 +910,9 @@ mod tests {
 
             let high_days: i32 = 1000000000;
             // This is possible
-            assert!(panic::catch_unwind(|| Duration::days(high_days as i64)).is_ok());
+            assert!(std::panic::catch_unwind(|| Duration::days(high_days as i64)).is_ok());
             // This panics on PyDelta::new
-            assert!(panic::catch_unwind(|| {
+            assert!(std::panic::catch_unwind(|| {
                 let py_delta = new_py_datetime_ob(py, "timedelta", (high_days, 0, 0));
                 if let Ok(_duration) = py_delta.extract::<Duration>() {
                     // So we should never get here

--- a/src/conversions/chrono.rs
+++ b/src/conversions/chrono.rs
@@ -714,6 +714,7 @@ fn py_datetime_to_datetime_with_timezone<Tz: TimeZone>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::{test_utils::assert_warnings, types::PyTuple, BoundObject};
     use core::cmp::Ordering;
     use std::panic;

--- a/src/conversions/chrono_tz.rs
+++ b/src/conversions/chrono_tz.rs
@@ -38,6 +38,7 @@ use crate::conversion::IntoPyObject;
 use crate::exceptions::PyValueError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_hint_identifier;
 use crate::types::{any::PyAnyMethods, PyTzInfo};

--- a/src/conversions/either.rs
+++ b/src/conversions/either.rs
@@ -131,6 +131,7 @@ mod tests {
     use alloc::borrow::Cow;
 
     use crate::exceptions::PyTypeError;
+    use crate::platform::prelude::*;
     use crate::{IntoPyObject, Python};
 
     use crate::types::PyAnyMethods;

--- a/src/conversions/eyre.rs
+++ b/src/conversions/eyre.rs
@@ -126,6 +126,7 @@ impl From<eyre::Report> for PyErr {
 #[cfg(test)]
 mod tests {
     use crate::exceptions::{PyRuntimeError, PyValueError};
+    use crate::platform::prelude::*;
     use crate::prelude::*;
     use crate::types::IntoPyDict;
 

--- a/src/conversions/jiff.rs
+++ b/src/conversions/jiff.rs
@@ -48,6 +48,7 @@
 use crate::exceptions::{PyTypeError, PyValueError};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 use crate::types::{PyAnyMethods, PyNone};
 use crate::types::{PyDate, PyDateTime, PyDelta, PyTime, PyTzInfo, PyTzInfoAccess};
 #[cfg(not(Py_LIMITED_API))]

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -47,11 +47,13 @@
 //! assert n + 1 == value
 //! ```
 
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 #[cfg(Py_LIMITED_API)]
 use crate::types::{bytes::PyBytesMethods, PyBytes};
 use crate::{
-    conversion::IntoPyObject, std::num::nb_index, types::PyInt, Borrowed, Bound, FromPyObject,
-    PyAny, PyErr, PyResult, Python,
+    conversion::IntoPyObject, conversions::std::num::nb_index, types::PyInt, Borrowed, Bound,
+    FromPyObject, PyAny, PyErr, PyResult, Python,
 };
 
 use num_bigint::{BigInt, BigUint};
@@ -435,7 +437,7 @@ class C:
             macro_rules! test {
                 ($T:ty, $value:expr, $py:expr) => {
                     let value = $value;
-                    println!("{}: {}", stringify!($T), value);
+                    std::println!("{}: {}", stringify!($T), value);
                     let python_value = value.clone().into_pyobject(py).unwrap();
                     let roundtrip_value = python_value.extract::<$T>().unwrap();
                     assert_eq!(value, roundtrip_value);

--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -49,11 +49,13 @@
 //! assert n + 1 == value
 //! ```
 
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 #[cfg(Py_LIMITED_API)]
 use crate::types::{bytes::PyBytesMethods, PyBytes};
 use crate::{
-    conversion::IntoPyObject, std::num::nb_index, types::PyInt, Borrowed, Bound, FromPyObject,
-    PyAny, PyErr, PyResult, Python,
+    conversion::IntoPyObject, conversions::std::num::nb_index, types::PyInt, Borrowed, Bound,
+    FromPyObject, PyAny, PyErr, PyResult, Python,
 };
 
 use num_bigint::{BigInt, BigUint};
@@ -437,7 +439,7 @@ class C:
             macro_rules! test {
                 ($T:ty, $value:expr, $py:expr) => {
                     let value = $value;
-                    println!("{}: {}", stringify!($T), value);
+                    std::println!("{}: {}", stringify!($T), value);
                     let python_value = value.clone().into_pyobject(py).unwrap();
                     let roundtrip_value = python_value.extract::<$T>().unwrap();
                     assert_eq!(value, roundtrip_value);

--- a/src/conversions/ordered_float.rs
+++ b/src/conversions/ordered_float.rs
@@ -55,6 +55,7 @@ use crate::conversion::IntoPyObject;
 use crate::exceptions::PyValueError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 use crate::types::PyFloat;
 use crate::{Borrowed, Bound, FromPyObject, PyAny, Python};
 use core::convert::Infallible;

--- a/src/conversions/rust_decimal.rs
+++ b/src/conversions/rust_decimal.rs
@@ -53,6 +53,7 @@ use crate::conversion::IntoPyObject;
 use crate::exceptions::PyValueError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 use crate::sync::PyOnceLock;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_hint_identifier;

--- a/src/conversions/serde.rs
+++ b/src/conversions/serde.rs
@@ -12,6 +12,7 @@
 //! serde = "1.0"
 //! ```
 
+use crate::platform::prelude::*;
 use crate::{Py, PyAny, PyClass, Python};
 use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -108,6 +108,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::types::{PyBytes, PyBytesMethods, PyDict, PyList};
 
     #[test]

--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -110,6 +110,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::types::{PyBytes, PyBytesMethods, PyDict, PyList};
 
     #[test]

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -132,6 +132,7 @@ pub(crate) fn invalid_sequence_length(expected: usize, actual: usize) -> PyErr {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     #[cfg(panic = "unwind")]
     use core::sync::atomic::{AtomicUsize, Ordering};
     #[cfg(panic = "unwind")]

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -135,6 +135,7 @@ pub(crate) fn invalid_sequence_length(expected: usize, actual: usize) -> PyErr {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     #[cfg(panic = "unwind")]
     use core::sync::atomic::{AtomicUsize, Ordering};
     #[cfg(panic = "unwind")]

--- a/src/conversions/std/cstring.rs
+++ b/src/conversions/std/cstring.rs
@@ -1,6 +1,8 @@
 use crate::exceptions::PyUnicodeDecodeError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;
 use crate::types::PyString;

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -6,6 +6,7 @@ use crate::conversion::{FromPyObjectSequence, IntoPyObject};
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 use crate::py_result_ext::PyResultExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -3,6 +3,7 @@ use crate::conversion::{FromPyObjectSequence, IntoPyObject};
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 use crate::py_result_ext::PyResultExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -6,6 +6,8 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
 use crate::instance::Bound;
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;
 use crate::types::PyString;
@@ -226,6 +228,8 @@ impl<'py> IntoPyObject<'py> for &OsString {
 mod tests {
     #[cfg(target_os = "wasi")]
     use crate::exceptions::PyFileNotFoundError;
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     use crate::types::{PyAnyMethods, PyString, PyStringMethods};
     use crate::{Bound, BoundObject, IntoPyObject, Python};
     use alloc::borrow::Cow;

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -9,6 +9,8 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
 use crate::instance::Bound;
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;
 use crate::types::PyString;
@@ -229,6 +231,8 @@ impl<'py> IntoPyObject<'py> for &OsString {
 mod tests {
     #[cfg(target_os = "wasi")]
     use crate::exceptions::PyFileNotFoundError;
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     use crate::types::{PyAnyMethods, PyString, PyStringMethods};
     use crate::{Bound, BoundObject, IntoPyObject, Python};
     use alloc::borrow::Cow;

--- a/src/conversions/std/slice.rs
+++ b/src/conversions/std/slice.rs
@@ -1,3 +1,4 @@
+use crate::platform::prelude::*;
 use alloc::borrow::Cow;
 
 #[cfg(feature = "experimental-inspect")]

--- a/src/conversions/std/string.rs
+++ b/src/conversions/std/string.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;
 use crate::{
@@ -177,6 +178,7 @@ impl FromPyObject<'_, '_> for char {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::types::any::PyAnyMethods;
     use crate::{IntoPyObject, Python};
     use alloc::borrow::Cow;

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -164,6 +164,7 @@ fn unix_epoch_py(py: Python<'_>) -> PyResult<Borrowed<'_, '_, PyDateTime>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::types::PyDict;
 
     #[test]

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -3,6 +3,7 @@
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_subscript, PyStaticExpr};
+use crate::platform::prelude::*;
 use crate::{
     conversion::{FromPyObject, FromPyObjectOwned, FromPyObjectSequence, IntoPyObject},
     exceptions::PyTypeError,
@@ -95,6 +96,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::conversion::IntoPyObject;
+    use crate::platform::prelude::*;
     use crate::types::{PyAnyMethods, PyBytes, PyBytesMethods, PyList};
     use crate::Python;
 

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_subscript, PyStaticExpr};
+use crate::platform::prelude::*;
 use crate::{
     conversion::{FromPyObject, FromPyObjectOwned, FromPyObjectSequence, IntoPyObject},
     exceptions::PyTypeError,
@@ -92,6 +93,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::conversion::IntoPyObject;
+    use crate::platform::prelude::*;
     use crate::types::{PyAnyMethods, PyBytes, PyBytesMethods, PyList};
     use crate::Python;
 

--- a/src/coroutine.rs
+++ b/src/coroutine.rs
@@ -10,6 +10,7 @@ use core::{
 
 use pyo3_macros::{pyclass, pymethods};
 
+use crate::platform::prelude::*;
 use crate::{
     coroutine::{cancel::ThrowCallback, waker::AsyncioWaker},
     exceptions::{PyAttributeError, PyRuntimeError, PyStopIteration},

--- a/src/err/cast_error.rs
+++ b/src/err/cast_error.rs
@@ -1,3 +1,4 @@
+use crate::platform::prelude::*;
 use alloc::borrow::Cow;
 
 use crate::{

--- a/src/err/downcast_error.rs
+++ b/src/err/downcast_error.rs
@@ -130,6 +130,7 @@ fn display_downcast_error(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
 
     #[test]
     fn test_display_downcast_error() {

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -1,3 +1,4 @@
+use crate::platform::prelude::*;
 use core::cell::UnsafeCell;
 use std::{
     sync::{Mutex, Once},
@@ -405,7 +406,8 @@ fn raise_lazy(py: Python<'_>, lazy: Box<PyErrStateLazyFn>) {
 
 #[cfg(test)]
 mod tests {
-
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     use crate::{
         exceptions::PyValueError, sync::PyOnceLock, Py, PyAny, PyErr, PyErrArguments, Python,
     };

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -1,6 +1,7 @@
 // TODO https://github.com/PyO3/pyo3/issues/5487
 #![allow(clippy::undocumented_unsafe_blocks)]
 
+use crate::platform::prelude::*;
 use core::cell::UnsafeCell;
 use std::{
     sync::{Mutex, Once},
@@ -408,7 +409,8 @@ fn raise_lazy(py: Python<'_>, lazy: Box<PyErrStateLazyFn>) {
 
 #[cfg(test)]
 mod tests {
-
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     use crate::{
         exceptions::PyValueError, sync::PyOnceLock, Py, PyAny, PyErr, PyErrArguments, Python,
     };

--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -1,3 +1,4 @@
+use crate::platform::prelude::*;
 use crate::{err::PyErrArguments, exceptions, types, PyErr, Python};
 use crate::{IntoPyObject, Py, PyAny};
 use std::io;

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -9,6 +9,7 @@ use crate::instance::Bound;
 #[cfg(Py_3_11)]
 use crate::intern;
 use crate::panic::PanicException;
+use crate::platform::prelude::*;
 use crate::py_result_ext::PyResultExt;
 use crate::type_object::PyTypeInfo;
 use crate::types::any::PyAnyMethods;
@@ -798,6 +799,7 @@ mod tests {
     use super::PyErrState;
     use crate::exceptions::{self, PyTypeError, PyValueError};
     use crate::impl_::pyclass::{value_of, IsSend, IsSync};
+    use crate::platform::prelude::*;
     use crate::test_utils::assert_warnings;
     use crate::{PyErr, PyTypeInfo, Python};
 

--- a/src/err/mod.rs
+++ b/src/err/mod.rs
@@ -6,6 +6,7 @@ use crate::instance::Bound;
 #[cfg(Py_3_11)]
 use crate::intern;
 use crate::panic::PanicException;
+use crate::platform::prelude::*;
 use crate::py_result_ext::PyResultExt;
 use crate::type_object::PyTypeInfo;
 use crate::types::any::PyAnyMethods;
@@ -798,6 +799,7 @@ mod tests {
     use super::PyErrState;
     use crate::exceptions::{self, PyTypeError, PyValueError};
     use crate::impl_::pyclass::{value_of, IsSend, IsSync};
+    use crate::platform::prelude::*;
     use crate::test_utils::assert_warnings;
     use crate::{PyErr, PyTypeInfo, Python};
 

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -953,6 +953,7 @@ pub mod socket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::types::any::PyAnyMethods;
     use crate::types::{IntoPyDict, PyDict};
     use crate::{IntoPyObjectExt as _, PyErr};

--- a/src/exceptions.rs
+++ b/src/exceptions.rs
@@ -947,6 +947,7 @@ pub mod socket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::types::any::PyAnyMethods;
     use crate::types::{IntoPyDict, PyDict};
     use crate::{IntoPyObjectExt as _, PyErr};

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,6 +1,8 @@
 // TODO https://github.com/PyO3/pyo3/issues/5487
 #![allow(clippy::undocumented_unsafe_blocks)]
 
+#[allow(unused_imports, reason = "used to build docs")]
+use crate::platform::prelude::*;
 #[cfg(any(doc, all(Py_3_14, not(Py_LIMITED_API))))]
 use crate::{types::PyString, Python};
 #[cfg(all(Py_3_14, not(Py_LIMITED_API)))]
@@ -42,12 +44,11 @@ macro_rules! py_format {
     ($py: expr, $($arg:tt)*) => {{
         if let Some(static_string) = format_args!($($arg)*).as_str() {
             static INTERNED: $crate::sync::PyOnceLock<$crate::Py<$crate::types::PyString>> = $crate::sync::PyOnceLock::new();
-            Ok(
+            Ok($crate::Bound::clone(
                 INTERNED
                 .get_or_init($py, || $crate::types::PyString::intern($py, static_string).unbind())
                 .bind($py)
-                .to_owned()
-            )
+            ))
         } else {
             $crate::types::PyString::from_fmt($py, format_args!($($arg)*))
         }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,3 +1,5 @@
+#[allow(unused_imports, reason = "used to build docs")]
+use crate::platform::prelude::*;
 #[cfg(any(doc, all(Py_3_14, not(Py_LIMITED_API))))]
 use crate::{types::PyString, Python};
 #[cfg(all(Py_3_14, not(Py_LIMITED_API)))]
@@ -40,12 +42,11 @@ macro_rules! py_format {
     ($py: expr, $($arg:tt)*) => {{
         if let Some(static_string) = format_args!($($arg)*).as_str() {
             static INTERNED: $crate::sync::PyOnceLock<$crate::Py<$crate::types::PyString>> = $crate::sync::PyOnceLock::new();
-            Ok(
+            Ok($crate::Bound::clone(
                 INTERNED
                 .get_or_init($py, || $crate::types::PyString::intern($py, static_string).unbind())
                 .bind($py)
-                .to_owned()
-            )
+            ))
         } else {
             $crate::types::PyString::from_fmt($py, format_args!($($arg)*))
         }

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -1,3 +1,4 @@
+use crate::platform::prelude::*;
 use core::ptr::NonNull;
 
 #[cfg(feature = "experimental-inspect")]
@@ -946,6 +947,7 @@ fn push_parameter_list(msg: &mut String, parameter_names: &[&str]) {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::types::{IntoPyDict, PyTuple};
     use crate::Python;
 

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -1,6 +1,7 @@
 // TODO https://github.com/PyO3/pyo3/issues/5487
 #![allow(clippy::undocumented_unsafe_blocks)]
 
+use crate::platform::prelude::*;
 use core::ptr::NonNull;
 
 #[cfg(feature = "experimental-inspect")]
@@ -1021,6 +1022,7 @@ fn push_parameter_list(msg: &mut String, parameter_names: &[&str]) {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::types::{IntoPyDict, PyTuple};
     use crate::Python;
 

--- a/src/impl_/freelist.rs
+++ b/src/impl_/freelist.rs
@@ -9,6 +9,7 @@
 //! [1]: https://en.wikipedia.org/wiki/Free_list
 
 use crate::ffi;
+use crate::platform::prelude::*;
 use core::mem;
 
 /// Represents a slot of a [`PyObjectFreeList`].

--- a/src/impl_/freelist.rs
+++ b/src/impl_/freelist.rs
@@ -9,6 +9,7 @@
 //! [1]: https://en.wikipedia.org/wiki/Free_list
 
 use crate::ffi;
+use crate::platform::prelude::*;
 use core::ptr::NonNull;
 
 /// A free allocation list for PyObject ffi pointers.

--- a/src/impl_/frompyobject.rs
+++ b/src/impl_/frompyobject.rs
@@ -1,3 +1,4 @@
+use crate::platform::prelude::*;
 use crate::types::any::PyAnyMethods;
 use crate::Bound;
 use crate::{exceptions::PyTypeError, FromPyObject, PyAny, PyErr, PyResult, Python};

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1,3 +1,5 @@
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 use crate::{
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError},
     ffi,
@@ -1442,6 +1444,7 @@ pub trait ExtractPyClassWithClone: generic_pyclass::Sealed {}
 #[cfg(test)]
 #[cfg(feature = "macros")]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::pycell::impl_::PyClassObjectContents;
 
     use super::*;

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1,6 +1,8 @@
 // TODO https://github.com/PyO3/pyo3/issues/5487
 #![allow(clippy::undocumented_unsafe_blocks)]
 
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 use crate::{
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError},
     ffi,

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -1,3 +1,4 @@
+use crate::platform::prelude::*;
 use core::{ffi::CStr, marker::PhantomData};
 use std::thread::{self, ThreadId};
 

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -1,6 +1,7 @@
 // TODO https://github.com/PyO3/pyo3/issues/5487
 #![allow(clippy::undocumented_unsafe_blocks)]
 
+use crate::platform::prelude::*;
 use core::{ffi::CStr, marker::PhantomData};
 use std::thread::{self, ThreadId};
 

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -704,6 +704,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
+
     #[test]
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     fn test_fastcall_function_with_keywords() {

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -718,6 +718,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
+
     #[test]
     #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
     fn test_fastcall_function_with_keywords() {

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 //! Implementation details of `#[pymodule]` which need to be accessible from proc-macro generated code.
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 use core::{
     cell::UnsafeCell,
     ffi::CStr,

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -1,4 +1,6 @@
 //! Implementation details of `#[pymodule]` which need to be accessible from proc-macro generated code.
+#[allow(unused_imports, reason = "conditionally used")]
+use crate::platform::prelude::*;
 use core::{
     cell::UnsafeCell,
     ffi::CStr,

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -8,6 +8,7 @@
 use core::{any::Any, ffi::c_int, panic::UnwindSafe};
 
 use crate::internal::state::AttachGuard;
+use crate::platform::prelude::*;
 use crate::{
     ffi, ffi_ptr_ext::FfiPtrExt, impl_::callback::PyCallbackOutput, impl_::panic::PanicTrap,
     panic::PanicException, types::PyModule, Bound, PyResult, Python,

--- a/src/impl_/unindent.rs
+++ b/src/impl_/unindent.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::undocumented_unsafe_blocks)]
 
 use crate::impl_::concat::slice_copy_from_slice;
+use crate::platform::prelude::*;
 
 /// This is a reimplementation of the `indoc` crate's unindent functionality:
 ///

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -174,6 +174,7 @@ impl<T> UnknownReturnType<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
 
     #[test]
     fn wrap_option() {

--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -449,6 +449,7 @@ impl AsRef<PyStaticExpr> for PyClassNameStaticExpr {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
 
     #[test]
     fn test_to_string() {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -6,6 +6,7 @@ use crate::err::{PyErr, PyResult};
 use crate::impl_::pyclass::PyClassImpl;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 use crate::pycell::impl_::PyClassObjectLayout;
 use crate::pycell::{PyBorrowError, PyBorrowMutError};
 use crate::pyclass::boolean_struct::{False, True};
@@ -2512,6 +2513,8 @@ mod tests {
     use super::{Bound, IntoPyObject, Py};
     #[cfg(all(feature = "macros", panic = "unwind"))]
     use crate::exceptions::PyValueError;
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     use crate::test_utils::generate_unique_module_name;
     #[cfg(all(feature = "macros", panic = "unwind"))]
     use crate::test_utils::UnraisableCapture;

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -6,6 +6,7 @@ use crate::err::{PyErr, PyResult};
 use crate::impl_::pyclass::PyClassImpl;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 use crate::pycell::impl_::PyClassObjectLayout;
 use crate::pycell::{PyBorrowError, PyBorrowMutError};
 use crate::pyclass::boolean_struct::{False, True};
@@ -2434,6 +2435,8 @@ mod tests {
     use super::{Bound, IntoPyObject, Py};
     #[cfg(all(feature = "macros", panic = "unwind"))]
     use crate::exceptions::PyValueError;
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     use crate::test_utils::generate_unique_module_name;
     #[cfg(all(feature = "macros", panic = "unwind"))]
     use crate::test_utils::UnraisableCapture;

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -2,6 +2,7 @@
 
 #[cfg(pyo3_disable_reference_pool)]
 use crate::impl_::panic::PanicTrap;
+use crate::platform::prelude::*;
 use crate::{ffi, Python};
 
 use core::cell::Cell;

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -5,6 +5,7 @@
 
 #[cfg(pyo3_disable_reference_pool)]
 use crate::impl_::panic::PanicTrap;
+use crate::platform::prelude::*;
 use crate::{ffi, Python};
 
 use core::cell::Cell;

--- a/src/internal_tricks.rs
+++ b/src/internal_tricks.rs
@@ -1,6 +1,7 @@
 use core::ptr::NonNull;
 
 use crate::ffi::{self, Py_ssize_t, PY_SSIZE_T_MAX};
+use crate::platform::prelude::*;
 
 macro_rules! pyo3_exception {
     ($doc: expr, $name: ident, $base: ty) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![warn(
     clippy::alloc_instead_of_core,
     clippy::std_instead_of_alloc,
@@ -341,7 +342,9 @@
 #![doc = concat!("[Features chapter of the guide]: https://pyo3.rs/v", env!("CARGO_PKG_VERSION"), "/features.html#features-reference \"Features Reference - PyO3 user guide\"")]
 //! [`Ungil`]: crate::marker::Ungil
 
+#[macro_use]
 extern crate alloc;
+extern crate std;
 
 pub use crate::class::*;
 pub use crate::conversion::{FromPyObject, IntoPyObject, IntoPyObjectExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![warn(
     clippy::alloc_instead_of_core,
     clippy::std_instead_of_alloc,
@@ -342,7 +343,9 @@
 #![doc = concat!("[Features chapter of the guide]: https://pyo3.rs/v", env!("CARGO_PKG_VERSION"), "/features.html#features-reference \"Features Reference - PyO3 user guide\"")]
 //! [`Ungil`]: crate::marker::Ungil
 
+#[macro_use]
 extern crate alloc;
+extern crate std;
 
 pub use crate::class::*;
 pub use crate::conversion::{FromPyObject, IntoPyObject, IntoPyObjectExt};
@@ -363,6 +366,8 @@ pub use crate::version::PythonVersionInfo;
 pub(crate) mod ffi_ptr_ext;
 pub(crate) mod py_result_ext;
 pub(crate) mod sealed;
+
+mod platform;
 
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -797,6 +797,7 @@ impl<'unbound> Python<'unbound> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::{
         internal::state::ForbidAttaching,
         types::{IntoPyDict, PyList},

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -800,6 +800,7 @@ impl<'unbound> Python<'unbound> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::{
         internal::state::ForbidAttaching,
         types::{IntoPyDict, PyList},

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,5 +1,6 @@
 //! Helper to convert Rust panics to Python exceptions.
 use crate::exceptions::PyBaseException;
+use crate::platform::prelude::*;
 use crate::PyErr;
 use core::any::Any;
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,15 @@
+//! This module is to support platform compatiblity with `no_std` environments.
+
+/// This prelude is intended to be used instead of the prelude from `std`.
+#[allow(unused_imports)]
+pub(crate) mod prelude {
+    pub use alloc::{
+        borrow::ToOwned,
+        boxed::Box,
+        string::{String, ToString},
+        vec::Vec,
+    };
+
+    // TODO find a `no_std` replacement for eprintln
+    pub use std::eprintln;
+}

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,6 +1,19 @@
 //! This module is to support platform compatiblity with `no_std` environments.
 #![allow(unused_imports)]
 
+/// This prelude is intended to be used instead of the prelude from `std`.
+pub(crate) mod prelude {
+    pub use alloc::{
+        borrow::ToOwned,
+        boxed::Box,
+        string::{String, ToString},
+        vec::Vec,
+    };
+
+    // TODO find a `no_std` replacement for eprintln
+    pub use std::eprintln;
+}
+
 #[cfg(feature = "hashbrown")]
 pub use hashbrown::{HashMap, HashSet};
 

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -5,6 +5,7 @@
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_hint_union;
 use crate::{

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -2,6 +2,7 @@
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_hint_union;
 use crate::{

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -196,6 +196,7 @@
 use crate::conversion::IntoPyObject;
 use crate::exceptions::PyRuntimeError;
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::platform::prelude::*;
 use crate::pyclass::{boolean_struct::False, PyClass};
 use crate::{ffi, Borrowed, Bound, PyErr, Python};
 use core::convert::Infallible;

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -199,6 +199,7 @@
 use crate::conversion::IntoPyObject;
 use crate::exceptions::PyRuntimeError;
 use crate::ffi_ptr_ext::FfiPtrExt;
+use crate::platform::prelude::*;
 use crate::pyclass::{boolean_struct::False, PyClass};
 use crate::{ffi, Borrowed, Bound, PyErr, Python};
 use core::convert::Infallible;

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -592,6 +592,8 @@ where
 mod tests {
     use super::*;
 
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     use crate::prelude::*;
     use crate::pyclass::boolean_struct::{False, True};
 

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -1,5 +1,6 @@
 use crate::exceptions::PyAttributeError;
 use crate::impl_::pymethods::{Deleter, PyDeleterDef};
+use crate::platform::prelude::*;
 #[cfg(not(Py_3_10))]
 use crate::types::typeobject::PyTypeMethods;
 use crate::{

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -3,6 +3,7 @@
 
 use crate::exceptions::PyAttributeError;
 use crate::impl_::pymethods::{Deleter, PyDeleterDef};
+use crate::platform::prelude::*;
 use crate::platform::HashMap;
 #[cfg(not(Py_3_10))]
 use crate::types::typeobject::PyTypeMethods;

--- a/src/sync/critical_section.rs
+++ b/src/sync/critical_section.rs
@@ -271,6 +271,8 @@ mod tests {
     use super::{with_critical_section, with_critical_section2};
     #[cfg(all(not(Py_LIMITED_API), Py_3_14))]
     use super::{with_critical_section_mutex, with_critical_section_mutex2};
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     #[cfg(all(not(Py_LIMITED_API), Py_3_14))]
     use crate::types::PyMutex;
     #[cfg(feature = "macros")]

--- a/src/sync/critical_section.rs
+++ b/src/sync/critical_section.rs
@@ -270,6 +270,8 @@ mod tests {
     use super::{with_critical_section, with_critical_section2};
     #[cfg(all(not(Py_LIMITED_API), Py_3_14))]
     use super::{with_critical_section_mutex, with_critical_section_mutex2};
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     #[cfg(all(not(Py_LIMITED_API), Py_3_14))]
     use crate::types::PyMutex;
     #[cfg(feature = "macros")]

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1457,6 +1457,7 @@ impl<'py> Bound<'py, PyAny> {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::{
         basic::CompareOp,
         test_utils::generate_unique_module_name,

--- a/src/types/any.rs
+++ b/src/types/any.rs
@@ -1668,6 +1668,7 @@ impl<'py> Bound<'py, PyAny> {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::{
         basic::CompareOp,
         test_utils::generate_unique_module_name,

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -1,6 +1,7 @@
 use crate::err::{PyErr, PyResult};
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::{Borrowed, Bound};
+use crate::platform::prelude::*;
 use crate::py_result_ext::PyResultExt;
 use crate::sync::critical_section::with_critical_section;
 use crate::{ffi, PyAny, Python};

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -1,6 +1,8 @@
 use crate::byteswriter::PyBytesWriter;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::{Borrowed, Bound};
+#[allow(unused_imports, reason = "used to build docs")]
+use crate::platform::prelude::*;
 use crate::{ffi, Py, PyAny, PyResult, Python};
 #[cfg(RustPython)]
 use crate::{

--- a/src/types/capsule.rs
+++ b/src/types/capsule.rs
@@ -3,6 +3,7 @@
 use crate::exceptions::PySystemError;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::box_into_non_null;
+use crate::platform::prelude::*;
 use crate::py_result_ext::PyResultExt;
 use crate::{ffi, PyAny};
 #[cfg(RustPython)]
@@ -688,6 +689,7 @@ fn name_ptr(name: Option<&CStr>) -> *const c_char {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::prelude::PyModule;
     use crate::types::capsule::PyCapsuleMethods;
     use crate::types::module::PyModuleMethods;

--- a/src/types/capsule.rs
+++ b/src/types/capsule.rs
@@ -2,6 +2,7 @@
 
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::box_into_non_null;
+use crate::platform::prelude::*;
 use crate::py_result_ext::PyResultExt;
 use crate::{ffi, PyAny};
 #[cfg(RustPython)]
@@ -731,6 +732,7 @@ fn name_ptr(name: Option<&CStr>) -> *const c_char {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::prelude::PyModule;
     use crate::types::capsule::PyCapsuleMethods;
     use crate::types::module::PyModuleMethods;

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -951,6 +951,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::platform::HashMap;
     use crate::types::{PyAnyMethods as _, PyTuple};
     use alloc::collections::BTreeMap;

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -953,6 +953,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::prelude::*;
     use crate::types::{PyAnyMethods as _, PyTuple};
     use alloc::collections::BTreeMap;
     use std::collections::HashMap;

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -1,5 +1,6 @@
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::impl_::pyfunction::create_py_c_function;
+use crate::platform::prelude::*;
 use crate::py_result_ext::PyResultExt;
 use crate::types::capsule::PyCapsuleMethods;
 use crate::{

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -162,6 +162,8 @@ mod tests {
     #[cfg(all(not(PyPy), Py_3_10))]
     use super::PySendResult;
     use crate::exceptions::PyTypeError;
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     #[cfg(all(not(PyPy), Py_3_10))]
     use crate::types::PyNone;
     use crate::types::{PyAnyMethods, PyDict, PyList, PyListMethods};

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -2,6 +2,8 @@ use crate::err::{self, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::get_ssize_index;
+#[allow(unused_imports, reason = "used to build docs")]
+use crate::platform::prelude::*;
 use crate::types::sequence::PySequenceMethods;
 use crate::types::{PySequence, PyTuple};
 #[cfg(RustPython)]
@@ -893,6 +895,7 @@ impl<'py> IntoIterator for &Bound<'py, PyList> {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::types::any::PyAnyMethods;
     use crate::types::list::PyListMethods;
     use crate::types::sequence::PySequenceMethods;

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -2,6 +2,8 @@ use crate::err::{self, PyResult};
 use crate::ffi::{self, Py_ssize_t};
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::internal_tricks::get_ssize_index;
+#[allow(unused_imports, reason = "used to build docs")]
+use crate::platform::prelude::*;
 use crate::types::sequence::PySequenceMethods;
 use crate::types::{PySequence, PyTuple};
 #[cfg(RustPython)]
@@ -959,6 +961,7 @@ impl<'py> IntoIterator for &Bound<'py, PyList> {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::types::any::PyAnyMethods;
     use crate::types::list::PyListMethods;
     use crate::types::sequence::PySequenceMethods;

--- a/src/types/mappingproxy.rs
+++ b/src/types/mappingproxy.rs
@@ -148,6 +148,7 @@ impl<'py> Iterator for BoundMappingProxyIterator<'py, '_> {
 mod tests {
 
     use super::*;
+    use crate::platform::prelude::*;
     use crate::types::dict::*;
     use crate::Python;
     use crate::{

--- a/src/types/mappingproxy.rs
+++ b/src/types/mappingproxy.rs
@@ -148,6 +148,7 @@ impl<'py> Iterator for BoundMappingProxyIterator<'py, '_> {
 mod tests {
 
     use super::*;
+    use crate::platform::prelude::*;
     use crate::platform::HashMap;
     use crate::types::dict::*;
     use crate::Python;

--- a/src/types/sequence.rs
+++ b/src/types/sequence.rs
@@ -360,6 +360,7 @@ impl<'py> PySequenceMethods<'py> for Bound<'py, PySequence> {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::types::{PyAnyMethods, PyList, PySequence, PySequenceMethods, PyTuple};
     use crate::{IntoPyObject, Py, PyAny, PyTypeInfo, Python};
     use core::ptr;

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -2,6 +2,7 @@
 use crate::exceptions::PyUnicodeDecodeError;
 use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::instance::Borrowed;
+use crate::platform::prelude::*;
 use crate::py_result_ext::PyResultExt;
 use crate::types::bytes::PyBytesMethods;
 use crate::types::PyBytes;

--- a/src/types/traceback.rs
+++ b/src/types/traceback.rs
@@ -1,4 +1,5 @@
 use crate::err::{error_on_minusone, PyResult};
+use crate::platform::prelude::*;
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, PyString};
 use crate::{ffi, Bound, PyAny};
 #[cfg(RustPython)]

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -4,6 +4,8 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::inspect::{type_hint_subscript, PyStaticExpr};
 use crate::instance::Borrowed;
 use crate::internal_tricks::get_ssize_index;
+#[allow(unused_imports, reason = "used to build docs")]
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;
 use crate::types::{sequence::PySequenceMethods, PyList, PySequence};
@@ -1064,6 +1066,7 @@ tuple_conversion!(
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::platform::HashSet;
     use crate::types::{any::PyAnyMethods, tuple::PyTupleMethods, PyList, PyTuple};
     use crate::{Bound, IntoPyObject, PyAny, Python};

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -4,6 +4,8 @@ use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::inspect::{type_hint_subscript, PyStaticExpr};
 use crate::instance::Borrowed;
 use crate::internal_tricks::get_ssize_index;
+#[allow(unused_imports, reason = "used to build docs")]
+use crate::platform::prelude::*;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_object::PyTypeInfo;
 use crate::types::{sequence::PySequenceMethods, PyList, PySequence};
@@ -1107,6 +1109,7 @@ tuple_conversion!(
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::types::{any::PyAnyMethods, tuple::PyTupleMethods, PyList, PyTuple};
     use crate::{IntoPyObject, Python};
     #[cfg(feature = "nightly")]

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -362,6 +362,8 @@ impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakref> {
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     use crate::types::any::{PyAny, PyAnyMethods};
     use crate::types::weakref::{PyWeakref, PyWeakrefMethods, PyWeakrefProxy, PyWeakrefReference};
     use crate::{Bound, PyResult, Python};

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -364,6 +364,8 @@ impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakref> {
 
 #[cfg(test)]
 mod tests {
+    #[allow(unused_imports, reason = "conditionally used")]
+    use crate::platform::prelude::*;
     use crate::types::any::{PyAny, PyAnyMethods};
     use crate::types::weakref::{PyWeakref, PyWeakrefMethods, PyWeakrefProxy, PyWeakrefReference};
     use crate::{Bound, PyResult, Python};

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -190,6 +190,7 @@ impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakrefProxy> {
 #[cfg(test)]
 mod tests {
     use crate::exceptions::{PyAttributeError, PyReferenceError, PyTypeError};
+    use crate::platform::prelude::*;
     use crate::types::any::{PyAny, PyAnyMethods};
     use crate::types::weakref::{PyWeakrefMethods, PyWeakrefProxy};
     use crate::{Bound, PyResult, Python};

--- a/src/types/weakref/proxy.rs
+++ b/src/types/weakref/proxy.rs
@@ -192,6 +192,7 @@ impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakrefProxy> {
 #[cfg(test)]
 mod tests {
     use crate::exceptions::{PyAttributeError, PyReferenceError, PyTypeError};
+    use crate::platform::prelude::*;
     use crate::types::any::{PyAny, PyAnyMethods};
     use crate::types::weakref::{PyWeakrefMethods, PyWeakrefProxy};
     use crate::{Bound, PyResult, Python};

--- a/src/types/weakref/reference.rs
+++ b/src/types/weakref/reference.rs
@@ -197,6 +197,7 @@ impl<'py> PyWeakrefMethods<'py> for Bound<'py, PyWeakrefReference> {
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::prelude::*;
     use crate::types::any::{PyAny, PyAnyMethods};
     use crate::types::weakref::{PyWeakrefMethods, PyWeakrefReference};
     use crate::{Bound, PyResult, Python};

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -7,6 +7,8 @@
 // the inner mod enables the #![allow(dead_code)] to
 // be applied - `src/test_utils.rs` uses `include!` to pull in this file
 
+extern crate alloc;
+
 #[allow(
     dead_code,
     unused_macros,
@@ -23,6 +25,8 @@ mod inner {
     use super::*;
 
     use pyo3::prelude::*;
+
+    use alloc::string::ToString;
 
     #[cfg(any(not(all(Py_GIL_DISABLED, Py_3_14)), feature = "macros"))]
     use pyo3::sync::MutexExt;

--- a/tests/ui/invalid_pyfunction_argument.inspect.stderr
+++ b/tests/ui/invalid_pyfunction_argument.inspect.stderr
@@ -75,9 +75,9 @@ help: the following other types implement trait `pyo3::PyClass`
  17 | #[pyclass(skip_from_py_object)]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo`
     |
-   ::: src/coroutine.rs:29:1
+   ::: src/coroutine.rs:30:1
     |
- 29 | #[pyclass(crate = "crate")]
+ 30 | #[pyclass(crate = "crate")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pyo3::coroutine::Coroutine`
     = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
     = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`


### PR DESCRIPTION
This PR is to prepare for `no_std` support.

- I've made the main crate `no_std` and added `extern crate std` instead.
- I've also added a new top-level mod `platform` to hold all the upcoming std replacements. As of now, it just has a prelude which contains
  - Things from the `alloc` crate people generate use from `std`'s prelude
  - the `eprintln` macro (we will need to find a replacement for this)
- I've added `import crate::platform::prelude::*` to every file that uses things from the standard prelude.
- The `test_utils` file could not import the prelude so it had to import directly from the `alloc` crate.
- in `py_format` macro: replace use of `ToOwned` with `Clone`

ETA: It looks like a large PR because of the number of files changed, but most of that is just importing the new prelude into the files that need it. There are only four files that have more changes than that.