### PR TITLE
Skip the reference pool mutex on attach when no decrefs are pending

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -16,7 +16,16 @@ env:
 
 jobs:
   benchmarks:
+    name: benchmarks/${{ matrix.mode }}
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - mode: simulation
+            session: codspeed
+          - mode: walltime
+            session: codspeed-walltime
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: astral-sh/setup-uv@v7
@@ -49,6 +58,6 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v5.0.1
         with:
-          run: uvx nox -s codspeed
+          run: uvx nox -s ${{ matrix.session }}
           token: ${{ secrets.CODSPEED_TOKEN }}
-          mode: simulation
+          mode: ${{ matrix.mode }}

--- a/newsfragments/6200.changed.md
+++ b/newsfragments/6200.changed.md
@@ -1,0 +1,1 @@
+Skip the deferred-decref pool's mutex on attach when no decrefs are pending. Attaching no longer serializes on a global mutex, which could cause excessive context switching in multithreaded free-threaded scenarios.

--- a/noxfile.py
+++ b/noxfile.py
@@ -318,6 +318,14 @@ def codspeed(session: nox.Session) -> bool:
     _run(session, "pytest", "--codspeed", external=True)
 
 
+@nox.session(name="codspeed-walltime")
+def codspeed_walltime(session: nox.Session) -> bool:
+    bench = "bench_attach_scaling"
+    os.chdir(PYO3_DIR / "pyo3-benches")
+    _run_cargo(session, "codspeed", "build", "--bench", bench)
+    _run_cargo(session, "codspeed", "run", "--bench", bench)
+
+
 @nox.session(name="clippy-all", venv_backend="none")
 def clippy_all(session: nox.Session) -> None:
     success = True

--- a/pyo3-benches/Cargo.toml
+++ b/pyo3-benches/Cargo.toml
@@ -31,6 +31,10 @@ name = "bench_attach"
 harness = false
 
 [[bench]]
+name = "bench_attach_scaling"
+harness = false
+
+[[bench]]
 name = "bench_call"
 harness = false
 

--- a/pyo3-benches/benches/bench_attach.rs
+++ b/pyo3-benches/benches/bench_attach.rs
@@ -13,9 +13,16 @@ fn bench_dirty_attach(b: &mut Bencher<'_>) {
     b.iter(|| Python::attach(|py| obj.clone_ref(py)));
 }
 
