### PR TITLE
Add eval frame FFI bindings

### DIFF
--- a/newsfragments/6195.added.md
+++ b/newsfragments/6195.added.md
@@ -1,0 +1,1 @@
+Added FFI bindings for CPython eval-frame get/set API

--- a/newsfragments/6195.fixed.md
+++ b/newsfragments/6195.fixed.md
@@ -1,0 +1,1 @@
+Fix the PyUnstable_Eval_RequestCodeExtraIndex FFI binding to link to the private CPython symbol on Python versions before 3.12.

--- a/pyo3-ffi/src/cpython/ceval.rs
+++ b/pyo3-ffi/src/cpython/ceval.rs
@@ -14,8 +14,8 @@ extern_libpython! {
 
     // skipped private _PyEval_EvalFrameDefault
 
-    // was moved to the unstable API tier on Py_3_12, use link_name for older versions
-    #[cfg_attr(Py_3_12, link_name = "_PyEval_RequestCodeExtraIndex")]
+    // Was moved to the unstable API tier on Py_3_12; older versions export the private name.
+    #[cfg_attr(not(Py_3_12), link_name = "_PyEval_RequestCodeExtraIndex")]
     pub fn PyUnstable_Eval_RequestCodeExtraIndex(func: freefunc) -> Py_ssize_t;
 }
 

--- a/pyo3-ffi/src/cpython/pystate.rs
+++ b/pyo3-ffi/src/cpython/pystate.rs
@@ -1,3 +1,5 @@
+#[cfg(all(Py_3_11, not(PyPy)))]
+use crate::cpython::pyframe::_PyInterpreterFrame;
 use crate::PyThreadState;
 use crate::{PyFrameObject, PyInterpreterState, PyObject};
 use core::ffi::c_int;
@@ -11,6 +13,20 @@ pub type Py_tracefunc = unsafe extern "C" fn(
     what: c_int,
     arg: *mut PyObject,
 ) -> c_int;
+
+#[cfg(all(not(Py_3_11), not(PyPy)))]
+pub type _PyFrameEvalFunction = unsafe extern "C" fn(
+    tstate: *mut PyThreadState,
+    frame: *mut PyFrameObject,
+    throwflag: c_int,
+) -> *mut PyObject;
+
+#[cfg(all(Py_3_11, not(PyPy)))]
+pub type _PyFrameEvalFunction = unsafe extern "C" fn(
+    tstate: *mut PyThreadState,
+    frame: *mut _PyInterpreterFrame,
+    throwflag: c_int,
+) -> *mut PyObject;
 
 pub const PyTrace_CALL: c_int = 0;
 pub const PyTrace_EXCEPTION: c_int = 1;
@@ -78,8 +94,18 @@ extern_libpython! {
 
     #[cfg_attr(PyPy, link_name = "PyPyThreadState_DeleteCurrent")]
     pub fn PyThreadState_DeleteCurrent();
-}
 
-// skipped private _PyFrameEvalFunction
-// skipped private _PyInterpreterState_GetEvalFrameFunc
-// skipped private _PyInterpreterState_SetEvalFrameFunc
+    #[cfg(all(not(Py_3_11), not(PyPy)))]
+    pub fn _PyInterpreterState_GetEvalFrameFunc(
+        interp: *mut PyInterpreterState,
+    ) -> Option<_PyFrameEvalFunction>;
+    #[cfg(all(Py_3_11, not(PyPy)))]
+    pub fn _PyInterpreterState_GetEvalFrameFunc(
+        interp: *mut PyInterpreterState,
+    ) -> _PyFrameEvalFunction;
+    #[cfg(not(PyPy))]
+    pub fn _PyInterpreterState_SetEvalFrameFunc(
+        interp: *mut PyInterpreterState,
+        eval_frame: Option<_PyFrameEvalFunction>,
+    );
+}

--- a/pyo3-ffi/src/impl_/macros.rs
+++ b/pyo3-ffi/src/impl_/macros.rs
@@ -87,6 +87,18 @@ macro_rules! extern_libpython_maybe_private_fn {
         extern_libpython_cpython_private_fn! { $(#[$attrs])* $vis $name($($args)*) $(-> $ret)? }
     };
     (
+        [_PyInterpreterState_GetEvalFrameFunc]
+        $(#[$attrs:meta])* $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)?
+    ) => {
+        extern_libpython_cpython_private_fn! { $(#[$attrs])* $vis $name($($args)*) $(-> $ret)? }
+    };
+    (
+        [_PyInterpreterState_SetEvalFrameFunc]
+        $(#[$attrs:meta])* $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)?
+    ) => {
+        extern_libpython_cpython_private_fn! { $(#[$attrs])* $vis $name($($args)*) $(-> $ret)? }
+    };
+    (
         [_PyObject_GC_New]
         $(#[$attrs:meta])* $vis:vis fn $name:ident($($args:tt)*) $(-> $ret:ty)?
     ) => {


### PR DESCRIPTION
Adds FFI bindings for `_PyInterpreterState_GetEvalFrameFunc`, `_PyInterpreterState_SetEvalFrameFunc`, and `_PyFrameEvalFunction`.

In 3.11 [`_PyInterpreterState_GetEvalFrameFunc`](https://github.com/python/cpython/blob/d2b2f5eacab4dd48446b63340613b05dcbbf0b44/Python/pystate.c#L2146) returns `_PyEval_EvalFrameDefault` if it is NULL, so the Option is removed from the return type.

Would it be acceptable to expose `_PyEval_EvalFrameDefault` in this PR since it may be required by older versions?
