### PR TITLE
fix: compile with PyPy when nightly feature is enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
       matrix:
         target: ["x86_64-unknown-linux-gnu"]
     name: check-nightly/${{ matrix.target }}/${{ matrix.rust }}
-    continue-on-error: ${{ matrix.rust != 'stable' }}
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6.0.3
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,29 @@ jobs:
     env:
       CARGO_BUILD_TARGET: ${{ matrix.target }}
 
+  check-nightly:
+    needs: [fmt]
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      # If one platform fails, allow the rest to keep testing if `CI-no-fail-fast` label is present
+      fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
+      matrix:
+        target: ["x86_64-unknown-linux-gnu"]
+    name: check-nightly/${{ matrix.target }}/${{ matrix.rust }}
+    continue-on-error: ${{ matrix.rust != 'stable' }}
+    steps:
+      - uses: actions/checkout@v6.0.3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: ${{ matrix.target }}
+          components: clippy,rust-src
+      - uses: astral-sh/setup-uv@v7
+        with:
+          save-cache: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
+      - run: uvx nox -s check-all
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.target }}
+
   build-pr:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-build-full') && github.event_name == 'pull_request' }}
     name: python${{ matrix.python-version }}-${{ matrix.platform.python-architecture }} ${{ matrix.platform.os }} rust-${{ matrix.rust }}
@@ -850,6 +873,7 @@ jobs:
       - fmt
       - check-msrv
       - clippy
+      - check-nightly
       - build-pr
       - build-full
       - valgrind

--- a/newsfragments/6146.fixed.md
+++ b/newsfragments/6146.fixed.md
@@ -1,0 +1,1 @@
+Fix compilation error when using the `nightly` feature with PyPy or GraalPy by conditionally excluding `!Ungil` implementations for FFI types not available on those platforms.

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -118,7 +118,7 @@
 //!
 //! [`SendWrapper`]: https://docs.rs/send_wrapper/latest/send_wrapper/struct.SendWrapper.html
 //! [`Rc`]: alloc::rc::Rc
-//! [`Py`]: crate::Py
+//! [`Py`]: Py
 use crate::conversion::IntoPyObject;
 use crate::err::{self, PyResult};
 use crate::internal::state::{AttachGuard, SuspendAttach};
@@ -286,10 +286,11 @@ mod nightly {
 
         impl !Ungil for crate::ffi::PyThreadState {}
         impl !Ungil for crate::ffi::PyInterpreterState {}
+        #[cfg(not(any(PyPy, GraalPy)))]
         impl !Ungil for crate::ffi::PyWeakReference {}
         impl !Ungil for crate::ffi::PyFrameObject {}
         impl !Ungil for crate::ffi::PyCodeObject {}
-        #[cfg(not(Py_LIMITED_API))]
+        #[cfg(all(not(PyPy), not(Py_LIMITED_API)))]
         impl !Ungil for crate::ffi::PyDictKeysObject {}
         #[cfg(not(any(Py_LIMITED_API, Py_3_10)))]
         impl !Ungil for crate::ffi::PyArena {}


### PR DESCRIPTION
From [lava-sh/yaml-rs CI](https://github.com/lava-sh/yaml-rs/actions/runs/27904060735/job/82569415590?pr=146#step:7:123)
```bash
[21](https://github.com/lava-sh/yaml-rs/actions/runs/27904060735/job/82569415590?pr=146#step:7:122)
   Compiling pyo3-macros v0.29.0
error[E0425]: cannot find type `PyWeakReference` in module `crate::ffi`
   --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\pyo3-0.29.0\src\marker.rs:289:37
    |
289 |         impl !Ungil for crate::ffi::PyWeakReference {}
    |                                     ^^^^^^^^^^^^^^^ not found in `crate::ffi`

error[E0425]: cannot find type `PyDictKeysObject` in module `crate::ffi`
   --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\pyo3-0.29.0\src\marker.rs:293:37
    |
293 |         impl !Ungil for crate::ffi::PyDictKeysObject {}
    |                                     ^^^^^^^^^^^^^^^^
    |
   ::: C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\pyo3-ffi-0.29.0\src\cpython\dictobject.rs:42:1
    |
 42 | pub struct PyDictObject {
    | ----------------------- similarly named struct `PyDictObject` defined here
    |
help: a struct with a similar name exists
    |
293 -         impl !Ungil for crate::ffi::PyDictKeysObject {}
293 +         impl !Ungil for crate::ffi::PyDictObject {}
    |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `pyo3` (lib) due to 2 previous errors
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Cargo build finished with "exit code: 101": `"cargo" "rustc" "--features" "mimalloc" "--message-format" "json-render-diagnostics" "--manifest-path" "D:\\a\\yaml-rs\\yaml-rs\\Cargo.toml" "--lib"`
Error: Process completed with exit code 1.
```