### PR TITLE
fix: skip libpython rpath args on Windows and Cygwin

### DIFF
--- a/newsfragments/6284.fixed.md
+++ b/newsfragments/6284.fixed.md
@@ -1,0 +1,1 @@
+Fix `pyo3_build_config::add_libpython_rpath_link_args` emitting Unix-style rpath linker arguments on Windows and Cygwin.

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -296,10 +296,12 @@ pub mod pyo3_build_script_impl {
             target.architecture,
             Architecture::Wasm32 | Architecture::Wasm64
         );
-        let is_emscripten = target.operating_system == target_lexicon::OperatingSystem::Emscripten;
+        let is_emscripten = target.operating_system == OperatingSystem::Emscripten;
+        let is_cygwin = target.operating_system == OperatingSystem::Cygwin;
+        let is_windows = target.operating_system == OperatingSystem::Windows;
         // webassembly targets generally don't support rpath, emscripten is the only exception currently aware of:
         // https://github.com/emscripten-core/emscripten/issues/22126
-        if is_linking_libpython && (!is_wasm || is_emscripten) {
+        if is_linking_libpython && !is_windows && !is_cygwin && (!is_wasm || is_emscripten) {
             if let Some(lib_dir) = interpreter_config.lib_dir() {
                 println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}");
             }


### PR DESCRIPTION
<!--

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [Documenting changes](https://pyo3.rs/main/contributing.html#documenting-changes)
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
   - or start the PR title with `internal:` if this is an internal change to skip the check
   - or start the PR title with `refactor:` if this is a refactor change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run `nox`. See `nox --list-sessions` for a list of supported actions.

Please do not submit unsolicited AI-generated PRs.
See our [contributing guidelines](https://pyo3.rs/main/contributing.html) for guidelines on how to use AI when contributing to PyO3.

-->
Fixes #6282
Related #6205 / #6212 

`add_libpython_rpath_link_args` shouldn't emit unix-style rpath linker args on Windows or Cygwin.