### PR TITLE
deprecate `PyRef(Mut)` (Part 1)

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -415,9 +415,8 @@ Currently, only classes defined in Rust and builtins provided by PyO3 can be inh
 
 To initialize a class, which inherits from another class, use the `PyClassInitializer` API.
 
-To get a parent class from a child, use [`PyRef`] instead of `&self` for methods, or [`PyRefMut`] instead of `&mut self`.
-Then you can access a parent class by `self_.as_super()` as `&PyRef<Self::BaseClass>`, or by `self_.into_super()` as `PyRef<Self::BaseClass>` (and similar for the `PyRefMut` case).
-For convenience, `self_.as_ref()` can also be used to get `&Self::BaseClass` directly; however, this approach does not let you access base classes higher in the inheritance hierarchy, for which you would need to chain multiple `as_super` or `into_super` calls.
+To get a parent class from a child, use [`PyClassGuard`] instead of `&self` for methods, or [`PyClassGuardMut`] instead of `&mut self`.
+Then you can access a parent class by `self_.as_super()` as `&PyClassGuard<Self::BaseClass>`, or by `self_.into_super()` as `PyClassGuard<Self::BaseClass>` (and similar for the `PyRefMut` case).
 
 ```rust
 # use pyo3::prelude::*;
@@ -452,8 +451,8 @@ impl SubClass {
             .add_subclass(SubClass { val2: 15 })
     }
 
-    fn method2(self_: PyRef<'_, Self>) -> PyResult<usize> {
-        let super_ = self_.as_super(); // Get &PyRef<BaseClass>
+    fn method2(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
+        let super_ = self_.as_super(); // Get &PyClassGuard<BaseClass>
         super_.method1().map(|x| x * self_.val2)
     }
 }
@@ -470,24 +469,24 @@ impl SubSubClass {
         PyClassInitializer::from(SubClass::new()).add_subclass(SubSubClass { val3: 20 })
     }
 
-    fn method3(self_: PyRef<'_, Self>) -> PyResult<usize> {
-        let base = self_.as_super().as_super(); // Get &PyRef<'_, BaseClass>
+    fn method3(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
+        let base = self_.as_super().as_super(); // Get &PyClassGuard<'_, BaseClass>
         base.method1().map(|x| x * self_.val3)
     }
 
-    fn method4(self_: PyRef<'_, Self>) -> PyResult<usize> {
+    fn method4(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
         let v = self_.val3;
-        let super_ = self_.into_super(); // Get PyRef<'_, SubClass>
+        let super_ = self_.into_super(); // Get PyClassGuard<'_, SubClass>
         SubClass::method2(super_).map(|x| x * v)
     }
 
-      fn get_values(self_: PyRef<'_, Self>) -> (usize, usize, usize) {
+      fn get_values(self_: PyClassGuard<'_, Self>) -> (usize, usize, usize) {
           let val1 = self_.as_super().as_super().val1;
           let val2 = self_.as_super().val2;
           (val1, val2, self_.val3)
       }
 
-    fn double_values(mut self_: PyRefMut<'_, Self>) {
+    fn double_values(mut self_: PyClassGuardMut<'_, Self>) {
         self_.as_super().as_super().val1 *= 2;
         self_.as_super().val2 *= 2;
         self_.val3 *= 2;
@@ -939,7 +938,7 @@ Class objects can be used as arguments to `#[pyfunction]`s and `#[pymethods]` in
 
 - `Py<T>` or `Bound<'py, T>` smart pointers to the class Python object,
 - `&T` or `&mut T` references to the Rust data contained in the Python object, or
-- `PyRef<T>` and `PyRefMut<T>` reference wrappers.
+- `PyClassGuard<T>` and `PyClassGuardMut<T>` reference wrappers.
 
 Examples of each of these below:
 
