### PR TITLE
Introspection: make Module.incomplete field optional during parsing

### DIFF
--- a/pyo3-introspection/src/introspection.rs
+++ b/pyo3-introspection/src/introspection.rs
@@ -685,6 +685,7 @@ enum Chunk {
         members: Vec<String>,
         #[serde(default)]
         doc: Option<String>,
+        #[serde(default)]
         incomplete: bool,
     },
     Class {


### PR DESCRIPTION
Allows to drop it in favor of generating __getitem__ macro-side in the future
