### PR TITLE
Do not use `wrapping_cast` in `PyUnicodeWriter::with_capacity`

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -7,7 +7,6 @@ use {
         PyUnicodeWriter_WriteChar, PyUnicodeWriter_WriteUTF8,
     },
     crate::ffi_ptr_ext::FfiPtrExt,
-    crate::impl_::callback::WrappingCastTo,
     crate::py_result_ext::PyResultExt,
     crate::IntoPyObject,
     crate::{ffi, Bound, PyErr, PyResult},
@@ -70,7 +69,7 @@ impl<'py> PyUnicodeWriter<'py> {
     /// Creates a new `PyUnicodeWriter` with the specified initial capacity.
     #[inline]
     pub fn with_capacity(py: Python<'py>, capacity: usize) -> PyResult<Self> {
-        match NonNull::new(unsafe { PyUnicodeWriter_Create(capacity.wrapping_cast()) }) {
+        match NonNull::new(unsafe { PyUnicodeWriter_Create(capacity.try_into()?) }) {
             Some(ptr) => Ok(PyUnicodeWriter {
                 python: py,
                 writer: ptr,


### PR DESCRIPTION
This fixes the nightly build on main.

https://github.com/PyO3/pyo3/actions/runs/27198006281/job/80301070755?pr=6117