### PR TITLE
ci: expand `pyo3-ffi-check` to check return type size / alignment

### DIFF
--- a/newsfragments/6090.fixed.md
+++ b/newsfragments/6090.fixed.md
@@ -1,1 +1,2 @@
 Fix return type of `PyBuffer_SizeFromFormat` on Python 3.8 (was changed from `c_int` to `Py_ssize_t` on Python 3.9).
+Fix return type of `PyUnicode_Tailmatch` on PyPy (is `c_int`, unlike CPython).

--- a/newsfragments/6090.fixed.md
+++ b/newsfragments/6090.fixed.md
@@ -1,0 +1,1 @@
+Fix return type of `PyBuffer_SizeFromFormat` on Python 3.8 (was changed from `c_int` to `Py_ssize_t` on Python 3.9).

--- a/pyo3-ffi-check/macro/src/lib.rs
+++ b/pyo3-ffi-check/macro/src/lib.rs
@@ -547,7 +547,6 @@ pub fn for_all_functions(_input: proc_macro::TokenStream) -> proc_macro::TokenSt
             modifiers,
             arg_count,
             variadic,
-            void_return,
         } = match (function_name, get_function_info(function_name, &entry)) {
             (_, Ok(info)) => info,
             // In some cases symbols and macros differ only by case, which is a problem for case-insensitive filesystems.
@@ -559,32 +558,27 @@ pub fn for_all_functions(_input: proc_macro::TokenStream) -> proc_macro::TokenSt
                 modifiers: quote!(),
                 arg_count: 1,
                 variadic: false,
-                void_return: true,
             },
             ("Py_IncRef", Err(FunctionNameMismatch(e))) if e == "Py_INCREF" => FunctionInfo {
                 modifiers: quote!(extern "C"),
                 arg_count: 1,
                 variadic: false,
-                void_return: true,
             },
             ("Py_DECREF", Err(FunctionNameMismatch(e))) if e == "Py_DecRef" => FunctionInfo {
                 modifiers: quote!(),
                 arg_count: 1,
                 variadic: false,
-                void_return: true,
             },
             ("Py_DecRef", Err(FunctionNameMismatch(e))) if e == "Py_DECREF" => FunctionInfo {
                 modifiers: quote!(extern "C"),
                 arg_count: 1,
                 variadic: false,
-                void_return: true,
             },
             ("PyThreadState_GET", Err(FunctionNameMismatch(e))) if e == "PyThreadState_Get" => {
                 FunctionInfo {
                     modifiers: quote!(),
                     arg_count: 0,
                     variadic: false,
-                    void_return: false,
                 }
             }
             ("PyThreadState_Get", Err(FunctionNameMismatch(e))) if e == "PyThreadState_GET" => {
@@ -592,7 +586,6 @@ pub fn for_all_functions(_input: proc_macro::TokenStream) -> proc_macro::TokenSt
                     modifiers: quote!(extern "C"),
                     arg_count: 0,
                     variadic: false,
-                    void_return: false,
                 }
             }
             (function_name, Err(FunctionNameMismatch(unexpected))) => {
@@ -607,8 +600,6 @@ pub fn for_all_functions(_input: proc_macro::TokenStream) -> proc_macro::TokenSt
         let function_ident = Ident::new(function_name, Span::call_site());
 
         let arg_types = std::iter::repeat_n(quote!(_), arg_count);
-
-        let retval = if void_return { quote!() } else { quote!(-> _) };
 
         let vararg = if variadic { Some(quote!(, ...)) } else { None };
 
@@ -634,24 +625,6 @@ pub fn for_all_functions(_input: proc_macro::TokenStream) -> proc_macro::TokenSt
             .map(|cfg| cfg.parse().expect("failed to parse macro exclusion cfg"));
 
         let has_symbol = BINDGEN_FUNCTION_NAMES.contains(function_name);
-
-        if has_symbol {
-            if let Ok(FunctionInfo {
-                void_return: bindgen_void_return,
-                ..
-            }) = get_function_info(
-                function_name,
-                &DOC_DIR.join(format!("bindgen/fn.{}.html", function_name)),
-            ) {
-                if void_return != bindgen_void_return {
-                    let error_message = format!(
-                        "void return mismatch between pyo3-ffi and bindgen for `{function_name}`: pyo3-ffi has void return {void_return}, but bindgen has void return {bindgen_void_return}",
-                    );
-                    output.extend(quote!(compile_error!(#error_message);));
-                }
-            }
-        }
-
         match (macro_exclusion_cfg, has_symbol) {
             (Some(cfg), true) => {
                 // emit an error if checking within the cfgs where a macro is expected
@@ -661,7 +634,7 @@ pub fn for_all_functions(_input: proc_macro::TokenStream) -> proc_macro::TokenSt
                 output.extend(quote!(#[cfg(#cfg)] compile_error!(#error_message);));
                 // if not within the macro range, we found a symbol, this should be good
                 output.extend(
-                    quote!(#[cfg(not(#cfg))] #macro_name!(#inline #function_ident, #modifiers (#(#arg_types),* #vararg) #retval);),
+                    quote!(#[cfg(not(#cfg))] #macro_name!(#inline #function_ident, #modifiers (#(#arg_types),* #vararg));),
                 );
             }
             (Some(cfg), false) => {
@@ -675,7 +648,7 @@ pub fn for_all_functions(_input: proc_macro::TokenStream) -> proc_macro::TokenSt
             (None, true) => {
                 // emit the comparison macro to check that the argument count matches
                 output.extend(
-                    quote!(#macro_name!(#inline #function_ident, #modifiers (#(#arg_types),* #vararg) #retval);),
+                    quote!(#macro_name!(#inline #function_ident, #modifiers (#(#arg_types),* #vararg));),
                 );
             }
             (None, false) => {
@@ -694,8 +667,8 @@ pub fn for_all_functions(_input: proc_macro::TokenStream) -> proc_macro::TokenSt
 struct FunctionInfo {
     modifiers: TokenStream, // e.g. `unsafe extern "C"`, empty for no modifiers
     arg_count: usize,       // not including the "..." for variadic functions
+    /// Whether the function is variadic (i.e. trailing `...` in argument list)
     variadic: bool,
-    void_return: bool, // whether the function returns void (i.e. has no return type in C)
 }
 
 // Error returned when the function definition does not match the expected name of the file
@@ -772,17 +745,10 @@ fn get_function_info(
         arg_count += 1;
     }
 
-    let end_paren = args_begin[end..]
-        .find(')')
-        .expect("function declaration should have closing paren after arguments");
-
-    let after_parens = args_begin[end + end_paren + 1..].trim_start();
-
     Ok(FunctionInfo {
         modifiers,
         arg_count,
         variadic,
-        void_return: !after_parens.contains("->"),
     })
 }
 

--- a/pyo3-ffi-check/src/main.rs
+++ b/pyo3-ffi-check/src/main.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CStr, process::exit};
+use std::{any::Any, ffi::CStr, process::exit};
 
 use pyo3_ffi_check_definitions::{bindgen as bindings, pyo3_ffi};
 
@@ -71,20 +71,107 @@ fn main() {
 
     pyo3_ffi_check_macro::for_all_structs!(check_struct);
 
-    // This macro attempts to check that both functions exist and have the same number of arguments, it is
-    // difficult to check the argument types match.
+    struct ReturnTypeSniffer<T> {
+        _marker: std::marker::PhantomData<T>,
+    }
+
+    impl<T: Any> ReturnTypeSniffer<T> {
+        /// Uses type inference of return value from a closure to sniff return type `T` without needing
+        /// to ever call the function.
+        fn new(_: impl FnOnce() -> T) -> Self {
+            Self {
+                _marker: std::marker::PhantomData,
+            }
+        }
+
+        fn check_compatible<U: Any>(
+            symbol: &str,
+            pyo3_ffi_type: &ReturnTypeSniffer<T>,
+            bindgen_type: &ReturnTypeSniffer<U>,
+        ) -> bool {
+            let mut compatible = true;
+            if std::mem::size_of::<T>() != std::mem::size_of::<U>() {
+                compatible = false;
+                println!(
+                    "error: {symbol} return type size differs (pyo3-ffi type is {}, bindgen type is {})",
+                    std::any::type_name::<T>(),
+                    std::any::type_name::<U>(),
+                );
+            }
+
+            if std::mem::align_of::<T>() != std::mem::align_of::<U>() {
+                compatible = false;
+                println!(
+                    "error: {symbol} return type alignment differs (pyo3-ffi type is is {}, bindgen type is {})",
+                    std::any::type_name::<T>(),
+                    std::any::type_name::<U>(),
+                );
+            }
+            compatible
+        }
+    }
+
+    /// tt muncher macro replacing arg types with `todo!()` to
+    /// allow to sniff return type
+    macro_rules! todo_args {
+        // entry point
+        (($f:expr)($($args:tt)*)) => {
+            todo_args!(@[($f)()] $($args)*)
+        };
+        // terminate when no more args
+        (@[($f:expr)($($inferred:tt)*)]) => {
+            // allow not expect because args might be empty
+            #[allow(unreachable_code, reason = "args are todo!()")]
+            ($f)($($inferred)*)
+        };
+        // consume comma
+        (@[($f:expr)($($inferred:tt)*)] , $($args:tt)*) => {
+            todo_args!(@[($f)($($inferred)* ,)] $($args)*)
+        };
+        // consume `_`
+        (@[($f:expr)($($inferred:tt)*)] _ $($args:tt)*) => {
+            todo_args!(@[($f)($($inferred)* todo!())] $($args)*)
+        };
+        // consume trailing `...`
+        (@[($f:expr)($($inferred:tt)*)] ...) => {
+            todo_args!(@[($f)($($inferred)*)])
+        };
+    }
+
     macro_rules! check_function {
-        ($name:ident, [$($modifiers:tt)*] ($($arg_types:tt)*) $(-> $($retval:tt)*)?) => {{
+        ($name:ident, [$($modifiers:tt)*] ($($arg_types:tt)*)) => {{
+            // Check functions have the same number of arguments
             #[allow(deprecated)]
-            { pyo3_ffi::$name as $($modifiers)* fn($($arg_types)*) $(-> $($retval)*)? };
-            bindings::$name as $($modifiers)* fn($($arg_types)*) $(-> $($retval)*)?;
+            { pyo3_ffi::$name as $($modifiers)* fn($($arg_types)*) -> _ };
+            bindings::$name as $($modifiers)* fn($($arg_types)*) -> _;
+
+            // TODO: can probably sniff arg types by binding sniffers for each argument position and then passing
+            // those inside `todo_args!` to use type inference for each argument.
+
+            // Check return types are compatible
+            #[allow(deprecated)]
+            let pyo3_ffi_return_type = ReturnTypeSniffer::new(|| unsafe { todo_args!((pyo3_ffi::$name)($($arg_types)*)) });
+            let bindgen_return_type = ReturnTypeSniffer::new(|| unsafe { todo_args!((bindings::$name)($($arg_types)*)) });
+
+            failed |= !ReturnTypeSniffer::check_compatible(stringify!($name), &pyo3_ffi_return_type, &bindgen_return_type);
         }};
         // case when the function is an inline function in the headers, in which case pyo3-ffi will use the
         // Rust abi and the extern symbol uses the C abi
-        (@inline $name:ident, ($($arg_types:tt)*) $(-> $($retval:tt)*)?) => {{
+        (@inline $name:ident, ($($arg_types:tt)*)) => {{
+            // Check functions have the same number of arguments
             #[allow(deprecated)]
-            { pyo3_ffi::$name as unsafe fn($($arg_types)*) $(-> $($retval)*)? };
-            bindings::$name as unsafe extern "C" fn($($arg_types)*) $(-> $($retval)*)?;
+            { pyo3_ffi::$name as unsafe fn($($arg_types)*) -> _ };
+            bindings::$name as unsafe extern "C" fn($($arg_types)*) -> _;
+
+            // TODO: can probably sniff arg types by binding sniffers for each argument position and then passing
+            // those inside `todo_args!` to use type inference for each argument.
+
+            // Check return types are compatible
+            #[allow(deprecated)]
+            let pyo3_ffi_return_type = ReturnTypeSniffer::new(|| unsafe { todo_args!((pyo3_ffi::$name)($($arg_types)*)) });
+            let bindgen_return_type = ReturnTypeSniffer::new(|| unsafe { todo_args!((bindings::$name)($($arg_types)*)) });
+
+            failed |= !ReturnTypeSniffer::check_compatible(stringify!($name), &pyo3_ffi_return_type, &bindgen_return_type);
         }};
     }
 

--- a/pyo3-ffi-check/src/main.rs
+++ b/pyo3-ffi-check/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
             if std::mem::align_of::<T>() != std::mem::align_of::<U>() {
                 compatible = false;
                 println!(
-                    "error: {symbol} return type alignment differs (pyo3-ffi type is is {}, bindgen type is {})",
+                    "error: {symbol} return type alignment differs (pyo3-ffi type is {}, bindgen type is {})",
                     std::any::type_name::<T>(),
                     std::any::type_name::<U>(),
                 );

--- a/pyo3-ffi-check/src/main.rs
+++ b/pyo3-ffi-check/src/main.rs
@@ -86,8 +86,8 @@ fn main() {
 
         fn check_compatible<U: Any>(
             symbol: &str,
-            pyo3_ffi_type: &ReturnTypeSniffer<T>,
-            bindgen_type: &ReturnTypeSniffer<U>,
+            _pyo3_ffi_type: &ReturnTypeSniffer<T>,
+            _bindgen_type: &ReturnTypeSniffer<U>,
         ) -> bool {
             let mut compatible = true;
             if std::mem::size_of::<T>() != std::mem::size_of::<U>() {

--- a/pyo3-ffi-check/src/main.rs
+++ b/pyo3-ffi-check/src/main.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, ffi::CStr, process::exit};
+use std::{ffi::CStr, process::exit};
 
 use pyo3_ffi_check_definitions::{bindgen as bindings, pyo3_ffi};
 
@@ -75,7 +75,7 @@ fn main() {
         _marker: std::marker::PhantomData<T>,
     }
 
-    impl<T: Any> ReturnTypeSniffer<T> {
+    impl<T> ReturnTypeSniffer<T> {
         /// Uses type inference of return value from a closure to sniff return type `T` without needing
         /// to ever call the function.
         fn new(_: impl FnOnce() -> T) -> Self {
@@ -84,7 +84,7 @@ fn main() {
             }
         }
 
-        fn check_compatible<U: Any>(
+        fn check_compatible<U>(
             symbol: &str,
             _pyo3_ffi_type: &ReturnTypeSniffer<T>,
             _bindgen_type: &ReturnTypeSniffer<U>,

--- a/pyo3-ffi/src/cpython/abstract_.rs
+++ b/pyo3-ffi/src/cpython/abstract_.rs
@@ -202,6 +202,10 @@ extern_libpython! {
         indices: *mut Py_ssize_t,
     ) -> *mut core::ffi::c_void;
     #[cfg_attr(PyPy, link_name = "PyPyBuffer_SizeFromFormat")]
+    #[cfg(not(Py_3_9))] // return value changed from c_int to Py_ssize_t in 3.9
+    pub fn PyBuffer_SizeFromFormat(format: *const c_char) -> c_int;
+    #[cfg_attr(PyPy, link_name = "PyPyBuffer_SizeFromFormat")]
+    #[cfg(Py_3_9)]
     pub fn PyBuffer_SizeFromFormat(format: *const c_char) -> Py_ssize_t;
     #[cfg_attr(PyPy, link_name = "PyPyBuffer_ToContiguous")]
     pub fn PyBuffer_ToContiguous(

--- a/pyo3-ffi/src/cpython/cellobject.rs
+++ b/pyo3-ffi/src/cpython/cellobject.rs
@@ -11,7 +11,7 @@ pub struct PyCellObject {
 extern_libpython! {
     pub fn PyCell_New(o: *mut PyObject) -> *mut PyObject;
     pub fn PyCell_Get(o: *mut PyObject) -> *mut PyObject;
-    pub fn PyCell_Set(o: *mut PyObject, val: *mut PyObject) -> *mut PyObject;
+    pub fn PyCell_Set(o: *mut PyObject, val: *mut PyObject) -> c_int;
     pub static mut PyCell_Type: PyTypeObject;
 }
 

--- a/pyo3-ffi/src/cpython/pyframe.rs
+++ b/pyo3-ffi/src/cpython/pyframe.rs
@@ -69,8 +69,8 @@ extern_libpython! {
     pub fn PyUnstable_InterpreterFrame_GetCode(frame: *mut _PyInterpreterFrame) -> *mut PyObject;
 
     #[cfg(Py_3_12)]
-    pub fn PyUnstable_InterpreterFrame_GetLasti(frame: *mut _PyInterpreterFrame) -> *mut PyObject;
+    pub fn PyUnstable_InterpreterFrame_GetLasti(frame: *mut _PyInterpreterFrame) -> c_int;
 
     #[cfg(Py_3_12)]
-    pub fn PyUnstable_InterpreterFrame_GetLine(frame: *mut _PyInterpreterFrame) -> *mut PyObject;
+    pub fn PyUnstable_InterpreterFrame_GetLine(frame: *mut _PyInterpreterFrame) -> c_int;
 }

--- a/pyo3-ffi/src/unicodeobject.rs
+++ b/pyo3-ffi/src/unicodeobject.rs
@@ -297,6 +297,15 @@ extern_libpython! {
     ) -> *mut PyObject;
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_Join")]
     pub fn PyUnicode_Join(separator: *mut PyObject, seq: *mut PyObject) -> *mut PyObject;
+}
+
+#[cfg(PyPy)]
+type TailmatchResult = c_int;
+
+#[cfg(not(PyPy))]
+type TailmatchResult = Py_ssize_t;
+
+extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_Tailmatch")]
     pub fn PyUnicode_Tailmatch(
         str: *mut PyObject,
@@ -304,7 +313,7 @@ extern_libpython! {
         start: Py_ssize_t,
         end: Py_ssize_t,
         direction: c_int,
-    ) -> Py_ssize_t;
+    ) -> TailmatchResult;
     #[cfg_attr(PyPy, link_name = "PyPyUnicode_Find")]
     pub fn PyUnicode_Find(
         str: *mut PyObject,


### PR DESCRIPTION
This PR expands `pyo3-ffi-check` to verify that FFI definition return types are approximately ABI compatible (size & alignment).

It also catches existing FFI definitions which are incorrect which slipped in; thankfully none made it to a release yet.