### PR TITLE
fix crash with GC occurring during class attribute initialization

### DIFF
--- a/guide/src/class.md
+++ b/guide/src/class.md
@@ -1565,6 +1565,11 @@ impl pyo3::impl_::pyclass::PyClassImpl for MyClass {
     fn __traverse__(&self, _visit: pyo3::pyclass::PyVisit<'_>) -> Result<(), pyo3::pyclass::PyTraverseError> {
         Ok(())
     }
+
+    fn token() -> *mut core::ffi::c_void {
+        static TOKEN: u8 = 0;
+        (&raw const TOKEN).cast_mut().cast()
+    }
 }
 
 # Python::attach(|py| {

--- a/pyo3-ffi/src/cpython/object.rs
+++ b/pyo3-ffi/src/cpython/object.rs
@@ -367,6 +367,7 @@ extern_libpython! {
 // skipped Py_TRASHCAN_END
 
 // skipped PyObject_GetItemData
+// skipped PyObject_GetItemData_DuringGC
 
 // skipped PyObject_VisitManagedDict
 // skipped _PyObject_SetManagedDict

--- a/pyo3-ffi/src/moduleobject.rs
+++ b/pyo3-ffi/src/moduleobject.rs
@@ -125,12 +125,19 @@ extern_libpython! {
     pub fn PyUnstable_Module_SetGIL(module: *mut PyObject, gil: *mut c_void) -> c_int;
 }
 
-#[cfg(Py_3_15)]
 extern_libpython! {
+    #[cfg(Py_3_15)]
     pub fn PyModule_FromSlotsAndSpec(slots: *const PySlot, spec: *mut PyObject) -> *mut PyObject;
+    #[cfg(Py_3_15)]
     pub fn PyModule_Exec(_mod: *mut PyObject) -> c_int;
+    #[cfg(Py_3_15)]
     pub fn PyModule_GetStateSize(_mod: *mut PyObject, result: *mut Py_ssize_t) -> c_int;
+    #[cfg(Py_3_15)]
     pub fn PyModule_GetToken(module: *mut PyObject, result: *mut *mut c_void) -> c_int;
+    #[cfg(Py_3_15)]
+    pub fn PyModule_GetState_DuringGC(module: *mut PyObject) -> *mut c_void;
+    #[cfg(Py_3_15)]
+    pub fn PyModule_GetToken_DuringGC(module: *mut PyObject, result: *mut *mut c_void) -> c_int;
 }
 
 #[cfg(not(all(Py_LIMITED_API, Py_GIL_DISABLED)))]

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -791,5 +791,8 @@ extern_libpython! {
     pub fn PyType_GetModule_DuringGC(type_: *mut PyTypeObject) -> *mut PyObject;
 
     #[cfg(Py_3_15)]
-    pub fn PyType_GetModuleByToken_DuringGC(type_: *mut PyTypeObject, mod_token: *const c_void) -> *mut PyObject;
+    pub fn PyType_GetModuleByToken_DuringGC(
+        type_: *mut PyTypeObject,
+        mod_token: *const c_void,
+    ) -> *mut PyObject;
 }

--- a/pyo3-ffi/src/object.rs
+++ b/pyo3-ffi/src/object.rs
@@ -768,6 +768,28 @@ extern_libpython! {
     pub fn PyType_Freeze(tp: *mut crate::PyTypeObject) -> c_int;
 
     #[cfg(Py_3_15)]
+    pub fn PyObject_CallFinalizerFromDealloc(arg1: *mut crate::PyObject) -> c_int;
+
+    #[cfg(Py_3_15)]
     pub fn PyType_GetModuleByToken(_type: *mut PyTypeObject, token: *const c_void)
         -> *mut PyObject;
+
+    #[cfg(Py_3_15)]
+    pub fn PyObject_GetTypeData_DuringGC(o: *mut PyObject, cls: *mut PyTypeObject) -> *mut c_void;
+
+    #[cfg(Py_3_15)]
+    pub fn PyType_GetModuleState_DuringGC(type_: *mut PyTypeObject) -> *mut c_void;
+
+    #[cfg(Py_3_15)]
+    pub fn PyType_GetBaseByToken_DuringGC(
+        type_: *mut PyTypeObject,
+        tp_token: *mut c_void,
+        result: *mut *mut PyTypeObject,
+    ) -> c_int;
+
+    #[cfg(Py_3_15)]
+    pub fn PyType_GetModule_DuringGC(type_: *mut PyTypeObject) -> *mut PyObject;
+
+    #[cfg(Py_3_15)]
+    pub fn PyType_GetModuleByToken_DuringGC(type_: *mut PyTypeObject, mod_token: *const c_void) -> *mut PyObject;
 }

--- a/pyo3-ffi/src/slots_generated.rs
+++ b/pyo3-ffi/src/slots_generated.rs
@@ -89,6 +89,7 @@ pub const Py_am_anext: c_int = 79;
 pub const Py_tp_finalize: c_int = 80;
 pub const Py_am_send: c_int = 81;
 pub const Py_tp_vectorcall: c_int = 82;
+#[cfg(Py_3_14)]
 pub const Py_tp_token: c_int = 83;
 pub const Py_mod_create: c_int = _Py_SLOT_COMPAT_VALUE(1, 84);
 pub const Py_mod_exec: c_int = _Py_SLOT_COMPAT_VALUE(2, 85);

--- a/pyo3-macros-backend/src/pyclass.rs
+++ b/pyo3-macros-backend/src/pyclass.rs
@@ -3101,6 +3101,11 @@ impl<'a> PyClassImplsBuilder<'a> {
                     use #pyo3_path::impl_::pyclass::{PyClassTraverse, PyClassImplCollector};
                     PyClassImplCollector::<Self>::new().__traverse__(self, visit)
                 }
+
+                fn token() -> *mut ::core::ffi::c_void {
+                    static TOKEN: u8 = 0;
+                    (&raw const TOKEN).cast_mut().cast()
+                }
             }
 
             #default_methods_impl

