### PR TITLE
ci: unblock CI via a uv constraint

### DIFF
--- a/.github/uv-constraints.txt
+++ b/.github/uv-constraints.txt
@@ -1,0 +1,2 @@
+# see https://github.com/kislyuk/argcomplete/issues/559
+argcomplete<3.7.1; python_version < "3.10"

--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/uv-constraints.txt
   UV_PYTHON: "3.14t"
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   NOX_DEFAULT_VENV_BACKEND: uv
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/uv-constraints.txt
 
 jobs:
   build:
@@ -49,16 +50,12 @@ jobs:
           # PyPy can have FFI changes within Python versions, which creates pain in CI
           check-latest: ${{ startsWith(inputs.python-version, 'pypy') }}
 
-      # workaround for the above, only available for 3.9
-      - if: ${{ inputs.os == 'macos-latest' && contains(fromJSON('["3.9"]'), inputs.python-version) && inputs.python-architecture == 'x64' }}
-        name: Set up Python ${{ inputs.python-version }}
+      - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: cpython-${{ inputs.python-version }}-macos-x86-64
+          # workaround for the above, only available for 3.9
+          python-version: ${{ inputs.os == 'macos-latest' && contains(fromJSON('["3.9"]'), inputs.python-version) && inputs.python-architecture == 'x64' && format('cpython-{0}-macos-x86-64', inputs.python-version) || '' }}
           save-cache: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-
-      - name: Install nox
-        run: python -m pip install --upgrade pip && pip install nox[uv]
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
@@ -87,7 +84,7 @@ jobs:
 
       - if: inputs.rust == inputs.MSRV
         name: Prepare MSRV package versions
-        run: nox -s set-msrv-package-versions
+        run: uvx nox -s set-msrv-package-versions
 
       - if: inputs.rust != 'stable'
         name: Ignore changed error messages for ui tests (still run for coverage)
@@ -109,20 +106,20 @@ jobs:
       - name: Run pyo3-ffi-check
         # TODO: investigate graalpy failures
         if: ${{ endsWith(inputs.python-version, '-dev') || (steps.ffi-changes.outputs.changed == 'true' && inputs.rust == 'stable' && !startsWith(inputs.python-version, 'graalpy')) }}
-        run: nox -s ffi-check
+        run: uvx nox -s ffi-check
 
       - uses: ./.github/actions/prepare-coverage
         if: ${{ inputs.os != 'windows-11-arm' }} # https://github.com/rust-lang/rust/issues/150123
 
       - name: Build docs
-        run: nox -s docs
+        run: uvx nox -s docs
 
       - name: Run Rust tests
-        run: nox -s test-rust
+        run: uvx nox -s test-rust
 
       - name: Test python examples and tests
         shell: bash
-        run: nox -s test-py
+        run: uvx nox -s test-py
         env:
           CARGO_TARGET_DIR: ${{ github.workspace }}/target
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.14'
-      - run: python -m pip install --upgrade pip && pip install nox[uv]
-      - run: nox -s check-changelog
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx nox -s check-changelog

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   NOX_DEFAULT_VENV_BACKEND: uv
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/uv-constraints.txt
   UV_PYTHON: 3.14
 
 jobs:
@@ -23,20 +24,20 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
-      - run: python -m pip install --upgrade pip && pip install nox[uv]
+      - uses: astral-sh/setup-uv@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
       - name: Check python formatting and lints (ruff)
-        run: nox -s ruff
+        run: uvx nox -s ruff
       - name: Check rust formatting (rustfmt)
-        run: nox -s rustfmt
+        run: uvx nox -s rustfmt
       - name: Check markdown formatting (rumdl)
-        run: nox -s rumdl
+        run: uvx nox -s rumdl
       - name: Check `required-features` in Cargo.toml
-        run: nox -s check-test-features
+        run: uvx nox -s check-test-features
       - name: Spell check
-        run: nox -s typos
+        run: uvx nox -s typos
 
   resolve:
     runs-on: ubuntu-latest
@@ -95,12 +96,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-      - run: python -m pip install --upgrade pip && pip install nox[uv]
+      - uses: astral-sh/setup-uv@v7
       # This is a smoke test to confirm that CI will run on MSRV (including dev dependencies)
       - name: Check with MSRV package versions
         run: |
