### PR TITLE
docs: document sys.stdout flush on exit

### DIFF
--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -383,6 +383,55 @@ Python::attach(|py| -> PyResult<()> {
 # }
 ```
 
+## `sys.stdout` and `sys.stderr` are not flushed when the Rust program exits
+
+When PyO3 embeds a Python interpreter inside a Rust binary, the interpreter's buffered streams (typically `sys.stdout` and `sys.stderr`) are not automatically flushed when the Rust process exits.
+Output written from Python without a trailing newline, or while the stream is fully buffered, may therefore be lost.
+PyO3 deliberately does not run `Py_Finalize` on shutdown because doing so can break C extensions and `async` code that hold references after the interpreter is gone (see [#1355](https://github.com/PyO3/pyo3/pull/1355) for the rationale).
+
+There are three workarounds, in increasing order of intrusiveness:
+
+1. **Run with `PYTHONUNBUFFERED=1`.**
+   This disables Python's stream buffering for the embedded interpreter, so every write is flushed immediately.
+   It also keeps Python and Rust output ordered consistently when both write to the same stream.
+
+2. **Call `sys.stdout.flush()` and `sys.stderr.flush()` from Python before the Rust caller returns.**
+   This is the lightest-weight in-process fix and only affects the streams you care about:
+
+   ```rust
+   use pyo3::prelude::*;
+
+   # fn main() -> PyResult<()> {
+   Python::attach(|py| {
+       let sys = py.import("sys")?;
+       sys.getattr("stdout")?.call_method0("flush")?;
+       sys.getattr("stderr")?.call_method0("flush")?;
+       Ok(())
+   })
+   # }
+   ```
+
+3. **Call `Py_Finalize` at the end of `main`.**
+   This runs the interpreter's full shutdown sequence, including `atexit` handlers and stream flushing, at the cost of the caveats noted above.
+   Only do this if your program does not keep Python objects alive past the finalize call:
+
+   ```rust,no_run
+   use pyo3::prelude::*;
+
+   fn main() -> PyResult<()> {
+       let result: PyResult<()> = Python::attach(|py| {
+           // ... your embedded Python work ...
+           # let _ = py;
+           Ok(())
+       });
+       // SAFETY: no PyO3 handles or Python references must outlive this call.
+       unsafe { pyo3::ffi::Py_Finalize() };
+       result
+   }
+   ```
+
+The Python C API documents the buffering behaviour and the finalisation contract in [Initialization, Finalization, and Threads](https://docs.python.org/3/c-api/init.html).
+
 [`py_run!`]: {{#PYO3_DOCS_URL}}/pyo3/macro.py_run.html
 [`Python::run`]: {{#PYO3_DOCS_URL}}/pyo3/marker/struct.Python.html#method.run
 [`PyModule::new`]: {{#PYO3_DOCS_URL}}/pyo3/types/struct.PyModule.html#method.new


### PR DESCRIPTION
# docs: document sys.stdout flush on exit

Closes [#1490](https://github.com/PyO3/pyo3/issues/1490).

## Summary

Issue #1490 reports that `sys.stdout` and `sys.stderr` are not flushed
when a Rust program embedding PyO3 exits, so Python writes without a
trailing newline can be silently dropped.

In 2021 the maintainer redirected the issue from "fix the runtime" to
"document the workaround":

> we added the finalizers to flush stdout and then removed them in
> [#1355](https://github.com/PyO3/pyo3/pull/1355) [...] In the end we
> decided there's too many issues with finalizers to run them
> ourselves. So I think this is a documentation issue.
>
> You may want to consider running with `PYTHONUNBUFFERED=1` [...]
> Alternatively you could add `unsafe { pyo3::ffi::Py_Finalize() }` at
> the end of your `main` function if it doesn't cause you problems.
>
> (@davidhewitt, [#1490 comment](https://github.com/PyO3/pyo3/issues/1490#issuecomment-798798869))

The issue carries the `documentation` and `needs-implementer` labels
and has had no follow-up PR.

## Change

Adds one section to `guide/src/python-from-rust/calling-existing-code.md`
titled "`sys.stdout` and `sys.stderr` are not flushed when the Rust
program exits", placed after "Handling system signals/interrupts
(Ctrl-C)" and before the link-reference block.

The section:

1. States the behaviour and links to PR #1355 for the rationale on why
   PyO3 does not run `Py_Finalize` automatically.
2. Lists three workarounds in increasing order of intrusiveness:
   `PYTHONUNBUFFERED=1`, explicit `sys.stdout.flush()` / `sys.stderr.flush()`
   from Python, and an `unsafe { pyo3::ffi::Py_Finalize() }` call in
   `main`, with a `SAFETY:` note on the lifetime constraint.
3. Cross-links the upstream CPython documentation at
   [Initialization, Finalization, and Threads](https://docs.python.org/3/c-api/init.html).

The explicit-flush code block uses the current `Python::attach` API and
follows the `# fn main() -> PyResult<()> {` hidden-line pattern already
used elsewhere in the file. The `Py_Finalize` block is marked
`rust,no_run` because finalising the interpreter inside a doctest would
interact badly with the rest of the test suite.

## Verification

- `cargo doc --no-deps -p pyo3` completes cleanly on the branch
  (`pyo3 v0.28.3` docs build, `Finished dev profile`).
- No new newsfragment per `Contributing.md`: "Docs-only PRs do not
  need news items; start your PR title with `docs:` to skip the check."
- The diff is a single markdown file, +44 / -0 lines.

## Out of scope

This PR does not change the runtime behaviour. PR #1355 already
documented the decision to remove automatic finalisation; the present
PR only fills the doc gap that decision left behind.
