### PR TITLE
fix possible type confusion in `PyClassGuardMut::as_super`

### DIFF
--- a/newsfragments/6104.added.md
+++ b/newsfragments/6104.added.md
@@ -1,0 +1,1 @@
+added `PyClassGuardMapSuper`

--- a/newsfragments/6104.fixed.md
+++ b/newsfragments/6104.fixed.md
@@ -1,0 +1,1 @@
+fixed soundness issue caused by exposing a mutable reference from `PyClassGuardMut::as_super` by moving into `PyClassGuardMutSuper`

--- a/src/pyclass.rs
+++ b/src/pyclass.rs
@@ -11,6 +11,7 @@ pub(crate) use self::create_type_object::{create_type_object, PyClassTypeObject}
 pub use self::gc::{PyTraverseError, PyVisit};
 pub use self::guard::{
     PyClassGuard, PyClassGuardError, PyClassGuardMap, PyClassGuardMut, PyClassGuardMutError,
+    PyClassGuardMutSuper,
 };
 
 /// Types that can be used as Python classes.

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -701,9 +701,15 @@ where
     /// super-superclass (and so on).
     ///
     /// See [`PyClassGuard::as_super`] for more.
-    pub fn as_super(&mut self) -> &mut PyClassGuardMut<'a, T::BaseType> {
-        // SAFETY: `PyClassGuardMut<T>` and `PyClassGuardMut<U>` have the same layout
-        unsafe { NonNull::from(self).cast().as_mut() }
+    ///
+    /// # Note
+    ///
+    /// The mutable reference to the is not exposed directly, but through [PyClassGuardMutSuper].
+    pub fn as_super(&mut self) -> PyClassGuardMutSuper<'_, 'a, T::BaseType> {
+        PyClassGuardMutSuper {
+            // SAFETY: `PyClassGuardMut<T>` and `PyClassGuardMut<U>` have the same layout
+            guard: unsafe { NonNull::from(self).cast().as_mut() },
+        }
     }
 
     /// Gets a `PyClassGuardMut<T::BaseType>`.
@@ -839,6 +845,59 @@ impl From<PyClassGuardMutError<'_, '_>> for PyErr {
         } else {
             PyBorrowMutError::new().into()
         }
+    }
+}
+
+/// Wraps a borrowed mutable reference to the base class `T::BaseType` of a PyClass `T`
+///
+/// See [`PyClassGuardMut::as_super`]
+#[repr(transparent)]
+pub struct PyClassGuardMutSuper<'a, 'g, T: PyClass<Frozen = False>> {
+    // NOTE: Exposing this directly from `PyClassGuardMut::as_super` would allow swapping this
+    // `guard` with another guard of the same basetype but different subtype. That is unsound as the
+    // original `PyClassGuardMut` allows access to the `T` stored inside. By wrapping the guard in a
+    // new type which does not expose a mutable reference to the guard directly we ensure that this
+    // swap is impossible.
+    guard: &'a mut PyClassGuardMut<'g, T>,
+}
+
+impl<'a, 'g, T> PyClassGuardMutSuper<'a, 'g, T>
+where
+    T: PyClass<Frozen = False>,
+    T::BaseType: PyClass<Frozen = False>,
+{
+    /// Borrows a mutable reference to `PyClassGuardMut<T::BaseType>`.
+    ///
+    /// See [`PyClassGuardMut::as_super`] for more.
+    pub fn as_super(&mut self) -> PyClassGuardMutSuper<'a, 'g, T::BaseType> {
+        PyClassGuardMutSuper {
+            // SAFETY: `PyClassGuardMut<T>` and `PyClassGuardMut<U>` have the same layout
+            guard: unsafe { NonNull::from(&mut *self.guard).cast().as_mut() },
+        }
+    }
+}
+
+impl<T> Deref for PyClassGuardMutSuper<'_, '_, T>
+where
+    T: PyClass<Frozen = False>,
+{
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: `PyClassObject<T>` contains a valid `T`, by construction no
+        // alias is enforced
+        unsafe { &*self.guard.as_class_object().get_ptr().cast_const() }
+    }
+}
+
+impl<T> DerefMut for PyClassGuardMutSuper<'_, '_, T>
+where
+    T: PyClass<Frozen = False>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: `PyClassObject<T>` contains a valid `T`, by construction no
+        // alias is enforced
+        unsafe { &mut *self.guard.as_class_object().get_ptr() }
     }
 }
 

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -704,7 +704,7 @@ where
     ///
     /// # Note
     ///
-    /// The mutable reference to the is not exposed directly, but through [PyClassGuardMutSuper].
+    /// The mutable reference to the base type is not exposed directly, but through [`PyClassGuardMutSuper`].
     pub fn as_super(&mut self) -> PyClassGuardMutSuper<'_, 'a, T::BaseType> {
         PyClassGuardMutSuper {
             // SAFETY: `PyClassGuardMut<T>` and `PyClassGuardMut<U>` have the same layout


### PR DESCRIPTION
This fixes a possible type confusion in `PyClassGuardMut::as_super` by moving the exposed mutable reference to the base guard inside a new type.

I also tried my suggestion of a second type parameter from https://github.com/PyO3/pyo3/issues/6083#issuecomment-4596044810. While it also worked, the implementation felt quite convoluted and more difficult to follow. Additionally explaining to downstream users what the second type is for didn't feel right, so I went with the more straight forward solution of just wrapping the mutable reference in a new type to prevent users from swapping out the guard.

Method chaining still works as before even though the underlying type is different, so UX wise there is not really a big change here.

Xref #6083 