### PR TITLE
internal: don't generate hash functions if `no_std`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -56,7 +56,9 @@ fn configure_pyo3() -> Result<()> {
 /// Enables a faux `std` feature by default.
 ///
 /// Set env var `PYO3_WIP_NO_STD` to `1` to disable it.
-// Has a matching function in pyo3-macros-backend's build.rs
+// Has matching functions in
+// - pyo3-macros-backend
+// - pytests
 fn configure_wip_no_std() {
     println!("cargo:rustc-check-cfg=cfg(wip_feature_std)");
     match env_var("PYO3_WIP_NO_STD").map(|s| s.into_string().unwrap()) {

--- a/build.rs
+++ b/build.rs
@@ -56,6 +56,7 @@ fn configure_pyo3() -> Result<()> {
 /// Enables a faux `std` feature by default.
 ///
 /// Set env var `PYO3_WIP_NO_STD` to `1` to disable it.
+// Has a matching function in pyo3-macros-backend's build.rs
 fn configure_wip_no_std() {
     println!("cargo:rustc-check-cfg=cfg(wip_feature_std)");
     match env_var("PYO3_WIP_NO_STD").map(|s| s.into_string().unwrap()) {

--- a/guide/src/class/object.md
+++ b/guide/src/class/object.md
@@ -179,6 +179,7 @@ This option also requires `eq`: According to the [Python docs](https://docs.pyth
 ```rust,no_run
 # use pyo3::prelude::*;
 #
+# #[cfg(wip_feature_std)]
 # #[allow(dead_code)]
 #[pyclass(frozen, eq, hash)]
 #[derive(PartialEq, Hash)]

--- a/noxfile.py
+++ b/noxfile.py
@@ -1756,6 +1756,9 @@ def update_ui_tests(session: nox.Session):
     _run_cargo(session, *command, "--features=full", env=env)
     _run_cargo(session, *command, "--features=abi3,full", env=env)
 
+    env["PYO3_WIP_NO_STD"] = "1"
+    _run_cargo(session, *command, "--features=macros,hashbrown", env=env)
+
 
 @nox.session(name="test-introspection")
 def test_introspection(session: nox.Session):

--- a/pyo3-macros-backend/build.rs
+++ b/pyo3-macros-backend/build.rs
@@ -1,0 +1,25 @@
+use std::env;
+use std::ffi::OsString;
+
+fn main() {
+    configure_wip_no_std();
+}
+
+/// Enables a faux `std` feature by default.
+///
+/// Set env var `PYO3_WIP_NO_STD` to `1` to disable it.
+// Has a matching function in pyo3's build.rs
+fn configure_wip_no_std() {
+    println!("cargo:rustc-check-cfg=cfg(wip_feature_std)");
+    match env_var("PYO3_WIP_NO_STD").map(|s| s.into_string().unwrap()) {
+        Some(no_std) if no_std.trim() == "1" || no_std.trim().eq_ignore_ascii_case("true") => (),
+        _ => println!("cargo:rustc-cfg=wip_feature_std"),
+    }
+}
+
+/// Gets an external environment variable, and registers the build script to rerun if
+/// the variable changes.
+fn env_var(var: &str) -> Option<OsString> {
+    println!("cargo:rerun-if-env-changed={var}");
+    env::var_os(var)
+}

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2536,11 +2536,19 @@ fn pyclass_hash(
     }
     match options.hash {
         Some(opt) => {
+            #[cfg(wip_feature_std)]
             let mut hash_impl = parse_quote_spanned! { opt.span() =>
                 fn __pyo3__generated____hash__(&self) -> u64 {
                     let mut s = std::collections::hash_map::DefaultHasher::new();
                     ::core::hash::Hash::hash(self, &mut s);
                     ::core::hash::Hasher::finish(&s)
+                }
+            };
+            #[cfg(not(wip_feature_std))]
+            let mut hash_impl = parse_quote_spanned! { opt.span() =>
+                fn __pyo3__generated____hash__(&self) -> u64 {
+                    compile_error!("please enable pyo3/std feature to generate a hash function");
+                    unreachable!()
                 }
             };
             let hash_slot = generate_protocol_slot(

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2547,7 +2547,7 @@ fn pyclass_hash(
             #[cfg(not(wip_feature_std))]
             let mut hash_impl = parse_quote_spanned! { opt.span() =>
                 fn __pyo3__generated____hash__(&self) -> u64 {
-                    compile_error!("please enable pyo3/std feature to generate a hash function");
+                    compile_error!("`#[pyclass(hash)]` requires PyO3's `std` feature");
                     unreachable!()
                 }
             };

--- a/pytests/build.rs
+++ b/pytests/build.rs
@@ -1,4 +1,27 @@
+use std::env;
+use std::ffi::OsString;
+
 fn main() {
+    configure_wip_no_std();
     pyo3_build_config::use_pyo3_cfgs();
     pyo3_build_config::add_extension_module_link_args();
+}
+
+/// Enables a faux `std` feature by default.
+///
+/// Set env var `PYO3_WIP_NO_STD` to `1` to disable it.
+// Has a matching function in pyo3's build.rs
+fn configure_wip_no_std() {
+    println!("cargo:rustc-check-cfg=cfg(wip_feature_std)");
+    match env_var("PYO3_WIP_NO_STD").map(|s| s.into_string().unwrap()) {
+        Some(no_std) if no_std.trim() == "1" || no_std.trim().eq_ignore_ascii_case("true") => (),
+        _ => println!("cargo:rustc-cfg=wip_feature_std"),
+    }
+}
+
+/// Gets an external environment variable, and registers the build script to rerun if
+/// the variable changes.
+fn env_var(var: &str) -> Option<OsString> {
+    println!("cargo:rerun-if-env-changed={var}");
+    env::var_os(var)
 }

--- a/pytests/src/comparisons.rs
+++ b/pytests/src/comparisons.rs
@@ -98,7 +98,8 @@ impl OrderedRichCmp {
     }
 }
 
-#[pyclass(eq, ord, hash, str, frozen)]
+#[cfg_attr(wip_feature_std, pyclass(eq, ord, hash, str, frozen))]
+#[cfg_attr(not(wip_feature_std), pyclass(eq, ord, str, frozen))]
 #[derive(PartialEq, Eq, Ord, PartialOrd, Hash)]
 struct OrderedDerived(i64);
 

--- a/tests/test_class_basics.rs
+++ b/tests/test_class_basics.rs
@@ -227,6 +227,7 @@ fn class_with_object_field() {
     });
 }
 
+#[cfg(wip_feature_std)]
 #[pyclass(frozen, eq, hash)]
 #[derive(PartialEq, Hash)]
 struct ClassWithHash {
@@ -234,6 +235,7 @@ struct ClassWithHash {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn class_with_hash() {
     Python::attach(|py| {
         use pyo3::types::IntoPyDict;

--- a/tests/test_compile_error.rs
+++ b/tests/test_compile_error.rs
@@ -1,6 +1,11 @@
 #![cfg(feature = "macros")]
 
-use std::env;
+use std::{
+    env,
+    panic::{RefUnwindSafe, UnwindSafe},
+};
+
+use ui_test::{spanned::Spanned, CommentParser, Revisioned};
 
 fn main() {
     if cfg!(target_arch = "wasm32") {
@@ -171,28 +176,34 @@ fn main() {
         ),
     ]);
 
+    /// Generic function to configure a revision to require a given feature to
+    /// be enabled or disabled (`custom_comments` requires function pointers).
+    fn require_feature_enabled<F: Feature, const ENABLED: bool>(
+        parser: &mut CommentParser<&mut Revisioned>,
+        _args: Spanned<&str>,
+        span: Span,
+    ) {
+        parser.set_custom_once(
+            F::ENABLED_FLAG,
+            SplitBuildOnFeature::<F>::new(ENABLED),
+            span,
+        );
+    }
+
+    config.custom_comments.insert(
+        ExperimentalInspect::ENABLED_FLAG,
+        require_feature_enabled::<ExperimentalInspect, true>,
+    );
+    config.custom_comments.insert(
+        ExperimentalInspect::DISABLED_FLAG,
+        require_feature_enabled::<ExperimentalInspect, false>,
+    );
     config
         .custom_comments
-        .insert("with-experimental-inspect", |parser, _args, span| {
-            parser.set_custom_once(
-                "with-experimental-inspect",
-                SplitBuildOnExperimentalInspect {
-                    requires_inspect: true,
-                },
-                span,
-            );
-        });
+        .insert(Std::ENABLED_FLAG, require_feature_enabled::<Std, true>);
     config
         .custom_comments
-        .insert("without-experimental-inspect", |parser, _args, span| {
-            parser.set_custom_once(
-                "without-experimental-inspect",
-                SplitBuildOnExperimentalInspect {
-                    requires_inspect: false,
-                },
-                span,
-            );
-        });
+        .insert(Std::DISABLED_FLAG, require_feature_enabled::<Std, false>);
 
     // `ctrlc` doesn't build on wasm
     #[cfg(not(target_arch = "wasm32"))]
@@ -321,14 +332,71 @@ fn bless_output_files_normalized(
     }
 }
 
-/// Some tests have different error messages when the `experimental-inspect` feature is
-/// enabled.
-#[derive(Clone, Debug)]
-struct SplitBuildOnExperimentalInspect {
-    requires_inspect: bool,
+/// Trait naming a feature which may be enabled or disabled in a given build.
+///
+/// The trait bounds are useful because `ui_test`'s `Flag` trait requires all these.
+trait Feature: Send + Sync + UnwindSafe + RefUnwindSafe + 'static {
+    const ENABLED: bool;
+    const ENABLED_FLAG: &'static str;
+    const DISABLED_FLAG: &'static str;
 }
 
-impl ui_test::custom_flags::Flag for SplitBuildOnExperimentalInspect {
+struct ExperimentalInspect;
+
+impl Feature for ExperimentalInspect {
+    const ENABLED: bool = cfg!(feature = "experimental-inspect");
+    const ENABLED_FLAG: &'static str = "with-experimental-inspect";
+    const DISABLED_FLAG: &'static str = "no-experimental-inspect";
+}
+
+struct Std;
+
+impl Feature for Std {
+    const ENABLED: bool = cfg!(wip_feature_std);
+    const ENABLED_FLAG: &'static str = "with-std";
+    const DISABLED_FLAG: &'static str = "no-std";
+}
+/// Some tests have different error messages when a given feature is
+/// enabled.
+struct SplitBuildOnFeature<F: Feature> {
+    /// Whether the revision requires the feature to be enabled.
+    feature_required: bool,
+    phantom: std::marker::PhantomData<F>,
+}
+
+// Avoid `#[derive(Clone)]` because `F` may not be `Clone`.
+impl<F: Feature> Clone for SplitBuildOnFeature<F> {
+    fn clone(&self) -> Self {
+        Self {
+            feature_required: self.feature_required,
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+// Debug the revision as the feature flag which it requires
+impl<F: Feature> std::fmt::Debug for SplitBuildOnFeature<F> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SplitBuildOnFeature")
+            .field(if self.feature_required {
+                &F::ENABLED_FLAG
+            } else {
+                &F::DISABLED_FLAG
+            })
+            .finish()
+    }
+}
+
+impl<F: Feature> SplitBuildOnFeature<F> {
+    fn new(feature_required: bool) -> Self {
+        Self {
+            feature_required,
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<F: Feature> ui_test::custom_flags::Flag for SplitBuildOnFeature<F> {
     fn clone_inner(&self) -> Box<dyn ui_test::custom_flags::Flag> {
         Box::new(self.clone())
     }
@@ -345,6 +413,6 @@ impl ui_test::custom_flags::Flag for SplitBuildOnExperimentalInspect {
     ) -> bool {
         // returning `true` skips the test, so return true when the feature doesn't
         // match the requirement of the test
-        self.requires_inspect != cfg!(feature = "experimental-inspect")
+        self.feature_required != F::ENABLED
     }
 }

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -285,6 +285,7 @@ fn test_simple_enum_eq_only() {
     })
 }
 
+#[cfg(wip_feature_std)]
 #[pyclass(frozen, eq, eq_int, hash)]
 #[derive(PartialEq, Hash)]
 enum SimpleEnumWithHash {
@@ -293,6 +294,7 @@ enum SimpleEnumWithHash {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn test_simple_enum_with_hash() {
     Python::attach(|py| {
         use pyo3::types::IntoPyDict;
@@ -315,6 +317,7 @@ fn test_simple_enum_with_hash() {
     });
 }
 
+#[cfg(wip_feature_std)]
 #[pyclass(eq, hash)]
 #[derive(PartialEq, Hash)]
 enum ComplexEnumWithHash {
@@ -323,6 +326,7 @@ enum ComplexEnumWithHash {
 }
 
 #[test]
+#[cfg(wip_feature_std)]
 fn test_complex_enum_with_hash() {
     Python::attach(|py| {
         use pyo3::types::IntoPyDict;

--- a/tests/ui/invalid_property_args.rs
+++ b/tests/ui/invalid_property_args.rs
@@ -1,5 +1,5 @@
 //@revisions: default inspect
-//@[default] without-experimental-inspect
+//@[default] no-experimental-inspect
 //@[inspect] with-experimental-inspect
 
 use pyo3::prelude::*;

--- a/tests/ui/invalid_pyclass_args.inspect.stderr
+++ b/tests/ui/invalid_pyclass_args.inspect.stderr
@@ -1,109 +1,109 @@
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
- --> tests/ui/invalid_pyclass_args.rs:9:11
-  |
-9 | #[pyclass(extend=pyo3::types::PyDict)]
-  |           ^^^^^^
+  --> tests/ui/invalid_pyclass_args.rs:11:11
+   |
+11 | #[pyclass(extend=pyo3::types::PyDict)]
+   |           ^^^^^^
 
 error: expected identifier
-  --> tests/ui/invalid_pyclass_args.rs:13:21
+  --> tests/ui/invalid_pyclass_args.rs:15:21
    |
-13 | #[pyclass(extends = "PyDict")]
+15 | #[pyclass(extends = "PyDict")]
    |                     ^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:17:18
+  --> tests/ui/invalid_pyclass_args.rs:19:18
    |
-17 | #[pyclass(name = m::MyClass)]
+19 | #[pyclass(name = m::MyClass)]
    |                  ^
 
 error: expected a single identifier in double quotes
-  --> tests/ui/invalid_pyclass_args.rs:21:18
+  --> tests/ui/invalid_pyclass_args.rs:23:18
    |
-21 | #[pyclass(name = "Custom Name")]
+23 | #[pyclass(name = "Custom Name")]
    |                  ^^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:25:18
+  --> tests/ui/invalid_pyclass_args.rs:27:18
    |
-25 | #[pyclass(name = CustomName)]
+27 | #[pyclass(name = CustomName)]
    |                  ^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:29:24
+  --> tests/ui/invalid_pyclass_args.rs:31:24
    |
-29 | #[pyclass(rename_all = camelCase)]
+31 | #[pyclass(rename_all = camelCase)]
    |                        ^^^^^^^^^
 
 error: expected a valid renaming rule, possible values are: "camelCase", "kebab-case", "lowercase", "PascalCase", "SCREAMING-KEBAB-CASE", "SCREAMING_SNAKE_CASE", "snake_case", "UPPERCASE"
-  --> tests/ui/invalid_pyclass_args.rs:33:24
+  --> tests/ui/invalid_pyclass_args.rs:35:24
    |
-33 | #[pyclass(rename_all = "Camel-Case")]
+35 | #[pyclass(rename_all = "Camel-Case")]
    |                        ^^^^^^^^^^^^
 
 error: expected string literal
-  --> tests/ui/invalid_pyclass_args.rs:37:20
+  --> tests/ui/invalid_pyclass_args.rs:39:20
    |
-37 | #[pyclass(module = my_module)]
+39 | #[pyclass(module = my_module)]
    |                    ^^^^^^^^^
 
 error: expected one of: `crate`, `dict`, `eq`, `eq_int`, `extends`, `freelist`, `frozen`, `get_all`, `hash`, `immutable_type`, `mapping`, `module`, `name`, `ord`, `rename_all`, `sequence`, `set_all`, `new`, `str`, `subclass`, `unsendable`, `weakref`, `generic`, `from_py_object`, `skip_from_py_object`
-  --> tests/ui/invalid_pyclass_args.rs:41:11
+  --> tests/ui/invalid_pyclass_args.rs:43:11
    |
-41 | #[pyclass(weakrev)]
+43 | #[pyclass(weakrev)]
    |           ^^^^^^^
 
 error: a `#[pyclass]` cannot be both a `mapping` and a `sequence`
-  --> tests/ui/invalid_pyclass_args.rs:46:8
+  --> tests/ui/invalid_pyclass_args.rs:48:8
    |
-46 | struct CannotBeMappingAndSequence {}
+48 | struct CannotBeMappingAndSequence {}
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: `eq_int` can only be used on simple enums.
-  --> tests/ui/invalid_pyclass_args.rs:73:11
+  --> tests/ui/invalid_pyclass_args.rs:75:11
    |
-73 | #[pyclass(eq_int)]
+75 | #[pyclass(eq_int)]
    |           ^^^^^^
 
 error: The `hash` option requires the `frozen` option.
-  --> tests/ui/invalid_pyclass_args.rs:82:11
+  --> tests/ui/invalid_pyclass_args.rs:85:11
    |
-82 | #[pyclass(hash)]
+85 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `hash` option requires the `eq` option.
-  --> tests/ui/invalid_pyclass_args.rs:82:11
+  --> tests/ui/invalid_pyclass_args.rs:85:11
    |
-82 | #[pyclass(hash)]
+85 | #[pyclass(hash)]
    |           ^^^^
 
 error: The `ord` option requires the `eq` option.
-   --> tests/ui/invalid_pyclass_args.rs:102:11
+   --> tests/ui/invalid_pyclass_args.rs:106:11
     |
-102 | #[pyclass(ord)]
+106 | #[pyclass(ord)]
     |           ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:110:12
+   --> tests/ui/invalid_pyclass_args.rs:114:12
     |
-110 |     #[pyo3(foo)]
+114 |     #[pyo3(foo)]
     |            ^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:112:12
+   --> tests/ui/invalid_pyclass_args.rs:116:12
     |
-112 |     #[pyo3(blah)]
+116 |     #[pyo3(blah)]
     |            ^^^^
 
 error: expected one of: `get`, `set`, `name`
-   --> tests/ui/invalid_pyclass_args.rs:115:12
+   --> tests/ui/invalid_pyclass_args.rs:119:12
     |
-115 |     #[pyo3(pop)]
+119 |     #[pyo3(pop)]
     |            ^^^
 
 error: invalid format string: expected `}` but string was terminated
-   --> tests/ui/invalid_pyclass_args.rs:139:19
+   --> tests/ui/invalid_pyclass_args.rs:143:19
     |
-139 | #[pyclass(str = "{")]
+143 | #[pyclass(str = "{")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -111,9 +111,9 @@ error: invalid format string: expected `}` but string was terminated
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: invalid format string: expected `}`, found `$`
-   --> tests/ui/invalid_pyclass_args.rs:144:19
+   --> tests/ui/invalid_pyclass_args.rs:148:19
     |
-144 | #[pyclass(str = "{$}")]
+148 | #[pyclass(str = "{$}")]
     |                  -^ expected `}` in format string
     |                  |
     |                  because of this opening brace
@@ -121,92 +121,92 @@ error: invalid format string: expected `}`, found `$`
     = note: if you intended to print `{`, you can escape it using `{{`
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:172:31
+   --> tests/ui/invalid_pyclass_args.rs:176:31
     |
-172 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+176 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:179:31
+   --> tests/ui/invalid_pyclass_args.rs:183:31
     |
-179 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
+183 | #[pyclass(name = "aaa", str = "unsafe: {unsafe_variable}")]
     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:185:17
+   --> tests/ui/invalid_pyclass_args.rs:189:17
     |
-185 | #[pyclass(str = "unsafe: {unsafe_variable}")]
+189 | #[pyclass(str = "unsafe: {unsafe_variable}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The format string syntax is incompatible with any renaming via `name` or `rename_all`
-   --> tests/ui/invalid_pyclass_args.rs:192:54
+   --> tests/ui/invalid_pyclass_args.rs:196:54
     |
-192 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
+196 | #[pyclass(rename_all = "SCREAMING_SNAKE_CASE", str = "{a_a}, {b_b}, {c_d_e}")]
     |                                                      ^^^^^^^^^^^^^^^^^^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:200:17
+   --> tests/ui/invalid_pyclass_args.rs:204:17
     |
-200 | #[pyclass(str = "{:?}")]
+204 | #[pyclass(str = "{:?}")]
     |                 ^^^^^^
 
 error: No member found, you must provide a named or positionally specified member.
-   --> tests/ui/invalid_pyclass_args.rs:208:17
+   --> tests/ui/invalid_pyclass_args.rs:212:17
     |
-208 | #[pyclass(str = "{}")]
+212 | #[pyclass(str = "{}")]
     |                 ^^^^
 
 error: The format string syntax cannot be used with enums
-   --> tests/ui/invalid_pyclass_args.rs:216:21
+   --> tests/ui/invalid_pyclass_args.rs:220:21
     |
-216 | #[pyclass(eq, str = "Stuff...")]
+220 | #[pyclass(eq, str = "Stuff...")]
     |                     ^^^^^^^^^^
 
 error: `skip_from_py_object` and `from_py_object` are mutually exclusive
-   --> tests/ui/invalid_pyclass_args.rs:230:27
+   --> tests/ui/invalid_pyclass_args.rs:234:27
     |
-230 | #[pyclass(from_py_object, skip_from_py_object)]
+234 | #[pyclass(from_py_object, skip_from_py_object)]
     |                           ^^^^^^^^^^^^^^^^^^^
 
 error: use of deprecated constant `pyo3::impl_::deprecated::SKIP_FROM_PY_OBJECT_DEPRECATED`: `skip_from_py_object` enabled by default. The option will be removed in the future
-   --> tests/ui/invalid_pyclass_args.rs:244:11
+   --> tests/ui/invalid_pyclass_args.rs:248:11
     |
-244 | #[pyclass(skip_from_py_object)]
+248 | #[pyclass(skip_from_py_object)]
     |           ^^^^^^^^^^^^^^^^^^^
     |
 note: the lint level is defined here
-   --> tests/ui/invalid_pyclass_args.rs:4:9
+   --> tests/ui/invalid_pyclass_args.rs:6:9
     |
-  4 | #![deny(deprecated)]
+  6 | #![deny(deprecated)]
     |         ^^^^^^^^^^
 
 error[E0277]: the trait bound `StructFromPyObjectNoClone: Clone` is not satisfied
-   --> tests/ui/invalid_pyclass_args.rs:237:11
+   --> tests/ui/invalid_pyclass_args.rs:241:11
     |
-237 | #[pyclass(from_py_object)]
+241 | #[pyclass(from_py_object)]
     |           ^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `StructFromPyObjectNoClone`
     |
 help: consider annotating `StructFromPyObjectNoClone` with `#[derive(Clone)]`
     |
-239 + #[derive(Clone)]
-240 | struct StructFromPyObjectNoClone {
+243 + #[derive(Clone)]
+244 | struct StructFromPyObjectNoClone {
     |
 
 error[E0119]: conflicting implementations of trait `pyo3::impl_::pyclass::doc::PyClassNewTextSignature` for type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:270:1
     |
-258 | #[pyclass(new = "from_fields")]
+262 | #[pyclass(new = "from_fields")]
     | ------------------------------- first implementation here
 ...
-266 | #[pymethods]
+270 | #[pymethods]
     | ^^^^^^^^^^^^ conflicting implementation for `NewFromFieldsWithManualNew`
     |
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:253:12
+   --> tests/ui/invalid_pyclass_args.rs:257:12
     |
-253 |     field: Box<dyn std::error::Error + Send + Sync>,
+257 |     field: Box<dyn std::error::Error + Send + Sync>,
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
     |
     = help: the trait `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, false>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
@@ -234,231 +234,231 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
   | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
 
 error[E0592]: duplicate definitions with name `__pymethod___richcmp____`
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:56:1
    |
-54 | #[pyclass(eq)]
+56 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___richcmp____`
 ...
-60 | #[pymethods]
+62 | #[pymethods]
    | ------------ other definition for `__pymethod___richcmp____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___hash____`
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:91:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+91 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___hash____`
 ...
-94 | #[pymethods]
+98 | #[pymethods]
    | ------------ other definition for `__pymethod___hash____`
    |
    = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___str____`
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:124:1
     |
-120 | #[pyclass(str)]
+124 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___str____`
 ...
-131 | #[pymethods]
+135 | #[pymethods]
     | ------------ other definition for `__pymethod___str____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0592]: duplicate definitions with name `__pymethod___new____`
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:262:1
     |
-258 | #[pyclass(new = "from_fields")]
+262 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate definitions for `__pymethod___new____`
 ...
-266 | #[pymethods]
+270 | #[pymethods]
     | ------------ other definition for `__pymethod___new____`
     |
     = note: this error originates in the attribute macro `pyclass` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0369]: binary operation `==` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:49:11
+  --> tests/ui/invalid_pyclass_args.rs:51:11
    |
-49 | #[pyclass(eq)]
+51 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:52:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-52 | struct EqOptRequiresEq {}
+54 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-52 + #[derive(PartialEq)]
-53 | struct EqOptRequiresEq {}
+54 + #[derive(PartialEq)]
+55 | struct EqOptRequiresEq {}
    |
 
 error[E0369]: binary operation `!=` cannot be applied to type `&EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:49:11
+  --> tests/ui/invalid_pyclass_args.rs:51:11
    |
-49 | #[pyclass(eq)]
+51 | #[pyclass(eq)]
    |           ^^
    |
 note: an implementation of `PartialEq` might be missing for `EqOptRequiresEq`
-  --> tests/ui/invalid_pyclass_args.rs:52:1
+  --> tests/ui/invalid_pyclass_args.rs:54:1
    |
-52 | struct EqOptRequiresEq {}
+54 | struct EqOptRequiresEq {}
    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
 help: consider annotating `EqOptRequiresEq` with `#[derive(PartialEq)]`
    |
-52 + #[derive(PartialEq)]
-53 | struct EqOptRequiresEq {}
+54 + #[derive(PartialEq)]
+55 | struct EqOptRequiresEq {}
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:56:1
    |
-54 | #[pyclass(eq)]
+56 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:56:1
    |
-54 | #[pyclass(eq)]
+56 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:60:1
+  --> tests/ui/invalid_pyclass_args.rs:62:1
    |
-60 | #[pymethods]
+62 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:60:1
+  --> tests/ui/invalid_pyclass_args.rs:62:1
    |
-60 | #[pymethods]
+62 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___richcmp____` found
    |
 note: candidate #1 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:54:1
+  --> tests/ui/invalid_pyclass_args.rs:56:1
    |
-54 | #[pyclass(eq)]
+56 | #[pyclass(eq)]
    | ^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
-  --> tests/ui/invalid_pyclass_args.rs:60:1
+  --> tests/ui/invalid_pyclass_args.rs:62:1
    |
-60 | #[pymethods]
+62 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
-  --> tests/ui/invalid_pyclass_args.rs:77:23
+  --> tests/ui/invalid_pyclass_args.rs:79:23
    |
-77 | #[pyclass(frozen, eq, hash)]
+79 | #[pyclass(frozen, eq, hash)]
    |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
    |
 help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
    |
-80 + #[derive(Hash)]
-81 | struct HashOptRequiresHash;
+83 + #[derive(Hash)]
+84 | struct HashOptRequiresHash;
    |
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:91:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+91 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:91:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+91 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:94:1
+  --> tests/ui/invalid_pyclass_args.rs:98:1
    |
-94 | #[pymethods]
+98 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-  --> tests/ui/invalid_pyclass_args.rs:94:1
+  --> tests/ui/invalid_pyclass_args.rs:98:1
    |
-94 | #[pymethods]
+98 | #[pymethods]
    | ^^^^^^^^^^^^ multiple `__pymethod___hash____` found
    |
 note: candidate #1 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:88:1
+  --> tests/ui/invalid_pyclass_args.rs:91:1
    |
-88 | #[pyclass(frozen, eq, hash)]
+91 | #[pyclass(frozen, eq, hash)]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `HashOptAndManualHash`
-  --> tests/ui/invalid_pyclass_args.rs:94:1
+  --> tests/ui/invalid_pyclass_args.rs:98:1
    |
-94 | #[pymethods]
+98 | #[pymethods]
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:124:1
     |
-120 | #[pyclass(str)]
+124 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:124:1
     |
-120 | #[pyclass(str)]
+124 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:131:1
+   --> tests/ui/invalid_pyclass_args.rs:135:1
     |
-131 | #[pymethods]
+135 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:131:1
+   --> tests/ui/invalid_pyclass_args.rs:135:1
     |
-131 | #[pymethods]
+135 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___str____` found
     |
 note: candidate #1 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:120:1
+   --> tests/ui/invalid_pyclass_args.rs:124:1
     |
-120 | #[pyclass(str)]
+124 | #[pyclass(str)]
     | ^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `StrOptAndManualStr`
-   --> tests/ui/invalid_pyclass_args.rs:131:1
+   --> tests/ui/invalid_pyclass_args.rs:135:1
     |
-131 | #[pymethods]
+135 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0609]: no field `aaaa` on type `&Point`
-   --> tests/ui/invalid_pyclass_args.rs:149:17
+   --> tests/ui/invalid_pyclass_args.rs:153:17
     |
-149 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}")]
+153 | #[pyclass(str = "X: {aaaa}, Y: {y}, Z: {z}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `zzz` on type `&Point2`
-   --> tests/ui/invalid_pyclass_args.rs:158:17
+   --> tests/ui/invalid_pyclass_args.rs:162:17
     |
-158 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}")]
+162 | #[pyclass(str = "X: {x}, Y: {y}}}, Z: {zzz}")]
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `x`, `y`, `z`
 
 error[E0609]: no field `162543` on type `&Coord3`
-   --> tests/ui/invalid_pyclass_args.rs:167:17
+   --> tests/ui/invalid_pyclass_args.rs:171:17
     |
-167 | #[pyclass(str = "{0}, {162543}, {2}")]
+171 | #[pyclass(str = "{0}, {162543}, {2}")]
     |                 ^^^^^^^^^^^^^^^^^^^^ unknown field
     |
     = note: available fields are: `0`, `1`, `2`
 
 error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Python function argument
-   --> tests/ui/invalid_pyclass_args.rs:253:12
+   --> tests/ui/invalid_pyclass_args.rs:257:12
     |
-253 |     field: Box<dyn std::error::Error + Send + Sync>,
+257 |     field: Box<dyn std::error::Error + Send + Sync>,
     |            ^^^ the trait `FromPyObject<'_, '_>` is not implemented for `Box<dyn std::error::Error + Send + Sync>`
     |
     = note: implement `FromPyObject` to enable using `Box<dyn std::error::Error + Send + Sync>` as a function argument
@@ -484,38 +484,38 @@ note: required by a bound in `pyo3::impl_::extract_argument::extract_required_ar
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `extract_required_argument`
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:262:1
     |
-258 | #[pyclass(new = "from_fields")]
+262 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:262:1
     |
-258 | #[pyclass(new = "from_fields")]
+262 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:270:1
     |
-266 | #[pymethods]
+270 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pyclass` which comes from the expansion of the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0034]: multiple applicable items in scope
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:270:1
     |
-266 | #[pymethods]
+270 | #[pymethods]
     | ^^^^^^^^^^^^ multiple `__pymethod___new____` found
     |
 note: candidate #1 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:258:1
+   --> tests/ui/invalid_pyclass_args.rs:262:1
     |
-258 | #[pyclass(new = "from_fields")]
+262 | #[pyclass(new = "from_fields")]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNew`
-   --> tests/ui/invalid_pyclass_args.rs:266:1
+   --> tests/ui/invalid_pyclass_args.rs:270:1
     |
-266 | #[pymethods]
+270 | #[pymethods]
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 

--- a/tests/ui/invalid_pyclass_args.nostd.stderr
+++ b/tests/ui/invalid_pyclass_args.nostd.stderr
@@ -64,6 +64,12 @@ error: `eq_int` can only be used on simple enums.
 75 | #[pyclass(eq_int)]
    |           ^^^^^^
 
+error: please enable pyo3/std feature to generate a hash function
+  --> tests/ui/invalid_pyclass_args.rs:79:23
+   |
+79 | #[pyclass(frozen, eq, hash)]
+   |                       ^^^^
+
 error: The `hash` option requires the `frozen` option.
   --> tests/ui/invalid_pyclass_args.rs:85:11
    |
@@ -75,6 +81,12 @@ error: The `hash` option requires the `eq` option.
    |
 85 | #[pyclass(hash)]
    |           ^^^^
+
+error: please enable pyo3/std feature to generate a hash function
+  --> tests/ui/invalid_pyclass_args.rs:91:23
+   |
+91 | #[pyclass(frozen, eq, hash)]
+   |                       ^^^^
 
 error: The `ord` option requires the `eq` option.
    --> tests/ui/invalid_pyclass_args.rs:106:11
@@ -317,18 +329,6 @@ note: candidate #2 is defined in an impl for the type `EqOptAndManualRichCmp`
    | ^^^^^^^^^^^^
    = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error[E0277]: the trait bound `HashOptRequiresHash: Hash` is not satisfied
-  --> tests/ui/invalid_pyclass_args.rs:79:23
-   |
-79 | #[pyclass(frozen, eq, hash)]
-   |                       ^^^^ the trait `Hash` is not implemented for `HashOptRequiresHash`
-   |
-help: consider annotating `HashOptRequiresHash` with `#[derive(Hash)]`
-   |
-83 + #[derive(Hash)]
-84 | struct HashOptRequiresHash;
-   |
-
 error[E0034]: multiple applicable items in scope
   --> tests/ui/invalid_pyclass_args.rs:91:1
    |
@@ -489,7 +489,7 @@ note: candidate #2 is defined in an impl for the type `NewFromFieldsWithManualNe
     | ^^^^^^^^^^^^
     = note: this error originates in the attribute macro `pymethods` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: aborting due to 49 previous errors
+error: aborting due to 50 previous errors
 
 Some errors have detailed explanations: E0034, E0119, E0277, E0369, E0592, E0609.
 For more information about an error, try `rustc --explain E0034`.

--- a/tests/ui/invalid_pyclass_args.nostd.stderr
+++ b/tests/ui/invalid_pyclass_args.nostd.stderr
@@ -64,7 +64,7 @@ error: `eq_int` can only be used on simple enums.
 75 | #[pyclass(eq_int)]
    |           ^^^^^^
 
-error: please enable pyo3/std feature to generate a hash function
+error: `#[pyclass(hash)]` requires PyO3's `std` feature
   --> tests/ui/invalid_pyclass_args.rs:79:23
    |
 79 | #[pyclass(frozen, eq, hash)]
@@ -82,7 +82,7 @@ error: The `hash` option requires the `eq` option.
 85 | #[pyclass(hash)]
    |           ^^^^
 
-error: please enable pyo3/std feature to generate a hash function
+error: `#[pyclass(hash)]` requires PyO3's `std` feature
   --> tests/ui/invalid_pyclass_args.rs:91:23
    |
 91 | #[pyclass(frozen, eq, hash)]

--- a/tests/ui/invalid_pyclass_args.rs
+++ b/tests/ui/invalid_pyclass_args.rs
@@ -1,6 +1,8 @@
-//@revisions: default inspect
-//@[default] without-experimental-inspect
+//@revisions: default nostd inspect
+//@[default,nostd] no-experimental-inspect
 //@[inspect] with-experimental-inspect
+//@[default,inspect] with-std
+//@[nostd] no-std
 #![deny(deprecated)]
 
 use pyo3::prelude::*;
@@ -75,7 +77,8 @@ impl EqOptAndManualRichCmp {
 struct NoEqInt {}
 
 #[pyclass(frozen, eq, hash)]
-//~^ ERROR: the trait bound `HashOptRequiresHash: Hash` is not satisfied
+//~[default,inspect]^ ERROR: the trait bound `HashOptRequiresHash: Hash` is not satisfied
+//~[nostd]| ERROR: please enable pyo3/std feature to generate a hash function
 #[derive(PartialEq)]
 struct HashOptRequiresHash;
 
@@ -88,6 +91,7 @@ struct HashWithoutFrozenAndEq;
 #[pyclass(frozen, eq, hash)]
 //~^ ERROR: duplicate definitions with name `__pymethod___hash____`
 //~| ERROR: multiple applicable items in scope
+//~[nostd]| ERROR: please enable pyo3/std feature to generate a hash function
 #[derive(PartialEq, Hash)]
 struct HashOptAndManualHash {}
 

--- a/tests/ui/invalid_pyclass_args.rs
+++ b/tests/ui/invalid_pyclass_args.rs
@@ -78,7 +78,7 @@ struct NoEqInt {}
 
 #[pyclass(frozen, eq, hash)]
 //~[default,inspect]^ ERROR: the trait bound `HashOptRequiresHash: Hash` is not satisfied
-//~[nostd]| ERROR: please enable pyo3/std feature to generate a hash function
+//~[nostd]| ERROR: `#[pyclass(hash)]` requires PyO3's `std` feature
 #[derive(PartialEq)]
 struct HashOptRequiresHash;
 
@@ -91,7 +91,7 @@ struct HashWithoutFrozenAndEq;
 #[pyclass(frozen, eq, hash)]
 //~^ ERROR: duplicate definitions with name `__pymethod___hash____`
 //~| ERROR: multiple applicable items in scope
-//~[nostd]| ERROR: please enable pyo3/std feature to generate a hash function
+//~[nostd]| ERROR: `#[pyclass(hash)]` requires PyO3's `std` feature
 #[derive(PartialEq, Hash)]
 struct HashOptAndManualHash {}
 

--- a/tests/ui/invalid_pyclass_enum.default.stderr
+++ b/tests/ui/invalid_pyclass_enum.default.stderr
@@ -1,0 +1,238 @@
+error: enums can't be inherited by other classes
+ --> tests/ui/invalid_pyclass_enum.rs:7:11
+  |
+7 | #[pyclass(subclass)]
+  |           ^^^^^^^^
+
+error: enums can't extend from other classes
+  --> tests/ui/invalid_pyclass_enum.rs:14:11
+   |
+14 | #[pyclass(extends = PyList)]
+   |           ^^^^^^^
+
+error: #[pyclass] can't be used on enums without any variants
+  --> tests/ui/invalid_pyclass_enum.rs:22:18
+   |
+22 | enum NoEmptyEnum {}
+   |                  ^^
+
+error: Unit variant `UnitVariant` is not yet supported in a complex enum
+       = help: change to an empty tuple variant instead: `UnitVariant()`
+       = note: the enum is complex because of non-unit variant `StructVariant`
+  --> tests/ui/invalid_pyclass_enum.rs:28:5
+   |
+28 |     UnitVariant,
+   |     ^^^^^^^^^^^
+
+error: `constructor` can't be used on a simple enum variant
+  --> tests/ui/invalid_pyclass_enum.rs:34:12
+   |
+34 |     #[pyo3(constructor = (a, b))]
+   |            ^^^^^^^^^^^
+
+error: The `eq_int` option requires the `eq` option.
+  --> tests/ui/invalid_pyclass_enum.rs:56:11
+   |
+56 | #[pyclass(eq_int)]
+   |           ^^^^^^
+
+error: `eq_int` can only be used on simple enums.
+  --> tests/ui/invalid_pyclass_enum.rs:63:11
+   |
+63 | #[pyclass(eq_int)]
+   |           ^^^^^^
+
+error: The `hash` option requires the `frozen` option.
+  --> tests/ui/invalid_pyclass_enum.rs:88:11
+   |
+88 | #[pyclass(hash)]
+   |           ^^^^
+
+error: The `hash` option requires the `eq` option.
+  --> tests/ui/invalid_pyclass_enum.rs:88:11
+   |
+88 | #[pyclass(hash)]
+   |           ^^^^
+
+error: The `hash` option requires the `eq` option.
+  --> tests/ui/invalid_pyclass_enum.rs:97:11
+   |
+97 | #[pyclass(hash)]
+   |           ^^^^
+
+error: The `ord` option requires the `eq` option.
+   --> tests/ui/invalid_pyclass_enum.rs:105:11
+    |
+105 | #[pyclass(ord)]
+    |           ^^^
+
+error: #[pyclass] can't be used on enums without any variants - all variants of enum `AllEnumVariantsDisabled` have been configured out by cfg attributes
+   --> tests/ui/invalid_pyclass_enum.rs:125:6
+    |
+125 | enum AllEnumVariantsDisabled {
+    |      ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0369]: binary operation `==` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:40:11
+   |
+40 | #[pyclass(eq, eq_int)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:43:1
+   |
+43 | enum SimpleEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `SimpleEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+43 + #[derive(PartialEq)]
+44 | enum SimpleEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `!=` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:40:11
+   |
+40 | #[pyclass(eq, eq_int)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:43:1
+   |
+43 | enum SimpleEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `SimpleEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+43 + #[derive(PartialEq)]
+44 | enum SimpleEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `==` cannot be applied to type `&ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:48:11
+   |
+48 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:51:1
+   |
+51 | enum ComplexEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `ComplexEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+51 + #[derive(PartialEq)]
+52 | enum ComplexEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `!=` cannot be applied to type `&ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:48:11
+   |
+48 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:51:1
+   |
+51 | enum ComplexEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `ComplexEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+51 + #[derive(PartialEq)]
+52 | enum ComplexEqOptRequiresPartialEq {
+   |
+
+error[E0277]: the trait bound `SimpleHashOptRequiresHash: Hash` is not satisfied
+  --> tests/ui/invalid_pyclass_enum.rs:70:31
+   |
+70 | #[pyclass(frozen, eq, eq_int, hash)]
+   |                               ^^^^ the trait `Hash` is not implemented for `SimpleHashOptRequiresHash`
+   |
+help: consider annotating `SimpleHashOptRequiresHash` with `#[derive(Hash)]`
+   |
+74 + #[derive(Hash)]
+75 | enum SimpleHashOptRequiresHash {
+   |
+
+error[E0277]: the trait bound `ComplexHashOptRequiresHash: Hash` is not satisfied
+  --> tests/ui/invalid_pyclass_enum.rs:79:23
+   |
+79 | #[pyclass(frozen, eq, hash)]
+   |                       ^^^^ the trait `Hash` is not implemented for `ComplexHashOptRequiresHash`
+   |
+help: consider annotating `ComplexHashOptRequiresHash` with `#[derive(Hash)]`
+   |
+83 + #[derive(Hash)]
+84 | enum ComplexHashOptRequiresHash {
+   |
+
+error[E0369]: binary operation `>` cannot be applied to type `&InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:112:15
+    |
+112 | #[pyclass(eq, ord)]
+    |               ^^^
+    |
+note: an implementation of `PartialOrd` might be missing for `InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:118:1
+    |
+118 | enum InvalidOrderedComplexEnum2 {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialOrd`
+help: consider annotating `InvalidOrderedComplexEnum2` with `#[derive(PartialEq, PartialOrd)]`
+    |
+118 + #[derive(PartialEq, PartialOrd)]
+119 | enum InvalidOrderedComplexEnum2 {
+    |
+
+error[E0369]: binary operation `<` cannot be applied to type `&InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:112:15
+    |
+112 | #[pyclass(eq, ord)]
+    |               ^^^
+    |
+note: an implementation of `PartialOrd` might be missing for `InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:118:1
+    |
+118 | enum InvalidOrderedComplexEnum2 {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialOrd`
+help: consider annotating `InvalidOrderedComplexEnum2` with `#[derive(PartialEq, PartialOrd)]`
+    |
+118 + #[derive(PartialEq, PartialOrd)]
+119 | enum InvalidOrderedComplexEnum2 {
+    |
+
+error[E0369]: binary operation `<=` cannot be applied to type `&InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:112:15
+    |
+112 | #[pyclass(eq, ord)]
+    |               ^^^
+    |
+note: an implementation of `PartialOrd` might be missing for `InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:118:1
+    |
+118 | enum InvalidOrderedComplexEnum2 {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialOrd`
+help: consider annotating `InvalidOrderedComplexEnum2` with `#[derive(PartialEq, PartialOrd)]`
+    |
+118 + #[derive(PartialEq, PartialOrd)]
+119 | enum InvalidOrderedComplexEnum2 {
+    |
+
+error[E0369]: binary operation `>=` cannot be applied to type `&InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:112:15
+    |
+112 | #[pyclass(eq, ord)]
+    |               ^^^
+    |
+note: an implementation of `PartialOrd` might be missing for `InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:118:1
+    |
+118 | enum InvalidOrderedComplexEnum2 {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialOrd`
+help: consider annotating `InvalidOrderedComplexEnum2` with `#[derive(PartialEq, PartialOrd)]`
+    |
+118 + #[derive(PartialEq, PartialOrd)]
+119 | enum InvalidOrderedComplexEnum2 {
+    |
+
+error: aborting due to 22 previous errors
+
+Some errors have detailed explanations: E0277, E0369.
+For more information about an error, try `rustc --explain E0277`.

--- a/tests/ui/invalid_pyclass_enum.nostd.stderr
+++ b/tests/ui/invalid_pyclass_enum.nostd.stderr
@@ -1,0 +1,225 @@
+error: enums can't be inherited by other classes
+ --> tests/ui/invalid_pyclass_enum.rs:7:11
+  |
+7 | #[pyclass(subclass)]
+  |           ^^^^^^^^
+
+error: enums can't extend from other classes
+  --> tests/ui/invalid_pyclass_enum.rs:14:11
+   |
+14 | #[pyclass(extends = PyList)]
+   |           ^^^^^^^
+
+error: #[pyclass] can't be used on enums without any variants
+  --> tests/ui/invalid_pyclass_enum.rs:22:18
+   |
+22 | enum NoEmptyEnum {}
+   |                  ^^
+
+error: Unit variant `UnitVariant` is not yet supported in a complex enum
+       = help: change to an empty tuple variant instead: `UnitVariant()`
+       = note: the enum is complex because of non-unit variant `StructVariant`
+  --> tests/ui/invalid_pyclass_enum.rs:28:5
+   |
+28 |     UnitVariant,
+   |     ^^^^^^^^^^^
+
+error: `constructor` can't be used on a simple enum variant
+  --> tests/ui/invalid_pyclass_enum.rs:34:12
+   |
+34 |     #[pyo3(constructor = (a, b))]
+   |            ^^^^^^^^^^^
+
+error: The `eq_int` option requires the `eq` option.
+  --> tests/ui/invalid_pyclass_enum.rs:56:11
+   |
+56 | #[pyclass(eq_int)]
+   |           ^^^^^^
+
+error: `eq_int` can only be used on simple enums.
+  --> tests/ui/invalid_pyclass_enum.rs:63:11
+   |
+63 | #[pyclass(eq_int)]
+   |           ^^^^^^
+
+error: please enable pyo3/std feature to generate a hash function
+  --> tests/ui/invalid_pyclass_enum.rs:70:31
+   |
+70 | #[pyclass(frozen, eq, eq_int, hash)]
+   |                               ^^^^
+
+error: please enable pyo3/std feature to generate a hash function
+  --> tests/ui/invalid_pyclass_enum.rs:79:23
+   |
+79 | #[pyclass(frozen, eq, hash)]
+   |                       ^^^^
+
+error: The `hash` option requires the `frozen` option.
+  --> tests/ui/invalid_pyclass_enum.rs:88:11
+   |
+88 | #[pyclass(hash)]
+   |           ^^^^
+
+error: The `hash` option requires the `eq` option.
+  --> tests/ui/invalid_pyclass_enum.rs:88:11
+   |
+88 | #[pyclass(hash)]
+   |           ^^^^
+
+error: The `hash` option requires the `eq` option.
+  --> tests/ui/invalid_pyclass_enum.rs:97:11
+   |
+97 | #[pyclass(hash)]
+   |           ^^^^
+
+error: The `ord` option requires the `eq` option.
+   --> tests/ui/invalid_pyclass_enum.rs:105:11
+    |
+105 | #[pyclass(ord)]
+    |           ^^^
+
+error: #[pyclass] can't be used on enums without any variants - all variants of enum `AllEnumVariantsDisabled` have been configured out by cfg attributes
+   --> tests/ui/invalid_pyclass_enum.rs:125:6
+    |
+125 | enum AllEnumVariantsDisabled {
+    |      ^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0369]: binary operation `==` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:40:11
+   |
+40 | #[pyclass(eq, eq_int)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:43:1
+   |
+43 | enum SimpleEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `SimpleEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+43 + #[derive(PartialEq)]
+44 | enum SimpleEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `!=` cannot be applied to type `&SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:40:11
+   |
+40 | #[pyclass(eq, eq_int)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `SimpleEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:43:1
+   |
+43 | enum SimpleEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `SimpleEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+43 + #[derive(PartialEq)]
+44 | enum SimpleEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `==` cannot be applied to type `&ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:48:11
+   |
+48 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:51:1
+   |
+51 | enum ComplexEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `ComplexEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+51 + #[derive(PartialEq)]
+52 | enum ComplexEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `!=` cannot be applied to type `&ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:48:11
+   |
+48 | #[pyclass(eq)]
+   |           ^^
+   |
+note: an implementation of `PartialEq` might be missing for `ComplexEqOptRequiresPartialEq`
+  --> tests/ui/invalid_pyclass_enum.rs:51:1
+   |
+51 | enum ComplexEqOptRequiresPartialEq {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq`
+help: consider annotating `ComplexEqOptRequiresPartialEq` with `#[derive(PartialEq)]`
+   |
+51 + #[derive(PartialEq)]
+52 | enum ComplexEqOptRequiresPartialEq {
+   |
+
+error[E0369]: binary operation `>` cannot be applied to type `&InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:112:15
+    |
+112 | #[pyclass(eq, ord)]
+    |               ^^^
+    |
+note: an implementation of `PartialOrd` might be missing for `InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:118:1
+    |
+118 | enum InvalidOrderedComplexEnum2 {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialOrd`
+help: consider annotating `InvalidOrderedComplexEnum2` with `#[derive(PartialEq, PartialOrd)]`
+    |
+118 + #[derive(PartialEq, PartialOrd)]
+119 | enum InvalidOrderedComplexEnum2 {
+    |
+
+error[E0369]: binary operation `<` cannot be applied to type `&InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:112:15
+    |
+112 | #[pyclass(eq, ord)]
+    |               ^^^
+    |
+note: an implementation of `PartialOrd` might be missing for `InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:118:1
+    |
+118 | enum InvalidOrderedComplexEnum2 {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialOrd`
+help: consider annotating `InvalidOrderedComplexEnum2` with `#[derive(PartialEq, PartialOrd)]`
+    |
+118 + #[derive(PartialEq, PartialOrd)]
+119 | enum InvalidOrderedComplexEnum2 {
+    |
+
+error[E0369]: binary operation `<=` cannot be applied to type `&InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:112:15
+    |
+112 | #[pyclass(eq, ord)]
+    |               ^^^
+    |
+note: an implementation of `PartialOrd` might be missing for `InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:118:1
+    |
+118 | enum InvalidOrderedComplexEnum2 {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialOrd`
+help: consider annotating `InvalidOrderedComplexEnum2` with `#[derive(PartialEq, PartialOrd)]`
+    |
+118 + #[derive(PartialEq, PartialOrd)]
+119 | enum InvalidOrderedComplexEnum2 {
+    |
+
+error[E0369]: binary operation `>=` cannot be applied to type `&InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:112:15
+    |
+112 | #[pyclass(eq, ord)]
+    |               ^^^
+    |
+note: an implementation of `PartialOrd` might be missing for `InvalidOrderedComplexEnum2`
+   --> tests/ui/invalid_pyclass_enum.rs:118:1
+    |
+118 | enum InvalidOrderedComplexEnum2 {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialOrd`
+help: consider annotating `InvalidOrderedComplexEnum2` with `#[derive(PartialEq, PartialOrd)]`
+    |
+118 + #[derive(PartialEq, PartialOrd)]
+119 | enum InvalidOrderedComplexEnum2 {
+    |
+
+error: aborting due to 22 previous errors
+
+For more information about this error, try `rustc --explain E0369`.

--- a/tests/ui/invalid_pyclass_enum.nostd.stderr
+++ b/tests/ui/invalid_pyclass_enum.nostd.stderr
@@ -42,13 +42,13 @@ error: `eq_int` can only be used on simple enums.
 63 | #[pyclass(eq_int)]
    |           ^^^^^^
 
-error: please enable pyo3/std feature to generate a hash function
+error: `#[pyclass(hash)]` requires PyO3's `std` feature
   --> tests/ui/invalid_pyclass_enum.rs:70:31
    |
 70 | #[pyclass(frozen, eq, eq_int, hash)]
    |                               ^^^^
 
-error: please enable pyo3/std feature to generate a hash function
+error: `#[pyclass(hash)]` requires PyO3's `std` feature
   --> tests/ui/invalid_pyclass_enum.rs:79:23
    |
 79 | #[pyclass(frozen, eq, hash)]

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -1,3 +1,7 @@
+//@revisions: default nostd
+//@[default] with-std
+//@[nostd] no-std
+
 use pyo3::prelude::*;
 
 #[pyclass(subclass)]
@@ -22,13 +26,13 @@ enum NoEmptyEnum {}
 enum NoUnitVariants {
     StructVariant { field: i32 },
     UnitVariant,
-//~^ ERROR: Unit variant `UnitVariant` is not yet supported in a complex enum
+    //~^ ERROR: Unit variant `UnitVariant` is not yet supported in a complex enum
 }
 
 #[pyclass]
 enum SimpleNoSignature {
     #[pyo3(constructor = (a, b))]
-//~^ ERROR: `constructor` can't be used on a simple enum variant
+    //~^ ERROR: `constructor` can't be used on a simple enum variant
     A,
     B,
 }
@@ -64,7 +68,8 @@ enum NoEqInt {
 }
 
 #[pyclass(frozen, eq, eq_int, hash)]
-//~^ ERROR: the trait bound `SimpleHashOptRequiresHash: Hash` is not satisfied
+//~[default]^ ERROR: the trait bound `SimpleHashOptRequiresHash: Hash` is not satisfied
+//~[nostd]| ERROR: please enable pyo3/std feature to generate a hash function
 #[derive(PartialEq)]
 enum SimpleHashOptRequiresHash {
     A,
@@ -72,7 +77,8 @@ enum SimpleHashOptRequiresHash {
 }
 
 #[pyclass(frozen, eq, hash)]
-//~^ ERROR: the trait bound `ComplexHashOptRequiresHash: Hash` is not satisfied
+//~[default]^ ERROR: the trait bound `ComplexHashOptRequiresHash: Hash` is not satisfied
+//~[nostd]| ERROR: please enable pyo3/std feature to generate a hash function
 #[derive(PartialEq)]
 enum ComplexHashOptRequiresHash {
     A(i32),
@@ -99,25 +105,25 @@ enum ComplexHashOptRequiresEq {
 #[pyclass(ord)]
 //~^ ERROR: The `ord` option requires the `eq` option.
 enum InvalidOrderedComplexEnum {
-    VariantA (i32),
-    VariantB { msg: String }
+    VariantA(i32),
+    VariantB { msg: String },
 }
 
-#[pyclass(eq,ord)]
+#[pyclass(eq, ord)]
 //~^ ERROR: binary operation `>` cannot be applied to type `&InvalidOrderedComplexEnum2`
 //~| ERROR: binary operation `<` cannot be applied to type `&InvalidOrderedComplexEnum2`
 //~| ERROR: binary operation `<=` cannot be applied to type `&InvalidOrderedComplexEnum2`
 //~| ERROR: binary operation `>=` cannot be applied to type `&InvalidOrderedComplexEnum2`
 #[derive(PartialEq)]
 enum InvalidOrderedComplexEnum2 {
-    VariantA (i32),
-    VariantB { msg: String }
+    VariantA(i32),
+    VariantB { msg: String },
 }
 
 #[pyclass(eq)]
 #[derive(PartialEq)]
 enum AllEnumVariantsDisabled {
-//~^ ERROR: #[pyclass] can't be used on enums without any variants - all variants of enum `AllEnumVariantsDisabled` have been configured out by cfg attributes
+    //~^ ERROR: #[pyclass] can't be used on enums without any variants - all variants of enum `AllEnumVariantsDisabled` have been configured out by cfg attributes
     #[cfg(any())]
     DisabledA,
     #[cfg(not(all()))]

--- a/tests/ui/invalid_pyclass_enum.rs
+++ b/tests/ui/invalid_pyclass_enum.rs
@@ -69,7 +69,7 @@ enum NoEqInt {
 
 #[pyclass(frozen, eq, eq_int, hash)]
 //~[default]^ ERROR: the trait bound `SimpleHashOptRequiresHash: Hash` is not satisfied
-//~[nostd]| ERROR: please enable pyo3/std feature to generate a hash function
+//~[nostd]| ERROR: `#[pyclass(hash)]` requires PyO3's `std` feature
 #[derive(PartialEq)]
 enum SimpleHashOptRequiresHash {
     A,
@@ -78,7 +78,7 @@ enum SimpleHashOptRequiresHash {
 
 #[pyclass(frozen, eq, hash)]
 //~[default]^ ERROR: the trait bound `ComplexHashOptRequiresHash: Hash` is not satisfied
-//~[nostd]| ERROR: please enable pyo3/std feature to generate a hash function
+//~[nostd]| ERROR: `#[pyclass(hash)]` requires PyO3's `std` feature
 #[derive(PartialEq)]
 enum ComplexHashOptRequiresHash {
     A(i32),

--- a/tests/ui/invalid_pyfunction_argument.rs
+++ b/tests/ui/invalid_pyfunction_argument.rs
@@ -1,5 +1,5 @@
 //@revisions: default inspect
-//@[default] without-experimental-inspect
+//@[default] no-experimental-inspect
 //@[inspect] with-experimental-inspect
 
 use pyo3::prelude::*;

--- a/tests/ui/missing_intopy.rs
+++ b/tests/ui/missing_intopy.rs
@@ -1,5 +1,5 @@
 //@revisions: default inspect
-//@[default] without-experimental-inspect
+//@[default] no-experimental-inspect
 //@[inspect] with-experimental-inspect
 
 struct Blah;


### PR DESCRIPTION
I've disabled the `hash` option when not using `std` as discussed [here](https://github.com/PyO3/pyo3/pull/6333#pullrequestreview-5000391526).

The ui tests do not pass for `no_std` as it now emits a compile error message about hashing functions not being available without the `std` feature. I am not sure how to proceed with this.

I've labeled this as internal because `no_std` is not user-visible yet.