### PR TITLE
fix lifetime of return value in `PyClassGuardMutSuper::as_super`

### DIFF
--- a/newsfragments/6181.fixed.md
+++ b/newsfragments/6181.fixed.md
@@ -1,0 +1,1 @@
+Fix return value of `PyClassGuardMutSuper::as_super` being scoped to the full guard lifetime, now the `&mut` borrow of the `as_super()` call.

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -884,11 +884,8 @@ where
     /// Borrows a mutable reference to `PyClassGuardMut<T::BaseType>`.
     ///
     /// See [`PyClassGuardMut::as_super`] for more.
-    pub fn as_super(&mut self) -> PyClassGuardMutSuper<'a, 'g, T::BaseType> {
-        PyClassGuardMutSuper {
-            // SAFETY: `PyClassGuardMut<T>` and `PyClassGuardMut<U>` have the same layout
-            guard: unsafe { NonNull::from(&mut *self.guard).cast().as_mut() },
-        }
+    pub fn as_super(&mut self) -> PyClassGuardMutSuper<'_, 'g, T::BaseType> {
+        self.guard.as_super()
     }
 }
 


### PR DESCRIPTION
`PyClassGuardMutSuper::as_super` was incorrectly returning a super-guard with lifetime `'a` decoupled from the `&mut` borrow of the guard. This allows the super-guard to exist after the `.as_super()` borrow ends, potentially leading to mutable aliasing issues.

cc @Icxolu - we missed this in #6104

(Credit to Codex security scanning for this discovery.)