### PR TITLE
Decref the reference to the type held by an instance when deallocating an instance of an extension type

### DIFF
--- a/newsfragments/6224.fixed.md
+++ b/newsfragments/6224.fixed.md
@@ -1,0 +1,1 @@
+Decref reference held by instance to its type

--- a/newsfragments/6224.fixed.md
+++ b/newsfragments/6224.fixed.md
@@ -1,1 +1,1 @@
-Decref reference held by instance to its type
+Decref the reference held by an instance of a heap allocated type to its type on deallocation

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -988,10 +988,6 @@ pub unsafe extern "C" fn free_with_freelist<T: PyClassWithFreeList>(obj: *mut c_
                 ffi::PyObject_Free
             };
             free(obj.as_ptr().cast());
-
-            if ffi::PyType_HasFeature(ty, ffi::Py_TPFLAGS_HEAPTYPE) != 0 {
-                ffi::Py_DECREF(ty as *mut ffi::PyObject);
-            }
         }
     }
 }

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -265,7 +265,8 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
         // FIXME: there is potentially subtle issues here if the base is overwritten
         // at runtime? To be investigated.
         let type_ptr = type_obj.as_type_ptr();
-        let actual_type = PyType::from_borrowed_type_ptr(py, ffi::Py_TYPE(slf));
+        let actual_type_ptr = ffi::Py_TYPE(slf);
+        let actual_type = PyType::from_borrowed_type_ptr(py, actual_type_ptr);
 
         // For `#[pyclass]` types which inherit from PyAny, we can just call tp_free
         #[cfg(not(RustPython))]
@@ -296,7 +297,7 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
         } else {
             type_obj.get_slot(TP_FREE).expect("type missing tp_free")(slf.cast());
         }
-        Py_DECREF(type_ptr as *mut ffi::PyObject);
+        Py_DECREF(actual_type_ptr as *mut ffi::PyObject);
     }
 }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -6,8 +6,6 @@ use core::marker::PhantomData;
 use core::mem::{offset_of, ManuallyDrop, MaybeUninit};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-use pyo3_ffi::Py_DECREF;
-
 use crate::impl_::pyclass::{
     PyClassBaseType, PyClassDict, PyClassImpl, PyClassThreadChecker, PyClassWeakRef, PyObjectOffset,
 };
@@ -16,7 +14,7 @@ use crate::internal::get_slot::{TP_DEALLOC, TP_FREE};
 use crate::sync::PyOnceLock;
 use crate::type_object::{PyLayout, PySizedLayout, PyTypeInfo};
 use crate::types::PyType;
-use crate::{ffi, PyClass, Python};
+use crate::{ffi, Bound, PyClass, Python};
 
 use crate::types::PyTypeMethods;
 
@@ -266,7 +264,20 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
         // at runtime? To be investigated.
         let type_ptr = type_obj.as_type_ptr();
         let actual_type_ptr = ffi::Py_TYPE(slf);
-        let actual_type = PyType::from_borrowed_type_ptr(py, actual_type_ptr);
+        let actual_type = if ffi::PyType_HasFeature(actual_type_ptr, ffi::Py_TPFLAGS_HEAPTYPE) != 0
+        {
+            // For heap types, instances must decref the type object  when they
+            // are deallocated, so we create a bound from a borrowed pointer as
+            // as if it was an owned pointer. In this way, when the bound is dropped,
+            // it will decref the type object.
+            Bound::from_owned_ptr(py, actual_type_ptr as *mut ffi::PyObject)
+                .cast_into_unchecked::<PyType>()
+        } else {
+            // For non heap types, we can just create a bound from a borrowed pointer.
+            // This aligns with Py_TYPE contract.
+            Bound::from_borrowed_ptr(py, actual_type_ptr as *mut ffi::PyObject)
+                .cast_into_unchecked::<PyType>()
+        };
 
         // For `#[pyclass]` types which inherit from PyAny, we can just call tp_free
         #[cfg(not(RustPython))]
@@ -297,7 +308,10 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
         } else {
             type_obj.get_slot(TP_FREE).expect("type missing tp_free")(slf.cast());
         }
-        Py_DECREF(actual_type_ptr as *mut ffi::PyObject);
+
+        // Cause the reference to the type to be decrefed for heap types, which
+        // is necessary to avoid a reference leak.
+        drop(actual_type);
     }
 }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -6,6 +6,8 @@ use core::marker::PhantomData;
 use core::mem::{offset_of, ManuallyDrop, MaybeUninit};
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+use pyo3_ffi::Py_DECREF;
+
 use crate::impl_::pyclass::{
     PyClassBaseType, PyClassDict, PyClassImpl, PyClassThreadChecker, PyClassWeakRef, PyObjectOffset,
 };