-          nox -s set-msrv-package-versions
-          nox -s check-all
+          uvx nox -s set-msrv-package-versions
+          uvx nox -s check-all
 
     env:
       CARGO_BUILD_TARGET: x86_64-unknown-linux-gnu
@@ -430,8 +431,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@valgrind
-      - run: python -m pip install --upgrade pip && pip install nox[uv]
-      - run: nox -s test-rust -- release skip-full
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx nox -s test-rust -- release skip-full
     env:
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: valgrind --leak-check=no --error-exitcode=1
       RUST_BACKTRACE: 1
@@ -453,8 +454,8 @@ jobs:
         with:
           components: rust-src
       - uses: taiki-e/install-action@cargo-careful
-      - run: python -m pip install --upgrade pip && pip install nox[uv]
-      - run: nox -s test-rust -- careful skip-full
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx nox -s test-rust -- careful skip-full
     env:
       RUST_BACKTRACE: 1
       UI_TEST: skip
@@ -644,8 +645,8 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-hack,cargo-minimal-versions
-      - run: python3 -m pip install --upgrade pip && pip install nox[uv]
-      - run: python3 -m nox -s check-feature-powerset -- ${{ matrix.rust != 'stable' && 'minimal-versions' || '' }}
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx nox -s check-feature-powerset -- ${{ matrix.rust != 'stable' && 'minimal-versions' || '' }}
 
   test-cross-compilation:
     needs: [fmt, resolve]
@@ -799,8 +800,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-      - run: python -m pip install --upgrade pip && pip install nox[uv]
-      - run: nox -s test-introspection
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx nox -s test-introspection
     env:
       CARGO_BUILD_TARGET: ${{ matrix.platform.rust-target }}
 
@@ -814,8 +815,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
-      - run: python -m pip install --upgrade pip && pip install nox[uv]
-      - run: nox -s test-introspection
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx nox -s test-introspection
 
   pytests-type-checking:
     needs: [fmt]
@@ -833,8 +834,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
-      - run: python -m pip install --upgrade pip && pip install nox[uv]
-      - run: nox -s ${{matrix.checker}}
+      - uses: astral-sh/setup-uv@v7
+      - run: uvx nox -s ${{matrix.checker}}
         working-directory: pytests
 
   conclusion:

--- a/.github/workflows/netlify-build.yml
+++ b/.github/workflows/netlify-build.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.14"
+      - uses: astral-sh/setup-uv@v7
 
       - uses: dtolnay/rust-toolchain@nightly
 
@@ -47,9 +48,7 @@ jobs:
 
       # This builds the book in target/guide/.
       - name: Build the guide
-        run: |
-          python -m pip install --upgrade pip && pip install nox[uv]
-          nox -s ${{ github.event_name == 'release' && 'build-guide' || 'check-guide' }}
+        run: uvx nox -s ${{ github.event_name == 'release' && 'build-guide' || 'check-guide' }}
         env:
           PYO3_VERSION_TAG: ${{ github.event_name == 'release' && steps.prepare_tag.outputs.tag_name || 'main' }}
           # allows lychee to get better rate limits from github
@@ -79,9 +78,7 @@ jobs:
           echo "PYO3_VERSION=${PYO3_VERSION}" >> $GITHUB_ENV
 
       - name: Build the site
-        run: |
-          python -m pip install --upgrade pip && pip install nox[uv] towncrier requests
-          nox -s build-netlify-site -- ${{ (github.ref != 'refs/heads/main' && '--preview') || '' }}
+        run: uvx --with requests nox -s build-netlify-site -- ${{ (github.ref != 'refs/heads/main' && '--preview') || '' }}
 
       # Upload the built site as an artifact for deploy workflow to consume
       - name: Upload Build Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       version:
         description: The version to build
 
+env:
+  UV_CONSTRAINT: ${{ github.workspace }}/.github/uv-constraints.txt
+
 jobs:
   release:
     permissions:


### PR DESCRIPTION
The 3.9 jobs are broken due to https://github.com/kislyuk/argcomplete/issues/559

I think it's possible to use a `uv` constraint override to fix the nox install. To make this work I had to migrate existing `pip install`s of `nox` to use `uvx nox` instead.