### PR TITLE
correct `register_decref` operation ordering

### DIFF
--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -217,8 +217,14 @@ impl ReferencePool {
     }
 
     fn register_decref(&self, obj: Py<PyAny>) {
-        self.dirty.store(true, Ordering::Relaxed);
+        // It is important to set the dirty flag _after_ pushing the object
+        // - at worst an existing drainer can take the object immediately and
+        // the dirty flag will lead to a false positive drain.
+        //
+        // If the order is reversed, the draining can run before the object
+        // is pushed and it might be leaked.
         self.pending_decrefs.lock().unwrap().push(obj);
+        self.dirty.store(true, Ordering::Relaxed);
     }
 
     fn drop_deferred_references(&self, py: Python<'_>) {


### PR DESCRIPTION
In #6307 the operations in `register_decref` accidentally had their order swapped; this can lead to cases where objects are stuck in the release pool with the dirty flag not set (see the comment I added in the diff below).