### PR TITLE
docs: fix invalid html in doc comment

### DIFF
--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -125,11 +125,10 @@ impl PyModule {
     ///
     /// <div class="information">
     ///     <div class="tooltip compile_fail" style="">&#x26a0; &#xfe0f;</div>
-    /// </div><div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
-    //
-    ///  <strong>Warning</strong>: This will compile and execute code. <strong>Never</strong> pass untrusted code to this function!
-    ///
-    /// </pre></div>
+    /// </div>
+    /// <div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
+    ///     <strong>Warning</strong>: This will compile and execute code. <strong>Never</strong> pass untrusted code to this function!
+    /// </div>
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Invalid HTML in doc comment is causing other PRs to fail.