### PR TITLE
fix bugs with list / tuple iterator "nth" operations

### DIFF
--- a/newsfragments/6086.fixed.md
+++ b/newsfragments/6086.fixed.md
@@ -1,0 +1,2 @@
+- Fix possible out of bounds read in `BoundListIterator` and `BoundTupleIterator`'s `nth` and `nth_back` implementations.
+- Fix `BoundListIterator` and `BoundTupleIterator` not being exhausted when `nth` or `nth_back` is called with N larger than the remaining count of items.

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -583,7 +583,7 @@ impl<'py> BoundListIterator<'py> {
                 // SAFETY: target_index is < current_length
                 let item = unsafe { list.get_item_unchecked(target_index) };
                 length.0 = target_index;
-                return Some(item.to_owned());
+                return Some(item);
             }
         }
 
@@ -859,7 +859,7 @@ impl DoubleEndedIterator for BoundListIterator<'_> {
             }
 
             // cannot overflow as length - index >= n
-            length.0 -= n;
+            length.0 = current_length - n;
             Ok(())
         })
     }
@@ -1590,7 +1590,7 @@ mod tests {
             assert_eq!(iter.nth(2).unwrap().extract::<i32>().unwrap(), 8);
             assert!(iter.next().is_none());
 
-            // nth consumes all elements in the tuple, even on `None` return
+            // nth consumes all elements in the list, even on `None` return
             let mut iter = list.iter();
             assert!(iter.nth(100).is_none());
             assert!(iter.next().is_none());

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -858,7 +858,7 @@ impl DoubleEndedIterator for BoundListIterator<'_> {
                 return Err(overflow);
             }
 
-            // cannot overflow as length - index >= n
+            // cannot overflow as current_length - index >= n
             length.0 = current_length - n;
             Ok(())
         })

