### PR TITLE
internal: simplify module creation conditional branches

### DIFF
--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -635,11 +635,8 @@ mod tests {
             assert_eq!(secondary_slots[0].value, SLOTS.0.get().cast());
             assert!(secondary_slots[1] == ffi::PyModuleDef_Slot::default());
         }
-        #[cfg(Py_3_15)]
-        {
-            assert_eq!(module_def.name, NAME);
-            assert_eq!(module_def.doc, DOC);
-        }
+
+        assert_eq!(module_def.name, NAME);
     }
 
     #[test]

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -51,7 +51,6 @@ pub struct ModuleDef {
     // wrapped in UnsafeCell so that Rust compiler treats this as interior mutability
     #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
     ffi_def: UnsafeCell<ffi::PyModuleDef>,
-    #[cfg(Py_3_15)]
     name: &'static CStr,
     #[cfg(Py_3_15)]
     doc: &'static CStr,
@@ -105,7 +104,6 @@ impl ModuleDef {
         ModuleDef {
             #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
             ffi_def,
-            #[cfg(Py_3_15)]
             name,
             #[cfg(Py_3_15)]
             doc,
@@ -176,66 +174,35 @@ impl ModuleDef {
         static SIMPLE_NAMESPACE: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
         let simple_ns = SIMPLE_NAMESPACE.import(py, "types", "SimpleNamespace")?;
 
-        #[cfg(not(Py_3_15))]
-        {
-            let ffi_def = self.ffi_def.get();
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("name", self.name)?;
+        let spec = simple_ns.call((), Some(&kwargs))?;
 
-            let m_name = unsafe { CStr::from_ptr((*ffi_def).m_name) };
-            let name = m_name
-                .to_str()
-                .map_err(|e| {
-                    crate::exceptions::PyUnicodeDecodeError::new_err_from_utf8(
-                        py,
-                        m_name.to_bytes(),
-                        e,
-                    )
-                })?
-                .to_string();
-            let kwargs = PyDict::new(py);
-            kwargs.set_item("name", name)?;
-            let spec = simple_ns.call((), Some(&kwargs))?;
+        self.module
+            .get_or_try_init(py, || {
+                let module = unsafe {
+                    cfg_select! {
+                        Py_3_15 => ffi::PyModule_FromSlotsAndSpec(self.get_slots(), spec.as_ptr()),
+                        not(Py_3_15) => ffi::PyModule_FromDefAndSpec(self.ffi_def.get(), spec.as_ptr()),
+                    }.assume_owned_or_err(py)
+                }?.cast_into()?;
 
-            self.module
-                .get_or_try_init(py, || {
-                    let def = self.ffi_def.get();
-                    let module = unsafe {
-                        ffi::PyModule_FromDefAndSpec(def, spec.as_ptr()).assume_owned_or_err(py)?
+                cfg_select! {
+                    Py_3_15 => {
+                        if unsafe { ffi::PyModule_Exec(module.as_ptr()) } != 0 {
+                            return Err(PyErr::fetch(py));
+                        }
+                    },
+                    not(Py_3_15) => {
+                        if unsafe { ffi::PyModule_ExecDef(module.as_ptr(), self.ffi_def.get()) } != 0 {
+                            return Err(PyErr::fetch(py));
+                        }
                     }
-                    .cast_into()?;
-                    if unsafe { ffi::PyModule_ExecDef(module.as_ptr(), def) } != 0 {
-                        return Err(PyErr::fetch(py));
-                    }
-                    Ok(module.unbind())
-                })
-                .map(|py_module| py_module.clone_ref(py))
-        }
+                };
 
-        #[cfg(Py_3_15)]
-        {
-            let name = self.name;
-            let doc = self.doc;
-            let kwargs = PyDict::new(py);
-            kwargs.set_item("name", name)?;
-            let spec = simple_ns.call((), Some(&kwargs))?;
-
-            self.module
-                .get_or_try_init(py, || {
-                    let slots = self.get_slots();
-                    let module = unsafe {
-                        ffi::PyModule_FromSlotsAndSpec(slots, spec.as_ptr())
-                            .assume_owned_or_err(py)?
-                    }
-                    .cast_into()?;
-                    if unsafe { ffi::PyModule_SetDocString(module.as_ptr(), doc.as_ptr()) } != 0 {
-                        return Err(PyErr::fetch(py));
-                    }
-                    if unsafe { ffi::PyModule_Exec(module.as_ptr()) } != 0 {
-                        return Err(PyErr::fetch(py));
-                    }
-                    Ok(module.unbind())
-                })
-                .map(|py_module| py_module.clone_ref(py))
-        }
+                Ok(module.unbind())
+            })
+            .map(|py_module| py_module.clone_ref(py))
     }
     #[cfg(Py_3_15)]
     pub fn get_slots(&'static self) -> *mut ffi::PySlot {

--- a/src/impl_/pymodule.rs
+++ b/src/impl_/pymodule.rs
@@ -32,16 +32,17 @@ use portable_atomic::AtomicI64;
 
 #[cfg(not(any(PyPy, GraalPy)))]
 use crate::exceptions::PyImportError;
+use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(any(not(all(Py_LIMITED_API, Py_GIL_DISABLED)), Py_3_15))]
 use crate::internal_tricks::array_ptr_as_mut;
 use crate::prelude::PyTypeMethods;
+use crate::{err::error_on_minusone, py_result_ext::PyResultExt};
 use crate::{
     ffi,
     impl_::pyfunction::PyFunctionDef,
     types::{PyModule, PyModuleMethods},
     Bound, PyClass, PyResult, PyTypeInfo,
 };
-use crate::{ffi_ptr_ext::FfiPtrExt, PyErr};
 use crate::{
     sync::PyOnceLock,
     types::{any::PyAnyMethods, dict::PyDictMethods, PyDict},
@@ -54,8 +55,6 @@ pub struct ModuleDef {
     #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
     ffi_def: UnsafeCell<ffi::PyModuleDef>,
     name: &'static CStr,
-    #[cfg(Py_3_15)]
-    doc: &'static CStr,
     #[cfg(Py_3_15)]
     slots: &'static PyModuleSlots,
     /// Interpreter ID where module was initialized (not applicable on PyPy).
@@ -81,41 +80,32 @@ impl ModuleDef {
         // This is only used in PyO3 for append_to_inittab on Python 3.15 and newer.
         // There could also be other tools that need the legacy init hook.
         #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
-        #[allow(clippy::declare_interior_mutable_const)]
-        const INIT: ffi::PyModuleDef = ffi::PyModuleDef {
-            m_base: ffi::PyModuleDef_HEAD_INIT,
-            m_name: core::ptr::null(),
-            m_doc: core::ptr::null(),
-            m_size: 0,
-            m_methods: core::ptr::null_mut(),
-            m_slots: core::ptr::null_mut(),
-            m_traverse: None,
-            m_clear: None,
-            m_free: None,
-        };
-
-        #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
         let ffi_def = UnsafeCell::new(ffi::PyModuleDef {
+            m_base: ffi::PyModuleDef_HEAD_INIT,
             m_name: name.as_ptr(),
             m_doc: doc.as_ptr(),
+            m_size: 0,
+            m_methods: core::ptr::null_mut(),
             m_slots: array_ptr_as_mut({
                 cfg_select! {
                     Py_3_15 => secondary_slots.0.get(),
                     _ => slots.0.get(),
                 }
             }),
-            ..INIT
+            m_traverse: None,
+            m_clear: None,
+            m_free: None,
         });
 
         #[cfg(any(not(Py_3_15), all(Py_LIMITED_API, Py_GIL_DISABLED)))]
         let _ = secondary_slots;
+        #[cfg(all(Py_LIMITED_API, Py_GIL_DISABLED))]
+        let _ = doc;
 
         ModuleDef {
             #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]
             ffi_def,
             name,
-            #[cfg(Py_3_15)]
-            doc,
             #[cfg(Py_3_15)]
             slots,
             // -1 is never expected to be a valid interpreter ID
@@ -189,25 +179,23 @@ impl ModuleDef {
 
         self.module
             .get_or_try_init(py, || {
-                let module = unsafe {
+                // SAFETY: slots / def are static and fully initialized, spec is a valid object,
+                // and these functions are known to create a valid module object on success
+                let module: Bound<'_, PyModule> = unsafe {
                     cfg_select! {
                         Py_3_15 => ffi::PyModule_FromSlotsAndSpec(self.get_slots(), spec.as_ptr()),
                         not(Py_3_15) => ffi::PyModule_FromDefAndSpec(self.ffi_def.get(), spec.as_ptr()),
                     }.assume_owned_or_err(py)
-                }?.cast_into()?;
+                    .cast_into_unchecked()
+                }?;
 
-                cfg_select! {
-                    Py_3_15 => {
-                        if unsafe { ffi::PyModule_Exec(module.as_ptr()) } != 0 {
-                            return Err(PyErr::fetch(py));
-                        }
-                    },
-                    not(Py_3_15) => {
-                        if unsafe { ffi::PyModule_ExecDef(module.as_ptr(), self.ffi_def.get()) } != 0 {
-                            return Err(PyErr::fetch(py));
-                        }
+                // SAFETY: module is a known valid module object
+                error_on_minusone(py, unsafe {
+                    cfg_select! {
+                        Py_3_15 => ffi::PyModule_Exec(module.as_ptr()),
+                        not(Py_3_15) => ffi::PyModule_ExecDef(module.as_ptr(), self.ffi_def.get()),
                     }
-                };
+                })?;
 
                 Ok(module.unbind())
             })


### PR DESCRIPTION
I noticed that the `not(Py_3_15)` path in module creation had quite a lot of complexity shared with the newer path, so I made them work identically.

The 3.15+ path had a `PyModule_SetDocString` call which should be redundant with the slot, so I removed it. Let's see what CI thinks...