### PR TITLE
internal: cleanup `tuple_conversion!` macro

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -147,7 +147,7 @@ To include your changes in the release notes, you should create one (or more) ne
 - `removed` - for features which have been removed
 - `fixed` - for "changed" features which were classed as a bugfix
 
-If your PR is a documentation, refactor, or internal change, prefix your PR title with `docs:`, `refactor`, or `internal` to skip this check.
+If your PR is a documentation, refactor, or internal change, prefix your PR title with `docs:`, `refactor:`, or `internal:` to skip this check.
 
 ### Style guide
 

--- a/Contributing.md
+++ b/Contributing.md
@@ -147,7 +147,7 @@ To include your changes in the release notes, you should create one (or more) ne
 - `removed` - for features which have been removed
 - `fixed` - for "changed" features which were classed as a bugfix
 
-Docs-only PRs do not need news items; start your PR title with `docs:` to skip the check.
+If your PR is a documentation, refactor, or internal change, prefix your PR title with `docs:`, `refactor`, or `internal` to skip this check.
 
 ### Style guide
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1156,7 +1156,7 @@ def check_changelog(session: nox.Session):
     if not fragments:
         session.error(
             "Changelog entry not found, please add one (or more) to the `newsfragments` directory.\n"
-            "Alternatively, start the PR title with `docs:`, `refactor`, or `internal` if applicable.\n"
+            "Alternatively, start the PR title with `docs:`, `refactor:`, or `internal:` if applicable.\n"
             "See https://github.com/PyO3/pyo3/blob/main/Contributing.md#documenting-changes for more information."
         )
 

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -624,7 +624,7 @@ fn wrong_tuple_length(t: Borrowed<'_, '_, PyTuple>, expected_length: usize) -> P
     exceptions::PyValueError::new_err(msg)
 }
 