--- a/src/types/list.rs
+++ b/src/types/list.rs
@@ -520,22 +520,27 @@ impl<'py> BoundListIterator<'py> {
     /// The caller must hold an active critical section on this list.
     #[inline]
     #[cfg(not(feature = "nightly"))]
-    unsafe fn nth_locked(
+    unsafe fn nth_unsynchronized(
         index: &mut Index,
         length: &mut Length,
         list: &Bound<'py, PyList>,
         n: usize,
     ) -> Option<Bound<'py, PyAny>> {
-        let length = length.0.min(list.len());
-        let target_index = index.0 + n;
-        if target_index < length {
-            // SAFETY: target_index < list.len() guarantees in bounds
-            let item = unsafe { list.get_item_unchecked(target_index) };
-            index.0 = target_index + 1;
-            Some(item)
-        } else {
-            None
+        let current_length = length.0.min(list.len());
+        if let Some(target_index) = index.0.checked_add(n) {
+            if target_index < current_length {
+                // SAFETY: target_index < current_length guarantees in bounds
+                let item = unsafe { list.get_item_unchecked(target_index) };
+                // +1 cannot overflow as target_index < current_length
+                index.0 = target_index + 1;
+                return Some(item);
+            }
         }
+
+        // n overflows the remaining length of the list;
+        // nth must exhaust all remaining items
+        index.0 = current_length;
+        None
     }
 
     /// # Safety
@@ -564,22 +569,28 @@ impl<'py> BoundListIterator<'py> {
     /// The caller must hold an active critical section on this list.
     #[inline]
     #[cfg(not(feature = "nightly"))]
-    unsafe fn nth_back_locked(
+    unsafe fn nth_back_unsynchronized(
         index: &mut Index,
         length: &mut Length,
         list: &Bound<'py, PyList>,
         n: usize,
     ) -> Option<Bound<'py, PyAny>> {
-        let length_size = length.0.min(list.len());
-        if index.0 + n < length_size {
-            let target_index = length_size - n - 1;
-            // SAFETY: target_index < list.len() guarantees in bounds
-            let item = unsafe { list.get_item_unchecked(target_index) };
-            length.0 = target_index;
-            Some(item)
-        } else {
-            None
+        let current_length = length.0.min(list.len());
+        if let Some(index_after_item) = current_length.checked_sub(n) {
+            if index.0 < index_after_item {
+                // -1 cannot underflow as index_after_item > index
+                let target_index = index_after_item - 1;
+                // SAFETY: target_index is < current_length
+                let item = unsafe { list.get_item_unchecked(target_index) };
+                length.0 = target_index;
+                return Some(item.to_owned());
+            }
         }
+
+        // n overflows the remaining length of the tuple;
+        // nth must exhaust all remaining items
+        length.0 = index.0;
+        None
     }
 
     fn with_critical_section<R>(
@@ -611,7 +622,7 @@ impl<'py> Iterator for BoundListIterator<'py> {
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         // SAFETY: with_critical_section locks the list
         self.with_critical_section(|index, length, list| unsafe {
-            Self::nth_locked(index, length, list, n)
+            Self::nth_unsynchronized(index, length, list, n)
         })
     }
 
@@ -768,25 +779,17 @@ impl<'py> Iterator for BoundListIterator<'py> {
     #[cfg(feature = "nightly")]
     fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
         self.with_critical_section(|index, length, list| {
-            let max_len = length.0.min(list.len());
-            let currently_at = index.0;
-            if currently_at >= max_len {
-                if n == 0 {
-                    return Ok(());
-                } else {
-                    return Err(unsafe { NonZero::new_unchecked(n) });
-                }
+            let current_length = length.0.min(list.len());
+            let items_left = current_length.saturating_sub(index.0);
+            if let Some(overflow) = NonZero::new(n.saturating_sub(items_left)) {
+                // n overflows the remaining length of the list; advance_by must exhaust all remaining items
+                index.0 = current_length;
+                return Err(overflow);
             }
 
-            let items_left = max_len - currently_at;
-            if n <= items_left {
-                index.0 += n;
-                Ok(())
-            } else {
-                index.0 = max_len;
-                let remainder = n - items_left;
-                Err(unsafe { NonZero::new_unchecked(remainder) })
-            }
+            // cannot overflow as length - index >= n
+            index.0 += n;
+            Ok(())
         })
     }
 }
@@ -804,7 +807,7 @@ impl DoubleEndedIterator for BoundListIterator<'_> {
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
         // SAFETY: with_critical_section locks the list
         self.with_critical_section(|index, length, list| unsafe {
-            Self::nth_back_locked(index, length, list, n)
+            Self::nth_back_unsynchronized(index, length, list, n)
         })
     }
 
@@ -847,25 +850,17 @@ impl DoubleEndedIterator for BoundListIterator<'_> {
     #[cfg(feature = "nightly")]
     fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
         self.with_critical_section(|index, length, list| {
-            let max_len = length.0.min(list.len());
-            let currently_at = index.0;
-            if currently_at >= max_len {
-                if n == 0 {
-                    return Ok(());
-                } else {
-                    return Err(unsafe { NonZero::new_unchecked(n) });
-                }
+            let current_length = length.0.min(list.len());
+            let items_left = current_length.saturating_sub(index.0);
+            if let Some(overflow) = NonZero::new(n.saturating_sub(items_left)) {
+                // n overflows the remaining length of the list; advance_back_by must exhaust all remaining items
+                length.0 = index.0;
+                return Err(overflow);
             }
 
-            let items_left = max_len - currently_at;
-            if n <= items_left {
-                length.0 = max_len - n;
-                Ok(())
-            } else {
-                length.0 = currently_at;
-                let remainder = n - items_left;
-                Err(unsafe { NonZero::new_unchecked(remainder) })
-            }
+            // cannot overflow as length - index >= n
+            length.0 -= n;
+            Ok(())
         })
     }
 }
@@ -1594,6 +1589,19 @@ mod tests {
             assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 9);
             assert_eq!(iter.nth(2).unwrap().extract::<i32>().unwrap(), 8);
             assert!(iter.next().is_none());
+
+            // nth consumes all elements in the tuple, even on `None` return
+            let mut iter = list.iter();
+            assert!(iter.nth(100).is_none());
+            assert!(iter.next().is_none());
+            assert!(iter.next_back().is_none());
+
+            // nth should not overflow the iterator
+            // a naive implementation of nth will overflow if number of advanced
+            // elements plus N overflows usize::MAX
+            let mut iter = list.iter();
+            assert!(iter.next().is_some());
+            assert!(iter.nth(usize::MAX).is_none());
         });
     }
 
