### PR TITLE
internal: suppress warning caused by stabilization of never type

### DIFF
--- a/pyo3-macros-backend/src/pymethod.rs
+++ b/pyo3-macros-backend/src/pymethod.rs
@@ -1230,6 +1230,7 @@ impl Ty {
                 let ty = arg.ty();
                 extract_error_mode.handle_error(
                     quote! {
+                            #[allow(unreachable_code, reason = "error type might be !")]
                             ::core::convert::TryInto::<#ty>::try_into(#ident).map_err(|e| #pyo3_path::exceptions::PyValueError::new_err(e.to_string()))
                     },
                     ctx

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -175,6 +175,7 @@ macro_rules! int_fits_c_long {
 
             fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
                 let val: c_long = extract_int!(obj, -1, ffi::PyLong_AsLong)?;
+                #[allow(unreachable_code, reason = "error type might be !")]
                 <$rust_type>::try_from(val)
                     .map_err(|e| exceptions::PyOverflowError::new_err(e.to_string()))
             }


### PR DESCRIPTION
Stabilization of never type on nightly causes a lint warning when calling `map_err` on a `Result<T, Infallible>`. This PR suppresses it in macro-generated code.

 https://github.com/PyO3/pyo3/actions/runs/32869499974/job/97872932450?pr=6343#step:14:263