### PR TITLE
Add z/OS (s390x-ibm-zos) cross-compilation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,3 +433,8 @@ required-features = ["macros"]
 [[test]]
 name = "test_various"
 required-features = ["macros"]
+
+[patch.crates-io]
+# target-lexicon 0.13.5 does not yet include OperatingSystem::Zos;
+# use the main branch until the next release.
+target-lexicon = { git = "https://github.com/bytecodealliance/target-lexicon", branch = "main" }

--- a/pyo3-build-config/src/impl_.rs
+++ b/pyo3-build-config/src/impl_.rs
@@ -1593,6 +1593,8 @@ pub fn is_linking_libpython_for_target(target: &Triple) -> bool {
     target.operating_system == OperatingSystem::Windows
         // See https://github.com/PyO3/pyo3/issues/4068#issuecomment-2051159852
         || target.operating_system == OperatingSystem::Aix
+        // z/OS uses XPLINK linkage; extension modules must link libpython explicitly
+        || target.operating_system == OperatingSystem::Zos
         || target.environment == Environment::Android
         || target.environment == Environment::Androideabi
         || target.operating_system == OperatingSystem::Cygwin

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -299,9 +299,11 @@ pub mod pyo3_build_script_impl {
         let is_emscripten = target.operating_system == OperatingSystem::Emscripten;
         let is_cygwin = target.operating_system == OperatingSystem::Cygwin;
         let is_windows = target.operating_system == OperatingSystem::Windows;
+        // z/OS uses LIBPATH for runtime library discovery, not ELF rpath
+        let is_zos = target.operating_system == OperatingSystem::Zos;
         // webassembly targets generally don't support rpath, emscripten is the only exception currently aware of:
         // https://github.com/emscripten-core/emscripten/issues/22126
-        if is_linking_libpython && !is_windows && !is_cygwin && (!is_wasm || is_emscripten) {
+        if is_linking_libpython && !is_windows && !is_cygwin && !is_zos && (!is_wasm || is_emscripten) {
             if let Some(lib_dir) = interpreter_config.lib_dir() {
                 println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}");
             }


### PR DESCRIPTION
## Summary

Add z/OS (`s390x-ibm-zos`) support to `pyo3-build-config`.

z/OS (IBM Z Operating System) is supported by the Rust compiler as the `s390x-ibm-zos` target. IBM Open Enterprise Python provides Python 3.11/3.12 on z/OS, and pyo3-based extension modules need two build-system fixes to work:

### Changes

**`pyo3-build-config/src/impl_.rs`** — add `OperatingSystem::Zos` to `is_linking_libpython_for_target()`

z/OS uses XPLINK (cross-language platform linkage) for shared libraries. Extension modules (`.so` files / `cdylib` crates) must link `libpython3.x` explicitly, for the same reason AIX does ([#4068](https://github.com/PyO3/pyo3/issues/4068)).

**`pyo3-build-config/src/lib.rs`** — skip `-Wl,-rpath` for z/OS in `print_libpython_rpath_link_args()`

z/OS uses `LIBPATH` for runtime library discovery rather than ELF-style `rpath`. Emitting `-Wl,-rpath` for z/OS causes a linker error. The caller sets `LIBPATH` at runtime instead.

### Cross-compilation

Cross-compilation from a Linux host is driven via `PYO3_CONFIG_FILE`:

```
implementation=CPython
version=3.11
shared=true
lib_name=python3.11
lib_dir=/usr/lpp/IBM/cyp/v3r11/pyz/lib
suppress_build_script_link_lines=false
```

### Testing

Tested by cross-compiling `pydantic-core` and `watchfiles` for z/OS from a Linux LoP machine, with `cargo check --target s390x-ibm-zos` passing. Full link test pending z/OS server availability.

### Note on `target-lexicon`

`OperatingSystem::Zos` is present in `target-lexicon` main but not yet in the 0.13.x release. This PR includes a `Cargo.toml` patch pointing to `target-lexicon` main; once `target-lexicon` cuts a release with `Zos`, the patch can be removed.