### PR TITLE
internal: blocklist suspicious symbols in pyo3-ffi-check bindgen

### DIFF
--- a/pyo3-ffi-check/definitions/build.rs
+++ b/pyo3-ffi-check/definitions/build.rs
@@ -61,7 +61,13 @@ fn main() {
         .header("wrapper.h")
         .clang_args(clang_args)
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .parse_callbacks(Box::new(ParseCallbacks));
+        .parse_callbacks(Box::new(ParseCallbacks))
+        .blocklist_item("memcpy")
+        .blocklist_item("memmove")
+        .blocklist_item("memset")
+        .blocklist_item("memcmp")
+        .blocklist_item("strlen")
+        .blocklist_item("bcmp");
 
     if matches!(
         config.implementation(),


### PR DESCRIPTION
Fix for the new warn-by-default lint that broke unrelated PRs https://github.com/PyO3/pyo3/actions/runs/32476692819/job/96754536304?pr=6333#step:12:162