### PR TITLE
Fix raw-dylib link names for MinGW-built Python on Windows

### DIFF
--- a/guide/src/building-and-distribution.md
+++ b/guide/src/building-and-distribution.md
@@ -397,9 +397,10 @@ PyO3's build script will detect that you are attempting a cross-compile based on
 When cross-compiling, PyO3's build script cannot execute the target Python interpreter to query the configuration, so there are a few additional environment variables you may need to set:
 
 - `PYO3_CROSS`: If present this variable forces PyO3 to configure as a cross-compilation.
-- `PYO3_CROSS_LIB_DIR`: This variable can be set to the directory containing the target's libpython DSO and the associated `_sysconfigdata*.py` file for Unix-like targets.
-  This variable is only needed when the output binary must link to libpython explicitly (e.g. when targeting Android or embedding a Python interpreter), or when it is absolutely required to get the interpreter configuration from `_sysconfigdata*.py`.
-  On Windows, this variable is not needed because PyO3 uses `raw-dylib` linking.
+- `PYO3_CROSS_LIB_DIR`: Directory with the target's libpython DSO and `_sysconfigdata*.py` on Unix-like targets, or with GNU import libraries (`libpython3.X.dll.a`) on `*-windows-gnu(llvm)` when PyO3 must link them.
+  On Unix-like targets, set this when the binary must link libpython explicitly (e.g. Android, embedding) or when configuration must come from `_sysconfigdata*.py`.
+  On `*-windows-msvc`, extension modules usually omit it: PyO3 uses `raw-dylib` linking.
+  On `*-windows-gnu(llvm)`, pure-Rust extension modules often omit it as well; set it for mixed Rust/C modules or for `i686-pc-windows-gnu` (see the MinGW example below).
 - `PYO3_CROSS_PYTHON_VERSION`: Major and minor version (e.g. 3.9) of the target Python installation.
   This variable is only needed if PyO3 cannot determine the version to target from `abi3-py3*` features, or if `PYO3_CROSS_LIB_DIR` is not set, or if there are multiple versions of Python present in `PYO3_CROSS_LIB_DIR`.
 - `PYO3_CROSS_PYTHON_IMPLEMENTATION`: Python implementation name ("CPython" or "PyPy") of the target Python installation.
@@ -422,7 +423,7 @@ export PYO3_CROSS_LIB_DIR="/home/pyo3/cross/sysroot/usr/lib"
 cargo build --target armv7-unknown-linux-gnueabihf
 ```
 
-Or another example building for Windows (no `PYO3_CROSS_LIB_DIR` needed thanks to `raw-dylib`):
+Or another example cross-compiling for MinGW Windows (e.g. MSYS2):
 
 ```sh
 export PYO3_CROSS_PYTHON_VERSION=3.9
