### PR TITLE
Avoid using `PyDictObject` when compiling for RustPython

### DIFF
--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -330,8 +330,11 @@ impl InterpreterConfig {
             PythonImplementation::RustPython => out.push("cargo:rustc-cfg=RustPython".to_owned()),
         }
 
-        // If Py_GIL_DISABLED is set, do not build with limited API support
-        if self.abi3 && !self.is_free_threaded() {
+        // RustPython always builds with limited API support.
+        // If Py_GIL_DISABLED is set, do not build with limited API support.
+        if (self.abi3 && !self.is_free_threaded())
+            || self.implementation == PythonImplementation::RustPython
+        {
             out.push("cargo:rustc-cfg=Py_LIMITED_API".to_owned());
         }
 
@@ -3186,6 +3189,22 @@ mod tests {
                 "cargo:rustc-cfg=Py_3_10".to_owned(),
                 "cargo:rustc-cfg=Py_3_11".to_owned(),
                 "cargo:rustc-cfg=PyPy".to_owned(),
+            ]
+        );
+
+        let interpreter_config =
+            InterpreterConfigBuilder::new(PythonImplementation::RustPython, version)
+                .finalize()
+                .unwrap();
+        assert_eq!(
+            interpreter_config.build_script_outputs(),
+            [
+                "cargo:rustc-cfg=Py_3_8".to_owned(),
+                "cargo:rustc-cfg=Py_3_9".to_owned(),
+                "cargo:rustc-cfg=Py_3_10".to_owned(),
+                "cargo:rustc-cfg=Py_3_11".to_owned(),
+                "cargo:rustc-cfg=RustPython".to_owned(),
+                "cargo:rustc-cfg=Py_LIMITED_API".to_owned(),
             ]
         );
     }

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -600,8 +600,8 @@ mod weakrefobject;
 pub mod structmember;
 
 // "Limited API" definitions matching Python's `include/cpython` directory.
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(not(any(Py_LIMITED_API, RustPython)))]
 mod cpython;
 
-#[cfg(not(Py_LIMITED_API))]
+#[cfg(not(any(Py_LIMITED_API, RustPython)))]
 pub use self::cpython::*;

--- a/src/types/dict.rs
+++ b/src/types/dict.rs
@@ -36,9 +36,8 @@ pyobject_native_type!(
 );
 
 #[cfg(RustPython)]
-pyobject_native_type!(
+pyobject_native_type_core!(
     PyDict,
-    ffi::PyDictObject,
     |py| {
         static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
         TYPE.import(py, "builtins", "dict").unwrap().as_type_ptr()


### PR DESCRIPTION
fixes https://github.com/PyO3/pyo3/issues/6047

Tested using:
```
~/repo/pyo3 ❱ RUSTFLAGS="--cfg RustPython" cargo clippy --features abi3-py314
   Compiling pyo3-ffi v0.28.3 (/Users/basschoenmaeckers/repo/pyo3/pyo3-ffi)
   Compiling pyo3 v0.28.3 (/Users/basschoenmaeckers/repo/pyo3)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.84s
```