### PR TITLE
Reduce the amount of code we generate from macros

### DIFF
--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -482,18 +482,19 @@ impl SelfType {
                         // type); on PyPy under `ExtractErrorMode::NotImplemented` they now
                         // fall back to the default like `TryFrom` failures always have,
                         // instead of raising directly.
-                        quote_spanned! { *span =>
-                            unsafe {
-                                #pyo3_path::impl_::extract_argument::extract_receiver_trusted::<#cls, _>(#bound_ref)
-                            }
-                        }
+                        // The `unsafe` token is deliberately spanned at the macro call site
+                        // (plain `quote!`) so that `#![forbid(unsafe_code)]` in user code
+                        // doesn't reject the generated unsafe block.
+                        let call = quote_spanned! { *span =>
+                            #pyo3_path::impl_::extract_argument::extract_receiver_trusted::<#cls, _>(#bound_ref)
+                        };
+                        quote! { unsafe { #call } }
                     }
                     SelfConversionPolicyInner::Checked => {
-                        quote_spanned! { *span =>
-                            unsafe {
-                                #pyo3_path::impl_::extract_argument::extract_receiver::<#cls, _>(#bound_ref)
-                            }
-                        }
+                        let call = quote_spanned! { *span =>
+                            #pyo3_path::impl_::extract_argument::extract_receiver::<#cls, _>(#bound_ref)
+                        };
+                        quote! { unsafe { #call } }
                     }
                 };
                 error_mode.handle_error(receiver, ctx)

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -435,9 +435,12 @@ impl SelfType {
                         //
                         // The trailing `?` exists because if the extraction fails here it represents
                         // a genuine type error, should not fall back to e.g. `ExtractErrorMode::NotImplemented`.
+                        //
+                        // The cast is inlined (without a redundant nested `unsafe` block, unlike
+                        // the `Checked` path below) to keep the generated code small.
                         quote! {
                             unsafe { #pyo3_path::impl_::extract_argument::#method::<#cls>(
-                                #arg,
+                                #pyo3_path::impl_::extract_argument::#cast_fn(#py, #slf),
                                 &mut #holder,
                             ) }?
                         }
@@ -462,9 +465,9 @@ impl SelfType {
             }
             SelfType::TryFromBoundRef { span, non_null } => {
                 let bound_ref = if *non_null {
-                    quote! { unsafe { #pyo3_path::Bound::ref_from_non_null(#py, &#slf) } }
+                    quote! { #pyo3_path::Bound::ref_from_non_null(#py, &#slf) }
                 } else {
-                    quote! { unsafe { #pyo3_path::Bound::ref_from_ptr(#py, &#slf) } }
+                    quote! { #pyo3_path::Bound::ref_from_ptr(#py, &#slf) }
                 };
                 let pyo3_path = pyo3_path.to_tokens_spanned(*span);
                 let receiver = match self_conversion.0 {
@@ -474,39 +477,26 @@ impl SelfType {
                         // an instance of the correct type (or a compatible subtype) before
                         // invoking the slot.
                         //
-                        // The wrapping `Ok(...?)` here is because an error here should not
-                        // be treated by e.g. `ExtractErrorMode::NotImplemented` as falling
-                        // back to the default, but instead a genuine type error.
-                        quote! {
+                        // Note: cast failures inside the fused helper can only occur on
+                        // PyPy (CPython's slot dispatch contract guarantees the receiver
+                        // type); on PyPy under `ExtractErrorMode::NotImplemented` they now
+                        // fall back to the default like `TryFrom` failures always have,
+                        // instead of raising directly.
+                        quote_spanned! { *span =>
                             unsafe {
-                                #pyo3_path::PyResult::Ok(
-                                    #pyo3_path::impl_::extract_argument::cast_bound_ref_trusted::<#cls>(#bound_ref)?
-                                )
+                                #pyo3_path::impl_::extract_argument::extract_receiver_trusted::<#cls, _>(#bound_ref)
                             }
                         }
                     }
                     SelfConversionPolicyInner::Checked => {
                         quote_spanned! { *span =>
-                            #bound_ref.cast::<#cls>()
-                                .map_err(::std::convert::Into::<#pyo3_path::PyErr>::into)
+                            unsafe {
+                                #pyo3_path::impl_::extract_argument::extract_receiver::<#cls, _>(#bound_ref)
+                            }
                         }
                     }
                 };
-                error_mode.handle_error(
-                    quote_spanned! { *span =>
-                        #receiver
-                            .and_then(
-                                #[allow(
-                                    clippy::unnecessary_fallible_conversions,
-                                    clippy::useless_conversion,
-                                    reason = "anything implementing `TryFrom<&Bound>` is permitted"
-                                )]
-                                |bound| ::std::convert::TryFrom::try_from(bound).map_err(::std::convert::Into::into)
-                            )
-
-                    },
-                    ctx
-                )
+                error_mode.handle_error(receiver, ctx)
             }
         }
     }
@@ -904,7 +894,11 @@ impl<'a> FnSpec<'a> {
                     (None, None)
                 };
                 let args = self_arg.into_iter().chain(args);
-                let ok_wrap = quotes::ok_wrap(ret_ident.to_token_stream(), ctx);
+                let return_conversion = quotes::wrap_into_pyobject(
+                    ret_ident.to_token_stream(),
+                    quote!(assume_attached.py()),
+                    ctx,
+                );
                 quote! {
                     {
                         let coroutine = {
@@ -930,8 +924,7 @@ impl<'a> FnSpec<'a> {
                                         function(#(#args),*)
                                     };
                                     let #ret_ident = future.await;
-                                    let #ret_ident = #ok_wrap;
-                                    #pyo3_path::impl_::wrap::converter(&#ret_ident).map_into_pyobject(assume_attached.py(), #ret_ident)
+                                    #return_conversion
                                 },
                             )
                         };
@@ -940,10 +933,7 @@ impl<'a> FnSpec<'a> {
                 }
             } else {
                 let args = self_arg.into_iter().chain(args);
-                let return_conversion = quotes::map_result_into_ptr(
-                    quotes::ok_wrap(ret_ident.to_token_stream(), ctx),
-                    ctx,
-                );
+                let return_conversion = quotes::wrap_into_ptr(ret_ident.to_token_stream(), ctx);
                 quote! {
                     {
                         #init_holders
@@ -990,8 +980,7 @@ impl<'a> FnSpec<'a> {
                     ) -> #pyo3_path::PyResult<*mut #pyo3_path::ffi::PyObject> {
                         let function = #rust_name; // Shadow the function name to avoid #3017
                         #warnings
-                        let result = #call;
-                        result
+                        #call
                     }
                 }
             }
@@ -1005,8 +994,7 @@ impl<'a> FnSpec<'a> {
                             let function = #rust_name; // Shadow the function name to avoid #3017
                             #arg_convert
                             #warnings
-                            let result = #call;
-                            result
+                            #call
                         }
                     );
                 }
@@ -1025,8 +1013,7 @@ impl<'a> FnSpec<'a> {
                         let function = #rust_name; // Shadow the function name to avoid #3017
                         #arg_convert
                         #warnings
-                        let result = #call;
-                        result
+                        #call
                     }
                 }
             }
@@ -1049,20 +1036,24 @@ impl<'a> FnSpec<'a> {
             FnType::FnStatic => quote! { .flags(#pyo3_path::ffi::METH_STATIC) },
             _ => quote! {},
         };
-        let trampoline = match convention {
-            CallingConvention::Noargs => Ident::new("noargs", Span::call_site()),
+        // Constructor names on `PyMethodDef` and (shorter) trampoline aliases in
+        // `impl_::trampoline` - the short aliases keep the generated code small.
+        let (constructor, trampoline) = match convention {
+            CallingConvention::Noargs => ("noargs", "noargs"),
             CallingConvention::Fastcall => {
-                Ident::new("maybe_fastcall_cfunction_with_keywords", Span::call_site())
+                ("maybe_fastcall_cfunction_with_keywords", "fastcall_kw")
             }
-            CallingConvention::Varargs => Ident::new("cfunction_with_keywords", Span::call_site()),
+            CallingConvention::Varargs => ("cfunction_with_keywords", "cfunc_kw"),
         };
+        let constructor = Ident::new(constructor, Span::call_site());
+        let trampoline = Ident::new(trampoline, Span::call_site());
         let doc = if let Some(doc) = doc {
             doc.to_cstr_stream(ctx)?
         } else {
             c"".to_token_stream()
         };
         Ok(quote! {
-            #pyo3_path::impl_::pymethods::PyMethodDef::#trampoline(
+            #pyo3_path::impl_::pymethods::PyMethodDef::#constructor(
                 #python_name,
                 #pyo3_path::impl_::trampoline::get_trampoline_function!(#trampoline, #wrapper),
                 #doc,

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -286,18 +286,13 @@ pub(crate) fn impl_regular_arg_param(
                 )?
             }
         } else {
-            // The `unsafe` token is deliberately spanned at the macro call site (plain
-            // `quote!`) so that `#![forbid(unsafe_code)]` in user code doesn't reject the
-            // generated unsafe block.
-            let call = quote_arg_span! {
+            quote_arg_span! {
                 #pyo3_path::impl_::extract_argument::from_py_with_required(
                     #arg_value.as_deref(),
                     #name_str,
                     #extractor,
-                )
-            };
-            let unsafe_call = quote! { unsafe { #call } };
-            quote_arg_span! { #unsafe_call? }
+                )?
+            }
         }
     } else if let Some(default) = default {
         let holder = holders.push_holder(arg.ty.span());
@@ -314,16 +309,12 @@ pub(crate) fn impl_regular_arg_param(
         }
     } else {
         let holder = holders.push_holder(arg.ty.span());
-        // As above, the `unsafe` token is spanned at the macro call site to be compatible
-        // with `#![forbid(unsafe_code)]` in user code.
-        let call = quote_arg_span! {
+        quote_arg_span! {
             #pyo3_path::impl_::extract_argument::extract_required_argument(
                 #arg_value,
                 &mut #holder,
                 #name_str
-            )
-        };
-        let unsafe_call = quote! { unsafe { #call } };
-        quote_arg_span! { #unsafe_call? }
+            )?
+        }
     }
 }

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -29,9 +29,18 @@ impl Holders {
     pub fn init_holders(&self, ctx: &Ctx) -> TokenStream {
         let Ctx { pyo3_path, .. } = ctx;
         let holders = &self.holders;
+        if holders.is_empty() {
+            return TokenStream::new();
+        }
+        // The holders are declared with a single tuple pattern to keep the generated code
+        // small (this also avoids triggering `clippy::let_unit_value` for the holders which
+        // are just `()`).
+        let holders_init = holders
+            .iter()
+            .map(|_| quote!(#pyo3_path::impl_::extract_argument::FunctionArgumentHolder::INIT))
+            .collect::<Vec<_>>();
         quote! {
-            #[allow(clippy::let_unit_value, reason = "many holders are just `()`")]
-            #(let mut #holders = #pyo3_path::impl_::extract_argument::FunctionArgumentHolder::INIT;)*
+            let (#(mut #holders,)*) = (#(#holders_init,)*);
         }
     }
 }
@@ -102,10 +111,7 @@ pub fn impl_arg_params(
         .map(|(name, default_value)| {
             let required = default_value.is_none();
             quote! {
-                #pyo3_path::impl_::extract_argument::KeywordOnlyParameterDescription {
-                    name: #name,
-                    required: #required,
-                }
+                #pyo3_path::impl_::extract_argument::KeywordOnlyParameterDescription::new(#name, #required)
             }
         });
 
@@ -165,14 +171,15 @@ pub fn impl_arg_params(
     // create array of arguments, and then parse
     (
         quote! {
-                const DESCRIPTION: #pyo3_path::impl_::extract_argument::FunctionDescription = #pyo3_path::impl_::extract_argument::FunctionDescription {
-                    cls_name: #cls_name,
-                    func_name: stringify!(#python_name),
-                    positional_parameter_names: &[#(#positional_parameter_names),*],
-                    positional_only_parameters: #positional_only_parameters,
-                    required_positional_parameters: #required_positional_parameters,
-                    keyword_only_parameters: &[#(#keyword_only_parameters),*],
-                };
+                const DESCRIPTION: #pyo3_path::impl_::extract_argument::FunctionDescription =
+                    #pyo3_path::impl_::extract_argument::FunctionDescription::new(
+                        #cls_name,
+                        stringify!(#python_name),
+                        &[#(#positional_parameter_names),*],
+                        #positional_only_parameters,
+                        #required_positional_parameters,
+                        &[#(#keyword_only_parameters),*],
+                    );
                 let mut #args_array = [::std::option::Option::None; #num_params];
                 let (_args, _kwargs) = #extract_expression;
                 #from_py_with
@@ -247,13 +254,10 @@ pub(crate) fn impl_regular_arg_param(
     let pyo3_path = pyo3_path.to_tokens_spanned(arg.ty.span());
 
     // Use this macro inside this function, to ensure that all code generated here is associated
-    // with the function argument
-    let use_probe = quote! {
-        #[allow(unused_imports, reason = "`Probe` trait used on negative case only")]
-        use #pyo3_path::impl_::pyclass::Probe as _;
-    };
+    // with the function argument. The `Probe` trait used by some of the extraction machinery is
+    // imported once per wrapper function (see `Holders::init_holders`).
     macro_rules! quote_arg_span {
-        ($($tokens:tt)*) => { quote_spanned!(arg.ty.span() => { #use_probe $($tokens)* }) }
+        ($($tokens:tt)*) => { quote_spanned!(arg.ty.span() => $($tokens)*) }
     }
 
     let name_str = arg.name.to_string();
@@ -282,13 +286,14 @@ pub(crate) fn impl_regular_arg_param(
                 )?
             }
         } else {
-            let unwrap = quote! {unsafe { #pyo3_path::impl_::extract_argument::unwrap_required_argument_bound(#arg_value.as_deref()) }};
             quote_arg_span! {
-                #pyo3_path::impl_::extract_argument::from_py_with(
-                    #unwrap,
-                    #name_str,
-                    #extractor,
-                )?
+                unsafe {
+                    #pyo3_path::impl_::extract_argument::from_py_with_required(
+                        #arg_value.as_deref(),
+                        #name_str,
+                        #extractor,
+                    )
+                }?
             }
         }
     } else if let Some(default) = default {
@@ -306,13 +311,14 @@ pub(crate) fn impl_regular_arg_param(
         }
     } else {
         let holder = holders.push_holder(arg.ty.span());
-        let unwrap = quote! { unsafe { #pyo3_path::impl_::extract_argument::unwrap_required_argument(#arg_value) } };
         quote_arg_span! {
-            #pyo3_path::impl_::extract_argument::extract_argument(
-                #unwrap,
-                &mut #holder,
-                #name_str
-            )?
+            unsafe {
+                #pyo3_path::impl_::extract_argument::extract_required_argument(
+                    #arg_value,
+                    &mut #holder,
+                    #name_str
+                )
+            }?
         }
     }
 }

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -286,15 +286,18 @@ pub(crate) fn impl_regular_arg_param(
                 )?
             }
         } else {
-            quote_arg_span! {
-                unsafe {
-                    #pyo3_path::impl_::extract_argument::from_py_with_required(
-                        #arg_value.as_deref(),
-                        #name_str,
-                        #extractor,
-                    )
-                }?
-            }
+            // The `unsafe` token is deliberately spanned at the macro call site (plain
+            // `quote!`) so that `#![forbid(unsafe_code)]` in user code doesn't reject the
+            // generated unsafe block.
+            let call = quote_arg_span! {
+                #pyo3_path::impl_::extract_argument::from_py_with_required(
+                    #arg_value.as_deref(),
+                    #name_str,
+                    #extractor,
+                )
+            };
+            let unsafe_call = quote! { unsafe { #call } };
+            quote_arg_span! { #unsafe_call? }
         }
     } else if let Some(default) = default {
         let holder = holders.push_holder(arg.ty.span());
@@ -311,14 +314,16 @@ pub(crate) fn impl_regular_arg_param(
         }
     } else {
         let holder = holders.push_holder(arg.ty.span());
-        quote_arg_span! {
-            unsafe {
-                #pyo3_path::impl_::extract_argument::extract_required_argument(
-                    #arg_value,
-                    &mut #holder,
-                    #name_str
-                )
-            }?
-        }
+        // As above, the `unsafe` token is spanned at the macro call site to be compatible
+        // with `#![forbid(unsafe_code)]` in user code.
+        let call = quote_arg_span! {
+            #pyo3_path::impl_::extract_argument::extract_required_argument(
+                #arg_value,
+                &mut #holder,
+                #name_str
+            )
+        };
+        let unsafe_call = quote! { unsafe { #call } };
+        quote_arg_span! { #unsafe_call? }
     }
 }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1136,14 +1136,11 @@ fn impl_simple_enum(
         quote! {
             impl<'py> #pyo3_path::conversion::IntoPyObject<'py> for #cls {
                 type Target = Self;
-                type Output = #pyo3_path::Bound<'py, <Self as #pyo3_path::conversion::IntoPyObject<'py>>::Target>;
+                type Output = #pyo3_path::Bound<'py, Self>;
                 type Error = #pyo3_path::PyErr;
                 #output_type
 
-                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<
-                    <Self as #pyo3_path::conversion::IntoPyObject<'py>>::Output,
-                    <Self as #pyo3_path::conversion::IntoPyObject<'py>>::Error,
-                > {
+                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<Self::Output> {
                     // TODO(icxolu): switch this to lookup the variants on the type object, once that is immutable
                     static SINGLETON: [#pyo3_path::sync::PyOnceLock<#pyo3_path::Py<#cls>>; #num] =
                         [const { #pyo3_path::sync::PyOnceLock::<#pyo3_path::Py<#cls>>::new() }; #num];
@@ -1268,14 +1265,11 @@ fn impl_complex_enum(
         quote! {
             impl<'py> #pyo3_path::conversion::IntoPyObject<'py> for #cls {
                 type Target = Self;
-                type Output = #pyo3_path::Bound<'py, <Self as #pyo3_path::conversion::IntoPyObject<'py>>::Target>;
+                type Output = #pyo3_path::Bound<'py, Self>;
                 type Error = #pyo3_path::PyErr;
                 #output_type
 
-                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<
-                    <Self as #pyo3_path::conversion::IntoPyObject>::Output,
-                    <Self as #pyo3_path::conversion::IntoPyObject>::Error,
-                > {
+                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<Self::Output> {
                     match self {
                         #(#match_arms)*
                     }
@@ -2309,15 +2303,7 @@ fn impl_pytypeinfo(cls: &Ident, attr: &PyClassArgs, ctx: &Ctx) -> TokenStream {
 
             #[inline]
             fn type_object_raw(py: #pyo3_path::Python<'_>) -> *mut #pyo3_path::ffi::PyTypeObject {
-                use #pyo3_path::prelude::PyTypeMethods;
-                <#cls as #pyo3_path::impl_::pyclass::PyClassImpl>::lazy_type_object()
-                    .get_or_try_init(py)
-                    .unwrap_or_else(|e| #pyo3_path::impl_::pyclass::type_object_init_failed(
-                        py,
-                        e,
-                        <Self as #pyo3_path::PyClass>::NAME
-                    ))
-                    .as_type_ptr()
+                #pyo3_path::impl_::pyclass::pyclass_type_object_raw::<Self>(py)
             }
         }
     }
@@ -2773,14 +2759,11 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote! {
                 impl<'py> #pyo3_path::conversion::IntoPyObject<'py> for #cls {
                     type Target = Self;
-                    type Output = #pyo3_path::Bound<'py, <Self as #pyo3_path::conversion::IntoPyObject<'py>>::Target>;
+                    type Output = #pyo3_path::Bound<'py, Self>;
                     type Error = #pyo3_path::PyErr;
                     #output_type
 
-                    fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> ::std::result::Result<
-                        <Self as #pyo3_path::conversion::IntoPyObject>::Output,
-                        <Self as #pyo3_path::conversion::IntoPyObject>::Error,
-                    > {
+                    fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<Self::Output> {
                         #pyo3_path::Bound::new(py, self)
                     }
                 }
@@ -2792,17 +2775,26 @@ impl<'a> PyClassImplsBuilder<'a> {
     fn impl_pyclassimpl(&self, ctx: &Ctx) -> Result<TokenStream> {
         let Ctx { pyo3_path, .. } = ctx;
         let cls = self.cls_ident;
-        let doc = if let Some(doc) = &self.doc {
-            doc.to_cstr_stream(ctx)?
-        } else {
-            c"".to_token_stream()
+        // `RAW_DOC` defaults to `c""` in the trait definition; only emit it when there is a
+        // docstring.
+        let raw_doc = match &self.doc {
+            Some(doc) => {
+                let doc = doc.to_cstr_stream(ctx)?;
+                Some(quote! { const RAW_DOC: &'static ::std::ffi::CStr = #doc; })
+            }
+            None => None,
         };
 
-        let module = if let Some(ModuleAttribute { value, .. }) = &self.attr.options.module {
-            quote! { ::core::option::Option::Some(#value) }
-        } else {
-            quote! { ::core::option::Option::None }
-        };
+        // All of these consts have defaults in the `PyClassImpl` trait definition; only emit
+        // them when they differ from the default, to keep the generated code small.
+        let module = self
+            .attr
+            .options
+            .module
+            .as_ref()
+            .map(|ModuleAttribute { value, .. }| {
+                quote! { const MODULE: ::std::option::Option<&str> = ::core::option::Option::Some(#value); }
+            });
 
         let is_basetype = self.attr.options.subclass.is_some();
         let base = match &self.attr.options.extends {
@@ -2818,6 +2810,13 @@ impl<'a> PyClassImplsBuilder<'a> {
             !(is_mapping && is_sequence),
             cls.span() => "a `#[pyclass]` cannot be both a `mapping` and a `sequence`"
         );
+
+        let is_basetype = is_basetype.then(|| quote! { const IS_BASETYPE: bool = true; });
+        let is_subclass_const = is_subclass.then(|| quote! { const IS_SUBCLASS: bool = true; });
+        let is_mapping = is_mapping.then(|| quote! { const IS_MAPPING: bool = true; });
+        let is_sequence = is_sequence.then(|| quote! { const IS_SEQUENCE: bool = true; });
+        let is_immutable_type =
+            is_immutable_type.then(|| quote! { const IS_IMMUTABLE_TYPE: bool = true; });
 
         let dict_offset = if self.attr.options.dict.is_some() {
             quote! {
@@ -2847,7 +2846,10 @@ impl<'a> PyClassImplsBuilder<'a> {
 
         let (pymethods_items, inventory, inventory_class) = match self.methods_type {
             PyClassMethodsType::Specialization => (
-                quote! {{ use #pyo3_path::impl_::pyclass::PyMethods as _; collector.py_methods() }},
+                quote! {{
+                    use #pyo3_path::impl_::pyclass::PyMethods as _;
+                    #pyo3_path::impl_::pyclass::PyClassImplCollector::<Self>::new().py_methods()
+                }},
                 None,
                 None,
             ),
@@ -2880,11 +2882,56 @@ impl<'a> PyClassImplsBuilder<'a> {
                 self.default_slots
                     .iter()
                     .map(|meth| &meth.associated_method),
-            );
+            )
+            .collect::<Vec<_>>();
+        // Skip emitting the associated-methods impl block entirely when it would be empty.
+        let default_methods_impl = (!default_methods.is_empty()).then(|| {
+            quote! {
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                impl #cls {
+                    #(#default_methods)*
+                }
+            }
+        });
 
-        let default_method_defs = self.default_methods.iter().map(|meth| &meth.method_def);
-        let default_slot_defs = self.default_slots.iter().map(|slot| &slot.slot_def);
+        let default_method_defs = self
+            .default_methods
+            .iter()
+            .map(|meth| &meth.method_def)
+            .collect::<Vec<_>>();
+        let default_slot_defs = self
+            .default_slots
+            .iter()
+            .map(|slot| &slot.slot_def)
+            .collect::<Vec<_>>();
         let freelist_slots = self.freelist_slots(ctx);
+
+        // When there are no intrinsic items, point at a shared empty `PyClassItems` to keep the
+        // generated code small.
+        let items_iter = if default_method_defs.is_empty()
+            && default_slot_defs.is_empty()
+            && freelist_slots.is_empty()
+        {
+            quote! {
+                fn items_iter() -> #pyo3_path::impl_::pyclass::PyClassItemsIter {
+                    #pyo3_path::impl_::pyclass::PyClassItemsIter::new(
+                        &#pyo3_path::impl_::pyclass::NO_PY_CLASS_ITEMS,
+                        #pymethods_items,
+                    )
+                }
+            }
+        } else {
+            quote! {
+                fn items_iter() -> #pyo3_path::impl_::pyclass::PyClassItemsIter {
+                    static INTRINSIC_ITEMS: #pyo3_path::impl_::pyclass::PyClassItems = #pyo3_path::impl_::pyclass::PyClassItems {
+                        methods: &[#(#default_method_defs),*],
+                        slots: &[#(#default_slot_defs),* #(#freelist_slots),*],
+                    };
+                    #pyo3_path::impl_::pyclass::PyClassItemsIter::new(&INTRINSIC_ITEMS, #pymethods_items)
+                }
+            }
+        };
 
         let class_mutability = if self.attr.options.frozen.is_some() {
             quote! {
@@ -2975,25 +3022,31 @@ impl<'a> PyClassImplsBuilder<'a> {
             TokenStream::new()
         };
 
+        let assertions = (!assertions.is_empty()).then(|| {
+            quote! {
+                #[allow(dead_code)]
+                const _: () = {
+                    #assertions
+                };
+            }
+        });
+
         Ok(quote! {
             #deprecation
 
             #extract_pyclass_with_clone
 
-            #[allow(dead_code)]
-            const _: () ={
-                #assertions
-            };
+            #assertions
 
             #pyclass_base_type_impl
 
             impl #pyo3_path::impl_::pyclass::PyClassImpl for #cls {
-                const MODULE: ::std::option::Option<&str> = #module;
-                const IS_BASETYPE: bool = #is_basetype;
-                const IS_SUBCLASS: bool = #is_subclass;
-                const IS_MAPPING: bool = #is_mapping;
-                const IS_SEQUENCE: bool = #is_sequence;
-                const IS_IMMUTABLE_TYPE: bool = #is_immutable_type;
+                #module
+                #is_basetype
+                #is_subclass_const
+                #is_mapping
+                #is_sequence
+                #is_immutable_type
 
                 type Layout = <Self::BaseNativeType as #pyo3_path::impl_::pyclass::PyClassBaseType>::Layout<Self>;
                 type BaseType = #base;
@@ -3004,27 +3057,16 @@ impl<'a> PyClassImplsBuilder<'a> {
                 type WeakRef = #weakref;
                 type BaseNativeType = #base_nativetype;
 
-                fn items_iter() -> #pyo3_path::impl_::pyclass::PyClassItemsIter {
-                    let collector = #pyo3_path::impl_::pyclass::PyClassImplCollector::<Self>::new();
-                    static INTRINSIC_ITEMS: #pyo3_path::impl_::pyclass::PyClassItems = #pyo3_path::impl_::pyclass::PyClassItems {
-                        methods: &[#(#default_method_defs),*],
-                        slots: &[#(#default_slot_defs),* #(#freelist_slots),*],
-                    };
-                    #pyo3_path::impl_::pyclass::PyClassItemsIter::new(&INTRINSIC_ITEMS, #pymethods_items)
-                }
+                #items_iter
 
-                const RAW_DOC: &'static ::std::ffi::CStr = #doc;
+                #raw_doc
 
-                const DOC: &'static ::std::ffi::CStr = {
-                    use #pyo3_path::impl_ as impl_;
-                    use impl_::pyclass::Probe as _;
-                    const DOC_PIECES: &'static [&'static [u8]] = impl_::pyclass::doc::PyClassDocGenerator::<
+                const DOC_PIECES: &'static [&'static [u8]] = {
+                    use #pyo3_path::impl_::pyclass::Probe as _;
+                    #pyo3_path::impl_::pyclass::doc::PyClassDocGenerator::<
                         #cls,
-                        { impl_::pyclass::HasNewTextSignature::<#cls>::VALUE }
-                    >::DOC_PIECES;
-                    const LEN: usize = impl_::concat::combined_len(DOC_PIECES);
-                    const DOC: &'static [u8] = &impl_::concat::combine_to_array::<LEN>(DOC_PIECES);
-                    impl_::pyclass::doc::doc_bytes_as_cstr(DOC)
+                        { #pyo3_path::impl_::pyclass::HasNewTextSignature::<#cls>::VALUE }
+                    >::DOC_PIECES
                 };
 
                 #dict_offset
@@ -3038,11 +3080,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                 }
             }
 
-            #[doc(hidden)]
-            #[allow(non_snake_case)]
-            impl #cls {
-                #(#default_methods)*
-            }
+            #default_methods_impl
 
             #inventory_class
         })

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1140,7 +1140,7 @@ fn impl_simple_enum(
                 type Error = #pyo3_path::PyErr;
                 #output_type
 
-                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<Self::Output> {
+                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<#pyo3_path::Bound<'py, Self>> {
                     // TODO(icxolu): switch this to lookup the variants on the type object, once that is immutable
                     static SINGLETON: [#pyo3_path::sync::PyOnceLock<#pyo3_path::Py<#cls>>; #num] =
                         [const { #pyo3_path::sync::PyOnceLock::<#pyo3_path::Py<#cls>>::new() }; #num];
@@ -1269,7 +1269,7 @@ fn impl_complex_enum(
                 type Error = #pyo3_path::PyErr;
                 #output_type
 
-                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<Self::Output> {
+                fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<#pyo3_path::Bound<'py, Self>> {
                     match self {
                         #(#match_arms)*
                     }
@@ -2763,7 +2763,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     type Error = #pyo3_path::PyErr;
                     #output_type
 
-                    fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<Self::Output> {
+                    fn into_pyobject(self, py: #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<#pyo3_path::Bound<'py, Self>> {
                         #pyo3_path::Bound::new(py, self)
                     }
                 }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -3061,12 +3061,16 @@ impl<'a> PyClassImplsBuilder<'a> {
 
                 #raw_doc
 
-                const DOC_PIECES: &'static [&'static [u8]] = {
-                    use #pyo3_path::impl_::pyclass::Probe as _;
-                    #pyo3_path::impl_::pyclass::doc::PyClassDocGenerator::<
+                const DOC: &'static ::std::ffi::CStr = {
+                    use #pyo3_path::impl_ as impl_;
+                    use impl_::pyclass::Probe as _;
+                    const DOC_PIECES: &'static [&'static [u8]] = impl_::pyclass::doc::PyClassDocGenerator::<
                         #cls,
-                        { #pyo3_path::impl_::pyclass::HasNewTextSignature::<#cls>::VALUE }
-                    >::DOC_PIECES
+                        { impl_::pyclass::HasNewTextSignature::<#cls>::VALUE }
+                    >::DOC_PIECES;
+                    const LEN: usize = impl_::concat::combined_len(DOC_PIECES);
+                    const DOC: &'static [u8] = &impl_::concat::combine_to_array::<LEN>(DOC_PIECES);
+                    impl_::pyclass::doc::doc_bytes_as_cstr(DOC)
                 };
 
                 #dict_offset

--- a/pyo3-macros-backend/src/pyimpl.rs
+++ b/pyo3-macros-backend/src/pyimpl.rs
@@ -223,16 +223,23 @@ pub fn impl_methods(
         PyClassMethodsType::Inventory => submit_methods_inventory(ty, methods, proto_impls, ctx),
     };
 
+    // Skip emitting the associated-methods impl block entirely when it would be empty.
+    let associated_methods_impl = (!associated_methods.is_empty()).then(|| {
+        quote! {
+            #[doc(hidden)]
+            #[allow(non_snake_case)]
+            impl #ty {
+                #(#associated_methods)*
+            }
+        }
+    });
+
     Ok(quote! {
         #(#extra_fragments)*
 
         #items
 
-        #[doc(hidden)]
-        #[allow(non_snake_case)]
-        impl #ty {
-            #(#associated_methods)*
-        }
+        #associated_methods_impl
     })
 }
 

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -562,13 +562,13 @@ pub(crate) fn impl_py_class_attribute(
 
     let wrapper_ident = format_ident!("__pymethod_{}__", name);
     let python_name = spec.null_terminated_python_name();
-    let body = quotes::ok_wrap(fncall, ctx);
+    let conversion = quotes::wrap_into_pyobject(quote!(result), quote!(py), ctx);
 
     let associated_method = quote! {
         fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
             let function = #cls::#name; // Shadow the method name to avoid #3017
-            let result = #body;
-            #pyo3_path::impl_::wrap::converter(&result).map_into_pyobject(py, result)
+            let result = #fncall;
+            #conversion
         }
     };
 
@@ -1546,7 +1546,7 @@ fn generate_method_body(
 
             let value = syn::Ident::new("value", Span::call_site());
             let resolver = quote_spanned! { *output_span =>
-                #pyo3_path::impl_::pymethods::tp_new_resolver::<#cls, _>(&#value).resolve(#value);
+                #pyo3_path::impl_::pymethods::tp_new_resolver::<#cls, _>(&#value).resolve(#value)
             };
 
             let body = quote! {

--- a/pyo3-macros-backend/src/quotes.rs
+++ b/pyo3-macros-backend/src/quotes.rs
@@ -9,28 +9,30 @@ pub(crate) fn some_wrap(obj: TokenStream, ctx: &Ctx) -> TokenStream {
     }
 }
 
-pub(crate) fn ok_wrap(obj: TokenStream, ctx: &Ctx) -> TokenStream {
-    let Ctx {
-        pyo3_path,
-        output_span,
-    } = ctx;
-    let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
-    quote_spanned! { *output_span => {
-        let obj = #obj;
-        #[allow(clippy::useless_conversion, reason = "needed for Into<PyErr> conversion, may be redundant")]
-        #pyo3_path::impl_::wrap::converter(&obj).wrap(obj).map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
-    }}
-}
-
-pub(crate) fn map_result_into_ptr(result: TokenStream, ctx: &Ctx) -> TokenStream {
+/// Fused return-value conversion: wraps a (possibly `Result`) return value and converts it
+/// into a `PyResult<*mut ffi::PyObject>` in a single call. `obj` must be an identifier
+/// bound to the function's return value (it is evaluated twice).
+pub(crate) fn wrap_into_ptr(obj: TokenStream, ctx: &Ctx) -> TokenStream {
     let Ctx {
         pyo3_path,
         output_span,
     } = ctx;
     let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
     let py = syn::Ident::new("py", proc_macro2::Span::call_site());
-    quote_spanned! { *output_span => {
-        let result = #result;
-        #pyo3_path::impl_::wrap::converter(&result).map_into_ptr(#py, result)
-    }}
+    quote_spanned! { *output_span =>
+        #pyo3_path::impl_::wrap::converter(&#obj).wrap_into_ptr(#py, #obj)
+    }
+}
+
+/// As `wrap_into_ptr`, but produces a `PyResult<Py<PyAny>>`. The Python token expression
+/// is supplied by the caller.
+pub(crate) fn wrap_into_pyobject(obj: TokenStream, py: TokenStream, ctx: &Ctx) -> TokenStream {
+    let Ctx {
+        pyo3_path,
+        output_span,
+    } = ctx;
+    let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
+    quote_spanned! { *output_span =>
+        #pyo3_path::impl_::wrap::converter(&#obj).wrap_into_pyobject(#py, #obj)
+    }
 }

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -340,13 +340,15 @@ where
     }
 }
 
-/// Fused version of [`unwrap_required_argument`] + [`extract_argument`], used for required
-/// arguments to keep the generated code small.
+/// Fused unwrap + [`extract_argument`], used for required arguments to keep the generated
+/// code small.
 ///
-/// # Safety
-/// `obj` must not be `None`
+/// The macro-generated caller guarantees `obj` is `Some` (the `FunctionDescription`
+/// `extract_arguments_` methods check that all required arguments are provided); the `None`
+/// arm is unreachable but kept as a branch so that this function is safe to call (avoiding
+/// an `unsafe` block in the generated code).
 #[inline]
-pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
     obj: Option<Borrowed<'a, 'py, PyAny>>,
     holder: &'holder mut T::Holder,
     arg_name: &str,
@@ -354,8 +356,10 @@ pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FR
 where
     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
 {
-    // SAFETY: caller guarantees `obj` is not `None`
-    extract_argument(unsafe { unwrap_required_argument(obj) }, holder, arg_name)
+    match obj {
+        Some(obj) => extract_argument(obj, holder, arg_name),
+        None => unreachable!("required argument was not extracted"),
+    }
 }
 
 /// Alternative to [`extract_argument`] used when the argument has a default value provided by an annotation.
@@ -386,23 +390,21 @@ pub fn from_py_with<'a, 'py, T>(
     }
 }
 
-/// Fused version of [`unwrap_required_argument_bound`] + [`from_py_with`], used for required
-/// arguments with a `#[pyo3(from_py_with)]` annotation to keep the generated code small.
+/// Fused unwrap + [`from_py_with`], used for required arguments with a
+/// `#[pyo3(from_py_with)]` annotation to keep the generated code small.
 ///
-/// # Safety
-/// `obj` must not be `None`
+/// As [`extract_required_argument`], the `None` arm is unreachable but kept as a branch so
+/// that this function is safe to call.
 #[inline]
-pub unsafe fn from_py_with_required<'a, 'py, T>(
+pub fn from_py_with_required<'a, 'py, T>(
     obj: Option<&'a Bound<'py, PyAny>>,
     arg_name: &str,
     extractor: fn(&'a Bound<'py, PyAny>) -> PyResult<T>,
 ) -> PyResult<T> {
-    // SAFETY: caller guarantees `obj` is not `None`
-    from_py_with(
-        unsafe { unwrap_required_argument_bound(obj) },
-        arg_name,
-        extractor,
-    )
+    match obj {
+        Some(obj) => from_py_with(obj, arg_name, extractor),
+        None => unreachable!("required argument was not extracted"),
+    }
 }
 
 /// Alternative to [`extract_argument`] used when the argument has a `#[pyo3(from_py_with)]` annotation and also a default value.
@@ -430,40 +432,6 @@ pub fn argument_extraction_error(py: Python<'_>, arg_name: &str, error: PyErr) -
             .call_method1(crate::intern!(py, "add_note"), (msg,));
     };
     error
-}
-
-/// Unwraps the Option<&PyAny> produced by the FunctionDescription `extract_arguments_` methods.
-/// They check if required methods are all provided.
-///
-/// # Safety
-/// `argument` must not be `None`
-#[inline]
-pub unsafe fn unwrap_required_argument<'a, 'py>(
-    argument: Option<Borrowed<'a, 'py, PyAny>>,
-) -> Borrowed<'a, 'py, PyAny> {
-    match argument {
-        Some(value) => value,
-        #[cfg(debug_assertions)]
-        None => unreachable!("required method argument was not extracted"),
-        // SAFETY: invariant of calling this function. Enforced by the macros.
-        #[cfg(not(debug_assertions))]
-        None => unsafe { core::hint::unreachable_unchecked() },
-    }
-}
-
-/// Variant of above used with `from_py_with` extractors on required arguments.
-#[inline]
-pub unsafe fn unwrap_required_argument_bound<'a, 'py>(
-    argument: Option<&'a Bound<'py, PyAny>>,
-) -> &'a Bound<'py, PyAny> {
-    match argument {
-        Some(value) => value,
-        #[cfg(debug_assertions)]
-        None => unreachable!("required method argument was not extracted"),
-        // SAFETY: invariant of calling this function. Enforced by the macros.
-        #[cfg(not(debug_assertions))]
-        None => unsafe { core::hint::unreachable_unchecked() },
-    }
 }
 
 /// Cast a raw `*mut ffi::PyObject` to a `PyArg`. This is used to access safer PyO3

--- a/src/impl_/extract_argument.rs
+++ b/src/impl_/extract_argument.rs
@@ -292,6 +292,39 @@ pub unsafe fn cast_bound_ref_trusted<'a, 'py, T: PyTypeCheck>(
     }
 }
 
+/// Fused extraction for receivers which implement `TryFrom<&Bound<T>>` (e.g. `Py<T>`,
+/// `Bound<T>`, `PyRef<T>`), used to keep the generated code small. Trusted variant: performs an
+/// unchecked cast for extension-type slot receivers where CPython guarantees the receiver type.
+///
+/// # Safety
+/// The caller must ensure that `bound_ref` is an instance of `T`. This invariant is upheld by
+/// CPython when dispatching through type slots.
+#[inline]
+pub unsafe fn extract_receiver_trusted<'a, 'py, T, R>(
+    bound_ref: &'a Bound<'py, PyAny>,
+) -> PyResult<R>
+where
+    T: PyTypeCheck + 'a,
+    R: TryFrom<&'a Bound<'py, T>>,
+    R::Error: Into<PyErr>,
+{
+    // SAFETY: caller guarantees `bound_ref` is an instance of `T`
+    let bound = unsafe { cast_bound_ref_trusted::<T>(bound_ref) }?;
+    R::try_from(bound).map_err(Into::into)
+}
+
+/// As [`extract_receiver_trusted`], but performs a checked cast.
+#[inline]
+pub fn extract_receiver<'a, 'py, T, R>(bound_ref: &'a Bound<'py, PyAny>) -> PyResult<R>
+where
+    T: PyTypeCheck + 'a,
+    R: TryFrom<&'a Bound<'py, T>>,
+    R::Error: Into<PyErr>,
+{
+    let bound = bound_ref.cast::<T>().map_err(PyErr::from)?;
+    R::try_from(bound).map_err(Into::into)
+}
+
 /// The standard implementation of how PyO3 extracts a `#[pyfunction]` or `#[pymethod]` function argument.
 pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
     obj: Borrowed<'a, 'py, PyAny>,
@@ -305,6 +338,24 @@ where
         Ok(value) => Ok(value),
         Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e.into())),
     }
+}
+
+/// Fused version of [`unwrap_required_argument`] + [`extract_argument`], used for required
+/// arguments to keep the generated code small.
+///
+/// # Safety
+/// `obj` must not be `None`
+#[inline]
+pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+    obj: Option<Borrowed<'a, 'py, PyAny>>,
+    holder: &'holder mut T::Holder,
+    arg_name: &str,
+) -> PyResult<T>
+where
+    T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+{
+    // SAFETY: caller guarantees `obj` is not `None`
+    extract_argument(unsafe { unwrap_required_argument(obj) }, holder, arg_name)
 }
 
 /// Alternative to [`extract_argument`] used when the argument has a default value provided by an annotation.
@@ -333,6 +384,25 @@ pub fn from_py_with<'a, 'py, T>(
         Ok(value) => Ok(value),
         Err(e) => Err(argument_extraction_error(obj.py(), arg_name, e)),
     }
+}
+
+/// Fused version of [`unwrap_required_argument_bound`] + [`from_py_with`], used for required
+/// arguments with a `#[pyo3(from_py_with)]` annotation to keep the generated code small.
+///
+/// # Safety
+/// `obj` must not be `None`
+#[inline]
+pub unsafe fn from_py_with_required<'a, 'py, T>(
+    obj: Option<&'a Bound<'py, PyAny>>,
+    arg_name: &str,
+    extractor: fn(&'a Bound<'py, PyAny>) -> PyResult<T>,
+) -> PyResult<T> {
+    // SAFETY: caller guarantees `obj` is not `None`
+    from_py_with(
+        unsafe { unwrap_required_argument_bound(obj) },
+        arg_name,
+        extractor,
+    )
 }
 
 /// Alternative to [`extract_argument`] used when the argument has a `#[pyo3(from_py_with)]` annotation and also a default value.
@@ -449,6 +519,13 @@ pub struct KeywordOnlyParameterDescription {
     pub required: bool,
 }
 
+impl KeywordOnlyParameterDescription {
+    /// Compact constructor used by the macros to keep the generated code small.
+    pub const fn new(name: &'static str, required: bool) -> Self {
+        Self { name, required }
+    }
+}
+
 /// Function argument specification for a `#[pyfunction]` or `#[pymethod]`.
 pub struct FunctionDescription {
     pub cls_name: Option<&'static str>,
@@ -460,6 +537,25 @@ pub struct FunctionDescription {
 }
 
 impl FunctionDescription {
+    /// Compact constructor used by the macros to keep the generated code small.
+    pub const fn new(
+        cls_name: Option<&'static str>,
+        func_name: &'static str,
+        positional_parameter_names: &'static [&'static str],
+        positional_only_parameters: usize,
+        required_positional_parameters: usize,
+        keyword_only_parameters: &'static [KeywordOnlyParameterDescription],
+    ) -> Self {
+        Self {
+            cls_name,
+            func_name,
+            positional_parameter_names,
+            positional_only_parameters,
+            required_positional_parameters,
+            keyword_only_parameters,
+        }
+    }
+
     fn full_name(&self) -> String {
         if let Some(cls_name) = self.cls_name {
             format!("{}.{}()", cls_name, self.func_name)

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -248,13 +248,11 @@ pub trait PyClassImpl: Sized + 'static {
     /// This is exposed for `PyClassDocGenerator` to use as a docstring piece.
     const RAW_DOC: &'static CStr = c"";
 
-    /// Pieces of the fully rendered class doc, including the `text_signature` if a constructor
-    /// is defined.
+    /// Fully rendered class doc, including the `text_signature` if a constructor is defined.
     ///
-    /// This is constructed with const specialization via the proc macros with help from the
-    /// `PyClassDocGenerator` type. The pieces are concatenated once at type-object creation
-    /// time; the final piece is `RAW_DOC` and is nul terminated.
-    const DOC_PIECES: &'static [&'static [u8]] = &[Self::RAW_DOC.to_bytes_with_nul()];
+    /// This is constructed at compile-time with const specialization via the proc macros with help
+    /// from the `PyClassDocGenerator` type.
+    const DOC: &'static CStr;
 
     fn items_iter() -> PyClassItemsIter;
 

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -33,7 +33,7 @@ mod lazy_type_object;
 mod probes;
 
 pub use assertions::*;
-pub use lazy_type_object::{type_object_init_failed, LazyTypeObject};
+pub use lazy_type_object::{pyclass_type_object_raw, type_object_init_failed, LazyTypeObject};
 pub use probes::*;
 
 /// Gets the offset of the dictionary from the start of the object in bytes.
@@ -179,6 +179,13 @@ pub struct PyClassItems {
 // Allow PyClassItems in statics
 unsafe impl Sync for PyClassItems {}
 
+/// Shared empty items, used by the macros for classes without any intrinsic items to keep the
+/// generated code small.
+pub static NO_PY_CLASS_ITEMS: PyClassItems = PyClassItems {
+    methods: &[],
+    slots: &[],
+};
+
 /// Implements the underlying functionality of `#[pyclass]`, assembled by various proc macros.
 ///
 /// Users are discouraged from implementing this trait manually; it is a PyO3 implementation detail
@@ -188,7 +195,7 @@ pub trait PyClassImpl: Sized + 'static {
     ///
     /// (Currently defaults to `builtins` if unset, this will likely be improved in the future, it
     /// may also be removed when passing module objects in class init.)
-    const MODULE: Option<&'static str>;
+    const MODULE: Option<&'static str> = None;
 
     /// #[pyclass(subclass)]
     const IS_BASETYPE: bool = false;
@@ -239,13 +246,15 @@ pub trait PyClassImpl: Sized + 'static {
     /// Docstring for the class provided on the struct or enum.
     ///
     /// This is exposed for `PyClassDocGenerator` to use as a docstring piece.
-    const RAW_DOC: &'static CStr;
+    const RAW_DOC: &'static CStr = c"";
 
-    /// Fully rendered class doc, including the `text_signature` if a constructor is defined.
+    /// Pieces of the fully rendered class doc, including the `text_signature` if a constructor
+    /// is defined.
     ///
-    /// This is constructed at compile-time with const specialization via the proc macros with help
-    /// from the PyClassDocGenerator` type.
-    const DOC: &'static CStr;
+    /// This is constructed with const specialization via the proc macros with help from the
+    /// `PyClassDocGenerator` type. The pieces are concatenated once at type-object creation
+    /// time; the final piece is `RAW_DOC` and is nul terminated.
+    const DOC_PIECES: &'static [&'static [u8]] = &[Self::RAW_DOC.to_bytes_with_nul()];
 
     fn items_iter() -> PyClassItemsIter;
 

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -261,6 +261,17 @@ pub fn type_object_init_failed(py: Python<'_>, err: PyErr, type_name: &str) -> !
     panic!("failed to create type object for `{type_name}`")
 }
 
+/// The full macro-expanded implementation of `type_object_raw` for `#[pyclass]` types, kept
+/// out-of-line here to reduce the amount of macro-generated code.
+#[inline]
+pub fn pyclass_type_object_raw<T: PyClass>(py: Python<'_>) -> *mut ffi::PyTypeObject {
+    use crate::types::PyTypeMethods;
+    T::lazy_type_object()
+        .get_or_try_init(py)
+        .unwrap_or_else(|e| type_object_init_failed(py, e, <T as PyClass>::NAME))
+        .as_type_ptr()
+}
+
 #[cold]
 fn wrap_in_runtime_error(py: Python<'_>, err: PyErr, message: String) -> PyErr {
     let runtime_err = PyRuntimeError::new_err(message);

--- a/src/impl_/trampoline.rs
+++ b/src/impl_/trampoline.rs
@@ -154,6 +154,10 @@ pub use self::fastcall_cfunction_with_keywords as maybe_fastcall_cfunction_with_
 #[cfg(not(any(Py_3_10, not(Py_LIMITED_API))))]
 pub use self::cfunction_with_keywords as maybe_fastcall_cfunction_with_keywords;
 
+/// Short aliases for the trampolines above, used by the macros to keep the generated code small.
+pub use self::cfunction_with_keywords as cfunc_kw;
+pub use self::maybe_fastcall_cfunction_with_keywords as fastcall_kw;
+
 // Trampolines used by slot methods
 trampolines!(
     pub fn getattrofunc(slf: *mut ffi::PyObject, attr: *mut ffi::PyObject) -> *mut ffi::PyObject;

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -3,7 +3,7 @@
 use core::{convert::Infallible, marker::PhantomData, ops::Deref};
 
 use crate::{
-    ffi, types::PyNone, Bound, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyResult, Python,
+    ffi, types::PyNone, Bound, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyErr, PyResult, Python,
 };
 
 /// Used to wrap values in `Option<T>` for default arguments.
@@ -104,10 +104,53 @@ impl EmptyTupleConverter<PyResult<()>> {
     }
 }
 
+impl EmptyTupleConverter<()> {
+    #[inline]
+    pub fn wrap_into_ptr(&self, py: Python<'_>, _obj: ()) -> PyResult<*mut ffi::PyObject> {
+        Ok(PyNone::get(py).to_owned().into_ptr())
+    }
+
+    #[inline]
+    pub fn wrap_into_pyobject(&self, py: Python<'_>, _obj: ()) -> PyResult<Py<PyAny>> {
+        Ok(PyNone::get(py).to_owned().into_any().unbind())
+    }
+}
+
+impl<E> EmptyTupleConverter<Result<(), E>>
+where
+    PyErr: From<E>,
+{
+    #[inline]
+    pub fn wrap_into_ptr(
+        &self,
+        py: Python<'_>,
+        obj: Result<(), E>,
+    ) -> PyResult<*mut ffi::PyObject> {
+        obj.map(|_| PyNone::get(py).to_owned().into_ptr())
+            .map_err(PyErr::from)
+    }
+
+    #[inline]
+    pub fn wrap_into_pyobject(&self, py: Python<'_>, obj: Result<(), E>) -> PyResult<Py<PyAny>> {
+        obj.map(|_| PyNone::get(py).to_owned().into_any().unbind())
+            .map_err(PyErr::from)
+    }
+}
+
 impl<'py, T: IntoPyObject<'py>> IntoPyObjectConverter<T> {
     #[inline]
     pub fn wrap(&self, obj: T) -> Result<T, Infallible> {
         Ok(obj)
+    }
+
+    #[inline]
+    pub fn wrap_into_ptr(&self, py: Python<'py>, obj: T) -> PyResult<*mut ffi::PyObject> {
+        obj.into_bound_py_any(py).map(Bound::into_ptr)
+    }
+
+    #[inline]
+    pub fn wrap_into_pyobject(&self, py: Python<'py>, obj: T) -> PyResult<Py<PyAny>> {
+        obj.into_py_any(py)
     }
 }
 
@@ -133,11 +176,49 @@ impl<'py, T: IntoPyObject<'py>, E> IntoPyObjectConverter<Result<T, E>> {
         obj.and_then(|obj| obj.into_bound_py_any(py))
             .map(Bound::into_ptr)
     }
+
+    #[inline]
+    pub fn wrap_into_ptr(&self, py: Python<'py>, obj: Result<T, E>) -> PyResult<*mut ffi::PyObject>
+    where
+        PyErr: From<E>,
+    {
+        obj.map_err(PyErr::from)
+            .and_then(|obj| obj.into_bound_py_any(py))
+            .map(Bound::into_ptr)
+    }
+
+    #[inline]
+    pub fn wrap_into_pyobject(&self, py: Python<'py>, obj: Result<T, E>) -> PyResult<Py<PyAny>>
+    where
+        PyErr: From<E>,
+    {
+        obj.map_err(PyErr::from).and_then(|obj| obj.into_py_any(py))
+    }
 }
 
 impl<T, E> UnknownReturnResultType<Result<T, E>> {
     #[inline]
     pub fn wrap<'py>(&self, _: Result<T, E>) -> Result<T, E>
+    where
+        T: IntoPyObject<'py>,
+    {
+        unreachable!("should be handled by IntoPyObjectConverter")
+    }
+
+    #[inline]
+    pub fn wrap_into_ptr<'py>(
+        &self,
+        _: Python<'py>,
+        _: Result<T, E>,
+    ) -> PyResult<*mut ffi::PyObject>
+    where
+        T: IntoPyObject<'py>,
+    {
+        unreachable!("should be handled by IntoPyObjectConverter")
+    }
+
+    #[inline]
+    pub fn wrap_into_pyobject<'py>(&self, _: Python<'py>, _: Result<T, E>) -> PyResult<Py<PyAny>>
     where
         T: IntoPyObject<'py>,
     {
@@ -164,6 +245,22 @@ impl<T> UnknownReturnType<T> {
 
     #[inline]
     pub fn map_into_ptr<'py>(&self, _: Python<'py>, _: PyResult<T>) -> PyResult<*mut ffi::PyObject>
+    where
+        T: IntoPyObject<'py>,
+    {
+        unreachable!("should be handled by IntoPyObjectConverter")
+    }
+
+    #[inline]
+    pub fn wrap_into_ptr<'py>(&self, _: Python<'py>, _: T) -> PyResult<*mut ffi::PyObject>
+    where
+        T: IntoPyObject<'py>,
+    {
+        unreachable!("should be handled by IntoPyObjectConverter")
+    }
+
+    #[inline]
+    pub fn wrap_into_pyobject<'py>(&self, _: Python<'py>, _: T) -> PyResult<Py<PyAny>>
     where
         T: IntoPyObject<'py>,
     {

--- a/src/impl_/wrap.rs
+++ b/src/impl_/wrap.rs
@@ -92,18 +92,6 @@ impl<T> Deref for UnknownReturnResultType<T> {
     }
 }
 
-impl EmptyTupleConverter<PyResult<()>> {
-    #[inline]
-    pub fn map_into_ptr(&self, py: Python<'_>, obj: PyResult<()>) -> PyResult<*mut ffi::PyObject> {
-        obj.map(|_| PyNone::get(py).to_owned().into_ptr())
-    }
-
-    #[inline]
-    pub fn map_into_pyobject(&self, py: Python<'_>, obj: PyResult<()>) -> PyResult<Py<PyAny>> {
-        obj.map(|_| PyNone::get(py).to_owned().into_any().unbind())
-    }
-}
-
 impl EmptyTupleConverter<()> {
     #[inline]
     pub fn wrap_into_ptr(&self, py: Python<'_>, _obj: ()) -> PyResult<*mut ffi::PyObject> {
@@ -161,23 +149,6 @@ impl<'py, T: IntoPyObject<'py>, E> IntoPyObjectConverter<Result<T, E>> {
     }
 
     #[inline]
-    pub fn map_into_pyobject(&self, py: Python<'py>, obj: PyResult<T>) -> PyResult<Py<PyAny>>
-    where
-        T: IntoPyObject<'py>,
-    {
-        obj.and_then(|obj| obj.into_py_any(py))
-    }
-
-    #[inline]
-    pub fn map_into_ptr(&self, py: Python<'py>, obj: PyResult<T>) -> PyResult<*mut ffi::PyObject>
-    where
-        T: IntoPyObject<'py>,
-    {
-        obj.and_then(|obj| obj.into_bound_py_any(py))
-            .map(Bound::into_ptr)
-    }
-
-    #[inline]
     pub fn wrap_into_ptr(&self, py: Python<'py>, obj: Result<T, E>) -> PyResult<*mut ffi::PyObject>
     where
         PyErr: From<E>,
@@ -229,22 +200,6 @@ impl<T, E> UnknownReturnResultType<Result<T, E>> {
 impl<T> UnknownReturnType<T> {
     #[inline]
     pub fn wrap<'py>(&self, _: T) -> T
-    where
-        T: IntoPyObject<'py>,
-    {
-        unreachable!("should be handled by IntoPyObjectConverter")
-    }
-
-    #[inline]
-    pub fn map_into_pyobject<'py>(&self, _: Python<'py>, _: PyResult<T>) -> PyResult<Py<PyAny>>
-    where
-        T: IntoPyObject<'py>,
-    {
-        unreachable!("should be handled by IntoPyObjectConverter")
-    }
-
-    #[inline]
-    pub fn map_into_ptr<'py>(&self, _: Python<'py>, _: PyResult<T>) -> PyResult<*mut ffi::PyObject>
     where
         T: IntoPyObject<'py>,
     {

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -59,7 +59,7 @@ where
         is_mapping: bool,
         is_sequence: bool,
         is_immutable_type: bool,
-        doc_pieces: &'static [&'static [u8]],
+        doc: &'static CStr,
         dict_offset: Option<PyObjectOffset>,
         weaklist_offset: Option<PyObjectOffset>,
         is_basetype: bool,
@@ -71,7 +71,6 @@ where
         unsafe {
             PyTypeBuilder {
                 slots: Vec::new(),
-                type_doc_storage: None,
                 method_defs: Vec::new(),
                 member_defs: Vec::new(),
                 getset_builders: HashMap::new(),
@@ -94,7 +93,7 @@ where
                 dict_offset: None,
                 class_flags: 0,
             }
-            .type_doc(doc_pieces)
+            .type_doc(doc)
             .offsets(dict_offset, weaklist_offset)
             .set_is_basetype(is_basetype)
             .class_items(items_iter)
@@ -113,7 +112,7 @@ where
             T::IS_MAPPING,
             T::IS_SEQUENCE,
             T::IS_IMMUTABLE_TYPE,
-            T::DOC_PIECES,
+            T::DOC,
             T::dict_offset(),
             T::weaklist_offset(),
             T::IS_BASETYPE,
@@ -130,9 +129,6 @@ type PyTypeBuilderCleanup = Box<dyn Fn(&PyTypeBuilder, *mut ffi::PyTypeObject)>;
 
 struct PyTypeBuilder {
     slots: Vec<ffi::PyType_Slot>,
-    /// Assembled type doc; kept alive here because `slots` borrows its buffer until
-    /// `PyType_FromSpec` (which copies the doc) has been called in `build`.
-    type_doc_storage: Option<CString>,
     method_defs: Vec<ffi::PyMethodDef>,
     member_defs: Vec<ffi::PyMemberDef>,
     getset_builders: HashMap<&'static CStr, GetSetDefBuilder>,
@@ -347,14 +343,9 @@ impl PyTypeBuilder {
         self
     }
 
-    fn type_doc(mut self, doc_pieces: &'static [&'static [u8]]) -> Self {
-        // The doc pieces are concatenated here, once per class at type-object creation time,
-        // rather than at compile time, to keep the amount of macro-generated code small. The
-        // final piece is nul terminated, so the concatenation is a valid C string.
-        let bytes = doc_pieces.concat();
-        if bytes.len() > 1 {
-            let type_doc =
-                CString::from_vec_with_nul(bytes).expect("pyclass doc contains nul bytes");
+    fn type_doc(mut self, type_doc: &'static CStr) -> Self {
+        let slice = type_doc.to_bytes();
+        if !slice.is_empty() {
             unsafe { self.push_slot(ffi::Py_tp_doc, type_doc.as_ptr() as *mut c_char) }
 
             #[cfg(all(not(Py_LIMITED_API), not(Py_3_10)))]
@@ -363,7 +354,6 @@ impl PyTypeBuilder {
                 // heap-types, and it removed the text_signature value from it.
                 // We go in after the fact and replace tp_doc with something
                 // that _does_ include the text_signature value!
-                let slice = type_doc.as_bytes().to_vec();
                 self.cleanup
                     .push(Box::new(move |_self, type_object| unsafe {
                         ffi::PyObject_Free((*type_object).tp_doc as _);
@@ -372,8 +362,6 @@ impl PyTypeBuilder {
                         (*type_object).tp_doc = data as _;
                     }))
             }
-
-            self.type_doc_storage = Some(type_doc);
         }
         self
     }

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -59,7 +59,7 @@ where
         is_mapping: bool,
         is_sequence: bool,
         is_immutable_type: bool,
-        doc: &'static CStr,
+        doc_pieces: &'static [&'static [u8]],
         dict_offset: Option<PyObjectOffset>,
         weaklist_offset: Option<PyObjectOffset>,
         is_basetype: bool,
@@ -71,6 +71,7 @@ where
         unsafe {
             PyTypeBuilder {
                 slots: Vec::new(),
+                type_doc_storage: None,
                 method_defs: Vec::new(),
                 member_defs: Vec::new(),
                 getset_builders: HashMap::new(),
@@ -93,7 +94,7 @@ where
                 dict_offset: None,
                 class_flags: 0,
             }
-            .type_doc(doc)
+            .type_doc(doc_pieces)
             .offsets(dict_offset, weaklist_offset)
             .set_is_basetype(is_basetype)
             .class_items(items_iter)
@@ -112,7 +113,7 @@ where
             T::IS_MAPPING,
             T::IS_SEQUENCE,
             T::IS_IMMUTABLE_TYPE,
-            T::DOC,
+            T::DOC_PIECES,
             T::dict_offset(),
             T::weaklist_offset(),
             T::IS_BASETYPE,
@@ -129,6 +130,9 @@ type PyTypeBuilderCleanup = Box<dyn Fn(&PyTypeBuilder, *mut ffi::PyTypeObject)>;
 
 struct PyTypeBuilder {
     slots: Vec<ffi::PyType_Slot>,
+    /// Assembled type doc; kept alive here because `slots` borrows its buffer until
+    /// `PyType_FromSpec` (which copies the doc) has been called in `build`.
+    type_doc_storage: Option<CString>,
     method_defs: Vec<ffi::PyMethodDef>,
     member_defs: Vec<ffi::PyMemberDef>,
     getset_builders: HashMap<&'static CStr, GetSetDefBuilder>,
@@ -343,9 +347,14 @@ impl PyTypeBuilder {
         self
     }
 
-    fn type_doc(mut self, type_doc: &'static CStr) -> Self {
-        let slice = type_doc.to_bytes();
-        if !slice.is_empty() {
+    fn type_doc(mut self, doc_pieces: &'static [&'static [u8]]) -> Self {
+        // The doc pieces are concatenated here, once per class at type-object creation time,
+        // rather than at compile time, to keep the amount of macro-generated code small. The
+        // final piece is nul terminated, so the concatenation is a valid C string.
+        let bytes = doc_pieces.concat();
+        if bytes.len() > 1 {
+            let type_doc =
+                CString::from_vec_with_nul(bytes).expect("pyclass doc contains nul bytes");
             unsafe { self.push_slot(ffi::Py_tp_doc, type_doc.as_ptr() as *mut c_char) }
 
             #[cfg(all(not(Py_LIMITED_API), not(Py_3_10)))]
@@ -354,6 +363,7 @@ impl PyTypeBuilder {
                 // heap-types, and it removed the text_signature value from it.
                 // We go in after the fact and replace tp_doc with something
                 // that _does_ include the text_signature value!
+                let slice = type_doc.as_bytes().to_vec();
                 self.cleanup
                     .push(Box::new(move |_self, type_object| unsafe {
                         ffi::PyObject_Free((*type_object).tp_doc as _);
@@ -362,6 +372,8 @@ impl PyTypeBuilder {
                         (*type_object).tp_doc = data as _;
                     }))
             }
+
+            self.type_doc_storage = Some(type_doc);
         }
         self
     }

--- a/src/pyclass/guard.rs
+++ b/src/pyclass/guard.rs
@@ -475,25 +475,12 @@ impl<U: ?Sized> Drop for PyClassGuardMap<'_, U> {
 ///         _slf: *mut ::pyo3::ffi::PyObject,
 ///     ) -> ::pyo3::PyResult<*mut ::pyo3::ffi::PyObject> {
 ///         let function = Number::increment;
-/// #       #[allow(clippy::let_unit_value)]
-///         let mut holder_0 = ::pyo3::impl_::extract_argument::FunctionArgumentHolder::INIT;
-///         let result = {
-///             let ret = function(::pyo3::impl_::extract_argument::extract_pyclass_ref_mut::<Number>(
-///                 unsafe { ::pyo3::impl_::extract_argument::cast_function_argument(py, _slf) },
-///                 &mut holder_0,
-///             )?);
-///             {
-///                 let result = {
-///                     let obj = ret;
-/// #                   #[allow(clippy::useless_conversion)]
-///                     ::pyo3::impl_::wrap::converter(&obj)
-///                         .wrap(obj)
-///                         .map_err(::core::convert::Into::<::pyo3::PyErr>::into)
-///                 };
-///                 ::pyo3::impl_::wrap::converter(&result).map_into_ptr(py, result)
-///             }
-///         };
-///         result
+///         let (mut holder_0,) = (::pyo3::impl_::extract_argument::FunctionArgumentHolder::INIT,);
+///         let ret = function(::pyo3::impl_::extract_argument::extract_pyclass_ref_mut::<Number>(
+///             unsafe { ::pyo3::impl_::extract_argument::cast_function_argument(py, _slf) },
+///             &mut holder_0,
+///         )?);
+///         ::pyo3::impl_::wrap::converter(&ret).wrap_into_ptr(py, ret)
 ///     }
 ///
 ///     unsafe {

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -17,9 +17,9 @@ error: `cancel_handle` attribute can only be used with `async fn`
    |                                                     ^^^^^^
 
 error: `from_py_with` and `cancel_handle` cannot be specified together
-  --> tests/ui/invalid_cancel_handle.rs:30:12
+  --> tests/ui/invalid_cancel_handle.rs:32:12
    |
-30 |     #[pyo3(cancel_handle, from_py_with = cancel_handle)] _param: pyo3::coroutine::CancelHandle,
+32 |     #[pyo3(cancel_handle, from_py_with = cancel_handle)] _param: pyo3::coroutine::CancelHandle,
    |            ^^^^^^^^^^^^^
 
 error[E0277]: `CancelHandle` cannot be used as a Python function argument
@@ -73,31 +73,92 @@ error[E0277]: `CancelHandle` cannot be used as a Python function argument
    --> tests/ui/invalid_cancel_handle.rs:24:50
     |
  24 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
-    |                                                  ^^^^ the trait `FromPyObject<'_, '_>` is not implemented for `CancelHandle`
+    |                                                  ^^^^ the trait `pyo3::PyClass` is not implemented for `CancelHandle`
     |
     = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
-              `&'a CStr` implements `FromPyObject<'a, '_>`
-              `&'a [u8]` implements `FromPyObject<'a, 'py>`
-              `&'a str` implements `FromPyObject<'a, '_>`
-              `(T0, T1)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
-            and $N others
-    = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
+help: the trait `pyo3::PyClass` is implemented for `pyo3::coroutine::Coroutine`
+ --> src/coroutine.rs
+  |
+  | #[pyclass(crate = "crate")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
+  = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 7 previous errors
+error[E0277]: `CancelHandle` cannot be used as a Python function argument
+   --> tests/ui/invalid_cancel_handle.rs:24:50
+    |
+ 24 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
+    |                                                  ^^^^ the trait `Clone` is not implemented for `CancelHandle`
+    |
+    = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
+    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
+help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
+ --> src/impl_/extract_argument.rs
+  |
+  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
+  | |     for &'holder Bound<'py, T>
+  | | where
+  | |     T: PyTypeCheck,
+  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
+  | | where
+  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
+  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+...
+  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
+  | |     for &'holder mut T
+  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+  = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
+  = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+
+error[E0277]: `CancelHandle` cannot be used as a Python function argument
+   --> tests/ui/invalid_cancel_handle.rs:24:50
+    |
+ 24 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
+    |                                                  ^^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `CancelHandle`
+    |
+    = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
+    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
+help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented for `pyo3::coroutine::Coroutine`
+ --> src/coroutine.rs
+  |
+  | #[pyclass(crate = "crate")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
+  = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -17,9 +17,9 @@ error: `cancel_handle` attribute can only be used with `async fn`
    |                                                     ^^^^^^
 
 error: `from_py_with` and `cancel_handle` cannot be specified together
-  --> tests/ui/invalid_cancel_handle.rs:32:12
+  --> tests/ui/invalid_cancel_handle.rs:30:12
    |
-32 |     #[pyo3(cancel_handle, from_py_with = cancel_handle)] _param: pyo3::coroutine::CancelHandle,
+30 |     #[pyo3(cancel_handle, from_py_with = cancel_handle)] _param: pyo3::coroutine::CancelHandle,
    |            ^^^^^^^^^^^^^
 
 error[E0277]: `CancelHandle` cannot be used as a Python function argument
@@ -73,57 +73,21 @@ error[E0277]: `CancelHandle` cannot be used as a Python function argument
    --> tests/ui/invalid_cancel_handle.rs:24:50
     |
  24 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
-    |                                                  ^^^^ the trait `pyo3::PyClass` is not implemented for `CancelHandle`
+    |                                                  ^^^^ the trait `FromPyObject<'_, '_>` is not implemented for `CancelHandle`
     |
     = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `pyo3::PyClass` is implemented for `pyo3::coroutine::Coroutine`
- --> src/coroutine.rs
-  |
-  | #[pyclass(crate = "crate")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-  = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `CancelHandle` cannot be used as a Python function argument
-   --> tests/ui/invalid_cancel_handle.rs:24:50
-    |
- 24 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
-    |                                                  ^^^^ the trait `Clone` is not implemented for `CancelHandle`
-    |
-    = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-  = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
+    = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -133,32 +97,7 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_required_ar
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
 
-error[E0277]: `CancelHandle` cannot be used as a Python function argument
-   --> tests/ui/invalid_cancel_handle.rs:24:50
-    |
- 24 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
-    |                                                  ^^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `CancelHandle`
-    |
-    = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented for `pyo3::coroutine::Coroutine`
- --> src/coroutine.rs
-  |
-  | #[pyclass(crate = "crate")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-  = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 9 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -87,8 +87,8 @@ help: the trait `pyo3::PyClass` is implemented for `pyo3::coroutine::Coroutine`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -127,8 +127,8 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -151,8 +151,8 @@ help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented f
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`

--- a/tests/ui/invalid_pyclass_args.default.stderr
+++ b/tests/ui/invalid_pyclass_args.default.stderr
@@ -1,109 +1,109 @@
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
- --> tests/ui/invalid_pyclass_args.rs:8:11
+ --> tests/ui/invalid_pyclass_args.rs:9:11
   |
-8 | #[pyclass(extend=pyo3::types::PyDict)]
+9 | #[pyclass(extend=pyo3::types::PyDict)]
   |           ^^^^^^
 
 error: expected identifier
-  --> tests/ui/invalid_pyclass_args.rs:12:21
+  --> tests/ui/invalid_pyclass_args.rs:13:21
    |
-12 | #[pyclass(extends = "PyDict")]
+13 | #[pyclass(extends = "PyDict")]
    |                     ^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:16:18
+  --> tests/ui/invalid_pyclass_args.rs:17:18
    |
-16 | #[pyclass(name = m::MyClass)]
+17 | #[pyclass(name = m::MyClass)]
    |                  ^
 
 error: expected a single identifier in double quotes
-  --> tests/ui/invalid_pyclass_args.rs:20:18
+  --> tests/ui/invalid_pyclass_args.rs:21:18
    |
-20 | #[pyclass(name = "Custom Name")]
+21 | #[pyclass(name = "Custom Name")]
    |                  ^^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:24:18
+  --> tests/ui/invalid_pyclass_args.rs:25:18
    |
-24 | #[pyclass(name = CustomName)]
+25 | #[pyclass(name = CustomName)]
    |                  ^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:28:24
+  --> tests/ui/invalid_pyclass_args.rs:29:24
    |
-28 | #[pyclass(rename_all = camelCase)]
+29 | #[pyclass(rename_all = camelCase)]
    |                        ^^^^^^^^^
 
 error: expected a valid renaming rule, possible values are: "camelCase", "kebab-case", "lowercase", "PascalCase", "SCREAMING-KEBAB-CASE", "SCREAMING_SNAKE_CASE", "snake_case", "UPPERCASE"
-  --> tests/ui/invalid_pyclass_args.rs:32:24
+  --> tests/ui/invalid_pyclass_args.rs:33:24
    |
-32 | #[pyclass(rename_all = "Camel-Case")]
+33 | #[pyclass(rename_all = "Camel-Case")]
    |                        ^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:36:20
+  --> tests/ui/invalid_pyclass_args.rs:37:20
    |
-36 | #[pyclass(module = my_module)]
+37 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
-  --> tests/ui/invalid_pyclass_args.rs:40:11
+  --> tests/ui/invalid_pyclass_args.rs:41:11
    |
-40 | #[pyclass(weakrev)]
+41 | #[pyclass(weakrev)]
    |           ^^^^^^^
 
 error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
-  --> tests/ui/invalid_pyclass_args.rs:45:8
+  --> tests/ui/invalid_pyclass_args.rs:46:8
    |
-45 | struct CannotBeMappingAndSequence {}
+46 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `eq_int` can only be used on simple enums.
-  --> tests/ui/invalid_pyclass_args.rs:72:11
+  --> tests/ui/invalid_pyclass_args.rs:73:11
    |
-72 | #[pyclass(eq_int)]
+73 | #[pyclass(eq_int)]
    |           ^^^^^^
 
 error: The `hash` option requires the `frozen` option.
-  --> tests/ui/invalid_pyclass_args.rs:81:11
+  --> tests/ui/invalid_pyclass_args.rs:82:11
    |
-81 | #[pyclass(hash)]
+82 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `hash` option requires the `eq` option.
-  --> tests/ui/invalid_pyclass_args.rs:81:11
+  --> tests/ui/invalid_pyclass_args.rs:82:11
    |
-81 | #[pyclass(hash)]
+82 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `ord` option requires the `eq` option.
-   --> tests/ui/invalid_pyclass_args.rs:101:11
+   --> tests/ui/invalid_pyclass_args.rs:102:11
     |
-101 | #[pyclass(ord)]
+102 | #[pyclass(ord)]
     |           ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:109:12
+   --> tests/ui/invalid_pyclass_args.rs:110:12
     |
-109 |     #[pyo3(foo)]
+110 |     #[pyo3(foo)]
     |            ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:111:12
+   --> tests/ui/invalid_pyclass_args.rs:112:12
     |
-111 |     #[pyo3(blah)]
+112 |     #[pyo3(blah)]
     |            ^^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:114:12
+   --> tests/ui/invalid_pyclass_args.rs:115:12
     |
-114 |     #[pyo3(pop)]
+115 |     #[pyo3(pop)]
     |            ^^^
 
 error: invalid format string: expected `}` but string was terminated
-   --> tests/ui/invalid_pyclass_args.rs:138:19
+   --> tests/ui/invalid_pyclass_args.rs:139:19
     |
-138 | #[pyclass(str = "{")]
+139 | #[pyclass(str = "{")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -111,9 +111,9 @@ error: invalid format string: expected `}` but string was terminated
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `}`, found `$`
-   --> tests/ui/invalid_pyclass_args.rs:143:19
+   --> tests/ui/invalid_pyclass_args.rs:144:19
     |
-143 | #[pyclass(str = "{$}")]
+144 | #[pyclass(str = "{$}")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -121,385 +121,329 @@ error: invalid format string: expected `}`, found `$`
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:171:31
+   --> tests/ui/invalid_pyclass_args.rs:172:31
     |
-171 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+172 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:178:31
+   --> tests/ui/invalid_pyclass_args.rs:179:31
     |
-178 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+179 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:184:17
+   --> tests/ui/invalid_pyclass_args.rs:185:17
     |
-184 | #[pyclass(str = "unsafe: {unsafe_variable}")]
+185 | #[pyclass(str = "unsafe: {unsafe_variable}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:191:54
+   --> tests/ui/invalid_pyclass_args.rs:192:54
     |
-191 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
+192 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
     |                                                      ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:199:17
+   --> tests/ui/invalid_pyclass_args.rs:200:17
     |
-199 | #[pyclass(str = "{:?}")]
+200 | #[pyclass(str = "{:?}")]
     |                 ^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:207:17
+   --> tests/ui/invalid_pyclass_args.rs:208:17
     |
-207 | #[pyclass(str = "{}")]
+208 | #[pyclass(str = "{}")]
     |                 ^^^^
 
 error: The format string syntax cannot be used with enums
-   --> tests/ui/invalid_pyclass_args.rs:215:21
+   --> tests/ui/invalid_pyclass_args.rs:216:21
     |
-215 | #[pyclass(eq, str = "Stuff...")]
+216 | #[pyclass(eq, str = "Stuff...")]
     |                     ^^^^^^^^^^
 
 error: `skip_from_py_object` and `from_py_object` are mutually exclusive
-   --> tests/ui/invalid_pyclass_args.rs:229:27
+   --> tests/ui/invalid_pyclass_args.rs:230:27
     |
-229 | #[pyclass(from_py_object, skip_from_py_object)]
+230 | #[pyclass(from_py_object, skip_from_py_object)]
     |                           ^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:236:11
+error: use of deprecated constant `pyo3::impl_::deprecated::SKIP_FROM_PY_OBJECT_DEPRECATED`: `skip_from_py_object` enabled by default. The option will be removed in the future
+   --> tests/ui/invalid_pyclass_args.rs:244:11
     |
-236 | #[pyclass(from_py_object)]
+244 | #[pyclass(skip_from_py_object)]
+    |           ^^^^^^^^^^^^^^^^^^^
+    |
+note: the lint level is defined here
+   --> tests/ui/invalid_pyclass_args.rs:4:9
+    |
+  4 | #![deny(deprecated)]
+    |         ^^^^^^^^^^
+
+error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
+   --> tests/ui/invalid_pyclass_args.rs:237:11
+    |
+237 | #[pyclass(from_py_object)]
     |           ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `StructFromPyObjectNoClone`
     |
 help: consider annotating `StructFromPyObjectNoClone` with `#[derive(Clone)]`
     |
-238 + #[derive(Clone)]
-239 | struct StructFromPyObjectNoClone {
+239 + #[derive(Clone)]
+240 | struct StructFromPyObjectNoClone {
     |
 
 error[E0119]: conflicting implementations of trait `pyo3::impl_::pyclass::doc::PyClassNewTextSignature` for type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ------------------------------- first implementation here
 ...
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^ conflicting implementation for `NewFromFieldsWithManualNew`
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___richcmp____`
 ...
-59 | #[pymethods]
+60 | #[pymethods]
    | ------------ other definition for `__pymethod___richcmp____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___hash____`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___hash____`
 ...
-93 | #[pymethods]
+94 | #[pymethods]
    | ------------ other definition for `__pymethod___hash____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___str____`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___str____`
 ...
-130 | #[pymethods]
+131 | #[pymethods]
     | ------------ other definition for `__pymethod___str____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___new____`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___new____`
 ...
-267 | #[pymethods]
+266 | #[pymethods]
     | ------------ other definition for `__pymethod___new____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `==` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:48:11
+  --> tests/ui/invalid_pyclass_args.rs:49:11
    |
-48 | #[pyclass(eq)]
+49 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:51:1
+  --> tests/ui/invalid_pyclass_args.rs:52:1
    |
-51 | struct EqOptRequiresEq {}
+52 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-51 + #[derive(PartialEq)]
-52 | struct EqOptRequiresEq {}
+52 + #[derive(PartialEq)]
+53 | struct EqOptRequiresEq {}
    |
 
 error[E0369]: binary operation `!=` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:48:11
+  --> tests/ui/invalid_pyclass_args.rs:49:11
    |
-48 | #[pyclass(eq)]
+49 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:51:1
+  --> tests/ui/invalid_pyclass_args.rs:52:1
    |
-51 | struct EqOptRequiresEq {}
+52 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-51 + #[derive(PartialEq)]
-52 | struct EqOptRequiresEq {}
+52 + #[derive(PartialEq)]
+53 | struct EqOptRequiresEq {}
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
-  --> tests/ui/invalid_pyclass_args.rs:76:23
+  --> tests/ui/invalid_pyclass_args.rs:77:23
    |
-76 | #[pyclass(frozen, eq, hash)]
+77 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
    |
 help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
    |
-79 + #[derive(Hash)]
-80 | struct HashOptRequiresHash;
+80 + #[derive(Hash)]
+81 | struct HashOptRequiresHash;
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `aaaa` on type `&Point`
-   --> tests/ui/invalid_pyclass_args.rs:148:17
+   --> tests/ui/invalid_pyclass_args.rs:149:17
     |
-148 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}", skip_from_py_object)]
+149 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `zzz` on type `&Point2`
-   --> tests/ui/invalid_pyclass_args.rs:157:17
+   --> tests/ui/invalid_pyclass_args.rs:158:17
     |
-157 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}", skip_from_py_object)]
+158 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `162543` on type `&Coord3`
-   --> tests/ui/invalid_pyclass_args.rs:166:17
+   --> tests/ui/invalid_pyclass_args.rs:167:17
     |
-166 | #[pyclass(str = "{0}, {162543}, {2}")]
+167 | #[pyclass(str = "{0}, {162543}, {2}")]
     |                 ^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `0`, `1`, `2`
 
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
+   --> tests/ui/invalid_pyclass_args.rs:253:12
     |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `PyClass` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
-    |
-    = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `PyClass`:
-              Coord
-              Coord2
-              Coord3
-              EqOptAndManualRichCmp
-              EqOptRequiresEq
-              HashOptAndManualHash
-              HashOptRequiresHash
-              NewFromFieldsWithManualNew
-            and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-
-error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
-    |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+253 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `pyo3::FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::impl_::pyclass::ExtractPyClassWithClone`:
-              Coord
-              Coord2
-              Coord3
-              EqOptAndManualRichCmp
-              EqOptRequiresEq
-              HashOptAndManualHash
-              HashOptRequiresHash
-              NewFromFieldsWithManualNew
+    = help: the following other types implement trait `pyo3::FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `pyo3::FromPyObject<'a, '_>`
+              `&'a [u8]` implements `pyo3::FromPyObject<'a, 'py>`
+              `&'a str` implements `pyo3::FromPyObject<'a, '_>`
+              `(T0, T1)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `pyo3::FromPyObject<'a, 'py>`
             and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-
-error[E0277]: the trait bound `dyn std::error::Error + Send + Sync: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:252:12
-    |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `Clone` is not implemented for `dyn std::error::Error + Send + Sync`
-    |
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `Clone`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -510,42 +454,42 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_required_ar
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 50 previous errors
+error: aborting due to 49 previous errors
 
 Some errors have detailed explanations: E0034, E0119, E0277, E0369, E0592, E0609.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_args.default.stderr
+++ b/tests/ui/invalid_pyclass_args.default.stderr
@@ -436,8 +436,8 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -465,8 +465,8 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -503,8 +503,8 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`

--- a/tests/ui/invalid_pyclass_args.default.stderr
+++ b/tests/ui/invalid_pyclass_args.default.stderr
@@ -1,109 +1,109 @@
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
- --> tests/ui/invalid_pyclass_args.rs:9:11
+ --> tests/ui/invalid_pyclass_args.rs:8:11
   |
-9 | #[pyclass(extend=pyo3::types::PyDict)]
+8 | #[pyclass(extend=pyo3::types::PyDict)]
   |           ^^^^^^
 
 error: expected identifier
-  --> tests/ui/invalid_pyclass_args.rs:13:21
+  --> tests/ui/invalid_pyclass_args.rs:12:21
    |
-13 | #[pyclass(extends = "PyDict")]
+12 | #[pyclass(extends = "PyDict")]
    |                     ^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:17:18
+  --> tests/ui/invalid_pyclass_args.rs:16:18
    |
-17 | #[pyclass(name = m::MyClass)]
+16 | #[pyclass(name = m::MyClass)]
    |                  ^
 
 error: expected a single identifier in double quotes
-  --> tests/ui/invalid_pyclass_args.rs:21:18
+  --> tests/ui/invalid_pyclass_args.rs:20:18
    |
-21 | #[pyclass(name = "Custom Name")]
+20 | #[pyclass(name = "Custom Name")]
    |                  ^^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:25:18
+  --> tests/ui/invalid_pyclass_args.rs:24:18
    |
-25 | #[pyclass(name = CustomName)]
+24 | #[pyclass(name = CustomName)]
    |                  ^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:29:24
+  --> tests/ui/invalid_pyclass_args.rs:28:24
    |
-29 | #[pyclass(rename_all = camelCase)]
+28 | #[pyclass(rename_all = camelCase)]
    |                        ^^^^^^^^^
 
 error: expected a valid renaming rule, possible values are: "camelCase", "kebab-case", "lowercase", "PascalCase", "SCREAMING-KEBAB-CASE", "SCREAMING_SNAKE_CASE", "snake_case", "UPPERCASE"
-  --> tests/ui/invalid_pyclass_args.rs:33:24
+  --> tests/ui/invalid_pyclass_args.rs:32:24
    |
-33 | #[pyclass(rename_all = "Camel-Case")]
+32 | #[pyclass(rename_all = "Camel-Case")]
    |                        ^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:37:20
+  --> tests/ui/invalid_pyclass_args.rs:36:20
    |
-37 | #[pyclass(module = my_module)]
+36 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
-  --> tests/ui/invalid_pyclass_args.rs:41:11
+  --> tests/ui/invalid_pyclass_args.rs:40:11
    |
-41 | #[pyclass(weakrev)]
+40 | #[pyclass(weakrev)]
    |           ^^^^^^^
 
 error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
-  --> tests/ui/invalid_pyclass_args.rs:46:8
+  --> tests/ui/invalid_pyclass_args.rs:45:8
    |
-46 | struct CannotBeMappingAndSequence {}
+45 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `eq_int` can only be used on simple enums.
-  --> tests/ui/invalid_pyclass_args.rs:73:11
+  --> tests/ui/invalid_pyclass_args.rs:72:11
    |
-73 | #[pyclass(eq_int)]
+72 | #[pyclass(eq_int)]
    |           ^^^^^^
 
 error: The `hash` option requires the `frozen` option.
-  --> tests/ui/invalid_pyclass_args.rs:82:11
+  --> tests/ui/invalid_pyclass_args.rs:81:11
    |
-82 | #[pyclass(hash)]
+81 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `hash` option requires the `eq` option.
-  --> tests/ui/invalid_pyclass_args.rs:82:11
+  --> tests/ui/invalid_pyclass_args.rs:81:11
    |
-82 | #[pyclass(hash)]
+81 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `ord` option requires the `eq` option.
-   --> tests/ui/invalid_pyclass_args.rs:102:11
+   --> tests/ui/invalid_pyclass_args.rs:101:11
     |
-102 | #[pyclass(ord)]
+101 | #[pyclass(ord)]
     |           ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:110:12
+   --> tests/ui/invalid_pyclass_args.rs:109:12
     |
-110 |     #[pyo3(foo)]
+109 |     #[pyo3(foo)]
     |            ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:112:12
+   --> tests/ui/invalid_pyclass_args.rs:111:12
     |
-112 |     #[pyo3(blah)]
+111 |     #[pyo3(blah)]
     |            ^^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:115:12
+   --> tests/ui/invalid_pyclass_args.rs:114:12
     |
-115 |     #[pyo3(pop)]
+114 |     #[pyo3(pop)]
     |            ^^^
 
 error: invalid format string: expected `}` but string was terminated
-   --> tests/ui/invalid_pyclass_args.rs:139:19
+   --> tests/ui/invalid_pyclass_args.rs:138:19
     |
-139 | #[pyclass(str = "{")]
+138 | #[pyclass(str = "{")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -111,9 +111,9 @@ error: invalid format string: expected `}` but string was terminated
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `}`, found `$`
-   --> tests/ui/invalid_pyclass_args.rs:144:19
+   --> tests/ui/invalid_pyclass_args.rs:143:19
     |
-144 | #[pyclass(str = "{$}")]
+143 | #[pyclass(str = "{$}")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -121,375 +121,431 @@ error: invalid format string: expected `}`, found `$`
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:172:31
+   --> tests/ui/invalid_pyclass_args.rs:171:31
     |
-172 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+171 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:179:31
+   --> tests/ui/invalid_pyclass_args.rs:178:31
     |
-179 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+178 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:185:17
+   --> tests/ui/invalid_pyclass_args.rs:184:17
     |
-185 | #[pyclass(str = "unsafe: {unsafe_variable}")]
+184 | #[pyclass(str = "unsafe: {unsafe_variable}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:192:54
+   --> tests/ui/invalid_pyclass_args.rs:191:54
     |
-192 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
+191 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
     |                                                      ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:200:17
+   --> tests/ui/invalid_pyclass_args.rs:199:17
     |
-200 | #[pyclass(str = "{:?}")]
+199 | #[pyclass(str = "{:?}")]
     |                 ^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:208:17
+   --> tests/ui/invalid_pyclass_args.rs:207:17
     |
-208 | #[pyclass(str = "{}")]
+207 | #[pyclass(str = "{}")]
     |                 ^^^^
 
 error: The format string syntax cannot be used with enums
-   --> tests/ui/invalid_pyclass_args.rs:216:21
+   --> tests/ui/invalid_pyclass_args.rs:215:21
     |
-216 | #[pyclass(eq, str = "Stuff...")]
+215 | #[pyclass(eq, str = "Stuff...")]
     |                     ^^^^^^^^^^
 
 error: `skip_from_py_object` and `from_py_object` are mutually exclusive
-   --> tests/ui/invalid_pyclass_args.rs:230:27
+   --> tests/ui/invalid_pyclass_args.rs:229:27
     |
-230 | #[pyclass(from_py_object, skip_from_py_object)]
+229 | #[pyclass(from_py_object, skip_from_py_object)]
     |                           ^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated constant `pyo3::impl_::deprecated::SKIP_FROM_PY_OBJECT_DEPRECATED`: `skip_from_py_object` enabled by default. The option will be removed in the future
-   --> tests/ui/invalid_pyclass_args.rs:244:11
-    |
-244 | #[pyclass(skip_from_py_object)]
-    |           ^^^^^^^^^^^^^^^^^^^
-    |
-note: the lint level is defined here
-   --> tests/ui/invalid_pyclass_args.rs:4:9
-    |
-  4 | #![deny(deprecated)]
-    |         ^^^^^^^^^^
-
 error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:237:11
+   --> tests/ui/invalid_pyclass_args.rs:236:11
     |
-237 | #[pyclass(from_py_object)]
+236 | #[pyclass(from_py_object)]
     |           ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `StructFromPyObjectNoClone`
     |
 help: consider annotating `StructFromPyObjectNoClone` with `#[derive(Clone)]`
     |
-239 + #[derive(Clone)]
-240 | struct StructFromPyObjectNoClone {
+238 + #[derive(Clone)]
+239 | struct StructFromPyObjectNoClone {
     |
 
 error[E0119]: conflicting implementations of trait `pyo3::impl_::pyclass::doc::PyClassNewTextSignature` for type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:267:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ------------------------------- first implementation here
 ...
-266 | #[pymethods]
+267 | #[pymethods]
     | ^^^^^^^^^^^^ conflicting implementation for `NewFromFieldsWithManualNew`
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:53:1
    |
-54 | #[pyclass(eq)]
+53 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___richcmp____`
 ...
-60 | #[pymethods]
+59 | #[pymethods]
    | ------------ other definition for `__pymethod___richcmp____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___hash____`
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:87:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+87 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___hash____`
 ...
-94 | #[pymethods]
+93 | #[pymethods]
    | ------------ other definition for `__pymethod___hash____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___str____`
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:119:1
     |
-120 | #[pyclass(str)]
+119 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___str____`
 ...
-131 | #[pymethods]
+130 | #[pymethods]
     | ------------ other definition for `__pymethod___str____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___new____`
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:259:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___new____`
 ...
-266 | #[pymethods]
+267 | #[pymethods]
     | ------------ other definition for `__pymethod___new____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `==` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:49:11
+  --> tests/ui/invalid_pyclass_args.rs:48:11
    |
-49 | #[pyclass(eq)]
+48 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:52:1
+  --> tests/ui/invalid_pyclass_args.rs:51:1
    |
-52 | struct EqOptRequiresEq {}
+51 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-52 + #[derive(PartialEq)]
-53 | struct EqOptRequiresEq {}
+51 + #[derive(PartialEq)]
+52 | struct EqOptRequiresEq {}
    |
 
 error[E0369]: binary operation `!=` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:49:11
+  --> tests/ui/invalid_pyclass_args.rs:48:11
    |
-49 | #[pyclass(eq)]
+48 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:52:1
+  --> tests/ui/invalid_pyclass_args.rs:51:1
    |
-52 | struct EqOptRequiresEq {}
+51 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-52 + #[derive(PartialEq)]
-53 | struct EqOptRequiresEq {}
+51 + #[derive(PartialEq)]
+52 | struct EqOptRequiresEq {}
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:53:1
    |
-54 | #[pyclass(eq)]
+53 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:53:1
    |
-54 | #[pyclass(eq)]
+53 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:60:1
+  --> tests/ui/invalid_pyclass_args.rs:59:1
    |
-60 | #[pymethods]
+59 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:60:1
+  --> tests/ui/invalid_pyclass_args.rs:59:1
    |
-60 | #[pymethods]
+59 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:53:1
    |
-54 | #[pyclass(eq)]
+53 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:60:1
+  --> tests/ui/invalid_pyclass_args.rs:59:1
    |
-60 | #[pymethods]
+59 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
-  --> tests/ui/invalid_pyclass_args.rs:77:23
+  --> tests/ui/invalid_pyclass_args.rs:76:23
    |
-77 | #[pyclass(frozen, eq, hash)]
+76 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
    |
 help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
    |
-80 + #[derive(Hash)]
-81 | struct HashOptRequiresHash;
+79 + #[derive(Hash)]
+80 | struct HashOptRequiresHash;
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:87:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+87 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:87:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+87 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:94:1
+  --> tests/ui/invalid_pyclass_args.rs:93:1
    |
-94 | #[pymethods]
+93 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:94:1
+  --> tests/ui/invalid_pyclass_args.rs:93:1
    |
-94 | #[pymethods]
+93 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:87:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+87 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:94:1
+  --> tests/ui/invalid_pyclass_args.rs:93:1
    |
-94 | #[pymethods]
+93 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:119:1
     |
-120 | #[pyclass(str)]
+119 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:119:1
     |
-120 | #[pyclass(str)]
+119 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:131:1
+   --> tests/ui/invalid_pyclass_args.rs:130:1
     |
-131 | #[pymethods]
+130 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:131:1
+   --> tests/ui/invalid_pyclass_args.rs:130:1
     |
-131 | #[pymethods]
+130 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:119:1
     |
-120 | #[pyclass(str)]
+119 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:131:1
+   --> tests/ui/invalid_pyclass_args.rs:130:1
     |
-131 | #[pymethods]
+130 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `aaaa` on type `&Point`
-   --> tests/ui/invalid_pyclass_args.rs:149:17
+   --> tests/ui/invalid_pyclass_args.rs:148:17
     |
-149 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}")]
+148 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}", skip_from_py_object)]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `zzz` on type `&Point2`
-   --> tests/ui/invalid_pyclass_args.rs:158:17
+   --> tests/ui/invalid_pyclass_args.rs:157:17
     |
-158 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}")]
+157 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}", skip_from_py_object)]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `162543` on type `&Coord3`
-   --> tests/ui/invalid_pyclass_args.rs:167:17
+   --> tests/ui/invalid_pyclass_args.rs:166:17
     |
-167 | #[pyclass(str = "{0}, {162543}, {2}")]
+166 | #[pyclass(str = "{0}, {162543}, {2}")]
     |                 ^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `0`, `1`, `2`
 
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:253:12
+   --> tests/ui/invalid_pyclass_args.rs:252:12
     |
-253 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+252 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `PyClass` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::FromPyObject<'a, 'py>`:
-              `&'a CStr` implements `pyo3::FromPyObject<'a, '_>`
-              `&'a [u8]` implements `pyo3::FromPyObject<'a, 'py>`
-              `&'a str` implements `pyo3::FromPyObject<'a, '_>`
-              `(T0, T1)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4, T5)` implements `pyo3::FromPyObject<'a, 'py>`
+    = help: the following other types implement trait `PyClass`:
+              Coord
+              Coord2
+              Coord3
+              EqOptAndManualRichCmp
+              EqOptRequiresEq
+              HashOptAndManualHash
+              HashOptRequiresHash
+              NewFromFieldsWithManualNew
             and $N others
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+
+error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
+   --> tests/ui/invalid_pyclass_args.rs:252:12
+    |
+252 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+    |
+    = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
+    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
+    = help: the following other types implement trait `pyo3::impl_::pyclass::ExtractPyClassWithClone`:
+              Coord
+              Coord2
+              Coord3
+              EqOptAndManualRichCmp
+              EqOptRequiresEq
+              HashOptAndManualHash
+              HashOptRequiresHash
+              NewFromFieldsWithManualNew
+            and $N others
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+
+error[E0277]: the trait bound `dyn std::error::Error + Send + Sync: Clone` is not satisfied
+   --> tests/ui/invalid_pyclass_args.rs:252:12
+    |
+252 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `Clone` is not implemented for `dyn std::error::Error + Send + Sync`
+    |
+help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
+ --> src/impl_/extract_argument.rs
+  |
+  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
+  | |     for &'holder Bound<'py, T>
+  | | where
+  | |     T: PyTypeCheck,
+  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
+  | | where
+  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
+  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+...
+  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
+  | |     for &'holder mut T
+  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `Clone`
+  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:259:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:259:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:267:1
     |
-266 | #[pymethods]
+267 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:267:1
     |
-266 | #[pymethods]
+267 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:259:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:267:1
     |
-266 | #[pymethods]
+267 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 49 previous errors
+error: aborting due to 50 previous errors
 
 Some errors have detailed explanations: E0034, E0119, E0277, E0369, E0592, E0609.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_args.inspect.stderr
+++ b/tests/ui/invalid_pyclass_args.inspect.stderr
@@ -1,109 +1,109 @@
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
- --> tests/ui/invalid_pyclass_args.rs:8:11
+ --> tests/ui/invalid_pyclass_args.rs:9:11
   |
-8 | #[pyclass(extend=pyo3::types::PyDict)]
+9 | #[pyclass(extend=pyo3::types::PyDict)]
   |           ^^^^^^
 
 error: expected identifier
-  --> tests/ui/invalid_pyclass_args.rs:12:21
+  --> tests/ui/invalid_pyclass_args.rs:13:21
    |
-12 | #[pyclass(extends = "PyDict")]
+13 | #[pyclass(extends = "PyDict")]
    |                     ^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:16:18
+  --> tests/ui/invalid_pyclass_args.rs:17:18
    |
-16 | #[pyclass(name = m::MyClass)]
+17 | #[pyclass(name = m::MyClass)]
    |                  ^
 
 error: expected a single identifier in double quotes
-  --> tests/ui/invalid_pyclass_args.rs:20:18
+  --> tests/ui/invalid_pyclass_args.rs:21:18
    |
-20 | #[pyclass(name = "Custom Name")]
+21 | #[pyclass(name = "Custom Name")]
    |                  ^^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:24:18
+  --> tests/ui/invalid_pyclass_args.rs:25:18
    |
-24 | #[pyclass(name = CustomName)]
+25 | #[pyclass(name = CustomName)]
    |                  ^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:28:24
+  --> tests/ui/invalid_pyclass_args.rs:29:24
    |
-28 | #[pyclass(rename_all = camelCase)]
+29 | #[pyclass(rename_all = camelCase)]
    |                        ^^^^^^^^^
 
 error: expected a valid renaming rule, possible values are: "camelCase", "kebab-case", "lowercase", "PascalCase", "SCREAMING-KEBAB-CASE", "SCREAMING_SNAKE_CASE", "snake_case", "UPPERCASE"
-  --> tests/ui/invalid_pyclass_args.rs:32:24
+  --> tests/ui/invalid_pyclass_args.rs:33:24
    |
-32 | #[pyclass(rename_all = "Camel-Case")]
+33 | #[pyclass(rename_all = "Camel-Case")]
    |                        ^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:36:20
+  --> tests/ui/invalid_pyclass_args.rs:37:20
    |
-36 | #[pyclass(module = my_module)]
+37 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
-  --> tests/ui/invalid_pyclass_args.rs:40:11
+  --> tests/ui/invalid_pyclass_args.rs:41:11
    |
-40 | #[pyclass(weakrev)]
+41 | #[pyclass(weakrev)]
    |           ^^^^^^^
 
 error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
-  --> tests/ui/invalid_pyclass_args.rs:45:8
+  --> tests/ui/invalid_pyclass_args.rs:46:8
    |
-45 | struct CannotBeMappingAndSequence {}
+46 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `eq_int` can only be used on simple enums.
-  --> tests/ui/invalid_pyclass_args.rs:72:11
+  --> tests/ui/invalid_pyclass_args.rs:73:11
    |
-72 | #[pyclass(eq_int)]
+73 | #[pyclass(eq_int)]
    |           ^^^^^^
 
 error: The `hash` option requires the `frozen` option.
-  --> tests/ui/invalid_pyclass_args.rs:81:11
+  --> tests/ui/invalid_pyclass_args.rs:82:11
    |
-81 | #[pyclass(hash)]
+82 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `hash` option requires the `eq` option.
-  --> tests/ui/invalid_pyclass_args.rs:81:11
+  --> tests/ui/invalid_pyclass_args.rs:82:11
    |
-81 | #[pyclass(hash)]
+82 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `ord` option requires the `eq` option.
-   --> tests/ui/invalid_pyclass_args.rs:101:11
+   --> tests/ui/invalid_pyclass_args.rs:102:11
     |
-101 | #[pyclass(ord)]
+102 | #[pyclass(ord)]
     |           ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:109:12
+   --> tests/ui/invalid_pyclass_args.rs:110:12
     |
-109 |     #[pyo3(foo)]
+110 |     #[pyo3(foo)]
     |            ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:111:12
+   --> tests/ui/invalid_pyclass_args.rs:112:12
     |
-111 |     #[pyo3(blah)]
+112 |     #[pyo3(blah)]
     |            ^^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:114:12
+   --> tests/ui/invalid_pyclass_args.rs:115:12
     |
-114 |     #[pyo3(pop)]
+115 |     #[pyo3(pop)]
     |            ^^^
 
 error: invalid format string: expected `}` but string was terminated
-   --> tests/ui/invalid_pyclass_args.rs:138:19
+   --> tests/ui/invalid_pyclass_args.rs:139:19
     |
-138 | #[pyclass(str = "{")]
+139 | #[pyclass(str = "{")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -111,9 +111,9 @@ error: invalid format string: expected `}` but string was terminated
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `}`, found `$`
-   --> tests/ui/invalid_pyclass_args.rs:143:19
+   --> tests/ui/invalid_pyclass_args.rs:144:19
     |
-143 | #[pyclass(str = "{$}")]
+144 | #[pyclass(str = "{$}")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -121,80 +121,92 @@ error: invalid format string: expected `}`, found `$`
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:171:31
+   --> tests/ui/invalid_pyclass_args.rs:172:31
     |
-171 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+172 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:178:31
+   --> tests/ui/invalid_pyclass_args.rs:179:31
     |
-178 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+179 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:184:17
+   --> tests/ui/invalid_pyclass_args.rs:185:17
     |
-184 | #[pyclass(str = "unsafe: {unsafe_variable}")]
+185 | #[pyclass(str = "unsafe: {unsafe_variable}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:191:54
+   --> tests/ui/invalid_pyclass_args.rs:192:54
     |
-191 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
+192 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
     |                                                      ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:199:17
+   --> tests/ui/invalid_pyclass_args.rs:200:17
     |
-199 | #[pyclass(str = "{:?}")]
+200 | #[pyclass(str = "{:?}")]
     |                 ^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:207:17
+   --> tests/ui/invalid_pyclass_args.rs:208:17
     |
-207 | #[pyclass(str = "{}")]
+208 | #[pyclass(str = "{}")]
     |                 ^^^^
 
 error: The format string syntax cannot be used with enums
-   --> tests/ui/invalid_pyclass_args.rs:215:21
+   --> tests/ui/invalid_pyclass_args.rs:216:21
     |
-215 | #[pyclass(eq, str = "Stuff...")]
+216 | #[pyclass(eq, str = "Stuff...")]
     |                     ^^^^^^^^^^
 
 error: `skip_from_py_object` and `from_py_object` are mutually exclusive
-   --> tests/ui/invalid_pyclass_args.rs:229:27
+   --> tests/ui/invalid_pyclass_args.rs:230:27
     |
-229 | #[pyclass(from_py_object, skip_from_py_object)]
+230 | #[pyclass(from_py_object, skip_from_py_object)]
     |                           ^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:236:11
+error: use of deprecated constant `pyo3::impl_::deprecated::SKIP_FROM_PY_OBJECT_DEPRECATED`: `skip_from_py_object` enabled by default. The option will be removed in the future
+   --> tests/ui/invalid_pyclass_args.rs:244:11
     |
-236 | #[pyclass(from_py_object)]
+244 | #[pyclass(skip_from_py_object)]
+    |           ^^^^^^^^^^^^^^^^^^^
+    |
+note: the lint level is defined here
+   --> tests/ui/invalid_pyclass_args.rs:4:9
+    |
+  4 | #![deny(deprecated)]
+    |         ^^^^^^^^^^
+
+error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
+   --> tests/ui/invalid_pyclass_args.rs:237:11
+    |
+237 | #[pyclass(from_py_object)]
     |           ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `StructFromPyObjectNoClone`
     |
 help: consider annotating `StructFromPyObjectNoClone` with `#[derive(Clone)]`
     |
-238 + #[derive(Clone)]
-239 | struct StructFromPyObjectNoClone {
+239 + #[derive(Clone)]
+240 | struct StructFromPyObjectNoClone {
     |
 
 error[E0119]: conflicting implementations of trait `pyo3::impl_::pyclass::doc::PyClassNewTextSignature` for type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ------------------------------- first implementation here
 ...
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^ conflicting implementation for `NewFromFieldsWithManualNew`
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
+   --> tests/ui/invalid_pyclass_args.rs:253:12
     |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
+253 |     field: Box<dyn std::error::Error + Send + Sync>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |
     = help: the trait `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, false>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
@@ -222,314 +234,246 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
   | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
 
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___richcmp____`
 ...
-59 | #[pymethods]
+60 | #[pymethods]
    | ------------ other definition for `__pymethod___richcmp____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___hash____`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___hash____`
 ...
-93 | #[pymethods]
+94 | #[pymethods]
    | ------------ other definition for `__pymethod___hash____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___str____`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___str____`
 ...
-130 | #[pymethods]
+131 | #[pymethods]
     | ------------ other definition for `__pymethod___str____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___new____`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___new____`
 ...
-267 | #[pymethods]
+266 | #[pymethods]
     | ------------ other definition for `__pymethod___new____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `==` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:48:11
+  --> tests/ui/invalid_pyclass_args.rs:49:11
    |
-48 | #[pyclass(eq)]
+49 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:51:1
+  --> tests/ui/invalid_pyclass_args.rs:52:1
    |
-51 | struct EqOptRequiresEq {}
+52 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-51 + #[derive(PartialEq)]
-52 | struct EqOptRequiresEq {}
+52 + #[derive(PartialEq)]
+53 | struct EqOptRequiresEq {}
    |
 
 error[E0369]: binary operation `!=` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:48:11
+  --> tests/ui/invalid_pyclass_args.rs:49:11
    |
-48 | #[pyclass(eq)]
+49 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:51:1
+  --> tests/ui/invalid_pyclass_args.rs:52:1
    |
-51 | struct EqOptRequiresEq {}
+52 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-51 + #[derive(PartialEq)]
-52 | struct EqOptRequiresEq {}
+52 + #[derive(PartialEq)]
+53 | struct EqOptRequiresEq {}
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
-  --> tests/ui/invalid_pyclass_args.rs:76:23
+  --> tests/ui/invalid_pyclass_args.rs:77:23
    |
-76 | #[pyclass(frozen, eq, hash)]
+77 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
    |
 help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
    |
-79 + #[derive(Hash)]
-80 | struct HashOptRequiresHash;
+80 + #[derive(Hash)]
+81 | struct HashOptRequiresHash;
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `aaaa` on type `&Point`
-   --> tests/ui/invalid_pyclass_args.rs:148:17
+   --> tests/ui/invalid_pyclass_args.rs:149:17
     |
-148 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}", skip_from_py_object)]
+149 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `zzz` on type `&Point2`
-   --> tests/ui/invalid_pyclass_args.rs:157:17
+   --> tests/ui/invalid_pyclass_args.rs:158:17
     |
-157 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}", skip_from_py_object)]
+158 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `162543` on type `&Coord3`
-   --> tests/ui/invalid_pyclass_args.rs:166:17
+   --> tests/ui/invalid_pyclass_args.rs:167:17
     |
-166 | #[pyclass(str = "{0}, {162543}, {2}")]
+167 | #[pyclass(str = "{0}, {162543}, {2}")]
     |                 ^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `0`, `1`, `2`
 
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
+   --> tests/ui/invalid_pyclass_args.rs:253:12
     |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::PyClass` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
-    |
-    = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::PyClass`:
-              Coord
-              Coord2
-              Coord3
-              EqOptAndManualRichCmp
-              EqOptRequiresEq
-              HashOptAndManualHash
-              HashOptRequiresHash
-              NewFromFieldsWithManualNew
-            and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-
-error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
-    |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+253 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `pyo3::FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::impl_::pyclass::ExtractPyClassWithClone`:
-              Coord
-              Coord2
-              Coord3
-              EqOptAndManualRichCmp
-              EqOptRequiresEq
-              HashOptAndManualHash
-              HashOptRequiresHash
-              NewFromFieldsWithManualNew
+    = help: the following other types implement trait `pyo3::FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `pyo3::FromPyObject<'a, '_>`
+              `&'a [u8]` implements `pyo3::FromPyObject<'a, 'py>`
+              `&'a str` implements `pyo3::FromPyObject<'a, '_>`
+              `(T0, T1)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `pyo3::FromPyObject<'a, 'py>`
             and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-
-error[E0277]: the trait bound `dyn std::error::Error + Send + Sync: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:252:12
-    |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `Clone` is not implemented for `dyn std::error::Error + Send + Sync`
-    |
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `Clone`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -540,42 +484,42 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_required_ar
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 51 previous errors
+error: aborting due to 50 previous errors
 
 Some errors have detailed explanations: E0034, E0119, E0277, E0369, E0592, E0609.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_args.inspect.stderr
+++ b/tests/ui/invalid_pyclass_args.inspect.stderr
@@ -466,8 +466,8 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -495,8 +495,8 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -533,8 +533,8 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`

--- a/tests/ui/invalid_pyclass_args.inspect.stderr
+++ b/tests/ui/invalid_pyclass_args.inspect.stderr
@@ -1,109 +1,109 @@
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
- --> tests/ui/invalid_pyclass_args.rs:9:11
+ --> tests/ui/invalid_pyclass_args.rs:8:11
   |
-9 | #[pyclass(extend=pyo3::types::PyDict)]
+8 | #[pyclass(extend=pyo3::types::PyDict)]
   |           ^^^^^^
 
 error: expected identifier
-  --> tests/ui/invalid_pyclass_args.rs:13:21
+  --> tests/ui/invalid_pyclass_args.rs:12:21
    |
-13 | #[pyclass(extends = "PyDict")]
+12 | #[pyclass(extends = "PyDict")]
    |                     ^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:17:18
+  --> tests/ui/invalid_pyclass_args.rs:16:18
    |
-17 | #[pyclass(name = m::MyClass)]
+16 | #[pyclass(name = m::MyClass)]
    |                  ^
 
 error: expected a single identifier in double quotes
-  --> tests/ui/invalid_pyclass_args.rs:21:18
+  --> tests/ui/invalid_pyclass_args.rs:20:18
    |
-21 | #[pyclass(name = "Custom Name")]
+20 | #[pyclass(name = "Custom Name")]
    |                  ^^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:25:18
+  --> tests/ui/invalid_pyclass_args.rs:24:18
    |
-25 | #[pyclass(name = CustomName)]
+24 | #[pyclass(name = CustomName)]
    |                  ^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:29:24
+  --> tests/ui/invalid_pyclass_args.rs:28:24
    |
-29 | #[pyclass(rename_all = camelCase)]
+28 | #[pyclass(rename_all = camelCase)]
    |                        ^^^^^^^^^
 
 error: expected a valid renaming rule, possible values are: "camelCase", "kebab-case", "lowercase", "PascalCase", "SCREAMING-KEBAB-CASE", "SCREAMING_SNAKE_CASE", "snake_case", "UPPERCASE"
-  --> tests/ui/invalid_pyclass_args.rs:33:24
+  --> tests/ui/invalid_pyclass_args.rs:32:24
    |
-33 | #[pyclass(rename_all = "Camel-Case")]
+32 | #[pyclass(rename_all = "Camel-Case")]
    |                        ^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:37:20
+  --> tests/ui/invalid_pyclass_args.rs:36:20
    |
-37 | #[pyclass(module = my_module)]
+36 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
-  --> tests/ui/invalid_pyclass_args.rs:41:11
+  --> tests/ui/invalid_pyclass_args.rs:40:11
    |
-41 | #[pyclass(weakrev)]
+40 | #[pyclass(weakrev)]
    |           ^^^^^^^
 
 error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
-  --> tests/ui/invalid_pyclass_args.rs:46:8
+  --> tests/ui/invalid_pyclass_args.rs:45:8
    |
-46 | struct CannotBeMappingAndSequence {}
+45 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `eq_int` can only be used on simple enums.
-  --> tests/ui/invalid_pyclass_args.rs:73:11
+  --> tests/ui/invalid_pyclass_args.rs:72:11
    |
-73 | #[pyclass(eq_int)]
+72 | #[pyclass(eq_int)]
    |           ^^^^^^
 
 error: The `hash` option requires the `frozen` option.
-  --> tests/ui/invalid_pyclass_args.rs:82:11
+  --> tests/ui/invalid_pyclass_args.rs:81:11
    |
-82 | #[pyclass(hash)]
+81 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `hash` option requires the `eq` option.
-  --> tests/ui/invalid_pyclass_args.rs:82:11
+  --> tests/ui/invalid_pyclass_args.rs:81:11
    |
-82 | #[pyclass(hash)]
+81 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `ord` option requires the `eq` option.
-   --> tests/ui/invalid_pyclass_args.rs:102:11
+   --> tests/ui/invalid_pyclass_args.rs:101:11
     |
-102 | #[pyclass(ord)]
+101 | #[pyclass(ord)]
     |           ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:110:12
+   --> tests/ui/invalid_pyclass_args.rs:109:12
     |
-110 |     #[pyo3(foo)]
+109 |     #[pyo3(foo)]
     |            ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:112:12
+   --> tests/ui/invalid_pyclass_args.rs:111:12
     |
-112 |     #[pyo3(blah)]
+111 |     #[pyo3(blah)]
     |            ^^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:115:12
+   --> tests/ui/invalid_pyclass_args.rs:114:12
     |
-115 |     #[pyo3(pop)]
+114 |     #[pyo3(pop)]
     |            ^^^
 
 error: invalid format string: expected `}` but string was terminated
-   --> tests/ui/invalid_pyclass_args.rs:139:19
+   --> tests/ui/invalid_pyclass_args.rs:138:19
     |
-139 | #[pyclass(str = "{")]
+138 | #[pyclass(str = "{")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -111,9 +111,9 @@ error: invalid format string: expected `}` but string was terminated
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `}`, found `$`
-   --> tests/ui/invalid_pyclass_args.rs:144:19
+   --> tests/ui/invalid_pyclass_args.rs:143:19
     |
-144 | #[pyclass(str = "{$}")]
+143 | #[pyclass(str = "{$}")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -121,92 +121,80 @@ error: invalid format string: expected `}`, found `$`
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:172:31
+   --> tests/ui/invalid_pyclass_args.rs:171:31
     |
-172 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+171 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:179:31
+   --> tests/ui/invalid_pyclass_args.rs:178:31
     |
-179 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+178 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:185:17
+   --> tests/ui/invalid_pyclass_args.rs:184:17
     |
-185 | #[pyclass(str = "unsafe: {unsafe_variable}")]
+184 | #[pyclass(str = "unsafe: {unsafe_variable}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:192:54
+   --> tests/ui/invalid_pyclass_args.rs:191:54
     |
-192 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
+191 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
     |                                                      ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:200:17
+   --> tests/ui/invalid_pyclass_args.rs:199:17
     |
-200 | #[pyclass(str = "{:?}")]
+199 | #[pyclass(str = "{:?}")]
     |                 ^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:208:17
+   --> tests/ui/invalid_pyclass_args.rs:207:17
     |
-208 | #[pyclass(str = "{}")]
+207 | #[pyclass(str = "{}")]
     |                 ^^^^
 
 error: The format string syntax cannot be used with enums
-   --> tests/ui/invalid_pyclass_args.rs:216:21
+   --> tests/ui/invalid_pyclass_args.rs:215:21
     |
-216 | #[pyclass(eq, str = "Stuff...")]
+215 | #[pyclass(eq, str = "Stuff...")]
     |                     ^^^^^^^^^^
 
 error: `skip_from_py_object` and `from_py_object` are mutually exclusive
-   --> tests/ui/invalid_pyclass_args.rs:230:27
+   --> tests/ui/invalid_pyclass_args.rs:229:27
     |
-230 | #[pyclass(from_py_object, skip_from_py_object)]
+229 | #[pyclass(from_py_object, skip_from_py_object)]
     |                           ^^^^^^^^^^^^^^^^^^^
 
-error: use of deprecated constant `pyo3::impl_::deprecated::SKIP_FROM_PY_OBJECT_DEPRECATED`: `skip_from_py_object` enabled by default. The option will be removed in the future
-   --> tests/ui/invalid_pyclass_args.rs:244:11
-    |
-244 | #[pyclass(skip_from_py_object)]
-    |           ^^^^^^^^^^^^^^^^^^^
-    |
-note: the lint level is defined here
-   --> tests/ui/invalid_pyclass_args.rs:4:9
-    |
-  4 | #![deny(deprecated)]
-    |         ^^^^^^^^^^
-
 error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:237:11
+   --> tests/ui/invalid_pyclass_args.rs:236:11
     |
-237 | #[pyclass(from_py_object)]
+236 | #[pyclass(from_py_object)]
     |           ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `StructFromPyObjectNoClone`
     |
 help: consider annotating `StructFromPyObjectNoClone` with `#[derive(Clone)]`
     |
-239 + #[derive(Clone)]
-240 | struct StructFromPyObjectNoClone {
+238 + #[derive(Clone)]
+239 | struct StructFromPyObjectNoClone {
     |
 
 error[E0119]: conflicting implementations of trait `pyo3::impl_::pyclass::doc::PyClassNewTextSignature` for type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:267:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ------------------------------- first implementation here
 ...
-266 | #[pymethods]
+267 | #[pymethods]
     | ^^^^^^^^^^^^ conflicting implementation for `NewFromFieldsWithManualNew`
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:253:12
+   --> tests/ui/invalid_pyclass_args.rs:252:12
     |
-253 |     field: Box<dyn std::error::Error + Send + Sync>,
+252 |     field: Box<dyn std::error::Error + Send + Sync>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |
     = help: the trait `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, false>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
@@ -234,292 +222,360 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
   | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
 
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:53:1
    |
-54 | #[pyclass(eq)]
+53 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___richcmp____`
 ...
-60 | #[pymethods]
+59 | #[pymethods]
    | ------------ other definition for `__pymethod___richcmp____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___hash____`
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:87:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+87 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___hash____`
 ...
-94 | #[pymethods]
+93 | #[pymethods]
    | ------------ other definition for `__pymethod___hash____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___str____`
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:119:1
     |
-120 | #[pyclass(str)]
+119 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___str____`
 ...
-131 | #[pymethods]
+130 | #[pymethods]
     | ------------ other definition for `__pymethod___str____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___new____`
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:259:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___new____`
 ...
-266 | #[pymethods]
+267 | #[pymethods]
     | ------------ other definition for `__pymethod___new____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `==` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:49:11
+  --> tests/ui/invalid_pyclass_args.rs:48:11
    |
-49 | #[pyclass(eq)]
+48 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:52:1
+  --> tests/ui/invalid_pyclass_args.rs:51:1
    |
-52 | struct EqOptRequiresEq {}
+51 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-52 + #[derive(PartialEq)]
-53 | struct EqOptRequiresEq {}
+51 + #[derive(PartialEq)]
+52 | struct EqOptRequiresEq {}
    |
 
 error[E0369]: binary operation `!=` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:49:11
+  --> tests/ui/invalid_pyclass_args.rs:48:11
    |
-49 | #[pyclass(eq)]
+48 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:52:1
+  --> tests/ui/invalid_pyclass_args.rs:51:1
    |
-52 | struct EqOptRequiresEq {}
+51 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-52 + #[derive(PartialEq)]
-53 | struct EqOptRequiresEq {}
+51 + #[derive(PartialEq)]
+52 | struct EqOptRequiresEq {}
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:53:1
    |
-54 | #[pyclass(eq)]
+53 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:53:1
    |
-54 | #[pyclass(eq)]
+53 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:60:1
+  --> tests/ui/invalid_pyclass_args.rs:59:1
    |
-60 | #[pymethods]
+59 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:60:1
+  --> tests/ui/invalid_pyclass_args.rs:59:1
    |
-60 | #[pymethods]
+59 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:53:1
    |
-54 | #[pyclass(eq)]
+53 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:60:1
+  --> tests/ui/invalid_pyclass_args.rs:59:1
    |
-60 | #[pymethods]
+59 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
-  --> tests/ui/invalid_pyclass_args.rs:77:23
+  --> tests/ui/invalid_pyclass_args.rs:76:23
    |
-77 | #[pyclass(frozen, eq, hash)]
+76 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
    |
 help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
    |
-80 + #[derive(Hash)]
-81 | struct HashOptRequiresHash;
+79 + #[derive(Hash)]
+80 | struct HashOptRequiresHash;
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:87:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+87 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:87:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+87 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:94:1
+  --> tests/ui/invalid_pyclass_args.rs:93:1
    |
-94 | #[pymethods]
+93 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:94:1
+  --> tests/ui/invalid_pyclass_args.rs:93:1
    |
-94 | #[pymethods]
+93 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:87:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+87 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:94:1
+  --> tests/ui/invalid_pyclass_args.rs:93:1
    |
-94 | #[pymethods]
+93 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:119:1
     |
-120 | #[pyclass(str)]
+119 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:119:1
     |
-120 | #[pyclass(str)]
+119 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:131:1
+   --> tests/ui/invalid_pyclass_args.rs:130:1
     |
-131 | #[pymethods]
+130 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:131:1
+   --> tests/ui/invalid_pyclass_args.rs:130:1
     |
-131 | #[pymethods]
+130 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:119:1
     |
-120 | #[pyclass(str)]
+119 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:131:1
+   --> tests/ui/invalid_pyclass_args.rs:130:1
     |
-131 | #[pymethods]
+130 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `aaaa` on type `&Point`
-   --> tests/ui/invalid_pyclass_args.rs:149:17
+   --> tests/ui/invalid_pyclass_args.rs:148:17
     |
-149 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}")]
+148 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}", skip_from_py_object)]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `zzz` on type `&Point2`
-   --> tests/ui/invalid_pyclass_args.rs:158:17
+   --> tests/ui/invalid_pyclass_args.rs:157:17
     |
-158 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}")]
+157 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}", skip_from_py_object)]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `162543` on type `&Coord3`
-   --> tests/ui/invalid_pyclass_args.rs:167:17
+   --> tests/ui/invalid_pyclass_args.rs:166:17
     |
-167 | #[pyclass(str = "{0}, {162543}, {2}")]
+166 | #[pyclass(str = "{0}, {162543}, {2}")]
     |                 ^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `0`, `1`, `2`
 
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:253:12
+   --> tests/ui/invalid_pyclass_args.rs:252:12
     |
-253 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+252 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `pyo3::PyClass` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::FromPyObject<'a, 'py>`:
-              `&'a CStr` implements `pyo3::FromPyObject<'a, '_>`
-              `&'a [u8]` implements `pyo3::FromPyObject<'a, 'py>`
-              `&'a str` implements `pyo3::FromPyObject<'a, '_>`
-              `(T0, T1)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4, T5)` implements `pyo3::FromPyObject<'a, 'py>`
+    = help: the following other types implement trait `pyo3::PyClass`:
+              Coord
+              Coord2
+              Coord3
+              EqOptAndManualRichCmp
+              EqOptRequiresEq
+              HashOptAndManualHash
+              HashOptRequiresHash
+              NewFromFieldsWithManualNew
             and $N others
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+
+error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
+   --> tests/ui/invalid_pyclass_args.rs:252:12
+    |
+252 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+    |
+    = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
+    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
+    = help: the following other types implement trait `pyo3::impl_::pyclass::ExtractPyClassWithClone`:
+              Coord
+              Coord2
+              Coord3
+              EqOptAndManualRichCmp
+              EqOptRequiresEq
+              HashOptAndManualHash
+              HashOptRequiresHash
+              NewFromFieldsWithManualNew
+            and $N others
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+
+error[E0277]: the trait bound `dyn std::error::Error + Send + Sync: Clone` is not satisfied
+   --> tests/ui/invalid_pyclass_args.rs:252:12
+    |
+252 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `Clone` is not implemented for `dyn std::error::Error + Send + Sync`
+    |
+help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
+ --> src/impl_/extract_argument.rs
+  |
+  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
+  | |     for &'holder Bound<'py, T>
+  | | where
+  | |     T: PyTypeCheck,
+  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
+  | | where
+  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
+  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+...
+  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
+  | |     for &'holder mut T
+  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `Clone`
+  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:259:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:259:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:267:1
     |
-266 | #[pymethods]
+267 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:267:1
     |
-266 | #[pymethods]
+267 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:259:1
     |
-258 | #[pyclass(new = "from_fields")]
+259 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:267:1
     |
-266 | #[pymethods]
+267 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 50 previous errors
+error: aborting due to 51 previous errors
 
 Some errors have detailed explanations: E0034, E0119, E0277, E0369, E0592, E0609.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_generic.rs
+++ b/tests/ui/invalid_pyclass_generic.rs
@@ -7,6 +7,7 @@ use pyo3::types::PyType;
 //~| ERROR: multiple applicable items in scope
 //~| ERROR: multiple applicable items in scope
 //~| ERROR: multiple applicable items in scope
+//~| ERROR: never type fallback affects this call to an `unsafe` function
 struct ClassRedefinesClassGetItem {}
 
 #[pymethods]
@@ -22,6 +23,7 @@ impl ClassRedefinesClassGetItem {
         //~| ERROR: multiple applicable items in scope
         cls: &Bound<'_, PyType>,
         key: &Bound<'_, PyAny>,
+        //~^ ERROR: never type fallback affects this call to an `unsafe` function
     ) -> PyResult<Py<PyAny>> {
         //~^ ERROR: multiple applicable items in scope
         pyo3::types::PyGenericAlias::new(cls.py(), cls.as_any(), key)

--- a/tests/ui/invalid_pyclass_generic.rs
+++ b/tests/ui/invalid_pyclass_generic.rs
@@ -7,7 +7,6 @@ use pyo3::types::PyType;
 //~| ERROR: multiple applicable items in scope
 //~| ERROR: multiple applicable items in scope
 //~| ERROR: multiple applicable items in scope
-//~| ERROR: never type fallback affects this call to an `unsafe` function
 struct ClassRedefinesClassGetItem {}
 
 #[pymethods]
@@ -23,7 +22,6 @@ impl ClassRedefinesClassGetItem {
         //~| ERROR: multiple applicable items in scope
         cls: &Bound<'_, PyType>,
         key: &Bound<'_, PyAny>,
-        //~^ ERROR: never type fallback affects this call to an `unsafe` function
     ) -> PyResult<Py<PyAny>> {
         //~^ ERROR: multiple applicable items in scope
         pyo3::types::PyGenericAlias::new(cls.py(), cls.as_any(), key)

--- a/tests/ui/invalid_pyclass_generic.stderr
+++ b/tests/ui/invalid_pyclass_generic.stderr
@@ -4,7 +4,7 @@ error[E0592]: duplicate definitions with name `__pymethod___class_getitem____`
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___class_getitem____`
 ...
-13 | #[pymethods]
+12 | #[pymethods]
    | ------------ other definition for `__pymethod___class_getitem____`
    |
    = note: this error originates in the macro `::pyo3::impl_::pymethods::maybe_define_fastcall_function_with_keywords` which comes from the expansion of the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -15,12 +15,12 @@ error[E0592]: duplicate definitions with name `__class_getitem__`
  4 |   #[pyclass(generic)]
    |   ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__class_getitem__`
 ...
-21 | /     pub fn __class_getitem__(
+20 | /     pub fn __class_getitem__(
+21 | |
 22 | |
-23 | |
-24 | |         cls: &Bound<'_, PyType>,
-...  |
-27 | |     ) -> PyResult<Py<PyAny>> {
+23 | |         cls: &Bound<'_, PyType>,
+24 | |         key: &Bound<'_, PyAny>,
+25 | |     ) -> PyResult<Py<PyAny>> {
    | |____________________________- other definition for `__class_getitem__`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -37,9 +37,9 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:13:1
+  --> tests/ui/invalid_pyclass_generic.rs:12:1
    |
-13 | #[pymethods]
+12 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -55,14 +55,14 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:21:5
+  --> tests/ui/invalid_pyclass_generic.rs:20:5
    |
-21 | /     pub fn __class_getitem__(
+20 | /     pub fn __class_getitem__(
+21 | |
 22 | |
-23 | |
-24 | |         cls: &Bound<'_, PyType>,
-...  |
-27 | |     ) -> PyResult<Py<PyAny>> {
+23 | |         cls: &Bound<'_, PyType>,
+24 | |         key: &Bound<'_, PyAny>,
+25 | |     ) -> PyResult<Py<PyAny>> {
    | |____________________________^
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -76,34 +76,22 @@ error[E0034]: multiple applicable items in scope
   = note: candidate #2 is defined in an impl for the type `pyo3::impl_::wrap::EmptyTupleConverter<Result<(), E>>`
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: never type fallback affects this call to an `unsafe` function
- --> tests/ui/invalid_pyclass_generic.rs:4:1
-  |
-4 | #[pyclass(generic)]
-  | ^^^^^^^^^^^^^^^^^^^
-  |
-  = help: specify the type explicitly
-  = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-  = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
-  = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0308]: mismatched types
-  --> tests/ui/invalid_pyclass_generic.rs:29:9
+  --> tests/ui/invalid_pyclass_generic.rs:27:9
    |
-27 |     ) -> PyResult<Py<PyAny>> {
+25 |     ) -> PyResult<Py<PyAny>> {
    |          ------------------- expected `Result<pyo3::Py<pyo3::PyAny>, PyErr>` because of return type
-28 |
-29 |         pyo3::types::PyGenericAlias::new(cls.py(), cls.as_any(), key)
+26 |
+27 |         pyo3::types::PyGenericAlias::new(cls.py(), cls.as_any(), key)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Py<PyAny>, PyErr>`, found `Result<Bound<'_, PyGenericAlias>, PyErr>`
    |
    = note: expected enum `Result<pyo3::Py<pyo3::PyAny>, _>`
               found enum `Result<pyo3::Bound<'_, PyGenericAlias>, _>`
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_generic.rs:21:12
+  --> tests/ui/invalid_pyclass_generic.rs:20:12
    |
-21 |     pub fn __class_getitem__(
+20 |     pub fn __class_getitem__(
    |            ^^^^^^^^^^^^^^^^^ multiple `__pymethod___class_getitem____` found
    |
 note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetItem`
@@ -112,16 +100,16 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:13:1
+  --> tests/ui/invalid_pyclass_generic.rs:12:1
    |
-13 | #[pymethods]
+12 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the macro `::pyo3::impl_::pymethods::maybe_define_fastcall_function_with_keywords` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_generic.rs:21:12
+  --> tests/ui/invalid_pyclass_generic.rs:20:12
    |
-21 |     pub fn __class_getitem__(
+20 |     pub fn __class_getitem__(
    |            ^^^^^^^^^^^^^^^^^ multiple `__class_getitem__` found
    |
 note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetItem`
@@ -130,37 +118,27 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:21:5
+  --> tests/ui/invalid_pyclass_generic.rs:20:5
    |
-21 | /     pub fn __class_getitem__(
+20 | /     pub fn __class_getitem__(
+21 | |
 22 | |
-23 | |
-24 | |         cls: &Bound<'_, PyType>,
-...  |
-27 | |     ) -> PyResult<Py<PyAny>> {
+23 | |         cls: &Bound<'_, PyType>,
+24 | |         key: &Bound<'_, PyAny>,
+25 | |     ) -> PyResult<Py<PyAny>> {
    | |____________________________^
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_generic.rs:27:10
+  --> tests/ui/invalid_pyclass_generic.rs:25:10
    |
-27 |     ) -> PyResult<Py<PyAny>> {
+25 |     ) -> PyResult<Py<PyAny>> {
    |          ^^^^^^^^ multiple `wrap_into_ptr` found
    |
    = note: candidate #1 is defined in an impl for the type `pyo3::impl_::wrap::EmptyTupleConverter<()>`
    = note: candidate #2 is defined in an impl for the type `pyo3::impl_::wrap::EmptyTupleConverter<Result<(), E>>`
 
-error: never type fallback affects this call to an `unsafe` function
-  --> tests/ui/invalid_pyclass_generic.rs:25:14
-   |
-25 |         key: &Bound<'_, PyAny>,
-   |              ^
-   |
-   = help: specify the type explicitly
-   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
-   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
-
-error: aborting due to 11 previous errors
+error: aborting due to 9 previous errors
 
 Some errors have detailed explanations: E0034, E0308, E0592.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_generic.stderr
+++ b/tests/ui/invalid_pyclass_generic.stderr
@@ -4,7 +4,7 @@ error[E0592]: duplicate definitions with name `__pymethod___class_getitem____`
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___class_getitem____`
 ...
-12 | #[pymethods]
+13 | #[pymethods]
    | ------------ other definition for `__pymethod___class_getitem____`
    |
    = note: this error originates in the macro `::pyo3::impl_::pymethods::maybe_define_fastcall_function_with_keywords` which comes from the expansion of the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -15,12 +15,12 @@ error[E0592]: duplicate definitions with name `__class_getitem__`
  4 |   #[pyclass(generic)]
    |   ^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__class_getitem__`
 ...
-20 | /     pub fn __class_getitem__(
-21 | |
+21 | /     pub fn __class_getitem__(
 22 | |
-23 | |         cls: &Bound<'_, PyType>,
-24 | |         key: &Bound<'_, PyAny>,
-25 | |     ) -> PyResult<Py<PyAny>> {
+23 | |
+24 | |         cls: &Bound<'_, PyType>,
+...  |
+27 | |     ) -> PyResult<Py<PyAny>> {
    | |____________________________- other definition for `__class_getitem__`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -37,9 +37,9 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:12:1
+  --> tests/ui/invalid_pyclass_generic.rs:13:1
    |
-12 | #[pymethods]
+13 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -55,14 +55,14 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:20:5
+  --> tests/ui/invalid_pyclass_generic.rs:21:5
    |
-20 | /     pub fn __class_getitem__(
-21 | |
+21 | /     pub fn __class_getitem__(
 22 | |
-23 | |         cls: &Bound<'_, PyType>,
-24 | |         key: &Bound<'_, PyAny>,
-25 | |     ) -> PyResult<Py<PyAny>> {
+23 | |
+24 | |         cls: &Bound<'_, PyType>,
+...  |
+27 | |     ) -> PyResult<Py<PyAny>> {
    | |____________________________^
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -70,28 +70,40 @@ error[E0034]: multiple applicable items in scope
  --> tests/ui/invalid_pyclass_generic.rs:4:1
   |
 4 | #[pyclass(generic)]
-  | ^^^^^^^^^^^^^^^^^^^ multiple `wrap` found
+  | ^^^^^^^^^^^^^^^^^^^ multiple `wrap_into_ptr` found
   |
-  = note: candidate #1 is defined in an impl for the type `pyo3::impl_::wrap::IntoPyObjectConverter<Result<T, E>>`
-  = note: candidate #2 is defined in an impl for the type `pyo3::impl_::wrap::IntoPyObjectConverter<T>`
+  = note: candidate #1 is defined in an impl for the type `pyo3::impl_::wrap::EmptyTupleConverter<()>`
+  = note: candidate #2 is defined in an impl for the type `pyo3::impl_::wrap::EmptyTupleConverter<Result<(), E>>`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: never type fallback affects this call to an `unsafe` function
+ --> tests/ui/invalid_pyclass_generic.rs:4:1
+  |
+4 | #[pyclass(generic)]
+  | ^^^^^^^^^^^^^^^^^^^
+  |
+  = help: specify the type explicitly
+  = warning: this changes meaning in Rust 2024 and in a future release in all editions!
+  = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
+  = note: `#[deny(never_type_fallback_flowing_into_unsafe)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
   = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/ui/invalid_pyclass_generic.rs:27:9
+  --> tests/ui/invalid_pyclass_generic.rs:29:9
    |
-25 |     ) -> PyResult<Py<PyAny>> {
+27 |     ) -> PyResult<Py<PyAny>> {
    |          ------------------- expected `Result<pyo3::Py<pyo3::PyAny>, PyErr>` because of return type
-26 |
-27 |         pyo3::types::PyGenericAlias::new(cls.py(), cls.as_any(), key)
+28 |
+29 |         pyo3::types::PyGenericAlias::new(cls.py(), cls.as_any(), key)
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `Result<Py<PyAny>, PyErr>`, found `Result<Bound<'_, PyGenericAlias>, PyErr>`
    |
    = note: expected enum `Result<pyo3::Py<pyo3::PyAny>, _>`
               found enum `Result<pyo3::Bound<'_, PyGenericAlias>, _>`
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_generic.rs:20:12
+  --> tests/ui/invalid_pyclass_generic.rs:21:12
    |
-20 |     pub fn __class_getitem__(
+21 |     pub fn __class_getitem__(
    |            ^^^^^^^^^^^^^^^^^ multiple `__pymethod___class_getitem____` found
    |
 note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetItem`
@@ -100,16 +112,16 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:12:1
+  --> tests/ui/invalid_pyclass_generic.rs:13:1
    |
-12 | #[pymethods]
+13 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the macro `::pyo3::impl_::pymethods::maybe_define_fastcall_function_with_keywords` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_generic.rs:20:12
+  --> tests/ui/invalid_pyclass_generic.rs:21:12
    |
-20 |     pub fn __class_getitem__(
+21 |     pub fn __class_getitem__(
    |            ^^^^^^^^^^^^^^^^^ multiple `__class_getitem__` found
    |
 note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetItem`
@@ -118,27 +130,37 @@ note: candidate #1 is defined in an impl for the type `ClassRedefinesClassGetIte
  4 | #[pyclass(generic)]
    | ^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `ClassRedefinesClassGetItem`
-  --> tests/ui/invalid_pyclass_generic.rs:20:5
+  --> tests/ui/invalid_pyclass_generic.rs:21:5
    |
-20 | /     pub fn __class_getitem__(
-21 | |
+21 | /     pub fn __class_getitem__(
 22 | |
-23 | |         cls: &Bound<'_, PyType>,
-24 | |         key: &Bound<'_, PyAny>,
-25 | |     ) -> PyResult<Py<PyAny>> {
+23 | |
+24 | |         cls: &Bound<'_, PyType>,
+...  |
+27 | |     ) -> PyResult<Py<PyAny>> {
    | |____________________________^
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_generic.rs:25:10
+  --> tests/ui/invalid_pyclass_generic.rs:27:10
    |
-25 |     ) -> PyResult<Py<PyAny>> {
-   |          ^^^^^^^^ multiple `wrap` found
+27 |     ) -> PyResult<Py<PyAny>> {
+   |          ^^^^^^^^ multiple `wrap_into_ptr` found
    |
-   = note: candidate #1 is defined in an impl for the type `pyo3::impl_::wrap::IntoPyObjectConverter<Result<T, E>>`
-   = note: candidate #2 is defined in an impl for the type `pyo3::impl_::wrap::IntoPyObjectConverter<T>`
+   = note: candidate #1 is defined in an impl for the type `pyo3::impl_::wrap::EmptyTupleConverter<()>`
+   = note: candidate #2 is defined in an impl for the type `pyo3::impl_::wrap::EmptyTupleConverter<Result<(), E>>`
 
-error: aborting due to 9 previous errors
+error: never type fallback affects this call to an `unsafe` function
+  --> tests/ui/invalid_pyclass_generic.rs:25:14
+   |
+25 |         key: &Bound<'_, PyAny>,
+   |              ^
+   |
+   = help: specify the type explicitly
+   = warning: this changes meaning in Rust 2024 and in a future release in all editions!
+   = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
+
+error: aborting due to 11 previous errors
 
 Some errors have detailed explanations: E0034, E0308, E0592.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyfunction_argument.default.stderr
+++ b/tests/ui/invalid_pyfunction_argument.default.stderr
@@ -16,8 +16,8 @@ help: the trait `PyClass` is implemented for `Foo`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -56,8 +56,8 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -95,8 +95,8 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -139,8 +139,8 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`

--- a/tests/ui/invalid_pyfunction_argument.default.stderr
+++ b/tests/ui/invalid_pyfunction_argument.default.stderr
@@ -2,96 +2,21 @@ error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
    --> tests/ui/invalid_pyfunction_argument.rs:9:37
     |
   9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `PyClass` is not implemented for `Atomic<*mut ()>`
+    |                                     ^^^^^^^^^ the trait `FromPyObject<'_, '_>` is not implemented for `Atomic<*mut ()>`
     |
     = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `PyClass` is implemented for `Foo`
-   --> tests/ui/invalid_pyfunction_argument.rs:17:1
-    |
- 17 | #[pyclass(skip_from_py_object)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
     = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:9:37
-    |
-  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `Clone` is not implemented for `Atomic<*mut ()>`
-    |
-    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
-  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-
-error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:9:37
-    |
-  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Atomic<*mut ()>`
-    |
-    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
-  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -102,40 +27,29 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_required_ar
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
 
 error[E0277]: `Foo` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:22:59
+   --> tests/ui/invalid_pyfunction_argument.rs:20:40
     |
- 22 | fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
-    |                                                           ^^^ unsatisfied trait bound
+ 20 | fn pyclass_without_from_py_object(arg: Foo) {
+    |                                        ^^^ unsatisfied trait bound
     |
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Foo`
-   --> tests/ui/invalid_pyfunction_argument.rs:19:1
+help: the trait `FromPyObject<'_, '_>` is not implemented for `Foo`
+   --> tests/ui/invalid_pyfunction_argument.rs:17:1
     |
- 19 | struct Foo;
+ 17 | struct Foo;
     | ^^^^^^^^^^
     = note: implement `FromPyObject` to enable using `Foo` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Foo` to implement `FromPyObject<'_, '_>`
-  = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
+    = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -145,6 +59,6 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_required_ar
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_pyfunction_argument.default.stderr
+++ b/tests/ui/invalid_pyfunction_argument.default.stderr
@@ -2,63 +2,149 @@ error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
    --> tests/ui/invalid_pyfunction_argument.rs:9:37
     |
   9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `FromPyObject<'_, '_>` is not implemented for `Atomic<*mut ()>`
+    |                                     ^^^^^^^^^ the trait `PyClass` is not implemented for `Atomic<*mut ()>`
     |
     = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
-              `&'a CStr` implements `FromPyObject<'a, '_>`
-              `&'a [u8]` implements `FromPyObject<'a, 'py>`
-              `&'a str` implements `FromPyObject<'a, '_>`
-              `(T0, T1)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
-            and $N others
-    = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-
-error[E0277]: `Foo` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:20:40
-    |
- 20 | fn pyclass_without_from_py_object(arg: Foo) {
-    |                                        ^^^ unsatisfied trait bound
-    |
-help: the trait `FromPyObject<'_, '_>` is not implemented for `Foo`
+help: the trait `PyClass` is implemented for `Foo`
    --> tests/ui/invalid_pyfunction_argument.rs:17:1
     |
- 17 | struct Foo;
+ 17 | #[pyclass(skip_from_py_object)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+    = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
+   --> tests/ui/invalid_pyfunction_argument.rs:9:37
+    |
+  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
+    |                                     ^^^^^^^^^ the trait `Clone` is not implemented for `Atomic<*mut ()>`
+    |
+    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
+    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
+help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
+ --> src/impl_/extract_argument.rs
+  |
+  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
+  | |     for &'holder Bound<'py, T>
+  | | where
+  | |     T: PyTypeCheck,
+  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
+  | | where
+  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
+  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+...
+  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
+  | |     for &'holder mut T
+  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+
+error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
+   --> tests/ui/invalid_pyfunction_argument.rs:9:37
+    |
+  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
+    |                                     ^^^^^^^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Atomic<*mut ()>`
+    |
+    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
+    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
+help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
+ --> src/impl_/extract_argument.rs
+  |
+  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
+  | |     for &'holder Bound<'py, T>
+  | | where
+  | |     T: PyTypeCheck,
+  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
+  | | where
+  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
+  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+...
+  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
+  | |     for &'holder mut T
+  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+
+error[E0277]: `Foo` cannot be used as a Python function argument
+   --> tests/ui/invalid_pyfunction_argument.rs:22:59
+    |
+ 22 | fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
+    |                                                           ^^^ unsatisfied trait bound
+    |
+help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Foo`
+   --> tests/ui/invalid_pyfunction_argument.rs:19:1
+    |
+ 19 | struct Foo;
     | ^^^^^^^^^^
     = note: implement `FromPyObject` to enable using `Foo` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
-              `&'a CStr` implements `FromPyObject<'a, '_>`
-              `&'a [u8]` implements `FromPyObject<'a, 'py>`
-              `&'a str` implements `FromPyObject<'a, '_>`
-              `(T0, T1)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
-            and $N others
-    = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
+help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
  --> src/impl_/extract_argument.rs
   |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
+  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
+  | |     for &'holder Bound<'py, T>
+  | | where
+  | |     T: PyTypeCheck,
+  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
+  | | where
+  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
+  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+...
+  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
+  | |     for &'holder mut T
+  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+  = note: required for `Foo` to implement `FromPyObject<'_, '_>`
+  = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
 
-error: aborting due to 2 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_pyfunction_argument.inspect.stderr
+++ b/tests/ui/invalid_pyfunction_argument.inspect.stderr
@@ -28,15 +28,15 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
   | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
 
 error[E0277]: `Foo` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:20:40
+   --> tests/ui/invalid_pyfunction_argument.rs:22:59
     |
- 20 | fn pyclass_without_from_py_object(arg: Foo) {
-    |                                        ^^^ unsatisfied trait bound
+ 22 | fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
+    |                                                           ^^^ unsatisfied trait bound
     |
 help: the trait `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, false>` is not implemented for `Foo`
-   --> tests/ui/invalid_pyfunction_argument.rs:17:1
+   --> tests/ui/invalid_pyfunction_argument.rs:19:1
     |
- 17 | struct Foo;
+ 19 | struct Foo;
     | ^^^^^^^^^^
     = note: implement `FromPyObject` to enable using `Foo` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
@@ -65,63 +65,126 @@ error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
    --> tests/ui/invalid_pyfunction_argument.rs:9:37
     |
   9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `FromPyObject<'_, '_>` is not implemented for `Atomic<*mut ()>`
+    |                                     ^^^^^^^^^ the trait `pyo3::PyClass` is not implemented for `Atomic<*mut ()>`
     |
     = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
-              `&'a CStr` implements `FromPyObject<'a, '_>`
-              `&'a [u8]` implements `FromPyObject<'a, 'py>`
-              `&'a str` implements `FromPyObject<'a, '_>`
-              `(T0, T1)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
-            and $N others
-    = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-
-error[E0277]: `Foo` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:20:40
-    |
- 20 | fn pyclass_without_from_py_object(arg: Foo) {
-    |                                        ^^^ unsatisfied trait bound
-    |
-help: the trait `FromPyObject<'_, '_>` is not implemented for `Foo`
+help: the following other types implement trait `pyo3::PyClass`
    --> tests/ui/invalid_pyfunction_argument.rs:17:1
     |
- 17 | struct Foo;
+ 17 | #[pyclass(skip_from_py_object)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo`
+    |
+   ::: src/coroutine.rs:30:1
+    |
+ 30 | #[pyclass(crate = "crate")]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pyo3::coroutine::Coroutine`
+    = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+    = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
+   --> tests/ui/invalid_pyfunction_argument.rs:9:37
+    |
+  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
+    |                                     ^^^^^^^^^ the trait `Clone` is not implemented for `Atomic<*mut ()>`
+    |
+    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
+    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
+help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
+ --> src/impl_/extract_argument.rs
+  |
+  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
+  | |     for &'holder Bound<'py, T>
+  | | where
+  | |     T: PyTypeCheck,
+  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
+  | | where
+  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
+  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
+...
+  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
+  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+...
+  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
+  | |     for &'holder mut T
+  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
+  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+
+error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
+   --> tests/ui/invalid_pyfunction_argument.rs:9:37
+    |
+  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
+    |                                     ^^^^^^^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Atomic<*mut ()>`
+    |
+    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
+    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
+help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented for `pyo3::coroutine::Coroutine`
+ --> src/coroutine.rs
+  |
+  | #[pyclass(crate = "crate")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
+...
+  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: `Foo` cannot be used as a Python function argument
+   --> tests/ui/invalid_pyfunction_argument.rs:22:59
+    |
+ 22 | fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
+    |                                                           ^^^ unsatisfied trait bound
+    |
+help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Foo`
+   --> tests/ui/invalid_pyfunction_argument.rs:19:1
+    |
+ 19 | struct Foo;
     | ^^^^^^^^^^
     = note: implement `FromPyObject` to enable using `Foo` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
-              `&'a CStr` implements `FromPyObject<'a, '_>`
-              `&'a [u8]` implements `FromPyObject<'a, 'py>`
-              `&'a str` implements `FromPyObject<'a, '_>`
-              `(T0, T1)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
-            and $N others
-    = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
+help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented for `pyo3::coroutine::Coroutine`
+ --> src/coroutine.rs
+  |
+  | #[pyclass(crate = "crate")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: required for `Foo` to implement `FromPyObject<'_, '_>`
+  = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
+  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |               ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
+  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 4 previous errors
+error: aborting due to 6 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_pyfunction_argument.inspect.stderr
+++ b/tests/ui/invalid_pyfunction_argument.inspect.stderr
@@ -84,8 +84,8 @@ help: the following other types implement trait `pyo3::PyClass`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -124,8 +124,8 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -148,8 +148,8 @@ help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented f
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
@@ -178,8 +178,8 @@ help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented f
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
-  | pub unsafe fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |               ------------------------- required by a bound in this function
+  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
+  |        ------------------------- required by a bound in this function
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`

--- a/tests/ui/invalid_pyfunction_argument.inspect.stderr
+++ b/tests/ui/invalid_pyfunction_argument.inspect.stderr
@@ -28,15 +28,15 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
   | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
 
 error[E0277]: `Foo` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:22:59
+   --> tests/ui/invalid_pyfunction_argument.rs:20:40
     |
- 22 | fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
-    |                                                           ^^^ unsatisfied trait bound
+ 20 | fn pyclass_without_from_py_object(arg: Foo) {
+    |                                        ^^^ unsatisfied trait bound
     |
 help: the trait `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, false>` is not implemented for `Foo`
-   --> tests/ui/invalid_pyfunction_argument.rs:19:1
+   --> tests/ui/invalid_pyfunction_argument.rs:17:1
     |
- 19 | struct Foo;
+ 17 | struct Foo;
     | ^^^^^^^^^^
     = note: implement `FromPyObject` to enable using `Foo` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
@@ -65,21 +65,20 @@ error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
    --> tests/ui/invalid_pyfunction_argument.rs:9:37
     |
   9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `pyo3::PyClass` is not implemented for `Atomic<*mut ()>`
+    |                                     ^^^^^^^^^ the trait `FromPyObject<'_, '_>` is not implemented for `Atomic<*mut ()>`
     |
     = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::PyClass`
-   --> tests/ui/invalid_pyfunction_argument.rs:17:1
-    |
- 17 | #[pyclass(skip_from_py_object)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo`
-    |
-   ::: src/coroutine.rs:30:1
-    |
- 30 | #[pyclass(crate = "crate")]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pyo3::coroutine::Coroutine`
-    = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
     = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
@@ -89,92 +88,31 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_required_ar
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:9:37
-    |
-  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `Clone` is not implemented for `Atomic<*mut ()>`
-    |
-    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
-  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-
-error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:9:37
-    |
-  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Atomic<*mut ()>`
-    |
-    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented for `pyo3::coroutine::Coroutine`
- --> src/coroutine.rs
-  |
-  | #[pyclass(crate = "crate")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
-  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_required_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ------------------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Foo` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:22:59
+   --> tests/ui/invalid_pyfunction_argument.rs:20:40
     |
- 22 | fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
-    |                                                           ^^^ unsatisfied trait bound
+ 20 | fn pyclass_without_from_py_object(arg: Foo) {
+    |                                        ^^^ unsatisfied trait bound
     |
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Foo`
-   --> tests/ui/invalid_pyfunction_argument.rs:19:1
+help: the trait `FromPyObject<'_, '_>` is not implemented for `Foo`
+   --> tests/ui/invalid_pyfunction_argument.rs:17:1
     |
- 19 | struct Foo;
+ 17 | struct Foo;
     | ^^^^^^^^^^
     = note: implement `FromPyObject` to enable using `Foo` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented for `pyo3::coroutine::Coroutine`
- --> src/coroutine.rs
-  |
-  | #[pyclass(crate = "crate")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  = note: required for `Foo` to implement `FromPyObject<'_, '_>`
-  = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
+    = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -183,8 +121,7 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_required_ar
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_pymethod_receiver.rs
+++ b/tests/ui/invalid_pymethod_receiver.rs
@@ -3,10 +3,14 @@ use pyo3::prelude::*;
 #[pyclass]
 struct MyClass {}
 
+// Deliberately a local type with no `From` implementations, so that the error output
+// doesn't include a candidate list which varies with the enabled features.
+struct NotASelfType;
+
 #[pymethods]
 impl MyClass {
-    fn method_with_invalid_self_type(_slf: i32, _py: Python<'_>, _index: u32) {}
-    //~^ ERROR: the trait bound `i32: TryFrom<&pyo3::Bound<'_, MyClass>>` is not satisfied
+    fn method_with_invalid_self_type(_slf: NotASelfType, _py: Python<'_>, _index: u32) {}
+    //~^ ERROR: the trait bound `NotASelfType: From<&pyo3::Bound<'_, MyClass>>` is not satisfied
 }
 
 fn main() {}

--- a/tests/ui/invalid_pymethod_receiver.rs
+++ b/tests/ui/invalid_pymethod_receiver.rs
@@ -10,7 +10,7 @@ struct NotASelfType;
 #[pymethods]
 impl MyClass {
     fn method_with_invalid_self_type(_slf: NotASelfType, _py: Python<'_>, _index: u32) {}
-    //~^ ERROR: the trait bound `NotASelfType: From<&pyo3::Bound<'_, MyClass>>` is not satisfied
+    //~^ ERROR: the trait bound `NotASelfType: TryFrom<&pyo3::Bound<'_, MyClass>>` is not satisfied
 }
 
 fn main() {}

--- a/tests/ui/invalid_pymethod_receiver.stderr
+++ b/tests/ui/invalid_pymethod_receiver.stderr
@@ -1,17 +1,16 @@
-error[E0277]: the trait bound `i32: TryFrom<&pyo3::Bound<'_, MyClass>>` is not satisfied
- --> tests/ui/invalid_pymethod_receiver.rs:8:44
-  |
-8 |     fn method_with_invalid_self_type(_slf: i32, _py: Python<'_>, _index: u32) {}
-  |                                            ^^^ the trait `From<&pyo3::Bound<'_, MyClass>>` is not implemented for `i32`
-  |
-  = help: `i32` implements trait `From<T>`:
-            From<bool>
-            From<i16>
-            From<i8>
-            From<u16>
-            From<u8>
-  = note: required for `&pyo3::Bound<'_, MyClass>` to implement `Into<i32>`
-  = note: required for `i32` to implement `TryFrom<&pyo3::Bound<'_, MyClass>>`
+error[E0277]: the trait bound `NotASelfType: From<&pyo3::Bound<'_, MyClass>>` is not satisfied
+  --> tests/ui/invalid_pymethod_receiver.rs:12:44
+   |
+12 |     fn method_with_invalid_self_type(_slf: NotASelfType, _py: Python<'_>, _index: u32) {}
+   |                                            ^^^^^^^^^^^^ unsatisfied trait bound
+   |
+help: the trait `From<&pyo3::Bound<'_, MyClass>>` is not implemented for `NotASelfType`
+  --> tests/ui/invalid_pymethod_receiver.rs:8:1
+   |
+ 8 | struct NotASelfType;
+   | ^^^^^^^^^^^^^^^^^^^
+   = note: required for `&pyo3::Bound<'_, MyClass>` to implement `Into<NotASelfType>`
+   = note: required for `NotASelfType` to implement `TryFrom<&pyo3::Bound<'_, MyClass>>`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/invalid_pymethod_receiver.stderr
+++ b/tests/ui/invalid_pymethod_receiver.stderr
@@ -1,16 +1,24 @@
-error[E0277]: the trait bound `NotASelfType: From<&pyo3::Bound<'_, MyClass>>` is not satisfied
-  --> tests/ui/invalid_pymethod_receiver.rs:12:44
-   |
-12 |     fn method_with_invalid_self_type(_slf: NotASelfType, _py: Python<'_>, _index: u32) {}
-   |                                            ^^^^^^^^^^^^ unsatisfied trait bound
-   |
+error[E0277]: the trait bound `NotASelfType: TryFrom<&pyo3::Bound<'_, MyClass>>` is not satisfied
+   --> tests/ui/invalid_pymethod_receiver.rs:12:44
+    |
+ 12 |     fn method_with_invalid_self_type(_slf: NotASelfType, _py: Python<'_>, _index: u32) {}
+    |                                            ^^^^^^^^^^^^ unsatisfied trait bound
+    |
 help: the trait `From<&pyo3::Bound<'_, MyClass>>` is not implemented for `NotASelfType`
-  --> tests/ui/invalid_pymethod_receiver.rs:8:1
-   |
- 8 | struct NotASelfType;
-   | ^^^^^^^^^^^^^^^^^^^
-   = note: required for `&pyo3::Bound<'_, MyClass>` to implement `Into<NotASelfType>`
-   = note: required for `NotASelfType` to implement `TryFrom<&pyo3::Bound<'_, MyClass>>`
+   --> tests/ui/invalid_pymethod_receiver.rs:8:1
+    |
+  8 | struct NotASelfType;
+    | ^^^^^^^^^^^^^^^^^^^
+    = note: required for `&pyo3::Bound<'_, MyClass>` to implement `Into<NotASelfType>`
+    = note: required for `NotASelfType` to implement `TryFrom<&pyo3::Bound<'_, MyClass>>`
+note: required by a bound in `pyo3::impl_::extract_argument::extract_receiver_trusted`
+ --> src/impl_/extract_argument.rs
+  |
+  | pub unsafe fn extract_receiver_trusted<'a, 'py, T, R>(
+  |               ------------------------ required by a bound in this function
+...
+  |     R: TryFrom<&'a Bound<'py, T>>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_receiver_trusted`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/invalid_result_conversion.stderr
+++ b/tests/ui/invalid_result_conversion.stderr
@@ -1,20 +1,27 @@
 error[E0277]: the trait bound `PyErr: From<MyError>` is not satisfied
-  --> tests/ui/invalid_result_conversion.rs:22:25
-   |
-22 | fn should_not_work() -> Result<(), MyError> {
-   |                         ^^^^^^ the trait `From<MyError>` is not implemented for `PyErr`
-   |
-   = help: `PyErr` implements trait `From<T>`:
-             From<AddrParseError>
-             From<CastError<'_, '_>>
-             From<CastIntoError<'_>>
-             From<CharTryFromError>
-             From<FromUtf8Error>
-             From<Infallible>
-             From<IntoInnerError<W>>
-             From<IntoStringError>
-           and $N others
-   = note: required for `MyError` to implement `Into<PyErr>`
+   --> tests/ui/invalid_result_conversion.rs:22:25
+    |
+ 22 | fn should_not_work() -> Result<(), MyError> {
+    |                         ^^^^^^ the trait `From<MyError>` is not implemented for `PyErr`
+    |
+    = help: `PyErr` implements trait `From<T>`:
+              From<AddrParseError>
+              From<CastError<'_, '_>>
+              From<CastIntoError<'_>>
+              From<CharTryFromError>
+              From<FromUtf8Error>
+              From<Infallible>
+              From<IntoInnerError<W>>
+              From<IntoStringError>
+            and $N others
+note: required by a bound in `pyo3::impl_::wrap::IntoPyObjectConverter::<Result<T, E>>::wrap_into_ptr`
+ --> src/impl_/wrap.rs
+  |
+  |     pub fn wrap_into_ptr(&self, py: Python<'py>, obj: Result<T, E>) -> PyResult<*mut ffi::PyObject>
+  |            ------------- required by a bound in this associated function
+  |     where
+  |         PyErr: From<E>,
+  |                ^^^^^^^ required by this bound in `IntoPyObjectConverter::<Result<T, E>>::wrap_into_ptr`
 
 error: aborting due to 1 previous error
 

--- a/tests/ui/missing_intopy.default.stderr
+++ b/tests/ui/missing_intopy.default.stderr
@@ -22,25 +22,15 @@ help: the trait `IntoPyObject<'_>` is not implemented for `Blah`
               &'a (T0, T1, T2, T3)
               &'a (T0, T1, T2, T3, T4)
             and $N others
-note: required by a bound in `pyo3::impl_::wrap::UnknownReturnType::<T>::wrap`
+note: required by a bound in `pyo3::impl_::wrap::UnknownReturnType::<T>::wrap_into_ptr`
  --> src/impl_/wrap.rs
   |
-  |     pub fn wrap<'py>(&self, _: T) -> T
-  |            ---- required by a bound in this associated function
+  |     pub fn wrap_into_ptr<'py>(&self, _: Python<'py>, _: T) -> PyResult<*mut ffi::PyObject>
+  |            ------------- required by a bound in this associated function
   |     where
   |         T: IntoPyObject<'py>,
-  |            ^^^^^^^^^^^^^^^^^ required by this bound in `UnknownReturnType::<T>::wrap`
+  |            ^^^^^^^^^^^^^^^^^ required by this bound in `UnknownReturnType::<T>::wrap_into_ptr`
 
-error[E0599]: no method named `map_err` found for struct `Blah` in the current scope
- --> tests/ui/missing_intopy.rs:8:14
-  |
-5 | struct Blah;
-  | ----------- method `map_err` not found for this struct
-...
-8 | fn blah() -> Blah {
-  |              ^^^^ method not found in `Blah`
+error: aborting due to 1 previous error
 
-error: aborting due to 2 previous errors
-
-Some errors have detailed explanations: E0277, E0599.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/missing_intopy.inspect.stderr
+++ b/tests/ui/missing_intopy.inspect.stderr
@@ -53,25 +53,15 @@ help: the trait `IntoPyObject<'_>` is not implemented for `Blah`
               &'a (T0, T1, T2, T3)
               &'a (T0, T1, T2, T3, T4)
             and $N others
-note: required by a bound in `pyo3::impl_::wrap::UnknownReturnType::<T>::wrap`
+note: required by a bound in `pyo3::impl_::wrap::UnknownReturnType::<T>::wrap_into_ptr`
  --> src/impl_/wrap.rs
   |
-  |     pub fn wrap<'py>(&self, _: T) -> T
-  |            ---- required by a bound in this associated function
+  |     pub fn wrap_into_ptr<'py>(&self, _: Python<'py>, _: T) -> PyResult<*mut ffi::PyObject>
+  |            ------------- required by a bound in this associated function
   |     where
   |         T: IntoPyObject<'py>,
-  |            ^^^^^^^^^^^^^^^^^ required by this bound in `UnknownReturnType::<T>::wrap`
+  |            ^^^^^^^^^^^^^^^^^ required by this bound in `UnknownReturnType::<T>::wrap_into_ptr`
 
-error[E0599]: no method named `map_err` found for struct `Blah` in the current scope
- --> tests/ui/missing_intopy.rs:8:14
-  |
-5 | struct Blah;
-  | ----------- method `map_err` not found for this struct
-...
-8 | fn blah() -> Blah {
-  |              ^^^^ method not found in `Blah`
+error: aborting due to 2 previous errors
 
-error: aborting due to 3 previous errors
-
-Some errors have detailed explanations: E0277, E0599.
-For more information about an error, try `rustc --explain E0277`.
+For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/missing_intopy.rs
+++ b/tests/ui/missing_intopy.rs
@@ -7,7 +7,6 @@ struct Blah;
 #[pyo3::pyfunction]
 fn blah() -> Blah {
     //~^ ERROR: `Blah` cannot be converted to a Python object
-    //~| ERROR: no method named `map_err` found for struct `Blah` in the current scope
     //~[inspect]| ERROR: the trait bound `Blah: pyo3::impl_::introspection::return_type::Sealed` is not satisfied
     Blah
 }


### PR DESCRIPTION
Headline results for pyca/cryptography:

| Metric (median)                                        | stock 0.29.0 | patched | Δ |
|--------------------------------------------------------|--------------|---------|-----|
| Macro-expanded size (`-Zunpretty=expanded`, lines)      | 84,975       | 67,069  | **−21.1%** |
| …of which pyo3-generated (excl. ~25.7k user lines)      | ~59,300      | ~41,300 | **−30%** |
| Debug touch-rebuild of leaf, incremental (7 runs)       | 2.84 s       | 2.53 s  | **−11.0%** |
| Debug rebuild of leaf, non-incremental (4 runs)         | 10.31 s      | 9.59 s  | **−6.9%** |
| rustc total CPU for leaf (`-Ztime-passes`, non-incr.)   | 10.30 s      | 9.41 s  | **−8.6%** |
| Release rebuild of leaf, non-incremental (3 runs)       | 18.85 s      | 18.45 s | −2.1% |


Origin of these wins:


| Category                       | stock  | patched | Δ |
|--------------------------------|--------|---------|------|
| 760 `__pymethod_*` wrappers    | 27,704 | 16,949  | −39% |
| 133 `PyClassImpl` impls        | 10,694 | 8,519   | −20% |
| 96 `PyMethods` items arrays    | 6,986  | 6,644   | −5%  |
| 77 `__pyfunction_*` wrappers   | 4,808  | 2,595   | −46% |
| 146 `PyTypeInfo` impls         | 2,032  | 1,500   | −26% |
| 108 `IntoPyObject` impls       | 1,973  | 1,433   | −27% |


(Work performed with Claude)