### PR TITLE
docs: fix improperly nested HTML in PyModule::from_code warning box

### DIFF
--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -126,9 +126,7 @@ impl PyModule {
     /// <div class="information">
     ///     <div class="tooltip compile_fail" style="">&#x26a0; &#xfe0f;</div>
     /// </div><div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
-    //
-    ///  <strong>Warning</strong>: This will compile and execute code. <strong>Never</strong> pass untrusted code to this function!
-    ///
+    /// <strong>Warning</strong>: This will compile and execute code. <strong>Never</strong> pass untrusted code to this function!
     /// </pre></div>
     ///
     /// # Errors


### PR DESCRIPTION
Nightly rustdoc's `rustdoc::invalid-html-tags` lint gained an "improperly nested Markdown paragraph" check, which broke the netlify-build CI job (`nox -s check-guide` runs `cargo doc` with `-Dwarnings`).

The warning box on `PyModule::from_code` contained a blank doc line before `</pre></div>`. A blank line terminates a CommonMark HTML block, so the closing tags landed in a separate block from the tags they close.

Keep the markup on contiguous doc lines so it forms a single HTML block. This also drops a stray `//` (rather than `///`) line, which was silently omitting content from the rendered docs.


Claude-Session: https://claude.ai/code/session_0176PdmBb2j8euHTFEv4huzz
