### PR TITLE
`experimental-inspect`: fix invalid JSON when a module member is cfg-ed out

### DIFF
--- a/newsfragments/6255.fixed.md
+++ b/newsfragments/6255.fixed.md
@@ -1,0 +1,1 @@
+`experimental-inspect`: fix the introspection data of `#[pymodule]`s whose first member is behind a `#[cfg]` that is disabled, which was serialized as invalid JSON and made `pyo3-introspection` fail to read the whole extension.

--- a/pyo3-macros-backend/src/introspection.rs
+++ b/pyo3-macros-backend/src/introspection.rs
@@ -425,20 +425,31 @@ impl IntrospectionNode<'_> {
             }
             Self::List(list) => {
                 content.push_str("[");
-                for (i, AttributedIntrospectionNode { node, attributes }) in
-                    list.into_iter().enumerate()
-                {
-                    if attributes.is_empty() {
+                if list.iter().all(|element| element.attributes.is_empty()) {
+                    for (i, element) in list.into_iter().enumerate() {
                         if i > 0 {
                             content.push_str(",");
                         }
-                        node.add_to_serialization(content, pyo3_crate_path);
-                    } else {
+                        element.node.add_to_serialization(content, pyo3_crate_path);
+                    }
+                } else {
+                    // A `,` must only be written if at least one of the elements before the one
+                    // it precedes is compiled in, so we gate it behind an `any(..)` of their
+                    // `cfg`s on top of the element's own. This needs no special case: `any()` is
+                    // false, so the first element gets no separator, and `all()` is true, so an
+                    // element without `cfg` makes every later separator unconditional.
+                    let mut preceding = Vec::new();
+                    for AttributedIntrospectionNode { node, attributes } in list {
+                        content.push_tokens(
+                            quote! { #[cfg(any(#(#preceding),*))] #(#attributes)* ",".as_bytes() },
+                        );
+                        let cfgs = attributes
+                            .iter()
+                            .filter_map(|attribute| attribute.meta.require_list().ok())
+                            .map(|cfg| &cfg.tokens);
+                        preceding.push(quote! { all(#(#cfgs),*) });
                         // We serialize the element to easily gate it behind the attributes
                         let mut nested_builder = ConcatenationBuilder::default();
-                        if i > 0 {
-                            nested_builder.push_str(",");
-                        }
                         node.add_to_serialization(&mut nested_builder, pyo3_crate_path);
                         let nested_content = nested_builder.into_token_stream(pyo3_crate_path);
                         content.push_tokens(quote! { #(#attributes)* #nested_content });

--- a/pytests/src/pyfunctions.rs
+++ b/pytests/src/pyfunctions.rs
@@ -129,6 +129,13 @@ fn many_keyword_arguments<'py>(
 
 #[pymodule]
 pub mod pyfunctions {
+    // `any()` is never true. Keeps the introspection data of a `#[pymodule]` whose first member
+    // is `cfg`-ed out covered by `nox -s test-introspection`; it used to serialize the member
+    // list as the invalid JSON `[,"..."]`.
+    #[cfg(any())]
+    #[pymodule_export]
+    use super::none;
+
     #[cfg(feature = "experimental-async")]
     #[pymodule_export]
     use super::with_async;
@@ -137,4 +144,9 @@ pub mod pyfunctions {
         args_kwargs, many_keyword_arguments, none, positional_only, simple, simple_args,
         simple_args_kwargs, simple_kwargs, with_typed_args,
     };
+
+    // Likewise for a `cfg`-ed out last member.
+    #[cfg(any())]
+    #[pymodule_export]
+    use super::simple;
 }


### PR DESCRIPTION
The comma (`,`) separating two elements of an introspection list was written as soon as the element was not the first, even when every preceding element was behind a disabled `#[cfg]`. A `#[pymodule]` whose first member is `cfg`-ed out therefore serialized its member list as `[,"..."]`, and since the parse error propagates, one such module makes `pyo3-introspection` reject the whole extension — no stubs at all. This is reachable in `pyo3_pytests` as it ships: building it with `experimental-inspect` but without `experimental-async` produces a binary the tool refuses.

Rather than reasoning about `cfg` predicates in the macro, the list is now assembled at const evaluation: `#[cfg]` on an array-literal element removes the element outright, so each element becomes one gated piece and `combine_json_list_to_array` places the `[`, `,` and `]` around whatever survived. Lists whose elements carry no attributes — every list but a module's members — keep folding into the surrounding string, so nothing extra is generated for them.

`nox -s test-introspection` never caught this because it always enables both features together, so `pyfunctions` gains a first and a last member behind `#[cfg(any())]`, which is never true. That changes neither the module at runtime nor the checked-in stubs, but every introspection run now walks the removed-element path, and a regression fails loudly before the session reaches the stub comparison.
