### PR TITLE
fix double-decref in PyPy in instance dealloc

### DIFF
--- a/newsfragments/6294.fixed.md
+++ b/newsfragments/6294.fixed.md
@@ -1,0 +1,1 @@
+Fix PyO3 0.29.1 regression on PyPy causing crashes when deallocating `#[pyclass]` instances.

--- a/pytests/src/exception.rs
+++ b/pytests/src/exception.rs
@@ -4,6 +4,19 @@ use pyo3::prelude::*;
 
 create_exception!(pytests.exception, MyValueError, PyValueError);
 
+#[cfg(any(not(Py_LIMITED_API), Py_3_12))]
+#[pyclass(extends = PyValueError)]
+pub struct MyValueErrorClass;
+
+#[cfg(any(not(Py_LIMITED_API), Py_3_12))]
+#[pymethods]
+impl MyValueErrorClass {
+    #[new]
+    fn new() -> PyClassInitializer<Self> {
+        PyClassInitializer::from(MyValueErrorClass)
+    }
+}
+
 #[pymodule(gil_used = false)]
 pub mod exception {
     use pyo3::exceptions::PyValueError;
@@ -11,6 +24,10 @@ pub mod exception {
 
     #[pymodule_export]
     use super::MyValueError;
+
+    #[cfg(any(not(Py_LIMITED_API), Py_3_12))]
+    #[pymodule_export]
+    use super::MyValueErrorClass;
 
     #[pyfunction]
     fn raise_my_value_error() -> PyResult<()> {

--- a/pytests/stubs/exception.pyi
+++ b/pytests/stubs/exception.pyi
@@ -1,5 +1,9 @@
 from _typeshed import Incomplete
-from typing import Any
+from typing import Any, final
+
+@final
+class MyValueErrorClass(ValueError):
+    def __new__(cls, /) -> MyValueErrorClass: ...
 
 def raise_my_value_error() -> None: ...
 def return_my_value_error() -> Any: ...

--- a/pytests/tests/test_exception.py
+++ b/pytests/tests/test_exception.py
@@ -1,0 +1,9 @@
+from pyo3_pytests import exception
+
+
+def test_pypy_exception_dealloc():
+    # See https://github.com/pypy/pypy/issues/5555
+    # - we had an issue caused by https://github.com/PyO3/pyo3/pull/6224
+    for _ in range(10_000):
+        instance = exception.MyValueErrorClass()
+        del instance

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -14,7 +14,7 @@ use crate::internal::get_slot::{TP_DEALLOC, TP_FREE};
 use crate::sync::PyOnceLock;
 use crate::type_object::{PyLayout, PySizedLayout, PyTypeInfo};
 use crate::types::PyType;
-use crate::{ffi, Bound, PyClass, Python};
+use crate::{ffi, PyClass, Python};
 
 use crate::types::PyTypeMethods;
 
@@ -270,8 +270,18 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
         // as if it was an owned pointer. In this way, when the bound is dropped,
         // it will decref the type object.
         debug_assert!(ffi::PyType_HasFeature(actual_type_ptr, ffi::Py_TPFLAGS_HEAPTYPE) != 0);
-        let actual_type = Bound::from_owned_ptr(py, actual_type_ptr as *mut ffi::PyObject)
-            .cast_into_unchecked::<PyType>();
+        let actual_type = cfg_select! {
+            not(PyPy) => crate::Bound::from_owned_ptr(py, actual_type_ptr as *mut ffi::PyObject)
+                .cast_into_unchecked::<PyType>(),
+            // See https://github.com/pypy/pypy/issues/5555 - it seems that PyPy does not
+            // support the CPython semantics properly, so we avoid taking ownership of the
+            // type object on PyPy.
+            //
+            // TODO: If the PyPy bug is fixed we should remove this workaround and just create
+            // a `Bound` as above.
+            PyPy => crate::Borrowed::from_ptr(py, actual_type_ptr as *mut ffi::PyObject)
+                .cast_unchecked::<PyType>(),
+        };
 
         // For `#[pyclass]` types which inherit from PyAny, we can just call tp_free
         #[cfg(not(RustPython))]
@@ -305,6 +315,10 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
 
         // Cause the reference to the type to be decrefed for heap types, which
         // is necessary to avoid a reference leak.
+        #[cfg_attr(
+            PyPy,
+            expect(dropping_copy_types, reason = "see PyPy workaround for decref above")
+        )]
         drop(actual_type);
     }
 }


### PR DESCRIPTION
Fixes the regression reported in https://github.com/PyO3/pyo3/pull/6224#issuecomment-5172410944

I wrote the test and verified it fails on `main` before landing the fix.