@@ -1651,6 +1659,17 @@ mod tests {
             iter3.nth(1);
             assert_eq!(iter3.nth_back(2).unwrap().extract::<i32>().unwrap(), 3);
             assert!(iter3.nth_back(0).is_none());
+
+            // nth_back consumes all elements in the list, even on `None` return
+            let mut iter4 = list.iter();
+            assert!(iter4.nth_back(100).is_none());
+            assert!(iter4.next_back().is_none());
+            assert!(iter4.next().is_none());
+
+            // nth_back should not overflow with usize::MAX
+            let mut iter5 = list.iter();
+            iter5.nth(1); //
+            assert!(iter5.nth_back(usize::MAX).is_none());
         });
     }
 
@@ -1677,6 +1696,19 @@ mod tests {
             let mut iter4 = list.iter();
             assert_eq!(iter4.advance_by(0), Ok(()));
             assert_eq!(iter4.next().unwrap().extract::<i32>().unwrap(), 1);
+
+            // advance_by should not overflow with usize::MAX
+            // - first advanc will overflow by MAX - len, and will exhaust the iterator
+            // - second advance will overflow by MAX
+            let mut iter5 = list.iter();
+            assert_eq!(
+                iter5.advance_by(usize::MAX),
+                Err(NonZero::new(usize::MAX - list.len()).unwrap())
+            );
+            assert_eq!(
+                iter5.advance_by(usize::MAX),
+                Err(NonZero::new(usize::MAX).unwrap())
+            );
         })
     }
 
@@ -1703,6 +1735,19 @@ mod tests {
             let mut iter4 = list.iter();
             assert_eq!(iter4.advance_back_by(0), Ok(()));
             assert_eq!(iter4.next_back().unwrap().extract::<i32>().unwrap(), 5);
+
+            // advance_back_by should not overflow with usize::MAX
+            // - first advance will overflow by MAX - len, and will exhaust the iterator
+            // - second advance will overflow by MAX
+            let mut iter5 = list.iter();
+            assert_eq!(
+                iter5.advance_back_by(usize::MAX),
+                Err(NonZero::new(usize::MAX - list.len()).unwrap())
+            );
+            assert_eq!(
+                iter5.advance_back_by(usize::MAX),
+                Err(NonZero::new(usize::MAX).unwrap())
+            );
         })
     }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -482,7 +482,7 @@ impl DoubleEndedIterator for BoundTupleIterator<'_> {
                 // SAFETY: target_index < self.length
                 let item = unsafe { self.tuple.get_item_unchecked(target_index) };
                 self.length = target_index;
-                return Some(item.to_owned());
+                return Some(item);
             }
         }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -426,37 +426,35 @@ impl<'py> Iterator for BoundTupleIterator<'py> {
     #[inline]
     #[cfg(not(feature = "nightly"))]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        let target_index = self.index + n;
-        if target_index < self.length {
-            // SAFETY: target_index < self.length
-            let item = unsafe { self.tuple.get_item_unchecked(target_index) };
-            self.index = target_index + 1;
-            Some(item)
-        } else {
-            None
+        if let Some(target_index) = self.index.checked_add(n) {
+            if target_index < self.length {
+                // SAFETY: target_index < self.length
+                let item = unsafe { self.tuple.get_item_unchecked(target_index) };
+                // +1 cannot overflow as target_index < self.length
+                self.index = target_index + 1;
+                return Some(item);
+            }
         }
+
+        // n overflows the remaining length of the tuple;
+        // nth must exhaust all remaining items
+        self.index = self.length;
+        None
     }
 
     #[inline]
     #[cfg(feature = "nightly")]
     fn advance_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
-        if self.index >= self.length {
-            if n == 0 {
-                return Ok(());
-            } else {
-                return Err(unsafe { NonZero::new_unchecked(n) });
-            }
+        let items_left = self.length.saturating_sub(self.index);
+        if let Some(overflow) = NonZero::new(n.saturating_sub(items_left)) {
+            // n overflows the remaining length of the tuple; advance_by must exhaust all remaining items
+            self.index = self.length;
+            return Err(overflow);
         }
 
-        let items_left = self.length - self.index;
-        if n <= items_left {
-            self.index += n;
-            Ok(())
-        } else {
-            self.index = self.length;
-            let remainder = n - items_left;
-            Err(unsafe { NonZero::new_unchecked(remainder) })
-        }
+        // cannot overflow as self.length - self.index >= n
+        self.index += n;
+        Ok(())
     }
 }
 
