### PR TITLE
deprecate `Bound|Py::(try_)borrow(_mut)` (Part 2)

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -314,17 +314,17 @@ struct MyClass {
 Python::attach(|py| {
     let obj = Bound::new(py, MyClass { num: 3 }).unwrap();
     {
-        let obj_ref = obj.borrow(); // Get PyRef
+        let obj_ref = obj.try_borrow_guard().unwrap(); // Get PyClassGuard
         assert_eq!(obj_ref.num, 3);
-        // You cannot get PyRefMut unless all PyRefs are dropped
-        assert!(obj.try_borrow_mut().is_err());
+        // You cannot get PyClassGuardMut unless all PyClassGuards are dropped
+        assert!(obj.try_borrow_guard_mut().is_err());
     }
     {
-        let mut obj_mut = obj.borrow_mut(); // Get PyRefMut
+        let mut obj_mut = obj.try_borrow_guard_mut().unwrap(); // Get PyClassGuardMut
         obj_mut.num = 5;
         // You cannot get any other refs until the PyRefMut is dropped
-        assert!(obj.try_borrow().is_err());
-        assert!(obj.try_borrow_mut().is_err());
+        assert!(obj.try_borrow_guard().is_err());
+        assert!(obj.try_borrow_guard_mut().is_err());
     }
 
     // You can convert `Bound` to a Python object
@@ -334,7 +334,6 @@ Python::attach(|py| {
 
 A `Bound<'py, T>` is restricted to the Python lifetime `'py`.
 To make the object longer lived (for example, to store it in a struct on the Rust side), use `Py<T>`.
-`Py<T>` needs a `Python<'_>` token to allow access:
 
 ```rust
 # use pyo3::prelude::*;
@@ -349,11 +348,8 @@ fn return_myclass() -> Py<MyClass> {
 
 let obj = return_myclass();
 
-Python::attach(move |py| {
-    let bound = obj.bind(py); // Py<MyClass>::bind returns &Bound<'py, MyClass>
-    let obj_ref = bound.borrow(); // Get PyRef<T>
-    assert_eq!(obj_ref.num, 1);
-});
+let obj_ref = obj.try_borrow_guard().unwrap(); // Get PyClassGuard<T>
+assert_eq!(obj_ref.num, 1);
 ```
 
 ### frozen classes: Opting out of interior mutability
@@ -525,7 +521,7 @@ You can inherit native types such as `PyDict`, if they implement [`PySizedLayout
 This is not supported when building for the Python limited API (aka the `abi3` feature of PyO3).
 
 To convert between the Rust type and its native base class, you can take `slf` as a Python object.
-To access the Rust fields use `slf.borrow()` or `slf.borrow_mut()`, and to access the base class use `slf.cast::<BaseClass>()`.
+To access the Rust fields use `slf.try_borrow_guard()` or `slf.try_borrow_guard_mut()`, and to access the base class use `slf.cast::<BaseClass>()`.
 
 ```rust
 # #[cfg(any(not(Py_LIMITED_API), Py_3_12))] {
@@ -547,7 +543,7 @@ impl DictWithCounter {
     }
 
     fn set(slf: &Bound<'_, Self>, key: String, value: Bound<'_, PyAny>) -> PyResult<()> {
-        slf.borrow_mut().counter.entry(key.clone()).or_insert(0);
+        slf.try_borrow_guard_mut()?.counter.entry(key.clone()).or_insert(0);
         let dict = slf.cast::<PyDict>()?;
         dict.set_item(key, value)
     }
@@ -966,10 +962,11 @@ fn print_field_and_return_me(my_class: PyClassGuard<'_, MyClass>) -> PyClassGuar
 
 // Take (a reference to) a Python object smart pointer when borrowing needs to be managed manually.
 #[pyfunction]
-fn increment_then_print_field(my_class: &Bound<'_, MyClass>) {
-    my_class.borrow_mut().my_field += 1;
+fn increment_then_print_field(my_class: &Bound<'_, MyClass>) -> PyResult<()> {
+    my_class.try_borrow_guard_mut()?.my_field += 1;
 
-    println!("{}", my_class.borrow().my_field);
+    println!("{}", my_class.try_borrow_guard()?.my_field);
+    Ok(())
 }
 
 // When the Python object smart pointer needs to be stored elsewhere prefer `Py<T>` over `Bound<'py, T>`

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -415,9 +415,8 @@ Currently, only classes defined in Rust and builtins provided by PyO3 can be inh
 
 To initialize a class, which inherits from another class, use the `PyClassInitializer` API.
 
-To get a parent class from a child, use [`PyRef`] instead of `&self` for methods, or [`PyRefMut`] instead of `&mut self`.
-Then you can access a parent class by `self_.as_super()` as `&PyRef<Self::BaseClass>`, or by `self_.into_super()` as `PyRef<Self::BaseClass>` (and similar for the `PyRefMut` case).
-For convenience, `self_.as_ref()` can also be used to get `&Self::BaseClass` directly; however, this approach does not let you access base classes higher in the inheritance hierarchy, for which you would need to chain multiple `as_super` or `into_super` calls.
+To get a parent class from a child, use [`PyClassGuard`] instead of `&self` for methods, or [`PyClassGuardMut`] instead of `&mut self`.
+Then you can access a parent class by `self_.as_super()` as `&PyClassGuard<Self::BaseClass>`, or by `self_.into_super()` as `PyClassGuard<Self::BaseClass>` (and similar for the `PyRefMut` case).
 
 ```rust
 # use pyo3::prelude::*;
@@ -452,8 +451,8 @@ impl SubClass {
             .add_subclass(SubClass { val2: 15 })
     }
 
-    fn method2(self_: PyRef<'_, Self>) -> PyResult<usize> {
-        let super_ = self_.as_super(); // Get &PyRef<BaseClass>
+    fn method2(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
+        let super_ = self_.as_super(); // Get &PyClassGuard<BaseClass>
         super_.method1().map(|x| x * self_.val2)
     }
 }
@@ -470,24 +469,24 @@ impl SubSubClass {
         PyClassInitializer::from(SubClass::new()).add_subclass(SubSubClass { val3: 20 })
     }
 
-    fn method3(self_: PyRef<'_, Self>) -> PyResult<usize> {
-        let base = self_.as_super().as_super(); // Get &PyRef<'_, BaseClass>
+    fn method3(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
+        let base = self_.as_super().as_super(); // Get &PyClassGuard<'_, BaseClass>
         base.method1().map(|x| x * self_.val3)
     }
 
-    fn method4(self_: PyRef<'_, Self>) -> PyResult<usize> {
+    fn method4(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
         let v = self_.val3;
-        let super_ = self_.into_super(); // Get PyRef<'_, SubClass>
+        let super_ = self_.into_super(); // Get PyClassGuard<'_, SubClass>
         SubClass::method2(super_).map(|x| x * v)
     }
 
-      fn get_values(self_: PyRef<'_, Self>) -> (usize, usize, usize) {
+      fn get_values(self_: PyClassGuard<'_, Self>) -> (usize, usize, usize) {
           let val1 = self_.as_super().as_super().val1;
           let val2 = self_.as_super().val2;
           (val1, val2, self_.val3)
       }
 
-    fn double_values(mut self_: PyRefMut<'_, Self>) {
+    fn double_values(mut self_: PyClassGuardMut<'_, Self>) {
         self_.as_super().as_super().val1 *= 2;
         self_.as_super().val2 *= 2;
         self_.val3 *= 2;
@@ -939,7 +938,7 @@ Class objects can be used as arguments to `#[pyfunction]`s and `#[pymethods]` in
 
 - `Py<T>` or `Bound<'py, T>` smart pointers to the class Python object,
 - `&T` or `&mut T` references to the Rust data contained in the Python object, or
-- `PyRef<T>` and `PyRefMut<T>` reference wrappers.
+- `PyClassGuard<T>` and `PyClassGuardMut<T>` reference wrappers.
 
 Examples of each of these below:
 
@@ -960,7 +959,7 @@ fn increment_field(my_class: &mut MyClass) {
 // Take a reference wrapper when borrowing should be automatic,
 // but access to the Python object is still needed
 #[pyfunction]
-fn print_field_and_return_me(my_class: PyRef<'_, MyClass>) -> PyRef<'_, MyClass> {
+fn print_field_and_return_me(my_class: PyClassGuard<'_, MyClass>) -> PyClassGuard<'_, MyClass> {
     println!("{}", my_class.my_field);
     my_class
 }
@@ -1579,8 +1578,8 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
 [`Py<T>`]: {{#PYO3_DOCS_URL}}/pyo3/struct.Py.html
 [`Bound<'py, T>`]: {{#PYO3_DOCS_URL}}/pyo3/struct.Bound.html
 [`PyClass`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/trait.PyClass.html
-[`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRefMut.html
+[`PyClassGuard`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuard.html
+[`PyClassGuardMut`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuardMut.html
 [`PyClassInitializer<T>`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass_init/struct.PyClassInitializer.html
 
 [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html

--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -415,9 +415,8 @@ Currently, only classes defined in Rust and builtins provided by PyO3 can be inh
 
 To initialize a class, which inherits from another class, use the `PyClassInitializer` API.
 
-To get a parent class from a child, use [`PyRef`] instead of `&self` for methods, or [`PyRefMut`] instead of `&mut self`.
-Then you can access a parent class by `self_.as_super()` as `&PyRef<Self::BaseClass>`, or by `self_.into_super()` as `PyRef<Self::BaseClass>` (and similar for the `PyRefMut` case).
-For convenience, `self_.as_ref()` can also be used to get `&Self::BaseClass` directly; however, this approach does not let you access base classes higher in the inheritance hierarchy, for which you would need to chain multiple `as_super` or `into_super` calls.
+To get a parent class from a child, use [`PyClassGuard`] instead of `&self` for methods, or [`PyClassGuardMut`] instead of `&mut self`.
+Then you can access a parent class by `self_.as_super()` as `&PyClassGuard<Self::BaseClass>`, or by `self_.into_super()` as `PyClassGuard<Self::BaseClass>` (and similar for the `PyRefMut` case).
 
 ```rust
 # use pyo3::prelude::*;
@@ -452,8 +451,8 @@ impl SubClass {
             .add_subclass(SubClass { val2: 15 })
     }
 
-    fn method2(self_: PyRef<'_, Self>) -> PyResult<usize> {
-        let super_ = self_.as_super(); // Get &PyRef<BaseClass>
+    fn method2(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
+        let super_ = self_.as_super(); // Get &PyClassGuard<BaseClass>
         super_.method1().map(|x| x * self_.val2)
     }
 }
@@ -470,24 +469,24 @@ impl SubSubClass {
         PyClassInitializer::from(SubClass::new()).add_subclass(SubSubClass { val3: 20 })
     }
 
-    fn method3(self_: PyRef<'_, Self>) -> PyResult<usize> {
-        let base = self_.as_super().as_super(); // Get &PyRef<'_, BaseClass>
+    fn method3(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
+        let base = self_.as_super().as_super(); // Get &PyClassGuard<'_, BaseClass>
         base.method1().map(|x| x * self_.val3)
     }
 
-    fn method4(self_: PyRef<'_, Self>) -> PyResult<usize> {
+    fn method4(self_: PyClassGuard<'_, Self>) -> PyResult<usize> {
         let v = self_.val3;
-        let super_ = self_.into_super(); // Get PyRef<'_, SubClass>
+        let super_ = self_.into_super(); // Get PyClassGuard<'_, SubClass>
         SubClass::method2(super_).map(|x| x * v)
     }
 
-      fn get_values(self_: PyRef<'_, Self>) -> (usize, usize, usize) {
+      fn get_values(self_: PyClassGuard<'_, Self>) -> (usize, usize, usize) {
           let val1 = self_.as_super().as_super().val1;
           let val2 = self_.as_super().val2;
           (val1, val2, self_.val3)
       }
 
-    fn double_values(mut self_: PyRefMut<'_, Self>) {
+    fn double_values(mut self_: PyClassGuardMut<'_, Self>) {
         self_.as_super().as_super().val1 *= 2;
         self_.as_super().val2 *= 2;
         self_.val3 *= 2;
@@ -939,7 +938,7 @@ Class objects can be used as arguments to `#[pyfunction]`s and `#[pymethods]` in
 
 - `Py<T>` or `Bound<'py, T>` smart pointers to the class Python object,
 - `&T` or `&mut T` references to the Rust data contained in the Python object, or
-- `PyRef<T>` and `PyRefMut<T>` reference wrappers.
+- `PyClassGuard<T>` and `PyClassGuardMut<T>` reference wrappers.
 
 Examples of each of these below:
 
@@ -960,7 +959,7 @@ fn increment_field(my_class: &mut MyClass) {
 // Take a reference wrapper when borrowing should be automatic,
 // but access to the Python object is still needed
 #[pyfunction]
-fn print_field_and_return_me(my_class: PyRef<'_, MyClass>) -> PyRef<'_, MyClass> {
+fn print_field_and_return_me(my_class: PyClassGuard<'_, MyClass>) -> PyClassGuard<'_, MyClass> {
     println!("{}", my_class.my_field);
     my_class
 }
@@ -1575,8 +1574,8 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
 [`Py<T>`]: {{#PYO3_DOCS_URL}}/pyo3/struct.Py.html
 [`Bound<'py, T>`]: {{#PYO3_DOCS_URL}}/pyo3/struct.Bound.html
 [`PyClass`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/trait.PyClass.html
-[`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRefMut.html
+[`PyClassGuard`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuard.html
+[`PyClassGuardMut`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuardMut.html
 [`PyClassInitializer<T>`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass_init/struct.PyClassInitializer.html
 
 [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html

--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -136,7 +136,7 @@ impl Number {
 #
 #[pymethods]
 impl Number {
-    fn __pos__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __pos__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 

--- a/guide/src/class/numeric.md
+++ b/guide/src/class/numeric.md
@@ -237,7 +237,7 @@ impl Number {
     fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
        // Get the class name dynamically in case `Number` is subclassed
        let class_name: Bound<'_, PyString> = slf.get_type().qualname()?;
-        Ok(format!("{}({})", class_name, slf.borrow().0))
+        Ok(format!("{}({})", class_name, slf.try_borrow_guard()?.0))
     }
 
     fn __str__(&self) -> String {

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -137,7 +137,7 @@ impl Number {
         // This is the equivalent of `self.__class__.__name__` in Python.
         let class_name: Bound<'_, PyString> = slf.get_type().qualname()?;
         // To access fields of the Rust struct, we need to borrow from the Bound object.
-        Ok(format!("{}({})", class_name, slf.borrow().0))
+        Ok(format!("{}({})", class_name, slf.try_borrow_guard()?.0))
     }
 }
 ```
@@ -357,7 +357,7 @@ impl Number {
 
     fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
         let class_name: Bound<'_, PyString> = slf.get_type().qualname()?;
-        Ok(format!("{}({})", class_name, slf.borrow().0))
+        Ok(format!("{}({})", class_name, slf.try_borrow_guard()?.0))
     }
 
     fn __str__(&self) -> String {

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -137,7 +137,7 @@ impl Number {
         // This is the equivalent of `self.__class__.__name__` in Python.
         let class_name: Bound<'_, PyString> = slf.get_type().qualname()?;
         // To access fields of the Rust struct, we need to borrow from the Bound object.
-        Ok(format!("{}({})", class_name, slf.borrow().0))
+        Ok(format!("{}({})", class_name, slf.try_borrow_guard()?.0))
     }
 }
 ```
@@ -358,7 +358,7 @@ impl Number {
 
     fn __repr__(slf: &Bound<'_, Self>) -> PyResult<String> {
         let class_name: Bound<'_, PyString> = slf.get_type().qualname()?;
-        Ok(format!("{}({})", class_name, slf.borrow().0))
+        Ok(format!("{}({})", class_name, slf.try_borrow_guard()?.0))
     }
 
     fn __str__(&self) -> String {

--- a/guide/src/class/protocols.md
+++ b/guide/src/class/protocols.md
@@ -33,7 +33,7 @@ The following sections list all magic methods for which PyO3 implements the nece
 The given signatures should be interpreted as follows:
 
 - All methods take a receiver as first argument, shown as `<self>`.
-  It can be `&self`, `&mut self` or a `Bound` reference like `self_: PyRef<'_, Self>` and `self_: PyRefMut<'_, Self>`, as described [in the parent section](../class.md#inheritance).
+  It can be `&self`, `&mut self` or a `Bound` reference like `self_: PyClassGuard<'_, Self>` and `self_: PyClassGuardMut<'_, Self>`, as described [in the parent section](../class.md#inheritance).
 - An optional `Python<'py>` argument is always allowed as the first argument.
 - Return values can be optionally wrapped in `PyResult`.
 - `object` means that any type is allowed that can be extracted from a Python
@@ -184,10 +184,10 @@ struct MyIterator {
 
 #[pymethods]
 impl MyIterator {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
-    fn __next__(slf: PyRefMut<'_, Self>) -> Option<Py<PyAny>> {
+    fn __next__(slf: PyClassGuardMut<'_, Self>) -> Option<Py<PyAny>> {
         slf.iter.lock().unwrap().next()
     }
 }
@@ -207,11 +207,11 @@ struct Iter {
 
 #[pymethods]
 impl Iter {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<usize> {
+    fn __next__(mut slf: PyClassGuardMut<'_, Self>) -> Option<usize> {
         slf.inner.next()
     }
 }
@@ -223,11 +223,11 @@ struct Container {
 
 #[pymethods]
 impl Container {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyResult<Py<Iter>> {
+    fn __iter__(slf: PyClassGuard<'_, Self>, py: Python<'_>) -> PyResult<Py<Iter>> {
         let iter = Iter {
             inner: slf.iter.clone().into_iter(),
         };
-        Py::new(slf.py(), iter)
+        Py::new(py, iter)
     }
 }
 

--- a/guide/src/conversions/tables.md
+++ b/guide/src/conversions/tables.md
@@ -54,8 +54,8 @@ It is also worth remembering the following special types:
 | `Python<'py>`    | A token used to prove attachment to the Python interpreter. |
 | `Bound<'py, T>`  | A Python object with a lifetime which binds it to the attachment to the Python interpreter. This provides access to most of PyO3's APIs. |
 | `Py<T>`          | A Python object not connected to any lifetime of attachment to the Python interpreter. This can be sent to other threads. |
-| `PyRef<T>`       | A `#[pyclass]` borrowed immutably.    |
-| `PyRefMut<T>`    | A `#[pyclass]` borrowed mutably.      |
+| `PyClassGuard<T>`       | A `#[pyclass]` borrowed immutably.    |
+| `PyClassGuardMut<T>`    | A `#[pyclass]` borrowed mutably.      |
 
 For more detail on accepting `#[pyclass]` values as function arguments, see [the section of this guide on Python Classes](../class.md).
 
@@ -105,8 +105,8 @@ Finally, the following Rust types are also able to convert to Python as return v
 | `BTreeSet<T>` | `Set[T]`                        |
 | `Py<T>` | `T`                                   |
 | `Bound<T>` | `T`                                |
-| `PyRef<T: PyClass>` | `T`                       |
-| `PyRefMut<T: PyClass>` | `T`                    |
+| `PyClassGuard<T: PyClass>` | `T`                       |
+| `PyClassGuardMut<T: PyClass>` | `T`                    |
 
 [^1]: Requires the `num-bigint` optional feature.
 

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -537,7 +537,7 @@ impl<'py> FromPyObject<'_, 'py> for Number {
 
     fn extract(obj: pyo3::Borrowed<'_, 'py, pyo3::PyAny>) -> Result<Self, Self::Error> {
         if let Ok(obj) = obj.cast::<Self>() { // first try extraction via class object
-            Ok(obj.borrow().clone())
+            Ok(obj.try_borrow_guard()?.clone())
         } else {
             obj.extract::<i32>().map(Self) // otherwise try integer directly
         }

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -23,7 +23,7 @@ let v: Vec<i32> = list.extract()?;
 This method is available for many Python object types, and can produce a wide variety of Rust types, which you can check out in the implementor list of [`FromPyObject`].
 
 [`FromPyObject`] is also implemented for your own Rust types wrapped as Python objects (see [the chapter about classes](../class.md)).
-There, in order to both be able to operate on mutable references *and* satisfy Rust's rules of non-aliasing mutable references, you have to extract the PyO3 reference wrappers [`PyRef`] and [`PyRefMut`].
+There, in order to both be able to operate on mutable references *and* satisfy Rust's rules of non-aliasing mutable references, you have to extract the PyO3 reference wrappers [`PyClassGuard`] and [`PyClassGuardMut`].
 They work like the reference wrappers of `std::cell::RefCell` and ensure (at runtime) that Rust borrows are allowed.
 
 ### Deriving [`FromPyObject`]
@@ -760,8 +760,8 @@ In the example above we used `BoundObject::into_any` and `BoundObject::unbind` t
 [`IntoPyObject`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObject.html
 [`IntoPyObjectExt`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObjectExt.html
 
-[`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRefMut.html
+[`PyClassGuard`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuard.html
+[`PyClassGuardMut`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuardMut.html
 [`BoundObject`]: {{#PYO3_DOCS_URL}}/pyo3/instance/trait.BoundObject.html
 
 [`Result`]: https://doc.rust-lang.org/stable/std/result/enum.Result.html

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -23,7 +23,7 @@ let v: Vec<i32> = list.extract()?;
 This method is available for many Python object types, and can produce a wide variety of Rust types, which you can check out in the implementor list of [`FromPyObject`].
 
 [`FromPyObject`] is also implemented for your own Rust types wrapped as Python objects (see [the chapter about classes](../class.md)).
-There, in order to both be able to operate on mutable references *and* satisfy Rust's rules of non-aliasing mutable references, you have to extract the PyO3 reference wrappers [`PyRef`] and [`PyRefMut`].
+There, in order to both be able to operate on mutable references *and* satisfy Rust's rules of non-aliasing mutable references, you have to extract the PyO3 reference wrappers [`PyClassGuard`] and [`PyClassGuardMut`].
 They work like the reference wrappers of `std::cell::RefCell` and ensure (at runtime) that Rust borrows are allowed.
 
 ### Deriving [`FromPyObject`]
@@ -771,8 +771,8 @@ In the example above we used `BoundObject::into_any` and `BoundObject::unbind` t
 [`IntoPyObject`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObject.html
 [`IntoPyObjectExt`]: {{#PYO3_DOCS_URL}}/pyo3/conversion/trait.IntoPyObjectExt.html
 
-[`PyRef`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRef.html
-[`PyRefMut`]: {{#PYO3_DOCS_URL}}/pyo3/pycell/struct.PyRefMut.html
+[`PyClassGuard`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuard.html
+[`PyClassGuardMut`]: {{#PYO3_DOCS_URL}}/pyo3/pyclass/struct.PyClassGuardMut.html
 [`BoundObject`]: {{#PYO3_DOCS_URL}}/pyo3/instance/trait.BoundObject.html
 
 [`Result`]: https://doc.rust-lang.org/stable/std/result/enum.Result.html

--- a/guide/src/parallelism.md
+++ b/guide/src/parallelism.md
@@ -155,9 +155,7 @@ let allowed_ids: Vec<bool> = Python::attach(|outer_py| {
     let instances: Vec<Py<UserID>> = (0..10).map(|x| Py::new(outer_py, UserID { id: x }).unwrap()).collect();
     outer_py.detach(|| {
         instances.par_iter().map(|instance| {
-            Python::attach(|inner_py| {
-                instance.borrow(inner_py).id > 5
-            })
+            instance.try_borrow_guard().unwrap().id > 5
         }).collect()
     })
 });

--- a/newsfragments/6120.changed.md
+++ b/newsfragments/6120.changed.md
@@ -1,0 +1,1 @@
+deprecate `PyRef` and `PyRefMut` in favor of `PyClassGuard` and `PyClassGuardMut` respectively

--- a/newsfragments/6121.added.md
+++ b/newsfragments/6121.added.md
@@ -1,0 +1,2 @@
+added `Bound::try_borrow_guard(_mut)`
+added `Py::try_borrow_guard(_mut)`

--- a/newsfragments/6121.changed.md
+++ b/newsfragments/6121.changed.md
@@ -1,0 +1,2 @@
+deprecated `Bound::(try_)borrow(_mut)`
+deprecated `Py::(try_)borrow(_mut)`

--- a/pytests/src/awaitable.rs
+++ b/pytests/src/awaitable.rs
@@ -27,11 +27,11 @@ pub mod awaitable {
             }
         }
 
-        fn __await__(pyself: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        fn __await__(pyself: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
             pyself
         }
 
-        fn __iter__(pyself: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        fn __iter__(pyself: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
             pyself
         }
 
@@ -79,15 +79,15 @@ pub mod awaitable {
             }
         }
 
-        fn __await__(pyself: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        fn __await__(pyself: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
             pyself
         }
 
-        fn __iter__(pyself: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        fn __iter__(pyself: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
             pyself
         }
 
-        fn __next__(mut pyself: PyRefMut<'_, Self>) -> PyResult<PyRefMut<'_, Self>> {
+        fn __next__(mut pyself: PyClassGuardMut<'_, Self>) -> PyResult<PyClassGuardMut<'_, Self>> {
             match pyself.result {
                 Some(_) => match pyself.result.take().unwrap() {
                     Ok(v) => Err(PyStopIteration::new_err(v)),
@@ -97,20 +97,20 @@ pub mod awaitable {
             }
         }
 
-        fn send<'py>(
-            pyself: PyRefMut<'py, Self>,
-            _value: Bound<'py, PyAny>,
-        ) -> PyResult<PyRefMut<'py, Self>> {
+        fn send<'a>(
+            pyself: PyClassGuardMut<'a, Self>,
+            _value: Bound<'_, PyAny>,
+        ) -> PyResult<PyClassGuardMut<'a, Self>> {
             Self::__next__(pyself)
         }
 
         #[pyo3(signature = (_value, _a = None, _b = None))]
-        fn throw<'py>(
-            pyself: PyRefMut<'py, Self>,
-            _value: Bound<'py, PyAny>,
-            _a: Option<Bound<'py, PyAny>>,
-            _b: Option<Bound<'py, PyAny>>,
-        ) -> PyResult<PyRefMut<'py, Self>> {
+        fn throw<'a>(
+            pyself: PyClassGuardMut<'a, Self>,
+            _value: Bound<'_, PyAny>,
+            _a: Option<Bound<'_, PyAny>>,
+            _b: Option<Bound<'_, PyAny>>,
+        ) -> PyResult<PyClassGuardMut<'a, Self>> {
             Self::__next__(pyself)
         }
 

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -297,7 +297,7 @@ impl Number {
         Self(self.0 ^ other.0)
     }
 
-    fn __pos__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __pos__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -309,7 +309,7 @@ impl Number {
         }
     }
 
-    fn __abs__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __abs__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -66,7 +66,7 @@ impl PyClassOptionIter {
         Default::default()
     }
 
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -94,7 +94,7 @@ impl PyClassResultOptionIter {
         Default::default()
     }
 
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -123,7 +123,7 @@ impl PyClassOptionAsyncIter {
         Default::default()
     }
 
-    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __aiter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -385,7 +385,7 @@ impl Number {
         Self(self.0 ^ other.0)
     }
 
-    fn __pos__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __pos__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -397,7 +397,7 @@ impl Number {
         }
     }
 
-    fn __abs__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __abs__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -7,9 +7,9 @@ use crate::pyclass::boolean_struct::False;
 use crate::pyclass::{PyClassGuardError, PyClassGuardMutError};
 use crate::types::PyList;
 use crate::types::PyTuple;
-use crate::{
-    Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyRef, PyRefMut, PyTypeCheck, Python,
-};
+use crate::{Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyTypeCheck, Python};
+#[expect(deprecated)]
+use crate::{PyRef, PyRefMut};
 use core::convert::Infallible;
 use core::marker::PhantomData;
 
@@ -510,6 +510,7 @@ pub(crate) use from_py_object_sequence::FromPyObjectSequence;
 pub trait FromPyObjectOwned<'py>: for<'a> FromPyObject<'a, 'py> {}
 impl<'py, T> FromPyObjectOwned<'py> for T where T: for<'a> FromPyObject<'a, 'py> {}
 
+#[expect(deprecated)]
 impl<'a, 'py, T> FromPyObject<'a, 'py> for PyRef<'py, T>
 where
     T: PyClass,
@@ -527,6 +528,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'a, 'py, T> FromPyObject<'a, 'py> for PyRefMut<'py, T>
 where
     T: PyClass<Frozen = False>,

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -594,7 +594,7 @@ mod tests {
 
             fn extract(obj: crate::Borrowed<'_, 'py, crate::PyAny>) -> Result<Self, Self::Error> {
                 if let Ok(obj) = obj.cast::<Self>() {
-                    Ok(obj.borrow().clone())
+                    Ok(obj.try_borrow_guard()?.clone())
                 } else {
                     obj.extract::<i32>().map(Self)
                 }

--- a/src/conversions/serde.rs
+++ b/src/conversions/serde.rs
@@ -24,11 +24,9 @@ where
     where
         S: Serializer,
     {
-        Python::attach(|py| {
-            self.try_borrow(py)
-                .map_err(|e| ser::Error::custom(e.to_string()))?
-                .serialize(serializer)
-        })
+        self.try_borrow_guard()
+            .map_err(|e| ser::Error::custom(e.to_string()))?
+            .serialize(serializer)
     }
 }
 

--- a/src/conversions/serde.rs
+++ b/src/conversions/serde.rs
@@ -24,11 +24,9 @@ where
     where
         S: Serializer,
     {
-        Python::attach(|py| {
-            self.try_borrow(py)
-                .map_err(|e| ser::Error::custom(e.to_string()))?
-                .serialize(serializer)
-        })
+        self.try_borrow_guard()
+            .map_err(|e| ser::Error::custom(e.to_string()))?
+            .serialize(serializer)
     }
 }
 
@@ -117,12 +115,18 @@ mod tests {
         assert_eq!(user.friends.len(), 1usize);
         let friend = user.friends.first().unwrap();
 
-        Python::attach(|py| {
-            assert_eq!(friend.borrow(py).username, "friend");
-            assert_eq!(
-                friend.borrow(py).group.as_ref().unwrap().borrow(py).name,
-                "danya's friends"
-            )
-        });
+        assert_eq!(friend.try_borrow_guard().unwrap().username, "friend");
+        assert_eq!(
+            friend
+                .try_borrow_guard()
+                .unwrap()
+                .group
+                .as_ref()
+                .unwrap()
+                .try_borrow_guard()
+                .unwrap()
+                .name,
+            "danya's friends"
+        );
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -13,10 +13,12 @@ use crate::pyclass::boolean_struct::{False, True};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
 use crate::types::{DerefToPyAny, PyDict, PyString};
 use crate::{
-    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyRef,
-    PyRefMut, PyTypeInfo, Python,
+    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyTypeInfo,
+    Python,
 };
 use crate::{internal::state, PyTypeCheck};
+#[expect(deprecated)]
+use crate::{PyRef, PyRefMut};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
@@ -151,8 +153,8 @@ impl<'py, T> Bound<'py, T> {
     ///
     ///     class_bound.borrow_mut().i += 1;
     ///
-    ///     // Alternatively you can get a `PyRefMut` directly
-    ///     let class_ref: PyRefMut<'_, Class> = class.extract()?;
+    ///     // Alternatively you can get a `PyClassGuardMut` directly
+    ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract()?;
     ///     assert_eq!(class_ref.i, 1);
     ///     Ok(())
     /// })
@@ -547,6 +549,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow(&self) -> PyRef<'py, T> {
@@ -582,6 +585,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow_mut(&self) -> PyRefMut<'py, T>
@@ -598,6 +602,7 @@ where
     /// This is the non-panicking variant of [`borrow`](#method.borrow).
     ///
     /// For frozen classes, the simpler [`get`][Self::get] is available.
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow(&self) -> Result<PyRef<'py, T>, PyBorrowError> {
         PyRef::try_borrow(self)
@@ -608,6 +613,7 @@ where
     /// The borrow lasts while the returned [`PyRefMut`] exists.
     ///
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow_mut(&self) -> Result<PyRefMut<'py, T>, PyBorrowMutError>
     where
@@ -1614,6 +1620,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow<'py>(&'py self, py: Python<'py>) -> PyRef<'py, T> {
@@ -1651,6 +1658,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow_mut<'py>(&'py self, py: Python<'py>) -> PyRefMut<'py, T>
@@ -1669,6 +1677,7 @@ where
     /// For frozen classes, the simpler [`get`][Self::get] is available.
     ///
     /// Equivalent to `self.bind(py).try_borrow()` - see [`Bound::try_borrow`].
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow<'py>(&'py self, py: Python<'py>) -> Result<PyRef<'py, T>, PyBorrowError> {
         self.bind(py).try_borrow()
@@ -1681,6 +1690,7 @@ where
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
     ///
     /// Equivalent to `self.bind(py).try_borrow_mut()` - see [`Bound::try_borrow_mut`].
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow_mut<'py>(
         &'py self,
@@ -2216,6 +2226,7 @@ impl<T> core::convert::From<Borrowed<'_, '_, T>> for Py<T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T> core::convert::From<PyRef<'py, T>> for Py<T>
 where
     T: PyClass,
@@ -2227,6 +2238,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T> core::convert::From<PyRefMut<'py, T>> for Py<T>
 where
     T: PyClass<Frozen = False>,
@@ -2395,8 +2407,8 @@ impl<T> Py<T> {
     ///
     ///     class_bound.borrow_mut().i += 1;
     ///
-    ///     // Alternatively you can get a `PyRefMut` directly
-    ///     let class_ref: PyRefMut<'_, Class> = class.extract(py)?;
+    ///     // Alternatively you can get a `PyClassGuardMut` directly
+    ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract(py)?;
     ///     assert_eq!(class_ref.i, 1);
     ///     Ok(())
     /// })

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -13,10 +13,12 @@ use crate::pyclass::boolean_struct::{False, True};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
 use crate::types::{DerefToPyAny, PyDict, PyString};
 use crate::{
-    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyRef,
-    PyRefMut, PyTypeInfo, Python,
+    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyTypeInfo,
+    Python,
 };
 use crate::{internal::state, PyTypeCheck};
+#[expect(deprecated)]
+use crate::{PyRef, PyRefMut};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ops::Deref;
@@ -151,8 +153,8 @@ impl<'py, T> Bound<'py, T> {
     ///
     ///     class_bound.borrow_mut().i += 1;
     ///
-    ///     // Alternatively you can get a `PyRefMut` directly
-    ///     let class_ref: PyRefMut<'_, Class> = class.extract()?;
+    ///     // Alternatively you can get a `PyClassGuardMut` directly
+    ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract()?;
     ///     assert_eq!(class_ref.i, 1);
     ///     Ok(())
     /// })
@@ -547,6 +549,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow(&self) -> PyRef<'py, T> {
@@ -582,6 +585,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow_mut(&self) -> PyRefMut<'py, T>
@@ -598,6 +602,7 @@ where
     /// This is the non-panicking variant of [`borrow`](#method.borrow).
     ///
     /// For frozen classes, the simpler [`get`][Self::get] is available.
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow(&self) -> Result<PyRef<'py, T>, PyBorrowError> {
         PyRef::try_borrow(self)
@@ -608,6 +613,7 @@ where
     /// The borrow lasts while the returned [`PyRefMut`] exists.
     ///
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow_mut(&self) -> Result<PyRefMut<'py, T>, PyBorrowMutError>
     where
@@ -1614,6 +1620,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow<'py>(&'py self, py: Python<'py>) -> PyRef<'py, T> {
@@ -1651,6 +1658,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[expect(deprecated)]
     #[inline]
     #[track_caller]
     pub fn borrow_mut<'py>(&'py self, py: Python<'py>) -> PyRefMut<'py, T>
@@ -1669,6 +1677,7 @@ where
     /// For frozen classes, the simpler [`get`][Self::get] is available.
     ///
     /// Equivalent to `self.bind(py).try_borrow()` - see [`Bound::try_borrow`].
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow<'py>(&'py self, py: Python<'py>) -> Result<PyRef<'py, T>, PyBorrowError> {
         self.bind(py).try_borrow()
@@ -1681,6 +1690,7 @@ where
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
     ///
     /// Equivalent to `self.bind(py).try_borrow_mut()` - see [`Bound::try_borrow_mut`].
+    #[expect(deprecated)]
     #[inline]
     pub fn try_borrow_mut<'py>(
         &'py self,
@@ -2216,6 +2226,7 @@ impl<T> core::convert::From<Borrowed<'_, '_, T>> for Py<T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T> core::convert::From<PyRef<'py, T>> for Py<T>
 where
     T: PyClass,
@@ -2227,6 +2238,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T> core::convert::From<PyRefMut<'py, T>> for Py<T>
 where
     T: PyClass<Frozen = False>,
@@ -2394,8 +2406,8 @@ impl<T> Py<T> {
     ///
     ///     class_bound.borrow_mut().i += 1;
     ///
-    ///     // Alternatively you can get a `PyRefMut` directly
-    ///     let class_ref: PyRefMut<'_, Class> = class.extract(py)?;
+    ///     // Alternatively you can get a `PyClassGuardMut` directly
+    ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract(py)?;
     ///     assert_eq!(class_ref.i, 1);
     ///     Ok(())
     /// })

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -13,8 +13,8 @@ use crate::pyclass::boolean_struct::{False, True};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
 use crate::types::{DerefToPyAny, PyDict, PyString};
 use crate::{
-    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyTypeInfo,
-    Python,
+    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassGuard, PyClassGuardMut,
+    PyClassInitializer, PyTypeInfo, Python,
 };
 use crate::{internal::state, PyTypeCheck};
 #[expect(deprecated)]
@@ -151,7 +151,7 @@ impl<'py, T> Bound<'py, T> {
     ///
     ///     let class_bound: &Bound<'_, Class> = class.cast()?;
     ///
-    ///     class_bound.borrow_mut().i += 1;
+    ///     class_bound.try_borrow_guard_mut()?.i += 1;
     ///
     ///     // Alternatively you can get a `PyClassGuardMut` directly
     ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract()?;
@@ -536,7 +536,7 @@ where
     /// # fn main() -> PyResult<()> {
     /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Bound<'_, Foo> = Bound::new(py, Foo { inner: 73 })?;
-    ///     let inner: &u8 = &foo.borrow().inner;
+    ///     let inner: &u8 = &foo.try_borrow_guard()?.inner;
     ///
     ///     assert_eq!(*inner, 73);
     ///     Ok(())
@@ -549,6 +549,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard` instead")]
     #[expect(deprecated)]
     #[inline]
     #[track_caller]
@@ -573,9 +574,9 @@ where
     /// # fn main() -> PyResult<()> {
     /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Bound<'_, Foo> = Bound::new(py, Foo { inner: 73 })?;
-    ///     foo.borrow_mut().inner = 35;
+    ///     foo.try_borrow_guard_mut()?.inner = 35;
     ///
-    ///     assert_eq!(foo.borrow().inner, 35);
+    ///     assert_eq!(foo.try_borrow_guard()?.inner, 35);
     ///     Ok(())
     /// })?;
     /// # Ok(())
@@ -585,6 +586,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard_mut` instead")]
     #[expect(deprecated)]
     #[inline]
     #[track_caller]
@@ -603,9 +605,19 @@ where
     ///
     /// For frozen classes, the simpler [`get`][Self::get] is available.
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard` instead")]
     #[inline]
     pub fn try_borrow(&self) -> Result<PyRef<'py, T>, PyBorrowError> {
         PyRef::try_borrow(self)
+    }
+
+    /// Attempts to immutably borrow the value `T`, returning an error if the value is currently mutably borrowed.
+    ///
+    /// The borrow lasts while the returned [`PyClassGuard`] exists.
+    ///
+    /// For frozen classes, the simpler [`get`][Self::get] is available.
+    pub fn try_borrow_guard(&self) -> Result<PyClassGuard<'_, T>, PyBorrowError> {
+        PyClassGuard::try_borrow(self.as_unbound())
     }
 
     /// Attempts to mutably borrow the value `T`, returning an error if the value is currently borrowed.
@@ -614,12 +626,23 @@ where
     ///
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard_mut` instead")]
     #[inline]
     pub fn try_borrow_mut(&self) -> Result<PyRefMut<'py, T>, PyBorrowMutError>
     where
         T: PyClass<Frozen = False>,
     {
         PyRefMut::try_borrow(self)
+    }
+
+    /// Attempts to mutably borrow the value `T`, returning an error if the value is currently borrowed.
+    ///
+    /// The borrow lasts while the returned [`PyClassGuardMut`] exists.
+    pub fn try_borrow_guard_mut(&self) -> Result<PyClassGuardMut<'_, T>, PyBorrowMutError>
+    where
+        T: PyClass<Frozen = False>,
+    {
+        PyClassGuardMut::try_borrow_mut(self.as_unbound())
     }
 
     /// Provide an immutable borrow of the value `T`.
@@ -1370,7 +1393,7 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// #         m.add_class::<Foo>()?;
 /// #
 /// #         let foo: Bound<'_, Foo> = m.getattr("Foo")?.call0()?.cast_into()?;
-/// #         let dict = &foo.borrow().inner;
+/// #         let dict = &foo.try_borrow_guard()?.inner;
 /// #         let dict: &Bound<'_, PyDict> = dict.bind(py);
 /// #
 /// #         Ok(())
@@ -1407,8 +1430,8 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// #         m.add_class::<Foo>()?;
 /// #
 /// #         let foo: Bound<'_, Foo> = m.getattr("Foo")?.call0()?.cast_into()?;
-/// #         let bar = &foo.borrow().inner;
-/// #         let bar: &Bar = &*bar.borrow(py);
+/// #         let bar = &foo.try_borrow_guard()?.inner;
+/// #         let bar: &Bar = &*bar.try_borrow_guard()?;
 /// #
 /// #         Ok(())
 /// #     })
@@ -1607,7 +1630,7 @@ where
     /// # fn main() -> PyResult<()> {
     /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Py<Foo> = Py::new(py, Foo { inner: 73 })?;
-    ///     let inner: &u8 = &foo.borrow(py).inner;
+    ///     let inner: &u8 = &foo.try_borrow_guard()?.inner;
     ///
     ///     assert_eq!(*inner, 73);
     ///     Ok(())
@@ -1620,6 +1643,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard` instead")]
     #[expect(deprecated)]
     #[inline]
     #[track_caller]
@@ -1646,9 +1670,9 @@ where
     /// # fn main() -> PyResult<()> {
     /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Py<Foo> = Py::new(py, Foo { inner: 73 })?;
-    ///     foo.borrow_mut(py).inner = 35;
+    ///     foo.try_borrow_guard_mut()?.inner = 35;
     ///
-    ///     assert_eq!(foo.borrow(py).inner, 35);
+    ///     assert_eq!(foo.try_borrow_guard()?.inner, 35);
     ///     Ok(())
     /// })?;
     /// # Ok(())
@@ -1659,6 +1683,7 @@ where
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard_mut` instead")]
     #[inline]
     #[track_caller]
     pub fn borrow_mut<'py>(&'py self, py: Python<'py>) -> PyRefMut<'py, T>
@@ -1678,9 +1703,22 @@ where
     ///
     /// Equivalent to `self.bind(py).try_borrow()` - see [`Bound::try_borrow`].
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard` instead")]
     #[inline]
     pub fn try_borrow<'py>(&'py self, py: Python<'py>) -> Result<PyRef<'py, T>, PyBorrowError> {
         self.bind(py).try_borrow()
+    }
+
+    /// Attempts to immutably borrow the value `T`, returning an error if the value is currently mutably borrowed.
+    ///
+    /// The borrow lasts while the returned [`PyClassGuard`] exists.
+    ///
+    /// For frozen classes, the simpler [`get`][Self::get] is available.
+    ///
+    /// Equivalent to [`Bound::try_borrow`].
+    #[inline]
+    pub fn try_borrow_guard<'a>(&'a self) -> Result<PyClassGuard<'a, T>, PyBorrowError> {
+        PyClassGuard::try_borrow(self)
     }
 
     /// Attempts to mutably borrow the value `T`, returning an error if the value is currently borrowed.
@@ -1691,6 +1729,7 @@ where
     ///
     /// Equivalent to `self.bind(py).try_borrow_mut()` - see [`Bound::try_borrow_mut`].
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard_mut` instead")]
     #[inline]
     pub fn try_borrow_mut<'py>(
         &'py self,
@@ -1700,6 +1739,19 @@ where
         T: PyClass<Frozen = False>,
     {
         self.bind(py).try_borrow_mut()
+    }
+
+    /// Attempts to mutably borrow the value `T`, returning an error if the value is currently borrowed.
+    ///
+    /// The borrow lasts while the returned [`PyClassGuardMut`] exists.
+    ///
+    /// Equivalent to [`Bound::try_borrow_mut`].
+    #[inline]
+    pub fn try_borrow_guard_mut<'a>(&'a self) -> Result<PyClassGuardMut<'a, T>, PyBorrowMutError>
+    where
+        T: PyClass<Frozen = False>,
+    {
+        PyClassGuardMut::try_borrow_mut(self)
     }
 
     /// Provide an immutable borrow of the value `T`.
@@ -2405,7 +2457,7 @@ impl<T> Py<T> {
     ///
     ///     let class_bound = class.cast_bound::<Class>(py)?;
     ///
-    ///     class_bound.borrow_mut().i += 1;
+    ///     class_bound.try_borrow_guard_mut()?.i += 1;
     ///
     ///     // Alternatively you can get a `PyClassGuardMut` directly
     ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract(py)?;
@@ -2872,40 +2924,50 @@ a = A()
         struct SomeClass(i32);
 
         #[test]
+        #[expect(deprecated)]
         fn py_borrow_methods() {
             // More detailed tests of the underlying semantics in pycell.rs
             Python::attach(|py| {
                 let instance = Py::new(py, SomeClass(0)).unwrap();
                 assert_eq!(instance.borrow(py).0, 0);
                 assert_eq!(instance.try_borrow(py).unwrap().0, 0);
+                assert_eq!(instance.try_borrow_guard().unwrap().0, 0);
                 assert_eq!(instance.borrow_mut(py).0, 0);
                 assert_eq!(instance.try_borrow_mut(py).unwrap().0, 0);
+                assert_eq!(instance.try_borrow_guard_mut().unwrap().0, 0);
 
-                instance.borrow_mut(py).0 = 123;
+                instance.try_borrow_guard_mut().unwrap().0 = 123;
 
                 assert_eq!(instance.borrow(py).0, 123);
                 assert_eq!(instance.try_borrow(py).unwrap().0, 123);
+                assert_eq!(instance.try_borrow_guard().unwrap().0, 123);
                 assert_eq!(instance.borrow_mut(py).0, 123);
                 assert_eq!(instance.try_borrow_mut(py).unwrap().0, 123);
+                assert_eq!(instance.try_borrow_guard_mut().unwrap().0, 123);
             })
         }
 
         #[test]
+        #[expect(deprecated)]
         fn bound_borrow_methods() {
             // More detailed tests of the underlying semantics in pycell.rs
             Python::attach(|py| {
                 let instance = Bound::new(py, SomeClass(0)).unwrap();
                 assert_eq!(instance.borrow().0, 0);
                 assert_eq!(instance.try_borrow().unwrap().0, 0);
+                assert_eq!(instance.try_borrow_guard().unwrap().0, 0);
                 assert_eq!(instance.borrow_mut().0, 0);
                 assert_eq!(instance.try_borrow_mut().unwrap().0, 0);
+                assert_eq!(instance.try_borrow_guard_mut().unwrap().0, 0);
 
-                instance.borrow_mut().0 = 123;
+                instance.try_borrow_guard_mut().unwrap().0 = 123;
 
                 assert_eq!(instance.borrow().0, 123);
                 assert_eq!(instance.try_borrow().unwrap().0, 123);
+                assert_eq!(instance.try_borrow_guard().unwrap().0, 123);
                 assert_eq!(instance.borrow_mut().0, 123);
                 assert_eq!(instance.try_borrow_mut().unwrap().0, 123);
+                assert_eq!(instance.try_borrow_guard_mut().unwrap().0, 123);
             })
         }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -13,8 +13,8 @@ use crate::pyclass::boolean_struct::{False, True};
 use crate::types::{any::PyAnyMethods, string::PyStringMethods, typeobject::PyTypeMethods};
 use crate::types::{DerefToPyAny, PyDict, PyString};
 use crate::{
-    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassInitializer, PyTypeInfo,
-    Python,
+    ffi, CastError, CastIntoError, FromPyObject, PyAny, PyClass, PyClassGuard, PyClassGuardMut,
+    PyClassInitializer, PyTypeInfo, Python,
 };
 use crate::{internal::state, PyTypeCheck};
 #[expect(deprecated)]
@@ -151,7 +151,7 @@ impl<'py, T> Bound<'py, T> {
     ///
     ///     let class_bound: &Bound<'_, Class> = class.cast()?;
     ///
-    ///     class_bound.borrow_mut().i += 1;
+    ///     class_bound.try_borrow_guard_mut()?.i += 1;
     ///
     ///     // Alternatively you can get a `PyClassGuardMut` directly
     ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract()?;
@@ -536,7 +536,7 @@ where
     /// # fn main() -> PyResult<()> {
     /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Bound<'_, Foo> = Bound::new(py, Foo { inner: 73 })?;
-    ///     let inner: &u8 = &foo.borrow().inner;
+    ///     let inner: &u8 = &foo.try_borrow_guard()?.inner;
     ///
     ///     assert_eq!(*inner, 73);
     ///     Ok(())
@@ -549,6 +549,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard` instead")]
     #[expect(deprecated)]
     #[inline]
     #[track_caller]
@@ -573,9 +574,9 @@ where
     /// # fn main() -> PyResult<()> {
     /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Bound<'_, Foo> = Bound::new(py, Foo { inner: 73 })?;
-    ///     foo.borrow_mut().inner = 35;
+    ///     foo.try_borrow_guard_mut()?.inner = 35;
     ///
-    ///     assert_eq!(foo.borrow().inner, 35);
+    ///     assert_eq!(foo.try_borrow_guard()?.inner, 35);
     ///     Ok(())
     /// })?;
     /// # Ok(())
@@ -585,6 +586,7 @@ where
     /// # Panics
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard_mut` instead")]
     #[expect(deprecated)]
     #[inline]
     #[track_caller]
@@ -603,9 +605,19 @@ where
     ///
     /// For frozen classes, the simpler [`get`][Self::get] is available.
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard` instead")]
     #[inline]
     pub fn try_borrow(&self) -> Result<PyRef<'py, T>, PyBorrowError> {
         PyRef::try_borrow(self)
+    }
+
+    /// Attempts to immutably borrow the value `T`, returning an error if the value is currently mutably borrowed.
+    ///
+    /// The borrow lasts while the returned [`PyClassGuard`] exists.
+    ///
+    /// For frozen classes, the simpler [`get`][Self::get] is available.
+    pub fn try_borrow_guard(&self) -> Result<PyClassGuard<'_, T>, PyBorrowError> {
+        PyClassGuard::try_borrow(self.as_unbound())
     }
 
     /// Attempts to mutably borrow the value `T`, returning an error if the value is currently borrowed.
@@ -614,12 +626,23 @@ where
     ///
     /// This is the non-panicking variant of [`borrow_mut`](#method.borrow_mut).
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard_mut` instead")]
     #[inline]
     pub fn try_borrow_mut(&self) -> Result<PyRefMut<'py, T>, PyBorrowMutError>
     where
         T: PyClass<Frozen = False>,
     {
         PyRefMut::try_borrow(self)
+    }
+
+    /// Attempts to mutably borrow the value `T`, returning an error if the value is currently borrowed.
+    ///
+    /// The borrow lasts while the returned [`PyClassGuardMut`] exists.
+    pub fn try_borrow_guard_mut(&self) -> Result<PyClassGuardMut<'_, T>, PyBorrowMutError>
+    where
+        T: PyClass<Frozen = False>,
+    {
+        PyClassGuardMut::try_borrow_mut(self.as_unbound())
     }
 
     /// Provide an immutable borrow of the value `T`.
@@ -1370,7 +1393,7 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// #         m.add_class::<Foo>()?;
 /// #
 /// #         let foo: Bound<'_, Foo> = m.getattr("Foo")?.call0()?.cast_into()?;
-/// #         let dict = &foo.borrow().inner;
+/// #         let dict = &foo.try_borrow_guard()?.inner;
 /// #         let dict: &Bound<'_, PyDict> = dict.bind(py);
 /// #
 /// #         Ok(())
@@ -1407,8 +1430,8 @@ impl<'a, 'py, T> BoundObject<'py, T> for Borrowed<'a, 'py, T> {
 /// #         m.add_class::<Foo>()?;
 /// #
 /// #         let foo: Bound<'_, Foo> = m.getattr("Foo")?.call0()?.cast_into()?;
-/// #         let bar = &foo.borrow().inner;
-/// #         let bar: &Bar = &*bar.borrow(py);
+/// #         let bar = &foo.try_borrow_guard()?.inner;
+/// #         let bar: &Bar = &*bar.try_borrow_guard()?;
 /// #
 /// #         Ok(())
 /// #     })
@@ -1607,7 +1630,7 @@ where
     /// # fn main() -> PyResult<()> {
     /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Py<Foo> = Py::new(py, Foo { inner: 73 })?;
-    ///     let inner: &u8 = &foo.borrow(py).inner;
+    ///     let inner: &u8 = &foo.try_borrow_guard()?.inner;
     ///
     ///     assert_eq!(*inner, 73);
     ///     Ok(())
@@ -1620,6 +1643,7 @@ where
     ///
     /// Panics if the value is currently mutably borrowed. For a non-panicking variant, use
     /// [`try_borrow`](#method.try_borrow).
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard` instead")]
     #[expect(deprecated)]
     #[inline]
     #[track_caller]
@@ -1646,9 +1670,9 @@ where
     /// # fn main() -> PyResult<()> {
     /// Python::attach(|py| -> PyResult<()> {
     ///     let foo: Py<Foo> = Py::new(py, Foo { inner: 73 })?;
-    ///     foo.borrow_mut(py).inner = 35;
+    ///     foo.try_borrow_guard_mut()?.inner = 35;
     ///
-    ///     assert_eq!(foo.borrow(py).inner, 35);
+    ///     assert_eq!(foo.try_borrow_guard()?.inner, 35);
     ///     Ok(())
     /// })?;
     /// # Ok(())
@@ -1659,6 +1683,7 @@ where
     /// Panics if the value is currently borrowed. For a non-panicking variant, use
     /// [`try_borrow_mut`](#method.try_borrow_mut).
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard_mut` instead")]
     #[inline]
     #[track_caller]
     pub fn borrow_mut<'py>(&'py self, py: Python<'py>) -> PyRefMut<'py, T>
@@ -1678,9 +1703,22 @@ where
     ///
     /// Equivalent to `self.bind(py).try_borrow()` - see [`Bound::try_borrow`].
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard` instead")]
     #[inline]
     pub fn try_borrow<'py>(&'py self, py: Python<'py>) -> Result<PyRef<'py, T>, PyBorrowError> {
         self.bind(py).try_borrow()
+    }
+
+    /// Attempts to immutably borrow the value `T`, returning an error if the value is currently mutably borrowed.
+    ///
+    /// The borrow lasts while the returned [`PyClassGuard`] exists.
+    ///
+    /// For frozen classes, the simpler [`get`][Self::get] is available.
+    ///
+    /// Equivalent to [`Bound::try_borrow`].
+    #[inline]
+    pub fn try_borrow_guard<'a>(&'a self) -> Result<PyClassGuard<'a, T>, PyBorrowError> {
+        PyClassGuard::try_borrow(self)
     }
 
     /// Attempts to mutably borrow the value `T`, returning an error if the value is currently borrowed.
@@ -1691,6 +1729,7 @@ where
     ///
     /// Equivalent to `self.bind(py).try_borrow_mut()` - see [`Bound::try_borrow_mut`].
     #[expect(deprecated)]
+    #[deprecated(since = "0.30.0", note = "use `try_borrow_guard_mut` instead")]
     #[inline]
     pub fn try_borrow_mut<'py>(
         &'py self,
@@ -1700,6 +1739,19 @@ where
         T: PyClass<Frozen = False>,
     {
         self.bind(py).try_borrow_mut()
+    }
+
+    /// Attempts to mutably borrow the value `T`, returning an error if the value is currently borrowed.
+    ///
+    /// The borrow lasts while the returned [`PyClassGuardMut`] exists.
+    ///
+    /// Equivalent to [`Bound::try_borrow_mut`].
+    #[inline]
+    pub fn try_borrow_guard_mut<'a>(&'a self) -> Result<PyClassGuardMut<'a, T>, PyBorrowMutError>
+    where
+        T: PyClass<Frozen = False>,
+    {
+        PyClassGuardMut::try_borrow_mut(self)
     }
 
     /// Provide an immutable borrow of the value `T`.
@@ -2404,7 +2456,7 @@ impl<T> Py<T> {
     ///
     ///     let class_bound = class.cast_bound::<Class>(py)?;
     ///
-    ///     class_bound.borrow_mut().i += 1;
+    ///     class_bound.try_borrow_guard_mut()?.i += 1;
     ///
     ///     // Alternatively you can get a `PyClassGuardMut` directly
     ///     let class_ref: PyClassGuardMut<'_, Class> = class.extract(py)?;
@@ -2871,40 +2923,50 @@ a = A()
         struct SomeClass(i32);
 
         #[test]
+        #[expect(deprecated)]
         fn py_borrow_methods() {
             // More detailed tests of the underlying semantics in pycell.rs
             Python::attach(|py| {
                 let instance = Py::new(py, SomeClass(0)).unwrap();
                 assert_eq!(instance.borrow(py).0, 0);
                 assert_eq!(instance.try_borrow(py).unwrap().0, 0);
+                assert_eq!(instance.try_borrow_guard().unwrap().0, 0);
                 assert_eq!(instance.borrow_mut(py).0, 0);
                 assert_eq!(instance.try_borrow_mut(py).unwrap().0, 0);
+                assert_eq!(instance.try_borrow_guard_mut().unwrap().0, 0);
 
-                instance.borrow_mut(py).0 = 123;
+                instance.try_borrow_guard_mut().unwrap().0 = 123;
 
                 assert_eq!(instance.borrow(py).0, 123);
                 assert_eq!(instance.try_borrow(py).unwrap().0, 123);
+                assert_eq!(instance.try_borrow_guard().unwrap().0, 123);
                 assert_eq!(instance.borrow_mut(py).0, 123);
                 assert_eq!(instance.try_borrow_mut(py).unwrap().0, 123);
+                assert_eq!(instance.try_borrow_guard_mut().unwrap().0, 123);
             })
         }
 
         #[test]
+        #[expect(deprecated)]
         fn bound_borrow_methods() {
             // More detailed tests of the underlying semantics in pycell.rs
             Python::attach(|py| {
                 let instance = Bound::new(py, SomeClass(0)).unwrap();
                 assert_eq!(instance.borrow().0, 0);
                 assert_eq!(instance.try_borrow().unwrap().0, 0);
+                assert_eq!(instance.try_borrow_guard().unwrap().0, 0);
                 assert_eq!(instance.borrow_mut().0, 0);
                 assert_eq!(instance.try_borrow_mut().unwrap().0, 0);
+                assert_eq!(instance.try_borrow_guard_mut().unwrap().0, 0);
 
-                instance.borrow_mut().0 = 123;
+                instance.try_borrow_guard_mut().unwrap().0 = 123;
 
                 assert_eq!(instance.borrow().0, 123);
                 assert_eq!(instance.try_borrow().unwrap().0, 123);
+                assert_eq!(instance.try_borrow_guard().unwrap().0, 123);
                 assert_eq!(instance.borrow_mut().0, 123);
                 assert_eq!(instance.try_borrow_mut().unwrap().0, 123);
+                assert_eq!(instance.try_borrow_guard_mut().unwrap().0, 123);
             })
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,7 @@ pub use crate::instance::{Borrowed, Bound, BoundObject, Py};
 #[cfg(not(any(PyPy, GraalPy)))]
 pub use crate::interpreter_lifecycle::with_embedded_python_interpreter;
 pub use crate::marker::Python;
+#[expect(deprecated)]
 pub use crate::pycell::{PyRef, PyRefMut};
 pub use crate::pyclass::{PyClass, PyClassGuard, PyClassGuardMut};
 pub use crate::pyclass_init::PyClassInitializer;

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -277,7 +277,9 @@ mod nightly {
         // This means that PyString, PyList, etc all inherit !Ungil from  this.
         impl !Ungil for crate::PyAny {}
 
+        #[expect(deprecated)]
         impl<T> !Ungil for crate::PyRef<'_, T> {}
+        #[expect(deprecated)]
         impl<T> !Ungil for crate::PyRefMut<'_, T> {}
 
         // FFI pointees

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -276,7 +276,9 @@ mod nightly {
         // This means that PyString, PyList, etc all inherit !Ungil from  this.
         impl !Ungil for crate::PyAny {}
 
+        #[expect(deprecated)]
         impl<T> !Ungil for crate::PyRef<'_, T> {}
+        #[expect(deprecated)]
         impl<T> !Ungil for crate::PyRefMut<'_, T> {}
 
         // FFI pointees

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,6 +12,7 @@ pub use crate::conversion::{FromPyObject, FromPyObjectOwned, IntoPyObject};
 pub use crate::err::{PyErr, PyResult};
 pub use crate::instance::{Borrowed, Bound, Py};
 pub use crate::marker::Python;
+#[expect(deprecated)]
 pub use crate::pycell::{PyRef, PyRefMut};
 pub use crate::pyclass_init::PyClassInitializer;
 pub use crate::types::{PyAny, PyModule};

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -100,6 +100,7 @@
 //!
 //!     // We borrow the guard and then dereference
 //!     // it to get a mutable reference to Number
+//! #   #[expect(deprecated)]
 //!     let mut guard: PyRefMut<'_, Number> = n.bind(py).borrow_mut();
 //!     let n_mutable: &mut Number = &mut *guard;
 //!
@@ -242,6 +243,7 @@ use impl_::{PyClassBorrowChecker, PyClassObjectBaseLayout, PyClassObjectLayout};
 ///             .add_subclass(Child { name: "Caterpillar" })
 ///     }
 ///
+/// #   #[expect(deprecated)]
 ///     fn format(slf: PyRef<'_, Self>) -> String {
 ///         // We can get *mut ffi::PyObject from PyRef
 ///         let refcnt = unsafe { pyo3::ffi::Py_REFCNT(slf.as_ptr()) };
@@ -258,12 +260,14 @@ use impl_::{PyClassBorrowChecker, PyClassObjectBaseLayout, PyClassObjectLayout};
 ///
 /// See the [module-level documentation](self) for more information.
 #[repr(transparent)]
+#[deprecated(since = "0.30.0", note = "use `PyClassGuard` instead")]
 pub struct PyRef<'p, T: PyClass> {
     // TODO: once the GIL Ref API is removed, consider adding a lifetime parameter to `PyRef` to
     // store `Borrowed` here instead, avoiding reference counting overhead.
     inner: Bound<'p, T>,
 }
 
+#[expect(deprecated)]
 impl<'p, T: PyClass> PyRef<'p, T> {
     /// Returns a `Python` token that is bound to the lifetime of the `PyRef`.
     pub fn py(&self) -> Python<'p> {
@@ -271,6 +275,7 @@ impl<'p, T: PyClass> PyRef<'p, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T, U> AsRef<U> for PyRef<'_, T>
 where
     T: PyClass<BaseType = U>,
@@ -281,6 +286,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass> PyRef<'py, T> {
     /// Returns the raw FFI pointer represented by self.
     ///
@@ -320,6 +326,7 @@ impl<'py, T: PyClass> PyRef<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'p, T> PyRef<'p, T>
 where
     T: PyClass,
@@ -359,6 +366,7 @@ where
     ///             .add_subclass(Base2 { name2: "base2" })
     ///             .add_subclass(Self { name3: "sub" })
     ///     }
+    /// #   #[expect(deprecated)]
     ///     fn name(slf: PyRef<'_, Self>) -> String {
     ///         let subname = slf.name3;
     ///         let super_ = slf.into_super();
@@ -442,6 +450,7 @@ where
     ///     fn sub_name_len(&self) -> usize {
     ///         self.sub_name.len()
     ///     }
+    /// #   #[expect(deprecated)]
     ///     fn format_name_lengths(slf: PyRef<'_, Self>) -> String {
     ///         format!("{} {}", slf.as_super().base_name_len(), slf.sub_name_len())
     ///     }
@@ -462,6 +471,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass> Deref for PyRef<'_, T> {
     type Target = T;
 
@@ -471,6 +481,7 @@ impl<T: PyClass> Deref for PyRef<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass> Drop for PyRef<'_, T> {
     fn drop(&mut self) {
         self.inner
@@ -480,6 +491,7 @@ impl<T: PyClass> Drop for PyRef<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass> IntoPyObject<'py> for PyRef<'py, T> {
     type Target = T;
     type Output = Bound<'py, T>;
@@ -493,6 +505,7 @@ impl<'py, T: PyClass> IntoPyObject<'py> for PyRef<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'a, 'py, T: PyClass> IntoPyObject<'py> for &'a PyRef<'py, T> {
     type Target = T;
     type Output = Borrowed<'a, 'py, T>;
@@ -506,12 +519,14 @@ impl<'a, 'py, T: PyClass> IntoPyObject<'py> for &'a PyRef<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass + fmt::Debug> fmt::Debug for PyRef<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass> TryFrom<&Bound<'py, T>> for PyRef<'py, T> {
     type Error = PyBorrowError;
     #[inline]
@@ -523,6 +538,7 @@ impl<'py, T: PyClass> TryFrom<&Bound<'py, T>> for PyRef<'py, T> {
 /// A wrapper type for a mutably borrowed value from a [`Bound<'py, T>`].
 ///
 /// See the [module-level documentation](self) for more information.
+#[deprecated(since = "0.30.0", note = "use `PyClassGuardMut` instead")]
 #[repr(transparent)]
 pub struct PyRefMut<'p, T: PyClass<Frozen = False>> {
     // TODO: once the GIL Ref API is removed, consider adding a lifetime parameter to `PyRef` to
@@ -530,6 +546,7 @@ pub struct PyRefMut<'p, T: PyClass<Frozen = False>> {
     inner: Bound<'p, T>,
 }
 
+#[expect(deprecated)]
 impl<'p, T: PyClass<Frozen = False>> PyRefMut<'p, T> {
     /// Returns a `Python` token that is bound to the lifetime of the `PyRefMut`.
     pub fn py(&self) -> Python<'p> {
@@ -537,6 +554,7 @@ impl<'p, T: PyClass<Frozen = False>> PyRefMut<'p, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T> AsRef<T::BaseType> for PyRefMut<'_, T>
 where
     T: PyClass<Frozen = False>,
@@ -547,6 +565,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<T> AsMut<T::BaseType> for PyRefMut<'_, T>
 where
     T: PyClass<Frozen = False>,
@@ -557,6 +576,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass<Frozen = False>> PyRefMut<'py, T> {
     /// Returns the raw FFI pointer represented by self.
     ///
@@ -603,6 +623,7 @@ impl<'py, T: PyClass<Frozen = False>> PyRefMut<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'p, T> PyRefMut<'p, T>
 where
     T: PyClass<Frozen = False>,
@@ -642,6 +663,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass<Frozen = False>> Deref for PyRefMut<'_, T> {
     type Target = T;
 
@@ -651,6 +673,7 @@ impl<T: PyClass<Frozen = False>> Deref for PyRefMut<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass<Frozen = False>> DerefMut for PyRefMut<'_, T> {
     #[inline]
     fn deref_mut(&mut self) -> &mut T {
@@ -658,6 +681,7 @@ impl<T: PyClass<Frozen = False>> DerefMut for PyRefMut<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass<Frozen = False>> Drop for PyRefMut<'_, T> {
     fn drop(&mut self) {
         self.inner
@@ -667,6 +691,7 @@ impl<T: PyClass<Frozen = False>> Drop for PyRefMut<'_, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for PyRefMut<'py, T> {
     type Target = T;
     type Output = Bound<'py, T>;
@@ -680,6 +705,7 @@ impl<'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for PyRefMut<'py, T> {
     }
 }
 
+#[expect(deprecated)]
 impl<'a, 'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for &'a PyRefMut<'py, T> {
     type Target = T;
     type Output = Borrowed<'a, 'py, T>;
@@ -693,12 +719,14 @@ impl<'a, 'py, T: PyClass<Frozen = False>> IntoPyObject<'py> for &'a PyRefMut<'py
     }
 }
 
+#[expect(deprecated)]
 impl<T: PyClass<Frozen = False> + fmt::Debug> fmt::Debug for PyRefMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(self.deref(), f)
     }
 }
 
+#[expect(deprecated)]
 impl<'py, T: PyClass<Frozen = False>> TryFrom<&Bound<'py, T>> for PyRefMut<'py, T> {
     type Error = PyBorrowMutError;
     #[inline]
@@ -834,12 +862,14 @@ mod tests {
             crate::Py::new(py, init).expect("allocation error")
         }
 
+        #[expect(deprecated)]
         fn get_values(self_: PyRef<'_, Self>) -> (usize, usize, usize) {
             let val1 = self_.as_super().as_super().val1;
             let val2 = self_.as_super().val2;
             (val1, val2, self_.val3)
         }
 
+        #[expect(deprecated)]
         fn double_values(mut self_: PyRefMut<'_, Self>) {
             self_.as_super().as_super().val1 *= 2;
             self_.as_super().val2 *= 2;

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -81,6 +81,7 @@
 //!
 //! However, we *do* need `PyCell` if we want to call its methods from Rust:
 //! ```rust
+//! # #![allow(deprecated)]
 //! # use pyo3::prelude::*;
 //! #
 //! # #[pyclass]
@@ -801,6 +802,8 @@ impl From<PyBorrowMutError> for PyErr {
 #[cfg(feature = "macros")]
 mod tests {
 
+    use crate::{PyClassGuard, PyClassGuardMut};
+
     use super::*;
 
     #[crate::pyclass]
@@ -809,6 +812,7 @@ mod tests {
     struct SomeClass(i32);
 
     #[test]
+    #[expect(deprecated)]
     fn test_as_ptr() {
         Python::attach(|py| {
             let cell = Bound::new(py, SomeClass(0)).unwrap();
@@ -820,6 +824,7 @@ mod tests {
     }
 
     #[test]
+    #[expect(deprecated)]
     fn test_into_ptr() {
         Python::attach(|py| {
             let cell = Bound::new(py, SomeClass(0)).unwrap();
@@ -862,15 +867,13 @@ mod tests {
             crate::Py::new(py, init).expect("allocation error")
         }
 
-        #[expect(deprecated)]
-        fn get_values(self_: PyRef<'_, Self>) -> (usize, usize, usize) {
+        fn get_values(self_: PyClassGuard<'_, Self>) -> (usize, usize, usize) {
             let val1 = self_.as_super().as_super().val1;
             let val2 = self_.as_super().val2;
             (val1, val2, self_.val3)
         }
 
-        #[expect(deprecated)]
-        fn double_values(mut self_: PyRefMut<'_, Self>) {
+        fn double_values(mut self_: PyClassGuardMut<'_, Self>) {
             self_.as_super().as_super().val1 *= 2;
             self_.as_super().val2 *= 2;
             self_.val3 *= 2;
@@ -881,12 +884,11 @@ mod tests {
     fn test_pyref_as_super() {
         Python::attach(|py| {
             let obj = SubSubClass::new(py).into_bound(py);
-            let pyref = obj.borrow();
-            assert_eq!(pyref.as_super().as_super().val1, 10);
-            assert_eq!(pyref.as_super().val2, 15);
-            assert_eq!(pyref.as_ref().val2, 15); // `as_ref` also works
-            assert_eq!(pyref.val3, 20);
-            assert_eq!(SubSubClass::get_values(pyref), (10, 15, 20));
+            let guard = obj.try_borrow_guard().unwrap();
+            assert_eq!(guard.as_super().as_super().val1, 10);
+            assert_eq!(guard.as_super().val2, 15);
+            assert_eq!(guard.val3, 20);
+            assert_eq!(SubSubClass::get_values(guard), (10, 15, 20));
         });
     }
 
@@ -894,18 +896,25 @@ mod tests {
     fn test_pyrefmut_as_super() {
         Python::attach(|py| {
             let obj = SubSubClass::new(py).into_bound(py);
-            assert_eq!(SubSubClass::get_values(obj.borrow()), (10, 15, 20));
+            assert_eq!(
+                SubSubClass::get_values(obj.try_borrow_guard().unwrap()),
+                (10, 15, 20)
+            );
             {
-                let mut pyrefmut = obj.borrow_mut();
-                assert_eq!(pyrefmut.as_super().as_ref().val1, 10);
-                pyrefmut.as_super().as_super().val1 -= 5;
-                pyrefmut.as_super().val2 -= 3;
-                pyrefmut.as_mut().val2 -= 2; // `as_mut` also works
-                pyrefmut.val3 -= 5;
+                let mut guard = obj.try_borrow_guard_mut().unwrap();
+                guard.as_super().as_super().val1 -= 5;
+                guard.as_super().val2 -= 5;
+                guard.val3 -= 5;
             }
-            assert_eq!(SubSubClass::get_values(obj.borrow()), (5, 10, 15));
-            SubSubClass::double_values(obj.borrow_mut());
-            assert_eq!(SubSubClass::get_values(obj.borrow()), (10, 20, 30));
+            assert_eq!(
+                SubSubClass::get_values(obj.try_borrow_guard().unwrap()),
+                (5, 10, 15)
+            );
+            SubSubClass::double_values(obj.try_borrow_guard_mut().unwrap());
+            assert_eq!(
+                SubSubClass::get_values(obj.try_borrow_guard().unwrap()),
+                (10, 20, 30)
+            );
         });
     }
 
@@ -941,8 +950,8 @@ mod tests {
 
         Python::attach(|py| {
             let obj = SubClass::new(py);
-            drop(obj.borrow().into_super());
-            assert!(obj.try_borrow_mut().is_ok());
+            drop(obj.try_borrow_guard().unwrap().into_super());
+            assert!(obj.try_borrow_guard_mut().is_ok());
         })
     }
 
@@ -974,10 +983,10 @@ mod tests {
 
         Python::attach(|py| {
             let obj = SubSubClass::new(py);
-            let _super_borrow = obj.borrow().into_super();
+            let _super_borrow = obj.try_borrow_guard().unwrap().into_super();
             // the whole object still has an immutable borrow, so we cannot
             // borrow any part mutably (the borrowflag is shared)
-            assert!(obj.try_borrow_mut().is_err());
+            assert!(obj.try_borrow_guard_mut().is_err());
         })
     }
 }

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -742,7 +742,7 @@ mod tests {
 
             let mmm_bound: &Bound<'_, MutableChildOfMutableChildOfMutableBase> = mmm.bind(py);
 
-            let mmm_refmut = mmm_bound.borrow_mut();
+            let mmm_refmut = mmm_bound.try_borrow_guard_mut().unwrap();
 
             // Cannot take any other mutable or immutable borrows whilst the object is borrowed mutably
             assert!(mmm_bound
@@ -799,7 +799,7 @@ mod tests {
 
             let mmm_bound: &Bound<'_, MutableChildOfMutableChildOfMutableBase> = mmm.bind(py);
 
-            let mmm_refmut = mmm_bound.borrow();
+            let mmm_refmut = mmm_bound.try_borrow_guard().unwrap();
 
             // Further immutable borrows are ok
             assert!(mmm_bound
@@ -854,17 +854,15 @@ mod tests {
                     let threads = (0..10)
                         .map(|_| {
                             s.spawn(|| {
-                                Python::attach(|py| {
-                                    // Each thread records its own view of how many writes it made
-                                    let mut local_modifications = 0;
-                                    for _ in 0..100 {
-                                        if let Ok(mut i) = inst.try_borrow_mut(py) {
-                                            i.x += 1;
-                                            local_modifications += 1;
-                                        }
+                                // Each thread records its own view of how many writes it made
+                                let mut local_modifications = 0;
+                                for _ in 0..100 {
+                                    if let Ok(mut i) = inst.try_borrow_guard_mut() {
+                                        i.x += 1;
+                                        local_modifications += 1;
                                     }
-                                    local_modifications
-                                })
+                                }
+                                local_modifications
                             })
                         })
                         .collect::<Vec<_>>();
@@ -876,7 +874,7 @@ mod tests {
 
             // If the implementation is free of data races, the total number of writes
             // should match the final value of `x`.
-            assert_eq!(total_modifications, inst.borrow(py).x);
+            assert_eq!(total_modifications, inst.try_borrow_guard().unwrap().x);
         });
     }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -746,37 +746,43 @@ mod tests {
 
             // Cannot take any other mutable or immutable borrows whilst the object is borrowed mutably
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
-                .is_err());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_err());
-            assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableBase>>()
                 .is_err());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
+                .is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_err());
 
             // With the borrow dropped, all other borrow attempts will succeed
             drop(mmm_refmut);
 
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound.extract::<PyClassGuard<'_, MutableBase>>().is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_ok());
         })
     }
 
@@ -797,32 +803,36 @@ mod tests {
 
             // Further immutable borrows are ok
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound.extract::<PyClassGuard<'_, MutableBase>>().is_ok());
 
             // Further mutable borrows are not ok
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_err());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_err());
 
             // With the borrow dropped, all mutable borrow attempts will succeed
             drop(mmm_refmut);
 
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_ok());
         })
     }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -773,37 +773,43 @@ mod tests {
 
             // Cannot take any other mutable or immutable borrows whilst the object is borrowed mutably
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
-                .is_err());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_err());
-            assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableBase>>()
                 .is_err());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
+                .is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_err());
 
             // With the borrow dropped, all other borrow attempts will succeed
             drop(mmm_refmut);
 
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound.extract::<PyClassGuard<'_, MutableBase>>().is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_ok());
         })
     }
 
@@ -824,32 +830,36 @@ mod tests {
 
             // Further immutable borrows are ok
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRef<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuard<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRef<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound.extract::<PyClassGuard<'_, MutableBase>>().is_ok());
 
             // Further mutable borrows are not ok
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_err());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_err());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_err());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_err());
 
             // With the borrow dropped, all mutable borrow attempts will succeed
             drop(mmm_refmut);
 
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableChildOfMutableBase>>()
                 .is_ok());
             assert!(mmm_bound
-                .extract::<PyRefMut<'_, MutableChildOfMutableBase>>()
+                .extract::<PyClassGuardMut<'_, MutableChildOfMutableBase>>()
                 .is_ok());
-            assert!(mmm_bound.extract::<PyRefMut<'_, MutableBase>>().is_ok());
+            assert!(mmm_bound
+                .extract::<PyClassGuardMut<'_, MutableBase>>()
+                .is_ok());
         })
     }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -769,7 +769,7 @@ mod tests {
 
             let mmm_bound: &Bound<'_, MutableChildOfMutableChildOfMutableBase> = mmm.bind(py);
 
-            let mmm_refmut = mmm_bound.borrow_mut();
+            let mmm_refmut = mmm_bound.try_borrow_guard_mut().unwrap();
 
             // Cannot take any other mutable or immutable borrows whilst the object is borrowed mutably
             assert!(mmm_bound
@@ -826,7 +826,7 @@ mod tests {
 
             let mmm_bound: &Bound<'_, MutableChildOfMutableChildOfMutableBase> = mmm.bind(py);
 
-            let mmm_refmut = mmm_bound.borrow();
+            let mmm_refmut = mmm_bound.try_borrow_guard().unwrap();
 
             // Further immutable borrows are ok
             assert!(mmm_bound
@@ -881,17 +881,15 @@ mod tests {
                     let threads = (0..10)
                         .map(|_| {
                             s.spawn(|| {
-                                Python::attach(|py| {
-                                    // Each thread records its own view of how many writes it made
-                                    let mut local_modifications = 0;
-                                    for _ in 0..100 {
-                                        if let Ok(mut i) = inst.try_borrow_mut(py) {
-                                            i.x += 1;
-                                            local_modifications += 1;
-                                        }
+                                // Each thread records its own view of how many writes it made
+                                let mut local_modifications = 0;
+                                for _ in 0..100 {
+                                    if let Ok(mut i) = inst.try_borrow_guard_mut() {
+                                        i.x += 1;
+                                        local_modifications += 1;
                                     }
-                                    local_modifications
-                                })
+                                }
+                                local_modifications
                             })
                         })
                         .collect::<Vec<_>>();
@@ -903,7 +901,7 @@ mod tests {
 
             // If the implementation is free of data races, the total number of writes
             // should match the final value of `x`.
-            assert_eq!(total_modifications, inst.borrow(py).x);
+            assert_eq!(total_modifications, inst.try_borrow_guard().unwrap().x);
         });
     }
 

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -1158,9 +1158,9 @@ mod tests {
             let obj = Bound::new(py, MyClass { data: [0; 100] })?;
             let data = PyClassGuard::try_borrow(obj.as_unbound())?.map(|c| &c.data);
             assert_eq!(data[0], 0);
-            assert!(obj.try_borrow_mut().is_err()); // obj is still protected
+            assert!(obj.try_borrow_guard_mut().is_err()); // obj is still protected
             drop(data);
-            assert!(obj.try_borrow_mut().is_ok()); // drop released shared borrow
+            assert!(obj.try_borrow_guard_mut().is_ok()); // drop released shared borrow
             Ok::<_, PyErr>(())
         })
         .unwrap()
@@ -1175,9 +1175,9 @@ mod tests {
             assert_eq!(data[0], 0);
             data[0] = 5;
             assert_eq!(data[0], 5);
-            assert!(obj.try_borrow_mut().is_err()); // obj is still protected
+            assert!(obj.try_borrow_guard_mut().is_err()); // obj is still protected
             drop(data);
-            assert!(obj.try_borrow_mut().is_ok()); // drop released mutable borrow
+            assert!(obj.try_borrow_guard_mut().is_ok()); // drop released mutable borrow
             Ok::<_, PyErr>(())
         })
         .unwrap()

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -1156,9 +1156,9 @@ mod tests {
             let obj = Bound::new(py, MyClass { data: [0; 100] })?;
             let data = PyClassGuard::try_borrow(obj.as_unbound())?.map(|c| &c.data);
             assert_eq!(data[0], 0);
-            assert!(obj.try_borrow_mut().is_err()); // obj is still protected
+            assert!(obj.try_borrow_guard_mut().is_err()); // obj is still protected
             drop(data);
-            assert!(obj.try_borrow_mut().is_ok()); // drop released shared borrow
+            assert!(obj.try_borrow_guard_mut().is_ok()); // drop released shared borrow
             Ok::<_, PyErr>(())
         })
         .unwrap()
@@ -1173,9 +1173,9 @@ mod tests {
             assert_eq!(data[0], 0);
             data[0] = 5;
             assert_eq!(data[0], 5);
-            assert!(obj.try_borrow_mut().is_err()); // obj is still protected
+            assert!(obj.try_borrow_guard_mut().is_err()); // obj is still protected
             drop(data);
-            assert!(obj.try_borrow_mut().is_ok()); // drop released mutable borrow
+            assert!(obj.try_borrow_guard_mut().is_ok()); // drop released mutable borrow
             Ok::<_, PyErr>(())
         })
         .unwrap()

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -884,7 +884,10 @@ mod tests {
                     barrier.wait();
                     // sleep to ensure the other thread actually blocks
                     std::thread::sleep(core::time::Duration::from_millis(10));
-                    (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                    (*b).try_borrow_guard()
+                        .unwrap()
+                        .0
+                        .store(true, Ordering::Release);
                     drop(b);
                 });
             });
@@ -893,7 +896,7 @@ mod tests {
                 Python::attach(|py| {
                     // blocks until the other thread releases the lock
                     let b = mutex.lock_py_attached(py).unwrap();
-                    assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                    assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                 });
             });
         });
@@ -919,7 +922,10 @@ mod tests {
                             barrier.wait();
                             // sleep to ensure the other thread actually blocks
                             std::thread::sleep(core::time::Duration::from_millis(10));
-                            (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                            (*b).try_borrow_guard()
+                                .unwrap()
+                                .0
+                                .store(true, Ordering::Release);
                             drop(b);
                         });
                     });
@@ -928,7 +934,7 @@ mod tests {
                         Python::attach(|py| {
                             // blocks until the other thread releases the lock
                             let b: $guard = mutex.lock_py_attached(py);
-                            assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                            assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                         });
                     });
                 });
@@ -1004,7 +1010,10 @@ mod tests {
                     barrier.wait();
                     // sleep to ensure the other thread actually blocks
                     std::thread::sleep(core::time::Duration::from_millis(10));
-                    (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                    (*b).try_borrow_guard()
+                        .unwrap()
+                        .0
+                        .store(true, Ordering::Release);
                     drop(b);
                 });
             });
@@ -1013,7 +1022,7 @@ mod tests {
                 Python::attach(|py| {
                     // blocks until the other thread releases the lock
                     let b = rwlock.read_py_attached(py).unwrap();
-                    assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                    assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                 });
             });
         });
@@ -1042,7 +1051,7 @@ mod tests {
 
                     // The bool must still be false (i.e., the writer did not actually write the
                     // value yet).
-                    assert!(!(*b).bind(py).borrow().0.load(Ordering::Acquire));
+                    assert!(!(*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                 });
             });
             s.spawn(|| {
@@ -1050,7 +1059,10 @@ mod tests {
                 Python::attach(|py| {
                     // blocks until the other thread releases the lock
                     let b = rwlock.write_py_attached(py).unwrap();
-                    (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                    (*b).try_borrow_guard()
+                        .unwrap()
+                        .0
+                        .store(true, Ordering::Release);
                     drop(b);
                 });
             });
@@ -1059,7 +1071,7 @@ mod tests {
         // Confirm that the writer did in fact run and write the expected `true` value.
         Python::attach(|py| {
             let b = rwlock.read_py_attached(py).unwrap();
-            assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+            assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
             drop(b);
         });
     }
@@ -1084,7 +1096,10 @@ mod tests {
                             barrier.wait();
                             // sleep to ensure the other thread actually blocks
                             std::thread::sleep(core::time::Duration::from_millis(10));
-                            (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                            (*b).try_borrow_guard()
+                                .unwrap()
+                                .0
+                                .store(true, Ordering::Release);
                             drop(b);
                         });
                     });
@@ -1093,7 +1108,7 @@ mod tests {
                         Python::attach(|py| {
                             // blocks until the other thread releases the lock
                             let b: $read_guard = rwlock.read_py_attached(py);
-                            assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                            assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                         });
                     });
                 });
@@ -1145,7 +1160,8 @@ mod tests {
 
                             // The bool must still be false (i.e., the writer did not actually write the
                             // value yet).
-                            assert!(!(*b).bind(py).borrow().0.load(Ordering::Acquire));                            (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                            assert!(!(*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
+                            (*b).try_borrow_guard().unwrap().0.store(true, Ordering::Release);
 
                             drop(b);
                         });
@@ -1155,7 +1171,7 @@ mod tests {
                         Python::attach(|py| {
                             // blocks until the other thread releases the lock
                             let b: $write_guard = rwlock.write_py_attached(py);
-                            (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                            (*b).try_borrow_guard().unwrap().0.store(true, Ordering::Release);
                         });
                     });
                 });
@@ -1163,7 +1179,7 @@ mod tests {
                 // Confirm that the writer did in fact run and write the expected `true` value.
                 Python::attach(|py| {
                     let b: $read_guard = rwlock.read_py_attached(py);
-                    assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                    assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                     drop(b);
                 });
             }};

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -932,7 +932,10 @@ mod tests {
                     barrier.wait();
                     // sleep to ensure the other thread actually blocks
                     std::thread::sleep(core::time::Duration::from_millis(10));
-                    (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                    (*b).try_borrow_guard()
+                        .unwrap()
+                        .0
+                        .store(true, Ordering::Release);
                     drop(b);
                 });
             });
@@ -941,7 +944,7 @@ mod tests {
                 Python::attach(|py| {
                     // blocks until the other thread releases the lock
                     let b = mutex.lock_py_attached(py).unwrap();
-                    assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                    assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                 });
             });
         });
@@ -967,7 +970,10 @@ mod tests {
                             barrier.wait();
                             // sleep to ensure the other thread actually blocks
                             std::thread::sleep(core::time::Duration::from_millis(10));
-                            (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                            (*b).try_borrow_guard()
+                                .unwrap()
+                                .0
+                                .store(true, Ordering::Release);
                             drop(b);
                         });
                     });
@@ -976,7 +982,7 @@ mod tests {
                         Python::attach(|py| {
                             // blocks until the other thread releases the lock
                             let b: $guard = mutex.lock_py_attached(py);
-                            assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                            assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                         });
                     });
                 });
@@ -1053,7 +1059,10 @@ mod tests {
                     barrier.wait();
                     // sleep to ensure the other thread actually blocks
                     std::thread::sleep(core::time::Duration::from_millis(10));
-                    (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                    (*b).try_borrow_guard()
+                        .unwrap()
+                        .0
+                        .store(true, Ordering::Release);
                     drop(b);
                 });
             });
@@ -1062,7 +1071,7 @@ mod tests {
                 Python::attach(|py| {
                     // blocks until the other thread releases the lock
                     let b = rwlock.read_py_attached(py).unwrap();
-                    assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                    assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                 });
             });
         });