--- a/src/impl_/pyclass.rs
+++ b/src/impl_/pyclass.rs
@@ -289,6 +289,10 @@ pub trait PyClassImpl: Sized + 'static {
     fn lazy_type_object() -> &'static LazyTypeObject<Self>;
 
     fn __traverse__(&self, visit: PyVisit<'_>) -> Result<(), PyTraverseError>;
+
+    /// Static token used for `Py_tp_token`. Emitted on all versions so that the macro
+    /// does not depend on the Python version, only used on 3.14+
+    fn token() -> *mut c_void;
 }
 
 mod generic_pyclass {

--- a/src/impl_/pyclass/lazy_type_object.rs
+++ b/src/impl_/pyclass/lazy_type_object.rs
@@ -76,6 +76,18 @@ impl<T: PyClass> LazyTypeObject<T> {
             T::items_iter(),
         )
     }
+
+    /// Gets the type object contained without performing any initialization work.
+    /// This avoids unsafe operations during GC.
+    #[cfg(not(Py_3_15))]
+    pub(crate) fn get_during_gc(&self) -> &Py<PyType> {
+        &self
+            .0
+            .value
+            .get_during_gc()
+            .expect("PyClass type object should have been created to reach GC")
+            .type_object
+    }
 }
 
 impl LazyTypeObjectInner {

--- a/src/impl_/pymethods.rs
+++ b/src/impl_/pymethods.rs
@@ -11,13 +11,14 @@ use crate::impl_::panic::PanicTrap;
 use crate::impl_::pyclass::PyClassDict as _;
 #[cfg(feature = "experimental-inspect")]
 use crate::inspect::PyStaticExpr;
+use crate::instance::PyBorrowedUnbound;
 use crate::internal::get_slot::{get_slot, TP_BASE, TP_CLEAR, TP_TRAVERSE};
 use crate::internal::pyclass_init::PyClassInit;
 use crate::internal::state::ForbidAttaching;
-use crate::pycell::impl_::{PyClassObjectBaseLayout, PyClassObjectLayout};
-use crate::pyclass::gc::{make_traverse_result, PyTraverseError, PyVisit};
+use crate::pycell::impl_::PyClassObjectLayout;
+use crate::pyclass::gc::{make_traverse_result, PyClassTraverseGuard, PyTraverseError, PyVisit};
 use crate::types::PyType;
-use crate::{ffi, Borrowed, Bound, Py, PyAny, PyClass, PyClassGuard, PyErr, PyResult, Python};
+use crate::{ffi, Borrowed, Bound, Py, PyAny, PyClass, PyErr, PyResult, Python};
 use core::ffi::CStr;
 use core::ffi::{c_int, c_void};
 use core::fmt;
@@ -370,6 +371,13 @@ where
     let trap = PanicTrap::new("uncaught panic inside __traverse__ handler");
     let lock = ForbidAttaching::during_traverse();
 
+    // SAFETY: Python will always call `tp_traverse` with a non-null pointer
+    // to a valid instance of `T`. The borrowed lifetime `'a` is only passed to
+    // `traverse_impl`; it does not widen outside this function call.
+    let slf = unsafe {
+        PyBorrowedUnbound::from_non_null(NonNull::new_unchecked(slf)).cast_unchecked::<T>()
+    };
+
     let retval = match catch_unwind(AssertUnwindSafe(move || unsafe {
         traverse_impl::<T>(slf, visit, arg, tp_traverse::<T>)
     })) {
@@ -391,8 +399,8 @@ where
 /// - `slf` must be a valid pointer to an instance of `T`.
 /// - Must only be called from `tp_traverse`, which holds the `PanicTrap` and `ForbidAttaching`
 ///   lock this relies on.
-unsafe fn traverse_impl<T>(
-    slf: *mut ffi::PyObject,
+unsafe fn traverse_impl<'a, T>(
+    slf: PyBorrowedUnbound<'a, T>,
     visit: ffi::visitproc,
     arg: *mut c_void,
     current_traverse: ffi::traverseproc,
@@ -400,24 +408,18 @@ unsafe fn traverse_impl<T>(
 where
     T: PyClass,
 {
-    unsafe { call_super_traverse(slf, visit, arg, current_traverse) }?;
-
-    // SAFETY: `slf` is a valid Python object pointer to a class object of type T, and
-    // traversal is running so no mutations can occur.
-    let class_object: &<T as PyClassImpl>::Layout = unsafe { &*slf.cast() };
+    unsafe { call_super_traverse(slf.as_ptr(), visit, arg, current_traverse) }?;
 
     // The `__dict__` is not Rust data, so it is visited without the thread and borrow checks
     // below: it must stay reachable to the GC even when the pyclass data cannot be traversed.
-    make_traverse_result(unsafe { class_object.contents().dict.traverse_dict(visit, arg) })?;
-
-    // Unsendable types: `PyClassGuard::try_from_class_object` will panic on thread safety issue,
-    // fail gracefully here first. This check is a no-op for types which are not `#[pyclass(unsendable)]`.
-    if class_object.check_threadsafe().is_err() {
-        return Ok(());
-    }
+    make_traverse_result(unsafe {
+        T::Layout::contents_during_gc(slf)
+            .dict
+            .traverse_dict(visit, arg)
+    })?;
 
     // If we cannot safely obtain Rust state to traverse, we cannot traverse the object.
-    let Ok(guard) = PyClassGuard::<T>::try_from_class_object(class_object) else {
+    let Some(guard) = PyClassTraverseGuard::<T>::try_from_class_object(slf) else {
         return Ok(());
     };
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1573,6 +1573,10 @@ impl<T> Py<T> {
         // Safety: all Py<T> are valid Py<PyAny>
         unsafe { Py::from_non_null(ManuallyDrop::new(self).0) }
     }
+
+    pub(crate) fn as_non_null(&self) -> NonNull<ffi::PyObject> {
+        self.0
+    }
 }
 
 impl<T> Py<T>
@@ -2417,6 +2421,63 @@ impl<T> Py<T> {
     pub unsafe fn cast_bound_unchecked<'py, U>(&self, py: Python<'py>) -> &Bound<'py, U> {
         // Safety: caller has upheld the safety contract
         unsafe { self.bind(py).cast_unchecked() }
+    }
+}
+
+/// Variant of [`Borrowed`] which doesn't have the attachment lifetime `'py` and therefore
+/// can be used in contexts where the Python interpreter is not attached, such as during
+/// GC traversal.
+///
+/// This is intended to be a private type for now as it's unlikely to have much use outside
+/// of PyO3 internals. It also has a horrible name. It comes in useful as a better
+/// alternative to `NonNull<ffi::PyObject>` because it carries the lifetime of validity
+/// plus type information.
+#[repr(transparent)]
+pub(crate) struct PyBorrowedUnbound<'a, T>(NonNull<ffi::PyObject>, PhantomData<&'a Py<T>>);
+
+impl<'a, T> Clone for PyBorrowedUnbound<'a, T> {
+    fn clone(&self) -> Self {
+        // No reference counting
+        Self(self.0, PhantomData)
+    }
+}
+
+impl<'a, T> Copy for PyBorrowedUnbound<'a, T> {}
+
+impl<'a> PyBorrowedUnbound<'a, PyAny> {
+    /// # Safety
+    ///
+    /// `ptr` must be a valid pointer to a Python object. The caller is responsible
+    /// for scoping the unbound lifetime `'a`.
+    #[inline]
+    pub(crate) unsafe fn from_non_null(ptr: NonNull<ffi::PyObject>) -> Self {
+        Self(ptr, PhantomData)
+    }
+}
+
+impl<'a, T> PyBorrowedUnbound<'a, T> {
+    #[cfg_attr(not(Py_3_15), expect(dead_code))]
+    pub(crate) fn as_any(self) -> PyBorrowedUnbound<'a, PyAny> {
+        // SAFETY: always can interpret as any
+        unsafe { self.cast_unchecked() }
+    }
+
+    /// # Safety
+    ///
+    /// Callers must ensure that the type is valid or risk type confusion.
+    #[inline]
+    pub(crate) unsafe fn cast_unchecked<U>(self) -> PyBorrowedUnbound<'a, U> {
+        PyBorrowedUnbound(self.0, PhantomData)
+    }
+}
+
+impl<'a, T> Deref for PyBorrowedUnbound<'a, T> {
+    type Target = Py<T>;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: `Py<T>` has the same layout as `PyBorrowedUnbound<'a, T>` - just `NonNull<ffi::PyObject>`
+        // and both are `#[repr(transparent)]`
+        unsafe { NonNull::from(self).cast().as_ref() }
     }
 }
 

