### PR TITLE
internal: remove `LazyLock` from `Python::version_str`

### DIFF
--- a/src/marker.rs
+++ b/src/marker.rs
@@ -131,7 +131,6 @@ use crate::version::PythonVersionInfo;
 use crate::{ffi, Bound, Py, PyTypeInfo};
 use core::ffi::CStr;
 use core::marker::PhantomData;
-use std::sync::LazyLock;
 
 /// Types that are safe to access while the GIL is not held.
 ///
@@ -697,13 +696,9 @@ impl<'py> Python<'py> {
     /// assert!(Python::version_str().starts_with("3."));
     /// ```
     pub fn version_str() -> &'static str {
-        static VERSION: LazyLock<&'static str> = LazyLock::new(|| unsafe {
-            CStr::from_ptr(ffi::Py_GetVersion())
-                .to_str()
-                .expect("Python version string not UTF-8")
-        });
-
-        &VERSION
+        unsafe { CStr::from_ptr(ffi::Py_GetVersion()) }
+            .to_str()
+            .expect("Python version string not UTF-8")
     }
 
     /// Gets the running Python interpreter version as a struct similar to


### PR DESCRIPTION
This is part of the WIP `no_std` support.

I've removed the use of `LazyLock` to cache the python version string because `LazyLock` is not available in `no_std`.

I can use an implementation from a different crate if needed, but I suspect that optimizing this particular function is not worth the added complexity.