### PR TITLE
ci: fail merge if wasm build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -886,6 +886,7 @@ jobs:
       - careful
       - docsrs
       - emscripten
+      - wasm32-wasip1
       - test-debug
       - test-version-limits
       - check-feature-powerset


### PR DESCRIPTION
Looks like we forgot this, although at the moment the wasm build is broken due to external factors, it looks like it would be possible for us to accidentally merge something which breaks it.