### PR TITLE
fix: release pyclass dict during deallocation

### DIFF
--- a/newsfragments/6198.fixed.md
+++ b/newsfragments/6198.fixed.md
@@ -1,0 +1,1 @@
+Fix a memory leak when deallocating `#[pyclass(dict)]` instances with a populated `__dict__`.

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -65,6 +65,9 @@ pub trait PyClassDict: sealed::Sealed {
     /// Empties the dictionary of its key-value pairs.
     #[inline]
     fn clear_dict(&self, _py: Python<'_>) {}
+    /// Releases the owned reference to the dictionary.
+    #[inline]
+    fn release_dict(&mut self, _py: Python<'_>) {}
     /// Visits the `__dict__`, if any, on behalf of `tp_traverse`.
     ///
     /// # Safety
@@ -113,6 +116,10 @@ impl PyClassDict for PyClassDictSlot {
         if !self.0.is_null() {
             unsafe { ffi::PyDict_Clear(self.0) }
         }
+    }
+    #[inline]
+    fn release_dict(&mut self, _py: Python<'_>) {
+        unsafe { ffi::Py_CLEAR(&raw mut self.0) }
     }
     #[inline]
     unsafe fn traverse_dict(&self, visit: ffi::visitproc, arg: *mut c_void) -> c_int {

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -380,7 +380,7 @@ impl<T: PyClassImpl> PyClassObjectContents<T> {
         if self.thread_checker.can_drop(py) {
             unsafe { ManuallyDrop::drop(&mut self.value) };
         }
-        self.dict.clear_dict(py);
+        self.dict.release_dict(py);
         unsafe { self.weakref.clear_weakrefs(py_object, py) };
     }
 }

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -475,6 +475,33 @@ fn access_dunder_dict() {
     });
 }
 
+#[test]
+fn dunder_dict_is_released() {
+    Python::attach(|py| {
+        let inst = Py::new(
+            py,
+            DunderDictSupport {
+                _pad: *b"DEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+            },
+        )
+        .unwrap();
+
+        inst.setattr(py, "a", 1).unwrap();
+
+        let dict = inst.bind(py).getattr("__dict__").unwrap();
+        let get_refcnt = || {
+            // SAFETY: `dict` holds a valid reference while its reference count is read.
+            unsafe { pyo3::ffi::Py_REFCNT(dict.as_ptr()) }
+        };
+        let refcnt = get_refcnt();
+
+        drop(inst);
+
+        assert_eq!(get_refcnt(), refcnt - 1);
+        py_assert!(py, dict, "dict == {'a': 1}");
+    });
+}
+
 // If the base class has dict support, child class also has dict
 #[pyclass(extends=DunderDictSupport)]
 struct InheritDict {


### PR DESCRIPTION
 Fixes #5953.

`PyClassDictSlot::clear_dict` previously called `PyDict_Clear`, which removed the contents of `__dict__` but did not release the pyclass instance's reference to the dictionary itself. This leaked the empty dictionary when the instance was deallocated.

Use `Py_CLEAR` to clear the slot and decrement the dictionary's reference count.

