### PR TITLE
fix reference count leak in `PyFrame::new`

### DIFF
--- a/src/types/frame.rs
+++ b/src/types/frame.rs
@@ -43,7 +43,7 @@ impl PyFrame {
         unsafe {
             Ok(ffi::PyFrame_New(
                 state,
-                code.into_ptr().cast(),
+                code.as_ptr().cast(),
                 globals.as_ptr(),
                 locals.as_ptr(),
             )


### PR DESCRIPTION
Codex security scanning spotted this; we haven't released it yet.

As far as I can tell from checking the implementation and docs of `PyFrame_New`, indeed the reference is not stolen so `.into_ptr()` was a leak.