### PR TITLE
refactor: allow r-a to look inside `extern_libpython` macro

### DIFF
--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -431,7 +431,9 @@ pub const fn _cstr_from_utf8_with_nul_checked(s: &str) -> &core::ffi::CStr {
 
 // Macros for declaring `extern` blocks that link against libpython.
 // See `impl_/macros.rs` for the implementation.
-include!("impl_/macros.rs");
+#[path = "impl_/macros.rs"]
+#[macro_use]
+mod macros;
 
 pub mod compat;
 mod impl_;

--- a/pyo3-ffi/src/lib.rs
+++ b/pyo3-ffi/src/lib.rs
@@ -430,7 +430,6 @@ pub const fn _cstr_from_utf8_with_nul_checked(s: &str) -> &core::ffi::CStr {
 }
 
 // Macros for declaring `extern` blocks that link against libpython.
-// See `impl_/macros.rs` for the implementation.
 #[path = "impl_/macros.rs"]
 #[macro_use]
 mod macros;


### PR DESCRIPTION
Places the `extern_libpython` macro inside a module and exports the macros to the crate instead of simply including the file into `lib.rs`. I think this should be functionally equivalent.

At least for me that fixes IDE (rust-analyzer) features such a "go to definition", "find symbol" or "find references", which were not working previously within `extern_libpython`. I don't think there is anything to test here, but maybe someone else can verify that this makes a difference outside of my dev environment.