### PR TITLE
No std hashing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ links = "pyo3-python"
 rust-version.workspace = true
 
 [dependencies]
+ahash = { version = "0.8", default-features = false }
 libc = "0.2.62"
 once_cell = "1.21"
 

--- a/newsfragments/6333.changed.md
+++ b/newsfragments/6333.changed.md
@@ -1,0 +1,1 @@
+Generated hash functions use the hashing implementation from the `ahash` crate instead of `std`

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2556,7 +2556,7 @@ fn pyclass_hash(
                     #[diagnostic::do_not_recommend]
                     #[allow(non_local_definitions, reason = "generated code")]
                     impl PyHashable for #cls {
-                        const RANDOM_STATE: RandomState = RandomState::with_seeds(#k0, #k1, #k2, #k3);
+                        const BUILD_HASHER: RandomState = RandomState::with_seeds(#k0, #k1, #k2, #k3);
                     }
 
                     <Self as PyHashable>::py_hash(self)

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
@@ -2528,6 +2529,7 @@ fn pyclass_hash(
     cls: &syn::Type,
     ctx: &Ctx,
 ) -> Result<(Option<syn::ImplItemFn>, Option<MethodAndSlotDef>)> {
+    let pyo3_path = &ctx.pyo3_path;
     if options.hash.is_some() {
         ensure_spanned!(
             options.frozen.is_some(), options.hash.span() => "The `hash` option requires the `frozen` option.";
@@ -2536,11 +2538,28 @@ fn pyclass_hash(
     }
     match options.hash {
         Some(opt) => {
+            // generate the keys for this class's RandomState
+            let mut hasher = DefaultHasher::new();
+            cls.hash(&mut hasher);
+            let k0 = hasher.finish();
+            k0.hash(&mut hasher);
+            let k1 = hasher.finish();
+            k1.hash(&mut hasher);
+            let k2 = hasher.finish();
+            k2.hash(&mut hasher);
+            let k3 = hasher.finish();
+
             let mut hash_impl = parse_quote_spanned! { opt.span() =>
-                fn __pyo3__generated____hash__(&self) -> u64 {
-                    let mut s = std::collections::hash_map::DefaultHasher::new();
-                    ::core::hash::Hash::hash(self, &mut s);
-                    ::core::hash::Hasher::finish(&s)
+                fn __pyo3__generated____hash__(&self) -> #pyo3_path::ffi::Py_hash_t {
+                    use #pyo3_path::impl_::hash::{PyHashable, RandomState};
+
+                    #[diagnostic::do_not_recommend]
+                    #[allow(non_local_definitions, reason = "generated code")]
+                    impl PyHashable for #cls {
+                        const RANDOM_STATE: RandomState = RandomState::with_seeds(#k0, #k1, #k2, #k3);
+                    }
+
+                    <Self as PyHashable>::py_hash(self)
                 }
             };
             let hash_slot = generate_protocol_slot(

--- a/src/impl_.rs
+++ b/src/impl_.rs
@@ -17,6 +17,7 @@ pub mod exceptions;
 pub mod extract_argument;
 pub mod freelist;
 pub mod frompyobject;
+pub mod hash;
 #[cfg(feature = "experimental-inspect")]
 pub mod introspection;
 pub mod panic;

--- a/src/impl_/hash.rs
+++ b/src/impl_/hash.rs
@@ -4,9 +4,9 @@ pub use ahash::RandomState;
 use pyo3_ffi::Py_hash_t;
 
 pub trait PyHashable: Hash {
-    const RANDOM_STATE: RandomState;
+    const BUILD_HASHER: RandomState;
 
     fn py_hash(&self) -> Py_hash_t {
-        Self::RANDOM_STATE.hash_one(self) as _
+        Self::BUILD_HASHER.hash_one(self) as _
     }
 }

--- a/src/impl_/hash.rs
+++ b/src/impl_/hash.rs
@@ -1,0 +1,12 @@
+use core::hash::Hash;
+
+pub use ahash::RandomState;
+use pyo3_ffi::Py_hash_t;
+
+pub trait PyHashable: Hash {
+    const RANDOM_STATE: RandomState;
+
+    fn py_hash(&self) -> Py_hash_t {
+        Self::RANDOM_STATE.hash_one(self) as _
+    }
+}

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -239,10 +239,8 @@ fn class_with_hash() {
         use pyo3::types::IntoPyDict;
         let class = ClassWithHash { value: 42 };
         let hash = {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            class.hash(&mut hasher);
-            hasher.finish() as isize
+            use pyo3::impl_::hash::PyHashable;
+            class.py_hash()
         };
 
         let env = [

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -298,10 +298,8 @@ fn test_simple_enum_with_hash() {
         use pyo3::types::IntoPyDict;
         let class = SimpleEnumWithHash::A;
         let hash = {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            class.hash(&mut hasher);
-            hasher.finish() as isize
+            use pyo3::impl_::hash::PyHashable;
+            class.py_hash()
         };
 
         let env = [
@@ -330,10 +328,8 @@ fn test_complex_enum_with_hash() {
             msg: String::from("Hello"),
         };
         let hash = {
-            use std::hash::{Hash, Hasher};
-            let mut hasher = std::collections::hash_map::DefaultHasher::new();
-            class.hash(&mut hasher);
-            hasher.finish() as isize
+            use pyo3::impl_::hash::PyHashable;
+            class.py_hash()
         };
 
         let env = [

--- a/tests/ui/invalid_pyclass_args.default.stderr
+++ b/tests/ui/invalid_pyclass_args.default.stderr
@@ -180,6 +180,23 @@ note: the lint level is defined here
   4 | #![deny(deprecated)]
     |         ^^^^^^^^^^
 
+error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
+  --> tests/ui/invalid_pyclass_args.rs:80:8
+   |
+80 | struct HashOptRequiresHash;
+   |        ^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
+   |
+note: required by a bound in `pyo3::impl_::hash::PyHashable`
+ --> src/impl_/hash.rs
+  |
+  | pub trait PyHashable: Hash {
+  |                       ^^^^ required by this bound in `PyHashable`
+help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
+   |
+80 + #[derive(Hash)]
+81 | struct HashOptRequiresHash;
+   |
+
 error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
    --> tests/ui/invalid_pyclass_args.rs:237:11
     |
@@ -323,6 +340,14 @@ error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
 77 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
    |
+note: required by a bound in `pyo3::impl_::hash::PyHashable::py_hash`
+ --> src/impl_/hash.rs
+  |
+  | pub trait PyHashable: Hash {
+  |                       ^^^^ required by this bound in `PyHashable::py_hash`
+...
+  |     fn py_hash(&self) -> Py_hash_t {
+  |        ------- required by a bound in this associated function
 help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
    |
 80 + #[derive(Hash)]
@@ -489,7 +514,7 @@ note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNe
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 49 previous errors
+error: aborting due to 50 previous errors
 
 Some errors have detailed explanations: E0034, E0119, E0277, E0369, E0592, E0609.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_args.inspect.stderr
+++ b/tests/ui/invalid_pyclass_args.inspect.stderr
@@ -180,6 +180,23 @@ note: the lint level is defined here
   4 | #![deny(deprecated)]
     |         ^^^^^^^^^^
 
+error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
+  --> tests/ui/invalid_pyclass_args.rs:80:8
+   |
+80 | struct HashOptRequiresHash;
+   |        ^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
+   |
+note: required by a bound in `pyo3::impl_::hash::PyHashable`
+ --> src/impl_/hash.rs
+  |
+  | pub trait PyHashable: Hash {
+  |                       ^^^^ required by this bound in `PyHashable`
+help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
+   |
+80 + #[derive(Hash)]
+81 | struct HashOptRequiresHash;
+   |
+
 error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
    --> tests/ui/invalid_pyclass_args.rs:237:11
     |
@@ -353,6 +370,14 @@ error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
 77 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
    |
+note: required by a bound in `pyo3::impl_::hash::PyHashable::py_hash`
+ --> src/impl_/hash.rs
+  |
+  | pub trait PyHashable: Hash {
+  |                       ^^^^ required by this bound in `PyHashable::py_hash`
+...
+  |     fn py_hash(&self) -> Py_hash_t {
+  |        ------- required by a bound in this associated function
 help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
    |
 80 + #[derive(Hash)]
@@ -519,7 +544,7 @@ note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNe
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 50 previous errors
+error: aborting due to 51 previous errors
 
 Some errors have detailed explanations: E0034, E0119, E0277, E0369, E0592, E0609.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_enum.stderr
+++ b/tests/ui/invalid_pyclass_enum.stderr
@@ -72,6 +72,40 @@ error: #[pyclass] can't be used on enums without any variants - all variants of 
 119 | enum AllEnumVariantsDisabled {
     |      ^^^^^^^^^^^^^^^^^^^^^^^
 
+error[E0277]: the trait bound `SimpleHashOptRequiresHash: Hash` is not satisfied
+  --> tests/ui/invalid_pyclass_enum.rs:69:6
+   |
+69 | enum SimpleHashOptRequiresHash {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `SimpleHashOptRequiresHash`
+   |
+note: required by a bound in `pyo3::impl_::hash::PyHashable`
+ --> src/impl_/hash.rs
+  |
+  | pub trait PyHashable: Hash {
+  |                       ^^^^ required by this bound in `PyHashable`
+help: consider annotating `SimpleHashOptRequiresHash` with `#[derive(Hash)]`
+   |
+69 + #[derive(Hash)]
+70 | enum SimpleHashOptRequiresHash {
+   |
+
+error[E0277]: the trait bound `ComplexHashOptRequiresHash: Hash` is not satisfied
+  --> tests/ui/invalid_pyclass_enum.rs:77:6
+   |
+77 | enum ComplexHashOptRequiresHash {
+   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Hash` is not implemented for `ComplexHashOptRequiresHash`
+   |
+note: required by a bound in `pyo3::impl_::hash::PyHashable`
+ --> src/impl_/hash.rs
+  |
+  | pub trait PyHashable: Hash {
+  |                       ^^^^ required by this bound in `PyHashable`
+help: consider annotating `ComplexHashOptRequiresHash` with `#[derive(Hash)]`
+   |
+77 + #[derive(Hash)]
+78 | enum ComplexHashOptRequiresHash {
+   |
+
 error[E0369]: binary operation `==` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
   --> tests/ui/invalid_pyclass_enum.rs:36:11
    |
@@ -146,6 +180,14 @@ error[E0277]: the trait bound `SimpleHashOptRequiresHash: Hash` is not satisfied
 66 | #[pyclass(frozen, eq, eq_int, hash)]
    |                               ^^^^ the trait `Hash` is not implemented for `SimpleHashOptRequiresHash`
    |
+note: required by a bound in `pyo3::impl_::hash::PyHashable::py_hash`
+ --> src/impl_/hash.rs
+  |
+  | pub trait PyHashable: Hash {
+  |                       ^^^^ required by this bound in `PyHashable::py_hash`
+...
+  |     fn py_hash(&self) -> Py_hash_t {
+  |        ------- required by a bound in this associated function
 help: consider annotating `SimpleHashOptRequiresHash` with `#[derive(Hash)]`
    |
 69 + #[derive(Hash)]
@@ -158,6 +200,14 @@ error[E0277]: the trait bound `ComplexHashOptRequiresHash: Hash` is not satisfie
 74 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `ComplexHashOptRequiresHash`
    |
+note: required by a bound in `pyo3::impl_::hash::PyHashable::py_hash`
+ --> src/impl_/hash.rs
+  |
+  | pub trait PyHashable: Hash {
+  |                       ^^^^ required by this bound in `PyHashable::py_hash`
+...
+  |     fn py_hash(&self) -> Py_hash_t {
+  |        ------- required by a bound in this associated function
 help: consider annotating `ComplexHashOptRequiresHash` with `#[derive(Hash)]`
    |
 77 + #[derive(Hash)]
@@ -232,7 +282,7 @@ help: consider annotating `InvalidOrderedComplexEnum2` with `#[derive(PartialEq,
 113 | enum InvalidOrderedComplexEnum2 {
     |
 
-error: aborting due to 22 previous errors
+error: aborting due to 24 previous errors
 
 Some errors have detailed explanations: E0277, E0369.
 For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Closes #6329 

I've added a new trait in `impl_`: `PyHashable`. I used [`ahash::randome_state::RandomState`](https://docs.rs/ahash/latest/ahash/random_state/struct.RandomState.html) as the build hasher but that can be replaced by any `BuildHasher` that can be constructed at compile time.