### PR TITLE
remove `FromPyObject` blanket implementation

### DIFF
--- a/guide/pyclass-parameters.md
+++ b/guide/pyclass-parameters.md
@@ -23,7 +23,6 @@
 | `sequence` |  Inform PyO3 that this class is a [`Sequence`][params-sequence], and so leave its C-API mapping length slot empty. |
 | `set_all` | Generates setters for all fields of the pyclass. |
 | `new = "from_fields"` | Generates a default `__new__` constructor with all fields as parameters in the `new()` method. |
-| `skip_from_py_object` | Prevents this PyClass from participating in the `FromPyObject: PyClass + Clone` blanket implementation. This allows a custom `FromPyObject` impl, even if `self` is `Clone`. |
 | `str` | Implements `__str__` using the `Display` implementation of the underlying Rust datatype or by passing an optional format string `str="<format string>"`. *Note: The optional format string is only allowed for structs.  `name` and `rename_all` are incompatible with the optional format string.  Additional details can be found in the discussion on this [PR](https://github.com/PyO3/pyo3/pull/4233).* |
 | `subclass` | Allows other Python classes and `#[pyclass]` to inherit from this class. Enums cannot be subclassed. |
 | `unsendable` | Required if your struct is not [`Send`][params-3]. Rather than using `unsendable`, consider implementing your struct in a thread-safe way by e.g. substituting [`Rc`][params-4] with [`Arc`][params-5]. By using `unsendable`, your class will panic when accessed by another thread. Also note the Python's GC is multi-threaded and while unsendable classes will not be traversed on foreign threads to avoid UB, this can lead to memory leaks. |

--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -525,7 +525,7 @@ Over the next few releases the blanket implementation is gradually phased out, a
 As a first step of this migration a new `skip_from_py_object` option for `#[pyclass]` was introduced, to opt-out of the blanket implementation and allow downstream users to provide their own implementation:
 
 ```rust
-# #![allow(dead_code)]
+# #![allow(dead_code, deprecated)]
 # use pyo3::prelude::*;
 
 #[pyclass(skip_from_py_object)] // opt-out of the PyO3 FromPyObject blanket
@@ -547,6 +547,10 @@ impl<'py> FromPyObject<'_, 'py> for Number {
 
 As a second step the `from_py_object` option was introduced.
 This option also opts-out of the blanket implementation and instead generates a custom `FromPyObject` implementation for the pyclass which is functionally equivalent to the blanket.
+
+As of PyO3 0.30.0 `skip_from_py_object` is the new default behavior.
+Setting the option is now deprecated and can be safely removed without changes in behavior.
+PyO3 will remove this option entirely in a future release.
 
 ## `IntoPyObject`
 

--- a/guide/src/migration.md
+++ b/guide/src/migration.md
@@ -173,7 +173,7 @@ struct PyClass {}
 
 After:
 
-```rust
+```rust,ignore
 # use pyo3::prelude::*;
 // If the automatic implementation of `FromPyObject` is desired, opt in:
 #[pyclass(from_py_object)]

--- a/newsfragments/6188.changed.md
+++ b/newsfragments/6188.changed.md
@@ -1,0 +1,2 @@
+switched the default pyclass behavior to not emit `FromPyObject` implementation (previously deprecated)
+deprecated `skip_from_py_object` pyclass option (as is is now the default)

--- a/newsfragments/6188.removed.md
+++ b/newsfragments/6188.removed.md
@@ -1,0 +1,1 @@
+removed deprecated `FromPyObject` blanket implementation

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2944,15 +2944,9 @@ impl<'a> PyClassImplsBuilder<'a> {
             });
         }
 
-        let deprecation = if self.attr.options.skip_from_py_object.is_none()
-            && self.attr.options.from_py_object.is_none()
-        {
-            quote! {
-                const _: () = {
-                    #[allow(unused_import)]
-                    use #pyo3_path::impl_::pyclass::Probe as _;
-                    #pyo3_path::impl_::deprecated::HasAutomaticFromPyObject::<{ #pyo3_path::impl_::pyclass::IsClone::<#cls>::VALUE }>::MSG
-                };
+        let deprecation = if self.attr.options.skip_from_py_object.is_some() {
+            quote_spanned! { self.attr.options.skip_from_py_object.span() =>
+                const _: () = #pyo3_path::impl_::deprecated::SKIP_FROM_PY_OBJECT_DEPRECATED;
             }
         } else {
             TokenStream::new()
@@ -2976,8 +2970,6 @@ impl<'a> PyClassImplsBuilder<'a> {
                     }
                 }
             }
-        } else if self.attr.options.skip_from_py_object.is_none() {
-            quote!( impl #pyo3_path::impl_::pyclass::ExtractPyClassWithClone for #cls {} )
         } else {
             TokenStream::new()
         };

--- a/pytests/src/pyclasses.rs
+++ b/pytests/src/pyclasses.rs
@@ -74,7 +74,7 @@ impl PyClassThreadIter {
 }
 
 /// Demonstrates a base class which can operate on the relevant subclass in its constructor.
-#[pyclass(subclass, skip_from_py_object)]
+#[pyclass(subclass)]
 #[derive(Clone, Debug)]
 struct AssertingBaseClass;
 
@@ -136,7 +136,7 @@ impl SubClassWithInit {
     }
 }
 
-#[pyclass(skip_from_py_object)]
+#[pyclass]
 #[derive(Clone)]
 struct ClassWithDecorators {
     attr: Option<usize>,

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,6 +1,5 @@
 //! Defines conversions between Rust and Python types.
 use crate::err::PyResult;
-use crate::impl_::pyclass::ExtractPyClassWithClone;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_identifier, type_hint_subscript, PyStaticExpr};
 use crate::platform::prelude::*;
@@ -9,8 +8,7 @@ use crate::pyclass::{PyClassGuardError, PyClassGuardMutError};
 use crate::types::PyList;
 use crate::types::PyTuple;
 use crate::{
-    Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyClassGuard, PyErr, PyRef, PyRefMut,
-    PyTypeCheck, Python,
+    Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyRef, PyRefMut, PyTypeCheck, Python,
 };
 use core::convert::Infallible;
 use core::marker::PhantomData;
@@ -512,20 +510,6 @@ pub(crate) use from_py_object_sequence::FromPyObjectSequence;
 pub trait FromPyObjectOwned<'py>: for<'a> FromPyObject<'a, 'py> {}
 impl<'py, T> FromPyObjectOwned<'py> for T where T: for<'a> FromPyObject<'a, 'py> {}
 
-impl<'a, 'py, T> FromPyObject<'a, 'py> for T
-where
-    T: PyClass + Clone + ExtractPyClassWithClone,
-{
-    type Error = PyClassGuardError<'a, 'py>;
-
-    #[cfg(feature = "experimental-inspect")]
-    const INPUT_TYPE: PyStaticExpr = <T as crate::PyTypeInfo>::TYPE_HINT;
-
-    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
-        Ok(obj.extract::<PyClassGuard<'_, T>>()?.clone())
-    }
-}
-
 impl<'a, 'py, T> FromPyObject<'a, 'py> for PyRef<'py, T>
 where
     T: PyClass,
@@ -595,6 +579,7 @@ mod test_no_clone {}
 mod tests {
     #[test]
     #[cfg(feature = "macros")]
+    #[expect(deprecated)]
     fn test_pyclass_skip_from_py_object() {
         use crate::{types::PyAnyMethods, FromPyObject, IntoPyObject, PyErr, Python};
 

--- a/src/impl_/deprecated.rs
+++ b/src/impl_/deprecated.rs
@@ -1,13 +1,5 @@
-pub struct HasAutomaticFromPyObject<const IS_CLONE: bool> {}
-
-impl HasAutomaticFromPyObject<true> {
-    #[deprecated(
-        since = "0.28.0",
-        note = "The `FromPyObject` implementation for `#[pyclass]` types which implement `Clone` is changing to an opt-in option. Use `#[pyclass(from_py_object)]` to opt-in to the `FromPyObject` derive now, or `#[pyclass(skip_from_py_object)]` to skip the `FromPyObject` implementation."
-    )]
-    pub const MSG: () = ();
-}
-
-impl HasAutomaticFromPyObject<false> {
-    pub const MSG: () = ();
-}
+#[deprecated(
+    since = "0.30.0",
+    note = "`skip_from_py_object` enabled by default. The option will be removed in the future"
+)]
+pub const SKIP_FROM_PY_OBJECT_DEPRECATED: () = ();

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1472,8 +1472,6 @@ impl<const IMPLEMENTS_INTOPYOBJECT: bool> ConvertField<false, IMPLEMENTS_INTOPYO
     }
 }
 
