### PR TITLE
fix broken ui tests

### DIFF
--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -38,10 +38,6 @@ fn test_compile_errors() {
     t.compile_fail("tests/ui/reject_generics.rs");
     t.compile_fail("tests/ui/invalid_closure.rs");
     t.compile_fail("tests/ui/pyclass_send.rs");
-    #[cfg(not(feature = "experimental-inspect"))]
-    t.compile_fail("tests/ui/invalid_annotation.rs");
-    #[cfg(not(feature = "experimental-inspect"))]
-    t.compile_fail("tests/ui/invalid_annotation_return.rs");
     t.compile_fail("tests/ui/invalid_argument_attributes.rs");
     t.compile_fail("tests/ui/invalid_intopy_derive.rs");
     #[cfg(not(windows))]
@@ -78,7 +74,6 @@ fn test_compile_errors() {
     #[cfg(any(not(Py_LIMITED_API), Py_3_10))] // to avoid PyFunctionArgument for &str
     t.compile_fail("tests/ui/invalid_cancel_handle.rs");
     t.pass("tests/ui/pymodule_missing_docs.rs");
-    #[cfg(not(any(Py_LIMITED_API, feature = "experimental-inspect")))]
     t.pass("tests/ui/forbid_unsafe.rs");
     #[cfg(all(Py_LIMITED_API, not(Py_3_12), feature = "experimental-async"))]
     // output changes with async feature

--- a/tests/ui/forbid_unsafe.rs
+++ b/tests/ui/forbid_unsafe.rs
@@ -1,6 +1,8 @@
 #![forbid(unsafe_code)]
 #![forbid(unsafe_op_in_unsafe_fn)]
 
+extern crate alloc;
+
 use pyo3::*;
 
 #[expect(unexpected_cfgs)]


### PR DESCRIPTION
While working on #5741 I noticed that some of our ui tests are broken, indicating that they are not running in CI. Looking in more detail it seem we either run without any features, which means ui tests are not running since they require `macros` or we are running `full`. Basically all tests that require the absence of a feature is not running in CI.

Quite a few of are gated on `#[cfg(not(feature = "experimental-inspect"))]` as the output changes with the feature enabled. We could invert the cfg, but this would decrease the readability of the output quite a bit. And for some of them this would not work, as they specifically test errors that we emit when a feature is not enabled.

Currently untested are (as far as I can tell):
- invalid_property_args
- invalid_pyclass_args
- invalid_pyfunction_argument
- invalid_async
- missing_intopy
- invalid_cancel_handle
- duplicate_pymodule_submodule

I already fixed a few simple ones, but I'm not sure how to best handle the rest. We could remove `experimental-inspect` and `experimental-async` from full and have separate runs, but that would probably increase CI time significantly and also feels more like a band aid rather than a fix. Maybe we should have a separate job that just runs `test_compile_error` with more feature combinations? An additional run with just `macros` would fix quite a few of these, but not all I believe. Ideas welcome.