@@ -477,37 +475,36 @@ impl DoubleEndedIterator for BoundTupleIterator<'_> {
     #[inline]
     #[cfg(not(feature = "nightly"))]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        if self.index + n < self.length {
-            let target_index = self.length - n - 1;
-            // SAFETY: target_index < self.length
-            let item = unsafe { self.tuple.get_item_unchecked(target_index) };
-            self.length = target_index;
-            Some(item)
-        } else {
-            None
+        if let Some(index_after_item) = self.length.checked_sub(n) {
+            if self.index < index_after_item {
+                // -1 cannot underflow as index_after_item > self.index
+                let target_index = index_after_item - 1;
+                // SAFETY: target_index < self.length
+                let item = unsafe { self.tuple.get_item_unchecked(target_index) };
+                self.length = target_index;
+                return Some(item.to_owned());
+            }
         }
+
+        // n overflows the remaining length of the tuple;
+        // nth must exhaust all remaining items
+        self.length = self.index;
+        None
     }
 
     #[inline]
     #[cfg(feature = "nightly")]
     fn advance_back_by(&mut self, n: usize) -> Result<(), NonZero<usize>> {
-        if self.index >= self.length {
-            if n == 0 {
-                return Ok(());
-            } else {
-                return Err(unsafe { NonZero::new_unchecked(n) });
-            }
+        let items_left = self.length.saturating_sub(self.index);
+        if let Some(overflow) = NonZero::new(n.saturating_sub(items_left)) {
+            // n overflows the remaining length of the tuple; advance_back_by must exhaust all remaining items
+            self.length = self.index;
+            return Err(overflow);
         }
 
-        let items_left = self.length - self.index;
-        if n <= items_left {
-            self.length -= n;
-            Ok(())
-        } else {
-            self.length = self.index;
-            let remainder = n - items_left;
-            Err(unsafe { NonZero::new_unchecked(remainder) })
-        }
+        // cannot overflow as self.length - self.index >= n
+        self.length -= n;
+        Ok(())
     }
 }
 
@@ -1663,6 +1660,19 @@ mod tests {
             assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 9);
             assert_eq!(iter.nth(2).unwrap().extract::<i32>().unwrap(), 8);
             assert!(iter.next().is_none());
+
+            // nth consumes all elements in the tuple, even on `None` return
+            let mut iter = tuple.iter();
+            assert!(iter.nth(100).is_none());
+            assert!(iter.next().is_none());
+            assert!(iter.next_back().is_none());
+
+            // nth should not overflow the iterator
+            // a naive implementation of nth will overflow if number of advanced
+            // elements plus N overflows usize::MAX
+            let mut iter = tuple.iter();
+            assert!(iter.next().is_some());
+            assert!(iter.nth(usize::MAX).is_none());
         });
     }
 
@@ -1705,6 +1715,17 @@ mod tests {
             iter3.nth(1);
             assert_eq!(iter3.nth_back(2).unwrap().extract::<i32>().unwrap(), 3);
             assert!(iter3.nth_back(0).is_none());
+
+            // nth_back consumes all elements in the tuple, even on `None` return
+            let mut iter4 = tuple.iter();
+            assert!(iter4.nth_back(100).is_none());
+            assert!(iter4.next_back().is_none());
+            assert!(iter4.next().is_none());
+
+            // nth_back should not overflow with usize::MAX
+            let mut iter5 = tuple.iter();
+            iter5.nth(1); //
+            assert!(iter5.nth_back(usize::MAX).is_none());
         });
     }
 
