### PR TITLE
docs: Add tibs library link to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ about this topic.
 - [rust-python-coverage](https://github.com/cjermain/rust-python-coverage) _Example PyO3 project with automated test coverage for Rust and Python._
 - [rnet](https://github.com/0x676e67/rnet) Asynchronous Python HTTP Client with Black Magic
 - [sail](https://github.com/lakehq/sail) _Unifying stream, batch, and AI workloads with Apache Spark compatibility._
+- [tibs](https://github.com/scott-griffiths/tibs) _A sleek Python library for binary data._
 - [tiktoken](https://github.com/openai/tiktoken) _A fast BPE tokeniser for use with OpenAI's models._
 - [tokenizers](https://github.com/huggingface/tokenizers/tree/main/bindings/python) _Python bindings to the Hugging Face tokenizers (NLP) written in Rust._
 - [tzfpy](http://github.com/ringsaturn/tzfpy) _A fast package to convert longitude/latitude to timezone name._


### PR DESCRIPTION
Adding link to the tibs library. Used for creating, interpreting and manipulating binary data, and 100% written in Rust with PyO3.