### PR TITLE
fix: return an error for oversized time durations

### DIFF
--- a/newsfragments/6266.fixed.md
+++ b/newsfragments/6266.fixed.md
@@ -1,0 +1,1 @@
+Fix conversion of out-of-range `time::Duration` values to return `OverflowError` instead of panicking.

--- a/src/conversions/time.rs
+++ b/src/conversions/time.rs
@@ -50,7 +50,7 @@
 //! }
 //! ```
 
-use crate::exceptions::{PyTypeError, PyValueError};
+use crate::exceptions::{PyOverflowError, PyTypeError, PyValueError};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
 #[cfg(Py_LIMITED_API)]
@@ -178,11 +178,13 @@ impl<'py> IntoPyObject<'py> for Duration {
                 total_seconds % SECONDS_PER_DAY,
             )
         };
-        // Create the timedelta with days, seconds, microseconds
-        // Safe to unwrap as we've verified the values are within bounds
+        let days = days
+            .try_into()
+            .map_err(|_| PyOverflowError::new_err("duration out of range for Python timedelta"))?;
+
         PyDelta::new(
             py,
-            days.try_into().expect("days overflow"),
+            days,
             seconds.try_into().expect("seconds overflow"),
             micro_seconds,
             true,
@@ -861,6 +863,11 @@ mod tests {
             assert!(result.is_err());
             let err_type = result.unwrap_err().get_type(py).name().unwrap();
             assert_eq!(err_type, "OverflowError");
+
+            for duration in [Duration::MIN, Duration::MAX] {
+                let err = duration.into_pyobject(py).unwrap_err();
+                assert_eq!(err.get_type(py).name().unwrap(), "OverflowError");
+            }
         });
     }
 


### PR DESCRIPTION
## Summary

`time::Duration::MIN` and `time::Duration::MAX` currently panic while converting to `datetime.timedelta` because their day counts do not fit in `i32`.

Return `OverflowError` for that range instead, matching `datetime.timedelta` overflow behavior, and cover both extremes with regression tests.

## Tests

- `cargo test --features time --lib conversions::time::tests`
- `cargo test --no-default-features --features abi3,time --lib test_time_duration_conversion_large_values`
- `cargo clippy --features time --lib --tests -- -D warnings`
- `uvx nox -s rustfmt`