@@ -960,7 +959,7 @@ fn increment_field(my_class: &mut MyClass) {
 // Take a reference wrapper when borrowing should be automatic,
 // but access to the Python object is still needed
 #[pyfunction]
-fn print_field_and_return_me(my_class: PyRef<'_, MyClass>) -> PyRef<'_, MyClass> {
+fn print_field_and_return_me(my_class: PyClassGuard<'_, MyClass>) -> PyClassGuard<'_, MyClass> {
     println!("{}", my_class.my_field);
     my_class
 }
@@ -1579,8 +1578,8 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
 [`Py<T>`]: {{#PYO3_DOCS_URL}}/pyo3/struct.Py.html
 [`Bound<'py, T>`]: {{#PYO3_DOCS_URL}}/pyo3/struct.Bound.html
 [`PyClass`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/trait.PyClass.html
-[`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRefMut.html
+[`PyClassGuard`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuard.html
+[`PyClassGuardMut`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuardMut.html
 [`PyClassInitializer<T>`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass_init/struct.PyClassInitializer.html
 
 [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -415,9 +415,8 @@ Currently, only classes defined in Rust and builtins provided by PyO3 can be inh
 
 To initialize a class, which inherits from another class, use the `PyClassInitializer` API.
 
-To get a parent class from a child, use [`PyRef`] instead of `&self` for methods, or [`PyRefMut`] instead of `&mut self`.
-Then you can access a parent class by `self_.as_super()` as `&PyRef<Self::BaseClass>`, or by `self_.into_super()` as `PyRef<Self::BaseClass>` (and similar for the `PyRefMut` case).
-For convenience, `self_.as_ref()` can also be used to get `&Self::BaseClass` directly; however, this approach does not let you access base classes higher in the inheritance hierarchy, for which you would need to chain multiple `as_super` or `into_super` calls.
+To get a parent class from a child, use [`PyClassGuard`] instead of `&self` for methods, or [`PyClassGuardMut`] instead of `&mut self`.
+Then you can access a parent class by `self_.as_super()` as `&PyClassGuard<Self::BaseClass>`, or by `self_.into_super()` as `PyClassGuard<Self::BaseClass>` (and similar for the `PyRefMut` case).
 
 ```rust
 # use pyo3::prelude::*;
@@ -452,8 +451,8 @@ impl SubClass {
             .add_subclass(SubClass { val2: 15 })
     }
 
-    fn method2(self_: PyRef<'_, Self>) -> PyResult<usize> {
-        let super_ = self_.as_super(); // Get &PyRef<BaseClass>
+    fn method2(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
+        let super_ = self_.as_super(); // Get &PyClassGuard<BaseClass>
         super_.method1().map(|x| x * self_.val2)
     }
 }
@@ -470,24 +469,24 @@ impl SubSubClass {
         PyClassInitializer::from(SubClass::new()).add_subclass(SubSubClass { val3: 20 })
     }
 
-    fn method3(self_: PyRef<'_, Self>) -> PyResult<usize> {
-        let base = self_.as_super().as_super(); // Get &PyRef<'_, BaseClass>
+    fn method3(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
+        let base = self_.as_super().as_super(); // Get &PyClassGuard<'_, BaseClass>
         base.method1().map(|x| x * self_.val3)
     }
 
-    fn method4(self_: PyRef<'_, Self>) -> PyResult<usize> {
+    fn method4(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
         let v = self_.val3;
-        let super_ = self_.into_super(); // Get PyRef<'_, SubClass>
+        let super_ = self_.into_super(); // Get PyClassGuard<'_, SubClass>
         SubClass::method2(super_).map(|x| x * v)
     }
 
-      fn get_values(self_: PyRef<'_, Self>) -> (usize, usize, usize) {
+      fn get_values(self_: PyClassGuard<'_, Self>) -> (usize, usize, usize) {
           let val1 = self_.as_super().as_super().val1;
           let val2 = self_.as_super().val2;
           (val1, val2, self_.val3)
       }
 
-    fn double_values(mut self_: PyRefMut<'_, Self>) {
+    fn double_values(mut self_: PyClassGuardMut<'_, Self>) {
         self_.as_super().as_super().val1 *= 2;
         self_.as_super().val2 *= 2;
         self_.val3 *= 2;
@@ -939,7 +938,7 @@ Class objects can be used as arguments to `#[pyfunction]`s and `#[pymethods]` in
 
 - `Py<T>` or `Bound<'py, T>` smart pointers to the class Python object,
 - `&T` or `&mut T` references to the Rust data contained in the Python object, or
-- `PyRef<T>` and `PyRefMut<T>` reference wrappers.
+- `PyClassGuard<T>` and `PyClassGuardMut<T>` reference wrappers.
 
 Examples of each of these below:
 
@@ -960,7 +959,7 @@ fn increment_field(my_class: &mut MyClass) {
 // Take a reference wrapper when borrowing should be automatic,
 // but access to the Python object is still needed
 #[pyfunction]
-fn print_field_and_return_me(my_class: PyRef<'_, MyClass>) -> PyRef<'_, MyClass> {
+fn print_field_and_return_me(my_class: PyClassGuard<'_, MyClass>) -> PyClassGuard<'_, MyClass> {
     println!("{}", my_class.my_field);
     my_class
 }
@@ -1575,8 +1574,8 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
 [`Py<T>`]: {{#PYO3_DOCS_URL}}/pyo3/struct.Py.html
 [`Bound<'py, T>`]: {{#PYO3_DOCS_URL}}/pyo3/struct.Bound.html
 [`PyClass`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/trait.PyClass.html
-[`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRefMut.html
+[`PyClassGuard`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuard.html
+[`PyClassGuardMut`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuardMut.html
 [`PyClassInitializer<T>`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass_init/struct.PyClassInitializer.html
 
 [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html

--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -136,7 +136,7 @@ impl Number {
 #
 #[pymethods]
 impl Number {
-    fn __pos__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __pos__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -33,7 +33,7 @@ The following sections list all magic methods for which PyO3 implements the nece
 The given signatures should be interpreted as follows:
 
 - All methods take a receiver as first argument, shown as `<self>`.
-  It can be `&self`, `&mut self` or a `Bound` reference like `self_: PyRef<'_, Self>` and `self_: PyRefMut<'_, Self>`, as described [in the parent section](../class.md#inheritance).
+  It can be `&self`, `&mut self` or a `Bound` reference like `self_: PyClassGuard<'_, Self>` and `self_: PyClassGuardMut<'_, Self>`, as described [in the parent section](../class.md#inheritance).
 - An optional `Python<'py>` argument is always allowed as the first argument.
 - Return values can be optionally wrapped in `PyResult`.
 - `object` means that any type is allowed that can be extracted from a Python
@@ -184,10 +184,10 @@ struct MyIterator {
 
 #[pymethods]
 impl MyIterator {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
-    fn __next__(slf: PyRefMut<'_, Self>) -> Option<Py<PyAny>> {
+    fn __next__(slf: PyClassGuardMut<'_, Self>) -> Option<Py<PyAny>> {
         slf.iter.lock().unwrap().next()
     }
 }
@@ -207,11 +207,11 @@ struct Iter {
 
 #[pymethods]
 impl Iter {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<usize> {
+    fn __next__(mut slf: PyClassGuardMut<'_, Self>) -> Option<usize> {
         slf.inner.next()
     }
 }
@@ -223,11 +223,11 @@ struct Container {
 
 #[pymethods]
 impl Container {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyResult<Py<Iter>> {
+    fn __iter__(slf: PyClassGuard<'_, Self>, py: Python<'_>) -> PyResult<Py<Iter>> {
         let iter = Iter {
             inner: slf.iter.clone().into_iter(),
         };
-        Py::new(slf.py(), iter)
+        Py::new(py, iter)
     }
 }
 

--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -54,8 +54,8 @@ It is also worth remembering the following special types:
 | `Python<'py>`    | A token used to prove attachment to the Python interpreter. |
 | `Bound<'py, T>`  | A Python object with a lifetime which binds it to the attachment to the Python interpreter. This provides access to most of PyO3's APIs. |
 | `Py<T>`          | A Python object not connected to any lifetime of attachment to the Python interpreter. This can be sent to other threads. |
-| `PyRef<T>`       | A `#[pyclass]` borrowed immutably.    |
-| `PyRefMut<T>`    | A `#[pyclass]` borrowed mutably.      |
+| `PyClassGuard<T>`       | A `#[pyclass]` borrowed immutably.    |
+| `PyClassGuardMut<T>`    | A `#[pyclass]` borrowed mutably.      |
 
 For more detail on accepting `#[pyclass]` values as function arguments, see [the section of this guide on Python Classes](../class.md).
 
@@ -105,8 +105,8 @@ Finally, the following Rust types are also able to convert to Python as return v
 | `BTreeSet<T>` | `Set[T]`                        |
 | `Py<T>` | `T`                                   |
 | `Bound<T>` | `T`                                |
-| `PyRef<T: PyClass>` | `T`                       |
-| `PyRefMut<T: PyClass>` | `T`                    |
+| `PyClassGuard<T: PyClass>` | `T`                       |
+| `PyClassGuardMut<T: PyClass>` | `T`                    |
 
 [^1]: Requires the `num-bigint` optional feature.
 

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -23,7 +23,7 @@ let v: Vec<i32> = list.extract()?;
 This method is available for many Python object types, and can produce a wide variety of Rust types, which you can check out in the implementor list of [`FromPyObject`].
 
 [`FromPyObject`] is also implemented for your own Rust types wrapped as Python objects (see [the chapter about classes](../class.md)).
-There, in order to both be able to operate on mutable references *and* satisfy Rust's rules of non-aliasing mutable references, you have to extract the PyO3 reference wrappers [`PyRef`] and [`PyRefMut`].
+There, in order to both be able to operate on mutable references *and* satisfy Rust's rules of non-aliasing mutable references, you have to extract the PyO3 reference wrappers [`PyClassGuard`] and [`PyClassGuardMut`].
 They work like the reference wrappers of `std::cell::RefCell` and ensure (at runtime) that Rust borrows are allowed.
 
 ### Deriving [`FromPyObject`]
@@ -760,8 +760,8 @@ In the example above we used `BoundObject::into_any` and `BoundObject::unbind` t
 [`IntoPyObject`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObject.html
 [`IntoPyObjectExt`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObjectExt.html
 
-[`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRefMut.html
+[`PyClassGuard`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuard.html
+[`PyClassGuardMut`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuardMut.html
 [`BoundObject`]: {{#PYO3_DOCS_URL}}/pyo3/instance/trait.BoundObject.html
 
 [`Result`]: https://doc.rust-lang.org/stable/std/result/enum.Result.html

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -23,7 +23,7 @@ let v: Vec<i32> = list.extract()?;
 This method is available for many Python object types, and can produce a wide variety of Rust types, which you can check out in the implementor list of [`FromPyObject`].
 
 [`FromPyObject`] is also implemented for your own Rust types wrapped as Python objects (see [the chapter about classes](../class.md)).
-There, in order to both be able to operate on mutable references *and* satisfy Rust's rules of non-aliasing mutable references, you have to extract the PyO3 reference wrappers [`PyRef`] and [`PyRefMut`].
+There, in order to both be able to operate on mutable references *and* satisfy Rust's rules of non-aliasing mutable references, you have to extract the PyO3 reference wrappers [`PyClassGuard`] and [`PyClassGuardMut`].
 They work like the reference wrappers of `std::cell::RefCell` and ensure (at runtime) that Rust borrows are allowed.
 
 ### Deriving [`FromPyObject`]
@@ -771,8 +771,8 @@ In the example above we used `BoundObject::into_any` and `BoundObject::unbind` t
 [`IntoPyObject`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObject.html
 [`IntoPyObjectExt`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObjectExt.html
 
-[`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRefMut.html
+[`PyClassGuard`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuard.html
+[`PyClassGuardMut`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuardMut.html
 [`BoundObject`]: {{#PYO3_DOCS_URL}}/pyo3/instance/trait.BoundObject.html
 
 [`Result`]: https://doc.rust-lang.org/stable/std/result/enum.Result.html

--- a/newsfragments/6120.changed.md
+++ b/newsfragments/6120.changed.md
@@ -1,0 +1,1 @@
+deprecate `PyRef` and `PyRefMut` in favor of `PyClassGuard` and `PyClassGuardMut` respectively

--- a/pytests/src/awaitable.rs
+++ b/pytests/src/awaitable.rs
@@ -27,11 +27,11 @@ pub mod awaitable {
             }
         }
 
-        fn __await__(pyself: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        fn __await__(pyself: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
             pyself
         }
 
-        fn __iter__(pyself: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        fn __iter__(pyself: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
             pyself
         }
 
@@ -79,15 +79,15 @@ pub mod awaitable {
             }
         }
 
-        fn __await__(pyself: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        fn __await__(pyself: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
             pyself
         }
 
-        fn __iter__(pyself: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        fn __iter__(pyself: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
             pyself
         }
 
-        fn __next__(mut pyself: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
+        fn __next__(mut pyself: PyClassGuardMut<'_, Self>) -> PyResult<PyClassGuardMut<'_, Self>> {
             match pyself.result {
                 Some(_) => match pyself.result.take().unwrap() {
                     Ok(v) => Err(PyStopIteration::new_err(v)),
@@ -97,20 +97,20 @@ pub mod awaitable {
             }
         }
 
-        fn send<'py>(
-            pyself: PyRefMut<'py, Self>,
-            _value: Bound<'py, PyAny>,
-        ) -> PyResult<PyRefMut<'py, Self>> {
+        fn send<'a>(
+            pyself: PyClassGuardMut<'a, Self>,
+            _value: Bound<'_, PyAny>,
+        ) -> PyResult<PyClassGuardMut<'a, Self>> {
             Self::__next__(pyself)
         }
 
         #[pyo3(signature = (_value, _a = None, _b = None))]
-        fn throw<'py>(
-            pyself: PyRefMut<'py, Self>,
-            _value: Bound<'py, PyAny>,
-            _a: Option<Bound<'py, PyAny>>,
-            _b: Option<Bound<'py, PyAny>>,
-        ) -> PyResult<PyRefMut<'py, Self>> {
+        fn throw<'a>(
+            pyself: PyClassGuardMut<'a, Self>,
+            _value: Bound<'_, PyAny>,
+            _a: Option<Bound<'_, PyAny>>,
+            _b: Option<Bound<'_, PyAny>>,
+        ) -> PyResult<PyClassGuardMut<'a, Self>> {
             Self::__next__(pyself)
         }
 

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -297,7 +297,7 @@ impl Number {
         Self(self.0 ^ other.0)
     }
 
-    fn __pos__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __pos__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -309,7 +309,7 @@ impl Number {
         }
     }
 
-    fn __abs__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __abs__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -66,7 +66,7 @@ impl PyClassOptionIter {
         Default::default()
     }
 
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -94,7 +94,7 @@ impl PyClassResultOptionIter {
         Default::default()
     }
 
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -123,7 +123,7 @@ impl PyClassOptionAsyncIter {
         Default::default()
     }
 
-    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __aiter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -385,7 +385,7 @@ impl Number {
         Self(self.0 ^ other.0)
     }
 
-    fn __pos__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __pos__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -397,7 +397,7 @@ impl Number {
         }
     }
 
-    fn __abs__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __abs__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -7,9 +7,9 @@ use crate::pyclass::boolean_struct::False;
 use crate::pyclass::{PyClassGuardError, PyClassGuardMutError};
 use crate::types::PyList;
 use crate::types::PyTuple;
-use crate::{
-    Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyRef, PyRefMut, PyTypeCheck, Python,
-};
+use crate::{Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyTypeCheck, Python};
+#[expect(deprecated)]
+use crate::{PyRef, PyRefMut};
 use core::convert::Infallible;
 use core::marker::PhantomData;
 
@@ -510,6 +510,7 @@ pub(crate) use from_py_object_sequence::FromPyObjectSequence;
 pub trait FromPyObjectOwned<'py>: for<'a> FromPyObject<'a, 'py> {}
 impl<'py, T> FromPyObjectOwned<'py> for T where T: for<'a> FromPyObject<'a, 'py> {}
 
+#[expect(deprecated)]
 impl<'a, 'py, T> FromPyObject<'a, 'py> for PyRef<'py, T>
 where
     T: PyClass,
@@ -527,6 +528,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'a, 'py, T> FromPyObject<'a, 'py> for PyRefMut<'py, T>
 where
     T: PyClass<Frozen = False>,

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -13,10 +13,12 @@ use crate::pyclass::boolean_struct::{False, True};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
 use crate::types::{DerefToPyAny, PyDict, PyString};
 use crate::{
-    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyRef,
-    PyRefMut, PyTypeInfo, Python,
+    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyTypeInfo,
+    Python,
 };
 use crate::{internal::state, PyTypeCheck};
+#[expect(deprecated)]
+use crate::{PyRef, PyRefMut};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
@@ -151,8 +153,8 @@ impl<'py, T> Bound<'py, T> {
     ///
     ///     class_bound.borrow_mut().i += 1;
     ///
-    ///     // Alternatively you can get a `PyRefMut` directly
-    ///     let class_ref: PyRefMut<'_, Class> = class.extract()?;
+    ///     // Alternatively you can get a `PyClassGuardMut` directly
+    ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract()?;
     ///     assert_eq!(class_ref.i, 1);
     ///     Ok(())
     /// })
@@ -547,6 +549,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow(&self) -> PyRef<'py, T> {
@@ -582,6 +585,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow_mut(&self) -> PyRefMut<'py, T>
@@ -598,6 +602,7 @@ where
     /// This is the non-panicking variant of [`borrow`](#method.borrow).
     ///
     /// For frozen classes, the simpler [`get`][Self::get] is available.
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow(&self) -> Result<PyRef<'py, T>, PyBorrowError> {
         PyRef::try_borrow(self)
@@ -608,6 +613,7 @@ where
     /// The borrow lasts while the returned [`PyRefMut`] exists.
     ///
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow_mut(&self) -> Result<PyRefMut<'py, T>, PyBorrowMutError>
     where
@@ -1614,6 +1620,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow<'py>(&'py self, py: Python<'py>) -> PyRef<'py, T> {
@@ -1651,6 +1658,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow_mut<'py>(&'py self, py: Python<'py>) -> PyRefMut<'py, T>
@@ -1669,6 +1677,7 @@ where
     /// For frozen classes, the simpler [`get`][Self::get] is available.
     ///
     /// Equivalent to `self.bind(py).try_borrow()` - see [`Bound::try_borrow`].
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow<'py>(&'py self, py: Python<'py>) -> Result<PyRef<'py, T>, PyBorrowError> {
         self.bind(py).try_borrow()
@@ -1681,6 +1690,7 @@ where
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
     ///
     /// Equivalent to `self.bind(py).try_borrow_mut()` - see [`Bound::try_borrow_mut`].
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow_mut<'py>(
         &'py self,
@@ -2216,6 +2226,7 @@ impl<T> core::convert::From<Borrowed<'_, '_, T>> for Py<T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T> core::convert::From<PyRef<'py, T>> for Py<T>
 where
     T: PyClass,
@@ -2227,6 +2238,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T> core::convert::From<PyRefMut<'py, T>> for Py<T>
 where
     T: PyClass<Frozen = False>,
@@ -2395,8 +2407,8 @@ impl<T> Py<T> {
     ///
     ///     class_bound.borrow_mut().i += 1;
     ///
-    ///     // Alternatively you can get a `PyRefMut` directly
-    ///     let class_ref: PyRefMut<'_, Class> = class.extract(py)?;
+    ///     // Alternatively you can get a `PyClassGuardMut` directly
+    ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract(py)?;
     ///     assert_eq!(class_ref.i, 1);
     ///     Ok(())
     /// })

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -13,10 +13,12 @@ use crate::pyclass::boolean_struct::{False, True};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
 use crate::types::{DerefToPyAny, PyDict, PyString};
 use crate::{
-    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyRef,
-    PyRefMut, PyTypeInfo, Python,
+    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyTypeInfo,
+    Python,
 };
 use crate::{internal::state, PyTypeCheck};
+#[expect(deprecated)]
+use crate::{PyRef, PyRefMut};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
@@ -151,8 +153,8 @@ impl<'py, T> Bound<'py, T> {
     ///
     ///     class_bound.borrow_mut().i += 1;
     ///
-    ///     // Alternatively you can get a `PyRefMut` directly
-    ///     let class_ref: PyRefMut<'_, Class> = class.extract()?;
+    ///     // Alternatively you can get a `PyClassGuardMut` directly
+    ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract()?;
     ///     assert_eq!(class_ref.i, 1);
     ///     Ok(())
     /// })
@@ -547,6 +549,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow(&self) -> PyRef<'py, T> {
@@ -582,6 +585,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow_mut(&self) -> PyRefMut<'py, T>
@@ -598,6 +602,7 @@ where
     /// This is the non-panicking variant of [`borrow`](#method.borrow).
     ///
     /// For frozen classes, the simpler [`get`][Self::get] is available.
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow(&self) -> Result<PyRef<'py, T>, PyBorrowError> {
         PyRef::try_borrow(self)
@@ -608,6 +613,7 @@ where
     /// The borrow lasts while the returned [`PyRefMut`] exists.
     ///
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow_mut(&self) -> Result<PyRefMut<'py, T>, PyBorrowMutError>
     where
@@ -1614,6 +1620,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow<'py>(&'py self, py: Python<'py>) -> PyRef<'py, T> {
@@ -1651,6 +1658,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow_mut<'py>(&'py self, py: Python<'py>) -> PyRefMut<'py, T>
@@ -1669,6 +1677,7 @@ where
     /// For frozen classes, the simpler [`get`][Self::get] is available.
     ///
     /// Equivalent to `self.bind(py).try_borrow()` - see [`Bound::try_borrow`].
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow<'py>(&'py self, py: Python<'py>) -> Result<PyRef<'py, T>, PyBorrowError> {
         self.bind(py).try_borrow()
@@ -1681,6 +1690,7 @@ where
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
     ///
     /// Equivalent to `self.bind(py).try_borrow_mut()` - see [`Bound::try_borrow_mut`].
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow_mut<'py>(
         &'py self,
@@ -2216,6 +2226,7 @@ impl<T> core::convert::From<Borrowed<'_, '_, T>> for Py<T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T> core::convert::From<PyRef<'py, T>> for Py<T>
 where
     T: PyClass,
@@ -2227,6 +2238,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T> core::convert::From<PyRefMut<'py, T>> for Py<T>
 where
     T: PyClass<Frozen = False>,
@@ -2394,8 +2406,8 @@ impl<T> Py<T> {
     ///
     ///     class_bound.borrow_mut().i += 1;
     ///
-    ///     // Alternatively you can get a `PyRefMut` directly
-    ///     let class_ref: PyRefMut<'_, Class> = class.extract(py)?;
+    ///     // Alternatively you can get a `PyClassGuardMut` directly
+    ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract(py)?;
     ///     assert_eq!(class_ref.i, 1);
     ///     Ok(())
     /// })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,7 @@ pub use crate::instance::{Borrowed, Bound, BoundObject, Py};
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use crate::interpreter_lifecycle::with_embedded_python_interpreter;
 pub use crate::marker::Python;
+#[expect(deprecated)]
 pub use crate::pycell::{PyRef, PyRefMut};
 pub use crate::pyclass::{PyClass, PyClassGuard, PyClassGuardMut};
 pub use crate::pyclass_init::PyClassInitializer;

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -277,7 +277,9 @@ mod nightly {
         // This means that PyString, PyList, etc all inherit !Ungil from  this.
         impl !Ungil for crate::PyAny {}
 
+        #[expect(deprecated)]
         impl<T> !Ungil for crate::PyRef<'_, T> {}
+        #[expect(deprecated)]
         impl<T> !Ungil for crate::PyRefMut<'_, T> {}
 
         // FFI pointees

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -276,7 +276,9 @@ mod nightly {
         // This means that PyString, PyList, etc all inherit !Ungil from  this.
         impl !Ungil for crate::PyAny {}
 
+        #[expect(deprecated)]
         impl<T> !Ungil for crate::PyRef<'_, T> {}
+        #[expect(deprecated)]
         impl<T> !Ungil for crate::PyRefMut<'_, T> {}
 
         // FFI pointees

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,6 +12,7 @@ pub use crate::conversion::{FromPyObject, FromPyObjectOwned, IntoPyObject};
 pub use crate::err::{PyErr, PyResult};
 pub use crate::instance::{Borrowed, Bound, Py};
 pub use crate::marker::Python;
+#[expect(deprecated)]
 pub use crate::pycell::{PyRef, PyRefMut};
 pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::types::{PyAny, PyModule};

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -100,6 +100,7 @@
 //!
 //!     // We borrow the guard and then dereference
 //!     // it to get a mutable reference to Number
+//! #   #[expect(deprecated)]
 //!     let mut guard: PyRefMut<'_, Number> = n.bind(py).borrow_mut();
 //!     let n_mutable: &mut Number = &mut *guard;
 //!
@@ -242,6 +243,7 @@ use impl_::{PyClassBorrowChecker, PyClassObjectBaseLayout, PyClassObjectLayout};
 ///             .add_subclass(Child { name: "Caterpillar" })
 ///     }
 ///
+/// #   #[expect(deprecated)]
 ///     fn format(slf: PyRef<'_, Self>) -> String {
 ///         // We can get *mut ffi::PyObject from PyRef
 ///         let refcnt = unsafe { pyo3::ffi::Py_REFCNT(slf.as_ptr()) };
@@ -258,12 +260,14 @@ use impl_::{PyClassBorrowChecker, PyClassObjectBaseLayout, PyClassObjectLayout};
 ///
 /// See the [module-level documentation](self) for more information.
 #[repr(transparent)]
+#[deprecated(since = "0.30.0", note = "use `PyClassGuard` instead")]
 pub struct PyRef<'p, T: PyClass> {
     // TODO: once the GIL Ref API is removed, consider adding a lifetime parameter to `PyRef` to
     // store `Borrowed` here instead, avoiding reference counting overhead.
     inner: Bound<'p, T>,
 }
 
+#[expect(deprecated)]
 impl<'p, T: PyClass> PyRef<'p, T> {
     /// Returns a `Python` token that is bound to the lifetime of the `PyRef`.
     pub fn py(&self) -> Python<'p> {
@@ -271,6 +275,7 @@ impl<'p, T: PyClass> PyRef<'p, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T, U> AsRef<U> for PyRef<'_, T>
 where
     T: PyClass<BaseType = U>,
@@ -281,6 +286,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass> PyRef<'py, T> {
     /// Returns the raw FFI pointer represented by self.
     ///
@@ -320,6 +326,7 @@ impl<'py, T: PyClass> PyRef<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'p, T> PyRef<'p, T>
 where
     T: PyClass,
@@ -359,6 +366,7 @@ where
     ///             .add_subclass(Base2 { name2: "base2" })
     ///             .add_subclass(Self { name3: "sub" })
     ///     }
+    /// #   #[expect(deprecated)]
     ///     fn name(slf: PyRef<'_, Self>) -> String {
     ///         let subname = slf.name3;
     ///         let super_ = slf.into_super();
@@ -442,6 +450,7 @@ where
     ///     fn sub_name_len(&self) -> usize {
     ///         self.sub_name.len()
     ///     }
+    /// #   #[expect(deprecated)]
     ///     fn format_name_lengths(slf: PyRef<'_, Self>) -> String {
     ///         format!("{} {}", slf.as_super().base_name_len(), slf.sub_name_len())
     ///     }
@@ -462,6 +471,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass> Deref for PyRef<'_, T> {
     type Target = T;
 
@@ -471,6 +481,7 @@ impl<T: PyClass> Deref for PyRef<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass> Drop for PyRef<'_, T> {
     fn drop(&mut self) {
         self.inner
@@ -480,6 +491,7 @@ impl<T: PyClass> Drop for PyRef<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass> IntoPyObject<'py> for PyRef<'py, T> {
     type Target = T;
     type Output = Bound<'py, T>;
@@ -493,6 +505,7 @@ impl<'py, T: PyClass> IntoPyObject<'py> for PyRef<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'a, 'py, T: PyClass> IntoPyObject<'py> for &'a PyRef<'py, T> {
     type Target = T;
     type Output = Borrowed<'a, 'py, T>;
@@ -506,12 +519,14 @@ impl<'a, 'py, T: PyClass> IntoPyObject<'py> for &'a PyRef<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass + fmt::Debug> fmt::Debug for PyRef<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass> TryFrom<&Bound<'py, T>> for PyRef<'py, T> {
     type Error = PyBorrowError;
     #[inline]
@@ -523,6 +538,7 @@ impl<'py, T: PyClass> TryFrom<&Bound<'py, T>> for PyRef<'py, T> {
 /// A wrapper type for a mutably borrowed value from a [`Bound<'py, T>`].
 ///
 /// See the [module-level documentation](self) for more information.
+#[deprecated(since = "0.30.0", note = "use `PyClassGuardMut` instead")]
 #[repr(transparent)]
 pub struct PyRefMut<'p, T: PyClass<Frozen = False>> {
     // TODO: once the GIL Ref API is removed, consider adding a lifetime parameter to `PyRef` to
@@ -530,6 +546,7 @@ pub struct PyRefMut<'p, T: PyClass<Frozen = False>> {
     inner: Bound<'p, T>,
 }
 
+#[expect(deprecated)]
 impl<'p, T: PyClass<Frozen = False>> PyRefMut<'p, T> {
     /// Returns a `Python` token that is bound to the lifetime of the `PyRefMut`.
     pub fn py(&self) -> Python<'p> {
@@ -537,6 +554,7 @@ impl<'p, T: PyClass<Frozen = False>> PyRefMut<'p, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T> AsRef<T::BaseType> for PyRefMut<'_, T>
 where
     T: PyClass<Frozen = False>,
@@ -547,6 +565,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<T> AsMut<T::BaseType> for PyRefMut<'_, T>
 where
     T: PyClass<Frozen = False>,
@@ -557,6 +576,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass<Frozen = False>> PyRefMut<'py, T> {
     /// Returns the raw FFI pointer represented by self.
     ///
@@ -603,6 +623,7 @@ impl<'py, T: PyClass<Frozen = False>> PyRefMut<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'p, T> PyRefMut<'p, T>
 where
     T: PyClass<Frozen = False>,
@@ -642,6 +663,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass<Frozen = False>> Deref for PyRefMut<'_, T> {
     type Target = T;
 
@@ -651,6 +673,7 @@ impl<T: PyClass<Frozen = False>> Deref for PyRefMut<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass<Frozen = False>> DerefMut for PyRefMut<'_, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
@@ -658,6 +681,7 @@ impl<T: PyClass<Frozen = False>> DerefMut for PyRefMut<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass<Frozen = False>> Drop for PyRefMut<'_, T> {
     fn drop(&mut self) {
         self.inner
@@ -667,6 +691,7 @@ impl<T: PyClass<Frozen = False>> Drop for PyRefMut<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for PyRefMut<'py, T> {
     type Target = T;
     type Output = Bound<'py, T>;
@@ -680,6 +705,7 @@ impl<'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for PyRefMut<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'a, 'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for &'a PyRefMut<'py, T> {
     type Target = T;
     type Output = Borrowed<'a, 'py, T>;
@@ -693,12 +719,14 @@ impl<'a, 'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for &'a PyRefMut<'py
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass<Frozen = False> + fmt::Debug> fmt::Debug for PyRefMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.deref(), f)
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass<Frozen = False>> TryFrom<&Bound<'py, T>> for PyRefMut<'py, T> {
     type Error = PyBorrowMutError;
     #[inline]
@@ -834,12 +862,14 @@ mod tests {
             crate::Py::new(py, init).expect("allocation error")
         }
 
+        #[expect(deprecated)]
         fn get_values(self_: PyRef<'_, Self>) -> (usize, usize, usize) {
             let val1 = self_.as_super().as_super().val1;
             let val2 = self_.as_super().val2;
             (val1, val2, self_.val3)
         }
 
+        #[expect(deprecated)]
         fn double_values(mut self_: PyRefMut<'_, Self>) {
             self_.as_super().as_super().val1 *= 2;
             self_.as_super().val2 *= 2;

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -746,37 +746,43 @@ mod tests {
 
             // Cannot take any other mutable or immutable borrows whilst the object is borrowed mutably
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
-                .is_err());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_err());
-            assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableBase>>()
                 .is_err());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
+                .is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_err());
 
             // With the borrow dropped, all other borrow attempts will succeed
             drop(mmm_refmut);
 
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound.extract::<PyClassGuard<'_, MutableBase>>().is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_ok());
         })
     }
 
@@ -797,32 +803,36 @@ mod tests {
 
             // Further immutable borrows are ok
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound.extract::<PyClassGuard<'_, MutableBase>>().is_ok());
 
             // Further mutable borrows are not ok
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_err());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_err());
 
             // With the borrow dropped, all mutable borrow attempts will succeed
             drop(mmm_refmut);
 
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_ok());
         })
     }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -773,37 +773,43 @@ mod tests {
 
             // Cannot take any other mutable or immutable borrows whilst the object is borrowed mutably
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
-                .is_err());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_err());
-            assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableBase>>()
                 .is_err());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
+                .is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_err());
 
             // With the borrow dropped, all other borrow attempts will succeed
             drop(mmm_refmut);
 
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound.extract::<PyClassGuard<'_, MutableBase>>().is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_ok());
         })
     }
 
@@ -824,32 +830,36 @@ mod tests {
 
             // Further immutable borrows are ok
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound.extract::<PyClassGuard<'_, MutableBase>>().is_ok());
 
             // Further mutable borrows are not ok
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_err());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_err());
 
             // With the borrow dropped, all mutable borrow attempts will succeed
             drop(mmm_refmut);
 
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_ok());
         })
     }
 

--- a/src/tests/hygiene/pymethods.rs
+++ b/src/tests/hygiene/pymethods.rs
@@ -123,7 +123,7 @@ impl Dummy {
 
     fn __delitem__(&self, key: u32) {}
 
-    fn __iter__(_: crate::pycell::PyRef<'_, Self>, py: crate::Python<'_>) -> crate::Py<DummyIter> {
+    fn __iter__(_: crate::PyClassGuard<'_, Self>, py: crate::Python<'_>) -> crate::Py<DummyIter> {
         crate::Py::new(py, DummyIter {}).unwrap()
     }
 
@@ -132,7 +132,7 @@ impl Dummy {
     }
 
     fn __reversed__(
-        slf: crate::pycell::PyRef<'_, Self>,
+        slf: crate::PyClassGuard<'_, Self>,
         py: crate::Python<'_>,
     ) -> crate::Py<DummyIter> {
         crate::Py::new(py, DummyIter {}).unwrap()
@@ -274,19 +274,19 @@ impl Dummy {
 
     fn __ior__(&mut self, other: &Self) {}
 
-    fn __neg__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __neg__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __pos__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __pos__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __abs__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __abs__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __invert__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __invert__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
@@ -344,7 +344,7 @@ impl Dummy {
     // Awaitable Objects
     //////////////////////
 
-    fn __await__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __await__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
@@ -354,7 +354,7 @@ impl Dummy {
     //////////////////////
 
     fn __aiter__(
-        slf: crate::pycell::PyRef<'_, Self>,
+        slf: crate::PyClassGuard<'_, Self>,
         py: crate::Python<'_>,
     ) -> crate::Py<DummyIter> {
         crate::Py::new(py, DummyIter {}).unwrap()
@@ -484,10 +484,10 @@ impl WarningDummy {
     }
 
     #[pyo3(warn(message = "this method raises warning"))]
-    fn method_with_warning(_slf: crate::PyRef<'_, Self>) {}
+    fn method_with_warning(_slf: crate::PyClassGuard<'_, Self>) {}
 
     #[pyo3(warn(message = "this method raises warning", category = crate::exceptions::PyFutureWarning))]
-    fn method_with_warning_and_custom_category(_slf: crate::PyRef<'_, Self>) {}
+    fn method_with_warning_and_custom_category(_slf: crate::PyClassGuard<'_, Self>) {}
 
     #[cfg(any(not(Py_LIMITED_API), Py_3_12))]
     #[pyo3(warn(message = "this method raises user-defined warning", category = UserDefinedWarning))]
@@ -525,7 +525,7 @@ impl WarningDummy {
     }
 
     #[pyo3(warn(message = "the + op method raises warning"))]
-    fn __add__(&self, other: crate::PyRef<'_, Self>) -> Self {
+    fn __add__(&self, other: crate::PyClassGuard<'_, Self>) -> Self {
         Self {
             value: self.value + other.value,
         }

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -403,43 +403,43 @@ impl LhsAndRhs {
     //     "BA"
     // }
 
-    fn __add__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __add__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} + {rhs:?}")
     }
 
-    fn __sub__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __sub__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} - {rhs:?}")
     }
 
-    fn __mul__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __mul__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} * {rhs:?}")
     }
 
-    fn __lshift__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __lshift__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} << {rhs:?}")
     }
 
-    fn __rshift__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __rshift__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} >> {rhs:?}")
     }
 
-    fn __and__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __and__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} & {rhs:?}")
     }
 
-    fn __xor__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __xor__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} ^ {rhs:?}")
     }
 
-    fn __or__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __or__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} | {rhs:?}")
     }
 
-    fn __pow__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>, _mod: Option<usize>) -> String {
+    fn __pow__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>, _mod: Option<usize>) -> String {
         format!("{lhs:?} ** {rhs:?}")
     }
 
-    fn __matmul__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __matmul__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} @ {rhs:?}")
     }
 
@@ -640,67 +640,115 @@ mod return_not_implemented {
             "RC_Self"
         }
 
-        fn __richcmp__(&self, other: PyRef<'_, Self>, _op: CompareOp) -> Py<PyAny> {
-            other.py().None()
+        fn __richcmp__(
+            &self,
+            py: Python<'_>,
+            _other: PyClassGuard<'_, Self>,
+            _op: CompareOp,
+        ) -> Py<PyAny> {
+            py.None()
         }
 
-        fn __add__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __add__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __sub__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __sub__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __mul__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __mul__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __matmul__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __matmul__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __truediv__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __truediv__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __floordiv__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __floordiv__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __mod__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __mod__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __pow__(slf: PyRef<'_, Self>, _other: u8, _modulo: Option<u8>) -> PyRef<'_, Self> {
+        fn __pow__(
+            slf: PyClassGuard<'_, Self>,
+            _other: u8,
+            _modulo: Option<u8>,
+        ) -> PyClassGuard<'_, Self> {
             slf
         }
-        fn __lshift__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __lshift__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __rshift__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __rshift__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __divmod__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __divmod__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __and__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __and__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __or__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __or__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __xor__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __xor__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
 
         // Inplace assignments
-        fn __iadd__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __isub__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __imul__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __imatmul__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __itruediv__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ifloordiv__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __imod__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ilshift__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __irshift__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __iand__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ior__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ixor__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ipow__(&mut self, _other: PyRef<'_, Self>, _modulo: Option<u8>) {}
+        fn __iadd__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __isub__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __imul__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __imatmul__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __itruediv__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ifloordiv__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __imod__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ilshift__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __irshift__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __iand__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ior__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ixor__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ipow__(&mut self, _other: PyClassGuard<'_, Self>, _modulo: Option<u8>) {}
     }
 
     fn _test_binary_dunder(dunder: &str) {

--- a/tests/test_buffer.rs
+++ b/tests/test_buffer.rs
@@ -29,7 +29,7 @@ struct TestBufferErrors {
 #[pymethods]
 impl TestBufferErrors {
     unsafe fn __getbuffer__(
-        slf: PyRefMut<'_, Self>,
+        slf: Bound<'_, Self>,
         view: *mut ffi::Py_buffer,
         flags: c_int,
     ) -> PyResult<()> {
@@ -41,7 +41,8 @@ impl TestBufferErrors {
             return Err(PyBufferError::new_err("Object is not writable"));
         }
 
-        let bytes = &slf.buf;
+        let borrow = slf.borrow_mut();
+        let bytes = &borrow.buf;
 
         unsafe {
             (*view).buf = bytes.as_ptr() as *mut c_void;
@@ -60,7 +61,7 @@ impl TestBufferErrors {
             (*view).suboffsets = ptr::null_mut();
             (*view).internal = ptr::null_mut();
 
-            if let Some(err) = &slf.error {
+            if let Some(err) = &borrow.error {
                 use TestGetBufferError::*;
                 match err {
                     NullShape => {

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -21,11 +21,11 @@ fn test_cloneable_pyclass() {
         let c2: Cloneable = py_c.extract(py).unwrap();
         assert_eq!(c, c2);
         {
-            let rc: PyRef<'_, Cloneable> = py_c.extract(py).unwrap();
+            let rc: PyClassGuard<'_, Cloneable> = py_c.extract(py).unwrap();
             assert_eq!(&c, &*rc);
-            // Drops PyRef before taking PyRefMut
+            // Drops PyClassGuard before taking PyClassGuardMut
         }
-        let mrc: PyRefMut<'_, Cloneable> = py_c.extract(py).unwrap();
+        let mrc: PyClassGuardMut<'_, Cloneable> = py_c.extract(py).unwrap();
         assert_eq!(&c, &*mrc);
     });
 }
@@ -127,16 +127,16 @@ fn test_pyref_as_base() {
         let cell = Bound::new(py, initializer).unwrap();
 
         // First try PyRefMut
-        let sub: PyRefMut<'_, SubClass> = cell.borrow_mut();
-        let mut base: PyRefMut<'_, BaseClass> = sub.into_super();
+        let sub = cell.borrow_mut();
+        let mut base = sub.into_super();
         assert_eq!(120, base.value);
         base.value = 999;
         assert_eq!(999, base.value);
         drop(base);
 
         // Repeat for PyRef
-        let sub: PyRef<'_, SubClass> = cell.borrow();
-        let base: PyRef<'_, BaseClass> = sub.into_super();
+        let sub = cell.borrow();
+        let base = sub.into_super();
         assert_eq!(999, base.value);
     });
 }

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -469,6 +469,7 @@ fn traverse_cannot_be_hijacked() {
         fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>;
     }
 
+    #[expect(deprecated)]
     impl Traversable for PyRef<'_, HijackedTraverse> {
         fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
             self.hijacked.store(true, Ordering::Release);

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -487,6 +487,7 @@ fn traverse_cannot_be_hijacked() {
         fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>;
     }
 
+    #[expect(deprecated)]
     impl Traversable for PyRef<'_, HijackedTraverse> {
         fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
             self.hijacked.store(true, Ordering::Release);

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -137,12 +137,12 @@ struct RefGetterSetter {
 #[pymethods]
 impl RefGetterSetter {
     #[getter]
-    fn get_num(slf: PyRef<'_, Self>) -> i32 {
+    fn get_num(slf: PyClassGuard<'_, Self>) -> i32 {
         slf.num
     }
 
     #[setter]
-    fn set_num(mut slf: PyRefMut<'_, Self>, value: i32) {
+    fn set_num(mut slf: PyClassGuardMut<'_, Self>, value: i32) {
         slf.num = value;
     }
 }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -796,7 +796,7 @@ impl MethodWithPyClassArg {
             value: self.value + other.value,
         }
     }
-    fn add_pyref(&self, other: PyRef<'_, MethodWithPyClassArg>) -> MethodWithPyClassArg {
+    fn add_pyref(&self, other: PyClassGuard<'_, MethodWithPyClassArg>) -> MethodWithPyClassArg {
         MethodWithPyClassArg {
             value: self.value + other.value,
         }
@@ -804,7 +804,7 @@ impl MethodWithPyClassArg {
     fn inplace_add(&self, other: &mut MethodWithPyClassArg) {
         other.value += self.value;
     }
-    fn inplace_add_pyref(&self, mut other: PyRefMut<'_, MethodWithPyClassArg>) {
+    fn inplace_add_pyref(&self, mut other: PyClassGuardMut<'_, MethodWithPyClassArg>) {
         other.value += self.value;
     }
     #[pyo3(signature=(other = None))]
@@ -1269,10 +1269,10 @@ fn test_pymethods_warn() {
         }
 
         #[pyo3(warn(message = "this method raises warning"))]
-        fn method_with_warning(_slf: PyRef<'_, Self>) {}
+        fn method_with_warning(_slf: PyClassGuard<'_, Self>) {}
 
         #[pyo3(warn(message = "this method raises warning", category = PyFutureWarning))]
-        fn method_with_warning_and_custom_category(_slf: PyRef<'_, Self>) {}
+        fn method_with_warning_and_custom_category(_slf: PyClassGuard<'_, Self>) {}
 
         #[cfg(any(not(Py_LIMITED_API), Py_3_12))]
         #[pyo3(warn(message = "this method raises user-defined warning", category = UserDefinedWarning))]
@@ -1308,7 +1308,7 @@ fn test_pymethods_warn() {
         }
 
         #[pyo3(warn(message = "the + op method raises warning"))]
-        fn __add__(&self, other: PyRef<'_, Self>) -> Self {
+        fn __add__(&self, other: PyClassGuard<'_, Self>) -> Self {
             Self {
                 value: self.value + other.value,
             }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -853,7 +853,7 @@ impl MethodWithPyClassArg {
             value: self.value + other.value,
         }
     }
-    fn add_pyref(&self, other: PyRef<'_, MethodWithPyClassArg>) -> MethodWithPyClassArg {
+    fn add_pyref(&self, other: PyClassGuard<'_, MethodWithPyClassArg>) -> MethodWithPyClassArg {
         MethodWithPyClassArg {
             value: self.value + other.value,
         }
@@ -861,7 +861,7 @@ impl MethodWithPyClassArg {
     fn inplace_add(&self, other: &mut MethodWithPyClassArg) {
         other.value += self.value;
     }
-    fn inplace_add_pyref(&self, mut other: PyRefMut<'_, MethodWithPyClassArg>) {
+    fn inplace_add_pyref(&self, mut other: PyClassGuardMut<'_, MethodWithPyClassArg>) {
         other.value += self.value;
     }
     #[pyo3(signature=(other = None))]
@@ -1326,10 +1326,10 @@ fn test_pymethods_warn() {
         }
 
         #[pyo3(warn(message = "this method raises warning"))]
-        fn method_with_warning(_slf: PyRef<'_, Self>) {}
+        fn method_with_warning(_slf: PyClassGuard<'_, Self>) {}
 
         #[pyo3(warn(message = "this method raises warning", category = PyFutureWarning))]
-        fn method_with_warning_and_custom_category(_slf: PyRef<'_, Self>) {}
+        fn method_with_warning_and_custom_category(_slf: PyClassGuard<'_, Self>) {}
 
         #[cfg(any(not(Py_LIMITED_API), Py_3_12))]
         #[pyo3(warn(message = "this method raises user-defined warning", category = UserDefinedWarning))]
@@ -1365,7 +1365,7 @@ fn test_pymethods_warn() {
         }
 
         #[pyo3(warn(message = "the + op method raises warning"))]
-        fn __add__(&self, other: PyRef<'_, Self>) -> Self {
+        fn __add__(&self, other: PyClassGuard<'_, Self>) -> Self {
             Self {
                 value: self.value + other.value,
             }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -424,11 +424,11 @@ struct Iterator {
 
 #[pymethods]
 impl Iterator {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __next__(slf: PyRefMut<'_, Self>) -> Option<i32> {
+    fn __next__(slf: PyClassGuardMut<'_, Self>) -> Option<i32> {
         slf.iter.lock().unwrap().next()
     }
 }
@@ -748,11 +748,11 @@ impl OnceFuture {
         }
     }
 
-    fn __await__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __await__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
     fn __next__<'py>(&mut self, py: Python<'py>) -> Option<&Bound<'py, PyAny>> {
@@ -809,7 +809,7 @@ impl AsyncIterator {
         }
     }
 
-    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __aiter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -872,10 +872,10 @@ impl DescrCounter {
     }
     /// Each access will increase the count
     fn __get__<'a>(
-        mut slf: PyRefMut<'a, Self>,
+        mut slf: PyClassGuardMut<'a, Self>,
         _instance: &Bound<'_, PyAny>,
         _owner: Option<&Bound<'_, PyType>>,
-    ) -> PyRefMut<'a, Self> {
+    ) -> PyClassGuardMut<'a, Self> {
         slf.count += 1;
         slf
     }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -423,11 +423,11 @@ struct Iterator {
 
 #[pymethods]
 impl Iterator {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<i32> {
+    fn __next__(mut slf: PyClassGuardMut<'_, Self>) -> Option<i32> {
         slf.iter.next()
     }
 }
@@ -747,11 +747,11 @@ impl OnceFuture {
         }
     }
 
-    fn __await__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __await__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
     fn __next__<'py>(&mut self, py: Python<'py>) -> Option<&Bound<'py, PyAny>> {
@@ -808,7 +808,7 @@ impl AsyncIterator {
         }
     }
 
-    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __aiter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -871,10 +871,10 @@ impl DescrCounter {
     }
     /// Each access will increase the count
     fn __get__<'a>(
-        mut slf: PyRefMut<'a, Self>,
+        mut slf: PyClassGuardMut<'a, Self>,
         _instance: &Bound<'_, PyAny>,
         _owner: Option<&Bound<'_, PyType>>,
-    ) -> PyRefMut<'a, Self> {
+    ) -> PyClassGuardMut<'a, Self> {
         slf.count += 1;
         slf
     }

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -34,7 +34,7 @@ impl Reader {
         }
     }
     fn get_iter_and_reset(
-        mut slf: PyRefMut<'_, Self>,
+        mut slf: PyClassGuardMut<'_, Self>,
         keys: Py<PyBytes>,
         py: Python<'_>,
     ) -> PyResult<Iter> {
@@ -59,16 +59,15 @@ struct Iter {
 #[pymethods]
 impl Iter {
     #[expect(clippy::self_named_constructors)]
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<Py<PyAny>>> {
-        let bytes = slf.keys.bind(slf.py()).as_bytes();
+    fn __next__(mut slf: PyClassGuardMut<'_, Self>, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        let bytes = slf.keys.bind(py).as_bytes();
         match bytes.get(slf.idx) {
             Some(&b) => {
                 slf.idx += 1;
-                let py = slf.py();
                 let reader = slf.reader.bind(py);
                 let reader_ref = reader.try_borrow()?;
                 let res = reader_ref

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -75,9 +75,12 @@ impl ByteSequence {
         Self { elements }
     }
 
-    fn __inplace_concat__(mut slf: PyRefMut<'_, Self>, other: &Self) -> Py<Self> {
+    fn __inplace_concat__<'a>(
+        mut slf: PyClassGuardMut<'a, Self>,
+        other: &Self,
+    ) -> PyClassGuardMut<'a, Self> {
         slf.elements.extend_from_slice(&other.elements);
-        slf.into()
+        slf
     }
 
     fn __repeat__(&self, count: isize) -> PyResult<Self> {
@@ -92,14 +95,18 @@ impl ByteSequence {
         }
     }
 
-    fn __inplace_repeat__(mut slf: PyRefMut<'_, Self>, count: isize) -> PyResult<Py<Self>> {
+    fn __inplace_repeat__(
+        mut slf: PyClassGuardMut<'_, Self>,
+        py: Python<'_>,
+        count: isize,
+    ) -> PyResult<Py<Self>> {
         if count >= 0 {
             let mut elements = Vec::with_capacity(slf.elements.len() * count as usize);
             for _ in 0..count {
                 elements.extend(&slf.elements);
             }
             slf.elements = elements;
-            Ok(slf.into())
+            Ok(slf.into_pyobject(py)?.to_owned().unbind())
         } else {
             Err(PyValueError::new_err("invalid repeat count"))
         }

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -18,7 +18,7 @@ impl MutRefArg {
     fn get(&self) -> i32 {
         self.n
     }
-    fn set_other(&self, mut other: PyRefMut<'_, MutRefArg>) {
+    fn set_other(&self, mut other: PyClassGuardMut<'_, MutRefArg>) {
         other.n = 100;
     }
 }

--- a/tests/ui/invalid_async.rs
+++ b/tests/ui/invalid_async.rs
@@ -11,7 +11,7 @@ pub(crate) struct AsyncRange {
 }
 #[pymethods]
 impl AsyncRange {
-    async fn __anext__(mut _pyself: PyRefMut<'_, Self>) -> PyResult<i32> {
+    async fn __anext__(mut _pyself: PyClassGuardMut<'_, Self>) -> PyResult<i32> {
 //~^ ERROR: async functions are only supported with the `experimental-async` feature
         Ok(0)
     }

--- a/tests/ui/invalid_async.stderr
+++ b/tests/ui/invalid_async.stderr
@@ -7,7 +7,7 @@ error: async functions are only supported with the `experimental-async` feature
 error: async functions are only supported with the `experimental-async` feature
   --> tests/ui/invalid_async.rs:14:5
    |
-14 |     async fn __anext__(mut _pyself: PyRefMut<'_, Self>) -> PyResult<i32> {
+14 |     async fn __anext__(mut _pyself: PyClassGuardMut<'_, Self>) -> PyResult<i32> {
    |     ^^^^^
 
 error: async functions are only supported with the `experimental-async` feature

--- a/tests/ui/traverse.rs
+++ b/tests/ui/traverse.rs
@@ -7,8 +7,9 @@ struct TraverseTriesToTakePyRef {}
 
 #[pymethods]
 impl TraverseTriesToTakePyRef {
+    #[expect(deprecated)]
     fn __traverse__(_slf: PyRef<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 }
@@ -18,8 +19,9 @@ struct TraverseTriesToTakePyRefMut {}
 
 #[pymethods]
 impl TraverseTriesToTakePyRefMut {
+    #[expect(deprecated)]
     fn __traverse__(_slf: PyRefMut<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 }
@@ -30,7 +32,7 @@ struct TraverseTriesToTakeBound {}
 #[pymethods]
 impl TraverseTriesToTakeBound {
     fn __traverse__(_slf: Bound<'_, Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 }
@@ -41,7 +43,7 @@ struct TraverseTriesToTakeMutSelf {}
 #[pymethods]
 impl TraverseTriesToTakeMutSelf {
     fn __traverse__(&mut self, _visit: PyVisit) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 }
@@ -62,7 +64,7 @@ struct Class;
 #[pymethods]
 impl Class {
     fn __traverse__(&self, _py: Python<'_>, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take `Python`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take `Python`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 

--- a/tests/ui/traverse.stderr
+++ b/tests/ui/traverse.stderr
@@ -1,31 +1,31 @@
 error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:10:27
+  --> tests/ui/traverse.rs:11:27
    |
-10 |     fn __traverse__(_slf: PyRef<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
+11 |     fn __traverse__(_slf: PyRef<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                           ^^^^^
 
 error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:21:27
+  --> tests/ui/traverse.rs:23:27
    |
-21 |     fn __traverse__(_slf: PyRefMut<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
+23 |     fn __traverse__(_slf: PyRefMut<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                           ^^^^^^^^
 
 error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:32:27
+  --> tests/ui/traverse.rs:34:27
    |
-32 |     fn __traverse__(_slf: Bound<'_, Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
+34 |     fn __traverse__(_slf: Bound<'_, Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                           ^^^^^
 
 error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:43:21
+  --> tests/ui/traverse.rs:45:21
    |
-43 |     fn __traverse__(&mut self, _visit: PyVisit) -> Result<(), PyTraverseError> {
+45 |     fn __traverse__(&mut self, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                     ^
 
 error: __traverse__ may not take `Python`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:64:33
+  --> tests/ui/traverse.rs:66:33
    |
-64 |     fn __traverse__(&self, _py: Python<'_>, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+66 |     fn __traverse__(&self, _py: Python<'_>, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
    |                                 ^^^^^^^^^^
 
 error: aborting due to 5 previous errors


### PR DESCRIPTION
First step of deprecating `PyRef` and `PyRefMut`. This PR deprecates the types itself (targeting 0.30.0 as per https://github.com/PyO3/pyo3/issues/6083#issuecomment-4658777595, so leaving as draft for now) 

We will need a migration guide entry, but I would like to defer that to the second part when I deprecate the `borrow` methods.

See also #6083 