### PR TITLE
internal: Avoid parallel test triggered GC to interfere with test_gc.rs

### DIFF
--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -790,6 +790,13 @@ fn test_drop_buffer_during_traversal_without_gil() {
 
 // A `visitproc` may return non-zero to halt traversal early -- `gc.get_referrers()` does this
 // once it has found the object it is looking for.
+thread_local! {
+    // Whether the `visit.call` below returned non-zero for the object being traversed right now.
+    // A collection triggered by another test visits with a `visitproc` which returns zero, so
+    // only `gc.get_referrers` sets this.
+    static SUPER_STOPPED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 #[pyclass(subclass)]
 struct TraverseBase {
     field: Option<Py<PyAny>>,
@@ -798,8 +805,13 @@ struct TraverseBase {
 #[pymethods]
 impl TraverseBase {
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+        SUPER_STOPPED.set(false);
         if let Some(field) = &self.field {
-            visit.call(field)?;
+            if let Err(err) = visit.call(field) {
+                SUPER_STOPPED.set(true);
+                SUPER_STOPPED_OBSERVED.store(true, Ordering::SeqCst);
+                return Err(err);
+            }
         }
         Ok(())
     }
@@ -809,9 +821,12 @@ impl TraverseBase {
     }
 }
 
-// Set by `TraverseChild::__traverse__` so the test can assert whether the child's own traverse
-// body ran.
-static CHILD_TRAVERSED: AtomicBool = AtomicBool::new(false);
+// Set when the super-type traverse asks to stop, so that the test can tell the early return was
+// reached rather than passing for want of a non-zero `visitproc`.
+static SUPER_STOPPED_OBSERVED: AtomicBool = AtomicBool::new(false);
+
+// Set if `TraverseChild::__traverse__` ran even though the super-type traverse asked to stop.
+static CHILD_RAN_AFTER_SUPER_STOPPED: AtomicBool = AtomicBool::new(false);
 
 #[pyclass(extends=TraverseBase)]
 struct TraverseChild {}
@@ -820,7 +835,9 @@ struct TraverseChild {}
 impl TraverseChild {
     #[expect(clippy::unnecessary_wraps)]
     fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-        CHILD_TRAVERSED.store(true, Ordering::SeqCst);
+        if SUPER_STOPPED.get() {
+            CHILD_RAN_AFTER_SUPER_STOPPED.store(true, Ordering::SeqCst);
+        }
         Ok(())
     }
 }
@@ -835,8 +852,6 @@ fn test_super_traverse_early_return_does_not_abort() {
         .add_subclass(TraverseChild {});
         let child = Bound::new(py, initializer).unwrap();
 
-        CHILD_TRAVERSED.store(false, Ordering::SeqCst);
-
         // `target` is held by the base, so the super-type traverse is the one which finds it and
         // returns non-zero into `TraverseChild`'s traverse. `_call_traverse` must stop there and
         // return that value, without going on to run `TraverseChild::__traverse__` (the early
@@ -848,7 +863,11 @@ fn test_super_traverse_early_return_does_not_abort() {
             .unwrap();
         assert!(referrers.len().unwrap() > 0);
         assert!(
-            !CHILD_TRAVERSED.load(Ordering::SeqCst),
+            SUPER_STOPPED_OBSERVED.load(Ordering::SeqCst),
+            "super-type traverse never returned non-zero, so the early return was not exercised"
+        );
+        assert!(
+            !CHILD_RAN_AFTER_SUPER_STOPPED.load(Ordering::SeqCst),
             "child __traverse__ ran despite the super-type traverse returning non-zero"
         );
 

--- a/tests/test_gc.rs
+++ b/tests/test_gc.rs
@@ -10,7 +10,7 @@ use pyo3::prelude::*;
 use pyo3::py_run;
 #[cfg(not(target_arch = "wasm32"))]
 use std::cell::Cell;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::sync::Once;
 use std::sync::{Arc, Mutex};
 
@@ -736,6 +736,27 @@ extern "C" fn visit_error(
     -1
 }
 
+// the fields visited below, set before driving the traversal
+static BASE_FIELD: AtomicPtr<pyo3::ffi::PyObject> = AtomicPtr::new(std::ptr::null_mut());
+static CHILD_FIELD: AtomicPtr<pyo3::ffi::PyObject> = AtomicPtr::new(std::ptr::null_mut());
+static BASE_VISITED: AtomicBool = AtomicBool::new(false);
+static CHILD_VISITED: AtomicBool = AtomicBool::new(false);
+
+// a visitor function which errors on `BASE_FIELD` only
+extern "C" fn visit_error_on_base_field(
+    object: *mut pyo3::ffi::PyObject,
+    _arg: *mut core::ffi::c_void,
+) -> std::ffi::c_int {
+    if object == CHILD_FIELD.load(Ordering::SeqCst) {
+        CHILD_VISITED.store(true, Ordering::SeqCst);
+    }
+    if object == BASE_FIELD.load(Ordering::SeqCst) {
+        BASE_VISITED.store(true, Ordering::SeqCst);
+        return -1;
+    }
+    0
+}
+
 #[test]
 #[cfg(any(not(Py_LIMITED_API), Py_3_11))] // buffer availability
 fn test_drop_buffer_during_traversal_without_gil() {
@@ -788,90 +809,70 @@ fn test_drop_buffer_during_traversal_without_gil() {
     });
 }
 
-// A `visitproc` may return non-zero to halt traversal early -- `gc.get_referrers()` does this
-// once it has found the object it is looking for.
-thread_local! {
-    // Whether the `visit.call` below returned non-zero for the object being traversed right now.
-    // A collection triggered by another test visits with a `visitproc` which returns zero, so
-    // only `gc.get_referrers` sets this.
-    static SUPER_STOPPED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
-}
-
-#[pyclass(subclass)]
-struct TraverseBase {
-    field: Option<Py<PyAny>>,
-}
-
-#[pymethods]
-impl TraverseBase {
-    fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-        SUPER_STOPPED.set(false);
-        if let Some(field) = &self.field {
-            if let Err(err) = visit.call(field) {
-                SUPER_STOPPED.set(true);
-                SUPER_STOPPED_OBSERVED.store(true, Ordering::SeqCst);
-                return Err(err);
-            }
-        }
-        Ok(())
-    }
-
-    fn __clear__(&mut self) {
-        self.field = None;
-    }
-}
-
-// Set when the super-type traverse asks to stop, so that the test can tell the early return was
-// reached rather than passing for want of a non-zero `visitproc`.
-static SUPER_STOPPED_OBSERVED: AtomicBool = AtomicBool::new(false);
-
-// Set if `TraverseChild::__traverse__` ran even though the super-type traverse asked to stop.
-static CHILD_RAN_AFTER_SUPER_STOPPED: AtomicBool = AtomicBool::new(false);
-
-#[pyclass(extends=TraverseBase)]
-struct TraverseChild {}
-
-#[pymethods]
-impl TraverseChild {
-    #[expect(clippy::unnecessary_wraps)]
-    fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
-        if SUPER_STOPPED.get() {
-            CHILD_RAN_AFTER_SUPER_STOPPED.store(true, Ordering::SeqCst);
-        }
-        Ok(())
-    }
-}
-
 #[test]
 fn test_super_traverse_early_return_does_not_abort() {
+    #[pyclass(subclass)]
+    struct TraverseBase {
+        field: Py<PyAny>,
+    }
+
+    #[pymethods]
+    impl TraverseBase {
+        fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+            visit.call(&self.field)
+        }
+    }
+
+    #[pyclass(extends=TraverseBase)]
+    struct TraverseChild {
+        field: Py<PyAny>,
+    }
+
+    #[pymethods]
+    impl TraverseChild {
+        fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+            visit.call(&self.field)
+        }
+    }
+
     Python::attach(|py| {
-        let target = pyo3::types::PyList::empty(py);
+        let base_field = pyo3::types::PyList::empty(py).into_any().unbind();
+        let child_field = pyo3::types::PyList::empty(py).into_any().unbind();
+
         let initializer = PyClassInitializer::from(TraverseBase {
-            field: Some(target.clone().into_any().unbind()),
+            field: base_field.clone_ref(py),
         })
-        .add_subclass(TraverseChild {});
+        .add_subclass(TraverseChild {
+            field: child_field.clone_ref(py),
+        });
         let child = Bound::new(py, initializer).unwrap();
 
-        // `target` is held by the base, so the super-type traverse is the one which finds it and
-        // returns non-zero into `TraverseChild`'s traverse. `_call_traverse` must stop there and
-        // return that value, without going on to run `TraverseChild::__traverse__` (the early
-        // return which used to drop the still-armed `PanicTrap` and abort the process).
-        let referrers = py
-            .import("gc")
-            .unwrap()
-            .call_method1("get_referrers", (&target,))
-            .unwrap();
-        assert!(referrers.len().unwrap() > 0);
+        BASE_FIELD.store(base_field.as_ptr(), Ordering::SeqCst);
+        CHILD_FIELD.store(child_field.as_ptr(), Ordering::SeqCst);
+
+        let traverse =
+            unsafe { get_type_traverse(py.get_type::<TraverseChild>().as_type_ptr()).unwrap() };
+
+        let retval = unsafe {
+            traverse(
+                child.as_ptr(),
+                visit_error_on_base_field,
+                std::ptr::null_mut(),
+            )
+        };
+
         assert!(
-            SUPER_STOPPED_OBSERVED.load(Ordering::SeqCst),
-            "super-type traverse never returned non-zero, so the early return was not exercised"
+            BASE_VISITED.load(Ordering::SeqCst),
+            "super-type traverse never visited its field, so the early return was not exercised"
+        );
+        assert_eq!(
+            retval, -1,
+            "traverse did not propagate the non-zero return of the super-type traverse"
         );
         assert!(
-            !CHILD_RAN_AFTER_SUPER_STOPPED.load(Ordering::SeqCst),
+            !CHILD_VISITED.load(Ordering::SeqCst),
             "child __traverse__ ran despite the super-type traverse returning non-zero"
         );
-
-        drop(child);
     });
 }
 


### PR DESCRIPTION
I suffered flaky test runs in https://github.com/PyO3/pyo3/pull/6200. test_super_traverse_early_return_does_not_abort (added in 218826555) fails reliably under parallelism because its process-global flag gets set by any concurrent GC traversal prior to this patch.

Closes https://github.com/PyO3/pyo3/issues/6243