### PR TITLE
Fix compilation with GraalPy 3.13

### DIFF
--- a/newsfragments/6208.fixed.md
+++ b/newsfragments/6208.fixed.md
@@ -1,0 +1,1 @@
+Fixed building on GraalPy 3.13.

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,7 +61,7 @@ def _get_output(*args: str, env: dict[str, str] | None = None) -> str:
 
 
 def _parse_supported_interpreter_version(
-    python_impl: Literal["cpython", "pypy"],
+    python_impl: Literal["cpython", "pypy", "graalpy"],
 ) -> tuple[str, str]:
     output = _get_output("cargo", "metadata", "--format-version=1", "--no-deps")
     cargo_packages = json.loads(output)["packages"]
@@ -75,7 +75,7 @@ def _parse_supported_interpreter_version(
 
 
 def _supported_interpreter_versions(
-    python_impl: Literal["cpython", "pypy"],
+    python_impl: Literal["cpython", "pypy", "graalpy"],
 ) -> list[str]:
     min_version, max_version = _parse_supported_interpreter_version(python_impl)
     major = int(min_version.split(".")[0])
@@ -95,6 +95,7 @@ ABI3T_PY_VERSIONS = [
     p for p in PY_VERSIONS if p.endswith("t") and int(p.split(".")[1].strip("t")) > 14
 ]
 PYPY_VERSIONS = _supported_interpreter_versions("pypy")
+GRAALPY_VERSIONS = _supported_interpreter_versions("graalpy")
 
 
 @nox.session(venv_backend="none")
@@ -1965,6 +1966,9 @@ def _for_all_version_configs(
 
         for version in PYPY_VERSIONS:
             _job_with_config("PyPy", version)
+
+        for version in GRAALPY_VERSIONS:
+            _job_with_config("GraalVM", version)
 
 
 class _ConfigFile:

--- a/pyo3-ffi/Cargo.toml
+++ b/pyo3-ffi/Cargo.toml
@@ -56,3 +56,7 @@ max-version = "3.15" # inclusive
 [package.metadata.pypy]
 min-version = "3.11"
 max-version = "3.11" # inclusive
+
+[package.metadata.graalpy]
+min-version = "3.12"
+max-version = "3.13" # inclusive

--- a/pyo3-ffi/src/cpython/dictobject.rs
+++ b/pyo3-ffi/src/cpython/dictobject.rs
@@ -2,6 +2,8 @@
 use crate::object::*;
 #[cfg(not(any(PyPy, GraalPy)))]
 use crate::pyport::Py_ssize_t;
+#[cfg(all(GraalPy, Py_3_13))]
+use crate::PyObject;
 
 #[cfg(Py_3_15)]
 use crate::{dictobject::PyDict_Check, PyDict_CheckExact};

--- a/pytests/pyproject.toml
+++ b/pytests/pyproject.toml
@@ -28,7 +28,8 @@ exclude = ["stubs"]
 [project.optional-dependencies]
 dev = [
     "hypothesis>=3.55",
-    "mypy~=1.0",
+    # mypy doesn't build on GraalPy when installed via uv
+    "mypy~=1.0; platform_python_implementation != 'GraalVM'",
     "pyrefly~=0.57.0",
     "pytest-asyncio>=0.21,<2",
     "pytest-benchmark>=3.4",


### PR DESCRIPTION
I'm working on updating GraalPy to 3.13 and I found out that there was an undefined symbol when the 3.13 `cfg`s activated. I tried adding GraalPy to `check-all` so that both versions are tested.

CC @timfel