@@ -1091,7 +1100,7 @@ mod tests {
 
                     // The bool must still be false (i.e., the writer did not actually write the
                     // value yet).
-                    assert!(!(*b).bind(py).borrow().0.load(Ordering::Acquire));
+                    assert!(!(*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                 });
             });
             s.spawn(|| {
@@ -1099,7 +1108,10 @@ mod tests {
                 Python::attach(|py| {
                     // blocks until the other thread releases the lock
                     let b = rwlock.write_py_attached(py).unwrap();
-                    (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                    (*b).try_borrow_guard()
+                        .unwrap()
+                        .0
+                        .store(true, Ordering::Release);
                     drop(b);
                 });
             });
@@ -1108,7 +1120,7 @@ mod tests {
         // Confirm that the writer did in fact run and write the expected `true` value.
         Python::attach(|py| {
             let b = rwlock.read_py_attached(py).unwrap();
-            assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+            assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
             drop(b);
         });
     }
@@ -1133,7 +1145,10 @@ mod tests {
                             barrier.wait();
                             // sleep to ensure the other thread actually blocks
                             std::thread::sleep(core::time::Duration::from_millis(10));
-                            (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                            (*b).try_borrow_guard()
+                                .unwrap()
+                                .0
+                                .store(true, Ordering::Release);
                             drop(b);
                         });
                     });
