### PR TITLE
No std `ThreadId`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+[[disallowed-types]]
+path = "std::thread::ThreadId"
+reason = "Use crate::platform::ThreadId for `no_std` compatibility"

--- a/newsfragments/6056.added.md
+++ b/newsfragments/6056.added.md
@@ -1,0 +1,1 @@
+Add `PyThread_get_thread_ident` to the ffi crate

--- a/newsfragments/6056.added.md
+++ b/newsfragments/6056.added.md
@@ -1,1 +1,1 @@
-Add `PyThread_get_thread_ident` to the ffi crate
+Add `PyThread_get_thread_ident` to the ffi crate when not using PyPy

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -484,6 +484,7 @@ pub use self::pyport::*;
 pub use self::pystate::*;
 pub use self::pystrtod::*;
 pub use self::pythonrun::*;
+pub use self::pythread::*;
 pub use self::pytypedefs::*;
 pub use self::rangeobject::*;
 pub use self::refcount::*;
@@ -577,7 +578,7 @@ mod pythonrun;
 // skipped pystrhex.h
 // skipped pystrcmp.h
 mod pystrtod;
-// skipped pythread.h
+mod pythread;
 // skipped pytime.h
 mod pytypedefs;
 mod rangeobject;

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -485,7 +485,6 @@ pub use self::pyport::*;
 pub use self::pystate::*;
 pub use self::pystrtod::*;
 pub use self::pythonrun::*;
-#[cfg_attr(PyPy, expect(unused_imports, reason = "not implemented for PyPy"))]
 pub use self::pythread::*;
 pub use self::pytypedefs::*;
 pub use self::rangeobject::*;

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -485,6 +485,7 @@ pub use self::pyport::*;
 pub use self::pystate::*;
 pub use self::pystrtod::*;
 pub use self::pythonrun::*;
+#[cfg_attr(PyPy, expect(unused_imports, reason = "not implemented for PyPy"))]
 pub use self::pythread::*;
 pub use self::pytypedefs::*;
 pub use self::rangeobject::*;

--- a/pyo3-ffi/src/pythread.rs
+++ b/pyo3-ffi/src/pythread.rs
@@ -1,0 +1,5 @@
+use core::num::NonZero;
+
+extern_libpython! {
+    pub fn PyThread_get_thread_ident() -> NonZero<u64>;
+}

--- a/pyo3-ffi/src/pythread.rs
+++ b/pyo3-ffi/src/pythread.rs
@@ -1,6 +1,4 @@
-#[cfg(not(PyPy))]
-use core::ffi::c_ulong;
-use core::ffi::{c_int, c_void};
+use core::ffi::{c_int, c_ulong, c_void};
 
 // skipped PyThread_type_lock
 // skipped PyLockStatus
@@ -9,7 +7,7 @@ use core::ffi::{c_int, c_void};
 // skipped PyThread_exit_thread
 
 extern_libpython! {
-    #[cfg(not(PyPy))]
+    #[cfg_attr(PyPy, link_name = "PyPyThread_get_thread_ident")]
     pub fn PyThread_get_thread_ident() -> c_ulong;
 }
 

--- a/pyo3-ffi/src/pythread.rs
+++ b/pyo3-ffi/src/pythread.rs
@@ -1,5 +1,4 @@
-use core::ffi::{c_int, c_void};
-use core::num::NonZero;
+use core::ffi::{c_int, c_ulong, c_void};
 
 // skipped PyThread_type_lock
 // skipped PyLockStatus
@@ -8,7 +7,7 @@ use core::num::NonZero;
 // skipped PyThread_exit_thread
 
 extern_libpython! {
-    pub fn PyThread_get_thread_ident() -> NonZero<u64>;
+    pub fn PyThread_get_thread_ident() -> c_ulong;
 }
 
 // skipped PyThread_get_thread_native_id

--- a/pyo3-ffi/src/pythread.rs
+++ b/pyo3-ffi/src/pythread.rs
@@ -7,6 +7,7 @@ use core::ffi::{c_int, c_ulong, c_void};
 // skipped PyThread_exit_thread
 
 extern_libpython! {
+    #[cfg_attr(PyPy, link_name = "PyPyThread_get_thread_ident")]
     pub fn PyThread_get_thread_ident() -> c_ulong;
 }
 

--- a/pyo3-ffi/src/pythread.rs
+++ b/pyo3-ffi/src/pythread.rs
@@ -1,11 +1,16 @@
 use core::ffi::{c_int, c_void};
+use core::num::NonZero;
 
 // skipped PyThread_type_lock
 // skipped PyLockStatus
 // skipped PyThread_init_thread
 // skipped PyThread_start_new_thread
 // skipped PyThread_exit_thread
-// skipped PyThread_get_thread_ident
+
+extern_libpython! {
+    pub fn PyThread_get_thread_ident() -> NonZero<u64>;
+}
+
 // skipped PyThread_get_thread_native_id
 // skipped PyThread_allocate_lock
 // skipped PyThread_free_lock

