### PR TITLE
fix: avoid #[pymethods] name collisions between regular methods and #[getter]/#[setter]/#[deleter]

### DIFF
--- a/newsfragments/6135.fixed.md
+++ b/newsfragments/6135.fixed.md
@@ -1,0 +1,1 @@
+Fix `#[pymethods]` so a regular method whose Python name starts with `get_`, `set_`, or `delete_` no longer collides with a property of the trimmed name (e.g. `fn get_x` alongside `#[getter] fn x`).

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -372,9 +372,6 @@ pub fn impl_py_method_def(
     ctx: &Ctx,
 ) -> Result<MethodAndMethodDef> {
     let Ctx { pyo3_path, .. } = ctx;
-    // The `method_` infix keeps the generated identifier from colliding with
-    // the wrappers for `#[getter]`/`#[setter]`/`#[deleter]`, which use the
-    // `get_`/`set_`/`delete_` prefixes (see #5974).
     let wrapper_ident = format_ident!("__pymethod_method_{}__", spec.python_name);
     let calling_convention = CallingConvention::from_signature(&spec.signature);
     let associated_method = spec.get_wrapper_function(

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -372,7 +372,10 @@ pub fn impl_py_method_def(
     ctx: &Ctx,
 ) -> Result<MethodAndMethodDef> {
     let Ctx { pyo3_path, .. } = ctx;
-    let wrapper_ident = format_ident!("__pymethod_{}__", spec.python_name);
+    // The `method_` infix keeps the generated identifier from colliding with
+    // the wrappers for `#[getter]`/`#[setter]`/`#[deleter]`, which use the
+    // `get_`/`set_`/`delete_` prefixes (see #5974).
+    let wrapper_ident = format_ident!("__pymethod_method_{}__", spec.python_name);
     let calling_convention = CallingConvention::from_signature(&spec.signature);
     let associated_method = spec.get_wrapper_function(
         &wrapper_ident,

--- a/tests/test_getter_setter.rs
+++ b/tests/test_getter_setter.rs
@@ -317,3 +317,82 @@ fn test_optional_setter() {
         );
     })
 }
+
+// Regression test for #5974: previously, the wrapper generated for a regular
+// method called `get_x` collided with the wrapper generated for a `#[getter]`
+// of `x`, because both produced an associated function named
+// `__pymethod_get_x__`. The same problem applied to setters/deleters and to
+// `#[pyo3(name = ...)]` renames that happened to start with `get_`/`set_`/
+// `delete_`. The fix is to use a distinct infix for regular methods.
+#[test]
+fn property_and_regular_method_can_share_name_prefix() {
+    #[pyclass]
+    struct Object {
+        x: u32,
+        y: u32,
+        z: u32,
+    }
+
+    #[pymethods]
+    impl Object {
+        #[getter]
+        fn x(&self) -> u32 {
+            self.x
+        }
+
+        // Was previously a compile error: wrapper collided with the `x` getter.
+        fn get_x(&self) -> u32 {
+            self.x + 1
+        }
+
+        #[getter]
+        fn y(&self) -> u32 {
+            self.y
+        }
+
+        // Was previously a compile error too: `#[pyo3(name = ...)]` is also
+        // routed through `python_name`.
+        #[pyo3(name = "get_y")]
+        fn y_get(&self) -> u32 {
+            self.y + 2
+        }
+
+        #[setter]
+        fn z(&mut self, value: u32) {
+            self.z = value;
+        }
+
+        // Same collision pattern as above, but for setters.
+        fn set_z(&mut self, value: u32) {
+            self.z = value + 1;
+        }
+    }
+
+    Python::attach(|py| {
+        let instance = Py::new(
+            py,
+            Object {
+                x: 10,
+                y: 20,
+                z: 30,
+            },
+        )
+        .unwrap();
+        py_run!(
+            py,
+            instance,
+            "assert instance.x == 10 and instance.get_x() == 11"
+        );
+        py_run!(
+            py,
+            instance,
+            "assert instance.y == 20 and instance.get_y() == 22"
+        );
+        // `z` has only a setter; we exercise both the setter and the regular
+        // method by routing reads through the borrowed Rust value.
+        py_run!(py, instance, "instance.z = 5");
+        assert_eq!(instance.borrow(py).z, 5);
+        py_run!(py, instance, "instance.set_z(5)");
+        assert_eq!(instance.borrow(py).z, 6);
+    })
+}

--- a/tests/ui/invalid_pyclass_generic.rs
+++ b/tests/ui/invalid_pyclass_generic.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyType;
 
 #[pyclass(generic)]
-//~^ ERROR: duplicate definitions with name `__pymethod___class_getitem____`
+//~^ ERROR: duplicate definitions with name `__pymethod_method___class_getitem____`
 //~| ERROR: duplicate definitions with name `__class_getitem__`
 //~| ERROR: multiple applicable items in scope
 //~| ERROR: multiple applicable items in scope

--- a/tests/ui/invalid_pyclass_generic.stderr
+++ b/tests/ui/invalid_pyclass_generic.stderr
@@ -1,11 +1,11 @@
-error[E0592]: duplicate definitions with name `__pymethod___class_getitem____`
+error[E0592]: duplicate definitions with name `__pymethod_method___class_getitem____`
   --> tests/ui/invalid_pyclass_generic.rs:4:1
    |
  4 | #[pyclass(generic)]
-   | ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___class_getitem____`
+   | ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod_method___class_getitem____`
 ...
 12 | #[pymethods]
-   | ------------ other definition for `__pymethod___class_getitem____`
+   | ------------ other definition for `__pymethod_method___class_getitem____`
    |
    = note: this error originates in the macro `::pyo3::impl_::pymethods::maybe_define_fastcall_function_with_keywords` which comes from the expansion of the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -29,7 +29,7 @@ error[E0034]: multiple applicable items in scope
   --> tests/ui/invalid_pyclass_generic.rs:4:1
    |
  4 | #[pyclass(generic)]
-   | ^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___class_getitem____` found
+   | ^^^^^^^^^^^^^^^^^^^ multiple `__pymethod_method___class_getitem____` found
    |
 note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetItem`
   --> tests/ui/invalid_pyclass_generic.rs:4:1
@@ -92,7 +92,7 @@ error[E0034]: multiple applicable items in scope
   --> tests/ui/invalid_pyclass_generic.rs:20:12
    |
 20 |     pub fn __class_getitem__(
-   |            ^^^^^^^^^^^^^^^^^ multiple `__pymethod___class_getitem____` found
+   |            ^^^^^^^^^^^^^^^^^ multiple `__pymethod_method___class_getitem____` found
    |
 note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetItem`
   --> tests/ui/invalid_pyclass_generic.rs:4:1

--- a/tests/ui/invalid_pymethods_duplicates.rs
+++ b/tests/ui/invalid_pymethods_duplicates.rs
@@ -25,7 +25,7 @@ impl TwoNew {
 struct DuplicateMethod {}
 
 #[pymethods]
-//~^ ERROR: duplicate definitions with name `__pymethod_func__`
+//~^ ERROR: duplicate definitions with name `__pymethod_method_func__`
 impl DuplicateMethod {
     #[pyo3(name = "func")]
     fn func_a(&self) {}

--- a/tests/ui/invalid_pymethods_duplicates.stderr
+++ b/tests/ui/invalid_pymethods_duplicates.stderr
@@ -20,14 +20,14 @@ error[E0592]: duplicate definitions with name `__pymethod___new____`
   |
   = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0592]: duplicate definitions with name `__pymethod_func__`
+error[E0592]: duplicate definitions with name `__pymethod_method_func__`
   --> tests/ui/invalid_pymethods_duplicates.rs:27:1
    |
 27 | #[pymethods]
    | ^^^^^^^^^^^^
    | |
-   | duplicate definitions for `__pymethod_func__`
-   | other definition for `__pymethod_func__`
+   | duplicate definitions for `__pymethod_method_func__`
+   | other definition for `__pymethod_method_func__`
    |
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 


### PR DESCRIPTION
Closes #5974.

## Bug

The `#[pymethods]` macro generates an internal associated function for
every entry in the `impl` block. Up to now those names came from two
different conventions that overlap:

| kind | wrapper name |
|------|--------------|
| `#[getter] fn x` | `__pymethod_get_x__` |
| `#[setter] fn x` | `__pymethod_set_x__` |
| `#[deleter] fn x` | `__pymethod_delete_x__` |
| regular method `fn x` | `__pymethod_x__` |

So defining both a property and a same-named accessor method — `#[getter] fn x` + `fn get_x` — collides on `__pymethod_get_x__` with `error[E0592]: duplicate definitions`. The same trap exists for `set_X` against `#[setter]` and `delete_X` against `#[deleter]`. It also survives `#[pyo3(name = "get_y")]` renames, because the regular-method wrapper is keyed off `spec.python_name`, not the Rust identifier:

```rust
#[pyclass]
pub struct Object { x: u32, y: u32 }

#[pymethods]
impl Object {
    #[getter] fn x(&self) -> u32 { self.x }
    fn get_x(&self) -> u32 { self.x }                        // collision

    #[getter] fn y(&self) -> u32 { self.y }
    #[pyo3(name = "get_y")] fn y_get(&self) -> u32 { self.y } // collision
}
// error[E0592]: duplicate definitions with name `__pymethod_get_x__`
// error[E0592]: duplicate definitions with name `__pymethod_get_y__`
```

This blocks a common Python pattern: shipping a cheap `value` property alongside a parameterised `get_value(...)` method for callers that need the underlying computation. The original report (#5974) is a real adaptation case where backwards-compatible naming required exactly this shape.

## Fix

Switch the wrapper name for regular methods from `__pymethod_{python_name}__` to `__pymethod_method_{python_name}__` in `impl_py_method_def`. The `method` infix can no longer be a substring of `get_`, `set_`, or `delete_`, so the prefix space is now disjoint regardless of which Python name the user chooses. This matches the direction agreed in [#5974 (comment)](https://github.com/PyO3/pyo3/issues/5974#issuecomment-3088197960) — pick a distinct prefix for "ordinary" methods — and `method` reads more naturally than `standard` while having the same effect.

The change is purely internal: these `__pymethod_*__` symbols are private associated items consumed by other macro-generated code in the same expansion. No public API moves.

## Scope

I deliberately kept this narrow:

- Only the regular-method site in `pyo3-macros-backend/src/pymethod.rs` is changed; the `#[classattr]` and `gen_py_const` sites also generate `__pymethod_{name}__`, but their collision space (uppercase-snake constants, class-level Python names) is much harder to hit in real code than `get_X` / `set_X` / `delete_X`. Happy to expand if reviewers prefer.
- `__pymethod___new____`, `__pymethod___richcmp____`, `__pymethod_traverse__`, `__pymethod_constructor__`, `__pymethod_variant_cls_*` etc. are unchanged — they don't share the property-prefix shape.

## Tests

- Added `property_and_regular_method_can_share_name_prefix` in `tests/test_getter_setter.rs`. It exercises all three collision shapes — regular method (`fn get_x`), `#[pyo3(name = "get_y")] fn y_get` rename, and the setter variant `fn set_z` against `#[setter] fn z` — and verifies that each callable reaches the right Rust impl from Python (`instance.x == 10` vs `instance.get_x() == 11`, etc.). Without the fix this test fails to compile with `E0592`.
- Updated `tests/ui/invalid_pymethods_duplicates.rs` (+ `.stderr` snapshot): the existing "two methods both renamed to `func`" duplicate-detection still trips, just on `__pymethod_method_func__` now.
- `cargo test -p pyo3 --tests` is green across the test suite I can run locally on macOS (class basics, class attributes, getter/setter, methods, proto methods, multiple-pymethods feature, inheritance, declarative module, etc.). UI tests that fail on my machine all fail identically on `main` — they're rustc-version-sensitive snapshots and unrelated to this change.
- `cargo fmt --check` clean; `cargo clippy --tests --features=macros` clean.