### PR TITLE
Record successful attach only after attaching in SuspendAttach

### DIFF
--- a/newsfragments/6404.fixed.md
+++ b/newsfragments/6404.fixed.md
@@ -1,0 +1,1 @@
+Fix crash when a detached thread is terminated while trying to reattach during interpreter finalization.

--- a/pytests/src/misc.rs
+++ b/pytests/src/misc.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use pyo3::{
     prelude::*,
     types::{PyDict, PyString},
@@ -13,6 +15,24 @@ fn issue_219() {
 struct LockHolder {
     #[expect(unused, reason = "used to block until sender is dropped")]
     sender: std::sync::mpsc::Sender<()>,
+}
+
+#[pyclass]
+struct FinalizationLockHolder {
+    sender: Option<std::sync::mpsc::Sender<()>>,
+    done: SyncReceiver<()>,
+    wait_for_thread: bool,
+}
+
+impl Drop for FinalizationLockHolder {
+    fn drop(&mut self) {
+        self.sender.take();
+        if self.wait_for_thread {
+            self.done
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .ok();
+        }
+    }
 }
 
 // This will repeatedly attach and detach from the Python interpreter
@@ -42,22 +62,66 @@ impl<T> std::ops::Deref for SyncReceiver<T> {
     }
 }
 
-// SAFETY: only used to allow the receiver to be used after detaching
+// SAFETY: each wrapped receiver is accessed from only one thread.
 unsafe impl<T> Sync for SyncReceiver<T> {}
 
+struct FinalizationThreadLocal {
+    object: Option<Py<PyAny>>,
+    done: std::sync::mpsc::Sender<()>,
+}
+
+#[pyclass]
+struct MustDropWhileAttached;
+
+impl Drop for MustDropWhileAttached {
+    fn drop(&mut self) {
+        // SAFETY: PyGILState_Check can always be called.
+        if unsafe { pyo3::ffi::PyGILState_Check() } == 0 {
+            std::process::abort();
+        }
+    }
+}
+
+impl Drop for FinalizationThreadLocal {
+    fn drop(&mut self) {
+        self.object.take();
+        self.done.send(()).ok();
+    }
+}
+
+thread_local! {
+    static DETACH_DURING_FINALIZATION_CONTEXT: RefCell<Option<FinalizationThreadLocal>> = const { RefCell::new(None) };
+}
+
 #[pyfunction]
-fn detach_during_finalization() -> LockHolder {
+fn detach_during_finalization(py: Python<'_>) -> FinalizationLockHolder {
     let (sender, receiver) = std::sync::mpsc::channel();
+    let (ready_sender, ready_receiver) = std::sync::mpsc::channel();
+    let (done_sender, done_receiver) = std::sync::mpsc::channel();
     let receiver = SyncReceiver(receiver);
     std::thread::spawn(move || {
         Python::attach(|py| {
+            DETACH_DURING_FINALIZATION_CONTEXT.with_borrow_mut(|context| {
+                *context = Some(FinalizationThreadLocal {
+                    object: Some(Py::new(py, MustDropWhileAttached).unwrap().into_any()),
+                    done: done_sender,
+                });
+            });
+            ready_sender.send(()).unwrap();
             py.detach(|| {
                 receiver.recv().ok();
                 // Interpreter is finalizing while we try to reattach after returning
             });
         });
     });
-    LockHolder { sender }
+    py.detach(move || ready_receiver.recv()).unwrap();
+    FinalizationLockHolder {
+        sender: Some(sender),
+        done: SyncReceiver(done_receiver),
+        // Older CPython releases run TLS destructors here on macOS and musl.
+        wait_for_thread: cfg!(any(target_os = "macos", target_env = "musl"))
+            && py.version_info() < (3, 13, 8),
+    }
 }
 
 #[pyfunction]

--- a/pytests/src/misc.rs
+++ b/pytests/src/misc.rs
@@ -75,9 +75,12 @@ struct MustDropWhileAttached;
 
 impl Drop for MustDropWhileAttached {
     fn drop(&mut self) {
-        // SAFETY: PyGILState_Check can always be called.
-        if unsafe { pyo3::ffi::PyGILState_Check() } == 0 {
-            std::process::abort();
+        #[cfg(not(Py_LIMITED_API))]
+        {
+            // SAFETY: PyGILState_Check can always be called.
+            if unsafe { pyo3::ffi::PyGILState_Check() } == 0 {
+                std::process::abort();
+            }
         }
     }
 }

--- a/pytests/src/misc.rs
+++ b/pytests/src/misc.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::Cell;
 
 use pyo3::{
     prelude::*,
@@ -17,24 +17,6 @@ struct LockHolder {
     sender: std::sync::mpsc::Sender<()>,
 }
 
-#[pyclass]
-struct FinalizationLockHolder {
-    sender: Option<std::sync::mpsc::Sender<()>>,
-    done: SyncReceiver<()>,
-    wait_for_thread: bool,
-}
-
-impl Drop for FinalizationLockHolder {
-    fn drop(&mut self) {
-        self.sender.take();
-        if self.wait_for_thread {
-            self.done
-                .recv_timeout(std::time::Duration::from_secs(10))
-                .ok();
-        }
-    }
-}
-
 // This will repeatedly attach and detach from the Python interpreter
 // once the LockHolder is dropped.
 #[pyfunction]
@@ -51,80 +33,36 @@ fn hammer_attaching_in_thread() -> LockHolder {
     LockHolder { sender }
 }
 
-/// Wrapper to mark Receiver as Sync.
-struct SyncReceiver<T>(std::sync::mpsc::Receiver<T>);
-
-impl<T> std::ops::Deref for SyncReceiver<T> {
-    type Target = std::sync::mpsc::Receiver<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-// SAFETY: each wrapped receiver is accessed from only one thread.
-unsafe impl<T> Sync for SyncReceiver<T> {}
-
-struct FinalizationThreadLocal {
-    object: Option<Py<PyAny>>,
-    done: std::sync::mpsc::Sender<()>,
-}
-
 #[pyclass]
 struct MustDropWhileAttached;
 
 impl Drop for MustDropWhileAttached {
     fn drop(&mut self) {
-        #[cfg(not(Py_LIMITED_API))]
-        {
-            // SAFETY: PyGILState_Check can always be called.
-            if unsafe { pyo3::ffi::PyGILState_Check() } == 0 {
-                std::process::abort();
-            }
-        }
-    }
-}
-
-impl Drop for FinalizationThreadLocal {
-    fn drop(&mut self) {
-        self.object.take();
-        self.done.send(()).ok();
+        // SAFETY: always callable; fatal error (abort) if the thread is not attached.
+        unsafe { pyo3::ffi::PyThreadState_Get() };
     }
 }
 
 thread_local! {
-    static DETACH_DURING_FINALIZATION_CONTEXT: RefCell<Option<FinalizationThreadLocal>> = const { RefCell::new(None) };
+    // Dropped when the thread exits, which on older CPython happens inside
+    // PyEval_RestoreThread when reattaching during finalization.
+    static DROPPED_ON_THREAD_EXIT: Cell<Option<Py<MustDropWhileAttached>>> = const { Cell::new(None) };
 }
 
 #[pyfunction]
-fn detach_during_finalization(py: Python<'_>) -> FinalizationLockHolder {
+fn detach_during_finalization(py: Python<'_>) -> LockHolder {
     let (sender, receiver) = std::sync::mpsc::channel();
     let (ready_sender, ready_receiver) = std::sync::mpsc::channel();
-    let (done_sender, done_receiver) = std::sync::mpsc::channel();
-    let receiver = SyncReceiver(receiver);
     std::thread::spawn(move || {
         Python::attach(|py| {
-            DETACH_DURING_FINALIZATION_CONTEXT.with_borrow_mut(|context| {
-                *context = Some(FinalizationThreadLocal {
-                    object: Some(Py::new(py, MustDropWhileAttached).unwrap().into_any()),
-                    done: done_sender,
-                });
-            });
+            DROPPED_ON_THREAD_EXIT.set(Some(Py::new(py, MustDropWhileAttached).unwrap()));
             ready_sender.send(()).unwrap();
-            py.detach(|| {
-                receiver.recv().ok();
-                // Interpreter is finalizing while we try to reattach after returning
-            });
+            py.detach(move || receiver.recv().ok());
+            // Interpreter is finalizing while we try to reattach after returning
         });
     });
     py.detach(move || ready_receiver.recv()).unwrap();
-    FinalizationLockHolder {
-        sender: Some(sender),
-        done: SyncReceiver(done_receiver),
-        // Older CPython releases run TLS destructors here on macOS and musl.
-        wait_for_thread: cfg!(any(target_os = "macos", target_env = "musl"))
-            && py.version_info() < (3, 13, 8),
-    }
+    LockHolder { sender }
 }
 
 #[pyfunction]

--- a/src/internal/state.rs
+++ b/src/internal/state.rs
@@ -300,9 +300,9 @@ impl SuspendAttach {
 
 impl Drop for SuspendAttach {
     fn drop(&mut self) {
-        ATTACH_COUNT.with(|c| c.set(self.count));
         // SAFETY: tstate come from call to PyEval_SaveThread and it was not re-attached yet
         unsafe { ffi::PyEval_RestoreThread(self.tstate) };
+        ATTACH_COUNT.with(|c| c.set(self.count));
         // Update counts of `Py<T>` that were dropped while not attached.
         #[cfg(not(pyo3_disable_reference_pool))]
         {


### PR DESCRIPTION
`SuspendAttach::drop` increments `ATTACH_COUNT` before successfully attaching. This was missed during review of #6085 (ping @anuraaga). The fix is to only increment if we actually successfully attach.

This bug can lead to crashes if the attach happens during interpreter shutdown on pythons older than 3.13.8.

I hit this while working on https://github.com/Quansight/spinningjenny/pull/14. See the workaround there for how I'm avoiding the problem. `spinningjenny` stores state in Rust TLS, and that pattern does not look like any existing tests in PyO3.

I updated the testing utilities we use in `test_finalization.py` to trigger this. It unfortunately requires a decent amount of complexity to ensure the race is triggered deterministically.

Adding the soundness label because I think the current behavior is unsound.