### PR TITLE
ci: bump WASI SDK to 33 so the setup action can verify it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,7 +541,9 @@ jobs:
       - name: "Install WASI SDK"
         uses: bytecodealliance/setup-wasi-sdk-action@main
         with:
-          version: "24"
+          # keep in sync with wasm/wasi/Makefile; must stay recent enough that the
+          # GitHub release assets carry the SHA-256 digest the action verifies
+          version: "33"
           # wasi sdk sets CC variables which break Python's configure script
           # (it also sets WASI_SDK_PATH even without `add-to-path`, which is sufficient)
           add-to-path: false

--- a/wasm/wasi/Makefile
+++ b/wasm/wasi/Makefile
@@ -1,6 +1,6 @@
 include ../common.mk
 
-WASI_SDK_VERSION=24
+WASI_SDK_VERSION=33
 WASMTIME_VERSION=46.0.1
 
 CONFIG_SITE=$(PYTHONBUILD)/Tools/wasm/wasi/config.site-wasm32-wasi


### PR DESCRIPTION
CI job `wasm32-wasip1` failed on PRs #6335, #6336, #6337 and #6328 too, last green `2026-08-18`.

`bytecodealliance/setup-wasi-sdk-action` now refuses to install a release whose GitHub asset carries no SHA-256 digest:

```
    ValueError: Release asset 'wasi-sdk-24.0-x86_64-linux.tar.gz'
    does not have a valid SHA-256 digest
```

wasi-sdk-24's assets were uploaded in 2024, before GitHub started computing asset digests, so `digest` is null for every one of them and the wasm32-wasip1 job has failed on every merge-queue run since. The first release whose assets have digests is wasi-sdk-27; I took 33, the current stable.

Tested SDKs:

| release | uploaded | digest |
| :--- | :--- | :--- |
| wasi-sdk-24 | 2024-08-02 | null |
| wasi-sdk-25 | 2024-12-12 | null |
| wasi-sdk-27 | 2025-07-27 | present |
| wasi-sdk-33 | 2026-04-30 | present |

Recent change in the github action `bytecodealliance/setup-wasi-sdk-action` https://github.com/bytecodealliance/setup-wasi-sdk-action/commit/0f51fb96f. That closed their long-standing issue [#3](https://github.com/bytecodealliance/setup-wasi-sdk-action/issues/3) ("No checksum/signature verification for downloads"). 