### PR TITLE
Add PyFloat_Pack and PyFloat_Unpack functions introduced in Python 3.11

### DIFF
--- a/newsfragments/6350.added.md
+++ b/newsfragments/6350.added.md
@@ -1,0 +1,1 @@
+Add these functions to the non-limited API: PyFloat_Pack{2,4,8} and PyFloat_Unpack{2,4,8}

--- a/pyo3-ffi/src/cpython/floatobject.rs
+++ b/pyo3-ffi/src/cpython/floatobject.rs
@@ -3,7 +3,7 @@ use crate::PyFloat_AsDouble;
 #[cfg(not(GraalPy))]
 use crate::PyFloat_Check;
 use crate::PyObject;
-use core::ffi::c_double;
+use core::ffi::{c_char, c_double, c_int};
 
 #[repr(C)]
 pub struct PyFloatObject {
@@ -28,16 +28,16 @@ pub unsafe fn PyFloat_AS_DOUBLE(op: *mut PyObject) -> c_double {
 
 extern_libpython! {
     #[cfg(Py_3_11)]
-    pub fn PyFloat_Pack2(x: c_double, p: *mut char, le: c_int) -> c_int;
+    pub fn PyFloat_Pack2(x: c_double, p: *mut c_char, le: c_int) -> c_int;
     #[cfg(Py_3_11)]
-    pub fn PyFloat_Pack4(x: c_double, p: *mut char, le: c_int) -> c_int;
+    pub fn PyFloat_Pack4(x: c_double, p: *mut c_char, le: c_int) -> c_int;
     #[cfg(Py_3_11)]
-    pub fn PyFloat_Pack8(x: c_double, p: *mut char, le: c_int) -> c_int;
+    pub fn PyFloat_Pack8(x: c_double, p: *mut c_char, le: c_int) -> c_int;
 
     #[cfg(Py_3_11)]
-    pub fn PyFloat_Unpack2(p: *const char, le: c_int) -> c_double;
+    pub fn PyFloat_Unpack2(p: *const c_char, le: c_int) -> c_double;
     #[cfg(Py_3_11)]
-    pub fn PyFloat_Unpack4(p: *const char, le: c_int) -> c_double;
+    pub fn PyFloat_Unpack4(p: *const c_char, le: c_int) -> c_double;
     #[cfg(Py_3_11)]
-    pub fn PyFloat_Unpack8(p: *const char, le: c_int) -> c_double;
+    pub fn PyFloat_Unpack8(p: *const c_char, le: c_int) -> c_double;
 }

--- a/pyo3-ffi/src/cpython/floatobject.rs
+++ b/pyo3-ffi/src/cpython/floatobject.rs
@@ -26,10 +26,18 @@ pub unsafe fn PyFloat_AS_DOUBLE(op: *mut PyObject) -> c_double {
     return PyFloat_AsDouble(op);
 }
 
-// skipped PyFloat_Pack2
-// skipped PyFloat_Pack4
-// skipped PyFloat_Pack8
+extern_libpython! {
+    #[cfg(Py_3_11)]
+    pub fn PyFloat_Pack2(x: c_double, p: *mut char, le: c_int) -> c_int;
+    #[cfg(Py_3_11)]
+    pub fn PyFloat_Pack4(x: c_double, p: *mut char, le: c_int) -> c_int;
+    #[cfg(Py_3_11)]
+    pub fn PyFloat_Pack8(x: c_double, p: *mut char, le: c_int) -> c_int;
 
-// skipped PyFloat_Unpack2
-// skipped PyFloat_Unpack4
-// skipped PyFloat_Unpack8
+    #[cfg(Py_3_11)]
+    pub fn PyFloat_Unpack2(p: *const char, le: c_int) -> c_double;
+    #[cfg(Py_3_11)]
+    pub fn PyFloat_Unpack4(p: *const char, le: c_int) -> c_double;
+    #[cfg(Py_3_11)]
+    pub fn PyFloat_Unpack8(p: *const char, le: c_int) -> c_double;
+}

--- a/pyo3-ffi/src/cpython/floatobject.rs
+++ b/pyo3-ffi/src/cpython/floatobject.rs
@@ -3,9 +3,9 @@ use crate::PyFloat_AsDouble;
 #[cfg(not(GraalPy))]
 use crate::PyFloat_Check;
 use crate::PyObject;
+use core::ffi::c_double;
 #[cfg(Py_3_11)]
 use core::ffi::{c_char, c_int};
-use core::ffi::c_double;
 
 #[repr(C)]
 pub struct PyFloatObject {

--- a/pyo3-ffi/src/cpython/floatobject.rs
+++ b/pyo3-ffi/src/cpython/floatobject.rs
@@ -3,7 +3,9 @@ use crate::PyFloat_AsDouble;
 #[cfg(not(GraalPy))]
 use crate::PyFloat_Check;
 use crate::PyObject;
-use core::ffi::{c_char, c_double, c_int};
+#[cfg(Py_3_11)]
+use core::ffi::{c_char, c_int};
+use core::ffi::c_double;
 
 #[repr(C)]
 pub struct PyFloatObject {


### PR DESCRIPTION
<!--

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [Documenting changes](https://pyo3.rs/main/contributing.html#documenting-changes)
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
   - or start the PR title with `internal:` if this is an internal change to skip the check
   - or start the PR title with `refactor:` if this is a refactor change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run `nox`. See `nox --list-sessions` for a list of supported actions.

Please do not submit unsolicited AI-generated PRs.
See our [contributing guidelines](https://pyo3.rs/main/contributing.html) for guidelines on how to use AI when contributing to PyO3.

-->
