### PR TITLE
internal: add safety comments in conversions (smallvec, path, vec)

### DIFF
--- a/src/conversions/smallvec.rs
+++ b/src/conversions/smallvec.rs
@@ -1,5 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg(feature = "smallvec")]
 
 //!  Conversions to and from [smallvec](https://docs.rs/smallvec/).
@@ -96,6 +94,7 @@ where
 {
     // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
     // to support this function and if not, we will only fail extraction safely.
+    // SAFETY: passing valid pointer to python API
     if unsafe { ffi::PySequence_Check(obj.as_ptr()) } == 0 {
         return Err(CastError::new(obj, PySequence::type_object(obj.py()).into_any()).into());
     }

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -1,6 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
-
 use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]
@@ -26,6 +23,8 @@ impl FromPyObject<'_, '_> for PathBuf {
 
     fn extract(ob: Borrowed<'_, '_, PyAny>) -> Result<Self, Self::Error> {
         // We use os.fspath to get the underlying path as bytes or str
+        // SAFETY: valid pointer is passed to python API, and `PyOS_FSPath` returns
+        // a new owned reference or NULL with an error set
         let path = unsafe { ffi::PyOS_FSPath(ob.as_ptr()).assume_owned_or_err(ob.py())? };
         Ok(path.extract::<OsString>()?.into())
     }

--- a/src/conversions/std/vec.rs
+++ b/src/conversions/std/vec.rs
@@ -1,6 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
-
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_subscript, PyStaticExpr};
 use crate::platform::prelude::*;
@@ -82,6 +79,7 @@ where
 {
     // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
     // to support this function and if not, we will only fail extraction safely.
+    // SAFETY: passing valid pointer to python API
     if unsafe { ffi::PySequence_Check(obj.as_ptr()) } == 0 {
         return Err(CastError::new(obj, PySequence::type_object(obj.py()).into_any()).into());
     }


### PR DESCRIPTION
Part of #5487, continuing from #6256.

Removes the `#![allow(clippy::undocumented_unsafe_blocks)]` exemption from three conversion files, each containing a single unsafe block, and adds `// SAFETY:` comments:

- `src/conversions/smallvec.rs`
- `src/conversions/std/path.rs`
- `src/conversions/std/vec.rs`

One commit per file for easier review. Happy to split into separate PRs if preferred.

Disclosure: I used AI assistance while analyzing this code; I have personally verified each safety argument against the documented contract of the API being called.