### PR TITLE
refactor: freelist

### DIFF
--- a/src/impl_/freelist.rs
+++ b/src/impl_/freelist.rs
@@ -9,34 +9,24 @@
 //! [1]: https://en.wikipedia.org/wiki/Free_list
 
 use crate::ffi;
-use core::mem;
-
-/// Represents a slot of a [`PyObjectFreeList`].
-enum PyObjectSlot {
-    /// A free slot.
-    Empty,
-    /// An allocated slot.
-    Filled(*mut ffi::PyObject),
-}
-
-// safety: access is guarded by a per-pyclass mutex
-unsafe impl Send for PyObjectSlot {}
+use core::ptr::NonNull;
 
 /// A free allocation list for PyObject ffi pointers.
 ///
 /// See [the parent module](crate::impl_::freelist) for more details.
 pub struct PyObjectFreeList {
-    entries: Box<[PyObjectSlot]>,
+    entries: Box<[Option<NonNull<ffi::PyObject>>]>,
     split: usize,
     capacity: usize,
 }
 
+// safety: access is guarded by a per-pyclass mutex
+unsafe impl Send for PyObjectFreeList {}
+
 impl PyObjectFreeList {
     /// Creates a new `PyObjectFreeList` instance with specified capacity.
     pub fn with_capacity(capacity: usize) -> PyObjectFreeList {
-        let entries = (0..capacity)
-            .map(|_| PyObjectSlot::Empty)
-            .collect::<Box<[_]>>();
+        let entries = vec![None; capacity].into_boxed_slice();
 
         PyObjectFreeList {
             entries,
@@ -46,26 +36,24 @@ impl PyObjectFreeList {
     }
 
     /// Pops the first non empty item.
-    pub fn pop(&mut self) -> Option<*mut ffi::PyObject> {
+    pub fn pop(&mut self) -> Option<NonNull<ffi::PyObject>> {
         let idx = self.split;
         if idx == 0 {
             None
         } else {
-            match mem::replace(&mut self.entries[idx - 1], PyObjectSlot::Empty) {
-                PyObjectSlot::Filled(v) => {
-                    self.split = idx - 1;
-                    Some(v)
-                }
-                _ => panic!("PyObjectFreeList is corrupt"),
-            }
+            let val = self.entries[idx - 1]
+                .take()
+                .expect("PyObjectFreeList is corrupt");
+            self.split = idx - 1;
+            Some(val)
         }
     }
 
     /// Inserts a value into the list. Returns `Some(val)` if the `PyObjectFreeList` is full.
-    pub fn insert(&mut self, val: *mut ffi::PyObject) -> Option<*mut ffi::PyObject> {
+    pub fn insert(&mut self, val: NonNull<ffi::PyObject>) -> Option<NonNull<ffi::PyObject>> {
         let next = self.split + 1;
         if next < self.capacity {
-            self.entries[self.split] = PyObjectSlot::Filled(val);
+            self.entries[self.split] = Some(val);
             self.split = next;
             None
         } else {

--- a/src/impl_/freelist.rs
+++ b/src/impl_/freelist.rs
@@ -20,7 +20,7 @@ pub struct PyObjectFreeList {
     capacity: usize,
 }
 
-// safety: access is guarded by a per-pyclass mutex
+// safety: the pointers are never used internally and they are cleared when they are given out
 unsafe impl Send for PyObjectFreeList {}
 
 impl PyObjectFreeList {

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -925,8 +925,8 @@ pub unsafe extern "C" fn alloc_with_freelist<T: PyClassWithFreeList>(
         let mut free_list = T::get_free_list(py).lock().unwrap();
         if let Some(obj) = free_list.pop() {
             drop(free_list);
-            unsafe { ffi::PyObject_Init(obj, subtype) };
-            return obj as _;
+            unsafe { ffi::PyObject_Init(obj.as_ptr(), subtype) };
+            return obj.as_ptr() as _;
         }
     }
 
@@ -939,16 +939,18 @@ pub unsafe extern "C" fn alloc_with_freelist<T: PyClassWithFreeList>(
 /// - `obj` must be a valid pointer to an instance of T (not a subclass).
 /// - The calling thread must be attached to the interpreter
 pub unsafe extern "C" fn free_with_freelist<T: PyClassWithFreeList>(obj: *mut c_void) {
-    let obj = obj as *mut ffi::PyObject;
+    let Some(obj) = NonNull::new(obj.cast()) else {
+        return;
+    };
     unsafe {
         debug_assert_eq!(
             T::type_object_raw(Python::assume_attached()),
-            ffi::Py_TYPE(obj)
+            ffi::Py_TYPE(obj.as_ptr())
         );
         let mut free_list = T::get_free_list(Python::assume_attached()).lock().unwrap();
         if let Some(obj) = free_list.insert(obj) {
             drop(free_list);
-            let ty = ffi::Py_TYPE(obj);
+            let ty = ffi::Py_TYPE(obj.as_ptr());
 
             // Deduce appropriate inverse of PyType_GenericAlloc
             let free = if ffi::PyType_IS_GC(ty) != 0 {
@@ -956,7 +958,7 @@ pub unsafe extern "C" fn free_with_freelist<T: PyClassWithFreeList>(obj: *mut c_
             } else {
                 ffi::PyObject_Free
             };
-            free(obj as *mut c_void);
+            free(obj.as_ptr().cast());
 
             if ffi::PyType_HasFeature(ty, ffi::Py_TPFLAGS_HEAPTYPE) != 0 {
                 ffi::Py_DECREF(ty as *mut ffi::PyObject);


### PR DESCRIPTION
- simplify `freelist.rs` a bit
- Use `Option<NonNull<ffi::PyObject>>` to take advantage of niche optimization
- fix safety comment