### PR TITLE
docs: fix improperly nested html

### DIFF
--- a/src/types/module.rs
+++ b/src/types/module.rs
@@ -129,7 +129,8 @@ impl PyModule {
     //
     ///  <strong>Warning</strong>: This will compile and execute code. <strong>Never</strong> pass untrusted code to this function!
     ///
-    /// </pre></div>
+    /// </pre>
+    /// </div>
     ///
     /// # Errors
     ///


### PR DESCRIPTION
I think there is a new check in nightly rustdoc that causes this previously accepted doc comment to emit a warning.