### PR TITLE
internal: use `hashbrown` internally if it's enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,9 @@ chrono = { version = "0.4.25", default-features = false, optional = true }
 chrono-tz = { version = ">= 0.10, < 0.11", default-features = false, optional = true }
 either = { version = "1.9", optional = true }
 eyre = { version = ">= 0.6.8, < 0.7", optional = true }
-hashbrown = { version = ">= 0.15.0, < 0.18", optional = true, default-features = false }
+hashbrown = { version = ">= 0.15.0, < 0.18", optional = true, default-features = false, features = [
+    "default-hasher",
+] }
 indexmap = { version = ">= 2.5.0, < 3", optional = true }
 jiff-02 = { package = "jiff", version = "0.2", optional = true }
 num-bigint = { version = "0.4.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,6 +364,8 @@ pub(crate) mod ffi_ptr_ext;
 pub(crate) mod py_result_ext;
 pub(crate) mod sealed;
 
+mod platform;
+
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///
 /// Prefer using the same content from `pyo3::pyclass`, e.g. `use pyo3::pyclass::CompareOp` instead

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,9 @@
+//! This module is to support platform compatiblity with `no_std` environments.
+#![allow(unused_imports)]
+
+#[cfg(feature = "hashbrown")]
+pub use hashbrown::{HashMap, HashSet};
+
+// TODO conditionally import these based on "std" feature
+#[cfg(not(feature = "hashbrown"))]
+pub use std::collections::{HashMap, HashSet};

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -620,7 +620,7 @@ mod test {
     #[test]
     fn test_backed_str_map_key() {
         Python::attach(|py| {
-            use std::collections::HashMap;
+            use crate::platform::HashMap;
 
             let mut map: HashMap<PyBackedStr, usize> = HashMap::new();
             let s: PyBackedStr = PyString::new(py, "key1").try_into().unwrap();

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -1,5 +1,6 @@
 use crate::exceptions::PyAttributeError;
 use crate::impl_::pymethods::{Deleter, PyDeleterDef};
+use crate::platform::HashMap;
 #[cfg(not(Py_3_10))]
 use crate::types::typeobject::PyTypeMethods;
 use crate::{
@@ -23,7 +24,7 @@ use core::{
     ffi::{c_char, c_int, c_ulong, c_void},
     ptr::{self, NonNull},
 };
-use std::{collections::HashMap, ffi::CString};
+use std::ffi::CString;
 
 pub(crate) struct PyClassTypeObject {
     pub type_object: Py<PyType>,

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -953,9 +953,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::platform::HashMap;
     use crate::types::{PyAnyMethods as _, PyTuple};
     use alloc::collections::BTreeMap;
-    use std::collections::HashMap;
 
     #[test]
     fn test_new() {

--- a/src/types/mapping.rs
+++ b/src/types/mapping.rs
@@ -195,8 +195,7 @@ impl<'py> PyMappingMethods<'py> for Bound<'py, PyMapping> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
+    use crate::platform::HashMap;
     use crate::{exceptions::PyKeyError, types::PyTuple};
 
     use super::*;

--- a/src/types/mappingproxy.rs
+++ b/src/types/mappingproxy.rs
@@ -148,6 +148,7 @@ impl<'py> Iterator for BoundMappingProxyIterator<'py, '_> {
 mod tests {
 
     use super::*;
+    use crate::platform::HashMap;
     use crate::types::dict::*;
     use crate::Python;
     use crate::{
@@ -155,7 +156,6 @@ mod tests {
         types::{PyInt, PyTuple},
     };
     use alloc::collections::BTreeMap;
-    use std::collections::HashMap;
 
     #[test]
     fn test_new() {

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -286,12 +286,12 @@ impl ExactSizeIterator for BoundSetIterator<'_> {
 #[cfg(test)]
 mod tests {
     use super::PySet;
+    use crate::platform::HashSet;
     use crate::{
         conversion::IntoPyObject,
         types::{PyAnyMethods, PySetMethods},
         Python,
     };
-    use std::collections::HashSet;
 
     #[test]
     fn test_set_new() {

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1107,12 +1107,13 @@ tuple_conversion!(
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::HashSet;
     use crate::types::{any::PyAnyMethods, tuple::PyTupleMethods, PyList, PyTuple};
     use crate::{IntoPyObject, Python};
     #[cfg(feature = "nightly")]
     use core::num::NonZero;
     use core::ops::Range;
-    use std::collections::HashSet;
+
     #[test]
     fn test_new() {
         Python::attach(|py| {


### PR DESCRIPTION
This PR is to prepare for `no_std` support.

I've added a `platform.rs` mod to include the replacements that will be needed.

If the `hashbrown` feature is enabled it re-exports `HashMap` and `HashSet` from there. If it's not, they are re-exported from `std`.

Once there is an `std` feature, those imports will be conditional as well. If the `hashbrown` and `std` features are both disabled, it can conditionally call the `compile_error` macro.