### PR TITLE
ci: optionally fail if `no_std` tests fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,11 @@ jobs:
       - name: Test
         run: uvx nox -s ${{ matrix.session }}
 
+  no_std-required:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'no_std') }}
+    needs: [no_std]
+    runs-on: ubuntu-latest
+
   test-debug:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}
     needs: [fmt]
@@ -828,6 +833,7 @@ jobs:
       - test-cross-compilation
       - test-cross-compilation-windows
       - test-introspection
+      - no_std-required
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,6 +536,8 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'no_std') }}
     needs: [no_std]
     runs-on: ubuntu-latest
+    steps:
+      - run: exit 0
 
   test-debug:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'CI-build-full') || github.event_name != 'pull_request' }}


### PR DESCRIPTION
I had this idea to let use use the merge queue and auto-merge for `no_std` PRs.

I think that if you create a new `no_std` label and apply it to a PR, then the job I am proposing in this PR will make `no_std` tests required for CI to pass.