### PR TITLE
internal: schedule buffer to release later instead of leaking

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -32,6 +32,8 @@ use core::ffi::{
 use core::marker::{PhantomData, PhantomPinned};
 use core::mem::ManuallyDrop;
 use core::pin::Pin;
+#[cfg(not(Py_3_11))]
+use core::ptr;
 use core::ptr::NonNull;
 use core::{cell, mem, slice};
 use core::{ffi::CStr, fmt::Debug};

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -726,15 +726,16 @@ impl RawBuffer {
 
 impl Drop for PyUntypedBuffer {
     fn drop(&mut self) {
-        if Python::try_attach(|_| unsafe { self.0.release() }).is_none()
-            && crate::internal::state::is_in_gc_traversal()
-        {
-            eprintln!("Warning: PyBuffer dropped while in GC traversal, this is a bug and will leak memory.");
+        if Python::try_attach(|_| unsafe { self.0.release() }).is_none() {
+            let buffer: *const ffi::Py_buffer = &raw const self.0 .0;
+            unsafe { ffi::Py_AddPendingCall(Some(deferred_release), buffer.cast_mut().cast()) };
+
+            extern "C" fn deferred_release(arg: *mut c_void) -> i32 {
+                let buffer: *mut ffi::Py_buffer = arg.cast();
+                unsafe { ffi::PyBuffer_Release(buffer) };
+                0
+            }
         }
-        // If `try_attach` failed and `is_in_gc_traversal()` is false, then probably the interpreter has
-        // already finalized and we can just assume that the underlying memory has already been freed.
-        //
-        // So we don't handle that case here.
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -30,9 +30,10 @@ use core::ffi::{
     c_ushort, c_void,
 };
 use core::marker::{PhantomData, PhantomPinned};
+use core::mem::ManuallyDrop;
 use core::pin::Pin;
 use core::ptr::NonNull;
-use core::{cell, mem, ptr, slice};
+use core::{cell, mem, slice};
 use core::{ffi::CStr, fmt::Debug};
 
 /// A typed form of [`PyUntypedBuffer`].
@@ -47,7 +48,7 @@ pub struct PyUntypedBuffer(
     // [`PyBuffer_FillInfo`](https://github.com/python/cpython/blob/2fd43a1ffe4ff1f6c46f6045bc327d6085c40fbf/Objects/abstract.c#L798-L802).
     //
     // Therefore we use `Pin<Box<...>>` to document for ourselves that the memory address of the `Py_buffer` is expected to be stable
-    Pin<Box<RawBuffer>>,
+    ManuallyDrop<Pin<Box<RawBuffer>>>,
 );
 
 /// Wrapper around `ffi::Py_buffer` to be `!Unpin`.
@@ -498,7 +499,7 @@ impl PyUntypedBuffer {
         };
         // Create PyBuffer immediately so that if validation checks fail, the PyBuffer::drop code
         // will call PyBuffer_Release (thus avoiding any leaks).
-        let buf = Self(Pin::from(buf));
+        let buf = Self(ManuallyDrop::new(Pin::from(buf)));
         let raw = buf.raw();
 
         if raw.shape.is_null() {
@@ -555,7 +556,7 @@ impl PyUntypedBuffer {
 
             // Finally, drop the contained Pin<Box<_>> in place, to free the
             // Box memory.
-            ptr::drop_in_place::<Pin<Box<RawBuffer>>>(&mut mdself.0);
+            ManuallyDrop::drop(&mut mdself.0);
         }
     }
 
@@ -726,13 +727,18 @@ impl RawBuffer {
 
 impl Drop for PyUntypedBuffer {
     fn drop(&mut self) {
-        if Python::try_attach(|_| unsafe { self.0.release() }).is_none() {
+        if Python::try_attach(|_| unsafe {
+            self.0.release();
+            ManuallyDrop::drop(&mut self.0);
+        })
+        .is_none()
+        {
             let buffer: *const ffi::Py_buffer = &raw const self.0 .0;
             unsafe { ffi::Py_AddPendingCall(Some(deferred_release), buffer.cast_mut().cast()) };
 
             extern "C" fn deferred_release(arg: *mut c_void) -> i32 {
-                let buffer: *mut ffi::Py_buffer = arg.cast();
-                unsafe { ffi::PyBuffer_Release(buffer) };
+                // SAFETY: PyUntypedBuffer is repr(transparent) around a pointer to a ffi::Py_buffer
+                let _: PyUntypedBuffer = unsafe { mem::transmute(arg) };
                 0
             }
         }

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -359,14 +359,6 @@ pub fn register_decref(obj: Py<PyAny>) {
     }
 }
 
-/// Private helper function to check if we are currently in a GC traversal (as detected by PyO3).
-#[cfg(any(not(Py_LIMITED_API), Py_3_11))]
-pub(crate) fn is_in_gc_traversal() -> bool {
-    ATTACH_COUNT
-        .try_with(|c| c.get() == ATTACH_FORBIDDEN_DURING_TRAVERSE)
-        .unwrap_or(false)
-}
-
 /// Increments pyo3's internal attach count - to be called whenever an AttachGuard is created.
 #[inline(always)]
 fn increment_attach_count() {


### PR DESCRIPTION
If a buffer is dropped during gc traversal, use `Py_AddPendingCall` to release it later instead of leaking it.

Hopefully this can also unblock #6261.