### PR TITLE
internal: Fix test_date_from_timestamp

### DIFF
--- a/pytests/pyproject.toml
+++ b/pytests/pyproject.toml
@@ -21,16 +21,9 @@ requires-python = ">=3.9"
 
 [tool.ruff]
 exclude = ["stubs"]
-[tool.ruff.lint]
-extend-ignore = [
-    "BLE001",
-    "TRY002",
-]
+
 [tool.ruff.per-file-target-version]
 "tests/test_enums_match.py" = "py310"
-[tool.ruff.lint.extend-per-file-ignores]
-# we deliberately want to exercise specific comparison operators
-"tests/test_comparisons.py" = ["SIM201", "SIM202"]
 
 [project.optional-dependencies]
 dev = [

--- a/pytests/tests/test_comparisons.py
+++ b/pytests/tests/test_comparisons.py
@@ -1,3 +1,4 @@
+# ruff: file-ignore[SIM201,SIM202] we deliberately want to exercise specific comparison operators
 import sys
 from typing import TypeVar
 

--- a/pytests/tests/test_datetime.py
+++ b/pytests/tests/test_datetime.py
@@ -91,17 +91,17 @@ def test_invalid_date_fails():
         rdt.make_date(2017, 2, 30)
 
 
-@given(d=st.dates(MIN_DATETIME.date(), MAX_DATETIME.date()))
-def test_date_from_timestamp(d):
+@given(dt=st.datetimes(MIN_DATETIME, MAX_DATETIME))
+def test_date_from_timestamp(dt):
     try:
-        ts = pdt.datetime.timestamp(d)
-    except Exception:
+        ts = pdt.datetime.timestamp(dt)
+    except OverflowError:
         # out of range for timestamp
         return
 
     try:
         expected = pdt.date.fromtimestamp(ts)  # noqa: DTZ012
-    except Exception as pdt_fail:
+    except OverflowError as pdt_fail:
         # date from timestamp failed; expect the same from Rust binding
         with pytest.raises(type(pdt_fail)) as exc_info:
             rdt.date_from_timestamp(ts)
@@ -241,13 +241,13 @@ def test_datetime_typeerror():
 def test_datetime_from_timestamp(dt):
     try:
         ts = pdt.datetime.timestamp(dt)
-    except Exception:
+    except OverflowError:
         # out of range for timestamp
         return
 
     try:
         expected = pdt.datetime.fromtimestamp(ts)  # noqa: DTZ006
-    except Exception as pdt_fail:
+    except OverflowError as pdt_fail:
         # datetime from timestamp failed; expect the same from Rust binding
         with pytest.raises(type(pdt_fail)) as exc_info:
             rdt.datetime_from_timestamp(ts)

--- a/pytests/tests/test_pyclasses.py
+++ b/pytests/tests/test_pyclasses.py
@@ -129,13 +129,12 @@ class ClassWithoutConstructor:
 )
 def test_no_constructor_defined_propagates_cause(cls: type, exc_message: str):
     original_error = ValueError("Original message")
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(TypeError) as exc_info:
         try:
             raise original_error
-        except Exception:
+        except ValueError:
             cls()  # should raise TypeError("No constructor defined for ...")
 
-    assert exc_info.type is TypeError
     assert exc_info.value.args == (exc_message,)
     assert exc_info.value.__context__ is original_error
 


### PR DESCRIPTION
This was trying to call datetime.datetime.timestamp on date objects and always failing, making the test_date_from_timestamp a no op in practice

This is changing the test to get the timestamp from a datetime

Also, specialize some exception takes to make ruff happy