@@ -1730,6 +1751,19 @@ mod tests {
             let mut iter4 = tuple.iter();
             assert_eq!(iter4.advance_by(0), Ok(()));
             assert_eq!(iter4.next().unwrap().extract::<i32>().unwrap(), 1);
+
+            // advance_by should not overflow with usize::MAX
+            // - first advance will overflow by MAX - len, and will exhaust the iterator
+            // - second advance will overflow by MAX
+            let mut iter5 = tuple.iter();
+            assert_eq!(
+                iter5.advance_by(usize::MAX),
+                Err(NonZero::new(usize::MAX - tuple.len()).unwrap())
+            );
+            assert_eq!(
+                iter5.advance_by(usize::MAX),
+                Err(NonZero::new(usize::MAX).unwrap())
+            );
         })
     }
 
@@ -1755,6 +1789,19 @@ mod tests {
             let mut iter4 = tuple.iter();
             assert_eq!(iter4.advance_back_by(0), Ok(()));
             assert_eq!(iter4.next_back().unwrap().extract::<i32>().unwrap(), 5);
+
+            // advance_back_by should not overflow with usize::MAX
+            // - first advance will overflow by MAX - len, and will exhaust the iterator
+            // - second advance will overflow by MAX
+            let mut iter5 = tuple.iter();
+            assert_eq!(
+                iter5.advance_back_by(usize::MAX),
+                Err(NonZero::new(usize::MAX - tuple.len()).unwrap())
+            );
+            assert_eq!(
+                iter5.advance_back_by(usize::MAX),
+                Err(NonZero::new(usize::MAX).unwrap())
+            );
         })
     }
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1087,7 +1087,7 @@ tuple_conversion!(
 #[cfg(test)]
 mod tests {
     use crate::types::{any::PyAnyMethods, tuple::PyTupleMethods, PyList, PyTuple};
-    use crate::{IntoPyObject, Python};
+    use crate::{Bound, IntoPyObject, PyAny, Python};
     #[cfg(feature = "nightly")]
     use core::num::NonZero;
     use core::ops::Range;
@@ -1634,193 +1634,233 @@ mod tests {
         })
     }
 
+    /// Runs `f` for each of `BoundTupleIterator` and `BorrowedTupleIterator`.
+    fn test_iterators(
+        tuple: &Bound<'_, PyTuple>,
+        f: impl Fn(&mut dyn DoubleEndedIterator<Item = Bound<'_, PyAny>>),
+    ) {
+        let mut iter = tuple.iter();
+        f(&mut iter);
+
+        let mut borrowed_iter = tuple.iter_borrowed().map(|item| item.to_owned());
+        f(&mut borrowed_iter);
+    }
+
     #[test]
-    fn test_bound_tuple_nth() {
+    fn test_tuple_iter_nth() {
         Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4]).unwrap();
-            let mut iter = tuple.iter();
-            assert_eq!(iter.nth(1).unwrap().extract::<i32>().unwrap(), 2);
-            assert_eq!(iter.nth(1).unwrap().extract::<i32>().unwrap(), 4);
-            assert!(iter.nth(1).is_none());
+
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.nth(1).unwrap().extract::<i32>().unwrap(), 2);
+                assert_eq!(iter.nth(1).unwrap().extract::<i32>().unwrap(), 4);
+                assert!(iter.nth(1).is_none());
+            });
 
             let tuple = PyTuple::new(py, Vec::<i32>::new()).unwrap();
-            let mut iter = tuple.iter();
-            iter.next();
-            assert!(iter.nth(1).is_none());
+            test_iterators(&tuple, |iter| {
+                iter.next();
+                assert!(iter.nth(1).is_none());
+            });
 
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
-            let mut iter = tuple.iter();
-            assert!(iter.nth(10).is_none());
+            test_iterators(&tuple, |iter| {
+                assert!(iter.nth(10).is_none());
+            });
 
             let tuple = PyTuple::new(py, vec![6, 7, 8, 9, 10]).unwrap();
-            let mut iter = tuple.iter();
-            assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 6);
-            assert_eq!(iter.nth(2).unwrap().extract::<i32>().unwrap(), 9);
-            assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 10);
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 6);
+                assert_eq!(iter.nth(2).unwrap().extract::<i32>().unwrap(), 9);
+                assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 10);
+            });
 
