### PR TITLE
Rust API for pyinitconfig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -363,6 +363,10 @@ name = "test_inheritance"
 required-features = ["macros"]
 
 [[test]]
+name = "test_init_config_add_module"
+required-features = ["macros"]
+
+[[test]]
 name = "test_intopyobject"
 required-features = ["macros"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -355,6 +355,10 @@ name = "test_inheritance"
 required-features = ["macros"]
 
 [[test]]
+name = "test_init_config_add_module"
+required-features = ["macros"]
+
+[[test]]
 name = "test_intopyobject"
 required-features = ["macros"]
 

--- a/newsfragments/6173.added.md
+++ b/newsfragments/6173.added.md
@@ -1,0 +1,1 @@
+Initialize embedded interpreter with configuration

--- a/pyo3-ffi/src/cpython/initconfig.rs
+++ b/pyo3-ffi/src/cpython/initconfig.rs
@@ -288,7 +288,7 @@ extern_libpython! {
     pub fn PyInitConfig_AddModule(
         config: *mut PyInitConfig,
         name: *const c_char,
-        initfunc: extern "C" fn() -> *mut PyObject,
+        initfunc: unsafe extern "C" fn() -> *mut PyObject,
     ) -> c_int;
 
     pub fn Py_InitializeFromInitConfig(config: *mut PyInitConfig) -> c_int;

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -125,10 +125,11 @@ impl InitConfig {
 
     /// Set a string list configuration option.
     pub fn set_str_list(&mut self, name: &CStr, items: &[&CStr]) -> Result<(), InitConfigError> {
+        let mut raw_cstrs: Vec<_> = items.iter().map(|cs| cs.as_ptr()).collect();
         self.check_error(
             // SAFETY: pointers are valid
             unsafe {
-                PyInitConfig_SetStrList(self.0, name.as_ptr(), items.len(), items.as_ptr() as _)
+                PyInitConfig_SetStrList(self.0, name.as_ptr(), items.len(), raw_cstrs.as_mut_ptr())
             },
         )
     }

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -44,21 +44,21 @@ impl InitConfig {
     ///
     /// # Panic
     /// Panics if the interpreter is already initialized.
-    pub fn initialize(self) -> Result<Option<c_int>, InitConfigError> {
+    pub fn initialize(self) -> Result<(), InitializeFromConfigError> {
         // SAFETY: points to a valid config object
         let result =
             unsafe { crate::interpreter_lifecycle::initialize_from_config(self.0.as_ptr()) }
                 .expect("python interpreter is already initialized");
         match result {
-            0 => Ok(None),
+            0 => Ok(()),
             -1 => {
                 let mut exitcode = 0;
                 // SAFETY: pointers are valid
                 let result =
                     unsafe { PyInitConfig_GetExitCode(self.0.as_ptr(), &raw mut exitcode) };
                 match result {
-                    0 => Err(self.get_err()),
-                    1 => Ok(Some(exitcode)),
+                    0 => Err(InitializeFromConfigError::Message(self.get_err())),
+                    1 => Err(InitializeFromConfigError::Exit(exitcode)),
                     _ => unreachable!(),
                 }
             }
@@ -178,6 +178,33 @@ impl InitConfig {
         // SAFETY: error message is a null terminated UTF-8 string
         let err_message = unsafe { CStr::from_ptr(err_message).to_str().unwrap_unchecked() };
         InitConfigError(err_message.into())
+    }
+}
+
+/// Error returned by [`InitConfig::initialize`]
+#[derive(Debug)]
+pub enum InitializeFromConfigError {
+    /// The interpreter requested exiting with
+    Exit(c_int),
+
+    /// The error message from the interpreter
+    Message(InitConfigError),
+}
+
+impl From<InitConfigError> for InitializeFromConfigError {
+    fn from(value: InitConfigError) -> Self {
+        Self::Message(value)
+    }
+}
+
+impl core::error::Error for InitializeFromConfigError {}
+
+impl Display for InitializeFromConfigError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Exit(n) => write!(f, "interpreter requested exit with code {n}"),
+            Self::Message(init_config_error) => Display::fmt(init_config_error, f),
+        }
     }
 }
 

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -256,7 +256,7 @@ impl StringListOption {
 
     /// Iterate over the list of strings
     #[inline]
-    pub fn iter(&self) -> StringListOptionIterator {
+    pub fn iter(&self) -> StringListOptionIterator<'_> {
         StringListOptionIterator {
             list: self,
             current: 0,

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -65,7 +65,7 @@ impl InitConfig {
         }
     }
 
-    /// Check if the configuation has an option called `name`.
+    /// Check if the configuration has an option called `name`.
     pub fn has_option(&self, name: &CStr) -> bool {
         // SAFETY: pointers are valid
         (unsafe { PyInitConfig_HasOption(self.0, name.as_ptr()) }) == 1

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -1,0 +1,247 @@
+use core::ffi::{c_char, c_int, CStr};
+use core::fmt::Display;
+use core::iter::FusedIterator;
+use core::ops::{Deref, Index};
+use core::ptr::{self, NonNull};
+
+use crate::platform::prelude::*;
+
+use pyo3_ffi::{
+    PyInitConfig_AddModule, PyInitConfig_Create, PyInitConfig_Free, PyInitConfig_FreeStrList,
+    PyInitConfig_GetError, PyInitConfig_GetExitCode, PyInitConfig_GetInt, PyInitConfig_GetStr,
+    PyInitConfig_GetStrList, PyInitConfig_HasOption, PyInitConfig_SetInt, PyInitConfig_SetStr,
+    PyInitConfig_SetStrList, PyObject,
+};
+
+pub struct InitConfig(*mut crate::ffi::PyInitConfig);
+
+impl Default for InitConfig {
+    /// Creates a new initialization configuration using isolated configuration default values.
+    fn default() -> Self {
+        // SAFETY: no requirements
+        let inner = unsafe { PyInitConfig_Create() };
+        assert!(!inner.is_null());
+        Self(inner)
+    }
+}
+
+impl Drop for InitConfig {
+    fn drop(&mut self) {
+        // SAFETY: pointer was returned by PyInitConfig_Create
+        unsafe { PyInitConfig_Free(self.0) };
+    }
+}
+
+impl InitConfig {
+    pub fn initialize(self) -> Result<Option<c_int>, InitConfigError> {
+        let result = unsafe { crate::interpreter_lifecycle::initialize_from_config(self.0) }
+            .expect("python interpreter is already initialized");
+        match result {
+            0 => Ok(None),
+            -1 => {
+                let mut exitcode = 0;
+                let result = unsafe { PyInitConfig_GetExitCode(self.0, &raw mut exitcode) };
+                match result {
+                    0 => Err(self.get_err()),
+                    1 => Ok(Some(exitcode)),
+                    _ => unreachable!(),
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn has_option(&self, name: &CStr) -> bool {
+        (unsafe { PyInitConfig_HasOption(self.0, name.as_ptr()) }) == 1
+    }
+
+    pub fn get_int(&self, name: &CStr) -> Result<u64, InitConfigError> {
+        let mut value = 1;
+        self.check_error(unsafe { PyInitConfig_GetInt(self.0, name.as_ptr(), &raw mut value) })?;
+        Ok(value)
+    }
+
+    pub fn get_str(&self, name: &CStr) -> Result<Option<StringOption>, InitConfigError> {
+        let mut value = ptr::null_mut();
+        self.check_error(unsafe { PyInitConfig_GetStr(self.0, name.as_ptr(), &raw mut value) })?;
+        Ok(NonNull::new(value).map(StringOption))
+    }
+
+    pub fn get_str_list(&self, name: &CStr) -> Result<StringListOption, InitConfigError> {
+        let mut length = 0;
+        let mut items = ptr::null_mut();
+        self.check_error(unsafe {
+            PyInitConfig_GetStrList(self.0, name.as_ptr(), &raw mut length, &raw mut items)
+        })?;
+        Ok(StringListOption {
+            length,
+            items: NonNull::new(items).unwrap(),
+        })
+    }
+
+    pub fn set_int(&self, name: &CStr, value: u64) -> Result<(), InitConfigError> {
+        self.check_error(unsafe { PyInitConfig_SetInt(self.0, name.as_ptr(), value) })
+    }
+
+    pub fn set_str(&self, name: &CStr, value: &CStr) -> Result<(), InitConfigError> {
+        self.check_error(unsafe { PyInitConfig_SetStr(self.0, name.as_ptr(), value.as_ptr()) })
+    }
+
+    pub fn set_str_list(&self, name: &CStr, items: &[&CStr]) -> Result<(), InitConfigError> {
+        self.check_error(unsafe {
+            PyInitConfig_SetStrList(self.0, name.as_ptr(), items.len(), items.as_ptr() as _)
+        })
+    }
+
+    #[doc(hidden)]
+    pub fn add_module(
+        &self,
+        name: &CStr,
+        initfunc: extern "C" fn() -> *mut PyObject,
+    ) -> Result<(), InitConfigError> {
+        self.check_error(unsafe { PyInitConfig_AddModule(self.0, name.as_ptr(), initfunc) })
+    }
+
+    #[track_caller]
+    fn check_error(&self, result: c_int) -> Result<(), InitConfigError> {
+        match result {
+            0 => Ok(()),
+            -1 => Err(self.get_err()),
+            n => unreachable!("PyInitConfig c-api function should return 0 or -1, got {n}"),
+        }
+    }
+
+    #[track_caller]
+    fn get_err(&self) -> InitConfigError {
+        let mut err_message: *const c_char = ptr::null();
+        assert_eq!(
+            (unsafe { PyInitConfig_GetError(self.0, &raw mut err_message) }),
+            1,
+            "PyInitConfig error message not set"
+        );
+        let err_message = unsafe { CStr::from_ptr(err_message).to_str().unwrap_unchecked() };
+        InitConfigError(err_message.into())
+    }
+}
+
+#[derive(Debug)]
+pub struct InitConfigError(Box<str>);
+
+impl Display for InitConfigError {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl core::error::Error for InitConfigError {}
+
+pub struct StringOption(NonNull<c_char>);
+
+impl Deref for StringOption {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: pointer received from python
+        unsafe { CStr::from_ptr(self.0.as_ptr()) }.to_str().unwrap()
+    }
+}
+
+impl Drop for StringOption {
+    fn drop(&mut self) {
+        // SAFETY: permitted (and required) as per cpython docs
+        //         https://docs.python.org/3/c-api/init_config.html#c.PyInitConfig_GetStr
+        unsafe { libc::free(self.0.as_ptr().cast()) };
+    }
+}
+
+pub struct StringListOption {
+    length: usize,
+    items: NonNull<*mut c_char>,
+}
+
+impl Drop for StringListOption {
+    fn drop(&mut self) {
+        // SAFETY: permitted (and required) as per cpython docs
+        //         https://docs.python.org/3/c-api/init_config.html#c.PyInitConfig_GetStrList
+        unsafe { PyInitConfig_FreeStrList(self.length, self.items.as_ptr()) };
+    }
+}
+
+impl Index<usize> for StringListOption {
+    type Output = str;
+
+    #[inline(always)]
+    #[track_caller]
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).unwrap()
+    }
+}
+
+impl<'a> IntoIterator for &'a StringListOption {
+    type Item = &'a str;
+    type IntoIter = StringListOptionIterator<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl StringListOption {
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&str> {
+        if index >= self.length {
+            None
+        } else {
+            let array_ptr = self.items.as_ptr();
+            Some(unsafe {
+                let item_ptr = *array_ptr.add(index);
+                CStr::from_ptr(item_ptr).to_str().unwrap_unchecked()
+            })
+        }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> StringListOptionIterator {
+        StringListOptionIterator {
+            list: self,
+            current: 0,
+        }
+    }
+}
+
+pub struct StringListOptionIterator<'a> {
+    list: &'a StringListOption,
+    current: usize,
+}
+
+impl<'a> Iterator for StringListOptionIterator<'a> {
+    type Item = &'a str;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current < self.list.length {
+            let item = self.list.get(self.current).unwrap();
+            self.current += 1;
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for StringListOptionIterator<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.list.length
+    }
+}
+
+impl FusedIterator for StringListOptionIterator<'_> {}

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -20,22 +20,21 @@ use pyo3_ffi::{
 /// [Here][1] is a list of configuration options.
 ///
 /// [1]: https://docs.python.org/3/c-api/init_config.html#configuration-options
-pub struct InitConfig(*mut crate::ffi::PyInitConfig);
+pub struct InitConfig(NonNull<crate::ffi::PyInitConfig>);
 
 impl Default for InitConfig {
     /// Creates a new initialization configuration using isolated configuration default values.
     fn default() -> Self {
         // SAFETY: no requirements
         let inner = unsafe { PyInitConfig_Create() };
-        assert!(!inner.is_null());
-        Self(inner)
+        Self(NonNull::new(inner).unwrap())
     }
 }
 
 impl Drop for InitConfig {
     fn drop(&mut self) {
         // SAFETY: pointer was returned by PyInitConfig_Create
-        unsafe { PyInitConfig_Free(self.0) };
+        unsafe { PyInitConfig_Free(self.0.as_ptr()) };
     }
 }
 
@@ -47,14 +46,16 @@ impl InitConfig {
     /// Panics if the interpreter is already initialized.
     pub fn initialize(self) -> Result<Option<c_int>, InitConfigError> {
         // SAFETY: points to a valid config object
-        let result = unsafe { crate::interpreter_lifecycle::initialize_from_config(self.0) }
-            .expect("python interpreter is already initialized");
+        let result =
+            unsafe { crate::interpreter_lifecycle::initialize_from_config(self.0.as_ptr()) }
+                .expect("python interpreter is already initialized");
         match result {
             0 => Ok(None),
             -1 => {
                 let mut exitcode = 0;
                 // SAFETY: pointers are valid
-                let result = unsafe { PyInitConfig_GetExitCode(self.0, &raw mut exitcode) };
+                let result =
+                    unsafe { PyInitConfig_GetExitCode(self.0.as_ptr(), &raw mut exitcode) };
                 match result {
                     0 => Err(self.get_err()),
                     1 => Ok(Some(exitcode)),
@@ -68,7 +69,7 @@ impl InitConfig {
     /// Check if the configuration has an option called `name`.
     pub fn has_option(&self, name: &CStr) -> bool {
         // SAFETY: pointers are valid
-        (unsafe { PyInitConfig_HasOption(self.0, name.as_ptr()) }) == 1
+        (unsafe { PyInitConfig_HasOption(self.0.as_ptr(), name.as_ptr()) }) == 1
     }
 
     /// Get an integer configuration option.
@@ -76,7 +77,7 @@ impl InitConfig {
         let mut value = 1;
         self.check_error(
             // SAFETY: pointers are valid
-            unsafe { PyInitConfig_GetInt(self.0, name.as_ptr(), &raw mut value) },
+            unsafe { PyInitConfig_GetInt(self.0.as_ptr(), name.as_ptr(), &raw mut value) },
         )?;
         Ok(value)
     }
@@ -86,7 +87,7 @@ impl InitConfig {
         let mut value = ptr::null_mut();
         self.check_error(
             // SAFETY: pointers are valid
-            unsafe { PyInitConfig_GetStr(self.0, name.as_ptr(), &raw mut value) },
+            unsafe { PyInitConfig_GetStr(self.0.as_ptr(), name.as_ptr(), &raw mut value) },
         )?;
         Ok(NonNull::new(value).map(StringOption))
     }
@@ -98,7 +99,12 @@ impl InitConfig {
         self.check_error(
             // SAFETY: pointers are valid
             unsafe {
-                PyInitConfig_GetStrList(self.0, name.as_ptr(), &raw mut length, &raw mut items)
+                PyInitConfig_GetStrList(
+                    self.0.as_ptr(),
+                    name.as_ptr(),
+                    &raw mut length,
+                    &raw mut items,
+                )
             },
         )?;
         Ok(StringListOption {
@@ -111,7 +117,7 @@ impl InitConfig {
     pub fn set_int(&mut self, name: &CStr, value: u64) -> Result<(), InitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
-            unsafe { PyInitConfig_SetInt(self.0, name.as_ptr(), value) },
+            unsafe { PyInitConfig_SetInt(self.0.as_ptr(), name.as_ptr(), value) },
         )
     }
 
@@ -119,7 +125,7 @@ impl InitConfig {
     pub fn set_str(&mut self, name: &CStr, value: &CStr) -> Result<(), InitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
-            unsafe { PyInitConfig_SetStr(self.0, name.as_ptr(), value.as_ptr()) },
+            unsafe { PyInitConfig_SetStr(self.0.as_ptr(), name.as_ptr(), value.as_ptr()) },
         )
     }
 
@@ -129,7 +135,12 @@ impl InitConfig {
         self.check_error(
             // SAFETY: pointers are valid
             unsafe {
-                PyInitConfig_SetStrList(self.0, name.as_ptr(), items.len(), raw_cstrs.as_mut_ptr())
+                PyInitConfig_SetStrList(
+                    self.0.as_ptr(),
+                    name.as_ptr(),
+                    items.len(),
+                    raw_cstrs.as_mut_ptr(),
+                )
             },
         )
     }
@@ -142,7 +153,7 @@ impl InitConfig {
     ) -> Result<(), InitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
-            unsafe { PyInitConfig_AddModule(self.0, name.as_ptr(), initfunc) },
+            unsafe { PyInitConfig_AddModule(self.0.as_ptr(), name.as_ptr(), initfunc) },
         )
     }
 
@@ -160,7 +171,7 @@ impl InitConfig {
         let mut err_message: *const c_char = ptr::null();
         assert_eq!(
             // SAFETY: pointers are valid
-            (unsafe { PyInitConfig_GetError(self.0, &raw mut err_message) }),
+            (unsafe { PyInitConfig_GetError(self.0.as_ptr(), &raw mut err_message) }),
             1,
             "PyInitConfig error message not set"
         );

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -317,6 +317,7 @@ mod tests {
         let mut config = InitConfig::default();
 
         config.set_int(c"non-existing", 0).unwrap_err();
+        assert!(config.get_int(c"non-existing").is_err());
 
         config.set_int(c"optimization_level", 100).unwrap();
         assert_eq!(100, config.get_int(c"optimization_level").unwrap());
@@ -330,6 +331,7 @@ mod tests {
         let mut config = InitConfig::default();
 
         config.set_str(c"non-existing", c"hello").unwrap_err();
+        assert!(config.get_str(c"non-existing").is_err());
 
         config.set_str(c"base_exec_prefix", c"/some/path").unwrap();
         assert_eq!(
@@ -348,12 +350,18 @@ mod tests {
         config
             .set_str_list(c"non-existing", &[c"hello"])
             .unwrap_err();
+        assert!(config.get_str_list(c"non-existing").is_err());
 
         config.set_str_list(c"argv", &[c"hello", c"world"]).unwrap();
         let list = config.get_str_list(c"argv").unwrap();
         assert_eq!("hello", list.get(0).unwrap());
         assert_eq!("world", list.get(1).unwrap());
         assert!(list.get(2).is_none());
+
+        let v = Vec::from_iter(&list);
+        assert_eq!("hello", v[0]);
+        assert_eq!("world", v[1]);
+        assert_eq!(2, v.len());
 
         // `optimization_level` is not a str list option
         config

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -1,3 +1,5 @@
+//! This module holds the [`InitConfig`] struct, see struct level docs for more detail.
+
 use core::ffi::{c_char, c_int, CStr};
 use core::fmt::Display;
 use core::iter::FusedIterator;
@@ -13,6 +15,11 @@ use pyo3_ffi::{
     PyInitConfig_SetStrList, PyObject,
 };
 
+/// Holds configuration that can be used to initialized the python interpreter.
+///
+/// [Here][1] is a list of configuration options.
+///
+/// [1]: https://docs.python.org/3/c-api/init_config.html#configuration-options
 pub struct InitConfig(*mut crate::ffi::PyInitConfig);
 
 impl Default for InitConfig {
@@ -33,13 +40,20 @@ impl Drop for InitConfig {
 }
 
 impl InitConfig {
+    /// Initializes the python interpreter from the configuration. On success it returns the exit code
+    /// requested by the interpreter, if present.
+    ///
+    /// # Panic
+    /// Panics if the interpreter is already initialized.
     pub fn initialize(self) -> Result<Option<c_int>, InitConfigError> {
+        // SAFETY: points to a valid config object
         let result = unsafe { crate::interpreter_lifecycle::initialize_from_config(self.0) }
             .expect("python interpreter is already initialized");
         match result {
             0 => Ok(None),
             -1 => {
                 let mut exitcode = 0;
+                // SAFETY: pointers are valid
                 let result = unsafe { PyInitConfig_GetExitCode(self.0, &raw mut exitcode) };
                 match result {
                     0 => Err(self.get_err()),
@@ -51,46 +65,72 @@ impl InitConfig {
         }
     }
 
+    /// Check if the configuation has an option called `name`.
     pub fn has_option(&self, name: &CStr) -> bool {
+        // SAFETY: pointers are valid
         (unsafe { PyInitConfig_HasOption(self.0, name.as_ptr()) }) == 1
     }
 
+    /// Get an integer configuration option.
     pub fn get_int(&self, name: &CStr) -> Result<u64, InitConfigError> {
         let mut value = 1;
-        self.check_error(unsafe { PyInitConfig_GetInt(self.0, name.as_ptr(), &raw mut value) })?;
+        self.check_error(
+            // SAFETY: pointers are valid
+            unsafe { PyInitConfig_GetInt(self.0, name.as_ptr(), &raw mut value) },
+        )?;
         Ok(value)
     }
 
+    /// Get a string configuration option.
     pub fn get_str(&self, name: &CStr) -> Result<Option<StringOption>, InitConfigError> {
         let mut value = ptr::null_mut();
-        self.check_error(unsafe { PyInitConfig_GetStr(self.0, name.as_ptr(), &raw mut value) })?;
+        self.check_error(
+            // SAFETY: pointers are valid
+            unsafe { PyInitConfig_GetStr(self.0, name.as_ptr(), &raw mut value) },
+        )?;
         Ok(NonNull::new(value).map(StringOption))
     }
 
+    /// Get a string list configuration option.
     pub fn get_str_list(&self, name: &CStr) -> Result<StringListOption, InitConfigError> {
         let mut length = 0;
         let mut items = ptr::null_mut();
-        self.check_error(unsafe {
-            PyInitConfig_GetStrList(self.0, name.as_ptr(), &raw mut length, &raw mut items)
-        })?;
+        self.check_error(
+            // SAFETY: pointers are valid
+            unsafe {
+                PyInitConfig_GetStrList(self.0, name.as_ptr(), &raw mut length, &raw mut items)
+            },
+        )?;
         Ok(StringListOption {
             length,
             items: NonNull::new(items).unwrap(),
         })
     }
 
+    /// Set an integer configuration option.
     pub fn set_int(&self, name: &CStr, value: u64) -> Result<(), InitConfigError> {
-        self.check_error(unsafe { PyInitConfig_SetInt(self.0, name.as_ptr(), value) })
+        self.check_error(
+            // SAFETY: pointers are valid
+            unsafe { PyInitConfig_SetInt(self.0, name.as_ptr(), value) },
+        )
     }
 
+    /// Set a string configuration option.
     pub fn set_str(&self, name: &CStr, value: &CStr) -> Result<(), InitConfigError> {
-        self.check_error(unsafe { PyInitConfig_SetStr(self.0, name.as_ptr(), value.as_ptr()) })
+        self.check_error(
+            // SAFETY: pointers are valid
+            unsafe { PyInitConfig_SetStr(self.0, name.as_ptr(), value.as_ptr()) },
+        )
     }
 
+    /// Set a string list configuration option.
     pub fn set_str_list(&self, name: &CStr, items: &[&CStr]) -> Result<(), InitConfigError> {
-        self.check_error(unsafe {
-            PyInitConfig_SetStrList(self.0, name.as_ptr(), items.len(), items.as_ptr() as _)
-        })
+        self.check_error(
+            // SAFETY: pointers are valid
+            unsafe {
+                PyInitConfig_SetStrList(self.0, name.as_ptr(), items.len(), items.as_ptr() as _)
+            },
+        )
     }
 
     #[doc(hidden)]
@@ -99,7 +139,10 @@ impl InitConfig {
         name: &CStr,
         initfunc: extern "C" fn() -> *mut PyObject,
     ) -> Result<(), InitConfigError> {
-        self.check_error(unsafe { PyInitConfig_AddModule(self.0, name.as_ptr(), initfunc) })
+        self.check_error(
+            // SAFETY: pointers are valid
+            unsafe { PyInitConfig_AddModule(self.0, name.as_ptr(), initfunc) },
+        )
     }
 
     #[track_caller]
@@ -115,15 +158,18 @@ impl InitConfig {
     fn get_err(&self) -> InitConfigError {
         let mut err_message: *const c_char = ptr::null();
         assert_eq!(
+            // SAFETY: pointers are valid
             (unsafe { PyInitConfig_GetError(self.0, &raw mut err_message) }),
             1,
             "PyInitConfig error message not set"
         );
+        // SAFETY: error message is a null terminated UTF-8 string
         let err_message = unsafe { CStr::from_ptr(err_message).to_str().unwrap_unchecked() };
         InitConfigError(err_message.into())
     }
 }
 
+/// Error type when [`InitConfig`] methods fail
 #[derive(Debug)]
 pub struct InitConfigError(Box<str>);
 
@@ -136,6 +182,8 @@ impl Display for InitConfigError {
 
 impl core::error::Error for InitConfigError {}
 
+/// A string option for python configuration, returned by [`InitConfig::get_str`].
+// NOTE: this cannot use a string because the memory needs to be freed with [`libc::free`]
 pub struct StringOption(NonNull<c_char>);
 
 impl Deref for StringOption {
@@ -155,6 +203,7 @@ impl Drop for StringOption {
     }
 }
 
+/// A list of strings for a python configuration option, returned by [`InitConfig::get_str_list`].
 pub struct StringListOption {
     length: usize,
     items: NonNull<*mut c_char>,
@@ -189,12 +238,15 @@ impl<'a> IntoIterator for &'a StringListOption {
 }
 
 impl StringListOption {
+    /// Get a string from the list. Returns [`None`] if index is out of bounds.
     #[inline]
     pub fn get(&self, index: usize) -> Option<&str> {
         if index >= self.length {
             None
         } else {
             let array_ptr = self.items.as_ptr();
+            // SAFETY: PyInitConfig_GetStrList returns an array of null terminated UTF-8 strings
+            //         and we just checked if the index is out of bounds.
             Some(unsafe {
                 let item_ptr = *array_ptr.add(index);
                 CStr::from_ptr(item_ptr).to_str().unwrap_unchecked()
@@ -202,6 +254,7 @@ impl StringListOption {
         }
     }
 
+    /// Iterate over the list of strings
     #[inline]
     pub fn iter(&self) -> StringListOptionIterator {
         StringListOptionIterator {
@@ -211,6 +264,7 @@ impl StringListOption {
     }
 }
 
+/// Iterator for [`StringListOption`]
 pub struct StringListOptionIterator<'a> {
     list: &'a StringListOption,
     current: usize,

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -138,7 +138,7 @@ impl InitConfig {
     pub fn add_module(
         &mut self,
         name: &CStr,
-        initfunc: extern "C" fn() -> *mut PyObject,
+        initfunc: unsafe extern "C" fn() -> *mut PyObject,
     ) -> Result<(), InitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -299,3 +299,64 @@ impl ExactSizeIterator for StringListOptionIterator<'_> {
 }
 
 impl FusedIterator for StringListOptionIterator<'_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_option() {
+        let config = InitConfig::default();
+        assert!(config.has_option(c"allocator"));
+        assert!(!config.has_option(c"non-existing"));
+    }
+
+    #[test]
+    fn int_option() {
+        let mut config = InitConfig::default();
+
+        config.set_int(c"non-existing", 0).unwrap_err();
+
+        config.set_int(c"optimization_level", 100).unwrap();
+        assert_eq!(100, config.get_int(c"optimization_level").unwrap());
+
+        // `base_exec_prefix` is not an int option
+        config.set_int(c"base_exec_prefix", 1).unwrap_err();
+    }
+
+    #[test]
+    fn str_option() {
+        let mut config = InitConfig::default();
+
+        config.set_str(c"non-existing", c"hello").unwrap_err();
+
+        config.set_str(c"base_exec_prefix", c"/some/path").unwrap();
+        assert_eq!(
+            "/some/path",
+            &*config.get_str(c"base_exec_prefix").unwrap().unwrap()
+        );
+
+        // `optimization_level` is not a str option
+        config.set_str(c"optimization_level", c"hello").unwrap_err();
+    }
+
+    #[test]
+    fn str_list_option() {
+        let mut config = InitConfig::default();
+
+        config
+            .set_str_list(c"non-existing", &[c"hello"])
+            .unwrap_err();
+
+        config.set_str_list(c"argv", &[c"hello", c"world"]).unwrap();
+        let list = config.get_str_list(c"argv").unwrap();
+        assert_eq!("hello", list.get(0).unwrap());
+        assert_eq!("world", list.get(1).unwrap());
+        assert!(list.get(2).is_none());
+
+        // `optimization_level` is not a str list option
+        config
+            .set_str_list(c"optimization_level", &[c"hello"])
+            .unwrap_err();
+    }
+}

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -108,7 +108,7 @@ impl InitConfig {
     }
 
     /// Set an integer configuration option.
-    pub fn set_int(&self, name: &CStr, value: u64) -> Result<(), InitConfigError> {
+    pub fn set_int(&mut self, name: &CStr, value: u64) -> Result<(), InitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
             unsafe { PyInitConfig_SetInt(self.0, name.as_ptr(), value) },
@@ -116,7 +116,7 @@ impl InitConfig {
     }
 
     /// Set a string configuration option.
-    pub fn set_str(&self, name: &CStr, value: &CStr) -> Result<(), InitConfigError> {
+    pub fn set_str(&mut self, name: &CStr, value: &CStr) -> Result<(), InitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
             unsafe { PyInitConfig_SetStr(self.0, name.as_ptr(), value.as_ptr()) },
@@ -124,7 +124,7 @@ impl InitConfig {
     }
 
     /// Set a string list configuration option.
-    pub fn set_str_list(&self, name: &CStr, items: &[&CStr]) -> Result<(), InitConfigError> {
+    pub fn set_str_list(&mut self, name: &CStr, items: &[&CStr]) -> Result<(), InitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
             unsafe {
@@ -135,7 +135,7 @@ impl InitConfig {
 
     #[doc(hidden)]
     pub fn add_module(
-        &self,
+        &mut self,
         name: &CStr,
         initfunc: extern "C" fn() -> *mut PyObject,
     ) -> Result<(), InitConfigError> {

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -39,8 +39,7 @@ impl Drop for InitConfig {
 }
 
 impl InitConfig {
-    /// Initializes the python interpreter from the configuration. On success it returns the exit code
-    /// requested by the interpreter, if present.
+    /// Initializes the python interpreter from the configuration.
     ///
     /// # Panic
     /// Panics if the interpreter is already initialized.

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -20,9 +20,9 @@ use pyo3_ffi::{
 /// [Here][1] is a list of configuration options.
 ///
 /// [1]: https://docs.python.org/3/c-api/init_config.html#configuration-options
-pub struct InitConfig(NonNull<crate::ffi::PyInitConfig>);
+pub struct PyInitConfig(NonNull<crate::ffi::PyInitConfig>);
 
-impl Default for InitConfig {
+impl Default for PyInitConfig {
     /// Creates a new initialization configuration using isolated configuration default values.
     fn default() -> Self {
         // SAFETY: no requirements
@@ -31,14 +31,14 @@ impl Default for InitConfig {
     }
 }
 
-impl Drop for InitConfig {
+impl Drop for PyInitConfig {
     fn drop(&mut self) {
         // SAFETY: pointer was returned by PyInitConfig_Create
         unsafe { PyInitConfig_Free(self.0.as_ptr()) };
     }
 }
 
-impl InitConfig {
+impl PyInitConfig {
     /// Initializes the python interpreter from the configuration.
     ///
     /// # Panic
@@ -72,7 +72,7 @@ impl InitConfig {
     }
 
     /// Get an integer configuration option.
-    pub fn get_int(&self, name: &CStr) -> Result<u64, InitConfigError> {
+    pub fn get_int(&self, name: &CStr) -> Result<u64, PyInitConfigError> {
         let mut value = 1;
         self.check_error(
             // SAFETY: pointers are valid
@@ -82,7 +82,7 @@ impl InitConfig {
     }
 
     /// Get a string configuration option.
-    pub fn get_str(&self, name: &CStr) -> Result<Option<StringOption>, InitConfigError> {
+    pub fn get_str(&self, name: &CStr) -> Result<Option<StringOption>, PyInitConfigError> {
         let mut value = ptr::null_mut();
         self.check_error(
             // SAFETY: pointers are valid
@@ -92,7 +92,7 @@ impl InitConfig {
     }
 
     /// Get a string list configuration option.
-    pub fn get_str_list(&self, name: &CStr) -> Result<StringListOption, InitConfigError> {
+    pub fn get_str_list(&self, name: &CStr) -> Result<StringListOption, PyInitConfigError> {
         let mut length = 0;
         let mut items = ptr::null_mut();
         self.check_error(
@@ -113,7 +113,7 @@ impl InitConfig {
     }
 
     /// Set an integer configuration option.
-    pub fn set_int(&mut self, name: &CStr, value: u64) -> Result<(), InitConfigError> {
+    pub fn set_int(&mut self, name: &CStr, value: u64) -> Result<(), PyInitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
             unsafe { PyInitConfig_SetInt(self.0.as_ptr(), name.as_ptr(), value) },
@@ -121,7 +121,7 @@ impl InitConfig {
     }
 
     /// Set a string configuration option.
-    pub fn set_str(&mut self, name: &CStr, value: &CStr) -> Result<(), InitConfigError> {
+    pub fn set_str(&mut self, name: &CStr, value: &CStr) -> Result<(), PyInitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
             unsafe { PyInitConfig_SetStr(self.0.as_ptr(), name.as_ptr(), value.as_ptr()) },
@@ -129,7 +129,7 @@ impl InitConfig {
     }
 
     /// Set a string list configuration option.
-    pub fn set_str_list(&mut self, name: &CStr, items: &[&CStr]) -> Result<(), InitConfigError> {
+    pub fn set_str_list(&mut self, name: &CStr, items: &[&CStr]) -> Result<(), PyInitConfigError> {
         let mut raw_cstrs: Vec<_> = items.iter().map(|cs| cs.as_ptr()).collect();
         self.check_error(
             // SAFETY: pointers are valid
@@ -149,7 +149,7 @@ impl InitConfig {
         &mut self,
         name: &CStr,
         initfunc: unsafe extern "C" fn() -> *mut PyObject,
-    ) -> Result<(), InitConfigError> {
+    ) -> Result<(), PyInitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
             unsafe { PyInitConfig_AddModule(self.0.as_ptr(), name.as_ptr(), initfunc) },
@@ -157,7 +157,7 @@ impl InitConfig {
     }
 
     #[track_caller]
-    fn check_error(&self, result: c_int) -> Result<(), InitConfigError> {
+    fn check_error(&self, result: c_int) -> Result<(), PyInitConfigError> {
         match result {
             0 => Ok(()),
             -1 => Err(self.get_err()),
@@ -166,7 +166,7 @@ impl InitConfig {
     }
 
     #[track_caller]
-    fn get_err(&self) -> InitConfigError {
+    fn get_err(&self) -> PyInitConfigError {
         let mut err_message: *const c_char = ptr::null();
         assert_eq!(
             // SAFETY: pointers are valid
@@ -176,7 +176,7 @@ impl InitConfig {
         );
         // SAFETY: error message is a null terminated UTF-8 string
         let err_message = unsafe { CStr::from_ptr(err_message).to_str().unwrap_unchecked() };
-        InitConfigError(err_message.into())
+        PyInitConfigError(err_message.into())
     }
 }
 
@@ -187,11 +187,11 @@ pub enum InitializeFromConfigError {
     Exit(c_int),
 
     /// The error message from the interpreter
-    Message(InitConfigError),
+    Message(PyInitConfigError),
 }
 
-impl From<InitConfigError> for InitializeFromConfigError {
-    fn from(value: InitConfigError) -> Self {
+impl From<PyInitConfigError> for InitializeFromConfigError {
+    fn from(value: PyInitConfigError) -> Self {
         Self::Message(value)
     }
 }
@@ -209,16 +209,16 @@ impl Display for InitializeFromConfigError {
 
 /// Error type when [`InitConfig`] methods fail
 #[derive(Debug)]
-pub struct InitConfigError(Box<str>);
+pub struct PyInitConfigError(Box<str>);
 
-impl Display for InitConfigError {
+impl Display for PyInitConfigError {
     #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         Display::fmt(&self.0, f)
     }
 }
 
-impl core::error::Error for InitConfigError {}
+impl core::error::Error for PyInitConfigError {}
 
 /// A string option for python configuration, returned by [`InitConfig::get_str`].
 // NOTE: this cannot use a string because the memory needs to be freed with [`libc::free`]
@@ -344,14 +344,14 @@ mod tests {
 
     #[test]
     fn has_option() {
-        let config = InitConfig::default();
+        let config = PyInitConfig::default();
         assert!(config.has_option(c"allocator"));
         assert!(!config.has_option(c"non-existing"));
     }
 
     #[test]
     fn int_option() {
-        let mut config = InitConfig::default();
+        let mut config = PyInitConfig::default();
 
         config.set_int(c"non-existing", 0).unwrap_err();
         assert!(config.get_int(c"non-existing").is_err());
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn str_option() {
-        let mut config = InitConfig::default();
+        let mut config = PyInitConfig::default();
 
         config.set_str(c"non-existing", c"hello").unwrap_err();
         assert!(config.get_str(c"non-existing").is_err());
@@ -382,7 +382,7 @@ mod tests {
 
     #[test]
     fn str_list_option() {
-        let mut config = InitConfig::default();
+        let mut config = PyInitConfig::default();
 
         config
             .set_str_list(c"non-existing", &[c"hello"])

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -43,7 +43,7 @@ impl InitConfig {
     ///
     /// # Panic
     /// Panics if the interpreter is already initialized.
-    pub fn initialize(self) -> Result<(), InitializeFromConfigError> {
+    pub(crate) fn initialize(self) -> Result<(), InitializeFromConfigError> {
         // SAFETY: points to a valid config object
         let result =
             unsafe { crate::interpreter_lifecycle::initialize_from_config(self.0.as_ptr()) }

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -144,15 +144,14 @@ impl PyInitConfig {
         )
     }
 
-    #[doc(hidden)]
-    pub fn add_module(
-        &mut self,
-        name: &CStr,
-        initfunc: unsafe extern "C" fn() -> *mut PyObject,
-    ) -> Result<(), PyInitConfigError> {
+    /// Add the module to the configuration so that the embedded interpreter initialized from this config
+    /// can use it.
+    ///
+    /// Create a [`PyModuleInitInfo`] with the macro [`pymodule_init_info`](crate::pymodule_init_info).
+    pub fn add_module(&mut self, module: PyModuleInitInfo) -> Result<(), PyInitConfigError> {
         self.check_error(
             // SAFETY: pointers are valid
-            unsafe { PyInitConfig_AddModule(self.0.as_ptr(), name.as_ptr(), initfunc) },
+            unsafe { PyInitConfig_AddModule(self.0.as_ptr(), module.name.as_ptr(), module.init) },
         )
     }
 
@@ -177,6 +176,21 @@ impl PyInitConfig {
         // SAFETY: error message is a null terminated UTF-8 string
         let err_message = unsafe { CStr::from_ptr(err_message).to_str().unwrap_unchecked() };
         PyInitConfigError(err_message.into())
+    }
+}
+
+/// Argument to [`PyInitConfig::add_module`].
+///
+/// Created with macro [`pymodule_init_info`](crate::pymodule_init_info).
+pub struct PyModuleInitInfo {
+    name: &'static CStr,
+    init: unsafe extern "C" fn() -> *mut PyObject,
+}
+
+impl PyModuleInitInfo {
+    #[doc(hidden)]
+    pub fn new(name: &'static CStr, init: unsafe extern "C" fn() -> *mut PyObject) -> Self {
+        Self { name, init }
     }
 }
 

--- a/src/init_config.rs
+++ b/src/init_config.rs
@@ -1,4 +1,4 @@
-//! This module holds the [`InitConfig`] struct, see struct level docs for more detail.
+//! This module holds the [`PyInitConfig`] struct, see struct level docs for more detail.
 
 use core::ffi::{c_char, c_int, CStr};
 use core::fmt::Display;
@@ -194,7 +194,7 @@ impl PyModuleInitInfo {
     }
 }
 
-/// Error returned by [`InitConfig::initialize`]
+/// Error returned by [`Python::initialize_from_init_config`](crate::Python::initialize_from_init_config)
 #[derive(Debug)]
 pub enum InitializeFromConfigError {
     /// The interpreter requested exiting with
@@ -221,7 +221,7 @@ impl Display for InitializeFromConfigError {
     }
 }
 
-/// Error type when [`InitConfig`] methods fail
+/// Error type when [`PyInitConfig`] methods fail
 #[derive(Debug)]
 pub struct PyInitConfigError(Box<str>);
 
@@ -234,7 +234,7 @@ impl Display for PyInitConfigError {
 
 impl core::error::Error for PyInitConfigError {}
 
-/// A string option for python configuration, returned by [`InitConfig::get_str`].
+/// A string option for python configuration, returned by [`PyInitConfig::get_str`].
 // NOTE: this cannot use a string because the memory needs to be freed with [`libc::free`]
 pub struct StringOption(NonNull<c_char>);
 
@@ -255,7 +255,7 @@ impl Drop for StringOption {
     }
 }
 
-/// A list of strings for a python configuration option, returned by [`InitConfig::get_str_list`].
+/// A list of strings for a python configuration option, returned by [`PyInitConfig::get_str_list`].
 pub struct StringListOption {
     length: usize,
     items: NonNull<*mut c_char>,

--- a/src/interpreter_lifecycle.rs
+++ b/src/interpreter_lifecycle.rs
@@ -1,7 +1,7 @@
 // TODO https://github.com/PyO3/pyo3/issues/5487
 #![allow(clippy::undocumented_unsafe_blocks)]
 
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 use core::ffi::c_int;
 
 #[cfg(not(any(PyPy, GraalPy)))]
@@ -32,7 +32,7 @@ pub(crate) fn initialize() {
 ///
 /// # Safety
 /// `config` must point to a valid [`PyInitConfig`](crate::ffi::PyInitConfig) object.
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 pub(crate) unsafe fn initialize_from_config(config: *mut ffi::PyInitConfig) -> Option<c_int> {
     let mut result = None;
     START.call_once_force(|_| unsafe {

--- a/src/interpreter_lifecycle.rs
+++ b/src/interpreter_lifecycle.rs
@@ -2,6 +2,9 @@
 #![allow(clippy::undocumented_unsafe_blocks)]
 
 #[cfg(not(any(PyPy, GraalPy)))]
+use core::ffi::c_int;
+
+#[cfg(not(any(PyPy, GraalPy)))]
 use crate::{ffi, internal::state::AttachGuard, Python};
 
 static START: std::sync::Once = std::sync::Once::new();
@@ -20,6 +23,27 @@ pub(crate) fn initialize() {
             ffi::PyEval_SaveThread();
         }
     });
+}
+
+/// Calls [`Py_InitializeFromInitConfig`](pyo3_ffi::Py_InitializeFromInitConfig) to initialzied the
+/// interpreter if it's not already initialized and returns its result.
+///
+/// Returns [`None`] if the interpreter is already initialized
+///
+/// # Safety
+/// `config` must point to a valid [`PyInitConfig`](crate::ffi::PyInitConfig) object.
+#[cfg(not(any(PyPy, GraalPy)))]
+pub(crate) unsafe fn initialize_from_config(config: *mut ffi::PyInitConfig) -> Option<c_int> {
+    let mut result = None;
+    START.call_once_force(|_| unsafe {
+        if ffi::Py_IsInitialized() == 0 {
+            result = Some(ffi::Py_InitializeFromInitConfig(config));
+
+            // Release the GIL
+            ffi::PyEval_SaveThread();
+        }
+    });
+    result
 }
 
 /// Executes the provided closure with an embedded Python interpreter.

--- a/src/interpreter_lifecycle.rs
+++ b/src/interpreter_lifecycle.rs
@@ -25,7 +25,7 @@ pub(crate) fn initialize() {
     });
 }
 
-/// Calls [`Py_InitializeFromInitConfig`](pyo3_ffi::Py_InitializeFromInitConfig) to initialzied the
+/// Calls [`Py_InitializeFromInitConfig`](pyo3_ffi::Py_InitializeFromInitConfig) to initialize the
 /// interpreter if it's not already initialized and returns its result.
 ///
 /// Returns [`None`] if the interpreter is already initialized

--- a/src/interpreter_lifecycle.rs
+++ b/src/interpreter_lifecycle.rs
@@ -3,7 +3,7 @@
 
 use crate::platform::sync::Once;
 
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 use core::ffi::c_int;
 
 #[cfg(not(any(PyPy, GraalPy)))]
@@ -34,10 +34,10 @@ pub(crate) fn initialize() {
 ///
 /// # Safety
 /// `config` must point to a valid [`PyInitConfig`](crate::ffi::PyInitConfig) object.
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 pub(crate) unsafe fn initialize_from_config(config: *mut ffi::PyInitConfig) -> Option<c_int> {
     let mut result = None;
-    START.call_once_force(|_| unsafe {
+    START.call_once_force(|| unsafe {
         if ffi::Py_IsInitialized() == 0 {
             result = Some(ffi::Py_InitializeFromInitConfig(config));
 

--- a/src/interpreter_lifecycle.rs
+++ b/src/interpreter_lifecycle.rs
@@ -27,7 +27,7 @@ pub(crate) fn initialize() {
     });
 }
 
-/// Calls [`Py_InitializeFromInitConfig`](pyo3_ffi::Py_InitializeFromInitConfig) to initialzied the
+/// Calls [`Py_InitializeFromInitConfig`](pyo3_ffi::Py_InitializeFromInitConfig) to initialize the
 /// interpreter if it's not already initialized and returns its result.
 ///
 /// Returns [`None`] if the interpreter is already initialized

--- a/src/interpreter_lifecycle.rs
+++ b/src/interpreter_lifecycle.rs
@@ -4,6 +4,9 @@
 use crate::platform::sync::Once;
 
 #[cfg(not(any(PyPy, GraalPy)))]
+use core::ffi::c_int;
+
+#[cfg(not(any(PyPy, GraalPy)))]
 use crate::{ffi, internal::state::AttachGuard, Python};
 
 static START: Once = Once::new();
@@ -22,6 +25,27 @@ pub(crate) fn initialize() {
             ffi::PyEval_SaveThread();
         }
     });
+}
+
+/// Calls [`Py_InitializeFromInitConfig`](pyo3_ffi::Py_InitializeFromInitConfig) to initialzied the
+/// interpreter if it's not already initialized and returns its result.
+///
+/// Returns [`None`] if the interpreter is already initialized
+///
+/// # Safety
+/// `config` must point to a valid [`PyInitConfig`](crate::ffi::PyInitConfig) object.
+#[cfg(not(any(PyPy, GraalPy)))]
+pub(crate) unsafe fn initialize_from_config(config: *mut ffi::PyInitConfig) -> Option<c_int> {
+    let mut result = None;
+    START.call_once_force(|_| unsafe {
+        if ffi::Py_IsInitialized() == 0 {
+            result = Some(ffi::Py_InitializeFromInitConfig(config));
+
+            // Release the GIL
+            ffi::PyEval_SaveThread();
+        }
+    });
+    result
 }
 
 /// Executes the provided closure with an embedded Python interpreter.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,7 @@ pub mod marshal;
 #[macro_use]
 pub mod sync;
 pub(crate) mod byteswriter;
-#[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 pub mod init_config;
 pub mod panic;
 pub mod pybacked;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,8 @@ pub mod marshal;
 #[macro_use]
 pub mod sync;
 pub(crate) mod byteswriter;
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
+pub mod init_config;
 pub mod panic;
 pub mod pybacked;
 pub mod pycell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,7 +436,7 @@ pub mod marker;
 pub mod marshal;
 #[macro_use]
 pub mod sync;
-#[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 pub mod init_config;
 #[cfg(wip_feature_std)]
 pub mod panic;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,6 +436,8 @@ pub mod marker;
 pub mod marshal;
 #[macro_use]
 pub mod sync;
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
+pub mod init_config;
 #[cfg(wip_feature_std)]
 pub mod panic;
 pub mod pybacked;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -228,3 +228,11 @@ macro_rules! append_to_inittab {
         }
     };
 }
+
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
+#[macro_export]
+macro_rules! add_module_to_init_config {
+    ($config:expr, $module:ident) => {
+        ($config).add_module($module::__PYO3_NAME, $module::__pyo3_init)
+    };
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -229,7 +229,7 @@ macro_rules! append_to_inittab {
     };
 }
 
-/// Add the module to the configuration so that the embedded intepreter intialized from this config
+/// Add the module to the configuration so that the embedded interpreter initialized from this config
 /// can use it. First argument is the config, second is the module name.
 ///
 /// Call [`InitConfig::initialize`](crate::init_config::InitConfig::initialize) instead of

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -229,6 +229,11 @@ macro_rules! append_to_inittab {
     };
 }
 
+/// Add the module to the configuration so that the embedded intepreter intialized from this config
+/// can use it. First argument is the config, second is the module name.
+///
+/// Call [`InitConfig::initialize`](crate::init_config::InitConfig::initialize) instead of
+/// [`Python::initialize`](crate::marker::Python::initialize) and leave feature `auto-initialize` off.
 #[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
 #[macro_export]
 macro_rules! add_module_to_init_config {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -229,15 +229,12 @@ macro_rules! append_to_inittab {
     };
 }
 
-/// Add the module to the configuration so that the embedded interpreter initialized from this config
-/// can use it. First argument is the config, second is the module name.
-///
-/// Call [`InitConfig::initialize`](crate::init_config::InitConfig::initialize) instead of
-/// [`Python::initialize`](crate::marker::Python::initialize) and leave feature `auto-initialize` off.
+/// Create a [`PyModuleInitInfo`](crate::init_config::PyModuleInitInfo) to be used with
+/// [`PyInitConfig::add_module`](crate::init_config::PyInitConfig::add_module).
 #[cfg(all(Py_3_14, not(any(PyPy, GraalPy))))]
 #[macro_export]
-macro_rules! add_module_to_init_config {
-    ($config:expr, $module:ident) => {
-        ($config).add_module($module::__PYO3_NAME, $module::__pyo3_init)
+macro_rules! pymodule_init_info {
+    ($module:ident) => {
+        $crate::init_config::PyModuleInitInfo::new($module::__PYO3_NAME, $module::__pyo3_init)
     };
 }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -122,7 +122,7 @@
 use crate::conversion::IntoPyObject;
 use crate::err::{self, PyResult};
 #[cfg(not(any(PyPy, GraalPy)))]
-use crate::init_config::{InitConfig, InitializeFromConfigError};
+use crate::init_config::{InitializeFromConfigError, PyInitConfig};
 use crate::internal::state::{AttachGuard, SuspendAttach};
 use crate::types::any::PyAnyMethods;
 use crate::types::code::PyCodeInput;
@@ -485,7 +485,7 @@ impl Python<'_> {
     #[cfg(not(any(PyPy, GraalPy)))]
     #[inline]
     pub fn initialize_from_init_config(
-        config: InitConfig,
+        config: PyInitConfig,
     ) -> Result<(), InitializeFromConfigError> {
         config.initialize()
     }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -121,7 +121,7 @@
 //! [`Py`]: Py
 use crate::conversion::IntoPyObject;
 use crate::err::{self, PyResult};
-#[cfg(not(any(PyPy, GraalPy)))]
+#[cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 use crate::init_config::{InitializeFromConfigError, PyInitConfig};
 use crate::internal::state::{AttachGuard, SuspendAttach};
 use crate::types::any::PyAnyMethods;
@@ -482,7 +482,7 @@ impl Python<'_> {
     ///
     /// # Panic
     /// Panics if the interpreter is already initialized.
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
     #[inline]
     pub fn initialize_from_init_config(
         config: PyInitConfig,

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -121,6 +121,8 @@
 //! [`Py`]: Py
 use crate::conversion::IntoPyObject;
 use crate::err::{self, PyResult};
+#[cfg(not(any(PyPy, GraalPy)))]
+use crate::init_config::{InitConfig, InitializeFromConfigError};
 use crate::internal::state::{AttachGuard, SuspendAttach};
 use crate::types::any::PyAnyMethods;
 use crate::types::code::PyCodeInput;
@@ -474,6 +476,18 @@ impl Python<'_> {
     #[cfg(not(any(PyPy, GraalPy)))]
     pub fn initialize() {
         crate::interpreter_lifecycle::initialize();
+    }
+
+    /// Initializes the python interpreter from the configuration.
+    ///
+    /// # Panic
+    /// Panics if the interpreter is already initialized.
+    #[cfg(not(any(PyPy, GraalPy)))]
+    #[inline]
+    pub fn initialize_from_init_config(
+        config: InitConfig,
+    ) -> Result<(), InitializeFromConfigError> {
+        config.initialize()
     }
 
     /// Like [`Python::attach`] except Python interpreter state checking is skipped.

--- a/tests/test_init_config_add_module.rs
+++ b/tests/test_init_config_add_module.rs
@@ -1,0 +1,30 @@
+#![cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
+#![cfg(feature = "macros")]
+#![allow(clippy::undocumented_unsafe_blocks, reason = "tests")]
+
+use pyo3::add_module_to_init_config;
+use pyo3::init_config::InitConfig;
+use pyo3::prelude::*;
+
+#[test]
+fn test_add_module() {
+    let mut config = InitConfig::default();
+    add_module_to_init_config!(config, m).unwrap();
+    config.initialize().unwrap();
+    Python::attach(|py| {
+        let m = py.import("m").unwrap();
+        let get_42 = m.getattr("get_42").unwrap();
+        let forty_two = get_42.call0().unwrap().extract::<i32>().unwrap();
+        assert_eq!(42, forty_two);
+    });
+}
+
+#[pymodule]
+mod m {
+    use pyo3::prelude::*;
+
+    #[pyfunction]
+    fn get_42() -> i32 {
+        42
+    }
+}

--- a/tests/test_init_config_add_module.rs
+++ b/tests/test_init_config_add_module.rs
@@ -2,14 +2,14 @@
 #![cfg(feature = "macros")]
 #![allow(clippy::undocumented_unsafe_blocks, reason = "tests")]
 
-use pyo3::add_module_to_init_config;
 use pyo3::init_config::PyInitConfig;
 use pyo3::prelude::*;
+use pyo3::pymodule_init_info;
 
 #[test]
 fn test_add_module() {
     let mut config = PyInitConfig::default();
-    add_module_to_init_config!(config, m).unwrap();
+    config.add_module(pymodule_init_info!(m)).unwrap();
     Python::initialize_from_init_config(config).unwrap();
     Python::attach(|py| {
         let m = py.import("m").unwrap();

--- a/tests/test_init_config_add_module.rs
+++ b/tests/test_init_config_add_module.rs
@@ -3,12 +3,12 @@
 #![allow(clippy::undocumented_unsafe_blocks, reason = "tests")]
 
 use pyo3::add_module_to_init_config;
-use pyo3::init_config::InitConfig;
+use pyo3::init_config::PyInitConfig;
 use pyo3::prelude::*;
 
 #[test]
 fn test_add_module() {
-    let mut config = InitConfig::default();
+    let mut config = PyInitConfig::default();
     add_module_to_init_config!(config, m).unwrap();
     Python::initialize_from_init_config(config).unwrap();
     Python::attach(|py| {

--- a/tests/test_init_config_add_module.rs
+++ b/tests/test_init_config_add_module.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 fn test_add_module() {
     let mut config = InitConfig::default();
     add_module_to_init_config!(config, m).unwrap();
-    config.initialize().unwrap();
+    Python::initialize_from_init_config(config).unwrap();
     Python::attach(|py| {
         let m = py.import("m").unwrap();
         let get_42 = m.getattr("get_42").unwrap();

--- a/tests/test_init_config_add_module.rs
+++ b/tests/test_init_config_add_module.rs
@@ -9,12 +9,18 @@ use pyo3::pymodule_init_info;
 #[test]
 fn test_add_module() {
     let mut config = PyInitConfig::default();
-    config.add_module(pymodule_init_info!(m)).unwrap();
-    Python::initialize_from_init_config(config).unwrap();
+    config
+        .add_module(pymodule_init_info!(m))
+        .expect("failed to add module");
+    Python::initialize_from_init_config(config).expect("failed to initialize interpreter");
     Python::attach(|py| {
-        let m = py.import("m").unwrap();
-        let get_42 = m.getattr("get_42").unwrap();
-        let forty_two = get_42.call0().unwrap().extract::<i32>().unwrap();
+        let m = py.import("m").expect("failed to import module");
+        let get_42 = m.getattr("get_42").expect("failed to get attribute");
+        let forty_two = get_42
+            .call0()
+            .expect("failed to call method")
+            .extract::<i32>()
+            .expect("failed to extract value from method call result");
         assert_eq!(42, forty_two);
     });
 }

--- a/tests/test_init_config_init_fail.rs
+++ b/tests/test_init_config_init_fail.rs
@@ -1,0 +1,12 @@
+#![cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
+
+use pyo3::init_config::InitConfig;
+
+#[test]
+fn test_init_fail() {
+    let mut config = InitConfig::default();
+    config
+        .set_str(c"prefix", c"/path/that/does/not/exit")
+        .unwrap();
+    config.initialize().unwrap_err();
+}

--- a/tests/test_init_config_init_fail.rs
+++ b/tests/test_init_config_init_fail.rs
@@ -1,11 +1,11 @@
 #![cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 
-use pyo3::init_config::InitConfig;
+use pyo3::init_config::PyInitConfig;
 use pyo3::prelude::Python;
 
 #[test]
 fn test_init_fail() {
-    let mut config = InitConfig::default();
+    let mut config = PyInitConfig::default();
     config
         .set_str(c"prefix", c"/path/that/does/not/exit")
         .unwrap();

--- a/tests/test_init_config_init_fail.rs
+++ b/tests/test_init_config_init_fail.rs
@@ -9,5 +9,5 @@ fn test_init_fail() {
     config
         .set_str(c"prefix", c"/path/that/does/not/exit")
         .unwrap();
-    Python::initialize_from_init_config(config).unwrap();
+    Python::initialize_from_init_config(config).unwrap_err();
 }

--- a/tests/test_init_config_init_fail.rs
+++ b/tests/test_init_config_init_fail.rs
@@ -4,6 +4,7 @@ use pyo3::init_config::PyInitConfig;
 use pyo3::prelude::Python;
 
 #[test]
+#[ignore = "this doesn't seem to be a reliable way to make python fail to initialize"]
 fn test_init_fail() {
     let mut config = PyInitConfig::default();
     config

--- a/tests/test_init_config_init_fail.rs
+++ b/tests/test_init_config_init_fail.rs
@@ -1,6 +1,7 @@
 #![cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 
 use pyo3::init_config::InitConfig;
+use pyo3::prelude::Python;
 
 #[test]
 fn test_init_fail() {
@@ -8,5 +9,5 @@ fn test_init_fail() {
     config
         .set_str(c"prefix", c"/path/that/does/not/exit")
         .unwrap();
-    config.initialize().unwrap_err();
+    Python::initialize_from_init_config(config).unwrap();
 }

--- a/tests/test_init_config_initializes_interpreter.rs
+++ b/tests/test_init_config_initializes_interpreter.rs
@@ -1,0 +1,10 @@
+#![allow(clippy::undocumented_unsafe_blocks, reason = "tests")]
+
+use pyo3::init_config::InitConfig;
+
+#[test]
+fn test_initializes_intepreter() {
+    let config = InitConfig::default();
+    config.initialize().unwrap();
+    assert_ne!(unsafe { pyo3::ffi::Py_IsInitialized() }, 0);
+}

--- a/tests/test_init_config_initializes_interpreter.rs
+++ b/tests/test_init_config_initializes_interpreter.rs
@@ -3,7 +3,7 @@
 use pyo3::init_config::InitConfig;
 
 #[test]
-fn test_initializes_intepreter() {
+fn test_initializes_interpreter() {
     let config = InitConfig::default();
     config.initialize().unwrap();
     assert_ne!(unsafe { pyo3::ffi::Py_IsInitialized() }, 0);

--- a/tests/test_init_config_initializes_interpreter.rs
+++ b/tests/test_init_config_initializes_interpreter.rs
@@ -1,3 +1,4 @@
+#![cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 #![allow(clippy::undocumented_unsafe_blocks, reason = "tests")]
 
 use pyo3::init_config::InitConfig;

--- a/tests/test_init_config_initializes_interpreter.rs
+++ b/tests/test_init_config_initializes_interpreter.rs
@@ -1,12 +1,12 @@
 #![cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 #![allow(clippy::undocumented_unsafe_blocks, reason = "tests")]
 
-use pyo3::init_config::InitConfig;
+use pyo3::init_config::PyInitConfig;
 use pyo3::prelude::Python;
 
 #[test]
 fn test_initializes_interpreter() {
-    let config = InitConfig::default();
+    let config = PyInitConfig::default();
     Python::initialize_from_init_config(config).unwrap();
     assert_ne!(unsafe { pyo3::ffi::Py_IsInitialized() }, 0);
 }

--- a/tests/test_init_config_initializes_interpreter.rs
+++ b/tests/test_init_config_initializes_interpreter.rs
@@ -2,10 +2,11 @@
 #![allow(clippy::undocumented_unsafe_blocks, reason = "tests")]
 
 use pyo3::init_config::InitConfig;
+use pyo3::prelude::Python;
 
 #[test]
 fn test_initializes_interpreter() {
     let config = InitConfig::default();
-    config.initialize().unwrap();
+    Python::initialize_from_init_config(config).unwrap();
     assert_ne!(unsafe { pyo3::ffi::Py_IsInitialized() }, 0);
 }

--- a/tests/tests_init_config_panics_if_already_initialized.rs
+++ b/tests/tests_init_config_panics_if_already_initialized.rs
@@ -1,3 +1,5 @@
+#![cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
+
 use pyo3::init_config::InitConfig;
 use pyo3::prelude::Python;
 

--- a/tests/tests_init_config_panics_if_already_initialized.rs
+++ b/tests/tests_init_config_panics_if_already_initialized.rs
@@ -1,0 +1,9 @@
+use pyo3::init_config::InitConfig;
+use pyo3::prelude::Python;
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn panics_if_already_init() {
+    Python::initialize();
+    InitConfig::default().initialize().unwrap();
+}

--- a/tests/tests_init_config_panics_if_already_initialized.rs
+++ b/tests/tests_init_config_panics_if_already_initialized.rs
@@ -7,5 +7,5 @@ use pyo3::prelude::Python;
 #[should_panic(expected = "already initialized")]
 fn panics_if_already_init() {
     Python::initialize();
-    InitConfig::default().initialize().unwrap();
+    Python::initialize_from_init_config(InitConfig::default()).unwrap();
 }

--- a/tests/tests_init_config_panics_if_already_initialized.rs
+++ b/tests/tests_init_config_panics_if_already_initialized.rs
@@ -1,11 +1,11 @@
 #![cfg(all(Py_3_14, not(any(PyPy, GraalPy, RustPython, Py_LIMITED_API))))]
 
-use pyo3::init_config::InitConfig;
+use pyo3::init_config::PyInitConfig;
 use pyo3::prelude::Python;
 
 #[test]
 #[should_panic(expected = "already initialized")]
 fn panics_if_already_init() {
     Python::initialize();
-    Python::initialize_from_init_config(InitConfig::default()).unwrap();
+    Python::initialize_from_init_config(PyInitConfig::default()).unwrap();
 }


### PR DESCRIPTION
Adds a rust API to initialize the embedded interpreter with configuration.

Closes #6153