### PR TITLE
internal: add safety comments in conversions (num-rational, num-complex, num-bigint)

### DIFF
--- a/src/conversions/num_bigint.rs
+++ b/src/conversions/num_bigint.rs
@@ -1,5 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg(feature = "num-bigint")]
 //!  Conversions to and from [num-bigint](https://docs.rs/num-bigint)’s [`BigInt`] and [`BigUint`] types.
 //!
@@ -124,6 +122,7 @@ macro_rules! bigint_conversion {
                     } else {
                         None
                     };
+                    // SAFETY: `int.from_bytes` returns a python `int`
                     unsafe {
                         py.get_type::<PyInt>()
                             .call_method("from_bytes", (bytes_obj, "little"), kwargs.as_ref())
@@ -239,6 +238,8 @@ fn int_to_u32_vec<const SIGNED: bool>(long: &Bound<'_, PyInt>) -> PyResult<Vec<u
         n_bits.div_ceil(32)
     };
     buffer.reserve_exact(n_digits);
+    // SAFETY: `buffer` has capacity for `n_digits` u32s, which `_PyLong_AsByteArray`
+    // fully initializes on success; `set_len` is only reached on success
     unsafe {
         crate::err::error_on_minusone(
             long.py(),
@@ -269,6 +270,7 @@ fn int_to_u32_vec<const SIGNED: bool>(long: &Bound<'_, PyInt>) -> PyResult<Vec<u
     if !SIGNED {
         flags |= ffi::Py_ASNATIVEBYTES_UNSIGNED_BUFFER | ffi::Py_ASNATIVEBYTES_REJECT_NEGATIVE;
     }
+    // SAFETY: passing a NULL buffer with size 0 is the documented way to query the required size
     let n_bytes =
         unsafe { ffi::PyLong_AsNativeBytes(long.as_ptr().cast(), core::ptr::null_mut(), 0, flags) };
     let n_bytes_unsigned: usize = n_bytes
@@ -279,6 +281,8 @@ fn int_to_u32_vec<const SIGNED: bool>(long: &Bound<'_, PyInt>) -> PyResult<Vec<u
     }
     let n_digits = n_bytes_unsigned.div_ceil(4);
     buffer.reserve_exact(n_digits);
+    // SAFETY: `buffer` has capacity for `n_digits` u32s; `PyLong_AsNativeBytes` fills
+    // the entire buffer regardless of the value, so `set_len` is always valid
     unsafe {
         ffi::PyLong_AsNativeBytes(
             long.as_ptr().cast(),

--- a/src/conversions/num_complex.rs
+++ b/src/conversions/num_complex.rs
@@ -1,5 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg(feature = "num-complex")]
 
 //!  Conversions to and from [num-complex](https://docs.rs/num-complex)’
@@ -112,6 +110,7 @@ impl PyComplex {
         py: Python<'_>,
         complex: Complex<F>,
     ) -> Bound<'_, PyComplex> {
+        // SAFETY: `PyComplex_FromDoubles` returns a new owned reference to a complex object
         unsafe {
             ffi::PyComplex_FromDoubles(complex.re.into(), complex.im.into())
                 .assume_owned(py)
@@ -132,6 +131,8 @@ macro_rules! complex_conversion {
             const OUTPUT_TYPE: PyStaticExpr = type_hint_identifier!("builtins", "complex");
 
             fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+                // SAFETY: `PyComplex_FromDoubles` returns a new owned reference to a
+                // complex object
                 unsafe {
                     Ok(
                         ffi::PyComplex_FromDoubles(self.re as c_double, self.im as c_double)
@@ -166,6 +167,7 @@ macro_rules! complex_conversion {
 
             fn extract(obj: Borrowed<'_, '_, PyAny>) -> Result<Complex<$float>, Self::Error> {
                 #[cfg(not(any(Py_LIMITED_API, PyPy)))]
+                // SAFETY: passing valid pointer to python API
                 unsafe {
                     let val = ffi::PyComplex_AsCComplex(obj.as_ptr());
                     if val.real == -1.0 {
@@ -177,6 +179,7 @@ macro_rules! complex_conversion {
                 }
 
                 #[cfg(any(Py_LIMITED_API, PyPy))]
+                // SAFETY: passing valid pointer to python API
                 unsafe {
                     use $crate::types::any::PyAnyMethods;
                     let complex;

--- a/src/conversions/num_rational.rs
+++ b/src/conversions/num_rational.rs
@@ -1,5 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg(feature = "num-rational")]
 //! Conversions to and from [num-rational](https://docs.rs/num-rational) types.
 //!
@@ -77,9 +75,11 @@ macro_rules! rational_conversion {
                 let py = obj.py();
                 let py_numerator_obj = obj.getattr(crate::intern!(py, "numerator"))?;
                 let py_denominator_obj = obj.getattr(crate::intern!(py, "denominator"))?;
+                // SAFETY: `PyNumber_Long` returns a new owned reference or NULL with an error set
                 let numerator_owned = unsafe {
                     Bound::from_owned_ptr_or_err(py, ffi::PyNumber_Long(py_numerator_obj.as_ptr()))?
                 };
+                // SAFETY: `PyNumber_Long` returns a new owned reference or NULL with an error set
                 let denominator_owned = unsafe {
                     Bound::from_owned_ptr_or_err(
                         py,


### PR DESCRIPTION
Part of #5487, continuing from #6256 and #6259.

Removes the `#![allow(clippy::undocumented_unsafe_blocks)]` exemption from the three num conversion files and adds `// SAFETY:` comments for their ten unsafe blocks:

- `src/conversions/num_rational.rs`
- `src/conversions/num_complex.rs`
- `src/conversions/num_bigint.rs`

One commit per file for easier review. Verified with clippy under both the default and `abi3` feature sets to cover the `Py_LIMITED_API` branches.

Disclosure: I used AI assistance while analyzing this code; I have personally verified each safety argument against the documented contracts, including the CPython source comment for the private `_PyLong_AsByteArray`.