### PR TITLE
internal: register all pytests submodules in `sys.modules`

### DIFF
--- a/pytests/src/lib.rs
+++ b/pytests/src/lib.rs
@@ -52,13 +52,18 @@ mod pyo3_pytests {
     fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
         let sys = PyModule::import(m.py(), "sys")?;
         let sys_modules = sys.getattr("modules")?.cast_into::<PyDict>()?;
+        #[cfg(feature = "experimental-inspect")]
+        sys_modules.set_item("pyo3_pytests.annotations", m.getattr("annotations")?)?;
         sys_modules.set_item("pyo3_pytests.awaitable", m.getattr("awaitable")?)?;
+        #[cfg(any(not(Py_LIMITED_API), Py_3_11))]
         sys_modules.set_item("pyo3_pytests.buf_and_str", m.getattr("buf_and_str")?)?;
         sys_modules.set_item("pyo3_pytests.comparisons", m.getattr("comparisons")?)?;
+        sys_modules.set_item("pyo3_pytests.consts", m.getattr("consts")?)?;
         #[cfg(not(Py_LIMITED_API))]
         sys_modules.set_item("pyo3_pytests.datetime", m.getattr("datetime")?)?;
         sys_modules.set_item("pyo3_pytests.dict_iter", m.getattr("dict_iter")?)?;
         sys_modules.set_item("pyo3_pytests.enums", m.getattr("enums")?)?;
+        sys_modules.set_item("pyo3_pytests.exception", m.getattr("exception")?)?;
         sys_modules.set_item("pyo3_pytests.misc", m.getattr("misc")?)?;
         sys_modules.set_item("pyo3_pytests.objstore", m.getattr("objstore")?)?;
         sys_modules.set_item("pyo3_pytests.othermod", m.getattr("othermod")?)?;


### PR DESCRIPTION
## What was wrong

`pytests/src/lib.rs` registers submodules into `sys.modules` by hand inside `#[pymodule_init] fn init`. The list had drifted from the `#[pymodule_export]` list: `annotations`, `consts` and `exception` were never registered, so `import pyo3_pytests.consts` raised `ModuleNotFoundError` and stubtest reported them as failed-to-import rather than checking them.

A second, separate drift: `buf_and_str` is exported under `#[cfg(any(not(Py_LIMITED_API), Py_3_11))]` but its `sys.modules` line was ungated, so an abi3-py39 or abi3-py310 build of pytests would call `m.getattr("buf_and_str")` on a module that does not exist and fail at import time. Not visible in the default CI build.

## The fix

Added the three missing registrations and gated each new and existing line to match its export site: `annotations` under `feature = "experimental-inspect"`, `buf_and_str` under `any(not(Py_LIMITED_API), Py_3_11)`, `consts` and `exception` ungated. Five lines in `pytests/src/lib.rs`.

## Follow-up worth considering, not implemented

Every PyO3 project that nests modules writes this same `sys.modules` loop by hand, and this issue is what happens when it drifts. `#[pymodule_export]` on a submodule already knows the parent and child names at macro-expansion time, so PyO3 could do the insertion itself and keep the two lists in sync by construction. Questions to settle first: whether it should be opt-in, and what happens on module re-init under subinterpreters where a stale `sys.modules` entry would be wrong.