@@ -267,26 +269,22 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
 
         // For `#[pyclass]` types which inherit from PyAny, we can just call tp_free
         #[cfg(not(RustPython))]
-        if core::ptr::eq(type_ptr, &raw const ffi::PyBaseObject_Type) {
-            let tp_free = actual_type
-                .get_slot(TP_FREE)
-                .expect("PyBaseObject_Type should have tp_free");
-            return tp_free(slf.cast());
-        }
+        let base_object_type_ptr = &raw const ffi::PyBaseObject_Type;
         #[cfg(RustPython)]
-        if core::ptr::eq(type_ptr, {
+        let base_object_type_ptr = {
             static TYPE: PyOnceLock<crate::Py<PyType>> = PyOnceLock::new();
             TYPE.import(py, "builtins", "object").unwrap().as_type_ptr()
-        }) {
+        };
+
+        if core::ptr::eq(type_ptr, base_object_type_ptr) {
             let tp_free = actual_type
                 .get_slot(TP_FREE)
                 .expect("PyBaseObject_Type should have tp_free");
-            return tp_free(slf.cast());
+            tp_free(slf.cast());
         }
-
         // More complex native types (e.g. `extends=PyDict`) require calling the base's dealloc.
         // FIXME: should this be using actual_type.tp_dealloc?
-        if let Some(dealloc) = type_obj.get_slot(TP_DEALLOC) {
+        else if let Some(dealloc) = type_obj.get_slot(TP_DEALLOC) {
             // Before CPython 3.11 BaseException_dealloc would use Py_GC_UNTRACK which
             // assumes the exception is currently GC tracked, so we have to re-track
             // before calling the dealloc so that it can safely call Py_GC_UNTRACK.
@@ -298,6 +296,7 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
         } else {
             type_obj.get_slot(TP_FREE).expect("type missing tp_free")(slf.cast());
         }
+        Py_DECREF(type_ptr as *mut ffi::PyObject);
     }
 }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -264,20 +264,14 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
         // at runtime? To be investigated.
         let type_ptr = type_obj.as_type_ptr();
         let actual_type_ptr = ffi::Py_TYPE(slf);
-        let actual_type = if ffi::PyType_HasFeature(actual_type_ptr, ffi::Py_TPFLAGS_HEAPTYPE) != 0
-        {
-            // For heap types, instances must decref the type object  when they
-            // are deallocated, so we create a bound from a borrowed pointer as
-            // as if it was an owned pointer. In this way, when the bound is dropped,
-            // it will decref the type object.
-            Bound::from_owned_ptr(py, actual_type_ptr as *mut ffi::PyObject)
-                .cast_into_unchecked::<PyType>()
-        } else {
-            // For non heap types, we can just create a bound from a borrowed pointer.
-            // This aligns with Py_TYPE contract.
-            Bound::from_borrowed_ptr(py, actual_type_ptr as *mut ffi::PyObject)
-                .cast_into_unchecked::<PyType>()
-        };
+
+        // For heap types, instances must decref the type object  when they
+        // are deallocated, so we create a bound from a borrowed pointer as
+        // as if it was an owned pointer. In this way, when the bound is dropped,
+        // it will decref the type object.
+        debug_assert!(ffi::PyType_HasFeature(actual_type_ptr, ffi::Py_TPFLAGS_HEAPTYPE) != 0);
+        let actual_type = Bound::from_owned_ptr(py, actual_type_ptr as *mut ffi::PyObject)
+            .cast_into_unchecked::<PyType>();
 
         // For `#[pyclass]` types which inherit from PyAny, we can just call tp_free
         #[cfg(not(RustPython))]

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -6,6 +6,46 @@ use pyo3::types::IntoPyDict;
 
 mod test_utils;
 
