### PR TITLE
internal: add safety comment in conversions/bytes.rs

### DIFF
--- a/src/conversions/bytes.rs
+++ b/src/conversions/bytes.rs
@@ -1,5 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg(feature = "bytes")]
 
 //! Conversions to and from [bytes](https://docs.rs/bytes/latest/bytes/)'s [`Bytes`].
@@ -141,6 +139,8 @@ mod tests {
             assert_eq!(&*bytes, b"foobar");
 
             // Editing the bytearray should not change extracted Bytes
+            // SAFETY: the slice is dropped within this statement without running any Python code,
+            // and `bytes` holds a copy of the data, so the buffer is not aliased
             unsafe { py_bytearray.as_bytes_mut()[0] = b'x' };
             assert_eq!(&bytes, "foobar");
             assert_eq!(&py_bytearray.extract::<Vec<u8>>().unwrap(), b"xoobar");


### PR DESCRIPTION
Part of #5487

Removes the `#![allow(clippy::undocumented_unsafe_blocks)]` exemption from `src/conversions/bytes.rs` and adds a `// SAFETY:` comment for the file's only unsafe block (a test that mutates a bytearray via `as_bytes_mut()` to verify the extracted `Bytes` is an independent copy).

As @davidhewitt suggested in the issue thread, this PR is kept to a single file.