### PR TITLE
Bump hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4.25", default-features = false, optional = true }
 chrono-tz = { version = ">= 0.10, < 0.11", default-features = false, optional = true }
 either = { version = "1.9", optional = true }
 eyre = { version = ">= 0.6.8, < 0.7", optional = true }
-hashbrown = { version = ">= 0.15.0, < 0.18", optional = true, default-features = false, features = [
+hashbrown = { version = ">= 0.16.0, < 0.18", optional = true, default-features = false, features = [
     "default-hasher",
 ] }
 indexmap = { version = ">= 2.5.0, < 3", optional = true }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+[[disallowed-types]]
+path = "core::hash::DefaultHasher"
+reason = "use crate::platform::DefaultHashBuilder instead"
+
+[[disallowed-types]]
+path = "core::hash::BuildHasherDefault"
+reason = "use crate::platform::DefaultHashBuilder instead"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,5 @@
 [[disallowed-types]]
-path = "core::hash::DefaultHasher"
+path = "std::hash::DefaultHasher"
 reason = "use crate::platform::DefaultHashBuilder instead"
 
 [[disallowed-types]]

--- a/newsfragments/6331.changed.md
+++ b/newsfragments/6331.changed.md
@@ -1,0 +1,2 @@
+- bump minimum hashbrown version from `0.15.0` to `0.16.0`
+- if hashbrown is enabled, generated hash functions use DefaultHasher from hashbrown

--- a/pyo3-macros-backend/src/introspection.rs
+++ b/pyo3-macros-backend/src/introspection.rs
@@ -15,6 +15,7 @@ use crate::utils::{PyO3CratePath, PythonDoc, StrOrExpr};
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, ToTokens};
 use std::borrow::Cow;
+#[expect(clippy::disallowed_types)]
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 use std::fmt::Write;

--- a/pyo3-macros-backend/src/introspection.rs
+++ b/pyo3-macros-backend/src/introspection.rs
@@ -603,6 +603,7 @@ pub fn introspection_id_const() -> TokenStream {
 }
 
 pub fn unique_element_id() -> u64 {
+    #[expect(clippy::disallowed_types)]
     let mut hasher = DefaultHasher::new();
     format!("{:?}", Span::call_site()).hash(&mut hasher); // Distinguishes between call sites
     GLOBAL_COUNTER_FOR_UNIQUE_NAMES

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2539,9 +2539,11 @@ fn pyclass_hash(
         Some(opt) => {
             let mut hash_impl = parse_quote_spanned! { opt.span() =>
                 fn __pyo3__generated____hash__(&self) -> u64 {
-                    use core::hash::BuildHasher;
+                    use ::core::hash::BuildHasher;
                     use #pyo3_path::platform::DefaultHashBuilder;
-                    DefaultHashBuilder::default().hash_one(self)
+                    let mut s = DefaultHashBuilder::default().build_hasher();
+                    ::core::hash::Hash::hash(self, &mut s);
+                    ::core::hash::Hasher::finish(&s)
                 }
             };
             let hash_slot = generate_protocol_slot(

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2539,9 +2539,9 @@ fn pyclass_hash(
         Some(opt) => {
             let mut hash_impl = parse_quote_spanned! { opt.span() =>
                 fn __pyo3__generated____hash__(&self) -> u64 {
-                    let mut s = #pyo3_path::platform::DefaultHasher::new();
-                    ::core::hash::Hash::hash(self, &mut s);
-                    ::core::hash::Hasher::finish(&s)
+                    use core::hash::BuildHasher;
+                    use #pyo3_path::platform::DefaultHashBuilder;
+                    DefaultHashBuilder::default().hash_one(self)
                 }
             };
             let hash_slot = generate_protocol_slot(

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2528,6 +2528,7 @@ fn pyclass_hash(
     cls: &syn::Type,
     ctx: &Ctx,
 ) -> Result<(Option<syn::ImplItemFn>, Option<MethodAndSlotDef>)> {
+    let pyo3_path = &ctx.pyo3_path;
     if options.hash.is_some() {
         ensure_spanned!(
             options.frozen.is_some(), options.hash.span() => "The `hash` option requires the `frozen` option.";
@@ -2538,7 +2539,7 @@ fn pyclass_hash(
         Some(opt) => {
             let mut hash_impl = parse_quote_spanned! { opt.span() =>
                 fn __pyo3__generated____hash__(&self) -> u64 {
-                    let mut s = std::collections::hash_map::DefaultHasher::new();
+                    let mut s = #pyo3_path::platform::DefaultHasher::new();
                     ::core::hash::Hash::hash(self, &mut s);
                     ::core::hash::Hasher::finish(&s)
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,8 @@ pub(crate) mod ffi_ptr_ext;
 pub(crate) mod py_result_ext;
 pub(crate) mod sealed;
 
-mod platform;
+#[doc(hidden)]
+pub mod platform;
 
 /// Old module which contained some implementation details of the `#[pyproto]` module.
 ///

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -15,10 +15,10 @@ pub(crate) mod prelude {
 }
 
 #[cfg(feature = "hashbrown")]
-pub use hashbrown::{HashMap, HashSet};
+pub use hashbrown::{DefaultHasher, HashMap, HashSet};
 
 #[cfg(all(not(feature = "hashbrown"), wip_feature_std))]
-pub use std::collections::{HashMap, HashSet};
+pub use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
 
 #[cfg(all(not(feature = "hashbrown"), not(wip_feature_std)))]
 compile_error!("Please enable at least one of the following features: hashbrown, std");

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -15,10 +15,30 @@ pub(crate) mod prelude {
 }
 
 #[cfg(feature = "hashbrown")]
-pub use hashbrown::{DefaultHasher, HashMap, HashSet};
+pub use hashbrown::{HashMap, HashSet};
 
 #[cfg(all(not(feature = "hashbrown"), wip_feature_std))]
-pub use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
+pub use std::collections::{HashMap, HashSet};
+
+#[cfg(feature = "hashbrown")]
+#[derive(Default)]
+pub struct DefaultHashBuilder(hashbrown::DefaultHashBuilder);
+
+#[cfg(all(not(feature = "hashbrown"), wip_feature_std))]
+#[derive(Default)]
+pub struct DefaultHashBuilder(core::hash::BuildHasherDefault<std::hash::DefaultHasher>);
+
+impl core::hash::BuildHasher for DefaultHashBuilder {
+    #[cfg(feature = "hashbrown")]
+    type Hasher = hashbrown::DefaultHasher;
+    #[cfg(all(not(feature = "hashbrown"), wip_feature_std))]
+    type Hasher = std::hash::DefaultHasher;
+
+    #[inline(always)]
+    fn build_hasher(&self) -> Self::Hasher {
+        self.0.build_hasher()
+    }
+}
 
 #[cfg(all(not(feature = "hashbrown"), not(wip_feature_std)))]
 compile_error!("Please enable at least one of the following features: hashbrown, std");

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -25,6 +25,7 @@ pub use std::collections::{HashMap, HashSet};
 pub struct DefaultHashBuilder(hashbrown::DefaultHashBuilder);
 
 #[cfg(all(not(feature = "hashbrown"), wip_feature_std))]
+#[expect(clippy::disallowed_types)]
 #[derive(Default)]
 pub struct DefaultHashBuilder(core::hash::BuildHasherDefault<std::hash::DefaultHasher>);
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -32,6 +32,7 @@ impl core::hash::BuildHasher for DefaultHashBuilder {
     #[cfg(feature = "hashbrown")]
     type Hasher = hashbrown::DefaultHasher;
     #[cfg(all(not(feature = "hashbrown"), wip_feature_std))]
+    #[expect(clippy::disallowed_types)]
     type Hasher = std::hash::DefaultHasher;
 
     #[inline(always)]

--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -429,10 +429,10 @@ use impl_traits;
 mod test {
     use super::*;
     use crate::impl_::pyclass::{value_of, IsSend, IsSync};
+    use crate::platform::DefaultHashBuilder;
     use crate::types::PyAnyMethods as _;
     use crate::{IntoPyObject, Python};
-    use core::hash::{Hash, Hasher};
-    use std::collections::hash_map::DefaultHasher;
+    use core::hash::BuildHasher;
 
     #[test]
     fn py_backed_str_empty() {
@@ -588,18 +588,10 @@ mod test {
     #[test]
     fn test_backed_str_hash() {
         Python::attach(|py| {
-            let h = {
-                let mut hasher = DefaultHasher::new();
-                "abcde".hash(&mut hasher);
-                hasher.finish()
-            };
+            let h = DefaultHashBuilder::default().hash_one("abcde");
 
             let s1: PyBackedStr = PyString::new(py, "abcde").try_into().unwrap();
-            let h1 = {
-                let mut hasher = DefaultHasher::new();
-                s1.hash(&mut hasher);
-                hasher.finish()
-            };
+            let h1 = DefaultHashBuilder::default().hash_one(&s1);
 
             assert_eq!(h, h1);
         });
@@ -734,25 +726,13 @@ mod test {
     #[test]
     fn test_backed_bytes_hash() {
         Python::attach(|py| {
-            let h = {
-                let mut hasher = DefaultHasher::new();
-                b"abcde".hash(&mut hasher);
-                hasher.finish()
-            };
+            let h = DefaultHashBuilder::default().hash_one(b"abcde");
 
             let b1: PyBackedBytes = PyBytes::new(py, b"abcde").into();
-            let h1 = {
-                let mut hasher = DefaultHasher::new();
-                b1.hash(&mut hasher);
-                hasher.finish()
-            };
+            let h1 = DefaultHashBuilder::default().hash_one(&b1);
 
             let b2: PyBackedBytes = PyByteArray::new(py, b"abcde").into();
-            let h2 = {
-                let mut hasher = DefaultHasher::new();
-                b2.hash(&mut hasher);
-                hasher.finish()
-            };
+            let h2 = DefaultHashBuilder::default().hash_one(&b2);
 
             assert_eq!(h, h1);
             assert_eq!(h, h2);

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -239,10 +239,8 @@ fn class_with_hash() {
         use pyo3::types::IntoPyDict;
         let class = ClassWithHash { value: 42 };
         let hash = {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            class.hash(&mut hasher);
-            hasher.finish() as isize
+            use core::hash::BuildHasher;
+            pyo3::platform::DefaultHashBuilder::default().hash_one(&class) as isize
         };
 
         let env = [

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -298,10 +298,8 @@ fn test_simple_enum_with_hash() {
         use pyo3::types::IntoPyDict;
         let class = SimpleEnumWithHash::A;
         let hash = {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            class.hash(&mut hasher);
-            hasher.finish() as isize
+            use core::hash::BuildHasher;
+            pyo3::platform::DefaultHashBuilder::default().hash_one(&class) as isize
         };
 
         let env = [

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -328,10 +328,8 @@ fn test_complex_enum_with_hash() {
             msg: String::from("Hello"),
         };
         let hash = {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            class.hash(&mut hasher);
-            hasher.finish() as isize
+            use core::hash::BuildHasher;
+            pyo3::platform::DefaultHashBuilder::default().hash_one(&class)
         };
 
         let env = [


### PR DESCRIPTION
- Bump minimum supported hashbrown to 0.16.0
- include `DefaultHasher` in `platform.rs`
- use `DefaultHasher` from `platform.rs` instead of `std` in generated code

Closes #6329 