### PR TITLE
Backports for 0.29.3

### DIFF
--- a/newsfragments/6309.fixed.md
+++ b/newsfragments/6309.fixed.md
@@ -1,0 +1,1 @@
+Fix `clippy::clone_on_copy` warnings triggered on nightly Rust by `#[pyclass(from_py_object)]` on classes which implement `Copy`.

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -2995,7 +2995,7 @@ impl<'a> PyClassImplsBuilder<'a> {
                     #input_type
 
                     fn extract(obj: #pyo3_path::Borrowed<'a, 'py, #pyo3_path::PyAny>) -> ::std::result::Result<Self,  <Self as #pyo3_path::FromPyObject<'a, 'py>>::Error> {
-                        ::std::result::Result::Ok(::std::clone::Clone::clone(&*obj.extract::<#pyo3_path::PyClassGuard<'_, #cls>>()?))
+                        #pyo3_path::impl_::pyclass::extract_pyclass_with_clone(obj)
                     }
                 }
             }

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -12,9 +12,10 @@ use crate::{
     },
     internal::pyclass_init::PyObjectInit,
     pycell::{impl_::PyClassObjectLayout, PyBorrowError},
+    pyclass::PyClassGuardError,
     types::{any::PyAnyMethods, PyBool},
-    Borrowed, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyClass, PyClassGuard, PyErr, PyResult,
-    PyTypeCheck, PyTypeInfo, Python,
+    Borrowed, FromPyObject, IntoPyObject, IntoPyObjectExt, Py, PyAny, PyClass, PyClassGuard, PyErr,
+    PyResult, PyTypeCheck, PyTypeInfo, Python,
 };
 use core::{
     ffi::CStr,
@@ -44,6 +45,16 @@ pub const fn dict_offset<T: PyClass>() -> PyObjectOffset {
 #[inline]
 pub const fn weaklist_offset<T: PyClass>() -> PyObjectOffset {
     <T as PyClassImpl>::Layout::WEAKLIST_OFFSET
+}
+
+/// Extracts a `T: PyClass + Clone` from a Python object by cloning it out of
+/// the [`PyClassGuard`].
+#[inline]
+pub fn extract_pyclass_with_clone<'a, 'py, T: PyClass + Clone>(
+    obj: Borrowed<'a, 'py, PyAny>,
+) -> Result<T, PyClassGuardError<'a, 'py>> {
+    let guard = <PyClassGuard<'a, T> as FromPyObject<'a, 'py>>::extract(obj)?;
+    Ok(T::clone(&guard))
 }
 
 mod sealed {

--- a/tests/test_enum.rs
+++ b/tests/test_enum.rs
@@ -6,8 +6,10 @@ use pyo3::types::PyString;
 
 mod test_utils;
 
+// `Copy` + `from_py_object` is a regression test for `clippy::clone_on_copy`
+// firing in the generated `FromPyObject` implementation (#6308)
 #[pyclass(eq, eq_int, from_py_object)]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum MyEnum {
     Variant,
     OtherVariant,

--- a/tests/ui/invalid_pyclass_args.default.stderr
+++ b/tests/ui/invalid_pyclass_args.default.stderr
@@ -440,7 +440,7 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
               HashOptRequiresHash
               NewFromFieldsWithManualNew
             and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
@@ -469,7 +469,7 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
               HashOptRequiresHash
               NewFromFieldsWithManualNew
             and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
@@ -507,7 +507,7 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
   | |     for &'holder mut T
   | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
   = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `Clone`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `FromPyObject<'_, '_>`
   = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs

--- a/tests/ui/invalid_pyclass_args.inspect.stderr
+++ b/tests/ui/invalid_pyclass_args.inspect.stderr
@@ -470,7 +470,7 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
               HashOptRequiresHash
               NewFromFieldsWithManualNew
             and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
@@ -499,7 +499,7 @@ error[E0277]: `Box<dyn std::error::Error + Send + Sync>` cannot be used as a Pyt
               HashOptRequiresHash
               NewFromFieldsWithManualNew
             and $N others
-    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+    = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `FromPyObject<'_, '_>`
     = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs
@@ -537,7 +537,7 @@ help: the following other types implement trait `pyo3::impl_::extract_argument::
   | |     for &'holder mut T
   | |______________________^ `&'holder mut T` implements `pyo3::impl_::extract_argument::PyFunctionArgument<'a, 'holder, '_, false>`
   = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `Clone`
-  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::FromPyObject<'_, '_>`
+  = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `FromPyObject<'_, '_>`
   = note: required for `Box<dyn std::error::Error + Send + Sync>` to implement `pyo3::impl_::extract_argument::PyFunctionArgument<'_, '_, '_, true>`
 note: required by a bound in `pyo3::impl_::extract_argument::extract_argument`
  --> src/impl_/extract_argument.rs


### PR DESCRIPTION
Running list of things to backport for a 0.29.3:

- [x] #6309

#6309 fixed #6308 (`clippy::clone_on_copy` firing on the `FromPyObject` impl
generated for `#[pyclass(from_py_object)]` types that are also `Copy`). It merged
to `main` on 2026-08-08, three days after 0.29.2 shipped, so it isn't in any
release and `release-0.29` doesn't have it.

### Why this might be worth a patch release

When #6308 was filed the lint was nightly-only. It is now in beta: I reproduced
it on `1.99.0-beta.1`, which promotes to stable on 2026-10-01. At that point any
crate that puts `#[pyclass(from_py_object)]` on a `Copy` type and runs
`cargo clippy -- -D warnings` in CI starts failing. Confirmed affected on the
current release (0.29.2, from crates.io), not just older 0.29.x.

Known affected downstreams: pyca/cryptography (the original report) and
OpenDevicePartnership/pico-de-gallo.

I appreciate 0.30 may not be far off. If it is likely to land before 2026-10-01
then this probably isn't worth a patch release, and I'm happy to close this.

### The backport

Both source hunks cherry-picked cleanly and are byte-identical to #6309 --
`PyClassGuard`, `PyClassGuardError` and `FromPyObject` all already exist on
`release-0.29`, so `extract_pyclass_with_clone` compiles there unchanged. The
regression test from #6309 (`Copy` on `MyEnum` in `tests/test_enum.rs`) came
across too.

The only conflicts were `tests/ui/invalid_pyclass_args.{default,inspect}.stderr`,
and they conflicted on unrelated divergence between `main` and `release-0.29`
rather than on this fix. I did not hand-merge them: I reset both to the
`release-0.29` baseline and regenerated with `UI_TEST=bless` across all three
feature combos from `nox -s update-ui-tests`. The result is 6 lines, all
`pyo3::FromPyObject` -> `FromPyObject`, which is just rustc shortening the
diagnostic path now that `FromPyObject` is imported in `src/impl_/pyclass.rs`.
Nothing semantic.

Verified locally on 1.98.0 stable and 1.99.0-beta.1:

- UI tests before blessing: 54 passed, 1 failed, and the single failure was
  exactly the expected file -- so these snapshots are not platform-sensitive here.
- UI tests after blessing: 55 passed on each of `macros`, `full`, `abi3,full`.
- `cargo test --test test_enum --features full`: 24 passed.
- Beta clippy on `test_enum`: clean. Reverting just the macro one-liner brings
  back `using 'clone' on type 'MyEnum' which implements the 'Copy' trait`, so the
  regression test is doing real work.
- `cargo fmt --all --check`: clean.

### Two CI notes

The `changelog` check will fail. The newsfragment is `6309.fixed.md`, keeping the
original PR number so the entry reads correctly in the 0.29.3 notes, but
`check-changelog` looks for a fragment named after *this* PR. Happy to rename it,
add a second one, or you can apply `CI-skip-changelog` -- whichever you prefer.

Beta clippy also flags `clippy::nonnull_unchecked_on_box_ptr` in
`src/internal_tricks.rs:56` on this branch. That is pre-existing on
`release-0.29` and unrelated to this backport; noting it only so it isn't
attributed to this change. The `clippy/beta` job is `continue-on-error`, so it
should not block.

---

Disclosure per Contributing.md: I used AI assistance to locate the upstream fix,
perform the cherry-pick, and run the verification above. The code is an
unmodified cherry-pick of #6309 with the UI snapshots regenerated by the
project's own bless tooling; authorship on the commit is preserved as
@alex via `cherry-pick -x`.
