### PR TITLE
fix `clippy::clone_on_copy` firing on `#[pyclass(from_py_object)]` + `Copy` classes

### DIFF
--- a/newsfragments/6309.fixed.md
+++ b/newsfragments/6309.fixed.md
@@ -1,0 +1,1 @@
+Fix `clippy::clone_on_copy` warnings triggered on nightly Rust by `#[pyclass(from_py_object)]` on classes which implement `Copy`.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -3019,7 +3019,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     #input_type
 
                     fn extract(obj: #pyo3_path::Borrowed<'a, 'py, #pyo3_path::PyAny>) -> ::std::result::Result<Self,  <Self as #pyo3_path::FromPyObject<'a, 'py>>::Error> {
-                        ::std::result::Result::Ok(::std::clone::Clone::clone(&*obj.extract::<#pyo3_path::PyClassGuard<'_, #cls>>()?))
+                        #pyo3_path::impl_::pyclass::extract_pyclass_with_clone(obj)
                     }
                 }
             }

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -14,9 +14,10 @@ use crate::{
     },
     internal::pyclass_init::PyObjectInit,
     pycell::{impl_::PyClassObjectLayout, PyBorrowError},
+    pyclass::PyClassGuardError,
     types::{any::PyAnyMethods, PyBool},
-    Borrowed, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyClass, PyClassGuard, PyErr, PyResult,
-    PyTypeCheck, PyTypeInfo, Python,
+    Borrowed, FromPyObject, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyClass, PyClassGuard, PyErr,
+    PyResult, PyTypeCheck, PyTypeInfo, Python,
 };
 use core::{
     ffi::CStr,
@@ -46,6 +47,16 @@ pub const fn dict_offset<T: PyClass>() -> PyObjectOffset {
 #[inline]
 pub const fn weaklist_offset<T: PyClass>() -> PyObjectOffset {
     <T as PyClassImpl>::Layout::WEAKLIST_OFFSET
+}
+
+/// Extracts a `T: PyClass + Clone` from a Python object by cloning it out of
+/// the [`PyClassGuard`].
+#[inline]
+pub fn extract_pyclass_with_clone<'a, 'py, T: PyClass + Clone>(
+    obj: Borrowed<'a, 'py, PyAny>,
+) -> Result<T, PyClassGuardError<'a, 'py>> {
+    let guard = <PyClassGuard<'a, T> as FromPyObject<'a, 'py>>::extract(obj)?;
+    Ok(T::clone(&guard))
 }
 
 mod sealed {

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -6,8 +6,10 @@ use pyo3::types::PyString;
 
 mod test_utils;
 
+// `Copy` + `from_py_object` is a regression test for `clippy::clone_on_copy`
+// firing in the generated `FromPyObject` implementation (#6308)
 #[pyclass(eq, eq_int, from_py_object)]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum MyEnum {
     Variant,
     OtherVariant,

--- a/tests/ui/invalid_pyclass_args.default.stderr
+++ b/tests/ui/invalid_pyclass_args.default.stderr
@@ -429,19 +429,19 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
    --> tests/ui/invalid_pyclass_args.rs:253:12
     |
 253 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+    |            ^^^ the trait `FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::FromPyObject<'a, 'py>`:
-              `&'a CStr` implements `pyo3::FromPyObject<'a, '_>`
-              `&'a [u8]` implements `pyo3::FromPyObject<'a, 'py>`
-              `&'a str` implements `pyo3::FromPyObject<'a, '_>`
-              `(T0, T1)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4, T5)` implements `pyo3::FromPyObject<'a, 'py>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
             and $N others
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`

--- a/tests/ui/invalid_pyclass_args.inspect.stderr
+++ b/tests/ui/invalid_pyclass_args.inspect.stderr
@@ -459,19 +459,19 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
    --> tests/ui/invalid_pyclass_args.rs:253:12
     |
 253 |     field: Box<dyn std::error::Error + Send + Sync>,
-    |            ^^^ the trait `pyo3::FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
+    |            ^^^ the trait `FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
     = note: `Python<'py>` is also a valid argument type to pass the Python token into `#[pyfunction]`s and `#[pymethods]`
-    = help: the following other types implement trait `pyo3::FromPyObject<'a, 'py>`:
-              `&'a CStr` implements `pyo3::FromPyObject<'a, '_>`
-              `&'a [u8]` implements `pyo3::FromPyObject<'a, 'py>`
-              `&'a str` implements `pyo3::FromPyObject<'a, '_>`
-              `(T0, T1)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4)` implements `pyo3::FromPyObject<'a, 'py>`
-              `(T0, T1, T2, T3, T4, T5)` implements `pyo3::FromPyObject<'a, 'py>`
+    = help: the following other types implement trait `FromPyObject<'a, 'py>`:
+              `&'a CStr` implements `FromPyObject<'a, '_>`
+              `&'a [u8]` implements `FromPyObject<'a, 'py>`
+              `&'a str` implements `FromPyObject<'a, '_>`
+              `(T0, T1)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4)` implements `FromPyObject<'a, 'py>`
+              `(T0, T1, T2, T3, T4, T5)` implements `FromPyObject<'a, 'py>`
             and $N others
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_required_argument`


### PR DESCRIPTION
Move the clone out of the generated `FromPyObject` impl into a generic helper where the type is only known to be `Clone`, so the lint cannot trigger. Fixes #6308.
