### PR TITLE
internal: no std mutex

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,7 @@
 [[disallowed-types]]
 path = "std::sync::Mutex"
 reason = "use crate::platform::sync::non_poison::Mutex for `no_std` compatibility"
+
+[[disallowed-types]]
+path = "std::sync::Once"
+reason = "use crate::platform::sync::Once for no_std compatibility"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+[[disallowed-types]]
+path = "std::sync::Mutex"
+reason = "use crate::platform::sync::non_poison::Mutex for `no_std` compatibility"

--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -205,20 +205,24 @@ Here the same example as above built using a [`Once`] instead of a
 
 ```rust
 # use pyo3::prelude::*;
+# #[cfg(wip_feature_std)]
 use std::sync::Once;
 use pyo3::sync::OnceExt;
 use pyo3::types::PyDict;
 
+# #[cfg(wip_feature_std)]
 struct RuntimeCache {
     once: Once,
     cache: Option<Py<PyDict>>
 }
 
+# #[cfg(wip_feature_std)]
 let mut cache = RuntimeCache {
     once: Once::new(),
     cache: None
 };
 
+# #[cfg(wip_feature_std)]
 Python::attach(|py| {
     // guaranteed to be called once and only once
     cache.once.call_once_py_attached(py, || {
@@ -241,11 +245,14 @@ Before:
 # use pyo3::prelude::*;
 use pyo3::sync::GILProtected;
 use pyo3::types::{PyDict, PyNone};
+# #[cfg(wip_feature_std)]
 use std::cell::RefCell;
 
+# #[cfg(wip_feature_std)]
 static OBJECTS: GILProtected<RefCell<Vec<Py<PyDict>>>> =
     GILProtected::new(RefCell::new(Vec::new()));
 
+# #[cfg(wip_feature_std)]
 Python::attach(|py| {
     // stand-in for something that executes arbitrary Python code
     let d = PyDict::new(py);
@@ -261,8 +268,10 @@ After (using a `Mutex`):
 # use pyo3::prelude::*;
 # fn main() {
 use pyo3::types::{PyDict, PyNone};
+# #[cfg(wip_feature_std)]
 use std::sync::Mutex;
 
+# #[cfg(wip_feature_std)]
 static OBJECTS: Mutex<Vec<Py<PyDict>>> = Mutex::new(Vec::new());
 
 Python::attach(|py| {
@@ -271,6 +280,7 @@ Python::attach(|py| {
     d.set_item(PyNone::get(py), PyNone::get(py)).unwrap();
     // as with any `Mutex` usage, lock the mutex for as little time as possible
     // in this case, we do it just while pushing into the `Vec`
+    # #[cfg(wip_feature_std)]
     OBJECTS.lock().unwrap().push(d.unbind());
 });
 # }

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -557,11 +557,14 @@ After:
 ```rust
 # use pyo3::prelude::*;
 use pyo3::sync::MutexExt;
+# #[cfg(wip_feature_std)]
 use std::sync::Mutex;
 # fn main() {
 # Python::attach(|py| {
