### PR TITLE
ci: switch to Cargo `build.warnings`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,5 +135,8 @@ jobs:
     env:
       CARGO_TERM_VERBOSE: ${{ inputs.verbose }}
       RUST_BACKTRACE: 1
-      RUSTFLAGS: "-D warnings"
+      # `build.warnings` avoids the cache-busting from `RUSTFLAGS`; respected on
+      # Cargo 1.97+ only (MSRV jobs fall back to warn). rustdoc isn't covered by
+      # it, so RUSTDOCFLAGS stays.
+      CARGO_BUILD_WARNINGS: deny
       RUSTDOCFLAGS: "-D warnings"

--- a/noxfile.py
+++ b/noxfile.py
@@ -1665,10 +1665,10 @@ def check_feature_powerset(session: nox.Session):
         *abi3t_version_features,
     ]
 
-    # deny warnings
+    # deny warnings; `build.warnings` avoids the cache-busting from `RUSTFLAGS`
+    # and is respected on Cargo 1.97+ only (MSRV falls back to warn).
     env = os.environ.copy()
-    rust_flags = env.get("RUSTFLAGS", "")
-    env["RUSTFLAGS"] = f"{rust_flags} -Dwarnings"
+    env["CARGO_BUILD_WARNINGS"] = "deny"
 
     subcommand = "hack"
     if "minimal-versions" in session.posargs:


### PR DESCRIPTION
Closes #6205.

Replaces `RUSTFLAGS=-D warnings` with Cargo's `build.warnings` (`CARGO_BUILD_WARNINGS=deny`) for the rustc-warning paths, so CI no longer cache-busts local builds — `RUSTFLAGS` is part of cargo's fingerprint, `build.warnings` is not.

Two things I kept separate from a straight swap:
- `build.warnings` is only respected on Cargo 1.97+. PyO3's MSRV is 1.83 and the MSRV jobs run through `build.yml` / `check-feature-powerset`, so there the setting is silently ignored and warnings stay non-fatal until the MSRV reaches 1.97; stable jobs still enforce them. I kept this simple rather than gating per-toolchain, since it self-resolves.
- `build.warnings` covers rustc build warnings but not rustdoc, so I left `RUSTDOCFLAGS=-D warnings` (and the `docs` nox session) in place.

Verified locally on 1.97.1 that `CARGO_BUILD_WARNINGS=deny` turns warnings into errors for `cargo build`, `test`, and `hack check`, and is ignored on 1.95.

(AI-assisted; the MSRV/rustdoc analysis and final decisions are my own.)
