### PR TITLE
internal: add cfg `wip_feature_std` in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use pyo3_build_config::pyo3_build_script_impl::{
-    cargo_env_var, errors::Result, print_feature_cfgs,
+    cargo_env_var, env_var, errors::Result, print_feature_cfgs,
 };
 use pyo3_build_config::{add_libpython_rpath_link_args, bail, InterpreterConfig};
 
@@ -58,7 +58,7 @@ fn configure_pyo3() -> Result<()> {
 /// Set env var `PYO3_WIP_NO_STD` to `1` to disable it.
 fn configure_wip_no_std() {
     println!("cargo:rustc-check-cfg=cfg(wip_feature_std)");
-    match cargo_env_var("PYO3_WIP_NO_STD") {
+    match env_var("PYO3_WIP_NO_STD").map(|s| s.into_string().unwrap()) {
         Some(no_std) if no_std.trim() == "1" || no_std.trim().eq_ignore_ascii_case("true") => (),
         _ => println!("cargo:rustc-cfg=wip_feature_std"),
     }

--- a/build.rs
+++ b/build.rs
@@ -53,7 +53,19 @@ fn configure_pyo3() -> Result<()> {
     Ok(())
 }
 
+/// Enables a faux `std` feature by default.
+///
+/// Set env var `PYO3_WIP_NO_STD` to `1` to disable it.
+fn configure_wip_no_std() {
+    println!("cargo:rustc-check-cfg=cfg(wip_feature_std)");
+    match cargo_env_var("PYO3_WIP_NO_STD") {
+        Some(no_std) if no_std.trim() == "1" || no_std.trim().eq_ignore_ascii_case("true") => (),
+        _ => println!("cargo:rustc-cfg=wip_feature_std"),
+    }
+}
+
 fn main() {
+    configure_wip_no_std();
     pyo3_build_config::print_expected_cfgs();
     if let Err(e) = configure_pyo3() {
         eprintln!("error: {}", e.report());


### PR DESCRIPTION
Adds a faux `std` feature that is enabled by default. It can be disabled by setting an environment variable at build time: `PYO3_WIP_NO_STD=1`.

It can be used like this:
```rust
#[cfg(wip_feature_std)]
use std::thread;
```

This will be useful while working on `no_std` support. Once `no_std` is ready to be shipped, we can mechanically replace all instances of `wip_feature_std` with `feature(std)` and remove the cfg option.

Discussed here: https://github.com/PyO3/pyo3/pull/6058#discussion_r3379240851