@@ -1142,7 +1157,7 @@ mod tests {
                         Python::attach(|py| {
                             // blocks until the other thread releases the lock
                             let b: $read_guard = rwlock.read_py_attached(py);
-                            assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                            assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                         });
                     });
                 });
@@ -1194,7 +1209,8 @@ mod tests {
 
                             // The bool must still be false (i.e., the writer did not actually write the
                             // value yet).
-                            assert!(!(*b).bind(py).borrow().0.load(Ordering::Acquire));                            (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                            assert!(!(*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
+                            (*b).try_borrow_guard().unwrap().0.store(true, Ordering::Release);
 
                             drop(b);
                         });
@@ -1204,7 +1220,7 @@ mod tests {
                         Python::attach(|py| {
                             // blocks until the other thread releases the lock
                             let b: $write_guard = rwlock.write_py_attached(py);
-                            (*b).bind(py).borrow().0.store(true, Ordering::Release);
+                            (*b).try_borrow_guard().unwrap().0.store(true, Ordering::Release);
                         });
                     });
                 });
@@ -1212,7 +1228,7 @@ mod tests {
                 // Confirm that the writer did in fact run and write the expected `true` value.
                 Python::attach(|py| {
                     let b: $read_guard = rwlock.read_py_attached(py);
-                    assert!((*b).bind(py).borrow().0.load(Ordering::Acquire));
+                    assert!((*b).try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                     drop(b);
                 });
             }};

