### PR TITLE
more `PyRef(Mut)` deprecation prep

### DIFF
--- a/newsfragments/6112.added.md
+++ b/newsfragments/6112.added.md
@@ -1,0 +1,2 @@
+added `PyClassGuard` and `PyClassGuardMut` to the prelude
+added `Debug` impls for `PyClassGuard` and `PyClassGuardMut`

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,6 +15,7 @@ pub use crate::marker::Python;
 pub use crate::pycell::{PyRef, PyRefMut};
 pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::types::{PyAny, PyModule};
+pub use crate::{PyClassGuard, PyClassGuardMut};
 
 #[cfg(feature = "macros")]
 pub use pyo3_macros::{

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -290,6 +290,12 @@ impl<T: PyClass> Deref for PyClassGuard<'_, T> {
     }
 }
 
+impl<T: PyClass + fmt::Debug> fmt::Debug for PyClassGuard<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.deref(), f)
+    }
+}
+
 impl<'a, 'py, T: PyClass> FromPyObject<'a, 'py> for PyClassGuard<'a, T> {
     type Error = PyClassGuardError<'a, 'py>;
 
@@ -741,6 +747,12 @@ impl<T: PyClass<Frozen = False>> DerefMut for PyClassGuardMut<'_, T> {
         // SAFETY: `PyClassObject<T>` contains a valid `T`, by construction no
         // alias is enforced
         unsafe { &mut *self.as_class_object().get_ptr() }
+    }
+}
+
+impl<T: PyClass<Frozen = False> + fmt::Debug> fmt::Debug for PyClassGuardMut<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.deref(), f)
     }
 }
 


### PR DESCRIPTION
Some more preparations for the `PyRef(Mut)` deprecation

- adds `PyClassGuard` and `PyClassGuardMut` to the prelude
- adds missing `Debug` impls

Additionally `PyRef(Mut)` currently provide `AsRef` and `AsMut` impls to get to the base type. I intentionally did not implement them for `PyClassGuard(Mut)`. I think they are confusing to read and calling `as_super` (which they do internally) directly is much clearer IMO.

 `PyRef(Mut)` also provided access to a `Python` token via `.py()`, which `PyClassGuard(Mut)` simply cannot do anymore.

Lastly there is `as_ptr` and `into_ptr` which `PyRef(Mut)` currently provide. `as_ptr` we could easily also provide if we wanted by simply returning the internal borrowed pointer from `PyClassGuard(Mut)`. For `into_ptr` we would need to take a `Python` token, such that we can INCREF the pointer. However I'm not sure how much demand there is for these methods. In out test suite we only used `into_ptr` directly once and it could easily be refactored to work around the missing method. So I'm inclined to not implement these methods (at least for now).

All other methods and traits are already available in the same form.
