### PR TITLE
Allow extending `PyDateTime`, `PyDate`, `PyTime`, `PyDelta` and `PyTzInfo` on abi3 with python 3.12+

### DIFF
--- a/newsfragments/6115.changed.md
+++ b/newsfragments/6115.changed.md
@@ -1,0 +1,1 @@
+Allow extending `PyDateTime`, `PyDate`, `PyTime`, `PyDelta` and `PyTzInfo` on abi3 with python 3.12+

--- a/src/types/datetime.rs
+++ b/src/types/datetime.rs
@@ -206,7 +206,6 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyDate_Check
 );
-#[cfg(not(Py_LIMITED_API))]
 pyobject_subclassable_native_type!(PyDate, crate::ffi::PyDateTime_Date);
 
 #[cfg(Py_LIMITED_API)]
@@ -296,7 +295,6 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyDateTime_Check
 );
-#[cfg(not(Py_LIMITED_API))]
 pyobject_subclassable_native_type!(PyDateTime, crate::ffi::PyDateTime_DateTime);
 
 #[cfg(Py_LIMITED_API)]
@@ -534,7 +532,6 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyTime_Check
 );
-#[cfg(not(Py_LIMITED_API))]
 pyobject_subclassable_native_type!(PyTime, crate::ffi::PyDateTime_Time);
 
 #[cfg(Py_LIMITED_API)]
@@ -711,7 +708,6 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyTZInfo_Check
 );
-#[cfg(not(Py_LIMITED_API))]
 pyobject_subclassable_native_type!(PyTzInfo, crate::ffi::PyObject);
 
 #[cfg(Py_LIMITED_API)]
@@ -816,7 +812,6 @@ pyobject_native_type!(
     #module=Some("datetime"),
     #checkfunction=PyDelta_Check
 );
-#[cfg(not(Py_LIMITED_API))]
 pyobject_subclassable_native_type!(PyDelta, crate::ffi::PyDateTime_Delta);
 
 #[cfg(Py_LIMITED_API)]

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -313,6 +313,50 @@ mod inheriting_native_type {
         })
     }
 
+    #[cfg(Py_3_12)]
+    #[test]
+    fn inherit_tzinfo() {
+        #[pyclass(extends=pyo3::types::PyTzInfo)]
+        struct TzInfoWithName {
+            #[pyo3(get)]
+            name: &'static str,
+        }
+
+        #[pymethods]
+        impl TzInfoWithName {
+            #[new]
+            fn new() -> Self {
+                Self { name: "Hello :)" }
+            }
+
+            #[pyo3(signature = (_dt, /))]
+            fn utcoffset<'py>(
+                &self,
+                _dt: Option<&Bound<'_, pyo3::types::PyDateTime>>,
+                py: Python<'py>,
+            ) -> PyResult<Bound<'py, pyo3::types::PyDelta>> {
+                pyo3::types::PyDelta::new(py, 0, 3600, 0, true)
+            }
+        }
+
+        Python::attach(|py| {
+            let tz = pyo3::Py::new(py, TzInfoWithName::new()).unwrap();
+            py_run!(
+                py,
+                tz,
+                r#"
+                    import datetime
+
+                    assert isinstance(tz, datetime.tzinfo)
+                    assert tz.name == "Hello :)"
+
+                    dt = datetime.datetime(2024, 1, 1, tzinfo=tz)
+                    assert dt.utcoffset() == datetime.timedelta(hours=1)
+                "#
+            );
+        });
+    }
+
     #[test]
     #[cfg(Py_3_12)]
     fn inherit_list() {


### PR DESCRIPTION
I'm not sure why this was still gated behind `not(Py_LIMITED_API)` but it seems to work just fine.