### PR TITLE
ci: bump wasi builds to use 3.15, read WASI SDK from cpython config

### DIFF
--- a/.github/actions/build-emscripten/action.yml
+++ b/.github/actions/build-emscripten/action.yml
@@ -1,0 +1,51 @@
+name: Build Emscripten
+description: Build the cached CPython Emscripten environment
+inputs:
+  save-cache:
+    description: Whether to save build caches
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Select Python
+      shell: bash
+      run: echo "UV_PYTHON=3.15" >> "$GITHUB_ENV"
+    - uses: astral-sh/setup-uv@v7
+      with:
+        save-cache: ${{ inputs.save-cache }}
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-emscripten
+        components: rust-src
+    - uses: actions/setup-node@v7
+      with:
+        node-version: 24
+    - name: Resolve CPython version
+      id: python
+      shell: bash
+      run: |
+        version=$(uv run --no-project --python "$UV_PYTHON" python -c 'import sys; print(sys.version.split()[0])')
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+    - name: Restore build cache
+      if: inputs.save-cache != 'true'
+      id: cache-restore
+      uses: actions/cache/restore@v6
+      with:
+        path: .nox/emscripten
+        key: emscripten-${{ hashFiles('wasm/emscripten/*', 'wasm/common.mk') }}-${{ hashFiles('noxfile.py') }}-${{ steps.python.outputs.version }}
+    - name: Restore and save build cache
+      if: inputs.save-cache == 'true'
+      id: cache
+      uses: actions/cache@v6
+      with:
+        path: .nox/emscripten
+        key: emscripten-${{ hashFiles('wasm/emscripten/*', 'wasm/common.mk') }}-${{ hashFiles('noxfile.py') }}-${{ steps.python.outputs.version }}
+    - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ inputs.save-cache }}
+    - name: Build
+      if: steps.cache.outputs.cache-hit != 'true' && steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: uvx nox -s build-emscripten

--- a/.github/actions/build-wasi/action.yml
+++ b/.github/actions/build-wasi/action.yml
@@ -1,0 +1,59 @@
+name: Build WASI
+description: Build the cached CPython WASI environment
+inputs:
+  save-cache:
+    description: Whether to save caches
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Select Python
+      shell: bash
+      run: echo "UV_PYTHON=3.15" >> "$GITHUB_ENV"
+    - uses: astral-sh/setup-uv@v7
+      with:
+        save-cache: ${{ inputs.save-cache }}
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-wasip1
+        components: rust-src
+    - name: Install wasmtime
+      uses: bytecodealliance/actions/wasmtime/setup@v1
+    - name: Resolve CPython version
+      id: python
+      shell: bash
+      run: |
+        version=$(uv run --no-project --python "$UV_PYTHON" python -c 'import sys; print(sys.version.split()[0])')
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+    - name: Restore build cache
+      if: inputs.save-cache != 'true'
+      id: cache-restore
+      uses: actions/cache/restore@v6
+      with:
+        path: .nox/wasi
+        key: wasi-${{ hashFiles('wasm/wasi/*', 'wasm/common.mk') }}-${{ hashFiles('noxfile.py') }}-${{ steps.python.outputs.version }}
+    - name: Restore and save build cache
+      if: inputs.save-cache == 'true'
+      id: cache
+      uses: actions/cache@v6
+      with:
+        path: .nox/wasi
+        key: wasi-${{ hashFiles('wasm/wasi/*', 'wasm/common.mk') }}-${{ hashFiles('noxfile.py') }}-${{ steps.python.outputs.version }}
+    - uses: Swatinem/rust-cache@v2
+      with:
+        save-if: ${{ inputs.save-cache }}
+    - name: Prepare CPython source
+      id: prepare
+      shell: bash
+      run: uvx nox -s prepare-wasm
+    - name: Install WASI SDK
+      uses: bytecodealliance/setup-wasi-sdk-action@v1
+      with:
+        version: ${{ steps.prepare.outputs.wasi-sdk-version }}
+        add-to-path: false
+    - name: Build
+      if: steps.cache.outputs.cache-hit != 'true' && steps.cache-restore.outputs.cache-hit != 'true'
+      shell: bash
+      run: uvx nox -s build-wasm

