### PR TITLE
use `PyModule_FromSlotsAndSpec` in inittab implementation

### DIFF
--- a/guide/src/python-from-rust/calling-existing-code.md
+++ b/guide/src/python-from-rust/calling-existing-code.md
@@ -154,13 +154,10 @@ mod foo {
     }
 }
 
-# #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
 fn main() -> PyResult<()> {
     pyo3::append_to_inittab!(foo);
     Python::attach(|py| Python::run(py, c"import foo; foo.add_one(6)", None, None))
 }
-# #[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
-# fn main() -> () {}
 ```
 
 If `append_to_inittab` cannot be used due to constraints in the program, an alternative is to create a module using [`PyModule::new`] and insert it manually into `sys.modules`:

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -27,6 +27,7 @@ use core::sync::atomic::AtomicI64;
     not(target_has_atomic = "64"),
 ))]
 use portable_atomic::AtomicI64;
+use std::panic::AssertUnwindSafe;
 
 #[cfg(not(any(PyPy, GraalPy)))]
 use crate::exceptions::PyImportError;
@@ -235,6 +236,19 @@ impl ModuleDef {
                 .map(|py_module| py_module.clone_ref(py))
         }
     }
+
+    /// Implementation of `initfunc` for `append_to_inittab`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must have an attached thread state.
+    pub unsafe fn initfunc(&'static self) -> *mut ffi::PyObject {
+        let slf = AssertUnwindSafe(self);
+        let make_module = |py: Python<'_>| slf.make_module(py).map(Py::into_ptr);
+        // SAFETY: caller has an attached thread state
+        unsafe { crate::impl_::trampoline::trampoline(make_module) }
+    }
+
     #[cfg(Py_3_15)]
     pub fn get_slots(&'static self) -> *mut ffi::PySlot {
         self.slots.0.get() as *mut ffi::PySlot

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -211,7 +211,7 @@ macro_rules! wrap_pymodule {
 ///
 /// Use it before [`Python::initialize`](crate::marker::Python::initialize) and
 /// leave feature `auto-initialize` off
-#[cfg(not(any(PyPy, GraalPy, all(Py_LIMITED_API, Py_GIL_DISABLED))))]
+#[cfg(not(any(PyPy, GraalPy)))]
 #[macro_export]
 macro_rules! append_to_inittab {
     ($module:ident) => {
@@ -221,9 +221,14 @@ macro_rules! append_to_inittab {
                     "called `append_to_inittab` but a Python interpreter is already running."
                 );
             }
+
+            unsafe extern "C" fn initfunc() -> *mut $crate::ffi::PyObject {
+                $module::_PYO3_DEF.initfunc()
+            }
+
             $crate::ffi::PyImport_AppendInittab(
                 $module::__PYO3_NAME.as_ptr(),
-                ::core::option::Option::Some($module::__pyo3_init),
+                ::core::option::Option::Some(initfunc),
             );
         }
     };

--- a/src/tests/hygiene/misc.rs
+++ b/src/tests/hygiene/misc.rs
@@ -31,7 +31,7 @@ fn intern(py: crate::Python<'_>) {
     let _bar = crate::intern!(py, stringify!(bar));
 }
 
-#[cfg(not(any(PyPy, GraalPy, all(Py_LIMITED_API, Py_GIL_DISABLED))))]
+#[cfg(not(any(PyPy, GraalPy)))]
 fn append_to_inittab() {
     #[crate::pymodule]
     #[pyo3(crate = "crate")]

--- a/tests/test_append_to_inittab.rs
+++ b/tests/test_append_to_inittab.rs
@@ -20,7 +20,7 @@ mod module_mod_with_functions {
     use super::foo;
 }
 
-#[cfg(not(any(PyPy, GraalPy, all(Py_LIMITED_API, Py_GIL_DISABLED))))]
+#[cfg(not(any(PyPy, GraalPy)))]
 #[test]
 fn test_module_append_to_inittab() {
     use pyo3::append_to_inittab;


### PR DESCRIPTION
Not sure if this is the way to go to make `inittab` support with `abi3t`.

Will fail 3.15 builds due to https://github.com/python/cpython/issues/151868