### PR TITLE
internal: Revert "internal: Add conditional compilation on `wip_feature_std`"

### DIFF
--- a/src/conversions/std/map.rs
+++ b/src/conversions/std/map.rs
@@ -8,11 +8,10 @@ use crate::{
     types::{any::PyAnyMethods, dict::PyDictMethods, PyDict},
     Borrowed, FromPyObject, PyAny, PyErr, Python,
 };
-use alloc::collections;
 use core::{cmp, hash};
+use std::collections;
 
-#[cfg(wip_feature_std)]
-impl<'py, K, V, H> IntoPyObject<'py> for std::collections::HashMap<K, V, H>
+impl<'py, K, V, H> IntoPyObject<'py> for collections::HashMap<K, V, H>
 where
     K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     V: IntoPyObject<'py>,
@@ -35,8 +34,7 @@ where
     }
 }
 
-#[cfg(wip_feature_std)]
-impl<'a, 'py, K, V, H> IntoPyObject<'py> for &'a std::collections::HashMap<K, V, H>
+impl<'a, 'py, K, V, H> IntoPyObject<'py> for &'a collections::HashMap<K, V, H>
 where
     &'a K: IntoPyObject<'py> + cmp::Eq + hash::Hash,
     &'a V: IntoPyObject<'py>,
@@ -105,8 +103,7 @@ where
     }
 }
 
-#[cfg(wip_feature_std)]
-impl<'py, K, V, S> FromPyObject<'_, 'py> for std::collections::HashMap<K, V, S>
+impl<'py, K, V, S> FromPyObject<'_, 'py> for collections::HashMap<K, V, S>
 where
     K: FromPyObjectOwned<'py> + cmp::Eq + hash::Hash,
     V: FromPyObjectOwned<'py>,
@@ -120,7 +117,7 @@ where
 
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         let dict = ob.cast::<PyDict>()?;
-        let mut ret = std::collections::HashMap::with_capacity_and_hasher(dict.len(), S::default());
+        let mut ret = collections::HashMap::with_capacity_and_hasher(dict.len(), S::default());
         for (k, v) in dict.iter() {
             ret.insert(
                 k.extract().map_err(Into::into)?,
@@ -159,13 +156,10 @@ where
 mod tests {
     use super::*;
     use alloc::collections::BTreeMap;
-    #[cfg(wip_feature_std)]
     use std::collections::HashMap;
 
     #[test]
-    #[cfg_attr(not(wip_feature_std), ignore)]
     fn test_hashmap_to_python() {
-        #[cfg(wip_feature_std)]
         Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);
@@ -209,9 +203,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(not(wip_feature_std), ignore)]
     fn test_hashmap_into_python() {
-        #[cfg(wip_feature_std)]
         Python::attach(|py| {
             let mut map = HashMap::<i32, i32>::new();
             map.insert(1, 1);

--- a/src/conversions/std/osstr.rs
+++ b/src/conversions/std/osstr.rs
@@ -1,5 +1,3 @@
-#![cfg(wip_feature_std)]
-
 use crate::conversion::IntoPyObject;
 #[cfg(not(target_os = "wasi"))]
 use crate::ffi;

--- a/src/conversions/std/path.rs
+++ b/src/conversions/std/path.rs
@@ -1,5 +1,3 @@
-#![cfg(wip_feature_std)]
-
 use crate::conversion::IntoPyObject;
 use crate::ffi_ptr_ext::FfiPtrExt;
 #[cfg(feature = "experimental-inspect")]

--- a/src/conversions/std/set.rs
+++ b/src/conversions/std/set.rs
@@ -1,6 +1,6 @@
-use alloc::collections;
 use alloc::vec::Vec;
 use core::{cmp, hash};
+use std::collections;
 
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_subscript, PyStaticExpr};
@@ -14,8 +14,7 @@ use crate::{
     Borrowed, Bound, FromPyObject, PyAny, PyErr, Python,
 };
 
-#[cfg(wip_feature_std)]
-impl<'py, K, S> IntoPyObject<'py> for std::collections::HashSet<K, S>
+impl<'py, K, S> IntoPyObject<'py> for collections::HashSet<K, S>
 where
     K: IntoPyObject<'py> + Eq + hash::Hash,
     S: hash::BuildHasher + Default,
@@ -32,8 +31,7 @@ where
     }
 }
 
-#[cfg(wip_feature_std)]
-impl<'a, 'py, K, H> IntoPyObject<'py> for &'a std::collections::HashSet<K, H>
+impl<'a, 'py, K, H> IntoPyObject<'py> for &'a collections::HashSet<K, H>
 where
     &'a K: IntoPyObject<'py> + Eq + hash::Hash,
     H: hash::BuildHasher,
@@ -49,8 +47,7 @@ where
     }
 }
 
-#[cfg(wip_feature_std)]
-impl<'py, K, S> FromPyObject<'_, 'py> for std::collections::HashSet<K, S>
+impl<'py, K, S> FromPyObject<'_, 'py> for collections::HashSet<K, S>
 where
     K: FromPyObjectOwned<'py> + cmp::Eq + hash::Hash,
     S: hash::BuildHasher + Default,