--- a/.github/workflows/ci-cache-warmup.yml
+++ b/.github/workflows/ci-cache-warmup.yml
@@ -32,3 +32,19 @@ jobs:
         with:
           path: ~/.cache/cargo-xwin
           key: cargo-xwin-cache
+
+  emscripten:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: ./.github/actions/build-emscripten
+        with:
+          save-cache: true
+
+  wasm32-wasip1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: ./.github/actions/build-wasi
+        with:
+          save-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,93 +485,28 @@ jobs:
   emscripten:
     name: emscripten
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
-    needs: [fmt]
+    needs: [fmt, resolve]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
-      - uses: astral-sh/setup-uv@v7
+      - uses: ./.github/actions/build-emscripten
         with:
           save-cache: ${{ needs.resolve.outputs.save-cache }}
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-emscripten
-          components: rust-src
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-      - uses: actions/cache/restore@v6
-        id: cache
-        with:
-          path: |
-            .nox/emscripten
-          key: emscripten-${{ hashFiles('wasm/emscripten/*', 'wasm/common.mk') }}-${{ hashFiles('noxfile.py') }}-${{ env.UV_PYTHON }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-      - name: Build
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: uvx nox -s build-emscripten
       - name: Test
         run: uvx nox -s test-emscripten
-      - uses: actions/cache/save@v6
-        if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-        with:
-          path: |
-            .nox/emscripten
-          key: emscripten-${{ hashFiles('wasm/emscripten/*', 'wasm/common.mk') }}-${{ hashFiles('noxfile.py') }}-${{ env.UV_PYTHON }}
 
   wasm32-wasip1:
     name: wasm32-wasip1
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
-    needs: [fmt]
+    needs: [fmt, resolve]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
-      - uses: astral-sh/setup-uv@v7
+      - uses: ./.github/actions/build-wasi
         with:
           save-cache: ${{ needs.resolve.outputs.save-cache }}
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-wasip1
-          components: rust-src
-      - name: "Install wasmtime"
-        uses: bytecodealliance/actions/wasmtime/setup@v1
-      - name: "Install WASI SDK"
-        uses: bytecodealliance/setup-wasi-sdk-action@main
-        with:
-          version: "24"
-          # wasi sdk sets CC variables which break Python's configure script
-          # (it also sets WASI_SDK_PATH even without `add-to-path`, which is sufficient)
-          add-to-path: false
-      # Key the cache on the CPython version nox will actually build so a new
-      # patch release busts cache properly
-      - name: Resolve CPython version for the WASI build
-        id: wasi-python
-        run: |
-          version=$(uv run --no-project --python "$UV_PYTHON" python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache/restore@v6
-        id: cache
-        with:
-          path: |
-            .nox/wasi
-          key: wasi-${{ hashFiles('wasm/wasi/*', 'wasm/common.mk') }}-${{ hashFiles('noxfile.py') }}-${{ steps.wasi-python.outputs.version }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-      - name: Build
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: uvx nox -s build-wasm
       - name: Test
         run: uvx nox -s test-wasm
-      - uses: actions/cache/save@v6
-        if: ${{ github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'CI-save-pr-cache') }}
-        with:
-          path: |
-            .nox/wasi
-          key: wasi-${{ hashFiles('wasm/wasi/*', 'wasm/common.mk') }}-${{ hashFiles('noxfile.py') }}-${{ steps.wasi-python.outputs.version }}
 
   no_std:
     needs: [fmt]

--- a/noxfile.py
+++ b/noxfile.py
@@ -542,19 +542,39 @@ class WasiInfo:
         self.libdir = crossbuild_dir / "build" / f"lib.wasi-wasm32-{self.pymajorminor}"
 
 
-@nox.session(name="build-wasm", venv_backend="none")
-def build_wasm(session: nox.Session):
-    info = WasiInfo()
+def _make_wasm(session: nox.Session, info: WasiInfo, *targets: str):
     _run(
         session,
         "make",
         "-C",
         str(info.wasi_dir),
+        *targets,
         f"PYTHON={sys.executable}",
         f"BUILDROOT={info.builddir}",
         f"PYMAJORMINORMICRO={info.pyversion}",
         external=True,
     )
+
+
+@nox.session(name="prepare-wasm", venv_backend="none")
+def prepare_wasm(session: nox.Session):
+    import tomllib
+
+    info = WasiInfo()
+    _make_wasm(session, info, "prepare")
+
+    with (info.cpython_dir / "Platforms/WASI/config.toml").open("rb") as config_file:
+        wasi_sdk_version = tomllib.load(config_file)["targets"]["wasi-sdk"]
+
+    session.log("CPython requires WASI SDK %s", wasi_sdk_version)
+    if github_output := os.environ.get("GITHUB_OUTPUT"):
+        with open(github_output, "a") as output_file:
+            print(f"wasi-sdk-version={wasi_sdk_version}", file=output_file)
+
+
+@nox.session(name="build-wasm", venv_backend="none")
+def build_wasm(session: nox.Session):
+    _make_wasm(session, WasiInfo())
 
 
 @nox.session(name="test-wasm", venv_backend="none")
@@ -582,7 +602,12 @@ def test_wasm(session: nox.Session):
             "-C link-arg=-lwasi-emulated-signal",
             "-C link-arg=-lwasi-emulated-process-clocks",
             "-C link-arg=-lwasi-emulated-getpid",
-            "-C link-arg=-lmpdec",
+            "-C link-arg=-lpthread",
+            "-C link-arg=-lHacl_Hash_MD5",
+            "-C link-arg=-lHacl_Hash_SHA1",
+            "-C link-arg=-lHacl_Hash_SHA2",
+            "-C link-arg=-lHacl_Hash_SHA3",
+            "-C link-arg=-lHacl_Hash_BLAKE2",
             "-C link-arg=-lHacl_HMAC",
             "-C link-arg=-lexpat",
         ]

--- a/noxfile.py
+++ b/noxfile.py
@@ -504,6 +504,8 @@ def test_emscripten(session: nox.Session):
             "-C link-arg=-sEXPORTED_FUNCTIONS=_main,__PyRuntime",
             "-C link-arg=-sALLOW_MEMORY_GROWTH=1",
             "-C link-arg=-sSTACK_SIZE=262144",
+            # https://github.com/python/cpython/issues/156243
+            "-C link-arg=-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$stringToNewUTF8",
         ]
     )
     session.env["RUSTDOCFLAGS"] = session.env["RUSTFLAGS"]