@@ -430,9 +431,16 @@ export PYO3_CROSS_PYTHON_VERSION=3.9
 cargo build --target x86_64-pc-windows-gnu
 ```
 
+`x86_64-pc-windows-gnu` and other `*-windows-gnu(llvm)` targets use the MinGW
+toolchain and must be paired with MinGW-built Python (`libpython3.X.dll`, e.g.
+MSYS2), not the python.org MSVC distribution (`x86_64-pc-windows-msvc`).
+PyO3 links the GNU import library alongside `raw-dylib` when needed so mixed
+Rust/C extension modules can resolve Python symbols PyO3 does not declare in its
+`extern` blocks.
+
 Any of the `abi3-py3*` features can be enabled instead of setting `PYO3_CROSS_PYTHON_VERSION` in the above examples.
 
-`PYO3_CROSS_LIB_DIR` can often be omitted when cross compiling extension modules for Unix, macOS, and Windows targets.
+`PYO3_CROSS_LIB_DIR` can often be omitted when cross compiling extension modules for Unix and macOS targets, and for `*-windows-msvc` targets.
 
 The following resources may also be useful for cross-compiling:
 

--- a/newsfragments/6182.changed.md
+++ b/newsfragments/6182.changed.md
@@ -1,0 +1,1 @@
+`*-windows-gnu(llvm)` targets now default to linking MinGW-built Python (`libpython3.X.dll`, e.g. MSYS2) instead of the python.org distribution, and also link its GNU import library for mixed Rust/C extension modules.

--- a/noxfile.py
+++ b/noxfile.py
@@ -1431,11 +1431,16 @@ def _check_raw_dylib_macro(session: nox.Session):
     min_minor = int(min_version.split(".")[1])
     max_minor = int(max_version.split(".")[1])
 
-    # Build the set of DLL names that default_lib_name_windows can produce
-    expected_dlls = {"python3", "python3_d"}
-    for minor in range(min_minor, max_minor + 1):
+    # Build the set of DLL names that default_lib_name_windows can produce.
+    # The range includes one minor version past the maximum supported version
+    # because pyo3-ffi allows building against the next in-development CPython
+    # version with a warning.
+    # MinGW-built CPython (e.g. MSYS2) ships `lib`-prefixed DLL names.
+    expected_dlls = {"python3", "python3_d", "libpython3"}
+    for minor in range(min_minor, max_minor + 2):
         expected_dlls.add(f"python3{minor}")
         expected_dlls.add(f"python3{minor}_d")
+        expected_dlls.add(f"libpython3.{minor}")
         if minor >= 13:
             expected_dlls.add(f"python3{minor}t")
             expected_dlls.add(f"python3{minor}t_d")
@@ -1452,7 +1457,7 @@ def _check_raw_dylib_macro(session: nox.Session):
 
     # Parse the DLL name list in the extern_libpython!(@impl ...) invocation
     lib_rs = (PYO3_DIR / "pyo3-ffi" / "src" / "impl_" / "macros.rs").read_text()
-    found_dlls = set(re.findall(r'"((?:python|libpypy)[^"]+)"', lib_rs))
+    found_dlls = set(re.findall(r'"((?:python|libpython|libpypy)[^"]+)"', lib_rs))
 
     missing = expected_dlls - found_dlls
     extra = found_dlls - expected_dlls

--- a/noxfile.py
+++ b/noxfile.py
@@ -1432,6 +1432,9 @@ def _check_raw_dylib_macro(session: nox.Session):
     max_minor = int(max_version.split(".")[1])
 
     # Build the set of DLL names that default_lib_name_windows can produce.
+    # Keep this in sync with `supported_pyo3_dll_names()` in
+    # `pyo3-build-config/src/impl_.rs` (the canonical list) and the
+    # `extern_libpython!` macro in `pyo3-ffi/src/impl_/macros.rs`.
     # The range includes one minor version past the maximum supported version
     # because pyo3-ffi allows building against the next in-development CPython
     # version with a warning.

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -150,9 +150,11 @@ pub struct InterpreterConfig {
 
     /// The name of the link library defining Python.
     ///
-    /// This effectively controls the `cargo:rustc-link-lib=<name>` value to
-    /// control how libpython is linked. Values should not contain the `lib`
-    /// prefix.
+    /// On Windows this is the name of the Python DLL without the `.dll`
+    /// suffix (e.g. `python312`, or `libpython3.12` for MinGW-built Python),
+    /// which is linked using `raw-dylib`. On other platforms this effectively
+    /// controls the `cargo:rustc-link-lib=<name>` value and should not
+    /// contain the `lib` prefix.
     ///
     /// Serialized to `lib_name`.
     #[deprecated(
@@ -284,9 +286,11 @@ impl InterpreterConfig {
 
     /// The name of the link library defining Python.
     ///
-    /// This effectively controls the `cargo:rustc-link-lib=<name>` value to
-    /// control how libpython is linked. Values should not contain the `lib`
-    /// prefix.
+    /// On Windows this is the name of the Python DLL without the `.dll`
+    /// suffix (e.g. `python312`, or `libpython3.12` for MinGW-built Python),
+    /// which is linked using `raw-dylib`. On other platforms this effectively
+    /// controls the `cargo:rustc-link-lib=<name>` value and should not
+    /// contain the `lib` prefix.
     ///
     /// Serialized to `lib_name`.
     pub fn lib_name(&self) -> Option<&str> {
@@ -521,11 +525,12 @@ print("gil_disabled", get_config_var("Py_GIL_DISABLED"))
             PythonAbi::from_build_env(implementation, version, stable_abi_version, gil_disabled)?;
 
         let cygwin = map["cygwin"].as_str() == "True";
+        let mingw = map["mingw"].as_str() == "True";
 
         let lib_name = if cfg!(windows) {
             default_lib_name_windows(
                 target_abi,
-                map["mingw"].as_str() == "True",
+                mingw,
                 // This is the best heuristic currently available to detect debug build
                 // on Windows from sysconfig - e.g. ext_suffix may be
                 // `_d.cp312-win_amd64.pyd` for 3.12 debug build
@@ -2298,10 +2303,53 @@ fn load_cross_compile_config(
 const WINDOWS_STABLE_ABI_LIB_NAME: &str = "python3";
 const WINDOWS_STABLE_ABI_DEBUG_LIB_NAME: &str = "python3_d";
 
+/// All Python DLL names (without the `.dll` suffix) supported by raw-dylib
+/// linking on Windows.
+///
+/// This should include one minor version past `STABLE_ABI_MAX_MINOR` because
+/// pyo3-ffi allows building against the next in-development CPython version
+/// with a warning.
+///
+/// Keep this in sync with the `extern_libpython!` macro in
+/// `pyo3-ffi/src/impl_/macros.rs` (checked by `nox -s ffi-check`).
+pub fn supported_pyo3_dll_names() -> Vec<String> {
+    let mut dll_names = vec![
+        // abi3
+        "python3".to_string(),
+        "python3_d".to_string(),
+        // abi3t
+        "python3t".to_string(),
+        "python3t_d".to_string(),
+        // abi3 for MinGW-built CPython (e.g. MSYS2)
+        "libpython3".to_string(),
+    ];
+    for i in MINIMUM_SUPPORTED_VERSION.minor..=STABLE_ABI_MAX_MINOR + 1 {
+        dll_names.push(format!("python3{i}"));
+        dll_names.push(format!("python3{i}_d"));
+        // free-threaded builds (3.13+)
+        if i >= 13 {
+            dll_names.push(format!("python3{i}t"));
+            dll_names.push(format!("python3{i}t_d"));
+        }
+        // MinGW-built CPython (libpython3.X.dll)
+        dll_names.push(format!("libpython3.{i}"));
+    }
+    // PyPy DLL names (libpypy3.X-c.dll)
+    for i in MINIMUM_SUPPORTED_VERSION_PYPY.minor..=MAXIMUM_SUPPORTED_VERSION_PYPY.minor {
+        dll_names.push(format!("libpypy3.{i}-c"));
+    }
+    dll_names
+}
+
 /// Generates the default library name for the target platform.
 #[allow(dead_code)]
 fn default_lib_name_for_target(abi: PythonAbi, target: &Triple) -> String {
     if target.operating_system == OperatingSystem::Windows {
+        // `mingw: false` even for `*-windows-gnu` targets: cross-compiling
+        // with a GNU toolchain usually targets the python.org distribution
+        // (`python3X.dll`), not a MinGW-built Python (`libpython3.X.dll`).
+        // Cross-compiling for e.g. MSYS2 Python requires setting `lib_name`
+        // explicitly via `PYO3_CONFIG_FILE`.
         default_lib_name_windows(abi, false, false).unwrap()
     } else {
         default_lib_name_unix(
@@ -2322,6 +2370,26 @@ fn default_lib_name_windows(abi: PythonAbi, mingw: bool, debug: bool) -> Result<
             "libpypy{}.{}-c",
             abi.version.major, abi.version.minor
         ))
+    } else if mingw {
+        ensure!(
+            !abi.kind.is_free_threaded(),
+            "MinGW free-threaded builds are not currently tested or supported"
+        );
+        // MinGW-built CPython (e.g. MSYS2) ships Unix-style `lib`-prefixed DLLs:
+        // `libpython3.X.dll`, and `libpython3.dll` for the stable ABI. With
+        // raw-dylib linking we need the real DLL name rather than the
+        // import-library alias. Debug builds are not shipped for MinGW, so
+        // `debug` is ignored here.
+        // https://packages.msys2.org/base/mingw-w64-python
+        if matches!(abi.kind, PythonAbiKind::Stable(_)) {
+            // `is_free_threaded()` above rejects Abi3t, so this is always Abi3.
+            Ok("libpython3".to_string())
+        } else {
+            Ok(format!(
+                "libpython{}.{}",
+                abi.version.major, abi.version.minor
+            ))
+        }
     } else if debug && abi.version < PythonVersion::PY310 {
         // CPython bug: linking against python3_d.dll raises error
         // https://github.com/python/cpython/issues/101614
@@ -2341,13 +2409,6 @@ fn default_lib_name_windows(abi: PythonAbi, mingw: bool, debug: bool) -> Result<
             lib_name = lib_name.replace("python3", "python3t");
         }
         Ok(lib_name)
-    } else if mingw {
-        ensure!(
-            !abi.kind.is_free_threaded(),
-            "MinGW free-threaded builds are not currently tested or supported"
-        );
-        // https://packages.msys2.org/base/mingw-w64-python
-        Ok(format!("python{}.{}", abi.version.major, abi.version.minor))
     } else if abi.kind().is_free_threaded() {
         #[expect(deprecated, reason = "using constant internally")]
         {
@@ -3281,6 +3342,7 @@ mod tests {
             .unwrap(),
             "python3",
         );
+        // MinGW-built CPython (e.g. MSYS2) uses `lib`-prefixed DLL names
         assert_eq!(
             super::default_lib_name_windows(
                 PythonAbiBuilder::new(PythonImplementation::CPython, PythonVersion::PY39)
@@ -3290,7 +3352,7 @@ mod tests {
                 false,
             )
             .unwrap(),
-            "python3.9",
+            "libpython3.9",
         );
         assert_eq!(
             super::default_lib_name_windows(
@@ -3302,7 +3364,19 @@ mod tests {
                 false,
             )
             .unwrap(),
-            "python3",
+            "libpython3",
+        );
+        // MinGW does not ship debug builds; the debug flag is ignored
+        assert_eq!(
+            super::default_lib_name_windows(
+                PythonAbiBuilder::new(PythonImplementation::CPython, PythonVersion::PY39)
+                    .finalize()
+                    .unwrap(),
+                true,
+                true,
+            )
+            .unwrap(),
+            "libpython3.9",
         );
         assert_eq!(
             super::default_lib_name_windows(
@@ -3376,6 +3450,16 @@ mod tests {
             false,
         )
         .is_err());
+        // ... including the free-threaded stable ABI
+        assert!(super::default_lib_name_windows(
+            PythonAbiBuilder::new(PythonImplementation::CPython, PythonVersion::PY315)
+                .stable_abi(StableAbi::Abi3t)
+                .finalize()
+                .unwrap(),
+            true,
+            false,
+        )
+        .is_err());
         assert_eq!(
             super::default_lib_name_windows(
                 PythonAbiBuilder::new(PythonImplementation::CPython, PythonVersion::PY313)
@@ -3424,6 +3508,60 @@ mod tests {
             .unwrap(),
             "python3t_d",
         );
+    }
+
+    #[test]
+    fn default_windows_lib_names_are_supported_dll_names() {
+        // Every name `default_lib_name_windows` can produce must be covered
+        // by `supported_pyo3_dll_names` (and hence by the `extern_libpython!`
+        // macro in pyo3-ffi), otherwise Windows builds fail to link.
+        let supported = supported_pyo3_dll_names();
+        let check = |abi: PythonAbi, mingw: bool, debug: bool| {
+            if let Ok(name) = super::default_lib_name_windows(abi, mingw, debug) {
+                assert!(
+                    supported.contains(&name),
+                    "`{name}` is missing from supported_pyo3_dll_names()"
+                );
+            }
+        };
+        for minor in MINIMUM_SUPPORTED_VERSION.minor..=STABLE_ABI_MAX_MINOR + 1 {
+            let version = PythonVersion { major: 3, minor };
+            for mingw in [false, true] {
+                for debug in [false, true] {
+                    let builder = || PythonAbiBuilder::new(PythonImplementation::CPython, version);
+                    // version-specific, GIL-enabled
+                    check(builder().finalize().unwrap(), mingw, debug);
+                    // abi3
+                    check(
+                        builder().stable_abi(StableAbi::Abi3).finalize().unwrap(),
+                        mingw,
+                        debug,
+                    );
+                    // free-threaded (3.13+)
+                    if minor >= 13 {
+                        check(builder().free_threaded().finalize().unwrap(), mingw, debug);
+                    }
+                    // abi3t (3.15+)
+                    if minor >= 15 {
+                        check(
+                            builder().stable_abi(StableAbi::Abi3t).finalize().unwrap(),
+                            mingw,
+                            debug,
+                        );
+                    }
+                }
+            }
+        }
+        for minor in MINIMUM_SUPPORTED_VERSION_PYPY.minor..=MAXIMUM_SUPPORTED_VERSION_PYPY.minor {
+            let version = PythonVersion { major: 3, minor };
+            check(
+                PythonAbiBuilder::new(PythonImplementation::PyPy, version)
+                    .finalize()
+                    .unwrap(),
+                false,
+                false,
+            );
+        }
     }
 
     #[test]

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -544,10 +544,13 @@ print("gil_disabled", get_config_var("Py_GIL_DISABLED"))
             )?
         };
 
-        let lib_dir = if cfg!(windows) {
+        let lib_dir = if cfg!(windows) && !mingw {
             map.get("base_prefix")
                 .map(|base_prefix| format!("{base_prefix}\\libs"))
         } else {
+            // On MinGW-built Python the import libraries live in the
+            // Unix-style `LIBDIR` (e.g. `C:/msys64/ucrt64/lib`), not in
+            // `base_prefix\libs`.
             map.get("libdir").cloned()
         };
 

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -658,7 +658,7 @@ print("gil_disabled", get_config_var("Py_GIL_DISABLED"))
             // For config files which don't apply a lib name, apply a default which we can use
             // for linking.
             if config.lib_name.is_none() {
-                config.lib_name = Some(default_lib_name_for_target(config.target_abi, target));
+                config.lib_name = Some(default_lib_name_for_target(config.target_abi, target)?);
             }
 
             Ok(config)
@@ -2219,7 +2219,7 @@ fn default_cross_compile(cross_compile_config: &CrossCompileConfig) -> Result<In
     let target_abi =
         PythonAbi::from_build_env(implementation, version, stable_abi_version, gil_disabled)?;
 
-    let lib_name = default_lib_name_for_target(target_abi, &cross_compile_config.target);
+    let lib_name = default_lib_name_for_target(target_abi, &cross_compile_config.target)?;
 
     let lib_dir = cross_compile_config.lib_dir_string();
 
@@ -2267,7 +2267,11 @@ fn default_stable_abi_config(
     let builder = InterpreterConfigBuilder::new(PythonImplementation::CPython, version)
         .target_abi(target_abi);
     if host.operating_system == OperatingSystem::Windows {
-        builder.lib_name(default_lib_name_windows(target_abi, false, false)?)
+        builder.lib_name(default_lib_name_windows(
+            target_abi,
+            is_mingw_windows_target(host),
+            false,
+        )?)
     } else {
         builder
     }
@@ -2344,23 +2348,26 @@ pub fn supported_pyo3_dll_names() -> Vec<String> {
     dll_names
 }
 
+/// Returns true when the Cargo target triple is a MinGW Windows environment.
+fn is_mingw_windows_target(target: &Triple) -> bool {
+    target.operating_system == OperatingSystem::Windows
+        && matches!(target.environment, Environment::Gnu | Environment::GnuLlvm)
+}
+
 /// Generates the default library name for the target platform.
 #[allow(dead_code)]
-fn default_lib_name_for_target(abi: PythonAbi, target: &Triple) -> String {
+fn default_lib_name_for_target(abi: PythonAbi, target: &Triple) -> Result<String> {
     if target.operating_system == OperatingSystem::Windows {
-        // `mingw: false` even for `*-windows-gnu` targets: cross-compiling
-        // with a GNU toolchain usually targets the python.org distribution
-        // (`python3X.dll`), not a MinGW-built Python (`libpython3.X.dll`).
-        // Cross-compiling for e.g. MSYS2 Python requires setting `lib_name`
-        // explicitly via `PYO3_CONFIG_FILE`.
-        default_lib_name_windows(abi, false, false).unwrap()
+        // `*-windows-gnu(llvm)` targets use the MinGW toolchain and are assumed
+        // to link against MinGW-built Python (`libpython3.X.dll`). The python.org
+        // MSVC distribution requires `*-windows-msvc` instead.
+        default_lib_name_windows(abi, is_mingw_windows_target(target), false)
     } else {
         default_lib_name_unix(
             abi,
             target.operating_system == OperatingSystem::Cygwin,
             None,
         )
-        .unwrap()
     }
 }
 
@@ -3047,6 +3054,22 @@ mod tests {
     }
 
     #[test]
+    fn windows_gnu_hardcoded_abi3_compile() {
+        let host = triple!("x86_64-pc-windows-gnu");
+        let implementation = PythonImplementation::CPython;
+        let version = PythonVersion::PY39;
+        let config = InterpreterConfigBuilder::new(implementation, version)
+            .stable_abi(StableAbi::Abi3)
+            .lib_name("libpython3".to_string())
+            .finalize()
+            .unwrap();
+        assert_eq!(
+            default_stable_abi_config(&host, Some(version), None).unwrap(),
+            config
+        );
+    }
+
+    #[test]
     fn windows_hardcoded_abi3t_compile() {
         let host = triple!("x86_64-pc-windows-msvc");
         let implementation = PythonImplementation::CPython;
@@ -3155,7 +3178,7 @@ mod tests {
         let implementation = PythonImplementation::CPython;
         let version = PythonVersion::PY39;
         let config = InterpreterConfigBuilder::new(implementation, version)
-            .lib_name("python39".to_string())
+            .lib_name("libpython3.9".to_string())
             .lib_dir("/usr/lib/mingw".to_string())
             .finalize()
             .unwrap();
@@ -3515,9 +3538,9 @@ mod tests {
 
     #[test]
     fn default_windows_lib_names_are_supported_dll_names() {
-        // Every name `default_lib_name_windows` can produce must be covered
-        // by `supported_pyo3_dll_names` (and hence by the `extern_libpython!`
-        // macro in pyo3-ffi), otherwise Windows builds fail to link.
+        // Every name `default_lib_name_windows` can produce must be covered by
+        // `supported_pyo3_dll_names`. Macro parity with `extern_libpython!` is
+        // checked separately by `nox -s ffi-check` (`_check_raw_dylib_macro`).
         let supported = supported_pyo3_dll_names();
         let check = |abi: PythonAbi, mingw: bool, debug: bool| {
             if let Ok(name) = super::default_lib_name_windows(abi, mingw, debug) {
@@ -4257,41 +4280,52 @@ mod tests {
         let unix = Triple::from_str("x86_64-unknown-linux-gnu").unwrap();
         let win_x64 = Triple::from_str("x86_64-pc-windows-msvc").unwrap();
         let win_arm64 = Triple::from_str("aarch64-pc-windows-msvc").unwrap();
+        let win_gnu = Triple::from_str("x86_64-pc-windows-gnu").unwrap();
 
-        let lib_name = default_lib_name_for_target(cpy39, &unix);
+        let lib_name = default_lib_name_for_target(cpy39, &unix).unwrap();
         assert_eq!(lib_name, "python3.9");
 
-        let lib_name = default_lib_name_for_target(cpy39, &win_x64);
+        let lib_name = default_lib_name_for_target(cpy39, &win_x64).unwrap();
         assert_eq!(lib_name, "python39");
 
-        let lib_name = default_lib_name_for_target(cpy39, &win_arm64);
+        let lib_name = default_lib_name_for_target(cpy39, &win_arm64).unwrap();
         assert_eq!(lib_name, "python39");
+
+        let lib_name = default_lib_name_for_target(cpy39, &win_gnu).unwrap();
+        assert_eq!(lib_name, "libpython3.9");
 
         // PyPy
-        let lib_name = default_lib_name_for_target(pypy311, &unix);
+        let lib_name = default_lib_name_for_target(pypy311, &unix).unwrap();
         assert_eq!(lib_name, "pypy3.11-c");
 
-        let lib_name = default_lib_name_for_target(pypy311, &win_x64);
+        let lib_name = default_lib_name_for_target(pypy311, &win_x64).unwrap();
         assert_eq!(lib_name, "libpypy3.11-c");
 
         // Free-threaded
-        let lib_name = default_lib_name_for_target(cpy313t, &unix);
+        let lib_name = default_lib_name_for_target(cpy313t, &unix).unwrap();
         assert_eq!(lib_name, "python3.13t");
 
-        let lib_name = default_lib_name_for_target(cpy313t, &win_x64);
+        let lib_name = default_lib_name_for_target(cpy313t, &win_x64).unwrap();
         assert_eq!(lib_name, "python313t");
 
-        let lib_name = default_lib_name_for_target(cpy313t, &win_arm64);
+        let lib_name = default_lib_name_for_target(cpy313t, &win_arm64).unwrap();
         assert_eq!(lib_name, "python313t");
+
+        // MinGW-built Python has no free-threaded distribution, so this must
+        // error rather than invent a lib name.
+        assert!(default_lib_name_for_target(cpy313t, &win_gnu).is_err());
 
         // abi3
-        let lib_name = default_lib_name_for_target(cpy313_abi3, &unix);
+        let lib_name = default_lib_name_for_target(cpy313_abi3, &unix).unwrap();
         assert_eq!(lib_name, "python3.13");
 
-        let lib_name = default_lib_name_for_target(cpy313_abi3, &win_x64);
+        let lib_name = default_lib_name_for_target(cpy313_abi3, &win_x64).unwrap();
         assert_eq!(lib_name, "python3");
 
-        let lib_name = default_lib_name_for_target(cpy313_abi3, &win_arm64);
+        let lib_name = default_lib_name_for_target(cpy313_abi3, &win_arm64).unwrap();
         assert_eq!(lib_name, "python3");
+
+        let lib_name = default_lib_name_for_target(cpy313_abi3, &win_gnu).unwrap();
+        assert_eq!(lib_name, "libpython3");
     }
 }

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -166,27 +166,7 @@ pub fn print_expected_cfgs() {
     }
 
     // pyo3_dll cfg for raw-dylib linking on Windows
-    let mut dll_names = vec![
-        "python3".to_string(),
-        "python3_d".to_string(),
-        "python3t".to_string(),
-        "python3t_d".to_string(),
-    ];
-    for i in impl_::MINIMUM_SUPPORTED_VERSION.minor..=impl_::STABLE_ABI_MAX_MINOR + 1 {
-        dll_names.push(format!("python3{i}"));
-        dll_names.push(format!("python3{i}_d"));
-        if i >= 13 {
-            dll_names.push(format!("python3{i}t"));
-            dll_names.push(format!("python3{i}t_d"));
-        }
-    }
-    // PyPy DLL names (libpypy3.X-c.dll)
-    for i in
-        impl_::MINIMUM_SUPPORTED_VERSION_PYPY.minor..=impl_::MAXIMUM_SUPPORTED_VERSION_PYPY.minor
-    {
-        dll_names.push(format!("libpypy3.{i}-c"));
-    }
-    let values = dll_names
+    let values = impl_::supported_pyo3_dll_names()
         .iter()
         .map(|n| format!("\"{n}\""))
         .collect::<Vec<_>>()
@@ -210,8 +190,9 @@ pub mod pyo3_build_script_impl {
         pub use crate::errors::*;
     }
     pub use crate::impl_::{
-        cargo_env_var, env_var, is_linking_libpython_for_target, target_triple_from_env,
-        InterpreterConfig, PythonAbi, PythonAbiKind, PythonVersion, StableAbi,
+        cargo_env_var, env_var, is_linking_libpython_for_target, supported_pyo3_dll_names,
+        target_triple_from_env, InterpreterConfig, PythonAbi, PythonAbiKind, PythonVersion,
+        StableAbi,
     };
     pub enum BuildConfigSource {
         /// Config was provided by `PYO3_CONFIG_FILE`.

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -228,8 +228,11 @@ fn emit_link_config(build_config: &BuildConfig) -> Result<()> {
         //    the import library resolves those symbols correctly.
         let target_env = cargo_env_var("CARGO_CFG_TARGET_ENV").unwrap();
         let mingw_import_lib = if matches!(target_env.as_str(), "gnu" | "gnullvm") {
-            // e.g. `libpython3.12` -> `-lpython3.12`, which GNU ld resolves to
-            // `libpython3.12.dll.a`.
+            // GNU import libraries use a `lib` prefix on the filename but not on
+            // the `-l` flag: e.g. `libpython3.12` -> `-lpython3.12` resolves to
+            // `libpython3.12.dll.a`. Only CPython names are mapped here: PyPy on
+            // Windows is MSVC-built (`libpypy3.X-c.dll`) and ships no GNU import
+            // library.
             lib_name
                 .strip_prefix("libpython")
                 .map(|version| format!("python{version}"))
@@ -237,10 +240,43 @@ fn emit_link_config(build_config: &BuildConfig) -> Result<()> {
             None
         };
 
+        // Emit the import-library link line only when GNU ld has a realistic
+        // chance of finding it: `lib_dir` puts it on the search path explicitly,
+        // and native builds (e.g. inside an MSYS2 environment) have it on the
+        // default search path. When cross-compiling without a lib dir, skip it
+        // and rely on raw-dylib alone rather than failing the link for pure-Rust
+        // modules — except on i686, where raw-dylib is broken (see above) and an
+        // early "cannot find" link error beats a subtly broken artifact.
+        let mut emitted_import_lib = false;
         if let Some(import_lib_name) = &mingw_import_lib {
-            println!("cargo:rustc-link-lib={import_lib_name}");
+            let is_cross = matches!(build_config.source, BuildConfigSource::CrossCompile);
+            let i686 = cargo_env_var("CARGO_CFG_TARGET_ARCH").unwrap() == "x86";
             if let Some(lib_dir) = interpreter_config.lib_dir() {
                 println!("cargo:rustc-link-search=native={lib_dir}");
+                println!("cargo:rustc-link-lib={import_lib_name}");
+                emitted_import_lib = true;
+            } else if !is_cross || i686 {
+                println!("cargo:rustc-link-lib={import_lib_name}");
+                emitted_import_lib = true;
+                if is_cross {
+                    warn!(
+                        "raw-dylib linking is not functional on i686-pc-windows-gnu \
+                         (https://github.com/rust-lang/rust/issues/138963), so the \
+                         GNU import library `lib{import_lib_name}.dll.a` is required. \
+                         Set PYO3_CROSS_LIB_DIR to the directory containing it if \
+                         the linker cannot find it."
+                    );
+                }
+            } else {
+                warn!(
+                    "Not linking the GNU import library `lib{import_lib_name}.dll.a` \
+                     because PYO3_CROSS_LIB_DIR is not set; relying on raw-dylib \
+                     linking only. Mixed Rust/C extension modules may fail to \
+                     resolve Python symbols not declared by PyO3 \
+                     (https://github.com/PyO3/pyo3/issues/6157) - set \
+                     PYO3_CROSS_LIB_DIR to the directory containing the import \
+                     library if needed."
+                );
             }
         }
 
@@ -259,11 +295,14 @@ fn emit_link_config(build_config: &BuildConfig) -> Result<()> {
                  If this Python distribution is a standard environment, please file \
                  a bug against PyO3: https://github.com/PyO3/pyo3/issues"
             );
-            if mingw_import_lib.is_some() {
-                // The conventional import-library link emitted above can still
-                // resolve the Python symbols at the final link, as it did before
-                // PyO3 0.28.
-                warn!("{message}");
+            if emitted_import_lib {
+                warn!(
+                    "{message}\n\
+                     \n\
+                     `extern_libpython!` will not apply a `#[link]` attribute for \
+                     this name; only the conventional import-library link line \
+                     emitted above can resolve Python symbols."
+                );
             } else {
                 bail!("{message}");
             }

