### PR TITLE
ci: fix ffi-check for backport of `Py_CompileStringFlags` symbol

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           architecture: ${{ inputs.python-architecture }}
-          # PyPy can have FFI changes within Python versions, which creates pain in CI
-          check-latest: ${{ startsWith(inputs.python-version, 'pypy') }}
+          check-latest: true
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7

--- a/pyo3-ffi-check/macro/src/lib.rs
+++ b/pyo3-ffi-check/macro/src/lib.rs
@@ -429,7 +429,7 @@ const MACRO_EXCLUSIONS: &[(&str, &str)] = &[
     ("PyVectorcall_NARGS", "not(Py_3_12)"),
     ("Py_CLEAR", ""),
     ("Py_CompileString", "not(Py_3_10)"),
-    ("Py_CompileStringFlags", "all(not(PyPy), not(Py_3_15))"),
+    ("Py_CompileStringFlags", "all(not(PyPy), not(Py_3_13))"),
     ("Py_DECREF", ""),
     ("Py_Ellipsis", ""),
     ("Py_False", ""),

--- a/pyo3-ffi/src/cpython/pythonrun.rs
+++ b/pyo3-ffi/src/cpython/pythonrun.rs
@@ -1,5 +1,5 @@
 use crate::object::*;
-#[cfg(not(any(PyPy, GraalPy, Py_LIMITED_API, Py_3_10)))]
+#[cfg(not(any(PyPy, GraalPy, Py_3_10)))]
 use crate::pyarena::PyArena;
 use crate::PyCompilerFlags;
 #[cfg(not(any(PyPy, GraalPy, Py_3_10)))]
@@ -97,6 +97,10 @@ extern_libpython! {
         flags: *mut PyCompilerFlags,
     ) -> *mut PyObject;
 
+    // skipped Py_CompileString - there is a symbol defined for this since Python 3.13
+    // but the symbol is overridden by a macro definition to call Py_CompileStringExFlags
+    // inline (see below)
+
     #[cfg(not(any(PyPy, GraalPy)))]
     pub fn Py_CompileStringExFlags(
         str: *const c_char,
@@ -105,7 +109,6 @@ extern_libpython! {
         flags: *mut PyCompilerFlags,
         optimize: c_int,
     ) -> *mut PyObject;
-    #[cfg(not(Py_LIMITED_API))]
     pub fn Py_CompileStringObject(
         str: *const c_char,
         filename: *mut PyObject,


### PR DESCRIPTION
As per https://github.com/PyO3/pyo3/pull/6273#issuecomment-5196971868