### PR TITLE
fix: use dedicated slots for in-place sequence operations

### DIFF
--- a/newsfragments/6260.fixed.md
+++ b/newsfragments/6260.fixed.md
@@ -1,0 +1,1 @@
+Fix `__inplace_concat__` and `__inplace_repeat__` overriding `__concat__` and `__repeat__` when both were defined.

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1084,8 +1084,8 @@ pub const __LEN__: SlotDef = SlotDef::new("Py_mp_length", "lenfunc");
 const __CONTAINS__: SlotDef = SlotDef::new("Py_sq_contains", "objobjproc");
 const __CONCAT__: SlotDef = SlotDef::new("Py_sq_concat", "binaryfunc");
 const __REPEAT__: SlotDef = SlotDef::new("Py_sq_repeat", "ssizeargfunc");
-const __INPLACE_CONCAT__: SlotDef = SlotDef::new("Py_sq_concat", "binaryfunc");
-const __INPLACE_REPEAT__: SlotDef = SlotDef::new("Py_sq_repeat", "ssizeargfunc");
+const __INPLACE_CONCAT__: SlotDef = SlotDef::new("Py_sq_inplace_concat", "binaryfunc");
+const __INPLACE_REPEAT__: SlotDef = SlotDef::new("Py_sq_inplace_repeat", "ssizeargfunc");
 pub const __GETITEM__: SlotDef = SlotDef::new("Py_mp_subscript", "binaryfunc");
 
 const __POS__: SlotDef = SlotDef::new("Py_nb_positive", "unaryfunc");

--- a/tests/test_sequence.rs
+++ b/tests/test_sequence.rs
@@ -253,6 +253,47 @@ fn test_inplace_repeat() {
     });
 }
 
+#[pyclass(sequence)]
+struct SequenceOperators;
+
+#[pymethods]
+impl SequenceOperators {
+    fn __concat__(&self, _other: &Self) -> &'static str {
+        "concat"
+    }
+
+    fn __inplace_concat__(&self, _other: &Self) -> &'static str {
+        "inplace_concat"
+    }
+
+    fn __repeat__(&self, _count: isize) -> &'static str {
+        "repeat"
+    }
+
+    fn __inplace_repeat__(&self, _count: isize) -> &'static str {
+        "inplace_repeat"
+    }
+}
+
+#[test]
+fn sequence_operators_use_distinct_slots() {
+    Python::attach(|py| {
+        let d = [
+            ("left", Bound::new(py, SequenceOperators).unwrap()),
+            ("right", Bound::new(py, SequenceOperators).unwrap()),
+        ]
+        .into_py_dict(py)
+        .unwrap();
+
+        py_assert!(py, *d, "left + right == 'concat'");
+        py_run!(py, *d, "result = left; result += right");
+        py_assert!(py, *d, "result == 'inplace_concat'");
+        py_assert!(py, *d, "left * 2 == 'repeat'");
+        py_run!(py, *d, "result = left; result *= 2");
+        py_assert!(py, *d, "result == 'inplace_repeat'");
+    });
+}
+
 // Check that #[pyo3(get, set)] works correctly for Vec<PyObject>
 
 #[pyclass]


### PR DESCRIPTION
Fixes #6211.

Use the dedicated sequence slots for `__inplace_concat__` and `__inplace_repeat__`, and add a regression test covering normal and in-place operations.