--- a/pyo3-ffi/build.rs
+++ b/pyo3-ffi/build.rs
@@ -3,7 +3,8 @@ use pyo3_build_config::{
     pyo3_build_script_impl::{
         cargo_env_var, env_var, errors::Result, is_linking_libpython_for_target,
         print_feature_cfgs, print_libpython_rpath_link_args, resolve_build_config,
-        target_triple_from_env, BuildConfig, BuildConfigSource, MaximumVersionExceeded,
+        supported_pyo3_dll_names, target_triple_from_env, BuildConfig, BuildConfigSource,
+        MaximumVersionExceeded,
     },
     warn, InterpreterConfig, PythonAbiKind, PythonImplementation, PythonVersion, StableAbi,
 };
@@ -208,6 +209,65 @@ fn emit_link_config(build_config: &BuildConfig) -> Result<()> {
         // Python interpreter on Windows is not supported by this path (and is not
         // officially supported by CPython on Windows).
         println!("cargo:rustc-cfg=pyo3_dll=\"{lib_name}\"");
+
+        // For MinGW-built CPython (e.g. MSYS2), which ships `lib`-prefixed DLLs
+        // (`libpython3.12.dll`) together with GNU import libraries
+        // (`libpython3.12.dll.a`), additionally emit a conventional link line on
+        // `*-windows-gnu(llvm)` targets. This is needed because:
+        //
+        // 1. rustc's generated raw-dylib import library only contains the symbols
+        //    declared in pyo3-ffi's extern blocks for the current configuration.
+        //    Non-Rust objects taking part in the same final link (e.g.
+        //    CFFI-generated C code in a mixed Rust/C extension module) may
+        //    reference other Python symbols - for example `__imp__Py_NoneStruct`
+        //    under abi3, where pyo3-ffi does not declare `_Py_NoneStruct` - which
+        //    can only be resolved from the distribution's complete import library.
+        //    See https://github.com/PyO3/pyo3/issues/6157.
+        // 2. rustc generates incorrectly decorated raw-dylib import symbols on
+        //    i686-pc-windows-gnu (https://github.com/rust-lang/rust/issues/138963);
+        //    the import library resolves those symbols correctly.
+        let target_env = cargo_env_var("CARGO_CFG_TARGET_ENV").unwrap();
+        let mingw_import_lib = if matches!(target_env.as_str(), "gnu" | "gnullvm") {
+            // e.g. `libpython3.12` -> `-lpython3.12`, which GNU ld resolves to
+            // `libpython3.12.dll.a`.
+            lib_name
+                .strip_prefix("libpython")
+                .map(|version| format!("python{version}"))
+        } else {
+            None
+        };
+
+        if let Some(import_lib_name) = &mingw_import_lib {
+            println!("cargo:rustc-link-lib={import_lib_name}");
+            if let Some(lib_dir) = interpreter_config.lib_dir() {
+                println!("cargo:rustc-link-search=native={lib_dir}");
+            }
+        }
+
+        // Fail fast if the config's lib_name is not covered by `extern_libpython!`.
+        // Otherwise the extern blocks would silently get no `#[link]` attribute at
+        // all, and the build would fail much later with hundreds of confusing
+        // undefined-symbol errors (see https://github.com/PyO3/pyo3/issues/6157).
+        if !supported_pyo3_dll_names()
+            .iter()
+            .any(|name| name == lib_name)
+        {
+            let message = format!(
+                "The Python library name `{lib_name}` is not supported by PyO3's \
+                 raw-dylib linking on Windows.\n\
+                 \n\
+                 If this Python distribution is a standard environment, please file \
+                 a bug against PyO3: https://github.com/PyO3/pyo3/issues"
+            );
+            if mingw_import_lib.is_some() {
+                // The conventional import-library link emitted above can still
+                // resolve the Python symbols at the final link, as it did before
+                // PyO3 0.28.
+                warn!("{message}");
+            } else {
+                bail!("{message}");
+            }
+        }
     } else {
         println!(
             "cargo:rustc-link-lib={link_model}{lib_name}",

--- a/pyo3-ffi/src/impl_/macros.rs
+++ b/pyo3-ffi/src/impl_/macros.rs
@@ -231,9 +231,9 @@ macro_rules! extern_libpython_items {
 /// Helper macro to declare `extern` blocks that link against libpython on Windows
 /// using `raw-dylib`, eliminating the need for import libraries.
 ///
-/// The build script sets a `pyo3_dll` cfg value to the target DLL name (e.g. `python312`),
-/// and this macro expands to the appropriate `#[link(name = "...", kind = "raw-dylib")]`
-/// attribute for that DLL.
+/// The build script sets a `pyo3_dll` cfg value to the target DLL name (e.g. `python312`,
+/// or `libpython3.12` for MinGW-built Python), and this macro expands to the appropriate
+/// `#[link(name = "...", kind = "raw-dylib")]` attribute for that DLL.
 ///
 /// # Usage
 ///
@@ -260,7 +260,10 @@ macro_rules! extern_libpython {
             "python3", "python3_d",
             // abi3t
             "python3t", "python3t_d",
-            // Python 3.9 - 3.15
+            // abi3 for MinGW-built CPython, e.g. MSYS2 (libpython3.dll)
+            "libpython3",
+            // Python 3.9 - 3.15, plus the next in-development version, which
+            // pyo3-ffi allows building against with a warning
             "python39", "python39_d",
             "python310", "python310_d",
             "python311", "python311_d",
@@ -268,10 +271,15 @@ macro_rules! extern_libpython {
             "python313", "python313_d",
             "python314", "python314_d",
             "python315", "python315_d",
+            "python316", "python316_d",
             // free-threaded builds (3.13+)
             "python313t", "python313t_d",
             "python314t", "python314t_d",
             "python315t", "python315t_d",
+            "python316t", "python316t_d",
+            // MinGW-built CPython (DLL is libpython3.X.dll, not python3X.dll)
+            "libpython3.9", "libpython3.10", "libpython3.11", "libpython3.12",
+            "libpython3.13", "libpython3.14", "libpython3.15", "libpython3.16",
             // PyPy (DLL is libpypy3.X-c.dll, not pythonXY.dll)
             "libpypy3.11-c",
         );

--- a/pyo3-ffi/src/impl_/macros.rs
+++ b/pyo3-ffi/src/impl_/macros.rs
@@ -11,11 +11,21 @@
 //
 // Variables are intentionally excluded here: `import_name_type` does not affect
 // variable imports, so `_Py_*` statics continue to work without any rewriting.
+//
+// This is gated to `target_env = "msvc"`. MSVC-built `python3X.dll` retains the
+// cdecl leading underscore on `_Py_*` exports, and MSVC's undecoration pass
+// strips the extra `_` added here back to CPython's export name. MinGW-built
+// `libpython3.X.dll` is produced with `--kill-at`, so it exports the bare C
+// names (e.g. `_Py_Dealloc`), and on `*-windows-gnu` rustc emits the
+// `link_name` verbatim — adding the extra `_` would yield a double-underscored
+// import (`__Py_Dealloc`) that the DLL does not export, failing at load time
+// with "The specified procedure could not be found". Skipping the workaround
+// there leaves the bare symbol name, which matches MinGW's exports.
 #[allow(unused_macros, reason = "used indirectly by extern_libpython_item!")]
 macro_rules! extern_libpython_cpython_private_fn {
     ($(#[$attrs:meta])* $vis:vis $name:ident($($args:tt)*) $(-> $ret:ty)?) => {
         #[cfg_attr(
-            all(windows, target_arch = "x86", not(any(PyPy, GraalPy))),
+            all(windows, target_arch = "x86", target_env = "msvc", not(any(PyPy, GraalPy))),
             link_name = concat!("_", stringify!($name))
         )]
         $(#[$attrs])*


### PR DESCRIPTION
Alternative to #6164

Closes #6157