--- a/src/sync/critical_section.rs
+++ b/src/sync/critical_section.rs
@@ -311,7 +311,10 @@ mod tests {
                     with_critical_section(b, || {
                         barrier.wait();
                         std::thread::sleep(core::time::Duration::from_millis(10));
-                        b.borrow().0.store(true, Ordering::Release);
+                        b.try_borrow_guard()
+                            .unwrap()
+                            .0
+                            .store(true, Ordering::Release);
                     })
                 });
             });
@@ -321,7 +324,7 @@ mod tests {
                     let b = bool_wrapper.bind(py);
                     // this blocks until the other thread's critical section finishes
                     with_critical_section(b, || {
-                        assert!(b.borrow().0.load(Ordering::Acquire));
+                        assert!(b.try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                     });
                 });
             });
@@ -379,8 +382,14 @@ mod tests {
                     with_critical_section2(b1, b2, || {
                         barrier.wait();
                         std::thread::sleep(core::time::Duration::from_millis(10));
-                        b1.borrow().0.store(true, Ordering::Release);
-                        b2.borrow().0.store(true, Ordering::Release);
+                        b1.try_borrow_guard()
+                            .unwrap()
+                            .0
+                            .store(true, Ordering::Release);
+                        b2.try_borrow_guard()
+                            .unwrap()
+                            .0
+                            .store(true, Ordering::Release);
                     })
                 });
             });
