### PR TITLE
internal: Support using nextest locally

### DIFF
--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -3,7 +3,7 @@
 use std::env;
 
 fn main() {
-    // miminal support for running in cargo-nextest
+    // minimal support for running in cargo-nextest
     // https://nexte.st/docs/design/custom-test-harnesses/
     {
         let mut list = false;

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -3,6 +3,26 @@
 use std::env;
 
 fn main() {
+    // miminal support for running in cargo-nextest
+    // https://nexte.st/docs/design/custom-test-harnesses/
+    {
+        let mut list = false;
+        let mut ignored = false;
+        for arg in env::args() {
+            match arg.as_str() {
+                "--list" => list = true,
+                "--ignored" => ignored = true,
+                _ => (),
+            }
+        }
+        if list {
+            if !ignored {
+                println!("ui_test: test");
+            }
+            return;
+        }
+    }
+
     if cfg!(target_arch = "wasm32") {
         // Not possible to invoke compiler from wasm
         return;


### PR DESCRIPTION
Add support for people to run the ui tests locally using cargo-nextest instead of cargo-test.