### PR TITLE
ci: try lld for windows linking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
     env:
+      CARGO_TARGET_AARCH64_PC_WINDOWS_MSVC_LINKER: lld-link.exe
+      CARGO_TARGET_I686_PC_WINDOWS_MSVC_LINKER: lld-link.exe
+      CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: lld-link.exe
       CARGO_TERM_VERBOSE: ${{ inputs.verbose }}
       RUST_BACKTRACE: 1
       RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
This is an experiment to see if using a different linker makes windows CI more efficient.