### PR TITLE
internal: add safety comments in pyclass/gc, call and marshal

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -1,6 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
-
 //! Defines how Python calls are dispatched, see [`PyCallArgs`].for more information.
 
 use crate::ffi_ptr_ext::FfiPtrExt as _;
@@ -197,6 +194,10 @@ impl<'py> PyCallArgs<'py> for Borrowed<'_, 'py, PyTuple> {
         kwargs: Borrowed<'_, 'py, PyDict>,
         _: private::Token,
     ) -> PyResult<Bound<'py, PyAny>> {
+        // SAFETY: `function`, `self` and `kwargs` are valid pointers to a
+        // callable, a tuple and a dict, and `PyObject_Call` returns a new
+        // owned reference on success, or NULL with an exception set on
+        // failure.
         unsafe {
             ffi::PyObject_Call(function.as_ptr(), self.as_ptr(), kwargs.as_ptr())
                 .assume_owned_or_err(function.py())
@@ -209,6 +210,10 @@ impl<'py> PyCallArgs<'py> for Borrowed<'_, 'py, PyTuple> {
         function: Borrowed<'_, 'py, PyAny>,
         _: private::Token,
     ) -> PyResult<Bound<'py, PyAny>> {
+        // SAFETY: `function` and `self` are valid pointers to a callable and
+        // a tuple, NULL is documented as a valid value for kwargs, and
+        // `PyObject_Call` returns a new owned reference on success, or NULL
+        // with an exception set on failure.
         unsafe {
             ffi::PyObject_Call(function.as_ptr(), self.as_ptr(), core::ptr::null_mut())
                 .assume_owned_or_err(function.py())

--- a/src/marshal.rs
+++ b/src/marshal.rs
@@ -1,5 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
 #![cfg(not(Py_LIMITED_API))]
 
 //! Support for the Python `marshal` format.
@@ -35,6 +33,9 @@ pub const VERSION: i32 = 4;
 /// # });
 /// ```
 pub fn dumps<'py>(object: &Bound<'py, PyAny>, version: i32) -> PyResult<Bound<'py, PyBytes>> {
+    // SAFETY: `object` is a valid object pointer, and a non-NULL return from
+    // `PyMarshal_WriteObjectToString` is a new owned reference to a bytes
+    // object.
     unsafe {
         ffi::PyMarshal_WriteObjectToString(object.as_ptr(), version as c_int)
             .assume_owned_or_err(object.py())
@@ -48,6 +49,9 @@ where
     B: AsRef<[u8]> + ?Sized,
 {
     let data = data.as_ref();
+    // SAFETY: `data` and `len` come from the same byte slice, so `data` points
+    // to `len` readable bytes, and `PyMarshal_ReadObjectFromString` returns a
+    // new owned reference on success, or NULL with an exception set on error.
     unsafe {
         ffi::PyMarshal_ReadObjectFromString(data.as_ptr().cast(), data.len() as isize)
             .assume_owned_or_err(py)

--- a/src/pyclass/gc.rs
+++ b/src/pyclass/gc.rs
@@ -1,6 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
-
 use core::{
     ffi::{c_int, c_void},
     marker::PhantomData,
@@ -42,6 +39,10 @@ impl PyVisit<'_> {
     {
         let ptr = obj.into().map_or_else(core::ptr::null_mut, Py::as_ptr);
         if !ptr.is_null() {
+            // SAFETY: `PyVisit` is only created during a `tp_traverse` call and
+            // cannot outlive it, so `visit` and `arg` are still the pair the
+            // interpreter passed in; `ptr` comes from `Py::as_ptr`, so it is a
+            // valid object pointer.
             match NonZero::new(unsafe { (self.visit)(ptr, self.arg) }) {
                 None => Ok(()),
                 Some(r) => Err(PyTraverseError(r)),


### PR DESCRIPTION
Part of #5487, continuing from #6256, #6259 and #6265.

Removes the `#![allow(clippy::undocumented_unsafe_blocks)]` exemption from three files and adds `// SAFETY:` comments for their five unsafe blocks:

- `src/pyclass/gc.rs`
- `src/call.rs`
- `src/marshal.rs`

One commit per file for easier review. Verified with clippy under both the default and `abi3` feature sets to cover the `Py_LIMITED_API` branches (note `marshal.rs` is cfg-gated out under `Py_LIMITED_API`, so the `abi3` pass does not exercise it).

Notes for review: the `pyclass/gc.rs` argument leans on `PyVisit`'s construction invariant (only created by PyO3's `tp_traverse` implementation, cannot outlive that call). The `PyMarshal_WriteObjectToString` comment deliberately claims only that a non-NULL return is a new owned reference to a bytes object: unlike the read direction, its C API documentation does not document the error return, and NULL is permitted by `Bound::from_owned_ptr_or_err` regardless.

Disclosure: I used AI assistance while analyzing this code; I have personally verified each safety argument against the documented contracts.