@@ -390,7 +399,7 @@ mod tests {
                     let b1 = bool_wrapper1.bind(py);
                     // this blocks until the other thread's critical section finishes
                     with_critical_section(b1, || {
-                        assert!(b1.borrow().0.load(Ordering::Acquire));
+                        assert!(b1.try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                     });
                 });
             });
@@ -400,7 +409,7 @@ mod tests {
                     let b2 = bool_wrapper2.bind(py);
                     // this blocks until the other thread's critical section finishes
                     with_critical_section(b2, || {
-                        assert!(b2.borrow().0.load(Ordering::Acquire));
+                        assert!(b2.try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                     });
                 });
             });
@@ -457,7 +466,10 @@ mod tests {
                     with_critical_section2(b, b, || {
                         barrier.wait();
                         std::thread::sleep(core::time::Duration::from_millis(10));
-                        b.borrow().0.store(true, Ordering::Release);
+                        b.try_borrow_guard()
+                            .unwrap()
+                            .0
+                            .store(true, Ordering::Release);
                     })
                 });
             });
@@ -467,7 +479,7 @@ mod tests {
                     let b = bool_wrapper.bind(py);
                     // this blocks until the other thread's critical section finishes
                     with_critical_section(b, || {
-                        assert!(b.borrow().0.load(Ordering::Acquire));
+                        assert!(b.try_borrow_guard().unwrap().0.load(Ordering::Acquire));
                     });
                 });
             });
@@ -523,7 +535,10 @@ mod tests {
                     let v2 = vec2.bind(py);
                     with_critical_section2(v1, v2, || {
                         // v2.extend(v1)
-                        v2.borrow_mut().0.extend(v1.borrow().0.iter());
+                        v2.try_borrow_guard_mut()
+                            .unwrap()
+                            .0
+                            .extend(v1.try_borrow_guard().unwrap().0.iter());
                     })
                 });
             });
@@ -533,7 +548,10 @@ mod tests {
                     let v2 = vec2.bind(py);
                     with_critical_section2(v1, v2, || {
                         // v1.extend(v2)
-                        v1.borrow_mut().0.extend(v2.borrow().0.iter());
+                        v1.try_borrow_guard_mut()
+                            .unwrap()
+                            .0
+                            .extend(v2.try_borrow_guard().unwrap().0.iter());
                     })
                 });
             });
@@ -554,8 +572,10 @@ mod tests {
             let expected2_vec2 = vec![4, 5, 1, 2, 3];
 
             assert!(
-                (v1.borrow().0.eq(&expected1_vec1) && v2.borrow().0.eq(&expected1_vec2))
-                    || (v1.borrow().0.eq(&expected2_vec1) && v2.borrow().0.eq(&expected2_vec2))
+                (v1.try_borrow_guard().unwrap().0.eq(&expected1_vec1)
+                    && v2.try_borrow_guard().unwrap().0.eq(&expected1_vec2))
+                    || (v1.try_borrow_guard().unwrap().0.eq(&expected2_vec1)
+                        && v2.try_borrow_guard().unwrap().0.eq(&expected2_vec2))
             );
         });
     }

--- a/src/tests/hygiene/pymethods.rs
+++ b/src/tests/hygiene/pymethods.rs
@@ -123,7 +123,7 @@ impl Dummy {
 
     fn __delitem__(&self, key: u32) {}
 
-    fn __iter__(_: crate::pycell::PyRef<'_, Self>, py: crate::Python<'_>) -> crate::Py<DummyIter> {
+    fn __iter__(_: crate::PyClassGuard<'_, Self>, py: crate::Python<'_>) -> crate::Py<DummyIter> {
         crate::Py::new(py, DummyIter {}).unwrap()
     }
 
@@ -132,7 +132,7 @@ impl Dummy {
     }
 
     fn __reversed__(
-        slf: crate::pycell::PyRef<'_, Self>,
+        slf: crate::PyClassGuard<'_, Self>,
         py: crate::Python<'_>,
     ) -> crate::Py<DummyIter> {
         crate::Py::new(py, DummyIter {}).unwrap()
@@ -274,19 +274,19 @@ impl Dummy {
 
     fn __ior__(&mut self, other: &Self) {}
 
-    fn __neg__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __neg__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __pos__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __pos__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __abs__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __abs__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __invert__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __invert__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
@@ -344,7 +344,7 @@ impl Dummy {
     // Awaitable Objects
     //////////////////////
 
-    fn __await__(slf: crate::pycell::PyRef<'_, Self>) -> crate::pycell::PyRef<'_, Self> {
+    fn __await__(slf: crate::PyClassGuard<'_, Self>) -> crate::PyClassGuard<'_, Self> {
         slf
     }
 
@@ -354,7 +354,7 @@ impl Dummy {
     //////////////////////
 
     fn __aiter__(
-        slf: crate::pycell::PyRef<'_, Self>,
+        slf: crate::PyClassGuard<'_, Self>,
         py: crate::Python<'_>,
     ) -> crate::Py<DummyIter> {
         crate::Py::new(py, DummyIter {}).unwrap()
@@ -484,10 +484,10 @@ impl WarningDummy {
     }
 
     #[pyo3(warn(message = "this method raises warning"))]
-    fn method_with_warning(_slf: crate::PyRef<'_, Self>) {}
+    fn method_with_warning(_slf: crate::PyClassGuard<'_, Self>) {}
 
     #[pyo3(warn(message = "this method raises warning", category = crate::exceptions::PyFutureWarning))]
-    fn method_with_warning_and_custom_category(_slf: crate::PyRef<'_, Self>) {}
+    fn method_with_warning_and_custom_category(_slf: crate::PyClassGuard<'_, Self>) {}
 
     #[cfg(any(not(Py_LIMITED_API), Py_3_12))]
     #[pyo3(warn(message = "this method raises user-defined warning", category = UserDefinedWarning))]
@@ -525,7 +525,7 @@ impl WarningDummy {
     }
 
     #[pyo3(warn(message = "the + op method raises warning"))]
-    fn __add__(&self, other: crate::PyRef<'_, Self>) -> Self {
+    fn __add__(&self, other: crate::PyClassGuard<'_, Self>) -> Self {
         Self {
             value: self.value + other.value,
         }

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -375,7 +375,13 @@ def fibonacci(target):
             );
 
             assert_eq!(
-                downcaster.borrow_mut(py).failed.take().unwrap().to_string(),
+                downcaster
+                    .try_borrow_guard_mut()
+                    .unwrap()
+                    .failed
+                    .take()
+                    .unwrap()
+                    .to_string(),
                 "TypeError: 'MySequence' object is not an instance of 'Iterator'"
             );
         });

--- a/src/types/iterator.rs
+++ b/src/types/iterator.rs
@@ -377,7 +377,13 @@ def fibonacci(target):
             );
 
             assert_eq!(
-                downcaster.borrow_mut(py).failed.take().unwrap().to_string(),
+                downcaster
+                    .try_borrow_guard_mut()
+                    .unwrap()
+                    .failed
+                    .take()
+                    .unwrap()
+                    .to_string(),
                 "TypeError: 'MySequence' object is not an instance of 'Iterator'"
             );
         });

--- a/src/types/weakref/anyref.rs
+++ b/src/types/weakref/anyref.rs
@@ -83,7 +83,7 @@ pub trait PyWeakrefMethods<'py>: crate::sealed::Sealed {
     ///
     /// fn parse_data(reference: Borrowed<'_, '_, PyWeakrefReference>) -> PyResult<String> {
     ///     if let Some(data_src) = reference.upgrade_as::<Foo>()? {
-    ///         let data = data_src.borrow();
+    ///         let data = data_src.try_borrow_guard()?;
     ///         let (name, score) = data.get_data();
     ///         Ok(format!("Processing '{}': score = {}", name, score))
     ///     } else {
@@ -155,13 +155,13 @@ pub trait PyWeakrefMethods<'py>: crate::sealed::Sealed {
     ///     }
     /// }
     ///
-    /// fn parse_data(reference: Borrowed<'_, '_, PyWeakrefReference>) -> String {
+    /// fn parse_data(reference: Borrowed<'_, '_, PyWeakrefReference>) -> PyResult<String> {
     ///     if let Some(data_src) = unsafe { reference.upgrade_as_unchecked::<Foo>() } {
-    ///         let data = data_src.borrow();
+    ///         let data = data_src.try_borrow_guard()?;
     ///         let (name, score) = data.get_data();
-    ///         format!("Processing '{}': score = {}", name, score)
+    ///         Ok(format!("Processing '{}': score = {}", name, score))
     ///     } else {
-    ///         "The supplied data reference is no longer relevant.".to_owned()
+    ///         Ok("The supplied data reference is no longer relevant.".to_owned())
     ///     }
     /// }
     ///
@@ -171,14 +171,14 @@ pub trait PyWeakrefMethods<'py>: crate::sealed::Sealed {
     ///     let reference = PyWeakrefReference::new(&data)?;
     ///
     ///     assert_eq!(
-    ///         parse_data(reference.as_borrowed()),
+    ///         parse_data(reference.as_borrowed())?,
     ///         "Processing 'Dave': score = 10"
     ///     );
     ///
     ///     drop(data);
     ///
     ///     assert_eq!(
-    ///         parse_data(reference.as_borrowed()),
+    ///         parse_data(reference.as_borrowed())?,
     ///         "The supplied data reference is no longer relevant."
     ///     );
     ///
@@ -221,7 +221,7 @@ pub trait PyWeakrefMethods<'py>: crate::sealed::Sealed {
     ///
     /// fn parse_data(reference: Borrowed<'_, '_, PyWeakrefReference>) -> PyResult<String> {
     ///     if let Some(data_src) = reference.upgrade_as_exact::<Foo>()? {
-    ///         let data = data_src.borrow();
+    ///         let data = data_src.try_borrow_guard()?;
     ///         let (name, score) = data.get_data();
     ///         Ok(format!("Processing '{}': score = {}", name, score))
     ///     } else {

--- a/tests/test_arithmetics.rs
+++ b/tests/test_arithmetics.rs
@@ -403,43 +403,43 @@ impl LhsAndRhs {
     //     "BA"
     // }
 
-    fn __add__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __add__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} + {rhs:?}")
     }
 
-    fn __sub__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __sub__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} - {rhs:?}")
     }
 
-    fn __mul__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __mul__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} * {rhs:?}")
     }
 
-    fn __lshift__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __lshift__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} << {rhs:?}")
     }
 
-    fn __rshift__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __rshift__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} >> {rhs:?}")
     }
 
-    fn __and__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __and__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} & {rhs:?}")
     }
 
