### PR TITLE
ci: turn off walltime benchmarks

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -16,16 +16,7 @@ env:
 
 jobs:
   benchmarks:
-    name: benchmarks/${{ matrix.mode }}
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - mode: simulation
-            session: codspeed
-          - mode: walltime
-            session: codspeed-walltime
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: astral-sh/setup-uv@v7
@@ -58,6 +49,6 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v5.0.3
         with:
-          run: uvx nox -s ${{ matrix.session }}
+          run: uvx nox -s codspeed
           token: ${{ secrets.CODSPEED_TOKEN }}
           mode: ${{ matrix.mode }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -328,14 +328,6 @@ def codspeed(session: nox.Session) -> bool:
     _run(session, "pytest", "--codspeed", external=True)
 
 
-@nox.session(name="codspeed-walltime")
-def codspeed_walltime(session: nox.Session) -> bool:
-    bench = "bench_attach_scaling"
-    os.chdir(PYO3_DIR / "pyo3-benches")
-    _run_cargo(session, "codspeed", "build", "--bench", bench)
-    _run_cargo(session, "codspeed", "run", "--bench", bench)
-
-
 @nox.session(name="clippy-all", venv_backend="none")
 def clippy_all(session: nox.Session) -> None:
     success = True

--- a/pyo3-benches/benches/bench_attach_scaling.rs
+++ b/pyo3-benches/benches/bench_attach_scaling.rs
@@ -102,6 +102,7 @@ mod scaling {
 
 fn criterion_benchmark(_c: &mut Criterion) {
     #[cfg(Py_GIL_DISABLED)]
+    #[cfg(not(codspeed))]
     scaling::benchmarks(_c);
 }
 


### PR DESCRIPTION
#6200 added walltime codspeed benchmarks, but we don't have a stable execution environment, so continuous benchmarking in CI will be super noisy. Let's just turn those off.