--- a/wasm/common.mk
+++ b/wasm/common.mk
@@ -6,20 +6,18 @@ CURDIR=$(abspath .)
 BUILDROOT ?= $(CURDIR)/builddir
 PYTHON ?= python3
 PYMAJORMINORMICRO ?= $(shell $(PYTHON) --version 2>&1 | awk '{print $$2}')
+PYPRERELEASE ?=
 
 # Set version variables.
 version_tuple := $(subst ., ,$(PYMAJORMINORMICRO:v%=%))
 PYMAJOR=$(word 1,$(version_tuple))
 PYMINOR=$(word 2,$(version_tuple))
 PYMICRO=$(word 3,$(version_tuple))
-PYVERSION=$(PYMAJORMINORMICRO)
+PYVERSION=$(PYMAJORMINORMICRO)$(PYPRERELEASE)
 PYMAJORMINOR=$(PYMAJOR).$(PYMINOR)
 
-ifneq ($(PYMAJORMINOR),3.14)
-$(error PYMAJORMINOR must be 3.14, got '$(PYMAJORMINOR)')
-endif
-
-PYTHONURL=https://www.python.org/ftp/python/$(PYMAJORMINORMICRO)/Python-$(PYVERSION).tgz
+PYTHONRELEASE=$(shell echo $(PYVERSION) | sed -E 's/(a|b|rc)[0-9]+$$//')
+PYTHONURL=https://www.python.org/ftp/python/$(PYTHONRELEASE)/Python-$(PYVERSION).tgz
 PYTHONTARBALL=$(BUILDROOT)/downloads/Python-$(PYVERSION).tgz
 PYTHONBUILD=$(BUILDROOT)/build/Python-$(PYVERSION)
 
