### PR TITLE
CI: Fix UI tests for Rust 1.96

### DIFF
--- a/tests/ui/invalid_pyclass_init.stderr
+++ b/tests/ui/invalid_pyclass_init.stderr
@@ -4,11 +4,11 @@ error[E0277]: the trait bound `i32: pyo3::impl_::callback::IntoPyCallbackOutput<
 8 |     fn __init__(&self) -> i32 {
   |                           ^^^ the trait `pyo3::impl_::callback::IntoPyCallbackOutput<'_, i32>` is not implemented for `i32`
   |
-help: the following other types implement trait `pyo3::impl_::callback::IntoPyCallbackOutput<'py, Target>`
+help: `usize` implements trait `pyo3::impl_::callback::IntoPyCallbackOutput<'py, Target>`
  --> src/impl_/callback.rs
   |
   | impl IntoPyCallbackOutput<'_, ffi::Py_ssize_t> for usize {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `usize` implements `pyo3::impl_::callback::IntoPyCallbackOutput<'_, isize>`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pyo3::impl_::callback::IntoPyCallbackOutput<'_, isize>`
 ...
   | impl IntoPyCallbackOutput<'_, usize> for usize {
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `usize` implements `pyo3::impl_::callback::IntoPyCallbackOutput<'_, usize>`
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pyo3::impl_::callback::IntoPyCallbackOutput<'_, usize>`


### PR DESCRIPTION
I think this should stabilize CI after the Rust 1.96 release today.