### PR TITLE
docs: add String interning section to the performance guide

### DIFF
--- a/guide/src/performance.md
+++ b/guide/src/performance.md
@@ -56,6 +56,47 @@ fn frobnicate<'py>(value: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
 }
 ```
 
+## String interning
+
+Every time a Rust `&str` is converted into a Python string, for example via `PyString::new` or through an `IntoPyObject` implementation, PyO3 allocates a new `PyString` object.
+For strings that are reused repeatedly at the same call site, e.g. as dictionary keys or attribute names, this repeated allocation is unnecessary overhead.
+
+The [`intern!`] macro caches a `PyString` in static storage the first time it is evaluated for a given call site, and returns a reference to that same object on every subsequent call, avoiding the repeated allocation.
+
+For example, instead of writing
+
+```rust,no_run
+# #![allow(dead_code)]
+# use pyo3::prelude::*;
+# use pyo3::types::PyDict;
+
+#[pyfunction]
+fn create_dict(py: Python<'_>) -> PyResult<Bound<'_, PyDict>> {
+    let dict = PyDict::new(py);
+    // A new `PyString` is created for every call of this function.
+    dict.set_item("foo", 42)?;
+    Ok(dict)
+}
+```
+
+use the more efficient
+
+```rust,no_run
+# #![allow(dead_code)]
+# use pyo3::prelude::*;
+# use pyo3::{intern, types::PyDict};
+
+#[pyfunction]
+fn create_dict(py: Python<'_>) -> PyResult<Bound<'_, PyDict>> {
+    let dict = PyDict::new(py);
+    // A `PyString` is created once and reused for the lifetime of the program.
+    dict.set_item(intern!(py, "foo"), 42)?;
+    Ok(dict)
+}
+```
+
+[`intern!`]: {{#PYO3_DOCS_URL}}/pyo3/macro.intern.html
+
 ## Access to Bound implies access to Python token
 
 Calling `Python::attach` is effectively a no-op when we're already attached to the interpreter, but checking that this is the case still has a cost.


### PR DESCRIPTION
Addresses one item from #3310's checklist: "String `intern!`".

## What's added

A new "String interning" section in `guide/src/performance.md`, documenting the `intern!` macro — it avoids repeatedly allocating a `PyString` at call sites that reuse the same string (dict keys, attribute names, etc.), returning a cached reference after the first call instead.

The example is adapted from `intern!`'s own doc comment in `src/sync.rs` (the `create_dict` / `create_dict_faster` pattern), which is an existing, already-passing doctest — not new example code. I matched the guide's existing before/after style used in the `extract` versus `cast` and `Bound::py` sections.

## What's intentionally not addressed here

#3310 lists several other items; I'm scoping this PR to just the one above:

- **`Vec<u8>` becoming `list[int]`, `Cow<[u8]>` as an alternative** — per the issue's own comment thread, @Icxolu confirmed this was already resolved by the `IntoPyObject` rework (and later specialization work for `FromPyObject`). Documenting it as a live gotcha in the performance guide would now be inaccurate, so I left it out rather than describe an already-fixed problem.
- **Overhead of conversions in general, `#[pyo3(get)]` deep-cloning non-`Py` data, dictionary dispatch** — these need more source-level investigation than fits cleanly in one PR (verifying current behavior, not just describing intent), so leaving them for a follow-up rather than writing something I haven't verified against the current codebase.
