### PR TITLE
ci: Use Cargo workspace publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,6 @@ jobs:
         id: auth
 
       - name: Publish to crates.io
-        run: uvx nox -s publish
+        run: cargo publish --workspace
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -384,11 +384,6 @@ def check_all(session: nox.Session) -> None:
 
 
 @nox.session(venv_backend="none")
-def publish(session: nox.Session) -> None:
-    _run_cargo(session, "publish", "--workspace")
-
-
-@nox.session(venv_backend="none")
 def contributors(session: nox.Session) -> None:
     import requests
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -385,12 +385,7 @@ def check_all(session: nox.Session) -> None:
 
 @nox.session(venv_backend="none")
 def publish(session: nox.Session) -> None:
-    _run_cargo_publish(session, package="pyo3-build-config")
-    _run_cargo_publish(session, package="pyo3-macros-backend")
-    _run_cargo_publish(session, package="pyo3-macros")
-    _run_cargo_publish(session, package="pyo3-ffi")
-    _run_cargo_publish(session, package="pyo3")
-    _run_cargo_publish(session, package="pyo3-introspection")
+    _run_cargo(session, "publish", "--workspace")
 
 
 @nox.session(venv_backend="none")
@@ -2005,10 +2000,6 @@ def _run_cargo_test(
             test_env["PATH"] = os.pathsep.join((str(abi3t_compat), path))
 
     _run(session, *command, external=True, env=test_env)
-
-
-def _run_cargo_publish(session: nox.Session, *, package: str) -> None:
-    _run_cargo(session, "publish", f"--package={package}")
 
 
 def _run_cargo_set_package_version(

--- a/tests/ui/base/Cargo.toml
+++ b/tests/ui/base/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pyo3_ui_tests"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 pyo3 = { version = "0.29.2", default-features = false, path = "../../../" }


### PR DESCRIPTION
Simplify the publishing setup by using https://doc.rust-lang.org/cargo/CHANGELOG.html#cargo-190-2025-09-18