-macro_rules! tuple_conversion ({$length:expr,$(($n:tt, $T:ident)),+} => {
+macro_rules! tuple_conversion (($length:expr, $(($n:tt, $T:ident)),+) => {
     impl <'py, $($T),+> IntoPyObject<'py> for ($($T,)+)
     where
         $($T: IntoPyObject<'py>,)+

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -1067,7 +1067,6 @@ tuple_conversion!(
     (9, T9),
     (10, T10)
 );
-
 tuple_conversion!(
     12,
     (0, T0),

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -624,7 +624,7 @@ fn wrong_tuple_length(t: Borrowed<'_, '_, PyTuple>, expected_length: usize) -> P
     exceptions::PyValueError::new_err(msg)
 }
 
-macro_rules! tuple_conversion ({$length:expr,$(($refN:ident, $n:tt, $T:ident)),+} => {
+macro_rules! tuple_conversion ({$length:expr,$(($n:tt, $T:ident)),+} => {
     impl <'py, $($T),+> IntoPyObject<'py> for ($($T,)+)
     where
         $($T: IntoPyObject<'py>,)+
@@ -980,108 +980,108 @@ const fn with_vectorcall_arguments_offset(n: size_t) -> size_t {
         .expect("overflow adding PY_VECTORCALL_ARGUMENTS_OFFSET")
 }
 
-tuple_conversion!(1, (ref0, 0, T0));
-tuple_conversion!(2, (ref0, 0, T0), (ref1, 1, T1));
-tuple_conversion!(3, (ref0, 0, T0), (ref1, 1, T1), (ref2, 2, T2));
+tuple_conversion!(1, (0, T0));
+tuple_conversion!(2, (0, T0), (1, T1));
+tuple_conversion!(3, (0, T0), (1, T1), (2, T2));
 tuple_conversion!(
     4,
-    (ref0, 0, T0),
-    (ref1, 1, T1),
-    (ref2, 2, T2),
-    (ref3, 3, T3)
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3)
 );
 tuple_conversion!(
     5,
-    (ref0, 0, T0),
-    (ref1, 1, T1),
-    (ref2, 2, T2),
-    (ref3, 3, T3),
-    (ref4, 4, T4)
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4)
 );
 tuple_conversion!(
     6,
-    (ref0, 0, T0),
-    (ref1, 1, T1),
-    (ref2, 2, T2),
-    (ref3, 3, T3),
-    (ref4, 4, T4),
-    (ref5, 5, T5)
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5)
 );
 tuple_conversion!(
     7,
-    (ref0, 0, T0),
-    (ref1, 1, T1),
-    (ref2, 2, T2),
-    (ref3, 3, T3),
-    (ref4, 4, T4),
-    (ref5, 5, T5),
-    (ref6, 6, T6)
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6)
 );
 tuple_conversion!(
     8,
-    (ref0, 0, T0),
-    (ref1, 1, T1),
-    (ref2, 2, T2),
-    (ref3, 3, T3),
-    (ref4, 4, T4),
-    (ref5, 5, T5),
-    (ref6, 6, T6),
-    (ref7, 7, T7)
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7)
 );
 tuple_conversion!(
     9,
-    (ref0, 0, T0),
-    (ref1, 1, T1),
-    (ref2, 2, T2),
-    (ref3, 3, T3),
-    (ref4, 4, T4),
-    (ref5, 5, T5),
-    (ref6, 6, T6),
-    (ref7, 7, T7),
-    (ref8, 8, T8)
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7),
+    (8, T8)
 );
 tuple_conversion!(
     10,
-    (ref0, 0, T0),
-    (ref1, 1, T1),
-    (ref2, 2, T2),
-    (ref3, 3, T3),
-    (ref4, 4, T4),
-    (ref5, 5, T5),
-    (ref6, 6, T6),
-    (ref7, 7, T7),
-    (ref8, 8, T8),
-    (ref9, 9, T9)
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7),
+    (8, T8),
+    (9, T9)
 );
 tuple_conversion!(
     11,
-    (ref0, 0, T0),
-    (ref1, 1, T1),
-    (ref2, 2, T2),
-    (ref3, 3, T3),
-    (ref4, 4, T4),
-    (ref5, 5, T5),
-    (ref6, 6, T6),
-    (ref7, 7, T7),
-    (ref8, 8, T8),
-    (ref9, 9, T9),
-    (ref10, 10, T10)
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7),
+    (8, T8),
+    (9, T9),
+    (10, T10)
 );
 
 tuple_conversion!(
     12,
-    (ref0, 0, T0),
-    (ref1, 1, T1),
-    (ref2, 2, T2),
-    (ref3, 3, T3),
-    (ref4, 4, T4),
-    (ref5, 5, T5),
-    (ref6, 6, T6),
-    (ref7, 7, T7),
-    (ref8, 8, T8),
-    (ref9, 9, T9),
-    (ref10, 10, T10),
-    (ref11, 11, T11)
+    (0, T0),
+    (1, T1),
+    (2, T2),
+    (3, T3),
+    (4, T4),
+    (5, T5),
+    (6, T6),
+    (7, T7),
+    (8, T8),
+    (9, T9),
+    (10, T10),
+    (11, T11)
 );
 
 #[cfg(test)]

--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -983,30 +983,9 @@ const fn with_vectorcall_arguments_offset(n: size_t) -> size_t {
 tuple_conversion!(1, (0, T0));
 tuple_conversion!(2, (0, T0), (1, T1));
 tuple_conversion!(3, (0, T0), (1, T1), (2, T2));
-tuple_conversion!(
-    4,
-    (0, T0),
-    (1, T1),
-    (2, T2),
-    (3, T3)
-);
-tuple_conversion!(
-    5,
-    (0, T0),
-    (1, T1),
-    (2, T2),
-    (3, T3),
-    (4, T4)
-);
-tuple_conversion!(
-    6,
-    (0, T0),
-    (1, T1),
-    (2, T2),
-    (3, T3),
-    (4, T4),
-    (5, T5)
-);
+tuple_conversion!(4, (0, T0), (1, T1), (2, T2), (3, T3));
+tuple_conversion!(5, (0, T0), (1, T1), (2, T2), (3, T3), (4, T4));
+tuple_conversion!(6, (0, T0), (1, T1), (2, T2), (3, T3), (4, T4), (5, T5));
 tuple_conversion!(
     7,
     (0, T0),


### PR DESCRIPTION
Hi, this is my first time contributing, so let me know if you need me to do anything else!

This PR makes some minor improvements to the private `tuple_conversion!` macro used to generate `impl` blocks for tuple pyramids.

In the future, you may be interested in using the unstable / internal `#[doc(fake_variadic)]` attribute to get something looking like this:

<img width="1922" height="238" alt="image" src="https://github.com/user-attachments/assets/61530018-801e-44c5-9d99-e38ba0e7e84a" />

Bevy uses this (https://github.com/bevyengine/bevy/issues/14697) through the [`variadics_please`](https://docs.rs/variadics_please) crate, although you can use `#[doc(fake_variadic)]` directly [like what `serde` does](https://github.com/serde-rs/serde/blob/5f0f18b9211732f2d82f73b5a43e4f5ff3701251/serde_core/src/de/impls.rs#L1469-L1479).