### PR TITLE
ci: avoid running the whole CI workflow for newsfragments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - "newsfragments/*.md"
   merge_group:
     types: [checks_requested]
   workflow_dispatch:


### PR DESCRIPTION
Skip `ci.yml` if the only thing that changed is a newsfragment.

Relevant github action docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-excluding-paths