### PR TITLE
ci: fix bugs to feature combinations in noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1716,7 +1716,7 @@ def check_feature_powerset(session: nox.Session):
             "--all-targets",
         ]
         if not _is_no_std():
-            args.push(f"--features={comma_join(_REQUIRED_FOR_NO_STD)}")
+            args.append(f"--features={comma_join(_REQUIRED_FOR_NO_STD)}")
         _run_cargo(*args, env=env)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,11 +18,7 @@ from functools import lru_cache
 from glob import glob
 from pathlib import Path
 from shlex import quote
-from typing import (
-    Any,
-    Callable,
-    Literal,
-)
+from typing import Any, Literal, Protocol
 
 import nox.command
 
@@ -278,10 +274,11 @@ def _clippy(
     *,
     env: dict[str, str] | None = None,
     version: tuple[int, int] | None = None,
+    free_threaded: bool = FREE_THREADED_BUILD,
 ) -> bool:
     success = True
     env = env or os.environ
-    for feature_set in _get_feature_sets(version):
+    for feature_set in _get_feature_sets(version=version, free_threaded=free_threaded):
         try:
             _run_cargo(
                 session,
@@ -342,10 +339,12 @@ def clippy_all(session: nox.Session) -> None:
     success = True
 
     def _clippy_with_config(
-        env: dict[str, str], version: tuple[int, int] | None
+        *, env: dict[str, str], version: tuple[int, int] | None, free_threaded: bool
     ) -> None:
         nonlocal success
-        success &= _clippy(session, env=env, version=version)
+        success &= _clippy(
+            session, env=env, version=version, free_threaded=free_threaded
+        )
 
     _for_all_version_configs(session, _clippy_with_config)
     success &= _clippy_additional_workspaces(session)
@@ -358,9 +357,13 @@ def clippy_all(session: nox.Session) -> None:
 def check_all(session: nox.Session) -> None:
     success = True
 
-    def _check(env: dict[str, str], version: tuple[int, int]) -> None:
+    def _check(
+        *, env: dict[str, str], version: tuple[int, int] | None, free_threaded: bool
+    ) -> None:
         nonlocal success
-        for feature_set in _get_feature_sets():
+        for feature_set in _get_feature_sets(
+            version=version, free_threaded=free_threaded
+        ):
             try:
                 _run_cargo(
                     session,
@@ -1712,7 +1715,7 @@ def check_feature_powerset(session: nox.Session):
             "check",
             "--all-targets",
         ]
-        if not _is_no_std:
+        if not _is_no_std():
             args.push(f"--features={comma_join(_REQUIRED_FOR_NO_STD)}")
         _run_cargo(*args, env=env)
 
@@ -1826,7 +1829,9 @@ def _get_rust_default_target() -> str:
 
 @lru_cache
 def _get_feature_sets(
+    *,
     version: tuple[int, int] | None = None,
+    free_threaded: bool = FREE_THREADED_BUILD,
 ) -> tuple[str | None, ...]:
     """Returns feature sets to use for Rust jobs"""
     if version is None:
@@ -1845,7 +1850,7 @@ def _get_feature_sets(
     if is_rust_nightly():
         features += ",nightly"
 
-    if FREE_THREADED_BUILD:
+    if free_threaded:
         if version >= (3, 15):
             return (
                 required,
@@ -1992,9 +1997,13 @@ def _run_cargo_set_package_version(
     _run(session, *command, external=True)
 
 
-def _for_all_version_configs(
-    session: nox.Session, job: Callable[[dict[str, str]], None]
-) -> None:
+class Job(Protocol):
+    def __call__(
+        self, *, env: dict[str, str], version: tuple[int, int], free_threaded: bool
+    ) -> None: ...
+
+
+def _for_all_version_configs(session: nox.Session, job: Job) -> None:
     env = os.environ.copy()
     with _config_file() as config_file:
         env["PYO3_CONFIG_FILE"] = config_file.name
@@ -2002,8 +2011,9 @@ def _for_all_version_configs(
         def _job_with_config(implementation, version):
             session.log(f"{implementation} {version}")
             config_file.set(implementation, version)
-            major_minor = tuple(map(int, version.strip("t").split(".")))
-            job(env, major_minor)
+            major_minor = tuple[int, int](map(int, version.strip("t").split(".")))
+            free_threaded = version.endswith("t")
+            job(env=env, version=major_minor, free_threaded=free_threaded)
 
         for version in PY_VERSIONS:
             _job_with_config("CPython", version)


### PR DESCRIPTION
Fixes two bugs to feature configurations in `noxfile.py`:
- `clippy-all` and `check-all` would skip `abi3` checks on relevant versions if the top-level `nox` process was running a free-threaded Python; I feed a `free_threaded` bool to `get_feature_sets` to resolve
- `check-feature-powerset` was incorrectly truth-testing `_is_no_std` function rather than `_is_no_std()` output