-            let mut iter = tuple.iter();
-            assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 9);
-            assert_eq!(iter.nth(2).unwrap().extract::<i32>().unwrap(), 8);
-            assert!(iter.next().is_none());
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 9);
+                assert_eq!(iter.nth(2).unwrap().extract::<i32>().unwrap(), 8);
+                assert!(iter.next().is_none());
+            });
 
             // nth consumes all elements in the tuple, even on `None` return
-            let mut iter = tuple.iter();
-            assert!(iter.nth(100).is_none());
-            assert!(iter.next().is_none());
-            assert!(iter.next_back().is_none());
+            test_iterators(&tuple, |iter| {
+                assert!(iter.nth(100).is_none());
+                assert!(iter.next().is_none());
+                assert!(iter.next_back().is_none());
+            });
 
             // nth should not overflow the iterator
             // a naive implementation of nth will overflow if number of advanced
             // elements plus N overflows usize::MAX
-            let mut iter = tuple.iter();
-            assert!(iter.next().is_some());
-            assert!(iter.nth(usize::MAX).is_none());
+            test_iterators(&tuple, |iter| {
+                assert!(iter.next().is_some());
+                assert!(iter.nth(usize::MAX).is_none());
+            });
         });
     }
 
     #[test]
-    fn test_bound_tuple_nth_back() {
+    fn test_tuple_iter_nth_back() {
         Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
-            let mut iter = tuple.iter();
-            assert_eq!(iter.nth_back(0).unwrap().extract::<i32>().unwrap(), 5);
-            assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 3);
-            assert!(iter.nth_back(2).is_none());
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.nth_back(0).unwrap().extract::<i32>().unwrap(), 5);
+                assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 3);
+                assert!(iter.nth_back(2).is_none());
+            });
 
             let tuple = PyTuple::new(py, Vec::<i32>::new()).unwrap();
-            let mut iter = tuple.iter();
-            assert!(iter.nth_back(0).is_none());
-            assert!(iter.nth_back(1).is_none());
+            test_iterators(&tuple, |iter| {
+                assert!(iter.nth_back(0).is_none());
+                assert!(iter.nth_back(1).is_none());
+            });
 
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
-            let mut iter = tuple.iter();
-            assert!(iter.nth_back(5).is_none());
+            test_iterators(&tuple, |iter| {
+                assert!(iter.nth_back(5).is_none());
+            });
 
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
-            let mut iter = tuple.iter();
-            iter.next_back(); // Consume the last element
-            assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 3);
-            assert_eq!(iter.next_back().unwrap().extract::<i32>().unwrap(), 2);
-            assert_eq!(iter.nth_back(0).unwrap().extract::<i32>().unwrap(), 1);
+            test_iterators(&tuple, |iter| {
+                iter.next_back(); // Consume the last element
+                assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 3);
+                assert_eq!(iter.next_back().unwrap().extract::<i32>().unwrap(), 2);
+                assert_eq!(iter.nth_back(0).unwrap().extract::<i32>().unwrap(), 1);
+            });
 
-            let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
-            let mut iter = tuple.iter();
-            assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 4);
-            assert_eq!(iter.nth_back(2).unwrap().extract::<i32>().unwrap(), 1);
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 4);
+                assert_eq!(iter.nth_back(2).unwrap().extract::<i32>().unwrap(), 1);
+            });
 
-            let mut iter2 = tuple.iter();
-            iter2.next_back();
-            assert_eq!(iter2.nth_back(1).unwrap().extract::<i32>().unwrap(), 3);
-            assert_eq!(iter2.next_back().unwrap().extract::<i32>().unwrap(), 2);
+            test_iterators(&tuple, |iter| {
+                iter.next_back();
+                assert_eq!(iter.nth_back(1).unwrap().extract::<i32>().unwrap(), 3);
+                assert_eq!(iter.next_back().unwrap().extract::<i32>().unwrap(), 2);
+            });
 
-            let mut iter3 = tuple.iter();
-            iter3.nth(1);
-            assert_eq!(iter3.nth_back(2).unwrap().extract::<i32>().unwrap(), 3);
-            assert!(iter3.nth_back(0).is_none());
+            test_iterators(&tuple, |iter| {
+                iter.nth(1);
+                assert_eq!(iter.nth_back(2).unwrap().extract::<i32>().unwrap(), 3);
+                assert!(iter.nth_back(0).is_none());
+            });
 
             // nth_back consumes all elements in the tuple, even on `None` return