--- a/src/pycell/impl_.rs
+++ b/src/pycell/impl_.rs
@@ -2,18 +2,29 @@
 //! Crate-private implementation of PyClassObject
 
 use core::cell::UnsafeCell;
+#[cfg(Py_3_14)]
+use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::mem::{offset_of, ManuallyDrop, MaybeUninit};
+#[cfg(Py_3_15)]
+use core::ptr::NonNull;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
+#[cfg(Py_3_14)]
+use crate::ffi_ptr_ext::FfiPtrExt;
 use crate::impl_::pyclass::{
     PyClassBaseType, PyClassDict, PyClassImpl, PyClassThreadChecker, PyClassWeakRef, PyObjectOffset,
 };
+use crate::instance::PyBorrowedUnbound;
 use crate::internal::get_slot::{TP_DEALLOC, TP_FREE};
 #[cfg(RustPython)]
 use crate::sync::PyOnceLock;
 use crate::type_object::{PyLayout, PySizedLayout, PyTypeInfo};
 use crate::types::PyType;
+#[cfg(Py_3_14)]
+use crate::Bound;
+#[cfg(Py_3_15)]
+use crate::PyAny;
 use crate::{ffi, PyClass, Python};
 
 use crate::types::PyTypeMethods;
@@ -184,28 +195,50 @@ pub trait GetBorrowChecker<T: PyClassImpl> {
     fn borrow_checker(
         class_object: &T::Layout,
     ) -> &<T::PyClassMutability as PyClassMutability>::Checker;
+
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn borrow_checker_during_gc(
+        class_object: PyBorrowedUnbound<'_, T>,
+    ) -> &<T::PyClassMutability as PyClassMutability>::Checker;
 }
 
 impl<T: PyClassImpl<PyClassMutability = Self>> GetBorrowChecker<T> for MutableClass {
     fn borrow_checker(class_object: &T::Layout) -> &BorrowChecker {
         &class_object.contents().borrow_checker
     }
-}
 
