### PR TITLE
fix: pass class to classmethod magic methods

### DIFF
--- a/newsfragments/6283.fixed.md
+++ b/newsfragments/6283.fixed.md
@@ -1,0 +1,1 @@
+Fix `#[classmethod]` magic methods receiving the instance instead of its type when invoked through a type slot.

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -235,6 +235,12 @@ pub enum FnType {
     ClassAttribute,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ClassMethodReceiver {
+    Class,
+    Instance,
+}
+
 impl FnType {
     pub fn skip_first_rust_argument_in_python_signature(&self) -> bool {
         match self {
@@ -264,6 +270,7 @@ impl FnType {
         cls: Option<&syn::Type>,
         error_mode: ExtractErrorMode,
         self_conversion: SelfConversionPolicy,
+        class_method_receiver: ClassMethodReceiver,
         holders: &mut Holders,
         ctx: &Ctx,
     ) -> Option<TokenStream> {
@@ -282,10 +289,32 @@ impl FnType {
                 let py = syn::Ident::new("py", Span::call_site());
                 let slf: Ident = syn::Ident::new("_slf", Span::call_site());
                 let pyo3_path = pyo3_path.to_tokens_spanned(*span);
+                let class_method_receiver = match class_method_receiver {
+                    ClassMethodReceiver::Class => quote! { #slf.cast() },
+                    ClassMethodReceiver::Instance => {
+                        let type_check = match self_conversion.0 {
+                            SelfConversionPolicyInner::Trusted => quote! {},
+                            SelfConversionPolicyInner::Checked => {
+                                let cls = cls.expect("no class given for a class method");
+                                let type_check = error_mode.handle_error(
+                                    quote_spanned! { *span =>
+                                        #pyo3_path::Bound::ref_from_ptr(#py, &#slf).cast::<#cls>()
+                                    },
+                                    ctx,
+                                );
+                                quote! { #type_check; }
+                            }
+                        };
+                        quote! {{
+                            #type_check
+                            #pyo3_path::ffi::Py_TYPE(#slf).cast()
+                        }}
+                    }
+                };
                 let ret = quote_spanned! { *span =>
                     #[allow(clippy::useless_conversion, reason = "#[classmethod] accepts anything which implements `From<&Bound<PyType>>`")]
                     ::std::convert::Into::into(
-                        #pyo3_path::Bound::ref_from_ptr(#py, &#slf.cast())
+                        #pyo3_path::Bound::ref_from_ptr(#py, &#class_method_receiver)
                             .cast_unchecked::<#pyo3_path::types::PyType>()
                     )
                 };
@@ -774,6 +803,7 @@ impl<'a> FnSpec<'a> {
         cls: Option<&syn::Type>,
         convention: CallingConvention,
         self_conversion: SelfConversionPolicy,
+        class_method_receiver: ClassMethodReceiver,
         ctx: &Ctx,
     ) -> Result<TokenStream> {
         let Ctx {
@@ -800,6 +830,7 @@ impl<'a> FnSpec<'a> {
                 cls,
                 ExtractErrorMode::Raise,
                 self_conversion,
+                class_method_receiver,
                 &mut holders,
                 ctx,
             );

--- a/pyo3-macros-backend/src/pyfunction.rs
+++ b/pyo3-macros-backend/src/pyfunction.rs
@@ -10,7 +10,7 @@ use crate::{
         self, get_pyo3_options, take_attributes, take_pyo3_options, CrateAttribute,
         FromPyWithAttribute, NameAttribute, TextSignatureAttribute,
     },
-    method::{self, CallingConvention, FnArg, SelfConversionPolicy},
+    method::{self, CallingConvention, ClassMethodReceiver, FnArg, SelfConversionPolicy},
     pymethod::check_generic,
 };
 use proc_macro2::{Span, TokenStream};
@@ -439,6 +439,7 @@ pub fn impl_wrap_pyfunction(
         None,
         calling_convention,
         SelfConversionPolicy::checked(),
+        ClassMethodReceiver::Class,
         ctx,
     )?;
     let methoddef = spec.get_methoddef(

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -4,7 +4,9 @@ use std::ffi::CString;
 use crate::attributes::{FromPyWithAttribute, NameAttribute, RenamingRule};
 #[cfg(feature = "experimental-inspect")]
 use crate::introspection::unique_element_id;
-use crate::method::{CallingConvention, ExtractErrorMode, PyArg, SelfConversionPolicy};
+use crate::method::{
+    CallingConvention, ClassMethodReceiver, ExtractErrorMode, PyArg, SelfConversionPolicy,
+};
 use crate::params::{impl_arg_params, impl_regular_arg_param, Holders};
 use crate::pyfunction::WarningFactory;
 use crate::utils::PythonDoc;
@@ -409,6 +411,7 @@ pub fn impl_py_method_def(
         // instance of the owning type before reaching the C function. The
         // trusted path is therefore valid.
         unsafe { SelfConversionPolicy::trusted() },
+        ClassMethodReceiver::Class,
         ctx,
     )?;
     let methoddef = spec.get_methoddef(
@@ -436,6 +439,7 @@ fn impl_call_slot(cls: &syn::Type, spec: &FnSpec<'_>, ctx: &Ctx) -> Result<Metho
         // SAFETY: The `tp_call` slot is dispatched by CPython, which guarantees
         // the receiver is of the correct type.
         unsafe { SelfConversionPolicy::trusted() },
+        ClassMethodReceiver::Instance,
         ctx,
     )?;
     let slot_def = quote! {
@@ -1538,9 +1542,19 @@ fn generate_method_body(
         pyo3_path,
         output_span,
     } = ctx;
-    let self_arg = spec
-        .tp
-        .self_arg(Some(cls), extract_error_mode, self_conversion, holders, ctx);
+    let self_arg = spec.tp.self_arg(
+        Some(cls),
+        extract_error_mode,
+        self_conversion,
+        match calling_convention {
+            SlotCallingConvention::TpNew => ClassMethodReceiver::Class,
+            SlotCallingConvention::TpInit | SlotCallingConvention::FixedArguments(_) => {
+                ClassMethodReceiver::Instance
+            }
+        },
+        holders,
+        ctx,
+    );
     let rust_name = spec.name;
     let warnings = spec.warnings.build_py_warning(ctx);
 

--- a/tests/test_methods.rs
+++ b/tests/test_methods.rs
@@ -123,6 +123,63 @@ fn class_method() {
     });
 }
 
+#[test]
+fn class_method_magic_methods() {
+    #[pyclass(subclass)]
+    struct ClassMethodMagic;
+
+    #[pymethods]
+    impl ClassMethodMagic {
+        #[new]
+        fn new() -> Self {
+            Self
+        }
+
+        #[classmethod]
+        fn __len__(cls: &Bound<'_, PyType>) -> usize {
+            if cls.is_exact_instance_of::<PyType>() {
+                42
+            } else {
+                0
+            }
+        }
+
+        #[classmethod]
+        fn __call__<'py>(cls: &Bound<'py, PyType>) -> Bound<'py, PyType> {
+            cls.clone()
+        }
+
+        #[classmethod]
+        fn __add__<'py>(cls: &Bound<'py, PyType>, _other: &Bound<'_, PyAny>) -> Bound<'py, PyType> {
+            cls.clone()
+        }
+    }
+
+    Python::attach(|py| {
+        let cls = py.get_type::<ClassMethodMagic>();
+        py_run!(
+            py,
+            cls,
+            r#"
+class Subclass(cls):
+    pass
+
+obj = Subclass()
+assert len(obj) == 42
+assert obj() is Subclass
+assert obj + None is Subclass
+
+try:
+    1 + obj
+except TypeError:
+    pass
+else:
+    raise AssertionError("the forward operator accepted the wrong receiver")
+"#
+        );
+    });
+}
+
 #[pyclass]
 struct ClassMethodWithArgs {}
 


### PR DESCRIPTION
Fixes #6088.

Convert slot receivers to their runtime type before passing them to `#[classmethod]` magic methods, while preserving receiver validation for binary operators.

Tests cover `__len__`, `__call__`, and `__add__`.