-    fn __xor__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __xor__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} ^ {rhs:?}")
     }
 
-    fn __or__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __or__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} | {rhs:?}")
     }
 
-    fn __pow__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>, _mod: Option<usize>) -> String {
+    fn __pow__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>, _mod: Option<usize>) -> String {
         format!("{lhs:?} ** {rhs:?}")
     }
 
-    fn __matmul__(lhs: PyRef<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
+    fn __matmul__(lhs: PyClassGuard<'_, Self>, rhs: &Bound<'_, PyAny>) -> String {
         format!("{lhs:?} @ {rhs:?}")
     }
 
@@ -640,67 +640,115 @@ mod return_not_implemented {
             "RC_Self"
         }
 
-        fn __richcmp__(&self, other: PyRef<'_, Self>, _op: CompareOp) -> Py<PyAny> {
-            other.py().None()
+        fn __richcmp__(
+            &self,
+            py: Python<'_>,
+            _other: PyClassGuard<'_, Self>,
+            _op: CompareOp,
+        ) -> Py<PyAny> {
+            py.None()
         }
 
-        fn __add__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __add__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __sub__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __sub__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __mul__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __mul__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __matmul__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __matmul__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __truediv__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __truediv__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __floordiv__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __floordiv__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __mod__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __mod__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __pow__(slf: PyRef<'_, Self>, _other: u8, _modulo: Option<u8>) -> PyRef<'_, Self> {
+        fn __pow__(
+            slf: PyClassGuard<'_, Self>,
+            _other: u8,
+            _modulo: Option<u8>,
+        ) -> PyClassGuard<'_, Self> {
             slf
         }
-        fn __lshift__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __lshift__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __rshift__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __rshift__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __divmod__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __divmod__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __and__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __and__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __or__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __or__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
-        fn __xor__<'p>(slf: PyRef<'p, Self>, _other: PyRef<'p, Self>) -> PyRef<'p, Self> {
+        fn __xor__<'p>(
+            slf: PyClassGuard<'p, Self>,
+            _other: PyClassGuard<'p, Self>,
+        ) -> PyClassGuard<'p, Self> {
             slf
         }
 
         // Inplace assignments
-        fn __iadd__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __isub__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __imul__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __imatmul__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __itruediv__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ifloordiv__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __imod__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ilshift__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __irshift__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __iand__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ior__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ixor__(&mut self, _other: PyRef<'_, Self>) {}
-        fn __ipow__(&mut self, _other: PyRef<'_, Self>, _modulo: Option<u8>) {}
+        fn __iadd__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __isub__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __imul__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __imatmul__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __itruediv__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ifloordiv__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __imod__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ilshift__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __irshift__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __iand__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ior__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ixor__(&mut self, _other: PyClassGuard<'_, Self>) {}
+        fn __ipow__(&mut self, _other: PyClassGuard<'_, Self>, _modulo: Option<u8>) {}
     }
 
     fn _test_binary_dunder(dunder: &str) {

--- a/tests/test_buffer.rs
+++ b/tests/test_buffer.rs
@@ -41,7 +41,7 @@ impl TestBufferErrors {
             return Err(PyBufferError::new_err("Object is not writable"));
         }
 
-        let borrow = slf.borrow_mut();
+        let borrow = slf.try_borrow_guard_mut()?;
         let bytes = &borrow.buf;
 
         unsafe {
@@ -80,7 +80,7 @@ impl TestBufferErrors {
                 }
             }
 
-            (*view).obj = slf.into_ptr();
+            (*view).obj = slf.clone().into_ptr();
         }
 
         Ok(())
@@ -101,7 +101,7 @@ fn test_get_buffer_errors() {
 
         assert!(PyBuffer::<u32>::get(instance.bind(py)).is_ok());
 
-        instance.borrow_mut(py).error = Some(TestGetBufferError::NullShape);
+        instance.try_borrow_guard_mut().unwrap().error = Some(TestGetBufferError::NullShape);
         assert_eq!(
             PyBuffer::<u32>::get(instance.bind(py))
                 .unwrap_err()
@@ -109,7 +109,7 @@ fn test_get_buffer_errors() {
             "BufferError: shape is null"
         );
 
-        instance.borrow_mut(py).error = Some(TestGetBufferError::NullStrides);
+        instance.try_borrow_guard_mut().unwrap().error = Some(TestGetBufferError::NullStrides);
         assert_eq!(
             PyBuffer::<u32>::get(instance.bind(py))
                 .unwrap_err()
@@ -117,7 +117,8 @@ fn test_get_buffer_errors() {
             "BufferError: strides is null"
         );
 
-        instance.borrow_mut(py).error = Some(TestGetBufferError::IncorrectItemSize);
+        instance.try_borrow_guard_mut().unwrap().error =
+            Some(TestGetBufferError::IncorrectItemSize);
         assert_eq!(
             PyBuffer::<u32>::get(instance.bind(py))
                 .unwrap_err()
@@ -125,7 +126,7 @@ fn test_get_buffer_errors() {
             "BufferError: buffer contents are not compatible with u32"
         );
 
-        instance.borrow_mut(py).error = Some(TestGetBufferError::IncorrectFormat);
+        instance.try_borrow_guard_mut().unwrap().error = Some(TestGetBufferError::IncorrectFormat);
         assert_eq!(
             PyBuffer::<u32>::get(instance.bind(py))
                 .unwrap_err()
@@ -133,7 +134,8 @@ fn test_get_buffer_errors() {
             "BufferError: buffer contents are not compatible with u32"
         );
 
-        instance.borrow_mut(py).error = Some(TestGetBufferError::IncorrectAlignment);
+        instance.try_borrow_guard_mut().unwrap().error =
+            Some(TestGetBufferError::IncorrectAlignment);
         assert_eq!(
             PyBuffer::<u32>::get(instance.bind(py))
                 .unwrap_err()

--- a/tests/test_buffer.rs
+++ b/tests/test_buffer.rs
@@ -29,7 +29,7 @@ struct TestBufferErrors {
 #[pymethods]
 impl TestBufferErrors {
     unsafe fn __getbuffer__(
-        slf: PyRefMut<'_, Self>,
+        slf: Bound<'_, Self>,
         view: *mut ffi::Py_buffer,
         flags: c_int,
     ) -> PyResult<()> {
@@ -41,7 +41,8 @@ impl TestBufferErrors {
             return Err(PyBufferError::new_err("Object is not writable"));
         }
 
-        let bytes = &slf.buf;
+        let borrow = slf.borrow_mut();
+        let bytes = &borrow.buf;
 
         unsafe {
             (*view).buf = bytes.as_ptr() as *mut c_void;
@@ -60,7 +61,7 @@ impl TestBufferErrors {
             (*view).suboffsets = ptr::null_mut();
             (*view).internal = ptr::null_mut();
 
-            if let Some(err) = &slf.error {
+            if let Some(err) = &borrow.error {
                 use TestGetBufferError::*;
                 match err {
                     NullShape => {

--- a/tests/test_buffer_protocol.rs
+++ b/tests/test_buffer_protocol.rs
@@ -29,7 +29,14 @@ impl TestBufferClass {
         view: *mut ffi::Py_buffer,
         flags: c_int,
     ) -> PyResult<()> {
-        unsafe { fill_view_from_readonly_data(view, flags, &slf.borrow().vec, slf.into_any()) }
+        unsafe {
+            fill_view_from_readonly_data(
+                view,
+                flags,
+                &slf.try_borrow_guard().unwrap().vec,
+                slf.clone().into_any(),
+            )
+        }
     }
 
     unsafe fn __releasebuffer__(&self, view: *mut ffi::Py_buffer) {

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -307,9 +307,7 @@ fn test_unsendable<T: PyClass + 'static>() -> PyResult<()> {
 
     let caught_panic = std::thread::spawn(move || {
         // This access must panic
-        Python::attach(move |py| {
-            obj.borrow(py);
-        });
+        obj.try_borrow_guard().unwrap();
     })
     .join();
 
@@ -423,7 +421,7 @@ fn test_tuple_struct_class() {
         "#
         );
 
-        assert_eq!(instance.borrow(py).0, 1234);
+        assert_eq!(instance.try_borrow_guard().unwrap().0, 1234);
     });
 }
 

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -309,9 +309,7 @@ fn test_unsendable<T: PyClass + 'static>() -> PyResult<()> {
 
     let caught_panic = std::thread::spawn(move || {
         // This access must panic
-        Python::attach(move |py| {
-            obj.borrow(py);
-        });
+        obj.try_borrow_guard().unwrap();
     })
     .join();
 
@@ -425,7 +423,7 @@ fn test_tuple_struct_class() {
         "#
         );
 
-        assert_eq!(instance.borrow(py).0, 1234);
+        assert_eq!(instance.try_borrow_guard().unwrap().0, 1234);
     });
 }
 

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -127,7 +127,7 @@ fn test_pyref_as_base() {
         let cell = Bound::new(py, initializer).unwrap();
 
         // First try PyRefMut
-        let sub = cell.borrow_mut();
+        let sub = cell.try_borrow_guard_mut().unwrap();
         let mut base = sub.into_super();
         assert_eq!(120, base.value);
         base.value = 999;
@@ -135,7 +135,7 @@ fn test_pyref_as_base() {
         drop(base);
 
         // Repeat for PyRef
-        let sub = cell.borrow();
+        let sub = cell.try_borrow_guard().unwrap();
         let base = sub.into_super();
         assert_eq!(999, base.value);
     });

--- a/tests/test_class_conversion.rs
+++ b/tests/test_class_conversion.rs
@@ -21,11 +21,11 @@ fn test_cloneable_pyclass() {
         let c2: Cloneable = py_c.extract(py).unwrap();
         assert_eq!(c, c2);
         {
-            let rc: PyRef<'_, Cloneable> = py_c.extract(py).unwrap();
+            let rc: PyClassGuard<'_, Cloneable> = py_c.extract(py).unwrap();
             assert_eq!(&c, &*rc);
-            // Drops PyRef before taking PyRefMut
+            // Drops PyClassGuard before taking PyClassGuardMut
         }
-        let mrc: PyRefMut<'_, Cloneable> = py_c.extract(py).unwrap();
+        let mrc: PyClassGuardMut<'_, Cloneable> = py_c.extract(py).unwrap();
         assert_eq!(&c, &*mrc);
     });
 }
@@ -127,16 +127,16 @@ fn test_pyref_as_base() {
         let cell = Bound::new(py, initializer).unwrap();
 
         // First try PyRefMut
-        let sub: PyRefMut<'_, SubClass> = cell.borrow_mut();
-        let mut base: PyRefMut<'_, BaseClass> = sub.into_super();
+        let sub = cell.borrow_mut();
+        let mut base = sub.into_super();
         assert_eq!(120, base.value);
         base.value = 999;
         assert_eq!(999, base.value);
         drop(base);
 
         // Repeat for PyRef
-        let sub: PyRef<'_, SubClass> = cell.borrow();
-        let base: PyRef<'_, BaseClass> = sub.into_super();
+        let sub = cell.borrow();
+        let base = sub.into_super();
         assert_eq!(999, base.value);
     });
 }

--- a/tests/test_class_init.rs
+++ b/tests/test_class_init.rs
@@ -25,7 +25,7 @@ fn test_base_init() {
         let typeobj = py.get_type::<Base>();
         let obj = typeobj.call((), None).unwrap().cast_into::<Base>().unwrap();
         // check __init__ was called
-        assert_eq!(obj.borrow().num, 42);
+        assert_eq!(obj.try_borrow_guard().unwrap().num, 42);
     });
 }
 
@@ -50,7 +50,7 @@ fn test_subclass_without_init_calls_base_init() {
             .cast_into::<SubWithoutInit>()
             .unwrap();
         // check Base.__init__ was called
-        assert_eq!(obj.as_super().borrow().num, 42);
+        assert_eq!(obj.as_super().try_borrow_guard().unwrap().num, 42);
     });
 }
 
@@ -81,7 +81,7 @@ fn test_subclass_with_init() {
             .unwrap();
         // check SubWithInit.__init__ was called, and Base.__init__ was only called once (through
         // SubWithInit.__init__)
-        assert_eq!(obj.as_super().borrow().num, 43);
+        assert_eq!(obj.as_super().try_borrow_guard().unwrap().num, 43);
     });
 }
 

--- a/tests/test_class_new.rs
+++ b/tests/test_class_new.rs
@@ -74,7 +74,7 @@ fn tuple_class_with_new() {
         let typeobj = py.get_type::<TupleClassWithNew>();
         let wrp = typeobj.call((42,), None).unwrap();
         let obj = wrp.cast::<TupleClassWithNew>().unwrap();
-        let obj_ref = obj.borrow();
+        let obj_ref = obj.try_borrow_guard().unwrap();
         assert_eq!(obj_ref.0, 42);
     });
 }
@@ -99,7 +99,7 @@ fn new_with_one_arg() {
         let typeobj = py.get_type::<NewWithOneArg>();
         let wrp = typeobj.call((42,), None).unwrap();
         let obj = wrp.cast::<NewWithOneArg>().unwrap();
-        let obj_ref = obj.borrow();
+        let obj_ref = obj.try_borrow_guard().unwrap();
         assert_eq!(obj_ref.data, 42);
     });
 }
@@ -130,7 +130,7 @@ fn new_with_two_args() {
             .map_err(|e| e.display(py))
             .unwrap();
         let obj = wrp.cast::<NewWithTwoArgs>().unwrap();
-        let obj_ref = obj.borrow();
+        let obj_ref = obj.try_borrow_guard().unwrap();
         assert_eq!(obj_ref.data1, 10);
         assert_eq!(obj_ref.data2, 20);
     });

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -469,6 +469,7 @@ fn traverse_cannot_be_hijacked() {
         fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>;
     }
 
+    #[expect(deprecated)]
     impl Traversable for PyRef<'_, HijackedTraverse> {
         fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
             self.hijacked.store(true, Ordering::Release);

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -49,8 +49,8 @@ fn spin_freelist(py: Python<'_>, data: usize) {
     for _ in 0..500 {
         let inst1 = Py::new(py, ClassWithFreelistAndData { data: Some(data) }).unwrap();
         let inst2 = Py::new(py, ClassWithFreelistAndData { data: Some(data) }).unwrap();
-        assert_eq!(inst1.borrow(py).data, Some(data));
-        assert_eq!(inst2.borrow(py).data, Some(data));
+        assert_eq!(inst1.try_borrow_guard().unwrap().data, Some(data));
+        assert_eq!(inst2.try_borrow_guard().unwrap().data, Some(data));
     }
 }
 
@@ -161,7 +161,7 @@ impl CycleWithClear {
     }
 
     fn __clear__(slf: &Bound<'_, Self>) {
-        slf.borrow_mut().cycle = None;
+        slf.try_borrow_guard_mut().unwrap().cycle = None;
     }
 }
 
@@ -179,7 +179,7 @@ fn test_cycle_clear() {
         )
         .unwrap();
 
-        inst.borrow_mut().cycle = Some(inst.clone().into_any().unbind());
+        inst.try_borrow_guard_mut().unwrap().cycle = Some(inst.clone().into_any().unbind());
 
         // gc.get_objects can create references to partially initialized objects,
         // leading to races on the free-threaded build.
@@ -225,7 +225,7 @@ fn gc_null_traversal() {
             },
         )
         .unwrap();
-        obj.borrow_mut(py).cycle = Some(obj.clone_ref(py));
+        obj.try_borrow_guard_mut().unwrap().cycle = Some(obj.clone_ref(py));
 
         // the object doesn't have to be cleaned up, it just needs to be traversed.
         py.run(c"import gc; gc.collect()", None, None).unwrap();
@@ -272,8 +272,8 @@ fn inheritance_with_new_methods_with_drop() {
             .cast_into::<SubClassWithDrop>()
             .unwrap();
 
-        inst.as_super().borrow_mut().guard = Some(guard_base);
-        inst.borrow_mut().guard = Some(guard_sub);
+        inst.as_super().try_borrow_guard_mut().unwrap().guard = Some(guard_base);
+        inst.try_borrow_guard_mut().unwrap().guard = Some(guard_sub);
 
         check_base.assert_not_dropped();
         check_sub.assert_not_dropped();
@@ -317,14 +317,22 @@ fn gc_during_borrow() {
         // create an object and check that traversing it works normally
         // when it's not borrowed
         let cell = Bound::new(py, TraversableClass::new()).unwrap();
-        assert!(!cell.borrow().traversed.load(Ordering::Relaxed));
+        assert!(!cell
+            .try_borrow_guard()
+            .unwrap()
+            .traversed
+            .load(Ordering::Relaxed));
         unsafe { traverse(cell.as_ptr(), novisit, std::ptr::null_mut()) };
-        assert!(cell.borrow().traversed.load(Ordering::Relaxed));
+        assert!(cell
+            .try_borrow_guard()
+            .unwrap()
+            .traversed
+            .load(Ordering::Relaxed));
 
         // create an object and check that it is not traversed if the GC
         // is invoked while it is already borrowed mutably
         let cell2 = Bound::new(py, TraversableClass::new()).unwrap();
-        let guard = cell2.borrow_mut();
+        let guard = cell2.try_borrow_guard_mut().unwrap();
         assert!(!guard.traversed.load(Ordering::Relaxed));
         unsafe { traverse(cell2.as_ptr(), novisit, std::ptr::null_mut()) };
         assert!(!guard.traversed.load(Ordering::Relaxed));
@@ -483,9 +491,15 @@ fn traverse_cannot_be_hijacked() {
         let traverse = unsafe { get_type_traverse(ty.as_type_ptr()).unwrap() };
 
         let cell = Bound::new(py, HijackedTraverse::new()).unwrap();
-        assert_eq!(cell.borrow().traversed_and_hijacked(), (false, false));
+        assert_eq!(
+            cell.try_borrow_guard().unwrap().traversed_and_hijacked(),
+            (false, false)
+        );
         unsafe { traverse(cell.as_ptr(), novisit, std::ptr::null_mut()) };
-        assert_eq!(cell.borrow().traversed_and_hijacked(), (true, false));
+        assert_eq!(
+            cell.try_borrow_guard().unwrap().traversed_and_hijacked(),
+            (true, false)
+        );
     })
 }
 
