### PR TITLE
replace remaining `PyRef` codepaths in macros with `PyClassGuard`

### DIFF
--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2394,8 +2394,8 @@ fn pyclass_richcmp_simple_enum(
     let eq = options.eq.map(|eq| {
         quote_spanned! { eq.span() =>
             let self_val = self;
-            if let ::std::result::Result::Ok(other) = other.cast::<Self>() {
-                let other = &*other.borrow();
+            if let ::std::result::Result::Ok(other) = #pyo3_path::types::PyAnyMethods::extract::<#pyo3_path::PyClassGuard<'_, Self>>(other) {
+                let other = &*other;
                 return match op {
                     #arms
                 }
@@ -2407,7 +2407,7 @@ fn pyclass_richcmp_simple_enum(
         quote_spanned! { eq_int.span() =>
             let self_val = self.__pyo3__int__();
             if let ::std::result::Result::Ok(other) = #pyo3_path::types::PyAnyMethods::extract::<#repr_type>(other).or_else(|_| {
-                other.cast::<Self>().map(|o| o.borrow().__pyo3__int__())
+                #pyo3_path::types::PyAnyMethods::extract::<#pyo3_path::PyClassGuard<'_, Self>>(other).map(|o| o.__pyo3__int__())
             }) {
                 return match op {
                     #arms
@@ -2489,8 +2489,8 @@ fn pyclass_richcmp(
                 op: #pyo3_path::pyclass::CompareOp
             ) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
                 let self_val = self;
-                if let ::std::result::Result::Ok(other) = other.cast::<Self>() {
-                    let other = &*other.borrow();
+                if let ::std::result::Result::Ok(other) = #pyo3_path::types::PyAnyMethods::extract::<#pyo3_path::PyClassGuard<'_, Self>>(other) {
+                    let other = &*other;
                     match op {
                         #arms
                     }

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -488,7 +488,7 @@ pub fn method_introspection_code(
     }
     let return_type = if spec.python_name == "__new__" {
         // Hack to return Self while implementing IntoPyObject
-        parse_quote!(-> #pyo3_path::PyRef<Self>)
+        parse_quote!(-> #pyo3_path::PyClassGuard<Self>)
     } else {
         spec.output.clone()
     };


### PR DESCRIPTION
In preparation of the `PyRef(Mut)` deprecation this updates the remaining code paths in our macros code to use `PyClassGuard(Mut)` instead.
