### PR TITLE
Use new `PyType_FromSlots` api

### DIFF
--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -513,9 +513,8 @@ impl PyTypeBuilder {
                 ffi::PySlot_UINT64(ffi::Py_tp_flags, flags.into()),
                 ffi::PySlot_DATA(ffi::Py_tp_slots, self.slots.as_mut_ptr().cast::<c_void>()),
                 match basicsize {
-                    1.. => ffi::PySlot_SIZE(ffi::Py_tp_basicsize, basicsize),
+                    0.. => ffi::PySlot_SIZE(ffi::Py_tp_basicsize, basicsize),
                     ..0 => ffi::PySlot_SIZE(ffi::Py_tp_extra_basicsize, -basicsize),
-                    0 => ffi::PySlot_END(),
                 },
                 ffi::PySlot_END(),
             ];

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -511,6 +511,7 @@ impl PyTypeBuilder {
             let mut slots = [
                 ffi::PySlot_DATA(ffi::Py_tp_name, class_name.as_ptr() as *mut c_void),
                 ffi::PySlot_SIZE(ffi::Py_tp_basicsize, basicsize),
+                ffi::PySlot_SIZE(ffi::Py_tp_itemsize, 0),
                 ffi::PySlot_UINT64(ffi::Py_tp_flags, flags.into()),
                 ffi::PySlot_DATA(ffi::Py_tp_slots, self.slots.as_mut_ptr().cast::<c_void>()),
                 ffi::PySlot_END(),

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -510,10 +510,13 @@ impl PyTypeBuilder {
         let type_object = {
             let mut slots = [
                 ffi::PySlot_DATA(ffi::Py_tp_name, class_name.as_ptr() as *mut c_void),
-                ffi::PySlot_SIZE(ffi::Py_tp_basicsize, basicsize),
-                ffi::PySlot_SIZE(ffi::Py_tp_itemsize, 0),
                 ffi::PySlot_UINT64(ffi::Py_tp_flags, flags.into()),
                 ffi::PySlot_DATA(ffi::Py_tp_slots, self.slots.as_mut_ptr().cast::<c_void>()),
+                match basicsize {
+                    1.. => ffi::PySlot_SIZE(ffi::Py_tp_basicsize, basicsize),
+                    ..0 => ffi::PySlot_SIZE(ffi::Py_tp_extra_basicsize, -basicsize),
+                    0 => ffi::PySlot_END(),
+                },
                 ffi::PySlot_END(),
             ];
 

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -504,23 +504,44 @@ impl PyTypeBuilder {
         unsafe { self.push_slot(0, ptr::null_mut::<c_void>()) }
 
         let class_name = py_class_qualified_name(module_name, name)?;
-        let mut spec = ffi::PyType_Spec {
-            name: class_name.as_ptr() as _,
-            basicsize: basicsize as c_int,
-            itemsize: 0,
+        let flags = ffi::Py_TPFLAGS_DEFAULT | self.class_flags;
 
-            flags: (ffi::Py_TPFLAGS_DEFAULT | self.class_flags)
-                .try_into()
-                .unwrap(),
-            slots: self.slots.as_mut_ptr(),
+        #[cfg(Py_3_15)]
+        let type_object = {
+            let mut slots = [
+                ffi::PySlot_DATA(ffi::Py_tp_name, class_name.as_ptr() as *mut c_void),
+                ffi::PySlot_SIZE(ffi::Py_tp_basicsize, basicsize),
+                ffi::PySlot_UINT64(ffi::Py_tp_flags, flags.into()),
+                ffi::PySlot_DATA(ffi::Py_tp_slots, self.slots.as_mut_ptr().cast::<c_void>()),
+                ffi::PySlot_END(),
+            ];
+
+            // SAFETY: We've correctly setup the slots array at this point.
+            // The FFI call is known to return a new type object or null on error.
+            unsafe {
+                ffi::PyType_FromSlots(slots.as_mut_ptr())
+                    .assume_owned_or_err(py)?
+                    .cast_into_unchecked::<PyType>()
+            }
         };
 
-        // SAFETY: We've correctly setup the PyType_Spec at this point
-        // The FFI call is known to return a new type object or null on error
-        let type_object = unsafe {
-            ffi::PyType_FromSpec(&mut spec)
-                .assume_owned_or_err(py)?
-                .cast_into_unchecked::<PyType>()
+        #[cfg(not(Py_3_15))]
+        let type_object = {
+            let mut spec = ffi::PyType_Spec {
+                name: class_name.as_ptr() as _,
+                basicsize: basicsize as c_int,
+                itemsize: 0,
+                flags: flags.try_into().unwrap(),
+                slots: self.slots.as_mut_ptr(),
+            };
+
+            // SAFETY: We've correctly setup the PyType_Spec at this point.
+            // The FFI call is known to return a new type object or null on error.
+            unsafe {
+                ffi::PyType_FromSpec(&mut spec)
+                    .assume_owned_or_err(py)?
+                    .cast_into_unchecked::<PyType>()
+            }
         };
 
         #[cfg(not(Py_3_11))]


### PR DESCRIPTION
This switches #[pyclass] type creation on Python 3.15+ to the new slots API from PEP 820.
Before this change, pyclass types were always created through PyType_FromSpec with PyType_Spec.
Now, on 3.15+, we build a PySlot array and call PyType_FromSlots instead.

The non-3.15 path is unchanged and still uses PyType_FromSpec.