### PR TITLE
Implement FromPyObject for ()

### DIFF
--- a/newsfragments/6375.added.md
+++ b/newsfragments/6375.added.md
@@ -1,0 +1,1 @@
+Implement FromPyObject for ()

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -1,12 +1,15 @@
 //! Defines conversions between Rust and Python types.
 use crate::err::PyResult;
+use crate::exceptions::PyValueError;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::{type_hint_identifier, type_hint_subscript, PyStaticExpr};
 use crate::platform::prelude::*;
 use crate::pyclass::boolean_struct::False;
 use crate::pyclass::{PyClassGuardError, PyClassGuardMutError};
-use crate::types::PyList;
+#[cfg(feature = "experimental-inspect")]
+use crate::types::PyNone;
 use crate::types::PyTuple;
+use crate::types::{PyAnyMethods as _, PyList};
 use crate::{
     Borrowed, Bound, BoundObject, Py, PyAny, PyClass, PyErr, PyRef, PyRefMut, PyTypeCheck, Python,
 };
@@ -541,6 +544,19 @@ where
             .map_err(|e| PyClassGuardMutError(Some(e)))?
             .try_borrow_mut()
             .map_err(|_| PyClassGuardMutError(None))
+    }
+}
+
+impl<'py> FromPyObject<'_, 'py> for () {
+    type Error = PyErr;
+
+    #[cfg(feature = "experimental-inspect")]
+    const INPUT_TYPE: PyStaticExpr = PyNone::TYPE_HINT;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
+        obj.is_none()
+            .then_some(())
+            .ok_or(PyValueError::new_err("expected None"))
     }
 }
 


### PR DESCRIPTION
When using macros to map expected Python return types to Rust types, the unit return type does not implement FromPyObject.

Implement FromPyObject for (); both are essentially the "unit value return type". E.g,

    fn func() -> ()

    def func() -> None:

<!--

Thank you for contributing to PyO3!

By submitting these contributions you agree for them to be dual-licensed under PyO3's [MIT OR Apache-2.0 license](https://github.com/PyO3/pyo3#license).

Please consider adding the following to your pull request:
 - an entry for this PR in newsfragments - see [Documenting changes](https://pyo3.rs/main/contributing.html#documenting-changes)
   - or start the PR title with `docs:` if this is a docs-only change to skip the check
   - or start the PR title with `ci:` if this is a ci-only change to skip the check
   - or start the PR title with `internal:` if this is an internal change to skip the check
   - or start the PR title with `refactor:` if this is a refactor change to skip the check
 - docs to all new functions and / or detail in the guide
 - tests for all new or changed functions

PyO3's CI pipeline will check your pull request, thus make sure you have checked the `Contributing.md` guidelines. To run most of its tests locally, you can run `nox`. See `nox --list-sessions` for a list of supported actions.

Please do not submit unsolicited AI-generated PRs.
See our [contributing guidelines](https://pyo3.rs/main/contributing.html) for guidelines on how to use AI when contributing to PyO3.

-->
