### PR TITLE
internal: use PyOnceLock instead of OnceLock in num conversions

### DIFF
--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -362,8 +362,11 @@ int_convert_u64_or_i64!(
 pub(crate) const PYLONG_BITS_IN_DIGIT: usize = 30;
 
 #[cfg(any(all(Py_3_14, not(Py_LIMITED_API)), Py_3_15))]
-pub(crate) fn is_30bit_layout() -> bool {
-    static DIGITS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+pub(crate) fn is_30bit_layout(py: Python<'_>) -> bool {
+    use crate::sync::PyOnceLock;
+
+    // static DIGITS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    static DIGITS: PyOnceLock<bool> = PyOnceLock::new();
 
     const PYLONG_DIGIT_SIZE: u8 = 4;
     const PYLONG_DIGITS_ORDER: i8 = -1;
@@ -373,7 +376,7 @@ pub(crate) fn is_30bit_layout() -> bool {
     #[cfg(target_endian = "big")]
     const NATIVE_DIGIT_ENDIANNESS: i8 = 1;
 
-    *DIGITS.get_or_init(|| {
+    *DIGITS.get_or_init(py, || {
         let layout = unsafe { &*ffi::PyLong_GetNativeLayout() };
         layout.bits_per_digit == PYLONG_BITS_IN_DIGIT as u8
             && layout.digit_size == PYLONG_DIGIT_SIZE
@@ -464,7 +467,7 @@ mod fast_128bit_int_conversion {
                 fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
                     #[cfg(Py_3_14)]
                     {
-                        if is_30bit_layout() {
+                        if is_30bit_layout(py) {
                             const DIGIT_MASK: u32 = (1 << PYLONG_BITS_IN_DIGIT) - 1;
                             let signed = self as i128;
                             let negative = $is_signed && signed < 0;
@@ -517,7 +520,7 @@ mod fast_128bit_int_conversion {
                     let num = nb_index(&ob)?;
                     #[cfg(Py_3_14)]
                     {
-                        if is_30bit_layout() {
+                        if is_30bit_layout(ob.py()) {
                             let overflow = || {
                                 exceptions::PyOverflowError::new_err(
                                     "Python int larger than 128 bits",

--- a/src/conversions/std/num.rs
+++ b/src/conversions/std/num.rs
@@ -365,7 +365,6 @@ pub(crate) const PYLONG_BITS_IN_DIGIT: usize = 30;
 pub(crate) fn is_30bit_layout(py: Python<'_>) -> bool {
     use crate::sync::PyOnceLock;
 
-    // static DIGITS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     static DIGITS: PyOnceLock<bool> = PyOnceLock::new();
 
     const PYLONG_DIGIT_SIZE: u8 = 4;


### PR DESCRIPTION
We already have a `no_std` replacement for `OnceLock`.