+/// Macro to generate refcount leak tests for types.
+/// Ensures that creating and destroying instances doesn't leak references to the type.
+/// Regression test for issues #1363 and #6223.
+macro_rules! assert_type_refcount_stable {
+    // Simple case: type with parameterless constructor
+    ($type_name:ty) => {
+        assert_type_refcount_stable!($type_name, stringify!($type_name), "Type()");
+    };
+    // With custom constructor
+    ($type_name:ty, $test_name:expr, $ctor:expr) => {{
+        Python::attach(|py| {
+            #[expect(non_snake_case)]
+            let Type = py.get_type::<$type_name>();
+            let ctor_code = $ctor;
+            py_run!(
+                py,
+                Type,
+                &format!(
+                    r#"
+                        import gc
+                        import sys
+
+                        gc.collect()
+                        count = sys.getrefcount(Type)
+
+                        for i in range(1000):
+                            obj = {}
+                            del obj
+
+                        gc.collect()
+                        after = sys.getrefcount(Type)
+                        assert after == count, f"Type ref count leaked: {{after}} vs {{count}}"
+                        "#,
+                    ctor_code
+                )
+            );
+        });
+    }};
+}
+
 #[pyclass(subclass)]
 struct BaseClass {
     #[pyo3(get)]
@@ -187,26 +227,28 @@ mod inheriting_native_type {
         },
     };
 