@@ -521,7 +535,7 @@ fn drop_during_traversal_with_gil() {
         )
         .unwrap();
 
-        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
+        *inst.try_borrow_guard_mut().unwrap().cycle.lock().unwrap() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         let ptr = inst.as_ptr();
@@ -555,7 +569,7 @@ fn drop_during_traversal_without_gil() {
         )
         .unwrap();
 
-        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
+        *inst.try_borrow_guard_mut().unwrap().cycle.lock().unwrap() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         inst
@@ -615,7 +629,7 @@ fn unsendable_are_not_traversed_on_foreign_thread() {
         .join()
         .unwrap();
 
-        assert!(!obj.borrow().traversed.get());
+        assert!(!obj.try_borrow_guard().unwrap().traversed.get());
 
         // traversal on home thread still works
         assert_eq!(
@@ -623,7 +637,7 @@ fn unsendable_are_not_traversed_on_foreign_thread() {
             0
         );
 
-        assert!(obj.borrow().traversed.get());
+        assert!(obj.try_borrow_guard().unwrap().traversed.get());
     });
 }
 
@@ -653,7 +667,8 @@ fn test_traverse_subclass() {
             PyClassInitializer::from(base).add_subclass(SubOverrideTraverse {}),
         )
         .unwrap();
-        obj.borrow_mut().as_super().cycle = Some(obj.clone().into_any().unbind());
+        obj.try_borrow_guard_mut().unwrap().as_super().cycle =
+            Some(obj.clone().into_any().unbind());
 
         check.assert_not_dropped();
         let ptr = obj.as_ptr();
@@ -700,7 +715,8 @@ fn test_traverse_subclass_override_clear() {
             PyClassInitializer::from(base).add_subclass(SubOverrideClear {}),
         )
         .unwrap();
-        obj.borrow_mut().as_super().cycle = Some(obj.clone().into_any().unbind());
+        obj.try_borrow_guard_mut().unwrap().as_super().cycle =
+            Some(obj.clone().into_any().unbind());
 
         check.assert_not_dropped();
         let ptr = obj.as_ptr();
@@ -801,7 +817,7 @@ fn test_drop_buffer_during_traversal_without_gil() {
         )
         .unwrap();
 
-        obj.borrow_mut(py).cycle = Some(obj.clone_ref(py).into_any());
+        obj.try_borrow_guard_mut().unwrap().cycle = Some(obj.clone_ref(py).into_any());
 
         let ptr = obj.as_ptr();
         drop(obj);

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -487,6 +487,7 @@ fn traverse_cannot_be_hijacked() {
         fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>;
     }
 
+    #[expect(deprecated)]
     impl Traversable for PyRef<'_, HijackedTraverse> {
         fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
             self.hijacked.store(true, Ordering::Release);

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -56,8 +56,8 @@ fn spin_freelist(py: Python<'_>, data: usize) {
     for _ in 0..500 {
         let inst1 = Py::new(py, ClassWithFreelistAndData { data: Some(data) }).unwrap();
         let inst2 = Py::new(py, ClassWithFreelistAndData { data: Some(data) }).unwrap();
-        assert_eq!(inst1.borrow(py).data, Some(data));
-        assert_eq!(inst2.borrow(py).data, Some(data));
+        assert_eq!(inst1.try_borrow_guard().unwrap().data, Some(data));
+        assert_eq!(inst2.try_borrow_guard().unwrap().data, Some(data));
     }
 }
 
@@ -177,7 +177,7 @@ impl CycleWithClear {
     }
 
     fn __clear__(slf: &Bound<'_, Self>) {
-        slf.borrow_mut().cycle = None;
+        slf.try_borrow_guard_mut().unwrap().cycle = None;
     }
 }
 
@@ -196,7 +196,7 @@ fn test_cycle_clear() {
         )
         .unwrap();
 
-        inst.borrow_mut().cycle = Some(inst.clone().into_any().unbind());
+        inst.try_borrow_guard_mut().unwrap().cycle = Some(inst.clone().into_any().unbind());
 
         // gc.get_objects can create references to partially initialized objects,
         // leading to races on the free-threaded build.
@@ -242,7 +242,7 @@ fn gc_null_traversal() {
             },
         )
         .unwrap();
-        obj.borrow_mut(py).cycle = Some(obj.clone_ref(py));
+        obj.try_borrow_guard_mut().unwrap().cycle = Some(obj.clone_ref(py));
 
         // the object doesn't have to be cleaned up, it just needs to be traversed.
         py.run(c"import gc; gc.collect()", None, None).unwrap();
@@ -290,8 +290,8 @@ fn inheritance_with_new_methods_with_drop() {
             .cast_into::<SubClassWithDrop>()
             .unwrap();
 
-        inst.as_super().borrow_mut().guard = Some(guard_base);
-        inst.borrow_mut().guard = Some(guard_sub);
+        inst.as_super().try_borrow_guard_mut().unwrap().guard = Some(guard_base);
+        inst.try_borrow_guard_mut().unwrap().guard = Some(guard_sub);
 
         check_base.assert_not_dropped();
         check_sub.assert_not_dropped();
@@ -335,14 +335,22 @@ fn gc_during_borrow() {
         // create an object and check that traversing it works normally
         // when it's not borrowed
         let cell = Bound::new(py, TraversableClass::new()).unwrap();
-        assert!(!cell.borrow().traversed.load(Ordering::Relaxed));
+        assert!(!cell
+            .try_borrow_guard()
+            .unwrap()
+            .traversed
+            .load(Ordering::Relaxed));
         unsafe { traverse(cell.as_ptr(), novisit, std::ptr::null_mut()) };
-        assert!(cell.borrow().traversed.load(Ordering::Relaxed));
+        assert!(cell
+            .try_borrow_guard()
+            .unwrap()
+            .traversed
+            .load(Ordering::Relaxed));
 
         // create an object and check that it is not traversed if the GC
         // is invoked while it is already borrowed mutably
         let cell2 = Bound::new(py, TraversableClass::new()).unwrap();
-        let guard = cell2.borrow_mut();
+        let guard = cell2.try_borrow_guard_mut().unwrap();
         assert!(!guard.traversed.load(Ordering::Relaxed));
         unsafe { traverse(cell2.as_ptr(), novisit, std::ptr::null_mut()) };
         assert!(!guard.traversed.load(Ordering::Relaxed));
@@ -501,9 +509,15 @@ fn traverse_cannot_be_hijacked() {
         let traverse = unsafe { get_type_traverse(ty.as_type_ptr()).unwrap() };
 
         let cell = Bound::new(py, HijackedTraverse::new()).unwrap();
-        assert_eq!(cell.borrow().traversed_and_hijacked(), (false, false));
+        assert_eq!(
+            cell.try_borrow_guard().unwrap().traversed_and_hijacked(),
+            (false, false)
+        );
         unsafe { traverse(cell.as_ptr(), novisit, std::ptr::null_mut()) };
-        assert_eq!(cell.borrow().traversed_and_hijacked(), (true, false));
+        assert_eq!(
+            cell.try_borrow_guard().unwrap().traversed_and_hijacked(),
+            (true, false)
+        );
     })
 }
 
@@ -542,7 +556,7 @@ fn drop_during_traversal_with_gil() {
         )
         .unwrap();
 
-        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
+        *inst.try_borrow_guard_mut().unwrap().cycle.lock().unwrap() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         let ptr = inst.as_ptr();
@@ -577,7 +591,7 @@ fn drop_during_traversal_without_gil() {
         )
         .unwrap();
 
-        *inst.borrow_mut(py).cycle.lock().unwrap() = Some(inst.clone_ref(py));
+        *inst.try_borrow_guard_mut().unwrap().cycle.lock().unwrap() = Some(inst.clone_ref(py));
 
         check.assert_not_dropped();
         inst
@@ -637,7 +651,7 @@ fn unsendable_are_not_traversed_on_foreign_thread() {
         .join()
         .unwrap();
 
-        assert!(!obj.borrow().traversed.get());
+        assert!(!obj.try_borrow_guard().unwrap().traversed.get());
 
         // traversal on home thread still works
         assert_eq!(
@@ -645,7 +659,7 @@ fn unsendable_are_not_traversed_on_foreign_thread() {
             0
         );
 
-        assert!(obj.borrow().traversed.get());
+        assert!(obj.try_borrow_guard().unwrap().traversed.get());
     });
 }
 
@@ -676,7 +690,8 @@ fn test_traverse_subclass() {
             PyClassInitializer::from(base).add_subclass(SubOverrideTraverse {}),
         )
         .unwrap();
-        obj.borrow_mut().as_super().cycle = Some(obj.clone().into_any().unbind());
+        obj.try_borrow_guard_mut().unwrap().as_super().cycle =
+            Some(obj.clone().into_any().unbind());
 
         check.assert_not_dropped();
         let ptr = obj.as_ptr();
@@ -724,7 +739,8 @@ fn test_traverse_subclass_override_clear() {
             PyClassInitializer::from(base).add_subclass(SubOverrideClear {}),
         )
         .unwrap();
-        obj.borrow_mut().as_super().cycle = Some(obj.clone().into_any().unbind());
+        obj.try_borrow_guard_mut().unwrap().as_super().cycle =
+            Some(obj.clone().into_any().unbind());
 
         check.assert_not_dropped();
         let ptr = obj.as_ptr();
@@ -838,7 +854,7 @@ fn test_drop_buffer_during_traversal_without_gil() {
         )
         .unwrap();
 
-        obj.borrow_mut(py).cycle = Some(obj.clone_ref(py).into_any());
+        obj.try_borrow_guard_mut().unwrap().cycle = Some(obj.clone_ref(py).into_any());
 
         let ptr = obj.as_ptr();
         drop(obj);
@@ -1143,7 +1159,7 @@ fn test_subclass_clear() {
             PyClassInitializer::from(base).add_subclass(SubClear { field: None }),
         )
         .unwrap();
