### PR TITLE
internal: introduce `cfg_select!` polyfill

### DIFF
--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -185,6 +185,7 @@ pub fn print_feature_cfgs() {
     print_feature_cfg(84, "const_is_null");
     print_feature_cfg(85, "fn_ptr_eq");
     print_feature_cfg(86, "from_bytes_with_nul_error");
+    print_feature_cfg(95, "cfg_select");
 }
 
 /// Registers `pyo3`s config names as reachable cfg expressions

--- a/src/byteswriter.rs
+++ b/src/byteswriter.rs
@@ -42,9 +42,8 @@ impl<'py> PyBytesWriter<'py> {
     #[inline]
     #[cfg_attr(Py_LIMITED_API, allow(clippy::unnecessary_wraps))]
     pub fn with_capacity(py: Python<'py>, capacity: usize) -> PyResult<Self> {
-        #[cfg(not(Py_LIMITED_API))]
-        {
-            NonNull::new(unsafe { PyBytesWriter_Create(capacity as _) }).map_or_else(
+        cfg_select! {
+            not(Py_LIMITED_API) => NonNull::new(unsafe { PyBytesWriter_Create(capacity as _) }).map_or_else(
                 || Err(PyErr::fetch(py)),
                 |writer| {
                     let mut writer = PyBytesWriter { python: py, writer };
@@ -54,12 +53,8 @@ impl<'py> PyBytesWriter<'py> {
                     }
                     Ok(writer)
                 },
-            )
-        }
-
-        #[cfg(Py_LIMITED_API)]
-        {
-            Ok(PyBytesWriter {
+            ),
+            Py_LIMITED_API => Ok(PyBytesWriter {
                 python: py,
                 buffer: Vec::with_capacity(capacity),
             })
@@ -69,14 +64,11 @@ impl<'py> PyBytesWriter<'py> {
     /// Get the current length of the internal buffer.
     #[inline]
     pub fn len(&self) -> usize {
-        #[cfg(not(Py_LIMITED_API))]
-        unsafe {
-            PyBytesWriter_GetSize(self.writer.as_ptr()) as _
-        }
-
-        #[cfg(Py_LIMITED_API)]
-        {
-            self.buffer.len()
+        cfg_select! {
+            not(Py_LIMITED_API) => unsafe {
+                PyBytesWriter_GetSize(self.writer.as_ptr()) as _
+            },
+            Py_LIMITED_API => self.buffer.len()
         }
     }
 
@@ -110,17 +102,16 @@ impl<'py> TryFrom<PyBytesWriter<'py>> for Bound<'py, PyBytes> {
     #[inline]
     fn try_from(value: PyBytesWriter<'py>) -> Result<Self, Self::Error> {
         let py = value.python;
-
-        #[cfg(not(Py_LIMITED_API))]
-        unsafe {
-            PyBytesWriter_Finish(ManuallyDrop::new(value).writer.as_ptr())
-                .assume_owned_or_err(py)
-                .cast_into_unchecked()
-        }
-
-        #[cfg(Py_LIMITED_API)]
-        {
-            Ok(PyBytes::new(py, &value.buffer))
+        cfg_select! {
+            // SAFETY:
+            //  - we no longer use `value` after this call
+            //  - `PyBytesWriter_Finish` will return a new reference to a bytes object on success
+            not(Py_LIMITED_API) => unsafe {
+                PyBytesWriter_Finish(ManuallyDrop::new(value).writer.as_ptr())
+                    .assume_owned_or_err(py)
+                    .cast_into_unchecked()
+            },
+            Py_LIMITED_API => Ok(PyBytes::new(py, &value.buffer))
         }
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,5 +1,8 @@
 //! Holding place for code which is not intended to be reachable from outside of PyO3.
 
+#[macro_use]
+pub(crate) mod macros;
+
 pub(crate) mod get_slot;
 pub(crate) mod pyclass_init;
 pub(crate) mod state;

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -1,0 +1,73 @@
+/// Polyfill of `cfg_select` for MSRV < 1.95
+#[doc(hidden)]
+#[cfg(not(cfg_select))]
+macro_rules! cfg_select {
+    // Final arm with _ to match any non-existing clauses
+    (
+        @parsed($($clauses:meta),*)
+        _ => $final_arm:expr $(,)?
+    ) => {
+        #[cfg(not(any($($clauses),+)))]
+        {
+            $final_arm
+        }
+    };
+
+    // Final arm has a clause, handle it plus a compile error if no clauses match
+    // Need to allow for trailing comma on final expression to be optional
+    (
+        @parsed($($clauses:meta),*)
+        $cfg:meta => $final_arm:expr $(,)?
+    ) => {
+        #[cfg($cfg)]
+        {
+            $final_arm
+        }
+
+        #[cfg(not(any($($clauses,)* $cfg)))]
+        compile_error!(
+            "cfg_select! requires a final `_ => expr` arm to be used as a fallback when no other cfg matches"
+        );
+    };
+
+    (
+        @parsed($($clauses:meta),*)
+        $cfg:meta => $arm:expr, $($rest:tt)*
+    ) => {
+        #[cfg($cfg)]
+        {
+            $arm
+        }
+
+
+        cfg_select! {
+            @parsed($($clauses,)* $cfg)
+            $($rest)*
+        }
+    };
+
+    (
+        @parsed($($clauses:meta),*)
+        $cfg:meta => $arm:block $($rest:tt)*
+    ) => {
+        #[cfg($cfg)]
+        $arm
+
+
+        cfg_select! {
+            @parsed($($clauses,)* $cfg)
+            $($rest)*
+        }
+    };
+
+    (
+        $cfg:meta => $($rest:tt)*
+    ) => {
+        {
+            cfg_select! {
+                @parsed()
+                $cfg => $($rest)*
+            }
+        }
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,6 +415,7 @@ pub mod impl_;
 
 #[macro_use]
 mod internal_tricks;
+#[macro_use]
 mod internal;
 
 pub mod buffer;

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -249,15 +249,15 @@ pub trait PyListMethods<'py>: crate::sealed::Sealed {
 impl<'py> PyListMethods<'py> for Bound<'py, PyList> {
     /// Returns the length of the list.
     fn len(&self) -> usize {
-        unsafe {
-            #[cfg(not(Py_LIMITED_API))]
-            let size = ffi::PyList_GET_SIZE(self.as_ptr());
-            #[cfg(Py_LIMITED_API)]
-            let size = ffi::PyList_Size(self.as_ptr());
+        let size = cfg_select! {
+            // SAFETY: self is valid list object
+            not(Py_LIMITED_API) => unsafe { ffi::PyList_GET_SIZE(self.as_ptr()) },
+            // SAFETY: as above
+            Py_LIMITED_API => unsafe { ffi::PyList_Size(self.as_ptr()) },
+        };
 
-            // non-negative Py_ssize_t should always fit into Rust usize
-            size as usize
-        }
+        // non-negative Py_ssize_t should always fit into Rust usize
+        size as usize
     }
 
     /// Checks if the list is empty.


### PR DESCRIPTION
This adds a polyfill for the `cfg_select!` macro released in Rust 1.95, and I use it in a few positions to evaluate how we like it.

If we are happy, I expect we can migrate code over to this gradually in follow up PRs.