+fn bench_empty_pool_attach(b: &mut Bencher<'_>) {
+    // Drop the returned clone while detached so that the reference pool exists but is empty.
+    drop(Python::attach(|py| py.None()));
+    b.iter(|| Python::attach(|_| {}));
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("clean_attach", bench_clean_attach);
     c.bench_function("dirty_attach", bench_dirty_attach);
+    c.bench_function("empty_pool_attach", bench_empty_pool_attach);
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/pyo3-benches/benches/bench_attach_scaling.rs
+++ b/pyo3-benches/benches/bench_attach_scaling.rs
@@ -1,0 +1,109 @@
+use codspeed_criterion_compat::{criterion_group, criterion_main, Criterion};
+
+// Attaching drains the deferred-decref pool behind a process-global mutex, which serializes
+// attaches across threads.
+#[cfg(Py_GIL_DISABLED)]
+mod scaling {
+    use codspeed_criterion_compat::{BenchmarkId, Criterion, Throughput};
+
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::channel,
+        Arc,
+    };
+    use std::thread::{sleep, spawn, JoinHandle};
+    use std::time::{Duration, Instant};
+
+    use pyo3::prelude::*;
+
+    const THREADS: [usize; 4] = [1, 2, 4, 8];
+
+    // Nested attaches, so that each iteration is a pool drain rather than a `PyGILState_Ensure`.
+    fn bench_nested_attach(c: &mut Criterion, name: &str) {
+        let mut group = c.benchmark_group(name);
+
+        for threads in THREADS {
+            group.throughput(Throughput::Elements(threads as u64));
+            group.bench_function(BenchmarkId::from_parameter(threads), |b| {
+                let (done, finished) = channel();
+
+                let senders = (0..threads)
+                    .map(|_| {
+                        let (sender, receiver) = channel();
+
+                        let done = done.clone();
+
+                        spawn(move || {
+                            for iters in receiver {
+                                Python::attach(|_| {
+                                    for _ in 0..iters {
+                                        Python::attach(|_| {});
+                                    }
+                                });
+
+                                done.send(()).unwrap();
+                            }
+                        });
+
+                        sender
+                    })
+                    .collect::<Vec<_>>();
+
+                b.iter_custom(|iters| {
+                    let start = Instant::now();
+
+                    for sender in &senders {
+                        sender.send(iters).unwrap();
+                    }
+
+                    for _ in 0..threads {
+                        finished.recv().unwrap();
+                    }
+
+                    start.elapsed()
+                });
+            });
+        }
+
+        group.finish();
+    }
+
+    // A detached thread trickling drops into the pool, as a real workload would.
+    fn spawn_dropper(stop: Arc<AtomicBool>) -> JoinHandle<()> {
+        spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                let objs =
+                    Python::attach(|py| (0..1000).map(|_| py.None()).collect::<Vec<Py<PyAny>>>());
+
+                for obj in objs {
+                    drop(obj);
+
+                    sleep(Duration::from_micros(50));
+                }
+            }
+        })
+    }
+
+    pub fn benchmarks(c: &mut Criterion) {
+        // Drop the returned clone while detached so that the reference pool exists but is empty.
+        drop(Python::attach(|py| py.None()));
+
+        bench_nested_attach(c, "nested_attach_scaling/empty_pool");
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let dropper = spawn_dropper(stop.clone());
+
+        bench_nested_attach(c, "nested_attach_scaling/sparse_pool");
+
+        stop.store(true, Ordering::Relaxed);
+        dropper.join().unwrap();
+    }
+}
+
+fn criterion_benchmark(_c: &mut Criterion) {
+    #[cfg(Py_GIL_DISABLED)]
+    scaling::benchmarks(_c);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/pyo3-benches/benches/bench_attach_scaling.rs
+++ b/pyo3-benches/benches/bench_attach_scaling.rs
@@ -16,7 +16,7 @@ mod scaling {
 
     use pyo3::prelude::*;
 
-    const THREADS: [usize; 4] = [1, 2, 4, 8];
+    const THREADS: [usize; 3] = [1, 2, 4];
 
     // Nested attaches, so that each iteration is a pool drain rather than a `PyGILState_Ensure`.
     fn bench_nested_attach(c: &mut Criterion, name: &str) {

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -9,6 +9,8 @@ use crate::platform::prelude::*;
 use crate::{ffi, Python};
 
 use core::cell::Cell;
+#[cfg(not(pyo3_disable_reference_pool))]
+use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg_attr(pyo3_disable_reference_pool, allow(unused_imports))]
 use core::{mem, ptr::NonNull};
 #[cfg(not(pyo3_disable_reference_pool))]
@@ -190,6 +192,8 @@ type PyObjVec = Vec<NonNull<ffi::PyObject>>;
 #[cfg(not(pyo3_disable_reference_pool))]
 /// Thread-safe storage for objects which were dec_ref while not attached.
 struct ReferencePool {
+    // Whether any decrefs are (or may be) pending
+    dirty: AtomicBool,
     pending_decrefs: Mutex<PyObjVec>,
 }
 
@@ -197,20 +201,23 @@ struct ReferencePool {
 impl ReferencePool {
     const fn new() -> Self {
         Self {
+            dirty: AtomicBool::new(false),
             pending_decrefs: Mutex::new(Vec::new()),
         }
     }
 
     fn register_decref(&self, obj: NonNull<ffi::PyObject>) {
         self.pending_decrefs.lock().unwrap().push(obj);
+        self.dirty.store(true, Ordering::Release);
     }
 
     fn drop_deferred_references(&self, _py: Python<'_>) {
-        let mut pending_decrefs = self.pending_decrefs.lock().unwrap();
-        if pending_decrefs.is_empty() {
+        if !self.dirty.load(Ordering::Acquire) {
             return;
         }
+        self.dirty.store(false, Ordering::Relaxed);
 
+        let mut pending_decrefs = self.pending_decrefs.lock().unwrap();
         let decrefs = mem::take(&mut *pending_decrefs);
         drop(pending_decrefs);
 
@@ -536,6 +543,21 @@ mod tests {
             let c = obj.clone();
             assert_eq!(count + 1, c._get_refcnt(py));
         })
+    }
+
+    #[test]
+    #[cfg(not(pyo3_disable_reference_pool))]
+    fn test_detached_drop_is_collected_on_next_attach() {
+        let obj = Python::attach(get_object);
+        let (count, ptr) = Python::attach(|py| (obj._get_refcnt(py), obj.clone_ref(py).into_ptr()));
+
+        // A decref registered while detached applies once an attach drains the pool.
+        get_pool().register_decref(NonNull::new(ptr).unwrap());
+
+        Python::attach(|py| {
+            assert_eq!(count, obj._get_refcnt(py));
+            drop(obj);
+        });
     }
 
     #[test]

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -192,7 +192,9 @@ type PyObjVec = Vec<NonNull<ffi::PyObject>>;
 #[cfg(not(pyo3_disable_reference_pool))]
 /// Thread-safe storage for objects which were dec_ref while not attached.
 struct ReferencePool {
-    // Whether any decrefs are (or may be) pending
+    // Whether any decrefs are (or may be) pending. The `Mutex` performs
+    // synchronization so we can use `Relaxed` ordering for all operations
+    // on this flag.
     dirty: AtomicBool,
     pending_decrefs: Mutex<PyObjVec>,
 }
@@ -208,16 +210,41 @@ impl ReferencePool {
 
     fn register_decref(&self, obj: NonNull<ffi::PyObject>) {
         self.pending_decrefs.lock().unwrap().push(obj);
-        self.dirty.store(true, Ordering::Release);
+        self.dirty.store(true, Ordering::Relaxed);
     }
 
-    fn drop_deferred_references(&self, _py: Python<'_>) {
-        if !self.dirty.load(Ordering::Acquire) {
+    fn drop_deferred_references(&self, py: Python<'_>) {
+        // Check the dirty flag first to avoid any possible contention from atomic
+        // RMW operation to update the dirty flag on a hit.
+        if !self.dirty.load(Ordering::Relaxed) {
             return;
         }
-        self.dirty.store(false, Ordering::Relaxed);
+
+        // dirty flag is set, we _probably_ need to drop references (the flag is
+        // not updated under the mutex so false positives are possible but rare)
+        self.drop_deferred_references_slow(py);
+    }
+
+    #[cold]
+    fn drop_deferred_references_slow(&self, _py: Python<'_>) {
+        // Compare and swap the dirty flag to false avoids multiple threads from having
+        // contention on the mutex.
+        if self
+            .dirty
+            .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            // Another thread is already dropping the references, so we can return early.
+            return;
+        }
 
         let mut pending_decrefs = self.pending_decrefs.lock().unwrap();
+        if pending_decrefs.is_empty() {
+            // We don't set the dirty flag under the mutex so it's possible to reach
+            // this case as a false positive. Returning early avoids a store on false
+            // positives.
+            return;
+        }
         let decrefs = mem::take(&mut *pending_decrefs);
         drop(pending_decrefs);
 


### PR DESCRIPTION
Closes https://github.com/PyO3/pyo3/issues/6199.
