### PR TITLE
Add MBCS and CodePage functions for Windows on PyUnicode objects

### DIFF
--- a/newsfragments/6349.added.md
+++ b/newsfragments/6349.added.md
@@ -1,0 +1,3 @@
+Add the following to `unicodeobject.rs‎`:
+
+* PyUnicode_DecodeMBCS, PyUnicode_DecodeMBCSStateful, PyUnicode_DecodeCodePagetateful, PyUnicode_AsMBCSString, PyUnicode_EncodeCodePage, PyUnicode_Equal

--- a/pyo3-ffi/src/unicodeobject.rs
+++ b/pyo3-ffi/src/unicodeobject.rs
@@ -248,7 +248,7 @@ extern_libpython! {
         mapping: *mut PyObject,
     ) -> *mut PyObject;
     #[cfg(target_os = "windows")]
-        pub fn PyUnicode_DecodeMBCS(
+    pub fn PyUnicode_DecodeMBCS(
         string: *const c_char,
         length: Py_ssize_t,
         errors: *const c_char,
@@ -269,14 +269,12 @@ extern_libpython! {
         consumed: *mut Py_ssize_t,
     ) -> *mut PyObject;
     #[cfg(target_os = "windows")]
-    pub fn PyUnicode_AsMBCSString(
-        unicode: *mut PyObject
-    ) -> *mut PyObject;
+    pub fn PyUnicode_AsMBCSString(unicode: *mut PyObject) -> *mut PyObject;
     #[cfg(target_os = "windows")]
     pub fn PyUnicode_EncodeCodePage(
         code_page: c_int,
         unicode: *mut PyObject,
-        errors: *const c_char
+        errors: *const c_char,
     ) -> *mut PyObject;
     pub fn PyUnicode_DecodeLocaleAndSize(
         str: *const c_char,

--- a/pyo3-ffi/src/unicodeobject.rs
+++ b/pyo3-ffi/src/unicodeobject.rs
@@ -247,11 +247,37 @@ extern_libpython! {
         unicode: *mut PyObject,
         mapping: *mut PyObject,
     ) -> *mut PyObject;
-    // skipped PyUnicode_DecodeMBCS
-    // skipped PyUnicode_DecodeMBCSStateful
-    // skipped PyUnicode_DecodeCodePageStateful
-    // skipped PyUnicode_AsMBCSString
-    // skipped PyUnicode_EncodeCodePage
+    #[cfg(target_os = "windows")]
+        pub fn PyUnicode_DecodeMBCS(
+        string: *const c_char,
+        length: Py_ssize_t,
+        errors: *const c_char,
+    ) -> *mut PyObject;
+    #[cfg(target_os = "windows")]
+    pub fn PyUnicode_DecodeMBCSStateful(
+        string: *const c_char,
+        length: Py_ssize_t,
+        errors: *const c_char,
+        consumed: *mut Py_ssize_t,
+    ) -> *mut PyObject;
+    #[cfg(target_os = "windows")]
+    pub fn PyUnicode_DecodeCodePagetateful(
+        code_page: c_int,
+        string: *const c_char,
+        length: Py_ssize_t,
+        errors: *const c_char,
+        consumed: *mut Py_ssize_t,
+    ) -> *mut PyObject;
+    #[cfg(target_os = "windows")]
+    pub fn PyUnicode_AsMBCSString(
+        unicode: *mut PyObject
+    ) -> *mut PyObject;
+    #[cfg(target_os = "windows")]
+    pub fn PyUnicode_EncodeCodePage(
+        code_page: c_int,
+        unicode: *mut PyObject,
+        errors: *const c_char
+    ) -> *mut PyObject;
     pub fn PyUnicode_DecodeLocaleAndSize(
         str: *const c_char,
         len: Py_ssize_t,
@@ -353,7 +379,8 @@ extern_libpython! {
         string: *const c_char,
         size: Py_ssize_t,
     ) -> c_int;
-    // skipped PyUnicode_Equal
+    #[cfg(Py_3_14)]
+    pub fn PyUnicode_Equal(str1: *mut PyObject, str2: *mut PyObject) -> c_int;
     pub fn PyUnicode_RichCompare(
         left: *mut PyObject,
         right: *mut PyObject,

--- a/pyo3-ffi/src/unicodeobject.rs
+++ b/pyo3-ffi/src/unicodeobject.rs
@@ -261,7 +261,7 @@ extern_libpython! {
         consumed: *mut Py_ssize_t,
     ) -> *mut PyObject;
     #[cfg(target_os = "windows")]
-    pub fn PyUnicode_DecodeCodePagetateful(
+    pub fn PyUnicode_DecodeCodePageStateful(
         code_page: c_int,
         string: *const c_char,
         length: Py_ssize_t,


### PR DESCRIPTION
<!--

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [Documenting changes](https://pyo3.rs/main/contributing.html#documenting-changes)
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
   - or start the PR title with `internal:` if this is an internal change to skip the check
   - or start the PR title with `refactor:` if this is a refactor change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run `nox`. See `nox --list-sessions` for a list of supported actions.

Please do not submit unsolicited AI-generated PRs.
See our [contributing guidelines](https://pyo3.rs/main/contributing.html) for guidelines on how to use AI when contributing to PyO3.

-->
