### PR TITLE
ci: fix benchmark workflow

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -51,4 +51,4 @@ jobs:
         with:
           run: uvx nox -s codspeed
           token: ${{ secrets.CODSPEED_TOKEN }}
-          mode: ${{ matrix.mode }}
+          mode: simulation


### PR DESCRIPTION
The workflow for benchmarks sets the benchmark mode to a matrix variable that was removed in a previous PR. This caused unrelated PRs to break. https://github.com/PyO3/pyo3/actions/runs/31920484961/job/95099496460?pr=6300#step:8:301