-impl<T: PyClassImpl<PyClassMutability = Self>> GetBorrowChecker<T> for ImmutableClass {
-    fn borrow_checker(class_object: &T::Layout) -> &EmptySlot {
-        &class_object.contents().borrow_checker
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn borrow_checker_during_gc(class_object: PyBorrowedUnbound<'_, T>) -> &BorrowChecker {
+        &T::Layout::contents_during_gc(class_object).borrow_checker
     }
 }
 
-impl<T: PyClassImpl<PyClassMutability = Self>, M: PyClassMutability> GetBorrowChecker<T>
+impl<T: PyClass<PyClassMutability = Self>> GetBorrowChecker<T> for ImmutableClass {
+    fn borrow_checker(class_object: &T::Layout) -> &EmptySlot {
+        &class_object.contents().borrow_checker
+    }
+
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn borrow_checker_during_gc(class_object: PyBorrowedUnbound<'_, T>) -> &EmptySlot {
+        &T::Layout::contents_during_gc(class_object).borrow_checker
+    }
+}
+
+impl<T: PyClass<PyClassMutability = Self>, M: PyClassMutability> GetBorrowChecker<T>
     for ExtendsMutableAncestor<M>
 where
     T::BaseType: PyClassImpl + PyClassBaseType<LayoutAsBase = <T::BaseType as PyClassImpl>::Layout>,
     <T::BaseType as PyClassImpl>::PyClassMutability: PyClassMutability<Checker = BorrowChecker>,
 {
     fn borrow_checker(class_object: &T::Layout) -> &BorrowChecker {
-        <<T::BaseType as PyClassImpl>::PyClassMutability as GetBorrowChecker<T::BaseType>>::borrow_checker(class_object.ob_base())
+        <<T::BaseType as PyClassImpl>::Layout>::borrow_checker(class_object.ob_base())
+    }
+
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn borrow_checker_during_gc(class_object: PyBorrowedUnbound<'_, T>) -> &BorrowChecker {
+        // SAFETY: `T` can always be interpreted as its base type
+        let super_obj = unsafe { class_object.cast_unchecked() };
+        <<T::BaseType as PyClassImpl>::Layout>::borrow_checker_during_gc(super_obj)
     }
 }
 
@@ -369,6 +402,10 @@ pub trait PyClassObjectLayout<T: PyClassImpl>: PyClassObjectBaseLayout<T> {
     /// Obtain a mutable reference to the structure that contains the pyclass struct and associated metadata.
     fn contents_mut(&mut self) -> &mut PyClassObjectContents<T>;
 
+    /// Variant of the above which is correct to call during GC (e.g. no refcounting)
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn contents_during_gc(this: PyBorrowedUnbound<'_, T>) -> &PyClassObjectContents<T>;
+
     /// Obtain a pointer to the pyclass struct.
     fn get_ptr(&self) -> *mut T;
 
@@ -376,6 +413,11 @@ pub trait PyClassObjectLayout<T: PyClassImpl>: PyClassObjectBaseLayout<T> {
     fn ob_base(&self) -> &<T::BaseType as PyClassBaseType>::LayoutAsBase;
 
     fn borrow_checker(&self) -> &<T::PyClassMutability as PyClassMutability>::Checker;
+
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn borrow_checker_during_gc(
+        this: PyBorrowedUnbound<'_, T>,
+    ) -> &<T::PyClassMutability as PyClassMutability>::Checker;
 }
 
 #[repr(C)]
@@ -463,6 +505,12 @@ impl<T: PyClassImpl<Layout = Self>> PyClassObjectLayout<T> for PyStaticClassObje
         &mut self.contents
     }
 
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn contents_during_gc(this: PyBorrowedUnbound<'_, T>) -> &PyClassObjectContents<T> {
+        let this = this.as_non_null().cast::<Self>();
+        unsafe { &this.as_ref().contents }
+    }
+
     fn get_ptr(&self) -> *mut T {
         self.contents.value.get()
     }
@@ -473,6 +521,13 @@ impl<T: PyClassImpl<Layout = Self>> PyClassObjectLayout<T> for PyStaticClassObje
 
     fn borrow_checker(&self) -> &<T::PyClassMutability as PyClassMutability>::Checker {
         T::PyClassMutability::borrow_checker(self)
+    }
+
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn borrow_checker_during_gc(
+        this: PyBorrowedUnbound<'_, T>,
+    ) -> &<T::PyClassMutability as PyClassMutability>::Checker {
+        T::PyClassMutability::borrow_checker_during_gc(this)
     }
 }
 
@@ -518,12 +573,23 @@ impl<T: PyClass<Layout = Self>> PyVariableClassObject<T> {
     unsafe fn get_contents_of_obj(
         obj: *mut ffi::PyObject,
     ) -> *mut MaybeUninit<PyClassObjectContents<T>> {
-        // TODO: it would be nice to eventually avoid coupling to the PyO3 statics here, maybe using
-        // 3.14's PyType_GetBaseByToken, to support PEP 587 / multiple interpreters better
-        // SAFETY: caller guarantees attached to the interpreter
-        let type_obj = T::type_object_raw(unsafe { Python::assume_attached() });
-        let pointer = unsafe { ffi::PyObject_GetTypeData(obj, type_obj) };
-        pointer.cast()
+        cfg_select! {
+            Py_3_14 => {
+                // SAFETY: thread is attached and `obj` is a valid pointer
+                let type_obj = unsafe { get_type_by_token(Python::assume_attached(), obj, T::token()) };
+                // SAFETY: `obj` and `type_obj` known to be valid pointers by the successful
+                // call to `PyType_GetBaseByToken`
+                let pointer = unsafe { ffi::PyObject_GetTypeData(obj, type_obj.as_type_ptr()) };
+                pointer.cast()
+            }
+            not(Py_3_14) => {
+                // This is technically not correct once PyO3 supports reloadable modules / module state;
+                // we should avoid going via the statics. 3.14+ can do this using the token API above.
+                let type_obj = T::type_object_raw(unsafe { Python::assume_attached() });
+                let pointer = unsafe { ffi::PyObject_GetTypeData(obj, type_obj) };
+                pointer.cast()
+            }
+        }
     }
 
     fn get_contents_ptr(&self) -> *mut PyClassObjectContents<T> {
@@ -579,8 +645,91 @@ impl<T: PyClass<Layout = Self>> PyClassObjectLayout<T> for PyVariableClassObject
             .expect("should be able to cast PyClassObjectContents pointer")
     }
 
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn contents_during_gc(this: PyBorrowedUnbound<'_, T>) -> &PyClassObjectContents<T> {
+        let obj: *mut ffi::PyObject = this.as_ptr();
+        let type_obj = cfg_select! {
+            Py_3_15 => {
+                // SAFETY: is during GC
+                unsafe { get_type_by_token_during_gc(this.as_any(), T::token()) }.as_ptr().cast()
+            },
+            not(Py_3_15) => {
+                // This goes through PyO3 statics which is technically not correct once PyO3 supports
+                // reloadable modules / module state, but we can't do better before 3.15 due to lack
+                // of `DuringGC` variants.
+                T::lazy_type_object().get_during_gc().as_ptr().cast::<ffi::PyTypeObject>()
+            }
+        };
+
+        let pointer = cfg_select! {
+            // SAFETY: `obj` and `type_obj` known to be valid pointers by the successful
+            // call to `PyType_GetBaseByToken_DuringGC`
+            Py_3_15 => unsafe { ffi::PyObject_GetTypeData_DuringGC(obj, type_obj) },
+            // SAFETY: `obj` and `type_obj` known to be valid pointers by the `get_during_gc` call
+            not(Py_3_15) => unsafe { ffi::PyObject_GetTypeData(obj, type_obj) },
+        };
+
+        // SAFETY: `PyObject_GetTypeData_DuringGC` returns a borrowed pointer to the contents of the object,
+        // valid for the lifetime of the object.
+        unsafe { &*pointer.cast() }
+    }
+
     fn borrow_checker(&self) -> &<T::PyClassMutability as PyClassMutability>::Checker {
         T::PyClassMutability::borrow_checker(self)
+    }
+
+    #[expect(private_interfaces, reason = "only intended for use within PyO3")]
+    fn borrow_checker_during_gc(
+        this: PyBorrowedUnbound<'_, T>,
+    ) -> &<T::PyClassMutability as PyClassMutability>::Checker {
+        T::PyClassMutability::borrow_checker_during_gc(this)
+    }
+}
+
+#[cfg(Py_3_14)]
+unsafe fn get_type_by_token<'py>(
+    py: Python<'py>,
+    obj: *mut ffi::PyObject,
+    token: *mut c_void,
+) -> Bound<'py, PyType> {
+    let mut type_obj = core::ptr::null_mut();
+    // SAFETY: `obj` is a valid object
+    match unsafe { ffi::PyType_GetBaseByToken(ffi::Py_TYPE(obj), token, &mut type_obj) } {
+        core::ffi::c_int::MIN..=-1 => {
+            // SAFETY: `obj` is a valid object, exception is known to be set
+            unsafe { ffi::PyErr_WriteUnraisable(obj) };
+            panic!("failed to get base type by token")
+        }
+        0 => panic!("failed to get base type by token"),
+        1..=core::ffi::c_int::MAX => unsafe {
+            type_obj
+                .cast::<ffi::PyObject>()
+                .assume_owned_unchecked(py)
+                .cast_into_unchecked()
+        },
+    }
+}
+
+/// # Safety
+///
+/// Only sound during GC; uses borrowed references
+#[cfg(Py_3_15)]
+unsafe fn get_type_by_token_during_gc(
+    obj: PyBorrowedUnbound<'_, PyAny>,
+    token: *mut c_void,
+) -> PyBorrowedUnbound<'_, PyType> {
+    let mut type_obj = core::ptr::null_mut();
+    // SAFETY: `obj` is a valid object
+    if unsafe {
+        ffi::PyType_GetBaseByToken_DuringGC(ffi::Py_TYPE(obj.as_ptr()), token, &mut type_obj)
+    } <= 0
+    {
+        panic!("failed to get base type by token");
+    }
+
+    // SAFETY: success guarantees non-null result
+    unsafe {
+        PyBorrowedUnbound::from_non_null(NonNull::new_unchecked(type_obj).cast()).cast_unchecked()
     }
 }
 