-        obj.borrow_mut().field = Some(obj.clone().into_any().unbind());
+        obj.try_borrow_guard_mut().unwrap().field = Some(obj.clone().into_any().unbind());
 
         check.assert_not_dropped();
         let ptr = obj.as_ptr();

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -137,12 +137,12 @@ struct RefGetterSetter {
 #[pymethods]
 impl RefGetterSetter {
     #[getter]
-    fn get_num(slf: PyRef<'_, Self>) -> i32 {
+    fn get_num(slf: PyClassGuard<'_, Self>) -> i32 {
         slf.num
     }
 
     #[setter]
-    fn set_num(mut slf: PyRefMut<'_, Self>, value: i32) {
+    fn set_num(mut slf: PyClassGuardMut<'_, Self>, value: i32) {
         slf.num = value;
     }
 }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -36,7 +36,7 @@ impl InstanceMethod {
 fn instance_method() {
     Python::attach(|py| {
         let obj = Bound::new(py, InstanceMethod { member: 42 }).unwrap();
-        let obj_ref = obj.borrow();
+        let obj_ref = obj.try_borrow_guard().unwrap();
         assert_eq!(obj_ref.method(), 42);
         py_assert!(py, obj, "obj.method() == 42");
         py_assert!(py, obj, "obj.add_other(obj) == 84");
@@ -76,7 +76,7 @@ impl InstanceMethodWithArgs {
 fn instance_method_with_args() {
     Python::attach(|py| {
         let obj = Bound::new(py, InstanceMethodWithArgs { member: 7 }).unwrap();
-        let obj_ref = obj.borrow();
+        let obj_ref = obj.try_borrow_guard().unwrap();
         assert_eq!(obj_ref.method(6), 42);
         py_assert!(py, obj, "obj.method(3) == 21");
         py_assert!(py, obj, "obj.method(multiplier=6) == 42");

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -796,7 +796,7 @@ impl MethodWithPyClassArg {
             value: self.value + other.value,
         }
     }
-    fn add_pyref(&self, other: PyRef<'_, MethodWithPyClassArg>) -> MethodWithPyClassArg {
+    fn add_pyref(&self, other: PyClassGuard<'_, MethodWithPyClassArg>) -> MethodWithPyClassArg {
         MethodWithPyClassArg {
             value: self.value + other.value,
         }
@@ -804,7 +804,7 @@ impl MethodWithPyClassArg {
     fn inplace_add(&self, other: &mut MethodWithPyClassArg) {
         other.value += self.value;
     }
-    fn inplace_add_pyref(&self, mut other: PyRefMut<'_, MethodWithPyClassArg>) {
+    fn inplace_add_pyref(&self, mut other: PyClassGuardMut<'_, MethodWithPyClassArg>) {
         other.value += self.value;
     }
     #[pyo3(signature=(other = None))]
@@ -1269,10 +1269,10 @@ fn test_pymethods_warn() {
         }
 
         #[pyo3(warn(message = "this method raises warning"))]
-        fn method_with_warning(_slf: PyRef<'_, Self>) {}
+        fn method_with_warning(_slf: PyClassGuard<'_, Self>) {}
 
         #[pyo3(warn(message = "this method raises warning", category = PyFutureWarning))]
-        fn method_with_warning_and_custom_category(_slf: PyRef<'_, Self>) {}
+        fn method_with_warning_and_custom_category(_slf: PyClassGuard<'_, Self>) {}
 
         #[cfg(any(not(Py_LIMITED_API), Py_3_12))]
         #[pyo3(warn(message = "this method raises user-defined warning", category = UserDefinedWarning))]
@@ -1308,7 +1308,7 @@ fn test_pymethods_warn() {
         }
 
         #[pyo3(warn(message = "the + op method raises warning"))]
-        fn __add__(&self, other: PyRef<'_, Self>) -> Self {
+        fn __add__(&self, other: PyClassGuard<'_, Self>) -> Self {
             Self {
                 value: self.value + other.value,
             }

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -853,7 +853,7 @@ impl MethodWithPyClassArg {
             value: self.value + other.value,
         }
     }
-    fn add_pyref(&self, other: PyRef<'_, MethodWithPyClassArg>) -> MethodWithPyClassArg {
+    fn add_pyref(&self, other: PyClassGuard<'_, MethodWithPyClassArg>) -> MethodWithPyClassArg {
         MethodWithPyClassArg {
             value: self.value + other.value,
         }
@@ -861,7 +861,7 @@ impl MethodWithPyClassArg {
     fn inplace_add(&self, other: &mut MethodWithPyClassArg) {
         other.value += self.value;
     }
-    fn inplace_add_pyref(&self, mut other: PyRefMut<'_, MethodWithPyClassArg>) {
+    fn inplace_add_pyref(&self, mut other: PyClassGuardMut<'_, MethodWithPyClassArg>) {
         other.value += self.value;
     }
     #[pyo3(signature=(other = None))]
@@ -1326,10 +1326,10 @@ fn test_pymethods_warn() {
         }
 
         #[pyo3(warn(message = "this method raises warning"))]
-        fn method_with_warning(_slf: PyRef<'_, Self>) {}
+        fn method_with_warning(_slf: PyClassGuard<'_, Self>) {}
 
         #[pyo3(warn(message = "this method raises warning", category = PyFutureWarning))]
-        fn method_with_warning_and_custom_category(_slf: PyRef<'_, Self>) {}
+        fn method_with_warning_and_custom_category(_slf: PyClassGuard<'_, Self>) {}
 
         #[cfg(any(not(Py_LIMITED_API), Py_3_12))]
         #[pyo3(warn(message = "this method raises user-defined warning", category = UserDefinedWarning))]
@@ -1365,7 +1365,7 @@ fn test_pymethods_warn() {
         }
 
         #[pyo3(warn(message = "the + op method raises warning"))]
-        fn __add__(&self, other: PyRef<'_, Self>) -> Self {
+        fn __add__(&self, other: PyClassGuard<'_, Self>) -> Self {
             Self {
                 value: self.value + other.value,
             }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -206,7 +206,7 @@ fn test_bool() {
     Python::attach(|py| {
         let example_py = make_example(py);
         assert!(example_py.is_truthy().unwrap());
-        example_py.borrow_mut().value = 0;
+        example_py.try_borrow_guard_mut().unwrap().value = 0;
         assert!(!example_py.is_truthy().unwrap());
 
         // Ensure that passing a wrong self type from Python does not cause UB
@@ -501,7 +501,7 @@ fn setitem() {
         let c = Bound::new(py, SetItem { key: 0, val: 0 }).unwrap();
         py_run!(py, c, "c[1] = 2");
         {
-            let c = c.borrow();
+            let c = c.try_borrow_guard().unwrap();
             assert_eq!(c.key, 1);
             assert_eq!(c.val, 2);
         }
@@ -530,7 +530,7 @@ fn delitem() {
         let c = Bound::new(py, DelItem { key: 0 }).unwrap();
         py_run!(py, c, "del c[1]");
         {
-            let c = c.borrow();
+            let c = c.try_borrow_guard().unwrap();
             assert_eq!(c.key, 1);
         }
         py_expect_exception!(py, c, "c[1] = 2", PyNotImplementedError);
@@ -562,11 +562,11 @@ fn setdelitem() {
         let c = Bound::new(py, SetDelItem { val: None }).unwrap();
         py_run!(py, c, "c[1] = 2");
         {
-            let c = c.borrow();
+            let c = c.try_borrow_guard().unwrap();
             assert_eq!(c.val, Some(2));
         }
         py_run!(py, c, "del c[1]");
-        let c = c.borrow();
+        let c = c.try_borrow_guard().unwrap();
         assert_eq!(c.val, None);
     });
 }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -424,11 +424,11 @@ struct Iterator {
 
 #[pymethods]
 impl Iterator {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __next__(slf: PyRefMut<'_, Self>) -> Option<i32> {
+    fn __next__(slf: PyClassGuardMut<'_, Self>) -> Option<i32> {
         slf.iter.lock().unwrap().next()
     }
 }
@@ -748,11 +748,11 @@ impl OnceFuture {
         }
     }
 
-    fn __await__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __await__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
     fn __next__<'py>(&mut self, py: Python<'py>) -> Option<&Bound<'py, PyAny>> {
@@ -809,7 +809,7 @@ impl AsyncIterator {
         }
     }
 
-    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __aiter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -872,10 +872,10 @@ impl DescrCounter {
     }
     /// Each access will increase the count
     fn __get__<'a>(
-        mut slf: PyRefMut<'a, Self>,
+        mut slf: PyClassGuardMut<'a, Self>,
         _instance: &Bound<'_, PyAny>,
         _owner: Option<&Bound<'_, PyType>>,
-    ) -> PyRefMut<'a, Self> {
+    ) -> PyClassGuardMut<'a, Self> {
         slf.count += 1;
         slf
     }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -423,11 +423,11 @@ struct Iterator {
 
 #[pymethods]
 impl Iterator {
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<i32> {
+    fn __next__(mut slf: PyClassGuardMut<'_, Self>) -> Option<i32> {
         slf.iter.next()
     }
 }
@@ -747,11 +747,11 @@ impl OnceFuture {
         }
     }
 
-    fn __await__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __await__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
     fn __next__<'py>(&mut self, py: Python<'py>) -> Option<&Bound<'py, PyAny>> {
@@ -808,7 +808,7 @@ impl AsyncIterator {
         }
     }
 
-    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __aiter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
@@ -871,10 +871,10 @@ impl DescrCounter {
     }
     /// Each access will increase the count
     fn __get__<'a>(
-        mut slf: PyRefMut<'a, Self>,
+        mut slf: PyClassGuardMut<'a, Self>,
         _instance: &Bound<'_, PyAny>,
         _owner: Option<&Bound<'_, PyType>>,
-    ) -> PyRefMut<'a, Self> {
+    ) -> PyClassGuardMut<'a, Self> {
         slf.count += 1;
         slf
     }

--- a/tests/test_proto_methods.rs
+++ b/tests/test_proto_methods.rs
@@ -205,7 +205,7 @@ fn test_bool() {
     Python::attach(|py| {
         let example_py = make_example(py);
         assert!(example_py.is_truthy().unwrap());
-        example_py.borrow_mut().value = 0;
+        example_py.try_borrow_guard_mut().unwrap().value = 0;
         assert!(!example_py.is_truthy().unwrap());
 
         // Ensure that passing a wrong self type from Python does not cause UB
@@ -500,7 +500,7 @@ fn setitem() {
         let c = Bound::new(py, SetItem { key: 0, val: 0 }).unwrap();
         py_run!(py, c, "c[1] = 2");
         {
-            let c = c.borrow();
+            let c = c.try_borrow_guard().unwrap();
             assert_eq!(c.key, 1);
             assert_eq!(c.val, 2);
         }
@@ -529,7 +529,7 @@ fn delitem() {
         let c = Bound::new(py, DelItem { key: 0 }).unwrap();
         py_run!(py, c, "del c[1]");
         {
-            let c = c.borrow();
+            let c = c.try_borrow_guard().unwrap();
             assert_eq!(c.key, 1);
         }
         py_expect_exception!(py, c, "c[1] = 2", PyNotImplementedError);
@@ -561,11 +561,11 @@ fn setdelitem() {
         let c = Bound::new(py, SetDelItem { val: None }).unwrap();
         py_run!(py, c, "c[1] = 2");
         {
-            let c = c.borrow();
+            let c = c.try_borrow_guard().unwrap();
             assert_eq!(c.val, Some(2));
         }
         py_run!(py, c, "del c[1]");
-        let c = c.borrow();
+        let c = c.try_borrow_guard().unwrap();
         assert_eq!(c.val, None);
     });
 }

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -34,7 +34,7 @@ impl Reader {
         }
     }
     fn get_iter_and_reset(
-        mut slf: PyRefMut<'_, Self>,
+        mut slf: PyClassGuardMut<'_, Self>,
         keys: Py<PyBytes>,
         py: Python<'_>,
     ) -> PyResult<Iter> {
@@ -59,16 +59,15 @@ struct Iter {
 #[pymethods]
 impl Iter {
     #[expect(clippy::self_named_constructors)]
-    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+    fn __iter__(slf: PyClassGuard<'_, Self>) -> PyClassGuard<'_, Self> {
         slf
     }
 
-    fn __next__(mut slf: PyRefMut<'_, Self>) -> PyResult<Option<Py<PyAny>>> {
-        let bytes = slf.keys.bind(slf.py()).as_bytes();
+    fn __next__(mut slf: PyClassGuardMut<'_, Self>, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
+        let bytes = slf.keys.bind(py).as_bytes();
         match bytes.get(slf.idx) {
             Some(&b) => {
                 slf.idx += 1;
-                let py = slf.py();
                 let reader = slf.reader.bind(py);
                 let reader_ref = reader.try_borrow()?;
                 let res = reader_ref

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -69,7 +69,7 @@ impl Iter {
             Some(&b) => {
                 slf.idx += 1;
                 let reader = slf.reader.bind(py);
-                let reader_ref = reader.try_borrow()?;
+                let reader_ref = reader.try_borrow_guard()?;
                 let res = reader_ref
                     .inner
                     .get(&b)
@@ -118,7 +118,7 @@ fn test_nested_iter_reset() {
             reader,
             "list(reader.get_iter_and_reset(bytes([3, 5, 2]))) == ['c', 'e', 'b']"
         );
-        let reader_ref = reader.borrow();
+        let reader_ref = reader.try_borrow_guard().unwrap();
         assert!(reader_ref.inner.is_empty());
     });
 }

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -75,9 +75,12 @@ impl ByteSequence {
         Self { elements }
     }
 
-    fn __inplace_concat__(mut slf: PyRefMut<'_, Self>, other: &Self) -> Py<Self> {
+    fn __inplace_concat__<'a>(
+        mut slf: PyClassGuardMut<'a, Self>,
+        other: &Self,
+    ) -> PyClassGuardMut<'a, Self> {
         slf.elements.extend_from_slice(&other.elements);
-        slf.into()
+        slf
     }
 
     fn __repeat__(&self, count: isize) -> PyResult<Self> {
@@ -92,14 +95,18 @@ impl ByteSequence {
         }
     }
 
-    fn __inplace_repeat__(mut slf: PyRefMut<'_, Self>, count: isize) -> PyResult<Py<Self>> {
+    fn __inplace_repeat__(
+        mut slf: PyClassGuardMut<'_, Self>,
+        py: Python<'_>,
+        count: isize,
+    ) -> PyResult<Py<Self>> {
         if count >= 0 {
             let mut elements = Vec::with_capacity(slf.elements.len() * count as usize);
             for _ in 0..count {
                 elements.extend(&slf.elements);
             }
             slf.elements = elements;
-            Ok(slf.into())
+            Ok(slf.into_pyobject(py)?.to_owned().unbind())
         } else {
             Err(PyValueError::new_err("invalid repeat count"))
         }

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -332,7 +332,8 @@ fn test_any_object_list_set() {
 
         py_run!(py, list, "list.items = [1, 2, 3]");
         assert!(list
-            .borrow()
+            .try_borrow_guard()
+            .unwrap()
             .items
             .iter()
             .zip(&[1u32, 2, 3])

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -69,11 +69,17 @@ fn test_deserialize() {
     assert_eq!(user.friends.len(), 1usize);
     let friend = user.friends.first().unwrap();
 
-    Python::attach(|py| {
-        assert_eq!(friend.borrow(py).username, "friend");
-        assert_eq!(
-            friend.borrow(py).group.as_ref().unwrap().borrow(py).name,
-            "danya's friends"
-        )
-    });
+    assert_eq!(friend.try_borrow_guard().unwrap().username, "friend");
+    assert_eq!(
+        friend
+            .try_borrow_guard()
+            .unwrap()
+            .group
+            .as_ref()
+            .unwrap()
+            .try_borrow_guard()
+            .unwrap()
+            .name,
+        "danya's friends"
+    );
 }

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -30,7 +30,7 @@ fn mut_ref_arg() {
         let inst2 = Py::new(py, MutRefArg { n: 0 }).unwrap();
 
         py_run!(py, inst1 inst2, "inst1.set_other(inst2)");
-        let inst2 = inst2.bind(py).borrow();
+        let inst2 = inst2.try_borrow_guard().unwrap();
         assert_eq!(inst2.n, 100);
     });
 }

--- a/tests/test_various.rs
+++ b/tests/test_various.rs
@@ -18,7 +18,7 @@ impl MutRefArg {
     fn get(&self) -> i32 {
         self.n
     }
-    fn set_other(&self, mut other: PyRefMut<'_, MutRefArg>) {
+    fn set_other(&self, mut other: PyClassGuardMut<'_, MutRefArg>) {
         other.n = 100;
     }
 }

--- a/tests/ui/invalid_async.rs
+++ b/tests/ui/invalid_async.rs
@@ -11,7 +11,7 @@ pub(crate) struct AsyncRange {
 }
 #[pymethods]
 impl AsyncRange {
-    async fn __anext__(mut _pyself: PyRefMut<'_, Self>) -> PyResult<i32> {
+    async fn __anext__(mut _pyself: PyClassGuardMut<'_, Self>) -> PyResult<i32> {
 //~^ ERROR: async functions are only supported with the `experimental-async` feature
         Ok(0)
     }

--- a/tests/ui/invalid_async.stderr
+++ b/tests/ui/invalid_async.stderr
@@ -7,7 +7,7 @@ error: async functions are only supported with the `experimental-async` feature
 error: async functions are only supported with the `experimental-async` feature
   --> tests/ui/invalid_async.rs:14:5
    |
-14 |     async fn __anext__(mut _pyself: PyRefMut<'_, Self>) -> PyResult<i32> {
+14 |     async fn __anext__(mut _pyself: PyClassGuardMut<'_, Self>) -> PyResult<i32> {
    |     ^^^^^
 
 error: async functions are only supported with the `experimental-async` feature

--- a/tests/ui/invalid_frozen_pyclass_borrow.rs
+++ b/tests/ui/invalid_frozen_pyclass_borrow.rs
@@ -13,8 +13,9 @@ impl Foo {
 }
 
 fn borrow_mut_fails(foo: Py<Foo>, py: Python) {
-    let borrow = foo.bind(py).borrow_mut();
-//~^ ERROR: type mismatch resolving `<Foo as PyClass>::Frozen == False`
+    let borrow = foo.try_borrow_guard_mut().unwrap();
+    //~^ ERROR: type mismatch resolving `<Foo as PyClass>::Frozen == False`
+    //~| ERROR: type mismatch resolving `<Foo as PyClass>::Frozen == False`
 }
 
 #[pyclass(subclass)]
@@ -24,24 +25,25 @@ struct MutableBase;
 struct ImmutableChild;
 
 fn borrow_mut_of_child_fails(child: Py<ImmutableChild>, py: Python) {
-    let borrow = child.bind(py).borrow_mut();
-//~^ ERROR: type mismatch resolving `<ImmutableChild as PyClass>::Frozen == False`
+    let borrow = child.try_borrow_guard_mut().unwrap();
+    //~^ ERROR: type mismatch resolving `<ImmutableChild as PyClass>::Frozen == False`
+    //~| ERROR: type mismatch resolving `<ImmutableChild as PyClass>::Frozen == False`
 }
 
 fn py_get_of_mutable_class_fails(class: Py<MutableBase>) {
     class.get();
-//~^ ERROR: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
+    //~^ ERROR: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
 }
 
 fn pyclass_get_of_mutable_class_fails(class: &Bound<'_, MutableBase>) {
     class.get();
-//~^ ERROR: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
+    //~^ ERROR: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
 }
 
 #[pyclass(frozen)]
 pub struct SetOnFrozenClass {
     #[pyo3(set)]
-//~^ ERROR: cannot use `#[pyo3(set)]` on a `frozen` class
+    //~^ ERROR: cannot use `#[pyo3(set)]` on a `frozen` class
     field: u32,
 }
 

--- a/tests/ui/invalid_frozen_pyclass_borrow.stderr
+++ b/tests/ui/invalid_frozen_pyclass_borrow.stderr
@@ -1,7 +1,7 @@
 error: cannot use `#[pyo3(set)]` on a `frozen` class
-  --> tests/ui/invalid_frozen_pyclass_borrow.rs:43:12
+  --> tests/ui/invalid_frozen_pyclass_borrow.rs:45:12
    |
-43 |     #[pyo3(set)]
+45 |     #[pyo3(set)]
    |            ^^^
 
 error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`
@@ -23,57 +23,93 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_pyclass_ref
   = note: this error originates in the attribute macro `pymethods` which comes from the expansion of the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`
-   --> tests/ui/invalid_frozen_pyclass_borrow.rs:16:31
+    --> tests/ui/invalid_frozen_pyclass_borrow.rs:16:22
+     |
+  16 |     let borrow = foo.try_borrow_guard_mut().unwrap();
+     |                      ^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<Foo as PyClass>::Frozen == False`
+     |
+note: expected this to be `pyo3::pyclass::boolean_struct::False`
+    --> tests/ui/invalid_frozen_pyclass_borrow.rs:3:1
+     |
+   3 | #[pyclass(frozen)]
+     | ^^^^^^^^^^^^^^^^^^
+note: required by a bound in `pyo3::Py::<T>::try_borrow_guard_mut`
+ --> src/instance.rs
+  |
+  |     pub fn try_borrow_guard_mut<'a>(&'a self) -> Result<PyClassGuardMut<'a, T>, PyBorrowMutError>
+  |            -------------------- required by a bound in this associated function
+  |     where
+  |         T: PyClass<Frozen = False>,
+  |                    ^^^^^^^^^^^^^^ required by this bound in `Py::<T>::try_borrow_guard_mut`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<Foo as PyClass>::Frozen == False`
+   --> tests/ui/invalid_frozen_pyclass_borrow.rs:16:18
     |
- 16 |     let borrow = foo.bind(py).borrow_mut();
-    |                               ^^^^^^^^^^ type mismatch resolving `<Foo as PyClass>::Frozen == False`
+ 16 |     let borrow = foo.try_borrow_guard_mut().unwrap();
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<Foo as PyClass>::Frozen == False`
     |
 note: expected this to be `pyo3::pyclass::boolean_struct::False`
    --> tests/ui/invalid_frozen_pyclass_borrow.rs:3:1
     |
   3 | #[pyclass(frozen)]
     | ^^^^^^^^^^^^^^^^^^
-note: required by a bound in `pyo3::Bound::<'py, T>::borrow_mut`
- --> src/instance.rs
+note: required by a bound in `PyClassGuardMut`
+ --> src/pyclass/guard.rs
   |
-  |     pub fn borrow_mut(&self) -> PyRefMut<'py, T>
-  |            ---------- required by a bound in this associated function
-  |     where
-  |         T: PyClass<Frozen = False>,
-  |                    ^^^^^^^^^^^^^^ required by this bound in `Bound::<'py, T>::borrow_mut`
+  | pub struct PyClassGuardMut<'a, T: PyClass<Frozen = False>> {
+  |                                           ^^^^^^^^^^^^^^ required by this bound in `PyClassGuardMut`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<ImmutableChild as PyClass>::Frozen == False`
-   --> tests/ui/invalid_frozen_pyclass_borrow.rs:27:33
-    |
- 27 |     let borrow = child.bind(py).borrow_mut();
-    |                                 ^^^^^^^^^^ type mismatch resolving `<ImmutableChild as PyClass>::Frozen == False`
-    |
+    --> tests/ui/invalid_frozen_pyclass_borrow.rs:28:24
+     |
+  28 |     let borrow = child.try_borrow_guard_mut().unwrap();
+     |                        ^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<ImmutableChild as PyClass>::Frozen == False`
+     |
 note: expected this to be `pyo3::pyclass::boolean_struct::False`
-   --> tests/ui/invalid_frozen_pyclass_borrow.rs:23:1
-    |
- 23 | #[pyclass(frozen, extends = MutableBase)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-note: required by a bound in `pyo3::Bound::<'py, T>::borrow_mut`
+    --> tests/ui/invalid_frozen_pyclass_borrow.rs:24:1
+     |
+  24 | #[pyclass(frozen, extends = MutableBase)]
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `pyo3::Py::<T>::try_borrow_guard_mut`
  --> src/instance.rs
   |
-  |     pub fn borrow_mut(&self) -> PyRefMut<'py, T>
-  |            ---------- required by a bound in this associated function
+  |     pub fn try_borrow_guard_mut<'a>(&'a self) -> Result<PyClassGuardMut<'a, T>, PyBorrowMutError>
+  |            -------------------- required by a bound in this associated function
   |     where
   |         T: PyClass<Frozen = False>,
-  |                    ^^^^^^^^^^^^^^ required by this bound in `Bound::<'py, T>::borrow_mut`
+  |                    ^^^^^^^^^^^^^^ required by this bound in `Py::<T>::try_borrow_guard_mut`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0271]: type mismatch resolving `<ImmutableChild as PyClass>::Frozen == False`
+   --> tests/ui/invalid_frozen_pyclass_borrow.rs:28:18
+    |
+ 28 |     let borrow = child.try_borrow_guard_mut().unwrap();
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch resolving `<ImmutableChild as PyClass>::Frozen == False`
+    |
+note: expected this to be `pyo3::pyclass::boolean_struct::False`
+   --> tests/ui/invalid_frozen_pyclass_borrow.rs:24:1
+    |
+ 24 | #[pyclass(frozen, extends = MutableBase)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+note: required by a bound in `PyClassGuardMut`
+ --> src/pyclass/guard.rs
+  |
+  | pub struct PyClassGuardMut<'a, T: PyClass<Frozen = False>> {
+  |                                           ^^^^^^^^^^^^^^ required by this bound in `PyClassGuardMut`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
-    --> tests/ui/invalid_frozen_pyclass_borrow.rs:32:11
+    --> tests/ui/invalid_frozen_pyclass_borrow.rs:34:11
      |
-  32 |     class.get();
+  34 |     class.get();
      |           ^^^ type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
      |
 note: expected this to be `pyo3::pyclass::boolean_struct::True`
-    --> tests/ui/invalid_frozen_pyclass_borrow.rs:20:1
+    --> tests/ui/invalid_frozen_pyclass_borrow.rs:21:1
      |
-  20 | #[pyclass(subclass)]
+  21 | #[pyclass(subclass)]
      | ^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `pyo3::Py::<T>::get`
  --> src/instance.rs
@@ -86,15 +122,15 @@ note: required by a bound in `pyo3::Py::<T>::get`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0271]: type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
-   --> tests/ui/invalid_frozen_pyclass_borrow.rs:37:11
+   --> tests/ui/invalid_frozen_pyclass_borrow.rs:39:11
     |
- 37 |     class.get();
+ 39 |     class.get();
     |           ^^^ type mismatch resolving `<MutableBase as PyClass>::Frozen == True`
     |
 note: expected this to be `pyo3::pyclass::boolean_struct::True`
-   --> tests/ui/invalid_frozen_pyclass_borrow.rs:20:1
+   --> tests/ui/invalid_frozen_pyclass_borrow.rs:21:1
     |
- 20 | #[pyclass(subclass)]
+ 21 | #[pyclass(subclass)]
     | ^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `pyo3::Bound::<'py, T>::get`
  --> src/instance.rs
@@ -106,6 +142,6 @@ note: required by a bound in `pyo3::Bound::<'py, T>::get`
   |                    ^^^^^^^^^^^^^ required by this bound in `Bound::<'py, T>::get`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 6 previous errors
+error: aborting due to 8 previous errors
 
 For more information about this error, try `rustc --explain E0271`.

--- a/tests/ui/traverse.rs
+++ b/tests/ui/traverse.rs
@@ -7,8 +7,9 @@ struct TraverseTriesToTakePyRef {}
 
 #[pymethods]
 impl TraverseTriesToTakePyRef {
+    #[expect(deprecated)]
     fn __traverse__(_slf: PyRef<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 }
@@ -18,8 +19,9 @@ struct TraverseTriesToTakePyRefMut {}
 
 #[pymethods]
 impl TraverseTriesToTakePyRefMut {
+    #[expect(deprecated)]
     fn __traverse__(_slf: PyRefMut<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 }
@@ -30,7 +32,7 @@ struct TraverseTriesToTakeBound {}
 #[pymethods]
 impl TraverseTriesToTakeBound {
     fn __traverse__(_slf: Bound<'_, Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 }
@@ -41,7 +43,7 @@ struct TraverseTriesToTakeMutSelf {}
 #[pymethods]
 impl TraverseTriesToTakeMutSelf {
     fn __traverse__(&mut self, _visit: PyVisit) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 }
@@ -62,7 +64,7 @@ struct Class;
 #[pymethods]
 impl Class {
     fn __traverse__(&self, _py: Python<'_>, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-//~^ ERROR: __traverse__ may not take `Python`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
+        //~^ ERROR: __traverse__ may not take `Python`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
         Ok(())
     }
 

--- a/tests/ui/traverse.stderr
+++ b/tests/ui/traverse.stderr
@@ -1,31 +1,31 @@
 error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:10:27
+  --> tests/ui/traverse.rs:11:27
    |
-10 |     fn __traverse__(_slf: PyRef<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
+11 |     fn __traverse__(_slf: PyRef<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                           ^^^^^
 
 error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:21:27
+  --> tests/ui/traverse.rs:23:27
    |
-21 |     fn __traverse__(_slf: PyRefMut<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
+23 |     fn __traverse__(_slf: PyRefMut<Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                           ^^^^^^^^
 
 error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:32:27
+  --> tests/ui/traverse.rs:34:27
    |
-32 |     fn __traverse__(_slf: Bound<'_, Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
+34 |     fn __traverse__(_slf: Bound<'_, Self>, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                           ^^^^^
 
 error: __traverse__ may not take a receiver other than `&self`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:43:21
+  --> tests/ui/traverse.rs:45:21
    |
-43 |     fn __traverse__(&mut self, _visit: PyVisit) -> Result<(), PyTraverseError> {
+45 |     fn __traverse__(&mut self, _visit: PyVisit) -> Result<(), PyTraverseError> {
    |                     ^
 
 error: __traverse__ may not take `Python`. Usually, an implementation of `__traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>` should do nothing but calls to `visit.call`. Most importantly, safe access to the Python interpreter is prohibited inside implementations of `__traverse__`, i.e. `Python::attach` will panic.
-  --> tests/ui/traverse.rs:64:33
+  --> tests/ui/traverse.rs:66:33
    |
-64 |     fn __traverse__(&self, _py: Python<'_>, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+66 |     fn __traverse__(&self, _py: Python<'_>, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
    |                                 ^^^^^^^^^^
 
 error: aborting due to 5 previous errors


### PR DESCRIPTION
Part 2 of #6120 

Deprecates `(try_)borrow(_mut)` family of methods on `Bound` and `Py`, and introducing `try_borrow_guard` and `try_borrow_guard_mut` as successors (to be renamed back at some later release). I intentionally did not reintroduce panicking variants. I think the error condition got more likely now with free-threading and we should encourage users to handle such errors gracefully.

Only the second commit is relevant, first commit is #6120. I'll rebase once #6120 lands.

- [ ] Write migration guide entry

See also #6083 