### PR TITLE
internal: Fix double copy creating `PyBackedBytes` from `PyByteArray`

### DIFF
--- a/src/pybacked.rs
+++ b/src/pybacked.rs
@@ -6,6 +6,7 @@
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
 use crate::platform::prelude::*;
+use crate::sync::critical_section::with_critical_section;
 #[cfg(feature = "experimental-inspect")]
 use crate::type_hint_union;
 use crate::{
@@ -272,7 +273,14 @@ impl From<Bound<'_, PyBytes>> for PyBackedBytes {
 
 impl From<Bound<'_, PyByteArray>> for PyBackedBytes {
     fn from(py_bytearray: Bound<'_, PyByteArray>) -> Self {
-        let s = Arc::<[u8]>::from(py_bytearray.to_vec());
+        let s = with_critical_section(&py_bytearray, || {
+            // SAFETY:
+            //  * `py_bytearray` is a `Bound` object, which guarantees that the Python GIL is held.
+            //  * For free-threaded Python, a critical section is used in lieu of the GIL.
+            //  * We don't interact with the interpreter
+            //  * We don't mutate the underlying slice
+            Arc::<[u8]>::from(unsafe { py_bytearray.as_bytes() })
+        });
         let data = NonNull::from(s.as_ref());
         Self {
             storage: PyBackedBytesStorage::Rust(s),


### PR DESCRIPTION
`Arc::<[u8]>::from(py_bytearray.to_vec())` creates a `Vec` copy of the `PyByteArray` contents, then immediately copies that `Vec` into an `Arc<[u8]>`. It should copy the `PyByteArray` contents directly into the `Arc<[u8]>`. This PR inlines `PyByteArrayMethods::to_vec` into `PyBackedBytes::from` without the unnecessary copy.

https://github.com/PyO3/pyo3/blob/75507833367e5267dd6fdd7e48de628e4b8e53e0/src/types/bytearray.rs#L291-L300