+# #[cfg(wip_feature_std)]
 static NUMBERS: Mutex<Vec<i32>> = Mutex::new(Vec::new());
 Python::attach(|py| {
+    # #[cfg(wip_feature_std)]
     NUMBERS.lock_py_attached(py).expect("no poisoning").push(42);
 });
 # })

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -3129,9 +3129,10 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote! {
                 impl #pyo3_path::impl_::pyclass::PyClassWithFreeList for #cls {
                     #[inline]
-                    fn get_free_list(py: #pyo3_path::Python<'_>) -> &'static #pyo3_path::platform::sync::non_poison::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList> {
-                        static FREELIST: #pyo3_path::sync::PyOnceLock<#pyo3_path::platform::sync::non_poison::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList>> = #pyo3_path::sync::PyOnceLock::new();
-                        &FREELIST.get_or_init(py, || #pyo3_path::platform::sync::non_poison::Mutex::new(#pyo3_path::impl_::freelist::PyObjectFreeList::with_capacity(#freelist)))
+                    fn get_free_list(py: #pyo3_path::Python<'_>) -> impl ::core::ops::DerefMut<Target = #pyo3_path::impl_::freelist::PyObjectFreeList> {
+                        static FREELIST: #pyo3_path::impl_::freelist::FreeList = #pyo3_path::impl_::freelist::FreeList::new();
+                        const CAPACITY: usize = const { #freelist };
+                        FREELIST.get(py, CAPACITY)
                     }
                 }
             }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -3120,9 +3120,9 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote! {
                 impl #pyo3_path::impl_::pyclass::PyClassWithFreeList for #cls {
                     #[inline]
-                    fn get_free_list(py: #pyo3_path::Python<'_>) -> &'static ::std::sync::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList> {
-                        static FREELIST: #pyo3_path::sync::PyOnceLock<::std::sync::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList>> = #pyo3_path::sync::PyOnceLock::new();
-                        &FREELIST.get_or_init(py, || ::std::sync::Mutex::new(#pyo3_path::impl_::freelist::PyObjectFreeList::with_capacity(#freelist)))
+                    fn get_free_list(py: #pyo3_path::Python<'_>) -> &'static #pyo3_path::platform::sync::non_poison::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList> {
+                        static FREELIST: #pyo3_path::sync::PyOnceLock<#pyo3_path::platform::sync::non_poison::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList>> = #pyo3_path::sync::PyOnceLock::new();
+                        &FREELIST.get_or_init(py, || #pyo3_path::platform::sync::non_poison::Mutex::new(#pyo3_path::impl_::freelist::PyObjectFreeList::with_capacity(#freelist)))
                     }
                 }
             }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -3129,9 +3129,9 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote! {
                 impl #pyo3_path::impl_::pyclass::PyClassWithFreeList for #cls {
                     #[inline]
-                    fn get_free_list(py: #pyo3_path::Python<'_>) -> &'static ::std::sync::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList> {
-                        static FREELIST: #pyo3_path::sync::PyOnceLock<::std::sync::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList>> = #pyo3_path::sync::PyOnceLock::new();
-                        &FREELIST.get_or_init(py, || ::std::sync::Mutex::new(#pyo3_path::impl_::freelist::PyObjectFreeList::with_capacity(#freelist)))
+                    fn get_free_list(py: #pyo3_path::Python<'_>) -> &'static #pyo3_path::platform::sync::non_poison::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList> {
+                        static FREELIST: #pyo3_path::sync::PyOnceLock<#pyo3_path::platform::sync::non_poison::Mutex<#pyo3_path::impl_::freelist::PyObjectFreeList>> = #pyo3_path::sync::PyOnceLock::new();
+                        &FREELIST.get_or_init(py, || #pyo3_path::platform::sync::non_poison::Mutex::new(#pyo3_path::impl_::freelist::PyObjectFreeList::with_capacity(#freelist)))
                     }
                 }
             }

--- a/src/coroutine/cancel.rs
+++ b/src/coroutine/cancel.rs
@@ -1,8 +1,8 @@
+use crate::platform::sync::non_poison::Mutex;
 use crate::{Py, PyAny};
 use alloc::sync::Arc;
 use core::future::poll_fn;
 use core::task::{Context, Poll, Waker};
-use std::sync::Mutex;
 
 #[derive(Debug, Default)]
 struct Inner {
@@ -24,12 +24,12 @@ impl CancelHandle {
 
     /// Returns whether the associated coroutine has been cancelled.
     pub fn is_cancelled(&self) -> bool {
-        self.0.lock().unwrap().exception.is_some()
+        self.0.lock().exception.is_some()
     }
 
     /// Poll to retrieve the exception thrown in the associated coroutine.
     pub fn poll_cancelled(&mut self, cx: &mut Context<'_>) -> Poll<Py<PyAny>> {
-        let mut inner = self.0.lock().unwrap();
+        let mut inner = self.0.lock();
         if let Some(exc) = inner.exception.take() {
             return Poll::Ready(exc);
         }
@@ -58,7 +58,7 @@ pub struct ThrowCallback(Arc<Mutex<Inner>>);
 
 impl ThrowCallback {
     pub(super) fn throw(&self, exc: Py<PyAny>) {
-        let mut inner = self.0.lock().unwrap();
+        let mut inner = self.0.lock();
         inner.exception = Some(exc);
         if let Some(waker) = inner.waker.take() {
             waker.wake();

--- a/src/coroutine/cancel.rs
+++ b/src/coroutine/cancel.rs
@@ -2,6 +2,7 @@ use crate::platform::sync::non_poison::Mutex;
 use crate::{Py, PyAny};
 use alloc::sync::Arc;
 use core::future::poll_fn;
+use core::panic::AssertUnwindSafe;
 use core::task::{Context, Poll, Waker};
 
 #[derive(Debug, Default)]
@@ -14,7 +15,7 @@ struct Inner {
 ///
 /// Only the last exception thrown can be retrieved.
 #[derive(Debug, Default)]
-pub struct CancelHandle(Arc<Mutex<Inner>>);
+pub struct CancelHandle(Arc<AssertUnwindSafe<Mutex<Inner>>>);
 
 impl CancelHandle {
     /// Create a new `CoroutineCancel`.
@@ -54,7 +55,7 @@ impl CancelHandle {
 }
 
 #[doc(hidden)]
-pub struct ThrowCallback(Arc<Mutex<Inner>>);
+pub struct ThrowCallback(Arc<AssertUnwindSafe<Mutex<Inner>>>);
 
 impl ThrowCallback {
     pub(super) fn throw(&self, exc: Py<PyAny>) {

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -2,11 +2,8 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 use crate::platform::prelude::*;
-use core::cell::UnsafeCell;
-use std::{
-    sync::{Mutex, Once},
-    thread::ThreadId,
-};
+use core::cell::{Cell, UnsafeCell};
+use std::{sync::Once, thread::ThreadId};
 
 #[cfg(not(Py_3_12))]
 use crate::sync::MutexExt;
@@ -23,7 +20,7 @@ pub(crate) struct PyErrState {
     // after normalization.
     normalized: Once,
     // Guard against re-entrancy when normalizing the exception state.
-    normalizing_thread: Mutex<Option<ThreadId>>,
+    normalizing_thread: Cell<Option<ThreadId>>,
     inner: UnsafeCell<Option<PyErrStateInner>>,
 }
 
@@ -68,7 +65,7 @@ impl PyErrState {
     fn from_inner(inner: PyErrStateInner) -> Self {
         Self {
             normalized: Once::new(),
-            normalizing_thread: Mutex::new(None),
+            normalizing_thread: Cell::new(None),
             inner: UnsafeCell::new(Some(inner)),
         }
     }
@@ -96,9 +93,10 @@ impl PyErrState {
 
         // Guard against re-entrant normalization, because `Once` does not provide
         // re-entrancy guarantees.
-        if let Some(thread) = self.normalizing_thread.lock().unwrap().as_ref() {
-            assert!(
-                !(*thread == std::thread::current().id()),
+        if let Some(thread) = self.normalizing_thread.get() {
+            assert_ne!(
+                thread,
+                std::thread::current().id(),
                 "Re-entrant normalization of PyErrState detected"
             );
         }
@@ -107,9 +105,7 @@ impl PyErrState {
         py.detach(|| {
             self.normalized.call_once(|| {
                 self.normalizing_thread
-                    .lock()
-                    .unwrap()
-                    .replace(std::thread::current().id());
+                    .set(Some(std::thread::current().id()));
 
                 // Safety: no other thread can access the inner value while we are normalizing it.
                 let state = unsafe {

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -142,7 +142,7 @@ pub(crate) struct PyErrStateNormalized {
     ptype: Py<PyType>,
     pub pvalue: Py<PyBaseException>,
     #[cfg(not(Py_3_12))]
-    ptraceback: std::sync::Mutex<Option<Py<PyTraceback>>>,
+    ptraceback: Mutex<Option<Py<PyTraceback>>>,
 }
 
 impl PyErrStateNormalized {
@@ -176,7 +176,6 @@ impl PyErrStateNormalized {
     pub(crate) fn ptraceback<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTraceback>> {
         self.ptraceback
             .lock_py_attached(py)
-            .unwrap()
             .as_ref()
             .map(|traceback| traceback.bind(py).clone())
     }
@@ -192,7 +191,7 @@ impl PyErrStateNormalized {
 
     #[cfg(not(Py_3_12))]
     pub(crate) fn set_ptraceback<'py>(&self, py: Python<'py>, tb: Option<Bound<'py, PyTraceback>>) {
-        *self.ptraceback.lock_py_attached(py).unwrap() = tb.map(Bound::unbind);
+        *self.ptraceback.lock_py_attached(py) = tb.map(Bound::unbind);
     }
 
     #[cfg(Py_3_12)]
@@ -250,7 +249,7 @@ impl PyErrStateNormalized {
             ptype.map(|ptype| PyErrStateNormalized {
                 ptype: ptype.unbind(),
                 pvalue: pvalue.expect("normalized exception value missing").unbind(),
-                ptraceback: std::sync::Mutex::new(ptraceback.map(Bound::unbind)),
+                ptraceback: Mutex::new(ptraceback.map(Bound::unbind)),
             })
         }
     }
@@ -293,7 +292,6 @@ impl PyErrStateNormalized {
             ptraceback: Mutex::new(
                 self.ptraceback
                     .lock_py_attached(py)
-                    .unwrap()
                     .as_ref()
                     .map(|ptraceback| ptraceback.clone_ref(py)),
             ),
@@ -349,7 +347,6 @@ impl PyErrStateInner {
                 pvalue.into_ptr(),
                 ptraceback
                     .into_inner()
-                    .unwrap()
                     .map_or(core::ptr::null_mut(), Py::into_ptr),
             ),
         };

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -288,7 +288,7 @@ impl PyErrStateNormalized {
             ptype: self.ptype.clone_ref(py),
             pvalue: self.pvalue.clone_ref(py),
             #[cfg(not(Py_3_12))]
-            ptraceback: std::sync::Mutex::new(
+            ptraceback: Mutex::new(
                 self.ptraceback
                     .lock_py_attached(py)
                     .unwrap()

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -2,8 +2,9 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 use crate::platform::prelude::*;
+use crate::platform::sync::Once;
 use core::cell::{Cell, UnsafeCell};
-use std::{sync::Once, thread::ThreadId};
+use std::thread::ThreadId;
 
 #[cfg(not(Py_3_12))]
 use crate::sync::MutexExt;

--- a/src/err/err_state.rs
+++ b/src/err/err_state.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 use crate::platform::prelude::*;
+#[cfg(not(Py_3_12))]
+use crate::platform::sync::non_poison::Mutex;
 use crate::platform::sync::Once;
 use core::cell::{Cell, UnsafeCell};
 use std::thread::ThreadId;

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -30,3 +30,7 @@ pub mod pymodule;
 pub mod trampoline;
 pub mod unindent;
 pub mod wrap;
+
+pub mod platform {
+    pub use crate::platform::*;
+}

--- a/src/impl_/freelist.rs
+++ b/src/impl_/freelist.rs
@@ -9,8 +9,32 @@
 //! [1]: https://en.wikipedia.org/wiki/Free_list
 
 use crate::ffi;
+use crate::marker::Python;
 use crate::platform::prelude::*;
+use crate::platform::sync::non_poison::Mutex;
+use crate::sync::{MutexExt, PyOnceLock};
+
+use core::ops::DerefMut;
 use core::ptr::NonNull;
+
+pub struct FreeList(PyOnceLock<Mutex<PyObjectFreeList>>);
+
+impl FreeList {
+    #[expect(clippy::new_without_default, reason = "always called in const context")]
+    pub const fn new() -> Self {
+        Self(PyOnceLock::new())
+    }
+
+    pub fn get(
+        &self,
+        py: Python<'_>,
+        capacity: usize,
+    ) -> impl DerefMut<Target = PyObjectFreeList> + '_ {
+        self.0
+            .get_or_init(py, || Mutex::new(PyObjectFreeList::with_capacity(capacity)))
+            .lock_py_attached(py)
+    }
+}
 
 /// A free allocation list for PyObject ffi pointers.
 ///

--- a/src/impl_/freelist.rs
+++ b/src/impl_/freelist.rs
@@ -18,7 +18,6 @@ use core::ptr::NonNull;
 pub struct PyObjectFreeList {
     entries: Box<[Option<NonNull<ffi::PyObject>>]>,
     split: usize,
-    capacity: usize,
 }
 
 // safety: the pointers are never used internally and they are cleared when they are given out
@@ -29,11 +28,7 @@ impl PyObjectFreeList {
     pub fn with_capacity(capacity: usize) -> PyObjectFreeList {
         let entries = vec![None; capacity].into_boxed_slice();
 
-        PyObjectFreeList {
-            entries,
-            split: 0,
-            capacity,
-        }
+        PyObjectFreeList { entries, split: 0 }
     }
 
     /// Pops the first non empty item.
@@ -53,7 +48,7 @@ impl PyObjectFreeList {
     /// Inserts a value into the list. Returns `Some(val)` if the `PyObjectFreeList` is full.
     pub fn insert(&mut self, val: NonNull<ffi::PyObject>) -> Option<NonNull<ffi::PyObject>> {
         let next = self.split + 1;
-        if next < self.capacity {
+        if next < self.entries.len() {
             self.entries[self.split] = Some(val);
             self.split = next;
             None

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -3,6 +3,7 @@
 
 #[allow(unused_imports, reason = "conditionally used")]
 use crate::platform::prelude::*;
+use crate::platform::sync::non_poison::Mutex;
 use crate::{
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError},
     ffi,
@@ -26,7 +27,7 @@ use core::{
     marker::PhantomData,
     ptr::{self, NonNull},
 };
-use std::{sync::Mutex, thread};
+use std::thread;
 
 mod assertions;
 pub mod doc;
@@ -998,7 +999,7 @@ pub unsafe extern "C" fn alloc_with_freelist<T: PyClassWithFreeList>(
     // If this type is a variable type or the subtype is not equal to this type, we cannot use the
     // freelist
     if nitems == 0 && ptr::eq(subtype, self_type) {
-        let mut free_list = T::get_free_list(py).lock().unwrap();
+        let mut free_list = T::get_free_list(py).lock();
         if let Some(obj) = free_list.pop() {
             drop(free_list);
             unsafe { ffi::PyObject_Init(obj.as_ptr(), subtype) };
@@ -1023,7 +1024,7 @@ pub unsafe extern "C" fn free_with_freelist<T: PyClassWithFreeList>(obj: *mut c_
             T::type_object_raw(Python::assume_attached()),
             ffi::Py_TYPE(obj.as_ptr())
         );
-        let mut free_list = T::get_free_list(Python::assume_attached()).lock().unwrap();
+        let mut free_list = T::get_free_list(Python::assume_attached()).lock();
         if let Some(obj) = free_list.insert(obj) {
             drop(free_list);
             let ty = ffi::Py_TYPE(obj.as_ptr());

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -3,7 +3,6 @@
 
 #[allow(unused_imports, reason = "conditionally used")]
 use crate::platform::prelude::*;
-use crate::platform::sync::non_poison::Mutex;
 use crate::{
     exceptions::{PyAttributeError, PyNotImplementedError, PyRuntimeError},
     ffi,
@@ -21,6 +20,8 @@ use crate::{
     Borrowed, FromPyObject, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyClass, PyClassGuard, PyErr,
     PyResult, PyTypeCheck, PyTypeInfo, Python,
 };
+
+use core::ops::DerefMut;
 use core::{
     ffi::CStr,
     ffi::{c_int, c_void},
@@ -981,7 +982,7 @@ pub use generate_pyclass_richcompare_slot;
 /// Do not implement this trait manually. Instead, use `#[pyclass(freelist = N)]`
 /// on a Rust struct to implement it.
 pub trait PyClassWithFreeList: PyClass + generic_pyclass::Sealed {
-    fn get_free_list(py: Python<'_>) -> &'static Mutex<PyObjectFreeList>;
+    fn get_free_list(py: Python<'_>) -> impl DerefMut<Target = PyObjectFreeList>;
 }
 
 /// Implementation of tp_alloc for `freelist` classes.
@@ -999,7 +1000,7 @@ pub unsafe extern "C" fn alloc_with_freelist<T: PyClassWithFreeList>(
     // If this type is a variable type or the subtype is not equal to this type, we cannot use the
     // freelist
     if nitems == 0 && ptr::eq(subtype, self_type) {
-        let mut free_list = T::get_free_list(py).lock();
+        let mut free_list = T::get_free_list(py);
         if let Some(obj) = free_list.pop() {
             drop(free_list);
             unsafe { ffi::PyObject_Init(obj.as_ptr(), subtype) };
@@ -1024,7 +1025,7 @@ pub unsafe extern "C" fn free_with_freelist<T: PyClassWithFreeList>(obj: *mut c_
             T::type_object_raw(Python::assume_attached()),
             ffi::Py_TYPE(obj.as_ptr())
         );
-        let mut free_list = T::get_free_list(Python::assume_attached()).lock();
+        let mut free_list = T::get_free_list(Python::assume_attached());
         if let Some(obj) = free_list.insert(obj) {
             drop(free_list);
             let ty = ffi::Py_TYPE(obj.as_ptr());

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -7,6 +7,7 @@ use std::thread::{self, ThreadId};
 
 #[cfg(Py_3_14)]
 use crate::err::error_on_minusone;
+use crate::platform::sync::non_poison::Mutex;
 #[allow(deprecated)]
 use crate::sync::GILOnceCell;
 #[cfg(Py_3_14)]
@@ -19,8 +20,6 @@ use crate::{
     types::PyType,
     Bound, Py, PyAny, PyClass, PyErr, PyResult, Python,
 };
-
-use std::sync::Mutex;
 
 use super::PyClassItemsIter;
 
@@ -136,7 +135,7 @@ impl LazyTypeObjectInner {
 
         let thread_id = thread::current().id();
         {
-            let mut threads = self.initializing_threads.lock().unwrap();
+            let mut threads = self.initializing_threads.lock();
             if threads.contains(&thread_id) {
                 // Reentrant call: just return the type object, even if the
                 // `tp_dict` is not filled yet.
@@ -151,7 +150,7 @@ impl LazyTypeObjectInner {
         }
         impl Drop for InitializationGuard<'_> {
             fn drop(&mut self) {
-                let mut threads = self.initializing_threads.lock().unwrap();
+                let mut threads = self.initializing_threads.lock();
                 threads.retain(|id| *id != self.thread_id);
             }
         }
@@ -218,7 +217,7 @@ impl LazyTypeObjectInner {
             // (No further calls to get_or_init() will try to init, on any thread.)
             let mut threads = {
                 drop(guard);
-                self.initializing_threads.lock().unwrap()
+                self.initializing_threads.lock()
             };
             threads.clear();
             Ok(type_object.clone().unbind())

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -437,7 +437,6 @@ mod tests {
     fn pool_dec_refs_contains(obj: &Py<PyAny>) -> bool {
         POOL.pending_decrefs
             .lock()
-            .unwrap()
             .iter()
             .any(|pending| pending.is(obj))
     }

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -431,7 +431,6 @@ mod tests {
     fn pool_dec_refs_contains(obj: &Py<PyAny>) -> bool {
         POOL.pending_decrefs
             .lock()
-            .unwrap()
             .iter()
             .any(|pending| pending.is(obj))
     }

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -5,13 +5,13 @@ use crate::impl_::panic::PanicTrap;
 use crate::platform::prelude::*;
 use crate::{ffi, Py, PyAny, Python};
 
+#[cfg(not(pyo3_disable_reference_pool))]
+use crate::platform::sync::non_poison::Mutex;
 use core::cell::Cell;
 #[cfg_attr(pyo3_disable_reference_pool, allow(unused_imports))]
 use core::mem;
 #[cfg(not(pyo3_disable_reference_pool))]
 use core::sync::atomic::{AtomicBool, Ordering};
-#[cfg(not(pyo3_disable_reference_pool))]
-use std::sync::Mutex;
 
 std::thread_local! {
     /// This is an internal counter in pyo3 monitoring whether this thread is attached to the interpreter.
@@ -223,7 +223,7 @@ impl ReferencePool {
         //
         // If the order is reversed, the draining can run before the object
         // is pushed and it might be leaked.
-        self.pending_decrefs.lock().unwrap().push(obj);
+        self.pending_decrefs.lock().push(obj);
         self.dirty.store(true, Ordering::Relaxed);
     }
 
@@ -252,7 +252,7 @@ impl ReferencePool {
             return;
         }
 
-        let mut pending_decrefs = self.pending_decrefs.lock().unwrap();
+        let mut pending_decrefs = self.pending_decrefs.lock();
         if pending_decrefs.is_empty() {
             // We don't set the dirty flag under the mutex so it's possible to reach
             // this case as a false positive. Returning early avoids a store on false
@@ -418,7 +418,6 @@ mod tests {
             if !POOL
                 .pending_decrefs
                 .lock()
-                .unwrap()
                 .iter()
                 .any(|pending| pending.is(obj))
             {

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -5,13 +5,13 @@ use crate::impl_::panic::PanicTrap;
 use crate::platform::prelude::*;
 use crate::{ffi, Py, PyAny, Python};
 
+#[cfg(not(pyo3_disable_reference_pool))]
+use crate::platform::sync::non_poison::Mutex;
 use core::cell::Cell;
 #[cfg_attr(pyo3_disable_reference_pool, allow(unused_imports))]
 use core::mem;
 #[cfg(not(pyo3_disable_reference_pool))]
 use core::sync::atomic::{AtomicBool, Ordering};
-#[cfg(not(pyo3_disable_reference_pool))]
-use std::sync::Mutex;
 
 std::thread_local! {
     /// This is an internal counter in pyo3 monitoring whether this thread is attached to the interpreter.
@@ -218,7 +218,7 @@ impl ReferencePool {
 
     fn register_decref(&self, obj: Py<PyAny>) {
         self.dirty.store(true, Ordering::Relaxed);
-        self.pending_decrefs.lock().unwrap().push(obj);
+        self.pending_decrefs.lock().push(obj);
     }
 
     fn drop_deferred_references(&self, py: Python<'_>) {
@@ -246,7 +246,7 @@ impl ReferencePool {
             return;
         }
 
-        let mut pending_decrefs = self.pending_decrefs.lock().unwrap();
+        let mut pending_decrefs = self.pending_decrefs.lock();
         if pending_decrefs.is_empty() {
             // We don't set the dirty flag under the mutex so it's possible to reach
             // this case as a false positive. Returning early avoids a store on false
@@ -412,7 +412,6 @@ mod tests {
             if !POOL
                 .pending_decrefs
                 .lock()
-                .unwrap()
                 .iter()
                 .any(|pending| pending.is(obj))
             {

--- a/src/interpreter_lifecycle.rs
+++ b/src/interpreter_lifecycle.rs
@@ -129,7 +129,7 @@ pub(crate) fn ensure_initialized() {
             initialize();
         }
 
-        START.call_once_force(|_| unsafe {
+        START.call_once_force(|| unsafe {
             // Use call_once_force because if there is a panic because the interpreter is
             // not initialized, it's fine for the user to initialize the interpreter and
             // retry.

--- a/src/interpreter_lifecycle.rs
+++ b/src/interpreter_lifecycle.rs
@@ -1,17 +1,19 @@
 // TODO https://github.com/PyO3/pyo3/issues/5487
 #![allow(clippy::undocumented_unsafe_blocks)]
 
+use crate::platform::sync::Once;
+
 #[cfg(not(any(PyPy, GraalPy)))]
 use crate::{ffi, internal::state::AttachGuard, Python};
 
-static START: std::sync::Once = std::sync::Once::new();
+static START: Once = Once::new();
 
 #[cfg(not(any(PyPy, GraalPy)))]
 pub(crate) fn initialize() {
     // Protect against race conditions when Python is not yet initialized and multiple threads
     // concurrently call 'initialize()'. Note that we do not protect against
     // concurrent initialization of the Python runtime by other users of the Python C API.
-    START.call_once_force(|_| unsafe {
+    START.call_once_force(|| unsafe {
         // Use call_once_force because if initialization panics, it's okay to try again.
         if ffi::Py_IsInitialized() == 0 {
             ffi::Py_InitializeEx(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,9 +364,6 @@ pub(crate) mod ffi_ptr_ext;
 pub(crate) mod py_result_ext;
 pub(crate) mod sealed;
 
-#[doc(hidden)]
-pub mod platform;
-
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///
 /// Prefer using the same content from `pyo3::pyclass`, e.g. `use pyo3::pyclass::CompareOp` instead
@@ -415,6 +412,9 @@ mod tests;
 mod internal;
 #[macro_use]
 mod internal_tricks;
+
+#[doc(hidden)]
+pub mod platform;
 
 // Macro dependencies, also contains macros exported for use across the codebase and
 // in expanded macros.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,8 @@ pub(crate) mod ffi_ptr_ext;
 pub(crate) mod py_result_ext;
 pub(crate) mod sealed;
 
-mod platform;
+#[doc(hidden)]
+pub mod platform;
 
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,8 +413,7 @@ mod internal;
 #[macro_use]
 mod internal_tricks;
 
-#[doc(hidden)]
-pub mod platform;
+mod platform;
 
 // Macro dependencies, also contains macros exported for use across the codebase and
 // in expanded macros.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -14,6 +14,8 @@ pub(crate) mod prelude {
     pub use std::eprintln;
 }
 
+pub mod sync;
+
 #[cfg(feature = "hashbrown")]
 pub use hashbrown::{HashMap, HashSet};
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,5 +1,6 @@
 //! This module is to support platform compatibility with `no_std` environments.
 #![allow(unused_imports)]
+#![doc(hidden)]
 
 /// This prelude is intended to be used instead of the prelude from `std`.
 pub(crate) mod prelude {

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -1,5 +1,3 @@
-// TODO compile_error if parking_lot and std are both disabled
-
 #[cfg(not(cfg_select))]
 use crate::internal::macros::cfg_select;
 use crate::sealed;

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -3,12 +3,18 @@
 use crate::sealed;
 use crate::sync::OnceExt;
 
-#[cfg(feature = "parking_lot")]
-type OnceInner = parking_lot::Once;
-
-#[cfg(not(feature = "parking_lot"))]
-#[allow(clippy::disallowed_types)]
-type OnceInner = std::sync::Once;
+cfg_select! {
+    wip_feature_std => {
+        #[allow(clippy::disallowed_types)]
+        type OnceInner = std::sync::Once;
+    },
+    feature = "parking_lot" => {
+        type OnceInner = parking_lot::Once;
+    },
+    _ => {
+        compile_error!("Please enable at least one of the following features: std, parking_lot");
+    },
+}
 
 pub struct Once(OnceInner);
 
@@ -37,15 +43,19 @@ impl Once {
         self.0.call_once_force(move |_| f());
     }
 
-    #[cfg(feature = "parking_lot")]
-    pub fn is_completed(&self) -> bool {
-        matches!(self.0.state(), parking_lot::OnceState::Done)
-    }
-
-    #[cfg(not(feature = "parking_lot"))]
     #[inline(always)]
     pub fn is_completed(&self) -> bool {
-        self.0.is_completed()
+        cfg_select! {
+            wip_feature_std => {
+                self.0.is_completed()
+            },
+            feature = "parking_lot" => {
+                matches!(self.0.state(), parking_lot::OnceState::Done)
+            },
+            _ => {
+                compile_error!("Please enable at least one of the following features: std, parking_lot")
+            }
+        }
     }
 }
 
@@ -67,20 +77,26 @@ impl OnceExt for Once {
 }
 
 pub mod non_poison {
-    #[cfg(feature = "parking_lot")]
-    pub use parking_lot::{Mutex, MutexGuard};
+    cfg_select! {
+        wip_feature_std => {
+            pub use std::sync::MutexGuard;
+        },
+        feature = "parking_lot" => {
+            pub use parking_lot::{Mutex, MutexGuard};
+        },
+        _ => {
+            compile_error!("Please enable at least one of the following features: std, parking_lot");
+        },
+    }
 
-    #[cfg(not(feature = "parking_lot"))]
-    pub use std::sync::MutexGuard;
-
-    #[cfg(not(feature = "parking_lot"))]
+    #[cfg(wip_feature_std)]
     #[derive(Default, Debug)]
     pub struct Mutex<T: ?Sized> {
         #[allow(clippy::disallowed_types)]
         inner: std::sync::Mutex<T>,
     }
 
-    #[cfg(not(feature = "parking_lot"))]
+    #[cfg(wip_feature_std)]
     impl<T> Mutex<T> {
         #[inline(always)]
         pub const fn new(t: T) -> Mutex<T> {
@@ -90,19 +106,12 @@ pub mod non_poison {
             }
         }
 
-        #[cfg(feature = "parking_lot")]
-        #[inline(always)]
-        pub fn into_inner(self) -> T {
-            self.inner.into_inner()
-        }
-
-        #[cfg(not(feature = "parking_lot"))]
         pub fn into_inner(self) -> T {
             self.inner.into_inner().unwrap_or_else(|e| e.into_inner())
         }
     }
 
-    #[cfg(not(feature = "parking_lot"))]
+    #[cfg(wip_feature_std)]
     impl<T: ?Sized> Mutex<T> {
         #[inline(always)]
         pub fn lock(&self) -> MutexGuard<'_, T> {
@@ -112,7 +121,7 @@ pub mod non_poison {
         // TODO try_lock
     }
 
-    #[cfg(not(feature = "parking_lot"))]
+    #[cfg(wip_feature_std)]
     impl<T> From<T> for Mutex<T> {
         #[inline(always)]
         fn from(t: T) -> Self {
@@ -123,10 +132,10 @@ pub mod non_poison {
         }
     }
 
-    #[cfg(not(feature = "parking_lot"))]
+    #[cfg(wip_feature_std)]
     impl<T> crate::sealed::Sealed for Mutex<T> {}
 
-    #[cfg(not(feature = "parking_lot"))]
+    #[cfg(wip_feature_std)]
     impl<T> crate::sync::MutexExt<T> for Mutex<T> {
         type LockResult<'a>
             = MutexGuard<'a, T>

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -1,9 +1,13 @@
 // TODO compile_error if parking_lot and std are both disabled
 
+use crate::sealed;
+use crate::sync::OnceExt;
+
 #[cfg(feature = "parking_lot")]
 type OnceInner = parking_lot::Once;
 
 #[cfg(not(feature = "parking_lot"))]
+#[allow(clippy::disallowed_types)]
 type OnceInner = std::sync::Once;
 
 pub struct Once(OnceInner);
@@ -42,6 +46,23 @@ impl Once {
     #[inline(always)]
     pub fn is_completed(&self) -> bool {
         self.0.is_completed()
+    }
+}
+
+impl sealed::Sealed for Once {}
+impl OnceExt for Once {
+    type OnceState = ();
+
+    fn call_once_py_attached(&self, py: crate::prelude::Python<'_>, f: impl FnOnce()) {
+        self.0.call_once_force_py_attached(py, move |_| f());
+    }
+
+    fn call_once_force_py_attached(
+        &self,
+        py: crate::prelude::Python<'_>,
+        f: impl FnOnce(&Self::OnceState),
+    ) {
+        self.0.call_once_force_py_attached(py, |_| f(&()));
     }
 }
 

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -41,16 +41,17 @@ impl Once {
 
     #[inline(always)]
     pub fn is_completed(&self) -> bool {
-        cfg_select! {
-            wip_feature_std => {
-                self.0.is_completed()
-            },
-            feature = "parking_lot" => {
-                matches!(self.0.state(), parking_lot::OnceState::Done)
-            },
-            _ => {
-                compile_error!("Please enable at least one of the following features: std, parking_lot")
-            }
+        #[cfg(wip_feature_std)]
+        {
+            self.0.is_completed()
+        }
+        #[cfg(all(not(wip_feature_std), feature = "parking_lot"))]
+        {
+            matches!(self.0.state(), parking_lot::OnceState::Done)
+        }
+        #[cfg(all(not(wip_feature_std), feature = "parking_lot"))]
+        {
+            compile_error!("Please enable at least one of the following features: std, parking_lot")
         }
     }
 }

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -1,20 +1,17 @@
-#[cfg(not(cfg_select))]
-use crate::internal::macros::cfg_select;
 use crate::sealed;
 use crate::sync::OnceExt;
 
-cfg_select! {
-    wip_feature_std => {
-        #[allow(clippy::disallowed_types)]
-        type OnceInner = std::sync::Once;
-    },
-    feature = "parking_lot" => {
-        type OnceInner = parking_lot::Once;
-    },
-    _ => {
-        compile_error!("Please enable at least one of the following features: std, parking_lot");
-    },
-}
+// TODO replace with cfg_select when MSRV >= 1.95.0
+
+#[cfg(wip_feature_std)]
+#[allow(clippy::disallowed_types)]
+type OnceInner = std::sync::Once;
+
+#[cfg(all(not(wip_feature_std), feature = "parking_lot"))]
+type OnceInner = parking_lot::Once;
+
+#[cfg(all(not(wip_feature_std), not(feature = "parking_lot")))]
+compile_error!("Please enable at least one of the following features: std, parking_lot");
 
 pub struct Once(OnceInner);
 
@@ -24,7 +21,6 @@ impl Default for Once {
     }
 }
 
-// #[cfg(feature = "parking_lot")]
 impl Once {
     /// Creates a new `Once` value.
     #[inline(always)]
@@ -77,17 +73,15 @@ impl OnceExt for Once {
 }
 
 pub mod non_poison {
-    cfg_select! {
-        wip_feature_std => {
-            pub use std::sync::MutexGuard;
-        },
-        feature = "parking_lot" => {
-            pub use parking_lot::{Mutex, MutexGuard};
-        },
-        _ => {
-            compile_error!("Please enable at least one of the following features: std, parking_lot");
-        },
-    }
+    // TODO replace with cfg_select when MSRV >= 1.95.0
+    #[cfg(wip_feature_std)]
+    pub use std::sync::MutexGuard;
+
+    #[cfg(all(not(wip_feature_std), feature = "parking_lot"))]
+    pub use parking_lot::{Mutex, MutexGuard};
+
+    #[cfg(all(not(wip_feature_std), not(feature = "parking_lot")))]
+    compile_error!("Please enable at least one of the following features: std, parking_lot");
 
     #[cfg(wip_feature_std)]
     #[derive(Default, Debug)]
@@ -114,7 +108,7 @@ pub mod non_poison {
     #[cfg(wip_feature_std)]
     impl<T: ?Sized> Mutex<T> {
         #[inline(always)]
-        pub fn lock(&self) -> MutexGuard<'_, T> {
+        pub fn lock(&self) -> std::sync::MutexGuard<'_, T> {
             self.inner.lock().unwrap_or_else(|e| e.into_inner())
         }
 

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -8,6 +8,12 @@ type OnceInner = std::sync::Once;
 
 pub struct Once(OnceInner);
 
+impl Default for Once {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // #[cfg(feature = "parking_lot")]
 impl Once {
     /// Creates a new `Once` value.

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -1,5 +1,7 @@
 // TODO compile_error if parking_lot and std are both disabled
 
+#[cfg(not(cfg_select))]
+use crate::internal::macros::cfg_select;
 use crate::sealed;
 use crate::sync::OnceExt;
 

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -89,6 +89,17 @@ pub mod non_poison {
                 inner: std::sync::Mutex::new(t),
             }
         }
+
+        #[cfg(feature = "parking_lot")]
+        #[inline(always)]
+        pub fn into_inner(self) -> T {
+            self.inner.into_inner()
+        }
+
+        #[cfg(not(feature = "parking_lot"))]
+        pub fn into_inner(self) -> T {
+            self.inner.into_inner().unwrap_or_else(|e| e.into_inner())
+        }
     }
 
     #[cfg(not(feature = "parking_lot"))]

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -1,0 +1,104 @@
+// TODO compile_error if parking_lot and std are both disabled
+
+#[cfg(feature = "parking_lot")]
+type OnceInner = parking_lot::Once;
+
+#[cfg(not(feature = "parking_lot"))]
+type OnceInner = std::sync::Once;
+
+pub struct Once(OnceInner);
+
+// #[cfg(feature = "parking_lot")]
+impl Once {
+    /// Creates a new `Once` value.
+    #[inline(always)]
+    #[must_use]
+    pub const fn new() -> Once {
+        Once(OnceInner::new())
+    }
+
+    #[inline]
+    pub fn call_once(&self, f: impl FnOnce()) {
+        self.0.call_once(f);
+    }
+
+    #[inline]
+    pub fn call_once_force(&self, f: impl FnOnce()) {
+        self.0.call_once_force(move |_| f());
+    }
+
+    #[cfg(feature = "parking_lot")]
+    pub fn is_completed(&self) -> bool {
+        matches!(self.0.state(), parking_lot::OnceState::Done)
+    }
+
+    #[cfg(not(feature = "parking_lot"))]
+    #[inline(always)]
+    pub fn is_completed(&self) -> bool {
+        self.0.is_completed()
+    }
+}
+
+pub mod non_poison {
+    #[cfg(feature = "parking_lot")]
+    pub use parking_lot::{Mutex, MutexGuard};
+
+    #[cfg(not(feature = "parking_lot"))]
+    pub use std::sync::MutexGuard;
+
+    #[cfg(not(feature = "parking_lot"))]
+    #[derive(Default, Debug)]
+    pub struct Mutex<T: ?Sized> {
+        #[allow(clippy::disallowed_types)]
+        inner: std::sync::Mutex<T>,
+    }
+
+    #[cfg(not(feature = "parking_lot"))]
+    impl<T> Mutex<T> {
+        #[inline(always)]
+        pub const fn new(t: T) -> Mutex<T> {
+            Mutex {
+                #[allow(clippy::disallowed_types)]
+                inner: std::sync::Mutex::new(t),
+            }
+        }
+    }
+
+    #[cfg(not(feature = "parking_lot"))]
+    impl<T: ?Sized> Mutex<T> {
+        #[inline(always)]
+        pub fn lock(&self) -> MutexGuard<'_, T> {
+            self.inner.lock().unwrap_or_else(|e| e.into_inner())
+        }
+
+        // TODO try_lock
+    }
+
+    #[cfg(not(feature = "parking_lot"))]
+    impl<T> From<T> for Mutex<T> {
+        #[inline(always)]
+        fn from(t: T) -> Self {
+            Mutex {
+                #[allow(clippy::disallowed_types)]
+                inner: std::sync::Mutex::new(t),
+            }
+        }
+    }
+
+    #[cfg(not(feature = "parking_lot"))]
+    impl<T> crate::sealed::Sealed for Mutex<T> {}
+
+    #[cfg(not(feature = "parking_lot"))]
+    impl<T> crate::sync::MutexExt<T> for Mutex<T> {
+        type LockResult<'a>
+            = MutexGuard<'a, T>
+        where
+            T: 'a;
+
+        fn lock_py_attached(&self, py: crate::prelude::Python<'_>) -> Self::LockResult<'_> {
+            self.inner
+                .lock_py_attached(py)
+                .unwrap_or_else(|e| e.into_inner())
+        }
+    }
+}

--- a/src/platform/sync.rs
+++ b/src/platform/sync.rs
@@ -41,17 +41,10 @@ impl Once {
 
     #[inline(always)]
     pub fn is_completed(&self) -> bool {
-        #[cfg(wip_feature_std)]
-        {
-            self.0.is_completed()
-        }
-        #[cfg(all(not(wip_feature_std), feature = "parking_lot"))]
-        {
-            matches!(self.0.state(), parking_lot::OnceState::Done)
-        }
-        #[cfg(all(not(wip_feature_std), feature = "parking_lot"))]
-        {
-            compile_error!("Please enable at least one of the following features: std, parking_lot")
+        cfg_select! {
+            wip_feature_std => self.0.is_completed(),
+            feature = "parking_lot" => matches!(self.0.state(), parking_lot::OnceState::Done),
+            _ => compile_error!("Please enable at least one of the following features: std, parking_lot"),
         }
     }
 }

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -65,6 +65,8 @@ impl Sealed for ModuleDef {}
 impl<T: crate::type_object::PyTypeInfo> Sealed for PyNativeTypeInitializer<T> {}
 impl<T: crate::pyclass::PyClass> Sealed for PyClassInitializer<T> {}
 
+#[cfg(wip_feature_std)]
+#[allow(clippy::disallowed_types)]
 impl Sealed for std::sync::Once {}
 #[cfg(wip_feature_std)]
 #[allow(clippy::disallowed_types)]

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -66,6 +66,8 @@ impl<T: crate::type_object::PyTypeInfo> Sealed for PyNativeTypeInitializer<T> {}
 impl<T: crate::pyclass::PyClass> Sealed for PyClassInitializer<T> {}
 
 impl Sealed for std::sync::Once {}
+#[cfg(wip_feature_std)]
+#[allow(clippy::disallowed_types)]
 impl<T> Sealed for std::sync::Mutex<T> {}
 #[cfg(feature = "lock_api")]
 impl<R, T> Sealed for lock_api::Mutex<R, T> {}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -335,6 +335,7 @@ pub trait RwLockExt<T>: rwlock_ext_sealed::Sealed {
     fn write_py_attached(&self, py: Python<'_>) -> Self::WriteLockResult<'_>;
 }
 
+#[cfg(wip_feature_std)]
 #[allow(clippy::disallowed_types)]
 impl OnceExt for std::sync::Once {
     type OnceState = std::sync::OnceState;
@@ -683,6 +684,7 @@ where
     }
 }
 
+#[cfg(wip_feature_std)]
 #[cold]
 #[allow(clippy::disallowed_types)]
 fn init_once_py_attached<F, T>(once: &std::sync::Once, _py: Python<'_>, f: F)
@@ -700,6 +702,7 @@ where
     });
 }
 
+#[cfg(wip_feature_std)]
 #[cold]
 #[allow(clippy::disallowed_types)]
 fn init_once_force_py_attached<F, T>(once: &std::sync::Once, _py: Python<'_>, f: F)
@@ -767,8 +770,10 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "macros")]
     use std::sync::Barrier;
+    #[cfg(wip_feature_std)]
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::Mutex;
+    #[cfg(wip_feature_std)]
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::{Once, OnceState};
 
@@ -842,6 +847,7 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
+    #[cfg(wip_feature_std)]
     fn test_once_ext() {
         macro_rules! test_once {
             ($once:expr, $is_poisoned:expr) => {{
@@ -887,6 +893,7 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
+    #[cfg(wip_feature_std)]
     #[test]
     fn test_once_lock_ext() {
         let cell = std::sync::OnceLock::new();
@@ -904,6 +911,7 @@ mod tests {
 
     #[cfg(feature = "macros")]
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
+    #[cfg(wip_feature_std)]
     #[test]
     fn test_mutex_ext() {
         let barrier = Barrier::new(2);
@@ -996,6 +1004,7 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
+    #[cfg(wip_feature_std)]
     #[test]
     fn test_mutex_ext_poison() {
         let mutex = Mutex::new(42);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -774,6 +774,7 @@ mod tests {
     use std::sync::Barrier;
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::Mutex;
+    #[cfg(not(target_arch = "wasm32"))]
     use std::sync::{Once, OnceState};
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -769,6 +769,7 @@ mod tests {
     use std::sync::Barrier;
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::Mutex;
+    #[cfg(not(target_arch = "wasm32"))]
     use std::sync::{Once, OnceState};
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -9,6 +9,7 @@
 //! interpreter.
 //!
 //! This module provides synchronization primitives which are able to synchronize under these conditions.
+use crate::platform::sync::Once;
 use crate::{
     internal::state::SuspendAttach,
     sealed::Sealed,
@@ -16,7 +17,6 @@ use crate::{
     Bound, Py, Python,
 };
 use core::{cell::UnsafeCell, marker::PhantomData, mem::MaybeUninit};
-use std::sync::{Once, OnceState};
 
 pub mod critical_section;
 pub(crate) mod once_lock;
@@ -160,7 +160,7 @@ impl<T> GILOnceCell<T> {
         // NB this can block, but since this is only writing a single value and
         // does not call arbitrary python code, we don't need to worry about
         // deadlocks with the GIL.
-        self.once.call_once_force(|_| {
+        self.once.call_once_force(|| {
             // SAFETY: no other threads can be writing this value, because we are
             // inside the `call_once_force` closure.
             unsafe {
@@ -335,8 +335,9 @@ pub trait RwLockExt<T>: rwlock_ext_sealed::Sealed {
     fn write_py_attached(&self, py: Python<'_>) -> Self::WriteLockResult<'_>;
 }
 
-impl OnceExt for Once {
-    type OnceState = OnceState;
+#[allow(clippy::disallowed_types)]
+impl OnceExt for std::sync::Once {
+    type OnceState = std::sync::OnceState;
 
     fn call_once_py_attached(&self, py: Python<'_>, f: impl FnOnce()) {
         if self.is_completed() {
@@ -346,7 +347,7 @@ impl OnceExt for Once {
         init_once_py_attached(self, py, f)
     }
 
-    fn call_once_force_py_attached(&self, py: Python<'_>, f: impl FnOnce(&OnceState)) {
+    fn call_once_force_py_attached(&self, py: Python<'_>, f: impl FnOnce(&std::sync::OnceState)) {
         if self.is_completed() {
             return;
         }
@@ -683,7 +684,8 @@ where
 }
 
 #[cold]
-fn init_once_py_attached<F, T>(once: &Once, _py: Python<'_>, f: F)
+#[allow(clippy::disallowed_types)]
+fn init_once_py_attached<F, T>(once: &std::sync::Once, _py: Python<'_>, f: F)
 where
     F: FnOnce() -> T,
 {
@@ -699,9 +701,10 @@ where
 }
 
 #[cold]
-fn init_once_force_py_attached<F, T>(once: &Once, _py: Python<'_>, f: F)
+#[allow(clippy::disallowed_types)]
+fn init_once_force_py_attached<F, T>(once: &std::sync::Once, _py: Python<'_>, f: F)
 where
-    F: FnOnce(&OnceState) -> T,
+    F: FnOnce(&std::sync::OnceState) -> T,
 {
     // SAFETY: detach from the runtime right before a possibly blocking call
     // then reattach when the blocking call completes and before calling
@@ -766,6 +769,7 @@ mod tests {
     use std::sync::Barrier;
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::Mutex;
+    use std::sync::{Once, OnceState};
 
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "macros")]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -340,6 +340,7 @@ pub trait RwLockExt<T>: rwlock_ext_sealed::Sealed {
     fn write_py_attached(&self, py: Python<'_>) -> Self::WriteLockResult<'_>;
 }
 
+#[cfg(wip_feature_std)]
 #[allow(clippy::disallowed_types)]
 impl OnceExt for std::sync::Once {
     type OnceState = std::sync::OnceState;
@@ -688,6 +689,7 @@ where
     }
 }
 
+#[cfg(wip_feature_std)]
 #[cold]
 #[allow(clippy::disallowed_types)]
 fn init_once_py_attached<F, T>(once: &std::sync::Once, _py: Python<'_>, f: F)
@@ -705,6 +707,7 @@ where
     });
 }
 
+#[cfg(wip_feature_std)]
 #[cold]
 #[allow(clippy::disallowed_types)]
 fn init_once_force_py_attached<F, T>(once: &std::sync::Once, _py: Python<'_>, f: F)
@@ -772,8 +775,10 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "macros")]
     use std::sync::Barrier;
+    #[cfg(wip_feature_std)]
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::Mutex;
+    #[cfg(wip_feature_std)]
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::{Once, OnceState};
 
@@ -847,6 +852,7 @@ mod tests {
 
     #[test]
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
+    #[cfg(wip_feature_std)]
     fn test_once_ext() {
         macro_rules! test_once {
             ($once:expr, $is_poisoned:expr) => {{
@@ -892,6 +898,7 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
+    #[cfg(wip_feature_std)]
     #[test]
     fn test_once_lock_ext() {
         let cell = std::sync::OnceLock::new();
@@ -909,6 +916,7 @@ mod tests {
 
     #[cfg(feature = "macros")]
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
+    #[cfg(wip_feature_std)]
     #[test]
     fn test_mutex_ext() {
         let barrier = Barrier::new(2);
@@ -1001,6 +1009,7 @@ mod tests {
     }
 
     #[cfg(not(target_arch = "wasm32"))] // We are building wasm Python with pthreads disabled
+    #[cfg(wip_feature_std)]
     #[test]
     fn test_mutex_ext_poison() {
         let mutex = Mutex::new(42);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -9,6 +9,7 @@
 //! interpreter.
 //!
 //! This module provides synchronization primitives which are able to synchronize under these conditions.
+use crate::platform::sync::Once;
 use crate::{
     internal::state::SuspendAttach,
     sealed::Sealed,
@@ -16,7 +17,6 @@ use crate::{
     Bound, Py, Python,
 };
 use core::{cell::UnsafeCell, marker::PhantomData, mem::MaybeUninit};
-use std::sync::{Once, OnceState};
 
 pub mod critical_section;
 #[cfg(all(not(Py_LIMITED_API), Py_3_13))]
@@ -165,7 +165,7 @@ impl<T> GILOnceCell<T> {
         // NB this can block, but since this is only writing a single value and
         // does not call arbitrary python code, we don't need to worry about
         // deadlocks with the GIL.
-        self.once.call_once_force(|_| {
+        self.once.call_once_force(|| {
             // SAFETY: no other threads can be writing this value, because we are
             // inside the `call_once_force` closure.
             unsafe {
@@ -340,8 +340,9 @@ pub trait RwLockExt<T>: rwlock_ext_sealed::Sealed {
     fn write_py_attached(&self, py: Python<'_>) -> Self::WriteLockResult<'_>;
 }
 
-impl OnceExt for Once {
-    type OnceState = OnceState;
+#[allow(clippy::disallowed_types)]
+impl OnceExt for std::sync::Once {
+    type OnceState = std::sync::OnceState;
 
     fn call_once_py_attached(&self, py: Python<'_>, f: impl FnOnce()) {
         if self.is_completed() {
@@ -351,7 +352,7 @@ impl OnceExt for Once {
         init_once_py_attached(self, py, f)
     }
 
-    fn call_once_force_py_attached(&self, py: Python<'_>, f: impl FnOnce(&OnceState)) {
+    fn call_once_force_py_attached(&self, py: Python<'_>, f: impl FnOnce(&std::sync::OnceState)) {
         if self.is_completed() {
             return;
         }
@@ -688,7 +689,8 @@ where
 }
 
 #[cold]
-fn init_once_py_attached<F, T>(once: &Once, _py: Python<'_>, f: F)
+#[allow(clippy::disallowed_types)]
+fn init_once_py_attached<F, T>(once: &std::sync::Once, _py: Python<'_>, f: F)
 where
     F: FnOnce() -> T,
 {
@@ -704,9 +706,10 @@ where
 }
 
 #[cold]
-fn init_once_force_py_attached<F, T>(once: &Once, _py: Python<'_>, f: F)
+#[allow(clippy::disallowed_types)]
+fn init_once_force_py_attached<F, T>(once: &std::sync::Once, _py: Python<'_>, f: F)
 where
-    F: FnOnce(&OnceState) -> T,
+    F: FnOnce(&std::sync::OnceState) -> T,
 {
     // SAFETY: detach from the runtime right before a possibly blocking call
     // then reattach when the blocking call completes and before calling
@@ -771,6 +774,7 @@ mod tests {
     use std::sync::Barrier;
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::Mutex;
+    use std::sync::{Once, OnceState};
 
     #[cfg(not(target_arch = "wasm32"))]
     #[cfg(feature = "macros")]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -407,6 +407,8 @@ impl<T> OnceLockExt<T> for std::sync::OnceLock<T> {
     }
 }
 
+#[cfg(wip_feature_std)]
+#[allow(clippy::disallowed_types)]
 impl<T> MutexExt<T> for std::sync::Mutex<T> {
     type LockResult<'a>
         = std::sync::LockResult<std::sync::MutexGuard<'a, T>>
@@ -750,6 +752,7 @@ mod rwlock_ext_sealed {
     impl<R, T> Sealed for alloc::sync::Arc<lock_api::RwLock<R, T>> {}
 }
 
+#[allow(clippy::disallowed_types, reason = "tests")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -412,6 +412,8 @@ impl<T> OnceLockExt<T> for std::sync::OnceLock<T> {
     }
 }
 
+#[cfg(wip_feature_std)]
+#[allow(clippy::disallowed_types)]
 impl<T> MutexExt<T> for std::sync::Mutex<T> {
     type LockResult<'a>
         = std::sync::LockResult<std::sync::MutexGuard<'a, T>>
@@ -755,6 +757,7 @@ mod rwlock_ext_sealed {
     impl<R, T> Sealed for alloc::sync::Arc<lock_api::RwLock<R, T>> {}
 }
 
+#[allow(clippy::disallowed_types, reason = "tests")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -335,6 +335,7 @@ impl<'py> TryFrom<&Bound<'py, PyAny>> for Bound<'py, PyByteArray> {
     }
 }
 
+#[allow(clippy::disallowed_types, reason = "tests")]
 #[cfg(test)]
 mod tests {
     use crate::types::{PyAnyMethods, PyByteArray, PyByteArrayMethods};

--- a/src/types/bytearray.rs
+++ b/src/types/bytearray.rs
@@ -482,11 +482,11 @@ mod tests {
     #[test]
     fn test_data_integrity_in_critical_section() {
         use crate::instance::Py;
+        use crate::platform::sync::non_poison::Mutex;
         use crate::sync::{critical_section::with_critical_section, MutexExt};
 
         use core::sync::atomic::{AtomicBool, Ordering};
         use core::time::Duration;
-        use std::sync::Mutex;
         use std::thread;
         use std::thread::ScopedJoinHandle;
 
@@ -509,12 +509,12 @@ mod tests {
             data: &Mutex<Py<PyByteArray>>,
             py: Python<'py>,
         ) -> Bound<'py, PyByteArray> {
-            data.lock_py_attached(py).unwrap().bind(py).clone()
+            data.lock_py_attached(py).bind(py).clone()
         }
 
         fn set_data(data: &Mutex<Py<PyByteArray>>, new: Bound<'_, PyByteArray>) {
             let py = new.py();
-            *data.lock_py_attached(py).unwrap() = new.unbind()
+            *data.lock_py_attached(py) = new.unbind()
         }
 
         let running = AtomicBool::new(true);

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -5,7 +5,7 @@
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
 use pyo3::ffi;
-use pyo3::platform::sync::non_poison::Mutex;
+use pyo3::platform::sync::{non_poison::Mutex, Once};
 use pyo3::prelude::*;
 #[cfg(not(Py_GIL_DISABLED))]
 use pyo3::py_run;
@@ -14,7 +14,6 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::sync::Arc;
-use std::sync::Once;
 
 mod test_utils;
 

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -5,6 +5,7 @@
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
 use pyo3::ffi;
+use pyo3::platform::sync::non_poison::Mutex;
 use pyo3::prelude::*;
 #[cfg(not(Py_GIL_DISABLED))]
 use pyo3::py_run;
@@ -12,8 +13,8 @@ use pyo3::py_run;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::Arc;
 use std::sync::Once;
-use std::sync::{Arc, Mutex};
 
 mod test_utils;
 
@@ -500,7 +501,7 @@ struct DropDuringTraversal {
 impl DropDuringTraversal {
     #[expect(clippy::unnecessary_wraps)]
     fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-        let mut cycle_ref = self.cycle.lock().unwrap();
+        let mut cycle_ref = self.cycle.lock();
         *cycle_ref = None;
         Ok(())
     }
@@ -522,7 +523,7 @@ fn drop_during_traversal_with_gil() {
         )
         .unwrap();
 
-        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
+        *inst.borrow_mut(py).cycle.lock() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         let ptr = inst.as_ptr();
@@ -556,7 +557,7 @@ fn drop_during_traversal_without_gil() {
         )
         .unwrap();
 
-        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
+        *inst.borrow_mut(py).cycle.lock() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         inst
@@ -791,7 +792,7 @@ fn test_drop_buffer_during_traversal_without_gil() {
     impl BufferDropDuringTraversal {
         #[expect(clippy::unnecessary_wraps)]
         fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-            self.inner.lock().unwrap().take();
+            self.inner.lock().take();
             Ok(())
         }
 

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -5,7 +5,6 @@
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
 use pyo3::ffi;
-use pyo3::platform::sync::{non_poison::Mutex, Once};
 use pyo3::prelude::*;
 #[cfg(not(Py_GIL_DISABLED))]
 use pyo3::py_run;
@@ -13,7 +12,10 @@ use pyo3::py_run;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+#[cfg(wip_feature_std)]
 use std::sync::Arc;
+#[cfg(wip_feature_std)]
+use std::sync::{Mutex, Once};
 
 mod test_utils;
 
@@ -71,6 +73,7 @@ fn multithreaded_class_with_freelist() {
 /// Helper function to create a pair of objects that can be used to test drops;
 /// the first object is a guard that records when it has been dropped, the second
 /// object is a check that can be used to assert that the guard has been dropped.
+#[cfg(wip_feature_std)]
 fn drop_check() -> (DropGuard, DropCheck) {
     let flag = Arc::new(Once::new());
     (DropGuard(flag.clone()), DropCheck(flag))
@@ -78,14 +81,18 @@ fn drop_check() -> (DropGuard, DropCheck) {
 
 /// Helper structure that records when it has been dropped
 #[pyclass]
+#[cfg(wip_feature_std)]
 struct DropGuard(Arc<Once>);
+#[cfg(wip_feature_std)]
 impl Drop for DropGuard {
     fn drop(&mut self) {
         self.0.call_once(|| ());
     }
 }
 
+#[cfg(wip_feature_std)]
 struct DropCheck(Arc<Once>);
+#[cfg(wip_feature_std)]
 impl DropCheck {
     #[track_caller]
     fn assert_not_dropped(&self) {
@@ -125,6 +132,7 @@ impl DropCheck {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn data_is_dropped() {
     #[pyclass]
     struct DataIsDropped {
@@ -150,12 +158,14 @@ fn data_is_dropped() {
     check2.assert_dropped();
 }
 
+#[cfg(wip_feature_std)]
 #[pyclass(subclass)]
 struct CycleWithClear {
     cycle: Option<Py<PyAny>>,
     _guard: DropGuard,
 }
 
+#[cfg(wip_feature_std)]
 #[pymethods]
 impl CycleWithClear {
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
@@ -168,6 +178,7 @@ impl CycleWithClear {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn test_cycle_clear() {
     let (guard, check) = drop_check();
 
@@ -235,6 +246,7 @@ fn gc_null_traversal() {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn inheritance_with_new_methods_with_drop() {
     #[pyclass(subclass)]
     struct BaseClassWithDrop {
@@ -490,12 +502,14 @@ fn traverse_cannot_be_hijacked() {
     })
 }
 
+#[cfg(wip_feature_std)]
 #[pyclass]
 struct DropDuringTraversal {
     cycle: Mutex<Option<Py<Self>>>,
     _guard: DropGuard,
 }
 
+#[cfg(wip_feature_std)]
 #[pymethods]
 impl DropDuringTraversal {
     #[expect(clippy::unnecessary_wraps)]
@@ -507,6 +521,7 @@ impl DropDuringTraversal {
 }
 
 #[cfg(not(pyo3_disable_reference_pool))]
+#[cfg(wip_feature_std)]
 #[test]
 fn drop_during_traversal_with_gil() {
     let (guard, check) = drop_check();
@@ -541,6 +556,7 @@ fn drop_during_traversal_with_gil() {
 }
 
 #[cfg(not(pyo3_disable_reference_pool))]
+#[cfg(wip_feature_std)]
 #[test]
 fn drop_during_traversal_without_gil() {
     let (guard, check) = drop_check();
@@ -629,6 +645,7 @@ fn unsendable_are_not_traversed_on_foreign_thread() {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn test_traverse_subclass() {
     #[pyclass(extends = CycleWithClear)]
     struct SubOverrideTraverse {}
@@ -670,6 +687,7 @@ fn test_traverse_subclass() {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn test_traverse_subclass_override_clear() {
     #[pyclass(extends = CycleWithClear)]
     struct SubOverrideClear {}
@@ -772,6 +790,7 @@ extern "C" fn visit_error_on_base_field(
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 #[cfg(any(not(Py_LIMITED_API), Py_3_11))] // buffer availability
 fn test_drop_buffer_during_traversal_without_gil() {
     use pyo3::buffer::PyBuffer;
@@ -916,6 +935,7 @@ fn test_super_traverse_early_return_does_not_abort() {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn python_subclass_type_cycle_is_collected() {
     #[pyclass(subclass)]
     struct Base {
@@ -971,6 +991,7 @@ class Sub(Base):
 // type-creation time.
 
 #[test]
+#[cfg(wip_feature_std)]
 fn dict_class_is_a_gc_type() {
     Python::attach(|py| {
         let ty = py.get_type::<DictCycleNoTraverse>();
@@ -980,12 +1001,14 @@ fn dict_class_is_a_gc_type() {
 }
 
 /// `#[pyclass(dict)]` with neither `__traverse__` nor `__clear__`: both slots are synthesized.
+#[cfg(wip_feature_std)]
 #[pyclass(dict)]
 struct DictCycleNoTraverse {
     _guard: DropGuard,
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn dict_cycle_collected_without_traverse() {
     let (guard, check) = drop_check();
 
@@ -1003,10 +1026,12 @@ fn dict_cycle_collected_without_traverse() {
 /// `#[pyclass(dict)]` with `__traverse__` but no `__clear__`: the `__dict__` is visited by
 /// `_call_traverse` and cleared by a synthesized `tp_clear`.
 #[pyclass(dict)]
+#[cfg(wip_feature_std)]
 struct DictCycleTraverseOnly {
     _guard: DropGuard,
 }
 
+#[cfg(wip_feature_std)]
 #[pymethods]
 impl DictCycleTraverseOnly {
     #[expect(clippy::unnecessary_wraps)]
@@ -1017,6 +1042,7 @@ impl DictCycleTraverseOnly {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn dict_cycle_collected_with_traverse_only() {
     let (guard, check) = drop_check();
 
@@ -1032,12 +1058,14 @@ fn dict_cycle_collected_with_traverse_only() {
 
 /// `#[pyclass(dict)]` with both `__traverse__` and `__clear__`: the `__dict__` is folded into
 /// the user-defined slots by `_call_traverse` / `_call_clear`.
+#[cfg(wip_feature_std)]
 #[pyclass(dict)]
 struct DictCycleTraverseAndClear {
     _guard: DropGuard,
     field: Option<Py<PyAny>>,
 }
 
+#[cfg(wip_feature_std)]
 #[pymethods]
 impl DictCycleTraverseAndClear {
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
@@ -1053,6 +1081,7 @@ impl DictCycleTraverseAndClear {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn dict_cycle_collected_with_traverse_and_clear() {
     let (guard, check) = drop_check();
 
@@ -1074,6 +1103,7 @@ fn dict_cycle_collected_with_traverse_and_clear() {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn test_subclass_clear() {
     // An incorrect PyO3 implementation would prevent subclass `__clear__`
     // from ever being installed, thus causing this cycle test to leak.

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -1,12 +1,16 @@
 // TODO https://github.com/PyO3/pyo3/issues/5487
 #![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg(feature = "macros")]
+#![cfg_attr(
+    wip_feature_std,
+    expect(clippy::disallowed_types, reason = "mutex and once used for std tests")
+)]
 
 use pyo3::class::PyTraverseError;
 use pyo3::class::PyVisit;
 use pyo3::ffi;
 use pyo3::prelude::*;
-#[cfg(not(Py_GIL_DISABLED))]
+#[cfg(all(wip_feature_std, not(Py_GIL_DISABLED)))]
 use pyo3::py_run;
 #[cfg(not(target_arch = "wasm32"))]
 use std::cell::Cell;
@@ -514,7 +518,7 @@ struct DropDuringTraversal {
 impl DropDuringTraversal {
     #[expect(clippy::unnecessary_wraps)]
     fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-        let mut cycle_ref = self.cycle.lock();
+        let mut cycle_ref = self.cycle.lock().unwrap();
         *cycle_ref = None;
         Ok(())
     }
@@ -537,7 +541,7 @@ fn drop_during_traversal_with_gil() {
         )
         .unwrap();
 
-        *inst.borrow_mut(py).cycle.lock() = Some(inst.clone_ref(py));
+        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         let ptr = inst.as_ptr();
@@ -572,7 +576,7 @@ fn drop_during_traversal_without_gil() {
         )
         .unwrap();
 
-        *inst.borrow_mut(py).cycle.lock() = Some(inst.clone_ref(py));
+        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         inst
@@ -810,7 +814,7 @@ fn test_drop_buffer_during_traversal_without_gil() {
     impl BufferDropDuringTraversal {
         #[expect(clippy::unnecessary_wraps)]
         fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-            self.inner.lock().take();
+            self.inner.lock().unwrap().take();
             Ok(())
         }
 

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "macros")]
 
 use pyo3::exceptions::{PyAttributeError, PyIndexError, PyValueError};
+use pyo3::platform::sync::non_poison::Mutex;
 use pyo3::types::{PyDict, PyList, PyMapping, PySequence, PySlice, PyType};
 use pyo3::{prelude::*, py_run};
 use std::iter;
-use std::sync::Mutex;
 
 mod test_utils;
 
@@ -429,7 +429,7 @@ impl Iterator {
     }
 
     fn __next__(slf: PyRefMut<'_, Self>) -> Option<i32> {
-        slf.iter.lock().unwrap().next()
+        slf.iter.lock().next()
     }
 }
 

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "macros")]
 
 use pyo3::exceptions::{PyAttributeError, PyIndexError, PyValueError};
-use pyo3::impl_::platform::sync::non_poison::Mutex;
 use pyo3::types::{PyDict, PyList, PyMapping, PySequence, PySlice, PyType};
 use pyo3::{prelude::*, py_run};
 use std::iter;
@@ -419,7 +418,7 @@ fn sequence() {
 
 #[pyclass]
 struct Iterator {
-    iter: Mutex<Box<dyn iter::Iterator<Item = i32> + Send>>,
+    iter: Box<dyn iter::Iterator<Item = i32> + Send + Sync>,
 }
 
 #[pymethods]
@@ -428,8 +427,8 @@ impl Iterator {
         slf
     }
 
-    fn __next__(slf: PyRefMut<'_, Self>) -> Option<i32> {
-        slf.iter.lock().next()
+    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<i32> {
+        slf.iter.next()
     }
 }
 
@@ -439,7 +438,7 @@ fn iterator() {
         let inst = Py::new(
             py,
             Iterator {
-                iter: Mutex::new(Box::new(5..8)),
+                iter: Box::new(5..8),
             },
         )
         .unwrap();

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "macros")]
 
 use pyo3::exceptions::{PyAttributeError, PyIndexError, PyValueError};
-use pyo3::platform::sync::non_poison::Mutex;
+use pyo3::impl_::platform::sync::non_poison::Mutex;
 use pyo3::types::{PyDict, PyList, PyMapping, PySequence, PySlice, PyType};
 use pyo3::{prelude::*, py_run};
 use std::iter;

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -234,9 +234,7 @@ mod inner {
         ) -> PyResult<R> {
             // NB this is best-effort, other tests could always call the warnings API directly.
             #[cfg(not(all(Py_GIL_DISABLED, Py_3_14)))]
-            let _mutex_guard = CATCH_WARNINGS_MUTEX
-                .lock_py_attached(py)
-                .unwrap_or_else(PoisonError::into_inner);
+            let _mutex_guard = CATCH_WARNINGS_MUTEX.lock_py_attached(py);
             let warnings = py.import("warnings")?;
             let kwargs = [("record", true)].into_py_dict(py)?;
             let catch_warnings = warnings

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -33,7 +33,7 @@ mod inner {
     use pyo3::types::{IntoPyDict, PyList};
 
     #[cfg(any(not(all(Py_GIL_DISABLED, Py_3_14)), feature = "macros"))]
-    use std::sync::{Mutex, PoisonError};
+    use pyo3::platform::sync::non_poison::Mutex;
 
     use uuid::Uuid;
 
@@ -150,10 +150,7 @@ mod inner {
             // unraisablehook is a global, so only one thread can be using this struct at a time.
             static UNRAISABLE_HOOK_MUTEX: Mutex<()> = Mutex::new(());
 
-            // NB this is best-effort, other tests could always modify sys.unraisablehook directly.
-            let mutex_guard = UNRAISABLE_HOOK_MUTEX
-                .lock_py_attached(py)
-                .unwrap_or_else(PoisonError::into_inner);
+            let mutex_guard = UNRAISABLE_HOOK_MUTEX.lock_py_attached(py);
 
             let guard = Self {
                 hook: UnraisableCaptureHook::install(py),
@@ -169,7 +166,7 @@ mod inner {
 
         /// Takes the captured unraisable error, if any.
         pub fn take_capture(&self) -> Option<(PyErr, Bound<'py, PyAny>)> {
-            let mut guard = self.hook.get().capture.lock().unwrap();
+            let mut guard = self.hook.get().capture.lock();
             guard.take().map(|(e, o)| (e, o.into_bound(self.hook.py())))
         }
     }
@@ -195,7 +192,7 @@ mod inner {
         pub fn hook(&self, unraisable: Bound<'_, PyAny>) {
             let err = PyErr::from_value(unraisable.getattr("exc_value").unwrap());
             let instance = unraisable.getattr("object").unwrap();
-            self.capture.lock().unwrap().replace((err, instance.into()));
+            self.capture.lock().replace((err, instance.into()));
         }
     }
 

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -33,7 +33,7 @@ mod inner {
     use pyo3::types::{IntoPyDict, PyList};
 
     #[cfg(any(not(all(Py_GIL_DISABLED, Py_3_14)), feature = "macros"))]
-    use std::sync::{Mutex, PoisonError};
+    use pyo3::platform::sync::non_poison::Mutex;
 
     use uuid::Uuid;
 
@@ -152,10 +152,7 @@ mod inner {
             // unraisablehook is a global, so only one thread can be using this struct at a time.
             static UNRAISABLE_HOOK_MUTEX: Mutex<()> = Mutex::new(());
 
-            // NB this is best-effort, other tests could always modify sys.unraisablehook directly.
-            let mutex_guard = UNRAISABLE_HOOK_MUTEX
-                .lock_py_attached(py)
-                .unwrap_or_else(PoisonError::into_inner);
+            let mutex_guard = UNRAISABLE_HOOK_MUTEX.lock_py_attached(py);
 
             let guard = Self {
                 hook: UnraisableCaptureHook::install(py),
@@ -171,7 +168,7 @@ mod inner {
 
         /// Takes the captured unraisable error, if any.
         pub fn take_capture(&self) -> Option<(PyErr, Bound<'py, PyAny>)> {
-            let mut guard = self.hook.get().capture.lock().unwrap();
+            let mut guard = self.hook.get().capture.lock();
             guard.take().map(|(e, o)| (e, o.into_bound(self.hook.py())))
         }
     }
@@ -197,7 +194,7 @@ mod inner {
         pub fn hook(&self, unraisable: Bound<'_, PyAny>) {
             let err = PyErr::from_value(unraisable.getattr("exc_value").unwrap());
             let instance = unraisable.getattr("object").unwrap();
-            self.capture.lock().unwrap().replace((err, instance.into()));
+            self.capture.lock().replace((err, instance.into()));
         }
     }
 

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -236,9 +236,7 @@ mod inner {
         ) -> PyResult<R> {
             // NB this is best-effort, other tests could always call the warnings API directly.
             #[cfg(not(all(Py_GIL_DISABLED, Py_3_14)))]
-            let _mutex_guard = CATCH_WARNINGS_MUTEX
-                .lock_py_attached(py)
-                .unwrap_or_else(PoisonError::into_inner);
+            let _mutex_guard = CATCH_WARNINGS_MUTEX.lock_py_attached(py);
             let warnings = py.import("warnings")?;
             let kwargs = [("record", true)].into_py_dict(py)?;
             let catch_warnings = warnings

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -33,7 +33,7 @@ mod inner {
     use pyo3::types::{IntoPyDict, PyList};
 
     #[cfg(any(not(all(Py_GIL_DISABLED, Py_3_14)), feature = "macros"))]
-    use pyo3::platform::sync::non_poison::Mutex;
+    use pyo3::impl_::platform::sync::non_poison::Mutex;
 
     use uuid::Uuid;
 


### PR DESCRIPTION
This PR is to prepare for `no_std` support.

I've added `non_poison::Mutex` and `Once` to the `platform` mod.

There was once place that relied on poisoning for correctness: `err_state.rs`, but that didn't really need a mutex because it was guarding a `Copy` type, I've replaced it with a `Cell`.