### PR TITLE
internal: use PySet_GET_SIZE for sets and frozensets

### DIFF
--- a/src/types/frozenset.rs
+++ b/src/types/frozenset.rs
@@ -159,7 +159,15 @@ pub trait PyFrozenSetMethods<'py>: crate::sealed::Sealed {
 impl<'py> PyFrozenSetMethods<'py> for Bound<'py, PyFrozenSet> {
     #[inline]
     fn len(&self) -> usize {
-        unsafe { ffi::PySet_Size(self.as_ptr()) as usize }
+        let size = cfg_select! {
+            // SAFETY: self is a valid frozenset object.
+            not(any(Py_LIMITED_API, PyPy, GraalPy)) => unsafe {
+                ffi::PySet_GET_SIZE(self.as_ptr())
+            },
+            // SAFETY: self is a valid frozenset object.
+            _ => unsafe { ffi::PySet_Size(self.as_ptr()) },
+        };
+        size as usize
     }
 
     fn contains<K>(&self, key: K) -> PyResult<bool>

--- a/src/types/set.rs
+++ b/src/types/set.rs
@@ -148,7 +148,15 @@ impl<'py> PySetMethods<'py> for Bound<'py, PySet> {
 
     #[inline]
     fn len(&self) -> usize {
-        unsafe { ffi::PySet_Size(self.as_ptr()) as usize }
+        let size = cfg_select! {
+            // SAFETY: self is a valid set object.
+            not(any(Py_LIMITED_API, PyPy, GraalPy)) => unsafe {
+                ffi::PySet_GET_SIZE(self.as_ptr())
+            },
+            // SAFETY: self is a valid set object.
+            _ => unsafe { ffi::PySet_Size(self.as_ptr()) },
+        };
+        size as usize
     }
 
     fn contains<K>(&self, key: K) -> PyResult<bool>


### PR DESCRIPTION
See: https://github.com/PyO3/pyo3/pull/6225#discussion_r3633382607

We can use `PySet_GET_SIZE` instead of `PySet_Size` when retrieving the length of Python sets and frozensets, matching the existing `PyList` fast path. Fall back to `PySet_Size` for limited-ABI builds, PyPy, and GraalPy.