### PR TITLE
internal: remove usages of std from generated code

### DIFF
--- a/pyo3-macros-backend/src/frompyobject.rs
+++ b/pyo3-macros-backend/src/frompyobject.rs
@@ -73,8 +73,8 @@ impl<'a> Enum<'a> {
                 }();
 
                 match maybe_ret {
-                    ok @ ::std::result::Result::Ok(_) => return ok,
-                    ::std::result::Result::Err(err) => err
+                    ok @ ::core::result::Result::Ok(_) => return ok,
+                    ::core::result::Result::Err(err) => err
                 }
             });
 
@@ -87,7 +87,7 @@ impl<'a> Enum<'a> {
             let errors = [
                 #(#var_extracts),*
             ];
-            ::std::result::Result::Err(
+            ::core::result::Result::Err(
                 #pyo3_path::impl_::frompyobject::failed_to_extract_enum(
                     obj.py(),
                     #ty_name,
@@ -377,8 +377,8 @@ impl<'a> Container<'a> {
 
         quote!(
             match #pyo3_path::types::PyAnyMethods::extract(obj) {
-                ::std::result::Result::Ok((#(#field_idents),*)) => ::std::result::Result::Ok(#self_ty(#(#fields),*)),
-                ::std::result::Result::Err(err) => ::std::result::Result::Err(err),
+                ::core::result::Result::Ok((#(#field_idents),*)) => ::core::result::Result::Ok(#self_ty(#(#fields),*)),
+                ::core::result::Result::Err(err) => ::core::result::Result::Err(err),
             }
         )
     }
@@ -436,9 +436,9 @@ impl<'a> Container<'a> {
                 let default_expr = if let Some(default_expr) = &default.value {
                     default_expr.to_token_stream()
                 } else {
-                    quote!(::std::default::Default::default())
+                    quote!(::core::default::Default::default())
                 };
-                quote!(if let ::std::result::Result::Ok(value) = #getter {
+                quote!(if let ::core::result::Result::Ok(value) = #getter {
                     #extractor
                 } else {
                     #default_expr
@@ -453,7 +453,7 @@ impl<'a> Container<'a> {
             fields.push(quote!(#ident: #extracted));
         }
 
-        quote!(::std::result::Result::Ok(#self_ty{#fields}))
+        quote!(::core::result::Result::Ok(#self_ty{#fields}))
     }
 
     #[cfg(feature = "experimental-inspect")]
@@ -588,7 +588,7 @@ pub fn build_derive_from_pyobject(tokens: &DeriveInput) -> Result<TokenStream> {
         #[automatically_derived]
         impl #impl_generics #pyo3_path::FromPyObject<'_, #lt_param> for #ident #ty_generics #where_clause {
             type Error = #pyo3_path::PyErr;
-            fn extract(obj: #pyo3_path::Borrowed<'_, #lt_param, #pyo3_path::PyAny>) -> ::std::result::Result<Self, #pyo3_path::PyErr> {
+            fn extract(obj: #pyo3_path::Borrowed<'_, #lt_param, #pyo3_path::PyAny>) -> ::core::result::Result<Self, #pyo3_path::PyErr> {
                 let obj: &#pyo3_path::Bound<'_, _> = &*obj;
                 #derives
             }

--- a/pyo3-macros-backend/src/intopyobject.rs
+++ b/pyo3-macros-backend/src/intopyobject.rs
@@ -274,12 +274,12 @@ impl<'a, const REF: bool> Container<'a, REF> {
 
                 if let Some(expr_path) = f.into_py_with.as_ref().map(|i|&i.value) {
                     let cow = if REF {
-                        quote!(::std::borrow::Cow::Borrowed(#value))
+                        quote!(#pyo3_path::impl_::alloc::borrow::Cow::Borrowed(#value))
                     } else {
-                        quote!(::std::borrow::Cow::Owned(#value))
+                        quote!(#pyo3_path::impl_::alloc::borrow::Cow::Owned(#value))
                     };
                     quote! {
-                        let into_py_with: fn(::std::borrow::Cow<'_, _>, #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<#pyo3_path::Bound<'py, #pyo3_path::PyAny>> = #expr_path;
+                        let into_py_with: fn(#pyo3_path::impl_::alloc::borrow::Cow<'_, _>, #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<#pyo3_path::Bound<'py, #pyo3_path::PyAny>> = #expr_path;
                         #pyo3_path::types::PyDictMethods::set_item(&dict, #key, into_py_with(#cow, py)?)?;
                     }
                 } else {
@@ -300,7 +300,7 @@ impl<'a, const REF: bool> Container<'a, REF> {
                 #unpack
                 let dict = #pyo3_path::types::PyDict::new(py);
                 #setter
-                ::std::result::Result::Ok::<_, Self::Error>(dict)
+                ::core::result::Result::Ok::<_, Self::Error>(dict)
             },
         }
     }
@@ -326,13 +326,13 @@ impl<'a, const REF: bool> Container<'a, REF> {
 
                 if let Some(expr_path) = f.into_py_with.as_ref().map(|i|&i.value) {
                     let cow = if REF {
-                        quote!(::std::borrow::Cow::Borrowed(#value))
+                        quote!(#pyo3_path::impl_::alloc::borrow::Cow::Borrowed(#value))
                     } else {
-                        quote!(::std::borrow::Cow::Owned(#value))
+                        quote!(#pyo3_path::impl_::alloc::borrow::Cow::Owned(#value))
                     };
                     quote_spanned! { ty.span() =>
                         {
-                            let into_py_with: fn(::std::borrow::Cow<'_, _>, #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<#pyo3_path::Bound<'py, #pyo3_path::PyAny>> = #expr_path;
+                            let into_py_with: fn(#pyo3_path::impl_::alloc::borrow::Cow<'_, _>, #pyo3_path::Python<'py>) -> #pyo3_path::PyResult<#pyo3_path::Bound<'py, #pyo3_path::PyAny>> = #expr_path;
                             into_py_with(#cow, py)?
                         },
                     }
@@ -446,7 +446,7 @@ impl<'a, const REF: bool> Enum<'a, REF> {
                         {#body}
                             .map(#pyo3_path::BoundObject::into_any)
                             .map(#pyo3_path::BoundObject::into_bound)
-                            .map_err(::std::convert::Into::<#pyo3_path::PyErr>::into)
+                            .map_err(::core::convert::Into::<#pyo3_path::PyErr>::into)
                     }
                 }
             })
@@ -611,7 +611,7 @@ pub fn build_derive_into_pyobject<const REF: bool>(tokens: &DeriveInput) -> Resu
             type Error = #error;
             #output_type
 
-            fn into_pyobject(self, py: #pyo3_path::Python<#lt_param>) -> ::std::result::Result<
+            fn into_pyobject(self, py: #pyo3_path::Python<#lt_param>) -> ::core::result::Result<
                 <Self as #pyo3_path::conversion::IntoPyObject<#lt_param>>::Output,
                 <Self as #pyo3_path::conversion::IntoPyObject<#lt_param>>::Error,
             > {

--- a/pyo3-macros-backend/src/method.rs
+++ b/pyo3-macros-backend/src/method.rs
@@ -313,7 +313,7 @@ impl FnType {
                 };
                 let ret = quote_spanned! { *span =>
                     #[allow(clippy::useless_conversion, reason = "#[classmethod] accepts anything which implements `From<&Bound<PyType>>`")]
-                    ::std::convert::Into::into(
+                    ::core::convert::Into::into(
                         #pyo3_path::Bound::ref_from_ptr(#py, &#class_method_receiver)
                             .cast_unchecked::<#pyo3_path::types::PyType>()
                     )
@@ -326,7 +326,7 @@ impl FnType {
                 let pyo3_path = pyo3_path.to_tokens_spanned(*span);
                 let ret = quote_spanned! { *span =>
                     #[allow(clippy::useless_conversion, reason = "`pass_module` accepts anything which implements `From<&Bound<PyModule>>`")]
-                    ::std::convert::Into::into(
+                    ::core::convert::Into::into(
                         #pyo3_path::Bound::ref_from_ptr(#py, &#slf.cast())
                             .cast_unchecked::<#pyo3_path::types::PyModule>()
                     )
@@ -414,8 +414,8 @@ impl ExtractErrorMode {
             ExtractErrorMode::Raise => quote! { #extract? },
             ExtractErrorMode::NotImplemented => quote! {
                 match #extract {
-                    ::std::result::Result::Ok(value) => value,
-                    ::std::result::Result::Err(_) => { return #pyo3_path::impl_::callback::convert(py, py.NotImplemented()); },
+                    ::core::result::Result::Ok(value) => value,
+                    ::core::result::Result::Err(_) => { return #pyo3_path::impl_::callback::convert(py, py.NotImplemented()); },
                 }
             },
         }

--- a/pyo3-macros-backend/src/module.rs
+++ b/pyo3-macros-backend/src/module.rs
@@ -428,7 +428,7 @@ pub fn pymodule_module_impl(
                 )*
 
                 #pymodule_init
-                ::std::result::Result::Ok(())
+                ::core::result::Result::Ok(())
             }
         }
     ))
@@ -484,7 +484,7 @@ pub fn pymodule_function_impl(
     if function.sig.inputs.len() == 2 {
         module_args.push(quote!(module.py()));
     }
-    module_args.push(quote!(::std::convert::Into::into(module)));
+    module_args.push(quote!(::core::convert::Into::into(module)));
 
     Ok(quote! {
         #[doc(hidden)]
@@ -528,7 +528,7 @@ fn module_initialization(
 
     let mut result = quote! {
         #[doc(hidden)]
-        pub static __PYO3_NAME: &'static ::std::ffi::CStr = #pyo3_name;
+        pub static __PYO3_NAME: &'static ::core::ffi::CStr = #pyo3_name;
 
         // This structure exists for `fn` modules declared within `fn` bodies, where due to the hidden
         // module (used for importing) the `fn` to initialize the module cannot be seen from the #module_def
@@ -540,11 +540,11 @@ fn module_initialization(
         pub static _PYO3_DEF: #pyo3_path::impl_::pymodule::ModuleDef = {
             use #pyo3_path::impl_::pymodule as impl_;
 
-            unsafe extern "C" fn __pyo3_module_exec(module: *mut #pyo3_path::ffi::PyObject) -> ::std::ffi::c_int {
+            unsafe extern "C" fn __pyo3_module_exec(module: *mut #pyo3_path::ffi::PyObject) -> ::core::ffi::c_int {
                 #pyo3_path::impl_::trampoline::module_exec(module, #module_exec)
             }
 
-            static DOC: &'static ::std::ffi::CStr = #doc;
+            static DOC: &'static ::core::ffi::CStr = #doc;
             static SLOTS: impl_::PrimaryModuleSlots = impl_::PyModuleSlotsBuilder::new()
                 .with_mod_exec(__pyo3_module_exec)
                 .with_abi_info()

--- a/pyo3-macros-backend/src/params.rs
+++ b/pyo3-macros-backend/src/params.rs
@@ -138,9 +138,9 @@ pub fn impl_arg_params(
     };
 
     let cls_name = if let Some(cls) = self_ {
-        quote! { ::std::option::Option::Some(<#cls as #pyo3_path::PyClass>::NAME) }
+        quote! { ::core::option::Option::Some(<#cls as #pyo3_path::PyClass>::NAME) }
     } else {
-        quote! { ::std::option::Option::None }
+        quote! { ::core::option::Option::None }
     };
     let python_name = &spec.python_name;
 
@@ -180,7 +180,7 @@ pub fn impl_arg_params(
                         #required_positional_parameters,
                         &[#(#keyword_only_parameters),*],
                     );
-                let mut #args_array = [::std::option::Option::None; #num_params];
+                let mut #args_array = [::core::option::Option::None; #num_params];
                 let (_args, _kwargs) = #extract_expression;
                 #from_py_with
         },
@@ -226,7 +226,7 @@ fn impl_arg_param(
                     _kwargs.as_ref().map(|d| d.as_any().as_borrowed()),
                     &mut #holder,
                     #name_str,
-                    || ::std::option::Option::None
+                    || ::core::option::Option::None
                 )?
             }
         }

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -934,6 +934,7 @@ fn implement_py_formatting(
     ctx: &Ctx,
     option: &StrFormatterAttribute,
 ) -> (ImplItemFn, MethodAndSlotDef) {
+    let pyo3_path = &ctx.pyo3_path;
     let mut fmt_impl = match &option.value {
         Some(opt) => {
             let fmt = &opt.fmt;
@@ -943,16 +944,16 @@ fn implement_py_formatting(
                 .map(|member| quote! {self.#member})
                 .collect::<Vec<TokenStream>>();
             let fmt_impl: ImplItemFn = syn::parse_quote! {
-                fn __pyo3__generated____str__(&self) -> ::std::string::String {
-                    ::std::format!(#fmt, #(#args, )*)
+                fn __pyo3__generated____str__(&self) -> #pyo3_path::impl_::alloc::string::String {
+                    #pyo3_path::impl_::alloc::format!(#fmt, #(#args, )*)
                 }
             };
             fmt_impl
         }
         None => {
             let fmt_impl: syn::ImplItemFn = syn::parse_quote! {
-                fn __pyo3__generated____str__(&self) -> ::std::string::String {
-                    ::std::format!("{}", &self)
+                fn __pyo3__generated____str__(&self) -> #pyo3_path::impl_::alloc::string::String {
+                    #pyo3_path::impl_::alloc::format!("{}", &self)
                 }
             };
             fmt_impl
@@ -967,7 +968,7 @@ fn implement_py_formatting(
         FunctionIntrospectionData {
             names: &["__str__"],
             arguments: Vec::new(),
-            returns: parse_quote! { ::std::string::String },
+            returns: parse_quote! { #pyo3_path::impl_::alloc::string::String },
             is_returning_not_implemented_on_extraction_error: false,
         },
         ctx,
@@ -1157,7 +1158,7 @@ fn impl_simple_enum(
                         <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::lazy_type_object().get_or_try_init(py)?;
                         SINGLETON[idx].get_or_try_init(py, || {
                             #pyo3_path::Py::new(py, self)
-                        }).map(|obj| ::std::clone::Clone::clone(obj.bind(py)))
+                        }).map(|obj| ::core::clone::Clone::clone(obj.bind(py)))
                     }
                 }
             }
@@ -1256,7 +1257,7 @@ fn impl_complex_enum(
                 let variant_cls = gen_complex_enum_variant_class_ident(cls, variant.get_ident());
                 quote! {
                     #cls::#variant_ident { .. } => {
-                        let pyclass_init = <#pyo3_path::PyClassInitializer<Self> as ::std::convert::From<Self>>::from(self).add_subclass(#variant_cls);
+                        let pyclass_init = <#pyo3_path::PyClassInitializer<Self> as ::core::convert::From<Self>>::from(self).add_subclass(#variant_cls);
                         unsafe { #pyo3_path::Bound::new(py, pyclass_init).map(|b| b.cast_into_unchecked()) }
                     }
                 }
@@ -1513,7 +1514,7 @@ fn impl_complex_enum_struct_variant_cls(
             #[allow(clippy::too_many_arguments)]
             fn __pymethod_constructor__(py: #pyo3_path::Python<'_>, #(#fields_with_types,)*) -> #pyo3_path::PyClassInitializer<#variant_cls> {
                 let base_value = #enum_name::#variant_ident { #(#field_names,)* };
-                <#pyo3_path::PyClassInitializer<#enum_name> as ::std::convert::From<#enum_name>>::from(base_value).add_subclass(#variant_cls)
+                <#pyo3_path::PyClassInitializer<#enum_name> as ::core::convert::From<#enum_name>>::from(base_value).add_subclass(#variant_cls)
             }
 
             #match_args_const_impl
@@ -1597,7 +1598,7 @@ fn impl_complex_enum_tuple_variant_len(
 
     let mut len_method_impl: syn::ImplItemFn = parse_quote! {
         fn __len__(slf: #pyo3_path::PyClassGuard<'_, Self>) -> #pyo3_path::PyResult<usize> {
-            ::std::result::Result::Ok(#num_fields)
+            ::core::result::Result::Ok(#num_fields)
         }
     };
 
@@ -1609,7 +1610,7 @@ fn impl_complex_enum_tuple_variant_len(
         FunctionIntrospectionData {
             names: &["__len__"],
             arguments: Vec::new(),
-            returns: parse_quote! { ::std::primitive::usize },
+            returns: parse_quote! { ::core::primitive::usize },
             is_returning_not_implemented_on_extraction_error: false,
         },
         ctx,
@@ -1639,7 +1640,7 @@ fn impl_complex_enum_tuple_variant_getitem(
         fn __getitem__(slf: #pyo3_path::PyClassGuard<'_, Self>, py: #pyo3_path::Python<'_>, idx: usize) -> #pyo3_path::PyResult< #pyo3_path::Py<#pyo3_path::PyAny>> {
             match idx {
                 #( #match_arms, )*
-                _ => ::std::result::Result::Err(#pyo3_path::exceptions::PyIndexError::new_err("tuple index out of range")),
+                _ => ::core::result::Result::Err(#pyo3_path::exceptions::PyIndexError::new_err("tuple index out of range")),
             }
         }
     };
@@ -1653,7 +1654,7 @@ fn impl_complex_enum_tuple_variant_getitem(
             names: &["__getitem__"],
             arguments: vec![FnArg::Regular(RegularArg {
                 name: Cow::Owned(Ident::new("key", variant_cls.span())),
-                ty: &parse_quote! { ::std::primitive::usize },
+                ty: &parse_quote! { ::core::primitive::usize },
                 from_py_with: None,
                 default_value: None,
                 option_wrapped_type: None,
@@ -1728,7 +1729,7 @@ fn impl_complex_enum_tuple_variant_cls(
             #[allow(clippy::too_many_arguments)]
             fn __pymethod_constructor__(py: #pyo3_path::Python<'_>, #(#field_names : #field_types,)*) -> #pyo3_path::PyClassInitializer<#variant_cls> {
                 let base_value = #enum_name::#variant_ident ( #(#field_names,)* );
-                <#pyo3_path::PyClassInitializer<#enum_name> as ::std::convert::From<#enum_name>>::from(base_value).add_subclass(#variant_cls)
+                <#pyo3_path::PyClassInitializer<#enum_name> as ::core::convert::From<#enum_name>>::from(base_value).add_subclass(#variant_cls)
             }
 
             #len_method_impl
@@ -1957,7 +1958,7 @@ pub fn gen_complex_enum_variant_attr(
     let variant_cls = gen_complex_enum_variant_class_ident(cls, member);
     let associated_method = quote! {
         fn #wrapper_ident(py: #pyo3_path::Python<'_>) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
-            ::std::result::Result::Ok(py.get_type::<#variant_cls>().into_any().unbind())
+            ::core::result::Result::Ok(py.get_type::<#variant_cls>().into_any().unbind())
         }
     };
 
@@ -2300,7 +2301,7 @@ fn impl_pytypeinfo(cls: &Ident, attr: &PyClassArgs, ctx: &Ctx) -> TokenStream {
         unsafe impl #pyo3_path::type_object::PyTypeInfo for #cls {
 
             const NAME: &str = <Self as #pyo3_path::PyClass>::NAME;
-            const MODULE: ::std::option::Option<&str> = <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::MODULE;
+            const MODULE: ::core::option::Option<&str> = <Self as #pyo3_path::impl_::pyclass::PyClassImpl>::MODULE;
 
             #type_hint
 
@@ -2356,7 +2357,7 @@ fn pyclass_richcmp_arms(
                  },
             }
         })
-        .unwrap_or_else(|| quote! { _ => ::std::result::Result::Ok(py.NotImplemented()) });
+        .unwrap_or_else(|| quote! { _ => ::core::result::Result::Ok(py.NotImplemented()) });
 
     Ok(quote! {
         #eq_arms
@@ -2384,7 +2385,7 @@ fn pyclass_richcmp_simple_enum(
     let eq = options.eq.map(|eq| {
         quote_spanned! { eq.span() =>
             let self_val = self;
-            if let ::std::result::Result::Ok(other) = #pyo3_path::types::PyAnyMethods::extract::<#pyo3_path::PyClassGuard<'_, Self>>(other) {
+            if let ::core::result::Result::Ok(other) = #pyo3_path::types::PyAnyMethods::extract::<#pyo3_path::PyClassGuard<'_, Self>>(other) {
                 let other = &*other;
                 return match op {
                     #arms
@@ -2396,7 +2397,7 @@ fn pyclass_richcmp_simple_enum(
     let eq_int = options.eq_int.map(|eq_int| {
         quote_spanned! { eq_int.span() =>
             let self_val = self.__pyo3__int__();
-            if let ::std::result::Result::Ok(other) = #pyo3_path::types::PyAnyMethods::extract::<#repr_type>(other).or_else(|_| {
+            if let ::core::result::Result::Ok(other) = #pyo3_path::types::PyAnyMethods::extract::<#repr_type>(other).or_else(|_| {
                 #pyo3_path::types::PyAnyMethods::extract::<#pyo3_path::PyClassGuard<'_, Self>>(other).map(|o| o.__pyo3__int__())
             }) {
                 return match op {
@@ -2417,7 +2418,7 @@ fn pyclass_richcmp_simple_enum(
 
             #eq_int
 
-            ::std::result::Result::Ok(py.NotImplemented())
+            ::core::result::Result::Ok(py.NotImplemented())
         }
     };
     #[cfg(feature = "experimental-inspect")]
@@ -2434,7 +2435,7 @@ fn pyclass_richcmp_simple_enum(
             option_wrapped_type: None,
             annotation: None,
         })],
-        returns: parse_quote!(::std::primitive::bool),
+        returns: parse_quote!(::core::primitive::bool),
         is_returning_not_implemented_on_extraction_error: true,
     };
     let richcmp_slot = if options.eq.is_some() {
@@ -2480,13 +2481,13 @@ fn pyclass_richcmp(
                 op: #pyo3_path::pyclass::CompareOp
             ) -> #pyo3_path::PyResult<#pyo3_path::Py<#pyo3_path::PyAny>> {
                 let self_val = self;
-                if let ::std::result::Result::Ok(other) = #pyo3_path::types::PyAnyMethods::extract::<#pyo3_path::PyClassGuard<'_, Self>>(other) {
+                if let ::core::result::Result::Ok(other) = #pyo3_path::types::PyAnyMethods::extract::<#pyo3_path::PyClassGuard<'_, Self>>(other) {
                     let other = &*other;
                     match op {
                         #arms
                     }
                 } else {
-                    ::std::result::Result::Ok(py.NotImplemented())
+                    ::core::result::Result::Ok(py.NotImplemented())
                 }
             }
         };
@@ -2511,7 +2512,7 @@ fn pyclass_richcmp(
                     option_wrapped_type: None,
                     annotation: None,
                 })],
-                returns: parse_quote! { ::std::primitive::bool },
+                returns: parse_quote! { ::core::primitive::bool },
                 is_returning_not_implemented_on_extraction_error: true,
             },
             ctx,
@@ -2537,9 +2538,9 @@ fn pyclass_hash(
         Some(opt) => {
             let mut hash_impl = parse_quote_spanned! { opt.span() =>
                 fn __pyo3__generated____hash__(&self) -> u64 {
-                    let mut s = ::std::collections::hash_map::DefaultHasher::new();
-                    ::std::hash::Hash::hash(self, &mut s);
-                    ::std::hash::Hasher::finish(&s)
+                    let mut s = std::collections::hash_map::DefaultHasher::new();
+                    ::core::hash::Hash::hash(self, &mut s);
+                    ::core::hash::Hasher::finish(&s)
                 }
             };
             let hash_slot = generate_protocol_slot(
@@ -2551,7 +2552,7 @@ fn pyclass_hash(
                 FunctionIntrospectionData {
                     names: &["__hash__"],
                     arguments: Vec::new(),
-                    returns: parse_quote! { ::std::primitive::u64 },
+                    returns: parse_quote! { ::core::primitive::u64 },
                     is_returning_not_implemented_on_extraction_error: false,
                 },
                 ctx,
@@ -2785,7 +2786,7 @@ impl<'a> PyClassImplsBuilder<'a> {
         let raw_doc = match &self.doc {
             Some(doc) => {
                 let doc = doc.to_cstr_stream(ctx)?;
-                Some(quote! { const RAW_DOC: &'static ::std::ffi::CStr = #doc; })
+                Some(quote! { const RAW_DOC: &'static ::core::ffi::CStr = #doc; })
             }
             None => None,
         };
@@ -2798,7 +2799,7 @@ impl<'a> PyClassImplsBuilder<'a> {
             .module
             .as_ref()
             .map(|ModuleAttribute { value, .. }| {
-                quote! { const MODULE: ::std::option::Option<&str> = ::core::option::Option::Some(#value); }
+                quote! { const MODULE: ::core::option::Option<&str> = ::core::option::Option::Some(#value); }
             });
 
         let is_basetype = self.attr.options.subclass.is_some();
@@ -2825,8 +2826,8 @@ impl<'a> PyClassImplsBuilder<'a> {
 
         let dict_offset = if self.attr.options.dict.is_some() {
             quote! {
-                fn dict_offset() -> ::std::option::Option<#pyo3_path::impl_::pyclass::PyObjectOffset> {
-                    ::std::option::Option::Some(#pyo3_path::impl_::pyclass::dict_offset::<Self>())
+                fn dict_offset() -> ::core::option::Option<#pyo3_path::impl_::pyclass::PyObjectOffset> {
+                    ::core::option::Option::Some(#pyo3_path::impl_::pyclass::dict_offset::<Self>())
                 }
             }
         } else {
@@ -2835,8 +2836,8 @@ impl<'a> PyClassImplsBuilder<'a> {
 
         let weaklist_offset = if self.attr.options.weakref.is_some() {
             quote! {
-                fn weaklist_offset() -> ::std::option::Option<#pyo3_path::impl_::pyclass::PyObjectOffset> {
-                    ::std::option::Option::Some(#pyo3_path::impl_::pyclass::weaklist_offset::<Self>())
+                fn weaklist_offset() -> ::core::option::Option<#pyo3_path::impl_::pyclass::PyObjectOffset> {
+                    ::core::option::Option::Some(#pyo3_path::impl_::pyclass::weaklist_offset::<Self>())
                 }
             }
         } else {
@@ -2866,8 +2867,8 @@ impl<'a> PyClassImplsBuilder<'a> {
                 );
                 (
                     quote! {
-                        ::std::boxed::Box::new(
-                            ::std::iter::Iterator::map(
+                        #pyo3_path::impl_::alloc::boxed::Box::new(
+                            ::core::iter::Iterator::map(
                                 #pyo3_path::inventory::iter::<<Self as #pyo3_path::impl_::pyclass::PyClassImpl>::Inventory>(),
                                 #pyo3_path::impl_::pyclass::PyClassInventory::items
                             )
@@ -3012,13 +3013,13 @@ impl<'a> PyClassImplsBuilder<'a> {
             quote_spanned! { from_py_object.span() =>
                 impl<'a, 'py> #pyo3_path::FromPyObject<'a, 'py> for #cls
                 where
-                    Self: ::std::clone::Clone,
+                    Self: ::core::clone::Clone,
                 {
                     type Error = #pyo3_path::pyclass::PyClassGuardError<'a, 'py>;
 
                     #input_type
 
-                    fn extract(obj: #pyo3_path::Borrowed<'a, 'py, #pyo3_path::PyAny>) -> ::std::result::Result<Self,  <Self as #pyo3_path::FromPyObject<'a, 'py>>::Error> {
+                    fn extract(obj: #pyo3_path::Borrowed<'a, 'py, #pyo3_path::PyAny>) -> ::core::result::Result<Self,  <Self as #pyo3_path::FromPyObject<'a, 'py>>::Error> {
                         #pyo3_path::impl_::pyclass::extract_pyclass_with_clone(obj)
                     }
                 }
@@ -3066,7 +3067,7 @@ impl<'a> PyClassImplsBuilder<'a> {
 
                 #raw_doc
 
-                const DOC: &'static ::std::ffi::CStr = {
+                const DOC: &'static ::core::ffi::CStr = {
                     use #pyo3_path::impl_ as impl_;
                     use impl_::pyclass::Probe as _;
                     const DOC_PIECES: &'static [&'static [u8]] = impl_::pyclass::doc::PyClassDocGenerator::<
@@ -3088,7 +3089,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     &TYPE_OBJECT
                 }
 
-                fn __traverse__(&self, visit: #pyo3_path::gc::PyVisit<'_>) -> ::std::result::Result<(), #pyo3_path::gc::PyTraverseError> {
+                fn __traverse__(&self, visit: #pyo3_path::gc::PyVisit<'_>) -> ::core::result::Result<(), #pyo3_path::gc::PyTraverseError> {
                     use #pyo3_path::impl_::pyclass::{PyClassTraverse, PyClassImplCollector};
                     PyClassImplCollector::<Self>::new().__traverse__(self, visit)
                 }

--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -494,7 +494,7 @@ fn impl_traverse_slot(cls: &syn::Type, spec: &FnSpec<'_>, ctx: &Ctx) -> syn::Res
                 self,
                 this: &#cls,
                 visit: #pyo3_path::pyclass::PyVisit<'_>
-            ) -> ::std::result::Result<(), #pyo3_path::pyclass::PyTraverseError> {
+            ) -> ::core::result::Result<(), #pyo3_path::pyclass::PyTraverseError> {
                 #cls::#rust_fn_ident(this, visit)
             }
         }
@@ -534,12 +534,12 @@ fn impl_clear_slot(cls: &syn::Type, spec: &FnSpec<'_>, ctx: &Ctx) -> syn::Result
     let associated_method = quote! {
         pub unsafe extern "C" fn __pymethod___clear____(
             _slf: *mut #pyo3_path::ffi::PyObject,
-        ) -> ::std::ffi::c_int {
+        ) -> ::core::ffi::c_int {
             #pyo3_path::impl_::pymethods::_call_clear::<#cls>(_slf, |py, _slf| {
                 #holders
                 let result = #fncall;
                 let result = #pyo3_path::impl_::wrap::converter(&result).wrap(result)?;
-                ::std::result::Result::Ok(result)
+                ::core::result::Result::Ok(result)
             }, #cls::__pymethod___clear____)
         }
     };
@@ -739,7 +739,7 @@ pub fn impl_py_setter_def(
             let extract = impl_regular_arg_param(
                 arg,
                 ident,
-                quote!(::std::option::Option::Some(_value)),
+                quote!(::core::option::Option::Some(_value)),
                 &mut holders,
                 ctx,
             );
@@ -788,10 +788,10 @@ pub fn impl_py_setter_def(
         #cfg_attrs
         unsafe fn #wrapper_ident(
             py: #pyo3_path::Python<'_>,
-            _slf: ::std::ptr::NonNull<#pyo3_path::ffi::PyObject>,
-            _value: ::std::ptr::NonNull<#pyo3_path::ffi::PyObject>,
-        ) -> #pyo3_path::PyResult<::std::ffi::c_int> {
-            use ::std::convert::Into;
+            _slf: ::core::ptr::NonNull<#pyo3_path::ffi::PyObject>,
+            _value: ::core::ptr::NonNull<#pyo3_path::ffi::PyObject>,
+        ) -> #pyo3_path::PyResult<::core::ffi::c_int> {
+            use ::core::convert::Into;
             let _value = #pyo3_path::impl_::extract_argument::cast_non_null_function_argument(py, _value);
             #init_holders
             #extract
@@ -899,7 +899,7 @@ pub fn impl_py_getter_def(
                     const GENERATOR: #pyo3_path::impl_::pyclass::PyClassGetterGenerator::<
                         #cls,
                         #ty,
-                        { ::std::mem::offset_of!(#cls, #field) },
+                        { ::core::mem::offset_of!(#cls, #field) },
                         { #pyo3_path::impl_::pyclass::IsPyT::<#ty>::VALUE },
                         { #pyo3_path::impl_::pyclass::IsIntoPyObjectRef::<#ty>::VALUE },
                     > = unsafe { #pyo3_path::impl_::pyclass::PyClassGetterGenerator::new() };
@@ -929,7 +929,7 @@ pub fn impl_py_getter_def(
                 #cfg_attrs
                 unsafe fn #wrapper_ident(
                     py: #pyo3_path::Python<'_>,
-                    _slf: ::std::ptr::NonNull<#pyo3_path::ffi::PyObject>
+                    _slf: ::core::ptr::NonNull<#pyo3_path::ffi::PyObject>
                 ) -> #pyo3_path::PyResult<*mut #pyo3_path::ffi::PyObject> {
                     #init_holders
                     #warnings
@@ -976,8 +976,8 @@ pub fn impl_py_deleter_def(
     let associated_method = quote! {
         unsafe fn #wrapper_ident(
             py: #pyo3_path::Python<'_>,
-            _slf: ::std::ptr::NonNull<#pyo3_path::ffi::PyObject>,
-        ) -> #pyo3_path::PyResult<::std::ffi::c_int> {
+            _slf: ::core::ptr::NonNull<#pyo3_path::ffi::PyObject>,
+        ) -> #pyo3_path::PyResult<::core::ffi::c_int> {
             #init_holders
             #warnings
             let result = #deleter_impl;
@@ -1170,8 +1170,8 @@ impl Ty {
         let pyo3_path = pyo3_path.to_tokens_spanned(*output_span);
         match self {
             Ty::Object | Ty::MaybeNullObject => quote! { *mut #pyo3_path::ffi::PyObject },
-            Ty::NonNullObject => quote! { ::std::ptr::NonNull<#pyo3_path::ffi::PyObject> },
-            Ty::Int | Ty::CompareOp => quote! { ::std::ffi::c_int },
+            Ty::NonNullObject => quote! { ::core::ptr::NonNull<#pyo3_path::ffi::PyObject> },
+            Ty::Int | Ty::CompareOp => quote! { ::core::ffi::c_int },
             Ty::PyHashT => quote! { #pyo3_path::ffi::Py_hash_t },
             Ty::PySsizeT => quote! { #pyo3_path::ffi::Py_ssize_t },
             Ty::Void => quote! { () },
@@ -1233,7 +1233,7 @@ impl Ty {
                 let ty = arg.ty();
                 extract_error_mode.handle_error(
                     quote! {
-                            ::std::convert::TryInto::<#ty>::try_into(#ident).map_err(|e| #pyo3_path::exceptions::PyValueError::new_err(e.to_string()))
+                            ::core::convert::TryInto::<#ty>::try_into(#ident).map_err(|e| #pyo3_path::exceptions::PyValueError::new_err(e.to_string()))
                     },
                     ctx
                 )
@@ -1326,7 +1326,7 @@ impl ReturnMode {
                 let _result: #pyo3_path::PyResult<()> = #pyo3_path::impl_::callback::convert(py, #call);
                 _result?;
                 #pyo3_path::ffi::Py_XINCREF(_slf);
-                ::std::result::Result::Ok(_slf)
+                ::core::result::Result::Ok(_slf)
             },
         }
     }
@@ -1964,8 +1964,8 @@ pub fn field_python_name(
 fn doc_to_optional_cstr(doc: Option<&PythonDoc>, ctx: &Ctx) -> Result<TokenStream> {
     Ok(if let Some(doc) = doc {
         let doc = doc.to_cstr_stream(ctx)?;
-        quote!(::std::option::Option::Some(#doc))
+        quote!(::core::option::Option::Some(#doc))
     } else {
-        quote!(::std::option::Option::None)
+        quote!(::core::option::Option::None)
     })
 }

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -6,6 +6,8 @@
 //! APIs may may change at any time without documentation in the CHANGELOG and without
 //! breaking semver guarantees.
 
+pub extern crate alloc;
+
 pub mod callback;
 pub mod concat;
 #[cfg(feature = "experimental-async")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -118,7 +118,7 @@ macro_rules! py_run_impl {
     }};
     ($py:expr, *$dict:expr, $code:expr) => {{
         use ::core::option::Option::*;
-        if let ::core::result::Result::Err(e) = $py.run(&::std::ffi::CString::new($code).unwrap(), None, Some(&$dict)) {
+        if let ::core::result::Result::Err(e) = $py.run(&$crate::impl_::alloc::ffi::CString::new($code).unwrap(), None, Some(&$dict)) {
             e.print($py);
             // So when this c api function the last line called printed the error to stderr,
             // the output is only written into a buffer which is never flushed because we

--- a/tests/test_utils/mod.rs
+++ b/tests/test_utils/mod.rs
@@ -65,7 +65,8 @@ mod inner {
         }};
         // Case2: dict & no err_msg
         ($py:expr, *$dict:expr, $code:expr, $err:ident) => {{
-            let res = $py.run(&std::ffi::CString::new($code).unwrap(), None, Some(&$dict.as_borrowed()));
+            extern crate alloc;
+            let res = $py.run(&alloc::ffi::CString::new($code).unwrap(), None, Some(&$dict.as_borrowed()));
             let err = res.expect_err(&format!("Did not raise {}", stringify!($err)));
             if !err.matches($py, $py.get_type::<pyo3::exceptions::$err>()).unwrap() {
                 panic!("Expected {} but got {:?}", stringify!($err), err)
@@ -103,7 +104,8 @@ mod inner {
         }};
         ($py:expr, *$dict:expr, $code:expr, [$(($warning_msg:literal, $warning_category:path)),+] $(,)?) => {{
             $crate::test_utils::CatchWarnings::enter($py, |warning_record| {
-                $py.run(&std::ffi::CString::new($code).unwrap(), None, Some(&$dict.as_borrowed())).expect("Failed to run warning testing code");
+                extern crate alloc;
+                $py.run(&alloc::ffi::CString::new($code).unwrap(), None, Some(&$dict.as_borrowed())).expect("Failed to run warning testing code");
                 let expected_warnings = [$(($warning_msg, <$warning_category as pyo3::PyTypeInfo>::type_object($py))),+];
 
                 assert_eq!(warning_record.len(), expected_warnings.len(), "Expecting {} warnings but got {}", expected_warnings.len(), warning_record.len());
@@ -285,9 +287,9 @@ mod inner {
     #[allow(unused_imports, reason = "not all tests use this macro")]
     pub(crate) use assert_warnings;
 
-    pub fn generate_unique_module_name(base: &str) -> std::ffi::CString {
+    pub fn generate_unique_module_name(base: &str) -> alloc::ffi::CString {
         let uuid = Uuid::new_v4().simple().to_string();
-        std::ffi::CString::new(format!("{base}_{uuid}")).unwrap()
+        alloc::ffi::CString::new(format!("{base}_{uuid}")).unwrap()
     }
 }
 


### PR DESCRIPTION
- Re-exports `extern crate alloc` from the private `impl_` mod.
- Replace most uses of `std` in generated code from `pyo3-macros-backend`