+    use pyo3::types::PySet;
+
+    #[cfg(not(any(PyPy, GraalPy)))]
+    #[pyclass(extends=PySet)]
+    #[derive(Debug)]
+    pub struct SetWithName {
+        #[pyo3(get, name = "name")]
+        _name: &'static str,
+    }
+
+    #[cfg(not(any(PyPy, GraalPy)))]
+    #[pymethods]
+    impl SetWithName {
+        #[new]
+        fn new() -> Self {
+            SetWithName { _name: "Hello :)" }
+        }
+    }
+
     #[cfg(not(any(PyPy, GraalPy)))]
     #[test]
     fn inherit_set() {
-        use pyo3::types::PySet;
-
-        #[pyclass(extends=PySet)]
-        #[derive(Debug)]
-        struct SetWithName {
-            #[pyo3(get, name = "name")]
-            _name: &'static str,
-        }
-
-        #[pymethods]
-        impl SetWithName {
-            #[new]
-            fn new() -> Self {
-                SetWithName { _name: "Hello :)" }
-            }
-        }
-
         Python::attach(|py| {
             let set_sub = pyo3::Py::new(py, SetWithName::new()).unwrap();
             py_run!(
@@ -314,31 +356,33 @@ mod inheriting_native_type {
     }
 
     #[cfg(Py_3_12)]
+    #[pyclass(extends=pyo3::types::PyTzInfo)]
+    struct TzInfoWithName {
+        #[pyo3(get)]
+        name: &'static str,
+    }
+
+    #[cfg(Py_3_12)]
+    #[pymethods]
+    impl TzInfoWithName {
+        #[new]
+        fn new() -> Self {
+            Self { name: "Hello :)" }
+        }
+
+        #[pyo3(signature = (_dt, /))]
+        fn utcoffset<'py>(
+            &self,
+            _dt: Option<&Bound<'_, pyo3::types::PyDateTime>>,
+            py: Python<'py>,
+        ) -> PyResult<Bound<'py, pyo3::types::PyDelta>> {
+            pyo3::types::PyDelta::new(py, 0, 3600, 0, true)
+        }
+    }
+
+    #[cfg(Py_3_12)]
     #[test]
     fn inherit_tzinfo() {
-        #[pyclass(extends=pyo3::types::PyTzInfo)]
-        struct TzInfoWithName {
-            #[pyo3(get)]
-            name: &'static str,
-        }
-
-        #[pymethods]
-        impl TzInfoWithName {
-            #[new]
-            fn new() -> Self {
-                Self { name: "Hello :)" }
-            }
-
-            #[pyo3(signature = (_dt, /))]
-            fn utcoffset<'py>(
-                &self,
-                _dt: Option<&Bound<'_, pyo3::types::PyDateTime>>,
-                py: Python<'py>,
-            ) -> PyResult<Bound<'py, pyo3::types::PyDelta>> {
-                pyo3::types::PyDelta::new(py, 0, 3600, 0, true)
-            }
-        }
-
         Python::attach(|py| {
             let tz = pyo3::Py::new(py, TzInfoWithName::new()).unwrap();
             py_run!(
@@ -357,39 +401,43 @@ mod inheriting_native_type {
         });
     }
 
-    #[test]
     #[cfg(Py_3_12)]
+    #[pyclass(extends=pyo3::types::PyList, subclass)]
+    struct ListWithName {
+        #[pyo3(get)]
+        name: &'static str,
+    }
+
+    #[cfg(Py_3_12)]
+    #[pymethods]
+    impl ListWithName {
+        #[new]
+        fn new() -> Self {
+            Self { name: "Hello :)" }
+        }
+    }
+
+    #[cfg(Py_3_12)]
+    #[pyclass(extends=ListWithName)]
+    struct SubListWithName {
+        #[pyo3(get)]
+        sub_name: &'static str,
+    }
+
+    #[cfg(Py_3_12)]
+    #[pymethods]
+    impl SubListWithName {
+        #[new]
+        fn new() -> PyClassInitializer<Self> {
+            PyClassInitializer::from(ListWithName::new()).add_subclass(Self {
+                sub_name: "Sublist",
+            })
+        }
+    }
+
+    #[cfg(Py_3_12)]
+    #[test]
     fn inherit_list() {
-        #[pyclass(extends=pyo3::types::PyList, subclass)]
-        struct ListWithName {
-            #[pyo3(get)]
-            name: &'static str,
-        }
-
-        #[pymethods]
-        impl ListWithName {
-            #[new]
-            fn new() -> Self {
-                Self { name: "Hello :)" }
-            }
-        }
-
-        #[pyclass(extends=ListWithName)]
-        struct SubListWithName {
-            #[pyo3(get)]
-            sub_name: &'static str,
-        }
-
-        #[pymethods]
-        impl SubListWithName {
-            #[new]
-            fn new() -> PyClassInitializer<Self> {
-                PyClassInitializer::from(ListWithName::new()).add_subclass(Self {
-                    sub_name: "Sublist",
-                })
-            }
-        }
-
         Python::attach(|py| {
             let list_with_name = pyo3::Bound::new(py, ListWithName::new()).unwrap();
             let sub_list_with_name = pyo3::Bound::new(py, SubListWithName::new()).unwrap();
@@ -409,6 +457,42 @@ mod inheriting_native_type {
             );
         });
     }
+
+    // Refcount tests for native type classes
+    #[cfg(not(any(PyPy, GraalPy)))]
+    #[test]
+    fn test_setwitname_ref_counts() {
+        assert_type_refcount_stable!(SetWithName);
+    }
+
+    #[cfg(not(GraalPy))]
+    #[test]
+    fn test_dictwithname_ref_counts() {
+        assert_type_refcount_stable!(DictWithName);
+    }
+
+    #[test]
+    fn test_customexception_ref_counts() {
+        assert_type_refcount_stable!(CustomException, "custom_exception", r#"Type('test')"#);
+    }
+
+    #[cfg(Py_3_12)]
+    #[test]
+    fn test_tzinfowithname_ref_counts() {
+        assert_type_refcount_stable!(TzInfoWithName);
+    }
+
+    #[cfg(Py_3_12)]
+    #[test]
+    fn test_listwithname_ref_counts() {
+        assert_type_refcount_stable!(ListWithName);
+    }
+
+    #[cfg(Py_3_12)]
+    #[test]
+    fn test_sublistwithname_ref_counts() {
+        assert_type_refcount_stable!(SubListWithName);
+    }
 }
 
 #[pyclass(subclass)]
@@ -422,37 +506,28 @@ impl SimpleClass {
     }
 }
 
+// Generate refcount tests for all top-level types
+#[test]
+fn test_baseclass_ref_counts() {
+    assert_type_refcount_stable!(BaseClass);
+}
+
 #[test]
 fn test_subclass_ref_counts() {
-    // regression test for issue #1363
-    Python::attach(|py| {
-        #[expect(non_snake_case)]
-        let SimpleClass = py.get_type::<SimpleClass>();
-        py_run!(
-            py,
-            SimpleClass,
-            r#"
-            import gc
-            import sys
+    assert_type_refcount_stable!(SubClass);
+}
 
-            class SubClass(SimpleClass):
-                pass
+#[test]
+fn test_base_class_with_result_ref_counts() {
+    assert_type_refcount_stable!(BaseClassWithResult, "base_class_with_result", "Type(10)");
+}
 
-            gc.collect()
-            count = sys.getrefcount(SubClass)
+#[test]
+fn test_subclass2_ref_counts() {
+    assert_type_refcount_stable!(SubClass2, "subclass2", "Type(10)");
+}
 
-            for i in range(1000):
-                c = SubClass()
-                del c
-
-            gc.collect()
-            after = sys.getrefcount(SubClass)
-            # depending on Python's GC the count may be either identical or exactly 1000 higher,
-            # both are expected values that are not representative of the issue.
-            #
-            # (With issue #1363 the count will be decreased.)
-            assert after == count or (after == count + 1000), f"{after} vs {count}"
-            "#
-        );
-    })
+#[test]
+fn test_simpleclass_ref_counts() {
+    assert_type_refcount_stable!(SimpleClass);
 }

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -227,8 +227,6 @@ mod inheriting_native_type {
         },
     };
 