@@ -155,13 +152,10 @@ mod tests {
     use crate::types::{any::PyAnyMethods, PyFrozenSet, PySet};
     use crate::{IntoPyObject, Python};
     use alloc::collections::BTreeSet;
-    #[cfg(wip_feature_std)]
     use std::collections::HashSet;
 
     #[test]
-    #[cfg_attr(not(wip_feature_std), ignore)]
     fn test_extract_hashset() {
-        #[cfg(wip_feature_std)]
         Python::attach(|py| {
             let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
             let hash_set: HashSet<usize> = set.extract().unwrap();
@@ -190,15 +184,12 @@ mod tests {
     fn test_set_into_pyobject() {
         Python::attach(|py| {
             let bt: BTreeSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();
-            #[cfg(wip_feature_std)]
             let hs: HashSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();
 
             let bto = (&bt).into_pyobject(py).unwrap();
-            #[cfg(wip_feature_std)]
             let hso = (&hs).into_pyobject(py).unwrap();
 
             assert_eq!(bt, bto.extract().unwrap());
-            #[cfg(wip_feature_std)]
             assert_eq!(hs, hso.extract().unwrap());
         });
     }

--- a/src/conversions/std/time.rs
+++ b/src/conversions/std/time.rs
@@ -1,5 +1,3 @@
-#![cfg(wip_feature_std)]
-
 use crate::conversion::IntoPyObject;
 use crate::exceptions::{PyOverflowError, PyValueError};
 #[cfg(feature = "experimental-inspect")]

--- a/src/err/impls.rs
+++ b/src/err/impls.rs
@@ -184,11 +184,8 @@ impl_to_pyerr!(core::str::ParseBoolError, exceptions::PyValueError);
 impl_to_pyerr!(alloc::ffi::NulError, exceptions::PyValueError);
 impl_to_pyerr!(core::net::AddrParseError, exceptions::PyValueError);
 impl_to_pyerr!(core::time::TryFromFloatSecsError, exceptions::PyValueError);
-#[cfg(wip_feature_std)]
 impl_to_pyerr!(std::time::SystemTimeError, exceptions::PyValueError);
-#[cfg(wip_feature_std)]
 impl_to_pyerr!(std::path::StripPrefixError, exceptions::PyValueError);
-#[cfg(wip_feature_std)]
 impl_to_pyerr!(std::env::JoinPathsError, exceptions::PyValueError);
 impl_to_pyerr!(core::char::ParseCharError, exceptions::PyValueError);
 impl_to_pyerr!(core::char::CharTryFromError, exceptions::PyValueError);

--- a/src/sealed.rs
+++ b/src/sealed.rs
@@ -65,9 +65,7 @@ impl Sealed for ModuleDef {}
 impl<T: crate::type_object::PyTypeInfo> Sealed for PyNativeTypeInitializer<T> {}
 impl<T: crate::pyclass::PyClass> Sealed for PyClassInitializer<T> {}
 
-#[cfg(wip_feature_std)]
 impl Sealed for std::sync::Once {}
-#[cfg(wip_feature_std)]
 impl<T> Sealed for std::sync::Mutex<T> {}
 #[cfg(feature = "lock_api")]
 impl<R, T> Sealed for lock_api::Mutex<R, T> {}

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -393,7 +393,6 @@ impl OnceExt for parking_lot::Once {
     }
 }
 
-#[cfg(wip_feature_std)]
 impl<T> OnceLockExt<T> for std::sync::OnceLock<T> {
     fn get_or_init_py_attached<F>(&self, py: Python<'_>, f: F) -> &T
     where
@@ -405,7 +404,6 @@ impl<T> OnceLockExt<T> for std::sync::OnceLock<T> {
     }
 }
 
-#[cfg(wip_feature_std)]
 impl<T> MutexExt<T> for std::sync::Mutex<T> {
     type LockResult<'a>
         = std::sync::LockResult<std::sync::MutexGuard<'a, T>>
@@ -524,7 +522,6 @@ where
     }
 }
 
-#[cfg(wip_feature_std)]
 impl<T> RwLockExt<T> for std::sync::RwLock<T> {
     type ReadLockResult<'a>
         = std::sync::LockResult<std::sync::RwLockReadGuard<'a, T>>
@@ -688,7 +685,6 @@ where
     });
 }
 
-#[cfg(wip_feature_std)]
 #[cold]
 fn init_once_lock_py_attached<'a, F, T>(
     lock: &'a std::sync::OnceLock<T>,
@@ -715,13 +711,11 @@ where
 
 mod once_lock_ext_sealed {
     pub trait Sealed {}
-    #[cfg(wip_feature_std)]
     impl<T> Sealed for std::sync::OnceLock<T> {}
 }
 
 mod rwlock_ext_sealed {
     pub trait Sealed {}
-    #[cfg(wip_feature_std)]
     impl<T> Sealed for std::sync::RwLock<T> {}
     #[cfg(feature = "lock_api")]
     impl<R, T> Sealed for lock_api::RwLock<R, T> {}

--- a/src/types/bytes.rs
+++ b/src/types/bytes.rs
@@ -12,7 +12,6 @@ use crate::{
 use core::ops::Index;
 use core::slice::SliceIndex;
 use core::str;
-#[cfg(wip_feature_std)]
 use std::io::Write;
 
 /// Represents a Python `bytes` object.


### PR DESCRIPTION
Reverts PyO3/pyo3#6248

Some of these changes do not compile for `no_std`. Some of them can be added back after CI checks for it. #6300 