### PR TITLE
docs: added pyo3-nest to the tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ about this topic.
 - [pyo3-built](https://github.com/PyO3/pyo3-built) _Simple macro to expose metadata obtained with the [`built`](https://crates.io/crates/built) crate as a [`PyDict`](https://docs.rs/pyo3/*/pyo3/types/struct.PyDict.html)_
 - [rust-numpy](https://github.com/PyO3/rust-numpy) _Rust binding of NumPy C-API_
 - [dict-derive](https://github.com/gperinazzo/dict-derive) _Derive FromPyObject to automatically transform Python dicts into Rust structs_
+- [pyo3-nest](https://github.com/ppmpreetham/pyo3-nest) _Directly nest submodules in pyo3_
 - [pyo3-log](https://github.com/vorner/pyo3-log) _Bridge from Rust to Python logging_
 - [pythonize](https://github.com/davidhewitt/pythonize) _Serde serializer for converting Rust objects to JSON-compatible Python objects_
 - [pyo3-async-runtimes](https://github.com/PyO3/pyo3-async-runtimes) _Utilities for interoperability with Python's Asyncio library and Rust's async runtimes._


### PR DESCRIPTION
Added [pyo3-nest](https://github.com/ppmpreetham/pyo3-nest) to the tools.

## Example
```rust
use pyo3::prelude::*;
use pyo3_nest::{submodule, add_classes, add_functions};

#[pyclass]
struct Router;

#[pyclass]
struct Route;

#[pyfunction]
fn hello() -> &'static str {
    "Hello from Rust!"
}

#[pymodule]
fn my_extension(m: &Bound<'_, PyModule>) -> PyResult<()> {
    // top level classes
    add_classes!(m, Router);

    // nested submodules
    submodule!(m, "routing", add_classes!(Router, Route));
    submodule!(m, "utils", add_functions!(hello));

    // classes + functions
    submodule!(m, "api.v1.responses", 
        add_classes!(JSONResponse, ErrorResponse) && 
        add_functions!(success_response, error_response)
    );

    Ok(())
}
```
## In Python:
```rust
from my_extension import Router
from my_extension.routing import Route
from my_extension.api.v1.responses import JSONResponse, success_response
```


## Before
```rust
let routing = PyModule::new(py, "routing")?;
routing.add_class::<Router>()?;
routing.add_class::<Route>()?;
m.add_submodule(&routing)?;
```

## After
```rust
submodule!(m, "routing", add_classes!(Router, Route));
```