-    use pyo3::types::PySet;
-
     #[cfg(not(any(PyPy, GraalPy)))]
     #[pyclass(extends=PySet)]
     #[derive(Debug)]

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -220,12 +220,15 @@ mod inheriting_native_type {
 
     #[cfg(not(GraalPy))]
     use {
-        pyo3::types::{PyCapsule, PyDict, PySet},
+        pyo3::types::{PyCapsule, PyDict},
         std::sync::{
             atomic::{AtomicBool, Ordering},
             Arc,
         },
     };
+
+    #[cfg(not(any(PyPy, GraalPy)))]
+    use pyo3::types::PySet;
 
     #[cfg(not(any(PyPy, GraalPy)))]
     #[pyclass(extends=PySet)]

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -220,7 +220,7 @@ mod inheriting_native_type {
 
     #[cfg(not(GraalPy))]
     use {
-        pyo3::types::{PyCapsule, PyDict},
+        pyo3::types::{PyCapsule, PyDict, PySet},
         std::sync::{
             atomic::{AtomicBool, Ordering},
             Arc,

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -460,36 +460,37 @@ mod inheriting_native_type {
     }
 
     // Refcount tests for native type classes
-    #[cfg(not(any(PyPy, GraalPy)))]
+    #[cfg(not(any(PyPy, GraalPy, Py_GIL_DISABLED)))]
     #[test]
     fn test_setwitname_ref_counts() {
         assert_type_refcount_stable!(SetWithName);
     }
 
-    #[cfg(not(GraalPy))]
+    #[cfg(not(any(GraalPy, Py_GIL_DISABLED)))]
     #[test]
     fn test_dictwithname_ref_counts() {
         assert_type_refcount_stable!(DictWithName);
     }
 
+    #[cfg(not(Py_GIL_DISABLED))]
     #[test]
     fn test_customexception_ref_counts() {
         assert_type_refcount_stable!(CustomException, "custom_exception", r#"Type('test')"#);
     }
 
-    #[cfg(Py_3_12)]
+    #[cfg(all(Py_3_12, not(Py_GIL_DISABLED)))]
     #[test]
     fn test_tzinfowithname_ref_counts() {
         assert_type_refcount_stable!(TzInfoWithName);
     }
 
-    #[cfg(Py_3_12)]
+    #[cfg(all(Py_3_12, not(Py_GIL_DISABLED)))]
     #[test]
     fn test_listwithname_ref_counts() {
         assert_type_refcount_stable!(ListWithName);
     }
 
-    #[cfg(Py_3_12)]
+    #[cfg(all(Py_3_12, not(Py_GIL_DISABLED)))]
     #[test]
     fn test_sublistwithname_ref_counts() {
         assert_type_refcount_stable!(SubListWithName);
@@ -508,26 +509,31 @@ impl SimpleClass {
 }
 
 // Generate refcount tests for all top-level types
+#[cfg(not(Py_GIL_DISABLED))]
 #[test]
 fn test_baseclass_ref_counts() {
     assert_type_refcount_stable!(BaseClass);
 }
 
+#[cfg(not(Py_GIL_DISABLED))]
 #[test]
 fn test_subclass_ref_counts() {
     assert_type_refcount_stable!(SubClass);
 }
 
+#[cfg(not(Py_GIL_DISABLED))]
 #[test]
 fn test_base_class_with_result_ref_counts() {
     assert_type_refcount_stable!(BaseClassWithResult, "base_class_with_result", "Type(10)");
 }
 
+#[cfg(not(Py_GIL_DISABLED))]
 #[test]
 fn test_subclass2_ref_counts() {
     assert_type_refcount_stable!(SubClass2, "subclass2", "Type(10)");
 }
 
+#[cfg(not(Py_GIL_DISABLED))]
 #[test]
 fn test_simpleclass_ref_counts() {
     assert_type_refcount_stable!(SimpleClass);

--- a/tests/test_inheritance.rs
+++ b/tests/test_inheritance.rs
@@ -9,6 +9,7 @@ mod test_utils;
 /// Macro to generate refcount leak tests for types.
 /// Ensures that creating and destroying instances doesn't leak references to the type.
 /// Regression test for issues #1363 and #6223.
+#[cfg(not(Py_GIL_DISABLED))]
 macro_rules! assert_type_refcount_stable {
     // Simple case: type with parameterless constructor
     ($type_name:ty) => {


### PR DESCRIPTION
I am not sure where best to locate the tests since ideally the test should ensure it works for any base type. Guidance is welcome on this point. I will keep the PR draft while tests have not been added.

Closes #6223 