### PR TITLE
Fix documentation typo

### DIFF
--- a/guide/src/free-threading.md
+++ b/guide/src/free-threading.md
@@ -171,7 +171,7 @@ For now you should explicitly add locking, possibly using conditional compilatio
 ### Cannot build extension modules using the limited API
 
 The free-threaded build uses a completely new ABI and there is not yet an equivalent to the limited API for the free-threaded ABI.
-That means if your crate depends on PyO3 using the `abi3` feature or an an `abi3-pyxx` feature, PyO3 will print a warning and ignore that setting when building extension modules using the free-threaded interpreter.
+That means if your crate depends on PyO3 using the `abi3` feature or an `abi3-pyxx` feature, PyO3 will print a warning and ignore that setting when building extension modules using the free-threaded interpreter.
 
 This means that if your package makes use of the ABI forward compatibility provided by the limited API to upload only one wheel for each release of your package, you will need to update your release procedure to also upload a version-specific free-threaded wheel.
 


### PR DESCRIPTION
Small documentation typo noticed in the guide:

- `guide/src/free-threading.md`: "or an an `abi3-pyxx` feature" -> "or an `abi3-pyxx` feature"

Documentation only; no code changes.
