### PR TITLE
internal: add safety comments in conversions/std/array, py_result_ext and impl_/pyfunction

### DIFF
--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -1,6 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
-
 use crate::conversion::{FromPyObjectOwned, FromPyObjectSequence, IntoPyObject};
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_subscript, PyStaticExpr};
@@ -73,6 +70,7 @@ where
 {
     // Types that pass `PySequence_Check` usually implement enough of the sequence protocol
     // to support this function and if not, we will only fail extraction safely.
+    // SAFETY: passing valid pointer to python API
     if unsafe { ffi::PySequence_Check(obj.as_ptr()) } == 0 {
         return Err(CastError::new(obj, PySequence::type_object(obj.py()).into_any()).into());
     }

--- a/src/impl_/pyfunction.rs
+++ b/src/impl_/pyfunction.rs
@@ -1,6 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
-
 use core::cell::UnsafeCell;
 
 use crate::{
@@ -125,6 +122,9 @@ pub unsafe fn create_py_c_function<'py>(
         .as_ref()
         .map_or(core::ptr::null_mut(), Bound::as_ptr);
 
+    // SAFETY: caller upholds that `method_def` outlives the returned function,
+    // and `PyCFunction_NewEx` returns a new owned reference to a builtin
+    // function object, or NULL with an exception set on error.
     unsafe {
         ffi::PyCFunction_NewEx(method_def, mod_ptr, module_name_ptr)
             .assume_owned_or_err(py)

--- a/src/py_result_ext.rs
+++ b/src/py_result_ext.rs
@@ -1,6 +1,3 @@
-// TODO https://github.com/PyO3/pyo3/issues/5487
-#![allow(clippy::undocumented_unsafe_blocks)]
-
 use crate::{Bound, PyAny, PyResult, PyTypeCheck};
 
 pub(crate) trait PyResultExt<'py>: crate::sealed::Sealed {
@@ -14,8 +11,12 @@ impl<'py> PyResultExt<'py> for PyResult<Bound<'py, PyAny>> {
         self.and_then(|instance| instance.cast_into().map_err(Into::into))
     }
 
+    /// # Safety
+    ///
+    /// see requirements for [`Bound::cast_into_unchecked`]
     #[inline]
     unsafe fn cast_into_unchecked<T>(self) -> PyResult<Bound<'py, T>> {
+        // SAFETY: caller upholds requirements
         self.map(|instance| unsafe { instance.cast_into_unchecked() })
     }
 }


### PR DESCRIPTION
Part of #5487, continuing from #6256, #6259, #6265 and #6288.

Removes the `#![allow(clippy::undocumented_unsafe_blocks)]` exemption from three files and adds `// SAFETY:` comments for their three unsafe blocks, plus a missing `/// # Safety` section on `PyResultExt::cast_into_unchecked`:

- `src/conversions/std/array.rs`
- `src/py_result_ext.rs`
- `src/impl_/pyfunction.rs`

Verified with clippy under both the default and `abi3` feature sets.
