### PR TITLE
internal: preliminary fixes for PyPy 3.12

### DIFF
--- a/pyo3-ffi/src/cpython/dictobject.rs
+++ b/pyo3-ffi/src/cpython/dictobject.rs
@@ -10,6 +10,7 @@ use crate::{dictobject::PyDict_Check, PyDict_CheckExact};
 
 #[cfg(all(not(PyPy), Py_3_13))]
 use core::ffi::c_char;
+#[cfg(Py_3_12)]
 use core::ffi::c_int;
 
 #[cfg(not(PyPy))]

--- a/pyo3-ffi/src/cpython/dictobject.rs
+++ b/pyo3-ffi/src/cpython/dictobject.rs
@@ -10,7 +10,6 @@ use crate::{dictobject::PyDict_Check, PyDict_CheckExact};
 
 #[cfg(all(not(PyPy), Py_3_13))]
 use core::ffi::c_char;
-#[cfg(all(not(PyPy), Py_3_12))]
 use core::ffi::c_int;
 
 #[cfg(not(PyPy))]

--- a/pyo3-ffi/src/cpython/pyframe.rs
+++ b/pyo3-ffi/src/cpython/pyframe.rs
@@ -66,11 +66,14 @@ extern_libpython! {
     pub fn PyFrame_GetVarString(frame: *mut PyFrameObject, name: *mut c_char) -> *mut PyObject;
 
     #[cfg(Py_3_12)]
+    #[cfg(not(PyPy))]
     pub fn PyUnstable_InterpreterFrame_GetCode(frame: *mut _PyInterpreterFrame) -> *mut PyObject;
 
     #[cfg(Py_3_12)]
+    #[cfg(not(PyPy))]
     pub fn PyUnstable_InterpreterFrame_GetLasti(frame: *mut _PyInterpreterFrame) -> c_int;
 
     #[cfg(Py_3_12)]
+    #[cfg(not(PyPy))]
     pub fn PyUnstable_InterpreterFrame_GetLine(frame: *mut _PyInterpreterFrame) -> c_int;
 }

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -390,7 +390,6 @@ extern_libpython! {
     ) -> *mut PyObject;
 
     #[cfg(Py_3_12)]
-    #[cfg_attr(PyPy, link_name = "PyPyObject_GetTypeData")]
     pub fn PyObject_GetTypeData(obj: *mut PyObject, cls: *mut PyTypeObject) -> *mut c_void;
 
     #[cfg(Py_3_12)]

--- a/pyo3-ffi/src/pyerrors.rs
+++ b/pyo3-ffi/src/pyerrors.rs
@@ -50,8 +50,10 @@ extern_libpython! {
         arg3: *mut *mut PyObject,
     );
     #[cfg(Py_3_12)]
+    #[cfg_attr(PyPy, link_name = "PyPyErr_GetRaisedException")]
     pub fn PyErr_GetRaisedException() -> *mut PyObject;
     #[cfg(Py_3_12)]
+    #[cfg_attr(PyPy, link_name = "PyPyErr_SetRaisedException")]
     pub fn PyErr_SetRaisedException(exc: *mut PyObject);
     #[cfg(Py_3_11)]
     #[cfg_attr(PyPy, link_name = "PyPyErr_GetHandledException")]

--- a/pyo3-ffi/src/pythonrun.rs
+++ b/pyo3-ffi/src/pythonrun.rs
@@ -17,6 +17,7 @@ extern_libpython! {
     pub fn PyErr_Display(arg1: *mut PyObject, arg2: *mut PyObject, arg3: *mut PyObject);
 
     #[cfg(Py_3_12)]
+    #[cfg_attr(PyPy, link_name = "PyPyErr_DisplayException")]
     pub fn PyErr_DisplayException(exc: *mut PyObject);
 }
 


### PR DESCRIPTION
Fixes #6345 
Fixes #6244

This lands some preliminary fixes to get the PyPy 3.12 test suite moving further along based on local testing.