### PR TITLE
internal: remove std usage from hashbrown tests

### DIFF
--- a/src/conversions/hashbrown.rs
+++ b/src/conversions/hashbrown.rs
@@ -176,13 +176,11 @@ where
 mod tests {
     use super::*;
     use crate::types::IntoPyDict;
-    use std::collections::hash_map::RandomState;
 
     #[test]
     fn test_hashbrown_hashmap_into_pyobject() {
         Python::attach(|py| {
-            let mut map =
-                hashbrown::HashMap::<i32, i32, RandomState>::with_hasher(RandomState::new());
+            let mut map = hashbrown::HashMap::<i32, i32>::default();
             map.insert(1, 1);
 
             let py_map = (&map).into_pyobject(py).unwrap();
@@ -204,8 +202,7 @@ mod tests {
     #[test]
     fn test_hashbrown_hashmap_into_dict() {
         Python::attach(|py| {
-            let mut map =
-                hashbrown::HashMap::<i32, i32, RandomState>::with_hasher(RandomState::new());
+            let mut map = hashbrown::HashMap::<i32, i32>::default();
             map.insert(1, 1);
 
             let py_map = map.into_py_dict(py).unwrap();
@@ -227,11 +224,11 @@ mod tests {
     fn test_extract_hashbrown_hashset() {
         Python::attach(|py| {
             let set = PySet::new(py, [1, 2, 3, 4, 5]).unwrap();
-            let hash_set: hashbrown::HashSet<usize, RandomState> = set.extract().unwrap();
+            let hash_set: hashbrown::HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
 
             let set = PyFrozenSet::new(py, [1, 2, 3, 4, 5]).unwrap();
-            let hash_set: hashbrown::HashSet<usize, RandomState> = set.extract().unwrap();
+            let hash_set: hashbrown::HashSet<usize> = set.extract().unwrap();
             assert_eq!(hash_set, [1, 2, 3, 4, 5].iter().copied().collect());
         });
     }
@@ -239,8 +236,7 @@ mod tests {
     #[test]
     fn test_hashbrown_hashset_into_pyobject() {
         Python::attach(|py| {
-            let hs: hashbrown::HashSet<u64, RandomState> =
-                [1, 2, 3, 4, 5].iter().cloned().collect();
+            let hs: hashbrown::HashSet<u64> = [1, 2, 3, 4, 5].iter().cloned().collect();
 
             let hso = hs.clone().into_pyobject(py).unwrap();
 


### PR DESCRIPTION
Test cases in hashbrown conversion were using `RandomState` from std instead of the default.