-pub trait ExtractPyClassWithClone: generic_pyclass::Sealed {}
-
 #[cfg(test)]
 #[cfg(feature = "macros")]
 mod tests {

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -970,7 +970,7 @@ mod tests {
     fn test_py_run_inserts_globals_2() {
         use alloc::ffi::CString;
 
-        #[crate::pyclass(crate = "crate", skip_from_py_object)]
+        #[crate::pyclass(crate = "crate")]
         #[derive(Clone)]
         struct CodeRunner {
             code: CString,

--- a/src/pycell.rs
+++ b/src/pycell.rs
@@ -775,7 +775,7 @@ mod tests {
 
     use super::*;
 
-    #[crate::pyclass(skip_from_py_object)]
+    #[crate::pyclass]
     #[pyo3(crate = "crate")]
     #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     struct SomeClass(i32);

--- a/tests/test_class_comparisons.rs
+++ b/tests/test_class_comparisons.rs
@@ -4,14 +4,14 @@ use pyo3::prelude::*;
 
 mod test_utils;
 
-#[pyclass(eq, skip_from_py_object)]
+#[pyclass(eq)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum MyEnum {
     Variant,
     OtherVariant,
 }
 
-#[pyclass(eq, ord, skip_from_py_object)]
+#[pyclass(eq, ord)]
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd)]
 pub enum MyEnumOrd {
     Variant,
@@ -63,14 +63,14 @@ fn test_simple_enum_ord_comparable() {
     })
 }
 
-#[pyclass(eq, ord, skip_from_py_object)]
+#[pyclass(eq, ord)]
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd)]
 pub enum MyComplexEnumOrd {
     Variant(i32),
     OtherVariant(String),
 }
 
-#[pyclass(eq, ord, skip_from_py_object)]
+#[pyclass(eq, ord)]
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd)]
 pub enum MyComplexEnumOrd2 {
     Variant { msg: String, idx: u32 },
@@ -145,7 +145,7 @@ fn test_complex_enum_ord_comparable() {
     })
 }
 
-#[pyclass(eq, ord, skip_from_py_object)]
+#[pyclass(eq, ord)]
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd)]
 pub struct Point {
     x: i32,
@@ -170,7 +170,7 @@ fn test_struct_numeric_ord_comparable() {
     })
 }
 
-#[pyclass(eq, ord, skip_from_py_object)]
+#[pyclass(eq, ord)]
 #[derive(Debug, PartialEq, Eq, Clone, PartialOrd)]
 pub struct Person {
     surname: String,
@@ -222,7 +222,7 @@ fn test_struct_string_ord_comparable() {
     })
 }
 
-#[pyclass(eq, ord, skip_from_py_object)]
+#[pyclass(eq, ord)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Record {
     name: String,

--- a/tests/test_class_formatting.rs
+++ b/tests/test_class_formatting.rs
@@ -49,7 +49,7 @@ fn test_enum_class_fmt() {
     })
 }
 
-#[pyclass(str = "X: {x}, Y: {y}, Z: {z}", skip_from_py_object)]
+#[pyclass(str = "X: {x}, Y: {y}, Z: {z}")]
 #[derive(PartialEq, Eq, Clone, PartialOrd)]
 pub struct Point {
     x: i32,
@@ -65,7 +65,7 @@ fn test_custom_struct_custom_str() {
     })
 }
 
-#[pyclass(str, skip_from_py_object)]
+#[pyclass(str)]
 #[derive(PartialEq, Eq, Clone, PartialOrd)]
 pub struct Point2 {
     x: i32,

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -94,7 +94,7 @@ fn test_enum_arg() {
     })
 }
 
-#[pyclass(eq, eq_int, skip_from_py_object)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 enum CustomDiscriminant {
     One = 1,
@@ -147,7 +147,7 @@ fn test_enum_compare_int() {
     })
 }
 
-#[pyclass(eq, eq_int, skip_from_py_object)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(u8)]
 enum SmallEnum {
@@ -162,7 +162,7 @@ fn test_enum_compare_int_no_throw_when_overflow() {
     })
 }
 
-#[pyclass(eq, eq_int, skip_from_py_object)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(usize)]
 #[allow(clippy::enum_clike_unportable_variant)]
@@ -181,7 +181,7 @@ fn test_big_enum_no_overflow() {
     })
 }
 
-#[pyclass(eq, eq_int, skip_from_py_object)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(u16, align(8))]
 enum TestReprParse {
@@ -193,7 +193,7 @@ fn test_repr_parse() {
     assert_eq!(std::mem::align_of::<TestReprParse>(), 8);
 }
 
-#[pyclass(eq, eq_int, name = "MyEnum", skip_from_py_object)]
+#[pyclass(eq, eq_int, name = "MyEnum")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RenameEnum {
     Variant,
@@ -207,7 +207,7 @@ fn test_rename_enum_repr_correct() {
     })
 }
 
-#[pyclass(eq, eq_int, skip_from_py_object)]
+#[pyclass(eq, eq_int)]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum RenameVariantEnum {
     #[pyo3(name = "VARIANT")]
@@ -222,7 +222,7 @@ fn test_rename_variant_repr_correct() {
     })
 }
 
-#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE", skip_from_py_object)]
+#[pyclass(eq, eq_int, rename_all = "SCREAMING_SNAKE_CASE")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[expect(clippy::enum_variant_names)]
 enum RenameAllVariantsEnum {
@@ -265,7 +265,7 @@ fn test_custom_module() {
     });
 }
 
-#[pyclass(eq, skip_from_py_object)]
+#[pyclass(eq)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum EqOnly {
     VariantA,
@@ -390,7 +390,7 @@ fn custom_eq() {
     })
 }
 
