### PR TITLE
internal: remove use of std in array-conversion tests

### DIFF
--- a/guide/src/conversions/traits.md
+++ b/guide/src/conversions/traits.md
@@ -640,6 +640,7 @@ All the same rules from above apply as well.
   # use pyo3::prelude::*;
   # use pyo3::IntoPyObjectExt;
   # use std::borrow::Cow;
+  # #[allow(dead_code)]
   #[derive(Clone)]
   struct NotIntoPy(usize);
 

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -175,6 +175,7 @@ pub(crate) fn invalid_sequence_length(expected: usize, actual: usize) -> PyErr {
 #[cfg(test)]
 mod tests {
     use crate::platform::prelude::*;
+    #[cfg(panic = "unwind")]
     use core::any::Any;
     #[cfg(panic = "unwind")]
     use core::sync::atomic::{AtomicUsize, Ordering};

--- a/src/conversions/std/array.rs
+++ b/src/conversions/std/array.rs
@@ -175,10 +175,16 @@ pub(crate) fn invalid_sequence_length(expected: usize, actual: usize) -> PyErr {
 #[cfg(test)]
 mod tests {
     use crate::platform::prelude::*;
+    use core::any::Any;
     #[cfg(panic = "unwind")]
     use core::sync::atomic::{AtomicUsize, Ordering};
+
+    // allow use of panic mod without leaking anything else from std
     #[cfg(panic = "unwind")]
-    use std::panic;
+    mod panic {
+        extern crate std;
+        pub use std::panic::*;
+    }
 
     use crate::{
         conversion::IntoPyObject,
@@ -345,7 +351,7 @@ mod tests {
 
     // https://stackoverflow.com/a/59211505
     #[cfg(panic = "unwind")]
-    fn catch_unwind_silent<F, R>(f: F) -> std::thread::Result<R>
+    fn catch_unwind_silent<F, R>(f: F) -> Result<R, Box<dyn Any + Send + 'static>>
     where
         F: FnOnce() -> R + panic::UnwindSafe,
     {


### PR DESCRIPTION
A few tests were using `std`, so it needs to declare `extern crate std`.