### PR TITLE
define `PyObject_GC_Track` and `PyObject_GC_UnTrack` for PyPy

### DIFF
--- a/newsfragments/6299.added.md
+++ b/newsfragments/6299.added.md
@@ -1,0 +1,1 @@
+Enable FFI definitions `PyObject_GC_Track` and `PyObject_GC_UnTrack` on PyPy.

--- a/pyo3-ffi/src/objimpl.rs
+++ b/pyo3-ffi/src/objimpl.rs
@@ -94,7 +94,17 @@ extern_libpython! {
 
     #[cfg(not(PyPy))]
     pub fn PyObject_GC_UnTrack(arg1: *mut c_void);
+}
 
+#[cfg(PyPy)]
+#[inline]
+pub fn PyObject_GC_Track(_: *mut c_void) {}
+
+#[cfg(PyPy)]
+#[inline]
+pub fn PyObject_GC_UnTrack(_: *mut c_void) {}
+
+extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyObject_GC_Del")]
     pub fn PyObject_GC_Del(arg1: *mut c_void);
 }

--- a/pyo3-ffi/src/objimpl.rs
+++ b/pyo3-ffi/src/objimpl.rs
@@ -96,13 +96,16 @@ extern_libpython! {
     pub fn PyObject_GC_UnTrack(arg1: *mut c_void);
 }
 
-#[cfg(PyPy)]
-#[inline]
-pub fn PyObject_GC_Track(_: *mut c_void) {}
+// PyPy currently implements the following two as no-op macros
+// https://github.com/pypy/pypy/blob/194f9f44b50552d75484d67cda6e2b36607dee0c/pypy/module/cpyext/include/objimpl.h#L178-L190
 
 #[cfg(PyPy)]
-#[inline]
-pub fn PyObject_GC_UnTrack(_: *mut c_void) {}
+#[inline(always)]
+pub unsafe fn PyObject_GC_Track(_: *mut c_void) {}
+
+#[cfg(PyPy)]
+#[inline(always)]
+pub unsafe fn PyObject_GC_UnTrack(_: *mut c_void) {}
 
 extern_libpython! {
     #[cfg_attr(PyPy, link_name = "PyPyObject_GC_Del")]

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -1165,10 +1165,9 @@ pub(crate) unsafe extern "C" fn tp_dealloc<T: PyClass>(obj: *mut ffi::PyObject) 
 
 /// Implementation of tp_dealloc for pyclasses with gc
 pub(crate) unsafe extern "C" fn tp_dealloc_with_gc<T: PyClass>(obj: *mut ffi::PyObject) {
-    #[cfg(not(PyPy))]
-    unsafe {
-        ffi::PyObject_GC_UnTrack(obj.cast());
-    }
+    // SAFETY: `tp_dealloc` is required to untrack GC objects before invalidating any fields
+    unsafe { ffi::PyObject_GC_UnTrack(obj.cast()) };
+    // SAFETY: `tp_dealloc` is called with valid `obj` by CPython, with an attached thread state
     unsafe { crate::impl_::trampoline::dealloc(obj, <T as PyClassImpl>::Layout::tp_dealloc) }
 }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -304,7 +304,7 @@ unsafe fn tp_dealloc(slf: *mut ffi::PyObject, type_obj: &crate::Bound<'_, PyType
             // Before CPython 3.11 BaseException_dealloc would use Py_GC_UNTRACK which
             // assumes the exception is currently GC tracked, so we have to re-track
             // before calling the dealloc so that it can safely call Py_GC_UNTRACK.
-            #[cfg(not(any(Py_3_11, PyPy)))]
+            #[cfg(not(Py_3_11))]
             if ffi::PyType_FastSubclass(type_ptr, ffi::Py_TPFLAGS_BASE_EXC_SUBCLASS) == 1 {
                 ffi::PyObject_GC_Track(slf.cast());
             }


### PR DESCRIPTION
PyPy defines these functions as macros that expand to no-ops; by doing the same we make it easier for downstream code to not have to be conditional on PyPy.

https://github.com/pypy/pypy/blob/194f9f44b50552d75484d67cda6e2b36607dee0c/pypy/module/cpyext/include/objimpl.h#L178-L190