--- a/pyo3-ffi/src/pythread.rs
+++ b/pyo3-ffi/src/pythread.rs
@@ -7,7 +7,7 @@ use core::ffi::{c_int, c_ulong, c_void};
 // skipped PyThread_exit_thread
 
 extern_libpython! {
-    #[cfg_attr(PyPy, link_name = "PyPyThread_get_thread_ident")]
+    #[cfg(not(PyPy))]
     pub fn PyThread_get_thread_ident() -> c_ulong;
 }
 

--- a/pyo3-ffi/src/pythread.rs
+++ b/pyo3-ffi/src/pythread.rs
@@ -1,4 +1,6 @@
-use core::ffi::{c_int, c_ulong, c_void};
+#[cfg(not(PyPy))]
+use core::ffi::c_ulong;
+use core::ffi::{c_int, c_void};
 
 // skipped PyThread_type_lock
 // skipped PyLockStatus

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -1,9 +1,7 @@
 use core::cell::UnsafeCell;
-use std::{
-    sync::{Mutex, Once},
-    thread::ThreadId,
-};
+use std::sync::{Mutex, Once};
 
+use crate::platform::thread::{self, ThreadId};
 #[cfg(not(Py_3_12))]
 use crate::sync::MutexExt;
 use crate::{
@@ -94,7 +92,7 @@ impl PyErrState {
         // re-entrancy guarantees.
         if let Some(thread) = self.normalizing_thread.lock().unwrap().as_ref() {
             assert!(
-                !(*thread == std::thread::current().id()),
+                !(*thread == thread::current().id()),
                 "Re-entrant normalization of PyErrState detected"
             );
         }
@@ -105,7 +103,7 @@ impl PyErrState {
                 self.normalizing_thread
                     .lock()
                     .unwrap()
-                    .replace(std::thread::current().id());
+                    .replace(thread::current().id());
 
                 // Safety: no other thread can access the inner value while we are normalizing it.
                 let state = unsafe {

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -3,11 +3,9 @@
 
 use crate::platform::prelude::*;
 use core::cell::UnsafeCell;
-use std::{
-    sync::{Mutex, Once},
-    thread::ThreadId,
-};
+use std::sync::{Mutex, Once};
 
+use crate::platform::thread::{self, ThreadId};
 #[cfg(not(Py_3_12))]
 use crate::sync::MutexExt;
 use crate::{
@@ -98,7 +96,7 @@ impl PyErrState {
         // re-entrancy guarantees.
         if let Some(thread) = self.normalizing_thread.lock().unwrap().as_ref() {
             assert!(
-                !(*thread == std::thread::current().id()),
+                !(*thread == thread::current().id()),
                 "Re-entrant normalization of PyErrState detected"
             );
         }
@@ -109,7 +107,7 @@ impl PyErrState {
                 self.normalizing_thread
                     .lock()
                     .unwrap()
-                    .replace(std::thread::current().id());
+                    .replace(thread::current().id());
 
                 // Safety: no other thread can access the inner value while we are normalizing it.
                 let state = unsafe {

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1,3 +1,4 @@
+use crate::platform::thread;
 use crate::{
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError},
     ffi,
@@ -19,7 +20,7 @@ use core::{
     marker::PhantomData,
     ptr::{self, NonNull},
 };
-use std::{sync::Mutex, thread};
+use std::sync::Mutex;
 
 mod assertions;
 pub mod doc;

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -3,6 +3,7 @@
 
 #[allow(unused_imports, reason = "conditionally used")]
 use crate::platform::prelude::*;
+use crate::platform::thread;
 use crate::{
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError},
     ffi,
@@ -26,7 +27,7 @@ use core::{
     marker::PhantomData,
     ptr::{self, NonNull},
 };
-use std::{sync::Mutex, thread};
+use std::sync::Mutex;
 
 mod assertions;
 pub mod doc;

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -1,5 +1,5 @@
+use crate::platform::thread::{self, ThreadId};
 use core::{ffi::CStr, marker::PhantomData};
-use std::thread::{self, ThreadId};
 
 #[cfg(Py_3_14)]
 use crate::err::error_on_minusone;

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -2,8 +2,8 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 use crate::platform::prelude::*;
+use crate::platform::thread::{self, ThreadId};
 use core::{ffi::CStr, marker::PhantomData};
-use std::thread::{self, ThreadId};
 
 #[cfg(Py_3_14)]
 use crate::err::error_on_minusone;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,6 +364,8 @@ pub(crate) mod ffi_ptr_ext;
 pub(crate) mod py_result_ext;
 pub(crate) mod sealed;
 
+mod platform;
+
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///
 /// Prefer using the same content from `pyo3::pyclass`, e.g. `use pyo3::pyclass::CompareOp` instead

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,8 +364,6 @@ pub(crate) mod ffi_ptr_ext;
 pub(crate) mod py_result_ext;
 pub(crate) mod sealed;
 
-mod platform;
-
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///
 /// Prefer using the same content from `pyo3::pyclass`, e.g. `use pyo3::pyclass::CompareOp` instead
@@ -414,6 +412,8 @@ mod tests;
 mod internal;
 #[macro_use]
 mod internal_tricks;
+
+mod platform;
 
 // Macro dependencies, also contains macros exported for use across the codebase and
 // in expanded macros.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,4 @@
+//! This module is to support platform compatiblity with `no_std` environments.
+#![allow(unused_imports)]
+
+pub mod thread;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -22,3 +22,5 @@ pub use std::collections::{HashMap, HashSet};
 
 #[cfg(all(not(feature = "hashbrown"), not(wip_feature_std)))]
 compile_error!("Please enable at least one of the following features: hashbrown, std");
+
+pub mod thread;

--- a/src/platform/thread.rs
+++ b/src/platform/thread.rs
@@ -1,0 +1,23 @@
+use core::num::NonZero;
+
+use pyo3_ffi::PyThread_get_thread_ident;
+
+#[must_use]
+pub fn current() -> Thread {
+    Thread {
+        id: ThreadId(unsafe { PyThread_get_thread_ident() }),
+    }
+}
+
+pub struct Thread {
+    id: ThreadId,
+}
+
+impl Thread {
+    pub fn id(&self) -> ThreadId {
+        self.id
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ThreadId(NonZero<u64>);

--- a/src/platform/thread.rs
+++ b/src/platform/thread.rs
@@ -1,3 +1,4 @@
+use core::ffi::c_ulong;
 use core::num::NonZero;
 
 use pyo3_ffi::PyThread_get_thread_ident;
@@ -5,7 +6,9 @@ use pyo3_ffi::PyThread_get_thread_ident;
 #[must_use]
 pub fn current() -> Thread {
     Thread {
-        id: ThreadId(unsafe { PyThread_get_thread_ident() }),
+        // SAFETY: PyThread_get_thread_ident never returns zero
+        // https://docs.python.org/3/c-api/threads.html#c.PyThread_get_thread_ident
+        id: ThreadId(unsafe { NonZero::new_unchecked(PyThread_get_thread_ident()) }),
     }
 }
 
@@ -20,4 +23,4 @@ impl Thread {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct ThreadId(NonZero<u64>);
+pub struct ThreadId(NonZero<c_ulong>);

--- a/src/platform/thread.rs
+++ b/src/platform/thread.rs
@@ -1,9 +1,6 @@
 use core::ffi::c_ulong;
 use core::num::NonZero;
 
-#[cfg(all(PyPy, not(wip_feature_std)))]
-compile_error!("Thread ID is not available for PyPy with no_std");
-
 #[cfg(not(wip_feature_std))]
 use pyo3_ffi::PyThread_get_thread_ident;
 

--- a/src/platform/thread.rs
+++ b/src/platform/thread.rs
@@ -1,14 +1,21 @@
 use core::ffi::c_ulong;
 use core::num::NonZero;
 
+#[cfg(all(PyPy, not(wip_feature_std)))]
+compile_error!("Thread ID is not available for PyPy with no_std");
+
+#[cfg(not(wip_feature_std))]
 use pyo3_ffi::PyThread_get_thread_ident;
 
 #[must_use]
 pub fn current() -> Thread {
-    Thread {
-        // SAFETY: PyThread_get_thread_ident never returns zero
-        // https://docs.python.org/3/c-api/threads.html#c.PyThread_get_thread_ident
-        id: ThreadId(unsafe { NonZero::new_unchecked(PyThread_get_thread_ident()) }),
+    cfg_select! {
+        wip_feature_std => Thread { id: ThreadId(std::thread::current().id()) },
+        _ => Thread {
+            // SAFETY: PyThread_get_thread_ident never returns zero
+            // https://docs.python.org/3/c-api/threads.html#c.PyThread_get_thread_ident
+            id: ThreadId(unsafe { NonZero::new_unchecked(PyThread_get_thread_ident()) }),
+        }
     }
 }
 
@@ -22,5 +29,17 @@ impl Thread {
     }
 }
 
+// This needs to be in a separate mod so that the `expect` attribute covers the derived code.
+#[cfg(wip_feature_std)]
+#[expect(clippy::disallowed_types)]
+mod std_feature {
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+    pub struct ThreadId(pub(super) std::thread::ThreadId);
+}
+
+#[cfg(wip_feature_std)]
+pub use std_feature::ThreadId;
+
+#[cfg(not(wip_feature_std))]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ThreadId(NonZero<c_ulong>);


### PR DESCRIPTION
Re-implement `ThreadId` using `PyThread_get_thread_ident`. This makes is usable in `no_std` context.