### PR TITLE
docs: `print_expected_cfgs` minor cleanup

### DIFF
--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -146,10 +146,10 @@ fn get_inner() -> InterpreterConfig {
     interpreter_config.expect("failed to parse PyO3 config")
 }
 
-/// Registers `pyo3`s config names as reachable cfg expressions
+/// Registers `pyo3`s config names as reachable cfg expressions.
 ///
 /// - <https://github.com/rust-lang/cargo/pull/13571>
-/// - <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg>
+/// - <https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-check-cfg>
 #[doc(hidden)]
 pub fn print_expected_cfgs() {
     println!("cargo:rustc-check-cfg=cfg(Py_LIMITED_API)");

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -188,6 +188,7 @@ pub mod pyo3_build_script_impl {
         cargo_env_var, env_var, is_linking_libpython_for_target, target_triple_from_env,
         InterpreterConfig, PythonAbi, PythonAbiKind, PythonVersion, StableAbi,
     };
+
     pub enum BuildConfigSource {
         /// Config was provided by `PYO3_CONFIG_FILE`.
         ConfigFile,

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -157,7 +157,9 @@ pub fn print_expected_cfgs() {
     println!("cargo:rustc-check-cfg=cfg(PyPy)");
     println!("cargo:rustc-check-cfg=cfg(GraalPy)");
     println!("cargo:rustc-check-cfg=cfg(RustPython)");
-    println!("cargo:rustc-check-cfg=cfg(py_sys_config, values(\"Py_DEBUG\", \"Py_REF_DEBUG\", \"Py_TRACE_REFS\", \"COUNT_ALLOCS\"))");
+    println!(
+        r#"cargo:rustc-check-cfg=cfg(py_sys_config, values("Py_DEBUG", "Py_REF_DEBUG", "Py_TRACE_REFS", "COUNT_ALLOCS"))"#
+    );
 
     // allow `Py_3_*` cfgs from the minimum supported version up to the
     // maximum minor version (+1 for development for the next)

--- a/pyo3-build-config/src/lib.rs
+++ b/pyo3-build-config/src/lib.rs
@@ -33,6 +33,7 @@ use target_lexicon::{Architecture, OperatingSystem};
 /// | `#[cfg(Py_GIL_DISABLED)]` | This marks code which is run on the free-threaded interpreter. |
 /// | `#[cfg(PyPy)]` | This marks code which is run when compiling for PyPy. |
 /// | `#[cfg(GraalPy)]` | This marks code which is run when compiling for GraalPy. |
+/// | `#[cfg(RustPython)]` | This marks code which is run when compiling for RustPython. |
 ///
 /// For examples of how to use these attributes,
 #[doc = concat!("[see PyO3's guide](https://pyo3.rs/v", env!("CARGO_PKG_VERSION"), "/building-and-distribution/multiple-python-versions.html)")]


### PR DESCRIPTION
<!--

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [Documenting changes](https://pyo3.rs/main/contributing.html#documenting-changes)
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
   - or start the PR title with `internal:` if this is an internal change to skip the check
   - or start the PR title with `refactor:` if this is a refactor change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run `nox`. See `nox --list-sessions` for a list of supported actions.

Please do not submit unsolicited AI-generated PRs.
See our [contributing guidelines](https://pyo3.rs/main/contributing.html) for guidelines on how to use AI when contributing to PyO3.

-->

this meant to be a "docs" PR, but then I saw the string escapes and decided to use raw strings, I can revert it if it's out of scope for this PR.