-            let mut iter4 = tuple.iter();
-            assert!(iter4.nth_back(100).is_none());
-            assert!(iter4.next_back().is_none());
-            assert!(iter4.next().is_none());
+            test_iterators(&tuple, |iter| {
+                assert!(iter.nth_back(100).is_none());
+                assert!(iter.next_back().is_none());
+                assert!(iter.next().is_none());
+            });
 
             // nth_back should not overflow with usize::MAX
-            let mut iter5 = tuple.iter();
-            iter5.nth(1); //
-            assert!(iter5.nth_back(usize::MAX).is_none());
+            test_iterators(&tuple, |iter| {
+                iter.nth(1);
+                assert!(iter.nth_back(usize::MAX).is_none());
+            });
         });
     }
 
     #[cfg(feature = "nightly")]
     #[test]
-    fn test_bound_tuple_advance_by() {
+    fn test_tuple_iter_advance_by() {
         Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
-            let mut iter = tuple.iter();
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.advance_by(2), Ok(()));
+                assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 3);
+                assert_eq!(iter.advance_by(0), Ok(()));
+                assert_eq!(iter.advance_by(100), Err(NonZero::new(98).unwrap()));
+                assert!(iter.next().is_none());
+            });
 
-            assert_eq!(iter.advance_by(2), Ok(()));
-            assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 3);
-            assert_eq!(iter.advance_by(0), Ok(()));
-            assert_eq!(iter.advance_by(100), Err(NonZero::new(98).unwrap()));
-            assert!(iter.next().is_none());
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.advance_by(6), Err(NonZero::new(1).unwrap()));
+            });
 
-            let mut iter2 = tuple.iter();
-            assert_eq!(iter2.advance_by(6), Err(NonZero::new(1).unwrap()));
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.advance_by(5), Ok(()));
+            });
 
-            let mut iter3 = tuple.iter();
-            assert_eq!(iter3.advance_by(5), Ok(()));
-
-            let mut iter4 = tuple.iter();
-            assert_eq!(iter4.advance_by(0), Ok(()));
-            assert_eq!(iter4.next().unwrap().extract::<i32>().unwrap(), 1);
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.advance_by(0), Ok(()));
+                assert_eq!(iter.next().unwrap().extract::<i32>().unwrap(), 1);
+            });
 
             // advance_by should not overflow with usize::MAX
             // - first advance will overflow by MAX - len, and will exhaust the iterator
             // - second advance will overflow by MAX
-            let mut iter5 = tuple.iter();
-            assert_eq!(
-                iter5.advance_by(usize::MAX),
-                Err(NonZero::new(usize::MAX - tuple.len()).unwrap())
-            );
-            assert_eq!(
-                iter5.advance_by(usize::MAX),
-                Err(NonZero::new(usize::MAX).unwrap())
-            );
+            test_iterators(&tuple, |iter| {
+                assert_eq!(
+                    iter.advance_by(usize::MAX),
+                    Err(NonZero::new(usize::MAX - 5).unwrap())
+                );
+                assert_eq!(
+                    iter.advance_by(usize::MAX),
+                    Err(NonZero::new(usize::MAX).unwrap())
+                );
+            });
         })
     }
 
     #[cfg(feature = "nightly")]
     #[test]
-    fn test_bound_tuple_advance_back_by() {
+    fn test_tuple_iter_advance_back_by() {
         Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3, 4, 5]).unwrap();
-            let mut iter = tuple.iter();
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.advance_back_by(2), Ok(()));
+                assert_eq!(iter.next_back().unwrap().extract::<i32>().unwrap(), 3);
+                assert_eq!(iter.advance_back_by(0), Ok(()));
+                assert_eq!(iter.advance_back_by(100), Err(NonZero::new(98).unwrap()));
+                assert!(iter.next_back().is_none());
+            });
 
