### PR TITLE
internal: use `CString` from `alloc` instead of `std`

### DIFF
--- a/src/conversions/std/cstring.rs
+++ b/src/conversions/std/cstring.rs
@@ -8,8 +8,8 @@ use crate::type_object::PyTypeInfo;
 use crate::types::PyString;
 use crate::{Borrowed, Bound, FromPyObject, IntoPyObject, PyAny, PyErr, Python};
 use alloc::borrow::Cow;
+use alloc::ffi::CString;
 use core::ffi::CStr;
-use std::ffi::CString;
 #[cfg(any(Py_3_10, not(Py_LIMITED_API)))]
 use {
     crate::{exceptions::PyValueError, ffi},

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -26,12 +26,12 @@ use crate::{
     types::PyType,
     Py, PyClass, PyResult, PyTypeInfo, Python,
 };
+use alloc::ffi::CString;
 use core::{
     ffi::CStr,
     ffi::{c_char, c_int, c_ulong, c_void},
     ptr::{self, NonNull},
 };
-use std::ffi::CString;
 
 pub(crate) struct PyClassTypeObject {
     pub type_object: Py<PyType>,

--- a/src/types/capsule.rs
+++ b/src/types/capsule.rs
@@ -14,11 +14,11 @@ use crate::{
 };
 use crate::{Bound, Python};
 use crate::{PyErr, PyResult};
+use alloc::ffi::CString;
 use core::ffi::CStr;
 use core::ffi::{c_char, c_int, c_void};
 use core::mem::offset_of;
 use core::ptr::{self, NonNull};
-use std::ffi::CString;
 
 /// Represents a Python Capsule
 /// as described in [Capsules](https://docs.python.org/3/c-api/capsule.html#capsules):


### PR DESCRIPTION
This is part of the WIP `no_std` support.