### PR TITLE
Add `PyInitConfig` to ffi crate

### DIFF
--- a/newsfragments/6152.added.md
+++ b/newsfragments/6152.added.md
@@ -1,0 +1,1 @@
+Add init config to `ffi` crate

--- a/pyo3-ffi/src/cpython/initconfig.rs
+++ b/pyo3-ffi/src/cpython/initconfig.rs
@@ -1,5 +1,7 @@
 /* --- PyStatus ----------------------------------------------- */
 
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
+use crate::PyObject;
 use crate::Py_ssize_t;
 use core::ffi::{c_char, c_int, c_ulong};
 use libc::wchar_t;
@@ -232,4 +234,46 @@ extern_libpython! {
 
 extern_libpython! {
     pub fn Py_GetArgcArgv(argc: *mut c_int, argv: *mut *mut *mut wchar_t);
+}
+
+// --- PyInitConfig ---------------------------------------------------------
+
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
+opaque_struct!(pub PyInitConfig);
+
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
+extern_libpython! {
+    pub fn PyInitConfig_Create() -> *mut PyInitConfig;
+    pub fn PyInitConfig_Free(config: *mut PyInitConfig);
+
+    pub fn PyInitConfig_GetError(config: *mut PyInitConfig, err_message: *mut *const c_char) -> c_int;
+    pub fn PyInitConfig_GetExitCode(config: *mut PyInitConfig, exitcode: *mut c_int) -> c_int;
+
+    pub fn PyInitConfig_HasOption(config: *mut PyInitConfig, name: *const c_char) -> c_int;
+    pub fn PyInitConfig_GetInt(config: *mut PyInitConfig, name: *const c_char, value: *mut u64) -> c_int;
+    pub fn PyInitConfig_GetStr(config: *mut PyInitConfig, name: *const c_char, value: *mut *mut c_char) -> c_int;
+    pub fn PyInitConfig_GetStrList(
+        config: *mut PyInitConfig,
+        name: *const c_char,
+        length: *mut usize,
+        items: *mut *mut *mut c_char
+    ) -> c_int;
+    pub fn PyInitConfig_FreeStrList(length: usize, items: *mut *mut c_char);
+
+    pub fn PyInitConfig_SetInt(config: *mut PyInitConfig, name: *const c_char, value: u64) -> c_int;
+    pub fn PyInitConfig_SetStr(config: *mut PyInitConfig, name: *const c_char, value: *const c_char) -> c_int;
+    pub fn PyInitConfig_SetStrList(
+        config: *mut PyInitConfig,
+        name: *const c_char,
+        length: usize,
+        items: *mut *const c_char
+    ) -> c_int;
+
+    pub fn PyInitConfig_AddModule(
+        config: *mut PyInitConfig,
+        name: *const c_char,
+        initfunc: extern "C" fn() -> *mut PyObject
+    ) -> c_int;
+
+    pub fn Py_InitializeFromInitConfig(config: *mut PyInitConfig) -> c_int;
 }

--- a/pyo3-ffi/src/cpython/initconfig.rs
+++ b/pyo3-ffi/src/cpython/initconfig.rs
@@ -246,33 +246,49 @@ extern_libpython! {
     pub fn PyInitConfig_Create() -> *mut PyInitConfig;
     pub fn PyInitConfig_Free(config: *mut PyInitConfig);
 
-    pub fn PyInitConfig_GetError(config: *mut PyInitConfig, err_message: *mut *const c_char) -> c_int;
+    pub fn PyInitConfig_GetError(
+        config: *mut PyInitConfig,
+        err_message: *mut *const c_char,
+    ) -> c_int;
     pub fn PyInitConfig_GetExitCode(config: *mut PyInitConfig, exitcode: *mut c_int) -> c_int;
 
     pub fn PyInitConfig_HasOption(config: *mut PyInitConfig, name: *const c_char) -> c_int;
-    pub fn PyInitConfig_GetInt(config: *mut PyInitConfig, name: *const c_char, value: *mut u64) -> c_int;
-    pub fn PyInitConfig_GetStr(config: *mut PyInitConfig, name: *const c_char, value: *mut *mut c_char) -> c_int;
+    pub fn PyInitConfig_GetInt(
+        config: *mut PyInitConfig,
+        name: *const c_char,
+        value: *mut u64,
+    ) -> c_int;
+    pub fn PyInitConfig_GetStr(
+        config: *mut PyInitConfig,
+        name: *const c_char,
+        value: *mut *mut c_char,
+    ) -> c_int;
     pub fn PyInitConfig_GetStrList(
         config: *mut PyInitConfig,
         name: *const c_char,
         length: *mut usize,
-        items: *mut *mut *mut c_char
+        items: *mut *mut *mut c_char,
     ) -> c_int;
     pub fn PyInitConfig_FreeStrList(length: usize, items: *mut *mut c_char);
 
-    pub fn PyInitConfig_SetInt(config: *mut PyInitConfig, name: *const c_char, value: u64) -> c_int;
-    pub fn PyInitConfig_SetStr(config: *mut PyInitConfig, name: *const c_char, value: *const c_char) -> c_int;
+    pub fn PyInitConfig_SetInt(config: *mut PyInitConfig, name: *const c_char, value: u64)
+        -> c_int;
+    pub fn PyInitConfig_SetStr(
+        config: *mut PyInitConfig,
+        name: *const c_char,
+        value: *const c_char,
+    ) -> c_int;
     pub fn PyInitConfig_SetStrList(
         config: *mut PyInitConfig,
         name: *const c_char,
         length: usize,
-        items: *mut *const c_char
+        items: *mut *const c_char,
     ) -> c_int;
 
     pub fn PyInitConfig_AddModule(
         config: *mut PyInitConfig,
         name: *const c_char,
-        initfunc: extern "C" fn() -> *mut PyObject
+        initfunc: extern "C" fn() -> *mut PyObject,
     ) -> c_int;
 
     pub fn Py_InitializeFromInitConfig(config: *mut PyInitConfig) -> c_int;


### PR DESCRIPTION
Starting with python 3.14, an embedded python interpreter can be initialized from a config.
https://docs.python.org/3/c-api/init_config.html

This PR adds that part of the API to the FFI crate.
https://github.com/python/cpython/blob/ebf955df7a89ed0c7968f79faec1de49f61ed7cb/Include/cpython/initconfig.h#L286-L327