@@ -39,6 +37,12 @@ $(PYTHONBUILD)/.exists: $(PYTHONTARBALL)
 		tar -C $(dir $(PYTHONBUILD)) -xf $(PYTHONTARBALL) \
 	)
 	touch $@
+
+.PHONY: prepare clean
+
+# downloads the Python source and extracts ready for config
+# parsing and build
+prepare: $(PYTHONBUILD)/.exists
 
 clean:
 	rm -rf $(BUILDROOT)

--- a/wasm/emscripten/Makefile
+++ b/wasm/emscripten/Makefile
@@ -1,5 +1,9 @@
 include ../common.mk
 
+ifneq ($(PYMAJORMINOR),3.15)
+$(error PYMAJORMINOR must be 3.15, got '$(PYMAJORMINOR)')
+endif
+
 NODE_VERSION=24.18.0
 
 PLATFORM=wasm32_emscripten

--- a/wasm/wasi/Makefile
+++ b/wasm/wasi/Makefile
@@ -1,9 +1,13 @@
 include ../common.mk
 
-WASI_SDK_VERSION=24
+ifneq ($(PYMAJORMINOR),3.15)
+$(error PYMAJORMINOR must be 3.15, got '$(PYMAJORMINOR)')
+endif
+
+WASI_SDK_VERSION=$(shell $(PYTHON) -c 'import tomllib; print(tomllib.load(open("$(PYTHONBUILD)/Platforms/WASI/config.toml", "rb"))["targets"]["wasi-sdk"])')
 WASMTIME_VERSION=46.0.1
 
-CONFIG_SITE=$(PYTHONBUILD)/Tools/wasm/wasi/config.site-wasm32-wasi
+CONFIG_SITE=$(PYTHONBUILD)/Platforms/WASI/config.site-wasm32-wasi
 CROSSBUILD=$(PYTHONBUILD)/cross-build/wasm32-wasip1
 LIBDIR=$(CROSSBUILD)/build/lib.wasi-wasm32-$(PYMAJORMINOR)
 
@@ -36,7 +40,7 @@ endif
 
 all: $(LIBDIR)/libpython$(PYMAJORMINOR).a
 
-$(WASI_SDK_DIR)/.exists: $(BUILDROOT)/.exists
+$(WASI_SDK_DIR)/.exists: $(PYTHONBUILD)/.exists
 	[ -d $(WASI_SDK_DIR) ] || mkdir -p $(WASI_SDK_DIR)
 	curl -s -S --location $(WASI_SDK_URL) | \
 		tar --strip-components 1 --directory $(WASI_SDK_DIR) --extract --gunzip
@@ -58,10 +62,9 @@ $(LIBDIR)/libpython$(PYMAJORMINOR).a: $(PYTHONBUILD)/.patched $(WASI_SDK_DEP) $(
 	cd $(PYTHONBUILD) && \
 		WASI_SDK_PATH=$(WASI_SDK_DIR) \
 		PATH=$(WASMTIME_PATH)$(PATH) \
-		$(PYTHON) Tools/wasm/wasi build -- --config-cache
+		$(PYTHON) Platforms/WASI build -- --config-cache
 	# Collect the static libraries the test build links against
 	cp $(CROSSBUILD)/libpython$(PYMAJORMINOR).a \
-	   $(CROSSBUILD)/Modules/_hacl/libHacl_HMAC.a \
-	   $(CROSSBUILD)/Modules/_decimal/libmpdec/libmpdec.a \
+	   $(CROSSBUILD)/Modules/_hacl/*.a \
 	   $(CROSSBUILD)/Modules/expat/libexpat.a \
 	   $(LIBDIR)


### PR DESCRIPTION
Current CI runs are failing because we use an old WASI SDK (24) which can't be verified by `setup-wasi-sdk-action`.

We use 24 because that's the version CPython 3.14 tests against.

In this PR I bump the wasm jobs (wasi & emscripten) to build against 3.15 rc1 instead, which I think is slightly early but probably fine. CPython 3.15 has a config file in-line in the repository to declare the supported WASI SDK version, so we can use that to decide what to install in CI. I think it should be new enough to satisfy the setup action 🤞 

While at it, I also replace #6030 with a new approach which creates a re-usable action to populate the wasm build cache and runs it on `main`.