### PR TITLE
ci: normalize rust src locations for ui_test

### DIFF
--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -142,6 +142,11 @@ fn main() {
             Regex::new(r"and \d+ others").unwrap().into(),
             b"and $$N others".to_vec(),
         ),
+        // Normalize paths into the Rust toolchain sources
+        (
+            Regex::new(r"[^\s]*?/rustlib/src/rust").unwrap().into(),
+            b"$$RUST_SRC".to_vec(),
+        ),
         // Some trait implementations which are only emitted with certain
         // features enabled
         (
@@ -259,13 +264,40 @@ fn normalize_src_blocks(output: &[u8]) -> Vec<u8> {
         .into_owned()
 }
 
+fn check_rust_src_paths(output: &[u8], errors: &mut Vec<ui_test::Error>) -> bool {
+    use std::sync::LazyLock;
+
+    use regex::bytes::Regex;
+
+    static REMAPPED_RUST_SRC: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"/rustc/[0-9a-f]{40}/library/").unwrap());
+
+    if REMAPPED_RUST_SRC.is_match(output) {
+        // This causes `ui_test` to emit:
+        //
+        // ```
+        // error: a bug in `ui_test` occurred
+        // rust-src is required for UI tests; install it with `rustup component add rust-src`
+        // ```
+        errors.push(ui_test::Error::Bug(
+            "rust-src is required for UI tests; install it with `rustup component add rust-src`"
+                .into(),
+        ));
+        false
+    } else {
+        true
+    }
+}
+
 fn error_on_output_conflict_normalized(
     path: &std::path::Path,
     output: &[u8],
     errors: &mut Vec<ui_test::Error>,
     config: &ui_test::per_test_config::TestConfig,
 ) {
-    ui_test::error_on_output_conflict(path, &normalize_src_blocks(output), errors, config);
+    if check_rust_src_paths(output, errors) {
+        ui_test::error_on_output_conflict(path, &normalize_src_blocks(output), errors, config);
+    }
 }
 
 fn bless_output_files_normalized(
@@ -274,7 +306,9 @@ fn bless_output_files_normalized(
     errors: &mut Vec<ui_test::Error>,
     config: &ui_test::per_test_config::TestConfig,
 ) {
-    ui_test::bless_output_files(path, &normalize_src_blocks(output), errors, config);
+    if check_rust_src_paths(output, errors) {
+        ui_test::bless_output_files(path, &normalize_src_blocks(output), errors, config);
+    }
 }
 
 /// Some tests have different error messages when the `experimental-inspect` feature is

--- a/tests/ui/not_send.rs
+++ b/tests/ui/not_send.rs
@@ -1,4 +1,4 @@
-//@normalize-stderr-test: ".*/src/rust/(.*)" -> "../src/$1"
+
 use pyo3::prelude::*;
 
 fn test_not_send_detach(py: Python<'_>) {

--- a/tests/ui/not_send.stderr
+++ b/tests/ui/not_send.stderr
@@ -8,7 +8,7 @@ error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safe
     |
     = help: within `pyo3::Python<'_>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
 note: required because it appears within the type `PhantomData<*mut pyo3::Python<'static>>`
-../src/library/core/src/marker.rs:811:12
+   --> $RUST_SRC/library/core/src/marker.rs:811:12
     |
 811 | pub struct PhantomData<T: PointeeSized>;
     |            ^^^^^^^^^^^
@@ -18,7 +18,7 @@ note: required because it appears within the type `pyo3::marker::NotSend`
   | struct NotSend(PhantomData<*mut Python<'static>>);
   |        ^^^^^^^
 note: required because it appears within the type `PhantomData<pyo3::marker::NotSend>`
-../src/library/core/src/marker.rs:811:12
+   --> $RUST_SRC/library/core/src/marker.rs:811:12
     |
 811 | pub struct PhantomData<T: PointeeSized>;
     |            ^^^^^^^^^^^

--- a/tests/ui/not_send2.rs
+++ b/tests/ui/not_send2.rs
@@ -1,4 +1,4 @@
-//@normalize-stderr-test: ".*/src/rust/(.*)" -> "../src/$1"
+
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 

--- a/tests/ui/not_send2.stderr
+++ b/tests/ui/not_send2.stderr
@@ -12,7 +12,7 @@ error[E0277]: `*mut pyo3::Python<'static>` cannot be shared between threads safe
     |
     = help: within `pyo3::Bound<'_, PyString>`, the trait `Sync` is not implemented for `*mut pyo3::Python<'static>`
 note: required because it appears within the type `PhantomData<*mut pyo3::Python<'static>>`
-../src/library/core/src/marker.rs:811:12
+   --> $RUST_SRC/library/core/src/marker.rs:811:12
     |
 811 | pub struct PhantomData<T: PointeeSized>;
     |            ^^^^^^^^^^^
@@ -22,7 +22,7 @@ note: required because it appears within the type `pyo3::marker::NotSend`
   | struct NotSend(PhantomData<*mut Python<'static>>);
   |        ^^^^^^^
 note: required because it appears within the type `PhantomData<pyo3::marker::NotSend>`
-../src/library/core/src/marker.rs:811:12
+   --> $RUST_SRC/library/core/src/marker.rs:811:12
     |
 811 | pub struct PhantomData<T: PointeeSized>;
     |            ^^^^^^^^^^^


### PR DESCRIPTION
I think this should unblock #6269 merging cleanly...

While at it I implemented a helper to try to tell users if their `rust-src` is not present which has been a common UI test pain historically.