--- a/src/pyclass/create_type_object.rs
+++ b/src/pyclass/create_type_object.rs
@@ -66,6 +66,7 @@ where
         name: &'static str,
         module: Option<&'static str>,
         basicsize: ffi::Py_ssize_t,
+        #[cfg(Py_3_14)] token: *mut c_void,
     ) -> PyResult<PyClassTypeObject> {
         unsafe {
             PyTypeBuilder {
@@ -88,6 +89,8 @@ where
                 has_clear: false,
                 dict_offset: None,
                 class_flags: ffi::Py_TPFLAGS_DEFAULT | ffi::Py_TPFLAGS_HAVE_GC,
+                #[cfg(Py_3_14)]
+                token,
             }
             .type_doc(doc)
             .offsets(dict_offset, weaklist_offset)
@@ -115,6 +118,8 @@ where
             <T as PyClass>::NAME,
             <T as PyClassImpl>::MODULE,
             <T as PyClassImpl>::Layout::BASIC_SIZE,
+            #[cfg(Py_3_14)]
+            T::token(),
         )
     }
 }
@@ -146,6 +151,8 @@ struct PyTypeBuilder {
     has_clear: bool,
     dict_offset: Option<PyObjectOffset>,
     class_flags: c_ulong,
+    #[cfg(Py_3_14)]
+    token: *mut c_void,
 }
 
 impl PyTypeBuilder {
@@ -405,6 +412,10 @@ impl PyTypeBuilder {
 
         let getset_defs = self.finalize_methods_and_properties();
 
+        #[cfg(Py_3_14)]
+        unsafe {
+            self.push_slot(ffi::Py_tp_token, self.token)
+        }
         unsafe { self.push_slot(ffi::Py_tp_base, self.tp_base as *mut c_void) }
 
         if !self.has_new {

--- a/src/pyclass/gc.rs
+++ b/src/pyclass/gc.rs
@@ -2,9 +2,17 @@ use core::{
     ffi::{c_int, c_void},
     marker::PhantomData,
     num::NonZero,
+    ops::Deref,
+    ptr::NonNull,
 };
 
-use crate::{ffi, Py};
+use crate::{
+    ffi,
+    impl_::{pycell::PyClassMutability, pyclass::PyClassThreadChecker},
+    instance::PyBorrowedUnbound,
+    pycell::impl_::{PyClassBorrowChecker, PyClassObjectLayout},
+    Py, PyClass,
+};
 
 /// Error returned by a `__traverse__` visitor implementation.
 #[repr(transparent)]
@@ -71,6 +79,61 @@ pub(crate) fn make_traverse_result(retval: c_int) -> Result<(), PyTraverseError>
     match NonZero::new(retval) {
         None => Ok(()),
         Some(r) => Err(PyTraverseError(r)),
+    }
+}
+
+/// Variant of [`crate::PyClassGuard`] that is used during `__traverse__` calls to
+/// ensure that only gc-safe operations are performed on the class instance.
+pub(crate) struct PyClassTraverseGuard<'a, T: PyClass> {
+    // Caching these two pointers avoids repeated by-token resolution, e.g. on drop
+    value: NonNull<T>,
+    borrow_checker: &'a <T::PyClassMutability as PyClassMutability>::Checker,
+    // The original reference which we're fundamentally handling
+    phantom: PhantomData<PyBorrowedUnbound<'a, T>>,
+}
+
+impl<'a, T: PyClass> PyClassTraverseGuard<'a, T> {
+    /// Attempts to create a `PyClassTraverseGuard` from a raw pointer to a class object.
+    ///
+    /// If the Rust state cannot be safely traversed (e.g. unsendable or currently borrowed),
+    /// this returns `None`. This will lead to an incomplete traversal, which is safe but
+    /// may leak memory.
+    pub(crate) fn try_from_class_object(class_object: PyBorrowedUnbound<'a, T>) -> Option<Self> {
+        let contents = T::Layout::contents_during_gc(class_object);
+
+        if !contents.thread_checker.check() {
+            return None;
+        }
+
+        // This doesn't read from contents because it might need to traverse the ancestry to
+        // find the actual borrow checker for the highest mutable base.
+        let borrow_checker = T::Layout::borrow_checker_during_gc(class_object);
+
+        borrow_checker.try_borrow().ok().map(|_| {
+            // SAFETY: successful borrow implies we have read access to
+            // the data, cache a `NonNull` pointer to it which we can use to deref freely
+            let value = unsafe { NonNull::from(&*contents.value.get()) };
+            Self {
+                value,
+                borrow_checker,
+                phantom: PhantomData,
+            }
+        })
+    }
+}
+
+impl<'a, T: PyClass> Deref for PyClassTraverseGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: we hold a borrow on the underlying data, so we can read it
+        unsafe { self.value.as_ref() }
+    }
+}
+
+impl<'a, T: PyClass> Drop for PyClassTraverseGuard<'a, T> {
+    fn drop(&mut self) {
+        self.borrow_checker.release_borrow();
     }
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -122,6 +122,16 @@ impl<T> GILOnceCell<T> {
         }
     }
 