-            assert_eq!(iter.advance_back_by(2), Ok(()));
-            assert_eq!(iter.next_back().unwrap().extract::<i32>().unwrap(), 3);
-            assert_eq!(iter.advance_back_by(0), Ok(()));
-            assert_eq!(iter.advance_back_by(100), Err(NonZero::new(98).unwrap()));
-            assert!(iter.next_back().is_none());
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.advance_back_by(6), Err(NonZero::new(1).unwrap()));
+            });
 
-            let mut iter2 = tuple.iter();
-            assert_eq!(iter2.advance_back_by(6), Err(NonZero::new(1).unwrap()));
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.advance_back_by(5), Ok(()));
+            });
 
-            let mut iter3 = tuple.iter();
-            assert_eq!(iter3.advance_back_by(5), Ok(()));
-
-            let mut iter4 = tuple.iter();
-            assert_eq!(iter4.advance_back_by(0), Ok(()));
-            assert_eq!(iter4.next_back().unwrap().extract::<i32>().unwrap(), 5);
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.advance_back_by(0), Ok(()));
+                assert_eq!(iter.next_back().unwrap().extract::<i32>().unwrap(), 5);
+            });
 
             // advance_back_by should not overflow with usize::MAX
             // - first advance will overflow by MAX - len, and will exhaust the iterator
             // - second advance will overflow by MAX
-            let mut iter5 = tuple.iter();
-            assert_eq!(
-                iter5.advance_back_by(usize::MAX),
-                Err(NonZero::new(usize::MAX - tuple.len()).unwrap())
-            );
-            assert_eq!(
-                iter5.advance_back_by(usize::MAX),
-                Err(NonZero::new(usize::MAX).unwrap())
-            );
+            test_iterators(&tuple, |iter| {
+                assert_eq!(
+                    iter.advance_back_by(usize::MAX),
+                    Err(NonZero::new(usize::MAX - 5).unwrap())
+                );
+                assert_eq!(
+                    iter.advance_back_by(usize::MAX),
+                    Err(NonZero::new(usize::MAX).unwrap())
+                );
+            });
         })
     }
 
     #[test]
-    fn test_iter_last() {
+    fn test_tuple_iter_last() {
         Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
-            let last = tuple.iter().last();
-            assert_eq!(last.unwrap().extract::<i32>().unwrap(), 3);
+            test_iterators(&tuple, |iter| {
+                let last = iter.last();
+                assert_eq!(last.unwrap().extract::<i32>().unwrap(), 3);
+            });
         })
     }
 
     #[test]
-    fn test_iter_count() {
+    fn test_tuple_iter_count() {
         Python::attach(|py| {
             let tuple = PyTuple::new(py, vec![1, 2, 3]).unwrap();
-            assert_eq!(tuple.iter().count(), 3);
+            test_iterators(&tuple, |iter| {
+                assert_eq!(iter.count(), 3);
+            });
         })
     }
 }

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -594,9 +594,11 @@ impl DoubleEndedIterator for BorrowedTupleIterator<'_, '_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.index < self.length {
-            // SAFETY: self.index < self.length
-            let item = unsafe { self.tuple.get_borrowed_item_unchecked(self.index) };
-            self.length -= 1;
+            // Cannot underflow as self.index < self.length implies self.length > 0
+            let target_index = self.length - 1;
+            // SAFETY: target_index < self.length
+            let item = unsafe { self.tuple.get_borrowed_item_unchecked(target_index) };
+            self.length = target_index;
             Some(item)
         } else {
             None


### PR DESCRIPTION
This PR fixes issues with `tuple` and `list` iterators:
- `nth` / `nth_back` with large N could overflow usize and wrap, leading to out of bounds reads via `get_unchecked`
- if N exceeds the number of remaining items in the iterator, `nth` / `nth_back` should exhaust the iterator - the existing implementations did not do this

This is primarily done by rewriting `nth` / `nth_back` to use `checked_` mathematical operations to avoid the possible overflow.

I verified the `advance_by` / `advance_back_by` nightly operations were not affected by the same issue; they turned out to be fine, however I wrote them to use `saturating_` operations to make it easier (for me) to read their implementations.

(Credit to Codex security scanning for the discovery of the out of bound reads; the failure to exhaust is my addition when scrutinising these methods.)