### PR TITLE
ci: use Cargo build warnings setting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,5 +135,4 @@ jobs:
     env:
       CARGO_TERM_VERBOSE: ${{ inputs.verbose }}
       RUST_BACKTRACE: 1
-      RUSTFLAGS: "-D warnings"
-      RUSTDOCFLAGS: "-D warnings"
+      CARGO_BUILD_WARNINGS: deny


### PR DESCRIPTION
## Summary

- replace the CI job's `RUSTFLAGS` and `RUSTDOCFLAGS` warning overrides with Cargo's `CARGO_BUILD_WARNINGS: deny` setting
- keep the warning policy scoped to CI

## Why

Closes #6205.

Cargo now provides `build.warnings` specifically for configuring the effective warning level of local packages. Using its environment-variable form removes the need to maintain separate low-level compiler and rustdoc flags.

## Impact

This is a CI-only configuration change. It does not affect PyO3's runtime behavior, dependencies, or public API.

## Validation

- parsed `.github/workflows/build.yml` successfully with Ruby's YAML parser
- ran `git diff --check`
- reviewed the environment mapping against Cargo's `build.warnings` configuration documentation

The full nox suite was not run because the change only updates the reusable GitHub Actions workflow environment.

## Authorship disclosure

This contribution was prepared by OpenAI Codex on behalf of @coyaSONG, after reviewing `Contributing.md`, the pull request template, and the Code of Conduct.
