### PR TITLE
Remove redundant clone

### DIFF
--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1339,7 +1339,7 @@ impl InterpreterConfigBuilder {
     }
 
     pub fn finalize(self) -> Result<InterpreterConfig> {
-        let mut build_flags = self.build_flags.clone();
+        let mut build_flags = self.build_flags;
         let py_gil_disabled = build_flags.0.contains(&BuildFlag::Py_GIL_DISABLED);
         let target_abi = match (self.target_abi, py_gil_disabled) {
             // No target ABI set, no Py_GIL_DISABLED: default to GIL-enabled version-specific.


### PR DESCRIPTION
If I am not overlooking anything, I believe this clone is redundant and can thus be safely removed.

For reference, this change was found by an optimizer developed as a research project.

CC @nunoplopes