+    #[cfg(not(Py_3_15))]
+    pub(crate) fn get_during_gc(&self) -> Option<&T> {
+        if self.once.is_completed() {
+            // SAFETY: the cell has been written.
+            Some(unsafe { (*self.data.get()).assume_init_ref() })
+        } else {
+            None
+        }
+    }
+
     /// Like `get_or_init`, but accepts a fallible initialization function. If it fails, the cell
     /// is left uninitialized.
     ///

--- a/tests/test_class_formatting.rs
+++ b/tests/test_class_formatting.rs
@@ -49,6 +49,68 @@ fn test_enum_class_fmt() {
     })
 }
 
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_gc_during_classattr_initialization() {
+    use pyo3::{PyTraverseError, PyVisit};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static CLASSATTR_CALLS: AtomicUsize = AtomicUsize::new(0);
+    static TRAVERSE_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[pyclass]
+    struct GcDuringClassattr;
+
+    #[pymethods]
+    impl GcDuringClassattr {
+        #[classattr]
+        fn instance(py: Python<'_>) -> PyResult<Py<PyAny>> {
+            if CLASSATTR_CALLS.fetch_add(1, Ordering::SeqCst) != 0 {
+                // Prevent infinite recursion of new threads & nested GC traversals.
+                return Ok(py.None());
+            }
+
+            let instance = Py::new(py, Self)?;
+
+            // Run GC traversal on a separate thread; incorrect coupling of Python statics
+            // can cause class attribute initialization to be triggered during GC traversal,
+            // which will corrupt GC state.
+            py.detach(|| {
+                std::thread::spawn(|| {
+                    Python::attach(|py| {
+                        let gc = py.import("gc").unwrap();
+                        let before = TRAVERSE_CALLS.load(Ordering::SeqCst);
+                        gc.call_method0("collect").unwrap();
+                        assert!(TRAVERSE_CALLS.load(Ordering::SeqCst) > before);
+                    });
+                })
+                .join()
+                .unwrap();
+            });
+            Ok(instance.into_any())
+        }
+
+        #[expect(clippy::unnecessary_wraps)]
+        fn __traverse__(&self, _visit: PyVisit<'_>) -> Result<(), PyTraverseError> {
+            TRAVERSE_CALLS.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    Python::attach(|py| {
+        let ty = py.get_type::<GcDuringClassattr>();
+        assert_eq!(
+            CLASSATTR_CALLS.load(Ordering::SeqCst),
+            1,
+            "GC traversal must not initialize class attributes"
+        );
+        assert!(ty
+            .getattr("instance")
+            .unwrap()
+            .is_instance_of::<GcDuringClassattr>());
+    });
+}
+
 #[pyclass(str = "X: {x}, Y: {y}, Z: {z}")]
 #[derive(PartialEq, Eq, Clone, PartialOrd)]
 pub struct Point {


### PR DESCRIPTION
Fixes #6390

This fixes a horrible bug lurking in the `abi3t` code paths for `PyVariableClassObject`. The crash formed as follows:
- When `#[classattr]` values are being created in `#[pyclass]` type object dicts, the arbitrary code execution can lead the interpreter to detach from the thread
- This can potentially cause other threads to begin to access the partially-initialized type object, such as during GC
- (The root cause bug) is that `PyVariableClassObject` would then use `T::type_object_raw` to look up `#[pyclass]` type, initializing it if needed (which can be concurrent with the original thread, see also #5211)
  - ... and if this look up occurs during GC traversal, we can't execute Python code, so boom.

I've ended up having to add several layers to this fix:
- We need to add `_during_gc` variants to several APIs to avoid possibly entering `T::type_object_raw` (which is only safe to call when attached to the interpreter
- This required introducing a `PyClassTraverseGuard` type, similar to `PyClassGuard`, but which avoids using `T::type_object_raw` and only goes via gc-safe pathways 
- For Python 3.15+ I use the new `_DuringGC` APIs to properly look up type data during the GC pass
  - This requires use of `Py_tp_token` slot, so I had to populate that in `create_type_object` with help of the `#[pyclass]` macro

I started passing a lot of `NonNull<ffi::PyObject>` all over the place while implementing these functions, but that felt pretty painful especially with borrowed data flying around. In the end, I also introduced a crate-private `PyBorrowedUnbound<'a, T>` helper, basically `Borrowed<'a, 'py, T>` but without attachment to the interpreter. This helped me write "safer" functions by requiring objects of the right type and connecting input & output lifetimes, (e.g. on `T::Layout::contents_during_gc`)

Some notes:
- I think I might want to add a `DuringGc` ZST to pass around to these `_during_gc` functions - I think otherwise they are typically `unsafe` to call because they do things like borrowed references, and I don't think I've marked them all properly.
- I 100% needed AI to figure out the interaction causing the crash and it wrote me the test case; from that point forward the fix is me just going loose on the codebase 😂 
- We could probably split the `tp_token` based lookup into a separate PR and just have a more targeted fix related to the GC soundness, but I started with the `tp_token` stuff as there was a TODO literally inside `PyVariableClassObject::get_contents_of_obj` right where the GC traversal was entering `T::type_object_raw`. We need this machinery anyway to eventually support module isolation / subinterpreters.