-#[pyclass(skip_from_py_object)]
+#[pyclass]
 #[derive(Clone, Copy)]
 pub enum ComplexEnumWithRaw {
     Raw { r#type: i32 },
@@ -427,7 +427,7 @@ fn complex_enum_with_raw_pattern_match() {
 
 #[test]
 fn complex_enum_variant_qualname() {
-    #[pyclass(skip_from_py_object)]
+    #[pyclass]
     pub enum ComplexEnum {
         A(i32),
         B { msg: String },
@@ -442,7 +442,7 @@ fn complex_enum_variant_qualname() {
 
 #[test]
 fn complex_enum_renamed_variant_qualname() {
-    #[pyclass(name = "ComplexEnum", skip_from_py_object)]
+    #[pyclass(name = "ComplexEnum")]
     pub enum PyComplexEnum {
         #[pyo3(name = "A")]
         PyA(i32),

--- a/tests/test_frompyobject.rs
+++ b/tests/test_frompyobject.rs
@@ -129,7 +129,7 @@ pub struct E<T, T2> {
     test2: T2,
 }
 
-#[pyclass(skip_from_py_object)]
+#[pyclass]
 #[derive(Clone)]
 pub struct PyE {
     #[pyo3(get)]

--- a/tests/test_pyself.rs
+++ b/tests/test_pyself.rs
@@ -9,7 +9,7 @@ mod test_utils;
 
 /// Assumes it's a file reader or so.
 /// Inspired by https://github.com/jothan/cordoba, thanks.
-#[pyclass(skip_from_py_object)]
+#[pyclass]
 #[derive(Clone, Debug)]
 struct Reader {
     inner: HashMap<u8, String>,

--- a/tests/ui/abi3_inheritance.stderr
+++ b/tests/ui/abi3_inheritance.stderr
@@ -34,15 +34,6 @@ note: required by a bound in `pyo3::impl_::pyclass::PyClassImpl::BaseType`
   |     type BaseType: PyTypeInfo + PyClassBaseType;
   |                                 ^^^^^^^^^^^^^^^ required by this bound in `PyClassImpl::BaseType`
 
-warning: use of deprecated associated constant `pyo3::impl_::deprecated::HasAutomaticFromPyObject::<true>::MSG`: The `FromPyObject` implementation for `#[pyclass]` types which implement `Clone` is changing to an opt-in option. Use `#[pyclass(from_py_object)]` to opt-in to the `FromPyObject` derive now, or `#[pyclass(skip_from_py_object)]` to skip the `FromPyObject` implementation.
- --> tests/ui/abi3_inheritance.rs:4:1
-  |
-4 | #[pyclass(extends=PyException)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(deprecated)]` on by default
-  = note: this warning originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 2 previous errors; 1 warning emitted
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/forbid_unsafe.rs
+++ b/tests/ui/forbid_unsafe.rs
@@ -13,20 +13,20 @@ mod gh_4394 {
     use pyo3::prelude::*;
 
     #[derive(Eq, Ord, PartialEq, PartialOrd, Clone)]
-    #[pyclass(get_all, skip_from_py_object)]
+    #[pyclass(get_all)]
     pub struct VersionSpecifier {
         pub(crate) operator: Operator,
         pub(crate) version: Version,
     }
 
     #[derive(Eq, Ord, PartialEq, PartialOrd, Debug, Hash, Clone, Copy)]
-    #[pyo3::pyclass(eq, eq_int, skip_from_py_object)]
+    #[pyo3::pyclass(eq, eq_int)]
     pub enum Operator {
         Equal,
     }
 
     #[derive(Clone, Eq, PartialEq, PartialOrd, Ord)]
-    #[pyclass(skip_from_py_object)]
+    #[pyclass]
     pub struct Version;
 }
 

--- a/tests/ui/invalid_cancel_handle.rs
+++ b/tests/ui/invalid_cancel_handle.rs
@@ -24,8 +24,6 @@ async fn cancel_handle_wrong_type(#[pyo3(cancel_handle)] _param: String) {}
 async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
 //~^ ERROR: `CancelHandle` cannot be used as a Python function argument
 //~| ERROR: `CancelHandle` cannot be used as a Python function argument
-//~| ERROR: `CancelHandle` cannot be used as a Python function argument
-//~| ERROR: `CancelHandle` cannot be used as a Python function argument
 
 #[pyfunction]
 async fn cancel_handle_and_from_py_with(

--- a/tests/ui/invalid_cancel_handle.stderr
+++ b/tests/ui/invalid_cancel_handle.stderr
@@ -17,9 +17,9 @@ error: `cancel_handle` attribute can only be used with `async fn`
    |                                                     ^^^^^^
 
 error: `from_py_with` and `cancel_handle` cannot be specified together
-  --> tests/ui/invalid_cancel_handle.rs:32:12
+  --> tests/ui/invalid_cancel_handle.rs:30:12
    |
-32 |     #[pyo3(cancel_handle, from_py_with = cancel_handle)] _param: pyo3::coroutine::CancelHandle,
+30 |     #[pyo3(cancel_handle, from_py_with = cancel_handle)] _param: pyo3::coroutine::CancelHandle,
    |            ^^^^^^^^^^^^^
 
 error[E0277]: `CancelHandle` cannot be used as a Python function argument
@@ -73,57 +73,21 @@ error[E0277]: `CancelHandle` cannot be used as a Python function argument
    --> tests/ui/invalid_cancel_handle.rs:24:50
     |
  24 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
-    |                                                  ^^^^ the trait `pyo3::PyClass` is not implemented for `CancelHandle`
+    |                                                  ^^^^ the trait `FromPyObject<'_, '_>` is not implemented for `CancelHandle`
     |
     = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `pyo3::PyClass` is implemented for `pyo3::coroutine::Coroutine`
- --> src/coroutine.rs
-  |
-  | #[pyclass(crate = "crate")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-  = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `CancelHandle` cannot be used as a Python function argument
-   --> tests/ui/invalid_cancel_handle.rs:24:50
-    |
- 24 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
-    |                                                  ^^^^ the trait `Clone` is not implemented for `CancelHandle`
-    |
-    = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-  = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
+    = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -133,32 +97,7 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
 
-error[E0277]: `CancelHandle` cannot be used as a Python function argument
-   --> tests/ui/invalid_cancel_handle.rs:24:50
-    |
- 24 | async fn missing_cancel_handle_attribute(_param: pyo3::coroutine::CancelHandle) {}
-    |                                                  ^^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `CancelHandle`
-    |
-    = note: implement `FromPyObject` to enable using `CancelHandle` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented for `pyo3::coroutine::Coroutine`
- --> src/coroutine.rs
-  |
-  | #[pyclass(crate = "crate")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  = note: required for `CancelHandle` to implement `FromPyObject<'_, '_>`
-  = note: required for `CancelHandle` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: aborting due to 9 previous errors
+error: aborting due to 7 previous errors
 
 Some errors have detailed explanations: E0277, E0308.
 For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_pyclass_args.default.stderr
+++ b/tests/ui/invalid_pyclass_args.default.stderr
@@ -1,109 +1,109 @@
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
- --> tests/ui/invalid_pyclass_args.rs:8:11
+ --> tests/ui/invalid_pyclass_args.rs:9:11
   |
-8 | #[pyclass(extend=pyo3::types::PyDict)]
+9 | #[pyclass(extend=pyo3::types::PyDict)]
   |           ^^^^^^
 
 error: expected identifier
-  --> tests/ui/invalid_pyclass_args.rs:12:21
+  --> tests/ui/invalid_pyclass_args.rs:13:21
    |
-12 | #[pyclass(extends = "PyDict")]
+13 | #[pyclass(extends = "PyDict")]
    |                     ^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:16:18
+  --> tests/ui/invalid_pyclass_args.rs:17:18
    |
-16 | #[pyclass(name = m::MyClass)]
+17 | #[pyclass(name = m::MyClass)]
    |                  ^
 
 error: expected a single identifier in double quotes
-  --> tests/ui/invalid_pyclass_args.rs:20:18
+  --> tests/ui/invalid_pyclass_args.rs:21:18
    |
-20 | #[pyclass(name = "Custom Name")]
+21 | #[pyclass(name = "Custom Name")]
    |                  ^^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:24:18
+  --> tests/ui/invalid_pyclass_args.rs:25:18
    |
-24 | #[pyclass(name = CustomName)]
+25 | #[pyclass(name = CustomName)]
    |                  ^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:28:24
+  --> tests/ui/invalid_pyclass_args.rs:29:24
    |
-28 | #[pyclass(rename_all = camelCase)]
+29 | #[pyclass(rename_all = camelCase)]
    |                        ^^^^^^^^^
 
 error: expected a valid renaming rule, possible values are: "camelCase", "kebab-case", "lowercase", "PascalCase", "SCREAMING-KEBAB-CASE", "SCREAMING_SNAKE_CASE", "snake_case", "UPPERCASE"
-  --> tests/ui/invalid_pyclass_args.rs:32:24
+  --> tests/ui/invalid_pyclass_args.rs:33:24
    |
-32 | #[pyclass(rename_all = "Camel-Case")]
+33 | #[pyclass(rename_all = "Camel-Case")]
    |                        ^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:36:20
+  --> tests/ui/invalid_pyclass_args.rs:37:20
    |
-36 | #[pyclass(module = my_module)]
+37 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
-  --> tests/ui/invalid_pyclass_args.rs:40:11
+  --> tests/ui/invalid_pyclass_args.rs:41:11
    |
-40 | #[pyclass(weakrev)]
+41 | #[pyclass(weakrev)]
    |           ^^^^^^^
 
 error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
-  --> tests/ui/invalid_pyclass_args.rs:45:8
+  --> tests/ui/invalid_pyclass_args.rs:46:8
    |
-45 | struct CannotBeMappingAndSequence {}
+46 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `eq_int` can only be used on simple enums.
-  --> tests/ui/invalid_pyclass_args.rs:72:11
+  --> tests/ui/invalid_pyclass_args.rs:73:11
    |
-72 | #[pyclass(eq_int)]
+73 | #[pyclass(eq_int)]
    |           ^^^^^^
 
 error: The `hash` option requires the `frozen` option.
-  --> tests/ui/invalid_pyclass_args.rs:81:11
+  --> tests/ui/invalid_pyclass_args.rs:82:11
    |
-81 | #[pyclass(hash)]
+82 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `hash` option requires the `eq` option.
-  --> tests/ui/invalid_pyclass_args.rs:81:11
+  --> tests/ui/invalid_pyclass_args.rs:82:11
    |
-81 | #[pyclass(hash)]
+82 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `ord` option requires the `eq` option.
-   --> tests/ui/invalid_pyclass_args.rs:101:11
+   --> tests/ui/invalid_pyclass_args.rs:102:11
     |
-101 | #[pyclass(ord)]
+102 | #[pyclass(ord)]
     |           ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:109:12
+   --> tests/ui/invalid_pyclass_args.rs:110:12
     |
-109 |     #[pyo3(foo)]
+110 |     #[pyo3(foo)]
     |            ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:111:12
+   --> tests/ui/invalid_pyclass_args.rs:112:12
     |
-111 |     #[pyo3(blah)]
+112 |     #[pyo3(blah)]
     |            ^^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:114:12
+   --> tests/ui/invalid_pyclass_args.rs:115:12
     |
-114 |     #[pyo3(pop)]
+115 |     #[pyo3(pop)]
     |            ^^^
 
 error: invalid format string: expected `}` but string was terminated
-   --> tests/ui/invalid_pyclass_args.rs:138:19
+   --> tests/ui/invalid_pyclass_args.rs:139:19
     |
-138 | #[pyclass(str = "{")]
+139 | #[pyclass(str = "{")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -111,9 +111,9 @@ error: invalid format string: expected `}` but string was terminated
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `}`, found `$`
-   --> tests/ui/invalid_pyclass_args.rs:143:19
+   --> tests/ui/invalid_pyclass_args.rs:144:19
     |
-143 | #[pyclass(str = "{$}")]
+144 | #[pyclass(str = "{$}")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -121,394 +121,329 @@ error: invalid format string: expected `}`, found `$`
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:171:31
+   --> tests/ui/invalid_pyclass_args.rs:172:31
     |
-171 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+172 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:178:31
+   --> tests/ui/invalid_pyclass_args.rs:179:31
     |
-178 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+179 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:184:17
+   --> tests/ui/invalid_pyclass_args.rs:185:17
     |
-184 | #[pyclass(str = "unsafe: {unsafe_variable}")]
+185 | #[pyclass(str = "unsafe: {unsafe_variable}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:191:54
+   --> tests/ui/invalid_pyclass_args.rs:192:54
     |
-191 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
+192 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
     |                                                      ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:199:17
+   --> tests/ui/invalid_pyclass_args.rs:200:17
     |
-199 | #[pyclass(str = "{:?}")]
+200 | #[pyclass(str = "{:?}")]
     |                 ^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:207:17
+   --> tests/ui/invalid_pyclass_args.rs:208:17
     |
-207 | #[pyclass(str = "{}")]
+208 | #[pyclass(str = "{}")]
     |                 ^^^^
 
 error: The format string syntax cannot be used with enums
-   --> tests/ui/invalid_pyclass_args.rs:215:21
+   --> tests/ui/invalid_pyclass_args.rs:216:21
     |
-215 | #[pyclass(eq, str = "Stuff...")]
+216 | #[pyclass(eq, str = "Stuff...")]
     |                     ^^^^^^^^^^
 
 error: `skip_from_py_object` and `from_py_object` are mutually exclusive
-   --> tests/ui/invalid_pyclass_args.rs:229:27
+   --> tests/ui/invalid_pyclass_args.rs:230:27
     |
-229 | #[pyclass(from_py_object, skip_from_py_object)]
+230 | #[pyclass(from_py_object, skip_from_py_object)]
     |                           ^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:236:11
+error: use of deprecated constant `pyo3::impl_::deprecated::SKIP_FROM_PY_OBJECT_DEPRECATED`: `skip_from_py_object` enabled by default. The option will be removed in the future
+   --> tests/ui/invalid_pyclass_args.rs:244:11
     |
-236 | #[pyclass(from_py_object)]
+244 | #[pyclass(skip_from_py_object)]
+    |           ^^^^^^^^^^^^^^^^^^^
+    |
+note: the lint level is defined here
+   --> tests/ui/invalid_pyclass_args.rs:4:9
+    |
+  4 | #![deny(deprecated)]
+    |         ^^^^^^^^^^
+
+error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
+   --> tests/ui/invalid_pyclass_args.rs:237:11
+    |
+237 | #[pyclass(from_py_object)]
     |           ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `StructFromPyObjectNoClone`
     |
 help: consider annotating `StructFromPyObjectNoClone` with `#[derive(Clone)]`
     |
-238 + #[derive(Clone)]
-239 | struct StructFromPyObjectNoClone {
+239 + #[derive(Clone)]
+240 | struct StructFromPyObjectNoClone {
     |
 
 error[E0119]: conflicting implementations of trait `pyo3::impl_::pyclass::doc::PyClassNewTextSignature` for type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ------------------------------- first implementation here
 ...
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^ conflicting implementation for `NewFromFieldsWithManualNew`
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___richcmp____`
 ...
-59 | #[pymethods]
+60 | #[pymethods]
    | ------------ other definition for `__pymethod___richcmp____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___hash____`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___hash____`
 ...
-93 | #[pymethods]
+94 | #[pymethods]
    | ------------ other definition for `__pymethod___hash____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___str____`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___str____`
 ...
-130 | #[pymethods]
+131 | #[pymethods]
     | ------------ other definition for `__pymethod___str____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___new____`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___new____`
 ...
-267 | #[pymethods]
+266 | #[pymethods]
     | ------------ other definition for `__pymethod___new____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `==` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:48:11
+  --> tests/ui/invalid_pyclass_args.rs:49:11
    |
-48 | #[pyclass(eq)]
+49 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:51:1
+  --> tests/ui/invalid_pyclass_args.rs:52:1
    |
-51 | struct EqOptRequiresEq {}
+52 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-51 + #[derive(PartialEq)]
-52 | struct EqOptRequiresEq {}
+52 + #[derive(PartialEq)]
+53 | struct EqOptRequiresEq {}
    |
 
 error[E0369]: binary operation `!=` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:48:11
+  --> tests/ui/invalid_pyclass_args.rs:49:11
    |
-48 | #[pyclass(eq)]
+49 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:51:1
+  --> tests/ui/invalid_pyclass_args.rs:52:1
    |
-51 | struct EqOptRequiresEq {}
+52 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-51 + #[derive(PartialEq)]
-52 | struct EqOptRequiresEq {}
+52 + #[derive(PartialEq)]
+53 | struct EqOptRequiresEq {}
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
-  --> tests/ui/invalid_pyclass_args.rs:76:23
+  --> tests/ui/invalid_pyclass_args.rs:77:23
    |
-76 | #[pyclass(frozen, eq, hash)]
+77 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
    |
 help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
    |
-79 + #[derive(Hash)]
-80 | struct HashOptRequiresHash;
+80 + #[derive(Hash)]
+81 | struct HashOptRequiresHash;
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `aaaa` on type `&Point`
-   --> tests/ui/invalid_pyclass_args.rs:148:17
+   --> tests/ui/invalid_pyclass_args.rs:149:17
     |
-148 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}", skip_from_py_object)]
+149 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `zzz` on type `&Point2`
-   --> tests/ui/invalid_pyclass_args.rs:157:17
+   --> tests/ui/invalid_pyclass_args.rs:158:17
     |
-157 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}", skip_from_py_object)]
+158 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `162543` on type `&Coord3`
-   --> tests/ui/invalid_pyclass_args.rs:166:17
+   --> tests/ui/invalid_pyclass_args.rs:167:17
     |
-166 | #[pyclass(str = "{0}, {162543}, {2}")]
+167 | #[pyclass(str = "{0}, {162543}, {2}")]
     |                 ^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `0`, `1`, `2`
 
-warning: use of deprecated associated constant `pyo3::impl_::deprecated::HasAutomaticFromPyObject::<true>::MSG`: The `FromPyObject` implementation for `#[pyclass]` types which implement `Clone` is changing to an opt-in option. Use `#[pyclass(from_py_object)]` to opt-in to the `FromPyObject` derive now, or `#[pyclass(skip_from_py_object)]` to skip the `FromPyObject` implementation.
-   --> tests/ui/invalid_pyclass_args.rs:243:1
-    |
-243 | #[pyclass]
-    | ^^^^^^^^^^
-    |
-    = note: `#[warn(deprecated)]` on by default
-    = note: this warning originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
+   --> tests/ui/invalid_pyclass_args.rs:253:12
     |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `PyClass` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+253 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `pyo3::FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `PyClass`:
-              Coord
-              Coord2
-              Coord3
-              EqOptAndManualRichCmp
-              EqOptRequiresEq
-              HashOptAndManualHash
-              HashOptRequiresHash
-              NewFromFieldsWithManualNew
+    = help: the following other types implement trait `pyo3::FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `pyo3::FromPyObject<'a, '_>`
+              `&'a [u8]` implements `pyo3::FromPyObject<'a, 'py>`
+              `&'a str` implements `pyo3::FromPyObject<'a, '_>`
+              `(T0, T1)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `pyo3::FromPyObject<'a, 'py>`
             and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-
-error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
-    |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
-    |
-    = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::impl_::pyclass::ExtractPyClassWithClone`:
-              Coord
-              Coord2
-              Coord3
-              EqOptAndManualRichCmp
-              EqOptRequiresEq
-              HashOptAndManualHash
-              HashOptRequiresHash
-              NewFromFieldsWithManualNew
-            and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-
-error[E0277]: the trait bound `dyn std::error::Error + Send + Sync: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:252:12
-    |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `Clone` is not implemented for `dyn std::error::Error + Send + Sync`
-    |
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `Clone`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -519,42 +454,42 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 50 previous errors; 1 warning emitted
+error: aborting due to 49 previous errors
 
 Some errors have detailed explanations: E0034, E0119, E0277, E0369, E0592, E0609.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_args.inspect.stderr
+++ b/tests/ui/invalid_pyclass_args.inspect.stderr
@@ -1,109 +1,109 @@
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
- --> tests/ui/invalid_pyclass_args.rs:8:11
+ --> tests/ui/invalid_pyclass_args.rs:9:11
   |
-8 | #[pyclass(extend=pyo3::types::PyDict)]
+9 | #[pyclass(extend=pyo3::types::PyDict)]
   |           ^^^^^^
 
 error: expected identifier
-  --> tests/ui/invalid_pyclass_args.rs:12:21
+  --> tests/ui/invalid_pyclass_args.rs:13:21
    |
-12 | #[pyclass(extends = "PyDict")]
+13 | #[pyclass(extends = "PyDict")]
    |                     ^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:16:18
+  --> tests/ui/invalid_pyclass_args.rs:17:18
    |
-16 | #[pyclass(name = m::MyClass)]
+17 | #[pyclass(name = m::MyClass)]
    |                  ^
 
 error: expected a single identifier in double quotes
-  --> tests/ui/invalid_pyclass_args.rs:20:18
+  --> tests/ui/invalid_pyclass_args.rs:21:18
    |
-20 | #[pyclass(name = "Custom Name")]
+21 | #[pyclass(name = "Custom Name")]
    |                  ^^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:24:18
+  --> tests/ui/invalid_pyclass_args.rs:25:18
    |
-24 | #[pyclass(name = CustomName)]
+25 | #[pyclass(name = CustomName)]
    |                  ^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:28:24
+  --> tests/ui/invalid_pyclass_args.rs:29:24
    |
-28 | #[pyclass(rename_all = camelCase)]
+29 | #[pyclass(rename_all = camelCase)]
    |                        ^^^^^^^^^
 
 error: expected a valid renaming rule, possible values are: "camelCase", "kebab-case", "lowercase", "PascalCase", "SCREAMING-KEBAB-CASE", "SCREAMING_SNAKE_CASE", "snake_case", "UPPERCASE"
-  --> tests/ui/invalid_pyclass_args.rs:32:24
+  --> tests/ui/invalid_pyclass_args.rs:33:24
    |
-32 | #[pyclass(rename_all = "Camel-Case")]
+33 | #[pyclass(rename_all = "Camel-Case")]
    |                        ^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:36:20
+  --> tests/ui/invalid_pyclass_args.rs:37:20
    |
-36 | #[pyclass(module = my_module)]
+37 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
-  --> tests/ui/invalid_pyclass_args.rs:40:11
+  --> tests/ui/invalid_pyclass_args.rs:41:11
    |
-40 | #[pyclass(weakrev)]
+41 | #[pyclass(weakrev)]
    |           ^^^^^^^
 
 error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
-  --> tests/ui/invalid_pyclass_args.rs:45:8
+  --> tests/ui/invalid_pyclass_args.rs:46:8
    |
-45 | struct CannotBeMappingAndSequence {}
+46 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `eq_int` can only be used on simple enums.
-  --> tests/ui/invalid_pyclass_args.rs:72:11
+  --> tests/ui/invalid_pyclass_args.rs:73:11
    |
-72 | #[pyclass(eq_int)]
+73 | #[pyclass(eq_int)]
    |           ^^^^^^
 
 error: The `hash` option requires the `frozen` option.
-  --> tests/ui/invalid_pyclass_args.rs:81:11
+  --> tests/ui/invalid_pyclass_args.rs:82:11
    |
-81 | #[pyclass(hash)]
+82 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `hash` option requires the `eq` option.
-  --> tests/ui/invalid_pyclass_args.rs:81:11
+  --> tests/ui/invalid_pyclass_args.rs:82:11
    |
-81 | #[pyclass(hash)]
+82 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `ord` option requires the `eq` option.
-   --> tests/ui/invalid_pyclass_args.rs:101:11
+   --> tests/ui/invalid_pyclass_args.rs:102:11
     |
-101 | #[pyclass(ord)]
+102 | #[pyclass(ord)]
     |           ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:109:12
+   --> tests/ui/invalid_pyclass_args.rs:110:12
     |
-109 |     #[pyo3(foo)]
+110 |     #[pyo3(foo)]
     |            ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:111:12
+   --> tests/ui/invalid_pyclass_args.rs:112:12
     |
-111 |     #[pyo3(blah)]
+112 |     #[pyo3(blah)]
     |            ^^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:114:12
+   --> tests/ui/invalid_pyclass_args.rs:115:12
     |
-114 |     #[pyo3(pop)]
+115 |     #[pyo3(pop)]
     |            ^^^
 
 error: invalid format string: expected `}` but string was terminated
-   --> tests/ui/invalid_pyclass_args.rs:138:19
+   --> tests/ui/invalid_pyclass_args.rs:139:19
     |
-138 | #[pyclass(str = "{")]
+139 | #[pyclass(str = "{")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -111,9 +111,9 @@ error: invalid format string: expected `}` but string was terminated
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `}`, found `$`
-   --> tests/ui/invalid_pyclass_args.rs:143:19
+   --> tests/ui/invalid_pyclass_args.rs:144:19
     |
-143 | #[pyclass(str = "{$}")]
+144 | #[pyclass(str = "{$}")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -121,80 +121,92 @@ error: invalid format string: expected `}`, found `$`
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:171:31
+   --> tests/ui/invalid_pyclass_args.rs:172:31
     |
-171 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+172 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:178:31
+   --> tests/ui/invalid_pyclass_args.rs:179:31
     |
-178 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+179 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:184:17
+   --> tests/ui/invalid_pyclass_args.rs:185:17
     |
-184 | #[pyclass(str = "unsafe: {unsafe_variable}")]
+185 | #[pyclass(str = "unsafe: {unsafe_variable}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:191:54
+   --> tests/ui/invalid_pyclass_args.rs:192:54
     |
-191 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
+192 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
     |                                                      ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:199:17
+   --> tests/ui/invalid_pyclass_args.rs:200:17
     |
-199 | #[pyclass(str = "{:?}")]
+200 | #[pyclass(str = "{:?}")]
     |                 ^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:207:17
+   --> tests/ui/invalid_pyclass_args.rs:208:17
     |
-207 | #[pyclass(str = "{}")]
+208 | #[pyclass(str = "{}")]
     |                 ^^^^
 
 error: The format string syntax cannot be used with enums
-   --> tests/ui/invalid_pyclass_args.rs:215:21
+   --> tests/ui/invalid_pyclass_args.rs:216:21
     |
-215 | #[pyclass(eq, str = "Stuff...")]
+216 | #[pyclass(eq, str = "Stuff...")]
     |                     ^^^^^^^^^^
 
 error: `skip_from_py_object` and `from_py_object` are mutually exclusive
-   --> tests/ui/invalid_pyclass_args.rs:229:27
+   --> tests/ui/invalid_pyclass_args.rs:230:27
     |
-229 | #[pyclass(from_py_object, skip_from_py_object)]
+230 | #[pyclass(from_py_object, skip_from_py_object)]
     |                           ^^^^^^^^^^^^^^^^^^^
 
-error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:236:11
+error: use of deprecated constant `pyo3::impl_::deprecated::SKIP_FROM_PY_OBJECT_DEPRECATED`: `skip_from_py_object` enabled by default. The option will be removed in the future
+   --> tests/ui/invalid_pyclass_args.rs:244:11
     |
-236 | #[pyclass(from_py_object)]
+244 | #[pyclass(skip_from_py_object)]
+    |           ^^^^^^^^^^^^^^^^^^^
+    |
+note: the lint level is defined here
+   --> tests/ui/invalid_pyclass_args.rs:4:9
+    |
+  4 | #![deny(deprecated)]
+    |         ^^^^^^^^^^
+
+error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
+   --> tests/ui/invalid_pyclass_args.rs:237:11
+    |
+237 | #[pyclass(from_py_object)]
     |           ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `StructFromPyObjectNoClone`
     |
 help: consider annotating `StructFromPyObjectNoClone` with `#[derive(Clone)]`
     |
-238 + #[derive(Clone)]
-239 | struct StructFromPyObjectNoClone {
+239 + #[derive(Clone)]
+240 | struct StructFromPyObjectNoClone {
     |
 
 error[E0119]: conflicting implementations of trait `pyo3::impl_::pyclass::doc::PyClassNewTextSignature` for type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ------------------------------- first implementation here
 ...
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^ conflicting implementation for `NewFromFieldsWithManualNew`
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
+   --> tests/ui/invalid_pyclass_args.rs:253:12
     |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
+253 |     field: Box<dyn std::error::Error + Send + Sync>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |
     = help: the trait `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, false>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
@@ -222,323 +234,246 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
   | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
 
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___richcmp____`
 ...
-59 | #[pymethods]
+60 | #[pymethods]
    | ------------ other definition for `__pymethod___richcmp____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___hash____`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___hash____`
 ...
-93 | #[pymethods]
+94 | #[pymethods]
    | ------------ other definition for `__pymethod___hash____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___str____`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___str____`
 ...
-130 | #[pymethods]
+131 | #[pymethods]
     | ------------ other definition for `__pymethod___str____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___new____`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___new____`
 ...
-267 | #[pymethods]
+266 | #[pymethods]
     | ------------ other definition for `__pymethod___new____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `==` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:48:11
+  --> tests/ui/invalid_pyclass_args.rs:49:11
    |
-48 | #[pyclass(eq)]
+49 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:51:1
+  --> tests/ui/invalid_pyclass_args.rs:52:1
    |
-51 | struct EqOptRequiresEq {}
+52 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-51 + #[derive(PartialEq)]
-52 | struct EqOptRequiresEq {}
+52 + #[derive(PartialEq)]
+53 | struct EqOptRequiresEq {}
    |
 
 error[E0369]: binary operation `!=` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:48:11
+  --> tests/ui/invalid_pyclass_args.rs:49:11
    |
-48 | #[pyclass(eq)]
+49 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:51:1
+  --> tests/ui/invalid_pyclass_args.rs:52:1
    |
-51 | struct EqOptRequiresEq {}
+52 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-51 + #[derive(PartialEq)]
-52 | struct EqOptRequiresEq {}
+52 + #[derive(PartialEq)]
+53 | struct EqOptRequiresEq {}
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:53:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-53 | #[pyclass(eq)]
+54 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:59:1
+  --> tests/ui/invalid_pyclass_args.rs:60:1
    |
-59 | #[pymethods]
+60 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
-  --> tests/ui/invalid_pyclass_args.rs:76:23
+  --> tests/ui/invalid_pyclass_args.rs:77:23
    |
-76 | #[pyclass(frozen, eq, hash)]
+77 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
    |
 help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
    |
-79 + #[derive(Hash)]
-80 | struct HashOptRequiresHash;
+80 + #[derive(Hash)]
+81 | struct HashOptRequiresHash;
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:87:1
+  --> tests/ui/invalid_pyclass_args.rs:88:1
    |
-87 | #[pyclass(frozen, eq, hash)]
+88 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:93:1
+  --> tests/ui/invalid_pyclass_args.rs:94:1
    |
-93 | #[pymethods]
+94 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:119:1
+   --> tests/ui/invalid_pyclass_args.rs:120:1
     |
-119 | #[pyclass(str)]
+120 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:130:1
+   --> tests/ui/invalid_pyclass_args.rs:131:1
     |
-130 | #[pymethods]
+131 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `aaaa` on type `&Point`
-   --> tests/ui/invalid_pyclass_args.rs:148:17
+   --> tests/ui/invalid_pyclass_args.rs:149:17
     |
-148 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}", skip_from_py_object)]
+149 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `zzz` on type `&Point2`
-   --> tests/ui/invalid_pyclass_args.rs:157:17
+   --> tests/ui/invalid_pyclass_args.rs:158:17
     |
-157 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}", skip_from_py_object)]
+158 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `162543` on type `&Coord3`
-   --> tests/ui/invalid_pyclass_args.rs:166:17
+   --> tests/ui/invalid_pyclass_args.rs:167:17
     |
-166 | #[pyclass(str = "{0}, {162543}, {2}")]
+167 | #[pyclass(str = "{0}, {162543}, {2}")]
     |                 ^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `0`, `1`, `2`
 
-warning: use of deprecated associated constant `pyo3::impl_::deprecated::HasAutomaticFromPyObject::<true>::MSG`: The `FromPyObject` implementation for `#[pyclass]` types which implement `Clone` is changing to an opt-in option. Use `#[pyclass(from_py_object)]` to opt-in to the `FromPyObject` derive now, or `#[pyclass(skip_from_py_object)]` to skip the `FromPyObject` implementation.
-   --> tests/ui/invalid_pyclass_args.rs:243:1
-    |
-243 | #[pyclass]
-    | ^^^^^^^^^^
-    |
-    = note: `#[warn(deprecated)]` on by default
-    = note: this warning originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
+   --> tests/ui/invalid_pyclass_args.rs:253:12
     |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::PyClass` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+253 |     field: Box<dyn std::error::Error + Send + Sync>,
+    |            ^^^ the trait `pyo3::FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::PyClass`:
-              Coord
-              Coord2
-              Coord3
-              EqOptAndManualRichCmp
-              EqOptRequiresEq
-              HashOptAndManualHash
-              HashOptRequiresHash
-              NewFromFieldsWithManualNew
+    = help: the following other types implement trait `pyo3::FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `pyo3::FromPyObject<'a, '_>`
+              `&'a [u8]` implements `pyo3::FromPyObject<'a, 'py>`
+              `&'a str` implements `pyo3::FromPyObject<'a, '_>`
+              `(T0, T1)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `pyo3::FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `pyo3::FromPyObject<'a, 'py>`
             and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-
-error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:252:12
-    |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
-    |
-    = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::impl_::pyclass::ExtractPyClassWithClone`:
-              Coord
-              Coord2
-              Coord3
-              EqOptAndManualRichCmp
-              EqOptRequiresEq
-              HashOptAndManualHash
-              HashOptRequiresHash
-              NewFromFieldsWithManualNew
-            and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-
-error[E0277]: the trait bound `dyn std::error::Error + Send + Sync: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:252:12
-    |
-252 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `Clone` is not implemented for `dyn std::error::Error + Send + Sync`
-    |
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `Clone`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -549,42 +484,42 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:259:1
+   --> tests/ui/invalid_pyclass_args.rs:258:1
     |
-259 | #[pyclass(new = "from_fields")]
+258 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:267:1
+   --> tests/ui/invalid_pyclass_args.rs:266:1
     |
-267 | #[pymethods]
+266 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 51 previous errors; 1 warning emitted
+error: aborting due to 50 previous errors
 
 Some errors have detailed explanations: E0034, E0119, E0277, E0369, E0592, E0609.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_args.rs
+++ b/tests/ui/invalid_pyclass_args.rs
@@ -1,6 +1,7 @@
 //@revisions: default inspect
 //@[default] without-experimental-inspect
 //@[inspect] with-experimental-inspect
+#![deny(deprecated)]
 
 use pyo3::prelude::*;
 use std::fmt::{Display, Formatter};
@@ -145,7 +146,7 @@ struct Coord(u32, u32, u32);
 #[derive(PartialEq)]
 struct Coord2(u32, u32, u32);
 
-#[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}", skip_from_py_object)]
+#[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}")]
 //~^ ERROR: no field `aaaa` on type `&Point`
 #[derive(PartialEq, Eq, Clone, PartialOrd)]
 pub struct Point {
@@ -154,7 +155,7 @@ pub struct Point {
     z: i32,
 }
 
-#[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}", skip_from_py_object)]
+#[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}")]
 //~^ ERROR: no field `zzz` on type `&Point2`
 #[derive(PartialEq, Eq, Clone, PartialOrd)]
 pub struct Point2 {
@@ -240,9 +241,9 @@ struct StructFromPyObjectNoClone {
     b: String,
 }
 
-#[pyclass]
-#[derive(Clone)]
-struct StructImplicitFromPyObjectDeprecated {
+#[pyclass(skip_from_py_object)]
+//~^ ERROR: use of deprecated constant `pyo3::impl_::deprecated::SKIP_FROM_PY_OBJECT_DEPRECATED`: `skip_from_py_object` enabled by default. The option will be removed in the future
+struct StructSkipFromPyObjectDeprecated {
     a: String,
     b: String,
 }
@@ -251,8 +252,6 @@ struct StructImplicitFromPyObjectDeprecated {
 struct NonPythonField {
     field: Box<dyn std::error::Error + Send + Sync>,
     //~^ ERROR: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-    //~| ERROR: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-    //~| ERROR: the trait bound `dyn std::error::Error + Send + Sync: Clone` is not satisfied
     //~[inspect]| ERROR: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
 }
 

--- a/tests/ui/invalid_pyfunction_argument.default.stderr
+++ b/tests/ui/invalid_pyfunction_argument.default.stderr
@@ -2,96 +2,21 @@ error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
    --> tests/ui/invalid_pyfunction_argument.rs:9:37
     |
   9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `PyClass` is not implemented for `Atomic<*mut ()>`
+    |                                     ^^^^^^^^^ the trait `FromPyObject<'_, '_>` is not implemented for `Atomic<*mut ()>`
     |
     = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `PyClass` is implemented for `Foo`
-   --> tests/ui/invalid_pyfunction_argument.rs:17:1
-    |
- 17 | #[pyclass(skip_from_py_object)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
     = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:9:37
-    |
-  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `Clone` is not implemented for `Atomic<*mut ()>`
-    |
-    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
-  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-
-error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:9:37
-    |
-  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Atomic<*mut ()>`
-    |
-    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
-  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -102,40 +27,29 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
 
 error[E0277]: `Foo` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:22:59
+   --> tests/ui/invalid_pyfunction_argument.rs:20:40
     |
- 22 | fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
-    |                                                           ^^^ unsatisfied trait bound
+ 20 | fn pyclass_without_from_py_object(arg: Foo) {
+    |                                        ^^^ unsatisfied trait bound
     |
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Foo`
-   --> tests/ui/invalid_pyfunction_argument.rs:19:1
+help: the trait `FromPyObject<'_, '_>` is not implemented for `Foo`
+   --> tests/ui/invalid_pyfunction_argument.rs:17:1
     |
- 19 | struct Foo;
+ 17 | struct Foo;
     | ^^^^^^^^^^
     = note: implement `FromPyObject` to enable using `Foo` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Foo` to implement `FromPyObject<'_, '_>`
-  = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
+    = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -145,6 +59,6 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
 
-error: aborting due to 4 previous errors
+error: aborting due to 2 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_pyfunction_argument.inspect.stderr
+++ b/tests/ui/invalid_pyfunction_argument.inspect.stderr
@@ -28,15 +28,15 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
   | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
 
 error[E0277]: `Foo` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:22:59
+   --> tests/ui/invalid_pyfunction_argument.rs:20:40
     |
- 22 | fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
-    |                                                           ^^^ unsatisfied trait bound
+ 20 | fn pyclass_without_from_py_object(arg: Foo) {
+    |                                        ^^^ unsatisfied trait bound
     |
 help: the trait `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, false>` is not implemented for `Foo`
-   --> tests/ui/invalid_pyfunction_argument.rs:19:1
+   --> tests/ui/invalid_pyfunction_argument.rs:17:1
     |
- 19 | struct Foo;
+ 17 | struct Foo;
     | ^^^^^^^^^^
     = note: implement `FromPyObject` to enable using `Foo` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
@@ -65,21 +65,20 @@ error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
    --> tests/ui/invalid_pyfunction_argument.rs:9:37
     |
   9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `pyo3::PyClass` is not implemented for `Atomic<*mut ()>`
+    |                                     ^^^^^^^^^ the trait `FromPyObject<'_, '_>` is not implemented for `Atomic<*mut ()>`
     |
     = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::PyClass`
-   --> tests/ui/invalid_pyfunction_argument.rs:17:1
-    |
- 17 | #[pyclass(skip_from_py_object)]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Foo`
-    |
-   ::: src/coroutine.rs:30:1
-    |
- 30 | #[pyclass(crate = "crate")]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `pyo3::coroutine::Coroutine`
-    = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
     = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
@@ -89,92 +88,31 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:9:37
-    |
-  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `Clone` is not implemented for `Atomic<*mut ()>`
-    |
-    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the following other types implement trait `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>`
- --> src/impl_/extract_argument.rs
-  |
-  | / impl<'a, 'holder, 'py, T: 'a + 'py> PyFunctionArgument<'a, 'holder, 'py, false>
-  | |     for &'holder Bound<'py, T>
-  | | where
-  | |     T: PyTypeCheck,
-  | |___________________^ `&'holder pyo3::Bound<'py, T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  | / impl<'a, 'holder, 'py, T> PyFunctionArgument<'a, 'holder, 'py, false> for Option<T>
-  | | where
-  | |     T: PyFunctionArgument<'a, 'holder, 'py, false>,
-  | |___________________________________________________^ `Option<T>` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, 'py, false>`
-...
-  |   impl<'a, 'holder, T: PyClass> PyFunctionArgument<'a, 'holder, '_, false> for &'holder T {
-  |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `&'holder T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-...
-  | / impl<'a, 'holder, T: PyClass<Frozen = False>> PyFunctionArgument<'a, 'holder, '_, false>
-  | |     for &'holder mut T
-  | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
-  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
-  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-
-error[E0277]: `Atomic<*mut ()>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:9:37
-    |
-  9 | fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
-    |                                     ^^^^^^^^^ the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Atomic<*mut ()>`
-    |
-    = note: implement `FromPyObject` to enable using `Atomic<*mut ()>` as a function argument
-    = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented for `pyo3::coroutine::Coroutine`
- --> src/coroutine.rs
-  |
-  | #[pyclass(crate = "crate")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  = note: required for `Atomic<*mut ()>` to implement `FromPyObject<'_, '_>`
-  = note: required for `Atomic<*mut ()>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
-note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
- --> src/impl_/extract_argument.rs
-  |
-  | pub fn extract_argument<'a, 'holder, 'py, T, const IMPLEMENTS_FROMPYOBJECT: bool>(
-  |        ---------------- required by a bound in this function
-...
-  |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Foo` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyfunction_argument.rs:22:59
+   --> tests/ui/invalid_pyfunction_argument.rs:20:40
     |
- 22 | fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
-    |                                                           ^^^ unsatisfied trait bound
+ 20 | fn pyclass_without_from_py_object(arg: Foo) {
+    |                                        ^^^ unsatisfied trait bound
     |
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is not implemented for `Foo`
-   --> tests/ui/invalid_pyfunction_argument.rs:19:1
+help: the trait `FromPyObject<'_, '_>` is not implemented for `Foo`
+   --> tests/ui/invalid_pyfunction_argument.rs:17:1
     |
- 19 | struct Foo;
+ 17 | struct Foo;
     | ^^^^^^^^^^
     = note: implement `FromPyObject` to enable using `Foo` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-help: the trait `pyo3::impl_::pyclass::ExtractPyClassWithClone` is implemented for `pyo3::coroutine::Coroutine`
- --> src/coroutine.rs
-  |
-  | #[pyclass(crate = "crate")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  = note: required for `Foo` to implement `FromPyObject<'_, '_>`
-  = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
+            and $N others
+    = note: required for `Foo` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
   |
@@ -183,8 +121,7 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
 ...
   |     T: PyFunctionArgument<'a, 'holder, 'py, IMPLEMENTS_FROMPYOBJECT>,
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_argument`
-  = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 6 previous errors
+error: aborting due to 4 previous errors
 
 For more information about this error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_pyfunction_argument.rs
+++ b/tests/ui/invalid_pyfunction_argument.rs
@@ -8,18 +8,16 @@ use std::sync::atomic::AtomicPtr;
 #[pyfunction]
 fn invalid_pyfunction_argument(arg: AtomicPtr<()>) {
     //~^ ERROR: `Atomic<*mut ()>` cannot be used as a Python function argument
-    //~| ERROR: `Atomic<*mut ()>` cannot be used as a Python function argument
-    //~| ERROR: `Atomic<*mut ()>` cannot be used as a Python function argument
     //~[inspect]| ERROR: `Atomic<*mut ()>` cannot be used as a Python function argument
     let _ = arg;
 }
 
-#[pyclass(skip_from_py_object)]
+#[pyclass]
 #[derive(Clone)]
 struct Foo;
 
 #[pyfunction]
-fn skip_from_py_object_without_custom_from_py_object(arg: Foo) {
+fn pyclass_without_from_py_object(arg: Foo) {
     //~^ ERROR: `Foo` cannot be used as a Python function argument
     //~[inspect]| ERROR: `Foo` cannot be used as a Python function argument
     let _ = arg;


### PR DESCRIPTION
This follows up on our deprecation of the `FromPyObject` blanket impl in 0.28 and removes it. We still accept the `skip_from_py_object` for now, but deprecate it, as it does not have any function now anymore.

A nice side effect is than many of the error messages of unsupported types are much nicer now 🎉 